### PR TITLE
fix(runtime): isolate AO tmux state

### DIFF
--- a/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
+++ b/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
@@ -4,7 +4,10 @@ package runtimeselect
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
+	"path/filepath"
 	"runtime"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/conpty"
@@ -32,13 +35,40 @@ var _ Runtime = (*conpty.Runtime)(nil)
 // New returns the per-platform runtime: tmux on Darwin/Linux, conpty on
 // Windows. log is accepted for signature stability with callers but is
 // currently unused. runFilePath is this daemon instance's running.json path
-// (config.Config.RunFilePath); on Windows it scopes the conpty pty-host
-// registry to the same instance, so two AO daemons on one machine with
-// different AO_RUN_FILE/AO_DATA_DIR overrides never share one registry — see
-// ptyregistry.SetRunFilePath.
+// (config.Config.RunFilePath): on Darwin/Linux it identifies the private tmux
+// socket, and on Windows it scopes the conpty pty-host registry to the same
+// instance. Two AO daemons with different run files therefore never share
+// terminal runtime state.
 func New(_ *slog.Logger, runFilePath string) Runtime {
 	if runtime.GOOS != "windows" {
-		return tmux.New(tmux.Options{})
+		return tmux.New(tmux.Options{SocketPath: privateTmuxSocketPath(runFilePath)})
 	}
 	return conpty.New(conpty.Options{RunFilePath: runFilePath})
+}
+
+const tmuxSocketIdentityBytes = 16
+
+// privateTmuxSocketPath gives each daemon identity its own explicit tmux
+// server. Config.Load resolves runFilePath to an absolute path; Abs also keeps
+// direct callers and tests on that same contract. Hashing the full path (not
+// merely its directory) prevents two AO run files beside each other from
+// sharing a server accidentally. The tmux adapter presents overly long paths
+// through a bounded /tmp directory alias while keeping the socket inode here,
+// beside the run file.
+func privateTmuxSocketPath(runFilePath string) string {
+	if runFilePath == "" {
+		// Runtime operations will fail closed on the empty socket path instead of
+		// placing terminal state relative to the daemon's incidental cwd.
+		return ""
+	}
+	absRunFilePath, err := filepath.Abs(runFilePath)
+	if err != nil {
+		// An already-absolute path never needs the working directory and cannot
+		// hit this branch. Keep the helper deterministic for an invalid direct
+		// caller; production receives config.Config.RunFilePath, which is absolute.
+		absRunFilePath = filepath.Clean(runFilePath)
+	}
+	digest := sha256.Sum256([]byte(absRunFilePath))
+	identity := hex.EncodeToString(digest[:tmuxSocketIdentityBytes])
+	return filepath.Join(filepath.Dir(absRunFilePath), "tmux-"+identity+".sock")
 }

--- a/backend/internal/adapters/runtime/runtimeselect/runtimeselect_test.go
+++ b/backend/internal/adapters/runtime/runtimeselect/runtimeselect_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package runtimeselect
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrivateTmuxSocketPathDerivesStableAbsolutePathFromFullRunFileIdentity(t *testing.T) {
+	dir := t.TempDir()
+	firstRunFile := filepath.Join(dir, "running.json")
+	secondRunFile := filepath.Join(dir, "development.json")
+
+	first := privateTmuxSocketPath(firstRunFile)
+	if !filepath.IsAbs(first) {
+		t.Fatalf("socket path = %q, want absolute", first)
+	}
+	if again := privateTmuxSocketPath(firstRunFile); again != first {
+		t.Fatalf("socket path changed for the same run file: first %q, again %q", first, again)
+	}
+
+	digest := sha256.Sum256([]byte(firstRunFile))
+	want := filepath.Join(dir, "tmux-"+hex.EncodeToString(digest[:tmuxSocketIdentityBytes])+".sock")
+	if first != want {
+		t.Fatalf("socket path = %q, want %q", first, want)
+	}
+
+	second := privateTmuxSocketPath(secondRunFile)
+	if second == first {
+		t.Fatalf("run files in the same directory shared socket %q", first)
+	}
+}
+
+func TestPrivateTmuxSocketPathAbsolutizesRelativeRunFile(t *testing.T) {
+	got := privateTmuxSocketPath(filepath.Join("state", "running.json"))
+	if !filepath.IsAbs(got) {
+		t.Fatalf("socket path = %q, want absolute", got)
+	}
+}
+
+func TestPrivateTmuxSocketPathFailsClosedWithoutRunFileIdentity(t *testing.T) {
+	if got := privateTmuxSocketPath(""); got != "" {
+		t.Fatalf("socket path = %q, want empty fail-closed path", got)
+	}
+}

--- a/backend/internal/adapters/runtime/tmux/environment.go
+++ b/backend/internal/adapters/runtime/tmux/environment.go
@@ -1,0 +1,168 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// syncCurrentEnvironment refreshes one tmux session's process-launch
+// environment from the daemon before its real pane is created or respawned.
+// tmux sessions snapshot the server environment, so a server which survives an
+// app restart otherwise keeps stale credentials, PATH entries, and socket
+// locations forever. Session-specific inspection also catches values which
+// were added only to this session and later removed.
+//
+// Values are sent through `source-file -` on stdin. They must never be added to
+// tmux argv: command lines are visible to other local processes on several
+// supported operating systems. Existing names are also inspected so variables
+// removed from the daemon environment are explicitly removed from tmux.
+func (r *Runtime) syncCurrentEnvironment(ctx context.Context, sessionID string, configured map[string]string) error {
+	current := sessionWorkloadEnvironment(os.Environ(), configured)
+	names := make(map[string]struct{}, len(current))
+	for key := range current {
+		names[key] = struct{}{}
+	}
+	queries := []struct {
+		scope string
+		args  []string
+	}{
+		{scope: "global", args: []string{"show-environment", "-g"}},
+		{scope: "session", args: []string{"show-environment", "-t", exactSessionTarget(sessionID)}},
+	}
+	for _, query := range queries {
+		out, err := r.run(ctx, query.args...)
+		if err != nil {
+			if serverUnreachableOutput(string(out)) {
+				return fmt.Errorf("private tmux server unavailable while refreshing session %s", sessionID)
+			}
+			return fmt.Errorf("inspect private tmux %s environment %s: %w", query.scope, sessionID, err)
+		}
+		for _, key := range parseTmuxEnvironmentNames(string(out)) {
+			names[key] = struct{}{}
+		}
+	}
+
+	script := buildEnvironmentSyncScript(current, names, sessionID)
+	if script == "" {
+		return nil
+	}
+	if _, err := r.runWithInput(ctx, []byte(script), "source-file", "-"); err != nil {
+		return fmt.Errorf("apply private tmux environment: %w", err)
+	}
+	return nil
+}
+
+// sessionWorkloadEnvironment applies the existing RuntimeConfig environment
+// semantics without putting any configured value in a command line. An absent
+// NO_COLOR is removed even when AO itself inherited it; COLORTERM and TERM stay
+// owned by AO/tmux; and an empty configured PATH retains the ambient PATH, as
+// the historical launch command did.
+func sessionWorkloadEnvironment(base []string, configured map[string]string) map[string]string {
+	result := currentWorkloadEnvironment(base)
+	if _, configuredNoColor := configured["NO_COLOR"]; !configuredNoColor {
+		delete(result, "NO_COLOR")
+	}
+	for key, value := range configured {
+		if key == "TERM" || key == "COLORTERM" || isolatedTmuxEnvironmentKey(key) {
+			continue
+		}
+		if key == "PATH" && value == "" {
+			continue
+		}
+		result[key] = value
+	}
+	result["COLORTERM"] = "truecolor"
+	return result
+}
+
+// currentWorkloadEnvironment is the subset of the daemon environment that
+// tmux should use for future panes. TERM is deliberately omitted because tmux
+// owns the TERM value inside panes; COLORTERM and ordinary workload variables
+// remain current. controlEnv has already removed the surrounding tmux identity
+// and AO's internal binary/socket selectors.
+func currentWorkloadEnvironment(base []string) map[string]string {
+	result := make(map[string]string)
+	for _, entry := range controlEnv(base) {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "TERM" || !validEnvKey(key) {
+			continue
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func isolatedTmuxEnvironmentKey(key string) bool {
+	switch key {
+	case "TMUX", "TMUX_PANE", "AO_TMUX_BINARY", "AO_TMUX_SOCKET_NAME":
+		return true
+	default:
+		return false
+	}
+}
+
+// parseTmuxEnvironmentNames extracts names from global or session
+// `show-environment` output. Removed entries are emitted as -NAME; ordinary
+// entries are NAME=value. Values are intentionally discarded and never copied
+// into argv or errors.
+func parseTmuxEnvironmentNames(output string) []string {
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		var key string
+		if strings.HasPrefix(line, "-") {
+			key = strings.TrimPrefix(line, "-")
+		} else if before, _, ok := strings.Cut(line, "="); ok {
+			key = before
+		}
+		if key == "TERM" || !validEnvKey(key) {
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func buildEnvironmentSyncScript(current map[string]string, names map[string]struct{}, sessionID string) string {
+	keys := make([]string, 0, len(names))
+	for key := range names {
+		if key == "TERM" || !validEnvKey(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var script strings.Builder
+	for _, key := range keys {
+		value, present := current[key]
+		if present {
+			fmt.Fprintf(&script, "set-environment -t %s %s %s\n", exactSessionTarget(sessionID), key, tmuxConfigQuote(value))
+			continue
+		}
+		fmt.Fprintf(&script, "set-environment -r -t %s %s\n", exactSessionTarget(sessionID), key)
+	}
+	return script.String()
+}
+
+// tmuxConfigQuote encodes every byte as a three-digit octal escape inside a
+// double-quoted tmux configuration string. This handles quotes, dollars,
+// backslashes, newlines, and UTF-8 without permitting configuration injection.
+func tmuxConfigQuote(value string) string {
+	var quoted strings.Builder
+	quoted.Grow(2 + len(value)*4)
+	quoted.WriteByte('"')
+	for _, b := range []byte(value) {
+		fmt.Fprintf(&quoted, "\\%03o", b)
+	}
+	quoted.WriteByte('"')
+	return quoted.String()
+}

--- a/backend/internal/adapters/runtime/tmux/socket_unix.go
+++ b/backend/internal/adapters/runtime/tmux/socket_unix.go
@@ -1,0 +1,156 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// Darwin's sockaddr_un.sun_path is 104 bytes including the trailing NUL.
+// Linux permits a little more, but using Darwin's ceiling keeps one portable
+// address contract for both bundled Unix targets.
+const maxUnixSocketPathBytes = 103
+
+const socketAliasIdentityBytes = 16
+
+// privateSocketAddress returns the pathname tmux should receive with -S. Short
+// AO-owned socket paths are used directly. For an arbitrarily deep AO_RUN_FILE,
+// a deterministic short directory symlink under /tmp points at the actual AO
+// runtime directory; binding through that alias keeps the socket inode beside
+// running.json while satisfying AF_UNIX's textual address limit. The alias is
+// stable because the tmux server intentionally survives daemon/app restarts.
+func privateSocketAddress(socketPath string) (string, error) {
+	targetDir, err := validatePrivateSocketDirectory(filepath.Dir(socketPath))
+	if err != nil {
+		return "", err
+	}
+	socketPath = filepath.Join(targetDir, filepath.Base(socketPath))
+	if len([]byte(socketPath)) <= maxUnixSocketPathBytes {
+		return socketPath, nil
+	}
+
+	digest := sha256.Sum256([]byte(socketPath))
+	identity := hex.EncodeToString(digest[:socketAliasIdentityBytes])
+	// The deterministic aliases live inside an owner-only root. Creating them
+	// directly in the shared /tmp namespace would let another local user
+	// pre-create an alias between AO's checks and tmux's bind.
+	aliasRoot := fmt.Sprintf("/tmp/ao-tmux-%d", os.Getuid())
+	if err := ensureSocketAliasRoot(aliasRoot); err != nil {
+		return "", err
+	}
+	aliasDir := filepath.Join(aliasRoot, identity)
+	address := filepath.Join(aliasDir, filepath.Base(socketPath))
+	if len([]byte(address)) > maxUnixSocketPathBytes {
+		return "", fmt.Errorf("tmux runtime: private socket alias is %d bytes; maximum is %d", len([]byte(address)), maxUnixSocketPathBytes)
+	}
+
+	if err := os.Symlink(targetDir, aliasDir); err != nil {
+		if !os.IsExist(err) {
+			return "", fmt.Errorf("tmux runtime: create private socket directory alias: %w", err)
+		}
+		if err := validateSocketAlias(aliasDir, targetDir); err != nil {
+			return "", err
+		}
+	}
+	return address, nil
+}
+
+// validatePrivateSocketDirectory returns a canonical directory which cannot be
+// redirected or modified by another local user. The leaf must belong to AO's
+// user. Every ancestor must belong to that user or root and must not be
+// group/other-writable, except for a root-owned sticky directory such as /tmp.
+func validatePrivateSocketDirectory(targetDir string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(targetDir)
+	if err != nil {
+		return "", fmt.Errorf("tmux runtime: resolve private socket directory: %w", err)
+	}
+	currentUID := int64(os.Getuid())
+	for current := resolved; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		if err != nil {
+			return "", fmt.Errorf("tmux runtime: inspect private socket directory: %w", err)
+		}
+		if !info.IsDir() {
+			return "", fmt.Errorf("tmux runtime: private socket path component is not a directory: %s", current)
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return "", fmt.Errorf("tmux runtime: cannot inspect private socket directory owner: %s", current)
+		}
+		ownerUID := int64(stat.Uid)
+		if current == resolved && ownerUID != currentUID {
+			return "", fmt.Errorf("tmux runtime: private socket directory is not owned by the current user: %s", current)
+		}
+		if ownerUID != currentUID && ownerUID != 0 {
+			return "", fmt.Errorf("tmux runtime: private socket path component has an untrusted owner: %s", current)
+		}
+		if info.Mode().Perm()&0o022 != 0 && (ownerUID != 0 || info.Mode()&os.ModeSticky == 0) {
+			return "", fmt.Errorf("tmux runtime: private socket directory is writable by other users: %s", current)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+	}
+	return resolved, nil
+}
+
+func ensureSocketAliasRoot(aliasRoot string) error {
+	err := os.Mkdir(aliasRoot, 0o700)
+	if err != nil && !os.IsExist(err) {
+		return fmt.Errorf("tmux runtime: create private socket alias root: %w", err)
+	}
+
+	info, err := os.Lstat(aliasRoot)
+	if err != nil {
+		return fmt.Errorf("tmux runtime: inspect private socket alias root: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("tmux runtime: private socket alias root is not a directory: %s", aliasRoot)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int64(stat.Uid) != int64(os.Getuid()) {
+		return fmt.Errorf("tmux runtime: private socket alias root is not owned by the current user: %s", aliasRoot)
+	}
+	if info.Mode().Perm() != 0o700 {
+		//nolint:gosec // This is an owner-only directory; execute permission is required to reach its socket aliases.
+		if err := os.Chmod(aliasRoot, 0o700); err != nil {
+			return fmt.Errorf("tmux runtime: secure private socket alias root: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateSocketAlias(aliasDir, wantTarget string) error {
+	info, err := os.Lstat(aliasDir)
+	if err != nil {
+		return fmt.Errorf("tmux runtime: inspect private socket directory alias: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("tmux runtime: private socket directory alias is not a symlink: %s", aliasDir)
+	}
+	gotTarget, err := os.Readlink(aliasDir)
+	if err != nil {
+		return fmt.Errorf("tmux runtime: read private socket directory alias: %w", err)
+	}
+	if !filepath.IsAbs(gotTarget) {
+		gotTarget = filepath.Join(filepath.Dir(aliasDir), gotTarget)
+	}
+	gotTarget, err = filepath.Abs(gotTarget)
+	if err != nil {
+		return fmt.Errorf("tmux runtime: resolve private socket directory alias: %w", err)
+	}
+	wantTarget, err = filepath.Abs(wantTarget)
+	if err != nil {
+		return fmt.Errorf("tmux runtime: resolve private socket directory: %w", err)
+	}
+	if filepath.Clean(gotTarget) != filepath.Clean(wantTarget) {
+		return fmt.Errorf("tmux runtime: private socket directory alias points to %s, want %s", gotTarget, wantTarget)
+	}
+	return nil
+}

--- a/backend/internal/adapters/runtime/tmux/socket_unix_test.go
+++ b/backend/internal/adapters/runtime/tmux/socket_unix_test.go
@@ -1,0 +1,150 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPrivateSocketAddressAliasesLongPathIntoRuntimeDirectory(t *testing.T) {
+	targetDir := filepath.Join(t.TempDir(), strings.Repeat("deep-runtime-directory-", 6))
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	socketPath := filepath.Join(targetDir, "tmux-0123456789abcdef0123456789abcdef.sock")
+	if len([]byte(socketPath)) <= maxUnixSocketPathBytes {
+		t.Fatalf("precondition: socket path is only %d bytes: %q", len([]byte(socketPath)), socketPath)
+	}
+
+	address, err := privateSocketAddress(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := filepath.Dir(address)
+	t.Cleanup(func() { _ = os.Remove(aliasDir) })
+	aliasRoot := filepath.Dir(aliasDir)
+	if got, want := aliasRoot, filepath.Join("/tmp", "ao-tmux-"+strconv.Itoa(os.Getuid())); got != want {
+		t.Fatalf("alias root = %q, want owner-specific root %q", got, want)
+	}
+	if info, err := os.Stat(aliasRoot); err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("alias root mode = %v, err=%v; want 0700", infoMode(info), err)
+	}
+	if len([]byte(address)) > maxUnixSocketPathBytes {
+		t.Fatalf("aliased socket path is %d bytes, maximum %d: %q", len([]byte(address)), maxUnixSocketPathBytes, address)
+	}
+	if strings.Contains(address, targetDir) {
+		t.Fatalf("aliased socket retained long runtime path: %q", address)
+	}
+	wantTarget, err := filepath.EvalSymlinks(targetDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target, err := os.Readlink(aliasDir); err != nil || target != wantTarget {
+		t.Fatalf("alias target = %q, err=%v; want %q", target, err, wantTarget)
+	}
+
+	// Creating through the short address must put the inode inside AO's runtime
+	// directory, not /tmp. A real tmux bind follows the same parent symlink.
+	if err := os.WriteFile(address, []byte("probe"), 0o600); err != nil {
+		t.Fatalf("write through alias: %v", err)
+	}
+	if got, err := os.ReadFile(socketPath); err != nil || string(got) != "probe" {
+		t.Fatalf("runtime-dir inode = %q, err=%v; want probe", got, err)
+	}
+}
+
+func TestPrivateSocketAddressRefusesForeignAlias(t *testing.T) {
+	targetDir := filepath.Join(t.TempDir(), strings.Repeat("deep-runtime-directory-", 6))
+	foreignDir := t.TempDir()
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	socketPath := filepath.Join(targetDir, "tmux-0123456789abcdef0123456789abcdef.sock")
+	address, err := privateSocketAddress(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := filepath.Dir(address)
+	if err := os.Remove(aliasDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(foreignDir, aliasDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(aliasDir) })
+
+	if _, err := privateSocketAddress(socketPath); err == nil || !strings.Contains(err.Error(), "points to") {
+		t.Fatalf("privateSocketAddress error = %v, want foreign alias rejection", err)
+	}
+}
+
+func TestEnsureSocketAliasRootRefusesSymlinkAndTightensPermissions(t *testing.T) {
+	parent := t.TempDir()
+	target := t.TempDir()
+	symlinkRoot := filepath.Join(parent, "symlink-root")
+	if err := os.Symlink(target, symlinkRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSocketAliasRoot(symlinkRoot); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("symlink root error = %v, want rejection", err)
+	}
+
+	looseRoot := filepath.Join(parent, "loose-root")
+	if err := os.Mkdir(looseRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(looseRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSocketAliasRoot(looseRoot); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(looseRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("secured alias root mode = %o, want 700", got)
+	}
+}
+
+func TestPrivateSocketAddressRejectsSharedWritableParent(t *testing.T) {
+	shared := filepath.Join(t.TempDir(), "shared")
+	if err := os.Mkdir(shared, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(shared, 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	shortPath := filepath.Join(shared, "tmux.sock")
+	if _, err := privateSocketAddress(shortPath); err == nil || !strings.Contains(err.Error(), "writable by other users") {
+		t.Fatalf("short private socket error = %v, want shared-parent rejection", err)
+	}
+
+	longDir := filepath.Join(shared, strings.Repeat("deep-runtime-directory-", 6))
+	if err := os.Mkdir(longDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(longDir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	longPath := filepath.Join(longDir, "tmux-0123456789abcdef0123456789abcdef.sock")
+	if len([]byte(longPath)) <= maxUnixSocketPathBytes {
+		t.Fatalf("precondition: long socket path is only %d bytes", len([]byte(longPath)))
+	}
+	if _, err := privateSocketAddress(longPath); err == nil || !strings.Contains(err.Error(), "writable by other users") {
+		t.Fatalf("long private socket error = %v, want shared-parent rejection", err)
+	}
+}
+
+func infoMode(info os.FileInfo) os.FileMode {
+	if info == nil {
+		return 0
+	}
+	return info.Mode().Perm()
+}

--- a/backend/internal/adapters/runtime/tmux/socket_windows.go
+++ b/backend/internal/adapters/runtime/tmux/socket_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package tmux
+
+// Windows selects ConPTY rather than tmux. Keep the adapter buildable for
+// cross-platform compile checks without adding Unix alias behavior here.
+func privateSocketAddress(socketPath string) (string, error) {
+	return socketPath, nil
+}

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -2,6 +2,7 @@
 package tmux
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -11,10 +12,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -48,41 +47,40 @@ var sessionIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 var getenv = os.Getenv
 
-// Options configures a tmux Runtime. Every field has a sensible default (see
-// New), so the zero value is usable.
+// Options configures a tmux Runtime. SocketPath is required: AO must always use
+// an explicitly managed server socket and must never fall back to tmux's
+// per-user default server.
 type Options struct {
-	Binary       string        // default configured/bundled/system tmux resolution
-	LegacyBinary string        // default system tmux from PATH when SocketName is set; used only for pre-private-socket sessions
-	SocketName   string        // default $AO_TMUX_SOCKET_NAME; empty uses tmux's machine-wide default socket
-	Shell        string        // default $SHELL else /bin/sh
-	Timeout      time.Duration // default 5s
-	ChunkSize    int           // default 16*1024
-	EnterDelay   time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
-	ReapGrace    time.Duration // grace between SIGTERM and SIGKILL when reaping a pane's leftover background processes on Destroy; default defaultReapGrace.
+	Binary     string        // default configured/bundled/system tmux resolution
+	SocketPath string        // required private socket path, passed to every tmux client with -S
+	Shell      string        // default $SHELL else /bin/sh
+	Timeout    time.Duration // default 5s
+	ChunkSize  int           // default 16*1024
+	EnterDelay time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
+	ReapGrace  time.Duration // grace between SIGTERM and SIGKILL when reaping a pane's leftover background processes on Destroy; default defaultReapGrace.
 }
 
 // Runtime runs agent sessions inside tmux sessions, driving them via the tmux
 // CLI. It implements ports.Runtime.
 type Runtime struct {
-	binary         string
-	legacyBinary   string
-	socketName     string
-	shell          string
-	timeout        time.Duration
-	chunkSize      int
-	enterDelay     time.Duration
-	reapGrace      time.Duration
-	runner         runner
-	reapSessions   func(ctx context.Context, pids []int, grace time.Duration)
-	socketMu       sync.RWMutex
-	sessionSockets map[string]string
+	binary           string
+	binaryResolveErr error
+	socketPath       string
+	shell            string
+	timeout          time.Duration
+	chunkSize        int
+	enterDelay       time.Duration
+	reapGrace        time.Duration
+	runner           runner
+	reapSessions     func(ctx context.Context, pids []int, grace time.Duration)
+	syncEnvironment  func(ctx context.Context, sessionID string, configured map[string]string) error
 }
 
 var _ ports.Runtime = (*Runtime)(nil)
 var _ ports.Attacher = (*Runtime)(nil)
 
 type runner interface {
-	Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
+	Run(ctx context.Context, env []string, stdin []byte, name string, args ...string) ([]byte, error)
 }
 
 // killSessionsByPID force-terminates every process in each pid's tmux pane
@@ -201,9 +199,19 @@ func sessionsHaveProcesses(ctx context.Context, pids []int) bool {
 
 type execRunner struct{}
 
-func (execRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+func (execRunner) Run(ctx context.Context, env []string, stdin []byte, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = append(append([]string(nil), os.Environ()...), env...)
+	// A non-nil environment is a complete, already-sanitized control
+	// environment. Do not append os.Environ here: doing so would silently
+	// reintroduce a surrounding TMUX identity and AO's internal tmux selectors.
+	// Nil retains os/exec's ordinary inherited-environment behavior for narrow
+	// callers and tests that do not supply an environment.
+	if env != nil {
+		cmd.Env = append([]string(nil), env...)
+	}
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
 	// Run from a stable directory, not whatever the daemon process's cwd happens
 	// to be. The first tmux CLI call auto-starts tmux's persistent server, which
 	// inherits ITS launching process's cwd and keeps it for the server's entire
@@ -249,16 +257,17 @@ func stableRunDir() string {
 // default timeout and output chunk size.
 func New(opts Options) *Runtime {
 	binary := opts.Binary
+	var binaryResolveErr error
 	if binary == "" {
 		resolution, err := tmuxbin.Resolve()
 		if err == nil {
 			binary = resolution.Path
-		} else if configured := strings.TrimSpace(getenv("AO_TMUX_BINARY")); configured != "" {
-			// Keep the configured path on failure so packaged builds fail closed
-			// when they eventually execute it instead of selecting machine tmux.
-			binary = configured
 		} else {
-			binary = "tmux"
+			binaryResolveErr = fmt.Errorf("tmux runtime: resolve tmux binary: %w", err)
+			// Retain the configured value for diagnostics, but managedArgs returns
+			// binaryResolveErr before any execution. In particular, a damaged
+			// packaged layout can never fall through to a machine tmux on PATH.
+			binary = strings.TrimSpace(getenv("AO_TMUX_BINARY"))
 		}
 	}
 	timeout := opts.Timeout
@@ -284,35 +293,20 @@ func New(opts Options) *Runtime {
 	if reapGrace <= 0 {
 		reapGrace = defaultReapGrace
 	}
-	socketName := strings.TrimSpace(opts.SocketName)
-	if socketName == "" {
-		socketName = strings.TrimSpace(getenv("AO_TMUX_SOCKET_NAME"))
+	runtime := &Runtime{
+		binary:           binary,
+		binaryResolveErr: binaryResolveErr,
+		socketPath:       opts.SocketPath,
+		shell:            shellPath,
+		timeout:          timeout,
+		chunkSize:        chunkSize,
+		enterDelay:       enterDelay,
+		reapGrace:        reapGrace,
+		runner:           execRunner{},
+		reapSessions:     killSessionsByPID,
 	}
-	legacyBinary := opts.LegacyBinary
-	if socketName == "" {
-		legacyBinary = binary
-	} else if legacyBinary == "" {
-		// Sessions created before AO introduced its private socket were started by
-		// the machine tmux from PATH. Use that matching client for the legacy
-		// default socket: tmux's client/server protocol is not guaranteed across
-		// versions, so AO's pinned bundled client may be unable to adopt them.
-		if systemTmux, err := exec.LookPath("tmux"); err == nil {
-			legacyBinary = systemTmux
-		}
-	}
-	return &Runtime{
-		binary:         binary,
-		legacyBinary:   legacyBinary,
-		socketName:     socketName,
-		shell:          shellPath,
-		timeout:        timeout,
-		chunkSize:      chunkSize,
-		enterDelay:     enterDelay,
-		reapGrace:      reapGrace,
-		runner:         execRunner{},
-		reapSessions:   killSessionsByPID,
-		sessionSockets: make(map[string]string),
-	}
+	runtime.syncEnvironment = runtime.syncCurrentEnvironment
+	return runtime
 }
 
 // Create starts a new tmux session in the workspace, running the agent's
@@ -332,14 +326,26 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 		return ports.RuntimeHandle{}, err
 	}
 
-	launchCmd := buildLaunchCommand(cfg)
-	args := newSessionArgs(id, cfg.WorkspacePath, r.shell, launchCmd)
+	// Start a harmless bootstrap pane first, then populate the session's
+	// environment over tmux's stdin channel before launching the real command.
+	// This keeps cfg.Env values out of both the tmux client's argv and the
+	// long-lived pane shell's argv.
+	args := newSessionArgs(id, cfg.WorkspacePath, r.shell, "exec cat >/dev/null")
 	if _, err := r.run(ctx, args...); err != nil {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: create session %s: %w", id, err)
 	}
-	r.rememberSessionSocket(id, r.socketName)
+	handle := ports.RuntimeHandle{ID: id}
+	if err := r.syncEnvironment(ctx, id, cfg.Env); err != nil {
+		_ = r.Destroy(context.Background(), handle)
+		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: refresh environment for session %s: %w", id, err)
+	}
+	launchCmd := buildLaunchCommand(cfg)
+	if _, err := r.run(ctx, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
+		_ = r.Destroy(context.Background(), handle)
+		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: launch session %s: %w", id, err)
+	}
 	if err := r.verifyPaneWorkingDirectory(ctx, id, cfg.WorkspacePath); err != nil {
-		_ = r.Destroy(context.Background(), ports.RuntimeHandle{ID: id})
+		_ = r.Destroy(context.Background(), handle)
 		return ports.RuntimeHandle{}, err
 	}
 
@@ -365,7 +371,6 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: set window-size %s: %w", id, err)
 	}
 
-	handle := ports.RuntimeHandle{ID: id}
 	alive, err := r.IsAlive(ctx, handle)
 	if err != nil {
 		_ = r.Destroy(context.Background(), handle)
@@ -403,8 +408,11 @@ func (r *Runtime) Restart(ctx context.Context, handle ports.RuntimeHandle, cfg p
 		return ports.RuntimeHandle{}, err
 	}
 
+	if err := r.syncEnvironment(ctx, id, cfg.Env); err != nil {
+		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: refresh environment for session %s: %w", id, err)
+	}
 	launchCmd := buildLaunchCommand(cfg)
-	if _, err := r.runForSession(ctx, id, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
+	if _, err := r.run(ctx, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: restart session %s: %w", id, err)
 	}
 	alive, err := r.IsAlive(ctx, handle)
@@ -442,7 +450,7 @@ func (r *Runtime) verifyPaneWorkingDirectory(ctx context.Context, id, want strin
 			case <-time.After(paneCwdVerifyRetryDelay):
 			}
 		}
-		out, err := r.runForSession(ctx, id, paneCurrentPathArgs(id)...)
+		out, err := r.run(ctx, paneCurrentPathArgs(id)...)
 		if err != nil {
 			// A later transient probe failure (e.g. a one-off tmux CLI hiccup)
 			// must not overwrite an already-observed cwd mismatch: the mismatch
@@ -484,7 +492,7 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	// not block the kill-session below.
 	sessionIDs := r.paneSessionIDs(ctx, id)
 
-	out, err := r.runForSession(ctx, id, killSessionArgs(id)...)
+	out, err := r.run(ctx, killSessionArgs(id)...)
 	// Reap regardless of the kill-session result: orphaned children outlive the
 	// session, so they must be cleaned up even when the session was already
 	// gone (a benign double-kill).
@@ -493,12 +501,10 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && killSessionMissingOutput(string(out)) {
-			r.forgetSessionSocket(id)
 			return nil
 		}
 		return fmt.Errorf("tmux runtime: destroy session %s: %w", id, err)
 	}
-	r.forgetSessionSocket(id)
 	return nil
 }
 
@@ -508,7 +514,7 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 // any error (including a missing session) or unparseable line yields no ids,
 // and pids <= 1 are skipped so we never signal init or the "current session".
 func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
-	out, err := r.runForSession(ctx, id, listPanePIDsArgs(id)...)
+	out, err := r.run(ctx, listPanePIDsArgs(id)...)
 	if err != nil {
 		return nil
 	}
@@ -535,7 +541,7 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 	if err != nil {
 		return false, err
 	}
-	out, err := r.runForSession(ctx, id, hasSessionArgs(id)...)
+	out, err := r.run(ctx, hasSessionArgs(id)...)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -590,7 +596,7 @@ func (r *Runtime) supervisedProcessTree(ctx context.Context, handle ports.Runtim
 	if err != nil {
 		return nil, 0, err
 	}
-	paneOut, err := r.runForSession(ctx, id, panePIDArgs(id)...)
+	paneOut, err := r.run(ctx, panePIDArgs(id)...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("tmux runtime: inspect pane pid %s: %w", id, err)
 	}
@@ -627,7 +633,7 @@ func (r *Runtime) SendMessage(ctx context.Context, handle ports.RuntimeHandle, m
 		sendCtx := ctx
 		var finishCancel context.CancelFunc
 		for i, chunk := range messageChunks {
-			if _, err := r.runForSession(sendCtx, id, sendKeysLiteralArgs(id, chunk)...); err != nil {
+			if _, err := r.run(sendCtx, sendKeysLiteralArgs(id, chunk)...); err != nil {
 				if finishCancel != nil {
 					finishCancel()
 				}
@@ -663,7 +669,7 @@ func (r *Runtime) SendMessage(ctx context.Context, handle ports.RuntimeHandle, m
 			}
 		}
 	}
-	if _, err := r.runForSession(enterCtx, id, sendEnterArgs(id)...); err != nil {
+	if _, err := r.run(enterCtx, sendEnterArgs(id)...); err != nil {
 		return fmt.Errorf("tmux runtime: send enter %s: %w", id, err)
 	}
 	return nil
@@ -680,7 +686,7 @@ func (r *Runtime) Interrupt(ctx context.Context, handle ports.RuntimeHandle) err
 	if err != nil {
 		return err
 	}
-	if _, err := r.runForSession(ctx, id, sendInterruptArgs(id)...); err != nil {
+	if _, err := r.run(ctx, sendInterruptArgs(id)...); err != nil {
 		return fmt.Errorf("tmux runtime: interrupt session %s: %w", id, err)
 	}
 	return nil
@@ -694,7 +700,7 @@ func (r *Runtime) SendInput(ctx context.Context, handle ports.RuntimeHandle, inp
 		return err
 	}
 	args := sendKeysLiteralArgs(id, input)
-	if _, err := r.runForSession(ctx, id, args...); err != nil {
+	if _, err := r.run(ctx, args...); err != nil {
 		return fmt.Errorf("tmux runtime: send input %s: %w", id, err)
 	}
 	return nil
@@ -710,7 +716,7 @@ func (r *Runtime) GetOutput(ctx context.Context, handle ports.RuntimeHandle, lin
 	if lines <= 0 {
 		return "", errors.New("tmux runtime: lines must be positive")
 	}
-	out, err := r.runForSession(ctx, id, capturePaneArgs(id, lines)...)
+	out, err := r.run(ctx, capturePaneArgs(id, lines)...)
 	if err != nil {
 		return "", fmt.Errorf("tmux runtime: capture output %s: %w", id, err)
 	}
@@ -726,7 +732,7 @@ func (r *Runtime) GetStyledOutput(ctx context.Context, handle ports.RuntimeHandl
 	if lines <= 0 {
 		return "", errors.New("tmux runtime: lines must be positive")
 	}
-	out, err := r.runForSession(ctx, id, capturePaneStyledArgs(id, lines)...)
+	out, err := r.run(ctx, capturePaneStyledArgs(id, lines)...)
 	if err != nil {
 		return "", fmt.Errorf("tmux runtime: capture styled output %s: %w", id, err)
 	}
@@ -737,16 +743,11 @@ func (r *Runtime) GetStyledOutput(ctx context.Context, handle ports.RuntimeHandl
 // local PTY, sized rows x cols from birth when known. ctx cancellation closes
 // the PTY.
 func (r *Runtime) Attach(ctx context.Context, handle ports.RuntimeHandle, rows, cols uint16) (ports.Stream, error) {
-	id, err := handleID(handle)
+	argv, err := r.attachCommand(handle)
 	if err != nil {
 		return nil, err
 	}
-	socketName, err := r.socketForSession(ctx, id)
-	if err != nil {
-		return nil, fmt.Errorf("tmux runtime: attach session %s: %w", id, err)
-	}
-	argv := r.attachCommandForSocket(id, socketName)
-	return ptyexec.Spawn(ctx, argv, attachEnv(os.Environ()), rows, cols)
+	return ptyexec.Spawn(ctx, argv, controlEnv(os.Environ()), rows, cols)
 }
 
 // attachCommand returns the argv to attach a terminal to the session.
@@ -772,149 +773,85 @@ func (r *Runtime) attachCommand(handle ports.RuntimeHandle) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.attachCommandForSocket(id, r.socketName), nil
-}
-
-func (r *Runtime) attachCommandForSocket(id, socketName string) []string {
 	// The embedded xterm renderer supports 24-bit SGR colors. Tell this tmux
 	// client explicitly so tmux forwards RGB instead of quantizing it to the
 	// xterm-256color palette. -T is available in AO's minimum tmux version (3.2).
-	argv := []string{r.binaryForSocket(socketName)}
-	if socketName != "" {
-		argv = append(argv, "-L", socketName)
-	} else if r.socketName != "" {
-		// A legacy session means tmux's historical machine default, never the
-		// socket named by an inherited TMUX from an AO worker or nested shell.
-		argv = append(argv, "-L", "default")
+	args, err := r.managedArgs("-u", "-T", "RGB", "attach-session", "-t", id)
+	if err != nil {
+		return nil, err
 	}
-	return append(argv, "-u", "-T", "RGB", "attach-session", "-t", id)
+	return append([]string{r.binary}, args...), nil
 }
 
-func attachEnv(base []string) []string {
-	env := append([]string(nil), base...)
-	hasTerm := false
-	hasColorTerm := false
-	for i, kv := range env {
+// controlEnv returns the complete environment for tmux control and attach
+// clients. Workload-relevant values (PATH, HOME, credentials, locale, SSH agent
+// sockets, TERMINFO, TMUX_TMPDIR, and so on) are preserved because the tmux
+// server is also the parent of AO's pane workloads. The inherited identity of
+// a surrounding tmux client and AO's internal binary/socket selectors are
+// removed. TERM and COLORTERM describe AO's embedded xterm surface and are
+// forced exactly once.
+func controlEnv(base []string) []string {
+	env := make([]string, 0, len(base)+2)
+	for _, kv := range base {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
 		switch {
-		case strings.HasPrefix(kv, "TERM="):
-			env[i] = "TERM=xterm-256color"
-			hasTerm = true
-		case strings.HasPrefix(kv, "COLORTERM="):
-			env[i] = "COLORTERM=truecolor"
-			hasColorTerm = true
+		case isolatedTmuxEnvironmentKey(key), key == "TERM", key == "COLORTERM":
+			continue
+		default:
+			env = append(env, kv)
 		}
 	}
-	if !hasTerm {
-		env = append(env, "TERM=xterm-256color")
+	return append(env, "TERM=xterm-256color", "COLORTERM=truecolor")
+}
+
+// managedArgs pins every tmux client to AO's explicit socket and an empty
+// private config. A missing socket path fails closed: omitting -S would connect
+// to the user's default tmux server.
+func (r *Runtime) managedArgs(args ...string) ([]string, error) {
+	if strings.TrimSpace(r.socketPath) == "" {
+		return nil, errors.New("tmux runtime: private socket path is required")
 	}
-	if !hasColorTerm {
-		env = append(env, "COLORTERM=truecolor")
+	if !filepath.IsAbs(r.socketPath) {
+		return nil, errors.New("tmux runtime: private socket path must be absolute")
 	}
-	return env
+	if r.binaryResolveErr != nil {
+		return nil, r.binaryResolveErr
+	}
+	address, err := privateSocketAddress(r.socketPath)
+	if err != nil {
+		return nil, err
+	}
+	managed := make([]string, 0, 4+len(args))
+	managed = append(managed, "-S", address, "-f", os.DevNull)
+	return append(managed, args...), nil
 }
 
 // run wraps runner.Run with a per-call timeout context.
 func (r *Runtime) run(ctx context.Context, args ...string) ([]byte, error) {
-	return r.runOnSocket(ctx, r.socketName, args...)
+	return r.runWithInput(ctx, nil, args...)
 }
 
-func (r *Runtime) runOnSocket(ctx context.Context, socketName string, args ...string) ([]byte, error) {
-	if socketName != "" {
-		args = append([]string{"-L", socketName}, args...)
-	} else if r.socketName != "" {
-		// Pin legacy discovery and commands to the historical machine default.
-		// Without -L, tmux honors inherited TMUX and may target an unrelated
-		// nested server whose session name happens to collide with AO's handle.
-		args = append([]string{"-L", "default"}, args...)
-	}
-	return r.runCommand(ctx, r.binaryForSocket(socketName), args...)
-}
-
-func (r *Runtime) binaryForSocket(socketName string) string {
-	if socketName == "" && r.socketName != "" {
-		return r.legacyBinary
-	}
-	return r.binary
-}
-
-// runForSession routes sessions created before AO introduced its private tmux
-// socket back to tmux's legacy default socket. The decision is discovered once
-// per daemon lifetime and cached. New sessions always use socketName.
-func (r *Runtime) runForSession(ctx context.Context, id string, args ...string) ([]byte, error) {
-	socketName, err := r.socketForSession(ctx, id)
+// runWithInput is run with bytes connected to the tmux client's stdin. It is
+// used for source-file so environment values never appear in process argv.
+func (r *Runtime) runWithInput(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+	managed, err := r.managedArgs(args...)
 	if err != nil {
 		return nil, err
 	}
-	return r.runOnSocket(ctx, socketName, args...)
-}
-
-func (r *Runtime) socketForSession(ctx context.Context, id string) (string, error) {
-	if r.socketName == "" {
-		return "", nil
-	}
-	r.socketMu.RLock()
-	socketName, ok := r.sessionSockets[id]
-	r.socketMu.RUnlock()
-	if ok {
-		return socketName, nil
-	}
-
-	out, err := r.runOnSocket(ctx, r.socketName, hasSessionArgs(id)...)
-	if err == nil {
-		r.rememberSessionSocket(id, r.socketName)
-		return r.socketName, nil
-	}
-	// Only cross the migration boundary when the private server definitively
-	// lacks this session. An ambiguous probe stays on the private socket so a
-	// transient error cannot redirect a live session elsewhere.
-	if !sessionMissingOutput(string(out)) && !serverNotRunningOutput(string(out)) {
-		return r.socketName, nil
-	}
-	if r.legacyBinary == "" {
-		return "", fmt.Errorf(
-			"%w: cannot inspect legacy default-socket session %s because system tmux is unavailable",
-			ports.ErrRuntimeProbeInconclusive,
-			id,
-		)
-	}
-	legacyOut, legacyErr := r.runOnSocket(ctx, "", hasSessionArgs(id)...)
-	if legacyErr == nil {
-		r.rememberSessionSocket(id, "")
-		return "", nil
-	}
-	if ctx.Err() != nil {
-		return "", ctx.Err()
-	}
-	if sessionMissingOutput(string(legacyOut)) || serverNotRunningOutput(string(legacyOut)) {
-		// Both known sockets definitively lack the session. Return the private
-		// target so IsAlive's ordinary exact-session handling reports false.
-		return r.socketName, nil
-	}
-	return "", fmt.Errorf(
-		"%w: system tmux %q could not inspect legacy default-socket session %s: %w",
-		ports.ErrRuntimeProbeInconclusive,
-		r.legacyBinary,
-		id,
-		legacyErr,
-	)
-}
-
-func (r *Runtime) rememberSessionSocket(id, socketName string) {
-	r.socketMu.Lock()
-	r.sessionSockets[id] = socketName
-	r.socketMu.Unlock()
-}
-
-func (r *Runtime) forgetSessionSocket(id string) {
-	r.socketMu.Lock()
-	delete(r.sessionSockets, id)
-	r.socketMu.Unlock()
+	return r.runCommandWithInput(ctx, input, r.binary, managed...)
 }
 
 func (r *Runtime) runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return r.runCommandWithInput(ctx, nil, name, args...)
+}
+
+func (r *Runtime) runCommandWithInput(ctx context.Context, input []byte, name string, args ...string) ([]byte, error) {
 	cmdCtx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
-	out, err := r.runner.Run(cmdCtx, nil, name, args...)
+	out, err := r.runner.Run(cmdCtx, controlEnv(os.Environ()), input, name, args...)
 	if cmdCtx.Err() != nil {
 		return out, cmdCtx.Err()
 	}
@@ -1216,33 +1153,17 @@ func validEnvKey(key string) bool {
 	return true
 }
 
-func sortedKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// buildLaunchCommand builds the shell command string passed to `sh -c`. It
-// exports env vars, runs argv, then keeps the tmux session alive. Supervised
-// launches park on a non-interpreting stdin sink after exit so bytes racing a
-// process exit can never become shell commands; legacy/unsupervised launches
-// retain the interactive-shell fallback used by manual recovery.
-//
-// PATH from cfg.Env is exported last, after all other keys, so an explicit
-// override takes effect.
+// buildLaunchCommand builds the shell command string passed to `sh -c`. The
+// caller installs cfg.Env in tmux's session environment over stdin before this
+// command is launched, so no configured values are embedded in process argv.
+// Supervised launches park on a non-interpreting stdin sink after exit so bytes
+// racing a process exit can never become shell commands; legacy/unsupervised
+// launches retain the interactive-shell fallback used by manual recovery.
 func buildLaunchCommand(cfg ports.RuntimeConfig) string {
-	path := cfg.Env["PATH"]
-	if path == "" {
-		path = getenv("PATH")
-	}
-
 	var b strings.Builder
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(cfg.WorkspacePath))
@@ -1254,25 +1175,11 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 		// opt out of color explicitly through its configured environment.
 		b.WriteString("unset NO_COLOR; ")
 	}
-	for _, key := range sortedKeys(cfg.Env) {
-		if key == "PATH" || key == "COLORTERM" {
-			continue
-		}
-		b.WriteString("export ")
-		b.WriteString(key)
-		b.WriteString("=")
-		b.WriteString(shellQuote(cfg.Env[key]))
-		b.WriteString("; ")
-	}
 	// The AO web terminal and tmux attach client both support 24-bit SGR color.
-	// Export this after caller env so agent color detection cannot accidentally
-	// downgrade rich syntax/diff colors to ANSI-256.
+	// Keep this constant defense in the launch command as well as the session
+	// environment so agent color detection cannot accidentally downgrade rich
+	// syntax/diff colors to ANSI-256.
 	b.WriteString("export COLORTERM='truecolor'; ")
-	if path != "" {
-		b.WriteString("export PATH=")
-		b.WriteString(shellQuote(path))
-		b.WriteString("; ")
-	}
 	// Quote each argv word so spaces inside a word are preserved.
 	parts := make([]string, len(cfg.Argv))
 	for i, a := range cfg.Argv {

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -20,7 +21,10 @@ func TestRuntimeIntegration(t *testing.T) {
 
 	ctx := context.Background()
 	id := strings.ReplaceAll(t.Name(), "/", "_")
-	r := New(Options{Timeout: 5 * time.Second})
+	r := New(Options{
+		SocketPath: integrationSocketPath(t),
+		Timeout:    5 * time.Second,
+	})
 
 	// Ensure clean slate: ignore errors (session may not exist).
 	_ = r.Destroy(ctx, ports.RuntimeHandle{ID: id})
@@ -95,7 +99,10 @@ func TestRuntimeIntegrationExactSessionParsing(t *testing.T) {
 	longID := base + "_long"
 	prefixID := base
 
-	r := New(Options{Timeout: 5 * time.Second})
+	r := New(Options{
+		SocketPath: integrationSocketPath(t),
+		Timeout:    5 * time.Second,
+	})
 	_ = r.Destroy(ctx, ports.RuntimeHandle{ID: longID})
 	_ = r.Destroy(ctx, ports.RuntimeHandle{ID: prefixID})
 
@@ -128,75 +135,6 @@ func TestRuntimeIntegrationExactSessionParsing(t *testing.T) {
 	}
 }
 
-func TestRuntimeIntegrationLegacyDefaultSocketIgnoresInheritedTMUX(t *testing.T) {
-	systemTmux, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux unavailable")
-	}
-
-	// tmux's Unix socket path has a small platform limit; Go's ordinary test
-	// temp root is long enough to exceed it on macOS.
-	tmuxTmpDir, err := os.MkdirTemp("/tmp", "ao-tmux-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(tmuxTmpDir) })
-	t.Setenv("TMUX_TMPDIR", tmuxTmpDir)
-	legacyID := strings.ReplaceAll(t.Name(), "/", "_") + "_legacy"
-	spoofID := strings.ReplaceAll(t.Name(), "/", "_") + "_spoof"
-	privateID := strings.ReplaceAll(t.Name(), "/", "_") + "_private"
-	for _, socketName := range []string{"default", "spoof", "ao"} {
-		t.Cleanup(func() {
-			_ = exec.Command(systemTmux, "-L", socketName, "kill-server").Run()
-		})
-	}
-	start := func(socketName, sessionID string) {
-		t.Helper()
-		if out, startErr := exec.Command(
-			systemTmux,
-			"-L", socketName,
-			"new-session", "-d", "-s", sessionID,
-			"sleep 30",
-		).CombinedOutput(); startErr != nil {
-			t.Fatalf("start tmux -L %s: %v: %s", socketName, startErr, out)
-		}
-	}
-	start("default", legacyID)
-	start("spoof", spoofID)
-	start("ao", privateID)
-
-	spoofIdentity, err := exec.Command(
-		systemTmux,
-		"-L", "spoof",
-		"display-message", "-p", "#{socket_path},#{pid},0",
-	).Output()
-	if err != nil {
-		t.Fatalf("read spoof socket identity: %v", err)
-	}
-	t.Setenv("TMUX", strings.TrimSpace(string(spoofIdentity)))
-	if out, err := exec.Command(systemTmux, "has-session", "-t", spoofID).CombinedOutput(); err != nil {
-		t.Fatalf("test setup did not redirect plain tmux through inherited TMUX: %v: %s", err, out)
-	}
-
-	r := New(Options{
-		Binary:       systemTmux,
-		LegacyBinary: systemTmux,
-		SocketName:   "ao",
-		Timeout:      5 * time.Second,
-	})
-	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: legacyID})
-	if err != nil || !alive {
-		t.Fatalf("legacy default-socket session = (%v, %v), want (true, nil)", alive, err)
-	}
-	alive, err = r.IsAlive(context.Background(), ports.RuntimeHandle{ID: spoofID})
-	if err != nil {
-		t.Fatalf("spoof-only session probe: %v", err)
-	}
-	if alive {
-		t.Fatal("spoof-only session was misclassified as AO's legacy session")
-	}
-}
-
 func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux unavailable")
@@ -205,7 +143,10 @@ func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 	ctx := context.Background()
 	id := strings.ReplaceAll(t.Name(), "/", "_")
 	const launchID = "launch-1"
-	r := New(Options{Timeout: 5 * time.Second})
+	r := New(Options{
+		SocketPath: integrationSocketPath(t),
+		Timeout:    5 * time.Second,
+	})
 	tmuxID := SessionName(id)
 	workspace := t.TempDir()
 	_ = r.Destroy(ctx, ports.RuntimeHandle{ID: tmuxID})
@@ -224,7 +165,7 @@ func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 		t.Fatal(err)
 	}
 	ref := ports.SupervisedProcessRef{SessionID: domain.SessionID(id), LaunchID: launchID}
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for {
 		alive, probeErr := r.IsSupervisedProcessAlive(ctx, h, ref)
 		if probeErr != nil {
@@ -241,7 +182,7 @@ func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 
 	// The helper exits normally, matching Codex /exit or EOF. The launch shell
 	// must then execute AO's keep-alive interactive shell.
-	deadline = time.Now().Add(5 * time.Second)
+	deadline = time.Now().Add(10 * time.Second)
 	for {
 		alive, probeErr := r.IsSupervisedProcessAlive(ctx, h, ref)
 		if probeErr != nil {
@@ -290,11 +231,172 @@ func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 	}
 }
 
+func TestRuntimeIntegrationRefreshesEnvironmentOnPersistentServer(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+
+	const envKey = "AO_TMUX_ENV_REFRESH_TEST"
+	t.Setenv(envKey, "old")
+	ctx := context.Background()
+	socketPath := integrationSocketPath(t)
+	r := New(Options{SocketPath: socketPath, Timeout: 5 * time.Second})
+	base := strings.ReplaceAll(t.Name(), "/", "_")
+	oldHandle, err := r.Create(ctx, ports.RuntimeConfig{
+		SessionID:     domain.SessionID(base + "_old"),
+		WorkspacePath: t.TempDir(),
+		Argv:          []string{"/bin/sh", "-c", "sleep 10"},
+	})
+	if err != nil {
+		t.Fatalf("create old-environment session: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Destroy(context.Background(), oldHandle) })
+
+	// Model an app/daemon restart while the private tmux server survives. A new
+	// Runtime object uses the same socket, but the next pane must receive the
+	// current daemon environment rather than the server's startup snapshot.
+	t.Setenv(envKey, "new")
+	restarted := New(Options{SocketPath: socketPath, Timeout: 5 * time.Second})
+	newHandle, err := restarted.Create(ctx, ports.RuntimeConfig{
+		SessionID:     domain.SessionID(base + "_new"),
+		WorkspacePath: t.TempDir(),
+		Argv:          []string{"/bin/sh", "-c", `printf 'env=%s\n' "$` + envKey + `"; sleep 10`},
+	})
+	if err != nil {
+		t.Fatalf("create refreshed-environment session: %v", err)
+	}
+	t.Cleanup(func() { _ = restarted.Destroy(context.Background(), newHandle) })
+
+	out := waitForOutput(t, restarted, newHandle, "env=new", 5*time.Second)
+	if strings.Contains(out, "env=old") {
+		t.Fatalf("new session inherited stale server environment: %q", out)
+	}
+
+	// Unsetting a variable must remove the value from tmux rather than merely
+	// omitting an update and allowing the persistent server's old value through.
+	if err := os.Unsetenv(envKey); err != nil {
+		t.Fatal(err)
+	}
+	withoutValue := New(Options{SocketPath: socketPath, Timeout: 5 * time.Second})
+	unsetHandle, err := withoutValue.Create(ctx, ports.RuntimeConfig{
+		SessionID:     domain.SessionID(base + "_unset"),
+		WorkspacePath: t.TempDir(),
+		Argv:          []string{"/bin/sh", "-c", `printf 'env=%s\n' "${` + envKey + `-unset}"; sleep 10`},
+	})
+	if err != nil {
+		t.Fatalf("create unset-environment session: %v", err)
+	}
+	t.Cleanup(func() { _ = withoutValue.Destroy(context.Background(), unsetHandle) })
+	out = waitForOutput(t, withoutValue, unsetHandle, "env=unset", 5*time.Second)
+	if strings.Contains(out, "env=old") || strings.Contains(out, "env=new") {
+		t.Fatalf("unset variable retained a stale server value: %q", out)
+	}
+
+	// Restart must inspect the target session as well as the daemon environment.
+	// A session-only value cannot be discovered by looking at the server's global
+	// environment, and would otherwise survive respawn-pane.
+	const sessionOnlyKey = "AO_TMUX_SESSION_ONLY_STALE_TEST"
+	if err := os.Unsetenv(sessionOnlyKey); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := withoutValue.run(ctx, "set-environment", "-t", exactSessionTarget(newHandle.ID), sessionOnlyKey, "stale"); err != nil {
+		t.Fatalf("seed session-only stale variable: %v", err)
+	}
+	if _, err := withoutValue.Restart(ctx, newHandle, ports.RuntimeConfig{
+		SessionID:     domain.SessionID(base + "_new"),
+		WorkspacePath: t.TempDir(),
+		Argv:          []string{"/bin/sh", "-c", `printf 'session=%s\n' "${` + sessionOnlyKey + `-unset}"; sleep 10`},
+	}); err != nil {
+		t.Fatalf("restart after session-only variable removal: %v", err)
+	}
+	out = waitForOutput(t, withoutValue, newHandle, "session=unset", 5*time.Second)
+	if strings.Contains(out, "session=stale") {
+		t.Fatalf("restart retained a session-only stale value: %q", out)
+	}
+}
+
+func TestRuntimeIntegrationKeepsConfiguredEnvironmentOutOfPaneArgv(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+
+	const (
+		envKey = "AO_TMUX_CONFIGURED_SECRET_TEST"
+		secret = "configured-secret-must-not-appear-in-argv"
+	)
+	r := New(Options{SocketPath: integrationSocketPath(t), Timeout: 5 * time.Second})
+	handle, err := r.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     domain.SessionID(strings.ReplaceAll(t.Name(), "/", "_")),
+		WorkspacePath: t.TempDir(),
+		Argv:          []string{"/bin/sh", "-c", `printf 'configured=%s\n' "$` + envKey + `"; sleep 10`},
+		Env:           map[string]string{envKey: secret},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = r.Destroy(context.Background(), handle) })
+	waitForOutput(t, r, handle, "configured="+secret, 5*time.Second)
+
+	panePID, err := r.run(context.Background(), panePIDArgs(handle.ID)...)
+	if err != nil {
+		t.Fatalf("inspect pane pid: %v", err)
+	}
+	argv, err := exec.Command("ps", "-ww", "-p", strings.TrimSpace(string(panePID)), "-o", "command=").Output()
+	if err != nil {
+		t.Fatalf("inspect pane argv: %v", err)
+	}
+	if strings.Contains(string(argv), secret) {
+		t.Fatalf("configured environment value leaked into pane argv: %q", argv)
+	}
+}
+
+func TestRuntimeIntegrationUsesAliasForLongPrivateSocket(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+
+	targetDir := filepath.Join(t.TempDir(), strings.Repeat("deep-runtime-directory-", 6))
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	socketPath := filepath.Join(targetDir, "tmux-0123456789abcdef0123456789abcdef.sock")
+	address, err := privateSocketAddress(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if address == socketPath {
+		t.Fatalf("precondition: long socket path was not aliased: %q", socketPath)
+	}
+	t.Cleanup(func() { _ = os.Remove(filepath.Dir(address)) })
+
+	r := New(Options{SocketPath: socketPath, Timeout: 5 * time.Second})
+	handle, err := r.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     domain.SessionID(strings.ReplaceAll(t.Name(), "/", "_")),
+		WorkspacePath: t.TempDir(),
+		Argv:          []string{"/bin/sh", "-c", "printf 'alias-ok\\n'; sleep 10"},
+	})
+	if err != nil {
+		t.Fatalf("create through long private socket: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Destroy(context.Background(), handle) })
+	waitForOutput(t, r, handle, "alias-ok", 5*time.Second)
+}
+
 func TestSupervisorProcessHelper(t *testing.T) {
 	if os.Getenv("AO_TMUX_SUPERVISOR_HELPER") != "1" {
 		return
 	}
 	time.Sleep(2 * time.Second)
+}
+
+func integrationSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ao-tmux-")
+	if err != nil {
+		t.Fatalf("create private tmux socket directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
 }
 
 // waitForOutput polls GetOutput until out contains want or the deadline passes.

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -26,13 +26,19 @@ type fakeRunner struct {
 }
 
 type runnerCall struct {
-	env  []string
-	name string
-	args []string
+	env   []string
+	stdin []byte
+	name  string
+	args  []string
 }
 
-func (f *fakeRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
-	f.calls = append(f.calls, runnerCall{env: append([]string(nil), env...), name: name, args: append([]string(nil), args...)})
+func (f *fakeRunner) Run(ctx context.Context, env []string, stdin []byte, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, runnerCall{
+		env:   append([]string(nil), env...),
+		stdin: append([]byte(nil), stdin...),
+		name:  name,
+		args:  append([]string(nil), args...),
+	})
 	var out []byte
 	if len(f.outputs) > 0 {
 		out = f.outputs[0]
@@ -66,22 +72,57 @@ func (rr *recordingReaper) reap(_ context.Context, pids []int, grace time.Durati
 
 // -- helpers --
 
+var testSocketPath = filepath.Join(os.TempDir(), "ao-tmux-unit-"+strconv.Itoa(os.Getpid()), "s")
+
+func TestMain(m *testing.M) {
+	testSocketDir := filepath.Dir(testSocketPath)
+	if err := os.MkdirAll(testSocketDir, 0o700); err != nil {
+		panic(err)
+	}
+	resolvedTestSocketDir, err := filepath.EvalSymlinks(testSocketDir)
+	if err != nil {
+		panic(err)
+	}
+	testSocketPath = filepath.Join(resolvedTestSocketDir, filepath.Base(testSocketPath))
+	code := m.Run()
+	_ = os.RemoveAll(testSocketDir)
+	os.Exit(code)
+}
+
 func newTestRuntime(chunkSize int) (*Runtime, *fakeRunner) {
 	fr := &fakeRunner{}
-	r := New(Options{Binary: "tmux-test", Timeout: time.Second, Shell: "/bin/sh", ChunkSize: chunkSize})
+	r := New(Options{
+		Binary:     "tmux-test",
+		SocketPath: testSocketPath,
+		Timeout:    time.Second,
+		Shell:      "/bin/sh",
+		ChunkSize:  chunkSize,
+	})
 	r.runner = fr
 	r.enterDelay = 0                           // tests must not pay the real 300ms pre-Enter pause
 	r.reapSessions = (&recordingReaper{}).reap // never signal real processes from unit tests
+	r.syncEnvironment = func(context.Context, string, map[string]string) error { return nil }
 	return r, fr
 }
 
+// logicalTmuxArgs removes AO's invariant global tmux flags so behavioral tests
+// can continue to assert the subcommand interface without brittle positional
+// coupling. Dedicated isolation tests below assert the raw -S/-f prefix.
+func logicalTmuxArgs(args []string) []string {
+	if len(args) >= 4 && args[0] == "-S" && args[2] == "-f" {
+		return args[4:]
+	}
+	return args
+}
+
 // countCalls returns how many of fr's recorded calls invoked the given tmux
-// subcommand (args[0]), e.g. "display-message" for pane cwd verification
+// subcommand, e.g. "display-message" for pane cwd verification
 // probes.
 func countCalls(fr *fakeRunner, subcommand string) int {
 	n := 0
 	for _, c := range fr.calls {
-		if len(c.args) > 0 && c.args[0] == subcommand {
+		args := logicalTmuxArgs(c.args)
+		if len(args) > 0 && args[0] == subcommand {
 			n++
 		}
 	}
@@ -122,55 +163,57 @@ func TestNewExplicitBinaryOverridesBundledTmuxEnv(t *testing.T) {
 	}
 }
 
-func TestNewUsesAppOwnedTmuxSocketFromEnv(t *testing.T) {
-	t.Setenv("AO_TMUX_SOCKET_NAME", "ao")
-	r := New(Options{Binary: "tmux-test"})
+func TestRunUsesExplicitPrivateSocketAndEmptyConfig(t *testing.T) {
+	r := New(Options{Binary: "tmux-test", SocketPath: testSocketPath})
 	fr := &fakeRunner{}
 	r.runner = fr
 
 	if _, err := r.run(context.Background(), "list-sessions"); err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if got, want := fr.calls[0].args, []string{"-L", "ao", "list-sessions"}; !reflect.DeepEqual(got, want) {
+	if got, want := fr.calls[0].args, []string{"-S", testSocketPath, "-f", os.DevNull, "list-sessions"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)
 	}
 }
 
-func TestNewUsesSystemTmuxForLegacyDefaultSocket(t *testing.T) {
-	binDir := t.TempDir()
-	systemTmux := filepath.Join(binDir, "tmux")
-	if err := os.WriteFile(systemTmux, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	bundledTmux := filepath.Join(t.TempDir(), "bundled-tmux")
-	if err := os.WriteFile(bundledTmux, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir)
-	t.Setenv("AO_TMUX_BINARY", bundledTmux)
-	t.Setenv("AO_TMUX_SOCKET_NAME", "ao")
+func TestRunFailsClosedWithoutPrivateSocket(t *testing.T) {
+	r := New(Options{Binary: "tmux-test"})
+	fr := &fakeRunner{}
+	r.runner = fr
 
-	r := New(Options{})
-	if got := r.binary; got != bundledTmux {
-		t.Fatalf("binary = %q, want bundled tmux %q", got, bundledTmux)
+	if _, err := r.run(context.Background(), "list-sessions"); err == nil || !strings.Contains(err.Error(), "private socket path is required") {
+		t.Fatalf("run error = %v, want missing private socket", err)
 	}
-	if got := r.legacyBinary; got != systemTmux {
-		t.Fatalf("legacy binary = %q, want system tmux %q", got, systemTmux)
+	if len(fr.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", fr.calls)
 	}
 }
 
-func TestNewLeavesLegacyTmuxUnavailableWithoutSystemTmux(t *testing.T) {
-	bundledTmux := filepath.Join(t.TempDir(), "bundled-tmux")
-	if err := os.WriteFile(bundledTmux, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", t.TempDir())
-	t.Setenv("AO_TMUX_BINARY", bundledTmux)
-	t.Setenv("AO_TMUX_SOCKET_NAME", "ao")
+func TestRunFailsClosedWithRelativePrivateSocket(t *testing.T) {
+	r := New(Options{Binary: "tmux-test", SocketPath: "relative.sock"})
+	fr := &fakeRunner{}
+	r.runner = fr
 
-	r := New(Options{})
-	if got := r.legacyBinary; got != "" {
-		t.Fatalf("legacy binary = %q, want unavailable", got)
+	if _, err := r.run(context.Background(), "list-sessions"); err == nil || !strings.Contains(err.Error(), "private socket path must be absolute") {
+		t.Fatalf("run error = %v, want relative private socket rejection", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", fr.calls)
+	}
+}
+
+func TestRunFailsClosedWhenConfiguredTmuxCannotBeResolved(t *testing.T) {
+	configured := filepath.Join(t.TempDir(), "missing-tmux")
+	t.Setenv("AO_TMUX_BINARY", configured)
+	r := New(Options{SocketPath: testSocketPath})
+	fr := &fakeRunner{}
+	r.runner = fr
+
+	if _, err := r.run(context.Background(), "list-sessions"); err == nil || !strings.Contains(err.Error(), "resolve tmux binary") {
+		t.Fatalf("run error = %v, want binary resolution failure", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Fatalf("runner calls = %#v, want none", fr.calls)
 	}
 }
 
@@ -184,7 +227,7 @@ func TestNewLeavesLegacyTmuxUnavailableWithoutSystemTmux(t *testing.T) {
 // execRunner (not the fakeRunner test seam every other test in this file
 // uses), so it is the only test that would catch a regression here.
 func TestExecRunnerRunsFromStableDir(t *testing.T) {
-	out, err := (execRunner{}).Run(context.Background(), nil, "sh", "-c", "pwd")
+	out, err := (execRunner{}).Run(context.Background(), nil, nil, "sh", "-c", "pwd")
 	if err != nil {
 		t.Fatalf("execRunner.Run: %v", err)
 	}
@@ -207,6 +250,22 @@ func TestExecRunnerRunsFromStableDir(t *testing.T) {
 	}
 }
 
+func TestExecRunnerTreatsProvidedEnvironmentAsComplete(t *testing.T) {
+	t.Setenv("AO_EXEC_RUNNER_AMBIENT", "must-not-leak")
+	out, err := (execRunner{}).Run(
+		context.Background(),
+		[]string{"AO_EXEC_RUNNER_EXPLICIT=present"},
+		nil,
+		"/bin/sh", "-c", `printf '%s|%s' "$AO_EXEC_RUNNER_EXPLICIT" "$AO_EXEC_RUNNER_AMBIENT"`,
+	)
+	if err != nil {
+		t.Fatalf("execRunner.Run: %v", err)
+	}
+	if got, want := string(out), "present|"; got != want {
+		t.Fatalf("execRunner environment = %q, want %q", got, want)
+	}
+}
+
 // TestExecRunnerFallsBackWhenTempDirMissing pins the guard on Fix 1's pin.
 // os.TempDir() returns $TMPDIR without checking it exists, so a stale or bogus
 // TMPDIR would otherwise set cmd.Dir to a dead path and fail EVERY tmux command
@@ -218,7 +277,7 @@ func TestExecRunnerFallsBackWhenTempDirMissing(t *testing.T) {
 		t.Fatalf("precondition: os.TempDir() %q should not exist, stat err = %v", os.TempDir(), err)
 	}
 
-	out, err := (execRunner{}).Run(context.Background(), nil, "sh", "-c", "pwd")
+	out, err := (execRunner{}).Run(context.Background(), nil, nil, "sh", "-c", "pwd")
 	if err != nil {
 		t.Fatalf("execRunner.Run with a missing TMPDIR: %v", err)
 	}
@@ -340,10 +399,10 @@ func TestCreateRejectsInvalidEnvKeys(t *testing.T) {
 // -- Create tests --
 
 func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
-	// new-session, display-message cwd verification, set-option status,
-	// set-option mouse, set-option window-size, has-session (exit 0 = alive)
+	// bootstrap new-session, respawn the real command, display-message cwd
+	// verification, set-option status/mouse/window-size, and has-session.
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
+	fr.outputs = [][]byte{nil, nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
 
 	h, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -357,14 +416,12 @@ func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	if h.ID != "sess-1" {
 		t.Fatalf("handle ID = %q, want sess-1", h.ID)
 	}
-	// Expect 6 calls: new-session, display-message cwd verification,
-	// set-option status, set-option mouse, set-option window-size, has-session.
-	if len(fr.calls) != 6 {
-		t.Fatalf("calls = %d, want 6", len(fr.calls))
+	if len(fr.calls) != 7 {
+		t.Fatalf("calls = %d, want 7", len(fr.calls))
 	}
 
 	// Call 0: new-session
-	if got := fr.calls[0].args[0]; got != "new-session" {
+	if got := logicalTmuxArgs(fr.calls[0].args)[0]; got != "new-session" {
 		t.Fatalf("call[0] = %q, want new-session", got)
 	}
 	// Check -s <id>, -c <cwd> are present.
@@ -379,37 +436,45 @@ func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	if !strings.Contains(joined, "-x 220") || !strings.Contains(joined, "-y 50") {
 		t.Fatalf("new-session args missing -x/-y: %v", fr.calls[0].args)
 	}
+	if !strings.Contains(joined, "exec cat >/dev/null") {
+		t.Fatalf("new-session did not use the environment-safe bootstrap pane: %v", fr.calls[0].args)
+	}
 
-	// Call 1: verify pane cwd.
-	if got, want := fr.calls[1].args, paneCurrentPathArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 1: respawn the real workload after its session environment is ready.
+	if got := logicalTmuxArgs(fr.calls[1].args)[0]; got != "respawn-pane" {
+		t.Fatalf("call[1] = %q, want respawn-pane", got)
+	}
+
+	// Call 2: verify pane cwd.
+	if got, want := logicalTmuxArgs(fr.calls[2].args), paneCurrentPathArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[1] = %#v, want %#v", got, want)
 	}
 
-	// Call 2: set-option status off (plain target, pane-targeting does not use =).
-	if got, want := fr.calls[2].args, setStatusOffArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 3: set-option status off (plain target, pane-targeting does not use =).
+	if got, want := logicalTmuxArgs(fr.calls[3].args), setStatusOffArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[2] = %#v, want %#v", got, want)
 	}
 
-	// Call 3: set-option mouse on (enables wheel-scroll of the pane).
-	if got, want := fr.calls[3].args, setMouseOnArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 4: set-option mouse on (enables wheel-scroll of the pane).
+	if got, want := logicalTmuxArgs(fr.calls[4].args), setMouseOnArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[3] = %#v, want %#v", got, want)
 	}
 
-	// Call 4: set-option window-size largest (multi-client sizing, see
+	// Call 5: set-option window-size largest (multi-client sizing, see
 	// setWindowSizeLargestArgs).
-	if got, want := fr.calls[4].args, setWindowSizeLargestArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[5].args), setWindowSizeLargestArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[4] = %#v, want %#v", got, want)
 	}
 
-	// Call 5: has-session (IsAlive, uses exact-match target =sess-1).
-	if got, want := fr.calls[5].args, hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 6: has-session (IsAlive, uses exact-match target =sess-1).
+	if got, want := logicalTmuxArgs(fr.calls[6].args), hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[5] = %#v, want %#v", got, want)
 	}
 }
 
 func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
+	fr.outputs = [][]byte{nil, nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
 
 	_, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -419,8 +484,9 @@ func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	// The launch command is the last argument to new-session (after shellPath -c).
-	args := fr.calls[0].args
+	// The launch command is the last argument to respawn-pane; new-session runs
+	// only the value-free bootstrap command.
+	args := fr.calls[1].args
 	launchCmd := args[len(args)-1]
 	if !strings.Contains(launchCmd, `exec "${SHELL:-/bin/sh}" -i`) {
 		t.Fatalf("launch command missing keep-alive shell: %q", launchCmd)
@@ -433,18 +499,10 @@ func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	}
 }
 
-func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
-	oldGetenv := getenv
-	getenv = func(key string) string {
-		if key == "PATH" {
-			return "/usr/bin:/bin"
-		}
-		return ""
-	}
-	defer func() { getenv = oldGetenv }()
-
+func TestCreateLaunchCommandKeepsConfiguredValuesOutOfArgv(t *testing.T) {
+	const secret = "configured-project-token"
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
+	fr.outputs = [][]byte{nil, nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
 
 	_, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -453,25 +511,22 @@ func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
 		Env: map[string]string{
 			"AO_SESSION_ID": "sess-1",
 			"COLORTERM":     "ansi",
-			"ODD":           "can't",
+			"PROJECT_TOKEN": secret,
 			"PATH":          "/custom/bin:/usr/bin",
 		},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	args := fr.calls[0].args
-	launchCmd := args[len(args)-1]
-	for _, want := range []string{
-		"unset NO_COLOR;",
-		"export AO_SESSION_ID='sess-1';",
-		"export COLORTERM='truecolor';",
-		"export ODD='can'\\''t';",
-		"export PATH='/custom/bin:/usr/bin';",
-	} {
-		if !strings.Contains(launchCmd, want) {
-			t.Fatalf("launch command missing %q in: %q", want, launchCmd)
+	for _, call := range fr.calls {
+		if strings.Contains(strings.Join(call.args, "\x00"), secret) {
+			t.Fatalf("configured secret leaked into process argv: %#v", call.args)
 		}
+	}
+	launchArgs := fr.calls[1].args
+	launchCmd := launchArgs[len(launchArgs)-1]
+	if !strings.Contains(launchCmd, "unset NO_COLOR;") || !strings.Contains(launchCmd, "export COLORTERM='truecolor';") {
+		t.Fatalf("launch command lost constant terminal policy: %q", launchCmd)
 	}
 }
 
@@ -482,9 +537,6 @@ func TestBuildLaunchCommandPreservesExplicitNoColor(t *testing.T) {
 		Env:           map[string]string{"NO_COLOR": "1"},
 	})
 
-	if !strings.Contains(launchCmd, "export NO_COLOR='1';") {
-		t.Fatalf("launch command does not preserve configured NO_COLOR: %q", launchCmd)
-	}
 	if strings.Contains(launchCmd, "unset NO_COLOR;") {
 		t.Fatalf("launch command unsets configured NO_COLOR: %q", launchCmd)
 	}
@@ -495,10 +547,10 @@ func TestBuildLaunchCommandPreservesExplicitNoColor(t *testing.T) {
 
 func TestCreateDestroysAndReturnsErrorWhenPaneCWDDoesNotMatch(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	// new-session, then a stale pane cwd on every one of the paneCwdVerifyAttempts
-	// retries: the pane never settles on the workspace, so Create must exhaust
-	// all attempts and fail with the typed mismatch error.
-	fr.outputs = [][]byte{nil}
+	// new-session and respawn, then a stale pane cwd on every one of the
+	// paneCwdVerifyAttempts retries: the pane never settles on the workspace, so
+	// Create must exhaust all attempts and fail with the typed mismatch error.
+	fr.outputs = [][]byte{nil, nil}
 	for i := 0; i < paneCwdVerifyAttempts; i++ {
 		fr.outputs = append(fr.outputs, []byte("/deleted/shipit\n"))
 	}
@@ -555,8 +607,8 @@ func TestVerifyPaneWorkingDirectoryKeepsMismatchErrorAfterLaterProbeFailure(t *t
 // sample if a later sample matches.
 func TestVerifyPaneWorkingDirectoryRetriesUntilMatch(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	// new-session, then a stale sample, then a matching sample.
-	fr.outputs = [][]byte{nil, []byte("/deleted/shipit\n"), []byte("/tmp/ws\n"), nil, nil, nil}
+	// new-session and respawn, then a stale sample, then a matching sample.
+	fr.outputs = [][]byte{nil, nil, []byte("/deleted/shipit\n"), []byte("/tmp/ws\n"), nil, nil, nil}
 
 	h, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -623,7 +675,8 @@ func TestCreateDestroysAndReturnsErrorWhenNotAlive(t *testing.T) {
 	}
 	sawHasSession := false
 	for _, c := range fr3.calls {
-		if len(c.args) > 0 && c.args[0] == "has-session" {
+		args := logicalTmuxArgs(c.args)
+		if len(args) > 0 && args[0] == "has-session" {
 			sawHasSession = true
 		}
 	}
@@ -633,7 +686,8 @@ func TestCreateDestroysAndReturnsErrorWhenNotAlive(t *testing.T) {
 	// Verify Destroy was called (kill-session).
 	hasKill := false
 	for _, c := range fr3.calls {
-		if len(c.args) > 0 && c.args[0] == "kill-session" {
+		args := logicalTmuxArgs(c.args)
+		if len(args) > 0 && args[0] == "kill-session" {
 			hasKill = true
 		}
 	}
@@ -653,12 +707,13 @@ type fakeRunnerSelectiveErr struct {
 	errOutput []byte
 }
 
-func (f *fakeRunnerSelectiveErr) Run(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
-	f.calls = append(f.calls, runnerCall{env: append([]string(nil), env...), name: name, args: append([]string(nil), args...)})
-	if len(args) > 0 && args[0] == f.exitErrOn {
+func (f *fakeRunnerSelectiveErr) Run(_ context.Context, env []string, stdin []byte, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, runnerCall{env: append([]string(nil), env...), stdin: append([]byte(nil), stdin...), name: name, args: append([]string(nil), args...)})
+	logical := logicalTmuxArgs(args)
+	if len(logical) > 0 && logical[0] == f.exitErrOn {
 		return f.errOutput, &exec.ExitError{}
 	}
-	if len(args) > 0 && args[0] == "display-message" {
+	if len(logical) > 0 && logical[0] == "display-message" {
 		return []byte("/tmp/ws\n"), nil
 	}
 	return nil, nil
@@ -680,8 +735,8 @@ type fakeRunnerSequence struct {
 	results []fakeRunnerResult
 }
 
-func (f *fakeRunnerSequence) Run(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
-	f.calls = append(f.calls, runnerCall{env: append([]string(nil), env...), name: name, args: append([]string(nil), args...)})
+func (f *fakeRunnerSequence) Run(_ context.Context, env []string, stdin []byte, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, runnerCall{env: append([]string(nil), env...), stdin: append([]byte(nil), stdin...), name: name, args: append([]string(nil), args...)})
 	idx := len(f.calls) - 1
 	if idx >= len(f.results) {
 		idx = len(f.results) - 1
@@ -710,10 +765,10 @@ func TestRestartRespawnsExistingPaneAndPreservesHandle(t *testing.T) {
 	if len(fr.calls) != 2 {
 		t.Fatalf("calls = %d, want respawn + liveness probe", len(fr.calls))
 	}
-	if args := fr.calls[0].args; len(args) < 6 || args[0] != "respawn-pane" || args[1] != "-k" || args[3] != "sess-1:0.0" || args[5] != "/tmp/ws" {
+	if args := logicalTmuxArgs(fr.calls[0].args); len(args) < 6 || args[0] != "respawn-pane" || args[1] != "-k" || args[3] != "sess-1:0.0" || args[5] != "/tmp/ws" {
 		t.Fatalf("respawn args = %#v", args)
 	}
-	if args := fr.calls[1].args; !reflect.DeepEqual(args, hasSessionArgs("sess-1")) {
+	if args := logicalTmuxArgs(fr.calls[1].args); !reflect.DeepEqual(args, hasSessionArgs("sess-1")) {
 		t.Fatalf("liveness args = %#v, want %#v", args, hasSessionArgs("sess-1"))
 	}
 }
@@ -733,123 +788,24 @@ func TestRestartRejectsMismatchedSessionHandle(t *testing.T) {
 	}
 }
 
-func TestIsAliveAdoptsSessionFromLegacyDefaultSocket(t *testing.T) {
-	r := New(Options{
-		Binary:       "bundled-tmux-test",
-		LegacyBinary: "system-tmux-test",
-		SocketName:   "ao",
-		Timeout:      time.Second,
-	})
-	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
-		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
-		{}, // legacy default-socket discovery
-		{}, // first has-session call after discovery
-		{}, // cached second has-session call
-	}}
+func TestIsAliveNeverProbesDefaultSocket(t *testing.T) {
+	r := New(Options{Binary: "tmux-test", SocketPath: testSocketPath, Timeout: time.Second})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{{
+		out: []byte("can't find session: sess-1"), err: &exec.ExitError{},
+	}}}
 	r.runner = fr
 	handle := ports.RuntimeHandle{ID: "sess-1"}
 
-	for i := 0; i < 2; i++ {
-		alive, err := r.IsAlive(context.Background(), handle)
-		if err != nil || !alive {
-			t.Fatalf("IsAlive call %d = (%v, %v), want (true, nil)", i+1, alive, err)
-		}
-	}
-	want := [][]string{
-		append([]string{"-L", "ao"}, hasSessionArgs("sess-1")...),
-		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
-		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
-		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
-	}
-	wantBinaries := []string{
-		"bundled-tmux-test",
-		"system-tmux-test",
-		"system-tmux-test",
-		"system-tmux-test",
-	}
-	if len(fr.calls) != len(want) {
-		t.Fatalf("calls = %d, want %d: %+v", len(fr.calls), len(want), fr.calls)
-	}
-	for i := range want {
-		if fr.calls[i].name != wantBinaries[i] {
-			t.Fatalf("call %d binary = %q, want %q", i, fr.calls[i].name, wantBinaries[i])
-		}
-		if !reflect.DeepEqual(fr.calls[i].args, want[i]) {
-			t.Fatalf("call %d args = %#v, want %#v", i, fr.calls[i].args, want[i])
-		}
-	}
-}
-
-func TestIsAliveReportsMissingLegacyClientAsProbeInconclusive(t *testing.T) {
-	r := New(Options{Binary: "bundled-tmux-test", SocketName: "ao", Timeout: time.Second})
-	r.legacyBinary = ""
-	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
-		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
-	}}
-	r.runner = fr
-
-	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
-	}
-	if alive {
-		t.Fatal("alive = true, want false with inconclusive error")
+	alive, err := r.IsAlive(context.Background(), handle)
+	if err != nil || alive {
+		t.Fatalf("IsAlive = (%v, %v), want (false, nil)", alive, err)
 	}
 	if len(fr.calls) != 1 {
-		t.Fatalf("calls = %d, want only the private-socket probe", len(fr.calls))
+		t.Fatalf("calls = %d, want one private-socket probe: %+v", len(fr.calls), fr.calls)
 	}
-}
-
-func TestIsAliveReportsIncompatibleLegacyClientAsProbeInconclusive(t *testing.T) {
-	r := New(Options{
-		Binary:       "bundled-tmux-test",
-		LegacyBinary: "system-tmux-test",
-		SocketName:   "ao",
-		Timeout:      time.Second,
-	})
-	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
-		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
-		{out: []byte("server exited unexpectedly"), err: &exec.ExitError{}},
-	}}
-	r.runner = fr
-
-	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
-	}
-	if alive {
-		t.Fatal("alive = true, want false with inconclusive error")
-	}
-	if !strings.Contains(err.Error(), "server exited unexpectedly") {
-		t.Fatalf("IsAlive err = %v, want actionable legacy client failure", err)
-	}
-	if len(fr.calls) != 2 {
-		t.Fatalf("calls = %d, want private then legacy probes only", len(fr.calls))
-	}
-}
-
-func TestIsAliveReportsTransientLegacyConnectionAsProbeInconclusive(t *testing.T) {
-	r := New(Options{
-		Binary:       "bundled-tmux-test",
-		LegacyBinary: "system-tmux-test",
-		SocketName:   "ao",
-		Timeout:      time.Second,
-	})
-	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
-		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
-		{out: []byte("error connecting to /tmp/tmux-1000/default (Connection refused)"), err: &exec.ExitError{}},
-	}}
-	r.runner = fr
-
-	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
-	}
-	if alive {
-		t.Fatal("alive = true, want false with inconclusive error")
-	}
-	if len(fr.calls) != 2 {
-		t.Fatalf("calls = %d, want private then legacy probes only", len(fr.calls))
+	want := append([]string{"-S", testSocketPath, "-f", os.DevNull}, hasSessionArgs("sess-1")...)
+	if !reflect.DeepEqual(fr.calls[0].args, want) {
+		t.Fatalf("args = %#v, want %#v", fr.calls[0].args, want)
 	}
 }
 
@@ -865,7 +821,7 @@ func TestDestroyIsIdempotentWhenSessionMissing(t *testing.T) {
 	if err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
 		t.Fatalf("Destroy: %v", err)
 	}
-	if len(fr.calls) != 2 || fr.calls[0].args[0] != "list-panes" || fr.calls[1].args[0] != "kill-session" {
+	if len(fr.calls) != 2 || logicalTmuxArgs(fr.calls[0].args)[0] != "list-panes" || logicalTmuxArgs(fr.calls[1].args)[0] != "kill-session" {
 		t.Fatalf("calls = %#v, want list-panes then kill-session", fr.calls)
 	}
 }
@@ -899,10 +855,10 @@ func TestDestroyArgs(t *testing.T) {
 	}
 	// list-panes discovers pane sessions; kill-session (exact-match target
 	// =<id>) tears the session down.
-	if got, want := fr.calls[0].args, listPanePIDsArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[0].args), listPanePIDsArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("list-panes args = %#v, want %#v", got, want)
 	}
-	if got, want := fr.calls[1].args, killSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[1].args), killSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("destroy args = %#v, want %#v", got, want)
 	}
 }
@@ -1037,7 +993,7 @@ func TestIsAliveReturnsTrueOnExitZero(t *testing.T) {
 	if !alive {
 		t.Fatal("alive = false, want true")
 	}
-	if got, want := fr.calls[0].args, hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[0].args), hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("has-session args = %#v, want %#v", got, want)
 	}
 }
@@ -1115,16 +1071,16 @@ func TestSendMessageChunksAndSendsEnter(t *testing.T) {
 	if len(fr.calls) != 4 {
 		t.Fatalf("calls = %d, want 4 (3 chunks + Enter)", len(fr.calls))
 	}
-	if got, want := fr.calls[0].args, sendKeysLiteralArgs("sess-1", "hello"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[0].args), sendKeysLiteralArgs("sess-1", "hello"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("chunk 1 args = %#v, want %#v", got, want)
 	}
-	if got, want := fr.calls[1].args, sendKeysLiteralArgs("sess-1", "世"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[1].args), sendKeysLiteralArgs("sess-1", "世"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("chunk 2 args = %#v, want %#v", got, want)
 	}
-	if got, want := fr.calls[2].args, sendKeysLiteralArgs("sess-1", "界"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[2].args), sendKeysLiteralArgs("sess-1", "界"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("chunk 3 args = %#v, want %#v", got, want)
 	}
-	if got, want := fr.calls[3].args, sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[3].args), sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("Enter args = %#v, want %#v", got, want)
 	}
 }
@@ -1135,8 +1091,9 @@ func TestSendMessageUsesLiteralFlag(t *testing.T) {
 		t.Fatalf("SendMessage: %v", err)
 	}
 	// First call must use -l so "Enter" is sent literally, not as a key binding.
-	if fr.calls[0].args[3] != "-l" {
-		t.Fatalf("send-keys args[3] = %q, want -l", fr.calls[0].args[3])
+	args := logicalTmuxArgs(fr.calls[0].args)
+	if args[3] != "-l" {
+		t.Fatalf("send-keys args[3] = %q, want -l", args[3])
 	}
 }
 
@@ -1172,7 +1129,7 @@ func TestSendMessageDelaysBeforeEnter(t *testing.T) {
 	if len(fr.calls) != 2 {
 		t.Fatalf("calls = %d, want 2 (chunk + Enter)", len(fr.calls))
 	}
-	if got, want := fr.calls[1].args, sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[1].args), sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("Enter args = %#v, want %#v", got, want)
 	}
 
@@ -1190,7 +1147,7 @@ func TestSendMessageDelaysBeforeEnter(t *testing.T) {
 	if len(frNudge.calls) != 1 {
 		t.Fatalf("nudge calls = %d, want 1 (Enter only)", len(frNudge.calls))
 	}
-	if got, want := frNudge.calls[0].args, sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(frNudge.calls[0].args), sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("nudge Enter args = %#v, want %#v", got, want)
 	}
 }
@@ -1216,7 +1173,7 @@ func TestSendMessageEnterSurvivesCallerCancel(t *testing.T) {
 	if len(fr.calls) != 2 {
 		t.Fatalf("calls = %d, want 2 (chunk + Enter despite the caller cancel after the paste)", len(fr.calls))
 	}
-	if got, want := fr.calls[1].args, sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[1].args), sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("Enter args = %#v, want %#v", got, want)
 	}
 }
@@ -1251,10 +1208,10 @@ func TestSendMessageRemainingChunksSurviveCallerCancel(t *testing.T) {
 	if len(fr.calls) != 3 {
 		t.Fatalf("calls = %d, want 3 (two chunks + Enter)", len(fr.calls))
 	}
-	if got, want := fr.calls[1].args, sendKeysLiteralArgs("sess-1", "world"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[1].args), sendKeysLiteralArgs("sess-1", "world"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("chunk 2 args = %#v, want %#v", got, want)
 	}
-	if got, want := fr.calls[2].args, sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[2].args), sendEnterArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("Enter args = %#v, want %#v", got, want)
 	}
 }
@@ -1292,7 +1249,7 @@ func TestInterruptSendsCtrlC(t *testing.T) {
 	if err := r.Interrupt(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
 		t.Fatalf("Interrupt: %v", err)
 	}
-	if got, want := fr.calls[0].args, sendInterruptArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[0].args), sendInterruptArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("interrupt args = %#v, want %#v", got, want)
 	}
 }
@@ -1305,7 +1262,7 @@ func TestSendInputSendsEscapeWithoutEnter(t *testing.T) {
 	if len(fr.calls) != 1 {
 		t.Fatalf("calls = %d, want 1", len(fr.calls))
 	}
-	if got, want := fr.calls[0].args, sendKeysLiteralArgs("sess-1", "\x1b"); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[0].args), sendKeysLiteralArgs("sess-1", "\x1b"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("escape args = %#v, want %#v", got, want)
 	}
 }
@@ -1354,7 +1311,7 @@ func TestGetOutputArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetOutput: %v", err)
 	}
-	if got, want := fr.calls[0].args, capturePaneArgs("sess-1", 10); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[0].args), capturePaneArgs("sess-1", 10); !reflect.DeepEqual(got, want) {
 		t.Fatalf("capture-pane args = %#v, want %#v", got, want)
 	}
 }
@@ -1370,7 +1327,7 @@ func TestGetStyledOutputPreservesCaptureMode(t *testing.T) {
 	if !strings.Contains(out, "\x1b[2m") {
 		t.Fatalf("styled output lost SGR sequence: %q", out)
 	}
-	if got, want := fr.calls[0].args, capturePaneStyledArgs("sess-1", 10); !reflect.DeepEqual(got, want) {
+	if got, want := logicalTmuxArgs(fr.calls[0].args), capturePaneStyledArgs("sess-1", 10); !reflect.DeepEqual(got, want) {
 		t.Fatalf("capture-pane args = %#v, want %#v", got, want)
 	}
 }
@@ -1378,38 +1335,24 @@ func TestGetStyledOutputPreservesCaptureMode(t *testing.T) {
 // -- AttachCommand tests --
 
 func TestAttachCommandReturnsExpectedArgv(t *testing.T) {
-	r := New(Options{Binary: "/usr/bin/tmux", Timeout: time.Second})
+	r := New(Options{Binary: "/usr/bin/tmux", SocketPath: testSocketPath, Timeout: time.Second})
 	argv, err := r.attachCommand(ports.RuntimeHandle{ID: "sess-1"})
 	if err != nil {
 		t.Fatalf("AttachCommand: %v", err)
 	}
-	want := []string{"/usr/bin/tmux", "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
+	want := []string{"/usr/bin/tmux", "-S", testSocketPath, "-f", os.DevNull, "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
 	if !reflect.DeepEqual(argv, want) {
 		t.Fatalf("argv = %#v, want %#v", argv, want)
 	}
 }
 
-func TestAttachCommandUsesAppOwnedSocket(t *testing.T) {
-	r := New(Options{Binary: "/opt/ao/resources/tmux/bin/tmux", SocketName: "ao", Timeout: time.Second})
+func TestAttachCommandUsesBundledBinaryWithPrivateSocket(t *testing.T) {
+	r := New(Options{Binary: "/opt/ao/resources/tmux/bin/tmux", SocketPath: testSocketPath, Timeout: time.Second})
 	argv, err := r.attachCommand(ports.RuntimeHandle{ID: "sess-1"})
 	if err != nil {
 		t.Fatalf("AttachCommand: %v", err)
 	}
-	want := []string{"/opt/ao/resources/tmux/bin/tmux", "-L", "ao", "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
-	if !reflect.DeepEqual(argv, want) {
-		t.Fatalf("argv = %#v, want %#v", argv, want)
-	}
-}
-
-func TestAttachCommandUsesSystemTmuxForLegacyDefaultSocket(t *testing.T) {
-	r := New(Options{
-		Binary:       "/opt/ao/resources/tmux/bin/tmux",
-		LegacyBinary: "/opt/homebrew/bin/tmux",
-		SocketName:   "ao",
-		Timeout:      time.Second,
-	})
-	argv := r.attachCommandForSocket("sess-1", "")
-	want := []string{"/opt/homebrew/bin/tmux", "-L", "default", "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
+	want := []string{"/opt/ao/resources/tmux/bin/tmux", "-S", testSocketPath, "-f", os.DevNull, "-u", "-T", "RGB", "attach-session", "-t", "sess-1"}
 	if !reflect.DeepEqual(argv, want) {
 		t.Fatalf("argv = %#v, want %#v", argv, want)
 	}
@@ -1423,15 +1366,138 @@ func TestAttachCommandRejectsInvalidHandle(t *testing.T) {
 	}
 }
 
-func TestAttachEnvForcesUsableTerm(t *testing.T) {
-	env := attachEnv([]string{"PATH=/bin", "TERM=dumb", "COLORTERM=ansi", "SHELL=/bin/sh"})
-	if got, want := env, []string{"PATH=/bin", "TERM=xterm-256color", "COLORTERM=truecolor", "SHELL=/bin/sh"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("attachEnv = %#v, want %#v", got, want)
+func TestControlEnvIsolatesTmuxAndPreservesWorkloadEnvironment(t *testing.T) {
+	base := []string{
+		"PATH=/custom/bin:/usr/bin",
+		"HOME=/home/me",
+		"OPENAI_API_KEY=credential",
+		"LANG=en_US.UTF-8",
+		"SHELL=/bin/zsh",
+		"TERM=dumb",
+		"COLORTERM=ansi",
+		"TMUX=/tmp/tmux-user/default,1,0",
+		"TMUX_PANE=%7",
+		"TMUX_TMPDIR=/tmp/user-tmux",
+		"TERMINFO=/home/me/.terminfo",
+		"TERMINFO_DIRS=/custom/terminfo",
+		"AO_TMUX_BINARY=/opt/ao/tmux",
+		"AO_TMUX_SOCKET_NAME=ao",
 	}
+	want := []string{
+		"PATH=/custom/bin:/usr/bin",
+		"HOME=/home/me",
+		"OPENAI_API_KEY=credential",
+		"LANG=en_US.UTF-8",
+		"SHELL=/bin/zsh",
+		"TMUX_TMPDIR=/tmp/user-tmux",
+		"TERMINFO=/home/me/.terminfo",
+		"TERMINFO_DIRS=/custom/terminfo",
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	}
+	if got := controlEnv(base); !reflect.DeepEqual(got, want) {
+		t.Fatalf("controlEnv = %#v, want %#v", got, want)
+	}
+}
 
-	env = attachEnv([]string{"PATH=/bin"})
-	if got, want := env, []string{"PATH=/bin", "TERM=xterm-256color", "COLORTERM=truecolor"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("attachEnv without TERM = %#v, want %#v", got, want)
+func TestRunPassesCompleteSanitizedControlEnvironment(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-user/default,1,0")
+	t.Setenv("TMUX_TMPDIR", "/tmp/user-tmux")
+	t.Setenv("TERMINFO", "/home/me/.terminfo")
+	t.Setenv("AO_TMUX_BINARY", "/opt/ao/tmux")
+	t.Setenv("AO_CONTROL_ENV_SENTINEL", "preserved")
+	r := New(Options{Binary: "tmux-test", SocketPath: testSocketPath})
+	fr := &fakeRunner{}
+	r.runner = fr
+
+	if _, err := r.run(context.Background(), "list-sessions"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fr.calls) != 1 || fr.calls[0].env == nil {
+		t.Fatalf("runner calls = %#v, want one call with a complete environment", fr.calls)
+	}
+	got := make(map[string]string)
+	for _, kv := range fr.calls[0].env {
+		key, value, ok := strings.Cut(kv, "=")
+		if ok {
+			got[key] = value
+		}
+	}
+	for _, key := range []string{"TMUX", "AO_TMUX_BINARY"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("control environment retained %s", key)
+		}
+	}
+	if got["AO_CONTROL_ENV_SENTINEL"] != "preserved" || got["TMUX_TMPDIR"] != "/tmp/user-tmux" || got["TERMINFO"] != "/home/me/.terminfo" || got["TERM"] != "xterm-256color" || got["COLORTERM"] != "truecolor" {
+		t.Fatalf("control environment lost required values: sentinel=%q TMUX_TMPDIR=%q TERMINFO=%q TERM=%q COLORTERM=%q", got["AO_CONTROL_ENV_SENTINEL"], got["TMUX_TMPDIR"], got["TERMINFO"], got["TERM"], got["COLORTERM"])
+	}
+}
+
+func TestEnvironmentSyncUsesStdinAndRemovesStaleNames(t *testing.T) {
+	const secret = "credential with spaces\n$and-quotes\""
+	r := New(Options{Binary: "tmux-test", SocketPath: testSocketPath, Timeout: time.Second})
+	fr := &fakeRunner{outputs: [][]byte{
+		[]byte("GLOBAL_STALE_TOKEN=old\nTERM=screen-256color\n"),
+		[]byte("SESSION_STALE_TOKEN=old\n"),
+	}}
+	r.runner = fr
+
+	if err := r.syncCurrentEnvironment(context.Background(), "sess-1", map[string]string{"AO_TMUX_SYNC_SECRET": secret}); err != nil {
+		t.Fatalf("syncCurrentEnvironment: %v", err)
+	}
+	if len(fr.calls) != 3 {
+		t.Fatalf("calls = %d, want global/session show-environment then source-file", len(fr.calls))
+	}
+	if got, want := logicalTmuxArgs(fr.calls[0].args), []string{"show-environment", "-g"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("inspect args = %#v, want %#v", got, want)
+	}
+	if got, want := logicalTmuxArgs(fr.calls[1].args), []string{"show-environment", "-t", "=sess-1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("inspect args = %#v, want %#v", got, want)
+	}
+	if got, want := logicalTmuxArgs(fr.calls[2].args), []string{"source-file", "-"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("apply args = %#v, want %#v", got, want)
+	}
+	for _, call := range fr.calls {
+		if strings.Contains(strings.Join(call.args, "\x00"), secret) {
+			t.Fatalf("secret leaked into argv: %#v", call.args)
+		}
+	}
+	script := string(fr.calls[2].stdin)
+	if script == "" {
+		t.Fatal("source-file stdin is empty")
+	}
+	if strings.Contains(script, secret) {
+		t.Fatal("source-file input retained the unencoded secret")
+	}
+	if !strings.Contains(script, "set-environment -t =sess-1 AO_TMUX_SYNC_SECRET ") {
+		t.Fatalf("source script did not refresh the current key: %q", script)
+	}
+	for _, staleKey := range []string{"GLOBAL_STALE_TOKEN", "SESSION_STALE_TOKEN"} {
+		if !strings.Contains(script, "set-environment -r -t =sess-1 "+staleKey+"\n") {
+			t.Fatalf("source script did not remove stale key %s from the restarted session: %q", staleKey, script)
+		}
+	}
+	if strings.Contains(script, "set-environment -r -t =sess-1 TERM") {
+		t.Fatalf("source script must leave tmux-owned TERM alone: %q", script)
+	}
+}
+
+func TestEnvironmentSyncConfigEncodingAndParsing(t *testing.T) {
+	if got, want := tmuxConfigQuote("a\n$\"é"), `"\141\012\044\042\303\251"`; got != want {
+		t.Fatalf("tmuxConfigQuote = %q, want %q", got, want)
+	}
+	if got, want := parseTmuxEnvironmentNames("B=two\n-A\nTERM=screen\nBAD-KEY=x\nC=three=four\n"), []string{"A", "B", "C"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseTmuxEnvironmentNames = %#v, want %#v", got, want)
+	}
+}
+
+func TestEnvironmentSyncRejectsMissingSessionServer(t *testing.T) {
+	serverMissing := fakeRunnerResult{out: []byte("no server running on private socket"), err: &exec.ExitError{}}
+	r := New(Options{Binary: "tmux-test", SocketPath: testSocketPath, Timeout: time.Second})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{serverMissing}}
+	r.runner = fr
+	if err := r.syncCurrentEnvironment(context.Background(), "sess-1", nil); err == nil || !strings.Contains(err.Error(), "server unavailable") {
+		t.Fatalf("restart sync error = %v, want unavailable server", err)
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -559,7 +559,9 @@ func TestWiring_StartLifecycleThreadsMessengerIntoLCM(t *testing.T) {
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	messenger := &captureMessenger{}
-	stack := startLifecycle(ctx, store, tmux.New(tmux.Options{}), messenger, nil, nil, nil, log)
+	stack := startLifecycle(ctx, store, tmux.New(tmux.Options{
+		SocketPath: shortPrivateTmuxSocket(t),
+	}), messenger, nil, nil, nil, log)
 	t.Cleanup(stack.Stop)
 	t.Cleanup(cancel)
 
@@ -590,6 +592,16 @@ func TestWiring_StartLifecycleThreadsMessengerIntoLCM(t *testing.T) {
 	if messenger.msgs[0].id != rec.ID {
 		t.Fatalf("nudge sent to %q, want %q", messenger.msgs[0].id, rec.ID)
 	}
+}
+
+func shortPrivateTmuxSocket(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ao-tmux-")
+	if err != nil {
+		t.Fatalf("create private tmux socket directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
 }
 
 // TestProjectRepoResolver_ResolvesRegisteredProject asserts the DB-backed repo

--- a/backend/internal/observe/activity/observer_integration_test.go
+++ b/backend/internal/observe/activity/observer_integration_test.go
@@ -2,7 +2,9 @@ package activity
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -70,7 +72,11 @@ func TestObserverIntegrationReconcilesRealTmuxOutputIntoSQLite(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			runtime := tmux.New(tmux.Options{Timeout: 5 * time.Second, ReapGrace: 100 * time.Millisecond})
+			runtime := tmux.New(tmux.Options{
+				SocketPath: shortPrivateTmuxSocket(t),
+				Timeout:    5 * time.Second,
+				ReapGrace:  100 * time.Millisecond,
+			})
 			handle, err := runtime.Create(ctx, ports.RuntimeConfig{
 				SessionID:     session.ID,
 				WorkspacePath: workspace,
@@ -113,6 +119,16 @@ func TestObserverIntegrationReconcilesRealTmuxOutputIntoSQLite(t *testing.T) {
 			}
 		})
 	}
+}
+
+func shortPrivateTmuxSocket(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ao-tmux-")
+	if err != nil {
+		t.Fatalf("create private tmux socket directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
 }
 
 func waitForTerminalOutput(t *testing.T, runtime *tmux.Runtime, handle ports.RuntimeHandle, want string) {

--- a/backend/internal/terminal/attachment_integration_test.go
+++ b/backend/internal/terminal/attachment_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -27,7 +28,10 @@ func TestAttachmentStreamsRealTmuxPane(t *testing.T) {
 	t.Setenv("TERM", "xterm-256color")
 
 	name := "ao-term-it-" + strconv.Itoa(os.Getpid())
-	rt := tmux.New(tmux.Options{Timeout: 10 * time.Second})
+	rt := tmux.New(tmux.Options{
+		SocketPath: shortPrivateTmuxSocket(t),
+		Timeout:    10 * time.Second,
+	})
 	handle, err := rt.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     domain.SessionID(name),
 		WorkspacePath: t.TempDir(),
@@ -70,7 +74,10 @@ func TestAttachmentReattachAdoptsNewSize(t *testing.T) {
 	t.Setenv("TERM", "xterm-256color")
 
 	name := "ao-term-size-it-" + strconv.Itoa(os.Getpid())
-	rt := tmux.New(tmux.Options{Timeout: 10 * time.Second})
+	rt := tmux.New(tmux.Options{
+		SocketPath: shortPrivateTmuxSocket(t),
+		Timeout:    10 * time.Second,
+	})
 	handle, err := rt.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     domain.SessionID(name),
 		WorkspacePath: t.TempDir(),
@@ -148,4 +155,14 @@ func TestAttachmentReattachAdoptsNewSize(t *testing.T) {
 	if !gotWidth {
 		t.Fatalf("reattached pane never reported B's width (cols>130) within 30s; captured:\n%q", captured)
 	}
+}
+
+func shortPrivateTmuxSocket(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ao-tmux-")
+	if err != nil {
+		t.Fatalf("create private tmux socket directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
 }

--- a/backend/internal/tmuxbin/resolve.go
+++ b/backend/internal/tmuxbin/resolve.go
@@ -37,8 +37,9 @@ func Resolve() (Resolution, error) {
 }
 
 // ResolveWith is Resolve with process lookups injected for callers and tests.
-// A configured path is fail-closed: packaged builds must never silently fall
-// back to a machine tmux when their bundled resource is missing or broken.
+// Configured paths and recognizable packaged layouts are fail-closed: a
+// packaged daemon must never silently fall back to a machine tmux when its
+// bundled resource is missing or broken.
 func ResolveWith(configured string, executable func() (string, error), lookPath func(string) (string, error)) (Resolution, error) {
 	if configured = strings.TrimSpace(configured); configured != "" {
 		path, err := lookPath(configured)
@@ -51,7 +52,7 @@ func ResolveWith(configured string, executable func() (string, error), lookPath 
 		return Resolution{}, errors.Join(err, errTmuxNotFound)
 	}
 
-	var bundledErr error
+	var executableErr error
 	if self, err := executable(); err == nil && self != "" {
 		if resolved, resolveErr := filepath.EvalSymlinks(self); resolveErr == nil {
 			self = resolved
@@ -61,10 +62,17 @@ func ResolveWith(configured string, executable func() (string, error), lookPath 
 			if lookupErr == nil && path != "" {
 				return Resolution{Path: path, Source: SourceBundled}, nil
 			}
-			bundledErr = lookupErr
+			if lookupErr == nil {
+				lookupErr = errTmuxNotFound
+			}
+			// Once the running executable proves this is a packaged desktop
+			// layout, the sibling resource is authoritative. Falling through to
+			// PATH here would silently mix AO's packaged daemon with an arbitrary
+			// user-installed tmux when the package is incomplete or damaged.
+			return Resolution{}, errors.Join(lookupErr, errTmuxNotFound)
 		}
 	} else if err != nil {
-		bundledErr = err
+		executableErr = err
 	}
 
 	path, err := lookPath("tmux")
@@ -74,7 +82,7 @@ func ResolveWith(configured string, executable func() (string, error), lookPath 
 	if err == nil {
 		err = errTmuxNotFound
 	}
-	return Resolution{}, errors.Join(bundledErr, err, errTmuxNotFound)
+	return Resolution{}, errors.Join(executableErr, err, errTmuxNotFound)
 }
 
 // bundledCandidate recognizes Electron's resource layout on macOS and Linux:

--- a/backend/internal/tmuxbin/resolve_test.go
+++ b/backend/internal/tmuxbin/resolve_test.go
@@ -68,6 +68,44 @@ func TestResolveWithFindsPackagedTmuxOnMacOSAndLinuxLayouts(t *testing.T) {
 	}
 }
 
+func TestResolveWithDoesNotFallbackFromBrokenPackagedTmux(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		lookupErr error
+	}{
+		{name: "missing", lookupErr: errors.New("not found")},
+		{name: "empty resolution"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			self := filepath.Join(t.TempDir(), "AO.app", "Contents", "Resources", "daemon", "ao")
+			bundled := filepath.Join(filepath.Dir(filepath.Dir(self)), "tmux", "bin", "tmux")
+			var lookups []string
+
+			_, err := ResolveWith("", func() (string, error) { return self, nil }, func(name string) (string, error) {
+				lookups = append(lookups, name)
+				if name == bundled {
+					return "", tc.lookupErr
+				}
+				// A system tmux is deliberately available: packaged resolution must
+				// still fail closed before consulting it.
+				if name == "tmux" {
+					return "/usr/bin/tmux", nil
+				}
+				return "", errors.New("unexpected lookup")
+			})
+			if err == nil {
+				t.Fatal("ResolveWith error = nil, want broken packaged tmux error")
+			}
+			if !errors.Is(err, errTmuxNotFound) {
+				t.Fatalf("ResolveWith error = %v, want errTmuxNotFound", err)
+			}
+			if !reflect.DeepEqual(lookups, []string{bundled}) {
+				t.Fatalf("lookups = %v, want packaged candidate only", lookups)
+			}
+		})
+	}
+}
+
 func TestResolveWithFollowsExecutableSymlinkIntoBundle(t *testing.T) {
 	daemonDir := filepath.Join(t.TempDir(), "AO.app", "Contents", "Resources", "daemon")
 	if err := os.MkdirAll(daemonDir, 0o755); err != nil {

--- a/docs/daemon-environment.md
+++ b/docs/daemon-environment.md
@@ -11,8 +11,18 @@ inherits a stunted environment (minimal `PATH`, no shell-exported credentials).
 The daemon then cannot find `git`/the agent CLIs, and the agents it launches
 cannot see API keys. Packaged macOS/Linux builds carry their own tmux and do
 not depend on a machine installation; development and standalone daemon runs
-still resolve tmux from `PATH`. The same app launched from a terminal works,
-because a terminal-started process inherits the shell's fully-populated
+still resolve tmux from `PATH`. On Unix, every daemon derives an explicit
+AO-private `tmux -S` socket from its run-file identity, starts tmux without the
+user's tmux configuration, and never probes the default socket. The socket
+inode stays beside the run file; deeply nested state paths use a validated,
+bounded, owner-only `/tmp` directory alias to satisfy macOS's Unix-socket path
+limit. Socket paths are canonicalized and fail closed if their directory or an
+ancestor is owned by an untrusted user or is shared-writable. Before a pane's
+real command starts, AO refreshes its merged daemon/project environment over
+tmux client stdin, including explicit removal of stale variables; environment
+values never become tmux or pane-shell arguments.
+Windows uses ConPTY instead of tmux. The same app launched from a terminal
+works, because a terminal-started process inherits the shell's fully-populated
 environment. The fix is to resolve the user's login-shell environment once at
 startup and use it as the base for the daemon's environment.
 
@@ -184,7 +194,9 @@ it. We shell out once to the user's own shell and adopt its result.
   credential pass-through are applied.
 - Manual: launch the packaged app from Finder (not a terminal) on a machine
   without tmux on `PATH`; confirm a new session spawns and attaches through the
-  bundled `resources/tmux/bin/tmux`, while `git`/agent binaries still resolve.
+  bundled `resources/tmux/bin/tmux` on the daemon's explicit private socket,
+  while `git`/agent binaries still resolve. Confirm a user `~/.tmux.conf` is
+  ignored and sessions on tmux's default socket are not discovered.
 
 ## Relevant code
 
@@ -196,9 +208,14 @@ it. We shell out once to the user's own shell and adopt its result.
   build copied into the macOS/Linux package.
 - `frontend/src/shared/bundled-tmux.ts` and `frontend/src/main.ts` - packaged
   resource resolution, durable versioned staging under the AO data directory,
-  and `AO_TMUX_BINARY`/AO-owned socket injection.
+  and `AO_TMUX_BINARY` injection.
 - `backend/internal/adapters/runtime/tmux/tmux.go` - honors
-  `AO_TMUX_BINARY`; standalone runs fall back to `exec.LookPath("tmux")`.
+  `AO_TMUX_BINARY`; standalone runs fall back to `exec.LookPath("tmux")`. The
+  daemon derives its explicit private `-S` socket from the run-file identity,
+  ignores user tmux configuration, refreshes the workload environment per pane,
+  and never probes tmux's default socket. A value-free bootstrap pane lets the
+  adapter apply project environment values over stdin before launching the real
+  command.
 - `backend/internal/observe/reaper/reaper.go`,
   `backend/internal/lifecycle/runtime.go` - liveness -> termination
   (`ProbeFailed` never terminates, so a daemon that cannot run `tmux` strands

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -26,10 +26,15 @@ on `main`; the PR-based flow below supersedes it.
 - macOS and Linux packages build and ship a pinned tmux under
   `resources/tmux/bin/tmux`. Before spawning the daemon, Electron atomically
   stages that binary in versioned storage under the AO data directory; this
-  keeps it available after a Linux AppImage mount disappears. The supervisor
-  pins new sessions to an AO-owned tmux socket. Sessions created by an older AO
-  release are discovered and kept on the legacy default socket until they end.
-  Windows uses ConPTY and carries no tmux resource.
+  keeps it available after a Linux AppImage mount disappears. The daemon
+  derives an explicit AO-private `tmux -S` socket from its run-file identity and
+  starts tmux without reading the user's tmux configuration. It never probes or
+  adopts sessions from tmux's default socket. Socket inodes remain in AO state;
+  a bounded owner-only `/tmp` directory alias handles deeply nested paths on
+  macOS, and unsafe shared-writable socket directories fail closed. Pane
+  environments are applied over stdin before the real command starts, keeping
+  configured values out of process arguments. Windows uses ConPTY and carries
+  no tmux resource.
 
 ## Hard rule: exactly one publisher
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -843,7 +843,7 @@ function daemonEnv(forceKeep = keepDaemonAlive(process.env)): NodeJS.ProcessEnv 
 			(app.isPackaged
 				? path.join(process.resourcesPath, "acp-runtime")
 				: path.join(app.getAppPath(), "resources", "acp-runtime")),
-		...(bundledTmuxBinary ? { AO_TMUX_BINARY: bundledTmuxBinary, AO_TMUX_SOCKET_NAME: "ao" } : {}),
+		...(bundledTmuxBinary ? { AO_TMUX_BINARY: bundledTmuxBinary } : {}),
 	};
 	// In dev mode, inject isolation defaults so the dev daemon never collides with
 	// the installed app. User-set env vars take priority (checked first).


### PR DESCRIPTION
Fixes [#4391](https://github.com/Untrivial-ai/agent-orchestrator/issues/4391).

Complements [#4385](https://github.com/Untrivial-ai/agent-orchestrator/pull/4385), which fixes the missing packaged terminfo database seen in the original report.

## Summary

- derive a stable per-run-file private tmux socket, force an empty tmux config, and never probe or adopt user/default tmux state
- validate socket-directory ownership and permissions, with an owner-only short alias for macOS Unix-socket limits
- refresh merged daemon/project pane environments over stdin, remove stale global/session variables, and keep configured values out of process arguments
- fail closed when a packaged tmux resource is unavailable; leave Windows on ConPTY

## Verification

- `npm run lint`
- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd backend && go test -race ./internal/adapters/runtime/tmux ./internal/adapters/runtime/runtimeselect ./internal/tmuxbin`
- `cd frontend && npm run typecheck`
- Windows cross-compilation for the tmux and runtime-selector packages

## Migration and risk

This is an intentional strict cutover. Sessions on the old `-L ao` or default tmux server remain running but are not adopted, because AO cannot prove that a same-named server belongs to AO rather than the user. New sessions use only the private socket. The socket identity remains stable across ordinary releases; a future incompatible tmux protocol upgrade will require an explicit migration policy.