### PR TITLE
fix: guard Agy sends at permission prompts

### DIFF
--- a/backend/internal/adapters/agent/agy/agy.go
+++ b/backend/internal/adapters/agent/agy/agy.go
@@ -47,6 +47,7 @@ var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
 var _ ports.SubmitActivitySignaler = (*Plugin)(nil)
 var _ ports.BlockedActivitySignaler = (*Plugin)(nil)
+var _ ports.TerminalDecisionDetector = (*Plugin)(nil)
 
 // EmitsSubmitActivity reports that PreInvocation proves submitted work has
 // reached AGY's execution loop.

--- a/backend/internal/adapters/agent/agy/terminal_activity.go
+++ b/backend/internal/adapters/agent/agy/terminal_activity.go
@@ -1,0 +1,28 @@
+package agy
+
+import (
+	"regexp"
+	"strings"
+)
+
+var agyTerminalEscape = regexp.MustCompile(`\x1b(?:\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]|\][^\x07]*(?:\x07|\x1b\\))`)
+
+// TerminalAwaitingDecision reports a blocked Agy permission picker only when
+// several structural markers are present together. Agy's hooks do not expose
+// permission-wait events, so terminal output is the only just-in-time signal
+// available before Send writes a message and its trailing Enter into the TUI.
+func (p *Plugin) TerminalAwaitingDecision(output string) bool {
+	plain := agyTerminalEscape.ReplaceAllString(strings.ReplaceAll(output, "\r", "\n"), "")
+	lines := strings.Split(plain, "\n")
+	if len(lines) > 20 {
+		lines = lines[len(lines)-20:]
+	}
+	plain = strings.ToLower(strings.Join(lines, "\n"))
+	if strings.Contains(plain, "requesting permission for:") &&
+		strings.Contains(plain, "do you want to proceed?") &&
+		strings.Contains(plain, "1. yes") &&
+		strings.Contains(plain, "3. no") {
+		return true
+	}
+	return false
+}

--- a/backend/internal/adapters/agent/agy/terminal_activity_test.go
+++ b/backend/internal/adapters/agent/agy/terminal_activity_test.go
@@ -1,0 +1,67 @@
+package agy
+
+import "testing"
+
+func TestDetectTerminalActivity(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name: "permission picker",
+			output: `Command
+Requesting permission for:
+git status
+Do you want to proceed?
+> 1. Yes
+  2. Yes, and don't ask again
+  3. No`,
+			want: true,
+		},
+		{
+			name:   "permission picker with ansi",
+			output: "\x1b[1mCommand\x1b[0m\nRequesting permission for:\napply_patch\nDo you want to proceed?\n\x1b[36m> 1. Yes\x1b[0m\n  3. No\n",
+			want:   true,
+		},
+		{name: "ordinary composer", output: "> continue\nGemini 3.7 Flash · high\n"},
+		{
+			name: "stale permission picker outside terminal tail",
+			output: `Requesting permission for:
+git status
+Do you want to proceed?
+> 1. Yes
+  3. No
+line 01
+line 02
+line 03
+line 04
+line 05
+line 06
+line 07
+line 08
+line 09
+line 10
+line 11
+line 12
+line 13
+line 14
+line 15
+line 16
+line 17
+line 18
+line 19
+line 20
+> current composer`,
+		},
+		{name: "assistant prose", output: "The docs ask: Do you want to proceed?\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := (&Plugin{}).TerminalAwaitingDecision(tt.output)
+			if got != tt.want {
+				t.Fatalf("TerminalAwaitingDecision() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -231,6 +231,13 @@ type TerminalActivityDetector interface {
 	DetectTerminalActivity(output string) (domain.ActivityState, bool)
 }
 
+// TerminalDecisionDetector is an optional safety capability for interactive
+// adapters whose lifecycle hooks cannot report a permission picker. It is
+// sampled immediately before AO injects a message and trailing Enter.
+type TerminalDecisionDetector interface {
+	TerminalAwaitingDecision(output string) bool
+}
+
 // EmptyComposerDetector is an opt-in safety capability for unsolicited
 // coordination sent to an already-running interactive agent. It must return
 // true only when current terminal evidence positively proves that the active

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2962,6 +2962,9 @@ func (m *Manager) send(ctx context.Context, id domain.SessionID, message, client
 	if err != nil {
 		return err
 	}
+	if m.terminalAwaitingDecision(ctx, id) {
+		return fmt.Errorf("send %s: %w", id, ErrAwaitingDecision)
+	}
 	var afterWrite func(context.Context) error
 	if strings.TrimSpace(message) != "" {
 		if recorder, ok := m.store.(latestUserPromptRecorder); ok {
@@ -3011,6 +3014,37 @@ func (m *Manager) send(ctx context.Context, id domain.SessionID, message, client
 		m.confirmActive(ctx, m.messenger, id)
 	}
 	return nil
+}
+
+// terminalAwaitingDecision performs a just-in-time safety check immediately
+// before Deliver writes to the pane. This supplements durable activity hooks
+// for interactive harnesses such as Agy that cannot report blocked state.
+func (m *Manager) terminalAwaitingDecision(ctx context.Context, id domain.SessionID) bool {
+	if m.runtime == nil || m.agents == nil {
+		return false
+	}
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil || !ok {
+		return false
+	}
+	agent, ok := m.agents.Agent(rec.Harness)
+	if !ok {
+		return false
+	}
+	detector, ok := agent.(ports.TerminalDecisionDetector)
+	if !ok {
+		return false
+	}
+	handle := runtimeHandle(rec.Metadata)
+	if handle.ID == "" {
+		return false
+	}
+	output, err := m.runtime.GetOutput(ctx, handle, 120)
+	if err != nil {
+		m.logger.Warn("send: terminal activity check failed", "sessionID", id, "error", err)
+		return false
+	}
+	return detector.TerminalAwaitingDecision(output)
 }
 
 func (m *Manager) prepareOutboundMessage(ctx context.Context, id domain.SessionID, message string) (string, error) {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -7719,6 +7719,15 @@ type submitOnlyAgent struct{ fakeAgent }
 func (submitOnlyAgent) EmitsSubmitActivity() bool  { return true }
 func (submitOnlyAgent) EmitsBlockedActivity() bool { return false }
 
+type terminalDetectingAgent struct {
+	fakeAgent
+	blocked bool
+}
+
+func (a terminalDetectingAgent) TerminalAwaitingDecision(string) bool {
+	return a.blocked
+}
+
 // newSendTestManager builds a Manager wired for Send confirmation tests with
 // fast (millisecond) confirmation timings so no test waits real seconds. The
 // returned messenger records every Send; the store is mutable so a test can
@@ -7762,6 +7771,55 @@ func TestSend_SkipsConfirmForHooklessHarness(t *testing.T) {
 	// Hookless path returns within milliseconds (no 2s+ confirmation wait).
 	if dt := time.Since(start); dt > 250*time.Millisecond {
 		t.Fatalf("Send took %s for a hookless harness; confirmActive should have been skipped", dt)
+	}
+}
+
+func TestSend_TerminalPermissionPromptRejectsDeliveryDespiteStaleIdleState(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["s1"] = domain.SessionRecord{
+		ID:       "s1",
+		Harness:  domain.HarnessAgy,
+		Mode:     domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityIdle},
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "h1"},
+	}
+	msg := &fakeMessenger{}
+	m := newSendTestManager(t, terminalDetectingAgent{blocked: true}, msg, st)
+	m.runtime.(*fakeRuntime).outputs = []string{`Command
+Requesting permission for:
+git status
+Do you want to proceed?
+> 1. Yes
+  2. Yes, and don't ask again
+  3. No`}
+
+	err := m.Send(context.Background(), "s1", "continue the task pack", nil)
+	if !errors.Is(err, ErrAwaitingDecision) {
+		t.Fatalf("Send error = %v, want ErrAwaitingDecision", err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("Send calls = %d, want 0 (permission picker must receive no paste or Enter)", len(msg.msgs))
+	}
+}
+
+func TestSend_UnknownTerminalActivityPreservesDelivery(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["s1"] = domain.SessionRecord{
+		ID:       "s1",
+		Harness:  domain.HarnessAgy,
+		Mode:     domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityIdle},
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "h1"},
+	}
+	msg := &fakeMessenger{}
+	m := newSendTestManager(t, terminalDetectingAgent{}, msg, st)
+	m.runtime.(*fakeRuntime).outputs = []string{"> current composer\nGemini 3.7 Flash · high\n"}
+
+	if err := m.Send(context.Background(), "s1", "continue the task pack", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("Send calls = %d, want 1", len(msg.msgs))
 	}
 }
 
@@ -7937,10 +7995,11 @@ func TestSend_NoNudgeWhenBlockedAppearsBeforeNudge(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code",
 		Activity: domain.Activity{State: domain.ActivityIdle}}
-	// blockAfterFirstReadStore flips the session to blocked on read #4. The
+	// blockAfterFirstReadStore flips the session to blocked on read #5. The
 	// deterministic read sequence (attemptDeadline 0 makes waitForActive do
-	// exactly one poll): #1 Deliver's pre-paste read, #2 Send's harness lookup,
-	// #3 waitForActive's poll (idle → timeout), #4 the JIT pre-nudge re-read —
+	// exactly one poll): #1 terminal-safety lookup, #2 Deliver's pre-paste
+	// read, #3 Send's harness lookup, #4 waitForActive's poll (idle → timeout),
+	// #5 the JIT pre-nudge re-read —
 	// which is the first to see blocked, landing the flip in the exact
 	// post-final-poll / pre-nudge window this test exists to cover.
 	bst := &blockAfterFirstReadStore{fakeStore: st, id: "s1"}
@@ -7958,8 +8017,8 @@ func TestSend_NoNudgeWhenBlockedAppearsBeforeNudge(t *testing.T) {
 	if len(msg.msgs) != 1 {
 		t.Fatalf("Send calls = %d, want 1 (blocked appeared before nudge, JIT re-read caught it)", len(msg.msgs))
 	}
-	if bst.reads < 4 {
-		t.Fatalf("GetSession reads = %d, want >= 4 (the JIT pre-nudge re-read must have run)", bst.reads)
+	if bst.reads < 5 {
+		t.Fatalf("GetSession reads = %d, want >= 5 (the JIT pre-nudge re-read must have run)", bst.reads)
 	}
 }
 
@@ -8024,10 +8083,11 @@ func TestSwitchTargetsOnlyRetryEnterWhenActivitySignalsMakeItSafe(t *testing.T) 
 }
 
 // blockAfterFirstReadStore wraps fakeStore and flips the session to
-// ActivityBlocked on the FOURTH GetSession call, so with attemptDeadline 0 the
+// ActivityBlocked on the FIFTH GetSession call, so with attemptDeadline 0 the
 // first read to observe blocked is confirmActive's just-in-time pre-nudge
-// re-read (reads #1-#3 are Deliver's pre-paste read, Send's harness lookup,
-// and waitForActive's single poll — see TestSend_NoNudgeWhenBlockedAppearsBeforeNudge).
+// re-read (reads #1-#4 are the terminal-safety lookup, Deliver's pre-paste
+// read, Send's harness lookup, and waitForActive's single poll — see
+// TestSend_NoNudgeWhenBlockedAppearsBeforeNudge).
 type blockAfterFirstReadStore struct {
 	*fakeStore
 	id    domain.SessionID
@@ -8036,7 +8096,7 @@ type blockAfterFirstReadStore struct {
 
 func (s *blockAfterFirstReadStore) GetSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error) {
 	s.reads++
-	if s.reads >= 4 {
+	if s.reads >= 5 {
 		if rec, ok := s.sessions[s.id]; ok {
 			rec.Activity.State = domain.ActivityBlocked
 			s.sessions[s.id] = rec


### PR DESCRIPTION
## Summary

- add a narrow terminal decision capability for interactive adapters whose hooks cannot report permission waits
- recognize Agy's permission picker from multiple structural terminal markers
- reject Send before any paste or trailing Enter when the picker is visible
- preserve delivery when terminal output does not authoritatively show a decision prompt

## Problem

Agy currently reports submit and stop activity but cannot report blocked permission state. A stale idle record therefore lets AO paste a Task Pack into the permission UI, where the trailing Enter can approve a command instead of submitting the message.

## Verification

- go test ./internal/adapters/agent/agy -count=1
- go test ./internal/session_manager -run ^TestSend_ -count=1
- go vet ./internal/adapters/agent/agy ./internal/session_manager ./internal/ports
- go build ./...
- git diff --check

The full Windows go test ./... run was stopped after reproducing numerous unrelated main-branch platform/environment failures (POSIX paths, symlink permissions, missing optional reviewer binaries, and environment-sensitive auth probes). The touched Agy package and every Send test pass.