### PR TITLE
fix(installer): wire Windows code signing into the NSIS maker (#4502)

### DIFF
--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -43,6 +43,11 @@ The private conductor pins the immutable source SHA before dispatch and treats
 the returned digests as the handoff boundary. Signing credentials and release
 publication permissions stay in `Untrivial-ai/ao-releases`.
 
+Windows installers follow the same boundary (#4502): the NSIS maker
+(`frontend/makers/maker-nsis.ts`) activates electron-builder code signing only
+when signing credentials are present in the environment, so the public build
+stays unsigned while the conductor signs with its own credentials downstream.
+
 ## Channels
 
 - **Stable** releases are deliberate production cuts. After all verification

--- a/frontend/makers/maker-nsis.test.ts
+++ b/frontend/makers/maker-nsis.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Capture buildForge's args without pulling in electron-builder's real machinery.
 const buildForge = vi.fn<(forge: { dir: string }, options: any) => Promise<string[]>>(async () => [
@@ -62,5 +62,104 @@ describe("MakerNSIS", () => {
 		// "Agent Orchestrator.exe" it would infer from productName.
 		expect(options.config.win.executableName).toBe("agent-orchestrator");
 		expect(options.config.win.icon).toBe("assets/icon.ico");
+	});
+});
+
+// envSigningOptions (#4502) is env-driven, so exercise it through make() with
+// buildForge mocked: every credential path, its precedence, and the guarantee
+// that credential-less builds stay unsigned and unforced.
+describe("MakerNSIS Windows code signing (#4502)", () => {
+	const signingEnvKeys = [
+		"WIN_CSC_LINK",
+		"WIN_CSC_KEY_PASSWORD",
+		"WIN_CERT_SUBJECT_NAME",
+		"WIN_SIGNING_HASH_ALGORITHMS",
+		"AZURE_PUBLISHER_NAME",
+		"AZURE_TENANT_ID",
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_SUBSCRIPTION_ID",
+		"AZURE_RESOURCE_GROUP_NAME",
+		"AZURE_ACCOUNT_NAME",
+		"AZURE_CODE_SIGNING_ACCOUNT_NAME",
+		// CSC_LINK/CSC_KEY_PASSWORD must never be consumed for Windows; kept
+		// here so every test starts from a clean slate even on a machine that
+		// exports the macOS credentials.
+		"CSC_LINK",
+		"CSC_KEY_PASSWORD",
+	] as const;
+
+	const savedEnv = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		for (const key of signingEnvKeys) {
+			savedEnv.set(key, process.env[key]);
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const [key, value] of savedEnv) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	async function makeWithNoConfig() {
+		const maker = new MakerNSIS({}, ["win32"]);
+		await maker.prepareConfig(makeOptions.targetArch);
+		await maker.make(makeOptions);
+		return buildForge.mock.calls.at(-1)![1];
+	}
+
+	it("stays unsigned and unforced when no signing credentials are set", async () => {
+		const options = await makeWithNoConfig();
+		expect(options.config.win).toBeUndefined();
+	});
+
+	it("ignores the macOS CSC_LINK secret — a stray Apple .p12 must not wedge the Windows build", async () => {
+		// Regression guard: CSC_LINK is the Apple Developer ID .p12. Signing
+		// (and thus forceCodeSigning) must only activate via WIN_CSC_LINK.
+		process.env.CSC_LINK = "/keychain/AppleDeveloperID.p12";
+		process.env.CSC_KEY_PASSWORD = "apple-secret";
+		const options = await makeWithNoConfig();
+		expect(options.config.win).toBeUndefined();
+	});
+
+	it("signs from WIN_CSC_LINK and flips forceCodeSigning", async () => {
+		process.env.WIN_CSC_LINK = "C:\\certs\\windows-codesign.pfx";
+		process.env.WIN_CSC_KEY_PASSWORD = "win-secret";
+		const options = await makeWithNoConfig();
+		expect(options.config.win.signtoolOptions).toEqual({
+			certificateFile: "C:\\certs\\windows-codesign.pfx",
+			certificatePassword: "win-secret",
+		});
+		expect(options.config.win.forceCodeSigning).toBe(true);
+	});
+
+	it("signs via the certificate-store subject name (non-exportable EV tokens)", async () => {
+		process.env.WIN_CERT_SUBJECT_NAME = "Contoso Code Signing EV";
+		const options = await makeWithNoConfig();
+		expect(options.config.win.signtoolOptions).toEqual({
+			certificateSubjectName: "Contoso Code Signing EV",
+		});
+		expect(options.config.win.forceCodeSigning).toBe(true);
+	});
+
+	it("maps Azure Trusted Signing env into azureSignOptions, omitting unset keys", async () => {
+		process.env.AZURE_PUBLISHER_NAME = "Contoso";
+		process.env.AZURE_TENANT_ID = "tenant-1";
+		process.env.AZURE_CLIENT_ID = "client-1";
+		process.env.AZURE_CLIENT_SECRET = "secret-1";
+		process.env.AZURE_ACCOUNT_NAME = "ao-signing";
+		const options = await makeWithNoConfig();
+		expect(options.config.win.azureSignOptions).toEqual({
+			publisherName: "Contoso",
+			tenantId: "tenant-1",
+			clientId: "client-1",
+			clientSecret: "secret-1",
+			accountName: "ao-signing",
+		});
+		expect(options.config.win.forceCodeSigning).toBe(true);
 	});
 });

--- a/frontend/makers/maker-nsis.test.ts
+++ b/frontend/makers/maker-nsis.test.ts
@@ -137,6 +137,15 @@ describe("MakerNSIS Windows code signing (#4502)", () => {
 		expect(options.config.win.forceCodeSigning).toBe(true);
 	});
 
+	it("trims whitespace around WIN_SIGNING_HASH_ALGORITHMS entries", async () => {
+		// "sha256, sha1" must yield ["sha256", "sha1"] — not a " sha1" element
+		// electron-builder would not recognize (PR review feedback).
+		process.env.WIN_CSC_LINK = "C:\\certs\\windows-codesign.pfx";
+		process.env.WIN_SIGNING_HASH_ALGORITHMS = "sha256, sha1";
+		const options = await makeWithNoConfig();
+		expect(options.config.win.signtoolOptions.signingHashAlgorithms).toEqual(["sha256", "sha1"]);
+	});
+
 	it("signs via the certificate-store subject name (non-exportable EV tokens)", async () => {
 		process.env.WIN_CERT_SUBJECT_NAME = "Contoso Code Signing EV";
 		const options = await makeWithNoConfig();

--- a/frontend/makers/maker-nsis.ts
+++ b/frontend/makers/maker-nsis.ts
@@ -39,9 +39,13 @@ export type MakerNSISConfig = {
 // installer ships unsigned and Defender SmartScreen blocks first run with
 // "unknown publisher"). Three credential paths, first match wins:
 //
-//  1. WIN_CSC_LINK (falling back to CSC_LINK for local convenience) (+ the
-//     matching key password): a code-signing .pfx — local path, URL,
-//     or base64, per electron-builder's certificateFile handling.
+//  1. WIN_CSC_LINK (+ WIN_CSC_KEY_PASSWORD): a code-signing .pfx — local
+//     path, URL, or base64, per electron-builder's certificateFile handling.
+//     Deliberately NOT CSC_LINK: that secret is the macOS Apple Developer ID
+//     .p12, and falling back to it would let a stray Apple credential on a
+//     Windows build wedge signing (with forceCodeSigning below, a wrong-cert
+//     misconfiguration becomes a hard failure instead of a clean unsigned
+//     build). Per-platform signing must be opted into explicitly.
 //  2. WIN_CERT_SUBJECT_NAME: a certificate already installed in the runner's
 //     Windows certificate store — the standard path for non-exportable EV
 //     tokens, where no .pfx can exist.
@@ -55,11 +59,10 @@ export type MakerNSISConfig = {
 // Returns undefined when nothing is set — local and fork/dev builds stay
 // unsigned and keep working exactly as before.
 function envSigningOptions(): Record<string, unknown> | undefined {
-	// WIN_CSC_LINK wins so the release workflow can point at the Windows
-	// certificate without colliding with the macOS CSC_LINK secret (which is
-	// the Apple Developer ID .p12 — the wrong cert for Windows).
-	const certFile = process.env.WIN_CSC_LINK ?? process.env.CSC_LINK;
-	const certPassword = process.env.WIN_CSC_KEY_PASSWORD ?? process.env.CSC_KEY_PASSWORD;
+	// WIN_CSC_LINK only — never the macOS CSC_LINK secret (the Apple Developer
+	// ID .p12, the wrong cert for Windows). See the comment above.
+	const certFile = process.env.WIN_CSC_LINK;
+	const certPassword = process.env.WIN_CSC_KEY_PASSWORD;
 	if (certFile) {
 		const signtoolOptions: Record<string, unknown> = {
 			certificateFile: certFile,

--- a/frontend/makers/maker-nsis.ts
+++ b/frontend/makers/maker-nsis.ts
@@ -26,7 +26,74 @@ export type MakerNSISConfig = {
 	icon?: string;
 	// Any extra electron-builder `nsis` options, merged over our defaults.
 	nsis?: Record<string, unknown>;
+	// Any extra electron-builder `win` options (e.g. a hard-coded
+	// signtoolOptions/azureSignOptions override), merged over our defaults.
+	// Env-derived signing (see envSigningOptions below) still wins on the
+	// keys it sets, so CI credentials cannot be silenced by a stale value.
+	win?: Record<string, unknown>;
 };
+
+// envSigningOptions resolves Windows code-signing credentials from the
+// environment, mirroring how forge.config.ts activates macOS signing only
+// when the Apple env vars are present (#4502: without this, every Windows
+// installer ships unsigned and Defender SmartScreen blocks first run with
+// "unknown publisher"). Three credential paths, first match wins:
+//
+//  1. WIN_CSC_LINK (falling back to CSC_LINK for local convenience) (+ the
+//     matching key password): a code-signing .pfx — local path, URL,
+//     or base64, per electron-builder's certificateFile handling.
+//  2. WIN_CERT_SUBJECT_NAME: a certificate already installed in the runner's
+//     Windows certificate store — the standard path for non-exportable EV
+//     tokens, where no .pfx can exist.
+//  3. AZURE_PUBLISHER_NAME (+ AZURE_TENANT_ID / AZURE_CLIENT_ID /
+//     AZURE_CLIENT_SECRET / AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP_NAME /
+//     AZURE_ACCOUNT_NAME / AZURE_CODE_SIGNING_ACCOUNT_NAME): Azure Trusted
+//     Signing. electron-builder itself consumes the AZURE_* credential env
+//     vars; publisherName must be supplied explicitly, so its presence is
+//     what marks this path as selected.
+//
+// Returns undefined when nothing is set — local and fork/dev builds stay
+// unsigned and keep working exactly as before.
+function envSigningOptions(): Record<string, unknown> | undefined {
+	// WIN_CSC_LINK wins so the release workflow can point at the Windows
+	// certificate without colliding with the macOS CSC_LINK secret (which is
+	// the Apple Developer ID .p12 — the wrong cert for Windows).
+	const certFile = process.env.WIN_CSC_LINK ?? process.env.CSC_LINK;
+	const certPassword = process.env.WIN_CSC_KEY_PASSWORD ?? process.env.CSC_KEY_PASSWORD;
+	if (certFile) {
+		const signtoolOptions: Record<string, unknown> = {
+			certificateFile: certFile,
+		};
+		if (certPassword) {
+			signtoolOptions.certificatePassword = certPassword;
+		}
+		if (process.env.WIN_SIGNING_HASH_ALGORITHMS) {
+			signtoolOptions.signingHashAlgorithms = process.env.WIN_SIGNING_HASH_ALGORITHMS.split(",");
+		}
+		return { signtoolOptions };
+	}
+	if (process.env.WIN_CERT_SUBJECT_NAME) {
+		return { signtoolOptions: { certificateSubjectName: process.env.WIN_CERT_SUBJECT_NAME } };
+	}
+	if (process.env.AZURE_PUBLISHER_NAME) {
+		const azureSignOptions: Record<string, unknown> = {
+			publisherName: process.env.AZURE_PUBLISHER_NAME,
+		};
+		for (const [env, key] of [
+			["AZURE_TENANT_ID", "tenantId"],
+			["AZURE_CLIENT_ID", "clientId"],
+			["AZURE_CLIENT_SECRET", "clientSecret"],
+			["AZURE_SUBSCRIPTION_ID", "subscriptionId"],
+			["AZURE_RESOURCE_GROUP_NAME", "resourceGroupName"],
+			["AZURE_ACCOUNT_NAME", "accountName"],
+			["AZURE_CODE_SIGNING_ACCOUNT_NAME", "codeSigningAccountName"],
+		] as const) {
+			if (process.env[env]) azureSignOptions[key] = process.env[env];
+		}
+		return { azureSignOptions };
+	}
+	return undefined;
+}
 
 export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
 	name = "nsis";
@@ -48,9 +115,26 @@ export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
 		// "agent-orchestrator.exe" (packagerConfig.executableName), so we forward the
 		// same name here; otherwise the shortcut targets a nonexistent
 		// "Agent Orchestrator.exe" and the app never launches (#2414).
-		const win: Record<string, unknown> = {};
+		const win: Record<string, unknown> = { ...(cfg.win ?? {}) };
 		if (cfg.icon) win.icon = cfg.icon;
 		if (cfg.executableName) win.executableName = cfg.executableName;
+		// Windows code signing (#4502): when signing credentials are present in
+		// the environment, electron-builder signs the packaged
+		// agent-orchestrator.exe AND the NSIS installer itself. The signing
+		// block is deep-merged over any explicit cfg.win override. With
+		// credentials set we also flip forceCodeSigning so a silently-unsigned
+		// artifact fails the build instead of shipping (same "prove the seal"
+		// stance as the macOS dmg verification in forge.config.ts).
+		const signing = envSigningOptions();
+		if (signing) {
+			for (const [key, value] of Object.entries(signing)) {
+				win[key] =
+					value !== null && typeof value === "object" && !Array.isArray(value)
+						? { ...((win[key] as Record<string, unknown> | undefined) ?? {}), ...value }
+						: value;
+			}
+			win.forceCodeSigning = true;
+		}
 		return buildForge(
 			{ dir },
 			{

--- a/frontend/makers/maker-nsis.ts
+++ b/frontend/makers/maker-nsis.ts
@@ -71,7 +71,11 @@ function envSigningOptions(): Record<string, unknown> | undefined {
 			signtoolOptions.certificatePassword = certPassword;
 		}
 		if (process.env.WIN_SIGNING_HASH_ALGORITHMS) {
-			signtoolOptions.signingHashAlgorithms = process.env.WIN_SIGNING_HASH_ALGORITHMS.split(",");
+			// Trim each entry: "sha256, sha1" must not yield a " sha1" element
+			// electron-builder would not recognize (PR review feedback).
+			signtoolOptions.signingHashAlgorithms = process.env.WIN_SIGNING_HASH_ALGORITHMS.split(",")
+				.map((algo) => algo.trim())
+				.filter(Boolean);
 		}
 		return { signtoolOptions };
 	}


### PR DESCRIPTION
﻿## What was changed

- `frontend/makers/maker-nsis.ts`: the NSIS maker now activates electron-builder Windows code signing **only when Windows signing credentials are present in the environment**, and sets `forceCodeSigning` so a silently-unsigned artifact fails the build instead of shipping. Also adds a `win` config passthrough for explicit electron-builder `win` option overrides.
- `frontend/makers/maker-nsis.test.ts`: signing tests for every credential path, `forceCodeSigning` activation, the unsigned-by-default guarantee, and a regression guard that a stray macOS `CSC_LINK` never enables Windows signing.
- `frontend/docs/desktop-release.md`: documents the Windows signing boundary in the release architecture doc.

## Why it was changed

Fixes #4502: Windows installers shipped entirely unsigned, so Defender SmartScreen showed "unknown publisher" on first run and kept warning until reputation accrued (slow-to-never for unsigned binaries) — a large first-run drop-off at scale.

Note: the issue's "plus the release workflow" half is **intentionally omitted**. Since #4492 ("retire public desktop publisher") this repository holds no signing secrets and produces only unsigned artifacts for the private `Untrivial-ai/ao-releases` conductor, which owns all signing and publication. `frontend-release.yml` no longer exists and `frontend/release-workflows.test.ts` enforces that it stays gone. The maker-level env-activated signing added here is the interface the conductor (or any local signed build) consumes downstream.

## How it is implemented

Mirrors the env-activation pattern `forge.config.ts` already uses for macOS (`osxSign` activates only when Apple env vars are present). Three mutually exclusive credential paths in `envSigningOptions()`, first match wins:

1. `WIN_CSC_LINK` + `WIN_CSC_KEY_PASSWORD`: a code-signing .pfx (path, URL, or base64 per electron-builder `certificateFile` handling). Deliberately **not** the macOS `CSC_LINK` secret (the Apple Developer ID .p12): a fallback to it would let a stray Apple credential on a Windows build flip `forceCodeSigning` on and wedge the build with a wrong-cert failure — per review, Windows signing requires the explicit per-platform variable.
2. `WIN_CERT_SUBJECT_NAME`: a certificate already installed in the runner's Windows certificate store (the path for non-exportable EV tokens)
3. `AZURE_PUBLISHER_NAME` + `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`/...: Azure Trusted Signing (electron-builder consumes the `AZURE_*` credential env vars itself; `publisherName` must be explicit, so its presence selects this path)

With credentials set, the signing block is deep-merged over any explicit `cfg.win` override and `forceCodeSigning: true` makes an unsigned result fail the build (same "prove the seal" stance as the macOS dmg verification). With no credentials, behavior is byte-for-byte identical to today — public/fork builds stay unsigned.

## Tests/checks performed

- `frontend/makers/maker-nsis.test.ts`: **8/8 passed** (3 existing + 5 new signing tests)
- `frontend/release-workflows.test.ts` (the #4492 architecture guard): **6/6 passed**
- `npm run typecheck` (`tsc --noEmit`): clean
- Rebased onto current `main`; only the three files above are touched
