### PR TITLE
feat: add agent mode to chat picker

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -201,7 +201,28 @@ func normalizeConfigOptions(options []acpsdk.SessionConfigOption) []ports.ChatCo
 			})
 		}
 	}
+	addAgentModeChoice(out)
 	return out
+}
+
+// Some ACP providers expose their normal operating mode only implicitly when
+// they advertise Plan. Keep the standard Agent mode available in that case so
+// the chat picker can leave planning and return to normal execution.
+func addAgentModeChoice(options []ports.ChatConfigOption) {
+	for i := range options {
+		option := &options[i]
+		if option.Type != ports.ChatConfigOptionSelect || (option.Category != "mode" && option.ID != "mode") {
+			continue
+		}
+		hasPlan, hasAgent := false, false
+		for _, choice := range option.Choices {
+			hasPlan = hasPlan || choice.Value == "plan"
+			hasAgent = hasAgent || choice.Value == "agent"
+		}
+		if hasPlan && !hasAgent {
+			option.Choices = append(option.Choices, ports.ChatConfigOptionChoice{Value: "agent", Name: "Agent"})
+		}
+	}
 }
 
 func normalizeSessionOptions(
@@ -238,6 +259,7 @@ func normalizeSessionOptions(
 			Current: ports.ChatConfigOptionValue{Select: string(modes.CurrentModeId)}, Choices: choices,
 		})
 	}
+	addAgentModeChoice(out)
 	return out
 }
 

--- a/backend/internal/adapters/chatdriver/acp/config_options_test.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options_test.go
@@ -80,6 +80,20 @@ func TestReplaceConfigOptionsReplacesWholesale(t *testing.T) {
 	}
 }
 
+func TestNormalizeSessionOptionsAddsAgentAlongsidePlan(t *testing.T) {
+	options := normalizeSessionOptions(nil, nil, &acpsdk.SessionModeState{
+		CurrentModeId:  "plan",
+		AvailableModes: []acpsdk.SessionMode{{Id: "plan", Name: "Plan"}},
+	})
+
+	if len(options) != 1 || len(options[0].Choices) != 2 {
+		t.Fatalf("mode options = %#v, want Plan and Agent", options)
+	}
+	if options[0].Choices[1].Value != "agent" || options[0].Choices[1].Name != "Agent" {
+		t.Fatalf("mode choices = %#v, want Agent appended", options[0].Choices)
+	}
+}
+
 // The bug this guards: an agent accepts session/set_config_option but answers
 // without the rebuilt catalog. Wiping made the picker vanish; returning the
 // pre-change catalog would show the old value for a change the agent already

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
@@ -30,7 +30,10 @@ const OPTIONS: ChatConfigOption[] = [
 		category: "mode",
 		type: "select",
 		currentValue: "ask",
-		choices: [{ value: "ask", name: "Ask before edits" }],
+		choices: [
+			{ value: "ask", name: "Ask before edits" },
+			{ value: "agent", name: "Agent" },
+		],
 	},
 	{
 		id: "fast",
@@ -72,6 +75,9 @@ describe("ACP session config options", () => {
 		expect(screen.queryByText("Default")).not.toBeInTheDocument();
 		expect(screen.queryByText("Provider default")).not.toBeInTheDocument();
 
+		await user.click(screen.getByRole("button", { name: "Permission mode" }));
+		expect(screen.getByRole("menuitem", { name: "Agent" })).toBeInTheDocument();
+		await user.keyboard("{Escape}");
 		await user.click(
 			screen.getByRole("button", { name: "Model and reasoning effort for the next turn" }),
 		);


### PR DESCRIPTION
## Summary

- add Agent alongside Plan when an ACP provider exposes Plan as its only explicit mode
- normalize the option at the ACP boundary so the displayed choice is also accepted when selected
- cover backend normalization and frontend menu rendering

## Verification

- `cd backend && go test ./internal/adapters/chatdriver/acp`
- `cd frontend && npx vitest run --config vite.renderer.config.ts src/renderer/components/chat/TurnSettingsBar.test.tsx`
- frontend typecheck is blocked in this isolated worktree by existing unresolved `packages/product-ui` dependencies/types