### PR TITLE
fix(chat): surface normalized provider error detail and action link

### DIFF
--- a/frontend/src/renderer/components/chat/ChatProviderSignal.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatProviderSignal.test.tsx
@@ -319,7 +319,13 @@ describe("provider error", () => {
 			/>,
 		);
 		expect(screen.getByText("Reconnecting... [1/5]")).toBeInTheDocument();
-		expect(screen.queryByText(/You have no credits remaining/i)).not.toBeInTheDocument();
+		// The reconnect headline stays, and the causal detail behind it surfaces too.
+		expect(screen.getByText(/You have no credits remaining/i)).toBeInTheDocument();
+		const action = screen.getByRole("link", { name: "Add credits" });
+		expect(action).toHaveAttribute(
+			"href",
+			"https://platform.openai.com/settings/organization/billing",
+		);
 		// The raw envelope must not paint as the row label — that is what overflowed the column.
 		expect(screen.queryByText(/codexErrorInfo/i)).not.toBeInTheDocument();
 		expect(screen.queryByText(/provider error:/i)).not.toBeInTheDocument();
@@ -341,7 +347,12 @@ describe("provider error", () => {
 			/>,
 		);
 		expect(screen.getByText("Reconnecting... [1/5]")).toBeInTheDocument();
-		expect(screen.queryByText(/You have no credits remaining/i)).not.toBeInTheDocument();
+		// The already-normalized detail carries the recovery action, not the reconnect noise.
+		expect(screen.getByText(/You have no credits remaining/i)).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Add credits" })).toHaveAttribute(
+			"href",
+			"https://platform.openai.com/settings/organization/billing",
+		);
 		expect(screen.queryByText(/codexErrorInfo/i)).not.toBeInTheDocument();
 	});
 
@@ -356,6 +367,44 @@ describe("provider error", () => {
 			/>,
 		);
 		expect(screen.getByText(/no credits remaining/i)).toBeInTheDocument();
+	});
+
+	it("never linkifies an unknown host's URL in the failure detail", () => {
+		render(
+			<ActivityRow
+				activity={activity({
+					activityKind: "error",
+					status: "failed",
+					summary: "Request failed",
+					detail: {
+						message: "Request failed",
+						error: "quota exceeded. Visit https://evil.example.com/steal-credits to fix it",
+					},
+				})}
+			/>,
+		);
+		// The detail still shows — escaped plain text, not a clickable surface.
+		expect(screen.getByText(/quota exceeded/i)).toBeInTheDocument();
+		expect(screen.getByText(/evil\.example\.com/)).toBeInTheDocument();
+		expect(screen.queryByRole("link")).not.toBeInTheDocument();
+	});
+
+	it("does not offer the billing action for a look-alike path on the real host", () => {
+		render(
+			<ActivityRow
+				activity={activity({
+					activityKind: "error",
+					status: "failed",
+					summary: "Request failed",
+					detail: {
+						message: "Request failed",
+						error:
+							"You have no credits remaining. See https://platform.openai.com/settings/organization/billing/other",
+					},
+				})}
+			/>,
+		);
+		expect(screen.queryByRole("link", { name: "Add credits" })).not.toBeInTheDocument();
 	});
 
 	it("stays inside the chat column instead of widening it", () => {

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -52,6 +52,7 @@ const activityIcon: Record<ActivityKind, typeof SquareTerminal> = {
 import { cn } from "../../lib/utils";
 import { caretNotation, stripAnsi } from "../../lib/ansi";
 import { getApiBaseUrl } from "../../lib/api-client";
+import { openLinkInSystemBrowser } from "../../lib/external-link-policy";
 import { ChatMarkdown } from "./ChatMarkdown";
 import { HighlightedCode } from "./HighlightedCode";
 import { CopyButton } from "./CopyButton";
@@ -1411,12 +1412,74 @@ function RerouteRow({ activity }: { activity: ConversationActivity }) {
  * reconnect row as `role="alert"` would interrupt a screen reader once per attempt.
  */
 function ErrorActivityRow({ activity }: { activity: ConversationActivity }) {
-	const { headline } = providerErrorCopy(activity);
+	const { headline, detail } = providerErrorCopy(activity);
+	const action = providerErrorAction(detail);
 	return (
 		<div className="flex min-w-0 max-w-full items-baseline overflow-hidden py-0.5 text-[11.5px] leading-snug text-muted-foreground">
-			<span className="wrap-anywhere min-w-0">{headline}</span>
+			<span className="wrap-anywhere min-w-0">
+				<span>{headline}</span>
+				{detail ? (
+					<>
+						{" — "}
+						{/* React escapes this, so unknown provider text stays inert text. */}
+						<span className="text-muted-foreground/80">{detail}</span>
+					</>
+				) : null}
+				{action ? (
+					<>
+						{" "}
+						<a
+							href={action.href}
+							target="_blank"
+							rel="noreferrer noopener"
+							onClick={(event) => {
+								event.preventDefault();
+								void openLinkInSystemBrowser(action.href);
+							}}
+							className="text-markdown-link underline decoration-markdown-link/45 underline-offset-2 transition-colors hover:text-markdown-link-hover hover:decoration-markdown-link-hover/75"
+						>
+							{action.label}
+						</a>
+					</>
+				) : null}
+			</span>
 		</div>
 	);
+}
+
+/**
+ * The one action a normalized provider error may offer, and where it may point.
+ *
+ * Provider envelopes carry arbitrary URLs; making any of them clickable would turn
+ * stored failure text into a phishing surface. Only hosts allow-listed here, on their
+ * known billing path, become an action — everything else stays plain escaped text.
+ */
+const providerErrorActions: Array<{ host: string; path: string; label: string }> = [
+	{
+		host: "platform.openai.com",
+		path: "/settings/organization/billing",
+		label: "Add credits",
+	},
+];
+
+export function providerErrorAction(
+	detail?: string,
+): { label: string; href: string } | undefined {
+	if (!detail) return undefined;
+	for (const match of detail.matchAll(/https?:\/\/[^\s)\]>]+/g)) {
+		let url: URL;
+		try {
+			url = new URL(match[0]);
+		} catch {
+			continue;
+		}
+		for (const allowed of providerErrorActions) {
+			if (url.host === allowed.host && url.pathname === allowed.path) {
+				return { label: allowed.label, href: url.href };
+			}
+		}
+	}
+	return undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes #4431

## Problem

`providerErrorCopy()` already unwraps Codex JSON error envelopes (including truncated, `provider error: `-prefixed ones) and returns `{ headline, detail }`, where `detail` carries the actionable part — e.g. "You have no credits remaining. Add credits to continue using the API at https://platform.openai.com/settings/organization/billing". But `ErrorActivityRow` destructured only `headline`, so users saw the generic reconnect copy while the recovery action was silently dropped. The tests explicitly asserted that absence.

## Change

- **`ErrorActivityRow`** now renders:
  - the headline (in its own span, keeping it a single text node for queries),
  - the normalized `detail` as escaped plain text below it — unknown/untrusted provider text stays inert,
  - a constrained action link when one applies.
- **New `providerErrorAction()` helper**: scans detail for URLs but only linkifies an allow-listed host + exact path (`platform.openai.com/settings/organization/billing` → "Add credits"). Arbitrary provider URLs are never made clickable (no phishing surface); look-alike paths on the real host do not trigger the action. Links open via the existing `openLinkInSystemBrowser` external-link policy.
- **Tests** flipped from asserting the credits detail is absent to asserting it renders with the correct `href`, plus two new cases: an unknown host's URL stays non-clickable, and a look-alike billing path produces no action.

## Verification

- `npx vitest run src/renderer/components/chat/ChatProviderSignal.test.tsx` — 35 passed
- `npx vitest run src/renderer/components/chat` — 20 files, 340 tests passed
- `npm run typecheck` — only the pre-existing `motion/react` error in `packages/product-ui`, which reproduces on clean `main` and is unrelated to this change.

Branch based on upstream `main` at `c9a0adb21`.
