### PR TITLE
Keep review controls aligned at narrow widths

### DIFF
--- a/frontend/e2e/reviews-tab.spec.ts
+++ b/frontend/e2e/reviews-tab.spec.ts
@@ -34,7 +34,7 @@ test("the Reviews tab stays hidden for a session with no reviewable PRs", async 
 	await expect(inspector.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
 });
 
-test("review content stays inside the inspector at its minimum width", async ({ page }) => {
+test("review controls stay aligned and collapse the run action at minimum width", async ({ page }) => {
 	await page.addInitScript(() => {
 		window.localStorage.setItem("ao.inspector.widthPx", "350");
 	});
@@ -52,7 +52,28 @@ test("review content stays inside the inspector at its minimum width", async ({ 
 		reviewerSelect.boundingBox(),
 	]);
 	if (!reviewerLabelBox || !reviewerSelectBox) throw new Error("reviewer controls are not visible");
-	expect(reviewerSelectBox.y).toBeGreaterThanOrEqual(reviewerLabelBox.y + reviewerLabelBox.height);
+	const reviewerLabelCenterY = reviewerLabelBox.y + reviewerLabelBox.height / 2;
+	const reviewerSelectCenterY = reviewerSelectBox.y + reviewerSelectBox.height / 2;
+	expect(Math.abs(reviewerLabelCenterY - reviewerSelectCenterY)).toBeLessThanOrEqual(2);
+
+	const controls = inspector.locator(".review-run-controls-container");
+	const controlsBox = await controls.boundingBox();
+	if (!controlsBox) throw new Error("review controls are not visible");
+	expect(reviewerSelectBox.width).toBeLessThan(controlsBox.width / 2);
+
+	const triggerLabel = inspector.getByText("Trigger review", { exact: true });
+	const runButton = inspector.getByRole("button", { name: "Re-run review" });
+	const [triggerLabelBox, runButtonBox] = await Promise.all([
+		triggerLabel.boundingBox(),
+		runButton.boundingBox(),
+	]);
+	if (!triggerLabelBox || !runButtonBox) throw new Error("review trigger controls are not visible");
+	const triggerLabelCenterY = triggerLabelBox.y + triggerLabelBox.height / 2;
+	const runButtonCenterY = runButtonBox.y + runButtonBox.height / 2;
+	expect(Math.abs(triggerLabelCenterY - runButtonCenterY)).toBeLessThanOrEqual(2);
+	await expect(runButton.locator(".review-run-action-label")).toBeHidden();
+	await runButton.hover();
+	await expect(page.getByRole("tooltip", { name: "Re-run review" })).toBeVisible();
 
 	const prRow = inspector.getByTestId("review-pr-row");
 	await expect(prRow).toHaveAttribute("aria-expanded", "false");

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -2127,7 +2127,7 @@ function ReviewPanel({
 					</TooltipProvider>
 				) : null}
 				<div className="review-run-controls-container min-w-0 divide-y divide-border/70 text-xs">
-					<div className="flex min-h-10 min-w-0 items-center justify-between gap-3 py-2 @max-[420px]/inspector:flex-col @max-[420px]/inspector:items-stretch @max-[420px]/inspector:gap-2">
+					<div className="flex min-h-10 min-w-0 items-center justify-between gap-3 py-2">
 						<span className="min-w-0 text-xs font-medium text-foreground">
 							{t("inspector.selectReviewerAgent")}
 						</span>
@@ -2141,7 +2141,7 @@ function ReviewPanel({
 							installed={agentCatalog?.installed}
 							onChange={(next) => onReviewerOverrideChange(next as ReviewerHarness | "")}
 							supported={agentCatalog?.supported}
-							triggerClassName="review-run-agent-select ml-auto h-control-md w-auto min-w-0 max-w-[11rem] shrink-0 justify-end px-2 text-right text-xs @max-[420px]/inspector:ml-0 @max-[420px]/inspector:w-full @max-[420px]/inspector:max-w-none @max-[420px]/inspector:justify-between @max-[420px]/inspector:text-left"
+							triggerClassName="review-run-agent-select ml-auto h-control-md w-auto min-w-0 max-w-[11rem] shrink-0 justify-end px-2 text-right text-xs"
 							value={reviewerOverride}
 							excludedHarness={resolvedDefaultHarness}
 							showDefaultOption
@@ -2156,22 +2156,26 @@ function ReviewPanel({
 						onCheckedChange={onAutoReviewChange}
 						tooltipClassName="max-w-64"
 					/>
-					<div className="flex min-h-10 min-w-0 items-center justify-between gap-3 py-2 @max-[420px]/inspector:flex-col @max-[420px]/inspector:items-stretch @max-[420px]/inspector:gap-2">
+					<div className="flex min-h-10 min-w-0 items-center justify-between gap-3 py-2">
 						<span className="text-xs font-medium text-foreground">{t("inspector.review.session")}</span>
 						<div className="flex min-w-0 items-center justify-end gap-1.5">
-							<Button
-								aria-label={primaryReviewActionLabel}
-								className="shrink-0 gap-1 px-1.5 text-xs [&_svg]:size-icon-sm"
-								disabled={reviewRunning ? isCancelling || isKilling || isSwitchingReviewer : runDisabled || autoReviewEnabled}
-								onClick={reviewRunning ? onCancel : onTrigger}
-								size="sm"
-								title={primaryReviewActionLabel}
-								type="button"
-								variant={reviewRunning ? "ghost" : reviewHasRun ? "secondary" : "primary"}
-							>
-								{reviewRunning ? <X aria-hidden="true" /> : <Play aria-hidden="true" />}
-								<span className="review-run-action-label">{primaryReviewActionLabel}</span>
-							</Button>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										aria-label={primaryReviewActionLabel}
+										className="shrink-0 gap-1 px-1.5 text-xs [&_svg]:size-icon-sm"
+										disabled={reviewRunning ? isCancelling || isKilling || isSwitchingReviewer : runDisabled || autoReviewEnabled}
+										onClick={reviewRunning ? onCancel : onTrigger}
+										size="sm"
+										type="button"
+										variant={reviewRunning ? "ghost" : reviewHasRun ? "secondary" : "primary"}
+									>
+										{reviewRunning ? <X aria-hidden="true" /> : <Play aria-hidden="true" />}
+										<span className="review-run-action-label">{primaryReviewActionLabel}</span>
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent side="top">{primaryReviewActionLabel}</TooltipContent>
+							</Tooltip>
 							{hasReviewerSession ? (
 								<Button
 								aria-label={isKilling ? t("inspector.review.killingSession") : t("inspector.review.killSession")}


### PR DESCRIPTION
## Summary

- Keep reviewer selection and review actions aligned on one row at narrow inspector widths
- Prevent the reviewer selector from expanding to full width
- Collapse the review action to an accessible icon-only button with a hover/focus tooltip
- Add responsive regression coverage for alignment and overflow

<img width="407" height="197" alt="image" src="https://github.com/user-attachments/assets/1d4746f7-15fc-4045-894c-328d60a194cf" />


## Testing

- `npm run test:e2e -- e2e/reviews-tab.spec.ts`
- `npm test -- src/renderer/components/SessionInspector.test.tsx`
- `npm run typecheck`
