### PR TITLE
feat(observability): wire Sentry DSNs into desktop + mobile builds

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -135,16 +135,21 @@ func Run() error {
 
 	telemetrySink := newTelemetrySink(cfg, store, log)
 	defer func() { _ = telemetrySink.Close(context.Background()) }()
-	// Daemon Sentry: captures genuine 5xx/panics with their Go stack. No-op
-	// unless AO_SENTRY_DSN is set. Flushed on shutdown so buffered faults send.
-	if err := sentryobs.Init(sentryobs.Config{
-		DSN:         cfg.Telemetry.SentryDSN,
-		Release:     cfg.Telemetry.AppVersion,
-		Environment: sentryEnvironment(cfg.Telemetry.AppVersion),
-	}); err != nil {
-		log.Warn("daemon sentry disabled", "err", err)
+	// Daemon Sentry: captures genuine 5xx/panics with their Go stack. Gated on
+	// the same consent switch as the remote telemetry sink (cfg.Telemetry.Events)
+	// so a user who has turned telemetry off never has faults reported, and a
+	// no-op besides unless a DSN is set. Flushed on shutdown so buffered faults
+	// send.
+	if cfg.Telemetry.Events {
+		if err := sentryobs.Init(sentryobs.Config{
+			DSN:         cfg.Telemetry.SentryDSN,
+			Release:     cfg.Telemetry.AppVersion,
+			Environment: sentryEnvironment(cfg.Telemetry.AppVersion),
+		}); err != nil {
+			log.Warn("daemon sentry disabled", "err", err)
+		}
+		defer sentryobs.Flush(2 * time.Second)
 	}
-	defer sentryobs.Flush(2 * time.Second)
 	telemetrySink.Emit(context.Background(), ports.TelemetryEvent{
 		Name:       "ao.daemon.started",
 		Source:     "daemon",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -90,6 +90,7 @@ import {
 	showCloudSignInFailure,
 } from "./main/cloud-auth";
 import { DEFAULT_POSTHOG_HOST, DEFAULT_POSTHOG_PROJECT_KEY } from "./shared/posthog-config";
+import { DEFAULT_SENTRY_DSN } from "./shared/sentry-config";
 import { buildTelemetryBootstrap } from "./shared/telemetry";
 import { createBrowserViewHost, type BrowserViewHost } from "./main/browser-view-host";
 import { createWindowComposition, type WindowComposition } from "./main/window-composition";
@@ -700,6 +701,11 @@ function telemetryOverrides(): Record<string, string> {
 		AO_TELEMETRY_REMOTE: process.env.AO_TELEMETRY_REMOTE ?? (isDev ? "off" : "posthog"),
 		AO_TELEMETRY_POSTHOG_KEY: process.env.AO_TELEMETRY_POSTHOG_KEY ?? DEFAULT_POSTHOG_PROJECT_KEY,
 		AO_TELEMETRY_POSTHOG_HOST: process.env.AO_TELEMETRY_POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST,
+		// Daemon-side Sentry (5xx + panics with Go stacks). Stamped on the daemon
+		// env so the spawned daemon inherits the DSN; off in dev to match the
+		// PostHog remote gate, and an explicit env always wins. A blank value
+		// leaves the daemon's Sentry a no-op.
+		AO_SENTRY_DSN: process.env.AO_SENTRY_DSN ?? (isDev ? "" : DEFAULT_SENTRY_DSN),
 		// The daemon binary has no version of its own that release tooling sets,
 		// so without this every daemon event lands unattributable to a release.
 		AO_TELEMETRY_APP_VERSION: process.env.AO_TELEMETRY_APP_VERSION ?? app.getVersion(),

--- a/frontend/src/main/sentry-main.ts
+++ b/frontend/src/main/sentry-main.ts
@@ -22,6 +22,8 @@
 // normalization. Sentry's cache resolves under Electron userData, which AO has
 // already pinned to ~/.ao/electron, so it honors the app-data rule.
 
+import { DEFAULT_SENTRY_DSN } from "../shared/sentry-config";
+
 const DENY_INTEGRATIONS = new Set([
 	"SentryMinidump",
 	"Screenshots",
@@ -71,7 +73,7 @@ let started = false;
  */
 export async function initMainSentry(version: string): Promise<void> {
 	if (started) return;
-	const dsn = (process.env.AO_SENTRY_DSN ?? "").trim();
+	const dsn = (process.env.AO_SENTRY_DSN ?? "").trim() || DEFAULT_SENTRY_DSN;
 	if (!dsn) return;
 	started = true;
 	try {

--- a/frontend/src/renderer/lib/sentry.ts
+++ b/frontend/src/renderer/lib/sentry.ts
@@ -10,6 +10,7 @@
 // happens once a DSN is present.
 
 import { classifyError, type ClassifyInput, type Triage } from "../../shared/observability";
+import { DEFAULT_SENTRY_DSN } from "../../shared/sentry-config";
 
 type SentryLike = {
 	init: (opts: Record<string, unknown>) => void;
@@ -23,9 +24,10 @@ let initStarted = false;
 
 function dsn(): string {
 	try {
-		return (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_AO_SENTRY_DSN ?? "";
+		const configured = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_AO_SENTRY_DSN?.trim();
+		return configured || DEFAULT_SENTRY_DSN;
 	} catch {
-		return "";
+		return DEFAULT_SENTRY_DSN;
 	}
 }
 

--- a/frontend/src/shared/sentry-config.ts
+++ b/frontend/src/shared/sentry-config.ts
@@ -1,0 +1,13 @@
+// Baked default Sentry DSN for the desktop surfaces (renderer, Electron main,
+// and the Go daemon spawned by the app), mirroring how DEFAULT_POSTHOG_PROJECT_KEY
+// is committed in posthog-config.ts. A client DSN is a write-only ingest
+// endpoint, so it is safe to ship in the client the same way the PostHog project
+// key already is; volume is bounded by the project's Sentry-side spike protection
+// and rate limit, not by anything secret here.
+//
+// Overridable per environment: the renderer reads VITE_AO_SENTRY_DSN, the main
+// process and daemon read AO_SENTRY_DSN, and both fall back to this constant.
+// Mobile has its own project and constant (see packages/mobile), because the
+// Expo bundle cannot reach frontend/src.
+export const DEFAULT_SENTRY_DSN =
+	"https://664339d231569b18bcf50d69a0ce37bf@o4511955966361600.ingest.us.sentry.io/4511955986677760";

--- a/packages/mobile/lib/sentry-config.ts
+++ b/packages/mobile/lib/sentry-config.ts
@@ -1,0 +1,11 @@
+// Baked default Sentry DSN for the mobile app, mirroring the desktop
+// DEFAULT_SENTRY_DSN. A separate project (and DSN) from desktop so mobile crash
+// waves, quotas, and native symbolication stay independent. A client DSN is a
+// write-only ingest endpoint, safe to ship in the client; volume is bounded by
+// the project's Sentry-side spike protection and rate limit.
+//
+// Overridable via EXPO_PUBLIC_SENTRY_DSN. Note: this only takes effect once the
+// @sentry/react-native SDK is installed (npx expo install @sentry/react-native +
+// config plugin + prebuild); until then sentry.ts stays a no-op.
+export const DEFAULT_SENTRY_DSN =
+	"https://1d7f28aaf986243fae2218db3be2812a@o4511955966361600.ingest.us.sentry.io/4511967513935872";

--- a/packages/mobile/lib/sentry.ts
+++ b/packages/mobile/lib/sentry.ts
@@ -18,6 +18,7 @@
 // Until then this file compiles and runs as a no-op with no native dependency.
 
 import { classifyError, type ClassifyInput, type Triage } from "./observability";
+import { DEFAULT_SENTRY_DSN } from "./sentry-config";
 
 type SentryLike = {
 	init: (opts: Record<string, unknown>) => void;
@@ -31,9 +32,9 @@ let initStarted = false;
 
 function dsn(): string {
 	try {
-		return process.env.EXPO_PUBLIC_SENTRY_DSN ?? "";
+		return process.env.EXPO_PUBLIC_SENTRY_DSN?.trim() || DEFAULT_SENTRY_DSN;
 	} catch {
-		return "";
+		return DEFAULT_SENTRY_DSN;
 	}
 }
 


### PR DESCRIPTION
## What

Bakes the two Sentry DSNs as committed default constants, mirroring how `DEFAULT_POSTHOG_PROJECT_KEY` already ships, so **nightly and stable both pick them up with no CI or secret setup**. Client DSNs are write-only ingest endpoints; volume is bounded by each project's Sentry-side spike protection + rate limit (both enabled: 300 events/min).

Two separate Sentry projects (`ao-desktop`, `ao-mobile`) so desktop and mobile crash waves, quotas, and native symbolication stay independent.

## Changes

- `shared/sentry-config.ts` (desktop) and `packages/mobile/lib/sentry-config.ts` (mobile) hold the two project DSNs.
- Fallbacks: renderer `VITE_AO_SENTRY_DSN`, Electron main + daemon `AO_SENTRY_DSN`, and mobile `EXPO_PUBLIC_SENTRY_DSN` all fall back to the baked constant; an explicit env still wins.
- `main.ts` stamps `AO_SENTRY_DSN` onto the spawned daemon env (**off in dev**, matching the PostHog remote gate), so the Go daemon — whose `sentry-go` SDK is already compiled in via #4346 — captures 5xx and panics on the next non-dev build.
- **Privacy:** `daemon.go` now gates `sentryobs.Init` on `cfg.Telemetry.Events`, the same consent switch as the remote telemetry sink, so a user who turned telemetry off never has daemon faults reported even though a DSN is now baked in.

## Activation status

| Surface | State |
|---|---|
| **Daemon (Go)** | **Live on next non-dev build** — SDK vendored (#4346), activates from the env stamp. This is where the ~230k INTERNAL_ERROR 500s originate. |
| Renderer / Electron main | DSN baked. Still needs `@sentry/electron` installed (it is in `package.json` but not the lockfile) and the lazy import converted to static before the packaged app resolves it. |
| Mobile | DSN baked. Still needs `npx expo install @sentry/react-native` + the config plugin + `expo prebuild` to activate. |

## Verification

- `go build`, `go vet`, and the daemon telemetry-sink test pass.
- Touched frontend/mobile files typecheck clean (unrelated cross-worktree i18n resolution noise aside).
- Not verifiable here and needs a real build: a packaged desktop/Expo build actually delivering renderer/mobile events. The daemon path is the one that goes live from this PR.

## Follow-ups (client SDK activation)

1. Desktop: `npm install @sentry/electron@7.17.0` to fix the lockfile, convert the lazy `await import(...)` in `renderer/lib/sentry.ts` and `main/sentry-main.ts` to static imports, verify a packaged build.
2. Mobile: `npx expo install @sentry/react-native`, add the config plugin, `expo prebuild`.
3. Optional: upload renderer source maps per release for readable JS stacks.