### PR TITLE
fix: polish mobile settings controls

### DIFF
--- a/frontend/src/renderer/components/ConnectMobileModal.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.test.tsx
@@ -111,6 +111,9 @@ test("keeps the mobile setup dropdowns at a shared width", async () => {
 	];
 	expect(controls[0]).toHaveClass("w-48", "justify-between");
 	expect(controls[1]).toHaveClass("w-48", "justify-between");
+
+	await userEvent.click(controls[0]);
+	expect(screen.getByRole("menu")).toHaveClass("w-48", "min-w-0");
 });
 
 test("shows a square Google Play QR tooltip for Android", async () => {

--- a/frontend/src/renderer/components/ConnectMobileModal.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.test.tsx
@@ -109,11 +109,11 @@ test("keeps the mobile setup dropdowns at a shared width", async () => {
 		screen.getByRole("button", { name: "Get the app" }),
 		screen.getByRole("button", { name: "Connection method" }),
 	];
-	expect(controls[0]).toHaveClass("w-48", "justify-between");
-	expect(controls[1]).toHaveClass("w-48", "justify-between");
+	expect(controls[0]).toHaveClass("w-44", "justify-between");
+	expect(controls[1]).toHaveClass("w-44", "justify-between");
 
 	await userEvent.click(controls[0]);
-	expect(screen.getByRole("menu")).toHaveClass("w-48", "min-w-0");
+	expect(screen.getByRole("menu")).toHaveClass("!w-44", "!min-w-0");
 });
 
 test("shows a square Google Play QR tooltip for Android", async () => {

--- a/frontend/src/renderer/components/ConnectMobileModal.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, expect, test, vi } from "vitest";
 import { TooltipProvider } from "./ui/tooltip";
+import { apiClient } from "../lib/api-client";
 
 // vi.mock is hoisted above module-level consts, so the shared double has to be
 // created inside vi.hoisted to exist by the time the factory runs.
@@ -90,6 +91,26 @@ test("encodes the LAN address by default", async () => {
 	renderMobileSettings();
 	await waitFor(() => expect(qrPayload()).not.toBeNull());
 	expect(JSON.parse(qrPayload()!).host).toBe("192.168.1.42");
+});
+
+test("can turn off the generated mobile connection", async () => {
+	renderMobileSettings();
+	const button = await screen.findByRole("button", { name: "Turn off mobile connection" });
+
+	await userEvent.click(button);
+	expect(apiClient.POST).toHaveBeenCalledWith("/api/v1/mobile/disable");
+});
+
+test("keeps the mobile setup dropdowns at a shared width", async () => {
+	renderMobileSettings();
+	await waitFor(() => expect(qrPayload()).not.toBeNull());
+
+	const controls = [
+		screen.getByRole("button", { name: "Get the app" }),
+		screen.getByRole("button", { name: "Connection method" }),
+	];
+	expect(controls[0]).toHaveClass("w-48", "justify-between");
+	expect(controls[1]).toHaveClass("w-48", "justify-between");
 });
 
 test("shows a square Google Play QR tooltip for Android", async () => {

--- a/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
@@ -235,7 +235,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 			<div className="flex flex-col gap-6 sm:flex-row sm:items-start">
 				{/* Left: platform + connection pickers above one combined walkthrough. */}
 				<div className="flex min-w-0 flex-1 flex-col">
-					<div className="flex flex-wrap items-center gap-2">
+					<div className="flex flex-nowrap items-center gap-2">
 						<SettingsOptionMenu
 							aria-label={t("mobile.getApp")}
 							value={platform}
@@ -244,6 +244,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							triggerClassName="w-48 justify-between"
 							renderMenuItem={renderPlatformOption}
 							renderTrigger={(selected) => selected && renderPlatformOption(selected)}
+							menuClassName="w-48 min-w-0"
 							menuAlign="start"
 						/>
 						<SettingsOptionMenu
@@ -252,6 +253,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							options={modeOptions}
 							onChange={setMode}
 							triggerClassName="w-48 justify-between"
+							menuClassName="w-48 min-w-0"
 							menuAlign="start"
 						/>
 					</div>

--- a/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
@@ -91,6 +91,12 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 		{ value: "lan", label: t("mobile.lan") },
 		{ value: "tailscale", label: t("mobile.tailscale") },
 	] satisfies SettingsOption<SetupMode>[];
+	const renderPlatformOption = (option: SettingsOption<MobilePlatform>) => (
+		<span className="flex min-w-0 items-center gap-1.5">
+			<span className="flex w-5 shrink-0 justify-center">{option.icon}</span>
+			<span className="min-w-0">{option.label}</span>
+		</span>
+	);
 
 	useEffect(() => {
 		return () => {
@@ -139,6 +145,14 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 		onSuccess: invalidate,
 	});
 
+	const disable = useMutation({
+		mutationFn: async () => {
+			const { error } = await apiClient.POST("/api/v1/mobile/disable");
+			if (error) throw new Error(apiErrorMessage(error));
+		},
+		onSuccess: invalidate,
+	});
+
 	const setSecure = useMutation({
 		mutationFn: async (secureEnabled: boolean) => {
 			const { data, error } = await apiClient.POST("/api/v1/mobile/secure-pairing", { body: { enabled: secureEnabled } });
@@ -158,11 +172,12 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 			: (status?.host ?? "");
 	const activePort = secureActive ? status!.securePairing.port : (status?.port ?? 0);
 	const secureBlocked = mode === "tailscale" && (status?.securePairing?.enabled ?? false) && !secureActive;
-	const busy = enable.isPending || regenerate.isPending || setSecure.isPending;
+	const busy = enable.isPending || regenerate.isPending || disable.isPending || setSecure.isPending;
 
 	const clearActionErrors = () => {
 		enable.reset();
 		regenerate.reset();
+		disable.reset();
 		setSecure.reset();
 	};
 
@@ -194,6 +209,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 	const actionError =
 		(enable.error instanceof Error && enable.error.message) ||
 		(regenerate.error instanceof Error && regenerate.error.message) ||
+		(disable.error instanceof Error && disable.error.message) ||
 		(setSecure.error instanceof Error && setSecure.error.message) ||
 		null;
 
@@ -225,6 +241,9 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							value={platform}
 							options={platformOptions}
 							onChange={setPlatform}
+							triggerClassName="w-48 justify-between"
+							renderMenuItem={renderPlatformOption}
+							renderTrigger={(selected) => selected && renderPlatformOption(selected)}
 							menuAlign="start"
 						/>
 						<SettingsOptionMenu
@@ -232,6 +251,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							value={mode}
 							options={modeOptions}
 							onChange={setMode}
+							triggerClassName="w-48 justify-between"
 							menuAlign="start"
 						/>
 					</div>
@@ -378,7 +398,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 				{/* Right: dedicated pairing-QR panel — square, clipping, flush with
 				    the content's right edge so bottom/right spacing match. */}
 				<div className="flex w-full shrink-0 flex-col gap-3 self-start sm:w-60">
-					<div className="relative aspect-square w-full overflow-hidden rounded-md border border-(--color-border-settings-input) bg-(--color-bg-settings-input)">
+					<div className="relative aspect-square w-full overflow-hidden rounded-md">
 						{enabled && !activeHost ? (
 							<div className="flex size-full items-center justify-center bg-(--color-bg-settings-input) p-4">
 								<p className="text-center text-caption leading-(--leading-settings-mobile-hint) text-settings-muted">
@@ -387,7 +407,13 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							</div>
 						) : (
 							<>
-								<div className={cn("size-full", !showRealQR && "opacity-60 blur-[6px]")} aria-hidden={!showRealQR}>
+								<div
+									className={cn(
+										"size-full transition-[filter,opacity] duration-300 ease-out",
+										!showRealQR && "opacity-60 blur-[6px]",
+									)}
+									aria-hidden={!showRealQR}
+								>
 									<StyledQRCode
 										value={showRealQR ? pairingPayload(activeHost, activePort, status.password, secureActive) : PLACEHOLDER_QR_VALUE}
 										data-qr-value={showRealQR ? pairingPayload(activeHost, activePort, status.password, secureActive) : undefined}
@@ -404,7 +430,6 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 											onClick={startBridge}
 											disabled={busy || (enabled && secureBlocked)}
 										>
-											{enable.isPending && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
 											{t("mobile.generate")}
 										</Button>
 									</div>
@@ -412,6 +437,20 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							</>
 						)}
 					</div>
+					{enabled && (
+						<Button
+							type="button"
+							variant="footer"
+							className="w-full"
+							disabled={busy}
+							onClick={() => {
+								clearActionErrors();
+								disable.mutate();
+							}}
+						>
+							{t("mobile.disable", "Turn off mobile connection")}
+						</Button>
+					)}
 					</div>
 			</div>
 		</div>

--- a/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
@@ -241,10 +241,10 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							value={platform}
 							options={platformOptions}
 							onChange={setPlatform}
-							triggerClassName="w-48 justify-between"
+							triggerClassName="w-44 justify-between"
 							renderMenuItem={renderPlatformOption}
 							renderTrigger={(selected) => selected && renderPlatformOption(selected)}
-							menuClassName="w-48 min-w-0"
+							menuClassName="!w-44 !min-w-0"
 							menuAlign="start"
 						/>
 						<SettingsOptionMenu
@@ -252,8 +252,8 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							value={mode}
 							options={modeOptions}
 							onChange={setMode}
-							triggerClassName="w-48 justify-between"
-							menuClassName="w-48 min-w-0"
+							triggerClassName="w-44 justify-between"
+							menuClassName="!w-44 !min-w-0"
 							menuAlign="start"
 						/>
 					</div>

--- a/frontend/src/renderer/components/settings/MobileDevicesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/MobileDevicesSection.test.tsx
@@ -50,6 +50,7 @@ describe("MobileDevicesSection", () => {
 		expect(screen.getAllByRole("listitem")[0]).not.toHaveClass("rounded-lg", "border", "px-3", "bg-[var(--color-bg-settings-input)]");
 		expect(screen.getByText("M31s")).toBeInTheDocument();
 		expect(screen.queryByText("Live")).not.toBeInTheDocument();
+		expect(screen.getAllByTestId("bell")).toHaveLength(2);
 		expect(screen.queryByText(/2 hours ago/)).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/settings/MobileDevicesSection.tsx
+++ b/frontend/src/renderer/components/settings/MobileDevicesSection.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Smartphone, Trash2 } from "lucide-react";
+import { Bell, Loader2, Trash2 } from "lucide-react";
 import { apiClient, apiErrorCode, apiErrorMessage } from "../../lib/api-client";
 import { Switch } from "../ui/switch";
 
@@ -135,7 +135,7 @@ export function MobileDevicesSection() {
 									key={device.installId}
 									className="flex min-h-12 items-center gap-3 py-2.5"
 								>
-									<Smartphone className="size-4 shrink-0 text-settings-muted" />
+									<Bell className="size-4 shrink-0 text-settings-muted" aria-hidden="true" data-testid="bell" />
 									<div className="min-w-0 flex-1">
 										<div className="truncate text-sm">{name}</div>
 									</div>

--- a/frontend/src/renderer/components/settings/MobileDevicesSection.tsx
+++ b/frontend/src/renderer/components/settings/MobileDevicesSection.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Bell, Loader2, Trash2 } from "lucide-react";
+import { Bell, Loader2, Smartphone, Trash2 } from "lucide-react";
 import { apiClient, apiErrorCode, apiErrorMessage } from "../../lib/api-client";
 import { Switch } from "../ui/switch";
 
@@ -135,19 +135,22 @@ export function MobileDevicesSection() {
 									key={device.installId}
 									className="flex min-h-12 items-center gap-3 py-2.5"
 								>
-									<Bell className="size-4 shrink-0 text-settings-muted" aria-hidden="true" data-testid="bell" />
+									<Smartphone className="size-4 shrink-0 text-settings-muted" aria-hidden="true" />
 									<div className="min-w-0 flex-1">
 										<div className="truncate text-sm">{name}</div>
 									</div>
 
-									<Switch
-										checked={device.notificationsEnabled && !device.muted}
-										disabled={mute.isPending || !device.notificationsEnabled}
-										aria-label={t("mobile.devices.notificationsFor", { name })}
-										onCheckedChange={(next) =>
-											mute.mutate({ installId: device.installId, muted: !next })
-										}
-									/>
+									<div className="flex items-center gap-2" title={t("mobile.devices.notificationsFor", { name })}>
+										<Bell className="size-4 text-settings-muted" aria-hidden="true" data-testid="bell" />
+										<Switch
+											checked={device.notificationsEnabled && !device.muted}
+											disabled={mute.isPending || !device.notificationsEnabled}
+											aria-label={t("mobile.devices.notificationsFor", { name })}
+											onCheckedChange={(next) =>
+												mute.mutate({ installId: device.installId, muted: !next })
+											}
+										/>
+									</div>
 
 									{confirmingRemoval === device.installId ? (
 										<button

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -378,6 +378,7 @@
 	"mobile.connectionMethod": "Verbindungsmethode",
 	"mobile.copyPassword": "Passwort kopieren",
 	"mobile.description": "Koppeln Sie die Agent Orchestrator Mobile-App über Ihr LAN mit diesem Desktop.",
+	"mobile.disable": "Mobile-Verbindung deaktivieren",
 	"mobile.devices.confirmRemove": "Entfernen bestätigen",
 	"mobile.devices.empty": "Noch keine Geräte gekoppelt.",
 	"mobile.devices.loading": "Geräte werden geladen…",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -378,6 +378,7 @@
 	"mobile.connectionMethod": "Connection method",
 	"mobile.copyPassword": "Copy password",
 	"mobile.description": "Pair the Agent Orchestrator mobile app with this desktop over your LAN.",
+	"mobile.disable": "Turn off mobile connection",
 	"mobile.devices.confirmRemove": "Confirm remove",
 	"mobile.devices.empty": "No devices paired yet.",
 	"mobile.devices.loading": "Loading devices…",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -380,6 +380,7 @@
 	"mobile.connectionMethod": "Método de conexión",
 	"mobile.copyPassword": "Copiar contraseña",
 	"mobile.description": "Empareja la aplicación móvil de Agent Orchestrator con este escritorio a través de tu LAN.",
+	"mobile.disable": "Desactivar conexión móvil",
 	"mobile.devices.confirmRemove": "Confirmar eliminación",
 	"mobile.devices.empty": "Aún no hay dispositivos emparejados.",
 	"mobile.devices.loading": "Cargando dispositivos…",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -380,6 +380,7 @@
 	"mobile.connectionMethod": "Méthode de connexion",
 	"mobile.copyPassword": "Copier le mot de passe",
 	"mobile.description": "Associez l'application mobile Agent Orchestrator à ce bureau via votre LAN.",
+	"mobile.disable": "Désactiver la connexion mobile",
 	"mobile.devices.confirmRemove": "Confirmer la suppression",
 	"mobile.devices.empty": "Aucun appareil associé pour le moment.",
 	"mobile.devices.loading": "Chargement des appareils…",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -378,6 +378,7 @@
 	"mobile.connectionMethod": "接続方法",
 	"mobile.copyPassword": "パスワードをコピー",
 	"mobile.description": "Agent Orchestrator モバイルアプリを、LAN 経由でこのデスクトップとペアリングします。",
+	"mobile.disable": "モバイル接続をオフにする",
 	"mobile.devices.confirmRemove": "削除を確定",
 	"mobile.devices.empty": "まだペアリングされたデバイスはありません。",
 	"mobile.devices.loading": "デバイスを読み込み中…",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -378,6 +378,7 @@
 	"mobile.connectionMethod": "연결 방법",
 	"mobile.copyPassword": "비밀번호 복사",
 	"mobile.description": "Agent Orchestrator 모바일 앱을 LAN을 통해 이 데스크톱과 페어링합니다.",
+	"mobile.disable": "모바일 연결 끄기",
 	"mobile.devices.confirmRemove": "제거 확인",
 	"mobile.devices.empty": "아직 페어링된 기기가 없습니다.",
 	"mobile.devices.loading": "기기를 불러오는 중…",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -380,6 +380,7 @@
 	"mobile.connectionMethod": "Método de conexão",
 	"mobile.copyPassword": "Copiar senha",
 	"mobile.description": "Emparelhe o app mobile do Agent Orchestrator com este desktop pela sua LAN.",
+	"mobile.disable": "Desativar conexão móvel",
 	"mobile.devices.confirmRemove": "Confirmar remoção",
 	"mobile.devices.empty": "Nenhum dispositivo emparelhado ainda.",
 	"mobile.devices.loading": "Carregando dispositivos…",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -378,6 +378,7 @@
 	"mobile.connectionMethod": "连接方式",
 	"mobile.copyPassword": "复制密码",
 	"mobile.description": "通过局域网将 Agent Orchestrator 手机应用与此桌面配对。",
+	"mobile.disable": "关闭移动连接",
 	"mobile.devices.confirmRemove": "确认移除",
 	"mobile.devices.empty": "尚未配对任何设备。",
 	"mobile.devices.loading": "正在加载设备…",


### PR DESCRIPTION
## Summary
- add a turn-off action for the generated mobile connection
- align mobile platform labels and standardize dropdown widths
- use notification bell icons for connected devices
- animate QR blur transitions and remove the QR container border/background

## Validation
- `npm test -- --run src/renderer/components/settings/MobileDevicesSection.test.tsx src/renderer/components/ConnectMobileModal.test.tsx` — 25 tests passed
- `npm run typecheck` — blocked by existing missing React dependencies/errors in `packages/product-ui`