### PR TITLE
feat(hosts): per-host API clients and flag-gated host boot

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -248,6 +248,14 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					list: async () => [],
 					getActive: async () => null,
 				},
+				remotes: {
+					list: async () => [],
+					add: async () => "offline" as const,
+					update: async () => "offline" as const,
+					remove: async () => undefined,
+					probe: async () => "offline" as const,
+					request: async () => ({ status: 0, body: null }),
+				},
 				cloud: {
 					getSession: async () => null,
 					signIn: async () => undefined,
@@ -746,6 +754,14 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				featureBuilds: {
 					list: async () => [],
 					getActive: async () => null,
+				},
+				remotes: {
+					list: async () => [],
+					add: async () => "offline" as const,
+					update: async () => "offline" as const,
+					remove: async () => undefined,
+					probe: async () => "offline" as const,
+					request: async () => ({ status: 0, body: null }),
 				},
 				cloud: {
 					getSession: async () => null,

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -255,6 +255,9 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					remove: async () => undefined,
 					probe: async () => "offline" as const,
 					request: async () => ({ status: 0, body: null }),
+					connect: async () => ({ label: "", url: "", base: "" }),
+					disconnect: async () => undefined,
+					connected: async () => [],
 				},
 				cloud: {
 					getSession: async () => null,
@@ -762,6 +765,9 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					remove: async () => undefined,
 					probe: async () => "offline" as const,
 					request: async () => ({ status: 0, body: null }),
+					connect: async () => ({ label: "", url: "", base: "" }),
+					disconnect: async () => undefined,
+					connected: async () => [],
 				},
 				cloud: {
 					getSession: async () => null,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -127,6 +127,7 @@ import { dockBounceType, shouldReplaceBounce, shouldSignalAttention, shouldToast
 import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./main/menu";
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 import { parseOpenFolderPathArg } from "./main/open-folder-arg";
+import { registerRemotesIpc, remotesFilePath } from "./main/remotes-main";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -1928,6 +1929,13 @@ async function chooseDirectory(title: string): Promise<string | null> {
 	if (result.canceled) return null;
 	return result.filePaths[0] ?? null;
 }
+
+registerRemotesIpc(ipcMain, {
+	file: remotesFilePath(),
+	// No host is ever connected yet; the proxy registry that owns live
+	// connections lands in the next change and replaces this.
+	disconnect: async () => undefined,
+});
 
 ipcMain.handle("app:chooseDirectory", async (_event, title?: string) => {
 	return chooseDirectory(typeof title === "string" && title.trim() ? title : "Choose a git repository");

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -128,6 +128,8 @@ import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./main/men
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 import { parseOpenFolderPathArg } from "./main/open-folder-arg";
 import { registerRemotesIpc, remotesFilePath } from "./main/remotes-main";
+import { RemoteRegistry } from "./main/remote-registry";
+import { startRemoteProxy } from "./main/remote-proxy";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -1930,12 +1932,8 @@ async function chooseDirectory(title: string): Promise<string | null> {
 	return result.filePaths[0] ?? null;
 }
 
-registerRemotesIpc(ipcMain, {
-	file: remotesFilePath(),
-	// No host is ever connected yet; the proxy registry that owns live
-	// connections lands in the next change and replaces this.
-	disconnect: async () => undefined,
-});
+const remoteRegistry = new RemoteRegistry(startRemoteProxy);
+registerRemotesIpc(ipcMain, { file: remotesFilePath(), registry: remoteRegistry });
 
 ipcMain.handle("app:chooseDirectory", async (_event, title?: string) => {
 	return chooseDirectory(typeof title === "string" && title.trim() ? title : "Choose a git repository");
@@ -2427,11 +2425,13 @@ app.on("before-quit", (event) => {
 	if (!browserCleanupComplete) {
 		event.preventDefault();
 		if (!browserQuitCleanupPromise) {
-			browserQuitCleanupPromise = disposeAllBrowserViewHosts().finally(() => {
-				browserCleanupComplete = true;
-				browserQuitCleanupPromise = null;
-				app.quit();
-			});
+			browserQuitCleanupPromise = Promise.all([disposeAllBrowserViewHosts(), remoteRegistry.closeAll()])
+				.then(() => undefined)
+				.finally(() => {
+					browserCleanupComplete = true;
+					browserQuitCleanupPromise = null;
+					app.quit();
+				});
 		}
 		return;
 	}

--- a/frontend/src/main/remote-proxy.test.ts
+++ b/frontend/src/main/remote-proxy.test.ts
@@ -293,6 +293,61 @@ describe("startRemoteProxy streams", () => {
 		expect(result).toBe("closed");
 	});
 
+	// Regression for the connection-status hang: the previous test's upstream
+	// writes its first chunk synchronously, so headers and that chunk reach the
+	// client together even without an explicit flush — it never exercised the
+	// gap. A real SSE upstream (GET /api/v1/events) can hold its first byte
+	// indefinitely; a client's EventSource must still see the response headers
+	// right away; otherwise it reports CONNECTING forever, which is exactly what
+	// "not receiving live updates" looked like before this was found.
+	it("flushes response headers before the first SSE byte arrives", async () => {
+		upstream = createServer((_req, res) => {
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			// The real daemon flushes its own headers immediately (confirmed by a
+			// direct curl against it) — this upstream must too, or the test would
+			// measure the fake upstream's header delay instead of the proxy's.
+			res.flushHeaders();
+			// The body is what's withheld for 500ms, like a daemon with nothing to
+			// say yet.
+			setTimeout(() => {
+				res.write("data: first\n\n");
+				res.end();
+			}, 500);
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const started = Date.now();
+		const head = await new Promise<string>((resolve) => {
+			const socket = netConnect(Number(proxyUrl.port), "127.0.0.1", () => {
+				socket.write(`GET ${proxyUrl.pathname}/api/v1/events HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n`);
+			});
+			socket.on("error", () => undefined);
+			let buf = "";
+			socket.on("data", (chunk: Buffer) => {
+				buf += chunk.toString();
+				if (buf.includes("\r\n\r\n")) {
+					socket.destroy();
+					resolve(buf);
+				}
+			});
+		});
+		const headersArrivedAfterMs = Date.now() - started;
+
+		expect(head).toContain("200");
+		expect(head.toLowerCase()).toContain("content-type: text/event-stream");
+		// The upstream withholds its first byte for 500ms; seeing the header
+		// block well before that proves the proxy flushes headers on their own
+		// rather than only when they can piggyback on the first body write.
+		expect(headersArrivedAfterMs).toBeLessThan(300);
+	});
+
 	it("delivers SSE chunks as they are written, not on close", async () => {
 		upstream = createServer((_req, res) => {
 			res.writeHead(200, { "content-type": "text/event-stream" });

--- a/frontend/src/main/remote-proxy.test.ts
+++ b/frontend/src/main/remote-proxy.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { connect as netConnect, type AddressInfo } from "node:net";
+import { startRemoteProxy, type ActiveProxy } from "./remote-proxy";
+
+type Seen = {
+	url: string;
+	auth: string | undefined;
+	origin: string | undefined;
+	body: string;
+};
+
+let upstream: Server | undefined;
+let proxy: ActiveProxy | undefined;
+// Lifecycle logging is the point of these spies, not a side effect to silence:
+// every assertion below reads them, and swallowing the output keeps the suite
+// readable while the proxy narrates itself.
+let logged: string[];
+let warned: string[];
+
+beforeEach(() => {
+	logged = [];
+	warned = [];
+	vi.spyOn(console, "log").mockImplementation((message: unknown) => {
+		logged.push(String(message));
+	});
+	vi.spyOn(console, "warn").mockImplementation((message: unknown) => {
+		warned.push(String(message));
+	});
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await proxy?.close();
+	await new Promise<void>((resolve) => (upstream ? upstream.close(() => resolve()) : resolve()));
+	upstream = undefined;
+	proxy = undefined;
+});
+
+async function startUpstream(
+	handler: (req: IncomingMessage, seen: Seen[]) => { status: number; body: string },
+): Promise<{ port: number; seen: Seen[] }> {
+	const seen: Seen[] = [];
+	upstream = createServer((req, res) => {
+		let body = "";
+		req.on("data", (chunk) => (body += chunk));
+		req.on("end", () => {
+			seen.push({
+				url: req.url ?? "",
+				auth: req.headers.authorization,
+				origin: req.headers.origin,
+				body,
+			});
+			const out = handler(req, seen);
+			res.writeHead(out.status, { "content-type": "application/json" });
+			res.end(out.body);
+		});
+	});
+	await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+	return { port: (upstream.address() as AddressInfo).port, seen };
+}
+
+describe("startRemoteProxy", () => {
+	it("forwards with the token stripped and the credential injected", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: '{"ok":true}',
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`, {
+			method: "POST",
+			headers: { "content-type": "application/json", origin: "app://renderer" },
+			body: '{"path":"/srv/repo"}',
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(seen).toHaveLength(1);
+		expect(seen[0].url).toBe("/api/v1/projects"); // token gone
+		expect(seen[0].auth).toBe("Bearer pw");
+		expect(seen[0].origin).toBeUndefined(); // app://renderer never reaches the daemon
+		expect(seen[0].body).toBe('{"path":"/srv/repo"}');
+	});
+
+	// The add-host dialog accepts https://, so this is what a Tailscale Serve or
+	// reverse-proxy address does today: the upstream is a TLS endpoint and the
+	// proxy must not put the connection password on the wire in the clear.
+	it("never sends the credential in the clear to an https host", async () => {
+		const { port, seen } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `https://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		// A cleartext listener cannot complete a TLS handshake, so the honest
+		// outcome is a failed request — never a plaintext one that succeeds.
+		const res = await fetch(`${proxy.base}/api/v1/projects`);
+		expect(res.status).toBe(502);
+		expect(seen).toHaveLength(0);
+	});
+
+	// A daemon can live behind a reverse proxy at a path. The renderer's base is
+	// the loopback proxy's own root, so the upstream prefix is restored here or
+	// every credentialled request lands on whatever else that vhost serves.
+	it("restores the host's path prefix upstream", async () => {
+		const { port, seen } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}/ao`,
+			password: "pw",
+		});
+
+		await fetch(`${proxy.base}/api/v1/projects`);
+		expect(seen[0].url).toBe("/ao/api/v1/projects");
+	});
+
+	it("refuses a request without the token and sends nothing upstream", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: "{}",
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const bare = new URL(proxy.base);
+		const res = await fetch(`${bare.origin}/api/v1/projects`);
+		expect(res.status).toBe(404);
+		expect(seen).toHaveLength(0);
+	});
+
+	it("refuses a near-miss token prefix", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: "{}",
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		// A path that merely starts with the token's characters is not the token:
+		// /<token>x/... must not authorize, or the token stops being a boundary.
+		const bare = new URL(proxy.base);
+		const res = await fetch(`${bare.origin}${bare.pathname}x/api/v1/projects`);
+		expect(res.status).toBe(404);
+		expect(seen).toHaveLength(0);
+	});
+
+	it("answers CORS preflight itself for the renderer origin", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: "{}",
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`, {
+			method: "OPTIONS",
+			headers: {
+				origin: "app://renderer",
+				"access-control-request-method": "POST",
+				"access-control-request-headers": "content-type",
+			},
+		});
+		expect(res.status).toBe(204);
+		expect(res.headers.get("access-control-allow-origin")).toBe("app://renderer");
+		expect(res.headers.get("access-control-allow-headers")).toMatch(/content-type/i);
+		expect(seen).toHaveLength(0); // preflight never leaves the machine
+	});
+
+	it("adds the renderer origin to real responses so cross-origin fetch succeeds", async () => {
+		const { port } = await startUpstream(() => ({
+			status: 400,
+			body: '{"error":"bad"}',
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`, {
+			headers: { origin: "app://renderer" },
+		});
+		expect(res.status).toBe(400); // errors pass through untouched…
+		expect(res.headers.get("access-control-allow-origin")).toBe("app://renderer"); // …but stay readable
+	});
+
+	it("returns 502 when the upstream is unreachable", async () => {
+		proxy = await startRemoteProxy({
+			label: "dead",
+			url: "http://127.0.0.1:1",
+			password: "pw",
+		});
+		const res = await fetch(`${proxy.base}/api/v1/projects`);
+		expect(res.status).toBe(502);
+	});
+
+	// "The app can't reach my host" had no answer anywhere before this, and the
+	// only thing that could make these lines unshippable is a secret in one.
+	it("logs its own lifecycle without the token or the password", async () => {
+		const { port } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({ label: "workbox", url: `http://127.0.0.1:${port}`, password: "hunter2secret" });
+		const token = new URL(proxy.base).pathname.slice(1);
+
+		expect(logged.some((line) => line.includes("[remote-proxy] started on 127.0.0.1:"))).toBe(true);
+		await proxy.close();
+		proxy = undefined;
+		expect(logged.some((line) => line.includes("[remote-proxy] stopped on 127.0.0.1:"))).toBe(true);
+
+		const everything = [...logged, ...warned].join("\n");
+		expect(everything).not.toContain("hunter2secret");
+		expect(everything).not.toContain(token);
+	});
+
+	it("warns which upstream failed when it answers 502, naming no secret", async () => {
+		const { port } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		await new Promise<void>((resolve) => (upstream ? upstream.close(() => resolve()) : resolve()));
+		upstream = undefined;
+		proxy = await startRemoteProxy({ label: "workbox", url: `http://127.0.0.1:${port}`, password: "hunter2secret" });
+		const token = new URL(proxy.base).pathname.slice(1);
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`);
+		expect(res.status).toBe(502);
+		const warning = warned.find((line) => line.includes("answering 502"));
+		expect(warning).toContain(`127.0.0.1:${port}`);
+		// The post-strip path, which is the useful half; req.url starts with the token.
+		expect(warning).toContain("/api/v1/projects");
+		expect(warning).not.toContain("hunter2secret");
+		expect(warning).not.toContain(token);
+	});
+
+	it("listens on loopback only", async () => {
+		const { port } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+		expect(new URL(proxy.base).hostname).toBe("127.0.0.1");
+	});
+});
+
+describe("startRemoteProxy streams", () => {
+	it("closes while an upgraded socket is still open", async () => {
+		upstream = createServer();
+		const upgraded = new Promise<void>((resolve) => {
+			upstream?.on("upgrade", (_req, socket) => {
+				socket.on("error", () => undefined);
+				socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+				socket.on("end", () => socket.destroy());
+				resolve();
+			});
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const socket = netConnect(Number(proxyUrl.port), "127.0.0.1");
+		socket.on("error", () => undefined);
+		socket.write(
+			`GET ${proxyUrl.pathname}/mux HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+		);
+		await upgraded;
+
+		const closing = proxy.close();
+		const result = await Promise.race([
+			closing.then(() => "closed"),
+			new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
+		]);
+		socket.destroy();
+		await closing;
+		proxy = undefined;
+
+		expect(result).toBe("closed");
+	});
+
+	it("delivers SSE chunks as they are written, not on close", async () => {
+		upstream = createServer((_req, res) => {
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			res.write("data: first\n\n");
+			setTimeout(() => {
+				res.write("data: second\n\n");
+				res.end();
+			}, 500);
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/events`);
+		const reader = res.body!.getReader();
+		const started = Date.now();
+		const first = new TextDecoder().decode((await reader.read()).value);
+		const firstArrivedAfterMs = Date.now() - started;
+
+		expect(first).toContain("data: first");
+		// The second chunk is written 500ms later; receiving the first well before
+		// that proves streaming rather than buffer-until-close.
+		expect(firstArrivedAfterMs).toBeLessThan(300);
+		let rest = "";
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			rest += new TextDecoder().decode(value);
+		}
+		expect(rest).toContain("data: second");
+	});
+
+	it("tunnels a WebSocket upgrade with the credential injected", async () => {
+		const sawAuth: Array<string | undefined> = [];
+		upstream = createServer();
+		upstream.on("upgrade", (req, socket) => {
+			sawAuth.push(req.headers.authorization);
+			socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+			socket.on("data", (d) => socket.write(d)); // echo frames back verbatim
+			// Upgraded sockets are half-open by default and would hold close() open.
+			socket.on("end", () => socket.destroy());
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const received: Buffer[] = [];
+		const socket = netConnect(Number(proxyUrl.port), "127.0.0.1");
+		await new Promise<void>((resolve) => socket.on("connect", () => resolve()));
+		socket.on("data", (d) => received.push(d));
+		socket.write(
+			`GET ${proxyUrl.pathname}/mux HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		socket.write("payload-bytes");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		socket.destroy();
+
+		const all = Buffer.concat(received).toString();
+		expect(all).toContain("101 Switching Protocols");
+		expect(all).toContain("payload-bytes"); // echoed through both pipes
+		expect(sawAuth).toEqual(["Bearer pw"]);
+	});
+
+	it("destroys an upgrade that carries no token", async () => {
+		const sawUpgrade: string[] = [];
+		upstream = createServer();
+		upstream.on("upgrade", (upgraded) => sawUpgrade.push(upgraded.url ?? ""));
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const socket = netConnect(Number(proxyUrl.port), "127.0.0.1");
+		await new Promise<void>((resolve) => socket.on("connect", () => resolve()));
+		const closed = new Promise<void>((resolve) => socket.on("close", () => resolve()));
+		socket.on("error", () => undefined);
+		socket.write(
+			"GET /mux HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		);
+		await closed;
+		expect(sawUpgrade).toEqual([]);
+	});
+});

--- a/frontend/src/main/remote-proxy.ts
+++ b/frontend/src/main/remote-proxy.ts
@@ -1,0 +1,214 @@
+import { createServer, request as httpRequest, type Server } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { connect as netConnect, type AddressInfo, type Socket } from "node:net";
+import { connect as tlsConnect } from "node:tls";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { RemoteEntry } from "./remotes-store";
+
+// Loopback proxy fronting one remote AO daemon. It exists because the renderer
+// cannot authenticate to a remote daemon itself: EventSource and WebSocket
+// cannot set an Authorization header, and app://renderer has no CORS standing
+// there. The proxy holds the credential in main-process memory, injects it on
+// every forwarded request, and answers CORS for the renderer origin locally.
+//
+// Loopback is ambient authority everywhere in AO, but this socket fronts a
+// DIFFERENT machine — so every request must carry a 128-bit token in the URL
+// path (the one place EventSource and WebSocket can both put it). The token is
+// stripped before forwarding: the remote daemon and its logs never see it.
+export type ActiveProxy = {
+	base: string;
+	url: string;
+	close: () => Promise<void>;
+};
+
+const RENDERER_ORIGIN = "app://renderer";
+// Hop-by-hop or wrong-machine headers that must not transit the proxy.
+const STRIP_REQUEST_HEADERS = [
+	"host",
+	"origin",
+	"connection",
+	"keep-alive",
+	"transfer-encoding",
+	"upgrade",
+	"proxy-authorization",
+];
+
+const CORS_HEADERS: Record<string, string> = {
+	"access-control-allow-origin": RENDERER_ORIGIN,
+	"access-control-allow-methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+	vary: "origin",
+};
+
+// Nothing in this file may log a secret. Not the connection password, not the
+// proxy token, and not `req.url` (its first segment IS the token) — only the
+// post-strip path, and the upstream address, which is a machine on the user's
+// own network named in their own console. That is the whole point: "the app
+// can't reach my host" had no answer anywhere before this.
+function log(message: string): void {
+	console.log(`[remote-proxy] ${message}`);
+}
+
+function warn(message: string): void {
+	console.warn(`[remote-proxy] ${message}`);
+}
+
+function equalsToken(candidate: string, token: string): boolean {
+	// Constant-time: the token is the only thing standing between a local
+	// process and another machine's daemon, so don't leak it a byte at a time.
+	const a = Buffer.from(candidate);
+	const b = Buffer.from(token);
+	return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function startRemoteProxy(entry: RemoteEntry): Promise<ActiveProxy> {
+	const token = randomBytes(16).toString("hex");
+	const upstream = new URL(entry.url);
+	const secure = upstream.protocol === "https:";
+	const upstreamPort = Number(upstream.port || (secure ? 443 : 80));
+	// An https host must be spoken to over TLS. Forwarding it as cleartext puts
+	// the connection password on the wire in the clear — and the address bar
+	// already accepts https:// (AddRemoteHostDialog), so this is reachable by
+	// typing a Tailscale Serve or reverse-proxy URL.
+	const upstreamRequest = secure ? httpsRequest : httpRequest;
+	const dialUpstream = (onReady: () => void): Socket =>
+		secure
+			? tlsConnect(upstreamPort, upstream.hostname, { servername: upstream.hostname }, onReady)
+			: netConnect(upstreamPort, upstream.hostname, onReady);
+	// A host may be a daemon behind a reverse proxy at a path ("http://box/ao").
+	// The renderer's base is the proxy's own root, so the upstream prefix has to
+	// be restored here — without it every forwarded request, credential and all,
+	// lands on whatever else that vhost serves at /api/v1.
+	const prefix = upstream.pathname.replace(/\/+$/, "");
+	const server: Server = createServer();
+	const tunnels = new Set<() => void>();
+	// SSE connections outlive any fixed request timeout.
+	server.requestTimeout = 0;
+
+	const stripToken = (rawUrl: string | undefined): string | null => {
+		if (!rawUrl || !rawUrl.startsWith("/")) return null;
+		const slash = rawUrl.indexOf("/", 1);
+		const first = slash === -1 ? rawUrl.slice(1) : rawUrl.slice(1, slash);
+		if (!equalsToken(first, token)) return null;
+		return prefix + (slash === -1 ? "/" : rawUrl.slice(slash));
+	};
+
+	const forwardHeaders = (incoming: NodeJS.Dict<string | string[]>): NodeJS.Dict<string | string[]> => {
+		const out: NodeJS.Dict<string | string[]> = {};
+		for (const [name, value] of Object.entries(incoming)) {
+			if (!STRIP_REQUEST_HEADERS.includes(name.toLowerCase())) out[name] = value;
+		}
+		out.host = upstream.host;
+		out.authorization = `Bearer ${entry.password}`;
+		return out;
+	};
+
+	server.on("request", (req, res) => {
+		if (req.method === "OPTIONS") {
+			res.writeHead(204, {
+				...CORS_HEADERS,
+				"access-control-allow-headers": String(req.headers["access-control-request-headers"] ?? "content-type"),
+				"access-control-max-age": "600",
+			});
+			res.end();
+			return;
+		}
+		const path = stripToken(req.url);
+		if (path === null) {
+			res.writeHead(404, {
+				"content-type": "application/json",
+				...CORS_HEADERS,
+			});
+			res.end('{"error":"unknown path"}');
+			return;
+		}
+		const proxied = upstreamRequest(
+			{
+				host: upstream.hostname,
+				port: upstreamPort,
+				method: req.method,
+				path,
+				headers: forwardHeaders(req.headers),
+			},
+			(upstreamRes) => {
+				const headers: NodeJS.Dict<string | string[] | number> = {
+					...upstreamRes.headers,
+					...CORS_HEADERS,
+				};
+				delete headers.connection;
+				delete headers["keep-alive"];
+				res.writeHead(upstreamRes.statusCode ?? 502, headers);
+				// pipe streams SSE chunk-by-chunk; node performs no extra buffering.
+				upstreamRes.pipe(res);
+			},
+		);
+		proxied.setTimeout(0);
+		proxied.on("error", (error: Error) => {
+			warn(`upstream ${upstream.host} failed on ${req.method} ${path} (${error.message}); answering 502`);
+			if (!res.headersSent)
+				res.writeHead(502, {
+					"content-type": "application/json",
+					...CORS_HEADERS,
+				});
+			res.end('{"error":"remote daemon unreachable"}');
+		});
+		req.pipe(proxied);
+	});
+
+	server.on("upgrade", (req, socket: Socket, head: Buffer) => {
+		const path = stripToken(req.url);
+		if (path === null) {
+			socket.destroy();
+			return;
+		}
+		const upstreamSocket = dialUpstream(() => {
+			const headers = forwardHeaders(req.headers);
+			const lines = [`${req.method} ${path} HTTP/1.1`];
+			// The WebSocket-specific headers were stripped as hop-by-hop; restore
+			// the two the handshake requires, with the credential injected above.
+			headers.connection = "Upgrade";
+			headers.upgrade = String(req.headers.upgrade ?? "websocket");
+			for (const [name, value] of Object.entries(headers)) {
+				for (const v of Array.isArray(value) ? value : [value]) lines.push(`${name}: ${v}`);
+			}
+			upstreamSocket.write(lines.join("\r\n") + "\r\n\r\n");
+			if (head.length > 0) upstreamSocket.write(head);
+			socket.pipe(upstreamSocket);
+			upstreamSocket.pipe(socket);
+		});
+		upstreamSocket.on("error", (error: Error) => {
+			warn(`upstream ${upstream.host} tunnel failed on ${path} (${error.message})`);
+		});
+		const drop = () => {
+			tunnels.delete(drop);
+			socket.destroy();
+			upstreamSocket.destroy();
+		};
+		tunnels.add(drop);
+		// http.Server keeps upgraded sockets half-open (allowHalfOpen), so a peer
+		// that only sends FIN never triggers "close" — tear the pair down on
+		// "end" too or every closed terminal leaks a socket to the remote host.
+		for (const event of ["error", "end", "close"] as const) {
+			upstreamSocket.on(event, drop);
+			socket.on(event, drop);
+		}
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const port = (server.address() as AddressInfo).port;
+	log(`started on 127.0.0.1:${port} for ${upstream.host}`);
+	return {
+		base: `http://127.0.0.1:${port}/${token}`,
+		url: entry.url,
+		close: () =>
+			new Promise((resolve) => {
+				// close() alone waits on keep-alive and tunnelled sockets forever;
+				// a deactivated proxy must actually stop serving.
+				for (const drop of tunnels) drop();
+				server.closeAllConnections();
+				server.close(() => {
+					log(`stopped on 127.0.0.1:${port} for ${upstream.host}`);
+					resolve();
+				});
+			}),
+	};
+}

--- a/frontend/src/main/remote-proxy.ts
+++ b/frontend/src/main/remote-proxy.ts
@@ -137,7 +137,12 @@ export async function startRemoteProxy(entry: RemoteEntry): Promise<ActiveProxy>
 				delete headers.connection;
 				delete headers["keep-alive"];
 				res.writeHead(upstreamRes.statusCode ?? 502, headers);
-				// pipe streams SSE chunk-by-chunk; node performs no extra buffering.
+				// Node holds the header block until the first body byte or an explicit
+				// flush. An SSE upstream (GET /api/v1/events) can go arbitrarily long
+				// before its first byte, so without this the client's EventSource sits
+				// in CONNECTING forever — flush headers on their own, then pipe.
+				res.flushHeaders();
+				// pipe streams SSE chunk-by-chunk once headers are already on the wire.
 				upstreamRes.pipe(res);
 			},
 		);

--- a/frontend/src/main/remote-registry.test.ts
+++ b/frontend/src/main/remote-registry.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { RemoteRegistry } from "./remote-registry";
+
+const WORKBOX = { label: "workbox", url: "http://192.0.2.1:3011", password: "pw-one" };
+const MINI = { label: "mini", url: "http://192.0.2.9:3011", password: "pw-two" };
+
+function fakeProxies() {
+	const closed: string[] = [];
+	const start = vi.fn(async (entry: { url: string }) => ({
+		base: `http://127.0.0.1:9999/${entry.url.replace(/\W/g, "")}`,
+		url: entry.url,
+		close: async () => {
+			closed.push(entry.url);
+		},
+	}));
+	return { start, closed };
+}
+
+describe("RemoteRegistry", () => {
+	it("keeps several hosts connected at once", async () => {
+		const { start } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await registry.connect(WORKBOX);
+		await registry.connect(MINI);
+		expect(registry.views().map((view) => view.url)).toEqual([WORKBOX.url, MINI.url]);
+		expect(start).toHaveBeenCalledTimes(2);
+	});
+
+	it("connecting the same url twice reuses the live proxy", async () => {
+		const { start } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		const first = await registry.connect(WORKBOX);
+		const second = await registry.connect(WORKBOX);
+		expect(second).toEqual(first);
+		expect(start).toHaveBeenCalledTimes(1);
+	});
+
+	it("disconnect closes only that host's proxy", async () => {
+		const { start, closed } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await registry.connect(WORKBOX);
+		await registry.connect(MINI);
+		await registry.disconnect(WORKBOX.url);
+		expect(closed).toEqual([WORKBOX.url]);
+		expect(registry.views().map((view) => view.url)).toEqual([MINI.url]);
+	});
+
+	it("disconnecting a host that was never connected is a no-op", async () => {
+		const { start, closed } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await expect(registry.disconnect(WORKBOX.url)).resolves.toBeUndefined();
+		expect(closed).toEqual([]);
+		expect(start).not.toHaveBeenCalled();
+	});
+
+	it("never exposes the password", async () => {
+		const registry = new RemoteRegistry(fakeProxies().start);
+		const view = await registry.connect(WORKBOX);
+		expect(JSON.stringify(view)).not.toContain("pw-one");
+		expect(JSON.stringify(registry.views())).not.toContain("pw-one");
+	});
+
+	it("a host that fails to start does not join the registry", async () => {
+		const registry = new RemoteRegistry(async () => {
+			throw new Error("EADDRNOTAVAIL");
+		});
+		await expect(registry.connect(WORKBOX)).rejects.toThrow("EADDRNOTAVAIL");
+		expect(registry.views()).toEqual([]);
+	});
+
+	it("closeAll tears every proxy down", async () => {
+		const { start, closed } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await registry.connect(WORKBOX);
+		await registry.connect(MINI);
+		await registry.closeAll();
+		expect(closed.sort()).toEqual([WORKBOX.url, MINI.url].sort());
+		expect(registry.views()).toEqual([]);
+	});
+});

--- a/frontend/src/main/remote-registry.ts
+++ b/frontend/src/main/remote-registry.ts
@@ -1,0 +1,48 @@
+import type { ActiveProxy } from "./remote-proxy";
+import type { RemoteEntry } from "./remotes-store";
+
+/** What the renderer may know about a connected host. Password stays here. */
+export type ConnectedHostView = {
+	label: string;
+	url: string;
+	base: string;
+};
+
+type StartProxy = (entry: RemoteEntry) => Promise<ActiveProxy>;
+
+// N hosts live at once, one proxy each, keyed by url: the app does not view
+// one host, it talks to several.
+export class RemoteRegistry {
+	private readonly live = new Map<string, { view: ConnectedHostView; proxy: ActiveProxy }>();
+
+	constructor(private readonly start: StartProxy) {}
+
+	async connect(entry: RemoteEntry): Promise<ConnectedHostView> {
+		const existing = this.live.get(entry.url);
+		// Reuse rather than restart: a second connect would strand the first
+		// proxy's port with the renderer still holding streams against it.
+		if (existing) return existing.view;
+
+		const proxy = await this.start(entry);
+		const view = { label: entry.label, url: entry.url, base: proxy.base };
+		this.live.set(entry.url, { view, proxy });
+		return view;
+	}
+
+	async disconnect(url: string): Promise<void> {
+		const entry = this.live.get(url);
+		if (!entry) return;
+		this.live.delete(url);
+		await entry.proxy.close();
+	}
+
+	views(): ConnectedHostView[] {
+		return [...this.live.values()].map(({ view }) => view);
+	}
+
+	async closeAll(): Promise<void> {
+		const entries = [...this.live.values()];
+		this.live.clear();
+		await Promise.all(entries.map(({ proxy }) => proxy.close()));
+	}
+}

--- a/frontend/src/main/remote-request.test.ts
+++ b/frontend/src/main/remote-request.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeRemote, remoteRequest } from "./remote-request";
+
+const entry = { label: "workbox", url: "http://192.0.2.1:3011", password: "pw" };
+
+// Typed as fetch so `mock.calls` carries fetch's argument tuple — an untyped
+// `vi.fn(async () => …)` records a zero-length tuple and indexing it is a type error.
+function fakeFetch(status: number, body: unknown = {}) {
+	return vi.fn<typeof fetch>(async () => new Response(JSON.stringify(body), { status }));
+}
+
+// A body that is not JSON at all, the way an SPA catch-all answers every path.
+function fakeTextFetch(status: number, text: string) {
+	return vi.fn<typeof fetch>(async () => new Response(text, { status }));
+}
+
+const daemonProbe = { status: "ok", service: "agent-orchestrator-daemon", pid: 1234 };
+
+describe("remoteRequest", () => {
+	it("sends the connection password as a Bearer token", async () => {
+		const doFetch = fakeFetch(201, { id: "p1" });
+		await remoteRequest(entry, { method: "POST", path: "/api/v1/projects", body: { path: "/srv/repo" } }, doFetch);
+
+		const [url, init] = doFetch.mock.calls[0] as unknown as [string, RequestInit];
+		expect(url).toBe("http://192.0.2.1:3011/api/v1/projects");
+		expect(new Headers(init.headers).get("Authorization")).toBe("Bearer pw");
+		expect(init.body).toBe('{"path":"/srv/repo"}');
+	});
+
+	it("returns the status and parsed body rather than throwing on 4xx", async () => {
+		const doFetch = fakeFetch(400, { error: "path must be absolute" });
+		await expect(remoteRequest(entry, { method: "POST", path: "/api/v1/projects" }, doFetch)).resolves.toEqual({
+			status: 400,
+			body: { error: "path must be absolute" },
+		});
+	});
+
+	// A path is concatenated onto the host url, and "@" turns everything before
+	// it into userinfo — so an unchecked path is a way to post this host's
+	// connection password to someone else's server.
+	it("refuses a path that redirects the credential to another host", async () => {
+		const doFetch = fakeFetch(200);
+		await expect(remoteRequest(entry, { method: "GET", path: "@evil.example/steal" }, doFetch)).rejects.toThrow(
+			/evil\.example/,
+		);
+		expect(doFetch).not.toHaveBeenCalled();
+	});
+
+	it("keeps a protocol-relative path on the saved host", async () => {
+		const doFetch = fakeFetch(200);
+		await remoteRequest(entry, { method: "GET", path: "//evil.example/x" }, doFetch);
+		expect(doFetch.mock.calls[0][0]).toBe("http://192.0.2.1:3011//evil.example/x");
+	});
+
+	it("keeps a reverse-proxy path prefix", async () => {
+		const doFetch = fakeFetch(200);
+		await remoteRequest({ ...entry, url: "http://192.0.2.1/ao" }, { method: "GET", path: "/healthz" }, doFetch);
+		expect(doFetch.mock.calls[0][0]).toBe("http://192.0.2.1/ao/healthz");
+	});
+
+	it("joins paths without doubling the slash on a trailing-slash url", async () => {
+		const doFetch = fakeFetch(200);
+		await remoteRequest({ ...entry, url: "http://192.0.2.1:3011/" }, { method: "GET", path: "/healthz" }, doFetch);
+		expect(doFetch.mock.calls[0][0]).toBe("http://192.0.2.1:3011/healthz");
+	});
+});
+
+describe("probeRemote", () => {
+	it("reports online on a 200 that carries the daemon's own probe body", async () => {
+		await expect(probeRemote(entry, fakeFetch(200, daemonProbe))).resolves.toBe("online");
+	});
+
+	it("distinguishes a bad password from an unreachable host", async () => {
+		await expect(probeRemote(entry, fakeFetch(401))).resolves.toBe("unauthorized");
+		const refused = vi.fn(async () => {
+			throw new TypeError("fetch failed");
+		});
+		await expect(probeRemote(entry, refused)).resolves.toBe("offline");
+	});
+
+	it("bounds probes to sleeping hosts", async () => {
+		const sleeping = vi.fn<typeof fetch>((_input, init) =>
+			new Promise((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+			}),
+		);
+
+		await expect(probeRemote(entry, sleeping, 1)).resolves.toBe("offline");
+		expect(sleeping.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	// The port typo that white-screened the app: :8081 was an Expo web server,
+	// whose SPA catch-all answers /healthz with 200 and an HTML page. A status
+	// code proves something replied, not that it speaks the daemon's protocol —
+	// and once such a host became the api base, every query returned that page.
+	it("rejects a 200 whose body is not a daemon probe", async () => {
+		const html = fakeTextFetch(200, "<!DOCTYPE html><html><title>AO</title></html>");
+		await expect(probeRemote(entry, html)).resolves.toBe("not-a-daemon");
+	});
+
+	it("rejects a 200 from a JSON service that is not the daemon", async () => {
+		await expect(probeRemote(entry, fakeFetch(200, { status: "ok" }))).resolves.toBe("not-a-daemon");
+		await expect(probeRemote(entry, fakeFetch(200, { ...daemonProbe, service: "grafana" }))).resolves.toBe(
+			"not-a-daemon",
+		);
+	});
+});

--- a/frontend/src/main/remote-request.ts
+++ b/frontend/src/main/remote-request.ts
@@ -1,0 +1,86 @@
+import { parseDaemonProbe } from "../shared/daemon-attach";
+import type { RemoteEntry } from "./remotes-store";
+
+// Remote HTTP lives in the main process for two reasons: the renderer's origin
+// is app://renderer and a remote daemon has no reason to allow it through CORS,
+// and the connection password must never enter renderer memory.
+export type RemoteRequestInit = {
+	method: "GET" | "POST" | "DELETE";
+	path: string;
+	body?: unknown;
+};
+
+export type RemoteResponse = {
+	status: number;
+	body: unknown;
+};
+
+// "not-a-daemon" is its own answer because the honest sentence differs: the
+// address replied, so telling someone it is unreachable sends them to debug a
+// network that is working.
+export type RemoteHealth = "online" | "unauthorized" | "offline" | "not-a-daemon";
+
+type FetchImpl = typeof fetch;
+
+export async function remoteRequest(
+	entry: RemoteEntry,
+	init: RemoteRequestInit,
+	fetchImpl: FetchImpl = fetch,
+	signal?: AbortSignal,
+): Promise<RemoteResponse> {
+	const base = entry.url.replace(/\/+$/, "");
+	// The path is concatenated, and a concatenated path can leave the host: a
+	// path starting with "@" turns the base into userinfo ("http://box:3011" +
+	// "@evil.com/" is a request to evil.com) and would hand this host's
+	// connection password to whoever answers there. The renderer is the only
+	// caller today, but it is the process that renders agent output, so the
+	// origin is checked here rather than trusted upstream.
+	const target = new URL(`${base}${init.path}`);
+	if (target.origin !== new URL(base).origin)
+		throw new Error(`refusing to send ${entry.url} credentials to ${target.origin}`);
+	const response = await fetchImpl(target.href, {
+		method: init.method,
+		headers: {
+			"Content-Type": "application/json",
+			// Same credential presentation as the CLI (cli/remote.go:374).
+			Authorization: `Bearer ${entry.password}`,
+		},
+		body: init.body === undefined ? undefined : JSON.stringify(init.body),
+		signal,
+	});
+
+	const text = await response.text();
+	let body: unknown = null;
+	try {
+		body = text ? JSON.parse(text) : null;
+	} catch {
+		body = text;
+	}
+	return { status: response.status, body };
+}
+
+export async function probeRemote(
+	entry: RemoteEntry,
+	fetchImpl: FetchImpl = fetch,
+	timeoutMs = 5_000,
+): Promise<RemoteHealth> {
+	try {
+		const { status, body } = await remoteRequest(
+			entry,
+			{ method: "GET", path: "/healthz" },
+			fetchImpl,
+			AbortSignal.timeout(timeoutMs),
+		);
+		if (status === 401 || status === 403) return "unauthorized";
+		if (status < 200 || status >= 300) return "offline";
+		// A status code proves something replied, not that it is a daemon. An SPA
+		// catch-all (an Expo dev server on a mistyped port, say) answers every path
+		// with 200 and an HTML page; accepting that as the api base hands the whole
+		// renderer bodies it will read fields off and crash on.
+		return parseDaemonProbe("healthz", body) === null ? "not-a-daemon" : "online";
+	} catch {
+		// A transport failure is indistinguishable from a wrong port here, and
+		// both mean the same thing to the user: it is not reachable.
+		return "offline";
+	}
+}

--- a/frontend/src/main/remotes-ipc.test.ts
+++ b/frontend/src/main/remotes-ipc.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findRemote, removeSavedRemote, toHostViews, updateSavedRemote } from "./remotes-ipc";
+import type { RemoteEntry } from "./remotes-store";
+
+const TWO_HOSTS =
+	'{"remotes":[{"label":"workbox","url":"http://192.0.2.1:1","password":"old"},{"label":"mini","url":"http://192.0.2.9:9","password":"m"}]}';
+
+async function tempFile(contents = TWO_HOSTS, mode = 0o600): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "ao-remotes-ipc-"));
+	const path = join(dir, "remotes.json");
+	await writeFile(path, contents, "utf8");
+	await chmod(path, mode);
+	return path;
+}
+
+const online = async () => "online" as const;
+const dropped = () => vi.fn<(url: string) => Promise<void>>().mockResolvedValue(undefined);
+
+describe("toHostViews", () => {
+	it("strips the password before anything crosses to the renderer", () => {
+		const views = toHostViews([{ label: "workbox", url: "http://192.0.2.1:3011", password: "supersecret" }]);
+		expect(views).toEqual([{ label: "workbox", url: "http://192.0.2.1:3011" }]);
+		expect(JSON.stringify(views)).not.toContain("supersecret");
+	});
+});
+
+describe("findRemote", () => {
+	it("returns the saved entry for a url", async () => {
+		const path = await tempFile();
+		await expect(findRemote(path, "http://192.0.2.9:9")).resolves.toEqual({ label: "mini", url: "http://192.0.2.9:9", password: "m" });
+	});
+
+	it("refuses a url it has never saved", async () => {
+		const path = await tempFile();
+		await expect(findRemote(path, "http://192.0.2.5:5")).rejects.toThrow(/no saved host/);
+	});
+});
+
+describe("updateSavedRemote", () => {
+	it("probes the merged entry before it writes anything", async () => {
+		const path = await tempFile();
+		const probed: RemoteEntry[] = [];
+		const health = await updateSavedRemote(path, "http://192.0.2.1:1", { password: "rotated" }, dropped(), async (entry) => {
+			probed.push(entry);
+			return "online";
+		});
+		expect(health).toBe("online");
+		// Probed with the new password against the saved address, not with either half.
+		expect(probed).toEqual([{ label: "workbox", url: "http://192.0.2.1:1", password: "rotated" }]);
+	});
+
+	it("saves nothing and drops nothing when the edited host does not answer", async () => {
+		const path = await tempFile();
+		const disconnect = dropped();
+		const health = await updateSavedRemote(path, "http://192.0.2.1:1", { password: "wrong" }, disconnect, async () => "unauthorized");
+		expect(health).toBe("unauthorized");
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+		expect(disconnect).not.toHaveBeenCalled();
+	});
+
+	// A live proxy holds the address and password that were saved when it
+	// started; after an edit both may be stale, so it does not get to keep serving.
+	it("drops the edited host's proxy by its old url", async () => {
+		const path = await tempFile();
+		const disconnect = dropped();
+		await updateSavedRemote(path, "http://192.0.2.1:1", { url: "http://192.0.2.5:5" }, disconnect, online);
+		expect(disconnect).toHaveBeenCalledTimes(1);
+		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+	});
+});
+
+describe("removeSavedRemote", () => {
+	it("forgets the host and drops its proxy", async () => {
+		const path = await tempFile();
+		const disconnect = dropped();
+		await removeSavedRemote(path, "http://192.0.2.1:1", disconnect);
+		expect(JSON.parse(await readFile(path, "utf8")).remotes).toEqual([{ label: "mini", url: "http://192.0.2.9:9", password: "m" }]);
+		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+	});
+
+	it("refuses to touch a file others can read", async () => {
+		const path = await tempFile(TWO_HOSTS, 0o644);
+		const disconnect = dropped();
+		await expect(removeSavedRemote(path, "http://192.0.2.1:1", disconnect)).rejects.toThrow(/chmod 600/);
+		expect(disconnect).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/main/remotes-ipc.ts
+++ b/frontend/src/main/remotes-ipc.ts
@@ -1,0 +1,55 @@
+import { probeRemote, type RemoteHealth } from "./remote-request";
+import {
+	applyRemoteChanges,
+	readRemotes,
+	removeRemote,
+	updateRemote,
+	type RemoteChanges,
+	type RemoteEntry,
+} from "./remotes-store";
+
+// What the renderer is allowed to see. The password stays in the main process.
+export type RemoteHostView = {
+	label: string;
+	url: string;
+};
+
+export function toHostViews(entries: RemoteEntry[]): RemoteHostView[] {
+	return entries.map(({ label, url }) => ({ label, url }));
+}
+
+export async function findRemote(path: string, url: string): Promise<RemoteEntry> {
+	const entry = (await readRemotes(path)).find((candidate) => candidate.url === url);
+	if (!entry) throw new Error(`no saved host for ${url}`);
+	return entry;
+}
+
+// Whatever is serving this url must stop: after an edit it holds a stale
+// address or password, after a removal it is an open door with no doorman.
+// Called unconditionally — dropping a host that was never connected is a no-op.
+type Disconnect = (url: string) => Promise<void>;
+
+/**
+ * Edit a saved host in place. Probes before saving exactly as adding does — an
+ * edit is how a host gets fixed, and one that lands somewhere unreachable only
+ * looks fixed.
+ */
+export async function updateSavedRemote(
+	path: string,
+	url: string,
+	changes: RemoteChanges,
+	disconnect: Disconnect,
+	probe: (entry: RemoteEntry) => Promise<RemoteHealth> = probeRemote,
+): Promise<RemoteHealth> {
+	const health = await probe(applyRemoteChanges(await findRemote(path, url), changes));
+	if (health !== "online") return health;
+	await updateRemote(path, url, changes);
+	await disconnect(url);
+	return health;
+}
+
+/** Forget a saved host. */
+export async function removeSavedRemote(path: string, url: string, disconnect: Disconnect): Promise<void> {
+	await removeRemote(path, url);
+	await disconnect(url);
+}

--- a/frontend/src/main/remotes-main.test.ts
+++ b/frontend/src/main/remotes-main.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerRemotesIpc } from "./remotes-main";
+
+type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
+
+// ipcMain stand-in: records what was registered and lets a test invoke it.
+function fakeIpc() {
+	const handlers = new Map<string, Handler>();
+	return {
+		ipcMain: { handle: (channel: string, handler: Handler) => void handlers.set(channel, handler) },
+		invoke: (channel: string, ...args: unknown[]) => {
+			const handler = handlers.get(channel);
+			if (!handler) throw new Error(`no handler for ${channel}`);
+			return handler({}, ...args);
+		},
+		channels: () => [...handlers.keys()].sort(),
+	};
+}
+
+async function tempFile(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "ao-remotes-main-"));
+	const path = join(dir, "remotes.json");
+	await writeFile(path, '{"remotes":[{"label":"workbox","url":"http://192.0.2.1:1","password":"old"}]}', "utf8");
+	await chmod(path, 0o600);
+	return path;
+}
+
+describe("registerRemotesIpc", () => {
+	it("registers the saved-host surface", async () => {
+		const ipc = fakeIpc();
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		expect(ipc.channels()).toEqual([
+			"remotes:add",
+			"remotes:list",
+			"remotes:probe",
+			"remotes:remove",
+			"remotes:request",
+			"remotes:update",
+		]);
+	});
+
+	it("lists hosts without their passwords", async () => {
+		const ipc = fakeIpc();
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		await expect(ipc.invoke("remotes:list")).resolves.toEqual([{ label: "workbox", url: "http://192.0.2.1:1" }]);
+	});
+
+	it("saves a new host only after it answers as a daemon", async () => {
+		const ipc = fakeIpc();
+		const file = await tempFile();
+		const probe = vi.fn().mockResolvedValueOnce("offline" as const).mockResolvedValueOnce("online" as const);
+		registerRemotesIpc(ipc.ipcMain, { file, disconnect: async () => undefined, probe });
+		const mini = { label: "mini", url: "http://192.0.2.9:9", password: "m" };
+
+		await expect(ipc.invoke("remotes:add", mini)).resolves.toBe("offline");
+		expect(JSON.parse(await readFile(file, "utf8")).remotes).toHaveLength(1);
+
+		await expect(ipc.invoke("remotes:add", mini)).resolves.toBe("online");
+		expect(JSON.parse(await readFile(file, "utf8")).remotes).toHaveLength(2);
+	});
+
+	it("drops the proxy of a removed host", async () => {
+		const ipc = fakeIpc();
+		const disconnect = vi.fn().mockResolvedValue(undefined);
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect });
+		await ipc.invoke("remotes:remove", "http://192.0.2.1:1");
+		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+	});
+});

--- a/frontend/src/main/remotes-main.test.ts
+++ b/frontend/src/main/remotes-main.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerRemotesIpc } from "./remotes-main";
+import { RemoteRegistry } from "./remote-registry";
 
 type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
 
@@ -28,12 +29,26 @@ async function tempFile(): Promise<string> {
 	return path;
 }
 
+
+function registryOf(closed: string[] = []) {
+	return new RemoteRegistry(async (entry) => ({
+		base: "http://127.0.0.1:9999/tok",
+		url: entry.url,
+		close: async () => {
+			closed.push(entry.url);
+		},
+	}));
+}
+
 describe("registerRemotesIpc", () => {
-	it("registers the saved-host surface", async () => {
+	it("registers the saved-host and connection surface", async () => {
 		const ipc = fakeIpc();
-		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf() });
 		expect(ipc.channels()).toEqual([
 			"remotes:add",
+			"remotes:connect",
+			"remotes:connected",
+			"remotes:disconnect",
 			"remotes:list",
 			"remotes:probe",
 			"remotes:remove",
@@ -44,7 +59,7 @@ describe("registerRemotesIpc", () => {
 
 	it("lists hosts without their passwords", async () => {
 		const ipc = fakeIpc();
-		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf() });
 		await expect(ipc.invoke("remotes:list")).resolves.toEqual([{ label: "workbox", url: "http://192.0.2.1:1" }]);
 	});
 
@@ -52,7 +67,7 @@ describe("registerRemotesIpc", () => {
 		const ipc = fakeIpc();
 		const file = await tempFile();
 		const probe = vi.fn().mockResolvedValueOnce("offline" as const).mockResolvedValueOnce("online" as const);
-		registerRemotesIpc(ipc.ipcMain, { file, disconnect: async () => undefined, probe });
+		registerRemotesIpc(ipc.ipcMain, { file, registry: registryOf(), probe });
 		const mini = { label: "mini", url: "http://192.0.2.9:9", password: "m" };
 
 		await expect(ipc.invoke("remotes:add", mini)).resolves.toBe("offline");
@@ -62,11 +77,36 @@ describe("registerRemotesIpc", () => {
 		expect(JSON.parse(await readFile(file, "utf8")).remotes).toHaveLength(2);
 	});
 
-	it("drops the proxy of a removed host", async () => {
+	it("connects a saved host only after it answers as a daemon, and hands back a password-free view", async () => {
 		const ipc = fakeIpc();
-		const disconnect = vi.fn().mockResolvedValue(undefined);
-		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect });
+		const probe = vi.fn().mockResolvedValueOnce("offline" as const).mockResolvedValueOnce("online" as const);
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf(), probe });
+
+		await expect(ipc.invoke("remotes:connect", "http://192.0.2.1:1")).rejects.toThrow(/is offline/);
+		await expect(ipc.invoke("remotes:connected")).resolves.toEqual([]);
+
+		const view = await ipc.invoke("remotes:connect", "http://192.0.2.1:1");
+		expect(view).toEqual({ label: "workbox", url: "http://192.0.2.1:1", base: "http://127.0.0.1:9999/tok" });
+		expect(JSON.stringify(await ipc.invoke("remotes:connected"))).not.toContain("old");
+	});
+
+	it("removing a connected host closes its proxy", async () => {
+		const ipc = fakeIpc();
+		const closed: string[] = [];
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf(closed), probe: async () => "online" });
+		await ipc.invoke("remotes:connect", "http://192.0.2.1:1");
 		await ipc.invoke("remotes:remove", "http://192.0.2.1:1");
-		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+		expect(closed).toEqual(["http://192.0.2.1:1"]);
+		await expect(ipc.invoke("remotes:connected")).resolves.toEqual([]);
+	});
+
+	it("disconnect closes the proxy and forgets the view", async () => {
+		const ipc = fakeIpc();
+		const closed: string[] = [];
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf(closed), probe: async () => "online" });
+		await ipc.invoke("remotes:connect", "http://192.0.2.1:1");
+		await ipc.invoke("remotes:disconnect", "http://192.0.2.1:1");
+		expect(closed).toEqual(["http://192.0.2.1:1"]);
+		await expect(ipc.invoke("remotes:connected")).resolves.toEqual([]);
 	});
 });

--- a/frontend/src/main/remotes-main.ts
+++ b/frontend/src/main/remotes-main.ts
@@ -1,0 +1,53 @@
+import os from "node:os";
+import path from "node:path";
+import { probeRemote, remoteRequest, type RemoteHealth, type RemoteRequestInit } from "./remote-request";
+import { findRemote, removeSavedRemote, toHostViews, updateSavedRemote } from "./remotes-ipc";
+import { addRemote, readRemotes, type RemoteChanges, type RemoteEntry } from "./remotes-store";
+
+// The CLI resolves this file through config.StateDir(), which is ~/.ao
+// unconditionally — it does NOT honour AO_DATA_DIR (that points at the daemon's
+// data dir). Following AO_DATA_DIR here would make the app read a different
+// file than `ao --url` writes, which defeats sharing one host list and one
+// credential store.
+export function remotesFilePath(): string {
+	return path.join(os.homedir(), ".ao", "remotes.json");
+}
+
+// The slice of Electron's ipcMain these handlers need, so tests need no Electron.
+type IpcMainLike = {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- the listener
+	// args must unify Electron's IpcMain (any[]) with a test fake (unknown[]),
+	// and `never[]` rejects both; `any[]` here leaks nowhere past registration.
+	handle(channel: string, listener: (event: unknown, ...args: any[]) => Promise<unknown>): void;
+};
+
+export type RemotesIpcDeps = {
+	file: string;
+	/** Stop whatever is serving this url; a no-op for a host that is not connected. */
+	disconnect: (url: string) => Promise<void>;
+	probe?: (entry: RemoteEntry) => Promise<RemoteHealth>;
+};
+
+/**
+ * Saved AO daemons, shared with the CLI's ~/.ao/remotes.json. Everything the
+ * renderer receives back is password-free (see remotes-ipc.ts); the plaintext
+ * password only ever travels renderer -> main, on `add`.
+ */
+export function registerRemotesIpc(ipcMain: IpcMainLike, { file, disconnect, probe = probeRemote }: RemotesIpcDeps): void {
+	ipcMain.handle("remotes:list", async () => toHostViews(await readRemotes(file)));
+	ipcMain.handle("remotes:add", async (_event, input: RemoteEntry) => {
+		// Probe before saving: a host that never answered is worse than no host,
+		// because it looks configured.
+		const health = await probe(input);
+		if (health === "online") await addRemote(file, input);
+		return health;
+	});
+	ipcMain.handle("remotes:probe", async (_event, url: string) => probe(await findRemote(file, url)));
+	ipcMain.handle("remotes:request", async (_event, url: string, init: RemoteRequestInit) =>
+		remoteRequest(await findRemote(file, url), init),
+	);
+	ipcMain.handle("remotes:update", async (_event, url: string, changes: RemoteChanges) =>
+		updateSavedRemote(file, url, changes, disconnect, probe),
+	);
+	ipcMain.handle("remotes:remove", async (_event, url: string) => removeSavedRemote(file, url, disconnect));
+}

--- a/frontend/src/main/remotes-main.ts
+++ b/frontend/src/main/remotes-main.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { probeRemote, remoteRequest, type RemoteHealth, type RemoteRequestInit } from "./remote-request";
 import { findRemote, removeSavedRemote, toHostViews, updateSavedRemote } from "./remotes-ipc";
+import type { RemoteRegistry } from "./remote-registry";
 import { addRemote, readRemotes, type RemoteChanges, type RemoteEntry } from "./remotes-store";
 
 // The CLI resolves this file through config.StateDir(), which is ~/.ao
@@ -23,8 +24,7 @@ type IpcMainLike = {
 
 export type RemotesIpcDeps = {
 	file: string;
-	/** Stop whatever is serving this url; a no-op for a host that is not connected. */
-	disconnect: (url: string) => Promise<void>;
+	registry: RemoteRegistry;
 	probe?: (entry: RemoteEntry) => Promise<RemoteHealth>;
 };
 
@@ -33,7 +33,9 @@ export type RemotesIpcDeps = {
  * renderer receives back is password-free (see remotes-ipc.ts); the plaintext
  * password only ever travels renderer -> main, on `add`.
  */
-export function registerRemotesIpc(ipcMain: IpcMainLike, { file, disconnect, probe = probeRemote }: RemotesIpcDeps): void {
+export function registerRemotesIpc(ipcMain: IpcMainLike, { file, registry, probe = probeRemote }: RemotesIpcDeps): void {
+	const disconnect = (url: string) => registry.disconnect(url);
+
 	ipcMain.handle("remotes:list", async () => toHostViews(await readRemotes(file)));
 	ipcMain.handle("remotes:add", async (_event, input: RemoteEntry) => {
 		// Probe before saving: a host that never answered is worse than no host,
@@ -50,4 +52,16 @@ export function registerRemotesIpc(ipcMain: IpcMainLike, { file, disconnect, pro
 		updateSavedRemote(file, url, changes, disconnect, probe),
 	);
 	ipcMain.handle("remotes:remove", async (_event, url: string) => removeSavedRemote(file, url, disconnect));
+
+	ipcMain.handle("remotes:connect", async (_event, url: string) => {
+		const entry = await findRemote(file, url);
+		// Probe before starting a proxy: a reachable port may serve something
+		// other than an AO daemon, and exposing it as connected can wedge the
+		// app at boot.
+		const health = await probe(entry);
+		if (health !== "online") throw new Error(`host ${url} is ${health}`);
+		return registry.connect(entry);
+	});
+	ipcMain.handle("remotes:disconnect", async (_event, url: string) => disconnect(url));
+	ipcMain.handle("remotes:connected", async () => registry.views());
 }

--- a/frontend/src/main/remotes-store.test.ts
+++ b/frontend/src/main/remotes-store.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { chmod, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addRemote, readRemotes, removeRemote, RemotesFilePermissionError, updateRemote } from "./remotes-store";
+
+async function tempFile(contents?: string, mode = 0o600): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "ao-remotes-"));
+	const path = join(dir, "remotes.json");
+	if (contents !== undefined) {
+		await writeFile(path, contents, "utf8");
+		await chmod(path, mode);
+	}
+	return path;
+}
+
+describe("readRemotes", () => {
+	it("returns an empty list when the file does not exist", async () => {
+		const path = await tempFile();
+		await expect(readRemotes(path)).resolves.toEqual([]);
+	});
+
+	it("reads entries from a 0600 file", async () => {
+		const path = await tempFile('{"remotes":[{"label":"workbox","url":"http://192.0.2.1:3011","password":"pw"}]}');
+		await expect(readRemotes(path)).resolves.toEqual([
+			{ label: "workbox", url: "http://192.0.2.1:3011", password: "pw" },
+		]);
+	});
+
+	it("refuses a file readable by others, naming the fix", async () => {
+		const path = await tempFile('{"remotes":[]}', 0o644);
+		await expect(readRemotes(path)).rejects.toBeInstanceOf(RemotesFilePermissionError);
+		await expect(readRemotes(path)).rejects.toThrow(/chmod 600/);
+	});
+
+	// Node reports 0o666 for every writable file on Windows, so the mode check
+	// there refuses a perfectly good file and takes saved hosts down with it.
+	// The CLI exempts win32 for the same reason (cli/remote.go:154).
+	it("does not apply the mode check on windows", async () => {
+		const path = await tempFile('{"remotes":[]}', 0o644);
+		const platform = Object.getOwnPropertyDescriptor(process, "platform");
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		try {
+			await expect(readRemotes(path)).resolves.toEqual([]);
+		} finally {
+			if (platform) Object.defineProperty(process, "platform", platform);
+		}
+	});
+});
+
+describe("addRemote", () => {
+	it("creates the file 0600 when absent", async () => {
+		const path = await tempFile();
+		await addRemote(path, { label: "workbox", url: "http://192.0.2.1:3011", password: "pw" });
+		expect((await stat(path)).mode & 0o777).toBe(0o600);
+		expect(JSON.parse(await readFile(path, "utf8")).remotes).toHaveLength(1);
+	});
+
+	it("appends without dropping existing entries", async () => {
+		const path = await tempFile('{"remotes":[{"label":"a","url":"http://192.0.2.1:1","password":"x"}]}');
+		await addRemote(path, { label: "b", url: "http://192.0.2.2:2", password: "y" });
+		const labels = JSON.parse(await readFile(path, "utf8")).remotes.map((r: { label: string }) => r.label);
+		expect(labels).toEqual(["a", "b"]);
+	});
+
+	it("replaces an entry with the same url rather than duplicating it", async () => {
+		const path = await tempFile('{"remotes":[{"label":"old","url":"http://192.0.2.1:1","password":"x"}]}');
+		await addRemote(path, { label: "new", url: "http://192.0.2.1:1", password: "z" });
+		const remotes = JSON.parse(await readFile(path, "utf8")).remotes;
+		expect(remotes).toEqual([{ label: "new", url: "http://192.0.2.1:1", password: "z" }]);
+	});
+});
+
+const TWO_HOSTS =
+	'{"remotes":[{"label":"workbox","url":"http://192.0.2.1:1","password":"old"},{"label":"mini","url":"http://192.0.2.9:9","password":"m"}]}';
+
+async function savedRemotes(path: string): Promise<unknown[]> {
+	return JSON.parse(await readFile(path, "utf8")).remotes;
+}
+
+describe("updateRemote", () => {
+	// The reason this exists: re-enabling the LAN bridge rotates the connection
+	// password, and until now the saved entry just died.
+	it("changes the password and nothing else", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await expect(updateRemote(path, "http://192.0.2.1:1", { password: "rotated" })).resolves.toEqual({
+			label: "workbox",
+			url: "http://192.0.2.1:1",
+			password: "rotated",
+		});
+		expect(await savedRemotes(path)).toEqual([
+			{ label: "workbox", url: "http://192.0.2.1:1", password: "rotated" },
+			{ label: "mini", url: "http://192.0.2.9:9", password: "m" },
+		]);
+	});
+
+	it("renames without touching the saved password", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { label: "the workbox" });
+		expect(await savedRemotes(path)).toContainEqual({ label: "the workbox", url: "http://192.0.2.1:1", password: "old" });
+	});
+
+	// An explicitly-undefined field survives Electron's structured clone, so
+	// "leave the password alone" arrives as a present key with no value.
+	it("treats an undefined field as absent rather than as a wipe", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { label: "renamed", password: undefined });
+		expect(await savedRemotes(path)).toContainEqual({ label: "renamed", url: "http://192.0.2.1:1", password: "old" });
+	});
+
+	it("moves the entry when the url changes instead of cloning it", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { url: "http://192.0.2.5:5" });
+		expect(await savedRemotes(path)).toEqual([
+			{ label: "workbox", url: "http://192.0.2.5:5", password: "old" },
+			{ label: "mini", url: "http://192.0.2.9:9", password: "m" },
+		]);
+	});
+
+	// Typing the address of a host you already saved must leave one host, not two
+	// rows racing to answer for the same machine.
+	it("absorbs another entry that already sits on the new url", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { url: "http://192.0.2.9:9" });
+		expect(await savedRemotes(path)).toEqual([{ label: "workbox", url: "http://192.0.2.9:9", password: "old" }]);
+	});
+
+	it("refuses a url it has never saved", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await expect(updateRemote(path, "http://192.0.2.7:7", { label: "ghost" })).rejects.toThrow(/no saved host/);
+	});
+
+	it("keeps the file 0600", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { password: "rotated" });
+		expect((await stat(path)).mode & 0o777).toBe(0o600);
+	});
+
+	it("refuses to touch a file others can read", async () => {
+		const path = await tempFile(TWO_HOSTS, 0o644);
+		await expect(updateRemote(path, "http://192.0.2.1:1", { password: "rotated" })).rejects.toBeInstanceOf(
+			RemotesFilePermissionError,
+		);
+		// And left the passwords exactly where they were.
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+	});
+});
+
+describe("removeRemote", () => {
+	it("drops only the named host", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await removeRemote(path, "http://192.0.2.1:1");
+		expect(await savedRemotes(path)).toEqual([{ label: "mini", url: "http://192.0.2.9:9", password: "m" }]);
+	});
+
+	it("keeps the file 0600", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await removeRemote(path, "http://192.0.2.1:1");
+		expect((await stat(path)).mode & 0o777).toBe(0o600);
+	});
+
+	it("is a no-op for a host that was never saved", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await removeRemote(path, "http://192.0.2.7:7");
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+	});
+
+	it("refuses to touch a file others can read", async () => {
+		const path = await tempFile(TWO_HOSTS, 0o644);
+		await expect(removeRemote(path, "http://192.0.2.1:1")).rejects.toBeInstanceOf(RemotesFilePermissionError);
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+	});
+});

--- a/frontend/src/main/remotes-store.ts
+++ b/frontend/src/main/remotes-store.ts
@@ -1,0 +1,94 @@
+import { readFile, stat, writeFile } from "node:fs/promises";
+
+// The CLI's saved-remote store, shared verbatim so the UI and `ao --url` agree
+// on which hosts exist and never hold two copies of a connection password.
+// Format and the 0600 requirement come from backend/internal/cli/remote.go:32-47.
+export type RemoteEntry = {
+	label: string;
+	url: string;
+	password: string;
+};
+
+export class RemotesFilePermissionError extends Error {
+	constructor(
+		readonly path: string,
+		readonly mode: number,
+	) {
+		super(
+			`${path} holds connection passwords and is readable by others (mode ${mode.toString(8).padStart(4, "0")}) — run: chmod 600 ${path}`,
+		);
+	}
+}
+
+function isMissing(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+export async function readRemotes(path: string): Promise<RemoteEntry[]> {
+	let mode: number;
+	try {
+		mode = (await stat(path)).mode & 0o777;
+	} catch (error) {
+		if (isMissing(error)) return [];
+		throw error;
+	}
+	// Mirrors the CLI: a world-readable credential file is refused, not tolerated.
+	// Windows is exempt for the same reason it is in the CLI (cli/remote.go:154):
+	// Node reports 0o666 for every writable file there, so the check would refuse
+	// every remotes.json on that platform and take saved hosts down with it.
+	if (process.platform !== "win32" && mode & 0o077) throw new RemotesFilePermissionError(path, mode);
+
+	const parsed = JSON.parse(await readFile(path, "utf8")) as { remotes?: RemoteEntry[] };
+	return parsed.remotes ?? [];
+}
+
+// Every write goes through here: mode on writeFile only applies at creation;
+// chmod-on-write would race, and readRemotes — which each of these calls first —
+// refuses anything looser on the next read regardless.
+async function writeRemotes(path: string, remotes: RemoteEntry[]): Promise<void> {
+	await writeFile(path, `${JSON.stringify({ remotes }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+}
+
+export async function addRemote(path: string, entry: RemoteEntry): Promise<void> {
+	const existing = await readRemotes(path);
+	await writeRemotes(path, [...existing.filter((candidate) => candidate.url !== entry.url), entry]);
+}
+
+/** An edit: only the fields it carries change. */
+export type RemoteChanges = Partial<RemoteEntry>;
+
+/**
+ * Absent fields keep their saved value. Written with an explicit `??` per field
+ * rather than a spread because Electron's structured clone preserves a key whose
+ * value is undefined — `{ password: undefined }` must not wipe a working
+ * password, which is exactly what "leave blank to keep it" sends.
+ */
+export function applyRemoteChanges(entry: RemoteEntry, changes: RemoteChanges): RemoteEntry {
+	return {
+		label: changes.label ?? entry.label,
+		url: changes.url ?? entry.url,
+		password: changes.password ?? entry.password,
+	};
+}
+
+export async function updateRemote(path: string, url: string, changes: RemoteChanges): Promise<RemoteEntry> {
+	const existing = await readRemotes(path);
+	const current = existing.find((candidate) => candidate.url === url);
+	if (!current) throw new Error(`no saved host for ${url}`);
+	const updated = applyRemoteChanges(current, changes);
+	// Re-pointing a host MOVES its entry: the row keeps its place, and any other
+	// row already sitting on the new url is absorbed rather than left as a twin.
+	const remotes = existing
+		.map((candidate) => (candidate === current ? updated : candidate))
+		.filter((candidate) => candidate === updated || candidate.url !== updated.url);
+	await writeRemotes(path, remotes);
+	return updated;
+}
+
+export async function removeRemote(path: string, url: string): Promise<void> {
+	const existing = await readRemotes(path);
+	const remaining = existing.filter((candidate) => candidate.url !== url);
+	// Removing what is not there is not an error, but it is not a write either.
+	if (remaining.length === existing.length) return;
+	await writeRemotes(path, remaining);
+}

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -16,6 +16,8 @@ import {
 	type TrayOpenSessionTarget,
 } from "./shared/tray";
 import type { DaemonStatus } from "./shared/daemon-status";
+import type { RemoteHostView } from "./main/remotes-ipc";
+import type { RemoteHealth, RemoteRequestInit, RemoteResponse } from "./main/remote-request";
 import type {
 	EditorHandoffState,
 	OpenSessionTargetInput,
@@ -491,6 +493,23 @@ const api = {
 	featureBuilds: {
 		list: () => ipcRenderer.invoke("featureBuilds:list") as Promise<FeatureBuild[]>,
 		getActive: () => ipcRenderer.invoke("featureBuilds:getActive") as Promise<{ pr: number } | null>,
+	},
+	// Saved AO daemons, shared with the CLI's ~/.ao/remotes.json. Everything the
+	// renderer receives back is password-free (see main/remotes-ipc.ts); the
+	// plaintext password only ever travels renderer -> main, on `add`.
+	remotes: {
+		list: () => ipcRenderer.invoke("remotes:list") as Promise<RemoteHostView[]>,
+		add: (input: { label: string; url: string; password: string }) =>
+			ipcRenderer.invoke("remotes:add", input) as Promise<RemoteHealth>,
+		// An edit carries only what changed: an omitted password keeps the saved
+		// one, so a rotated credential is fixed without the renderer ever holding
+		// the old one.
+		update: (url: string, changes: { label?: string; url?: string; password?: string }) =>
+			ipcRenderer.invoke("remotes:update", url, changes) as Promise<RemoteHealth>,
+		remove: (url: string) => ipcRenderer.invoke("remotes:remove", url) as Promise<void>,
+		probe: (url: string) => ipcRenderer.invoke("remotes:probe", url) as Promise<RemoteHealth>,
+		request: (url: string, init: RemoteRequestInit) =>
+			ipcRenderer.invoke("remotes:request", url, init) as Promise<RemoteResponse>,
 	},
 	cloud: {
 		getSession: () => ipcRenderer.invoke("cloud:getSession") as Promise<CloudAccount | null>,

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -17,6 +17,7 @@ import {
 } from "./shared/tray";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { RemoteHostView } from "./main/remotes-ipc";
+import type { ConnectedHostView } from "./main/remote-registry";
 import type { RemoteHealth, RemoteRequestInit, RemoteResponse } from "./main/remote-request";
 import type {
 	EditorHandoffState,
@@ -510,6 +511,9 @@ const api = {
 		probe: (url: string) => ipcRenderer.invoke("remotes:probe", url) as Promise<RemoteHealth>,
 		request: (url: string, init: RemoteRequestInit) =>
 			ipcRenderer.invoke("remotes:request", url, init) as Promise<RemoteResponse>,
+		connect: (url: string) => ipcRenderer.invoke("remotes:connect", url) as Promise<ConnectedHostView>,
+		disconnect: (url: string) => ipcRenderer.invoke("remotes:disconnect", url) as Promise<void>,
+		connected: () => ipcRenderer.invoke("remotes:connected") as Promise<ConnectedHostView[]>,
 	},
 	cloud: {
 		getSession: () => ipcRenderer.invoke("cloud:getSession") as Promise<CloudAccount | null>,

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -162,7 +162,7 @@ beforeEach(async () => {
 		saving: false,
 		saveError: false,
 	});
-	useUiStore.setState({ developerMode: false });
+	useUiStore.setState({ developerMode: false, remoteHosts: false });
 	document.documentElement.lang = "en";
 });
 
@@ -195,6 +195,21 @@ describe("GlobalSettingsForm", () => {
 		expect(window.localStorage.getItem("ao.developerMode")).toBe("true");
 		await user.click(screen.getByLabelText("Updates channel"));
 		expect(await screen.findByRole("menuitem", { name: "Feature Releases" })).toBeInTheDocument();
+	});
+
+	it("offers Remote hosts as a switch right below Developer Mode and persists it", async () => {
+		const user = userEvent.setup();
+		renderForm();
+		const developerMode = await screen.findByRole("switch", { name: "Developer Mode" });
+		const remoteHosts = screen.getByRole("switch", { name: "Remote hosts (experimental)" });
+		expect(remoteHosts).toHaveAttribute("aria-checked", "false");
+		// "Underneath Developer Mode": the next switch in document order.
+		expect(developerMode.compareDocumentPosition(remoteHosts) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(screen.getAllByRole("switch").indexOf(remoteHosts)).toBe(screen.getAllByRole("switch").indexOf(developerMode) + 1);
+
+		await user.click(remoteHosts);
+		expect(window.localStorage.getItem("ao.remoteHosts")).toBe("true");
+		expect(useUiStore.getState().remoteHosts).toBe(true);
 	});
 
 	it("shows the available feature builds after choosing Feature Releases", async () => {

--- a/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -152,6 +152,8 @@ export function GeneralSettingsSection({
 	const soundNotificationsSaveError = useSoundNotificationsStore((state) => state.saveError);
 	const developerMode = useUiStore((state) => state.developerMode);
 	const setDeveloperMode = useUiStore((state) => state.setDeveloperMode);
+	const remoteHosts = useUiStore((state) => state.remoteHosts);
+	const setRemoteHosts = useUiStore((state) => state.setRemoteHosts);
 
 	const themeOptions = [
 		{ value: "light", label: t("settings.theme.light") },
@@ -236,6 +238,13 @@ export function GeneralSettingsSection({
 						aria-label={t("settings.developerMode")}
 						checked={developerMode}
 						onCheckedChange={setDeveloperMode}
+					/>
+				</SettingsRow>
+				<SettingsRow label={t("settings.remoteHosts")}>
+					<Switch
+						aria-label={t("settings.remoteHosts")}
+						checked={remoteHosts}
+						onCheckedChange={setRemoteHosts}
 					/>
 				</SettingsRow>
 				{developerMode && <CloudOfferingRow />}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -637,6 +637,7 @@
 	"settings.close": "Einstellungen schließen",
 	"settings.connectMobile": "Mobile verbinden",
 	"settings.developerMode": "Entwicklermodus",
+	"settings.remoteHosts": "Remote-Hosts (experimentell)",
 	"settings.general": "Allgemein",
 	"settings.appearance": "Erscheinungsbild",
 	"settings.sessions": "Sitzungen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -629,6 +629,7 @@
 	"settings.cloudAgents.valid": "Valid",
 	"settings.connectMobile": "Connect Mobile",
 	"settings.developerMode": "Developer Mode",
+	"settings.remoteHosts": "Remote hosts (experimental)",
 	"settings.general": "General",
 	"settings.appearance": "Appearance",
 	"settings.sessions": "Sessions",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -646,6 +646,7 @@
 	"settings.close": "Cerrar ajustes",
 	"settings.connectMobile": "Conectar móvil",
 	"settings.developerMode": "Modo desarrollador",
+	"settings.remoteHosts": "Hosts remotos (experimental)",
 	"settings.general": "General",
 	"settings.appearance": "Apariencia",
 	"settings.sessions": "Sesiones",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -646,6 +646,7 @@
 	"settings.close": "Fermer les paramètres",
 	"settings.connectMobile": "Connecter le mobile",
 	"settings.developerMode": "Mode développeur",
+	"settings.remoteHosts": "Hôtes distants (expérimental)",
 	"settings.general": "Général",
 	"settings.appearance": "Apparence",
 	"settings.sessions": "Sessions",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -637,6 +637,7 @@
 	"settings.close": "設定を閉じる",
 	"settings.connectMobile": "モバイル接続",
 	"settings.developerMode": "開発者モード",
+	"settings.remoteHosts": "リモートホスト（実験的）",
 	"settings.general": "一般",
 	"settings.appearance": "外観",
 	"settings.sessions": "セッション",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -637,6 +637,7 @@
 	"settings.close": "설정 닫기",
 	"settings.connectMobile": "모바일 연결",
 	"settings.developerMode": "개발자 모드",
+	"settings.remoteHosts": "원격 호스트 (실험적)",
 	"settings.general": "일반",
 	"settings.appearance": "모양",
 	"settings.sessions": "세션",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -646,6 +646,7 @@
 	"settings.close": "Fechar configurações",
 	"settings.connectMobile": "Conectar mobile",
 	"settings.developerMode": "Modo desenvolvedor",
+	"settings.remoteHosts": "Hosts remotos (experimental)",
 	"settings.general": "Geral",
 	"settings.appearance": "Aparência",
 	"settings.sessions": "Sessões",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -619,6 +619,7 @@
 	"settings.close": "关闭设置",
 	"settings.connectMobile": "连接手机",
 	"settings.developerMode": "开发者模式",
+	"settings.remoteHosts": "远程主机（实验性）",
 	"settings.general": "通用",
 	"settings.appearance": "外观",
 	"settings.sessions": "会话",

--- a/frontend/src/renderer/lib/active-host.test.ts
+++ b/frontend/src/renderer/lib/active-host.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { aoBridge } from "./bridge";
+import { setApiBaseUrl } from "./api-client";
+import { initHosts } from "./active-host";
+import { baseUrlFor, forgetHost } from "./host-clients";
+import { useUiStore } from "../stores/ui-store";
+
+const WORKBOX = "http://192.0.2.1:3011";
+const MINI = "http://192.0.2.9:3011";
+
+beforeEach(() => {
+	localStorage.clear();
+	forgetHost(WORKBOX);
+	forgetHost(MINI);
+	setApiBaseUrl(null);
+	vi.restoreAllMocks();
+	useUiStore.setState({ remoteHosts: true });
+});
+
+function savedHosts() {
+	vi.spyOn(aoBridge.remotes, "list").mockResolvedValue([
+		{ label: "workbox", url: WORKBOX },
+		{ label: "mini", url: MINI },
+	]);
+	vi.spyOn(aoBridge.remotes, "connect").mockImplementation(async (url) => ({
+		label: url === WORKBOX ? "workbox" : "mini",
+		url,
+		base: url === WORKBOX ? "http://127.0.0.1:9001/one" : "http://127.0.0.1:9002/two",
+	}));
+}
+
+describe("remoteHosts flag", () => {
+	it("never reads the saved hosts while the flag is off", async () => {
+		useUiStore.setState({ remoteHosts: false });
+		savedHosts();
+
+		await initHosts();
+
+		expect(aoBridge.remotes.list).not.toHaveBeenCalled();
+		expect(aoBridge.remotes.connect).not.toHaveBeenCalled();
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+	});
+
+	it("connects the saved hosts when the flag is turned on", async () => {
+		useUiStore.setState({ remoteHosts: false });
+		savedHosts();
+		await initHosts();
+		expect(baseUrlFor(MINI)).toBeNull();
+
+		useUiStore.getState().setRemoteHosts(true);
+
+		await vi.waitFor(() => expect(baseUrlFor(MINI)).toBe("http://127.0.0.1:9002/two"));
+		expect(baseUrlFor(WORKBOX)).toBe("http://127.0.0.1:9001/one");
+	});
+
+	it("disconnects every remote host when the flag is turned off", async () => {
+		savedHosts();
+		const disconnect = vi.spyOn(aoBridge.remotes, "disconnect").mockResolvedValue(undefined);
+		await initHosts();
+		expect(baseUrlFor(WORKBOX)).not.toBeNull();
+
+		useUiStore.getState().setRemoteHosts(false);
+
+		await vi.waitFor(() => expect(disconnect).toHaveBeenCalledTimes(2));
+		expect(disconnect).toHaveBeenCalledWith(WORKBOX);
+		expect(disconnect).toHaveBeenCalledWith(MINI);
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+		expect(baseUrlFor(MINI)).toBeNull();
+	});
+});
+
+describe("multi-host boot", () => {
+	it("connects every saved host", async () => {
+		savedHosts();
+
+		await initHosts();
+
+		expect(aoBridge.remotes.connect).toHaveBeenCalledTimes(2);
+		expect(baseUrlFor(WORKBOX)).toBe("http://127.0.0.1:9001/one");
+		expect(baseUrlFor(MINI)).toBe("http://127.0.0.1:9002/two");
+	});
+
+	it("keeps connecting other saved hosts when one is unavailable", async () => {
+		vi.spyOn(aoBridge.remotes, "list").mockResolvedValue([
+			{ label: "workbox", url: WORKBOX },
+			{ label: "mini", url: MINI },
+		]);
+		vi.spyOn(aoBridge.remotes, "connect").mockImplementation(async (url) => {
+			if (url === WORKBOX) throw new Error("offline");
+			return { label: "mini", url, base: "http://127.0.0.1:9002/two" };
+		});
+
+		await initHosts();
+
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+		expect(baseUrlFor(MINI)).toBe("http://127.0.0.1:9002/two");
+	});
+
+	it("treats an unreadable saved-host list as no remote hosts", async () => {
+		vi.spyOn(aoBridge.remotes, "list").mockRejectedValue(new Error("chmod 600 required"));
+
+		await expect(initHosts()).resolves.toBeUndefined();
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+		expect(baseUrlFor(MINI)).toBeNull();
+	});
+});

--- a/frontend/src/renderer/lib/active-host.ts
+++ b/frontend/src/renderer/lib/active-host.ts
@@ -1,0 +1,32 @@
+import { useUiStore } from "../stores/ui-store";
+import { aoBridge } from "./bridge";
+import { connectedHosts, connectHost, disconnectHost } from "./host-clients";
+
+/** Connect every saved host without making any one host own the window. */
+async function connectSavedHosts(): Promise<void> {
+	const saved = await aoBridge.remotes.list().catch(() => []);
+	await Promise.allSettled(saved.map(({ url }) => connectHost(url)));
+}
+
+async function disconnectAllHosts(): Promise<void> {
+	await Promise.allSettled(connectedHosts().map((host) => disconnectHost(host)));
+}
+
+let watchingFlag = false;
+
+/**
+ * Boot the remote-host layer, honouring the Remote hosts flag. Off means no
+ * saved host is read, probed or connected — not "connected but hidden" — so a
+ * reviewer can verify the off state from the network side. Flipping the switch
+ * connects or tears down without a restart.
+ */
+export async function initHosts(): Promise<void> {
+	if (!watchingFlag) {
+		watchingFlag = true;
+		useUiStore.subscribe((state, previous) => {
+			if (state.remoteHosts === previous.remoteHosts) return;
+			void (state.remoteHosts ? connectSavedHosts() : disconnectAllHosts());
+		});
+	}
+	if (useUiStore.getState().remoteHosts) await connectSavedHosts();
+}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -223,6 +223,17 @@ export const aoBridge: AoBridge =
 			list: async () => [],
 			getActive: async () => null,
 		},
+		// The daemon-served web build has no Electron bridge and so no access to
+		// ~/.ao/remotes.json. Reporting no hosts leaves the UI showing local only,
+		// which is the truth there.
+		remotes: {
+			list: async () => [],
+			add: async () => "offline" as const,
+			update: async () => "offline" as const,
+			remove: async () => undefined,
+			probe: async () => "offline" as const,
+			request: async () => ({ status: 0, body: null }),
+		},
 		cloud: {
 			getSession: async () => null,
 			signIn: async () => undefined,

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -233,6 +233,11 @@ export const aoBridge: AoBridge =
 			remove: async () => undefined,
 			probe: async () => "offline" as const,
 			request: async () => ({ status: 0, body: null }),
+			connect: async () => {
+				throw new Error("remote hosts need the desktop app");
+			},
+			disconnect: async () => undefined,
+			connected: async () => [],
 		},
 		cloud: {
 			getSession: async () => null,

--- a/frontend/src/renderer/lib/host-clients.test.ts
+++ b/frontend/src/renderer/lib/host-clients.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setApiBaseUrl } from "./api-client";
+import { aoBridge } from "./bridge";
+import { LOCAL_HOST } from "./hosts";
+import {
+	baseUrlFor,
+	clientFor,
+	connectedHosts,
+	connectHost,
+	disconnectHost,
+	forgetHost,
+	hostLabelFor,
+	isHostReady,
+	registerHostBase,
+	subscribeConnectedHosts,
+} from "./host-clients";
+
+const REMOTE = "http://192.0.2.1:3011";
+const OTHER_REMOTE = "http://192.0.2.9:3011";
+
+beforeEach(() => {
+	forgetHost(REMOTE);
+	forgetHost(OTHER_REMOTE);
+	setApiBaseUrl("http://127.0.0.1:3001");
+	vi.restoreAllMocks();
+});
+
+describe("host-clients", () => {
+	it("resolves the local host to the daemon base", () => {
+		expect(baseUrlFor(LOCAL_HOST)).toBe("http://127.0.0.1:3001");
+		expect(isHostReady(LOCAL_HOST)).toBe(true);
+	});
+
+	it("reports an unregistered remote as not ready rather than throwing", () => {
+		expect(baseUrlFor(REMOTE)).toBeNull();
+		expect(isHostReady(REMOTE)).toBe(false);
+	});
+
+	it("routes a remote request through that host's proxy base", async () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response('{"projects":[]}', {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		await clientFor(REMOTE).GET("/api/v1/projects");
+		expect((fetchSpy.mock.calls[0][0] as Request).url).toBe(
+			"http://127.0.0.1:9999/tok/api/v1/projects",
+		);
+	});
+
+	it("routes a local request to the local daemon, not a proxy", async () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response('{"projects":[]}', {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		await clientFor(LOCAL_HOST).GET("/api/v1/projects");
+		expect((fetchSpy.mock.calls[0][0] as Request).url).toBe(
+			"http://127.0.0.1:3001/api/v1/projects",
+		);
+	});
+
+	it("follows the local base when the daemon moves port", async () => {
+		clientFor(LOCAL_HOST);
+		setApiBaseUrl("http://127.0.0.1:3037");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response('{"projects":[]}', {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		await clientFor(LOCAL_HOST).GET("/api/v1/projects");
+
+		expect((fetchSpy.mock.calls[0][0] as Request).url).toBe(
+			"http://127.0.0.1:3037/api/v1/projects",
+		);
+	});
+
+	it("forgetting a host makes it not ready again", () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		expect(isHostReady(REMOTE)).toBe(true);
+		forgetHost(REMOTE);
+		expect(isHostReady(REMOTE)).toBe(false);
+	});
+
+	it("binds a connected host to the proxy base returned by main", async () => {
+		vi.spyOn(aoBridge.remotes, "connect").mockResolvedValue({
+			label: "workbox",
+			url: REMOTE,
+			base: "http://127.0.0.1:9999/tok",
+		});
+
+		await connectHost(REMOTE);
+
+		expect(baseUrlFor(REMOTE)).toBe("http://127.0.0.1:9999/tok");
+		expect(hostLabelFor(REMOTE)).toBe("workbox");
+	});
+
+	it("publishes connected-host changes for a mounted workspace query", () => {
+		const changed = vi.fn();
+		const unsubscribe = subscribeConnectedHosts(changed);
+
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok", "workbox");
+		expect(changed).toHaveBeenCalledOnce();
+		expect(connectedHosts()).toEqual([REMOTE]);
+
+		forgetHost(REMOTE);
+		expect(changed).toHaveBeenCalledTimes(2);
+		unsubscribe();
+	});
+
+	it("forgets a host before waiting for its proxy to close", async () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		let finishDisconnect!: () => void;
+		const disconnect = vi
+			.spyOn(aoBridge.remotes, "disconnect")
+			.mockReturnValue(
+				new Promise<void>((resolve) => {
+					finishDisconnect = resolve;
+				}),
+			);
+
+		const pending = disconnectHost(REMOTE);
+
+		expect(isHostReady(REMOTE)).toBe(false);
+		expect(disconnect).toHaveBeenCalledWith(REMOTE);
+		finishDisconnect();
+		await pending;
+	});
+});

--- a/frontend/src/renderer/lib/host-clients.ts
+++ b/frontend/src/renderer/lib/host-clients.ts
@@ -1,0 +1,81 @@
+import createClient from "openapi-fetch";
+import type { paths } from "../../api/schema";
+import { getApiBaseUrl, hasTrustedApiBaseUrl } from "./api-client";
+import { aoBridge } from "./bridge";
+import { isLocal, type HostId } from "./hosts";
+
+// One client per host. Local reads the live daemon base (which still moves when
+// the daemon restarts on a new port); a remote reads the loopback proxy base its
+// main-process proxy is listening on.
+const remoteBases = new Map<HostId, string>();
+const remoteLabels = new Map<HostId, string>();
+const clients = new Map<HostId, ReturnType<typeof createClient<paths>>>();
+const listeners = new Set<() => void>();
+let connectedSnapshot: HostId[] = [];
+
+function publishConnectedHosts(): void {
+	connectedSnapshot = [...remoteBases.keys()];
+	for (const listener of listeners) listener();
+}
+
+export function registerHostBase(host: HostId, base: string, label = host): void {
+	remoteLabels.set(host, label);
+	if (remoteBases.get(host) === base) return;
+	remoteBases.set(host, base);
+	// A changed base invalidates the cached client bound to the old one.
+	clients.delete(host);
+	publishConnectedHosts();
+}
+
+export function forgetHost(host: HostId): void {
+	const removed = remoteBases.delete(host);
+	remoteLabels.delete(host);
+	clients.delete(host);
+	if (removed) publishConnectedHosts();
+}
+
+export function connectedHosts(): HostId[] {
+	return connectedSnapshot;
+}
+
+export function subscribeConnectedHosts(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function hostLabelFor(host: HostId): string {
+	return remoteLabels.get(host) ?? host;
+}
+
+export function baseUrlFor(host: HostId): string | null {
+	if (isLocal(host)) return hasTrustedApiBaseUrl() ? getApiBaseUrl() : null;
+	return remoteBases.get(host) ?? null;
+}
+
+export function isHostReady(host: HostId): boolean {
+	return baseUrlFor(host) !== null;
+}
+
+export function clientFor(host: HostId) {
+	const base = baseUrlFor(host);
+	if (base === null) throw new Error(`host ${host} is not connected`);
+	// The local client is not cached: its base follows the daemon across restarts
+	// and a stale cached client would keep talking to a dead port.
+	if (isLocal(host)) return createClient<paths>({ baseUrl: base });
+	const cached = clients.get(host);
+	if (cached) return cached;
+	const client = createClient<paths>({ baseUrl: base });
+	clients.set(host, client);
+	return client;
+}
+
+/** Start (or reuse) a proxy for a saved host and bind a client to its base. */
+export async function connectHost(url: HostId): Promise<void> {
+	const view = await aoBridge.remotes.connect(url);
+	registerHostBase(view.url, view.base, view.label);
+}
+
+export async function disconnectHost(url: HostId): Promise<void> {
+	forgetHost(url);
+	await aoBridge.remotes.disconnect(url);
+}

--- a/frontend/src/renderer/lib/hosts.test.ts
+++ b/frontend/src/renderer/lib/hosts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isLocal, LOCAL_HOST, parseRefKey, refKey, type Ref } from "./hosts";
+
+describe("refKey", () => {
+	it("round-trips a local ref", () => {
+		const ref: Ref = { host: LOCAL_HOST, id: "skyvern-cloud" };
+		expect(refKey(ref)).toBe("local:skyvern-cloud");
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("round-trips a remote ref whose host url contains colons and slashes", () => {
+		const ref: Ref = { host: "http://192.0.2.1:3011", id: "skyvern-cloud" };
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("round-trips an id that itself contains a colon", () => {
+		// Ids come from another machine; nothing guarantees they are colon-free.
+		const ref: Ref = { host: "http://192.0.2.1:3011", id: "weird:id" };
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("distinguishes the same id on two hosts", () => {
+		expect(refKey({ host: LOCAL_HOST, id: "skyvern-cloud" })).not.toBe(
+			refKey({ host: "http://192.0.2.1:3011", id: "skyvern-cloud" }),
+		);
+	});
+});
+
+describe("isLocal", () => {
+	it("is true only for the local host", () => {
+		expect(isLocal(LOCAL_HOST)).toBe(true);
+		expect(isLocal("http://192.0.2.1:3011")).toBe(false);
+	});
+});

--- a/frontend/src/renderer/lib/hosts.ts
+++ b/frontend/src/renderer/lib/hosts.ts
@@ -1,0 +1,30 @@
+// Host identity. Local is a host like any other — the one whose requests skip
+// the proxy — so no code path has to special-case "is this remote?".
+export type HostId = string;
+
+export const LOCAL_HOST: HostId = "local";
+
+/** Anything addressable across hosts. A bare id is never enough to act on. */
+export type Ref = {
+	host: HostId;
+	id: string;
+};
+
+export function isLocal(host: HostId): boolean {
+	return host === LOCAL_HOST;
+}
+
+// A host id is a URL and an id may contain anything, so the key encodes both
+// halves rather than relying on a separator being absent from either.
+export function refKey(ref: Ref): string {
+	return `${encodeURIComponent(ref.host)}:${encodeURIComponent(ref.id)}`;
+}
+
+export function parseRefKey(key: string): Ref {
+	const separator = key.indexOf(":");
+	if (separator === -1) throw new Error(`malformed ref key: ${key}`);
+	return {
+		host: decodeURIComponent(key.slice(0, separator)),
+		id: decodeURIComponent(key.slice(separator + 1)),
+	};
+}

--- a/frontend/src/renderer/main.tsx
+++ b/frontend/src/renderer/main.tsx
@@ -17,6 +17,7 @@ import { startUpdateTelemetry } from "./lib/update-telemetry";
 import { appI18n } from "./i18n";
 import { useLocaleStore } from "./stores/locale-store";
 import { useSoundNotificationsStore } from "./stores/sound-notifications-store";
+import { initHosts } from "./lib/active-host";
 
 const router = createAppRouter(queryClient);
 
@@ -91,6 +92,11 @@ async function renderApp(): Promise<void> {
 			</I18nextProvider>
 		</React.StrictMode>,
 	);
+	// Saved hosts are additive. A bad credential file or sleeping machine must
+	// never block local first paint; the reactive host registry adds each proxy
+	// to the workspace fan-out as it connects. Inert while the Remote hosts
+	// flag is off.
+	void initHosts();
 }
 
 void renderApp();

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -1,16 +1,23 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sidebarIsCompact, sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "./ui-store";
 
-describe("sidebar workspace pressure", () => {
-	beforeEach(() => {
-		window.localStorage.clear();
-		useUiStore.setState({
-			isSidebarOpen: true,
-			isSidebarAutoCollapsed: false,
-			sidebarAutoCollapseOverride: false,
-			sidebarWorkspaceDemandPx: null,
-		});
+beforeEach(() => {
+	window.localStorage.clear();
+	vi.resetModules();
+	useUiStore.setState({
+		isSidebarOpen: true,
+		isSidebarAutoCollapsed: false,
+		sidebarAutoCollapseOverride: false,
+		sidebarWorkspaceDemandPx: null,
 	});
+});
+
+// A fresh module sees exactly what a booting renderer sees: only storage.
+async function bootStore() {
+	return (await import("./ui-store")).useUiStore;
+}
+
+describe("sidebar workspace pressure", () => {
 
 	it("temporarily compacts navigation without changing the saved preference", () => {
 		useUiStore.getState().setSidebarAutoCollapsed(true);
@@ -61,5 +68,24 @@ describe("sidebar workspace pressure", () => {
 		expect(state.isSidebarOpen).toBe(true);
 		expect(state.sidebarAutoCollapseOverride).toBe(false);
 		expect(sidebarIsVisible(state)).toBe(true);
+	});
+});
+
+
+describe("remoteHosts flag", () => {
+	it("is off until the user turns it on", async () => {
+		expect((await bootStore()).getState().remoteHosts).toBe(false);
+	});
+
+	it("persists the switch so the choice survives a restart", () => {
+		useUiStore.getState().setRemoteHosts(true);
+		expect(useUiStore.getState().remoteHosts).toBe(true);
+		expect(window.localStorage.getItem("ao.remoteHosts")).toBe("true");
+		useUiStore.getState().setRemoteHosts(false);
+	});
+
+	it("reads a stored choice back at startup", async () => {
+		window.localStorage.setItem("ao.remoteHosts", "true");
+		expect((await bootStore()).getState().remoteHosts).toBe(true);
 	});
 });

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -68,6 +68,8 @@ export type UiState = {
 	themeStyle: ThemeStyle;
 	/** When true, developer-only release controls are available. Default off. */
 	developerMode: boolean;
+	/** Experimental: connect to AO daemons on other machines. Default off; off means no remote host is ever contacted. */
+	remoteHosts: boolean;
 	restartingProjectIds: ReadonlySet<string>;
 	orchestratorReplacementErrors: Record<string, OrchestratorReplacementFailure>;
 	orchestratorStartupErrors: Record<string, string>;
@@ -105,6 +107,7 @@ export type UiState = {
 	setThemePreference: (theme: ThemePreference) => void;
 	setThemeStyle: (style: ThemeStyle) => void;
 	setDeveloperMode: (enabled: boolean) => void;
+	setRemoteHosts: (enabled: boolean) => void;
 	openGlobalSettings: (section?: GlobalSettingsSection) => void;
 	openProjectSettings: (projectId: string) => void;
 	closeSettings: () => void;
@@ -149,6 +152,7 @@ export type OrchestratorReplacementFailure = {
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
+const remoteHostsStorageKey = "ao.remoteHosts";
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
 	return window.localStorage;
@@ -160,6 +164,10 @@ function initialSidebarOpen() {
 
 function initialDeveloperMode() {
 	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
+}
+
+function initialRemoteHosts() {
+	return getLocalStorage()?.getItem(remoteHostsStorageKey) === "true";
 }
 
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
@@ -201,6 +209,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	resolvedTheme: resolveTheme(initialThemePreference),
 	themeStyle: initialThemeStyle,
 	developerMode: initialDeveloperMode(),
+	remoteHosts: initialRemoteHosts(),
 	restartingProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
 	orchestratorStartupErrors: {},
@@ -231,6 +240,10 @@ export const useUiStore = create<UiState>((set, get) => ({
 	setDeveloperMode: (developerMode) => {
 		getLocalStorage()?.setItem(developerModeStorageKey, String(developerMode));
 		set({ developerMode });
+	},
+	setRemoteHosts: (remoteHosts) => {
+		getLocalStorage()?.setItem(remoteHostsStorageKey, String(remoteHosts));
+		set({ remoteHosts });
 	},
 	openGlobalSettings: (section) => set({ settingsModal: { scope: "global", section } }),
 	openProjectSettings: (projectId) => set({ settingsModal: { scope: "project", projectId } }),

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -310,6 +310,14 @@ if (typeof window !== "undefined") {
 			list: async () => [],
 			getActive: async () => null,
 		},
+		remotes: {
+			list: async () => [],
+			add: async () => "offline" as const,
+			update: async () => "offline" as const,
+			remove: async () => undefined,
+			probe: async () => "offline" as const,
+			request: async () => ({ status: 0, body: null }),
+		},
 		cloud: {
 			getSession: async () => null,
 			signIn: async () => undefined,

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -317,6 +317,9 @@ if (typeof window !== "undefined") {
 			remove: async () => undefined,
 			probe: async () => "offline" as const,
 			request: async () => ({ status: 0, body: null }),
+			connect: async () => ({ label: "", url: "", base: "" }),
+			disconnect: async () => undefined,
+			connected: async () => [],
 		},
 		cloud: {
 			getSession: async () => null,


### PR DESCRIPTION
## Ticket

No upstream issue. [RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md). Stacked on #4366, #4365, #4368.

## Problem

The flag, the host primitives, and the saved-host store all exist, but nothing in the renderer boots a connection to a saved host or knows how to address one once connected — there is no per-host API client and no point in the app's lifecycle where a saved host actually gets opened.

## Solution

`clientFor(host)` binds an `openapi-fetch` client to each connected host's proxy base, and local keeps reading the live daemon base. `initHosts()` runs after first paint and connects every saved host, but only while the Remote hosts flag is on; off means the saved-host file is never read and no proxy starts, and turning the flag off tears every remote proxy down without a restart.

## How Has This Been Tested?

`cd frontend && npm run typecheck && npx vitest run src/renderer/lib/host-clients.test.ts src/renderer/lib/active-host.test.ts` on the current `main` (`c9a0adb2`): green, 15 tests, including `initHosts()` never calling `remotes.list` with the flag off. No Go or OpenAPI surface is touched.

## Artifacts (if appropriate):

No renderable surface: a client-binding module and boot hook, no UI change. Reviewer-verifiable: `connectedHosts()` is `[]` with the flag off, so every later fan-out is a loop of one.
