### PR TITLE
fix(frontend): match notification scrollbar styling

### DIFF
--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -289,6 +289,7 @@ describe("NotificationCenter", () => {
 		await clickOpen();
 
 		const panel = within(screen.getByRole("dialog", { name: "Notifications" }));
+		expect(panel.getByRole("list")).toHaveClass("board-scrollbar", "overflow-y-auto");
 		expect(panel.queryByRole("tab", { name: "Unread" })).not.toBeInTheDocument();
 		expect(panel.queryByRole("tab", { name: "All" })).not.toBeInTheDocument();
 		expect(panel.queryByText("Unseen")).not.toBeInTheDocument();

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -353,7 +353,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 				) : (
 					<div
 						aria-busy={allQuery.isFetchingNextPage}
-						className="max-h-notification-max-height overflow-y-auto overscroll-contain py-1.5"
+						className="board-scrollbar max-h-notification-max-height overflow-y-auto overscroll-contain py-1.5"
 						onScroll={loadEarlierOnScroll}
 						role="list"
 					>


### PR DESCRIPTION
## What

Apply AO shared minimal scrollbar styling to the notification list.

## Why

The notification panel was rendering the wide native scrollbar, which did not match the rest of the AO interface.

## How

Reuse the existing `board-scrollbar` class on the notification list. Scrolling, overscroll containment, and paginated loading behavior remain unchanged.

## Testing

- `npm test -- --run src/renderer/components/NotificationCenter.test.tsx` — 27 tests passed
- `npm run typecheck` — passed after installing the linked `packages/product-ui` dependencies
- `git diff --check` — passed
- Full `npm test` attempted on Windows: 200 test files and 2,863 tests passed; unrelated platform/dependency failures and worker OOM remain outside this change
- `npm run build` is not available in `frontend/package.json`
- Manual desktop visual testing intentionally left to the requester

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)