### PR TITLE
fix: propagate CI injection toggle to session PRs

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2087,7 +2087,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Not Implemented
-      summary: Set the automatic CI-failure injection default for new session PRs
+      summary: Set automatic CI-failure injection for a session and its PRs
       tags:
       - sessions
   /api/v1/sessions/{sessionId}/auto-inject-review:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -1718,7 +1718,7 @@ func sessionOperations() []operation {
 		},
 		{
 			method: http.MethodPatch, path: "/api/v1/sessions/{sessionId}/auto-inject-ci", id: "setSessionAutoInjectCI", tag: "sessions",
-			summary:    "Set the automatic CI-failure injection default for new session PRs",
+			summary:    "Set automatic CI-failure injection for a session and its PRs",
 			pathParams: []any{controllers.SessionIDParam{}},
 			reqBody:    controllers.SetSessionAutoInjectCIRequest{},
 			resps: []respUnit{

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -567,13 +567,13 @@ type SetSessionAutoInjectReviewResponse struct {
 	Session          SessionView      `json:"session"`
 }
 
-// SetSessionAutoInjectCIRequest updates the default automatic CI delivery
-// policy captured by PRs created after the change.
+// SetSessionAutoInjectCIRequest updates automatic CI delivery for a session
+// and every PR currently owned by it.
 type SetSessionAutoInjectCIRequest struct {
 	AutoInjectCI bool `json:"autoInjectCI"`
 }
 
-// SetSessionAutoInjectCIResponse confirms the persisted session default.
+// SetSessionAutoInjectCIResponse confirms the persisted session policy.
 type SetSessionAutoInjectCIResponse struct {
 	OK           bool             `json:"ok"`
 	SessionID    domain.SessionID `json:"sessionId"`

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -684,6 +684,20 @@ func (q *Queries) ResolveConflictingPRAliasNotifications(ctx context.Context, ar
 	return err
 }
 
+const setPRAutoInjectCIBySession = `-- name: SetPRAutoInjectCIBySession :exec
+UPDATE pr SET auto_inject_ci = ? WHERE session_id = ?
+`
+
+type SetPRAutoInjectCIBySessionParams struct {
+	AutoInjectCI bool
+	SessionID    domain.SessionID
+}
+
+func (q *Queries) SetPRAutoInjectCIBySession(ctx context.Context, arg SetPRAutoInjectCIBySessionParams) error {
+	_, err := q.db.ExecContext(ctx, setPRAutoInjectCIBySession, arg.AutoInjectCI, arg.SessionID)
+	return err
+}
+
 const updatePRLastNudgeSignature = `-- name: UpdatePRLastNudgeSignature :exec
 UPDATE pr SET last_nudge_signature = ? WHERE url = ?
 `

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -114,6 +114,7 @@ var shippedMigrations = map[int64]string{
 	108: "0108_conversation_retry_source.sql",
 	109: "0109_session_latest_user_prompt_at.sql",
 	110: "0110_approximate_conversation_branches.sql",
+	111: "0111_pr_auto_inject_ci_cdc.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0111_pr_auto_inject_ci_cdc.sql
+++ b/backend/internal/storage/sqlite/migrations/0111_pr_auto_inject_ci_cdc.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+DROP TRIGGER IF EXISTS pr_cdc_update;
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+    OR OLD.auto_inject_ci <> NEW.auto_inject_ci
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability,
+                    'autoInjectCI', json(CASE WHEN NEW.auto_inject_ci THEN 'true' ELSE 'false' END)),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TRIGGER IF EXISTS pr_cdc_update;
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -185,6 +185,9 @@ SELECT last_nudge_signature FROM pr WHERE url = ?;
 -- name: UpdatePRLastNudgeSignature :exec
 UPDATE pr SET last_nudge_signature = ? WHERE url = ?;
 
+-- name: SetPRAutoInjectCIBySession :exec
+UPDATE pr SET auto_inject_ci = ? WHERE session_id = ?;
+
 -- name: GetDisplayPRFactsBySession :one
 SELECT
     pr.url,

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -193,20 +193,38 @@ func (s *Store) SetSessionAutoInjectReview(ctx context.Context, id domain.Sessio
 	return rows > 0, nil
 }
 
-// SetSessionAutoInjectCI persists the default CI-failure injection policy that
-// newly created PRs snapshot. Existing PR rows retain their original value.
+// SetSessionAutoInjectCI persists the CI-failure injection policy for the
+// session and every PR currently owned by it. Future PRs still inherit this
+// value from the session row when first observed.
 func (s *Store) SetSessionAutoInjectCI(ctx context.Context, id domain.SessionID, autoInject bool, updatedAt time.Time) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	rows, err := s.qw.SetSessionAutoInjectCI(ctx, gen.SetSessionAutoInjectCIParams{
-		ID:           id,
-		AutoInjectCI: autoInject,
-		UpdatedAt:    updatedAt,
+	var updated bool
+	err := s.inTx(ctx, fmt.Sprintf("set auto-inject CI for session %s", id), func(q *gen.Queries) error {
+		rows, err := q.SetSessionAutoInjectCI(ctx, gen.SetSessionAutoInjectCIParams{
+			ID:           id,
+			AutoInjectCI: autoInject,
+			UpdatedAt:    updatedAt,
+		})
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		updated = true
+		if err := q.SetPRAutoInjectCIBySession(ctx, gen.SetPRAutoInjectCIBySessionParams{
+			AutoInjectCI: autoInject,
+			SessionID:    id,
+		}); err != nil {
+			return err
+		}
+		return nil
 	})
 	if err != nil {
-		return false, fmt.Errorf("set auto-inject CI for session %s: %w", id, err)
+		return false, err
 	}
-	return rows > 0, nil
+	return updated, nil
 }
 
 // SetSessionReviewerHarness persists the reviewer preference for one session.

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -797,7 +797,7 @@ func TestPRCRUD(t *testing.T) {
 	}
 }
 
-func TestPRAutoInjectCISnapshotsSessionDefaultAtCreation(t *testing.T) {
+func TestPRAutoInjectCITracksSessionPolicyChanges(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	seedProject(t, s, "mer")
@@ -817,37 +817,47 @@ func TestPRAutoInjectCISnapshotsSessionDefaultAtCreation(t *testing.T) {
 	changedAt := now.Add(time.Minute)
 	ok, err := s.SetSessionAutoInjectCI(ctx, owner.ID, false, changedAt)
 	if err != nil || !ok {
-		t.Fatalf("disable session CI default: ok=%v err=%v", ok, err)
+		t.Fatalf("disable session CI policy: ok=%v err=%v", ok, err)
 	}
 	session, found, err := s.GetSession(ctx, owner.ID)
 	if err != nil || !found || session.AutoInjectCI {
-		t.Fatalf("disabled session default = found:%v err:%v session:%+v", found, err, session)
+		t.Fatalf("disabled session policy = found:%v err:%v session:%+v", found, err, session)
 	}
 
 	events, err := s.EventsAfter(ctx, base, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(events) != 1 || string(events[0].Type) != "session_updated" {
-		t.Fatalf("policy change events = %+v, want one session_updated", events)
+	if len(events) != 2 {
+		t.Fatalf("policy change events = %+v, want session and PR updates", events)
+	}
+	var sessionPayload []byte
+	for i := range events {
+		if string(events[i].Type) == "session_updated" {
+			sessionPayload = events[i].Payload
+			break
+		}
+	}
+	if sessionPayload == nil {
+		t.Fatalf("policy change events = %+v, want session_updated", events)
 	}
 	var payload map[string]any
-	if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+	if err := json.Unmarshal(sessionPayload, &payload); err != nil {
 		t.Fatal(err)
 	}
 	if enabled, ok := payload["autoInjectCI"].(bool); !ok || enabled {
 		t.Fatalf("autoInjectCI payload = %#v, want false", payload["autoInjectCI"])
 	}
 
-	// Re-observing the first PR after changing the session default must preserve
-	// the value captured when that PR was first inserted.
+	// Re-observing the first PR after changing the session policy must preserve
+	// the currently selected policy.
 	first.UpdatedAt = changedAt.Add(time.Minute)
 	if err := s.WritePR(ctx, first, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	got, _, _ = s.GetPR(ctx, first.URL)
-	if !got.AutoInjectCI {
-		t.Fatal("session toggle rewrote the first PR's enabled snapshot")
+	if got.AutoInjectCI {
+		t.Fatal("session toggle did not rewrite the first PR's enabled policy")
 	}
 
 	second := domain.PullRequest{URL: "https://github.com/o/r/pull/2", SessionID: owner.ID, Number: 2, UpdatedAt: changedAt}
@@ -856,19 +866,19 @@ func TestPRAutoInjectCISnapshotsSessionDefaultAtCreation(t *testing.T) {
 	}
 	got, _, _ = s.GetPR(ctx, second.URL)
 	if got.AutoInjectCI {
-		t.Fatal("PR created while disabled did not capture the disabled default")
+		t.Fatal("PR created while disabled did not inherit the disabled session policy")
 	}
 
 	if ok, err := s.SetSessionAutoInjectCI(ctx, owner.ID, true, changedAt.Add(time.Minute)); err != nil || !ok {
-		t.Fatalf("enable session CI default: ok=%v err=%v", ok, err)
+		t.Fatalf("enable session CI policy: ok=%v err=%v", ok, err)
 	}
 	second.UpdatedAt = changedAt.Add(2 * time.Minute)
 	if err := s.WritePR(ctx, second, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	got, _, _ = s.GetPR(ctx, second.URL)
-	if got.AutoInjectCI {
-		t.Fatal("later session enable rewrote the second PR's disabled snapshot")
+	if !got.AutoInjectCI {
+		t.Fatal("later session enable did not rewrite the second PR's disabled policy")
 	}
 }
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -756,7 +756,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        /** Set the automatic CI-failure injection default for new session PRs */
+        /** Set automatic CI-failure injection for a session and its PRs */
         patch: operations["setSessionAutoInjectCI"];
         trace?: never;
     };

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -663,7 +663,7 @@ describe("SessionInspector PR section", () => {
     }
     expect(
       screen.getByRole("button", {
-        name: "Sends CI failures to the worker.",
+        name: "Sends CI failures to the worker for this session's PRs.",
       }),
     ).toBeInTheDocument();
     expect(

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -683,7 +683,7 @@ describe("SessionInspector PR section", () => {
 
   });
 
-  it("persists the CI injection default before a PR exists", async () => {
+  it("persists the CI injection policy before a PR exists", async () => {
     renderWithQuery(<SessionInspector session={session([])} />);
 
     const toggle = screen.getByRole("switch", {

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -243,7 +243,7 @@
 	"inspector.aria": "Sitzungs-Inspektor",
 	"inspector.branch": "Branch",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "Legt die Standardeinstellung für neu erstellte Pull Requests fest. Wenn deaktiviert, werden CI-Fehler nicht an den Worker-Agenten zur Behebung gesendet.",
+	"inspector.ci.autoInjectDescription": "Sendet CI-Fehler für die Pull Requests dieser Sitzung an den Worker-Agenten.",
 	"inspector.ci.autoInjectError": "Automatische CI-Übertragung konnte nicht aktualisiert werden ({{status}})",
 	"inspector.ci.notInjected": "CI-Fehler wurden nicht gesendet",
 	"inspector.browser": "Browser",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -243,7 +243,7 @@
 	"inspector.aria": "Session inspector",
 	"inspector.branch": "Branch",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "Sends CI failures to the worker.",
+	"inspector.ci.autoInjectDescription": "Sends CI failures to the worker for this session's PRs.",
 	"inspector.ci.autoInjectError": "Unable to update automatic CI injection ({{status}})",
 	"inspector.ci.notInjected": "CI failures not injected",
 	"inspector.browser": "Browser",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -245,7 +245,7 @@
 	"inspector.aria": "Inspector de sesión",
 	"inspector.branch": "Rama",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "Define el valor predeterminado para los pull requests nuevos. Cuando está desactivado, los fallos de CI no se envían al agente de trabajo para corregirlos.",
+	"inspector.ci.autoInjectDescription": "Envía los fallos de CI de los pull requests de esta sesión al agente de trabajo.",
 	"inspector.ci.autoInjectError": "No se pudo actualizar la inyección automática de CI ({{status}})",
 	"inspector.ci.notInjected": "Fallos de CI no enviados",
 	"inspector.browser": "Navegador",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -245,7 +245,7 @@
 	"inspector.aria": "Inspecteur de session",
 	"inspector.branch": "Branche",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "Définit le comportement par défaut des nouvelles pull requests. Lorsque cette option est désactivée, les échecs CI ne sont pas envoyés à l’agent worker pour correction.",
+	"inspector.ci.autoInjectDescription": "Envoie les échecs CI des pull requests de cette session à l’agent worker.",
 	"inspector.ci.autoInjectError": "Impossible de mettre à jour l’injection automatique de la CI ({{status}})",
 	"inspector.ci.notInjected": "Échecs CI non injectés",
 	"inspector.browser": "Navigateur",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -243,7 +243,7 @@
 	"inspector.aria": "セッションインスペクター",
 	"inspector.branch": "ブランチ",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "新しく作成されたプルリクエストのデフォルトを設定します。無効にすると、CI 失敗は修正のためにワーカーエージェントへ送信されません。",
+	"inspector.ci.autoInjectDescription": "このセッションのプルリクエストの CI 失敗をワーカーエージェントへ送信します。",
 	"inspector.ci.autoInjectError": "CI の自動注入を更新できませんでした ({{status}})",
 	"inspector.ci.notInjected": "CI 失敗は注入されていません",
 	"inspector.browser": "ブラウザ",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -243,7 +243,7 @@
 	"inspector.aria": "세션 인스펙터",
 	"inspector.branch": "브랜치",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "새로 생성된 PR의 기본값을 설정합니다. 비활성화하면 CI 실패가 수정을 위해 워커 에이전트에 전송되지 않습니다.",
+	"inspector.ci.autoInjectDescription": "이 세션의 PR에서 발생한 CI 실패를 워커 에이전트에게 보냅니다.",
 	"inspector.ci.autoInjectError": "CI 자동 주입을 업데이트할 수 없습니다 ({{status}})",
 	"inspector.ci.notInjected": "CI 실패가 주입되지 않음",
 	"inspector.browser": "브라우저",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -245,7 +245,7 @@
 	"inspector.aria": "Inspetor da sessão",
 	"inspector.branch": "Branch",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "Define o padrão para novos pull requests. Quando desativado, as falhas de CI não são enviadas ao agente worker para correção.",
+	"inspector.ci.autoInjectDescription": "Envia falhas de CI dos pull requests desta sessão para o agente worker.",
 	"inspector.ci.autoInjectError": "Não foi possível atualizar a injeção automática de CI ({{status}})",
 	"inspector.ci.notInjected": "Falhas de CI não injetadas",
 	"inspector.browser": "Navegador",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -243,7 +243,7 @@
 	"inspector.aria": "会话检查器",
 	"inspector.branch": "分支",
 	"inspector.ci.autoInject": "Automatically fix CI failures",
-	"inspector.ci.autoInjectDescription": "设置新创建拉取请求的默认值。禁用后，CI 失败不会发送给 worker 代理进行修复。",
+	"inspector.ci.autoInjectDescription": "将此会话的拉取请求 CI 失败发送给 worker 代理。",
 	"inspector.ci.autoInjectError": "无法更新 CI 自动注入设置（{{status}}）",
 	"inspector.ci.notInjected": "CI 失败未注入",
 	"inspector.browser": "浏览器",

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -88,7 +88,7 @@ export type WorkspaceSession = {
 	terminateOnPrMerge?: boolean;
 	/** Whether SCM review feedback is automatically injected into the worker. */
 	autoInjectReview?: boolean;
-	/** Default captured by newly created PRs for automatic CI-failure injection. */
+	/** Whether CI failures are automatically injected into the worker. */
 	autoInjectCI?: boolean;
 	/** ISO timestamp from the daemon — used for relative time in the inspector. */
 	createdAt?: string;


### PR DESCRIPTION
## Summary
- propagate the session CI auto-injection toggle to PR rows already owned by the session
- emit PR CDC updates when autoInjectCI changes so session PR summaries refresh
- update API/schema/type/i18n wording so the toggle is no longer described as only a new-PR default

## Tests
- go test ./internal/storage/sqlite/... ./internal/lifecycle ./internal/service/session ./internal/httpd/controllers ./internal/httpd/apispec/...
- npm run sqlc
- npm run api:spec
- npx openapi-typescript@7.4.4 backend/internal/httpd/apispec/openapi.yaml -o frontend/src/api/schema.ts

## Verification caveats
- npm run frontend:typecheck could not start in this worktree because tsc is missing from frontend/node_modules
- broad backend go test ./... still has unrelated environment-sensitive failures around missing configured bundled tmux plus existing tmux/cli/session-manager/systemcheck expectations