### PR TITLE
chore(desktop): de-duplicate the bundled tmux version literal

### DIFF
--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -6,6 +6,7 @@ import MakerAppImage from "./makers/maker-appimage";
 import { existsSync, readdirSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { BUNDLED_TMUX_VERSION } from "./scripts/tmux-version.mjs";
 
 // Default GitHub release target (production). Releases land on Untrivial-ai
 // (the org the repo was transferred to in July 2026; AgentWrapper and aoagents
@@ -122,7 +123,7 @@ const config: ForgeConfig = {
 				const binary = path.join(resourcesPath, "tmux", "bin", "tmux");
 				if (!existsSync(binary)) throw new Error(`packaged tmux missing from ${binary}`);
 				const version = spawnSync(binary, ["-V"], { encoding: "utf8" });
-				if (version.status !== 0 || version.stdout.trim() !== "tmux 3.5a") {
+				if (version.status !== 0 || version.stdout.trim() !== `tmux ${BUNDLED_TMUX_VERSION}`) {
 					throw new Error(`packaged tmux failed verification at ${binary}: ${version.stderr || version.stdout}`);
 				}
 			}

--- a/frontend/scripts/build-tmux.mjs
+++ b/frontend/scripts/build-tmux.mjs
@@ -13,13 +13,14 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { BUNDLED_TMUX_SHA256, BUNDLED_TMUX_VERSION } from "./tmux-version.mjs";
 
 const TMUX = {
 	name: "tmux",
-	version: "3.5a",
-	url: "https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz",
-	sha256: "16216bd0877170dfcc64157085ba9013610b12b082548c7c9542cc0103198951",
-	directory: "tmux-3.5a",
+	version: BUNDLED_TMUX_VERSION,
+	url: `https://github.com/tmux/tmux/releases/download/${BUNDLED_TMUX_VERSION}/tmux-${BUNDLED_TMUX_VERSION}.tar.gz`,
+	sha256: BUNDLED_TMUX_SHA256,
+	directory: `tmux-${BUNDLED_TMUX_VERSION}`,
 	license: "COPYING",
 };
 const LIBEVENT = {

--- a/frontend/scripts/tmux-version.mjs
+++ b/frontend/scripts/tmux-version.mjs
@@ -1,0 +1,11 @@
+// Single source of truth for the bundled tmux release.
+//
+// Two places need it and must never drift: build-tmux.mjs (what gets compiled)
+// and forge.config.ts's postPackage gate (what the packaged app is verified
+// against). A duplicated literal in the gate is what turns a deliberate version
+// bump into a packaging failure.
+//
+// tmux's client/server protocol is not compatible across versions, so this pin
+// also decides which running tmux servers a packaged AO can still talk to.
+export const BUNDLED_TMUX_VERSION = "3.5a";
+export const BUNDLED_TMUX_SHA256 = "16216bd0877170dfcc64157085ba9013610b12b082548c7c9542cc0103198951";


### PR DESCRIPTION
## What

`build-tmux.mjs` and the `postPackage` verification gate in `forge.config.ts`
each hardcode the bundled tmux version (`"3.5a"`) independently. Hoist the
version and its checksum into a single `frontend/scripts/tmux-version.mjs` and
have both files read it.

## Why

Two literals for the same truth drift silently. Bumping the version in
`build-tmux.mjs` alone leaves the gate checking the old one, so a deliberate
version change turns into a packaging failure:

```
Error: packaged tmux failed verification at <path>/tmux: tmux 3.5a
```

The gate runs `tmux -V` and rejects anything that isn't the literal string. The
only correct fix to date has been to remember to edit the gate too — easy to
miss, and the failure mode is late (after a full package).

## Test plan

No behavior change; `3.5a` is preserved. `node --check` on the new module and
the builder's own self-verification (`tmux -V` vs `TMUX.version`) are unaffected.
The postPackage gate now reads the same constant the builder uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)