### PR TITLE
fix(desktop): embed tmux terminfo fallback

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -51,19 +51,21 @@ var getenv = os.Getenv
 // Options configures a tmux Runtime. Every field has a sensible default (see
 // New), so the zero value is usable.
 type Options struct {
-	Binary     string        // default configured/bundled/system tmux resolution
-	SocketName string        // default $AO_TMUX_SOCKET_NAME; empty uses tmux's machine-wide default socket
-	Shell      string        // default $SHELL else /bin/sh
-	Timeout    time.Duration // default 5s
-	ChunkSize  int           // default 16*1024
-	EnterDelay time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
-	ReapGrace  time.Duration // grace between SIGTERM and SIGKILL when reaping a pane's leftover background processes on Destroy; default defaultReapGrace.
+	Binary       string        // default configured/bundled/system tmux resolution
+	LegacyBinary string        // default system tmux from PATH when SocketName is set; used only for pre-private-socket sessions
+	SocketName   string        // default $AO_TMUX_SOCKET_NAME; empty uses tmux's machine-wide default socket
+	Shell        string        // default $SHELL else /bin/sh
+	Timeout      time.Duration // default 5s
+	ChunkSize    int           // default 16*1024
+	EnterDelay   time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
+	ReapGrace    time.Duration // grace between SIGTERM and SIGKILL when reaping a pane's leftover background processes on Destroy; default defaultReapGrace.
 }
 
 // Runtime runs agent sessions inside tmux sessions, driving them via the tmux
 // CLI. It implements ports.Runtime.
 type Runtime struct {
 	binary         string
+	legacyBinary   string
 	socketName     string
 	shell          string
 	timeout        time.Duration
@@ -286,8 +288,22 @@ func New(opts Options) *Runtime {
 	if socketName == "" {
 		socketName = strings.TrimSpace(getenv("AO_TMUX_SOCKET_NAME"))
 	}
+	legacyBinary := opts.LegacyBinary
+	if legacyBinary == "" && socketName != "" {
+		// Sessions created before AO introduced its private socket were started by
+		// the machine tmux from PATH. Use that matching client for the legacy
+		// default socket: tmux's client/server protocol is not guaranteed across
+		// versions, so AO's pinned bundled client may be unable to adopt them.
+		if systemTmux, err := exec.LookPath("tmux"); err == nil {
+			legacyBinary = systemTmux
+		}
+	}
+	if legacyBinary == "" {
+		legacyBinary = binary
+	}
 	return &Runtime{
 		binary:         binary,
+		legacyBinary:   legacyBinary,
 		socketName:     socketName,
 		shell:          shellPath,
 		timeout:        timeout,
@@ -758,7 +774,7 @@ func (r *Runtime) attachCommandForSocket(id, socketName string) []string {
 	// The embedded xterm renderer supports 24-bit SGR colors. Tell this tmux
 	// client explicitly so tmux forwards RGB instead of quantizing it to the
 	// xterm-256color palette. -T is available in AO's minimum tmux version (3.2).
-	argv := []string{r.binary}
+	argv := []string{r.binaryForSocket(socketName)}
 	if socketName != "" {
 		argv = append(argv, "-L", socketName)
 	}
@@ -797,7 +813,14 @@ func (r *Runtime) runOnSocket(ctx context.Context, socketName string, args ...st
 	if socketName != "" {
 		args = append([]string{"-L", socketName}, args...)
 	}
-	return r.runCommand(ctx, r.binary, args...)
+	return r.runCommand(ctx, r.binaryForSocket(socketName), args...)
+}
+
+func (r *Runtime) binaryForSocket(socketName string) string {
+	if socketName == "" && r.socketName != "" {
+		return r.legacyBinary
+	}
+	return r.binary
 }
 
 // runForSession routes sessions created before AO introduced its private tmux

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -525,13 +525,11 @@ func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
 
 // IsAlive reports whether the handle's session still exists via `tmux
 // has-session`. Exit 0 means alive. A non-zero exit with output naming this
-// session as missing is a definitive false, nil. A server-level failure ("no
-// server running", "error connecting") wraps ports.ErrRuntimeUnavailable: the
-// probe learned nothing about this session — the agent process may well still
-// be running as an orphan of the dead server — so it must never be read as
-// per-session death (issue #3475). Any other non-zero exit is a plain probe
-// error so callers (the reaper feeding the LCM) treat it as a failed probe
-// and never kill a session on a transient error.
+// session as missing is a definitive false, nil. A conclusively absent server
+// wraps ports.ErrRuntimeUnavailable so recovery may recreate it. A transient
+// connection or protocol/client failure wraps ErrRuntimeProbeInconclusive so
+// no caller can treat a possibly-live session as absent. Any other non-zero
+// exit is a plain probe error, which is likewise never per-session death.
 func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
 	id, err := handleID(handle)
 	if err != nil {
@@ -544,9 +542,13 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 			if sessionMissingOutput(string(out)) {
 				return false, nil
 			}
-			if serverUnreachableOutput(string(out)) {
+			if serverNotRunningOutput(string(out)) {
 				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",
 					id, ports.ErrRuntimeUnavailable, strings.TrimSpace(string(out)))
+			}
+			if transientServerFailureOutput(string(out)) {
+				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",
+					id, ports.ErrRuntimeProbeInconclusive, strings.TrimSpace(string(out)))
 			}
 		}
 		return false, fmt.Errorf("tmux runtime: probe session %s: %w", id, err)
@@ -865,13 +867,13 @@ func (r *Runtime) socketForSession(ctx context.Context, id string) (string, erro
 	// Only cross the migration boundary when the private server definitively
 	// lacks this session. An ambiguous probe stays on the private socket so a
 	// transient error cannot redirect a live session elsewhere.
-	if !sessionMissingOutput(string(out)) && !serverAbsentOutput(string(out)) {
+	if !sessionMissingOutput(string(out)) && !serverNotRunningOutput(string(out)) {
 		return r.socketName, nil
 	}
 	if r.legacyBinary == "" {
 		return "", fmt.Errorf(
 			"%w: cannot inspect legacy default-socket session %s because system tmux is unavailable",
-			ports.ErrRuntimeUnavailable,
+			ports.ErrRuntimeProbeInconclusive,
 			id,
 		)
 	}
@@ -883,14 +885,14 @@ func (r *Runtime) socketForSession(ctx context.Context, id string) (string, erro
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}
-	if sessionMissingOutput(string(legacyOut)) || serverAbsentOutput(string(legacyOut)) {
+	if sessionMissingOutput(string(legacyOut)) || serverNotRunningOutput(string(legacyOut)) {
 		// Both known sockets definitively lack the session. Return the private
 		// target so IsAlive's ordinary exact-session handling reports false.
 		return r.socketName, nil
 	}
 	return "", fmt.Errorf(
 		"%w: system tmux %q could not inspect legacy default-socket session %s: %w",
-		ports.ErrRuntimeUnavailable,
+		ports.ErrRuntimeProbeInconclusive,
 		r.legacyBinary,
 		id,
 		legacyErr,
@@ -1107,13 +1109,19 @@ func sessionMissingOutput(out string) bool {
 // server itself could not be reached, which is inconclusive for any single
 // session's liveness.
 func serverUnreachableOutput(out string) bool {
-	s := strings.ToLower(out)
-	return serverAbsentOutput(s) || strings.Contains(s, "protocol version mismatch")
+	return serverNotRunningOutput(out) || transientServerFailureOutput(out)
 }
 
-func serverAbsentOutput(out string) bool {
+func serverNotRunningOutput(out string) bool {
 	s := strings.ToLower(out)
-	return strings.Contains(s, "no server running") || strings.Contains(s, "error connecting")
+	return strings.Contains(s, "no server running")
+}
+
+func transientServerFailureOutput(out string) bool {
+	s := strings.ToLower(out)
+	return strings.Contains(s, "error connecting") ||
+		strings.Contains(s, "protocol version mismatch") ||
+		strings.Contains(s, "server exited unexpectedly")
 }
 
 // killSessionMissingOutput reports whether a non-zero `tmux kill-session`

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -289,7 +289,9 @@ func New(opts Options) *Runtime {
 		socketName = strings.TrimSpace(getenv("AO_TMUX_SOCKET_NAME"))
 	}
 	legacyBinary := opts.LegacyBinary
-	if legacyBinary == "" && socketName != "" {
+	if socketName == "" {
+		legacyBinary = binary
+	} else if legacyBinary == "" {
 		// Sessions created before AO introduced its private socket were started by
 		// the machine tmux from PATH. Use that matching client for the legacy
 		// default socket: tmux's client/server protocol is not guaranteed across
@@ -297,9 +299,6 @@ func New(opts Options) *Runtime {
 		if systemTmux, err := exec.LookPath("tmux"); err == nil {
 			legacyBinary = systemTmux
 		}
-	}
-	if legacyBinary == "" {
-		legacyBinary = binary
 	}
 	return &Runtime{
 		binary:         binary,
@@ -740,7 +739,11 @@ func (r *Runtime) Attach(ctx context.Context, handle ports.RuntimeHandle, rows, 
 	if err != nil {
 		return nil, err
 	}
-	argv := r.attachCommandForSocket(id, r.socketForSession(ctx, id))
+	socketName, err := r.socketForSession(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("tmux runtime: attach session %s: %w", id, err)
+	}
+	argv := r.attachCommandForSocket(id, socketName)
 	return ptyexec.Spawn(ctx, argv, attachEnv(os.Environ()), rows, cols)
 }
 
@@ -777,6 +780,10 @@ func (r *Runtime) attachCommandForSocket(id, socketName string) []string {
 	argv := []string{r.binaryForSocket(socketName)}
 	if socketName != "" {
 		argv = append(argv, "-L", socketName)
+	} else if r.socketName != "" {
+		// A legacy session means tmux's historical machine default, never the
+		// socket named by an inherited TMUX from an AO worker or nested shell.
+		argv = append(argv, "-L", "default")
 	}
 	return append(argv, "-u", "-T", "RGB", "attach-session", "-t", id)
 }
@@ -812,6 +819,11 @@ func (r *Runtime) run(ctx context.Context, args ...string) ([]byte, error) {
 func (r *Runtime) runOnSocket(ctx context.Context, socketName string, args ...string) ([]byte, error) {
 	if socketName != "" {
 		args = append([]string{"-L", socketName}, args...)
+	} else if r.socketName != "" {
+		// Pin legacy discovery and commands to the historical machine default.
+		// Without -L, tmux honors inherited TMUX and may target an unrelated
+		// nested server whose session name happens to collide with AO's handle.
+		args = append([]string{"-L", "default"}, args...)
 	}
 	return r.runCommand(ctx, r.binaryForSocket(socketName), args...)
 }
@@ -827,36 +839,62 @@ func (r *Runtime) binaryForSocket(socketName string) string {
 // socket back to tmux's legacy default socket. The decision is discovered once
 // per daemon lifetime and cached. New sessions always use socketName.
 func (r *Runtime) runForSession(ctx context.Context, id string, args ...string) ([]byte, error) {
-	return r.runOnSocket(ctx, r.socketForSession(ctx, id), args...)
+	socketName, err := r.socketForSession(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return r.runOnSocket(ctx, socketName, args...)
 }
 
-func (r *Runtime) socketForSession(ctx context.Context, id string) string {
+func (r *Runtime) socketForSession(ctx context.Context, id string) (string, error) {
 	if r.socketName == "" {
-		return ""
+		return "", nil
 	}
 	r.socketMu.RLock()
 	socketName, ok := r.sessionSockets[id]
 	r.socketMu.RUnlock()
 	if ok {
-		return socketName
+		return socketName, nil
 	}
 
 	out, err := r.runOnSocket(ctx, r.socketName, hasSessionArgs(id)...)
 	if err == nil {
 		r.rememberSessionSocket(id, r.socketName)
-		return r.socketName
+		return r.socketName, nil
 	}
 	// Only cross the migration boundary when the private server definitively
 	// lacks this session. An ambiguous probe stays on the private socket so a
 	// transient error cannot redirect a live session elsewhere.
 	if !sessionMissingOutput(string(out)) && !serverAbsentOutput(string(out)) {
-		return r.socketName
+		return r.socketName, nil
 	}
-	if _, legacyErr := r.runOnSocket(ctx, "", hasSessionArgs(id)...); legacyErr == nil {
+	if r.legacyBinary == "" {
+		return "", fmt.Errorf(
+			"%w: cannot inspect legacy default-socket session %s because system tmux is unavailable",
+			ports.ErrRuntimeUnavailable,
+			id,
+		)
+	}
+	legacyOut, legacyErr := r.runOnSocket(ctx, "", hasSessionArgs(id)...)
+	if legacyErr == nil {
 		r.rememberSessionSocket(id, "")
-		return ""
+		return "", nil
 	}
-	return r.socketName
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	if sessionMissingOutput(string(legacyOut)) || serverAbsentOutput(string(legacyOut)) {
+		// Both known sockets definitively lack the session. Return the private
+		// target so IsAlive's ordinary exact-session handling reports false.
+		return r.socketName, nil
+	}
+	return "", fmt.Errorf(
+		"%w: system tmux %q could not inspect legacy default-socket session %s: %w",
+		ports.ErrRuntimeUnavailable,
+		r.legacyBinary,
+		id,
+		legacyErr,
+	)
 }
 
 func (r *Runtime) rememberSessionSocket(id, socketName string) {

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -128,6 +128,75 @@ func TestRuntimeIntegrationExactSessionParsing(t *testing.T) {
 	}
 }
 
+func TestRuntimeIntegrationLegacyDefaultSocketIgnoresInheritedTMUX(t *testing.T) {
+	systemTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux unavailable")
+	}
+
+	// tmux's Unix socket path has a small platform limit; Go's ordinary test
+	// temp root is long enough to exceed it on macOS.
+	tmuxTmpDir, err := os.MkdirTemp("/tmp", "ao-tmux-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmuxTmpDir) })
+	t.Setenv("TMUX_TMPDIR", tmuxTmpDir)
+	legacyID := strings.ReplaceAll(t.Name(), "/", "_") + "_legacy"
+	spoofID := strings.ReplaceAll(t.Name(), "/", "_") + "_spoof"
+	privateID := strings.ReplaceAll(t.Name(), "/", "_") + "_private"
+	for _, socketName := range []string{"default", "spoof", "ao"} {
+		t.Cleanup(func() {
+			_ = exec.Command(systemTmux, "-L", socketName, "kill-server").Run()
+		})
+	}
+	start := func(socketName, sessionID string) {
+		t.Helper()
+		if out, startErr := exec.Command(
+			systemTmux,
+			"-L", socketName,
+			"new-session", "-d", "-s", sessionID,
+			"sleep 30",
+		).CombinedOutput(); startErr != nil {
+			t.Fatalf("start tmux -L %s: %v: %s", socketName, startErr, out)
+		}
+	}
+	start("default", legacyID)
+	start("spoof", spoofID)
+	start("ao", privateID)
+
+	spoofIdentity, err := exec.Command(
+		systemTmux,
+		"-L", "spoof",
+		"display-message", "-p", "#{socket_path},#{pid},0",
+	).Output()
+	if err != nil {
+		t.Fatalf("read spoof socket identity: %v", err)
+	}
+	t.Setenv("TMUX", strings.TrimSpace(string(spoofIdentity)))
+	if out, err := exec.Command(systemTmux, "has-session", "-t", spoofID).CombinedOutput(); err != nil {
+		t.Fatalf("test setup did not redirect plain tmux through inherited TMUX: %v: %s", err, out)
+	}
+
+	r := New(Options{
+		Binary:       systemTmux,
+		LegacyBinary: systemTmux,
+		SocketName:   "ao",
+		Timeout:      5 * time.Second,
+	})
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: legacyID})
+	if err != nil || !alive {
+		t.Fatalf("legacy default-socket session = (%v, %v), want (true, nil)", alive, err)
+	}
+	alive, err = r.IsAlive(context.Background(), ports.RuntimeHandle{ID: spoofID})
+	if err != nil {
+		t.Fatalf("spoof-only session probe: %v", err)
+	}
+	if alive {
+		t.Fatal("spoof-only session was misclassified as AO's legacy session")
+	}
+}
+
 func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux unavailable")

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -69,8 +69,8 @@ func TestRuntimeIntegration(t *testing.T) {
 
 	// Destroy and verify liveness goes false. When this was the server's last
 	// session the server itself exits with it, and the probe reports the
-	// server-level outage as an inconclusive ErrRuntimeUnavailable rather than
-	// a per-session death (issue #3475); both outcomes mean the handle is gone.
+	// server-level outage as ErrRuntimeUnavailable rather than a per-session
+	// false result (issue #3475); both outcomes mean the tmux handle is gone.
 	if err := r.Destroy(ctx, h); err != nil {
 		t.Fatalf("Destroy: %v", err)
 	}

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -136,6 +136,44 @@ func TestNewUsesAppOwnedTmuxSocketFromEnv(t *testing.T) {
 	}
 }
 
+func TestNewUsesSystemTmuxForLegacyDefaultSocket(t *testing.T) {
+	binDir := t.TempDir()
+	systemTmux := filepath.Join(binDir, "tmux")
+	if err := os.WriteFile(systemTmux, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundledTmux := filepath.Join(t.TempDir(), "bundled-tmux")
+	if err := os.WriteFile(bundledTmux, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("AO_TMUX_BINARY", bundledTmux)
+	t.Setenv("AO_TMUX_SOCKET_NAME", "ao")
+
+	r := New(Options{})
+	if got := r.binary; got != bundledTmux {
+		t.Fatalf("binary = %q, want bundled tmux %q", got, bundledTmux)
+	}
+	if got := r.legacyBinary; got != systemTmux {
+		t.Fatalf("legacy binary = %q, want system tmux %q", got, systemTmux)
+	}
+}
+
+func TestNewFallsBackToPrimaryTmuxForLegacySocketWithoutSystemTmux(t *testing.T) {
+	bundledTmux := filepath.Join(t.TempDir(), "bundled-tmux")
+	if err := os.WriteFile(bundledTmux, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("AO_TMUX_BINARY", bundledTmux)
+	t.Setenv("AO_TMUX_SOCKET_NAME", "ao")
+
+	r := New(Options{})
+	if got := r.legacyBinary; got != bundledTmux {
+		t.Fatalf("legacy binary = %q, want primary fallback %q", got, bundledTmux)
+	}
+}
+
 // TestExecRunnerRunsFromStableDir is the direct regression test for Fix 1:
 // execRunner.Run must pin cmd.Dir to os.TempDir() rather than inheriting
 // whatever the daemon process's own cwd happens to be. The first tmux CLI
@@ -696,7 +734,12 @@ func TestRestartRejectsMismatchedSessionHandle(t *testing.T) {
 }
 
 func TestIsAliveAdoptsSessionFromLegacyDefaultSocket(t *testing.T) {
-	r := New(Options{Binary: "tmux-test", SocketName: "ao", Timeout: time.Second})
+	r := New(Options{
+		Binary:       "bundled-tmux-test",
+		LegacyBinary: "system-tmux-test",
+		SocketName:   "ao",
+		Timeout:      time.Second,
+	})
 	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
 		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
 		{}, // legacy default-socket discovery
@@ -718,10 +761,19 @@ func TestIsAliveAdoptsSessionFromLegacyDefaultSocket(t *testing.T) {
 		hasSessionArgs("sess-1"),
 		hasSessionArgs("sess-1"),
 	}
+	wantBinaries := []string{
+		"bundled-tmux-test",
+		"system-tmux-test",
+		"system-tmux-test",
+		"system-tmux-test",
+	}
 	if len(fr.calls) != len(want) {
 		t.Fatalf("calls = %d, want %d: %+v", len(fr.calls), len(want), fr.calls)
 	}
 	for i := range want {
+		if fr.calls[i].name != wantBinaries[i] {
+			t.Fatalf("call %d binary = %q, want %q", i, fr.calls[i].name, wantBinaries[i])
+		}
 		if !reflect.DeepEqual(fr.calls[i].args, want[i]) {
 			t.Fatalf("call %d args = %#v, want %#v", i, fr.calls[i].args, want[i])
 		}
@@ -1272,6 +1324,20 @@ func TestAttachCommandUsesAppOwnedSocket(t *testing.T) {
 		t.Fatalf("AttachCommand: %v", err)
 	}
 	want := []string{"/opt/ao/resources/tmux/bin/tmux", "-L", "ao", "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("argv = %#v, want %#v", argv, want)
+	}
+}
+
+func TestAttachCommandUsesSystemTmuxForLegacyDefaultSocket(t *testing.T) {
+	r := New(Options{
+		Binary:       "/opt/ao/resources/tmux/bin/tmux",
+		LegacyBinary: "/opt/homebrew/bin/tmux",
+		SocketName:   "ao",
+		Timeout:      time.Second,
+	})
+	argv := r.attachCommandForSocket("sess-1", "")
+	want := []string{"/opt/homebrew/bin/tmux", "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
 	if !reflect.DeepEqual(argv, want) {
 		t.Fatalf("argv = %#v, want %#v", argv, want)
 	}

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -780,7 +780,7 @@ func TestIsAliveAdoptsSessionFromLegacyDefaultSocket(t *testing.T) {
 	}
 }
 
-func TestIsAliveReportsMissingLegacyClientAsRuntimeUnavailable(t *testing.T) {
+func TestIsAliveReportsMissingLegacyClientAsProbeInconclusive(t *testing.T) {
 	r := New(Options{Binary: "bundled-tmux-test", SocketName: "ao", Timeout: time.Second})
 	r.legacyBinary = ""
 	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
@@ -789,8 +789,8 @@ func TestIsAliveReportsMissingLegacyClientAsRuntimeUnavailable(t *testing.T) {
 	r.runner = fr
 
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
 	}
 	if alive {
 		t.Fatal("alive = true, want false with inconclusive error")
@@ -800,7 +800,7 @@ func TestIsAliveReportsMissingLegacyClientAsRuntimeUnavailable(t *testing.T) {
 	}
 }
 
-func TestIsAliveReportsIncompatibleLegacyClientAsRuntimeUnavailable(t *testing.T) {
+func TestIsAliveReportsIncompatibleLegacyClientAsProbeInconclusive(t *testing.T) {
 	r := New(Options{
 		Binary:       "bundled-tmux-test",
 		LegacyBinary: "system-tmux-test",
@@ -814,14 +814,39 @@ func TestIsAliveReportsIncompatibleLegacyClientAsRuntimeUnavailable(t *testing.T
 	r.runner = fr
 
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
 	}
 	if alive {
 		t.Fatal("alive = true, want false with inconclusive error")
 	}
 	if !strings.Contains(err.Error(), "server exited unexpectedly") {
 		t.Fatalf("IsAlive err = %v, want actionable legacy client failure", err)
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("calls = %d, want private then legacy probes only", len(fr.calls))
+	}
+}
+
+func TestIsAliveReportsTransientLegacyConnectionAsProbeInconclusive(t *testing.T) {
+	r := New(Options{
+		Binary:       "bundled-tmux-test",
+		LegacyBinary: "system-tmux-test",
+		SocketName:   "ao",
+		Timeout:      time.Second,
+	})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
+		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
+		{out: []byte("error connecting to /tmp/tmux-1000/default (Connection refused)"), err: &exec.ExitError{}},
+	}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
+	}
+	if alive {
+		t.Fatal("alive = true, want false with inconclusive error")
 	}
 	if len(fr.calls) != 2 {
 		t.Fatalf("calls = %d, want private then legacy probes only", len(fr.calls))
@@ -1031,11 +1056,10 @@ func TestIsAliveReturnsFalseNilOnCantFindSession(t *testing.T) {
 	}
 }
 
-// A server-level failure says nothing about one session: the whole server is
-// gone (or unreachable), and the agent may still be alive as an orphan. It
-// must surface as ports.ErrRuntimeUnavailable — an inconclusive probe — never
-// as a definitive "this session is dead" (issue #3475: reading it as death
-// archived every session on the board in one pass).
+// A conclusively absent server means the tmux runtime handle is gone, although
+// the agent may still be alive as an orphan. Surface the infrastructure-level
+// sentinel rather than a per-session false result: the reaper treats errors as
+// failed probes, while explicit recovery paths may recreate the missing server.
 func TestIsAliveReportsNoServerAsRuntimeUnavailable(t *testing.T) {
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{[]byte("no server running on /tmp/tmux-1000/default")}
@@ -1050,14 +1074,14 @@ func TestIsAliveReportsNoServerAsRuntimeUnavailable(t *testing.T) {
 	}
 }
 
-func TestIsAliveReportsErrorConnectingAsRuntimeUnavailable(t *testing.T) {
+func TestIsAliveReportsErrorConnectingAsProbeInconclusive(t *testing.T) {
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{[]byte("error connecting to /tmp/tmux-1000/default (No such file or directory)")}
 	fr.err = &exec.ExitError{}
 
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
 	}
 	if alive {
 		t.Fatal("alive = true, want false")

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -159,7 +159,7 @@ func TestNewUsesSystemTmuxForLegacyDefaultSocket(t *testing.T) {
 	}
 }
 
-func TestNewFallsBackToPrimaryTmuxForLegacySocketWithoutSystemTmux(t *testing.T) {
+func TestNewLeavesLegacyTmuxUnavailableWithoutSystemTmux(t *testing.T) {
 	bundledTmux := filepath.Join(t.TempDir(), "bundled-tmux")
 	if err := os.WriteFile(bundledTmux, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
@@ -169,8 +169,8 @@ func TestNewFallsBackToPrimaryTmuxForLegacySocketWithoutSystemTmux(t *testing.T)
 	t.Setenv("AO_TMUX_SOCKET_NAME", "ao")
 
 	r := New(Options{})
-	if got := r.legacyBinary; got != bundledTmux {
-		t.Fatalf("legacy binary = %q, want primary fallback %q", got, bundledTmux)
+	if got := r.legacyBinary; got != "" {
+		t.Fatalf("legacy binary = %q, want unavailable", got)
 	}
 }
 
@@ -757,9 +757,9 @@ func TestIsAliveAdoptsSessionFromLegacyDefaultSocket(t *testing.T) {
 	}
 	want := [][]string{
 		append([]string{"-L", "ao"}, hasSessionArgs("sess-1")...),
-		hasSessionArgs("sess-1"),
-		hasSessionArgs("sess-1"),
-		hasSessionArgs("sess-1"),
+		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
+		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
+		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
 	}
 	wantBinaries := []string{
 		"bundled-tmux-test",
@@ -777,6 +777,54 @@ func TestIsAliveAdoptsSessionFromLegacyDefaultSocket(t *testing.T) {
 		if !reflect.DeepEqual(fr.calls[i].args, want[i]) {
 			t.Fatalf("call %d args = %#v, want %#v", i, fr.calls[i].args, want[i])
 		}
+	}
+}
+
+func TestIsAliveReportsMissingLegacyClientAsRuntimeUnavailable(t *testing.T) {
+	r := New(Options{Binary: "bundled-tmux-test", SocketName: "ao", Timeout: time.Second})
+	r.legacyBinary = ""
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
+		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
+	}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	}
+	if alive {
+		t.Fatal("alive = true, want false with inconclusive error")
+	}
+	if len(fr.calls) != 1 {
+		t.Fatalf("calls = %d, want only the private-socket probe", len(fr.calls))
+	}
+}
+
+func TestIsAliveReportsIncompatibleLegacyClientAsRuntimeUnavailable(t *testing.T) {
+	r := New(Options{
+		Binary:       "bundled-tmux-test",
+		LegacyBinary: "system-tmux-test",
+		SocketName:   "ao",
+		Timeout:      time.Second,
+	})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
+		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
+		{out: []byte("server exited unexpectedly"), err: &exec.ExitError{}},
+	}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	}
+	if alive {
+		t.Fatal("alive = true, want false with inconclusive error")
+	}
+	if !strings.Contains(err.Error(), "server exited unexpectedly") {
+		t.Fatalf("IsAlive err = %v, want actionable legacy client failure", err)
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("calls = %d, want private then legacy probes only", len(fr.calls))
 	}
 }
 
@@ -1337,7 +1385,7 @@ func TestAttachCommandUsesSystemTmuxForLegacyDefaultSocket(t *testing.T) {
 		Timeout:      time.Second,
 	})
 	argv := r.attachCommandForSocket("sess-1", "")
-	want := []string{"/opt/homebrew/bin/tmux", "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
+	want := []string{"/opt/homebrew/bin/tmux", "-L", "default", "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
 	if !reflect.DeepEqual(argv, want) {
 		t.Fatalf("argv = %#v, want %#v", argv, want)
 	}

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -329,14 +329,17 @@ var (
 	// actionable apierr instead of letting it fall through to an opaque 500
 	// with no message (issue #2775).
 	ErrRuntimeWorkspaceCwdMismatch = errors.New("runtime: session working directory mismatch")
-	// ErrRuntimeUnavailable reports that a liveness probe could not reach the
-	// runtime infrastructure at all (e.g. tmux "no server running" or "error
-	// connecting"). It says nothing about any individual session, so callers
-	// must treat it as an inconclusive probe, never as per-session death
-	// (issue #3475: reading a server-level outage as N session deaths archived
-	// every session on the board). Adapters wrap this sentinel via fmt.Errorf
-	// so callers can match it with errors.Is.
+	// ErrRuntimeUnavailable reports that the runtime infrastructure is
+	// conclusively absent (for example tmux reports "no server running"). Some
+	// recovery callers intentionally use that evidence to recreate a runtime.
 	ErrRuntimeUnavailable = errors.New("runtime: infrastructure unavailable")
+	// ErrRuntimeProbeInconclusive reports that a liveness probe could not inspect
+	// a possibly-live runtime (for example a transient socket error, missing
+	// compatible client, or client/server protocol mismatch). Callers must
+	// preserve the existing controller and must not recreate, destroy, archive,
+	// or otherwise treat the session as dead. Adapters wrap this sentinel via
+	// fmt.Errorf so callers can match it with errors.Is.
+	ErrRuntimeProbeInconclusive = errors.New("runtime: liveness probe inconclusive")
 )
 
 // WorkspaceConfig is the spec for creating or restoring a session's workspace.

--- a/backend/internal/session_manager/agent_switching.go
+++ b/backend/internal/session_manager/agent_switching.go
@@ -3124,6 +3124,12 @@ func (m *Manager) reconcileStartingTarget(ctx context.Context, store ports.Agent
 	handle := ports.RuntimeHandle{ID: targetHandleID}
 	alive, err := m.runtime.IsAlive(ctx, handle)
 	if err != nil {
+		if errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+			// The durable target handle may still own a live controller. Preserve
+			// the controller, workspace, switch facts, and input fence until a
+			// later reconciliation can inspect it conclusively.
+			return false, err
+		}
 		if destroyErr := m.runtime.Destroy(ctx, handle); destroyErr != nil {
 			// The target may exist and the durable row still names the source. Keep
 			// the input fence closed until a later daemon reconciliation can prove

--- a/backend/internal/session_manager/agent_switching_test.go
+++ b/backend/internal/session_manager/agent_switching_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -3669,6 +3670,51 @@ func TestReconcileAgentSwitchesUsesDurableBoundaries(t *testing.T) {
 				t.Fatal("resolved recovery left input gated")
 			}
 		})
+	}
+}
+
+func TestReconcileStartingTargetPreservesInconclusiveRuntime(t *testing.T) {
+	probeErr := fmt.Errorf("legacy target inspection failed: %w", ports.ErrRuntimeProbeInconclusive)
+	runtime := &fakeRestartRuntime{fakeRuntime: &fakeRuntime{aliveErr: probeErr}}
+	manager, store, messenger := newSwitchTestManager(t, runtime)
+	target := manager.agents.(switchTestAgents)[domain.HarnessCodex].(*switchTestAgent)
+	now := time.Now().UTC()
+	targetRef := domain.AgentNativeSessionID("native-target")
+	sw := domain.AgentSwitch{
+		ID: "switch-inconclusive-target", SessionID: "proj-1", IdempotencyKey: "inconclusive-target",
+		RequestFingerprint: domain.ComputeAgentSwitchRequestFingerprint("proj-1", domain.HarnessCodex, ""),
+		FromHarness:        domain.HarnessClaudeCode, TargetHarness: domain.HarnessCodex,
+		TargetNativeSessionRef: &targetRef, TargetStartMode: domain.AgentSwitchTargetStartFresh,
+		State: domain.AgentSwitchStartingTarget, AgentHandoffStatus: domain.AgentHandoffUnavailable,
+		SourceGenerationID: "source-generation", TargetGenerationID: "target-generation",
+		TargetRuntimeHandleID: "durable-target-handle", RequestedAt: now, UpdatedAt: now,
+	}
+	store.switches[sw.ID] = sw
+	recBefore := store.sessions[sw.SessionID]
+	recBefore.Activity = domain.Activity{State: domain.ActivityExited, LastActivityAt: now}
+	store.sessions[recBefore.ID] = recBefore
+
+	err := manager.ReconcileAgentSwitches(context.Background())
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("reconcile error = %v, want ErrRuntimeProbeInconclusive", err)
+	}
+	if got := store.switches[sw.ID]; got != sw {
+		t.Fatalf("inconclusive recovery mutated switch:\n got  %+v\n want %+v", got, sw)
+	}
+	if got := store.sessions[recBefore.ID]; !reflect.DeepEqual(got, recBefore) {
+		t.Fatalf("inconclusive recovery mutated session:\n got  %+v\n want %+v", got, recBefore)
+	}
+	if len(runtime.destroyedIDs) != 0 {
+		t.Fatalf("inconclusive recovery destroyed runtimes: %v", runtime.destroyedIDs)
+	}
+	if target.cleanupCalls != 0 {
+		t.Fatalf("inconclusive recovery cleaned target workspace %d times, want 0", target.cleanupCalls)
+	}
+	if len(messenger.msgs) != 0 {
+		t.Fatalf("inconclusive recovery sent continuation: %#v", messenger.msgs)
+	}
+	if !manager.SessionMutationInProgress(sw.SessionID) {
+		t.Fatal("inconclusive recovery reopened session input")
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -7528,6 +7528,52 @@ func TestReconcileLive_ProbeErrorIsNotDeath(t *testing.T) {
 	}
 }
 
+func TestReconcileLive_InconclusiveRuntimeProbeDoesNotRelaunch(t *testing.T) {
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{aliveErr: fmt.Errorf("legacy client mismatch: %w", ports.ErrRuntimeProbeInconclusive)}
+	ws := &fakeWorkspace{}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: lcm,
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID: "s-inconclusive", ProjectID: "p1", Harness: domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/s-inconclusive/root", WorkspacePath: "/wt/s-inconclusive", RuntimeHandleID: "s-inconclusive",
+		},
+	}
+	st.sessions[rec.ID] = rec
+
+	err := m.reconcileLive(context.Background(), rec)
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("reconcileLive err = %v, want ErrRuntimeProbeInconclusive", err)
+	}
+	if rt.created != 0 || rt.destroyed != 0 {
+		t.Fatalf("inconclusive probe changed runtime: created=%d destroyed=%d", rt.created, rt.destroyed)
+	}
+	if ws.stashCalls != 0 || lcm.terminated[rec.ID] != 0 {
+		t.Fatalf("inconclusive probe changed lifecycle: stash=%d terminated=%d", ws.stashCalls, lcm.terminated[rec.ID])
+	}
+}
+
+func TestRestartRuntime_InconclusiveProbeDoesNotCreateReplacement(t *testing.T) {
+	rt := &fakeRuntime{aliveErr: fmt.Errorf("legacy client unavailable: %w", ports.ErrRuntimeProbeInconclusive)}
+	m := New(Deps{Runtime: rt})
+
+	_, err := m.restartRuntime(context.Background(), ports.RuntimeHandle{ID: "legacy-live"}, ports.RuntimeConfig{
+		SessionID: "legacy-live",
+	})
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("restartRuntime err = %v, want ErrRuntimeProbeInconclusive", err)
+	}
+	if rt.created != 0 || rt.destroyed != 0 {
+		t.Fatalf("inconclusive probe replaced runtime: created=%d destroyed=%d", rt.created, rt.destroyed)
+	}
+}
+
 func TestReconcileLive_ScratchDeadRuntimeTerminatesWithoutWorkspaceTeardown(t *testing.T) {
 	st := newFakeStore()
 	st.projects["scratch"] = domain.ProjectRecord{ID: "scratch", Kind: domain.ProjectKindScratch, Config: testRoleAgents()}

--- a/frontend/scripts/build-tmux.mjs
+++ b/frontend/scripts/build-tmux.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { cpus } from "node:os";
+import { cpus, tmpdir } from "node:os";
 import {
 	chmodSync,
 	copyFileSync,
@@ -47,7 +47,7 @@ const UTF8PROC = {
 	license: "LICENSE.md",
 };
 const SOURCES = [TMUX, LIBEVENT, NCURSES, UTF8PROC];
-const BUILD_REVISION = 3;
+const BUILD_REVISION = 4;
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const frontendRoot = resolve(scriptsDir, "..");
@@ -109,6 +109,7 @@ const version = run(outputBinary, ["-V"], { capture: true }).stdout.trim();
 if (version !== `tmux ${TMUX.version}`) {
 	fail(`bundled tmux reported ${JSON.stringify(version)}, expected ${JSON.stringify(`tmux ${TMUX.version}`)}`);
 }
+verifyTerminfoAttach(outputBinary);
 console.log(`Bundled ${version} at ${outputBinary}`);
 
 async function build() {
@@ -145,7 +146,6 @@ async function build() {
 			"--without-cxx",
 			"--without-cxx-binding",
 			"--without-tests",
-			"--without-progs",
 			"--without-manpages",
 			"--enable-widec",
 			"--with-termlib",
@@ -154,6 +154,26 @@ async function build() {
 		],
 		{ cwd: ncursesDir, env: commonEnv },
 	);
+	run("make", ["-j", jobs], { cwd: ncursesDir, env: commonEnv });
+	// Runtime.Attach always presents xterm-256color. Generate its fallback
+	// with the matching pinned tic/infocmp we just built: macOS's older host
+	// tools cannot compile the ncurses 6.5 entry. Rebuilding embeds the entry
+	// into libtinfo so the shipped binary needs no host terminfo database.
+	const ncursesBuildDir = join(ncursesDir, "ncurses");
+	const fallback = run(
+		"sh",
+		[
+			"-e",
+			"./tinfo/MKfallback.sh",
+			join(prefix, "share", "terminfo"),
+			"../misc/terminfo.src",
+			"../progs/tic",
+			"../progs/infocmp",
+			"xterm-256color",
+		],
+		{ cwd: ncursesBuildDir, env: commonEnv },
+	);
+	writeFileSync(join(ncursesBuildDir, "fallback.c"), fallback.stdout);
 	run("make", ["-j", jobs], { cwd: ncursesDir, env: commonEnv });
 	run("make", ["install.libs", "install.includes"], { cwd: ncursesDir, env: commonEnv });
 
@@ -188,6 +208,8 @@ async function build() {
 		...commonEnv,
 		LIBTINFO_CFLAGS: `-I${join(prefix, "include", "ncursesw")} -I${join(prefix, "include")}`,
 		LIBTINFO_LIBS: join(prefix, "lib", "libtinfow.a"),
+		LIBUTF8PROC_CFLAGS: `-I${join(prefix, "include")}`,
+		LIBUTF8PROC_LIBS: join(prefix, "lib", "libutf8proc.a"),
 	};
 	run("./configure", tmuxConfigureArgs, { cwd: tmuxDir, env: tmuxEnv });
 	run("make", ["-j", jobs], { cwd: tmuxDir, env: tmuxEnv });
@@ -253,13 +275,57 @@ function verifyPortableLinkage(binary, buildPrefix) {
 	}
 }
 
+function verifyTerminfoAttach(binary) {
+	const identity = `ao-tmux-smoke-${process.pid}`;
+	const socket = join(tmpdir(), `${identity}.sock`);
+	const session = "terminfo";
+	const missingTerminfo = join(tmpdir(), identity, "missing-terminfo");
+	const attachEnvironment = {
+		...process.env,
+		HOME: join(tmpdir(), identity, "missing-home"),
+		TERM: "xterm-256color",
+		TERMINFO: missingTerminfo,
+		TERMINFO_DIRS: missingTerminfo,
+	};
+	run(binary, ["-S", socket, "-f", "/dev/null", "new-session", "-d", "-s", session, "sleep 10"]);
+	try {
+		const tmuxArgs = [binary, "-S", socket, "-u", "-T", "RGB", "attach-session", "-t", session];
+		const result =
+			process.platform === "darwin"
+				? run("script", ["-q", "/dev/null", ...tmuxArgs], {
+						capture: true,
+						allowFailure: true,
+						ignoreStdin: true,
+						env: attachEnvironment,
+					})
+				: run("script", ["-q", "-e", "-c", tmuxArgs.map(shellQuote).join(" "), "/dev/null"], {
+						capture: true,
+						allowFailure: true,
+						ignoreStdin: true,
+						env: attachEnvironment,
+					});
+		const output = `${result.stdout}\n${result.stderr}`;
+		if (result.status !== 0 || /terminfo database/i.test(output)) {
+			fail(`bundled tmux could not attach with TERM=xterm-256color:\n${output}`);
+		}
+	} finally {
+		run(binary, ["-S", socket, "kill-server"], { capture: true, allowFailure: true });
+		rmSync(socket, { force: true });
+	}
+}
+
+function shellQuote(value) {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
 function run(command, args, options = {}) {
 	const capture = options.capture || process.env.AO_VERBOSE_NATIVE_BUILD !== "1";
 	const result = spawnSync(command, args, {
 		cwd: options.cwd,
 		env: options.env,
 		encoding: capture ? "utf8" : undefined,
-		stdio: capture ? "pipe" : "inherit",
+		maxBuffer: 64 * 1024 * 1024,
+		stdio: capture ? [options.ignoreStdin ? "ignore" : "pipe", "pipe", "pipe"] : "inherit",
 		windowsHide: true,
 	});
 	if (result.error) fail(`failed to start ${command}: ${result.error.message}`);


### PR DESCRIPTION
Fixes #4382

## Summary

- build ncurses's matching `tic` and `infocmp` tools, then embed the pinned `xterm-256color` entry into the static libtinfo used by bundled tmux
- avoid host `pkg-config` dependency by pointing tmux directly at AO's pinned static utf8proc archive
- replace the version-only artifact check with a real pseudo-terminal attach while `HOME`, `TERMINFO`, and `TERMINFO_DIRS` point to nonexistent paths
- bump the native build revision so release jobs cannot reuse the broken cached artifact
- preserve pre-bundling TUI sessions by using the system tmux client for the legacy default socket while retaining AO's bundled client for the private `ao` socket
- pin every migrated legacy probe, command, and PTY attach to `-L default`, preventing inherited `TMUX` from redirecting AO to a nested or unrelated server
- distinguish conclusively absent infrastructure from an inconclusive legacy inspection: missing clients, protocol mismatches, and transient connection failures now return `ErrRuntimeProbeInconclusive`, which boot/restart/reaper paths cannot treat as session death or permission to create a replacement

## Upgrade-path coverage

- **Pre-regression → fixed:** legacy sessions are discovered and operated through the system tmux from `PATH`, avoiding tmux client/server protocol mismatches with AO's pinned bundled version. All legacy operations explicitly target the historical `default` socket. New sessions use the private socket and bundled client.
- **Broken nightly → fixed:** existing private-socket sessions continue through the bundled client, while the new app version stages the fixed binary at its own durable versioned path.
- **Mixed state:** exact private-socket probing remains first; sessions absent there are classified against the pinned legacy socket. The selected socket/client pair is cached for every subsequent operation.
- Only a conclusive `no server running` result is recoverable infrastructure absence. A missing/incompatible client or transient `error connecting` result preserves the existing controller and propagates an actionable, inconclusive error.

## Verification

- `cd frontend && npm run build:tmux` (macOS arm64; real PTY attach passed with no host terminfo database)
- `cd frontend && npm test -- --run forge.config.test.ts src/shared/bundled-tmux.test.ts` (12 tests passed)
- `cd frontend && npm run typecheck`
- clean AO environment: `npm run lint` (all Go tests and golangci-lint passed)
- `cd backend && go test -race ./internal/adapters/runtime/tmux ./internal/session_manager`
- repeated tmux runtime package integration suite (`-count=3`)
- live protocol compatibility on macOS arm64:
  - system tmux 3.6b successfully queried the 16-session legacy default-socket server
  - bundled tmux 3.5a reproduced `server exited unexpectedly` against that server
  - bundled tmux 3.5a successfully queried the 11-session private `ao`-socket server
- real three-server integration regression:
  - creates isolated `default`, private `ao`, and spoof sockets
  - injects `TMUX` pointing at the spoof server with a colliding session namespace
  - verifies AO adopts the real default-socket session and rejects the spoof-only session
- unit regressions cover unavailable legacy client, incompatible-client output, transient legacy `error connecting`, client routing, and explicit `-L default` PTY attachment
- session-manager regressions prove boot reconciliation and explicit restart propagate inconclusive legacy probes without Create, Restart, Destroy, termination, or workspace changes
- `otool -L frontend/tmux/bin/tmux` (system libraries only)

## Risk

The terminfo fallback is intentionally limited to `xterm-256color`, which is the exact terminal AO forces for bundled tmux attachments. Legacy default-socket sessions depend on a compatible system tmux remaining available from the daemon's inherited `PATH`, matching the dependency that created those pre-bundling sessions. If it is unavailable or incompatible, the session and controller are preserved and AO surfaces an inconclusive runtime error; it is not archived, destroyed, or duplicated. Linux and macOS Intel release artifacts still need to pass their native release-runner attach smoke tests.
