### PR TITLE
fix(terminal): back-pressure PTY output instead of killing the WebSocket

### DIFF
--- a/backend/internal/terminal/manager.go
+++ b/backend/internal/terminal/manager.go
@@ -32,8 +32,11 @@ type wsConn interface {
 }
 
 const (
-	defaultHeartbeat   = 15 * time.Second
-	defaultWriteBuffer = 1024
+	defaultHeartbeat = 15 * time.Second
+	// dataWatermark caps queued PTY output per connection. Above it the producing
+	// attachment's read loop blocks, so tmux throttles at the source instead of
+	// the connection being torn down under a flood.
+	dataWatermark = 1 << 20
 )
 
 // Manager serves WebSocket clients, opening one attach Stream per opened pane
@@ -337,8 +340,9 @@ func (m *Manager) Serve(ctx context.Context, conn wsConn) {
 	c := &connState{
 		mgr:    m,
 		conn:   conn,
+		ctx:    ctx,
 		cancel: cancel,
-		out:    make(chan serverMsg, defaultWriteBuffer),
+		out:    newOutQueue(),
 		terms:  map[string]*attachment{},
 	}
 	defer c.cleanup()
@@ -362,8 +366,9 @@ func (m *Manager) Serve(ctx context.Context, conn wsConn) {
 type connState struct {
 	mgr    *Manager
 	conn   wsConn
+	ctx    context.Context
 	cancel context.CancelFunc
-	out    chan serverMsg
+	out    *outQueue
 
 	mu        sync.Mutex
 	terms     map[string]*attachment // terminal id -> this conn's own attach PTY
@@ -523,15 +528,63 @@ func (c *connState) handleSubscribe(msg clientMsg) {
 	c.mu.Unlock()
 }
 
-// enqueue pushes a frame to the writer. If the buffer is full the client is too
-// slow to keep up; tear the connection down rather than block the attachment's
-// PTY read loop behind it.
-func (c *connState) enqueue(msg serverMsg) {
+// outQueue is the per-connection write queue. A buffered channel cannot serve
+// both frame classes: control frames must never be dropped or block their
+// caller, while PTY output must push back on its own read loop.
+type outQueue struct {
+	mu     sync.Mutex
+	frames []serverMsg
+	bytes  int
+	wake   chan struct{}
+	room   chan struct{}
+}
+
+func newOutQueue() *outQueue {
+	return &outQueue{wake: make(chan struct{}, 1), room: make(chan struct{}, 1)}
+}
+
+func (q *outQueue) push(msg serverMsg) {
+	q.mu.Lock()
+	q.frames = append(q.frames, msg)
+	q.bytes += len(msg.Data)
+	q.mu.Unlock()
 	select {
-	case c.out <- msg:
+	case q.wake <- struct{}{}:
 	default:
-		c.cancel()
 	}
+}
+
+func (q *outQueue) full() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.bytes >= dataWatermark
+}
+
+func (q *outQueue) drain() []serverMsg {
+	q.mu.Lock()
+	frames := q.frames
+	q.frames, q.bytes = nil, 0
+	q.mu.Unlock()
+	select {
+	case q.room <- struct{}{}:
+	default:
+	}
+	return frames
+}
+
+// enqueue pushes a frame to the writer. Data frames wait for room so the
+// attachment's PTY read loop stalls and tmux throttles the producer; control
+// frames never wait, because the CDC fan-out enqueues on one goroutine shared
+// by every connection.
+func (c *connState) enqueue(msg serverMsg) {
+	for msg.Type == msgData && c.out.full() {
+		select {
+		case <-c.out.room:
+		case <-c.ctx.Done():
+			return
+		}
+	}
+	c.out.push(msg)
 }
 
 func (c *connState) writeLoop(ctx context.Context) {
@@ -539,10 +592,12 @@ func (c *connState) writeLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case msg := <-c.out:
-			if err := c.conn.WriteJSON(ctx, msg); err != nil {
-				c.cancel()
-				return
+		case <-c.out.wake:
+			for _, msg := range c.out.drain() {
+				if err := c.conn.WriteJSON(ctx, msg); err != nil {
+					c.cancel()
+					return
+				}
 			}
 		}
 	}

--- a/backend/internal/terminal/manager_test.go
+++ b/backend/internal/terminal/manager_test.go
@@ -3,6 +3,8 @@ package terminal
 import (
 	"context"
 	"encoding/base64"
+	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -662,18 +664,89 @@ func TestManagerCloseKillsLiveAttachments(t *testing.T) {
 	}
 }
 
-func TestEnqueueOverflowCancelsConn(t *testing.T) {
-	cancelled := make(chan struct{})
+// newFloodedConn returns a conn whose queue already holds more PTY output than
+// the watermark allows, so the next data frame must wait.
+func newFloodedConn(ctx context.Context, cancel context.CancelFunc) *connState {
 	c := &connState{
-		out:    make(chan serverMsg, 1),
-		cancel: func() { close(cancelled) },
+		ctx:    ctx,
+		cancel: cancel,
+		out:    newOutQueue(),
 		terms:  map[string]*attachment{},
 	}
-	c.enqueue(serverMsg{Ch: chTerminal, Type: msgData}) // fills buffer
-	c.enqueue(serverMsg{Ch: chTerminal, Type: msgData}) // overflow -> cancel
+	c.enqueue(serverMsg{Ch: chTerminal, ID: "t1", Type: msgData, Data: strings.Repeat("x", dataWatermark)})
+	return c
+}
+
+// A flood must throttle its own PTY read loop, not tear the connection down:
+// cancelling here would kill every other pane on the same connection.
+func TestEnqueueDataBlocksUntilDrained(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newFloodedConn(ctx, func() { t.Error("a flood must not cancel the connection") })
+
+	done := make(chan struct{})
+	go func() {
+		c.enqueue(serverMsg{Ch: chTerminal, ID: "t1", Type: msgData, Data: "more"})
+		close(done)
+	}()
+
 	select {
-	case <-cancelled:
+	case <-done:
+		t.Fatal("data frame must wait while the queue is over the watermark")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	c.out.drain()
+	select {
+	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("overflow must cancel the connection")
+		t.Fatal("draining the queue must release the waiting data frame")
+	}
+}
+
+// The CDC fan-out enqueues session frames on one goroutine shared by every
+// connection, so a flooded connection must never block or drop a control frame.
+func TestEnqueueControlFramesNeverWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newFloodedConn(ctx, func() { t.Error("a control frame must not cancel the connection") })
+
+	done := make(chan struct{})
+	go func() {
+		c.enqueue(serverMsg{Ch: chTerminal, ID: "t1", Type: msgExited})
+		c.enqueue(serverMsg{Ch: chSessions, Type: msgSnapshot})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control frames must not wait behind a flood")
+	}
+
+	var types []string
+	for _, m := range c.out.drain() {
+		types = append(types, m.Type)
+	}
+	want := []string{msgData, msgExited, msgSnapshot}
+	if !slices.Equal(types, want) {
+		t.Fatalf("frames = %v, want %v (order must be preserved)", types, want)
+	}
+}
+
+// A blocked producer must not outlive its connection, or daemon shutdown hangs.
+func TestEnqueueDataUnblocksOnConnClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newFloodedConn(ctx, cancel)
+
+	done := make(chan struct{})
+	go func() {
+		c.enqueue(serverMsg{Ch: chTerminal, ID: "t1", Type: msgData, Data: "more"})
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cancelling the connection must release a waiting data frame")
 	}
 }


### PR DESCRIPTION
Fixes #4499.

## Approach

`enqueue` pushed every server frame onto a 1024-slot buffered channel and called `c.cancel()` when it was full, so one high-output pane tore down the whole connection.

Replace the channel with a per-connection queue that treats the two frame classes differently:

- **PTY output** waits for room above a 1MB watermark. The attachment's read loop stalls, so tmux throttles at the source.
- **Control frames** (`opened`, `exited`, `error`, `resize`, `pong`, session snapshots) never wait and are never dropped. The CDC fan-out enqueues on one goroutine shared by every connection, so blocking there would stall unrelated connections.

Ordering is unchanged: one queue, appended in production order, drained in order. A waiting producer is released by a drain or by the connection's context.