### PR TITLE
fix(frontend): lock task launch controls while starting

### DIFF
--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -233,19 +233,23 @@ describe("TaskComposer", () => {
 		const agent = await screen.findByTestId("agent-field");
 		await waitFor(() => expect(agent).toHaveAttribute("data-value", "codex"));
 		const model = screen.getByRole("textbox", { name: "Model" });
+		const prompt = task();
 		expect(agent).toBeEnabled();
 		expect(model).toBeEnabled();
+		expect(prompt).toBeEnabled();
 
 		fireEvent.click(screen.getByRole("button", { name: "Start task" }));
 
 		await waitFor(() => expect(h.post).toHaveBeenCalledOnce());
 		expect(agent).toBeDisabled();
 		expect(model).toBeDisabled();
+		expect(prompt).toBeDisabled();
 
 		await act(async () => rejectCreate(new Error("creation failed")));
 		await screen.findByText("creation failed");
 		expect(agent).toBeEnabled();
 		expect(model).toBeEnabled();
+		expect(prompt).toBeEnabled();
 	});
 
 	it("attaches a selected file and sends it in the delegate body", async () => {

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -23,10 +23,12 @@ vi.mock("./CreateProjectAgentSheet", () => ({
 		value,
 		onChange,
 		triggerClassName,
+		disabled,
 	}: {
 		value: string;
 		onChange: (value: string) => void;
 		triggerClassName?: string;
+		disabled?: boolean;
 	}) => {
 		h.agentValues.push(value);
 		return (
@@ -36,6 +38,7 @@ vi.mock("./CreateProjectAgentSheet", () => ({
 				className={triggerClassName}
 				data-testid="agent-field"
 				data-value={value}
+				disabled={disabled}
 				onClick={() => onChange(value === "codex" ? "claude-code" : "codex")}
 			/>
 		);
@@ -201,6 +204,48 @@ describe("TaskComposer", () => {
 		await act(async () => resolveCreate({ data: { workerId: "sess-1" } }));
 		await waitFor(() => expect(onCreated).toHaveBeenCalledWith("sess-1"));
 		await waitFor(() => expect(onSubmittingChange).toHaveBeenLastCalledWith(false));
+	});
+
+	it("locks agent and model selection while task creation is in flight, then unlocks them after failure", async () => {
+		h.get.mockImplementation(async (path: string) => {
+			if (path.includes("/models")) {
+				return {
+					data: {
+						agent: "codex",
+						selectionMode: "text",
+						models: [],
+						allowCustom: true,
+						refreshRecommended: false,
+					},
+				};
+			}
+			return { data: { status: "ok", project: { agent: "codex", config: {} } } };
+		});
+		let rejectCreate!: (error: Error) => void;
+		h.post.mockReturnValueOnce(new Promise((_resolve, reject) => (rejectCreate = reject)));
+
+		render(
+			<Wrap>
+				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+			</Wrap>,
+		);
+
+		const agent = await screen.findByTestId("agent-field");
+		await waitFor(() => expect(agent).toHaveAttribute("data-value", "codex"));
+		const model = screen.getByRole("textbox", { name: "Model" });
+		expect(agent).toBeEnabled();
+		expect(model).toBeEnabled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Start task" }));
+
+		await waitFor(() => expect(h.post).toHaveBeenCalledOnce());
+		expect(agent).toBeDisabled();
+		expect(model).toBeDisabled();
+
+		await act(async () => rejectCreate(new Error("creation failed")));
+		await screen.findByText("creation failed");
+		expect(agent).toBeEnabled();
+		expect(model).toBeEnabled();
 	});
 
 	it("attaches a selected file and sends it in the delegate body", async () => {

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -232,7 +232,7 @@ describe("TaskComposer", () => {
 
 		const agent = await screen.findByTestId("agent-field");
 		await waitFor(() => expect(agent).toHaveAttribute("data-value", "codex"));
-		const model = screen.getByRole("textbox", { name: "Model" });
+		const model = await screen.findByRole("textbox", { name: "Model" });
 		const prompt = task();
 		expect(agent).toBeEnabled();
 		expect(model).toBeEnabled();
@@ -250,6 +250,71 @@ describe("TaskComposer", () => {
 		expect(agent).toBeEnabled();
 		expect(model).toBeEnabled();
 		expect(prompt).toBeEnabled();
+	});
+
+	it.each([
+		{
+			name: "mode",
+			catalog: {
+				agent: "codex",
+				selectionMode: "mode",
+				models: [{ id: "plan", label: "Plan", isDefault: true }],
+				allowCustom: false,
+			},
+			controls: async () => [await screen.findByRole("button", { name: "Model" })],
+		},
+		{
+			name: "catalog",
+			catalog: {
+				agent: "codex",
+				selectionMode: "catalog",
+				models: [{ id: "gpt-5", label: "GPT-5", isDefault: true }],
+				allowCustom: false,
+			},
+			controls: async () => [await screen.findByRole("button", { name: "Model" })],
+		},
+		{
+			name: "custom input and browse",
+			catalog: {
+				agent: "codex",
+				selectionMode: "catalog",
+				models: [{ id: "gpt-5", label: "GPT-5", isDefault: true }],
+				allowCustom: true,
+			},
+			controls: async () => {
+				await userEvent.click(await screen.findByRole("button", { name: "Model" }));
+				await userEvent.click(await screen.findByRole("menuitem", { name: "Custom model…" }));
+				return [
+					screen.getByRole("textbox", { name: "Model" }),
+					screen.getByRole("button", { name: "Model options" }),
+				];
+			},
+		},
+	])("locks the $name selector while creating and restores it after failure", async ({ catalog, controls }) => {
+		h.get.mockImplementation(async (path: string) => {
+			if (path.includes("/models")) return { data: catalog };
+			return { data: { status: "ok", project: { agent: "codex", config: {} } } };
+		});
+		let rejectCreate!: (error: Error) => void;
+		h.post.mockReturnValueOnce(new Promise((_resolve, reject) => (rejectCreate = reject)));
+
+		render(
+			<Wrap>
+				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+			</Wrap>,
+		);
+
+		const modelControls = await controls();
+		for (const control of modelControls) expect(control).toBeEnabled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Start task" }));
+
+		await waitFor(() => expect(h.post).toHaveBeenCalledOnce());
+		for (const control of modelControls) expect(control).toBeDisabled();
+
+		await act(async () => rejectCreate(new Error("creation failed")));
+		await screen.findByText("creation failed");
+		for (const control of modelControls) expect(control).toBeEnabled();
 	});
 
 	it("attaches a selected file and sends it in the delegate body", async () => {

--- a/frontend/src/renderer/components/TaskComposer.tsx
+++ b/frontend/src/renderer/components/TaskComposer.tsx
@@ -377,7 +377,7 @@ export function TaskComposer({
 				authorized: agentCatalog?.authorized,
 				installed: agentCatalog?.installed,
 				supported: agentCatalog?.supported,
-				disabled: agentsQuery.isFetching && agentCatalog === undefined,
+				disabled: isSubmitting || (agentsQuery.isFetching && agentCatalog === undefined),
 				onChange: (value) => {
 					setAgent(value);
 					setAgentTouched(true);
@@ -390,6 +390,7 @@ export function TaskComposer({
 				agentId: selectedAgent,
 				agentLabel: selectedAgentLabel,
 				projectId: projectId ?? "",
+				disabled: isSubmitting,
 				value: model,
 				mode,
 				catalog: modelCatalog,
@@ -447,6 +448,7 @@ function TaskModelPicker({
 	agentId,
 	agentLabel,
 	catalog,
+	disabled,
 	fetching,
 	loading,
 	value,
@@ -485,6 +487,7 @@ function TaskModelPicker({
 		return (
 			<SettingsOptionMenu
 				aria-label={t("newTask.model")}
+				disabled={disabled}
 				value={mode || "__default__"}
 				options={options}
 				triggerClassName="composer-chip composer-toolbar-option w-full justify-between"
@@ -522,6 +525,7 @@ function TaskModelPicker({
 				value={value}
 				models={displayModels}
 				allowCustom={catalog.allowCustom}
+				disabled={disabled}
 				emptyLabel={noOverrideLabel}
 				onChange={selectCatalogModel}
 				onCustom={selectCustomModel}
@@ -552,7 +556,7 @@ function TaskModelPicker({
 					!hasCatalog && "rounded-r-md!",
 				)}
 				value={value}
-				disabled={agentId === ""}
+				disabled={disabled || agentId === ""}
 				onChange={(event) => onModelChange(event.target.value)}
 				placeholder={fetching ? t("settings.models.loading") : noOverrideLabel}
 			/>
@@ -563,6 +567,7 @@ function TaskModelPicker({
 					value={value}
 					models={displayModels}
 					allowCustom={catalog.allowCustom}
+					disabled={disabled}
 					emptyLabel={noOverrideLabel}
 					onChange={selectCatalogModel}
 					onCustom={selectCustomModel}

--- a/packages/product-ui/src/TaskComposerView.test.tsx
+++ b/packages/product-ui/src/TaskComposerView.test.tsx
@@ -175,6 +175,57 @@ describe("TaskComposerView", () => {
 		expect(onAddFiles).toHaveBeenLastCalledWith([file]);
 	});
 
+	it("locks attachment editing while submitting and restores it for retry", () => {
+		const onAddFiles = vi.fn();
+		const onRemove = vi.fn();
+		const file = new File(["notes"], "notes.txt", { type: "text/plain" });
+		const attachments = {
+			items: [{ id: "attachment-1", name: "notes.txt" }],
+			onAddFiles,
+			onRemove,
+		};
+		const { container, rerender } = render(
+			<TaskComposerView
+				{...viewProps({
+					attachments,
+					submission: {
+						showFallbackAction: false,
+						isSubmitting: true,
+						onFallbackAction: vi.fn(),
+						onSubmit: vi.fn(),
+					},
+				})}
+			/>,
+		);
+
+		const form = container.querySelector("form") as HTMLFormElement;
+		const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+		const addFile = screen.getByRole("button", { name: "Add file" });
+		const removeFile = screen.getByRole("button", { name: "Remove notes.txt" });
+		expect(input).toBeDisabled();
+		expect(addFile).toBeDisabled();
+		expect(removeFile).toBeDisabled();
+
+		fireEvent.change(input, { target: { files: [file] } });
+		fireEvent.paste(screen.getByRole("textbox", { name: "Task" }), {
+			clipboardData: { files: [file] },
+		});
+		fireEvent.drop(form, { dataTransfer: { files: [file] } });
+		fireEvent.click(removeFile);
+		expect(onAddFiles).not.toHaveBeenCalled();
+		expect(onRemove).not.toHaveBeenCalled();
+
+		rerender(<TaskComposerView {...viewProps({ attachments })} />);
+		expect(input).toBeEnabled();
+		expect(addFile).toBeEnabled();
+		expect(removeFile).toBeEnabled();
+
+		fireEvent.change(input, { target: { files: [file] } });
+		fireEvent.click(removeFile);
+		expect(onAddFiles).toHaveBeenCalledWith([file]);
+		expect(onRemove).toHaveBeenCalledWith("attachment-1");
+	});
+
 	it("keeps attachment previews hidden until a file is selected", () => {
 		const { container, rerender } = render(<TaskComposerView {...viewProps()} />);
 

--- a/packages/product-ui/src/TaskComposerView.test.tsx
+++ b/packages/product-ui/src/TaskComposerView.test.tsx
@@ -51,6 +51,7 @@ function viewProps(overrides: Partial<TaskComposerViewProps> = {}): TaskComposer
 			agentId: "codex",
 			agentLabel: "Codex",
 			projectId: "project-1",
+			disabled: false,
 			value: "gpt-5",
 			mode: "",
 			catalog: {

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -211,6 +211,7 @@ export function TaskComposerView({
 	};
 
 	const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+		if (submission.isSubmitting) return;
 		const files = Array.from(event.clipboardData?.files ?? []);
 		if (files.length === 0) return;
 		event.preventDefault();
@@ -220,11 +221,13 @@ export function TaskComposerView({
 	const handleDrop = (event: DragEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		setIsDragging(false);
+		if (submission.isSubmitting) return;
 		const files = Array.from(event.dataTransfer?.files ?? []);
 		if (files.length > 0) attachments.onAddFiles(files);
 	};
 
 	const handleDragOver = (event: DragEvent<HTMLFormElement>) => {
+		if (submission.isSubmitting) return;
 		if (Array.from(event.dataTransfer?.items ?? []).some((item) => item.kind === "file")) {
 			event.preventDefault();
 			setIsDragging(true);
@@ -277,9 +280,12 @@ export function TaskComposerView({
 											/>
 											<button
 												type="button"
-												className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background/80 text-muted-foreground hover:bg-background hover:text-foreground shadow-sm transition-colors"
+												disabled={submission.isSubmitting}
+												className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background/80 text-muted-foreground hover:bg-background hover:text-foreground shadow-sm transition-colors disabled:pointer-events-none disabled:opacity-50"
 												aria-label={labels.removeFile(attachment.name)}
-												onClick={() => attachments.onRemove(attachment.id)}
+												onClick={() => {
+													if (!submission.isSubmitting) attachments.onRemove(attachment.id);
+												}}
 											>
 												<X className="size-3" aria-hidden="true" />
 											</button>
@@ -300,9 +306,12 @@ export function TaskComposerView({
 											</div>
 											<button
 												type="button"
-												className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background border border-border text-muted-foreground hover:bg-muted hover:text-foreground shadow-sm transition-colors"
+												disabled={submission.isSubmitting}
+												className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background border border-border text-muted-foreground hover:bg-muted hover:text-foreground shadow-sm transition-colors disabled:pointer-events-none disabled:opacity-50"
 												aria-label={labels.removeFile(attachment.name)}
-												onClick={() => attachments.onRemove(attachment.id)}
+												onClick={() => {
+													if (!submission.isSubmitting) attachments.onRemove(attachment.id);
+												}}
 											>
 												<X className="size-3" aria-hidden="true" />
 											</button>
@@ -318,8 +327,10 @@ export function TaskComposerView({
 				ref={fileInputRef}
 				type="file"
 				multiple
+				disabled={submission.isSubmitting}
 				className="hidden"
 				onChange={(event) => {
+					if (submission.isSubmitting) return;
 					if (event.target.files) attachments.onAddFiles(Array.from(event.target.files));
 					event.target.value = "";
 				}}
@@ -367,9 +378,12 @@ export function TaskComposerView({
 
 				<button
 					type="button"
-					className="inline-flex size-(--size-settings-action-height) shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					disabled={submission.isSubmitting}
+					className="inline-flex size-(--size-settings-action-height) shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
 					aria-label={labels.addFile}
-					onClick={() => fileInputRef.current?.click()}
+					onClick={() => {
+						if (!submission.isSubmitting) fileInputRef.current?.click();
+					}}
 				>
 					<Paperclip className="size-icon-base" aria-hidden="true" />
 				</button>

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -118,6 +118,7 @@ export type TaskComposerViewProps = {
 
 type TaskPromptProps = {
 	autoFocus?: boolean;
+	disabled: boolean;
 	id: string;
 	initialValue: string;
 	label: string;
@@ -128,6 +129,7 @@ type TaskPromptProps = {
 
 const TaskPrompt = memo(function TaskPrompt({
 	autoFocus,
+	disabled,
 	id,
 	initialValue,
 	label,
@@ -154,7 +156,8 @@ const TaskPrompt = memo(function TaskPrompt({
 				ref={textareaRef}
 				id={id}
 				autoFocus={autoFocus}
-				className="min-h-[calc(3lh+1.75rem)] max-h-[calc(8lh+1.75rem)] w-full resize-none overflow-y-auto bg-transparent px-4 pb-3 pt-4 text-md leading-relaxed text-foreground outline-none placeholder:text-passive"
+				className="min-h-[calc(3lh+1.75rem)] max-h-[calc(8lh+1.75rem)] w-full resize-none overflow-y-auto bg-transparent px-4 pb-3 pt-4 text-md leading-relaxed text-foreground outline-none placeholder:text-passive disabled:cursor-not-allowed disabled:opacity-50"
+				disabled={disabled}
 				placeholder={placeholder}
 				value={value}
 				onChange={(event) => {
@@ -242,6 +245,7 @@ export function TaskComposerView({
 		>
 			<TaskPrompt
 				autoFocus={autoFocusPrompt}
+				disabled={submission.isSubmitting}
 				id={promptId}
 				initialValue={initialPrompt}
 				label={labels.task}

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -58,6 +58,7 @@ export type TaskComposerModelControl = {
 	agentId: string;
 	agentLabel: string;
 	catalog?: TaskComposerModelCatalog;
+	disabled: boolean;
 	fetching: boolean;
 	id: string;
 	loading: boolean;


### PR DESCRIPTION
## Summary
- disable the new-task task editor as soon as task creation starts
- disable attachment add, paste, drop, and removal paths while submission is pending
- disable the agent selector and every model selector variant while the request is pending
- restore all controls after a failed creation attempt
- add pending and retry regression coverage for text, mode, catalog, custom, and browse selectors

## Test
- TaskComposer.test.tsx: 24 passed
- Product UI: 83 passed
- frontend TypeScript check: passed
- Product UI TypeScript check: passed
- git diff --check: passed

## Issue
No originating issue exists; this PR was created from a direct request, so there is no issue to close.

## Note
The repository-wide frontend Vitest run was attempted locally after a clean dependency restore. The affected suites above passed; the full run remained blocked by unrelated sandbox socket restrictions and baseline suite failures, including listen EPERM errors.