### PR TITLE
feat(hosts): host identity primitives

### DIFF
--- a/frontend/src/renderer/lib/hosts.test.ts
+++ b/frontend/src/renderer/lib/hosts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isLocal, LOCAL_HOST, parseRefKey, refKey, type Ref } from "./hosts";
+
+describe("refKey", () => {
+	it("round-trips a local ref", () => {
+		const ref: Ref = { host: LOCAL_HOST, id: "skyvern-cloud" };
+		expect(refKey(ref)).toBe("local:skyvern-cloud");
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("round-trips a remote ref whose host url contains colons and slashes", () => {
+		const ref: Ref = { host: "http://192.0.2.1:3011", id: "skyvern-cloud" };
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("round-trips an id that itself contains a colon", () => {
+		// Ids come from another machine; nothing guarantees they are colon-free.
+		const ref: Ref = { host: "http://192.0.2.1:3011", id: "weird:id" };
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("distinguishes the same id on two hosts", () => {
+		expect(refKey({ host: LOCAL_HOST, id: "skyvern-cloud" })).not.toBe(
+			refKey({ host: "http://192.0.2.1:3011", id: "skyvern-cloud" }),
+		);
+	});
+});
+
+describe("isLocal", () => {
+	it("is true only for the local host", () => {
+		expect(isLocal(LOCAL_HOST)).toBe(true);
+		expect(isLocal("http://192.0.2.1:3011")).toBe(false);
+	});
+});

--- a/frontend/src/renderer/lib/hosts.ts
+++ b/frontend/src/renderer/lib/hosts.ts
@@ -1,0 +1,30 @@
+// Host identity. Local is a host like any other — the one whose requests skip
+// the proxy — so no code path has to special-case "is this remote?".
+export type HostId = string;
+
+export const LOCAL_HOST: HostId = "local";
+
+/** Anything addressable across hosts. A bare id is never enough to act on. */
+export type Ref = {
+	host: HostId;
+	id: string;
+};
+
+export function isLocal(host: HostId): boolean {
+	return host === LOCAL_HOST;
+}
+
+// A host id is a URL and an id may contain anything, so the key encodes both
+// halves rather than relying on a separator being absent from either.
+export function refKey(ref: Ref): string {
+	return `${encodeURIComponent(ref.host)}:${encodeURIComponent(ref.id)}`;
+}
+
+export function parseRefKey(key: string): Ref {
+	const separator = key.indexOf(":");
+	if (separator === -1) throw new Error(`malformed ref key: ${key}`);
+	return {
+		host: decodeURIComponent(key.slice(0, separator)),
+		id: decodeURIComponent(key.slice(separator + 1)),
+	};
+}


### PR DESCRIPTION
## Ticket

No upstream issue yet. Design note: [remote hosts RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md).

## Problem

Nothing in the codebase can name "which machine" a session or project lives on. A project id is `filepath.Base(path)` on every machine, so two machines that both cloned this repository both call the project `agent-orchestrator`, and there is no type that can qualify a bare id at the addressing boundary before the rest of the series needs one.

## Solution

`HostId`, `Ref = {host, id}`, `LOCAL_HOST`, and a composite `refKey`. Local is a host like any other, so no code path special-cases "is this remote?" — everything downstream can treat local and remote uniformly. No importer yet; this PR adds the primitives and nothing consumes them.

## How Has This Been Tested?

`cd frontend && npm run typecheck && npx vitest run src/renderer/lib/hosts.test.ts` on the current `main` (`c9a0adb2`): green, 5 tests. No Go or OpenAPI surface is touched, so the `go` and `api-drift` CI jobs are unaffected. This file has no consumers yet, so the existing full-suite run is unaffected by construction.

## Artifacts (if appropriate):

No renderable surface: a headless type/data-structure module (`lib/hosts.ts`) with no UI consumer in this PR. Covered by the unit tests above.
