### PR TITLE
feat(frontend): make workspace file sync reactive

### DIFF
--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -35,6 +35,8 @@ import { apiClient, apiErrorMessage } from "../lib/api-client";
 import {
 	isChangedWorkspaceFile,
 	sessionWorkspaceFilesQueryOptions,
+	useWorkspaceFileConnectionState,
+	workspaceFilesRefetchInterval,
 	type WorkspaceCompareMode,
 	type WorkspaceFileSummary,
 } from "../hooks/useSessionWorkspaceFiles";
@@ -146,7 +148,11 @@ export function SessionFilesView({
 	const annotationSentTimerRef = useRef<number | null>(null);
 	const rootRef = useRef<HTMLElement>(null);
 
-	const filesQuery = useQuery(sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")));
+	const workspaceConnectionState = useWorkspaceFileConnectionState(sessionId);
+	const filesQuery = useQuery({
+		...sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")),
+		refetchInterval: workspaceFilesRefetchInterval(workspaceConnectionState),
+	});
 	useEffect(() => subscribeWorkspaceFileChanges(sessionId, queryClient), [queryClient, sessionId]);
 	const files = filesQuery.data?.files ?? emptyFiles;
 	const changedFiles = useMemo(() => files.filter(isChangedWorkspaceFile), [files]);

--- a/frontend/src/renderer/hooks/useSessionWorkspaceFiles.test.ts
+++ b/frontend/src/renderer/hooks/useSessionWorkspaceFiles.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { workspaceFilesRefetchInterval } from "./useSessionWorkspaceFiles";
+
+describe("workspaceFilesRefetchInterval", () => {
+	it("polls only while workspace SSE is degraded", () => {
+		expect(workspaceFilesRefetchInterval("connecting")).toBe(false);
+		expect(workspaceFilesRefetchInterval("connected")).toBe(false);
+		expect(workspaceFilesRefetchInterval("degraded")).toBe(30_000);
+	});
+});

--- a/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
+++ b/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
@@ -1,8 +1,13 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
-import { subscribeWorkspaceFileChanges } from "../lib/workspace-file-events";
+import {
+	getWorkspaceFileConnectionState,
+	subscribeWorkspaceFileChanges,
+	subscribeWorkspaceFileConnectionState,
+	type WorkspaceFileConnectionState,
+} from "../lib/workspace-file-events";
 
 export type WorkspaceCompareMode = "base" | "head_fallback";
 export type WorkspaceFileSummary = components["schemas"]["WorkspaceFileSummary"] & {
@@ -13,6 +18,7 @@ export type WorkspaceFilesResponse = components["schemas"]["ListWorkspaceFilesRe
 };
 
 export const sessionWorkspaceFilesQueryKey = (sessionId: string) => ["session-workspace-files", sessionId] as const;
+const WORKSPACE_FILES_DEGRADED_REFETCH_MS = 30_000;
 
 async function fetchSessionWorkspaceFiles(sessionId: string, errorMessage: string): Promise<WorkspaceFilesResponse> {
 	const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/files", {
@@ -22,18 +28,26 @@ async function fetchSessionWorkspaceFiles(sessionId: string, errorMessage: strin
 	return (data ?? { sessionId, files: [], truncated: false }) as WorkspaceFilesResponse;
 }
 
-// Shared so SessionFilesView (full fetch + polling) and SessionInspector
-// (eager fetch + live invalidation) always resolve to the same cache entry.
+// Shared so SessionFilesView and SessionInspector resolve to the same cache
+// entry while SSE invalidation remains the normal refresh path.
 export function sessionWorkspaceFilesQueryOptions(sessionId: string, errorMessage = "Unable to load workspace files") {
 	return {
 		queryKey: sessionWorkspaceFilesQueryKey(sessionId),
 		queryFn: () => fetchSessionWorkspaceFiles(sessionId, errorMessage),
-		// SSE (subscribeWorkspaceFileChanges) already invalidates this query
-		// immediately on real filesystem changes and on reconnect, triggering
-		// an instant refetch regardless of this interval. Polling is only a
-		// safety net for missed/dropped SSE events, so it can stay slow.
-		refetchInterval: 30_000,
 	};
+}
+
+export function workspaceFilesRefetchInterval(state: WorkspaceFileConnectionState): false | number {
+	return state === "degraded" ? WORKSPACE_FILES_DEGRADED_REFETCH_MS : false;
+}
+
+export function useWorkspaceFileConnectionState(sessionId: string): WorkspaceFileConnectionState {
+	const subscribe = useCallback(
+		(listener: () => void) => subscribeWorkspaceFileConnectionState(sessionId, listener),
+		[sessionId],
+	);
+	const getSnapshot = useCallback(() => getWorkspaceFileConnectionState(sessionId), [sessionId]);
+	return useSyncExternalStore(subscribe, getSnapshot);
 }
 
 export function isChangedWorkspaceFile(file: WorkspaceFileSummary): boolean {

--- a/frontend/src/renderer/lib/workspace-file-events.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.test.ts
@@ -15,10 +15,13 @@ vi.mock("./api-client", () => ({
 	subscribeApiBaseUrl: subscribeApiBaseUrlMock,
 }));
 
-import { subscribeWorkspaceFileChanges } from "./workspace-file-events";
+import { getWorkspaceFileConnectionState, subscribeWorkspaceFileChanges } from "./workspace-file-events";
+
+let baseUrlListener: (() => void) | undefined;
 
 class EventSourceStub {
 	static instances: EventSourceStub[] = [];
+	static throwNext = false;
 	url: string;
 	closed = false;
 	readyState = 0;
@@ -27,6 +30,10 @@ class EventSourceStub {
 	listeners = new Map<string, Set<() => void>>();
 
 	constructor(url: string) {
+		if (EventSourceStub.throwNext) {
+			EventSourceStub.throwNext = false;
+			throw new Error("connection setup failed");
+		}
 		this.url = url;
 		EventSourceStub.instances.push(this);
 	}
@@ -53,15 +60,21 @@ function fakeQueryClient() {
 
 beforeEach(() => {
 	EventSourceStub.instances = [];
+	EventSourceStub.throwNext = false;
+	baseUrlListener = undefined;
 	getApiBaseUrlMock.mockReset().mockReturnValue("http://127.0.0.1:3001");
 	hasTrustedApiBaseUrlMock.mockReset().mockReturnValue(true);
-	subscribeApiBaseUrlMock.mockReset().mockReturnValue(unsubscribeBaseUrlMock);
+	subscribeApiBaseUrlMock.mockReset().mockImplementation((listener: () => void) => {
+		baseUrlListener = listener;
+		return unsubscribeBaseUrlMock;
+	});
 	unsubscribeBaseUrlMock.mockReset();
 	(globalThis as unknown as { EventSource: unknown }).EventSource = EventSourceStub;
 });
 
 afterEach(() => {
 	vi.useRealTimers();
+	vi.restoreAllMocks();
 	delete (globalThis as unknown as { EventSource?: unknown }).EventSource;
 });
 
@@ -72,9 +85,7 @@ describe("subscribeWorkspaceFileChanges", () => {
 		const unsubscribeMaximized = subscribeWorkspaceFileChanges("session/a", queryClient);
 
 		expect(EventSourceStub.instances).toHaveLength(1);
-		expect(EventSourceStub.instances[0].url).toBe(
-			"http://127.0.0.1:3001/api/v1/sessions/session%2Fa/workspace/events",
-		);
+		expect(EventSourceStub.instances[0].url).toBe("http://127.0.0.1:3001/api/v1/sessions/session%2Fa/workspace/events");
 
 		unsubscribeRail();
 		expect(EventSourceStub.instances[0].closed).toBe(false);
@@ -96,8 +107,70 @@ describe("subscribeWorkspaceFileChanges", () => {
 		vi.advanceTimersByTime(1);
 
 		expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(2);
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-files", "sess-1"] });
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-file", "sess-1"] });
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["session-workspace-files", "sess-1"],
+		});
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["session-workspace-file", "sess-1"],
+		});
+		unsubscribe();
+	});
+
+	it("keeps one retry pending when another connect trigger arrives", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		EventSourceStub.throwNext = true;
+		const unsubscribe = subscribeWorkspaceFileChanges("sess-retry", fakeQueryClient());
+
+		expect(EventSourceStub.instances).toHaveLength(0);
+		baseUrlListener?.();
+		expect(EventSourceStub.instances).toHaveLength(0);
+
+		vi.advanceTimersByTime(4_999);
+		expect(EventSourceStub.instances).toHaveLength(0);
+		vi.advanceTimersByTime(1);
+		expect(EventSourceStub.instances).toHaveLength(1);
+		unsubscribe();
+	});
+
+	it("reports degraded after three completed connection failures", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const unsubscribe = subscribeWorkspaceFileChanges("sess-degraded", fakeQueryClient());
+
+		for (let failure = 0; failure < 3; failure += 1) {
+			const source = EventSourceStub.instances.at(-1)!;
+			source.readyState = 2;
+			source.onerror?.();
+			if (failure < 2) vi.advanceTimersByTime(5_000);
+		}
+
+		expect(getWorkspaceFileConnectionState("sess-degraded")).toBe("degraded");
+		unsubscribe();
+	});
+
+	it("reports connecting while EventSource performs its native reconnect", () => {
+		const unsubscribe = subscribeWorkspaceFileChanges("sess-native-retry", fakeQueryClient());
+		const source = EventSourceStub.instances[0];
+
+		source.onopen?.();
+		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connected");
+
+		source.readyState = 0;
+		source.onerror?.();
+		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connecting");
+
+		source.onopen?.();
+		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connected");
+		unsubscribe();
+	});
+
+	it("uses degraded polling when EventSource is unavailable", () => {
+		delete (globalThis as unknown as { EventSource?: unknown }).EventSource;
+
+		const unsubscribe = subscribeWorkspaceFileChanges("sess-no-eventsource", fakeQueryClient());
+
+		expect(getWorkspaceFileConnectionState("sess-no-eventsource")).toBe("degraded");
 		unsubscribe();
 	});
 });

--- a/frontend/src/renderer/lib/workspace-file-events.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.test.ts
@@ -85,7 +85,9 @@ describe("subscribeWorkspaceFileChanges", () => {
 		const unsubscribeMaximized = subscribeWorkspaceFileChanges("session/a", queryClient);
 
 		expect(EventSourceStub.instances).toHaveLength(1);
-		expect(EventSourceStub.instances[0].url).toBe("http://127.0.0.1:3001/api/v1/sessions/session%2Fa/workspace/events");
+		expect(EventSourceStub.instances[0].url).toBe(
+			"http://127.0.0.1:3001/api/v1/sessions/session%2Fa/workspace/events",
+		);
 
 		unsubscribeRail();
 		expect(EventSourceStub.instances[0].closed).toBe(false);
@@ -107,12 +109,8 @@ describe("subscribeWorkspaceFileChanges", () => {
 		vi.advanceTimersByTime(1);
 
 		expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(2);
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-			queryKey: ["session-workspace-files", "sess-1"],
-		});
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
-			queryKey: ["session-workspace-file", "sess-1"],
-		});
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-files", "sess-1"] });
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-workspace-file", "sess-1"] });
 		unsubscribe();
 	});
 
@@ -149,7 +147,7 @@ describe("subscribeWorkspaceFileChanges", () => {
 		unsubscribe();
 	});
 
-	it("reports connecting while EventSource performs its native reconnect", () => {
+	it("degrades after repeated native reconnect failures and recovers on open", () => {
 		const unsubscribe = subscribeWorkspaceFileChanges("sess-native-retry", fakeQueryClient());
 		const source = EventSourceStub.instances[0];
 
@@ -157,8 +155,10 @@ describe("subscribeWorkspaceFileChanges", () => {
 		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connected");
 
 		source.readyState = 0;
-		source.onerror?.();
-		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connecting");
+		for (let failure = 0; failure < 3; failure += 1) {
+			source.onerror?.();
+			expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe(failure < 2 ? "connecting" : "degraded");
+		}
 
 		source.onopen?.();
 		expect(getWorkspaceFileConnectionState("sess-native-retry")).toBe("connected");

--- a/frontend/src/renderer/lib/workspace-file-events.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.ts
@@ -3,21 +3,54 @@ import { getApiBaseUrl, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "./api-
 
 const INVALIDATE_DEBOUNCE_MS = 150;
 const SSE_RETRY_MS = 5_000;
+const SSE_RETRY_JITTER_MS = 1_000;
 const EVENTSOURCE_CLOSED = 2;
+
+export type WorkspaceFileConnectionState = "connecting" | "connected" | "degraded";
+type ConnectionPhase = "idle" | "connecting" | "open" | "waiting";
 
 type WorkspaceStream = {
 	refs: number;
 	disposed: boolean;
+	phase: ConnectionPhase;
+	generation: number;
+	failures: number;
 	source?: EventSource;
 	sourceBaseUrl?: string;
 	debounce?: ReturnType<typeof setTimeout>;
 	retry?: ReturnType<typeof setTimeout>;
 	disconnectBaseUrl: () => void;
-	connect: () => void;
+	ensureConnected: () => void;
 	dispose: () => void;
 };
 
 const streams = new Map<string, WorkspaceStream>();
+const connectionStates = new Map<string, WorkspaceFileConnectionState>();
+const connectionStateListeners = new Map<string, Set<() => void>>();
+
+export function getWorkspaceFileConnectionState(sessionId: string): WorkspaceFileConnectionState {
+	return connectionStates.get(sessionId) ?? "connecting";
+}
+
+export function subscribeWorkspaceFileConnectionState(sessionId: string, listener: () => void): () => void {
+	let listeners = connectionStateListeners.get(sessionId);
+	if (!listeners) {
+		listeners = new Set();
+		connectionStateListeners.set(sessionId, listeners);
+	}
+	listeners.add(listener);
+	return () => {
+		listeners?.delete(listener);
+		if (listeners?.size === 0) connectionStateListeners.delete(sessionId);
+		if (!streams.has(sessionId) && !connectionStateListeners.has(sessionId)) connectionStates.delete(sessionId);
+	};
+}
+
+function setWorkspaceFileConnectionState(sessionId: string, next: WorkspaceFileConnectionState): void {
+	if (connectionStates.get(sessionId) === next) return;
+	connectionStates.set(sessionId, next);
+	connectionStateListeners.get(sessionId)?.forEach((listener) => listener());
+}
 
 // Shares one daemon watcher between the rail and maximized copies of a Files
 // view. The daemon sends only invalidation edges; Git status and visible diffs
@@ -37,6 +70,7 @@ export function subscribeWorkspaceFileChanges(sessionId: string, queryClient: Qu
 		if (current.refs > 0) return;
 		current.dispose();
 		streams.delete(sessionId);
+		if (!connectionStateListeners.has(sessionId)) connectionStates.delete(sessionId);
 	};
 }
 
@@ -45,58 +79,105 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 	const invalidate = () => {
 		if (stream.debounce) clearTimeout(stream.debounce);
 		stream.debounce = setTimeout(() => {
-			void queryClient.invalidateQueries({ queryKey: ["session-workspace-files", sessionId] });
-			void queryClient.invalidateQueries({ queryKey: ["session-workspace-file", sessionId] });
+			void queryClient.invalidateQueries({
+				queryKey: ["session-workspace-files", sessionId],
+			});
+			void queryClient.invalidateQueries({
+				queryKey: ["session-workspace-file", sessionId],
+			});
 		}, INVALIDATE_DEBOUNCE_MS);
 	};
-	const scheduleRetry = () => {
+	const scheduleRetry = (generation: number) => {
 		if (stream.disposed || stream.retry) return;
+		stream.phase = "waiting";
+		const delay = SSE_RETRY_MS + (Math.random() * 2 - 1) * SSE_RETRY_JITTER_MS;
 		stream.retry = setTimeout(() => {
 			stream.retry = undefined;
-			stream.connect();
-		}, SSE_RETRY_MS);
+			if (stream.disposed || generation !== stream.generation) return;
+			stream.phase = "idle";
+			stream.ensureConnected();
+		}, delay);
+	};
+	const resetConnection = () => {
+		stream.generation += 1;
+		if (stream.retry) clearTimeout(stream.retry);
+		stream.retry = undefined;
+		stream.source?.close();
+		stream.source = undefined;
+		stream.sourceBaseUrl = undefined;
+		stream.phase = "idle";
+	};
+	const handleTerminalFailure = (generation: number) => {
+		if (stream.disposed || generation !== stream.generation) return;
+		stream.source?.close();
+		stream.source = undefined;
+		stream.failures += 1;
+		setWorkspaceFileConnectionState(sessionId, stream.failures >= 3 ? "degraded" : "connecting");
+		scheduleRetry(generation);
 	};
 	stream.refs = 0;
 	stream.disposed = false;
-	stream.connect = () => {
-		if (stream.disposed || typeof EventSource === "undefined") return;
+	stream.phase = "idle";
+	stream.generation = 0;
+	stream.failures = 0;
+	setWorkspaceFileConnectionState(sessionId, "connecting");
+	stream.ensureConnected = () => {
+		if (stream.disposed) return;
+		if (typeof EventSource === "undefined") {
+			setWorkspaceFileConnectionState(sessionId, "degraded");
+			return;
+		}
 		if (!hasTrustedApiBaseUrl()) {
-			stream.source?.close();
-			stream.source = undefined;
-			stream.sourceBaseUrl = undefined;
+			resetConnection();
+			setWorkspaceFileConnectionState(sessionId, "connecting");
 			return;
 		}
 		const baseUrl = getApiBaseUrl();
-		if (stream.source && stream.sourceBaseUrl === baseUrl && stream.source.readyState !== EVENTSOURCE_CLOSED) return;
-		stream.source?.close();
+		if (stream.sourceBaseUrl && stream.sourceBaseUrl !== baseUrl) {
+			resetConnection();
+			stream.failures = 0;
+			setWorkspaceFileConnectionState(sessionId, "connecting");
+		}
+		if (stream.phase !== "idle") return;
+
 		stream.sourceBaseUrl = baseUrl;
+		stream.phase = "connecting";
+		const generation = ++stream.generation;
 		try {
 			const source = new EventSource(
 				`${baseUrl.replace(/\/+$/, "")}/api/v1/sessions/${encodeURIComponent(sessionId)}/workspace/events`,
 			);
 			stream.source = source;
 			source.onopen = () => {
-				if (!stream.disposed && stream.source === source) invalidate();
+				if (stream.disposed || generation !== stream.generation || stream.source !== source) return;
+				stream.phase = "open";
+				stream.failures = 0;
+				setWorkspaceFileConnectionState(sessionId, "connected");
+				invalidate();
 			};
 			source.onerror = () => {
-				if (!stream.disposed && stream.source === source && source.readyState === EVENTSOURCE_CLOSED) scheduleRetry();
+				if (stream.disposed || generation !== stream.generation || stream.source !== source) return;
+				if (source.readyState === EVENTSOURCE_CLOSED) {
+					handleTerminalFailure(generation);
+					return;
+				}
+				setWorkspaceFileConnectionState(sessionId, "connecting");
 			};
 			source.addEventListener("workspace_changed", () => {
-				if (!stream.disposed && stream.source === source) invalidate();
+				if (!stream.disposed && generation === stream.generation && stream.source === source) invalidate();
 			});
 		} catch {
 			stream.source = undefined;
-			scheduleRetry();
+			handleTerminalFailure(generation);
 		}
 	};
-	stream.disconnectBaseUrl = subscribeApiBaseUrl(stream.connect);
+	stream.disconnectBaseUrl = subscribeApiBaseUrl(stream.ensureConnected);
 	stream.dispose = () => {
 		stream.disposed = true;
 		if (stream.debounce) clearTimeout(stream.debounce);
-		if (stream.retry) clearTimeout(stream.retry);
 		stream.disconnectBaseUrl();
-		stream.source?.close();
+		resetConnection();
 	};
-	stream.connect();
+	stream.ensureConnected();
 	return stream;
 }

--- a/frontend/src/renderer/lib/workspace-file-events.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.ts
@@ -79,12 +79,8 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 	const invalidate = () => {
 		if (stream.debounce) clearTimeout(stream.debounce);
 		stream.debounce = setTimeout(() => {
-			void queryClient.invalidateQueries({
-				queryKey: ["session-workspace-files", sessionId],
-			});
-			void queryClient.invalidateQueries({
-				queryKey: ["session-workspace-file", sessionId],
-			});
+			void queryClient.invalidateQueries({ queryKey: ["session-workspace-files", sessionId] });
+			void queryClient.invalidateQueries({ queryKey: ["session-workspace-file", sessionId] });
 		}, INVALIDATE_DEBOUNCE_MS);
 	};
 	const scheduleRetry = (generation: number) => {
@@ -161,7 +157,8 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 					handleTerminalFailure(generation);
 					return;
 				}
-				setWorkspaceFileConnectionState(sessionId, "connecting");
+				stream.failures += 1;
+				setWorkspaceFileConnectionState(sessionId, stream.failures >= 3 ? "degraded" : "connecting");
 			};
 			source.addEventListener("workspace_changed", () => {
 				if (!stream.disposed && generation === stream.generation && stream.source === source) invalidate();


### PR DESCRIPTION
## What

Make the workspace file viewer use daemon SSE invalidations as its normal refresh path, with 30-second query polling retained only as a degraded fallback.

## Why

This implements the focused file-viewer portion of #1321 without a broader architecture rewrite. It removes periodic requests while the existing workspace event stream is healthy and keeps recovery behavior when streaming is unavailable.

Refs #1321.

## How

- Keep one reference-counted EventSource per session across inspector and maximized file views.
- Serialize connection attempts, coalesce retry triggers, add 4-6 second jittered retries, and ignore stale connection callbacks.
- Track connecting, connected, and degraded health; degrade after three terminal failures or when EventSource is unavailable.
- Disable workspace-file polling while connecting or connected, and enable a 30-second fallback only while degraded.

Intentional omission: this PR does not change session, PR, CI, file-content, daemon, or lifecycle synchronization.

## Testing

- npm test -- src/renderer/lib/workspace-file-events.test.ts src/renderer/hooks/useSessionWorkspaceFiles.test.ts (7 passed)
- git diff --check
- Full frontend run: 2,787 passed; 31 unrelated Windows/macOS, Unix-socket, landing dependency, and path-separator tests failed.
- npm run typecheck is blocked by unresolved React and utility dependencies in the untouched packages/product-ui workspace.

## Checklist

- [x] Branched from main
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (targeted tests pass; workspace-wide limitations documented above)