### PR TITLE
fix(runtime): recover owned legacy tmux sessions after desktop update

### DIFF
--- a/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
+++ b/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
@@ -41,7 +41,10 @@ var _ Runtime = (*conpty.Runtime)(nil)
 // terminal runtime state.
 func New(_ *slog.Logger, runFilePath string) Runtime {
 	if runtime.GOOS != "windows" {
-		return tmux.New(tmux.Options{SocketPath: privateTmuxSocketPath(runFilePath)})
+		return tmux.New(tmux.Options{
+			SocketPath:  privateTmuxSocketPath(runFilePath),
+			RunFilePath: runFilePath,
+		})
 	}
 	return conpty.New(conpty.Options{RunFilePath: runFilePath})
 }

--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -99,6 +99,14 @@ func listPanePIDsArgs(id string) []string {
 	return []string{"list-panes", "-s", "-t", exactSessionTarget(id), "-F", "#{pane_pid}"}
 }
 
+// paneStartCommandsArgs returns the immutable command tmux recorded for every
+// pane in a session. Legacy-socket adoption uses it as provenance: sessions
+// created by AO before the private-socket cutover carry the AO run-file,
+// session id, supervised-process marker, and supervisor launch id here.
+func paneStartCommandsArgs(id string) []string {
+	return []string{"list-panes", "-s", "-t", exactSessionTarget(id), "-F", "#{pane_start_command}"}
+}
+
 // sendKeysLiteralArgs builds args for `tmux send-keys -t <id> -l <chunk>`.
 // The -l flag stops tmux interpreting words like "Enter" as key names so the
 // text is sent verbatim.

--- a/backend/internal/adapters/runtime/tmux/environment.go
+++ b/backend/internal/adapters/runtime/tmux/environment.go
@@ -33,12 +33,12 @@ func (r *Runtime) syncCurrentEnvironment(ctx context.Context, sessionID string, 
 		{scope: "session", args: []string{"show-environment", "-t", exactSessionTarget(sessionID)}},
 	}
 	for _, query := range queries {
-		out, err := r.run(ctx, query.args...)
+		out, err := r.runForSession(ctx, sessionID, query.args...)
 		if err != nil {
 			if serverUnreachableOutput(string(out)) {
-				return fmt.Errorf("private tmux server unavailable while refreshing session %s", sessionID)
+				return fmt.Errorf("tmux server unavailable while refreshing session %s", sessionID)
 			}
-			return fmt.Errorf("inspect private tmux %s environment %s: %w", query.scope, sessionID, err)
+			return fmt.Errorf("inspect tmux %s environment %s: %w", query.scope, sessionID, err)
 		}
 		for _, key := range parseTmuxEnvironmentNames(string(out)) {
 			names[key] = struct{}{}
@@ -49,8 +49,8 @@ func (r *Runtime) syncCurrentEnvironment(ctx context.Context, sessionID string, 
 	if script == "" {
 		return nil
 	}
-	if _, err := r.runWithInput(ctx, []byte(script), "source-file", "-"); err != nil {
-		return fmt.Errorf("apply private tmux environment: %w", err)
+	if _, err := r.runWithInputForSession(ctx, sessionID, []byte(script), "source-file", "-"); err != nil {
+		return fmt.Errorf("apply tmux session environment: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -47,25 +48,36 @@ var sessionIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 var getenv = os.Getenv
 
-// Options configures a tmux Runtime. SocketPath is required: AO must always use
-// an explicitly managed server socket and must never fall back to tmux's
-// per-user default server.
+// Options configures a tmux Runtime. SocketPath is required for every newly
+// created session. RunFilePath enables ownership-verified adoption of sessions
+// created by this AO instance before the private-socket cutover.
 type Options struct {
-	Binary     string        // default configured/bundled/system tmux resolution
-	SocketPath string        // required private socket path, passed to every tmux client with -S
-	Shell      string        // default $SHELL else /bin/sh
-	Timeout    time.Duration // default 5s
-	ChunkSize  int           // default 16*1024
-	EnterDelay time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
-	ReapGrace  time.Duration // grace between SIGTERM and SIGKILL when reaping a pane's leftover background processes on Destroy; default defaultReapGrace.
+	Binary       string        // default configured/bundled/system tmux resolution
+	LegacyBinary string        // system tmux compatible with the historical default-socket server
+	SocketPath   string        // required private socket path, passed to every new-session client with -S
+	RunFilePath  string        // current absolute running.json path; empty disables legacy adoption
+	Shell        string        // default $SHELL else /bin/sh
+	Timeout      time.Duration // default 5s
+	ChunkSize    int           // default 16*1024
+	EnterDelay   time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
+	ReapGrace    time.Duration // grace between SIGTERM and SIGKILL when reaping a pane's leftover background processes on Destroy; default defaultReapGrace.
 }
+
+type sessionRoute uint8
+
+const (
+	routePrivate sessionRoute = iota
+	routeLegacyDefault
+)
 
 // Runtime runs agent sessions inside tmux sessions, driving them via the tmux
 // CLI. It implements ports.Runtime.
 type Runtime struct {
 	binary           string
 	binaryResolveErr error
+	legacyBinary     string
 	socketPath       string
+	runFilePath      string
 	shell            string
 	timeout          time.Duration
 	chunkSize        int
@@ -74,10 +86,14 @@ type Runtime struct {
 	runner           runner
 	reapSessions     func(ctx context.Context, pids []int, grace time.Duration)
 	syncEnvironment  func(ctx context.Context, sessionID string, configured map[string]string) error
+	routeMu          sync.RWMutex
+	sessionRoutes    map[string]sessionRoute
+	legacyLaunchIDs  map[string]string
 }
 
 var _ ports.Runtime = (*Runtime)(nil)
 var _ ports.Attacher = (*Runtime)(nil)
+var _ ports.RuntimeIdentityInspector = (*Runtime)(nil)
 
 type runner interface {
 	Run(ctx context.Context, env []string, stdin []byte, name string, args ...string) ([]byte, error)
@@ -293,10 +309,19 @@ func New(opts Options) *Runtime {
 	if reapGrace <= 0 {
 		reapGrace = defaultReapGrace
 	}
+	legacyBinary := strings.TrimSpace(opts.LegacyBinary)
+	runFilePath := strings.TrimSpace(opts.RunFilePath)
+	if runFilePath != "" && legacyBinary == "" {
+		if systemTmux, err := exec.LookPath("tmux"); err == nil {
+			legacyBinary = systemTmux
+		}
+	}
 	runtime := &Runtime{
 		binary:           binary,
 		binaryResolveErr: binaryResolveErr,
+		legacyBinary:     legacyBinary,
 		socketPath:       opts.SocketPath,
+		runFilePath:      runFilePath,
 		shell:            shellPath,
 		timeout:          timeout,
 		chunkSize:        chunkSize,
@@ -304,6 +329,8 @@ func New(opts Options) *Runtime {
 		reapGrace:        reapGrace,
 		runner:           execRunner{},
 		reapSessions:     killSessionsByPID,
+		sessionRoutes:    make(map[string]sessionRoute),
+		legacyLaunchIDs:  make(map[string]string),
 	}
 	runtime.syncEnvironment = runtime.syncCurrentEnvironment
 	return runtime
@@ -334,13 +361,14 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 	if _, err := r.run(ctx, args...); err != nil {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: create session %s: %w", id, err)
 	}
+	r.rememberSessionRoute(id, routePrivate, "")
 	handle := ports.RuntimeHandle{ID: id}
 	if err := r.syncEnvironment(ctx, id, cfg.Env); err != nil {
 		_ = r.Destroy(context.Background(), handle)
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: refresh environment for session %s: %w", id, err)
 	}
 	launchCmd := buildLaunchCommand(cfg)
-	if _, err := r.run(ctx, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
+	if _, err := r.runForSession(ctx, id, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
 		_ = r.Destroy(context.Background(), handle)
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: launch session %s: %w", id, err)
 	}
@@ -412,7 +440,7 @@ func (r *Runtime) Restart(ctx context.Context, handle ports.RuntimeHandle, cfg p
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: refresh environment for session %s: %w", id, err)
 	}
 	launchCmd := buildLaunchCommand(cfg)
-	if _, err := r.run(ctx, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
+	if _, err := r.runForSession(ctx, id, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: restart session %s: %w", id, err)
 	}
 	alive, err := r.IsAlive(ctx, handle)
@@ -492,7 +520,7 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	// not block the kill-session below.
 	sessionIDs := r.paneSessionIDs(ctx, id)
 
-	out, err := r.run(ctx, killSessionArgs(id)...)
+	out, err := r.runForSession(ctx, id, killSessionArgs(id)...)
 	// Reap regardless of the kill-session result: orphaned children outlive the
 	// session, so they must be cleaned up even when the session was already
 	// gone (a benign double-kill).
@@ -501,10 +529,12 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && killSessionMissingOutput(string(out)) {
+			r.forgetSessionRoute(id)
 			return nil
 		}
 		return fmt.Errorf("tmux runtime: destroy session %s: %w", id, err)
 	}
+	r.forgetSessionRoute(id)
 	return nil
 }
 
@@ -514,7 +544,7 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 // any error (including a missing session) or unparseable line yields no ids,
 // and pids <= 1 are skipped so we never signal init or the "current session".
 func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
-	out, err := r.run(ctx, listPanePIDsArgs(id)...)
+	out, err := r.runForSession(ctx, id, listPanePIDsArgs(id)...)
 	if err != nil {
 		return nil
 	}
@@ -541,7 +571,7 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 	if err != nil {
 		return false, err
 	}
-	out, err := r.run(ctx, hasSessionArgs(id)...)
+	out, err := r.runForSession(ctx, id, hasSessionArgs(id)...)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -572,7 +602,11 @@ func (r *Runtime) IsSupervisedProcessAlive(ctx context.Context, handle ports.Run
 	if err != nil {
 		return false, err
 	}
-	return containsManagedWorkload(entries, panePID, string(ref.SessionID), ref.LaunchID), nil
+	alive := containsManagedWorkload(entries, panePID, string(ref.SessionID), ref.LaunchID)
+	if !alive && containsSupervisorForSession(entries, panePID, string(ref.SessionID)) {
+		return false, fmt.Errorf("tmux runtime: supervised generation differs for session %s: %w", ref.SessionID, ports.ErrRuntimeProbeInconclusive)
+	}
+	return alive, nil
 }
 
 // IsExactSupervisedProcessAlive reports only the AO supervisor matching ref
@@ -596,7 +630,7 @@ func (r *Runtime) supervisedProcessTree(ctx context.Context, handle ports.Runtim
 	if err != nil {
 		return nil, 0, err
 	}
-	paneOut, err := r.run(ctx, panePIDArgs(id)...)
+	paneOut, err := r.runForSession(ctx, id, panePIDArgs(id)...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("tmux runtime: inspect pane pid %s: %w", id, err)
 	}
@@ -633,7 +667,7 @@ func (r *Runtime) SendMessage(ctx context.Context, handle ports.RuntimeHandle, m
 		sendCtx := ctx
 		var finishCancel context.CancelFunc
 		for i, chunk := range messageChunks {
-			if _, err := r.run(sendCtx, sendKeysLiteralArgs(id, chunk)...); err != nil {
+			if _, err := r.runForSession(sendCtx, id, sendKeysLiteralArgs(id, chunk)...); err != nil {
 				if finishCancel != nil {
 					finishCancel()
 				}
@@ -669,7 +703,7 @@ func (r *Runtime) SendMessage(ctx context.Context, handle ports.RuntimeHandle, m
 			}
 		}
 	}
-	if _, err := r.run(enterCtx, sendEnterArgs(id)...); err != nil {
+	if _, err := r.runForSession(enterCtx, id, sendEnterArgs(id)...); err != nil {
 		return fmt.Errorf("tmux runtime: send enter %s: %w", id, err)
 	}
 	return nil
@@ -686,7 +720,7 @@ func (r *Runtime) Interrupt(ctx context.Context, handle ports.RuntimeHandle) err
 	if err != nil {
 		return err
 	}
-	if _, err := r.run(ctx, sendInterruptArgs(id)...); err != nil {
+	if _, err := r.runForSession(ctx, id, sendInterruptArgs(id)...); err != nil {
 		return fmt.Errorf("tmux runtime: interrupt session %s: %w", id, err)
 	}
 	return nil
@@ -700,7 +734,7 @@ func (r *Runtime) SendInput(ctx context.Context, handle ports.RuntimeHandle, inp
 		return err
 	}
 	args := sendKeysLiteralArgs(id, input)
-	if _, err := r.run(ctx, args...); err != nil {
+	if _, err := r.runForSession(ctx, id, args...); err != nil {
 		return fmt.Errorf("tmux runtime: send input %s: %w", id, err)
 	}
 	return nil
@@ -716,7 +750,7 @@ func (r *Runtime) GetOutput(ctx context.Context, handle ports.RuntimeHandle, lin
 	if lines <= 0 {
 		return "", errors.New("tmux runtime: lines must be positive")
 	}
-	out, err := r.run(ctx, capturePaneArgs(id, lines)...)
+	out, err := r.runForSession(ctx, id, capturePaneArgs(id, lines)...)
 	if err != nil {
 		return "", fmt.Errorf("tmux runtime: capture output %s: %w", id, err)
 	}
@@ -732,7 +766,7 @@ func (r *Runtime) GetStyledOutput(ctx context.Context, handle ports.RuntimeHandl
 	if lines <= 0 {
 		return "", errors.New("tmux runtime: lines must be positive")
 	}
-	out, err := r.run(ctx, capturePaneStyledArgs(id, lines)...)
+	out, err := r.runForSession(ctx, id, capturePaneStyledArgs(id, lines)...)
 	if err != nil {
 		return "", fmt.Errorf("tmux runtime: capture styled output %s: %w", id, err)
 	}
@@ -743,7 +777,15 @@ func (r *Runtime) GetStyledOutput(ctx context.Context, handle ports.RuntimeHandl
 // local PTY, sized rows x cols from birth when known. ctx cancellation closes
 // the PTY.
 func (r *Runtime) Attach(ctx context.Context, handle ports.RuntimeHandle, rows, cols uint16) (ports.Stream, error) {
-	argv, err := r.attachCommand(handle)
+	id, err := handleID(handle)
+	if err != nil {
+		return nil, err
+	}
+	route, err := r.routeForSession(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("tmux runtime: attach session %s: %w", id, err)
+	}
+	argv, err := r.attachCommandForRoute(id, route)
 	if err != nil {
 		return nil, err
 	}
@@ -776,11 +818,23 @@ func (r *Runtime) attachCommand(handle ports.RuntimeHandle) ([]string, error) {
 	// The embedded xterm renderer supports 24-bit SGR colors. Tell this tmux
 	// client explicitly so tmux forwards RGB instead of quantizing it to the
 	// xterm-256color palette. -T is available in AO's minimum tmux version (3.2).
-	args, err := r.managedArgs("-u", "-T", "RGB", "attach-session", "-t", id)
+	return r.attachCommandForRoute(id, routePrivate)
+}
+
+func (r *Runtime) attachCommandForRoute(id string, route sessionRoute) ([]string, error) {
+	args := []string{"-u", "-T", "RGB", "attach-session", "-t", id}
+	if route == routeLegacyDefault {
+		managed, err := r.legacyArgs(args...)
+		if err != nil {
+			return nil, err
+		}
+		return append([]string{r.legacyBinary}, managed...), nil
+	}
+	managed, err := r.managedArgs(args...)
 	if err != nil {
 		return nil, err
 	}
-	return append([]string{r.binary}, args...), nil
+	return append([]string{r.binary}, managed...), nil
 }
 
 // controlEnv returns the complete environment for tmux control and attach
@@ -829,6 +883,197 @@ func (r *Runtime) managedArgs(args ...string) ([]string, error) {
 	return append(managed, args...), nil
 }
 
+func (r *Runtime) legacyArgs(args ...string) ([]string, error) {
+	if strings.TrimSpace(r.legacyBinary) == "" {
+		return nil, fmt.Errorf("%w: system tmux is unavailable for legacy default-socket inspection", ports.ErrRuntimeProbeInconclusive)
+	}
+	managed := make([]string, 0, 4+len(args))
+	managed = append(managed, "-L", "default", "-f", os.DevNull)
+	return append(managed, args...), nil
+}
+
+// routeForSession selects one socket/client pair for the daemon lifetime. The
+// private socket always wins. Crossing to tmux's historical default socket is
+// allowed only when the private runtime definitively lacks the handle and the
+// legacy pane proves it was launched by this AO run-file identity.
+func (r *Runtime) routeForSession(ctx context.Context, id string) (sessionRoute, error) {
+	r.routeMu.RLock()
+	route, ok := r.sessionRoutes[id]
+	r.routeMu.RUnlock()
+	if ok {
+		return route, nil
+	}
+	if r.runFilePath == "" {
+		return routePrivate, nil
+	}
+
+	privateOut, privateErr := r.run(ctx, hasSessionArgs(id)...)
+	if privateErr == nil {
+		r.rememberSessionRoute(id, routePrivate, "")
+		return routePrivate, nil
+	}
+	if ctx.Err() != nil {
+		return routePrivate, ctx.Err()
+	}
+	if !privateSessionDefinitelyAbsent(string(privateOut)) {
+		// Preserve the private target for protocol, permission, and transient
+		// failures. The actual operation will surface its classifiable error.
+		return routePrivate, nil
+	}
+	if r.legacyBinary == "" {
+		return routePrivate, fmt.Errorf(
+			"%w: cannot inspect legacy default-socket session %s because system tmux is unavailable",
+			ports.ErrRuntimeProbeInconclusive,
+			id,
+		)
+	}
+
+	legacyOut, legacyErr := r.runOnLegacy(ctx, nil, hasSessionArgs(id)...)
+	if legacyErr == nil {
+		launchID, owned, err := r.inspectLegacyPaneIdentity(ctx, id)
+		if err != nil {
+			return routePrivate, err
+		}
+		if !owned {
+			return routePrivate, fmt.Errorf(
+				"%w: default-socket session %s does not carry this AO run-file provenance",
+				ports.ErrRuntimeProbeInconclusive,
+				id,
+			)
+		}
+		// Close the only meaningful selection race: a post-update session with
+		// this name may have appeared on the private socket while provenance was
+		// inspected. Private always wins, so adopt legacy only after a second
+		// conclusive private absence.
+		privateOut, privateErr = r.run(ctx, hasSessionArgs(id)...)
+		if privateErr == nil {
+			r.rememberSessionRoute(id, routePrivate, "")
+			return routePrivate, nil
+		}
+		if ctx.Err() != nil {
+			return routePrivate, ctx.Err()
+		}
+		if !privateSessionDefinitelyAbsent(string(privateOut)) {
+			return routePrivate, fmt.Errorf(
+				"%w: private tmux session %s changed while inspecting its legacy predecessor: %v",
+				ports.ErrRuntimeProbeInconclusive,
+				id,
+				privateErr,
+			)
+		}
+		r.rememberSessionRoute(id, routeLegacyDefault, launchID)
+		return routeLegacyDefault, nil
+	}
+	if ctx.Err() != nil {
+		return routePrivate, ctx.Err()
+	}
+	if sessionMissingOutput(string(legacyOut)) || serverNotRunningOutput(string(legacyOut)) {
+		// Both known sockets conclusively lack the handle. Keep the private route
+		// so the caller preserves the ordinary missing-session/no-server result.
+		return routePrivate, nil
+	}
+	return routePrivate, fmt.Errorf(
+		"%w: system tmux %q could not inspect legacy default-socket session %s: %v",
+		ports.ErrRuntimeProbeInconclusive,
+		r.legacyBinary,
+		id,
+		legacyErr,
+	)
+}
+
+func privateSessionDefinitelyAbsent(out string) bool {
+	return sessionMissingOutput(out) || serverNotRunningOutput(out) || privateSocketMissingOutput(out)
+}
+
+// A never-started explicit -S server is reported by tmux as an error
+// connecting to a nonexistent socket, not as "no server running". This exact
+// ENOENT form is conclusive for the private socket at the instant of the probe;
+// other connection failures remain inconclusive. routeForSession re-probes
+// after legacy provenance inspection to close a concurrent-create race.
+func privateSocketMissingOutput(out string) bool {
+	s := strings.ToLower(out)
+	return strings.Contains(s, "error connecting") && strings.Contains(s, "no such file or directory")
+}
+
+func (r *Runtime) inspectLegacyPaneIdentity(ctx context.Context, id string) (string, bool, error) {
+	out, err := r.runOnLegacy(ctx, nil, paneStartCommandsArgs(id)...)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: inspect legacy pane provenance for %s: %v", ports.ErrRuntimeProbeInconclusive, id, err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) != 1 {
+		return "", false, nil
+	}
+	launchID, owned := legacyPaneIdentity(lines[0], id, r.runFilePath)
+	return launchID, owned, nil
+}
+
+func legacyPaneIdentity(command, id, runFilePath string) (string, bool) {
+	required := []string{
+		"export AO_RUN_FILE=" + shellQuote(runFilePath) + ";",
+		"export AO_SESSION_ID=" + shellQuote(id) + ";",
+		"export AO_SUPERVISED_PROCESS='1';",
+	}
+	for _, fragment := range required {
+		if !strings.Contains(command, fragment) {
+			return "", false
+		}
+	}
+	pattern := regexp.MustCompile(
+		`'agent-process'\s+'supervise'\s+'--session'\s+'` + regexp.QuoteMeta(id) + `'\s+'--launch'\s+'([^']+)'`,
+	)
+	match := pattern.FindStringSubmatch(command)
+	if len(match) != 2 || strings.TrimSpace(match[1]) == "" {
+		return "", false
+	}
+	return match[1], true
+}
+
+func (r *Runtime) rememberSessionRoute(id string, route sessionRoute, launchID string) {
+	r.routeMu.Lock()
+	r.sessionRoutes[id] = route
+	if route == routeLegacyDefault && launchID != "" {
+		r.legacyLaunchIDs[id] = launchID
+	} else {
+		delete(r.legacyLaunchIDs, id)
+	}
+	r.routeMu.Unlock()
+}
+
+func (r *Runtime) forgetSessionRoute(id string) {
+	r.routeMu.Lock()
+	delete(r.sessionRoutes, id)
+	delete(r.legacyLaunchIDs, id)
+	r.routeMu.Unlock()
+}
+
+// InspectRuntimeIdentity returns the launch generation recovered while proving
+// ownership of a pre-cutover default-socket pane. Private sessions already use
+// the durable generation written during Create/Restart and need no repair.
+func (r *Runtime) InspectRuntimeIdentity(ctx context.Context, handle ports.RuntimeHandle, sessionID domain.SessionID) (ports.RuntimeIdentity, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return ports.RuntimeIdentity{}, err
+	}
+	if id != string(sessionID) {
+		return ports.RuntimeIdentity{}, fmt.Errorf("tmux runtime: identity handle %s does not match session %s", id, sessionID)
+	}
+	route, err := r.routeForSession(ctx, id)
+	if err != nil {
+		return ports.RuntimeIdentity{}, err
+	}
+	if route != routeLegacyDefault {
+		return ports.RuntimeIdentity{}, nil
+	}
+	r.routeMu.RLock()
+	launchID := r.legacyLaunchIDs[id]
+	r.routeMu.RUnlock()
+	if launchID == "" {
+		return ports.RuntimeIdentity{}, fmt.Errorf("%w: adopted legacy session %s has no supervisor generation", ports.ErrRuntimeProbeInconclusive, id)
+	}
+	return ports.RuntimeIdentity{LaunchID: launchID, Legacy: true}, nil
+}
+
 // run wraps runner.Run with a per-call timeout context.
 func (r *Runtime) run(ctx context.Context, args ...string) ([]byte, error) {
 	return r.runWithInput(ctx, nil, args...)
@@ -842,6 +1087,29 @@ func (r *Runtime) runWithInput(ctx context.Context, input []byte, args ...string
 		return nil, err
 	}
 	return r.runCommandWithInput(ctx, input, r.binary, managed...)
+}
+
+func (r *Runtime) runForSession(ctx context.Context, id string, args ...string) ([]byte, error) {
+	return r.runWithInputForSession(ctx, id, nil, args...)
+}
+
+func (r *Runtime) runWithInputForSession(ctx context.Context, id string, input []byte, args ...string) ([]byte, error) {
+	route, err := r.routeForSession(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if route == routeLegacyDefault {
+		return r.runOnLegacy(ctx, input, args...)
+	}
+	return r.runWithInput(ctx, input, args...)
+}
+
+func (r *Runtime) runOnLegacy(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+	managed, err := r.legacyArgs(args...)
+	if err != nil {
+		return nil, err
+	}
+	return r.runCommandWithInput(ctx, input, r.legacyBinary, managed...)
 }
 
 func (r *Runtime) runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
@@ -925,6 +1193,23 @@ func containsManagedWorkload(entries []processEntry, rootPID int, sessionID, lau
 	// supervisor remains, the pane root is the preserved interactive shell and
 	// any child is a workload the operator launched from that shell.
 	return hasChild && !hasSupervisor
+}
+
+func containsSupervisorForSession(entries []processEntry, rootPID int, sessionID string) bool {
+	descendants := descendantPIDs(entries, rootPID)
+	for _, entry := range entries {
+		if entry.pid == rootPID || !descendants[entry.pid] {
+			continue
+		}
+		fields := strings.Fields(entry.command)
+		for i := 0; i+3 < len(fields); i++ {
+			if fields[i] == "agent-process" && fields[i+1] == "supervise" &&
+				fields[i+2] == "--session" && fields[i+3] == sessionID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func containsExactSupervisedWorkload(entries []processEntry, rootPID int, sessionID, launchID string) bool {

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -955,7 +955,7 @@ func (r *Runtime) routeForSession(ctx context.Context, id string) (sessionRoute,
 		}
 		if !privateSessionDefinitelyAbsent(string(privateOut)) {
 			return routePrivate, fmt.Errorf(
-				"%w: private tmux session %s changed while inspecting its legacy predecessor: %v",
+				"%w: private tmux session %s changed while inspecting its legacy predecessor: %w",
 				ports.ErrRuntimeProbeInconclusive,
 				id,
 				privateErr,
@@ -973,7 +973,7 @@ func (r *Runtime) routeForSession(ctx context.Context, id string) (sessionRoute,
 		return routePrivate, nil
 	}
 	return routePrivate, fmt.Errorf(
-		"%w: system tmux %q could not inspect legacy default-socket session %s: %v",
+		"%w: system tmux %q could not inspect legacy default-socket session %s: %w",
 		ports.ErrRuntimeProbeInconclusive,
 		r.legacyBinary,
 		id,
@@ -998,7 +998,7 @@ func privateSocketMissingOutput(out string) bool {
 func (r *Runtime) inspectLegacyPaneIdentity(ctx context.Context, id string) (string, bool, error) {
 	out, err := r.runOnLegacy(ctx, nil, paneStartCommandsArgs(id)...)
 	if err != nil {
-		return "", false, fmt.Errorf("%w: inspect legacy pane provenance for %s: %v", ports.ErrRuntimeProbeInconclusive, id, err)
+		return "", false, fmt.Errorf("%w: inspect legacy pane provenance for %s: %w", ports.ErrRuntimeProbeInconclusive, id, err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	if len(lines) != 1 {

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -382,11 +382,101 @@ func TestRuntimeIntegrationUsesAliasForLongPrivateSocket(t *testing.T) {
 	waitForOutput(t, r, handle, "alias-ok", 5*time.Second)
 }
 
+// TestRuntimeIntegrationAdoptsLegacyDefaultSocketAcrossPrivateSocketUpgrade
+// models the desktop update boundary which moved AO from the system tmux
+// default socket to its hashed private socket. The old, ownership-stamped pane
+// must remain reachable while every newly-created session stays isolated on
+// the private socket.
+func TestRuntimeIntegrationAdoptsLegacyDefaultSocketAcrossPrivateSocketUpgrade(t *testing.T) {
+	systemTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not available")
+	}
+
+	// Never inspect or mutate the developer's real default server. TMUX_TMPDIR
+	// gives this test an isolated server which still exercises tmux's -L default
+	// naming path exactly as an upgraded desktop install does.
+	legacySocketRoot, err := os.MkdirTemp("", "ao-legacy-")
+	if err != nil {
+		t.Fatalf("create isolated legacy socket directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(legacySocketRoot) })
+	t.Setenv("TMUX_TMPDIR", legacySocketRoot)
+	ctx := context.Background()
+	runFile := filepath.Join(t.TempDir(), "running.json")
+	r := New(Options{
+		Binary:       systemTmux,
+		LegacyBinary: systemTmux,
+		SocketPath:   integrationSocketPath(t),
+		RunFilePath:  runFile,
+		Timeout:      5 * time.Second,
+	})
+	base := strings.ReplaceAll(t.Name(), "/", "_")
+	legacyID := base + "_legacy"
+	privateID := base + "_private"
+	const legacyLaunchID = "launch-before-update"
+
+	legacyCommand := "cd " + shellQuote(t.TempDir()) + " || exit; " +
+		"export AO_RUN_FILE=" + shellQuote(runFile) + "; " +
+		"export AO_SESSION_ID=" + shellQuote(legacyID) + "; " +
+		"export AO_SUPERVISED_PROCESS='1'; " +
+		"export AO_TMUX_LEGACY_UPGRADE_HELPER='1'; " +
+		shellQuote(os.Args[0]) + " '-test.run=TestLegacyUpgradeProcessHelper' '--' " +
+		"'agent-process' 'supervise' '--session' " + shellQuote(legacyID) +
+		" '--launch' " + shellQuote(legacyLaunchID) + " '--'"
+	if out, createErr := r.runOnLegacy(ctx, nil, newSessionArgs(legacyID, t.TempDir(), "/bin/sh", legacyCommand)...); createErr != nil {
+		t.Fatalf("create isolated legacy session: %v: %s", createErr, out)
+	}
+	t.Cleanup(func() {
+		_, _ = r.runOnLegacy(context.Background(), nil, killSessionArgs(legacyID)...)
+	})
+
+	legacyHandle := ports.RuntimeHandle{ID: legacyID}
+	if alive, aliveErr := r.IsAlive(ctx, legacyHandle); aliveErr != nil || !alive {
+		t.Fatalf("legacy IsAlive = (%v, %v), want (true, nil)", alive, aliveErr)
+	}
+	waitForOutput(t, r, legacyHandle, "legacy-upgrade-ready", 5*time.Second)
+	identity, err := r.InspectRuntimeIdentity(ctx, legacyHandle, domain.SessionID(legacyID))
+	if err != nil || !identity.Legacy || identity.LaunchID != legacyLaunchID {
+		t.Fatalf("legacy identity = (%+v, %v), want launch %q", identity, err, legacyLaunchID)
+	}
+	attachArgv, err := r.attachCommandForRoute(legacyID, routeLegacyDefault)
+	if err != nil || len(attachArgv) < 5 || attachArgv[0] != systemTmux || attachArgv[1] != "-L" || attachArgv[2] != "default" {
+		t.Fatalf("legacy attach argv = (%#v, %v), want system tmux -L default", attachArgv, err)
+	}
+
+	privateHandle, err := r.Create(ctx, ports.RuntimeConfig{
+		SessionID:     domain.SessionID(privateID),
+		WorkspacePath: t.TempDir(),
+		Argv:          []string{"/bin/sh", "-c", "printf 'private-upgrade-ready\\n'; sleep 30"},
+	})
+	if err != nil {
+		t.Fatalf("create private post-update session: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Destroy(context.Background(), privateHandle) })
+	waitForOutput(t, r, privateHandle, "private-upgrade-ready", 5*time.Second)
+
+	if out, probeErr := r.run(ctx, hasSessionArgs(legacyID)...); probeErr == nil || !sessionMissingOutput(string(out)) {
+		t.Fatalf("legacy session unexpectedly exists on private socket: (%q, %v)", out, probeErr)
+	}
+	if out, probeErr := r.runOnLegacy(ctx, nil, hasSessionArgs(privateID)...); probeErr == nil || !sessionMissingOutput(string(out)) {
+		t.Fatalf("new session unexpectedly exists on legacy socket: (%q, %v)", out, probeErr)
+	}
+}
+
 func TestSupervisorProcessHelper(t *testing.T) {
 	if os.Getenv("AO_TMUX_SUPERVISOR_HELPER") != "1" {
 		return
 	}
 	time.Sleep(2 * time.Second)
+}
+
+func TestLegacyUpgradeProcessHelper(t *testing.T) {
+	if os.Getenv("AO_TMUX_LEGACY_UPGRADE_HELPER") != "1" {
+		return
+	}
+	_, _ = os.Stdout.WriteString("legacy-upgrade-ready\n")
+	time.Sleep(30 * time.Second)
 }
 
 func integrationSocketPath(t *testing.T) string {

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -788,7 +788,7 @@ func TestRestartRejectsMismatchedSessionHandle(t *testing.T) {
 	}
 }
 
-func TestIsAliveNeverProbesDefaultSocket(t *testing.T) {
+func TestIsAliveNeverProbesDefaultSocketWhenLegacyAdoptionIsDisabled(t *testing.T) {
 	r := New(Options{Binary: "tmux-test", SocketPath: testSocketPath, Timeout: time.Second})
 	fr := &fakeRunnerSequence{results: []fakeRunnerResult{{
 		out: []byte("can't find session: sess-1"), err: &exec.ExitError{},
@@ -806,6 +806,142 @@ func TestIsAliveNeverProbesDefaultSocket(t *testing.T) {
 	want := append([]string{"-S", testSocketPath, "-f", os.DevNull}, hasSessionArgs("sess-1")...)
 	if !reflect.DeepEqual(fr.calls[0].args, want) {
 		t.Fatalf("args = %#v, want %#v", fr.calls[0].args, want)
+	}
+}
+
+func legacyOwnedPaneCommand(runFile, sessionID, launchID string) string {
+	return `/bin/zsh -c "cd '/tmp/worktree' || exit; ` +
+		"export AO_RUN_FILE=" + shellQuote(runFile) + "; " +
+		"export AO_SESSION_ID=" + shellQuote(sessionID) + "; " +
+		"export AO_SUPERVISED_PROCESS='1'; " +
+		"'/Applications/Agent Orchestrator.app/Contents/Resources/daemon/ao' 'agent-process' 'supervise' " +
+		"'--session' " + shellQuote(sessionID) + " '--launch' " + shellQuote(launchID) + " '--' 'codex'" + `"`
+}
+
+func TestIsAliveAdoptsOwnershipVerifiedLegacyDefaultSession(t *testing.T) {
+	const (
+		runFile  = "/tmp/ao/running.json"
+		session  = "sess-1"
+		launchID = "legacy-launch"
+	)
+	r := New(Options{
+		Binary:       "bundled-tmux",
+		LegacyBinary: "system-tmux",
+		SocketPath:   testSocketPath,
+		RunFilePath:  runFile,
+		Timeout:      time.Second,
+	})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
+		{out: []byte("can't find session: " + session), err: &exec.ExitError{}},
+		{},
+		{out: []byte(legacyOwnedPaneCommand(runFile, session, launchID) + "\n")},
+		{out: []byte("can't find session: " + session), err: &exec.ExitError{}},
+		{},
+	}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: session})
+	if err != nil || !alive {
+		t.Fatalf("IsAlive = (%v, %v), want (true, nil)", alive, err)
+	}
+	identity, err := r.InspectRuntimeIdentity(context.Background(), ports.RuntimeHandle{ID: session}, session)
+	if err != nil || !identity.Legacy || identity.LaunchID != launchID {
+		t.Fatalf("identity = (%+v, %v), want legacy launch %q", identity, err, launchID)
+	}
+	if len(fr.calls) != 5 {
+		t.Fatalf("calls = %d, want private probe + legacy probe/provenance + private race probe + final probe", len(fr.calls))
+	}
+	if fr.calls[0].name != "bundled-tmux" || fr.calls[1].name != "system-tmux" || fr.calls[2].name != "system-tmux" || fr.calls[3].name != "bundled-tmux" || fr.calls[4].name != "system-tmux" {
+		t.Fatalf("client routing = %q, %q, %q, %q, %q", fr.calls[0].name, fr.calls[1].name, fr.calls[2].name, fr.calls[3].name, fr.calls[4].name)
+	}
+	for _, call := range []runnerCall{fr.calls[1], fr.calls[2], fr.calls[4]} {
+		if len(call.args) < 4 || !reflect.DeepEqual(call.args[:4], []string{"-L", "default", "-f", os.DevNull}) {
+			t.Fatalf("legacy args = %#v, want explicit default socket and empty config", call.args)
+		}
+	}
+}
+
+func TestIsAliveRejectsSameNamedForeignLegacySession(t *testing.T) {
+	r := New(Options{
+		Binary:       "bundled-tmux",
+		LegacyBinary: "system-tmux",
+		SocketPath:   testSocketPath,
+		RunFilePath:  "/tmp/ao/running.json",
+		Timeout:      time.Second,
+	})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
+		{out: []byte("can't find session: sess-1"), err: &exec.ExitError{}},
+		{},
+		{out: []byte("/bin/zsh -c 'exec user-shell'\n")},
+	}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if alive || !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("IsAlive = (%v, %v), want inconclusive foreign collision", alive, err)
+	}
+}
+
+func TestPrivateSessionWinsOverSameNamedLegacySession(t *testing.T) {
+	r := New(Options{
+		Binary:       "bundled-tmux",
+		LegacyBinary: "system-tmux",
+		SocketPath:   testSocketPath,
+		RunFilePath:  "/tmp/ao/running.json",
+		Timeout:      time.Second,
+	})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{{}, {}}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if err != nil || !alive {
+		t.Fatalf("IsAlive = (%v, %v), want private live session", alive, err)
+	}
+	if len(fr.calls) != 2 || fr.calls[0].name != "bundled-tmux" || fr.calls[1].name != "bundled-tmux" {
+		t.Fatalf("calls = %#v, want private client only", fr.calls)
+	}
+}
+
+func TestPrivateSessionAppearingDuringLegacyInspectionWins(t *testing.T) {
+	const (
+		runFile = "/tmp/ao/running.json"
+		session = "sess-1"
+	)
+	r := New(Options{
+		Binary:       "bundled-tmux",
+		LegacyBinary: "system-tmux",
+		SocketPath:   testSocketPath,
+		RunFilePath:  runFile,
+		Timeout:      time.Second,
+	})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
+		{out: []byte("can't find session: " + session), err: &exec.ExitError{}},
+		{},
+		{out: []byte(legacyOwnedPaneCommand(runFile, session, "legacy-launch") + "\n")},
+		{}, // A private session appeared before adoption was committed.
+		{}, // IsAlive's routed probe remains private.
+	}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: session})
+	if err != nil || !alive {
+		t.Fatalf("IsAlive = (%v, %v), want private live session", alive, err)
+	}
+	if len(fr.calls) != 5 || fr.calls[3].name != "bundled-tmux" || fr.calls[4].name != "bundled-tmux" {
+		t.Fatalf("calls = %#v, want private race probe and final private probe", fr.calls)
+	}
+}
+
+func TestLegacyPaneIdentityRequiresExactRunFileAndSupervisor(t *testing.T) {
+	command := legacyOwnedPaneCommand("/tmp/ao/running.json", "sess-1", "launch-1")
+	if launchID, ok := legacyPaneIdentity(command, "sess-1", "/tmp/ao/running.json"); !ok || launchID != "launch-1" {
+		t.Fatalf("legacyPaneIdentity = (%q, %v), want launch-1, true", launchID, ok)
+	}
+	if _, ok := legacyPaneIdentity(command, "sess-1", "/tmp/other/running.json"); ok {
+		t.Fatal("pane with another AO run-file identity was accepted")
+	}
+	if _, ok := legacyPaneIdentity(strings.Replace(command, "'agent-process'", "'other-process'", 1), "sess-1", "/tmp/ao/running.json"); ok {
+		t.Fatal("pane without the AO supervisor was accepted")
 	}
 }
 

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -1006,6 +1006,46 @@ func (m *Manager) MarkSpawned(ctx context.Context, id domain.SessionID, metadata
 	return nil
 }
 
+// ReconcileRuntimeIdentity repairs the durable generation after boot adopts an
+// ownership-verified pre-private-socket runtime. The expected handle and launch
+// form a compare-and-swap fence: a concurrent restore, switch, or kill wins and
+// this stale observation becomes a no-op.
+func (m *Manager) ReconcileRuntimeIdentity(
+	ctx context.Context,
+	id domain.SessionID,
+	expectedHandleID string,
+	expectedLaunchID string,
+	actualLaunchID string,
+) error {
+	actualLaunchID = strings.TrimSpace(actualLaunchID)
+	if actualLaunchID == "" {
+		return errors.New("lifecycle: reconciled runtime launch id is required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("lifecycle: reconcile runtime identity for unknown session %q", id)
+	}
+	if rec.IsTerminated || rec.Metadata.RuntimeHandleID != expectedHandleID ||
+		rec.Metadata.RuntimeLaunchID != expectedLaunchID {
+		return nil
+	}
+	if rec.Metadata.RuntimeLaunchID == actualLaunchID {
+		return nil
+	}
+	rec.Metadata.RuntimeLaunchID = actualLaunchID
+	if rec.Metadata.AgentSessionID != "" &&
+		(rec.Metadata.AgentSessionIDLaunchID == "" || rec.Metadata.AgentSessionIDLaunchID == expectedLaunchID) {
+		rec.Metadata.AgentSessionIDLaunchID = actualLaunchID
+	}
+	rec.UpdatedAt = m.clock()
+	return m.store.UpdateSession(ctx, rec)
+}
+
 // CommitControllerEpoch atomically changes which controller owns a live
 // session. Session Manager coordinates the external-process saga, but only
 // Lifecycle Manager is allowed to write the durable controller/activity facts.

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -1580,6 +1580,44 @@ func TestMarkSpawnedStoresRuntimeMetadata(t *testing.T) {
 	}
 }
 
+func TestReconcileRuntimeIdentityRepairsMatchingLiveGeneration(t *testing.T) {
+	store := newFakeStore()
+	store.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1",
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID:        "mer-1",
+			RuntimeLaunchID:        "stale-launch",
+			AgentSessionID:         "native-1",
+			AgentSessionIDLaunchID: "stale-launch",
+		},
+	}
+	m := New(store, nil)
+
+	if err := m.ReconcileRuntimeIdentity(ctx, "mer-1", "mer-1", "stale-launch", "legacy-live-launch"); err != nil {
+		t.Fatal(err)
+	}
+	got := store.sessions["mer-1"]
+	if got.Metadata.RuntimeLaunchID != "legacy-live-launch" || got.Metadata.AgentSessionIDLaunchID != "legacy-live-launch" {
+		t.Fatalf("metadata = %+v", got.Metadata)
+	}
+}
+
+func TestReconcileRuntimeIdentityIgnoresStaleObservation(t *testing.T) {
+	store := newFakeStore()
+	store.sessions["mer-1"] = domain.SessionRecord{
+		ID:       "mer-1",
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "mer-1", RuntimeLaunchID: "newer-launch"},
+	}
+	m := New(store, nil)
+
+	if err := m.ReconcileRuntimeIdentity(ctx, "mer-1", "mer-1", "stale-launch", "legacy-live-launch"); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.sessions["mer-1"].Metadata.RuntimeLaunchID; got != "newer-launch" {
+		t.Fatalf("launch id = %q, want newer-launch", got)
+	}
+}
+
 func TestMarkSpawnedPersistsAndPreservesDiffBase(t *testing.T) {
 	m, st, _ := newManager()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true}

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -153,6 +153,21 @@ type ExactSupervisedProcessInspector interface {
 	IsExactSupervisedProcessAlive(ctx context.Context, handle RuntimeHandle, ref SupervisedProcessRef) (bool, error)
 }
 
+// RuntimeIdentity is provenance recovered from a surviving runtime during an
+// upgrade. Legacy is true only after the adapter has proved that the runtime
+// belongs to this AO run-file identity rather than a same-named user session.
+type RuntimeIdentity struct {
+	LaunchID string
+	Legacy   bool
+}
+
+// RuntimeIdentityInspector is an optional upgrade capability. It lets boot
+// reconciliation repair a stale durable generation after safely adopting a
+// pre-private-socket runtime that survived one or more desktop updates.
+type RuntimeIdentityInspector interface {
+	InspectRuntimeIdentity(ctx context.Context, handle RuntimeHandle, sessionID domain.SessionID) (RuntimeIdentity, error)
+}
+
 // ContainerReaper removes Docker containers a worker session owns, identified
 // by the ao.session=<id> label convention (see EnvSessionID). It is an
 // optional capability: nil wiring means container reaping is a no-op, not an

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -234,6 +234,16 @@ type lifecycleRecorder interface {
 	MarkTerminated(ctx context.Context, id domain.SessionID) error
 }
 
+type runtimeIdentityReconciler interface {
+	ReconcileRuntimeIdentity(
+		ctx context.Context,
+		id domain.SessionID,
+		expectedHandleID string,
+		expectedLaunchID string,
+		actualLaunchID string,
+	) error
+}
+
 // ShellTerminalCloser gates a session's scoped shell terminals around every
 // path that releases its worktree (Kill, Cleanup, RetireForReplacement, the
 // reconcile/shutdown save-and-teardown path), so none of them removes a
@@ -2265,6 +2275,9 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 				return fmt.Errorf("reconcile %s: probe: %w", rec.ID, err)
 			}
 			if alive {
+				if err := m.reconcileSurvivingRuntimeIdentity(ctx, rec, handle); err != nil {
+					return fmt.Errorf("reconcile %s: runtime identity: %w", rec.ID, err)
+				}
 				return nil // adopt: the session survived the crash.
 			}
 		}
@@ -2296,6 +2309,36 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 		}
 	}
 	return nil
+}
+
+func (m *Manager) reconcileSurvivingRuntimeIdentity(
+	ctx context.Context,
+	rec domain.SessionRecord,
+	handle ports.RuntimeHandle,
+) error {
+	inspector, ok := m.runtime.(ports.RuntimeIdentityInspector)
+	if !ok {
+		return nil
+	}
+	identity, err := inspector.InspectRuntimeIdentity(ctx, handle, rec.ID)
+	if err != nil {
+		return err
+	}
+	if !identity.Legacy || strings.TrimSpace(identity.LaunchID) == "" ||
+		identity.LaunchID == rec.Metadata.RuntimeLaunchID {
+		return nil
+	}
+	reconciler, ok := m.lcm.(runtimeIdentityReconciler)
+	if !ok {
+		return errors.New("lifecycle manager cannot reconcile an adopted legacy runtime identity")
+	}
+	return reconciler.ReconcileRuntimeIdentity(
+		ctx,
+		rec.ID,
+		rec.Metadata.RuntimeHandleID,
+		rec.Metadata.RuntimeLaunchID,
+		identity.LaunchID,
+	)
 }
 
 func (m *Manager) liveRelaunchCommitted(ctx context.Context, before domain.SessionRecord) (bool, error) {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -170,6 +170,27 @@ type fakeLCM struct {
 	cancelled []string
 	// terminated counts MarkTerminated calls per session id.
 	terminated map[domain.SessionID]int
+	reconciled []string
+}
+
+func (l *fakeLCM) ReconcileRuntimeIdentity(
+	_ context.Context,
+	id domain.SessionID,
+	expectedHandleID string,
+	expectedLaunchID string,
+	actualLaunchID string,
+) error {
+	l.reconciled = append(l.reconciled, string(id)+":"+expectedHandleID+":"+expectedLaunchID+":"+actualLaunchID)
+	rec := l.store.sessions[id]
+	if rec.IsTerminated || rec.Metadata.RuntimeHandleID != expectedHandleID || rec.Metadata.RuntimeLaunchID != expectedLaunchID {
+		return nil
+	}
+	rec.Metadata.RuntimeLaunchID = actualLaunchID
+	if rec.Metadata.AgentSessionID != "" && rec.Metadata.AgentSessionIDLaunchID == expectedLaunchID {
+		rec.Metadata.AgentSessionIDLaunchID = actualLaunchID
+	}
+	l.store.sessions[id] = rec
+	return nil
 }
 
 func (l *fakeLCM) PrepareLaunch(id domain.SessionID, launchID string) error {
@@ -274,6 +295,11 @@ type fakeRuntime struct {
 	supervisedAliveOverride *bool
 	supervisedSequence      []bool
 	destroyedIDs            []string
+	identities              map[string]ports.RuntimeIdentity
+}
+
+func (r *fakeRuntime) InspectRuntimeIdentity(_ context.Context, handle ports.RuntimeHandle, _ domain.SessionID) (ports.RuntimeIdentity, error) {
+	return r.identities[handle.ID], nil
 }
 
 func (r *fakeRuntime) Interrupt(_ context.Context, handle ports.RuntimeHandle) error {
@@ -7402,6 +7428,42 @@ func TestReconcileLive_AliveSessionAdoptedNoop(t *testing.T) {
 	}
 	if ws.stashCalls != 0 || lcm.terminated["s2"] != 0 || rt.destroyed != 0 {
 		t.Fatalf("adopt should be a no-op: stash=%d term=%d destroy=%d", ws.stashCalls, lcm.terminated["s2"], rt.destroyed)
+	}
+}
+
+func TestReconcileLive_RepairsAdoptedLegacyLaunchIdentity(t *testing.T) {
+	st := newFakeStore()
+	rt := &fakeRuntime{
+		aliveByHandle: map[string]bool{"s2": true},
+		identities: map[string]ports.RuntimeIdentity{
+			"s2": {Legacy: true, LaunchID: "legacy-live-launch"},
+		},
+	}
+	ws := &fakeWorkspace{}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st, Messenger: &fakeMessenger{}, Lifecycle: lcm})
+
+	rec := domain.SessionRecord{
+		ID: "s2", ProjectID: "p1",
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/s2/root", WorkspacePath: "/wt/s2", RuntimeHandleID: "s2",
+			RuntimeLaunchID: "stale-db-launch", AgentSessionID: "native-1", AgentSessionIDLaunchID: "stale-db-launch",
+		},
+	}
+	st.sessions[rec.ID] = rec
+
+	if err := m.reconcileLive(context.Background(), rec); err != nil {
+		t.Fatalf("reconcileLive: %v", err)
+	}
+	got := st.sessions[rec.ID]
+	if got.Metadata.RuntimeLaunchID != "legacy-live-launch" || got.Metadata.AgentSessionIDLaunchID != "legacy-live-launch" {
+		t.Fatalf("reconciled metadata = %+v", got.Metadata)
+	}
+	if len(lcm.reconciled) != 1 {
+		t.Fatalf("identity reconciliations = %v, want one", lcm.reconciled)
+	}
+	if ws.stashCalls != 0 || rt.destroyed != 0 {
+		t.Fatalf("adoption mutated runtime/workspace: stash=%d destroy=%d", ws.stashCalls, rt.destroyed)
 	}
 }
 

--- a/docs/daemon-environment.md
+++ b/docs/daemon-environment.md
@@ -13,7 +13,11 @@ cannot see API keys. Packaged macOS/Linux builds carry their own tmux and do
 not depend on a machine installation; development and standalone daemon runs
 still resolve tmux from `PATH`. On Unix, every daemon derives an explicit
 AO-private `tmux -S` socket from its run-file identity, starts tmux without the
-user's tmux configuration, and never probes the default socket. The socket
+user's tmux configuration, and creates every new session there. During the
+private-socket upgrade bridge, an existing session may be recovered from the
+system tmux default socket only when its immutable pane start command proves
+the same AO run-file, session id, supervised marker, and launch generation;
+same-named user sessions fail closed. The socket
 inode stays beside the run file; deeply nested state paths use a validated,
 bounded, owner-only `/tmp` directory alias to satisfy macOS's Unix-socket path
 limit. Socket paths are canonicalized and fail closed if their directory or an
@@ -196,7 +200,10 @@ it. We shell out once to the user's own shell and adopt its result.
   without tmux on `PATH`; confirm a new session spawns and attaches through the
   bundled `resources/tmux/bin/tmux` on the daemon's explicit private socket,
   while `git`/agent binaries still resolve. Confirm a user `~/.tmux.conf` is
-  ignored and sessions on tmux's default socket are not discovered.
+  ignored. In an isolated `TMUX_TMPDIR`, confirm an ownership-stamped session
+  from the historical default socket remains attachable after upgrade, its
+  durable launch generation is repaired, a foreign same-named session is not
+  adopted, and all post-upgrade sessions stay on the private socket.
 
 ## Relevant code
 
@@ -213,7 +220,8 @@ it. We shell out once to the user's own shell and adopt its result.
   `AO_TMUX_BINARY`; standalone runs fall back to `exec.LookPath("tmux")`. The
   daemon derives its explicit private `-S` socket from the run-file identity,
   ignores user tmux configuration, refreshes the workload environment per pane,
-  and never probes tmux's default socket. A value-free bootstrap pane lets the
+  and uses the system tmux client only for ownership-verified recovery of
+  pre-cutover default-socket sessions. A value-free bootstrap pane lets the
   adapter apply project environment values over stdin before launching the real
   command.
 - `backend/internal/observe/reaper/reaper.go`,

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -28,8 +28,12 @@ on `main`; the PR-based flow below supersedes it.
   stages that binary in versioned storage under the AO data directory; this
   keeps it available after a Linux AppImage mount disappears. The daemon
   derives an explicit AO-private `tmux -S` socket from its run-file identity and
-  starts tmux without reading the user's tmux configuration. It never probes or
-  adopts sessions from tmux's default socket. Socket inodes remain in AO state;
+  starts tmux without reading the user's tmux configuration. New sessions never
+  leave that socket. For updates from pre-cutover releases, the daemon may route
+  an existing session to the system tmux default socket only after its immutable
+  pane command proves the same AO run-file, session id, supervised marker, and
+  launch generation; it then repairs the stale durable generation during boot.
+  A same-named user session is never adopted. Socket inodes remain in AO state;
   a bounded owner-only `/tmp` directory alias handles deeply nested paths on
   macOS, and unsafe shared-writable socket directories fail closed. Pane
   environments are applied over stdin before the real command starts, keeping


### PR DESCRIPTION
Fixes #4458

Summary:
- keep the hashed AO-private tmux socket authoritative for every new session
- recover pre-cutover default-socket sessions only after immutable pane provenance proves the AO run file, session id, supervised marker, and launch generation
- route attach, capture, input, restart, liveness, process inspection, environment sync, and teardown through the selected socket
- repair stale runtime and agent-session launch generations during boot with compare-and-swap fencing
- fail closed for foreign same-name sessions and prefer a concurrently appearing private session

Upgrade behavior:
Users already on the regressed nightly and users updating directly from pre-private-socket releases get the same automatic boot reconciliation. Live legacy panes remain on the legacy server; no process or worktree migration is required. New sessions stay on the hashed private socket.

Tests:
- npm run lint
- cd backend && go build ./...
- race-enabled focused runtime/lifecycle/session reconciliation tests
- isolated real-tmux integration covering legacy -L default plus the new hashed -S private socket across an update boundary

Risk controls:
The integration test isolates the default server through TMUX_TMPDIR. No production sessions or user tmux servers are touched.