### PR TITLE
fix(cli): judge a remote --path and a remote project by the remote host's rules

### DIFF
--- a/backend/internal/cli/client.go
+++ b/backend/internal/cli/client.go
@@ -91,7 +91,37 @@ func (c *commandContext) doJSON(ctx context.Context, method, path string, body, 
 }
 
 func (c *commandContext) postLoopbackJSON(ctx context.Context, path string, body any) error {
+	// These are loopback-only control routes (/internal/*), 404'd at the LAN
+	// socket by design — and CLI telemetry has no business reaching a daemon on
+	// someone else's machine. Drop them when a remote target is set.
+	if c.remote != nil {
+		return nil
+	}
 	return c.doJSONPath(ctx, http.MethodPost, path, body, nil)
+}
+
+// daemonBase returns the base URL every daemon call targets. With a remote
+// target it is the given URL; otherwise it is the loopback daemon discovered
+// through the run-file, gated on a live local PID as before.
+func (c *commandContext) daemonBase() (string, error) {
+	if c.remote != nil {
+		return c.remote.baseURL, nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return "", err
+	}
+	info, err := runfile.Read(cfg.RunFilePath)
+	if err != nil {
+		return "", err
+	}
+	if info == nil {
+		return "", fmt.Errorf("AO daemon is not running — start it with `ao start`")
+	}
+	if !c.deps.ProcessAlive(info.PID) {
+		return "", fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
+	}
+	return fmt.Sprintf("http://%s:%d", config.LoopbackHost, info.Port), nil
 }
 
 func (c *commandContext) doJSONPath(ctx context.Context, method, path string, body, out any) error {
@@ -114,19 +144,9 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 	headers map[string]string,
 	timeout time.Duration,
 ) error {
-	cfg, err := config.Load()
+	base, err := c.daemonBase()
 	if err != nil {
 		return err
-	}
-	info, err := runfile.Read(cfg.RunFilePath)
-	if err != nil {
-		return err
-	}
-	if info == nil {
-		return fmt.Errorf("AO daemon is not running — start it with `ao start`")
-	}
-	if !c.deps.ProcessAlive(info.PID) {
-		return fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
 	}
 
 	var reader io.Reader = http.NoBody
@@ -137,14 +157,14 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 		}
 		reader = bytes.NewReader(payload)
 	}
-	url := fmt.Sprintf("http://%s:%d%s", config.LoopbackHost, info.Port, path)
-	req, err := http.NewRequestWithContext(ctx, method, url, reader) // #nosec G704 -- daemon host is fixed loopback; path is an internal API route.
+	req, err := http.NewRequestWithContext(ctx, method, base+path, reader) // #nosec G704 -- host is loopback or an explicitly configured daemon URL; path is an internal API route.
 	if err != nil {
 		return err
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	c.authorize(req)
 	for name, value := range headers {
 		req.Header.Set(name, value)
 	}
@@ -153,7 +173,7 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 	// give daemon API calls far more headroom than the 2s status-probe timeout.
 	client := *c.deps.HTTPClient
 	client.Timeout = timeout
-	resp, err := client.Do(req) // #nosec G704 -- request target is the fixed loopback daemon URL above.
+	resp, err := client.Do(req) // #nosec G704 -- request target is the daemon base URL resolved above.
 	if err != nil {
 		return fmt.Errorf("call daemon: %w", err)
 	}

--- a/backend/internal/cli/pr_ref.go
+++ b/backend/internal/cli/pr_ref.go
@@ -17,6 +17,27 @@ func (c *commandContext) resolvePRRef(ctx context.Context, ref string, project p
 	if isNumericPRRef(ref) {
 		repo := strings.TrimSpace(project.Repo)
 		if repo == "" {
+			// The gh fallback below is local-only in the same sense as `ao doctor`,
+			// but it is a fallback inside a command that otherwise works remotely,
+			// so refuseLocalOnly's "`<command>` <why>" shape does not fit: the
+			// command is fine, this one branch is not, and resolvePRRef does not
+			// know whether it was reached from `ao spawn` or `ao session claim-pr`.
+			//
+			// project.Path came from the REMOTE daemon and CommandOutputInDir runs
+			// HERE. If that path does not exist locally the operator is told "gh not
+			// available", which is a misdiagnosis; if it happens to exist locally —
+			// two machines with the same checkout layout is the normal case — the PR
+			// is resolved from this machine's checkout and this machine's gh
+			// credentials, silently, and the resulting URL is sent to the remote
+			// daemon as if it had come from there.
+			if c.remote != nil {
+				return "", usageError{fmt.Errorf(
+					"%s targets the remote daemon at %s, and that project's record has no repo URL — "+
+						"resolving PR %s by number would run `gh repo view` on THIS machine in %q, a path "+
+						"that belongs to the remote host, reading this machine's checkout and gh "+
+						"credentials. Pass the full PR URL (https://github.com/<owner>/<repo>/pull/<number>)",
+					c.remote.source, c.remote.baseURL, ref, project.Path)}
+			}
 			// The daemon must not shell out to external CLIs from its loopback API;
 			// when the durable project record lacks repo_origin_url, the thin CLI
 			// does the one-off gh lookup from the registered project checkout and

--- a/backend/internal/cli/pr_ref_remote_test.go
+++ b/backend/internal/cli/pr_ref_remote_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// resolvePRRef's gh fallback runs on the machine executing the CLI, in
+// project.Path — a path the REMOTE daemon reported. The assertion that matters
+// is the call count, not the message: "refused" and "ran gh against the wrong
+// checkout and got a plausible URL back" produce output that looks the same.
+//
+// Deliberately path-free (no filepath, no t.Chdir, no absolute-path literals):
+// project.Path here is an opaque string the CLI must never hand to a
+// subprocess, and it must stay opaque on every runner OS.
+func TestResolvePRRefRefusesLocalGhForRemoteProject(t *testing.T) {
+	project := projectDetails{ID: "p1", Path: "remote/host/checkout", Repo: ""}
+
+	for _, source := range []string{"--url", "AO_URL"} {
+		t.Run(source, func(t *testing.T) {
+			calls := 0
+			ctx := &commandContext{
+				deps: Deps{CommandOutputInDir: func(context.Context, string, string, ...string) ([]byte, error) {
+					calls++
+					return []byte("https://github.com/laptop/wrong-repo"), nil
+				}}.withDefaults(),
+				remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: source},
+			}
+
+			got, err := ctx.resolvePRRef(context.Background(), "42", project)
+			if err == nil {
+				t.Fatalf("resolvePRRef = %q, want a refusal", got)
+			}
+			if calls != 0 {
+				t.Fatalf("refused resolvePRRef still ran %d subprocess(es)", calls)
+			}
+			if code := ExitCode(err); code != 2 {
+				t.Errorf("exit code = %d, want 2 (usage)", code)
+			}
+			for _, want := range []string{source, "http://host:3011", "gh repo view", "full PR URL"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not name %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// A full PR URL needs no repo lookup, so it stays usable against a remote
+// target — the refusal must be scoped to the fallback, not to the command.
+func TestResolvePRRefAcceptsFullURLForRemoteProject(t *testing.T) {
+	calls := 0
+	ctx := &commandContext{
+		deps: Deps{CommandOutputInDir: func(context.Context, string, string, ...string) ([]byte, error) {
+			calls++
+			return nil, errors.New("must not run")
+		}}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "--url"},
+	}
+
+	got, err := ctx.resolvePRRef(context.Background(), "https://github.com/owner/repo/pull/7", projectDetails{Path: "remote/host/checkout"})
+	if err != nil {
+		t.Fatalf("resolvePRRef = %v, want success", err)
+	}
+	if want := "https://github.com/owner/repo/pull/7"; got != want {
+		t.Errorf("resolvePRRef = %q, want %q", got, want)
+	}
+	if calls != 0 {
+		t.Errorf("full PR URL ran %d subprocess(es), want 0", calls)
+	}
+}
+
+// End to end through the real command, against an httptest stand-in remote
+// daemon that serves a project record with an empty repo — the case the audit
+// could not reach on live hardware. It proves the guard is actually reachable
+// from `ao session claim-pr --url`, which the unit tests above cannot: an
+// earlier step could have short-circuited it.
+//
+// Two assertions, neither of which is the message: no subprocess ran, and the
+// remote request log stops after the two reads, with no PR claimed. Without the
+// guard the laptop's gh answers, the claim POST goes out carrying a URL derived
+// from this machine's checkout, and the command prints a plain success.
+func TestSessionClaimPRRefusesLocalGhAgainstRemoteDaemon(t *testing.T) {
+	aoHome(t)
+	setConfigEnv(t)
+	t.Setenv("AO_TOKEN", "tok")
+
+	log := &sessionRequestLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.append(r)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions/demo-1":
+			_, _ = io.WriteString(w, `{"session":`+sessionJSON("demo-1", "demo", "worker", "working", false)+`}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/demo":
+			_, _ = io.WriteString(w, `{"status":"ok","project":{"id":"demo","name":"Demo","path":"remote/host/checkout","repo":"","defaultBranch":"main"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/demo-1/pr/claim":
+			// Answers happily, so that without the guard this test's failure mode
+			// is what the audit describes: a plain success on the wrong PR.
+			_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-1","prs":[],"branchChanged":false,"takenOverFrom":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	calls := 0
+	_, _, err := executeCLI(t, Deps{
+		CommandOutputInDir: func(context.Context, string, string, ...string) ([]byte, error) {
+			calls++
+			return []byte("https://github.com/laptop/wrong-repo"), nil
+		},
+	}, "session", "claim-pr", "demo-1", "142", "--url", srv.URL)
+	if err == nil {
+		t.Fatal("session claim-pr --url with a repo-less remote project succeeded, want a refusal")
+	}
+	if calls != 0 {
+		t.Fatalf("refused claim-pr still ran %d subprocess(es)", calls)
+	}
+	if code := ExitCode(err); code != 2 {
+		t.Errorf("exit code = %d, want 2 (usage)", code)
+	}
+	for _, req := range log.all() {
+		if strings.Contains(req, "/pr/claim") {
+			t.Errorf("refused claim-pr still claimed a PR on the remote daemon: %v", log.all())
+		}
+	}
+}
+
+// Local behavior must not change: with no remote target the gh fallback still
+// runs and still resolves a bare number.
+func TestResolvePRRefLocalStillUsesGhFallback(t *testing.T) {
+	calls := 0
+	ctx := &commandContext{
+		deps: Deps{CommandOutputInDir: func(_ context.Context, dir, name string, _ ...string) ([]byte, error) {
+			calls++
+			if dir != "local/checkout" || name != "gh" {
+				t.Errorf("CommandOutputInDir(%q, %q), want the project path and gh", dir, name)
+			}
+			return []byte("https://github.com/owner/repo\n"), nil
+		}}.withDefaults(),
+	}
+
+	got, err := ctx.resolvePRRef(context.Background(), "#42", projectDetails{Path: "local/checkout"})
+	if err != nil {
+		t.Fatalf("resolvePRRef = %v, want success", err)
+	}
+	if want := "https://github.com/owner/repo/pull/42"; got != want {
+		t.Errorf("resolvePRRef = %q, want %q", got, want)
+	}
+	if calls != 1 {
+		t.Errorf("gh fallback ran %d times, want 1", calls)
+	}
+}

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -47,8 +47,13 @@ type addProjectRequest struct {
 }
 
 type projectSummary struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// Path is the project root as resolved by the daemon that answered — which,
+	// with --url, is a path on THAT host, not on this machine. The daemon has
+	// always returned it; the CLI used to drop it on decode, so neither the
+	// table nor --json could say where a project actually lives.
+	Path          string `json:"path,omitempty"`
 	Kind          string `json:"kind"`
 	SessionPrefix string `json:"sessionPrefix"`
 	ResolveError  string `json:"resolveError,omitempty"`
@@ -248,6 +253,9 @@ func newProjectAddCommand(ctx *commandContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.path == "" {
 				return usageError{fmt.Errorf("--path is required")}
+			}
+			if err := ctx.checkRemoteProjectPath(opts.path); err != nil {
+				return err
 			}
 			req := addProjectRequest{Path: opts.path, AsWorkspace: opts.asWorkspace}
 			if opts.id != "" {
@@ -483,7 +491,10 @@ func writeProjectList(cmd *cobra.Command, projects []projectSummary) error {
 	}
 
 	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "ID\tNAME\tKIND\tSESSION PREFIX\tSTATUS"); err != nil {
+	// PATH last: it is the widest column and the only one whose meaning depends
+	// on which daemon answered, so it reads as a qualifier rather than pushing
+	// the identifying columns around.
+	if _, err := fmt.Fprintln(tw, "ID\tNAME\tKIND\tSESSION PREFIX\tSTATUS\tPATH"); err != nil {
 		return err
 	}
 	for _, p := range projects {
@@ -495,7 +506,7 @@ func writeProjectList(cmd *cobra.Command, projects []projectSummary) error {
 		if kind == "" {
 			kind = "single_repo"
 		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", p.ID, p.Name, kind, p.SessionPrefix, status); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", p.ID, p.Name, kind, p.SessionPrefix, status, p.Path); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -451,3 +451,34 @@ func TestProjectRemove_YesSkipsConfirmationAndSupportsBackendRemoveEnvelope(t *t
 		t.Fatalf("--yes output should skip prompt and print removal:\n%s", out)
 	}
 }
+
+// The daemon has always returned `path` in the projects list; the CLI's own
+// summary struct dropped it on decode, so neither the table nor --json could
+// answer "where does this project actually live" — which is the whole question
+// when the answering daemon is on another machine.
+func TestProjectList_SurfacesPath(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := projectServer(t, http.StatusOK,
+		`{"projects":[{"id":"zeta","name":"Zeta","sessionPrefix":"zeta","path":"/srv/repos/zeta"}]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "project", "ls")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "PATH") {
+		t.Fatalf("table missing PATH column:\n%s", out)
+	}
+	if !strings.Contains(out, "/srv/repos/zeta") {
+		t.Fatalf("table missing the project path:\n%s", out)
+	}
+
+	// --json must carry it too: a remote-aware UI reads that, not the table.
+	out, errOut, err = executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "project", "ls", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, `"path": "/srv/repos/zeta"`) && !strings.Contains(out, `"path":"/srv/repos/zeta"`) {
+		t.Fatalf("--json dropped the path:\n%s", out)
+	}
+}

--- a/backend/internal/cli/remote.go
+++ b/backend/internal/cli/remote.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+)
+
+// A remote target replaces the local run-file handshake: instead of reading
+// running.json and gating on a live local PID, every daemon call goes to the
+// given base URL carrying the daemon's connection password as a Bearer token —
+// the same credential channel the mobile client uses (ADR 0001).
+//
+// It is opt-in and never inferred: with no --url and no AO_URL, the CLI keeps
+// its loopback-only behavior exactly as before.
+type remoteTarget struct {
+	baseURL string
+	token   string
+	// source names where the URL came from ("--url" or "AO_URL") so an error can
+	// tell the user which one is pointing them off-box.
+	source string
+}
+
+// remotesFileName holds saved remote daemons under the AO home directory. It
+// carries connection passwords in plaintext, so it must be mode 0600.
+const remotesFileName = "remotes.json"
+
+// remotesFile mirrors the mobile app's multi-node store
+// (packages/mobile/lib/config.ts): a list of saved nodes, each labelled, each
+// with its own connection password. The CLI has no OS keystore to split the
+// secret into, so the password lives in the file and the file must be 0600.
+type remotesFile struct {
+	Remotes []remoteEntry `json:"remotes"`
+}
+
+type remoteEntry struct {
+	Label    string `json:"label,omitempty"`
+	URL      string `json:"url"`
+	Password string `json:"password"`
+}
+
+// resolveRemoteTarget resolves the remote daemon this invocation targets, or
+// nil for the default local daemon. The URL comes from --url or AO_URL; the
+// credential from AO_TOKEN or a matching entry in ~/.ao/remotes.json.
+func resolveRemoteTarget(flagURL string) (*remoteTarget, error) {
+	raw, source := strings.TrimSpace(flagURL), "--url"
+	if raw == "" {
+		raw, source = strings.TrimSpace(os.Getenv("AO_URL")), "AO_URL"
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	base, err := normalizeRemoteURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	token := strings.TrimSpace(os.Getenv("AO_TOKEN"))
+	if token == "" {
+		entry, err := lookupRemoteEntry(base)
+		if err != nil {
+			return nil, err
+		}
+		path, _ := remotesFilePath()
+		switch {
+		case entry == nil:
+			return nil, fmt.Errorf("no connection password for %s — set AO_TOKEN or add an entry for it to %s", base, path)
+		case strings.TrimSpace(entry.Password) == "":
+			return nil, fmt.Errorf("the entry for %s in %s has an empty password — set its password, or use AO_TOKEN", base, path)
+		}
+		token = strings.TrimSpace(entry.Password)
+	}
+	return &remoteTarget{baseURL: base, token: token, source: source}, nil
+}
+
+// normalizeRemoteURL turns a user-supplied target into a base URL with no
+// trailing slash. A bare "host:3011" is accepted and assumed plaintext http,
+// matching the LAN listener (ADR 0001 is deliberately http-only).
+func normalizeRemoteURL(raw string) (string, error) {
+	// A URL-embedded credential is never trusted — the connection password comes
+	// from AO_TOKEN or remotes.json. Silently dropping it would leave the user
+	// certain they had passed a password and then told there was none, so say so
+	// instead. Checked first, and reported without quoting the URL, so no later
+	// error path can echo the credential into a message or a log line.
+	if hasUserinfo(raw) {
+		return "", errors.New("invalid daemon URL: it must not carry a username or password — " +
+			"pass the connection password in AO_TOKEN or a ~/.ao/remotes.json entry")
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid daemon URL %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid daemon URL %q: scheme must be http or https", raw)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid daemon URL %q: missing host", raw)
+	}
+	return strings.TrimRight(u.Scheme+"://"+u.Host+u.Path, "/"), nil
+}
+
+// hasUserinfo reports whether raw's authority component carries userinfo. It
+// works textually, before url.Parse, so that a malformed URL cannot slip a
+// credential into the parse error — and it catches the scheme-less form
+// ("user:pw@host:3011") too. An "@" in the path or query is not authority.
+func hasUserinfo(raw string) bool {
+	authority := raw
+	if i := strings.Index(authority, "://"); i >= 0 {
+		authority = authority[i+3:]
+	}
+	if i := strings.IndexAny(authority, "/?#"); i >= 0 {
+		authority = authority[:i]
+	}
+	return strings.Contains(authority, "@")
+}
+
+func remotesFilePath() (string, error) {
+	dir, err := config.StateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, remotesFileName), nil
+}
+
+// lookupRemoteEntry returns the saved entry for base, or nil when the file does
+// not exist or holds no entry for it. A nil entry and an entry with an empty
+// password are different problems, so the caller can say which one it is. A file
+// readable by anyone but the owner is refused rather than used: it is a
+// plaintext credential store.
+func lookupRemoteEntry(base string) (*remoteEntry, error) {
+	path, err := remotesFilePath()
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	// Windows file modes do not carry meaningful group/other bits, so the check
+	// would reject every file there.
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("%s holds connection passwords and is readable by others (mode %04o) — run: chmod 600 %s",
+			path, info.Mode().Perm(), path)
+	}
+	raw, err := os.ReadFile(path) // #nosec G304 -- fixed path under the AO home directory.
+	if err != nil {
+		return nil, err
+	}
+	var file remotesFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, entry := range file.Remotes {
+		saved, err := normalizeRemoteURL(entry.URL)
+		if err != nil {
+			continue // a hand-edited entry must not break every other one
+		}
+		if saved == base {
+			return &entry, nil
+		}
+	}
+	return nil, nil
+}
+
+// authorize presents the remote connection password. Loopback calls carry no
+// credential: the local daemon's loopback listener has no auth at all.
+func (c *commandContext) authorize(req *http.Request) {
+	if c.remote != nil {
+		req.Header.Set("Authorization", "Bearer "+c.remote.token)
+	}
+}

--- a/backend/internal/cli/remote.go
+++ b/backend/internal/cli/remote.go
@@ -175,6 +175,99 @@ func lookupRemoteEntry(base string) (*remoteEntry, error) {
 	return nil, nil
 }
 
+// checkRemoteProjectPath refuses a host-relative path aimed at a remote daemon.
+//
+// Refuse rather than warn: "~/repo" and "./repo" are resolved by the daemon
+// against its own home and its own working directory, so against a remote
+// target they silently name a directory on someone else's machine. There is no
+// reading under which the operator meant the remote daemon's home — and unlike
+// an absolute path, which may legitimately exist on either host, a host-relative
+// path cannot be checked by the operator after the fact. A warning on stderr
+// would be missed exactly when it matters, in a script or a busy terminal.
+//
+// Absolute paths are deliberately still allowed: they are meaningful on the
+// remote host, and refusing them would make a remote target useless.
+func (c *commandContext) checkRemoteProjectPath(path string) error {
+	if c.remote == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(path)
+	switch {
+	case strings.HasPrefix(trimmed, "~"):
+		return usageError{fmt.Errorf(
+			"--path %q is relative to a home directory, and %s targets the remote daemon at %s, "+
+				"where it would mean that host's home — pass an absolute path as it exists on that host",
+			path, c.remote.source, c.remote.baseURL)}
+	case !isAbsForSomeHost(trimmed):
+		return usageError{fmt.Errorf(
+			"--path %q is relative, and %s targets the remote daemon at %s, where it would be resolved "+
+				"against that daemon's working directory — pass an absolute path as it exists on that host",
+			path, c.remote.source, c.remote.baseURL)}
+	}
+	return nil
+}
+
+// isAbsForSomeHost reports whether p is an absolute path on ANY host AO might
+// talk to, rather than on the machine running the CLI.
+//
+// filepath.IsAbs is the wrong question here and shipping it was a bug: it
+// judges by the local OS, so on Windows it calls "/srv/repo" relative — and a
+// Windows operator targeting a Linux remote host, which is exactly what remote
+// execution creates, was refused a perfectly valid path on that host. The
+// destination filesystem is the remote daemon's, so the CLI must accept every
+// absolute form and let the daemon judge its own.
+//
+// Deliberately NOT accepted, because both are host-relative even on Windows:
+// a bare drive-relative path ("C:foo") and a single leading backslash
+// ("\foo", relative to the current drive).
+func isAbsForSomeHost(p string) bool {
+	if strings.HasPrefix(p, "/") {
+		return true // POSIX absolute
+	}
+	if strings.HasPrefix(p, `\\`) {
+		return true // Windows UNC: \\server\share
+	}
+	// Windows drive-absolute: C:\foo or C:/foo (a slash after the colon is
+	// what separates this from drive-RELATIVE "C:foo").
+	if len(p) >= 3 && p[1] == ':' && (p[2] == '\\' || p[2] == '/') {
+		return (p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')
+	}
+	return false
+}
+
+// checkRemoteImplicitProject refuses to resolve a project from a local signal
+// when the command targets a remote daemon.
+//
+// Refuse rather than guess, for the same reason as checkRemoteProjectPath:
+// AO_PROJECT_ID, AO_SESSION_ID and the current directory all describe THIS
+// machine, but with a remote target they are matched against the remote
+// daemon's projects. Measured: `ao spawn --url <remote>` run inside any AO
+// session inherits an AO_PROJECT_ID the operator never typed and spawns
+// against whatever project on the remote host happens to share that id — and
+// cwd matching picks a remote project whenever the two machines' paths
+// coincide. A session started on the wrong machine cannot be caught after the
+// fact from the output, which names only the session it created.
+//
+// So --project is required for a remote target: it is the one input that means
+// the same thing on both hosts.
+func (c *commandContext) checkRemoteImplicitProject(explicit string) error {
+	if c.remote == nil || strings.TrimSpace(explicit) != "" {
+		return nil
+	}
+	signal := "the current directory"
+	switch {
+	case strings.TrimSpace(os.Getenv("AO_PROJECT_ID")) != "":
+		signal = "AO_PROJECT_ID"
+	case strings.TrimSpace(os.Getenv("AO_SESSION_ID")) != "":
+		signal = "AO_SESSION_ID"
+	}
+	return usageError{fmt.Errorf(
+		"%s describes this machine, and %s targets the remote daemon at %s, where it would select "+
+			"a project on that host — pass --project <id> as it exists on that host "+
+			"(list them with `ao project ls --url %s`)",
+		signal, c.remote.source, c.remote.baseURL, c.remote.baseURL)}
+}
+
 // authorize presents the remote connection password. Loopback calls carry no
 // credential: the local daemon's loopback listener has no auth at all.
 func (c *commandContext) authorize(req *http.Request) {

--- a/backend/internal/cli/remote_test.go
+++ b/backend/internal/cli/remote_test.go
@@ -1,0 +1,447 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/daemonmeta"
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+)
+
+// aoHome points the AO home directory (and therefore remotes.json) at a temp
+// dir, and clears the remote env vars so a developer's real AO_URL/AO_TOKEN
+// cannot leak into a test.
+func aoHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+	t.Setenv("AO_URL", "")
+	t.Setenv("AO_TOKEN", "")
+	return dir
+}
+
+func writeRemotes(t *testing.T, home string, perm os.FileMode, entries ...remoteEntry) {
+	t.Helper()
+	raw, err := json.Marshal(remotesFile{Remotes: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".ao"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".ao", remotesFileName)
+	if err := os.WriteFile(path, raw, perm); err != nil {
+		t.Fatal(err)
+	}
+	// WriteFile honors umask, so force the mode the test asked for.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNormalizeRemoteURL(t *testing.T) {
+	ok := map[string]string{
+		"http://host:3011":         "http://host:3011",
+		"http://host:3011/":        "http://host:3011",
+		"host:3011":                "http://host:3011", // bare host defaults to plaintext http
+		"https://box.ts.net":       "https://box.ts.net",
+		"http://host:3011/ao/":     "http://host:3011/ao",
+		"HTTP://Host:3011":         "http://Host:3011",
+		"http://100.64.0.1:3011//": "http://100.64.0.1:3011",
+	}
+	for in, want := range ok {
+		got, err := normalizeRemoteURL(in)
+		if err != nil {
+			t.Fatalf("normalizeRemoteURL(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("normalizeRemoteURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+	for _, in := range []string{"ftp://host", "ws://host:3011", "http://", "://x"} {
+		if got, err := normalizeRemoteURL(in); err == nil {
+			t.Errorf("normalizeRemoteURL(%q) = %q, want error", in, got)
+		}
+	}
+
+	// An "@" outside the authority is not userinfo and must still parse.
+	for _, in := range []string{"http://host:3011/a@b", "http://host:3011/x?q=a@b"} {
+		if _, err := normalizeRemoteURL(in); err != nil {
+			t.Errorf("normalizeRemoteURL(%q): %v", in, err)
+		}
+	}
+}
+
+// A credential typed into the URL is rejected outright rather than silently
+// dropped — and the error must never echo it back.
+func TestNormalizeRemoteURLRejectsUserinfo(t *testing.T) {
+	for _, in := range []string{
+		"http://user:hunter2@host:3011",
+		"https://user:hunter2@host:3011/path",
+		"user:hunter2@host:3011", // scheme-less form
+		"http://hunter2@host:3011",
+	} {
+		_, err := normalizeRemoteURL(in)
+		if err == nil {
+			t.Fatalf("normalizeRemoteURL(%q) succeeded, want a userinfo rejection", in)
+		}
+		if !strings.Contains(err.Error(), "must not carry a username or password") {
+			t.Errorf("normalizeRemoteURL(%q) error = %q, want a userinfo rejection", in, err)
+		}
+		if strings.Contains(err.Error(), "hunter2") {
+			t.Errorf("normalizeRemoteURL(%q) echoed the credential: %q", in, err)
+		}
+	}
+}
+
+// The same rejection must reach the user through the real resolution path, with
+// the credential still absent from the message.
+func TestResolveRemoteTargetRejectsUserinfo(t *testing.T) {
+	aoHome(t)
+	_, err := resolveRemoteTarget("http://user:hunter2@host:3011")
+	if err == nil || strings.Contains(err.Error(), "hunter2") {
+		t.Fatalf("err = %v, want a rejection that does not echo the password", err)
+	}
+}
+
+// No --url and no AO_URL must resolve to nil: that is what keeps every local
+// invocation on the run-file path it has always used.
+func TestResolveRemoteTargetDefaultsToLocal(t *testing.T) {
+	aoHome(t)
+	got, err := resolveRemoteTarget("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("resolveRemoteTarget = %+v, want nil (local)", got)
+	}
+}
+
+func TestResolveRemoteTargetCredentialSources(t *testing.T) {
+	t.Run("AO_TOKEN wins over remotes.json", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{URL: "http://host:3011", Password: "fromfile"})
+		t.Setenv("AO_TOKEN", "fromenv")
+
+		got, err := resolveRemoteTarget("http://host:3011")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.token != "fromenv" || got.baseURL != "http://host:3011" || got.source != "--url" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("remotes.json entry matched by URL", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600,
+			remoteEntry{Label: "other", URL: "http://elsewhere:3011", Password: "nope"},
+			// Stored with a trailing slash: matching is on the normalized URL.
+			remoteEntry{Label: "desk", URL: "http://host:3011/", Password: "s3cret12"},
+		)
+		got, err := resolveRemoteTarget("host:3011")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.token != "s3cret12" {
+			t.Fatalf("token = %q, want s3cret12", got.token)
+		}
+	})
+
+	t.Run("AO_URL when no flag", func(t *testing.T) {
+		aoHome(t)
+		t.Setenv("AO_URL", "http://host:3011")
+		t.Setenv("AO_TOKEN", "tok")
+
+		got, err := resolveRemoteTarget("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.source != "AO_URL" {
+			t.Fatalf("source = %q, want AO_URL", got.source)
+		}
+	})
+
+	t.Run("no credential is an error", func(t *testing.T) {
+		aoHome(t)
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil || !strings.Contains(err.Error(), "AO_TOKEN") {
+			t.Fatalf("err = %v, want a missing-credential error naming AO_TOKEN", err)
+		}
+	})
+
+	t.Run("unknown host in remotes.json is an error", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{URL: "http://elsewhere:3011", Password: "nope"})
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil || !strings.Contains(err.Error(), "no connection password") {
+			t.Fatalf("err = %v, want the missing-entry error", err)
+		}
+	})
+
+	// An entry that exists but carries no password is a different problem from
+	// no entry at all, and must not be told to add the entry it already has.
+	t.Run("matching entry with an empty password says so", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{Label: "desk", URL: "http://host:3011", Password: ""})
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil {
+			t.Fatal("want an error for an entry with an empty password")
+		}
+		if !strings.Contains(err.Error(), "has an empty password") {
+			t.Fatalf("err = %q, want it to name the empty password", err)
+		}
+		if strings.Contains(err.Error(), "add an entry") {
+			t.Fatalf("err = %q, must not tell the user to add an entry that already exists", err)
+		}
+	})
+}
+
+// remotes.json holds connection passwords in plaintext, so a group/other
+// readable file is refused rather than silently used.
+func TestResolveRemoteTargetRejectsLooseRemotesFilePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not meaningful on Windows")
+	}
+	home := aoHome(t)
+	writeRemotes(t, home, 0o644, remoteEntry{URL: "http://host:3011", Password: "s3cret12"})
+
+	_, err := resolveRemoteTarget("http://host:3011")
+	if err == nil || !strings.Contains(err.Error(), "chmod 600") {
+		t.Fatalf("err = %v, want a permissions refusal", err)
+	}
+}
+
+// With no remote target, daemonBase must still go through the run-file and the
+// local liveness gate — byte-identical to the pre-remote behavior.
+func TestDaemonBaseLocalUsesRunFile(t *testing.T) {
+	dir := aoHome(t)
+	runFile := filepath.Join(dir, "running.json")
+	t.Setenv("AO_RUN_FILE", runFile)
+	t.Setenv("AO_DATA_DIR", filepath.Join(dir, "data"))
+
+	c := &commandContext{deps: Deps{ProcessAlive: func(int) bool { return true }}.withDefaults()}
+
+	if _, err := c.daemonBase(); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("err = %v, want 'not running' with no run-file", err)
+	}
+
+	if err := runfile.Write(runFile, runfile.Info{PID: 4242, Port: 3999, StartedAt: time.Unix(100, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	base, err := c.daemonBase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != "http://127.0.0.1:3999" {
+		t.Fatalf("base = %q, want the loopback daemon URL", base)
+	}
+
+	dead := &commandContext{deps: Deps{ProcessAlive: func(int) bool { return false }}.withDefaults()}
+	if _, err := dead.daemonBase(); err == nil || !strings.Contains(err.Error(), "stale run-file") {
+		t.Fatalf("err = %v, want the stale run-file error", err)
+	}
+}
+
+// A remote target skips the run-file read and the local ProcessAlive gate
+// entirely: neither exists on the machine running the command.
+func TestDaemonBaseRemoteSkipsRunFile(t *testing.T) {
+	dir := aoHome(t)
+	t.Setenv("AO_RUN_FILE", filepath.Join(dir, "no-such-running.json"))
+
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("ProcessAlive must not be consulted for a remote"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "--url"},
+	}
+	base, err := c.daemonBase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != "http://host:3011" {
+		t.Fatalf("base = %q", base)
+	}
+}
+
+// `ao status --url ...` must work on a machine with no local run file at all,
+// and must present the connection password as a Bearer token.
+func TestStatusRemoteWithoutLocalRunFile(t *testing.T) {
+	dir := aoHome(t)
+	t.Setenv("AO_RUN_FILE", filepath.Join(dir, "no-such-running.json"))
+
+	var gotAuth []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		status := "ok"
+		if r.URL.Path == "/readyz" {
+			status = "ready"
+		}
+		_ = json.NewEncoder(w).Encode(probeResult{Status: status, Service: daemonmeta.ServiceName, PID: 777})
+	}))
+	defer srv.Close()
+
+	t.Setenv("AO_TOKEN", "s3cret12")
+	var out bytes.Buffer
+	err := executeWithDeps(Deps{
+		Out: &out,
+		Err: &out,
+		// A remote invocation must never consult local process liveness.
+		ProcessAlive: func(int) bool { t.Error("ProcessAlive called for a remote target"); return false },
+	}, []string{"status", "--url", srv.URL})
+	if err != nil {
+		t.Fatalf("ao status --url: %v\n%s", err, out.String())
+	}
+
+	if want := []string{"Bearer s3cret12", "Bearer s3cret12"}; len(gotAuth) != 2 || gotAuth[0] != want[0] || gotAuth[1] != want[1] {
+		t.Fatalf("Authorization headers = %q, want %q", gotAuth, want)
+	}
+	for _, want := range []string{"AO daemon: ready", "url: " + srv.URL, "pid: 777"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("status output missing %q:\n%s", want, out.String())
+		}
+	}
+	// There is no local run-file or data dir to report for a remote daemon.
+	if strings.Contains(out.String(), "run file:") {
+		t.Fatalf("remote status reported a local run file:\n%s", out.String())
+	}
+}
+
+// A daemon that answers but is not ours must not be reported as a healthy AO.
+func TestStatusRemoteRejectsForeignService(t *testing.T) {
+	aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(probeResult{Status: "ok", Service: "something-else"})
+	}))
+	defer srv.Close()
+
+	c := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: srv.URL, token: "tok"},
+	}
+	st := c.inspectRemoteDaemon(context.Background())
+	if st.State != stateUnhealthy || !strings.Contains(st.Error, "not from AO daemon") {
+		t.Fatalf("state = %q, error = %q", st.State, st.Error)
+	}
+}
+
+// A 429 from a remote daemon is the LAN listener's per-source lockout, not an
+// unhealthy daemon. Reporting it as "unhealthy" inverts the diagnosis.
+func TestStatusRemoteReportsLockoutDistinctly(t *testing.T) {
+	aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: srv.URL, token: "tok"},
+	}
+	st := c.inspectRemoteDaemon(context.Background())
+	if st.State != stateLockedOut {
+		t.Fatalf("state = %q, want %q", st.State, stateLockedOut)
+	}
+	if !strings.Contains(st.Error, "locked out") {
+		t.Fatalf("error = %q, want it to name the lockout", st.Error)
+	}
+	// The whole point: it must not send the user to debug a healthy daemon.
+	if strings.Contains(string(st.State), "unhealthy") || strings.Contains(st.Error, "HTTP 429") {
+		t.Fatalf("lockout still rendered as a daemon fault: state=%q error=%q", st.State, st.Error)
+	}
+}
+
+// ...and the LOCAL path must render the very same 429 exactly as before. The
+// lockout cannot occur on loopback, so nothing about local status may change.
+func TestStatusLocalUnchangedForSameHTTPStatus(t *testing.T) {
+	dir := aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	port, err := strconv.Atoi(srv.URL[strings.LastIndex(srv.URL, ":")+1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	runFile := filepath.Join(dir, "running.json")
+	t.Setenv("AO_RUN_FILE", runFile)
+	t.Setenv("AO_DATA_DIR", filepath.Join(dir, "data"))
+	if err := runfile.Write(runFile, runfile.Info{PID: os.Getpid(), Port: port, StartedAt: time.Unix(100, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &commandContext{deps: Deps{
+		ProcessAlive: func(int) bool { return true },
+		Now:          func() time.Time { return time.Unix(200, 0).UTC() },
+	}.withDefaults()}
+
+	st, err := c.inspectDaemon(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != stateUnhealthy {
+		t.Fatalf("local state = %q, want unhealthy (unchanged)", st.State)
+	}
+	if st.Error != "healthz: HTTP 429" {
+		t.Fatalf("local error = %q, want the byte-identical %q", st.Error, "healthz: HTTP 429")
+	}
+}
+
+// A stray --url must never shut down someone else's daemon.
+func TestStopRefusesRemoteTarget(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("stop must refuse before touching local state"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "AO_URL"},
+	}
+	_, err := c.stopDaemon(context.Background(), stopOptions{})
+	if err == nil {
+		t.Fatal("ao stop --url must refuse")
+	}
+	for _, want := range []string{"refusing to stop a remote daemon", "AO_URL", "http://host:3011"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+	// The message must not assert anything about what the target exposes: a
+	// loopback --url refuses too, and there /shutdown IS reachable.
+	if strings.Contains(err.Error(), "/shutdown") {
+		t.Fatalf("error %q claims something about the target's routes", err.Error())
+	}
+}
+
+// The refusal is unconditional: a --url that happens to name loopback is still
+// not the daemon `ao stop` discovered locally, and must not be stopped.
+func TestStopRefusesLoopbackURLToo(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("stop must refuse before touching local state"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://127.0.0.1:3001", token: "tok", source: "--url"},
+	}
+	if _, err := c.stopDaemon(context.Background(), stopOptions{}); err == nil {
+		t.Fatal("ao stop --url http://127.0.0.1:3001 must refuse")
+	}
+}
+
+// CLI telemetry posts to loopback-only /internal routes, which are 404'd at the
+// LAN socket — and must not be sent to another machine's daemon regardless.
+func TestPostLoopbackJSONSkippedForRemote(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("telemetry must not reach a remote daemon"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok"},
+	}
+	if err := c.postLoopbackJSON(context.Background(), "/internal/telemetry/cli-invoked", map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/cli/remote_test.go
+++ b/backend/internal/cli/remote_test.go
@@ -445,3 +445,150 @@ func TestPostLoopbackJSONSkippedForRemote(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// A host-relative path aimed at a remote daemon is refused, because the daemon
+// resolves it against ITS OWN home/cwd — silently naming a directory on another
+// machine. Measured: `ao project add --path '~/repo' --url <remote>` registers
+// the remote host's ~/repo and never consults the operator's.
+func TestCheckRemoteProjectPathRefusesHostRelative(t *testing.T) {
+	aoHome(t)
+	remote := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "--url"},
+	}
+	for _, p := range []string{"~", "~/repo", "~user/repo", "repo", "./repo", "../repo"} {
+		err := remote.checkRemoteProjectPath(p)
+		if err == nil {
+			t.Fatalf("checkRemoteProjectPath(%q) = nil, want a refusal", p)
+		}
+		if ExitCode(err) != 2 {
+			t.Errorf("checkRemoteProjectPath(%q) exit code = %d, want 2 (usage)", p, ExitCode(err))
+		}
+		if !strings.Contains(err.Error(), "http://host:3011") {
+			t.Errorf("refusal for %q does not name the target: %v", p, err)
+		}
+	}
+
+	// Absolute paths stay allowed: they are meaningful on the remote host, and
+	// refusing them would make a remote target useless. Every absolute FORM must
+	// be accepted regardless of the OS running this test — the destination
+	// filesystem is the remote daemon's, not this machine's. Using
+	// filepath.IsAbs here shipped as a bug: it calls "/srv/repo" relative on
+	// Windows, so a Windows CLI could not register a project on a Linux host.
+	for _, p := range []string{
+		"/srv/repo",        // POSIX absolute
+		`C:\srv\repo`,      // Windows drive-absolute, backslash
+		"C:/srv/repo",      // Windows drive-absolute, forward slash
+		`\\server\share\r`, // Windows UNC
+	} {
+		if err := remote.checkRemoteProjectPath(p); err != nil {
+			t.Errorf("absolute path %q refused: %v", p, err)
+		}
+	}
+
+	// Still refused everywhere: forms that are host-relative even on Windows.
+	for _, p := range []string{`C:repo`, `\repo`} {
+		if err := remote.checkRemoteProjectPath(p); err == nil {
+			t.Errorf("checkRemoteProjectPath(%q) = nil, want a refusal (drive/current-drive relative)", p)
+		}
+	}
+
+	// Local behavior is untouched — every form above is still accepted.
+	local := &commandContext{deps: Deps{}.withDefaults()}
+	for _, p := range []string{"~", "~/repo", "repo", "./repo", "/srv/repo"} {
+		if err := local.checkRemoteProjectPath(p); err != nil {
+			t.Fatalf("local checkRemoteProjectPath(%q) = %v, want nil", p, err)
+		}
+	}
+}
+
+// A local signal — AO_PROJECT_ID, AO_SESSION_ID or the current directory —
+// must never select a project on a remote daemon. Measured on the base commit:
+// `ao spawn --url <remote>` run inside an AO session inherited AO_PROJECT_ID
+// and spawned a real session on the remote host, exit 0, no warning.
+//
+// Deliberately path-free so the assertion is identical on every runner OS.
+func TestCheckRemoteImplicitProjectRefusesLocalSignals(t *testing.T) {
+	newRemote := func() *commandContext {
+		return &commandContext{
+			deps:   Deps{}.withDefaults(),
+			remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "--url"},
+		}
+	}
+	for _, tc := range []struct {
+		name       string
+		projectID  string
+		sessionID  string
+		wantSignal string
+	}{
+		{name: "AO_PROJECT_ID", projectID: "demo", wantSignal: "AO_PROJECT_ID"},
+		{name: "AO_SESSION_ID", sessionID: "demo-1", wantSignal: "AO_SESSION_ID"},
+		{name: "cwd", wantSignal: "the current directory"},
+		// An id that is only whitespace is not a signal — resolution would fall
+		// through to the next one, so the refusal must name that one instead.
+		{name: "blank AO_PROJECT_ID falls through", projectID: " \t ", sessionID: "demo-1", wantSignal: "AO_SESSION_ID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AO_PROJECT_ID", tc.projectID)
+			t.Setenv("AO_SESSION_ID", tc.sessionID)
+			err := newRemote().checkRemoteImplicitProject("")
+			if err == nil {
+				t.Fatal("checkRemoteImplicitProject = nil, want a refusal")
+			}
+			if ExitCode(err) != 2 {
+				t.Errorf("exit code = %d, want 2 (usage)", ExitCode(err))
+			}
+			for _, want := range []string{tc.wantSignal, "--url", "http://host:3011", "--project"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("refusal does not mention %q: %v", want, err)
+				}
+			}
+		})
+	}
+
+	// An explicit --project is the one input that means the same on both hosts.
+	t.Setenv("AO_PROJECT_ID", "demo")
+	if err := newRemote().checkRemoteImplicitProject("other"); err != nil {
+		t.Errorf("explicit --project refused: %v", err)
+	}
+
+	// Local behavior is untouched: every implicit signal is still accepted.
+	local := &commandContext{deps: Deps{}.withDefaults()}
+	for _, id := range []string{"", "demo"} {
+		if err := local.checkRemoteImplicitProject(id); err != nil {
+			t.Errorf("local checkRemoteImplicitProject(%q) = %v, want nil", id, err)
+		}
+	}
+}
+
+// End to end: the refusal must land BEFORE any request, so a wrong-machine
+// spawn cannot happen at all. The empty request log is the real assertion —
+// a session created on the wrong host is undetectable from the output.
+func TestSpawnRemoteRefusesInheritedProjectEnv(t *testing.T) {
+	aoHome(t)
+	t.Setenv("AO_SESSION_ID", "")
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	t.Setenv("AO_TOKEN", "s3cret12")
+	t.Setenv("AO_PROJECT_ID", "demo")
+
+	var out bytes.Buffer
+	err := executeWithDeps(Deps{Out: &out, Err: &out, ProcessAlive: func(int) bool { return true }},
+		[]string{"spawn", "--url", srv.URL, "--name", "worker", "--prompt", "hi"})
+	if err == nil {
+		t.Fatalf("spawn --url with an inherited AO_PROJECT_ID succeeded: %s", out.String())
+	}
+	if ExitCode(err) != 2 {
+		t.Errorf("exit code = %d, want 2 (usage)", ExitCode(err))
+	}
+	if !strings.Contains(err.Error(), "AO_PROJECT_ID") || !strings.Contains(err.Error(), "--project") {
+		t.Errorf("error does not name the signal and the remedy: %v", err)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("refused spawn still contacted the remote daemon: %v", requests)
+	}
+}

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -162,6 +162,7 @@ func (d Deps) withDefaults() Deps {
 func NewRootCommand(deps Deps) *cobra.Command {
 	deps = deps.withDefaults()
 	ctx := &commandContext{deps: deps}
+	var remoteURL string
 
 	root := &cobra.Command{
 		Use:           "ao",
@@ -171,12 +172,21 @@ func NewRootCommand(deps Deps) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Resolve before anything else: every daemon call below, telemetry
+			// included, depends on which daemon this invocation targets.
+			remote, err := resolveRemoteTarget(remoteURL)
+			if err != nil {
+				return err
+			}
+			ctx.remote = remote
 			if shouldEmitCLIInvocation(cmd) {
 				ctx.emitCLIInvoked(cmd.Context(), cmd)
 			}
 			return nil
 		},
 	}
+	root.PersistentFlags().StringVar(&remoteURL, "url", "",
+		"Base URL of a remote AO daemon, e.g. http://host:3011 (env AO_URL); credential from AO_TOKEN or ~/.ao/remotes.json")
 	root.SetIn(deps.In)
 	root.SetOut(deps.Out)
 	root.SetErr(deps.Err)
@@ -217,6 +227,8 @@ func NewRootCommand(deps Deps) *cobra.Command {
 
 type commandContext struct {
 	deps Deps
+	// remote is nil for the default local daemon; see remote.go.
+	remote *remoteTarget
 }
 
 func shouldEmitCLIInvocation(cmd *cobra.Command) bool {

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -182,7 +182,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 		}
 		return pflag.NormalizedName(name)
 	})
-	f.StringVar(&opts.project, "project", "", "Project id to spawn the session in (default: AO_PROJECT_ID, current registered repo, or Scratch when it is the only project)")
+	f.StringVar(&opts.project, "project", "", "Project id to spawn the session in (default: AO_PROJECT_ID, current registered repo, or Scratch when it is the only project; required with --url)")
 	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, muse, kiro, kilocode, vibe, pi, kimchi, prime-agent, autohand (default: project worker.agent; orchestrator spawns default to project orchestrator.agent; required if the project has none)")
 	f.StringVar(&opts.kind, "kind", "", "Session role: worker or orchestrator (default: worker)")
 	f.StringVar(&opts.mode, "mode", "", "Initial session interface: chat (structured agent connection) or tui (the agent's native terminal). Omitted uses the daemon default; compatible sessions can switch later.")
@@ -216,6 +216,11 @@ func (c *commandContext) fetchAgentInventory(ctx context.Context, refresh bool) 
 func (c *commandContext) resolveSpawnProject(ctx context.Context, explicit string) (projectDetails, error) {
 	if id := strings.TrimSpace(explicit); id != "" {
 		return c.fetchProjectDetails(ctx, id)
+	}
+	// Every fallback below reads a LOCAL signal and resolves it against
+	// whichever daemon we are talking to. That is only safe for the local one.
+	if err := c.checkRemoteImplicitProject(explicit); err != nil {
+		return projectDetails{}, err
 	}
 	if id := strings.TrimSpace(os.Getenv("AO_PROJECT_ID")); id != "" {
 		return c.fetchProjectDetails(ctx, id)

--- a/backend/internal/cli/status.go
+++ b/backend/internal/cli/status.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -28,7 +29,22 @@ const (
 	stateStale     daemonState = "stale"
 	stateUnhealthy daemonState = "unhealthy"
 	stateNotReady  daemonState = "not_ready"
+	// stateLockedOut is reachable only for a remote target: the per-source
+	// lockout lives in the LAN listener's auth middleware, which the loopback
+	// path never reaches. See remoteProbeFailure.
+	stateLockedOut daemonState = "locked_out"
 )
+
+// probeHTTPError is a non-2xx probe response. Its message is deliberately
+// identical to the plain error it replaces, so the local path renders
+// byte-for-byte as before; it exists so the remote path can read the status code
+// back out and tell a lockout apart from an unhealthy daemon.
+type probeHTTPError struct {
+	path   string
+	status int
+}
+
+func (e probeHTTPError) Error() string { return fmt.Sprintf("%s: HTTP %d", e.path, e.status) }
 
 type daemonStatus struct {
 	State     daemonState `json:"state"`
@@ -36,12 +52,15 @@ type daemonStatus struct {
 	Port      int         `json:"port,omitempty"`
 	StartedAt *time.Time  `json:"startedAt,omitempty"`
 	Uptime    string      `json:"uptime,omitempty"`
-	RunFile   string      `json:"runFile"`
-	DataDir   string      `json:"dataDir"`
-	Health    string      `json:"health,omitempty"`
-	Ready     string      `json:"ready,omitempty"`
-	Error     string      `json:"error,omitempty"`
-	owned     bool
+	RunFile   string      `json:"runFile,omitempty"`
+	DataDir   string      `json:"dataDir,omitempty"`
+	// URL is set only for a remote target, where there is no local run-file or
+	// data dir to report.
+	URL    string `json:"url,omitempty"`
+	Health string `json:"health,omitempty"`
+	Ready  string `json:"ready,omitempty"`
+	Error  string `json:"error,omitempty"`
+	owned  bool
 }
 
 type probeResult struct {
@@ -74,6 +93,9 @@ func newStatusCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error) {
+	if c.remote != nil {
+		return c.inspectRemoteDaemon(ctx), nil
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return daemonStatus{}, err
@@ -100,7 +122,7 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 		return st, nil
 	}
 
-	health, err := c.readProbe(ctx, info.Port, "healthz")
+	health, err := c.readProbe(ctx, loopbackBase(info.Port), "healthz")
 	if err != nil {
 		st.State = stateUnhealthy
 		st.Error = err.Error()
@@ -118,7 +140,7 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 		return st, nil
 	}
 
-	ready, err := c.readProbe(ctx, info.Port, "readyz")
+	ready, err := c.readProbe(ctx, loopbackBase(info.Port), "readyz")
 	if err != nil {
 		st.State = stateNotReady
 		st.Error = err.Error()
@@ -139,21 +161,81 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 	return st, nil
 }
 
-func (c *commandContext) readProbe(ctx context.Context, port int, path string) (probeResult, error) {
+func loopbackBase(port int) string {
+	return fmt.Sprintf("http://%s:%d", config.LoopbackHost, port)
+}
+
+// inspectRemoteDaemon reports the state of a daemon reached over the network.
+// There is no run-file and no local PID to gate on, so liveness comes entirely
+// from the authenticated /healthz and /readyz probes.
+func (c *commandContext) inspectRemoteDaemon(ctx context.Context) daemonStatus {
+	st := daemonStatus{State: stateStopped, URL: c.remote.baseURL}
+
+	health, err := c.readProbe(ctx, c.remote.baseURL, "healthz")
+	if err != nil {
+		return remoteProbeFailure(st, err, stateUnhealthy)
+	}
+	if health.Service != daemonmeta.ServiceName {
+		st.State = stateUnhealthy
+		st.Error = "healthz: response is not from AO daemon"
+		return st
+	}
+	st.PID = health.PID
+	st.Health = health.Status
+	if health.Status != "ok" {
+		st.State = stateUnhealthy
+		return st
+	}
+
+	ready, err := c.readProbe(ctx, c.remote.baseURL, "readyz")
+	if err != nil {
+		return remoteProbeFailure(st, err, stateNotReady)
+	}
+	st.Ready = ready.Status
+	if ready.Status == string(stateReady) {
+		st.State = stateReady
+		return st
+	}
+	st.State = stateNotReady
+	return st
+}
+
+// remoteProbeFailure classifies a failed probe against a remote daemon. A 429 is
+// the LAN listener's per-source lockout after repeated bad connection passwords:
+// the daemon is healthy, so reporting "unhealthy" inverts the diagnosis and
+// sends a user who fat-fingered a password off to investigate a daemon that is
+// fine. Remote-only by construction — the lockout lives in the authenticated
+// listener's middleware, which the loopback path never reaches — so local status
+// is untouched.
+func remoteProbeFailure(st daemonStatus, err error, fallback daemonState) daemonStatus {
+	var httpErr probeHTTPError
+	if errors.As(err, &httpErr) && httpErr.status == http.StatusTooManyRequests {
+		st.State = stateLockedOut
+		st.Error = "too many failed connection passwords from this machine; it is temporarily locked out — " +
+			"wait for the lockout to clear, then retry with the correct password. The daemon itself is fine."
+		return st
+	}
+	st.State = fallback
+	st.Error = err.Error()
+	return st
+}
+
+func (c *commandContext) readProbe(ctx context.Context, base, path string) (probeResult, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("http://%s:%d/%s", config.LoopbackHost, port, path), http.NoBody)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+"/"+path, http.NoBody) // #nosec G704 -- base is loopback or an explicitly configured daemon URL.
 	if err != nil {
 		return probeResult{}, err
 	}
+	c.authorize(req)
 	resp, err := c.deps.HTTPClient.Do(req)
 	if err != nil {
 		return probeResult{}, fmt.Errorf("%s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return probeResult{}, fmt.Errorf("%s: HTTP %d", path, resp.StatusCode)
+		return probeResult{}, probeHTTPError{path: path, status: resp.StatusCode}
 	}
 	var body probeResult
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
@@ -200,11 +282,20 @@ func writeStatus(cmd *cobra.Command, st daemonStatus) error {
 			return err
 		}
 	}
-	if _, err := fmt.Fprintf(out, "  run file: %s\n", st.RunFile); err != nil {
-		return err
+	if st.URL != "" {
+		if _, err := fmt.Fprintf(out, "  url: %s\n", st.URL); err != nil {
+			return err
+		}
 	}
-	if _, err := fmt.Fprintf(out, "  data dir: %s\n", st.DataDir); err != nil {
-		return err
+	if st.RunFile != "" {
+		if _, err := fmt.Fprintf(out, "  run file: %s\n", st.RunFile); err != nil {
+			return err
+		}
+	}
+	if st.DataDir != "" {
+		if _, err := fmt.Fprintf(out, "  data dir: %s\n", st.DataDir); err != nil {
+			return err
+		}
 	}
 	if st.Health != "" {
 		if _, err := fmt.Fprintf(out, "  healthz: %s\n", st.Health); err != nil {

--- a/backend/internal/cli/stop.go
+++ b/backend/internal/cli/stop.go
@@ -46,6 +46,19 @@ func newStopCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) stopDaemon(ctx context.Context, opts stopOptions) (daemonStatus, error) {
+	// `ao stop` is the one command that must never follow a stray --url/AO_URL:
+	// silently shutting down a daemon on someone else's machine is not a
+	// recoverable mistake. The refusal is unconditional, and deliberately does
+	// NOT branch on whether the URL looks like loopback — --url means "a daemon
+	// other than the one I discovered locally", and letting the single
+	// destructive verb behave differently based on how a string happens to look
+	// is exactly the surprise worth refusing.
+	if c.remote != nil {
+		return daemonStatus{}, fmt.Errorf(
+			"refusing to stop a remote daemon: %s targets %s. `ao stop` only ever stops the local daemon "+
+				"it discovers through the run-file, never a --url/AO_URL target — stop that daemon on the machine running it",
+			c.remote.source, c.remote.baseURL)
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return daemonStatus{}, err

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -518,6 +518,11 @@ func resolveDataDir() (string, error) {
 	return filepath.Join(stateDir, "data"), nil
 }
 
+// StateDir returns the canonical AO home directory (~/.ao) that holds
+// running.json, the data dir, and the CLI's remotes file. Exported for callers
+// that need the directory itself rather than a path Load already resolves.
+func StateDir() (string, error) { return defaultStateDir() }
+
 func defaultStateDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -17,6 +17,48 @@ go build -o ./bin/ao ./cmd/ao
 ./bin/ao agent ls
 ```
 
+## Targeting a remote daemon
+
+By default every command talks to the local daemon: it reads `running.json`,
+checks the PID is alive, and calls `127.0.0.1`. The global `--url` flag (or
+`AO_URL`) points the same commands at another machine's LAN listener instead
+(see [ADR 0001](../adr/0001-lan-listener-for-mobile.md)), skipping the run-file
+and the local liveness check entirely — so it works on a machine that has never
+run AO:
+
+```bash
+ao status --url http://100.64.0.1:3011
+AO_URL=http://100.64.0.1:3011 ao agent ls
+```
+
+The credential is the daemon's connection password — the same one the mobile app
+pairs with — sent as `Authorization: Bearer <password>`. It comes from `AO_TOKEN`,
+or from `~/.ao/remotes.json`, which mirrors the mobile app's saved-node list and
+must be mode `0600` (the CLI refuses to read it otherwise):
+
+```json
+{
+  "remotes": [
+    { "label": "desk", "url": "http://100.64.0.1:3011", "password": "abcd1234" }
+  ]
+}
+```
+
+Notes:
+
+- The link is plain HTTP by design (ADR 0001, home network / Tailscale only).
+  There is no TLS or certificate pinning.
+- The URL must not carry a username or password. A credential belongs in
+  `AO_TOKEN` or the `remotes.json` entry, so `--url http://user:pw@host:3011` is
+  rejected rather than silently stripped.
+- `ao stop` only ever stops the local daemon it found through `running.json`. A
+  `--url` / `AO_URL` target is refused — including one that names loopback, so
+  the single destructive verb never changes behavior based on how the URL looks.
+- CLI telemetry (`/internal/*`) is never sent to a remote daemon.
+- Repeated bad passwords lock your source address out of the LAN listener for a
+  minute. `ao status` reports that as `locked_out` rather than `unhealthy` — the
+  daemon is fine; wait and retry. This state cannot occur against a local daemon.
+
 ## Current commands
 
 Every product command resolves to a daemon HTTP route. Run `ao <command>


### PR DESCRIPTION
## Ticket

No upstream issue. [RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md). Stacked on #4358.

## Problem

With `--url`, the daemon resolves `--path` against its own filesystem, and every implicit project signal — `AO_PROJECT_ID`, `AO_SESSION_ID`, the current directory — describes the machine running the CLI, not the remote one. Each is silently matched against the wrong host's projects, with output that looks like success, and a PR-ref lookup can fall back to running `gh` against a local checkout while addressing a remote daemon.

## Solution

Host-relative paths are refused for a remote target; absolute paths (including Windows drive-absolute and UNC forms) are judged for any host rather than the OS running the CLI. Implicit-project matching requires an explicit `--project` for a remote target. PR-ref resolution refuses its local-`gh` fallback and asks for a full URL instead. `project ls` gains a `PATH` column so "where does this project live" has an answer once the daemon isn't this machine.

## How Has This Been Tested?

`cd backend && go build ./... && go vet ./... && go test ./... && go test -race ./internal/cli/` on the current `main` (`c9a0adb2`): 158 packages ok, `gofmt -l` clean. Eight new tests cover path refusal across every host-relative/absolute form, implicit-project refusal with the explicit-`--project` escape, `ao spawn --url` refusing before any request, and four `resolvePRRef` cases.

## Artifacts (if appropriate):

No renderable surface: Go CLI code only, no files under `frontend/src`. Behaviour is covered by the tests above.
