### PR TITLE
fix: report live workspace branch in sessions

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/current_branch_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/current_branch_test.go
@@ -1,0 +1,61 @@
+package gitworktree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCurrentBranchReadsManagedWorktreeSymbolicRef(t *testing.T) {
+	managedRoot := t.TempDir()
+	workspacePath := filepath.Join(managedRoot, "mer", "mer-1")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var gotArgs []string
+	w := &Workspace{
+		binary:      "git",
+		managedRoot: managedRoot,
+		run: func(_ context.Context, _ string, args ...string) ([]byte, error) {
+			gotArgs = append([]string(nil), args...)
+			return []byte("ao/mer-1/fix-346\n"), nil
+		},
+	}
+
+	got, err := w.CurrentBranch(context.Background(), workspacePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "ao/mer-1/fix-346" {
+		t.Fatalf("branch = %q", got)
+	}
+	wantArgs := []string{"-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("git args = %q, want %q", gotArgs, wantArgs)
+	}
+}
+
+func TestCurrentBranchRejectsPathOutsideManagedRoot(t *testing.T) {
+	managedRoot := t.TempDir()
+	outside := t.TempDir()
+	runCalled := false
+	w := &Workspace{
+		binary:      "git",
+		managedRoot: managedRoot,
+		run: func(context.Context, string, ...string) ([]byte, error) {
+			runCalled = true
+			return nil, nil
+		},
+	}
+
+	_, err := w.CurrentBranch(context.Background(), outside)
+	if !errors.Is(err, ErrUnsafePath) {
+		t.Fatalf("err = %v, want ErrUnsafePath", err)
+	}
+	if runCalled {
+		t.Fatal("git must not run for a path outside ManagedRoot")
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -86,6 +86,7 @@ type Workspace struct {
 type commandRunner func(ctx context.Context, binary string, args ...string) ([]byte, error)
 
 var _ ports.Workspace = (*Workspace)(nil)
+var _ ports.WorkspaceBranchReader = (*Workspace)(nil)
 var _ ports.WorkspaceDefaultBranchRefresher = (*Workspace)(nil)
 var _ ports.WorkspaceProject = (*Workspace)(nil)
 var _ ports.WorkspaceObserver = (*Workspace)(nil)
@@ -113,6 +114,26 @@ func New(opts Options) (*Workspace, error) {
 		repos:       opts.RepoResolver,
 		run:         runCommand,
 	}, nil
+}
+
+// CurrentBranch returns the symbolic branch checked out in an existing AO
+// managed worktree. The path is validated against ManagedRoot before invoking
+// git so a corrupted session row cannot turn read-model enrichment into an
+// arbitrary filesystem probe.
+func (w *Workspace) CurrentBranch(ctx context.Context, workspacePath string) (string, error) {
+	path, err := w.validateManagedPath(workspacePath)
+	if err != nil {
+		return "", fmt.Errorf("current branch: %w", err)
+	}
+	out, err := w.run(ctx, w.binary, "-C", path, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("current branch for %s: %w", path, err)
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "" {
+		return "", fmt.Errorf("current branch for %s: empty symbolic ref", path)
+	}
+	return branch, nil
 }
 
 // ResolveDefaultBranch selects a canonical remote-tracking ref using only local

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -223,6 +223,7 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		Store:             store,
 		PRClaimer:         store,
 		SCM:               scmProvider,
+		WorkspaceBranches: gitWS,
 		DataDir:           cfg.DataDir,
 		Tracker:           tracker,
 		Telemetry:         telemetry,

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -215,6 +215,13 @@ type Workspace interface {
 	AddExclude(ctx context.Context, info WorkspaceInfo, patterns ...string) error
 }
 
+// WorkspaceBranchReader reports the branch currently checked out in an
+// existing managed workspace. Session read models use this optional surface to
+// avoid presenting the spawn-time branch after an agent changes branches.
+type WorkspaceBranchReader interface {
+	CurrentBranch(ctx context.Context, workspacePath string) (string, error)
+}
+
 // WorkspaceDefaultBranchRefresher is an optional capability for Git-backed
 // workspaces. Resolution is local-only so callers can retain the canonical ref
 // even when the subsequent best-effort network refresh fails.

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -152,6 +152,7 @@ type Service struct {
 	prClaimer           ports.PRClaimer
 	scm                 scmProvider
 	tracker             ports.Tracker
+	workspaceBranches   ports.WorkspaceBranchReader
 	clock               func() time.Time
 	dataDir             string
 	telemetry           ports.EventSink
@@ -187,10 +188,14 @@ type Deps struct {
 	PRClaimer ports.PRClaimer
 	SCM       scmProvider
 	Tracker   ports.Tracker
-	Clock     func() time.Time
-	DataDir   string
-	Telemetry ports.EventSink
-	Logger    *slog.Logger
+	// WorkspaceBranches resolves the live branch for active git workspaces.
+	// When unavailable or resolution fails, read models retain the durable
+	// spawn-time branch as a fallback.
+	WorkspaceBranches ports.WorkspaceBranchReader
+	Clock             func() time.Time
+	DataDir           string
+	Telemetry         ports.EventSink
+	Logger            *slog.Logger
 	// BackgroundContext owns best-effort work that must survive an HTTP request
 	// returning but stop with the daemon. It defaults to context.Background for
 	// focused service tests and non-daemon callers.
@@ -207,7 +212,7 @@ func NewWithDeps(d Deps) *Service {
 	if backgroundContext == nil {
 		backgroundContext = context.Background()
 	}
-	s := &Service{manager: d.Manager, store: d.Store, prClaimer: d.PRClaimer, scm: d.SCM, tracker: d.Tracker, clock: d.Clock, dataDir: d.DataDir, signalCapable: d.SignalCapable, telemetry: d.Telemetry, logger: d.Logger, backgroundContext: backgroundContext}
+	s := &Service{manager: d.Manager, store: d.Store, prClaimer: d.PRClaimer, scm: d.SCM, tracker: d.Tracker, workspaceBranches: d.WorkspaceBranches, clock: d.Clock, dataDir: d.DataDir, signalCapable: d.SignalCapable, telemetry: d.Telemetry, logger: d.Logger, backgroundContext: backgroundContext}
 	if s.prClaimer == nil {
 		if w, ok := d.Store.(ports.PRClaimer); ok {
 			s.prClaimer = w
@@ -1095,6 +1100,7 @@ func toSpawnAPIError(err error) error {
 }
 
 func (s *Service) toSession(ctx context.Context, rec domain.SessionRecord) (domain.Session, error) {
+	rec = s.withCurrentWorkspaceBranch(ctx, rec)
 	prs, err := s.store.ListPRFactsForSession(ctx, rec.ID)
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("pr facts %s: %w", rec.ID, err)

--- a/backend/internal/service/session/workspace_branch.go
+++ b/backend/internal/service/session/workspace_branch.go
@@ -1,0 +1,29 @@
+package session
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// withCurrentWorkspaceBranch overlays mutable git state onto the API read
+// model. Metadata.Branch remains the durable spawn-time fallback: branch
+// changes can also be made directly by an agent, outside AO's command path, so
+// treating that seed value as the live source of truth produces stale UI/API
+// state.
+func (s *Service) withCurrentWorkspaceBranch(ctx context.Context, rec domain.SessionRecord) domain.SessionRecord {
+	if s.workspaceBranches == nil || rec.IsTerminated ||
+		strings.TrimSpace(rec.Metadata.Branch) == "" ||
+		strings.TrimSpace(rec.Metadata.WorkspacePath) == "" {
+		return rec
+	}
+	branch, err := s.workspaceBranches.CurrentBranch(ctx, rec.Metadata.WorkspacePath)
+	if err != nil {
+		return rec
+	}
+	if branch = strings.TrimSpace(branch); branch != "" {
+		rec.Metadata.Branch = branch
+	}
+	return rec
+}

--- a/backend/internal/service/session/workspace_branch_test.go
+++ b/backend/internal/service/session/workspace_branch_test.go
@@ -1,0 +1,92 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type fakeWorkspaceBranchReader struct {
+	branch string
+	err    error
+	paths  []string
+}
+
+func (f *fakeWorkspaceBranchReader) CurrentBranch(_ context.Context, workspacePath string) (string, error) {
+	f.paths = append(f.paths, workspacePath)
+	return f.branch, f.err
+}
+
+func TestGetUsesCurrentWorkspaceBranchInsteadOfSpawnBranch(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		Metadata: domain.SessionMetadata{
+			Branch:        "ao/mer-1/root",
+			WorkspacePath: "/managed/mer/mer-1",
+		},
+	}
+	branches := &fakeWorkspaceBranchReader{branch: "ao/mer-1/fix-346"}
+	svc := NewWithDeps(Deps{Store: st, WorkspaceBranches: branches})
+
+	got, err := svc.Get(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata.Branch != "ao/mer-1/fix-346" {
+		t.Fatalf("branch = %q, want current workspace branch", got.Metadata.Branch)
+	}
+	if len(branches.paths) != 1 || branches.paths[0] != "/managed/mer/mer-1" {
+		t.Fatalf("branch reader paths = %v", branches.paths)
+	}
+}
+
+func TestGetRetainsSpawnBranchWhenCurrentBranchCannotBeRead(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		Metadata: domain.SessionMetadata{
+			Branch:        "ao/mer-1/root",
+			WorkspacePath: "/managed/mer/mer-1",
+		},
+	}
+	branches := &fakeWorkspaceBranchReader{err: errors.New("worktree unavailable")}
+	svc := NewWithDeps(Deps{Store: st, WorkspaceBranches: branches})
+
+	got, err := svc.Get(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata.Branch != "ao/mer-1/root" {
+		t.Fatalf("branch = %q, want durable fallback", got.Metadata.Branch)
+	}
+}
+
+func TestListUsesCurrentWorkspaceBranchForActiveSessions(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		Metadata: domain.SessionMetadata{
+			Branch:        "ao/mer-1/root",
+			WorkspacePath: "/managed/mer/mer-1",
+		},
+	}
+	branches := &fakeWorkspaceBranchReader{branch: "ao/mer-1/fix-346"}
+	svc := NewWithDeps(Deps{Store: st, WorkspaceBranches: branches})
+
+	got, err := svc.List(context.Background(), ListFilter{ProjectID: "mer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Metadata.Branch != "ao/mer-1/fix-346" {
+		t.Fatalf("sessions = %+v, want current workspace branch", got)
+	}
+}


### PR DESCRIPTION
## Summary

- resolve each active git session's branch from its managed worktree when assembling session read models
- keep the durable spawn-time branch as a fallback when the worktree is unavailable or detached
- validate the workspace path against AO's managed root before running the single read-only Git probe

## Root cause

`SessionMetadata.Branch` is captured when a session is spawned, but an agent or host can change the worktree branch directly with Git. Session GET/list responses continued projecting that seed value, so the API could report `ao/<session>/root` while the worktree and claimed PR were already on a feature branch.

The fix treats the checked-out branch as mutable external state and overlays it at service read-model assembly time. This also covers spawn, restore, and resume responses that use the same assembly path. It does not perform a checkout or mutate SQLite.

## Verification

- `go test ./internal/service/session ./internal/adapters/workspace/gitworktree ./internal/daemon -count=1` (pass)
- `go build ./...` (pass)
- `go vet ./...` (pass)
- Windows/amd64 cross-compile of the three affected test packages (pass)
- `go test ./... -count=1` in the Linux Go 1.25.7 container reaches unrelated environment-sensitive baseline failures:
  - fake-agent lifecycle hook log is not created in the container
  - mobilebridge chmod-based write-failure tests run as container root and remain writable
  - one session-manager test requires tmux, which is not installed in the build container

No frontend or API schema shape changes are required.
