### PR TITLE
fix(mobile): drop the computed import() that breaks every Metro bundle

### DIFF
--- a/packages/mobile/lib/sentry.test.ts
+++ b/packages/mobile/lib/sentry.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { captureMobileApiError, captureMobileException, initMobileSentry } from "./sentry";
+
+// No SDK installed yet: init must resolve and captures must never throw.
+describe("sentry — SDK not installed", () => {
+	it("captures are no-ops before init", () => {
+		expect(() => captureMobileException(new Error("boom"), { category: "native_crash" })).not.toThrow();
+		expect(() => captureMobileApiError("/api/v1/sessions/123", "http_5xx", 503)).not.toThrow();
+	});
+
+	it("init resolves without the SDK and captures stay no-ops", async () => {
+		await expect(initMobileSentry({ release: "0.0.0@1" })).resolves.toBeUndefined();
+		expect(() => captureMobileException(new Error("boom"), { category: "native_crash" })).not.toThrow();
+		expect(() => captureMobileApiError("/api/v1/sessions/123", "http_5xx", 503)).not.toThrow();
+	});
+});

--- a/packages/mobile/lib/sentry.ts
+++ b/packages/mobile/lib/sentry.ts
@@ -9,7 +9,8 @@
 // cycle to regenerate the committed native projects, and the config plugin for
 // source maps. Adding it without that would leave the committed ios/ prebuild
 // inconsistent. Ship steps, in order:
-//   1. `npx expo install @sentry/react-native`  (do not hand-pin the version)
+//   1. `npx expo install @sentry/react-native`  (do not hand-pin the version),
+//      then point loadSdk() below at the real import
 //   2. add the @sentry/react-native Expo config plugin, then `npx expo prebuild`
 //   3. wire EAS build-time source-map upload (there is no OTA: no expo-updates,
 //      so maps are keyed by release + dist at EAS build time, not at OTA push)
@@ -74,7 +75,13 @@ export function setMobileDaemonVersion(version: string): void {
 	ctx = { ...ctx, daemonVersion: version };
 }
 
-/** Initialize once. No DSN → stays a no-op forever. */
+// Stub until @sentry/react-native is installed (ship steps above). Not a
+// computed import(): Metro rejects those in app code at bundle time.
+async function loadSdk(): Promise<SentryLike | null> {
+	return null;
+}
+
+/** Initialize once. No DSN or no SDK → stays a no-op forever. */
 export async function initMobileSentry(context: MobileObservabilityContext = {}): Promise<void> {
 	ctx = context;
 	if (initStarted || sentry) return;
@@ -82,12 +89,8 @@ export async function initMobileSentry(context: MobileObservabilityContext = {})
 	if (!d) return;
 	initStarted = true;
 	try {
-		// Dormant placeholder: Metro only bundles a dynamic import() with a static
-		// string literal, so this computed specifier is intentionally NOT bundled
-		// today (keeps the package dependency-free). SHIP STEP: install the SDK and
-		// replace this line with `const mod = await import("@sentry/react-native")`.
-		const spec = ["@sentry", "react-native"].join("/");
-		const mod = (await import(spec)) as unknown as SentryLike;
+		const mod = await loadSdk();
+		if (!mod) return;
 		mod.init({
 			dsn: d,
 			release: context.release,


### PR DESCRIPTION
## Summary
- Since #4394 every mobile bundle fails with `SyntaxError: lib/sentry.ts: Invalid call at line 90: import(spec)` — Metro rejects a computed `import()` in app code at bundle time, it doesn't skip it.
- Replace the placeholder with a `loadSdk()` stub that returns `null` until `@sentry/react-native` is actually installed. Sentry stays a no-op, as before.
- Add `sentry.test.ts` covering the no-op path.

## Test plan
- `npm run typecheck`, `npm test` — 477 pass
- `npx expo export --platform ios` / `--platform android` — both bundle again; both fail on `main`
- Worth a separate PR: run `expo export` in `mobile.yml` so this can't land again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
