### PR TITLE
fix(topbar): surface the real reason when opening an editor fails

### DIFF
--- a/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
@@ -40,6 +40,24 @@ function renderButton() {
 }
 
 describe("TopbarOpenEditorButton", () => {
+	// Regression: an ipcMain rejection arrives wrapped as "Error invoking remote
+	// method 'editorHandoff:open': Error: <reason>", and the topbar used to paint
+	// that whole string into the actions row.
+	it("shows the reason, not Electron's remote-method wrapper, when the open fails", async () => {
+		setState(availableState);
+		window.ao!.editorHandoff.open = vi.fn().mockRejectedValue(
+			new Error("Error invoking remote method 'editorHandoff:open': Error: Session workspace is not available"),
+		);
+		renderButton();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Open in Cursor" }));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent("Session workspace is not available");
+		expect(alert.textContent).not.toContain("Error invoking remote method");
+	});
+
+
 	beforeEach(() => {
 		openMock.mockClear();
 		openMock.mockImplementation(async ({ targetId }: OpenSessionTargetInput) => {

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
@@ -40,6 +40,31 @@ function renderButton() {
 }
 
 describe("TopbarOpenEditorButton", () => {
+	// The bug this PR chases: the worktree goes away after getState was cached,
+	// so the control is still enabled, the click fails, and nothing refreshes the
+	// state, leaving it enabled to fail again. Failing the open must re-read
+	// availability and disable the control.
+	it("refreshes availability after a failed open so the control stops inviting the click", async () => {
+		const getState = vi
+			.fn()
+			.mockResolvedValueOnce(availableState)
+			.mockResolvedValue({ ...availableState, workspaceAvailable: false, unavailableReason: "Session workspace is not available" });
+		window.ao!.editorHandoff.getState = getState;
+		window.ao!.editorHandoff.open = vi.fn().mockRejectedValue(
+			new Error("Error invoking remote method 'editorHandoff:open': Error: Session workspace is not available"),
+		);
+		renderButton();
+
+		const main = await screen.findByRole("button", { name: "Open in Cursor" });
+		expect(main).toBeEnabled();
+
+		await userEvent.click(main);
+
+		// the failure must trigger a refetch, not just show a message
+		await waitFor(() => expect(getState).toHaveBeenCalledTimes(2));
+		await waitFor(() => expect(screen.getByRole("button", { name: "Open in Cursor" })).toBeDisabled());
+	});
+
 	// Regression: an ipcMain rejection arrives wrapped as "Error invoking remote
 	// method 'editorHandoff:open': Error: <reason>", and the topbar used to paint
 	// that whole string into the actions row.

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, Code2, FolderOpen, SquareTerminal } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { OpenTarget, OpenTargetId } from "../../shared/editor-handoff";
-import { editorHandoffErrorMessage, useEditorHandoffState, useOpenSessionTarget } from "../hooks/useEditorHandoff";
+import { useEditorHandoffState, useOpenSessionTarget } from "../hooks/useEditorHandoff";
 import { TopbarActionError, TopbarButton } from "./TopbarButton";
 import {
 	DropdownMenu,
@@ -89,7 +89,7 @@ export function TopbarOpenEditorButton({
 		open.reset();
 		open.mutate({ sessionId, projectId, ...(targetId ? { targetId } : {}) });
 	};
-	const launchError = editorHandoffErrorMessage(open.error);
+	const launchError = open.error instanceof Error ? open.error.message : null;
 	const guidance = !stateQuery.isPending && !workspaceAvailable
 		? state?.unavailableReason ?? t("editor.workspaceUnavailable")
 		: !stateQuery.isPending && editors.length === 0

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, Code2, FolderOpen, SquareTerminal } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { OpenTarget, OpenTargetId } from "../../shared/editor-handoff";
-import { useEditorHandoffState, useOpenSessionTarget } from "../hooks/useEditorHandoff";
+import { editorHandoffErrorMessage, useEditorHandoffState, useOpenSessionTarget } from "../hooks/useEditorHandoff";
 import { TopbarActionError, TopbarButton } from "./TopbarButton";
 import {
 	DropdownMenu,
@@ -89,7 +89,7 @@ export function TopbarOpenEditorButton({
 		open.reset();
 		open.mutate({ sessionId, projectId, ...(targetId ? { targetId } : {}) });
 	};
-	const launchError = open.error instanceof Error ? open.error.message : null;
+	const launchError = editorHandoffErrorMessage(open.error);
 	const guidance = !stateQuery.isPending && !workspaceAvailable
 		? state?.unavailableReason ?? t("editor.workspaceUnavailable")
 		: !stateQuery.isPending && editors.length === 0

--- a/frontend/src/renderer/hooks/useEditorHandoff.test.ts
+++ b/frontend/src/renderer/hooks/useEditorHandoff.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { editorHandoffErrorMessage } from "./useEditorHandoff";
+
+// Electron wraps ipcMain rejections; the topbar used to render the wrapper
+// verbatim, so a missing worktree read as "Error invoking remote method
+// 'editorHandoff:open': Error: Session workspace is not available".
+describe("editorHandoffErrorMessage", () => {
+	it("strips the Electron remote-method wrapper", () => {
+		const raw = new Error(
+			"Error invoking remote method 'editorHandoff:open': Error: Session workspace is not available",
+		);
+		expect(editorHandoffErrorMessage(raw)).toBe("Session workspace is not available");
+	});
+
+	it("strips the wrapper for other channels and error classes", () => {
+		expect(
+			editorHandoffErrorMessage(
+				new Error("Error invoking remote method 'editorHandoff:getState': TypeError: boom"),
+			),
+		).toBe("boom");
+	});
+
+	it("leaves an already-clean message alone", () => {
+		expect(editorHandoffErrorMessage(new Error("That editor is not installed. Choose another option."))).toBe(
+			"That editor is not installed. Choose another option.",
+		);
+	});
+
+	it("keeps the original when stripping would leave nothing", () => {
+		const raw = new Error("Error invoking remote method 'editorHandoff:open': Error:");
+		expect(editorHandoffErrorMessage(raw)).toBe(raw.message);
+	});
+
+	it("returns null for non-Error rejections", () => {
+		expect(editorHandoffErrorMessage("nope")).toBeNull();
+		expect(editorHandoffErrorMessage(undefined)).toBeNull();
+	});
+});

--- a/frontend/src/renderer/hooks/useEditorHandoff.ts
+++ b/frontend/src/renderer/hooks/useEditorHandoff.ts
@@ -45,6 +45,9 @@ export function useOpenSessionTarget() {
 			try {
 				return await aoBridge.editorHandoff.open({ sessionId, ...(targetId ? { targetId } : {}) });
 			} catch (error) {
+				// Normalize here, once, so every consumer of this mutation gets the
+				// reason rather than the IPC wrapper. Callers render error.message
+				// directly and should not each have to strip it.
 				throw new Error(editorHandoffErrorMessage(error) ?? String(error));
 			}
 		},

--- a/frontend/src/renderer/hooks/useEditorHandoff.ts
+++ b/frontend/src/renderer/hooks/useEditorHandoff.ts
@@ -5,6 +5,18 @@ import { captureRendererEvent } from "../lib/telemetry";
 
 export const editorHandoffQueryKey = (sessionId: string) => ["editor-handoff", sessionId] as const;
 
+// Electron wraps anything an ipcMain handler throws as
+// "Error invoking remote method '<channel>': Error: <real message>". That prefix
+// is developer noise, and the topbar renders the message verbatim, so strip it
+// and surface only what the main process actually said.
+const IPC_WRAPPER = /^Error invoking remote method '[^']*':\s*(?:[A-Za-z]*Error:\s*)?/;
+
+export function editorHandoffErrorMessage(error: unknown): string | null {
+	if (!(error instanceof Error)) return null;
+	const message = error.message.replace(IPC_WRAPPER, "").trim();
+	return message || error.message;
+}
+
 export function useEditorHandoffState(sessionId: string) {
 	return useQuery({
 		queryKey: editorHandoffQueryKey(sessionId),
@@ -30,7 +42,11 @@ export function useOpenSessionTarget() {
 				target_kind: targetId === "file-manager" ? "file_manager" : targetId === "terminal" ? "terminal" : "editor",
 				...(targetId && isEditorId(targetId) ? { editor_id: targetId } : {}),
 			});
-			return aoBridge.editorHandoff.open({ sessionId, ...(targetId ? { targetId } : {}) });
+			try {
+				return await aoBridge.editorHandoff.open({ sessionId, ...(targetId ? { targetId } : {}) });
+			} catch (error) {
+				throw new Error(editorHandoffErrorMessage(error) ?? String(error));
+			}
 		},
 		onSuccess: (result, input) => {
 			if (result.kind === "editor" && isEditorId(result.id)) {
@@ -45,6 +61,10 @@ export function useOpenSessionTarget() {
 			});
 		},
 		onError: (_error, input) => {
+			// The usual cause is the worktree going away after the cached state was
+			// read (session killed, merged, cleaned up). Refetch so the control
+			// disables itself instead of inviting the same failing click again.
+			void queryClient.invalidateQueries({ queryKey: editorHandoffQueryKey(input.sessionId) });
 			void captureRendererEvent("ao.renderer.open_in_editor_failed", { project_id: input.projectId });
 		},
 	});


### PR DESCRIPTION
## Summary

Opening a session whose worktree is gone (terminated, merged, cleaned up) put
Electron's IPC plumbing straight into the topbar actions row:

> Error invoking remote method 'editorHandoff:open': Error: Session workspace is not available

Reproduced against real local data, where 27 of the first 40 sessions have no
resolvable workspace (`/api/v1/desktop/sessions/{id}/workspace` returns 404).

## What was wrong

Two separate things, and the guard that exists is not the problem.

`TopbarOpenEditorButton` already disables itself when `getState` reports
`workspaceAvailable: false`, and that works. Confirmed live: on a terminated
session the control is disabled with the tooltip "Session workspace is not
available".

What bites is staleness. `useEditorHandoffState` caches with
`staleTime: 10_000` and nothing invalidated it on failure, so a worktree that
disappears *after* the state was read leaves the button enabled. The click
fails, the state is never refreshed, and the button stays enabled to fail again.

Separately, the message shown was raw plumbing.
`TopbarOpenEditorButton.tsx` rendered `open.error.message` verbatim, which is
Electron's wrapper around anything an `ipcMain` handler throws.

## The fix

Renderer-side, in `useEditorHandoff.ts`:

- Strip the `Error invoking remote method '<channel>': Error:` wrapper and
  rethrow a clean error, so the topbar shows what the main process actually
  said. This covers the other failure paths too, which were equally buried:
  "That editor is not installed", "Could not open <name>".
- Invalidate the handoff state query on error so the control re-checks
  availability rather than inviting the same failing click.

## Verification

Reproduced and fixed in the running desktop app against real session data, not
just in tests. Before: the raw wrapper. After: the disabled control carries the
clean reason as its tooltip.

Five unit tests on the normalizer plus a component regression test that clicks
through and asserts the rendered alert. The regression test is not vacuous:
with both changes reverted it fails with `expected 'Error invoking remote
method...' not to contain 'Error invoking remote method'`.

Full frontend suite: 2867 tests across 217 files. Typecheck clean.

## Notes for review

The code being fixed came from commit 728400ca8 in #3284, which replaced an
earlier HTTP implementation with this IPC one. I did not write it, so a look
from its author is worth having.

This treats the symptom in the renderer. Arguably `open()` in
`frontend/src/main/editor-handoff.ts` should also resolve the workspace inside
its `try`/`catch` so the failure comes back as a friendly message at the source
rather than as a raw throw. Left alone to keep this change narrow; happy to
fold it in.
