### PR TITLE
fix(updates): never resolve a prerelease update through a draft release

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -327,6 +327,157 @@ describe("startAutoUpdates", () => {
     }
   });
 
+  // Regression guard, not new behaviour: the nightly resolver already filtered
+  // drafts. It is pinned here because releases.atom really does list drafts
+  // (observed in production on 2026-08-25), so this filter is now the only
+  // thing standing between a prerelease install and an undownloadable release.
+  it("skips a draft release, which the Atom feed lists but nobody can download", async () => {
+    const platformManifest =
+      process.platform === "darwin"
+        ? "nightly-mac.yml"
+        : process.platform === "linux"
+          ? "nightly-linux.yml"
+          : "nightly.yml";
+    const resourcesPath = mkdtempSync(
+      nodePath.join(os.tmpdir(), "ao-nightly-feed-"),
+    );
+    writeFileSync(
+      nodePath.join(resourcesPath, "app-update.yml"),
+      "provider: github\nowner: Untrivial-ai\nrepo: agent-orchestrator\n",
+    );
+    const originalResourcesPath = Object.getOwnPropertyDescriptor(
+      process,
+      "resourcesPath",
+    );
+    Object.defineProperty(process, "resourcesPath", {
+      configurable: true,
+      value: resourcesPath,
+    });
+    // A draft carrying a complete asset set is still unreachable: its download
+    // URLs 404 for everyone, so picking it strands the install.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            tag_name: "v1.0.2-nightly.202608251410",
+            draft: true,
+            prerelease: true,
+            assets: [{ name: platformManifest }],
+          },
+          {
+            tag_name: "v1.0.1-nightly.202608250031",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: platformManifest }],
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const { module, autoUpdater } = await importAutoUpdater({
+        enabled: true,
+        channel: "nightly",
+        nightlyAck: true,
+        feature: null,
+      });
+
+      await module.checkForUpdatesNow(stateDir);
+
+      expect(autoUpdater.setFeedURL).toHaveBeenNthCalledWith(1, {
+        provider: "generic",
+        url: "https://github.com/Untrivial-ai/agent-orchestrator/releases/download/v1.0.1-nightly.202608250031",
+        channel: "nightly",
+        useMultipleRangeRequest: false,
+      });
+    } finally {
+      if (originalResourcesPath) {
+        Object.defineProperty(process, "resourcesPath", originalResourcesPath);
+      } else {
+        Reflect.deleteProperty(process, "resourcesPath");
+      }
+      rmSync(resourcesPath, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a pinned feature build through the API too, so drafts cannot reach it", async () => {
+    const platformManifest =
+      process.platform === "darwin"
+        ? "pr4242-mac.yml"
+        : process.platform === "linux"
+          ? "pr4242-linux.yml"
+          : "pr4242.yml";
+    const resourcesPath = mkdtempSync(
+      nodePath.join(os.tmpdir(), "ao-feature-feed-"),
+    );
+    writeFileSync(
+      nodePath.join(resourcesPath, "app-update.yml"),
+      "provider: github\nowner: Untrivial-ai\nrepo: agent-orchestrator\n",
+    );
+    const originalResourcesPath = Object.getOwnPropertyDescriptor(
+      process,
+      "resourcesPath",
+    );
+    Object.defineProperty(process, "resourcesPath", {
+      configurable: true,
+      value: resourcesPath,
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            tag_name: "v1.0.2-pr4242.2",
+            draft: true,
+            prerelease: true,
+            assets: [{ name: platformManifest }],
+          },
+          {
+            tag_name: "v1.0.2-pr4242.1",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: platformManifest }],
+          },
+          {
+            tag_name: "v1.0.3-nightly.202608251410",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: "nightly-mac.yml" }],
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const { module, autoUpdater } = await importAutoUpdater({
+        enabled: true,
+        channel: "nightly",
+        nightlyAck: true,
+        feature: { pr: 4242 },
+      });
+
+      await module.checkForUpdatesNow(stateDir);
+
+      // The pin wins over the newer nightly, and the draft pr build is skipped.
+      expect(autoUpdater.setFeedURL).toHaveBeenNthCalledWith(1, {
+        provider: "generic",
+        url: "https://github.com/Untrivial-ai/agent-orchestrator/releases/download/v1.0.2-pr4242.1",
+        channel: "pr4242",
+        useMultipleRangeRequest: false,
+      });
+    } finally {
+      if (originalResourcesPath) {
+        Object.defineProperty(process, "resourcesPath", originalResourcesPath);
+      } else {
+        Reflect.deleteProperty(process, "resourcesPath");
+      }
+      rmSync(resourcesPath, { recursive: true, force: true });
+    }
+  });
+
   it("automatic nightly checks resolve the newest completed release without the Atom feed", async () => {
     const platformManifest =
       process.platform === "darwin"

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -255,9 +255,10 @@ interface GitHubReleaseSummary {
  * This is used only for user-requested checks; failures fall back to the normal
  * provider so API rate limits or an outage never break update checks.
  */
-async function fetchLatestCompletedNightlyTag(
+async function fetchLatestCompletedPrereleaseTag(
   owner: string,
   repo: string,
+  channel: string,
 ): Promise<string | undefined> {
   try {
     const response = await fetch(
@@ -274,7 +275,7 @@ async function fetchLatestCompletedNightlyTag(
     );
     if (!response.ok) return undefined;
     const releases = (await response.json()) as GitHubReleaseSummary[];
-    const manifestName = `nightly${platformSuffix()}.yml`;
+    const manifestName = `${channel}${platformSuffix()}.yml`;
     return releases
       .filter((release) => {
         const parsed = semver.valid(release.tag_name);
@@ -282,7 +283,7 @@ async function fetchLatestCompletedNightlyTag(
           !release.draft &&
           release.prerelease &&
           parsed !== null &&
-          semver.prerelease(parsed)?.[0] === "nightly" &&
+          semver.prerelease(parsed)?.[0] === channel &&
           release.assets?.some((asset) => asset.name === manifestName) === true
         );
       })
@@ -293,14 +294,21 @@ async function fetchLatestCompletedNightlyTag(
   }
 }
 
-function usesDirectNightlyFeed(
+// Which prerelease channel this install tracks, or undefined for stable.
+// Stable resolves through GitHub's /releases/latest, which already excludes
+// drafts and prereleases; every prerelease channel otherwise falls back to
+// electron-updater's releases.atom scan, and that feed LISTS DRAFTS. A draft's
+// assets are not public, so the manifest 404s and the automatic path swallows
+// it: the install goes stale against a release the user can never download.
+function directFeedChannel(
   settings: Pick<UpdateSettings, "channel" | "feature">,
-): boolean {
-  return settings.channel === "nightly" && settings.feature === null;
+): string | undefined {
+  if (settings.feature != null) return `pr${settings.feature.pr}`;
+  return settings.channel === "nightly" ? "nightly" : undefined;
 }
 
 /**
- * Point one Nightly check directly at the newest completed release. Applies to
+ * Point one prerelease check directly at the newest completed release. Applies to
  * automatic checks as well as manual ones: an atom feed that lags a fresh
  * release makes a background check answer "not-available" and the install goes
  * silently stale, and an entry whose manifest has not finished uploading 404s
@@ -310,21 +318,23 @@ function usesDirectNightlyFeed(
  * checks; electron-updater retains the direct provider with the discovered
  * update, so a subsequent Download action still uses the correct asset URLs.
  */
-async function configureDirectNightlyFeed(
+async function configureDirectPrereleaseFeed(
   settings: UpdateSettings,
 ): Promise<(() => void) | undefined> {
-  if (!usesDirectNightlyFeed(settings)) return undefined;
+  const channel = directFeedChannel(settings);
+  if (channel === undefined) return undefined;
   const coordinates = await readAppUpdateYml();
   if (!coordinates) return undefined;
-  const tag = await fetchLatestCompletedNightlyTag(
+  const tag = await fetchLatestCompletedPrereleaseTag(
     coordinates.owner,
     coordinates.repo,
+    channel,
   );
   if (!tag) return undefined;
   const runningVersion = app.getVersion();
   if (
     semver.valid(runningVersion) !== null &&
-    semver.prerelease(runningVersion)?.[0] === "nightly" &&
+    semver.prerelease(runningVersion)?.[0] === channel &&
     semver.lt(tag, runningVersion)
   ) {
     return undefined;
@@ -333,7 +343,7 @@ async function configureDirectNightlyFeed(
   autoUpdater.setFeedURL({
     provider: "generic",
     url: `https://github.com/${coordinates.owner}/${coordinates.repo}/releases/download/${tag}`,
-    channel: "nightly",
+    channel,
     useMultipleRangeRequest: false,
   });
   return () => {
@@ -794,11 +804,12 @@ async function runAutomaticUpdateCheck(
       configureFeed(settings);
       autoUpdater.autoDownload = true;
       applyInstallOnQuitPolicy();
-      // Only nightly resolves a direct feed. Skipping the await entirely on the
-      // other channels keeps this check's event ordering exactly as it was.
-      const restoreFeed = usesDirectNightlyFeed(settings)
-        ? await configureDirectNightlyFeed(settings)
-        : undefined;
+      // Only prerelease channels resolve a direct feed. Skipping the await
+      // entirely on stable keeps its check's event ordering exactly as it was.
+      const restoreFeed =
+        directFeedChannel(settings) !== undefined
+          ? await configureDirectPrereleaseFeed(settings)
+          : undefined;
       try {
         const result = await autoUpdater.checkForUpdates();
         if (result?.downloadPromise) await result.downloadPromise;
@@ -951,7 +962,7 @@ export async function checkForUpdatesNow(
         autoUpdater.autoDownload = false;
         applyInstallOnQuitPolicy();
         broadcastUpdaterStatus({ state: "checking" });
-        const restoreFeed = await configureDirectNightlyFeed(settings);
+        const restoreFeed = await configureDirectPrereleaseFeed(settings);
         try {
           await autoUpdater.checkForUpdates();
         } finally {


### PR DESCRIPTION
Stacked on #4397. Base is `ao/ao-41/sidebar-update-action`, so this diff is just the one commit; retarget to `main` once #4397 merges.

## The bug, observed in production

GitHub's `releases.atom` lists **draft** releases, and electron-updater discovers prereleases through that feed. Draft assets are not public, so the channel manifest 404s. On the automatic path that error is deliberately swallowed, so the install silently goes stale against a release the user could never have downloaded.

Checked against the live feed on 2026-08-25, the newest atom entry was the draft `v0.12.8-nightly.202608251410`:

```
nightly-mac.yml -> 404
latest-mac.yml  -> 404   (electron-updater's fallback)
```

Meanwhile `v0.12.7-nightly.202608250031` was published, complete and downloadable. Every nightly install was aiming at the draft and reporting nothing.

## What this changes

The nightly channel already sidesteps the atom feed by resolving the newest completed release through the API, which filters `draft: false` and requires the platform manifest. A **pinned feature build did not**: `configureFeed` sets `allowPrerelease` for `pr<N>` and leaves discovery to the atom feed, so a draft `pr<N>` build strands the pin the same way.

This generalizes the resolver from `"nightly"` to any prerelease channel and routes feature pins through it. Stable is untouched: it resolves via `/releases/latest`, which excludes drafts and prereleases by definition, so it takes no extra request.

## Tests

- A pinned feature build skips a draft `pr<N>` release and resolves the newest published one, and the pin still outranks a newer nightly. **Confirmed to fail without the production change.**
- A draft nightly is skipped in favour of the newest published release. This one **passes without the change** and is labelled in the source as a regression guard rather than new behaviour, since nightly draft filtering already existed. It is pinned because the atom feed really does list drafts, making this filter the only thing between a prerelease install and an undownloadable release.

65/65 `auto-updater.test.ts`, 162/162 across the update-related files, `frontend:typecheck` clean.

## Scope

This is the **client half only**. It stops a draft from stranding an install. It does not stop drafts appearing in the feed, and it cannot fix a release pipeline that publishes a build and later returns it to draft.

Two things seen while investigating that this PR does not address, and that no workflow in this repository appears to own (there is no nightly release workflow here):

- A **draft build was downloaded onto a real machine** (`0.12.8-nightly.202608251410`, 168MB, staged 2026-08-25 20:03) while the release is a draft now and its assets 404. That implies the build was published and later returned to draft.
- Two **published** nightlies, `202608241447` and `202608242034`, carry **no mac manifest at all**, so they 404 the same way for any client that selects them.

Both look like release-pipeline problems and probably deserve their own issue.
