### PR TITLE
fix(browser): stop auto-sending browser errors

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -525,7 +525,6 @@ async function createWindowInternal(): Promise<void> {
 		isKeybindingRecording: () => keybindingRecordingActive,
 		agentBrowserRuntime,
 		isCloseShellTerminalShortcutEnabled: () => closeShellTerminalShortcutEnabled,
-		getDaemonPort: () => (daemonStatus.state === "ready" ? daemonStatus.port : undefined),
 	});
 	if (daemonStatus.state === "ready") establishBrowserRuntimeLink();
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { net } from "electron";
 import {
 	type BrowserNavState,
 	type BrowserTabsState,
@@ -10,6 +11,11 @@ import {
 } from "./browser-view-host";
 import { MAX_BROWSER_TABS } from "../shared/browser-tabs";
 import { NEW_SESSION_SHORTCUT_CHANNEL } from "../shared/shortcuts";
+
+vi.mock("electron", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("electron")>();
+	return { ...actual, net: { fetch: vi.fn() } };
+});
 
 type InvokeHandler = (event: unknown, ...args: unknown[]) => unknown;
 type EventHandler = (event: { sender: { id: number; getZoomFactor?: () => number } }, ...args: unknown[]) => unknown;
@@ -220,6 +226,7 @@ function setupTabHost() {
 			closeDevTools: ReturnType<typeof vi.fn>;
 			openWindow: (url: string) => void;
 			close: ReturnType<typeof vi.fn>;
+			emitConsoleMessage: (level: number, message: string, line?: number, sourceId?: string) => void;
 			session: {
 				webRequest: {
 					onCompleted: ReturnType<typeof vi.fn>;
@@ -375,6 +382,9 @@ function setupTabHost() {
 		annotatePreloadPath: "/preload.js",
 		rendererOrigin: "http://localhost:5173",
 		agentBrowserRuntime: runtime,
+		// Kept only as a regression tripwire: the removed auto-send path used
+		// this option to discover the daemon before calling net.fetch.
+		...({ getDaemonPort: () => 43123 } as Record<string, unknown>),
 	});
 	const invoke = (channel: string, ...args: unknown[]) =>
 		handlers.get(channel)!({ sender: { id: 1 } }, ...args) as Promise<unknown>;
@@ -1184,6 +1194,72 @@ describe("agent browser runtime", () => {
 			expect.any(Function),
 		);
 		expect(views[0].webContents.session.webRequest.onErrorOccurred).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps browser failures available for an explicit errors query after the old auto-send window", async () => {
+		vi.useFakeTimers();
+		const fetchSpy = vi.mocked(net.fetch).mockResolvedValue(new Response());
+		try {
+			const { host, views } = setupTabHost();
+			await host.execute("sess-1", "open", { url: "http://localhost:3000" });
+
+			views[0].webContents.emitConsoleMessage(3, "render failed", 42, "http://localhost:3000/app.js");
+			const onErrorOccurred = views[0].webContents.session.webRequest.onErrorOccurred.mock.calls[0]?.[1] as
+				| ((details: {
+						resourceType: string;
+						method: string;
+						url: string;
+						error: string;
+				  }) => void)
+				| undefined;
+			onErrorOccurred?.({
+				resourceType: "xhr",
+				method: "GET",
+				url: "http://localhost:3000/api/data",
+				error: "net::ERR_CONNECTION_REFUSED",
+			});
+
+			await vi.advanceTimersByTimeAsync(5_000);
+			expect(fetchSpy).not.toHaveBeenCalled();
+			const result = (await host.execute("sess-1", "errors")) as {
+				messages: Array<{ level: string; message: string }>;
+			};
+
+			expect(result.messages).toHaveLength(2);
+			expect(result.messages[0]).toMatchObject({ level: "error" });
+			expect(result.messages[0]?.message).toContain(
+				"render failed (http://localhost:3000/app.js:42)",
+			);
+			expect(result.messages[1]).toMatchObject({ level: "error" });
+			expect(result.messages[1]?.message).toContain(
+				"GET http://localhost:3000/api/data failed: net::ERR_CONNECTION_REFUSED",
+			);
+		} finally {
+			fetchSpy.mockReset();
+			vi.useRealTimers();
+		}
+	});
+
+	it("caps each stored browser failure before retaining it", async () => {
+		const { host, views } = setupTabHost();
+		await host.execute("sess-1", "open", { url: "http://localhost:3000" });
+
+		views[0].webContents.emitConsoleMessage(3, "x".repeat(20_000));
+		const result = (await host.execute("sess-1", "errors")) as {
+			messages: Array<{ message: string }>;
+		};
+
+		expect(result.messages[0]?.message).toContain("[Content truncated at 16384 bytes]");
+	});
+
+	it("detaches browser failure listeners when their session is destroyed", async () => {
+		const { host, views } = setupTabHost();
+		await host.execute("sess-1", "open", { url: "http://localhost:3000" });
+
+		await host.execute("sess-1", "__destroy-session");
+
+		expect(views[0].webContents.session.webRequest.onCompleted).toHaveBeenLastCalledWith(null);
+		expect(views[0].webContents.session.webRequest.onErrorOccurred).toHaveBeenLastCalledWith(null);
 	});
 
 	it("exposes owned tab state and manual tab actions to the renderer", async () => {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -8,7 +8,7 @@ import type {
 	WebContents,
 	OpenDevToolsOptions,
 } from "electron";
-import { nativeImage, net } from "electron";
+import { nativeImage } from "electron";
 import { randomUUID } from "node:crypto";
 import type {
 	BrowserAnnotationCancelPayload,
@@ -206,10 +206,6 @@ export type BrowserViewHostOptions = {
 	isKeybindingRecording?: () => boolean;
 	agentBrowserRuntime?: AgentBrowserRuntime;
 	isCloseShellTerminalShortcutEnabled?: () => boolean;
-	// Lets browser-view-host report console errors / failed requests to the
-	// session's agent via the daemon's own HTTP API (see recordBrowserSignal).
-	// Undefined/no port yet (daemon not ready) just means signals are dropped.
-	getDaemonPort?: () => number | undefined;
 };
 
 export type BrowserViewHost = {
@@ -267,12 +263,11 @@ type BrowserSessionEntry = {
 	nativeActiveTabId?: string;
 	nativeOperationQueue: Promise<void>;
 	devtoolsPlacement: BrowserDevToolsPlacement;
-	// Buffered console-error / failed-request signals awaiting a debounced
-	// flush to the session's agent. See recordBrowserSignal/flushBrowserSignals.
+	// Bounded browser diagnostics exposed only through an explicit errors query.
 	signals: {
-		pending: BrowserSignalEntry[];
-		flushTimer: NodeJS.Timeout | null;
+		entries: BrowserSignalEntry[];
 		webRequestRegistered: boolean;
+		webRequest?: Session["webRequest"];
 	};
 	devtools?: {
 		contents: BrowserWebContents;
@@ -299,6 +294,7 @@ type BrowserLogEntry = {
 type BrowserSignalEntry = {
 	kind: "console-error" | "network-failure";
 	message: string;
+	timestamp: string;
 };
 
 type BrowserNetworkRequest = {
@@ -351,13 +347,10 @@ const BROWSER_VIEW_BORDER_RADIUS = 10;
 const DEFAULT_NETWORK_CAPTURE_SECONDS = 60;
 const MAX_NETWORK_CAPTURE_SECONDS = 300;
 const MAX_NETWORK_REQUESTS = 200;
-// Always-on console-error/failed-request reporting (distinct from the
-// on-demand capture above, which stays opt-in): same cap philosophy — bounded
-// buffer, no bodies — but debounced into a single message per burst instead
-// of accumulated for on-demand query.
+// Keep a bounded, metadata-only history for explicit errors queries. Browser
+// failures must never be pushed into an agent's live conversation on their own.
 const MAX_BROWSER_SIGNALS = MAX_NETWORK_REQUESTS;
-const BROWSER_SIGNAL_FLUSH_DELAY_MS = 5_000;
-const MAX_BROWSER_SIGNALS_PER_MESSAGE = 10;
+const MAX_BROWSER_SIGNAL_BYTES = 16 * 1024;
 const FAVICON_SIZE = 32;
 const MAX_FAVICON_BYTES = 256 * 1024;
 const DEFAULT_NATIVE_DEVTOOLS_PLACEMENT: BrowserDevToolsPlacement = "right";
@@ -632,7 +625,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 				agentBrowserCommands: 0,
 				nativeOperationQueue: Promise.resolve(),
 				devtoolsPlacement: DEFAULT_NATIVE_DEVTOOLS_PLACEMENT,
-				signals: { pending: [], flushTimer: null, webRequestRegistered: false },
+				signals: { entries: [], webRequestRegistered: false },
 			};
 			entries.set(viewId, session);
 			viewIdsBySessionId.set(sessionId, viewId);
@@ -675,6 +668,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		// doubles that don't care about network-failure signals can omit it).
 		if (!electronSession?.webRequest) return;
 		session.signals.webRequestRegistered = true;
+		session.signals.webRequest = electronSession.webRequest;
 		const filter = { urls: ["*://*/*"] };
 		electronSession.webRequest.onCompleted(filter, (details) => {
 			if (details.resourceType !== "xhr" || details.statusCode < 400) return;
@@ -692,46 +686,17 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		});
 	};
 
-	// Debounces a burst of errors (a broken page often fires several at once)
-	// into a single agent-facing message instead of one message per error.
-	const recordBrowserSignal = (session: BrowserSessionEntry, entry: BrowserSignalEntry): void => {
-		const { pending } = session.signals;
-		pending.push(entry);
-		if (pending.length > MAX_BROWSER_SIGNALS) pending.splice(0, pending.length - MAX_BROWSER_SIGNALS);
-		if (session.signals.flushTimer) return;
-		session.signals.flushTimer = setTimeout(() => {
-			session.signals.flushTimer = null;
-			void flushBrowserSignals(session);
-		}, BROWSER_SIGNAL_FLUSH_DELAY_MS);
-	};
-
-	const flushBrowserSignals = async (session: BrowserSessionEntry): Promise<void> => {
-		const queued = session.signals.pending.splice(0, session.signals.pending.length);
-		if (queued.length === 0) return;
-		const port = options.getDaemonPort?.();
-		if (!port) return;
-		const shown = queued.slice(0, MAX_BROWSER_SIGNALS_PER_MESSAGE);
-		const omitted = queued.length - shown.length;
-		const lines = shown.map(
-			(entry) => `- [${entry.kind === "console-error" ? "console" : "network"}] ${entry.message}`,
-		);
-		const message = [
-			`Browser detected ${queued.length} issue${queued.length === 1 ? "" : "s"} on this page:`,
-			...lines,
-			omitted > 0 ? `…and ${omitted} more` : null,
-		]
-			.filter((line): line is string => line !== null)
-			.join("\n");
-		try {
-			await net.fetch(`http://127.0.0.1:${port}/api/v1/sessions/${encodeURIComponent(session.sessionId)}/send`, {
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify({ message }),
-			});
-		} catch {
-			// Best-effort notification. A delivery failure here must not surface as
-			// a browser error itself or disrupt the tab that triggered it.
-		}
+	const recordBrowserSignal = (
+		session: BrowserSessionEntry,
+		entry: Omit<BrowserSignalEntry, "timestamp">,
+	): void => {
+		const { entries } = session.signals;
+		entries.push({
+			...entry,
+			message: externalText(entry.message, MAX_BROWSER_SIGNAL_BYTES),
+			timestamp: new Date().toISOString(),
+		});
+		if (entries.length > MAX_BROWSER_SIGNALS) entries.splice(0, entries.length - MAX_BROWSER_SIGNALS);
 	};
 
 	const ensureNativeActiveTab = async (session: BrowserSessionEntry, signal?: AbortSignal): Promise<void> => {
@@ -1185,6 +1150,10 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	const destroy = (viewId: string): void => {
 		const session = entries.get(viewId);
 		if (!session) return;
+		session.signals.entries.length = 0;
+		session.signals.webRequest?.onCompleted(null);
+		session.signals.webRequest?.onErrorOccurred(null);
+		session.signals.webRequest = undefined;
 		if (options.mainWindow.isDestroyed?.()) session.devtools = undefined;
 		else destroyDevTools(session);
 		void options.agentBrowserRuntime?.closeSession(session.sessionId);
@@ -1587,8 +1556,14 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 				case "network-clear":
 					return clearNetworkCapture(networkEntryFor(session));
 				case "console":
-				case "errors":
 					return normalizeNativeMessages(await runNative(action), action);
+				case "errors": {
+					const native = normalizeNativeMessages(await runNative(action), action);
+					return {
+						...native,
+						messages: [...native.messages, ...browserSignalMessages(session)],
+					};
+				}
 				default:
 					throw browserError("INVALID_ARGUMENT", `Unsupported browser action: ${action}`);
 			}
@@ -2318,11 +2293,11 @@ function normalizeAgentBrowserURL(input: string): string {
 	return normalized.href;
 }
 
-function externalText(value: unknown): string {
+function externalText(value: unknown, maxBytes = MAX_EXTERNAL_TEXT_BYTES): string {
 	const raw = value == null ? "" : String(value);
 	const bytes = Buffer.from(raw, "utf8");
-	if (bytes.length <= MAX_EXTERNAL_TEXT_BYTES) return raw;
-	return `${bytes.subarray(0, MAX_EXTERNAL_TEXT_BYTES).toString("utf8")}\n[Content truncated at ${MAX_EXTERNAL_TEXT_BYTES} bytes]`;
+	if (bytes.length <= maxBytes) return raw;
+	return `${bytes.subarray(0, maxBytes).toString("utf8")}\n[Content truncated at ${maxBytes} bytes]`;
 }
 
 function markUntrusted(value: string): string {
@@ -2332,7 +2307,19 @@ function markUntrusted(value: string): string {
 	return `${UNTRUSTED_BEGIN}\n${escaped}\n${UNTRUSTED_END}`;
 }
 
-function normalizeNativeMessages(result: Record<string, unknown>, action: string): Record<string, unknown> {
+function browserSignalMessages(session: BrowserSessionEntry): BrowserLogEntry[] {
+	return session.signals.entries.map((entry) => ({
+		level: "error",
+		message: markUntrusted(externalText(entry.message)),
+		source: entry.kind === "console-error" ? "browser-console" : "browser-network",
+		timestamp: entry.timestamp,
+	}));
+}
+
+function normalizeNativeMessages(
+	result: Record<string, unknown>,
+	action: string,
+): { messages: BrowserLogEntry[]; untrustedExternalContent: true } {
 	const raw = Array.isArray(result.messages) ? result.messages : Array.isArray(result.value) ? result.value : [];
 	const messages = raw.map((item): BrowserLogEntry => {
 		if (typeof item === "string") {


### PR DESCRIPTION
## What

Stops browser console and failed-request diagnostics from being injected automatically into an active agent conversation.

Browser failures remain available through an explicit `ao browser errors` query for manual or agent-driven inspection.

## Why

The always-on browser signal path posted batched errors to the daemon session send endpoint. That unsolicited message could interrupt work already in progress and wake unrelated or idle agent sessions.

## How

- Removes the daemon-port and `net.fetch` auto-send path from the browser view host.
- Retains a session-local FIFO history of the latest 200 browser failures.
- Caps each retained entry at 16 KiB before storage.
- Preserves timestamps, console/network source classification, and untrusted-content boundaries.
- Detaches webRequest listeners and clears retained diagnostics when a session is destroyed.
- Merges retained diagnostics into the existing explicit browser errors response.
- Adds regression coverage proving the former five-second window performs no outbound send.

## Testing

- `npx vitest run --config vite.renderer.config.ts src/main/browser-view-host.test.ts` — 75 passed.
- `npm run typecheck` — passed.
- `git diff --check` — passed.
- Independent code review — no remaining Critical or Important findings.
- Full frontend suite attempted on Windows: 2,823 passed, 31 failed, 2 skipped. The failures are outside the touched browser-host area and relate to macOS path assumptions, unavailable Windows Unix-socket/symlink operations, and missing landing-package dependencies.

Manual testing requested before merge: open a page that emits console errors or failed XHR/fetch requests, confirm the active agent session is not interrupted, then run `ao browser errors` and confirm the diagnostics are returned.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for user-visible behavior
- [x] Relevant frontend checks pass for the touched area
