### PR TITLE
fix(sidebar): reclaim idle session action space

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -563,6 +563,65 @@ describe("Sidebar", () => {
 		expect(screen.getByLabelText("Kill session")).toHaveProperty("tabIndex", 0);
 	});
 
+	it("lets an idle session label use the action strip and yields it on hover or focus", () => {
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+
+		const openSession = screen.getByLabelText("Open fix login");
+		const label = within(openSession).getByText("fix login");
+		const actions = screen.getByLabelText("Pin session").parentElement;
+
+		expect(openSession).not.toHaveClass("pr-[70px]");
+		expect(openSession).toHaveClass(
+			"group-hover/session-row:pr-[70px]",
+			"group-focus-within/session-row:pr-[70px]",
+		);
+		expect(label).toHaveClass("min-w-0", "flex-1", "truncate");
+		expect(actions).toHaveAttribute("data-session-actions");
+		expect(actions).toHaveClass(
+			"pointer-events-none",
+			"opacity-0",
+			"group-hover/session-row:pointer-events-auto",
+			"group-hover/session-row:opacity-100",
+			"group-focus-within/session-row:pointer-events-auto",
+			"group-focus-within/session-row:opacity-100",
+		);
+	});
+
+	it("keeps session status and actions stable when an action receives keyboard focus", async () => {
+		const user = userEvent.setup();
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+
+		const openSession = screen.getByLabelText("Open fix login");
+		const row = openSession.closest<HTMLElement>("[data-session-row]");
+		const status = openSession.querySelector("[data-session-status]");
+
+		if (!row) throw new Error("Session row not found");
+		expect(status).toBeInTheDocument();
+		openSession.focus();
+		await user.tab();
+
+		expect(screen.getByLabelText("Pin session")).toHaveFocus();
+		expect(row).toContainElement(openSession);
+		expect(row).toContainElement(status as HTMLElement);
+		expect(row).toContainElement(screen.getByLabelText("Pin session"));
+	});
+
+	it("keeps action pointer presses from triggering the session press surface", () => {
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+
+		const openSession = screen.getByLabelText("Open fix login");
+		const row = openSession.closest<HTMLElement>("[data-session-row]");
+		if (!row) throw new Error("Session row not found");
+
+		fireEvent.pointerDown(openSession);
+		expect(row).toHaveClass("scale-[0.97]");
+		fireEvent.pointerUp(openSession);
+		expect(row).not.toHaveClass("scale-[0.97]");
+
+		fireEvent.pointerDown(screen.getByLabelText("Rename fix login"));
+		expect(row).not.toHaveClass("scale-[0.97]");
+	});
+
 	it("toggles project sessions from the folder icon without selecting the project first", async () => {
 		const user = userEvent.setup();
 		const other: WorkspaceSummary = {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -131,9 +131,8 @@ const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperti
 const HOVER_ACTION_CLASS =
 	"grid size-5 shrink-0 place-items-center rounded-md bg-transparent text-passive hover:bg-transparent focus:bg-transparent focus-visible:bg-transparent active:bg-transparent data-[state=open]:bg-transparent hover:text-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:text-foreground [&_svg]:size-icon-lg";
 
-// Session actions keep a stable hit strip, but the controls themselves are
-// quiet glyphs. Opacity is the only hover transition; the row should not gain
-// three filled icon-button pills or reflow its label when the strip appears.
+// Session actions overlay the row without changing its footprint. The primary
+// label only yields their width while the row is hovered or contains focus.
 const SESSION_ACTION_CLASS =
 	"grid size-5 shrink-0 place-items-center rounded-md bg-transparent p-1 text-passive hover:bg-transparent focus:bg-transparent focus-visible:bg-transparent active:bg-transparent data-[state=open]:bg-transparent hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-3!";
 
@@ -1473,7 +1472,7 @@ const ProjectDragPreview = memo(function ProjectDragPreview({ workspace, expande
 						return (
 							<div className="pl-4.5" key={session.id}>
 								<div className={cn("flex h-8 w-full items-center rounded-lg", active && "bg-interactive-active text-foreground")}>
-									<div className="flex h-8 min-w-0 flex-1 items-center gap-1.5 px-2.5 pr-[70px] text-sm">
+									<div className="flex h-8 min-w-0 flex-1 items-center gap-1.5 px-2.5 text-sm">
 										<SessionStatusDot session={session} />
 										<span className="flex min-w-0 flex-1 items-center gap-1.5">
 											<span className={cn("min-w-0 flex-1 truncate", active ? "text-foreground" : "text-muted-foreground")}>
@@ -1680,7 +1679,9 @@ function SessionRow({
 							aria-describedby={describedBy}
 							aria-label={t("shell.openSession", { title: session.title })}
 							className={cn(
-							"flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2.5 py-0 pr-[70px] text-left text-sm outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+								"flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2.5 py-0 text-left text-sm outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+								!reorder?.isDragging &&
+									"group-hover/session-row:pr-[70px] group-focus-within/session-row:pr-[70px]",
 								reorder && "cursor-grab active:cursor-grabbing",
 								reorder?.isDragging && "!cursor-grabbing",
 							)}
@@ -1707,9 +1708,8 @@ function SessionRow({
 							</span>
 						</button>
 					</div>
-					{/* Pin, rename, kill stay in a reserved strip so showing them never
-				    changes the label width. The strip fades as a group; its glyphs
-				    remain transparent/no-fill until focused or hovered. */}
+					{/* Pin, rename, and kill overlay the row. The label uses this space
+					    while idle, then yields it when hover or focus reveals the strip. */}
 					<SessionActions
 						isDragging={Boolean(reorder?.isDragging)}
 						onStartEditing={startEditing}


### PR DESCRIPTION
## Summary

- let idle session names consume the space occupied by the hidden pin, rename, and terminate controls
- yield the label space only while the row is hovered or contains keyboard focus, without changing the row footprint
- preserve dragging, touch press isolation, status/selection presentation, accessible labels, and action tab order

## Before / after evidence

The supplied before screenshot shows idle names truncating against a permanently reserved 70 px action strip even though the strip is invisible.

Live renderer verification against the AO dev preview:

| State | Right padding | Action opacity | Pointer events | Focus |
| --- | ---: | ---: | --- | --- |
| Before, idle | 70 px | 0 | none | — |
| After, idle | 10 px | 0 | none | — |
| After, hover | 70 px | 1 | auto | — |
| After, keyboard | 70 px | 1 | auto | Pin session |

The measured row width remained 192 px while the label yielded space, so revealing controls does not shift the row. The AO Browser panel preview shows the full idle label extending through the reclaimed area; hovering reveals the three controls in place and truncates the label cleanly.

## Tests

- `npm test -- --run src/renderer/components/Sidebar.test.tsx` — 83 passed
- `npm run typecheck`
- `npx vite build --config vite.renderer.config.ts`
- `npm test` — 218 files, 2,957 passed, 1 skipped
- AO Browser panel preview plus live computed-style verification for idle, hover, and keyboard focus states