### PR TITLE
fix(updates): preserve selected-feed intent across staged installs

### DIFF
--- a/frontend/e2e/updates-settings.spec.ts
+++ b/frontend/e2e/updates-settings.spec.ts
@@ -17,7 +17,7 @@ test("downloaded update keeps the full version readable and actions aligned", as
 	await page.goto("/#/settings");
 	await page.getByRole("button", { name: "Updates" }).click();
 
-	await expect(page.locator("#update-status-line")).toContainText("Downloaded. Restart to finish updating.");
+	await expect(page.locator("#update-status-line")).toContainText("Downloaded from Nightly (Pre-release). Restart to finish updating.");
 	const version = page.getByTestId("app-version");
 	await expect(version).toContainText("v0.12.7-nightly.202608240525");
 	await expect(page.getByRole("button", { name: "Restart & install" })).toBeVisible();

--- a/frontend/e2e/updates-settings.spec.ts
+++ b/frontend/e2e/updates-settings.spec.ts
@@ -30,8 +30,6 @@ test("downloaded update keeps the full version readable and actions aligned", as
 	expect(lineCount).toBe(1);
 
 	const restartBox = await page.getByRole("button", { name: "Restart & install" }).boundingBox();
-	const checkBox = await page.getByRole("button", { name: "Check for updates" }).boundingBox();
 	expect(restartBox).not.toBeNull();
-	expect(checkBox).not.toBeNull();
-	expect(Math.abs((restartBox?.height ?? 0) - (checkBox?.height ?? 0))).toBeLessThan(1);
+	expect(restartBox?.height).toBeGreaterThan(0);
 });

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -188,6 +188,7 @@ describe("startAutoUpdates", () => {
   const stateDir = "/tmp/ao-state";
 
   afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -826,8 +826,9 @@ describe("startAutoUpdates", () => {
     });
 
     const startPromise = module.startAutoUpdates(stateDir);
-    await Promise.resolve();
-    await Promise.resolve();
+    await vi.waitFor(() => {
+      expect(updaterEvents.get("error")).toBeTypeOf("function");
+    });
     let startSettled = false;
     void startPromise.then(() => {
       startSettled = true;

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,7 +1,7 @@
 import { autoUpdater } from "electron-updater";
 import { app, BrowserWindow, dialog } from "electron";
 import { accessSync, constants as fsConstants, existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import semver from "semver";
 import {
@@ -22,6 +22,8 @@ import {
   type UpdatePhase,
   type UpdateTrigger,
 } from "../shared/update-telemetry";
+
+const STAGED_UPDATE_FILE_NAME = "staged-update.json";
 
 // reconcileAndPersist clears a pinned feature build whose PR has been retired
 // (merged/closed/deleted/expired) and persists the change, so the next check
@@ -62,6 +64,7 @@ async function reconcileAndPersist(
 export function configureFeed(
   settings: Pick<UpdateSettings, "channel" | "feature">,
 ): void {
+  currentFeed = feedIdentity(settings);
   if (settings.feature !== null && settings.feature !== undefined) {
     // Feature build: pin to the pr<N> semver prerelease identifier channel.
     autoUpdater.channel = `pr${settings.feature.pr}`;
@@ -91,6 +94,8 @@ let stagedVersion: string | undefined;
 let stagedAtMs: number | undefined;
 let stagedEscalated = false;
 let stagedRequestId: string | undefined;
+let currentFeed = "latest";
+let stagedInstallInvalidated = false;
 let escalationTimer: ReturnType<typeof setInterval> | undefined;
 let escalationStateDir: string | undefined;
 const STABLE_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
@@ -397,6 +402,53 @@ function stagedDownloadedStatus(): UpdateStatus {
   };
 }
 
+function feedIdentity(settings: Pick<UpdateSettings, "channel" | "feature">): string {
+  return settings.feature === null || settings.feature === undefined
+    ? settings.channel
+    : `pr${settings.feature.pr}`;
+}
+
+async function clearStagedUpdate(stateDir: string): Promise<void> {
+  stagedVersion = undefined;
+  stagedAtMs = undefined;
+  stagedEscalated = false;
+  stagedRequestId = undefined;
+  stagedInstallInvalidated = true;
+  stopEscalationTimer();
+  autoUpdater.autoInstallOnAppQuit = false;
+  await unlink(path.join(stateDir, STAGED_UPDATE_FILE_NAME)).catch(() => undefined);
+}
+
+async function restoreStagedUpdate(stateDir: string, settings: UpdateSettings): Promise<void> {
+  try {
+    const raw = JSON.parse(await readFile(path.join(stateDir, STAGED_UPDATE_FILE_NAME), "utf8")) as {
+      version?: unknown;
+      stagedAt?: unknown;
+      feed?: unknown;
+    };
+    if (
+      typeof raw.version !== "string" ||
+      typeof raw.stagedAt !== "number" ||
+      typeof raw.feed !== "string" ||
+      raw.feed !== feedIdentity(settings) ||
+      raw.version === app.getVersion()
+    ) {
+      await clearStagedUpdate(stateDir);
+      return;
+    }
+    stagedVersion = raw.version;
+    stagedAtMs = raw.stagedAt;
+    stagedInstallInvalidated = false;
+    stagedEscalated = false;
+  } catch {
+    stagedVersion = undefined;
+    stagedAtMs = undefined;
+    // If metadata exists but cannot be read, fail closed: an unknown staged
+    // package must never be installed automatically.
+    stagedInstallInvalidated = true;
+  }
+}
+
 // runEscalationCheck re-reads settings and feeds, then rebroadcasts the
 // downloaded status with a fresh escalated flag. The timer is keyed on a build
 // being staged (stagedAtMs set), NOT on lastStatus: a manual re-check flips
@@ -681,6 +733,19 @@ function wireUpdaterEvents(): void {
     stagedAtMs = Date.now();
     stagedEscalated = false;
     stagedRequestId = activeUpdaterRequestId;
+    stagedInstallInvalidated = false;
+    const stagedStateDir = escalationStateDir;
+    if (stagedStateDir !== undefined && stagedVersion !== undefined) {
+      void mkdir(stagedStateDir, { recursive: true })
+        .then(() =>
+          writeFile(
+            path.join(stagedStateDir, STAGED_UPDATE_FILE_NAME),
+            `${JSON.stringify({ version: stagedVersion, stagedAt: stagedAtMs, feed: currentFeed })}\n`,
+            { mode: 0o600 },
+          ),
+        )
+        .catch(() => undefined);
+    }
     automaticCheckPreviousStatus = undefined;
     // A completed automatic download advances the independent baseline; a
     // renderer-requested download additionally carries its request ownership.
@@ -881,6 +946,14 @@ async function requestAutomaticUpdateCheck(
 // It is a thin shell: all policy (channel, opt-in) comes from update-settings.
 // Caller guards on app.isPackaged.
 export async function startAutoUpdates(stateDir: string): Promise<void> {
+  try {
+    if (existsSync(path.join(stateDir, STAGED_UPDATE_FILE_NAME))) {
+      const settings = await readUpdateSettings(stateDir);
+      await restoreStagedUpdate(stateDir, settings);
+    }
+  } catch {
+    // requestAutomaticUpdateCheck owns the existing settings-error handling.
+  }
   startRetirementPollTimer(stateDir);
   const intervalMs = await requestAutomaticUpdateCheck(stateDir);
   if (intervalMs !== undefined)
@@ -891,6 +964,10 @@ async function persistUpdaterSettings(
   stateDir: string,
   settings: UpdateSettings,
 ): Promise<void> {
+  const previous = await readUpdateSettings(stateDir);
+  if (feedIdentity(previous) !== feedIdentity(settings)) {
+    await clearStagedUpdate(stateDir);
+  }
   await writeUpdateSettings(stateDir, settings);
   configureFeed(settings);
   reconcileAutomaticUpdateSchedule(stateDir, settings);
@@ -941,7 +1018,7 @@ export async function checkForUpdatesNow(
       "manual-check",
       async () => {
         if (options.settings)
-          await writeUpdateSettings(stateDir, options.settings);
+          await persistUpdaterSettings(stateDir, options.settings);
         const settings = await reconcileAndPersist(
           stateDir,
           options.settings ?? (await readUpdateSettings(stateDir)),
@@ -1136,7 +1213,7 @@ export function getMacInstallBlocker(): string | undefined {
 // the staged build wait for a location it can actually install from.
 function applyInstallOnQuitPolicy(): void {
   const blocker = getMacInstallBlocker();
-  autoUpdater.autoInstallOnAppQuit = blocker === undefined;
+  autoUpdater.autoInstallOnAppQuit = blocker === undefined && !stagedInstallInvalidated;
   if (blocker !== undefined) {
     console.warn(
       "install-on-quit disabled; the update cannot be installed from here:",

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -339,6 +339,12 @@ describe("GlobalSettingsForm", () => {
 		expect(await screen.findByTestId("installed-update-channel")).toHaveTextContent("Nightly (Pre-release)");
 	});
 
+	it("labels an installed feature build separately from Stable", async () => {
+		getVersion.mockResolvedValue("1.4.0-pr4536.202608271030");
+		renderForm();
+		expect(await screen.findByTestId("installed-update-channel")).toHaveTextContent("Feature Releases");
+	});
+
 	it("shows an explicit idle update state and triggers a manual check", async () => {
 		renderForm();
 		expect(await screen.findByTestId("app-version")).toHaveTextContent("v1.4.0");

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -287,6 +287,36 @@ describe("GlobalSettingsForm", () => {
 		expect(await screen.findByText(/Nightly updates daily and may be unstable or cause data loss/i)).toBeInTheDocument();
 	});
 
+	it("keeps the newest combined intent when saves overlap", async () => {
+		const resolvers: Array<() => void> = [];
+		setUpdate.mockImplementation(
+			() => new Promise<void>((resolve) => resolvers.push(resolve)),
+		);
+		renderForm();
+
+		const automatic = await screen.findByRole("switch", { name: "Automatic Updates" });
+		await userEvent.click(automatic);
+		await userEvent.click(await screen.findByLabelText("Updates channel"));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Nightly (Pre-release)" }));
+		await waitFor(() => expect(setUpdate).toHaveBeenCalledTimes(2));
+
+		await act(async () => resolvers[0]?.());
+		await waitFor(() => {
+			expect(automatic).toBeEnabled();
+			expect(automatic).not.toBeChecked();
+		});
+		await userEvent.click(automatic);
+		await waitFor(() => expect(setUpdate).toHaveBeenCalledTimes(3));
+		expect(setUpdate.mock.calls[2]?.[0]).toEqual(
+			expect.objectContaining({ enabled: true, channel: "nightly", nightlyAck: true, feature: null }),
+		);
+
+		await act(async () => {
+			resolvers[1]?.();
+			resolvers[2]?.();
+		});
+	});
+
 	it("checks the newly selected channel and explains how to switch after an update", async () => {
 		let emit: (s: { state: string; version?: string; requestId?: string }) => void = () => undefined;
 		updOnStatus.mockImplementation((cb: (s: unknown) => void) => {
@@ -417,7 +447,7 @@ describe("GlobalSettingsForm", () => {
 		});
 
 		await waitFor(
-			() => expect(screen.getByRole("status")).toHaveTextContent("Downloaded. Restart to finish updating."),
+			() => expect(screen.getByRole("status")).toHaveTextContent("Downloaded from Stable. Restart to finish updating."),
 			{ timeout: 1_500 },
 		);
 		expect(screen.queryByRole("button", { name: "Check for updates" })).not.toBeInTheDocument();

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -58,7 +58,13 @@ export function GlobalSettingsForm({
 			)}
 
 			{(all || section === "updates") && (
-				<Suspense fallback={null}>
+				<Suspense
+					fallback={
+						<SettingsContentPanel>
+							<div className="h-24 animate-pulse motion-reduce:animate-none" aria-label={t("settings.updates")} />
+						</SettingsContentPanel>
+					}
+				>
 					<UpdatesSection titleHidden={titleHidden} />
 				</Suspense>
 			)}

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -46,6 +46,7 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 	const [savingFields, setSavingFields] = useState<Set<"automatic" | "channel">>(new Set());
 	const latestSaveByFieldRef = useRef<Record<"automatic" | "channel", number>>({ automatic: 0, channel: 0 });
 	const saveSequenceRef = useRef(0);
+	const pendingSaveCountRef = useRef(0);
 	const [pendingPin, setPendingPin] = useState<{ pr: number; title: string } | null>(null);
 	const [manualCheckRequestId, setManualCheckRequestId] = useState<string | null>(null);
 	const [channelSwitch, setChannelSwitch] = useState<{ channel: UpdateChannel; requestId: string } | null>(null);
@@ -98,7 +99,7 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 	const handledStatusRef = useRef<UpdateState | null>(null);
 
 	useEffect(() => {
-		if (query.data) setForm(query.data);
+		if (query.data && pendingSaveCountRef.current === 0) setForm(query.data);
 	}, [query.data]);
 
 	useEffect(() => {
@@ -122,16 +123,22 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 			return next;
 		},
 		onSuccess: (next, { field, intent }) => {
+			pendingSaveCountRef.current -= 1;
 			setSavingFields((fields) => {
 				const nextFields = new Set(fields);
 				nextFields.delete(field);
 				return nextFields;
 			});
 			if (latestSaveByFieldRef.current[field] !== intent) return;
-			setForm(next);
+			setForm((current) =>
+				field === "automatic"
+					? { ...current, enabled: next.enabled }
+					: { ...current, channel: next.channel, nightlyAck: next.nightlyAck, feature: next.feature },
+			);
 			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		},
 		onError: (_error, { field, intent }) => {
+			pendingSaveCountRef.current -= 1;
 			setSavingFields((fields) => {
 				const nextFields = new Set(fields);
 				nextFields.delete(field);
@@ -139,13 +146,21 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 			});
 			if (latestSaveByFieldRef.current[field] !== intent) return;
 			const previous = queryClient.getQueryData<UpdateSettings>(updateSettingsQueryKey);
-			if (previous) setForm(previous);
+			if (previous) {
+				setForm((current) =>
+					field === "automatic"
+						? { ...current, enabled: previous.enabled }
+						: { ...current, channel: previous.channel, nightlyAck: previous.nightlyAck, feature: previous.feature },
+				);
+			}
+			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		},
 	});
 
 	const saveField = (field: "automatic" | "channel", next: UpdateSettings) => {
 		const intent = ++saveSequenceRef.current;
 		latestSaveByFieldRef.current[field] = intent;
+		pendingSaveCountRef.current += 1;
 		setSavingFields((fields) => new Set(fields).add(field));
 		setForm(next);
 		save.mutate({ next, field, intent });
@@ -250,6 +265,7 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 					startManualCheck={startManualCheck}
 					finishManualCheck={finishManualCheck}
 					channelSwitch={channelSwitch}
+					downloadedFrom={form.feature ? t("settings.updates.channel.feature") : form.channel === "nightly" ? t("settings.updates.channel.nightly") : t("settings.updates.channel.stable")}
 				/>
 
 				{featurePr != null && (
@@ -359,12 +375,14 @@ function UpdateActions({
 	startManualCheck,
 	finishManualCheck,
 	channelSwitch,
+	downloadedFrom,
 }: {
 	status: UpdateStatus;
 	manualCheckRequestId: string | null;
 	startManualCheck: (requestId: string) => void;
 	finishManualCheck: (requestId: string) => void;
 	channelSwitch: { channel: UpdateChannel; requestId: string } | null;
+	downloadedFrom: string;
 }) {
 	const { t, i18n } = useTranslation();
 	const version = useQuery({ queryKey: ["app-version"], queryFn: () => aoBridge.app.getVersion() });
@@ -440,7 +458,7 @@ function UpdateActions({
 							<span className="sr-only">{t("settings.updates.checking")}</span>
 						) : displayStatus.state !== "available" && displayStatus.state !== "idle" && displayStatus.state !== "downloading" ? (
 							<span className={checkedAt ? undefined : "sr-only"}>
-								<UpdateStatusLine status={displayStatus} />
+								<UpdateStatusLine status={displayStatus} downloadedFrom={downloadedFrom} />
 							</span>
 						) : null}
 						{channelSwitchMessage && <p className="mt-1 text-xs leading-4 text-settings-muted">{channelSwitchMessage}</p>}
@@ -470,7 +488,7 @@ function UpdateActions({
 									exit={{ opacity: 0, filter: "blur(4px)" }}
 									className="absolute inset-0 flex items-center"
 								>
-									<UpdateStatusLine status={displayStatus} />
+									<UpdateStatusLine status={displayStatus} downloadedFrom={downloadedFrom} />
 								</motion.span>
 							)}
 						</AnimatePresence>
@@ -552,7 +570,7 @@ function installedUpdateChannel(version: string | undefined): InstalledChannel {
 	return /^\d+\.\d+\.\d+(?:\+[0-9A-Za-z.-]+)?$/.test(version) ? "latest" : "unknown";
 }
 
-function UpdateStatusLine({ status }: { status: UpdateStatus }) {
+function UpdateStatusLine({ status, downloadedFrom }: { status: UpdateStatus; downloadedFrom?: string }) {
 	const { t } = useTranslation();
 	let className = "text-settings-muted";
 	let label: string;
@@ -571,7 +589,7 @@ function UpdateStatusLine({ status }: { status: UpdateStatus }) {
 			break;
 		case "downloaded":
 			className = "text-success";
-			label = t("settings.updates.downloaded");
+			label = downloadedFrom ? t("settings.updates.downloadedFrom", { channel: downloadedFrom }) : t("settings.updates.downloaded");
 			break;
 		case "not-available":
 			className = "text-success";

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -43,7 +43,9 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 	const formRef = useRef(form);
 	formRef.current = form;
 	const [showFeature, setShowFeature] = useState(false);
-	const [savingField, setSavingField] = useState<"automatic" | "channel" | null>(null);
+	const [savingFields, setSavingFields] = useState<Set<"automatic" | "channel">>(new Set());
+	const latestSaveByFieldRef = useRef<Record<"automatic" | "channel", number>>({ automatic: 0, channel: 0 });
+	const saveSequenceRef = useRef(0);
 	const [pendingPin, setPendingPin] = useState<{ pr: number; title: string } | null>(null);
 	const [manualCheckRequestId, setManualCheckRequestId] = useState<string | null>(null);
 	const [channelSwitch, setChannelSwitch] = useState<{ channel: UpdateChannel; requestId: string } | null>(null);
@@ -115,21 +117,39 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 	}, [status]);
 
 	const save = useMutation({
-		mutationFn: async (next: UpdateSettings) => {
+		mutationFn: async ({ next }: { next: UpdateSettings; field: "automatic" | "channel"; intent: number }) => {
 			await aoBridge.updateSettings.set(next);
 			return next;
 		},
-		onSuccess: (next) => {
-			setSavingField(null);
+		onSuccess: (next, { field, intent }) => {
+			setSavingFields((fields) => {
+				const nextFields = new Set(fields);
+				nextFields.delete(field);
+				return nextFields;
+			});
+			if (latestSaveByFieldRef.current[field] !== intent) return;
 			setForm(next);
 			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		},
-		onError: () => {
-			setSavingField(null);
+		onError: (_error, { field, intent }) => {
+			setSavingFields((fields) => {
+				const nextFields = new Set(fields);
+				nextFields.delete(field);
+				return nextFields;
+			});
+			if (latestSaveByFieldRef.current[field] !== intent) return;
 			const previous = queryClient.getQueryData<UpdateSettings>(updateSettingsQueryKey);
 			if (previous) setForm(previous);
 		},
 	});
+
+	const saveField = (field: "automatic" | "channel", next: UpdateSettings) => {
+		const intent = ++saveSequenceRef.current;
+		latestSaveByFieldRef.current[field] = intent;
+		setSavingFields((fields) => new Set(fields).add(field));
+		setForm(next);
+		save.mutate({ next, field, intent });
+	};
 
 	const channelOptions: { value: PrimaryValue; label: string }[] = [
 		{ value: "latest", label: t("settings.updates.channel.stable") },
@@ -139,10 +159,8 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 	const primaryValue: PrimaryValue = developerMode && (form.feature !== null || showFeature) ? "feature" : form.channel;
 
 	const setEnabled = (enabled: boolean) => {
-		setSavingField("automatic");
 		const next = { ...formRef.current, enabled };
-		setForm(next);
-		save.mutate(next);
+		saveField("automatic", next);
 	};
 
 	const handlePrimaryChannel = (value: PrimaryValue) => {
@@ -151,7 +169,6 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 			return;
 		}
 		setShowFeature(false);
-		setSavingField("channel");
 		const next = {
 			...formRef.current,
 			channel: value,
@@ -160,8 +177,7 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 		};
 		const from = releaseChannelFrom(formRef.current);
 		const to = releaseChannelFrom(next);
-		setForm(next);
-		save.mutate(next);
+		saveField("channel", next);
 		if (from !== to) {
 			// Reported on the switch rather than inferred later, because someone who
 			// moves to nightly and does not update yet is on nightly by intent while
@@ -260,7 +276,7 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 						aria-label={t("settings.updates.automatic")}
 						checked={form.enabled}
 						onCheckedChange={setEnabled}
-						disabled={savingField === "automatic"}
+						disabled={savingFields.has("automatic")}
 					/>
 				</SettingsRow>
 
@@ -270,7 +286,7 @@ export function UpdatesSection({ titleHidden }: { titleHidden?: boolean } = {}) 
 						value={primaryValue}
 						options={developerMode ? channelOptions : channelOptions.filter((option) => option.value !== "feature")}
 						onChange={handlePrimaryChannel}
-						disabled={savingField === "channel"}
+						disabled={savingFields.has("channel")}
 					/>
 				</SettingsRow>
 
@@ -398,9 +414,18 @@ function UpdateActions({
 						>
 							{version.data ? `v${version.data}` : "…"}
 						</span>
-						<Badge data-testid="installed-update-channel" variant={installedChannel === "nightly" ? "warning" : "neutral"}>
-							{installedChannel === "nightly" ? t("settings.updates.channel.nightly") : t("settings.updates.channel.stable")}
-						</Badge>
+						{installedChannel !== "unknown" && (
+							<Badge
+								data-testid="installed-update-channel"
+								variant={installedChannel === "nightly" ? "warning" : installedChannel === "feature" ? "accent" : "neutral"}
+							>
+								{installedChannel === "nightly"
+									? t("settings.updates.channel.nightly")
+									: installedChannel === "feature"
+										? t("settings.updates.channel.feature")
+										: t("settings.updates.channel.stable")}
+							</Badge>
+						)}
 					</div>
 
 					<div
@@ -414,7 +439,9 @@ function UpdateActions({
 						{displayStatus.state === "checking" ? (
 							<span className="sr-only">{t("settings.updates.checking")}</span>
 						) : displayStatus.state !== "available" && displayStatus.state !== "idle" && displayStatus.state !== "downloading" ? (
-							<UpdateStatusLine status={displayStatus} />
+							<span className={checkedAt ? undefined : "sr-only"}>
+								<UpdateStatusLine status={displayStatus} />
+							</span>
 						) : null}
 						{channelSwitchMessage && <p className="mt-1 text-xs leading-4 text-settings-muted">{channelSwitchMessage}</p>}
 					</div>
@@ -435,17 +462,17 @@ function UpdateActions({
 										{t("settings.updates.lastChecked", { time: checkedAt })}
 									</span>
 								</motion.div>
-							) : displayStatus.state === "idle" ? (
+							) : (
 								<motion.span
-									key="not-checked"
+									key={displayStatus.state}
 									initial={{ opacity: 1, filter: "blur(0px)" }}
 									animate={{ opacity: 1, filter: "blur(0px)" }}
 									exit={{ opacity: 0, filter: "blur(4px)" }}
-									className="absolute inset-0"
+									className="absolute inset-0 flex items-center"
 								>
-									{t("settings.updates.notChecked")}
+									<UpdateStatusLine status={displayStatus} />
 								</motion.span>
-							) : null}
+							)}
 						</AnimatePresence>
 					</div>
 				</div>
@@ -516,8 +543,13 @@ function DownloadProgressIcon({ percent }: { percent: number }) {
 	);
 }
 
-function installedUpdateChannel(version: string | undefined): UpdateChannel {
-	return /-nightly(?:[.+]|$)/.test(version ?? "") ? "nightly" : "latest";
+type InstalledChannel = UpdateChannel | "feature" | "unknown";
+
+function installedUpdateChannel(version: string | undefined): InstalledChannel {
+	if (!version) return "unknown";
+	if (/-nightly(?:[.+]|$)/.test(version)) return "nightly";
+	if (/-pr\d+(?:[.+]|$)/.test(version)) return "feature";
+	return /^\d+\.\d+\.\d+(?:\+[0-9A-Za-z.-]+)?$/.test(version) ? "latest" : "unknown";
 }
 
 function UpdateStatusLine({ status }: { status: UpdateStatus }) {

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -715,6 +715,7 @@
 	"settings.updates.confirm": "Bestätigen",
 	"settings.updates.disabled": "Deaktiviert",
 	"settings.updates.downloaded": "Heruntergeladen. Neu starten, um das Update abzuschließen.",
+	"settings.updates.downloadedFrom": "Von {{channel}} heruntergeladen. Neu starten, um das Update abzuschließen.",
 	"settings.updates.downloading": "Wird heruntergeladen… {{percent}}%",
 	"settings.updates.enabled": "Aktiviert",
 	"settings.updates.featureBuild": "Feature-Build",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -716,6 +716,7 @@
 	"settings.updates.confirm": "Confirm",
 	"settings.updates.disabled": "Disabled",
 	"settings.updates.downloaded": "Downloaded. Restart to finish updating.",
+	"settings.updates.downloadedFrom": "Downloaded from {{channel}}. Restart to finish updating.",
 	"settings.updates.downloading": "Downloading… {{percent}}%",
 	"settings.updates.enabled": "Enabled",
 	"settings.updates.featureBuild": "Feature build",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -724,6 +724,7 @@
 	"settings.updates.confirm": "Confirmar",
 	"settings.updates.disabled": "Desactivado",
 	"settings.updates.downloaded": "Descargado. Reinicia para terminar la actualización.",
+	"settings.updates.downloadedFrom": "Descargado de {{channel}}. Reinicia para terminar la actualización.",
 	"settings.updates.downloading": "Descargando… {{percent}}%",
 	"settings.updates.enabled": "Activado",
 	"settings.updates.featureBuild": "Compilación de funciones",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -724,6 +724,7 @@
 	"settings.updates.confirm": "Confirmer",
 	"settings.updates.disabled": "Désactivé",
 	"settings.updates.downloaded": "Téléchargé. Redémarrez pour terminer la mise à jour.",
+	"settings.updates.downloadedFrom": "Téléchargé depuis {{channel}}. Redémarrez pour terminer la mise à jour.",
 	"settings.updates.downloading": "Téléchargement… {{percent}} %",
 	"settings.updates.enabled": "Activé",
 	"settings.updates.featureBuild": "Build de fonctionnalité",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -715,6 +715,7 @@
 	"settings.updates.confirm": "確認",
 	"settings.updates.disabled": "無効",
 	"settings.updates.downloaded": "ダウンロード済み。再起動して更新を完了してください。",
+	"settings.updates.downloadedFrom": "{{channel}} からダウンロード済み。再起動して更新を完了してください。",
 	"settings.updates.downloading": "ダウンロード中… {{percent}}%",
 	"settings.updates.enabled": "有効",
 	"settings.updates.featureBuild": "機能ビルド",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -715,6 +715,7 @@
 	"settings.updates.confirm": "확인",
 	"settings.updates.disabled": "사용 안 함",
 	"settings.updates.downloaded": "다운로드됨. 다시 시작하여 업데이트를 완료하세요.",
+	"settings.updates.downloadedFrom": "{{channel}}에서 다운로드됨. 다시 시작하여 업데이트를 완료하세요.",
 	"settings.updates.downloading": "다운로드 중… {{percent}}%",
 	"settings.updates.enabled": "사용",
 	"settings.updates.featureBuild": "기능 빌드",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -724,6 +724,7 @@
 	"settings.updates.confirm": "Confirmar",
 	"settings.updates.disabled": "Desativado",
 	"settings.updates.downloaded": "Baixado. Reinicie para concluir a atualização.",
+	"settings.updates.downloadedFrom": "Baixado de {{channel}}. Reinicie para concluir a atualização.",
 	"settings.updates.downloading": "Baixando… {{percent}}%",
 	"settings.updates.enabled": "Ativado",
 	"settings.updates.featureBuild": "Build de feature",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -699,6 +699,7 @@
 	"settings.updates.confirm": "确认",
 	"settings.updates.disabled": "已关闭",
 	"settings.updates.downloaded": "已下载。重启以完成更新。",
+	"settings.updates.downloadedFrom": "已从 {{channel}} 下载。重启以完成更新。",
 	"settings.updates.downloading": "正在下载… {{percent}}%",
 	"settings.updates.enabled": "已开启",
 	"settings.updates.featureBuild": "功能构建",


### PR DESCRIPTION
Closes #4537

## Summary
- Persist staged update feed provenance and invalidate staged installs when the selected feed changes.
- Preserve the newest combined Automatic Updates and channel intent across overlapping saves.
- Label downloaded updates by feed and classify installed Stable, Nightly, Feature, and unresolved versions truthfully.
- Keep the Updates panel populated during lazy loading and every updater state.
- Fix the contradictory downloaded-action E2E geometry assertion.

## Validation
- 95 focused updater/settings tests passing.
- E2E TypeScript check passing.
- git diff --check passing.
- Full repository tests and live Playwright execution remain environment-blocked by unrelated workspace failures and sandbox port permissions.