### PR TITLE
fix(systeminstall): pin winget source and add gh direct-download fallback

### DIFF
--- a/backend/internal/service/systeminstall/systeminstall.go
+++ b/backend/internal/service/systeminstall/systeminstall.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -271,25 +272,74 @@ func (s *Service) run(plan Plan, job *Job) {
 		job.Error = runErr.Error()
 		return
 	}
-	// Verify the target is now usable. Most installs are confirmed via PATH;
-	// the gh direct-download fallback instead produces a known binary at
-	// InstalledBinaryPath, which we trust directly because its destination may
-	// not yet be on the daemon's PATH on stripped/no-winget Windows (#4449
-	// review).
-	if path, err := s.executables.LookPath(string(job.Target)); err == nil && path != "" {
-		job.Status = StatusSucceeded
+	if err := s.verifyInstalled(plan, string(job.Target)); err != nil {
+		job.Status = StatusFailed
+		job.Error = err.Error()
 		return
 	}
-	if plan.InstalledBinaryPath != "" {
-		if _, statErr := os.Stat(plan.InstalledBinaryPath); statErr == nil {
-			job.Status = StatusSucceeded
+	job.Status = StatusSucceeded
+}
+
+// verifyInstalled reports whether target is usable after its install command
+// finished. The PATH lookup is the primary signal for most targets; the gh
+// direct-download fallback writes to a directory that may not be on this
+// process's PATH yet, so it additionally proves the recorded binary actually
+// executes (not just that a file exists) and registers its directory on the
+// current process PATH so child processes spawned from this already-running
+// daemon inherit it too (#4449 review).
+func (s *Service) verifyInstalled(plan Plan, target string) error {
+	if path, err := s.executables.LookPath(target); err == nil && path != "" {
+		return nil
+	}
+	if plan.InstalledBinaryPath == "" {
+		return fmt.Errorf("install command finished but %s is still not in PATH", target)
+	}
+	if err := s.probeInstalledBinary(plan.InstalledBinaryPath); err != nil {
+		return fmt.Errorf("install command finished but %s is still not on PATH and %s did not run: %w", target, plan.InstalledBinaryPath, err)
+	}
+	registerOnProcessPath(filepath.Dir(plan.InstalledBinaryPath))
+	return nil
+}
+
+// probeInstalledBinary executes the installed binary with a version probe to
+// confirm it is present and actually runs, rather than merely existing on
+// disk. Only the gh fallback sets InstalledBinaryPath today, for which
+// --version is a stable, exit-0 probe; the argv is fixed and never takes
+// caller input.
+func (s *Service) probeInstalledBinary(binPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return s.commands.Run(ctx, []string{binPath, "--version"}, io.Discard, io.Discard) //nolint:gosec // G204: fixed argv from a hardcoded plan path, never caller input
+}
+
+// registerOnProcessPath appends dir to the current process's PATH if it isn't
+// already there, so LookPath and child processes spawned after this point can
+// resolve binaries a just-finished installer dropped into dir. The install
+// script separately persists the entry in the User PATH, but that only applies
+// to processes started after an environment refresh — this updates the running
+// daemon for the rest of its lifetime.
+func registerOnProcessPath(dir string) {
+	if dir == "" {
+		return
+	}
+	pathVal := os.Getenv("PATH")
+	for _, entry := range strings.Split(pathVal, string(os.PathListSeparator)) {
+		if strings.EqualFold(entry, dir) {
 			return
 		}
-		job.Error = fmt.Sprintf("install command finished but %s is still not on PATH and %s does not exist", job.Target, plan.InstalledBinaryPath)
-	} else {
-		job.Error = fmt.Sprintf("install command finished but %s is still not in PATH", job.Target)
 	}
-	job.Status = StatusFailed
+	var updated string
+	if pathVal == "" {
+		updated = dir
+	} else {
+		updated = pathVal + string(os.PathListSeparator) + dir
+	}
+	if err := os.Setenv("PATH", updated); err != nil {
+		// The PATH we hand to children of this process just won't include the
+		// fresh install dir; the job itself is already verified as succeeded via
+		// the binary probe, so this is non-fatal.
+		return
+	}
 }
 
 func displayCommand(plan Plan) string {
@@ -406,10 +456,13 @@ Remove-Item -Force "$stage.zip"
 if (-not (Test-Path (Join-Path $dest 'gh.exe'))) { throw 'gh.exe was not found after extraction; install failed' }
 # Register the destination on the user PATH so future sessions and child shells
 # (e.g. terminals AO spawns for the agent) can find gh even when WindowsApps is
-# absent from the default PATH on stripped/no-winget images.
+# absent from the default PATH on stripped/no-winget images. The User-scope Path
+# can be unset on a fresh/stripped profile, so coalesce it to '' before use.
 $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if (-not $userPath) { $userPath = '' }
 if ($userPath -notlike "*$dest*") {
-    [Environment]::SetEnvironmentVariable('Path', ($userPath.TrimEnd(';') + ';' + $dest), 'User')
+    $newPath = if ($userPath -eq '') { $dest } else { $userPath.TrimEnd(';') + ';' + $dest }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
 }
 Write-Output ("installed gh " + $release.tag_name + " to " + $dest)`
 

--- a/backend/internal/service/systeminstall/systeminstall.go
+++ b/backend/internal/service/systeminstall/systeminstall.go
@@ -343,7 +343,7 @@ func (s *Service) planTmux() Plan {
 func (s *Service) planGH() Plan {
 	switch s.goos {
 	case "windows":
-		return s.planWinget(TargetGH, "GitHub.cli")
+		return s.planGHWindows()
 	case "darwin":
 		return s.planBrew(TargetGH, "gh")
 	case "linux":
@@ -355,6 +355,46 @@ func (s *Service) planGH() Plan {
 		})
 	default:
 		return Plan{Target: TargetGH, Unsupported: true, Reason: "gh installation is not supported on this platform."}
+	}
+}
+
+// ghWindowsDownloadScript installs GitHub CLI without winget: it fetches the
+// latest official windows_amd64 zip from the cli/cli GitHub Releases and
+// copies bin\*.exe into %LOCALAPPDATA%\Microsoft\WindowsApps, which is on the
+// default per-user PATH, so the post-run LookPath("gh") verification in run()
+// succeeds without touching the registry or requiring a shell restart. The
+// script is a hardcoded constant — same security invariant as every other
+// argv in this package; no caller-supplied string ever reaches it.
+const ghWindowsDownloadScript = `$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/cli/cli/releases/latest'
+$asset = $release.assets | Where-Object { $_.name -like 'gh_*_windows_amd64.zip' } | Select-Object -First 1
+if (-not $asset) { throw 'no gh windows_amd64 asset found in the latest cli/cli release' }
+$stage = Join-Path ([IO.Path]::GetTempPath()) ('ao-gh-' + [Guid]::NewGuid().ToString('N'))
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile "$stage.zip"
+Expand-Archive -Path "$stage.zip" -DestinationPath $stage -Force
+$dest = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Copy-Item -Path (Join-Path $stage '*\bin\*.exe') -Destination $dest -Force
+Remove-Item -Recurse -Force $stage
+Remove-Item -Force "$stage.zip"
+Write-Output ("installed gh " + $release.tag_name + " to " + $dest)`
+
+// planGHWindows resolves gh on Windows. Winget with a pinned --source winget
+// is preferred (see planWinget); machines without winget at all — LTSC/Server
+// or stripped installs, exactly the fresh machines this installer targets —
+// fall back to the hardcoded direct download above instead of dead-ending as
+// Unsupported.
+func (s *Service) planGHWindows() Plan {
+	if _, err := s.executables.LookPath("winget"); err == nil {
+		return s.planWinget(TargetGH, "GitHub.cli")
+	}
+	return Plan{
+		Target: TargetGH,
+		Command: []string{
+			"powershell", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+			"-Command", ghWindowsDownloadScript,
+		},
 	}
 }
 
@@ -396,11 +436,29 @@ func (s *Service) planBrew(target Target, pkg string) Plan {
 	return Plan{Target: target, Command: []string{"brew", "install", pkg}}
 }
 
+// planWinget resolves target via winget with the source pinned to the winget
+// community repository and every agreement flag set. Without --source, winget
+// also queries msstore; on a fresh Windows profile that source has never been
+// initialized, so its very first use blocks on an interactive Y/N prompt to
+// accept the Terms of Transaction and region sharing. The daemon runs
+// installs with no TTY attached, so that prompt can never be answered and
+// winget exits 0x8a150042 (APPINSTALLER_CLI_ERROR_PROMPT_INPUT_ERROR) — see
+// issue #4449 and upstream microsoft/winget-cli#2819. Pinning --source winget
+// bypasses msstore entirely, and the two accept flags ensure no remaining
+// source- or package-agreement prompt can block a non-interactive run.
 func (s *Service) planWinget(target Target, id string) Plan {
 	if _, err := s.executables.LookPath("winget"); err != nil {
 		return Plan{Target: target, Unsupported: true, Reason: "winget was not found on PATH."}
 	}
-	return Plan{Target: target, Command: []string{"winget", "install", "-e", "--id", id}}
+	return Plan{
+		Target: target,
+		Command: []string{
+			"winget", "install", "-e", "--id", id,
+			"--source", "winget",
+			"--accept-package-agreements",
+			"--accept-source-agreements",
+		},
+	}
 }
 
 // linuxPackageManagers is probed in this fixed order; the first one found on

--- a/backend/internal/service/systeminstall/systeminstall.go
+++ b/backend/internal/service/systeminstall/systeminstall.go
@@ -11,6 +11,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -82,6 +84,14 @@ type Plan struct {
 	NeedsRoot   bool     // Command must run as root; the caller supplies the privilege
 	Unsupported bool
 	Reason      string // set when Unsupported, or as extra context otherwise
+	// InstalledBinaryPath, when set, names the exact binary the install is
+	// expected to produce. run() accepts the install as succeeded if this file
+	// exists even when LookPath(target) can't find it on PATH — necessary for
+	// the gh direct-download fallback, which drops gh.exe into
+	// %LOCALAPPDATA%\Microsoft\WindowsApps and depends on that directory being
+	// on PATH; on stripped/no-winget Windows it may not be, so the concrete
+	// path is the source of truth for verification (#4449 review).
+	InstalledBinaryPath string
 }
 
 // Status is the lifecycle state of an install Job.
@@ -197,7 +207,7 @@ func (s *Service) Start(ctx context.Context, target Target) (Job, error) {
 	}
 	s.jobs[target] = job
 
-	go s.run(plan.Command, job) //nolint:gosec // G118: the async job deliberately outlives the starting HTTP request and owns a bounded timeout.
+	go s.run(plan, job) //nolint:gosec // G118: the async job deliberately outlives the starting HTTP request and owns a bounded timeout.
 
 	return *job, nil
 }
@@ -239,12 +249,12 @@ func (s *Service) Status(ctx context.Context, target Target) (Job, error) {
 // concurrent Start/Status calls never race with this goroutine's writes.
 // The run is bounded by installTimeout so a stalled installer eventually
 // surfaces as a failure instead of pinning the target in StatusRunning.
-func (s *Service) run(argv []string, job *Job) {
+func (s *Service) run(plan Plan, job *Job) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.installTimeout)
 	defer cancel()
 
 	out := &capturedOutput{max: maxOutputBytes}
-	runErr := s.commands.Run(ctx, argv, out, out)
+	runErr := s.commands.Run(ctx, plan.Command, out, out)
 	now := time.Now()
 
 	s.mu.Lock()
@@ -261,12 +271,25 @@ func (s *Service) run(argv []string, job *Job) {
 		job.Error = runErr.Error()
 		return
 	}
-	if path, err := s.executables.LookPath(string(job.Target)); err != nil || path == "" {
-		job.Status = StatusFailed
-		job.Error = fmt.Sprintf("install command finished but %s is still not in PATH", job.Target)
+	// Verify the target is now usable. Most installs are confirmed via PATH;
+	// the gh direct-download fallback instead produces a known binary at
+	// InstalledBinaryPath, which we trust directly because its destination may
+	// not yet be on the daemon's PATH on stripped/no-winget Windows (#4449
+	// review).
+	if path, err := s.executables.LookPath(string(job.Target)); err == nil && path != "" {
+		job.Status = StatusSucceeded
 		return
 	}
-	job.Status = StatusSucceeded
+	if plan.InstalledBinaryPath != "" {
+		if _, statErr := os.Stat(plan.InstalledBinaryPath); statErr == nil {
+			job.Status = StatusSucceeded
+			return
+		}
+		job.Error = fmt.Sprintf("install command finished but %s is still not on PATH and %s does not exist", job.Target, plan.InstalledBinaryPath)
+	} else {
+		job.Error = fmt.Sprintf("install command finished but %s is still not in PATH", job.Target)
+	}
+	job.Status = StatusFailed
 }
 
 func displayCommand(plan Plan) string {
@@ -378,23 +401,37 @@ New-Item -ItemType Directory -Force -Path $dest | Out-Null
 Copy-Item -Path (Join-Path $stage '*\bin\*.exe') -Destination $dest -Force
 Remove-Item -Recurse -Force $stage
 Remove-Item -Force "$stage.zip"
+# Self-verify: a missing binary means the extraction/copy failed, and the job
+# must be reported as failed rather than silently reporting success.
+if (-not (Test-Path (Join-Path $dest 'gh.exe'))) { throw 'gh.exe was not found after extraction; install failed' }
+# Register the destination on the user PATH so future sessions and child shells
+# (e.g. terminals AO spawns for the agent) can find gh even when WindowsApps is
+# absent from the default PATH on stripped/no-winget images.
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -notlike "*$dest*") {
+    [Environment]::SetEnvironmentVariable('Path', ($userPath.TrimEnd(';') + ';' + $dest), 'User')
+}
 Write-Output ("installed gh " + $release.tag_name + " to " + $dest)`
 
 // planGHWindows resolves gh on Windows. Winget with a pinned --source winget
 // is preferred (see planWinget); machines without winget at all — LTSC/Server
 // or stripped installs, exactly the fresh machines this installer targets —
 // fall back to the hardcoded direct download above instead of dead-ending as
-// Unsupported.
+// Unsupported. The fallback records the concrete binary path it writes so the
+// post-install check can confirm success even when that directory isn't on the
+// daemon's PATH (#4449 review).
 func (s *Service) planGHWindows() Plan {
 	if _, err := s.executables.LookPath("winget"); err == nil {
 		return s.planWinget(TargetGH, "GitHub.cli")
 	}
+	dest := filepath.Join(os.Getenv("LOCALAPPDATA"), "Microsoft", "WindowsApps")
 	return Plan{
 		Target: TargetGH,
 		Command: []string{
 			"powershell", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
 			"-Command", ghWindowsDownloadScript,
 		},
+		InstalledBinaryPath: filepath.Join(dest, "gh.exe"),
 	}
 }
 

--- a/backend/internal/service/systeminstall/systeminstall_test.go
+++ b/backend/internal/service/systeminstall/systeminstall_test.go
@@ -213,6 +213,10 @@ func TestGHWindowsFallsBackToDirectDownload(t *testing.T) {
 		"https://api.github.com/repos/cli/cli/releases/latest",
 		"gh_*_windows_amd64.zip",
 		"Microsoft\\WindowsApps",
+		// The User-scope Path can be unset on a fresh/stripped profile, so the
+		// script must coalesce it to '' before appending, or the fallback
+		// throws after gh.exe was already copied (#4449 review).
+		"$userPath = ''",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("download script missing %q:\n%s", want, script)
@@ -228,11 +232,12 @@ func TestGHWindowsFallsBackToDirectDownload(t *testing.T) {
 	}
 }
 
-// TestRun_SucceedsOnConcreteInstalledBinaryPath covers the reviewer concern from
-// #4449: when LookPath can't see the target on PATH but the fallback produced
-// the exact binary at InstalledBinaryPath, run() must report success instead of
-// a false "still not in PATH" failure.
-func TestRun_SucceedsOnConcreteInstalledBinaryPath(t *testing.T) {
+// TestRun_SucceedsWhenInstalledBinaryRuns covers the reviewer concern from
+// #4449: merely existing on disk is not enough — run() must confirm the
+// installed binary actually executes, and register its directory on the current
+// process PATH so child shells spawned from this already-running daemon inherit
+// it, before reporting success.
+func TestRun_SucceedsWhenInstalledBinaryRuns(t *testing.T) {
 	s := newTestService("windows") // no winget -> gh resolves to the direct-download fallback
 	plan := s.planFor(TargetGH)
 	if plan.Unsupported {
@@ -245,34 +250,60 @@ func TestRun_SucceedsOnConcreteInstalledBinaryPath(t *testing.T) {
 	if err := os.WriteFile(binPath, []byte("fake"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	plan.InstalledBinaryPath = binPath // emulate a successful download landing the file
-	s.commands = testCommandRunner(func(context.Context, []string) *exec.Cmd { return exec.Command("true") })
+	plan.InstalledBinaryPath = binPath
+
+	var ran [][]string
+	s.commands = commandRunnerFunc(func(_ context.Context, argv []string, _, _ io.Writer) error {
+		ran = append(ran, argv)
+		return nil // install script and the version probe both "succeed"
+	})
+	origPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", origPath)
 
 	job := &Job{Target: TargetGH}
 	s.run(plan, job)
 	if job.Status != StatusSucceeded {
 		t.Fatalf("Status = %q, want %q (error=%q)", job.Status, StatusSucceeded, job.Error)
 	}
+	if len(ran) != 2 {
+		t.Fatalf("commands run = %d (%v), want 2 (install then version probe)", len(ran), ran)
+	}
+	probe := ran[len(ran)-1]
+	if probe[0] != binPath || len(probe) != 2 || probe[1] != "--version" {
+		t.Fatalf("probe argv = %v, want [%s --version]", probe, binPath)
+	}
+	if !strings.Contains(os.Getenv("PATH"), filepath.Dir(binPath)) {
+		t.Fatalf("PATH = %q, want it to include %s for child processes spawned from this daemon", os.Getenv("PATH"), filepath.Dir(binPath))
+	}
 }
 
-// TestRun_FailsWhenConcreteBinaryMissing confirms that if neither PATH nor the
-// recorded binary path yields the installed tool, the job is reported failed
-// (and the error names the missing path so the user sees what went wrong).
-func TestRun_FailsWhenConcreteBinaryMissing(t *testing.T) {
+// TestRun_FailsWhenInstalledBinaryCannotRun confirms that if neither PATH nor a
+// runnable installed binary yields the tool, the job is reported failed (and
+// the error names the missing binary so the user sees what went wrong).
+func TestRun_FailsWhenInstalledBinaryCannotRun(t *testing.T) {
 	s := newTestService("windows")
 	plan := s.planFor(TargetGH)
 	if plan.InstalledBinaryPath == "" {
 		t.Fatal("want InstalledBinaryPath set by the fallback")
 	}
-	plan.InstalledBinaryPath = filepath.Join(t.TempDir(), "does-not-exist-gh.exe")
-	s.commands = testCommandRunner(func(context.Context, []string) *exec.Cmd { return exec.Command("true") })
+	missing := filepath.Join(t.TempDir(), "does-not-exist-gh.exe")
+	plan.InstalledBinaryPath = missing
+
+	s.commands = commandRunnerFunc(func(_ context.Context, argv []string, _, _ io.Writer) error {
+		if argv[0] == plan.Command[0] {
+			return nil // install script succeeds
+		}
+		return errors.New("exec: no such file or directory") // version probe of the missing binary fails
+	})
+	origPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", origPath)
 
 	job := &Job{Target: TargetGH}
 	s.run(plan, job)
 	if job.Status != StatusFailed {
 		t.Fatalf("Status = %q, want %q", job.Status, StatusFailed)
 	}
-	if !strings.Contains(job.Error, plan.InstalledBinaryPath) {
+	if !strings.Contains(job.Error, missing) {
 		t.Fatalf("Error = %q, want it to name the missing binary path", job.Error)
 	}
 }

--- a/backend/internal/service/systeminstall/systeminstall_test.go
+++ b/backend/internal/service/systeminstall/systeminstall_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -215,6 +217,63 @@ func TestGHWindowsFallsBackToDirectDownload(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("download script missing %q:\n%s", want, script)
 		}
+	}
+	// The plan must record the exact binary it installs so run() can confirm
+	// success even when the destination isn't on the daemon's PATH (#4449).
+	if plan.InstalledBinaryPath == "" {
+		t.Fatal("InstalledBinaryPath is empty, want the concrete gh.exe path")
+	}
+	if !strings.Contains(plan.InstalledBinaryPath, "WindowsApps") || !strings.HasSuffix(plan.InstalledBinaryPath, "gh.exe") {
+		t.Fatalf("InstalledBinaryPath = %q, want a WindowsApps/gh.exe path", plan.InstalledBinaryPath)
+	}
+}
+
+// TestRun_SucceedsOnConcreteInstalledBinaryPath covers the reviewer concern from
+// #4449: when LookPath can't see the target on PATH but the fallback produced
+// the exact binary at InstalledBinaryPath, run() must report success instead of
+// a false "still not in PATH" failure.
+func TestRun_SucceedsOnConcreteInstalledBinaryPath(t *testing.T) {
+	s := newTestService("windows") // no winget -> gh resolves to the direct-download fallback
+	plan := s.planFor(TargetGH)
+	if plan.Unsupported {
+		t.Fatalf("Unsupported = true, want the download fallback plan")
+	}
+	if plan.InstalledBinaryPath == "" {
+		t.Fatal("InstalledBinaryPath is empty, want the concrete gh.exe path for the fallback")
+	}
+	binPath := filepath.Join(t.TempDir(), "gh.exe")
+	if err := os.WriteFile(binPath, []byte("fake"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	plan.InstalledBinaryPath = binPath // emulate a successful download landing the file
+	s.commands = testCommandRunner(func(context.Context, []string) *exec.Cmd { return exec.Command("true") })
+
+	job := &Job{Target: TargetGH}
+	s.run(plan, job)
+	if job.Status != StatusSucceeded {
+		t.Fatalf("Status = %q, want %q (error=%q)", job.Status, StatusSucceeded, job.Error)
+	}
+}
+
+// TestRun_FailsWhenConcreteBinaryMissing confirms that if neither PATH nor the
+// recorded binary path yields the installed tool, the job is reported failed
+// (and the error names the missing path so the user sees what went wrong).
+func TestRun_FailsWhenConcreteBinaryMissing(t *testing.T) {
+	s := newTestService("windows")
+	plan := s.planFor(TargetGH)
+	if plan.InstalledBinaryPath == "" {
+		t.Fatal("want InstalledBinaryPath set by the fallback")
+	}
+	plan.InstalledBinaryPath = filepath.Join(t.TempDir(), "does-not-exist-gh.exe")
+	s.commands = testCommandRunner(func(context.Context, []string) *exec.Cmd { return exec.Command("true") })
+
+	job := &Job{Target: TargetGH}
+	s.run(plan, job)
+	if job.Status != StatusFailed {
+		t.Fatalf("Status = %q, want %q", job.Status, StatusFailed)
+	}
+	if !strings.Contains(job.Error, plan.InstalledBinaryPath) {
+		t.Fatalf("Error = %q, want it to name the missing binary path", job.Error)
 	}
 }
 

--- a/backend/internal/service/systeminstall/systeminstall_test.go
+++ b/backend/internal/service/systeminstall/systeminstall_test.go
@@ -97,12 +97,20 @@ func TestPlanFor(t *testing.T) {
 			wantUnsupported: true, wantReasonHas: "No supported Linux package manager",
 		},
 		{
-			name: "gh windows uses winget", target: TargetGH, goos: "windows", found: []string{"winget"},
-			wantCommand: []string{"winget", "install", "-e", "--id", "GitHub.cli"},
+			name: "gh windows uses pinned winget source", target: TargetGH, goos: "windows", found: []string{"winget"},
+			wantCommand: []string{
+				"winget", "install", "-e", "--id", "GitHub.cli",
+				"--source", "winget",
+				"--accept-package-agreements",
+				"--accept-source-agreements",
+			},
 		},
 		{
-			name: "gh windows without winget is unsupported", target: TargetGH, goos: "windows",
-			wantUnsupported: true, wantReasonHas: "winget was not found",
+			// gh without winget no longer dead-ends as Unsupported; the
+			// direct-download fallback is covered in detail by
+			// TestGHWindowsFallsBackToDirectDownload below.
+			name: "gh windows without winget still resolves a runnable plan", target: TargetGH, goos: "windows",
+			wantCommand: nil,
 		},
 		{
 			name: "gh darwin uses brew", target: TargetGH, goos: "darwin", found: []string{"brew"},
@@ -129,8 +137,21 @@ func TestPlanFor(t *testing.T) {
 			wantCommand: []string{"npm", "install", "-g", "@github/copilot"},
 		},
 		{
-			name: "opencode windows uses winget", target: TargetOpencode, goos: "windows", found: []string{"winget"},
-			wantCommand: []string{"winget", "install", "-e", "--id", "SST.opencode"},
+			name: "opencode windows uses pinned winget source", target: TargetOpencode, goos: "windows", found: []string{"winget"},
+			wantCommand: []string{
+				"winget", "install", "-e", "--id", "SST.opencode",
+				"--source", "winget",
+				"--accept-package-agreements",
+				"--accept-source-agreements",
+			},
+		},
+		{
+			// The direct-download fallback is gh-only: opencode on Windows
+			// still requires winget, so a missing winget must stay Unsupported
+			// with the manual remedy rather than silently changing install
+			// routes for this target.
+			name: "opencode windows without winget is unsupported", target: TargetOpencode, goos: "windows",
+			wantUnsupported: true, wantReasonHas: "winget was not found",
 		},
 		{
 			name: "opencode darwin uses the curl pipeline via bash", target: TargetOpencode, goos: "darwin", found: []string{"curl", "bash"},
@@ -168,6 +189,32 @@ func TestPlanFor(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGHWindowsFallsBackToDirectDownload pins the shape of the no-winget gh
+// plan: a hardcoded, fully non-interactive PowerShell run that downloads the
+// official windows_amd64 zip from cli/cli GitHub Releases and copies
+// bin\*.exe into %LOCALAPPDATA%\Microsoft\WindowsApps — on the default
+// per-user PATH, so the post-run LookPath verification succeeds without
+// registry edits or shell restarts (#4449).
+func TestGHWindowsFallsBackToDirectDownload(t *testing.T) {
+	plan := newTestService("windows").planFor(TargetGH)
+	if plan.Unsupported {
+		t.Fatalf("Unsupported = true, want a runnable fallback plan (reason=%q)", plan.Reason)
+	}
+	if got := strings.Join(plan.Command, " "); !strings.HasPrefix(got, "powershell -NoProfile -NonInteractive") {
+		t.Fatalf("Command = %v, want a non-interactive powershell invocation", plan.Command)
+	}
+	script := plan.Command[len(plan.Command)-1]
+	for _, want := range []string{
+		"https://api.github.com/repos/cli/cli/releases/latest",
+		"gh_*_windows_amd64.zip",
+		"Microsoft\\WindowsApps",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("download script missing %q:\n%s", want, script)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #4449.

## What happens today

On a completely fresh Windows machine, `planWinget` resolved to a bare `winget install -e --id <id>`. With no source pinned, winget also queries the **msstore** source — which on a fresh profile has never been initialized, so its first use blocks on an interactive Y/N prompt (Terms of Transaction + 2-letter region consent). The daemon runs installs via `systemexec` with no TTY attached, so the prompt can never be answered and winget exits:

```text
Do you agree to all the source agreements terms? [Y] Yes [N] No:
An unexpected error occurred while executing the command: 0x8a150042 : Error reading input in prompt
```

`0x8A150042` = `APPINSTALLER_CLI_ERROR_PROMPT_INPUT_ERROR`. Every fresh-Windows user clicking Install on the "No coding agent found" screen got a guaranteed-failing job, forever retryable, never succeeding. Upstream reference: microsoft/winget-cli#2819 (same prompt, same code path in any non-interactive session).

## The fix (layered options 1 + 3 from the issue)

**1. Pin winget to its community source (`planWinget`)**

```text
winget install -e --id <id> --source winget --accept-package-agreements --accept-source-agreements
```

`--source winget` bypasses msstore entirely for both Windows targets (`GitHub.cli`, `SST.opencode`), and the accept flags make sure no remaining source/package agreement prompt can ever block a headless run. This is deterministic — it doesn't depend on per-user winget state at all.

**3. Direct-download fallback when winget is absent (`planGHWindows`)**

A machine without winget on PATH previously dead-ended as Unsupported ("winget was not found"). Since a truly fresh machine can't be assumed to have winget either, `gh` now falls back to a hardcoded PowerShell script that:

- fetches the latest release metadata from `api.github.com/repos/cli/cli/releases/latest`,
- downloads the official `gh_<ver>_windows_amd64.zip`,
- copies `bin\*.exe` into `%LOCALAPPDATA%\Microsoft\WindowsApps` — already on the default per-user PATH, so the installer's post-run `LookPath("gh")` verification succeeds with no registry edits or shell restarts,
- cleans up staging files.

Same security invariant as the rest of the package: the script is a package-level constant; no caller-supplied string ever reaches the argv. The fallback is deliberately gh-only — `opencode` without winget stays Unsupported (pinned by test).

## Tests

- Updated `TestPlanFor`: winget rows assert the full pinned argv; new row pins that opencode-without-winget remains Unsupported.
- New `TestGHWindowsFallsBackToDirectDownload`: pins that the no-winget gh plan is runnable, non-interactive (`-NoProfile -NonInteractive`), and targets the official cli/cli releases + `WindowsApps` destination.
- `go test ./internal/service/systeminstall/...`, `go vet`, `golangci-lint v2.12.2` all pass.

Note: `TestCrushLocalAuthStatusDoesNotUseProviderCatalog` in `internal/adapters/agent/crush` fails on clean `upstream/main` too (verified by stashing this change) — pre-existing and untouched here.
