### PR TITLE
chore(mobile): react-native 0.86.2 to 0.86.3

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -34,7 +34,7 @@
 				"expo-updates": "~57.0.16",
 				"posthog-react-native": "^4.62.0",
 				"react": "19.2.3",
-				"react-native": "0.86.2",
+				"react-native": "0.86.3",
 				"react-native-safe-area-context": "~5.7.0",
 				"react-native-screens": "~4.26.0",
 				"react-native-webview": "13.16.1"
@@ -2277,9 +2277,9 @@
 			}
 		},
 		"node_modules/@react-native/assets-registry": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.2.tgz",
-			"integrity": "sha512-vcX/mBjWAVnWofu7KecotquI2unZ/tITwA7OGdq/mdY/zmGXIEvYhfEYyOQij/LRqi9WAL+iizInTBWnxDhK/Q==",
+			"version": "0.86.3",
+			"resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.3.tgz",
+			"integrity": "sha512-TDhgCZA4wjJg84d5A9swiOQYPIWSKEEVdg9IwMFZDupQzW/F3QoLUrfAJOcalgqTDA9/buTB8awhE3Whwg6u9Q==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
@@ -2335,12 +2335,12 @@
 			}
 		},
 		"node_modules/@react-native/community-cli-plugin": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.2.tgz",
-			"integrity": "sha512-YHXNKoM6Y/HjREySZ5arET2xgiHgg67r1MdwJB//MPJAJ0Xc5g0u6UHxY9VzsHO3Y07dre6s0BinYwjt1SEWvQ==",
+			"version": "0.86.3",
+			"resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.3.tgz",
+			"integrity": "sha512-qSDL9LQc5mZSZPNczT95WU9YQuPzxBklgON9vLhhqfI0yWIwKInqFx88dQ/uiEXBtf0yossthaQIqA4Ml6bF6g==",
 			"license": "MIT",
 			"dependencies": {
-				"@react-native/dev-middleware": "0.86.2",
+				"@react-native/dev-middleware": "0.86.3",
 				"debug": "^4.4.0",
 				"invariant": "^2.2.4",
 				"metro": "^0.84.3",
@@ -2353,80 +2353,13 @@
 			},
 			"peerDependencies": {
 				"@react-native-community/cli": "*",
-				"@react-native/metro-config": "0.86.2"
+				"@react-native/metro-config": "0.86.3"
 			},
 			"peerDependenciesMeta": {
 				"@react-native-community/cli": {
 					"optional": true
 				},
 				"@react-native/metro-config": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.2.tgz",
-			"integrity": "sha512-KGS1aV5F6cIqpnoIUhLBXyVzy1oAj8jBFGau6vX4Vy0HXRJN7p+68RU7x6NuyraHvQcR14ccMGT5TkFuNjQ4gA==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-			}
-		},
-		"node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-shell": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.2.tgz",
-			"integrity": "sha512-/TaVJ2+gGajZPJGrFaObUQmHmlaxAlfmOPZicl6pNKDUjzSgFMpcLkdTOExvb+USYTVdGX1XwxXyvjQdUO2bvg==",
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"debug": "^4.4.0",
-				"fb-dotslash": "0.5.8"
-			},
-			"engines": {
-				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-			}
-		},
-		"node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.2.tgz",
-			"integrity": "sha512-B7L0vKvg+IcEElT7Vpqh1xj5yJAqWUegjbP+bQRaorJMAYnv11GkliTnZV2AdTDfZQJWgOEx8i8LGkHkUg7bnA==",
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/ttlcache": "^1.4.1",
-				"@react-native/debugger-frontend": "0.86.2",
-				"@react-native/debugger-shell": "0.86.2",
-				"chrome-launcher": "^0.15.2",
-				"chromium-edge-launcher": "^0.3.0",
-				"connect": "^3.6.5",
-				"debug": "^4.4.0",
-				"invariant": "^2.2.4",
-				"nullthrows": "^1.1.1",
-				"open": "^7.0.3",
-				"serve-static": "^1.16.2",
-				"ws": "^7.5.10"
-			},
-			"engines": {
-				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-			}
-		},
-		"node_modules/@react-native/community-cli-plugin/node_modules/ws": {
-			"version": "7.5.13",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
 					"optional": true
 				}
 			}
@@ -2499,18 +2432,18 @@
 			}
 		},
 		"node_modules/@react-native/gradle-plugin": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.2.tgz",
-			"integrity": "sha512-2F6x14NcHMpVmfTTFKfMkpV5dZedZrLiv6PE+c3vgnesV2bjleUBydr4U+NI8VkI7OwW71L0A5qQ76I9LCrfoQ==",
+			"version": "0.86.3",
+			"resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.3.tgz",
+			"integrity": "sha512-lxmx0GqLEWRIpZfpYFXlYVIs3ENQwaW6Vmp6oi29l2GoQJ1wZfFZRdMimDWlGEk8LKfHar3QH3iaPMkTcK9lEQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/@react-native/js-polyfills": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.2.tgz",
-			"integrity": "sha512-bIwNcGBaQ74shB5z1mRkxOpjikimuwsnOCEkZSzL67Z1FTyK1ObpENfyd2QvcvVW9Cjl+tHuw9ynpBnb2jPoJQ==",
+			"version": "0.86.3",
+			"resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.3.tgz",
+			"integrity": "sha512-eYIJ0es967+tePBFQDnl/gidVFxLns3fnbiK6rxscQrGodvuUO6hwxpQnfNynJ8MjbbndImXihXjcnJdc7SzJg==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
@@ -2523,9 +2456,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@react-native/virtualized-lists": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.2.tgz",
-			"integrity": "sha512-uO0J72gh3EvE+1/GHRk18QRyBDTRHRB0AraAfojsRjbT7VMuJwKrZYaKGshavoaEud6aw00ZB9/8mTMIKjjcAw==",
+			"version": "0.86.3",
+			"resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.3.tgz",
+			"integrity": "sha512-1j44NEyNn05Ut40vHAmoSWbsIcybFkMAOBTwQt1PrESyfSS+qBoyU1LGIogNva0VIa0rQyEC5PzbA7R4/7Nhyw==",
 			"license": "MIT",
 			"dependencies": {
 				"invariant": "^2.2.4",
@@ -2537,7 +2470,7 @@
 			"peerDependencies": {
 				"@types/react": "^19.2.0",
 				"react": "*",
-				"react-native": "0.86.2"
+				"react-native": "0.86.3"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -5063,9 +4996,9 @@
 			}
 		},
 		"node_modules/hermes-compiler": {
-			"version": "250829098.0.16",
-			"resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.16.tgz",
-			"integrity": "sha512-xsgzk+mUyvt9t1nUbF8USBlYxajTUtPJhVZ86q85s/SEoMKCF+52YZcudb0ENSnV3T3lV9mgB3s6R7+pH90zgw==",
+			"version": "250829098.0.17",
+			"resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.17.tgz",
+			"integrity": "sha512-qG1PXzTEtriF6oQLZF3vyHhSMxOdW5h2TqqLri0rdpstPustd2fSvRZQMVAPdlhgFwBfYnj3OUZtiO6LjYsEFw==",
 			"license": "MIT"
 		},
 		"node_modules/hermes-estree": {
@@ -7096,18 +7029,18 @@
 			"license": "MIT"
 		},
 		"node_modules/react-native": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.2.tgz",
-			"integrity": "sha512-zbJXGZpwfZGA79Z9ob6Atvfx4nAQL8yJBa35s58E4Oo+khPykfQP2sTeumkKbjwajFYfVayg8pj7Il9nIfTk7A==",
+			"version": "0.86.3",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.3.tgz",
+			"integrity": "sha512-JR5s3bM9ezud+Mw24GlNXNfthqPIKwrQgPPJcam+L97t2sKjjEavhCzBn+fyqZZRcM5+XlhYxpTxVkK7e1n38Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@react-native/assets-registry": "0.86.2",
-				"@react-native/codegen": "0.86.2",
-				"@react-native/community-cli-plugin": "0.86.2",
-				"@react-native/gradle-plugin": "0.86.2",
-				"@react-native/js-polyfills": "0.86.2",
-				"@react-native/normalize-colors": "0.86.2",
-				"@react-native/virtualized-lists": "0.86.2",
+				"@react-native/assets-registry": "0.86.3",
+				"@react-native/codegen": "0.86.3",
+				"@react-native/community-cli-plugin": "0.86.3",
+				"@react-native/gradle-plugin": "0.86.3",
+				"@react-native/js-polyfills": "0.86.3",
+				"@react-native/normalize-colors": "0.86.3",
+				"@react-native/virtualized-lists": "0.86.3",
 				"abort-controller": "^3.0.0",
 				"anser": "^1.4.9",
 				"ansi-regex": "^5.0.0",
@@ -7115,7 +7048,7 @@
 				"base64-js": "^1.5.1",
 				"commander": "^12.0.0",
 				"flow-enums-runtime": "^0.0.6",
-				"hermes-compiler": "250829098.0.16",
+				"hermes-compiler": "250829098.0.17",
 				"invariant": "^2.2.4",
 				"memoize-one": "^5.0.0",
 				"metro-runtime": "^0.84.3",
@@ -7141,7 +7074,7 @@
 				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			},
 			"peerDependencies": {
-				"@react-native/jest-preset": "0.86.2",
+				"@react-native/jest-preset": "0.86.3",
 				"@types/react": "^19.1.1",
 				"react": "^19.2.3"
 			},
@@ -7207,33 +7140,6 @@
 				"react": "*",
 				"react-native": "*"
 			}
-		},
-		"node_modules/react-native/node_modules/@react-native/codegen": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.2.tgz",
-			"integrity": "sha512-xKkudsahUJ1n//55g4fXk5BStVqqmZlz8HQveL45ZxcfDnwvhuYe2GymksQANFsSN+slvrarjrfq8kIxJzbceA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.25.2",
-				"@babel/parser": "^7.29.0",
-				"hermes-parser": "0.36.0",
-				"invariant": "^2.2.4",
-				"nullthrows": "^1.1.1",
-				"tinyglobby": "^0.2.15",
-				"yargs": "^17.6.2"
-			},
-			"engines": {
-				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "*"
-			}
-		},
-		"node_modules/react-native/node_modules/@react-native/normalize-colors": {
-			"version": "0.86.2",
-			"resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.2.tgz",
-			"integrity": "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg==",
-			"license": "MIT"
 		},
 		"node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
 			"version": "0.36.0",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -40,7 +40,7 @@
 		"expo-updates": "~57.0.16",
 		"posthog-react-native": "^4.62.0",
 		"react": "19.2.3",
-		"react-native": "0.86.2",
+		"react-native": "0.86.3",
 		"react-native-safe-area-context": "~5.7.0",
 		"react-native-screens": "~4.26.0",
 		"react-native-webview": "13.16.1"


### PR DESCRIPTION
## What

`react-native` 0.86.2 → 0.86.3. One line in `package.json`; the lock diff is `@react-native/*` moving in lockstep plus some nested duplicates collapsing now that versions align. `expo` stays at 57.0.17.

## Why now

`expo-doctor` has been failing on `main` since #4474:

> Expected version for react-native: 0.86.3, found: 0.86.2

`package.json` pins `"expo": "^57.0.15"` (caret) against `"react-native": "0.86.2"` (exact). #4474 regenerated the lock from scratch, which re-resolved the caret to expo 57.0.17 while the exact pin held. 57.0.17 is the patch where the expected react-native moves to 0.86.3 — confirmed against each version's `bundledNativeModules.json`:

| expo | expects react-native |
| --- | --- |
| 57.0.15 | 0.86.2 |
| 57.0.16 | 0.86.2 |
| 57.0.17 | **0.86.3** |

CI runs typecheck and vitest only, so this was invisible except to anyone running doctor by hand. It was a known, accepted gap at merge time, split out so an RN bump stays bisectable on its own.

## What 0.86.3 contains

No breaking changes. Two fixes land on code this app actually runs:

- **Custom fonts with an explicit `fontWeight` no longer render at maximum weight on the New Architecture.** There are ~109 `fontWeight` usages paired with `fontFamily: t.fontMono`, so this is a live rendering bug on 0.86.2.
- **`getInitialURL` no longer throws `ConcurrentModificationException` when it re-enters during `onHostResume`.** The app uses `expo-linking`, and `UpdatesManager` (new in #4474) now does work on the `AppState` resume path.

Also in the release: Hermes bumped to 250829098.0.17, a use-after-free data race fixed in `EventEmitter.cpp`, `parentNode`/`parentElement` fixed for `<Modal>` and nested root host views, and `Podfile.lock` SPEC CHECKSUMS made deterministic across machines.

## Verification

- `expo-doctor` **21/21** (was 20/21 on `main`)
- `tsc --noEmit` clean
- 495 tests across 58 files passing
- `expo-updates runtimeversion:resolve` stable across repeated runs on both platforms — ios `8c22f70a…`, android `0d5c95ec…`. The value differs from `main`'s, as expected: an RN bump changes native inputs, so the fingerprint runtime moves. Nothing has shipped on the old runtime, so no build is stranded.

## Not verified

- **Native builds on either platform.** Needs `npx expo prebuild --clean` then a real iOS and Android build before this is trusted — doctor, typecheck and tests all passed while `expo-speech-recognition` was broken during the SDK 57 upgrade, so this trio is not sufficient evidence.
- **The font-weight fix, visually.** Text using `fontFamily: t.fontMono` with an explicit weight should visibly differentiate after this; currently it renders uniformly bold. Worth an eyeball on device to confirm the fix took.
