### PR TITLE
fix(session): resolve spawn atomicity and boot-time zombie session leaks

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -251,15 +251,15 @@ func (s *Service) spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	cfg = s.withIssueContext(ctx, cfg, project)
 	rec, promptBytes, systemPromptBytes, err := s.manager.Spawn(ctx, cfg)
 	if err != nil {
-	apiErr := toSpawnAPIError(err)
-			s.emitSpawnFailed(cfg, apiErr, s.now().Sub(start).Milliseconds())
-			if toAPIError(err) == err && s.logger != nil {
-				s.logger.Error("spawn: unclassified internal error",
-					"projectID", cfg.ProjectID,
-					"kind", cfg.Kind,
-					"harness", cfg.Harness,
-					"error", err)
-			}
+		apiErr := toSpawnAPIError(err)
+		s.emitSpawnFailed(cfg, apiErr, s.now().Sub(start).Milliseconds())
+		if toAPIError(err) == err && s.logger != nil {
+			s.logger.Error("spawn: unclassified internal error",
+				"projectID", cfg.ProjectID,
+				"kind", cfg.Kind,
+				"harness", cfg.Harness,
+				"error", err)
+		}
 		return domain.Session{}, 0, 0, apiErr
 	}
 	s.emitSpawned(rec, s.now().Sub(start).Milliseconds())

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -253,7 +253,7 @@ func (s *Service) spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	if err != nil {
 		apiErr := toSpawnAPIError(err)
 		s.emitSpawnFailed(cfg, apiErr, s.now().Sub(start).Milliseconds())
-		if toAPIError(err) == err && s.logger != nil {
+		if errors.Is(toAPIError(err), err) && s.logger != nil {
 			s.logger.Error("spawn: unclassified internal error",
 				"projectID", cfg.ProjectID,
 				"kind", cfg.Kind,

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -251,8 +251,15 @@ func (s *Service) spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	cfg = s.withIssueContext(ctx, cfg, project)
 	rec, promptBytes, systemPromptBytes, err := s.manager.Spawn(ctx, cfg)
 	if err != nil {
-		apiErr := toSpawnAPIError(err)
-		s.emitSpawnFailed(cfg, apiErr, s.now().Sub(start).Milliseconds())
+	apiErr := toSpawnAPIError(err)
+			s.emitSpawnFailed(cfg, apiErr, s.now().Sub(start).Milliseconds())
+			if toAPIError(err) == err && s.logger != nil {
+				s.logger.Error("spawn: unclassified internal error",
+					"projectID", cfg.ProjectID,
+					"kind", cfg.Kind,
+					"harness", cfg.Harness,
+					"error", err)
+			}
 		return domain.Session{}, 0, 0, apiErr
 	}
 	s.emitSpawned(rec, s.now().Sub(start).Milliseconds())
@@ -941,6 +948,9 @@ func toAPIError(err error) error {
 			"Session agent is still starting; retry after the agent prompt is ready", nil)
 	case errors.Is(err, sessionmanager.ErrIncompleteHandle):
 		return apierr.Conflict("SESSION_INCOMPLETE_HANDLE", "Session is missing runtime or workspace handles", nil)
+	case errors.Is(err, sessionmanager.ErrIncompleteSpawn):
+		return apierr.Conflict("SESSION_SPAWN_INCOMPLETE",
+			"Session spawn did not complete; the session has been terminated. Spawn a new session.", nil)
 	case errors.Is(err, sessionmanager.ErrNotResumable):
 		return apierr.Conflict("SESSION_NOT_RESUMABLE",
 			"This session has no saved agent session or prompt to resume from", nil)

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -4333,4 +4334,92 @@ func sameStrings(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+// TestSpawn_UnclassifiedErrorIsLoggedBeforeBeingMasked asserts that when
+// manager.Spawn returns an unclassified internal error, the Service logs the
+// raw cause at ERROR level with structured context before returning the API error.
+func TestSpawn_UnclassifiedErrorIsLoggedBeforeBeingMasked(t *testing.T) {
+	// Arrange
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1"}
+	rawErr := errors.New("sqlite3: database is locked")
+	mgr := &fakeCommander{spawnErr: rawErr}
+
+	var logBuf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	svc := NewWithDeps(Deps{
+		Manager: mgr,
+		Store:   st,
+		Logger:  logger,
+		Clock:   func() time.Time { return time.Time{} },
+	})
+
+	// Act
+	_, _, _, err := svc.Spawn(context.Background(), ports.SpawnConfig{
+		ProjectID: "p1",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Prompt:    "implement the feature",
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("Spawn: expected non-nil error for a failing manager, got nil")
+	}
+
+	logOutput := logBuf.String()
+	if logOutput == "" {
+		t.Fatal("no log output produced; the service must log spawn errors before masking them")
+	}
+	if !strings.Contains(logOutput, "ERROR") {
+		t.Errorf("log level is not ERROR; got:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, rawErr.Error()) {
+		t.Errorf("raw error %q not found in log output:\n%s", rawErr.Error(), logOutput)
+	}
+	if !strings.Contains(logOutput, "p1") {
+		t.Errorf("projectID not logged; got:\n%s", logOutput)
+	}
+}
+
+// TestToAPIError_MapsIncompleteSpawnToConflict asserts that ErrIncompleteSpawn
+// is translated to a typed 409 Conflict with SESSION_SPAWN_INCOMPLETE code.
+func TestToAPIError_MapsIncompleteSpawnToConflict(t *testing.T) {
+	// Arrange
+	wrapped := fmt.Errorf("reconcile p1-1: mark terminated: %w", sessionmanager.ErrIncompleteSpawn)
+
+	// Act
+	result := toAPIError(wrapped)
+
+	// Assert
+	var apiErr *apierr.Error
+	if !errors.As(result, &apiErr) {
+		t.Fatalf("toAPIError(ErrIncompleteSpawn) = %T(%v), want *apierr.Error", result, result)
+	}
+	if apiErr.Kind != apierr.KindConflict {
+		t.Errorf("apierr.Kind = %q, want KindConflict", apiErr.Kind)
+	}
+	if apiErr.Code != "SESSION_SPAWN_INCOMPLETE" {
+		t.Errorf("apierr.Code = %q, want SESSION_SPAWN_INCOMPLETE", apiErr.Code)
+	}
+}
+
+// TestToAPIError_KnownSentinelsAreNotUnclassified confirms that known sentinels
+// (including ErrIncompleteSpawn) are recognized by toAPIError and mapped to typed errors.
+func TestToAPIError_KnownSentinelsAreNotUnclassified(t *testing.T) {
+	sentinels := []error{
+		sessionmanager.ErrNotFound,
+		sessionmanager.ErrTerminated,
+		sessionmanager.ErrIncompleteSpawn,
+		sessionmanager.ErrIncompleteHandle,
+		sessionmanager.ErrMissingHarness,
+	}
+	for _, sentinel := range sentinels {
+		result := toAPIError(sentinel)
+		if result == sentinel {
+			t.Errorf("toAPIError(%v) returned the sentinel unchanged; it must be mapped to a typed API error", sentinel)
+		}
+	}
 }

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -4418,7 +4418,7 @@ func TestToAPIError_KnownSentinelsAreNotUnclassified(t *testing.T) {
 	}
 	for _, sentinel := range sentinels {
 		result := toAPIError(sentinel)
-		if result == sentinel {
+		if errors.Is(result, sentinel) {
 			t.Errorf("toAPIError(%v) returned the sentinel unchanged; it must be mapped to a typed API error", sentinel)
 		}
 	}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -38,6 +38,14 @@ var (
 	ErrAgentExited      = errors.New("session: agent exited")
 	ErrAgentNotExited   = errors.New("session: agent has not exited")
 	ErrIncompleteHandle = errors.New("session: incomplete teardown handle")
+	// ErrIncompleteSpawn identifies a session whose spawn never completed. The
+	// session row exists and is not terminated, but WorkspacePath and/or
+	// RuntimeHandleID were never written — either because the daemon crashed
+	// mid-spawn or because MarkSpawned failed after runtime.Create. Boot-time
+	// reconciliation (reconcileLive) detects and terminates these sessions.
+	// The API maps it to a 409 Conflict so the caller knows the session is
+	// unrecoverable and must spawn a fresh one.
+	ErrIncompleteSpawn = errors.New("session: spawn did not complete")
 	// ErrProjectNotResolvable means the spawn's project has no usable repo
 	// (unregistered, archived, or missing a path). The API maps it to a 400.
 	ErrProjectNotResolvable = errors.New("session: project repo not resolvable")
@@ -2242,7 +2250,48 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 		return err
 	}
 	projectKind := project.Kind.WithDefault()
-	if rec.Metadata.WorkspacePath == "" || (rec.Metadata.Branch == "" && projectKind != domain.ProjectKindScratch) {
+
+	// Detect sessions whose spawn never completed. These fall into two sub-cases
+	// distinguished by whether runtime.Create had already been called:
+	//
+	//  1. Pure zombie: WorkspacePath and RuntimeHandleID are both empty. The row
+	//     was created by CreateSession but spawn failed before createSessionWorkspace
+	//     returned. There is no workspace on disk and no runtime process — only the
+	//     DB row. Terminate it outright so it does not appear live on the dashboard.
+	//
+	//  2. Partial spawn: WorkspacePath is empty but RuntimeHandleID is set. Spawn
+	//     called runtime.Create successfully but then MarkSpawned (or an earlier
+	//     step that writes WorkspacePath to metadata) failed. A real process may
+	//     be running orphaned. Destroy it before terminating so it does not leak.
+	//
+	// Both cases must never reach the normal relaunch/adopt logic below, which
+	// assumes a real worktree exists and is safe to stash or attach to.
+	if rec.Metadata.WorkspacePath == "" {
+		handle := runtimeHandle(rec.Metadata)
+		if handle.ID != "" {
+			// Partial spawn: an orphaned runtime process may be running.
+			// Destroy it best-effort; a failure here is logged but must not
+			// prevent the session from being terminated, since there is no
+			// workspace to restore and the session is unrecoverable regardless.
+			if err := m.runtime.Destroy(ctx, handle); err != nil {
+				m.logger.Warn("reconcile: failed to destroy orphaned runtime for partial-spawn session; terminating anyway",
+					"sessionID", rec.ID, "handleID", handle.ID, "error", err)
+			}
+		} else {
+			m.logger.Warn("reconcile: incomplete-spawn zombie has no workspace or runtime; terminating",
+				"sessionID", rec.ID)
+		}
+		if err := m.lcm.MarkTerminated(ctx, rec.ID); err != nil {
+			return fmt.Errorf("%w: %w", ErrIncompleteSpawn, err)
+		}
+		return nil
+	}
+
+	// From here WorkspacePath is set: the spawn completed far enough that a real
+	// worktree exists. The existing Branch guard below still applies for non-scratch
+	// projects — a missing Branch with a present WorkspacePath is an edge case
+	// (e.g. interrupted just after workspace create), treated the same way.
+	if rec.Metadata.Branch == "" && projectKind != domain.ProjectKindScratch {
 		return nil
 	}
 	// A chat controller is an in-process child of the daemon, so unlike tmux it can

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -8163,3 +8163,327 @@ func (m *flipOnNudgeMessenger) Send(_ context.Context, _ domain.SessionID, msg s
 	}
 	return nil
 }
+
+// TestReconcileLive_TerminatesIncompleteSpawnWithNoWorkspaceOrRuntime verifies
+// that a session row with empty WorkspacePath and RuntimeHandleID (pure zombie)
+// is marked terminated during boot reconciliation.
+func TestReconcileLive_TerminatesIncompleteSpawnWithNoWorkspaceOrRuntime(t *testing.T) {
+	// Arrange
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: lcm,
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID:        "p1-1",
+		ProjectID: "p1",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+	}
+	st.sessions[rec.ID] = rec
+
+	// Act
+	err := m.reconcileLive(context.Background(), rec)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("reconcileLive: %v", err)
+	}
+	if !st.sessions[rec.ID].IsTerminated {
+		t.Error("incomplete-spawn zombie must be terminated by reconcileLive; session is still live")
+	}
+	if lcm.terminated[rec.ID] != 1 {
+		t.Errorf("MarkTerminated calls = %d, want exactly 1", lcm.terminated[rec.ID])
+	}
+	if ws.stashCalls != 0 || len(ws.calls) != 0 {
+		t.Errorf("workspace touched on a zombie session: stash=%d calls=%v", ws.stashCalls, ws.calls)
+	}
+	if rt.created != 0 || rt.destroyed != 0 {
+		t.Errorf("runtime touched on a zombie session: created=%d destroyed=%d", rt.created, rt.destroyed)
+	}
+}
+
+// TestReconcileLive_DestroysLeakedRuntimeWhenWorkspacePathMissing covers the partial spawn
+// case where runtime.Create succeeded but MarkSpawned failed before writing WorkspacePath.
+// reconcileLive must destroy the leaked runtime before terminating the session.
+func TestReconcileLive_DestroysLeakedRuntimeWhenWorkspacePathMissing(t *testing.T) {
+	// Arrange
+	const leakedHandle = "leaked-h1"
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{aliveByHandle: map[string]bool{leakedHandle: true}}
+	ws := &fakeWorkspace{}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: lcm,
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID:        "p1-2",
+		ProjectID: "p1",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID: leakedHandle,
+		},
+	}
+	st.sessions[rec.ID] = rec
+
+	// Act
+	err := m.reconcileLive(context.Background(), rec)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("reconcileLive: %v", err)
+	}
+	if !st.sessions[rec.ID].IsTerminated {
+		t.Error("partial-spawn session with leaked runtime must be terminated by reconcileLive")
+	}
+	if lcm.terminated[rec.ID] != 1 {
+		t.Errorf("MarkTerminated calls = %d, want exactly 1", lcm.terminated[rec.ID])
+	}
+	if rt.destroyed != 1 {
+		t.Errorf("Destroy calls = %d, want exactly 1 (leaked runtime must be reaped)", rt.destroyed)
+	}
+	if len(rt.destroyedIDs) != 1 || rt.destroyedIDs[0] != leakedHandle {
+		t.Errorf("destroyedIDs = %v, want [%s]", rt.destroyedIDs, leakedHandle)
+	}
+	if ws.stashCalls != 0 || len(ws.calls) != 0 {
+		t.Errorf("workspace touched on a partial-spawn session: stash=%d calls=%v", ws.stashCalls, ws.calls)
+	}
+}
+
+// TestPreserveFailedSpawnWorkspace_ClearsRuntimeHandleWhenRuntimeDestroyed asserts
+// that when workspace cleanup fails during spawn rollback with runtimeDestroyed=true,
+// preserveFailedSpawnWorkspace clears RuntimeHandleID and marks the session terminated.
+func TestPreserveFailedSpawnWorkspace_ClearsRuntimeHandleWhenRuntimeDestroyed(t *testing.T) {
+	// Arrange
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{destroyErr: errors.New("git worktree remove: directory is busy")}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: lcm,
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID:        "p1-3",
+		ProjectID: "p1",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID: "h-was-created-then-destroyed",
+		},
+	}
+	st.sessions[rec.ID] = rec
+	wsInfo := ports.WorkspaceInfo{
+		SessionID: rec.ID,
+		Branch:    "ao/p1-3/root",
+		Path:      "/wt/p1-3",
+	}
+
+	// Act
+	m.rollbackSeedSpawnWorkspace(context.Background(), rec, wsInfo, nil, true)
+
+	// Assert
+	stored := st.sessions[rec.ID]
+	if !stored.IsTerminated {
+		t.Error("rollbackSeedSpawnWorkspace must terminate the row when workspace destroy fails")
+	}
+	if lcm.terminated[rec.ID] != 1 {
+		t.Errorf("MarkTerminated calls = %d, want 1", lcm.terminated[rec.ID])
+	}
+	if stored.Metadata.WorkspacePath != wsInfo.Path {
+		t.Errorf("WorkspacePath = %q, want %q (orphaned worktree must be traceable)",
+			stored.Metadata.WorkspacePath, wsInfo.Path)
+	}
+	if stored.Metadata.Branch != wsInfo.Branch {
+		t.Errorf("Branch = %q, want %q", stored.Metadata.Branch, wsInfo.Branch)
+	}
+	if stored.Metadata.RuntimeHandleID != "" {
+		t.Errorf("RuntimeHandleID = %q, want empty (runtime was destroyed during rollback)",
+			stored.Metadata.RuntimeHandleID)
+	}
+}
+
+// TestPreserveFailedSpawnWorkspace_KeepsRuntimeHandleWhenDestroyFailed asserts that when
+// runtime destruction fails during rollback, preserveFailedSpawnWorkspace retains
+// RuntimeHandleID so boot reconciliation can attempt process adoption or cleanup.
+func TestPreserveFailedSpawnWorkspace_KeepsRuntimeHandleWhenDestroyFailed(t *testing.T) {
+	// Arrange
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{destroyErr: errors.New("workspace: device or resource busy")}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: lcm,
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+	const aliveHandle = "still-running-h1"
+	rec := domain.SessionRecord{
+		ID:        "p1-4",
+		ProjectID: "p1",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID: aliveHandle,
+		},
+	}
+	st.sessions[rec.ID] = rec
+	wsInfo := ports.WorkspaceInfo{
+		SessionID: rec.ID,
+		Branch:    "ao/p1-4/root",
+		Path:      "/wt/p1-4",
+	}
+
+	// Act
+	m.rollbackPreparedSpawnWorkspace(context.Background(), rec, wsInfo, nil, false)
+
+	// Assert
+	stored := st.sessions[rec.ID]
+	if stored.Metadata.WorkspacePath != wsInfo.Path {
+		t.Errorf("WorkspacePath = %q, want %q", stored.Metadata.WorkspacePath, wsInfo.Path)
+	}
+	if stored.Metadata.RuntimeHandleID != aliveHandle {
+		t.Errorf("RuntimeHandleID = %q, want %q (runtime survived, must be kept for boot adopt)",
+			stored.Metadata.RuntimeHandleID, aliveHandle)
+	}
+}
+
+// failingMarkSpawnedLCM wraps fakeLCM and injects an error on MarkSpawned.
+type failingMarkSpawnedLCM struct {
+	*fakeLCM
+	markSpawnedErr error
+	markSpawnedHit bool
+}
+
+func (l *failingMarkSpawnedLCM) MarkSpawned(ctx context.Context, id domain.SessionID, metadata domain.SessionMetadata) error {
+	l.markSpawnedHit = true
+	if l.markSpawnedErr != nil {
+		return l.markSpawnedErr
+	}
+	return l.fakeLCM.MarkSpawned(ctx, id, metadata)
+}
+
+// TestSpawn_MarkSpawnedFailureLeavesTerminatedRow verifies end-to-end spawn rollback when
+// MarkSpawned fails after runtime.Create succeeded.
+func TestSpawn_MarkSpawnedFailureLeavesTerminatedRow(t *testing.T) {
+	// Arrange
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	baseLCM := &fakeLCM{store: st}
+	lcm := &failingMarkSpawnedLCM{
+		fakeLCM:        baseLCM,
+		markSpawnedErr: errors.New("sqlite3: database is locked"),
+	}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: lcm,
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	// Act
+	_, _, _, err := m.Spawn(context.Background(), ports.SpawnConfig{
+		ProjectID: "p1",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Prompt:    "implement the feature",
+	})
+
+	// Assert
+	if err == nil {
+		t.Fatal("Spawn: expected non-nil error when MarkSpawned fails, got nil")
+	}
+	if !lcm.markSpawnedHit {
+		t.Fatal("MarkSpawned was never called; test did not reach the target failure point")
+	}
+	if rt.destroyed == 0 {
+		t.Errorf("runtime.Destroy calls = %d, want >= 1 (orphaned runtime must be cleaned up)", rt.destroyed)
+	}
+	for id, row := range st.sessions {
+		if !row.IsTerminated {
+			t.Errorf("session %s is still live after a failed MarkSpawned; want terminated or deleted", id)
+		}
+	}
+}
+
+// TestReconcile_DoesNotRelaunchPreservedFailedSpawnWorkspace verifies that Reconcile on daemon start
+// does not resurrect a session preserved from a failed spawn attempt.
+func TestReconcile_DoesNotRelaunchPreservedFailedSpawnWorkspace(t *testing.T) {
+	// Arrange
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	lcm := &fakeLCM{store: st}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: lcm,
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+	st.sessions["p1-5"] = domain.SessionRecord{
+		ID: "p1-5", ProjectID: "p1", Kind: domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Activity:     domain.Activity{State: domain.ActivityExited},
+		Metadata: domain.SessionMetadata{
+			Branch:        "ao/p1-5/root",
+			WorkspacePath: "/wt/p1-5",
+		},
+	}
+
+	// Act
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// Assert
+	if !st.sessions["p1-5"].IsTerminated {
+		t.Error("Reconcile must not resurrect a terminated preserved-spawn-failure session")
+	}
+	if rt.created != 0 {
+		t.Errorf("runtime.Create calls = %d, want 0 (failed spawn must not be relaunched)", rt.created)
+	}
+	if len(ws.restoreConfigs) != 0 {
+		t.Errorf("workspace.Restore calls = %v, want 0 (no restore marker present)", ws.restoreConfigs)
+	}
+	if st.num != 0 {
+		t.Errorf("Reconcile minted %d new session(s); a failed spawn must never be resurrected", st.num)
+	}
+}


### PR DESCRIPTION
Code changes: +29 -1  
Tests: +413 -0  
Others: +0 -0

Fixes #4744

## What
- Implemented boot-time reconciliation for incomplete spawn sessions (`WorkspacePath == ""`), terminating zombie rows and reaping orphaned runtime handles (`runtime.Destroy`).
- Ensured atomic spawn rollback logic clears `RuntimeHandleID` when runtime destruction succeeds, preventing orphaned process adoption on reboot.
- Added structured `slog.Error` logging in `Service.Spawn` for unclassified internal errors prior to API error masking.
- Introduced `ErrIncompleteSpawn` sentinel error mapped to HTTP `409 Conflict` (`SESSION_SPAWN_INCOMPLETE`).


## Why
Intermittent errors during `ao spawn` were leaving behind orphaned Git worktrees, unkillable database rows, and unmonitored tmux/agent runtime processes. Server logs lacked context for unclassified spawn failures.


## How
- `reconcileLive` in `manager.go`: Added detection for missing `WorkspacePath`. Reaps orphaned handles and marks rows terminated.
- `service.go`: Added identity check `apiErr == err` to log raw errors at `ERROR` level before returning masked 500s.
- `manager.go` & `service.go`: Defined `ErrIncompleteSpawn` sentinel and mapped it to `apierr.Conflict("SESSION_SPAWN_INCOMPLETE", ...)`.


## Testing
- `go test ./internal/session_manager/...` (Added 6 integration tests)
- `go test ./internal/service/session/...` (Added 3 unit tests)

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
