### PR TITLE
feat(preview): suggest detected ports in the Browser panel

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -783,3 +783,15 @@ func (c *conversation) promptContent(message ports.ChatUserMessage) ([]acpsdk.Co
 	}
 	return prompt, nil
 }
+
+// ProcessID is the provider process this conversation owns, satisfying
+// ports.ChatProcessInspector. It is the root of everything the conversation has
+// started, so a caller can scope a machine-wide observation (which ports this
+// session is serving on, for instance) to this session alone. 0 means there is
+// no local process to point at.
+func (c *conversation) ProcessID() int {
+	if c.proc == nil {
+		return 0
+	}
+	return c.proc.pid
+}

--- a/backend/internal/adapters/chatdriver/acp/process.go
+++ b/backend/internal/adapters/chatdriver/acp/process.go
@@ -14,7 +14,11 @@ import (
 type process struct {
 	stdin  io.WriteCloser
 	stdout io.Reader
-	stop   func() error
+	// pid is the provider process AO started. Retained for observation only
+	// (see ports.ChatProcessInspector); shutdown goes through stop, which owns
+	// the process group.
+	pid  int
+	stop func() error
 }
 
 type spawnFunc func(Launch, string) (*process, error)
@@ -51,6 +55,7 @@ func spawnAgent(launch Launch, workdir string) (*process, error) {
 	return &process{
 		stdin:  stdin,
 		stdout: stdout,
+		pid:    cmd.Process.Pid,
 		stop: func() error {
 			var stopErr error
 			once.Do(func() {

--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -952,3 +952,13 @@ func approvalReply(method string, decision ports.ChatDecision) any {
 	}
 	return map[string]any{"decision": decision.ID}
 }
+
+// ProcessID is the app-server process this conversation owns, satisfying
+// ports.ChatProcessInspector. See that interface: it is an observation root,
+// never a lifecycle handle.
+func (c *conversation) ProcessID() int {
+	if c.proc == nil {
+		return 0
+	}
+	return c.proc.pid
+}

--- a/backend/internal/adapters/chatdriver/codexappserver/driver.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver.go
@@ -50,6 +50,9 @@ type codexPlugin interface {
 type process struct {
 	stdin  io.WriteCloser
 	stdout io.Reader
+	// pid is the app-server process AO started. Retained for observation only
+	// (see ports.ChatProcessInspector); shutdown goes through stop.
+	pid int
 	// stop releases the process. It must be safe to call more than once.
 	stop func() error
 }
@@ -420,6 +423,7 @@ func spawnAppServer(ctx context.Context, bin, workdir string, env []string) (*pr
 	return &process{
 		stdin:  stdin,
 		stdout: stdout,
+		pid:    cmd.Process.Pid,
 		stop: func() error {
 			if stopped {
 				return nil

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -609,6 +609,26 @@ func (r *Runtime) supervisedProcessTree(ctx context.Context, handle ports.Runtim
 	return entries, panePID, nil
 }
 
+// RootProcessID is the pid of tmux's direct pane process, the root of
+// everything this session has started. It satisfies
+// ports.SessionRootProcessInspector, which forbids treating it as a lifecycle
+// handle: a failure here says nothing about whether the session is alive.
+func (r *Runtime) RootProcessID(ctx context.Context, handle ports.RuntimeHandle) (int, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return 0, err
+	}
+	out, err := r.run(ctx, panePIDArgs(id)...)
+	if err != nil {
+		return 0, fmt.Errorf("tmux runtime: inspect pane pid %s: %w", id, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("tmux runtime: invalid pane pid %q", strings.TrimSpace(string(out)))
+	}
+	return pid, nil
+}
+
 // SendMessage sends literal text to the session (chunked via send-keys -l) then
 // presses Enter to submit. An empty message presses Enter alone (the nudge
 // contract on ports.AgentMessenger).

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -1674,3 +1674,11 @@ func exitCodeErr(t *testing.T, code int) error {
 	}
 	return err
 }
+
+// -- detected preview ports --
+
+// The runtime satisfies the optional capability preview-port detection
+// type-asserts for; dropping the method would otherwise silently degrade the
+// feature to "nothing detected". The scan itself is portscan's job and is
+// tested there.
+var _ ports.SessionRootProcessInspector = (*Runtime)(nil)

--- a/backend/internal/cli/preview.go
+++ b/backend/internal/cli/preview.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +37,17 @@ type previewServerStatusDTO struct {
 	StartedAt     time.Time `json:"startedAt,omitempty"`
 	Error         string    `json:"error,omitempty"`
 	Logs          []string  `json:"logs"`
+}
+
+type detectedPreviewPortDTO struct {
+	Port    int    `json:"port"`
+	PID     int    `json:"pid"`
+	Command string `json:"command,omitempty"`
+}
+
+type detectedPreviewPortsDTO struct {
+	SessionID string                   `json:"sessionId"`
+	Ports     []detectedPreviewPortDTO `json:"ports"`
 }
 
 func newPreviewCommand(ctx *commandContext) *cobra.Command {
@@ -124,6 +136,26 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
 	}
 	stopCmd.Flags().BoolVar(&stopJSON, "json", false, "print JSON")
 	cmd.AddCommand(stopCmd)
+
+	var portsJSON bool
+	portsCmd := &cobra.Command{
+		Use:   "ports",
+		Short: "List TCP ports detected inside this session's own process tree",
+		Long: "List TCP ports this session's own processes are listening on.\n\n" +
+			"Best effort: a machine that cannot enumerate listening sockets prints\n" +
+			"nothing rather than failing. Unlike the server subcommands this needs no\n" +
+			"session capability, because it starts nothing.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			detected, err := ctx.previewPorts(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return writeDetectedPreviewPorts(cmd.OutOrStdout(), detected, portsJSON)
+		},
+	}
+	portsCmd.Flags().BoolVar(&portsJSON, "json", false, "print JSON")
+	cmd.AddCommand(portsCmd)
 	return cmd
 }
 
@@ -213,6 +245,42 @@ func (c *commandContext) stopPreviewServer(ctx context.Context) (previewServerSt
 	}
 	err = c.doJSONPathWithHeaders(ctx, http.MethodDelete, "/api/v1/"+path, nil, &out, headers)
 	return out, err
+}
+
+// previewPorts sends no capability header: the route observes rather than
+// executes, so the daemon does not gate it on session ownership.
+func (c *commandContext) previewPorts(ctx context.Context) (detectedPreviewPortsDTO, error) {
+	path, err := sessionPreviewPath()
+	if err != nil {
+		return detectedPreviewPortsDTO{}, err
+	}
+	path += "/ports"
+	var out detectedPreviewPortsDTO
+	err = c.doJSONPathWithHeaders(ctx, http.MethodGet, "/api/v1/"+path, nil, &out, nil)
+	return out, err
+}
+
+// writeDetectedPreviewPorts prints one "port command" line per detection. An
+// empty result prints nothing at all in text mode: there is no difference a
+// caller can act on between "nothing is serving" and "this machine cannot
+// tell", so inventing a message for either would overstate what is known.
+func writeDetectedPreviewPorts(out io.Writer, detected detectedPreviewPortsDTO, jsonOutput bool) error {
+	if jsonOutput {
+		if detected.Ports == nil {
+			detected.Ports = []detectedPreviewPortDTO{}
+		}
+		return writeJSON(out, detected)
+	}
+	for _, port := range detected.Ports {
+		line := strconv.Itoa(port.Port)
+		if port.Command != "" {
+			line += "\t" + port.Command
+		}
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func previewServerHeaders() (map[string]string, error) {

--- a/backend/internal/cli/preview_test.go
+++ b/backend/internal/cli/preview_test.go
@@ -303,3 +303,96 @@ func TestPreview_BlankSessionIDIsUsageError(t *testing.T) {
 		t.Fatal("daemon should not be contacted when AO_SESSION_ID is blank")
 	}
 }
+
+// previewPortsServer answers the detection route and records the capability
+// header the CLI sent (it must send none).
+func previewPortsServer(t *testing.T, status int, respBody string) (*httptest.Server, *previewCapture, *string) {
+	t.Helper()
+	capture := &previewCapture{}
+	capability := new(string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/sessions/aa-47/preview/ports" {
+			http.NotFound(w, r)
+			return
+		}
+		capture.called = true
+		capture.path = r.URL.Path
+		capture.method = r.Method
+		*capability = r.Header.Get(browserCapabilityHeader)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, capture, capability
+}
+
+func TestPreviewPortsListsDetectionsWithoutCapability(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "aa-47")
+	cfg := setConfigEnv(t)
+	srv, capture, capability := previewPortsServer(
+		t,
+		http.StatusOK,
+		`{"sessionId":"aa-47","ports":[{"port":5173,"pid":812,"command":"node"},{"port":8080,"pid":900}]}`,
+	)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "preview", "ports")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodGet || capture.path != "/api/v1/sessions/aa-47/preview/ports" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	if *capability != "" {
+		t.Fatalf("capability header = %q, want none", *capability)
+	}
+	if out != "5173\tnode\n8080\n" {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+// Nothing detected prints nothing: "no ports" and "cannot detect ports" are
+// indistinguishable to the caller, so the CLI claims neither.
+func TestPreviewPortsPrintsNothingWhenEmpty(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "aa-47")
+	cfg := setConfigEnv(t)
+	srv, _, _ := previewPortsServer(t, http.StatusOK, `{"sessionId":"aa-47","ports":[]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "preview", "ports")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if out != "" {
+		t.Fatalf("output = %q, want empty", out)
+	}
+}
+
+func TestPreviewPortsJSONAlwaysCarriesAPortsArray(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "aa-47")
+	cfg := setConfigEnv(t)
+	srv, _, _ := previewPortsServer(t, http.StatusOK, `{"sessionId":"aa-47"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "preview", "ports", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var decoded detectedPreviewPortsDTO
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("decode %q: %v", out, err)
+	}
+	if !strings.Contains(out, `"ports": []`) && !strings.Contains(out, `"ports":[]`) {
+		t.Fatalf("output = %q, want an empty ports array", out)
+	}
+}
+
+func TestPreviewPortsRequiresSession(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "")
+	setConfigEnv(t)
+
+	if _, _, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "preview", "ports"); err == nil {
+		t.Fatal("expected a usage error outside an AO session")
+	}
+}

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -468,6 +468,7 @@ func (r projectRepoResolver) RepoPath(projectID domain.ProjectID) (string, error
 type chatLauncher struct{ svc *chatsvc.Service }
 
 var _ sessionmanager.ChatLauncher = chatLauncher{}
+var _ sessionmanager.ChatProcessLocator = chatLauncher{}
 var _ interface {
 	ArmChatHandoff(context.Context, domain.SessionID, domain.SessionInterfaceTransitionPolicy) error
 	PrepareChatHandoff(context.Context, domain.SessionID, domain.SessionInterfaceTransitionPolicy) error
@@ -476,6 +477,12 @@ var _ interface {
 
 func (c chatLauncher) SupportsChat(harness domain.AgentHarness) bool {
 	return c.svc.SupportsChat(harness)
+}
+
+// ChatProcessID satisfies sessionmanager.ChatProcessLocator so preview-port
+// detection can root a chat session's scan at its provider process.
+func (c chatLauncher) ChatProcessID(id domain.SessionID) (int, bool) {
+	return c.svc.ChatProcessID(id)
 }
 
 func (c chatLauncher) PreflightChat(

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -3856,6 +3856,51 @@ paths:
       summary: Serve a static browser preview file from a session workspace
       tags:
       - sessions
+  /api/v1/sessions/{sessionId}/preview/ports:
+    get:
+      operationId: listSessionPreviewPorts
+      parameters:
+      - description: Session identifier, e.g. project-1.
+        in: path
+        name: sessionId
+        required: true
+        schema:
+          description: Session identifier, e.g. project-1.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetectedPreviewPortsResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: List TCP ports detected inside a session's own process tree
+      tags:
+      - sessions
   /api/v1/sessions/{sessionId}/preview/server:
     delete:
       operationId: stopSessionPreviewServer
@@ -6863,6 +6908,30 @@ components:
       required:
       - sessionId
       - workspacePath
+      type: object
+    DetectedPreviewPort:
+      properties:
+        command:
+          type: string
+        pid:
+          type: integer
+        port:
+          type: integer
+      required:
+      - port
+      - pid
+      type: object
+    DetectedPreviewPortsResponse:
+      properties:
+        ports:
+          items:
+            $ref: '#/components/schemas/DetectedPreviewPort'
+          type: array
+        sessionId:
+          type: string
+      required:
+      - sessionId
+      - ports
       type: object
     DevImportProjectsConflict:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -216,6 +216,8 @@ var schemaNames = map[string]string{
 	"ControllersSetSessionPreviewRequest":                 "SetSessionPreviewRequest",
 	"ControllersStartPreviewServerRequest":                "StartPreviewServerRequest",
 	"ControllersPreviewServerStatusResponse":              "PreviewServerStatusResponse",
+	"ControllersDetectedPreviewPort":                      "DetectedPreviewPort",
+	"ControllersDetectedPreviewPortsResponse":             "DetectedPreviewPortsResponse",
 	"ControllersBrowserStatusQuery":                       "BrowserStatusQuery",
 	"ControllersBrowserStatusResponse":                    "BrowserStatusResponse",
 	"ControllersBrowserCommandRequest":                    "BrowserCommandRequest",
@@ -1550,6 +1552,18 @@ func sessionOperations() []operation {
 			resps: []respUnit{
 				{http.StatusOK, controllers.PreviewServerStatusResponse{}},
 				{http.StatusForbidden, envelope.APIError{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodGet, path: "/api/v1/sessions/{sessionId}/preview/ports", id: "listSessionPreviewPorts", tag: "sessions",
+			summary:    "List TCP ports detected inside a session's own process tree",
+			pathParams: []any{controllers.SessionIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.DetectedPreviewPortsResponse{}},
 				{http.StatusNotFound, envelope.APIError{}},
 				{http.StatusConflict, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -497,6 +497,25 @@ type PreviewServerStatusResponse struct {
 	Logs          []string         `json:"logs"`
 }
 
+// DetectedPreviewPort is one TCP port a session's own processes are listening
+// on. Command is a short display label ("vite", "npm") and may be empty; it is
+// never an identifier.
+type DetectedPreviewPort struct {
+	Port    int    `json:"port"`
+	PID     int    `json:"pid"`
+	Command string `json:"command,omitempty"`
+}
+
+// DetectedPreviewPortsResponse lists preview suggestions detected inside one
+// session's process tree. Unlike PreviewServerStatusResponse, which describes
+// the one server AO started and controls, this is a best-effort observation:
+// an empty list means "nothing detected", which covers a machine that cannot
+// enumerate sockets as well as a session that is simply not serving anything.
+type DetectedPreviewPortsResponse struct {
+	SessionID domain.SessionID      `json:"sessionId"`
+	Ports     []DetectedPreviewPort `json:"ports"`
+}
+
 // BrowserStatusQuery selects the session whose logical browser is inspected.
 type BrowserStatusQuery struct {
 	SessionID domain.SessionID `query:"sessionId" description:"AO session identifier."`

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -107,6 +107,7 @@ type SessionService interface {
 	StageAttachments(ctx context.Context, id domain.SessionID, attachments []ports.SpawnAttachment) ([]string, error)
 	WorkspaceWatchPaths(ctx context.Context, id domain.SessionID) ([]string, error)
 	ListWorkspaceFiles(ctx context.Context, id domain.SessionID) (sessionsvc.WorkspaceFiles, error)
+	ListPreviewPorts(ctx context.Context, id domain.SessionID) ([]ports.DetectedPort, error)
 	GetWorkspaceFile(ctx context.Context, id domain.SessionID, path string, section sessionsvc.WorkspaceFileSection) (sessionsvc.WorkspaceFileDetail, error)
 	GetWorkspaceFileBlob(ctx context.Context, id domain.SessionID, path string, side sessionsvc.WorkspaceFileBlobSide) (sessionsvc.WorkspaceFileBlob, error)
 	ListWorkspaceTree(ctx context.Context, id domain.SessionID, path string) (sessionsvc.WorkspaceTree, error)
@@ -167,6 +168,7 @@ func (c *SessionsController) Register(r chi.Router) {
 	r.Get("/sessions/{sessionId}/preview/server", c.previewServerStatus)
 	r.Post("/sessions/{sessionId}/preview/server", c.startPreviewServer)
 	r.Delete("/sessions/{sessionId}/preview/server", c.stopPreviewServer)
+	r.Get("/sessions/{sessionId}/preview/ports", c.previewPorts)
 	r.Get("/sessions/{sessionId}/preview/files/*", c.previewFile)
 	r.Post("/sessions/{sessionId}/attachments", c.stageAttachments)
 	r.Get("/sessions/{sessionId}/workspace/files", c.listWorkspaceFiles)
@@ -855,6 +857,47 @@ func (c *SessionsController) stopPreviewServer(w http.ResponseWriter, r *http.Re
 		}
 	}
 	envelope.WriteJSON(w, http.StatusOK, previewServerStatusResponse(status))
+}
+
+// previewPorts lists the TCP ports this session's own processes are listening
+// on, as clickable suggestions for the desktop browser panel.
+//
+// It deliberately carries no X-AO-Browser-Capability check, unlike the
+// /preview/server routes above. Those start and stop a process, so they must
+// prove the caller owns the session; this one only observes, and its consumer
+// is the desktop panel, which is never issued a session capability. Exposure
+// is bounded at the listener instead: the path is blocked on the opt-in LAN
+// listener (see httpd/lan_listener.go) so a detected-port list never leaves
+// this machine.
+//
+// Detection failures are not errors. A missing enumeration tool, a permission
+// denial, or a runtime with no process tree all return 200 with an empty list,
+// because "nothing detected" is exactly what the panel renders for them.
+func (c *SessionsController) previewPorts(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, http.MethodGet, "/api/v1/sessions/{sessionId}/preview/ports")
+		return
+	}
+	id := sessionID(r)
+	sess, err := c.Svc.Get(r.Context(), id)
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	if sess.IsTerminated {
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict", "SESSION_TERMINATED", "Session is terminated", nil)
+		return
+	}
+	detected, err := c.Svc.ListPreviewPorts(r.Context(), id)
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	out := make([]DetectedPreviewPort, 0, len(detected))
+	for _, port := range detected {
+		out = append(out, DetectedPreviewPort{Port: port.Port, PID: port.PID, Command: port.Command})
+	}
+	envelope.WriteJSON(w, http.StatusOK, DetectedPreviewPortsResponse{SessionID: id, Ports: out})
 }
 
 func (c *SessionsController) authorizePreviewServer(w http.ResponseWriter, r *http.Request) bool {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -65,6 +65,8 @@ type fakeSessionService struct {
 	handoffSource        domain.AgentGenerationID
 	autoInjectCISession  domain.SessionID
 	autoInjectCIEnabled  bool
+	previewPorts         []ports.DetectedPort
+	previewPortsErr      error
 }
 
 type fakeInterfaceTransitionSessionService struct {
@@ -533,6 +535,10 @@ func (f *fakeSessionService) StageAttachments(
 	}
 	f.staged = attachments
 	return f.stagedPaths, nil
+}
+
+func (f *fakeSessionService) ListPreviewPorts(_ context.Context, _ domain.SessionID) ([]ports.DetectedPort, error) {
+	return f.previewPorts, f.previewPortsErr
 }
 
 func (f *fakeSessionService) ListWorkspaceFiles(_ context.Context, id domain.SessionID) (sessionsvc.WorkspaceFiles, error) {
@@ -2048,6 +2054,57 @@ func TestSessionsAPI_ClearPreviewNotFound(t *testing.T) {
 
 	body, status, _ := doRequest(t, srv, "DELETE", "/api/v1/sessions/missing-1/preview", "")
 	assertErrorCode(t, body, status, http.StatusNotFound, "SESSION_NOT_FOUND")
+}
+
+func TestSessionsAPI_DetectedPreviewPortsAreListed(t *testing.T) {
+	svc := newFakeSessionService()
+	svc.previewPorts = []ports.DetectedPort{
+		{Port: 5173, PID: 812, Command: "node"},
+		{Port: 8080, PID: 900},
+	}
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, http.MethodGet, "/api/v1/sessions/ao-1/preview/ports", "")
+	if status != http.StatusOK || !containsAll(body, `"port":5173`, `"pid":812`, `"command":"node"`, `"port":8080`) {
+		t.Fatalf("list preview ports = %d body=%s", status, body)
+	}
+	// An unlabeled process must omit the field rather than send an empty one.
+	if bytes.Contains(body, []byte(`"pid":900,"command"`)) {
+		t.Fatalf("empty command was serialized: %s", body)
+	}
+}
+
+// Detection is a suggestion source, so a machine that cannot enumerate sockets
+// gets an empty list, never an error the user has to read.
+func TestSessionsAPI_DetectedPreviewPortsFailOpen(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, http.MethodGet, "/api/v1/sessions/ao-1/preview/ports", "")
+	if status != http.StatusOK || !containsAll(body, `"sessionId":"ao-1"`, `"ports":[]`) {
+		t.Fatalf("list preview ports = %d body=%s", status, body)
+	}
+}
+
+func TestSessionsAPI_DetectedPreviewPortsUnknownSession(t *testing.T) {
+	srv := newSessionTestServer(t, newFakeSessionService())
+
+	body, status, _ := doRequest(t, srv, http.MethodGet, "/api/v1/sessions/missing-1/preview/ports", "")
+	assertErrorCode(t, body, status, http.StatusNotFound, "SESSION_NOT_FOUND")
+}
+
+// A terminated session's recorded runtime handle may already be recycled, so
+// its process tree is never scanned.
+func TestSessionsAPI_DetectedPreviewPortsRejectTerminatedSession(t *testing.T) {
+	svc := newFakeSessionService()
+	session := svc.sessions["ao-1"]
+	session.IsTerminated = true
+	svc.sessions["ao-1"] = session
+	svc.previewPorts = []ports.DetectedPort{{Port: 5173, PID: 812}}
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, http.MethodGet, "/api/v1/sessions/ao-1/preview/ports", "")
+	assertErrorCode(t, body, status, http.StatusConflict, "SESSION_TERMINATED")
 }
 
 func TestSessionsAPI_ManagedPreviewStartsExactApplicationAndPersistsTarget(t *testing.T) {

--- a/backend/internal/httpd/lan_listener.go
+++ b/backend/internal/httpd/lan_listener.go
@@ -82,8 +82,14 @@ func lanControlBlock(next http.Handler) http.Handler {
 // beneath it ("/api/v1/mobile/status") but must not catch unrelated siblings
 // such as "/api/v1/mobileapp".
 func isLANControlBlockedPath(path string) bool {
-	if strings.HasPrefix(path, "/api/v1/sessions/") && strings.HasSuffix(strings.TrimSuffix(path, "/"), "/preview/server") {
-		return true
+	// /preview/server runs a process; /preview/ports reports which local ports
+	// a session is serving on. Neither belongs on a listener the rest of the
+	// home network can reach.
+	if strings.HasPrefix(path, "/api/v1/sessions/") {
+		suffix := strings.TrimSuffix(path, "/")
+		if strings.HasSuffix(suffix, "/preview/server") || strings.HasSuffix(suffix, "/preview/ports") {
+			return true
+		}
 	}
 	for _, prefix := range lanControlBlockedPrefixes {
 		trimmed := prefix

--- a/backend/internal/httpd/lan_listener_test.go
+++ b/backend/internal/httpd/lan_listener_test.go
@@ -72,6 +72,7 @@ func TestLANManagerBlocksLoopbackOnlyControlRoutes(t *testing.T) {
 		"/api/v1/desktop/sessions/ao-1/workspace",
 		"/api/v1/system/install/tmux",
 		"/api/v1/sessions/ao-1/preview/server",
+		"/api/v1/sessions/ao-1/preview/ports",
 	}
 	for _, path := range blocked {
 		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d%s", port, path), nil)

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -916,6 +916,19 @@ type ChatConversation interface {
 	Close() error
 }
 
+// ChatProcessInspector is optionally implemented by a conversation that runs
+// its provider as a local child process. ProcessID is the root of everything
+// that conversation has started -- the provider, its tools, and any server an
+// agent launched through them -- so callers can scope a machine observation to
+// one session's own work.
+//
+// It is an observation, not a lifecycle handle: 0 means "no local process to
+// point at", and a non-zero pid is not a promise the process is still alive.
+// Nothing may kill, signal, or infer session liveness from it.
+type ChatProcessInspector interface {
+	ProcessID() int
+}
+
 // ChatHistoryReader is optionally implemented by a conversation whose native
 // protocol can read the durable thread it resumed. Events are returned oldest
 // first, settled, and with stable ProviderEventID values so importing the same

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -153,6 +153,28 @@ type ExactSupervisedProcessInspector interface {
 	IsExactSupervisedProcessAlive(ctx context.Context, handle RuntimeHandle, ref SupervisedProcessRef) (bool, error)
 }
 
+// DetectedPort is one TCP port a session's own process tree is listening on.
+// Command is a short display label for the owning process, not a stable
+// identifier: it exists so the desktop can show "5173 vite" instead of a bare
+// number, and may be empty.
+type DetectedPort struct {
+	Port    int
+	PID     int
+	Command string
+}
+
+// SessionRootProcessInspector is an optional runtime capability: the pid of the
+// process a session's own work hangs off, such as a tmux pane's shell. Callers
+// use it to scope a machine observation (which ports this session is serving
+// on, for instance) to one session.
+//
+// It is an observation root, not a lifecycle handle. A returned pid is not a
+// promise the process is alive, an error is not evidence a session is dead, and
+// nothing may signal or reap what it points at.
+type SessionRootProcessInspector interface {
+	RootProcessID(ctx context.Context, handle RuntimeHandle) (int, error)
+}
+
 // ContainerReaper removes Docker containers a worker session owns, identified
 // by the ao.session=<id> label convention (see EnvSessionID). It is an
 // optional capability: nil wiring means container reaping is a no-op, not an

--- a/backend/internal/portscan/cwd_linux.go
+++ b/backend/internal/portscan/cwd_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package portscan
+
+import (
+	"context"
+	"os"
+	"strconv"
+)
+
+// workspaceProcesses lists processes whose working directory is inside
+// workspace. /proc/<pid>/cwd is a symlink the kernel maintains, so this is one
+// readlink per process and needs no subprocess. An unreadable link (the process
+// exited mid-scan, or belongs to another user) contributes nothing.
+func workspaceProcesses(_ context.Context, procs []process, workspace string) []int {
+	if workspace == "" {
+		return nil
+	}
+	var pids []int
+	for _, proc := range procs {
+		cwd, err := os.Readlink("/proc/" + strconv.Itoa(proc.PID) + "/cwd")
+		if err != nil {
+			continue
+		}
+		if underWorkspace(cwd, workspace) {
+			pids = append(pids, proc.PID)
+		}
+	}
+	return pids
+}

--- a/backend/internal/portscan/cwd_unix.go
+++ b/backend/internal/portscan/cwd_unix.go
@@ -1,0 +1,63 @@
+//go:build !linux && !windows
+
+package portscan
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// cwdTimeout bounds the lookup; a stalled lsof must not hold a request open.
+const cwdTimeout = 2 * time.Second
+
+// workspaceProcesses lists processes whose working directory is inside
+// workspace. There is no /proc on macOS, so one lsof asks for the cwd
+// descriptor of every process in the table at once rather than per process.
+func workspaceProcesses(ctx context.Context, procs []process, workspace string) []int {
+	if workspace == "" || len(procs) == 0 {
+		return nil
+	}
+	list := make([]string, 0, len(procs))
+	for _, proc := range procs {
+		list = append(list, strconv.Itoa(proc.PID))
+	}
+	cwdCtx, cancel := context.WithTimeout(ctx, cwdTimeout)
+	defer cancel()
+	out, err := aoprocess.CommandContext(
+		cwdCtx, "lsof", "-a", "-d", "cwd", "-p", strings.Join(list, ","), "-F", "pn",
+	).Output()
+	if err != nil && len(out) == 0 {
+		return nil
+	}
+	return parseCwdListing(string(out), workspace)
+}
+
+// parseCwdListing reads lsof -F field output, where a "p" line opens a process
+// block and the following "n" line is that process's working directory.
+func parseCwdListing(out, workspace string) []int {
+	var pids []int
+	pid := 0
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) < 2 {
+			continue
+		}
+		value := strings.TrimSpace(line[1:])
+		switch line[0] {
+		case 'p':
+			pid = 0
+			if parsed, err := strconv.Atoi(value); err == nil && parsed > 0 {
+				pid = parsed
+			}
+		case 'n':
+			if pid > 0 && underWorkspace(value, workspace) {
+				pids = append(pids, pid)
+				pid = 0
+			}
+		}
+	}
+	return pids
+}

--- a/backend/internal/portscan/lsof.go
+++ b/backend/internal/portscan/lsof.go
@@ -1,0 +1,71 @@
+package portscan
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// lsofArgs builds the listening-socket query for pids.
+//
+//   - -nP suppresses DNS and /etc/services lookups, so a NAME field is always
+//     numeric host:port and never blocks on a resolver.
+//   - -a -p <list> restricts the scan to the caller's own process set instead
+//     of enumerating every socket on the machine.
+//   - -F pn selects machine-readable field output. lsof's default column
+//     layout differs between macOS and Linux builds; the field format does not.
+func lsofArgs(pids []int) []string {
+	list := make([]string, 0, len(pids))
+	for _, pid := range pids {
+		list = append(list, strconv.Itoa(pid))
+	}
+	sort.Strings(list)
+	return []string{"-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", strings.Join(list, ","), "-F", "pn"}
+}
+
+// parseLsof reads lsof -F field output: one field per line, first byte naming
+// the field. A "p" line opens a process block and every following "n" line is
+// one of that process's sockets. want re-filters the pids because -p is a
+// request, not a guarantee -- an lsof build that ignores or widens it must not
+// leak another session's ports into the result.
+func parseLsof(out string, want map[int]bool) []boundPort {
+	var found []boundPort
+	pid := 0
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) < 2 {
+			continue
+		}
+		value := strings.TrimSpace(line[1:])
+		switch line[0] {
+		case 'p':
+			pid = 0
+			if parsed, err := strconv.Atoi(value); err == nil && parsed > 0 {
+				pid = parsed
+			}
+		case 'n':
+			if pid == 0 || !want[pid] {
+				continue
+			}
+			if port, ok := parseListenPort(value); ok {
+				found = append(found, boundPort{PID: pid, Port: port})
+			}
+		}
+	}
+	return found
+}
+
+// parseListenPort pulls the port out of an lsof NAME field. Under -n the field
+// is "127.0.0.1:5173", "[::1]:5173" or "*:5173", optionally followed by a
+// parenthesized state, so the port is what follows the last colon.
+func parseListenPort(name string) (int, bool) {
+	name, _, _ = strings.Cut(strings.TrimSpace(name), " ")
+	idx := strings.LastIndex(name, ":")
+	if idx < 0 {
+		return 0, false
+	}
+	port, err := strconv.Atoi(name[idx+1:])
+	if err != nil || port <= 0 || port > 65535 {
+		return 0, false
+	}
+	return port, true
+}

--- a/backend/internal/portscan/portscan.go
+++ b/backend/internal/portscan/portscan.go
@@ -1,0 +1,58 @@
+// Package portscan answers one question: which TCP ports are these processes
+// listening on?
+//
+// It is best effort by deliberate design. The desktop preview shows detected
+// ports as clickable suggestions, so a machine without a usable enumeration
+// path (no /proc, no lsof, a permission denial) must yield "nothing detected"
+// rather than an error a user has to read and cannot act on. Every entry point
+// here therefore returns a possibly-empty slice and no error.
+package portscan
+
+import (
+	"context"
+	"sort"
+)
+
+// boundPort is one TCP socket in the LISTEN state and the process that owns it.
+type boundPort struct {
+	PID  int
+	Port int
+}
+
+// ownedListeners returns the TCP listening sockets owned by pids, deduplicated: a
+// server bound to both 0.0.0.0 and ::1 is one entry, not two. Order is stable
+// (port, then pid) so a polling caller does not see the list reshuffle.
+func ownedListeners(ctx context.Context, pids []int) []boundPort {
+	want := make(map[int]bool, len(pids))
+	for _, pid := range pids {
+		if pid > 0 {
+			want[pid] = true
+		}
+	}
+	if len(want) == 0 {
+		return nil
+	}
+	return dedupe(listeners(ctx, want))
+}
+
+func dedupe(found []boundPort) []boundPort {
+	if len(found) == 0 {
+		return nil
+	}
+	seen := make(map[boundPort]bool, len(found))
+	out := make([]boundPort, 0, len(found))
+	for _, entry := range found {
+		if seen[entry] {
+			continue
+		}
+		seen[entry] = true
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Port != out[j].Port {
+			return out[i].Port < out[j].Port
+		}
+		return out[i].PID < out[j].PID
+	})
+	return out
+}

--- a/backend/internal/portscan/portscan_test.go
+++ b/backend/internal/portscan/portscan_test.go
@@ -1,0 +1,172 @@
+package portscan
+
+import (
+	"reflect"
+	"testing"
+)
+
+// procNetTCPSample is a real /proc/net/tcp table: a header row, two listening
+// sockets (st 0A) and one established connection that must not be reported.
+const procNetTCPSample = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 3600007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000   974        0 1706 1 00000000a430142f 100 0 0 10 5
+   1: 0100007F:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 30594 1 000000001064da26 100 0 0 10 0
+   2: 0100007F:1435 0100007F:C1A2 01 00000000:00000000 00:00000000 00000000  1000        0 30777 1 00000000b282d564 100 0 0 10 0
+`
+
+// procNetTCP6Sample is the IPv6 table for the same machine. Its address column
+// is four times wider, which must not shift the st or inode columns.
+const procNetTCP6Sample = `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:1435 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 30595 1 00000000cbaa7f01 100 0 0 10 5
+`
+
+func TestParseProcNetTCPKeepsOnlyListeningRows(t *testing.T) {
+	got := parseProcNetTCP(procNetTCPSample)
+	want := map[uint64]int{1706: 53, 30594: 5173}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseProcNetTCP = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseProcNetTCP6ColumnsAreNotShifted(t *testing.T) {
+	got := parseProcNetTCP(procNetTCP6Sample)
+	want := map[uint64]int{30595: 5173}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseProcNetTCP = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseProcNetTCPTolerance(t *testing.T) {
+	for name, table := range map[string]string{
+		"empty":         "",
+		"header only":   "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n",
+		"short row":     "   0: 0100007F:1435 00000000:0000 0A\n",
+		"bad port":      "   0: 0100007F:ZZZZ 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 30594 1\n",
+		"port zero":     "   0: 0100007F:0000 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 30594 1\n",
+		"bad inode":     "   0: 0100007F:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 nope 1\n",
+		"inode zero":    "   0: 0100007F:1435 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 0 1\n",
+		"no port colon": "   0: 0100007F 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 30594 1\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := parseProcNetTCP(table); len(got) != 0 {
+				t.Fatalf("parseProcNetTCP = %#v, want empty", got)
+			}
+		})
+	}
+}
+
+func TestParseSocketLink(t *testing.T) {
+	for name, tc := range map[string]struct {
+		target string
+		inode  uint64
+		ok     bool
+	}{
+		"socket":          {target: "socket:[30594]", inode: 30594, ok: true},
+		"regular file":    {target: "/home/dev/app/log.txt"},
+		"pipe":            {target: "pipe:[30594]"},
+		"anon inode":      {target: "anon_inode:[eventpoll]"},
+		"missing bracket": {target: "socket:[30594"},
+		"not a number":    {target: "socket:[abc]"},
+		"zero inode":      {target: "socket:[0]"},
+		"empty":           {target: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			inode, ok := parseSocketLink(tc.target)
+			if ok != tc.ok || inode != tc.inode {
+				t.Fatalf("parseSocketLink(%q) = %d, %t; want %d, %t", tc.target, inode, ok, tc.inode, tc.ok)
+			}
+		})
+	}
+}
+
+// lsofSample is lsof -F pn output for two processes. process 812 holds the same
+// server on IPv4 and IPv6; 900 is a second server; 4242 was never asked for and
+// must be dropped even though lsof reported it.
+const lsofSample = `p812
+n127.0.0.1:5173
+n[::1]:5173
+p900
+n*:8080
+p4242
+n127.0.0.1:9999
+`
+
+func TestParseLsofAttributesPortsToTheirProcess(t *testing.T) {
+	got := parseLsof(lsofSample, map[int]bool{812: true, 900: true})
+	want := []boundPort{
+		{PID: 812, Port: 5173},
+		{PID: 812, Port: 5173},
+		{PID: 900, Port: 8080},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseLsof = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseLsofIgnoresUnrelatedLines(t *testing.T) {
+	// lsof writes its warnings to stderr, but a build that mixes them into
+	// stdout must not derail the field parse either.
+	out := "lsof: WARNING: can't stat() overlay file system /var/lib/docker\np812\nf23\nn127.0.0.1:5173\n"
+	got := parseLsof(out, map[int]bool{812: true})
+	want := []boundPort{{PID: 812, Port: 5173}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseLsof = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseListenPort(t *testing.T) {
+	for name, tc := range map[string]struct {
+		name string
+		port int
+		ok   bool
+	}{
+		"ipv4":            {name: "127.0.0.1:5173", port: 5173, ok: true},
+		"ipv6":            {name: "[::1]:5173", port: 5173, ok: true},
+		"wildcard":        {name: "*:8080", port: 8080, ok: true},
+		"trailing state":  {name: "*:8080 (LISTEN)", port: 8080, ok: true},
+		"named port":      {name: "127.0.0.1:http"},
+		"no colon":        {name: "127.0.0.1"},
+		"port zero":       {name: "127.0.0.1:0"},
+		"port over range": {name: "127.0.0.1:70000"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			port, ok := parseListenPort(tc.name)
+			if ok != tc.ok || port != tc.port {
+				t.Fatalf("parseListenPort(%q) = %d, %t; want %d, %t", tc.name, port, ok, tc.port, tc.ok)
+			}
+		})
+	}
+}
+
+func TestLsofArgsRestrictsToRequestedPIDs(t *testing.T) {
+	got := lsofArgs([]int{900, 812})
+	want := []string{"-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", "812,900", "-F", "pn"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("lsofArgs = %#v, want %#v", got, want)
+	}
+}
+
+func TestDedupeCollapsesDualStackAndSorts(t *testing.T) {
+	got := dedupe([]boundPort{
+		{PID: 812, Port: 5173},
+		{PID: 900, Port: 8080},
+		{PID: 812, Port: 5173},
+		{PID: 700, Port: 8080},
+	})
+	want := []boundPort{
+		{PID: 812, Port: 5173},
+		{PID: 700, Port: 8080},
+		{PID: 900, Port: 8080},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dedupe = %#v, want %#v", got, want)
+	}
+}
+
+func TestOwnedListenersWithoutUsablePIDsScansNothing(t *testing.T) {
+	if got := ownedListeners(t.Context(), nil); got != nil {
+		t.Fatalf("ownedListeners(nil) = %#v, want nil", got)
+	}
+	if got := ownedListeners(t.Context(), []int{0, -1}); got != nil {
+		t.Fatalf("ownedListeners(invalid) = %#v, want nil", got)
+	}
+}

--- a/backend/internal/portscan/procnet.go
+++ b/backend/internal/portscan/procnet.go
@@ -1,0 +1,58 @@
+package portscan
+
+import (
+	"strconv"
+	"strings"
+)
+
+// procTCPListen is the st column value for TCP_LISTEN in /proc/net/tcp.
+const procTCPListen = "0A"
+
+// parseProcNetTCP maps socket inode -> local port for every listening row of a
+// /proc/net/tcp or /proc/net/tcp6 table. The header row and every non-listening
+// connection are skipped, as is any row whose port or inode does not parse:
+// this table is a suggestion source, so a malformed row is dropped rather than
+// failing the whole scan.
+func parseProcNetTCP(table string) map[uint64]int {
+	out := map[uint64]int{}
+	for _, line := range strings.Split(table, "\n") {
+		fields := strings.Fields(line)
+		// sl local_address rem_address st tx_rx tr retrnsmt uid timeout inode
+		if len(fields) < 10 || fields[3] != procTCPListen {
+			continue
+		}
+		_, hexPort, ok := strings.Cut(fields[1], ":")
+		if !ok {
+			continue
+		}
+		port, err := strconv.ParseUint(hexPort, 16, 32)
+		if err != nil || port == 0 || port > 65535 {
+			continue
+		}
+		inode, err := strconv.ParseUint(fields[9], 10, 64)
+		if err != nil || inode == 0 {
+			continue
+		}
+		out[inode] = int(port)
+	}
+	return out
+}
+
+// parseSocketLink extracts the inode from a /proc/<pid>/fd symlink target.
+// Socket descriptors read as "socket:[12345]"; regular files, pipes and
+// anonymous inodes are not sockets and are skipped.
+func parseSocketLink(target string) (uint64, bool) {
+	rest, ok := strings.CutPrefix(target, "socket:[")
+	if !ok {
+		return 0, false
+	}
+	rest, ok = strings.CutSuffix(rest, "]")
+	if !ok {
+		return 0, false
+	}
+	inode, err := strconv.ParseUint(rest, 10, 64)
+	if err != nil || inode == 0 {
+		return 0, false
+	}
+	return inode, true
+}

--- a/backend/internal/portscan/scan_linux.go
+++ b/backend/internal/portscan/scan_linux.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package portscan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// listeners resolves ports without spawning anything: the kernel already
+// publishes every listening socket in /proc/net/tcp, and /proc/<pid>/fd names
+// the sockets each process holds. Both sides are keyed by inode, so the match
+// is two small file reads plus one directory listing per caller-supplied pid.
+// That keeps a polling caller cheap enough that no OS-level "port opened"
+// event is needed (none exists unprivileged on any platform AO ships to).
+func listeners(_ context.Context, want map[int]bool) []boundPort {
+	ports := map[uint64]int{}
+	for _, table := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		data, err := os.ReadFile(table)
+		if err != nil {
+			continue
+		}
+		for inode, port := range parseProcNetTCP(string(data)) {
+			ports[inode] = port
+		}
+	}
+	if len(ports) == 0 {
+		return nil
+	}
+	var found []boundPort
+	for pid := range want {
+		for _, inode := range socketInodes(pid) {
+			if port, ok := ports[inode]; ok {
+				found = append(found, boundPort{PID: pid, Port: port})
+			}
+		}
+	}
+	return found
+}
+
+// socketInodes lists the socket inodes held by pid. An unreadable directory
+// (the process exited mid-scan, or runs as another user) contributes nothing
+// rather than failing the scan for every other pid.
+func socketInodes(pid int) []uint64 {
+	dir := "/proc/" + strconv.Itoa(pid) + "/fd"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var inodes []uint64
+	for _, entry := range entries {
+		target, err := os.Readlink(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if inode, ok := parseSocketLink(target); ok {
+			inodes = append(inodes, inode)
+		}
+	}
+	return inodes
+}

--- a/backend/internal/portscan/scan_linux_test.go
+++ b/backend/internal/portscan/scan_linux_test.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+package portscan
+
+import (
+	"net"
+	"os"
+	"testing"
+)
+
+// The Linux scanner reads live kernel state, so this exercises it against a
+// socket the test actually opened rather than a recorded /proc table.
+func TestOwnedListenersFindsThisProcessListeningSocket(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	port := listener.Addr().(*net.TCPAddr).Port
+	self := os.Getpid()
+
+	found := ownedListeners(t.Context(), []int{self})
+	if !containsListener(found, boundPort{PID: self, Port: port}) {
+		t.Fatalf("ownedListeners(self) = %#v, want it to contain port %d", found, port)
+	}
+
+	// pid 1 is not ours: its descriptors are unreadable for an ordinary user,
+	// which must yield nothing rather than leaking this process's port or
+	// failing the scan.
+	if other := ownedListeners(t.Context(), []int{1}); containsListener(other, boundPort{PID: 1, Port: port}) {
+		t.Fatalf("ownedListeners(1) = %#v, want no claim on port %d", other, port)
+	}
+}
+
+// Detect end to end against live kernel state: a socket this process opened is
+// found when scanning from this process, and is invisible when scanning from an
+// unrelated root.
+func TestDetectFindsAPortUnderTheScannedRoot(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	found := Detect(t.Context(), os.Getpid(), "")
+	if !containsPort(found, port) {
+		t.Fatalf("Detect(self) = %#v, want it to contain port %d", found, port)
+	}
+
+	// Scoping: the test binary spawns nothing, so every port Detect reports for
+	// it must be one this process holds. Anything else means the tree walk
+	// escaped its root and picked up unrelated software on the machine.
+	for _, detected := range found {
+		if detected.PID != os.Getpid() {
+			t.Fatalf("Detect(self) reported pid %d, which is not this process or a child of it", detected.PID)
+		}
+	}
+
+	// A root that does not exist owns nothing, so rooting is not a no-op that
+	// happens to return everything.
+	if orphan := Detect(t.Context(), deadPID, ""); len(orphan) != 0 {
+		t.Fatalf("Detect(dead root) = %#v, want none", orphan)
+	}
+}
+
+// deadPID is above the default pid_max, so no live process can hold it.
+const deadPID = 2147483647
+
+func containsPort(found []Detected, port int) bool {
+	for _, detected := range found {
+		if detected.Port == port {
+			return true
+		}
+	}
+	return false
+}
+
+func containsListener(found []boundPort, want boundPort) bool {
+	for _, entry := range found {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/portscan/scan_unix.go
+++ b/backend/internal/portscan/scan_unix.go
@@ -1,0 +1,36 @@
+//go:build !linux && !windows
+
+package portscan
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// lsofTimeout bounds the scan. lsof can stall on an unresponsive mount, and a
+// stalled suggestion list must never hold a preview request open.
+const lsofTimeout = 2 * time.Second
+
+// listeners shells out to lsof. macOS has no /proc, and its supported
+// alternatives (Endpoint Security, DTrace) need root or a special entitlement,
+// so a short-lived lsof per scan is the only unprivileged path.
+func listeners(ctx context.Context, want map[int]bool) []boundPort {
+	pids := make([]int, 0, len(want))
+	for pid := range want {
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids)
+
+	scanCtx, cancel := context.WithTimeout(ctx, lsofTimeout)
+	defer cancel()
+	// lsof exits non-zero when nothing matched, with valid (often empty)
+	// stdout, so the output is parsed whenever there is any.
+	out, err := aoprocess.CommandContext(scanCtx, "lsof", lsofArgs(pids)...).Output()
+	if err != nil && len(out) == 0 {
+		return nil
+	}
+	return parseLsof(string(out), want)
+}

--- a/backend/internal/portscan/tree.go
+++ b/backend/internal/portscan/tree.go
@@ -1,0 +1,234 @@
+package portscan
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// maxDetected caps a suggestion list. A session with more listening ports than
+// this has something unusual going on, and a toolbar dropdown is not the place
+// to enumerate it.
+const maxDetected = 20
+
+// Detected is one port a session is serving on, with a display label for the
+// process that owns it. Command is a convenience for the reader, never an
+// identifier, and may be empty.
+type Detected struct {
+	Port    int
+	PID     int
+	Command string
+}
+
+// process is one row of the machine's process table.
+type process struct {
+	PID     int
+	PPID    int
+	Command string
+}
+
+// Detect returns the TCP ports one session is serving on.
+//
+// A session is identified two ways, and a process qualifies on EITHER:
+//
+//   - it descends from rootPID, the session's own entry point (a tmux pane's
+//     shell, or the provider process a chat session spawned); or
+//   - its working directory is inside workspace, the session's worktree.
+//
+// The second anchor is not redundant. Agents routinely start a dev server in
+// the background, and a backgrounded process calls setsid and is reparented to
+// init the moment its launching shell exits. From then on it descends from
+// nothing AO owns, so tree scoping alone reports nothing. Its working directory
+// does not move, and a worktree belongs to exactly one session, so cwd keeps
+// the scan correctly scoped after the tree connection is gone.
+//
+// Best effort throughout: an unreadable process table, a missing enumeration
+// tool, or a permission denial all yield an empty list rather than an error,
+// because "no suggestions" is a normal outcome that every caller renders.
+func Detect(ctx context.Context, rootPID int, workspace string) []Detected {
+	procs := processTable(ctx)
+	if len(procs) == 0 {
+		return nil
+	}
+	candidates := map[int]bool{}
+	if rootPID > 0 {
+		for pid := range descendants(procs, rootPID) {
+			candidates[pid] = true
+		}
+	}
+	for _, pid := range workspaceProcesses(ctx, procs, workspace) {
+		candidates[pid] = true
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	pids := make([]int, 0, len(candidates))
+	for pid := range candidates {
+		pids = append(pids, pid)
+	}
+	return attribute(procs, rootPID, ownedListeners(ctx, pids))
+}
+
+// underWorkspace reports whether cwd is the workspace directory or inside it.
+// A plain string prefix would let "/w/app-old" match a workspace of "/w/app",
+// so the boundary must fall on a separator.
+func underWorkspace(cwd, workspace string) bool {
+	if cwd == "" || workspace == "" {
+		return false
+	}
+	if cwd == workspace {
+		return true
+	}
+	prefix := strings.TrimSuffix(workspace, string(filepath.Separator)) + string(filepath.Separator)
+	return strings.HasPrefix(cwd, prefix)
+}
+
+// descendants is rootPID plus every process beneath it, by repeated sweeps over
+// the table until nothing new is adopted. The table is a snapshot, so a process
+// whose parent exited is simply absent from the tree rather than reparented.
+func descendants(procs []process, rootPID int) map[int]bool {
+	tree := map[int]bool{rootPID: true}
+	for changed := true; changed; {
+		changed = false
+		for _, proc := range procs {
+			if tree[proc.PID] || !tree[proc.PPID] {
+				continue
+			}
+			tree[proc.PID] = true
+			changed = true
+		}
+	}
+	return tree
+}
+
+// attribute turns raw (pid, port) pairs into one entry per port.
+//
+// A server started from a shell is normally reported several times over: the
+// child inherits the listening descriptor, so the shell, the package runner and
+// the server itself all hold it. When several processes claim one port the
+// DEEPEST in the tree wins — that is the process that actually bound it
+// (`next-server`), not the wrapper that spawned it (`zsh`, `bun`), and it is
+// also the more useful label to show.
+func attribute(procs []process, rootPID int, listeners []boundPort) []Detected {
+	if len(listeners) == 0 {
+		return nil
+	}
+	parents := make(map[int]int, len(procs))
+	commands := make(map[int]string, len(procs))
+	for _, proc := range procs {
+		parents[proc.PID] = proc.PPID
+		commands[proc.PID] = proc.Command
+	}
+	owners := make(map[int]int, len(listeners))
+	order := make([]int, 0, len(listeners))
+	for _, listener := range listeners {
+		current, claimed := owners[listener.Port]
+		if !claimed {
+			order = append(order, listener.Port)
+		}
+		// Depth only orders processes that are IN the tree. A reparented server
+		// reaches no root, so every candidate for its port ties at -1 and the
+		// first one seen keeps it -- correct, because there is no ancestry left
+		// to prefer one over another.
+		if !claimed || depth(parents, listener.PID, rootPID) > depth(parents, current, rootPID) {
+			owners[listener.Port] = listener.PID
+		}
+	}
+	sort.Ints(order)
+	if len(order) > maxDetected {
+		order = order[:maxDetected]
+	}
+	out := make([]Detected, 0, len(order))
+	for _, port := range order {
+		pid := owners[port]
+		out = append(out, Detected{Port: port, PID: pid, Command: commandLabel(commands[pid])})
+	}
+	return out
+}
+
+// depth counts the hops from pid up to rootPID. A pid whose ancestry does not
+// reach the root (its parent exited between the snapshot and the socket scan,
+// or the chain loops) scores lowest, so it never displaces a process whose
+// ancestry is known.
+func depth(parents map[int]int, pid, rootPID int) int {
+	for hops := 0; hops <= len(parents); hops++ {
+		if pid == rootPID {
+			return hops
+		}
+		parent, ok := parents[pid]
+		if !ok || parent <= 0 {
+			return -1
+		}
+		pid = parent
+	}
+	return -1
+}
+
+// genericRuntimes are executables that say nothing about what is being served.
+// For these the first real argument is the informative half of the command, so
+// "node .../next/dist/bin/next" labels as "next" rather than "node".
+var genericRuntimes = map[string]bool{
+	"bash": true, "bun": true, "deno": true, "node": true, "perl": true,
+	"php": true, "python": true, "python2": true, "python3": true, "ruby": true,
+	"sh": true, "zsh": true,
+}
+
+// commandLabel shortens a full argv line to something worth showing next to a
+// port number.
+func commandLabel(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	label := filepath.Base(fields[0])
+	if !genericRuntimes[label] {
+		return label
+	}
+	for _, field := range fields[1:] {
+		if strings.HasPrefix(field, "-") {
+			continue
+		}
+		if arg := filepath.Base(field); arg != "" && arg != "." && arg != "/" {
+			return trimScriptExt(arg)
+		}
+	}
+	return label
+}
+
+// trimScriptExt drops a JavaScript entry-point suffix so a bin script reads as
+// "vite" rather than "vite.js". Only these extensions are stripped: a module
+// name like "http.server" is not a filename and must survive intact.
+func trimScriptExt(arg string) string {
+	for _, ext := range []string{".mjs", ".cjs", ".js"} {
+		if trimmed, ok := strings.CutSuffix(arg, ext); ok && trimmed != "" {
+			return trimmed
+		}
+	}
+	return arg
+}
+
+// parseProcessTable reads `pid ppid args` rows. A row that does not parse is
+// skipped rather than failing the scan: one unreadable process must not cost
+// the caller every other suggestion.
+func parseProcessTable(out string) []process {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	procs := make([]process, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		ppid, err := strconv.Atoi(fields[1])
+		if err != nil || ppid < 0 {
+			continue
+		}
+		procs = append(procs, process{PID: pid, PPID: ppid, Command: strings.Join(fields[2:], " ")})
+	}
+	return procs
+}

--- a/backend/internal/portscan/tree_test.go
+++ b/backend/internal/portscan/tree_test.go
@@ -1,0 +1,153 @@
+package portscan
+
+import (
+	"reflect"
+	"testing"
+)
+
+// devServerTree is a session shell that ran `bun run dev`, which spawned turbo,
+// which spawned two Next.js servers. All the ancestors hold each listening
+// descriptor because a child inherits it.
+const devServerTree = `100 1 /bin/zsh -i
+101 100 bun run dev
+102 101 turbo run dev
+103 102 /usr/bin/node /work/node_modules/next/dist/bin/next dev --port 3000
+104 102 /usr/bin/node /work/node_modules/next/dist/bin/next dev --port 3001
+900 1 /usr/bin/unrelated-daemon
+`
+
+func table(t *testing.T) []process {
+	t.Helper()
+	procs := parseProcessTable(devServerTree)
+	if len(procs) != 6 {
+		t.Fatalf("parseProcessTable returned %d rows, want 6", len(procs))
+	}
+	return procs
+}
+
+func TestParseProcessTableSkipsUnparseableRows(t *testing.T) {
+	procs := parseProcessTable("100 1 /bin/zsh\nnope 1 /bin/sh\n101 bad /bin/sh\n102\n103 100 vite\n")
+	want := []process{
+		{PID: 100, PPID: 1, Command: "/bin/zsh"},
+		{PID: 103, PPID: 100, Command: "vite"},
+	}
+	if !reflect.DeepEqual(procs, want) {
+		t.Fatalf("parseProcessTable = %#v, want %#v", procs, want)
+	}
+}
+
+func TestDescendantsAreScopedToTheRoot(t *testing.T) {
+	tree := descendants(table(t), 100)
+	for _, pid := range []int{100, 101, 102, 103, 104} {
+		if !tree[pid] {
+			t.Fatalf("descendants missing pid %d", pid)
+		}
+	}
+	// The whole point of the feature: another app on the machine is not ours.
+	if tree[900] {
+		t.Fatal("descendants adopted an unrelated process")
+	}
+}
+
+func TestAttributeCreditsTheDeepestProcessHoldingAPort(t *testing.T) {
+	got := attribute(table(t), 100, []boundPort{
+		{PID: 100, Port: 3000},
+		{PID: 101, Port: 3000},
+		{PID: 103, Port: 3000},
+		{PID: 102, Port: 3000},
+	})
+	want := []Detected{{Port: 3000, PID: 103, Command: "next"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("attribute = %#v, want %#v", got, want)
+	}
+}
+
+func TestAttributeSortsByPort(t *testing.T) {
+	got := attribute(table(t), 100, []boundPort{
+		{PID: 104, Port: 3001},
+		{PID: 103, Port: 3000},
+	})
+	want := []Detected{
+		{Port: 3000, PID: 103, Command: "next"},
+		{Port: 3001, PID: 104, Command: "next"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("attribute = %#v, want %#v", got, want)
+	}
+}
+
+// A pid whose ancestry does not reach the root (its parent was reaped between
+// the process snapshot and the socket scan) must never outrank a known
+// descendant.
+func TestAttributeIgnoresUnreachableAncestry(t *testing.T) {
+	got := attribute(table(t), 100, []boundPort{
+		{PID: 103, Port: 3000},
+		{PID: 900, Port: 3000},
+	})
+	want := []Detected{{Port: 3000, PID: 103, Command: "next"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("attribute = %#v, want %#v", got, want)
+	}
+}
+
+func TestAttributeCapsTheSuggestionList(t *testing.T) {
+	listeners := make([]boundPort, 0, maxDetected+5)
+	for i := range maxDetected + 5 {
+		listeners = append(listeners, boundPort{PID: 103, Port: 3000 + i})
+	}
+	if got := attribute(table(t), 100, listeners); len(got) != maxDetected {
+		t.Fatalf("attribute returned %d entries, want %d", len(got), maxDetected)
+	}
+}
+
+func TestAttributeWithoutListenersIsEmpty(t *testing.T) {
+	if got := attribute(table(t), 100, nil); got != nil {
+		t.Fatalf("attribute = %#v, want nil", got)
+	}
+}
+
+func TestCommandLabel(t *testing.T) {
+	for name, tc := range map[string]struct{ command, want string }{
+		// A bare runtime name says nothing about what is being served, so the
+		// first real argument is the informative half.
+		"node script":      {command: "/usr/bin/node /work/node_modules/next/dist/bin/next dev", want: "next"},
+		"bun script":       {command: "bun run dev", want: "run"},
+		"python module":    {command: "python3 -m http.server 8000", want: "http.server"},
+		"runtime only":     {command: "/usr/bin/node", want: "node"},
+		"runtime flagonly": {command: "node --inspect", want: "node"},
+		"named binary":     {command: "/usr/local/bin/next-server --port 3000", want: "next-server"},
+		"bare name":        {command: "vite", want: "vite"},
+		"js entry point":   {command: "node /work/node_modules/.bin/vite.js --host", want: "vite"},
+		"empty":            {command: "", want: ""},
+		"whitespace":       {command: "   ", want: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := commandLabel(tc.command); got != tc.want {
+				t.Fatalf("commandLabel(%q) = %q, want %q", tc.command, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnderWorkspace(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cwd, workspace string
+		want           bool
+	}{
+		"exact match":     {cwd: "/w/app", workspace: "/w/app", want: true},
+		"nested":          {cwd: "/w/app/packages/web", workspace: "/w/app", want: true},
+		"trailing slash":  {cwd: "/w/app/src", workspace: "/w/app/", want: true},
+		"sibling prefix":  {cwd: "/w/app-old", workspace: "/w/app"},
+		"parent":          {cwd: "/w", workspace: "/w/app"},
+		"unrelated":       {cwd: "/opt/other", workspace: "/w/app"},
+		"empty cwd":       {workspace: "/w/app"},
+		"empty workspace": {cwd: "/w/app"},
+		"both empty":      {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := underWorkspace(tc.cwd, tc.workspace); got != tc.want {
+				t.Fatalf("underWorkspace(%q, %q) = %t, want %t", tc.cwd, tc.workspace, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/portscan/tree_unix.go
+++ b/backend/internal/portscan/tree_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package portscan
+
+import (
+	"context"
+	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// processTableTimeout bounds the snapshot. A stalled `ps` must never hold a
+// preview request open.
+const processTableTimeout = 2 * time.Second
+
+// processTable snapshots the machine's processes. `ps` rather than /proc even
+// on Linux: one exec per scan is cheap next to reading a stat file for every
+// pid on the machine, and it is the same invocation the tmux runtime already
+// uses for its own process-tree work.
+func processTable(ctx context.Context) []process {
+	tableCtx, cancel := context.WithTimeout(ctx, processTableTimeout)
+	defer cancel()
+	out, err := aoprocess.CommandContext(tableCtx, "ps", "-ww", "-axo", "pid=,ppid=,args=").Output()
+	if err != nil && len(out) == 0 {
+		return nil
+	}
+	return parseProcessTable(string(out))
+}

--- a/backend/internal/portscan/windows.go
+++ b/backend/internal/portscan/windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package portscan
+
+import "context"
+
+// Windows detects nothing yet. Its socket enumeration and process walk land
+// together in a follow-up (GetExtendedTcpTable plus CreateToolhelp32Snapshot);
+// until then every anchor returns empty, which is the package's normal result
+// rather than an error.
+
+func listeners(_ context.Context, _ map[int]bool) []boundPort { return nil }
+
+func processTable(_ context.Context) []process { return nil }
+
+func workspaceProcesses(_ context.Context, _ []process, _ string) []int { return nil }

--- a/backend/internal/previewserver/manager.go
+++ b/backend/internal/previewserver/manager.go
@@ -2,6 +2,14 @@
 // processes used by the desktop preview. It deliberately does not scan global
 // localhost ports: a server is started from an explicit project configuration,
 // so its worker, command, working directory, and URL are known.
+//
+// That is not a rule against port detection anywhere in AO, only against
+// guessing here. The Browser panel additionally offers detected ports as
+// clickable suggestions (ports.DescendantPortLister, internal/portscan), and
+// the two are complementary rather than contradictory: this package knows what
+// it started and can start, stop and report on it, while detection only
+// observes what already exists inside one session's process tree and never
+// controls it. Neither reads global localhost.
 package previewserver
 
 import (

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -929,6 +929,18 @@ func (c *Controller) State() ports.ChatControllerState {
 	return c.state
 }
 
+// ProcessID is the local provider process backing this controller, or 0 when
+// the driver runs no local child (or does not report one). It is an observation
+// root for machine-scoped questions about what this session started -- see
+// ports.ChatProcessInspector, which forbids using it as a lifecycle handle.
+func (c *Controller) ProcessID() int {
+	inspector, ok := c.conv.(ports.ChatProcessInspector)
+	if !ok {
+		return 0
+	}
+	return inspector.ProcessID()
+}
+
 // Capabilities reports what this session's provider can do, so a client can gate
 // a control before drawing it rather than discovering the answer from a refusal.
 func (c *Controller) Capabilities() ports.ChatCapabilities {

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -572,6 +572,27 @@ func (s *Service) HasLiveChatController(sessionID domain.SessionID) bool {
 	return controller != nil && controller.State() != ports.ChatControllerStopped
 }
 
+// ChatProcessID is the live provider process for a chat session, and whether
+// there is one to report. A session with no controller, a stopped controller,
+// or a driver that runs no local child all report (0, false).
+//
+// Callers may only observe with this. It is not a lifecycle handle: the process
+// may already have exited, and nothing here is evidence about session liveness
+// (HasLiveChatController answers that question).
+func (s *Service) ChatProcessID(sessionID domain.SessionID) (int, bool) {
+	s.mu.RLock()
+	controller := s.controllers[sessionID]
+	s.mu.RUnlock()
+	if controller == nil || controller.State() == ports.ChatControllerStopped {
+		return 0, false
+	}
+	pid := controller.ProcessID()
+	if pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
 // requireChatSession reads the persisted mode and refuses anything that is not a
 // Chat session. Dispatch is decided by durable state, never by the caller.
 func (s *Service) requireChatSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, error) {

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -82,6 +82,13 @@ type interfaceTransitionCommander interface {
 	AcknowledgeInterfaceTransitionNotice(context.Context, domain.SessionID, string) (domain.SessionInterfaceTransition, error)
 }
 
+// previewPortsCommander is an optional command capability, kept separate from
+// commander for the same reason as interfaceTransitionCommander: focused
+// session-service fakes should not have to grow a method for it.
+type previewPortsCommander interface {
+	ListDescendantPorts(ctx context.Context, id domain.SessionID) ([]ports.DetectedPort, error)
+}
+
 // RollbackOutcome reports what happened in a rollback: either the seed row was
 // deleted, or the partially-spawned session was killed (runtime+workspace torn
 // down, row marked terminated).
@@ -554,6 +561,26 @@ func (s *Service) InterfaceTransitionStatus(ctx context.Context, id domain.Sessi
 		ReasonCode: status.ReasonCode, Reason: status.Reason,
 		Transition: status.Transition,
 	}, nil
+}
+
+// ListPreviewPorts returns the TCP ports this session's own processes are
+// listening on, as clickable suggestions for the desktop browser panel.
+//
+// Suggestions only: a build or runtime that cannot detect ports returns an
+// empty list, never an error. That is deliberately unlike
+// InterfaceTransitionStatus above, which reports an unsupported build as a
+// conflict -- there the user asked for an action that cannot happen, here they
+// only asked what is running.
+func (s *Service) ListPreviewPorts(ctx context.Context, id domain.SessionID) ([]ports.DetectedPort, error) {
+	manager, ok := s.manager.(previewPortsCommander)
+	if !ok {
+		return nil, nil
+	}
+	detected, err := manager.ListDescendantPorts(ctx, id)
+	if err != nil {
+		return nil, toAPIError(err)
+	}
+	return detected, nil
 }
 
 // StartInterfaceTransition begins a durable, asynchronous controller handoff.

--- a/backend/internal/session_manager/preview_ports.go
+++ b/backend/internal/session_manager/preview_ports.go
@@ -1,0 +1,93 @@
+package sessionmanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/portscan"
+)
+
+// ChatProcessLocator is an optional ChatLauncher capability: the live provider
+// process for a chat session, and whether there is one. Kept separate from
+// ChatLauncher itself so focused chat fakes do not have to grow a method for a
+// purely observational read.
+type ChatProcessLocator interface {
+	ChatProcessID(id domain.SessionID) (int, bool)
+}
+
+// ListDescendantPorts reports the TCP ports one session is serving on, so the
+// desktop can offer them as preview suggestions.
+//
+// Detection is anchored two ways, and a process counts on either: it is under
+// the session's own root process, or its working directory is inside the
+// session's worktree. Both are needed. The root process differs by mode -- a
+// terminal session's work hangs off its runtime (a tmux pane's shell), while a
+// chat session has no runtime handle at all and hangs off the provider process
+// the chat controller owns -- and neither survives an agent backgrounding a dev
+// server, which detaches it from every AO-owned parent. The worktree does not
+// move and belongs to exactly one session, so it keeps the scan scoped when the
+// process tree no longer can.
+//
+// Detection is best effort in every mode. A missing capability, a session with
+// no live process, a terminated session, and a failed scan all yield an empty
+// list rather than an error, because "no suggestions" is a normal outcome the
+// desktop already renders. Only an unreadable store or an unknown session id is
+// an error: those describe a bad request, not absent detection.
+func (m *Manager) ListDescendantPorts(ctx context.Context, id domain.SessionID) ([]ports.DetectedPort, error) {
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("list descendant ports %s: %w", id, err)
+	}
+	if !ok {
+		return nil, ErrNotFound
+	}
+	// A terminated session's recorded handle may already have been recycled by
+	// the runtime, and its worktree may be gone or reassigned.
+	if rec.IsTerminated {
+		return nil, nil
+	}
+	rootPID := m.sessionRootProcess(ctx, rec)
+	workspace := strings.TrimSpace(rec.Metadata.WorkspacePath)
+	if rootPID <= 0 && workspace == "" {
+		return nil, nil
+	}
+	detected := portscan.Detect(ctx, rootPID, workspace)
+	out := make([]ports.DetectedPort, 0, len(detected))
+	for _, port := range detected {
+		out = append(out, ports.DetectedPort{Port: port.Port, PID: port.PID, Command: port.Command})
+	}
+	return out, nil
+}
+
+// sessionRootProcess is the process a session's own work hangs off, or 0 when
+// there is none to point at. Chat sessions get it from the chat controller
+// (their provider is a child of the daemon, not of any runtime); every other
+// mode gets it from the runtime adapter.
+func (m *Manager) sessionRootProcess(ctx context.Context, rec domain.SessionRecord) int {
+	if rec.Mode == domain.SessionModeChat {
+		if m.chat == nil {
+			return 0
+		}
+		locator, ok := m.chat.(ChatProcessLocator)
+		if !ok {
+			return 0
+		}
+		pid, ok := locator.ChatProcessID(rec.ID)
+		if !ok {
+			return 0
+		}
+		return pid
+	}
+	inspector, ok := m.runtime.(ports.SessionRootProcessInspector)
+	if !ok || strings.TrimSpace(rec.Metadata.RuntimeHandleID) == "" {
+		return 0
+	}
+	pid, err := inspector.RootProcessID(ctx, runtimeHandle(rec.Metadata))
+	if err != nil {
+		return 0
+	}
+	return pid
+}

--- a/backend/internal/session_manager/preview_ports_test.go
+++ b/backend/internal/session_manager/preview_ports_test.go
@@ -1,0 +1,159 @@
+package sessionmanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// rootProcessRuntime is a runtime that implements the optional root-process
+// capability, and records whether the manager reached for it.
+type rootProcessRuntime struct {
+	*fakeRuntime
+	calls []ports.RuntimeHandle
+	pid   int
+	err   error
+}
+
+func (r *rootProcessRuntime) RootProcessID(_ context.Context, handle ports.RuntimeHandle) (int, error) {
+	r.calls = append(r.calls, handle)
+	return r.pid, r.err
+}
+
+// chatPortLauncher is a chat launcher that also reports its provider process.
+type chatPortLauncher struct {
+	*recordingLauncher
+	pid     int
+	hasPID  bool
+	lookups []domain.SessionID
+}
+
+func (l *chatPortLauncher) ChatProcessID(id domain.SessionID) (int, bool) {
+	l.lookups = append(l.lookups, id)
+	return l.pid, l.hasPID
+}
+
+func seedPortSession(st *fakeStore, id domain.SessionID, mode domain.SessionMode, handleID, workspace string) {
+	st.sessions[id] = domain.SessionRecord{
+		ID:        id,
+		ProjectID: chatTestProject,
+		Mode:      mode,
+		Metadata:  domain.SessionMetadata{RuntimeHandleID: handleID, WorkspacePath: workspace},
+	}
+}
+
+// A terminal session's work hangs off its runtime handle, so the runtime is
+// what knows the root process.
+func TestListDescendantPortsRootsTerminalSessionsAtTheRuntime(t *testing.T) {
+	launcher := &chatPortLauncher{recordingLauncher: &recordingLauncher{}}
+	m, st, rt := newChatManager(launcher)
+	inspector := &rootProcessRuntime{fakeRuntime: rt, pid: 4242}
+	m.runtime = inspector
+	seedPortSession(st, "sess-tui", domain.SessionModeTUI, "handle-1", "")
+
+	if _, err := m.ListDescendantPorts(t.Context(), "sess-tui"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inspector.calls) != 1 || inspector.calls[0].ID != "handle-1" {
+		t.Fatalf("runtime calls = %#v", inspector.calls)
+	}
+	if len(launcher.lookups) != 0 {
+		t.Fatal("a terminal session asked the chat launcher for a process")
+	}
+}
+
+// A chat session has no runtime handle at all: its provider is a child of the
+// daemon, so the chat controller owns the only usable root. Asking the runtime
+// instead is what made chat sessions detect nothing.
+func TestListDescendantPortsRootsChatSessionsAtTheProvider(t *testing.T) {
+	launcher := &chatPortLauncher{recordingLauncher: &recordingLauncher{}, pid: 4242, hasPID: true}
+	m, st, rt := newChatManager(launcher)
+	inspector := &rootProcessRuntime{fakeRuntime: rt, pid: 99}
+	m.runtime = inspector
+	seedPortSession(st, "sess-chat", domain.SessionModeChat, "", "")
+
+	if _, err := m.ListDescendantPorts(t.Context(), "sess-chat"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(launcher.lookups) != 1 || launcher.lookups[0] != "sess-chat" {
+		t.Fatalf("chat lookups = %#v", launcher.lookups)
+	}
+	if len(inspector.calls) != 0 {
+		t.Fatalf("a chat session was rooted through the runtime: %#v", inspector.calls)
+	}
+}
+
+// Every "cannot detect" shape is an empty list, never an error: the desktop
+// renders no suggestions for all of them, and an error would be noise.
+func TestListDescendantPortsFailOpen(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mode       domain.SessionMode
+		handleID   string
+		terminated bool
+		hasPID     bool
+		rootErr    error
+		plainRT    bool
+	}{
+		"chat session with no live provider":    {mode: domain.SessionModeChat},
+		"terminal session with no handle yet":   {mode: domain.SessionModeTUI},
+		"runtime without the capability":        {mode: domain.SessionModeTUI, handleID: "handle-1", plainRT: true},
+		"root process lookup failed":            {mode: domain.SessionModeTUI, handleID: "handle-1", rootErr: errors.New("no tmux")},
+		"terminated session is never scanned":   {mode: domain.SessionModeTUI, handleID: "handle-1", terminated: true},
+		"terminated chat session is not probed": {mode: domain.SessionModeChat, terminated: true, hasPID: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			launcher := &chatPortLauncher{recordingLauncher: &recordingLauncher{}, hasPID: tc.hasPID}
+			m, st, rt := newChatManager(launcher)
+			if !tc.plainRT {
+				m.runtime = &rootProcessRuntime{fakeRuntime: rt, err: tc.rootErr}
+			}
+			// No workspace path either, so nothing is left to anchor a scan to.
+			seedPortSession(st, "sess-1", tc.mode, tc.handleID, "")
+			if tc.terminated {
+				rec := st.sessions["sess-1"]
+				rec.IsTerminated = true
+				st.sessions["sess-1"] = rec
+			}
+
+			got, err := m.ListDescendantPorts(t.Context(), "sess-1")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != 0 {
+				t.Fatalf("ports = %#v, want none", got)
+			}
+			if tc.terminated && len(launcher.lookups) != 0 {
+				t.Fatal("a terminated session was probed for a live process")
+			}
+		})
+	}
+}
+
+// An agent that backgrounds a dev server detaches it from every AO-owned
+// parent, so a session whose root process is gone must still scan on its
+// worktree alone rather than giving up.
+func TestListDescendantPortsScansOnWorkspaceWithoutARootProcess(t *testing.T) {
+	launcher := &chatPortLauncher{recordingLauncher: &recordingLauncher{}}
+	m, st, rt := newChatManager(launcher)
+	m.runtime = &rootProcessRuntime{fakeRuntime: rt, err: errors.New("pane is gone")}
+	seedPortSession(st, "sess-1", domain.SessionModeTUI, "handle-1", t.TempDir())
+
+	// The scan itself finds nothing for an empty temp dir; what matters is that
+	// it ran instead of short-circuiting on the missing root.
+	if _, err := m.ListDescendantPorts(t.Context(), "sess-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// An unknown session is a bad request, not absent detection, so it stays an
+// error the API can turn into a 404.
+func TestListDescendantPortsUnknownSession(t *testing.T) {
+	m, _, _ := newChatManager(&chatPortLauncher{recordingLauncher: &recordingLauncher{}})
+
+	if _, err := m.ListDescendantPorts(t.Context(), "missing-1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/backend/internal/skillassets/using-ao/commands/preview.md
+++ b/backend/internal/skillassets/using-ao/commands/preview.md
@@ -88,7 +88,9 @@ ao preview stop [--json]
 ```
 
 This command is for an existing, intentional project configuration. Do not
-create the file as routine preview setup. Do not scan unrelated ports.
+create the file as routine preview setup. Do not go looking for servers you did
+not start: `ao preview ports` below is the only sanctioned way to find a port,
+and it reports this session's own processes only.
 `${PORT}` is expanded in `runtimeArgs`, `url`, and `env`; AO also sets `PORT`,
 `AO_PREVIEW_PORT`, and `AO_SESSION_ID`.
 
@@ -122,6 +124,38 @@ taking over the visible browser. When several configurations exist, select the
 one relevant to the user's request by name. If the agent starts a server
 outside this lifecycle, explicitly adopt its known URL with `ao preview <url>`;
 terminal URLs are not automatically ranked or selected.
+
+---
+
+### ao preview ports
+
+List the TCP ports this session's own processes are listening on, then open one
+with `ao preview http://localhost:<port>`.
+
+```bash
+ao preview ports [--json]
+```
+
+Scoped to this session: a process counts when it descends from the session's
+own root process, or when its working directory is inside the session
+workspace. A server another session started, and anything else running on the
+machine, are never reported. Use it after starting a dev server whose port you
+do not already know, instead of reading it out of scrollback or probing ports
+by hand.
+
+Backgrounding a server does not hide it. A detached process is reparented away
+from everything AO owns, but it keeps its working directory, so it is still
+found.
+
+Best effort by design. It prints nothing when the session is serving nothing,
+and also when the machine cannot enumerate listening sockets at all — those two
+cases are indistinguishable, so do not report "no servers are running" on an
+empty result. Nothing here says whether a server is healthy or ready; only that
+something in this session holds the port.
+
+Prefer a URL you already know. If you started the server yourself, or the
+project has a `.ao/launch.json`, you know its port already and should adopt it
+directly rather than searching for it.
 
 ---
 

--- a/backend/internal/skillassets/using-ao/references.md
+++ b/backend/internal/skillassets/using-ao/references.md
@@ -7,6 +7,7 @@ Natural-language-to-command mappings for common AO tasks.
 | Show me this webpage / open this page | `ao preview "<url>"` |
 | Start an existing configured dev app | `ao preview start [configuration]` |
 | Check or stop the worker's managed dev app | `ao preview status` / `ao preview stop` |
+| Find the port a server in this session is on | `ao preview ports` |
 | Show this Markdown or HTML file without a server | `ao preview "<workspace-path>"` |
 | Hand off a newly created browser-displayable artifact | `ao preview "<workspace-path>"` immediately after writing the primary artifact |
 | Inspect and verify this webpage as the agent | `ao browser open "<url>"`, then `ao browser snapshot` |

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -130,6 +130,7 @@ var legacyActorlessUserCLICommands = map[string]struct{}{
 	"ao pr resolve-comments":    {},
 	"ao preview":                {},
 	"ao preview clear":          {},
+	"ao preview ports":          {},
 	"ao preview start":          {},
 	"ao preview status":         {},
 	"ao preview stop":           {},

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1275,6 +1275,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sessions/{sessionId}/preview/ports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List TCP ports detected inside a session's own process tree */
+        get: operations["listSessionPreviewPorts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sessions/{sessionId}/preview/server": {
         parameters: {
             query?: never;
@@ -2310,6 +2327,15 @@ export interface components {
         DesktopWorkspaceLocationResponse: {
             sessionId: string;
             workspacePath: string;
+        };
+        DetectedPreviewPort: {
+            command?: string;
+            pid: number;
+            port: number;
+        };
+        DetectedPreviewPortsResponse: {
+            ports: components["schemas"]["DetectedPreviewPort"][];
+            sessionId: string;
         };
         DevImportProjectsConflict: {
             path: string;
@@ -8165,6 +8191,65 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    listSessionPreviewPorts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Session identifier, e.g. project-1. */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetectedPreviewPortsResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1,5 +1,7 @@
-import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render as rtlRender, renderHook, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { useBrowserView, type BrowserNavState } from "../hooks/useBrowserView";
@@ -13,14 +15,25 @@ import type {
 } from "../../shared/browser-annotations";
 
 const postMock = vi.hoisted(() => vi.fn());
+const getMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../lib/api-client", () => ({
-	apiClient: { POST: postMock },
+	apiClient: { GET: getMock, POST: postMock },
 	apiErrorMessage: (error: unknown, fallback = "Request failed") =>
 		typeof error === "object" && error !== null && "message" in error
 			? String((error as { message: unknown }).message)
 			: fallback,
 }));
+
+// The panel polls for detected preview ports, so every render needs a query
+// client. rerender is wrapped as well so re-rendering tests keep one client
+// (and therefore one cache) across renders, as the real app does.
+function render(ui: ReactElement) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const wrap = (node: ReactElement) => <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+	const result = rtlRender(wrap(ui));
+	return { ...result, rerender: (next: ReactElement) => result.rerender(wrap(next)) };
+}
 
 const hookState = vi.hoisted(() => ({
 	navigate: vi.fn(),
@@ -181,6 +194,8 @@ describe("BrowserPanel", () => {
 		hookState.setAnnotationMode.mockResolvedValue(undefined);
 		postMock.mockReset();
 		postMock.mockResolvedValue({ data: {} });
+		getMock.mockReset();
+		getMock.mockResolvedValue({ data: { sessionId: "sess-1", ports: [] } });
 		annotationSubmitListeners.clear();
 		annotationCancelListeners.clear();
 		window.ao!.browser.onAnnotationSubmit = vi.fn((listener: (payload: BrowserAnnotationSubmitPayload) => void) => {
@@ -1255,6 +1270,82 @@ describe("BrowserPanel", () => {
 			const tooltip = await screen.findByRole("tooltip");
 			expect(tooltip.closest('[data-browser-native-overlay="true"]')).not.toBeNull();
 			expect(document.querySelector(OPEN_BROWSER_OVERLAY_SELECTOR)).not.toBeNull();
+		});
+	});
+
+	describe("detected preview ports", () => {
+		it("hides the control entirely when nothing is detected", async () => {
+			render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			await waitFor(() => expect(getMock).toHaveBeenCalled());
+			// No empty state: a toolbar has no room to explain the difference
+			// between "nothing is serving" and "this machine cannot tell".
+			expect(screen.queryByTestId("browser-detected-ports")).toBeNull();
+		});
+
+		it("opens a detected port the same way `ao preview <url>` does", async () => {
+			getMock.mockResolvedValue({
+				data: { sessionId: "sess-1", ports: [{ port: 5173, pid: 812, command: "node" }] },
+			});
+			render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			const trigger = await screen.findByTestId("browser-detected-ports");
+			await userEvent.click(trigger);
+			await userEvent.click(await screen.findByRole("menuitem", { name: /5173/ }));
+
+			// The daemon persists the target and bumps the preview revision, so
+			// the panel returns to this page after a remount or session switch.
+			await waitFor(() =>
+				expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/preview", {
+					params: { path: { sessionId: "sess-1" } },
+					body: { url: "http://localhost:5173" },
+				}),
+			);
+		});
+
+		// The live page paints as a native view above this HTML. An overlay that
+		// does not announce itself renders behind the page: invisible, with its
+		// clicks landing on the page instead.
+		it("marks the menu as a native overlay so it paints above the live page", async () => {
+			getMock.mockResolvedValue({
+				data: { sessionId: "sess-1", ports: [{ port: 5173, pid: 812, command: "node" }] },
+			});
+			render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			await userEvent.click(await screen.findByTestId("browser-detected-ports"));
+			const item = await screen.findByRole("menuitem", { name: /5173/ });
+			const overlay = item.closest('[data-browser-native-overlay="true"]');
+			if (overlay === null) {
+				throw new Error("detected-ports menu is not tagged as a browser native overlay");
+			}
+			if (document.querySelector(OPEN_BROWSER_OVERLAY_SELECTOR) === null) {
+				throw new Error("open detected-ports menu does not match OPEN_BROWSER_OVERLAY_SELECTOR");
+			}
+		});
+
+		it("labels each entry with its owning process", async () => {
+			getMock.mockResolvedValue({
+				data: {
+					sessionId: "sess-1",
+					ports: [
+						{ port: 5173, pid: 812, command: "node" },
+						{ port: 8080, pid: 900 },
+					],
+				},
+			});
+			render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			await userEvent.click(await screen.findByTestId("browser-detected-ports"));
+			expect(await screen.findByText("node")).toBeTruthy();
+			// An unlabeled process still gets an entry; only the label is absent.
+			expect(await screen.findByRole("menuitem", { name: /8080/ })).toBeTruthy();
+		});
+
+		it("does not scan while the panel is off screen", async () => {
+			render(<BrowserPanel active={false} onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			await waitFor(() => expect(screen.getByTestId("browser-panel")).toBeTruthy());
+			expect(getMock).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -13,12 +13,15 @@ import {
 	MousePointer2,
 	Plus,
 	RefreshCw,
+	Server,
 	Smartphone,
 	Tablet,
 	X,
 } from "lucide-react";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { useBrowserView, type BrowserViewModel } from "../hooks/useBrowserView";
+import { useDetectedPreviewPorts } from "../hooks/useDetectedPreviewPorts";
+import { useSessionBrowserLink } from "../hooks/useSessionBrowserLink";
 import { formatBrowserAnnotationMessage, type BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 import { MAX_BROWSER_TABS } from "../../shared/browser-tabs";
 import type { WorkspaceSession } from "../types/workspace";
@@ -278,6 +281,8 @@ export function BrowserPanel({
 }
 
 export function BrowserPanelView({
+	session,
+	active,
 	poppedOut,
 	onTogglePopOut,
 	browserView,
@@ -318,6 +323,10 @@ export function BrowserPanelView({
 	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);
 	const canRetryAnnotation = status === "error" && queuedCount > 0;
 	const canOpenTab = tabs.length < MAX_BROWSER_TABS;
+	// Suggestions are only worth scanning for while someone is looking at the
+	// panel; a popped-out panel is on screen too, so both count as visible.
+	const detectedPorts = useDetectedPreviewPorts(session.id, active || poppedOut);
+	const openSessionLink = useSessionBrowserLink(session);
 	const [devicePreset, setDevicePreset] = useState<string | null>(null);
 	const [customDeviceWidth, setCustomDeviceWidth] = useState("390");
 	const deviceFrameWidth =
@@ -542,6 +551,44 @@ export function BrowserPanelView({
 						value={urlInput}
 					/>
 				</div>
+				{detectedPorts.length > 0 ? (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								aria-label={t("browser.detectedPorts")}
+								data-testid="browser-detected-ports"
+								size="icon-sm"
+								title={t("browser.detectedPorts")}
+								type="button"
+								variant="ghost"
+							>
+								<Server aria-hidden="true" className="size-icon-base" />
+							</Button>
+						</DropdownMenuTrigger>
+						{/* data-browser-native-overlay is load-bearing, not decoration:
+						    the live page paints as a native view ABOVE this HTML, so
+						    useBrowserView's observer needs this attribute to lower it
+						    while the menu is open. Without it the menu renders behind
+						    the page -- invisible, and clicks land on the page instead. */}
+						<DropdownMenuContent align="end" data-browser-native-overlay="true">
+							{detectedPorts.map((detected) => (
+								<DropdownMenuItem
+									aria-label={t("browser.openDetectedPort", { port: detected.port })}
+									key={detected.port}
+									// localhost, not 127.0.0.1: dev servers with host
+									// allowlists (Vite's default among them) accept the
+									// name and reject the literal address.
+									onSelect={() => openSessionLink(`http://localhost:${detected.port}`)}
+								>
+									<span className="font-mono text-xs">{detected.port}</span>
+									{detected.command ? (
+										<span className="truncate text-caption text-muted-foreground">{detected.command}</span>
+									) : null}
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuContent>
+					</DropdownMenu>
+				) : null}
 				{tabNotice ? (
 					<span className="max-w-24 truncate text-caption text-accent" role="status">
 						{tabNotice}

--- a/frontend/src/renderer/hooks/useDetectedPreviewPorts.ts
+++ b/frontend/src/renderer/hooks/useDetectedPreviewPorts.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import type { components } from "../../api/schema";
+import { apiClient } from "../lib/api-client";
+
+export type DetectedPreviewPort = components["schemas"]["DetectedPreviewPort"];
+
+export const detectedPreviewPortsQueryKey = (sessionId: string) => ["session-preview-ports", sessionId] as const;
+
+// Detected ports have no change feed to subscribe to. Nothing in the daemon is
+// told when an agent starts a dev server, and no OS AO ships to reports "a port
+// opened" without root, so the panel asks on a timer instead — and only while
+// it is on screen, since an unwatched panel would be scanning process trees for
+// nobody. The scan itself is cheap by design (see internal/portscan).
+export const DETECTED_PORTS_POLL_MS = 5_000;
+
+const NO_PORTS: DetectedPreviewPort[] = [];
+
+/**
+ * Ports the session's own processes are listening on, offered as preview
+ * suggestions. Never throws and never surfaces an error: a daemon without the
+ * route, a terminated session, and a machine that cannot enumerate sockets all
+ * mean "nothing detected", which the panel renders as no list at all.
+ */
+export function useDetectedPreviewPorts(sessionId: string, enabled: boolean): DetectedPreviewPort[] {
+	const query = useQuery({
+		queryKey: detectedPreviewPortsQueryKey(sessionId),
+		queryFn: async (): Promise<DetectedPreviewPort[]> => {
+			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/preview/ports", {
+				params: { path: { sessionId } },
+			});
+			if (error || !data) return NO_PORTS;
+			return data.ports ?? NO_PORTS;
+		},
+		enabled: enabled && sessionId !== "",
+		refetchInterval: DETECTED_PORTS_POLL_MS,
+	});
+	return query.data ?? NO_PORTS;
+}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "Benutzerdefinierte Breite",
 	"browser.deviceFit": "Auf Panel anpassen",
 	"browser.devicePreset": "Geräte-Voreinstellung",
+	"browser.detectedPorts": "Erkannte Ports",
+	"browser.openDetectedPort": "localhost:{{port}} öffnen",
 	"browser.emptyUrl": "Geben Sie eine URL ein oder klicken Sie eine im Terminal an.",
 	"browser.forward": "Vorwärts",
 	"browser.newTab": "Neuer Tab",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "Custom width",
 	"browser.deviceFit": "Fit panel",
 	"browser.devicePreset": "Device preset",
+	"browser.detectedPorts": "Detected ports",
+	"browser.openDetectedPort": "Open localhost:{{port}}",
 	"browser.emptyUrl": "Enter a URL or click one in the terminal.",
 	"browser.forward": "Forward",
 	"browser.newTab": "New tab",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "Ancho personalizado",
 	"browser.deviceFit": "Ajustar al panel",
 	"browser.devicePreset": "Preajuste de dispositivo",
+	"browser.detectedPorts": "Puertos detectados",
+	"browser.openDetectedPort": "Abrir localhost:{{port}}",
 	"browser.emptyUrl": "Introduce una URL o haz clic en una en el terminal.",
 	"browser.forward": "Adelante",
 	"browser.newTab": "Nueva pestaña",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "Largeur personnalisée",
 	"browser.deviceFit": "Ajuster au panneau",
 	"browser.devicePreset": "Préréglage d'appareil",
+	"browser.detectedPorts": "Ports détectés",
+	"browser.openDetectedPort": "Ouvrir localhost:{{port}}",
 	"browser.emptyUrl": "Saisissez une URL ou cliquez-en une dans le terminal.",
 	"browser.forward": "Suivant",
 	"browser.newTab": "Nouvel onglet",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "カスタム幅",
 	"browser.deviceFit": "パネルに合わせる",
 	"browser.devicePreset": "デバイスプリセット",
+	"browser.detectedPorts": "検出されたポート",
+	"browser.openDetectedPort": "localhost:{{port}} を開く",
 	"browser.emptyUrl": "URL を入力するか、ターミナル内のリンクをクリックしてください。",
 	"browser.forward": "進む",
 	"browser.newTab": "新しいタブ",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "사용자 지정 너비",
 	"browser.deviceFit": "패널에 맞추기",
 	"browser.devicePreset": "기기 사전 설정",
+	"browser.detectedPorts": "감지된 포트",
+	"browser.openDetectedPort": "localhost:{{port}} 열기",
 	"browser.emptyUrl": "URL을 입력하거나 터미널에서 링크를 클릭하세요.",
 	"browser.forward": "앞으로",
 	"browser.newTab": "새 탭",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "Largura personalizada",
 	"browser.deviceFit": "Ajustar ao painel",
 	"browser.devicePreset": "Predefinição de dispositivo",
+	"browser.detectedPorts": "Portas detectadas",
+	"browser.openDetectedPort": "Abrir localhost:{{port}}",
 	"browser.emptyUrl": "Digite uma URL ou clique em uma no terminal.",
 	"browser.forward": "Avançar",
 	"browser.newTab": "Nova aba",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -24,6 +24,8 @@
 	"browser.deviceCustomWidth": "自定义宽度",
 	"browser.deviceFit": "适应面板",
 	"browser.devicePreset": "设备预设",
+	"browser.detectedPorts": "检测到的端口",
+	"browser.openDetectedPort": "打开 localhost:{{port}}",
 	"browser.emptyUrl": "输入网址，或在终端中点击链接。",
 	"browser.forward": "前进",
 	"browser.newTab": "新标签",

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -93,6 +93,7 @@ const ROUTE_TEMPLATES = [
 	"/api/v1/sessions/{sessionId}/pr/claim",
 	"/api/v1/sessions/{sessionId}/preview",
 	"/api/v1/sessions/{sessionId}/preview/files/*",
+	"/api/v1/sessions/{sessionId}/preview/ports",
 	"/api/v1/sessions/{sessionId}/preview/server",
 	"/api/v1/sessions/{sessionId}/resume-agent",
 	"/api/v1/sessions/{sessionId}/restore",


### PR DESCRIPTION
## What

The Browser panel offers the ports a session is actually serving on, next to the address bar. Clicking one opens it the way `ao preview <url>` does. Same view from the CLI via `ao preview ports [--json]`.

## Why

Finding a dev server's port meant reading it out of terminal scrollback and typing it into the address bar.

## How

Detection is scoped to a session two ways, and a process qualifies on either: it descends from the session's root process, or its working directory is inside the session's worktree. Both are needed — the root process differs by mode (a tmux pane's shell for terminal sessions, the provider process for chat), and neither survives an agent backgrounding a dev server, since a detached process is reparented to init. The worktree does not move and belongs to one session.

`internal/portscan` reads `/proc` on Linux and shells out to `lsof` elsewhere, then credits each port to the deepest process holding it — a server started from a shell is reported by every ancestor that inherited the descriptor.

Everything fails open: a missing `lsof`, an unreadable process table, a permission denial, or a session with no live process all yield an empty list, never an error. Windows detects nothing for now (`portscan/windows.go`); its socket enumeration lands separately.

`GET /api/v1/sessions/{id}/preview/ports` carries no capability header — it starts nothing — and is blocked on the LAN listener instead (`httpd/lan_listener.go:84`), so the list never leaves the machine.

## Testing

`go build ./...`, `go vet`, and `go test` pass on `internal/portscan`, `internal/cli`, `internal/httpd/...`, `internal/session_manager`. Cross-compiled `portscan` for `GOOS=windows` and `GOOS=darwin`. `BrowserPanel.test.tsx` passes 58/58. Not verified in the running desktop app.

## When Server is not Live

<img width="590" height="165" alt="image" src="https://github.com/user-attachments/assets/7433b9f3-6363-44ed-9a3d-d10e9f377e26" />

## When Server is Live

<img width="512" height="316" alt="image" src="https://github.com/user-attachments/assets/1ca8aef8-86bb-44e7-be5e-c2f2086a5efa" />


## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
