### PR TITLE
fix(observability): harden daemon Sentry capture (re-land #4352)

### DIFF
--- a/backend/internal/httpd/log.go
+++ b/backend/internal/httpd/log.go
@@ -34,6 +34,9 @@ func requestLogger(log *slog.Logger, sink ports.EventSink) func(http.Handler) ht
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 			r, capturedErr := envelope.WithErrorCapture(r)
+			// Install the single-capture marker before the inner recover
+			// middleware runs, so a recovered panic captures exactly once.
+			r = withSentryCaptureState(r)
 			start := time.Now()
 			defer func() {
 				attrs := []any{
@@ -86,8 +89,11 @@ func requestLogger(log *slog.Logger, sink ports.EventSink) func(http.Handler) ht
 						})
 					}
 					// Capture genuine faults to Sentry with the real error/stack.
-					// 503 (transient contention) is excluded by ShouldCaptureStatus.
-					if sentryobs.ShouldCaptureStatus(ww.Status()) {
+					// Skip when the panic recover middleware already captured this
+					// failure (otherwise one panic becomes two issues), and skip the
+					// deliberate SERVICE_UNAVAILABLE backpressure 503 (other typed
+					// 503 outages are still captured).
+					if !sentryAlreadyCaptured(r.Context()) && sentryobs.ShouldCapture(ww.Status(), errorCode) {
 						err := capErr
 						if err == nil {
 							err = fmt.Errorf("HTTP %d %s %s", ww.Status(), r.Method, path)

--- a/backend/internal/httpd/recover.go
+++ b/backend/internal/httpd/recover.go
@@ -51,7 +51,9 @@ func recoverTelemetry(log *slog.Logger, sink ports.EventSink) func(http.Handler)
 							},
 						})
 					}
-					// Capture the panic to Sentry with its Go stack.
+					// Capture the panic to Sentry with its Go stack, then mark this
+					// request captured so the outer 5xx logger does not emit a second
+					// generic event for the 500 this recovery is about to write.
 					sentryobs.CapturePanic(r.Context(), rec, stack, map[string]string{
 						"component":  "httpd",
 						"operation":  "http_request_panic",
@@ -60,6 +62,7 @@ func recoverTelemetry(log *slog.Logger, sink ports.EventSink) func(http.Handler)
 						"panic_kind": panicKind,
 						"request_id": middleware.GetReqID(r.Context()),
 					}, fingerprint)
+					markSentryCaptured(r.Context())
 					writeRecoveredError(w, r)
 				}
 			}()

--- a/backend/internal/httpd/sentry_capture.go
+++ b/backend/internal/httpd/sentry_capture.go
@@ -1,0 +1,42 @@
+package httpd
+
+import (
+	"context"
+	"net/http"
+)
+
+// sentryCaptureState is a request-scoped flag marking that a failure for this
+// request has already been sent to Sentry. It lets the panic recover middleware
+// and the outer 5xx access-log seam agree on a single capture: recovery sends
+// the panic (fatal, with the Go stack and request id) and sets this, so the
+// logger does not then manufacture a second generic "HTTP 500" event with a
+// different fingerprint — one panic would otherwise become two issues.
+//
+// The slot is installed by the outer request logger and confined to a single
+// request goroutine (chi serves each request on one goroutine, and the recover
+// and logger deferreds both run on it in sequence), so the plain bool needs no
+// synchronization.
+type sentryCaptureState struct{ captured bool }
+
+type sentryCaptureKey struct{}
+
+// withSentryCaptureState installs the marker on the request context. The request
+// logger (outer middleware) installs it so the inner recover middleware shares
+// the same slot.
+func withSentryCaptureState(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), sentryCaptureKey{}, &sentryCaptureState{}))
+}
+
+// markSentryCaptured records that this request's failure was already captured.
+func markSentryCaptured(ctx context.Context) {
+	if s, ok := ctx.Value(sentryCaptureKey{}).(*sentryCaptureState); ok {
+		s.captured = true
+	}
+}
+
+// sentryAlreadyCaptured reports whether a failure was already captured for this
+// request.
+func sentryAlreadyCaptured(ctx context.Context) bool {
+	s, ok := ctx.Value(sentryCaptureKey{}).(*sentryCaptureState)
+	return ok && s.captured
+}

--- a/backend/internal/httpd/sentry_capture_test.go
+++ b/backend/internal/httpd/sentry_capture_test.go
@@ -1,0 +1,158 @@
+package httpd
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/observe/sentryobs"
+)
+
+// recordingTransport is a synchronous in-memory sentry.Transport used to count
+// and inspect the events the SDK actually processes for a request.
+type recordingTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *recordingTransport) Configure(sentry.ClientOptions) {}
+func (t *recordingTransport) SendEvent(event *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+func (t *recordingTransport) Flush(time.Duration) bool              { return true }
+func (t *recordingTransport) FlushWithContext(context.Context) bool { return true }
+func (t *recordingTransport) Close()                                {}
+
+func (t *recordingTransport) snapshot() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]*sentry.Event, len(t.events))
+	copy(out, t.events)
+	return out
+}
+
+// enableRecordingSentry enables sentryobs and routes captures to an in-memory
+// recording transport, restoring prior state on cleanup.
+func enableRecordingSentry(t *testing.T) *recordingTransport {
+	t.Helper()
+	// A non-empty DSN flips sentryobs on; the client is then replaced so events
+	// land in the recording transport instead of going over the network.
+	if err := sentryobs.Init(sentryobs.Config{DSN: "http://publickey@127.0.0.1:1/1"}); err != nil {
+		t.Fatalf("init sentry: %v", err)
+	}
+	tr := &recordingTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{Transport: tr, SampleRate: 1.0})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	prev := sentry.CurrentHub().Client()
+	sentry.CurrentHub().BindClient(client)
+	t.Cleanup(func() {
+		sentry.CurrentHub().BindClient(prev)
+		sentryobs.Disable()
+	})
+	return tr
+}
+
+// TestPanicCapturedExactlyOnce is the regression guard for issue #4352,
+// problem 2: the recover middleware captures a panic (fatal, with the Go stack
+// and request id), then the outer 5xx logger observes the resulting 500 and
+// would manufacture a second generic "HTTP 500" event with a different
+// fingerprint. Recovery now marks the request captured so the logger skips it.
+// Exactly one event must be captured, and it must be the panic event.
+func TestPanicCapturedExactlyOnce(t *testing.T) {
+	tr := enableRecordingSentry(t)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Same order as router.go: RequestID (so a request id exists) → requestLogger
+	// (outer) → recoverTelemetry (inner) → handler.
+	handler := middleware.RequestID(requestLogger(log, nil)(recoverTelemetry(log, nil)(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			panic("kaboom from handler")
+		}),
+	)))
+
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, httptest.NewRequest(http.MethodPost, "/api/v1/sessions/x/kill", nil))
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp.Code)
+	}
+
+	events := tr.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("captured %d Sentry events, want exactly 1", len(events))
+	}
+	ev := events[0]
+	if ev.Level != sentry.LevelFatal {
+		t.Fatalf("event level = %q, want fatal (the panic event, not the generic 500)", ev.Level)
+	}
+	if len(ev.Exception) == 0 || !strings.Contains(ev.Exception[0].Value, "panic: kaboom from handler") {
+		t.Fatalf("event does not carry the panic value: %+v", ev.Exception)
+	}
+	if _, ok := ev.Contexts["runtime"]; !ok {
+		t.Fatalf("event missing the Go stack (runtime context): %+v", ev.Contexts)
+	}
+	if ev.Tags["request_id"] == "" {
+		t.Fatalf("event missing request_id tag: %+v", ev.Tags)
+	}
+	if ev.Tags["operation"] != "http_request_panic" {
+		t.Fatalf("event operation tag = %q, want http_request_panic", ev.Tags["operation"])
+	}
+}
+
+// TestNonPanic5xxStillCaptured confirms the dedup marker does not suppress the
+// ordinary path: a handler that writes a 500 via envelope.WriteError (no panic,
+// so recovery never runs) is still captured once by the 5xx logger seam.
+func TestNonPanic5xxStillCaptured(t *testing.T) {
+	tr := enableRecordingSentry(t)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	handler := middleware.RequestID(requestLogger(log, nil)(recoverTelemetry(log, nil)(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+	)))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/api/v1/x", nil))
+
+	events := tr.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("captured %d events for a plain 500, want exactly 1", len(events))
+	}
+	if events[0].Level != sentry.LevelError {
+		t.Fatalf("plain 500 event level = %q, want error", events[0].Level)
+	}
+}
+
+// TestTyped503CapturePolicy is the regression guard for issue #4352, problem 3:
+// only the deliberate SERVICE_UNAVAILABLE backpressure 503 is suppressed; other
+// typed 503 outages are captured.
+func TestTyped503CapturePolicy(t *testing.T) {
+	cases := []struct {
+		code     string
+		captured bool
+	}{
+		{code: "SERVICE_UNAVAILABLE", captured: false},
+		{code: "SCM_UNAVAILABLE", captured: true},
+		{code: "BROWSER_RUNTIME_UNAVAILABLE", captured: true},
+		{code: "DEVICE_REGISTRY_UNAVAILABLE", captured: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			if got := sentryobs.ShouldCapture(http.StatusServiceUnavailable, tc.code); got != tc.captured {
+				t.Fatalf("ShouldCapture(503, %q) = %v, want %v", tc.code, got, tc.captured)
+			}
+		})
+	}
+}

--- a/backend/internal/observe/sentryobs/capture_transport_test.go
+++ b/backend/internal/observe/sentryobs/capture_transport_test.go
@@ -1,0 +1,136 @@
+package sentryobs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// recordingTransport is an in-memory sentry.Transport that records every event
+// the client sends, synchronously and under a mutex so it is safe under -race.
+type recordingTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *recordingTransport) Configure(sentry.ClientOptions) {}
+func (t *recordingTransport) SendEvent(event *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+func (t *recordingTransport) Flush(time.Duration) bool              { return true }
+func (t *recordingTransport) FlushWithContext(context.Context) bool { return true }
+func (t *recordingTransport) Close()                                {}
+
+func (t *recordingTransport) snapshot() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]*sentry.Event, len(t.events))
+	copy(out, t.events)
+	return out
+}
+
+// bindRecordingClient wires a client with the recording transport onto the
+// process hub and marks sentryobs enabled, restoring both on cleanup. It uses
+// the same BeforeSend scrub as Init so captures go through the real pipeline.
+func bindRecordingClient(t *testing.T) *recordingTransport {
+	t.Helper()
+	tr := &recordingTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Transport:  tr,
+		SampleRate: 1.0,
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			return scrubEvent(event)
+		},
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	prev := sentry.CurrentHub().Client()
+	sentry.CurrentHub().BindClient(client)
+	enabled.Store(true)
+	t.Cleanup(func() {
+		enabled.Store(false)
+		sentry.CurrentHub().BindClient(prev)
+	})
+	return tr
+}
+
+// TestConcurrentCapturesDoNotShareScope is the regression guard for issue #4352,
+// problem 1: package-level sentry.WithScope / CaptureException share one scope
+// stack on the global hub, so concurrent captures can interleave and stamp one
+// request's request id / fingerprint onto another's event. Each capture now runs
+// on its own hub, so every recorded event must carry only its own metadata.
+// Run under `go test -race`.
+func TestConcurrentCapturesDoNotShareScope(t *testing.T) {
+	tr := bindRecordingClient(t)
+
+	const n = 64
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("req-%03d", i)
+			CaptureHTTPError(context.Background(), fmt.Errorf("boom %s", id), map[string]string{
+				"request_id": id,
+				"operation":  "http_request",
+			}, id)
+		}(i)
+	}
+	wg.Wait()
+
+	events := tr.snapshot()
+	if len(events) != n {
+		t.Fatalf("recorded %d events, want %d", len(events), n)
+	}
+	seen := make(map[string]int, n)
+	for _, ev := range events {
+		reqID := ev.Tags["request_id"]
+		if reqID == "" {
+			t.Fatalf("event missing request_id tag: %+v", ev.Tags)
+		}
+		// The fingerprint was set to the same id as the request_id tag. If two
+		// captures' scopes interleaved, an event would carry one request's id
+		// with another's fingerprint.
+		if len(ev.Fingerprint) != 1 || ev.Fingerprint[0] != reqID {
+			t.Fatalf("event request_id=%q has fingerprint %v, want [%q] (scopes crossed)", reqID, ev.Fingerprint, reqID)
+		}
+		if ev.Tags["platform"] != "daemon" {
+			t.Fatalf("event %q missing platform=daemon tag: %+v", reqID, ev.Tags)
+		}
+		seen[reqID]++
+	}
+	if len(seen) != n {
+		t.Fatalf("distinct request ids = %d, want %d (events lost or duplicated)", len(seen), n)
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("request id %q captured %d times, want 1", id, count)
+		}
+	}
+}
+
+// TestCaptureHTTPErrorScrubsThroughTransport confirms the enabled capture path
+// scrubs a local path from the message before it reaches the transport (not just
+// in the pure scrub helper).
+func TestCaptureHTTPErrorScrubsThroughTransport(t *testing.T) {
+	tr := bindRecordingClient(t)
+	CaptureHTTPError(context.Background(), fmt.Errorf("open /Users/secret/x.go: denied"),
+		map[string]string{"request_id": "r1"}, "fp")
+	events := tr.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("recorded %d events, want 1", len(events))
+	}
+	for _, ex := range events[0].Exception {
+		if strings.Contains(ex.Value, "/Users/secret") {
+			t.Fatalf("exception value leaked local path: %q", ex.Value)
+		}
+	}
+}

--- a/backend/internal/observe/sentryobs/sentryobs.go
+++ b/backend/internal/observe/sentryobs/sentryobs.go
@@ -77,6 +77,11 @@ func Init(cfg Config) error {
 // Enabled reports whether Sentry is active (a DSN was configured).
 func Enabled() bool { return enabled.Load() }
 
+// Disable turns capture back into a no-op. Every capture short-circuits on the
+// enabled flag, so this is sufficient to quiesce reporting without touching the
+// bound client. Symmetric with Init; used to restore a clean state in tests.
+func Disable() { enabled.Store(false) }
+
 func scrubEvent(event *sentry.Event) *sentry.Event {
 	event.Message = scrub(event.Message)
 	event.ServerName = "" // never leak the machine hostname
@@ -93,36 +98,70 @@ func scrubEvent(event *sentry.Event) *sentry.Event {
 	return event
 }
 
-// ShouldCaptureStatus reports whether an HTTP status is a genuine server fault
-// worth an issue. 5xx qualifies, except 503 (transient/retryable contention).
-func ShouldCaptureStatus(status int) bool {
-	return status >= http.StatusInternalServerError && status != http.StatusServiceUnavailable
+// BackpressureCode is the one 503 that is deliberate, retryable contention
+// rather than a fault: the daemon's SERVICE_UNAVAILABLE backpressure signal.
+// Every other 5xx — including typed 503 outages such as SCM_UNAVAILABLE,
+// BROWSER_RUNTIME_UNAVAILABLE, or DEVICE_REGISTRY_UNAVAILABLE — is a genuine
+// fault worth an issue.
+const BackpressureCode = "SERVICE_UNAVAILABLE"
+
+// ShouldCapture reports whether an HTTP status paired with its normalized daemon
+// error code is a genuine server fault worth an issue. 5xx qualifies, except a
+// 503 that carries the deliberate SERVICE_UNAVAILABLE backpressure code. A 503
+// with any other (or no) code is a real outage and is captured.
+func ShouldCapture(status int, errorCode string) bool {
+	if status < http.StatusInternalServerError {
+		return false
+	}
+	if status == http.StatusServiceUnavailable && errorCode == BackpressureCode {
+		return false
+	}
+	return true
+}
+
+// hubFromContext returns an isolated Sentry hub for this capture. The
+// package-level sentry.WithScope / sentry.CaptureException operate on the
+// process-global CurrentHub, whose scope stack is shared: two concurrent
+// requests can interleave push/callback/pop and stamp one request's tags,
+// fingerprint, and request id onto another's event. A hub carried on the
+// request context is used when present; otherwise the current hub is cloned so
+// each capture gets its own scope stack.
+func hubFromContext(ctx context.Context) *sentry.Hub {
+	if ctx != nil {
+		if hub := sentry.GetHubFromContext(ctx); hub != nil {
+			return hub
+		}
+	}
+	return sentry.CurrentHub().Clone()
 }
 
 // CaptureHTTPError captures a server-fault error with the given tags and a
-// fingerprint identical to the PostHog grouping key. No-op when disabled or the
-// error is nil.
-func CaptureHTTPError(_ context.Context, err error, tags map[string]string, fingerprint string) {
+// fingerprint identical to the PostHog grouping key, on a hub isolated to this
+// request. No-op when disabled or the error is nil.
+func CaptureHTTPError(ctx context.Context, err error, tags map[string]string, fingerprint string) {
 	if !enabled.Load() || err == nil {
 		return
 	}
-	sentry.WithScope(func(scope *sentry.Scope) {
+	hub := hubFromContext(ctx)
+	hub.WithScope(func(scope *sentry.Scope) {
 		scope.SetLevel(sentry.LevelError)
 		applyTags(scope, tags)
 		if fingerprint != "" {
 			scope.SetFingerprint([]string{fingerprint})
 		}
-		sentry.CaptureException(err)
+		hub.CaptureException(err)
 	})
 }
 
-// CapturePanic captures a recovered panic with its Go stack (as scrubbed extra)
-// at fatal level. No-op when disabled.
-func CapturePanic(_ context.Context, recovered any, stack string, tags map[string]string, fingerprint string) {
+// CapturePanic captures a recovered panic with its Go stack (as scrubbed
+// context) at fatal level, on a hub isolated to this request. No-op when
+// disabled.
+func CapturePanic(ctx context.Context, recovered any, stack string, tags map[string]string, fingerprint string) {
 	if !enabled.Load() {
 		return
 	}
-	sentry.WithScope(func(scope *sentry.Scope) {
+	hub := hubFromContext(ctx)
+	hub.WithScope(func(scope *sentry.Scope) {
 		scope.SetLevel(sentry.LevelFatal)
 		applyTags(scope, tags)
 		if stack != "" {
@@ -131,7 +170,7 @@ func CapturePanic(_ context.Context, recovered any, stack string, tags map[strin
 		if fingerprint != "" {
 			scope.SetFingerprint([]string{fingerprint})
 		}
-		sentry.CaptureException(fmt.Errorf("panic: %v", recovered))
+		hub.CaptureException(fmt.Errorf("panic: %v", recovered))
 	})
 }
 

--- a/backend/internal/observe/sentryobs/sentryobs_test.go
+++ b/backend/internal/observe/sentryobs/sentryobs_test.go
@@ -24,19 +24,29 @@ func TestScrubRedactsLocalPaths(t *testing.T) {
 	}
 }
 
-func TestShouldCaptureStatus(t *testing.T) {
+func TestShouldCapture(t *testing.T) {
 	t.Parallel()
-	cases := map[int]bool{
-		200: false,
-		404: false,
-		500: true,
-		502: true,
-		503: false, // transient contention (see #4325) — never an issue
-		504: true,
+	cases := []struct {
+		status int
+		code   string
+		want   bool
+	}{
+		{status: 200, want: false},
+		{status: 404, want: false},
+		{status: 500, want: true},
+		{status: 502, want: true},
+		{status: 504, want: true},
+		// 503 is captured or suppressed based on the typed code, not status alone.
+		{status: 503, code: "SERVICE_UNAVAILABLE", want: false}, // deliberate backpressure
+		{status: 503, code: "SCM_UNAVAILABLE", want: true},      // real outage
+		{status: 503, code: "BROWSER_RUNTIME_UNAVAILABLE", want: true},
+		{status: 503, code: "DEVICE_REGISTRY_UNAVAILABLE", want: true},
+		{status: 503, code: "", want: true},                    // untyped 503 is treated as a fault
+		{status: 500, code: "SERVICE_UNAVAILABLE", want: true}, // code only suppresses on 503
 	}
-	for status, want := range cases {
-		if got := ShouldCaptureStatus(status); got != want {
-			t.Fatalf("ShouldCaptureStatus(%d) = %v, want %v", status, got, want)
+	for _, c := range cases {
+		if got := ShouldCapture(c.status, c.code); got != c.want {
+			t.Fatalf("ShouldCapture(%d, %q) = %v, want %v", c.status, c.code, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
Re-lands the daemon-Sentry hardening from #4352 that never reached main: a PR-head desync left #4346 merging the pre-hardening commit, so `origin/main` still has the shared-hub capture, double panic-capture, and all-503-suppressed policy. This is the exact verified change from that work, cherry-picked onto current main.

## Fixes
1. **Request-isolated hub.** `CaptureHTTPError`/`CapturePanic` used package-level `sentry.WithScope`/`CaptureException` on the process-global `CurrentHub`, so concurrent requests could interleave scope push/pop and stamp one request's request_id/fingerprint onto another's event. Each capture now resolves a hub from the request context or clones the current hub. Covered by a `-race` test that fails if reverted.
2. **Single panic capture.** The recover middleware captured a panic (fatal, with the Go stack) and the outer 5xx logger then manufactured a second generic `HTTP 500` event with a different fingerprint. Recovery now marks the request via a request-scoped flag and the logger skips its capture when set. Exactly one event, verified through a recording transport.
3. **Code-aware 503.** `ShouldCaptureStatus(status)` dropped every 503, but AO also uses 503 for typed outages (`SCM_UNAVAILABLE`, `BROWSER_RUNTIME_UNAVAILABLE`, `DEVICE_REGISTRY_UNAVAILABLE`). Replaced with `ShouldCapture(status, errorCode)`: only the deliberate `SERVICE_UNAVAILABLE` backpressure is suppressed.

Adds `Disable()` for shutdown/tests. All tests pass under `go test -race`.

Note: overlaps `internal/observe/sentryobs/sentryobs.go` with the noise-filter PR #4475; whichever merges second needs a trivial rebase.