### PR TITLE
fix: validate Goose binary identity

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,6 +47,22 @@ jobs:
       - name: Test
         run: go test -race ./...
 
+  windows-goose:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache: false
+
+      - name: Test Goose adapter
+        run: go test ./internal/process ./internal/adapters/agent/goose
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/backend/internal/adapters/agent/binaryutil/binaryutil.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil.go
@@ -72,14 +72,15 @@ type WinPath struct {
 	Parts []string
 }
 
-// ResolveBinary returns the path to spec's binary, searching PATH then the
-// platform's candidate install locations. It returns a wrapped
-// ports.ErrAgentBinaryNotFound when nothing matches, so callers surface a clear
-// "command not found" rather than launching an empty argv. ctx cancellation is
-// honored between probes.
-func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
+// ResolveBinaryCandidates returns spec's ordered binary candidates. PATH is
+// searched first, followed by the platform's configured paths, package-manager
+// paths, and (when enabled) version-manager paths. Candidates are deduplicated
+// while preserving their first occurrence. The returned paths are not all
+// necessarily executable; callers that need to validate a candidate should do
+// so themselves. ctx cancellation is honored while discovering candidates.
+func ResolveBinaryCandidates(ctx context.Context, spec BinarySpec) ([]string, error) {
 	if err := ctx.Err(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	names := spec.Names
@@ -87,16 +88,28 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 		names = spec.WinNames
 	}
 
+	candidates := make([]string, 0)
+	seen := make(map[string]struct{})
+	appendCandidate := func(candidate string) {
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		candidates = append(candidates, candidate)
+	}
+
 	for _, name := range names {
 		if err := ctx.Err(); err != nil {
-			return "", err
+			return nil, err
 		}
 		if path, err := exec.LookPath(name); err == nil && path != "" {
-			return path, nil
+			appendCandidate(path)
 		}
 	}
 
-	var candidates []string
 	if runtime.GOOS == "windows" {
 		home, _ := os.UserHomeDir()
 		appData := os.Getenv("APPDATA")
@@ -114,22 +127,46 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 			if base == "" {
 				continue
 			}
-			candidates = append(candidates, filepath.Join(append([]string{base}, wp.Parts...)...))
+			appendCandidate(filepath.Join(append([]string{base}, wp.Parts...)...))
 		}
-		candidates = append(candidates, WindowsPackageManagerBinCandidates(executableNames(spec)...)...)
+		for _, candidate := range WindowsPackageManagerBinCandidates(executableNames(spec)...) {
+			appendCandidate(candidate)
+		}
 	} else {
-		candidates = append(candidates, spec.UnixPaths...)
+		for _, candidate := range spec.UnixPaths {
+			appendCandidate(candidate)
+		}
 		if home, err := os.UserHomeDir(); err == nil {
-			candidates = append(candidates, joinAll(home, spec.UnixHomePaths)...)
-			candidates = append(candidates, UnixPackageManagerBinCandidates(home, spec.Names...)...)
+			for _, candidate := range joinAll(home, spec.UnixHomePaths) {
+				appendCandidate(candidate)
+			}
+			for _, candidate := range UnixPackageManagerBinCandidates(home, spec.Names...) {
+				appendCandidate(candidate)
+			}
 			if spec.NodeManaged {
 				nodeManagerCandidates, err := UnixNodeManagerBinCandidates(ctx, home, spec.Names...)
 				if err != nil {
-					return "", err
+					return nil, err
 				}
-				candidates = append(candidates, nodeManagerCandidates...)
+				for _, candidate := range nodeManagerCandidates {
+					appendCandidate(candidate)
+				}
 			}
 		}
+	}
+
+	return candidates, nil
+}
+
+// ResolveBinary returns the path to spec's binary, searching PATH then the
+// platform's candidate install locations. It returns a wrapped
+// ports.ErrAgentBinaryNotFound when nothing matches, so callers surface a clear
+// "command not found" rather than launching an empty argv. ctx cancellation is
+// honored between probes.
+func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
+	candidates, err := ResolveBinaryCandidates(ctx, spec)
+	if err != nil {
+		return "", err
 	}
 
 	for _, candidate := range candidates {

--- a/backend/internal/adapters/agent/binaryutil/binaryutil.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil.go
@@ -164,6 +164,23 @@ func ResolveBinaryCandidates(ctx context.Context, spec BinarySpec) ([]string, er
 // "command not found" rather than launching an empty argv. ctx cancellation is
 // honored between probes.
 func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	names := spec.Names
+	if runtime.GOOS == "windows" {
+		names = spec.WinNames
+	}
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if path, err := exec.LookPath(name); err == nil && path != "" {
+			return path, nil
+		}
+	}
+
 	candidates, err := ResolveBinaryCandidates(ctx, spec)
 	if err != nil {
 		return "", err

--- a/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -29,6 +30,56 @@ func TestResolveBinaryPrefersPath(t *testing.T) {
 	if got != bin {
 		t.Fatalf("got %q, want %q", got, bin)
 	}
+}
+
+func TestResolveBinaryReturnsPATHCandidateBeforeFallbackDeadline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH lookup shape differs on windows")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "widget")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("HOME", t.TempDir())
+
+	ctx := &deadlineAfterErrsContext{
+		Context:   context.Background(),
+		remaining: 2,
+		done:      make(chan struct{}),
+	}
+	got, err := ResolveBinary(ctx, BinarySpec{
+		Label:       "widget",
+		Names:       []string{"widget"},
+		NodeManaged: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want %q", got, bin)
+	}
+}
+
+type deadlineAfterErrsContext struct {
+	context.Context
+	remaining int
+	done      chan struct{}
+	once      sync.Once
+}
+
+func (c *deadlineAfterErrsContext) Err() error {
+	if c.remaining > 0 {
+		c.remaining--
+		return nil
+	}
+	c.once.Do(func() { close(c.done) })
+	return context.DeadlineExceeded
+}
+
+func (c *deadlineAfterErrsContext) Done() <-chan struct{} {
+	return c.done
 }
 
 func TestResolveBinaryCandidatesPreservesOrderAndDeduplicates(t *testing.T) {

--- a/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
@@ -31,6 +31,42 @@ func TestResolveBinaryPrefersPath(t *testing.T) {
 	}
 }
 
+func TestResolveBinaryCandidatesPreservesOrderAndDeduplicates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix candidate shape")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	pathBin := filepath.Join(pathDir, "widget")
+	if err := os.WriteFile(pathBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := ResolveBinaryCandidates(context.Background(), BinarySpec{
+		Label:         "widget",
+		Names:         []string{"widget"},
+		UnixPaths:     []string{pathBin, pathBin},
+		UnixHomePaths: [][]string{{".local", "bin", "widget"}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveBinaryCandidates: %v", err)
+	}
+	if len(candidates) == 0 || candidates[0] != pathBin {
+		t.Fatalf("first candidates = %#v, want PATH candidate %q", candidates, pathBin)
+	}
+	count := 0
+	for _, candidate := range candidates {
+		if candidate == pathBin {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("PATH candidate count = %d, want 1: %#v", count, candidates)
+	}
+}
+
 func TestDefaultFNMDirDarwin(t *testing.T) {
 	home := filepath.Join(string(filepath.Separator), "Users", "tester")
 	want := filepath.Join(home, "Library", "Application Support", "fnm")

--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -304,7 +304,7 @@ func isOfficialGooseBinary(ctx context.Context, binary string) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	out, err := aoprocess.CommandContext(probeCtx, binary, "--version").CombinedOutput()
+	out, err := aoprocess.CommandContextForPath(probeCtx, binary, "--version").CombinedOutput()
 	if err != nil || probeCtx.Err() != nil {
 		return false
 	}

--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -27,13 +27,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 const (
@@ -271,10 +275,66 @@ var gooseBinarySpec = binaryutil.BinarySpec{
 	},
 }
 
-// ResolveGooseBinary returns the path to the goose binary, or a wrapped
-// ports.ErrAgentBinaryNotFound when it is absent.
+// ResolveGooseBinary returns the Block/AI Goose path, or a wrapped
+// ports.ErrAgentBinaryNotFound when it is absent or a different goose CLI.
 func ResolveGooseBinary(ctx context.Context) (string, error) {
-	return binaryutil.ResolveBinary(ctx, gooseBinarySpec)
+	return resolveGooseBinary(ctx, gooseBinarySpec)
+}
+
+func resolveGooseBinary(ctx context.Context, spec binaryutil.BinarySpec) (string, error) {
+	first, err := binaryutil.ResolveBinary(ctx, spec)
+	if err != nil {
+		return "", err
+	}
+
+	candidates := append([]string{first}, gooseCanonicalBinaryCandidates(spec)...)
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if isOfficialGooseBinary(ctx, candidate) {
+			return candidate, nil
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("%s: %w", spec.Label, ports.ErrAgentBinaryNotFound)
+}
+
+func isOfficialGooseBinary(ctx context.Context, binary string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	out, err := aoprocess.CommandContext(probeCtx, binary, "--version").CombinedOutput()
+	if err != nil || probeCtx.Err() != nil {
+		return false
+	}
+	version := strings.TrimSpace(string(out))
+	return strings.HasPrefix(version, "goose ") && !strings.HasPrefix(version, "goose version:")
+}
+
+func gooseCanonicalBinaryCandidates(spec binaryutil.BinarySpec) []string {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	candidates := append([]string(nil), spec.UnixPaths...)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return candidates
+	}
+	for _, parts := range spec.UnixHomePaths {
+		candidates = append(candidates, filepath.Join(append([]string{home}, parts...)...))
+	}
+	return candidates
 }
 
 func (p *Plugin) gooseBinary(ctx context.Context) (string, error) {

--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -27,8 +27,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -63,6 +61,7 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.AgentBinaryPresenceResolver = (*Plugin)(nil)
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {
@@ -282,24 +281,15 @@ func ResolveGooseBinary(ctx context.Context) (string, error) {
 }
 
 func resolveGooseBinary(ctx context.Context, spec binaryutil.BinarySpec) (string, error) {
-	first, err := binaryutil.ResolveBinary(ctx, spec)
+	candidates, err := binaryutil.ResolveBinaryCandidates(ctx, spec)
 	if err != nil {
 		return "", err
 	}
 
-	candidates := append([]string{first}, gooseCanonicalBinaryCandidates(spec)...)
-	seen := make(map[string]struct{}, len(candidates))
 	for _, candidate := range candidates {
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
-		if candidate == "" {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
 		if isOfficialGooseBinary(ctx, candidate) {
 			return candidate, nil
 		}
@@ -322,33 +312,41 @@ func isOfficialGooseBinary(ctx context.Context, binary string) bool {
 	return strings.HasPrefix(version, "goose ") && !strings.HasPrefix(version, "goose version:")
 }
 
-func gooseCanonicalBinaryCandidates(spec binaryutil.BinarySpec) []string {
-	if runtime.GOOS == "windows" {
-		return nil
-	}
-	candidates := append([]string(nil), spec.UnixPaths...)
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return candidates
-	}
-	for _, parts := range spec.UnixHomePaths {
-		candidates = append(candidates, filepath.Join(append([]string{home}, parts...)...))
-	}
-	return candidates
-}
-
 func (p *Plugin) gooseBinary(ctx context.Context) (string, error) {
-	p.binaryMu.Lock()
-	defer p.binaryMu.Unlock()
-
-	if p.resolvedBinary != "" {
-		return p.resolvedBinary, nil
+	if err := ctx.Err(); err != nil {
+		return "", err
 	}
 
+	p.binaryMu.Lock()
+	binary := p.resolvedBinary
+	p.binaryMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if binary != "" {
+		return binary, nil
+	}
+
+	// Binary identity probing can execute an untrusted PATH collision and may
+	// take several seconds. Keep it outside the cache mutex so other callers
+	// can observe cancellation and do not queue behind the probe.
 	binary, err := ResolveGooseBinary(ctx)
 	if err != nil {
 		return "", err
 	}
-	p.resolvedBinary = binary
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	p.binaryMu.Lock()
+	if p.resolvedBinary != "" {
+		binary = p.resolvedBinary
+	} else {
+		p.resolvedBinary = binary
+	}
+	p.binaryMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	return binary, nil
 }

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -544,6 +546,49 @@ func TestResolveGooseBinaryFallback(t *testing.T) {
 	}
 	if bin == "" {
 		t.Fatal("ResolveGooseBinary returned empty path with no error")
+	}
+}
+
+func TestResolveGooseBinaryRejectsPresslyGoose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "goose")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf 'goose version: 3.27.1\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	_, err := resolveGooseBinary(context.Background(), binaryutil.BinarySpec{
+		Label: "goose",
+		Names: []string{"goose"},
+	})
+	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+		t.Fatalf("err = %v, want ErrAgentBinaryNotFound", err)
+	}
+}
+
+func TestResolveGooseBinaryAcceptsBlockGoose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "goose")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf 'goose 1.46.0\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := resolveGooseBinary(context.Background(), binaryutil.BinarySpec{
+		Label: "goose",
+		Names: []string{"goose"},
+	})
+	if err != nil {
+		t.Fatalf("resolveGooseBinary = (%q, %v), want (%q, nil)", got, err, path)
+	}
+	if got != path {
+		t.Fatalf("resolveGooseBinary = %q, want %q", got, path)
 	}
 }
 

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
@@ -589,6 +590,211 @@ func TestResolveGooseBinaryAcceptsBlockGoose(t *testing.T) {
 	}
 	if got != path {
 		t.Fatalf("resolveGooseBinary = %q, want %q", got, path)
+	}
+}
+
+func TestResolveGooseBinaryFallsBackPastForeignPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	foreign := filepath.Join(pathDir, "goose")
+	if err := os.WriteFile(foreign, []byte("#!/bin/sh\nprintf 'goose version: 3.27.1\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		path      string
+		unixPaths []string
+	}{
+		{
+			name:      "unix path",
+			path:      filepath.Join(home, "installed", "goose"),
+			unixPaths: []string{filepath.Join(home, "installed", "goose")},
+		},
+		{
+			name: "package manager",
+			path: filepath.Join(home, ".bun", "bin", "goose"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.MkdirAll(filepath.Dir(tt.path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(tt.path, []byte("#!/bin/sh\nprintf 'goose 1.46.0\\n'\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := resolveGooseBinary(context.Background(), binaryutil.BinarySpec{
+				Label:     "goose",
+				Names:     []string{"goose"},
+				UnixPaths: tt.unixPaths,
+			})
+			if err != nil {
+				t.Fatalf("resolveGooseBinary = (%q, %v), want (%q, nil)", got, err, tt.path)
+			}
+			if got != tt.path {
+				t.Fatalf("resolveGooseBinary = %q, want %q", got, tt.path)
+			}
+		})
+	}
+}
+
+func TestResolveGooseBinaryRejectsMalformedAndNonZeroProbes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture")
+	}
+	for _, tt := range []struct {
+		name   string
+		script string
+	}{
+		{name: "malformed output", script: "#!/bin/sh\nprintf 'not goose\\n'\n"},
+		{name: "non-zero exit", script: "#!/bin/sh\nprintf 'goose 1.46.0\\n'\nexit 7\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "goose")
+			if err := os.WriteFile(path, []byte(tt.script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir)
+
+			_, err := resolveGooseBinary(context.Background(), binaryutil.BinarySpec{
+				Label: "goose",
+				Names: []string{"goose"},
+			})
+			if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+				t.Fatalf("err = %v, want ErrAgentBinaryNotFound", err)
+			}
+		})
+	}
+}
+
+func TestResolveGooseBinaryContinuesAfterProbeTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	timedOut := filepath.Join(pathDir, "goose")
+	if err := os.WriteFile(timedOut, []byte("#!/bin/sh\nexec /bin/sleep 5\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	valid := filepath.Join(home, ".bun", "bin", "goose")
+	if err := os.MkdirAll(filepath.Dir(valid), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(valid, []byte("#!/bin/sh\nprintf 'goose 1.46.0\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveGooseBinary(context.Background(), binaryutil.BinarySpec{
+		Label: "goose",
+		Names: []string{"goose"},
+	})
+	if err != nil {
+		t.Fatalf("resolveGooseBinary = (%q, %v), want (%q, nil)", got, err, valid)
+	}
+	if got != valid {
+		t.Fatalf("resolveGooseBinary = %q, want %q", got, valid)
+	}
+}
+
+func TestResolveGooseBinaryFallsBackPastForeignPathOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows fixture")
+	}
+	home := t.TempDir()
+	appData := filepath.Join(home, "AppData", "Roaming")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("APPDATA", appData)
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	pathDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	foreign := filepath.Join(pathDir, "goose.cmd")
+	if err := os.WriteFile(foreign, []byte("@echo goose version: 3.27.1\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := filepath.Join(appData, "npm", "goose.cmd")
+	if err := os.MkdirAll(filepath.Dir(valid), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(valid, []byte("@echo goose 1.46.0\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveGooseBinary(context.Background(), binaryutil.BinarySpec{
+		Label:    "goose",
+		WinNames: []string{"goose.cmd", "goose.exe", "goose"},
+		WinPaths: []binaryutil.WinPath{{Base: binaryutil.WinAppData, Parts: []string{"npm", "goose.cmd"}}},
+	})
+	if err != nil {
+		t.Fatalf("resolveGooseBinary = (%q, %v), want (%q, nil)", got, err, valid)
+	}
+	if got != valid {
+		t.Fatalf("resolveGooseBinary = %q, want %q", got, valid)
+	}
+}
+
+func TestResolveGooseBinaryPresenceDoesNotExecute(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "goose")
+	marker := filepath.Join(dir, "executed")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf x > "+marker+"\nprintf 'goose 1.46.0\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := (&Plugin{}).ResolveBinaryPresence(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveBinaryPresence = (%q, %v), want (%q, nil)", got, err, path)
+	}
+	if got != path {
+		t.Fatalf("ResolveBinaryPresence = %q, want %q", got, path)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("presence resolver executed Goose: stat marker = %v", err)
+	}
+}
+
+func TestGooseBinaryHonorsParentCancellationDuringProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	path := filepath.Join(dir, "goose")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexec /bin/sleep 5\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := (&Plugin{}).gooseBinary(ctx)
+		done <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("gooseBinary error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gooseBinary did not stop after parent cancellation")
 	}
 }
 

--- a/backend/internal/adapters/agent/goose/install.go
+++ b/backend/internal/adapters/agent/goose/install.go
@@ -1,8 +1,20 @@
 package goose
 
-import "context"
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+)
 
 // ResolveBinary resolves the executable path for the plugin.
 func (p *Plugin) ResolveBinary(ctx context.Context) (string, error) {
 	return p.gooseBinary(ctx)
+}
+
+// ResolveBinaryPresence resolves a local Goose executable without the normal
+// version-signature process. The desktop startup gate only needs to know that
+// an agent binary exists; full Goose resolution validates its identity before
+// a session can launch.
+func (p *Plugin) ResolveBinaryPresence(ctx context.Context) (string, error) {
+	return binaryutil.ResolveBinary(ctx, gooseBinarySpec)
 }

--- a/backend/internal/process/command.go
+++ b/backend/internal/process/command.go
@@ -19,3 +19,10 @@ func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd 
 	configureHidden(cmd)
 	return cmd
 }
+
+// CommandContextForPath is CommandContext for an already-resolved executable
+// path. Windows command shims are routed through cmd.exe so .cmd and .bat
+// files can be probed with the same argv semantics as native executables.
+func CommandContextForPath(ctx context.Context, path string, args ...string) *exec.Cmd {
+	return commandContextForPath(ctx, path, args...)
+}

--- a/backend/internal/process/command_other.go
+++ b/backend/internal/process/command_other.go
@@ -2,6 +2,13 @@
 
 package process
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 func configureHidden(_ *exec.Cmd) {}
+
+func commandContextForPath(ctx context.Context, path string, args ...string) *exec.Cmd {
+	return CommandContext(ctx, path, args...)
+}

--- a/backend/internal/process/command_windows.go
+++ b/backend/internal/process/command_windows.go
@@ -3,7 +3,11 @@
 package process
 
 import (
+	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -14,4 +18,41 @@ func configureHidden(cmd *exec.Cmd) {
 		CreationFlags: windows.CREATE_NO_WINDOW,
 		HideWindow:    true,
 	}
+}
+
+func commandContextForPath(ctx context.Context, path string, args ...string) *exec.Cmd {
+	if !isWindowsBatchFile(path) {
+		return CommandContext(ctx, path, args...)
+	}
+
+	shell := strings.TrimSpace(os.Getenv("COMSPEC"))
+	if shell == "" {
+		shell = "cmd.exe"
+	}
+	cmd := exec.CommandContext(ctx, shell) //nolint:gosec // COMSPEC is the OS-selected command interpreter.
+	configureHidden(cmd)
+	cmd.Args = nil
+	cmd.SysProcAttr.CmdLine = `/d /s /c "` + windowsBatchCommandLine(path, args) + `"`
+	return cmd
+}
+
+func isWindowsBatchFile(path string) bool {
+	extension := filepath.Ext(path)
+	return strings.EqualFold(extension, ".cmd") || strings.EqualFold(extension, ".bat")
+}
+
+// cmd.exe uses different quoting rules from native Windows executables. The
+// outer quotes are consumed by /s /c; each token remains quoted so spaces and
+// command metacharacters cannot turn an argument into another command.
+func windowsBatchCommandLine(executable string, args []string) string {
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, quoteWindowsBatchArg(executable))
+	for _, arg := range args {
+		parts = append(parts, quoteWindowsBatchArg(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func quoteWindowsBatchArg(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }

--- a/backend/internal/process/command_windows_test.go
+++ b/backend/internal/process/command_windows_test.go
@@ -4,6 +4,9 @@ package process
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/windows"
@@ -19,5 +22,26 @@ func TestCommandContextHidesConsoleWindow(t *testing.T) {
 	}
 	if !cmd.SysProcAttr.HideWindow {
 		t.Fatal("HideWindow = false, want true")
+	}
+}
+
+func TestCommandContextForPathRunsQuotedBatchShim(t *testing.T) {
+	dir := t.TempDir()
+	for _, extension := range []string{".cmd", ".bat"} {
+		t.Run(extension, func(t *testing.T) {
+			shim := filepath.Join(dir, "goose helper"+extension)
+			if err := os.WriteFile(shim, []byte("@echo off\r\necho batch-ok\r\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := CommandContextForPath(context.Background(), shim, `safe & echo injected`)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run batch shim: %v\n%s", err, output)
+			}
+			if got := strings.TrimSpace(string(output)); got != "batch-ok" {
+				t.Fatalf("output = %q, want quoted argument to remain inert", got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Add Goose binary identity validation to prevent pressly/goose from being detected as the Goose AI harness.

## Why

Fixes #4516.

## How

Added a bounded, cancellable `goose --version` probe that accepts Block Goose and rejects the pressly migration CLI.

## Testing

- `go test ./internal/adapters/agent/goose`
- `go test -race ./internal/adapters/agent/goose`
- `go vet ./internal/adapters/agent/goose`
- `git diff --check`

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows repository conventions and PR hygiene
- [x] Tests added for pressly rejection and Block Goose acceptance
- [x] Relevant backend checks pass