### PR TITLE
fix(new-task): streamline composer attachments

### DIFF
--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -99,6 +99,7 @@ describe("TaskComposer", () => {
 		);
 
 		expect(task().getAttribute("placeholder")).toBeTruthy();
+		expect(task()).toHaveClass("min-h-[calc(3lh+1.75rem)]");
 		expect(screen.getByRole("button", { name: "Start task" })).toBeEnabled();
 		fireEvent.click(screen.getByText("Start task"));
 
@@ -125,6 +126,23 @@ describe("TaskComposer", () => {
 		expect(task()).toHaveValue("Investigate the failure");
 	});
 
+	it("does not rerender the agent control for every prompt keystroke", async () => {
+		render(
+			<Wrap>
+				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+			</Wrap>,
+		);
+
+		await waitFor(() => expect(screen.getByTestId("agent-field")).toBeInTheDocument());
+		h.agentValues.length = 0;
+
+		fireEvent.change(task(), { target: { value: "a" } });
+		fireEvent.change(task(), { target: { value: "ab" } });
+		fireEvent.change(task(), { target: { value: "abc" } });
+
+		expect(h.agentValues).toHaveLength(1);
+	});
+
 	it("keeps agent and model in equal stable toolbar tracks", () => {
 		render(
 			<Wrap>
@@ -141,14 +159,14 @@ describe("TaskComposer", () => {
 		expect(runControls.querySelector(".composer-toolbar-divider")).not.toBeNull();
 	});
 
-	it("keeps the file attach control inside the prompt surface", () => {
+	it("keeps the file attach control in the bottom action row", () => {
 		render(
 			<Wrap>
 				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
-		expect(screen.getByRole("button", { name: "Add file" }).closest(".composer-prompt-surface")).not.toBeNull();
+		expect(screen.getByRole("button", { name: "Add file" }).closest(".composer-toolbar")).not.toBeNull();
 	});
 
 	it("emits busy state around an in-flight create and reports the new session", async () => {

--- a/frontend/src/renderer/components/TaskComposer.tsx
+++ b/frontend/src/renderer/components/TaskComposer.tsx
@@ -85,7 +85,7 @@ export function TaskComposer({
 			: "";
 	}, [t]);
 	const queryClient = useQueryClient();
-	const [prompt, setPrompt] = useState("");
+	const [isPromptDirty, setIsPromptDirty] = useState(false);
 	const [model, setModel] = useState("");
 	const [mode, setMode] = useState("");
 	const [agent, setAgent] = useState("");
@@ -236,7 +236,11 @@ export function TaskComposer({
 		}
 	}, [defaultModelForSelectedAgent, defaultModeForSelectedAgent, modelTouched]);
 
-	const isDirty = prompt.trim() !== "" || modelTouched || attachments.length > 0;
+	const isDirty = isPromptDirty || modelTouched || attachments.length > 0;
+	const handlePromptChange = useCallback((value: string) => {
+		const nextDirty = value.trim() !== "";
+		setIsPromptDirty((wasDirty) => (wasDirty === nextDirty ? wasDirty : nextDirty));
+	}, []);
 	useEffect(() => {
 		onDirtyChange?.(isDirty);
 	}, [isDirty, onDirtyChange]);
@@ -249,6 +253,7 @@ export function TaskComposer({
 	useEffect(() => () => clearAttachments(), [clearAttachments]);
 
 	const submitTask = async (
+		brief: string,
 		interfaceMode?: "tui",
 		approvalMode?: "bypass-permissions",
 	) => {
@@ -268,7 +273,7 @@ export function TaskComposer({
 			const attachmentPayloads = await toSettledPayload();
 			const sessionId = await createTask({
 				projectId,
-				brief: prompt,
+				brief,
 				// The visible selection is authoritative: it is either the user's pick
 				// or the resolved default, so spawning names it explicitly.
 				agent: selectedAgent ? (selectedAgent as CreateTaskInput["agent"]) : undefined,
@@ -303,8 +308,7 @@ export function TaskComposer({
 		<TaskComposerView
 			autoFocusPrompt={autoFocusTitle}
 			canSubmit={Boolean(projectId)}
-			prompt={prompt}
-			onPromptChange={setPrompt}
+			onPromptChange={handlePromptChange}
 			labels={{
 				addFile: t("newTask.addFile"),
 				fallbackAction: fallbackAction === "bypass-permissions"
@@ -367,11 +371,11 @@ export function TaskComposer({
 				error,
 				isSubmitting,
 				modelWarning,
-				onFallbackAction: () =>
+				onFallbackAction: (brief) =>
 					void (fallbackAction === "bypass-permissions"
-						? submitTask(undefined, "bypass-permissions")
-						: submitTask("tui")),
-				onSubmit: () => void submitTask(requiresTuiFallback ? "tui" : undefined),
+						? submitTask(brief, undefined, "bypass-permissions")
+						: submitTask(brief, "tui")),
+				onSubmit: (brief) => void submitTask(brief, requiresTuiFallback ? "tui" : undefined),
 			}}
 			renderAgentControl={(control) => <DesktopAgentControl {...control} />}
 			renderModelControl={(control) => <TaskModelPicker {...control} />}

--- a/packages/product-ui/src/TaskComposerView.test.tsx
+++ b/packages/product-ui/src/TaskComposerView.test.tsx
@@ -8,7 +8,7 @@ import {
 function viewProps(overrides: Partial<TaskComposerViewProps> = {}): TaskComposerViewProps {
 	return {
 		canSubmit: true,
-		prompt: "",
+		initialPrompt: "",
 		onPromptChange: vi.fn(),
 		labels: {
 			addFile: "Add file",
@@ -88,6 +88,16 @@ describe("TaskComposerView", () => {
 		expect(screen.getByRole("group", { name: "Runs with" })).toHaveClass("composer-run-controls");
 	});
 
+	it("keeps the surrounding controls stable while typing", () => {
+		const renderAgentControl = vi.fn((control) => <button type="button">{control.value}</button>);
+		render(<TaskComposerView {...viewProps({ renderAgentControl })} />);
+		renderAgentControl.mockClear();
+
+		fireEvent.change(screen.getByRole("textbox", { name: "Task" }), { target: { value: "Fast draft" } });
+
+		expect(renderAgentControl).not.toHaveBeenCalled();
+	});
+
 	it("submits on the button or unmodified Enter and respects project availability", () => {
 		const props = viewProps();
 		const { rerender } = render(<TaskComposerView {...props} />);
@@ -138,6 +148,28 @@ describe("TaskComposerView", () => {
 			dataTransfer: { files: [file] },
 		});
 		expect(onAddFiles).toHaveBeenLastCalledWith([file]);
+	});
+
+	it("keeps attachment previews hidden until a file is selected", () => {
+		const { container, rerender } = render(<TaskComposerView {...viewProps()} />);
+
+		const addFile = screen.getByRole("button", { name: "Add file" });
+		expect(addFile.closest(".composer-toolbar")).not.toBeNull();
+		expect(container.querySelector("ul")).toBeNull();
+
+		rerender(
+			<TaskComposerView
+				{...viewProps({
+					attachments: {
+						items: [{ id: "attachment-1", name: "notes.txt" }],
+						onAddFiles: vi.fn(),
+						onRemove: vi.fn(),
+					},
+				})}
+			/>,
+		);
+
+		expect(container.querySelector("ul")).not.toBeNull();
 	});
 
 	it("shows attachment and submission errors with a fallback action", () => {

--- a/packages/product-ui/src/TaskComposerView.test.tsx
+++ b/packages/product-ui/src/TaskComposerView.test.tsx
@@ -1,9 +1,28 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { createElement, type ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	TaskComposerView,
 	type TaskComposerViewProps,
 } from "./TaskComposerView";
+
+const useReducedMotionMock = vi.hoisted(() => vi.fn(() => false));
+const lastAttachmentTransition = vi.hoisted(() => ({
+	current: undefined as { duration?: number } | undefined,
+}));
+
+vi.mock("motion/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("motion/react")>();
+	function MotionDiv(props: ComponentProps<typeof actual.motion.div>) {
+		lastAttachmentTransition.current = props.transition as { duration?: number } | undefined;
+		return createElement(actual.motion.div, props);
+	}
+	return {
+		...actual,
+		useReducedMotion: useReducedMotionMock,
+		motion: { ...actual.motion, div: MotionDiv },
+	};
+});
 
 function viewProps(overrides: Partial<TaskComposerViewProps> = {}): TaskComposerViewProps {
 	return {
@@ -72,6 +91,11 @@ function viewProps(overrides: Partial<TaskComposerViewProps> = {}): TaskComposer
 }
 
 describe("TaskComposerView", () => {
+	beforeEach(() => {
+		useReducedMotionMock.mockReturnValue(false);
+		lastAttachmentTransition.current = undefined;
+	});
+
 	it("renders controlled project, agent, model, and prompt state", () => {
 		const props = viewProps();
 		render(<TaskComposerView {...props} />);
@@ -170,6 +194,23 @@ describe("TaskComposerView", () => {
 		);
 
 		expect(container.querySelector("ul")).not.toBeNull();
+	});
+
+	it("makes the attachment transition instant when reduced motion is preferred", () => {
+		useReducedMotionMock.mockReturnValue(true);
+		render(
+			<TaskComposerView
+				{...viewProps({
+					attachments: {
+						items: [{ id: "attachment-1", name: "notes.txt" }],
+						onAddFiles: vi.fn(),
+						onRemove: vi.fn(),
+					},
+				})}
+			/>,
+		);
+
+		expect(lastAttachmentTransition.current).toEqual({ duration: 0 });
 	});
 
 	it("shows attachment and submission errors with a fallback action", () => {

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -3,17 +3,25 @@ import {
 	type DragEvent,
 	type FormEvent,
 	type ReactNode,
+	memo,
+	useCallback,
 	useEffect,
 	useId,
 	useRef,
 	useState,
 } from "react";
+import { AnimatePresence, motion } from "motion/react";
 import {
 	FileTextIcon as FileText,
 	LoaderCircleIcon as Loader2,
-	PlusIcon as Plus,
+	PaperclipIcon as Paperclip,
 	XIcon as X,
 } from "./icons";
+
+// One fixed-height, non-wrapping row: 56px attachment tiles plus 6px top and
+// 8px bottom padding. Keeping this numeric avoids Motion's auto-height layout
+// measurement when an image is pasted.
+const ATTACHMENT_ROW_HEIGHT = 70;
 
 export type TaskComposerAgentOption = {
 	authStatus?: "authorized" | "unauthorized" | "unknown";
@@ -78,8 +86,8 @@ export type TaskComposerSubmission = {
 	error?: string;
 	isSubmitting: boolean;
 	modelWarning?: string;
-	onFallbackAction: () => void;
-	onSubmit: () => void;
+	onFallbackAction: (prompt: string) => void;
+	onSubmit: (prompt: string) => void;
 };
 
 export type TaskComposerLabels = {
@@ -98,24 +106,82 @@ export type TaskComposerViewProps = {
 	attachments: TaskComposerAttachments;
 	autoFocusPrompt?: boolean;
 	canSubmit: boolean;
+	initialPrompt?: string;
 	labels: TaskComposerLabels;
 	model: Omit<TaskComposerModelControl, "id">;
 	onPromptChange: (value: string) => void;
-	prompt: string;
 	renderAgentControl: (control: TaskComposerAgentControl) => ReactNode;
 	renderModelControl: (control: TaskComposerModelControl) => ReactNode;
 	submission: TaskComposerSubmission;
 };
+
+type TaskPromptProps = {
+	autoFocus?: boolean;
+	id: string;
+	initialValue: string;
+	label: string;
+	onChange: (value: string) => void;
+	onPaste: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
+	placeholder: string;
+};
+
+const TaskPrompt = memo(function TaskPrompt({
+	autoFocus,
+	id,
+	initialValue,
+	label,
+	onChange,
+	onPaste,
+	placeholder,
+}: TaskPromptProps) {
+	const [value, setValue] = useState(initialValue);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		const el = textareaRef.current;
+		if (!el) return;
+		el.style.height = "auto";
+		el.style.height = `${el.scrollHeight}px`;
+	}, [value]);
+
+	return (
+		<>
+			<label className="sr-only" htmlFor={id}>
+				{label}
+			</label>
+			<textarea
+				ref={textareaRef}
+				id={id}
+				autoFocus={autoFocus}
+				className="min-h-[calc(3lh+1.75rem)] max-h-[calc(8lh+1.75rem)] w-full resize-none overflow-y-auto bg-transparent px-4 pb-3 pt-4 text-md leading-relaxed text-foreground outline-none placeholder:text-passive"
+				placeholder={placeholder}
+				value={value}
+				onChange={(event) => {
+					const nextValue = event.target.value;
+					setValue(nextValue);
+					onChange(nextValue);
+				}}
+				onPaste={onPaste}
+				onKeyDown={(event) => {
+					if (event.key === "Enter" && !event.shiftKey && !event.altKey && !event.nativeEvent.isComposing) {
+						event.preventDefault();
+						event.currentTarget.form?.requestSubmit();
+					}
+				}}
+			/>
+		</>
+	);
+});
 
 export function TaskComposerView({
 	agent,
 	attachments,
 	autoFocusPrompt,
 	canSubmit,
+	initialPrompt = "",
 	labels,
 	model,
 	onPromptChange,
-	prompt,
 	renderAgentControl,
 	renderModelControl,
 	submission,
@@ -124,19 +190,19 @@ export function TaskComposerView({
 	const modelId = useId();
 	const agentId = useId();
 	const fileInputRef = useRef<HTMLInputElement>(null);
-	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const promptRef = useRef(initialPrompt);
 	const [isDragging, setIsDragging] = useState(false);
-
-	useEffect(() => {
-		const el = textareaRef.current;
-		if (!el) return;
-		el.style.height = "auto";
-		el.style.height = `${el.scrollHeight}px`;
-	}, [prompt]);
+	const handlePromptChange = useCallback(
+		(value: string) => {
+			promptRef.current = value;
+			onPromptChange(value);
+		},
+		[onPromptChange],
+	);
 
 	const submit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
-		submission.onSubmit();
+		submission.onSubmit(promptRef.current);
 	};
 
 	const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
@@ -172,84 +238,74 @@ export function TaskComposerView({
 				if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) setIsDragging(false);
 			}}
 		>
-			<label className="sr-only" htmlFor={promptId}>
-				{labels.task}
-			</label>
-			<textarea
-				ref={textareaRef}
-				id={promptId}
+			<TaskPrompt
 				autoFocus={autoFocusPrompt}
-				className="min-h-[calc(2lh+1.75rem)] max-h-[calc(8lh+1.75rem)] w-full resize-none overflow-y-auto bg-transparent px-4 pb-3 pt-4 text-md leading-relaxed text-foreground outline-none placeholder:text-passive"
-				placeholder={labels.taskPlaceholder}
-				value={prompt}
-				onChange={(event) => onPromptChange(event.target.value)}
+				id={promptId}
+				initialValue={initialPrompt}
+				label={labels.task}
+				onChange={handlePromptChange}
 				onPaste={handlePaste}
-				onKeyDown={(event) => {
-					if (event.key === "Enter" && !event.shiftKey && !event.altKey && !event.nativeEvent.isComposing) {
-						event.preventDefault();
-						event.currentTarget.form?.requestSubmit();
-					}
-				}}
+				placeholder={labels.taskPlaceholder}
 			/>
 
-			<ul className="scrollbar-none flex w-full flex-row flex-nowrap items-center gap-2 overflow-x-auto px-3 pt-1.5 pb-2">
-				<li className="shrink-0">
-					<button
-						type="button"
-						className="flex size-14 cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-border text-muted-foreground transition-colors hover:border-accent hover:bg-surface hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[dragging=true]:border-accent data-[dragging=true]:bg-surface"
-						data-dragging={isDragging || undefined}
-						aria-label={labels.addFile}
-						onClick={() => fileInputRef.current?.click()}
+			<AnimatePresence initial={false}>
+				{attachments.items.length > 0 ? (
+					<motion.div
+						className="overflow-hidden"
+						initial={{ height: 0 }}
+						animate={{ height: ATTACHMENT_ROW_HEIGHT }}
+						exit={{ height: 0 }}
+						transition={{ type: "spring", duration: 0.3, bounce: 0 }}
 					>
-						<Plus className="size-5" aria-hidden="true" />
-					</button>
-				</li>
-
-				{attachments.items.map((attachment) => (
-					<li key={attachment.id} className="shrink-0">
-						{attachment.previewUrl ? (
-							<div className="relative size-14 rounded-lg border border-border bg-surface overflow-hidden group">
-								<img
-									src={attachment.previewUrl}
-									alt=""
-									className="size-full object-cover"
-								/>
-								<button
-									type="button"
-									className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background/80 text-muted-foreground hover:bg-background hover:text-foreground shadow-sm transition-colors"
-									aria-label={labels.removeFile(attachment.name)}
-									onClick={() => attachments.onRemove(attachment.id)}
-								>
-									<X className="size-3" aria-hidden="true" />
-								</button>
-							</div>
-						) : (
-							<div className="relative flex h-14 min-w-36 max-w-48 items-center gap-2 rounded-lg border border-border bg-surface pl-2.5 pr-8 py-1.5 text-xs text-foreground group">
-								<FileText
-									className="size-7.5 shrink-0 rounded bg-input/60 p-1.5 text-muted-foreground"
-									aria-hidden="true"
-								/>
-								<div className="min-w-0 flex-1 flex flex-col justify-center">
-									<span className="truncate font-semibold leading-tight" title={attachment.name}>
-										{attachment.name}
-									</span>
-									<span className="text-[10px] text-muted-foreground leading-normal mt-0.5 truncate">
-										File
-									</span>
-								</div>
-								<button
-									type="button"
-									className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background border border-border text-muted-foreground hover:bg-muted hover:text-foreground shadow-sm transition-colors"
-									aria-label={labels.removeFile(attachment.name)}
-									onClick={() => attachments.onRemove(attachment.id)}
-								>
-									<X className="size-3" aria-hidden="true" />
-								</button>
-							</div>
-						)}
-					</li>
-				))}
-			</ul>
+						<ul className="scrollbar-none flex w-full flex-row flex-nowrap items-center gap-2 overflow-x-auto px-3 pt-1.5 pb-2">
+							{attachments.items.map((attachment) => (
+								<li key={attachment.id} className="shrink-0">
+									{attachment.previewUrl ? (
+										<div className="relative size-14 rounded-lg border border-border bg-surface overflow-hidden group">
+											<img
+												src={attachment.previewUrl}
+												alt=""
+												className="size-full object-cover"
+											/>
+											<button
+												type="button"
+												className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background/80 text-muted-foreground hover:bg-background hover:text-foreground shadow-sm transition-colors"
+												aria-label={labels.removeFile(attachment.name)}
+												onClick={() => attachments.onRemove(attachment.id)}
+											>
+												<X className="size-3" aria-hidden="true" />
+											</button>
+										</div>
+									) : (
+										<div className="relative flex h-14 min-w-36 max-w-48 items-center gap-2 rounded-lg border border-border bg-surface pl-2.5 pr-8 py-1.5 text-xs text-foreground group">
+											<FileText
+												className="size-7.5 shrink-0 rounded bg-input/60 p-1.5 text-muted-foreground"
+												aria-hidden="true"
+											/>
+											<div className="min-w-0 flex-1 flex flex-col justify-center">
+												<span className="truncate font-semibold leading-tight" title={attachment.name}>
+													{attachment.name}
+												</span>
+												<span className="text-[10px] text-muted-foreground leading-normal mt-0.5 truncate">
+													File
+												</span>
+											</div>
+											<button
+												type="button"
+												className="absolute top-1 right-1 grid size-4.5 place-items-center rounded-full bg-background border border-border text-muted-foreground hover:bg-muted hover:text-foreground shadow-sm transition-colors"
+												aria-label={labels.removeFile(attachment.name)}
+												onClick={() => attachments.onRemove(attachment.id)}
+											>
+												<X className="size-3" aria-hidden="true" />
+											</button>
+										</div>
+									)}
+								</li>
+							))}
+						</ul>
+					</motion.div>
+				) : null}
+			</AnimatePresence>
 			<input
 				ref={fileInputRef}
 				type="file"
@@ -276,7 +332,7 @@ export function TaskComposerView({
 								<button
 									type="button"
 									disabled={submission.isSubmitting}
-									onClick={submission.onFallbackAction}
+									onClick={() => submission.onFallbackAction(promptRef.current)}
 									className="inline-flex h-control-md shrink-0 items-center justify-center rounded-md border border-border bg-background px-2.5 text-xs text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
 								>
 									{labels.fallbackAction}
@@ -300,6 +356,15 @@ export function TaskComposerView({
 						{renderModelControl({ ...model, id: modelId })}
 					</div>
 				</div>
+
+				<button
+					type="button"
+					className="inline-flex size-(--size-settings-action-height) shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					aria-label={labels.addFile}
+					onClick={() => fileInputRef.current?.click()}
+				>
+					<Paperclip className="size-icon-base" aria-hidden="true" />
+				</button>
 
 				<button
 					type="submit"

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -10,7 +10,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
 	FileTextIcon as FileText,
 	LoaderCircleIcon as Loader2,
@@ -191,6 +191,7 @@ export function TaskComposerView({
 	const agentId = useId();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const promptRef = useRef(initialPrompt);
+	const prefersReducedMotion = useReducedMotion();
 	const [isDragging, setIsDragging] = useState(false);
 	const handlePromptChange = useCallback(
 		(value: string) => {
@@ -252,10 +253,12 @@ export function TaskComposerView({
 				{attachments.items.length > 0 ? (
 					<motion.div
 						className="overflow-hidden"
-						initial={{ height: 0 }}
+						initial={prefersReducedMotion ? false : { height: 0 }}
 						animate={{ height: ATTACHMENT_ROW_HEIGHT }}
 						exit={{ height: 0 }}
-						transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+						transition={
+							prefersReducedMotion ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 }
+						}
 					>
 						<ul className="scrollbar-none flex w-full flex-row flex-nowrap items-center gap-2 overflow-x-auto px-3 pt-1.5 pb-2">
 							{attachments.items.map((attachment) => (


### PR DESCRIPTION
## Summary

- Move the new-task attachment action into the bottom toolbar and show previews only after files are attached.
- Animate the fixed-height attachment container without auto-height measurement.
- Keep prompt state local to avoid re-rendering composer controls on every keystroke.

## Test plan

- [x] `npm --prefix frontend test -- src/renderer/components/TaskComposer.test.tsx` (20 passing)