### PR TITLE
fix(desktop): refresh new session workspace readiness

### DIFF
--- a/frontend/src/renderer/components/GlobalNewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/GlobalNewTaskDialog.test.tsx
@@ -51,6 +51,7 @@ function renderDialog() {
 			<GlobalNewTaskDialog />
 		</QueryClientProvider>,
 	);
+	return queryClient;
 }
 
 beforeEach(() => {
@@ -70,7 +71,8 @@ describe("GlobalNewTaskDialog", () => {
 
 	it("opens for the requested project and navigates to the created session", async () => {
 		const user = userEvent.setup();
-		renderDialog();
+		const queryClient = renderDialog();
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
 
 		act(() => {
 			useUiStore.getState().requestNewTask("proj-7");
@@ -80,6 +82,8 @@ describe("GlobalNewTaskDialog", () => {
 		expect(dialog).toHaveAttribute("data-project", "proj-7");
 
 		await user.click(screen.getByRole("button", { name: "create" }));
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ["editor-handoff", "sess-9"] });
 		expect(navigateMock).toHaveBeenCalledWith({
 			to: "/projects/$projectId/sessions/$sessionId",
 			params: { projectId: "proj-7", sessionId: "sess-9" },

--- a/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
+++ b/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
+import { editorHandoffQueryKey } from "../hooks/useEditorHandoff";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useUiStore } from "../stores/ui-store";
 import { NewTaskDialog } from "./NewTaskDialog";
@@ -32,7 +33,10 @@ export function GlobalNewTaskDialog() {
 
 	const handleCreated = async (sessionId: string) => {
 		if (!projectId) return;
-		await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
+			queryClient.invalidateQueries({ queryKey: editorHandoffQueryKey(sessionId) }),
+		]);
 		void navigate({
 			to: "/projects/$projectId/sessions/$sessionId",
 			params: { projectId, sessionId },

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -371,6 +371,8 @@ export function ShellTopbar({
 								key={`open-workspace-${session.id}`}
 								sessionId={session.id}
 								projectId={session.workspaceId}
+								sessionCreatedAt={session.createdAt}
+								sessionTerminated={session.isTerminated}
 								style={noDragStyle}
 							/>
 						) : null}

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
@@ -167,8 +167,15 @@ describe("TopbarOpenEditorButton", () => {
 		expect(screen.getByRole("button", { name: "Open workspace options" })).toBeDisabled();
 	});
 
-	it("keeps a fresh session neutral while bounded readiness polling recovers", async () => {
+	it("never renders a transient unavailable error while a fresh session becomes ready", async () => {
 		vi.useFakeTimers();
+		const renderedAlerts: string[] = [];
+		const alertObserver = new MutationObserver(() => {
+			for (const alert of document.querySelectorAll('[role="alert"]')) {
+				renderedAlerts.push(alert.textContent ?? "");
+			}
+		});
+		alertObserver.observe(document.body, { childList: true, subtree: true, characterData: true });
 		try {
 			const getState = vi
 				.fn()
@@ -187,13 +194,52 @@ describe("TopbarOpenEditorButton", () => {
 			expect(screen.getByRole("button", { name: "Preparing workspace…" })).toBeDisabled();
 
 			await act(async () => {
-				await vi.advanceTimersByTimeAsync(500);
+				await vi.advanceTimersByTimeAsync(499);
+			});
+			expect(getState).toHaveBeenCalledTimes(1);
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Preparing workspace…" })).toBeDisabled();
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(1);
 			});
 			await act(async () => {
 				await vi.runOnlyPendingTimersAsync();
 			});
 			expect(getState).toHaveBeenCalledTimes(2);
 			expect(screen.getByRole("button", { name: "Open in Cursor" })).toBeEnabled();
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+			expect(renderedAlerts).toEqual([]);
+		} finally {
+			alertObserver.disconnect();
+			vi.useRealTimers();
+		}
+	});
+
+	it("shows the unavailable error only after the fresh-session readiness timeout", async () => {
+		vi.useFakeTimers();
+		try {
+			const getState = vi.fn().mockResolvedValue({
+				...availableState,
+				workspaceAvailable: false,
+				unavailableReason: "Session workspace is not available.",
+			});
+			window.ao!.editorHandoff.getState = getState;
+			renderButton({ sessionCreatedAt: new Date().toISOString() });
+
+			await act(async () => {});
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Preparing workspace…" })).toBeDisabled();
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(5_000);
+			});
+			await act(async () => {
+				await vi.runOnlyPendingTimersAsync();
+			});
+			expect(getState).toHaveBeenCalledTimes(11);
+			expect(screen.getByRole("alert")).toHaveTextContent("Session workspace is not available.");
+			expect(screen.getByRole("button", { name: "Open in Cursor" })).toBeDisabled();
 		} finally {
 			vi.useRealTimers();
 		}

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EditorHandoffState, OpenSessionTargetInput } from "../../shared/editor-handoff";
@@ -31,12 +31,19 @@ function setState(state: EditorHandoffState) {
 	window.ao!.editorHandoff.open = openMock;
 }
 
-function renderButton() {
+function renderButton(
+	{ sessionCreatedAt, sessionTerminated }: { sessionCreatedAt?: string; sessionTerminated?: boolean } = {},
+) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
 	return render(
 		<QueryClientProvider client={client}>
 			<TooltipProvider>
-				<TopbarOpenEditorButton sessionId="sess-1" projectId="proj-1" />
+			<TopbarOpenEditorButton
+				sessionId="sess-1"
+				projectId="proj-1"
+				sessionCreatedAt={sessionCreatedAt}
+				sessionTerminated={sessionTerminated}
+			/>
 			</TooltipProvider>
 		</QueryClientProvider>,
 	);
@@ -158,6 +165,51 @@ describe("TopbarOpenEditorButton", () => {
 		expect(await screen.findByRole("alert")).toHaveTextContent("Session workspace is not available.");
 		expect(screen.getByRole("button", { name: "Open in Cursor" })).toBeDisabled();
 		expect(screen.getByRole("button", { name: "Open workspace options" })).toBeDisabled();
+	});
+
+	it("keeps a fresh session neutral while bounded readiness polling recovers", async () => {
+		vi.useFakeTimers();
+		try {
+			const getState = vi
+				.fn()
+				.mockResolvedValueOnce({
+					...availableState,
+					workspaceAvailable: false,
+					unavailableReason: "Session workspace is not available.",
+				})
+				.mockResolvedValue(availableState);
+			window.ao!.editorHandoff.getState = getState;
+			renderButton({ sessionCreatedAt: new Date().toISOString() });
+
+			await act(async () => {});
+			expect(getState).toHaveBeenCalledTimes(1);
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Preparing workspace…" })).toBeDisabled();
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(500);
+			});
+			await act(async () => {
+				await vi.runOnlyPendingTimersAsync();
+			});
+			expect(getState).toHaveBeenCalledTimes(2);
+			expect(screen.getByRole("button", { name: "Open in Cursor" })).toBeEnabled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not poll a terminated session whose workspace is gone", async () => {
+		const getState = vi.fn().mockResolvedValue({
+			...availableState,
+			workspaceAvailable: false,
+			unavailableReason: "Session workspace is not available.",
+		});
+		window.ao!.editorHandoff.getState = getState;
+		renderButton({ sessionCreatedAt: new Date().toISOString(), sessionTerminated: true });
+
+		expect(await screen.findByRole("alert")).toHaveTextContent("Session workspace is not available.");
+		expect(getState).toHaveBeenCalledTimes(1);
 	});
 
 	it("opens safe native fallbacks from the menu", async () => {

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
@@ -38,12 +38,12 @@ function renderButton(
 	return render(
 		<QueryClientProvider client={client}>
 			<TooltipProvider>
-			<TopbarOpenEditorButton
-				sessionId="sess-1"
-				projectId="proj-1"
-				sessionCreatedAt={sessionCreatedAt}
-				sessionTerminated={sessionTerminated}
-			/>
+				<TopbarOpenEditorButton
+					sessionId="sess-1"
+					projectId="proj-1"
+					sessionCreatedAt={sessionCreatedAt}
+					sessionTerminated={sessionTerminated}
+				/>
 			</TooltipProvider>
 		</QueryClientProvider>,
 	);

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
@@ -123,7 +123,11 @@ export function TopbarOpenEditorButton({
 					<TooltipTrigger asChild>
 						<span className="inline-flex">
 							<TopbarButton
-								aria-label={stateQuery.isPending ? t("editor.preparingWorkspace") : preferred ? t("editor.openInAria", { name: preferred.name }) : t("editor.chooseEditor")}
+								aria-label={stateQuery.isPending
+									? t("editor.preparingWorkspace")
+									: preferred
+										? t("editor.openInAria", { name: preferred.name })
+										: t("editor.chooseEditor")}
 								className="hover:bg-transparent"
 								disabled={mainDisabled}
 								onClick={() => launch()}

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
@@ -66,14 +66,18 @@ function TargetIcon({ target, className }: { target?: OpenTarget; className?: st
 export function TopbarOpenEditorButton({
 	sessionId,
 	projectId,
+	sessionCreatedAt,
+	sessionTerminated,
 	style,
 }: {
 	sessionId: string;
 	projectId: string;
+	sessionCreatedAt?: string;
+	sessionTerminated?: boolean;
 	style?: React.CSSProperties;
 }) {
 	const { t } = useTranslation();
-	const stateQuery = useEditorHandoffState(sessionId);
+	const stateQuery = useEditorHandoffState(sessionId, { sessionCreatedAt, sessionTerminated });
 	const open = useOpenSessionTarget();
 	const state = stateQuery.data;
 	const [menuOpen, setMenuOpen] = useState(false);
@@ -98,8 +102,10 @@ export function TopbarOpenEditorButton({
 		: !stateQuery.isPending && editors.length === 0
 			? t("editor.noEditorGuidance", { fileManager: fileManagerName, terminal: terminalName })
 			: null;
-	const mainTitle = guidance
-		?? (preferred ? t("editor.openWorkspaceInTitle", { name: preferred.name }) : t("editor.chooseEditorTitle"));
+	const mainTitle = stateQuery.isPending
+		? t("editor.preparingWorkspace")
+		: (guidance
+			?? (preferred ? t("editor.openWorkspaceInTitle", { name: preferred.name }) : t("editor.chooseEditorTitle")));
 
 	return (
 		<>
@@ -117,7 +123,7 @@ export function TopbarOpenEditorButton({
 					<TooltipTrigger asChild>
 						<span className="inline-flex">
 							<TopbarButton
-								aria-label={preferred ? t("editor.openInAria", { name: preferred.name }) : t("editor.chooseEditor")}
+								aria-label={stateQuery.isPending ? t("editor.preparingWorkspace") : preferred ? t("editor.openInAria", { name: preferred.name }) : t("editor.chooseEditor")}
 								className="hover:bg-transparent"
 								disabled={mainDisabled}
 								onClick={() => launch()}

--- a/frontend/src/renderer/hooks/useEditorHandoff.ts
+++ b/frontend/src/renderer/hooks/useEditorHandoff.ts
@@ -4,6 +4,42 @@ import { aoBridge } from "../lib/bridge";
 import { captureRendererEvent } from "../lib/telemetry";
 
 export const editorHandoffQueryKey = (sessionId: string) => ["editor-handoff", sessionId] as const;
+export const editorHandoffQueryRoot = ["editor-handoff"] as const;
+
+const NEW_SESSION_READINESS_WINDOW_MS = 30_000;
+const WORKSPACE_READINESS_RETRY_MS = 500;
+const WORKSPACE_READINESS_MAX_RETRIES = 10;
+
+type EditorHandoffReadiness = {
+	sessionCreatedAt?: string;
+	sessionTerminated?: boolean;
+};
+
+function shouldAwaitWorkspace({ sessionCreatedAt, sessionTerminated }: EditorHandoffReadiness): boolean {
+	if (sessionTerminated || !sessionCreatedAt) return false;
+	const createdAt = Date.parse(sessionCreatedAt);
+	if (!Number.isFinite(createdAt)) return false;
+	const age = Date.now() - createdAt;
+	return age >= 0 && age <= NEW_SESSION_READINESS_WINDOW_MS;
+}
+
+function waitForWorkspaceRetry(signal: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal.aborted) {
+			reject(signal.reason ?? new DOMException("Workspace readiness check cancelled", "AbortError"));
+			return;
+		}
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal.reason ?? new DOMException("Workspace readiness check cancelled", "AbortError"));
+		};
+		const timer = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, WORKSPACE_READINESS_RETRY_MS);
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+}
 
 // Electron wraps anything an ipcMain handler throws as
 // "Error invoking remote method '<channel>': Error: <real message>". That prefix
@@ -17,13 +53,26 @@ export function editorHandoffErrorMessage(error: unknown): string | null {
 	return message || error.message;
 }
 
-export function useEditorHandoffState(sessionId: string) {
+export function useEditorHandoffState(sessionId: string, readiness: EditorHandoffReadiness = {}) {
+	const awaitWorkspace = shouldAwaitWorkspace(readiness);
 	return useQuery({
 		queryKey: editorHandoffQueryKey(sessionId),
 		enabled: Boolean(sessionId),
 		staleTime: 10_000,
 		retry: false,
-		queryFn: () => aoBridge.editorHandoff.getState(sessionId),
+		queryFn: async ({ signal }) => {
+			// A missing workspace is returned as successful state rather than an
+			// exception, so TanStack's retry option cannot recover it. Poll only
+			// during the bounded window in which a newly created session can still
+			// be crossing the daemon/UI readiness boundary.
+			for (let retries = 0; ; retries += 1) {
+				const state = await aoBridge.editorHandoff.getState(sessionId);
+				if (state.workspaceAvailable || !awaitWorkspace || retries >= WORKSPACE_READINESS_MAX_RETRIES) {
+					return state;
+				}
+				await waitForWorkspaceRetry(signal);
+			}
+		},
 	});
 }
 

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -303,6 +303,7 @@
 	"daemon.title.unreachable": "AO-Daemon ist nicht erreichbar",
 	"editor.open": "Öffnen",
 	"editor.opening": "Wird geöffnet…",
+	"editor.preparingWorkspace": "Arbeitsbereich wird vorbereitet…",
 	"editor.chooseEditor": "Editor auswählen",
 	"editor.chooseEditorTitle": "Installierten Editor oder native Option auswählen",
 	"editor.fileManager": "Dateimanager",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -303,6 +303,7 @@
 	"daemon.title.unreachable": "AO daemon is unreachable",
 	"editor.open": "Open",
 	"editor.opening": "Opening…",
+	"editor.preparingWorkspace": "Preparing workspace…",
 	"editor.chooseEditor": "Choose editor",
 	"editor.chooseEditorTitle": "Choose an installed editor or use a native fallback",
 	"editor.fileManager": "File Manager",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -305,6 +305,7 @@
 	"daemon.title.unreachable": "El daemon de AO no es accesible",
 	"editor.open": "Abrir",
 	"editor.opening": "Abriendo…",
+	"editor.preparingWorkspace": "Preparando espacio de trabajo…",
 	"editor.chooseEditor": "Elegir editor",
 	"editor.chooseEditorTitle": "Elige un editor instalado o una opción nativa",
 	"editor.fileManager": "Administrador de archivos",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -305,6 +305,7 @@
 	"daemon.title.unreachable": "Le daemon AO est inaccessible",
 	"editor.open": "Ouvrir",
 	"editor.opening": "Ouverture…",
+	"editor.preparingWorkspace": "Préparation de l’espace de travail…",
 	"editor.chooseEditor": "Choisir un éditeur",
 	"editor.chooseEditorTitle": "Choisir un éditeur installé ou une option native",
 	"editor.fileManager": "Gestionnaire de fichiers",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -303,6 +303,7 @@
 	"daemon.title.unreachable": "AO デーモンに接続できません",
 	"editor.open": "開く",
 	"editor.opening": "開いています…",
+	"editor.preparingWorkspace": "ワークスペースを準備中…",
 	"editor.chooseEditor": "エディターを選択",
 	"editor.chooseEditorTitle": "インストール済みのエディターまたは標準アプリを選択",
 	"editor.fileManager": "ファイルマネージャー",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -303,6 +303,7 @@
 	"daemon.title.unreachable": "AO 데몬에 연결할 수 없습니다",
 	"editor.open": "열기",
 	"editor.opening": "여는 중…",
+	"editor.preparingWorkspace": "워크스페이스 준비 중…",
 	"editor.chooseEditor": "편집기 선택",
 	"editor.chooseEditorTitle": "설치된 편집기 또는 기본 앱 선택",
 	"editor.fileManager": "파일 관리자",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -305,6 +305,7 @@
 	"daemon.title.unreachable": "O daemon do AO está inacessível",
 	"editor.open": "Abrir",
 	"editor.opening": "Abrindo…",
+	"editor.preparingWorkspace": "Preparando workspace…",
 	"editor.chooseEditor": "Escolher editor",
 	"editor.chooseEditorTitle": "Escolha um editor instalado ou uma opção nativa",
 	"editor.fileManager": "Gerenciador de arquivos",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -303,6 +303,7 @@
 	"daemon.title.unreachable": "无法连接 AO 守护进程",
 	"editor.open": "打开",
 	"editor.opening": "正在打开…",
+	"editor.preparingWorkspace": "正在准备工作区…",
 	"editor.chooseEditor": "选择编辑器",
 	"editor.chooseEditorTitle": "选择已安装的编辑器或系统应用",
 	"editor.fileManager": "文件管理器",

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -228,6 +228,7 @@ describe("createEventTransport", () => {
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-agent-switches"] }, { cancelRefetch: false });
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-scm-summary"] }, { cancelRefetch: false });
 			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["session-usage"] }, { cancelRefetch: false });
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["editor-handoff"] }, { cancelRefetch: false });
 		} finally {
 			vi.useRealTimers();
 		}
@@ -284,6 +285,35 @@ describe("createEventTransport", () => {
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
 				queryKey: ["session-scm-summary"],
 			});
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+				queryKey: ["editor-handoff", "chat-1"],
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("invalidates editor-handoff readiness for a durable session update", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			EventSourceStub.instances[0].emit(
+				"session_updated",
+				JSON.stringify({
+					seq: 44,
+					projectId: "proj-1",
+					sessionId: "session-1",
+					type: "session_updated",
+					payload: { id: "session-1", activity: "idle", isTerminated: false },
+					createdAt: "2026-08-27T02:31:38Z",
+				}),
+			);
+
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+				queryKey: ["editor-handoff", "session-1"],
+			}, { cancelRefetch: false });
 		} finally {
 			vi.useRealTimers();
 		}

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -1,3 +1,4 @@
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { computeSseRetryDelayMs } from "./sse-backoff";
@@ -315,6 +316,45 @@ describe("createEventTransport", () => {
 				queryKey: ["editor-handoff", "session-1"],
 			}, { cancelRefetch: false });
 		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("refetches cached unavailable state after the post-spawn session update", async () => {
+		vi.useFakeTimers();
+		let disconnect: (() => void) | undefined;
+		let unsubscribe: (() => void) | undefined;
+		try {
+			const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+			const queryKey = ["editor-handoff", "agent-orchestrator-260"] as const;
+			const queryFn = vi
+				.fn()
+				.mockResolvedValueOnce({ workspaceAvailable: false })
+				.mockResolvedValue({ workspaceAvailable: true });
+			await queryClient.fetchQuery({ queryKey, queryFn, staleTime: 10_000 });
+			const observer = new QueryObserver(queryClient, { queryKey, queryFn, staleTime: 10_000 });
+			unsubscribe = observer.subscribe(() => {});
+			disconnect = createEventTransport(queryClient).connect();
+
+			expect(queryClient.getQueryData(queryKey)).toEqual({ workspaceAvailable: false });
+			EventSourceStub.instances[0].emit(
+				"session_updated",
+				JSON.stringify({
+					seq: 667762,
+					projectId: "agent-orchestrator",
+					sessionId: "agent-orchestrator-260",
+					type: "session_updated",
+					payload: { id: "agent-orchestrator-260" },
+					createdAt: "2026-08-29T07:55:18.913484Z",
+				}),
+			);
+
+			await vi.advanceTimersByTimeAsync(200);
+			expect(queryFn).toHaveBeenCalledTimes(2);
+			expect(queryClient.getQueryData(queryKey)).toEqual({ workspaceAvailable: true });
+		} finally {
+			unsubscribe?.();
+			disconnect?.();
 			vi.useRealTimers();
 		}
 	});

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -1,4 +1,3 @@
-import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { computeSseRetryDelayMs } from "./sse-backoff";
@@ -288,7 +287,7 @@ describe("createEventTransport", () => {
 			});
 			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
 				queryKey: ["editor-handoff", "chat-1"],
-			});
+			}, { cancelRefetch: false });
 		} finally {
 			vi.useRealTimers();
 		}
@@ -299,7 +298,7 @@ describe("createEventTransport", () => {
 		try {
 			const queryClient = fakeQueryClient();
 			createEventTransport(queryClient).connect();
-			EventSourceStub.instances[0].emit(
+			cdcSources()[0].emit(
 				"session_updated",
 				JSON.stringify({
 					seq: 44,
@@ -337,7 +336,7 @@ describe("createEventTransport", () => {
 			disconnect = createEventTransport(queryClient).connect();
 
 			expect(queryClient.getQueryData(queryKey)).toEqual({ workspaceAvailable: false });
-			EventSourceStub.instances[0].emit(
+			cdcSources()[0].emit(
 				"session_updated",
 				JSON.stringify({
 					seq: 667762,

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -11,6 +11,7 @@ import { sessionUsageQueryRoot } from "../hooks/useSessionUsageSummaries";
 import { agentSwitchVisibility } from "./agent-switch-visibility";
 import { codexAccountsQueryKey, writeCodexAccounts } from "../hooks/codex-accounts-state";
 import type { components } from "../../api/schema";
+import { editorHandoffQueryKey, editorHandoffQueryRoot } from "../hooks/useEditorHandoff";
 
 export type EventTransport = {
 	connect: () => () => void;
@@ -44,8 +45,9 @@ const CDC_EVENT_TYPES = [
  *   - daemon lifecycle over Electron IPC (coming up/down changes session availability)
  *   - the backend CDC stream over SSE (project/session/PR changes)
  *   - the Codex account stream over SSE (account, capacity, and switch state)
- * Both invalidate the ["workspaces"] query so the UI refetches. Invalidations are
- * batched because a single user action can emit a burst of CDC events.
+ * Lifecycle and CDC events invalidate the workspace cache; durable per-session
+ * updates also refresh editor-handoff readiness. Invalidations are batched
+ * because a single user action can emit a burst of CDC events.
  */
 export function createEventTransport(queryClient: QueryClient): EventTransport {
 	return {
@@ -54,8 +56,10 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			let refreshTimer: ReturnType<typeof setTimeout> | undefined;
 			const pendingConversationSessions = new Set<string>();
 			const pendingInterfaceTransitionSessions = new Set<string>();
+			const pendingEditorHandoffSessions = new Set<string>();
 			let workspaceInvalidationPending = false;
 			let allConversationsInvalidationPending = false;
+			let allEditorHandoffsInvalidationPending = false;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
@@ -103,11 +107,13 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 					// the header reporting that clamp, so refresh every conversation instead of
 					// leaving an open chat frozen on its pre-gap snapshot.
 					allConversationsInvalidationPending = true;
+					allEditorHandoffsInvalidationPending = true;
 				}
 				if (event && "data" in event) {
 					try {
 						const decoded = JSON.parse(String((event as MessageEvent).data)) as {
 							sessionId?: unknown;
+							type?: unknown;
 							payload?: unknown;
 						};
 						// The SSE endpoint sends the complete durable CDC event. Routing
@@ -139,6 +145,15 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 							pendingConversationSessions.add(decoded.sessionId);
 							conversationOnly = true;
 						}
+						if (
+							decoded.type === "session_updated" &&
+							typeof decoded.sessionId === "string" &&
+							decoded.sessionId &&
+							typeof payload?.conversationId !== "string" &&
+							typeof payload?.interfaceTransitionId !== "string"
+						) {
+							pendingEditorHandoffSessions.add(decoded.sessionId);
+						}
 					} catch {
 						// A malformed CDC payload still invalidates workspaces; it simply
 						// cannot target a conversation cache precisely.
@@ -160,6 +175,16 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						invalidate(sessionScmSummaryQueryKey());
 						invalidate(sessionUsageQueryRoot);
 						workspaceInvalidationPending = false;
+					}
+					if (allEditorHandoffsInvalidationPending) {
+						invalidate(editorHandoffQueryRoot);
+						allEditorHandoffsInvalidationPending = false;
+						pendingEditorHandoffSessions.clear();
+					} else {
+						for (const sessionId of pendingEditorHandoffSessions) {
+							invalidate(editorHandoffQueryKey(sessionId));
+						}
+						pendingEditorHandoffSessions.clear();
 					}
 					for (const sessionId of pendingConversationSessions) {
 						invalidate(conversationQueryKey(sessionId));


### PR DESCRIPTION
Fixes #4531

## Summary

- invalidate editor-handoff readiness after successful New Task creation and on the existing durable `session_updated` SSE signal
- keep conversation-only and interface-transition CDC from causing unrelated editor-handoff refetches
- retry an unavailable workspace every 500 ms for at most five seconds, only while a session is under 30 seconds old and not terminated
- render the bounded readiness window as a neutral disabled **Preparing workspace…** control instead of a failure banner
- preserve the existing one-shot unavailable behavior for mature or terminated sessions

No daemon protocol or API change is needed: the durable CDC/SSE channel already carries the session identifier and post-provisioning update, while Electron main remains the only process that receives the absolute workspace path.

## Current-main verification

Rebased onto `7805e0052` (2026-09-05), preserving current-main tooltip presentation and coalesced/non-cancelling SSE refreshes. Tests select the CDC stream explicitly now that account events use a separate stream. A fresh nightly reproduction on `agent-orchestrator-260` produced the same stale-negative state: the worker was active and its worktree existed, then the daemon workspace endpoint returned HTTP 200. Its first post-spawn non-conversation `session_updated` event was CDC sequence `667762` at `2026-08-29T07:55:18.913484Z`; the added integration test feeds that exact event into a cached unavailable editor-handoff query and verifies an active observer refetches to available. The topbar regression test records every alert rendered across an initial unavailable response, the neutral readiness wait, and successful readiness, proving that the transient red error is never presented; a persistent miss becomes an error only after the bounded timeout.

### Verification safety correction

The earlier packaged Electron run used production AO_DATA_DIR despite a separate run file, userData, and port. It was **not data-isolated** and caused unrelated session reconciliation; it must not be treated as valid isolation/safety evidence. That lifecycle incident is separate from this renderer-only PR. No packaged app or daemon was launched for this rebase verification.

## Tests (2026-09-05)

After installing the current lockfile dependencies:
- `cd frontend && npm test` — 276 files passed; 3,767 tests passed, 7 skipped
- `cd frontend && npm run typecheck` — passed
- `cd frontend && npx vite build --config vite.renderer.config.ts` — passed (chunk-size warning)
- `git diff --check` — passed

## Risk

Low and renderer-scoped. The fallback performs up to ten additional readiness reads, but only for an active session created within the last 30 seconds; terminated and established sessions never enter the retry loop.

The fallback bounds retry count, not total IPC latency: it waits approximately five seconds plus readiness-call latency before reporting unavailability. It does not optimize worktree provisioning itself.
