### PR TITLE
ci: guard the nightly feed head the way stable is guarded

### DIFF
--- a/.github/workflows/release-nightly-guard.yml
+++ b/.github/workflows/release-nightly-guard.yml
@@ -1,0 +1,77 @@
+name: Release nightly guard
+
+# The stable channel has release-latest-guard.yml. Nightly had nothing, and it
+# is the channel that actually breaks: three of the six nightlies cut between
+# 2026-08-23 and 2026-08-25 shipped without their updater manifests, and one of
+# those was still a draft. Any of them strands every nightly install.
+#
+# Why the newest release is the only one that matters: electron-updater
+# discovers prereleases through releases.atom, takes the FIRST entry matching
+# the channel, fetches that release's <channel>-<platform>.yml, and on 404
+# retries exactly one fallback before giving up. It never walks to the next
+# entry. So one bad release at the top of the feed wedges every client, even
+# with a perfectly good release directly beneath it.
+#
+# Drafts count. releases.atom lists them, but their assets are not public, so a
+# draft at the top of the feed 404s for everyone.
+on:
+  release:
+    types: [published, edited, released, created, prereleased]
+  schedule:
+    - cron: "23 * * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly-feed:
+    # Forks copy this workflow but cut no nightlies, so the hourly schedule
+    # would fail red forever. Same guard as release-latest-guard.yml.
+    if: github.repository == 'Untrivial-ai/agent-orchestrator'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify the nightly feed head is installable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Read the same feed the client reads, rather than the API, so this
+          # checks what users actually resolve to (the API omits drafts; the
+          # Atom feed does not).
+          atom="$(curl -fsSL "https://github.com/$REPO/releases.atom")"
+          tag="$(grep -oE '/tag/[^\"]+' <<<"$atom" | sed 's|/tag/||' | grep -m1 -- '-nightly\.' || true)"
+
+          if [[ -z "$tag" ]]; then
+            echo "No nightly release in the feed yet; nothing to guard."
+            exit 0
+          fi
+
+          echo "Nightly feed head: $tag"
+
+          release_json="$(gh release view "$tag" --repo "$REPO" --json isDraft,assets)"
+          draft="$(jq -r '.isDraft' <<<"$release_json")"
+
+          if [[ "$draft" == "true" ]]; then
+            echo "::error::Nightly feed head '$tag' is a DRAFT. releases.atom lists drafts, but their assets 404, so every nightly install fails its update check against this release. Publish it with its updater manifests or delete it."
+            exit 1
+          fi
+
+          mapfile -t assets < <(jq -r '.assets[].name' <<<"$release_json")
+
+          missing=()
+          for required in nightly.yml nightly-mac.yml nightly-linux.yml; do
+            if ! printf '%s\n' "${assets[@]}" | grep -Fxq "$required"; then
+              missing+=("$required")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Nightly feed head '$tag' is missing updater manifest(s): ${missing[*]}. Every nightly install 404s its update check against this release. Generate and upload them (frontend/scripts/feed.mjs <dir> <version> nightly) or delete the release."
+            printf 'Assets present:\n%s\n' "${assets[@]}"
+            exit 1
+          fi
+
+          echo "OK: $tag is published and carries nightly.yml, nightly-mac.yml, nightly-linux.yml."


### PR DESCRIPTION
## Why

`release-latest-guard.yml` protects the stable channel from a `/releases/latest` that electron-updater cannot install from. Nightly had no equivalent, and nightly is the channel that actually breaks. Of the six nightlies cut between 2026-08-23 and 2026-08-25:

| Release | State | Manifests |
| --- | --- | --- |
| `v0.12.8-nightly.202608251410` | draft | **missing** |
| `v0.12.8-nightly.202608250759` | draft | ok |
| `v0.12.7-nightly.202608250031` | published | ok |
| `v0.12.7-nightly.202608242034` | **published** | **missing** |
| `v0.12.7-nightly.202608241447` | **published** | **missing** |
| `v0.12.7-nightly.202608241408` | published | ok |

Any one of these at the head of the feed strands **every** nightly install.

electron-updater discovers prereleases through `releases.atom`, takes the **first** entry matching the channel, fetches that release's manifest, and on 404 retries exactly one fallback before giving up. It never walks to the next entry. So one bad release at the top wedges every client even with a good release directly beneath it — which is the current state:

```
feed head:      v0.12.8-nightly.202608251410
  nightly-mac.yml -> 404
  latest-mac.yml  -> 404   (the single fallback)
  => ERR_UPDATER_CHANNEL_FILE_NOT_FOUND, gives up

one entry down: v0.12.7-nightly.202608250031
  nightly-mac.yml -> 200   (never reached)
```

The failure is invisible. Automatic check errors are suppressed by design, so affected installs show nothing at all and simply stop updating. On one machine this had been going on for two days across an app restart.

## What it does

Fails when the nightly feed head is a draft, or is missing `nightly.yml` / `nightly-mac.yml` / `nightly-linux.yml`, and says what to do about it.

It reads `releases.atom`, not the API, on purpose: the API omits drafts, the Atom feed lists them, and a draft's assets are not public, so a draft at the head 404s for everyone. Checking the API would miss exactly the case that broke this week.

Same shape as the stable guard: hourly schedule, release triggers, and the `github.repository` condition so forks do not fail red.

## Verified against the live feed

Ran the check logic against real releases:

- `v0.12.8-nightly.202608251410` (draft, no manifests) → **fails**, reports the draft
- `v0.12.7-nightly.202608242034` (published, no manifests) → **fails**, names the three missing files
- `v0.12.7-nightly.202608250031` → passes
- `v0.12.7-nightly.202608241408` → passes

So it catches both real failure modes and does not fire on healthy releases. Note this guard will fail on `main` until the current feed head is fixed — that is the point, not a defect in the workflow.

## Scope

This detects the breakage; it does not prevent it. Nightlies are cut by hand (`frontend-nightly.yml` was removed in #3070) and the manifest generation is a separate step from the artifact publish, which is what makes it easy to skip. Automating the nightly cut so the manifests cannot be forgotten is the real fix and is a larger change than this.

Related: #4397 and #4462 harden the client so it skips drafts and manifest-less releases and resolves to the newest installable one. This guards the release side; those guard the client side.
