### PR TITLE
fix(daemon): distinguish a LAN policy block from a missing route

### DIFF
--- a/backend/internal/cli/client.go
+++ b/backend/internal/cli/client.go
@@ -91,7 +91,37 @@ func (c *commandContext) doJSON(ctx context.Context, method, path string, body, 
 }
 
 func (c *commandContext) postLoopbackJSON(ctx context.Context, path string, body any) error {
+	// These are loopback-only control routes (/internal/*), 404'd at the LAN
+	// socket by design — and CLI telemetry has no business reaching a daemon on
+	// someone else's machine. Drop them when a remote target is set.
+	if c.remote != nil {
+		return nil
+	}
 	return c.doJSONPath(ctx, http.MethodPost, path, body, nil)
+}
+
+// daemonBase returns the base URL every daemon call targets. With a remote
+// target it is the given URL; otherwise it is the loopback daemon discovered
+// through the run-file, gated on a live local PID as before.
+func (c *commandContext) daemonBase() (string, error) {
+	if c.remote != nil {
+		return c.remote.baseURL, nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return "", err
+	}
+	info, err := runfile.Read(cfg.RunFilePath)
+	if err != nil {
+		return "", err
+	}
+	if info == nil {
+		return "", fmt.Errorf("AO daemon is not running — start it with `ao start`")
+	}
+	if !c.deps.ProcessAlive(info.PID) {
+		return "", fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
+	}
+	return fmt.Sprintf("http://%s:%d", config.LoopbackHost, info.Port), nil
 }
 
 func (c *commandContext) doJSONPath(ctx context.Context, method, path string, body, out any) error {
@@ -114,19 +144,9 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 	headers map[string]string,
 	timeout time.Duration,
 ) error {
-	cfg, err := config.Load()
+	base, err := c.daemonBase()
 	if err != nil {
 		return err
-	}
-	info, err := runfile.Read(cfg.RunFilePath)
-	if err != nil {
-		return err
-	}
-	if info == nil {
-		return fmt.Errorf("AO daemon is not running — start it with `ao start`")
-	}
-	if !c.deps.ProcessAlive(info.PID) {
-		return fmt.Errorf("AO daemon is not running (stale run-file at %s) — start it with `ao start`", cfg.RunFilePath)
 	}
 
 	var reader io.Reader = http.NoBody
@@ -137,14 +157,14 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 		}
 		reader = bytes.NewReader(payload)
 	}
-	url := fmt.Sprintf("http://%s:%d%s", config.LoopbackHost, info.Port, path)
-	req, err := http.NewRequestWithContext(ctx, method, url, reader) // #nosec G704 -- daemon host is fixed loopback; path is an internal API route.
+	req, err := http.NewRequestWithContext(ctx, method, base+path, reader) // #nosec G704 -- host is loopback or an explicitly configured daemon URL; path is an internal API route.
 	if err != nil {
 		return err
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	c.authorize(req)
 	for name, value := range headers {
 		req.Header.Set(name, value)
 	}
@@ -153,7 +173,7 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 	// give daemon API calls far more headroom than the 2s status-probe timeout.
 	client := *c.deps.HTTPClient
 	client.Timeout = timeout
-	resp, err := client.Do(req) // #nosec G704 -- request target is the fixed loopback daemon URL above.
+	resp, err := client.Do(req) // #nosec G704 -- request target is the daemon base URL resolved above.
 	if err != nil {
 		return fmt.Errorf("call daemon: %w", err)
 	}

--- a/backend/internal/cli/loopback_only_test.go
+++ b/backend/internal/cli/loopback_only_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
+	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
+)
+
+// A route the daemon blocks on its LAN listener must not reach the operator as
+// ROUTE_NOT_FOUND. That code reads as "that daemon is too old / that endpoint
+// does not exist" and sends whoever hits it off to audit daemon builds, when
+// the truth is that the block is a deliberate policy.
+//
+// The stand-in remote is the REAL LAN listener (httpd.NewMobileLAN), not a
+// hand-written envelope, so this pins what the CLI actually renders for what
+// the daemon actually sends — the two cannot drift apart. The inner handler
+// records every request it sees: it must record none, since the block sits
+// outside both auth and the router.
+func TestRemoteRendersLoopbackOnlyBlockNotMissingRoute(t *testing.T) {
+	setBrowserIdentity(t)
+	aoHome(t)
+	t.Setenv("AO_TOKEN", "s3cret12")
+
+	var reached []string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = append(reached, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"sessionId":"ao-1","connected":true,"transport":"electron-webcontents-debugger"}`)
+	})
+	lan := httpd.NewMobileLAN(inner, 0, slog.Default(), nil)
+	lan.SetPasswordHash(mobilebridge.HashPassword("s3cret12"))
+	port, err := lan.Start(0)
+	if err != nil {
+		t.Fatalf("start LAN listener: %v", err)
+	}
+	defer lan.Stop(context.Background())
+
+	var out bytes.Buffer
+	err = executeWithDeps(
+		Deps{Out: &out, Err: &out, ProcessAlive: func(int) bool { return true }},
+		[]string{"browser", "status", "--url", fmt.Sprintf("http://127.0.0.1:%d", port)},
+	)
+	if err == nil {
+		t.Fatalf("a LAN-blocked route succeeded: %s", out.String())
+	}
+	msg := err.Error()
+	for _, want := range []string{"ROUTE_LOOPBACK_ONLY", "loopback listener only"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error does not read as a policy block (missing %q): %v", want, err)
+		}
+	}
+	for _, unwanted := range []string{"ROUTE_NOT_FOUND", "has no handler"} {
+		if strings.Contains(msg, unwanted) {
+			t.Errorf("error still reads as a missing route (%q): %v", unwanted, err)
+		}
+	}
+	if len(reached) != 0 {
+		t.Fatalf("blocked request reached the router: %v", reached)
+	}
+}

--- a/backend/internal/cli/remote.go
+++ b/backend/internal/cli/remote.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+)
+
+// A remote target replaces the local run-file handshake: instead of reading
+// running.json and gating on a live local PID, every daemon call goes to the
+// given base URL carrying the daemon's connection password as a Bearer token —
+// the same credential channel the mobile client uses (ADR 0001).
+//
+// It is opt-in and never inferred: with no --url and no AO_URL, the CLI keeps
+// its loopback-only behavior exactly as before.
+type remoteTarget struct {
+	baseURL string
+	token   string
+	// source names where the URL came from ("--url" or "AO_URL") so an error can
+	// tell the user which one is pointing them off-box.
+	source string
+}
+
+// remotesFileName holds saved remote daemons under the AO home directory. It
+// carries connection passwords in plaintext, so it must be mode 0600.
+const remotesFileName = "remotes.json"
+
+// remotesFile mirrors the mobile app's multi-node store
+// (packages/mobile/lib/config.ts): a list of saved nodes, each labelled, each
+// with its own connection password. The CLI has no OS keystore to split the
+// secret into, so the password lives in the file and the file must be 0600.
+type remotesFile struct {
+	Remotes []remoteEntry `json:"remotes"`
+}
+
+type remoteEntry struct {
+	Label    string `json:"label,omitempty"`
+	URL      string `json:"url"`
+	Password string `json:"password"`
+}
+
+// resolveRemoteTarget resolves the remote daemon this invocation targets, or
+// nil for the default local daemon. The URL comes from --url or AO_URL; the
+// credential from AO_TOKEN or a matching entry in ~/.ao/remotes.json.
+func resolveRemoteTarget(flagURL string) (*remoteTarget, error) {
+	raw, source := strings.TrimSpace(flagURL), "--url"
+	if raw == "" {
+		raw, source = strings.TrimSpace(os.Getenv("AO_URL")), "AO_URL"
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	base, err := normalizeRemoteURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	token := strings.TrimSpace(os.Getenv("AO_TOKEN"))
+	if token == "" {
+		entry, err := lookupRemoteEntry(base)
+		if err != nil {
+			return nil, err
+		}
+		path, _ := remotesFilePath()
+		switch {
+		case entry == nil:
+			return nil, fmt.Errorf("no connection password for %s — set AO_TOKEN or add an entry for it to %s", base, path)
+		case strings.TrimSpace(entry.Password) == "":
+			return nil, fmt.Errorf("the entry for %s in %s has an empty password — set its password, or use AO_TOKEN", base, path)
+		}
+		token = strings.TrimSpace(entry.Password)
+	}
+	return &remoteTarget{baseURL: base, token: token, source: source}, nil
+}
+
+// normalizeRemoteURL turns a user-supplied target into a base URL with no
+// trailing slash. A bare "host:3011" is accepted and assumed plaintext http,
+// matching the LAN listener (ADR 0001 is deliberately http-only).
+func normalizeRemoteURL(raw string) (string, error) {
+	// A URL-embedded credential is never trusted — the connection password comes
+	// from AO_TOKEN or remotes.json. Silently dropping it would leave the user
+	// certain they had passed a password and then told there was none, so say so
+	// instead. Checked first, and reported without quoting the URL, so no later
+	// error path can echo the credential into a message or a log line.
+	if hasUserinfo(raw) {
+		return "", errors.New("invalid daemon URL: it must not carry a username or password — " +
+			"pass the connection password in AO_TOKEN or a ~/.ao/remotes.json entry")
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid daemon URL %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid daemon URL %q: scheme must be http or https", raw)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid daemon URL %q: missing host", raw)
+	}
+	return strings.TrimRight(u.Scheme+"://"+u.Host+u.Path, "/"), nil
+}
+
+// hasUserinfo reports whether raw's authority component carries userinfo. It
+// works textually, before url.Parse, so that a malformed URL cannot slip a
+// credential into the parse error — and it catches the scheme-less form
+// ("user:pw@host:3011") too. An "@" in the path or query is not authority.
+func hasUserinfo(raw string) bool {
+	authority := raw
+	if i := strings.Index(authority, "://"); i >= 0 {
+		authority = authority[i+3:]
+	}
+	if i := strings.IndexAny(authority, "/?#"); i >= 0 {
+		authority = authority[:i]
+	}
+	return strings.Contains(authority, "@")
+}
+
+func remotesFilePath() (string, error) {
+	dir, err := config.StateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, remotesFileName), nil
+}
+
+// lookupRemoteEntry returns the saved entry for base, or nil when the file does
+// not exist or holds no entry for it. A nil entry and an entry with an empty
+// password are different problems, so the caller can say which one it is. A file
+// readable by anyone but the owner is refused rather than used: it is a
+// plaintext credential store.
+func lookupRemoteEntry(base string) (*remoteEntry, error) {
+	path, err := remotesFilePath()
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	// Windows file modes do not carry meaningful group/other bits, so the check
+	// would reject every file there.
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("%s holds connection passwords and is readable by others (mode %04o) — run: chmod 600 %s",
+			path, info.Mode().Perm(), path)
+	}
+	raw, err := os.ReadFile(path) // #nosec G304 -- fixed path under the AO home directory.
+	if err != nil {
+		return nil, err
+	}
+	var file remotesFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, entry := range file.Remotes {
+		saved, err := normalizeRemoteURL(entry.URL)
+		if err != nil {
+			continue // a hand-edited entry must not break every other one
+		}
+		if saved == base {
+			return &entry, nil
+		}
+	}
+	return nil, nil
+}
+
+// authorize presents the remote connection password. Loopback calls carry no
+// credential: the local daemon's loopback listener has no auth at all.
+func (c *commandContext) authorize(req *http.Request) {
+	if c.remote != nil {
+		req.Header.Set("Authorization", "Bearer "+c.remote.token)
+	}
+}

--- a/backend/internal/cli/remote_test.go
+++ b/backend/internal/cli/remote_test.go
@@ -1,0 +1,447 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/daemonmeta"
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+)
+
+// aoHome points the AO home directory (and therefore remotes.json) at a temp
+// dir, and clears the remote env vars so a developer's real AO_URL/AO_TOKEN
+// cannot leak into a test.
+func aoHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+	t.Setenv("AO_URL", "")
+	t.Setenv("AO_TOKEN", "")
+	return dir
+}
+
+func writeRemotes(t *testing.T, home string, perm os.FileMode, entries ...remoteEntry) {
+	t.Helper()
+	raw, err := json.Marshal(remotesFile{Remotes: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".ao"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".ao", remotesFileName)
+	if err := os.WriteFile(path, raw, perm); err != nil {
+		t.Fatal(err)
+	}
+	// WriteFile honors umask, so force the mode the test asked for.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNormalizeRemoteURL(t *testing.T) {
+	ok := map[string]string{
+		"http://host:3011":         "http://host:3011",
+		"http://host:3011/":        "http://host:3011",
+		"host:3011":                "http://host:3011", // bare host defaults to plaintext http
+		"https://box.ts.net":       "https://box.ts.net",
+		"http://host:3011/ao/":     "http://host:3011/ao",
+		"HTTP://Host:3011":         "http://Host:3011",
+		"http://100.64.0.1:3011//": "http://100.64.0.1:3011",
+	}
+	for in, want := range ok {
+		got, err := normalizeRemoteURL(in)
+		if err != nil {
+			t.Fatalf("normalizeRemoteURL(%q): %v", in, err)
+		}
+		if got != want {
+			t.Errorf("normalizeRemoteURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+	for _, in := range []string{"ftp://host", "ws://host:3011", "http://", "://x"} {
+		if got, err := normalizeRemoteURL(in); err == nil {
+			t.Errorf("normalizeRemoteURL(%q) = %q, want error", in, got)
+		}
+	}
+
+	// An "@" outside the authority is not userinfo and must still parse.
+	for _, in := range []string{"http://host:3011/a@b", "http://host:3011/x?q=a@b"} {
+		if _, err := normalizeRemoteURL(in); err != nil {
+			t.Errorf("normalizeRemoteURL(%q): %v", in, err)
+		}
+	}
+}
+
+// A credential typed into the URL is rejected outright rather than silently
+// dropped — and the error must never echo it back.
+func TestNormalizeRemoteURLRejectsUserinfo(t *testing.T) {
+	for _, in := range []string{
+		"http://user:hunter2@host:3011",
+		"https://user:hunter2@host:3011/path",
+		"user:hunter2@host:3011", // scheme-less form
+		"http://hunter2@host:3011",
+	} {
+		_, err := normalizeRemoteURL(in)
+		if err == nil {
+			t.Fatalf("normalizeRemoteURL(%q) succeeded, want a userinfo rejection", in)
+		}
+		if !strings.Contains(err.Error(), "must not carry a username or password") {
+			t.Errorf("normalizeRemoteURL(%q) error = %q, want a userinfo rejection", in, err)
+		}
+		if strings.Contains(err.Error(), "hunter2") {
+			t.Errorf("normalizeRemoteURL(%q) echoed the credential: %q", in, err)
+		}
+	}
+}
+
+// The same rejection must reach the user through the real resolution path, with
+// the credential still absent from the message.
+func TestResolveRemoteTargetRejectsUserinfo(t *testing.T) {
+	aoHome(t)
+	_, err := resolveRemoteTarget("http://user:hunter2@host:3011")
+	if err == nil || strings.Contains(err.Error(), "hunter2") {
+		t.Fatalf("err = %v, want a rejection that does not echo the password", err)
+	}
+}
+
+// No --url and no AO_URL must resolve to nil: that is what keeps every local
+// invocation on the run-file path it has always used.
+func TestResolveRemoteTargetDefaultsToLocal(t *testing.T) {
+	aoHome(t)
+	got, err := resolveRemoteTarget("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("resolveRemoteTarget = %+v, want nil (local)", got)
+	}
+}
+
+func TestResolveRemoteTargetCredentialSources(t *testing.T) {
+	t.Run("AO_TOKEN wins over remotes.json", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{URL: "http://host:3011", Password: "fromfile"})
+		t.Setenv("AO_TOKEN", "fromenv")
+
+		got, err := resolveRemoteTarget("http://host:3011")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.token != "fromenv" || got.baseURL != "http://host:3011" || got.source != "--url" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("remotes.json entry matched by URL", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600,
+			remoteEntry{Label: "other", URL: "http://elsewhere:3011", Password: "nope"},
+			// Stored with a trailing slash: matching is on the normalized URL.
+			remoteEntry{Label: "desk", URL: "http://host:3011/", Password: "s3cret12"},
+		)
+		got, err := resolveRemoteTarget("host:3011")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.token != "s3cret12" {
+			t.Fatalf("token = %q, want s3cret12", got.token)
+		}
+	})
+
+	t.Run("AO_URL when no flag", func(t *testing.T) {
+		aoHome(t)
+		t.Setenv("AO_URL", "http://host:3011")
+		t.Setenv("AO_TOKEN", "tok")
+
+		got, err := resolveRemoteTarget("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.source != "AO_URL" {
+			t.Fatalf("source = %q, want AO_URL", got.source)
+		}
+	})
+
+	t.Run("no credential is an error", func(t *testing.T) {
+		aoHome(t)
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil || !strings.Contains(err.Error(), "AO_TOKEN") {
+			t.Fatalf("err = %v, want a missing-credential error naming AO_TOKEN", err)
+		}
+	})
+
+	t.Run("unknown host in remotes.json is an error", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{URL: "http://elsewhere:3011", Password: "nope"})
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil || !strings.Contains(err.Error(), "no connection password") {
+			t.Fatalf("err = %v, want the missing-entry error", err)
+		}
+	})
+
+	// An entry that exists but carries no password is a different problem from
+	// no entry at all, and must not be told to add the entry it already has.
+	t.Run("matching entry with an empty password says so", func(t *testing.T) {
+		home := aoHome(t)
+		writeRemotes(t, home, 0o600, remoteEntry{Label: "desk", URL: "http://host:3011", Password: ""})
+		_, err := resolveRemoteTarget("http://host:3011")
+		if err == nil {
+			t.Fatal("want an error for an entry with an empty password")
+		}
+		if !strings.Contains(err.Error(), "has an empty password") {
+			t.Fatalf("err = %q, want it to name the empty password", err)
+		}
+		if strings.Contains(err.Error(), "add an entry") {
+			t.Fatalf("err = %q, must not tell the user to add an entry that already exists", err)
+		}
+	})
+}
+
+// remotes.json holds connection passwords in plaintext, so a group/other
+// readable file is refused rather than silently used.
+func TestResolveRemoteTargetRejectsLooseRemotesFilePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not meaningful on Windows")
+	}
+	home := aoHome(t)
+	writeRemotes(t, home, 0o644, remoteEntry{URL: "http://host:3011", Password: "s3cret12"})
+
+	_, err := resolveRemoteTarget("http://host:3011")
+	if err == nil || !strings.Contains(err.Error(), "chmod 600") {
+		t.Fatalf("err = %v, want a permissions refusal", err)
+	}
+}
+
+// With no remote target, daemonBase must still go through the run-file and the
+// local liveness gate — byte-identical to the pre-remote behavior.
+func TestDaemonBaseLocalUsesRunFile(t *testing.T) {
+	dir := aoHome(t)
+	runFile := filepath.Join(dir, "running.json")
+	t.Setenv("AO_RUN_FILE", runFile)
+	t.Setenv("AO_DATA_DIR", filepath.Join(dir, "data"))
+
+	c := &commandContext{deps: Deps{ProcessAlive: func(int) bool { return true }}.withDefaults()}
+
+	if _, err := c.daemonBase(); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("err = %v, want 'not running' with no run-file", err)
+	}
+
+	if err := runfile.Write(runFile, runfile.Info{PID: 4242, Port: 3999, StartedAt: time.Unix(100, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	base, err := c.daemonBase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != "http://127.0.0.1:3999" {
+		t.Fatalf("base = %q, want the loopback daemon URL", base)
+	}
+
+	dead := &commandContext{deps: Deps{ProcessAlive: func(int) bool { return false }}.withDefaults()}
+	if _, err := dead.daemonBase(); err == nil || !strings.Contains(err.Error(), "stale run-file") {
+		t.Fatalf("err = %v, want the stale run-file error", err)
+	}
+}
+
+// A remote target skips the run-file read and the local ProcessAlive gate
+// entirely: neither exists on the machine running the command.
+func TestDaemonBaseRemoteSkipsRunFile(t *testing.T) {
+	dir := aoHome(t)
+	t.Setenv("AO_RUN_FILE", filepath.Join(dir, "no-such-running.json"))
+
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("ProcessAlive must not be consulted for a remote"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "--url"},
+	}
+	base, err := c.daemonBase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base != "http://host:3011" {
+		t.Fatalf("base = %q", base)
+	}
+}
+
+// `ao status --url ...` must work on a machine with no local run file at all,
+// and must present the connection password as a Bearer token.
+func TestStatusRemoteWithoutLocalRunFile(t *testing.T) {
+	dir := aoHome(t)
+	t.Setenv("AO_RUN_FILE", filepath.Join(dir, "no-such-running.json"))
+
+	var gotAuth []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		status := "ok"
+		if r.URL.Path == "/readyz" {
+			status = "ready"
+		}
+		_ = json.NewEncoder(w).Encode(probeResult{Status: status, Service: daemonmeta.ServiceName, PID: 777})
+	}))
+	defer srv.Close()
+
+	t.Setenv("AO_TOKEN", "s3cret12")
+	var out bytes.Buffer
+	err := executeWithDeps(Deps{
+		Out: &out,
+		Err: &out,
+		// A remote invocation must never consult local process liveness.
+		ProcessAlive: func(int) bool { t.Error("ProcessAlive called for a remote target"); return false },
+	}, []string{"status", "--url", srv.URL})
+	if err != nil {
+		t.Fatalf("ao status --url: %v\n%s", err, out.String())
+	}
+
+	if want := []string{"Bearer s3cret12", "Bearer s3cret12"}; len(gotAuth) != 2 || gotAuth[0] != want[0] || gotAuth[1] != want[1] {
+		t.Fatalf("Authorization headers = %q, want %q", gotAuth, want)
+	}
+	for _, want := range []string{"AO daemon: ready", "url: " + srv.URL, "pid: 777"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("status output missing %q:\n%s", want, out.String())
+		}
+	}
+	// There is no local run-file or data dir to report for a remote daemon.
+	if strings.Contains(out.String(), "run file:") {
+		t.Fatalf("remote status reported a local run file:\n%s", out.String())
+	}
+}
+
+// A daemon that answers but is not ours must not be reported as a healthy AO.
+func TestStatusRemoteRejectsForeignService(t *testing.T) {
+	aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(probeResult{Status: "ok", Service: "something-else"})
+	}))
+	defer srv.Close()
+
+	c := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: srv.URL, token: "tok"},
+	}
+	st := c.inspectRemoteDaemon(context.Background())
+	if st.State != stateUnhealthy || !strings.Contains(st.Error, "not from AO daemon") {
+		t.Fatalf("state = %q, error = %q", st.State, st.Error)
+	}
+}
+
+// A 429 from a remote daemon is the LAN listener's per-source lockout, not an
+// unhealthy daemon. Reporting it as "unhealthy" inverts the diagnosis.
+func TestStatusRemoteReportsLockoutDistinctly(t *testing.T) {
+	aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := &commandContext{
+		deps:   Deps{}.withDefaults(),
+		remote: &remoteTarget{baseURL: srv.URL, token: "tok"},
+	}
+	st := c.inspectRemoteDaemon(context.Background())
+	if st.State != stateLockedOut {
+		t.Fatalf("state = %q, want %q", st.State, stateLockedOut)
+	}
+	if !strings.Contains(st.Error, "locked out") {
+		t.Fatalf("error = %q, want it to name the lockout", st.Error)
+	}
+	// The whole point: it must not send the user to debug a healthy daemon.
+	if strings.Contains(string(st.State), "unhealthy") || strings.Contains(st.Error, "HTTP 429") {
+		t.Fatalf("lockout still rendered as a daemon fault: state=%q error=%q", st.State, st.Error)
+	}
+}
+
+// ...and the LOCAL path must render the very same 429 exactly as before. The
+// lockout cannot occur on loopback, so nothing about local status may change.
+func TestStatusLocalUnchangedForSameHTTPStatus(t *testing.T) {
+	dir := aoHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	port, err := strconv.Atoi(srv.URL[strings.LastIndex(srv.URL, ":")+1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	runFile := filepath.Join(dir, "running.json")
+	t.Setenv("AO_RUN_FILE", runFile)
+	t.Setenv("AO_DATA_DIR", filepath.Join(dir, "data"))
+	if err := runfile.Write(runFile, runfile.Info{PID: os.Getpid(), Port: port, StartedAt: time.Unix(100, 0).UTC()}); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &commandContext{deps: Deps{
+		ProcessAlive: func(int) bool { return true },
+		Now:          func() time.Time { return time.Unix(200, 0).UTC() },
+	}.withDefaults()}
+
+	st, err := c.inspectDaemon(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != stateUnhealthy {
+		t.Fatalf("local state = %q, want unhealthy (unchanged)", st.State)
+	}
+	if st.Error != "healthz: HTTP 429" {
+		t.Fatalf("local error = %q, want the byte-identical %q", st.Error, "healthz: HTTP 429")
+	}
+}
+
+// A stray --url must never shut down someone else's daemon.
+func TestStopRefusesRemoteTarget(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("stop must refuse before touching local state"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok", source: "AO_URL"},
+	}
+	_, err := c.stopDaemon(context.Background(), stopOptions{})
+	if err == nil {
+		t.Fatal("ao stop --url must refuse")
+	}
+	for _, want := range []string{"refusing to stop a remote daemon", "AO_URL", "http://host:3011"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+	// The message must not assert anything about what the target exposes: a
+	// loopback --url refuses too, and there /shutdown IS reachable.
+	if strings.Contains(err.Error(), "/shutdown") {
+		t.Fatalf("error %q claims something about the target's routes", err.Error())
+	}
+}
+
+// The refusal is unconditional: a --url that happens to name loopback is still
+// not the daemon `ao stop` discovered locally, and must not be stopped.
+func TestStopRefusesLoopbackURLToo(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("stop must refuse before touching local state"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://127.0.0.1:3001", token: "tok", source: "--url"},
+	}
+	if _, err := c.stopDaemon(context.Background(), stopOptions{}); err == nil {
+		t.Fatal("ao stop --url http://127.0.0.1:3001 must refuse")
+	}
+}
+
+// CLI telemetry posts to loopback-only /internal routes, which are 404'd at the
+// LAN socket — and must not be sent to another machine's daemon regardless.
+func TestPostLoopbackJSONSkippedForRemote(t *testing.T) {
+	aoHome(t)
+	c := &commandContext{
+		deps:   Deps{ProcessAlive: func(int) bool { t.Fatal("telemetry must not reach a remote daemon"); return false }}.withDefaults(),
+		remote: &remoteTarget{baseURL: "http://host:3011", token: "tok"},
+	}
+	if err := c.postLoopbackJSON(context.Background(), "/internal/telemetry/cli-invoked", map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -162,6 +162,7 @@ func (d Deps) withDefaults() Deps {
 func NewRootCommand(deps Deps) *cobra.Command {
 	deps = deps.withDefaults()
 	ctx := &commandContext{deps: deps}
+	var remoteURL string
 
 	root := &cobra.Command{
 		Use:           "ao",
@@ -171,12 +172,21 @@ func NewRootCommand(deps Deps) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Resolve before anything else: every daemon call below, telemetry
+			// included, depends on which daemon this invocation targets.
+			remote, err := resolveRemoteTarget(remoteURL)
+			if err != nil {
+				return err
+			}
+			ctx.remote = remote
 			if shouldEmitCLIInvocation(cmd) {
 				ctx.emitCLIInvoked(cmd.Context(), cmd)
 			}
 			return nil
 		},
 	}
+	root.PersistentFlags().StringVar(&remoteURL, "url", "",
+		"Base URL of a remote AO daemon, e.g. http://host:3011 (env AO_URL); credential from AO_TOKEN or ~/.ao/remotes.json")
 	root.SetIn(deps.In)
 	root.SetOut(deps.Out)
 	root.SetErr(deps.Err)
@@ -217,6 +227,8 @@ func NewRootCommand(deps Deps) *cobra.Command {
 
 type commandContext struct {
 	deps Deps
+	// remote is nil for the default local daemon; see remote.go.
+	remote *remoteTarget
 }
 
 func shouldEmitCLIInvocation(cmd *cobra.Command) bool {

--- a/backend/internal/cli/status.go
+++ b/backend/internal/cli/status.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -28,7 +29,22 @@ const (
 	stateStale     daemonState = "stale"
 	stateUnhealthy daemonState = "unhealthy"
 	stateNotReady  daemonState = "not_ready"
+	// stateLockedOut is reachable only for a remote target: the per-source
+	// lockout lives in the LAN listener's auth middleware, which the loopback
+	// path never reaches. See remoteProbeFailure.
+	stateLockedOut daemonState = "locked_out"
 )
+
+// probeHTTPError is a non-2xx probe response. Its message is deliberately
+// identical to the plain error it replaces, so the local path renders
+// byte-for-byte as before; it exists so the remote path can read the status code
+// back out and tell a lockout apart from an unhealthy daemon.
+type probeHTTPError struct {
+	path   string
+	status int
+}
+
+func (e probeHTTPError) Error() string { return fmt.Sprintf("%s: HTTP %d", e.path, e.status) }
 
 type daemonStatus struct {
 	State     daemonState `json:"state"`
@@ -36,12 +52,15 @@ type daemonStatus struct {
 	Port      int         `json:"port,omitempty"`
 	StartedAt *time.Time  `json:"startedAt,omitempty"`
 	Uptime    string      `json:"uptime,omitempty"`
-	RunFile   string      `json:"runFile"`
-	DataDir   string      `json:"dataDir"`
-	Health    string      `json:"health,omitempty"`
-	Ready     string      `json:"ready,omitempty"`
-	Error     string      `json:"error,omitempty"`
-	owned     bool
+	RunFile   string      `json:"runFile,omitempty"`
+	DataDir   string      `json:"dataDir,omitempty"`
+	// URL is set only for a remote target, where there is no local run-file or
+	// data dir to report.
+	URL    string `json:"url,omitempty"`
+	Health string `json:"health,omitempty"`
+	Ready  string `json:"ready,omitempty"`
+	Error  string `json:"error,omitempty"`
+	owned  bool
 }
 
 type probeResult struct {
@@ -74,6 +93,9 @@ func newStatusCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error) {
+	if c.remote != nil {
+		return c.inspectRemoteDaemon(ctx), nil
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return daemonStatus{}, err
@@ -100,7 +122,7 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 		return st, nil
 	}
 
-	health, err := c.readProbe(ctx, info.Port, "healthz")
+	health, err := c.readProbe(ctx, loopbackBase(info.Port), "healthz")
 	if err != nil {
 		st.State = stateUnhealthy
 		st.Error = err.Error()
@@ -118,7 +140,7 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 		return st, nil
 	}
 
-	ready, err := c.readProbe(ctx, info.Port, "readyz")
+	ready, err := c.readProbe(ctx, loopbackBase(info.Port), "readyz")
 	if err != nil {
 		st.State = stateNotReady
 		st.Error = err.Error()
@@ -139,21 +161,81 @@ func (c *commandContext) inspectDaemon(ctx context.Context) (daemonStatus, error
 	return st, nil
 }
 
-func (c *commandContext) readProbe(ctx context.Context, port int, path string) (probeResult, error) {
+func loopbackBase(port int) string {
+	return fmt.Sprintf("http://%s:%d", config.LoopbackHost, port)
+}
+
+// inspectRemoteDaemon reports the state of a daemon reached over the network.
+// There is no run-file and no local PID to gate on, so liveness comes entirely
+// from the authenticated /healthz and /readyz probes.
+func (c *commandContext) inspectRemoteDaemon(ctx context.Context) daemonStatus {
+	st := daemonStatus{State: stateStopped, URL: c.remote.baseURL}
+
+	health, err := c.readProbe(ctx, c.remote.baseURL, "healthz")
+	if err != nil {
+		return remoteProbeFailure(st, err, stateUnhealthy)
+	}
+	if health.Service != daemonmeta.ServiceName {
+		st.State = stateUnhealthy
+		st.Error = "healthz: response is not from AO daemon"
+		return st
+	}
+	st.PID = health.PID
+	st.Health = health.Status
+	if health.Status != "ok" {
+		st.State = stateUnhealthy
+		return st
+	}
+
+	ready, err := c.readProbe(ctx, c.remote.baseURL, "readyz")
+	if err != nil {
+		return remoteProbeFailure(st, err, stateNotReady)
+	}
+	st.Ready = ready.Status
+	if ready.Status == string(stateReady) {
+		st.State = stateReady
+		return st
+	}
+	st.State = stateNotReady
+	return st
+}
+
+// remoteProbeFailure classifies a failed probe against a remote daemon. A 429 is
+// the LAN listener's per-source lockout after repeated bad connection passwords:
+// the daemon is healthy, so reporting "unhealthy" inverts the diagnosis and
+// sends a user who fat-fingered a password off to investigate a daemon that is
+// fine. Remote-only by construction — the lockout lives in the authenticated
+// listener's middleware, which the loopback path never reaches — so local status
+// is untouched.
+func remoteProbeFailure(st daemonStatus, err error, fallback daemonState) daemonStatus {
+	var httpErr probeHTTPError
+	if errors.As(err, &httpErr) && httpErr.status == http.StatusTooManyRequests {
+		st.State = stateLockedOut
+		st.Error = "too many failed connection passwords from this machine; it is temporarily locked out — " +
+			"wait for the lockout to clear, then retry with the correct password. The daemon itself is fine."
+		return st
+	}
+	st.State = fallback
+	st.Error = err.Error()
+	return st
+}
+
+func (c *commandContext) readProbe(ctx context.Context, base, path string) (probeResult, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, fmt.Sprintf("http://%s:%d/%s", config.LoopbackHost, port, path), http.NoBody)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+"/"+path, http.NoBody) // #nosec G704 -- base is loopback or an explicitly configured daemon URL.
 	if err != nil {
 		return probeResult{}, err
 	}
+	c.authorize(req)
 	resp, err := c.deps.HTTPClient.Do(req)
 	if err != nil {
 		return probeResult{}, fmt.Errorf("%s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return probeResult{}, fmt.Errorf("%s: HTTP %d", path, resp.StatusCode)
+		return probeResult{}, probeHTTPError{path: path, status: resp.StatusCode}
 	}
 	var body probeResult
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
@@ -200,11 +282,20 @@ func writeStatus(cmd *cobra.Command, st daemonStatus) error {
 			return err
 		}
 	}
-	if _, err := fmt.Fprintf(out, "  run file: %s\n", st.RunFile); err != nil {
-		return err
+	if st.URL != "" {
+		if _, err := fmt.Fprintf(out, "  url: %s\n", st.URL); err != nil {
+			return err
+		}
 	}
-	if _, err := fmt.Fprintf(out, "  data dir: %s\n", st.DataDir); err != nil {
-		return err
+	if st.RunFile != "" {
+		if _, err := fmt.Fprintf(out, "  run file: %s\n", st.RunFile); err != nil {
+			return err
+		}
+	}
+	if st.DataDir != "" {
+		if _, err := fmt.Fprintf(out, "  data dir: %s\n", st.DataDir); err != nil {
+			return err
+		}
 	}
 	if st.Health != "" {
 		if _, err := fmt.Fprintf(out, "  healthz: %s\n", st.Health); err != nil {

--- a/backend/internal/cli/stop.go
+++ b/backend/internal/cli/stop.go
@@ -46,6 +46,19 @@ func newStopCommand(ctx *commandContext) *cobra.Command {
 }
 
 func (c *commandContext) stopDaemon(ctx context.Context, opts stopOptions) (daemonStatus, error) {
+	// `ao stop` is the one command that must never follow a stray --url/AO_URL:
+	// silently shutting down a daemon on someone else's machine is not a
+	// recoverable mistake. The refusal is unconditional, and deliberately does
+	// NOT branch on whether the URL looks like loopback — --url means "a daemon
+	// other than the one I discovered locally", and letting the single
+	// destructive verb behave differently based on how a string happens to look
+	// is exactly the surprise worth refusing.
+	if c.remote != nil {
+		return daemonStatus{}, fmt.Errorf(
+			"refusing to stop a remote daemon: %s targets %s. `ao stop` only ever stops the local daemon "+
+				"it discovers through the run-file, never a --url/AO_URL target — stop that daemon on the machine running it",
+			c.remote.source, c.remote.baseURL)
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return daemonStatus{}, err

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -518,6 +518,11 @@ func resolveDataDir() (string, error) {
 	return filepath.Join(stateDir, "data"), nil
 }
 
+// StateDir returns the canonical AO home directory (~/.ao) that holds
+// running.json, the data dir, and the CLI's remotes file. Exported for callers
+// that need the directory itself rather than a path Load already resolves.
+func StateDir() (string, error) { return defaultStateDir() }
+
 func defaultStateDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/backend/internal/httpd/lan_listener.go
+++ b/backend/internal/httpd/lan_listener.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -62,14 +63,46 @@ var lanControlBlockedPrefixes = []string{
 	"/api/v1/system/install",
 }
 
+// loopbackOnlyJSON answers a request for a route this daemon serves, but not on
+// this listener. It is deliberately NOT ROUTE_NOT_FOUND: that code reads as
+// "this daemon is too old / that endpoint does not exist", so an operator who
+// hits a policy block goes and audits daemon builds and finds nothing wrong,
+// because nothing is wrong. This says the block is a decision.
+//
+// What it does not do is resolve the route. Every path under a blocked prefix
+// gets this same answer whether or not a handler exists behind it, so the
+// response is a compile-time constant of the AO build and never an oracle for
+// which loopback-only routes this particular daemon has. That is also why it is
+// safe to serve before authMiddleware: see the note on lanControlBlock.
+//
+// The status stays 404. The route genuinely is not mounted on this listener —
+// the LAN handler chain is a different one — and holding the status still keeps
+// every existing client's error handling working; the code and message are
+// what carry the diagnosis.
+func loopbackOnlyJSON(w http.ResponseWriter, r *http.Request) {
+	envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "ROUTE_LOOPBACK_ONLY",
+		r.Method+" "+r.URL.Path+" is served on this daemon's loopback listener only and is deliberately "+
+			"not exposed on the network listener — run the command on that machine, or over loopback", nil)
+}
+
 // lanControlBlock returns 404 for any request whose path is, or is nested
 // under, a loopback-only control-route prefix, before it ever reaches auth or
-// the shared router. It answers as if the route were never mounted at all —
-// no 403/401 that would confirm the path exists.
+// the shared router. It also stamps the LAN-listener marker every layer below
+// reads.
+//
+// It answers before authMiddleware, and stays there. Being outermost is the
+// load-bearing property: no code below — not auth, not the router's middleware
+// stack — can run for a blocked path, whatever headers the caller forged. A
+// message that only an authenticated caller could see would mean moving this
+// inside auth, or evaluating the credential twice; the first trades a
+// structural guarantee for wording, and neither buys anything, because what an
+// unauthenticated caller learns here is a constant of the AO build (the prefix
+// list, which is in the source) and not a fact about this machine. It still
+// never confirms that a specific route exists — see loopbackOnlyJSON.
 func lanControlBlock(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isLANControlBlockedPath(r.URL.Path) || isLANControlBlockedRequest(r.Method, r.URL.Path) {
-			notFoundJSON(w, r)
+			loopbackOnlyJSON(w, r)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/backend/internal/httpd/lan_listener_test.go
+++ b/backend/internal/httpd/lan_listener_test.go
@@ -2,12 +2,17 @@ package httpd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
 )
@@ -111,6 +116,150 @@ func TestLANManagerBlocksLoopbackOnlyControlRoutes(t *testing.T) {
 		t.Fatalf("/api/v1/sessions: got 404, should not be blocked by the control-route filter")
 	}
 
+}
+
+// --- a blocked route must not look like a missing one -----------------------
+//
+// The block list is a policy decision, so it must not be reported with the code
+// that means "this daemon does not have that endpoint" — an operator chasing
+// ROUTE_NOT_FOUND audits daemon builds and finds nothing wrong. These tests pin
+// the distinction on the wire, and pin exactly how much of it an unauthenticated
+// LAN caller can see.
+
+// lanBlockFixture builds a LAN listener over a real chi router, so route
+// matching (and therefore webUIBypass) behaves as it does in the daemon:
+// /api/v1/dev/import-projects is a registered route, /api/v1/no-such-route is
+// not, and unmatched paths get the router's locked JSON 404.
+func lanBlockFixture(t *testing.T) (router http.Handler, port int) {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Get("/api/v1/dev/import-projects", func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, "ok")
+	})
+	r.Get("/api/v1/sessions", func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, "ok")
+	})
+	r.NotFound(notFoundJSON)
+
+	st := &authState{}
+	st.setHash(mobilebridge.HashPassword("secret12"))
+	m := NewLANManager(r, st, 0, slog.Default(), nil)
+	port, err := m.Start(0)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { m.Stop(context.Background()) })
+	return r, port
+}
+
+// lanTestClient keeps no idle connections: these fixtures start and stop
+// listeners on ephemeral ports within a single package run, and a pooled
+// connection must never outlive the listener it was opened to.
+var lanTestClient = &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+
+// lanGet issues a GET to the LAN listener and returns the status and the decoded
+// error envelope (zero-valued when the body is not one — raw keeps the bytes so
+// a failure says what actually came back).
+func lanGet(t *testing.T, port int, path, bearer string) (int, envelopeBody) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d%s", port, path), nil)
+	if err != nil {
+		t.Fatalf("%s: new request: %v", path, err)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := lanTestClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s: request failed: %v", path, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var body envelopeBody
+	_ = json.Unmarshal(raw, &body)
+	body.raw = string(raw)
+	return resp.StatusCode, body
+}
+
+type envelopeBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	raw     string
+}
+
+func TestLANBlockedRouteIsNotReportedAsMissing(t *testing.T) {
+	_, port := lanBlockFixture(t)
+
+	// A loopback-only route over the LAN listener: still 404 (it is genuinely
+	// not mounted on this listener), but the code says policy, not absence.
+	status, body := lanGet(t, port, "/api/v1/dev/import-projects", "secret12")
+	if status != http.StatusNotFound || body.Code != "ROUTE_LOOPBACK_ONLY" {
+		t.Fatalf("blocked route: got %d %s, want 404 ROUTE_LOOPBACK_ONLY (body %s)", status, body.Code, body.raw)
+	}
+	if !strings.Contains(body.Message, "loopback listener only") {
+		t.Fatalf("blocked route: message does not say why: %q", body.Message)
+	}
+
+	// A genuinely absent route keeps meaning exactly what it did before.
+	status, body = lanGet(t, port, "/api/v1/no-such-route", "secret12")
+	if status != http.StatusNotFound || body.Code != "ROUTE_NOT_FOUND" {
+		t.Fatalf("absent route: got %d %s, want 404 ROUTE_NOT_FOUND (body %s)", status, body.Code, body.raw)
+	}
+
+	// An unrelated app route is untouched by either.
+	if status, _ := lanGet(t, port, "/api/v1/sessions", "secret12"); status != http.StatusOK {
+		t.Fatalf("/api/v1/sessions: got %d, want 200", status)
+	}
+}
+
+// The loopback listener serves the shared router directly — lanControlBlock
+// wraps the LAN-served handler only — so the same route is unchanged there.
+func TestLoopbackStillServesBlockedRoute(t *testing.T) {
+	router, _ := lanBlockFixture(t)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/dev/import-projects")
+	if err != nil {
+		t.Fatalf("loopback request: %v", err)
+	}
+	defer resp.Body.Close()
+	got, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || string(got) != "ok" {
+		t.Fatalf("loopback: got %d %q, want 200 \"ok\"", resp.StatusCode, got)
+	}
+}
+
+// What an unauthenticated LAN caller may learn. The answer is a constant of the
+// AO build — "paths under this prefix are loopback-only" — and never which
+// routes exist behind it: a registered blocked route and a path under the same
+// prefix that no handler serves are byte-identical. Without this, a nicer error
+// message would have turned the block into a route-table oracle for anyone who
+// can reach the socket.
+func TestUnauthenticatedLANCallerLearnsNoRouteTable(t *testing.T) {
+	_, port := lanBlockFixture(t)
+
+	const realPath, fakePath = "/api/v1/dev/import-projects", "/api/v1/dev/no-such-dev-route"
+	realStatus, hit := lanGet(t, port, realPath, "")
+	fakeStatus, fake := lanGet(t, port, fakePath, "")
+	if realStatus != fakeStatus || hit.Code != fake.Code {
+		t.Fatalf("blocked prefix leaks route existence: real %d %q vs absent %d %q",
+			realStatus, hit.Code, fakeStatus, fake.Code)
+	}
+	if hit.Code != "ROUTE_LOOPBACK_ONLY" {
+		t.Fatalf("unauthenticated blocked path: got code %q, want ROUTE_LOOPBACK_ONLY (body %s)", hit.Code, hit.raw)
+	}
+	// The messages differ only where they echo the caller's own path back, so
+	// the answer carries nothing the caller did not already supply.
+	if got := strings.Replace(fake.Message, fakePath, realPath, 1); got != hit.Message {
+		t.Fatalf("blocked-path message is not a pure function of the requested path:\n real: %q\nabsent: %q",
+			hit.Message, fake.Message)
+	}
+
+	// Outside the blocked prefixes nothing changed: no credential, no answer.
+	if status, _ := lanGet(t, port, "/api/v1/no-such-route", ""); status != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated ordinary path: got %d, want 401", status)
+	}
 }
 
 func TestLANManagerStartStopIdempotent(t *testing.T) {

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -17,6 +17,48 @@ go build -o ./bin/ao ./cmd/ao
 ./bin/ao agent ls
 ```
 
+## Targeting a remote daemon
+
+By default every command talks to the local daemon: it reads `running.json`,
+checks the PID is alive, and calls `127.0.0.1`. The global `--url` flag (or
+`AO_URL`) points the same commands at another machine's LAN listener instead
+(see [ADR 0001](../adr/0001-lan-listener-for-mobile.md)), skipping the run-file
+and the local liveness check entirely — so it works on a machine that has never
+run AO:
+
+```bash
+ao status --url http://100.64.0.1:3011
+AO_URL=http://100.64.0.1:3011 ao agent ls
+```
+
+The credential is the daemon's connection password — the same one the mobile app
+pairs with — sent as `Authorization: Bearer <password>`. It comes from `AO_TOKEN`,
+or from `~/.ao/remotes.json`, which mirrors the mobile app's saved-node list and
+must be mode `0600` (the CLI refuses to read it otherwise):
+
+```json
+{
+  "remotes": [
+    { "label": "desk", "url": "http://100.64.0.1:3011", "password": "abcd1234" }
+  ]
+}
+```
+
+Notes:
+
+- The link is plain HTTP by design (ADR 0001, home network / Tailscale only).
+  There is no TLS or certificate pinning.
+- The URL must not carry a username or password. A credential belongs in
+  `AO_TOKEN` or the `remotes.json` entry, so `--url http://user:pw@host:3011` is
+  rejected rather than silently stripped.
+- `ao stop` only ever stops the local daemon it found through `running.json`. A
+  `--url` / `AO_URL` target is refused — including one that names loopback, so
+  the single destructive verb never changes behavior based on how the URL looks.
+- CLI telemetry (`/internal/*`) is never sent to a remote daemon.
+- Repeated bad passwords lock your source address out of the LAN listener for a
+  minute. `ao status` reports that as `locked_out` rather than `unhealthy` — the
+  daemon is fine; wait and retry. This state cannot occur against a local daemon.
+
 ## Current commands
 
 Every product command resolves to a daemon HTTP route. Run `ao <command>


### PR DESCRIPTION
## Ticket

No upstream issue. [RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md). Stacked on #4358.

## Problem

The LAN listener blocks loopback-only control prefixes (`/shutdown`, `/internal/`, `/api/v1/mobile`, `/api/v1/dev`, `/api/v1/system/install`) before auth, but answers with the same code that means "this endpoint does not exist." An operator who hits a deliberate policy block goes and audits daemon builds and finds nothing wrong — a misdiagnosis now reachable by anyone running `ao … --url`.

## Solution

The block now answers `ROUTE_LOOPBACK_ONLY` at the same 404 status, naming the diagnosis and where to run the command instead. The block stays outermost, in front of auth, so no code below runs for a blocked path regardless of forged headers; an unauthenticated caller learns only a constant of the AO build, never a fact about this machine.

## How Has This Been Tested?

`cd backend && go build ./... && go vet ./... && go test ./... && go test -race ./internal/httpd/ ./internal/cli/` on the current `main` (`c9a0adb2`): 158 packages ok, `gofmt -l` clean. Four new tests: a blocked route vs. a genuinely absent route vs. an ordinary 200; unchanged behaviour over the loopback listener; indistinguishability of blocked-vs-absent to an unauthenticated caller; and one end-to-end case driving the real CLI through `--url` against the real LAN listener.

## Artifacts (if appropriate):

No renderable surface: Go daemon code only, no files under `frontend/src`. Behaviour is covered by the tests above.
