### PR TITLE
fix(runtime): adopt legacy tmux sessions when named socket is absent

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -867,7 +867,9 @@ func (r *Runtime) socketForSession(ctx context.Context, id string) (string, erro
 	// Only cross the migration boundary when the private server definitively
 	// lacks this session. An ambiguous probe stays on the private socket so a
 	// transient error cannot redirect a live session elsewhere.
-	if !sessionMissingOutput(string(out)) && !serverNotRunningOutput(string(out)) {
+	if !sessionMissingOutput(string(out)) &&
+		!serverNotRunningOutput(string(out)) &&
+		!migrationSocketAbsentOutput(string(out)) {
 		return r.socketName, nil
 	}
 	if r.legacyBinary == "" {
@@ -1115,6 +1117,16 @@ func serverUnreachableOutput(out string) bool {
 func serverNotRunningOutput(out string) bool {
 	s := strings.ToLower(out)
 	return strings.Contains(s, "no server running")
+}
+
+// migrationSocketAbsentOutput identifies a named migration target whose Unix
+// socket does not exist. This is definitive only for choosing whether to
+// inspect the legacy default socket; it must not become per-session evidence
+// of death, because the session may still be alive on that legacy server.
+func migrationSocketAbsentOutput(out string) bool {
+	s := strings.ToLower(out)
+	return strings.Contains(s, "error connecting") &&
+		strings.Contains(s, "no such file or directory")
 }
 
 func transientServerFailureOutput(out string) bool {

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -197,6 +197,66 @@ func TestRuntimeIntegrationLegacyDefaultSocketIgnoresInheritedTMUX(t *testing.T)
 	}
 }
 
+func TestRuntimeIntegrationAdoptsLegacyDefaultWhenNamedSocketDoesNotExist(t *testing.T) {
+	systemTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux unavailable")
+	}
+
+	// Isolate both socket names so the test starts with a live legacy default
+	// server and no named AO server, matching an untouched pre-cutover install.
+	tmuxTmpDir, err := os.MkdirTemp("/tmp", "ao-tmux-migration-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmuxTmpDir) })
+	t.Setenv("TMUX_TMPDIR", tmuxTmpDir)
+	legacyID := strings.ReplaceAll(t.Name(), "/", "_") + "_legacy"
+	for _, socketName := range []string{"default", "ao"} {
+		t.Cleanup(func() {
+			_ = exec.Command(systemTmux, "-L", socketName, "kill-server").Run()
+		})
+	}
+	if out, startErr := exec.Command(
+		systemTmux,
+		"-L", "default",
+		"new-session", "-d", "-s", legacyID,
+		"sh",
+	).CombinedOutput(); startErr != nil {
+		t.Fatalf("start legacy tmux session: %v: %s", startErr, out)
+	}
+	missingOut, missingErr := exec.Command(systemTmux, "-L", "ao", "has-session", "-t", legacyID).CombinedOutput()
+	if missingErr == nil {
+		t.Fatal("test setup unexpectedly found a named AO server")
+	}
+	if !migrationSocketAbsentOutput(string(missingOut)) {
+		t.Fatalf("named AO probe = %q, want missing-socket diagnostic", missingOut)
+	}
+
+	r := New(Options{
+		Binary:       systemTmux,
+		LegacyBinary: systemTmux,
+		SocketName:   "ao",
+		Timeout:      5 * time.Second,
+	})
+	r.enterDelay = 0
+	handle := ports.RuntimeHandle{ID: legacyID}
+	alive, err := r.IsAlive(context.Background(), handle)
+	if err != nil || !alive {
+		t.Fatalf("legacy default-socket session = (%v, %v), want (true, nil)", alive, err)
+	}
+	if err := r.SendMessage(context.Background(), handle, "echo legacy-send-ok"); err != nil {
+		t.Fatalf("SendMessage to adopted legacy session: %v", err)
+	}
+	out := waitForOutput(t, r, handle, "legacy-send-ok", 5*time.Second)
+	if !strings.Contains(out, "legacy-send-ok") {
+		t.Fatalf("legacy output = %q, want legacy-send-ok", out)
+	}
+	if out, probeErr := exec.Command(systemTmux, "-L", "ao", "list-sessions").CombinedOutput(); probeErr == nil {
+		t.Fatalf("legacy discovery unexpectedly created named AO server: %s", out)
+	}
+}
+
 func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux unavailable")

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -780,6 +780,80 @@ func TestIsAliveAdoptsSessionFromLegacyDefaultSocket(t *testing.T) {
 	}
 }
 
+func TestIsAliveAdoptsLegacyDefaultSessionWhenNamedSocketDoesNotExist(t *testing.T) {
+	r := New(Options{
+		Binary:       "bundled-tmux-test",
+		LegacyBinary: "system-tmux-test",
+		SocketName:   "ao",
+		Timeout:      time.Second,
+	})
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{
+		{
+			out: []byte("error connecting to /private/tmp/tmux-501/ao (No such file or directory)"),
+			err: &exec.ExitError{},
+		},
+		{}, // legacy default-socket discovery
+		{}, // has-session on the adopted legacy socket
+	}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if err != nil || !alive {
+		t.Fatalf("IsAlive = (%v, %v), want (true, nil)", alive, err)
+	}
+	want := [][]string{
+		append([]string{"-L", "ao"}, hasSessionArgs("sess-1")...),
+		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
+		append([]string{"-L", "default"}, hasSessionArgs("sess-1")...),
+	}
+	wantBinaries := []string{"bundled-tmux-test", "system-tmux-test", "system-tmux-test"}
+	if len(fr.calls) != len(want) {
+		t.Fatalf("calls = %d, want %d: %+v", len(fr.calls), len(want), fr.calls)
+	}
+	for i := range want {
+		if fr.calls[i].name != wantBinaries[i] {
+			t.Fatalf("call %d binary = %q, want %q", i, fr.calls[i].name, wantBinaries[i])
+		}
+		if !reflect.DeepEqual(fr.calls[i].args, want[i]) {
+			t.Fatalf("call %d args = %#v, want %#v", i, fr.calls[i].args, want[i])
+		}
+	}
+}
+
+func TestIsAliveKeepsAmbiguousNamedSocketFailureInNamedNamespace(t *testing.T) {
+	r := New(Options{
+		Binary:       "bundled-tmux-test",
+		LegacyBinary: "system-tmux-test",
+		SocketName:   "ao",
+		Timeout:      time.Second,
+	})
+	connectionRefused := fakeRunnerResult{
+		out: []byte("error connecting to /private/tmp/tmux-501/ao (Connection refused)"),
+		err: &exec.ExitError{},
+	}
+	fr := &fakeRunnerSequence{results: []fakeRunnerResult{connectionRefused, connectionRefused}}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if !errors.Is(err, ports.ErrRuntimeProbeInconclusive) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeProbeInconclusive", err)
+	}
+	if alive {
+		t.Fatal("alive = true, want false with inconclusive error")
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("calls = %d, want named discovery and named liveness probe", len(fr.calls))
+	}
+	for i, call := range fr.calls {
+		if call.name != "bundled-tmux-test" {
+			t.Fatalf("call %d binary = %q, want bundled-tmux-test", i, call.name)
+		}
+		if len(call.args) < 2 || call.args[0] != "-L" || call.args[1] != "ao" {
+			t.Fatalf("call %d args = %#v, want named ao socket", i, call.args)
+		}
+	}
+}
+
 func TestIsAliveReportsMissingLegacyClientAsProbeInconclusive(t *testing.T) {
 	r := New(Options{Binary: "bundled-tmux-test", SocketName: "ao", Timeout: time.Second})
 	r.legacyBinary = ""


### PR DESCRIPTION
Fixes [#4469](https://github.com/Untrivial-ai/agent-orchestrator/issues/4469)

## Summary

- treat `error connecting … (No such file or directory)` as definitive only while deciding whether to inspect the legacy default tmux socket
- keep generic connection failures fail-closed, preserving the liveness protection from [#3475](https://github.com/Untrivial-ai/agent-orchestrator/issues/3475)
- add unit and real-tmux regression coverage for an untouched pre-cutover install with live default-socket sessions and no named `ao` server
- verify message delivery reaches the adopted legacy session without creating a named server

This intentionally does not change reconciliation, restart, runtime replacement, DB state, or the steady-state `ErrRuntimeProbeInconclusive` classification. It borrows the narrow ENOENT distinction discussed in [PR #3801](https://github.com/Untrivial-ai/agent-orchestrator/pull/3801) without taking that PR's broader lifecycle changes.

## Tests

- `go build ./...`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID -u AO_TMUX_BINARY -u AO_TMUX_SOCKET_NAME go test ./...`
- `env -u AO_TMUX_SOCKET_NAME -u AO_TMUX_BINARY go test ./internal/adapters/runtime/tmux -count=1`
- isolated-cache `golangci-lint v2.12.2 run --path-mode=abs`

## Risk

Low and deliberately bounded: only an ENOENT result from the configured named migration target enables legacy discovery. `Connection refused`, permission failures, protocol mismatches, and other ambiguous failures do not cross namespaces.
