### PR TITLE
fix(session): map ErrNoController to a typed 409 on the send path, not a raw 500

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
 	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
 )
@@ -902,6 +903,14 @@ func toAPIError(err error) error {
 		return apierr.Conflict("SESSION_NOT_RESTORABLE", "Session is not restorable", nil)
 	case errors.Is(err, sessionmanager.ErrTerminated):
 		return apierr.Conflict("SESSION_TERMINATED", "Session is terminated", nil)
+	case errors.Is(err, chatsvc.ErrNoController):
+		// The session's chat controller is not live yet (daemon just restarted,
+		// controller stopped, mid-reconnect). This is a transient not-ready, not a
+		// server fault, so it must be a typed 409 rather than an untyped 500. The
+		// conversation-send path already maps it this way; the session-send path
+		// (orchestrator relay, `ao send`) fell through to a raw 500 here.
+		return apierr.Conflict("CHAT_CONTROLLER_NOT_READY",
+			"the agent controller for this session is not running", nil)
 	case errors.Is(err, sessionmanager.ErrAgentExited):
 		return apierr.Conflict("AGENT_EXITED",
 			"The agent process exited; relaunch it before sending another message", nil)

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
 	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
 )
 
@@ -3061,6 +3062,19 @@ func TestToAPIError_NotResumable(t *testing.T) {
 	var e *apierr.Error
 	if !errors.As(mapped, &e) || e.Kind != apierr.KindConflict || e.Code != "SESSION_NOT_RESUMABLE" {
 		t.Fatalf("mapped = %v, want Conflict SESSION_NOT_RESUMABLE", mapped)
+	}
+}
+
+// A send to a session whose chat controller is not live must map to a typed 409
+// CHAT_CONTROLLER_NOT_READY, not a raw 500. Regression for the session-send path
+// (orchestrator relay / `ao send`) that previously fell through toAPIError's
+// default and surfaced `send X: no live chat controller for session` as a 500.
+func TestToAPIError_NoChatController(t *testing.T) {
+	err := fmt.Errorf("send mer-1: %w", chatsvc.ErrNoController)
+	mapped := toAPIError(err)
+	var e *apierr.Error
+	if !errors.As(mapped, &e) || e.Kind != apierr.KindConflict || e.Code != "CHAT_CONTROLLER_NOT_READY" {
+		t.Fatalf("mapped = %v, want Conflict CHAT_CONTROLLER_NOT_READY", mapped)
 	}
 }
 


### PR DESCRIPTION
A send to a session whose chat controller is not live (daemon just restarted, controller stopped, mid-reconnect) returned `chatsvc.ErrNoController`, which had no case in `toAPIError` and fell through to a raw 500 `INTERNAL_ERROR`, shipping `send <id>: no live chat controller for session` to the client and Sentry. The conversation-send path already maps this to 409 `CHAT_CONTROLLER_NOT_READY`; the session-send path (orchestrator relay, `ao send`) diverged.

Fix: add the `ErrNoController` case to `toAPIError` returning the same typed 409, plus a regression test. No import cycle (service/chat does not import service/session).

QA audit finding CHAT-1 (production error AO-DESKTOP-5).