### PR TITLE
fix: reject TUI sends until first agent hook arrives

### DIFF
--- a/backend/internal/adapters/agent/cursor/cursor.go
+++ b/backend/internal/adapters/agent/cursor/cursor.go
@@ -40,6 +40,13 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.StartupInputReadinessSignaler = (*Plugin)(nil)
+
+// FirstSignalProvesInputReady reports that Cursor's sessionStart hook is
+// emitted only after pre-session startup dialogs, including project MCP server
+// approval, have cleared. Before that signal, pane input may be consumed by a
+// dialog instead of the agent composer.
+func (p *Plugin) FirstSignalProvesInputReady() bool { return true }
 
 // cursorDataDir returns the isolated Cursor profile AO uses for managed Cursor
 // sessions. This keeps Cursor's trust/cache state under AO_DATA_DIR instead of

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -62,6 +62,7 @@ func startLifecycle(ctx context.Context, store *sqlite.Store, runtime ports.Runt
 		lifecycle.WithTelemetry(telemetry),
 		lifecycle.WithContainerReaper(dockerreap.New(), store),
 		lifecycle.WithActiveSteering(activeTurnSteering(agents)),
+		lifecycle.WithStartupSignalGate(startupSignalGatesInput(agents)),
 	)
 	rp := reaper.New(lcm, store, runtime, reaper.Config{Logger: logger})
 	activityPoller := activityobserver.New(store, lcm, runtime, agents, activityobserver.Config{Logger: logger})
@@ -70,6 +71,23 @@ func startLifecycle(ctx context.Context, store *sqlite.Store, runtime ports.Runt
 		runtimeReaper: rp,
 		reaperDone:    rp.Start(ctx),
 		activityDone:  activityPoller.Start(ctx),
+	}
+}
+
+// startupSignalGatesInput resolves whether an adapter promises that its first
+// hook proves native TUI startup dialogs have cleared. Unknown and hookless
+// adapters remain ungated.
+func startupSignalGatesInput(agents ports.AgentResolver) func(domain.AgentHarness) bool {
+	return func(harness domain.AgentHarness) bool {
+		if agents == nil {
+			return false
+		}
+		agent, ok := agents.Agent(harness)
+		if !ok {
+			return false
+		}
+		signaler, ok := agent.(ports.StartupInputReadinessSignaler)
+		return ok && signaler.FirstSignalProvesInputReady()
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -170,6 +170,27 @@ func TestWiring_ActiveTurnSteeringComesFromAdapters(t *testing.T) {
 	}
 }
 
+func TestWiring_StartupSignalGateComesFromAdapters(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	agents, err := buildAgentResolver(config.DefaultAgent, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gates := startupSignalGatesInput(agents)
+
+	if !gates(domain.HarnessCursor) {
+		t.Error("cursor declares startup-ready signaling; want its TUI input gated")
+	}
+	for _, harness := range []domain.AgentHarness{domain.HarnessAider, domain.HarnessOMP, "definitely-not-an-agent", ""} {
+		if gates(harness) {
+			t.Errorf("harness %q must not require a startup signal", harness)
+		}
+	}
+	if startupSignalGatesInput(nil)(domain.HarnessCursor) {
+		t.Error("a nil resolver must leave startup input ungated")
+	}
+}
+
 // TestWiring_StartSessionBuildsSessionService asserts the daemon's startSession
 // constructs a real controller-facing session service end to end (resolver +
 // gitworktree workspace + session manager over the shared store/LCM), which is

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -152,6 +152,16 @@ func WithActiveSteering(pred func(domain.AgentHarness) bool) Option {
 	}
 }
 
+// WithStartupSignalGate supplies the adapter capability predicate used to
+// suppress reaction writes until a TUI's first startup-ready hook arrives.
+func WithStartupSignalGate(pred func(domain.AgentHarness) bool) Option {
+	return func(m *Manager) {
+		if pred != nil {
+			m.startupSignalGatesInput = pred
+		}
+	}
+}
+
 // Manager reduces runtime, activity, spawn, and termination observations into durable session facts.
 // It also owns agent nudges caused by PR observations, including merge-conflict, CI-failure, and review-feedback prompts.
 type Manager struct {
@@ -192,7 +202,8 @@ type Manager struct {
 	// active turn (input steers the run) rather than only while idle. Supplied by
 	// the agent adapter via WithActiveSteering; the default answers false, so an
 	// unknown harness is only written to while idle.
-	steerActive func(domain.AgentHarness) bool
+	steerActive             func(domain.AgentHarness) bool
+	startupSignalGatesInput func(domain.AgentHarness) bool
 }
 
 // New builds a Lifecycle Manager over the session store it writes and the messenger it uses for agent nudges.
@@ -203,19 +214,23 @@ func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Ma
 	// WithClock option may still override this in tests.
 	clock := func() time.Time { return time.Now().UTC() }
 	m := &Manager{
-		store:           store,
-		window:          defaultRecentActivityWindow,
-		clock:           clock,
-		react:           newReactionState(),
-		flights:         map[domain.SessionID]*toolFlight{},
-		pendingLaunches: map[domain.SessionID]pendingLaunch{},
-		steerActive:     func(domain.AgentHarness) bool { return false },
+		store:                   store,
+		window:                  defaultRecentActivityWindow,
+		clock:                   clock,
+		react:                   newReactionState(),
+		flights:                 map[domain.SessionID]*toolFlight{},
+		pendingLaunches:         map[domain.SessionID]pendingLaunch{},
+		steerActive:             func(domain.AgentHarness) bool { return false },
+		startupSignalGatesInput: func(domain.AgentHarness) bool { return false },
 	}
 	if messenger != nil {
 		m.guard = sessionguard.New(store, messenger, nil)
 	}
 	for _, opt := range opts {
 		opt(m)
+	}
+	if m.guard != nil {
+		m.guard.SetStartupSignalGate(m.startupSignalGatesInput)
 	}
 	return m
 }

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2613,6 +2613,39 @@ func TestLifecycleNudgeUsesLateBoundSessionInputLease(t *testing.T) {
 	}
 }
 
+func TestLifecycleNudgeStartupGateUsesAdapterCapability(t *testing.T) {
+	tests := []struct {
+		name     string
+		harness  domain.AgentHarness
+		gate     bool
+		wantSent bool
+	}{
+		{name: "startup-signaling adapter is gated", harness: domain.HarnessCursor, gate: true, wantSent: false},
+		{name: "hookless adapter remains deliverable", harness: domain.HarnessAider, gate: false, wantSent: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := newFakeStore()
+			msg := &fakeMessenger{}
+			m := New(st, msg, WithStartupSignalGate(func(harness domain.AgentHarness) bool {
+				return harness == tt.harness && tt.gate
+			}))
+			st.sessions["mer-1"] = domain.SessionRecord{
+				ID: "mer-1", Harness: tt.harness, Mode: domain.SessionModeTUI,
+				Activity: domain.Activity{State: domain.ActivityIdle},
+			}
+
+			outcome, err := m.sendOnce(ctx, "mer-1", "", "tracker-comment:1", "1", "review this", 0)
+			if err != nil {
+				t.Fatalf("sendOnce: %v", err)
+			}
+			if got := len(msg.msgs) == 1; got != tt.wantSent {
+				t.Fatalf("sent = %v, want %v (outcome %v)", got, tt.wantSent, outcome)
+			}
+		})
+	}
+}
+
 func TestApplyTrackerFacts_AssigneeChangedIsLogOnly(t *testing.T) {
 	m, st, msg := newManager()
 	st.sessions["mer-1"] = working("mer-1")

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -378,7 +378,12 @@ func newManager() (*Manager, *fakeStore, *fakeMessenger) {
 }
 
 func working(id domain.SessionID) domain.SessionRecord {
-	return domain.SessionRecord{ID: id, ProjectID: "mer", Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: time.Now()}, AutoInjectReview: true}
+	return domain.SessionRecord{
+		ID: id, ProjectID: "mer",
+		Activity:         domain.Activity{State: domain.ActivityActive, LastActivityAt: time.Now()},
+		AutoInjectReview: true,
+		FirstSignalAt:    time.Now(),
+	}
 }
 
 func TestRuntimeObservation_ConfirmedRuntimeDeathTerminates(t *testing.T) {

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -312,6 +312,15 @@ type BlockedActivitySignaler interface {
 	EmitsBlockedActivity() bool
 }
 
+// StartupInputReadinessSignaler is an OPTIONAL capability for a TUI adapter
+// whose first lifecycle hook cannot arrive until native startup dialogs have
+// cleared and the agent can safely accept pane input. AO gates user and
+// automation writes on FirstSignalAt only for adapters that opt in here;
+// hookless adapters must remain usable without manufacturing a signal.
+type StartupInputReadinessSignaler interface {
+	FirstSignalProvesInputReady() bool
+}
+
 // ActiveTurnSteerer is an OPTIONAL capability an Agent adapter implements when
 // submitting input while its harness is mid-turn STEERS the running turn rather
 // than being swallowed, queued, or applied to a dialog. AO uses it to decide

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -936,6 +936,9 @@ func toAPIError(err error) error {
 	case errors.Is(err, sessionmanager.ErrAwaitingDecision):
 		return apierr.Conflict("SESSION_AWAITING_DECISION",
 			"Session is paused on a permission decision; answer it in the session terminal first", nil)
+	case errors.Is(err, sessionmanager.ErrStartupPending):
+		return apierr.Conflict("SESSION_STARTUP_PENDING",
+			"Session agent is still starting; retry after the agent prompt is ready", nil)
 	case errors.Is(err, sessionmanager.ErrIncompleteHandle):
 		return apierr.Conflict("SESSION_INCOMPLETE_HANDLE", "Session is missing runtime or workspace handles", nil)
 	case errors.Is(err, sessionmanager.ErrNotResumable):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2657,6 +2657,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"unknown harness", fmt.Errorf("spawn: %w: %q", sessionmanager.ErrUnknownHarness, "bogus"), apierr.KindInvalid, "UNKNOWN_HARNESS"},
 		{"missing harness", fmt.Errorf("spawn: %w: configure project worker.agent or pass --harness", sessionmanager.ErrMissingHarness), apierr.KindInvalid, "AGENT_REQUIRED"},
 		{"awaiting decision", fmt.Errorf("send mer-1: %w", sessionmanager.ErrAwaitingDecision), apierr.KindConflict, "SESSION_AWAITING_DECISION"},
+		{"startup pending", fmt.Errorf("send mer-1: %w", sessionmanager.ErrStartupPending), apierr.KindConflict, "SESSION_STARTUP_PENDING"},
 		{"agent exited", fmt.Errorf("send mer-1: %w", sessionmanager.ErrAgentExited), apierr.KindConflict, "AGENT_EXITED"},
 		{"agent not exited", fmt.Errorf("resume agent mer-1: %w", sessionmanager.ErrAgentNotExited), apierr.KindConflict, "AGENT_NOT_EXITED"},
 		{"resume in progress", fmt.Errorf("resume agent mer-1: %w", sessionmanager.ErrResumeInProgress), apierr.KindConflict, "AGENT_RESUME_IN_PROGRESS"},

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -141,6 +141,10 @@ var (
 	// would answer it on the user's behalf. The API maps it to a 409; the
 	// caller retries once the user has answered in the terminal.
 	ErrAwaitingDecision = errors.New("session: awaiting a user decision")
+	// ErrStartupPending means a TUI session has not yet received its first
+	// agent hook callback, so the native startup sequence (including pre-session
+	// approval dialogs) may still be consuming pane input.
+	ErrStartupPending = errors.New("session: agent startup not ready for input")
 
 	// Spawn-stage sentinels. Each is the existing log word after "spawn" /
 	// "spawn <id>:" so wrapping them does not change daemon-log wording, while
@@ -2986,6 +2990,8 @@ func (m *Manager) send(ctx context.Context, id domain.SessionID, message, client
 		return fmt.Errorf("send %s: %w", id, ErrAgentExited)
 	case sessionguard.SuppressedAwaitingUser:
 		return fmt.Errorf("send %s: %w", id, ErrAwaitingDecision)
+	case sessionguard.SuppressedStartupPending:
+		return fmt.Errorf("send %s: %w", id, ErrStartupPending)
 	case sessionguard.SuppressedInputGated:
 		return fmt.Errorf("send %s: %w", id, ErrSwitchInProgress)
 	}
@@ -4053,6 +4059,8 @@ func (m *Manager) deliverAfterStartPrompt(ctx context.Context, agent ports.Agent
 		return fmt.Errorf("send %s: %w", id, ErrAgentExited)
 	case sessionguard.SuppressedAwaitingUser:
 		return fmt.Errorf("send %s: %w", id, ErrAwaitingDecision)
+	case sessionguard.SuppressedStartupPending:
+		return fmt.Errorf("send %s: %w", id, ErrStartupPending)
 	case sessionguard.SuppressedInputGated:
 		return fmt.Errorf("send %s: %w", id, ErrSwitchInProgress)
 	case sessionguard.SuppressedUnknown:

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -731,6 +731,7 @@ func New(d Deps) *Manager {
 	// is built after the logger default).
 	m.messenger = sessionguard.New(d.Store, d.Messenger, m.logger)
 	m.messenger.SetInputLease(m)
+	m.messenger.SetStartupSignalGate(m.harnessStartupSignalGatesInput)
 	return m
 }
 
@@ -3072,6 +3073,18 @@ func (m *Manager) harnessNudgeSafe(harness domain.AgentHarness) bool {
 	}
 	blk, ok := agent.(ports.BlockedActivitySignaler)
 	return ok && blk.EmitsBlockedActivity()
+}
+
+func (m *Manager) harnessStartupSignalGatesInput(harness domain.AgentHarness) bool {
+	if m.agents == nil {
+		return false
+	}
+	agent, ok := m.agents.Agent(harness)
+	if !ok {
+		return false
+	}
+	signaler, ok := agent.(ports.StartupInputReadinessSignaler)
+	return ok && signaler.FirstSignalProvesInputReady()
 }
 
 // waitOutcome is one poll round's verdict on whether confirmActive should

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -7756,6 +7756,10 @@ type signalingAgent struct{ fakeAgent }
 func (signalingAgent) EmitsSubmitActivity() bool  { return true }
 func (signalingAgent) EmitsBlockedActivity() bool { return true }
 
+type startupReadySignalingAgent struct{ fakeAgent }
+
+func (startupReadySignalingAgent) FirstSignalProvesInputReady() bool { return true }
+
 // submitOnlyAgent advertises a prompt-submit signal but NOT a blocked one — a
 // harness like goose/opencode/agy that submits yet installs no permission hook.
 // confirmActive must refuse to nudge it (it could Enter into a decision the
@@ -7935,7 +7939,7 @@ func TestSend_TUIStartupPendingRejectsDelivery(t *testing.T) {
 		Metadata: domain.SessionMetadata{RuntimeHandleID: "h1"},
 	}
 	msg := &fakeMessenger{}
-	m := newSendTestManager(t, fakeAgent{}, msg, st)
+	m := newSendTestManager(t, startupReadySignalingAgent{}, msg, st)
 
 	err := m.Send(context.Background(), "s1", "follow-up after spawn", nil)
 	if !errors.Is(err, ErrStartupPending) {
@@ -7943,6 +7947,24 @@ func TestSend_TUIStartupPendingRejectsDelivery(t *testing.T) {
 	}
 	if len(msg.msgs) != 0 {
 		t.Fatalf("Send calls = %d, want 0 before first hook signal", len(msg.msgs))
+	}
+}
+
+func TestSend_HooklessTUIStartupAllowsDelivery(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["s1"] = domain.SessionRecord{
+		ID: "s1", Harness: domain.HarnessAider, Mode: domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityIdle},
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "h1"},
+	}
+	msg := &fakeMessenger{}
+	m := newSendTestManager(t, fakeAgent{}, msg, st)
+
+	if err := m.Send(context.Background(), "s1", "follow-up after spawn", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("Send calls = %d, want 1 for hookless TUI harness", len(msg.msgs))
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -978,12 +978,12 @@ func (m *fakeMessenger) Send(_ context.Context, id domain.SessionID, msg string)
 
 func TestSend_WrapsCopilotOrchestratorMessageWithDelegationDirective(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{
+	st.sessions["mer-1"] = pastStartupGate(domain.SessionRecord{
 		ID:        "mer-1",
 		ProjectID: "mer",
 		Kind:      domain.KindOrchestrator,
 		Harness:   domain.HarnessCopilot,
-	}
+	})
 	msg := &fakeMessenger{}
 	m := New(Deps{Store: st, Messenger: msg})
 
@@ -1009,12 +1009,12 @@ func TestSend_WrapsCopilotOrchestratorMessageWithDelegationDirective(t *testing.
 
 func TestSend_DoesNotWrapCopilotWorkerMessage(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["mer-2"] = domain.SessionRecord{
+	st.sessions["mer-2"] = pastStartupGate(domain.SessionRecord{
 		ID:        "mer-2",
 		ProjectID: "mer",
 		Kind:      domain.KindWorker,
 		Harness:   domain.HarnessCopilot,
-	}
+	})
 	msg := &fakeMessenger{}
 	m := New(Deps{Store: st, Messenger: msg})
 
@@ -1028,12 +1028,12 @@ func TestSend_DoesNotWrapCopilotWorkerMessage(t *testing.T) {
 
 func TestSend_DoesNotWrapNonCopilotOrchestratorMessage(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{
+	st.sessions["mer-1"] = pastStartupGate(domain.SessionRecord{
 		ID:        "mer-1",
 		ProjectID: "mer",
 		Kind:      domain.KindOrchestrator,
 		Harness:   domain.HarnessClaudeCode,
-	}
+	})
 	msg := &fakeMessenger{}
 	m := New(Deps{Store: st, Messenger: msg})
 
@@ -1048,13 +1048,13 @@ func TestSend_DoesNotWrapNonCopilotOrchestratorMessage(t *testing.T) {
 func TestSend_WritesAttachmentAndAppendsReference(t *testing.T) {
 	dir := t.TempDir()
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{
+	st.sessions["mer-1"] = pastStartupGate(domain.SessionRecord{
 		ID:        "mer-1",
 		ProjectID: "mer",
 		Kind:      domain.KindWorker,
 		Harness:   domain.HarnessClaudeCode,
 		Metadata:  domain.SessionMetadata{WorkspacePath: dir},
-	}
+	})
 	msg := &fakeMessenger{}
 	ws := &fakeWorkspace{}
 	m := New(Deps{Store: st, Messenger: msg, Workspace: ws, DataDir: t.TempDir()})
@@ -1101,7 +1101,7 @@ func TestSend_WritesAttachmentAndAppendsReference(t *testing.T) {
 
 func TestSend_WithoutAttachmentSkipsWorkspaceWrite(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}
+	st.sessions["mer-1"] = pastStartupGate(domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker})
 	msg := &fakeMessenger{}
 	ws := &fakeWorkspace{}
 	m := New(Deps{Store: st, Messenger: msg, Workspace: ws})
@@ -7789,12 +7789,21 @@ func newSendTestManager(t *testing.T, agent ports.Agent, messenger ports.AgentMe
 	return m
 }
 
+// pastStartupGate marks a TUI session as having received its first hook
+// callback so send-path tests exercise post-startup behavior.
+func pastStartupGate(rec domain.SessionRecord) domain.SessionRecord {
+	if rec.FirstSignalAt.IsZero() {
+		rec.FirstSignalAt = time.Now()
+	}
+	return rec
+}
+
 func TestSend_SkipsConfirmForHooklessHarness(t *testing.T) {
 	// A harness whose adapter does NOT implement the activity-signal interfaces (plain
 	// fakeAgent) must skip confirmActive entirely: one Send, no nudges, and the
 	// call returns immediately without polling.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code"}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code"})
 	msg := &fakeMessenger{}
 	m := newSendTestManager(t, fakeAgent{}, msg, st)
 
@@ -7813,7 +7822,7 @@ func TestSend_SkipsConfirmForHooklessHarness(t *testing.T) {
 
 func TestSend_RecordsDeliveredUserInput(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code"}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code"})
 	m := newSendTestManager(t, fakeAgent{}, &fakeMessenger{}, st)
 
 	if err := m.Send(context.Background(), "s1", "continue with the migration", nil); err != nil {
@@ -7829,8 +7838,8 @@ func TestSend_ConfirmsAndNudgesUntilActive(t *testing.T) {
 	// flip the session active, after which confirmActive stops. Net: the
 	// initial message plus exactly one nudge.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code",
-		Activity: domain.Activity{State: domain.ActivityIdle}}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code",
+		Activity: domain.Activity{State: domain.ActivityIdle}})
 	// A messenger that flips the session active on the first Enter-only nudge,
 	// mimicking the agent accepting the prompt.
 	msg := &flipOnNudgeMessenger{sessionID: "s1", store: st}
@@ -7857,8 +7866,8 @@ func TestSend_ConfirmBudgetCapsRetries(t *testing.T) {
 	// A signaling harness that never goes active must still terminate: at most
 	// maxAttempts Sends (initial + maxAttempts-1 nudges), and Send never errors.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code",
-		Activity: domain.Activity{State: domain.ActivityIdle}}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code",
+		Activity: domain.Activity{State: domain.ActivityIdle}})
 	msg := &fakeMessenger{}
 	m := newSendTestManager(t, signalingAgent{}, msg, st)
 	var logBuf bytes.Buffer
@@ -7888,8 +7897,8 @@ func TestSend_BlockedSessionRejectsDelivery(t *testing.T) {
 	// Send surfaces ErrAwaitingDecision (the API's 409) and the messenger is
 	// never called, so nothing — message or nudge — reaches the pane.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code",
-		Activity: domain.Activity{State: domain.ActivityBlocked}}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code",
+		Activity: domain.Activity{State: domain.ActivityBlocked}})
 	msg := &fakeMessenger{}
 	m := newSendTestManager(t, signalingAgent{}, msg, st)
 
@@ -7918,13 +7927,32 @@ func TestSend_ExitedAgentRejectsDelivery(t *testing.T) {
 	}
 }
 
+func TestSend_TUIStartupPendingRejectsDelivery(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["s1"] = domain.SessionRecord{
+		ID: "s1", Harness: domain.HarnessCursor, Mode: domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityIdle},
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "h1"},
+	}
+	msg := &fakeMessenger{}
+	m := newSendTestManager(t, fakeAgent{}, msg, st)
+
+	err := m.Send(context.Background(), "s1", "follow-up after spawn", nil)
+	if !errors.Is(err, ErrStartupPending) {
+		t.Fatalf("Send error = %v, want ErrStartupPending", err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("Send calls = %d, want 0 before first hook signal", len(msg.msgs))
+	}
+}
+
 func TestSend_NoNudgeWhenBlockedAppearsMidWait(t *testing.T) {
 	// The permission dialog can appear between polls (e.g. the delivered prompt
 	// itself triggered a tool approval). The confirm loop must abort on the
 	// first blocked observation instead of nudging after the deadline.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code",
-		Activity: domain.Activity{State: domain.ActivityIdle}}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code",
+		Activity: domain.Activity{State: domain.ActivityIdle}})
 	msg := &blockOnSendMessenger{sessionID: "s1", store: st}
 	m := newSendTestManager(t, signalingAgent{}, msg, st)
 
@@ -7941,8 +7969,8 @@ func TestSend_StillNudgesWhenWaitingInput(t *testing.T) {
 	// PRIMARY nudge scenario: a long-idle worker with an unsubmitted pasted
 	// draft. The decision-safety guard must not disable it.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code",
-		Activity: domain.Activity{State: domain.ActivityWaitingInput}}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code",
+		Activity: domain.Activity{State: domain.ActivityWaitingInput}})
 	msg := &flipOnNudgeMessenger{sessionID: "s1", store: st}
 	m := newSendTestManager(t, signalingAgent{}, msg, st)
 
@@ -7981,8 +8009,8 @@ func TestSend_NoNudgeWhenBlockedAppearsBeforeNudge(t *testing.T) {
 	// before the Enter-only nudge. The just-in-time re-read in confirmActive
 	// must catch it — exactly one Send, no nudge.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "claude-code",
-		Activity: domain.Activity{State: domain.ActivityIdle}}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "claude-code",
+		Activity: domain.Activity{State: domain.ActivityIdle}})
 	// blockAfterFirstReadStore flips the session to blocked on read #4. The
 	// deterministic read sequence (attemptDeadline 0 makes waitForActive do
 	// exactly one poll): #1 Deliver's pre-paste read, #2 Send's harness lookup,
@@ -8014,8 +8042,8 @@ func TestSend_SkipsConfirmForSubmitOnlyHarness(t *testing.T) {
 	// NOT nudge-safe: confirmActive must be skipped entirely, so an Enter can
 	// never reach a permission dialog the harness could not have signalled.
 	st := newFakeStore()
-	st.sessions["s1"] = domain.SessionRecord{ID: "s1", Harness: "goose",
-		Activity: domain.Activity{State: domain.ActivityIdle}}
+	st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Harness: "goose",
+		Activity: domain.Activity{State: domain.ActivityIdle}})
 	msg := &fakeMessenger{}
 	m := newSendTestManager(t, submitOnlyAgent{}, msg, st)
 

--- a/backend/internal/session_manager/message_delivery.go
+++ b/backend/internal/session_manager/message_delivery.go
@@ -37,6 +37,7 @@ func (m *Manager) WaitForMessageDeliveryReady(ctx context.Context, id domain.Ses
 	mode := domain.NormalizeSessionMode(rec.Mode)
 	var detector ports.TerminalActivityDetector
 	var handle ports.RuntimeHandle
+	requireFirstSignal := false
 	if mode == domain.SessionModeTUI {
 		if rec.Metadata.RuntimeHandleID == "" {
 			return ErrIncompleteHandle
@@ -46,6 +47,8 @@ func (m *Manager) WaitForMessageDeliveryReady(ctx context.Context, id domain.Ses
 			return fmt.Errorf("%w: %s", ErrUnknownHarness, rec.Harness)
 		}
 		detector, _ = agent.(ports.TerminalActivityDetector)
+		signaler, signalsReadiness := agent.(ports.StartupInputReadinessSignaler)
+		requireFirstSignal = signalsReadiness && signaler.FirstSignalProvesInputReady()
 		handle = runtimeHandle(rec.Metadata)
 	}
 
@@ -79,11 +82,15 @@ func (m *Manager) WaitForMessageDeliveryReady(ctx context.Context, id domain.Ses
 				}
 			} else {
 				// MarkSpawned records idle before the TUI is necessarily ready.
-				// A first hook signal proves the relaunched agent reached its own
-				// startup lifecycle. Hookless adapters get a bounded degraded
-				// fallback while idle so title refinement remains best-effort.
-				ready = ready && !rec.FirstSignalAt.IsZero()
-				if !ready && rec.Activity.State == domain.ActivityIdle && time.Since(startedAt) >= messageDeliveryReadyFallback {
+				// Capability-declaring adapters require their first startup-ready
+				// hook. Hookless adapters retain the bounded degraded fallback that
+				// existed before the startup input gate.
+				if requireFirstSignal {
+					ready = ready && !rec.FirstSignalAt.IsZero()
+				} else {
+					ready = false
+				}
+				if !requireFirstSignal && rec.Activity.State == domain.ActivityIdle && time.Since(startedAt) >= messageDeliveryReadyFallback {
 					m.logger.Warn("message delivery readiness timed out; falling back while session is idle",
 						"sessionID", id,
 						"timeout", messageDeliveryReadyFallback.String(),

--- a/backend/internal/session_manager/message_delivery_test.go
+++ b/backend/internal/session_manager/message_delivery_test.go
@@ -71,7 +71,7 @@ func TestWaitForMessageDeliveryReadyWaitsForFirstHookSignal(t *testing.T) {
 		Activity:  domain.Activity{State: domain.ActivityIdle},
 		Metadata:  domain.SessionMetadata{RuntimeHandleID: "cursor-1"},
 	}
-	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: fakeAgent{}}, Store: st})
+	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: startupReadySignalingAgent{}}, Store: st})
 
 	done := make(chan error, 1)
 	go func() {

--- a/backend/internal/session_manager/message_delivery_test.go
+++ b/backend/internal/session_manager/message_delivery_test.go
@@ -60,3 +60,35 @@ func TestWaitForMessageDeliveryReadyHonorsContextWhileTerminalStarts(t *testing.
 		t.Fatalf("WaitForMessageDeliveryReady error = %v, want context deadline", err)
 	}
 }
+
+func TestWaitForMessageDeliveryReadyWaitsForFirstHookSignal(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["cursor-1"] = domain.SessionRecord{
+		ID:        "cursor-1",
+		ProjectID: "phoenix",
+		Harness:   domain.HarnessCursor,
+		Mode:      domain.SessionModeTUI,
+		Activity:  domain.Activity{State: domain.ActivityIdle},
+		Metadata:  domain.SessionMetadata{RuntimeHandleID: "cursor-1"},
+	}
+	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: fakeAgent{}}, Store: st})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.WaitForMessageDeliveryReady(context.Background(), "cursor-1")
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	rec := st.sessions["cursor-1"]
+	rec.FirstSignalAt = time.Now()
+	st.sessions["cursor-1"] = rec
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WaitForMessageDeliveryReady: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for readiness after first hook signal")
+	}
+}

--- a/backend/internal/session_manager/message_delivery_test.go
+++ b/backend/internal/session_manager/message_delivery_test.go
@@ -3,11 +3,31 @@ package sessionmanager
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
+
+type synchronizedSessionStore struct {
+	*fakeStore
+	mu sync.RWMutex
+}
+
+func (s *synchronizedSessionStore) GetSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.fakeStore.GetSession(ctx, id)
+}
+
+func (s *synchronizedSessionStore) markFirstSignal(id domain.SessionID, at time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec := s.sessions[id]
+	rec.FirstSignalAt = at
+	s.sessions[id] = rec
+}
 
 type terminalReadyAgent struct{ fakeAgent }
 
@@ -62,7 +82,7 @@ func TestWaitForMessageDeliveryReadyHonorsContextWhileTerminalStarts(t *testing.
 }
 
 func TestWaitForMessageDeliveryReadyWaitsForFirstHookSignal(t *testing.T) {
-	st := newFakeStore()
+	st := &synchronizedSessionStore{fakeStore: newFakeStore()}
 	st.sessions["cursor-1"] = domain.SessionRecord{
 		ID:        "cursor-1",
 		ProjectID: "phoenix",
@@ -79,9 +99,7 @@ func TestWaitForMessageDeliveryReadyWaitsForFirstHookSignal(t *testing.T) {
 	}()
 
 	time.Sleep(30 * time.Millisecond)
-	rec := st.sessions["cursor-1"]
-	rec.FirstSignalAt = time.Now()
-	st.sessions["cursor-1"] = rec
+	st.markFirstSignal("cursor-1", time.Now())
 
 	select {
 	case err := <-done:

--- a/backend/internal/sessionguard/guard.go
+++ b/backend/internal/sessionguard/guard.go
@@ -67,6 +67,11 @@ const (
 	// agent switch, resume, restore, or kill) closed pane-input admission before
 	// this write acquired a lease.
 	SuppressedInputGated
+	// SuppressedStartupPending means a TUI session has not yet received its
+	// first agent hook callback. Pre-session dialogs (for example Cursor's MCP
+	// server approval) leave the row idle with FirstSignalAt unset; writing
+	// there consumes input on the dialog instead of the agent composer.
+	SuppressedStartupPending
 )
 
 // String names the outcome for logs.
@@ -86,9 +91,37 @@ func (o Outcome) String() string {
 		return "suppressed_busy"
 	case SuppressedInputGated:
 		return "suppressed_input_gated"
+	case SuppressedStartupPending:
+		return "suppressed_startup_pending"
 	default:
 		return "suppressed_unknown"
 	}
+}
+
+// tuiAwaitingStartupInput reports whether a TUI session is still in its native
+// startup sequence before the first hook callback arrives.
+func tuiAwaitingStartupInput(rec domain.SessionRecord) bool {
+	return domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeTUI && rec.FirstSignalAt.IsZero()
+}
+
+func refuseDeliver(rec domain.SessionRecord) (Outcome, bool) {
+	if tuiAwaitingStartupInput(rec) {
+		return SuppressedStartupPending, true
+	}
+	if rec.Activity.State == domain.ActivityBlocked {
+		return SuppressedAwaitingUser, true
+	}
+	return SuppressedUnknown, false
+}
+
+func refuseNudge(rec domain.SessionRecord) (Outcome, bool) {
+	if tuiAwaitingStartupInput(rec) {
+		return SuppressedStartupPending, true
+	}
+	if rec.Activity.State.NeedsInput() {
+		return SuppressedAwaitingUser, true
+	}
+	return SuppressedUnknown, false
 }
 
 // Guard is the guarded pane-write primitive shared by the session manager and
@@ -145,9 +178,7 @@ func (g *Guard) Send(ctx context.Context, id domain.SessionID, msg string) error
 // sitting at an idle prompt is exactly where a user message (or the Enter that
 // submits its unsent draft) belongs.
 func (g *Guard) Deliver(ctx context.Context, id domain.SessionID, msg string) (Outcome, error) {
-	return g.send(ctx, id, msg, func(rec domain.SessionRecord) (Outcome, bool) {
-		return SuppressedAwaitingUser, rec.Activity.State == domain.ActivityBlocked
-	})
+	return g.send(ctx, id, msg, refuseDeliver)
 }
 
 // DeliverWithPostWrite is Deliver plus a callback that runs only after a
@@ -155,9 +186,7 @@ func (g *Guard) Deliver(ctx context.Context, id domain.SessionID, msg string) (O
 // Manager uses it to persist narrow message facts before a provider switch can
 // close admission and snapshot handoff context.
 func (g *Guard) DeliverWithPostWrite(ctx context.Context, id domain.SessionID, msg string, after func(context.Context) error) (Outcome, error) {
-	return g.sendThen(ctx, id, msg, func(rec domain.SessionRecord) (Outcome, bool) {
-		return SuppressedAwaitingUser, rec.Activity.State == domain.ActivityBlocked
-	}, after)
+	return g.sendThen(ctx, id, msg, refuseDeliver, after)
 }
 
 // DeliverUnderMutation applies the same just-in-time session safety checks as
@@ -232,9 +261,7 @@ func (g *Guard) coordinationUnderMutation(
 // decision or waiting at the prompt — because an automated paste+Enter there
 // either answers a dialog or submits text the user never saw.
 func (g *Guard) Nudge(ctx context.Context, id domain.SessionID, msg string) (Outcome, error) {
-	return g.send(ctx, id, msg, func(rec domain.SessionRecord) (Outcome, bool) {
-		return SuppressedAwaitingUser, rec.Activity.State.NeedsInput()
-	})
+	return g.send(ctx, id, msg, refuseNudge)
 }
 
 // NudgeCoordination writes an AO-initiated coordination message under the full
@@ -246,6 +273,9 @@ func (g *Guard) Nudge(ctx context.Context, id domain.SessionID, msg string) (Out
 // unsolicited write during a live turn.
 func (g *Guard) NudgeCoordination(ctx context.Context, id domain.SessionID, msg string, steersActiveTurn func(domain.AgentHarness) bool) (Outcome, error) {
 	return g.send(ctx, id, msg, func(rec domain.SessionRecord) (Outcome, bool) {
+		if tuiAwaitingStartupInput(rec) {
+			return SuppressedStartupPending, true
+		}
 		if rec.Activity.State.NeedsInput() {
 			return SuppressedAwaitingUser, true
 		}

--- a/backend/internal/sessionguard/guard.go
+++ b/backend/internal/sessionguard/guard.go
@@ -98,32 +98,6 @@ func (o Outcome) String() string {
 	}
 }
 
-// tuiAwaitingStartupInput reports whether a TUI session is still in its native
-// startup sequence before the first hook callback arrives.
-func tuiAwaitingStartupInput(rec domain.SessionRecord) bool {
-	return domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeTUI && rec.FirstSignalAt.IsZero()
-}
-
-func refuseDeliver(rec domain.SessionRecord) (Outcome, bool) {
-	if tuiAwaitingStartupInput(rec) {
-		return SuppressedStartupPending, true
-	}
-	if rec.Activity.State == domain.ActivityBlocked {
-		return SuppressedAwaitingUser, true
-	}
-	return SuppressedUnknown, false
-}
-
-func refuseNudge(rec domain.SessionRecord) (Outcome, bool) {
-	if tuiAwaitingStartupInput(rec) {
-		return SuppressedStartupPending, true
-	}
-	if rec.Activity.State.NeedsInput() {
-		return SuppressedAwaitingUser, true
-	}
-	return SuppressedUnknown, false
-}
-
 // Guard is the guarded pane-write primitive shared by the session manager and
 // lifecycle. Its small lease lock only protects late binding; it is never held
 // across a store read or pane write. It implements
@@ -136,9 +110,42 @@ type Guard struct {
 
 	leaseMu sync.RWMutex
 	lease   InputLease
+
+	startupGateMu           sync.RWMutex
+	startupSignalGatesInput func(domain.AgentHarness) bool
 }
 
 var _ ports.AgentMessenger = (*Guard)(nil)
+
+func (g *Guard) tuiAwaitingStartupInput(rec domain.SessionRecord) bool {
+	if domain.NormalizeSessionMode(rec.Mode) != domain.SessionModeTUI || !rec.FirstSignalAt.IsZero() {
+		return false
+	}
+	g.startupGateMu.RLock()
+	requiresSignal := g.startupSignalGatesInput
+	g.startupGateMu.RUnlock()
+	return requiresSignal != nil && requiresSignal(rec.Harness)
+}
+
+func (g *Guard) refuseDeliver(rec domain.SessionRecord) (Outcome, bool) {
+	if g.tuiAwaitingStartupInput(rec) {
+		return SuppressedStartupPending, true
+	}
+	if rec.Activity.State == domain.ActivityBlocked {
+		return SuppressedAwaitingUser, true
+	}
+	return SuppressedUnknown, false
+}
+
+func (g *Guard) refuseNudge(rec domain.SessionRecord) (Outcome, bool) {
+	if g.tuiAwaitingStartupInput(rec) {
+		return SuppressedStartupPending, true
+	}
+	if rec.Activity.State.NeedsInput() {
+		return SuppressedAwaitingUser, true
+	}
+	return SuppressedUnknown, false
+}
 
 // New builds a Guard over the store it re-reads and the messenger it writes
 // through. A nil logger falls back to slog.Default().
@@ -156,6 +163,15 @@ func (g *Guard) SetInputLease(lease InputLease) {
 	g.leaseMu.Lock()
 	g.lease = lease
 	g.leaseMu.Unlock()
+}
+
+// SetStartupSignalGate supplies the adapter capability predicate that decides
+// whether a TUI session must receive its first hook before pane input is safe.
+// A nil predicate leaves hookless and unknown adapters ungated.
+func (g *Guard) SetStartupSignalGate(pred func(domain.AgentHarness) bool) {
+	g.startupGateMu.Lock()
+	g.startupSignalGatesInput = pred
+	g.startupGateMu.Unlock()
 }
 
 // Send satisfies ports.AgentMessenger so a Guard can sit in for the raw
@@ -178,7 +194,7 @@ func (g *Guard) Send(ctx context.Context, id domain.SessionID, msg string) error
 // sitting at an idle prompt is exactly where a user message (or the Enter that
 // submits its unsent draft) belongs.
 func (g *Guard) Deliver(ctx context.Context, id domain.SessionID, msg string) (Outcome, error) {
-	return g.send(ctx, id, msg, refuseDeliver)
+	return g.send(ctx, id, msg, g.refuseDeliver)
 }
 
 // DeliverWithPostWrite is Deliver plus a callback that runs only after a
@@ -186,7 +202,7 @@ func (g *Guard) Deliver(ctx context.Context, id domain.SessionID, msg string) (O
 // Manager uses it to persist narrow message facts before a provider switch can
 // close admission and snapshot handoff context.
 func (g *Guard) DeliverWithPostWrite(ctx context.Context, id domain.SessionID, msg string, after func(context.Context) error) (Outcome, error) {
-	return g.sendThen(ctx, id, msg, refuseDeliver, after)
+	return g.sendThen(ctx, id, msg, g.refuseDeliver, after)
 }
 
 // DeliverUnderMutation applies the same just-in-time session safety checks as
@@ -261,7 +277,7 @@ func (g *Guard) coordinationUnderMutation(
 // decision or waiting at the prompt — because an automated paste+Enter there
 // either answers a dialog or submits text the user never saw.
 func (g *Guard) Nudge(ctx context.Context, id domain.SessionID, msg string) (Outcome, error) {
-	return g.send(ctx, id, msg, refuseNudge)
+	return g.send(ctx, id, msg, g.refuseNudge)
 }
 
 // NudgeCoordination writes an AO-initiated coordination message under the full
@@ -273,7 +289,7 @@ func (g *Guard) Nudge(ctx context.Context, id domain.SessionID, msg string) (Out
 // unsolicited write during a live turn.
 func (g *Guard) NudgeCoordination(ctx context.Context, id domain.SessionID, msg string, steersActiveTurn func(domain.AgentHarness) bool) (Outcome, error) {
 	return g.send(ctx, id, msg, func(rec domain.SessionRecord) (Outcome, bool) {
-		if tuiAwaitingStartupInput(rec) {
+		if g.tuiAwaitingStartupInput(rec) {
 			return SuppressedStartupPending, true
 		}
 		if rec.Activity.State.NeedsInput() {

--- a/backend/internal/sessionguard/guard_test.go
+++ b/backend/internal/sessionguard/guard_test.go
@@ -123,6 +123,7 @@ func TestGuard_TUIStartupPendingBlocksDeliver(t *testing.T) {
 		Activity: domain.Activity{State: domain.ActivityIdle},
 	}
 	g := New(&fakeStore{rec: rec, ok: true}, msgr, nil)
+	g.SetStartupSignalGate(func(domain.AgentHarness) bool { return true })
 
 	got, err := g.Deliver(context.Background(), "s1", "follow-up")
 	if err != nil {
@@ -143,6 +144,29 @@ func TestGuard_TUIStartupPendingBlocksDeliver(t *testing.T) {
 	}
 	if got != Sent {
 		t.Fatalf("outcome after signal = %v, want Sent", got)
+	}
+}
+
+func TestGuard_TUIWithoutStartupCapabilityAllowsDelivery(t *testing.T) {
+	msgr := &fakeMessenger{}
+	rec := domain.SessionRecord{
+		ID:       "s1",
+		Harness:  domain.HarnessAider,
+		Mode:     domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityIdle},
+	}
+	g := New(&fakeStore{rec: rec, ok: true}, msgr, nil)
+	g.SetStartupSignalGate(func(domain.AgentHarness) bool { return false })
+
+	got, err := g.Deliver(context.Background(), "s1", "follow-up")
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if got != Sent {
+		t.Fatalf("outcome = %v, want Sent for adapter without startup capability", got)
+	}
+	if len(msgr.sent) != 1 {
+		t.Fatalf("messenger sends = %d, want 1", len(msgr.sent))
 	}
 }
 

--- a/backend/internal/sessionguard/guard_test.go
+++ b/backend/internal/sessionguard/guard_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
@@ -59,7 +60,12 @@ func (m *blockingMessenger) Send(context.Context, domain.SessionID, string) erro
 }
 
 func record(state domain.ActivityState, terminated bool) domain.SessionRecord {
-	return domain.SessionRecord{ID: "s1", IsTerminated: terminated, Activity: domain.Activity{State: state}}
+	return domain.SessionRecord{
+		ID:            "s1",
+		IsTerminated:  terminated,
+		Activity:      domain.Activity{State: state},
+		FirstSignalAt: time.Now(),
+	}
 }
 
 func TestGuard_OutcomeByState(t *testing.T) {
@@ -106,6 +112,37 @@ func TestGuard_OutcomeByState(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGuard_TUIStartupPendingBlocksDeliver(t *testing.T) {
+	msgr := &fakeMessenger{}
+	rec := domain.SessionRecord{
+		ID:       "s1",
+		Mode:     domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityIdle},
+	}
+	g := New(&fakeStore{rec: rec, ok: true}, msgr, nil)
+
+	got, err := g.Deliver(context.Background(), "s1", "follow-up")
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if got != SuppressedStartupPending {
+		t.Fatalf("outcome = %v, want SuppressedStartupPending", got)
+	}
+	if len(msgr.sent) != 0 {
+		t.Fatalf("messenger sends = %d, want 0 before first hook", len(msgr.sent))
+	}
+
+	rec.FirstSignalAt = time.Now()
+	g = New(&fakeStore{rec: rec, ok: true}, msgr, nil)
+	got, err = g.Deliver(context.Background(), "s1", "follow-up")
+	if err != nil {
+		t.Fatalf("Deliver after signal: %v", err)
+	}
+	if got != Sent {
+		t.Fatalf("outcome after signal = %v, want Sent", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Gate TUI pane delivery on `FirstSignalAt` only for adapters that explicitly declare `StartupInputReadinessSignaler`.
- Make Cursor opt into that capability because its `sessionStart` hook arrives after pre-session dialogs such as project MCP approval.
- Return `SESSION_STARTUP_PENDING` (409) instead of reporting success when user or automation input would land on Cursor's startup dialog.
- Keep hookless TUI adapters such as Aider and OMP deliverable; unknown adapters default to the compatibility-safe ungated behavior.
- Apply the same adapter-backed policy to Session Manager sends, lifecycle reaction nudges, and message-delivery readiness waits.
- Keep mutation-owned spawn/restore writes on `DeliverUnderMutation`; only ordinary user and automation delivery is gated.

Fixes #4333.

## Test plan

- [x] Cursor TUI with no first signal rejects delivery without writing to the pane.
- [x] Cursor TUI accepts delivery after the first hook signal.
- [x] Hookless Aider/OMP and unknown adapters do not get permanently stuck in `SESSION_STARTUP_PENDING`.
- [x] Lifecycle nudges consume the same adapter capability as ordinary sends.
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs --timeout=20m` — 0 issues
- [ ] Live Cursor TUI: send while MCP approval is visible, approve it, then retry after `sessionStart`.
