### PR TITLE
feat(settings): add an experimental Remote hosts flag

### DIFF
--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -162,7 +162,7 @@ beforeEach(async () => {
 		saving: false,
 		saveError: false,
 	});
-	useUiStore.setState({ developerMode: false });
+	useUiStore.setState({ developerMode: false, remoteHosts: false });
 	document.documentElement.lang = "en";
 });
 
@@ -195,6 +195,21 @@ describe("GlobalSettingsForm", () => {
 		expect(window.localStorage.getItem("ao.developerMode")).toBe("true");
 		await user.click(screen.getByLabelText("Updates channel"));
 		expect(await screen.findByRole("menuitem", { name: "Feature Releases" })).toBeInTheDocument();
+	});
+
+	it("offers Remote hosts as a switch right below Developer Mode and persists it", async () => {
+		const user = userEvent.setup();
+		renderForm();
+		const developerMode = await screen.findByRole("switch", { name: "Developer Mode" });
+		const remoteHosts = screen.getByRole("switch", { name: "Remote hosts (experimental)" });
+		expect(remoteHosts).toHaveAttribute("aria-checked", "false");
+		// "Underneath Developer Mode": the next switch in document order.
+		expect(developerMode.compareDocumentPosition(remoteHosts) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(screen.getAllByRole("switch").indexOf(remoteHosts)).toBe(screen.getAllByRole("switch").indexOf(developerMode) + 1);
+
+		await user.click(remoteHosts);
+		expect(window.localStorage.getItem("ao.remoteHosts")).toBe("true");
+		expect(useUiStore.getState().remoteHosts).toBe(true);
 	});
 
 	it("shows the available feature builds after choosing Feature Releases", async () => {

--- a/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -152,6 +152,8 @@ export function GeneralSettingsSection({
 	const soundNotificationsSaveError = useSoundNotificationsStore((state) => state.saveError);
 	const developerMode = useUiStore((state) => state.developerMode);
 	const setDeveloperMode = useUiStore((state) => state.setDeveloperMode);
+	const remoteHosts = useUiStore((state) => state.remoteHosts);
+	const setRemoteHosts = useUiStore((state) => state.setRemoteHosts);
 
 	const themeOptions = [
 		{ value: "light", label: t("settings.theme.light") },
@@ -236,6 +238,13 @@ export function GeneralSettingsSection({
 						aria-label={t("settings.developerMode")}
 						checked={developerMode}
 						onCheckedChange={setDeveloperMode}
+					/>
+				</SettingsRow>
+				<SettingsRow label={t("settings.remoteHosts")}>
+					<Switch
+						aria-label={t("settings.remoteHosts")}
+						checked={remoteHosts}
+						onCheckedChange={setRemoteHosts}
 					/>
 				</SettingsRow>
 				{developerMode && <CloudOfferingRow />}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -637,6 +637,7 @@
 	"settings.close": "Einstellungen schließen",
 	"settings.connectMobile": "Mobile verbinden",
 	"settings.developerMode": "Entwicklermodus",
+	"settings.remoteHosts": "Remote-Hosts (experimentell)",
 	"settings.general": "Allgemein",
 	"settings.appearance": "Erscheinungsbild",
 	"settings.sessions": "Sitzungen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -629,6 +629,7 @@
 	"settings.cloudAgents.valid": "Valid",
 	"settings.connectMobile": "Connect Mobile",
 	"settings.developerMode": "Developer Mode",
+	"settings.remoteHosts": "Remote hosts (experimental)",
 	"settings.general": "General",
 	"settings.appearance": "Appearance",
 	"settings.sessions": "Sessions",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -646,6 +646,7 @@
 	"settings.close": "Cerrar ajustes",
 	"settings.connectMobile": "Conectar móvil",
 	"settings.developerMode": "Modo desarrollador",
+	"settings.remoteHosts": "Hosts remotos (experimental)",
 	"settings.general": "General",
 	"settings.appearance": "Apariencia",
 	"settings.sessions": "Sesiones",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -646,6 +646,7 @@
 	"settings.close": "Fermer les paramètres",
 	"settings.connectMobile": "Connecter le mobile",
 	"settings.developerMode": "Mode développeur",
+	"settings.remoteHosts": "Hôtes distants (expérimental)",
 	"settings.general": "Général",
 	"settings.appearance": "Apparence",
 	"settings.sessions": "Sessions",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -637,6 +637,7 @@
 	"settings.close": "設定を閉じる",
 	"settings.connectMobile": "モバイル接続",
 	"settings.developerMode": "開発者モード",
+	"settings.remoteHosts": "リモートホスト（実験的）",
 	"settings.general": "一般",
 	"settings.appearance": "外観",
 	"settings.sessions": "セッション",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -637,6 +637,7 @@
 	"settings.close": "설정 닫기",
 	"settings.connectMobile": "모바일 연결",
 	"settings.developerMode": "개발자 모드",
+	"settings.remoteHosts": "원격 호스트 (실험적)",
 	"settings.general": "일반",
 	"settings.appearance": "모양",
 	"settings.sessions": "세션",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -646,6 +646,7 @@
 	"settings.close": "Fechar configurações",
 	"settings.connectMobile": "Conectar mobile",
 	"settings.developerMode": "Modo desenvolvedor",
+	"settings.remoteHosts": "Hosts remotos (experimental)",
 	"settings.general": "Geral",
 	"settings.appearance": "Aparência",
 	"settings.sessions": "Sessões",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -619,6 +619,7 @@
 	"settings.close": "关闭设置",
 	"settings.connectMobile": "连接手机",
 	"settings.developerMode": "开发者模式",
+	"settings.remoteHosts": "远程主机（实验性）",
 	"settings.general": "通用",
 	"settings.appearance": "外观",
 	"settings.sessions": "会话",

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -1,16 +1,23 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sidebarIsCompact, sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "./ui-store";
 
-describe("sidebar workspace pressure", () => {
-	beforeEach(() => {
-		window.localStorage.clear();
-		useUiStore.setState({
-			isSidebarOpen: true,
-			isSidebarAutoCollapsed: false,
-			sidebarAutoCollapseOverride: false,
-			sidebarWorkspaceDemandPx: null,
-		});
+beforeEach(() => {
+	window.localStorage.clear();
+	vi.resetModules();
+	useUiStore.setState({
+		isSidebarOpen: true,
+		isSidebarAutoCollapsed: false,
+		sidebarAutoCollapseOverride: false,
+		sidebarWorkspaceDemandPx: null,
 	});
+});
+
+// A fresh module sees exactly what a booting renderer sees: only storage.
+async function bootStore() {
+	return (await import("./ui-store")).useUiStore;
+}
+
+describe("sidebar workspace pressure", () => {
 
 	it("temporarily compacts navigation without changing the saved preference", () => {
 		useUiStore.getState().setSidebarAutoCollapsed(true);
@@ -61,5 +68,24 @@ describe("sidebar workspace pressure", () => {
 		expect(state.isSidebarOpen).toBe(true);
 		expect(state.sidebarAutoCollapseOverride).toBe(false);
 		expect(sidebarIsVisible(state)).toBe(true);
+	});
+});
+
+
+describe("remoteHosts flag", () => {
+	it("is off until the user turns it on", async () => {
+		expect((await bootStore()).getState().remoteHosts).toBe(false);
+	});
+
+	it("persists the switch so the choice survives a restart", () => {
+		useUiStore.getState().setRemoteHosts(true);
+		expect(useUiStore.getState().remoteHosts).toBe(true);
+		expect(window.localStorage.getItem("ao.remoteHosts")).toBe("true");
+		useUiStore.getState().setRemoteHosts(false);
+	});
+
+	it("reads a stored choice back at startup", async () => {
+		window.localStorage.setItem("ao.remoteHosts", "true");
+		expect((await bootStore()).getState().remoteHosts).toBe(true);
 	});
 });

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -68,6 +68,8 @@ export type UiState = {
 	themeStyle: ThemeStyle;
 	/** When true, developer-only release controls are available. Default off. */
 	developerMode: boolean;
+	/** Experimental: connect to AO daemons on other machines. Default off; off means no remote host is ever contacted. */
+	remoteHosts: boolean;
 	restartingProjectIds: ReadonlySet<string>;
 	orchestratorReplacementErrors: Record<string, OrchestratorReplacementFailure>;
 	orchestratorStartupErrors: Record<string, string>;
@@ -105,6 +107,7 @@ export type UiState = {
 	setThemePreference: (theme: ThemePreference) => void;
 	setThemeStyle: (style: ThemeStyle) => void;
 	setDeveloperMode: (enabled: boolean) => void;
+	setRemoteHosts: (enabled: boolean) => void;
 	openGlobalSettings: (section?: GlobalSettingsSection) => void;
 	openProjectSettings: (projectId: string) => void;
 	closeSettings: () => void;
@@ -149,6 +152,7 @@ export type OrchestratorReplacementFailure = {
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
+const remoteHostsStorageKey = "ao.remoteHosts";
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
 	return window.localStorage;
@@ -160,6 +164,10 @@ function initialSidebarOpen() {
 
 function initialDeveloperMode() {
 	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
+}
+
+function initialRemoteHosts() {
+	return getLocalStorage()?.getItem(remoteHostsStorageKey) === "true";
 }
 
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
@@ -201,6 +209,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	resolvedTheme: resolveTheme(initialThemePreference),
 	themeStyle: initialThemeStyle,
 	developerMode: initialDeveloperMode(),
+	remoteHosts: initialRemoteHosts(),
 	restartingProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
 	orchestratorStartupErrors: {},
@@ -231,6 +240,10 @@ export const useUiStore = create<UiState>((set, get) => ({
 	setDeveloperMode: (developerMode) => {
 		getLocalStorage()?.setItem(developerModeStorageKey, String(developerMode));
 		set({ developerMode });
+	},
+	setRemoteHosts: (remoteHosts) => {
+		getLocalStorage()?.setItem(remoteHostsStorageKey, String(remoteHosts));
+		set({ remoteHosts });
 	},
 	openGlobalSettings: (section) => set({ settingsModal: { scope: "global", section } }),
 	openProjectSettings: (projectId) => set({ settingsModal: { scope: "project", projectId } }),


### PR DESCRIPTION
## Ticket

No upstream issue yet. Design note: [remote hosts RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md).

## Problem

The remote-hosts series below this PR needs a way to land its early, dark slices safely: primitives, a saved-host store, and per-host clients all have to merge before there is anything a user can see or reach, and there is currently no flag to keep that work invisible while it lands in small, reviewable pieces.

## Solution

A Remote hosts switch directly below Developer Mode in Settings, modelled on it: `remoteHosts` in `ui-store`, persisted at `ao.remoteHosts`, default off. Nothing reads the flag yet — every later PR in the series checks it, so with it off there is no behaviour change at all beyond the one new settings row.

## How Has This Been Tested?

`cd frontend && npm run typecheck && npx vitest run src/renderer/stores/ui-store.test.ts src/renderer/components/GeneralSettingsSection.test.tsx` on the current `main` (`c9a0adb2`): both suites green. Full `vitest run src/renderer` on this base: 2013/2014 passing, one unrelated failure in `Sidebar.test.tsx` reproduced identically on unmodified `main` under the same machine load — not caused by this change. No Go or OpenAPI surface is touched.

## Artifacts (if appropriate):

![Settings modal with the Remote hosts (experimental) toggle on](https://raw.githubusercontent.com/AronPerez/agent-orchestrator/campaign-assets/qa-evidence/a1-flag.png)
