### PR TITLE
fix(omp): report TUI activity via managed extension

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/fake"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimchi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/muse"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/omp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/primeagent"
@@ -46,6 +47,7 @@ var Derivers = map[string]DeriveFunc{
 	"prime-agent": primeagent.DeriveActivityState,
 	"amp":         amp.DeriveActivityState,
 	"pi":          pi.DeriveActivityState,
+	"omp":         omp.DeriveActivityState,
 	"auggie":      auggie.DeriveActivityState,
 	"goose":       activitystate.StandardDeriveActivityState,
 	"devin":       activitystate.StandardDeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -22,7 +22,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessMuse, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe, domain.HarnessPrimeAgent, domain.HarnessAmp, domain.HarnessPi, domain.HarnessAuggie} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessMuse, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe, domain.HarnessPrimeAgent, domain.HarnessAmp, domain.HarnessPi, domain.HarnessOMP, domain.HarnessAuggie} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}
@@ -45,6 +45,7 @@ func TestAmpPiAndAuggieDispatchActivity(t *testing.T) {
 	}{
 		{agent: "amp", event: "thread-state", payload: `{"state":"awaiting-approval"}`, want: domain.ActivityWaitingInput},
 		{agent: "pi", event: "user-prompt-submit", payload: `{}`, want: domain.ActivityActive},
+		{agent: "omp", event: "user-prompt-submit", payload: `{}`, want: domain.ActivityActive},
 		{agent: "auggie", event: "stop", payload: `{"agent_stop_cause":"error"}`, want: domain.ActivityWaitingInput},
 	}
 

--- a/backend/internal/adapters/agent/omp/activity.go
+++ b/backend/internal/adapters/agent/omp/activity.go
@@ -1,0 +1,21 @@
+package omp
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// DeriveActivityState maps the lifecycle callbacks emitted by AO's managed OMP
+// extension onto normalized activity. session-start is idle because OMP emits
+// it before any prompt starts; before_agent_start supplies the active
+// transition. StandardDeriveActivityState cannot be reused because it treats
+// session-start as active.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start", "stop":
+		return domain.ActivityIdle, true
+	case "user-prompt-submit":
+		return domain.ActivityActive, true
+	case "session-end":
+		return domain.ActivityExited, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/omp/activity_test.go
+++ b/backend/internal/adapters/agent/omp/activity_test.go
@@ -1,0 +1,31 @@
+package omp
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestDeriveActivityState(t *testing.T) {
+	tests := []struct {
+		event  string
+		want   domain.ActivityState
+		wantOK bool
+	}{
+		{event: "session-start", want: domain.ActivityIdle, wantOK: true},
+		{event: "user-prompt-submit", want: domain.ActivityActive, wantOK: true},
+		{event: "stop", want: domain.ActivityIdle, wantOK: true},
+		{event: "session-end", want: domain.ActivityExited, wantOK: true},
+		{event: "turn-start"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := DeriveActivityState(tt.event, nil)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)",
+					tt.event, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/agent/omp/hooks.go
+++ b/backend/internal/adapters/agent/omp/hooks.go
@@ -1,0 +1,160 @@
+package omp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	ompExtensionsDirName = "extensions"
+	ompExtensionFileName = "ao-activity.ts"
+	ompExtensionSentinel = "agent-orchestrator: managed omp activity extension"
+)
+
+func ompExtensionPath(workspacePath string) string {
+	return filepath.Join(workspacePath, ".omp", ompExtensionsDirName, ompExtensionFileName)
+}
+
+// GetAgentHooks installs AO's project-local OMP extension. Launch and restore
+// pass it explicitly with --extension, so activity reporting does not depend on
+// OMP's project auto-discovery.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("omp.GetAgentHooks: WorkspacePath is required")
+	}
+
+	path := ompExtensionPath(cfg.WorkspacePath)
+	if data, err := os.ReadFile(path); err == nil { //nolint:gosec // caller-owned workspace path
+		if !strings.Contains(string(data), ompExtensionSentinel) {
+			return fmt.Errorf("omp.GetAgentHooks: refusing to overwrite non-AO file at %s", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("omp.GetAgentHooks: read managed extension: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("omp.GetAgentHooks: create extension dir: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(path, []byte(ompActivityExtensionSource()), 0o600); err != nil {
+		return fmt.Errorf("omp.GetAgentHooks: write extension: %w", err)
+	}
+	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(path), ompExtensionFileName); err != nil {
+		return fmt.Errorf("omp.GetAgentHooks: gitignore: %w", err)
+	}
+	return nil
+}
+
+// UninstallHooks removes AO's OMP activity extension when it carries the AO
+// sentinel. A missing file, or a same-named file without the sentinel, is a no-op.
+func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return errors.New("omp.UninstallHooks: workspacePath is required")
+	}
+
+	path := ompExtensionPath(workspacePath)
+	managed, err := isAOManagedExtension(path)
+	if err != nil {
+		return fmt.Errorf("omp.UninstallHooks: %w", err)
+	}
+	if !managed {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("omp.UninstallHooks: remove extension: %w", err)
+	}
+	return nil
+}
+
+// AreHooksInstalled reports whether AO's OMP activity extension is present.
+// A missing file, or a same-named file without the AO sentinel, means none.
+func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return false, errors.New("omp.AreHooksInstalled: workspacePath is required")
+	}
+	managed, err := isAOManagedExtension(ompExtensionPath(workspacePath))
+	if err != nil {
+		return false, fmt.Errorf("omp.AreHooksInstalled: %w", err)
+	}
+	return managed, nil
+}
+
+func appendOmpExtensionFlag(cmd *[]string, workspacePath string) {
+	if strings.TrimSpace(workspacePath) == "" {
+		return
+	}
+	*cmd = append(*cmd, "--extension", ompExtensionPath(workspacePath))
+}
+
+func isAOManagedExtension(path string) (bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path built from caller-owned workspace dir
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return strings.Contains(string(data), ompExtensionSentinel), nil
+}
+
+func ompActivityExtensionSource() string {
+	return `// ` + ompExtensionSentinel + ` (do not edit)
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import { spawnSync } from "node:child_process";
+
+const HOOK_TIMEOUT_MS = 5_000;
+
+function callHookSync(hookName: string, payload: Record<string, unknown>) {
+  try {
+    const result = spawnSync("ao", ["hooks", "omp", hookName], {
+      input: JSON.stringify(payload) + "\n",
+      encoding: "utf8",
+      stdio: ["pipe", "ignore", "pipe"],
+      timeout: HOOK_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    // AO's hook command records daemon delivery failures itself. A missing AO
+    // executable or timeout is deliberately ignored so OMP remains usable.
+    void result;
+  } catch {
+    // Activity reporting is best-effort and must never interrupt OMP.
+  }
+}
+
+function sessionID(ctx: any): string {
+  return ctx.sessionManager.getSessionId() ?? "";
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    callHookSync("session-start", { session_id: sessionID(ctx) });
+  });
+  pi.on("before_agent_start", async (event, ctx) => {
+    callHookSync("user-prompt-submit", { session_id: sessionID(ctx), prompt: event.prompt });
+  });
+  // session_stop is OMP's settle event: the main-agent turn is about to go
+  // idle. agent_end can fire before retries or compaction, so stop waits here.
+  pi.on("session_stop", async (_event, ctx) => {
+    callHookSync("stop", { session_id: sessionID(ctx) });
+  });
+  pi.on("session_shutdown", async (_event, ctx) => {
+    callHookSync("session-end", { session_id: sessionID(ctx) });
+  });
+}
+`
+}

--- a/backend/internal/adapters/agent/omp/hooks_test.go
+++ b/backend/internal/adapters/agent/omp/hooks_test.go
@@ -1,0 +1,85 @@
+package omp
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestOmpExtensionMapsLifecycleEvents(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ao executable fixture uses a Unix shebang")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the OMP extension fixture")
+	}
+
+	fixtureDir := t.TempDir()
+	modulePath := filepath.Join(fixtureDir, "ao-activity.mjs")
+	source := strings.NewReplacer(
+		`import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";`+"\n", "",
+		`function callHookSync(hookName: string, payload: Record<string, unknown>)`, `function callHookSync(hookName, payload)`,
+		`function sessionID(ctx: any): string`, `function sessionID(ctx)`,
+		`export default function (pi: ExtensionAPI)`, `export default function (pi)`,
+	).Replace(ompActivityExtensionSource())
+	if err := os.WriteFile(modulePath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	capturePath := filepath.Join(fixtureDir, "calls.jsonl")
+	if err := os.WriteFile(filepath.Join(fixtureDir, "ao"), []byte(`#!/usr/bin/env node
+const fs = require("node:fs");
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => { input += chunk; });
+process.stdin.on("end", () => {
+  fs.appendFileSync(process.env.AO_TEST_CAPTURE, JSON.stringify({args: process.argv.slice(2), source: process.env.OMP_EVENT_SOURCE, input}) + "\n");
+});
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	harnessPath := filepath.Join(fixtureDir, "harness.mjs")
+	if err := os.WriteFile(harnessPath, []byte(`import { pathToFileURL } from "node:url";
+const handlers = new Map();
+const loaded = await import(pathToFileURL(process.argv[2]).href);
+loaded.default({ on(name, handler) { handlers.set(name, handler); } });
+const ctx = { sessionManager: { getSessionId() { return "omp-session-1"; } } };
+process.env.OMP_EVENT_SOURCE = "session_start";
+await handlers.get("session_start")({}, ctx);
+process.env.OMP_EVENT_SOURCE = "before_agent_start";
+await handlers.get("before_agent_start")({ prompt: "fix bug" }, ctx);
+process.env.OMP_EVENT_SOURCE = "session_stop";
+await handlers.get("session_stop")({}, ctx);
+process.env.OMP_EVENT_SOURCE = "session_shutdown";
+await handlers.get("session_shutdown")({}, ctx);
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.CommandContext(context.Background(), node, harnessPath, modulePath)
+	cmd.Env = append(os.Environ(), "PATH="+fixtureDir+string(os.PathListSeparator)+os.Getenv("PATH"), "AO_TEST_CAPTURE="+capturePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("OMP extension harness failed: %v\n%s", err, output)
+	}
+	data, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if got := strings.Count(text, `["hooks","omp","stop"]`); got != 1 {
+		t.Fatalf("stop hook count = %d, want 1:\n%s", got, text)
+	}
+	if !strings.Contains(text, `"source":"session_stop"`) {
+		t.Fatalf("stop hook did not come from session_stop:\n%s", text)
+	}
+	if !strings.Contains(text, `["hooks","omp","session-start"]`) || !strings.Contains(text, `["hooks","omp","user-prompt-submit"]`) || !strings.Contains(text, `["hooks","omp","session-end"]`) {
+		t.Fatalf("expected lifecycle hook calls missing:\n%s", text)
+	}
+	if !strings.Contains(text, `fix bug`) {
+		t.Fatalf("user-prompt-submit payload missing prompt:\n%s", text)
+	}
+}

--- a/backend/internal/adapters/agent/omp/omp.go
+++ b/backend/internal/adapters/agent/omp/omp.go
@@ -1,6 +1,10 @@
 // Package omp implements AO's OMP agent adapter. OMP is a terminal-first
 // coding harness, so AO launches it interactively inside the session terminal
 // pane and keeps protocol-level RPC/ACP integration out of this adapter.
+//
+// Hooks/activity: AO installs a workspace-local TypeScript extension and
+// passes it explicitly with --extension. It reports OMP's session and agent
+// lifecycle without depending on project-local extension auto-discovery.
 package omp
 
 import (
@@ -55,15 +59,16 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 
 // GetLaunchCommand builds the argv to start a fresh interactive OMP session:
 //
-//	omp [--append-system-prompt <system prompt>] [--model <model>] [<prompt>]
+//	omp [--extension <path>] [--append-system-prompt <system prompt>] [--model <model>] [<prompt>]
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) ([]string, error) {
 	binary, err := p.ompBinary(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd := make([]string, 0, 5)
+	cmd := make([]string, 0, 7)
 	cmd = append(cmd, binary)
+	appendOmpExtensionFlag(&cmd, cfg.WorkspacePath)
 	if err := appendSystemPrompt(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
 		return nil, err
 	}
@@ -90,8 +95,9 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err != nil {
 		return nil, false, err
 	}
-	cmd := make([]string, 0, 5)
+	cmd := make([]string, 0, 8)
 	cmd = append(cmd, binary)
+	appendOmpExtensionFlag(&cmd, cfg.Session.WorkspacePath)
 	if err := appendSystemPrompt(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
 		return nil, false, err
 	}

--- a/backend/internal/adapters/agent/omp/omp_test.go
+++ b/backend/internal/adapters/agent/omp/omp_test.go
@@ -2,9 +2,11 @@ package omp
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
@@ -134,5 +136,192 @@ func TestGetRestoreCommandWithoutNativeSessionIDReturnsNotOK(t *testing.T) {
 	}
 	if ok || cmd != nil {
 		t.Fatalf("cmd=%#v ok=%v, want nil false", cmd, ok)
+	}
+}
+
+func TestGetLaunchCommandExplicitlyLoadsManagedExtension(t *testing.T) {
+	workspace := t.TempDir()
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		WorkspacePath: workspace,
+		Prompt:        "fix the bug",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"omp", "--extension", filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts"), "fix the bug"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandExplicitlyLoadsManagedExtension(t *testing.T) {
+	workspace := t.TempDir()
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			WorkspacePath: workspace,
+			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "native-omp-1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"omp", "--extension", filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts"), "--resume", "native-omp-1"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetAgentHooksInstallsManagedActivityExtension(t *testing.T) {
+	workspace := t.TempDir()
+	plugin := &Plugin{resolvedBinary: "omp"}
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	extensionPath := filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts")
+	data, err := os.ReadFile(extensionPath)
+	if err != nil {
+		t.Fatalf("read managed extension: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"agent-orchestrator: managed omp activity extension",
+		`pi.on("session_start"`,
+		`pi.on("before_agent_start"`,
+		`pi.on("session_stop"`,
+		`pi.on("session_shutdown"`,
+		`"hooks", "omp", hookName`,
+		"getSessionId()",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("managed extension missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, `pi.on("agent_settled"`) {
+		t.Fatal("OMP extension must not listen for Pi-only agent_settled")
+	}
+
+	gitignore, err := os.ReadFile(filepath.Join(workspace, ".omp", "extensions", ".gitignore"))
+	if err != nil {
+		t.Fatalf("read extension .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignore), "/ao-activity.ts") {
+		t.Fatalf("extension .gitignore does not ignore AO file:\n%s", gitignore)
+	}
+
+	installed, err := plugin.AreHooksInstalled(context.Background(), workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !installed {
+		t.Fatal("AreHooksInstalled after install = false, want true")
+	}
+
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatalf("second GetAgentHooks err = %v", err)
+	}
+}
+
+func TestGetAgentHooksRefusesForeignManagedPath(t *testing.T) {
+	workspace := t.TempDir()
+	extensionPath := filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts")
+	if err := os.MkdirAll(filepath.Dir(extensionPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(extensionPath, []byte("export default function userExtension() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := (&Plugin{resolvedBinary: "omp"}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace})
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Fatalf("GetAgentHooks err = %v, want foreign-file refusal", err)
+	}
+}
+
+func TestUninstallHooksRemovesManagedExtension(t *testing.T) {
+	workspace := t.TempDir()
+	plugin := &Plugin{resolvedBinary: "omp"}
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatal(err)
+	}
+	if err := plugin.UninstallHooks(context.Background(), workspace); err != nil {
+		t.Fatal(err)
+	}
+	installed, err := plugin.AreHooksInstalled(context.Background(), workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed {
+		t.Fatal("AreHooksInstalled after uninstall = true, want false")
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts")); !os.IsNotExist(err) {
+		t.Fatalf("managed extension still present after uninstall: %v", err)
+	}
+}
+
+func TestUninstallHooksPreservesForeignExtension(t *testing.T) {
+	workspace := t.TempDir()
+	extensionPath := filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts")
+	if err := os.MkdirAll(filepath.Dir(extensionPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(extensionPath, []byte("export default function userExtension() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin := &Plugin{resolvedBinary: "omp"}
+	if err := plugin.UninstallHooks(context.Background(), workspace); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(extensionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "export default function userExtension() {}\n" {
+		t.Fatalf("foreign extension rewritten:\n%s", data)
+	}
+}
+
+func TestUninstallHooksMissingFileIsNoOp(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "omp"}
+	if err := plugin.UninstallHooks(context.Background(), t.TempDir()); err != nil {
+		t.Fatalf("uninstall on missing file = %v, want nil", err)
+	}
+	installed, err := plugin.AreHooksInstalled(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed {
+		t.Fatal("AreHooksInstalled on empty workspace = true, want false")
+	}
+}
+
+func TestGetAgentHooksRequiresWorkspacePath(t *testing.T) {
+	err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{})
+	if err == nil || !strings.Contains(err.Error(), "WorkspacePath is required") {
+		t.Fatalf("GetAgentHooks err = %v, want WorkspacePath message", err)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
+	}
+	if err := (&Plugin{}).UninstallHooks(ctx, t.TempDir()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("UninstallHooks err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).AreHooksInstalled(ctx, t.TempDir()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("AreHooksInstalled err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
 	}
 }

--- a/docs/harnesses/omp.md
+++ b/docs/harnesses/omp.md
@@ -44,9 +44,29 @@ When configured, AO forwards:
 
 - `--model <model>` from the agent config model field
 - `--append-system-prompt <text>` for AO's role/system prompt
+- `--extension <workspace>/.omp/extensions/ao-activity.ts` so OMP reports
+  TUI activity through `ao hooks omp`
 
 The process remains interactive after the initial prompt, so users can keep
 working directly in the OMP TUI.
+
+## Activity
+
+AO installs a workspace-local TypeScript extension and passes it explicitly
+with `--extension`. The extension maps OMP lifecycle events onto AO activity:
+
+| OMP event | AO hook | Activity |
+| --- | --- | --- |
+| `session_start` | `session-start` | idle |
+| `before_agent_start` | `user-prompt-submit` | active |
+| `session_stop` | `stop` | idle |
+| `session_shutdown` | `session-end` | exited |
+
+`session_start` is idle because OMP emits it before any prompt starts. The
+active transition comes from `before_agent_start`. OMP has no `agent_settled`
+event; `session_stop` is the settle signal that a main-agent turn is about to
+go idle. Launch and restore pass `--extension` so reporting does not depend
+on project-local extension auto-discovery. Chat-mode activity is unchanged.
 
 ## Restore
 
@@ -75,7 +95,7 @@ provider configuration, or selected model availability.
 - ACP editor integration (`omp acp`)
 - RPC mode (`omp --mode rpc`)
 - Chat UI handoff
-- AO-managed OMP extensions or hooks
 
 Those surfaces would require a separate structured protocol driver rather than
-the terminal harness adapter.
+the terminal harness adapter. The TUI activity extension above is installed
+and loaded by this adapter; it is not a Chat/ACP driver.


### PR DESCRIPTION
## What

OMP TUI workers now report activity through a managed workspace extension, the same way Pi does. `ao session get` / `ao session ls` can show `active` while omp is working instead of remaining idle at spawn time.

## Why

Fixes #4407.

TUI activity is driven by `ao hooks <harness> …`. The OMP adapter never installed an extension or passed `--extension`, so hooks never fired and `sessions.activity_state` stayed `idle`.

## How

- Install gitignored `.omp/extensions/ao-activity.ts` from `GetAgentHooks` (sentinel-guarded overwrite, plus `UninstallHooks` / `AreHooksInstalled`).
- Pass `--extension` on launch and restore so reporting does not depend on project auto-discovery.
- Map OMP v17 events: `session_start` → idle, `before_agent_start` → active, `session_stop` → idle, `session_shutdown` → exited.
- Register the omp deriver in `activitydispatch`. Chat-mode activity is unchanged; no tmux scraping.

OMP has `session_stop` rather than Pi's `agent_settled`; stop is reported from that settle event.

## Testing

```bash
cd backend && go test ./internal/adapters/agent/omp/... ./internal/adapters/agent/pi/... ./internal/adapters/agent/activitydispatch/...
```

All three packages passed.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)