### PR TITLE
feat(chat): keep Codex provider alive across daemon restart

### DIFF
--- a/backend/e2e/chat_lifecycle_test.go
+++ b/backend/e2e/chat_lifecycle_test.go
@@ -61,44 +61,35 @@ func TestChatSurvivesADaemonRestartWithNativeContext(t *testing.T) {
 	}
 }
 
-// A crash mid-turn must not leave the turn looking like it is still working. A
-// controller that stopped running a turn is not evidence the work finished, and a
-// turn stuck at "running" forever is a session the user cannot reason about.
-func TestChatRestartMidTurnSettlesTheTurnHonestly(t *testing.T) {
+// The detached Codex host is outside the daemon's process group. Even SIGKILL of
+// the daemon must leave the provider turn running for the replacement to adopt.
+func TestChatRestartMidTurnKeepsCodexRunning(t *testing.T) {
 	requireE2E(t)
 	dataDir := t.TempDir()
 	d := startDaemon(t, dataDir)
 	project := seedProject(t, d, "midturn")
 	session := chatSession(t, d, project, "Reply with exactly: READY")
 
-	send(t, d, session, "Sleep for 120 seconds using a shell command, then reply with exactly: NEVER", "long")
+	send(t, d, session, "Run the shell command `sleep 20`, then reply with exactly: SURVIVED-SIGKILL", "long")
 	d.awaitConversation(session, 90*time.Second, "the long turn to start running", func(s snapshot) bool {
 		return s.Turns[len(s.Turns)-1].State == "running"
 	})
+	hostBefore := persistentHostPID(t, dataDir, session)
 
-	// SIGKILL: no shutdown hook runs, so whatever the next boot concludes it has to
-	// conclude from disk alone.
 	d.kill()
+	if !processAlive(hostBefore) {
+		t.Fatalf("detached host %d died with the killed daemon", hostBefore)
+	}
 	restarted := startDaemon(t, dataDir)
-
-	snap := restarted.awaitConversation(session, 90*time.Second, "the orphaned turn to settle",
+	restarted.awaitLiveController(session, 90*time.Second)
+	snap := restarted.awaitConversation(session, 3*time.Minute, "the surviving turn to finish",
 		func(s snapshot) bool { return terminal(s.Turns[len(s.Turns)-1].State) })
 
 	last := snap.Turns[len(snap.Turns)-1]
-	if last.State == "completed" {
-		t.Fatalf("a turn interrupted by a daemon crash was recorded as completed:\n%s", describe(snap))
-	}
-	if last.ErrorMessage == "" {
-		t.Errorf("orphaned turn %s carries no explanation of why it ended", short(last.ID))
-	}
-
-	// And the session is still usable afterwards, rather than wedged.
-	restarted.awaitLiveController(session, 90*time.Second)
-	send(t, restarted, session, "Reply with exactly: ALIVE", "post-crash")
-	revived := restarted.awaitConversation(session, 3*time.Minute, "a turn after the crash",
-		func(s snapshot) bool { return contains(s.assistantText(), "ALIVE") })
-	if !contains(revived.assistantText(), "ALIVE") {
-		t.Errorf("the session never recovered after a mid-turn crash:\n%s", describe(revived))
+	hostAfter := persistentHostPID(t, dataDir, session)
+	t.Logf("abrupt daemon simulation: host_pid=%d->%d turn_state=%s", hostBefore, hostAfter, last.State)
+	if hostAfter != hostBefore || last.State != "completed" || !contains(snap.assistantText(), "SURVIVED-SIGKILL") {
+		t.Fatalf("real Codex turn did not survive abrupt daemon replacement:\n%s", describe(snap))
 	}
 }
 
@@ -112,7 +103,7 @@ func TestChatQueuedMessageIsAccountedForAcrossARestart(t *testing.T) {
 	project := seedProject(t, d, "queuecrash")
 	session := chatSession(t, d, project, "Reply with exactly: READY")
 
-	send(t, d, session, "Sleep for 120 seconds using a shell command, then reply with exactly: NEVER", "qc-slow")
+	send(t, d, session, "Run the shell command `sleep 20`, then reply with exactly: FIRST-SURVIVED", "qc-slow")
 	d.awaitConversation(session, 90*time.Second, "the slow turn to start running", func(s snapshot) bool {
 		return s.Turns[len(s.Turns)-1].State == "running"
 	})
@@ -125,9 +116,9 @@ func TestChatQueuedMessageIsAccountedForAcrossARestart(t *testing.T) {
 	restarted := startDaemon(t, dataDir)
 	restarted.awaitLiveController(session, 90*time.Second)
 
-	snap := restarted.awaitConversation(session, 2*time.Minute, "the queued message to be accounted for",
+	snap := restarted.awaitConversation(session, 3*time.Minute, "the queued message to be delivered",
 		func(s snapshot) bool {
-			return terminal(s.userTurnStates()["Reply with exactly: QUEUED-ACROSS-RESTART"]) ||
+			return terminal(s.userTurnStates()["Reply with exactly: QUEUED-ACROSS-RESTART"]) &&
 				contains(s.assistantText(), "QUEUED-ACROSS-RESTART")
 		})
 
@@ -137,8 +128,8 @@ func TestChatQueuedMessageIsAccountedForAcrossARestart(t *testing.T) {
 	if state == "" {
 		t.Fatalf("the queued message disappeared across the restart:\n%s", describe(snap))
 	}
-	if state == "queued" {
-		t.Errorf("the message is still queued behind a controller that died; nothing will ever send it")
+	if state != "completed" || !contains(snap.assistantText(), "QUEUED-ACROSS-RESTART") {
+		t.Errorf("queued message was not completed after the surviving turn: state=%q\n%s", state, describe(snap))
 	}
 	t.Logf("queued-across-restart resolved as %q", state)
 }

--- a/backend/e2e/chat_persistent_host_test.go
+++ b/backend/e2e/chat_persistent_host_test.go
@@ -1,0 +1,98 @@
+//go:build !windows
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func persistentHostPID(t *testing.T, dataDir, sessionID string) int {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dataDir, "chat-hosts", sessionID, "host.json"))
+	if err != nil {
+		t.Fatalf("read persistent host descriptor: %v", err)
+	}
+	var d struct {
+		PID int `json:"pid"`
+	}
+	if err := json.Unmarshal(b, &d); err != nil || d.PID <= 0 {
+		t.Fatalf("decode persistent host descriptor: pid=%d err=%v", d.PID, err)
+	}
+	return d.PID
+}
+
+func processAlive(pid int) bool { return syscall.Kill(pid, 0) == nil }
+
+func TestChatTurnSurvivesGracefulUpdaterStyleRestart(t *testing.T) {
+	requireE2E(t)
+	dataDir := t.TempDir()
+	d := startDaemon(t, dataDir)
+	project := seedProject(t, d, "graceful-midturn")
+	session := chatSession(t, d, project, "Reply with exactly: READY")
+
+	send(t, d, session, "Run the shell command `sleep 20`, then reply with exactly: SURVIVED-GRACEFUL", "graceful-long")
+	d.awaitConversation(session, 90*time.Second, "the graceful-restart turn to run", func(s snapshot) bool {
+		return s.Turns[len(s.Turns)-1].State == "running"
+	})
+	hostBefore := persistentHostPID(t, dataDir, session)
+	d.stop()
+	if !processAlive(hostBefore) {
+		t.Fatalf("detached host %d died with the old daemon", hostBefore)
+	}
+
+	restarted := startDaemon(t, dataDir)
+	restarted.awaitLiveController(session, 90*time.Second)
+	finished := restarted.awaitConversation(session, 3*time.Minute, "the detached real Codex turn to finish", func(s snapshot) bool {
+		return terminal(s.Turns[len(s.Turns)-1].State)
+	})
+	hostAfter := persistentHostPID(t, dataDir, session)
+	last := finished.Turns[len(finished.Turns)-1]
+	t.Logf("graceful updater simulation: host_pid=%d->%d turn_state=%s", hostBefore, hostAfter, last.State)
+	if hostAfter != hostBefore || last.State != "completed" || !contains(finished.assistantText(), "SURVIVED-GRACEFUL") {
+		t.Fatalf("real Codex turn did not survive graceful replacement:\n%s", describe(finished))
+	}
+}
+
+func TestChatSessionRecoversAfterMachineStyleHostLoss(t *testing.T) {
+	requireE2E(t)
+	dataDir := t.TempDir()
+	d := startDaemon(t, dataDir)
+	project := seedProject(t, d, "machine-loss")
+	session := chatSession(t, d, project, "Reply with exactly: READY")
+
+	send(t, d, session, "Run the shell command `sleep 20`, then reply with exactly: MUST-NOT-COMPLETE", "machine-loss-long")
+	d.awaitConversation(session, 90*time.Second, "the machine-loss turn to run", func(s snapshot) bool {
+		return s.Turns[len(s.Turns)-1].State == "running"
+	})
+	hostBefore := persistentHostPID(t, dataDir, session)
+	// The detached host is a session leader; killing its process group removes
+	// both host and provider, matching the process loss caused by a machine reboot.
+	if err := syscall.Kill(-hostBefore, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill detached host process group %d: %v", hostBefore, err)
+	}
+	d.kill()
+
+	restarted := startDaemon(t, dataDir)
+	restarted.awaitLiveController(session, 90*time.Second)
+	settled := restarted.awaitConversation(session, 2*time.Minute, "the lost in-flight turn to settle", func(s snapshot) bool {
+		return terminal(s.Turns[len(s.Turns)-1].State)
+	})
+	lost := settled.Turns[len(settled.Turns)-1]
+	if lost.State == "completed" || contains(settled.assistantText(), "MUST-NOT-COMPLETE") {
+		t.Fatalf("provider loss falsely completed the interrupted turn:\n%s", describe(settled))
+	}
+	send(t, restarted, session, "Reply with exactly: RECOVERED-AFTER-HOST-LOSS", "machine-loss-after")
+	recovered := restarted.awaitConversation(session, 3*time.Minute, "a turn after host loss", func(s snapshot) bool {
+		return contains(s.assistantText(), "RECOVERED-AFTER-HOST-LOSS")
+	})
+	hostAfter := persistentHostPID(t, dataDir, session)
+	t.Logf("machine-style host loss: old_host_pid=%d new_host_pid=%d interrupted_state=%s", hostBefore, hostAfter, lost.State)
+	if hostAfter == hostBefore || !contains(recovered.assistantText(), "RECOVERED-AFTER-HOST-LOSS") {
+		t.Fatalf("session did not recover through native resume:\n%s", describe(recovered))
+	}
+}

--- a/backend/e2e/harness_test.go
+++ b/backend/e2e/harness_test.go
@@ -360,6 +360,11 @@ func seedProject(t *testing.T, d *daemon, name string) string {
 	}
 	run("git", "add", "-A")
 	run("git", "commit", "-m", "init")
+	// Strict default-branch resolution deliberately refuses a local-only HEAD.
+	// Give the fixture a primary remote with a cached HEAD like a real project.
+	run("git", "remote", "add", "origin", dir)
+	run("git", "fetch", "origin", "main")
+	run("git", "remote", "set-head", "origin", "main")
 
 	var out struct {
 		Project struct{ ID string } `json:"project"`

--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -110,7 +110,7 @@ func newConversation(proc *process, log *slog.Logger) *conversation {
 		pending:  make(map[string]*parkedRequest),
 		pumpDone: make(chan struct{}),
 	}
-	c.conn = newConn(proc.stdin, proc.stdout, log, c.handleServerRequest)
+	c.conn = newConnAt(proc.stdin, proc.stdout, log, c.handleServerRequest, proc.nextRequestID)
 	return c
 }
 
@@ -126,6 +126,14 @@ func (c *conversation) start(threadID, model, effort string) {
 
 // ProviderConversationID is the Codex thread id AO persists for resume.
 func (c *conversation) ProviderConversationID() string { return c.threadID }
+
+// PreservesProviderOnClose tells the daemon controller that Close only detaches
+// from a host; it must not project provider death or fail in-flight work.
+func (c *conversation) PreservesProviderOnClose() bool { return c.proc.terminate != nil }
+
+// ReconnectedLive distinguishes attachment to the same initialized process from
+// native-history resume in a replacement process.
+func (c *conversation) ReconnectedLive() bool { return c.proc.reconnected }
 
 // Capabilities reports what this conversation can do.
 func (c *conversation) Capabilities() ports.ChatCapabilities { return capabilities() }
@@ -793,8 +801,24 @@ func (c *conversation) failPendingApprovals() {
 // Close releases the controller without touching provider-side history.
 func (c *conversation) Close() error {
 	c.closeOnce.Do(func() {
-		c.failPendingApprovals()
+		if c.proc.terminate == nil {
+			c.failPendingApprovals()
+		}
 		if c.proc.stop != nil {
+			_ = c.proc.stop()
+		}
+	})
+	return nil
+}
+
+// Terminate destroys the provider host. Close only detaches and is used by
+// daemon-wide shutdown; explicit session/controller replacement calls this.
+func (c *conversation) Terminate() error {
+	c.closeOnce.Do(func() {
+		c.failPendingApprovals()
+		if c.proc.terminate != nil {
+			_ = c.proc.terminate()
+		} else if c.proc.stop != nil {
 			_ = c.proc.stop()
 		}
 	})

--- a/backend/internal/adapters/chatdriver/codexappserver/driver.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/persistenthost"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/processenv"
 	"github.com/aoagents/agent-orchestrator/backend/internal/agentlaunch"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -52,14 +53,22 @@ type codexPlugin interface {
 type process struct {
 	stdin  io.WriteCloser
 	stdout io.Reader
+	// reconnected means the provider process and initialized protocol connection
+	// survived a prior daemon. The replacement must not initialize/resume it a
+	// second time.
+	reconnected   bool
+	nextRequestID int64
 	// stop releases the process. It must be safe to call more than once.
 	stop func() error
+	// terminate destroys a persistent host for explicit session shutdown.
+	terminate func() error
 }
 
 // spawnFunc launches an app-server. Injected so tests never exec anything.
 type spawnFunc func(ctx context.Context, bin, workdir string, env []string) (*process, error)
 
 type versionProbeFunc func(context.Context, string) (string, error)
+type persistentConnectFunc func(context.Context, persistenthost.Config) (*persistenthost.Transport, error)
 
 // Driver opens Codex conversations over `codex app-server`.
 type Driver struct {
@@ -67,6 +76,8 @@ type Driver struct {
 	log          *slog.Logger
 	spawn        spawnFunc
 	versionProbe versionProbeFunc
+	persistent   bool
+	connectHost  persistentConnectFunc
 }
 
 // New builds a Chat driver over the existing Codex agent plugin.
@@ -76,7 +87,7 @@ func New(plugin codexPlugin, log *slog.Logger) *Driver {
 	}
 	return &Driver{
 		plugin: plugin, log: log, spawn: spawnAppServer,
-		versionProbe: installedCodexVersion,
+		versionProbe: installedCodexVersion, persistent: true, connectHost: persistenthost.ConnectOrStart,
 	}
 }
 
@@ -244,9 +255,15 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 		return nil, fmt.Errorf("workspace path must be absolute, got %q", cfg.WorkspacePath)
 	}
 
-	conv, err := d.connect(ctx, cfg.WorkspacePath, cfg.Env)
+	conv, reconnected, err := d.connectSession(ctx, cfg.SessionID, cfg.DataDir, cfg.WorkspacePath, cfg.Env, cfg.AllowConcurrentHostReplacement)
 	if err != nil {
 		return nil, err
+	}
+	if reconnected {
+		// A fresh-start request colliding with a surviving host is a durable-state
+		// mismatch, not permission to destroy a provider that may still be working.
+		_ = conv.Close()
+		return nil, errors.New("persistent chat host already owns a provider conversation for a fresh session")
 	}
 
 	policy, sandbox := approvalSettings(cfg.Permissions)
@@ -272,11 +289,11 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 	openCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
 	defer cancel()
 	if err := conv.conn.request(openCtx, "thread/start", params, &resp); err != nil {
-		_ = conv.Close()
+		_ = conv.Terminate()
 		return nil, fmt.Errorf("thread/start: %w", err)
 	}
 	if resp.Thread.ID == "" {
-		_ = conv.Close()
+		_ = conv.Terminate()
 		return nil, errors.New("thread/start returned no thread id")
 	}
 
@@ -294,9 +311,16 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 		return nil, fmt.Errorf("workspace path must be absolute, got %q", cfg.WorkspacePath)
 	}
 
-	conv, err := d.connect(ctx, cfg.WorkspacePath, cfg.Env)
+	conv, reconnected, err := d.connectSession(ctx, cfg.SessionID, cfg.DataDir, cfg.WorkspacePath, cfg.Env, cfg.AllowConcurrentHostReplacement)
 	if err != nil {
 		return nil, err
+	}
+	if reconnected {
+		// The host preserved the already-initialized app-server connection and its
+		// loaded thread. Host replay bridges output and unresolved server requests
+		// across the daemon detach without waiting for the active turn to settle.
+		conv.start(cfg.ProviderConversationID, cfg.Model, "")
+		return conv, nil
 	}
 
 	policy, sandbox := approvalSettings(cfg.Permissions)
@@ -323,7 +347,7 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 	}
 	err = conv.conn.request(resumeCtx, "thread/resume", params, &resp)
 	if err != nil {
-		_ = conv.Close()
+		_ = conv.Terminate()
 		// Deliberately not falling back to thread/start: silently opening a new
 		// conversation would present unrelated history as continuous.
 		return nil, fmt.Errorf("%w: %w", ports.ErrChatResumeFailed, err)
@@ -370,6 +394,81 @@ func (d *Driver) connect(ctx context.Context, workdir string, env map[string]str
 		return nil, fmt.Errorf("notify initialized: %w", err)
 	}
 	return conv, nil
+}
+
+func (d *Driver) connectSession(
+	ctx context.Context,
+	sessionID domain.SessionID,
+	dataDir, workdir string,
+	env map[string]string,
+	allowConcurrentHostReplacement bool,
+) (*conversation, bool, error) {
+	// Injected driver tests intentionally retain the direct pipe launcher. The
+	// shipped driver uses spawnAppServer and therefore the persistent host.
+	if !d.persistent {
+		conv, err := d.connect(ctx, workdir, env)
+		return conv, false, err
+	}
+	bin, err := d.plugin.ResolveBinary(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: %w", ports.ErrChatDriverUnavailable, err)
+	}
+	transport, err := d.connectHost(ctx, persistenthost.Config{
+		SessionID: string(sessionID),
+		DataDir:   dataDir,
+		Workdir:   workdir,
+		Env:       envSlice(env),
+		Argv:      []string{bin, "app-server"},
+	})
+	if err != nil {
+		// Branch activation intentionally stages a replacement controller before
+		// terminating the source. The persistent host correctly refuses that second
+		// owner; retain the established safe handoff by staging this replacement in
+		// a direct app-server. On the next daemon reconciliation it is resumed into a
+		// persistent host. Other host failures fail closed and never spawn a rival.
+		if allowConcurrentHostReplacement && errors.Is(err, persistenthost.ErrAttached) {
+			conv, directErr := d.connect(ctx, workdir, env)
+			return conv, false, directErr
+		}
+		return nil, false, fmt.Errorf("%w: persistent host: %w", ports.ErrChatDriverUnavailable, err)
+	}
+	proc := &process{
+		stdin:         transport.Stdin,
+		stdout:        transport.Stdout,
+		reconnected:   transport.Reconnected,
+		nextRequestID: transport.NextRequestID,
+		stop:          transport.Stdin.Close,
+		terminate: func() error {
+			_ = transport.Stdin.Close()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			return persistenthost.Shutdown(shutdownCtx, dataDir, string(sessionID))
+		},
+	}
+	conv := newConversation(proc, d.log)
+	if transport.Reconnected {
+		return conv, true, nil
+	}
+	if err := d.initialize(ctx, conv); err != nil {
+		_ = conv.Terminate()
+		return nil, false, err
+	}
+	return conv, false, nil
+}
+
+func (d *Driver) initialize(ctx context.Context, conv *conversation) error {
+	initCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer cancel()
+	if err := conv.conn.request(initCtx, "initialize", map[string]any{
+		"clientInfo":   map[string]any{"name": clientName, "title": clientTitle, "version": clientVersion},
+		"capabilities": map[string]any{"experimentalApi": true, "optOutNotificationMethods": nil},
+	}, nil); err != nil {
+		return fmt.Errorf("%w: initialize: %w", ports.ErrChatDriverIncompatible, err)
+	}
+	if err := conv.conn.notify("initialized", nil); err != nil {
+		return fmt.Errorf("notify initialized: %w", err)
+	}
+	return nil
 }
 
 // approvalSettings maps AO's existing per-session permission mode onto Codex's

--- a/backend/internal/adapters/chatdriver/codexappserver/driver.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver.go
@@ -370,28 +370,9 @@ func (d *Driver) connect(ctx context.Context, workdir string, env map[string]str
 	}
 
 	conv := newConversation(proc, d.log)
-
-	initCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
-	defer cancel()
-	if err := conv.conn.request(initCtx, "initialize", map[string]any{
-		"clientInfo": map[string]any{
-			"name":    clientName,
-			"title":   clientTitle,
-			"version": clientVersion,
-		},
-		"capabilities": map[string]any{
-			"experimentalApi":           true,
-			"optOutNotificationMethods": nil,
-		},
-	}, nil); err != nil {
+	if err := d.initialize(ctx, conv); err != nil {
 		_ = conv.Close()
-		// A handshake the provider rejects means a protocol AO cannot speak.
-		return nil, fmt.Errorf("%w: initialize: %w", ports.ErrChatDriverIncompatible, err)
-	}
-
-	if err := conv.conn.notify("initialized", nil); err != nil {
-		_ = conv.Close()
-		return nil, fmt.Errorf("notify initialized: %w", err)
+		return nil, err
 	}
 	return conv, nil
 }
@@ -429,6 +410,12 @@ func (d *Driver) connectSession(
 		if allowConcurrentHostReplacement && errors.Is(err, persistenthost.ErrAttached) {
 			conv, directErr := d.connect(ctx, workdir, env)
 			return conv, false, directErr
+		}
+		if errors.Is(err, persistenthost.ErrOwnershipInconclusive) ||
+			errors.Is(err, persistenthost.ErrAttached) ||
+			errors.Is(err, persistenthost.ErrIncompatible) ||
+			errors.Is(err, persistenthost.ErrUnauthorized) {
+			return nil, false, fmt.Errorf("%w: persistent host: %w", ports.ErrChatRecoveryInconclusive, err)
 		}
 		return nil, false, fmt.Errorf("%w: persistent host: %w", ports.ErrChatDriverUnavailable, err)
 	}

--- a/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
@@ -324,6 +324,9 @@ func TestResumeDoesNotCompeteWithAttachedHostDuringDaemonOverlap(t *testing.T) {
 	if err == nil || !errors.Is(err, persistenthost.ErrAttached) {
 		t.Fatalf("Resume error = %v, want attached-host refusal", err)
 	}
+	if !errors.Is(err, ports.ErrChatRecoveryInconclusive) {
+		t.Fatalf("Resume error = %v, want recovery-inconclusive classification", err)
+	}
 	if srv.sentMethod("initialize") || srv.sentMethod("thread/resume") {
 		t.Fatal("daemon overlap launched a competing direct provider")
 	}

--- a/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/persistenthost"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -248,6 +249,83 @@ func TestStartCompletesHandshakeAndOpensThread(t *testing.T) {
 	// Default permissions must match what AO already gives a Codex TUI session.
 	if params.ApprovalPolicy != "never" || params.Sandbox != "danger-full-access" {
 		t.Errorf("default posture = %q/%q, want never/danger-full-access", params.ApprovalPolicy, params.Sandbox)
+	}
+}
+
+func TestResumeReconnectsInitializedHostWithoutNativeResume(t *testing.T) {
+	d, srv := newTestDriver(t)
+	proc, err := d.spawn(context.Background(), "codex", "/tmp/ws", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.persistent = true
+	d.connectHost = func(context.Context, persistenthost.Config) (*persistenthost.Transport, error) {
+		return &persistenthost.Transport{
+			Stdin: proc.stdin, Stdout: proc.stdout, Reconnected: true, NextRequestID: 41,
+		}, nil
+	}
+
+	conv, err := d.Resume(context.Background(), ports.ChatResumeConfig{
+		SessionID: "ao-reconnect", ProviderConversationID: "thread-survived",
+		DataDir: t.TempDir(), WorkspacePath: "/tmp/ws",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	defer func() { _ = conv.Close() }()
+	if got := conv.ProviderConversationID(); got != "thread-survived" {
+		t.Fatalf("provider conversation id = %q", got)
+	}
+	if srv.sentMethod("initialize") || srv.sentMethod("thread/resume") {
+		t.Fatalf("reconnect repeated handshake: initialize=%v resume=%v",
+			srv.sentMethod("initialize"), srv.sentMethod("thread/resume"))
+	}
+
+	lister := conv.(ports.ChatModelLister)
+	if _, err := lister.ListModels(context.Background()); err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	request := srv.awaitFrame(func(f frame) bool { return f.Method == "model/list" })
+	if request.ID == nil || string(*request.ID) != "42" {
+		t.Fatalf("first request id after reconnect = %v, want 42", request.ID)
+	}
+}
+
+func TestResumeStagesDirectProcessWhenBranchSourceOwnsHost(t *testing.T) {
+	d, srv := newTestDriver(t)
+	d.persistent = true
+	d.connectHost = func(context.Context, persistenthost.Config) (*persistenthost.Transport, error) {
+		return nil, persistenthost.ErrAttached
+	}
+	conv, err := d.Resume(context.Background(), ports.ChatResumeConfig{
+		SessionID: "ao-branch", ProviderConversationID: "thread-branch",
+		DataDir: t.TempDir(), WorkspacePath: "/tmp/ws", AllowConcurrentHostReplacement: true,
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	defer func() { _ = conv.Close() }()
+	if !srv.sentMethod("initialize") || !srv.sentMethod("thread/resume") {
+		t.Fatalf("branch staging handshake: initialize=%v resume=%v",
+			srv.sentMethod("initialize"), srv.sentMethod("thread/resume"))
+	}
+}
+
+func TestResumeDoesNotCompeteWithAttachedHostDuringDaemonOverlap(t *testing.T) {
+	d, srv := newTestDriver(t)
+	d.persistent = true
+	d.connectHost = func(context.Context, persistenthost.Config) (*persistenthost.Transport, error) {
+		return nil, persistenthost.ErrAttached
+	}
+	_, err := d.Resume(context.Background(), ports.ChatResumeConfig{
+		SessionID: "ao-overlap", ProviderConversationID: "thread-live",
+		DataDir: t.TempDir(), WorkspacePath: "/tmp/ws",
+	})
+	if err == nil || !errors.Is(err, persistenthost.ErrAttached) {
+		t.Fatalf("Resume error = %v, want attached-host refusal", err)
+	}
+	if srv.sentMethod("initialize") || srv.sentMethod("thread/resume") {
+		t.Fatal("daemon overlap launched a competing direct provider")
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/codexappserver/rpc.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/rpc.go
@@ -103,6 +103,10 @@ type conn struct {
 const notificationBuffer = 4096
 
 func newConn(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverRequestHandler) *conn {
+	return newConnAt(w, r, log, onReq, 0)
+}
+
+func newConnAt(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverRequestHandler, nextID int64) *conn {
 	c := &conn{
 		w:               w,
 		log:             log,
@@ -111,6 +115,7 @@ func newConn(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverReques
 		onServerRequest: onReq,
 		done:            make(chan struct{}),
 	}
+	c.nextID.Store(nextID)
 	go c.readLoop(r)
 	return c
 }
@@ -235,7 +240,18 @@ func (c *conn) deliver(f frame) {
 // own goroutine so a slow decision (a user staring at an approval card) does not
 // stall the read loop and starve streaming deltas.
 func (c *conn) answer(req serverRequest) {
-	result, err := c.onServerRequest(context.Background(), req)
+	ctx, cancel := context.WithCancel(context.Background())
+	finished := make(chan struct{})
+	go func() {
+		select {
+		case <-c.done:
+			cancel()
+		case <-finished:
+		}
+	}()
+	result, err := c.onServerRequest(ctx, req)
+	close(finished)
+	cancel()
 
 	reply := map[string]any{"id": req.ID}
 	if err != nil {

--- a/backend/internal/adapters/chatdriver/codexappserver/rpc.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/rpc.go
@@ -102,7 +102,10 @@ type conn struct {
 	readErr error
 }
 
-const notificationBuffer = 4096
+const (
+	maxNotificationQueuedBytes = 32 << 20
+	notificationQueueOverhead  = 64
+)
 
 func newConn(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverRequestHandler) *conn {
 	return newConnAt(w, r, log, onReq, 0)
@@ -114,7 +117,7 @@ func newConnAt(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverRequ
 		log:               log,
 		pending:           make(map[int64]chan frame),
 		notificationInput: make(chan notification),
-		notifications:     make(chan notification, notificationBuffer),
+		notifications:     make(chan notification),
 		onServerRequest:   onReq,
 		done:              make(chan struct{}),
 	}
@@ -131,8 +134,13 @@ func newConnAt(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverRequ
 func (c *conn) relayNotifications() {
 	defer close(c.notifications)
 	var queued []notification
+	queuedBytes := 0
 	input := c.notificationInput
 	for input != nil || len(queued) > 0 {
+		receive := input
+		if queuedBytes >= maxNotificationQueuedBytes {
+			receive = nil
+		}
 		var output chan notification
 		var next notification
 		if len(queued) > 0 {
@@ -140,17 +148,26 @@ func (c *conn) relayNotifications() {
 			next = queued[0]
 		}
 		select {
-		case n, ok := <-input:
+		case n, ok := <-receive:
 			if !ok {
 				input = nil
 				continue
 			}
 			queued = append(queued, n)
+			queuedBytes += notificationBytes(n)
 		case output <- next:
+			queuedBytes -= notificationBytes(next)
 			queued[0] = notification{}
 			queued = queued[1:]
+			if len(queued) == 0 {
+				queued = nil
+			}
 		}
 	}
+}
+
+func notificationBytes(n notification) int {
+	return notificationQueueOverhead + len(n.Method) + len(n.Params)
 }
 
 // notifications the caller consumes. Closed when the connection ends.

--- a/backend/internal/adapters/chatdriver/codexappserver/rpc.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/rpc.go
@@ -86,9 +86,11 @@ type conn struct {
 	pending map[int64]chan frame
 	closed  bool
 
-	// notifications is bounded. Overflow is dropped and logged rather than
-	// allowed to block the reader, which would deadlock the provider.
-	notifications chan notification
+	// notificationInput decouples provider reads from notification consumption.
+	// The relay owns an ordered queue so a replay burst cannot block response
+	// correlation or silently drop a lifecycle frame.
+	notificationInput chan notification
+	notifications     chan notification
 
 	onServerRequest serverRequestHandler
 
@@ -108,16 +110,47 @@ func newConn(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverReques
 
 func newConnAt(w io.WriteCloser, r io.Reader, log *slog.Logger, onReq serverRequestHandler, nextID int64) *conn {
 	c := &conn{
-		w:               w,
-		log:             log,
-		pending:         make(map[int64]chan frame),
-		notifications:   make(chan notification, notificationBuffer),
-		onServerRequest: onReq,
-		done:            make(chan struct{}),
+		w:                 w,
+		log:               log,
+		pending:           make(map[int64]chan frame),
+		notificationInput: make(chan notification),
+		notifications:     make(chan notification, notificationBuffer),
+		onServerRequest:   onReq,
+		done:              make(chan struct{}),
 	}
 	c.nextID.Store(nextID)
+	go c.relayNotifications()
 	go c.readLoop(r)
 	return c
+}
+
+// relayNotifications keeps provider reads independent from a slow consumer
+// without discarding protocol frames. The host bounds a detached replay by
+// bytes; this queue preserves that replay's order while the conversation pump
+// catches up.
+func (c *conn) relayNotifications() {
+	defer close(c.notifications)
+	var queued []notification
+	input := c.notificationInput
+	for input != nil || len(queued) > 0 {
+		var output chan notification
+		var next notification
+		if len(queued) > 0 {
+			output = c.notifications
+			next = queued[0]
+		}
+		select {
+		case n, ok := <-input:
+			if !ok {
+				input = nil
+				continue
+			}
+			queued = append(queued, n)
+		case output <- next:
+			queued[0] = notification{}
+			queued = queued[1:]
+		}
+	}
 }
 
 // notifications the caller consumes. Closed when the connection ends.
@@ -148,7 +181,7 @@ func (c *conn) readLoop(r io.Reader) {
 		for _, ch := range pending {
 			close(ch)
 		}
-		close(c.notifications)
+		close(c.notificationInput)
 		close(c.done)
 	}()
 
@@ -179,11 +212,7 @@ func (c *conn) readLoop(r io.Reader) {
 		case f.ID != nil:
 			c.deliver(f)
 		case f.Method != "":
-			select {
-			case c.notifications <- notification{Method: f.Method, Params: f.Params}:
-			default:
-				c.log.Warn("dropped app-server notification: buffer full", "method", f.Method)
-			}
+			c.notificationInput <- notification{Method: f.Method, Params: f.Params}
 		}
 	}
 }

--- a/backend/internal/adapters/chatdriver/codexappserver/rpc_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/rpc_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const notificationReplayBurst = 4096
+
 // fakeAppServer stands in for the `codex app-server` process over in-memory
 // pipes, so the transport is tested without spawning anything.
 type fakeAppServer struct {
@@ -182,19 +184,56 @@ func TestNotificationsAreFannedOut(t *testing.T) {
 
 func TestNotificationReplayBurstRetainsTerminalFrame(t *testing.T) {
 	c, fake := newFakeAppServer(t, rejectAllServerRequests)
-	for i := 0; i < notificationBuffer; i++ {
+	for i := 0; i < notificationReplayBurst; i++ {
 		fake.push(`{"method":"item/agentMessage/delta","params":{"delta":"x"}}`)
 	}
 	fake.push(`{"method":"turn/completed","params":{"turn":{"status":"completed"}}}`)
 
 	foundTerminal := false
-	for i := 0; i < notificationBuffer+1; i++ {
+	for i := 0; i < notificationReplayBurst+1; i++ {
 		if n := <-c.notifs(); n.Method == "turn/completed" {
 			foundTerminal = true
 		}
 	}
 	if !foundTerminal {
 		t.Fatal("turn/completed was dropped when replay exceeded the notification buffer")
+	}
+}
+
+func TestNotificationRelayAppliesBackpressureAtByteLimit(t *testing.T) {
+	c, fake := newFakeAppServer(t, rejectAllServerRequests)
+	const oversizedReplayFrames = 40
+	largeFrame := `{"method":"item/agentMessage/delta","params":{"delta":"` +
+		strings.Repeat("x", 1<<20) + `"}}`
+	producerDone := make(chan error, 1)
+	go func() {
+		for i := 0; i < oversizedReplayFrames; i++ {
+			if _, err := io.WriteString(fake.toClient, largeFrame+"\n"); err != nil {
+				producerDone <- err
+				return
+			}
+		}
+		producerDone <- nil
+	}()
+
+	select {
+	case err := <-producerDone:
+		if err != nil {
+			t.Fatalf("provider write failed before backpressure: %v", err)
+		}
+		t.Fatal("notification relay accepted more than its byte budget without backpressure")
+	case <-time.After(3 * time.Second):
+	}
+
+	for i := 0; i < oversizedReplayFrames; i++ {
+		select {
+		case <-c.notifs():
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out draining notification %d", i)
+		}
+	}
+	if err := <-producerDone; err != nil {
+		t.Fatalf("provider did not resume after notifications drained: %v", err)
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/codexappserver/rpc_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/rpc_test.go
@@ -180,6 +180,24 @@ func TestNotificationsAreFannedOut(t *testing.T) {
 	}
 }
 
+func TestNotificationReplayBurstRetainsTerminalFrame(t *testing.T) {
+	c, fake := newFakeAppServer(t, rejectAllServerRequests)
+	for i := 0; i < notificationBuffer; i++ {
+		fake.push(`{"method":"item/agentMessage/delta","params":{"delta":"x"}}`)
+	}
+	fake.push(`{"method":"turn/completed","params":{"turn":{"status":"completed"}}}`)
+
+	foundTerminal := false
+	for i := 0; i < notificationBuffer+1; i++ {
+		if n := <-c.notifs(); n.Method == "turn/completed" {
+			foundTerminal = true
+		}
+	}
+	if !foundTerminal {
+		t.Fatal("turn/completed was dropped when replay exceeded the notification buffer")
+	}
+}
+
 // A frame this build cannot parse must be skipped, not fatal: the provider is
 // free to add shapes we do not model yet.
 func TestUnparseableFrameDoesNotKillConnection(t *testing.T) {

--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -1,0 +1,664 @@
+// Package persistenthost keeps a provider stdio process alive while AO's daemon
+// is replaced. The host is deliberately provider-neutral: it forwards newline-
+// delimited protocol frames and knows only how to authenticate one controller,
+// replay output produced while detached, and terminate explicitly.
+package persistenthost
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
+)
+
+const (
+	// ProtocolVersion fences daemon/host control-plane compatibility.
+	ProtocolVersion  = 1
+	maxDetachedBytes = 32 << 20
+	startupTimeout   = 10 * time.Second
+)
+
+var (
+	// ErrAttached reports that another daemon controller owns the host.
+	ErrAttached = errors.New("chat host already has a controller")
+	// ErrUnauthorized reports an invalid host capability.
+	ErrUnauthorized = errors.New("chat host authentication failed")
+	// ErrIncompatible reports a control-plane protocol version mismatch.
+	ErrIncompatible = errors.New("chat host protocol incompatible")
+	// ErrHostExists reports an atomic per-session launch-lock conflict.
+	ErrHostExists = errors.New("chat host already exists")
+)
+
+// Descriptor is the private connection record published by a running host.
+type Descriptor struct {
+	Version   int       `json:"version"`
+	SessionID string    `json:"sessionId"`
+	Address   string    `json:"address"`
+	Token     string    `json:"token"`
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// Config identifies one provider process and its AO session ownership.
+type Config struct {
+	SessionID string
+	DataDir   string
+	Workdir   string
+	Env       []string
+	Argv      []string
+}
+
+// Transport is one authenticated attachment to a persistent provider host.
+type Transport struct {
+	Stdin         io.WriteCloser
+	Stdout        io.Reader
+	Reconnected   bool
+	NextRequestID int64
+}
+
+type hello struct {
+	Version int    `json:"version"`
+	Token   string `json:"token"`
+	Action  string `json:"action"`
+}
+
+type helloResponse struct {
+	OK            bool   `json:"ok"`
+	Error         string `json:"error,omitempty"`
+	NextRequestID int64  `json:"nextRequestId,omitempty"`
+}
+
+func hostDir(dataDir, sessionID string) (string, error) {
+	if sessionID == "" || filepath.Base(sessionID) != sessionID || strings.ContainsAny(sessionID, `/\\`) {
+		return "", errors.New("invalid chat host session id")
+	}
+	if !filepath.IsAbs(dataDir) {
+		return "", errors.New("chat host data dir must be absolute")
+	}
+	return filepath.Join(dataDir, "chat-hosts", sessionID), nil
+}
+
+func descriptorPath(dataDir, sessionID string) (string, error) {
+	dir, err := hostDir(dataDir, sessionID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "host.json"), nil
+}
+
+func lockPath(dataDir, sessionID string) (string, error) {
+	dir, err := hostDir(dataDir, sessionID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "host.lock"), nil
+}
+
+func acquireHostLock(dataDir, sessionID string) (func(), error) {
+	dir, err := hostDir(dataDir, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // Directories need execute permission; access is owner-only.
+		return nil, err
+	}
+	path, _ := lockPath(dataDir, sessionID)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // AO-owned capability directory.
+	if errors.Is(err, os.ErrExist) {
+		return nil, ErrHostExists
+	}
+	if err != nil {
+		return nil, err
+	}
+	if _, err := fmt.Fprintf(f, "%d\n", os.Getpid()); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	return func() { _ = os.Remove(path) }, nil
+}
+
+func readDescriptor(dataDir, sessionID string) (Descriptor, error) {
+	path, err := descriptorPath(dataDir, sessionID)
+	if err != nil {
+		return Descriptor{}, err
+	}
+	b, err := os.ReadFile(path) //nolint:gosec // AO-owned path derived from validated session id.
+	if err != nil {
+		return Descriptor{}, err
+	}
+	var d Descriptor
+	if err := json.Unmarshal(b, &d); err != nil {
+		return Descriptor{}, fmt.Errorf("decode chat host descriptor: %w", err)
+	}
+	if d.SessionID != sessionID || d.Address == "" || d.Token == "" {
+		return Descriptor{}, errors.New("invalid chat host descriptor")
+	}
+	return d, nil
+}
+
+func writeDescriptor(dataDir string, d Descriptor) error {
+	dir, err := hostDir(dataDir, d.SessionID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // Directories need execute permission; access is owner-only.
+		return err
+	}
+	b, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(dir, ".host.json.tmp-"+strconv.Itoa(os.Getpid()))
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "host.json")
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}
+
+func randomToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// ConnectOrStart attaches to an existing compatible host or starts one with the
+// current AO executable. Failed/incompatible probes never terminate that host.
+func ConnectOrStart(ctx context.Context, cfg Config) (*Transport, error) {
+	if d, err := readDescriptor(cfg.DataDir, cfg.SessionID); err == nil {
+		transport, attachErr := attach(ctx, d, true)
+		if attachErr == nil {
+			return transport, nil
+		}
+		if errors.Is(attachErr, ErrAttached) {
+			// Desktop updater handoff can briefly start the replacement daemon
+			// before the old controller has detached. Wait for exclusive ownership;
+			// never turn that overlap into a competing provider process.
+			deadline := time.Now().Add(startupTimeout)
+			for time.Now().Before(deadline) && processalive.Alive(d.PID) {
+				timer := time.NewTimer(20 * time.Millisecond)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, ctx.Err()
+				case <-timer.C:
+				}
+				transport, attachErr = attach(ctx, d, true)
+				if attachErr == nil {
+					return transport, nil
+				}
+				if !errors.Is(attachErr, ErrAttached) {
+					break
+				}
+			}
+		}
+		// A failed socket probe is not proof that a provider is dead. Only an OS
+		// process observation permits clearing the descriptor and falling back to
+		// native resume in a new host.
+		if processalive.Alive(d.PID) {
+			return nil, attachErr
+		}
+		path, _ := descriptorPath(cfg.DataDir, cfg.SessionID)
+		_ = os.Remove(path)
+		lock, _ := lockPath(cfg.DataDir, cfg.SessionID)
+		_ = os.Remove(lock)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		// A malformed or unreadable ownership record is not proof that no host
+		// exists. Fail closed instead of launching a competing process.
+		return nil, err
+	}
+	if len(cfg.Argv) == 0 || !filepath.IsAbs(cfg.Workdir) {
+		return nil, errors.New("chat host start requires provider argv and absolute workdir")
+	}
+	if err := spawnDetached(cfg); err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(startupTimeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		d, err := readDescriptor(cfg.DataDir, cfg.SessionID)
+		if err == nil {
+			transport, attachErr := attach(ctx, d, false)
+			if attachErr == nil {
+				return transport, nil
+			}
+			lastErr = attachErr
+		} else {
+			lastErr = err
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("start chat host: %w", lastErr)
+}
+
+// Reconcile terminates compatible authenticated hosts whose durable session no
+// longer exists. Live-session hosts, incompatible hosts, and inconclusive probes
+// are preserved.
+func Reconcile(ctx context.Context, dataDir string, keep map[string]struct{}) error {
+	root := filepath.Join(dataDir, "chat-hosts")
+	entries, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionID := entry.Name()
+		if _, ok := keep[sessionID]; ok {
+			continue
+		}
+		d, readErr := readDescriptor(dataDir, sessionID)
+		if readErr != nil {
+			continue
+		}
+		if d.Version != ProtocolVersion {
+			continue
+		}
+		if !processalive.Alive(d.PID) {
+			path, _ := descriptorPath(dataDir, sessionID)
+			_ = os.Remove(path)
+			lock, _ := lockPath(dataDir, sessionID)
+			_ = os.Remove(lock)
+			continue
+		}
+		if shutdownErr := Shutdown(ctx, dataDir, sessionID); shutdownErr != nil {
+			errs = append(errs, fmt.Errorf("reap chat host %s: %w", sessionID, shutdownErr))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func attach(ctx context.Context, d Descriptor, reconnected bool) (*Transport, error) {
+	if d.Version != ProtocolVersion {
+		return nil, fmt.Errorf("%w: host=%d daemon=%d", ErrIncompatible, d.Version, ProtocolVersion)
+	}
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "tcp", d.Address)
+	if err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(conn)
+	if err := json.NewEncoder(conn).Encode(hello{Version: ProtocolVersion, Token: d.Token, Action: "attach"}); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	var response helloResponse
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err := json.Unmarshal(line, &response); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if !response.OK {
+		_ = conn.Close()
+		switch response.Error {
+		case ErrAttached.Error():
+			return nil, ErrAttached
+		case ErrUnauthorized.Error():
+			return nil, ErrUnauthorized
+		default:
+			return nil, errors.New(response.Error)
+		}
+	}
+	return &Transport{Stdin: conn, Stdout: reader, Reconnected: reconnected, NextRequestID: response.NextRequestID}, nil
+}
+
+// Shutdown terminates an authenticated host. Missing or unreachable hosts are
+// harmless; callers use this only for explicit session destruction/orphan reap.
+func Shutdown(ctx context.Context, dataDir, sessionID string) error {
+	d, err := readDescriptor(dataDir, sessionID)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", d.Address)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	if err := json.NewEncoder(conn).Encode(hello{Version: ProtocolVersion, Token: d.Token, Action: "shutdown"}); err != nil {
+		return err
+	}
+	var response helloResponse
+	if err := json.NewDecoder(conn).Decode(&response); err != nil {
+		return err
+	}
+	if !response.OK {
+		return errors.New(response.Error)
+	}
+	return nil
+}
+
+// Run owns the provider until it exits or an authenticated shutdown arrives.
+func Run(cfg Config) error {
+	if len(cfg.Argv) == 0 || !filepath.IsAbs(cfg.Workdir) {
+		return errors.New("chat host requires provider argv and absolute workdir")
+	}
+	releaseLock, err := acquireHostLock(cfg.DataDir, cfg.SessionID)
+	if err != nil {
+		return err
+	}
+	defer releaseLock()
+	token, err := randomToken()
+	if err != nil {
+		return err
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = listener.Close() }()
+
+	child := exec.Command(cfg.Argv[0], cfg.Argv[1:]...) //nolint:gosec // provider argv is constructed by AO's driver.
+	child.Dir = cfg.Workdir
+	child.Env = cfg.Env
+	stdin, err := child.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := child.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	child.Stderr = io.Discard
+	if err := child.Start(); err != nil {
+		return err
+	}
+
+	d := Descriptor{Version: ProtocolVersion, SessionID: cfg.SessionID, Address: listener.Addr().String(), Token: token, PID: os.Getpid(), StartedAt: time.Now().UTC()}
+	if err := writeDescriptor(cfg.DataDir, d); err != nil {
+		_ = child.Process.Kill()
+		return err
+	}
+	path, _ := descriptorPath(cfg.DataDir, cfg.SessionID)
+	defer func() { _ = os.Remove(path) }()
+
+	h := &host{
+		listener: listener, child: child, stdin: stdin, token: token,
+		detached: make([][]byte, 0, 64), pendingRequests: make(map[string]*pendingRequest),
+		shutdown: make(chan struct{}),
+	}
+	h.cond = sync.NewCond(&h.mu)
+	providerDone := make(chan error, 1)
+	go func() { providerDone <- h.forwardProvider(stdout) }()
+	acceptDone := make(chan error, 1)
+	go func() { acceptDone <- h.accept() }()
+
+	select {
+	case <-providerDone:
+	case <-h.shutdown:
+		_ = stdin.Close()
+		select {
+		case <-providerDone:
+		case <-time.After(3 * time.Second):
+			_ = child.Process.Kill()
+		}
+	case err := <-acceptDone:
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			_ = child.Process.Kill()
+			return err
+		}
+	}
+	_ = listener.Close()
+	_ = child.Wait()
+	return nil
+}
+
+type host struct {
+	listener net.Listener
+	child    *exec.Cmd
+	stdin    io.WriteCloser
+	token    string
+
+	mu              sync.Mutex
+	cond            *sync.Cond
+	client          net.Conn
+	detached        [][]byte
+	detachedBytes   int
+	pendingRequests map[string]*pendingRequest
+	pendingOrder    []string
+	maxRequestID    int64
+	shutdown        chan struct{}
+	shutdownOnce    sync.Once
+}
+
+type pendingRequest struct {
+	frame    []byte
+	buffered bool
+}
+
+func (h *host) accept() error {
+	for {
+		conn, err := h.listener.Accept()
+		if err != nil {
+			return err
+		}
+		go h.handle(conn)
+	}
+}
+
+func (h *host) handle(conn net.Conn) {
+	reader := bufio.NewReader(conn)
+	var request hello
+	if err := json.NewDecoder(reader).Decode(&request); err != nil {
+		_ = conn.Close()
+		return
+	}
+	if request.Version != ProtocolVersion {
+		_ = json.NewEncoder(conn).Encode(helloResponse{Error: ErrIncompatible.Error()})
+		_ = conn.Close()
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(request.Token), []byte(h.token)) != 1 {
+		_ = json.NewEncoder(conn).Encode(helloResponse{Error: ErrUnauthorized.Error()})
+		_ = conn.Close()
+		return
+	}
+	if request.Action == "shutdown" {
+		_ = json.NewEncoder(conn).Encode(helloResponse{OK: true})
+		_ = conn.Close()
+		h.shutdownOnce.Do(func() { close(h.shutdown) })
+		return
+	}
+	if request.Action != "attach" {
+		_ = json.NewEncoder(conn).Encode(helloResponse{Error: "unknown chat host action"})
+		_ = conn.Close()
+		return
+	}
+
+	h.mu.Lock()
+	if h.client != nil {
+		h.mu.Unlock()
+		_ = json.NewEncoder(conn).Encode(helloResponse{Error: ErrAttached.Error()})
+		_ = conn.Close()
+		return
+	}
+	h.client = conn
+	writeErr := json.NewEncoder(conn).Encode(helloResponse{OK: true, NextRequestID: h.maxRequestID})
+	if writeErr == nil {
+		for _, frame := range h.detached {
+			if _, writeErr = conn.Write(frame); writeErr != nil {
+				break
+			}
+		}
+	}
+	if writeErr == nil {
+		h.detached = h.detached[:0]
+		h.detachedBytes = 0
+		for _, pending := range h.pendingRequests {
+			pending.buffered = false
+		}
+		h.cond.Broadcast()
+	}
+	h.mu.Unlock()
+	if writeErr != nil {
+		h.detach(conn)
+		return
+	}
+
+	for {
+		frame, readErr := reader.ReadBytes('\n')
+		if len(frame) > 0 {
+			if _, err := h.stdin.Write(frame); err != nil {
+				readErr = err
+			} else {
+				h.observeClientFrame(frame)
+			}
+		}
+		if readErr != nil {
+			h.detach(conn)
+			return
+		}
+	}
+}
+
+func (h *host) observeClientFrame(frame []byte) {
+	var value struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	if json.Unmarshal(frame, &value) != nil || len(value.ID) == 0 {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if value.Method != "" {
+		var id int64
+		if json.Unmarshal(value.ID, &id) == nil && id > h.maxRequestID {
+			h.maxRequestID = id
+		}
+		return
+	}
+	requestID := string(value.ID)
+	if _, ok := h.pendingRequests[requestID]; ok {
+		delete(h.pendingRequests, requestID)
+		for i, id := range h.pendingOrder {
+			if id == requestID {
+				h.pendingOrder = append(h.pendingOrder[:i], h.pendingOrder[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+func (h *host) detach(conn net.Conn) {
+	h.mu.Lock()
+	if h.client == conn {
+		h.client = nil
+		h.bufferPendingRequestsLocked()
+	}
+	h.mu.Unlock()
+	_ = conn.Close()
+}
+
+func (h *host) forwardProvider(stdout io.Reader) error {
+	reader := bufio.NewReader(stdout)
+	for {
+		frame, err := reader.ReadBytes('\n')
+		if len(frame) > 0 {
+			h.mu.Lock()
+			if requestID, ok := serverRequestID(frame); ok {
+				if _, exists := h.pendingRequests[requestID]; !exists {
+					h.pendingRequests[requestID] = &pendingRequest{frame: append([]byte(nil), frame...)}
+					h.pendingOrder = append(h.pendingOrder, requestID)
+				}
+			}
+			for h.client == nil && h.detachedBytes+len(frame) > maxDetachedBytes {
+				h.cond.Wait()
+			}
+			if h.client != nil {
+				if _, writeErr := h.client.Write(frame); writeErr != nil {
+					_ = h.client.Close()
+					h.client = nil
+					h.bufferPendingRequestsLocked()
+					if _, pending := serverRequestID(frame); !pending {
+						h.bufferFrameLocked(frame)
+					}
+				}
+			} else {
+				if requestID, pending := serverRequestID(frame); !pending || !h.pendingRequests[requestID].buffered {
+					h.bufferFrameLocked(frame)
+					if pending {
+						h.pendingRequests[requestID].buffered = true
+					}
+				}
+			}
+			h.mu.Unlock()
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func serverRequestID(frame []byte) (string, bool) {
+	var value struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	if json.Unmarshal(frame, &value) != nil || len(value.ID) == 0 || value.Method == "" {
+		return "", false
+	}
+	return string(value.ID), true
+}
+
+func (h *host) bufferPendingRequestsLocked() {
+	for _, requestID := range h.pendingOrder {
+		pending := h.pendingRequests[requestID]
+		if pending == nil || pending.buffered {
+			continue
+		}
+		h.bufferFrameLocked(pending.frame)
+		pending.buffered = true
+	}
+}
+
+func (h *host) bufferFrameLocked(frame []byte) {
+	h.detached = append(h.detached, append([]byte(nil), frame...))
+	h.detachedBytes += len(frame)
+}

--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -344,14 +344,19 @@ func attach(ctx context.Context, d Descriptor, reconnected bool) (*Transport, er
 	if err != nil {
 		return nil, err
 	}
+	finishHandshake := bindConnToContext(ctx, conn)
 	reader := bufio.NewReader(conn)
 	if err := json.NewEncoder(conn).Encode(hello{Version: ProtocolVersion, Token: d.Token, Action: "attach"}); err != nil {
 		_ = conn.Close()
-		return nil, err
+		return nil, finishHandshake(err)
 	}
 	var response helloResponse
 	line, err := reader.ReadBytes('\n')
 	if err != nil {
+		_ = conn.Close()
+		return nil, finishHandshake(err)
+	}
+	if err := finishHandshake(nil); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}
@@ -373,6 +378,18 @@ func attach(ctx context.Context, d Descriptor, reconnected bool) (*Transport, er
 	return &Transport{Stdin: conn, Stdout: reader, Reconnected: reconnected, NextRequestID: response.NextRequestID}, nil
 }
 
+func bindConnToContext(ctx context.Context, conn net.Conn) func(error) error {
+	stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	return func(err error) error {
+		stop()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			_ = conn.Close()
+			return ctxErr
+		}
+		return err
+	}
+}
+
 // Shutdown terminates an authenticated host. Missing or unreachable hosts are
 // harmless; callers use this only for explicit session destruction/orphan reap.
 func Shutdown(ctx context.Context, dataDir, sessionID string) error {
@@ -388,11 +405,15 @@ func Shutdown(ctx context.Context, dataDir, sessionID string) error {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
+	finishHandshake := bindConnToContext(ctx, conn)
 	if err := json.NewEncoder(conn).Encode(hello{Version: ProtocolVersion, Token: d.Token, Action: "shutdown"}); err != nil {
-		return err
+		return finishHandshake(err)
 	}
 	var response helloResponse
 	if err := json.NewDecoder(conn).Decode(&response); err != nil {
+		return finishHandshake(err)
+	}
+	if err := finishHandshake(nil); err != nil {
 		return err
 	}
 	if !response.OK {

--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -248,10 +248,10 @@ func ConnectOrStart(ctx context.Context, cfg Config) (*Transport, error) {
 		if processalive.Alive(d.PID) {
 			return nil, fmt.Errorf("%w: %w", ErrOwnershipInconclusive, attachErr)
 		}
-		path, _ := descriptorPath(cfg.DataDir, cfg.SessionID)
-		_ = os.Remove(path)
-		lock, _ := lockPath(cfg.DataDir, cfg.SessionID)
-		_ = os.Remove(lock)
+		// Do not remove stale ownership files here. Another starter may have
+		// already reclaimed the dead lock and published a replacement descriptor
+		// since this client read d. The detached host's O_EXCL lock acquisition is
+		// the single authority for reclaiming dead ownership.
 	} else if !errors.Is(err, os.ErrNotExist) {
 		// A malformed or unreadable ownership record is not proof that no host
 		// exists. Fail closed instead of launching a competing process.
@@ -316,10 +316,16 @@ func Reconcile(ctx context.Context, dataDir string, keep map[string]struct{}) er
 			continue
 		}
 		if !processalive.Alive(d.PID) {
+			// Claim the launch lock before cleaning a dead descriptor. If a new host
+			// already owns it, preserve its descriptor instead of deleting ownership
+			// state observed by a stale reconciler.
+			release, lockErr := acquireHostLock(dataDir, sessionID)
+			if lockErr != nil {
+				continue
+			}
 			path, _ := descriptorPath(dataDir, sessionID)
 			_ = os.Remove(path)
-			lock, _ := lockPath(dataDir, sessionID)
-			_ = os.Remove(lock)
+			release()
 			continue
 		}
 		if shutdownErr := Shutdown(ctx, dataDir, sessionID); shutdownErr != nil {

--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -31,6 +31,8 @@ const (
 	ProtocolVersion  = 1
 	maxDetachedBytes = 32 << 20
 	startupTimeout   = 10 * time.Second
+	// Host hello is local control-plane I/O and must not stall daemon recovery.
+	handshakeTimeout = time.Second
 )
 
 var (
@@ -339,12 +341,14 @@ func attach(ctx context.Context, d Descriptor, reconnected bool) (*Transport, er
 	if d.Version != ProtocolVersion {
 		return nil, fmt.Errorf("%w: host=%d daemon=%d", ErrIncompatible, d.Version, ProtocolVersion)
 	}
+	handshakeCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer cancel()
 	dialer := net.Dialer{}
-	conn, err := dialer.DialContext(ctx, "tcp", d.Address)
+	conn, err := dialer.DialContext(handshakeCtx, "tcp", d.Address)
 	if err != nil {
 		return nil, err
 	}
-	finishHandshake := bindConnToContext(ctx, conn)
+	finishHandshake := bindConnToContext(handshakeCtx, conn)
 	reader := bufio.NewReader(conn)
 	if err := json.NewEncoder(conn).Encode(hello{Version: ProtocolVersion, Token: d.Token, Action: "attach"}); err != nil {
 		_ = conn.Close()
@@ -400,12 +404,14 @@ func Shutdown(ctx context.Context, dataDir, sessionID string) error {
 	if err != nil {
 		return err
 	}
-	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", d.Address)
+	handshakeCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(handshakeCtx, "tcp", d.Address)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
-	finishHandshake := bindConnToContext(ctx, conn)
+	finishHandshake := bindConnToContext(handshakeCtx, conn)
 	if err := json.NewEncoder(conn).Encode(hello{Version: ProtocolVersion, Token: d.Token, Action: "shutdown"}); err != nil {
 		return finishHandshake(err)
 	}

--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -42,6 +42,10 @@ var (
 	ErrIncompatible = errors.New("chat host protocol incompatible")
 	// ErrHostExists reports an atomic per-session launch-lock conflict.
 	ErrHostExists = errors.New("chat host already exists")
+	// ErrOwnershipInconclusive means a descriptor or live host exists, but this
+	// client could not prove that it is safe to replace. Callers must preserve the
+	// durable session rather than treating the failed attachment as provider death.
+	ErrOwnershipInconclusive = errors.New("chat host ownership is inconclusive")
 )
 
 // Descriptor is the private connection record published by a running host.
@@ -123,7 +127,21 @@ func acquireHostLock(dataDir, sessionID string) (func(), error) {
 	path, _ := lockPath(dataDir, sessionID)
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // AO-owned capability directory.
 	if errors.Is(err, os.ErrExist) {
-		return nil, ErrHostExists
+		owner, readErr := os.ReadFile(path) //nolint:gosec // AO-owned path derived from validated session id.
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(owner)))
+		if readErr != nil || parseErr != nil || pid <= 0 || processalive.Alive(pid) {
+			return nil, ErrHostExists
+		}
+		// A host can die after atomically creating its launch lock but before it
+		// publishes host.json. Reclaim only a lock whose recorded owner is proven
+		// dead, then retry the same O_EXCL acquisition once.
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return nil, ErrHostExists
+		}
+		f, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // AO-owned capability directory.
+		if errors.Is(err, os.ErrExist) {
+			return nil, ErrHostExists
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -228,7 +246,7 @@ func ConnectOrStart(ctx context.Context, cfg Config) (*Transport, error) {
 		// process observation permits clearing the descriptor and falling back to
 		// native resume in a new host.
 		if processalive.Alive(d.PID) {
-			return nil, attachErr
+			return nil, fmt.Errorf("%w: %w", ErrOwnershipInconclusive, attachErr)
 		}
 		path, _ := descriptorPath(cfg.DataDir, cfg.SessionID)
 		_ = os.Remove(path)
@@ -237,12 +255,12 @@ func ConnectOrStart(ctx context.Context, cfg Config) (*Transport, error) {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		// A malformed or unreadable ownership record is not proof that no host
 		// exists. Fail closed instead of launching a competing process.
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrOwnershipInconclusive, err)
 	}
 	if len(cfg.Argv) == 0 || !filepath.IsAbs(cfg.Workdir) {
 		return nil, errors.New("chat host start requires provider argv and absolute workdir")
 	}
-	if err := spawnDetached(cfg); err != nil {
+	if err := spawnDetached(ctx, cfg); err != nil {
 		return nil, err
 	}
 	deadline := time.Now().Add(startupTimeout)
@@ -262,6 +280,9 @@ func ConnectOrStart(ctx context.Context, cfg Config) (*Transport, error) {
 			lastErr = err
 		}
 		time.Sleep(20 * time.Millisecond)
+	}
+	if d, readErr := readDescriptor(cfg.DataDir, cfg.SessionID); readErr == nil && processalive.Alive(d.PID) {
+		return nil, fmt.Errorf("%w: %w", ErrOwnershipInconclusive, lastErr)
 	}
 	return nil, fmt.Errorf("start chat host: %w", lastErr)
 }
@@ -375,7 +396,7 @@ func Shutdown(ctx context.Context, dataDir, sessionID string) error {
 }
 
 // Run owns the provider until it exits or an authenticated shutdown arrives.
-func Run(cfg Config) error {
+func Run(ctx context.Context, cfg Config) error {
 	if len(cfg.Argv) == 0 || !filepath.IsAbs(cfg.Workdir) {
 		return errors.New("chat host requires provider argv and absolute workdir")
 	}
@@ -429,15 +450,22 @@ func Run(cfg Config) error {
 	acceptDone := make(chan error, 1)
 	go func() { acceptDone <- h.accept() }()
 
-	select {
-	case <-providerDone:
-	case <-h.shutdown:
+	stopProvider := func() {
 		_ = stdin.Close()
 		select {
 		case <-providerDone:
 		case <-time.After(3 * time.Second):
 			_ = child.Process.Kill()
 		}
+	}
+	var runErr error
+	select {
+	case <-providerDone:
+	case <-h.shutdown:
+		stopProvider()
+	case <-ctx.Done():
+		runErr = ctx.Err()
+		stopProvider()
 	case err := <-acceptDone:
 		if err != nil && !errors.Is(err, net.ErrClosed) {
 			_ = child.Process.Kill()
@@ -446,7 +474,7 @@ func Run(cfg Config) error {
 	}
 	_ = listener.Close()
 	_ = child.Wait()
-	return nil
+	return runErr
 }
 
 type host struct {

--- a/backend/internal/adapters/chatdriver/persistenthost/host_race_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_race_test.go
@@ -1,0 +1,114 @@
+package persistenthost
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Two daemons can observe the same dead descriptor before either starts its
+// replacement. A stale observer must never delete ownership published by the
+// winner; the host's O_EXCL launch lock is the only replacement authority.
+func TestConnectOrStartConcurrentStaleProbeDoesNotStartRivalHost(t *testing.T) {
+	dataDir := t.TempDir()
+	sessionID := "stale-race"
+	dir, _ := hostDir(dataDir, sessionID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	stale := Descriptor{
+		Version: ProtocolVersion, SessionID: sessionID, Address: ln.Addr().String(),
+		Token: "stale", PID: 2147483647, StartedAt: time.Now(),
+	}
+	if err := writeDescriptor(dataDir, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	accepted := make(chan net.Conn, 2)
+	go func() {
+		for i := 0; i < 2; i++ {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			var req hello
+			if json.NewDecoder(conn).Decode(&req) != nil {
+				_ = conn.Close()
+				return
+			}
+			accepted <- conn
+		}
+	}()
+
+	startLog := filepath.Join(t.TempDir(), "providers.log")
+	cfg := Config{SessionID: sessionID, DataDir: dataDir, Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_START_LOG="+startLog),
+		Argv: []string{"/bin/sh", "-c", `echo $$ >> "$AO_START_LOG"; exec cat`}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := make(chan *Transport, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			tr, connectErr := ConnectOrStart(ctx, cfg)
+			if connectErr == nil {
+				results <- tr
+			}
+		}()
+	}
+
+	firstProbe, secondProbe := <-accepted, <-accepted
+	_ = json.NewEncoder(firstProbe).Encode(helloResponse{Error: ErrUnauthorized.Error()})
+	_ = firstProbe.Close()
+	var firstHost int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if current, readErr := readDescriptor(dataDir, sessionID); readErr == nil && current.PID != stale.PID {
+			firstHost = current.PID
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if firstHost == 0 {
+		t.Fatal("first recovery never published a replacement host")
+	}
+	t.Cleanup(func() { _ = syscall.Kill(-firstHost, syscall.SIGKILL) })
+
+	// Release the second stale probe only after the first host owns the lock and
+	// has published its descriptor. The old code deleted both files here.
+	_ = json.NewEncoder(secondProbe).Encode(helloResponse{Error: ErrUnauthorized.Error()})
+	_ = secondProbe.Close()
+	time.Sleep(300 * time.Millisecond)
+	secondHost := awaitDescriptor(t, dataDir, sessionID).PID
+	if secondHost != firstHost {
+		t.Cleanup(func() { _ = syscall.Kill(-secondHost, syscall.SIGKILL) })
+	}
+
+	cancel()
+	for i := 0; i < 2; i++ {
+		select {
+		case tr := <-results:
+			_ = tr.Stdin.Close()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	b, readErr := os.ReadFile(startLog)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		t.Fatal(readErr)
+	}
+	starts := strings.Fields(string(b))
+	if firstHost != secondHost || len(starts) != 1 {
+		t.Fatalf("stale cleanup launched rival hosts: host_pids=%d,%d provider_starts=%v", firstHost, secondHost, starts)
+	}
+}

--- a/backend/internal/adapters/chatdriver/persistenthost/host_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMain(m *testing.M) {
 	if len(os.Args) >= 6 && os.Args[1] == "chat-host" && os.Args[5] == "--" {
-		err := Run(Config{
+		err := Run(context.Background(), Config{
 			SessionID: os.Args[2], DataDir: os.Args[3], Workdir: os.Args[4],
 			Env: os.Environ(), Argv: os.Args[6:],
 		})
@@ -70,7 +70,7 @@ func TestHostReconnectsSameProviderAndReplaysDetachedOutput(t *testing.T) {
 		Argv:      []string{os.Args[0], "-test.run=TestProviderHelper"},
 	}
 	hostDone := make(chan error, 1)
-	go func() { hostDone <- Run(cfg) }()
+	go func() { hostDone <- Run(context.Background(), cfg) }()
 
 	d := awaitDescriptor(t, dataDir, cfg.SessionID)
 	first, err := attach(context.Background(), d, false)
@@ -182,7 +182,7 @@ func TestHostReplaysUnansweredServerRequestAfterDetach(t *testing.T) {
 		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
 		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
 	done := make(chan error, 1)
-	go func() { done <- Run(cfg) }()
+	go func() { done <- Run(context.Background(), cfg) }()
 	d := awaitDescriptor(t, dataDir, cfg.SessionID)
 	first, err := attach(context.Background(), d, false)
 	if err != nil {
@@ -227,7 +227,7 @@ func TestAttachRejectsBadCapabilityAndVersion(t *testing.T) {
 		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
 		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
 	done := make(chan error, 1)
-	go func() { done <- Run(cfg) }()
+	go func() { done <- Run(context.Background(), cfg) }()
 	d := awaitDescriptor(t, dataDir, cfg.SessionID)
 	bad := d
 	bad.Token = "wrong"
@@ -253,7 +253,7 @@ func TestReconcileKeepsDurableSessionAndStopsOrphan(t *testing.T) {
 		cfg := Config{SessionID: sessionID, DataDir: dataDir, Workdir: workdir,
 			Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
 			Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
-		go func() { done <- Run(cfg) }()
+		go func() { done <- Run(context.Background(), cfg) }()
 		_ = awaitDescriptor(t, dataDir, sessionID)
 		return done
 	}
@@ -290,9 +290,9 @@ func TestHostLaunchLockFencesConcurrentProvider(t *testing.T) {
 		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
 		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
 	firstDone := make(chan error, 1)
-	go func() { firstDone <- Run(cfg) }()
+	go func() { firstDone <- Run(context.Background(), cfg) }()
 	d := awaitDescriptor(t, dataDir, cfg.SessionID)
-	if err := Run(cfg); !errors.Is(err, ErrHostExists) {
+	if err := Run(context.Background(), cfg); !errors.Is(err, ErrHostExists) {
 		t.Fatalf("second Run error = %v, want ErrHostExists", err)
 	}
 	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
@@ -306,13 +306,38 @@ func TestHostLaunchLockFencesConcurrentProvider(t *testing.T) {
 	}
 }
 
+func TestAcquireHostLockReclaimsDeadOwner(t *testing.T) {
+	dataDir := t.TempDir()
+	sessionID := "stale-lock"
+	dir, err := hostDir(dataDir, sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path, err := lockPath(dataDir, sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("2147483647\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := acquireHostLock(dataDir, sessionID)
+	if err != nil {
+		t.Fatalf("acquire stale host lock: %v", err)
+	}
+	release()
+}
+
 func TestConnectOrStartWaitsForOldControllerToDetach(t *testing.T) {
 	dataDir := t.TempDir()
 	cfg := Config{SessionID: "overlap", DataDir: dataDir, Workdir: t.TempDir(),
 		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
 		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
 	done := make(chan error, 1)
-	go func() { done <- Run(cfg) }()
+	go func() { done <- Run(context.Background(), cfg) }()
 	d := awaitDescriptor(t, dataDir, cfg.SessionID)
 	old, err := attach(context.Background(), d, false)
 	if err != nil {

--- a/backend/internal/adapters/chatdriver/persistenthost/host_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"testing"
@@ -243,6 +244,132 @@ func TestAttachRejectsBadCapabilityAndVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	<-done
+}
+
+func TestAttachHonorsContextAfterDial(t *testing.T) {
+	address, accepted := silentHandshakePeer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, attachErr := attach(ctx, Descriptor{
+			Version: ProtocolVersion,
+			Address: address,
+			Token:   "token",
+		}, true)
+		result <- attachErr
+	}()
+
+	serverConn := awaitSilentHandshake(t, accepted)
+	defer func() { _ = serverConn.Close() }()
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("attach error = %v, want context canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		_ = serverConn.Close()
+		<-result
+		t.Fatal("attach ignored its context after connecting")
+	}
+}
+
+func TestShutdownHonorsContextAfterDial(t *testing.T) {
+	address, accepted := silentHandshakePeer(t)
+	dataDir := t.TempDir()
+	const sessionID = "silent-shutdown"
+	if err := writeDescriptor(dataDir, Descriptor{
+		Version:   ProtocolVersion,
+		SessionID: sessionID,
+		Address:   address,
+		Token:     "token",
+		PID:       os.Getpid(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- Shutdown(ctx, dataDir, sessionID) }()
+
+	serverConn := awaitSilentHandshake(t, accepted)
+	defer func() { _ = serverConn.Close() }()
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("shutdown error = %v, want context canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		_ = serverConn.Close()
+		<-result
+		t.Fatal("shutdown ignored its context after connecting")
+	}
+}
+
+func TestAttachedTransportOutlivesHandshakeContext(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := Config{SessionID: "context-detached", DataDir: dataDir, Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
+	done := make(chan error, 1)
+	go func() { done <- Run(context.Background(), cfg) }()
+	d := awaitDescriptor(t, dataDir, cfg.SessionID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	transport, err := attach(ctx, d, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if pid := requestProviderPID(t, transport, 1, "still-connected"); pid <= 0 {
+		t.Fatalf("provider pid after handshake cancellation = %d", pid)
+	}
+
+	_ = transport.Stdin.Close()
+	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type silentHandshake struct {
+	conn net.Conn
+	err  error
+}
+
+func silentHandshakePeer(t *testing.T) (string, <-chan silentHandshake) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan silentHandshake, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			_, acceptErr = bufio.NewReader(conn).ReadBytes('\n')
+		}
+		accepted <- silentHandshake{conn: conn, err: acceptErr}
+	}()
+	return listener.Addr().String(), accepted
+}
+
+func awaitSilentHandshake(t *testing.T, accepted <-chan silentHandshake) net.Conn {
+	t.Helper()
+	select {
+	case result := <-accepted:
+		if result.err != nil {
+			t.Fatalf("accept silent handshake: %v", result.err)
+		}
+		return result.conn
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for silent handshake")
+		return nil
+	}
 }
 
 func TestReconcileKeepsDurableSessionAndStopsOrphan(t *testing.T) {

--- a/backend/internal/adapters/chatdriver/persistenthost/host_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_test.go
@@ -274,6 +274,46 @@ func TestAttachHonorsContextAfterDial(t *testing.T) {
 	}
 }
 
+func TestConnectOrStartTimesOutSilentLiveHost(t *testing.T) {
+	address, accepted := silentHandshakePeer(t)
+	dataDir := t.TempDir()
+	const sessionID = "silent-connect"
+	if err := writeDescriptor(dataDir, Descriptor{
+		Version:   ProtocolVersion,
+		SessionID: sessionID,
+		Address:   address,
+		Token:     "token",
+		PID:       os.Getpid(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	workdir := t.TempDir()
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := ConnectOrStart(context.Background(), Config{
+			SessionID: sessionID,
+			DataDir:   dataDir,
+			Workdir:   workdir,
+			Argv:      []string{os.Args[0], "-test.run=TestProviderHelper"},
+		})
+		result <- err
+	}()
+
+	serverConn := awaitSilentHandshake(t, accepted)
+	defer func() { _ = serverConn.Close() }()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, ErrOwnershipInconclusive) {
+			t.Fatalf("connect error = %v, want deadline exceeded ownership-inconclusive error", err)
+		}
+	case <-time.After(2 * time.Second):
+		_ = serverConn.Close()
+		<-result
+		t.Fatal("connect to silent live host exceeded the handshake limit")
+	}
+}
+
 func TestShutdownHonorsContextAfterDial(t *testing.T) {
 	address, accepted := silentHandshakePeer(t)
 	dataDir := t.TempDir()
@@ -304,6 +344,37 @@ func TestShutdownHonorsContextAfterDial(t *testing.T) {
 		_ = serverConn.Close()
 		<-result
 		t.Fatal("shutdown ignored its context after connecting")
+	}
+}
+
+func TestShutdownTimesOutSilentLiveHost(t *testing.T) {
+	address, accepted := silentHandshakePeer(t)
+	dataDir := t.TempDir()
+	const sessionID = "silent-shutdown-timeout"
+	if err := writeDescriptor(dataDir, Descriptor{
+		Version:   ProtocolVersion,
+		SessionID: sessionID,
+		Address:   address,
+		Token:     "token",
+		PID:       os.Getpid(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result := make(chan error, 1)
+	go func() { result <- Shutdown(context.Background(), dataDir, sessionID) }()
+
+	serverConn := awaitSilentHandshake(t, accepted)
+	defer func() { _ = serverConn.Close() }()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("shutdown error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		_ = serverConn.Close()
+		<-result
+		t.Fatal("shutdown of silent live host exceeded the handshake limit")
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/persistenthost/host_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_test.go
@@ -1,0 +1,407 @@
+package persistenthost
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	if len(os.Args) >= 6 && os.Args[1] == "chat-host" && os.Args[5] == "--" {
+		err := Run(Config{
+			SessionID: os.Args[2], DataDir: os.Args[3], Workdir: os.Args[4],
+			Env: os.Environ(), Argv: os.Args[6:],
+		})
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestProviderHelper(t *testing.T) {
+	if os.Getenv("AO_CHAT_HOST_PROVIDER_HELPER") != "1" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var frame struct {
+			ID     int64  `json:"id"`
+			Method string `json:"method"`
+		}
+		if json.Unmarshal(scanner.Bytes(), &frame) != nil {
+			continue
+		}
+		if frame.Method == "emit-later" {
+			time.Sleep(50 * time.Millisecond)
+			_, _ = fmt.Fprintln(os.Stdout, `{"method":"turn/completed","params":{"turn":{"id":"survived"}}}`)
+			continue
+		}
+		if frame.Method == "request-approval" {
+			_, _ = fmt.Fprintln(os.Stdout, `{"id":700,"method":"item/commandExecution/requestApproval","params":{"turnId":"turn-live"}}`)
+			continue
+		}
+		if frame.Method == "" && frame.ID == 700 {
+			_, _ = fmt.Fprintln(os.Stdout, `{"method":"approval/received","params":{"turnId":"turn-live"}}`)
+			continue
+		}
+		_, _ = fmt.Fprintf(os.Stdout, `{"id":%d,"result":{"pid":%d}}`+"\n", frame.ID, os.Getpid())
+	}
+	os.Exit(0)
+}
+
+func TestHostReconnectsSameProviderAndReplaysDetachedOutput(t *testing.T) {
+	dataDir := t.TempDir()
+	workdir := t.TempDir()
+	cfg := Config{
+		SessionID: "project-7",
+		DataDir:   dataDir,
+		Workdir:   workdir,
+		Env:       append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv:      []string{os.Args[0], "-test.run=TestProviderHelper"},
+	}
+	hostDone := make(chan error, 1)
+	go func() { hostDone <- Run(cfg) }()
+
+	d := awaitDescriptor(t, dataDir, cfg.SessionID)
+	first, err := attach(context.Background(), d, false)
+	if err != nil {
+		t.Fatalf("first attach: %v", err)
+	}
+	if _, err := attach(context.Background(), d, true); !errors.Is(err, ErrAttached) {
+		t.Fatalf("concurrent attach error = %v, want ErrAttached", err)
+	}
+	pid := requestProviderPID(t, first, 7, "pid")
+	if _, err := fmt.Fprintln(first.Stdin, `{"id":8,"method":"emit-later"}`); err != nil {
+		t.Fatalf("send delayed frame: %v", err)
+	}
+	if err := first.Stdin.Close(); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+
+	var second *Transport
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		second, err = attach(context.Background(), d, true)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, ErrAttached) {
+			t.Fatalf("reattach: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if second == nil {
+		t.Fatal("host never released first controller")
+	}
+	if !second.Reconnected || second.NextRequestID != 8 {
+		t.Fatalf("reattach metadata = reconnected:%v next:%d", second.Reconnected, second.NextRequestID)
+	}
+
+	_ = second.Stdin.(interface{ SetReadDeadline(time.Time) error }).SetReadDeadline(time.Now().Add(3 * time.Second))
+	line, err := bufio.NewReader(second.Stdout).ReadBytes('\n')
+	if err != nil || !json.Valid(line) {
+		t.Fatalf("replayed output = %q err=%v", line, err)
+	}
+	var replay struct {
+		Method string `json:"method"`
+	}
+	_ = json.Unmarshal(line, &replay)
+	if replay.Method != "turn/completed" {
+		t.Fatalf("replayed method = %q", replay.Method)
+	}
+	if got := requestProviderPID(t, second, 9, "pid-again"); got != pid {
+		t.Fatalf("provider pid changed across daemon detach: %d -> %d", pid, got)
+	}
+	_ = second.Stdin.Close()
+	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	select {
+	case err := <-hostDone:
+		if err != nil {
+			t.Fatalf("host exit: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("host did not exit after explicit shutdown")
+	}
+}
+
+func TestConnectOrStartLaunchesDetachedHost(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := Config{
+		SessionID: "detached", DataDir: dataDir, Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"},
+	}
+	transport, err := ConnectOrStart(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ConnectOrStart: %v", err)
+	}
+	t.Cleanup(func() { _ = Shutdown(context.Background(), dataDir, cfg.SessionID) })
+	if transport.Reconnected {
+		t.Fatal("new detached host reported reconnect")
+	}
+	d, err := readDescriptor(dataDir, cfg.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.PID == os.Getpid() {
+		t.Fatalf("host pid = test pid %d; process was not detached", d.PID)
+	}
+	if pid := requestProviderPID(t, transport, 1, "pid"); pid == os.Getpid() || pid == d.PID {
+		t.Fatalf("provider pid %d was not a distinct child of detached host %d", pid, d.PID)
+	}
+	_ = transport.Stdin.Close()
+	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	path, _ := descriptorPath(dataDir, cfg.SessionID)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("detached host did not remove its descriptor after shutdown")
+}
+
+func TestHostReplaysUnansweredServerRequestAfterDetach(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := Config{SessionID: "approval", DataDir: dataDir, Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
+	done := make(chan error, 1)
+	go func() { done <- Run(cfg) }()
+	d := awaitDescriptor(t, dataDir, cfg.SessionID)
+	first, err := attach(context.Background(), d, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintln(first.Stdin, `{"id":5,"method":"request-approval"}`); err != nil {
+		t.Fatal(err)
+	}
+	firstReader := bufio.NewReader(first.Stdout)
+	line, err := firstReader.ReadBytes('\n')
+	if err != nil || !bytes.Contains(line, []byte(`"id":700`)) {
+		t.Fatalf("first server request = %q err=%v", line, err)
+	}
+	_ = first.Stdin.Close()
+
+	second := awaitAttach(t, d)
+	secondReader := bufio.NewReader(second.Stdout)
+	line, err = secondReader.ReadBytes('\n')
+	if err != nil || !bytes.Contains(line, []byte(`"id":700`)) {
+		t.Fatalf("replayed server request = %q err=%v", line, err)
+	}
+	if _, err := fmt.Fprintln(second.Stdin, `{"id":700,"result":{"decision":"accept"}}`); err != nil {
+		t.Fatal(err)
+	}
+	line, err = secondReader.ReadBytes('\n')
+	if err != nil || !bytes.Contains(line, []byte(`"method":"approval/received"`)) {
+		t.Fatalf("provider did not continue after replayed approval = %q err=%v", line, err)
+	}
+	_ = second.Stdin.Close()
+	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAttachRejectsBadCapabilityAndVersion(t *testing.T) {
+	dataDir := t.TempDir()
+	workdir := t.TempDir()
+	cfg := Config{SessionID: "project-8", DataDir: dataDir, Workdir: workdir,
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
+	done := make(chan error, 1)
+	go func() { done <- Run(cfg) }()
+	d := awaitDescriptor(t, dataDir, cfg.SessionID)
+	bad := d
+	bad.Token = "wrong"
+	if _, err := attach(context.Background(), bad, true); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("bad token error = %v", err)
+	}
+	bad = d
+	bad.Version++
+	if _, err := attach(context.Background(), bad, true); !errors.Is(err, ErrIncompatible) {
+		t.Fatalf("bad version error = %v", err)
+	}
+	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+}
+
+func TestReconcileKeepsDurableSessionAndStopsOrphan(t *testing.T) {
+	dataDir := t.TempDir()
+	workdir := t.TempDir()
+	start := func(sessionID string) <-chan error {
+		done := make(chan error, 1)
+		cfg := Config{SessionID: sessionID, DataDir: dataDir, Workdir: workdir,
+			Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+			Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
+		go func() { done <- Run(cfg) }()
+		_ = awaitDescriptor(t, dataDir, sessionID)
+		return done
+	}
+	keepDone := start("keep")
+	orphanDone := start("orphan")
+
+	if err := Reconcile(context.Background(), dataDir, map[string]struct{}{"keep": {}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	select {
+	case err := <-orphanDone:
+		if err != nil {
+			t.Fatalf("orphan host exit: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("orphan host survived reconciliation")
+	}
+
+	d := awaitDescriptor(t, dataDir, "keep")
+	transport, err := attach(context.Background(), d, true)
+	if err != nil {
+		t.Fatalf("kept host is not attachable: %v", err)
+	}
+	_ = transport.Stdin.Close()
+	if err := Shutdown(context.Background(), dataDir, "keep"); err != nil {
+		t.Fatalf("shutdown kept host: %v", err)
+	}
+	<-keepDone
+}
+
+func TestHostLaunchLockFencesConcurrentProvider(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := Config{SessionID: "fenced", DataDir: dataDir, Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- Run(cfg) }()
+	d := awaitDescriptor(t, dataDir, cfg.SessionID)
+	if err := Run(cfg); !errors.Is(err, ErrHostExists) {
+		t.Fatalf("second Run error = %v, want ErrHostExists", err)
+	}
+	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	if processalive := d.PID; processalive <= 0 {
+		t.Fatalf("host descriptor pid = %d", processalive)
+	}
+}
+
+func TestConnectOrStartWaitsForOldControllerToDetach(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := Config{SessionID: "overlap", DataDir: dataDir, Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
+	done := make(chan error, 1)
+	go func() { done <- Run(cfg) }()
+	d := awaitDescriptor(t, dataDir, cfg.SessionID)
+	old, err := attach(context.Background(), d, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connected := make(chan *Transport, 1)
+	connectErr := make(chan error, 1)
+	go func() {
+		transport, err := ConnectOrStart(context.Background(), cfg)
+		if err != nil {
+			connectErr <- err
+			return
+		}
+		connected <- transport
+	}()
+	select {
+	case <-connected:
+		t.Fatal("replacement attached while old controller still owned the host")
+	case err := <-connectErr:
+		t.Fatalf("replacement failed during expected overlap: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	_ = old.Stdin.Close()
+	var replacement *Transport
+	select {
+	case replacement = <-connected:
+	case err := <-connectErr:
+		t.Fatalf("replacement attach: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("replacement did not attach after old controller detached")
+	}
+	_ = replacement.Stdin.Close()
+	if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+}
+
+func awaitDescriptor(t *testing.T, dataDir, sessionID string) Descriptor {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		d, err := readDescriptor(dataDir, sessionID)
+		if err == nil {
+			return d
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("chat host descriptor not published")
+	return Descriptor{}
+}
+
+func awaitAttach(t *testing.T, d Descriptor) *Transport {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		transport, err := attach(context.Background(), d, true)
+		if err == nil {
+			return transport
+		}
+		if !errors.Is(err, ErrAttached) {
+			t.Fatalf("attach: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("host never released detached controller")
+	return nil
+}
+
+func requestProviderPID(t *testing.T, transport *Transport, id int64, method string) int {
+	t.Helper()
+	if _, err := fmt.Fprintf(transport.Stdin, `{"id":%d,"method":%q}`+"\n", id, method); err != nil {
+		t.Fatalf("provider request: %v", err)
+	}
+	line, err := bufio.NewReader(transport.Stdout).ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("provider response: %v", err)
+	}
+	var response struct {
+		ID     int64 `json:"id"`
+		Result struct {
+			PID int `json:"pid"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(line, &response); err != nil {
+		t.Fatalf("decode provider response %q: %v", line, err)
+	}
+	if response.ID != id || response.Result.PID <= 0 {
+		t.Fatalf("provider response = id:%d pid:%s", response.ID, strconv.Itoa(response.Result.PID))
+	}
+	return response.Result.PID
+}

--- a/backend/internal/adapters/chatdriver/persistenthost/spawn_unix.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/spawn_unix.go
@@ -3,13 +3,17 @@
 package persistenthost
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
 )
 
-func spawnDetached(cfg Config) error {
+func spawnDetached(ctx context.Context, cfg Config) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	exe, err := os.Executable()
 	if err != nil {
 		return err

--- a/backend/internal/adapters/chatdriver/persistenthost/spawn_unix.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/spawn_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package persistenthost
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func spawnDetached(cfg Config) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	args := make([]string, 0, 5+len(cfg.Argv))
+	args = append(args, "chat-host", cfg.SessionID, cfg.DataDir, cfg.Workdir, "--")
+	args = append(args, cfg.Argv...)
+	cmd := exec.Command(exe, args...)
+	cmd.Dir = cfg.Workdir
+	cmd.Env = cfg.Env
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("spawn detached chat host: %w", err)
+	}
+	return cmd.Process.Release()
+}

--- a/backend/internal/adapters/chatdriver/persistenthost/spawn_windows.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/spawn_windows.go
@@ -3,6 +3,7 @@
 package persistenthost
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +11,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func spawnDetached(cfg Config) error {
+func spawnDetached(ctx context.Context, cfg Config) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	exe, err := os.Executable()
 	if err != nil {
 		return err

--- a/backend/internal/adapters/chatdriver/persistenthost/spawn_windows.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/spawn_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package persistenthost
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"golang.org/x/sys/windows"
+)
+
+func spawnDetached(cfg Config) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	args := make([]string, 0, 5+len(cfg.Argv))
+	args = append(args, "chat-host", cfg.SessionID, cfg.DataDir, cfg.Workdir, "--")
+	args = append(args, cfg.Argv...)
+	cmd := exec.Command(exe, args...)
+	cmd.Dir = cfg.Workdir
+	cmd.Env = cfg.Env
+	cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP, HideWindow: true}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("spawn detached chat host: %w", err)
+	}
+	return cmd.Process.Release()
+}

--- a/backend/internal/cli/chat_host.go
+++ b/backend/internal/cli/chat_host.go
@@ -16,11 +16,11 @@ func newChatHostCommand() *cobra.Command {
 		Short:              "Run a persistent Chat provider host (internal)",
 		Hidden:             true,
 		DisableFlagParsing: true,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 5 || args[3] != "--" {
-				return errors.New("chat-host requires <session> <data-dir> <workdir> -- <provider> [args...]")
+				return usageError{errors.New("chat-host requires <session> <data-dir> <workdir> -- <provider> [args...]")}
 			}
-			return persistenthost.Run(persistenthost.Config{
+			return persistenthost.Run(cmd.Context(), persistenthost.Config{
 				SessionID: strings.TrimSpace(args[0]),
 				DataDir:   args[1],
 				Workdir:   args[2],

--- a/backend/internal/cli/chat_host.go
+++ b/backend/internal/cli/chat_host.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/persistenthost"
+)
+
+func newChatHostCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:                "chat-host",
+		Short:              "Run a persistent Chat provider host (internal)",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) < 5 || args[3] != "--" {
+				return errors.New("chat-host requires <session> <data-dir> <workdir> -- <provider> [args...]")
+			}
+			return persistenthost.Run(persistenthost.Config{
+				SessionID: strings.TrimSpace(args[0]),
+				DataDir:   args[1],
+				Workdir:   args[2],
+				Env:       os.Environ(),
+				Argv:      args[4:],
+			})
+		},
+	}
+}

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -199,6 +199,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	root.AddCommand(newBrowserCommand(ctx))
 	root.AddCommand(newHooksCommand(ctx))
 	root.AddCommand(newAgentProcessCommand(ctx))
+	root.AddCommand(newChatHostCommand())
 	root.AddCommand(newLaunchCommand(ctx))
 	root.AddCommand(newPtyHostCommand())
 	root.AddCommand(newImportCommand(ctx))
@@ -228,7 +229,7 @@ func shouldEmitCLIInvocation(cmd *cobra.Command) bool {
 	// "ao completion"/"ao help" are shell setup and self-documentation.
 	// "ao pty-host" and "ao agent-process" are internal runtime processes.
 	// None reflect user activity.
-	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host", "ao agent-process", "ao agent-process supervise":
+	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host", "ao chat-host", "ao agent-process", "ao agent-process supervise":
 		return false
 	default:
 		return true

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -70,6 +70,25 @@ func TestCommandsRejectUnexpectedArgs(t *testing.T) {
 	}
 }
 
+func TestChatHostRejectsMalformedInternalArgumentsAsUsage(t *testing.T) {
+	setConfigEnv(t)
+	for _, args := range [][]string{
+		{"chat-host"},
+		{"chat-host", "session", "/tmp/data", "/tmp/work", "provider"},
+		{"chat-host", "session", "/tmp/data", "/tmp/work", "not-a-separator", "provider"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			_, _, err := executeCLI(t, Deps{}, args...)
+			if err == nil {
+				t.Fatal("expected usage error")
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Fatalf("ExitCode(%v) = %d, want 2", err, got)
+			}
+		})
+	}
+}
+
 func TestVersionEmitsCLIInvocationBestEffort(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "")
 	cfg := setConfigEnv(t)

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -155,6 +155,7 @@ func TestTelemetryMetaClassifiesRegisteredCommandPaths(t *testing.T) {
 	systemCommands := map[string]struct{}{
 		"ao agent-process":           {},
 		"ao agent-process supervise": {},
+		"ao chat-host":               {},
 		"ao completion":              {},
 		"ao daemon":                  {},
 		"ao help":                    {},

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -576,6 +576,9 @@ func Run() error {
 		startupReconcileDone = done
 		go func() {
 			defer close(done)
+			if reconcileErr := reconcilePersistentChatHosts(ctx, cfg.DataDir, store); reconcileErr != nil {
+				log.Error("persistent chat host reconciliation on boot failed", "err", reconcileErr)
+			}
 			if reconcileErr := sessMgr.ReconcileBackground(ctx); reconcileErr != nil {
 				log.Error("background session reconciliation on boot failed", "err", reconcileErr)
 			}
@@ -606,9 +609,11 @@ func Run() error {
 	switchCancel()
 	managedPreview.Close()
 	<-previewDone
-	// Close chat controllers before the lifecycle stack: each owns an app-server
-	// child process, and closing them also settles any turn left in flight so a
-	// restart does not read a half-finished turn as still working.
+	// Detach chat controllers before stopping the lifecycle stack. Persistent
+	// provider hosts deliberately survive this daemon and preserve in-flight
+	// turns; the replacement daemon reconnects to the same initialized stream and
+	// consumes host-replayed output. Explicit session termination, not daemon
+	// shutdown, destroys them.
 	chatStopCtx, chatCancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
 	chatSvc.StopAll(chatStopCtx)
 	chatCancel()

--- a/backend/internal/daemon/persistent_chat_wiring.go
+++ b/backend/internal/daemon/persistent_chat_wiring.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/persistenthost"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type persistentChatSessionStore interface {
+	ListAllSessions(context.Context) ([]domain.SessionRecord, error)
+}
+
+// reconcilePersistentChatHosts removes hosts only when durable state proves
+// there is no live Codex Chat session to adopt. An unreadable session set is not
+// evidence that any host is orphaned.
+func reconcilePersistentChatHosts(ctx context.Context, dataDir string, store persistentChatSessionStore) error {
+	records, err := store.ListAllSessions(ctx)
+	if err != nil {
+		return fmt.Errorf("list sessions for persistent chat hosts: %w", err)
+	}
+	return persistenthost.Reconcile(ctx, dataDir, persistentChatHostKeepSet(records))
+}
+
+func persistentChatHostKeepSet(records []domain.SessionRecord) map[string]struct{} {
+	keep := make(map[string]struct{})
+	for _, rec := range records {
+		if rec.IsTerminated || domain.NormalizeSessionMode(rec.Mode) != domain.SessionModeChat || rec.Harness != domain.HarnessCodex {
+			continue
+		}
+		keep[string(rec.ID)] = struct{}{}
+	}
+	return keep
+}

--- a/backend/internal/daemon/persistent_chat_wiring_test.go
+++ b/backend/internal/daemon/persistent_chat_wiring_test.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestPersistentChatHostKeepSetUsesDurableOwnership(t *testing.T) {
+	records := []domain.SessionRecord{
+		{ID: "live-chat", Mode: domain.SessionModeChat, Harness: domain.HarnessCodex},
+		{ID: "terminated-chat", Mode: domain.SessionModeChat, Harness: domain.HarnessCodex, IsTerminated: true},
+		{ID: "tui", Mode: domain.SessionModeTUI, Harness: domain.HarnessCodex},
+		{ID: "other-provider", Mode: domain.SessionModeChat, Harness: domain.HarnessClaudeCode},
+	}
+	keep := persistentChatHostKeepSet(records)
+	if len(keep) != 1 {
+		t.Fatalf("keep = %v, want only live-chat", keep)
+	}
+	if _, ok := keep["live-chat"]; !ok {
+		t.Fatalf("keep = %v, missing live-chat", keep)
+	}
+}

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -38,6 +38,11 @@ var (
 	// resumed. Callers must surface a recovery choice, never silently start a
 	// new provider conversation.
 	ErrChatResumeFailed = errors.New("chat conversation resume failed")
+	// ErrChatRecoveryInconclusive means a detached provider host may still own
+	// live work, but this daemon could not safely attach to it. Startup recovery
+	// must preserve the durable session and worktree rather than treating the
+	// failed attachment as proof that the provider died.
+	ErrChatRecoveryInconclusive = errors.New("chat conversation recovery is inconclusive")
 	// ErrChatNoActiveTurn means an interrupt found nothing to cancel — either AO
 	// has no turn in flight, or the provider no longer considers the named turn
 	// active. A driver must translate its provider's refusal into this rather than
@@ -922,6 +927,24 @@ type ChatConversation interface {
 	Events() <-chan ChatEvent
 	// Close releases the controller. It does not delete provider-side history.
 	Close() error
+}
+
+// ChatProviderPreserver is optionally implemented when Close only detaches the
+// daemon-side controller and deliberately leaves provider work alive.
+type ChatProviderPreserver interface {
+	PreservesProviderOnClose() bool
+}
+
+// ChatProviderTerminator is optionally implemented when explicit session
+// destruction must do more than detach the controller.
+type ChatProviderTerminator interface {
+	Terminate() error
+}
+
+// ChatLiveReconnector identifies attachment to the same initialized provider
+// process, as distinct from native resume in a replacement process.
+type ChatLiveReconnector interface {
+	ReconnectedLive() bool
 }
 
 // ChatHistoryReader is optionally implemented by a conversation whose native

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -232,6 +232,12 @@ type ChatStartConfig struct {
 	// MCPServers are client-supplied tool servers for this provider conversation.
 	// User/provider configuration still loads normally; these are additive.
 	MCPServers []ChatMCPServerConfig
+	// AllowConcurrentHostReplacement is set only by the idle branch-handoff
+	// coordinator, which deliberately stages a replacement before destroying the
+	// source. Ordinary startup/reconciliation must leave this false so a second
+	// daemon can never mistake an attached persistent host for permission to
+	// launch a competing provider.
+	AllowConcurrentHostReplacement bool
 }
 
 // ChatResumeConfig reattaches to a provider conversation after a restart.
@@ -252,6 +258,8 @@ type ChatResumeConfig struct {
 	ProviderScopeID       string
 	AdditionalDirectories []string
 	MCPServers            []ChatMCPServerConfig
+	// See ChatStartConfig.AllowConcurrentHostReplacement.
+	AllowConcurrentHostReplacement bool
 }
 
 // ChatMCPServerConfig is the provider-neutral session-setup shape for a tool

--- a/backend/internal/service/chat/branch_persistent_test.go
+++ b/backend/internal/service/chat/branch_persistent_test.go
@@ -1,0 +1,55 @@
+package chat
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type persistentBranchConversation struct {
+	stopped    chan struct{}
+	closed     atomic.Bool
+	terminated atomic.Bool
+}
+
+func (c *persistentBranchConversation) ProviderConversationID() string { return "thread-branch" }
+func (c *persistentBranchConversation) Capabilities() ports.ChatCapabilities {
+	return nil
+}
+func (c *persistentBranchConversation) SendTurn(context.Context, ports.ChatUserMessage) (ports.ChatTurnRef, error) {
+	return ports.ChatTurnRef{}, nil
+}
+func (c *persistentBranchConversation) Interrupt(context.Context, string) error { return nil }
+func (c *persistentBranchConversation) ResolveRequest(context.Context, string, ports.ChatDecision) error {
+	return nil
+}
+func (c *persistentBranchConversation) Events() <-chan ports.ChatEvent { return nil }
+func (c *persistentBranchConversation) Close() error {
+	c.closed.Store(true)
+	close(c.stopped)
+	return nil
+}
+func (c *persistentBranchConversation) PreservesProviderOnClose() bool { return true }
+func (c *persistentBranchConversation) Terminate() error {
+	c.terminated.Store(true)
+	close(c.stopped)
+	return nil
+}
+
+func TestBranchHandoffTerminatesPersistentProvider(t *testing.T) {
+	stopped := make(chan struct{})
+	provider := &persistentBranchConversation{stopped: stopped}
+	controller := &Controller{conv: provider, stopped: stopped}
+
+	if err := controller.closeForBranchHandoff(context.Background()); err != nil {
+		t.Fatalf("closeForBranchHandoff: %v", err)
+	}
+	if !provider.terminated.Load() {
+		t.Fatal("branch handoff detached the persistent provider instead of releasing its host")
+	}
+	if provider.closed.Load() {
+		t.Fatal("branch handoff used ordinary daemon-detach semantics")
+	}
+}

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -10,8 +10,8 @@
 //     never disagree with the timeline derived from it;
 //   - an event carrying a stale controller generation is dropped, so a controller
 //     that is dying cannot mutate the session that replaced it;
-//   - a turn left in flight when a controller ends settles as failed, because a
-//     controller that stopped running a turn is not evidence the work finished.
+//   - a turn left in flight when its provider ends settles as failed. Deliberate
+//     daemon detach from a persistent provider is not provider termination.
 package chat
 
 import (
@@ -202,6 +202,10 @@ type Controller struct {
 	// started until this controller reports quiescent and is closed.
 	handoff           controllerHandoff
 	branchHandoffDone chan struct{}
+	// preserveProviderOnStop is set before deliberate daemon detach. It prevents
+	// the closing controller from projecting a false provider exit or failing work
+	// that the detached host continues to run.
+	preserveProviderOnStop bool
 
 	// account, threadState and mcpServers are merged here before being written,
 	// because the provider reports each of them in pieces: account/updated carries
@@ -1986,12 +1990,17 @@ func (c *Controller) Rollback(ctx context.Context, turnID string) (int, error) {
 	return discarded, nil
 }
 
-// Close releases the controller. Settling in-flight work is not done here: it
-// happens when the event stream ends, which covers a provider that died on its
-// own as well as a shutdown AO initiated. Close only has to make the stream end
-// and wait for that to finish.
+// Close detaches this daemon's controller. Persistent provider hosts keep the
+// native connection and any in-flight turn alive; non-persistent drivers retain
+// their historical process-close behavior. The persistent host replays detached
+// output and unresolved provider requests to the replacement controller.
 func (c *Controller) Close(ctx context.Context) error {
 	c.once.Do(func() {
+		if preserver, ok := c.conv.(interface{ PreservesProviderOnClose() bool }); ok && preserver.PreservesProviderOnClose() {
+			c.mu.Lock()
+			c.preserveProviderOnStop = true
+			c.mu.Unlock()
+		}
 		c.closeErr = c.conv.Close()
 	})
 	select {
@@ -2005,12 +2014,35 @@ func (c *Controller) Close(ctx context.Context) error {
 	}
 }
 
-// closeForBranchHandoff retires a source controller without publishing a
-// session-level exit. Branch replacement is an in-place writer handoff, not the
-// end of the session; the replacement generation continues the lifecycle.
+// Terminate closes the controller and explicitly destroys a persistent provider
+// host. Daemon shutdown uses Close so the host survives; user/session teardown
+// and controller replacement use Terminate.
+func (c *Controller) Terminate(ctx context.Context) error {
+	c.once.Do(func() {
+		if terminator, ok := c.conv.(interface{ Terminate() error }); ok {
+			c.closeErr = terminator.Terminate()
+		} else {
+			c.closeErr = c.conv.Close()
+		}
+	})
+	select {
+	case <-c.stopped:
+		return c.closeErr
+	case <-ctx.Done():
+		if c.closeErr != nil {
+			return errors.Join(c.closeErr, ctx.Err())
+		}
+		return ctx.Err()
+	}
+}
+
+// closeForBranchHandoff retires and terminates a source controller without
+// publishing a session-level exit. Branch replacement is an in-place writer
+// handoff, not the end of the session; the replacement generation continues the
+// lifecycle, but the old persistent host must release exclusive ownership.
 func (c *Controller) closeForBranchHandoff(ctx context.Context) error {
 	c.prepareBranchHandoffStop()
-	return c.Close(ctx)
+	return c.Terminate(ctx)
 }
 
 func (c *Controller) prepareBranchHandoffStop() {
@@ -2038,7 +2070,8 @@ func (c *Controller) reportFailedBranchHandoff(ctx context.Context) {
 func (c *Controller) Wait() { <-c.stopped }
 
 // project consumes the driver's normalized events and writes them down. It runs
-// until the driver's stream closes, which happens when the provider process ends.
+// until this controller's stream closes. That can mean provider termination or a
+// deliberate detach from a provider that remains alive in a persistent host.
 func (c *Controller) project() {
 	defer close(c.stopped)
 
@@ -2047,6 +2080,12 @@ func (c *Controller) project() {
 	ctx := context.WithoutCancel(context.Background())
 
 	for event := range c.conv.Events() {
+		c.mu.Lock()
+		preserveProvider := c.preserveProviderOnStop
+		c.mu.Unlock()
+		if preserveProvider && event.Kind == ports.ChatEventControllerState && event.ControllerState == ports.ChatControllerStopped {
+			continue
+		}
 		// A lifecycle event and a concurrent Send must agree on whether the root
 		// conversation is busy. Holding the same lock Send/dispatch use closes the
 		// window between the durable projection and the in-memory ownership update.
@@ -2072,7 +2111,11 @@ func (c *Controller) project() {
 	c.mu.Lock()
 	c.state = ports.ChatControllerStopped
 	suppressStoppedActivity := c.suppressStoppedActivity
+	preserveProvider := c.preserveProviderOnStop
 	c.mu.Unlock()
+	if preserveProvider {
+		return
+	}
 
 	// The stream has ended, so nothing more can arrive for this controller. This
 	// is the only place that reliably knows that — a provider process can die on

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -312,6 +312,29 @@ func newController(
 	return c
 }
 
+// restoreLiveTurnOwnership rebuilds the volatile busy gate from durable facts
+// before a replacement daemon publishes a reconnected controller. The provider
+// kept running while AO was detached, so forgetting this turn would let a new
+// Send start a second root turn on the same native conversation.
+func (c *Controller) restoreLiveTurnOwnership(turns []domain.ConversationTurn) {
+	var latest *domain.ConversationTurn
+	for i := range turns {
+		turn := &turns[i]
+		if turn.State != domain.TurnStateRunning || turn.ProviderTurnID == "" || turn.RolledBackAt != nil {
+			continue
+		}
+		if latest == nil || turn.RequestedAt.After(latest.RequestedAt) {
+			latest = turn
+		}
+	}
+	if latest == nil {
+		return
+	}
+	c.pendingTurnID = latest.ProviderTurnID
+	c.ackedTurnID = latest.ProviderTurnID
+	c.state = ports.ChatControllerBusy
+}
+
 // start begins live provider consumption after any durable native history has
 // been imported. Keeping construction and consumption separate prevents a resume
 // notification from racing ahead of the older turns it follows.
@@ -1996,7 +2019,7 @@ func (c *Controller) Rollback(ctx context.Context, turnID string) (int, error) {
 // output and unresolved provider requests to the replacement controller.
 func (c *Controller) Close(ctx context.Context) error {
 	c.once.Do(func() {
-		if preserver, ok := c.conv.(interface{ PreservesProviderOnClose() bool }); ok && preserver.PreservesProviderOnClose() {
+		if preserver, ok := c.conv.(ports.ChatProviderPreserver); ok && preserver.PreservesProviderOnClose() {
 			c.mu.Lock()
 			c.preserveProviderOnStop = true
 			c.mu.Unlock()
@@ -2019,7 +2042,7 @@ func (c *Controller) Close(ctx context.Context) error {
 // and controller replacement use Terminate.
 func (c *Controller) Terminate(ctx context.Context) error {
 	c.once.Do(func() {
-		if terminator, ok := c.conv.(interface{ Terminate() error }); ok {
+		if terminator, ok := c.conv.(ports.ChatProviderTerminator); ok {
 			c.closeErr = terminator.Terminate()
 		} else {
 			c.closeErr = c.conv.Close()

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -58,6 +58,20 @@ func openStore(t *testing.T) *sqlite.Store {
 	return st
 }
 
+func fullSnapshotReader(st *sqlite.Store) chatsvc.SnapshotReader {
+	return chatsvc.SnapshotReaderFunc(func(ctx context.Context, conversationID string) (chatsvc.ConversationRows, error) {
+		rows, err := st.LoadConversationSnapshot(ctx, conversationID)
+		if err != nil {
+			return chatsvc.ConversationRows{}, err
+		}
+		return chatsvc.ConversationRows{
+			Conversation: rows.Conversation, Turns: rows.Turns,
+			Messages: rows.Messages, Activities: rows.Activities,
+			BranchPoints: rows.BranchPoints, BranchedFromEarlierMessage: rows.BranchedFromEarlierMessage,
+		}, nil
+	})
+}
+
 /* ---- a fake conversation the controller can drive ---------------------- */
 
 type fakeConversation struct {
@@ -3623,7 +3637,7 @@ func TestServiceLiveReconnectSkipsSettledHistoryBarrier(t *testing.T) {
 	native := &nativeHistoryConversation{fakeConversation: newFakeConversation(), err: ports.ErrChatHistoryUnsettled}
 	provider := &liveReconnectedConversation{nativeHistoryConversation: native}
 	svc := chatsvc.New(chatsvc.Options{
-		Store: st, Sessions: st, Drivers: fakeRegistry{driver: fakeDriver{conv: provider}},
+		Store: st, Reader: fullSnapshotReader(st), Sessions: st, Drivers: fakeRegistry{driver: fakeDriver{conv: provider}},
 		Log: slog.New(slog.DiscardHandler), NewID: func() string { return "live-reconnect-id" },
 	})
 	if _, err := svc.Start(context.Background(), chatsvc.StartConfig{
@@ -3635,6 +3649,71 @@ func TestServiceLiveReconnectSkipsSettledHistoryBarrier(t *testing.T) {
 	defer svc.StopAll(context.Background())
 	if reads := native.historyReads(); reads != 0 {
 		t.Fatalf("native history reads = %d, live reconnect must not wait for active turn to settle", reads)
+	}
+}
+
+func TestServiceLiveReconnectKeepsDurableRunningTurnBusy(t *testing.T) {
+	st := openStore(t)
+	reader := fullSnapshotReader(st)
+	var ids atomic.Int32
+	newID := func() string { return fmt.Sprintf("reconnect-%d", ids.Add(1)) }
+	firstProvider := &terminatingConversation{fakeConversation: newFakeConversation()}
+	first := chatsvc.New(chatsvc.Options{
+		Store: st, Reader: reader, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{conv: firstProvider}},
+		Log:     slog.New(slog.DiscardHandler), NewID: newID,
+	})
+	firstController, err := first.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	turn, err := firstController.Send(context.Background(), ports.ChatUserMessage{Text: "keep working"})
+	if err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	firstProvider.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnStarted, ProviderTurnID: turn.ProviderTurnID,
+		ProviderConversationID: firstProvider.ProviderConversationID(),
+	})
+	h := &harness{st: st, ctrl: firstController}
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, candidate := range s.Turns {
+			if candidate.ID == turn.ID {
+				return candidate.State == domain.TurnStateRunning
+			}
+		}
+		return false
+	})
+	first.StopAll(context.Background())
+
+	secondProvider := &liveReconnectedConversation{nativeHistoryConversation: &nativeHistoryConversation{
+		fakeConversation: newFakeConversation(),
+	}}
+	second := chatsvc.New(chatsvc.Options{
+		Store: st, Reader: reader, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{conv: secondProvider}},
+		Log:     slog.New(slog.DiscardHandler), NewID: newID,
+	})
+	t.Cleanup(func() { second.StopAll(context.Background()) })
+	secondController, err := second.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: firstProvider.ProviderConversationID(),
+	})
+	if err != nil {
+		t.Fatalf("reconnect Start: %v", err)
+	}
+	queued, err := secondController.Send(context.Background(), ports.ChatUserMessage{Text: "after restart"})
+	if err != nil {
+		t.Fatalf("reconnect Send: %v", err)
+	}
+	if queued.State != domain.TurnStateQueued {
+		t.Fatalf("reconnect Send state = %s, want queued behind surviving turn", queued.State)
+	}
+	if got := secondProvider.sentTexts(); len(got) != 0 {
+		t.Fatalf("reconnected provider received concurrent turns: %v", got)
 	}
 }
 

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -172,6 +172,22 @@ type stuckConversation struct {
 
 func (s *stuckConversation) Close() error { return s.closeErr }
 
+type terminatingConversation struct {
+	*fakeConversation
+	terminated atomic.Bool
+}
+
+func (c *terminatingConversation) Terminate() error {
+	c.terminated.Store(true)
+	return c.Close()
+}
+
+func (c *terminatingConversation) PreservesProviderOnClose() bool { return true }
+
+type liveReconnectedConversation struct{ *nativeHistoryConversation }
+
+func (c *liveReconnectedConversation) ReconnectedLive() bool { return true }
+
 func (f *deferredConversation) StartDeferredTurn(providerTurnID string) error {
 	return f.start(providerTurnID)
 }
@@ -3548,6 +3564,78 @@ func TestServiceStopRetainsControllerUntilItsEventStreamActuallyEnds(t *testing.
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("controller registry did not release the stopped stream")
+}
+
+func TestServiceStopTerminatesPersistentConversation(t *testing.T) {
+	provider := &terminatingConversation{fakeConversation: newFakeConversation()}
+	h := newHarnessWithConversation(t, provider)
+	if err := h.svc.Stop(context.Background(), testSession); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if !provider.terminated.Load() {
+		t.Fatal("explicit session stop detached persistent conversation instead of terminating it")
+	}
+}
+
+func TestServiceStopAllOnlyDetachesPersistentConversation(t *testing.T) {
+	provider := &terminatingConversation{fakeConversation: newFakeConversation()}
+	h := newHarnessWithConversation(t, provider)
+	turn, err := h.ctrl.Send(context.Background(), ports.ChatUserMessage{Text: "keep working"})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	provider.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnStarted, ProviderTurnID: turn.ProviderTurnID,
+		ProviderConversationID: provider.ProviderConversationID(),
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, candidate := range s.Turns {
+			if candidate.ID == turn.ID {
+				return candidate.State == domain.TurnStateRunning
+			}
+		}
+		return false
+	})
+	h.svc.StopAll(context.Background())
+	if provider.terminated.Load() {
+		t.Fatal("daemon-wide shutdown terminated persistent conversation")
+	}
+	rec, found, err := h.st.GetSession(context.Background(), testSession)
+	if err != nil || !found {
+		t.Fatalf("GetSession: found=%v err=%v", found, err)
+	}
+	if rec.Activity.State == domain.ActivityExited {
+		t.Fatal("daemon detach projected a false provider exit")
+	}
+	snapshot, err := h.st.LoadConversationSnapshot(context.Background(), h.ctrl.ConversationID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range snapshot.Turns {
+		if candidate.ID == turn.ID && candidate.State != domain.TurnStateRunning {
+			t.Fatalf("in-flight turn settled on daemon detach: %s", candidate.State)
+		}
+	}
+}
+
+func TestServiceLiveReconnectSkipsSettledHistoryBarrier(t *testing.T) {
+	st := openStore(t)
+	native := &nativeHistoryConversation{fakeConversation: newFakeConversation(), err: ports.ErrChatHistoryUnsettled}
+	provider := &liveReconnectedConversation{nativeHistoryConversation: native}
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st, Drivers: fakeRegistry{driver: fakeDriver{conv: provider}},
+		Log: slog.New(slog.DiscardHandler), NewID: func() string { return "live-reconnect-id" },
+	})
+	if _, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: "thread-1",
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.StopAll(context.Background())
+	if reads := native.historyReads(); reads != 0 {
+		t.Fatalf("native history reads = %d, live reconnect must not wait for active turn to settle", reads)
+	}
 }
 
 func TestStartWaitsForStoppedControllerCleanupBeforeRelaunch(t *testing.T) {

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -680,7 +680,7 @@ func (s *Service) activateBranchLocked(ctx context.Context, id domain.SessionID,
 	replacement := newController(id, conversation, generation, provider, s.store, s.activity, s.log, s.newID, s.now)
 	if err := s.store.ActivateConversationBranch(operationCtx, id, conversation.ID, branch.ID,
 		branch.ProviderConversationID, generation, s.now()); err != nil {
-		_ = provider.Close()
+		cleanupUnpublishedConversation(provider, true)
 		activateErr := err
 		if restoreErr := s.restoreClosedSourceController(
 			operationCtx, id, source, activeBranch, cfg, driver); restoreErr != nil {
@@ -809,7 +809,7 @@ func (s *Service) installStartedBranchController(
 	s.mu.Lock()
 	if s.controllers[id] != source {
 		s.mu.Unlock()
-		_ = replacement.Close(ctx)
+		_ = replacement.Terminate(ctx)
 		if err := s.store.ActivateConversationBranch(ctx, id, source.conversation.ID,
 			sourceBranchID, source.ProviderConversationID(), source.generation, s.now()); err != nil {
 			return fmt.Errorf("restore source branch after controller swap conflict: %w", err)

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -466,8 +466,20 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 		)
 	}
 	liveReconnect := false
-	if reconnected, ok := conv.(interface{ ReconnectedLive() bool }); ok {
+	if reconnected, ok := conv.(ports.ChatLiveReconnector); ok {
 		liveReconnect = reconnected.ReconnectedLive()
+	}
+	var liveRows ConversationRows
+	if liveReconnect {
+		if s.reader == nil {
+			cleanupUnpublishedConversation(conv, false)
+			return nil, fmt.Errorf("%w: durable conversation snapshot is unavailable", ports.ErrChatRecoveryInconclusive)
+		}
+		liveRows, err = s.reader.LoadConversationSnapshot(ctx, conversation.ID)
+		if err != nil {
+			cleanupUnpublishedConversation(conv, false)
+			return nil, fmt.Errorf("%w: load live conversation before reconnect: %w", ports.ErrChatRecoveryInconclusive, err)
+		}
 	}
 
 	// Claim the durable fence before the controller starts consuming events. A
@@ -510,6 +522,9 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	controller := newController(
 		cfg.SessionID, conversation, generation, conv, s.store, s.activity, s.log, s.newID, s.now)
 	var commitProviderHistory func(context.Context) error
+	if liveReconnect {
+		controller.restoreLiveTurnOwnership(liveRows.Turns)
+	}
 	if cfg.ProviderConversationID != "" && !cfg.SkipNativeHistoryImport && !liveReconnect {
 		// The provider's native thread is the continuity authority across TUI and
 		// Chat. Import it before the live projector starts so the first notification
@@ -630,7 +645,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 // import failure cannot interrupt provider work that was already in flight.
 func cleanupUnpublishedConversation(conv ports.ChatConversation, fresh bool) {
 	if fresh {
-		if terminator, ok := conv.(interface{ Terminate() error }); ok {
+		if terminator, ok := conv.(ports.ChatProviderTerminator); ok {
 			_ = terminator.Terminate()
 			return
 		}

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -459,11 +459,15 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	if cfg.ProviderConversationID != "" &&
 		conv.ProviderConversationID() != cfg.ProviderConversationID {
 		returned := conv.ProviderConversationID()
-		_ = conv.Close()
+		cleanupUnpublishedConversation(conv, false)
 		return nil, fmt.Errorf(
 			"resumed provider conversation handle %q does not match requested handle %q",
 			returned, cfg.ProviderConversationID,
 		)
+	}
+	liveReconnect := false
+	if reconnected, ok := conv.(interface{ ReconnectedLive() bool }); ok {
+		liveReconnect = reconnected.ReconnectedLive()
 	}
 
 	// Claim the durable fence before the controller starts consuming events. A
@@ -476,7 +480,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	}
 	if providerBoundaryID == "" {
 		if err := s.store.ClaimChatControllerGeneration(ctx, cfg.SessionID, generation, s.now()); err != nil {
-			_ = conv.Close()
+			cleanupUnpublishedConversation(conv, cfg.ProviderConversationID == "")
 			return nil, fmt.Errorf("claim chat controller: %w", err)
 		}
 	}
@@ -498,13 +502,15 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	// behind a controller that no longer existed. Nothing would ever have corrected
 	// it. Settling here covers every way a controller can come up, and is a no-op
 	// for a session that has none of it.
-	s.settleOrphanedWork(ctx, cfg.SessionID, conversation.ID)
+	if !liveReconnect {
+		s.settleOrphanedWork(ctx, cfg.SessionID, conversation.ID)
+	}
 	// A fresh generation per launch, so events from the controller this one
 	// replaced can be told apart from the current one's.
 	controller := newController(
 		cfg.SessionID, conversation, generation, conv, s.store, s.activity, s.log, s.newID, s.now)
 	var commitProviderHistory func(context.Context) error
-	if cfg.ProviderConversationID != "" && !cfg.SkipNativeHistoryImport {
+	if cfg.ProviderConversationID != "" && !cfg.SkipNativeHistoryImport && !liveReconnect {
 		// The provider's native thread is the continuity authority across TUI and
 		// Chat. Import it before the live projector starts so the first notification
 		// cannot appear ahead of the older prompt, tool work, and answer it follows.
@@ -518,7 +524,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 		if s.reader != nil {
 			existing, err = s.reader.LoadConversationSnapshot(ctx, conversation.ID)
 			if err != nil {
-				_ = conv.Close()
+				cleanupUnpublishedConversation(conv, false)
 				return nil, fmt.Errorf("load conversation before native history import: %w", err)
 			}
 		}
@@ -532,7 +538,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			cfg.RequireNativeHistory, replayCheckpoint,
 		)
 		if historyErr != nil {
-			_ = conv.Close()
+			cleanupUnpublishedConversation(conv, false)
 			return nil, historyErr
 		}
 		if providerBoundary != nil {
@@ -545,7 +551,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 				return controller.projectNativeHistory(commitCtx, events)
 			}
 		} else if err := controller.projectNativeHistory(ctx, events); err != nil {
-			_ = conv.Close()
+			cleanupUnpublishedConversation(conv, false)
 			return nil, err
 		}
 	}
@@ -553,7 +559,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 		cfg, controller, providerBoundary, commitProviderHistory,
 	)
 	if err != nil {
-		_ = conv.Close()
+		cleanupUnpublishedConversation(conv, cfg.ProviderConversationID == "")
 		return nil, err
 	}
 	if providerBoundary != nil {
@@ -616,6 +622,20 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 	}()
 
 	return controller, nil
+}
+
+// cleanupUnpublishedConversation rolls back a provider opened before its AO
+// controller was published. A fresh thread has no durable resume handle and must
+// be destroyed; a resumed thread is detached so a transient AO persistence or
+// import failure cannot interrupt provider work that was already in flight.
+func cleanupUnpublishedConversation(conv ports.ChatConversation, fresh bool) {
+	if fresh {
+		if terminator, ok := conv.(interface{ Terminate() error }); ok {
+			_ = terminator.Terminate()
+			return
+		}
+	}
+	_ = conv.Close()
 }
 
 // Controller returns a session's live controller.
@@ -785,7 +805,7 @@ func (s *Service) Stop(ctx context.Context, id domain.SessionID) error {
 		s.mu.Unlock()
 		return nil
 	}
-	err := controller.Close(ctx)
+	err := controller.Terminate(ctx)
 
 	// Keep the only handle to a controller whose event stream has not ended. A
 	// caller can then retry the idempotent close rather than assuming a timeout

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2279,6 +2279,9 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 		if relaunchErr == nil {
 			return nil
 		}
+		if errors.Is(relaunchErr, ports.ErrChatRecoveryInconclusive) {
+			return fmt.Errorf("reconcile %s: preserve detached Chat provider: %w", rec.ID, relaunchErr)
+		}
 		restoreErr = relaunchErr
 	}
 	// A provider or runtime dependency can be temporarily unavailable during an

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -7733,6 +7733,44 @@ func TestReconcileLive_ProbeErrorIsNotDeath(t *testing.T) {
 	}
 }
 
+func TestReconcileLive_InconclusiveChatRecoveryDoesNotTeardown(t *testing.T) {
+	st := newFakeStore()
+	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}
+	ws := &fakeWorkspace{stashRef: "refs/ao/preserved/chat-live"}
+	lcm := &fakeLCM{store: st}
+	chat := &recordingLauncher{
+		startErr: fmt.Errorf("persistent host unavailable: %w", ports.ErrChatRecoveryInconclusive),
+	}
+	m := New(Deps{
+		Runtime: &fakeRuntime{}, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: lcm, Chat: chat,
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+	rec := domain.SessionRecord{
+		ID: "chat-live", ProjectID: "p1", Harness: domain.HarnessCodex,
+		Mode: domain.SessionModeChat,
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/chat-live", WorkspacePath: "/wt/chat-live",
+			ProviderConversationID: "thread-live", ControllerGeneration: "generation-old",
+		},
+	}
+	st.sessions[rec.ID] = rec
+
+	err := m.reconcileLive(context.Background(), rec)
+	if !errors.Is(err, ports.ErrChatRecoveryInconclusive) {
+		t.Fatalf("reconcileLive error = %v, want ErrChatRecoveryInconclusive", err)
+	}
+	if ws.stashCalls != 0 || lcm.terminated[rec.ID] != 0 {
+		t.Fatalf("inconclusive live host must remain intact: stash=%d terminated=%d",
+			ws.stashCalls, lcm.terminated[rec.ID])
+	}
+	for _, call := range ws.calls {
+		if call == "ForceDestroy:chat-live" {
+			t.Fatalf("inconclusive live host lost its worktree: calls=%v", ws.calls)
+		}
+	}
+}
+
 func TestReconcileLive_InconclusiveRuntimeProbeDoesNotRelaunch(t *testing.T) {
 	st := newFakeStore()
 	st.projects["p1"] = domain.ProjectRecord{ID: "p1", Config: testRoleAgents()}

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -65,6 +65,7 @@ func CLIActorType(actorType, commandPath string) string {
 var legacyActorlessSystemCLICommands = map[string]struct{}{
 	"ao agent-process":           {},
 	"ao agent-process supervise": {},
+	"ao chat-host":               {},
 	"ao completion":              {},
 	"ao daemon":                  {},
 	"ao help":                    {},

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -43,6 +43,11 @@ surface (`npm run sqlc`, `npm run api`).
   conversation between TUI and Chat without changing the AO session/worktree;
   rollback, restart recovery, controller-generation fencing, and a transition
   message outbox preserve the one-controller invariant.
+- Codex Chat app-server processes are owned by authenticated, detached
+  per-session hosts. Desktop close, full quit, and updater daemon replacement
+  detach and reconnect without relaunching the provider or interrupting an
+  in-flight turn; explicit session termination destroys the host. Other Chat
+  drivers still use native resume after daemon replacement.
 - Durable Chat conversations with project-scoped orchestrator continuity,
   session-scoped worker history, bounded history pages, transactional raw-event
   archive/projection, controller-generation fencing, turns, messages,

--- a/docs/adr/0003-persistent-chat-provider-host.md
+++ b/docs/adr/0003-persistent-chat-provider-host.md
@@ -1,0 +1,93 @@
+# 3. Persistent provider hosts for Chat sessions
+
+Date: 2026-08-26
+Status: Accepted (Codex slice implemented; ACP bindings follow)
+
+## Context
+
+Chat controllers historically spawned a provider process (`codex app-server` or
+an ACP adapter) as a child of the daemon. Desktop close, full quit, and updater
+restart all stop that daemon. `Chat.Service.StopAll` therefore closed every
+provider pipe, interrupted any active generation, and the replacement daemon had
+to launch a new provider process and invoke native resume. The durable thread was
+preserved, but the process and in-flight turn were not. TUI sessions did not have
+this failure because tmux/conpty already owns their harness outside the daemon.
+
+## Decision
+
+AO will move native Chat provider process ownership into a detached, per-session
+host. The daemon is an authenticated, exclusive client of that host, not its
+parent lifetime owner.
+
+The first production slice applies to Codex app-server:
+
+- `ao chat-host` launches the provider in the session worktree and listens only
+  on an ephemeral loopback TCP port. A 256-bit capability and protocol version
+  live in a mode-0600 descriptor below `~/.ao/data/chat-hosts/<session>/`.
+- Exactly one controller may attach. The host retains provider stdin/stdout when
+  that client disconnects, so an active turn continues. A replacement daemon
+  authenticates, takes the exclusive attachment, and does not repeat
+  `initialize` or `thread/resume`. If updater processes overlap, the replacement
+  waits for the old attachment to release instead of launching a rival provider.
+- Provider frames produced while detached are replayed in order from a bounded
+  32 MiB buffer. At the bound, the host applies backpressure instead of silently
+  losing protocol output. Unanswered provider-to-client requests are retained
+  even if a previous daemon received them, then replayed until a controller
+  response is forwarded, so an approval cannot disappear across detach. Codex
+  native history remains the repair source after host/provider failure.
+- The host records the greatest numeric client request id it forwarded. A new
+  controller starts above that high-water mark, preventing a late provider
+  response from correlating with a replacement request.
+- Controller-generation checks in SQLite remain the projection fence. The
+  transport additionally rejects concurrent attachment, preventing two live
+  daemon controllers from writing the provider connection.
+- Normal daemon shutdown—including window-close supervisor shutdown, full app
+  quit, and updater handoff—detaches. Explicit session kill, controller
+  replacement, or durable orphan reconciliation sends authenticated shutdown.
+- Deliberate detach does not project `ActivityExited`, settle the active turn, or
+  fail pending input. A live reconnect also skips the native-history settled
+  barrier; buffered protocol events continue the turn immediately on the same
+  initialized connection.
+- Startup orphan reconciliation only destroys a compatible host when durable
+  state proves its Codex Chat session is terminated or absent. An unreadable
+  store, incompatible descriptor, live PID with an unreachable endpoint, or
+  failed auth is preserved rather than treated as death.
+- Branch activation keeps its existing launch-before-destroy safety ordering. If
+  the source controller still owns the exclusive host, its staged replacement
+  uses a direct app-server; the next daemon reconciliation resumes that branch
+  into a persistent host. This avoids breaking branch rollback but leaves a
+  bounded migration gap: a daemon exit after branch activation and before the
+  next reconciliation uses native resume rather than live reconnect.
+
+The host inherits the already-resolved provider environment once at launch; no
+credentials are written to its descriptor. Possession of the descriptor
+capability grants control, so its directory and file permissions are part of the
+security boundary. The daemon never exposes this transport through its HTTP API.
+
+## Compatibility and update handoff
+
+The descriptor protocol is explicitly versioned. A new daemon attaches only to
+the exact supported version and leaves an incompatible live host untouched. This
+fails closed—without spawning a competing provider—until an explicit compatible
+handoff or session termination occurs. Provider protocol compatibility is
+inherited from the already-running binary because reconnect does not relaunch or
+renegotiate it.
+
+Future host versions should add a sequence-numbered, disk-backed replay journal
+with daemon acknowledgements before the detached window or provider protocol
+requires more than the bounded Codex-first bridge. ACP drivers should reuse this
+host transport after their request-id and initialization/resume semantics are
+made explicit; they continue to use process restart plus native resume until
+then.
+
+## Consequences
+
+- Closing/updating AO no longer terminates a Codex Chat harness or interrupts its
+  active generation. Reopen latency loses provider launch, initialization, and
+  native resume; it retains daemon reconciliation and native-history repair.
+- The detached host is a new local process and capability-bearing control plane
+  that must remain backwards-compatible across desktop updates.
+- TUI lifecycle is unchanged: tmux/conpty remains its external owner. Non-Codex
+  Chat bindings are unchanged in this slice and remain a known migration gap.
+- Host crashes still require ordinary native resume. In-memory replay protects
+  daemon replacement, not host or machine failure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Agent Orchestrator Architecture
 
-Agent Orchestrator is a long-running Go daemon that supervises multiple parallel AI coding agent sessions. Every session owns an isolated git worktree and one committed interface mode at a time. A TUI session runs its agent inside a tmux/conpty runtime; a Chat session runs a native protocol controller without an agent terminal runtime. A durable handoff may move a compatible native conversation between them, but both controllers are never live at once. The daemon coordinates both through the same session, lifecycle, workspace, storage, and observation boundaries.
+Agent Orchestrator is a long-running Go daemon that supervises multiple parallel AI coding agent sessions. Every session owns an isolated git worktree and one committed interface mode at a time. A TUI session runs its agent inside a tmux/conpty runtime; a Chat session runs a native protocol controller without an agent terminal runtime. Codex Chat provider processes live in a detached per-session host so daemon/desktop replacement reconnects without stopping an in-flight turn; other Chat drivers currently retain daemon-owned process lifetime. A durable handoff may move a compatible native conversation between TUI and Chat, but both controllers are never live at once. The daemon coordinates both through the same session, lifecycle, workspace, storage, and observation boundaries.
 
 ## Table of Contents
 
@@ -196,7 +196,7 @@ backend/internal/
 ├── service/             # Controller-facing services
 │   ├── project/         # Project CRUD
 │   ├── session/         # Session read-model assembly
-│   ├── chat/            # Runtime-less Chat controllers + durable projection
+│   ├── chat/            # Chat controllers, persistent Codex hosts + durable projection
 │   ├── pr/              # PR observation service
 │   └── review/          # Code review service
 ├── session_manager/     # Internal session command engine


### PR DESCRIPTION
Refs #4526

## Summary

- move Codex Chat app-server ownership into a detached, authenticated per-session host
- reconnect one fenced daemon controller to the same initialized provider, replaying detached output and unresolved approvals without false Exited projection
- distinguish daemon detach from explicit session termination and reconcile proven durable orphans on boot
- document the compatibility, security, update-handoff, crash-recovery, branch-transition, and ACP migration boundaries

## Verification

- `npm run lint` (with AO worker environment unset)
- `go test -count=1 -timeout=60s ./internal/adapters/chatdriver/persistenthost ./internal/adapters/chatdriver/codexappserver ./internal/service/chat ./internal/daemon`
- `go test -race -count=1 ./internal/adapters/chatdriver/persistenthost ./internal/adapters/chatdriver/codexappserver ./internal/service/chat`
- `go build ./...`
- `GOOS=windows GOARCH=amd64 go build ./cmd/ao`

## Known follow-ups

- ACP Chat bindings still use daemon-owned processes and native resume; issue #4526 remains open for that migration.
- The v1 host uses bounded in-memory replay. Host or machine failure falls back to native history; a disk-backed acknowledged journal is a future protocol revision.
- Branch activation retains launch-before-destroy rollback safety through a direct staged provider and therefore has a bounded live-reconnect gap until the next daemon reconciliation.