### PR TITLE
fix(updates): prevent stuck manual check loader

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 
+import type { UpdateSettings, UpdateStatus } from "../../src/main/update-settings";
 import type { AoBridge } from "../../src/preload";
 import type { DaemonStatus } from "../../src/shared/daemon-status";
 import { coerceUiSettings, DEFAULT_UI_SETTINGS } from "../../src/shared/ui-locale";
@@ -34,15 +35,23 @@ export type FakeBridgeOptions = {
 	daemonState?: "ready" | "starting" | "stopped" | "error";
 	/** REST port advertised when ready (mock data is served regardless). */
 	daemonPort?: number;
+	/** Desktop updater state surfaced in Settings > Updates. */
+	updateStatus?: UpdateStatus;
+	/** Persisted automatic-update policy surfaced in Settings > Updates. */
+	updateSettings?: UpdateSettings;
 };
 
 export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}): Promise<void> {
 	const version = opts.version ?? "9.9.9-test";
 	const daemonState = opts.daemonState ?? "ready";
 	const daemonPort = opts.daemonPort ?? 8080;
+	const updateStatus = opts.updateStatus ?? ({ state: "idle" } satisfies UpdateStatus);
+	const updateSettings =
+		opts.updateSettings ??
+		({ enabled: false, channel: "latest", nightlyAck: false, feature: null } satisfies UpdateSettings);
 
 	await page.addInitScript(
-		({ version, daemonState, daemonPort }) => {
+		({ version, daemonState, daemonPort, updateStatus, updateSettings }) => {
 			const unsubscribe = () => () => undefined;
 			const status: DaemonStatus =
 				daemonState === "ready" ? { state: "ready", port: daemonPort } : { state: daemonState };
@@ -180,7 +189,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					setMigration: async () => undefined,
 				},
 				updateSettings: {
-					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
+					get: async () => updateSettings,
 					set: async () => undefined,
 				},
 				uiSettings: {
@@ -193,7 +202,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					setRecording: async () => undefined,
 				},
 				updates: {
-					getStatus: async () => ({ state: "idle" }),
+					getStatus: async () => updateStatus,
 					check: async () => undefined,
 					returnHome: async () => undefined,
 					download: async () => undefined,
@@ -216,7 +225,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 			} satisfies AoBridge;
 			(window as unknown as { ao: unknown }).ao = ao;
 		},
-		{ version, daemonState, daemonPort },
+		{ version, daemonState, daemonPort, updateStatus, updateSettings },
 	);
 }
 

--- a/frontend/e2e/updates-settings.spec.ts
+++ b/frontend/e2e/updates-settings.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+import { installFakeBridge } from "./support/fake-bridge";
+
+test("downloaded update keeps the full version readable and actions aligned", async ({ page }) => {
+	await page.setViewportSize({ width: 1010, height: 700 });
+	await page.emulateMedia({ colorScheme: "dark" });
+	await installFakeBridge(page, {
+		version: "0.12.7-nightly.202608240525",
+		updateSettings: { enabled: true, channel: "nightly", nightlyAck: true, feature: null },
+		updateStatus: {
+			state: "downloaded",
+			version: "0.12.8-nightly.202608241447",
+			checkedAt: new Date("2026-08-24T17:11:00.000Z").getTime(),
+		},
+	});
+
+	await page.goto("/#/settings");
+	await page.getByRole("button", { name: "Updates" }).click();
+
+	await expect(page.getByRole("status")).toContainText("Downloaded. Restart to finish updating.");
+	const version = page.getByTestId("app-version");
+	await expect(version).toContainText("v0.12.7-nightly.202608240525");
+	await expect(page.getByRole("button", { name: "Restart & install" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Check for updates" })).toBeVisible();
+	await expect(page.getByText("Enabled", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Updates channel" })).toContainText("Nightly");
+	await expect(page.locator(".nightly-warning")).toBeVisible();
+
+	const lineCount = await version.evaluate((element) => element.getClientRects().length);
+	expect(lineCount).toBe(1);
+
+	const restartBox = await page.getByRole("button", { name: "Restart & install" }).boundingBox();
+	const checkBox = await page.getByRole("button", { name: "Check for updates" }).boundingBox();
+	expect(restartBox).not.toBeNull();
+	expect(checkBox).not.toBeNull();
+	expect(Math.abs((restartBox?.height ?? 0) - (checkBox?.height ?? 0))).toBeLessThan(1);
+});

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -845,6 +845,39 @@ describe("startAutoUpdates", () => {
     );
   });
 
+  it("restores an earlier staged status immediately after the owned manual-check failure", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents, statusMessages } =
+      await importAutoUpdater();
+    const err = new Error(
+      'Cannot find latest-mac.yml in the latest release artifacts (https://github.com/AgentWrapper/agent-orchestrator/releases/download/v0.10.1/latest-mac.yml):\nHttpError: 404 "method: GET url: https://github.com/AgentWrapper/agent-orchestrator/releases/download/v0.10.1/latest-mac.yml"',
+    );
+    autoUpdater.checkForUpdates.mockImplementationOnce(() => {
+      updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+      return Promise.resolve();
+    });
+    await module.checkForUpdatesNow(stateDir, {
+      requestId: "earlier-download",
+    });
+
+    autoUpdater.checkForUpdates.mockRejectedValueOnce(err);
+    await module.checkForUpdatesNow(stateDir, {
+      requestId: "manual-update",
+    });
+
+    expect(statusMessages().slice(-2).map((message) => message.payload)).toEqual([
+      expect.objectContaining({
+        state: "error",
+        requestId: "manual-update",
+      }),
+      expect.objectContaining({
+        state: "downloaded",
+        version: "2.1.0",
+        requestId: "earlier-download",
+      }),
+    ]);
+  });
+
   it("still surfaces non-manifest 404 errors", async () => {
     const { module, updaterEvents } = await importAutoUpdater();
     const err = new Error(

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -367,6 +367,30 @@ describe("GlobalSettingsForm", () => {
 		expect(button).toBeEnabled();
 	});
 
+	it("stops manual loading when a completed check is immediately followed by the restored staged update", async () => {
+		let emit: (status: { state: string; version?: string; requestId?: string }) => void = () => undefined;
+		updOnStatus.mockImplementation((listener: (status: unknown) => void) => {
+			emit = listener as typeof emit;
+			return () => undefined;
+		});
+		updCheck.mockReturnValue(new Promise<void>(() => undefined));
+		renderForm();
+		const button = await screen.findByRole("button", { name: "Check for updates" });
+
+		await userEvent.click(button);
+		const requestId = updCheck.mock.calls[0]?.[0]?.requestId;
+		expect(requestId).toMatch(/^manual-update-/);
+
+		act(() => {
+			emit({ state: "error", requestId });
+			emit({ state: "downloaded", version: "1.2.3", requestId: "earlier-download" });
+		});
+
+		expect(screen.getByRole("status")).toHaveTextContent("Downloaded. Restart to finish updating.");
+		expect(screen.getByRole("button", { name: "Check for updates" })).toBeEnabled();
+		expect(screen.getByRole("button", { name: "Restart & install" })).toBeInTheDocument();
+	});
+
 	it("shows when the updater last completed a check", async () => {
 		const checkedAt = new Date("2026-08-19T12:51:00.000Z").getTime();
 		updGetStatus.mockResolvedValue({ state: "not-available", checkedAt });

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { AlertCircle, AlertTriangle, CheckCircle2, CircleDashed, Clock3, Download, Loader2, RefreshCw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { aoBridge } from "../../lib/bridge";
@@ -42,9 +43,14 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 	formRef.current = form;
 	const [showFeature, setShowFeature] = useState(false);
 	const [pendingPin, setPendingPin] = useState<{ pr: number; title: string } | null>(null);
+	const [manualCheckRequestId, setManualCheckRequestId] = useState<string | null>(null);
 	const developerMode = useUiStore((state) => state.developerMode);
 
-	const status = useUpdateStatus();
+	const status = useUpdateStatus((next) => {
+		setManualCheckRequestId((pending) =>
+			pending !== null && next.requestId === pending && next.state !== "checking" ? null : pending,
+		);
+	});
 	// Set only for the owned pin/home transition request, so unrelated hourly
 	// updater events cannot auto-progress through download/install.
 	const autoProgressRef = useRef<string | null>(null);
@@ -171,7 +177,11 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 	return (
 		<>
 			<SettingsSection title={t("settings.updates")} sectionId="updates" titleHidden={titleHidden} grouped>
-				<UpdateActions status={status} />
+				<UpdateActions
+					status={status}
+					manualCheckRequestId={manualCheckRequestId}
+					setManualCheckRequestId={setManualCheckRequestId}
+				/>
 
 				{featurePr != null && (
 					<div className="mt-3 flex flex-col gap-2 rounded-(--radius-settings-panel) border border-[var(--color-border-settings-dialog)] bg-[var(--color-bg-settings-input)] p-1">
@@ -208,7 +218,7 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 					</SettingsRow>
 
 					{form.enabled && (
-						<div className="update-policy-details border-t border-[var(--color-border-settings-dialog)]">
+						<div className="border-t border-[var(--color-border-settings-dialog)]">
 							<SettingsRow label={t("settings.updates.channel")}>
 								<SettingsOptionMenu
 									aria-label={t("settings.updates.channel")}
@@ -286,10 +296,17 @@ function FeatureBuildsSelect({
 	);
 }
 
-function UpdateActions({ status }: { status: UpdateStatus }) {
+function UpdateActions({
+	status,
+	manualCheckRequestId,
+	setManualCheckRequestId,
+}: {
+	status: UpdateStatus;
+	manualCheckRequestId: string | null;
+	setManualCheckRequestId: Dispatch<SetStateAction<string | null>>;
+}) {
 	const { t, i18n } = useTranslation();
 	const version = useQuery({ queryKey: ["app-version"], queryFn: () => aoBridge.app.getVersion() });
-	const [manualCheckRequestId, setManualCheckRequestId] = useState<string | null>(null);
 
 	const manualCheckPending = manualCheckRequestId !== null;
 	const checking = status.state === "checking" || manualCheckPending;
@@ -305,11 +322,6 @@ function UpdateActions({ status }: { status: UpdateStatus }) {
 			}).format(status.checkedAt)
 		: null;
 
-	useEffect(() => {
-		if (manualCheckRequestId === null || status.requestId !== manualCheckRequestId) return;
-		if (status.state !== "checking") setManualCheckRequestId(null);
-	}, [manualCheckRequestId, status.requestId, status.state]);
-
 	const checkNow = async () => {
 		const requestId = nextUpdateRequestId("manual-update");
 		setManualCheckRequestId(requestId);
@@ -323,85 +335,86 @@ function UpdateActions({ status }: { status: UpdateStatus }) {
 	};
 
 	return (
-		<div className="update-status-panel rounded-(--radius-settings-panel)" data-tone={tone}>
-			<div className="relative z-1 flex flex-col gap-4 px-4 py-4 sm:px-5 sm:py-5">
-				<div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-					<div className="flex min-w-0 flex-1 items-start gap-3.5">
-						<div className="update-status-glyph mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-lg" aria-hidden="true">
-							<UpdateStatusIcon status={displayStatus} />
-						</div>
-
-						<div
-							key={displayStatus.state}
-							id="update-status-line"
-							role="status"
-							aria-live="polite"
-							aria-atomic="true"
-							aria-busy={checking}
-							className="update-status-content min-w-0"
-						>
-							<UpdateStatusLine status={displayStatus} />
-							<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] leading-4 text-settings-muted">
-								<span className="font-mono tabular-nums" data-testid="app-version">
-									{t("settings.updates.currentVersion", { version: version.data ? `v${version.data}` : "…" })}
-								</span>
-								{checkedAt && (
-									<>
-										<span className="hidden size-0.5 rounded-full bg-current opacity-50 sm:block" aria-hidden="true" />
-										<span className="inline-flex items-center gap-1.5 tabular-nums" data-testid="update-checked-at">
-											<Clock3 className="size-3" aria-hidden="true" />
-											{t("settings.updates.lastChecked", { time: checkedAt })}
-										</span>
-									</>
-								)}
-							</div>
-						</div>
+		<div
+			className="update-status-panel overflow-hidden rounded-(--radius-settings-panel) border border-[var(--color-border-settings-dialog)] bg-[var(--color-bg-settings-input)]"
+			data-tone={tone}
+		>
+			<div className="grid gap-3 px-4 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+				<div className="flex min-w-0 items-center gap-3">
+					<div className="update-status-glyph flex size-9 shrink-0 items-center justify-center rounded-lg" aria-hidden="true">
+						<UpdateStatusIcon status={displayStatus} />
 					</div>
 
-					<div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
-						{!checking && status.state === "available" && (
-							<Button type="button" variant="primary" onClick={() => void aoBridge.updates.download()}>
-								{status.version ? t("settings.updates.updateTo", { version: `v${status.version}` }) : t("settings.updates.updateToLatest")}
-							</Button>
-						)}
-						{!checking && status.state === "downloaded" && (
-							<Button type="button" variant="primary" onClick={() => void aoBridge.updates.install()}>
-								{t("settings.updates.restartInstall")}
-							</Button>
-						)}
-						<Button
-							type="button"
-							aria-label={checking ? t("settings.updates.checking") : t("settings.updates.check")}
-							aria-describedby="update-status-line"
-							variant="outline"
-							size="sm"
-							className="min-w-36 bg-background/45"
-							onClick={() => void checkNow()}
-							disabled={busy}
-						>
-							{checking ? (
-								<Loader2 className="size-icon-sm animate-spin motion-reduce:animate-none" aria-hidden="true" />
-							) : (
-								<RefreshCw className="size-icon-sm" aria-hidden="true" />
-							)}
-							{checking ? t("settings.updates.checking") : t("settings.updates.check")}
-						</Button>
+					<div
+						id="update-status-line"
+						role="status"
+						aria-live="polite"
+						aria-atomic="true"
+						aria-busy={checking}
+						className="min-w-0"
+					>
+						<UpdateStatusLine status={displayStatus} />
 					</div>
 				</div>
 
-				{displayStatus.state === "downloading" && (
-					<div className="h-1 overflow-hidden rounded-full bg-foreground/8" aria-hidden="true">
-						<div className="update-download-progress h-full origin-left rounded-full bg-primary" style={{ transform: `scaleX(${progress / 100})` }} />
-					</div>
-				)}
+				<div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end [&>button]:flex-1 sm:[&>button]:flex-none">
+					{!checking && status.state === "available" && (
+						<Button type="button" variant="primary" size="sm" onClick={() => void aoBridge.updates.download()}>
+							{status.version ? t("settings.updates.updateTo", { version: `v${status.version}` }) : t("settings.updates.updateToLatest")}
+						</Button>
+					)}
+					{!checking && status.state === "downloaded" && (
+						<Button type="button" variant="primary" size="sm" onClick={() => void aoBridge.updates.install()}>
+							{t("settings.updates.restartInstall")}
+						</Button>
+					)}
+					<Button
+						type="button"
+						aria-label={checking ? t("settings.updates.checking") : t("settings.updates.check")}
+						aria-describedby="update-status-line"
+						variant="outline"
+						size="sm"
+						className="min-w-36"
+						onClick={() => void checkNow()}
+						disabled={busy}
+					>
+						{checking ? (
+							<Loader2 className="size-icon-sm animate-spin motion-reduce:animate-none" aria-hidden="true" />
+						) : (
+							<RefreshCw className="size-icon-sm" aria-hidden="true" />
+						)}
+						{checking ? t("settings.updates.checking") : t("settings.updates.check")}
+					</Button>
+				</div>
 
-				{status.staleCheckNudge && (
-					<p className="flex items-start gap-2 border-t border-[color-mix(in_oklch,var(--update-status-tone)_18%,transparent)] pt-3 text-xs leading-5 text-warning">
-						<AlertTriangle className="mt-0.5 size-icon-sm shrink-0" aria-hidden="true" />
-						<span>{t("settings.updates.networkStale")}</span>
-					</p>
-				)}
+				<div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 border-t border-[var(--color-border-settings-dialog)] pt-3 text-xs leading-4 text-settings-muted sm:col-span-2 sm:ml-12">
+					<span className="min-w-0 font-mono tabular-nums sm:whitespace-nowrap" data-testid="app-version">
+						{t("settings.updates.currentVersion", { version: version.data ? `v${version.data}` : "…" })}
+					</span>
+					{checkedAt && (
+						<>
+							<span className="hidden size-0.5 rounded-full bg-current opacity-50 sm:block" aria-hidden="true" />
+							<span className="inline-flex items-center gap-1.5 tabular-nums" data-testid="update-checked-at">
+								<Clock3 className="size-3" aria-hidden="true" />
+								{t("settings.updates.lastChecked", { time: checkedAt })}
+							</span>
+						</>
+					)}
+				</div>
 			</div>
+
+			{displayStatus.state === "downloading" && (
+				<div className="mx-4 mb-4 h-1 overflow-hidden rounded-full bg-foreground/8" aria-hidden="true">
+					<div className="h-full origin-left rounded-full bg-primary" style={{ transform: `scaleX(${progress / 100})` }} />
+				</div>
+			)}
+
+			{status.staleCheckNudge && (
+				<p className="mx-4 mb-4 flex items-start gap-2 border-t border-[var(--color-border-settings-dialog)] pt-3 text-xs leading-5 text-warning">
+					<AlertTriangle className="mt-0.5 size-icon-sm shrink-0" aria-hidden="true" />
+					<span>{t("settings.updates.networkStale")}</span>
+				</p>
+			)}
 		</div>
 	);
 }
@@ -445,7 +458,7 @@ function UpdateStatusLine({ status }: { status: UpdateStatus }) {
 	}
 
 	return (
-		<p className={cn("text-pretty text-[15px] font-medium leading-5 tracking-[-0.01em]", className)}>{label}</p>
+		<p className={cn("text-pretty text-sm font-medium leading-5", className)}>{label}</p>
 	);
 }
 

--- a/frontend/src/renderer/hooks/useUpdateStatus.ts
+++ b/frontend/src/renderer/hooks/useUpdateStatus.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { UpdateStatus } from "../../main/update-settings";
 import { aoBridge } from "../lib/bridge";
 
@@ -12,14 +12,21 @@ import { aoBridge } from "../lib/bridge";
  * the main process suppresses them for automatic checks. Update telemetry is
  * owned by the main process and subscribed once in lib/update-telemetry.ts.
  */
-export function useUpdateStatus(): UpdateStatus {
+export function useUpdateStatus(onStatusEvent?: (status: UpdateStatus) => void): UpdateStatus {
 	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+	const onStatusEventRef = useRef(onStatusEvent);
+	onStatusEventRef.current = onStatusEvent;
 	useEffect(() => {
 		let live = true;
 		void aoBridge.updates.getStatus().then((s) => {
-			if (live) setStatus(s);
+			if (!live) return;
+			onStatusEventRef.current?.(s);
+			setStatus(s);
 		});
-		const off = aoBridge.updates.onStatus(setStatus);
+		const off = aoBridge.updates.onStatus((next) => {
+			onStatusEventRef.current?.(next);
+			setStatus(next);
+		});
 		return () => {
 			live = false;
 			off?.();

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -627,18 +627,10 @@
 	border-block-start: 0 !important;
 }
 
-/* The updater is a compact instrument panel: status owns the visual hierarchy,
- * while the dotted field and state rail make activity legible without adding
- * decorative chrome. */
+/* Keep updater state legible without tinting the whole surface. The glyph is
+ * the single state-colored affordance; the panel otherwise matches Settings. */
 .update-status-panel {
 	--update-status-tone: var(--muted-foreground);
-	position: relative;
-	isolation: isolate;
-	overflow: hidden;
-	border: 1px solid color-mix(in oklch, var(--update-status-tone) 24%, var(--color-border-settings-dialog));
-	background:
-		linear-gradient(108deg, color-mix(in oklch, var(--update-status-tone) 9%, transparent), transparent 48%),
-		var(--color-bg-settings-input);
 	box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 5%, transparent);
 }
 
@@ -658,81 +650,11 @@
 	--update-status-tone: var(--color-error);
 }
 
-.update-status-panel::before {
-	position: absolute;
-	inset-block: 0;
-	inset-inline-start: 0;
-	width: 2px;
-	background: var(--update-status-tone);
-	content: "";
-}
-
-.update-status-panel::after {
-	position: absolute;
-	inset-block: 0;
-	inset-inline-end: 0;
-	width: 46%;
-	background-image: radial-gradient(
-		circle,
-		color-mix(in oklch, var(--update-status-tone) 27%, transparent) 0.7px,
-		transparent 0.8px
-	);
-	background-size: 14px 14px;
-	content: "";
-	mask-image: linear-gradient(to left, rgb(0 0 0 / 0.72), transparent);
-	pointer-events: none;
-}
-
 .update-status-glyph {
 	border: 1px solid color-mix(in oklch, var(--update-status-tone) 30%, transparent);
 	background: color-mix(in oklch, var(--update-status-tone) 11%, transparent);
 	color: var(--update-status-tone);
 	box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 5%, transparent);
-}
-
-.update-status-content {
-	animation: update-status-content-in 180ms var(--ease-out);
-}
-
-.update-download-progress {
-	transition: transform 240ms var(--ease-out);
-}
-
-.update-policy-details {
-	animation: update-policy-details-in 160ms var(--ease-out);
-}
-
-@keyframes update-status-content-in {
-	from {
-		opacity: 0.45;
-		transform: translateY(3px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
-}
-
-@keyframes update-policy-details-in {
-	from {
-		opacity: 0;
-		transform: translateY(-3px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.update-status-content,
-	.update-policy-details {
-		animation: none;
-	}
-
-	.update-download-progress {
-		transition: none;
-	}
 }
 
 /* Tailwind preflight clears button backgrounds; keep settings rows filled. */


### PR DESCRIPTION
Regression follow-up to #4284. This replaces the update-card styling approach attempted in #4292; the two UI diffs should not be merged together.

## Summary

- consume every updater status push before React can batch away an intermediate terminal event
- clear a manual check only from its matching request ID, while preserving a previously staged update
- simplify the status card and keep long Nightly versions readable with aligned actions
- cover the real main-process event order, the renderer race, and the reported downloaded + Nightly geometry

## Root cause

With an update already staged, a failed manual manifest check can publish these statuses synchronously:

1. `error` for the current manual request ID
2. restored `downloaded` state carrying the earlier staged request ID

The fix in #4285 cleared local loading from a React effect that only observed the latest committed status. React batches both pushes, so the matching terminal event could be discarded before that effect ran. The local request ID stayed set and forced the card back to `checking` forever, even though the updater had restored a valid downloaded state.

`useUpdateStatus` now exposes a lossless per-event callback. `UpdatesSection` uses it to clear only the matching manual request before updating the rendered snapshot, so the following staged status renders normally.

The new renderer regression test failed against the old implementation with `Checking for updates…` where `Downloaded. Restart to finish updating.` was expected.

## Visual evidence

This deterministic renderer state matches the report: dark mode, automatic updates enabled, Nightly selected, a staged download, and the long installed Nightly version. The Playwright test also asserts that the version stays on one line and both actions have equal height.

![Settings Updates after: downloaded Nightly state with readable version and aligned actions](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/pr-assets-update-loader-lost-status/.issue-assets/update-loader-lost-status/after-dark.png)

The screenshot is visual-state evidence. The updater behavior itself is proven separately by the main-process producer test and renderer regression test.

## Native Electron verification

The branch was launched in the real Electron app with isolated AO data and the real preload bridge. Settings → Updates rendered correctly, and clicking **Check for updates** completed with `Updates are only available in the installed app.`, leaving the button enabled and `aria-busy=false`.

Unpackaged Electron intentionally has no release feed, so the exact packaged staged-update sequence is reproduced at its two real boundaries in tests rather than claimed from the screenshot.

## Tests

- `cd frontend && npm test -- --run` — 218 files passed; 2,875 tests passed; 1 skipped
- `cd frontend && npm test -- --run src/renderer/components/GlobalSettingsForm.test.tsx src/renderer/components/Sidebar.test.tsx src/main/auto-updater.test.ts` — 152 passed
- `cd frontend && npm run typecheck` — passed
- `cd frontend && npm run typecheck:e2e` — passed
- `cd frontend && npx playwright test e2e/updates-settings.spec.ts --reporter=line` — passed
- `cd frontend && npm run package` — production Electron package completed
