### PR TITLE
fix(observability): drop request-cancellation noise from daemon Sentry

### DIFF
--- a/backend/internal/observe/sentryobs/noise_filter_test.go
+++ b/backend/internal/observe/sentryobs/noise_filter_test.go
@@ -1,0 +1,87 @@
+package sentryobs
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func TestIsNoiseError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain fault", fmt.Errorf("boom"), false},
+		{"canceled", context.Canceled, true},
+		{"deadline", context.DeadlineExceeded, true},
+		{"wrapped canceled", fmt.Errorf("list prs for x: %w", context.Canceled), true},
+		{"wrapped deadline", fmt.Errorf("skills/list: %w", context.DeadlineExceeded), true},
+		{"deep wrap", fmt.Errorf("a: %w", fmt.Errorf("b: %w", context.Canceled)), true},
+	}
+	for _, c := range cases {
+		if got := IsNoiseError(c.err); got != c.want {
+			t.Errorf("IsNoiseError(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+type noiseRecordingTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *noiseRecordingTransport) Configure(sentry.ClientOptions) {}
+func (t *noiseRecordingTransport) SendEvent(e *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, e)
+}
+func (t *noiseRecordingTransport) Flush(time.Duration) bool              { return true }
+func (t *noiseRecordingTransport) FlushWithContext(context.Context) bool { return true }
+func (t *noiseRecordingTransport) Close()                                {}
+
+// TestCaptureHTTPErrorDropsCancellationNoise drives the enabled capture path
+// through a recording transport and asserts that context-cancellation errors
+// (the dominant, un-actionable churn in the feed) are dropped while a genuine
+// fault still reaches the wire.
+func TestCaptureHTTPErrorDropsCancellationNoise(t *testing.T) {
+	tr := &noiseRecordingTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: tr, SampleRate: 1.0})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	prev := sentry.CurrentHub().Client()
+	sentry.CurrentHub().BindClient(client)
+	enabled.Store(true)
+	t.Cleanup(func() {
+		enabled.Store(false)
+		sentry.CurrentHub().BindClient(prev)
+	})
+
+	ctx := context.Background()
+	CaptureHTTPError(ctx, fmt.Errorf("list prs for autoads-2: %w", context.Canceled), map[string]string{"path": "/x"}, "fp1")
+	CaptureHTTPError(ctx, fmt.Errorf("skills/list: %w", context.DeadlineExceeded), map[string]string{"path": "/y"}, "fp2")
+	CaptureHTTPError(ctx, context.DeadlineExceeded, map[string]string{"path": "/z"}, "fp3")
+
+	tr.mu.Lock()
+	afterNoise := len(tr.events)
+	tr.mu.Unlock()
+	if afterNoise != 0 {
+		t.Fatalf("cancellation noise produced %d events, want 0", afterNoise)
+	}
+
+	CaptureHTTPError(ctx, fmt.Errorf("aggregate usage: no such table: openai_usage_event_details"), map[string]string{"path": "/u"}, "fp4")
+	tr.mu.Lock()
+	afterReal := len(tr.events)
+	tr.mu.Unlock()
+	if afterReal != 1 {
+		t.Fatalf("genuine fault produced %d events, want 1", afterReal)
+	}
+}

--- a/backend/internal/observe/sentryobs/sentryobs.go
+++ b/backend/internal/observe/sentryobs/sentryobs.go
@@ -13,6 +13,7 @@ package sentryobs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -99,11 +100,23 @@ func ShouldCaptureStatus(status int) bool {
 	return status >= http.StatusInternalServerError && status != http.StatusServiceUnavailable
 }
 
+// IsNoiseError reports whether err is request-cancellation noise rather than a
+// server fault worth an issue. context.Canceled means the client (usually the
+// renderer) went away mid-request; context.DeadlineExceeded means the request or
+// a downstream op ran past its deadline. Neither is an actionable server bug,
+// and together they otherwise dominate the issue feed with un-fixable churn, so
+// they are dropped before capture. Genuine slow-path/contention is still visible
+// as the aggregated ao.http.5xx rollup and (for retryable DB contention) the
+// typed 503 path.
+func IsNoiseError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
 // CaptureHTTPError captures a server-fault error with the given tags and a
-// fingerprint identical to the PostHog grouping key. No-op when disabled or the
-// error is nil.
+// fingerprint identical to the PostHog grouping key. No-op when disabled, the
+// error is nil, or the error is request-cancellation noise (see IsNoiseError).
 func CaptureHTTPError(_ context.Context, err error, tags map[string]string, fingerprint string) {
-	if !enabled.Load() || err == nil {
+	if !enabled.Load() || err == nil || IsNoiseError(err) {
 		return
 	}
 	sentry.WithScope(func(scope *sentry.Scope) {


### PR DESCRIPTION
## Why

With daemon Sentry live, `context.Canceled` and `context.DeadlineExceeded` errors are the dominant, un-actionable churn in the issue feed (client/renderer disconnecting mid-request, or a request/op running past its deadline). They are not server bugs, and they bury the real faults.

## What

`CaptureHTTPError` now drops any error that is or wraps `context.Canceled` / `context.DeadlineExceeded` before capture, via a new `IsNoiseError` (`errors.Is`, so wrapped chains like `list prs for x: context canceled` and the bare `context deadlineExceededError` are both caught).

Genuine slow-path/contention stays observable elsewhere: the aggregated `ao.http.5xx` rollup still counts it, and retryable DB contention has the typed 503 path.

## Tests

- `IsNoiseError` over nil / plain fault / canceled / deadline / wrapped / deep-wrapped.
- Recording-transport test: three cancellation errors produce **zero** captured events; a genuine fault (`no such table: ...`) still reaches the wire.

Observed in production feed: `context canceled` / `context deadline exceeded` across `list prs`, `pr facts`, `skills/list`, `conversation`, and bare deadline errors — all now suppressed.