### PR TITLE
feat: enable Cursor chat and TUI handoff

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/auggie"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/fake"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimchi"
@@ -49,7 +50,7 @@ var Derivers = map[string]DeriveFunc{
 	"auggie":      auggie.DeriveActivityState,
 	"goose":       activitystate.StandardDeriveActivityState,
 	"devin":       activitystate.StandardDeriveActivityState,
-	"cursor":      activitystate.StandardDeriveActivityState,
+	"cursor":      cursor.DeriveActivityState,
 	"qwen":        activitystate.StandardDeriveActivityState,
 	"copilot":     activitystate.StandardDeriveActivityState,
 	"kimi":        activitystate.StandardDeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -83,6 +83,29 @@ func TestPrimeAgentDerivesManagedExtensionActivity(t *testing.T) {
 	}
 }
 
+func TestCursorDerivesManagedHookActivity(t *testing.T) {
+	tests := []struct {
+		event string
+		want  domain.ActivityState
+	}{
+		{"session-start", domain.ActivityActive},
+		{"user-prompt-submit", domain.ActivityActive},
+		{"stop", domain.ActivityIdle},
+		{"after-shell-execution", domain.ActivityActive},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := Derive("cursor", tt.event, []byte(`{}`))
+			if !ok || got != tt.want {
+				t.Fatalf("Derive(cursor, %q) = (%q, %v), want (%q, true)", tt.event, got, ok, tt.want)
+			}
+		})
+	}
+	if got, ok := Derive("cursor", "before-shell-execution", []byte(`{}`)); ok {
+		t.Fatalf("Derive(cursor, before-shell-execution) = (%q, true), want no activity from deriver", got)
+	}
+}
+
 func TestMuseDerivesManagedHookActivity(t *testing.T) {
 	tests := []struct {
 		event string

--- a/backend/internal/adapters/agent/cursor/activity.go
+++ b/backend/internal/adapters/agent/cursor/activity.go
@@ -1,0 +1,90 @@
+package cursor
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// EnvPermissionMode carries the AO permission mode for hook-time evaluation.
+// session_manager pins it into the runtime env at spawn/restore.
+const EnvPermissionMode = "AO_PERMISSION_MODE"
+
+// PermissionDecision is the outcome of evaluating a Cursor before-execution hook
+// against AO's permission policy.
+type PermissionDecision struct {
+	Permission     string
+	State          domain.ActivityState
+	ReportActivity bool
+}
+
+// DeriveActivityState maps a Cursor hook sub-command onto an AO activity state.
+// Before-execution hooks carry no fixed mapping — the CLI evaluates them via
+// EvaluatePermission and posts the resulting state separately.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start", "user-prompt-submit":
+		return domain.ActivityActive, true
+	case "stop":
+		return domain.ActivityIdle, true
+	case "after-shell-execution", "after-mcp-execution", "post-tool-use", "post-tool-use-failure":
+		return domain.ActivityActive, true
+	case "before-shell-execution", "before-mcp-execution":
+		return "", false
+	default:
+		return "", false
+	}
+}
+
+// EvaluatePermission decides whether a Cursor shell/MCP attempt needs user
+// approval under AO's permission mode. waiting_input is used (not blocked)
+// because Cursor installs no pre/post-tool-use correlation trio.
+func EvaluatePermission(mode ports.PermissionMode, _ string, _ []byte) PermissionDecision {
+	if permissionRequired(mode) {
+		return PermissionDecision{
+			Permission:     "ask",
+			State:          domain.ActivityWaitingInput,
+			ReportActivity: true,
+		}
+	}
+	return PermissionDecision{
+		Permission:     "allow",
+		State:          domain.ActivityActive,
+		ReportActivity: true,
+	}
+}
+
+func permissionRequired(mode ports.PermissionMode) bool {
+	switch ports.NormalizePermissionMode(mode) {
+	case ports.PermissionModeBypassPermissions, ports.PermissionModeAuto:
+		return false
+	default:
+		return true
+	}
+}
+
+// HookToolName extracts a display/correlation name from a Cursor hook payload.
+func HookToolName(event string, payload []byte) string {
+	var p struct {
+		Command  string `json:"command"`
+		ToolName string `json:"tool_name"`
+	}
+	_ = json.Unmarshal(payload, &p)
+	switch event {
+	case "before-shell-execution", "after-shell-execution":
+		return capHookField(p.Command)
+	default:
+		return capHookField(p.ToolName)
+	}
+}
+
+func capHookField(value string) string {
+	value = strings.TrimSpace(value)
+	const maxLen = 256
+	if len(value) <= maxLen {
+		return value
+	}
+	return value[:maxLen]
+}

--- a/backend/internal/adapters/agent/cursor/activity_test.go
+++ b/backend/internal/adapters/agent/cursor/activity_test.go
@@ -1,0 +1,76 @@
+package cursor
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestDeriveActivityState(t *testing.T) {
+	tests := []struct {
+		event  string
+		want   domain.ActivityState
+		wantOK bool
+	}{
+		{"session-start", domain.ActivityActive, true},
+		{"user-prompt-submit", domain.ActivityActive, true},
+		{"stop", domain.ActivityIdle, true},
+		{"after-shell-execution", domain.ActivityActive, true},
+		{"after-mcp-execution", domain.ActivityActive, true},
+		{"post-tool-use", domain.ActivityActive, true},
+		{"post-tool-use-failure", domain.ActivityActive, true},
+		{"before-shell-execution", "", false},
+		{"before-mcp-execution", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := DeriveActivityState(tt.event, []byte(`{}`))
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)", tt.event, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestEvaluatePermission(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       ports.PermissionMode
+		wantPerm   string
+		wantState  domain.ActivityState
+	}{
+		{"default asks", ports.PermissionModeDefault, "ask", domain.ActivityWaitingInput},
+		{"accept-edits asks", ports.PermissionModeAcceptEdits, "ask", domain.ActivityWaitingInput},
+		{"auto allows", ports.PermissionModeAuto, "allow", domain.ActivityActive},
+		{"bypass allows", ports.PermissionModeBypassPermissions, "allow", domain.ActivityActive},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EvaluatePermission(tt.mode, "before-shell-execution", []byte(`{"command":"git status"}`))
+			if got.Permission != tt.wantPerm || got.State != tt.wantState || !got.ReportActivity {
+				t.Fatalf("EvaluatePermission() = %+v, want permission=%q state=%q report=true", got, tt.wantPerm, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestHookToolName(t *testing.T) {
+	tests := []struct {
+		event   string
+		payload string
+		want    string
+	}{
+		{"before-shell-execution", `{"command":"git status"}`, "git status"},
+		{"after-shell-execution", `{"command":"npm test"}`, "npm test"},
+		{"before-mcp-execution", `{"tool_name":"search"}`, "search"},
+		{"after-mcp-execution", `{"tool_name":"fetch"}`, "fetch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			if got := HookToolName(tt.event, []byte(tt.payload)); got != tt.want {
+				t.Fatalf("HookToolName(%q) = %q, want %q", tt.event, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/agent/cursor/cursor.go
+++ b/backend/internal/adapters/agent/cursor/cursor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/pkg/agentruntime"
 )
@@ -40,6 +41,7 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.AgentInterfaceHandoff = (*Plugin)(nil)
 
 // cursorDataDir returns the isolated Cursor profile AO uses for managed Cursor
 // sessions. This keeps Cursor's trust/cache state under AO_DATA_DIR instead of
@@ -134,6 +136,26 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		Model:      cfg.Config.Model,
 		Permission: agentruntime.PermissionPolicy(cfg.Permissions),
 	})
+}
+
+// NativeConversationID bridges Cursor's terminal resume id and ACP session id.
+// Both surfaces use the same Cursor chat id; a TUI source must have reported it
+// through its sessionStart hook before AO may replace the controller.
+func (p *Plugin) NativeConversationID(
+	ctx context.Context,
+	session ports.SessionRef,
+	currentMode domain.SessionMode,
+	providerConversationID string,
+) (string, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return "", false, err
+	}
+	if currentMode == domain.SessionModeChat {
+		id := strings.TrimSpace(providerConversationID)
+		return id, id != "", nil
+	}
+	id := strings.TrimSpace(session.Metadata[ports.MetadataKeyAgentSessionID])
+	return id, id != "", nil
 }
 
 // SessionInfo surfaces Cursor hook-derived metadata. Metadata is intentionally

--- a/backend/internal/adapters/agent/cursor/cursor_test.go
+++ b/backend/internal/adapters/agent/cursor/cursor_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -198,6 +199,49 @@ func TestGetRestoreCommandFalseWithoutAgentSessionID(t *testing.T) {
 			}
 			if cmd != nil {
 				t.Fatalf("cmd = %#v, want nil", cmd)
+			}
+		})
+	}
+}
+
+func TestNativeConversationIDUsesCursorIdentityFromCurrentInterface(t *testing.T) {
+	plugin := &Plugin{}
+	tuiID, ok, err := plugin.NativeConversationID(context.Background(), ports.SessionRef{
+		ID: "ao-session-1",
+		Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID: "cursor-native-1",
+		},
+	}, domain.SessionModeTUI, "stale-chat-id")
+	if err != nil || !ok || tuiID != "cursor-native-1" {
+		t.Fatalf("TUI native id = %q ok=%v err=%v", tuiID, ok, err)
+	}
+
+	chatID, ok, err := plugin.NativeConversationID(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "stale-tui-id"},
+	}, domain.SessionModeChat, "cursor-native-1")
+	if err != nil || !ok || chatID != "cursor-native-1" {
+		t.Fatalf("Chat native id = %q ok=%v err=%v", chatID, ok, err)
+	}
+}
+
+func TestNativeConversationIDRefusesMissingCursorIdentity(t *testing.T) {
+	plugin := &Plugin{}
+	for _, test := range []struct {
+		name       string
+		mode       domain.SessionMode
+		providerID string
+		metadata   map[string]string
+	}{
+		{name: "TUI does not derive AO id", mode: domain.SessionModeTUI, metadata: map[string]string{}},
+		{name: "blank TUI id", mode: domain.SessionModeTUI, metadata: map[string]string{ports.MetadataKeyAgentSessionID: "  "}},
+		{name: "blank Chat id", mode: domain.SessionModeChat, providerID: "  ", metadata: map[string]string{ports.MetadataKeyAgentSessionID: "stale"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			id, ok, err := plugin.NativeConversationID(context.Background(), ports.SessionRef{
+				ID: "ao-session-1", Metadata: test.metadata,
+			}, test.mode, test.providerID)
+			if err != nil || ok || id != "" {
+				t.Fatalf("native id = %q ok=%v err=%v, want empty/false/nil", id, ok, err)
 			}
 		})
 	}

--- a/backend/internal/adapters/agent/cursor/hooks.go
+++ b/backend/internal/adapters/agent/cursor/hooks.go
@@ -61,8 +61,12 @@ var cursorManagedHooks = []cursorHookSpec{
 	{Event: "sessionStart", Command: cursorHookCommandPrefix + "session-start"},
 	{Event: "beforeSubmitPrompt", Command: cursorHookCommandPrefix + "user-prompt-submit"},
 	{Event: "stop", Command: cursorHookCommandPrefix + "stop"},
-	{Event: "beforeShellExecution", Command: cursorHookCommandPrefix + "permission-request"},
-	{Event: "beforeMCPExecution", Command: cursorHookCommandPrefix + "permission-request"},
+	{Event: "beforeShellExecution", Command: cursorHookCommandPrefix + "before-shell-execution"},
+	{Event: "beforeMCPExecution", Command: cursorHookCommandPrefix + "before-mcp-execution"},
+	{Event: "afterShellExecution", Command: cursorHookCommandPrefix + "after-shell-execution"},
+	{Event: "afterMCPExecution", Command: cursorHookCommandPrefix + "after-mcp-execution"},
+	{Event: "postToolUse", Command: cursorHookCommandPrefix + "post-tool-use"},
+	{Event: "postToolUseFailure", Command: cursorHookCommandPrefix + "post-tool-use-failure"},
 }
 
 // GetAgentHooks installs AO's Cursor hooks into the worktree-local

--- a/backend/internal/adapters/agent/cursor/terminal_surface.go
+++ b/backend/internal/adapters/agent/cursor/terminal_surface.go
@@ -1,0 +1,75 @@
+package cursor
+
+import (
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/terminalui"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const cursorTerminalActivityLookbackLines = 16
+
+// InspectTerminalSurface identifies Cursor's current composer only when its
+// provider-owned model footer appears below it. That structural boundary keeps
+// prompt-shaped transcript text from being treated as safe current input.
+func (p *Plugin) InspectTerminalSurface(output string) ports.TerminalSurfaceObservation {
+	lines := terminalui.PlainTerminalLines(output)
+	prompt := -1
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "→") {
+			prompt = i
+			break
+		}
+	}
+	if prompt < 0 || !cursorFooterAfter(lines, prompt) {
+		return ports.TerminalSurfaceObservation{}
+	}
+
+	text := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[prompt]), "→"))
+	composer := ports.TerminalComposerDraft
+	switch text {
+	case "", "Add a follow-up", "Plan, search, build anything":
+		composer = ports.TerminalComposerEmpty
+	}
+	work := ports.TerminalSurfaceWorkIdle
+	start := prompt - cursorTerminalActivityLookbackLines
+	if start < 0 {
+		start = 0
+	}
+	for _, raw := range lines[start:prompt] {
+		if strings.Contains(strings.ToLower(raw), "esc to interrupt") {
+			work = ports.TerminalSurfaceWorkActive
+		}
+	}
+	return ports.TerminalSurfaceObservation{
+		Work:     work,
+		Composer: composer,
+	}
+}
+
+func cursorFooterAfter(lines []string, prompt int) bool {
+	for _, raw := range lines[prompt+1:] {
+		line := strings.TrimSpace(raw)
+		if (strings.HasPrefix(line, "Cursor ") || strings.HasPrefix(line, "Composer ")) &&
+			strings.Contains(line, " · ") {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectTerminalActivity provides the legacy activity-only view of Cursor's
+// current terminal surface.
+func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
+	if p.InspectTerminalSurface(output).Work == ports.TerminalSurfaceWorkIdle {
+		return domain.ActivityIdle, true
+	}
+	return "", false
+}
+
+// ComposerIsEmpty reports whether Cursor's structurally current composer is
+// empty or showing one of its provider-owned placeholder strings.
+func (p *Plugin) ComposerIsEmpty(output string) bool {
+	return p.InspectTerminalSurface(output).Composer == ports.TerminalComposerEmpty
+}

--- a/backend/internal/adapters/agent/cursor/terminal_surface_test.go
+++ b/backend/internal/adapters/agent/cursor/terminal_surface_test.go
@@ -1,0 +1,70 @@
+package cursor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestCursorTerminalSurfaceRecognizesCurrentEmptyComposer(t *testing.T) {
+	output := "cursor-retrieval: tracing to '/tmp/cursor.log'\n\n" +
+		"  Cursor Agent\n  \x1b[2mv2026.08.11-e8db854\x1b[0m\n\n" +
+		"  Hi — what would you like to work on?\n\n" +
+		" \x1b[48;2;21;21;21m                                                                             \x1b[49m\n" +
+		" \x1b[48;2;21;21;21m \x1b[2m→ \x1b[0;7m\x1b[48;2;21;21;21mA\x1b[0;2m\x1b[48;2;21;21;21mdd a follow-up\x1b[0m\x1b[48;2;21;21;21m                                                           \x1b[49m\n" +
+		" \x1b[48;2;21;21;21m                                                                             \x1b[49m\n\n" +
+		"  \x1b[2mCursor Grok 4.6 High Fast\x1b[0m \x1b[2m·\x1b[0m \x1b[2m7%\x1b[0m\n" +
+		"  \x1b[2m~/project\x1b[0m\n"
+
+	inspector, ok := any(New()).(ports.TerminalSurfaceInspector)
+	if !ok {
+		t.Fatal("Cursor adapter does not expose terminal surface inspection")
+	}
+	got := inspector.InspectTerminalSurface(output)
+	if got.Work != ports.TerminalSurfaceWorkIdle || got.Composer != ports.TerminalComposerEmpty {
+		t.Fatalf("InspectTerminalSurface() = %+v, want idle empty composer", got)
+	}
+}
+
+func TestCursorTerminalSurfacePreservesDraft(t *testing.T) {
+	output := "  Cursor Agent\n\n" +
+		"  → keep this unsent draft\n\n" +
+		"  Cursor Grok 4.6 High Fast · 7%\n" +
+		"  ~/project\n"
+
+	inspector, ok := any(New()).(ports.TerminalSurfaceInspector)
+	if !ok {
+		t.Fatal("Cursor adapter does not expose terminal surface inspection")
+	}
+	got := inspector.InspectTerminalSurface(output)
+	if got.Work != ports.TerminalSurfaceWorkIdle || got.Composer != ports.TerminalComposerDraft {
+		t.Fatalf("InspectTerminalSurface() = %+v, want idle draft composer", got)
+	}
+}
+
+func TestCursorTerminalSurfaceFindsComposerAboveTallViewportPadding(t *testing.T) {
+	output := "  Cursor Agent\n\n" +
+		"  AO_HANDOFF_TERMINAL\n\n" +
+		"  → Add a follow-up\n\n" +
+		"  Composer 2.5 Fast · 7.9%\n" +
+		"  ~/project\n" + strings.Repeat("\n", 32)
+
+	got := New().InspectTerminalSurface(output)
+	if got.Work != ports.TerminalSurfaceWorkIdle || got.Composer != ports.TerminalComposerEmpty {
+		t.Fatalf("InspectTerminalSurface() = %+v, want idle empty composer above viewport padding", got)
+	}
+}
+
+func TestCursorTerminalSurfaceDoesNotTreatInterruptibleFrameAsIdle(t *testing.T) {
+	output := "  Cursor Agent\n\n" +
+		"  Working (esc to interrupt)\n" +
+		"  → Add a follow-up\n\n" +
+		"  Cursor Grok 4.6 High Fast · 7%\n" +
+		"  ~/project\n"
+
+	got := New().InspectTerminalSurface(output)
+	if got.Work != ports.TerminalSurfaceWorkActive {
+		t.Fatalf("InspectTerminalSurface() = %+v, want active work", got)
+	}
+}

--- a/backend/internal/adapters/chatdriver/acp/driver.go
+++ b/backend/internal/adapters/chatdriver/acp/driver.go
@@ -33,14 +33,25 @@ type Launch struct {
 // construct its process. It intentionally contains no install mechanism: binary
 // ownership stays with the existing agent plugin.
 type LaunchConfig struct {
-	SessionID     domain.SessionID
-	DataDir       string
-	WorkspacePath string
-	Env           map[string]string
-	Model         string
-	Permissions   ports.PermissionMode
-	SystemPrompt  string
+	SessionID            domain.SessionID
+	DataDir              string
+	WorkspacePath        string
+	Env                  map[string]string
+	Model                string
+	Permissions          ports.PermissionMode
+	SystemPrompt         string
+	RequireNativeHistory bool
 }
+
+// NativeHistoryAugmenter lets one ACP binding supplement an incomplete
+// session/load replay with provider-owned local history. It is invoked only for
+// an explicit interface handoff; ordinary resumes keep the protocol replay as-is.
+type NativeHistoryAugmenter func(
+	context.Context,
+	LaunchConfig,
+	string,
+	[]ports.ChatEvent,
+) ([]ports.ChatEvent, error)
 
 // Config binds one harness to an ACP agent implementation.
 type Config struct {
@@ -75,7 +86,8 @@ type Config struct {
 	ClientExtensionAliases map[string]string
 	// ValidateTurnSettings rejects provider settings that cannot be applied to a
 	// live process. The initial permission mode is the launch-time value.
-	ValidateTurnSettings TurnSettingsValidator
+	ValidateTurnSettings   TurnSettingsValidator
+	NativeHistoryAugmenter NativeHistoryAugmenter
 }
 
 // TurnSettingsValidator validates live turn settings against launch-time state.
@@ -221,6 +233,7 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 	launchCfg := LaunchConfig{
 		SessionID: cfg.SessionID, DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath,
 		Env: cfg.Env, Model: cfg.Model, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
+		RequireNativeHistory: cfg.RequireNativeHistory,
 	}
 	conv, init, err := d.connect(ctx, launchCfg)
 	if err != nil {
@@ -268,6 +281,19 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 			return nil, fmt.Errorf("%w: %w", ports.ErrChatResumeFailed, normalizeACPError("ACP session/load", err))
 		}
 		conv.finishHistoryReplay()
+		if cfg.RequireNativeHistory && d.cfg.NativeHistoryAugmenter != nil {
+			history, historyErr := conv.ReadHistory(resumeCtx)
+			if historyErr == nil {
+				history, historyErr = d.cfg.NativeHistoryAugmenter(
+					resumeCtx, launchCfg, cfg.ProviderConversationID, history,
+				)
+			}
+			if historyErr != nil {
+				_ = conv.Close()
+				return nil, fmt.Errorf("%w: augment ACP native history: %w", ports.ErrChatResumeFailed, historyErr)
+			}
+			conv.replaceHistoryEvents(history)
+		}
 		configOptions = resp.ConfigOptions
 		modes = resp.Modes
 	} else {

--- a/backend/internal/adapters/chatdriver/acp/history.go
+++ b/backend/internal/adapters/chatdriver/acp/history.go
@@ -111,6 +111,14 @@ func (c *conversation) ReadHistory(ctx context.Context) ([]ports.ChatEvent, erro
 	return append([]ports.ChatEvent(nil), c.historyEvents...), nil
 }
 
+func (c *conversation) replaceHistoryEvents(events []ports.ChatEvent) {
+	c.historyMu.Lock()
+	c.historyEvents = append([]ports.ChatEvent(nil), events...)
+	c.historyErr = nil
+	c.historyLoaded = true
+	c.historyMu.Unlock()
+}
+
 // prepareHistoryUpdate handles the one replay notification that the ordinary live
 // path intentionally ignores: user_message_chunk. For all other replay updates it
 // establishes the reconstructed turn, then lets SessionUpdate's existing ACP -> AO

--- a/backend/internal/adapters/chatdriver/cursoracp/driver.go
+++ b/backend/internal/adapters/chatdriver/cursoracp/driver.go
@@ -34,8 +34,9 @@ func New(plugin nativeacp.Plugin, log *slog.Logger) ports.ChatDriver {
 			askQuestionMethod: "_cursor/ask_question",
 			createPlanMethod:  "_cursor/create_plan",
 		},
-		ValidateTurnSettings: validateTurnSettings,
-		VersionProbe:         versionProbe,
+		ValidateTurnSettings:   validateTurnSettings,
+		NativeHistoryAugmenter: augmentCursorHandoffHistory,
+		VersionProbe:           versionProbe,
 	}, log)
 }
 

--- a/backend/internal/adapters/chatdriver/cursoracp/handoff_history.go
+++ b/backend/internal/adapters/chatdriver/cursoracp/handoff_history.go
@@ -1,0 +1,432 @@
+package cursoracp
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const cursorHandoffTranscriptLimit = 512 << 10
+
+type cursorTranscriptLine struct {
+	Role    string `json:"role"`
+	Message struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"message"`
+}
+
+type cursorTranscriptTurn struct {
+	user      string
+	assistant string
+	migrated  bool
+}
+
+type cursorInterfaceHandoffEnvelope struct {
+	XMLName  xml.Name                        `xml:"ao-interface-handoff"`
+	Messages []cursorInterfaceHandoffMessage `xml:"message"`
+}
+
+type cursorInterfaceHandoffMessage struct {
+	Role string `xml:"role,attr"`
+	Text string `xml:",chardata"`
+}
+
+type cursorHistoryBlock struct {
+	events       []ports.ChatEvent
+	userKey      string
+	assistantKey string
+	turnID       string
+	drop         bool
+}
+
+type cursorHistoryMatchKey struct {
+	user      string
+	assistant string
+	migrated  bool
+}
+
+func augmentCursorHandoffHistory(
+	ctx context.Context,
+	cfg acpdriver.LaunchConfig,
+	providerConversationID string,
+	history []ports.ChatEvent,
+) ([]ports.ChatEvent, error) {
+	if !cfg.RequireNativeHistory {
+		return history, nil
+	}
+	turns, err := readCursorTerminalTranscript(ctx, cfg.DataDir, providerConversationID)
+	if err != nil {
+		return nil, err
+	}
+	blocks, err := cursorProviderHistoryBlocks(history)
+	if err != nil {
+		return nil, err
+	}
+	providerIndexes := make([]int, 0, len(blocks))
+	providerKeys := make([]cursorHistoryMatchKey, 0, len(blocks))
+	for index, block := range blocks {
+		if block.userKey != "" {
+			providerIndexes = append(providerIndexes, index)
+			providerKeys = append(providerKeys, cursorHistoryMatchKey{
+				user: block.userKey, assistant: block.assistantKey,
+			})
+		}
+	}
+	transcriptKeys := make([]cursorHistoryMatchKey, len(turns))
+	for index, turn := range turns {
+		transcriptKeys[index] = cursorHistoryMatchKey{
+			user: normalizeCursorHistoryText(turn.user), assistant: normalizeCursorHistoryText(turn.assistant),
+			migrated: turn.migrated,
+		}
+	}
+	matches := cursorHistoryLCS(providerKeys, transcriptKeys)
+
+	result := make([]ports.ChatEvent, 0, len(history)+len(turns)*4)
+	providerBlock := 0
+	transcriptTurn := 0
+	for _, match := range matches {
+		matchedBlock := providerIndexes[match[0]]
+		for ; providerBlock < matchedBlock; providerBlock++ {
+			result = append(result, blocks[providerBlock].events...)
+		}
+		for ; transcriptTurn < match[1]; transcriptTurn++ {
+			result = appendCursorTranscriptTurn(result, providerConversationID, transcriptTurn, turns[transcriptTurn])
+		}
+		if turns[transcriptTurn].migrated {
+			// Cursor ACP can flatten the envelope and concatenate replies from
+			// separate Chat turns. The native transcript retains their exact frames.
+			result = appendCursorTranscriptTurn(result, providerConversationID, transcriptTurn, turns[transcriptTurn])
+		} else {
+			result = append(result, completedCursorHistoryBlock(
+				blocks[matchedBlock].events, turns[transcriptTurn].assistant != "")...)
+		}
+		providerBlock = matchedBlock + 1
+		transcriptTurn++
+	}
+	for ; providerBlock < len(blocks); providerBlock++ {
+		result = append(result, blocks[providerBlock].events...)
+	}
+	for ; transcriptTurn < len(turns); transcriptTurn++ {
+		result = appendCursorTranscriptTurn(result, providerConversationID, transcriptTurn, turns[transcriptTurn])
+	}
+	return result, nil
+}
+
+func completedCursorHistoryBlock(events []ports.ChatEvent, answered bool) []ports.ChatEvent {
+	if !answered {
+		return events
+	}
+	for index := range events {
+		if events[index].Kind == ports.ChatEventTurnCompleted &&
+			events[index].TurnState == domain.TurnStateRecovered {
+			events[index].TurnState = domain.TurnStateCompleted
+		}
+	}
+	return events
+}
+
+func cursorProviderHistoryBlocks(history []ports.ChatEvent) ([]cursorHistoryBlock, error) {
+	var blocks []cursorHistoryBlock
+	for _, event := range history {
+		if len(blocks) == 0 || event.ProviderTurnID == "" ||
+			blocks[len(blocks)-1].turnID != event.ProviderTurnID {
+			blocks = append(blocks, cursorHistoryBlock{turnID: event.ProviderTurnID})
+		}
+		block := &blocks[len(blocks)-1]
+		if block.drop {
+			continue
+		}
+		block.events = append(block.events, event)
+		switch event.Kind {
+		case ports.ChatEventUserMessageCompleted:
+			query := cursorUserQuery(event.Text)
+			if cursorInterfaceHandoffCandidate(query) {
+				if _, ok := cursorInterfaceHandoffMessages(query); !ok {
+					return nil, fmt.Errorf("%w: malformed Cursor interface handoff envelope", ports.ErrChatHistoryUnavailable)
+				}
+				// Drop the raw transport turn and its acknowledgement. Canonical
+				// visible messages are reconstructed from the native transcript.
+				block.events = nil
+				block.userKey = ""
+				block.drop = true
+				continue
+			}
+			block.userKey = normalizeCursorHistoryText(event.Text)
+		case ports.ChatEventMessageCompleted:
+			if text := normalizeCursorHistoryText(event.Text); text != "" {
+				block.assistantKey = strings.TrimSpace(block.assistantKey + " " + text)
+			}
+		}
+	}
+	kept := blocks[:0]
+	for _, block := range blocks {
+		if !block.drop && len(block.events) > 0 {
+			kept = append(kept, block)
+		}
+	}
+	return kept, nil
+}
+
+func cursorHistoryLCS(provider, transcript []cursorHistoryMatchKey) [][2]int {
+	table := make([][]int, len(provider)+1)
+	for index := range table {
+		table[index] = make([]int, len(transcript)+1)
+	}
+	for p := len(provider) - 1; p >= 0; p-- {
+		for t := len(transcript) - 1; t >= 0; t-- {
+			table[p][t] = max(table[p+1][t], table[p][t+1])
+			if score := cursorHistoryMatchScore(provider[p], transcript[t]); score >= 0 {
+				table[p][t] = max(table[p][t], score+table[p+1][t+1])
+			}
+		}
+	}
+	var matches [][2]int
+	for p, t := 0, 0; p < len(provider) && t < len(transcript); {
+		score := cursorHistoryMatchScore(provider[p], transcript[t])
+		matchTotal := -1
+		if score >= 0 {
+			matchTotal = score + table[p+1][t+1]
+		}
+		switch {
+		case matchTotal >= table[p+1][t] && matchTotal >= table[p][t+1]:
+			matches = append(matches, [2]int{p, t})
+			p++
+			t++
+		case table[p+1][t] >= table[p][t+1]:
+			p++
+		default:
+			t++
+		}
+	}
+	return matches
+}
+
+func cursorHistoryMatchScore(provider, transcript cursorHistoryMatchKey) int {
+	if provider.user != transcript.user {
+		return -1
+	}
+	if provider.assistant == "" || transcript.assistant == "" {
+		return 1
+	}
+	if provider.assistant == transcript.assistant {
+		return 2
+	}
+	// Cursor can prepend status text when ACP flattens an AO migration turn.
+	// Native transcript content remains the canonical visible answer.
+	if transcript.migrated && strings.Contains(provider.assistant, transcript.assistant) {
+		return 2
+	}
+	return 1
+}
+
+func appendCursorTranscriptTurn(
+	result []ports.ChatEvent,
+	providerConversationID string,
+	ordinal int,
+	turn cursorTranscriptTurn,
+) []ports.ChatEvent {
+	turnID := fmt.Sprintf("cursor-terminal-history:%s:%d", providerConversationID, ordinal)
+	result = append(result, cursorTerminalHistoryEvent(providerConversationID, ordinal, "turn-started",
+		ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: turnID}))
+	result = append(result, cursorTerminalHistoryEvent(providerConversationID, ordinal, "user",
+		ports.ChatEvent{
+			Kind: ports.ChatEventUserMessageCompleted, ProviderTurnID: turnID,
+			ProviderItemID: turnID + ":user", ClientMessageID: turnID + ":user", Text: turn.user,
+		}))
+	if turn.assistant != "" {
+		result = append(result, cursorTerminalHistoryEvent(providerConversationID, ordinal, "assistant",
+			ports.ChatEvent{
+				Kind: ports.ChatEventMessageCompleted, ProviderTurnID: turnID,
+				ProviderItemID: turnID + ":assistant", Text: turn.assistant,
+			}))
+	}
+	turnState := domain.TurnStateRecovered
+	if turn.assistant != "" {
+		turnState = domain.TurnStateCompleted
+	}
+	return append(result, cursorTerminalHistoryEvent(providerConversationID, ordinal, "turn-completed",
+		ports.ChatEvent{
+			Kind: ports.ChatEventTurnCompleted, ProviderTurnID: turnID, TurnState: turnState,
+		}))
+}
+
+func normalizeCursorHistoryText(text string) string {
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func cursorTerminalHistoryEvent(
+	providerConversationID string,
+	ordinal int,
+	kind string,
+	event ports.ChatEvent,
+) ports.ChatEvent {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s\x00%d\x00%s", providerConversationID, ordinal, kind)))
+	event.ProviderEventID = "cursor-terminal:" + hex.EncodeToString(sum[:16])
+	return event
+}
+
+func readCursorTerminalTranscript(
+	ctx context.Context,
+	dataDir string,
+	providerConversationID string,
+) ([]cursorTranscriptTurn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(providerConversationID)
+	if id == "" || filepath.Base(id) != id || strings.ContainsAny(id, `*?[]/\`) {
+		return nil, fmt.Errorf("%w: invalid Cursor native conversation id", ports.ErrChatHistoryUnavailable)
+	}
+	pattern := filepath.Join(dataDir, "cursor", "projects", "*", "agent-transcripts", id, id+".jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("%w: locate Cursor terminal transcript: %v", ports.ErrChatHistoryUnavailable, err)
+	}
+	if len(matches) != 1 {
+		return nil, fmt.Errorf("%w: expected one Cursor terminal transcript for %s, found %d",
+			ports.ErrChatHistoryUnavailable, id, len(matches))
+	}
+	info, err := os.Stat(matches[0])
+	if err != nil {
+		return nil, fmt.Errorf("%w: stat Cursor terminal transcript: %v", ports.ErrChatHistoryUnavailable, err)
+	}
+	if info.Size() > cursorHandoffTranscriptLimit {
+		return nil, fmt.Errorf("%w: Cursor terminal transcript exceeds %d bytes",
+			ports.ErrChatHistoryUnavailable, cursorHandoffTranscriptLimit)
+	}
+	file, err := os.Open(matches[0])
+	if err != nil {
+		return nil, fmt.Errorf("%w: open Cursor terminal transcript: %v", ports.ErrChatHistoryUnavailable, err)
+	}
+	defer file.Close()
+
+	var turns []cursorTranscriptTurn
+	skipHandoffAssistant := false
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64<<10), cursorHandoffTranscriptLimit)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var line cursorTranscriptLine
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			continue
+		}
+		text := cursorTranscriptText(line)
+		switch line.Role {
+		case "user":
+			query := cursorUserQuery(text)
+			if messages, ok := cursorInterfaceHandoffMessages(query); ok {
+				for _, message := range messages {
+					switch message.Role {
+					case "user":
+						turns = append(turns, cursorTranscriptTurn{user: message.Text, migrated: true})
+					case "assistant":
+						if len(turns) > 0 && turns[len(turns)-1].assistant == "" {
+							turns[len(turns)-1].assistant = message.Text
+						}
+					}
+				}
+				skipHandoffAssistant = true
+				continue
+			}
+			if cursorInterfaceHandoffCandidate(query) {
+				return nil, fmt.Errorf("%w: malformed Cursor interface handoff envelope", ports.ErrChatHistoryUnavailable)
+			}
+			skipHandoffAssistant = false
+			if query != "" {
+				turns = append(turns, cursorTranscriptTurn{user: query})
+			}
+		case "assistant":
+			if skipHandoffAssistant {
+				continue
+			}
+			text = cleanCursorTranscriptAssistant(text)
+			if text != "" && len(turns) > 0 {
+				if turns[len(turns)-1].assistant != "" {
+					turns[len(turns)-1].assistant += "\n"
+				}
+				turns[len(turns)-1].assistant += text
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%w: read Cursor terminal transcript: %v", ports.ErrChatHistoryUnavailable, err)
+	}
+	if len(turns) == 0 {
+		return nil, fmt.Errorf("%w: Cursor terminal transcript contains no user turns", ports.ErrChatHistoryUnavailable)
+	}
+	return turns, nil
+}
+
+func cleanCursorTranscriptAssistant(text string) string {
+	lines := strings.Split(text, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "[REDACTED]" {
+			kept = append(kept, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+func cursorInterfaceHandoffMessages(query string) ([]cursorInterfaceHandoffMessage, bool) {
+	if !strings.HasPrefix(strings.TrimSpace(query), `<ao-interface-handoff version="1">`) {
+		return nil, false
+	}
+	var envelope cursorInterfaceHandoffEnvelope
+	if err := xml.Unmarshal([]byte(query), &envelope); err != nil || envelope.XMLName.Local != "ao-interface-handoff" {
+		return nil, false
+	}
+	messages := envelope.Messages[:0]
+	for _, message := range envelope.Messages {
+		message.Role = strings.TrimSpace(message.Role)
+		message.Text = strings.TrimSpace(message.Text)
+		if message.Text != "" && (message.Role == "user" || message.Role == "assistant") {
+			messages = append(messages, message)
+		}
+	}
+	return messages, true
+}
+
+func cursorInterfaceHandoffCandidate(query string) bool {
+	return strings.HasPrefix(strings.TrimSpace(query), "<ao-interface-handoff")
+}
+
+func cursorTranscriptText(line cursorTranscriptLine) string {
+	var parts []string
+	for _, content := range line.Message.Content {
+		if content.Type == "text" && strings.TrimSpace(content.Text) != "" {
+			parts = append(parts, strings.TrimSpace(content.Text))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func cursorUserQuery(text string) string {
+	const open, close = "<user_query>", "</user_query>"
+	start := strings.Index(text, open)
+	if start < 0 {
+		return strings.TrimSpace(text)
+	}
+	rest := text[start+len(open):]
+	end := strings.Index(rest, close)
+	if end < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(rest[:end])
+}

--- a/backend/internal/adapters/chatdriver/nativeacp/driver.go
+++ b/backend/internal/adapters/chatdriver/nativeacp/driver.go
@@ -50,6 +50,7 @@ type Config struct {
 	ClientExtension        acpdriver.ClientExtensionHandler
 	ClientExtensionAliases map[string]string
 	ValidateTurnSettings   acpdriver.TurnSettingsValidator
+	NativeHistoryAugmenter acpdriver.NativeHistoryAugmenter
 	// VersionProbe optionally gates admission on a minimum binary version.
 	VersionProbe VersionProbe
 }
@@ -140,5 +141,6 @@ func buildConfig(plugin Plugin, cfg Config, log *slog.Logger) acpdriver.Config {
 		ClientExtension:        cfg.ClientExtension,
 		ClientExtensionAliases: cfg.ClientExtensionAliases,
 		ValidateTurnSettings:   cfg.ValidateTurnSettings,
+		NativeHistoryAugmenter: cfg.NativeHistoryAugmenter,
 	}
 }

--- a/backend/internal/cli/agent_process.go
+++ b/backend/internal/cli/agent_process.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -27,6 +28,7 @@ func newAgentProcessCommand(ctx *commandContext) *cobra.Command {
 func newAgentProcessSuperviseCommand(ctx *commandContext) *cobra.Command {
 	var sessionID string
 	var launchID string
+	var terminalHistoryPath string
 	cmd := &cobra.Command{
 		Use:    "supervise --session <id> --launch <id> -- <command> [args...]",
 		Short:  "Supervise one managed agent process (internal)",
@@ -46,16 +48,24 @@ func newAgentProcessSuperviseCommand(ctx *commandContext) *cobra.Command {
 			if !sessionIDPattern.MatchString(launchID) {
 				return usageError{fmt.Errorf("invalid launch id")}
 			}
-			ctx.runSupervisedProcess(cmd.Context(), sessionID, launchID, args)
+			ctx.runSupervisedProcess(cmd.Context(), sessionID, launchID, terminalHistoryPath, args)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&sessionID, "session", "", "AO session id")
 	cmd.Flags().StringVar(&launchID, "launch", "", "AO process launch id")
+	cmd.Flags().StringVar(&terminalHistoryPath, "terminal-history", "", "render an AO-owned conversation snapshot before starting the agent")
 	return cmd
 }
 
-func (c *commandContext) runSupervisedProcess(ctx context.Context, sessionID, launchID string, argv []string) {
+func (c *commandContext) runSupervisedProcess(ctx context.Context, sessionID, launchID, terminalHistoryPath string, argv []string) {
+	if terminalHistoryPath != "" {
+		if err := renderTerminalHistory(c.deps.Out, terminalHistoryPath); err != nil {
+			_, _ = fmt.Fprintf(c.deps.Err, "ao: render terminal history: %v\n", err)
+			c.reportSupervisedExit(sessionID, launchID)
+			return
+		}
+	}
 	child := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec // argv is constructed by the selected agent adapter.
 	child.Stdin = c.deps.In
 	child.Stdout = c.deps.Out
@@ -76,6 +86,27 @@ func (c *commandContext) runSupervisedProcess(ctx context.Context, sessionID, la
 	signal.Stop(interrupts)
 
 	c.reportSupervisedExit(sessionID, launchID)
+}
+
+func renderTerminalHistory(out io.Writer, path string) error {
+	history, err := os.ReadFile(path) //nolint:gosec // internal path is created by Session Manager under AO_DATA_DIR.
+	if err != nil {
+		return err
+	}
+	for len(history) > 0 {
+		written, writeErr := out.Write(history)
+		if writeErr != nil {
+			return writeErr
+		}
+		if written <= 0 || written > len(history) {
+			return io.ErrShortWrite
+		}
+		history = history[written:]
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove rendered snapshot: %w", err)
+	}
+	return nil
 }
 
 func (c *commandContext) reportSupervisedExit(sessionID, launchID string) {

--- a/backend/internal/cli/agent_process_unix_test.go
+++ b/backend/internal/cli/agent_process_unix_test.go
@@ -4,10 +4,23 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type failingTerminalWriter struct{ written bool }
+
+func (w *failingTerminalWriter) Write(p []byte) (int, error) {
+	if !w.written {
+		w.written = true
+		return min(3, len(p)), nil
+	}
+	return 0, errors.New("terminal closed")
+}
 
 func TestAgentProcessSuperviseReportsExitAndPreservesOutput(t *testing.T) {
 	cfg := setConfigEnv(t)
@@ -31,6 +44,44 @@ func TestAgentProcessSuperviseReportsExitAndPreservesOutput(t *testing.T) {
 	want := setActivityAPIRequest{State: "exited", Event: "process-exited", LaunchID: "launch-3"}
 	if req != want {
 		t.Fatalf("exit report = %+v, want %+v", req, want)
+	}
+}
+
+func TestAgentProcessSupervisePrintsAndRemovesTerminalHistory(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	historyPath := filepath.Join(t.TempDir(), "history.txt")
+	if err := os.WriteFile(historyPath, []byte("Previous conversation\n\nYou\nhello\n\nCursor\nhi\n\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, errOut, err := executeCLI(t, Deps{
+		In:           strings.NewReader(""),
+		ProcessAlive: func(int) bool { return true },
+	}, "agent-process", "supervise", "--session", "ao-7", "--launch", "launch-3",
+		"--terminal-history", historyPath, "--", "sh", "-c", "printf cursor-started")
+	if err != nil {
+		t.Fatalf("supervise returned error: %v\nstderr=%s", err, errOut)
+	}
+	if want := "Previous conversation\n\nYou\nhello\n\nCursor\nhi\n\ncursor-started"; out != want {
+		t.Fatalf("stdout = %q, want %q", out, want)
+	}
+	if _, err := os.Stat(historyPath); !os.IsNotExist(err) {
+		t.Fatalf("terminal history file still exists after rendering: %v", err)
+	}
+}
+
+func TestRenderTerminalHistoryRetainsArtifactWhenTerminalWriteFails(t *testing.T) {
+	historyPath := filepath.Join(t.TempDir(), "history.txt")
+	if err := os.WriteFile(historyPath, []byte("previous conversation"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := renderTerminalHistory(&failingTerminalWriter{}, historyPath); err == nil {
+		t.Fatal("terminal write failure was ignored")
+	}
+	if _, err := os.Stat(historyPath); err != nil {
+		t.Fatalf("history artifact was removed before a complete terminal write: %v", err)
 	}
 }
 

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -15,7 +15,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/activitydispatch"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 // sessionIDPattern bounds the AO_SESSION_ID we will place in a request path to
@@ -253,6 +255,10 @@ type sessionStartHookOutput struct {
 	} `json:"hookSpecificOutput"`
 }
 
+type cursorPermissionHookOutput struct {
+	Permission string `json:"permission"`
+}
+
 // newHooksCommand builds the hidden `ao hooks <agent> <event>` command that
 // agent CLIs invoke from their workspace-local hook config. It reads the native
 // hook payload from stdin and the AO session id from AO_SESSION_ID, derives an
@@ -303,6 +309,9 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 	if shouldEmitSessionStartContext(agent, event) {
 		c.emitSessionStartContext(agent, event, sessionID)
 	}
+	if isCursorPermissionHook(agent, event) {
+		return c.runCursorPermissionHook(ctx, agent, event, sessionID, payload)
+	}
 
 	state, hasActivity := activitydispatch.Derive(agent, event, payload)
 	agentSessionID := ""
@@ -346,6 +355,46 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		// Surface the failure for diagnosis, but exit 0: a failed activity
 		// report must not disrupt the agent.
 		c.reportHookFailure(agent, event, sessionID, err)
+	}
+	return nil
+}
+
+func isCursorPermissionHook(agent, event string) bool {
+	if domain.AgentHarness(agent) != domain.HarnessCursor {
+		return false
+	}
+	switch event {
+	case "before-shell-execution", "before-mcp-execution":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *commandContext) runCursorPermissionHook(ctx context.Context, agent, event, sessionID string, payload []byte) error {
+	mode := ports.PermissionMode(strings.TrimSpace(os.Getenv(cursor.EnvPermissionMode)))
+	decision := cursor.EvaluatePermission(mode, event, payload)
+
+	launchID := validLaunchID(os.Getenv("AO_RUNTIME_LAUNCH_ID"))
+	if launchID == "" {
+		launchID = validLaunchID(hookLaunchID(payload))
+	}
+
+	path := "sessions/" + url.PathEscape(sessionID) + "/activity"
+	req := setActivityAPIRequest{
+		State:          string(decision.State),
+		Event:          event,
+		ToolName:       cursor.HookToolName(event, payload),
+		AgentSessionID: hookAgentSessionID(payload),
+		LaunchID:       launchID,
+	}
+	if err := c.postJSON(ctx, path, req, nil); err != nil {
+		c.reportHookFailure(agent, event, sessionID, err)
+	}
+
+	out := cursorPermissionHookOutput{Permission: decision.Permission}
+	if err := json.NewEncoder(c.deps.Out).Encode(out); err != nil {
+		c.reportHookFailure(agent, event, sessionID, fmt.Errorf("write permission response: %w", err))
 	}
 	return nil
 }

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -1133,3 +1133,73 @@ func TestHooks_DaemonErrorIsSwallowed(t *testing.T) {
 		t.Errorf("expected the failure surfaced to stderr, got %q", errOut)
 	}
 }
+
+func TestHooks_CursorBeforeShellDefaultModeReportsWaitingInput(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	t.Setenv("AO_PERMISSION_MODE", "default")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	stdout, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"command":"git status"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "cursor", "before-shell-execution")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := capturedState(t, capture); got != "waiting_input" {
+		t.Fatalf("state = %q, want waiting_input", got)
+	}
+	var out cursorPermissionHookOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &out); err != nil {
+		t.Fatalf("decode stdout: %v\nstdout=%q", err, stdout)
+	}
+	if out.Permission != "ask" {
+		t.Fatalf("permission = %q, want ask", out.Permission)
+	}
+}
+
+func TestHooks_CursorBeforeShellAutoModeReportsActive(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	t.Setenv("AO_PERMISSION_MODE", "auto")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	stdout, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"command":"git status"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "cursor", "before-shell-execution")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := capturedState(t, capture); got != "active" {
+		t.Fatalf("state = %q, want active", got)
+	}
+	var out cursorPermissionHookOutput
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &out); err != nil {
+		t.Fatalf("decode stdout: %v\nstdout=%q", err, stdout)
+	}
+	if out.Permission != "allow" {
+		t.Fatalf("permission = %q, want allow", out.Permission)
+	}
+}
+
+func TestHooks_CursorAfterShellExecutionReportsActive(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"command":"git status","output":"ok"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "cursor", "after-shell-execution")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := capturedState(t, capture); got != "active" {
+		t.Fatalf("state = %q, want active", got)
+	}
+}

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -454,10 +454,15 @@ var _ interface {
 	ArmChatHandoff(context.Context, domain.SessionID, domain.SessionInterfaceTransitionPolicy) error
 	PrepareChatHandoff(context.Context, domain.SessionID, domain.SessionInterfaceTransitionPolicy) error
 	AbortChatHandoff(domain.SessionID)
+	InterfaceHandoffMessages(context.Context, domain.SessionID) ([]domain.ConversationMessage, error)
 } = chatLauncher{}
 
 func (c chatLauncher) SupportsChat(harness domain.AgentHarness) bool {
 	return c.svc.SupportsChat(harness)
+}
+
+func (c chatLauncher) InterfaceHandoffMessages(ctx context.Context, id domain.SessionID) ([]domain.ConversationMessage, error) {
+	return c.svc.InterfaceHandoffMessages(ctx, id)
 }
 
 func (c chatLauncher) PreflightChat(

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -242,6 +242,9 @@ type ChatResumeConfig struct {
 	SystemPrompt          string
 	AdditionalDirectories []string
 	MCPServers            []ChatMCPServerConfig
+	// RequireNativeHistory makes a missing typed provider replay fatal. Interface
+	// transitions set this for TUI -> Chat handoffs that must import history.
+	RequireNativeHistory bool
 }
 
 // ChatMCPServerConfig is the provider-neutral session-setup shape for a tool

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -354,6 +354,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			SystemPrompt:           cfg.SystemPrompt,
 			AdditionalDirectories:  cfg.AdditionalDirectories,
 			MCPServers:             cfg.MCPServers,
+			RequireNativeHistory:   cfg.RequireNativeHistory,
 		})
 	} else {
 		conv, err = driver.Start(ctx, ports.ChatStartConfig{
@@ -604,6 +605,27 @@ func (s *Service) PrepareChatHandoff(
 		return err
 	}
 	return controller.BeginHandoff(ctx, policy)
+}
+
+// InterfaceHandoffMessages returns the durable user/assistant transcript that
+// AO may render into a target terminal's scrollback. It is display-only: the
+// messages are never submitted to the provider as a continuation prompt.
+func (s *Service) InterfaceHandoffMessages(
+	ctx context.Context,
+	id domain.SessionID,
+) ([]domain.ConversationMessage, error) {
+	conversation, err := s.store.ConversationForSession(ctx, id)
+	if errors.Is(err, domain.ErrNoConversation) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("conversation for %s: %w", id, err)
+	}
+	rows, err := s.reader.LoadConversationSnapshot(ctx, conversation.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load conversation %s: %w", conversation.ID, err)
+	}
+	return rows.Messages, nil
 }
 
 // AbortChatHandoff reopens the existing controller when the user cancels before

--- a/backend/internal/session_manager/agent_switching.go
+++ b/backend/internal/session_manager/agent_switching.go
@@ -1148,6 +1148,7 @@ func (m *Manager) prepareTargetActivation(ctx context.Context, store ports.Agent
 		config.Model = model
 	}
 	env := m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env)
+	pinRuntimePermissionEnv(env, config.Permissions)
 	m.augmentAgentRuntimeEnv(agent, env)
 	configDir, err := nativeConfigDir(ctx, agent, env)
 	if err != nil {

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -2,10 +2,14 @@ package sessionmanager
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -51,6 +55,10 @@ type chatHandoffLauncher interface {
 	ArmChatHandoff(context.Context, domain.SessionID, domain.SessionInterfaceTransitionPolicy) error
 	PrepareChatHandoff(context.Context, domain.SessionID, domain.SessionInterfaceTransitionPolicy) error
 	AbortChatHandoff(domain.SessionID)
+}
+
+type chatHandoffMessageReader interface {
+	InterfaceHandoffMessages(context.Context, domain.SessionID) ([]domain.ConversationMessage, error)
 }
 
 type runtimeInterrupter interface {
@@ -162,6 +170,10 @@ func (m *Manager) StartInterfaceTransition(
 	if err != nil {
 		return domain.SessionInterfaceTransition{}, err
 	}
+	previous, previousFound, err := store.GetLatestSessionInterfaceTransition(ctx, id)
+	if err != nil {
+		return domain.SessionInterfaceTransition{}, err
+	}
 	now := m.clock()
 	transition, created, err := store.CreateSessionInterfaceTransition(ctx, domain.SessionInterfaceTransition{
 		ID: m.newLaunchID(), SessionID: id, SourceMode: source, TargetMode: target,
@@ -173,6 +185,9 @@ func (m *Manager) StartInterfaceTransition(
 	}
 	if !created {
 		return transition, ErrInterfaceTransitionInProgress
+	}
+	if previousFound {
+		_ = os.Remove(m.terminalHistoryPath(previous.ID))
 	}
 	if source == domain.SessionModeChat {
 		handoff, ok := m.chat.(chatHandoffLauncher)
@@ -314,8 +329,14 @@ func (m *Manager) runInterfaceTransition(
 	sourcePrepared := transition.SourceMode == domain.SessionModeChat
 	sourceStopped := false
 	modeChanged := false
+	var terminalHistory []byte
+	terminalHistoryPath := ""
 	var sourceRuntimeHandle ports.RuntimeHandle
 	fail := func(code string, cause error) {
+		if terminalHistoryPath != "" && !sourceStopped {
+			_ = os.Remove(terminalHistoryPath)
+			terminalHistoryPath = ""
+		}
 		if sourcePrepared && !sourceStopped {
 			m.abortSourceHandoff(transition)
 		}
@@ -325,7 +346,7 @@ func (m *Manager) runInterfaceTransition(
 			return
 		}
 		if sourceStopped {
-			m.rollbackInterfaceTransition(transition, sourceRuntimeHandle, modeChanged, code, cause)
+			m.rollbackInterfaceTransition(transition, sourceRuntimeHandle, modeChanged, terminalHistoryPath, code, cause)
 			return
 		}
 		_ = m.finishInterfaceTransition(transition.ID, domain.SessionInterfaceTransitionFailed, code, cause.Error())
@@ -378,6 +399,21 @@ func (m *Manager) runInterfaceTransition(
 		return
 	}
 	sourcePrepared = true
+	if transition.SourceMode == domain.SessionModeChat &&
+		transition.TargetMode == domain.SessionModeTUI && rec.Harness == domain.HarnessCursor {
+		terminalHistory, err = m.cursorTerminalHistory(ctx, rec.ID)
+		if err != nil {
+			fail("SOURCE_HISTORY_UNAVAILABLE", err)
+			return
+		}
+		if len(terminalHistory) > 0 {
+			terminalHistoryPath, err = m.writeTerminalHistory(transition.ID, terminalHistory)
+			if err != nil {
+				fail("SOURCE_HISTORY_UNAVAILABLE", err)
+				return
+			}
+		}
+	}
 	// A promptless TUI may not create a provider conversation until its first
 	// submitted turn. When the transition was admitted from positive initial-
 	// composer proof, resolve again after input is frozen and drain is complete.
@@ -425,6 +461,10 @@ func (m *Manager) runInterfaceTransition(
 	// be proven stopped, do not launch either controller: recovery is safer than
 	// two writers racing on one native conversation.
 	if err := m.stopSourceControllerConclusive(rec); err != nil {
+		if terminalHistoryPath != "" {
+			_ = os.Remove(terminalHistoryPath)
+			terminalHistoryPath = ""
+		}
 		detail := "AO could not prove that the old controller stopped. Restart AO to reconcile this session before sending more work: " + err.Error()
 		_ = m.finishInterfaceTransition(transition.ID, domain.SessionInterfaceTransitionRecovery,
 			"SOURCE_STOP_UNCERTAIN", detail)
@@ -453,7 +493,7 @@ func (m *Manager) runInterfaceTransition(
 		fail("TRANSITION_STATE_FAILED", err)
 		return
 	}
-	if err := m.startTransitionTarget(ctx, rec.ID, transition.NativeConversationID == "", true); err != nil {
+	if err := m.startTransitionTarget(ctx, rec.ID, transition.NativeConversationID == "", true, terminalHistoryPath); err != nil {
 		code := "TARGET_RESUME_FAILED"
 		switch {
 		case errors.Is(err, ports.ErrChatHistoryUnavailable):
@@ -970,7 +1010,7 @@ func (m *Manager) stopSourceControllerConclusive(rec domain.SessionRecord) error
 	return fmt.Errorf("could not prove the source controller stopped after retry: %w", errors.Join(failures...))
 }
 
-func (m *Manager) startTransitionTarget(ctx context.Context, id domain.SessionID, fresh, requireNativeHistory bool) error {
+func (m *Manager) startTransitionTarget(ctx context.Context, id domain.SessionID, fresh, requireNativeHistory bool, terminalHistoryPath string) error {
 	ctx, cancel := context.WithTimeout(ctx, interfaceTransitionStepLimit)
 	defer cancel()
 	rec, ok, err := m.store.GetSession(ctx, id)
@@ -990,7 +1030,7 @@ func (m *Manager) startTransitionTarget(ctx context.Context, id domain.SessionID
 	// daemon restore deliberately use the normal context-resume policy.
 	_, err = m.relaunchSessionWithPolicy(
 		ctx, "switch interface", rec, project, ws, nil,
-		fresh, requireNativeHistory && !fresh,
+		fresh, requireNativeHistory && !fresh, terminalHistoryPath,
 	)
 	return err
 }
@@ -999,11 +1039,16 @@ func (m *Manager) rollbackInterfaceTransition(
 	transition domain.SessionInterfaceTransition,
 	sourceRuntimeHandle ports.RuntimeHandle,
 	modeChanged bool,
+	terminalHistoryPath string,
 	code string,
 	cause error,
 ) {
 	ctx, cancel := context.WithTimeout(context.Background(), interfaceTransitionStepLimit)
 	defer cancel()
+	if !modeChanged && transition.SourceMode == domain.SessionModeChat && terminalHistoryPath != "" {
+		_ = os.Remove(terminalHistoryPath)
+		terminalHistoryPath = ""
+	}
 	if modeChanged {
 		// A target may have partially started. Stop whatever its committed mode can
 		// identify before restoring the old writer.
@@ -1027,6 +1072,10 @@ func (m *Manager) rollbackInterfaceTransition(
 				"RECOVERY_REQUIRED", detail)
 			return
 		}
+		if transition.SourceMode == domain.SessionModeChat && terminalHistoryPath != "" {
+			_ = os.Remove(terminalHistoryPath)
+			terminalHistoryPath = ""
+		}
 	}
 	// A conclusive liveness probe can prove the source process exited even when
 	// its first teardown timed out. Clear any stale runtime registration using
@@ -1039,7 +1088,7 @@ func (m *Manager) rollbackInterfaceTransition(
 			return
 		}
 	}
-	if err := m.startTransitionTarget(ctx, transition.SessionID, transition.NativeConversationID == "", false); err != nil {
+	if err := m.startTransitionTarget(ctx, transition.SessionID, transition.NativeConversationID == "", false, ""); err != nil {
 		_ = m.finishInterfaceTransition(transition.ID, domain.SessionInterfaceTransitionRecovery,
 			"RECOVERY_REQUIRED", cause.Error()+"; source restore: "+err.Error())
 		return
@@ -1346,6 +1395,18 @@ func (m *Manager) recoverInterruptedInterfaceTransitions(
 	for i := range active {
 		transition := &active[i]
 		detail := "The daemon restarted during the interface switch; AO recovered the session from its last committed mode."
+		if transition.SourceMode == domain.SessionModeChat && transition.TargetMode == domain.SessionModeTUI {
+			rec, found, readErr := m.store.GetSession(ctx, transition.SessionID)
+			if readErr != nil {
+				return nil, readErr
+			}
+			// This snapshot is needed only after the controller epoch committed to
+			// TUI. An earlier crash recovers in Chat and must erase the plaintext
+			// artifact instead of leaving it behind indefinitely.
+			if !found || rec.IsTerminated || domain.NormalizeSessionMode(rec.Mode) != transition.TargetMode {
+				_ = os.Remove(m.terminalHistoryPath(transition.ID))
+			}
+		}
 		if transition.SourceMode == domain.SessionModeTUI && transition.TargetMode == domain.SessionModeChat {
 			rec, found, readErr := m.store.GetSession(ctx, transition.SessionID)
 			if readErr != nil {
@@ -1394,7 +1455,248 @@ func (m *Manager) recoverInterruptedInterfaceTransitions(
 		transition.UpdatedAt = m.clock()
 		transition.CompletedAt = transition.UpdatedAt
 	}
+	if err := m.sweepTerminalHistoryArtifacts(ctx); err != nil {
+		return nil, err
+	}
 	return active, nil
+}
+
+const interfaceTerminalHistoryMaxBytes = 256 << 10
+
+func (m *Manager) cursorTerminalHistory(ctx context.Context, id domain.SessionID) ([]byte, error) {
+	reader, ok := m.chat.(chatHandoffMessageReader)
+	if !ok {
+		return nil, errors.New("Cursor Chat history reader is unavailable")
+	}
+	messages, err := reader.InterfaceHandoffMessages(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("read Cursor Chat history: %w", err)
+	}
+	blocks := make([]string, 0, len(messages))
+	for _, message := range messages {
+		text := cleanCursorTerminalHistoryText(message.Text)
+		if text == "" {
+			continue
+		}
+		switch message.Role {
+		case domain.MessageRoleUser:
+			if message.Origin != "" && message.Origin != domain.MessageOriginHuman {
+				continue
+			}
+			blocks = append(blocks, boundedTerminalHistoryBlock("You", text))
+		case domain.MessageRoleAssistant:
+			if message.Origin != "" && message.Origin != domain.MessageOriginProvider {
+				continue
+			}
+			blocks = append(blocks, boundedTerminalHistoryBlock("Cursor", text))
+		default:
+			continue
+		}
+	}
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	const fullHeader = "Previous conversation\n\n"
+	const truncatedHeader = "Previous conversation (earlier messages omitted)\n\n"
+	used := len(truncatedHeader)
+	first := len(blocks)
+	for first > 0 {
+		next := len(blocks[first-1])
+		if used+next > interfaceTerminalHistoryMaxBytes {
+			break
+		}
+		used += next
+		first--
+	}
+	header := fullHeader
+	if first > 0 {
+		header = truncatedHeader
+	}
+	var body strings.Builder
+	body.Grow(len(header) + used)
+	body.WriteString(header)
+	for _, block := range blocks[first:] {
+		body.WriteString(block)
+	}
+	return []byte(body.String()), nil
+}
+
+func boundedTerminalHistoryBlock(label, text string) string {
+	const marker = "\n[... message truncated for terminal display ...]"
+	prefix := label + "\n"
+	suffix := "\n\n"
+	budget := interfaceTerminalHistoryMaxBytes - len("Previous conversation (earlier messages omitted)\n\n") - len(prefix) - len(marker) - len(suffix)
+	if len(text) > budget {
+		text = truncateUTF8Prefix(text, budget) + marker
+	}
+	return prefix + text + suffix
+}
+
+func truncateUTF8Prefix(text string, byteLimit int) string {
+	if len(text) <= byteLimit {
+		return text
+	}
+	used := 0
+	for index, r := range text {
+		size := len(string(r))
+		if used+size > byteLimit {
+			return text[:index]
+		}
+		used += size
+	}
+	return text
+}
+
+func cleanCursorTerminalHistoryText(text string) string {
+	text = ansiOSC.ReplaceAllString(text, "")
+	text = ansiCSI.ReplaceAllString(text, "")
+	text = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "[REDACTED]" {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+func (m *Manager) writeTerminalHistory(transitionID string, history []byte) (string, error) {
+	dir := filepath.Join(m.dataDir, "interface-handoffs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create terminal history directory: %w", err)
+	}
+	path := m.terminalHistoryPath(transitionID)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("write terminal history: %w", err)
+	}
+	if _, err := file.Write(history); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", fmt.Errorf("write terminal history: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("close terminal history: %w", err)
+	}
+	return path, nil
+}
+
+func (m *Manager) terminalHistoryPath(transitionID string) string {
+	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(transitionID)))
+	return filepath.Join(m.dataDir, "interface-handoffs", digest+".txt")
+}
+
+func (m *Manager) cleanupTerminalHistoryForSession(ctx context.Context, id domain.SessionID) {
+	store, ok := m.store.(interfaceTransitionStore)
+	if !ok {
+		return
+	}
+	transition, found, err := store.GetLatestSessionInterfaceTransition(ctx, id)
+	if err == nil && found {
+		_ = os.Remove(m.terminalHistoryPath(transition.ID))
+	}
+}
+
+func (m *Manager) recoveryTerminalHistoryPath(ctx context.Context, rec domain.SessionRecord) (string, error) {
+	if rec.Harness != domain.HarnessCursor || domain.NormalizeSessionMode(rec.Mode) != domain.SessionModeTUI {
+		return "", nil
+	}
+	store, ok := m.store.(interfaceTransitionStore)
+	if !ok {
+		return "", nil
+	}
+	transition, found, err := store.GetLatestSessionInterfaceTransition(ctx, rec.ID)
+	if err != nil || !found {
+		return "", err
+	}
+	if transition.SourceMode != domain.SessionModeChat || transition.TargetMode != domain.SessionModeTUI {
+		return "", nil
+	}
+	path := m.terminalHistoryPath(transition.ID)
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("terminal history recovery path is not a regular file")
+	}
+	return path, nil
+}
+
+func (m *Manager) sweepTerminalHistoryArtifacts(ctx context.Context) error {
+	dir := filepath.Join(m.dataDir, "interface-handoffs")
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read terminal history directory: %w", err)
+	}
+	keep := make(map[string]bool)
+	sessions, err := m.store.ListAllSessions(ctx)
+	if err != nil {
+		return err
+	}
+	store, ok := m.store.(interfaceTransitionStore)
+	if !ok {
+		return nil
+	}
+	for _, rec := range sessions {
+		if rec.Harness != domain.HarnessCursor || domain.NormalizeSessionMode(rec.Mode) != domain.SessionModeTUI {
+			continue
+		}
+		if rec.IsTerminated {
+			rows, rowsErr := m.store.ListSessionWorktrees(ctx, rec.ID)
+			if rowsErr != nil {
+				return rowsErr
+			}
+			if len(restorableWorktreeRows(rows)) == 0 {
+				continue
+			}
+		}
+		transition, found, readErr := store.GetLatestSessionInterfaceTransition(ctx, rec.ID)
+		if readErr != nil {
+			return readErr
+		}
+		if found && transition.SourceMode == domain.SessionModeChat && transition.TargetMode == domain.SessionModeTUI {
+			keep[filepath.Base(m.terminalHistoryPath(transition.ID))] = true
+		}
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.Type().IsRegular() && terminalHistoryFilename(name) && !keep[name] {
+			if err := os.Remove(filepath.Join(dir, name)); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove stale terminal history %s: %w", name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func terminalHistoryFilename(name string) bool {
+	if len(name) != 68 || !strings.HasSuffix(name, ".txt") {
+		return false
+	}
+	for _, r := range strings.TrimSuffix(name, ".txt") {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
 }
 
 func oppositeSessionMode(mode domain.SessionMode) domain.SessionMode {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -198,6 +199,8 @@ const (
 	EnvSupervisedProcess = "AO_SUPERVISED_PROCESS"
 	// EnvDataDir tells a spawned agent's AO hook commands where the store lives.
 	EnvDataDir = "AO_DATA_DIR"
+	// EnvPermissionMode tells hook commands which AO approval policy applies.
+	EnvPermissionMode = "AO_PERMISSION_MODE"
 	// EnvRunFile tells spawned AO hook commands which live daemon owns the
 	// session. AO_DATA_DIR is durable storage, not daemon discovery; custom and
 	// isolated daemons therefore need this coordinate explicitly.
@@ -902,6 +905,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, 0, 0, wrapSpawnStage(id, ErrSpawnBrowser, err)
 	}
 	m.augmentAgentRuntimeEnv(agent, env)
+	pinRuntimePermissionEnv(env, adapterConfig.Permissions)
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path, systemPrompt, systemPromptFile, adapterConfig, env); err != nil {
 		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, false)
 		return domain.SessionRecord{}, 0, 0, wrapSpawnStage(id, ErrSpawnPrepare, err)
@@ -1511,6 +1515,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	if !ok {
 		return false, nil // already gone: benign race
 	}
+	m.cleanupTerminalHistoryForSession(context.WithoutCancel(ctx), id)
 	m.stopPreviewBestEffort(ctx, id)
 	m.destroyBrowserBestEffort(ctx, id)
 	handle := runtimeHandle(rec.Metadata)
@@ -1931,10 +1936,14 @@ func (m *Manager) ResumeAgentWithMode(ctx context.Context, id domain.SessionID) 
 }
 
 func (m *Manager) relaunchSession(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle) (RestoreResult, error) {
-	return m.relaunchSessionWithPolicy(ctx, operation, rec, project, ws, restartHandle, false, false)
+	terminalHistoryPath, err := m.recoveryTerminalHistoryPath(ctx, rec)
+	if err != nil {
+		return RestoreResult{}, fmt.Errorf("%s %s: terminal history recovery: %w", operation, rec.ID, err)
+	}
+	return m.relaunchSessionWithPolicy(ctx, operation, rec, project, ws, restartHandle, false, false, terminalHistoryPath)
 }
 
-func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle, forceFresh, requireNativeHistory bool) (RestoreResult, error) {
+func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle, forceFresh, requireNativeHistory bool, terminalHistoryPath string) (RestoreResult, error) {
 	// Relaunch dispatches from the currently committed persisted mode, never from
 	// a caller hint. The interface-transition coordinator changes that fact only
 	// after stopping the old controller, then reuses this ordinary restore path.
@@ -1979,6 +1988,7 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 		return RestoreResult{}, fmt.Errorf("%s %s: persist browser capability: %w", operation, rec.ID, err)
 	}
 	m.augmentAgentRuntimeEnv(agent, env)
+	pinRuntimePermissionEnv(env, agentConfig.Permissions)
 	if err := m.prepareWorkspace(ctx, agent, rec.ID, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
 		return RestoreResult{}, fmt.Errorf("%s %s: %w", operation, rec.ID, err)
 	}
@@ -2001,7 +2011,15 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 		return RestoreResult{}, fmt.Errorf("%s %s: %w", operation, rec.ID, err)
 	}
 	m.augmentRuntimePATHForLaunchBinary(ctx, env, argv)
-	argv, launchID, err := m.superviseAgentProcess(agent, rec.ID, env, argv)
+	var launchID string
+	if terminalHistoryPath == "" {
+		argv, launchID, err = m.superviseAgentProcess(agent, rec.ID, env, argv)
+	} else {
+		argv, launchID, err = m.superviseAgentProcessMode(agent, rec.ID, env, argv, true)
+		if err == nil {
+			argv, err = addTerminalHistoryToSupervisedArgv(argv, terminalHistoryPath)
+		}
+	}
 	if err != nil {
 		m.cleanupSystemPromptDir(rec.ID)
 		return RestoreResult{}, fmt.Errorf("%s %s: supervisor: %w", operation, rec.ID, err)
@@ -2076,6 +2094,18 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 		return RestoreResult{}, err
 	}
 	return RestoreResult{Session: updated, Mode: mode}, nil
+}
+
+func addTerminalHistoryToSupervisedArgv(argv []string, historyPath string) ([]string, error) {
+	separator := slices.Index(argv, "--")
+	if separator < 0 {
+		return nil, errors.New("supervised launch omitted command separator")
+	}
+	withHistory := make([]string, 0, len(argv)+2)
+	withHistory = append(withHistory, argv[:separator]...)
+	withHistory = append(withHistory, "--terminal-history", historyPath)
+	withHistory = append(withHistory, argv[separator:]...)
+	return withHistory, nil
 }
 
 func (m *Manager) restartRuntime(ctx context.Context, handle ports.RuntimeHandle, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
@@ -3775,6 +3805,16 @@ func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issu
 	}
 	env["PATH"] = path
 	return env
+}
+
+// pinRuntimePermissionEnv exposes the session's AO approval policy to hook
+// commands so adapters like Cursor can decide whether a tool attempt needs
+// user approval before returning a native permission response.
+func pinRuntimePermissionEnv(env map[string]string, mode domain.PermissionMode) {
+	if env == nil {
+		return
+	}
+	env[EnvPermissionMode] = string(ports.NormalizePermissionMode(mode))
 }
 
 func (m *Manager) launchRuntimeEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, projectEnv map[string]string) (map[string]string, string, error) {

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -23,10 +23,12 @@ vi.mock("./CreateProjectAgentSheet", () => ({
 		value,
 		onChange,
 		triggerClassName,
+		disabled,
 	}: {
 		value: string;
 		onChange: (value: string) => void;
 		triggerClassName?: string;
+		disabled?: boolean;
 	}) => {
 		h.agentValues.push(value);
 		return (
@@ -36,6 +38,7 @@ vi.mock("./CreateProjectAgentSheet", () => ({
 				className={triggerClassName}
 				data-testid="agent-field"
 				data-value={value}
+				disabled={disabled}
 				onClick={() => onChange(value === "codex" ? "claude-code" : "codex")}
 			/>
 		);
@@ -183,6 +186,48 @@ describe("TaskComposer", () => {
 		await act(async () => resolveCreate({ data: { workerId: "sess-1" } }));
 		await waitFor(() => expect(onCreated).toHaveBeenCalledWith("sess-1"));
 		await waitFor(() => expect(onSubmittingChange).toHaveBeenLastCalledWith(false));
+	});
+
+	it("locks agent and model selection while task creation is in flight, then unlocks them after failure", async () => {
+		h.get.mockImplementation(async (path: string) => {
+			if (path.includes("/models")) {
+				return {
+					data: {
+						agent: "codex",
+						selectionMode: "text",
+						models: [],
+						allowCustom: true,
+						refreshRecommended: false,
+					},
+				};
+			}
+			return { data: { status: "ok", project: { agent: "codex", config: {} } } };
+		});
+		let rejectCreate!: (error: Error) => void;
+		h.post.mockReturnValueOnce(new Promise((_resolve, reject) => (rejectCreate = reject)));
+
+		render(
+			<Wrap>
+				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+			</Wrap>,
+		);
+
+		const agent = await screen.findByTestId("agent-field");
+		await waitFor(() => expect(agent).toHaveAttribute("data-value", "codex"));
+		const model = screen.getByRole("textbox", { name: "Model" });
+		expect(agent).toBeEnabled();
+		expect(model).toBeEnabled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Start task" }));
+
+		await waitFor(() => expect(h.post).toHaveBeenCalledOnce());
+		expect(agent).toBeDisabled();
+		expect(model).toBeDisabled();
+
+		await act(async () => rejectCreate(new Error("creation failed")));
+		await screen.findByText("creation failed");
+		expect(agent).toBeEnabled();
+		expect(model).toBeEnabled();
 	});
 
 	it("attaches a selected file and sends it in the delegate body", async () => {

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -215,19 +215,23 @@ describe("TaskComposer", () => {
 		const agent = await screen.findByTestId("agent-field");
 		await waitFor(() => expect(agent).toHaveAttribute("data-value", "codex"));
 		const model = screen.getByRole("textbox", { name: "Model" });
+		const prompt = task();
 		expect(agent).toBeEnabled();
 		expect(model).toBeEnabled();
+		expect(prompt).toBeEnabled();
 
 		fireEvent.click(screen.getByRole("button", { name: "Start task" }));
 
 		await waitFor(() => expect(h.post).toHaveBeenCalledOnce());
 		expect(agent).toBeDisabled();
 		expect(model).toBeDisabled();
+		expect(prompt).toBeDisabled();
 
 		await act(async () => rejectCreate(new Error("creation failed")));
 		await screen.findByText("creation failed");
 		expect(agent).toBeEnabled();
 		expect(model).toBeEnabled();
+		expect(prompt).toBeEnabled();
 	});
 
 	it("attaches a selected file and sends it in the delegate body", async () => {

--- a/frontend/src/renderer/components/TaskComposer.tsx
+++ b/frontend/src/renderer/components/TaskComposer.tsx
@@ -324,7 +324,7 @@ export function TaskComposer({
 				authorized: agentCatalog?.authorized,
 				installed: agentCatalog?.installed,
 				supported: agentCatalog?.supported,
-				disabled: agentsQuery.isFetching && agentCatalog === undefined,
+				disabled: isSubmitting || (agentsQuery.isFetching && agentCatalog === undefined),
 				onChange: (value) => {
 					setAgent(value);
 					setAgentTouched(true);
@@ -337,6 +337,7 @@ export function TaskComposer({
 				agentId: selectedAgent,
 				agentLabel: selectedAgentLabel,
 				projectId: projectId ?? "",
+				disabled: isSubmitting,
 				value: model,
 				mode,
 				catalog: modelCatalog,
@@ -394,6 +395,7 @@ function TaskModelPicker({
 	agentId,
 	agentLabel,
 	catalog,
+	disabled,
 	fetching,
 	loading,
 	value,
@@ -432,6 +434,7 @@ function TaskModelPicker({
 		return (
 			<SettingsOptionMenu
 				aria-label={t("newTask.model")}
+				disabled={disabled}
 				value={mode || "__default__"}
 				options={options}
 				triggerClassName="composer-chip composer-toolbar-option w-full justify-between"
@@ -469,6 +472,7 @@ function TaskModelPicker({
 				value={value}
 				models={displayModels}
 				allowCustom={catalog.allowCustom}
+				disabled={disabled}
 				emptyLabel={noOverrideLabel}
 				onChange={selectCatalogModel}
 				onCustom={selectCustomModel}
@@ -499,7 +503,7 @@ function TaskModelPicker({
 					!hasCatalog && "rounded-r-md!",
 				)}
 				value={value}
-				disabled={agentId === ""}
+				disabled={disabled || agentId === ""}
 				onChange={(event) => onModelChange(event.target.value)}
 				placeholder={fetching ? t("settings.models.loading") : noOverrideLabel}
 			/>
@@ -510,6 +514,7 @@ function TaskModelPicker({
 					value={value}
 					models={displayModels}
 					allowCustom={catalog.allowCustom}
+					disabled={disabled}
 					emptyLabel={noOverrideLabel}
 					onChange={selectCatalogModel}
 					onCustom={selectCustomModel}

--- a/packages/product-ui/src/TaskComposerView.test.tsx
+++ b/packages/product-ui/src/TaskComposerView.test.tsx
@@ -32,6 +32,7 @@ function viewProps(overrides: Partial<TaskComposerViewProps> = {}): TaskComposer
 			agentId: "codex",
 			agentLabel: "Codex",
 			projectId: "project-1",
+			disabled: false,
 			value: "gpt-5",
 			mode: "",
 			catalog: {

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -50,6 +50,7 @@ export type TaskComposerModelControl = {
 	agentId: string;
 	agentLabel: string;
 	catalog?: TaskComposerModelCatalog;
+	disabled: boolean;
 	fetching: boolean;
 	id: string;
 	loading: boolean;

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -180,7 +180,8 @@ export function TaskComposerView({
 				ref={textareaRef}
 				id={promptId}
 				autoFocus={autoFocusPrompt}
-				className="min-h-[calc(2lh+1.75rem)] max-h-[calc(8lh+1.75rem)] w-full resize-none overflow-y-auto bg-transparent px-4 pb-3 pt-4 text-md leading-relaxed text-foreground outline-none placeholder:text-passive"
+				className="min-h-[calc(2lh+1.75rem)] max-h-[calc(8lh+1.75rem)] w-full resize-none overflow-y-auto bg-transparent px-4 pb-3 pt-4 text-md leading-relaxed text-foreground outline-none placeholder:text-passive disabled:cursor-not-allowed disabled:opacity-50"
+				disabled={submission.isSubmitting}
 				placeholder={labels.taskPlaceholder}
 				value={prompt}
 				onChange={(event) => onPromptChange(event.target.value)}


### PR DESCRIPTION
## Summary

- preserve Cursor's provider-native conversation ID across Chat UI and Terminal UI
- resume Chat → TUI with Cursor's exact single-argument form `agent --resume=<session-id>` (using AO's resolved Cursor executable); do not replay the transcript to Cursor or trigger an extra model turn
- render AO's durable user/assistant transcript directly into terminal scrollback before Cursor starts, because Cursor does not hydrate ACP-created Chat history into its local TUI store
- exclude system prompts, tool output, attachments, standalone redaction placeholders, ANSI escapes, and unsafe control characters from that display-only transcript
- consume the bounded mode-0600 transcript artifact once, with crash recovery and cleanup for cancellation, rollback, shutdown restore, termination, and superseding transitions
- restore TUI → Chat through ACP `session/load`, reconciling Cursor's native transcript so Chat and terminal turns remain visible once and in chronological order
- wire the production daemon's Chat adapter to the durable transcript reader (the cause of the reported “Cursor Chat history reader is unavailable” failure)

## Verification

- `go test ./internal/daemon ./internal/cli ./internal/service/chat ./internal/session_manager ./internal/adapters/chatdriver/cursoracp`
- `go build ./...`
- `git diff --check`
- regression test verified red before the daemon adapter forwarding method and green after it

## Local desktop validation

Launched the PR checkout as the real Electron desktop app in isolated mode using `~/.ao/dev`. Verified the rebuilt daemon at `127.0.0.1:3002`, renderer at `localhost:5173`, and successful project API response. The pre-fix test session was terminated during the required backend restart, so a new Cursor Chat session is required for the next manual handoff attempt.
