### PR TITLE
fix(chat): TurnOutcome no longer crashes on an unmapped turn state

### DIFF
--- a/frontend/src/renderer/components/chat/ChatTimelineItems.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.test.tsx
@@ -8,6 +8,11 @@ describe("TurnOutcome", () => {
 		expect(screen.getByText("Outcome unknown")).toBeInTheDocument();
 		expect(screen.queryByText("Done")).not.toBeInTheDocument();
 	});
+
+	it("renders a daemon-reported state this build does not recognize instead of crashing", () => {
+		render(<TurnOutcome state="orphaned" />);
+		expect(screen.getByText("orphaned")).toBeInTheDocument();
+	});
 });
 
 describe("ActivityRow", () => {

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -2235,14 +2235,19 @@ export function TurnOutcome({
 	state,
 	error,
 }: {
-	state: "recovered" | "interrupted" | "failed";
+	state: "recovered" | "interrupted" | "failed" | (string & {});
 	error?: string;
 }) {
-	const copy = {
-		recovered: { label: "Outcome unknown", tone: "text-muted-foreground/70" },
-		interrupted: { label: "Stopped", tone: "text-muted-foreground/70" },
-		failed: { label: "Failed", tone: "text-destructive" },
-	}[state];
+	// `state` is cast from the wire response (see useConversation.ts toSnapshot),
+	// not validated at runtime — a daemon reporting a TurnState this build predates
+	// must not crash the whole timeline, just show it as-is.
+	const copy = (
+		{
+			recovered: { label: "Outcome unknown", tone: "text-muted-foreground/70" },
+			interrupted: { label: "Stopped", tone: "text-muted-foreground/70" },
+			failed: { label: "Failed", tone: "text-destructive" },
+		} as Record<string, { label: string; tone: string }>
+	)[state] ?? { label: state, tone: "text-muted-foreground/70" };
 
 	return (
 		<div className="flex items-center gap-2 pt-1">


### PR DESCRIPTION
Chat crashes with `Cannot read properties of undefined (reading 'tone')` whenever a turn's `state` reaches `TurnOutcome` with a value outside `recovered | interrupted | failed`.

**Root cause:** `useConversation.ts` casts the wire response with `turn.state as TurnState` — no runtime validation. `TurnOutcome` (ChatTimelineItems.tsx) then does an unguarded object lookup keyed by that value and immediately reads `.tone` off the result. If the daemon ever reports a state this frontend build doesn't recognize — most plausibly during a version skew right after an app auto-update — `copy` is `undefined` and the whole chat timeline crashes behind the generic error boundary, with no way to recover the session short of restarting.

Observed on a fresh `brew install` (0.12.6 cask) while trying to open the project orchestrator: the session first surfaced `SESSION_NOT_FOUND`, and the timeline crashed on reload with this error.

**Fix:** fall back to rendering the raw state label when the lookup misses, instead of assuming it always succeeds. Added a regression test covering an unmapped state string.

Verified: `npm test` passes (3/3, including the new case) and `tsc --noEmit` reports no new errors in the touched files.