### PR TITLE
fix(kimi): seed OAuth config into managed home

### DIFF
--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -127,6 +127,47 @@ type kimiAuthConfig struct {
 	Providers map[string]kimiCredentialSource `json:"providers" toml:"providers"`
 }
 
+func kimiConfigOAuthCredentialPaths(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, nil
+	}
+	var config kimiAuthConfig
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		err = json.Unmarshal(data, &config)
+	} else {
+		err = toml.Unmarshal(data, &config)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0, len(config.Providers))
+	seen := make(map[string]struct{}, len(config.Providers))
+	for _, provider := range config.Providers {
+		if provider.OAuth == nil {
+			continue
+		}
+		credentialPath := kimiOAuthCredentialPath(filepath.Dir(path), provider.OAuth.Key)
+		if credentialPath == "" {
+			continue
+		}
+		clean := filepath.Clean(credentialPath)
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		paths = append(paths, clean)
+	}
+	return paths, nil
+}
+
 func kimiConfigAuthStatus(path string) (ports.AgentAuthStatus, bool, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -196,9 +196,27 @@ func kimiSeedConfig(targetPath string, existing []byte) ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("read source Kimi config %s: %w", sourcePath, err)
 	}
 	if !kimiConfigHasAPIKey(source) {
-		return nil, false, nil
+		// Device-code logins leave api_key empty and keep their tokens in the
+		// credential file. The full config is still required for default_model,
+		// the provider/OAuth mapping, model aliases, services, and permissions.
+		authorized, err := kimiSourceOAuthAuthorized(sourceHome)
+		if err != nil {
+			return nil, false, err
+		}
+		if !authorized {
+			return nil, false, nil
+		}
 	}
 	return source, true, nil
+}
+
+func kimiSourceOAuthAuthorized(sourceHome string) (bool, error) {
+	path := filepath.Join(sourceHome, "credentials", "kimi-code.json")
+	status, ok, err := kimiCredentialsAuthStatus(path)
+	if err != nil {
+		return false, fmt.Errorf("read source Kimi credentials %s: %w", path, err)
+	}
+	return ok && status == ports.AgentAuthStatusAuthorized, nil
 }
 
 func kimiConfigCanSeed(existing []byte) bool {

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -134,8 +134,26 @@ func seedKimiCredentials(targetHome string) error {
 	if !ok {
 		return nil
 	}
-	sourcePath := filepath.Join(sourceHome, "credentials", "kimi-code.json")
-	targetPath := filepath.Join(targetHome, "credentials", "kimi-code.json")
+	sourceConfigPath := filepath.Join(sourceHome, "config.toml")
+	sourcePaths, err := kimiConfigOAuthCredentialPaths(sourceConfigPath)
+	if err != nil {
+		return fmt.Errorf("read source Kimi config %s: %w", sourceConfigPath, err)
+	}
+	if len(sourcePaths) == 0 {
+		// Preserve the legacy credential-only seed path for profiles created by
+		// Kimi versions that did not persist an OAuth reference in config.toml.
+		sourcePaths = []string{filepath.Join(sourceHome, "credentials", "kimi-code.json")}
+	}
+	for _, sourcePath := range sourcePaths {
+		targetPath := filepath.Join(targetHome, "credentials", filepath.Base(sourcePath))
+		if err := seedKimiCredential(sourcePath, targetPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func seedKimiCredential(sourcePath, targetPath string) error {
 	if sameKimiConfigPath(sourcePath, targetPath) {
 		return nil
 	}
@@ -211,12 +229,21 @@ func kimiSeedConfig(targetPath string, existing []byte) ([]byte, bool, error) {
 }
 
 func kimiSourceOAuthAuthorized(sourceHome string) (bool, error) {
-	path := filepath.Join(sourceHome, "credentials", "kimi-code.json")
-	status, ok, err := kimiCredentialsAuthStatus(path)
+	configPath := filepath.Join(sourceHome, "config.toml")
+	paths, err := kimiConfigOAuthCredentialPaths(configPath)
 	if err != nil {
-		return false, fmt.Errorf("read source Kimi credentials %s: %w", path, err)
+		return false, fmt.Errorf("read source Kimi config %s: %w", configPath, err)
 	}
-	return ok && status == ports.AgentAuthStatusAuthorized, nil
+	for _, path := range paths {
+		status, ok, err := kimiCredentialsAuthStatus(path)
+		if err != nil {
+			return false, fmt.Errorf("read source Kimi credentials %s: %w", path, err)
+		}
+		if ok && status == ports.AgentAuthStatusAuthorized {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func kimiConfigCanSeed(existing []byte) bool {

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -431,6 +431,129 @@ default_model = "kimi-code/kimi-for-coding"
 	}
 }
 
+const kimiOAuthUserConfig = `default_model = "kimi-code/kimi-for-coding"
+
+[providers."managed:kimi-code"]
+api_key = ""
+
+[providers."managed:kimi-code".oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[models."kimi-code/kimi-for-coding"]
+provider = "managed:kimi-code"
+`
+
+func TestGetAgentHooksSeedsAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	userCredentials := []byte(`{"refresh_token":"user-refresh"}`)
+	writeKimiOAuthProfile(t, userHome, userCredentials)
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	assertKimiOAuthProfileSeeded(t, userHome, aoHome, userCredentials, userCredentials)
+}
+
+func TestGetAgentHooksReseedsHookOnlyAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	userCredentials := []byte(`{"access_token":"user-access"}`)
+	aoCredentials := []byte(`{"refresh_token":"ao-refresh"}`)
+	writeKimiOAuthProfile(t, userHome, userCredentials)
+	if err := os.WriteFile(filepath.Join(aoHome, "config.toml"), []byte(kimiHooksConfigBlock()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath := filepath.Join(aoHome, "credentials", "kimi-code.json")
+	if err := os.MkdirAll(filepath.Dir(credentialsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(credentialsPath, aoCredentials, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	assertKimiOAuthProfileSeeded(t, userHome, aoHome, userCredentials, aoCredentials)
+}
+
+func writeKimiOAuthProfile(t *testing.T, home string, credentials []byte) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(kimiOAuthUserConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath := filepath.Join(home, "credentials", "kimi-code.json")
+	if err := os.MkdirAll(filepath.Dir(credentialsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(credentialsPath, credentials, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertKimiOAuthProfileSeeded(
+	t *testing.T,
+	userHome, aoHome string,
+	userCredentials, wantAOCredentials []byte,
+) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`default_model = "kimi-code/kimi-for-coding"`,
+		`[providers."managed:kimi-code".oauth]`,
+		`[models."kimi-code/kimi-for-coding"]`,
+		`command = "ao hooks kimi session-start"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("AO config missing %q:\n%s", want, text)
+		}
+	}
+	if got := strings.Count(text, kimiHooksSentinelStart); got != 1 {
+		t.Fatalf("managed hook block count = %d, want 1:\n%s", got, text)
+	}
+
+	credentials, err := os.ReadFile(filepath.Join(aoHome, "credentials", "kimi-code.json"))
+	if err != nil {
+		t.Fatalf("read AO credentials: %v", err)
+	}
+	if string(credentials) != string(wantAOCredentials) {
+		t.Fatalf("AO credentials = %s, want %s", credentials, wantAOCredentials)
+	}
+
+	sourceConfig, err := os.ReadFile(filepath.Join(userHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read source config: %v", err)
+	}
+	if string(sourceConfig) != kimiOAuthUserConfig {
+		t.Fatalf("source config mutated:\n%s", sourceConfig)
+	}
+	sourceCredentials, err := os.ReadFile(filepath.Join(userHome, "credentials", "kimi-code.json"))
+	if err != nil {
+		t.Fatalf("read source credentials: %v", err)
+	}
+	if string(sourceCredentials) != string(userCredentials) {
+		t.Fatalf("source credentials mutated: %s", sourceCredentials)
+	}
+}
+
 func TestGetAgentHooksSeedsAOManagedCredentialsFromUserKimiHome(t *testing.T) {
 	workspace := t.TempDir()
 	userHome := t.TempDir()

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -462,6 +462,77 @@ func TestGetAgentHooksSeedsAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
 	assertKimiOAuthProfileSeeded(t, userHome, aoHome, userCredentials, userCredentials)
 }
 
+func TestGetAgentHooksSeedsCredentialReferencedByOAuthConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		writeDefaultSource bool
+	}{
+		{name: "scoped credential only"},
+		{name: "scoped and unrelated default credentials", writeDefaultSource: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			userHome := t.TempDir()
+			aoHome := t.TempDir()
+			t.Setenv(kimiCodeHomeEnv, userHome)
+
+			const scopedName = "kimi-code-env-a1b2c3"
+			userConfig := strings.Replace(
+				kimiOAuthUserConfig,
+				`key = "oauth/kimi-code"`,
+				`key = "oauth/`+scopedName+`"`,
+				1,
+			)
+			if err := os.WriteFile(filepath.Join(userHome, "config.toml"), []byte(userConfig), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			credentialsDir := filepath.Join(userHome, "credentials")
+			if err := os.MkdirAll(credentialsDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			scopedCredentials := []byte(`{"refresh_token":"scoped-refresh"}`)
+			if err := os.WriteFile(filepath.Join(credentialsDir, scopedName+".json"), scopedCredentials, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if tc.writeDefaultSource {
+				if err := os.WriteFile(
+					filepath.Join(credentialsDir, "kimi-code.json"),
+					[]byte(`{"access_token":"unrelated-default"}`),
+					0o600,
+				); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+				WorkspacePath: workspace,
+				Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+			}); err != nil {
+				t.Fatalf("GetAgentHooks err = %v", err)
+			}
+
+			config, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+			if err != nil {
+				t.Fatalf("read AO config: %v", err)
+			}
+			if !strings.Contains(string(config), `default_model = "kimi-code/kimi-for-coding"`) {
+				t.Fatalf("AO config did not seed the scoped OAuth profile:\n%s", config)
+			}
+			targetScopedPath := filepath.Join(aoHome, "credentials", scopedName+".json")
+			gotCredentials, err := os.ReadFile(targetScopedPath)
+			if err != nil {
+				t.Fatalf("read AO scoped credentials: %v", err)
+			}
+			if string(gotCredentials) != string(scopedCredentials) {
+				t.Fatalf("AO scoped credentials = %s, want %s", gotCredentials, scopedCredentials)
+			}
+			if _, err := os.Stat(filepath.Join(aoHome, "credentials", "kimi-code.json")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("unreferenced default AO credential stat err = %v, want not exist", err)
+			}
+		})
+	}
+}
+
 func TestGetAgentHooksReseedsHookOnlyAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
 	workspace := t.TempDir()
 	userHome := t.TempDir()


### PR DESCRIPTION
## What

Seed the user's complete native Kimi config and its exact referenced OAuth credential into AO's isolated Kimi home when the source profile uses device-code OAuth, not only when it contains a non-empty literal `api_key`.

The change keeps the existing first-use boundary: only an empty or AO-hook-only managed config is seedable, after which AO merges exactly one lifecycle-hook block.

Fixes #4520.

This is a surgical current-`main` replacement for the remaining config-seeding delta in #2960, which is currently conflicting and also carries broader storage-layout work. Original contributor @serhatsayat is credited in the commit.

## Why

AO worker `reverb-45` reproduced the failure on current `main`: Kimi `0.38.0` launched by AO displayed `Error: LLM not set, send /login to login`, while the same binary launched manually in the same worktree loaded its model and worked.

### RCA

AO deliberately launches Kimi with `KIMI_CODE_HOME=<AO_DATA_DIR>/kimi` so lifecycle hooks and Kimi state remain isolated under `~/.ao`. Hook preparation already copied a usable native OAuth credential into that home, but `kimiSeedConfig` accepted the matching native `config.toml` only when `kimiConfigHasAPIKey(source)` found a non-empty literal API key.

Kimi's device-code OAuth profile intentionally has empty API-key fields. Its config still carries the required `default_model`, provider/OAuth mapping, model aliases, services, permissions, and model definitions. The API-key-only gate therefore produced an inconsistent managed profile:

- credential: present
- AO lifecycle hooks: present
- default model/provider/model graph: missing

Kimi rejected AO's injected task before creating a native session or emitting lifecycle hooks, so `no_signal` was a downstream symptom rather than a process crash or readiness bug.

The regression is the untested intersection of two existing paths: API-key profile-config seeding and OAuth credential seeding.

## How

- If the native config has a non-empty API key, preserve the existing path.
- Otherwise, parse each provider OAuth reference, resolve it through Kimi's existing `kimiOAuthCredentialPath` mapping, and positively verify the exact referenced access/refresh credential before seeding the native config.
- Copy usable referenced credentials to their matching AO-managed paths; retain `credentials/kimi-code.json` only as a legacy fallback when no OAuth reference was persisted. An unrelated default credential is not copied when the config references a scoped key.
- Copy the complete config rather than cherry-picking `default_model`; the provider/OAuth reference, aliases, services, permissions, and model definitions form one internally consistent profile.
- Merge AO's hook block exactly once.

### Intentional security/state behavior

- `KIMI_CODE_HOME` remains under `AO_DATA_DIR`; managed sessions never point at or write hooks into the native `~/.kimi-code` profile.
- Credential contents are neither logged nor committed. First-use copies continue to be written owner-only (`0600`) inside AO-managed state.
- Native config and credentials remain byte-for-byte unchanged.
- Any AO config containing non-hook state is preserved; only AO's owned hook block is merged/updated.
- An existing AO-managed credential is never overwritten. This preserves an independent managed login or a token that Kimi refreshed inside the isolated profile.
- A token-less/missing native credential does not make an empty-key profile seedable.

### Intentional limitations

- Native and AO-managed credentials can diverge after first seeding. If an existing managed credential later becomes unusable, the user must log in within the managed Kimi profile or deliberately remove it to allow first-use reseeding; AO does not silently overwrite an existing managed secret.
- OAuth profiles whose usable token exists only in an external credential store and cannot be positively verified from local credential JSON remain outside this change; the advisory-auth variant is tracked by #4031.
- Existing AO configs with non-hook content are not repaired or replaced automatically, even if they are incomplete.

## Testing

The original OAuth regression tests and the scoped-reference review tests were run against their respective old gates and failed for the expected missing-config/missing-credential reasons; they pass with the fixes.

- `cd backend && go test -race ./internal/adapters/agent/kimi -count=1`
- `cd backend && go vet ./internal/adapters/agent/kimi`
- `cd backend && go test ./internal/adapters/agent/registry ./internal/session_manager -count=1`
- `cd backend && go build ./...`
- `env -i HOME="$HOME" PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" npm run lint`
  - full `go test ./...`
  - golangci-lint v2.12.2: `0 issues`
- `git diff --check`

Coverage verifies:

- OAuth config + first-use credential seeding into an empty managed home
- recovery from the exact hook-only managed config state in the reproduction
- complete default-model/provider/OAuth/model graph preservation
- exactly one AO hook block
- native config and credential immutability
- preservation of an existing, divergent AO-managed credential
- scoped OAuth keys such as `oauth/kimi-code-env-<hash>` with and without an unrelated default credential
- copying only credentials referenced by the seeded config

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Focused regression tests added with a verified red-green cycle
- [x] Relevant backend tests, build, vet, and lint pass

