### PR TITLE
fix(scm/github): make rate-limit errors trigger observer cooldown

### DIFF
--- a/backend/internal/adapters/scm/github/client.go
+++ b/backend/internal/adapters/scm/github/client.go
@@ -56,6 +56,26 @@ func (e *RateLimitError) Error() string {
 // Is lets errors.Is match a *RateLimitError against ErrRateLimited.
 func (e *RateLimitError) Is(target error) bool { return target == ErrRateLimited }
 
+// GetRetryAfter exposes the Retry-After hint for the provider-neutral observer's
+// rateLimitCooldown helper. Without this getter (and GetResetAt below) the
+// observer's errors.As match fails for GitHub, so a GitHub rate-limit never puts
+// the provider into cooldown and the daemon keeps polling every tick. Mirrors
+// the GitLab RateLimitError getters.
+func (e *RateLimitError) GetRetryAfter() time.Duration {
+	if e == nil {
+		return 0
+	}
+	return e.RetryAfter
+}
+
+// GetResetAt exposes the RateLimit-Reset hint for the observer's cooldown helper.
+func (e *RateLimitError) GetResetAt() time.Time {
+	if e == nil {
+		return time.Time{}
+	}
+	return e.ResetAt
+}
+
 // ClientOptions configures a Client. Production code sets Token alone;
 // tests inject HTTPClient and the URL fields to point at an httptest fake.
 type ClientOptions struct {

--- a/backend/internal/adapters/scm/github/ratelimit_getters_test.go
+++ b/backend/internal/adapters/scm/github/ratelimit_getters_test.go
@@ -1,0 +1,37 @@
+package github
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// rateLimitCooldownSource is the shape the provider-neutral observer requires
+// (observe/scm/observer.go) to extract a cooldown from a rate-limit error via
+// errors.As. Regression guard for the bug where *RateLimitError carried the
+// hints as fields but not methods, so the observer's errors.As never matched
+// for GitHub and cooldown never fired. A test double previously masked this.
+type rateLimitCooldownSource interface {
+	error
+	GetRetryAfter() time.Duration
+	GetResetAt() time.Time
+}
+
+func TestRateLimitErrorSatisfiesObserverCooldownContract(t *testing.T) {
+	reset := time.Now().Add(90 * time.Second)
+	var err error = &RateLimitError{ResetAt: reset, RetryAfter: 42 * time.Second, Message: "secondary limit"}
+
+	var src rateLimitCooldownSource
+	if !errors.As(err, &src) {
+		t.Fatal("*github.RateLimitError must satisfy the observer's cooldown getter interface (errors.As failed)")
+	}
+	if got := src.GetRetryAfter(); got != 42*time.Second {
+		t.Fatalf("GetRetryAfter = %v, want 42s", got)
+	}
+	if got := src.GetResetAt(); !got.Equal(reset) {
+		t.Fatalf("GetResetAt = %v, want %v", got, reset)
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatal("must still match ErrRateLimited")
+	}
+}


### PR DESCRIPTION
GitHub `RateLimitError` exposed `ResetAt`/`RetryAfter` as fields but not methods, so the observer's `errors.As` (which needs `GetRetryAfter()`/`GetResetAt()`) never matched for GitHub. Result: a GitHub rate-limit never triggers the bounded cooldown and the daemon keeps polling every 30s, worsening exhaustion. GitLab already implements the interface, so the fleet degrades asymmetrically. Masked in tests by a local double that implements the getters.

Fix: add the two getters mirroring `gitlab/client.go`, plus a regression test that a real `*github.RateLimitError` satisfies the observer's cooldown contract via `errors.As`.

Found in the pre-10k QA audit (finding GH-1).