### PR TITLE
fix(sidebar): fade message age out under the hover actions

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -575,16 +575,16 @@ describe("Sidebar", () => {
 		const actionButtons = screen.getByLabelText("Pin session").parentElement;
 		const time = actions?.querySelector("time");
 
-		expect(openSession).toHaveClass("pr-[34px]");
+		expect(openSession).toHaveClass("pr-[36px]");
 		expect(openSession).toHaveClass(
-			"group-hover/session-row:pr-[52px]",
-			"group-focus-within/session-row:pr-[52px]",
+			"group-hover/session-row:pr-[50px]",
+			"group-focus-within/session-row:pr-[50px]",
 		);
 		expect(label).toHaveClass("min-w-0", "flex-1", "truncate");
 		expect(actions).toHaveAttribute("data-session-actions");
 		expect(actionButtons).toHaveClass(
 			"absolute",
-			"right-0",
+			"right-0.5",
 			"opacity-0",
 			"group-hover/session-row:pointer-events-auto",
 			"group-hover/session-row:opacity-100",
@@ -594,7 +594,7 @@ describe("Sidebar", () => {
 		expect(time).toHaveAttribute("datetime", lastUserMessageAt);
 		expect(time).toHaveClass(
 			"absolute",
-			"right-0",
+			"right-1.5",
 			"opacity-100",
 			"group-hover/session-row:opacity-0",
 			"group-focus-within/session-row:opacity-0",

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -563,7 +563,7 @@ describe("Sidebar", () => {
 		expect(screen.getByLabelText("Kill session")).toHaveProperty("tabIndex", 0);
 	});
 
-	it("keeps the message age visible while the label yields only the hover action space", () => {
+	it("fades the message age out in favor of the overlaid hover actions", () => {
 		const lastUserMessageAt = "2026-06-29T23:55:00Z";
 		renderSidebar({
 			workspaces: [{ ...workspace, sessions: [{ ...session, lastUserMessageAt }] }],
@@ -577,12 +577,14 @@ describe("Sidebar", () => {
 
 		expect(openSession).toHaveClass("pr-[34px]");
 		expect(openSession).toHaveClass(
-			"group-hover/session-row:pr-[78px]",
-			"group-focus-within/session-row:pr-[78px]",
+			"group-hover/session-row:pr-[52px]",
+			"group-focus-within/session-row:pr-[52px]",
 		);
 		expect(label).toHaveClass("min-w-0", "flex-1", "truncate");
 		expect(actions).toHaveAttribute("data-session-actions");
 		expect(actionButtons).toHaveClass(
+			"absolute",
+			"right-0",
 			"opacity-0",
 			"group-hover/session-row:pointer-events-auto",
 			"group-hover/session-row:opacity-100",
@@ -590,7 +592,13 @@ describe("Sidebar", () => {
 			"group-focus-within/session-row:opacity-100",
 		);
 		expect(time).toHaveAttribute("datetime", lastUserMessageAt);
-		expect(time).not.toHaveClass("opacity-0");
+		expect(time).toHaveClass(
+			"absolute",
+			"right-0",
+			"opacity-100",
+			"group-hover/session-row:opacity-0",
+			"group-focus-within/session-row:opacity-0",
+		);
 		expect(openSession).toHaveClass("pl-1.5");
 		expect(openSession.closest("li")).toHaveClass("pl-0.5");
 	});

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1631,7 +1631,10 @@ function SessionRow({
 					<input
 						aria-label={t("shell.renameSession", { title: session.title })}
 						autoFocus
-						className="h-full min-w-0 flex-1 appearance-none border-0 bg-transparent! p-0 text-sm text-foreground outline-none ring-0 focus:outline-none focus:ring-0"
+						className={cn(
+							"h-full min-w-0 flex-1 appearance-none border-0 bg-transparent! p-0 text-sm text-foreground outline-none ring-0 focus:outline-none focus:ring-0",
+							session.lastUserMessageAt && "pr-[34px]",
+						)}
 						data-session-inline-editor=""
 						maxLength={MAX_DISPLAY_NAME_LEN}
 						onBlur={() => void commit()}
@@ -1693,9 +1696,7 @@ function SessionRow({
 								"flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-lg py-0 pl-1.5 text-left text-sm outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring",
 								session.lastUserMessageAt ? "pr-[34px]" : "pr-2.5",
 								!reorder?.isDragging &&
-									(session.lastUserMessageAt
-										? "group-hover/session-row:pr-[78px] group-focus-within/session-row:pr-[78px]"
-										: "group-hover/session-row:pr-[52px] group-focus-within/session-row:pr-[52px]"),
+									"group-hover/session-row:pr-[52px] group-focus-within/session-row:pr-[52px]",
 								reorder && "cursor-grab active:cursor-grabbing",
 								reorder?.isDragging && "!cursor-grabbing",
 							)}
@@ -1772,7 +1773,7 @@ const SessionMessageAge = memo(function SessionMessageAge({ session }: { session
 
 	return (
 		<time
-			className="min-w-0 shrink-0 whitespace-nowrap font-mono text-micro text-passive"
+			className="absolute inset-y-0 right-0 flex min-w-0 shrink-0 items-center whitespace-nowrap font-mono text-micro text-passive opacity-100 transition-opacity duration-100 ease-out group-hover/session-row:opacity-0 group-focus-within/session-row:opacity-0"
 			data-session-message-age=""
 			dateTime={session.lastUserMessageAt}
 			title={t("shell.lastMessageAt", { time: formatTimeCompact(session.lastUserMessageAt) })}
@@ -1796,13 +1797,13 @@ const SessionActions = memo(function SessionActions({
 
 	return (
 		<div
-			className="pointer-events-none absolute inset-y-0 right-1 z-chrome flex items-center gap-1"
+			className="pointer-events-none absolute inset-y-0 right-1 z-chrome"
 			data-session-actions=""
 			onPointerDown={(event) => event.stopPropagation()}
 		>
 			<div
 				className={cn(
-					"flex items-center gap-px opacity-0",
+					"absolute inset-y-0 right-0 flex items-center gap-px opacity-0 transition-opacity duration-100 ease-out",
 					!isDragging &&
 						"group-hover/session-row:pointer-events-auto group-hover/session-row:opacity-100 group-focus-within/session-row:pointer-events-auto group-focus-within/session-row:opacity-100",
 				)}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1633,7 +1633,7 @@ function SessionRow({
 						autoFocus
 						className={cn(
 							"h-full min-w-0 flex-1 appearance-none border-0 bg-transparent! p-0 text-sm text-foreground outline-none ring-0 focus:outline-none focus:ring-0",
-							session.lastUserMessageAt && "pr-[34px]",
+							session.lastUserMessageAt && "pr-[36px]",
 						)}
 						data-session-inline-editor=""
 						maxLength={MAX_DISPLAY_NAME_LEN}
@@ -1694,9 +1694,9 @@ function SessionRow({
 							aria-label={t("shell.openSession", { title: session.title })}
 							className={cn(
 								"flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-lg py-0 pl-1.5 text-left text-sm outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring",
-								session.lastUserMessageAt ? "pr-[34px]" : "pr-2.5",
+								session.lastUserMessageAt ? "pr-[36px]" : "pr-2.5",
 								!reorder?.isDragging &&
-									"group-hover/session-row:pr-[52px] group-focus-within/session-row:pr-[52px]",
+									"group-hover/session-row:pr-[50px] group-focus-within/session-row:pr-[50px]",
 								reorder && "cursor-grab active:cursor-grabbing",
 								reorder?.isDragging && "!cursor-grabbing",
 							)}
@@ -1773,7 +1773,7 @@ const SessionMessageAge = memo(function SessionMessageAge({ session }: { session
 
 	return (
 		<time
-			className="absolute inset-y-0 right-0 flex min-w-0 shrink-0 items-center whitespace-nowrap font-mono text-micro text-passive opacity-100 transition-opacity duration-100 ease-out group-hover/session-row:opacity-0 group-focus-within/session-row:opacity-0"
+			className="absolute inset-y-0 right-1.5 flex min-w-0 shrink-0 items-center whitespace-nowrap font-mono text-micro text-passive opacity-100 transition-opacity duration-100 ease-out group-hover/session-row:opacity-0 group-focus-within/session-row:opacity-0"
 			data-session-message-age=""
 			dateTime={session.lastUserMessageAt}
 			title={t("shell.lastMessageAt", { time: formatTimeCompact(session.lastUserMessageAt) })}
@@ -1797,13 +1797,13 @@ const SessionActions = memo(function SessionActions({
 
 	return (
 		<div
-			className="pointer-events-none absolute inset-y-0 right-1 z-chrome"
+			className="pointer-events-none absolute inset-y-0 right-0 z-chrome"
 			data-session-actions=""
 			onPointerDown={(event) => event.stopPropagation()}
 		>
 			<div
 				className={cn(
-					"absolute inset-y-0 right-0 flex items-center gap-px opacity-0 transition-opacity duration-100 ease-out",
+					"absolute inset-y-0 right-0.5 flex items-center gap-px opacity-0 transition-opacity duration-100 ease-out",
 					!isDragging &&
 						"group-hover/session-row:pointer-events-auto group-hover/session-row:opacity-100 group-focus-within/session-row:pointer-events-auto group-focus-within/session-row:opacity-100",
 				)}


### PR DESCRIPTION
## Summary
- The pin/kill action buttons were appearing to the left of the message-age timestamp on hover, requiring extra reserved padding and making the row feel crowded.
- The timestamp now fades out (`opacity-0`) on row hover/focus, and the action buttons overlay the same right-aligned slot instead of pushing further left.
- Reserved hover padding dropped from `78px` to `52px` since the buttons no longer need to coexist with the timestamp.
- Updated the inline-rename row so the now-absolutely-positioned timestamp doesn't overlap the rename input.

BEFORE:
https://github.com/user-attachments/assets/190297fb-57b2-4339-9e4a-14975f36bb17


AFTER:
https://github.com/user-attachments/assets/64436fbc-2495-4066-95e0-383cb965c885



## Test plan
- [x] `Sidebar.test.tsx` updated and passing (86/86)
- [ ] Manual check in the desktop app: hover a session row and confirm the timestamp fades out as the pin/kill buttons fade in, with no layout shift