### PR TITLE
fix(cursor): resolve ACP model aliases

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -312,11 +312,18 @@ func resolveLegacyModelChoice(choices []ports.ChatConfigOptionChoice, requested 
 
 	matched := ""
 	for _, choice := range choices {
-		alias, parameterized := parameterizedModelAlias(choice.Value)
+		aliases, parameterized := parameterizedModelAliases(choice.Value)
 		if !parameterized {
 			continue
 		}
-		if alias != requested {
+		matches := false
+		for _, alias := range aliases {
+			if alias == requested {
+				matches = true
+				break
+			}
+		}
+		if !matches {
 			continue
 		}
 		if matched != "" {
@@ -327,30 +334,40 @@ func resolveLegacyModelChoice(choices []ports.ChatConfigOptionChoice, requested 
 	return matched, matched != ""
 }
 
-func parameterizedModelAlias(value string) (string, bool) {
+func parameterizedModelAliases(value string) ([]string, bool) {
 	open := strings.IndexByte(value, '[')
 	if open <= 0 || !strings.HasSuffix(value, "]") {
-		return "", false
+		return nil, false
 	}
-	alias := value[:open]
+	base := value[:open]
+	body := value[open+1 : len(value)-1]
+	if body == "" {
+		if base == "default" {
+			return []string{"auto"}, true
+		}
+		return nil, false
+	}
+	if strings.HasPrefix(base, "grok-") {
+		base = "cursor-" + base
+	}
 	effort := ""
 	fast := false
 	fastSet := false
 	thinking := false
 	thinkingSet := false
 	parameterized := false
-	params := strings.Split(value[open+1:len(value)-1], ",")
+	params := strings.Split(body, ",")
 	for _, param := range params {
 		key, raw, found := strings.Cut(strings.TrimSpace(param), "=")
 		key = strings.TrimSpace(key)
 		raw = strings.TrimSpace(raw)
 		if !found || key == "" || raw == "" {
-			return "", false
+			return nil, false
 		}
 		switch key {
 		case "reasoning", "effort", "reasoning_effort":
 			if effort != "" && effort != raw {
-				return "", false
+				return nil, false
 			}
 			effort = raw
 			parameterized = true
@@ -361,10 +378,10 @@ func parameterizedModelAlias(value string) (string, bool) {
 				parsed = true
 			case "false":
 			default:
-				return "", false
+				return nil, false
 			}
 			if fastSet && fast != parsed {
-				return "", false
+				return nil, false
 			}
 			fast = parsed
 			fastSet = true
@@ -376,10 +393,10 @@ func parameterizedModelAlias(value string) (string, bool) {
 				parsed = true
 			case "false":
 			default:
-				return "", false
+				return nil, false
 			}
 			if thinkingSet && thinking != parsed {
-				return "", false
+				return nil, false
 			}
 			thinking = parsed
 			thinkingSet = true
@@ -393,25 +410,32 @@ func parameterizedModelAlias(value string) (string, bool) {
 			// Never derive an alias while silently discarding a provider-owned
 			// semantic parameter. New Cursor parameters must be mapped here
 			// deliberately before their opaque values can be selected by alias.
-			return "", false
+			return nil, false
 		}
 	}
 	if !parameterized {
-		return "", false
+		return nil, false
 	}
-	// Cursor's thinking variants currently pair thinking=true with an effort
-	// suffix (for example claude-opus-5-high). Without one, no safe CLI alias
-	// can be derived for the thinking semantic.
-	if thinking && effort == "" {
-		return "", false
-	}
-	if effort != "" {
-		alias += "-" + effort
-	}
+	fastSuffix := ""
 	if fast {
-		alias += "-fast"
+		fastSuffix = "-fast"
 	}
-	return alias, true
+	if !thinking {
+		if effort != "" {
+			base += "-" + effort
+		}
+		return []string{base + fastSuffix}, true
+	}
+	if effort == "" {
+		return []string{base + "-thinking" + fastSuffix}, true
+	}
+	// Cursor has shipped both thinking-effort and effort-thinking alias orders
+	// across Claude model families. Both retain the same advertised semantics;
+	// the caller still rejects any alias shared by multiple advertised choices.
+	return []string{
+		base + "-thinking-" + effort + fastSuffix,
+		base + "-" + effort + "-thinking" + fastSuffix,
+	}, true
 }
 
 func cloneConfigOptions(options []ports.ChatConfigOption) []ports.ChatConfigOption {

--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -296,6 +297,61 @@ func choiceOffered(choices []ports.ChatConfigOptionChoice, value string) bool {
 		}
 	}
 	return false
+}
+
+// resolveLegacyModelChoice translates a CLI-facing model alias into the exact
+// opaque value an ACP agent advertised. Cursor's CLI lists composer-2.5 while
+// its legacy ACP selector offers composer-2.5[fast=false]; session/set_model
+// accepts only the latter. Exact provider values always win, and an alias is
+// accepted only when it identifies one advertised choice unambiguously.
+func resolveLegacyModelChoice(choices []ports.ChatConfigOptionChoice, requested string) (string, bool) {
+	if choiceOffered(choices, requested) {
+		return requested, true
+	}
+
+	matched := ""
+	for _, choice := range choices {
+		base, fast, parameterized := parameterizedModelAlias(choice.Value)
+		if !parameterized {
+			continue
+		}
+		alias := base
+		if fast {
+			alias += "-fast"
+		}
+		if alias != requested {
+			continue
+		}
+		if matched != "" {
+			return "", false
+		}
+		matched = choice.Value
+	}
+	return matched, matched != ""
+}
+
+func parameterizedModelAlias(value string) (base string, fast bool, ok bool) {
+	open := strings.IndexByte(value, '[')
+	if open <= 0 || !strings.HasSuffix(value, "]") {
+		return "", false, false
+	}
+	base = value[:open]
+	params := strings.Split(value[open+1:len(value)-1], ",")
+	for _, param := range params {
+		key, raw, found := strings.Cut(strings.TrimSpace(param), "=")
+		if !found || strings.TrimSpace(key) != "fast" {
+			continue
+		}
+		switch strings.TrimSpace(raw) {
+		case "true":
+			return base, true, true
+		case "false":
+			return base, false, true
+		default:
+			return "", false, false
+		}
+	}
+	return "", false, false
 }
 
 func cloneConfigOptions(options []ports.ChatConfigOption) []ports.ChatConfigOption {

--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -333,39 +333,80 @@ func parameterizedModelAlias(value string) (string, bool) {
 		return "", false
 	}
 	alias := value[:open]
-	reasoning := ""
+	effort := ""
 	fast := false
+	fastSet := false
+	thinking := false
+	thinkingSet := false
 	parameterized := false
 	params := strings.Split(value[open+1:len(value)-1], ",")
 	for _, param := range params {
 		key, raw, found := strings.Cut(strings.TrimSpace(param), "=")
-		if !found {
-			continue
+		key = strings.TrimSpace(key)
+		raw = strings.TrimSpace(raw)
+		if !found || key == "" || raw == "" {
+			return "", false
 		}
-		switch strings.TrimSpace(key) {
-		case "reasoning":
-			reasoning = strings.TrimSpace(raw)
-			if reasoning == "" {
+		switch key {
+		case "reasoning", "effort", "reasoning_effort":
+			if effort != "" && effort != raw {
 				return "", false
 			}
+			effort = raw
 			parameterized = true
 		case "fast":
-			switch strings.TrimSpace(raw) {
+			parsed := false
+			switch raw {
 			case "true":
-				fast = true
+				parsed = true
 			case "false":
-				fast = false
 			default:
 				return "", false
 			}
+			if fastSet && fast != parsed {
+				return "", false
+			}
+			fast = parsed
+			fastSet = true
 			parameterized = true
+		case "thinking":
+			parsed := false
+			switch raw {
+			case "true":
+				parsed = true
+			case "false":
+			default:
+				return "", false
+			}
+			if thinkingSet && thinking != parsed {
+				return "", false
+			}
+			thinking = parsed
+			thinkingSet = true
+			parameterized = true
+		case "context":
+			// Cursor does not include the context window in its CLI alias. If
+			// multiple advertised values differ only by context, the caller's
+			// ambiguity check still rejects the alias.
+			parameterized = true
+		default:
+			// Never derive an alias while silently discarding a provider-owned
+			// semantic parameter. New Cursor parameters must be mapped here
+			// deliberately before their opaque values can be selected by alias.
+			return "", false
 		}
 	}
 	if !parameterized {
 		return "", false
 	}
-	if reasoning != "" {
-		alias += "-" + reasoning
+	// Cursor's thinking variants currently pair thinking=true with an effort
+	// suffix (for example claude-opus-5-high). Without one, no safe CLI alias
+	// can be derived for the thinking semantic.
+	if thinking && effort == "" {
+		return "", false
+	}
+	if effort != "" {
+		alias += "-" + effort
 	}
 	if fast {
 		alias += "-fast"

--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -327,10 +327,29 @@ func resolveLegacyModelChoice(choices []ports.ChatConfigOptionChoice, requested 
 		}
 		matched = choice.Value
 	}
+	if matched != "" {
+		return matched, true
+	}
+
+	// Cursor may advertise only one parameterized value for a model base, with
+	// flags reflecting the session's current account/runtime state. The CLI still
+	// exposes the stable base id. Selecting that id is safe when exactly one
+	// advertised opaque value has the same base; multiple variants remain
+	// ambiguous and are rejected.
+	for _, choice := range choices {
+		open := strings.IndexByte(choice.Value, '[')
+		if open <= 0 || !strings.HasSuffix(choice.Value, "]") || choice.Value[:open] != requested {
+			continue
+		}
+		if matched != "" {
+			return "", false
+		}
+		matched = choice.Value
+	}
 	return matched, matched != ""
 }
 
-func parameterizedModelAlias(value string) (base string, fast bool, ok bool) {
+func parameterizedModelAlias(value string) (base string, fast, ok bool) {
 	open := strings.IndexByte(value, '[')
 	if open <= 0 || !strings.HasSuffix(value, "]") {
 		return "", false, false

--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -300,10 +300,11 @@ func choiceOffered(choices []ports.ChatConfigOptionChoice, value string) bool {
 }
 
 // resolveLegacyModelChoice translates a CLI-facing model alias into the exact
-// opaque value an ACP agent advertised. Cursor's CLI lists composer-2.5 while
-// its legacy ACP selector offers composer-2.5[fast=false]; session/set_model
-// accepts only the latter. Exact provider values always win, and an alias is
-// accepted only when it identifies one advertised choice unambiguously.
+// opaque value an ACP agent advertised. Cursor's CLI lists aliases such as
+// composer-2.5-fast and gpt-5.5-medium while its legacy ACP selector includes
+// those settings as parameters; session/set_model accepts only the latter.
+// Exact provider values always win, and an alias is accepted only when it
+// identifies one advertised choice unambiguously.
 func resolveLegacyModelChoice(choices []ports.ChatConfigOptionChoice, requested string) (string, bool) {
 	if choiceOffered(choices, requested) {
 		return requested, true
@@ -311,34 +312,11 @@ func resolveLegacyModelChoice(choices []ports.ChatConfigOptionChoice, requested 
 
 	matched := ""
 	for _, choice := range choices {
-		base, fast, parameterized := parameterizedModelAlias(choice.Value)
+		alias, parameterized := parameterizedModelAlias(choice.Value)
 		if !parameterized {
 			continue
 		}
-		alias := base
-		if fast {
-			alias += "-fast"
-		}
 		if alias != requested {
-			continue
-		}
-		if matched != "" {
-			return "", false
-		}
-		matched = choice.Value
-	}
-	if matched != "" {
-		return matched, true
-	}
-
-	// Cursor may advertise only one parameterized value for a model base, with
-	// flags reflecting the session's current account/runtime state. The CLI still
-	// exposes the stable base id. Selecting that id is safe when exactly one
-	// advertised opaque value has the same base; multiple variants remain
-	// ambiguous and are rejected.
-	for _, choice := range choices {
-		open := strings.IndexByte(choice.Value, '[')
-		if open <= 0 || !strings.HasSuffix(choice.Value, "]") || choice.Value[:open] != requested {
 			continue
 		}
 		if matched != "" {
@@ -349,28 +327,50 @@ func resolveLegacyModelChoice(choices []ports.ChatConfigOptionChoice, requested 
 	return matched, matched != ""
 }
 
-func parameterizedModelAlias(value string) (base string, fast, ok bool) {
+func parameterizedModelAlias(value string) (string, bool) {
 	open := strings.IndexByte(value, '[')
 	if open <= 0 || !strings.HasSuffix(value, "]") {
-		return "", false, false
+		return "", false
 	}
-	base = value[:open]
+	alias := value[:open]
+	reasoning := ""
+	fast := false
+	parameterized := false
 	params := strings.Split(value[open+1:len(value)-1], ",")
 	for _, param := range params {
 		key, raw, found := strings.Cut(strings.TrimSpace(param), "=")
-		if !found || strings.TrimSpace(key) != "fast" {
+		if !found {
 			continue
 		}
-		switch strings.TrimSpace(raw) {
-		case "true":
-			return base, true, true
-		case "false":
-			return base, false, true
-		default:
-			return "", false, false
+		switch strings.TrimSpace(key) {
+		case "reasoning":
+			reasoning = strings.TrimSpace(raw)
+			if reasoning == "" {
+				return "", false
+			}
+			parameterized = true
+		case "fast":
+			switch strings.TrimSpace(raw) {
+			case "true":
+				fast = true
+			case "false":
+				fast = false
+			default:
+				return "", false
+			}
+			parameterized = true
 		}
 	}
-	return "", false, false
+	if !parameterized {
+		return "", false
+	}
+	if reasoning != "" {
+		alias += "-" + reasoning
+	}
+	if fast {
+		alias += "-fast"
+	}
+	return alias, true
 }
 
 func cloneConfigOptions(options []ports.ChatConfigOption) []ports.ChatConfigOption {

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -272,6 +272,7 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 	validateSettings := c.validateSettings
 	legacyModel := c.legacyModel
 	legacyMode := c.legacyMode
+	configOptions := cloneConfigOptions(c.configOptions)
 	c.mu.Unlock()
 	if sessionID == "" {
 		return errors.New("ACP session is not open")
@@ -282,13 +283,25 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 		}
 	}
 	if legacyModel && settings.Model != "" {
-		if err := c.legacyWire.setModel(ctx, sessionID, settings.Model); err != nil {
-			if isACPMethodNotFound(err) {
-				return fmt.Errorf("%w: session/set_model %q", ErrACPSetterUnsupported, settings.Model)
+		model := settings.Model
+		for _, option := range configOptions {
+			if option.ID != "model" {
+				continue
 			}
-			return fmt.Errorf("set ACP session model %q: %w", settings.Model, err)
+			resolved, ok := resolveLegacyModelChoice(option.Choices, model)
+			if !ok {
+				return fmt.Errorf("%w: ACP session model does not offer %q", ports.ErrChatConfigOptionInvalid, model)
+			}
+			model = resolved
+			break
 		}
-		c.applyAcceptedConfigOption("model", ports.ChatConfigOptionValue{Select: settings.Model})
+		if err := c.legacyWire.setModel(ctx, sessionID, model); err != nil {
+			if isACPMethodNotFound(err) {
+				return fmt.Errorf("%w: session/set_model %q", ErrACPSetterUnsupported, model)
+			}
+			return fmt.Errorf("set ACP session model %q: %w", model, err)
+		}
+		c.applyAcceptedConfigOption("model", ports.ChatConfigOptionValue{Select: model})
 	}
 	if modeFor != nil {
 		if mode := modeFor(settings.Approval); mode != "" {

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -284,16 +284,21 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 	}
 	if legacyModel && settings.Model != "" {
 		model := settings.Model
+		modelOptionFound := false
 		for _, option := range configOptions {
 			if option.ID != "model" {
 				continue
 			}
+			modelOptionFound = true
 			resolved, ok := resolveLegacyModelChoice(option.Choices, model)
 			if !ok {
 				return fmt.Errorf("%w: ACP session model does not offer %q", ports.ErrChatConfigOptionInvalid, model)
 			}
 			model = resolved
 			break
+		}
+		if !modelOptionFound {
+			return fmt.Errorf("%w: ACP session does not advertise a model option", ports.ErrChatConfigOptionInvalid)
 		}
 		if err := c.legacyWire.setModel(ctx, sessionID, model); err != nil {
 			if isACPMethodNotFound(err) {

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -1574,8 +1574,28 @@ func TestResolveLegacyModelChoiceDerivesParameterizedCursorAliases(t *testing.T)
 		},
 		{
 			name:      "thinking with effort",
-			requested: "claude-opus-5-high",
+			requested: "claude-opus-5-thinking-high",
 			choice:    "claude-opus-5[thinking=true,context=300k,effort=high,fast=false]",
+		},
+		{
+			name:      "thinking after effort",
+			requested: "claude-4.6-sonnet-medium-thinking",
+			choice:    "claude-4.6-sonnet[thinking=true,context=1m,effort=medium,fast=false]",
+		},
+		{
+			name:      "thinking without effort",
+			requested: "claude-4.5-sonnet-thinking",
+			choice:    "claude-4.5-sonnet[thinking=true,context=200k]",
+		},
+		{
+			name:      "cursor-prefixed grok",
+			requested: "cursor-grok-4.6-high-fast",
+			choice:    "grok-4.6[effort=high,fast=true]",
+		},
+		{
+			name:      "auto",
+			requested: "auto",
+			choice:    "default[]",
 		},
 	}
 	for _, tt := range tests {
@@ -1596,8 +1616,8 @@ func TestResolveLegacyModelChoiceRejectsDroppedParameterizedSemantics(t *testing
 		choice    string
 	}{
 		{
-			name:      "thinking variant is not plain base",
-			requested: "claude-opus-5",
+			name:      "thinking variant is not non-thinking alias",
+			requested: "claude-opus-5-high",
 			choice:    "claude-opus-5[thinking=true,context=300k,effort=high,fast=false]",
 		},
 		{
@@ -1621,6 +1641,34 @@ func TestResolveLegacyModelChoiceRejectsDroppedParameterizedSemantics(t *testing
 			choices := []ports.ChatConfigOptionChoice{{Value: tt.choice}}
 			if got, ok := resolveLegacyModelChoice(choices, tt.requested); ok {
 				t.Fatalf("resolveLegacyModelChoice(%q) = %q, true; want rejection", tt.requested, got)
+			}
+		})
+	}
+}
+
+func TestResolveLegacyModelChoiceDistinguishesThinkingVariants(t *testing.T) {
+	choices := []ports.ChatConfigOptionChoice{
+		{Value: "claude-opus-5[thinking=false,context=300k,effort=high,fast=false]"},
+		{Value: "claude-opus-5[thinking=true,context=300k,effort=high,fast=false]"},
+	}
+	tests := []struct {
+		requested string
+		want      string
+	}{
+		{
+			requested: "claude-opus-5-high",
+			want:      choices[0].Value,
+		},
+		{
+			requested: "claude-opus-5-thinking-high",
+			want:      choices[1].Value,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.requested, func(t *testing.T) {
+			got, ok := resolveLegacyModelChoice(choices, tt.requested)
+			if !ok || got != tt.want {
+				t.Fatalf("resolveLegacyModelChoice(%q) = %q, %v; want %q, true", tt.requested, got, ok, tt.want)
 			}
 		})
 	}

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -1562,6 +1562,21 @@ func TestResolveLegacyModelChoiceDerivesParameterizedCursorAliases(t *testing.T)
 			requested: "gpt-5.5-high-fast",
 			choice:    "gpt-5.5[context=272k,reasoning=high,fast=true]",
 		},
+		{
+			name:      "effort",
+			requested: "gemini-3.6-flash-high",
+			choice:    "gemini-3.6-flash[effort=high]",
+		},
+		{
+			name:      "reasoning effort",
+			requested: "gpt-5.5-low",
+			choice:    "gpt-5.5[reasoning_effort=low,fast=false]",
+		},
+		{
+			name:      "thinking with effort",
+			requested: "claude-opus-5-high",
+			choice:    "claude-opus-5[thinking=true,context=300k,effort=high,fast=false]",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1569,6 +1584,43 @@ func TestResolveLegacyModelChoiceDerivesParameterizedCursorAliases(t *testing.T)
 			got, ok := resolveLegacyModelChoice(choices, tt.requested)
 			if !ok || got != tt.choice {
 				t.Fatalf("resolveLegacyModelChoice(%q) = %q, %v; want %q, true", tt.requested, got, ok, tt.choice)
+			}
+		})
+	}
+}
+
+func TestResolveLegacyModelChoiceRejectsDroppedParameterizedSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		choice    string
+	}{
+		{
+			name:      "thinking variant is not plain base",
+			requested: "claude-opus-5",
+			choice:    "claude-opus-5[thinking=true,context=300k,effort=high,fast=false]",
+		},
+		{
+			name:      "thinking without effort has no known alias",
+			requested: "claude-opus-5",
+			choice:    "claude-opus-5[thinking=true,context=300k,fast=false]",
+		},
+		{
+			name:      "unknown semantic parameter",
+			requested: "future-model",
+			choice:    "future-model[quality=high,fast=false]",
+		},
+		{
+			name:      "conflicting effort parameters",
+			requested: "gpt-5.5-high",
+			choice:    "gpt-5.5[reasoning=high,reasoning_effort=medium]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			choices := []ports.ChatConfigOptionChoice{{Value: tt.choice}}
+			if got, ok := resolveLegacyModelChoice(choices, tt.requested); ok {
+				t.Fatalf("resolveLegacyModelChoice(%q) = %q, true; want rejection", tt.requested, got)
 			}
 		})
 	}

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -1504,12 +1504,12 @@ func TestACPDriverResolvesCLIModelToAdvertisedParameterizedLegacyChoice(t *testi
 	}
 }
 
-func TestACPDriverResolvesBaseAliasToOnlyAdvertisedParameterizedLegacyChoice(t *testing.T) {
+func TestACPDriverRejectsNonFastAliasWhenOnlyFastParameterizedChoiceIsAdvertised(t *testing.T) {
 	agent := &legacyKimiAgent{
 		currentModel: "auto",
 		availableModels: []legacyModelInfo{
 			{ModelID: "auto", Name: "Auto"},
-			{ModelID: "composer-2.5[fast=true]", Name: "composer-2.5"},
+			{ModelID: "composer-2.5[fast=true]", Name: "Composer 2.5 Fast"},
 		},
 		rejectUnknownModel: true,
 	}
@@ -1527,19 +1527,50 @@ func TestACPDriverResolvesBaseAliasToOnlyAdvertisedParameterizedLegacyChoice(t *
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	driver.spawn = fakeLegacyKimiSpawn(agent)
 
-	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{
+	_, err := driver.Start(context.Background(), ports.ChatStartConfig{
 		WorkspacePath: t.TempDir(), Model: "composer-2.5",
 	})
-	if err != nil {
-		t.Fatalf("Start with sole advertised parameterized model: %v", err)
+	if !errors.Is(err, ports.ErrChatConfigOptionInvalid) {
+		t.Fatalf("Start with unavailable non-fast alias: err = %v, want ErrChatConfigOptionInvalid", err)
 	}
-	defer conv.Close()
-
 	agent.mu.Lock()
-	model, calls := agent.model, agent.modelCalls
+	calls := agent.modelCalls
 	agent.mu.Unlock()
-	if model != "composer-2.5[fast=true]" || calls != 1 {
-		t.Fatalf("legacy model setter = %q across %d calls, want sole advertised exact value", model, calls)
+	if calls != 0 {
+		t.Fatalf("legacy model setter called %d times, want 0", calls)
+	}
+}
+
+func TestResolveLegacyModelChoiceDerivesParameterizedCursorAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		choice    string
+	}{
+		{
+			name:      "fast",
+			requested: "composer-2.5-fast",
+			choice:    "composer-2.5[fast=true]",
+		},
+		{
+			name:      "reasoning",
+			requested: "gpt-5.5-medium",
+			choice:    "gpt-5.5[context=272k,reasoning=medium,fast=false]",
+		},
+		{
+			name:      "reasoning and fast",
+			requested: "gpt-5.5-high-fast",
+			choice:    "gpt-5.5[context=272k,reasoning=high,fast=true]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			choices := []ports.ChatConfigOptionChoice{{Value: tt.choice}}
+			got, ok := resolveLegacyModelChoice(choices, tt.requested)
+			if !ok || got != tt.choice {
+				t.Fatalf("resolveLegacyModelChoice(%q) = %q, %v; want %q, true", tt.requested, got, ok, tt.choice)
+			}
+		})
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -1504,6 +1504,75 @@ func TestACPDriverResolvesCLIModelToAdvertisedParameterizedLegacyChoice(t *testi
 	}
 }
 
+func TestACPDriverRejectsLegacyModelAliasWithoutAdvertisedModelCatalog(t *testing.T) {
+	agent := &legacyKimiAgent{
+		currentModel: "auto",
+		availableModels: []legacyModelInfo{
+			{ModelID: "auto", Name: "Auto"},
+			{ModelID: "composer-2.5[fast=false]", Name: "Composer 2.5"},
+		},
+		rejectUnknownModel: true,
+	}
+	driver := New(Config{
+		Harness:      domain.HarnessCursor,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeLegacyKimiSpawn(agent)
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conv.Close()
+
+	conv.(*conversation).replaceConfigOptions(nil)
+	_, err = conv.SendTurn(context.Background(), ports.ChatUserMessage{
+		Text: "hello", Settings: ports.ChatTurnSettings{Model: "composer-2.5"},
+	})
+	if !errors.Is(err, ports.ErrChatConfigOptionInvalid) {
+		t.Fatalf("SendTurn without advertised model catalog: err = %v, want ErrChatConfigOptionInvalid", err)
+	}
+	agent.mu.Lock()
+	calls := agent.modelCalls
+	agent.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("legacy model setter called %d times, want 0", calls)
+	}
+}
+
+func TestACPDriverRejectsAmbiguousLegacyModelAlias(t *testing.T) {
+	agent := &legacyKimiAgent{
+		currentModel: "auto",
+		availableModels: []legacyModelInfo{
+			{ModelID: "composer-2.5[fast=false]", Name: "Composer 2.5"},
+			{ModelID: "composer-2.5[context=1m,fast=false]", Name: "Composer 2.5 1M"},
+		},
+		rejectUnknownModel: true,
+	}
+	driver := New(Config{
+		Harness:      domain.HarnessCursor,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeLegacyKimiSpawn(agent)
+
+	_, err := driver.Start(context.Background(), ports.ChatStartConfig{
+		WorkspacePath: t.TempDir(), Model: "composer-2.5",
+	})
+	if !errors.Is(err, ports.ErrChatConfigOptionInvalid) {
+		t.Fatalf("Start with ambiguous model alias: err = %v, want ErrChatConfigOptionInvalid", err)
+	}
+	agent.mu.Lock()
+	calls := agent.modelCalls
+	agent.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("legacy model setter called %d times, want 0", calls)
+	}
+}
+
 func TestACPDriverExposesDynamicAvailableCommandsAsSkills(t *testing.T) {
 	agent := &fakeAgent{}
 	driver := New(Config{

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -1504,6 +1504,45 @@ func TestACPDriverResolvesCLIModelToAdvertisedParameterizedLegacyChoice(t *testi
 	}
 }
 
+func TestACPDriverResolvesBaseAliasToOnlyAdvertisedParameterizedLegacyChoice(t *testing.T) {
+	agent := &legacyKimiAgent{
+		currentModel: "auto",
+		availableModels: []legacyModelInfo{
+			{ModelID: "auto", Name: "Auto"},
+			{ModelID: "composer-2.5[fast=true]", Name: "composer-2.5"},
+		},
+		rejectUnknownModel: true,
+	}
+	driver := New(Config{
+		Harness:      domain.HarnessCursor,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+		SessionOptions: func(settings ports.ChatTurnSettings) []SessionOption {
+			if settings.Model == "" {
+				return nil
+			}
+			return []SessionOption{{ID: "model", Value: settings.Model}}
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeLegacyKimiSpawn(agent)
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{
+		WorkspacePath: t.TempDir(), Model: "composer-2.5",
+	})
+	if err != nil {
+		t.Fatalf("Start with sole advertised parameterized model: %v", err)
+	}
+	defer conv.Close()
+
+	agent.mu.Lock()
+	model, calls := agent.model, agent.modelCalls
+	agent.mu.Unlock()
+	if model != "composer-2.5[fast=true]" || calls != 1 {
+		t.Fatalf("legacy model setter = %q across %d calls, want sole advertised exact value", model, calls)
+	}
+}
+
 func TestACPDriverRejectsLegacyModelAliasWithoutAdvertisedModelCatalog(t *testing.T) {
 	agent := &legacyKimiAgent{
 		currentModel: "auto",

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -57,12 +57,15 @@ type fakeAgent struct {
 }
 
 type legacyKimiAgent struct {
-	mu          sync.Mutex
-	model       string
-	modelCalls  int
-	mode        string
-	modeCalls   int
-	configCalls int
+	mu                 sync.Mutex
+	currentModel       string
+	availableModels    []legacyModelInfo
+	rejectUnknownModel bool
+	model              string
+	modelCalls         int
+	mode               string
+	modeCalls          int
+	configCalls        int
 }
 
 func fakeLegacyKimiSpawn(agent *legacyKimiAgent) spawnFunc {
@@ -109,14 +112,21 @@ func serveLegacyKimi(agent *legacyKimiAgent, in io.Reader, out io.Writer) {
 				},
 			}
 		case "session/new":
+			currentModel := agent.currentModel
+			availableModels := agent.availableModels
+			if currentModel == "" {
+				currentModel = "kimi-code/kimi-for-coding"
+			}
+			if len(availableModels) == 0 {
+				availableModels = []legacyModelInfo{{
+					ModelID: "kimi-code/kimi-for-coding", Name: "Kimi for Coding",
+				}}
+			}
 			result = map[string]any{
 				"sessionId": "kimi-session-1",
 				"models": map[string]any{
-					"currentModelId": "kimi-code/kimi-for-coding",
-					"availableModels": []map[string]any{{
-						"modelId": "kimi-code/kimi-for-coding",
-						"name":    "Kimi for Coding", "description": "Kimi coding model",
-					}},
+					"currentModelId":  currentModel,
+					"availableModels": availableModels,
 				},
 				"modes": map[string]any{
 					"currentModeId": "default",
@@ -131,8 +141,19 @@ func serveLegacyKimi(agent *legacyKimiAgent, in io.Reader, out io.Writer) {
 			}
 			_ = json.Unmarshal(request.Params, &params)
 			agent.mu.Lock()
-			agent.model = params.ModelID
-			agent.modelCalls++
+			accepted := !agent.rejectUnknownModel
+			for _, model := range agent.availableModels {
+				accepted = accepted || model.ModelID == params.ModelID
+			}
+			if accepted {
+				agent.model = params.ModelID
+				agent.modelCalls++
+			} else {
+				responseError = map[string]any{
+					"code": -32602, "message": "Invalid params",
+					"data": map[string]any{"message": "Invalid model value: " + params.ModelID},
+				}
+			}
 			agent.mu.Unlock()
 		case "session/set_mode":
 			var params struct {
@@ -1440,6 +1461,46 @@ func TestACPDriverConsumesLegacyKimiSelectorsOnSDK0135(t *testing.T) {
 		mode != "default" || modeCalls != 1 || configCalls != 0 {
 		t.Fatalf("legacy setters: model=%q/%d mode=%q/%d config=%d",
 			model, modelCalls, mode, modeCalls, configCalls)
+	}
+}
+
+func TestACPDriverResolvesCLIModelToAdvertisedParameterizedLegacyChoice(t *testing.T) {
+	agent := &legacyKimiAgent{
+		currentModel: "auto",
+		availableModels: []legacyModelInfo{
+			{ModelID: "auto", Name: "Auto"},
+			{ModelID: "composer-2.5[fast=false]", Name: "Composer 2.5"},
+			{ModelID: "composer-2.5[fast=true]", Name: "Composer 2.5 Fast"},
+		},
+		rejectUnknownModel: true,
+	}
+	driver := New(Config{
+		Harness:      domain.HarnessCursor,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+		SessionOptions: func(settings ports.ChatTurnSettings) []SessionOption {
+			if settings.Model == "" {
+				return nil
+			}
+			return []SessionOption{{ID: "model", Value: settings.Model}}
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeLegacyKimiSpawn(agent)
+
+	conv, err := driver.Start(context.Background(), ports.ChatStartConfig{
+		WorkspacePath: t.TempDir(), Model: "composer-2.5",
+	})
+	if err != nil {
+		t.Fatalf("Start with CLI model alias: %v", err)
+	}
+	defer conv.Close()
+
+	agent.mu.Lock()
+	model, calls := agent.model, agent.modelCalls
+	agent.mu.Unlock()
+	if model != "composer-2.5[fast=false]" || calls != 1 {
+		t.Fatalf("legacy model setter = %q across %d calls, want advertised non-fast value", model, calls)
 	}
 }
 


### PR DESCRIPTION
## What

Resolve Cursor CLI model aliases to the exact model values advertised by the ACP session before calling the legacy `session/set_model` endpoint.

## Why

Cursor's TUI accepts CLI aliases such as `composer-2.5`, but Cursor ACP advertises and validates parameterized values such as `composer-2.5[fast=false]`. The Chat UI forwarded the raw CLI alias, causing task startup to fail with `Invalid model value: composer-2.5`.

## How

- Preserve exact advertised model values when already selected.
- Map unambiguous non-fast and fast CLI aliases to their advertised parameterized ACP values.
- Reject missing, unavailable, or ambiguous advertised model choices with `ErrChatConfigOptionInvalid` instead of sending an unsafe raw fallback.
- Keep the legacy setter behavior used by existing ACP providers.

## Testing

- `go test ./...`
- `go test -race -count=1 ./internal/adapters/chatdriver/acp/... ./internal/adapters/chatdriver/cursoracp/...`
- `go vet ./internal/adapters/chatdriver/acp/... ./internal/adapters/chatdriver/cursoracp/...`
- `go build ./...`
- Added regression coverage for Cursor's parameterized model choices, missing model catalogs, and ambiguous aliases.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
