### PR TITLE
feat(hosts): one terminal mux per host

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -248,6 +248,14 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					list: async () => [],
 					getActive: async () => null,
 				},
+				remotes: {
+					list: async () => [],
+					add: async () => "offline" as const,
+					update: async () => "offline" as const,
+					remove: async () => undefined,
+					probe: async () => "offline" as const,
+					request: async () => ({ status: 0, body: null }),
+				},
 				cloud: {
 					getSession: async () => null,
 					signIn: async () => undefined,
@@ -746,6 +754,14 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				featureBuilds: {
 					list: async () => [],
 					getActive: async () => null,
+				},
+				remotes: {
+					list: async () => [],
+					add: async () => "offline" as const,
+					update: async () => "offline" as const,
+					remove: async () => undefined,
+					probe: async () => "offline" as const,
+					request: async () => ({ status: 0, body: null }),
 				},
 				cloud: {
 					getSession: async () => null,

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -255,6 +255,9 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					remove: async () => undefined,
 					probe: async () => "offline" as const,
 					request: async () => ({ status: 0, body: null }),
+					connect: async () => ({ label: "", url: "", base: "" }),
+					disconnect: async () => undefined,
+					connected: async () => [],
 				},
 				cloud: {
 					getSession: async () => null,
@@ -762,6 +765,9 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					remove: async () => undefined,
 					probe: async () => "offline" as const,
 					request: async () => ({ status: 0, body: null }),
+					connect: async () => ({ label: "", url: "", base: "" }),
+					disconnect: async () => undefined,
+					connected: async () => [],
 				},
 				cloud: {
 					getSession: async () => null,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -127,6 +127,7 @@ import { dockBounceType, shouldReplaceBounce, shouldSignalAttention, shouldToast
 import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./main/menu";
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 import { parseOpenFolderPathArg } from "./main/open-folder-arg";
+import { registerRemotesIpc, remotesFilePath } from "./main/remotes-main";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -1928,6 +1929,13 @@ async function chooseDirectory(title: string): Promise<string | null> {
 	if (result.canceled) return null;
 	return result.filePaths[0] ?? null;
 }
+
+registerRemotesIpc(ipcMain, {
+	file: remotesFilePath(),
+	// No host is ever connected yet; the proxy registry that owns live
+	// connections lands in the next change and replaces this.
+	disconnect: async () => undefined,
+});
 
 ipcMain.handle("app:chooseDirectory", async (_event, title?: string) => {
 	return chooseDirectory(typeof title === "string" && title.trim() ? title : "Choose a git repository");

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -128,6 +128,8 @@ import { buildMacAppMenuTemplate, buildWindowsAppMenuTemplate } from "./main/men
 import { ancestorRepositorySetupWarning, scanImportFolder } from "./main/import-folder-scan";
 import { parseOpenFolderPathArg } from "./main/open-folder-arg";
 import { registerRemotesIpc, remotesFilePath } from "./main/remotes-main";
+import { RemoteRegistry } from "./main/remote-registry";
+import { startRemoteProxy } from "./main/remote-proxy";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -1930,12 +1932,8 @@ async function chooseDirectory(title: string): Promise<string | null> {
 	return result.filePaths[0] ?? null;
 }
 
-registerRemotesIpc(ipcMain, {
-	file: remotesFilePath(),
-	// No host is ever connected yet; the proxy registry that owns live
-	// connections lands in the next change and replaces this.
-	disconnect: async () => undefined,
-});
+const remoteRegistry = new RemoteRegistry(startRemoteProxy);
+registerRemotesIpc(ipcMain, { file: remotesFilePath(), registry: remoteRegistry });
 
 ipcMain.handle("app:chooseDirectory", async (_event, title?: string) => {
 	return chooseDirectory(typeof title === "string" && title.trim() ? title : "Choose a git repository");
@@ -2427,11 +2425,13 @@ app.on("before-quit", (event) => {
 	if (!browserCleanupComplete) {
 		event.preventDefault();
 		if (!browserQuitCleanupPromise) {
-			browserQuitCleanupPromise = disposeAllBrowserViewHosts().finally(() => {
-				browserCleanupComplete = true;
-				browserQuitCleanupPromise = null;
-				app.quit();
-			});
+			browserQuitCleanupPromise = Promise.all([disposeAllBrowserViewHosts(), remoteRegistry.closeAll()])
+				.then(() => undefined)
+				.finally(() => {
+					browserCleanupComplete = true;
+					browserQuitCleanupPromise = null;
+					app.quit();
+				});
 		}
 		return;
 	}

--- a/frontend/src/main/remote-proxy.test.ts
+++ b/frontend/src/main/remote-proxy.test.ts
@@ -293,6 +293,61 @@ describe("startRemoteProxy streams", () => {
 		expect(result).toBe("closed");
 	});
 
+	// Regression for the connection-status hang: the previous test's upstream
+	// writes its first chunk synchronously, so headers and that chunk reach the
+	// client together even without an explicit flush — it never exercised the
+	// gap. A real SSE upstream (GET /api/v1/events) can hold its first byte
+	// indefinitely; a client's EventSource must still see the response headers
+	// right away; otherwise it reports CONNECTING forever, which is exactly what
+	// "not receiving live updates" looked like before this was found.
+	it("flushes response headers before the first SSE byte arrives", async () => {
+		upstream = createServer((_req, res) => {
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			// The real daemon flushes its own headers immediately (confirmed by a
+			// direct curl against it) — this upstream must too, or the test would
+			// measure the fake upstream's header delay instead of the proxy's.
+			res.flushHeaders();
+			// The body is what's withheld for 500ms, like a daemon with nothing to
+			// say yet.
+			setTimeout(() => {
+				res.write("data: first\n\n");
+				res.end();
+			}, 500);
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const started = Date.now();
+		const head = await new Promise<string>((resolve) => {
+			const socket = netConnect(Number(proxyUrl.port), "127.0.0.1", () => {
+				socket.write(`GET ${proxyUrl.pathname}/api/v1/events HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n`);
+			});
+			socket.on("error", () => undefined);
+			let buf = "";
+			socket.on("data", (chunk: Buffer) => {
+				buf += chunk.toString();
+				if (buf.includes("\r\n\r\n")) {
+					socket.destroy();
+					resolve(buf);
+				}
+			});
+		});
+		const headersArrivedAfterMs = Date.now() - started;
+
+		expect(head).toContain("200");
+		expect(head.toLowerCase()).toContain("content-type: text/event-stream");
+		// The upstream withholds its first byte for 500ms; seeing the header
+		// block well before that proves the proxy flushes headers on their own
+		// rather than only when they can piggyback on the first body write.
+		expect(headersArrivedAfterMs).toBeLessThan(300);
+	});
+
 	it("delivers SSE chunks as they are written, not on close", async () => {
 		upstream = createServer((_req, res) => {
 			res.writeHead(200, { "content-type": "text/event-stream" });

--- a/frontend/src/main/remote-proxy.test.ts
+++ b/frontend/src/main/remote-proxy.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { connect as netConnect, type AddressInfo } from "node:net";
+import { startRemoteProxy, type ActiveProxy } from "./remote-proxy";
+
+type Seen = {
+	url: string;
+	auth: string | undefined;
+	origin: string | undefined;
+	body: string;
+};
+
+let upstream: Server | undefined;
+let proxy: ActiveProxy | undefined;
+// Lifecycle logging is the point of these spies, not a side effect to silence:
+// every assertion below reads them, and swallowing the output keeps the suite
+// readable while the proxy narrates itself.
+let logged: string[];
+let warned: string[];
+
+beforeEach(() => {
+	logged = [];
+	warned = [];
+	vi.spyOn(console, "log").mockImplementation((message: unknown) => {
+		logged.push(String(message));
+	});
+	vi.spyOn(console, "warn").mockImplementation((message: unknown) => {
+		warned.push(String(message));
+	});
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await proxy?.close();
+	await new Promise<void>((resolve) => (upstream ? upstream.close(() => resolve()) : resolve()));
+	upstream = undefined;
+	proxy = undefined;
+});
+
+async function startUpstream(
+	handler: (req: IncomingMessage, seen: Seen[]) => { status: number; body: string },
+): Promise<{ port: number; seen: Seen[] }> {
+	const seen: Seen[] = [];
+	upstream = createServer((req, res) => {
+		let body = "";
+		req.on("data", (chunk) => (body += chunk));
+		req.on("end", () => {
+			seen.push({
+				url: req.url ?? "",
+				auth: req.headers.authorization,
+				origin: req.headers.origin,
+				body,
+			});
+			const out = handler(req, seen);
+			res.writeHead(out.status, { "content-type": "application/json" });
+			res.end(out.body);
+		});
+	});
+	await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+	return { port: (upstream.address() as AddressInfo).port, seen };
+}
+
+describe("startRemoteProxy", () => {
+	it("forwards with the token stripped and the credential injected", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: '{"ok":true}',
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`, {
+			method: "POST",
+			headers: { "content-type": "application/json", origin: "app://renderer" },
+			body: '{"path":"/srv/repo"}',
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(seen).toHaveLength(1);
+		expect(seen[0].url).toBe("/api/v1/projects"); // token gone
+		expect(seen[0].auth).toBe("Bearer pw");
+		expect(seen[0].origin).toBeUndefined(); // app://renderer never reaches the daemon
+		expect(seen[0].body).toBe('{"path":"/srv/repo"}');
+	});
+
+	// The add-host dialog accepts https://, so this is what a Tailscale Serve or
+	// reverse-proxy address does today: the upstream is a TLS endpoint and the
+	// proxy must not put the connection password on the wire in the clear.
+	it("never sends the credential in the clear to an https host", async () => {
+		const { port, seen } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `https://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		// A cleartext listener cannot complete a TLS handshake, so the honest
+		// outcome is a failed request — never a plaintext one that succeeds.
+		const res = await fetch(`${proxy.base}/api/v1/projects`);
+		expect(res.status).toBe(502);
+		expect(seen).toHaveLength(0);
+	});
+
+	// A daemon can live behind a reverse proxy at a path. The renderer's base is
+	// the loopback proxy's own root, so the upstream prefix is restored here or
+	// every credentialled request lands on whatever else that vhost serves.
+	it("restores the host's path prefix upstream", async () => {
+		const { port, seen } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}/ao`,
+			password: "pw",
+		});
+
+		await fetch(`${proxy.base}/api/v1/projects`);
+		expect(seen[0].url).toBe("/ao/api/v1/projects");
+	});
+
+	it("refuses a request without the token and sends nothing upstream", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: "{}",
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const bare = new URL(proxy.base);
+		const res = await fetch(`${bare.origin}/api/v1/projects`);
+		expect(res.status).toBe(404);
+		expect(seen).toHaveLength(0);
+	});
+
+	it("refuses a near-miss token prefix", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: "{}",
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		// A path that merely starts with the token's characters is not the token:
+		// /<token>x/... must not authorize, or the token stops being a boundary.
+		const bare = new URL(proxy.base);
+		const res = await fetch(`${bare.origin}${bare.pathname}x/api/v1/projects`);
+		expect(res.status).toBe(404);
+		expect(seen).toHaveLength(0);
+	});
+
+	it("answers CORS preflight itself for the renderer origin", async () => {
+		const { port, seen } = await startUpstream(() => ({
+			status: 200,
+			body: "{}",
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`, {
+			method: "OPTIONS",
+			headers: {
+				origin: "app://renderer",
+				"access-control-request-method": "POST",
+				"access-control-request-headers": "content-type",
+			},
+		});
+		expect(res.status).toBe(204);
+		expect(res.headers.get("access-control-allow-origin")).toBe("app://renderer");
+		expect(res.headers.get("access-control-allow-headers")).toMatch(/content-type/i);
+		expect(seen).toHaveLength(0); // preflight never leaves the machine
+	});
+
+	it("adds the renderer origin to real responses so cross-origin fetch succeeds", async () => {
+		const { port } = await startUpstream(() => ({
+			status: 400,
+			body: '{"error":"bad"}',
+		}));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`, {
+			headers: { origin: "app://renderer" },
+		});
+		expect(res.status).toBe(400); // errors pass through untouched…
+		expect(res.headers.get("access-control-allow-origin")).toBe("app://renderer"); // …but stay readable
+	});
+
+	it("returns 502 when the upstream is unreachable", async () => {
+		proxy = await startRemoteProxy({
+			label: "dead",
+			url: "http://127.0.0.1:1",
+			password: "pw",
+		});
+		const res = await fetch(`${proxy.base}/api/v1/projects`);
+		expect(res.status).toBe(502);
+	});
+
+	// "The app can't reach my host" had no answer anywhere before this, and the
+	// only thing that could make these lines unshippable is a secret in one.
+	it("logs its own lifecycle without the token or the password", async () => {
+		const { port } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({ label: "workbox", url: `http://127.0.0.1:${port}`, password: "hunter2secret" });
+		const token = new URL(proxy.base).pathname.slice(1);
+
+		expect(logged.some((line) => line.includes("[remote-proxy] started on 127.0.0.1:"))).toBe(true);
+		await proxy.close();
+		proxy = undefined;
+		expect(logged.some((line) => line.includes("[remote-proxy] stopped on 127.0.0.1:"))).toBe(true);
+
+		const everything = [...logged, ...warned].join("\n");
+		expect(everything).not.toContain("hunter2secret");
+		expect(everything).not.toContain(token);
+	});
+
+	it("warns which upstream failed when it answers 502, naming no secret", async () => {
+		const { port } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		await new Promise<void>((resolve) => (upstream ? upstream.close(() => resolve()) : resolve()));
+		upstream = undefined;
+		proxy = await startRemoteProxy({ label: "workbox", url: `http://127.0.0.1:${port}`, password: "hunter2secret" });
+		const token = new URL(proxy.base).pathname.slice(1);
+
+		const res = await fetch(`${proxy.base}/api/v1/projects`);
+		expect(res.status).toBe(502);
+		const warning = warned.find((line) => line.includes("answering 502"));
+		expect(warning).toContain(`127.0.0.1:${port}`);
+		// The post-strip path, which is the useful half; req.url starts with the token.
+		expect(warning).toContain("/api/v1/projects");
+		expect(warning).not.toContain("hunter2secret");
+		expect(warning).not.toContain(token);
+	});
+
+	it("listens on loopback only", async () => {
+		const { port } = await startUpstream(() => ({ status: 200, body: "{}" }));
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+		expect(new URL(proxy.base).hostname).toBe("127.0.0.1");
+	});
+});
+
+describe("startRemoteProxy streams", () => {
+	it("closes while an upgraded socket is still open", async () => {
+		upstream = createServer();
+		const upgraded = new Promise<void>((resolve) => {
+			upstream?.on("upgrade", (_req, socket) => {
+				socket.on("error", () => undefined);
+				socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+				socket.on("end", () => socket.destroy());
+				resolve();
+			});
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const socket = netConnect(Number(proxyUrl.port), "127.0.0.1");
+		socket.on("error", () => undefined);
+		socket.write(
+			`GET ${proxyUrl.pathname}/mux HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+		);
+		await upgraded;
+
+		const closing = proxy.close();
+		const result = await Promise.race([
+			closing.then(() => "closed"),
+			new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
+		]);
+		socket.destroy();
+		await closing;
+		proxy = undefined;
+
+		expect(result).toBe("closed");
+	});
+
+	it("delivers SSE chunks as they are written, not on close", async () => {
+		upstream = createServer((_req, res) => {
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			res.write("data: first\n\n");
+			setTimeout(() => {
+				res.write("data: second\n\n");
+				res.end();
+			}, 500);
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const res = await fetch(`${proxy.base}/api/v1/events`);
+		const reader = res.body!.getReader();
+		const started = Date.now();
+		const first = new TextDecoder().decode((await reader.read()).value);
+		const firstArrivedAfterMs = Date.now() - started;
+
+		expect(first).toContain("data: first");
+		// The second chunk is written 500ms later; receiving the first well before
+		// that proves streaming rather than buffer-until-close.
+		expect(firstArrivedAfterMs).toBeLessThan(300);
+		let rest = "";
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			rest += new TextDecoder().decode(value);
+		}
+		expect(rest).toContain("data: second");
+	});
+
+	it("tunnels a WebSocket upgrade with the credential injected", async () => {
+		const sawAuth: Array<string | undefined> = [];
+		upstream = createServer();
+		upstream.on("upgrade", (req, socket) => {
+			sawAuth.push(req.headers.authorization);
+			socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+			socket.on("data", (d) => socket.write(d)); // echo frames back verbatim
+			// Upgraded sockets are half-open by default and would hold close() open.
+			socket.on("end", () => socket.destroy());
+		});
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const received: Buffer[] = [];
+		const socket = netConnect(Number(proxyUrl.port), "127.0.0.1");
+		await new Promise<void>((resolve) => socket.on("connect", () => resolve()));
+		socket.on("data", (d) => received.push(d));
+		socket.write(
+			`GET ${proxyUrl.pathname}/mux HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		socket.write("payload-bytes");
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		socket.destroy();
+
+		const all = Buffer.concat(received).toString();
+		expect(all).toContain("101 Switching Protocols");
+		expect(all).toContain("payload-bytes"); // echoed through both pipes
+		expect(sawAuth).toEqual(["Bearer pw"]);
+	});
+
+	it("destroys an upgrade that carries no token", async () => {
+		const sawUpgrade: string[] = [];
+		upstream = createServer();
+		upstream.on("upgrade", (upgraded) => sawUpgrade.push(upgraded.url ?? ""));
+		await new Promise<void>((resolve) => upstream?.listen(0, "127.0.0.1", resolve));
+		const port = (upstream.address() as AddressInfo).port;
+		proxy = await startRemoteProxy({
+			label: "workbox",
+			url: `http://127.0.0.1:${port}`,
+			password: "pw",
+		});
+
+		const proxyUrl = new URL(proxy.base);
+		const socket = netConnect(Number(proxyUrl.port), "127.0.0.1");
+		await new Promise<void>((resolve) => socket.on("connect", () => resolve()));
+		const closed = new Promise<void>((resolve) => socket.on("close", () => resolve()));
+		socket.on("error", () => undefined);
+		socket.write(
+			"GET /mux HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGVzdA==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		);
+		await closed;
+		expect(sawUpgrade).toEqual([]);
+	});
+});

--- a/frontend/src/main/remote-proxy.ts
+++ b/frontend/src/main/remote-proxy.ts
@@ -1,0 +1,214 @@
+import { createServer, request as httpRequest, type Server } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { connect as netConnect, type AddressInfo, type Socket } from "node:net";
+import { connect as tlsConnect } from "node:tls";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { RemoteEntry } from "./remotes-store";
+
+// Loopback proxy fronting one remote AO daemon. It exists because the renderer
+// cannot authenticate to a remote daemon itself: EventSource and WebSocket
+// cannot set an Authorization header, and app://renderer has no CORS standing
+// there. The proxy holds the credential in main-process memory, injects it on
+// every forwarded request, and answers CORS for the renderer origin locally.
+//
+// Loopback is ambient authority everywhere in AO, but this socket fronts a
+// DIFFERENT machine — so every request must carry a 128-bit token in the URL
+// path (the one place EventSource and WebSocket can both put it). The token is
+// stripped before forwarding: the remote daemon and its logs never see it.
+export type ActiveProxy = {
+	base: string;
+	url: string;
+	close: () => Promise<void>;
+};
+
+const RENDERER_ORIGIN = "app://renderer";
+// Hop-by-hop or wrong-machine headers that must not transit the proxy.
+const STRIP_REQUEST_HEADERS = [
+	"host",
+	"origin",
+	"connection",
+	"keep-alive",
+	"transfer-encoding",
+	"upgrade",
+	"proxy-authorization",
+];
+
+const CORS_HEADERS: Record<string, string> = {
+	"access-control-allow-origin": RENDERER_ORIGIN,
+	"access-control-allow-methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+	vary: "origin",
+};
+
+// Nothing in this file may log a secret. Not the connection password, not the
+// proxy token, and not `req.url` (its first segment IS the token) — only the
+// post-strip path, and the upstream address, which is a machine on the user's
+// own network named in their own console. That is the whole point: "the app
+// can't reach my host" had no answer anywhere before this.
+function log(message: string): void {
+	console.log(`[remote-proxy] ${message}`);
+}
+
+function warn(message: string): void {
+	console.warn(`[remote-proxy] ${message}`);
+}
+
+function equalsToken(candidate: string, token: string): boolean {
+	// Constant-time: the token is the only thing standing between a local
+	// process and another machine's daemon, so don't leak it a byte at a time.
+	const a = Buffer.from(candidate);
+	const b = Buffer.from(token);
+	return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function startRemoteProxy(entry: RemoteEntry): Promise<ActiveProxy> {
+	const token = randomBytes(16).toString("hex");
+	const upstream = new URL(entry.url);
+	const secure = upstream.protocol === "https:";
+	const upstreamPort = Number(upstream.port || (secure ? 443 : 80));
+	// An https host must be spoken to over TLS. Forwarding it as cleartext puts
+	// the connection password on the wire in the clear — and the address bar
+	// already accepts https:// (AddRemoteHostDialog), so this is reachable by
+	// typing a Tailscale Serve or reverse-proxy URL.
+	const upstreamRequest = secure ? httpsRequest : httpRequest;
+	const dialUpstream = (onReady: () => void): Socket =>
+		secure
+			? tlsConnect(upstreamPort, upstream.hostname, { servername: upstream.hostname }, onReady)
+			: netConnect(upstreamPort, upstream.hostname, onReady);
+	// A host may be a daemon behind a reverse proxy at a path ("http://box/ao").
+	// The renderer's base is the proxy's own root, so the upstream prefix has to
+	// be restored here — without it every forwarded request, credential and all,
+	// lands on whatever else that vhost serves at /api/v1.
+	const prefix = upstream.pathname.replace(/\/+$/, "");
+	const server: Server = createServer();
+	const tunnels = new Set<() => void>();
+	// SSE connections outlive any fixed request timeout.
+	server.requestTimeout = 0;
+
+	const stripToken = (rawUrl: string | undefined): string | null => {
+		if (!rawUrl || !rawUrl.startsWith("/")) return null;
+		const slash = rawUrl.indexOf("/", 1);
+		const first = slash === -1 ? rawUrl.slice(1) : rawUrl.slice(1, slash);
+		if (!equalsToken(first, token)) return null;
+		return prefix + (slash === -1 ? "/" : rawUrl.slice(slash));
+	};
+
+	const forwardHeaders = (incoming: NodeJS.Dict<string | string[]>): NodeJS.Dict<string | string[]> => {
+		const out: NodeJS.Dict<string | string[]> = {};
+		for (const [name, value] of Object.entries(incoming)) {
+			if (!STRIP_REQUEST_HEADERS.includes(name.toLowerCase())) out[name] = value;
+		}
+		out.host = upstream.host;
+		out.authorization = `Bearer ${entry.password}`;
+		return out;
+	};
+
+	server.on("request", (req, res) => {
+		if (req.method === "OPTIONS") {
+			res.writeHead(204, {
+				...CORS_HEADERS,
+				"access-control-allow-headers": String(req.headers["access-control-request-headers"] ?? "content-type"),
+				"access-control-max-age": "600",
+			});
+			res.end();
+			return;
+		}
+		const path = stripToken(req.url);
+		if (path === null) {
+			res.writeHead(404, {
+				"content-type": "application/json",
+				...CORS_HEADERS,
+			});
+			res.end('{"error":"unknown path"}');
+			return;
+		}
+		const proxied = upstreamRequest(
+			{
+				host: upstream.hostname,
+				port: upstreamPort,
+				method: req.method,
+				path,
+				headers: forwardHeaders(req.headers),
+			},
+			(upstreamRes) => {
+				const headers: NodeJS.Dict<string | string[] | number> = {
+					...upstreamRes.headers,
+					...CORS_HEADERS,
+				};
+				delete headers.connection;
+				delete headers["keep-alive"];
+				res.writeHead(upstreamRes.statusCode ?? 502, headers);
+				// pipe streams SSE chunk-by-chunk; node performs no extra buffering.
+				upstreamRes.pipe(res);
+			},
+		);
+		proxied.setTimeout(0);
+		proxied.on("error", (error: Error) => {
+			warn(`upstream ${upstream.host} failed on ${req.method} ${path} (${error.message}); answering 502`);
+			if (!res.headersSent)
+				res.writeHead(502, {
+					"content-type": "application/json",
+					...CORS_HEADERS,
+				});
+			res.end('{"error":"remote daemon unreachable"}');
+		});
+		req.pipe(proxied);
+	});
+
+	server.on("upgrade", (req, socket: Socket, head: Buffer) => {
+		const path = stripToken(req.url);
+		if (path === null) {
+			socket.destroy();
+			return;
+		}
+		const upstreamSocket = dialUpstream(() => {
+			const headers = forwardHeaders(req.headers);
+			const lines = [`${req.method} ${path} HTTP/1.1`];
+			// The WebSocket-specific headers were stripped as hop-by-hop; restore
+			// the two the handshake requires, with the credential injected above.
+			headers.connection = "Upgrade";
+			headers.upgrade = String(req.headers.upgrade ?? "websocket");
+			for (const [name, value] of Object.entries(headers)) {
+				for (const v of Array.isArray(value) ? value : [value]) lines.push(`${name}: ${v}`);
+			}
+			upstreamSocket.write(lines.join("\r\n") + "\r\n\r\n");
+			if (head.length > 0) upstreamSocket.write(head);
+			socket.pipe(upstreamSocket);
+			upstreamSocket.pipe(socket);
+		});
+		upstreamSocket.on("error", (error: Error) => {
+			warn(`upstream ${upstream.host} tunnel failed on ${path} (${error.message})`);
+		});
+		const drop = () => {
+			tunnels.delete(drop);
+			socket.destroy();
+			upstreamSocket.destroy();
+		};
+		tunnels.add(drop);
+		// http.Server keeps upgraded sockets half-open (allowHalfOpen), so a peer
+		// that only sends FIN never triggers "close" — tear the pair down on
+		// "end" too or every closed terminal leaks a socket to the remote host.
+		for (const event of ["error", "end", "close"] as const) {
+			upstreamSocket.on(event, drop);
+			socket.on(event, drop);
+		}
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const port = (server.address() as AddressInfo).port;
+	log(`started on 127.0.0.1:${port} for ${upstream.host}`);
+	return {
+		base: `http://127.0.0.1:${port}/${token}`,
+		url: entry.url,
+		close: () =>
+			new Promise((resolve) => {
+				// close() alone waits on keep-alive and tunnelled sockets forever;
+				// a deactivated proxy must actually stop serving.
+				for (const drop of tunnels) drop();
+				server.closeAllConnections();
+				server.close(() => {
+					log(`stopped on 127.0.0.1:${port} for ${upstream.host}`);
+					resolve();
+				});
+			}),
+	};
+}

--- a/frontend/src/main/remote-proxy.ts
+++ b/frontend/src/main/remote-proxy.ts
@@ -137,7 +137,12 @@ export async function startRemoteProxy(entry: RemoteEntry): Promise<ActiveProxy>
 				delete headers.connection;
 				delete headers["keep-alive"];
 				res.writeHead(upstreamRes.statusCode ?? 502, headers);
-				// pipe streams SSE chunk-by-chunk; node performs no extra buffering.
+				// Node holds the header block until the first body byte or an explicit
+				// flush. An SSE upstream (GET /api/v1/events) can go arbitrarily long
+				// before its first byte, so without this the client's EventSource sits
+				// in CONNECTING forever — flush headers on their own, then pipe.
+				res.flushHeaders();
+				// pipe streams SSE chunk-by-chunk once headers are already on the wire.
 				upstreamRes.pipe(res);
 			},
 		);

--- a/frontend/src/main/remote-registry.test.ts
+++ b/frontend/src/main/remote-registry.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { RemoteRegistry } from "./remote-registry";
+
+const WORKBOX = { label: "workbox", url: "http://192.0.2.1:3011", password: "pw-one" };
+const MINI = { label: "mini", url: "http://192.0.2.9:3011", password: "pw-two" };
+
+function fakeProxies() {
+	const closed: string[] = [];
+	const start = vi.fn(async (entry: { url: string }) => ({
+		base: `http://127.0.0.1:9999/${entry.url.replace(/\W/g, "")}`,
+		url: entry.url,
+		close: async () => {
+			closed.push(entry.url);
+		},
+	}));
+	return { start, closed };
+}
+
+describe("RemoteRegistry", () => {
+	it("keeps several hosts connected at once", async () => {
+		const { start } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await registry.connect(WORKBOX);
+		await registry.connect(MINI);
+		expect(registry.views().map((view) => view.url)).toEqual([WORKBOX.url, MINI.url]);
+		expect(start).toHaveBeenCalledTimes(2);
+	});
+
+	it("connecting the same url twice reuses the live proxy", async () => {
+		const { start } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		const first = await registry.connect(WORKBOX);
+		const second = await registry.connect(WORKBOX);
+		expect(second).toEqual(first);
+		expect(start).toHaveBeenCalledTimes(1);
+	});
+
+	it("disconnect closes only that host's proxy", async () => {
+		const { start, closed } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await registry.connect(WORKBOX);
+		await registry.connect(MINI);
+		await registry.disconnect(WORKBOX.url);
+		expect(closed).toEqual([WORKBOX.url]);
+		expect(registry.views().map((view) => view.url)).toEqual([MINI.url]);
+	});
+
+	it("disconnecting a host that was never connected is a no-op", async () => {
+		const { start, closed } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await expect(registry.disconnect(WORKBOX.url)).resolves.toBeUndefined();
+		expect(closed).toEqual([]);
+		expect(start).not.toHaveBeenCalled();
+	});
+
+	it("never exposes the password", async () => {
+		const registry = new RemoteRegistry(fakeProxies().start);
+		const view = await registry.connect(WORKBOX);
+		expect(JSON.stringify(view)).not.toContain("pw-one");
+		expect(JSON.stringify(registry.views())).not.toContain("pw-one");
+	});
+
+	it("a host that fails to start does not join the registry", async () => {
+		const registry = new RemoteRegistry(async () => {
+			throw new Error("EADDRNOTAVAIL");
+		});
+		await expect(registry.connect(WORKBOX)).rejects.toThrow("EADDRNOTAVAIL");
+		expect(registry.views()).toEqual([]);
+	});
+
+	it("closeAll tears every proxy down", async () => {
+		const { start, closed } = fakeProxies();
+		const registry = new RemoteRegistry(start);
+		await registry.connect(WORKBOX);
+		await registry.connect(MINI);
+		await registry.closeAll();
+		expect(closed.sort()).toEqual([WORKBOX.url, MINI.url].sort());
+		expect(registry.views()).toEqual([]);
+	});
+});

--- a/frontend/src/main/remote-registry.ts
+++ b/frontend/src/main/remote-registry.ts
@@ -1,0 +1,48 @@
+import type { ActiveProxy } from "./remote-proxy";
+import type { RemoteEntry } from "./remotes-store";
+
+/** What the renderer may know about a connected host. Password stays here. */
+export type ConnectedHostView = {
+	label: string;
+	url: string;
+	base: string;
+};
+
+type StartProxy = (entry: RemoteEntry) => Promise<ActiveProxy>;
+
+// N hosts live at once, one proxy each, keyed by url: the app does not view
+// one host, it talks to several.
+export class RemoteRegistry {
+	private readonly live = new Map<string, { view: ConnectedHostView; proxy: ActiveProxy }>();
+
+	constructor(private readonly start: StartProxy) {}
+
+	async connect(entry: RemoteEntry): Promise<ConnectedHostView> {
+		const existing = this.live.get(entry.url);
+		// Reuse rather than restart: a second connect would strand the first
+		// proxy's port with the renderer still holding streams against it.
+		if (existing) return existing.view;
+
+		const proxy = await this.start(entry);
+		const view = { label: entry.label, url: entry.url, base: proxy.base };
+		this.live.set(entry.url, { view, proxy });
+		return view;
+	}
+
+	async disconnect(url: string): Promise<void> {
+		const entry = this.live.get(url);
+		if (!entry) return;
+		this.live.delete(url);
+		await entry.proxy.close();
+	}
+
+	views(): ConnectedHostView[] {
+		return [...this.live.values()].map(({ view }) => view);
+	}
+
+	async closeAll(): Promise<void> {
+		const entries = [...this.live.values()];
+		this.live.clear();
+		await Promise.all(entries.map(({ proxy }) => proxy.close()));
+	}
+}

--- a/frontend/src/main/remote-request.test.ts
+++ b/frontend/src/main/remote-request.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeRemote, remoteRequest } from "./remote-request";
+
+const entry = { label: "workbox", url: "http://192.0.2.1:3011", password: "pw" };
+
+// Typed as fetch so `mock.calls` carries fetch's argument tuple — an untyped
+// `vi.fn(async () => …)` records a zero-length tuple and indexing it is a type error.
+function fakeFetch(status: number, body: unknown = {}) {
+	return vi.fn<typeof fetch>(async () => new Response(JSON.stringify(body), { status }));
+}
+
+// A body that is not JSON at all, the way an SPA catch-all answers every path.
+function fakeTextFetch(status: number, text: string) {
+	return vi.fn<typeof fetch>(async () => new Response(text, { status }));
+}
+
+const daemonProbe = { status: "ok", service: "agent-orchestrator-daemon", pid: 1234 };
+
+describe("remoteRequest", () => {
+	it("sends the connection password as a Bearer token", async () => {
+		const doFetch = fakeFetch(201, { id: "p1" });
+		await remoteRequest(entry, { method: "POST", path: "/api/v1/projects", body: { path: "/srv/repo" } }, doFetch);
+
+		const [url, init] = doFetch.mock.calls[0] as unknown as [string, RequestInit];
+		expect(url).toBe("http://192.0.2.1:3011/api/v1/projects");
+		expect(new Headers(init.headers).get("Authorization")).toBe("Bearer pw");
+		expect(init.body).toBe('{"path":"/srv/repo"}');
+	});
+
+	it("returns the status and parsed body rather than throwing on 4xx", async () => {
+		const doFetch = fakeFetch(400, { error: "path must be absolute" });
+		await expect(remoteRequest(entry, { method: "POST", path: "/api/v1/projects" }, doFetch)).resolves.toEqual({
+			status: 400,
+			body: { error: "path must be absolute" },
+		});
+	});
+
+	// A path is concatenated onto the host url, and "@" turns everything before
+	// it into userinfo — so an unchecked path is a way to post this host's
+	// connection password to someone else's server.
+	it("refuses a path that redirects the credential to another host", async () => {
+		const doFetch = fakeFetch(200);
+		await expect(remoteRequest(entry, { method: "GET", path: "@evil.example/steal" }, doFetch)).rejects.toThrow(
+			/evil\.example/,
+		);
+		expect(doFetch).not.toHaveBeenCalled();
+	});
+
+	it("keeps a protocol-relative path on the saved host", async () => {
+		const doFetch = fakeFetch(200);
+		await remoteRequest(entry, { method: "GET", path: "//evil.example/x" }, doFetch);
+		expect(doFetch.mock.calls[0][0]).toBe("http://192.0.2.1:3011//evil.example/x");
+	});
+
+	it("keeps a reverse-proxy path prefix", async () => {
+		const doFetch = fakeFetch(200);
+		await remoteRequest({ ...entry, url: "http://192.0.2.1/ao" }, { method: "GET", path: "/healthz" }, doFetch);
+		expect(doFetch.mock.calls[0][0]).toBe("http://192.0.2.1/ao/healthz");
+	});
+
+	it("joins paths without doubling the slash on a trailing-slash url", async () => {
+		const doFetch = fakeFetch(200);
+		await remoteRequest({ ...entry, url: "http://192.0.2.1:3011/" }, { method: "GET", path: "/healthz" }, doFetch);
+		expect(doFetch.mock.calls[0][0]).toBe("http://192.0.2.1:3011/healthz");
+	});
+});
+
+describe("probeRemote", () => {
+	it("reports online on a 200 that carries the daemon's own probe body", async () => {
+		await expect(probeRemote(entry, fakeFetch(200, daemonProbe))).resolves.toBe("online");
+	});
+
+	it("distinguishes a bad password from an unreachable host", async () => {
+		await expect(probeRemote(entry, fakeFetch(401))).resolves.toBe("unauthorized");
+		const refused = vi.fn(async () => {
+			throw new TypeError("fetch failed");
+		});
+		await expect(probeRemote(entry, refused)).resolves.toBe("offline");
+	});
+
+	it("bounds probes to sleeping hosts", async () => {
+		const sleeping = vi.fn<typeof fetch>((_input, init) =>
+			new Promise((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+			}),
+		);
+
+		await expect(probeRemote(entry, sleeping, 1)).resolves.toBe("offline");
+		expect(sleeping.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	// The port typo that white-screened the app: :8081 was an Expo web server,
+	// whose SPA catch-all answers /healthz with 200 and an HTML page. A status
+	// code proves something replied, not that it speaks the daemon's protocol —
+	// and once such a host became the api base, every query returned that page.
+	it("rejects a 200 whose body is not a daemon probe", async () => {
+		const html = fakeTextFetch(200, "<!DOCTYPE html><html><title>AO</title></html>");
+		await expect(probeRemote(entry, html)).resolves.toBe("not-a-daemon");
+	});
+
+	it("rejects a 200 from a JSON service that is not the daemon", async () => {
+		await expect(probeRemote(entry, fakeFetch(200, { status: "ok" }))).resolves.toBe("not-a-daemon");
+		await expect(probeRemote(entry, fakeFetch(200, { ...daemonProbe, service: "grafana" }))).resolves.toBe(
+			"not-a-daemon",
+		);
+	});
+});

--- a/frontend/src/main/remote-request.ts
+++ b/frontend/src/main/remote-request.ts
@@ -1,0 +1,86 @@
+import { parseDaemonProbe } from "../shared/daemon-attach";
+import type { RemoteEntry } from "./remotes-store";
+
+// Remote HTTP lives in the main process for two reasons: the renderer's origin
+// is app://renderer and a remote daemon has no reason to allow it through CORS,
+// and the connection password must never enter renderer memory.
+export type RemoteRequestInit = {
+	method: "GET" | "POST" | "DELETE";
+	path: string;
+	body?: unknown;
+};
+
+export type RemoteResponse = {
+	status: number;
+	body: unknown;
+};
+
+// "not-a-daemon" is its own answer because the honest sentence differs: the
+// address replied, so telling someone it is unreachable sends them to debug a
+// network that is working.
+export type RemoteHealth = "online" | "unauthorized" | "offline" | "not-a-daemon";
+
+type FetchImpl = typeof fetch;
+
+export async function remoteRequest(
+	entry: RemoteEntry,
+	init: RemoteRequestInit,
+	fetchImpl: FetchImpl = fetch,
+	signal?: AbortSignal,
+): Promise<RemoteResponse> {
+	const base = entry.url.replace(/\/+$/, "");
+	// The path is concatenated, and a concatenated path can leave the host: a
+	// path starting with "@" turns the base into userinfo ("http://box:3011" +
+	// "@evil.com/" is a request to evil.com) and would hand this host's
+	// connection password to whoever answers there. The renderer is the only
+	// caller today, but it is the process that renders agent output, so the
+	// origin is checked here rather than trusted upstream.
+	const target = new URL(`${base}${init.path}`);
+	if (target.origin !== new URL(base).origin)
+		throw new Error(`refusing to send ${entry.url} credentials to ${target.origin}`);
+	const response = await fetchImpl(target.href, {
+		method: init.method,
+		headers: {
+			"Content-Type": "application/json",
+			// Same credential presentation as the CLI (cli/remote.go:374).
+			Authorization: `Bearer ${entry.password}`,
+		},
+		body: init.body === undefined ? undefined : JSON.stringify(init.body),
+		signal,
+	});
+
+	const text = await response.text();
+	let body: unknown = null;
+	try {
+		body = text ? JSON.parse(text) : null;
+	} catch {
+		body = text;
+	}
+	return { status: response.status, body };
+}
+
+export async function probeRemote(
+	entry: RemoteEntry,
+	fetchImpl: FetchImpl = fetch,
+	timeoutMs = 5_000,
+): Promise<RemoteHealth> {
+	try {
+		const { status, body } = await remoteRequest(
+			entry,
+			{ method: "GET", path: "/healthz" },
+			fetchImpl,
+			AbortSignal.timeout(timeoutMs),
+		);
+		if (status === 401 || status === 403) return "unauthorized";
+		if (status < 200 || status >= 300) return "offline";
+		// A status code proves something replied, not that it is a daemon. An SPA
+		// catch-all (an Expo dev server on a mistyped port, say) answers every path
+		// with 200 and an HTML page; accepting that as the api base hands the whole
+		// renderer bodies it will read fields off and crash on.
+		return parseDaemonProbe("healthz", body) === null ? "not-a-daemon" : "online";
+	} catch {
+		// A transport failure is indistinguishable from a wrong port here, and
+		// both mean the same thing to the user: it is not reachable.
+		return "offline";
+	}
+}

--- a/frontend/src/main/remotes-ipc.test.ts
+++ b/frontend/src/main/remotes-ipc.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findRemote, removeSavedRemote, toHostViews, updateSavedRemote } from "./remotes-ipc";
+import type { RemoteEntry } from "./remotes-store";
+
+const TWO_HOSTS =
+	'{"remotes":[{"label":"workbox","url":"http://192.0.2.1:1","password":"old"},{"label":"mini","url":"http://192.0.2.9:9","password":"m"}]}';
+
+async function tempFile(contents = TWO_HOSTS, mode = 0o600): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "ao-remotes-ipc-"));
+	const path = join(dir, "remotes.json");
+	await writeFile(path, contents, "utf8");
+	await chmod(path, mode);
+	return path;
+}
+
+const online = async () => "online" as const;
+const dropped = () => vi.fn<(url: string) => Promise<void>>().mockResolvedValue(undefined);
+
+describe("toHostViews", () => {
+	it("strips the password before anything crosses to the renderer", () => {
+		const views = toHostViews([{ label: "workbox", url: "http://192.0.2.1:3011", password: "supersecret" }]);
+		expect(views).toEqual([{ label: "workbox", url: "http://192.0.2.1:3011" }]);
+		expect(JSON.stringify(views)).not.toContain("supersecret");
+	});
+});
+
+describe("findRemote", () => {
+	it("returns the saved entry for a url", async () => {
+		const path = await tempFile();
+		await expect(findRemote(path, "http://192.0.2.9:9")).resolves.toEqual({ label: "mini", url: "http://192.0.2.9:9", password: "m" });
+	});
+
+	it("refuses a url it has never saved", async () => {
+		const path = await tempFile();
+		await expect(findRemote(path, "http://192.0.2.5:5")).rejects.toThrow(/no saved host/);
+	});
+});
+
+describe("updateSavedRemote", () => {
+	it("probes the merged entry before it writes anything", async () => {
+		const path = await tempFile();
+		const probed: RemoteEntry[] = [];
+		const health = await updateSavedRemote(path, "http://192.0.2.1:1", { password: "rotated" }, dropped(), async (entry) => {
+			probed.push(entry);
+			return "online";
+		});
+		expect(health).toBe("online");
+		// Probed with the new password against the saved address, not with either half.
+		expect(probed).toEqual([{ label: "workbox", url: "http://192.0.2.1:1", password: "rotated" }]);
+	});
+
+	it("saves nothing and drops nothing when the edited host does not answer", async () => {
+		const path = await tempFile();
+		const disconnect = dropped();
+		const health = await updateSavedRemote(path, "http://192.0.2.1:1", { password: "wrong" }, disconnect, async () => "unauthorized");
+		expect(health).toBe("unauthorized");
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+		expect(disconnect).not.toHaveBeenCalled();
+	});
+
+	// A live proxy holds the address and password that were saved when it
+	// started; after an edit both may be stale, so it does not get to keep serving.
+	it("drops the edited host's proxy by its old url", async () => {
+		const path = await tempFile();
+		const disconnect = dropped();
+		await updateSavedRemote(path, "http://192.0.2.1:1", { url: "http://192.0.2.5:5" }, disconnect, online);
+		expect(disconnect).toHaveBeenCalledTimes(1);
+		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+	});
+});
+
+describe("removeSavedRemote", () => {
+	it("forgets the host and drops its proxy", async () => {
+		const path = await tempFile();
+		const disconnect = dropped();
+		await removeSavedRemote(path, "http://192.0.2.1:1", disconnect);
+		expect(JSON.parse(await readFile(path, "utf8")).remotes).toEqual([{ label: "mini", url: "http://192.0.2.9:9", password: "m" }]);
+		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+	});
+
+	it("refuses to touch a file others can read", async () => {
+		const path = await tempFile(TWO_HOSTS, 0o644);
+		const disconnect = dropped();
+		await expect(removeSavedRemote(path, "http://192.0.2.1:1", disconnect)).rejects.toThrow(/chmod 600/);
+		expect(disconnect).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/main/remotes-ipc.ts
+++ b/frontend/src/main/remotes-ipc.ts
@@ -1,0 +1,55 @@
+import { probeRemote, type RemoteHealth } from "./remote-request";
+import {
+	applyRemoteChanges,
+	readRemotes,
+	removeRemote,
+	updateRemote,
+	type RemoteChanges,
+	type RemoteEntry,
+} from "./remotes-store";
+
+// What the renderer is allowed to see. The password stays in the main process.
+export type RemoteHostView = {
+	label: string;
+	url: string;
+};
+
+export function toHostViews(entries: RemoteEntry[]): RemoteHostView[] {
+	return entries.map(({ label, url }) => ({ label, url }));
+}
+
+export async function findRemote(path: string, url: string): Promise<RemoteEntry> {
+	const entry = (await readRemotes(path)).find((candidate) => candidate.url === url);
+	if (!entry) throw new Error(`no saved host for ${url}`);
+	return entry;
+}
+
+// Whatever is serving this url must stop: after an edit it holds a stale
+// address or password, after a removal it is an open door with no doorman.
+// Called unconditionally — dropping a host that was never connected is a no-op.
+type Disconnect = (url: string) => Promise<void>;
+
+/**
+ * Edit a saved host in place. Probes before saving exactly as adding does — an
+ * edit is how a host gets fixed, and one that lands somewhere unreachable only
+ * looks fixed.
+ */
+export async function updateSavedRemote(
+	path: string,
+	url: string,
+	changes: RemoteChanges,
+	disconnect: Disconnect,
+	probe: (entry: RemoteEntry) => Promise<RemoteHealth> = probeRemote,
+): Promise<RemoteHealth> {
+	const health = await probe(applyRemoteChanges(await findRemote(path, url), changes));
+	if (health !== "online") return health;
+	await updateRemote(path, url, changes);
+	await disconnect(url);
+	return health;
+}
+
+/** Forget a saved host. */
+export async function removeSavedRemote(path: string, url: string, disconnect: Disconnect): Promise<void> {
+	await removeRemote(path, url);
+	await disconnect(url);
+}

--- a/frontend/src/main/remotes-main.test.ts
+++ b/frontend/src/main/remotes-main.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerRemotesIpc } from "./remotes-main";
+
+type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
+
+// ipcMain stand-in: records what was registered and lets a test invoke it.
+function fakeIpc() {
+	const handlers = new Map<string, Handler>();
+	return {
+		ipcMain: { handle: (channel: string, handler: Handler) => void handlers.set(channel, handler) },
+		invoke: (channel: string, ...args: unknown[]) => {
+			const handler = handlers.get(channel);
+			if (!handler) throw new Error(`no handler for ${channel}`);
+			return handler({}, ...args);
+		},
+		channels: () => [...handlers.keys()].sort(),
+	};
+}
+
+async function tempFile(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "ao-remotes-main-"));
+	const path = join(dir, "remotes.json");
+	await writeFile(path, '{"remotes":[{"label":"workbox","url":"http://192.0.2.1:1","password":"old"}]}', "utf8");
+	await chmod(path, 0o600);
+	return path;
+}
+
+describe("registerRemotesIpc", () => {
+	it("registers the saved-host surface", async () => {
+		const ipc = fakeIpc();
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		expect(ipc.channels()).toEqual([
+			"remotes:add",
+			"remotes:list",
+			"remotes:probe",
+			"remotes:remove",
+			"remotes:request",
+			"remotes:update",
+		]);
+	});
+
+	it("lists hosts without their passwords", async () => {
+		const ipc = fakeIpc();
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		await expect(ipc.invoke("remotes:list")).resolves.toEqual([{ label: "workbox", url: "http://192.0.2.1:1" }]);
+	});
+
+	it("saves a new host only after it answers as a daemon", async () => {
+		const ipc = fakeIpc();
+		const file = await tempFile();
+		const probe = vi.fn().mockResolvedValueOnce("offline" as const).mockResolvedValueOnce("online" as const);
+		registerRemotesIpc(ipc.ipcMain, { file, disconnect: async () => undefined, probe });
+		const mini = { label: "mini", url: "http://192.0.2.9:9", password: "m" };
+
+		await expect(ipc.invoke("remotes:add", mini)).resolves.toBe("offline");
+		expect(JSON.parse(await readFile(file, "utf8")).remotes).toHaveLength(1);
+
+		await expect(ipc.invoke("remotes:add", mini)).resolves.toBe("online");
+		expect(JSON.parse(await readFile(file, "utf8")).remotes).toHaveLength(2);
+	});
+
+	it("drops the proxy of a removed host", async () => {
+		const ipc = fakeIpc();
+		const disconnect = vi.fn().mockResolvedValue(undefined);
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect });
+		await ipc.invoke("remotes:remove", "http://192.0.2.1:1");
+		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+	});
+});

--- a/frontend/src/main/remotes-main.test.ts
+++ b/frontend/src/main/remotes-main.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerRemotesIpc } from "./remotes-main";
+import { RemoteRegistry } from "./remote-registry";
 
 type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
 
@@ -28,12 +29,26 @@ async function tempFile(): Promise<string> {
 	return path;
 }
 
+
+function registryOf(closed: string[] = []) {
+	return new RemoteRegistry(async (entry) => ({
+		base: "http://127.0.0.1:9999/tok",
+		url: entry.url,
+		close: async () => {
+			closed.push(entry.url);
+		},
+	}));
+}
+
 describe("registerRemotesIpc", () => {
-	it("registers the saved-host surface", async () => {
+	it("registers the saved-host and connection surface", async () => {
 		const ipc = fakeIpc();
-		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf() });
 		expect(ipc.channels()).toEqual([
 			"remotes:add",
+			"remotes:connect",
+			"remotes:connected",
+			"remotes:disconnect",
 			"remotes:list",
 			"remotes:probe",
 			"remotes:remove",
@@ -44,7 +59,7 @@ describe("registerRemotesIpc", () => {
 
 	it("lists hosts without their passwords", async () => {
 		const ipc = fakeIpc();
-		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect: async () => undefined });
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf() });
 		await expect(ipc.invoke("remotes:list")).resolves.toEqual([{ label: "workbox", url: "http://192.0.2.1:1" }]);
 	});
 
@@ -52,7 +67,7 @@ describe("registerRemotesIpc", () => {
 		const ipc = fakeIpc();
 		const file = await tempFile();
 		const probe = vi.fn().mockResolvedValueOnce("offline" as const).mockResolvedValueOnce("online" as const);
-		registerRemotesIpc(ipc.ipcMain, { file, disconnect: async () => undefined, probe });
+		registerRemotesIpc(ipc.ipcMain, { file, registry: registryOf(), probe });
 		const mini = { label: "mini", url: "http://192.0.2.9:9", password: "m" };
 
 		await expect(ipc.invoke("remotes:add", mini)).resolves.toBe("offline");
@@ -62,11 +77,36 @@ describe("registerRemotesIpc", () => {
 		expect(JSON.parse(await readFile(file, "utf8")).remotes).toHaveLength(2);
 	});
 
-	it("drops the proxy of a removed host", async () => {
+	it("connects a saved host only after it answers as a daemon, and hands back a password-free view", async () => {
 		const ipc = fakeIpc();
-		const disconnect = vi.fn().mockResolvedValue(undefined);
-		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), disconnect });
+		const probe = vi.fn().mockResolvedValueOnce("offline" as const).mockResolvedValueOnce("online" as const);
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf(), probe });
+
+		await expect(ipc.invoke("remotes:connect", "http://192.0.2.1:1")).rejects.toThrow(/is offline/);
+		await expect(ipc.invoke("remotes:connected")).resolves.toEqual([]);
+
+		const view = await ipc.invoke("remotes:connect", "http://192.0.2.1:1");
+		expect(view).toEqual({ label: "workbox", url: "http://192.0.2.1:1", base: "http://127.0.0.1:9999/tok" });
+		expect(JSON.stringify(await ipc.invoke("remotes:connected"))).not.toContain("old");
+	});
+
+	it("removing a connected host closes its proxy", async () => {
+		const ipc = fakeIpc();
+		const closed: string[] = [];
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf(closed), probe: async () => "online" });
+		await ipc.invoke("remotes:connect", "http://192.0.2.1:1");
 		await ipc.invoke("remotes:remove", "http://192.0.2.1:1");
-		expect(disconnect).toHaveBeenCalledWith("http://192.0.2.1:1");
+		expect(closed).toEqual(["http://192.0.2.1:1"]);
+		await expect(ipc.invoke("remotes:connected")).resolves.toEqual([]);
+	});
+
+	it("disconnect closes the proxy and forgets the view", async () => {
+		const ipc = fakeIpc();
+		const closed: string[] = [];
+		registerRemotesIpc(ipc.ipcMain, { file: await tempFile(), registry: registryOf(closed), probe: async () => "online" });
+		await ipc.invoke("remotes:connect", "http://192.0.2.1:1");
+		await ipc.invoke("remotes:disconnect", "http://192.0.2.1:1");
+		expect(closed).toEqual(["http://192.0.2.1:1"]);
+		await expect(ipc.invoke("remotes:connected")).resolves.toEqual([]);
 	});
 });

--- a/frontend/src/main/remotes-main.ts
+++ b/frontend/src/main/remotes-main.ts
@@ -1,0 +1,53 @@
+import os from "node:os";
+import path from "node:path";
+import { probeRemote, remoteRequest, type RemoteHealth, type RemoteRequestInit } from "./remote-request";
+import { findRemote, removeSavedRemote, toHostViews, updateSavedRemote } from "./remotes-ipc";
+import { addRemote, readRemotes, type RemoteChanges, type RemoteEntry } from "./remotes-store";
+
+// The CLI resolves this file through config.StateDir(), which is ~/.ao
+// unconditionally — it does NOT honour AO_DATA_DIR (that points at the daemon's
+// data dir). Following AO_DATA_DIR here would make the app read a different
+// file than `ao --url` writes, which defeats sharing one host list and one
+// credential store.
+export function remotesFilePath(): string {
+	return path.join(os.homedir(), ".ao", "remotes.json");
+}
+
+// The slice of Electron's ipcMain these handlers need, so tests need no Electron.
+type IpcMainLike = {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- the listener
+	// args must unify Electron's IpcMain (any[]) with a test fake (unknown[]),
+	// and `never[]` rejects both; `any[]` here leaks nowhere past registration.
+	handle(channel: string, listener: (event: unknown, ...args: any[]) => Promise<unknown>): void;
+};
+
+export type RemotesIpcDeps = {
+	file: string;
+	/** Stop whatever is serving this url; a no-op for a host that is not connected. */
+	disconnect: (url: string) => Promise<void>;
+	probe?: (entry: RemoteEntry) => Promise<RemoteHealth>;
+};
+
+/**
+ * Saved AO daemons, shared with the CLI's ~/.ao/remotes.json. Everything the
+ * renderer receives back is password-free (see remotes-ipc.ts); the plaintext
+ * password only ever travels renderer -> main, on `add`.
+ */
+export function registerRemotesIpc(ipcMain: IpcMainLike, { file, disconnect, probe = probeRemote }: RemotesIpcDeps): void {
+	ipcMain.handle("remotes:list", async () => toHostViews(await readRemotes(file)));
+	ipcMain.handle("remotes:add", async (_event, input: RemoteEntry) => {
+		// Probe before saving: a host that never answered is worse than no host,
+		// because it looks configured.
+		const health = await probe(input);
+		if (health === "online") await addRemote(file, input);
+		return health;
+	});
+	ipcMain.handle("remotes:probe", async (_event, url: string) => probe(await findRemote(file, url)));
+	ipcMain.handle("remotes:request", async (_event, url: string, init: RemoteRequestInit) =>
+		remoteRequest(await findRemote(file, url), init),
+	);
+	ipcMain.handle("remotes:update", async (_event, url: string, changes: RemoteChanges) =>
+		updateSavedRemote(file, url, changes, disconnect, probe),
+	);
+	ipcMain.handle("remotes:remove", async (_event, url: string) => removeSavedRemote(file, url, disconnect));
+}

--- a/frontend/src/main/remotes-main.ts
+++ b/frontend/src/main/remotes-main.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { probeRemote, remoteRequest, type RemoteHealth, type RemoteRequestInit } from "./remote-request";
 import { findRemote, removeSavedRemote, toHostViews, updateSavedRemote } from "./remotes-ipc";
+import type { RemoteRegistry } from "./remote-registry";
 import { addRemote, readRemotes, type RemoteChanges, type RemoteEntry } from "./remotes-store";
 
 // The CLI resolves this file through config.StateDir(), which is ~/.ao
@@ -23,8 +24,7 @@ type IpcMainLike = {
 
 export type RemotesIpcDeps = {
 	file: string;
-	/** Stop whatever is serving this url; a no-op for a host that is not connected. */
-	disconnect: (url: string) => Promise<void>;
+	registry: RemoteRegistry;
 	probe?: (entry: RemoteEntry) => Promise<RemoteHealth>;
 };
 
@@ -33,7 +33,9 @@ export type RemotesIpcDeps = {
  * renderer receives back is password-free (see remotes-ipc.ts); the plaintext
  * password only ever travels renderer -> main, on `add`.
  */
-export function registerRemotesIpc(ipcMain: IpcMainLike, { file, disconnect, probe = probeRemote }: RemotesIpcDeps): void {
+export function registerRemotesIpc(ipcMain: IpcMainLike, { file, registry, probe = probeRemote }: RemotesIpcDeps): void {
+	const disconnect = (url: string) => registry.disconnect(url);
+
 	ipcMain.handle("remotes:list", async () => toHostViews(await readRemotes(file)));
 	ipcMain.handle("remotes:add", async (_event, input: RemoteEntry) => {
 		// Probe before saving: a host that never answered is worse than no host,
@@ -50,4 +52,16 @@ export function registerRemotesIpc(ipcMain: IpcMainLike, { file, disconnect, pro
 		updateSavedRemote(file, url, changes, disconnect, probe),
 	);
 	ipcMain.handle("remotes:remove", async (_event, url: string) => removeSavedRemote(file, url, disconnect));
+
+	ipcMain.handle("remotes:connect", async (_event, url: string) => {
+		const entry = await findRemote(file, url);
+		// Probe before starting a proxy: a reachable port may serve something
+		// other than an AO daemon, and exposing it as connected can wedge the
+		// app at boot.
+		const health = await probe(entry);
+		if (health !== "online") throw new Error(`host ${url} is ${health}`);
+		return registry.connect(entry);
+	});
+	ipcMain.handle("remotes:disconnect", async (_event, url: string) => disconnect(url));
+	ipcMain.handle("remotes:connected", async () => registry.views());
 }

--- a/frontend/src/main/remotes-store.test.ts
+++ b/frontend/src/main/remotes-store.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { chmod, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addRemote, readRemotes, removeRemote, RemotesFilePermissionError, updateRemote } from "./remotes-store";
+
+async function tempFile(contents?: string, mode = 0o600): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "ao-remotes-"));
+	const path = join(dir, "remotes.json");
+	if (contents !== undefined) {
+		await writeFile(path, contents, "utf8");
+		await chmod(path, mode);
+	}
+	return path;
+}
+
+describe("readRemotes", () => {
+	it("returns an empty list when the file does not exist", async () => {
+		const path = await tempFile();
+		await expect(readRemotes(path)).resolves.toEqual([]);
+	});
+
+	it("reads entries from a 0600 file", async () => {
+		const path = await tempFile('{"remotes":[{"label":"workbox","url":"http://192.0.2.1:3011","password":"pw"}]}');
+		await expect(readRemotes(path)).resolves.toEqual([
+			{ label: "workbox", url: "http://192.0.2.1:3011", password: "pw" },
+		]);
+	});
+
+	it("refuses a file readable by others, naming the fix", async () => {
+		const path = await tempFile('{"remotes":[]}', 0o644);
+		await expect(readRemotes(path)).rejects.toBeInstanceOf(RemotesFilePermissionError);
+		await expect(readRemotes(path)).rejects.toThrow(/chmod 600/);
+	});
+
+	// Node reports 0o666 for every writable file on Windows, so the mode check
+	// there refuses a perfectly good file and takes saved hosts down with it.
+	// The CLI exempts win32 for the same reason (cli/remote.go:154).
+	it("does not apply the mode check on windows", async () => {
+		const path = await tempFile('{"remotes":[]}', 0o644);
+		const platform = Object.getOwnPropertyDescriptor(process, "platform");
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		try {
+			await expect(readRemotes(path)).resolves.toEqual([]);
+		} finally {
+			if (platform) Object.defineProperty(process, "platform", platform);
+		}
+	});
+});
+
+describe("addRemote", () => {
+	it("creates the file 0600 when absent", async () => {
+		const path = await tempFile();
+		await addRemote(path, { label: "workbox", url: "http://192.0.2.1:3011", password: "pw" });
+		expect((await stat(path)).mode & 0o777).toBe(0o600);
+		expect(JSON.parse(await readFile(path, "utf8")).remotes).toHaveLength(1);
+	});
+
+	it("appends without dropping existing entries", async () => {
+		const path = await tempFile('{"remotes":[{"label":"a","url":"http://192.0.2.1:1","password":"x"}]}');
+		await addRemote(path, { label: "b", url: "http://192.0.2.2:2", password: "y" });
+		const labels = JSON.parse(await readFile(path, "utf8")).remotes.map((r: { label: string }) => r.label);
+		expect(labels).toEqual(["a", "b"]);
+	});
+
+	it("replaces an entry with the same url rather than duplicating it", async () => {
+		const path = await tempFile('{"remotes":[{"label":"old","url":"http://192.0.2.1:1","password":"x"}]}');
+		await addRemote(path, { label: "new", url: "http://192.0.2.1:1", password: "z" });
+		const remotes = JSON.parse(await readFile(path, "utf8")).remotes;
+		expect(remotes).toEqual([{ label: "new", url: "http://192.0.2.1:1", password: "z" }]);
+	});
+});
+
+const TWO_HOSTS =
+	'{"remotes":[{"label":"workbox","url":"http://192.0.2.1:1","password":"old"},{"label":"mini","url":"http://192.0.2.9:9","password":"m"}]}';
+
+async function savedRemotes(path: string): Promise<unknown[]> {
+	return JSON.parse(await readFile(path, "utf8")).remotes;
+}
+
+describe("updateRemote", () => {
+	// The reason this exists: re-enabling the LAN bridge rotates the connection
+	// password, and until now the saved entry just died.
+	it("changes the password and nothing else", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await expect(updateRemote(path, "http://192.0.2.1:1", { password: "rotated" })).resolves.toEqual({
+			label: "workbox",
+			url: "http://192.0.2.1:1",
+			password: "rotated",
+		});
+		expect(await savedRemotes(path)).toEqual([
+			{ label: "workbox", url: "http://192.0.2.1:1", password: "rotated" },
+			{ label: "mini", url: "http://192.0.2.9:9", password: "m" },
+		]);
+	});
+
+	it("renames without touching the saved password", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { label: "the workbox" });
+		expect(await savedRemotes(path)).toContainEqual({ label: "the workbox", url: "http://192.0.2.1:1", password: "old" });
+	});
+
+	// An explicitly-undefined field survives Electron's structured clone, so
+	// "leave the password alone" arrives as a present key with no value.
+	it("treats an undefined field as absent rather than as a wipe", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { label: "renamed", password: undefined });
+		expect(await savedRemotes(path)).toContainEqual({ label: "renamed", url: "http://192.0.2.1:1", password: "old" });
+	});
+
+	it("moves the entry when the url changes instead of cloning it", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { url: "http://192.0.2.5:5" });
+		expect(await savedRemotes(path)).toEqual([
+			{ label: "workbox", url: "http://192.0.2.5:5", password: "old" },
+			{ label: "mini", url: "http://192.0.2.9:9", password: "m" },
+		]);
+	});
+
+	// Typing the address of a host you already saved must leave one host, not two
+	// rows racing to answer for the same machine.
+	it("absorbs another entry that already sits on the new url", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { url: "http://192.0.2.9:9" });
+		expect(await savedRemotes(path)).toEqual([{ label: "workbox", url: "http://192.0.2.9:9", password: "old" }]);
+	});
+
+	it("refuses a url it has never saved", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await expect(updateRemote(path, "http://192.0.2.7:7", { label: "ghost" })).rejects.toThrow(/no saved host/);
+	});
+
+	it("keeps the file 0600", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await updateRemote(path, "http://192.0.2.1:1", { password: "rotated" });
+		expect((await stat(path)).mode & 0o777).toBe(0o600);
+	});
+
+	it("refuses to touch a file others can read", async () => {
+		const path = await tempFile(TWO_HOSTS, 0o644);
+		await expect(updateRemote(path, "http://192.0.2.1:1", { password: "rotated" })).rejects.toBeInstanceOf(
+			RemotesFilePermissionError,
+		);
+		// And left the passwords exactly where they were.
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+	});
+});
+
+describe("removeRemote", () => {
+	it("drops only the named host", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await removeRemote(path, "http://192.0.2.1:1");
+		expect(await savedRemotes(path)).toEqual([{ label: "mini", url: "http://192.0.2.9:9", password: "m" }]);
+	});
+
+	it("keeps the file 0600", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await removeRemote(path, "http://192.0.2.1:1");
+		expect((await stat(path)).mode & 0o777).toBe(0o600);
+	});
+
+	it("is a no-op for a host that was never saved", async () => {
+		const path = await tempFile(TWO_HOSTS);
+		await removeRemote(path, "http://192.0.2.7:7");
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+	});
+
+	it("refuses to touch a file others can read", async () => {
+		const path = await tempFile(TWO_HOSTS, 0o644);
+		await expect(removeRemote(path, "http://192.0.2.1:1")).rejects.toBeInstanceOf(RemotesFilePermissionError);
+		expect(await readFile(path, "utf8")).toBe(TWO_HOSTS);
+	});
+});

--- a/frontend/src/main/remotes-store.ts
+++ b/frontend/src/main/remotes-store.ts
@@ -1,0 +1,94 @@
+import { readFile, stat, writeFile } from "node:fs/promises";
+
+// The CLI's saved-remote store, shared verbatim so the UI and `ao --url` agree
+// on which hosts exist and never hold two copies of a connection password.
+// Format and the 0600 requirement come from backend/internal/cli/remote.go:32-47.
+export type RemoteEntry = {
+	label: string;
+	url: string;
+	password: string;
+};
+
+export class RemotesFilePermissionError extends Error {
+	constructor(
+		readonly path: string,
+		readonly mode: number,
+	) {
+		super(
+			`${path} holds connection passwords and is readable by others (mode ${mode.toString(8).padStart(4, "0")}) — run: chmod 600 ${path}`,
+		);
+	}
+}
+
+function isMissing(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+export async function readRemotes(path: string): Promise<RemoteEntry[]> {
+	let mode: number;
+	try {
+		mode = (await stat(path)).mode & 0o777;
+	} catch (error) {
+		if (isMissing(error)) return [];
+		throw error;
+	}
+	// Mirrors the CLI: a world-readable credential file is refused, not tolerated.
+	// Windows is exempt for the same reason it is in the CLI (cli/remote.go:154):
+	// Node reports 0o666 for every writable file there, so the check would refuse
+	// every remotes.json on that platform and take saved hosts down with it.
+	if (process.platform !== "win32" && mode & 0o077) throw new RemotesFilePermissionError(path, mode);
+
+	const parsed = JSON.parse(await readFile(path, "utf8")) as { remotes?: RemoteEntry[] };
+	return parsed.remotes ?? [];
+}
+
+// Every write goes through here: mode on writeFile only applies at creation;
+// chmod-on-write would race, and readRemotes — which each of these calls first —
+// refuses anything looser on the next read regardless.
+async function writeRemotes(path: string, remotes: RemoteEntry[]): Promise<void> {
+	await writeFile(path, `${JSON.stringify({ remotes }, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+}
+
+export async function addRemote(path: string, entry: RemoteEntry): Promise<void> {
+	const existing = await readRemotes(path);
+	await writeRemotes(path, [...existing.filter((candidate) => candidate.url !== entry.url), entry]);
+}
+
+/** An edit: only the fields it carries change. */
+export type RemoteChanges = Partial<RemoteEntry>;
+
+/**
+ * Absent fields keep their saved value. Written with an explicit `??` per field
+ * rather than a spread because Electron's structured clone preserves a key whose
+ * value is undefined — `{ password: undefined }` must not wipe a working
+ * password, which is exactly what "leave blank to keep it" sends.
+ */
+export function applyRemoteChanges(entry: RemoteEntry, changes: RemoteChanges): RemoteEntry {
+	return {
+		label: changes.label ?? entry.label,
+		url: changes.url ?? entry.url,
+		password: changes.password ?? entry.password,
+	};
+}
+
+export async function updateRemote(path: string, url: string, changes: RemoteChanges): Promise<RemoteEntry> {
+	const existing = await readRemotes(path);
+	const current = existing.find((candidate) => candidate.url === url);
+	if (!current) throw new Error(`no saved host for ${url}`);
+	const updated = applyRemoteChanges(current, changes);
+	// Re-pointing a host MOVES its entry: the row keeps its place, and any other
+	// row already sitting on the new url is absorbed rather than left as a twin.
+	const remotes = existing
+		.map((candidate) => (candidate === current ? updated : candidate))
+		.filter((candidate) => candidate === updated || candidate.url !== updated.url);
+	await writeRemotes(path, remotes);
+	return updated;
+}
+
+export async function removeRemote(path: string, url: string): Promise<void> {
+	const existing = await readRemotes(path);
+	const remaining = existing.filter((candidate) => candidate.url !== url);
+	// Removing what is not there is not an error, but it is not a write either.
+	if (remaining.length === existing.length) return;
+	await writeRemotes(path, remaining);
+}

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -16,6 +16,8 @@ import {
 	type TrayOpenSessionTarget,
 } from "./shared/tray";
 import type { DaemonStatus } from "./shared/daemon-status";
+import type { RemoteHostView } from "./main/remotes-ipc";
+import type { RemoteHealth, RemoteRequestInit, RemoteResponse } from "./main/remote-request";
 import type {
 	EditorHandoffState,
 	OpenSessionTargetInput,
@@ -491,6 +493,23 @@ const api = {
 	featureBuilds: {
 		list: () => ipcRenderer.invoke("featureBuilds:list") as Promise<FeatureBuild[]>,
 		getActive: () => ipcRenderer.invoke("featureBuilds:getActive") as Promise<{ pr: number } | null>,
+	},
+	// Saved AO daemons, shared with the CLI's ~/.ao/remotes.json. Everything the
+	// renderer receives back is password-free (see main/remotes-ipc.ts); the
+	// plaintext password only ever travels renderer -> main, on `add`.
+	remotes: {
+		list: () => ipcRenderer.invoke("remotes:list") as Promise<RemoteHostView[]>,
+		add: (input: { label: string; url: string; password: string }) =>
+			ipcRenderer.invoke("remotes:add", input) as Promise<RemoteHealth>,
+		// An edit carries only what changed: an omitted password keeps the saved
+		// one, so a rotated credential is fixed without the renderer ever holding
+		// the old one.
+		update: (url: string, changes: { label?: string; url?: string; password?: string }) =>
+			ipcRenderer.invoke("remotes:update", url, changes) as Promise<RemoteHealth>,
+		remove: (url: string) => ipcRenderer.invoke("remotes:remove", url) as Promise<void>,
+		probe: (url: string) => ipcRenderer.invoke("remotes:probe", url) as Promise<RemoteHealth>,
+		request: (url: string, init: RemoteRequestInit) =>
+			ipcRenderer.invoke("remotes:request", url, init) as Promise<RemoteResponse>,
 	},
 	cloud: {
 		getSession: () => ipcRenderer.invoke("cloud:getSession") as Promise<CloudAccount | null>,

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -17,6 +17,7 @@ import {
 } from "./shared/tray";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { RemoteHostView } from "./main/remotes-ipc";
+import type { ConnectedHostView } from "./main/remote-registry";
 import type { RemoteHealth, RemoteRequestInit, RemoteResponse } from "./main/remote-request";
 import type {
 	EditorHandoffState,
@@ -510,6 +511,9 @@ const api = {
 		probe: (url: string) => ipcRenderer.invoke("remotes:probe", url) as Promise<RemoteHealth>,
 		request: (url: string, init: RemoteRequestInit) =>
 			ipcRenderer.invoke("remotes:request", url, init) as Promise<RemoteResponse>,
+		connect: (url: string) => ipcRenderer.invoke("remotes:connect", url) as Promise<ConnectedHostView>,
+		disconnect: (url: string) => ipcRenderer.invoke("remotes:disconnect", url) as Promise<void>,
+		connected: () => ipcRenderer.invoke("remotes:connected") as Promise<ConnectedHostView[]>,
 	},
 	cloud: {
 		getSession: () => ipcRenderer.invoke("cloud:getSession") as Promise<CloudAccount | null>,

--- a/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
@@ -39,6 +39,7 @@ describe("shell index route", () => {
 	it("renders the home page instead of redirecting to a scratch board when projects exist", async () => {
 		routeMocks.workspaces = [
 			{
+				host: "local",
 				id: "scratch",
 				name: "Scratch",
 				kind: "scratch",
@@ -55,16 +56,16 @@ describe("shell index route", () => {
 
 	it("opens a project from the recent-project list", async () => {
 		routeMocks.workspaces = [
-			{ id: "scratch", name: "Scratch", kind: "scratch", path: "/scratch", sessions: [] },
-			{ id: "proj-1", name: "Project One", kind: "single_repo", path: "/repo/project-one", sessions: [] },
+			{ host: "local", id: "scratch", name: "Scratch", kind: "scratch", path: "/scratch", sessions: [] },
+			{ host: "local", id: "proj-1", name: "Project One", kind: "single_repo", path: "/repo/project-one", sessions: [] },
 		];
 
 		render(<HomePage />);
 
 		fireEvent.click(screen.getByRole("button", { name: /Project One/ }));
 		expect(routeMocks.navigate).toHaveBeenCalledWith({
-			to: "/projects/$projectId",
-			params: { projectId: "proj-1" },
+			to: "/host/$hostId/project/$projectId",
+			params: { hostId: "local", projectId: "proj-1" },
 		});
 	});
 });

--- a/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
@@ -13,7 +13,10 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
 }));
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => ({ data: routeMocks.workspaces, isSuccess: true }),
+	useWorkspaceQuery: () => ({
+		data: [{ host: "local", label: "Local", status: "ready", workspaces: routeMocks.workspaces, failure: null }],
+		isSuccess: true,
+	}),
 }));
 
 vi.mock("../components/BoardEmptyStates", () => ({

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -271,7 +271,7 @@ describe("global board first launch", () => {
 describe("project board with no sessions", () => {
 	it("shows the task invitation instead of empty columns", async () => {
 		respondWith([project], []);
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		expect(await screen.findByText("No worker sessions yet")).toBeInTheDocument();
 		// Board header + empty state each offer the pair; the orchestrator is primary in both.
@@ -284,7 +284,7 @@ describe("project board with no sessions", () => {
 	it("surfaces the daemon error when spawning the orchestrator fails", async () => {
 		respondWith([project], []);
 		spawnOrchestratorMock.mockRejectedValue(new Error("branch is already checked out in another worktree"));
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		await screen.findByText("No worker sessions yet");
 		const [spawnButton] = screen.getAllByRole("button", { name: "Spawn Orchestrator" });
@@ -299,7 +299,7 @@ describe("project board with no sessions", () => {
 			code: "CHAT_DRIVER_UNAVAILABLE",
 		});
 		spawnOrchestratorMock.mockRejectedValueOnce(preflightError).mockResolvedValueOnce("proj-1-orchestrator");
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		await screen.findByText("No worker sessions yet");
 		const [spawnButton] = screen.getAllByRole("button", { name: "Spawn Orchestrator" });
@@ -313,13 +313,13 @@ describe("project board with no sessions", () => {
 	it("opens project settings instead of spawning when no orchestrator agent is configured", async () => {
 		const unconfiguredProject = { ...project, orchestratorAgent: undefined };
 		respondWith([unconfiguredProject], []);
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		await screen.findByText("No worker sessions yet");
 		const [spawnButton] = screen.getAllByRole("button", { name: "Spawn Orchestrator" });
 		await userEvent.click(spawnButton);
 
-		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", project: { host: "local", id: "proj-1" } });
 		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnOrchestratorMock).not.toHaveBeenCalled();
 	});
@@ -332,7 +332,7 @@ describe("project board with no sessions", () => {
 				"proj-1",
 				"Project added, but orchestrator did not start: branch is already checked out in another worktree",
 			);
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		expect(await screen.findByText(/Project added, but orchestrator did not start/)).toBeInTheDocument();
 		expect(screen.getByText(/branch is already checked out/)).toBeInTheDocument();
@@ -347,7 +347,7 @@ describe("project board with no sessions", () => {
 				"Project added, but orchestrator did not start: branch is already checked out in another worktree",
 			);
 		spawnOrchestratorMock.mockResolvedValue("proj-1-orchestrator");
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		await screen.findByText(/Project added, but orchestrator did not start/);
 		const [spawnButton] = screen.getAllByRole("button", { name: "Spawn Orchestrator" });
@@ -368,13 +368,13 @@ describe("project board with no sessions", () => {
 				"proj-1",
 				"Project added, but orchestrator did not start: branch is already checked out in another worktree",
 			);
-		const { rerender } = renderBoard(<SessionsBoard projectId="proj-1" />);
+		const { rerender } = renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		await screen.findByText(/Project added, but orchestrator did not start/);
 		rerender(
 			<QueryClientProvider client={lastQueryClient!}>
 				<ShellProvider value={lastShell!}>
-					<SessionsBoard projectId="proj-2" />
+					<SessionsBoard project={{ host: "local", id: "proj-2" }} />
 				</ShellProvider>
 			</QueryClientProvider>,
 		);
@@ -392,7 +392,7 @@ describe("project board with no sessions", () => {
 				"proj-1",
 				"Project added, but orchestrator did not start: branch is already checked out in another worktree",
 			);
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		await screen.findByText("No worker sessions yet");
 		await waitFor(() => expect(useUiStore.getState().orchestratorStartupErrors["proj-1"]).toBeUndefined());
@@ -403,7 +403,7 @@ describe("project board with no sessions", () => {
 		const otherProject: Project = { id: "proj-2", name: "other-app", path: "/repo/other-app" };
 		respondWith([project, otherProject], []);
 		spawnOrchestratorMock.mockRejectedValue(new Error("branch is already checked out in another worktree"));
-		const { rerender } = renderBoard(<SessionsBoard projectId="proj-1" />);
+		const { rerender } = renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		await screen.findByText("No worker sessions yet");
 		const [spawnButton] = screen.getAllByRole("button", { name: "Spawn Orchestrator" });
@@ -413,7 +413,7 @@ describe("project board with no sessions", () => {
 		rerender(
 			<QueryClientProvider client={lastQueryClient!}>
 				<ShellProvider value={lastShell!}>
-					<SessionsBoard projectId="proj-2" />
+					<SessionsBoard project={{ host: "local", id: "proj-2" }} />
 				</ShellProvider>
 			</QueryClientProvider>,
 		);
@@ -423,7 +423,7 @@ describe("project board with no sessions", () => {
 
 	it("keeps the columns once the project has a session", async () => {
 		respondWith([project], [workerSession]);
-		renderBoard(<SessionsBoard projectId="proj-1" />);
+		renderBoard(<SessionsBoard project={{ host: "local", id: "proj-1" }} />);
 
 		expect(await screen.findByText("fix the bug")).toBeInTheDocument();
 		expect(screen.queryByText("No worker sessions yet")).not.toBeInTheDocument();

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -36,6 +36,21 @@ vi.mock("../../lib/api-client", () => ({
 	hasTrustedApiBaseUrl: () => true,
 }));
 
+// The workspace query fans out over hosts now; with the flag off that is a loop
+// of one, and clientFor(LOCAL_HOST) is the client apiClient already was.
+vi.mock("../../lib/host-clients", () => ({
+	clientFor: () => ({ GET: getMock, POST: vi.fn() }),
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
+	hostLabelFor: (host: string) => host,
+	isHostReady: () => true,
+	subscribeConnectedHosts: () => () => undefined,
+}));
+
 vi.mock("../../lib/bridge", () => ({
 	aoBridge: {
 		app: { chooseDirectory: chooseDirectoryMock },

--- a/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
@@ -19,6 +19,21 @@ vi.mock("../../lib/api-client", () => ({
 	hasTrustedApiBaseUrl: () => true,
 }));
 
+// The workspace query fans out over hosts now; with the flag off that is a loop
+// of one, and clientFor(LOCAL_HOST) is the client apiClient already was.
+vi.mock("../../lib/host-clients", () => ({
+	clientFor: () => ({ GET: getMock, POST: vi.fn() }),
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
+	hostLabelFor: (host: string) => host,
+	isHostReady: () => true,
+	subscribeConnectedHosts: () => () => undefined,
+}));
+
 vi.mock("@tanstack/react-router", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@tanstack/react-router")>();
 	return { ...actual, useNavigate: () => navigateMock };

--- a/frontend/src/renderer/components/AgentModelPicker.tsx
+++ b/frontend/src/renderer/components/AgentModelPicker.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { refKey, type Ref } from "../lib/hosts";
 import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,7 +16,7 @@ import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
 type AgentModelPickerProps = {
 	agentId: string;
 	agentLabel: string;
-	projectId: string;
+	project: Ref;
 	value: string;
 	mode: string;
 	disabled?: boolean;
@@ -27,7 +28,7 @@ type AgentModelPickerProps = {
 export function AgentModelPicker({
 	agentId,
 	agentLabel,
-	projectId,
+	project,
 	value,
 	mode,
 	disabled = false,
@@ -38,20 +39,20 @@ export function AgentModelPicker({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [customAgentId, setCustomAgentId] = useState<string | null>(null);
-	const query = useQuery(agentModelsQueryOptions(agentId, projectId));
+	const query = useQuery(agentModelsQueryOptions(agentId, project));
 	const catalog: AgentModelCatalog | undefined = query.data;
 	const revalidationQuery = useQuery({
-		queryKey: ["agent-model-revalidation", agentId, projectId, catalog?.validatedAt ?? ""],
-		queryFn: () => revalidateAgentModels(agentId, projectId),
+		queryKey: ["agent-model-revalidation", agentId, refKey(project), catalog?.validatedAt ?? ""],
+		queryFn: () => revalidateAgentModels(agentId, project),
 		enabled: agentId !== "" && catalog?.refreshRecommended === true,
 		staleTime: Number.POSITIVE_INFINITY,
 		retry: false,
 	});
 	useEffect(() => {
 		if (revalidationQuery.data) {
-			queryClient.setQueryData(agentModelsQueryKey(agentId, projectId), revalidationQuery.data);
+			queryClient.setQueryData(agentModelsQueryKey(agentId, project), revalidationQuery.data);
 		}
-	}, [agentId, projectId, queryClient, revalidationQuery.data]);
+	}, [agentId, project, queryClient, revalidationQuery.data]);
 	const warning =
 		(revalidationQuery.isError
 			? revalidationQuery.error instanceof Error

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -95,6 +95,7 @@ vi.mock("../hooks/useBrowserView", () => ({
 }));
 
 const session: WorkspaceSession = {
+	host: "local",
 	id: "sess-1",
 	workspaceId: "ws-1",
 	workspaceName: "my-app",

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -128,6 +128,7 @@ const worker = {
 	updatedAt: "2026-06-10T00:00:00Z",
 	activity: { state: "active", lastActivityAt: "2026-06-10T00:00:00Z" },
 	prs: [],
+	host: "local",
 } satisfies WorkspaceSession;
 
 function switchRecord(overrides: Partial<AgentSwitch> = {}): AgentSwitch {
@@ -291,6 +292,7 @@ describe("CenterPane toolbar session label", () => {
 			...worker,
 			provider: "codex",
 			terminalHandleId: "settled-target-terminal",
+			host: "local",
 		} satisfies WorkspaceSession;
 		agentSwitchMocks.switches.push(switchRecord({ state: "completed" }));
 		agentSwitchMocks.mutation.input = {
@@ -392,6 +394,7 @@ describe("CenterPane toolbar session label", () => {
 			...worker,
 			activeAgentSwitch: requestedSwitch,
 			activity: { state: "waiting_input", lastActivityAt: "2026-06-10T00:00:02Z" },
+			host: "local",
 		} satisfies WorkspaceSession;
 		const view = renderCenterPane({
 			onSelectSessionTerminal,

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -174,6 +174,7 @@ beforeEach(() => {
 describe("CenterPane toolbar session label", () => {
 	const makeShells = (count: number) =>
 		Array.from({ length: count }, (_, i) => ({
+			host: "local",
 			handleId: `h-${i}`,
 			title: `agent-orchestrator-${i}`,
 			workingDir: "/tmp/ws",
@@ -374,7 +375,7 @@ describe("CenterPane toolbar session label", () => {
 			onSelectSessionTerminal,
 			session: { ...worker, activeAgentSwitch: activeSwitch },
 			shellTerminals: [shell],
-			terminalTarget: { generation: shell.createdAt, kind: "shell", handleId: shell.handleId, title: shell.title },
+			terminalTarget: { generation: shell.createdAt, host: "local", kind: "shell", handleId: shell.handleId, session: { host: "local", id: worker.id }, title: shell.title },
 		});
 
 		expect(screen.getByTestId("terminal-interaction-surface")).not.toHaveAttribute("inert");
@@ -400,7 +401,7 @@ describe("CenterPane toolbar session label", () => {
 			onSelectSessionTerminal,
 			session: sourceSession,
 			shellTerminals: [shell],
-			terminalTarget: { generation: shell.createdAt, kind: "shell", handleId: shell.handleId, title: shell.title },
+			terminalTarget: { generation: shell.createdAt, host: "local", kind: "shell", handleId: shell.handleId, session: { host: "local", id: worker.id }, title: shell.title },
 		});
 
 		expect(onSelectSessionTerminal).toHaveBeenCalledOnce();
@@ -605,6 +606,7 @@ describe("CenterPane toolbar session label", () => {
 			shellTerminals: [shell],
 			terminalTarget: {
 				generation: shell.createdAt,
+				host: "local",
 				kind: "shell",
 				handleId: shell.handleId,
 				title: shell.title,
@@ -657,6 +659,7 @@ describe("CenterPane toolbar session label", () => {
 			shellTerminals: [shell],
 			terminalTarget: {
 				generation: shell.createdAt,
+				host: "local",
 				kind: "shell",
 				handleId: shell.handleId,
 				title: shell.title,
@@ -691,7 +694,7 @@ describe("CenterPane toolbar session label", () => {
 		renderCenterPane({
 			session: worker,
 			shellTerminals: [shell],
-			terminalTarget: { generation: shell.createdAt, kind: "shell", handleId: shell.handleId, title: shell.title },
+			terminalTarget: { generation: shell.createdAt, host: "local", kind: "shell", handleId: shell.handleId, session: { host: "local", id: worker.id }, title: shell.title },
 			onSelectSessionTerminal,
 		});
 
@@ -706,6 +709,7 @@ describe("CenterPane toolbar session label", () => {
 			shellTerminals: [shell],
 			terminalTarget: {
 				generation: shell.createdAt,
+				host: "local",
 				kind: "shell",
 				handleId: shell.handleId,
 				title: shell.title,
@@ -724,7 +728,7 @@ describe("CenterPane toolbar session label", () => {
 			session: worker,
 			reviewerTerminal: { handleId: "review-sess-1", harness: "codex" },
 			shellTerminals: [shell],
-			terminalTarget: { kind: "reviewer", handleId: "review-sess-1", harness: "codex", sessionId: worker.id },
+			terminalTarget: { kind: "reviewer", handleId: "review-sess-1", harness: "codex", session: { host: "local", id: worker.id } },
 		});
 
 		const reviewerTab = screen.getByRole("tab", { name: "Reviewer" });
@@ -1041,6 +1045,7 @@ describe("CenterPane toolbar session label", () => {
 					terminalTarget={{
 						generation: shell.createdAt,
 						handleId: shell.handleId,
+						host: "local",
 						kind: "shell",
 						title: shell.title,
 					}}

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -202,7 +202,7 @@ export function CenterPane({
 		showRightFade,
 	} = useTabScrollEdges([tabOverflowWatch]);
 	const previousTabCountRef = useRef(availableAuxiliaryKeys.length);
-	const agentSwitchesQuery = useAgentSwitches(session?.id ?? "");
+	const agentSwitchesQuery = useAgentSwitches(session);
 	const agentSwitches = agentSwitchesQuery.data ?? [];
 	const switchMutation = useSwitchAgentState(session?.id ?? "");
 	const mountedSessionIdRef = useRef(session?.id);

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -91,7 +91,7 @@ const ctx = vi.hoisted(() => {
 		},
 	];
 	return {
-		params: {} as { projectId?: string; sessionId?: string },
+		params: {} as { hostId?: string; projectId?: string; sessionId?: string },
 		enabled: true,
 		workspaces,
 	};
@@ -172,13 +172,13 @@ function StubNestedLayer() {
 
 vi.mock("./TaskComposer", () => ({
 	TaskComposer: (props: {
-		projectId?: string;
+		project?: { host: string; id: string };
 		onCreated: (id: string) => void;
 		onDirtyChange?: (dirty: boolean) => void;
 		onSubmittingChange?: (submitting: boolean) => void;
 	}) => (
 		<div data-testid="task-composer">
-			<span>composer {props.projectId}</span>
+			<span>composer {props.project?.id}</span>
 			<StubNestedLayer />
 			<button type="button" onClick={() => props.onDirtyChange?.(true)}>
 				stub-dirty
@@ -394,8 +394,8 @@ describe("CommandPalette drill-in + Enter", () => {
 		fireEvent.keyDown(actionsInput, { key: "Enter" });
 
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "w-merge" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "w-merge" },
 		});
 		await waitFor(() => expect(paletteInput()).toBeNull());
 	});
@@ -415,7 +415,7 @@ describe("CommandPalette drill-in + Enter", () => {
 		});
 		fireEvent.keyDown(input, { key: "Enter" });
 
-		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/host/$hostId/project/$projectId", params: { hostId: "local", projectId: "proj-1" } });
 	});
 
 	it("jumps to an archived (terminated) session via search + Enter", async () => {
@@ -475,8 +475,8 @@ describe("CommandPalette drill-in + Enter", () => {
 		await waitFor(() => expect(restoreMock).toHaveBeenCalledWith("w-archived"));
 		await waitFor(() =>
 			expect(navigateMock).toHaveBeenCalledWith({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId: "proj-1", sessionId: "w-archived" },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: "local", sessionId: "w-archived" },
 			}),
 		);
 		await waitFor(() => expect(paletteInput()).toBeNull());
@@ -557,7 +557,7 @@ describe("CommandPalette actions", () => {
 		await screen.findByPlaceholderText(/search projects/i);
 		fireEvent.click(screen.getByText("Open orchestrator"));
 
-		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-2" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", project: { host: "local", id: "proj-2" } });
 		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnMock).not.toHaveBeenCalled();
 		await waitFor(() => expect(paletteInput()).toBeNull());
@@ -569,7 +569,7 @@ describe("CommandPalette actions", () => {
 		act(() => useUiStore.getState().setCommandPaletteOpen(true));
 		await screen.findByPlaceholderText(/search projects/i);
 		fireEvent.click(screen.getByText("lib"));
-		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-2" } });
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/host/$hostId/project/$projectId", params: { hostId: "local", projectId: "proj-2" } });
 		await waitFor(() => expect(paletteInput()).toBeNull());
 	});
 
@@ -950,8 +950,8 @@ describe("CommandPalette inline task composer", () => {
 		fireEvent.click(screen.getByText("stub-create"));
 		await waitFor(() =>
 			expect(navigateMock).toHaveBeenCalledWith({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId: "proj-1", sessionId: "new-session" },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: "local", sessionId: "new-session" },
 			}),
 		);
 		await waitFor(() => expect(paletteInput()).toBeNull());
@@ -991,9 +991,55 @@ describe("CommandPalette inline task composer", () => {
 		fireEvent.click(screen.getByText("stub-create"));
 		await waitFor(() =>
 			expect(navigateMock).toHaveBeenCalledWith({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId: "proj-1", sessionId: "new-session" },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: "local", sessionId: "new-session" },
 			}),
 		);
+	});
+});
+
+describe("CommandPalette across hosts", () => {
+	// A second host running the same project: session ids repeat across hosts, so
+	// the palette must scope the route's session to the route's host.
+	beforeEach(() => {
+		ctx.workspaces.push({
+			host: "remote",
+			id: "proj-1",
+			name: "app",
+			path: "/repos/app",
+			type: "main",
+			orchestratorAgent: "codex",
+			sessions: [
+				{
+					host: "remote",
+					id: "w-merge",
+					workspaceId: "proj-1",
+					workspaceName: "app",
+					title: "remote banner",
+					provider: "codex",
+					kind: "worker",
+					branch: "feature/remote-banner",
+					status: "mergeable",
+					updatedAt: "2026-06-10T00:00:00Z",
+					prs: [],
+				},
+			],
+		});
+	});
+
+	afterEach(() => {
+		ctx.workspaces.length = 2;
+	});
+
+	it("copies the branch of the session on the route's host", async () => {
+		ctx.params = { hostId: "remote", sessionId: "w-merge" };
+		renderPalette();
+		act(() => useUiStore.getState().setCommandPaletteOpen(true));
+		const input = await screen.findByPlaceholderText(/search projects/i);
+
+		fireEvent.change(input, { target: { value: "copy branch" } });
+
+		await waitFor(() => expect(screen.getByText("feature/remote-banner")).toBeInTheDocument());
+		expect(screen.queryByText("feature/ship")).toBeNull();
 	});
 });

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -110,7 +110,7 @@ vi.mock("../hooks/useCommandPaletteEnabled", () => ({
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceQuery: (options: { subscribed?: boolean }) => {
 		workspaceSubscriptionMock(options);
-		return { data: ctx.workspaces };
+		return { data: [{ host: "local", label: "Local", status: "ready", workspaces: ctx.workspaces, failure: null }] };
 	},
 	workspaceQueryKey: ["workspaces"],
 }));
@@ -140,7 +140,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -19,6 +19,7 @@ const workspaceSubscriptionMock = vi.hoisted(() => vi.fn());
 const ctx = vi.hoisted(() => {
 	const workspaces: WorkspaceSummary[] = [
 		{
+			host: "local",
 			id: "proj-1",
 			name: "app",
 			path: "/repos/app",
@@ -26,6 +27,7 @@ const ctx = vi.hoisted(() => {
 			orchestratorAgent: "codex",
 			sessions: [
 				{
+					host: "local",
 					id: "w-merge",
 					workspaceId: "proj-1",
 					workspaceName: "app",
@@ -38,6 +40,7 @@ const ctx = vi.hoisted(() => {
 					prs: [],
 				},
 				{
+					host: "local",
 					id: "w-fix",
 					workspaceId: "proj-1",
 					workspaceName: "app",
@@ -50,6 +53,7 @@ const ctx = vi.hoisted(() => {
 					prs: [],
 				},
 				{
+					host: "local",
 					id: "w-archived",
 					workspaceId: "proj-1",
 					workspaceName: "app",
@@ -62,6 +66,7 @@ const ctx = vi.hoisted(() => {
 					prs: [],
 				},
 				{
+					host: "local",
 					id: "orch",
 					workspaceId: "proj-1",
 					workspaceName: "app",
@@ -76,6 +81,7 @@ const ctx = vi.hoisted(() => {
 			],
 		},
 		{
+			host: "local",
 			id: "proj-2",
 			name: "lib",
 			path: "/repos/lib",
@@ -129,6 +135,19 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({
+		GET: getMock,
+		POST: postMock,
+	}),
+}));
 
 vi.mock("../lib/bridge", () => ({
 	aoBridge: {

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -32,7 +32,7 @@ import { CreateProjectFlow } from "./CreateProjectFlow";
 import { TaskComposer } from "./TaskComposer";
 import { CommandDialog, CommandEmpty, CommandFooter, CommandGroup, CommandInput, CommandItem, CommandList } from "./ui/command";
 
-import type { Ref } from "../lib/hosts";
+import { LOCAL_HOST, type Ref } from "../lib/hosts";
 const PALETTE_REVIEW_STALE_TIME_MS = 60_000;
 type PaletteView =
 	| { mode: "root" }
@@ -51,7 +51,8 @@ export function CommandPalette() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const restoreSessionById = useRestoreSession();
-	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
+	const params = useParams({ strict: false }) as { hostId?: string; projectId?: string; sessionId?: string };
+	const routeHost = params.hostId ?? LOCAL_HOST;
 	const { cloneProject, createProject, initializeProjectRepository } = useShell();
 	const resolvedTheme = useUiStore((s) => s.resolvedTheme);
 	const setThemePreference = useUiStore((s) => s.setThemePreference);
@@ -79,7 +80,9 @@ export function CommandPalette() {
 	viewRef.current = view;
 	const closeResetTimerRef = useRef<number | null>(null);
 
-	const currentSession = params.sessionId ? findSession(workspaces, params.sessionId)?.session : undefined;
+	const currentSession = params.sessionId
+		? findSession(workspaces, { host: routeHost, id: params.sessionId })?.session
+		: undefined;
 	const currentProjectId = currentSession?.workspaceId ?? params.projectId;
 
 	const sessionsWithOpenPRs = useMemo(
@@ -135,15 +138,16 @@ export function CommandPalette() {
 		() =>
 			buildCommands({
 				workspaces,
+				currentHostId: routeHost,
 				currentProjectId,
 				currentSessionId: params.sessionId,
 				restartingProjectIds,
 				reviewStatesBySessionId: reviewStatesSnapshot,
 			}, t),
-		[workspaces, currentProjectId, params.sessionId, restartingProjectIds, reviewStatesSnapshot, t, i18n.resolvedLanguage],
+		[workspaces, routeHost, currentProjectId, params.sessionId, restartingProjectIds, reviewStatesSnapshot, t, i18n.resolvedLanguage],
 	);
 	const scoped = useMemo(
-		() => (view.mode === "session-actions" ? findSession(workspaces, view.session.id) : undefined),
+		() => (view.mode === "session-actions" ? findSession(workspaces, view.session) : undefined),
 		[view, workspaces],
 	);
 	const sessionActionItems = useMemo(

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -24,7 +24,7 @@ import { isMacPlatform } from "../lib/platform";
 import { sessionReviewsQueryOptions, type PRReviewState } from "../lib/session-reviews";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { useShell } from "../lib/shell-context";
-import { findProjectOrchestrator, hasConfiguredOrchestratorAgent, openPRs, workerSessions } from "../types/workspace";
+import { flattenHostSections, findProjectOrchestrator, hasConfiguredOrchestratorAgent, openPRs, workerSessions } from "../types/workspace";
 import { useUiStore } from "../stores/ui-store";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
 import { Button } from "./ui/button";
@@ -62,7 +62,7 @@ export function CommandPalette() {
 	// The palette stays mounted to preserve its close animation and global
 	// shortcut. While closed, commands are invisible, so retain the cached
 	// snapshot without subscribing this hidden surface to streamed updates.
-	const workspaces = useWorkspaceQuery({ subscribed: isOpen }).data ?? [];
+	const workspaces = flattenHostSections(useWorkspaceQuery({ subscribed: isOpen }).data);
 
 	const [view, setView] = useState<PaletteView>({ mode: "root" });
 	const [query, setQuery] = useState("");

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -32,11 +32,12 @@ import { CreateProjectFlow } from "./CreateProjectFlow";
 import { TaskComposer } from "./TaskComposer";
 import { CommandDialog, CommandEmpty, CommandFooter, CommandGroup, CommandInput, CommandItem, CommandList } from "./ui/command";
 
+import type { Ref } from "../lib/hosts";
 const PALETTE_REVIEW_STALE_TIME_MS = 60_000;
 type PaletteView =
 	| { mode: "root" }
-	| { mode: "session-actions"; sessionId: string }
-	| { mode: "new-task"; projectId: string };
+	| { mode: "session-actions"; session: Ref }
+	| { mode: "new-task"; project: Ref };
 
 function terminalHasFocus(): boolean {
 	if (typeof document === "undefined") return false;
@@ -142,7 +143,7 @@ export function CommandPalette() {
 		[workspaces, currentProjectId, params.sessionId, restartingProjectIds, reviewStatesSnapshot, t, i18n.resolvedLanguage],
 	);
 	const scoped = useMemo(
-		() => (view.mode === "session-actions" ? findSession(workspaces, view.sessionId) : undefined),
+		() => (view.mode === "session-actions" ? findSession(workspaces, view.session.id) : undefined),
 		[view, workspaces],
 	);
 	const sessionActionItems = useMemo(
@@ -279,13 +280,13 @@ export function CommandPalette() {
 					// Modal — do not route to /settings (that legacy path redirects home).
 					useUiStore.getState().openGlobalSettings();
 					break;
-				case "/projects/$projectId":
+				case "/host/$hostId/project/$projectId":
 					void navigate({ to: target.to, params: target.params });
 					break;
-				case "/projects/$projectId/settings":
-					useUiStore.getState().openProjectSettings(target.params.projectId);
+				case "/host/$hostId/project/$projectId/settings":
+					useUiStore.getState().openProjectSettings({ host: target.params.hostId, id: target.params.projectId });
 					break;
-				case "/projects/$projectId/sessions/$sessionId":
+				case "/host/$hostId/session/$sessionId":
 					void navigate({ to: target.to, params: target.params });
 					break;
 			}
@@ -300,38 +301,46 @@ export function CommandPalette() {
 	}, [t]);
 
 	const openOrchestrator = useCallback(
-		async (projectId: string) => {
-			if (blockedByRestart(projectId)) return;
-			const orchestrator = findProjectOrchestrator(workspaces, projectId);
+		async (project: Ref) => {
+			if (blockedByRestart(project.id)) return;
+			const orchestrator = findProjectOrchestrator(workspaces, project);
 			if (orchestrator) {
 				navigateToTarget({
-					to: "/projects/$projectId/sessions/$sessionId",
-					params: { projectId, sessionId: orchestrator.id },
+					to: "/host/$hostId/session/$sessionId",
+					params: { hostId: orchestrator.host, sessionId: orchestrator.id },
 				});
 				closePalette();
 				return;
 			}
-			const workspace = workspaces.find((candidate) => candidate.id === projectId);
+			const workspace = workspaces.find(
+				(candidate) => candidate.host === project.host && candidate.id === project.id,
+			);
 			// Cloud projects carry no local orchestrator-agent config; spawn the
 			// orchestrator as a cloud session in its own sandbox instead of falling
 			// through to the project-settings page.
 			if (workspace?.kind === "cloud") {
-				const sessionId = await spawnCloudOrchestrator(queryClient, projectId);
+				const sessionId = await spawnCloudOrchestrator(queryClient, project.id);
 				await queryClient.invalidateQueries({ queryKey: cloudSessionsQueryKey });
-				navigateToTarget({ to: "/projects/$projectId/sessions/$sessionId", params: { projectId, sessionId } });
+				navigateToTarget({
+					to: "/host/$hostId/session/$sessionId",
+					params: { hostId: project.host, sessionId },
+				});
 				closePalette();
 				return;
 			}
 			if (!hasConfiguredOrchestratorAgent(workspace)) {
 				if (workspace) {
-					navigateToTarget({ to: "/projects/$projectId/settings", params: { projectId } });
+					navigateToTarget({
+						to: "/host/$hostId/project/$projectId/settings",
+						params: { hostId: project.host, projectId: project.id },
+					});
 					closePalette();
 				}
 				return;
 			}
-			const sessionId = await spawnOrchestrator(projectId, "command_palette");
+			const sessionId = await spawnOrchestrator(project.id, "command_palette");
 			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			navigateToTarget({ to: "/projects/$projectId/sessions/$sessionId", params: { projectId, sessionId } });
+			navigateToTarget({ to: "/host/$hostId/session/$sessionId", params: { hostId: project.host, sessionId } });
 			closePalette();
 		},
 		[workspaces, navigateToTarget, queryClient, closePalette, blockedByRestart],
@@ -389,32 +398,32 @@ export function CommandPalette() {
 					break;
 				}
 				case "open-session-actions":
-					pushView({ mode: "session-actions", sessionId: action.sessionId });
+					pushView({ mode: "session-actions", session: action.session });
 					break;
 				case "resume-session": {
-					const message = await resumeSession(action.sessionId);
+					const message = await resumeSession(action.session.id);
 					if (!isCurrentRun()) break;
 					if (message) {
 						setError(message);
 						break;
 					}
 					navigateToTarget({
-						to: "/projects/$projectId/sessions/$sessionId",
-						params: { projectId: action.projectId, sessionId: action.sessionId },
+						to: "/host/$hostId/session/$sessionId",
+						params: { hostId: action.session.host, sessionId: action.session.id },
 					});
 						closePalette();
 						break;
 					}
 					case "open-new-task":
-						if (blockedByRestart(action.projectId)) break;
-						pushView({ mode: "new-task", projectId: action.projectId });
+						if (blockedByRestart(action.project.id)) break;
+						pushView({ mode: "new-task", project: action.project });
 						break;
 					case "open-new-project":
 						closePalette();
 						choosePathRef.current?.();
 						break;
 					case "open-orchestrator":
-							await openOrchestrator(action.projectId);
+							await openOrchestrator(action.project);
 							break;
 				}
 			} catch (err) {
@@ -437,12 +446,12 @@ export function CommandPalette() {
 	);
 
 	const handleTaskCreated = useCallback(
-		async (projectId: string, sessionId: string) => {
+		async (project: Ref, sessionId: string) => {
 			closePalette();
 			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: project.host, sessionId },
 			});
 		},
 		[navigate, queryClient, closePalette],
@@ -551,11 +560,11 @@ export function CommandPalette() {
 							</div>
 						)}
 						<TaskComposer
-							projectId={view.projectId}
+							project={view.project}
 							autoFocusTitle
 							onDirtyChange={onComposerDirtyChange}
 							onSubmittingChange={onComposerSubmittingChange}
-							onCreated={(sessionId) => void handleTaskCreated(view.projectId, sessionId)}
+							onCreated={(sessionId) => void handleTaskCreated(view.project, sessionId)}
 						/>
 					</div>
 				) : (

--- a/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
+++ b/frontend/src/renderer/components/DiffSelectionMenu.test.tsx
@@ -14,6 +14,21 @@ vi.mock("../lib/api-client", () => ({
 			: fallback,
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ POST: postMock }),
+}));
+
 const writeTextMock = vi.hoisted(() => vi.fn());
 
 const SAMPLE_LINES: DiffSelectionLine[] = [

--- a/frontend/src/renderer/components/FileContentPane.test.tsx
+++ b/frontend/src/renderer/components/FileContentPane.test.tsx
@@ -17,6 +17,8 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+
+vi.mock("../lib/host-clients", () => ({ clientFor: () => ({ GET: getMock }) }));
 function renderWithQuery(children: ReactNode) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(<QueryClientProvider client={client}>{children}</QueryClientProvider>);

--- a/frontend/src/renderer/components/FileTree.test.tsx
+++ b/frontend/src/renderer/components/FileTree.test.tsx
@@ -16,6 +16,8 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+
+vi.mock("../lib/host-clients", () => ({ clientFor: () => ({ GET: getMock }) }));
 function renderWithQuery(children: ReactNode) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	const view = render(<QueryClientProvider client={client}>{children}</QueryClientProvider>);

--- a/frontend/src/renderer/components/GlobalNewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/GlobalNewTaskDialog.test.tsx
@@ -17,18 +17,18 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("./NewTaskDialog", () => ({
 	NewTaskDialog: ({
 		open,
-		projectId,
+		project,
 		onCreated,
 		onOpenChange,
 	}: {
 		open: boolean;
-		projectId?: string;
+		project?: { host: string; id: string };
 		onCreated: (id: string) => void;
 		onOpenChange: (open: boolean) => void;
 	}) => {
 		const [draft, setDraft] = useState("");
 		return open ? (
-			<div data-testid="new-task-dialog" data-project={projectId}>
+			<div data-testid="new-task-dialog" data-project={project?.id}>
 				<label>
 					task
 					<input aria-label="task" value={draft} onChange={(event) => setDraft(event.currentTarget.value)} />
@@ -73,7 +73,7 @@ describe("GlobalNewTaskDialog", () => {
 		renderDialog();
 
 		act(() => {
-			useUiStore.getState().requestNewTask("proj-7");
+			useUiStore.getState().requestNewTask({ host: "local", id: "proj-7" });
 		});
 
 		const dialog = await screen.findByTestId("new-task-dialog");
@@ -81,8 +81,8 @@ describe("GlobalNewTaskDialog", () => {
 
 		await user.click(screen.getByRole("button", { name: "create" }));
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-7", sessionId: "sess-9" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-9" },
 		});
 	});
 
@@ -91,7 +91,7 @@ describe("GlobalNewTaskDialog", () => {
 		renderDialog();
 
 		act(() => {
-			useUiStore.getState().requestNewTask("proj-7");
+			useUiStore.getState().requestNewTask({ host: "local", id: "proj-7" });
 		});
 		await screen.findByTestId("new-task-dialog");
 
@@ -99,7 +99,7 @@ describe("GlobalNewTaskDialog", () => {
 		expect(screen.queryByTestId("new-task-dialog")).not.toBeInTheDocument();
 
 		act(() => {
-			useUiStore.getState().requestNewTask("proj-7");
+			useUiStore.getState().requestNewTask({ host: "local", id: "proj-7" });
 		});
 		expect(await screen.findByTestId("new-task-dialog")).toHaveAttribute("data-project", "proj-7");
 	});
@@ -109,13 +109,13 @@ describe("GlobalNewTaskDialog", () => {
 		renderDialog();
 
 		act(() => {
-			useUiStore.getState().requestNewTask("proj-7");
+			useUiStore.getState().requestNewTask({ host: "local", id: "proj-7" });
 		});
 		const dialog = await screen.findByTestId("new-task-dialog");
 		await user.type(screen.getByRole("textbox", { name: "task" }), "keep this draft");
 
 		act(() => {
-			useUiStore.getState().requestNewTask("proj-8");
+			useUiStore.getState().requestNewTask({ host: "local", id: "proj-8" });
 		});
 		expect(dialog).toHaveAttribute("data-project", "proj-7");
 		expect(screen.getByRole("textbox", { name: "task" })).toHaveValue("keep this draft");
@@ -124,7 +124,7 @@ describe("GlobalNewTaskDialog", () => {
 		expect(screen.queryByTestId("new-task-dialog")).not.toBeInTheDocument();
 
 		act(() => {
-			useUiStore.getState().requestNewTask("proj-8");
+			useUiStore.getState().requestNewTask({ host: "local", id: "proj-8" });
 		});
 		expect(await screen.findByTestId("new-task-dialog")).toHaveAttribute("data-project", "proj-8");
 	});

--- a/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
+++ b/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
@@ -5,6 +5,7 @@ import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useUiStore } from "../stores/ui-store";
 import { NewTaskDialog } from "./NewTaskDialog";
 
+import type { Ref } from "../lib/hosts";
 // App-level New Task surface. Lives in the shell (always mounted, on every
 // route and platform, unlike ShellTopbar which unmounts on Linux boards) so a
 // ⌘N / Ctrl+Shift+N shortcut or the sidebar "New session" item can open a
@@ -16,7 +17,7 @@ export function GlobalNewTaskDialog() {
 	const queryClient = useQueryClient();
 	const newTaskRequest = useUiStore((state) => state.newTaskRequest);
 	const [open, setOpen] = useState(false);
-	const [projectId, setProjectId] = useState<string | undefined>(undefined);
+	const [project, setProject] = useState<Ref | undefined>(undefined);
 	const lastNonce = useRef(0);
 
 	useEffect(() => {
@@ -26,23 +27,23 @@ export function GlobalNewTaskDialog() {
 		// particular, do not retarget a populated form to another project, and do
 		// not replay the ignored request when the user later closes the dialog.
 		if (open) return;
-		setProjectId(newTaskRequest.projectId);
+		setProject(newTaskRequest.project);
 		setOpen(true);
 	}, [newTaskRequest, open]);
 
 	const handleCreated = async (sessionId: string) => {
-		if (!projectId) return;
+		if (!project) return;
 		await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 		void navigate({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId, sessionId },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: project.host, sessionId },
 		});
 	};
 
 	return (
 		<NewTaskDialog
 			open={open}
-			projectId={projectId}
+			project={project}
 			onCreated={(sessionId) => void handleCreated(sessionId)}
 			onOpenChange={setOpen}
 		/>

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -162,7 +162,7 @@ beforeEach(async () => {
 		saving: false,
 		saveError: false,
 	});
-	useUiStore.setState({ developerMode: false });
+	useUiStore.setState({ developerMode: false, remoteHosts: false });
 	document.documentElement.lang = "en";
 });
 
@@ -195,6 +195,21 @@ describe("GlobalSettingsForm", () => {
 		expect(window.localStorage.getItem("ao.developerMode")).toBe("true");
 		await user.click(screen.getByLabelText("Updates channel"));
 		expect(await screen.findByRole("menuitem", { name: "Feature Releases" })).toBeInTheDocument();
+	});
+
+	it("offers Remote hosts as a switch right below Developer Mode and persists it", async () => {
+		const user = userEvent.setup();
+		renderForm();
+		const developerMode = await screen.findByRole("switch", { name: "Developer Mode" });
+		const remoteHosts = screen.getByRole("switch", { name: "Remote hosts (experimental)" });
+		expect(remoteHosts).toHaveAttribute("aria-checked", "false");
+		// "Underneath Developer Mode": the next switch in document order.
+		expect(developerMode.compareDocumentPosition(remoteHosts) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(screen.getAllByRole("switch").indexOf(remoteHosts)).toBe(screen.getAllByRole("switch").indexOf(developerMode) + 1);
+
+		await user.click(remoteHosts);
+		expect(window.localStorage.getItem("ao.remoteHosts")).toBe("true");
+		expect(useUiStore.getState().remoteHosts).toBe(true);
 	});
 
 	it("shows the available feature builds after choosing Feature Releases", async () => {

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -65,7 +65,12 @@ export function HomePage() {
 							<ProjectRow
 								key={project.id}
 								project={project}
-								onClick={() => void navigate({ to: "/projects/$projectId", params: { projectId: project.id } })}
+								onClick={() =>
+									void navigate({
+										to: "/host/$hostId/project/$projectId",
+										params: { hostId: project.host, projectId: project.id },
+									})
+								}
 							/>
 						))}
 					</div>

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Folder, Star } from "lucide-react";
 import { aoBridge } from "../lib/bridge";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
-import type { WorkspaceSummary } from "../types/workspace";
+import { flattenHostSections, type WorkspaceSummary } from "../types/workspace";
 import { BoardWelcome } from "./BoardEmptyStates";
 import { TopbarButton } from "./TopbarButton";
 
@@ -38,7 +38,7 @@ export function HomePage() {
 	const navigate = useNavigate();
 	const { t } = useTranslation();
 	const workspaceQuery = useWorkspaceQuery();
-	const projects = (workspaceQuery.data ?? [])
+	const projects = flattenHostSections(workspaceQuery.data)
 		.slice()
 		.sort((left, right) => latestProjectTimestamp(right).localeCompare(latestProjectTimestamp(left)))
 		.slice(0, 3);

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -35,12 +35,22 @@ vi.mock("../lib/api-client", () => ({
 			: undefined,
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ GET: (...args: unknown[]) => getMock(...args), POST: (...args: unknown[]) => postMock(...args) }),
+}));
+
 function renderDialog() {
 	const onCreated = vi.fn();
 	const onOpenChange = vi.fn();
 	render(
 		<QueryClientProvider client={new QueryClient()}>
-			<NewTaskDialog open projectId="proj-1" onCreated={onCreated} onOpenChange={onOpenChange} />
+			<NewTaskDialog open project={{ host: "local", id: "proj-1" }} onCreated={onCreated} onOpenChange={onOpenChange} />
 		</QueryClientProvider>,
 	);
 	return { onCreated, onOpenChange };

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -39,7 +39,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({ GET: (...args: unknown[]) => getMock(...args), POST: (...args: unknown[]) => postMock(...args) }),

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -1,15 +1,16 @@
 import * as Dialog from "@radix-ui/react-dialog";
+import type { Ref } from "../lib/hosts";
 import { useTranslation } from "react-i18next";
 import { TaskComposer } from "./TaskComposer";
 
 type NewTaskDialogProps = {
 	open: boolean;
-	projectId?: string;
+	project?: Ref;
 	onCreated: (sessionId: string) => void;
 	onOpenChange: (open: boolean) => void;
 };
 
-export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewTaskDialogProps) {
+export function NewTaskDialog({ open, project, onCreated, onOpenChange }: NewTaskDialogProps) {
 	const { t } = useTranslation();
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -21,7 +22,7 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 					<Dialog.Title className="settings-dialog-title px-4 pt-3">{t("newTask.title")}</Dialog.Title>
 					<Dialog.Description className="sr-only">{t("newTask.description")}</Dialog.Description>
 					<TaskComposer
-						projectId={projectId}
+						project={project}
 						autoFocusTitle
 						onCreated={(sessionId) => {
 							onCreated(sessionId);

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -492,8 +492,8 @@ describe("NotificationCenter", () => {
 
 		await userEvent.click(screen.getByText("The agent is waiting for your response."));
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-1" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-1" },
 		});
 	});
 
@@ -504,8 +504,8 @@ describe("NotificationCenter", () => {
 		await userEvent.click(screen.getByLabelText("Fix checkout totals · PR #67"));
 		expect(window.open).not.toHaveBeenCalled();
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-2" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-2" },
 		});
 	});
 
@@ -574,8 +574,8 @@ describe("NotificationCenter", () => {
 		await userEvent.keyboard("{Enter}");
 
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-1" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-1" },
 		});
 	});
 
@@ -590,8 +590,8 @@ describe("NotificationCenter", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Restore session" }));
 		await waitFor(() => expect(restoreSessionMock).toHaveBeenCalledWith("sess-dead"));
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-dead" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-dead" },
 		});
 	});
 
@@ -637,8 +637,8 @@ describe("NotificationCenter", () => {
 		await userEvent.click(screen.getByText("The agent session has ended."));
 		expect(restoreSessionMock).not.toHaveBeenCalled();
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-dead" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-dead" },
 		});
 	});
 

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -95,7 +95,17 @@ vi.mock("../hooks/useRestoreSession", () => ({
 }));
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => workspaceQueryMock(),
+	useWorkspaceQuery: () => (() => {
+		// useWorkspaceQuery returns one section per host now; these fixtures still
+		// describe the local host's workspaces, so wrap them in its section.
+		const result = workspaceQueryMock();
+		return {
+			...result,
+			data: result.data
+				? [{ host: "local", label: "Local", status: "ready", workspaces: result.data, failure: null }]
+				: undefined,
+		};
+	})(),
 	workspaceQueryKey: ["workspaces"],
 }));
 

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -41,6 +41,7 @@ import { TopbarButton } from "./TopbarButton";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
+import { LOCAL_HOST } from "../lib/hosts";
 type NotificationCenterProps = {
 	style?: React.CSSProperties;
 };
@@ -52,7 +53,7 @@ function useNotificationTargetNavigation() {
 			const sessionId = notification.target.sessionId || notification.sessionId;
 			if (!sessionId) return;
 			void captureRendererEvent("ao.renderer.notification_opened", { target: "session" });
-			navigateToSession(notification.projectId, sessionId);
+			navigateToSession({ host: LOCAL_HOST, id: sessionId });
 		},
 		[navigateToSession],
 	);

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -19,7 +19,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode
 import { useMarkAllNotificationsReadMutation, useNotificationsQuery } from "../hooks/useNotificationsQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
-import type { WorkspaceSummary } from "../types/workspace";
+import { flattenHostSections, type WorkspaceSummary } from "../types/workspace";
 import { aoBridge } from "../lib/bridge";
 import { openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { formatTimeCompact } from "../lib/format-time";
@@ -122,24 +122,25 @@ function NotificationWorkspaceState({
 	}) => ReactNode;
 }) {
 	const workspaceQuery = useWorkspaceQuery();
+	const workspaces = flattenHostSections(workspaceQuery.data);
 	const retryWorkspace = useCallback(() => {
 		void workspaceQuery.refetch();
 	}, [workspaceQuery.refetch]);
 	const { sessionsReady, terminatedIds, workspaceError } = useSessionTerminationLookup(
-		workspaceQuery.data,
+		workspaces,
 		workspaceQuery.isError,
 		workspaceQuery.isSuccess,
 		retryWorkspace,
 	);
 	const sessionMeta = useMemo(() => {
 		const map = new Map<string, { projectName: string; sessionName: string }>();
-		for (const workspace of workspaceQuery.data ?? []) {
+		for (const workspace of workspaces) {
 			for (const session of workspace.sessions) {
 				map.set(session.id, { projectName: workspace.name, sessionName: session.title });
 			}
 		}
 		return map;
-	}, [workspaceQuery.data]);
+	}, [workspaces]);
 	return <>{children({ retryWorkspace, sessionMeta, sessionsReady, terminatedIds, workspaceError })}</>;
 }
 

--- a/frontend/src/renderer/components/OrchestratorReplacementDialog.tsx
+++ b/frontend/src/renderer/components/OrchestratorReplacementDialog.tsx
@@ -1,4 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
+import type { Ref } from "../lib/hosts";
 import { useNavigate } from "@tanstack/react-router";
 import { AlertTriangle, RotateCw, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -13,16 +14,16 @@ import {
 } from "./ui/dialog";
 
 type OrchestratorReplacementDialogProps = {
-	projectId: string | null;
+	project: Ref | null;
 	error?: OrchestratorReplacementFailure;
 	workspaces: WorkspaceSummary[];
 	onOpenChange: (open: boolean) => void;
-	onRetry: (projectId: string) => void;
-	onRetryAsTui: (projectId: string) => void;
+	onRetry: (project: Ref) => void;
+	onRetryAsTui: (project: Ref) => void;
 };
 
 export function OrchestratorReplacementDialog({
-	projectId,
+	project,
 	error,
 	workspaces,
 	onOpenChange,
@@ -31,15 +32,15 @@ export function OrchestratorReplacementDialog({
 }: OrchestratorReplacementDialogProps) {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
-	const open = Boolean(projectId && error);
-	const orchestrator = projectId ? findProjectOrchestrator(workspaces, projectId) : undefined;
+	const open = Boolean(project && error);
+	const orchestrator = project ? findProjectOrchestrator(workspaces, project) : undefined;
 
 	const openCurrent = () => {
-		if (!projectId || !orchestrator) return;
+		if (!project || !orchestrator) return;
 		onOpenChange(false);
 		void navigate({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId, sessionId: orchestrator.id },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: orchestrator.host, sessionId: orchestrator.id },
 		});
 	};
 
@@ -74,7 +75,7 @@ export function OrchestratorReplacementDialog({
 					</div>
 					<div className={settingsDialogFooterClass}>
 						{error && isChatPreflightCode(error.code) ? (
-							<Button type="button" variant="footer" onClick={() => projectId && onRetryAsTui(projectId)}>
+							<Button type="button" variant="footer" onClick={() => project && onRetryAsTui(project)}>
 								{t("newTask.createAsTui")}
 							</Button>
 						) : null}
@@ -86,7 +87,7 @@ export function OrchestratorReplacementDialog({
 						<Button
 							type="button"
 							variant="footer-primary"
-							onClick={() => projectId && onRetry(projectId)}
+							onClick={() => project && onRetry(project)}
 						>
 							<RotateCw className="size-3.5" aria-hidden="true" />
 							{t("orchestratorReplacement.retry")}

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { agentReadiness } from "../test/agent-readiness-fixtures";
 import { TooltipProvider } from "./ui/tooltip";
+import { refKey, type Ref } from "../lib/hosts";
 
 function render(ui: ReactElement) {
 	return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
@@ -69,6 +70,16 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ GET: getMock, POST: postMock, PUT: putMock }),
+}));
+
 import { ProjectSettingsForm, type ProjectSettingsSaveState, type ProjectSettingsSection } from "./ProjectSettingsForm";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import type { WorkspaceSummary } from "../types/workspace";
@@ -79,10 +90,10 @@ async function beginEdit(label: string) {
 }
 
 function TestProjectSettings({
-	projectId,
+	projectRef,
 	section,
 }: {
-	projectId: string;
+	projectRef: Ref;
 	section?: ProjectSettingsSection;
 }) {
 	const [saveState, setSaveState] = useState<ProjectSettingsSaveState>({
@@ -95,7 +106,7 @@ function TestProjectSettings({
 	});
 	return (
 		<>
-			<ProjectSettingsForm projectId={projectId} section={section} onSaveState={setSaveState} />
+			<ProjectSettingsForm projectRef={projectRef} section={section} onSaveState={setSaveState} />
 			{saveState.validationError && <span>{saveState.validationError}</span>}
 			{saveState.mutationError && <span>{saveState.mutationError}</span>}
 			{saveState.saved && <span>{"Saved"}</span>}
@@ -116,7 +127,7 @@ function renderSettings(projectId = "proj-1", workspaces?: WorkspaceSummary[], s
 	}
 	render(
 		<QueryClientProvider client={queryClient}>
-			<TestProjectSettings projectId={projectId} section={section} />
+			<TestProjectSettings projectRef={{ host: "local", id: projectId }} section={section} />
 		</QueryClientProvider>,
 	);
 	return queryClient;
@@ -135,8 +146,8 @@ function submitSettings() {
 async function expectReplacementNavigation(sessionId = "proj-1-orch-2") {
 	await waitFor(() =>
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId },
 		}),
 	);
 	expect(closeSettingsMock).toHaveBeenCalledTimes(1);
@@ -1547,12 +1558,13 @@ describe("ProjectSettingsForm", () => {
 
 		renderSettings("proj-1", [
 			{
+				host: "local",
 				id: "proj-1",
 				name: "Project One",
 				path: "/repo/project-one",
 				orchestratorAgent: "goose",
 				sessions: [
-					{
+					{ host: "local",
 						id: "proj-1-orchestrator",
 						workspaceId: "proj-1",
 						workspaceName: "Project One",
@@ -1642,10 +1654,10 @@ describe("ProjectSettingsForm", () => {
 		expect(await screen.findByText("Saved")).toBeInTheDocument();
 		expect(await screen.findByText("Orchestrator restart failed: missing goose binary")).toBeInTheDocument();
 		expect(screen.queryByText("Save failed")).not.toBeInTheDocument();
-		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project", "proj-1"] });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project", refKey({ host: "local", id: "proj-1" })] });
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceQueryKey });
 		expect(closeSettingsMock).toHaveBeenCalledTimes(1);
-		expect(setOrchestratorReplacementErrorMock).toHaveBeenCalledWith("proj-1", {
+		expect(setOrchestratorReplacementErrorMock).toHaveBeenCalledWith({ host: "local", id: "proj-1" }, {
 			message: "missing goose binary",
 			code: "ORCHESTRATOR_SPAWN_FAILED",
 			requestId: "request-42",

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { agentReadiness } from "../test/agent-readiness-fixtures";
 import { TooltipProvider } from "./ui/tooltip";
-import { refKey, type Ref } from "../lib/hosts";
+import { LOCAL_HOST, refKey, type Ref } from "../lib/hosts";
 
 function render(ui: ReactElement) {
 	return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
@@ -74,14 +74,19 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({ GET: getMock, POST: postMock, PUT: putMock }),
 }));
 
 import { ProjectSettingsForm, type ProjectSettingsSaveState, type ProjectSettingsSection } from "./ProjectSettingsForm";
-import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { workspaceHostQueryKey, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import type { WorkspaceSummary } from "../types/workspace";
 
 async function beginEdit(label: string) {
@@ -123,7 +128,9 @@ function renderSettings(projectId = "proj-1", workspaces?: WorkspaceSummary[], s
 		},
 	});
 	if (workspaces) {
-		queryClient.setQueryData(workspaceQueryKey, workspaces);
+		queryClient.setQueryData(workspaceHostQueryKey(LOCAL_HOST), [
+			{ host: LOCAL_HOST, label: "Local", status: "ready", workspaces, failure: null },
+		]);
 	}
 	render(
 		<QueryClientProvider client={queryClient}>

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { refKey, type Ref } from "../lib/hosts";
 import { useNavigate } from "@tanstack/react-router";
 import {
 	ProjectAgentsSettingsView,
@@ -22,6 +23,7 @@ import {
 import { useAgentReadinessQuery, useEnsureAgentReadiness } from "../hooks/useAgentReadinessQuery";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
 import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-replacement-telemetry";
 import { OrchestratorSpawnError, spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { captureRendererEvent } from "../lib/telemetry";
@@ -44,7 +46,7 @@ type TrackerIntakeConfig = components["schemas"]["TrackerIntakeConfig"];
 const PERMISSION_MODE_VALUES = ["default", "accept-edits", "auto", "bypass-permissions"] as const;
 const DEFAULT_BRANCH_AUTO = "auto";
 
-const projectQueryKey = (id: string) => ["project", id] as const;
+const projectQueryKey = (project: Ref) => ["project", refKey(project)] as const;
 
 type SettingsSaveResult = {
 	replacementError: string | null;
@@ -64,11 +66,11 @@ export interface ProjectSettingsSaveState {
 }
 
 export function ProjectSettingsForm({
-	projectId,
+	projectRef,
 	section = "general",
 	onSaveState,
 }: {
-	projectId: string;
+	projectRef: Ref;
 	section?: ProjectSettingsSection;
 	onSaveState?: (state: ProjectSettingsSaveState) => void;
 }) {
@@ -76,10 +78,10 @@ export function ProjectSettingsForm({
 	const queryClient = useQueryClient();
 
 	const query = useQuery({
-		queryKey: projectQueryKey(projectId),
+		queryKey: projectQueryKey(projectRef),
 		queryFn: async () => {
-			const { data, error } = await apiClient.GET("/api/v1/projects/{id}", {
-				params: { path: { id: projectId } },
+			const { data, error } = await clientFor(projectRef.host).GET("/api/v1/projects/{id}", {
+				params: { path: { id: projectRef.id } },
 			});
 			if (error) throw new Error(apiErrorMessage(error));
 			if (data?.status !== "ok") throw new Error(t("settings.project.degraded"));
@@ -97,14 +99,14 @@ export function ProjectSettingsForm({
 				</p>
 			) : (
 				<SettingsBody
-					key={projectId}
+					key={refKey(projectRef)}
 					project={query.data}
 					onSaved={() =>
 						queryClient.invalidateQueries({ queryKey: workspaceQueryKey }).catch(() => {
 							// Saving succeeds even if the cache refresh fails.
 						})
 					}
-					projectId={projectId}
+					projectRef={projectRef}
 					section={section}
 					onSaveState={onSaveState}
 				/>
@@ -115,13 +117,13 @@ export function ProjectSettingsForm({
 
 function SettingsBody({
 	project,
-	projectId,
+	projectRef,
 	onSaved,
 	section = "general",
 	onSaveState,
 }: {
 	project: Project;
-	projectId: string;
+	projectRef: Ref;
 	onSaved: () => Promise<void>;
 	section?: ProjectSettingsSection;
 	onSaveState?: (state: ProjectSettingsSaveState) => void;
@@ -134,7 +136,7 @@ function SettingsBody({
 	const workspaceQuery = useWorkspaceQuery();
 	const config = project.config ?? {};
 	const isScratchProject = project.kind === "scratch";
-	const workspace = workspaceQuery.data?.find((item) => item.id === projectId);
+	const workspace = workspaceQuery.data?.find((item) => item.host === projectRef.host && item.id === projectRef.id);
 	const activeOrchestrator = newestActiveOrchestrator(workspace?.sessions ?? []);
 	const intake: TrackerIntakeConfig = config.trackerIntake ?? {};
 	const [form, setForm] = useState({
@@ -162,7 +164,7 @@ function SettingsBody({
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const initialOrchestratorAgent = config.orchestrator?.agent ?? "";
 	const missingRequiredAgent = form.workerAgent === "" || form.orchestratorAgent === "";
-	const agentsQuery = useAgentReadinessQuery();
+	const agentsQuery = useAgentReadinessQuery(true, projectRef.host);
 	useEnsureAgentReadiness();
 	useEnsureAgentReadiness({
 		agentIds: [form.workerAgent, form.orchestratorAgent, form.reviewerHarness],
@@ -186,7 +188,7 @@ function SettingsBody({
 	const reviewerWarning = reviewerTrustWarning(form.reviewerHarness);
 	const mutation = useMutation({
 		mutationFn: async () => {
-			void captureRendererEvent("ao.renderer.settings_save_requested", { project_id: projectId });
+			void captureRendererEvent("ao.renderer.settings_save_requested", { project_id: projectRef.id });
 			const displayName = form.displayName.trim();
 			const {
 				model: _legacyModel,
@@ -255,7 +257,7 @@ function SettingsBody({
 						autoReview: form.autoReview,
 					};
 			const { error } = await apiClient.PUT("/api/v1/projects/{id}", {
-				params: { path: { id: projectId } },
+				params: { path: { id: projectRef.id } },
 				body: { displayName, config: next },
 			});
 			if (error) throw new Error(apiErrorMessage(error));
@@ -264,7 +266,7 @@ function SettingsBody({
 				(activeOrchestrator && activeOrchestrator.provider !== form.orchestratorAgent)
 			) {
 				try {
-					const sessionId = await spawnOrchestrator(projectId, "settings", true);
+					const sessionId = await spawnOrchestrator(projectRef.id, "settings", true);
 					return {
 						replacementError: null,
 						replacementSessionId: sessionId,
@@ -295,33 +297,33 @@ function SettingsBody({
 			} satisfies SettingsSaveResult;
 		},
 		onSuccess: async (result) => {
-			void captureRendererEvent("ao.renderer.settings_save_succeeded", { project_id: projectId });
+			void captureRendererEvent("ao.renderer.settings_save_succeeded", { project_id: projectRef.id });
 			setSavedAt(Date.now());
 			setReplacementError(result.replacementError);
 			setValidationError(null);
-			void queryClient.invalidateQueries({ queryKey: ["project", projectId] });
+			void queryClient.invalidateQueries({ queryKey: ["project", refKey(projectRef)] });
 			const workspaceRefresh = onSaved();
 
 			if (result.replacementSessionId) {
 				await workspaceRefresh;
 				closeSettings();
 				void navigate({
-					to: "/projects/$projectId/sessions/$sessionId",
-					params: { projectId, sessionId: result.replacementSessionId },
+					to: "/host/$hostId/session/$sessionId",
+					params: { hostId: projectRef.host, sessionId: result.replacementSessionId },
 				});
 				return;
 			}
 
 			if (result.replacementFailure) {
 				closeSettings();
-				setOrchestratorReplacementError(projectId, result.replacementFailure);
+				setOrchestratorReplacementError(projectRef, result.replacementFailure);
 				if (result.spawnError) {
-					captureOrchestratorReplacementFailure(result.spawnError, projectId);
+					captureOrchestratorReplacementFailure(result.spawnError, projectRef.id);
 				}
 			}
 		},
 		onError: () => {
-			void captureRendererEvent("ao.renderer.settings_save_failed", { project_id: projectId });
+			void captureRendererEvent("ao.renderer.settings_save_failed", { project_id: projectRef.id });
 		},
 	});
 
@@ -443,7 +445,7 @@ function SettingsBody({
 							<AgentModelField
 								role="worker"
 								agentId={form.workerAgent}
-								projectId={projectId}
+								projectRef={projectRef}
 								model={form.workerModel}
 								mode={form.workerMode}
 								onModelChange={(workerModel) => setForm((f) => ({ ...f, workerModel }))}
@@ -474,7 +476,7 @@ function SettingsBody({
 							<AgentModelField
 								role="orchestrator"
 								agentId={form.orchestratorAgent}
-								projectId={projectId}
+								projectRef={projectRef}
 								model={form.orchestratorModel}
 								mode={form.orchestratorMode}
 								onModelChange={(orchestratorModel) => setForm((f) => ({ ...f, orchestratorModel }))}
@@ -515,7 +517,7 @@ function SettingsBody({
 								}
 								model={form.reviewerModel}
 								mode={form.reviewerMode}
-								projectId={projectId}
+								project={projectRef}
 								ariaLabel={t("settings.project.defaultReviewer")}
 								agents={agentCatalog?.agents}
 								defaultOptionLabel={t("settings.project.default")}
@@ -619,7 +621,7 @@ function SettingsBody({
 function AgentModelField({
 	role,
 	agentId,
-	projectId,
+	projectRef,
 	model,
 	mode,
 	onModelChange,
@@ -627,7 +629,7 @@ function AgentModelField({
 }: {
 	role: "worker" | "orchestrator";
 	agentId: string;
-	projectId: string;
+	projectRef: Ref;
 	model: string;
 	mode: string;
 	onModelChange: (value: string) => void;
@@ -636,20 +638,20 @@ function AgentModelField({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [customAgentId, setCustomAgentId] = useState<string | null>(null);
-	const query = useQuery(agentModelsQueryOptions(agentId, projectId));
+	const query = useQuery(agentModelsQueryOptions(agentId, projectRef));
 	const catalog: AgentModelCatalog | undefined = query.data;
 	const revalidationQuery = useQuery({
-		queryKey: ["agent-model-revalidation", agentId, projectId, catalog?.validatedAt ?? ""],
-		queryFn: () => revalidateAgentModels(agentId, projectId),
+		queryKey: ["agent-model-revalidation", agentId, refKey(projectRef), catalog?.validatedAt ?? ""],
+		queryFn: () => revalidateAgentModels(agentId, projectRef),
 		enabled: agentId !== "" && catalog?.refreshRecommended === true,
 		staleTime: Number.POSITIVE_INFINITY,
 		retry: false,
 	});
 	useEffect(() => {
 		if (revalidationQuery.data) {
-			queryClient.setQueryData(agentModelsQueryKey(agentId, projectId), revalidationQuery.data);
+			queryClient.setQueryData(agentModelsQueryKey(agentId, projectRef), revalidationQuery.data);
 		}
-	}, [agentId, projectId, queryClient, revalidationQuery.data]);
+	}, [agentId, projectRef, queryClient, revalidationQuery.data]);
 	const isMode = catalog?.selectionMode === "mode";
 	const label = t(`settings.models.${role}${isMode ? "Mode" : "Model"}`);
 	const datalistID = `${role}-model-options`;

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -28,7 +28,7 @@ import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-repla
 import { OrchestratorSpawnError, spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { captureRendererEvent } from "../lib/telemetry";
 import { type OrchestratorReplacementFailure, useUiStore } from "../stores/ui-store";
-import { newestActiveOrchestrator } from "../types/workspace";
+import { flattenHostSections, newestActiveOrchestrator } from "../types/workspace";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
 import { buildIntake, deriveRepoPath, deriveRepoHost, IntakeFields, type IntakeForm } from "./IntakeFields";
 import { ProductExternalLink } from "./ProductExternalLink";
@@ -134,9 +134,10 @@ function SettingsBody({
 	const closeSettings = useUiStore((state) => state.closeSettings);
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
 	const workspaceQuery = useWorkspaceQuery();
+	const workspaces = flattenHostSections(workspaceQuery.data);
 	const config = project.config ?? {};
 	const isScratchProject = project.kind === "scratch";
-	const workspace = workspaceQuery.data?.find((item) => item.host === projectRef.host && item.id === projectRef.id);
+	const workspace = workspaces.find((item) => item.host === projectRef.host && item.id === projectRef.id);
 	const activeOrchestrator = newestActiveOrchestrator(workspace?.sessions ?? []);
 	const intake: TrackerIntakeConfig = config.trackerIntake ?? {};
 	const [form, setForm] = useState({

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../lib/spawn-orchestrator", () => ({
 }));
 
 const session: WorkspaceSession = {
+	host: "local",
 	id: "orch-old",
 	workspaceId: "proj-1",
 	workspaceName: "Project One",
@@ -31,6 +32,7 @@ const session: WorkspaceSession = {
 };
 
 const workspace: WorkspaceSummary = {
+	host: "local",
 	id: "proj-1",
 	name: "Project One",
 	path: "/repo/project-one",
@@ -64,7 +66,7 @@ describe("RestoreUnavailableDialog", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Configure orchestrator agent" }));
 
 		expect(onOpenChange).toHaveBeenCalledWith(false);
-		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", project: { host: "local", id: "proj-1" } });
 		expect(spawnMock).not.toHaveBeenCalled();
 		expect(onRecreated).not.toHaveBeenCalled();
 	});

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
@@ -24,7 +24,7 @@ type RestoreUnavailableDialogProps = {
 
 export function RestoreUnavailableDialog({ open, session, onOpenChange, onRecreated }: RestoreUnavailableDialogProps) {
 	const { t } = useTranslation();
-	const workspaceQuery = useWorkspaceScope(session.workspaceId);
+	const workspaceQuery = useWorkspaceScope(session.host, session.workspaceId);
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | undefined>();
 	const orchestrator = isOrchestratorSession(session);

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
@@ -36,7 +36,7 @@ export function RestoreUnavailableDialog({ open, session, onOpenChange, onRecrea
 		if (checkingProject) return;
 		if (!hasOrchestratorAgent) {
 			onOpenChange(false);
-			useUiStore.getState().openProjectSettings(session.workspaceId);
+			useUiStore.getState().openProjectSettings({ host: session.host, id: session.workspaceId });
 			return;
 		}
 		setBusy(true);

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -11,6 +11,7 @@ import {
 	type RankedAgentOption,
 	unknownAgentReadiness,
 } from "../lib/agent-select-options";
+import { LOCAL_HOST, type Ref } from "../lib/hosts";
 import { KNOWN_REVIEWER_HARNESS_IDS } from "../lib/reviewer-harnesses";
 import { cn } from "../lib/utils";
 import { AgentAvatar } from "./AgentAvatar";
@@ -51,7 +52,7 @@ export function ReviewerSelect({
 	onConfigChange,
 	model = "",
 	mode = "",
-	projectId,
+	project,
 	triggerClassName,
 	ariaLabel = "Default reviewer agent",
 	defaultHarness,
@@ -68,7 +69,7 @@ export function ReviewerSelect({
 	onConfigChange?: (harness: string, config: ReviewerAgentConfig) => void;
 	model?: string;
 	mode?: string;
-	projectId?: string;
+	project?: Ref;
 	triggerClassName?: string;
 	ariaLabel?: string;
 	defaultHarness?: string;
@@ -102,8 +103,11 @@ export function ReviewerSelect({
 		return true;
 	});
 	const effectiveHarness = value || defaultHarness || "";
-	const menuProjectID = projectId ?? "";
-	const triggerCatalog = useQuery(agentModelsQueryOptions(effectiveHarness, menuProjectID));
+	const menuProject: Ref = useMemo(
+		() => ({ host: project?.host ?? LOCAL_HOST, id: project?.id ?? "" }),
+		[project?.host, project?.id],
+	);
+	const triggerCatalog = useQuery(agentModelsQueryOptions(effectiveHarness, menuProject));
 
 	useEffect(() => {
 		if (!menuOpen) return;
@@ -114,9 +118,9 @@ export function ReviewerSelect({
 		}
 		for (const harness of harnesses) {
 			if (!harness) continue;
-			void queryClient.prefetchQuery(agentModelsQueryOptions(harness, menuProjectID));
+			void queryClient.prefetchQuery(agentModelsQueryOptions(harness, menuProject));
 		}
-	}, [defaultHarness, menuOpen, menuProjectID, queryClient, selectableOptions]);
+	}, [defaultHarness, menuOpen, menuProject, queryClient, selectableOptions]);
 	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
 	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
 		.filter(Boolean)
@@ -149,7 +153,7 @@ export function ReviewerSelect({
 							onChange(nextHarness);
 							onConfigChange?.(nextHarness, nextConfig);
 						}}
-						projectId={menuProjectID}
+						project={menuProject}
 						resolvedHarness={defaultHarness}
 						persistHarness=""
 					/>
@@ -165,7 +169,7 @@ export function ReviewerSelect({
 							onChange(nextHarness);
 							onConfigChange?.(nextHarness, nextConfig);
 						}}
-						projectId={menuProjectID}
+						project={menuProject}
 						resolvedHarness={agent.id}
 						persistHarness={agent.id}
 					/>
@@ -181,7 +185,7 @@ function ReviewerHarnessOption({
 	currentModel,
 	currentMode,
 	onSelect,
-	projectId,
+	project,
 	resolvedHarness,
 	persistHarness,
 }: {
@@ -190,14 +194,14 @@ function ReviewerHarnessOption({
 	currentModel: string;
 	currentMode: string;
 	onSelect: (harness: string, config: ReviewerAgentConfig) => void;
-	projectId: string;
+	project: Ref;
 	resolvedHarness?: string;
 	persistHarness: string;
 }) {
 	const { t } = useTranslation();
 	const [open, setOpen] = useState(false);
 	const catalogQuery = useQuery({
-		...agentModelsQueryOptions(resolvedHarness ?? "", projectId),
+		...agentModelsQueryOptions(resolvedHarness ?? "", project),
 		enabled: false,
 	});
 	const catalog = catalogQuery.data;

--- a/frontend/src/renderer/components/SessionFileExplorer.test.tsx
+++ b/frontend/src/renderer/components/SessionFileExplorer.test.tsx
@@ -20,6 +20,8 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+
+vi.mock("../lib/host-clients", () => ({ clientFor: () => ({ GET: getMock, POST: postMock }) }));
 vi.mock("./FileTree", () => ({
 	FileTree: ({
 		changedOnly,

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -74,6 +74,21 @@ vi.mock("../lib/api-client", () => ({
   },
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({
+    GET: getMock,
+    PATCH: patchMock,
+    POST: postMock,
+    PUT: putMock,
+  }),
+}));
+
 const pr = (
   n: number,
   state: PRState,
@@ -94,6 +109,7 @@ const session = (
   prs: PullRequestFacts[],
   overrides: Partial<WorkspaceSession> = {},
 ): WorkspaceSession => ({
+	host: "local",
   id: "sess-1",
   workspaceId: "ws-1",
   workspaceName: "my-app",
@@ -488,7 +504,7 @@ describe("SessionInspector PR section", () => {
       <SessionInspector session={session([pr(7, "open")])} />,
       undefined,
       (client) => {
-        client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [
+        client.setQueryData(sessionScmSummaryQueryKey({ host: "local", id: "sess-1" }), [
           prSummary(7, "open", {
             review: {
               decision: "approved",
@@ -539,7 +555,7 @@ describe("SessionInspector PR section", () => {
       <SessionInspector session={session([pr(7, "open")])} />,
       undefined,
       (client) => {
-        client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [readyPR]);
+        client.setQueryData(sessionScmSummaryQueryKey({ host: "local", id: "sess-1" }), [readyPR]);
       },
     );
 
@@ -583,7 +599,7 @@ describe("SessionInspector PR section", () => {
         <SessionInspector session={session([pr(7, "open")])} />,
         undefined,
         (client) => {
-          client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [
+          client.setQueryData(sessionScmSummaryQueryKey({ host: "local", id: "sess-1" }), [
             prSummary(7, "open", {
               ci: { autoInjectCI: true, state: "passing", failingChecks: [] },
               review: { decision: "approved", hasUnresolvedHumanComments: false, unresolvedBy: [] },
@@ -601,7 +617,7 @@ describe("SessionInspector PR section", () => {
       <SessionInspector session={session([pr(7, "open")])} />,
       undefined,
       (client) => {
-        client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [
+        client.setQueryData(sessionScmSummaryQueryKey({ host: "local", id: "sess-1" }), [
           prSummary(7, "open", {
             headSha: "",
             ci: { autoInjectCI: true, state: "passing", failingChecks: [] },
@@ -769,7 +785,7 @@ describe("SessionInspector PR section", () => {
       <SessionInspector session={session([pr(7, "open")])} />,
       undefined,
       (client) => {
-        client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [failingPR]);
+        client.setQueryData(sessionScmSummaryQueryKey({ host: "local", id: "sess-1" }), [failingPR]);
       },
     );
 
@@ -1112,7 +1128,7 @@ describe("SessionInspector completion controls", () => {
       title: "orchestrator",
     });
     renderWithQuery(<SessionInspector session={worker} />, [
-      {
+      { host: "local",
         id: "ws-1",
         name: "my-app",
         path: "/repo",
@@ -1142,8 +1158,8 @@ describe("SessionInspector completion controls", () => {
     });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(navigateMock).toHaveBeenCalledWith({
-      to: "/projects/$projectId/sessions/$sessionId",
-      params: { projectId: "ws-1", sessionId: "orch-1" },
+      to: "/host/$hostId/session/$sessionId",
+      params: { hostId: "local", sessionId: "orch-1" },
     });
   });
 
@@ -1170,8 +1186,8 @@ describe("SessionInspector completion controls", () => {
     await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(navigateMock).toHaveBeenCalledWith({
-      to: "/projects/$projectId",
-      params: { projectId: "ws-1" },
+      to: "/host/$hostId/project/$projectId",
+      params: { hostId: "local", projectId: "ws-1" },
     });
   });
 
@@ -1691,7 +1707,7 @@ describe("SessionInspector Activity section", () => {
       />,
       undefined,
       (client) =>
-        client.setQueryData(sessionScmSummaryQueryKey("sess-1"), summaries),
+        client.setQueryData(sessionScmSummaryQueryKey({ host: "local", id: "sess-1" }), summaries),
     );
 
     const section = screen

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -15,8 +15,9 @@ import { TooltipProvider } from "./ui/tooltip";
 import type { SessionPRSummary } from "../hooks/useSessionScmSummary";
 import { sessionScmSummaryQueryKey } from "../hooks/useSessionScmSummary";
 import { sessionWorkspaceFilesQueryKey } from "../hooks/useSessionWorkspaceFiles";
-import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { workspaceHostQueryKey } from "../hooks/useWorkspaceQuery";
 import { agentReadiness } from "../test/agent-readiness-fixtures";
+import { LOCAL_HOST } from "../lib/hosts";
 import { useUiStore } from "../stores/ui-store";
 import type {
   PRState,
@@ -78,7 +79,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({
@@ -179,7 +185,10 @@ function renderWithQuery(
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  if (workspaces) client.setQueryData(workspaceQueryKey, workspaces);
+  if (workspaces)
+    client.setQueryData(workspaceHostQueryKey(LOCAL_HOST), [
+      { host: LOCAL_HOST, label: "Local", status: "ready", workspaces, failure: null },
+    ]);
   seed?.(client);
   return {
     ...render(

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -40,6 +40,8 @@ import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { captureRendererEvent } from "../lib/telemetry";
+import { refKey, type Ref } from "../lib/hosts";
+import { clientFor } from "../lib/host-clients";
 import { formatTimeCompact } from "../lib/format-time";
 import { AgentAvatar } from "./AgentAvatar";
 import { ProductExternalLink } from "./ProductExternalLink";
@@ -272,9 +274,9 @@ const SummaryView = memo(function SummaryView({
 	session: WorkspaceSession;
 }) {
 	const { t } = useTranslation();
-	const query = useSessionScmSummary(session.id);
+	const query = useSessionScmSummary(session);
 	const developerMode = useUiStore((state) => state.developerMode);
-	const usageQuery = useSessionUsage(session.id, developerMode);
+	const usageQuery = useSessionUsage(session, developerMode);
 	const showUsage =
 		developerMode &&
 		!usageQuery.isLoading &&
@@ -303,7 +305,7 @@ const SummaryView = memo(function SummaryView({
 								key={pr.url || pr.htmlUrl || pr.number}
 								onOpenReviews={onOpenReviews}
 								pr={pr}
-								sessionId={session.id}
+								session={session}
 							/>
 						))
 					) : (
@@ -1093,17 +1095,20 @@ function SessionControls({ session }: { session: WorkspaceSession }) {
 
 	const confirmTermination = () => {
 		const workspaces = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey) ?? [];
-		const orchestrator = findProjectOrchestrator(workspaces, session.workspaceId);
+		const orchestrator = findProjectOrchestrator(workspaces, { host: session.host, id: session.workspaceId });
 		setConfirmOpen(false);
 		terminate.mutate(session);
 		if (orchestrator) {
 			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId: session.workspaceId, sessionId: orchestrator.id },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: orchestrator.host, sessionId: orchestrator.id },
 			});
 			return;
 		}
-		void navigate({ to: "/projects/$projectId", params: { projectId: session.workspaceId } });
+		void navigate({
+			to: "/host/$hostId/project/$projectId",
+			params: { hostId: session.host, projectId: session.workspaceId },
+		});
 	};
 
 	if (session.isTerminated === true) return null;
@@ -1179,12 +1184,12 @@ function PRSummaryCard({
 	canOpenReviews,
 	onOpenReviews,
 	pr,
-	sessionId,
+	session,
 }: {
 	canOpenReviews: boolean;
 	onOpenReviews: () => void;
 	pr: SessionPRSummary;
-	sessionId: string;
+	session: Ref;
 }) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
@@ -1206,7 +1211,7 @@ function PRSummaryCard({
 		},
 		onSuccess: async () => {
 			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey(sessionId) }),
+				queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey(session) }),
 				queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
 			]);
 		},
@@ -1480,14 +1485,14 @@ function ReviewsSection({
 			return session.autoReviewEnabled === true ? 10_000 : false;
 		},
 	});
-	const agentsQuery = useAgentReadinessQuery();
+	const agentsQuery = useAgentReadinessQuery(true, session.host);
 	useEnsureAgentReadiness();
 	const projectConfigQuery = useQuery({
-		queryKey: ["project-config", session.workspaceId],
+		queryKey: ["project-config", refKey({ host: session.host, id: session.workspaceId })],
 		enabled: hasPr,
 		queryFn: async () => {
 			if (usePreviewData) return mockProjectConfig();
-			const { data, error } = await apiClient.GET("/api/v1/projects/{id}", {
+			const { data, error } = await clientFor(session.host).GET("/api/v1/projects/{id}", {
 				params: { path: { id: session.workspaceId } },
 			});
 			if (error) return undefined;
@@ -1612,7 +1617,7 @@ function ReviewsSection({
 	});
 	const reviewStates = reviewsQuery.data?.reviews ?? [];
 	const autoReviewEnabled = session.autoReviewEnabled === true;
-	const scmSummary = useSessionScmSummary(session.id);
+	const scmSummary = useSessionScmSummary(session);
 	const prSummaries = sessionPRDisplaySummaries(session, scmSummary.data);
 	const githubReviews = prSummaries.filter(
 		(pr) =>
@@ -1730,7 +1735,7 @@ function MergedReviewsSection({
 			body: { pullRequestUrl: comment.pullRequestUrl, commentUrl: comment.url ?? "" },
 		});
 		if (error) throw new Error(apiErrorMessage(error, "Unable to resolve review comment"));
-		void queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey(session.id) });
+		void queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey(session) });
 		void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 	};
 	const sendInlineCommentToWorker = async (comment: InspectorInlineComment & { reviewerId?: string }) => {
@@ -2269,7 +2274,7 @@ function ReviewPanel({
 							onConfigChange={(harness, config) => onReviewerOverrideChange(harness as ReviewerHarness | "", config)}
 							model={reviewerModel}
 							mode={reviewerMode}
-							projectId={session.workspaceId}
+							project={{ host: session.host, id: session.workspaceId }}
 							triggerClassName="review-run-agent-select ml-auto h-control-md w-auto min-w-0 max-w-[11rem] shrink-0 justify-end px-2 text-right text-xs"
 							value={reviewerOverride}
 							showDefaultOption

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -38,7 +38,7 @@ import {
 } from "lucide-react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
-import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { workspaceHostQueryKey, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { captureRendererEvent } from "../lib/telemetry";
 import { refKey, type Ref } from "../lib/hosts";
 import { clientFor } from "../lib/host-clients";
@@ -57,8 +57,8 @@ import { clearTerminateSessionState, useTerminateSession } from "../hooks/useTer
 import { formatEstimatedCost, type EstimatedCost } from "../lib/format-cost";
 import { prBrowserUrl, prCardPresentation, prNounKeys, sessionPRDisplaySummaries } from "../lib/pr-display";
 import { formatTokenCount } from "../lib/format-token-count";
-import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
-import { findProjectOrchestrator, sortedPRs } from "../types/workspace";
+import type { HostSection, WorkspaceSession, WorkspaceSummary } from "../types/workspace";
+import { findProjectOrchestrator, flattenHostSections, sortedPRs, updateHostWorkspaces } from "../types/workspace";
 import { getAgentActivityView, getSessionTimelinePillView } from "../lib/session-presentation";
 import { aoBridge } from "../lib/bridge";
 import { BrowserPanelView, type BrowserAnnotationQueueModel } from "./BrowserPanel";
@@ -551,16 +551,20 @@ function AutoInjectCIPolicyControl({ session }: { session: WorkspaceSession }) {
 			if (error) throw new Error(apiErrorMessage(error, t("inspector.ci.autoInjectError", { status: response.status })));
 		},
 		onMutate: async (autoInjectCI) => {
-			await queryClient.cancelQueries({ queryKey: workspaceQueryKey });
-			const previous = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
-			queryClient.setQueryData<WorkspaceSummary[]>(workspaceQueryKey, (current) =>
-				updateSessionAutoInjectCI(current, session.id, autoInjectCI),
+			// The cache is per host, so the optimistic edit names the session's own.
+			const hostKey = workspaceHostQueryKey(session.host);
+			await queryClient.cancelQueries({ queryKey: hostKey });
+			const previous = queryClient.getQueryData<HostSection[]>(hostKey);
+			queryClient.setQueryData<HostSection[]>(hostKey, (current) =>
+				updateHostWorkspaces(current, session.host, (workspaces) =>
+					updateSessionAutoInjectCI(workspaces, session.id, autoInjectCI),
+				),
 			);
 			return { previous };
 		},
 		onError: (_error, _next, context) => {
 			setEnabled(session.autoInjectCI ?? true);
-			if (context?.previous) queryClient.setQueryData(workspaceQueryKey, context.previous);
+			if (context?.previous) queryClient.setQueryData(workspaceHostQueryKey(session.host), context.previous);
 		},
 		onSettled: () => {
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
@@ -685,11 +689,11 @@ function AutoInjectReviewPolicyControl({ session }: { session: WorkspaceSession 
 }
 
 function updateSessionAutoInjectCI(
-	workspaces: WorkspaceSummary[] | undefined,
+	workspaces: WorkspaceSummary[],
 	sessionId: string,
 	autoInjectCI: boolean,
-): WorkspaceSummary[] | undefined {
-	return workspaces?.map((workspace) => ({
+): WorkspaceSummary[] {
+	return workspaces.map((workspace) => ({
 		...workspace,
 		sessions: workspace.sessions.map((candidate) =>
 			candidate.id === sessionId ? { ...candidate, autoInjectCI } : candidate,
@@ -1076,15 +1080,19 @@ function SessionControls({ session }: { session: WorkspaceSession }) {
 			if (error) throw new Error(apiErrorMessage(error, `Failed to update merge policy (${response.status})`));
 		},
 		onMutate: async (terminateOnPrMerge) => {
-			await queryClient.cancelQueries({ queryKey: workspaceQueryKey });
-			const previous = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
-			queryClient.setQueryData<WorkspaceSummary[]>(workspaceQueryKey, (current) =>
-				updateSessionMergePolicy(current, session.id, terminateOnPrMerge),
+			// The cache is per host, so the optimistic edit names the session's own.
+			const hostKey = workspaceHostQueryKey(session.host);
+			await queryClient.cancelQueries({ queryKey: hostKey });
+			const previous = queryClient.getQueryData<HostSection[]>(hostKey);
+			queryClient.setQueryData<HostSection[]>(hostKey, (current) =>
+				updateHostWorkspaces(current, session.host, (workspaces) =>
+					updateSessionMergePolicy(workspaces, session.id, terminateOnPrMerge),
+				),
 			);
 			return { previous };
 		},
 		onError: (_error, _next, context) => {
-			if (context?.previous) queryClient.setQueryData(workspaceQueryKey, context.previous);
+			if (context?.previous) queryClient.setQueryData(workspaceHostQueryKey(session.host), context.previous);
 		},
 		onSettled: () => {
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
@@ -1094,7 +1102,7 @@ function SessionControls({ session }: { session: WorkspaceSession }) {
 	const canTerminateNow = session.status === "merged";
 
 	const confirmTermination = () => {
-		const workspaces = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey) ?? [];
+		const workspaces = flattenHostSections(queryClient.getQueryData<HostSection[]>(workspaceHostQueryKey(session.host)));
 		const orchestrator = findProjectOrchestrator(workspaces, { host: session.host, id: session.workspaceId });
 		setConfirmOpen(false);
 		terminate.mutate(session);
@@ -1168,11 +1176,11 @@ function SessionControls({ session }: { session: WorkspaceSession }) {
 }
 
 function updateSessionMergePolicy(
-	workspaces: WorkspaceSummary[] | undefined,
+	workspaces: WorkspaceSummary[],
 	sessionId: string,
 	terminateOnPrMerge: boolean,
-): WorkspaceSummary[] | undefined {
-	return workspaces?.map((workspace) => ({
+): WorkspaceSummary[] {
+	return workspaces.map((workspace) => ({
 		...workspace,
 		sessions: workspace.sessions.map((candidate) =>
 			candidate.id === sessionId ? { ...candidate, terminateOnPrMerge } : candidate,

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -551,10 +551,10 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 		data: workspaceQueryState.data,
 		isLoading: workspaceQueryState.isLoading,
 	}),
-	useWorkspaceSession: (sessionId: string) => ({
+	useWorkspaceSession: (session: { host: string; id: string }) => ({
 		data: workspaceQueryState.data
 			?.flatMap((workspace) => workspace.sessions)
-			.find((session) => session.id === sessionId),
+			.find((candidate) => candidate.host === session.host && candidate.id === session.id),
 		isLoading: workspaceQueryState.isLoading,
 	}),
 }));
@@ -768,6 +768,25 @@ describe("SessionView", () => {
 		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 
 		expect(screen.getByTestId("chat-surface")).not.toBe(firstSurface);
+	});
+
+	// Regression: two hosts can hold sessions that share an id, so resolving the
+	// route's session by bare id renders whichever host sorts first in the tree —
+	// i.e. the wrong machine's session under the right URL.
+	it("resolves the session on the ref's host, not the first matching id", () => {
+		const remoteTwin: WorkspaceSession = {
+			...workspaces[0].sessions[0],
+			host: "remote",
+			title: "the remote thing",
+		};
+		workspaceQueryState.data = [
+			...workspaces,
+			{ host: "remote", id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [remoteTwin] },
+		];
+
+		render(<SessionView sessionRef={{ host: "remote", id: "sess-1" }} />);
+
+		expect(screen.getByTestId("session-tab")).toHaveTextContent("the remote thing");
 	});
 
 	// The strip only ever shows the session on screen — pinning another session's

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -111,7 +111,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({
@@ -548,7 +553,9 @@ vi.mock("../lib/shell-context", () => ({
 }));
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceQuery: () => ({
-		data: workspaceQueryState.data,
+		data: workspaceQueryState.data
+			? [{ host: "local", label: "Local", status: "ready", workspaces: workspaceQueryState.data, failure: null }]
+			: undefined,
 		isLoading: workspaceQueryState.isLoading,
 	}),
 	useWorkspaceSession: (session: { host: string; id: string }) => ({

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -171,7 +171,7 @@ const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() =
 	};
 	const shellTerminalsState: {
 		data: Array<{
-			host: "local",
+			host: string;
 			handleId: string;
 			projectId?: string;
 			sessionId?: string;
@@ -569,7 +569,12 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.
 vi.mock("../hooks/useShellTerminals", () => ({
-	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
+	// Per host, like the real hook: a call that omits the host gets the local
+	// shells, which is exactly the defect a host-blind call site would hide.
+	useShellTerminals: (host = "local") => ({
+		data: shellTerminalsState.data.filter((shell) => shell.host === host),
+		isLoading: false,
+	}),
 	useOpenShellTerminal: () => ({ open: openShellTerminalMock, isPending: false }),
 	useCloseShellTerminal: () => ({ mutate: closeShellTerminalMock }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
@@ -682,6 +687,41 @@ describe("SessionView", () => {
 			}
 			return { data: { reviewerHandleId: "", reviews: [], runs: [] }, error: undefined };
 		});
+	});
+
+	// A session's shells live on the session's host. Asking the local host for a
+	// remote session's shells returns another machine's list — and leaves the
+	// session's own shells with no tab strip to appear in.
+	it("reads the shell terminals of the session's own host", () => {
+		const remoteTwin: WorkspaceSession = { ...workspaces[0].sessions[0], host: "remote" };
+		workspaceQueryState.data = [
+			...workspaces,
+			{ host: "remote", id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [remoteTwin] },
+		];
+		shellTerminalsState.data = [
+			{
+				host: "local",
+				handleId: "sh-local",
+				sessionId: "sess-1",
+				title: "local-shell",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+			{
+				host: "remote",
+				handleId: "sh-remote",
+				sessionId: "sess-1",
+				title: "remote-shell",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+
+		render(<SessionView sessionRef={{ host: "remote", id: "sess-1" }} />);
+
+		const tabs = screen.getByTestId("shell-tabs");
+		expect(tabs).toHaveTextContent("remote-shell");
+		expect(tabs).not.toHaveTextContent("local-shell");
 	});
 
 	// Regression: shell terminals are an app-wide list, so without a per-session
@@ -915,6 +955,7 @@ describe("SessionView", () => {
 		workerSession("sess-2").mode = "chat";
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "sh-a",
 				projectId: "proj-1",
 				sessionId: "sess-1",
@@ -950,6 +991,7 @@ describe("SessionView", () => {
 		workerSession("sess-1").mode = "chat";
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "sh-a",
 				projectId: "proj-1",
 				sessionId: "sess-1",
@@ -986,6 +1028,7 @@ describe("SessionView", () => {
 		];
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "sh-a",
 				projectId: "proj-1",
 				sessionId: "sess-1",
@@ -1026,6 +1069,7 @@ describe("SessionView", () => {
 		workerSession("sess-1").mode = "chat";
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "sh-a",
 				projectId: "proj-1",
 				sessionId: "sess-1",

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render as rtlRender, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { refKey } from "../lib/hosts";
+import { refKey, type Ref } from "../lib/hosts";
 import { SessionView } from "./SessionView";
 import { SessionTopbarProvider } from "./SessionTopbarPortal";
 import { TooltipProvider } from "./ui/tooltip";
@@ -171,6 +171,7 @@ const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() =
 	};
 	const shellTerminalsState: {
 		data: Array<{
+			host: "local",
 			handleId: string;
 			projectId?: string;
 			sessionId?: string;
@@ -643,10 +644,11 @@ describe("SessionView", () => {
 		shellTerminalsState.data = [];
 		navigateMock.mockReset();
 		openShellTerminalMock.mockReset();
-		openShellTerminalMock.mockImplementation((input: { projectId?: string; sessionId?: string }) => ({
+		openShellTerminalMock.mockImplementation((input: { project?: Ref; session?: Ref }) => ({
+			host: input.session?.host ?? input.project?.host ?? "local",
 			handleId: "pending-shell:test",
-			projectId: input.projectId,
-			sessionId: input.sessionId,
+			projectId: input.project?.id,
+			sessionId: input.session?.id,
 			workingDir: "",
 			title: "Terminal 1",
 			createdAt: "2026-08-31T00:00:00Z",
@@ -689,6 +691,7 @@ describe("SessionView", () => {
 	it("shows only the current session's shell terminals as tabs", () => {
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "sh-a",
 				sessionId: "sess-1",
 				title: "sess-1-shell",
@@ -696,13 +699,14 @@ describe("SessionView", () => {
 				createdAt: "2026-07-24T00:00:00Z",
 			},
 			{
+				host: "local",
 				handleId: "sh-b",
 				sessionId: "sess-2",
 				title: "sess-2-shell",
 				workingDir: "/q",
 				createdAt: "2026-07-24T00:00:00Z",
 			},
-			{ handleId: "sh-c", title: "loose-shell", workingDir: "/r", createdAt: "2026-07-24T00:00:00Z" },
+			{ host: "local", handleId: "sh-c", title: "loose-shell", workingDir: "/r", createdAt: "2026-07-24T00:00:00Z" },
 		];
 		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		const tabs = screen.getByTestId("shell-tabs");
@@ -718,6 +722,7 @@ describe("SessionView", () => {
 	it("publishes which terminal the session pane is showing", () => {
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "sh-a",
 				sessionId: "sess-1",
 				title: "sess-1-shell",
@@ -744,6 +749,7 @@ describe("SessionView", () => {
 		workspaces[0].sessions[0].mode = "chat";
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "chat-shell",
 				sessionId: "sess-1",
 				title: "chat worktree shell",
@@ -813,12 +819,16 @@ describe("SessionView", () => {
 
 		const newTerminalButton = screen.getByRole("button", { name: "New terminal" });
 		fireEvent.click(newTerminalButton);
-		expect(openShellTerminalMock).toHaveBeenCalledWith({ projectId: "proj-1", sessionId: "sess-2" }, expect.anything());
+		expect(openShellTerminalMock).toHaveBeenCalledWith(
+			{ project: { host: "local", id: "proj-1" }, session: { host: "local", id: "sess-2" } },
+			expect.anything(),
+		);
 		expect(useUiStore.getState().activeShellTerminalHandleId).toBe("pending-shell:test");
 	});
 
 	it("activates a new terminal opened while a file tab is selected", async () => {
 		const shell = {
+			host: "local",
 			handleId: "sh-after-file",
 			projectId: "proj-1",
 			sessionId: "sess-1",
@@ -871,6 +881,7 @@ describe("SessionView", () => {
 		const session = workspaces[0]!.sessions.find((candidate) => candidate.id === "sess-1")!;
 		session.mode = "chat";
 		const shell = {
+			host: "local" as const,
 			handleId: "sh-chat",
 			projectId: "proj-1",
 			sessionId: "sess-1",
@@ -1454,6 +1465,7 @@ describe("SessionView", () => {
 	it("walks backward through auxiliary terminals before returning to the permanent terminal", () => {
 		shellTerminalsState.data = [
 			{
+				host: "local",
 				handleId: "sh-a",
 				sessionId: "sess-1",
 				title: "first shell",
@@ -1461,6 +1473,7 @@ describe("SessionView", () => {
 				createdAt: "2026-07-24T00:00:00Z",
 			},
 			{
+				host: "local",
 				handleId: "sh-b",
 				sessionId: "sess-1",
 				title: "second shell",
@@ -1474,14 +1487,14 @@ describe("SessionView", () => {
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("sh-b");
 
 		fireEvent.click(screen.getByRole("button", { name: "close second shell" }));
-		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-b", expect.any(Object));
+		expect(closeShellTerminalMock).toHaveBeenCalledWith({ host: "local", id: "sh-b" }, expect.any(Object));
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("sh-a");
 		expect(useUiStore.getState().activeShellTerminalHandleId).toBe("sh-a");
 
 		shellTerminalsState.data = shellTerminalsState.data.filter((shell) => shell.handleId !== "sh-b");
 		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		fireEvent.click(screen.getByRole("button", { name: "close first shell" }));
-		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-a", expect.any(Object));
+		expect(closeShellTerminalMock).toHaveBeenCalledWith({ host: "local", id: "sh-a" }, expect.any(Object));
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("worker");
 		expect(useUiStore.getState().activeShellTerminalHandleId).toBeNull();
 	});

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render as rtlRender, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { refKey } from "../lib/hosts";
 import { SessionView } from "./SessionView";
 import { SessionTopbarProvider } from "./SessionTopbarPortal";
 import { TooltipProvider } from "./ui/tooltip";
@@ -106,6 +107,18 @@ vi.mock("../lib/api-client", () => ({
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({
+		GET: reviewGetMock,
+	}),
+}));
+
 const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() => {
 	const worker = {
 		id: "sess-1",
@@ -118,18 +131,21 @@ const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() =
 		status: "working",
 		updatedAt: "2026-06-10T00:00:00Z",
 		prs: [],
+		host: "local",
 	} satisfies WorkspaceSession;
 	const secondWorker = {
 		...worker,
 		id: "sess-2",
 		title: "do the other thing",
 		branch: "ao/sess-2",
+		host: "local",
 	} satisfies WorkspaceSession;
 	const orchestrator = {
 		...worker,
 		id: "sess-orch",
 		kind: "orchestrator",
 		title: "orchestrate",
+		host: "local",
 	} satisfies WorkspaceSession;
 	const crossProjectWorker = {
 		...worker,
@@ -138,10 +154,11 @@ const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() =
 		workspaceName: "other-app",
 		title: "cross-project task",
 		branch: "ao/cross-project",
+		host: "local",
 	} satisfies WorkspaceSession;
 	const workspaces: WorkspaceSummary[] = [
-		{ id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [worker, secondWorker, orchestrator] },
-		{ id: "proj-2", name: "other-app", path: "/q", type: "main", sessions: [crossProjectWorker] },
+		{ host: "local", id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [worker, secondWorker, orchestrator] },
+		{ host: "local", id: "proj-2", name: "other-app", path: "/q", type: "main", sessions: [crossProjectWorker] },
 	];
 	const workspaceQueryState: { data: WorkspaceSummary[] | undefined; isLoading: boolean } = {
 		data: workspaces,
@@ -680,7 +697,7 @@ describe("SessionView", () => {
 			},
 			{ handleId: "sh-c", title: "loose-shell", workingDir: "/r", createdAt: "2026-07-24T00:00:00Z" },
 		];
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		const tabs = screen.getByTestId("shell-tabs");
 		expect(tabs).toHaveTextContent("sess-1-shell");
 		expect(tabs).not.toHaveTextContent("sess-2-shell");
@@ -701,7 +718,7 @@ describe("SessionView", () => {
 				createdAt: "2026-07-24T00:00:00Z",
 			},
 		];
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(useUiStore.getState().visibleTerminalKindBySession["sess-1"]).toBe("worker");
 
 		fireEvent.click(screen.getByRole("button", { name: "select sess-1-shell" }));
@@ -728,7 +745,7 @@ describe("SessionView", () => {
 			},
 		];
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
 
 		// Selecting the shell keeps the chat surface mounted — the shell renders
@@ -745,10 +762,10 @@ describe("SessionView", () => {
 	it("remounts the session-owned Chat surface when navigation selects another Chat session", () => {
 		workerSession("sess-1").mode = "chat";
 		workerSession("sess-2").mode = "chat";
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		const firstSurface = screen.getByTestId("chat-surface");
 
-		view.rerender(<SessionView sessionId="sess-2" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 
 		expect(screen.getByTestId("chat-surface")).not.toBe(firstSurface);
 	});
@@ -756,7 +773,7 @@ describe("SessionView", () => {
 	// The strip only ever shows the session on screen — pinning another session's
 	// terminal as a tab (and the cross-project picker that did it) is gone (#3208).
 	it("shows only the session on screen in the tab strip", () => {
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByTestId("session-tab")).toHaveTextContent("do the thing");
 		expect(screen.getByTestId("session-tab")).not.toHaveTextContent("do the other thing");
@@ -766,7 +783,7 @@ describe("SessionView", () => {
 	// The daemon roots a shell in the session's worktree when it is given that
 	// session's id, so a new terminal must name the session actually on screen.
 	it("opens new terminals in the on-screen session's worktree", () => {
-		render(<SessionView sessionId="sess-2" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 
 		const newTerminalButton = screen.getByRole("button", { name: "New terminal" });
 		fireEvent.click(newTerminalButton);
@@ -787,7 +804,7 @@ describe("SessionView", () => {
 			shellTerminalsState.data = [shell];
 			options.onSuccess(shell);
 		});
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
 		expect(await screen.findByTestId("session-file-workspace")).toHaveTextContent("src/panel.tsx");
@@ -798,7 +815,7 @@ describe("SessionView", () => {
 	});
 
 	it("does not offer a new terminal for orchestrator sessions", () => {
-		render(<SessionView sessionId="sess-orch" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-orch" }} />);
 
 		expect(screen.queryByRole("button", { name: "New terminal" })).not.toBeInTheDocument();
 	});
@@ -814,7 +831,7 @@ describe("SessionView", () => {
 	] as const)("keeps the git branch out of %s session's top bar", (_label, sessionId, mode, offersNewTerminal) => {
 		workerSession(sessionId).mode = mode;
 
-		render(<SessionView sessionId={sessionId} />);
+		render(<SessionView sessionRef={{ host: "local", id: sessionId }} />);
 
 		expect(screen.queryByText("ao/sess-1")).not.toBeInTheDocument();
 		expect(screen.queryByTitle("ao/sess-1")).not.toBeInTheDocument();
@@ -841,7 +858,7 @@ describe("SessionView", () => {
 			return shell;
 		});
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.getByText("chat surface")).toBeInTheDocument();
 
 		// Opening a shell from chat keeps the chat surface mounted: the shell is
@@ -869,7 +886,7 @@ describe("SessionView", () => {
 				createdAt: "2026-08-31T00:00:00Z",
 			},
 		];
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
 		await screen.findByTestId("session-file-workspace");
@@ -878,15 +895,15 @@ describe("SessionView", () => {
 			"sh-a|file:src/panel.tsx",
 		);
 
-		view.rerender(<SessionView sessionId="sess-2" />);
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
 			"sh-a|file:src/panel.tsx",
 		);
 
 		workerSession("sess-1").mode = "tui";
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.getByTestId("auxiliary-tab-order-tui-sess-1")).toHaveTextContent(
 			"sh-a|file:src/panel.tsx",
 		);
@@ -904,7 +921,7 @@ describe("SessionView", () => {
 				createdAt: "2026-08-31T00:00:00Z",
 			},
 		];
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
 		await screen.findByTestId("session-file-workspace");
@@ -944,7 +961,7 @@ describe("SessionView", () => {
 			data: { reviewerHandleId: "review-sess-1", reviewerHarness: "codex", reviews: [] },
 			error: undefined,
 		});
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await screen.findByRole("button", { name: "Reviewer" });
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
@@ -956,11 +973,11 @@ describe("SessionView", () => {
 
 		worker.status = "terminated";
 		worker.isTerminated = true;
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		fireEvent.click(screen.getByRole("button", { name: "reorder visible tabs" }));
 		worker.status = "working";
 		worker.isTerminated = false;
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await screen.findByRole("button", { name: "Reviewer" });
 		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
@@ -983,14 +1000,14 @@ describe("SessionView", () => {
 		closeShellTerminalMock.mockImplementation((_handleId, options) => {
 			options?.onError?.({ code: "SHELL_TERMINAL_CLOSE_FAILED" });
 		});
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
 		await screen.findByTestId("session-file-workspace");
 		fireEvent.click(screen.getByRole("button", { name: "reorder auxiliary tabs" }));
 		fireEvent.click(screen.getByRole("button", { name: "session one shell" }));
 		fireEvent.click(screen.getByRole("button", { name: "close session one shell" }));
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
 			"sh-a|file:src/panel.tsx",
@@ -1007,7 +1024,7 @@ describe("SessionView", () => {
 		session.status = "idle";
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId={sessionId} />);
+		render(<SessionView sessionRef={{ host: "local", id: sessionId }} />);
 
 		await chooseSessionAction(buttonName);
 
@@ -1025,7 +1042,7 @@ describe("SessionView", () => {
 		session.status = "idle";
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId={sessionId} />);
+		render(<SessionView sessionRef={{ host: "local", id: sessionId }} />);
 		fireEvent.click(screen.getByRole("button", { name: "report chat work" }));
 
 		await chooseSessionAction("Switch to terminal UI");
@@ -1041,7 +1058,7 @@ describe("SessionView", () => {
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
 		interfaceTransitionMock.start.mockRejectedValueOnce(new Error("switch failed"));
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await chooseSessionAction("Switch to chat UI");
 
@@ -1056,7 +1073,7 @@ describe("SessionView", () => {
 		session.activity = { state: "active", lastActivityAt: "2026-08-06T00:00:00Z" };
 		interfaceTransitionMock.start.mockRejectedValueOnce(new Error("switch failed"));
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await chooseSessionAction("Switch to terminal UI");
 		expect(screen.getByRole("dialog", { name: "Switch to Terminal UI?" })).toBeInTheDocument();
@@ -1079,7 +1096,7 @@ describe("SessionView", () => {
 		session.status = status;
 		session.activity = { state: activityState, lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId={sessionId} />);
+		render(<SessionView sessionRef={{ host: "local", id: sessionId }} />);
 
 		await chooseSessionAction(buttonName);
 
@@ -1094,7 +1111,7 @@ describe("SessionView", () => {
 		session.status = "idle";
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		await chooseSessionAction("Switch to terminal UI");
 
 		expect(screen.getByRole("dialog", { name: "Switch to Terminal UI?" })).toBeInTheDocument();
@@ -1114,7 +1131,7 @@ describe("SessionView", () => {
 		session.status = status;
 		session.activity = { state: activityState, lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId={sessionId} />);
+		render(<SessionView sessionRef={{ host: "local", id: sessionId }} />);
 
 		await chooseSessionAction("Switch to terminal UI");
 
@@ -1134,7 +1151,7 @@ describe("SessionView", () => {
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
 		Object.assign(chatSurfaceWorkState, work);
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		fireEvent.click(screen.getByRole("button", { name: "report chat work" }));
 		await chooseSessionAction("Switch to terminal UI");
 
@@ -1152,9 +1169,9 @@ describe("SessionView", () => {
 		}
 		chatSurfaceWorkState.queuedTurnCount = 1;
 
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		fireEvent.click(screen.getByRole("button", { name: "report chat work" }));
-		view.rerender(<SessionView sessionId="sess-2" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 		chatSurfaceWorkState.queuedTurnCount = 0;
 		fireEvent.click(screen.getByRole("button", { name: "report chat work" }));
 		await chooseSessionAction("Switch to terminal UI");
@@ -1173,7 +1190,7 @@ describe("SessionView", () => {
 		session.status = "working";
 		session.activity = { state: "active", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await chooseSessionAction("Switch to terminal UI");
 		expect(interfaceTransitionMock.start).not.toHaveBeenCalled();
@@ -1190,7 +1207,7 @@ describe("SessionView", () => {
 		session.status = "working";
 		session.activity = { state: "active", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		const chatSurface = () => screen.getByTestId("chat-surface");
 		expect(chatSurface()).toHaveAttribute("data-new-work-disabled", "false");
 
@@ -1199,7 +1216,7 @@ describe("SessionView", () => {
 		expect(interfaceTransitionMock.start).toHaveBeenCalledWith({ targetMode: "tui", policy: "drain" });
 
 		interfaceTransitionState.starting = true;
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(chatSurface()).toHaveAttribute("data-new-work-disabled", "true");
 
 		interfaceTransitionState.starting = false;
@@ -1217,16 +1234,16 @@ describe("SessionView", () => {
 				updatedAt: "2026-08-06T00:00:01Z",
 			},
 		};
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(chatSurface()).toHaveAttribute("data-new-work-disabled", "true");
 
 		interfaceTransitionState.status.transition!.phase = "completed";
 		interfaceTransitionState.settling = true;
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(chatSurface()).toHaveAttribute("data-new-work-disabled", "true");
 
 		interfaceTransitionState.settling = false;
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(chatSurface()).toHaveAttribute("data-new-work-disabled", "false");
 	});
 
@@ -1238,16 +1255,16 @@ describe("SessionView", () => {
 			session.status = "working";
 			session.activity = { state: "active", lastActivityAt: "2026-08-06T00:00:00Z" };
 		}
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await chooseSessionAction("Switch to terminal UI");
 		expect(screen.getByRole("dialog", { name: "Switch to Terminal UI?" })).toBeInTheDocument();
 
-		view.rerender(<SessionView sessionId="sess-2" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 		expect(interfaceTransitionMock.start).not.toHaveBeenCalled();
 
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 	});
 
@@ -1265,7 +1282,7 @@ describe("SessionView", () => {
 				finishFirstSwitch = resolve;
 			}),
 		);
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await chooseSessionAction("Switch to terminal UI");
 		fireEvent.click(screen.getByRole("button", { name: /^Stop now and switch/ }));
@@ -1274,7 +1291,7 @@ describe("SessionView", () => {
 			policy: "interrupt",
 		});
 
-		view.rerender(<SessionView sessionId="sess-2" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 		await chooseSessionAction("Switch to terminal UI");
 		expect(screen.getByRole("dialog", { name: "Switch to Terminal UI?" })).toBeInTheDocument();
 
@@ -1289,18 +1306,18 @@ describe("SessionView", () => {
 		session.mode = "chat";
 		session.status = "working";
 		session.activity = { state: "active", lastActivityAt: "2026-08-06T00:00:00Z" };
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await chooseSessionAction("Switch to terminal UI");
 		expect(screen.getByRole("dialog", { name: "Switch to Terminal UI?" })).toBeInTheDocument();
 
 		interfaceTransitionState.status = { supported: true, targetMode: "chat" };
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 		expect(interfaceTransitionMock.start).not.toHaveBeenCalled();
 
 		interfaceTransitionState.status = { supported: true, targetMode: "tui" };
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 	});
 
@@ -1313,7 +1330,7 @@ describe("SessionView", () => {
 		other.status = "working";
 		other.activity = { state: "active", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await chooseSessionAction("Switch to chat UI");
 
@@ -1340,7 +1357,7 @@ describe("SessionView", () => {
 			Object.assign(transition, { noticeAcknowledgedAt: "2026-08-13T08:00:00Z" });
 		});
 
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.getByText(transition.errorDetail)).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("button", { name: "Dismiss interface switch message" }));
 		await waitFor(() =>
@@ -1348,7 +1365,7 @@ describe("SessionView", () => {
 		);
 
 		view.unmount();
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.queryByText(transition.errorDetail)).not.toBeInTheDocument();
 	});
 
@@ -1372,7 +1389,7 @@ describe("SessionView", () => {
 		};
 		interfaceTransitionState.status = { supported: true, targetMode: "chat", transition };
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(screen.queryByTestId("chat-surface")).not.toBeInTheDocument();
@@ -1389,7 +1406,7 @@ describe("SessionView", () => {
 		session.status = "idle";
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId={sessionId} />);
+		render(<SessionView sessionRef={{ host: "local", id: sessionId }} />);
 
 		await userEvent.click(screen.getByRole("button", { name: "Session actions" }));
 		expect(screen.queryByRole("menuitem", { name: "Switch to chat UI" })).not.toBeInTheDocument();
@@ -1402,7 +1419,7 @@ describe("SessionView", () => {
 		session.status = "idle";
 		session.activity = { state: "idle", lastActivityAt: "2026-08-06T00:00:00Z" };
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await userEvent.click(screen.getByRole("button", { name: "Session actions" }));
 		expect(screen.getByRole("menuitem", { name: "Switch to chat UI" })).toBeInTheDocument();
@@ -1425,7 +1442,7 @@ describe("SessionView", () => {
 				createdAt: "2026-07-24T00:01:00Z",
 			},
 		];
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "select second shell" }));
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("sh-b");
@@ -1436,7 +1453,7 @@ describe("SessionView", () => {
 		expect(useUiStore.getState().activeShellTerminalHandleId).toBe("sh-a");
 
 		shellTerminalsState.data = shellTerminalsState.data.filter((shell) => shell.handleId !== "sh-b");
-		view.rerender(<SessionView sessionId="sess-1" />);
+		view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		fireEvent.click(screen.getByRole("button", { name: "close first shell" }));
 		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-a", expect.any(Object));
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("worker");
@@ -1462,7 +1479,7 @@ describe("SessionView", () => {
 			error: undefined,
 		});
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		await waitFor(() => expect(screen.getByTestId("reviewer-harness")).toHaveTextContent("codex"));
 	});
@@ -1485,7 +1502,7 @@ describe("SessionView", () => {
 			error: undefined,
 		});
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		await screen.findByRole("button", { name: "Reviewer" });
 		fireEvent.click(screen.getByRole("button", { name: "Reviewer" }));
 		// The chat surface stays mounted; the reviewer pane renders inside it.
@@ -1516,13 +1533,13 @@ describe("SessionView", () => {
 			error: undefined,
 		});
 
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		await screen.findByRole("button", { name: "select reviewer tab" });
 		fireEvent.click(screen.getByRole("button", { name: "select reviewer tab" }));
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("reviewer");
 
 		act(() => {
-			view.client.setQueryData(["session-reviews", "sess-1"], { reviewerHandleId: "", reviews: [] });
+			view.client.setQueryData(["session-reviews", refKey({ host: "local", id: "sess-1" })], { reviewerHandleId: "", reviews: [] });
 		});
 
 		await waitFor(() => expect(screen.getByTestId("terminal-target")).toHaveTextContent("worker"));
@@ -1551,7 +1568,7 @@ describe("SessionView", () => {
 				error: undefined,
 			});
 
-			const view = render(<SessionView sessionId="sess-1" />);
+			const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 			const reviewerButtonName = mode === "chat" ? "Reviewer" : "select reviewer tab";
 			await screen.findByRole("button", { name: reviewerButtonName });
 			fireEvent.click(screen.getByRole("button", { name: reviewerButtonName }));
@@ -1559,14 +1576,14 @@ describe("SessionView", () => {
 
 			worker.status = "terminated";
 			worker.isTerminated = true;
-			view.rerender(<SessionView sessionId="sess-1" />);
+			view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 			if (mode === "chat") expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
 			expect(screen.getByTestId("terminal-target")).toHaveTextContent("reviewer");
 			expect(screen.queryByRole("button", { name: reviewerButtonName })).not.toBeInTheDocument();
 
 			worker.status = "working";
 			worker.isTerminated = false;
-			view.rerender(<SessionView sessionId="sess-1" />);
+			view.rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 			await screen.findByRole("button", { name: reviewerButtonName });
 			expect(screen.getByTestId("terminal-target")).toHaveTextContent("reviewer");
@@ -1574,7 +1591,7 @@ describe("SessionView", () => {
 	);
 
 	it("opens the inspector with the shared sidebar spring tokens", () => {
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByTestId("panel-group")).toHaveStyle({
 			"--session-inspector-motion-duration": "300ms",
@@ -1586,7 +1603,7 @@ describe("SessionView", () => {
 	});
 
 	it("opens the Summary inspector alongside the terminal by default", () => {
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(screen.getByTestId("panel-inspector")).toHaveAttribute("data-state", "expanded");
@@ -1600,13 +1617,13 @@ describe("SessionView", () => {
 		worker.status = "merged";
 		worker.isTerminated = true;
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(browserViewOptions.current).toMatchObject({ sessionId: "sess-1", terminated: true });
 	});
 
 	it("mounts the inspector open by default", () => {
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		const pane = screen.getByTestId("panel-inspector");
 		expect(pane).not.toHaveAttribute("inert");
@@ -1616,7 +1633,7 @@ describe("SessionView", () => {
 
 	it("mounts collapsed and inert when the store says closed", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		const pane = screen.getByTestId("panel-inspector");
 		expect(pane).toHaveAttribute("inert");
@@ -1629,7 +1646,7 @@ describe("SessionView", () => {
 
 	it("keeps inspector chrome visible from the first render of the opening transition", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		const renderCountBeforeOpening = inspectorVisibilityRenders.length;
 
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
@@ -1640,7 +1657,7 @@ describe("SessionView", () => {
 	});
 
 	it("starts collapsing the resize handle with the inspector panel", () => {
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 
@@ -1652,7 +1669,7 @@ describe("SessionView", () => {
 	it("keeps StrictMode mount from collapsing, then collapses on the first user toggle", () => {
 		render(
 			<StrictMode>
-				<SessionView sessionId="sess-1" />
+				<SessionView sessionRef={{ host: "local", id: "sess-1" }} />
 			</StrictMode>,
 		);
 
@@ -1667,7 +1684,7 @@ describe("SessionView", () => {
 	it("marks the split for live terminal fitting throughout the inspector transition", () => {
 		vi.useFakeTimers();
 		try {
-			render(<SessionView sessionId="sess-1" />);
+			render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 			fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 			const split = screen.getByTestId("panel-group");
@@ -1690,7 +1707,7 @@ describe("SessionView", () => {
 		vi.useFakeTimers();
 		try {
 			act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
-			render(<SessionView sessionId="sess-1" />);
+			render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 			act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 
@@ -1720,7 +1737,7 @@ describe("SessionView", () => {
 			});
 		try {
 			act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
-			render(<SessionView sessionId="sess-1" />);
+			render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 			act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 
@@ -1737,7 +1754,7 @@ describe("SessionView", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
 		render(
 			<StrictMode>
-				<SessionView sessionId="sess-1" />
+				<SessionView sessionRef={{ host: "local", id: "sess-1" }} />
 			</StrictMode>,
 		);
 
@@ -1751,7 +1768,7 @@ describe("SessionView", () => {
 
 	it("toggles the inspector with mod+shift+B", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
 		expect(inspectorOpen("sess-1")).toBe(false);
@@ -1768,7 +1785,7 @@ describe("SessionView", () => {
 
 	it("keeps the inspector toggle and trailing notification pinned while the panel changes state", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		const actions = screen.getByTestId("session-pinned-actions");
 		const toggle = within(actions).getByRole("button", { name: "Close inspector panel" });
 		const notification = within(actions).getByRole("button", { name: "Notifications" });
@@ -1793,7 +1810,7 @@ describe("SessionView", () => {
 			inspectorSessions: { "sess-1": { initialized: true, isOpen: true, view: "browser" } },
 		});
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		const topbar = screen.getByTestId("mock-session-topbar");
 		expect(topbar).toHaveAttribute("data-compact-actions", "true");
@@ -1806,12 +1823,12 @@ describe("SessionView", () => {
 	it("restores and clamps the persisted inspector width in pixels", () => {
 		window.localStorage.setItem("ao.inspector.widthPx", "240");
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(document.documentElement.style.getPropertyValue("--ao-inspector-w")).toBe("340px");
 	});
 
 	it("grows Browser into a co-work canvas while utility surfaces stay consistent", async () => {
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(screen.getByTestId("panel-group")).toHaveAttribute("data-workspace-mode", "utility");
 		expect(document.documentElement.style.getPropertyValue("--ao-inspector-w")).toBe("500px");
 
@@ -1837,7 +1854,7 @@ describe("SessionView", () => {
 	it("keeps Browser entry and utility return on one complete workspace spring", () => {
 		vi.useFakeTimers();
 		try {
-			render(<SessionView sessionId="sess-1" />);
+			render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 			fireEvent.click(screen.getByRole("tab", { name: "Browser" }));
 
 			const split = screen.getByTestId("panel-group");
@@ -1858,7 +1875,7 @@ describe("SessionView", () => {
 
 	it("restores a separate user-sized Browser workspace without changing utility width", () => {
 		window.localStorage.setItem("ao.workspace.browser.canvasWidthPx", "820");
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("tab", { name: "Browser" }));
 		expect(document.documentElement.style.getPropertyValue("--ao-inspector-w")).toBe("820px");
@@ -1869,7 +1886,7 @@ describe("SessionView", () => {
 	});
 
 	it("raises shell pressure only for Browser and clears it for every utility view", async () => {
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(useUiStore.getState().sidebarWorkspaceDemandPx).toBeNull();
 
 		fireEvent.click(screen.getByRole("tab", { name: "Reviews" }));
@@ -1891,11 +1908,11 @@ describe("SessionView", () => {
 	});
 
 	it("mounts the inspector in sync when navigating from an orchestrator session", () => {
-		const { rerender } = render(<SessionView sessionId="sess-orch" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-orch" }} />);
 		expect(screen.queryByTestId("panel-inspector")).not.toBeInTheDocument();
 
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByTestId("panel-inspector")).toHaveAttribute("data-state", "expanded");
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
@@ -1903,14 +1920,14 @@ describe("SessionView", () => {
 
 	it("expands on the first toggle after a closed worker inspector remounts", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		act(() => useUiStore.getState().setInspectorOpen("sess-2", false));
-		rerender(<SessionView sessionId="sess-orch" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-orch" }} />);
 		expect(screen.queryByTestId("panel-inspector")).not.toBeInTheDocument();
 
 		act(() => useUiStore.getState().setInspectorOpen("sess-2", false));
-		rerender(<SessionView sessionId="sess-2" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 		expect(screen.getByTestId("panel-inspector")).toHaveAttribute("data-state", "collapsed");
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
@@ -1920,7 +1937,7 @@ describe("SessionView", () => {
 	});
 
 	it("renders no inspector panel or handle for orchestrator sessions", () => {
-		render(<SessionView sessionId="sess-orch" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-orch" }} />);
 
 		expect(screen.queryByTestId("panel-inspector")).not.toBeInTheDocument();
 		expect(screen.queryByTestId("inspector-resize-handle")).not.toBeInTheDocument();
@@ -1946,7 +1963,7 @@ describe("SessionView", () => {
 		const rect = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(dockRect);
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		try {
-			render(<SessionView sessionId="sess-1" />);
+			render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 			expect(screen.getByText("terminal center")).toBeInTheDocument();
 			fireEvent.click(screen.getByRole("button", { name: "pop browser" }));
@@ -1982,7 +1999,7 @@ describe("SessionView", () => {
 	it("does not reserve the traffic-light band during native macOS fullscreen", () => {
 		nativeFullScreenMock.mockReturnValue(true);
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "pop browser" }));
 
@@ -1991,19 +2008,19 @@ describe("SessionView", () => {
 
 	it("does not carry popped-out browser visibility into the next session", () => {
 		act(() => useUiStore.getState().setInspectorView("sess-1", "browser"));
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "pop browser" }));
 		expect(browserViewOptions.current).toMatchObject({ sessionId: "sess-1", active: true });
 
-		rerender(<SessionView sessionId="sess-2" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 
 		expect(browserViewOptions.current).toMatchObject({ sessionId: "sess-2", active: false });
 	});
 
 	it("opens the files view in the inspector rail first", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
 
@@ -2016,7 +2033,7 @@ describe("SessionView", () => {
 
 	it("opens docked files as center tabs while preserving the agent surface", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
 		fireEvent.click(screen.getByRole("button", { name: "open src/App.tsx" }));
@@ -2032,7 +2049,7 @@ describe("SessionView", () => {
 
 	it("opens a review file target in a center tab and keeps the Files inspector visible", async () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
 
@@ -2072,7 +2089,7 @@ describe("SessionView", () => {
 		});
 
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review basename" }));
 
@@ -2110,7 +2127,7 @@ describe("SessionView", () => {
 		});
 
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "open chat basename" }));
 
@@ -2121,7 +2138,7 @@ describe("SessionView", () => {
 
 	it("maximizes files over the whole app window and returns to the rail", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
 		fireEvent.click(within(screen.getByTestId("panel-inspector")).getByRole("button", { name: "files rail" }));
@@ -2143,7 +2160,7 @@ describe("SessionView", () => {
 	it("does not reserve the traffic-light band for maximized files during native macOS fullscreen", () => {
 		nativeFullScreenMock.mockReturnValue(true);
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
 		fireEvent.click(within(screen.getByTestId("panel-inspector")).getByRole("button", { name: "files rail" }));
@@ -2153,13 +2170,13 @@ describe("SessionView", () => {
 
 	it("badges Browser as unseen for a new live `ao preview` target instead of auto-opening it", () => {
 		const worker = workerSession("sess-1");
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		const viewBefore = inspectorButton().getAttribute("data-view");
 		const openBefore = inspectorOpen("sess-1");
 
 		worker.previewUrl = "http://localhost:5173/";
 		worker.previewRevision = 1;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(inspectorOpen("sess-1")).toBe(openBefore);
@@ -2170,11 +2187,11 @@ describe("SessionView", () => {
 	it("badges Browser as unseen without opening a collapsed inspector when a new live preview arrives", () => {
 		const worker = workerSession("sess-1");
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		worker.previewUrl = "http://localhost:5173/";
 		worker.previewRevision = 1;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(inspectorOpen("sess-1")).toBe(false);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
@@ -2186,18 +2203,18 @@ describe("SessionView", () => {
 		secondWorker.previewUrl = "http://localhost:5173/";
 		secondWorker.previewRevision = 1;
 
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(screen.getByTestId("panel-inspector")).toHaveAttribute("data-state", "expanded");
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 
-		rerender(<SessionView sessionId="sess-2" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 		expect(browserUnseen("sess-2")).toBe(false);
 
 		secondWorker.previewRevision = 2;
-		rerender(<SessionView sessionId="sess-2" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 		expect(browserUnseen("sess-2")).toBe(true);
 	});
@@ -2208,16 +2225,16 @@ describe("SessionView", () => {
 	// identical to a first-ever visit and forced it back to Summary — silently
 	// discarding whatever tab (Files, Browser) the user had left it on.
 	it("remembers the tab a session was left on when returning to it after visiting another session", () => {
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
 		expect(inspectorButton()).toHaveAttribute("data-view", "files");
 
-		rerender(<SessionView sessionId="sess-2" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "files");
 	});
 
@@ -2228,7 +2245,7 @@ describe("SessionView", () => {
 	// marker now lives in the ui-store's persisted inspectorSessions state, so
 	// it survives unmount/remount, not just re-renders of one mounted instance.
 	it("remembers the tab a session was left on after unmounting and remounting the view", () => {
-		const view = render(<SessionView sessionId="sess-1" />);
+		const view = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
@@ -2236,7 +2253,7 @@ describe("SessionView", () => {
 
 		view.unmount();
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "files");
 	});
 
@@ -2247,11 +2264,11 @@ describe("SessionView", () => {
 		workspaceQueryState.data = undefined;
 		workspaceQueryState.isLoading = true;
 
-		const { rerender } = render(<SessionView sessionId="sess-2" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 
 		workspaceQueryState.data = workspaces;
 		workspaceQueryState.isLoading = false;
-		rerender(<SessionView sessionId="sess-2" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 
 		expect(inspectorOpen("sess-2")).toBe(true);
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
@@ -2261,16 +2278,16 @@ describe("SessionView", () => {
 	});
 
 	it("glows for agent browser activity after the user leaves Browser", () => {
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		browserViewState.url = "http://localhost:4173/";
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 
 		act(() => useUiStore.getState().setInspectorView("sess-1", "browser"));
 
 		browserViewState.agentBrowserActive = true;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(browserUnseen("sess-1")).toBe(false);
 
 		// Switching away during an already-running command must still mark the
@@ -2285,7 +2302,7 @@ describe("SessionView", () => {
 		const worker = workerSession("sess-1");
 		worker.previewUrl = "http://localhost:4173/";
 		worker.previewRevision = 1;
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		fireEvent.click(screen.getByRole("button", { name: "pop browser" }));
 		expect(screen.getByRole("button", { name: "browser center" })).toBeInTheDocument();
@@ -2293,7 +2310,7 @@ describe("SessionView", () => {
 
 		worker.previewRevision = 2;
 		browserViewState.agentBrowserActive = true;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(browserUnseen("sess-1")).toBe(false);
 	});
@@ -2313,11 +2330,11 @@ describe("SessionView", () => {
 				},
 			});
 		});
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		fireEvent.click(screen.getByRole("button", { name: "pop browser" }));
 		expect(screen.getByRole("button", { name: "browser center" })).toBeInTheDocument();
 
-		rerender(<SessionView sessionId="sess-2" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-2" }} />);
 
 		expect(browserUnseen("sess-2")).toBe(false);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
@@ -2325,11 +2342,11 @@ describe("SessionView", () => {
 
 	it("does not open Browser when `ao preview clear` removes the target", () => {
 		const worker = workerSession("sess-1");
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		worker.previewUrl = "http://localhost:5173/";
 		worker.previewRevision = 1;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 		expect(browserUnseen("sess-1")).toBe(true);
 
@@ -2340,7 +2357,7 @@ describe("SessionView", () => {
 
 		worker.previewUrl = undefined;
 		worker.previewRevision = 2;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(inspectorOpen("sess-1")).toBe(false);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
@@ -2348,7 +2365,7 @@ describe("SessionView", () => {
 
 		worker.previewUrl = "http://localhost:3000/";
 		worker.previewRevision = 3;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(inspectorOpen("sess-1")).toBe(false);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
@@ -2365,7 +2382,7 @@ describe("SessionView", () => {
 		worker.previewUrl = "http://localhost:5173/";
 		worker.previewRevision = 1;
 
-		render(<SessionView sessionId="sess-1" />);
+		render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 		expect(useUiStore.getState().inspectorSessions["sess-1"]?.browserContentRevealed).toBeFalsy();
@@ -2376,11 +2393,11 @@ describe("SessionView", () => {
 	// Gating the glow on hasBrowserContent/browserContentRevealed meant a
 	// command run before any page loaded never surfaced as unseen.
 	it("glows for agent browser activity even before any browser content has loaded", () => {
-		const { rerender } = render(<SessionView sessionId="sess-1" />);
+		const { rerender } = render(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 
 		browserViewState.agentBrowserActive = true;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 
 		expect(browserUnseen("sess-1")).toBe(true);
 
@@ -2388,7 +2405,7 @@ describe("SessionView", () => {
 		// already empty, so only previewRevision changes.
 		browserViewState.agentBrowserActive = false;
 		workerSession("sess-1").previewRevision = 1;
-		rerender(<SessionView sessionId="sess-1" />);
+		rerender(<SessionView sessionRef={{ host: "local", id: "sess-1" }} />);
 		expect(browserUnseen("sess-1")).toBe(false);
 	});
 });

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -532,8 +532,10 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 	const reviewerTerminal = session && sessionIsActive(session) ? availableReviewerTerminal : undefined;
 
 	// Shell terminals opened inside a session live beside its pane as extra tabs,
-	// scoped to the session on screen so each session has its own shell set.
-	const allShellTerminals = useShellTerminals().data ?? [];
+	// scoped to the session on screen so each session has its own shell set. They
+	// live on that session's host, so that is the host that gets asked — and
+	// filtering the answer by bare session id is then unambiguous.
+	const allShellTerminals = useShellTerminals(sessionRef.host).data ?? [];
 	const shellTerminals = useMemo(
 		() => allShellTerminals.filter((shell) => shell.sessionId === sessionId),
 		[allShellTerminals, sessionId],

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { refKey, type Ref } from "../lib/hosts";
 import { PanelRight, Plus } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import {
@@ -59,9 +60,10 @@ import { useWorkspaceSession } from "../hooks/useWorkspaceQuery";
 import { useSessionHandoffMenu } from "../hooks/useSessionHandoffMenu";
 import { clearSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
-import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
 import { sessionWorkspaceFilesQueryOptions } from "../hooks/useSessionWorkspaceFiles";
 import { matchWorkspaceFilePath } from "../lib/workspace-file-path";
+import { apiErrorCode, apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
 import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
 import {
 	activateSessionFile,
@@ -243,7 +245,7 @@ function reviewerTerminalFromReviews(data?: ReviewsResponse): ReviewerTerminalTa
 }
 
 type SessionViewProps = {
-	sessionId: string;
+	sessionRef: Ref;
 };
 
 // Mirrors the left sidebar: a Motion gap takes layout width while a sibling
@@ -376,7 +378,8 @@ function SessionInspectorRail({
 // x-transform). Summary/Reviews/Files share a utility width, while Browser
 // automatically grows into a co-work canvas. Chat readability clamps either
 // profile before the conversation can become unusably narrow.
-export function SessionView({ sessionId }: SessionViewProps) {
+export function SessionView({ sessionRef }: SessionViewProps) {
+	const sessionId = sessionRef.id;
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const workspaceQuery = useWorkspaceSession(sessionId);
@@ -509,7 +512,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const session = workspaceQuery.data;
 	const interfaceSwitch = useSessionInterfaceTransition(session?.id);
 	const reviewerQuery = useQuery({
-		queryKey: ["session-reviews", sessionId],
+		queryKey: ["session-reviews", refKey(sessionRef)],
 		enabled: Boolean(
 			window.ao && session && sessionIsActive(session) && !isOrchestratorSession(session) && session.prs.length > 0,
 		),
@@ -518,7 +521,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			return data?.reviews?.some((review) => review.status === "running") ? 2500 : false;
 		},
 		queryFn: async () => {
-			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/reviews", {
+			const { data, error } = await clientFor(sessionRef.host).GET("/api/v1/sessions/{sessionId}/reviews", {
 				params: { path: { sessionId } },
 			});
 			if (error) throw new Error(apiErrorMessage(error, "Unable to load reviews"));
@@ -1198,9 +1201,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 
 	const fetchWorkspaceFiles = useCallback(async () => {
 		return queryClient.fetchQuery(
-			sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")),
+			sessionWorkspaceFilesQueryOptions(sessionRef, t("files.error.loadWorkspace")),
 		);
-	}, [queryClient, sessionId, t]);
+	}, [queryClient, sessionRef, t]);
 
 	const openResolvedWorkspaceFile = useCallback(
 		async (rawPath: string) => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -382,7 +382,7 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 	const sessionId = sessionRef.id;
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
-	const workspaceQuery = useWorkspaceSession(sessionId);
+	const workspaceQuery = useWorkspaceSession(sessionRef);
 	const theme = useResolvedTheme();
 	const prefersReducedMotion = useReducedMotion();
 	const isInspectorOpen = useUiStore((state) => state.inspectorSessions[sessionId]?.isOpen ?? true);

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -627,7 +627,7 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 					kind: "reviewer",
 					handleId: reviewerTerminal.handleId,
 					harness: reviewerTerminal.harness,
-					sessionId,
+					session: sessionRef,
 				});
 				setFileTabsBySession((current) => ({
 					...current,
@@ -640,9 +640,10 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 				setActiveShellTerminal(shell.handleId);
 				setTerminalTarget({
 					generation: shell.createdAt,
+					host: shell.host,
 					kind: "shell",
 					handleId: shell.handleId,
-					sessionId,
+					session: sessionRef,
 					title: shell.title,
 				});
 				setFileTabsBySession((current) => ({
@@ -658,7 +659,7 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 				[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
 			}));
 		},
-		[reviewerTerminal, sessionId, shellTerminals, setActiveShellTerminal],
+		[reviewerTerminal, sessionId, sessionRef, shellTerminals, setActiveShellTerminal],
 	);
 	const adjacentAuxiliaryTab = useCallback(
 		(closingKey: string) => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -559,7 +559,8 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 	const setVisibleTerminalKind = useUiStore((state) => state.setVisibleTerminalKind);
 	const clearVisibleTerminalKind = useUiStore((state) => state.clearVisibleTerminalKind);
 	const renameShellTerminalByHandle = useCallback(
-		(handleId: string, title: string) => renameShellTerminal.mutate({ handleId, title }),
+		(handleId: string, title: string) =>
+			renameShellTerminal.mutate({ terminal: { host: sessionRef.host, id: handleId }, title }),
 		[renameShellTerminal],
 	);
 
@@ -568,7 +569,10 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 	// workspace can no longer be resolved).
 	const addShellTerminal = useCallback(() => {
 		const shell = openShellTerminal.open(
-			{ projectId: session?.workspaceId, sessionId },
+			{
+				project: session ? { host: session.host, id: session.workspaceId } : undefined,
+				session: sessionRef,
+			},
 			{
 				onSuccess: (openedShell) => {
 					setActiveShellTerminal(openedShell.handleId);
@@ -578,9 +582,10 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 					}));
 					setTerminalTarget({
 						generation: openedShell.createdAt,
+						host: openedShell.host,
 						kind: "shell",
 						handleId: openedShell.handleId,
-						sessionId,
+						session: sessionRef,
 						title: openedShell.title,
 					});
 				},
@@ -594,12 +599,13 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 		setActiveShellTerminal(shell.handleId);
 		setTerminalTarget({
 			generation: shell.createdAt,
+			host: shell.host,
 			kind: "shell",
 			handleId: shell.handleId,
-			sessionId,
+			session: sessionRef,
 			title: shell.title,
 		});
-	}, [openShellTerminal, sessionId, session?.workspaceId, setActiveShellTerminal]);
+	}, [openShellTerminal, sessionId, session, sessionRef, setActiveShellTerminal]);
 
 	const activateAuxiliaryTab = useCallback(
 		(key?: string) => {
@@ -672,9 +678,10 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 			}));
 			setTerminalTarget({
 				generation: shell.createdAt,
+				host: shell.host,
 				kind: "shell",
 				handleId: shell.handleId,
-				sessionId,
+				session: sessionRef,
 				title: shell.title,
 			});
 		},
@@ -689,12 +696,15 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 			} else if (activeShellTerminalHandleId === handleId) {
 				setActiveShellTerminal(null);
 			}
-			closeShellTerminal.mutate(handleId, {
-				onSuccess: () => removeAuxiliaryTab(handleId),
-				onError: (error) => {
-					if (apiErrorCode(error) === "SHELL_TERMINAL_NOT_FOUND") removeAuxiliaryTab(handleId);
+			closeShellTerminal.mutate(
+				{ host: sessionRef.host, id: handleId },
+				{
+					onSuccess: () => removeAuxiliaryTab(handleId),
+					onError: (error) => {
+						if (apiErrorCode(error) === "SHELL_TERMINAL_NOT_FOUND") removeAuxiliaryTab(handleId);
+					},
 				},
-			});
+			);
 		},
 		[
 			activeShellTerminalHandleId,
@@ -702,6 +712,7 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 			adjacentAuxiliaryTab,
 			closeShellTerminal,
 			removeAuxiliaryTab,
+			sessionRef,
 			setActiveShellTerminal,
 			terminalTarget,
 		],
@@ -719,12 +730,12 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 	}, [sessionId, setActiveShellTerminal]);
 	const selectReviewerTerminal = useCallback((target: ReviewerTerminalTarget) => {
 		setActiveShellTerminal(null);
-		setTerminalTarget({ kind: "reviewer", handleId: target.handleId, harness: target.harness, sessionId });
+		setTerminalTarget({ kind: "reviewer", handleId: target.handleId, harness: target.harness, session: sessionRef });
 		setFileTabsBySession((current) => ({
 			...current,
 			[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
 		}));
-	}, [sessionId, setActiveShellTerminal]);
+	}, [sessionId, sessionRef, setActiveShellTerminal]);
 	const openCenterFile = useCallback((path: string) => {
 		setFileTabsBySession((current) => ({
 			...current,
@@ -777,9 +788,10 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 				? current
 				: {
 						generation: shell.createdAt,
+						host: shell.host,
 						kind: "shell",
 						handleId: shell.handleId,
-						sessionId,
+						session: sessionRef,
 						title: shell.title,
 					},
 		);
@@ -1084,7 +1096,7 @@ export function SessionView({ sessionRef }: SessionViewProps) {
 	// Route props change one render before the passive reset above. Reject the
 	// previous session's shell/reviewer synchronously so its handle can never be
 	// cached under the destination session.
-	const routedTerminalTarget = terminalTargetBelongsToSession(terminalTarget, sessionId)
+	const routedTerminalTarget = terminalTargetBelongsToSession(terminalTarget, sessionRef)
 		? terminalTarget
 		: ({ kind: "worker" } satisfies TerminalTarget);
 	// Chat surface stays mounted in chat mode for worker, reviewer, and shell

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { refKey } from "../lib/hosts";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { toKanbanColumn } from "@aoagents/product-ui";
 import { appI18n } from "../i18n";
@@ -56,6 +57,16 @@ vi.mock("../lib/api-client", () => ({
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ POST: (...args: unknown[]) => postMock(...args) }),
+}));
+
 vi.mock("../lib/bridge", () => ({
 	aoBridge: {
 		clipboard: {
@@ -91,7 +102,7 @@ function renderBoardWithClient(queryClient: QueryClient, projectId?: string) {
 	return render(
 		<QueryClientProvider client={queryClient}>
 			<TooltipProvider>
-				<SessionsBoard projectId={projectId} />
+				<SessionsBoard project={projectId ? { host: "local", id: projectId } : undefined} />
 			</TooltipProvider>
 		</QueryClientProvider>,
 	);
@@ -332,7 +343,7 @@ describe("SessionsBoard", () => {
 		usageQueryMock.mockReturnValue({
 			data: new Map([
 				[
-					"s-active",
+					refKey({ host: "local", id: "s-active" }),
 					{
 						estimatedCost: {
 							cachedInputNanos: 100_000_000,
@@ -349,7 +360,7 @@ describe("SessionsBoard", () => {
 					},
 				],
 				[
-					"s-empty",
+					refKey({ host: "local", id: "s-empty" }),
 					{
 						estimatedCost: null,
 						sessionId: "s-empty",
@@ -359,7 +370,7 @@ describe("SessionsBoard", () => {
 					},
 				],
 				[
-					"s-tokens",
+					refKey({ host: "local", id: "s-tokens" }),
 					{
 						estimatedCost: null,
 						sessionId: "s-tokens",
@@ -369,7 +380,7 @@ describe("SessionsBoard", () => {
 					},
 				],
 				[
-					"s-dead",
+					refKey({ host: "local", id: "s-dead" }),
 					{
 						estimatedCost: {
 							cachedInputNanos: null,
@@ -404,7 +415,7 @@ describe("SessionsBoard", () => {
 		const tokensOnlyCard = screen.getByText("tokens worker").closest('[data-testid="board-session-card"]') as HTMLElement;
 		expect(within(tokensOnlyCard).getByText("800", { selector: "span" })).toHaveAttribute("aria-hidden", "true");
 		expect(within(tokensOnlyCard).getByText("800 tokens")).toHaveClass("sr-only");
-		expect(usageQueryMock).toHaveBeenCalledWith("p1");
+		expect(usageQueryMock).toHaveBeenCalledWith({ host: "local", id: "p1" });
 
 		const archive = await expandArchive();
 		expect(within(archive).getByText("$0.02")).toHaveAttribute("aria-hidden", "true");
@@ -424,7 +435,7 @@ describe("SessionsBoard", () => {
 		usageQueryMock.mockReturnValue({
 			data: new Map([
 				[
-					"s-keyboard",
+					refKey({ host: "local", id: "s-keyboard" }),
 					{
 						estimatedCost: {
 							cachedInputNanos: 100_000_000,
@@ -475,7 +486,7 @@ describe("SessionsBoard", () => {
 		usageQueryMock.mockReturnValue({
 			data: new Map([
 				[
-					"s-tokens",
+					refKey({ host: "local", id: "s-tokens" }),
 					{
 						estimatedCost: null,
 						incomplete: false,
@@ -646,7 +657,7 @@ describe("SessionsBoard", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				workspaceWithSessions([
-					{
+					{ host: "local",
 						id: "s-exited",
 						workspaceId: "p1",
 						workspaceName: "radic",
@@ -758,7 +769,7 @@ describe("SessionsBoard", () => {
 		view.rerender(
 			<QueryClientProvider client={queryClient}>
 				<TooltipProvider>
-					<SessionsBoard projectId="p2" />
+					<SessionsBoard project={{ host: "local", id: "p2" }} />
 				</TooltipProvider>
 			</QueryClientProvider>,
 		);
@@ -901,8 +912,8 @@ describe("SessionsBoard", () => {
 		);
 		expect(invalidate).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "p1", sessionId: "s-dead" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "s-dead" },
 		});
 	});
 
@@ -1051,7 +1062,7 @@ describe("SessionsBoard", () => {
 		view.rerender(
 			<QueryClientProvider client={queryClient}>
 				<TooltipProvider>
-					<SessionsBoard projectId="p2" />
+					<SessionsBoard project={{ host: "local", id: "p2" }} />
 				</TooltipProvider>
 			</QueryClientProvider>,
 		);
@@ -1092,7 +1103,7 @@ describe("SessionsBoard", () => {
 		view.rerender(
 			<QueryClientProvider client={queryClient}>
 				<TooltipProvider>
-					<SessionsBoard projectId="p2" />
+					<SessionsBoard project={{ host: "local", id: "p2" }} />
 				</TooltipProvider>
 			</QueryClientProvider>,
 		);
@@ -1123,8 +1134,8 @@ describe("SessionsBoard", () => {
 
 		expect(postMock).not.toHaveBeenCalled();
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "p1", sessionId: "s-merged" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "s-merged" },
 		});
 	});
 
@@ -1441,6 +1452,7 @@ describe("SessionsBoard", () => {
 
 function workspaceWithSessions(sessions: WorkspaceSession[]): WorkspaceSummary {
 	return {
+		host: "local",
 		id: "p1",
 		name: "radic",
 		path: "/tmp/radic",
@@ -1452,6 +1464,7 @@ function boardSession(
 	overrides: Pick<WorkspaceSession, "id" | "title" | "status"> & Partial<WorkspaceSession>,
 ): WorkspaceSession {
 	return {
+		host: "local",
 		workspaceId: "p1",
 		workspaceName: "radic",
 		provider: "claude-code",
@@ -1479,6 +1492,7 @@ function activeAgentSwitch(
 
 function terminatedSession(overrides: Partial<WorkspaceSession> = {}): WorkspaceSession {
 	return {
+		host: "local",
 		id: "s-dead",
 		workspaceId: "p1",
 		workspaceName: "radic",

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -38,7 +38,17 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	workspaceQueryKey: ["workspaces"],
-	useWorkspaceQuery: workspaceQueryMock,
+	// useWorkspaceQuery returns one section per host now; these fixtures still
+	// describe the local host's workspaces, so wrap them in its section.
+	useWorkspaceQuery: () => {
+		const result = workspaceQueryMock();
+		return {
+			...result,
+			data: result.data
+				? [{ host: "local", label: "Local", status: "ready", workspaces: result.data, failure: null }]
+				: undefined,
+		};
+	},
 	useWorkspaceScope: (projectId?: string) => {
 		const query = workspaceQueryMock();
 		return {
@@ -61,7 +71,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({ POST: (...args: unknown[]) => postMock(...args) }),
@@ -190,11 +205,13 @@ describe("SessionsBoard", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
+					host: "local",
 					id: "p1",
 					name: "solkit-ui",
 					path: "/tmp/solkit-ui",
 					sessions: [
 						{
+							host: "local",
 							id: "s1",
 							workspaceId: "p1",
 							workspaceName: "solkit-ui",
@@ -233,11 +250,13 @@ describe("SessionsBoard", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
+					host: "local",
 					id: "p1",
 					name: "solkit-ui",
 					path: "/tmp/solkit-ui",
 					sessions: [
 						{
+							host: "local",
 							id: "orch-1",
 							workspaceId: "p1",
 							workspaceName: "solkit-ui",
@@ -273,6 +292,7 @@ describe("SessionsBoard", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
+					host: "local",
 					id: "p1",
 					name: "solkit-ui",
 					path: "/tmp/solkit-ui",
@@ -292,11 +312,13 @@ describe("SessionsBoard", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
+					host: "local",
 					id: "p1",
 					name: "radic",
 					path: "/tmp/radic",
 					sessions: [
 						{
+							host: "local",
 							id: "s1",
 							workspaceId: "p1",
 							workspaceName: "radic",
@@ -588,11 +610,13 @@ describe("SessionsBoard", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
+					host: "local",
 					id: "p1",
 					name: "radic",
 					path: "/tmp/radic",
 					sessions: [
 						{
+							host: "local",
 							id: "s0",
 							workspaceId: "p1",
 							workspaceName: "radic",
@@ -605,6 +629,7 @@ describe("SessionsBoard", () => {
 							prs: [],
 						},
 						{
+							host: "local",
 							id: "s1",
 							workspaceId: "p1",
 							workspaceName: "radic",
@@ -617,6 +642,7 @@ describe("SessionsBoard", () => {
 							prs: [],
 						},
 						{
+							host: "local",
 							id: "s2",
 							workspaceId: "p1",
 							workspaceName: "radic",
@@ -696,11 +722,13 @@ describe("SessionsBoard", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
+					host: "local",
 					id: "p1",
 					name: "radic",
 					path: "/tmp/radic",
 					sessions: [
 						{
+							host: "local",
 							id: "p1-active",
 							workspaceId: "p1",
 							workspaceName: "radic",
@@ -713,6 +741,7 @@ describe("SessionsBoard", () => {
 							prs: [],
 						},
 						{
+							host: "local",
 							id: "p1-idle",
 							workspaceId: "p1",
 							workspaceName: "radic",
@@ -727,11 +756,13 @@ describe("SessionsBoard", () => {
 					],
 				},
 				{
+					host: "local",
 					id: "p2",
 					name: "other",
 					path: "/tmp/other",
 					sessions: [
 						{
+							host: "local",
 							id: "p2-active",
 							workspaceId: "p2",
 							workspaceName: "other",
@@ -744,6 +775,7 @@ describe("SessionsBoard", () => {
 							prs: [],
 						},
 						{
+							host: "local",
 							id: "p2-idle",
 							workspaceId: "p2",
 							workspaceName: "other",
@@ -1044,6 +1076,7 @@ describe("SessionsBoard", () => {
 			data: [
 				workspaceWithSessions([terminatedSession()]),
 				{
+					host: "local",
 					id: "p2",
 					name: "other",
 					path: "/tmp/other",
@@ -1085,6 +1118,7 @@ describe("SessionsBoard", () => {
 			data: [
 				workspaceWithSessions([terminatedSession()]),
 				{
+					host: "local",
 					id: "p2",
 					name: "other",
 					path: "/tmp/other",

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState, type MouseEvent } from "react";
+import { LOCAL_HOST, refKey, type Ref } from "../lib/hosts";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
@@ -54,7 +55,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type SessionsBoardProps = {
 	/** When set, the board shows only this project's sessions. */
-	projectId?: string;
+	project?: Ref;
 };
 
 type UsageBySession = ReadonlyMap<string, SessionUsageSummary>;
@@ -75,7 +76,8 @@ const isMac = isMacPlatform();
 const dragStyle = isMac ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
-export function SessionsBoard({ projectId }: SessionsBoardProps) {
+export function SessionsBoard({ project }: SessionsBoardProps) {
+	const projectId = project?.id;
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
@@ -85,7 +87,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const columns: KanbanColumnView[] = boardKanbanColumnOrder.map((column) => getKanbanColumnView(column, t));
 	const workspaceQuery = useWorkspaceQuery();
 	const shell = useShellMaybe();
-	const liveUsageBySession = useSessionUsageSummaries(projectId).data ?? emptyUsageBySession;
+	const liveUsageBySession = useSessionUsageSummaries(project).data ?? emptyUsageBySession;
 	// Evaluated at render so platform mocks in tests can flip the in-panel chrome.
 	const boardActionsInPanel = usesBoardActionsInPanel();
 	/** Bell lives in the board action row when the shell topbar does not host it. */
@@ -103,8 +105,8 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const usageBySession = usesPreviewWorkspaceData
 		? new Map<string, SessionUsageSummary>(
 				sessions.map((session, index) => [
-						session.id,
-						liveUsageBySession.get(session.id) ?? {
+						refKey(session),
+						liveUsageBySession.get(refKey(session)) ?? {
 							estimatedCost: null,
 							sessionId: session.id,
 							processedTokens: [18_400, 46_700, 12_900, 81_200, 3_100][index % 5],
@@ -182,16 +184,16 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const openSession = useCallback((session: WorkspaceSession) =>
 		void navigate({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: session.workspaceId, sessionId: session.id },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: session.host, sessionId: session.id },
 		}), [navigate]);
 
 	const openOrchestrator = async (mode?: "tui") => {
 		if (!projectId || isProjectRestarting) return;
 		if (orchestrator) {
 			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId: orchestrator.id },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: orchestrator.host, sessionId: orchestrator.id },
 			});
 			return;
 		}
@@ -218,7 +220,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 		}
 		if (!hasConfiguredOrchestratorAgent(workspace)) {
 			if (workspace) {
-				useUiStore.getState().openProjectSettings(projectId);
+				if (project) useUiStore.getState().openProjectSettings(project);
 			}
 			return;
 		}
@@ -231,8 +233,8 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 			setOrchestratorStartupError(projectId, null);
 			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: project?.host ?? LOCAL_HOST, sessionId },
 			});
 		} catch (error) {
 			// Never fail silently: the daemon's message (e.g. a worktree/branch
@@ -246,9 +248,9 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	};
 
 	const restartOrchestrator = async () => {
-		if (!projectId) return;
+		if (!project) return;
 		await restartProjectOrchestrator({
-			projectId,
+			project,
 			queryClient,
 			navigate,
 			setProjectRestarting,
@@ -276,7 +278,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							className="topbar-control--labeled"
 							data-priority="primary"
 							disabled={isProjectRestarting}
-							onClick={() => projectId && requestNewTask(projectId)}
+							onClick={() => project && requestNewTask(project)}
 							variant="accent"
 						>
 							<Plus className="size-icon-md" aria-hidden="true" />
@@ -381,7 +383,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						hasOrchestrator={orchestrator !== undefined}
 						isSpawning={isSpawning}
 						isProjectRestarting={isProjectRestarting}
-						onNewTask={() => projectId && requestNewTask(projectId)}
+						onNewTask={() => project && requestNewTask(project)}
 						onOpenOrchestrator={() => void openOrchestrator()}
 						onOpenOrchestratorAsTui={canCreateAsTui ? () => void openOrchestrator("tui") : undefined}
 						spawnError={visibleSpawnError}
@@ -396,7 +398,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 								onOpenSession={openSession}
 								onTerminateSession={terminateSession.mutate}
 								session={session}
-								usage={usageBySession.get(session.id)}
+								usage={usageBySession.get(refKey(session))}
 							/>
 						)}
 						sessions={activeSessions}
@@ -479,8 +481,8 @@ const BoardArchivePanel = memo(function BoardArchivePanel({
 			if (!isStillActiveProject()) return;
 			if (result.status === "success") {
 				void navigate({
-					to: "/projects/$projectId/sessions/$sessionId",
-					params: { projectId: session.workspaceId, sessionId: session.id },
+					to: "/host/$hostId/session/$sessionId",
+					params: { hostId: session.host, sessionId: session.id },
 				});
 				return;
 			}
@@ -511,7 +513,7 @@ const BoardArchivePanel = memo(function BoardArchivePanel({
 						restoreAction={(event) => void restoreArchivedSession(event, session)}
 						restoreError={restoreErrors[session.id]}
 						session={session}
-						usage={usageBySession.get(session.id)}
+						usage={usageBySession.get(refKey(session))}
 					/>
 				)}
 				resetKey={projectId}

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -15,6 +15,7 @@ import {
 	newestActiveOrchestrator,
 	orchestratorHealth,
 	workerSessions,
+	flattenHostSections,
 } from "../types/workspace";
 import {
 	boardKanbanColumnOrder,
@@ -92,8 +93,10 @@ export function SessionsBoard({ project }: SessionsBoardProps) {
 	const boardActionsInPanel = usesBoardActionsInPanel();
 	/** Bell lives in the board action row when the shell topbar does not host it. */
 	const boardOwnsNotificationCenter = isLinuxPlatform() || boardActionsInPanel;
-	const all = workspaceQuery.data ?? [];
-	const workspaces = projectId ? all.filter((workspace) => workspace.id === projectId) : all;
+	const all = flattenHostSections(workspaceQuery.data);
+	const workspaces = project
+		? all.filter((workspace) => workspace.host === project.host && workspace.id === project.id)
+		: all;
 	const workspace = projectId ? workspaces[0] : undefined;
 	// Board chrome stays route-oriented; project context remains in the sidebar.
 	const boardLabel = t("shell.board");

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -150,7 +150,7 @@ const DesktopSessionCard = memo(function DesktopSessionCard({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [confirmOpen, setConfirmOpen] = useState(false);
-	const summaries = sessionPRDisplaySummaries(session, useSessionScmSummary(session.id).data);
+	const summaries = sessionPRDisplaySummaries(session, useSessionScmSummary(session).data);
 	const termination = useTerminateSessionState(session.id);
 	const showTerminate = interactive && session.isTerminated !== true && onTerminate;
 	const keepTerminateVisible = session.status === "merged";

--- a/frontend/src/renderer/components/SettingsDialog.test.tsx
+++ b/frontend/src/renderer/components/SettingsDialog.test.tsx
@@ -45,7 +45,7 @@ describe("SettingsDialog", () => {
 	});
 
 	it("does not dismiss project settings while a save is pending", async () => {
-		useUiStore.getState().openProjectSettings("proj-1");
+		useUiStore.getState().openProjectSettings({ host: "local", id: "proj-1" });
 		render(<SettingsDialog />);
 
 		await userEvent.click(await screen.findByRole("button", { name: "Start pending save" }));
@@ -53,7 +53,7 @@ describe("SettingsDialog", () => {
 		expect(closeButton).toBeDisabled();
 
 		await userEvent.keyboard("{Escape}");
-		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", project: { host: "local", id: "proj-1" } });
 	});
 
 	it("opens the requested global settings page", async () => {

--- a/frontend/src/renderer/components/SettingsDialog.tsx
+++ b/frontend/src/renderer/components/SettingsDialog.tsx
@@ -186,7 +186,7 @@ export function SettingsDialog() {
 						<div className={cn(settingsDialogBodyClass, "flex-1")}>
 							{displaySettings?.scope === "project" ? (
 								<ProjectSettingsForm
-									projectId={displaySettings.projectId}
+									projectRef={displaySettings.project}
 									section={activeProjectSection}
 									onSaveState={setProjectSaveState}
 								/>

--- a/frontend/src/renderer/components/ShellTerminalTab.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.test.tsx
@@ -10,6 +10,7 @@ vi.mock("../lib/platform", () => ({ isWindowsPlatform }));
 afterEach(() => isWindowsPlatform.mockReturnValue(false));
 
 const shell: ShellTerminal = {
+	host: "local",
 	handleId: "shellterm-1",
 	projectId: "ao",
 	workingDir: "/repos/ao",

--- a/frontend/src/renderer/components/ShellTerminalsView.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.test.tsx
@@ -1,6 +1,7 @@
-import { render as rtlRender, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render as rtlRender, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ShellTerminalsView } from "./ShellTerminalsView";
 import { TooltipProvider } from "./ui/tooltip";
 
@@ -8,10 +9,25 @@ function render(ui: ReactElement) {
 	return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
-vi.mock("../hooks/useShellTerminals", () => ({
-	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
-	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
-	useShellTerminals: () => ({ data: [] }),
+const { hosts } = vi.hoisted(() => ({
+	hosts: {
+		connected: [] as string[],
+		shells: {} as Record<string, Array<Record<string, unknown>>>,
+	},
+}));
+
+// The real useShellTerminals hooks run against these: the standalone screen is
+// an app-wide list, so what it shows is decided by which hosts it asks.
+vi.mock("../lib/host-clients", () => ({
+	connectedHosts: () => hosts.connected,
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: (host: string) => ({
+		GET: () => Promise.resolve({ data: { shellTerminals: hosts.shells[host] ?? [] }, error: undefined }),
+		DELETE: () => Promise.resolve({ data: {}, error: undefined }),
+		PATCH: () => Promise.resolve({ data: {}, error: undefined }),
+		POST: () => Promise.resolve({ data: {}, error: undefined }),
+	}),
 }));
 
 vi.mock("../lib/shell-context", () => ({
@@ -20,12 +36,65 @@ vi.mock("../lib/shell-context", () => ({
 
 vi.mock("./TerminalPane", () => ({ TerminalPane: () => <div>terminal body</div> }));
 
+function shell(overrides: { handleId: string; title: string; sessionId?: string }) {
+	return {
+		workingDir: "/repos/app",
+		createdAt: "2026-08-24T00:00:00Z",
+		...overrides,
+	};
+}
+
+function renderView() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<ShellTerminalsView />
+		</QueryClientProvider>,
+	);
+}
+
 describe("ShellTerminalsView", () => {
+	beforeEach(() => {
+		hosts.connected = [];
+		hosts.shells = {};
+	});
+
 	it("points the empty state at the visible plus tab-strip control", () => {
-		render(<ShellTerminalsView />);
+		renderView();
 
 		expect(screen.getByText("No terminals open")).toBeInTheDocument();
 		expect(screen.getByText(/use the \+ button/i)).toBeInTheDocument();
 		expect(screen.queryByText(/terminal button/i)).not.toBeInTheDocument();
+	});
+
+	// The standalone terminals screen is app-wide, not local-only: a shell opened
+	// on a remote host has nowhere else to appear, so asking only the local host
+	// leaves it with no UI surface at all.
+	it("lists the standalone shells of every connected host", async () => {
+		hosts.connected = ["remote"];
+		hosts.shells = {
+			local: [shell({ handleId: "sh-local", title: "local shell" })],
+			remote: [shell({ handleId: "sh-remote", title: "remote shell" })],
+		};
+
+		renderView();
+
+		expect(await screen.findByText("remote shell")).toBeInTheDocument();
+		expect(screen.getByText("local shell")).toBeInTheDocument();
+	});
+
+	// A session's shells belong beside that session's pane, on whichever host
+	// they live — the filter has to hold across hosts, not just locally.
+	it("leaves every host's session-scoped shells out of the standalone list", async () => {
+		hosts.connected = ["remote"];
+		hosts.shells = {
+			local: [shell({ handleId: "sh-local", title: "local shell" })],
+			remote: [shell({ handleId: "sh-remote-sess", title: "remote session shell", sessionId: "sess-1" })],
+		};
+
+		renderView();
+
+		await waitFor(() => expect(screen.getByText("local shell")).toBeInTheDocument());
+		expect(screen.queryByText("remote session shell")).toBeNull();
 	});
 });

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -63,7 +63,7 @@ export function ShellTerminalsView() {
 	useEffect(
 		() =>
 			aoBridge.app.onCloseShellTerminalShortcut(() => {
-				if (active) closeShellTerminal.mutate(active.handleId);
+				if (active) closeShellTerminal.mutate({ host: active.host, id: active.handleId });
 			}),
 		[active, closeShellTerminal],
 	);
@@ -122,8 +122,8 @@ export function ShellTerminalsView() {
 							<ShellTerminalTab
 								key={shell.handleId}
 								isActive={isActive}
-								onClose={() => closeShellTerminal.mutate(shell.handleId)}
-								onRename={(title) => renameShellTerminal.mutate({ handleId: shell.handleId, title })}
+								onClose={() => closeShellTerminal.mutate({ host: shell.host, id: shell.handleId })}
+								onRename={(title) => renameShellTerminal.mutate({ terminal: { host: shell.host, id: shell.handleId }, title })}
 								onSelect={() => setActiveShellTerminal(shell.handleId)}
 								shell={shell}
 							/>
@@ -170,9 +170,10 @@ export function ShellTerminalsView() {
 						fontSize={12}
 						terminalTarget={{
 							generation: active.createdAt,
+							host: active.host,
 							kind: "shell",
 							handleId: active.handleId,
-							sessionId: active.sessionId,
+							session: active.sessionId ? { host: active.host, id: active.sessionId } : undefined,
 							title: active.title,
 						}}
 						theme={theme}

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { defaultShortcutBindings, shortcutBindingLabel } from "../../shared/shortcuts";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
-import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
+import { useCloseShellTerminal, useConnectedShellTerminals, useRenameShellTerminal } from "../hooks/useShellTerminals";
 import { useShell } from "../lib/shell-context";
 import { aoBridge } from "../lib/bridge";
 import { isMacPlatform } from "../lib/platform";
@@ -29,8 +29,10 @@ export function ShellTerminalsView() {
 	const { daemonStatus } = useShell();
 	const theme = useResolvedTheme();
 	// The standalone screen shows only session-less shells; a session's own
-	// shells belong to that session's tab strip, not this global list.
-	const shellTerminals = (useShellTerminals().data ?? []).filter((s) => !s.sessionId);
+	// shells belong to that session's tab strip, not this global list. It is the
+	// only home a shell opened on a remote host has, so it asks every connected
+	// host rather than just the local one.
+	const shellTerminals = useConnectedShellTerminals().filter((s) => !s.sessionId);
 	const closeShellTerminal = useCloseShellTerminal();
 	const renameShellTerminal = useRenameShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -16,7 +16,11 @@ import { TooltipProvider } from "./ui/tooltip";
 const { navigateMock, onKilledMock, paramsMock, postMock, spawnMock, useWorkspaceQueryMock } = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
 	onKilledMock: vi.fn(),
-	paramsMock: { projectId: undefined as string | undefined, sessionId: undefined as string | undefined },
+	paramsMock: {
+		hostId: undefined as string | undefined,
+		projectId: undefined as string | undefined,
+		sessionId: undefined as string | undefined,
+	},
 	postMock: vi.fn(),
 	spawnMock: vi.fn(),
 	useWorkspaceQueryMock: vi.fn(),
@@ -34,10 +38,15 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceScope: () => {
 		const query = useWorkspaceQueryMock();
-		const project = query.data?.find((workspace: WorkspaceSummary) => workspace.id === paramsMock.projectId);
+		const routeHost = paramsMock.hostId ?? "local";
+		const project = query.data?.find(
+			(workspace: WorkspaceSummary) => workspace.host === routeHost && workspace.id === paramsMock.projectId,
+		);
 		const session = query.data
 			?.flatMap((workspace: WorkspaceSummary) => workspace.sessions)
-			.find((candidate: WorkspaceSession) => candidate.id === paramsMock.sessionId);
+			.find(
+				(candidate: WorkspaceSession) => candidate.host === routeHost && candidate.id === paramsMock.sessionId,
+			);
 		return {
 			...query,
 			data: {
@@ -202,6 +211,7 @@ async function clickKillDialogConfirm() {
 beforeEach(() => {
 	navigateMock.mockReset();
 	onKilledMock.mockReset();
+	paramsMock.hostId = undefined;
 	paramsMock.projectId = undefined;
 	paramsMock.sessionId = undefined;
 	postMock.mockReset();
@@ -218,6 +228,35 @@ describe("ShellTopbar status pill", () => {
 		const header = screen.getByTestId("workspace-topbar-actions").closest("header");
 		expect(header).toHaveClass("pr-2");
 		expect(header).not.toHaveClass("pr-4");
+	});
+
+	// Regression: session ids are unique per host, not across them. Resolving the
+	// route's session by bare id names whichever host sorts first in the tree, so
+	// the crumb, status pill and kill button all describe the wrong machine.
+	it("names the session on the route's host, not the first matching id", () => {
+		const localTwin = sessionWith({ host: "local", title: "the local thing" });
+		const remoteTwin = sessionWith({ host: "remote", title: "the remote thing" });
+		useWorkspaceQueryMock.mockReturnValue({
+			data: [
+				{ host: "local", id: "proj-1", name: "my-app", path: "/repo/my-app", sessions: [localTwin] },
+				{ host: "remote", id: "proj-1", name: "my-app", path: "/repo/my-app", sessions: [remoteTwin] },
+			] satisfies WorkspaceSummary[],
+			isError: false,
+			isLoading: false,
+		});
+		paramsMock.hostId = "remote";
+		paramsMock.projectId = "proj-1";
+		paramsMock.sessionId = "sess-1";
+
+		render(
+			<QueryClientProvider client={new QueryClient()}>
+				<TooltipProvider>
+					<ShellTopbar />
+				</TooltipProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getByTestId("session-topbar-identity").textContent).toContain("the remote thing");
 	});
 
 	it("shows the worker session name and activity in the full topbar identity", () => {

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -75,6 +75,7 @@ vi.mock("./NotificationCenter", () => ({
 }));
 
 const worker: WorkspaceSession = {
+	host: "local",
 	id: "sess-1",
 	workspaceId: "proj-1",
 	workspaceName: "my-app",
@@ -95,6 +96,7 @@ const secondWorker: WorkspaceSession = {
 };
 
 const orchestrator: WorkspaceSession = {
+	host: "local",
 	id: "orch-1",
 	workspaceId: "proj-1",
 	workspaceName: "my-app",
@@ -141,6 +143,7 @@ function renderTopbarSessions(
 ) {
 	const data: WorkspaceSummary[] = [
 		{
+			host: "local",
 			id: sessions[0].workspaceId,
 			name: sessions[0].workspaceName,
 			path: "/repo/my-app",
@@ -391,8 +394,8 @@ describe("ShellTopbar orchestrator actions", () => {
 		expect(screen.queryByText("my-app")).not.toBeInTheDocument();
 		await userEvent.click(kanbanButton);
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId",
-			params: { projectId: "proj-1" },
+			to: "/host/$hostId/project/$projectId",
+			params: { hostId: "local", projectId: "proj-1" },
 		});
 	});
 
@@ -405,8 +408,8 @@ describe("ShellTopbar orchestrator actions", () => {
 		expect(screen.getByRole("button", { name: "New task" })).toHaveClass("bg-raised");
 		await userEvent.click(kanbanButton);
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId",
-			params: { projectId: "proj-1" },
+			to: "/host/$hostId/project/$projectId",
+			params: { hostId: "local", projectId: "proj-1" },
 		});
 	});
 
@@ -414,6 +417,7 @@ describe("ShellTopbar orchestrator actions", () => {
 		useWorkspaceQueryMock.mockReturnValue({
 			data: [
 				{
+					host: "local",
 					id: "proj-1",
 					name: "my-app",
 					path: "/repo/my-app",
@@ -435,7 +439,7 @@ describe("ShellTopbar orchestrator actions", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: "Open orchestrator" }));
 
-		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", project: { host: "local", id: "proj-1" } });
 		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnMock).not.toHaveBeenCalled();
 	});
@@ -448,8 +452,8 @@ describe("ShellTopbar orchestrator actions", () => {
 		await clickKillDialogConfirm();
 
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "orch-1" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "orch-1" },
 		});
 	});
 });

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -40,6 +40,7 @@ import {
 } from "../lib/agent-switch-presentation";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
+import { LOCAL_HOST, type Ref } from "../lib/hosts";
 const isMac = isMacPlatform();
 const boardActionsInPanel = usesBoardActionsInPanel();
 const dragStyle = isMac ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
@@ -82,7 +83,7 @@ export function ShellTopbar({
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
-	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
+	const params = useParams({ strict: false }) as { hostId?: string; projectId?: string; sessionId?: string };
 	const currentSessionId = params.sessionId;
 	const isInspectorOpen = useUiStore((state) =>
 		currentSessionId ? (state.inspectorSessions[currentSessionId]?.isOpen ?? true) : false,
@@ -122,7 +123,9 @@ export function ShellTopbar({
 	// projectId that no longer resolves (stale route after the project was
 	// removed, or data still loading) shows an empty crumb — never the raw
 	// route slug. "Board" is the root-board crumb only.
+	const projectHost = session?.host ?? params.hostId ?? LOCAL_HOST;
 	const projectId = session?.workspaceId ?? params.projectId;
+	const projectRef: Ref | undefined = projectId ? { host: projectHost, id: projectId } : undefined;
 	const isProjectRestarting = useUiStore((state) =>
 		projectId ? state.restartingProjectIds.has(projectId) : false,
 	);
@@ -140,11 +143,16 @@ export function ShellTopbar({
 			: orchestratorActionLabel;
 
 	const openBoard = () =>
-		projectId ? void navigate({ to: "/projects/$projectId", params: { projectId } }) : void navigate({ to: "/" });
+		projectRef
+			? void navigate({
+					to: "/host/$hostId/project/$projectId",
+					params: { hostId: projectRef.host, projectId: projectRef.id },
+				})
+			: void navigate({ to: "/" });
 
 	const openNewTask = () => {
 		if (!projectId || isProjectRestarting) return;
-		requestNewTask(projectId);
+		if (projectRef) requestNewTask(projectRef);
 	};
 
 	const openOrchestrator = async () => {
@@ -159,8 +167,8 @@ export function ShellTopbar({
 		void captureRendererEvent("ao.renderer.orchestrator_open_requested", { project_id: projectId });
 		if (orchestrator) {
 			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId: orchestrator.id },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: orchestrator.host, sessionId: orchestrator.id },
 			});
 			return;
 		}
@@ -186,7 +194,7 @@ export function ShellTopbar({
 		}
 		if (!hasConfiguredOrchestratorAgent(project)) {
 			if (project) {
-				useUiStore.getState().openProjectSettings(projectId);
+				if (projectRef) useUiStore.getState().openProjectSettings(projectRef);
 			}
 			return;
 		}
@@ -195,8 +203,8 @@ export function ShellTopbar({
 			const sessionId = await spawnOrchestrator(projectId, "topbar");
 			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: projectHost, sessionId },
 			});
 		} catch (error) {
 			void captureRendererException(error, {
@@ -391,12 +399,15 @@ export function ShellTopbar({
 										onKilled={(workspaceId, orchestratorId) => {
 											if (orchestratorId) {
 												void navigate({
-													to: "/projects/$projectId/sessions/$sessionId",
-													params: { projectId: workspaceId, sessionId: orchestratorId },
+													to: "/host/$hostId/session/$sessionId",
+													params: { hostId: session.host, sessionId: orchestratorId },
 												});
 												return;
 											}
-											void navigate({ to: "/projects/$projectId", params: { projectId: workspaceId } });
+											void navigate({
+												to: "/host/$hostId/project/$projectId",
+												params: { hostId: session.host, projectId: workspaceId },
+											});
 										}}
 									/>
 								) : null}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -114,7 +114,11 @@ export function ShellTopbar({
 	const [isSpawning, setIsSpawning] = useState(false);
 	// Board-scope spawn failures surface where the board actions render.
 	const [boardSpawnError, setBoardSpawnError] = useState<string | null>(null);
-	const workspaceScope = useWorkspaceScope(params.projectId, params.sessionId).data;
+	// Session ids are unique per host, not across them: matching on id alone
+	// would name another host's same-id session in the crumb, pill and kill
+	// button. useWorkspaceScope matches session/project on this route host.
+	const routeHost = params.hostId ?? LOCAL_HOST;
+	const workspaceScope = useWorkspaceScope(routeHost, params.projectId, params.sessionId).data;
 	const session = workspaceScope?.session;
 	const isSessionRoute = Boolean(params.sessionId);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
@@ -123,9 +127,10 @@ export function ShellTopbar({
 	// projectId that no longer resolves (stale route after the project was
 	// removed, or data still loading) shows an empty crumb — never the raw
 	// route slug. "Board" is the root-board crumb only.
-	const projectHost = session?.host ?? params.hostId ?? LOCAL_HOST;
 	const projectId = session?.workspaceId ?? params.projectId;
-	const projectRef: Ref | undefined = projectId ? { host: projectHost, id: projectId } : undefined;
+	// projectHost reduces to routeHost: a resolved session's host is already the
+	// route's by construction (see useWorkspaceScope above).
+	const projectRef: Ref | undefined = projectId ? { host: routeHost, id: projectId } : undefined;
 	const isProjectRestarting = useUiStore((state) =>
 		projectId ? state.restartingProjectIds.has(projectId) : false,
 	);
@@ -204,7 +209,7 @@ export function ShellTopbar({
 			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 			void navigate({
 				to: "/host/$hostId/session/$sessionId",
-				params: { hostId: projectHost, sessionId },
+				params: { hostId: routeHost, sessionId },
 			});
 		} catch (error) {
 			void captureRendererException(error, {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -166,7 +166,18 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ GET: getMock }),
+}));
+
 const workspace: WorkspaceSummary = {
+	host: "local",
 	id: "proj-1",
 	name: "Project One",
 	path: "/repo/project-one",
@@ -175,6 +186,7 @@ const workspace: WorkspaceSummary = {
 };
 
 const session: WorkspaceSession = {
+	host: "local",
 	id: "proj-1-1",
 	workspaceId: "proj-1",
 	workspaceName: "Project One",
@@ -468,7 +480,7 @@ describe("Sidebar", () => {
 
 		await user.click(screen.getByRole("button", { name: "Spawn Project One orchestrator" }));
 
-		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", projectId: "proj-1" });
+		expect(useUiStore.getState().settingsModal).toEqual({ scope: "project", project: { host: "local", id: "proj-1" } });
 		expect(navigateMock).not.toHaveBeenCalled();
 		expect(spawnMock).not.toHaveBeenCalled();
 	});
@@ -554,7 +566,7 @@ describe("Sidebar", () => {
 		await user.click(await screen.findByRole("menuitem", { name: /New session/ }));
 
 		const request = useUiStore.getState().newTaskRequest;
-		expect(request?.projectId).toBe("proj-1");
+		expect(request?.project.id).toBe("proj-1");
 		expect(request?.nonce ?? 0).toBeGreaterThan(before);
 	});
 
@@ -677,6 +689,7 @@ describe("Sidebar", () => {
 	it("toggles project sessions from the folder icon without selecting the project first", async () => {
 		const user = userEvent.setup();
 		const other: WorkspaceSummary = {
+			host: "local",
 			id: "proj-2",
 			name: "Project Two",
 			path: "/repo/project-two",
@@ -758,7 +771,7 @@ describe("Sidebar", () => {
 		// Click the project name text — it's inside SidebarMenuButton and bubbles up to onProjectClick.
 		await user.click(screen.getByText("Project One"));
 
-		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/host/$hostId/project/$projectId", params: { hostId: "local", projectId: "proj-1" } });
 	});
 
 	it("returns to the project board from an orchestrator session without collapsing", async () => {
@@ -779,7 +792,7 @@ describe("Sidebar", () => {
 
 		await user.click(screen.getByText("Project One"));
 
-		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/host/$hostId/project/$projectId", params: { hostId: "local", projectId: "proj-1" } });
 		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
 		expect(screen.getByText("Project One").closest("button")).toHaveAttribute("aria-expanded", "true");
 	});
@@ -820,8 +833,8 @@ describe("Sidebar", () => {
 		await user.click(screen.getByRole("button", { name: "Open Project One orchestrator" }));
 
 		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "proj-1-orc" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "proj-1-orc" },
 		});
 		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
 		expect(screen.getByText("Project One").closest("button")).toHaveAttribute("aria-expanded", "true");

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -170,7 +170,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({ GET: getMock }),

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useCanGoBack, useNavigate, useParams, useRouter, useRouterState } from "@tanstack/react-router";
+import { LOCAL_HOST, type Ref } from "../lib/hosts";
 import {
 	DndContext,
 	DragOverlay,
@@ -350,31 +351,25 @@ function useSelection() {
 	const navigate = useNavigate();
 	const openGlobalSettings = useUiStore((state) => state.openGlobalSettings);
 	const openProjectSettings = useUiStore((state) => state.openProjectSettings);
-	const params = useParams({ strict: false }) as {
-		projectId?: string;
-		sessionId?: string;
-	};
-	const pathname = useRouterState({
-		select: (state) => state.location.pathname,
-	});
+	const params = useParams({ strict: false }) as { hostId?: string; projectId?: string; sessionId?: string };
+	const pathname = useRouterState({ select: (state) => state.location.pathname });
 	const goHome = useCallback(() => void navigate({ to: "/" }), [navigate]);
 	const goGlobalSettings = useCallback(() => openGlobalSettings(), [openGlobalSettings]);
 	const goConnectMobile = useCallback(() => openGlobalSettings("mobile"), [openGlobalSettings]);
-	const goSettings = useCallback((projectId: string) => openProjectSettings(projectId), [openProjectSettings]);
+	const goSettings = useCallback((project: Ref) => openProjectSettings(project), [openProjectSettings]);
 	const goProject = useCallback(
-		(projectId: string) => void navigate({ to: "/projects/$projectId", params: { projectId } }),
+		(project: Ref) =>
+			void navigate({ to: "/host/$hostId/project/$projectId", params: { hostId: project.host, projectId: project.id } }),
 		[navigate],
 	);
 	const goSession = useCallback(
-		(projectId: string, sessionId: string) =>
-			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId },
-			}),
+		(session: Ref) =>
+			void navigate({ to: "/host/$hostId/session/$sessionId", params: { hostId: session.host, sessionId: session.id } }),
 		[navigate],
 	);
 	return useMemo(() => ({
 		isHome: pathname === "/",
+		activeHostId: params.hostId ?? LOCAL_HOST,
 		activeProjectId: params.projectId,
 		activeSessionId: params.sessionId,
 		goHome,
@@ -385,7 +380,7 @@ function useSelection() {
 		goSettings,
 		goProject,
 		goSession,
-	}), [goConnectMobile, goGlobalSettings, goHome, goProject, goSession, goSettings, params.projectId, params.sessionId, pathname]);
+	}), [goConnectMobile, goGlobalSettings, goHome, goProject, goSession, goSettings, openGlobalSettings, params.hostId, params.projectId, params.sessionId, pathname]);
 }
 
 // Colour tracks the session's board section, preserving SCM state while the
@@ -1136,7 +1131,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 		if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
 	}, []);
 	const openSession = useCallback((sessionId: string) => {
-		selection.goSession(workspace.id, sessionId);
+		selection.goSession({ host: workspace.host, id: sessionId });
 	}, [selection, workspace.id]);
 	// The project's live orchestrator (if any) backs the hover Orchestrator
 	// button: navigate to it when present, otherwise spawn one first.
@@ -1154,7 +1149,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 		if (isProjectRestarting) return;
 		if (!expanded) toggleDisclosure();
 		if (orchestrator) {
-			selection.goSession(workspace.id, orchestrator.id);
+			selection.goSession({ host: orchestrator.host, id: orchestrator.id });
 			return;
 		}
 		// A cloud project has no local orchestrator-agent config, so the settings
@@ -1165,7 +1160,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 			try {
 				const sessionId = await spawnCloudOrchestrator(queryClient, workspace.id);
 				await queryClient.invalidateQueries({ queryKey: cloudSessionsQueryKey });
-				selection.goSession(workspace.id, sessionId);
+				selection.goSession({ host: workspace.host, id: sessionId });
 			} catch (err) {
 				console.error("Failed to spawn cloud orchestrator:", err);
 			} finally {
@@ -1174,14 +1169,14 @@ const ProjectItemContent = memo(function ProjectItemContent({
 			return;
 		}
 		if (!hasConfiguredOrchestratorAgent(workspace)) {
-			selection.goSettings(workspace.id);
+			selection.goSettings({ host: workspace.host, id: workspace.id });
 			return;
 		}
 		setIsSpawning(true);
 		try {
 			const sessionId = await spawnOrchestrator(workspace.id, "sidebar");
 			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			selection.goSession(workspace.id, sessionId);
+			selection.goSession({ host: workspace.host, id: sessionId });
 		} catch (err) {
 			console.error("Failed to spawn orchestrator:", err);
 		} finally {
@@ -1197,11 +1192,11 @@ const ProjectItemContent = memo(function ProjectItemContent({
 		if (consumeDragClick(workspace.id)) return;
 		if (!expanded) {
 			toggleDisclosure();
-			selection.goProject(workspace.id);
+			selection.goProject({ host: workspace.host, id: workspace.id });
 		} else if (dashboardActive) {
 			toggleDisclosure();
 		} else {
-			selection.goProject(workspace.id);
+			selection.goProject({ host: workspace.host, id: workspace.id });
 		}
 	};
 
@@ -1436,12 +1431,12 @@ const ProjectItemContent = memo(function ProjectItemContent({
 										</TooltipContent>
 									</Tooltip>
 									<DropdownMenuContent side="right" align="start" className="min-w-44">
-										<DropdownMenuItem disabled={isProjectRestarting} onSelect={() => requestNewTask(workspace.id)}>
+										<DropdownMenuItem disabled={isProjectRestarting} onSelect={() => requestNewTask({ host: workspace.host, id: workspace.id })}>
 											<Plus aria-hidden="true" />
 											{t("shell.newSession")}
 										</DropdownMenuItem>
 										<DropdownMenuSeparator />
-										<DropdownMenuItem onSelect={() => selection.goSettings(workspace.id)}>
+										<DropdownMenuItem onSelect={() => selection.goSettings({ host: workspace.host, id: workspace.id })}>
 											<Settings aria-hidden="true" />
 											{t("shell.projectSettings")}
 										</DropdownMenuItem>
@@ -1561,12 +1556,12 @@ const ProjectItemContent = memo(function ProjectItemContent({
 				</motion.li>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="min-w-44">
-				<ContextMenuItem disabled={isProjectRestarting} onSelect={() => requestNewTask(workspace.id)}>
+				<ContextMenuItem disabled={isProjectRestarting} onSelect={() => requestNewTask({ host: workspace.host, id: workspace.id })}>
 					<Plus aria-hidden="true" />
 					{t("shell.newSession")}
 				</ContextMenuItem>
 				<ContextMenuSeparator />
-				<ContextMenuItem onSelect={() => selection.goSettings(workspace.id)}>
+				<ContextMenuItem onSelect={() => selection.goSettings({ host: workspace.host, id: workspace.id })}>
 					<Settings aria-hidden="true" />
 					{t("shell.projectSettings")}
 				</ContextMenuItem>
@@ -1641,9 +1636,9 @@ const PinnedSessionRow = memo(function PinnedSessionRow({
 }: {
 	session: WorkspaceSession;
 	active: boolean;
-	onOpenSession: (projectId: string, sessionId: string) => void;
+	onOpenSession: (session: Ref) => void;
 }) {
-	const onOpen = useCallback(() => onOpenSession(session.workspaceId, session.id), [onOpenSession, session.id, session.workspaceId]);
+	const onOpen = useCallback(() => onOpenSession({ host: session.host, id: session.id }), [onOpenSession, session.host, session.id]);
 	return <SessionRow session={session} active={active} indented={false} onOpen={onOpen} />;
 });
 

--- a/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { agentModelsQueryKey } from "../hooks/useAgentModelsQuery";
+import { refKey } from "../lib/hosts";
 import type { AgentSwitchSummary, WorkspaceSession } from "../types/workspace";
 import { SwitchAgentDialog } from "./SwitchAgentDialog";
 import { TooltipProvider } from "./ui/tooltip";
@@ -34,6 +35,7 @@ vi.mock("../hooks/useSwitchAgent", async (importOriginal) => {
 });
 
 const worker: WorkspaceSession = {
+	host: "local",
 	activity: { state: "active", lastActivityAt: "2026-06-10T00:00:00Z" },
 	branch: "ao/sess-1",
 	id: "sess-1",
@@ -57,7 +59,7 @@ function renderDialog(
 		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
 	});
 	for (const agentId of ["claude-code", "codex"]) {
-		queryClient.setQueryData(agentModelsQueryKey(agentId, session.workspaceId), {
+		queryClient.setQueryData(agentModelsQueryKey(agentId, { host: session.host, id: session.workspaceId }), {
 			agentId,
 			allowCustom: false,
 			fetchedAt: "2026-06-10T00:00:00Z",
@@ -243,6 +245,7 @@ describe("SwitchAgentDialog", () => {
 				state: "starting_target",
 				targetHarness: "codex",
 			},
+			host: "local",
 		} satisfies WorkspaceSession;
 		const { queryClient } = renderDialog(recoverySession);
 		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
@@ -252,7 +255,7 @@ describe("SwitchAgentDialog", () => {
 		expect(within(dialog).queryByRole("button", { name: "Target agent" })).not.toBeInTheDocument();
 		await userEvent.click(within(dialog).getByRole("button", { name: "Refresh" }));
 
-		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-agent-switches", "sess-1"] });
+		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-agent-switches", refKey({ host: "local", id: "sess-1" })] });
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
 	});
 
@@ -267,6 +270,7 @@ describe("SwitchAgentDialog", () => {
 				state: "source_stopped",
 				targetHarness: "codex",
 			},
+			host: "local",
 		} satisfies WorkspaceSession;
 		renderDialog(recoverySession);
 		const dialog = screen.getByRole("dialog", { name: "Switch agent" });
@@ -274,7 +278,7 @@ describe("SwitchAgentDialog", () => {
 		expect(within(dialog).getByText("Claude Code could not be restored")).toBeInTheDocument();
 		await userEvent.click(within(dialog).getByRole("button", { name: "Restore Claude Code" }));
 		expect(switchMocks.recoverMutate).toHaveBeenCalledWith({
-			sessionId: "sess-1",
+			session: { host: "local", id: "sess-1" },
 			switchId: "switch-source-recovery",
 		});
 		expect(within(dialog).queryByRole("button", { name: "Target agent" })).not.toBeInTheDocument();
@@ -291,6 +295,7 @@ describe("SwitchAgentDialog", () => {
 				state: "stopping_source",
 				targetHarness: "codex",
 			},
+			host: "local",
 		} satisfies WorkspaceSession;
 		renderDialog(recoverySession);
 		const dialog = screen.getByRole("dialog", { name: "Switch agent" });
@@ -298,7 +303,7 @@ describe("SwitchAgentDialog", () => {
 		expect(within(dialog).getByText("Claude Code status could not be confirmed")).toBeInTheDocument();
 		await userEvent.click(within(dialog).getByRole("button", { name: "Check Claude Code" }));
 		expect(switchMocks.recoverMutate).toHaveBeenCalledWith({
-			sessionId: "sess-1",
+			session: { host: "local", id: "sess-1" },
 			switchId: "switch-source-stop-recovery",
 		});
 	});

--- a/frontend/src/renderer/components/SwitchAgentDialog.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.tsx
@@ -202,7 +202,7 @@ export function SwitchAgentDialog({ agentSwitch, container, open, session, onOpe
 		setRefreshingRecovery(true);
 		try {
 			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: agentSwitchesQueryKey(session.id) }),
+				queryClient.invalidateQueries({ queryKey: agentSwitchesQueryKey(session) }),
 				queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
 			]);
 		} finally {
@@ -272,7 +272,7 @@ export function SwitchAgentDialog({ agentSwitch, container, open, session, onOpe
 									disabled={recoverAgentSwitch.isPending}
 									onClick={() =>
 										recoverAgentSwitch.mutate({
-											sessionId: session.id,
+											session: { host: session.host, id: session.id },
 											switchId: durableSwitch.id,
 										})
 									}
@@ -340,7 +340,7 @@ export function SwitchAgentDialog({ agentSwitch, container, open, session, onOpe
 											setMode("");
 										}}
 										onWarningChange={setModelWarning}
-										projectId={session.workspaceId}
+										project={{ host: session.host, id: session.workspaceId }}
 										value={model}
 									/>
 								</div>

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { refKey } from "../lib/hosts";
 
 const h = vi.hoisted(() => ({
 	get: vi.fn(),
@@ -57,6 +58,16 @@ vi.mock("../lib/api-client", () => ({
 	},
 	apiErrorCode: (error: { code?: string }) => error?.code,
 	apiErrorMessage: (error: { message?: string }, fallback = "err") => error?.message ?? fallback,
+}));
+
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ GET: h.get, POST: h.post }),
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: h.capture }));
@@ -174,7 +185,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={onCreated} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={onCreated} />
 			</Wrap>,
 		);
 
@@ -195,7 +206,7 @@ describe("TaskComposer", () => {
 	it("keeps prompt guidance in the field instead of adding a separate footer row", () => {
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -209,7 +220,7 @@ describe("TaskComposer", () => {
 	it("does not rerender the agent control for every prompt keystroke", async () => {
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -226,7 +237,7 @@ describe("TaskComposer", () => {
 	it("keeps agent and model in equal stable toolbar tracks", () => {
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -242,7 +253,7 @@ describe("TaskComposer", () => {
 	it("keeps the file attach control in the bottom action row", () => {
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -257,7 +268,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={onCreated} onSubmittingChange={onSubmittingChange} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={onCreated} onSubmittingChange={onSubmittingChange} />
 			</Wrap>,
 		);
 
@@ -303,7 +314,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -377,7 +388,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -399,7 +410,7 @@ describe("TaskComposer", () => {
 
 		const { container } = render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -441,7 +452,7 @@ describe("TaskComposer", () => {
 
 		const { container } = render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -466,7 +477,7 @@ describe("TaskComposer", () => {
 
 		const { container } = render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -491,7 +502,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} onSubmittingChange={onSubmittingChange} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} onSubmittingChange={onSubmittingChange} />
 			</Wrap>,
 		);
 
@@ -510,7 +521,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={onCreated} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={onCreated} />
 			</Wrap>,
 		);
 		fireEvent.change(task(), { target: { value: "Do the thing" } });
@@ -548,7 +559,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={onCreated} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={onCreated} />
 			</Wrap>,
 		);
 		await waitFor(() => expect(screen.getByTestId("agent-field")).toHaveAttribute("data-value", "cursor"));
@@ -571,7 +582,7 @@ describe("TaskComposer", () => {
 		const onDirtyChange = vi.fn();
 		const { unmount } = render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} onDirtyChange={onDirtyChange} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} onDirtyChange={onDirtyChange} />
 			</Wrap>,
 		);
 		fireEvent.change(task(), { target: { value: "T" } });
@@ -593,7 +604,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -625,11 +636,11 @@ describe("TaskComposer", () => {
 			return { data: { status: "ok", project: { agent: "codex", config: {} } } };
 		});
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		queryClient.setQueryData(["project", "proj-1"], { agent: "codex", config: {} });
+		queryClient.setQueryData(["project", refKey({ host: "local", id: "proj-1" })], { agent: "codex", config: {} });
 
 		render(
 			<QueryClientProvider client={queryClient}>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</QueryClientProvider>,
 		);
 
@@ -647,7 +658,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -674,7 +685,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -711,7 +722,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -751,7 +762,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
@@ -788,7 +799,7 @@ describe("TaskComposer", () => {
 
 		render(
 			<Wrap>
-				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+				<TaskComposer project={{ host: "local", id: "proj-1" }} onCreated={vi.fn()} />
 			</Wrap>,
 		);
 

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -64,7 +64,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({ GET: h.get, POST: h.post }),

--- a/frontend/src/renderer/components/TaskComposer.tsx
+++ b/frontend/src/renderer/components/TaskComposer.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { LOCAL_HOST, refKey, type Ref } from "../lib/hosts";
 import {
 	TaskComposerView,
 	type TaskComposerAgentControl,
@@ -11,6 +12,7 @@ import { Loader2 } from "lucide-react";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
 import { captureRendererEvent } from "../lib/telemetry";
 import {
 	cacheAgentReadiness,
@@ -36,7 +38,7 @@ type Project = components["schemas"]["Project"];
 type DelegateAgent = components["schemas"]["DelegateTaskRequest"]["agent"];
 
 type CreateTaskInput = {
-	projectId: string;
+	project: Ref;
 	brief: string;
 	agent?: DelegateAgent;
 	model?: string;
@@ -73,7 +75,7 @@ function hasErrorDetail(details: components["schemas"]["APIError"]["details"] | 
 }
 
 export type TaskComposerProps = {
-	projectId?: string;
+	project?: Ref;
 	onCreated: (sessionId: string) => void;
 	onDirtyChange?: (dirty: boolean) => void;
 	onSubmittingChange?: (submitting: boolean) => void;
@@ -81,13 +83,14 @@ export type TaskComposerProps = {
 };
 
 export function TaskComposer({
-	projectId,
+	project,
 	onCreated,
 	onDirtyChange,
 	onSubmittingChange,
 	autoFocusTitle,
 }: TaskComposerProps) {
 	const { t } = useTranslation();
+	const projectHost = project?.host ?? LOCAL_HOST;
 	const taskPlaceholder = useMemo(() => {
 		const placeholders = t("newTask.taskPlaceholders" as never, { returnObjects: true }) as string[];
 		return Array.isArray(placeholders)
@@ -119,19 +122,19 @@ export function TaskComposer({
 	const { org: cloudOrg } = useCloudOrg();
 	const cloudProjects = useCloudProjectsQuery();
 	const isCloudProject =
-		Boolean(projectId) && (cloudProjects.data ?? []).some((project) => project.id === projectId);
+		project !== undefined && (cloudProjects.data ?? []).some((cloudProject) => cloudProject.id === project.id);
 	// A cloud project is unknown to the local daemon, so the local model catalog
 	// must be queried agent-level (no project scope); otherwise the request 404s
 	// and the model dropdown spins forever. Local projects keep their scope.
-	const modelsProjectId = isCloudProject ? "" : (projectId ?? "");
+	const modelsProject = isCloudProject ? { host: LOCAL_HOST, id: "" } : (project ?? { host: LOCAL_HOST, id: "" });
 
 	const createCloudTask = useCallback(
 		async (input: CreateTaskInput): Promise<string> => {
-			void captureRendererEvent("ao.renderer.task_create_requested", { project_id: input.projectId });
+			void captureRendererEvent("ao.renderer.task_create_requested", { project_id: input.project.id });
 			if (!cloudOrg?.id) throw new Error(t("newTask.unableToStart"));
 			try {
 				const { session } = await cloudClient.createSession(cloudOrg.id, {
-					projectId: input.projectId,
+					projectId: input.project.id,
 					kind: "worker",
 					harness: input.agent ?? "claude-code",
 					displayName: input.brief.trim().slice(0, 80) || (input.agent ?? "claude-code"),
@@ -140,10 +143,10 @@ export function TaskComposer({
 				// The control plane provisions the sandbox asynchronously; surface the
 				// new session on the board immediately.
 				void queryClient.invalidateQueries({ queryKey: cloudSessionsQueryKey });
-				void captureRendererEvent("ao.renderer.task_create_succeeded", { project_id: input.projectId });
+				void captureRendererEvent("ao.renderer.task_create_succeeded", { project_id: input.project.id });
 				return session.id;
 			} catch (err) {
-				void captureRendererEvent("ao.renderer.task_create_failed", { project_id: input.projectId });
+				void captureRendererEvent("ao.renderer.task_create_failed", { project_id: input.project.id });
 				throw err instanceof Error ? err : new Error(t("newTask.unableToStart"));
 			}
 		},
@@ -152,11 +155,11 @@ export function TaskComposer({
 
 	const createLocalTask = useCallback(
 		async (input: CreateTaskInput): Promise<string> => {
-			void captureRendererEvent("ao.renderer.task_create_requested", { project_id: input.projectId });
+			void captureRendererEvent("ao.renderer.task_create_requested", { project_id: input.project.id });
 			try {
 				const { data, error } = await apiClient.POST("/api/v1/orchestrators/delegate", {
 					body: {
-						projectId: input.projectId,
+						projectId: input.project.id,
 						brief: input.brief,
 						agent: input.agent,
 						model: input.model,
@@ -173,10 +176,10 @@ export function TaskComposer({
 					);
 				}
 				if (!data?.workerId) throw new Error(t("newTask.noSession"));
-				void captureRendererEvent("ao.renderer.task_create_succeeded", { project_id: input.projectId });
+				void captureRendererEvent("ao.renderer.task_create_succeeded", { project_id: input.project.id });
 				return data.workerId;
 			} catch (err) {
-				void captureRendererEvent("ao.renderer.task_create_failed", { project_id: input.projectId });
+				void captureRendererEvent("ao.renderer.task_create_failed", { project_id: input.project.id });
 				if (
 					err instanceof TaskCreateError &&
 					err.code &&
@@ -203,20 +206,20 @@ export function TaskComposer({
 	);
 
 	const projectQuery = useQuery({
+		queryKey: ["project", project ? refKey(project) : ""],
 		// A cloud project lives in the control plane, not the local daemon, so this
 		// local lookup would 404 (PROJECT_NOT_FOUND); skip it for cloud projects.
-		queryKey: ["project", projectId],
-		enabled: Boolean(projectId) && !isCloudProject,
+		enabled: Boolean(project) && !isCloudProject,
 		queryFn: async () => {
-			const { data, error: apiError } = await apiClient.GET("/api/v1/projects/{id}", {
-				params: { path: { id: projectId ?? "" } },
+			const { data, error: apiError } = await clientFor(projectHost).GET("/api/v1/projects/{id}", {
+				params: { path: { id: project?.id ?? "" } },
 			});
 			if (apiError) throw new Error(apiErrorMessage(apiError));
 			if (data?.status !== "ok") throw new Error(t("newTask.configUnavailable"));
 			return data.project as Project;
 		},
 	});
-	const agentsQuery = useAgentReadinessQuery();
+	const agentsQuery = useAgentReadinessQuery(true, projectHost);
 	const { settings } = useSettings();
 	// The composer preselects the agent and model a spawn would actually use
 	// instead of parking the controls on a "default" label the user has to
@@ -240,15 +243,15 @@ export function TaskComposer({
 	const agentCatalog = agentsQuery.data;
 
 	// Shares the picker's query key, so this is the same fetch, not a second one.
-	const modelCatalogQuery = useQuery(agentModelsQueryOptions(selectedAgent, modelsProjectId));
+	const modelCatalogQuery = useQuery(agentModelsQueryOptions(selectedAgent, modelsProject));
 	const revalidationQuery = useQuery({
 		queryKey: [
 			"agent-model-revalidation",
 			selectedAgent,
-			modelsProjectId,
+			refKey(modelsProject),
 			modelCatalogQuery.data?.validatedAt ?? "",
 		],
-		queryFn: () => revalidateAgentModels(selectedAgent, modelsProjectId),
+		queryFn: () => revalidateAgentModels(selectedAgent, modelsProject),
 		enabled: selectedAgent !== "" && modelCatalogQuery.data?.refreshRecommended === true,
 		staleTime: Number.POSITIVE_INFINITY,
 		retry: false,
@@ -256,11 +259,11 @@ export function TaskComposer({
 	useEffect(() => {
 		if (revalidationQuery.data) {
 			queryClient.setQueryData(
-				agentModelsQueryKey(selectedAgent, modelsProjectId),
+				agentModelsQueryKey(selectedAgent, modelsProject),
 				revalidationQuery.data,
 			);
 		}
-	}, [modelsProjectId, queryClient, revalidationQuery.data, selectedAgent]);
+	}, [modelsProject, queryClient, revalidationQuery.data, selectedAgent]);
 	const modelWarning =
 		(revalidationQuery.isError
 			? revalidationQuery.error instanceof Error
@@ -323,7 +326,7 @@ export function TaskComposer({
 		interfaceMode?: "tui",
 		approvalMode?: "bypass-permissions",
 	) => {
-		if (!projectId || isSubmitting) return;
+		if (!project || isSubmitting) return;
 
 		const cleanModel = model.trim();
 		const cleanMode = mode.trim();
@@ -338,7 +341,7 @@ export function TaskComposer({
 		try {
 			const attachmentPayloads = await toSettledPayload();
 			const sessionId = await createTask({
-				projectId,
+				project,
 				brief,
 				// The visible selection is authoritative: it is either the user's pick
 				// or the resolved default, so spawning names it explicitly.
@@ -373,7 +376,7 @@ export function TaskComposer({
 	return (
 		<TaskComposerView
 			autoFocusPrompt={autoFocusTitle}
-			canSubmit={Boolean(projectId)}
+			canSubmit={Boolean(project)}
 			onPromptChange={handlePromptChange}
 			labels={{
 				addFile: t("newTask.addFile"),
@@ -404,7 +407,7 @@ export function TaskComposer({
 			model={{
 				agentId: selectedAgent,
 				agentLabel: selectedAgentLabel,
-				projectId: projectId ?? "",
+				project: project ?? { host: LOCAL_HOST, id: "" },
 				disabled: isSubmitting,
 				value: model,
 				mode,

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -115,6 +115,7 @@ const worker = {
 	status: "working",
 	updatedAt: "2026-06-10T00:00:00Z",
 	prs: [],
+	host: "local",
 } satisfies WorkspaceSession;
 
 const orchestrator = {
@@ -122,6 +123,7 @@ const orchestrator = {
 	id: "sess-orch",
 	title: "orchestrate",
 	kind: "orchestrator",
+	host: "local",
 } satisfies WorkspaceSession;
 
 beforeEach(() => {
@@ -651,6 +653,7 @@ describe("terminal restore", () => {
 			...worker,
 			status: "terminated",
 			terminalHandleId: "term-1",
+			host: "local",
 		} satisfies WorkspaceSession;
 		const view = renderCachedPane({ session: terminated, sessions: [terminated] });
 		try {

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { shellTerminalsQueryKey, type ShellTerminal } from "../hooks/useShellTerminals";
 import { workspaceHostQueryKey } from "../hooks/useWorkspaceQuery";
-import { LOCAL_HOST } from "../lib/hosts";
+import { LOCAL_HOST, refKey } from "../lib/hosts";
 import type { AttachableTerminal } from "../hooks/useTerminalSession";
 import type { TerminalTarget } from "../types/terminal";
 import type { WorkspaceSession } from "../types/workspace";
@@ -190,11 +190,14 @@ function renderCachedPane({
 	shellTerminals?: ShellTerminal[];
 	terminalTarget?: TerminalTarget;
 }) {
-	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	// Seeded caches are the fixture here: without staleTime the per-host
+	// shell-terminals query refetches on mount against no daemon and the
+	// lifecycle effects stop trusting it.
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } } });
 	queryClient.setQueryData(workspaceHostQueryKey(LOCAL_HOST), [
 		{ host: LOCAL_HOST, label: "Local", status: "ready", workspaces: workspaceWithSessions(sessions), failure: null },
 	]);
-	queryClient.setQueryData(shellTerminalsQueryKey, shellTerminals);
+	queryClient.setQueryData(shellTerminalsQueryKey(LOCAL_HOST), shellTerminals);
 	const previousAO = window.ao;
 	window.ao = {} as typeof window.ao;
 
@@ -462,7 +465,7 @@ describe("TerminalCacheProvider", () => {
 				view.show(session);
 				await waitFor(() =>
 					expect(
-						document.querySelector(`[data-terminal-cache-key^="session:${session.id}:worker|"]`),
+						document.querySelector(`[data-terminal-cache-key^="session:${refKey(session)}:worker|"]`),
 					).not.toBeNull(),
 				);
 			}
@@ -538,6 +541,7 @@ describe("TerminalCacheProvider", () => {
 
 	it("disposes a parked shell when the shell lifecycle removes its handle", async () => {
 		const shell: ShellTerminal = {
+			host: "local",
 			handleId: "shell-handle",
 			sessionId: sessionA.id,
 			workingDir: "/repo/my-app",
@@ -546,9 +550,10 @@ describe("TerminalCacheProvider", () => {
 		};
 		const shellTarget: TerminalTarget = {
 			generation: shell.createdAt,
+			host: "local",
 			kind: "shell",
 			handleId: shell.handleId,
-			sessionId: sessionA.id,
+			session: { host: "local", id: sessionA.id },
 			title: shell.title,
 		};
 		const view = renderCachedPane({
@@ -562,7 +567,7 @@ describe("TerminalCacheProvider", () => {
 			view.show(sessionA, { kind: "worker" });
 			await waitFor(() => expect(activeXterm()).not.toBe(shellXterm));
 			act(() => {
-				view.queryClient.setQueryData(shellTerminalsQueryKey, []);
+				view.queryClient.setQueryData(shellTerminalsQueryKey(LOCAL_HOST), []);
 			});
 
 			await waitFor(() => expect(shellXterm.isConnected).toBe(false));
@@ -577,7 +582,7 @@ describe("TerminalCacheProvider", () => {
 			handleId: "stable-reviewer-handle",
 			harness: "codex",
 			kind: "reviewer",
-			sessionId: sessionA.id,
+			session: { host: sessionA.host, id: sessionA.id },
 		} satisfies TerminalTarget;
 		const view = renderCachedPane({
 			session: sessionA,

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -4,7 +4,8 @@ import userEvent from "@testing-library/user-event";
 import { useEffect, useRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { shellTerminalsQueryKey, type ShellTerminal } from "../hooks/useShellTerminals";
-import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { workspaceHostQueryKey } from "../hooks/useWorkspaceQuery";
+import { LOCAL_HOST } from "../lib/hosts";
 import type { AttachableTerminal } from "../hooks/useTerminalSession";
 import type { TerminalTarget } from "../types/terminal";
 import type { WorkspaceSession } from "../types/workspace";
@@ -167,6 +168,7 @@ function renderPane(session?: WorkspaceSession) {
 function workspaceWithSessions(sessions: WorkspaceSession[]) {
 	return [
 		{
+			host: LOCAL_HOST,
 			id: "proj-1",
 			name: "my-app",
 			kind: "single_repo" as const,
@@ -189,7 +191,9 @@ function renderCachedPane({
 	terminalTarget?: TerminalTarget;
 }) {
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	queryClient.setQueryData(workspaceQueryKey, workspaceWithSessions(sessions));
+	queryClient.setQueryData(workspaceHostQueryKey(LOCAL_HOST), [
+		{ host: LOCAL_HOST, label: "Local", status: "ready", workspaces: workspaceWithSessions(sessions), failure: null },
+	]);
 	queryClient.setQueryData(shellTerminalsQueryKey, shellTerminals);
 	const previousAO = window.ao;
 	window.ao = {} as typeof window.ao;
@@ -497,7 +501,9 @@ describe("TerminalCacheProvider", () => {
 		try {
 			const oldGeneration = await waitFor(() => activeXterm());
 			act(() => {
-				view.queryClient.setQueryData(workspaceQueryKey, workspaceWithSessions([replacement]));
+				view.queryClient.setQueryData(workspaceHostQueryKey(LOCAL_HOST), [
+		{ host: LOCAL_HOST, label: "Local", status: "ready", workspaces: workspaceWithSessions([replacement]), failure: null },
+	]);
 			});
 			view.show(replacement);
 
@@ -518,7 +524,9 @@ describe("TerminalCacheProvider", () => {
 			view.show(sessionB);
 			await waitFor(() => expect(activeXterm()).not.toBe(terminalA));
 			act(() => {
-				view.queryClient.setQueryData(workspaceQueryKey, workspaceWithSessions([sessionB]));
+				view.queryClient.setQueryData(workspaceHostQueryKey(LOCAL_HOST), [
+		{ host: LOCAL_HOST, label: "Local", status: "ready", workspaces: workspaceWithSessions([sessionB]), failure: null },
+	]);
 			});
 
 			await waitFor(() => expect(terminalA.isConnected).toBe(false));

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -289,6 +289,7 @@ describe("TerminalPane empty states", () => {
 
 	it("selects a temporary shell without attaching xterm to its temporary handle", () => {
 		const shell = {
+			host: worker.host,
 			handleId: "pending-shell:test",
 			sessionId: worker.id,
 			workingDir: "",
@@ -304,9 +305,10 @@ describe("TerminalPane empty states", () => {
 			shellTerminals: [],
 			terminalTarget: {
 				generation: shell.createdAt,
+				host: shell.host,
 				kind: "shell",
 				handleId: shell.handleId,
-				sessionId: worker.id,
+				session: { host: worker.host, id: worker.id },
 				title: shell.title,
 			},
 		});
@@ -490,7 +492,7 @@ describe("TerminalCacheProvider", () => {
 			await waitFor(() => expect(activeXterm()).not.toBe(terminalA));
 
 			view.show(sessionA);
-			const host = document.querySelector<HTMLElement>(`[data-terminal-cache-key^="session:${sessionA.id}:worker|"]`);
+			const host = document.querySelector<HTMLElement>(`[data-terminal-cache-key^="session:${refKey(sessionA)}:worker|"]`);
 			expect(host).toHaveAttribute("data-terminal-activation-phase", "visible");
 			expect(host?.style.visibility).not.toBe("hidden");
 		} finally {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -15,7 +15,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { terminalTargetBelongsToSession, type TerminalTarget } from "../types/terminal";
-import { sessionIsActive, type WorkspaceSession } from "../types/workspace";
+import { flattenHostSections, sessionIsActive, type WorkspaceSession } from "../types/workspace";
 import type { Theme } from "../stores/ui-store";
 import {
 	useTerminalSession,
@@ -469,7 +469,7 @@ export function TerminalCacheProvider({
 	useEffect(() => {
 		if (!workspaceQuery.isSuccess) return;
 		const sessions = new Map(
-			(workspaceQuery.data ?? []).flatMap((workspace) =>
+			flattenHostSections(workspaceQuery.data).flatMap((workspace) =>
 				workspace.sessions.map((session) => [session.id, session] as const),
 			),
 		);

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { RotateCcw } from "lucide-react";
 import {
 	createContext,
@@ -23,18 +23,18 @@ import {
 	type TerminalSessionState,
 } from "../hooks/useTerminalSession";
 import { useSessionBrowserLink } from "../hooks/useSessionBrowserLink";
-import { getApiBaseUrl } from "../lib/api-client";
 import {
 	createTerminalMux,
 	createTerminalMuxPool,
-	muxUrlFromApiBase,
+	muxUrlForHost,
 	type TerminalMux,
 	type TerminalMuxPool,
 } from "../lib/terminal-mux";
+import { refKey, type HostId } from "../lib/hosts";
 import { cn } from "../lib/utils";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
-import { useShellTerminals } from "../hooks/useShellTerminals";
+import { shellTerminalsQueryOptions } from "../hooks/useShellTerminals";
 import { useCloudCp } from "../hooks/useCloudCp";
 import { createCloudTerminalMux } from "../lib/cloud-terminal-mux";
 import { XtermTerminal } from "./XtermTerminal";
@@ -57,7 +57,7 @@ type TerminalPaneProps = {
 	/** Focus the terminal when an in-flight controller asks for human input. */
 	focusRequested?: boolean;
 	/** Provider-owned shared transport lease factory. */
-	createMux?: () => TerminalMux;
+	createMux?: (host: HostId) => TerminalMux;
 };
 
 type TerminalCacheDescriptor = {
@@ -66,7 +66,8 @@ type TerminalCacheDescriptor = {
 	handleId: string;
 	kind: "shell" | "worker";
 	ownerKey: string;
-	sessionId?: string;
+	host: HostId;
+	sessionKey?: string;
 };
 
 type CachedTerminalEntry = TerminalCacheDescriptor & {
@@ -96,10 +97,16 @@ function terminalTargetMatches(left?: TerminalTarget, right?: TerminalTarget): b
 	if (!left || !right || left.kind !== right.kind) return false;
 	if (left.kind === "worker" && right.kind === "worker") return true;
 	if (left.kind === "reviewer" && right.kind === "reviewer") {
-		return left.handleId === right.handleId && left.harness === right.harness;
+		return (
+			refKey(left.session) === refKey(right.session) &&
+			left.handleId === right.handleId &&
+			left.harness === right.harness
+		);
 	}
 	if (left.kind === "shell" && right.kind === "shell") {
 		return (
+			left.host === right.host &&
+			(left.session ? refKey(left.session) : undefined) === (right.session ? refKey(right.session) : undefined) &&
 			left.handleId === right.handleId &&
 			left.generation === right.generation &&
 			left.title === right.title
@@ -129,15 +136,17 @@ function cacheDescriptor(
 	terminalTarget: TerminalTarget | undefined,
 ): TerminalCacheDescriptor | null {
 	if (terminalTarget?.kind === "shell") {
-		if (!terminalTargetBelongsToSession(terminalTarget, session?.id)) return null;
-		const ownerKey = `shell:${session?.id ?? "standalone"}:${terminalTarget.handleId}`;
+		if (!terminalTargetBelongsToSession(terminalTarget, session)) return null;
+		const sessionKey = session ? refKey(session) : undefined;
+		const ownerKey = `shell:${sessionKey ?? terminalTarget.host}:${terminalTarget.handleId}`;
 		return {
 			cacheKey: `${ownerKey}|handle:${terminalTarget.handleId}|generation:${terminalTarget.generation}`,
 			generation: terminalTarget.generation,
 			handleId: terminalTarget.handleId,
+			host: terminalTarget.host,
 			kind: "shell",
 			ownerKey,
-			sessionId: session?.id,
+			sessionKey,
 		};
 	}
 
@@ -146,13 +155,15 @@ function cacheDescriptor(
 	if (terminalTarget?.kind === "reviewer") return null;
 	const handleId = session?.terminalHandleId;
 	if (!session?.id || !handleId) return null;
-	const ownerKey = `session:${session.id}:worker`;
+	const sessionKey = refKey(session);
+	const ownerKey = `session:${sessionKey}:worker`;
 	return {
 		cacheKey: `${ownerKey}|handle:${handleId}`,
 		handleId,
+		host: session.host,
 		kind: "worker",
 		ownerKey,
-		sessionId: session.id,
+		sessionKey,
 	};
 }
 
@@ -267,15 +278,16 @@ export function TerminalCacheProvider({
 	theme: Theme;
 }) {
 	const workspaceQuery = useWorkspaceQuery();
-	const shellTerminalsQuery = useShellTerminals();
+	// One shell-terminal query per host the board knows about, so a remote's
+	// shells are tracked without the local host waiting on it.
+	const hosts = workspaceQuery.data?.map((section) => section.host) ?? [];
+	const shellTerminalsQueries = useQueries({ queries: hosts.map(shellTerminalsQueryOptions) });
 	const entriesRef = useRef(new Map<string, CachedTerminalEntry>());
 	const activeRef = useRef<ActiveTerminalEntry | null>(null);
 	const parkingRef = useRef<HTMLDivElement | null>(null);
 	const muxPoolRef = useRef<TerminalMuxPool | null>(null);
 	if (!muxPoolRef.current) {
-		muxPoolRef.current = createTerminalMuxPool(() =>
-			createTerminalMux(muxUrlFromApiBase(getApiBaseUrl())),
-		);
+		muxPoolRef.current = createTerminalMuxPool((host) => createTerminalMux(muxUrlForHost(host)));
 	}
 	const muxPool = muxPoolRef.current;
 	// Cloud sessions do not share the pooled local-daemon socket: each runs in its
@@ -291,16 +303,16 @@ export function TerminalCacheProvider({
 	// connect time rather than whatever was resolved on first render.
 	const cloudCpRef = useRef({ client: cloudClient, baseUrl: cloudBaseUrl });
 	cloudCpRef.current = { client: cloudClient, baseUrl: cloudBaseUrl };
-	const cloudMuxFactoriesRef = useRef(new Map<string, () => TerminalMux>());
+	const cloudMuxFactoriesRef = useRef(new Map<string, (host: HostId) => TerminalMux>());
 	const resolveCreateMux = useCallback(
-		(paneSession?: WorkspaceSession): (() => TerminalMux) => {
+		(paneSession?: WorkspaceSession): ((host: HostId) => TerminalMux) => {
 			const cloud = paneSession?.cloud;
 			if (!cloud) return muxPool.acquire;
 			const cached = cloudMuxFactoriesRef.current.get(paneSession.id);
 			if (cached) return cached;
 			const sessionId = paneSession.id;
 			const orgId = cloud.orgId;
-			const factory = () =>
+			const factory = (_host: HostId) =>
 				createCloudTerminalMux({
 					wsBaseUrl: `${cloudCpRef.current.baseUrl.replace(/^http/i, "ws").replace(/\/+$/, "")}/api/cloud/v1`,
 					kind: "agent",
@@ -468,14 +480,19 @@ export function TerminalCacheProvider({
 	// snapshot no longer contains their logical session.
 	useEffect(() => {
 		if (!workspaceQuery.isSuccess) return;
+		// Only a host that actually answered is authoritative about its sessions;
+		// a failed section must not evict the terminals it could not report.
+		const readySections = (workspaceQuery.data ?? []).filter((section) => section.status === "ready");
+		const authoritativeHosts = new Set(readySections.map((section) => section.host));
 		const sessions = new Map(
-			flattenHostSections(workspaceQuery.data).flatMap((workspace) =>
-				workspace.sessions.map((session) => [session.id, session] as const),
+			flattenHostSections(readySections).flatMap((workspace) =>
+				workspace.sessions.map((session) => [refKey(session), session] as const),
 			),
 		);
 		for (const entry of entriesRef.current.values()) {
-			const session = entry.sessionId ? sessions.get(entry.sessionId) : undefined;
-			if (entry.sessionId && !session) {
+			if (!authoritativeHosts.has(entry.host)) continue;
+			const session = entry.sessionKey ? sessions.get(entry.sessionKey) : undefined;
+			if (entry.sessionKey && !session) {
 				removeEntry(entry.cacheKey);
 				continue;
 			}
@@ -497,17 +514,25 @@ export function TerminalCacheProvider({
 	// Shell handles have their own lifecycle outside WorkspaceSession. Closing a
 	// shell must close its retained mux writer even if it was parked.
 	useEffect(() => {
-		if (!shellTerminalsQuery.isSuccess) return;
+		if (!workspaceQuery.isSuccess) return;
+		const authoritativeHosts = new Set<HostId>();
 		const shells = new Map(
-			(shellTerminalsQuery.data ?? []).map((terminal) => [terminal.handleId, terminal] as const),
+			shellTerminalsQueries
+				.flatMap((query, index) => {
+					const section = workspaceQuery.data?.[index];
+					if (section?.status !== "ready" || !query.isSuccess) return [];
+					authoritativeHosts.add(section.host);
+					return query.data ?? [];
+				})
+				.map((terminal) => [refKey({ host: terminal.host, id: terminal.handleId }), terminal] as const),
 		);
 		for (const entry of entriesRef.current.values()) {
-			if (entry.kind !== "shell") continue;
-			const shell = shells.get(entry.handleId);
+			if (entry.kind !== "shell" || !authoritativeHosts.has(entry.host)) continue;
+			const shell = shells.get(refKey({ host: entry.host, id: entry.handleId }));
 			if (
 				!shell ||
 				shell.createdAt !== entry.generation ||
-				shell.sessionId !== entry.sessionId
+				(shell.sessionId ? refKey({ host: shell.host, id: shell.sessionId }) : undefined) !== entry.sessionKey
 			) {
 				removeEntry(entry.cacheKey);
 				continue;
@@ -521,7 +546,7 @@ export function TerminalCacheProvider({
 				rerender();
 			}
 		}
-	}, [removeEntry, shellTerminalsQuery.data, shellTerminalsQuery.isSuccess]);
+	}, [removeEntry, shellTerminalsQueries, workspaceQuery.data, workspaceQuery.isSuccess]);
 
 	// The provider is the final shell ownership boundary. React disposes the
 	// portals; remove their externally-created host nodes as well.
@@ -580,7 +605,7 @@ function CachedTerminalSlot({
 		if (!cache || !slot) return;
 		cache.activate(descriptor, props, slot);
 		return () => cache.deactivate(descriptor.cacheKey, slot);
-	}, [cache, descriptor.cacheKey, descriptor.handleId, descriptor.kind, descriptor.ownerKey, descriptor.sessionId]);
+	}, [cache, descriptor.cacheKey, descriptor.handleId, descriptor.host, descriptor.kind, descriptor.ownerKey, descriptor.sessionKey]);
 
 	useLayoutEffect(() => {
 		cache?.update(descriptor.cacheKey, props);
@@ -604,16 +629,20 @@ export function TerminalPane({
 	const { t } = useTranslation();
 	const terminalTarget =
 		requestedTerminalTarget &&
-		terminalTargetBelongsToSession(requestedTerminalTarget, session?.id)
+		terminalTargetBelongsToSession(requestedTerminalTarget, session)
 			? requestedTerminalTarget
 			: ({ kind: "worker" } satisfies TerminalTarget);
 	const isOptimisticShell =
 		terminalTarget.kind === "shell" && terminalTarget.handleId.startsWith("pending-shell:");
 	const cache = useContext(TerminalCacheContext);
 	const terminalKey =
-		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"
-			? terminalTarget.handleId
-			: (session?.terminalHandleId ?? "empty");
+		terminalTarget?.kind === "reviewer"
+			? `reviewer:${refKey(terminalTarget.session)}:${terminalTarget.handleId}`
+			: terminalTarget?.kind === "shell"
+				? `shell:${terminalTarget.host}:${terminalTarget.handleId}:${terminalTarget.generation}`
+				: session?.terminalHandleId
+					? `worker:${refKey(session)}:${session.terminalHandleId}`
+					: "empty";
 
 	if (!window.ao) {
 		// A standalone shell has no agent and no branch, so it previews as a plain

--- a/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
+++ b/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
@@ -31,7 +31,18 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ GET: getMock, POST: postMock }),
+}));
+
 const worker: WorkspaceSession = {
+	host: "local",
 	activity: { state: "active", lastActivityAt: "2026-06-10T00:00:00Z" },
 	branch: "ao/sess-1",
 	id: "sess-1",
@@ -275,6 +286,7 @@ describe("TerminalSwitchAgentButton", () => {
 			activeAgentSwitch: activeSwitch,
 			activity: { state: "exited", lastActivityAt: "2026-06-10T00:00:02Z" },
 			status: "exited",
+			host: "local",
 		} satisfies WorkspaceSession;
 		renderControl(exitedSession, switchPresentation(activeSwitch, exitedSession));
 
@@ -292,6 +304,7 @@ describe("TerminalSwitchAgentButton", () => {
 			activeAgentSwitch: recoverySwitch,
 			activity: { state: "exited", lastActivityAt: "2026-06-10T00:00:02Z" },
 			status: "exited",
+			host: "local",
 		} satisfies WorkspaceSession;
 		renderControl(exitedSession, switchPresentation(recoverySwitch, exitedSession));
 

--- a/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
+++ b/frontend/src/renderer/components/TerminalSwitchAgentButton.test.tsx
@@ -35,7 +35,12 @@ vi.mock("../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({ GET: getMock, POST: postMock }),

--- a/frontend/src/renderer/components/TrayRuntime.test.tsx
+++ b/frontend/src/renderer/components/TrayRuntime.test.tsx
@@ -44,6 +44,7 @@ import { TrayRuntime } from "./TrayRuntime";
 
 function worker(overrides: Partial<WorkspaceSession> & { id: string }): WorkspaceSession {
 	return {
+		host: "local",
 		workspaceId: "proj-1",
 		workspaceName: "note-tauri",
 		title: overrides.id,
@@ -60,6 +61,7 @@ function worker(overrides: Partial<WorkspaceSession> & { id: string }): Workspac
 function workspaces(): WorkspaceSummary[] {
 	return [
 		{
+			host: "local",
 			id: "proj-1",
 			name: "note-tauri",
 			path: "/repos/note",
@@ -97,7 +99,7 @@ describe("TrayRuntime", () => {
 		h.workspaces = workspaces();
 		render(<TrayRuntime />);
 		act(() => h.listener?.({ projectId: "proj-1", sessionId: "s-need" }));
-		expect(h.navigateToSession).toHaveBeenCalledWith("proj-1", "s-need");
+		expect(h.navigateToSession).toHaveBeenCalledWith({ host: "local", id: "s-need" });
 	});
 
 	it("excludes an already-merged session even though it shares the merge zone", () => {

--- a/frontend/src/renderer/components/TrayRuntime.tsx
+++ b/frontend/src/renderer/components/TrayRuntime.tsx
@@ -3,6 +3,7 @@ import { useWorkspaceTraySessions } from "../hooks/useWorkspaceQuery";
 import { aoBridge } from "../lib/bridge";
 import { useNavigateToSession } from "../lib/navigate-to-session";
 
+import { LOCAL_HOST } from "../lib/hosts";
 export function TrayRuntime() {
 	const sessions = useWorkspaceTraySessions().data ?? [];
 	const navigateToSession = useNavigateToSession();
@@ -17,7 +18,7 @@ export function TrayRuntime() {
 
 	useEffect(() => {
 		return aoBridge.tray.onOpenSession((target) => {
-			navigateToSession(target.projectId, target.sessionId);
+			navigateToSession({ host: LOCAL_HOST, id: target.sessionId });
 		});
 	}, [navigateToSession]);
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -183,6 +183,7 @@ const chatSession = {
 	updatedAt: "2026-08-15T00:00:00Z",
 	activity: { state: "active", lastActivityAt: "2026-08-15T00:00:00Z" },
 	prs: [],
+	host: "local",
 } satisfies WorkspaceSession;
 
 describe("HumanMessage attachments", () => {
@@ -190,8 +191,7 @@ describe("HumanMessage attachments", () => {
 		render(
 			<HumanMessage
 				message={humanMessage(`check again\n\n${header}\n- .ao/attachments/${name}`)}
-				sessionId="ao session/1"
-			/>,
+				sessionId="ao session/1" />,
 		);
 
 		const image = screen.getByRole("img", { name });
@@ -234,8 +234,7 @@ describe("HumanMessage attachments", () => {
 				message={humanMessage(
 					`${authoredBody}\n\nAttached files (read these files in the workspace):\n- .ao/attachments/attachment-ab12.png`,
 				)}
-				sessionId="ao-1"
-			/>,
+				sessionId="ao-1" />,
 		);
 
 		expect(container.querySelector(".cursor-chat-human-message > p")?.textContent).toBe(
@@ -249,8 +248,7 @@ describe("HumanMessage attachments", () => {
 				message={humanMessage(
 					"inspect these\n\nAttached files (read these files in the workspace):\n- .ao/attachments/attachment-ab12.png\n- .ao/attachments/attachment-cd34.pdf",
 				)}
-				sessionId="ao-1"
-			/>,
+				sessionId="ao-1" />,
 		);
 
 		expect(screen.getByRole("img", { name: "attachment-ab12.png" })).toBeInTheDocument();

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -2122,6 +2122,37 @@ describe("ChatWorkspace reviewer tabs", () => {
 		act(() => [...previousTabListeners][0]?.());
 		expect(onSelectChat).toHaveBeenCalledOnce();
 	});
+
+	it("keeps reviewer and shell tabs in the auxiliary scroll strip", () => {
+		const shells = [
+			{
+				handleId: "shell-1",
+				host: "local",
+				sessionId: chatFixture.sessionId,
+				title: "chat worktree shell",
+				workingDir: "/p",
+				createdAt: "2026-08-04T00:00:00Z",
+			},
+		];
+		render(
+			<ChatWorkspace
+				snapshot={idleSnapshot()}
+				session={chatSession}
+				reviewerTerminal={reviewerTerminal}
+				shellTerminals={shells}
+			/>,
+		);
+
+		const tabList = screen.getByRole("tablist", { name: "Chat tabs" });
+		const scrollRegion = tabList.querySelector(".overflow-x-auto");
+		const chatTab = screen.getByRole("tab", { name: /^Codex/ });
+		const reviewerTab = screen.getByRole("tab", { name: "Reviewer" });
+		const shellTab = screen.getByRole("tab", { name: "chat worktree shell" });
+
+		expect(scrollRegion?.contains(chatTab)).toBe(false);
+		expect(scrollRegion?.contains(reviewerTab)).toBe(true);
+		expect(scrollRegion?.contains(shellTab)).toBe(true);
+	});
 });
 
 describe("promptSpacerHeight", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -1920,7 +1920,7 @@ describe("ChatWorkspace reviewer tabs", () => {
 	const reviewerTarget = {
 		kind: "reviewer" as const,
 		...reviewerTerminal,
-		sessionId: chatSession.id,
+		session: { host: chatSession.host, id: chatSession.id },
 	};
 
 	it("makes each full-height tile its semantic click target", () => {
@@ -2154,6 +2154,7 @@ describe("promptSpacerHeight", () => {
 describe("ChatWorkspace shell tabs", () => {
 	const shells = [
 		{
+			host: "local",
 			handleId: "shell-1",
 			sessionId: chatFixture.sessionId,
 			title: "chat worktree shell",
@@ -2161,6 +2162,7 @@ describe("ChatWorkspace shell tabs", () => {
 			createdAt: "2026-08-04T00:00:00Z",
 		},
 		{
+			host: "local",
 			handleId: "shell-2",
 			sessionId: chatFixture.sessionId,
 			title: "second shell",
@@ -2173,8 +2175,9 @@ describe("ChatWorkspace shell tabs", () => {
 		return {
 			kind: "shell" as const,
 			generation: shell.createdAt,
+			host: "local",
 			handleId,
-			sessionId: chatFixture.sessionId,
+			session: { host: "local", id: chatFixture.sessionId },
 			title: shell.title,
 		};
 	};
@@ -2255,7 +2258,7 @@ describe("ChatWorkspace shell tabs", () => {
 					kind: "reviewer",
 					handleId: "review-1",
 					harness: "codex",
-					sessionId: chatFixture.sessionId,
+					session: { host: "local", id: chatFixture.sessionId },
 				}}
 			/>,
 		);
@@ -2315,7 +2318,7 @@ describe("ChatWorkspace shell tabs", () => {
 					kind: "reviewer",
 					handleId: "review-1",
 					harness: "codex",
-					sessionId: chatFixture.sessionId,
+					session: { host: "local", id: chatFixture.sessionId },
 				}}
 			/>,
 		);

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -2145,7 +2145,7 @@ describe("ChatWorkspace reviewer tabs", () => {
 
 		const tabList = screen.getByRole("tablist", { name: "Chat tabs" });
 		const scrollRegion = tabList.querySelector(".overflow-x-auto");
-		const chatTab = screen.getByRole("tab", { name: /^Codex/ });
+		const chatTab = screen.getByRole("tab", { name: /^Reviewer chat/ });
 		const reviewerTab = screen.getByRole("tab", { name: "Reviewer" });
 		const shellTab = screen.getByRole("tab", { name: "chat worktree shell" });
 

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -64,6 +64,16 @@ vi.mock("../../lib/api-client", () => ({
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
 }));
 
+// clientFor(LOCAL_HOST) is the client apiClient already was, so the local
+// host resolves to the same fake the api-client mock installs.
+vi.mock("../../lib/host-clients", () => ({
+	baseUrlFor: () => "http://127.0.0.1:3001",
+	connectedHosts: () => [],
+	subscribeConnectedHosts: () => () => undefined,
+	isHostReady: () => true,
+	clientFor: () => ({ GET: getMock, POST: postMock }),
+}));
+
 vi.mock("../../hooks/useConversation", () => ({
 	useConversation: (sessionId: string) => ({
 		...conversationState,
@@ -137,6 +147,7 @@ const session = {
 	status: "working",
 	updatedAt: "2026-08-08T00:00:00Z",
 	prs: [],
+	host: "local",
 } satisfies WorkspaceSession;
 
 function Wrapper({ client, children }: { client: QueryClient; children: ReactNode }) {
@@ -498,7 +509,7 @@ describe("SessionChatSurface link routing", () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 		});
-		queryClient.setQueryData(agentSwitchesQueryKey(session.id), [historicalSwitch]);
+		queryClient.setQueryData(agentSwitchesQueryKey(session), [historicalSwitch]);
 
 		render(
 			<Wrapper client={queryClient}>
@@ -543,7 +554,7 @@ describe("SessionChatSurface link routing", () => {
 
 		agentSwitchState.data = [failedSwitch];
 		act(() => {
-			queryClient.setQueryData(agentSwitchesQueryKey(session.id), [failedSwitch]);
+			queryClient.setQueryData(agentSwitchesQueryKey(session), [failedSwitch]);
 		});
 		view.rerender(
 			<Wrapper client={queryClient}>
@@ -571,7 +582,7 @@ describe("SessionChatSurface link routing", () => {
 		} satisfies AgentSwitchSummary;
 		agentSwitchState.data = [retrySwitch, failedSwitch];
 		act(() => {
-			queryClient.setQueryData(agentSwitchesQueryKey(session.id), [retrySwitch, failedSwitch]);
+			queryClient.setQueryData(agentSwitchesQueryKey(session), [retrySwitch, failedSwitch]);
 		});
 		view.rerender(
 			<Wrapper client={queryClient}>
@@ -591,7 +602,7 @@ describe("SessionChatSurface link routing", () => {
 		conversationState.snapshot = { capabilities: [], controller: { state: "ready" } };
 		agentSwitchState.data = [completedRetry, failedSwitch];
 		act(() => {
-			queryClient.setQueryData(agentSwitchesQueryKey(session.id), [completedRetry, failedSwitch]);
+			queryClient.setQueryData(agentSwitchesQueryKey(session), [completedRetry, failedSwitch]);
 		});
 		view.rerender(
 			<Wrapper client={queryClient}>

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -653,9 +653,10 @@ describe("SessionChatSurface link routing", () => {
 				<SessionChatSurface
 					session={session}
 					shellTarget={{
+						host: "local",
 						kind: "shell",
 						handleId: "shell-1",
-						sessionId: session.id,
+						session: { host: "local", id: session.id },
 						title: "shell",
 						generation: "2026-08-16T00:00:00Z",
 					}}

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -68,7 +68,12 @@ vi.mock("../../lib/api-client", () => ({
 // host resolves to the same fake the api-client mock installs.
 vi.mock("../../lib/host-clients", () => ({
 	baseUrlFor: () => "http://127.0.0.1:3001",
-	connectedHosts: () => [],
+	connectedHosts: (() => {
+		// useSyncExternalStore requires a stable snapshot: a fresh [] each call
+		// re-renders forever.
+		const hosts: string[] = [];
+		return () => hosts;
+	})(),
 	subscribeConnectedHosts: () => () => undefined,
 	isHostReady: () => true,
 	clientFor: () => ({ GET: getMock, POST: postMock }),

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -175,7 +175,7 @@ export function SessionChatSurface({
 	const openLinkInBrowser = useSessionBrowserLink(session);
 	// Agent-switch presentation for the chat surface progress track and input locks.
 	const switchMutation = useSwitchAgentState(session.id);
-	const agentSwitches = useAgentSwitches(session.id).data ?? [];
+	const agentSwitches = useAgentSwitches(session).data ?? [];
 	const activeHistorySwitch = findActiveAgentSwitch(agentSwitches);
 	const selectedDurableAgentSwitch = selectDurableAgentSwitch(
 		session.activeAgentSwitch,

--- a/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -152,6 +152,8 @@ export function GeneralSettingsSection({
 	const soundNotificationsSaveError = useSoundNotificationsStore((state) => state.saveError);
 	const developerMode = useUiStore((state) => state.developerMode);
 	const setDeveloperMode = useUiStore((state) => state.setDeveloperMode);
+	const remoteHosts = useUiStore((state) => state.remoteHosts);
+	const setRemoteHosts = useUiStore((state) => state.setRemoteHosts);
 
 	const themeOptions = [
 		{ value: "light", label: t("settings.theme.light") },
@@ -236,6 +238,13 @@ export function GeneralSettingsSection({
 						aria-label={t("settings.developerMode")}
 						checked={developerMode}
 						onCheckedChange={setDeveloperMode}
+					/>
+				</SettingsRow>
+				<SettingsRow label={t("settings.remoteHosts")}>
+					<Switch
+						aria-label={t("settings.remoteHosts")}
+						checked={remoteHosts}
+						onCheckedChange={setRemoteHosts}
 					/>
 				</SettingsRow>
 				{developerMode && <CloudOfferingRow />}

--- a/frontend/src/renderer/hooks/useAgentModelsQuery.ts
+++ b/frontend/src/renderer/hooks/useAgentModelsQuery.ts
@@ -1,26 +1,30 @@
 import { queryOptions } from "@tanstack/react-query";
+import { refKey, type Ref } from "../lib/hosts";
 import type { components } from "../../api/schema";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
 
 export type AgentModelCatalog = components["schemas"]["AgentModelsResponse"];
 
 const MODEL_CATALOG_VALIDATION_INTERVAL_MS = 10 * 60 * 1_000;
 
-export const agentModelsQueryKey = (agentId: string, projectId: string) =>
-	["agent-models", agentId, projectId] as const;
+export const agentModelsQueryKey = (agentId: string, project: Ref) =>
+	["agent-models", agentId, refKey(project)] as const;
 
 async function requestAgentModels(
 	agentId: string,
-	projectId: string,
+	project: Ref,
 	mode: "cached" | "refresh" | "revalidate",
 ): Promise<AgentModelCatalog> {
 	const path = { agent: agentId };
+	const projectId = project.id;
+	const client = clientFor(project.host);
 	const result =
 		mode === "cached"
-			? await apiClient.GET("/api/v1/agents/{agent}/models", {
+			? await client.GET("/api/v1/agents/{agent}/models", {
 					params: { path, query: { projectId: projectId || undefined } },
 				})
-			: await apiClient.POST("/api/v1/agents/{agent}/models/refresh", {
+			: await client.POST("/api/v1/agents/{agent}/models/refresh", {
 					params: {
 						path,
 						query: { projectId: projectId || undefined, revalidate: mode === "revalidate" || undefined },
@@ -30,19 +34,19 @@ async function requestAgentModels(
 	return result.data as AgentModelCatalog;
 }
 
-export function agentModelsQueryOptions(agentId: string, projectId: string) {
+export function agentModelsQueryOptions(agentId: string, project: Ref) {
 	return queryOptions({
-		queryKey: agentModelsQueryKey(agentId, projectId),
-		queryFn: () => requestAgentModels(agentId, projectId, "cached"),
+		queryKey: agentModelsQueryKey(agentId, project),
+		queryFn: () => requestAgentModels(agentId, project, "cached"),
 		enabled: agentId !== "",
 		staleTime: MODEL_CATALOG_VALIDATION_INTERVAL_MS,
 	});
 }
 
-export function refreshAgentModels(agentId: string, projectId: string) {
-	return requestAgentModels(agentId, projectId, "refresh");
+export function refreshAgentModels(agentId: string, project: Ref) {
+	return requestAgentModels(agentId, project, "refresh");
 }
 
-export function revalidateAgentModels(agentId: string, projectId: string) {
-	return requestAgentModels(agentId, projectId, "revalidate");
+export function revalidateAgentModels(agentId: string, project: Ref) {
+	return requestAgentModels(agentId, project, "revalidate");
 }

--- a/frontend/src/renderer/hooks/useAgentReadinessQuery.ts
+++ b/frontend/src/renderer/hooks/useAgentReadinessQuery.ts
@@ -2,19 +2,27 @@ import { useEffect, useMemo } from "react";
 import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
+import { LOCAL_HOST, type HostId } from "../lib/hosts";
 
 export type AgentReadiness = components["schemas"]["AgentReadinessResponse"];
 export type AgentReadinessSnapshot = components["schemas"]["AgentReadinessSnapshot"];
 export type AgentReadinessPurpose = components["schemas"]["EnsureAgentReadinessRequest"]["purpose"];
 
 export const agentReadinessQueryKey = ["agent-readiness"] as const;
+// The local host keeps the bare key so nothing that reads or invalidates
+// ["agent-readiness"] today has to learn about hosts.
+export const agentReadinessQueryKeyFor = (host: HostId) =>
+	host === LOCAL_HOST ? agentReadinessQueryKey : ([...agentReadinessQueryKey, host] as const);
 
-async function fetchAgentReadiness(): Promise<AgentReadiness> {
-	const { data, error } = await apiClient.GET("/api/v1/agents/readiness");
+async function fetchAgentReadiness(host: HostId): Promise<AgentReadiness> {
+	const { data, error } = await clientFor(host).GET("/api/v1/agents/readiness");
 	if (error) throw new Error(apiErrorMessage(error));
 	return data as AgentReadiness;
 }
 
+// Stays on apiClient (always local), like every other mutation: only reads
+// are converted to clientFor(host) so far.
 export async function ensureAgentReadiness(
 	agentIds: string[] = [],
 	purpose: AgentReadinessPurpose = "display",
@@ -36,23 +44,28 @@ export function mergeAgentReadiness(
 	return { agents: [...byID.values()].sort((a, b) => a.id.localeCompare(b.id)) };
 }
 
+// ensureAgentReadiness only ever probes the local daemon, so its result is
+// always cached under the local host's key regardless of which host a reader
+// happens to be displaying.
 export function cacheAgentReadiness(queryClient: QueryClient, next: AgentReadiness): void {
-	queryClient.setQueryData<AgentReadiness>(agentReadinessQueryKey, (current) =>
+	queryClient.setQueryData<AgentReadiness>(agentReadinessQueryKeyFor(LOCAL_HOST), (current) =>
 		mergeAgentReadiness(current, next),
 	);
 }
 
-export const agentReadinessQueryOptions = {
-	queryKey: agentReadinessQueryKey,
-	queryFn: fetchAgentReadiness,
+export const agentReadinessQueryOptionsFor = (host: HostId) => ({
+	queryKey: agentReadinessQueryKeyFor(host),
+	queryFn: () => fetchAgentReadiness(host),
 	retry: 1,
 	// Freshness belongs to the daemon coordinator. React Query only retains the
 	// latest display copy and must never decide whether native work is required.
 	staleTime: Number.POSITIVE_INFINITY,
-};
+});
 
-export function useAgentReadinessQuery(enabled = true) {
-	return useQuery({ ...agentReadinessQueryOptions, enabled });
+export const agentReadinessQueryOptions = agentReadinessQueryOptionsFor(LOCAL_HOST);
+
+export function useAgentReadinessQuery(enabled = true, host: HostId = LOCAL_HOST) {
+	return useQuery({ ...agentReadinessQueryOptionsFor(host), enabled });
 }
 
 export function useEnsureAgentReadiness({

--- a/frontend/src/renderer/hooks/useAgentSwitches.ts
+++ b/frontend/src/renderer/hooks/useAgentSwitches.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
+import { refKey, type Ref } from "../lib/hosts";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import type { AgentSwitchSummary } from "../types/workspace";
 
@@ -8,7 +10,8 @@ export type AgentSwitch = AgentSwitchSummary;
 const terminalAgentSwitchStates = new Set<AgentSwitch["state"]>(["completed", "failed"]);
 
 export const agentSwitchesQueryRoot = ["session-agent-switches"] as const;
-export const agentSwitchesQueryKey = (sessionId: string) => [...agentSwitchesQueryRoot, sessionId] as const;
+export const agentSwitchesQueryKey = (session?: Ref) =>
+	session ? ([...agentSwitchesQueryRoot, refKey(session)] as const) : agentSwitchesQueryRoot;
 
 export function isTerminalAgentSwitch(agentSwitch: AgentSwitch): boolean {
 	return terminalAgentSwitchStates.has(agentSwitch.state);
@@ -75,9 +78,9 @@ export function agentSwitchesRefetchInterval(agentSwitches: AgentSwitch[]): 1_00
 		: false;
 }
 
-async function fetchAgentSwitches(sessionId: string): Promise<AgentSwitch[]> {
-	const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/agent-switches", {
-		params: { path: { sessionId } },
+async function fetchAgentSwitches(session: Ref): Promise<AgentSwitch[]> {
+	const { data, error } = await clientFor(session.host).GET("/api/v1/sessions/{sessionId}/agent-switches", {
+		params: { path: { sessionId: session.id } },
 	});
 	if (error) {
 		throw new Error(apiErrorMessage(error, "Unable to load agent switch status"));
@@ -85,11 +88,11 @@ async function fetchAgentSwitches(sessionId: string): Promise<AgentSwitch[]> {
 	return data?.switches ?? [];
 }
 
-export function useAgentSwitches(sessionId: string) {
+export function useAgentSwitches(session: Ref | undefined) {
 	return useQuery({
-		queryKey: agentSwitchesQueryKey(sessionId),
-		enabled: Boolean(sessionId),
-		queryFn: () => (usesPreviewWorkspaceData ? Promise.resolve([]) : fetchAgentSwitches(sessionId)),
+		queryKey: agentSwitchesQueryKey(session),
+		enabled: Boolean(session?.id),
+		queryFn: () => (usesPreviewWorkspaceData ? Promise.resolve([]) : fetchAgentSwitches(session!)),
 		// Keep active sagas fresh even if the CDC connection is temporarily
 		// unavailable. Source-recovery endpoints accept work asynchronously, so
 		// those recovery rows must also poll until their worker settles.

--- a/frontend/src/renderer/hooks/useSessionHandoffMenu.ts
+++ b/frontend/src/renderer/hooks/useSessionHandoffMenu.ts
@@ -20,7 +20,7 @@ export function useSessionHandoffMenu(
 	options: UseSessionHandoffMenuOptions = {},
 ) {
 	const sessionId = session?.id ?? "";
-	const agentSwitches = useAgentSwitches(sessionId).data ?? [];
+	const agentSwitches = useAgentSwitches(session).data ?? [];
 	const switchMutation = useSwitchAgentState(sessionId);
 	const selectedAgentSwitch = selectDurableAgentSwitch(session?.activeAgentSwitch, agentSwitches);
 	const activeHistorySwitch = findActiveAgentSwitch(agentSwitches);

--- a/frontend/src/renderer/hooks/useSessionScmSummary.ts
+++ b/frontend/src/renderer/hooks/useSessionScmSummary.ts
@@ -1,34 +1,35 @@
 import { useQuery } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
-import { apiClient } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
+import { refKey, type Ref } from "../lib/hosts";
 
 export type SessionPRSummary = components["schemas"]["SessionPRSummary"];
 
-export const sessionScmSummaryQueryKey = (sessionId?: string) =>
-	sessionId ? (["session-scm-summary", sessionId] as const) : (["session-scm-summary"] as const);
+export const sessionScmSummaryQueryKey = (session?: Ref) =>
+	session ? (["session-scm-summary", refKey(session)] as const) : (["session-scm-summary"] as const);
 
-export async function fetchSessionScmSummary(sessionId: string): Promise<SessionPRSummary[]> {
-	const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/pr", {
-		params: { path: { sessionId } },
+export async function fetchSessionScmSummary(session: Ref): Promise<SessionPRSummary[]> {
+	const { data, error } = await clientFor(session.host).GET("/api/v1/sessions/{sessionId}/pr", {
+		params: { path: { sessionId: session.id } },
 	});
 	if (error) throw error;
 	return data?.prs ?? [];
 }
 
-export function sessionScmSummaryQueryOptions(sessionId: string) {
+export function sessionScmSummaryQueryOptions(session: Ref) {
 	return {
-		queryKey: sessionScmSummaryQueryKey(sessionId),
-		enabled: Boolean(sessionId),
-		queryFn: () => fetchSessionScmSummary(sessionId),
+		queryKey: sessionScmSummaryQueryKey(session),
+		enabled: Boolean(session.id),
+		queryFn: () => fetchSessionScmSummary(session),
 		retry: 1,
 	};
 }
 
-export function useSessionScmSummary(sessionId?: string) {
+export function useSessionScmSummary(session?: Ref) {
 	return useQuery({
-		queryKey: sessionScmSummaryQueryKey(sessionId),
-		enabled: Boolean(sessionId),
-		queryFn: () => fetchSessionScmSummary(sessionId!),
+		queryKey: sessionScmSummaryQueryKey(session),
+		enabled: Boolean(session),
+		queryFn: () => fetchSessionScmSummary(session!),
 		retry: 1,
 	});
 }

--- a/frontend/src/renderer/hooks/useSessionUsage.ts
+++ b/frontend/src/renderer/hooks/useSessionUsage.ts
@@ -1,26 +1,29 @@
 import { useQuery } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
-import { apiClient } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
+import { refKey, type Ref } from "../lib/hosts";
 import { sessionUsageQueryRoot } from "./useSessionUsageSummaries";
 
 export type SessionUsage = components["schemas"]["SessionUsageResponse"];
 
-export const sessionUsageDetailQueryKey = (sessionId: string) =>
-	[...sessionUsageQueryRoot, "detail", sessionId] as const;
+// Keyed by ref, not by bare id: two hosts can hand out the same session id, and
+// a bare-id key would serve one host's usage for the other's session.
+export const sessionUsageDetailQueryKey = (session: Ref) =>
+	[...sessionUsageQueryRoot, "detail", refKey(session)] as const;
 
-export async function fetchSessionUsage(sessionId: string): Promise<SessionUsage> {
-	const { data, error } = await apiClient.GET("/api/v1/usage/sessions/{sessionId}", {
-		params: { path: { sessionId } },
+export async function fetchSessionUsage(session: Ref): Promise<SessionUsage> {
+	const { data, error } = await clientFor(session.host).GET("/api/v1/usage/sessions/{sessionId}", {
+		params: { path: { sessionId: session.id } },
 	});
 	if (error) throw error;
 	return data;
 }
 
-export function useSessionUsage(sessionId: string, enabled = true) {
+export function useSessionUsage(session: Ref, enabled = true) {
 	return useQuery({
-		queryKey: sessionUsageDetailQueryKey(sessionId),
-		queryFn: () => fetchSessionUsage(sessionId),
-		enabled: enabled && Boolean(sessionId),
+		queryKey: sessionUsageDetailQueryKey(session),
+		queryFn: () => fetchSessionUsage(session),
+		enabled: enabled && Boolean(session.id),
 		retry: 1,
 	});
 }

--- a/frontend/src/renderer/hooks/useSessionUsageSummaries.test.ts
+++ b/frontend/src/renderer/hooks/useSessionUsageSummaries.test.ts
@@ -7,6 +7,11 @@ vi.mock("../lib/api-client", () => ({
 }));
 
 import { sessionUsageDetailQueryKey } from "./useSessionUsage";
+// clientFor(LOCAL_HOST) is the client apiClient already was.
+vi.mock("../lib/host-clients", () => ({
+	clientFor: () => ({ GET: (...args: unknown[]) => getMock(...args) }),
+}));
+
 import {
 	fetchSessionUsageSummaries,
 	sessionUsageQueryRoot,
@@ -19,23 +24,23 @@ describe("session usage summaries", () => {
 	});
 
 	it("fetches one project batch and relies on event invalidation", async () => {
-		await fetchSessionUsageSummaries("reverb");
+		await fetchSessionUsageSummaries({ host: "local", id: "reverb" });
 
 		expect(getMock).toHaveBeenCalledOnce();
 		expect(getMock).toHaveBeenCalledWith("/api/v1/usage/sessions", {
 			params: { query: { projectId: "reverb" } },
 		});
-		expect(sessionUsageQueryOptions("reverb")).not.toHaveProperty("refetchInterval");
+		expect(sessionUsageQueryOptions({ host: "local", id: "reverb" })).not.toHaveProperty("refetchInterval");
 	});
 
 	// The detail query lives in useSessionUsage.ts and must stay beneath this
 	// root, or a usage event invalidates the board summaries without touching
 	// the inspector's open session.
 	it("keeps the detail query beneath the shared usage query root", () => {
-		expect(sessionUsageDetailQueryKey("sess-1")).toEqual([
+		expect(sessionUsageDetailQueryKey({ host: "local", id: "sess-1" })).toEqual([
 			...sessionUsageQueryRoot,
 			"detail",
-			"sess-1",
+			"local:sess-1",
 		]);
 	});
 });

--- a/frontend/src/renderer/hooks/useSessionUsageSummaries.ts
+++ b/frontend/src/renderer/hooks/useSessionUsageSummaries.ts
@@ -1,31 +1,34 @@
 import { useQuery } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
-import { apiClient } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
+import { LOCAL_HOST, refKey, type Ref } from "../lib/hosts";
 
 export type SessionUsageSummary = components["schemas"]["CompactSessionUsageResponse"];
 
 export const sessionUsageQueryRoot = ["session-usage"] as const;
-export const sessionUsageQueryKey = (projectId?: string) =>
-	[...sessionUsageQueryRoot, projectId ?? "all"] as const;
+export const sessionUsageQueryKey = (project?: Ref) =>
+	[...sessionUsageQueryRoot, project ? refKey(project) : "all"] as const;
 
-export async function fetchSessionUsageSummaries(projectId?: string): Promise<SessionUsageSummary[]> {
-	const { data, error } = await apiClient.GET("/api/v1/usage/sessions", {
-		params: { query: projectId ? { projectId } : {} },
+export async function fetchSessionUsageSummaries(project?: Ref): Promise<SessionUsageSummary[]> {
+	const { data, error } = await clientFor(project?.host ?? LOCAL_HOST).GET("/api/v1/usage/sessions", {
+		params: { query: project ? { projectId: project.id } : {} },
 	});
 	if (error) throw error;
 	return data?.sessions ?? [];
 }
 
-export function sessionUsageQueryOptions(projectId?: string) {
+export function sessionUsageQueryOptions(project?: Ref) {
 	return {
-		queryKey: sessionUsageQueryKey(projectId),
-		queryFn: () => fetchSessionUsageSummaries(projectId),
+		queryKey: sessionUsageQueryKey(project),
+		queryFn: () => fetchSessionUsageSummaries(project),
 		retry: 1,
+		// The map is keyed by ref for the same reason the query is: a summary
+		// looked up by bare session id could come from the wrong machine.
 		select: (items: SessionUsageSummary[]) =>
-			new Map(items.map((item) => [item.sessionId, item] as const)),
+			new Map(items.map((item) => [refKey({ host: project?.host ?? LOCAL_HOST, id: item.sessionId }), item] as const)),
 	};
 }
 
-export function useSessionUsageSummaries(projectId?: string) {
-	return useQuery(sessionUsageQueryOptions(projectId));
+export function useSessionUsageSummaries(project?: Ref) {
+	return useQuery(sessionUsageQueryOptions(project));
 }

--- a/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
+++ b/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
@@ -2,6 +2,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
+import { refKey, type Ref } from "../lib/hosts";
 import {
 	getWorkspaceFileConnectionState,
 	subscribeWorkspaceFileChanges,
@@ -24,16 +26,24 @@ export type WorkspaceFileDetail = components["schemas"]["WorkspaceFileResponse"]
 	compareMode?: WorkspaceCompareMode;
 };
 
-export const sessionWorkspaceFilesQueryKey = (sessionId: string) => ["session-workspace-files", sessionId] as const;
+type WorkspaceSessionRef = string | Ref;
+
+const sessionId = (session: WorkspaceSessionRef) => (typeof session === "string" ? session : session.id);
+const sessionKey = (session: WorkspaceSessionRef) => (typeof session === "string" ? session : refKey(session));
+const sessionClient = (session: WorkspaceSessionRef) => (typeof session === "string" ? apiClient : clientFor(session.host));
+
+export const sessionWorkspaceFilesQueryKey = (session: WorkspaceSessionRef) =>
+	["session-workspace-files", sessionKey(session)] as const;
 const WORKSPACE_FILES_DEGRADED_REFETCH_MS = 30_000;
 
-async function fetchSessionWorkspaceFiles(sessionId: string, errorMessage: string): Promise<WorkspaceFilesResponse> {
-	const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/files", {
-		params: { path: { sessionId } },
+async function fetchSessionWorkspaceFiles(session: WorkspaceSessionRef, errorMessage: string): Promise<WorkspaceFilesResponse> {
+	const id = sessionId(session);
+	const { data, error } = await sessionClient(session).GET("/api/v1/sessions/{sessionId}/workspace/files", {
+		params: { path: { sessionId: id } },
 	});
 	if (error) throw new Error(apiErrorMessage(error, errorMessage));
 	return (data ?? {
-		sessionId,
+		sessionId: id,
 		files: [],
 		truncated: false,
 		sections: { staged: [], unstaged: [], untracked: [], committed: [] },
@@ -42,12 +52,16 @@ async function fetchSessionWorkspaceFiles(sessionId: string, errorMessage: strin
 	}) as WorkspaceFilesResponse;
 }
 
-export const sessionWorkspaceFileQueryKey = (sessionId: string, path: string) =>
-	["session-workspace-file", sessionId, path] as const;
+export const sessionWorkspaceFileQueryKey = (session: WorkspaceSessionRef, path: string) =>
+	["session-workspace-file", sessionKey(session), path] as const;
 
-async function fetchSessionWorkspaceFile(sessionId: string, path: string, errorMessage: string): Promise<WorkspaceFileDetail> {
-	const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/file", {
-		params: { path: { sessionId }, query: { path } },
+async function fetchSessionWorkspaceFile(
+	session: WorkspaceSessionRef,
+	path: string,
+	errorMessage: string,
+): Promise<WorkspaceFileDetail> {
+	const { data, error } = await sessionClient(session).GET("/api/v1/sessions/{sessionId}/workspace/file", {
+		params: { path: { sessionId: sessionId(session) }, query: { path } },
 	});
 	if (error) throw new Error(apiErrorMessage(error, errorMessage));
 	if (!data) throw new Error(errorMessage);
@@ -56,19 +70,26 @@ async function fetchSessionWorkspaceFile(sessionId: string, path: string, errorM
 
 // Shared so the diff view (expand-on-demand) and the plain read-only viewer
 // always resolve to the same cache entry for a given (session, path).
-export function sessionWorkspaceFileQueryOptions(sessionId: string, path: string, errorMessage = "Unable to load workspace file") {
+export function sessionWorkspaceFileQueryOptions(
+	session: WorkspaceSessionRef,
+	path: string,
+	errorMessage = "Unable to load workspace file",
+) {
 	return {
-		queryKey: sessionWorkspaceFileQueryKey(sessionId, path),
-		queryFn: () => fetchSessionWorkspaceFile(sessionId, path, errorMessage),
+		queryKey: sessionWorkspaceFileQueryKey(session, path),
+		queryFn: () => fetchSessionWorkspaceFile(session, path, errorMessage),
 	};
 }
 
 // Shared so SessionFileExplorer and SessionInspector resolve to the same cache
 // entry while SSE invalidation remains the normal refresh path.
-export function sessionWorkspaceFilesQueryOptions(sessionId: string, errorMessage = "Unable to load workspace files") {
+export function sessionWorkspaceFilesQueryOptions(
+	session: WorkspaceSessionRef,
+	errorMessage = "Unable to load workspace files",
+) {
 	return {
-		queryKey: sessionWorkspaceFilesQueryKey(sessionId),
-		queryFn: () => fetchSessionWorkspaceFiles(sessionId, errorMessage),
+		queryKey: sessionWorkspaceFilesQueryKey(session),
+		queryFn: () => fetchSessionWorkspaceFiles(session, errorMessage),
 	};
 }
 

--- a/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
+++ b/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
@@ -1,9 +1,9 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 import type { components } from "../../api/schema";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { apiErrorMessage } from "../lib/api-client";
 import { clientFor } from "../lib/host-clients";
-import { refKey, type Ref } from "../lib/hosts";
+import { LOCAL_HOST, refKey, type Ref } from "../lib/hosts";
 import {
 	getWorkspaceFileConnectionState,
 	subscribeWorkspaceFileChanges,
@@ -26,24 +26,27 @@ export type WorkspaceFileDetail = components["schemas"]["WorkspaceFileResponse"]
 	compareMode?: WorkspaceCompareMode;
 };
 
-type WorkspaceSessionRef = string | Ref;
-
-const sessionId = (session: WorkspaceSessionRef) => (typeof session === "string" ? session : session.id);
-const sessionKey = (session: WorkspaceSessionRef) => (typeof session === "string" ? session : refKey(session));
-const sessionClient = (session: WorkspaceSessionRef) => (typeof session === "string" ? apiClient : clientFor(session.host));
-
-export const sessionWorkspaceFilesQueryKey = (session: WorkspaceSessionRef) =>
-	["session-workspace-files", sessionKey(session)] as const;
+const emptySessionRef: Ref = { host: LOCAL_HOST, id: "" };
 const WORKSPACE_FILES_DEGRADED_REFETCH_MS = 30_000;
 
-async function fetchSessionWorkspaceFiles(session: WorkspaceSessionRef, errorMessage: string): Promise<WorkspaceFilesResponse> {
-	const id = sessionId(session);
-	const { data, error } = await sessionClient(session).GET("/api/v1/sessions/{sessionId}/workspace/files", {
-		params: { path: { sessionId: id } },
+export type WorkspaceSessionRef = Ref | string;
+
+// Existing Files components pass a local id until the presentational Ref slice
+// lands; all remote callers must provide the host-qualified Ref.
+export function workspaceSessionRef(session: WorkspaceSessionRef): Ref {
+	return typeof session === "string" ? { host: LOCAL_HOST, id: session } : session;
+}
+
+export const sessionWorkspaceFilesQueryKey = (session: WorkspaceSessionRef) =>
+	["session-workspace-files", refKey(workspaceSessionRef(session))] as const;
+
+async function fetchSessionWorkspaceFiles(session: Ref, errorMessage: string): Promise<WorkspaceFilesResponse> {
+	const { data, error } = await clientFor(session.host).GET("/api/v1/sessions/{sessionId}/workspace/files", {
+		params: { path: { sessionId: session.id } },
 	});
 	if (error) throw new Error(apiErrorMessage(error, errorMessage));
 	return (data ?? {
-		sessionId: id,
+		sessionId: session.id,
 		files: [],
 		truncated: false,
 		sections: { staged: [], unstaged: [], untracked: [], committed: [] },
@@ -53,15 +56,11 @@ async function fetchSessionWorkspaceFiles(session: WorkspaceSessionRef, errorMes
 }
 
 export const sessionWorkspaceFileQueryKey = (session: WorkspaceSessionRef, path: string) =>
-	["session-workspace-file", sessionKey(session), path] as const;
+	["session-workspace-file", refKey(workspaceSessionRef(session)), path] as const;
 
-async function fetchSessionWorkspaceFile(
-	session: WorkspaceSessionRef,
-	path: string,
-	errorMessage: string,
-): Promise<WorkspaceFileDetail> {
-	const { data, error } = await sessionClient(session).GET("/api/v1/sessions/{sessionId}/workspace/file", {
-		params: { path: { sessionId: sessionId(session) }, query: { path } },
+async function fetchSessionWorkspaceFile(session: Ref, path: string, errorMessage: string): Promise<WorkspaceFileDetail> {
+	const { data, error } = await clientFor(session.host).GET("/api/v1/sessions/{sessionId}/workspace/file", {
+		params: { path: { sessionId: session.id }, query: { path } },
 	});
 	if (error) throw new Error(apiErrorMessage(error, errorMessage));
 	if (!data) throw new Error(errorMessage);
@@ -75,9 +74,10 @@ export function sessionWorkspaceFileQueryOptions(
 	path: string,
 	errorMessage = "Unable to load workspace file",
 ) {
+	const ref = workspaceSessionRef(session);
 	return {
-		queryKey: sessionWorkspaceFileQueryKey(session, path),
-		queryFn: () => fetchSessionWorkspaceFile(session, path, errorMessage),
+		queryKey: sessionWorkspaceFileQueryKey(ref, path),
+		queryFn: () => fetchSessionWorkspaceFile(ref, path, errorMessage),
 	};
 }
 
@@ -87,9 +87,10 @@ export function sessionWorkspaceFilesQueryOptions(
 	session: WorkspaceSessionRef,
 	errorMessage = "Unable to load workspace files",
 ) {
+	const ref = workspaceSessionRef(session);
 	return {
-		queryKey: sessionWorkspaceFilesQueryKey(session),
-		queryFn: () => fetchSessionWorkspaceFiles(session, errorMessage),
+		queryKey: sessionWorkspaceFilesQueryKey(ref),
+		queryFn: () => fetchSessionWorkspaceFiles(ref, errorMessage),
 	};
 }
 
@@ -97,12 +98,13 @@ export function workspaceFilesRefetchInterval(state: WorkspaceFileConnectionStat
 	return state === "degraded" ? WORKSPACE_FILES_DEGRADED_REFETCH_MS : false;
 }
 
-export function useWorkspaceFileConnectionState(sessionId: string): WorkspaceFileConnectionState {
+export function useWorkspaceFileConnectionState(session: WorkspaceSessionRef): WorkspaceFileConnectionState {
+	const ref = workspaceSessionRef(session);
 	const subscribe = useCallback(
-		(listener: () => void) => subscribeWorkspaceFileConnectionState(sessionId, listener),
-		[sessionId],
+		(listener: () => void) => subscribeWorkspaceFileConnectionState(ref, listener),
+		[ref.host, ref.id],
 	);
-	const getSnapshot = useCallback(() => getWorkspaceFileConnectionState(sessionId), [sessionId]);
+	const getSnapshot = useCallback(() => getWorkspaceFileConnectionState(ref), [ref.host, ref.id]);
 	return useSyncExternalStore(subscribe, getSnapshot);
 }
 
@@ -113,19 +115,22 @@ export function isChangedWorkspaceFile(file: WorkspaceFileSummary): boolean {
 // Keep the lightweight summary query warm while the inspector is open. The
 // Files view then mounts against current cache data instead of flashing a
 // misleading zero while its first request starts.
-export function useSessionWorkspaceFilesChangedCount(sessionId: string | undefined): number | undefined {
+export function useSessionWorkspaceFilesChangedCount(session: WorkspaceSessionRef | undefined): number | undefined {
 	const queryClient = useQueryClient();
+	const ref = session ? workspaceSessionRef(session) : undefined;
+	const sessionHost = ref?.host;
+	const sessionId = ref?.id;
 	const query = useQuery({
-		...sessionWorkspaceFilesQueryOptions(sessionId ?? ""),
-		enabled: Boolean(sessionId),
+		...sessionWorkspaceFilesQueryOptions(ref ?? emptySessionRef),
+		enabled: Boolean(ref),
 		// Live invalidations keep the inactive tab fresh; polling starts only
 		// when the full Files view is visible.
 		refetchInterval: false,
 		select: (data: WorkspaceFilesResponse) => data.files.filter(isChangedWorkspaceFile).length,
 	});
 	useEffect(() => {
-		if (!sessionId) return;
-		return subscribeWorkspaceFileChanges(sessionId, queryClient);
-	}, [queryClient, sessionId]);
-	return sessionId ? query.data : undefined;
+		if (!sessionHost || !sessionId) return;
+		return subscribeWorkspaceFileChanges({ host: sessionHost, id: sessionId }, queryClient);
+	}, [queryClient, sessionHost, sessionId]);
+	return ref ? query.data : undefined;
 }

--- a/frontend/src/renderer/hooks/useSessionWorkspaceTree.ts
+++ b/frontend/src/renderer/hooks/useSessionWorkspaceTree.ts
@@ -1,19 +1,26 @@
 import type { components } from "../../api/schema";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
-import { isChangedWorkspaceFile, type WorkspaceFileSummary } from "./useSessionWorkspaceFiles";
+import { apiErrorMessage } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
+import { refKey, type Ref } from "../lib/hosts";
+import {
+	isChangedWorkspaceFile,
+	workspaceSessionRef,
+	type WorkspaceFileSummary,
+	type WorkspaceSessionRef,
+} from "./useSessionWorkspaceFiles";
 
 export type WorkspaceTreeEntry = components["schemas"]["WorkspaceTreeEntry"];
 export type WorkspaceTreeResponse = components["schemas"]["ListWorkspaceTreeResponse"];
 
-export const sessionWorkspaceTreeQueryKey = (sessionId: string, dir: string) =>
-	["session-workspace-tree", sessionId, dir] as const;
+export const sessionWorkspaceTreeQueryKey = (session: WorkspaceSessionRef, dir: string) =>
+	["session-workspace-tree", refKey(workspaceSessionRef(session)), dir] as const;
 
-async function fetchSessionWorkspaceTree(sessionId: string, dir: string, errorMessage: string): Promise<WorkspaceTreeResponse> {
-	const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/tree", {
-		params: { path: { sessionId }, query: dir ? { path: dir } : {} },
+async function fetchSessionWorkspaceTree(session: Ref, dir: string, errorMessage: string): Promise<WorkspaceTreeResponse> {
+	const { data, error } = await clientFor(session.host).GET("/api/v1/sessions/{sessionId}/workspace/tree", {
+		params: { path: { sessionId: session.id }, query: dir ? { path: dir } : {} },
 	});
 	if (error) throw new Error(apiErrorMessage(error, errorMessage));
-	return (data ?? { sessionId, path: dir, entries: [], truncated: false }) as WorkspaceTreeResponse;
+	return (data ?? { sessionId: session.id, path: dir, entries: [], truncated: false }) as WorkspaceTreeResponse;
 }
 
 // dir is a directory path relative to the workspace root, "" for the root.
@@ -21,10 +28,15 @@ async function fetchSessionWorkspaceTree(sessionId: string, dir: string, errorMe
 // coarse "something changed" signal (see workspace-file-events.ts), which
 // invalidates every mounted directory query by key prefix — a directory the
 // user isn't currently looking at just stays stale until they revisit it.
-export function sessionWorkspaceTreeQueryOptions(sessionId: string, dir: string, errorMessage = "Unable to load workspace tree") {
+export function sessionWorkspaceTreeQueryOptions(
+	session: WorkspaceSessionRef,
+	dir: string,
+	errorMessage = "Unable to load workspace tree",
+) {
+	const ref = workspaceSessionRef(session);
 	return {
-		queryKey: sessionWorkspaceTreeQueryKey(sessionId, dir),
-		queryFn: () => fetchSessionWorkspaceTree(sessionId, dir, errorMessage),
+		queryKey: sessionWorkspaceTreeQueryKey(ref, dir),
+		queryFn: () => fetchSessionWorkspaceTree(ref, dir, errorMessage),
 	};
 }
 

--- a/frontend/src/renderer/hooks/useShellTerminals.test.tsx
+++ b/frontend/src/renderer/hooks/useShellTerminals.test.tsx
@@ -16,10 +16,15 @@ const { deleteMock, postMock, isWindowsMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/api-client", () => ({
-	apiClient: { DELETE: deleteMock, PATCH: patchMock, POST: postMock },
 	apiErrorCode: (error: unknown) =>
 		typeof error === "object" && error !== null && "code" in error ? (error as { code?: string }).code : undefined,
-	hasTrustedApiBaseUrl: () => true,
+}));
+
+vi.mock("../lib/host-clients", () => ({
+	clientFor: () => ({ DELETE: deleteMock, PATCH: patchMock, POST: postMock }),
+	connectedHosts: () => [],
+	isHostReady: () => true,
+	subscribeConnectedHosts: () => () => {},
 }));
 
 vi.mock("../lib/platform", () => ({ isWindowsPlatform: isWindowsMock }));
@@ -41,16 +46,20 @@ const shells: ShellTerminal[] = [
 	{
 		createdAt: "2026-08-27T00:00:00Z",
 		handleId: "ptyhost-v1:shellterm-one",
+		host: "local",
 		title: "one",
 		workingDir: "/tmp",
 	},
 	{
 		createdAt: "2026-08-27T00:01:00Z",
 		handleId: "ptyhost-v1:shellterm-two",
+		host: "local",
 		title: "two",
 		workingDir: "/tmp",
 	},
 ];
+const localShellsQueryKey = shellTerminalsQueryKey("local");
+const shellRef = (shell: ShellTerminal) => ({ host: shell.host, id: shell.handleId });
 
 function wrapper(queryClient: QueryClient) {
 	return function Wrapper({ children }: { children: ReactNode }) {
@@ -62,7 +71,7 @@ function queryClientWithShells() {
 	const queryClient = new QueryClient({
 		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
 	});
-	queryClient.setQueryData(shellTerminalsQueryKey, shells);
+	queryClient.setQueryData(localShellsQueryKey, shells);
 	return queryClient;
 }
 
@@ -92,12 +101,12 @@ describe("useOpenShellTerminal", () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
 		});
-		queryClient.setQueryData(shellTerminalsQueryKey, []);
+		queryClient.setQueryData(localShellsQueryKey, []);
 		const { result } = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
 
 		await act(async () => result.current.mutateAsync({}));
 
-		expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([shell]);
+		expect(queryClient.getQueryData(localShellsQueryKey)).toEqual([shell]);
 	});
 
 	it("sends the saved Windows shell preference to the daemon", async () => {
@@ -161,10 +170,10 @@ describe("useRenameShellTerminal", () => {
 		const queryClient = queryClientWithShells();
 		const { result } = renderHook(() => useRenameShellTerminal(), { wrapper: wrapper(queryClient) });
 
-		act(() => result.current.mutate({ handleId: shells[0].handleId, title: "server — zsh" }));
+		act(() => result.current.mutate({ terminal: shellRef(shells[0]), title: "server — zsh" }));
 
 		await waitFor(() =>
-			expect(queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey)?.[0]?.title).toBe("server — zsh"),
+			expect(queryClient.getQueryData<ShellTerminal[]>(localShellsQueryKey)?.[0]?.title).toBe("server — zsh"),
 		);
 		act(() => finishRename({ data: { shellTerminal: { ...shells[0], title: "server — zsh" } } }));
 		await waitFor(() => expect(result.current.isPending).toBe(false));
@@ -184,9 +193,9 @@ describe("useCloseShellTerminal", () => {
 		);
 		const { result } = renderHook(() => useCloseShellTerminal(), { wrapper: wrapper(queryClient) });
 
-		act(() => result.current.mutate(shells[0].handleId));
+		act(() => result.current.mutate(shellRef(shells[0])));
 
-		await waitFor(() => expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([shells[1]]));
+		await waitFor(() => expect(queryClient.getQueryData(localShellsQueryKey)).toEqual([shells[1]]));
 		expect(deleteMock).not.toHaveBeenCalled();
 		expect(result.current.isPending).toBe(true);
 
@@ -202,11 +211,11 @@ describe("useCloseShellTerminal", () => {
 		const queryClient = queryClientWithShells();
 		const { result } = renderHook(() => useCloseShellTerminal(), { wrapper: wrapper(queryClient) });
 
-		act(() => result.current.mutate(shells[0].handleId));
-		await waitFor(() => expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([shells[1]]));
+		act(() => result.current.mutate(shellRef(shells[0])));
+		await waitFor(() => expect(queryClient.getQueryData(localShellsQueryKey)).toEqual([shells[1]]));
 
 		act(() => finishDelete({ error: { code: "SHELL_TERMINAL_CLOSE_FAILED" } }));
-		await waitFor(() => expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual(shells));
+		await waitFor(() => expect(queryClient.getQueryData(localShellsQueryKey)).toEqual(shells));
 	});
 
 	it("does not restore a stale tab when the daemon reports that its PTY is already gone", async () => {
@@ -214,9 +223,9 @@ describe("useCloseShellTerminal", () => {
 		const queryClient = queryClientWithShells();
 		const { result } = renderHook(() => useCloseShellTerminal(), { wrapper: wrapper(queryClient) });
 
-		await expect(result.current.mutateAsync(shells[0].handleId)).rejects.toEqual({
+		await expect(result.current.mutateAsync(shellRef(shells[0]))).rejects.toEqual({
 			code: "SHELL_TERMINAL_NOT_FOUND",
 		});
-		expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([shells[1]]);
+		expect(queryClient.getQueryData(localShellsQueryKey)).toEqual([shells[1]]);
 	});
 });

--- a/frontend/src/renderer/hooks/useShellTerminals.test.tsx
+++ b/frontend/src/renderer/hooks/useShellTerminals.test.tsx
@@ -116,7 +116,7 @@ describe("useOpenShellTerminal", () => {
 		const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
 		const { result } = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
 
-		await act(async () => result.current.mutateAsync({ projectId: "project-1" }));
+		await act(async () => result.current.mutateAsync({ project: { host: "local", id: "project-1" } }));
 
 		expect(shellStoreMock.load).toHaveBeenCalledOnce();
 		expect(postMock).toHaveBeenCalledWith("/api/v1/shell-terminals", {

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -3,14 +3,18 @@
 // the workspaces query — they are not sessions, never appear on the board, and
 // must not invalidate session state when they come and go.
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSyncExternalStore } from "react";
 import type { components } from "../../api/schema";
-import { apiClient, apiErrorCode, hasTrustedApiBaseUrl } from "../lib/api-client";
+import { apiErrorCode } from "../lib/api-client";
+import { clientFor, connectedHosts, isHostReady, subscribeConnectedHosts } from "../lib/host-clients";
+import { LOCAL_HOST, refKey, type HostId, type Ref } from "../lib/hosts";
 import { mockShellTerminals } from "../lib/mock-data";
 import { isWindowsPlatform } from "../lib/platform";
 import { terminalShellRequestValue, useTerminalShellStore } from "../stores/terminal-shell-store";
 
 export type ShellTerminal = {
+	host: HostId;
 	/** Runtime handle the terminal mux attaches to, exactly like a session pane's. */
 	handleId: string;
 	projectId?: string;
@@ -27,7 +31,7 @@ export type ShellTerminal = {
 	optimistic?: true;
 };
 
-export const shellTerminalsQueryKey = ["shell-terminals"] as const;
+export const shellTerminalsQueryKey = (host: HostId) => ["shell-terminals", host] as const;
 const usePreviewData = import.meta.env.VITE_NO_ELECTRON === "1";
 
 function isLegacyDirectoryTitle(title: string, workingDir: string): boolean {
@@ -35,9 +39,10 @@ function isLegacyDirectoryTitle(title: string, workingDir: string): boolean {
 	return parts.at(-1) === title;
 }
 
-function toShellTerminal(t: components["schemas"]["ShellTerminalResponse"]): ShellTerminal {
+function toShellTerminal(host: HostId, t: components["schemas"]["ShellTerminalResponse"]): ShellTerminal {
 	const title = isLegacyDirectoryTitle(t.title, t.workingDir) ? "Terminal" : t.title;
 	return {
+		host,
 		handleId: t.handleId,
 		projectId: t.projectId,
 		sessionId: t.sessionId,
@@ -53,37 +58,49 @@ function toShellTerminal(t: components["schemas"]["ShellTerminalResponse"]): She
 // open/close mutate this array instead — keeping the tab strip fully
 // interactive (open, select, close) without a backend, which is what the e2e
 // suite drives.
-let previewShellTerminals: ShellTerminal[] = [...mockShellTerminals];
+let previewShellTerminals: ShellTerminal[] = mockShellTerminals.map((shell) => ({ ...shell, host: LOCAL_HOST }));
 let previewShellSeq = 0;
 
-async function fetchShellTerminals(): Promise<ShellTerminal[]> {
+async function fetchShellTerminals(host: HostId): Promise<ShellTerminal[]> {
 	if (usePreviewData) {
-		return previewShellTerminals;
+		return previewShellTerminals.filter((shell) => shell.host === host);
 	}
-	if (!hasTrustedApiBaseUrl()) {
+	if (!isHostReady(host)) {
 		return [];
 	}
-	const { data, error } = await apiClient.GET("/api/v1/shell-terminals");
+	const { data, error } = await clientFor(host).GET("/api/v1/shell-terminals");
 	if (error) throw error;
-	return (data?.shellTerminals ?? []).map(toShellTerminal);
+	return (data?.shellTerminals ?? []).map((shell) => toShellTerminal(host, shell));
 }
 
 // No refetchInterval: shell terminals only change when this client opens or
 // closes one, and both mutations invalidate the query. Polling would spend a
 // liveness probe per shell per interval for no new information.
-export const shellTerminalsQueryOptions = {
-	queryKey: shellTerminalsQueryKey,
-	queryFn: fetchShellTerminals,
+export const shellTerminalsQueryOptions = (host: HostId) => ({
+	queryKey: shellTerminalsQueryKey(host),
+	queryFn: () => fetchShellTerminals(host),
 	retry: 1,
-};
+});
 
-export function useShellTerminals() {
-	return useQuery(shellTerminalsQueryOptions);
+export function useShellTerminals(host: HostId = LOCAL_HOST) {
+	return useQuery(shellTerminalsQueryOptions(host));
 }
 
-export type OpenShellTerminalInput = { projectId?: string; sessionId?: string; shell?: string };
+export function useConnectedShellTerminals(): ShellTerminal[] {
+	const remotes = useSyncExternalStore(subscribeConnectedHosts, connectedHosts, connectedHosts);
+	return useQueries({
+		queries: [LOCAL_HOST, ...remotes].map(shellTerminalsQueryOptions),
+		combine: (results) => results.flatMap((result) => result.data ?? []),
+	});
+}
+
+export type OpenShellTerminalInput = { project?: Ref; session?: Ref; shell?: string };
 type OpenShellTerminalMutationInput = OpenShellTerminalInput & { optimisticShell?: ShellTerminal };
 type OpenShellTerminalCallbacks = { onSuccess?: (shell: ShellTerminal) => void };
+
+function shellTerminalHost(input: OpenShellTerminalInput): HostId {
+	return input.session?.host ?? input.project?.host ?? LOCAL_HOST;
+}
 
 function nextShellTerminalTitle(terminals: ShellTerminal[]): string {
 	let maxNumber = 0;
@@ -98,15 +115,13 @@ function nextShellTerminalTitle(terminals: ShellTerminal[]): string {
 	return `Terminal ${maxNumber + 1}`;
 }
 
-function createOptimisticShellTerminal(
-	{ projectId, sessionId }: OpenShellTerminalInput,
-	terminals: ShellTerminal[],
-): ShellTerminal {
+function createOptimisticShellTerminal(input: OpenShellTerminalInput, host: HostId, terminals: ShellTerminal[]): ShellTerminal {
 	const id = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	return {
+		host,
 		handleId: `pending-shell:${id}`,
-		projectId,
-		sessionId,
+		projectId: input.project?.id,
+		sessionId: input.session?.id,
 		workingDir: "",
 		title: nextShellTerminalTitle(terminals),
 		createdAt: new Date().toISOString(),
@@ -115,7 +130,8 @@ function createOptimisticShellTerminal(
 }
 
 function addOptimisticShell(queryClient: ReturnType<typeof useQueryClient>, shell: ShellTerminal) {
-	queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+	const queryKey = shellTerminalsQueryKey(shell.host);
+	queryClient.setQueryData<ShellTerminal[]>(queryKey, (current) =>
 		current?.some((candidate) => candidate.handleId === shell.handleId) ? current : [...(current ?? []), shell],
 	);
 }
@@ -128,10 +144,15 @@ function addOptimisticShell(queryClient: ReturnType<typeof useQueryClient>, shel
 export function useOpenShellTerminal() {
 	const queryClient = useQueryClient();
 	const mutation = useMutation({
-		mutationFn: async ({ projectId, sessionId, shell, optimisticShell }: OpenShellTerminalMutationInput = {}): Promise<ShellTerminal> => {
+		mutationFn: async ({ project, session, shell, optimisticShell }: OpenShellTerminalMutationInput = {}): Promise<ShellTerminal> => {
+			if (project && session && project.host !== session.host) throw new Error("shell target hosts do not match");
+			const host = session?.host ?? project?.host ?? LOCAL_HOST;
+			const projectId = project?.id;
+			const sessionId = session?.id;
 			if (usePreviewData) {
 				previewShellSeq += 1;
 				const shell: ShellTerminal = {
+					host,
 					handleId: `shellterm-preview-${previewShellSeq}`,
 					projectId,
 					sessionId,
@@ -142,39 +163,42 @@ export function useOpenShellTerminal() {
 				previewShellTerminals = [...previewShellTerminals, shell];
 				return shell;
 			}
-			const body: OpenShellTerminalInput = {};
+			const body: { projectId?: string; sessionId?: string; shell?: string } = {};
 			if (projectId) body.projectId = projectId;
 			if (sessionId) body.sessionId = sessionId;
 			if (isWindowsPlatform()) {
 				await useTerminalShellStore.getState().load();
 				body.shell = shell ?? terminalShellRequestValue(useTerminalShellStore.getState().preference);
 			}
-			const { data, error } = await apiClient.POST("/api/v1/shell-terminals", { body });
+			const { data, error } = await clientFor(host).POST("/api/v1/shell-terminals", { body });
 			if (error) throw error;
 			if (!data) throw new Error("Daemon returned no shell terminal");
-			return toShellTerminal(data.shellTerminal);
+			return toShellTerminal(host, data.shellTerminal);
 		},
 		onMutate: (input) => {
+			const host = shellTerminalHost(input);
 			const optimisticShell =
 				input.optimisticShell ??
-				createOptimisticShellTerminal(input, queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? []);
+				createOptimisticShellTerminal(input, host, queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey(host)) ?? []);
 			addOptimisticShell(queryClient, optimisticShell);
 			return { optimisticHandleId: optimisticShell.handleId };
 		},
 		onSuccess: (shell, _input, context) => {
 			// Replace, rather than append to, the tab that was visible while the POST
 			// ran. This preserves selection and prevents a duplicate tab flash.
-			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) => {
+			const queryKey = shellTerminalsQueryKey(shell.host);
+			queryClient.setQueryData<ShellTerminal[]>(queryKey, (current) => {
 				if (current?.some((candidate) => candidate.handleId === shell.handleId)) return current;
 				const optimisticHandleId = context?.optimisticHandleId;
 				const index = current?.findIndex((candidate) => candidate.handleId === optimisticHandleId) ?? -1;
 				if (index < 0) return [...(current ?? []), shell];
 				return current?.map((candidate, candidateIndex) => (candidateIndex === index ? shell : candidate)) ?? [shell];
 			});
-			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+			void queryClient.invalidateQueries({ queryKey });
 		},
-		onError: (error, _input, context) => {
-			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+		onError: (error, input, context) => {
+			const queryKey = shellTerminalsQueryKey(shellTerminalHost(input));
+			queryClient.setQueryData<ShellTerminal[]>(queryKey, (current) =>
 				current?.filter((shell) => shell.handleId !== context?.optimisticHandleId),
 			);
 			console.error("Failed to open shell terminal:", error);
@@ -182,8 +206,8 @@ export function useOpenShellTerminal() {
 				void useTerminalShellStore.getState().setPreference({ kind: "auto" });
 			}
 		},
-		onSettled: () => {
-			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		onSettled: (_data, _error, input) => {
+			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey(shellTerminalHost(input)) });
 		},
 	});
 
@@ -191,9 +215,11 @@ export function useOpenShellTerminal() {
 	// it in the same click event. Other callers can keep using mutation.mutate;
 	// onMutate supplies an optimistic entry for them too.
 	const open = (input: OpenShellTerminalInput = {}, callbacks?: OpenShellTerminalCallbacks) => {
+		const host = shellTerminalHost(input);
 		const optimisticShell = createOptimisticShellTerminal(
 			input,
-			queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? [],
+			host,
+			queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey(host)) ?? [],
 		);
 		addOptimisticShell(queryClient, optimisticShell);
 		mutation.mutate({ ...input, optimisticShell }, callbacks);
@@ -207,85 +233,85 @@ export function useOpenShellTerminal() {
 export function useCloseShellTerminal() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: async (handleId: string): Promise<void> => {
+		mutationFn: async (terminal: Ref): Promise<void> => {
 			if (usePreviewData) {
-				previewShellTerminals = previewShellTerminals.filter((s) => s.handleId !== handleId);
+				previewShellTerminals = previewShellTerminals.filter((s) => refKey({ host: s.host, id: s.handleId }) !== refKey(terminal));
 				return;
 			}
-			const { error } = await apiClient.DELETE("/api/v1/shell-terminals/{handleId}", {
-				params: { path: { handleId } },
+			const { error } = await clientFor(terminal.host).DELETE("/api/v1/shell-terminals/{handleId}", {
+				params: { path: { handleId: terminal.id } },
 			});
 			if (error) throw error;
 		},
-		onMutate: async (handleId) => {
-			const previous = queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey);
+		onMutate: async (terminal) => {
+			const queryKey = shellTerminalsQueryKey(terminal.host);
+			const previous = queryClient.getQueryData<ShellTerminal[]>(queryKey);
 			const removeClosedShell = () => {
-				queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
-					current?.filter((shell) => shell.handleId !== handleId),
+				queryClient.setQueryData<ShellTerminal[]>(queryKey, (current) =>
+					current?.filter((shell) => shell.handleId !== terminal.id),
 				);
 			};
-			// Remove the pill synchronously. Waiting for cancellation first leaves the
-			// closed tab visible for the duration of an in-flight list request.
 			removeClosedShell();
-			await queryClient.cancelQueries({ queryKey: shellTerminalsQueryKey });
-			// A request that resolved while cancellation was being scheduled may have
-			// restored its stale snapshot; make the optimistic state authoritative.
+			await queryClient.cancelQueries({ queryKey });
 			removeClosedShell();
 			return { previous };
 		},
-		onError: (error, _handleId, context) => {
-			// A 404 means the daemon has already removed the shell, so restoring its
-			// stale tab would be misleading. Other failures put the tab back so the
-			// user can retry instead of losing access to a still-live PTY.
+		onError: (error, terminal, context) => {
 			if (apiErrorCode(error) !== "SHELL_TERMINAL_NOT_FOUND" && context?.previous) {
-				queryClient.setQueryData(shellTerminalsQueryKey, context.previous);
+				queryClient.setQueryData(shellTerminalsQueryKey(terminal.host), context.previous);
 			}
 		},
 		// Settled, not success: a close that 404s means the daemon already lost
 		// the shell, and the stale tab still needs to disappear.
-		onSettled: () => {
-			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		onSettled: (_data, _error, terminal) => {
+			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey(terminal.host) });
 		},
 	});
 }
 
-export type RenameShellTerminalInput = { handleId: string; title: string };
+export type RenameShellTerminalInput = { terminal: Ref; title: string };
 
 /** Renames a shell terminal's tab. The new title persists on the daemon. */
 export function useRenameShellTerminal() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: async ({ handleId, title }: RenameShellTerminalInput): Promise<ShellTerminal> => {
+		mutationFn: async ({ terminal, title }: RenameShellTerminalInput): Promise<ShellTerminal> => {
 			if (usePreviewData) {
-				previewShellTerminals = previewShellTerminals.map((s) => (s.handleId === handleId ? { ...s, title } : s));
-				const shell = previewShellTerminals.find((s) => s.handleId === handleId);
+				previewShellTerminals = previewShellTerminals.map((s) =>
+					refKey({ host: s.host, id: s.handleId }) === refKey(terminal) ? { ...s, title } : s,
+				);
+				const shell = previewShellTerminals.find((s) => refKey({ host: s.host, id: s.handleId }) === refKey(terminal));
 				if (!shell) throw new Error("No such shell terminal");
 				return shell;
 			}
-			const { data, error } = await apiClient.PATCH("/api/v1/shell-terminals/{handleId}", {
-				params: { path: { handleId } },
+			const { data, error } = await clientFor(terminal.host).PATCH("/api/v1/shell-terminals/{handleId}", {
+				params: { path: { handleId: terminal.id } },
 				body: { title },
 			});
 			if (error) throw error;
 			if (!data) throw new Error("Daemon returned no shell terminal");
-			return toShellTerminal(data.shellTerminal);
+			return toShellTerminal(terminal.host, data.shellTerminal);
 		},
-		onMutate: async ({ handleId, title }) => {
-			await queryClient.cancelQueries({ queryKey: shellTerminalsQueryKey });
-			const previous = queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey);
-			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
-				current?.map((shell) => (shell.handleId === handleId ? { ...shell, title } : shell)),
+		onMutate: async ({ terminal, title }) => {
+			const queryKey = shellTerminalsQueryKey(terminal.host);
+			await queryClient.cancelQueries({ queryKey });
+			const previous = queryClient.getQueryData<ShellTerminal[]>(queryKey);
+			queryClient.setQueryData<ShellTerminal[]>(queryKey, (current) =>
+				current?.map((shell) => (shell.handleId === terminal.id ? { ...shell, title } : shell)),
 			);
 			return { previous };
 		},
-		onError: (_error, _input, context) => {
-			if (context?.previous) queryClient.setQueryData(shellTerminalsQueryKey, context.previous);
+		onError: (_error, { terminal }, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(shellTerminalsQueryKey(terminal.host), context.previous);
+			}
 		},
 		onSuccess: (shell) => {
-			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+			const queryKey = shellTerminalsQueryKey(shell.host);
+			queryClient.setQueryData<ShellTerminal[]>(queryKey, (current) =>
 				current?.map((candidate) => (candidate.handleId === shell.handleId ? shell : candidate)),
 			);
-			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+			void queryClient.invalidateQueries({ queryKey });
 		},
 	});
 }

--- a/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
+++ b/frontend/src/renderer/hooks/useSwitchAgent.test.tsx
@@ -26,6 +26,7 @@ const session = {
 	updatedAt: "2026-06-10T00:00:00Z",
 	workspaceId: "proj-1",
 	workspaceName: "my-app",
+	host: "local",
 } satisfies WorkspaceSession;
 
 function wrapper(queryClient: QueryClient) {

--- a/frontend/src/renderer/hooks/useSwitchAgent.ts
+++ b/frontend/src/renderer/hooks/useSwitchAgent.ts
@@ -1,6 +1,7 @@
 import { type QueryClient, useMutation, useMutationState, useQueryClient } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
+import type { Ref } from "../lib/hosts";
 import type { WorkspaceSession } from "../types/workspace";
 import { agentSwitchesQueryKey, type AgentSwitch } from "./useAgentSwitches";
 import {
@@ -112,7 +113,7 @@ export function useSwitchAgent() {
 		onSuccess: (agentSwitch, variables) => {
 			if (!agentSwitch) return;
 			queryClient.setQueryData<AgentSwitch[]>(
-				agentSwitchesQueryKey(variables.session.id),
+				agentSwitchesQueryKey(variables.session),
 				(current = []) => [agentSwitch, ...current.filter((entry) => entry.id !== agentSwitch.id)],
 			);
 			void queryClient.invalidateQueries({ queryKey: conversationQueryKey(variables.session.id) });
@@ -123,7 +124,7 @@ export function useSwitchAgent() {
 		},
 		onSettled: (_data, _error, variables) => {
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			void queryClient.invalidateQueries({ queryKey: agentSwitchesQueryKey(variables.session.id) });
+			void queryClient.invalidateQueries({ queryKey: agentSwitchesQueryKey(variables.session) });
 		},
 	});
 }
@@ -132,10 +133,10 @@ export function useRecoverAgentSwitch() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationKey: recoverAgentSwitchMutationKey,
-		mutationFn: async ({ sessionId, switchId }: { sessionId: string; switchId: string }) => {
+		mutationFn: async ({ session, switchId }: { session: Ref; switchId: string }) => {
 			const { data, error, response } = await apiClient.POST(
 				"/api/v1/sessions/{sessionId}/agent-switches/{switchId}/recover",
-				{ params: { path: { sessionId, switchId } } },
+				{ params: { path: { sessionId: session.id, switchId } } },
 			);
 			if (error || response.status !== 202 || !data?.switch) {
 				const fallback = response
@@ -147,13 +148,13 @@ export function useRecoverAgentSwitch() {
 		},
 		onSuccess: (agentSwitch, variables) => {
 			queryClient.setQueryData<AgentSwitch[]>(
-				agentSwitchesQueryKey(variables.sessionId),
+				agentSwitchesQueryKey(variables.session),
 				(current = []) => [agentSwitch, ...current.filter((entry) => entry.id !== agentSwitch.id)],
 			);
 		},
 		onSettled: (_data, _error, variables) => {
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			void queryClient.invalidateQueries({ queryKey: agentSwitchesQueryKey(variables.sessionId) });
+			void queryClient.invalidateQueries({ queryKey: agentSwitchesQueryKey(variables.session) });
 		},
 	});
 }

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -8,6 +8,7 @@ import { useTerminalSession, type AttachableTerminal } from "./useTerminalSessio
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 const session: WorkspaceSession = {
+	host: "local",
 	id: "sess-1",
 	terminalHandleId: "handle-1",
 	workspaceId: "ws-1",

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -14,9 +14,9 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { getApiBaseUrl } from "../lib/api-client";
+import { LOCAL_HOST, type HostId } from "../lib/hosts";
 import { captureRendererEvent } from "../lib/telemetry";
-import { createTerminalMux, muxUrlFromApiBase, type TerminalMux } from "../lib/terminal-mux";
+import { createTerminalMux, muxUrlForHost, type TerminalMux } from "../lib/terminal-mux";
 import { sessionIsActive, type WorkspaceSession } from "../types/workspace";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
@@ -71,8 +71,8 @@ export type UseTerminalSessionOptions = {
 	 * recovery continue, but hidden panes cannot send user input or PTY resizes.
 	 */
 	isVisible?: boolean;
-	/** Test seam: build the mux client. Defaults to a fresh socket against the current API base. */
-	createMux?: () => TerminalMux;
+	/** Test seam: build the mux client. Defaults to a fresh socket against the session's host. */
+	createMux?: (host: HostId) => TerminalMux;
 	/**
 	 * Attach to a standalone shell terminal (POST /api/v1/shell-terminals)
 	 * instead of a session's pane. When set it wins over `session`, which
@@ -148,9 +148,9 @@ const REPLAY_WRITE_BATCH_BYTES = 256 * 1024;
 // QUIET_MS would uncover panes that were about to draw.
 const REPLAY_FIRST_BYTE_MS = 250;
 
-function defaultCreateMux(): TerminalMux {
+function defaultCreateMux(host: HostId): TerminalMux {
 	// Resolved per connect, not per hook: a daemon restart can change the port.
-	return createTerminalMux(muxUrlFromApiBase(getApiBaseUrl()));
+	return createTerminalMux(muxUrlForHost(host));
 }
 
 export function useTerminalSession(session: WorkspaceSession | undefined, options: UseTerminalSessionOptions) {
@@ -355,7 +355,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		r.inputReady = false;
 		teardownMux();
 
-		const mux = (optionsRef.current.createMux ?? defaultCreateMux)();
+		const mux = (optionsRef.current.createMux ?? defaultCreateMux)(sessionRef.current?.host ?? LOCAL_HOST);
 		r.mux = mux;
 
 		let pendingReplayWrites = 0;

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
+import { LOCAL_HOST } from "../lib/hosts";
 
 const { captureRendererEventMock, cloudState, getMock, hasTrustedApiBaseUrlMock, listProjectsMock } = vi.hoisted(
 	() => ({
@@ -404,6 +405,7 @@ describe("useWorkspaceQuery", () => {
 
 		expect(result.current.data?.[0]).toMatchObject({ id: "proj-1", name: "my-app", path: "/p" });
 		expect(result.current.data?.[1]).toEqual({
+			host: LOCAL_HOST,
 			id: "cp-1",
 			name: "cloud-app",
 			kind: "cloud",

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -1,39 +1,60 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import createClient from "openapi-fetch";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
-import { LOCAL_HOST } from "../lib/hosts";
+import type { paths } from "../../api/schema";
+import { fakeDaemon, type Behaviour } from "../test/fake-daemon";
 
-const { captureRendererEventMock, cloudState, getMock, hasTrustedApiBaseUrlMock, listProjectsMock } = vi.hoisted(
-	() => ({
-		captureRendererEventMock: vi.fn().mockResolvedValue(undefined),
-		cloudState: { ready: false, org: undefined as { id: string } | undefined },
-		getMock: vi.fn(),
-		hasTrustedApiBaseUrlMock: vi.fn(() => true),
-		listProjectsMock: vi.fn(),
-	}),
-);
+const {
+	captureRendererEventMock,
+	cloudState,
+	connectedHostsMock,
+	getMock,
+	hostListeners,
+	isHostReadyMock,
+	listProjectsMock,
+	listSessionsMock,
+} = vi.hoisted(() => ({
+	captureRendererEventMock: vi.fn().mockResolvedValue(undefined),
+	cloudState: { ready: false, org: undefined as { id: string } | undefined },
+	connectedHostsMock: vi.fn((): string[] => []),
+	getMock: vi.fn(),
+	hostListeners: new Set<() => void>(),
+	isHostReadyMock: vi.fn(() => true),
+	listProjectsMock: vi.fn(),
+	listSessionsMock: vi.fn(),
+}));
 
 vi.mock("../lib/api-client", () => ({
-	apiClient: { GET: getMock },
-	hasTrustedApiBaseUrl: hasTrustedApiBaseUrlMock,
+	apiErrorMessage: (error: unknown, fallback: string) => (error instanceof Error ? error.message : fallback),
+}));
+
+vi.mock("../lib/host-clients", () => ({
+	clientFor: (host: string) => ({ GET: (url: string) => getMock(host, url) }),
+	connectedHosts: connectedHostsMock,
+	hostLabelFor: (host: string) => host === "http://192.0.2.1:3011" ? "workbox" : host,
+	isHostReady: isHostReadyMock,
+	subscribeConnectedHosts: (listener: () => void) => {
+		hostListeners.add(listener);
+		return () => hostListeners.delete(listener);
+	},
 }));
 
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: captureRendererEventMock }));
-
 vi.mock("./useCloudCp", () => ({
 	useCloudCp: () => ({
-		client: { listProjects: listProjectsMock },
+		client: { listProjects: listProjectsMock, listSessions: listSessionsMock },
 		ready: cloudState.ready,
 		baseUrl: "https://cp.example.com",
 	}),
 }));
-
 vi.mock("./useCloudOrg", () => ({
 	useCloudOrg: () => ({ org: cloudState.org, isLoading: false, error: undefined, ready: cloudState.ready }),
 }));
 
 import { useWorkspaceQuery, useWorkspaceTraySessions } from "./useWorkspaceQuery";
+import { LOCAL_HOST, refKey, type HostId } from "../lib/hosts";
 
 function wrapper({ children }: { children: ReactNode }) {
 	// The hook pins its own retry policy; retryDelay 0 keeps the error tests fast.
@@ -41,11 +62,15 @@ function wrapper({ children }: { children: ReactNode }) {
 	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }
 
+function renderWorkspaceQuery() {
+	return renderHook(() => useWorkspaceQuery(), { wrapper });
+}
+
 function respondWith(payload: {
 	projects?: { data?: unknown; error?: unknown };
 	sessions?: { data?: unknown; error?: unknown };
 }) {
-	getMock.mockImplementation(async (url: string) => {
+	getMock.mockImplementation(async (_host: HostId, url: string) => {
 		if (url === "/api/v1/projects") return payload.projects ?? { data: { projects: [] }, error: undefined };
 		if (url === "/api/v1/sessions") return payload.sessions ?? { data: { sessions: [] }, error: undefined };
 		throw new Error(`unexpected GET ${url}`);
@@ -55,20 +80,93 @@ function respondWith(payload: {
 beforeEach(() => {
 	captureRendererEventMock.mockClear();
 	getMock.mockReset();
-	hasTrustedApiBaseUrlMock.mockReset().mockReturnValue(true);
+	connectedHostsMock.mockReset().mockReturnValue([]);
+	hostListeners.clear();
+	isHostReadyMock.mockReset().mockReturnValue(true);
 	cloudState.ready = false;
 	cloudState.org = undefined;
 	listProjectsMock.mockReset();
+	listSessionsMock.mockReset();
 });
 
+type HostFixture = {
+	host: HostId;
+	projects?: Array<{ id: string; name: string; path?: string }>;
+	sessions?: Array<{ id: string; projectId: string }>;
+	fail?: string;
+	body?: unknown;
+};
+
+async function fetchAllForTest(fixtures: HostFixture[]) {
+	connectedHostsMock.mockReturnValue(fixtures.map(({ host }) => host).filter((host) => host !== LOCAL_HOST));
+	getMock.mockImplementation(async (host: HostId, url: string) => {
+		const fixture = fixtures.find((candidate) => candidate.host === host);
+		if (!fixture) throw new Error(`unexpected host ${host}`);
+		if (fixture.fail) throw new Error(fixture.fail);
+		if (fixture.body !== undefined) return { data: fixture.body, error: undefined };
+		if (url === "/api/v1/projects") {
+			return {
+				data: {
+					projects: (fixture.projects ?? []).map((project) => ({ path: `/${project.id}`, ...project })),
+				},
+				error: undefined,
+			};
+		}
+		if (url === "/api/v1/sessions") {
+			return {
+				data: {
+					sessions: (fixture.sessions ?? []).map((session) => ({
+						isTerminated: false,
+						updatedAt: "2026-08-11T00:00:00Z",
+						...session,
+					})),
+				},
+				error: undefined,
+			};
+		}
+		throw new Error(`unexpected GET ${url}`);
+	});
+
+	const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
+	await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	return result.current.data ?? [];
+}
+
 describe("useWorkspaceQuery", () => {
-	it("rejects workspace reads while the daemon base URL is untrusted", async () => {
-		hasTrustedApiBaseUrlMock.mockReturnValue(false);
+	it.each<Behaviour>(["html-catchall", "wrong-shape"])(
+		"reports %s workspace responses as malformed instead of throwing",
+		async (behaviour) => {
+			const client = createClient<paths>({ baseUrl: "http://x", fetch: fakeDaemon(behaviour) });
+			getMock.mockImplementation((_host: HostId, url: "/api/v1/projects" | "/api/v1/sessions") =>
+				client.GET(url),
+			);
+
+			let rendered: ReturnType<typeof renderWorkspaceQuery> | undefined;
+			expect(() => {
+				rendered = renderWorkspaceQuery();
+			}).not.toThrow();
+			if (!rendered) throw new Error("workspace query did not render");
+			const { result } = rendered;
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true));
+			expect(result.current.data?.[0]).toMatchObject({
+				status: "failed",
+				failure: "Host returned malformed workspace data",
+			});
+		},
+	);
+
+	it("reports the local host as failed while the daemon client is not ready", async () => {
+		isHostReadyMock.mockReturnValue(false);
 
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 
-		await waitFor(() => expect(result.current.isError).toBe(true));
-		expect(result.current.error).toEqual(new Error("AO daemon API is not ready"));
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.[0]).toMatchObject({
+			host: LOCAL_HOST,
+			status: "failed",
+			workspaces: [],
+		});
 		expect(getMock).not.toHaveBeenCalled();
 	});
 
@@ -147,7 +245,9 @@ describe("useWorkspaceQuery", () => {
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		const [workspace] = result.current.data ?? [];
+		const workspace = result.current.data?.[0].workspaces[0];
+		expect(workspace).toBeDefined();
+		if (!workspace) throw new Error("workspace missing");
 		expect(workspace).toMatchObject({
 			id: "proj-1",
 			name: "my-app",
@@ -235,11 +335,11 @@ describe("useWorkspaceQuery", () => {
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(result.current.data?.[0]).toMatchObject({
+		expect(result.current.data?.[0].workspaces[0]).toMatchObject({
 			id: "scratch",
 			kind: "scratch",
 		});
-		expect(result.current.data?.[0].sessions[0]).toMatchObject({
+		expect(result.current.data?.[0].workspaces[0].sessions[0]).toMatchObject({
 			id: "scratch-worker-1",
 			branch: undefined,
 		});
@@ -286,7 +386,7 @@ describe("useWorkspaceQuery", () => {
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		const sessions = result.current.data?.[0].sessions ?? [];
+		const sessions = result.current.data?.[0].workspaces[0].sessions ?? [];
 		expect(sessions[0].prs).toEqual([
 			{
 				number: 278,
@@ -325,8 +425,8 @@ describe("useWorkspaceQuery", () => {
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(result.current.data?.[0].sessions[0].status).toBe("merged");
-		expect(result.current.data?.[0].sessions[0].isTerminated).toBe(true);
+		expect(result.current.data?.[0].workspaces[0].sessions[0].status).toBe("merged");
+		expect(result.current.data?.[0].workspaces[0].sessions[0].isTerminated).toBe(true);
 	});
 
 	it("falls back to terminated for terminated sessions without a known backend status", async () => {
@@ -351,21 +451,22 @@ describe("useWorkspaceQuery", () => {
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(result.current.data?.[0].sessions[0].status).toBe("terminated");
-		expect(result.current.data?.[0].sessions[0].isTerminated).toBe(true);
+		expect(result.current.data?.[0].workspaces[0].sessions[0].status).toBe("terminated");
+		expect(result.current.data?.[0].workspaces[0].sessions[0].isTerminated).toBe(true);
 	});
 
-	it("surfaces a projects fetch error", async () => {
+	it("reports a projects fetch error on the local host", async () => {
 		const failure = new TypeError("Failed to fetch");
 		respondWith({ projects: { data: undefined, error: failure } });
 
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 
-		await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 3_000 });
-		expect(result.current.error).toBe(failure);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.[0]).toMatchObject({ status: "failed", failure: "Failed to fetch" });
+		expect(result.current.localFailure).toBe("Failed to fetch");
 	});
 
-	it("surfaces a sessions fetch error even when projects load", async () => {
+	it("reports a sessions fetch error on the local host even when projects load", async () => {
 		const failure = new Error("sessions backend down");
 		respondWith({
 			projects: { data: { projects: [{ id: "proj-1", name: "my-app", path: "/p" }] }, error: undefined },
@@ -374,73 +475,203 @@ describe("useWorkspaceQuery", () => {
 
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 
-		await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 3_000 });
-		expect(result.current.error).toBe(failure);
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.[0]).toMatchObject({ status: "failed", failure: "sessions backend down" });
 	});
 
-	it("merges control-plane projects after local ones with kind cloud", async () => {
+	// Every client here is a plain openapi-fetch client, so none of these
+	// failures reach api-client's ao.renderer.api_error. Before this the data
+	// just stopped loading, with nothing anywhere saying so.
+	it("reports a failed host fetch with the status that explains it", async () => {
+		getMock.mockImplementation(async (_host: HostId, url: string) =>
+			url === "/api/v1/projects"
+				? { data: undefined, error: { message: "unauthorized" }, response: new Response(null, { status: 401 }) }
+				: { data: { sessions: [] }, error: undefined, response: new Response(null, { status: 200 }) },
+		);
+
+		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		expect(captureRendererEventMock).toHaveBeenCalledWith(
+			"ao.renderer.host_query_failed",
+			expect.objectContaining({ host_kind: "local", status: 401 }),
+		);
+	});
+
+	it("adds control-plane projects after local projects in the local host section", async () => {
 		cloudState.ready = true;
 		cloudState.org = { id: "org-1" };
 		listProjectsMock.mockResolvedValue({
-			items: [
-				{
-					id: "cp-1",
-					orgId: "org-1",
-					displayName: "cloud-app",
-					repositoryUrl: "https://github.com/acme/cloud-app",
-					defaultBranch: "main",
-					config: {},
-					createdAt: "2026-08-01T00:00:00Z",
-					updatedAt: "2026-08-01T00:00:00Z",
-				},
-			],
+			items: [{
+				id: "cp-1",
+				orgId: "org-1",
+				displayName: "cloud-app",
+				repositoryUrl: "https://github.com/acme/cloud-app",
+				defaultBranch: "main",
+				config: {},
+				createdAt: "2026-08-01T00:00:00Z",
+				updatedAt: "2026-08-01T00:00:00Z",
+			}],
 			page: { hasMore: false },
 		});
+		listSessionsMock.mockResolvedValue({ items: [], page: { hasMore: false } });
 		respondWith({
 			projects: { data: { projects: [{ id: "proj-1", name: "my-app", path: "/p" }] }, error: undefined },
 		});
 
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
-		await waitFor(() => expect(result.current.data).toHaveLength(2));
+		await waitFor(() => expect(result.current.data?.[0]?.workspaces).toHaveLength(2));
 
-		expect(result.current.data?.[0]).toMatchObject({ id: "proj-1", name: "my-app", path: "/p" });
-		expect(result.current.data?.[1]).toEqual({
-			host: LOCAL_HOST,
-			id: "cp-1",
-			name: "cloud-app",
-			kind: "cloud",
-			path: "",
-			sessions: [],
-		});
+		expect(result.current.data?.[0]?.workspaces.map((workspace) => workspace.id)).toEqual(["proj-1", "cp-1"]);
+		expect(result.current.data?.[0]?.workspaces[1]).toMatchObject({ host: LOCAL_HOST, kind: "cloud" });
 		expect(listProjectsMock).toHaveBeenCalledWith("org-1", { limit: 100 });
 	});
+});
 
-	it("keeps local projects when the cloud fetch fails", async () => {
-		cloudState.ready = true;
-		cloudState.org = { id: "org-1" };
-		listProjectsMock.mockRejectedValue(new Error("control plane down"));
-		respondWith({
-			projects: { data: { projects: [{ id: "proj-1", name: "my-app", path: "/p" }] }, error: undefined },
-		});
+describe("useWorkspaceQuery — multi-host", () => {
+	const REMOTE = "http://192.0.2.1:3011";
 
-		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
-		await waitFor(() => expect(result.current.isSuccess).toBe(true));
-		await waitFor(() => expect(listProjectsMock).toHaveBeenCalled());
-
-		expect(result.current.data).toHaveLength(1);
-		expect(result.current.data?.[0]).toMatchObject({ id: "proj-1" });
-		expect(result.current.isError).toBe(false);
+	it("tags every workspace and session with its host", async () => {
+		const sections = await fetchAllForTest([
+			{
+				host: LOCAL_HOST,
+				projects: [{ id: "skyvern-cloud", name: "skyvern-cloud" }],
+				sessions: [{ id: "s1", projectId: "skyvern-cloud" }],
+			},
+			{
+				host: REMOTE,
+				projects: [{ id: "skyvern-cloud", name: "skyvern-cloud" }],
+				sessions: [{ id: "s1", projectId: "skyvern-cloud" }],
+			},
+		]);
+		const hosts = sections.flatMap((section) => section.workspaces.map((workspace) => workspace.host));
+		expect(hosts).toEqual([LOCAL_HOST, REMOTE]);
+		expect(refKey({ host: LOCAL_HOST, id: "skyvern-cloud" })).not.toBe(
+			refKey({ host: REMOTE, id: "skyvern-cloud" }),
+		);
+		expect(sections[0].workspaces[0].sessions[0].host).toBe(LOCAL_HOST);
+		expect(sections[1].label).toBe("workbox");
 	});
 
-	it("does not call the control plane while cloud is not ready", async () => {
-		respondWith({
-			projects: { data: { projects: [{ id: "proj-1", name: "my-app", path: "/p" }] }, error: undefined },
+	it("one host failing does not discard another host's data", async () => {
+		const sections = await fetchAllForTest([
+			{ host: LOCAL_HOST, projects: [{ id: "p", name: "p" }], sessions: [] },
+			{ host: REMOTE, fail: "connect ECONNREFUSED" },
+		]);
+		expect(sections.find((section) => section.host === LOCAL_HOST)?.status).toBe("ready");
+		expect(sections.find((section) => section.host === LOCAL_HOST)?.workspaces).toHaveLength(1);
+		const failed = sections.find((section) => section.host === REMOTE);
+		expect(failed?.status).toBe("failed");
+		expect(failed?.workspaces).toEqual([]);
+		expect(failed?.failure).toMatch(/ECONNREFUSED/);
+	});
+
+	it("keeps the local board painted while a newly connected host is pending", async () => {
+		getMock.mockImplementation(async (host: HostId, url: string) => {
+			if (host === REMOTE) return new Promise(() => undefined);
+			if (url === "/api/v1/projects") {
+				return { data: { projects: [{ id: "local-project", name: "local-project", path: "/local" }] } };
+			}
+			if (url === "/api/v1/sessions") return { data: { sessions: [] } };
+			throw new Error(`unexpected GET ${url}`);
+		});
+		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
+		await waitFor(() => expect(result.current.data?.[0]?.host).toBe(LOCAL_HOST));
+
+		connectedHostsMock.mockReturnValue([REMOTE]);
+		act(() => {
+			for (const listener of hostListeners) listener();
 		});
 
-		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
+		expect(result.current.isSuccess).toBe(true);
+		expect(result.current.isLoading).toBe(false);
+		expect(result.current.data?.map((section) => section.host)).toEqual([LOCAL_HOST]);
+	});
+
+	it("refetches only the host targeted by a host-scoped invalidation", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } });
+		const fetchCounts = new Map<HostId, number>();
+		connectedHostsMock.mockReturnValue([REMOTE]);
+		getMock.mockImplementation(async (host: HostId, url: string) => {
+			if (url === "/api/v1/projects") {
+				const count = (fetchCounts.get(host) ?? 0) + 1;
+				fetchCounts.set(host, count);
+				return { data: { projects: [{ id: host, name: `${host}-${count}`, path: `/${host}` }] } };
+			}
+			if (url === "/api/v1/sessions") return { data: { sessions: [] } };
+			throw new Error(`unexpected GET ${url}`);
+		});
+		const queryWrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper: queryWrapper });
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(listProjectsMock).not.toHaveBeenCalled();
+		await act(async () => {
+			await queryClient.invalidateQueries({ queryKey: ["workspaces", REMOTE] });
+		});
+
+		await waitFor(() =>
+			expect(result.current.data?.find((section) => section.host === REMOTE)?.workspaces[0].name).toBe(
+				`${REMOTE}-2`,
+			),
+		);
+		expect(fetchCounts.get(REMOTE)).toBe(2);
+		expect(fetchCounts.get(LOCAL_HOST)).toBe(1);
+	});
+
+	it("retains last-good host data when an invalidated host refetch fails", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } });
+		let remoteFails = false;
+		connectedHostsMock.mockReturnValue([REMOTE]);
+		getMock.mockImplementation(async (host: HostId, url: string) => {
+			if (host === REMOTE && remoteFails) throw new Error("remote daemon dropped");
+			if (url === "/api/v1/projects") {
+				return { data: { projects: [{ id: host, name: host, path: `/${host}` }] } };
+			}
+			if (url === "/api/v1/sessions") return { data: { sessions: [] } };
+			throw new Error(`unexpected GET ${url}`);
+		});
+		const queryWrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper: queryWrapper });
+		await waitFor(() => expect(result.current.data).toHaveLength(2));
+
+		remoteFails = true;
+		await act(async () => {
+			await queryClient.invalidateQueries({ queryKey: ["workspaces", REMOTE] });
+		});
+		await waitFor(() =>
+			expect(result.current.data?.find((section) => section.host === REMOTE)?.status).toBe("failed"),
+		);
+
+		const remote = result.current.data?.find((section) => section.host === REMOTE);
+		expect(remote).toMatchObject({ status: "failed", failure: "remote daemon dropped" });
+		expect(remote?.workspaces.map((workspace) => workspace.id)).toEqual([REMOTE]);
+		expect(result.current.data?.find((section) => section.host === LOCAL_HOST)?.workspaces).toHaveLength(1);
+	});
+
+	it("a host returning a malformed body fails that host, it does not throw", async () => {
+		const sections = await fetchAllForTest([
+			{ host: LOCAL_HOST, projects: [], sessions: [] },
+			{ host: REMOTE, body: "<!doctype html><html></html>" },
+		]);
+		expect(sections.find((section) => section.host === REMOTE)?.status).toBe("failed");
+		expect(sections.find((section) => section.host === LOCAL_HOST)?.status).toBe("ready");
+	});
+
+	it("joins sessions to projects within a host, never across hosts", async () => {
+		const sections = await fetchAllForTest([
+			{ host: LOCAL_HOST, projects: [{ id: "shared", name: "shared" }], sessions: [] },
+			{
+				host: REMOTE,
+				projects: [{ id: "shared", name: "shared" }],
+				sessions: [{ id: "r1", projectId: "shared" }],
+			},
+		]);
+		expect(sections.find((section) => section.host === LOCAL_HOST)?.workspaces[0].sessions).toEqual([]);
+		expect(sections.find((section) => section.host === REMOTE)?.workspaces[0].sessions).toHaveLength(1);
 	});
 
 	it("selects only attention-worthy worker sessions for the always-mounted tray", async () => {

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { TraySessionEntry } from "../../shared/tray";
 import { useMemo } from "react";
-import { LOCAL_HOST } from "../lib/hosts";
+import { LOCAL_HOST, type Ref } from "../lib/hosts";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import type { CloudCpProject, CloudCpSession } from "../lib/cloud-cp";
@@ -296,11 +296,15 @@ export function useWorkspaceQuery(options: WorkspaceSubscriptionOptions = {}) {
  * tree. TanStack Query applies structural sharing to the selected value, so an
  * activity update elsewhere no longer redraws the open session workspace.
  */
-export function useWorkspaceSession(sessionId: string) {
+export function useWorkspaceSession(session: Ref) {
 	const selectLocalSession = useMemo(
 		() => (workspaces: WorkspaceSummary[]) =>
-			workspaces.flatMap((workspace) => workspace.sessions).find((session) => session.id === sessionId),
-		[sessionId],
+			// Session ids are unique per host, not across them: matching on id
+			// alone would resolve another host's same-id session here.
+			workspaces
+				.flatMap((workspace) => workspace.sessions)
+				.find((candidate) => candidate.host === session.host && candidate.id === session.id),
+		[session.host, session.id],
 	);
 	const local = useQuery({ ...workspaceQueryOptions, select: selectLocalSession });
 	const cloud = useCloudProjectsQuery();
@@ -308,11 +312,13 @@ export function useWorkspaceSession(sessionId: string) {
 	const { org, ready } = useCloudOrg();
 	const cloudSession = useMemo(() => {
 		if (!ready || !org?.id || !cloud.data || !cloudSessions.data) return undefined;
-		const session = cloudSessions.data.find((candidate) => candidate.id === sessionId);
-		if (!session) return undefined;
-		const project = cloud.data.find((candidate) => candidate.id === session.projectId);
-		return project ? toCloudWorkspaceSession(session, project, org.id) : undefined;
-	}, [cloud.data, cloudSessions.data, org?.id, ready, sessionId]);
+		// Cloud sessions always carry LOCAL_HOST (see toCloudWorkspaceSession), so
+		// a bare-id match is safe here regardless of the requested session's host.
+		const found = cloudSessions.data.find((candidate) => candidate.id === session.id);
+		if (!found) return undefined;
+		const project = cloud.data.find((candidate) => candidate.id === found.projectId);
+		return project ? toCloudWorkspaceSession(found, project, org.id) : undefined;
+	}, [cloud.data, cloudSessions.data, org?.id, ready, session.id]);
 	return { ...local, data: local.data ?? cloudSession };
 }
 

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { TraySessionEntry } from "../../shared/tray";
 import { useMemo } from "react";
+import { LOCAL_HOST } from "../lib/hosts";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import type { CloudCpProject, CloudCpSession } from "../lib/cloud-cp";
@@ -90,6 +91,7 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 	return (projectsData?.projects ?? []).map((project) => {
 		const kind = toProjectKind(project.kind);
 		return {
+			host: LOCAL_HOST,
 			id: project.id,
 			name: project.name,
 			kind,
@@ -107,6 +109,7 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 						reportUnknownSessionField("activity", session.activity?.state);
 					}
 					return {
+						host: LOCAL_HOST,
 						id: session.id,
 						terminalHandleId: session.terminalHandleId,
 						workspaceId: project.id,
@@ -180,6 +183,7 @@ function toCloudWorkspaceSession(
 	orgId: string,
 ): WorkspaceSession {
 	return {
+		host: LOCAL_HOST,
 		id: session.id,
 		// The terminal pane only mounts for a session that has a terminal handle.
 		// A cloud session's PTY is addressed by the session id over its ticketed
@@ -209,6 +213,7 @@ function toCloudWorkspace(
 	orgId: string,
 ): WorkspaceSummary {
 	return {
+		host: LOCAL_HOST,
 		id: project.id,
 		name: project.displayName,
 		kind: "cloud",

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { TraySessionEntry } from "../../shared/tray";
 import { useMemo } from "react";
-import { LOCAL_HOST, type Ref } from "../lib/hosts";
+import { LOCAL_HOST, type HostId, type Ref } from "../lib/hosts";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
 import type { CloudCpProject, CloudCpSession } from "../lib/cloud-cp";
@@ -330,14 +330,21 @@ export type WorkspaceScope = {
 
 function selectWorkspaceScope(
 	workspaces: WorkspaceSummary[],
+	host: HostId,
 	projectId: string | undefined,
 	sessionId: string | undefined,
 ): WorkspaceScope {
+	// Session and project ids are unique per host, not across them: matching on
+	// id alone would resolve another host's same-id record for this scope.
 	const session = sessionId
-		? workspaces.flatMap((workspace) => workspace.sessions).find((candidate) => candidate.id === sessionId)
+		? workspaces
+				.flatMap((workspace) => workspace.sessions)
+				.find((candidate) => candidate.host === host && candidate.id === sessionId)
 		: undefined;
 	const resolvedProjectId = session?.workspaceId ?? projectId;
-	const workspace = resolvedProjectId ? workspaces.find((candidate) => candidate.id === resolvedProjectId) : undefined;
+	const workspace = resolvedProjectId
+		? workspaces.find((candidate) => candidate.host === host && candidate.id === resolvedProjectId)
+		: undefined;
 	// Do not carry the project's complete sessions array into shell chrome. With
 	// React Query's structural sharing, this small metadata projection retains
 	// its identity when another session in the same project streams an update.
@@ -356,10 +363,10 @@ function selectWorkspaceScope(
  * Subscribe shell chrome to just the routed project and session. This avoids
  * redrawing the topbar for streamed activity from every other project.
  */
-export function useWorkspaceScope(projectId?: string, sessionId?: string) {
+export function useWorkspaceScope(host: HostId, projectId?: string, sessionId?: string) {
 	const selectLocalScope = useMemo(
-		() => (workspaces: WorkspaceSummary[]) => selectWorkspaceScope(workspaces, projectId, sessionId),
-		[projectId, sessionId],
+		() => (workspaces: WorkspaceSummary[]) => selectWorkspaceScope(workspaces, host, projectId, sessionId),
+		[host, projectId, sessionId],
 	);
 	const local = useQuery({ ...workspaceQueryOptions, select: selectLocalScope });
 	const cloud = useCloudProjectsQuery();
@@ -368,8 +375,8 @@ export function useWorkspaceScope(projectId?: string, sessionId?: string) {
 	const cloudScope = useMemo(() => {
 		if (!ready || !org?.id || !cloud.data) return undefined;
 		const workspaces = cloud.data.map((project) => toCloudWorkspace(project, cloudSessions.data ?? [], org.id));
-		return selectWorkspaceScope(workspaces, projectId, sessionId);
-	}, [cloud.data, cloudSessions.data, org?.id, projectId, ready, sessionId]);
+		return selectWorkspaceScope(workspaces, host, projectId, sessionId);
+	}, [cloud.data, cloudSessions.data, host, org?.id, projectId, ready, sessionId]);
 	// Match useWorkspaceQuery's local-first semantics: do not reveal cloud
 	// records before the local workspace query has resolved successfully.
 	return { ...local, data: local.data ?? (local.isSuccess ? cloudScope : undefined) };

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -1,20 +1,25 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery, type QueryFunctionContext, type UseQueryResult } from "@tanstack/react-query";
 import type { TraySessionEntry } from "../../shared/tray";
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import { LOCAL_HOST, type HostId, type Ref } from "../lib/hosts";
 import type { components } from "../../api/schema";
-import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
+import { apiErrorMessage } from "../lib/api-client";
 import type { CloudCpProject, CloudCpSession } from "../lib/cloud-cp";
-import { useCloudCp } from "./useCloudCp";
-import { useCloudOrg } from "./useCloudOrg";
+import { clientFor, connectedHosts, hostLabelFor, isHostReady, subscribeConnectedHosts } from "../lib/host-clients";
+import { hostConnectionState } from "../lib/host-events";
+import { reportHostQueryFailed } from "../lib/host-telemetry";
 import { mockWorkspaces } from "../lib/mock-data";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
+import { parseResponseArray } from "../lib/response-validation";
 import { toReviewerHarnessId } from "../lib/reviewer-harnesses";
 import { captureRendererEvent } from "../lib/telemetry";
+import { useCloudCp } from "./useCloudCp";
+import { useCloudOrg } from "./useCloudOrg";
 import {
 	type AgentSwitchSummary,
 	type PRState,
 	type PullRequestFacts,
+	type HostSection,
 	toAgentProvider,
 	toKanbanColumn,
 	toProjectKind,
@@ -22,10 +27,13 @@ import {
 	toSessionStatus,
 	newestActiveOrchestrator,
 	attentionZone,
+	flattenHostSections,
 	workerSessions,
-	type WorkspaceSession,
 	type WorkspaceSummary,
+	type WorkspaceSession,
 } from "../types/workspace";
+
+export type { HostSection } from "../types/workspace";
 
 function toAgentSwitchSummary(
 	agentSwitch: components["schemas"]["AgentSwitch"],
@@ -56,6 +64,10 @@ function toPullRequestFacts(pr: components["schemas"]["SessionPRFacts"]): PullRe
 export const workspaceQueryKey = ["workspaces"] as const;
 const reportedUnknownSessionFields = new Set<string>();
 
+export function workspaceHostQueryKey(host: HostId) {
+	return [...workspaceQueryKey, host] as const;
+}
+
 function reportUnknownSessionField(field: "status" | "activity", value?: string): void {
 	const reason = value ? "unrecognized" : "missing";
 	const key = `${field}:${reason}`;
@@ -71,33 +83,73 @@ function reportUnknownSessionField(field: "status" | "activity", value?: string)
 // and always hits the real daemon.
 type FakeAgentSeam = { snapshot: () => WorkspaceSummary[] };
 
-async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
-	if (usesPreviewWorkspaceData) {
+type ProjectSummaryDTO = components["schemas"]["ProjectSummary"];
+type SessionDTO = components["schemas"]["ControllersSessionView"];
+
+function isProject(value: unknown): value is ProjectSummaryDTO {
+	if (typeof value !== "object" || value === null) return false;
+	const project = value as Partial<ProjectSummaryDTO>;
+	return typeof project.id === "string" && typeof project.name === "string" && typeof project.path === "string";
+}
+
+function isSession(value: unknown): value is SessionDTO {
+	if (typeof value !== "object" || value === null) return false;
+	const session = value as Partial<SessionDTO>;
+	return typeof session.id === "string" && typeof session.projectId === "string";
+}
+
+function tagWorkspaces(host: HostId, workspaces: WorkspaceSummary[]): WorkspaceSummary[] {
+	return workspaces.map((workspace) => ({
+		...workspace,
+		host,
+		sessions: workspace.sessions.map((session) => ({ ...session, host })),
+	}));
+}
+
+async function fetchWorkspaces(host: HostId): Promise<WorkspaceSummary[]> {
+	if (usesPreviewWorkspaceData && host === LOCAL_HOST) {
 		const fake =
 			typeof window !== "undefined"
 				? (window as unknown as { __aoFakeAgent?: FakeAgentSeam }).__aoFakeAgent
 				: undefined;
-		return fake ? fake.snapshot() : mockWorkspaces;
+		return tagWorkspaces(host, fake ? fake.snapshot() : mockWorkspaces);
 	}
-	if (!hasTrustedApiBaseUrl()) {
-		throw new Error("AO daemon API is not ready");
+	if (!isHostReady(host)) throw new Error(`host ${host} is not connected`);
+
+	const client = clientFor(host);
+	const [
+		{ data: projectsData, error: projectsError, response: projectsResponse },
+		{ data: sessionsData, error: sessionsError, response: sessionsResponse },
+	] = await Promise.all([client.GET("/api/v1/projects"), client.GET("/api/v1/sessions")]).catch((error: unknown) => {
+		if (error instanceof SyntaxError) throw new Error("Host returned malformed workspace data");
+		throw error;
+	});
+
+	if (projectsError || sessionsError) {
+		// The status lives on the response and nowhere else, and it is what
+		// separates a rotated password (401) from a host the proxy cannot reach
+		// (502). Carried on the thrown error so the caller can report it; the
+		// message is precomputed from the daemon's envelope so what the user
+		// reads is unchanged.
+		const failed = projectsError ? projectsResponse : sessionsResponse;
+		throw Object.assign(new Error(apiErrorMessage(projectsError ?? sessionsError, "Could not load projects")), {
+			status: failed?.status,
+		});
 	}
+	const projects = parseResponseArray(projectsData, "projects", isProject);
+	const sessions = parseResponseArray(sessionsData, "sessions", isSession);
+	if (projects === null || sessions === null) throw new Error("Host returned malformed workspace data");
 
-	const [{ data: projectsData, error: projectsError }, { data: sessionsData, error: sessionsError }] =
-		await Promise.all([apiClient.GET("/api/v1/projects"), apiClient.GET("/api/v1/sessions")]);
-
-	if (projectsError || sessionsError) throw projectsError ?? sessionsError;
-
-	return (projectsData?.projects ?? []).map((project) => {
+	return projects.map((project) => {
 		const kind = toProjectKind(project.kind);
 		return {
-			host: LOCAL_HOST,
+			host,
 			id: project.id,
 			name: project.name,
 			kind,
 			path: project.path,
 			orchestratorAgent: project.orchestratorAgent ? toAgentProvider(project.orchestratorAgent) : undefined,
-			sessions: (sessionsData?.sessions ?? [])
+			sessions: sessions
 				.filter((session) => session.projectId === project.id)
 				.map((session) => {
 					const status = toSessionStatus(session.status, session.isTerminated);
@@ -109,7 +161,7 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 						reportUnknownSessionField("activity", session.activity?.state);
 					}
 					return {
-						host: LOCAL_HOST,
+						host,
 						id: session.id,
 						terminalHandleId: session.terminalHandleId,
 						workspaceId: project.id,
@@ -158,25 +210,77 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 	});
 }
 
-// Shared so route loaders can prefetch via queryClient.ensureQueryData (paired
-// with the router's defaultPreload: "intent") and the hook reads the same cache.
-export const workspaceQueryOptions = {
-	queryKey: workspaceQueryKey,
-	queryFn: fetchWorkspaces,
-	retry: 1,
-	refetchInterval: 15_000,
-};
+function errorStatus(error: unknown): number | undefined {
+	const status = (error as { status?: unknown } | null)?.status;
+	return typeof status === "number" ? status : undefined;
+}
 
-// Cloud projects are a separate query so a control-plane failure can never
-// break the local list: on error TanStack keeps this query's last known data,
-// and until the first successful fetch the merge below simply omits cloud
-// items. Invalidated by the cloud create flow (CreateProjectFlow).
+async function fetchHostSection(host: HostId, lastGoodWorkspaces: WorkspaceSummary[] = []): Promise<HostSection[]> {
+	const label = host === LOCAL_HOST ? "Local" : hostLabelFor(host);
+	try {
+		const workspaces = await fetchWorkspaces(host);
+		// Read after the fetch, not before: this is what the sidebar shows when it
+		// renders these workspaces, and a stream that dropped mid-fetch is exactly
+		// the case worth catching.
+		return [{ host, label, status: "ready", streamState: hostConnectionState(host), workspaces, failure: null }];
+	} catch (error) {
+		// Remote clients are plain openapi-fetch clients, so none of this reaches
+		// api-client's ao.renderer.api_error. Without this a remote host's data
+		// simply stopped loading, silently.
+		reportHostQueryFailed(host, errorStatus(error));
+		return [{
+			host,
+			label,
+			status: "failed",
+			streamState: hostConnectionState(host),
+			workspaces: lastGoodWorkspaces,
+			failure: apiErrorMessage(error, "Could not load projects"),
+		}];
+	}
+}
+
+function workspaceHostQueryOptions(host: HostId) {
+	const queryKey = workspaceHostQueryKey(host);
+	return {
+		queryKey,
+		queryFn: ({ client }: QueryFunctionContext<typeof queryKey>) =>
+			fetchHostSection(host, client.getQueryData<HostSection[]>(queryKey)?.[0]?.workspaces),
+		retry: 1,
+		refetchInterval: 15_000,
+	};
+}
+
+export function localWorkspaceFailure(sections: readonly HostSection[] | undefined): string | undefined {
+	const local = sections?.find((section) => section.host === LOCAL_HOST);
+	return local?.status === "failed" ? (local.failure ?? "Could not load projects") : undefined;
+}
+
+function combineWorkspaceQueries(results: UseQueryResult<HostSection[]>[]) {
+	const local = results[0];
+	const isSuccess = local?.isSuccess ?? false;
+	const data = isSuccess ? results.flatMap((result) => result.data ?? []) : undefined;
+	return {
+		data,
+		dataUpdatedAt: Math.max(0, ...results.map((result) => result.dataUpdatedAt)),
+		error: local?.error ?? null,
+		isError: local?.isError ?? false,
+		isLoading: local?.isLoading ?? true,
+		isSuccess,
+		localFailure: localWorkspaceFailure(data),
+		refetch: () => Promise.all(results.map((result) => result.refetch())),
+	};
+}
+
+// Shared so route loaders can prefetch the local host via
+// queryClient.ensureQueryData and the hook reads the same cache.
+export const workspaceQueryOptions = workspaceHostQueryOptions(LOCAL_HOST);
+
+// Cloud projects are separate from daemon hosts, but share the local section:
+// they cannot be queried through a remote daemon client and their sessions use
+// the control-plane terminal transport.
 export const cloudProjectsQueryKey = ["cloud-projects"] as const;
 export const cloudSessionsQueryKey = ["cloud-sessions"] as const;
 
-// Maps one control-plane session onto the board's session shape. Cloud sessions
-// carry the same status/activity/harness vocabulary as local ones, so the same
-// product-ui mappers apply; fields with no cloud analogue take safe defaults.
 function toCloudWorkspaceSession(
 	session: CloudCpSession,
 	project: CloudCpProject,
@@ -185,9 +289,6 @@ function toCloudWorkspaceSession(
 	return {
 		host: LOCAL_HOST,
 		id: session.id,
-		// The terminal pane only mounts for a session that has a terminal handle.
-		// A cloud session's PTY is addressed by the session id over its ticketed
-		// CP WebSocket, so the session id is its handle.
 		terminalHandleId: session.id,
 		workspaceId: project.id,
 		workspaceName: project.displayName,
@@ -201,8 +302,6 @@ function toCloudWorkspaceSession(
 		updatedAt: session.updatedAt,
 		activity: toSessionActivity({ state: session.activityState }),
 		prs: [],
-		// Marks this as a control-plane session so the terminal opens against the
-		// CP (ticket + sandbox WebSocket) instead of the local daemon mux.
 		cloud: { orgId },
 	};
 }
@@ -217,7 +316,6 @@ function toCloudWorkspace(
 		id: project.id,
 		name: project.displayName,
 		kind: "cloud",
-		// Cloud projects run in control-plane sandboxes; there is no local folder.
 		path: "",
 		sessions: sessions
 			.filter((session) => session.projectId === project.id)
@@ -240,8 +338,6 @@ export function useCloudProjectsQuery(options: WorkspaceSubscriptionOptions = {}
 		retry: 1,
 		queryFn: async (): Promise<CloudCpProject[]> => {
 			if (orgId === undefined) return [];
-			// First page only (control-plane max page size); pagination UI is a
-			// later phase alongside cloud sessions.
 			const response = await client.listProjects(orgId, { limit: 100 });
 			return response.items;
 		},
@@ -257,8 +353,6 @@ export function useCloudSessionsQuery(options: WorkspaceSubscriptionOptions = {}
 		enabled: ready && orgId !== undefined,
 		subscribed: options.subscribed,
 		retry: 1,
-		// A provisioning sandbox changes state without a client action, so poll to
-		// reflect requested -> running -> ready the same way local sessions stream.
 		refetchInterval: 5000,
 		queryFn: async (): Promise<CloudCpSession[]> => {
 			if (orgId === undefined) return [];
@@ -269,26 +363,33 @@ export function useCloudSessionsQuery(options: WorkspaceSubscriptionOptions = {}
 }
 
 export function useWorkspaceQuery(options: WorkspaceSubscriptionOptions = {}) {
-	const local = useQuery({ ...workspaceQueryOptions, subscribed: options.subscribed });
+	const remotes = useSyncExternalStore(subscribeConnectedHosts, connectedHosts, connectedHosts);
+	const hostQueries = useQueries({
+		queries: [LOCAL_HOST, ...remotes].map((host) => ({
+			...workspaceHostQueryOptions(host),
+			subscribed: options.subscribed,
+		})),
+		combine: combineWorkspaceQueries,
+	});
 	const cloud = useCloudProjectsQuery(options);
 	const cloudSessions = useCloudSessionsQuery(options);
 	const { org, ready } = useCloudOrg();
 	const orgId = org?.id;
-	const localData = local.data;
-	const cloudData = cloud.data;
-	const cloudSessionData = cloudSessions.data;
 	const data = useMemo(() => {
-		// Local stays authoritative for loading/error semantics: cloud items only
-		// render once the local list exists, and never replace it.
-		if (localData === undefined || cloudData === undefined || cloudData.length === 0) return localData;
-		// Signing out (or turning the offering off) disables the cloud queries,
-		// but react-query keeps their last data; without this gate the stale
-		// cloud projects would keep rendering for a signed-out user.
-		if (!ready || orgId === undefined) return localData;
-		const sessions = cloudSessionData ?? [];
-		return [...localData, ...cloudData.map((project) => toCloudWorkspace(project, sessions, orgId))];
-	}, [localData, cloudData, cloudSessionData, orgId, ready]);
-	return { ...local, data };
+		const sections = hostQueries.data;
+		const projects = cloud.data;
+		if (sections === undefined || projects === undefined || projects.length === 0 || !ready || orgId === undefined) {
+			return sections;
+		}
+		const sessions = cloudSessions.data ?? [];
+		const cloudWorkspaces = projects.map((project) => toCloudWorkspace(project, sessions, orgId));
+		return sections.map((section) =>
+			section.host === LOCAL_HOST
+				? { ...section, workspaces: [...section.workspaces, ...cloudWorkspaces] }
+				: section,
+		);
+	}, [cloud.data, cloudSessions.data, hostQueries.data, orgId, ready]);
+	return { ...hostQueries, data };
 }
 
 /**
@@ -298,10 +399,10 @@ export function useWorkspaceQuery(options: WorkspaceSubscriptionOptions = {}) {
  */
 export function useWorkspaceSession(session: Ref) {
 	const selectLocalSession = useMemo(
-		() => (workspaces: WorkspaceSummary[]) =>
+		() => (sections: HostSection[]) =>
 			// Session ids are unique per host, not across them: matching on id
 			// alone would resolve another host's same-id session here.
-			workspaces
+			flattenHostSections(sections)
 				.flatMap((workspace) => workspace.sessions)
 				.find((candidate) => candidate.host === session.host && candidate.id === session.id),
 		[session.host, session.id],
@@ -365,7 +466,7 @@ function selectWorkspaceScope(
  */
 export function useWorkspaceScope(host: HostId, projectId?: string, sessionId?: string) {
 	const selectLocalScope = useMemo(
-		() => (workspaces: WorkspaceSummary[]) => selectWorkspaceScope(workspaces, host, projectId, sessionId),
+		() => (sections: HostSection[]) => selectWorkspaceScope(flattenHostSections(sections), host, projectId, sessionId),
 		[host, projectId, sessionId],
 	);
 	const local = useQuery({ ...workspaceQueryOptions, select: selectLocalScope });
@@ -406,7 +507,10 @@ function selectTraySessions(workspaces: WorkspaceSummary[]): TraySessionEntry[] 
  * query boundary so ordinary streamed activity does not wake the runtime.
  */
 export function useWorkspaceTraySessions() {
-	const local = useQuery({ ...workspaceQueryOptions, select: selectTraySessions });
+	const local = useQuery({
+		...workspaceQueryOptions,
+		select: (sections: HostSection[]) => selectTraySessions(flattenHostSections(sections)),
+	});
 	const cloud = useCloudProjectsQuery();
 	const cloudSessions = useCloudSessionsQuery();
 	const { org, ready } = useCloudOrg();

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -637,6 +637,7 @@
 	"settings.close": "Einstellungen schließen",
 	"settings.connectMobile": "Mobile verbinden",
 	"settings.developerMode": "Entwicklermodus",
+	"settings.remoteHosts": "Remote-Hosts (experimentell)",
 	"settings.general": "Allgemein",
 	"settings.appearance": "Erscheinungsbild",
 	"settings.sessions": "Sitzungen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -629,6 +629,7 @@
 	"settings.cloudAgents.valid": "Valid",
 	"settings.connectMobile": "Connect Mobile",
 	"settings.developerMode": "Developer Mode",
+	"settings.remoteHosts": "Remote hosts (experimental)",
 	"settings.general": "General",
 	"settings.appearance": "Appearance",
 	"settings.sessions": "Sessions",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -646,6 +646,7 @@
 	"settings.close": "Cerrar ajustes",
 	"settings.connectMobile": "Conectar móvil",
 	"settings.developerMode": "Modo desarrollador",
+	"settings.remoteHosts": "Hosts remotos (experimental)",
 	"settings.general": "General",
 	"settings.appearance": "Apariencia",
 	"settings.sessions": "Sesiones",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -646,6 +646,7 @@
 	"settings.close": "Fermer les paramètres",
 	"settings.connectMobile": "Connecter le mobile",
 	"settings.developerMode": "Mode développeur",
+	"settings.remoteHosts": "Hôtes distants (expérimental)",
 	"settings.general": "Général",
 	"settings.appearance": "Apparence",
 	"settings.sessions": "Sessions",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -637,6 +637,7 @@
 	"settings.close": "設定を閉じる",
 	"settings.connectMobile": "モバイル接続",
 	"settings.developerMode": "開発者モード",
+	"settings.remoteHosts": "リモートホスト（実験的）",
 	"settings.general": "一般",
 	"settings.appearance": "外観",
 	"settings.sessions": "セッション",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -637,6 +637,7 @@
 	"settings.close": "설정 닫기",
 	"settings.connectMobile": "모바일 연결",
 	"settings.developerMode": "개발자 모드",
+	"settings.remoteHosts": "원격 호스트 (실험적)",
 	"settings.general": "일반",
 	"settings.appearance": "모양",
 	"settings.sessions": "세션",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -646,6 +646,7 @@
 	"settings.close": "Fechar configurações",
 	"settings.connectMobile": "Conectar mobile",
 	"settings.developerMode": "Modo desenvolvedor",
+	"settings.remoteHosts": "Hosts remotos (experimental)",
 	"settings.general": "Geral",
 	"settings.appearance": "Aparência",
 	"settings.sessions": "Sessões",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -619,6 +619,7 @@
 	"settings.close": "关闭设置",
 	"settings.connectMobile": "连接手机",
 	"settings.developerMode": "开发者模式",
+	"settings.remoteHosts": "远程主机（实验性）",
 	"settings.general": "通用",
 	"settings.appearance": "外观",
 	"settings.sessions": "会话",

--- a/frontend/src/renderer/lib/active-host.test.ts
+++ b/frontend/src/renderer/lib/active-host.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { aoBridge } from "./bridge";
+import { setApiBaseUrl } from "./api-client";
+import { initHosts } from "./active-host";
+import { baseUrlFor, forgetHost } from "./host-clients";
+import { useUiStore } from "../stores/ui-store";
+
+const WORKBOX = "http://192.0.2.1:3011";
+const MINI = "http://192.0.2.9:3011";
+
+beforeEach(() => {
+	localStorage.clear();
+	forgetHost(WORKBOX);
+	forgetHost(MINI);
+	setApiBaseUrl(null);
+	vi.restoreAllMocks();
+	useUiStore.setState({ remoteHosts: true });
+});
+
+function savedHosts() {
+	vi.spyOn(aoBridge.remotes, "list").mockResolvedValue([
+		{ label: "workbox", url: WORKBOX },
+		{ label: "mini", url: MINI },
+	]);
+	vi.spyOn(aoBridge.remotes, "connect").mockImplementation(async (url) => ({
+		label: url === WORKBOX ? "workbox" : "mini",
+		url,
+		base: url === WORKBOX ? "http://127.0.0.1:9001/one" : "http://127.0.0.1:9002/two",
+	}));
+}
+
+describe("remoteHosts flag", () => {
+	it("never reads the saved hosts while the flag is off", async () => {
+		useUiStore.setState({ remoteHosts: false });
+		savedHosts();
+
+		await initHosts();
+
+		expect(aoBridge.remotes.list).not.toHaveBeenCalled();
+		expect(aoBridge.remotes.connect).not.toHaveBeenCalled();
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+	});
+
+	it("connects the saved hosts when the flag is turned on", async () => {
+		useUiStore.setState({ remoteHosts: false });
+		savedHosts();
+		await initHosts();
+		expect(baseUrlFor(MINI)).toBeNull();
+
+		useUiStore.getState().setRemoteHosts(true);
+
+		await vi.waitFor(() => expect(baseUrlFor(MINI)).toBe("http://127.0.0.1:9002/two"));
+		expect(baseUrlFor(WORKBOX)).toBe("http://127.0.0.1:9001/one");
+	});
+
+	it("disconnects every remote host when the flag is turned off", async () => {
+		savedHosts();
+		const disconnect = vi.spyOn(aoBridge.remotes, "disconnect").mockResolvedValue(undefined);
+		await initHosts();
+		expect(baseUrlFor(WORKBOX)).not.toBeNull();
+
+		useUiStore.getState().setRemoteHosts(false);
+
+		await vi.waitFor(() => expect(disconnect).toHaveBeenCalledTimes(2));
+		expect(disconnect).toHaveBeenCalledWith(WORKBOX);
+		expect(disconnect).toHaveBeenCalledWith(MINI);
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+		expect(baseUrlFor(MINI)).toBeNull();
+	});
+});
+
+describe("multi-host boot", () => {
+	it("connects every saved host", async () => {
+		savedHosts();
+
+		await initHosts();
+
+		expect(aoBridge.remotes.connect).toHaveBeenCalledTimes(2);
+		expect(baseUrlFor(WORKBOX)).toBe("http://127.0.0.1:9001/one");
+		expect(baseUrlFor(MINI)).toBe("http://127.0.0.1:9002/two");
+	});
+
+	it("keeps connecting other saved hosts when one is unavailable", async () => {
+		vi.spyOn(aoBridge.remotes, "list").mockResolvedValue([
+			{ label: "workbox", url: WORKBOX },
+			{ label: "mini", url: MINI },
+		]);
+		vi.spyOn(aoBridge.remotes, "connect").mockImplementation(async (url) => {
+			if (url === WORKBOX) throw new Error("offline");
+			return { label: "mini", url, base: "http://127.0.0.1:9002/two" };
+		});
+
+		await initHosts();
+
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+		expect(baseUrlFor(MINI)).toBe("http://127.0.0.1:9002/two");
+	});
+
+	it("treats an unreadable saved-host list as no remote hosts", async () => {
+		vi.spyOn(aoBridge.remotes, "list").mockRejectedValue(new Error("chmod 600 required"));
+
+		await expect(initHosts()).resolves.toBeUndefined();
+		expect(baseUrlFor(WORKBOX)).toBeNull();
+		expect(baseUrlFor(MINI)).toBeNull();
+	});
+});

--- a/frontend/src/renderer/lib/active-host.ts
+++ b/frontend/src/renderer/lib/active-host.ts
@@ -1,0 +1,32 @@
+import { useUiStore } from "../stores/ui-store";
+import { aoBridge } from "./bridge";
+import { connectedHosts, connectHost, disconnectHost } from "./host-clients";
+
+/** Connect every saved host without making any one host own the window. */
+async function connectSavedHosts(): Promise<void> {
+	const saved = await aoBridge.remotes.list().catch(() => []);
+	await Promise.allSettled(saved.map(({ url }) => connectHost(url)));
+}
+
+async function disconnectAllHosts(): Promise<void> {
+	await Promise.allSettled(connectedHosts().map((host) => disconnectHost(host)));
+}
+
+let watchingFlag = false;
+
+/**
+ * Boot the remote-host layer, honouring the Remote hosts flag. Off means no
+ * saved host is read, probed or connected — not "connected but hidden" — so a
+ * reviewer can verify the off state from the network side. Flipping the switch
+ * connects or tears down without a restart.
+ */
+export async function initHosts(): Promise<void> {
+	if (!watchingFlag) {
+		watchingFlag = true;
+		useUiStore.subscribe((state, previous) => {
+			if (state.remoteHosts === previous.remoteHosts) return;
+			void (state.remoteHosts ? connectSavedHosts() : disconnectAllHosts());
+		});
+	}
+	if (useUiStore.getState().remoteHosts) await connectSavedHosts();
+}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -223,6 +223,17 @@ export const aoBridge: AoBridge =
 			list: async () => [],
 			getActive: async () => null,
 		},
+		// The daemon-served web build has no Electron bridge and so no access to
+		// ~/.ao/remotes.json. Reporting no hosts leaves the UI showing local only,
+		// which is the truth there.
+		remotes: {
+			list: async () => [],
+			add: async () => "offline" as const,
+			update: async () => "offline" as const,
+			remove: async () => undefined,
+			probe: async () => "offline" as const,
+			request: async () => ({ status: 0, body: null }),
+		},
 		cloud: {
 			getSession: async () => null,
 			signIn: async () => undefined,

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -233,6 +233,11 @@ export const aoBridge: AoBridge =
 			remove: async () => undefined,
 			probe: async () => "offline" as const,
 			request: async () => ({ status: 0, body: null }),
+			connect: async () => {
+				throw new Error("remote hosts need the desktop app");
+			},
+			disconnect: async () => undefined,
+			connected: async () => [],
 		},
 		cloud: {
 			getSession: async () => null,

--- a/frontend/src/renderer/lib/command-palette.test.ts
+++ b/frontend/src/renderer/lib/command-palette.test.ts
@@ -65,13 +65,69 @@ function workspaces(): WorkspaceSummary[] {
 
 const byId = (items: CommandItem[]) => new Map(items.map((item) => [item.id, item]));
 
+// A second host running the same project: ids repeat across hosts, so every
+// fixture here has a same-id twin on "remote" to catch host-blind lookups.
+function remoteTwin(): WorkspaceSummary {
+	return {
+		host: "remote",
+		id: "proj-1",
+		name: "app",
+		path: "/repos/app",
+		type: "main",
+		sessions: [
+			session({ id: "w-pr", host: "remote", title: "remote cache", branch: "feature/remote-cache", status: "pr_open", prs: [pr(7)] }),
+			session({ id: "w-action", host: "remote", title: "remote flake", branch: "feature/remote-flake", status: "needs_input" }),
+		],
+	};
+}
+
+function bothHosts(): WorkspaceSummary[] {
+	return [...workspaces(), remoteTwin()];
+}
+
 describe("findSession", () => {
 	it("returns the workspace and session together", () => {
-		const result = findSession(workspaces(), "w-pr");
+		const result = findSession(workspaces(), { host: "local", id: "w-pr" });
 
 		expect(result?.workspace.id).toBe("proj-1");
 		expect(result?.session.id).toBe("w-pr");
-		expect(findSession(workspaces(), "missing")).toBeUndefined();
+		expect(findSession(workspaces(), { host: "local", id: "missing" })).toBeUndefined();
+	});
+
+	// Session ids are unique per host, not across them. A bare-id lookup returns
+	// whichever host sorts first in the tree — the wrong machine's session.
+	it("resolves on the ref's host when two hosts share a session id", () => {
+		expect(findSession(bothHosts(), { host: "remote", id: "w-pr" })?.session.title).toBe("remote cache");
+		expect(findSession(bothHosts(), { host: "local", id: "w-pr" })?.session.title).toBe("add cache");
+		expect(findSession(bothHosts(), { host: "other", id: "w-pr" })).toBeUndefined();
+	});
+});
+
+describe("buildCommands across hosts", () => {
+	it("scopes the current session to the current host", () => {
+		const items = buildCommands({
+			workspaces: bothHosts(),
+			currentHostId: "remote",
+			currentProjectId: "proj-1",
+			currentSessionId: "w-pr",
+		});
+
+		expect(byId(items).get("current-copy-branch")?.subtitle).toBe("feature/remote-cache");
+	});
+
+	// Excluding "the current session" by bare id also hides the other host's
+	// same-id session, so a machine's session vanishes from the palette.
+	it("keeps the other host's same-id session listed", () => {
+		const items = buildCommands({
+			workspaces: bothHosts(),
+			currentHostId: "local",
+			currentProjectId: "proj-1",
+			currentSessionId: "w-pr",
+		});
+		const listed = items.filter((item) => item.group === "sessions" || item.group === "attention").map((item) => item.title);
+
+		expect(listed).toContain("remote cache");
+		expect(listed).not.toContain("add cache");
 	});
 });
 
@@ -85,7 +141,7 @@ describe("buildCommands grouping", () => {
 	});
 
 	it("puts current-scoped actions in the Current group when the project is valid", () => {
-		const items = buildCommands({ workspaces: workspaces(), currentProjectId: "proj-1", currentSessionId: "w-pr" });
+		const items = buildCommands({ workspaces: workspaces(), currentHostId: "local", currentProjectId: "proj-1", currentSessionId: "w-pr" });
 		const map = byId(items);
 		expect(map.get("current-new-task")?.group).toBe("current");
 		expect(map.get("current-open-orchestrator")?.group).toBe("current");
@@ -95,7 +151,7 @@ describe("buildCommands grouping", () => {
 	});
 
 	it("disables New task with a reason when the route project is absent from workspaces", () => {
-		const items = buildCommands({ workspaces: workspaces(), currentProjectId: "missing", currentSessionId: undefined });
+		const items = buildCommands({ workspaces: workspaces(), currentHostId: "local", currentProjectId: "missing", currentSessionId: undefined });
 		const newTask = byId(items).get("current-new-task");
 		expect(newTask?.disabled).toBe(true);
 		expect(newTask?.disabledReason).toBe("No current project");
@@ -119,16 +175,16 @@ describe("buildCommands grouping", () => {
 	});
 
 	it("omits Copy branch for a synthetic (session/<id>) branch and for orchestrators", () => {
-		const synthetic = buildCommands({ workspaces: workspaces(), currentSessionId: "w-synthetic" });
+		const synthetic = buildCommands({ workspaces: workspaces(), currentHostId: "local", currentSessionId: "w-synthetic" });
 		expect(byId(synthetic).has("current-copy-branch")).toBe(false);
-		const orch = buildCommands({ workspaces: workspaces(), currentSessionId: "orch" });
+		const orch = buildCommands({ workspaces: workspaces(), currentHostId: "local", currentSessionId: "orch" });
 		expect(byId(orch).has("current-copy-branch")).toBe(false);
 	});
 
 	it("recognises an orchestrator by its id suffix, not just its kind", () => {
 		const rows = workspaces();
 		rows[0].sessions.push(session({ id: "proj-1-orchestrator", title: "legacy orch", branch: "main" }));
-		const items = buildCommands({ workspaces: rows, currentSessionId: "proj-1-orchestrator" });
+		const items = buildCommands({ workspaces: rows, currentHostId: "local", currentSessionId: "proj-1-orchestrator" });
 		expect(byId(items).has("current-copy-branch")).toBe(false);
 	});
 });
@@ -145,7 +201,7 @@ describe("buildCommands attention", () => {
 	});
 
 	it("omits the current session from Needs attention (already in view)", () => {
-		const items = buildCommands({ workspaces: workspaces(), currentSessionId: "w-merge" });
+		const items = buildCommands({ workspaces: workspaces(), currentHostId: "local", currentSessionId: "w-merge" });
 		const ids = new Set(items.map((item) => item.id));
 		expect(ids.has("attention:w-merge")).toBe(false);
 		expect(ids.has("attention:w-action")).toBe(true);
@@ -154,7 +210,7 @@ describe("buildCommands attention", () => {
 
 describe("buildCommands sessions", () => {
 	it("does not repeat attention or current sessions in the flat Sessions list", () => {
-		const items = buildCommands({ workspaces: workspaces(), currentSessionId: "w-working" });
+		const items = buildCommands({ workspaces: workspaces(), currentHostId: "local", currentSessionId: "w-working" });
 		const ids = new Set(items.map((item) => item.id));
 		expect(ids.has("attention:w-merge")).toBe(true);
 		expect(ids.has("session:w-merge")).toBe(false);
@@ -372,7 +428,7 @@ describe("buildCommands PR actions", () => {
 	});
 
 	it("discovers Copy branch name via git and copy keywords", () => {
-		const items = buildCommands({ workspaces: workspaces(), currentProjectId: "proj-1", currentSessionId: "w-pr" });
+		const items = buildCommands({ workspaces: workspaces(), currentHostId: "local", currentProjectId: "proj-1", currentSessionId: "w-pr" });
 		const keywords = byId(items).get("current-copy-branch")?.keywords ?? [];
 		expect(keywords).toContain("copy");
 		expect(keywords).toContain("git");

--- a/frontend/src/renderer/lib/command-palette.test.ts
+++ b/frontend/src/renderer/lib/command-palette.test.ts
@@ -18,6 +18,7 @@ import { appI18n } from "../i18n";
 
 function session(overrides: Partial<WorkspaceSession> & { id: string }): WorkspaceSession {
 	return {
+		host: "local",
 		workspaceId: "proj-1",
 		workspaceName: "app",
 		title: overrides.id,
@@ -45,6 +46,7 @@ const pr = (number: number, url = `https://github.com/o/r/pull/${number}`): Pull
 function workspaces(): WorkspaceSummary[] {
 	return [
 		{
+			host: "local",
 			id: "proj-1",
 			name: "app",
 			path: "/repos/app",
@@ -182,6 +184,7 @@ describe("buildCommands pull requests", () => {
 		const closed: PullRequestFacts = { ...pr(8), state: "closed" };
 		const ws: WorkspaceSummary[] = [
 			{
+				host: "local",
 				id: "proj-1",
 				name: "app",
 				path: "/repos/app",
@@ -302,6 +305,7 @@ describe("buildCommands PR actions", () => {
 
 		const draftWorkspaces: WorkspaceSummary[] = [
 			{
+				host: "local",
 				id: "proj-1",
 				name: "app",
 				path: "/repos/app",
@@ -321,6 +325,7 @@ describe("buildCommands PR actions", () => {
 	it("emits per-PR action items for every open PR of a multi-PR session, all triggering the session", () => {
 		const multiWorkspaces: WorkspaceSummary[] = [
 			{
+				host: "local",
 				id: "proj-1",
 				name: "app",
 				path: "/repos/app",
@@ -340,6 +345,7 @@ describe("buildCommands PR actions", () => {
 		const closed: PullRequestFacts = { ...pr(8), state: "closed" };
 		const ws: WorkspaceSummary[] = [
 			{
+				host: "local",
 				id: "proj-1",
 				name: "app",
 				path: "/repos/app",
@@ -377,6 +383,7 @@ describe("buildCommands finished sessions", () => {
 	function withFinished(): WorkspaceSummary[] {
 		return [
 			{
+				host: "local",
 				id: "proj-1",
 				name: "app",
 				path: "/repos/app",
@@ -408,6 +415,7 @@ describe("buildCommands finished sessions", () => {
 describe("result caps", () => {
 	const manyProjects = (n: number): WorkspaceSummary[] =>
 		Array.from({ length: n }, (_, i) => ({
+			host: "local",
 			id: `p${i}`,
 			name: `project-${i}`,
 			path: `/repos/p${i}`,
@@ -434,7 +442,7 @@ describe("result caps", () => {
 			session({ id: `deploy-hot-${i}`, title: `deploy hot ${i}`, status: "needs_input" }),
 		);
 		const workspaces: WorkspaceSummary[] = [
-			{ id: "deploy", name: "deploy proj", path: "/repos/deploy", type: "main", sessions: attentionSessions },
+			{ host: "local", id: "deploy", name: "deploy proj", path: "/repos/deploy", type: "main", sessions: attentionSessions },
 		];
 		const groups = displayGroups(buildCommands({ workspaces }), "deploy");
 		const total = groups.reduce((n, g) => n + g.items.length, 0);
@@ -444,6 +452,7 @@ describe("result caps", () => {
 	it("keeps search hits under category headings, best-matching category first", () => {
 		const workspaces: WorkspaceSummary[] = [
 			{
+				host: "local",
 				id: "alpha",
 				name: "alpha",
 				path: "/repos/alpha",
@@ -470,6 +479,7 @@ describe("result caps", () => {
 	it("floats attention matches into their own category during search", () => {
 		const workspaces: WorkspaceSummary[] = [
 			{
+				host: "local",
 				id: "alpha",
 				name: "alpha",
 				path: "/repos/alpha",
@@ -495,6 +505,7 @@ describe("result caps", () => {
 		const manyPrs = Array.from({ length: 30 }, (_, i) => pr(i + 1));
 		const workspaces: WorkspaceSummary[] = [
 			{
+				host: "local",
 				id: "proj-deploy",
 				name: "proj-deploy",
 				path: "/repos/deploy",
@@ -512,6 +523,7 @@ describe("result caps", () => {
 
 	it("never lets a flood of attention matches crowd out an exact non-attention match", () => {
 		const floodedWorkspace: WorkspaceSummary = {
+			host: "local",
 			id: "proj-deploy",
 			name: "proj-deploy",
 			path: "/repos/deploy",
@@ -521,6 +533,7 @@ describe("result caps", () => {
 			),
 		};
 		const exactMatchWorkspace: WorkspaceSummary = {
+			host: "local",
 			id: "deploy",
 			name: "deploy",
 			path: "/repos/deploy-exact",
@@ -541,6 +554,7 @@ describe("result caps", () => {
 
 	it("still surfaces the exact match when every attention title also prefix-matches (tied score)", () => {
 		const floodedWorkspace: WorkspaceSummary = {
+			host: "local",
 			id: "proj-1",
 			name: "proj-1",
 			path: "/repos/proj-1",
@@ -550,6 +564,7 @@ describe("result caps", () => {
 			),
 		};
 		const exactMatchWorkspace: WorkspaceSummary = {
+			host: "local",
 			id: "deploy",
 			name: "deploy",
 			path: "/repos/deploy-exact",
@@ -595,13 +610,13 @@ describe("session rows open the actions panel", () => {
 	it("emits open-session-actions for session rows while PR rows stay navigate", () => {
 		const items = buildCommands({ workspaces: workspaces() });
 		const map = byId(items);
-		expect(map.get("attention:w-merge")?.action).toEqual({ kind: "open-session-actions", sessionId: "w-merge" });
+		expect(map.get("attention:w-merge")?.action).toEqual({ kind: "open-session-actions", session: { host: "local", id: "w-merge" } });
 		expect(map.get("pr:w-pr:42")?.action?.kind).toBe("navigate");
 		expect(map.get("project:proj-1")?.action?.kind).toBe("navigate");
 	});
 });
 
-const workspace: WorkspaceSummary = { id: "proj-1", name: "app", path: "/repos/app", type: "main", sessions: [] };
+const workspace: WorkspaceSummary = { host: "local", id: "proj-1", name: "app", path: "/repos/app", type: "main", sessions: [] };
 const actionKinds = (items: CommandItem[]) => items.map((item) => item.action?.kind ?? "none");
 
 describe("buildSessionActions", () => {
@@ -610,7 +625,7 @@ describe("buildSessionActions", () => {
 		expect(items.map((i) => i.title)).toEqual(["Jump to session", "Copy branch name"]);
 		expect(items[0].action).toEqual({
 			kind: "navigate",
-			target: { to: "/projects/$projectId/sessions/$sessionId", params: { projectId: "proj-1", sessionId: "live" } },
+			target: { to: "/host/$hostId/session/$sessionId", params: { hostId: "local", sessionId: "live" } },
 		});
 	});
 
@@ -618,8 +633,7 @@ describe("buildSessionActions", () => {
 		const terminated = buildSessionActions(workspace, session({ id: "gone", status: "terminated" }));
 		expect(terminated.find((i) => i.action?.kind === "resume-session")?.action).toEqual({
 			kind: "resume-session",
-			projectId: "proj-1",
-			sessionId: "gone",
+			session: { host: "local", id: "gone" },
 		});
 		for (const status of ["working", "needs_input", "no_signal", "mergeable"] as const) {
 			const items = buildSessionActions(workspace, session({ id: `s-${status}`, status }));

--- a/frontend/src/renderer/lib/command-palette.ts
+++ b/frontend/src/renderer/lib/command-palette.ts
@@ -20,7 +20,7 @@ import {
 } from "./session-reviews";
 import { appI18n, type MessageKey } from "../i18n";
 
-import type { Ref } from "./hosts";
+import { refKey, type HostId, type Ref } from "./hosts";
 export type CommandGroupId = "current" | "attention" | "projects" | "sessions" | "prs" | "global";
 
 export type NavigateTarget =
@@ -57,6 +57,8 @@ export type CommandItem = {
 
 export type CommandPaletteContext = {
 	workspaces: WorkspaceSummary[];
+	/** Host the route is on; without it the current session cannot be resolved. */
+	currentHostId?: HostId;
 	currentProjectId?: string;
 	currentSessionId?: string;
 	restartingProjectIds?: ReadonlySet<string>;
@@ -179,22 +181,28 @@ export function buildSessionActions(
 	return items;
 }
 
-export function findSession(workspaces: WorkspaceSummary[], sessionId: string): WorkspaceSessionContext | undefined {
+// Takes a Ref, not a bare id: session ids are unique per host, not across them,
+// so an id alone matches whichever host sorts first in the tree.
+export function findSession(workspaces: WorkspaceSummary[], ref: Ref): WorkspaceSessionContext | undefined {
 	for (const workspace of workspaces) {
-		const match = workspace.sessions.find((session) => session.id === sessionId);
+		const match = workspace.sessions.find((session) => session.host === ref.host && session.id === ref.id);
 		if (match) return { workspace, session: match };
 	}
 	return undefined;
 }
 
 export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n.t): CommandItem[] {
-	const { workspaces, currentProjectId, currentSessionId, restartingProjectIds, reviewStatesBySessionId } = ctx;
+	const { workspaces, currentHostId, currentProjectId, currentSessionId, restartingProjectIds, reviewStatesBySessionId } =
+		ctx;
 	const items: CommandItem[] = [];
 
 	const currentProject = currentProjectId
 		? workspaces.find((workspace) => workspace.id === currentProjectId)
 		: undefined;
-	const currentSession = currentSessionId ? findSession(workspaces, currentSessionId)?.session : undefined;
+	const currentRef: Ref | undefined =
+		currentHostId && currentSessionId ? { host: currentHostId, id: currentSessionId } : undefined;
+	const currentSessionKey = currentRef ? refKey(currentRef) : undefined;
+	const currentSession = currentRef ? findSession(workspaces, currentRef)?.session : undefined;
 	const isProjectRestarting = Boolean(currentProject && restartingProjectIds?.has(currentProject.id));
 
 	items.push({
@@ -255,14 +263,14 @@ export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n
 		.flatMap((workspace) => workerSessions(workspace.sessions).map((session) => ({ workspace, session })))
 		.filter(
 			({ session }) =>
-				session.id !== currentSessionId && (attentionZone(session) === "merge" || sessionNeedsAttention(session)),
+				refKey(session) !== currentSessionKey && (attentionZone(session) === "merge" || sessionNeedsAttention(session)),
 		)
 		.sort(
 			(a, b) =>
 				attentionZoneOrder.indexOf(attentionZone(a.session)) - attentionZoneOrder.indexOf(attentionZone(b.session)),
 		);
 
-	const attentionIds = new Set(attentionSessions.map(({ session }) => session.id));
+	const attentionKeys = new Set(attentionSessions.map(({ session }) => refKey(session)));
 
 	for (const { workspace, session } of attentionSessions) {
 		items.push(sessionCommand(workspace, session, "attention"));
@@ -286,7 +294,7 @@ export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n
 
 	for (const workspace of workspaces) {
 		for (const session of workerSessions(workspace.sessions).filter(
-			(session) => !attentionIds.has(session.id) && session.id !== currentSessionId,
+			(session) => !attentionKeys.has(refKey(session)) && refKey(session) !== currentSessionKey,
 		)) {
 			items.push({ ...sessionCommand(workspace, session, "sessions"), searchOnly: !sessionIsActive(session) });
 		}

--- a/frontend/src/renderer/lib/command-palette.ts
+++ b/frontend/src/renderer/lib/command-palette.ts
@@ -20,21 +20,22 @@ import {
 } from "./session-reviews";
 import { appI18n, type MessageKey } from "../i18n";
 
+import type { Ref } from "./hosts";
 export type CommandGroupId = "current" | "attention" | "projects" | "sessions" | "prs" | "global";
 
 export type NavigateTarget =
 	| { to: "/settings" }
-	| { to: "/projects/$projectId"; params: { projectId: string } }
-	| { to: "/projects/$projectId/settings"; params: { projectId: string } }
-	| { to: "/projects/$projectId/sessions/$sessionId"; params: { projectId: string; sessionId: string } };
+	| { to: "/host/$hostId/project/$projectId"; params: { hostId: string; projectId: string } }
+	| { to: "/host/$hostId/project/$projectId/settings"; params: { hostId: string; projectId: string } }
+	| { to: "/host/$hostId/session/$sessionId"; params: { hostId: string; sessionId: string } };
 
 export type CommandAction =
 	| { kind: "navigate"; target: NavigateTarget }
-	| { kind: "open-new-task"; projectId: string }
+	| { kind: "open-new-task"; project: Ref }
 	| { kind: "open-new-project" }
-	| { kind: "open-orchestrator"; projectId: string }
-	| { kind: "open-session-actions"; sessionId: string }
-	| { kind: "resume-session"; projectId: string; sessionId: string }
+	| { kind: "open-orchestrator"; project: Ref }
+	| { kind: "open-session-actions"; session: Ref }
+	| { kind: "resume-session"; session: Ref }
 	| { kind: "copy-branch"; branch: string }
 	| { kind: "open-pr"; url: string }
 	| { kind: "copy-pr-url"; url: string }
@@ -115,10 +116,10 @@ export type WorkspaceSessionContext = {
 	session: WorkspaceSession;
 };
 
-function jumpTarget(workspace: WorkspaceSummary, session: WorkspaceSession): NavigateTarget {
+function jumpTarget(_workspace: WorkspaceSummary, session: WorkspaceSession): NavigateTarget {
 	return {
-		to: "/projects/$projectId/sessions/$sessionId",
-		params: { projectId: workspace.id, sessionId: session.id },
+		to: "/host/$hostId/session/$sessionId",
+		params: { hostId: session.host, sessionId: session.id },
 	};
 }
 
@@ -134,7 +135,7 @@ function sessionCommand(
 		subtitle: workspace.name,
 		zone: attentionZone(session),
 		keywords: [workspace.name, session.branch ?? "", session.issueId ?? ""],
-		action: { kind: "open-session-actions", sessionId: session.id },
+		action: { kind: "open-session-actions", session: { host: session.host, id: session.id } },
 	};
 }
 
@@ -160,7 +161,7 @@ export function buildSessionActions(
 			title: t("command.resumeAgent"),
 			subtitle: t("command.resumeAgentSubtitle"),
 			keywords: ["restore", "restart", "retry", "resume", session.title],
-			action: { kind: "resume-session", projectId: workspace.id, sessionId: session.id },
+			action: { kind: "resume-session", session: { host: session.host, id: session.id } },
 		});
 	}
 
@@ -208,7 +209,7 @@ export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n
 			: isProjectRestarting
 				? t("command.orchestratorRestarting")
 				: undefined,
-		...(currentProject ? { action: { kind: "open-new-task" as const, projectId: currentProject.id } } : {}),
+		...(currentProject ? { action: { kind: "open-new-task" as const, project: { host: currentProject.host, id: currentProject.id } } } : {}),
 	});
 
 	if (currentProject) {
@@ -220,7 +221,7 @@ export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n
 			keywords: ["orchestrator", "spawn", currentProject.name],
 			disabled: isProjectRestarting,
 			disabledReason: isProjectRestarting ? t("command.orchestratorRestarting") : undefined,
-			action: { kind: "open-orchestrator", projectId: currentProject.id },
+			action: { kind: "open-orchestrator", project: { host: currentProject.host, id: currentProject.id } },
 		});
 		items.push({
 			id: "current-project-settings",
@@ -230,7 +231,10 @@ export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n
 			keywords: ["settings", "config", currentProject.name],
 			action: {
 				kind: "navigate",
-				target: { to: "/projects/$projectId/settings", params: { projectId: currentProject.id } },
+				target: {
+					to: "/host/$hostId/project/$projectId/settings",
+					params: { hostId: currentProject.host, projectId: currentProject.id },
+				},
 			},
 		});
 	}
@@ -270,7 +274,13 @@ export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n
 			group: "projects",
 			title: workspace.name,
 			keywords: [workspace.path],
-			action: { kind: "navigate", target: { to: "/projects/$projectId", params: { projectId: workspace.id } } },
+			action: {
+				kind: "navigate",
+				target: {
+					to: "/host/$hostId/project/$projectId",
+					params: { hostId: workspace.host, projectId: workspace.id },
+				},
+			},
 		});
 	}
 
@@ -312,8 +322,8 @@ export function buildCommands(ctx: CommandPaletteContext, t: TFunction = appI18n
 					action: {
 						kind: "navigate",
 						target: {
-							to: "/projects/$projectId/sessions/$sessionId",
-							params: { projectId: workspace.id, sessionId: session.id },
+							to: "/host/$hostId/session/$sessionId",
+							params: { hostId: session.host, sessionId: session.id },
 						},
 					},
 				});

--- a/frontend/src/renderer/lib/demo-board-sessions.ts
+++ b/frontend/src/renderer/lib/demo-board-sessions.ts
@@ -1,3 +1,4 @@
+import { LOCAL_HOST } from "./hosts";
 import type { WorkspaceSession } from "../types/workspace";
 
 const demoUpdatedAt = "2026-08-26T08:00:00Z";
@@ -7,6 +8,7 @@ export function demoBoardSessions(workspaceId: string): WorkspaceSession[] {
 	const base = {
 		activity: { state: "idle" as const, lastActivityAt: demoUpdatedAt },
 		createdAt: "2026-08-25T08:00:00Z",
+		host: LOCAL_HOST,
 		isTerminated: false,
 		provider: "claude-code" as const,
 		prs: [],

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -1,7 +1,10 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { aoBridge } from "./bridge";
-import { getApiBaseUrl, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "./api-client";
+import { subscribeApiBaseUrl } from "./api-client";
 import { setEventsConnectionState } from "./events-connection";
+import { connectedHosts, subscribeConnectedHosts } from "./host-clients";
+import { closeAllHostStreams, syncHostStreams } from "./host-events";
+import { LOCAL_HOST, type HostId } from "./hosts";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { sessionScmSummaryQueryKey } from "../hooks/useSessionScmSummary";
 import { conversationQueryKey, conversationQueryRoot } from "../hooks/useConversation";
@@ -13,58 +16,28 @@ export type EventTransport = {
 };
 
 const INVALIDATE_DEBOUNCE_MS = 150;
-// How long to wait before rebuilding an EventSource the browser gave up on
-// (readyState CLOSED — e.g. the daemon answered with a non-SSE response).
-const SSE_RETRY_MS = 5_000;
-// EventSource.CLOSED, referenced numerically so test stubs without the static
-// constants still work.
-const EVENTSOURCE_CLOSED = 2;
-
-// CDC event types the daemon pushes over the SSE stream (see
-// backend/internal/cdc/event.go). The SSE writer tags each frame with
-// `event: <type>`, so named events bypass EventSource.onmessage and must be
-// subscribed explicitly. Every one of these can change the project/session list
-// the sidebar renders, so they all trigger a (debounced) workspace refetch.
-const CDC_EVENT_TYPES = [
-	"session_created",
-	"session_updated",
-	"pr_created",
-	"pr_updated",
-	"pr_check_recorded",
-	"pr_session_changed",
-	"pr_review_thread_added",
-	"pr_review_thread_resolved",
-	"review_run_created",
-	"review_run_updated",
-] as const;
 
 /**
  * Wires live server state into the TanStack Query cache. Two sources feed it:
  *   - daemon lifecycle over Electron IPC (coming up/down changes session availability)
  *   - the backend CDC stream over SSE (project/session/PR changes)
- * Both invalidate the ["workspaces"] query so the UI refetches. Invalidations are
- * debounced because a single user action can emit a burst of CDC events.
+ * Daemon lifecycle invalidates the workspace root; each SSE stream invalidates
+ * only its host key. Invalidations are debounced because one action can emit a
+ * burst of CDC events.
  */
 export function createEventTransport(queryClient: QueryClient): EventTransport {
 	return {
 		connect() {
+			closeAllHostStreams();
 			let debounce: ReturnType<typeof setTimeout> | undefined;
 			const pendingConversationSessions = new Set<string>();
 			const pendingInterfaceTransitionSessions = new Set<string>();
 			let workspaceInvalidationPending = false;
 			let allConversationsInvalidationPending = false;
-			let retryTimer: ReturnType<typeof setTimeout> | undefined;
-			let source: EventSource | undefined;
-			let sourceBaseUrl: string | undefined;
-			const refreshWorkspaces = (event?: Event) => {
+			const pendingWorkspaceHosts = new Set<HostId>();
+			const refreshWorkspaces = (host?: HostId, event?: Event) => {
 				let conversationOnly = false;
 				if (event === undefined) {
-					// A lifecycle refresh -- reconnect, daemon status change, base-URL change --
-					// carries no event, so we cannot know which conversations moved. Normally the
-					// replay that follows tells us, but when the event log has been truncated the
-					// daemon starts us at head and no CDC arrives at all. EventSource cannot read
-					// the header reporting that clamp, so refresh every conversation instead of
-					// leaving an open chat frozen on its pre-gap snapshot.
 					allConversationsInvalidationPending = true;
 				}
 				if (event && "data" in event) {
@@ -107,7 +80,10 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						// cannot target a conversation cache precisely.
 					}
 				}
-				if (!conversationOnly) workspaceInvalidationPending = true;
+				if (!conversationOnly) {
+					if (host) pendingWorkspaceHosts.add(host);
+					else workspaceInvalidationPending = true;
+				}
 				if (debounce) clearTimeout(debounce);
 				debounce = setTimeout(() => {
 					if (allConversationsInvalidationPending) {
@@ -121,6 +97,12 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						void queryClient.invalidateQueries({ queryKey: sessionUsageQueryRoot });
 						workspaceInvalidationPending = false;
 					}
+					for (const pendingHost of pendingWorkspaceHosts) {
+						void queryClient.invalidateQueries({
+							queryKey: [...workspaceQueryKey, pendingHost],
+						});
+					}
+					pendingWorkspaceHosts.clear();
 					for (const sessionId of pendingConversationSessions) {
 						void queryClient.invalidateQueries({ queryKey: conversationQueryKey(sessionId) });
 					}
@@ -134,71 +116,26 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				}, INVALIDATE_DEBOUNCE_MS);
 			};
 
-			const scheduleRetry = () => {
-				if (retryTimer) return;
-				retryTimer = setTimeout(() => {
-					retryTimer = undefined;
-					connectSource();
-				}, SSE_RETRY_MS);
-			};
-
-			const connectSource = () => {
-				// EventSource is unavailable in jsdom (tests) and some preview surfaces; guard it.
-				if (typeof EventSource === "undefined") return;
-				if (!hasTrustedApiBaseUrl()) {
-					source?.close();
-					source = undefined;
-					sourceBaseUrl = undefined;
-					setEventsConnectionState("disconnected");
-					return;
-				}
-				const baseUrl = getApiBaseUrl();
-				// Keep a still-usable source on the same base URL; replace one the
-				// browser abandoned (CLOSED) or one bound to a stale port.
-				if (source && sourceBaseUrl === baseUrl && source.readyState !== EVENTSOURCE_CLOSED) return;
-				source?.close();
-				source = undefined;
-				sourceBaseUrl = baseUrl;
-				try {
-					source = new EventSource(`${baseUrl.replace(/\/+$/, "")}/api/v1/events`);
-					source.onopen = () => {
-						setEventsConnectionState("connected");
-						// Events emitted during the gap were lost; refetch once on (re)open.
-						refreshWorkspaces();
-					};
-					source.onerror = () => {
-						// While readyState is CONNECTING the browser retries on its own;
-						// either way the stream is not delivering, so surface it instead
-						// of looping silently against a dead daemon.
-						setEventsConnectionState("disconnected");
-						if (source?.readyState === EVENTSOURCE_CLOSED) scheduleRetry();
-					};
-					source.onmessage = refreshWorkspaces; // unnamed events, if any
-					for (const type of CDC_EVENT_TYPES) {
-						source.addEventListener(type, refreshWorkspaces);
-					}
-					// EventSource auto-reconnects and resumes via Last-Event-ID while
-					// CONNECTING; scheduleRetry only covers the terminal CLOSED state.
-				} catch {
-					source = undefined;
-				}
+			const connectSources = () => {
+				syncHostStreams([LOCAL_HOST, ...connectedHosts()], refreshWorkspaces);
 			};
 
 			const removeDaemonListener = aoBridge.daemon.onStatus(() => {
-				connectSource();
+				connectSources();
 				refreshWorkspaces();
 			});
 			// Rebind when the daemon comes back on a different port, independent of
 			// status-event ordering.
-			const removeBaseUrlListener = subscribeApiBaseUrl(connectSource);
-			connectSource();
+			const removeBaseUrlListener = subscribeApiBaseUrl(connectSources);
+			const removeHostsListener = subscribeConnectedHosts(connectSources);
+			connectSources();
 
 			return () => {
 				if (debounce) clearTimeout(debounce);
-				if (retryTimer) clearTimeout(retryTimer);
 				removeDaemonListener();
 				removeBaseUrlListener();
-				source?.close();
+				removeHostsListener();
+				closeAllHostStreams();
 				setEventsConnectionState("idle");
 			};
 		},

--- a/frontend/src/renderer/lib/host-clients.test.ts
+++ b/frontend/src/renderer/lib/host-clients.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setApiBaseUrl } from "./api-client";
+import { aoBridge } from "./bridge";
+import { LOCAL_HOST } from "./hosts";
+import {
+	baseUrlFor,
+	clientFor,
+	connectedHosts,
+	connectHost,
+	disconnectHost,
+	forgetHost,
+	hostLabelFor,
+	isHostReady,
+	registerHostBase,
+	subscribeConnectedHosts,
+} from "./host-clients";
+
+const REMOTE = "http://192.0.2.1:3011";
+const OTHER_REMOTE = "http://192.0.2.9:3011";
+
+beforeEach(() => {
+	forgetHost(REMOTE);
+	forgetHost(OTHER_REMOTE);
+	setApiBaseUrl("http://127.0.0.1:3001");
+	vi.restoreAllMocks();
+});
+
+describe("host-clients", () => {
+	it("resolves the local host to the daemon base", () => {
+		expect(baseUrlFor(LOCAL_HOST)).toBe("http://127.0.0.1:3001");
+		expect(isHostReady(LOCAL_HOST)).toBe(true);
+	});
+
+	it("reports an unregistered remote as not ready rather than throwing", () => {
+		expect(baseUrlFor(REMOTE)).toBeNull();
+		expect(isHostReady(REMOTE)).toBe(false);
+	});
+
+	it("routes a remote request through that host's proxy base", async () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response('{"projects":[]}', {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		await clientFor(REMOTE).GET("/api/v1/projects");
+		expect((fetchSpy.mock.calls[0][0] as Request).url).toBe(
+			"http://127.0.0.1:9999/tok/api/v1/projects",
+		);
+	});
+
+	it("routes a local request to the local daemon, not a proxy", async () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response('{"projects":[]}', {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		await clientFor(LOCAL_HOST).GET("/api/v1/projects");
+		expect((fetchSpy.mock.calls[0][0] as Request).url).toBe(
+			"http://127.0.0.1:3001/api/v1/projects",
+		);
+	});
+
+	it("follows the local base when the daemon moves port", async () => {
+		clientFor(LOCAL_HOST);
+		setApiBaseUrl("http://127.0.0.1:3037");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response('{"projects":[]}', {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		await clientFor(LOCAL_HOST).GET("/api/v1/projects");
+
+		expect((fetchSpy.mock.calls[0][0] as Request).url).toBe(
+			"http://127.0.0.1:3037/api/v1/projects",
+		);
+	});
+
+	it("forgetting a host makes it not ready again", () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		expect(isHostReady(REMOTE)).toBe(true);
+		forgetHost(REMOTE);
+		expect(isHostReady(REMOTE)).toBe(false);
+	});
+
+	it("binds a connected host to the proxy base returned by main", async () => {
+		vi.spyOn(aoBridge.remotes, "connect").mockResolvedValue({
+			label: "workbox",
+			url: REMOTE,
+			base: "http://127.0.0.1:9999/tok",
+		});
+
+		await connectHost(REMOTE);
+
+		expect(baseUrlFor(REMOTE)).toBe("http://127.0.0.1:9999/tok");
+		expect(hostLabelFor(REMOTE)).toBe("workbox");
+	});
+
+	it("publishes connected-host changes for a mounted workspace query", () => {
+		const changed = vi.fn();
+		const unsubscribe = subscribeConnectedHosts(changed);
+
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok", "workbox");
+		expect(changed).toHaveBeenCalledOnce();
+		expect(connectedHosts()).toEqual([REMOTE]);
+
+		forgetHost(REMOTE);
+		expect(changed).toHaveBeenCalledTimes(2);
+		unsubscribe();
+	});
+
+	it("forgets a host before waiting for its proxy to close", async () => {
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		let finishDisconnect!: () => void;
+		const disconnect = vi
+			.spyOn(aoBridge.remotes, "disconnect")
+			.mockReturnValue(
+				new Promise<void>((resolve) => {
+					finishDisconnect = resolve;
+				}),
+			);
+
+		const pending = disconnectHost(REMOTE);
+
+		expect(isHostReady(REMOTE)).toBe(false);
+		expect(disconnect).toHaveBeenCalledWith(REMOTE);
+		finishDisconnect();
+		await pending;
+	});
+});

--- a/frontend/src/renderer/lib/host-clients.ts
+++ b/frontend/src/renderer/lib/host-clients.ts
@@ -1,0 +1,81 @@
+import createClient from "openapi-fetch";
+import type { paths } from "../../api/schema";
+import { getApiBaseUrl, hasTrustedApiBaseUrl } from "./api-client";
+import { aoBridge } from "./bridge";
+import { isLocal, type HostId } from "./hosts";
+
+// One client per host. Local reads the live daemon base (which still moves when
+// the daemon restarts on a new port); a remote reads the loopback proxy base its
+// main-process proxy is listening on.
+const remoteBases = new Map<HostId, string>();
+const remoteLabels = new Map<HostId, string>();
+const clients = new Map<HostId, ReturnType<typeof createClient<paths>>>();
+const listeners = new Set<() => void>();
+let connectedSnapshot: HostId[] = [];
+
+function publishConnectedHosts(): void {
+	connectedSnapshot = [...remoteBases.keys()];
+	for (const listener of listeners) listener();
+}
+
+export function registerHostBase(host: HostId, base: string, label = host): void {
+	remoteLabels.set(host, label);
+	if (remoteBases.get(host) === base) return;
+	remoteBases.set(host, base);
+	// A changed base invalidates the cached client bound to the old one.
+	clients.delete(host);
+	publishConnectedHosts();
+}
+
+export function forgetHost(host: HostId): void {
+	const removed = remoteBases.delete(host);
+	remoteLabels.delete(host);
+	clients.delete(host);
+	if (removed) publishConnectedHosts();
+}
+
+export function connectedHosts(): HostId[] {
+	return connectedSnapshot;
+}
+
+export function subscribeConnectedHosts(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function hostLabelFor(host: HostId): string {
+	return remoteLabels.get(host) ?? host;
+}
+
+export function baseUrlFor(host: HostId): string | null {
+	if (isLocal(host)) return hasTrustedApiBaseUrl() ? getApiBaseUrl() : null;
+	return remoteBases.get(host) ?? null;
+}
+
+export function isHostReady(host: HostId): boolean {
+	return baseUrlFor(host) !== null;
+}
+
+export function clientFor(host: HostId) {
+	const base = baseUrlFor(host);
+	if (base === null) throw new Error(`host ${host} is not connected`);
+	// The local client is not cached: its base follows the daemon across restarts
+	// and a stale cached client would keep talking to a dead port.
+	if (isLocal(host)) return createClient<paths>({ baseUrl: base });
+	const cached = clients.get(host);
+	if (cached) return cached;
+	const client = createClient<paths>({ baseUrl: base });
+	clients.set(host, client);
+	return client;
+}
+
+/** Start (or reuse) a proxy for a saved host and bind a client to its base. */
+export async function connectHost(url: HostId): Promise<void> {
+	const view = await aoBridge.remotes.connect(url);
+	registerHostBase(view.url, view.base, view.label);
+}
+
+export async function disconnectHost(url: HostId): Promise<void> {
+	forgetHost(url);
+	await aoBridge.remotes.disconnect(url);
+}

--- a/frontend/src/renderer/lib/host-events.test.ts
+++ b/frontend/src/renderer/lib/host-events.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setApiBaseUrl } from "./api-client";
+import { forgetHost, registerHostBase } from "./host-clients";
+import { LOCAL_HOST } from "./hosts";
+import { closeAllHostStreams, hostConnectionState, syncHostStreams } from "./host-events";
+import { reportHostStreamState } from "./host-telemetry";
+
+vi.mock("./host-telemetry", () => ({ reportHostStreamState: vi.fn() }));
+
+const reportStreamState = vi.mocked(reportHostStreamState);
+
+const REMOTE = "http://192.0.2.1:3011";
+
+class FakeEventSource {
+	static instances: FakeEventSource[] = [];
+	readyState = 0;
+	onopen: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	listeners = new Map<string, () => void>();
+	closed = false;
+	constructor(readonly url: string) {
+		FakeEventSource.instances.push(this);
+	}
+	addEventListener(type: string, fn: () => void) {
+		this.listeners.set(type, fn);
+	}
+	close() {
+		this.closed = true;
+	}
+	emit(type: string) {
+		this.listeners.get(type)?.();
+	}
+}
+
+beforeEach(() => {
+	setApiBaseUrl("http://127.0.0.1:3001");
+	reportStreamState.mockClear();
+});
+
+afterEach(() => {
+	closeAllHostStreams();
+	forgetHost(REMOTE);
+	setApiBaseUrl(null);
+	FakeEventSource.instances = [];
+	vi.unstubAllGlobals();
+});
+
+describe("host-events", () => {
+	it("opens one stream per host, at each host's own base", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		syncHostStreams([LOCAL_HOST, REMOTE], vi.fn());
+		expect(FakeEventSource.instances.map((source) => source.url)).toEqual([
+			expect.stringContaining("/api/v1/events"),
+			"http://127.0.0.1:9999/tok/api/v1/events",
+		]);
+	});
+
+	it("reports which host an event came from", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		const onEvent = vi.fn();
+		syncHostStreams([LOCAL_HOST, REMOTE], onEvent);
+		FakeEventSource.instances[1].emit("session_updated");
+		expect(onEvent).toHaveBeenCalledWith(REMOTE);
+		expect(onEvent).not.toHaveBeenCalledWith(LOCAL_HOST);
+	});
+
+	it("one host's stream failing leaves the others connected", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		syncHostStreams([LOCAL_HOST, REMOTE], vi.fn());
+		FakeEventSource.instances[0].onopen?.();
+		FakeEventSource.instances[1].onopen?.();
+		FakeEventSource.instances[1].readyState = 2;
+		FakeEventSource.instances[1].onerror?.();
+		expect(hostConnectionState(LOCAL_HOST)).toBe("connected");
+		expect(hostConnectionState(REMOTE)).toBe("disconnected");
+	});
+
+	it("dropping a host closes only its stream", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		syncHostStreams([LOCAL_HOST, REMOTE], vi.fn());
+		syncHostStreams([LOCAL_HOST], vi.fn());
+		expect(FakeEventSource.instances[1].closed).toBe(true);
+		expect(FakeEventSource.instances[0].closed).toBe(false);
+	});
+
+	it("re-syncing the same hosts does not churn live streams", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		syncHostStreams([LOCAL_HOST], vi.fn());
+		syncHostStreams([LOCAL_HOST], vi.fn());
+		expect(FakeEventSource.instances).toHaveLength(1);
+	});
+
+	// A host that never opened a stream is not a host whose stream died: only
+	// the second one means the board went stale, so only it may be reported.
+	it("separates a host with no stream from one whose stream dropped", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		expect(hostConnectionState(REMOTE)).toBe("idle");
+
+		syncHostStreams([REMOTE], vi.fn());
+		FakeEventSource.instances[0].onopen?.();
+		FakeEventSource.instances[0].readyState = 2;
+		FakeEventSource.instances[0].onerror?.();
+		expect(hostConnectionState(REMOTE)).toBe("disconnected");
+
+		syncHostStreams([], vi.fn());
+		expect(hostConnectionState(REMOTE)).toBe("idle");
+	});
+
+	it("reports one event per state change, counting the drops", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		syncHostStreams([REMOTE], vi.fn());
+		const source = FakeEventSource.instances[0];
+
+		source.onopen?.();
+		source.readyState = 2;
+		// EventSource fires onerror repeatedly while it retries; one drop is one drop.
+		source.onerror?.();
+		source.onerror?.();
+
+		expect(reportStreamState.mock.calls).toEqual([
+			[REMOTE, "connected", 0],
+			[REMOTE, "disconnected", 1],
+		]);
+	});
+
+	it("says nothing when a host is deliberately dropped", () => {
+		vi.stubGlobal("EventSource", FakeEventSource);
+		registerHostBase(REMOTE, "http://127.0.0.1:9999/tok");
+		syncHostStreams([REMOTE], vi.fn());
+		FakeEventSource.instances[0].onopen?.();
+		reportStreamState.mockClear();
+
+		syncHostStreams([], vi.fn());
+		expect(reportStreamState).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/lib/host-events.ts
+++ b/frontend/src/renderer/lib/host-events.ts
@@ -1,0 +1,128 @@
+import { baseUrlFor } from "./host-clients";
+import { reportHostStreamState } from "./host-telemetry";
+import { LOCAL_HOST, type HostId } from "./hosts";
+import { setEventsConnectionState, type EventsConnectionState } from "./events-connection";
+
+const SSE_RETRY_MS = 5_000;
+const EVENTSOURCE_CLOSED = 2;
+
+const CDC_EVENT_TYPES = [
+	"session_created",
+	"session_updated",
+	"pr_created",
+	"pr_updated",
+	"pr_check_recorded",
+	"pr_session_changed",
+	"pr_review_thread_added",
+	"pr_review_thread_resolved",
+	"review_run_created",
+	"review_run_updated",
+] as const;
+
+type HostEventHandler = (host: HostId, event?: Event) => void;
+type HostStream = {
+	source: EventSource;
+	base: string;
+	state: "connected" | "disconnected";
+	onEvent: HostEventHandler;
+	retryTimer?: ReturnType<typeof setTimeout>;
+};
+
+const streams = new Map<HostId, HostStream>();
+// How many times each host's stream has dropped this session. Kept beside the
+// streams rather than on one, because a reconnect builds a new stream object
+// and the count of drops is the whole point of the signal.
+const streamDrops = new Map<HostId, number>();
+
+function setConnectionState(host: HostId, stream: HostStream, state: HostStream["state"]): void {
+	// Transitions only: onerror fires repeatedly while EventSource is CONNECTING,
+	// and one drop must report as one drop.
+	if (stream.state === state) return;
+	stream.state = state;
+	if (host === LOCAL_HOST) setEventsConnectionState(state);
+	if (state === "disconnected") streamDrops.set(host, (streamDrops.get(host) ?? 0) + 1);
+	reportHostStreamState(host, state, streamDrops.get(host) ?? 0);
+}
+
+function closeHostStream(host: HostId): void {
+	const stream = streams.get(host);
+	if (!stream) return;
+	if (stream.retryTimer) clearTimeout(stream.retryTimer);
+	stream.source.close();
+	streams.delete(host);
+	// A deliberate teardown is not a drop, so the count goes with the stream.
+	streamDrops.delete(host);
+	if (host === LOCAL_HOST) setEventsConnectionState("disconnected");
+}
+
+function connectHostStream(host: HostId, onEvent: HostEventHandler): void {
+	// EventSource is unavailable in jsdom and some preview surfaces.
+	if (typeof EventSource === "undefined") return;
+	const base = baseUrlFor(host);
+	if (base === null) {
+		closeHostStream(host);
+		if (host === LOCAL_HOST) setEventsConnectionState("disconnected");
+		return;
+	}
+
+	const current = streams.get(host);
+	if (current && current.base === base && current.source.readyState !== EVENTSOURCE_CLOSED) {
+		current.onEvent = onEvent;
+		return;
+	}
+	closeHostStream(host);
+
+	try {
+		const source = new EventSource(`${base.replace(/\/+$/, "")}/api/v1/events`);
+		const stream: HostStream = { source, base, state: "disconnected", onEvent };
+		streams.set(host, stream);
+
+		const reportEvent = (event?: Event) => {
+			if (event === undefined) stream.onEvent(host);
+			else stream.onEvent(host, event);
+		};
+		source.onopen = () => {
+			if (streams.get(host) !== stream) return;
+			setConnectionState(host, stream, "connected");
+			// Events emitted during the gap were lost; refetch once on (re)open.
+			stream.onEvent(host);
+		};
+		source.onerror = () => {
+			if (streams.get(host) !== stream) return;
+			setConnectionState(host, stream, "disconnected");
+			// While CONNECTING the browser retries and resumes via Last-Event-ID.
+			if (source.readyState !== EVENTSOURCE_CLOSED || stream.retryTimer) return;
+			stream.retryTimer = setTimeout(() => {
+				stream.retryTimer = undefined;
+				if (streams.get(host) === stream) connectHostStream(host, stream.onEvent);
+			}, SSE_RETRY_MS);
+		};
+		source.onmessage = reportEvent;
+		for (const type of CDC_EVENT_TYPES) source.addEventListener(type, reportEvent);
+	} catch {
+		if (host === LOCAL_HOST) setEventsConnectionState("disconnected");
+	}
+}
+
+export function syncHostStreams(hosts: HostId[], onEvent: HostEventHandler): void {
+	const wanted = new Set(hosts);
+	for (const host of streams.keys()) {
+		if (!wanted.has(host)) closeHostStream(host);
+	}
+	for (const host of wanted) connectHostStream(host, onEvent);
+}
+
+/**
+ * Whether this host's live updates are flowing.
+ *
+ * "idle" — no stream at all (never opened, or torn down) — is deliberately
+ * distinct from "disconnected": only the second one means the board went stale
+ * on a host that is meant to be live, and only it is worth telling anyone about.
+ */
+export function hostConnectionState(host: HostId): EventsConnectionState {
+	return streams.get(host)?.state ?? "idle";
+}
+
+export function closeAllHostStreams(): void {
+	for (const host of [...streams.keys()]) closeHostStream(host);
+}

--- a/frontend/src/renderer/lib/host-telemetry.ts
+++ b/frontend/src/renderer/lib/host-telemetry.ts
@@ -1,0 +1,42 @@
+import { LOCAL_HOST, type HostId } from "./hosts";
+import { captureRendererEvent } from "./telemetry";
+
+// The remote path shipped with no telemetry at all: a host whose event stream
+// died left the board quietly polling, with nothing anywhere able to answer
+// "why isn't my remote updating?".
+//
+// No address, label or connection password ever leaves the machine. A host id
+// IS its URL, so it is handed over as `host_id` and reaches PostHog only as a
+// SHA-256 digest — sanitizeRendererProperties in telemetry.ts does the hashing
+// and drops everything not on its allowlist.
+
+type HostStreamState = "connected" | "disconnected";
+
+function hostFields(host: HostId) {
+	return { host_id: host, host_kind: host === LOCAL_HOST ? "local" : "remote" };
+}
+
+/** A host's live event stream opening or dropping, with how often it has dropped this session. */
+export function reportHostStreamState(host: HostId, state: HostStreamState, reconnectCount: number): void {
+	void captureRendererEvent("ao.renderer.host_stream_state", {
+		...hostFields(host),
+		state,
+		reconnect_count: reconnectCount,
+	});
+}
+
+// A host that stays down fails its refetch every 15 seconds forever, and
+// captureRendererEvent's per-name daily ceiling is shared: one dead host would
+// spend the whole budget and hide the next host to break. Collapse repeats of
+// the same (host, status), the same guard api-client already runs over api_error.
+const QUERY_FAILED_DEDUPE_MS = 5 * 60_000;
+const lastQueryFailureAt = new Map<string, number>();
+
+/** A host's projects/sessions fetch failing — invisible until now, since remote clients bypass api-client. */
+export function reportHostQueryFailed(host: HostId, status?: number, now = Date.now()): void {
+	const key = `${host}|${status ?? ""}`;
+	const last = lastQueryFailureAt.get(key);
+	if (last !== undefined && now - last < QUERY_FAILED_DEDUPE_MS) return;
+	lastQueryFailureAt.set(key, now);
+	void captureRendererEvent("ao.renderer.host_query_failed", { ...hostFields(host), status });
+}

--- a/frontend/src/renderer/lib/hosts.test.ts
+++ b/frontend/src/renderer/lib/hosts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isLocal, LOCAL_HOST, parseRefKey, refKey, type Ref } from "./hosts";
+
+describe("refKey", () => {
+	it("round-trips a local ref", () => {
+		const ref: Ref = { host: LOCAL_HOST, id: "skyvern-cloud" };
+		expect(refKey(ref)).toBe("local:skyvern-cloud");
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("round-trips a remote ref whose host url contains colons and slashes", () => {
+		const ref: Ref = { host: "http://192.0.2.1:3011", id: "skyvern-cloud" };
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("round-trips an id that itself contains a colon", () => {
+		// Ids come from another machine; nothing guarantees they are colon-free.
+		const ref: Ref = { host: "http://192.0.2.1:3011", id: "weird:id" };
+		expect(parseRefKey(refKey(ref))).toEqual(ref);
+	});
+
+	it("distinguishes the same id on two hosts", () => {
+		expect(refKey({ host: LOCAL_HOST, id: "skyvern-cloud" })).not.toBe(
+			refKey({ host: "http://192.0.2.1:3011", id: "skyvern-cloud" }),
+		);
+	});
+});
+
+describe("isLocal", () => {
+	it("is true only for the local host", () => {
+		expect(isLocal(LOCAL_HOST)).toBe(true);
+		expect(isLocal("http://192.0.2.1:3011")).toBe(false);
+	});
+});

--- a/frontend/src/renderer/lib/hosts.ts
+++ b/frontend/src/renderer/lib/hosts.ts
@@ -1,0 +1,30 @@
+// Host identity. Local is a host like any other — the one whose requests skip
+// the proxy — so no code path has to special-case "is this remote?".
+export type HostId = string;
+
+export const LOCAL_HOST: HostId = "local";
+
+/** Anything addressable across hosts. A bare id is never enough to act on. */
+export type Ref = {
+	host: HostId;
+	id: string;
+};
+
+export function isLocal(host: HostId): boolean {
+	return host === LOCAL_HOST;
+}
+
+// A host id is a URL and an id may contain anything, so the key encodes both
+// halves rather than relying on a separator being absent from either.
+export function refKey(ref: Ref): string {
+	return `${encodeURIComponent(ref.host)}:${encodeURIComponent(ref.id)}`;
+}
+
+export function parseRefKey(key: string): Ref {
+	const separator = key.indexOf(":");
+	if (separator === -1) throw new Error(`malformed ref key: ${key}`);
+	return {
+		host: decodeURIComponent(key.slice(0, separator)),
+		id: decodeURIComponent(key.slice(separator + 1)),
+	};
+}

--- a/frontend/src/renderer/lib/mock-data.ts
+++ b/frontend/src/renderer/lib/mock-data.ts
@@ -1,4 +1,5 @@
 import type { PRState, PullRequestFacts, WorkspaceSummary } from "../types/workspace";
+import { LOCAL_HOST } from "./hosts";
 import type { SessionPRSummary } from "../hooks/useSessionScmSummary";
 import type { ShellTerminal } from "../hooks/useShellTerminals";
 
@@ -38,6 +39,7 @@ export const mockShellTerminals: ShellTerminal[] = [
 
 export const mockWorkspaces: WorkspaceSummary[] = [
 	{
+		host: LOCAL_HOST,
 		id: "ao-demo",
 		name: "ao-demo",
 		path: "/demo/ao-demo",
@@ -46,6 +48,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 		accentColor: "var(--color-project-accent-mint)",
 		sessions: [
 			{
+				host: LOCAL_HOST,
 				id: "ao-demo-orchestrator",
 				terminalHandleId: "ao-demo-orchestrator/terminal_0",
 				workspaceId: "ao-demo",
@@ -63,6 +66,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				prs: [],
 			},
 			{
+				host: LOCAL_HOST,
 				id: "demo-working",
 				terminalHandleId: "demo-working/terminal_0",
 				workspaceId: "ao-demo",
@@ -84,6 +88,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				prs: [],
 			},
 			{
+				host: LOCAL_HOST,
 				id: "demo-needs-input",
 				terminalHandleId: "demo-needs-input/terminal_0",
 				workspaceId: "ao-demo",
@@ -105,6 +110,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				prs: [demoPr(318, "open", "passing", "changes_requested")],
 			},
 			{
+				host: LOCAL_HOST,
 				id: "demo-review-stack",
 				terminalHandleId: "demo-review-stack/terminal_0",
 				workspaceId: "ao-demo",
@@ -134,6 +140,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				],
 			},
 			{
+				host: LOCAL_HOST,
 				id: "demo-in-review",
 				terminalHandleId: "demo-in-review/terminal_0",
 				workspaceId: "ao-demo",
@@ -150,6 +157,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				prs: [demoPr(322, "open", "pending", "none", "unknown")],
 			},
 			{
+				host: LOCAL_HOST,
 				id: "demo-ready",
 				terminalHandleId: "demo-ready/terminal_0",
 				workspaceId: "ao-demo",
@@ -170,6 +178,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				prs: [demoPr(323, "open", "passing", "approved")],
 			},
 			{
+				host: LOCAL_HOST,
 				id: "demo-ci-failed",
 				terminalHandleId: "demo-ci-failed/terminal_0",
 				workspaceId: "ao-demo",
@@ -189,6 +198,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 		],
 	},
 	{
+		host: LOCAL_HOST,
 		id: "docs-site",
 		name: "docs-site",
 		path: "/demo/docs-site",
@@ -197,6 +207,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 		accentColor: "var(--color-project-accent-sky)",
 		sessions: [
 			{
+				host: LOCAL_HOST,
 				id: "docs-installation",
 				terminalHandleId: "docs-installation/terminal_0",
 				workspaceId: "docs-site",
@@ -213,6 +224,7 @@ export const mockWorkspaces: WorkspaceSummary[] = [
 				prs: [],
 			},
 			{
+				host: LOCAL_HOST,
 				id: "docs-ready",
 				terminalHandleId: "docs-ready/terminal_0",
 				workspaceId: "docs-site",

--- a/frontend/src/renderer/lib/mock-data.ts
+++ b/frontend/src/renderer/lib/mock-data.ts
@@ -29,6 +29,7 @@ const demoPr = (
 // enough to exercise the tab strip's layout, selection, and close control.
 export const mockShellTerminals: ShellTerminal[] = [
 	{
+		host: LOCAL_HOST,
 		handleId: "shellterm-demo-1",
 		projectId: "ao-demo",
 		workingDir: "/Users/demo/Projects/ao-demo",

--- a/frontend/src/renderer/lib/navigate-to-session.ts
+++ b/frontend/src/renderer/lib/navigate-to-session.ts
@@ -1,19 +1,16 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
-export function useNavigateToSession(): (projectId: string | undefined, sessionId: string) => void {
+import type { Ref } from "./hosts";
+export function useNavigateToSession(): (session: Ref) => void {
 	const navigate = useNavigate();
 	return useCallback(
-		(projectId: string | undefined, sessionId: string) => {
-			if (!sessionId) return;
-			if (projectId) {
-				void navigate({
-					to: "/projects/$projectId/sessions/$sessionId",
-					params: { projectId, sessionId },
-				});
-				return;
-			}
-			void navigate({ to: "/sessions/$sessionId", params: { sessionId } });
+		(session: Ref) => {
+			if (!session.id) return;
+			void navigate({
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: session.host, sessionId: session.id },
+			});
 		},
 		[navigate],
 	);

--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -35,7 +35,7 @@ const summary = (overrides: Partial<SessionPRSummary> = {}): SessionPRSummary =>
 	...overrides,
 });
 
-const session = (prs: WorkspaceSession["prs"]): WorkspaceSession => ({
+const session = (prs: WorkspaceSession["prs"]): WorkspaceSession => ({ host: "local",
 	id: "sess-1",
 	workspaceId: "ws-1",
 	workspaceName: "repo",
@@ -49,6 +49,7 @@ const session = (prs: WorkspaceSession["prs"]): WorkspaceSession => ({
 
 function sessionWith(overrides: Partial<WorkspaceSession> = {}): WorkspaceSession {
 	return {
+		host: "local",
 		id: "sess-1",
 		workspaceId: "ws-1",
 		workspaceName: "my-app",

--- a/frontend/src/renderer/lib/response-validation.ts
+++ b/frontend/src/renderer/lib/response-validation.ts
@@ -1,0 +1,9 @@
+export function parseResponseArray<T>(
+	body: unknown,
+	key: string,
+	isItem: (value: unknown) => value is T,
+): T[] | null {
+	if (typeof body !== "object" || body === null) return null;
+	const items = (body as Record<string, unknown>)[key];
+	return Array.isArray(items) && items.every(isItem) ? items : null;
+}

--- a/frontend/src/renderer/lib/restart-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.test.ts
@@ -39,7 +39,7 @@ describe("restartProjectOrchestrator", () => {
 		spawnMock.mockRejectedValue(failure);
 
 		await restartProjectOrchestrator({
-			projectId: "proj-1",
+			project: { host: "local", id: "proj-1" },
 			queryClient,
 			navigate,
 			setProjectRestarting,
@@ -49,8 +49,8 @@ describe("restartProjectOrchestrator", () => {
 
 		expect(spawnMock).toHaveBeenCalledWith("proj-1", "restart", true, undefined);
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceQueryKey });
-		expect(setOrchestratorReplacementError).toHaveBeenNthCalledWith(1, "proj-1", null);
-		expect(setOrchestratorReplacementError).toHaveBeenNthCalledWith(2, "proj-1", {
+		expect(setOrchestratorReplacementError).toHaveBeenNthCalledWith(1, { host: "local", id: "proj-1" }, null);
+		expect(setOrchestratorReplacementError).toHaveBeenNthCalledWith(2, { host: "local", id: "proj-1" }, {
 			message: "missing goose binary",
 		});
 		expect(setProjectRestarting).toHaveBeenNthCalledWith(1, "proj-1", true);
@@ -70,7 +70,7 @@ describe("restartProjectOrchestrator", () => {
 		spawnMock.mockRejectedValue(failure);
 
 		await restartProjectOrchestrator({
-			projectId: "proj-1",
+			project: { host: "local", id: "proj-1" },
 			queryClient,
 			navigate,
 			setProjectRestarting,
@@ -78,7 +78,7 @@ describe("restartProjectOrchestrator", () => {
 			onError,
 		});
 
-		expect(setOrchestratorReplacementError).toHaveBeenLastCalledWith("proj-1", {
+		expect(setOrchestratorReplacementError).toHaveBeenLastCalledWith({ host: "local", id: "proj-1" }, {
 			message: "missing goose binary",
 		});
 		expect(setProjectRestarting).toHaveBeenLastCalledWith("proj-1", false);
@@ -100,7 +100,7 @@ describe("restartProjectOrchestrator", () => {
 		);
 
 		await restartProjectOrchestrator({
-			projectId: "proj-1",
+			project: { host: "local", id: "proj-1" },
 			queryClient,
 			navigate: vi.fn(),
 			setProjectRestarting: vi.fn(),
@@ -109,7 +109,7 @@ describe("restartProjectOrchestrator", () => {
 		});
 
 		expect(spawnMock).toHaveBeenCalledWith("proj-1", "restart", true, "tui");
-		expect(setOrchestratorReplacementError).toHaveBeenLastCalledWith("proj-1", {
+		expect(setOrchestratorReplacementError).toHaveBeenLastCalledWith({ host: "local", id: "proj-1" }, {
 			message: "Claude Code is unavailable",
 			code: "CHAT_DRIVER_UNAVAILABLE",
 			requestId: "request-42",

--- a/frontend/src/renderer/lib/restart-orchestrator.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.ts
@@ -1,20 +1,21 @@
 import type { QueryClient } from "@tanstack/react-query";
+import type { Ref } from "./hosts";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import type { SessionMode } from "../types/conversation";
 import { OrchestratorSpawnError, spawnOrchestrator } from "./spawn-orchestrator";
 import type { OrchestratorReplacementFailure } from "../stores/ui-store";
 
 type NavigateToSession = (options: {
-	to: "/projects/$projectId/sessions/$sessionId";
-	params: { projectId: string; sessionId: string };
+	to: "/host/$hostId/session/$sessionId";
+	params: { hostId: string; sessionId: string };
 }) => unknown;
 
 type RestartProjectOrchestratorOptions = {
-	projectId: string;
+	project: Ref;
 	queryClient: QueryClient;
 	navigate: NavigateToSession;
 	setProjectRestarting: (projectId: string, restarting: boolean) => void;
-	setOrchestratorReplacementError: (projectId: string, failure: OrchestratorReplacementFailure | null) => void;
+	setOrchestratorReplacementError: (project: Ref, failure: OrchestratorReplacementFailure | null) => void;
 	onError?: (error: unknown) => void;
 	mode?: SessionMode;
 };
@@ -29,7 +30,7 @@ async function refreshWorkspaceState(queryClient: QueryClient) {
 }
 
 export async function restartProjectOrchestrator({
-	projectId,
+	project,
 	queryClient,
 	navigate,
 	setProjectRestarting,
@@ -37,18 +38,18 @@ export async function restartProjectOrchestrator({
 	onError,
 	mode,
 }: RestartProjectOrchestratorOptions) {
-	setProjectRestarting(projectId, true);
-	setOrchestratorReplacementError(projectId, null);
+	setProjectRestarting(project.id, true);
+	setOrchestratorReplacementError(project, null);
 	try {
-		const sessionId = await spawnOrchestrator(projectId, "restart", true, mode);
+		const sessionId = await spawnOrchestrator(project.id, "restart", true, mode);
 		await refreshWorkspaceState(queryClient);
 		void navigate({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId, sessionId },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: project.host, sessionId },
 		});
 	} catch (error) {
 		await refreshWorkspaceState(queryClient);
-		setOrchestratorReplacementError(projectId, {
+		setOrchestratorReplacementError(project, {
 			message: error instanceof Error ? error.message : "Could not replace orchestrator",
 			...(error instanceof OrchestratorSpawnError
 				? { code: error.code, requestId: error.requestId }
@@ -56,6 +57,6 @@ export async function restartProjectOrchestrator({
 		});
 		onError?.(error);
 	} finally {
-		setProjectRestarting(projectId, false);
+		setProjectRestarting(project.id, false);
 	}
 }

--- a/frontend/src/renderer/lib/session-presentation.test.ts
+++ b/frontend/src/renderer/lib/session-presentation.test.ts
@@ -13,6 +13,7 @@ import type { WorkspaceSession } from "../types/workspace";
 
 function sessionWith(overrides: Partial<WorkspaceSession>): WorkspaceSession {
 	return {
+		host: "local",
 		id: "sess-1",
 		workspaceId: "ws-1",
 		workspaceName: "my-app",

--- a/frontend/src/renderer/lib/session-reviews.test.ts
+++ b/frontend/src/renderer/lib/session-reviews.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { appI18n } from "../i18n";
+import { refKey } from "./hosts";
 import type { PullRequestFacts, WorkspaceSession } from "../types/workspace";
 import {
 	openReviewStatesFor,
@@ -12,6 +13,7 @@ import {
 
 function session(overrides: Partial<WorkspaceSession> = {}): WorkspaceSession {
 	return {
+		host: "local",
 		workspaceId: "proj-1",
 		workspaceName: "app",
 		title: "review work",
@@ -30,7 +32,7 @@ describe("sessionReviewsQueryOptions", () => {
 	it("owns the shared reviews query key", () => {
 		expect(sessionReviewsQueryOptions(session(), true).queryKey).toEqual([
 			"session-reviews",
-			"session-1",
+			refKey(session()),
 		]);
 	});
 

--- a/frontend/src/renderer/lib/session-reviews.ts
+++ b/frontend/src/renderer/lib/session-reviews.ts
@@ -2,7 +2,9 @@ import { queryOptions } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
 import { appI18n } from "../i18n";
 import { sortedPRs, type WorkspaceSession } from "../types/workspace";
-import { apiClient, apiErrorMessage } from "./api-client";
+import { apiErrorMessage } from "./api-client";
+import { clientFor } from "./host-clients";
+import { refKey } from "./hosts";
 import { usesPreviewWorkspaceData as usePreviewData } from "./preview-mode";
 
 export type PRReviewState = components["schemas"]["PRReviewState"];
@@ -17,7 +19,7 @@ export type ReviewRunFacts = components["schemas"]["ReviewRun"];
  */
 export function sessionReviewsQueryOptions(session: WorkspaceSession, enabled: boolean, staleTime?: number) {
 	return queryOptions({
-		queryKey: ["session-reviews", session.id] as const,
+		queryKey: ["session-reviews", refKey(session)] as const,
 		enabled,
 		...(staleTime !== undefined ? { staleTime } : {}),
 		refetchInterval: (query) => {
@@ -27,7 +29,7 @@ export function sessionReviewsQueryOptions(session: WorkspaceSession, enabled: b
 		},
 		queryFn: async () => {
 			if (usePreviewData) return mockReviewsResponse(session);
-			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/reviews", {
+			const { data, error } = await clientFor(session.host).GET("/api/v1/sessions/{sessionId}/reviews", {
 				params: { path: { sessionId: session.id } },
 			});
 			if (error) throw new Error(apiErrorMessage(error, "Unable to load reviews"));

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -4,7 +4,6 @@ import { isLoopbackHostname } from "./loopback";
 import { ORCHESTRATOR_SPAWN_SOURCES } from "./orchestrator-spawn-sources";
 import { DEFAULT_POSTHOG_HOST, DEFAULT_POSTHOG_PROJECT_KEY } from "../../shared/posthog-config";
 import { EDITOR_IDS } from "../../shared/editor-handoff";
-import { captureExceptionToSentry, initSentry } from "./sentry";
 
 const POSTHOG_KEY = import.meta.env.VITE_AO_POSTHOG_KEY?.trim() || DEFAULT_POSTHOG_PROJECT_KEY;
 const POSTHOG_HOST = import.meta.env.VITE_AO_POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST;
@@ -443,6 +442,24 @@ async function sanitizeRendererContextProperties(properties?: TelemetryPropertie
 
 const ORCHESTRATOR_SPAWN_SOURCE_SET = new Set<string>(ORCHESTRATOR_SPAWN_SOURCES);
 
+/**
+ * Host identity for the ao.renderer.host_* events.
+ *
+ * A host id IS a LAN address — "http://192.168.1.250:3011" — so it is never
+ * sent. Only its digest goes out, exactly as project ids do, which keeps hosts
+ * countable without naming a machine. `host_kind` stays in the clear because
+ * "the local daemon's stream dropped" and "a remote's did" are different bugs.
+ */
+async function sanitizeHostProperties(properties?: TelemetryProperties): Promise<TelemetryProperties> {
+	const safe: TelemetryProperties = {};
+	const hostIDHash = await hashedTelemetryID(properties?.host_id);
+	if (hostIDHash) safe.host_id_hash = hostIDHash;
+	if (properties?.host_kind === "local" || properties?.host_kind === "remote") {
+		safe.host_kind = properties.host_kind;
+	}
+	return safe;
+}
+
 const EDITOR_ID_SET = new Set<string>(EDITOR_IDS);
 const OPEN_TARGET_KIND_SET = new Set(["editor", "file_manager", "terminal"]);
 
@@ -592,6 +609,22 @@ export async function sanitizeRendererProperties(
 			}
 			if (properties?.outcome === "succeeded" || properties?.outcome === "failed") safe.outcome = properties.outcome;
 			break;
+		case "ao.renderer.host_stream_state": {
+			// An event with no case here emits with every property stripped, so the
+			// allowlist is what makes this signal exist at all.
+			Object.assign(safe, await sanitizeHostProperties(properties));
+			if (properties?.state === "connected" || properties?.state === "disconnected") safe.state = properties.state;
+			if (typeof properties?.reconnect_count === "number") safe.reconnect_count = properties.reconnect_count;
+			break;
+		}
+		case "ao.renderer.host_query_failed": {
+			// The failure message is deliberately absent: it is the daemon's own
+			// error text and can carry paths. A status separates a rotated
+			// password (401) from a host the proxy cannot reach (502).
+			Object.assign(safe, await sanitizeHostProperties(properties));
+			if (typeof properties?.status === "number") safe.status = properties.status;
+			break;
+		}
 		case "ao.renderer.review_auto_review_toggled":
 			// The session-scoped switch duplicates a project-level setting, so
 			// whether anyone reaches for it decides if it stays a separate control.
@@ -691,19 +724,15 @@ export async function initTelemetry(): Promise<boolean> {
 		// unpackaged build that has not opted in. The client is never created.
 		if (!bootstrap) return false;
 		disabledEventMatchers = bootstrap.disabledEvents ?? [];
-		const channel = releaseChannelFrom(await readUpdateSettingsForTelemetry());
-		telemetryContext = buildTelemetryContext(bootstrap.appVersion, bootstrap.platform, channel);
+		telemetryContext = buildTelemetryContext(
+			bootstrap.appVersion,
+			bootstrap.platform,
+			releaseChannelFrom(await readUpdateSettingsForTelemetry()),
+		);
 		posthog.init(POSTHOG_KEY, buildPostHogConfig(bootstrap.distinctId));
 		posthog.register({
 			...telemetryContext,
 			surface: "renderer",
-		});
-		// Same consent gate as PostHog. No-op unless VITE_AO_SENTRY_DSN is set.
-		void initSentry({
-			release: bootstrap.appVersion,
-			channel,
-			platform: bootstrap.platform,
-			distinctId: bootstrap.distinctId,
 		});
 		bindErrorHandlers();
 		startDailyActiveHeartbeat({
@@ -771,14 +800,6 @@ export async function captureRendererException(error: unknown, properties?: Reco
 	if (!(await initTelemetry())) return;
 	const safeProperties = withTelemetryContext(await sanitizeRendererExceptionProperties(error, properties));
 	posthog.captureException(normalizeException(error), safeProperties);
-	// Mirror into Sentry (no-op unless a DSN is configured). Source drives the
-	// category so a boundary crash classifies as render_crash.
-	const source = typeof properties?.source === "string" ? properties.source : undefined;
-	captureExceptionToSentry(normalizeException(error), {
-		category: source === "react-error-boundary" ? "render_crash" : undefined,
-		operation: typeof properties?.operation === "string" ? properties.operation : undefined,
-		unhandled: properties?.unhandled === true,
-	});
 }
 
 export async function addRendererExceptionStep(message: string, properties?: Record<string, unknown>): Promise<void> {

--- a/frontend/src/renderer/lib/terminal-mux.test.ts
+++ b/frontend/src/renderer/lib/terminal-mux.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { setApiBaseUrl } from "./api-client";
+import { forgetHost, registerHostBase } from "./host-clients";
+import { LOCAL_HOST } from "./hosts";
 import {
 	base64ToBytes,
 	bytesToBase64,
@@ -7,9 +10,75 @@ import {
 	createTerminalMuxPool,
 	dataFrame,
 	muxUrlFromApiBase,
+	muxUrlForHost,
 	openFrame,
 	resizeFrame,
+	type TerminalMux,
 } from "./terminal-mux";
+
+const REMOTE_HOST = "http://192.0.2.1:3011";
+
+function fakeMux(onDispose: () => void = () => undefined): TerminalMux {
+	return {
+		open: () => undefined,
+		sendInput: () => undefined,
+		resize: () => undefined,
+		close: () => undefined,
+		onData: () => () => undefined,
+		onExit: () => () => undefined,
+		onOpened: () => () => undefined,
+		onError: () => () => undefined,
+		onConnectionChange: () => () => undefined,
+		dispose: onDispose,
+	};
+}
+
+describe("mux across hosts", () => {
+	afterEach(() => {
+		forgetHost(REMOTE_HOST);
+		setApiBaseUrl("http://127.0.0.1:3001");
+	});
+
+	it("builds each host's mux url from that host's base", () => {
+		registerHostBase(REMOTE_HOST, "http://127.0.0.1:9999/tok");
+		setApiBaseUrl("http://127.0.0.1:3001");
+
+		expect(muxUrlForHost(LOCAL_HOST)).toBe("ws://127.0.0.1:3001/mux");
+		expect(muxUrlForHost(REMOTE_HOST)).toBe("ws://127.0.0.1:9999/tok/mux");
+	});
+
+	it("keeps one live socket per host, not one globally", () => {
+		const made: string[] = [];
+		const pool = createTerminalMuxPool((host) => {
+			made.push(host);
+			return fakeMux();
+		});
+		const local = pool.acquire(LOCAL_HOST);
+		const remote = pool.acquire(REMOTE_HOST);
+		const secondLocal = pool.acquire(LOCAL_HOST);
+
+		expect(made).toEqual([LOCAL_HOST, REMOTE_HOST]);
+
+		local.dispose();
+		remote.dispose();
+		secondLocal.dispose();
+	});
+
+	it("closing one host's mux leaves the other open", () => {
+		const closed: string[] = [];
+		const pool = createTerminalMuxPool((host) => fakeMux(() => closed.push(host)));
+		const local = pool.acquire(LOCAL_HOST);
+		const remote = pool.acquire(REMOTE_HOST);
+		const secondLocal = pool.acquire(LOCAL_HOST);
+
+		remote.dispose();
+		expect(closed).toEqual([REMOTE_HOST]);
+		local.dispose();
+		expect(closed).toEqual([REMOTE_HOST]);
+		secondLocal.dispose();
+		expect(closed).toEqual([REMOTE_HOST, LOCAL_HOST]);
+	});
+});
 
 describe("terminal-mux framing", () => {
 	it("round-trips arbitrary (non-UTF8) bytes through base64", () => {

--- a/frontend/src/renderer/lib/terminal-mux.ts
+++ b/frontend/src/renderer/lib/terminal-mux.ts
@@ -13,6 +13,9 @@
 // The renderer connects directly to the loopback daemon (same host/port as the
 // REST API, path `/mux`); it is not proxied through the Electron main process.
 
+import { baseUrlFor } from "./host-clients";
+import { LOCAL_HOST, type HostId } from "./hosts";
+
 type ServerFrame = {
 	ch: string;
 	id?: string;
@@ -83,6 +86,13 @@ export function muxUrlFromApiBase(apiBaseUrl: string): string {
 	return `${ws.replace(/\/+$/, "")}/mux`;
 }
 
+// A remote host's base is the loopback proxy's `http://127.0.0.1:<port>/<token>/`,
+// so the prefix has to survive: dropping it sends the socket to a 404 and,
+// worse, drops the token the proxy authenticates on.
+export function muxUrlForHost(host: HostId): string {
+	return muxUrlFromApiBase(baseUrlFor(host) ?? "");
+}
+
 type DataListener = (bytes: Uint8Array) => void;
 type ExitListener = () => void;
 type OpenedListener = () => void;
@@ -118,10 +128,10 @@ export type TerminalMux = {
 export type TerminalMuxPool = {
 	/**
 	 * Acquire an independently disposable attachment lease over the shared
-	 * browser-to-daemon mux socket.
+	 * browser-to-daemon mux socket for one host.
 	 */
-	acquire: () => TerminalMux;
-	/** Release the current shared socket and every listener (the pool stays reusable). */
+	acquire: (host?: HostId) => TerminalMux;
+	/** Release every shared socket and listener (the pool stays reusable). */
 	dispose: () => void;
 };
 
@@ -262,41 +272,43 @@ export function createTerminalMux(url: string, WebSocketImpl: typeof WebSocket =
 }
 
 /**
- * Share the mux transport without sharing attachment ownership.
+ * Share each host's mux transport without sharing attachment ownership.
  *
  * The daemon protocol already multiplexes frames by terminal id. A lease keeps
  * listener and cleanup ownership local to one useTerminalSession instance while
- * avoiding one WebSocket and ping timer per retained xterm. The last lease
- * closes the underlying client. A socket-level failure retires that client so
- * reconnecting leases converge on one replacement socket.
+ * avoiding one WebSocket and ping timer per retained xterm. A host's last lease
+ * closes its underlying client. A socket-level failure retires that client so
+ * reconnecting leases for that host converge on one replacement socket.
  */
-export function createTerminalMuxPool(createMux: () => TerminalMux): TerminalMuxPool {
+export function createTerminalMuxPool(createMux: (host: HostId) => TerminalMux): TerminalMuxPool {
 	type Connection = {
 		closed: boolean;
 		disposed: boolean;
+		host: HostId;
 		mux: TerminalMux;
 		refs: number;
 		unsubscribeState: () => void;
 	};
 
 	const connections = new Set<Connection>();
-	let current: Connection | null = null;
+	const current = new Map<HostId, Connection>();
 
 	const disposeConnection = (connection: Connection) => {
 		if (connection.disposed) return;
 		connection.disposed = true;
 		connection.closed = true;
-		if (current === connection) current = null;
+		if (current.get(connection.host) === connection) current.delete(connection.host);
 		connections.delete(connection);
 		connection.unsubscribeState();
 		connection.mux.dispose();
 	};
 
-	const newConnection = (): Connection => {
-		const mux = createMux();
+	const newConnection = (host: HostId): Connection => {
+		const mux = createMux(host);
 		const connection: Connection = {
 			closed: false,
 			disposed: false,
+			host,
 			mux,
 			refs: 0,
 			unsubscribeState: () => undefined,
@@ -304,16 +316,17 @@ export function createTerminalMuxPool(createMux: () => TerminalMux): TerminalMux
 		connection.unsubscribeState = mux.onConnectionChange((state) => {
 			if (state !== "closed") return;
 			connection.closed = true;
-			if (current === connection) current = null;
+			if (current.get(host) === connection) current.delete(host);
 			if (connection.refs === 0) disposeConnection(connection);
 		});
 		connections.add(connection);
-		current = connection;
+		current.set(host, connection);
 		return connection;
 	};
 
-	const acquire = (): TerminalMux => {
-		const connection = current && !current.closed && !current.disposed ? current : newConnection();
+	const acquire = (host: HostId = LOCAL_HOST): TerminalMux => {
+		const existing = current.get(host);
+		const connection = existing && !existing.closed && !existing.disposed ? existing : newConnection(host);
 		connection.refs += 1;
 		let released = false;
 		const subscriptions = new Set<() => void>();
@@ -367,7 +380,7 @@ export function createTerminalMuxPool(createMux: () => TerminalMux): TerminalMux
 	return {
 		acquire,
 		dispose: () => {
-			current = null;
+			current.clear();
 			for (const connection of [...connections]) disposeConnection(connection);
 		},
 	};

--- a/frontend/src/renderer/lib/workspace-file-events.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.test.ts
@@ -1,23 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getApiBaseUrlMock, hasTrustedApiBaseUrlMock, subscribeApiBaseUrlMock, unsubscribeBaseUrlMock } = vi.hoisted(
+const { baseUrlForMock, subscribeApiBaseUrlMock, subscribeConnectedHostsMock, unsubscribeBaseUrlMock } = vi.hoisted(
 	() => ({
-		getApiBaseUrlMock: vi.fn(() => "http://127.0.0.1:3001"),
-		hasTrustedApiBaseUrlMock: vi.fn(() => true),
+		baseUrlForMock: vi.fn(() => "http://127.0.0.1:3001"),
 		subscribeApiBaseUrlMock: vi.fn(),
+		subscribeConnectedHostsMock: vi.fn(),
 		unsubscribeBaseUrlMock: vi.fn(),
 	}),
 );
 
-vi.mock("./api-client", () => ({
-	getApiBaseUrl: getApiBaseUrlMock,
-	hasTrustedApiBaseUrl: hasTrustedApiBaseUrlMock,
-	subscribeApiBaseUrl: subscribeApiBaseUrlMock,
+vi.mock("./api-client", () => ({ subscribeApiBaseUrl: subscribeApiBaseUrlMock }));
+vi.mock("./host-clients", () => ({
+	baseUrlFor: baseUrlForMock,
+	subscribeConnectedHosts: subscribeConnectedHostsMock,
 }));
 
 import { getWorkspaceFileConnectionState, subscribeWorkspaceFileChanges } from "./workspace-file-events";
 
 let baseUrlListener: (() => void) | undefined;
+
+const session = (id: string) => ({ host: "local", id });
 
 class EventSourceStub {
 	static instances: EventSourceStub[] = [];
@@ -62,12 +64,12 @@ beforeEach(() => {
 	EventSourceStub.instances = [];
 	EventSourceStub.throwNext = false;
 	baseUrlListener = undefined;
-	getApiBaseUrlMock.mockReset().mockReturnValue("http://127.0.0.1:3001");
-	hasTrustedApiBaseUrlMock.mockReset().mockReturnValue(true);
+	baseUrlForMock.mockReset().mockReturnValue("http://127.0.0.1:3001");
 	subscribeApiBaseUrlMock.mockReset().mockImplementation((listener: () => void) => {
 		baseUrlListener = listener;
 		return unsubscribeBaseUrlMock;
 	});
+	subscribeConnectedHostsMock.mockReset().mockReturnValue(unsubscribeBaseUrlMock);
 	unsubscribeBaseUrlMock.mockReset();
 	(globalThis as unknown as { EventSource: unknown }).EventSource = EventSourceStub;
 });
@@ -81,8 +83,8 @@ afterEach(() => {
 describe("subscribeWorkspaceFileChanges", () => {
 	it("shares one daemon stream until the final Files view unmounts", () => {
 		const queryClient = fakeQueryClient();
-		const unsubscribeRail = subscribeWorkspaceFileChanges("session/a", queryClient);
-		const unsubscribeMaximized = subscribeWorkspaceFileChanges("session/a", queryClient);
+		const unsubscribeRail = subscribeWorkspaceFileChanges(session("session/a"), queryClient);
+		const unsubscribeMaximized = subscribeWorkspaceFileChanges(session("session/a"), queryClient);
 
 		expect(EventSourceStub.instances).toHaveLength(1);
 		expect(EventSourceStub.instances[0].url).toBe(
@@ -99,7 +101,7 @@ describe("subscribeWorkspaceFileChanges", () => {
 	it("coalesces filesystem events and invalidates the list plus visible details", () => {
 		vi.useFakeTimers();
 		const queryClient = fakeQueryClient();
-		const unsubscribe = subscribeWorkspaceFileChanges("sess-1", queryClient);
+		const unsubscribe = subscribeWorkspaceFileChanges(session("sess-1"), queryClient);
 		const source = EventSourceStub.instances[0];
 
 		source.dispatch("workspace_changed");
@@ -109,9 +111,9 @@ describe("subscribeWorkspaceFileChanges", () => {
 		vi.advanceTimersByTime(1);
 
 		expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(3);
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-files", "sess-1"] });
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-file", "sess-1"] });
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-tree", "sess-1"] });
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-files", "local:sess-1"] });
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-file", "local:sess-1"] });
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-tree", "local:sess-1"] });
 		unsubscribe();
 	});
 
@@ -119,7 +121,7 @@ describe("subscribeWorkspaceFileChanges", () => {
 		vi.useFakeTimers();
 		vi.spyOn(Math, "random").mockReturnValue(0.5);
 		EventSourceStub.throwNext = true;
-		const unsubscribe = subscribeWorkspaceFileChanges("sess-retry", fakeQueryClient());
+		const unsubscribe = subscribeWorkspaceFileChanges(session("sess-retry"), fakeQueryClient());
 
 		expect(EventSourceStub.instances).toHaveLength(0);
 		baseUrlListener?.();
@@ -135,7 +137,7 @@ describe("subscribeWorkspaceFileChanges", () => {
 	it("reports degraded after three completed connection failures", () => {
 		vi.useFakeTimers();
 		vi.spyOn(Math, "random").mockReturnValue(0.5);
-		const unsubscribe = subscribeWorkspaceFileChanges("sess-degraded", fakeQueryClient());
+		const unsubscribe = subscribeWorkspaceFileChanges(session("sess-degraded"), fakeQueryClient());
 
 		for (let failure = 0; failure < 3; failure += 1) {
 			const source = EventSourceStub.instances.at(-1)!;
@@ -144,34 +146,49 @@ describe("subscribeWorkspaceFileChanges", () => {
 			if (failure < 2) vi.advanceTimersByTime(5_000);
 		}
 
-		expect(getWorkspaceFileConnectionState("sess-degraded")).toBe("degraded");
+		expect(getWorkspaceFileConnectionState(session("sess-degraded"))).toBe("degraded");
 		unsubscribe();
 	});
 
 	it("degrades after repeated native reconnect failures and recovers on open", () => {
-		const unsubscribe = subscribeWorkspaceFileChanges("sess-native-retry", fakeQueryClient());
+		const unsubscribe = subscribeWorkspaceFileChanges(session("sess-native-retry"), fakeQueryClient());
 		const source = EventSourceStub.instances[0];
 
 		source.onopen?.();
-		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connected");
+		expect(getWorkspaceFileConnectionState(session("sess-native-retry"))).toBe("connected");
 
 		source.readyState = 0;
 		for (let failure = 0; failure < 3; failure += 1) {
 			source.onerror?.();
-			expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe(failure < 2 ? "connecting" : "degraded");
+			expect(getWorkspaceFileConnectionState(session("sess-native-retry"))).toBe(failure < 2 ? "connecting" : "degraded");
 		}
 
 		source.onopen?.();
-		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connected");
+		expect(getWorkspaceFileConnectionState(session("sess-native-retry"))).toBe("connected");
+		unsubscribe();
+	});
+
+	it("uses a remote host's proxy base and distinct cache key", () => {
+		baseUrlForMock.mockImplementation((...args: unknown[]) =>
+			args[0] === "https://remote.example" ? "http://127.0.0.1:43123" : "http://127.0.0.1:3001",
+		);
+		const remote = { host: "https://remote.example", id: "sess-1" };
+		const unsubscribe = subscribeWorkspaceFileChanges(remote, fakeQueryClient());
+
+		expect(EventSourceStub.instances[0].url).toBe(
+			"http://127.0.0.1:43123/api/v1/sessions/sess-1/workspace/events",
+		);
+		expect(subscribeApiBaseUrlMock).not.toHaveBeenCalled();
+		expect(subscribeConnectedHostsMock).toHaveBeenCalledTimes(1);
 		unsubscribe();
 	});
 
 	it("uses degraded polling when EventSource is unavailable", () => {
 		delete (globalThis as unknown as { EventSource?: unknown }).EventSource;
 
-		const unsubscribe = subscribeWorkspaceFileChanges("sess-no-eventsource", fakeQueryClient());
+		const unsubscribe = subscribeWorkspaceFileChanges(session("sess-no-eventsource"), fakeQueryClient());
 
-		expect(getWorkspaceFileConnectionState("sess-no-eventsource")).toBe("degraded");
+		expect(getWorkspaceFileConnectionState(session("sess-no-eventsource"))).toBe("degraded");
 		unsubscribe();
 	});
 });

--- a/frontend/src/renderer/lib/workspace-file-events.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.ts
@@ -1,5 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { getApiBaseUrl, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "./api-client";
+import { subscribeApiBaseUrl } from "./api-client";
+import { baseUrlFor, subscribeConnectedHosts } from "./host-clients";
+import { isLocal, refKey, type Ref } from "./hosts";
 
 const INVALIDATE_DEBOUNCE_MS = 150;
 const SSE_RETRY_MS = 5_000;
@@ -28,60 +30,67 @@ const streams = new Map<string, WorkspaceStream>();
 const connectionStates = new Map<string, WorkspaceFileConnectionState>();
 const connectionStateListeners = new Map<string, Set<() => void>>();
 
-export function getWorkspaceFileConnectionState(sessionId: string): WorkspaceFileConnectionState {
-	return connectionStates.get(sessionId) ?? "connecting";
+export function getWorkspaceFileConnectionState(session: Ref): WorkspaceFileConnectionState {
+	return connectionStates.get(refKey(session)) ?? "connecting";
 }
 
-export function subscribeWorkspaceFileConnectionState(sessionId: string, listener: () => void): () => void {
-	let listeners = connectionStateListeners.get(sessionId);
+export function subscribeWorkspaceFileConnectionState(session: Ref, listener: () => void): () => void {
+	const sessionKey = refKey(session);
+	let listeners = connectionStateListeners.get(sessionKey);
 	if (!listeners) {
 		listeners = new Set();
-		connectionStateListeners.set(sessionId, listeners);
+		connectionStateListeners.set(sessionKey, listeners);
 	}
 	listeners.add(listener);
 	return () => {
 		listeners?.delete(listener);
-		if (listeners?.size === 0) connectionStateListeners.delete(sessionId);
-		if (!streams.has(sessionId) && !connectionStateListeners.has(sessionId)) connectionStates.delete(sessionId);
+		if (listeners?.size === 0) connectionStateListeners.delete(sessionKey);
+		if (!streams.has(sessionKey) && !connectionStateListeners.has(sessionKey)) connectionStates.delete(sessionKey);
 	};
 }
 
-function setWorkspaceFileConnectionState(sessionId: string, next: WorkspaceFileConnectionState): void {
-	if (connectionStates.get(sessionId) === next) return;
-	connectionStates.set(sessionId, next);
-	connectionStateListeners.get(sessionId)?.forEach((listener) => listener());
+function setWorkspaceFileConnectionState(sessionKey: string, next: WorkspaceFileConnectionState): void {
+	if (connectionStates.get(sessionKey) === next) return;
+	connectionStates.set(sessionKey, next);
+	connectionStateListeners.get(sessionKey)?.forEach((listener) => listener());
 }
 
 // Shares one daemon watcher between the rail and maximized copies of a Files
 // view. The daemon sends only invalidation edges; Git status and visible diffs
 // are then refetched through the existing typed queries.
-export function subscribeWorkspaceFileChanges(sessionId: string, queryClient: QueryClient): () => void {
-	let stream = streams.get(sessionId);
+export function subscribeWorkspaceFileChanges(session: Ref, queryClient: QueryClient): () => void {
+	const sessionKey = refKey(session);
+	let stream = streams.get(sessionKey);
 	if (!stream) {
-		stream = createWorkspaceStream(sessionId, queryClient);
-		streams.set(sessionId, stream);
+		stream = createWorkspaceStream(session, queryClient);
+		streams.set(sessionKey, stream);
 	}
 	stream.refs += 1;
 
 	return () => {
-		const current = streams.get(sessionId);
+		const current = streams.get(sessionKey);
 		if (!current) return;
 		current.refs -= 1;
 		if (current.refs > 0) return;
 		current.dispose();
-		streams.delete(sessionId);
-		if (!connectionStateListeners.has(sessionId)) connectionStates.delete(sessionId);
+		streams.delete(sessionKey);
+		if (!connectionStateListeners.has(sessionKey)) connectionStates.delete(sessionKey);
 	};
 }
 
-function createWorkspaceStream(sessionId: string, queryClient: QueryClient): WorkspaceStream {
+function subscribeHostBase(session: Ref, listener: () => void): () => void {
+	return isLocal(session.host) ? subscribeApiBaseUrl(listener) : subscribeConnectedHosts(listener);
+}
+
+function createWorkspaceStream(session: Ref, queryClient: QueryClient): WorkspaceStream {
+	const sessionKey = refKey(session);
 	const stream = {} as WorkspaceStream;
 	const invalidate = () => {
 		if (stream.debounce) clearTimeout(stream.debounce);
 		stream.debounce = setTimeout(() => {
-			void queryClient.invalidateQueries({ queryKey: ["session-workspace-files", sessionId] });
-			void queryClient.invalidateQueries({ queryKey: ["session-workspace-file", sessionId] });
-			void queryClient.invalidateQueries({ queryKey: ["session-workspace-tree", sessionId] });
+			void queryClient.invalidateQueries({ queryKey: ["session-workspace-files", sessionKey] });
+			void queryClient.invalidateQueries({ queryKey: ["session-workspace-file", sessionKey] });
+			void queryClient.invalidateQueries({ queryKey: ["session-workspace-tree", sessionKey] });
 		}, INVALIDATE_DEBOUNCE_MS);
 	};
 	const scheduleRetry = (generation: number) => {
@@ -109,7 +118,7 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 		stream.source?.close();
 		stream.source = undefined;
 		stream.failures += 1;
-		setWorkspaceFileConnectionState(sessionId, stream.failures >= 3 ? "degraded" : "connecting");
+		setWorkspaceFileConnectionState(sessionKey, stream.failures >= 3 ? "degraded" : "connecting");
 		scheduleRetry(generation);
 	};
 	stream.refs = 0;
@@ -117,23 +126,24 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 	stream.phase = "idle";
 	stream.generation = 0;
 	stream.failures = 0;
-	setWorkspaceFileConnectionState(sessionId, "connecting");
+	setWorkspaceFileConnectionState(sessionKey, "connecting");
 	stream.ensureConnected = () => {
 		if (stream.disposed) return;
 		if (typeof EventSource === "undefined") {
-			setWorkspaceFileConnectionState(sessionId, "degraded");
+			setWorkspaceFileConnectionState(sessionKey, "degraded");
 			return;
 		}
-		if (!hasTrustedApiBaseUrl()) {
+		if (baseUrlFor(session.host) === null) {
 			resetConnection();
-			setWorkspaceFileConnectionState(sessionId, "connecting");
+			setWorkspaceFileConnectionState(sessionKey, "connecting");
 			return;
 		}
-		const baseUrl = getApiBaseUrl();
+		const baseUrl = baseUrlFor(session.host);
+		if (baseUrl === null) return;
 		if (stream.sourceBaseUrl && stream.sourceBaseUrl !== baseUrl) {
 			resetConnection();
 			stream.failures = 0;
-			setWorkspaceFileConnectionState(sessionId, "connecting");
+			setWorkspaceFileConnectionState(sessionKey, "connecting");
 		}
 		if (stream.phase !== "idle") return;
 
@@ -142,14 +152,14 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 		const generation = ++stream.generation;
 		try {
 			const source = new EventSource(
-				`${baseUrl.replace(/\/+$/, "")}/api/v1/sessions/${encodeURIComponent(sessionId)}/workspace/events`,
+				`${baseUrl.replace(/\/+$/, "")}/api/v1/sessions/${encodeURIComponent(session.id)}/workspace/events`,
 			);
 			stream.source = source;
 			source.onopen = () => {
 				if (stream.disposed || generation !== stream.generation || stream.source !== source) return;
 				stream.phase = "open";
 				stream.failures = 0;
-				setWorkspaceFileConnectionState(sessionId, "connected");
+				setWorkspaceFileConnectionState(sessionKey, "connected");
 				invalidate();
 			};
 			source.onerror = () => {
@@ -159,7 +169,7 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 					return;
 				}
 				stream.failures += 1;
-				setWorkspaceFileConnectionState(sessionId, stream.failures >= 3 ? "degraded" : "connecting");
+				setWorkspaceFileConnectionState(sessionKey, stream.failures >= 3 ? "degraded" : "connecting");
 			};
 			source.addEventListener("workspace_changed", () => {
 				if (!stream.disposed && generation === stream.generation && stream.source === source) invalidate();
@@ -169,7 +179,7 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 			handleTerminalFailure(generation);
 		}
 	};
-	stream.disconnectBaseUrl = subscribeApiBaseUrl(stream.ensureConnected);
+	stream.disconnectBaseUrl = subscribeHostBase(session, stream.ensureConnected);
 	stream.dispose = () => {
 		stream.disposed = true;
 		if (stream.debounce) clearTimeout(stream.debounce);

--- a/frontend/src/renderer/main.tsx
+++ b/frontend/src/renderer/main.tsx
@@ -17,6 +17,7 @@ import { startUpdateTelemetry } from "./lib/update-telemetry";
 import { appI18n } from "./i18n";
 import { useLocaleStore } from "./stores/locale-store";
 import { useSoundNotificationsStore } from "./stores/sound-notifications-store";
+import { initHosts } from "./lib/active-host";
 
 const router = createAppRouter(queryClient);
 
@@ -91,6 +92,11 @@ async function renderApp(): Promise<void> {
 			</I18nextProvider>
 		</React.StrictMode>,
 	);
+	// Saved hosts are additive. A bad credential file or sleeping machine must
+	// never block local first paint; the reactive host registry adds each proxy
+	// to the workspace fan-out as it connects. Inert while the Remote hosts
+	// flag is off.
+	void initHosts();
 }
 
 void renderApp();

--- a/frontend/src/renderer/routeTree.gen.ts
+++ b/frontend/src/renderer/routeTree.gen.ts
@@ -17,6 +17,9 @@ import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.proj
 import { Route as ShellSessionsSessionIdRouteImport } from './routes/_shell.sessions.$sessionId'
 import { Route as ShellProjectsProjectIdSettingsRouteImport } from './routes/_shell.projects.$projectId_.settings'
 import { Route as ShellProjectsProjectIdSessionsSessionIdRouteImport } from './routes/_shell.projects.$projectId_.sessions.$sessionId'
+import { Route as ShellHostHostIdSessionSessionIdRouteImport } from './routes/_shell.host.$hostId.session.$sessionId'
+import { Route as ShellHostHostIdProjectProjectIdRouteImport } from './routes/_shell.host.$hostId.project.$projectId'
+import { Route as ShellHostHostIdProjectProjectIdSettingsRouteImport } from './routes/_shell.host.$hostId.project.$projectId_.settings'
 
 const ShellRoute = ShellRouteImport.update({
   id: '/_shell',
@@ -59,6 +62,24 @@ const ShellProjectsProjectIdSessionsSessionIdRoute =
     path: '/projects/$projectId/sessions/$sessionId',
     getParentRoute: () => ShellRoute,
   } as any)
+const ShellHostHostIdSessionSessionIdRoute =
+  ShellHostHostIdSessionSessionIdRouteImport.update({
+    id: '/host/$hostId/session/$sessionId',
+    path: '/host/$hostId/session/$sessionId',
+    getParentRoute: () => ShellRoute,
+  } as any)
+const ShellHostHostIdProjectProjectIdRoute =
+  ShellHostHostIdProjectProjectIdRouteImport.update({
+    id: '/host/$hostId/project/$projectId',
+    path: '/host/$hostId/project/$projectId',
+    getParentRoute: () => ShellRoute,
+  } as any)
+const ShellHostHostIdProjectProjectIdSettingsRoute =
+  ShellHostHostIdProjectProjectIdSettingsRouteImport.update({
+    id: '/host/$hostId/project/$projectId_/settings',
+    path: '/host/$hostId/project/$projectId/settings',
+    getParentRoute: () => ShellRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof ShellIndexRoute
@@ -67,7 +88,10 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId': typeof ShellProjectsProjectIdRoute
   '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
   '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
+  '/host/$hostId/project/$projectId': typeof ShellHostHostIdProjectProjectIdRoute
+  '/host/$hostId/session/$sessionId': typeof ShellHostHostIdSessionSessionIdRoute
   '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
+  '/host/$hostId/project/$projectId/settings': typeof ShellHostHostIdProjectProjectIdSettingsRoute
 }
 export interface FileRoutesByTo {
   '/settings': typeof ShellSettingsRoute
@@ -76,7 +100,10 @@ export interface FileRoutesByTo {
   '/projects/$projectId': typeof ShellProjectsProjectIdRoute
   '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
   '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
+  '/host/$hostId/project/$projectId': typeof ShellHostHostIdProjectProjectIdRoute
+  '/host/$hostId/session/$sessionId': typeof ShellHostHostIdSessionSessionIdRoute
   '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
+  '/host/$hostId/project/$projectId/settings': typeof ShellHostHostIdProjectProjectIdSettingsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -87,7 +114,10 @@ export interface FileRoutesById {
   '/_shell/projects/$projectId': typeof ShellProjectsProjectIdRoute
   '/_shell/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
   '/_shell/projects/$projectId_/settings': typeof ShellProjectsProjectIdSettingsRoute
+  '/_shell/host/$hostId/project/$projectId': typeof ShellHostHostIdProjectProjectIdRoute
+  '/_shell/host/$hostId/session/$sessionId': typeof ShellHostHostIdSessionSessionIdRoute
   '/_shell/projects/$projectId_/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
+  '/_shell/host/$hostId/project/$projectId_/settings': typeof ShellHostHostIdProjectProjectIdSettingsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -98,7 +128,10 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/sessions/$sessionId'
     | '/projects/$projectId/settings'
+    | '/host/$hostId/project/$projectId'
+    | '/host/$hostId/session/$sessionId'
     | '/projects/$projectId/sessions/$sessionId'
+    | '/host/$hostId/project/$projectId/settings'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/settings'
@@ -107,7 +140,10 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/sessions/$sessionId'
     | '/projects/$projectId/settings'
+    | '/host/$hostId/project/$projectId'
+    | '/host/$hostId/session/$sessionId'
     | '/projects/$projectId/sessions/$sessionId'
+    | '/host/$hostId/project/$projectId/settings'
   id:
     | '__root__'
     | '/_shell'
@@ -117,7 +153,10 @@ export interface FileRouteTypes {
     | '/_shell/projects/$projectId'
     | '/_shell/sessions/$sessionId'
     | '/_shell/projects/$projectId_/settings'
+    | '/_shell/host/$hostId/project/$projectId'
+    | '/_shell/host/$hostId/session/$sessionId'
     | '/_shell/projects/$projectId_/sessions/$sessionId'
+    | '/_shell/host/$hostId/project/$projectId_/settings'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -182,6 +221,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellProjectsProjectIdSessionsSessionIdRouteImport
       parentRoute: typeof ShellRoute
     }
+    '/_shell/host/$hostId/session/$sessionId': {
+      id: '/_shell/host/$hostId/session/$sessionId'
+      path: '/host/$hostId/session/$sessionId'
+      fullPath: '/host/$hostId/session/$sessionId'
+      preLoaderRoute: typeof ShellHostHostIdSessionSessionIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/host/$hostId/project/$projectId': {
+      id: '/_shell/host/$hostId/project/$projectId'
+      path: '/host/$hostId/project/$projectId'
+      fullPath: '/host/$hostId/project/$projectId'
+      preLoaderRoute: typeof ShellHostHostIdProjectProjectIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/host/$hostId/project/$projectId_/settings': {
+      id: '/_shell/host/$hostId/project/$projectId_/settings'
+      path: '/host/$hostId/project/$projectId/settings'
+      fullPath: '/host/$hostId/project/$projectId/settings'
+      preLoaderRoute: typeof ShellHostHostIdProjectProjectIdSettingsRouteImport
+      parentRoute: typeof ShellRoute
+    }
   }
 }
 
@@ -192,7 +252,10 @@ interface ShellRouteChildren {
   ShellProjectsProjectIdRoute: typeof ShellProjectsProjectIdRoute
   ShellSessionsSessionIdRoute: typeof ShellSessionsSessionIdRoute
   ShellProjectsProjectIdSettingsRoute: typeof ShellProjectsProjectIdSettingsRoute
+  ShellHostHostIdProjectProjectIdRoute: typeof ShellHostHostIdProjectProjectIdRoute
+  ShellHostHostIdSessionSessionIdRoute: typeof ShellHostHostIdSessionSessionIdRoute
   ShellProjectsProjectIdSessionsSessionIdRoute: typeof ShellProjectsProjectIdSessionsSessionIdRoute
+  ShellHostHostIdProjectProjectIdSettingsRoute: typeof ShellHostHostIdProjectProjectIdSettingsRoute
 }
 
 const ShellRouteChildren: ShellRouteChildren = {
@@ -202,8 +265,12 @@ const ShellRouteChildren: ShellRouteChildren = {
   ShellProjectsProjectIdRoute: ShellProjectsProjectIdRoute,
   ShellSessionsSessionIdRoute: ShellSessionsSessionIdRoute,
   ShellProjectsProjectIdSettingsRoute: ShellProjectsProjectIdSettingsRoute,
+  ShellHostHostIdProjectProjectIdRoute: ShellHostHostIdProjectProjectIdRoute,
+  ShellHostHostIdSessionSessionIdRoute: ShellHostHostIdSessionSessionIdRoute,
   ShellProjectsProjectIdSessionsSessionIdRoute:
     ShellProjectsProjectIdSessionsSessionIdRoute,
+  ShellHostHostIdProjectProjectIdSettingsRoute:
+    ShellHostHostIdProjectProjectIdSettingsRoute,
 }
 
 const ShellRouteWithChildren = ShellRoute._addFileChildren(ShellRouteChildren)

--- a/frontend/src/renderer/routes/-session-route.test.ts
+++ b/frontend/src/renderer/routes/-session-route.test.ts
@@ -1,0 +1,65 @@
+import { QueryClient } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter } from "@tanstack/react-router";
+import { describe, expect, it } from "vitest";
+import { LOCAL_HOST } from "../lib/hosts";
+import { routeTree } from "../routeTree.gen";
+
+describe("host-qualified session route", () => {
+	it("restores the session on the host encoded in the URL", async () => {
+		const hostId = "http://192.0.2.1:3011";
+		const sessionId = "same:id";
+		const history = createMemoryHistory({
+			initialEntries: [`/host/${encodeURIComponent(hostId)}/session/${encodeURIComponent(sessionId)}`],
+		});
+		const router = createRouter({
+			history,
+			routeTree,
+			context: { queryClient: new QueryClient() },
+		});
+
+		await router.load();
+
+		expect(router.state.matches.at(-1)?.params).toMatchObject({ hostId, sessionId });
+	});
+
+	it("restores the project on the host encoded in the URL", async () => {
+		const hostId = "http://192.0.2.1:3011";
+		const projectId = "same:id";
+		const history = createMemoryHistory({
+			initialEntries: [`/host/${encodeURIComponent(hostId)}/project/${encodeURIComponent(projectId)}`],
+		});
+		const router = createRouter({
+			history,
+			routeTree,
+			context: { queryClient: new QueryClient() },
+		});
+
+		await router.load();
+
+		expect(router.state.matches.at(-1)?.params).toMatchObject({ hostId, projectId });
+	});
+});
+
+// The four unqualified paths below are the shape every link, bookmark and
+// deep link minted before hosts existed still points at. They are kept as
+// redirects to the local host — the only host such a URL could have meant —
+// and nothing else in the tree covers them.
+describe("legacy routes redirect", () => {
+	it.each([
+		["/sessions/ao-1", { hostId: LOCAL_HOST, sessionId: "ao-1" }],
+		["/projects/agent-orchestrator", { hostId: LOCAL_HOST, projectId: "agent-orchestrator" }],
+		["/projects/agent-orchestrator/settings", { hostId: LOCAL_HOST, projectId: "agent-orchestrator" }],
+		["/projects/agent-orchestrator/sessions/ao-1", { hostId: LOCAL_HOST, sessionId: "ao-1" }],
+	])("%s lands on the local host's route", async (from, params) => {
+		const router = createRouter({
+			history: createMemoryHistory({ initialEntries: [from] }),
+			routeTree,
+			context: { queryClient: new QueryClient() },
+		});
+
+		await router.load();
+
+		expect(router.state.matches.at(-1)?.params).toMatchObject(params);
+		expect(router.state.location.pathname).toContain("/host/");
+	});
+});

--- a/frontend/src/renderer/routes/_shell.host.$hostId.project.$projectId.tsx
+++ b/frontend/src/renderer/routes/_shell.host.$hostId.project.$projectId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SessionsBoard } from "../components/SessionsBoard";
+
+export const Route = createFileRoute("/_shell/host/$hostId/project/$projectId")({
+	component: ProjectBoardRoute,
+});
+
+function ProjectBoardRoute() {
+	const { hostId, projectId } = Route.useParams();
+	return <SessionsBoard project={{ host: hostId, id: projectId }} />;
+}

--- a/frontend/src/renderer/routes/_shell.host.$hostId.project.$projectId_.settings.tsx
+++ b/frontend/src/renderer/routes/_shell.host.$hostId.project.$projectId_.settings.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { useUiStore } from "../stores/ui-store";
+
+export const Route = createFileRoute("/_shell/host/$hostId/project/$projectId_/settings")({
+	component: ProjectSettingsRoute,
+});
+
+// Deep-link shim: project settings is a modal. In-app openers call
+// openProjectSettings() directly; this route only handles cold loads.
+function ProjectSettingsRoute() {
+	const { hostId, projectId } = Route.useParams();
+	const navigate = useNavigate();
+	const openProjectSettings = useUiStore((state) => state.openProjectSettings);
+
+	useEffect(() => {
+		openProjectSettings({ host: hostId, id: projectId });
+		void navigate({
+			to: "/host/$hostId/project/$projectId",
+			params: { hostId, projectId },
+			replace: true,
+		});
+	}, [hostId, navigate, openProjectSettings, projectId]);
+
+	return null;
+}

--- a/frontend/src/renderer/routes/_shell.host.$hostId.session.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.host.$hostId.session.$sessionId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SessionView } from "../components/SessionView";
+
+export const Route = createFileRoute("/_shell/host/$hostId/session/$sessionId")({
+	component: HostSessionRoute,
+});
+
+function HostSessionRoute() {
+	const { hostId, sessionId } = Route.useParams();
+	return <SessionView sessionRef={{ host: hostId, id: sessionId }} />;
+}

--- a/frontend/src/renderer/routes/_shell.projects.$projectId.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId.tsx
@@ -1,11 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { SessionsBoard } from "../components/SessionsBoard";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { LOCAL_HOST } from "../lib/hosts";
 
+// See _shell.sessions.$sessionId.tsx: the old, unqualified project path is
+// kept as a redirect so existing links survive the move to /host/$hostId/….
 export const Route = createFileRoute("/_shell/projects/$projectId")({
-	component: ProjectBoardRoute,
+	beforeLoad: ({ params }) => {
+		throw redirect({
+			to: "/host/$hostId/project/$projectId",
+			params: { hostId: LOCAL_HOST, projectId: params.projectId },
+			replace: true,
+		});
+	},
 });
-
-function ProjectBoardRoute() {
-	const { projectId } = Route.useParams();
-	return <SessionsBoard projectId={projectId} />;
-}

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
@@ -1,11 +1,15 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { SessionView } from "../components/SessionView";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { LOCAL_HOST } from "../lib/hosts";
 
+// A session is addressed by host and id alone, so the old nested
+// project→session path has no host-qualified twin: it redirects to the
+// session itself, dropping the project segment it never needed.
 export const Route = createFileRoute("/_shell/projects/$projectId_/sessions/$sessionId")({
-	component: ProjectSessionRoute,
+	beforeLoad: ({ params }) => {
+		throw redirect({
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: LOCAL_HOST, sessionId: params.sessionId },
+			replace: true,
+		});
+	},
 });
-
-function ProjectSessionRoute() {
-	const { sessionId } = Route.useParams();
-	return <SessionView sessionId={sessionId} />;
-}

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.settings.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.settings.tsx
@@ -1,22 +1,12 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
-import { useUiStore } from "../stores/ui-store";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { LOCAL_HOST } from "../lib/hosts";
 
 export const Route = createFileRoute("/_shell/projects/$projectId_/settings")({
-	component: ProjectSettingsRoute,
+	beforeLoad: ({ params }) => {
+		throw redirect({
+			to: "/host/$hostId/project/$projectId/settings",
+			params: { hostId: LOCAL_HOST, projectId: params.projectId },
+			replace: true,
+		});
+	},
 });
-
-// Deep-link shim: project settings is a modal. In-app openers call
-// openProjectSettings() directly; this route only handles cold loads.
-function ProjectSettingsRoute() {
-	const { projectId } = Route.useParams();
-	const navigate = useNavigate();
-	const openProjectSettings = useUiStore((state) => state.openProjectSettings);
-
-	useEffect(() => {
-		openProjectSettings(projectId);
-		void navigate({ to: "/projects/$projectId", params: { projectId }, replace: true });
-	}, [navigate, openProjectSettings, projectId]);
-
-	return null;
-}

--- a/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
@@ -1,11 +1,15 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { SessionView } from "../components/SessionView";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { LOCAL_HOST } from "../lib/hosts";
 
+// Sessions became host-qualified. Every link, bookmark and deep link minted
+// before that points here, so this path keeps working and resolves to the
+// local host — the only host those URLs could ever have meant.
 export const Route = createFileRoute("/_shell/sessions/$sessionId")({
-	component: SessionRoute,
+	beforeLoad: ({ params }) => {
+		throw redirect({
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: LOCAL_HOST, sessionId: params.sessionId },
+			replace: true,
+		});
+	},
 });
-
-function SessionRoute() {
-	const { sessionId } = Route.useParams();
-	return <SessionView sessionId={sessionId} />;
-}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -25,7 +25,12 @@ import { agentModelsQueryOptions } from "../hooks/useAgentModelsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
-import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
+import {
+	useWorkspaceQuery,
+	workspaceHostQueryKey,
+	workspaceQueryKey,
+	workspaceQueryOptions,
+} from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { clientFor } from "../lib/host-clients";
 import { refreshDaemonStatus } from "../lib/daemon-status";
@@ -48,7 +53,14 @@ import {
 } from "../lib/platform";
 import { sidebarIsCompact, sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "../stores/ui-store";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
-import { sessionIsActive, toProjectKind, type WorkspaceSummary } from "../types/workspace";
+import {
+	flattenHostSections,
+	sessionIsActive,
+	toProjectKind,
+	updateHostWorkspaces,
+	type HostSection,
+	type WorkspaceSummary,
+} from "../types/workspace";
 import type { components } from "../../api/schema";
 import { useAgentInventoryTelemetry } from "../hooks/useAgentInventoryTelemetry";
 
@@ -151,7 +163,7 @@ function ShellLayout() {
 	const matchRoute = useMatchRoute();
 	const queryClient = useQueryClient();
 	const workspaceQuery = useWorkspaceQuery();
-	const workspaces = workspaceQuery.data ?? [];
+	const workspaces = useMemo(() => flattenHostSections(workspaceQuery.data), [workspaceQuery.data]);
 	// Global shortcut listeners need the latest workspace list, but recreating
 	// those subscriptions for every streamed activity update is avoidable.
 	const workspacesRef = useRef(workspaces);
@@ -399,7 +411,15 @@ function ShellLayout() {
 
 	const updateWorkspaces = useCallback(
 		(updater: (workspaces: WorkspaceSummary[]) => WorkspaceSummary[]) => {
-			queryClient.setQueryData<WorkspaceSummary[]>(workspaceQueryKey, (current = []) => updater(current));
+			// The cache is per host now, so an optimistic edit has to name the host
+			// it belongs to; these are all local-project edits.
+			queryClient.setQueryData<HostSection[]>(workspaceHostQueryKey(LOCAL_HOST), (current) =>
+				updateHostWorkspaces(
+					current ?? [{ host: LOCAL_HOST, label: "Local", status: "ready", workspaces: [], failure: null }],
+					LOCAL_HOST,
+					updater,
+				),
+			);
 		},
 		[queryClient],
 	);
@@ -646,7 +666,7 @@ function ShellLayout() {
 		}
 
 		workspaceStartupBaselineRef.current =
-			queryClient.getQueryState(workspaceQueryKey)?.dataUpdatedAt ?? 0;
+			queryClient.getQueryState(workspaceHostQueryKey(LOCAL_HOST))?.dataUpdatedAt ?? 0;
 		setWorkspaceStartupState("loading");
 		void queryClient
 			.fetchQuery({ ...workspaceQueryOptions, staleTime: 0 })

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
+import { LOCAL_HOST, parseRefKey, refKey, type Ref } from "../lib/hosts";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { memo, type CSSProperties, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { FolderPlus } from "lucide-react";
@@ -26,6 +27,7 @@ import { useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
+import { clientFor } from "../lib/host-clients";
 import { refreshDaemonStatus } from "../lib/daemon-status";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
@@ -234,7 +236,7 @@ function ShellLayout() {
 	const handledShellNonceRef = useRef(newShellTerminalNonce);
 	const [isKeyboardShortcutsOpen, setIsKeyboardShortcutsOpen] = useState(false);
 	const [isKeyboardShortcutsSettingsOpen, setIsKeyboardShortcutsSettingsOpen] = useState(false);
-	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
+	const routeParams = useParams({ strict: false }) as { hostId?: string; projectId?: string; sessionId?: string };
 	useEffect(() => {
 		document.addEventListener("click", handleModifierLinkClick);
 		return () => document.removeEventListener("click", handleModifierLinkClick);
@@ -298,23 +300,29 @@ function ShellLayout() {
 	// Project in scope for a new-session shortcut: the route's project, or the
 	// workspace owning the open session (so the shortcut works from a worker's
 	// detail view, where the URL carries only a sessionId).
-	const scopedProjectId = routeParams.projectId
-		? routeParams.projectId
+	const scopedProject: Ref | undefined = routeParams.projectId
+		? { host: routeParams.hostId ?? LOCAL_HOST, id: routeParams.projectId }
 		: routeParams.sessionId
-			? workspaces.find((workspace) => workspace.sessions.some((session) => session.id === routeParams.sessionId))?.id
+			? (() => {
+					const owner = workspaces.find((workspace) =>
+						workspace.sessions.some((session) => session.id === routeParams.sessionId),
+					);
+					return owner ? { host: owner.host, id: owner.id } : undefined;
+				})()
 			: undefined;
+	const scopedProjectId = scopedProject?.id;
 	// Warms the New Task composer's model-catalog cache while the user is just
 	// looking at the project, so the picker never shows a loading flash the
 	// first time they actually open the dialog.
 	useEffect(() => {
-		if (!scopedProjectId) return;
-		const projectQueryKey = ["project", scopedProjectId];
+		if (!scopedProject) return;
+		const projectQueryKey = ["project", refKey(scopedProject)];
 		void queryClient
 			.prefetchQuery({
 				queryKey: projectQueryKey,
 				queryFn: async () => {
-					const { data, error: apiError } = await apiClient.GET("/api/v1/projects/{id}", {
-						params: { path: { id: scopedProjectId } },
+					const { data, error: apiError } = await clientFor(scopedProject.host).GET("/api/v1/projects/{id}", {
+						params: { path: { id: scopedProject.id } },
 					});
 					if (apiError) throw new Error(apiErrorMessage(apiError));
 					if (data?.status !== "ok") throw new Error("Project config unavailable");
@@ -325,16 +333,16 @@ function ShellLayout() {
 				const project = queryClient.getQueryData<components["schemas"]["Project"]>(projectQueryKey);
 				const defaultWorkerAgent = project?.config?.worker?.agent || project?.agent || "";
 				if (defaultWorkerAgent) {
-					void queryClient.prefetchQuery(agentModelsQueryOptions(defaultWorkerAgent, scopedProjectId));
+					void queryClient.prefetchQuery(agentModelsQueryOptions(defaultWorkerAgent, scopedProject));
 				}
 			});
-	}, [queryClient, scopedProjectId]);
+	}, [queryClient, scopedProject]);
 	// The root route is the intentionally minimal home surface, regardless of
 	// whether projects have already been registered.
 	const isHomeRoute = Boolean(matchRoute({ to: "/" }));
 	const isSettingsRoute =
 		Boolean(matchRoute({ to: "/settings", fuzzy: true })) ||
-		Boolean(matchRoute({ to: "/projects/$projectId/settings", fuzzy: true }));
+		Boolean(matchRoute({ to: "/host/$hostId/project/$projectId/settings", fuzzy: true }));
 	// Welcome/settings always self-frame. Platforms that hide the shell-owned
 	// topbar (macOS) use the same full-height inset; session actions mount
 	// inside SessionView.
@@ -347,7 +355,9 @@ function ShellLayout() {
 	const orchestratorReplacementErrors = useUiStore((state) => state.orchestratorReplacementErrors);
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
 	const setOrchestratorStartupError = useUiStore((state) => state.setOrchestratorStartupError);
-	const replacementErrorProjectId = Object.keys(orchestratorReplacementErrors)[0] ?? null;
+	const replacementErrorKey = Object.keys(orchestratorReplacementErrors)[0] ?? null;
+	// The store keys failures by refKey so two hosts' same-named projects cannot collide.
+	const replacementErrorRef = replacementErrorKey ? parseRefKey(replacementErrorKey) : null;
 	const isStartupLoading =
 		!usesPreviewWorkspaceData &&
 		!daemonStatus.code &&
@@ -369,8 +379,8 @@ function ShellLayout() {
 			const session = sessions[nextIndex];
 			if (!session || session.id === routeParams.sessionId) return;
 			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId: scopedProjectId, sessionId: session.id },
+				to: "/host/$hostId/session/$sessionId",
+				params: { hostId: session.host, sessionId: session.id },
 			});
 		},
 		[navigate, routeParams.sessionId, scopedProjectId],
@@ -390,6 +400,7 @@ function ShellLayout() {
 			source: "project_add" | "project_clone",
 		) => {
 			const workspace: WorkspaceSummary = {
+				host: LOCAL_HOST,
 				id: project.id,
 				name: project.name,
 				kind: toProjectKind(project.kind),
@@ -431,15 +442,18 @@ function ShellLayout() {
 				const sessionId = spawnData.session.id;
 				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 				void navigate({
-					to: "/projects/$projectId/sessions/$sessionId",
-					params: { projectId: workspace.id, sessionId },
+					to: "/host/$hostId/session/$sessionId",
+					params: { hostId: workspace.host, sessionId },
 				});
 			} catch (spawnError) {
 				void captureRendererEvent("ao.renderer.orchestrator_spawn_failed", {
 					project_id: workspace.id,
 					source,
 				});
-				void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
+				void navigate({
+					to: "/host/$hostId/project/$projectId",
+					params: { hostId: workspace.host, projectId: workspace.id },
+				});
 				const message = spawnError instanceof Error ? spawnError.message : "Could not start orchestrator";
 				const startupMessage = `Project added, but orchestrator did not start: ${message}`;
 				setOrchestratorStartupError(workspace.id, startupMessage);
@@ -575,16 +589,16 @@ function ShellLayout() {
 	);
 
 	const restartOrchestrator = useCallback(
-		async (projectId: string, mode?: "chat" | "tui") => {
+		async (project: Ref, mode?: "chat" | "tui") => {
 			await restartProjectOrchestrator({
-				projectId,
+				project,
 				queryClient,
 				navigate,
 				setProjectRestarting,
 				setOrchestratorReplacementError,
 				mode,
 				onError: (error) => {
-					captureOrchestratorReplacementFailure(error, projectId);
+					captureOrchestratorReplacementFailure(error, project.id);
 				},
 			});
 		},
@@ -695,7 +709,10 @@ function ShellLayout() {
 				const workspace = workspacesRef.current[Number(event.key) - 1];
 				if (workspace) {
 					event.preventDefault();
-					void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
+					void navigate({
+						to: "/host/$hostId/project/$projectId",
+						params: { hostId: workspace.host, projectId: workspace.id },
+					});
 				}
 			}
 		};
@@ -711,7 +728,7 @@ function ShellLayout() {
 		() =>
 			aoBridge.app.onNewSessionShortcut(() => {
 				if (scopedProjectId) {
-					requestNewTask(scopedProjectId);
+					if (scopedProject) requestNewTask(scopedProject);
 				} else {
 					requestCreateProject();
 				}
@@ -953,13 +970,13 @@ function ShellLayout() {
 					/>
 				</SidebarProvider>
 				<OrchestratorReplacementDialog
-					error={replacementErrorProjectId ? orchestratorReplacementErrors[replacementErrorProjectId] : undefined}
+					error={replacementErrorKey ? orchestratorReplacementErrors[replacementErrorKey] : undefined}
 					onOpenChange={(open) => {
-						if (!open && replacementErrorProjectId) setOrchestratorReplacementError(replacementErrorProjectId, null);
+						if (!open && replacementErrorRef) setOrchestratorReplacementError(replacementErrorRef, null);
 					}}
-					onRetry={(projectId) => void restartOrchestrator(projectId)}
-					onRetryAsTui={(projectId) => void restartOrchestrator(projectId, "tui")}
-					projectId={replacementErrorProjectId}
+					onRetry={(project) => void restartOrchestrator(project)}
+					onRetryAsTui={(project) => void restartOrchestrator(project, "tui")}
+					project={replacementErrorRef}
 					workspaces={workspaces}
 				/>
 					<CommandPalette />

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -300,17 +300,24 @@ function ShellLayout() {
 	// Project in scope for a new-session shortcut: the route's project, or the
 	// workspace owning the open session (so the shortcut works from a worker's
 	// detail view, where the URL carries only a sessionId).
+	const routeHost = routeParams.hostId ?? LOCAL_HOST;
 	const scopedProject: Ref | undefined = routeParams.projectId
-		? { host: routeParams.hostId ?? LOCAL_HOST, id: routeParams.projectId }
+		? { host: routeHost, id: routeParams.projectId }
 		: routeParams.sessionId
 			? (() => {
+					// Session ids repeat across hosts, so the owner search is scoped to
+					// the route's host — otherwise the shortcut opens a shell, or a new
+					// task, on whichever machine sorts first in the tree.
 					const owner = workspaces.find((workspace) =>
-						workspace.sessions.some((session) => session.id === routeParams.sessionId),
+						workspace.sessions.some(
+							(session) => session.host === routeHost && session.id === routeParams.sessionId,
+						),
 					);
 					return owner ? { host: owner.host, id: owner.id } : undefined;
 				})()
 			: undefined;
 	const scopedProjectId = scopedProject?.id;
+	const scopedProjectHost = scopedProject?.host;
 	// Warms the New Task composer's model-catalog cache while the user is just
 	// looking at the project, so the picker never shows a loading flash the
 	// first time they actually open the dialog.
@@ -365,9 +372,13 @@ function ShellLayout() {
 	const navigateSession = useCallback(
 		(direction: -1 | 1) => {
 			if (!scopedProjectId) return;
-			const sessions = (workspacesRef.current.find((workspace) => workspace.id === scopedProjectId)?.sessions ?? []).filter(
-				sessionIsActive,
-			);
+			// Project ids repeat across hosts too: cycling through the wrong host's
+			// project would navigate to a session on a machine the user left.
+			const sessions = (
+				workspacesRef.current.find(
+					(workspace) => workspace.host === scopedProjectHost && workspace.id === scopedProjectId,
+				)?.sessions ?? []
+			).filter(sessionIsActive);
 			if (sessions.length === 0) return;
 			const currentIndex = sessions.findIndex((session) => session.id === routeParams.sessionId);
 			const nextIndex =
@@ -383,7 +394,7 @@ function ShellLayout() {
 				params: { hostId: session.host, sessionId: session.id },
 			});
 		},
-		[navigate, routeParams.sessionId, scopedProjectId],
+		[navigate, routeParams.sessionId, scopedProjectHost, scopedProjectId],
 	);
 
 	const updateWorkspaces = useCallback(

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -798,9 +798,7 @@ function ShellLayout() {
 		openShellTerminal.mutate(
 			{
 				project: scopedProject,
-				session: routeParams.sessionId
-					? { host: scopedProject?.host ?? LOCAL_HOST, id: routeParams.sessionId }
-					: undefined,
+				session: routeParams.sessionId ? { host: routeHost, id: routeParams.sessionId } : undefined,
 			},
 			{
 				onSuccess: (shell) => {

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -796,7 +796,12 @@ function ShellLayout() {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
 		openShellTerminal.mutate(
-			{ projectId: scopedProjectId, sessionId: routeParams.sessionId },
+			{
+				project: scopedProject,
+				session: routeParams.sessionId
+					? { host: scopedProject?.host ?? LOCAL_HOST, id: routeParams.sessionId }
+					: undefined,
+			},
 			{
 				onSuccess: (shell) => {
 					setActiveShellTerminal(shell.handleId);

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -1,16 +1,23 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sidebarIsCompact, sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "./ui-store";
 
-describe("sidebar workspace pressure", () => {
-	beforeEach(() => {
-		window.localStorage.clear();
-		useUiStore.setState({
-			isSidebarOpen: true,
-			isSidebarAutoCollapsed: false,
-			sidebarAutoCollapseOverride: false,
-			sidebarWorkspaceDemandPx: null,
-		});
+beforeEach(() => {
+	window.localStorage.clear();
+	vi.resetModules();
+	useUiStore.setState({
+		isSidebarOpen: true,
+		isSidebarAutoCollapsed: false,
+		sidebarAutoCollapseOverride: false,
+		sidebarWorkspaceDemandPx: null,
 	});
+});
+
+// A fresh module sees exactly what a booting renderer sees: only storage.
+async function bootStore() {
+	return (await import("./ui-store")).useUiStore;
+}
+
+describe("sidebar workspace pressure", () => {
 
 	it("temporarily compacts navigation without changing the saved preference", () => {
 		useUiStore.getState().setSidebarAutoCollapsed(true);
@@ -61,5 +68,24 @@ describe("sidebar workspace pressure", () => {
 		expect(state.isSidebarOpen).toBe(true);
 		expect(state.sidebarAutoCollapseOverride).toBe(false);
 		expect(sidebarIsVisible(state)).toBe(true);
+	});
+});
+
+
+describe("remoteHosts flag", () => {
+	it("is off until the user turns it on", async () => {
+		expect((await bootStore()).getState().remoteHosts).toBe(false);
+	});
+
+	it("persists the switch so the choice survives a restart", () => {
+		useUiStore.getState().setRemoteHosts(true);
+		expect(useUiStore.getState().remoteHosts).toBe(true);
+		expect(window.localStorage.getItem("ao.remoteHosts")).toBe("true");
+		useUiStore.getState().setRemoteHosts(false);
+	});
+
+	it("reads a stored choice back at startup", async () => {
+		window.localStorage.setItem("ao.remoteHosts", "true");
+		expect((await bootStore()).getState().remoteHosts).toBe(true);
 	});
 });

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -68,6 +68,8 @@ export type UiState = {
 	themeStyle: ThemeStyle;
 	/** When true, developer-only release controls are available. Default off. */
 	developerMode: boolean;
+	/** Experimental: connect to AO daemons on other machines. Default off; off means no remote host is ever contacted. */
+	remoteHosts: boolean;
 	restartingProjectIds: ReadonlySet<string>;
 	orchestratorReplacementErrors: Record<string, OrchestratorReplacementFailure>;
 	orchestratorStartupErrors: Record<string, string>;
@@ -105,6 +107,7 @@ export type UiState = {
 	setThemePreference: (theme: ThemePreference) => void;
 	setThemeStyle: (style: ThemeStyle) => void;
 	setDeveloperMode: (enabled: boolean) => void;
+	setRemoteHosts: (enabled: boolean) => void;
 	openGlobalSettings: (section?: GlobalSettingsSection) => void;
 	openProjectSettings: (projectId: string) => void;
 	closeSettings: () => void;
@@ -149,6 +152,7 @@ export type OrchestratorReplacementFailure = {
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
+const remoteHostsStorageKey = "ao.remoteHosts";
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
 	return window.localStorage;
@@ -160,6 +164,10 @@ function initialSidebarOpen() {
 
 function initialDeveloperMode() {
 	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
+}
+
+function initialRemoteHosts() {
+	return getLocalStorage()?.getItem(remoteHostsStorageKey) === "true";
 }
 
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
@@ -201,6 +209,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	resolvedTheme: resolveTheme(initialThemePreference),
 	themeStyle: initialThemeStyle,
 	developerMode: initialDeveloperMode(),
+	remoteHosts: initialRemoteHosts(),
 	restartingProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
 	orchestratorStartupErrors: {},
@@ -231,6 +240,10 @@ export const useUiStore = create<UiState>((set, get) => ({
 	setDeveloperMode: (developerMode) => {
 		getLocalStorage()?.setItem(developerModeStorageKey, String(developerMode));
 		set({ developerMode });
+	},
+	setRemoteHosts: (remoteHosts) => {
+		getLocalStorage()?.setItem(remoteHostsStorageKey, String(remoteHosts));
+		set({ remoteHosts });
 	},
 	openGlobalSettings: (section) => set({ settingsModal: { scope: "global", section } }),
 	openProjectSettings: (projectId) => set({ settingsModal: { scope: "project", projectId } }),

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { refKey, type Ref } from "../lib/hosts";
 import type { TerminalTarget } from "../types/terminal";
 import {
 	applyDocumentTheme,
@@ -24,7 +25,7 @@ export type SettingsModal =
 	| { scope: "global"; section?: GlobalSettingsSection }
 	| {
 			scope: "project";
-			projectId: string;
+			project: Ref;
 	};
 
 /** Worker detail view toggles — Changes (Git rail) is the default. */
@@ -77,7 +78,7 @@ export type UiState = {
 	// bumps on every request so a repeat press (even for the same project) still
 	// re-fires; the always-mounted GlobalNewTaskDialog consumes it. Selection
 	// still lives in the URL — this is a one-shot action, not persisted state.
-	newTaskRequest: { projectId: string; nonce: number } | null;
+	newTaskRequest: { project: Ref; nonce: number } | null;
 	// Bumps to ask the sidebar's create-project flow to open (the ⌘N fallback
 	// when no project is in scope).
 	createProjectNonce: number;
@@ -109,7 +110,7 @@ export type UiState = {
 	setDeveloperMode: (enabled: boolean) => void;
 	setRemoteHosts: (enabled: boolean) => void;
 	openGlobalSettings: (section?: GlobalSettingsSection) => void;
-	openProjectSettings: (projectId: string) => void;
+	openProjectSettings: (project: Ref) => void;
 	closeSettings: () => void;
 	/** Refresh resolvedTheme from OS without writing light/dark to storage. */
 	syncSystemTheme: () => void;
@@ -133,9 +134,9 @@ export type UiState = {
 	setFilesChangedOnly: (sessionId: string, changedOnly: boolean) => void;
 	setCommandPaletteOpen: (open: boolean) => void;
 	setProjectRestarting: (projectId: string, restarting: boolean) => void;
-	setOrchestratorReplacementError: (projectId: string, failure: OrchestratorReplacementFailure | null) => void;
+	setOrchestratorReplacementError: (project: Ref, failure: OrchestratorReplacementFailure | null) => void;
 	setOrchestratorStartupError: (projectId: string, message: string | null) => void;
-	requestNewTask: (projectId: string) => void;
+	requestNewTask: (project: Ref) => void;
 	requestCreateProject: () => void;
 	requestCreateProjectFromPath: (path: string) => void;
 	requestNewShellTerminal: () => void;
@@ -246,7 +247,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 		set({ remoteHosts });
 	},
 	openGlobalSettings: (section) => set({ settingsModal: { scope: "global", section } }),
-	openProjectSettings: (projectId) => set({ settingsModal: { scope: "project", projectId } }),
+	openProjectSettings: (project) => set({ settingsModal: { scope: "project", project } }),
 	closeSettings: () => set({ settingsModal: null }),
 	syncSystemTheme: () => {
 		const { themePreference, resolvedTheme } = get();
@@ -391,13 +392,13 @@ export const useUiStore = create<UiState>((set, get) => ({
 			}
 			return { restartingProjectIds };
 		}),
-	setOrchestratorReplacementError: (projectId, failure) =>
+	setOrchestratorReplacementError: (project, failure) =>
 		set((state) => {
 			const orchestratorReplacementErrors = { ...state.orchestratorReplacementErrors };
 			if (failure) {
-				orchestratorReplacementErrors[projectId] = failure;
+				orchestratorReplacementErrors[refKey(project)] = failure;
 			} else {
-				delete orchestratorReplacementErrors[projectId];
+				delete orchestratorReplacementErrors[refKey(project)];
 			}
 			return { orchestratorReplacementErrors };
 		}),
@@ -411,8 +412,8 @@ export const useUiStore = create<UiState>((set, get) => ({
 			}
 			return { orchestratorStartupErrors };
 		}),
-	requestNewTask: (projectId) =>
-		set((state) => ({ newTaskRequest: { projectId, nonce: (state.newTaskRequest?.nonce ?? 0) + 1 } })),
+	requestNewTask: (project) =>
+		set((state) => ({ newTaskRequest: { project, nonce: (state.newTaskRequest?.nonce ?? 0) + 1 } })),
 	requestCreateProject: () => set((state) => ({ createProjectNonce: state.createProjectNonce + 1 })),
 	requestCreateProjectFromPath: (path) =>
 		set((state) => ({ folderDropRequest: { path, nonce: (state.folderDropRequest?.nonce ?? 0) + 1 } })),

--- a/frontend/src/renderer/test/fake-daemon.test.ts
+++ b/frontend/src/renderer/test/fake-daemon.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { fakeDaemon } from "./fake-daemon";
+
+describe("fakeDaemon", () => {
+	it("html-catchall answers every path with a 200 HTML page", async () => {
+		const fetch = fakeDaemon("html-catchall");
+		for (const path of ["/healthz", "/api/v1/projects", "/unknown"]) {
+			const response = await fetch(`http://x${path}`);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("content-type")).toMatch(/html/);
+		}
+	});
+
+	it("wrong-shape returns valid JSON that is not the expected schema", async () => {
+		const response = await fakeDaemon("wrong-shape")(
+			"http://x/api/v1/projects",
+		);
+		expect(response.status).toBe(200);
+		expect(await response.json()).not.toHaveProperty("projects");
+	});
+
+	it("unauthorized returns the daemon's real 401 envelope", async () => {
+		const response = await fakeDaemon("unauthorized")(
+			"http://x/api/v1/projects",
+		);
+		expect(response.status).toBe(401);
+		expect((await response.json()).code).toBe("BAD_PASSWORD");
+	});
+
+	it("unreachable rejects the way the network does", async () => {
+		await expect(
+			fakeDaemon("unreachable")("http://x/healthz"),
+		).rejects.toThrow(/fetch failed/);
+	});
+
+	it("route-missing 404s unknown routes but serves known ones", async () => {
+		const fetch = fakeDaemon("route-missing");
+		expect((await fetch("http://x/api/v1/fs/dirs")).status).toBe(404);
+		expect((await fetch("http://x/api/v1/projects")).status).toBe(200);
+	});
+});

--- a/frontend/src/renderer/test/fake-daemon.ts
+++ b/frontend/src/renderer/test/fake-daemon.ts
@@ -1,0 +1,118 @@
+export type Behaviour =
+	| "healthy"
+	| "html-catchall"
+	| "wrong-shape"
+	| "unauthorized"
+	| "unreachable"
+	| "route-missing"
+	| "slow";
+
+function json(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json; charset=utf-8" },
+	});
+}
+
+function healthyResponse(input: RequestInfo | URL): Response {
+	const url = new URL(
+		input instanceof Request ? input.url : input.toString(),
+	);
+	switch (url.pathname) {
+		case "/healthz":
+			return json({
+				status: "ok",
+				service: "agent-orchestrator-daemon",
+				pid: 1,
+			});
+		case "/readyz":
+			return json({
+				status: "ready",
+				service: "agent-orchestrator-daemon",
+				pid: 1,
+			});
+		case "/api/v1/projects":
+			return json({ projects: [] });
+		case "/api/v1/sessions":
+			return json({ sessions: [] });
+		case "/api/v1/fs/dirs":
+			return json({
+				path: "/home/test",
+				parent: "/home",
+				entries: [],
+				truncated: false,
+			});
+		default:
+			return json(
+				{
+					error: "not_found",
+					code: "NOT_FOUND",
+					message: "route not found",
+				},
+				404,
+			);
+	}
+}
+
+function neverRespond(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+): Promise<Response> {
+	const signal =
+		init?.signal ?? (input instanceof Request ? input.signal : null);
+	return new Promise((_, reject) => {
+		const abort = () =>
+			reject(
+				signal?.reason ??
+					new DOMException("The operation was aborted", "AbortError"),
+			);
+		if (signal?.aborted) abort();
+		else signal?.addEventListener("abort", abort, { once: true });
+	});
+}
+
+export function fakeDaemon(behaviour: Behaviour): typeof fetch {
+	return async (input, init) => {
+		switch (behaviour) {
+			case "healthy":
+				return healthyResponse(input);
+			case "html-catchall":
+				return new Response(
+					"<!doctype html><html><body>AO</body></html>",
+					{
+						status: 200,
+						headers: { "Content-Type": "text/html; charset=utf-8" },
+					},
+				);
+			case "wrong-shape":
+				return json({ ok: true });
+			case "unauthorized":
+				return json(
+					{
+						error: "unauthorized",
+						code: "BAD_PASSWORD",
+						message: "missing or invalid connection password",
+						requestId: "fake-request",
+					},
+					401,
+				);
+			case "unreachable":
+				throw new TypeError("fetch failed");
+			case "route-missing":
+				return new URL(
+					input instanceof Request ? input.url : input.toString(),
+				).pathname === "/api/v1/fs/dirs"
+					? json(
+							{
+								error: "not_found",
+								code: "NOT_FOUND",
+								message: "route not found",
+							},
+							404,
+						)
+					: healthyResponse(input);
+			case "slow":
+				return neverRespond(input, init);
+		}
+	};
+}

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -310,6 +310,14 @@ if (typeof window !== "undefined") {
 			list: async () => [],
 			getActive: async () => null,
 		},
+		remotes: {
+			list: async () => [],
+			add: async () => "offline" as const,
+			update: async () => "offline" as const,
+			remove: async () => undefined,
+			probe: async () => "offline" as const,
+			request: async () => ({ status: 0, body: null }),
+		},
 		cloud: {
 			getSession: async () => null,
 			signIn: async () => undefined,

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -317,6 +317,9 @@ if (typeof window !== "undefined") {
 			remove: async () => undefined,
 			probe: async () => "offline" as const,
 			request: async () => ({ status: 0, body: null }),
+			connect: async () => ({ label: "", url: "", base: "" }),
+			disconnect: async () => undefined,
+			connected: async () => [],
 		},
 		cloud: {
 			getSession: async () => null,

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -167,6 +167,11 @@ vi.mock("../hooks/useCloudCp", () => ({
 // shortcut subscriptions, so the mutation is stubbed rather than driven.
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: [], isSuccess: true }),
+	shellTerminalsQueryKey: (host: string) => ["shell-terminals", host],
+	shellTerminalsQueryOptions: (host: string) => ({
+		queryKey: ["shell-terminals", host],
+		queryFn: () => [],
+	}),
 	useOpenShellTerminal: () => ({ mutate: shellMocks.openShellTerminal }),
 }));
 
@@ -555,7 +560,7 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 		pressNewShellTerminal();
 
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
-			expect.objectContaining({ projectId: "proj-1" }),
+			expect.objectContaining({ project: { host: "local", id: "proj-1" } }),
 			expect.anything(),
 		);
 	});
@@ -570,7 +575,7 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 		pressNewShellTerminal();
 
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
-			expect.objectContaining({ projectId: "proj-1", sessionId: "sess-1" }),
+			expect.objectContaining({ project: { host: "local", id: "proj-1" }, session: { host: "local", id: "sess-1" } }),
 			expect.anything(),
 		);
 	});
@@ -584,7 +589,7 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 		pressNewShellTerminal();
 
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
-			expect.objectContaining({ projectId: "proj-2", sessionId: "sess-cross" }),
+			expect.objectContaining({ project: { host: "local", id: "proj-2" }, session: { host: "local", id: "sess-cross" } }),
 			expect.anything(),
 		);
 	});

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -16,7 +16,7 @@ const shellMocks = vi.hoisted(() => {
 		nextSessionListener: undefined as (() => void) | undefined,
 		focusTerminalListener: undefined as (() => void) | undefined,
 		openFolderPathListener: undefined as ((path: string) => void) | undefined,
-		routeParams: {} as { projectId?: string; sessionId?: string },
+		routeParams: {} as { hostId?: string; projectId?: string; sessionId?: string },
 		routeSearch: {} as Record<string, unknown>,
 		workspaces: [] as WorkspaceSummary[],
 		workspaceQuery: {
@@ -644,6 +644,37 @@ describe("shell application shortcut subscriptions", () => {
 		expect(shellMocks.navigate).toHaveBeenCalledWith({
 			to: "/host/$hostId/session/$sessionId",
 			params: { hostId: "local", sessionId: "sess-3" },
+		});
+	});
+
+	// Session and project ids both repeat across hosts, so resolving the route's
+	// session by bare id can pick the wrong machine's project — and the next /
+	// previous shortcut then walks that machine's sessions.
+	it("cycles within the route host's project when two hosts share the ids", async () => {
+		shellMocks.state.workspaceQuery = {
+			...shellMocks.state.workspaceQuery,
+			data: [
+				...workspaces,
+				{
+					host: "remote",
+					id: "proj-1",
+					name: "Project One",
+					path: "/one",
+					sessions: [
+						{ host: "remote", id: "sess-1", workspaceId: "proj-1", status: "working" },
+						{ host: "remote", id: "sess-remote-next", workspaceId: "proj-1", status: "idle" },
+					],
+				},
+			] as unknown as WorkspaceSummary[],
+		};
+		shellMocks.state.routeParams = { hostId: "remote", sessionId: "sess-1" };
+		await renderShell();
+
+		act(() => shellMocks.state.nextSessionListener?.());
+
+		expect(shellMocks.navigate).toHaveBeenCalledWith({
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "remote", sessionId: "sess-remote-next" },
 		});
 	});
 

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -594,6 +594,37 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 		);
 	});
 
+	// Session ids repeat across hosts, so finding the session's owning project by
+	// bare id can name a project on the wrong machine — and the shell then opens
+	// there, silently, on a daemon the user is not looking at.
+	it("scopes the terminal to the session's own host when two hosts share the id", async () => {
+		shellMocks.state.workspaceQuery = {
+			...shellMocks.state.workspaceQuery,
+			data: [
+				...workspaces,
+				{
+					host: "remote",
+					id: "proj-1",
+					name: "Project One",
+					path: "/one",
+					sessions: [{ host: "remote", id: "sess-1", workspaceId: "proj-1", status: "working" }],
+				},
+			] as unknown as WorkspaceSummary[],
+		};
+		shellMocks.state.routeParams = { hostId: "remote", sessionId: "sess-1" };
+		await renderShell();
+
+		pressNewShellTerminal();
+
+		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
+			expect.objectContaining({
+				project: { host: "remote", id: "proj-1" },
+				session: { host: "remote", id: "sess-1" },
+			}),
+			expect.anything(),
+		);
+	});
+
 	it("re-fires on a repeat press so a second terminal can be opened", async () => {
 		await renderShell();
 

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -208,7 +208,7 @@ vi.mock("../components/GlobalNewTaskDialog", async () => {
 	return {
 		GlobalNewTaskDialog: () => {
 			const request = useStore((state) => state.newTaskRequest);
-			return request ? <div data-testid="new-task-flow" data-project={request.projectId} /> : null;
+			return request ? <div data-testid="new-task-flow" data-project={request.project.id} /> : null;
 		},
 	};
 });
@@ -236,21 +236,23 @@ const ShellRoute = Route.options.component as ComponentType;
 
 const workspaces = [
 	{
+		host: "local",
 		id: "proj-1",
 		name: "Project One",
 		path: "/one",
 		sessions: [
-			{ id: "sess-1", workspaceId: "proj-1", status: "working" },
-			{ id: "sess-2", workspaceId: "proj-1", status: "terminated" },
-			{ id: "sess-merged-terminated", workspaceId: "proj-1", status: "merged", isTerminated: true },
-			{ id: "sess-3", workspaceId: "proj-1", status: "idle" },
+			{ host: "local", id: "sess-1", workspaceId: "proj-1", status: "working" },
+			{ host: "local", id: "sess-2", workspaceId: "proj-1", status: "terminated" },
+			{ host: "local", id: "sess-merged-terminated", workspaceId: "proj-1", status: "merged", isTerminated: true },
+			{ host: "local", id: "sess-3", workspaceId: "proj-1", status: "idle" },
 		],
 	},
 	{
+		host: "local",
 		id: "proj-2",
 		name: "Project Two",
 		path: "/two",
-		sessions: [{ id: "sess-cross", workspaceId: "proj-2", status: "working" }],
+		sessions: [{ host: "local", id: "sess-cross", workspaceId: "proj-2", status: "working" }],
 	},
 ] as unknown as WorkspaceSummary[];
 
@@ -640,8 +642,8 @@ describe("shell application shortcut subscriptions", () => {
 		act(() => shellMocks.state.nextSessionListener?.());
 
 		expect(shellMocks.navigate).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-3" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-3" },
 		});
 	});
 
@@ -652,8 +654,8 @@ describe("shell application shortcut subscriptions", () => {
 		act(() => shellMocks.state.previousSessionListener?.());
 
 		expect(shellMocks.navigate).toHaveBeenCalledWith({
-			to: "/projects/$projectId/sessions/$sessionId",
-			params: { projectId: "proj-1", sessionId: "sess-3" },
+			to: "/host/$hostId/session/$sessionId",
+			params: { hostId: "local", sessionId: "sess-3" },
 		});
 	});
 

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -128,10 +128,27 @@ vi.mock("../lib/bridge", () => ({
 	},
 }));
 
+// useWorkspaceQuery returns one section per host now; these fixtures still
+// describe the local host's workspaces, so wrap them in its section — cached by
+// the fixture array, since a fresh section object every render would look like
+// new data to the shell's startup effect.
+const localSections = new WeakMap<object, unknown>();
+function asLocalSections(result: { data?: unknown }) {
+	if (!result.data) return { ...result, data: undefined };
+	const key = result.data as object;
+	if (!localSections.has(key)) {
+		localSections.set(key, [
+			{ host: "local", label: "Local", status: "ready", workspaces: result.data, failure: null },
+		]);
+	}
+	return { ...result, data: localSections.get(key) };
+}
+
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => shellMocks.state.workspaceQuery,
+	useWorkspaceQuery: () => asLocalSections(shellMocks.state.workspaceQuery),
 	useWorkspaceTraySessions: () => ({ data: [] }),
 	workspaceQueryKey: ["workspaces"],
+	workspaceHostQueryKey: (host: string) => ["workspaces", host],
 	workspaceQueryOptions: {},
 }));
 

--- a/frontend/src/renderer/types/terminal.ts
+++ b/frontend/src/renderer/types/terminal.ts
@@ -4,7 +4,7 @@ export type TerminalTarget =
 			kind: "reviewer";
 			handleId: string;
 			harness: string;
-			sessionId: string;
+			session: import("../lib/hosts").Ref;
 	  }
 	// A standalone shell the user opened by hand — no agent session behind it,
 	// so unlike "worker" and "reviewer" it carries its own handle and never
@@ -12,14 +12,19 @@ export type TerminalTarget =
 	| {
 			/** Shell creation identity; prevents a reused handle inheriting old state. */
 			generation: string;
+			host: import("../lib/hosts").HostId;
 			kind: "shell";
 			handleId: string;
 			/** Undefined only for a standalone shell outside a session route. */
-			sessionId?: string;
+			session?: import("../lib/hosts").Ref;
 			title: string;
 	  };
 
-export function terminalTargetBelongsToSession(target: TerminalTarget, sessionId: string | undefined): boolean {
+export function terminalTargetBelongsToSession(
+	target: TerminalTarget,
+	session: import("../lib/hosts").Ref | undefined,
+): boolean {
 	if (target.kind === "worker") return true;
-	return target.sessionId === sessionId;
+	if (!target.session || !session) return target.session === session;
+	return target.session.host === session.host && target.session.id === session.id;
 }

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -33,6 +33,7 @@ describe("canonicalTrackerIssueId", () => {
 
 function sessionWith(overrides: Partial<WorkspaceSession>): WorkspaceSession {
 	return {
+		host: "local",
 		id: "sess-1",
 		workspaceId: "ws-1",
 		workspaceName: "my-app",
@@ -114,7 +115,7 @@ describe("sessionIsActive", () => {
 
 describe("findProjectOrchestrator", () => {
 	function workspaceWith(sessions: WorkspaceSession[]): WorkspaceSummary {
-		return { id: "skills", name: "skills", path: "/tmp/skills", sessions };
+		return { host: "local", id: "skills", name: "skills", path: "/tmp/skills", sessions };
 	}
 
 	it("skips a terminated orchestrator that precedes the live one", () => {
@@ -124,28 +125,28 @@ describe("findProjectOrchestrator", () => {
 		const dead = sessionWith({ id: "skills-4", kind: "orchestrator", status: "terminated" });
 		const live = sessionWith({ id: "skills-5", kind: "orchestrator", status: "needs_input" });
 		const worker = sessionWith({ id: "skills-6", kind: "worker", status: "working" });
-		expect(findProjectOrchestrator([workspaceWith([dead, live, worker])], "skills")).toBe(live);
+		expect(findProjectOrchestrator([workspaceWith([dead, live, worker])], { host: "local", id: "skills" })).toBe(live);
 	});
 
 	it("prefers the newest live orchestrator when multiple replacements overlap", () => {
 		const older = sessionWith({ id: "skills-4", kind: "orchestrator", status: "idle", provider: "claude-code" });
 		const newer = sessionWith({ id: "skills-5", kind: "orchestrator", status: "working", provider: "codex" });
-		expect(findProjectOrchestrator([workspaceWith([older, newer])], "skills")).toBe(newer);
+		expect(findProjectOrchestrator([workspaceWith([older, newer])], { host: "local", id: "skills" })).toBe(newer);
 	});
 
 	it("returns undefined when every orchestrator is terminated", () => {
 		const dead = sessionWith({ id: "skills-4", kind: "orchestrator", status: "terminated" });
-		expect(findProjectOrchestrator([workspaceWith([dead])], "skills")).toBeUndefined();
+		expect(findProjectOrchestrator([workspaceWith([dead])], { host: "local", id: "skills" })).toBeUndefined();
 	});
 
 	it("ignores live workers when looking for an orchestrator", () => {
 		const worker = sessionWith({ id: "skills-6", kind: "worker", status: "working" });
-		expect(findProjectOrchestrator([workspaceWith([worker])], "skills")).toBeUndefined();
+		expect(findProjectOrchestrator([workspaceWith([worker])], { host: "local", id: "skills" })).toBeUndefined();
 	});
 
 	it("returns undefined for an unknown project", () => {
 		const live = sessionWith({ id: "skills-5", kind: "orchestrator", status: "working" });
-		expect(findProjectOrchestrator([workspaceWith([live])], "other")).toBeUndefined();
+		expect(findProjectOrchestrator([workspaceWith([live])], { host: "local", id: "other" })).toBeUndefined();
 	});
 
 	it("selects the newest active orchestrator, not the first active one", () => {
@@ -163,7 +164,7 @@ describe("findProjectOrchestrator", () => {
 			createdAt: "2026-01-02T00:00:00Z",
 			updatedAt: "2026-01-02T00:00:00Z",
 		});
-		expect(findProjectOrchestrator([workspaceWith([older, newer])], "skills")).toBe(newer);
+		expect(findProjectOrchestrator([workspaceWith([older, newer])], { host: "local", id: "skills" })).toBe(newer);
 	});
 
 	it("uses updatedAt and id as newest orchestrator tie breakers", () => {
@@ -233,6 +234,7 @@ describe("orchestratorHealth", () => {
 
 		expect(
 			orchestratorHealth({
+				host: "local",
 				id: "skills",
 				name: "skills",
 				path: "/tmp/skills",
@@ -247,6 +249,7 @@ describe("orchestratorHealth", () => {
 
 		expect(
 			orchestratorHealth({
+				host: "local",
 				id: "skills",
 				name: "skills",
 				path: "/tmp/skills",

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -12,6 +12,7 @@ import {
 } from "@aoagents/product-ui";
 
 import type { ReviewerHarnessId } from "../lib/reviewer-harnesses";
+import type { HostId, Ref } from "../lib/hosts";
 
 export { toKanbanColumn, toSessionActivity, toSessionStatus };
 export type { KanbanColumn, SessionActivity, SessionActivityState, SessionStatus };
@@ -61,6 +62,7 @@ export type AgentSwitchSummary = {
 };
 
 export type WorkspaceSession = {
+	host: HostId;
 	id: string;
 	terminalHandleId?: string;
 	workspaceId: string;
@@ -225,9 +227,9 @@ export function isOrchestratorSession(session: WorkspaceSession): boolean {
  */
 export function findProjectOrchestrator(
 	workspaces: WorkspaceSummary[],
-	projectId: string,
+	project: Ref,
 ): WorkspaceSession | undefined {
-	const workspace = workspaces.find((w) => w.id === projectId);
+	const workspace = workspaces.find((w) => w.host === project.host && w.id === project.id);
 	return newestActiveOrchestrator(workspace?.sessions ?? []);
 }
 
@@ -301,6 +303,7 @@ export { attentionZone, attentionZoneLabel, attentionZoneOrder } from "../lib/se
 export type { AttentionZone } from "../lib/session-presentation";
 
 export type WorkspaceSummary = {
+	host: HostId;
 	id: string;
 	name: string;
 	/**

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -12,6 +12,7 @@ import {
 } from "@aoagents/product-ui";
 
 import type { ReviewerHarnessId } from "../lib/reviewer-harnesses";
+import type { EventsConnectionState } from "../lib/events-connection";
 import type { HostId, Ref } from "../lib/hosts";
 
 export { toKanbanColumn, toSessionActivity, toSessionStatus };
@@ -325,6 +326,35 @@ export type WorkspaceSummary = {
 	};
 	sessions: WorkspaceSession[];
 };
+
+export type HostSection = {
+	host: HostId;
+	label: string;
+	status: "ready" | "failed";
+	/**
+	 * This host's live event stream when the section was built. Absent means
+	 * unknown (no stream was ever opened — jsdom, preview surfaces); only
+	 * "disconnected" means the board is quietly falling back to polling.
+	 */
+	streamState?: EventsConnectionState;
+	workspaces: WorkspaceSummary[];
+	failure: string | null;
+};
+
+export function flattenHostSections(sections: readonly HostSection[] | undefined): WorkspaceSummary[] {
+	return sections?.flatMap((section) => section.workspaces) ?? [];
+}
+
+export function updateHostWorkspaces(
+	sections: HostSection[] | undefined,
+	host: HostId,
+	update: (workspaces: WorkspaceSummary[]) => WorkspaceSummary[],
+): HostSection[] | undefined {
+	if (!sections) return sections;
+	return sections.map((section) =>
+		section.host === host ? { ...section, workspaces: update(section.workspaces) } : section,
+	);
+}
 
 export function hasConfiguredOrchestratorAgent(
 	workspace: Pick<WorkspaceSummary, "orchestratorAgent"> | undefined,

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -73,7 +73,7 @@ export type TaskComposerModelControl = {
 	mode: string;
 	onModeChange: (value: string) => void;
 	onModelChange: (value: string) => void;
-	projectId: string;
+	project: { host: string; id: string };
 	value: string;
 };
 


### PR DESCRIPTION
## Ticket

No upstream issue. [RFC](https://github.com/AronPerez/agent-orchestrator/blob/plan/2026-08-24-wave3/docs/upstreaming-rfc-remote-hosts.md). Stacked on #4374.

## Problem

The terminal mux pool holds one current socket for the whole app. With two hosts, opening a terminal on the second machine silently retires the first machine's connection, and a remote host's mux URL loses its loopback-proxy path prefix — dropping the token the proxy authenticates on.

## Solution

`createTerminalMuxPool` holds a `Map<HostId, Connection>` instead of one `current`; `muxUrlForHost(host)` derives from that host's own base, so the proxy token survives in the path. Retained terminals are keyed by `Ref`, and `useShellTerminals` becomes per host in full, mutations included.

## How Has This Been Tested?

`cd frontend && npm run typecheck && npm run typecheck:e2e && npx vitest run src/renderer` on the current `main` (`c9a0adb2`): 143 files / 2077 tests, all green (base was 143/2063). New cases: each host's mux URL keeps its token segment; the pool keeps one live socket per host; closing one host's mux leaves the other open.

**Update:** QA found "`useShellTerminals` becomes per host in full" overstated the UI's reach — `useConnectedShellTerminals()` existed but had zero consumers, so no surface actually showed a remote host's shell terminal. Fixed: `ShellTerminalsView` now uses it for the standalone list, and `SessionView` calls `useShellTerminals(sessionRef.host)`. Two lines of production code; the test count above includes the RED-then-GREEN coverage.

## Artifacts (if appropriate):

![Standalone terminals list, remote host's shell active — cwd is the remote checkout](https://raw.githubusercontent.com/AronPerez/agent-orchestrator/campaign-assets/qa-evidence/a8c-terminals.png)
![Same tab strip, local shell active — cwd is the local checkout](https://raw.githubusercontent.com/AronPerez/agent-orchestrator/campaign-assets/qa-evidence/a8c-terminals-2.png)

Real PTYs on two real daemons (`cwd` in-frame is the discriminator). One caveat visible above: the tab strip doesn't name which host a shell belongs to — both default to the project title. Real UX gap, not a capture artifact.

*Captured on a dev build; `--disable-web-security` bridges the dev-origin CORS gap only (production origin `app://renderer` passes the same check natively) — the daemon, proxy, credential, and traffic are all real.*
