### PR TITLE
fix(storage): repair legacy migration profiles

### DIFF
--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -131,6 +131,9 @@ func migrate(db *sql.DB) error {
 	if err := goose.SetDialect("sqlite3"); err != nil {
 		return fmt.Errorf("set goose dialect: %w", err)
 	}
+	if err := retirePublishedPipelinesProfile(context.Background(), db); err != nil {
+		return fmt.Errorf("retire published Pipelines migration profile: %w", err)
+	}
 	if err := repairRenumberedChatMigrationHistory(db); err != nil {
 		return fmt.Errorf("repair renumbered chat migration history: %w", err)
 	}
@@ -155,12 +158,6 @@ func migrate(db *sql.DB) error {
 	if err := prepareQueuedTurnPromotionMigration(db); err != nil {
 		return fmt.Errorf("prepare queued-turn promotion migration: %w", err)
 	}
-	if err := prepareLegacyPipelineCDCBeforeReviewRunMigration(db); err != nil {
-		return fmt.Errorf("prepare legacy pipeline CDC migration: %w", err)
-	}
-	if err := prepareAppSettingsSingletonMigration(db); err != nil {
-		return fmt.Errorf("prepare app settings singleton migration: %w", err)
-	}
 	// Builds can advance a database past a migration that is added or
 	// renumbered later (notably across fast-moving Nightly releases). Apply
 	// those embedded migrations instead of permanently wedging daemon startup
@@ -169,180 +166,6 @@ func migrate(db *sql.DB) error {
 		return fmt.Errorf("run migrations: %w", err)
 	}
 	return reconcileSchema(db)
-}
-
-// prepareLegacyPipelineCDCBeforeReviewRunMigration repairs Nightly databases
-// that briefly carried the abandoned pipeline CDC schema. The 0103 migration
-// rebuilds change_log; SQLite refuses to drop that table while these old trigger
-// bodies still reference it, and any retained pipeline_* event rows would fail
-// 0103's narrower CHECK constraint.
-func prepareLegacyPipelineCDCBeforeReviewRunMigration(db *sql.DB) error {
-	var gooseTable int
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'goose_db_version'`,
-	).Scan(&gooseTable); err != nil {
-		return err
-	}
-	if gooseTable == 0 {
-		return nil
-	}
-
-	var applied103 int
-	if err := db.QueryRow(`
-SELECT COALESCE((
-    SELECT is_applied FROM goose_db_version
-    WHERE version_id = 103 ORDER BY id DESC LIMIT 1
-), 0)`).Scan(&applied103); err != nil {
-		return err
-	}
-	if applied103 != 0 {
-		return nil
-	}
-
-	if _, err := db.Exec(`
-DROP TRIGGER IF EXISTS pipeline_definitions_cdc_insert;
-DROP TRIGGER IF EXISTS pipeline_definitions_cdc_update;
-DROP TRIGGER IF EXISTS pipeline_definitions_cdc_delete;
-DROP TRIGGER IF EXISTS pipeline_runs_cdc_insert;
-DROP TRIGGER IF EXISTS pipeline_runs_cdc_update;
-DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_insert;
-DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_update;
-DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_insert;
-DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_update;`); err != nil {
-		return err
-	}
-
-	var changeLogTable int
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'change_log'`,
-	).Scan(&changeLogTable); err != nil {
-		return err
-	}
-	if changeLogTable == 0 {
-		return nil
-	}
-
-	_, err := db.Exec(`
-DELETE FROM change_log
-WHERE event_type IN (
-    'pipeline_definition_changed',
-    'pipeline_run_updated',
-    'pipeline_stage_run_updated',
-    'pipeline_artifact_updated'
-);`)
-	return err
-}
-
-// prepareAppSettingsSingletonMigration repairs feature-build databases whose
-// app_settings table came from the abandoned pipeline key/value migration. Some
-// of those databases already recorded 0067 through a burned migration profile;
-// the published PR build stopped at 0051 and has not. Recreate 0067's physical
-// schema and ledger effect together so goose neither skips a missing schema nor
-// replays CREATE TABLE over the repaired table.
-func prepareAppSettingsSingletonMigration(db *sql.DB) error {
-	var tableExists int
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'app_settings'`,
-	).Scan(&tableExists); err != nil {
-		return err
-	}
-	if tableExists == 0 {
-		return nil
-	}
-
-	var columnCount, idColumn, modeColumn, updatedAtColumn, keyColumn, valueColumn int
-	if err := db.QueryRow(`
-SELECT COUNT(*),
-       SUM(name = 'id'),
-       SUM(name = 'default_session_mode'),
-       SUM(name = 'updated_at'),
-       SUM(name = 'key'),
-       SUM(name = 'value')
-FROM pragma_table_info('app_settings')`).Scan(
-		&columnCount,
-		&idColumn,
-		&modeColumn,
-		&updatedAtColumn,
-		&keyColumn,
-		&valueColumn,
-	); err != nil {
-		return err
-	}
-	if idColumn > 0 && modeColumn > 0 && updatedAtColumn > 0 {
-		return nil
-	}
-	if columnCount != 2 || keyColumn != 1 || valueColumn != 1 {
-		return fmt.Errorf(
-			"unsupported app_settings schema: columns=%d id=%d default_session_mode=%d updated_at=%d key=%d value=%d",
-			columnCount, idColumn, modeColumn, updatedAtColumn, keyColumn, valueColumn,
-		)
-	}
-
-	var gooseTable int
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'goose_db_version'`,
-	).Scan(&gooseTable); err != nil {
-		return err
-	}
-	if gooseTable == 0 {
-		return fmt.Errorf("legacy app_settings schema exists without goose migration history")
-	}
-
-	tx, err := db.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	var defaultMode string
-	if err := tx.QueryRow(`
-SELECT COALESCE((
-    SELECT value FROM app_settings
-    WHERE key = 'default_session_mode' AND value IN ('chat', 'tui')
-    LIMIT 1
-), 'tui')`).Scan(&defaultMode); err != nil {
-		return err
-	}
-
-	var applied67 int
-	if err := tx.QueryRow(`
-SELECT COALESCE((
-    SELECT is_applied FROM goose_db_version
-    WHERE version_id = 67 ORDER BY id DESC LIMIT 1
-), 0)`).Scan(&applied67); err != nil {
-		return err
-	}
-
-	if _, err := tx.Exec(
-		`ALTER TABLE app_settings RENAME TO app_settings_legacy_before_0067_repair`,
-	); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`
-CREATE TABLE app_settings (
-    id                   INTEGER PRIMARY KEY CHECK (id = 1),
-    default_session_mode TEXT NOT NULL DEFAULT 'tui'
-        CHECK (default_session_mode IN ('chat', 'tui')),
-    updated_at           TIMESTAMP NOT NULL
-)`); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`
-INSERT INTO app_settings (id, default_session_mode, updated_at)
-VALUES (1, ?, CURRENT_TIMESTAMP)`, defaultMode); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`DROP TABLE app_settings_legacy_before_0067_repair`); err != nil {
-		return err
-	}
-	if applied67 == 0 {
-		if _, err := tx.Exec(
-			`INSERT INTO goose_db_version (version_id, is_applied) VALUES (67, 1)`,
-		); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
 }
 
 // prepareAutoInjectReviewMigration preserves development databases whose

--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -155,6 +155,12 @@ func migrate(db *sql.DB) error {
 	if err := prepareQueuedTurnPromotionMigration(db); err != nil {
 		return fmt.Errorf("prepare queued-turn promotion migration: %w", err)
 	}
+	if err := prepareLegacyPipelineCDCBeforeReviewRunMigration(db); err != nil {
+		return fmt.Errorf("prepare legacy pipeline CDC migration: %w", err)
+	}
+	if err := prepareAppSettingsSingletonMigration(db); err != nil {
+		return fmt.Errorf("prepare app settings singleton migration: %w", err)
+	}
 	// Builds can advance a database past a migration that is added or
 	// renumbered later (notably across fast-moving Nightly releases). Apply
 	// those embedded migrations instead of permanently wedging daemon startup
@@ -163,6 +169,138 @@ func migrate(db *sql.DB) error {
 		return fmt.Errorf("run migrations: %w", err)
 	}
 	return reconcileSchema(db)
+}
+
+// prepareLegacyPipelineCDCBeforeReviewRunMigration repairs Nightly databases
+// that briefly carried the abandoned pipeline CDC schema. The 0103 migration
+// rebuilds change_log; SQLite refuses to drop that table while these old trigger
+// bodies still reference it, and any retained pipeline_* event rows would fail
+// 0103's narrower CHECK constraint.
+func prepareLegacyPipelineCDCBeforeReviewRunMigration(db *sql.DB) error {
+	var gooseTable int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'goose_db_version'`,
+	).Scan(&gooseTable); err != nil {
+		return err
+	}
+	if gooseTable == 0 {
+		return nil
+	}
+
+	var applied103 int
+	if err := db.QueryRow(`
+SELECT COALESCE((
+    SELECT is_applied FROM goose_db_version
+    WHERE version_id = 103 ORDER BY id DESC LIMIT 1
+), 0)`).Scan(&applied103); err != nil {
+		return err
+	}
+	if applied103 != 0 {
+		return nil
+	}
+
+	if _, err := db.Exec(`
+DROP TRIGGER IF EXISTS pipeline_definitions_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_definitions_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_definitions_cdc_delete;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_update;`); err != nil {
+		return err
+	}
+
+	var changeLogTable int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'change_log'`,
+	).Scan(&changeLogTable); err != nil {
+		return err
+	}
+	if changeLogTable == 0 {
+		return nil
+	}
+
+	_, err := db.Exec(`
+DELETE FROM change_log
+WHERE event_type IN (
+    'pipeline_definition_changed',
+    'pipeline_run_updated',
+    'pipeline_stage_run_updated',
+    'pipeline_artifact_updated'
+);`)
+	return err
+}
+
+// prepareAppSettingsSingletonMigration repairs development databases whose
+// app_settings table came from an older key/value experiment while 0067 is
+// already marked applied. Later migrations update the singleton row by id, so
+// normalize the physical schema before goose reaches those migrations.
+func prepareAppSettingsSingletonMigration(db *sql.DB) error {
+	var tableExists int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'app_settings'`,
+	).Scan(&tableExists); err != nil {
+		return err
+	}
+	if tableExists == 0 {
+		return nil
+	}
+
+	var idColumn, modeColumn, keyColumn, valueColumn int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'id'`,
+	).Scan(&idColumn); err != nil {
+		return err
+	}
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'default_session_mode'`,
+	).Scan(&modeColumn); err != nil {
+		return err
+	}
+	if idColumn > 0 && modeColumn > 0 {
+		return nil
+	}
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'key'`,
+	).Scan(&keyColumn); err != nil {
+		return err
+	}
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'value'`,
+	).Scan(&valueColumn); err != nil {
+		return err
+	}
+
+	var defaultMode string
+	if keyColumn > 0 && valueColumn > 0 {
+		if err := db.QueryRow(`
+SELECT COALESCE((
+    SELECT value FROM app_settings
+    WHERE key = 'default_session_mode' AND value IN ('chat', 'tui')
+    LIMIT 1
+), 'tui')`).Scan(&defaultMode); err != nil {
+			return err
+		}
+	} else {
+		defaultMode = "tui"
+	}
+
+	_, err := db.Exec(`
+BEGIN;
+ALTER TABLE app_settings RENAME TO app_settings_legacy_before_0067_repair;
+CREATE TABLE app_settings (
+    id                   INTEGER PRIMARY KEY CHECK (id = 1),
+    default_session_mode TEXT NOT NULL DEFAULT 'tui'
+        CHECK (default_session_mode IN ('chat', 'tui')),
+    updated_at           TIMESTAMP NOT NULL
+);
+INSERT INTO app_settings (id, default_session_mode, updated_at)
+VALUES (1, ?, CURRENT_TIMESTAMP);
+DROP TABLE app_settings_legacy_before_0067_repair;
+COMMIT;`, defaultMode)
+	return err
 }
 
 // prepareAutoInjectReviewMigration preserves development databases whose

--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -233,10 +233,12 @@ WHERE event_type IN (
 	return err
 }
 
-// prepareAppSettingsSingletonMigration repairs development databases whose
-// app_settings table came from an older key/value experiment while 0067 is
-// already marked applied. Later migrations update the singleton row by id, so
-// normalize the physical schema before goose reaches those migrations.
+// prepareAppSettingsSingletonMigration repairs feature-build databases whose
+// app_settings table came from the abandoned pipeline key/value migration. Some
+// of those databases already recorded 0067 through a burned migration profile;
+// the published PR build stopped at 0051 and has not. Recreate 0067's physical
+// schema and ledger effect together so goose neither skips a missing schema nor
+// replays CREATE TABLE over the repaired table.
 func prepareAppSettingsSingletonMigration(db *sql.DB) error {
 	var tableExists int
 	if err := db.QueryRow(
@@ -248,59 +250,99 @@ func prepareAppSettingsSingletonMigration(db *sql.DB) error {
 		return nil
 	}
 
-	var idColumn, modeColumn, keyColumn, valueColumn int
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'id'`,
-	).Scan(&idColumn); err != nil {
+	var columnCount, idColumn, modeColumn, updatedAtColumn, keyColumn, valueColumn int
+	if err := db.QueryRow(`
+SELECT COUNT(*),
+       SUM(name = 'id'),
+       SUM(name = 'default_session_mode'),
+       SUM(name = 'updated_at'),
+       SUM(name = 'key'),
+       SUM(name = 'value')
+FROM pragma_table_info('app_settings')`).Scan(
+		&columnCount,
+		&idColumn,
+		&modeColumn,
+		&updatedAtColumn,
+		&keyColumn,
+		&valueColumn,
+	); err != nil {
 		return err
 	}
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'default_session_mode'`,
-	).Scan(&modeColumn); err != nil {
-		return err
-	}
-	if idColumn > 0 && modeColumn > 0 {
+	if idColumn > 0 && modeColumn > 0 && updatedAtColumn > 0 {
 		return nil
 	}
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'key'`,
-	).Scan(&keyColumn); err != nil {
-		return err
-	}
-	if err := db.QueryRow(
-		`SELECT COUNT(*) FROM pragma_table_info('app_settings') WHERE name = 'value'`,
-	).Scan(&valueColumn); err != nil {
-		return err
+	if columnCount != 2 || keyColumn != 1 || valueColumn != 1 {
+		return fmt.Errorf(
+			"unsupported app_settings schema: columns=%d id=%d default_session_mode=%d updated_at=%d key=%d value=%d",
+			columnCount, idColumn, modeColumn, updatedAtColumn, keyColumn, valueColumn,
+		)
 	}
 
+	var gooseTable int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'goose_db_version'`,
+	).Scan(&gooseTable); err != nil {
+		return err
+	}
+	if gooseTable == 0 {
+		return fmt.Errorf("legacy app_settings schema exists without goose migration history")
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	var defaultMode string
-	if keyColumn > 0 && valueColumn > 0 {
-		if err := db.QueryRow(`
+	if err := tx.QueryRow(`
 SELECT COALESCE((
     SELECT value FROM app_settings
     WHERE key = 'default_session_mode' AND value IN ('chat', 'tui')
     LIMIT 1
 ), 'tui')`).Scan(&defaultMode); err != nil {
-			return err
-		}
-	} else {
-		defaultMode = "tui"
+		return err
 	}
 
-	_, err := db.Exec(`
-BEGIN;
-ALTER TABLE app_settings RENAME TO app_settings_legacy_before_0067_repair;
+	var applied67 int
+	if err := tx.QueryRow(`
+SELECT COALESCE((
+    SELECT is_applied FROM goose_db_version
+    WHERE version_id = 67 ORDER BY id DESC LIMIT 1
+), 0)`).Scan(&applied67); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(
+		`ALTER TABLE app_settings RENAME TO app_settings_legacy_before_0067_repair`,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
 CREATE TABLE app_settings (
     id                   INTEGER PRIMARY KEY CHECK (id = 1),
     default_session_mode TEXT NOT NULL DEFAULT 'tui'
         CHECK (default_session_mode IN ('chat', 'tui')),
     updated_at           TIMESTAMP NOT NULL
-);
+)`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
 INSERT INTO app_settings (id, default_session_mode, updated_at)
-VALUES (1, ?, CURRENT_TIMESTAMP);
-DROP TABLE app_settings_legacy_before_0067_repair;
-COMMIT;`, defaultMode)
-	return err
+VALUES (1, ?, CURRENT_TIMESTAMP)`, defaultMode); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DROP TABLE app_settings_legacy_before_0067_repair`); err != nil {
+		return err
+	}
+	if applied67 == 0 {
+		if _, err := tx.Exec(
+			`INSERT INTO goose_db_version (version_id, is_applied) VALUES (67, 1)`,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // prepareAutoInjectReviewMigration preserves development databases whose

--- a/backend/internal/storage/sqlite/legacy_pipeline_profile.go
+++ b/backend/internal/storage/sqlite/legacy_pipeline_profile.go
@@ -1,0 +1,796 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	legacyPipelineArchivePrefix  = "_ao_legacy_pr2863_"
+	legacyPipelineRecoveryMarker = legacyPipelineArchivePrefix + "recovery"
+	legacyPipelineProfileID      = "v0.11.1-pr2863.202607311655"
+)
+
+var legacyPipelineLineageVersions = []int64{45, 46, 50, 51}
+
+var legacyPipelineEventTypes = []string{
+	"pipeline_artifact_updated",
+	"pipeline_definition_changed",
+	"pipeline_run_updated",
+	"pipeline_stage_run_updated",
+}
+
+var publishedPipelineTableColumns = map[string][]string{
+	"pipeline_definitions": {
+		"id", "project_id", "name", "yaml_source", "config_json", "created_at", "updated_at",
+	},
+	"pipeline_runs": {
+		"id", "project_id", "pipeline_id", "pipeline_name", "subject_kind", "session_id",
+		"pr_number", "pr_repo", "pr_url", "head_sha", "pr_head_branch", "pr_base_branch",
+		"from_fork", "status", "run_dir", "definition_json", "cancel_reason", "created_at",
+		"updated_at", "settled_at", "run_number",
+	},
+	"pipeline_stage_runs": {
+		"run_id", "project_id", "stage_id", "outcome", "attempt", "entered_via", "prev_stage",
+		"failed_stage", "failed_outcome", "session_id", "workspace_kind", "workspace_path",
+		"deadline_at", "started_at", "settled_at", "reason", "output_tail", "nudged", "pgid",
+	},
+	"pipeline_stage_signals": {
+		"id", "run_id", "stage_id", "kind", "reason", "created_at",
+	},
+	"pipeline_credentials": {
+		"project_id", "name", "env_json", "created_at", "updated_at",
+	},
+}
+
+// Fingerprints are SHA-256 over lowercase, whitespace-collapsed sqlite_master
+// SQL from the frozen published-release fixture. Column lists above keep
+// diagnostics readable; these fingerprints also cover types, constraints,
+// defaults, foreign keys, and complete trigger bodies.
+var publishedPipelineSchemaFingerprints = map[string]string{ //nolint:gosec // SHA-256 schema fingerprints, not credentials.
+	"pipeline_credentials":              "5274a0c3e184e268f3b24b29b20884befe3699e91d90221ca49946eb5af10ae8",
+	"pipeline_definitions":              "8626c9a9e61637b225f994622555e5857beac4c12fb4a9b835c277f5c1fd8f9e",
+	"pipeline_runs":                     "b56c3d27fc0de0a399dfb7ed16b832dbd5926b748f2abe6e9dd7527597a93628",
+	"pipeline_stage_runs":               "41b69d599c0d7d1c0955f805931904f98925297c5e377600092f4d31f90495a9",
+	"pipeline_stage_signals":            "ec8e23a0bf7eff69dcc7d6b5b2e6a1de4b628d7ebb327ffd5ad1d73fb87d2084",
+	"pipeline_definitions_cdc_delete":   "f4c4fa4a1f7ed858134b5b216672d0f0fe80aa3a04f688183fe04faccd4584cf",
+	"pipeline_definitions_cdc_insert":   "eb8595ec69ca2050e0f9059099ba263ebcf19e59b90f70b08485111559299cb6",
+	"pipeline_definitions_cdc_update":   "54d3fc57cab96670089a2f350f3c1444f77ca94452831934001302019e6f92d2",
+	"pipeline_runs_cdc_insert":          "2d2629319f99708d40c93ac13bf9a95b3c46b2104ba094f68ea6e1c8d55a8d54",
+	"pipeline_runs_cdc_update":          "dc3a7b63333babd57baed224d0bf285bb45174cb8eb238f3d1fb5b455d92b494",
+	"pipeline_stage_runs_cdc_insert":    "2e3babe9ae8c0cee6b7cb679434f94c7fcbcd2f20c29ecd58796a9528483bac9",
+	"pipeline_stage_runs_cdc_update":    "0c461c9d2211109c9aaa05fd4d3aae2068ab759ee1061b8a9eaade31d4cdbe20",
+	"idx_pipeline_runs_number":          "f094a489d151e7233f30adba6aa0efd34878199e5960f65b320c2b6819a0c00f",
+	"idx_pipeline_runs_project_created": "507bf16ed0033fd54aa88340bda6750aca14d1c236002b6d2e59b54b6e73335b",
+	"idx_pipeline_runs_unsettled":       "60d439e5d2594f95e233baad8834020884cd5afb60edfaa901ba9a51b788e9ef",
+	"idx_pipeline_stage_signals_stage":  "917ad4b5afba41e68ac001942a24c29e729fca50efb783d5f1d0b2d19575c549",
+}
+
+type publishedPipelineIndex struct {
+	table string
+}
+
+var publishedPipelineIndexes = map[string]publishedPipelineIndex{
+	"idx_pipeline_runs_number":          {table: "pipeline_runs"},
+	"idx_pipeline_runs_project_created": {table: "pipeline_runs"},
+	"idx_pipeline_runs_unsettled":       {table: "pipeline_runs"},
+	"idx_pipeline_stage_signals_stage":  {table: "pipeline_stage_signals"},
+}
+
+type publishedPipelineTrigger struct {
+	table string
+}
+
+var publishedPipelineTriggers = map[string]publishedPipelineTrigger{
+	"pipeline_definitions_cdc_insert": {table: "pipeline_definitions"},
+	"pipeline_definitions_cdc_update": {table: "pipeline_definitions"},
+	"pipeline_definitions_cdc_delete": {table: "pipeline_definitions"},
+	"pipeline_runs_cdc_insert":        {table: "pipeline_runs"},
+	"pipeline_runs_cdc_update":        {table: "pipeline_runs"},
+	"pipeline_stage_runs_cdc_insert":  {table: "pipeline_stage_runs"},
+	"pipeline_stage_runs_cdc_update":  {table: "pipeline_stage_runs"},
+}
+
+type legacyProfileQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+type appSettingsProfile int
+
+const (
+	appSettingsAbsent appSettingsProfile = iota
+	appSettingsLegacyKeyValue
+	appSettingsCanonical
+)
+
+// retirePublishedPipelinesProfile retires the database profile created by the
+// published Pipelines feature release v0.11.1-pr2863.202607311655. Destructive
+// authority comes from migration versions that the feature release applied but
+// main never owned, followed by exact validation of every live legacy object.
+// Unknown or mixed profiles fail before the transaction performs any write.
+func retirePublishedPipelinesProfile(ctx context.Context, db *sql.DB) error {
+	gooseExists, err := legacyTableExists(ctx, db, "goose_db_version")
+	if err != nil || !gooseExists {
+		return err
+	}
+	completed, err := publishedPipelineRetirementRecorded(ctx, db)
+	if err != nil || completed {
+		return err
+	}
+
+	lineageCount, err := appliedLineageCount(ctx, db)
+	if err != nil {
+		return err
+	}
+	applied103, err := latestMigrationApplied(ctx, db, 103)
+	if err != nil {
+		return err
+	}
+	// Current-main databases cannot contain a live published-Pipelines profile:
+	// they have no foreign lineage and migration 103's CHECK constraint rejects
+	// the retired event types. Returning here also leaves future pipeline_* names
+	// outside this one-time compatibility shim's authority.
+	if lineageCount == 0 && applied103 {
+		return nil
+	}
+	hasHints, err := hasPublishedPipelineHints(ctx, db, !applied103)
+	if err != nil {
+		return err
+	}
+	if !hasHints {
+		return nil
+	}
+	if lineageCount != len(legacyPipelineLineageVersions) {
+		return fmt.Errorf(
+			"unsupported legacy Pipelines profile: %d/%d lineage migrations applied (need 45, 46, 50, and 51)",
+			lineageCount, len(legacyPipelineLineageVersions),
+		)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if count, err := appliedLineageCount(ctx, tx); err != nil {
+		return err
+	} else if count != len(legacyPipelineLineageVersions) {
+		return fmt.Errorf("legacy Pipelines lineage changed during recovery inspection")
+	}
+	if err := retirePublishedPipelinesProfileTx(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func retirePublishedPipelinesProfileTx(ctx context.Context, tx *sql.Tx) error {
+	completed, err := publishedPipelineRetirementRecorded(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if completed {
+		return nil
+	}
+	settingsProfile, err := inspectAppSettingsProfile(ctx, tx)
+	if err != nil {
+		return err
+	}
+	settingsArchive := legacyPipelineArchivePrefix + "app_settings"
+	settingsArchiveExists, err := legacyTableExists(ctx, tx, settingsArchive)
+	if err != nil {
+		return err
+	}
+	if settingsProfile == appSettingsAbsent {
+		return fmt.Errorf("unsupported legacy Pipelines profile: app_settings is missing")
+	}
+	if settingsProfile == appSettingsLegacyKeyValue && settingsArchiveExists {
+		return fmt.Errorf("unsupported legacy Pipelines profile: live and archived app_settings both exist")
+	}
+
+	defaultMode := ""
+	if settingsProfile == appSettingsLegacyKeyValue {
+		defaultMode, err = validateLegacyPipelineSettings(ctx, tx)
+		if err != nil {
+			return err
+		}
+	}
+
+	activeTables, err := inspectPublishedPipelineTables(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if err := inspectPublishedPipelineIndexes(ctx, tx, activeTables); err != nil {
+		return err
+	}
+	triggerNames, err := inspectPublishedPipelineTriggers(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	for _, table := range activeTables {
+		archive := legacyPipelineArchivePrefix + table
+		exists, err := legacyTableExists(ctx, tx, archive)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("unsupported legacy Pipelines profile: live and archived %s both exist", table)
+		}
+	}
+
+	changeLogExists, err := legacyTableExists(ctx, tx, "change_log")
+	if err != nil {
+		return err
+	}
+	if !changeLogExists {
+		return fmt.Errorf("unsupported legacy Pipelines profile: change_log is missing")
+	}
+	if err := validatePublishedPipelineEvents(ctx, tx); err != nil {
+		return err
+	}
+	archiveChangeLog := legacyPipelineArchivePrefix + "change_log"
+	archiveChangeLogExists, err := legacyTableExists(ctx, tx, archiveChangeLog)
+	if err != nil {
+		return err
+	}
+	livePipelineEvents, err := countPipelineEvents(ctx, tx, "change_log")
+	if err != nil {
+		return err
+	}
+	if archiveChangeLogExists && livePipelineEvents > 0 {
+		return fmt.Errorf("unsupported legacy Pipelines profile: live and archived pipeline change-log rows both exist")
+	}
+
+	applied67, err := latestMigrationApplied(ctx, tx, 67)
+	if err != nil {
+		return err
+	}
+	applied105, err := latestMigrationApplied(ctx, tx, 105)
+	if err != nil {
+		return err
+	}
+	if settingsProfile == appSettingsLegacyKeyValue {
+		if defaultMode == "" {
+			if applied105 {
+				defaultMode = "chat"
+			} else {
+				defaultMode = "tui"
+			}
+		}
+		if _, err := tx.ExecContext(ctx,
+			`ALTER TABLE app_settings RENAME TO `+quoteSQLiteIdent(settingsArchive),
+		); err != nil {
+			return fmt.Errorf("archive legacy app settings: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+CREATE TABLE app_settings (
+    id                   INTEGER PRIMARY KEY CHECK (id = 1),
+    default_session_mode TEXT NOT NULL DEFAULT 'tui'
+        CHECK (default_session_mode IN ('chat', 'tui')),
+    updated_at           TIMESTAMP NOT NULL
+);
+INSERT INTO app_settings (id, default_session_mode, updated_at)
+VALUES (1, ?, CURRENT_TIMESTAMP);`, defaultMode); err != nil {
+			return fmt.Errorf("create canonical app settings: %w", err)
+		}
+	}
+	if !applied67 {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO goose_db_version (version_id, is_applied) VALUES (67, 1)`,
+		); err != nil {
+			return fmt.Errorf("record app settings migration 67: %w", err)
+		}
+	}
+
+	if !archiveChangeLogExists {
+		if _, err := tx.ExecContext(ctx, `
+CREATE TABLE `+quoteSQLiteIdent(archiveChangeLog)+` AS
+SELECT seq, project_id, session_id, event_type, payload, created_at
+FROM change_log
+WHERE event_type IN (
+    'pipeline_definition_changed',
+    'pipeline_run_updated',
+    'pipeline_stage_run_updated',
+    'pipeline_artifact_updated'
+);`); err != nil {
+			return fmt.Errorf("archive legacy pipeline change log: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+DELETE FROM change_log
+WHERE event_type IN (
+    'pipeline_definition_changed',
+    'pipeline_run_updated',
+    'pipeline_stage_run_updated',
+    'pipeline_artifact_updated'
+);`); err != nil {
+		return fmt.Errorf("remove archived pipeline change-log rows: %w", err)
+	}
+
+	for _, name := range triggerNames {
+		if _, err := tx.ExecContext(ctx, `DROP TRIGGER `+quoteSQLiteIdent(name)); err != nil {
+			return fmt.Errorf("drop legacy pipeline trigger %s: %w", name, err)
+		}
+	}
+
+	for _, table := range activeTables {
+		archive := legacyPipelineArchivePrefix + table
+		if _, err := tx.ExecContext(ctx,
+			`CREATE TABLE `+quoteSQLiteIdent(archive)+` AS SELECT * FROM `+quoteSQLiteIdent(table),
+		); err != nil {
+			return fmt.Errorf("archive legacy pipeline table %s: %w", table, err)
+		}
+		var sourceRows, archivedRows int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM `+quoteSQLiteIdent(table),
+		).Scan(&sourceRows); err != nil {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM `+quoteSQLiteIdent(archive),
+		).Scan(&archivedRows); err != nil {
+			return err
+		}
+		if sourceRows != archivedRows {
+			return fmt.Errorf("archive legacy pipeline table %s: copied %d/%d rows", table, archivedRows, sourceRows)
+		}
+	}
+	for _, table := range []string{
+		"pipeline_stage_signals",
+		"pipeline_stage_runs",
+		"pipeline_credentials",
+		"pipeline_runs",
+		"pipeline_definitions",
+	} {
+		if !containsString(activeTables, table) {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `DROP TABLE `+quoteSQLiteIdent(table)); err != nil {
+			return fmt.Errorf("retire legacy pipeline table %s: %w", table, err)
+		}
+	}
+
+	if err := verifyPublishedPipelineRetirement(ctx, tx); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+CREATE TABLE `+quoteSQLiteIdent(legacyPipelineRecoveryMarker)+` (
+    profile_id   TEXT PRIMARY KEY,
+    completed_at TIMESTAMP NOT NULL
+);
+INSERT INTO `+quoteSQLiteIdent(legacyPipelineRecoveryMarker)+` (profile_id, completed_at)
+VALUES (?, CURRENT_TIMESTAMP);`, legacyPipelineProfileID); err != nil {
+		return fmt.Errorf("record legacy Pipelines retirement: %w", err)
+	}
+	return nil
+}
+
+func hasPublishedPipelineHints(ctx context.Context, q legacyProfileQuerier, inspectEvents bool) (bool, error) {
+	var objects int
+	if err := q.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM sqlite_master
+WHERE (type IN ('table', 'trigger') AND name GLOB 'pipeline_*')
+   OR (type = 'table' AND name GLOB ?)`, legacyPipelineArchivePrefix+"*").Scan(&objects); err != nil {
+		return false, err
+	}
+	if objects > 0 {
+		return true, nil
+	}
+	profile, err := inspectAppSettingsProfile(ctx, q)
+	if err != nil {
+		return false, err
+	}
+	if profile == appSettingsLegacyKeyValue {
+		return true, nil
+	}
+	if !inspectEvents {
+		return false, nil
+	}
+	changeLogExists, err := legacyTableExists(ctx, q, "change_log")
+	if err != nil || !changeLogExists {
+		return false, err
+	}
+	return hasPipelinePrefixedEvents(ctx, q)
+}
+
+func publishedPipelineRetirementRecorded(ctx context.Context, q legacyProfileQuerier) (bool, error) {
+	exists, err := legacyTableExists(ctx, q, legacyPipelineRecoveryMarker)
+	if err != nil || !exists {
+		return false, err
+	}
+	columns, err := legacyTableColumns(ctx, q, legacyPipelineRecoveryMarker)
+	if err != nil {
+		return false, err
+	}
+	if !equalStringSlices(columns, []string{"profile_id", "completed_at"}) {
+		return false, fmt.Errorf("invalid legacy Pipelines recovery marker columns: %v", columns)
+	}
+	var total, matching int
+	if err := q.QueryRowContext(ctx,
+		`SELECT COUNT(*), COUNT(*) FILTER (WHERE profile_id = ? AND completed_at IS NOT NULL)
+FROM `+quoteSQLiteIdent(legacyPipelineRecoveryMarker),
+		legacyPipelineProfileID,
+	).Scan(&total, &matching); err != nil {
+		return false, err
+	}
+	if total != 1 || matching != 1 {
+		return false, fmt.Errorf("invalid legacy Pipelines recovery marker contents")
+	}
+	return true, nil
+}
+
+func appliedLineageCount(ctx context.Context, q legacyProfileQuerier) (int, error) {
+	count := 0
+	for _, version := range legacyPipelineLineageVersions {
+		applied, err := latestMigrationApplied(ctx, q, version)
+		if err != nil {
+			return 0, err
+		}
+		if applied {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func latestMigrationApplied(ctx context.Context, q legacyProfileQuerier, version int64) (bool, error) {
+	var applied int
+	if err := q.QueryRowContext(ctx, `
+SELECT COALESCE((
+    SELECT is_applied FROM goose_db_version
+    WHERE version_id = ? ORDER BY id DESC LIMIT 1
+), 0)`, version).Scan(&applied); err != nil {
+		return false, err
+	}
+	return applied != 0, nil
+}
+
+func legacyTableExists(ctx context.Context, q legacyProfileQuerier, name string) (bool, error) {
+	var count int
+	if err := q.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name,
+	).Scan(&count); err != nil {
+		return false, err
+	}
+	return count != 0, nil
+}
+
+type legacyColumnInfo struct {
+	name       string
+	columnType string
+	notNull    int
+	primaryKey int
+}
+
+func inspectAppSettingsProfile(ctx context.Context, q legacyProfileQuerier) (appSettingsProfile, error) {
+	exists, err := legacyTableExists(ctx, q, "app_settings")
+	if err != nil || !exists {
+		return appSettingsAbsent, err
+	}
+	rows, err := q.QueryContext(ctx, `SELECT name, type, "notnull", pk FROM pragma_table_xinfo('app_settings') ORDER BY cid`)
+	if err != nil {
+		return appSettingsAbsent, err
+	}
+	defer func() { _ = rows.Close() }()
+	columns := []legacyColumnInfo{}
+	for rows.Next() {
+		var column legacyColumnInfo
+		if err := rows.Scan(&column.name, &column.columnType, &column.notNull, &column.primaryKey); err != nil {
+			return appSettingsAbsent, err
+		}
+		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return appSettingsAbsent, err
+	}
+	if len(columns) == 2 &&
+		columns[0].name == "key" && strings.EqualFold(columns[0].columnType, "TEXT") && columns[0].primaryKey == 1 &&
+		columns[1].name == "value" && strings.EqualFold(columns[1].columnType, "TEXT") && columns[1].notNull == 1 {
+		return appSettingsLegacyKeyValue, nil
+	}
+
+	required := map[string]bool{
+		"id":                   false,
+		"default_session_mode": false,
+		"updated_at":           false,
+	}
+	for _, column := range columns {
+		if _, ok := required[column.name]; ok {
+			required[column.name] = true
+		}
+	}
+	if required["id"] && required["default_session_mode"] && required["updated_at"] {
+		return appSettingsCanonical, nil
+	}
+	columnNames := make([]string, 0, len(columns))
+	for _, column := range columns {
+		columnNames = append(columnNames, column.name)
+	}
+	return appSettingsAbsent, fmt.Errorf("unsupported legacy Pipelines profile: app_settings columns are %v", columnNames)
+}
+
+func validateLegacyPipelineSettings(ctx context.Context, q legacyProfileQuerier) (string, error) {
+	rows, err := q.QueryContext(ctx, `SELECT key, value FROM app_settings ORDER BY key`)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = rows.Close() }()
+	defaultMode := ""
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return "", err
+		}
+		switch key {
+		case "pipelines.enabled":
+			if value != "true" && value != "false" {
+				return "", fmt.Errorf("unsupported legacy Pipelines setting pipelines.enabled=%q", value)
+			}
+		case "default_session_mode":
+			if value != "chat" && value != "tui" {
+				return "", fmt.Errorf("unsupported legacy Pipelines setting default_session_mode=%q", value)
+			}
+			defaultMode = value
+		default:
+			return "", fmt.Errorf("unsupported legacy Pipelines setting key %q", key)
+		}
+	}
+	return defaultMode, rows.Err()
+}
+
+func inspectPublishedPipelineTables(ctx context.Context, q legacyProfileQuerier) ([]string, error) {
+	rows, err := q.QueryContext(ctx, `
+SELECT name, COALESCE(sql, '') FROM sqlite_master
+WHERE type = 'table' AND name GLOB 'pipeline_*'
+ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	tables := []string{}
+	definitions := map[string]string{}
+	for rows.Next() {
+		var table, definition string
+		if err := rows.Scan(&table, &definition); err != nil {
+			return nil, err
+		}
+		tables = append(tables, table)
+		definitions[table] = definition
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for _, table := range tables {
+		want, ok := publishedPipelineTableColumns[table]
+		if !ok {
+			return nil, fmt.Errorf("unsupported legacy Pipelines table %q", table)
+		}
+		got, err := legacyTableColumns(ctx, q, table)
+		if err != nil {
+			return nil, err
+		}
+		if !equalStringSlices(got, want) {
+			return nil, fmt.Errorf("unsupported legacy Pipelines table %s columns: got %v, want %v", table, got, want)
+		}
+		if !matchesPublishedPipelineSchema(table, definitions[table]) {
+			return nil, fmt.Errorf("unsupported legacy Pipelines table definition %q", table)
+		}
+	}
+	return tables, nil
+}
+
+func inspectPublishedPipelineIndexes(ctx context.Context, q legacyProfileQuerier, activeTables []string) error {
+	rows, err := q.QueryContext(ctx, `
+SELECT name, tbl_name, COALESCE(sql, '')
+FROM sqlite_master
+WHERE type = 'index' AND tbl_name GLOB 'pipeline_*' AND sql IS NOT NULL
+ORDER BY name`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	found := map[string]bool{}
+	for rows.Next() {
+		var name, table, definition string
+		if err := rows.Scan(&name, &table, &definition); err != nil {
+			return err
+		}
+		spec, ok := publishedPipelineIndexes[name]
+		if !ok || table != spec.table || !matchesPublishedPipelineSchema(name, definition) {
+			return fmt.Errorf("unsupported legacy Pipelines index %q", name)
+		}
+		found[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for name, spec := range publishedPipelineIndexes {
+		if containsString(activeTables, spec.table) && !found[name] {
+			return fmt.Errorf("unsupported legacy Pipelines profile: index %q is missing", name)
+		}
+	}
+	return nil
+}
+
+func inspectPublishedPipelineTriggers(ctx context.Context, q legacyProfileQuerier) ([]string, error) {
+	rows, err := q.QueryContext(ctx, `
+SELECT name, tbl_name, COALESCE(sql, '')
+FROM sqlite_master
+WHERE type = 'trigger'
+  AND (name GLOB 'pipeline_*' OR tbl_name GLOB 'pipeline_*')
+ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	names := []string{}
+	for rows.Next() {
+		var name, table, definition string
+		if err := rows.Scan(&name, &table, &definition); err != nil {
+			return nil, err
+		}
+		spec, ok := publishedPipelineTriggers[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported legacy Pipelines trigger %q", name)
+		}
+		if table != spec.table || !matchesPublishedPipelineSchema(name, definition) {
+			return nil, fmt.Errorf("unsupported legacy Pipelines trigger definition %q", name)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+func legacyTableColumns(ctx context.Context, q legacyProfileQuerier, table string) ([]string, error) {
+	rows, err := q.QueryContext(ctx, `SELECT name FROM pragma_table_xinfo(?) ORDER BY cid`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	columns := []string{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		columns = append(columns, name)
+	}
+	return columns, rows.Err()
+}
+
+func hasPipelinePrefixedEvents(ctx context.Context, q legacyProfileQuerier) (bool, error) {
+	var found int
+	if err := q.QueryRowContext(ctx, `
+SELECT EXISTS (
+    SELECT 1 FROM change_log WHERE event_type GLOB 'pipeline_*' LIMIT 1
+)`).Scan(&found); err != nil {
+		return false, err
+	}
+	return found != 0, nil
+}
+
+func validatePublishedPipelineEvents(ctx context.Context, q legacyProfileQuerier) error {
+	rows, err := q.QueryContext(ctx, `
+SELECT DISTINCT event_type
+FROM change_log
+WHERE event_type GLOB 'pipeline_*'
+ORDER BY event_type`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var eventType string
+		if err := rows.Scan(&eventType); err != nil {
+			return err
+		}
+		if !containsString(legacyPipelineEventTypes, eventType) {
+			return fmt.Errorf("unsupported legacy Pipelines change-log event type %q", eventType)
+		}
+	}
+	return rows.Err()
+}
+
+func countPipelineEvents(ctx context.Context, q legacyProfileQuerier, table string) (int, error) {
+	var count int
+	query := `SELECT COUNT(*) FROM ` + quoteSQLiteIdent(table) + ` WHERE event_type IN (?, ?, ?, ?)`
+	if err := q.QueryRowContext(ctx, query,
+		legacyPipelineEventTypes[0],
+		legacyPipelineEventTypes[1],
+		legacyPipelineEventTypes[2],
+		legacyPipelineEventTypes[3],
+	).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func verifyPublishedPipelineRetirement(ctx context.Context, q legacyProfileQuerier) error {
+	profile, err := inspectAppSettingsProfile(ctx, q)
+	if err != nil {
+		return err
+	}
+	if profile != appSettingsCanonical {
+		return fmt.Errorf("legacy Pipelines recovery left app_settings noncanonical")
+	}
+	applied67, err := latestMigrationApplied(ctx, q, 67)
+	if err != nil {
+		return err
+	}
+	if !applied67 {
+		return fmt.Errorf("legacy Pipelines recovery did not record migration 67")
+	}
+	activeTables, err := inspectPublishedPipelineTables(ctx, q)
+	if err != nil {
+		return err
+	}
+	if len(activeTables) != 0 {
+		return fmt.Errorf("legacy Pipelines recovery left active tables %v", activeTables)
+	}
+	triggers, err := inspectPublishedPipelineTriggers(ctx, q)
+	if err != nil {
+		return err
+	}
+	if len(triggers) != 0 {
+		return fmt.Errorf("legacy Pipelines recovery left active triggers %v", triggers)
+	}
+	changeLogExists, err := legacyTableExists(ctx, q, "change_log")
+	if err != nil {
+		return err
+	}
+	if changeLogExists {
+		count, err := countPipelineEvents(ctx, q, "change_log")
+		if err != nil {
+			return err
+		}
+		if count != 0 {
+			return fmt.Errorf("legacy Pipelines recovery left %d live pipeline change-log rows", count)
+		}
+	}
+	rows, err := q.QueryContext(ctx, `PRAGMA foreign_key_check`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	if rows.Next() {
+		return fmt.Errorf("legacy Pipelines recovery failed foreign-key verification")
+	}
+	return rows.Err()
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(values []string, target string) bool {
+	i := sort.SearchStrings(values, target)
+	return i < len(values) && values[i] == target
+}
+
+func matchesPublishedPipelineSchema(name, definition string) bool {
+	want, ok := publishedPipelineSchemaFingerprints[name]
+	if !ok {
+		return false
+	}
+	normalized := strings.Join(strings.Fields(strings.ToLower(definition)), " ")
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:]) == want
+}

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -120,6 +120,9 @@ var shippedMigrations = map[int64]string{
 // new file claiming one would be skipped silently there.
 //
 //   - 22 shipped in a nightly (#2412) and was deleted by the revert.
+//   - 45, 46, 50, and 51 were applied by the published Pipelines feature
+//     release v0.11.1-pr2863.202607311655. Main never owned those slots, but
+//     real databases retain them and would skip any future reuse.
 //
 // Beware of the adjacent hazard this cannot catch: at least one field profile
 // has versions 40 through 51 recorded as applied by a foreign build
@@ -127,7 +130,12 @@ var shippedMigrations = map[int64]string{
 // Any such migration whose schema the generated queries depend on must add a
 // schemaRepairs entry in db.go.
 func burnedVersion(v int64) bool {
-	return v == 22
+	switch v {
+	case 22, 45, 46, 50, 51:
+		return true
+	default:
+		return false
+	}
 }
 
 // TestMigrationVersionLedger enforces the append-only migration ledger: every

--- a/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
+++ b/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
@@ -1,0 +1,97 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestMigration0103DropsLegacyPipelineCDCTriggers(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 102)
+
+	// A short-lived pipeline branch created CDC triggers under a burned migration
+	// number. Those triggers keep referencing change_log when 0103 rebuilds it.
+	if _, err := db.Exec(`
+CREATE TABLE pipeline_definitions (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    yaml_source TEXT NOT NULL,
+    config_json TEXT NOT NULL CHECK (json_valid(config_json)),
+    created_at  TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP NOT NULL
+);
+CREATE TRIGGER pipeline_definitions_cdc_insert
+AFTER INSERT ON pipeline_definitions
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_definition_changed',
+        json_object('id', NEW.id, 'name', NEW.name, 'change', 'created'),
+        NEW.updated_at);
+END;
+`); err != nil {
+		t.Fatalf("seed legacy pipeline trigger: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate database with legacy pipeline CDC trigger: %v", err)
+	}
+
+	var triggerCount, applied103 int
+	if err := db.QueryRow(`
+SELECT COUNT(*) FROM sqlite_master
+WHERE type = 'trigger' AND name = 'pipeline_definitions_cdc_insert'`).Scan(&triggerCount); err != nil {
+		t.Fatalf("read legacy trigger count: %v", err)
+	}
+	if err := db.QueryRow(`
+SELECT COUNT(*) FROM goose_db_version
+WHERE version_id = 103 AND is_applied = 1`).Scan(&applied103); err != nil {
+		t.Fatalf("read migration 103 ledger: %v", err)
+	}
+	if triggerCount != 0 || applied103 != 1 {
+		t.Fatalf("legacy trigger count = %d, applied 103 entries = %d; want 0, 1", triggerCount, applied103)
+	}
+}
+
+func TestMigrateRepairsLegacyKeyValueAppSettings(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 66)
+
+	if _, err := db.Exec(`
+CREATE TABLE app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+INSERT INTO app_settings (key, value) VALUES ('default_session_mode', 'tui');
+INSERT INTO goose_db_version (version_id, is_applied) VALUES (67, 1);
+`); err != nil {
+		t.Fatalf("seed legacy key/value app settings: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate database with legacy app settings: %v", err)
+	}
+
+	wantColumns := []string{"id", "default_session_mode", "updated_at"}
+	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, wantColumns) {
+		t.Fatalf("app_settings columns = %v, want %v", got, wantColumns)
+	}
+
+	var mode string
+	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
+		t.Fatalf("read repaired default session mode: %v", err)
+	}
+	if mode != "chat" {
+		t.Fatalf("default session mode = %q, want chat after 0105", mode)
+	}
+}

--- a/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
+++ b/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
@@ -18,6 +18,8 @@ func TestMigration0103DropsLegacyPipelineCDCTriggers(t *testing.T) {
 	// A short-lived pipeline branch created CDC triggers under a burned migration
 	// number. Those triggers keep referencing change_log when 0103 rebuilds it.
 	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at)
+VALUES ('pipeline-project', '/tmp/pipeline-project', CURRENT_TIMESTAMP);
 CREATE TABLE pipeline_definitions (
     id          TEXT PRIMARY KEY,
     project_id  TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
@@ -38,60 +40,132 @@ END;
 `); err != nil {
 		t.Fatalf("seed legacy pipeline trigger: %v", err)
 	}
+	if _, err := db.Exec(`PRAGMA ignore_check_constraints = ON`); err != nil {
+		t.Fatalf("allow legacy pipeline event: %v", err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO change_log (project_id, event_type, payload, created_at)
+VALUES ('pipeline-project', 'pipeline_definition_changed', '{}', CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatalf("seed legacy pipeline event: %v", err)
+	}
+	if _, err := db.Exec(`PRAGMA ignore_check_constraints = OFF`); err != nil {
+		t.Fatalf("restore check constraints: %v", err)
+	}
 
 	if err := migrate(db); err != nil {
 		t.Fatalf("migrate database with legacy pipeline CDC trigger: %v", err)
 	}
 
-	var triggerCount, applied103 int
+	var triggerCount, legacyEventCount, applied103 int
 	if err := db.QueryRow(`
 SELECT COUNT(*) FROM sqlite_master
 WHERE type = 'trigger' AND name = 'pipeline_definitions_cdc_insert'`).Scan(&triggerCount); err != nil {
 		t.Fatalf("read legacy trigger count: %v", err)
 	}
 	if err := db.QueryRow(`
+SELECT COUNT(*) FROM change_log
+WHERE event_type = 'pipeline_definition_changed'`).Scan(&legacyEventCount); err != nil {
+		t.Fatalf("read legacy event count: %v", err)
+	}
+	if err := db.QueryRow(`
 SELECT COUNT(*) FROM goose_db_version
 WHERE version_id = 103 AND is_applied = 1`).Scan(&applied103); err != nil {
 		t.Fatalf("read migration 103 ledger: %v", err)
 	}
-	if triggerCount != 0 || applied103 != 1 {
-		t.Fatalf("legacy trigger count = %d, applied 103 entries = %d; want 0, 1", triggerCount, applied103)
+	if triggerCount != 0 || legacyEventCount != 0 || applied103 != 1 {
+		t.Fatalf(
+			"legacy trigger count = %d, event count = %d, applied 103 entries = %d; want 0, 0, 1",
+			triggerCount, legacyEventCount, applied103,
+		)
 	}
 }
 
 func TestMigrateRepairsLegacyKeyValueAppSettings(t *testing.T) {
-	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	upTo(t, db, 66)
+	for _, tc := range []struct {
+		name      string
+		applied67 bool
+	}{
+		{name: "before migration 0067"},
+		{name: "with burned migration 0067", applied67: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+			if err != nil {
+				t.Fatalf("open sqlite: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			upTo(t, db, 51)
 
-	if _, err := db.Exec(`
+			if _, err := db.Exec(`
 CREATE TABLE app_settings (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
 INSERT INTO app_settings (key, value) VALUES ('default_session_mode', 'tui');
-INSERT INTO goose_db_version (version_id, is_applied) VALUES (67, 1);
 `); err != nil {
-		t.Fatalf("seed legacy key/value app settings: %v", err)
+				t.Fatalf("seed legacy key/value app settings: %v", err)
+			}
+			if tc.applied67 {
+				if _, err := db.Exec(
+					`INSERT INTO goose_db_version (version_id, is_applied) VALUES (67, 1)`,
+				); err != nil {
+					t.Fatalf("seed burned migration 67: %v", err)
+				}
+			}
+
+			if err := migrate(db); err != nil {
+				t.Fatalf("migrate database with legacy app settings: %v", err)
+			}
+
+			wantColumns := []string{"id", "default_session_mode", "updated_at"}
+			if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, wantColumns) {
+				t.Fatalf("app_settings columns = %v, want %v", got, wantColumns)
+			}
+
+			var mode string
+			if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
+				t.Fatalf("read repaired default session mode: %v", err)
+			}
+			if mode != "chat" {
+				t.Fatalf("default session mode = %q, want chat after 0105", mode)
+			}
+
+			var applied67 int
+			if err := db.QueryRow(`
+SELECT COUNT(*) FROM goose_db_version
+WHERE version_id = 67 AND is_applied = 1`).Scan(&applied67); err != nil {
+				t.Fatalf("read migration 67 ledger: %v", err)
+			}
+			if applied67 != 1 {
+				t.Fatalf("applied migration 67 entries = %d, want 1", applied67)
+			}
+		})
+	}
+}
+
+func TestPrepareAppSettingsSingletonMigrationRejectsPartialSchema(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 51)
+
+	if _, err := db.Exec(`
+CREATE TABLE app_settings (
+    id                   INTEGER PRIMARY KEY CHECK (id = 1),
+    default_session_mode TEXT NOT NULL
+);`); err != nil {
+		t.Fatalf("seed partial app settings: %v", err)
 	}
 
-	if err := migrate(db); err != nil {
-		t.Fatalf("migrate database with legacy app settings: %v", err)
+	err = prepareAppSettingsSingletonMigration(db)
+	if err == nil {
+		t.Fatal("prepare partial app settings schema succeeded, want error")
 	}
 
-	wantColumns := []string{"id", "default_session_mode", "updated_at"}
+	wantColumns := []string{"id", "default_session_mode"}
 	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, wantColumns) {
-		t.Fatalf("app_settings columns = %v, want %v", got, wantColumns)
-	}
-
-	var mode string
-	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
-		t.Fatalf("read repaired default session mode: %v", err)
-	}
-	if mode != "chat" {
-		t.Fatalf("default session mode = %q, want chat after 0105", mode)
+		t.Fatalf("app_settings columns after rejected repair = %v, want %v", got, wantColumns)
 	}
 }

--- a/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
+++ b/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
@@ -2,170 +2,479 @@ package sqlite
 
 import (
 	"database/sql"
+	"embed"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/pressly/goose/v3"
 )
 
-func TestMigration0103DropsLegacyPipelineCDCTriggers(t *testing.T) {
-	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+// These migrations are frozen verbatim from the published Pipelines feature
+// release v0.11.1-pr2863.202607311655. Migrations 0001-0039 are byte-identical
+// to main, so applying main through 0039 and this fixture through 0051 produces
+// the real foreign migration profile that reached users.
+//
+//go:embed testdata/pipeline_pr2863_migrations/*.sql
+var pipelinePR2863Migrations embed.FS
+
+func TestOpenUpgradesPublishedPipelineProfileWithoutLosingData(t *testing.T) {
+	dataDir := t.TempDir()
+	seedPublishedPipelineProfile(t, dataDir)
+
+	store, err := Open(dataDir)
 	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
+		t.Fatalf("open published Pipelines profile: %v", err)
 	}
-	t.Cleanup(func() { _ = db.Close() })
-	upTo(t, db, 102)
-
-	// A short-lived pipeline branch created CDC triggers under a burned migration
-	// number. Those triggers keep referencing change_log when 0103 rebuilds it.
-	if _, err := db.Exec(`
-INSERT INTO projects (id, path, registered_at)
-VALUES ('pipeline-project', '/tmp/pipeline-project', CURRENT_TIMESTAMP);
-CREATE TABLE pipeline_definitions (
-    id          TEXT PRIMARY KEY,
-    project_id  TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
-    name        TEXT NOT NULL,
-    yaml_source TEXT NOT NULL,
-    config_json TEXT NOT NULL CHECK (json_valid(config_json)),
-    created_at  TIMESTAMP NOT NULL,
-    updated_at  TIMESTAMP NOT NULL
-);
-CREATE TRIGGER pipeline_definitions_cdc_insert
-AFTER INSERT ON pipeline_definitions
-BEGIN
-    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
-    VALUES (NEW.project_id, NULL, 'pipeline_definition_changed',
-        json_object('id', NEW.id, 'name', NEW.name, 'change', 'created'),
-        NEW.updated_at);
-END;
-`); err != nil {
-		t.Fatalf("seed legacy pipeline trigger: %v", err)
-	}
-	if _, err := db.Exec(`PRAGMA ignore_check_constraints = ON`); err != nil {
-		t.Fatalf("allow legacy pipeline event: %v", err)
-	}
-	if _, err := db.Exec(`
-INSERT INTO change_log (project_id, event_type, payload, created_at)
-VALUES ('pipeline-project', 'pipeline_definition_changed', '{}', CURRENT_TIMESTAMP)`); err != nil {
-		t.Fatalf("seed legacy pipeline event: %v", err)
-	}
-	if _, err := db.Exec(`PRAGMA ignore_check_constraints = OFF`); err != nil {
-		t.Fatalf("restore check constraints: %v", err)
+	if err := store.Close(); err != nil {
+		t.Fatalf("close upgraded store: %v", err)
 	}
 
-	if err := migrate(db); err != nil {
-		t.Fatalf("migrate database with legacy pipeline CDC trigger: %v", err)
+	db := openPipelineProfileCheckDB(t, dataDir)
+	assertPublishedPipelineProfileRetired(t, db)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close upgraded check database: %v", err)
 	}
 
-	var triggerCount, legacyEventCount, applied103 int
-	if err := db.QueryRow(`
-SELECT COUNT(*) FROM sqlite_master
-WHERE type = 'trigger' AND name = 'pipeline_definitions_cdc_insert'`).Scan(&triggerCount); err != nil {
-		t.Fatalf("read legacy trigger count: %v", err)
+	// Recovery and ordinary migrations are both idempotent across a real second
+	// startup; archived rows must not be duplicated or discarded.
+	store, err = Open(dataDir)
+	if err != nil {
+		t.Fatalf("reopen upgraded Pipelines profile: %v", err)
 	}
-	if err := db.QueryRow(`
-SELECT COUNT(*) FROM change_log
-WHERE event_type = 'pipeline_definition_changed'`).Scan(&legacyEventCount); err != nil {
-		t.Fatalf("read legacy event count: %v", err)
+	if err := store.Close(); err != nil {
+		t.Fatalf("close reopened store: %v", err)
 	}
-	if err := db.QueryRow(`
-SELECT COUNT(*) FROM goose_db_version
-WHERE version_id = 103 AND is_applied = 1`).Scan(&applied103); err != nil {
-		t.Fatalf("read migration 103 ledger: %v", err)
-	}
-	if triggerCount != 0 || legacyEventCount != 0 || applied103 != 1 {
-		t.Fatalf(
-			"legacy trigger count = %d, event count = %d, applied 103 entries = %d; want 0, 0, 1",
-			triggerCount, legacyEventCount, applied103,
-		)
-	}
+	db = openPipelineProfileCheckDB(t, dataDir)
+	defer func() { _ = db.Close() }()
+	assertPublishedPipelineProfileRetired(t, db)
 }
 
-func TestMigrateRepairsLegacyKeyValueAppSettings(t *testing.T) {
+func TestOpenRejectsUnknownPublishedPipelineSettingWithoutMutation(t *testing.T) {
+	dataDir := t.TempDir()
+	seedPublishedPipelineProfile(t, dataDir)
+
+	db := openPipelineProfileCheckDB(t, dataDir)
+	if _, err := db.Exec(
+		`INSERT INTO app_settings (key, value) VALUES ('future.feature.enabled', 'true')`,
+	); err != nil {
+		t.Fatalf("seed unknown legacy setting: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close profile with unknown setting: %v", err)
+	}
+
+	store, err := Open(dataDir)
+	if err == nil {
+		_ = store.Close()
+		t.Fatal("open profile with unknown legacy setting succeeded, want fail-closed error")
+	}
+	if !strings.Contains(err.Error(), "future.feature.enabled") {
+		t.Fatalf("open error = %q, want unknown setting key", err)
+	}
+
+	db = openPipelineProfileCheckDB(t, dataDir)
+	defer func() { _ = db.Close() }()
+	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, []string{"key", "value"}) {
+		t.Fatalf("app_settings columns after rejected recovery = %v, want untouched key/value schema", got)
+	}
+	assertCount(t, db, `SELECT COUNT(*) FROM app_settings`, 2)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'pipeline_%'`, 5)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'pipeline_%_cdc_%'`, 7)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_ao_legacy_pr2863_app_settings'`, 0)
+}
+
+func TestOpenRejectsUnknownPublishedPipelineCDCWithoutMutation(t *testing.T) {
+	t.Run("event type", func(t *testing.T) {
+		dataDir := t.TempDir()
+		seedPublishedPipelineProfile(t, dataDir)
+		db := openPipelineProfileCheckDB(t, dataDir)
+		if _, err := db.Exec(`
+PRAGMA ignore_check_constraints = ON;
+INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+VALUES ('legacy-project', NULL, 'pipeline_future_event', '{}', '2026-07-31T17:01:00Z');
+PRAGMA ignore_check_constraints = OFF;
+`); err != nil {
+			_ = db.Close()
+			t.Fatalf("seed unknown pipeline event: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close profile with unknown pipeline event: %v", err)
+		}
+
+		store, err := Open(dataDir)
+		if err == nil {
+			_ = store.Close()
+			t.Fatal("open profile with unknown pipeline event succeeded")
+		}
+		if !strings.Contains(err.Error(), "pipeline_future_event") {
+			t.Fatalf("open error = %q, want unknown pipeline event", err)
+		}
+		assertPublishedPipelineProfileUntouched(t, dataDir)
+	})
+
+	t.Run("trigger", func(t *testing.T) {
+		dataDir := t.TempDir()
+		seedPublishedPipelineProfile(t, dataDir)
+		db := openPipelineProfileCheckDB(t, dataDir)
+		if _, err := db.Exec(`
+CREATE TRIGGER pipeline_custom_cdc
+AFTER UPDATE ON sessions
+BEGIN
+    SELECT 1;
+END;
+`); err != nil {
+			_ = db.Close()
+			t.Fatalf("seed unknown pipeline trigger: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close profile with unknown pipeline trigger: %v", err)
+		}
+
+		store, err := Open(dataDir)
+		if err == nil {
+			_ = store.Close()
+			t.Fatal("open profile with unknown pipeline trigger succeeded")
+		}
+		if !strings.Contains(err.Error(), "pipeline_custom_cdc") {
+			t.Fatalf("open error = %q, want unknown pipeline trigger", err)
+		}
+		assertPublishedPipelineProfileUntouched(t, dataDir)
+	})
+
+	t.Run("modified published trigger", func(t *testing.T) {
+		dataDir := t.TempDir()
+		seedPublishedPipelineProfile(t, dataDir)
+		db := openPipelineProfileCheckDB(t, dataDir)
+		var definition string
+		if err := db.QueryRow(`
+SELECT sql FROM sqlite_master
+WHERE type = 'trigger' AND name = 'pipeline_runs_cdc_update'`).Scan(&definition); err != nil {
+			_ = db.Close()
+			t.Fatalf("read published trigger: %v", err)
+		}
+		modified := strings.TrimSuffix(definition, "END") + "    SELECT 1;\nEND"
+		if _, err := db.Exec(`DROP TRIGGER pipeline_runs_cdc_update`); err != nil {
+			_ = db.Close()
+			t.Fatalf("drop published trigger: %v", err)
+		}
+		if _, err := db.Exec(modified); err != nil {
+			_ = db.Close()
+			t.Fatalf("seed modified published trigger: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close profile with modified published trigger: %v", err)
+		}
+
+		store, err := Open(dataDir)
+		if err == nil {
+			_ = store.Close()
+			t.Fatal("open profile with modified published trigger succeeded")
+		}
+		if !strings.Contains(err.Error(), "pipeline_runs_cdc_update") {
+			t.Fatalf("open error = %q, want modified pipeline trigger", err)
+		}
+		assertPublishedPipelineProfileUntouched(t, dataDir)
+	})
+}
+
+func TestOpenDoesNotClaimFuturePipelineSchema(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		applied67 bool
+		name  string
+		setup func(*testing.T, string)
 	}{
-		{name: "before migration 0067"},
-		{name: "with burned migration 0067", applied67: true},
+		{
+			name: "healthy main database",
+			setup: func(t *testing.T, dataDir string) {
+				store, err := Open(dataDir)
+				if err != nil {
+					t.Fatalf("create healthy main database: %v", err)
+				}
+				if err := store.Close(); err != nil {
+					t.Fatalf("close healthy main database: %v", err)
+				}
+			},
+		},
+		{
+			name: "retired published profile",
+			setup: func(t *testing.T, dataDir string) {
+				seedPublishedPipelineProfile(t, dataDir)
+				store, err := Open(dataDir)
+				if err != nil {
+					t.Fatalf("retire published profile: %v", err)
+				}
+				if err := store.Close(); err != nil {
+					t.Fatalf("close retired published profile: %v", err)
+				}
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+			dataDir := t.TempDir()
+			tc.setup(t, dataDir)
+			db := openPipelineProfileCheckDB(t, dataDir)
+			if _, err := db.Exec(`CREATE TABLE pipeline_future_state (id TEXT PRIMARY KEY)`); err != nil {
+				_ = db.Close()
+				t.Fatalf("create future pipeline schema: %v", err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("close future pipeline database: %v", err)
+			}
+
+			store, err := Open(dataDir)
 			if err != nil {
-				t.Fatalf("open sqlite: %v", err)
+				t.Fatalf("reopen with future pipeline schema: %v", err)
 			}
-			t.Cleanup(func() { _ = db.Close() })
-			upTo(t, db, 51)
-
-			if _, err := db.Exec(`
-CREATE TABLE app_settings (
-    key   TEXT PRIMARY KEY,
-    value TEXT NOT NULL
-);
-INSERT INTO app_settings (key, value) VALUES ('default_session_mode', 'tui');
-`); err != nil {
-				t.Fatalf("seed legacy key/value app settings: %v", err)
+			if err := store.Close(); err != nil {
+				t.Fatalf("close reopened future pipeline database: %v", err)
 			}
-			if tc.applied67 {
-				if _, err := db.Exec(
-					`INSERT INTO goose_db_version (version_id, is_applied) VALUES (67, 1)`,
-				); err != nil {
-					t.Fatalf("seed burned migration 67: %v", err)
-				}
-			}
-
-			if err := migrate(db); err != nil {
-				t.Fatalf("migrate database with legacy app settings: %v", err)
-			}
-
-			wantColumns := []string{"id", "default_session_mode", "updated_at"}
-			if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, wantColumns) {
-				t.Fatalf("app_settings columns = %v, want %v", got, wantColumns)
-			}
-
-			var mode string
-			if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
-				t.Fatalf("read repaired default session mode: %v", err)
-			}
-			if mode != "chat" {
-				t.Fatalf("default session mode = %q, want chat after 0105", mode)
-			}
-
-			var applied67 int
-			if err := db.QueryRow(`
-SELECT COUNT(*) FROM goose_db_version
-WHERE version_id = 67 AND is_applied = 1`).Scan(&applied67); err != nil {
-				t.Fatalf("read migration 67 ledger: %v", err)
-			}
-			if applied67 != 1 {
-				t.Fatalf("applied migration 67 entries = %d, want 1", applied67)
-			}
+			db = openPipelineProfileCheckDB(t, dataDir)
+			defer func() { _ = db.Close() }()
+			assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'pipeline_future_state'`, 1)
 		})
 	}
 }
 
-func TestPrepareAppSettingsSingletonMigrationRejectsPartialSchema(t *testing.T) {
-	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+func TestOpenRejectsUnrecognizedKeyValueSettingsProfileWithoutMutation(t *testing.T) {
+	dataDir := t.TempDir()
+	db := openPipelineProfileCheckDB(t, dataDir)
 	upTo(t, db, 51)
-
 	if _, err := db.Exec(`
 CREATE TABLE app_settings (
-    id                   INTEGER PRIMARY KEY CHECK (id = 1),
-    default_session_mode TEXT NOT NULL
-);`); err != nil {
-		t.Fatalf("seed partial app settings: %v", err)
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+INSERT INTO app_settings (key, value) VALUES ('pipelines.enabled', 'true');
+`); err != nil {
+		t.Fatalf("seed unrecognized key/value settings profile: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close unrecognized settings profile: %v", err)
 	}
 
-	err = prepareAppSettingsSingletonMigration(db)
+	store, err := Open(dataDir)
 	if err == nil {
-		t.Fatal("prepare partial app settings schema succeeded, want error")
+		_ = store.Close()
+		t.Fatal("open unrecognized key/value settings profile succeeded, want fail-closed error")
+	}
+	if !strings.Contains(err.Error(), "0/4 lineage migrations") {
+		t.Fatalf("open error = %q, want missing-lineage diagnostic", err)
 	}
 
-	wantColumns := []string{"id", "default_session_mode"}
-	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, wantColumns) {
-		t.Fatalf("app_settings columns after rejected repair = %v, want %v", got, wantColumns)
+	db = openPipelineProfileCheckDB(t, dataDir)
+	defer func() { _ = db.Close() }()
+	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, []string{"key", "value"}) {
+		t.Fatalf("app_settings columns after rejected profile = %v, want untouched key/value schema", got)
+	}
+	assertCount(t, db, `SELECT COUNT(*) FROM app_settings WHERE key = 'pipelines.enabled' AND value = 'true'`, 1)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE name GLOB '_ao_legacy_pr2863_*'`, 0)
+}
+
+func TestOpenRollsBackPublishedPipelineRecoveryOnFailure(t *testing.T) {
+	dataDir := t.TempDir()
+	seedPublishedPipelineProfile(t, dataDir)
+	db := openPipelineProfileCheckDB(t, dataDir)
+	if _, err := db.Exec(`
+CREATE TRIGGER reject_pipeline_profile_recovery_0067
+BEFORE INSERT ON goose_db_version
+WHEN NEW.version_id = 67
+BEGIN
+    SELECT RAISE(ABORT, 'forced migration 67 ledger failure');
+END;
+`); err != nil {
+		t.Fatalf("seed recovery failure: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close profile with recovery failure: %v", err)
+	}
+
+	store, err := Open(dataDir)
+	if err == nil {
+		_ = store.Close()
+		t.Fatal("open profile with forced recovery failure succeeded")
+	}
+	if !strings.Contains(err.Error(), "forced migration 67 ledger failure") {
+		t.Fatalf("open error = %q, want forced ledger failure", err)
+	}
+
+	db = openPipelineProfileCheckDB(t, dataDir)
+	defer func() { _ = db.Close() }()
+	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, []string{"key", "value"}) {
+		t.Fatalf("app_settings columns after rollback = %v, want original key/value schema", got)
+	}
+	assertCount(t, db, `SELECT COUNT(*) FROM app_settings WHERE key = 'pipelines.enabled' AND value = 'true'`, 1)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'pipeline_%'`, 5)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'pipeline_%_cdc_%'`, 7)
+	assertCount(t, db, `SELECT COUNT(*) FROM change_log WHERE event_type LIKE 'pipeline_%'`, 3)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE name GLOB '_ao_legacy_pr2863_*'`, 0)
+}
+
+func assertPublishedPipelineProfileUntouched(t *testing.T, dataDir string) {
+	t.Helper()
+	db := openPipelineProfileCheckDB(t, dataDir)
+	defer func() { _ = db.Close() }()
+	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, []string{"key", "value"}) {
+		t.Fatalf("app_settings columns after rejected recovery = %v, want untouched key/value schema", got)
+	}
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'pipeline_%'`, 5)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name GLOB '_ao_legacy_pr2863_*'`, 0)
+}
+
+func seedPublishedPipelineProfile(t *testing.T, dataDir string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(dataDir, "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open seed database: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	upTo(t, db, 39)
+	applyPublishedPipelineMigrations(t, db)
+
+	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at)
+VALUES ('legacy-project', '/repos/legacy-project', '2026-07-31T16:55:00Z');
+
+INSERT INTO sessions (
+    id, project_id, num, activity_last_at, created_at, updated_at
+) VALUES (
+    'legacy-project-1', 'legacy-project', 1,
+    '2026-07-31T16:55:01Z', '2026-07-31T16:55:01Z', '2026-07-31T16:55:01Z'
+);
+
+INSERT INTO app_settings (key, value) VALUES ('pipelines.enabled', 'true');
+
+INSERT INTO pipeline_definitions (
+    id, project_id, name, yaml_source, config_json, created_at, updated_at
+) VALUES (
+    'pipeline-1', 'legacy-project', 'Release', 'stages: []', '{}',
+    '2026-07-31T16:56:00Z', '2026-07-31T16:56:00Z'
+);
+
+INSERT INTO pipeline_runs (
+    id, project_id, pipeline_id, pipeline_name, subject_kind, session_id,
+    status, definition_json, created_at, updated_at, run_number
+) VALUES (
+    'run-1', 'legacy-project', 'pipeline-1', 'Release', 'session',
+    'legacy-project-1', 'running', '{}',
+    '2026-07-31T16:57:00Z', '2026-07-31T16:57:00Z', 1
+);
+
+INSERT INTO pipeline_stage_runs (
+    run_id, project_id, stage_id, outcome, session_id, started_at, pgid
+) VALUES (
+    'run-1', 'legacy-project', 'review', 'running', 'legacy-project-1',
+    '2026-07-31T16:58:00Z', 4242
+);
+
+INSERT INTO pipeline_stage_signals (run_id, stage_id, kind, reason, created_at)
+VALUES ('run-1', 'review', 'done', 'approved', '2026-07-31T16:59:00Z');
+
+INSERT INTO pipeline_credentials (
+    project_id, name, env_json, created_at, updated_at
+) VALUES (
+    'legacy-project', 'release-token', '{"TOKEN":"secret"}',
+    '2026-07-31T17:00:00Z', '2026-07-31T17:00:00Z'
+);
+`); err != nil {
+		_ = db.Close()
+		t.Fatalf("seed published Pipelines data: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seeded published profile: %v", err)
+	}
+}
+
+func applyPublishedPipelineMigrations(t *testing.T, db *sql.DB) {
+	t.Helper()
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+	goose.SetBaseFS(pipelinePR2863Migrations)
+	goose.SetLogger(goose.NopLogger())
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("set legacy migration dialect: %v", err)
+	}
+	if err := goose.UpTo(db, "testdata/pipeline_pr2863_migrations", 51); err != nil {
+		t.Fatalf("apply published Pipelines migrations: %v", err)
+	}
+}
+
+func openPipelineProfileCheckDB(t *testing.T, dataDir string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(dataDir, "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open profile check database: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	return db
+}
+
+func assertPublishedPipelineProfileRetired(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, []string{"id", "default_session_mode", "updated_at"}) {
+		t.Fatalf("canonical app_settings columns = %v", got)
+	}
+	var mode string
+	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {
+		t.Fatalf("read canonical default mode: %v", err)
+	}
+	if mode != "chat" {
+		t.Fatalf("canonical default mode = %q, want chat", mode)
+	}
+
+	var pipelineEnabled string
+	if err := db.QueryRow(`
+SELECT value FROM _ao_legacy_pr2863_app_settings
+WHERE key = 'pipelines.enabled'`).Scan(&pipelineEnabled); err != nil {
+		t.Fatalf("read archived pipeline setting: %v", err)
+	}
+	if pipelineEnabled != "true" {
+		t.Fatalf("archived pipelines.enabled = %q, want true", pipelineEnabled)
+	}
+
+	for table, want := range map[string]int{
+		"_ao_legacy_pr2863_pipeline_definitions":   1,
+		"_ao_legacy_pr2863_pipeline_runs":          1,
+		"_ao_legacy_pr2863_pipeline_stage_runs":    1,
+		"_ao_legacy_pr2863_pipeline_stage_signals": 1,
+		"_ao_legacy_pr2863_pipeline_credentials":   1,
+	} {
+		assertCount(t, db, `SELECT COUNT(*) FROM `+quoteSQLiteIdent(table), want)
+	}
+	var envJSON string
+	if err := db.QueryRow(`SELECT env_json FROM _ao_legacy_pr2863_pipeline_credentials`).Scan(&envJSON); err != nil {
+		t.Fatalf("read archived credential: %v", err)
+	}
+	if envJSON != `{"TOKEN":"secret"}` {
+		t.Fatalf("archived credential payload = %q", envJSON)
+	}
+
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'pipeline_%'`, 0)
+	assertCount(t, db, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'pipeline_%_cdc_%'`, 0)
+	assertCount(t, db, `SELECT COUNT(*) FROM change_log WHERE event_type LIKE 'pipeline_%'`, 0)
+	assertCount(t, db, `SELECT COUNT(*) FROM _ao_legacy_pr2863_change_log`, 3)
+	assertCount(t, db, `SELECT COUNT(*) FROM _ao_legacy_pr2863_recovery WHERE profile_id = 'v0.11.1-pr2863.202607311655'`, 1)
+	assertCount(t, db, `SELECT COUNT(*) FROM change_log WHERE event_type = 'session_created'`, 1)
+	assertCount(t, db, `SELECT COUNT(*) FROM goose_db_version WHERE version_id = 67 AND is_applied = 1`, 1)
+	assertCount(t, db, `SELECT COUNT(*) FROM goose_db_version WHERE version_id = 103 AND is_applied = 1`, 1)
+
+	var integrity string
+	if err := db.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil {
+		t.Fatalf("run integrity check: %v", err)
+	}
+	if integrity != "ok" {
+		t.Fatalf("integrity_check = %q, want ok", integrity)
+	}
+	assertCount(t, db, `SELECT COUNT(*) FROM pragma_foreign_key_check`, 0)
+}
+
+func assertCount(t *testing.T, db *sql.DB, query string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(query).Scan(&got); err != nil {
+		t.Fatalf("count query %q: %v", query, err)
+	}
+	if got != want {
+		t.Fatalf("count query %q = %d, want %d", query, got, want)
 	}
 }

--- a/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
+++ b/backend/internal/storage/sqlite/migrate_pipeline_cdc_test.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -411,8 +412,11 @@ func openPipelineProfileCheckDB(t *testing.T, dataDir string) *sql.DB {
 
 func assertPublishedPipelineProfileRetired(t *testing.T, db *sql.DB) {
 	t.Helper()
-	if got := tableColumns(t, db, "app_settings"); !reflect.DeepEqual(got, []string{"id", "default_session_mode", "updated_at"}) {
-		t.Fatalf("canonical app_settings columns = %v", got)
+	gotSettingsColumns := tableColumns(t, db, "app_settings")
+	for _, required := range []string{"id", "default_session_mode", "updated_at"} {
+		if !slices.Contains(gotSettingsColumns, required) {
+			t.Fatalf("canonical app_settings columns = %v, missing %q", gotSettingsColumns, required)
+		}
 	}
 	var mode string
 	if err := db.QueryRow(`SELECT default_session_mode FROM app_settings WHERE id = 1`).Scan(&mode); err != nil {

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0040_pipeline_tables.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0040_pipeline_tables.sql
@@ -1,0 +1,743 @@
+-- Pipelines v1 store (issue #229). Four tables back the pipeline subsystem:
+--
+--   pipeline_definitions  CRUD-authored pipeline configs. Carries BOTH the raw
+--                         YAML as authored and the validated, normalized JSON
+--                         snapshot (spec §4b). Runs snapshot the JSON at trigger
+--                         time so editing a def never mutates a live run.
+--   pipeline_runs         one row per execution. Run-level scalars plus the
+--                         frozen config snapshot and the run's fingerprint set.
+--                         Stages live in pipeline_stage_runs; findings live in
+--                         pipeline_artifacts; the full RunState is reconstructed
+--                         from all three on hydrate.
+--   pipeline_stage_runs   per-stage runtime state within a run, one row per
+--                         (run, stage name). stage_run_id is an attribute (it is
+--                         reassigned on resume) rather than the key.
+--   pipeline_artifacts    findings + JSON artifacts. Immutable payload kept as a
+--                         JSON blob; status/sent_to_agent_at are the only mutable
+--                         columns and are authoritative over the blob on read.
+--
+-- (pipeline_thread_messages is phase 2 and intentionally not created here.)
+--
+-- CDC: triggers on every pipeline_* table write into change_log so pipeline
+-- events ride the existing change_log -> /events SSE stream (spec §4b). Pipeline
+-- events are project-level (change_log.session_id is left NULL) because a run's
+-- session_id may be a manual-run placeholder that is not a real sessions row.
+-- Emitting the new event_type values first requires widening the change_log
+-- CHECK, which SQLite can only do by rebuilding the table. Rebuilding forces the
+-- change_log-referencing CDC triggers to be dropped first (dropping the table
+-- while a trigger references it errors) and recreated after; their bodies are
+-- the current definitions (sessions_cdc_update carries the 0019 form) so this
+-- does not revert 0010/0017/0019.
+
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_update;
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+DROP TRIGGER IF EXISTS pr_cdc_insert;
+DROP TRIGGER IF EXISTS pr_cdc_update;
+DROP TRIGGER IF EXISTS pr_session_cdc_update;
+DROP TRIGGER IF EXISTS pr_checks_cdc_insert;
+DROP TRIGGER IF EXISTS pr_checks_cdc_update;
+DROP TRIGGER IF EXISTS session_cleanup_facts_cdc_update;
+DROP TRIGGER IF EXISTS session_cleanup_facts_cdc_insert;
+
+CREATE TABLE change_log_new (
+    seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL REFERENCES projects (id),
+    session_id TEXT REFERENCES sessions (id),
+    event_type TEXT NOT NULL
+        CHECK (event_type IN (
+            'session_created',
+            'session_updated',
+            'pr_created',
+            'pr_updated',
+            'pr_check_recorded',
+            'pr_session_changed',
+            'pr_review_thread_added',
+            'pr_review_thread_resolved',
+            'pipeline_definition_changed',
+            'pipeline_run_updated',
+            'pipeline_stage_run_updated',
+            'pipeline_artifact_updated'
+        )),
+    payload    TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO change_log_new (seq, project_id, session_id, event_type, payload, created_at)
+SELECT seq, project_id, session_id, event_type, payload, created_at
+FROM change_log;
+
+DROP INDEX IF EXISTS idx_change_log_project;
+DROP TABLE change_log;
+ALTER TABLE change_log_new RENAME TO change_log;
+CREATE INDEX idx_change_log_project ON change_log (project_id, seq);
+-- +goose StatementEnd
+
+-- Recreate the change_log-referencing CDC triggers (current definitions).
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_insert
+AFTER INSERT ON sessions
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_created',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END)),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_insert
+AFTER INSERT ON pr
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_created',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_session_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.session_id <> NEW.session_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT project_id FROM sessions WHERE id = NEW.session_id),
+        NEW.session_id,
+        'pr_session_changed',
+        json_object(
+            'url', NEW.url,
+            'fromSession', OLD.session_id,
+            'toSession', NEW.session_id),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_insert
+AFTER INSERT ON pr_checks
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_update
+AFTER UPDATE ON pr_checks
+WHEN OLD.status <> NEW.status
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_insert
+AFTER INSERT ON pr_review_threads
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_added',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END),
+            'isBot', json(CASE WHEN NEW.is_bot THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_update
+AFTER UPDATE ON pr_review_threads
+WHEN OLD.resolved <> NEW.resolved
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_resolved',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- 0030's cleanup-facts triggers also write into change_log, so they are dropped
+-- with the rest before the table is rebuilt (SQLite re-parses every trigger body
+-- on ALTER TABLE ... RENAME TO, and one naming the dropped change_log aborts the
+-- migration) and recreated verbatim here.
+-- +goose StatementBegin
+CREATE TRIGGER session_cleanup_facts_cdc_insert
+AFTER INSERT ON session_cleanup_facts
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'session_updated',
+        json_object('id', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER session_cleanup_facts_cdc_update
+AFTER UPDATE ON session_cleanup_facts
+WHEN OLD.workspace_disposition <> NEW.workspace_disposition
+    OR (OLD.runtime_released_at IS NULL) <> (NEW.runtime_released_at IS NULL)
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'session_updated',
+        json_object('id', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_definitions (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    yaml_source TEXT NOT NULL,
+    config_json TEXT NOT NULL CHECK (json_valid(config_json)),
+    created_at  TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP NOT NULL,
+    UNIQUE (project_id, name)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_runs (
+    id                 TEXT PRIMARY KEY,
+    project_id         TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    -- pipeline_id references the def this run came from but is NOT a foreign
+    -- key: runs snapshot their config and outlive definition deletes.
+    pipeline_id        TEXT NOT NULL,
+    pipeline_name      TEXT NOT NULL,
+    session_id         TEXT NOT NULL DEFAULT '',
+    head_sha           TEXT NOT NULL DEFAULT '',
+    loop_state         TEXT NOT NULL,
+    termination_reason TEXT NOT NULL DEFAULT '',
+    loop_rounds        INTEGER NOT NULL DEFAULT 0,
+    config_snapshot    TEXT NOT NULL CHECK (json_valid(config_snapshot)),
+    fingerprints       TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(fingerprints)),
+    created_at         TIMESTAMP NOT NULL,
+    updated_at         TIMESTAMP NOT NULL
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Runs list newest-first per project; the loop index feeds hydrate's
+-- currentRunByLoop / historySummaries reconstruction.
+CREATE INDEX idx_pipeline_runs_project_created ON pipeline_runs (project_id, created_at DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_runs_loop ON pipeline_runs (project_id, session_id, pipeline_name, created_at);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_stage_runs (
+    run_id        TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id    TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_name    TEXT NOT NULL,
+    stage_run_id  TEXT NOT NULL,
+    status        TEXT NOT NULL,
+    attempt       INTEGER NOT NULL DEFAULT 0,
+    verdict       TEXT NOT NULL DEFAULT '',
+    started_at    TIMESTAMP,
+    completed_at  TIMESTAMP,
+    error_message TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (run_id, stage_name)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_artifacts (
+    id               TEXT PRIMARY KEY,
+    pipeline_run_id  TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id       TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_run_id     TEXT NOT NULL,
+    stage_name       TEXT NOT NULL,
+    kind             TEXT NOT NULL,
+    fingerprint      TEXT NOT NULL DEFAULT '',
+    -- status + sent_to_agent_at are the only mutable fields and are
+    -- authoritative over anything in payload on read.
+    status           TEXT NOT NULL DEFAULT 'open',
+    sent_to_agent_at TIMESTAMP,
+    -- payload is the full artifact envelope minus the mutable fields above,
+    -- kept as a JSON blob so the append path never has to touch a wide column
+    -- list and reconstruction is one unmarshal.
+    payload          TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at       TIMESTAMP NOT NULL
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_artifacts_run ON pipeline_artifacts (pipeline_run_id, created_at);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_artifacts_stage_run ON pipeline_artifacts (stage_run_id);
+-- +goose StatementEnd
+
+-- Pipeline CDC triggers. All pipeline events are project-level (session_id NULL).
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_definitions_cdc_insert
+AFTER INSERT ON pipeline_definitions
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_definition_changed',
+        json_object('id', NEW.id, 'name', NEW.name, 'change', 'created'),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_definitions_cdc_update
+AFTER UPDATE ON pipeline_definitions
+WHEN OLD.updated_at <> NEW.updated_at
+    OR OLD.name <> NEW.name
+    OR OLD.config_json <> NEW.config_json
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_definition_changed',
+        json_object('id', NEW.id, 'name', NEW.name, 'change', 'updated'),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_definitions_cdc_delete
+AFTER DELETE ON pipeline_definitions
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (OLD.project_id, NULL, 'pipeline_definition_changed',
+        json_object('id', OLD.id, 'name', OLD.name, 'change', 'deleted'),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_insert
+AFTER INSERT ON pipeline_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'sessionId', NEW.session_id,
+            'headSha', NEW.head_sha,
+            'loopState', NEW.loop_state,
+            'terminationReason', NEW.termination_reason,
+            'loopRounds', NEW.loop_rounds),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_update
+AFTER UPDATE ON pipeline_runs
+WHEN OLD.updated_at <> NEW.updated_at
+    OR OLD.loop_state <> NEW.loop_state
+    OR OLD.loop_rounds <> NEW.loop_rounds
+    OR OLD.termination_reason <> NEW.termination_reason
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'sessionId', NEW.session_id,
+            'headSha', NEW.head_sha,
+            'loopState', NEW.loop_state,
+            'terminationReason', NEW.termination_reason,
+            'loopRounds', NEW.loop_rounds),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_insert
+AFTER INSERT ON pipeline_stage_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'status', NEW.status,
+            'attempt', NEW.attempt,
+            'verdict', NEW.verdict),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_update
+AFTER UPDATE ON pipeline_stage_runs
+WHEN OLD.status <> NEW.status
+    OR OLD.attempt <> NEW.attempt
+    OR OLD.verdict <> NEW.verdict
+    OR OLD.stage_run_id <> NEW.stage_run_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'status', NEW.status,
+            'attempt', NEW.attempt,
+            'verdict', NEW.verdict),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_artifacts_cdc_insert
+AFTER INSERT ON pipeline_artifacts
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_artifact_updated',
+        json_object(
+            'artifactId', NEW.id,
+            'runId', NEW.pipeline_run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'kind', NEW.kind,
+            'status', NEW.status,
+            'fingerprint', NEW.fingerprint),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_artifacts_cdc_update
+AFTER UPDATE ON pipeline_artifacts
+WHEN OLD.status <> NEW.status
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_artifact_updated',
+        json_object(
+            'artifactId', NEW.id,
+            'runId', NEW.pipeline_run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'kind', NEW.kind,
+            'status', NEW.status,
+            'fingerprint', NEW.fingerprint),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_definitions_cdc_delete;
+DROP TRIGGER IF EXISTS pipeline_definitions_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_definitions_cdc_insert;
+DROP TABLE IF EXISTS pipeline_artifacts;
+DROP TABLE IF EXISTS pipeline_stage_runs;
+DROP TABLE IF EXISTS pipeline_runs;
+DROP TABLE IF EXISTS pipeline_definitions;
+
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_update;
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+DROP TRIGGER IF EXISTS pr_cdc_insert;
+DROP TRIGGER IF EXISTS pr_cdc_update;
+DROP TRIGGER IF EXISTS pr_session_cdc_update;
+DROP TRIGGER IF EXISTS pr_checks_cdc_insert;
+DROP TRIGGER IF EXISTS pr_checks_cdc_update;
+DROP TRIGGER IF EXISTS session_cleanup_facts_cdc_update;
+DROP TRIGGER IF EXISTS session_cleanup_facts_cdc_insert;
+
+CREATE TABLE change_log_old (
+    seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL REFERENCES projects (id),
+    session_id TEXT REFERENCES sessions (id),
+    event_type TEXT NOT NULL
+        CHECK (event_type IN (
+            'session_created',
+            'session_updated',
+            'pr_created',
+            'pr_updated',
+            'pr_check_recorded',
+            'pr_session_changed',
+            'pr_review_thread_added',
+            'pr_review_thread_resolved'
+        )),
+    payload    TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO change_log_old (seq, project_id, session_id, event_type, payload, created_at)
+SELECT seq, project_id, session_id, event_type, payload, created_at
+FROM change_log
+WHERE event_type NOT LIKE 'pipeline_%';
+
+DROP INDEX IF EXISTS idx_change_log_project;
+DROP TABLE change_log;
+ALTER TABLE change_log_old RENAME TO change_log;
+CREATE INDEX idx_change_log_project ON change_log (project_id, seq);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_insert
+AFTER INSERT ON sessions
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_created',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END)),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_insert
+AFTER INSERT ON pr
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_created',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_session_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.session_id <> NEW.session_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT project_id FROM sessions WHERE id = NEW.session_id),
+        NEW.session_id,
+        'pr_session_changed',
+        json_object(
+            'url', NEW.url,
+            'fromSession', OLD.session_id,
+            'toSession', NEW.session_id),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_insert
+AFTER INSERT ON pr_checks
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_update
+AFTER UPDATE ON pr_checks
+WHEN OLD.status <> NEW.status
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_insert
+AFTER INSERT ON pr_review_threads
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_added',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END),
+            'isBot', json(CASE WHEN NEW.is_bot THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_update
+AFTER UPDATE ON pr_review_threads
+WHEN OLD.resolved <> NEW.resolved
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_resolved',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- 0030's cleanup-facts triggers also write into change_log, so they are dropped
+-- with the rest before the table is rebuilt (SQLite re-parses every trigger body
+-- on ALTER TABLE ... RENAME TO, and one naming the dropped change_log aborts the
+-- migration) and recreated verbatim here.
+-- +goose StatementBegin
+CREATE TRIGGER session_cleanup_facts_cdc_insert
+AFTER INSERT ON session_cleanup_facts
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'session_updated',
+        json_object('id', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER session_cleanup_facts_cdc_update
+AFTER UPDATE ON session_cleanup_facts
+WHEN OLD.workspace_disposition <> NEW.workspace_disposition
+    OR (OLD.runtime_released_at IS NULL) <> (NEW.runtime_released_at IS NULL)
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'session_updated',
+        json_object('id', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0041_pr_is_from_fork.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0041_pr_is_from_fork.sql
@@ -1,0 +1,17 @@
+-- Fork provenance for the pipeline command-executor gate (spec §4b T6, gap
+-- flagged in the T5 review PR #235). The SCM observer sees a PR's head repo,
+-- but that never survived to the pr table, so a real PR could only ever be
+-- classified ForkUnknown after the fact. This nullable tri-state column
+-- persists it: NULL = unknown (fail-safe default for legacy rows), 0 = not a
+-- fork, 1 = from a fork. The command executor blocks fork + unknown PRs unless
+-- allowForkPRs is set.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pr ADD COLUMN is_from_fork INTEGER;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pr DROP COLUMN is_from_fork;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0042_pr_cdc_update_head_sha.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0042_pr_cdc_update_head_sha.sql
@@ -1,0 +1,51 @@
+-- New-SHA cancel-and-rearm (spec decision 9) rides the CDC pr_updated event, but
+-- the pr_cdc_update trigger (migration 0040) fired only when pr_state, ci_state,
+-- review_decision, or mergeability changed. A push that changes ONLY pr.head_sha
+-- (no CI reporting yet, or a repo without CI) emitted no event, so the pipeline
+-- trigger bridge never saw the new SHA: the stale run kept running and no fresh
+-- run armed. Add OLD.head_sha <> NEW.head_sha to the WHEN clause so a head-SHA
+-- change alone emits pr_updated. The payload is unchanged (the bridge reads
+-- head_sha from the store by url, not from the payload).
+
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pr_cdc_update;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+    OR OLD.head_sha <> NEW.head_sha
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pr_cdc_update;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0043_app_settings.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0043_app_settings.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Global (not per-project) app settings as a small key/value table. One row per
+-- setting. The daemon reads these at boot regardless of who launched it (the
+-- Electron supervisor or `ao start`), which is why the flag lives here rather
+-- than in Electron userData. First consumer: "pipelines.enabled" (spec §4b T12).
+CREATE TABLE app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE app_settings;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0044_pipeline_run_context.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0044_pipeline_run_context.sql
@@ -1,0 +1,17 @@
+-- Persist a pipeline run's RunContext (PR identity, issue id, session facts).
+-- PR #275 added RunContext to the in-memory RunState and threaded it to stage
+-- executors, but never persisted it, so a daemon restart rehydrated every run
+-- with an empty context. Per-PR loop keys (issue #270) derive from Context.PRURL,
+-- so without this column a restart collapses sibling PR runs back onto the shared
+-- session+pipeline key. Store the context as JSON; legacy rows default to '{}',
+-- which hydrates to the zero RunContext and degrades to the old key shape.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs ADD COLUMN context_json TEXT NOT NULL DEFAULT '{}';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs DROP COLUMN context_json;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0045_pipeline_run_blocks_merge.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0045_pipeline_run_blocks_merge.sql
@@ -1,0 +1,16 @@
+-- Persist a pipeline run's terminal merge-blocking decision. ExitPredicates
+-- .BlocksMerge and StagePolicy.BlocksMerge were parsed and editable but never
+-- evaluated, stored, or consumed. The reducer now sets RunState.BlocksMerge when
+-- a run reaches a terminal loop state, and the lifecycle merge-readiness path
+-- consults the most recent settled run for a PR. Store it as an integer bool;
+-- legacy rows default to 0 (does not block), which is the safe no-opinion value.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs ADD COLUMN blocks_merge INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs DROP COLUMN blocks_merge;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0046_pipeline_stage_run_session_notes.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0046_pipeline_stage_run_session_notes.sql
@@ -1,0 +1,30 @@
+-- Persist per-stage session id, human notes, and captured output on
+-- pipeline_stage_runs. StageState.SessionID (the agent session a stage ran in,
+-- for run-detail click-through), StageState.Notes (fork-skip, findings-
+-- truncated, exit-mode, unknown-fingerprint annotations), and StageState.Output
+-- (command stdout+stderr tail) all round-trip through RunState but had no
+-- columns, so the run detail served from the store lost them. Store notes as a
+-- JSON array text; legacy rows default to empty, which renders as no session
+-- link and no notes.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN session_id TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN notes TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN output TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN session_id;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN notes;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN output;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0047_pipelines_v2.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0047_pipelines_v2.sql
@@ -1,0 +1,431 @@
+-- Pipelines v2 store. v1 shipped only behind the AO_PIPELINES flag and was
+-- never released, so no data is owed a migration: the run tables are dropped
+-- and recreated in the v2 shape rather than backfilled.
+--
+--   pipeline_definitions  UNCHANGED. Definitions travel as raw YAML plus a
+--                         parsed snapshot; v1 YAML simply fails v2 validation
+--                         when the editor opens it.
+--   pipeline_runs         one row per run. Run-level scalars, the flattened
+--                         subject, and the frozen definition the run executes.
+--   pipeline_stage_runs   one row per (run, stage), mirroring pipeline.StageState.
+--   pipeline_stage_signals  append-only `ao pipeline done|fail` signals; reads
+--                         take the latest row for a (run, stage).
+--   pipeline_credentials  engine-held command-stage credentials. Values live
+--                         only in the daemon and are never echoed by a read
+--                         path a human can reach.
+--   pipeline_artifacts    DROPPED with the whole findings subsystem.
+--
+-- Three columns are not in the v2 design's scalar list but are required for a
+-- run to survive a daemon restart, since SQLite (not the run folder) is the
+-- store of record: definition_json (the frozen definition), the PR branch pair
+-- (a `workspace: checkout` stage needs them after a restart), and the per-stage
+-- nudged flag (RunState.Nudged).
+--
+-- change_log keeps its CHECK list as written in 0040: 'pipeline_artifact_updated'
+-- stays a legal value with no emitter, because narrowing the CHECK means
+-- rebuilding change_log and re-creating every CDC trigger in the schema for no
+-- behavioural gain.
+
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_artifacts_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_insert;
+DROP INDEX IF EXISTS idx_pipeline_artifacts_stage_run;
+DROP INDEX IF EXISTS idx_pipeline_artifacts_run;
+DROP INDEX IF EXISTS idx_pipeline_runs_loop;
+DROP INDEX IF EXISTS idx_pipeline_runs_project_created;
+DROP TABLE IF EXISTS pipeline_artifacts;
+DROP TABLE IF EXISTS pipeline_stage_runs;
+DROP TABLE IF EXISTS pipeline_runs;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_runs (
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    -- pipeline_id names the definition this run came from but is NOT a foreign
+    -- key: a run freezes its definition and outlives a definition delete.
+    pipeline_id     TEXT NOT NULL,
+    pipeline_name   TEXT NOT NULL,
+    -- Subject, flattened. session_id is set for session subjects and for PR
+    -- subjects that have a local session; the pr_* columns are set for PR
+    -- subjects only (a sessionless PR subject is first class).
+    subject_kind    TEXT NOT NULL,
+    session_id      TEXT NOT NULL DEFAULT '',
+    pr_number       INTEGER NOT NULL DEFAULT 0,
+    pr_repo         TEXT NOT NULL DEFAULT '',
+    pr_url          TEXT NOT NULL DEFAULT '',
+    head_sha        TEXT NOT NULL DEFAULT '',
+    pr_head_branch  TEXT NOT NULL DEFAULT '',
+    pr_base_branch  TEXT NOT NULL DEFAULT '',
+    from_fork       INTEGER NOT NULL DEFAULT 0,
+    status          TEXT NOT NULL,
+    run_dir         TEXT NOT NULL DEFAULT '',
+    -- The definition as frozen at trigger time. Editing a definition never
+    -- changes a run in flight, and hydration on restart replays what ran.
+    definition_json TEXT NOT NULL CHECK (json_valid(definition_json)),
+    cancel_reason   TEXT NOT NULL DEFAULT '',
+    created_at      TIMESTAMP NOT NULL,
+    updated_at      TIMESTAMP NOT NULL,
+    -- NULL while the run is in flight. Hydration selects on it, so it is the
+    -- one nullable timestamp on the row.
+    settled_at      TIMESTAMP
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- The Kanban board lists a project's runs newest-first.
+CREATE INDEX idx_pipeline_runs_project_created ON pipeline_runs (project_id, created_at DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Hydration on engine start reads exactly the unsettled runs of one project.
+CREATE INDEX idx_pipeline_runs_unsettled ON pipeline_runs (project_id, created_at) WHERE settled_at IS NULL;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_stage_runs (
+    run_id         TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id     TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_id       TEXT NOT NULL,
+    outcome        TEXT NOT NULL,
+    attempt        INTEGER NOT NULL DEFAULT 0,
+    entered_via    TEXT NOT NULL DEFAULT '',
+    prev_stage     TEXT NOT NULL DEFAULT '',
+    failed_stage   TEXT NOT NULL DEFAULT '',
+    failed_outcome TEXT NOT NULL DEFAULT '',
+    session_id     TEXT NOT NULL DEFAULT '',
+    workspace_kind TEXT NOT NULL DEFAULT '',
+    workspace_path TEXT NOT NULL DEFAULT '',
+    -- Nullable rather than zero-defaulted: a stage that has not started has no
+    -- deadline yet, and a zero time is not the same statement.
+    deadline_at    TIMESTAMP,
+    started_at     TIMESTAMP,
+    settled_at     TIMESTAMP,
+    reason         TEXT NOT NULL DEFAULT '',
+    output_tail    TEXT NOT NULL DEFAULT '',
+    -- RunState.Nudged, stored where it belongs: one nudge per stage, ever.
+    nudged         INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (run_id, stage_id)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Append-only. The engine's SignalReader takes the newest row per (run, stage),
+-- so a post-nudge signal supersedes the first without losing it.
+CREATE TABLE pipeline_stage_signals (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id     TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    stage_id   TEXT NOT NULL,
+    kind       TEXT NOT NULL CHECK (kind IN ('done', 'fail')),
+    reason     TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_stage_signals_stage ON pipeline_stage_signals (run_id, stage_id, created_at DESC, id DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- env_json is a JSON object of environment variables injected into a command
+-- stage's process at exec time. Same trust level as the gh token already on
+-- disk: no UI editor, no read path that echoes a value back.
+CREATE TABLE pipeline_credentials (
+    project_id TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    name       TEXT NOT NULL,
+    env_json   TEXT NOT NULL CHECK (json_valid(env_json)),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (project_id, name)
+);
+-- +goose StatementEnd
+
+-- Pipeline CDC triggers. All pipeline events are project-level (session_id
+-- NULL) because a run's session id may be absent or may not be a sessions row.
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_insert
+AFTER INSERT ON pipeline_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'status', NEW.status,
+            'subjectKind', NEW.subject_kind,
+            'sessionId', NEW.session_id,
+            'prNumber', NEW.pr_number,
+            'headSha', NEW.head_sha),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_update
+AFTER UPDATE ON pipeline_runs
+WHEN OLD.status <> NEW.status
+    OR OLD.updated_at <> NEW.updated_at
+    OR OLD.cancel_reason <> NEW.cancel_reason
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'status', NEW.status,
+            'subjectKind', NEW.subject_kind,
+            'sessionId', NEW.session_id,
+            'prNumber', NEW.pr_number,
+            'headSha', NEW.head_sha),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_insert
+AFTER INSERT ON pipeline_stage_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageId', NEW.stage_id,
+            'outcome', NEW.outcome,
+            'attempt', NEW.attempt,
+            'sessionId', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_update
+AFTER UPDATE ON pipeline_stage_runs
+WHEN OLD.outcome <> NEW.outcome
+    OR OLD.attempt <> NEW.attempt
+    OR OLD.session_id <> NEW.session_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageId', NEW.stage_id,
+            'outcome', NEW.outcome,
+            'attempt', NEW.attempt,
+            'sessionId', NEW.session_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_stage_runs_cdc_insert;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_update;
+DROP TRIGGER IF EXISTS pipeline_runs_cdc_insert;
+DROP INDEX IF EXISTS idx_pipeline_stage_signals_stage;
+DROP INDEX IF EXISTS idx_pipeline_runs_unsettled;
+DROP INDEX IF EXISTS idx_pipeline_runs_project_created;
+DROP TABLE IF EXISTS pipeline_credentials;
+DROP TABLE IF EXISTS pipeline_stage_signals;
+DROP TABLE IF EXISTS pipeline_stage_runs;
+DROP TABLE IF EXISTS pipeline_runs;
+-- +goose StatementEnd
+
+-- Recreate the v1 tables and their triggers as 0040 through 0046 left them, so
+-- a down migration lands on the schema those migrations describe. The rows are
+-- gone either way: the up migration dropped them.
+-- +goose StatementBegin
+CREATE TABLE pipeline_runs (
+    id                 TEXT PRIMARY KEY,
+    project_id         TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    pipeline_id        TEXT NOT NULL,
+    pipeline_name      TEXT NOT NULL,
+    session_id         TEXT NOT NULL DEFAULT '',
+    head_sha           TEXT NOT NULL DEFAULT '',
+    loop_state         TEXT NOT NULL,
+    termination_reason TEXT NOT NULL DEFAULT '',
+    loop_rounds        INTEGER NOT NULL DEFAULT 0,
+    config_snapshot    TEXT NOT NULL CHECK (json_valid(config_snapshot)),
+    fingerprints       TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(fingerprints)),
+    created_at         TIMESTAMP NOT NULL,
+    updated_at         TIMESTAMP NOT NULL,
+    context_json       TEXT NOT NULL DEFAULT '{}',
+    blocks_merge       INTEGER NOT NULL DEFAULT 0
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_runs_project_created ON pipeline_runs (project_id, created_at DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_runs_loop ON pipeline_runs (project_id, session_id, pipeline_name, created_at);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_stage_runs (
+    run_id        TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id    TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_name    TEXT NOT NULL,
+    stage_run_id  TEXT NOT NULL,
+    status        TEXT NOT NULL,
+    attempt       INTEGER NOT NULL DEFAULT 0,
+    verdict       TEXT NOT NULL DEFAULT '',
+    started_at    TIMESTAMP,
+    completed_at  TIMESTAMP,
+    error_message TEXT NOT NULL DEFAULT '',
+    session_id    TEXT NOT NULL DEFAULT '',
+    notes         TEXT NOT NULL DEFAULT '',
+    output        TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (run_id, stage_name)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE pipeline_artifacts (
+    id               TEXT PRIMARY KEY,
+    pipeline_run_id  TEXT NOT NULL REFERENCES pipeline_runs (id) ON DELETE CASCADE,
+    project_id       TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    stage_run_id     TEXT NOT NULL,
+    stage_name       TEXT NOT NULL,
+    kind             TEXT NOT NULL,
+    fingerprint      TEXT NOT NULL DEFAULT '',
+    status           TEXT NOT NULL DEFAULT 'open',
+    sent_to_agent_at TIMESTAMP,
+    payload          TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at       TIMESTAMP NOT NULL
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_artifacts_run ON pipeline_artifacts (pipeline_run_id, created_at);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_pipeline_artifacts_stage_run ON pipeline_artifacts (stage_run_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_insert
+AFTER INSERT ON pipeline_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'sessionId', NEW.session_id,
+            'headSha', NEW.head_sha,
+            'loopState', NEW.loop_state,
+            'terminationReason', NEW.termination_reason,
+            'loopRounds', NEW.loop_rounds),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_runs_cdc_update
+AFTER UPDATE ON pipeline_runs
+WHEN OLD.updated_at <> NEW.updated_at
+    OR OLD.loop_state <> NEW.loop_state
+    OR OLD.loop_rounds <> NEW.loop_rounds
+    OR OLD.termination_reason <> NEW.termination_reason
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_run_updated',
+        json_object(
+            'runId', NEW.id,
+            'pipelineId', NEW.pipeline_id,
+            'pipelineName', NEW.pipeline_name,
+            'sessionId', NEW.session_id,
+            'headSha', NEW.head_sha,
+            'loopState', NEW.loop_state,
+            'terminationReason', NEW.termination_reason,
+            'loopRounds', NEW.loop_rounds),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_insert
+AFTER INSERT ON pipeline_stage_runs
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'status', NEW.status,
+            'attempt', NEW.attempt,
+            'verdict', NEW.verdict),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_stage_runs_cdc_update
+AFTER UPDATE ON pipeline_stage_runs
+WHEN OLD.status <> NEW.status
+    OR OLD.attempt <> NEW.attempt
+    OR OLD.verdict <> NEW.verdict
+    OR OLD.stage_run_id <> NEW.stage_run_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_stage_run_updated',
+        json_object(
+            'runId', NEW.run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'status', NEW.status,
+            'attempt', NEW.attempt,
+            'verdict', NEW.verdict),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_artifacts_cdc_insert
+AFTER INSERT ON pipeline_artifacts
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_artifact_updated',
+        json_object(
+            'artifactId', NEW.id,
+            'runId', NEW.pipeline_run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'kind', NEW.kind,
+            'status', NEW.status,
+            'fingerprint', NEW.fingerprint),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pipeline_artifacts_cdc_update
+AFTER UPDATE ON pipeline_artifacts
+WHEN OLD.status <> NEW.status
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'pipeline_artifact_updated',
+        json_object(
+            'artifactId', NEW.id,
+            'runId', NEW.pipeline_run_id,
+            'stageRunId', NEW.stage_run_id,
+            'stageName', NEW.stage_name,
+            'kind', NEW.kind,
+            'status', NEW.status,
+            'fingerprint', NEW.fingerprint),
+        datetime('now'));
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0048_session_pipeline_metadata.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0048_session_pipeline_metadata.sql
@@ -1,0 +1,89 @@
+-- +goose Up
+-- Two pipeline facts on the session row.
+--
+-- pipeline_run_id records the pipeline run that spawned the session. It is the
+-- session trigger bridge's loop guard: without a durable marker, a pipeline
+-- agent going idle fires the session pipelines, whose agents go idle, forever.
+-- It must survive a daemon restart, so it is a column and not in-process state.
+--
+-- pipeline_orphan is the JSON PipelineOrphanInfo a stage writes when its
+-- kill-on rule spared the session (no_output, no_signal, timed_out): the run,
+-- the stage, the outcome that spared it and when it was kept. Empty string
+-- means the session is not pipeline-orphaned. JSON rather than five columns
+-- because nothing queries inside it: the daemon reads it whole and the session
+-- list renders it whole.
+-- +goose StatementBegin
+ALTER TABLE sessions ADD COLUMN pipeline_run_id TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE sessions ADD COLUMN pipeline_orphan TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- Recreate the sessions update CDC trigger so marking a session
+-- pipeline-orphaned fans out a session_updated event. Without this the badge
+-- would only appear on the next unrelated session change, which is exactly the
+-- moment nobody is looking. Guard-only change: session_updated is an
+-- invalidation nudge, so the payload stays as-is.
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+    OR OLD.pipeline_orphan <> NEW.pipeline_orphan
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+    OR OLD.terminate_on_pr_merge <> NEW.terminate_on_pr_merge
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object(
+            'id', NEW.id,
+            'activity', NEW.activity_state,
+            'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END),
+            'terminateOnPrMerge', json(CASE WHEN NEW.terminate_on_pr_merge THEN 'true' ELSE 'false' END),
+            'previewUrl', NEW.preview_url,
+            'previewRevision', NEW.preview_revision
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN pipeline_orphan;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN pipeline_run_id;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0049_session_workspace_adopted.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0049_session_workspace_adopted.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- workspace_adopted marks a session that runs in a tree it does not own: the
+-- spawn named an existing workspace (a pipeline run's, spec section 5) instead
+-- of creating a worktree. Every teardown path reads it before removing a
+-- worktree, so it has to survive a daemon restart the same way workspace_path
+-- does: an adopted session read back with the flag lost would hand a live run's
+-- workspace to session cleanup.
+-- +goose StatementBegin
+ALTER TABLE sessions ADD COLUMN workspace_adopted BOOLEAN NOT NULL DEFAULT FALSE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN workspace_adopted;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0050_pipeline_stage_run_pgid.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0050_pipeline_stage_run_pgid.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- pgid is the OS process group a command stage was launched in. The engine's
+-- handle on that process dies with the daemon, so a restart could settle the
+-- stage as lost while its work kept running unowned; the group id is the only
+-- thing that lets the next boot find it and reap it. 0 means no group was
+-- recorded (an agent stage, a stage that never launched, or a platform that
+-- gives a command none).
+--
+-- Read with started_at, which is stamped by the same event: the pair is the
+-- identity check that keeps a reused pid from being killed as if it were ours.
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs ADD COLUMN pgid INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pipeline_stage_runs DROP COLUMN pgid;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0051_pipeline_run_number.sql
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/0051_pipeline_run_number.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+-- run_number is the per-pipeline counter humans refer to a run by ("inform #3
+-- failed"), the way GitHub Actions numbers workflow runs. It is allocated in
+-- the INSERT that creates the run (see UpsertPipelineRun) and never rewritten,
+-- so a number, once shown, always means the same run.
+--
+-- The counter is scoped to (project_id, pipeline_name), not to pipeline_id: a
+-- definition that is deleted and recreated gets a fresh id but keeps its name,
+-- and its old runs stay in the table and in their run folders. Scoping by name
+-- means the recreated definition continues from where the old one stopped
+-- instead of handing out numbers that already appear in an older run's
+-- run.json. A rename starts a fresh sequence, which is safe because the new
+-- name has no runs behind it.
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs ADD COLUMN run_number INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Backfill the runs that predate the counter, oldest first, so existing runs
+-- read in the same order the list already shows them in.
+UPDATE pipeline_runs SET run_number = (
+    SELECT ranked.n FROM (
+        SELECT id, ROW_NUMBER() OVER (
+            PARTITION BY project_id, pipeline_name ORDER BY created_at, id
+        ) AS n
+        FROM pipeline_runs
+    ) AS ranked
+    WHERE ranked.id = pipeline_runs.id
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- The allocation is a MAX(...)+1 subquery inside the insert, which is atomic
+-- within its statement; this index is what makes a duplicate impossible rather
+-- than merely unlikely, so two racing triggers for one pipeline can never end
+-- up both called #4.
+CREATE UNIQUE INDEX idx_pipeline_runs_number ON pipeline_runs (project_id, pipeline_name, run_number);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_pipeline_runs_number;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE pipeline_runs DROP COLUMN run_number;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/README.md
+++ b/backend/internal/storage/sqlite/testdata/pipeline_pr2863_migrations/README.md
@@ -1,0 +1,14 @@
+# Published Pipelines migration profile
+
+The SQL files in this directory are frozen verbatim from the published tag
+`v0.11.1-pr2863.202607311655`. They are test fixtures, not active migrations.
+
+Migrations `0001` through `0039` at that tag are byte-identical to the active
+files on main. The end-to-end migration test therefore applies main through
+`0039`, applies these fixtures through `0051`, seeds representative durable
+data, closes the database, and upgrades it through the production `sqlite.Open`
+entrypoint.
+
+Do not edit these fixtures to match current migrations. Their purpose is to
+freeze the database lineage that reached users and prevent the compatibility
+repair from drifting away from its source profile.


### PR DESCRIPTION
## Summary
- retire the exact SQLite profile shipped by `v0.11.1-pr2863.202607311655`, whose foreign migrations occupied 45, 46, 50, and 51 and left key/value `app_settings`
- fingerprint the published tables, indexes, triggers, settings, lineage, and CDC values before any destructive write
- atomically archive the abandoned Pipeline values, remove the live Pipeline schema/CDC, create canonical settings, and record a terminal recovery marker
- reserve the burned migration numbers and add a frozen, provenance-documented release fixture exercised through production `sqlite.Open`

## Safety
- no committed SQLite migration is edited
- fresh and healthy main databases take a constant-time gate; they do not scan the append-only `change_log`
- completed recovery self-disables, so a future legitimate `pipeline_*` schema remains outside this shim
- unknown settings, event types, triggers, indexes, or schema definitions fail closed before mutation
- all recovery writes and postcondition checks run in one transaction; injected failure proves full rollback
- Pipeline settings, CDC rows, table rows, and credentials are retained under `_ao_legacy_pr2863_*` forensic archive tables
- unseen partial Nightly variants are intentionally rejected instead of guessed; this PR supports the exact published profile named above

## Before / after
Before the hardened recovery, the exact release fixture failed startup validation because its legacy settings were discarded rather than archived, and an unknown legacy setting was silently accepted. After this change, the real release profile upgrades through current main, preserves all seeded values, passes integrity and foreign-key checks, reopens idempotently, and rejects altered profiles without mutation.

## Local verification
- focused exact-release and adversarial E2E tests, repeated 10 times
- `cd backend && go test ./internal/storage/sqlite/... -count=1`
- `cd backend && go test -race ./internal/storage/sqlite/... -count=1`
- `cd backend && go test -p 1 ./...`
- `cd backend && go build ./...`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs`
- `git diff --check`
