### PR TITLE
fix(browser): match preview scrollbars to AO

### DIFF
--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -225,10 +225,10 @@ describe("browser scrollbar styling", () => {
 		expect(insertCSS).toHaveBeenCalledOnce();
 		const css = insertCSS.mock.calls[0]?.[0] ?? "";
 		expect(insertCSS.mock.calls[0]?.[1]).toEqual({ cssOrigin: "user" });
-		expect(css).toContain("::-webkit-scrollbar-thumb");
-		expect(css).toContain("::-webkit-scrollbar-track");
-		expect(css).not.toContain("scrollbar-width");
-		expect(css).not.toMatch(/\b(?:width|height):/);
+		expect(css).toContain("scrollbar-width: thin");
+		expect(css).toContain("scrollbar-color: rgba(232, 232, 232, 0.26) transparent");
+		expect(css).not.toContain("::-webkit-scrollbar");
+		expect(css).not.toMatch(/^\s*(?:width|height):/m);
 		expect(css).not.toContain("min-height");
 		expect(css).not.toContain("min-width");
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -225,9 +225,10 @@ describe("browser scrollbar styling", () => {
 		expect(insertCSS).toHaveBeenCalledOnce();
 		const css = insertCSS.mock.calls[0]?.[0] ?? "";
 		expect(insertCSS.mock.calls[0]?.[1]).toEqual({ cssOrigin: "user" });
-		expect(css).toContain("scrollbar-width: thin");
-		expect(css).toContain("scrollbar-color:");
-		expect(css).not.toContain("::-webkit-scrollbar");
+		expect(css).toContain("::-webkit-scrollbar-thumb");
+		expect(css).toContain("::-webkit-scrollbar-track");
+		expect(css).not.toContain("scrollbar-width");
+		expect(css).not.toMatch(/\b(?:width|height):/);
 		expect(css).not.toContain("min-height");
 		expect(css).not.toContain("min-width");
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -22,6 +22,7 @@ type EventHandler = (event: { sender: { id: number; getZoomFactor?: () => number
 
 function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").AgentBrowserRuntime) {
 	let currentURL = "";
+	let browserZoomFactor = 1;
 	const webContentsListeners = new Map<string, (...args: never[]) => void>();
 	const debuggerListeners = new Map<string, (...args: never[]) => void>();
 	let debuggerAttached = false;
@@ -60,6 +61,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 		clearHistory: () => undefined,
 		getTitle: () => "",
 		getURL: () => currentURL,
+		getZoomFactor: () => browserZoomFactor,
 		goBack: () => undefined,
 		goForward: () => undefined,
 		isLoading: () => false,
@@ -207,6 +209,9 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 		openDevTools,
 		closeDevTools,
 		insertCSS,
+		setBrowserZoomFactor: (zoomFactor: number) => {
+			browserZoomFactor = zoomFactor;
+		},
 		view,
 		webContents,
 		webContentsListeners,
@@ -217,7 +222,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 
 describe("browser scrollbar styling", () => {
 	it("injects AO-styled horizontal and vertical scrollbars whenever a browser page becomes ready", async () => {
-		const { insertCSS, invoke, webContentsListeners } = setupHost();
+		const { insertCSS, invoke, setBrowserZoomFactor, webContentsListeners } = setupHost();
 
 		await invoke("browser:ensure", "sess-1");
 		webContentsListeners.get("dom-ready")?.();
@@ -237,6 +242,13 @@ describe("browser scrollbar styling", () => {
 
 		webContentsListeners.get("dom-ready")?.();
 		expect(insertCSS).toHaveBeenCalledTimes(2);
+
+		setBrowserZoomFactor(4);
+		webContentsListeners.get("zoom-changed")?.();
+		expect(insertCSS).toHaveBeenCalledTimes(3);
+		const zoomedCss = insertCSS.mock.calls[2]?.[0] ?? "";
+		expect(zoomedCss).toContain("width: 2px");
+		expect(zoomedCss).toContain("height: 2px");
 	});
 });
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -225,9 +225,9 @@ describe("browser scrollbar styling", () => {
 		expect(insertCSS).toHaveBeenCalledOnce();
 		const css = insertCSS.mock.calls[0]?.[0] ?? "";
 		expect(insertCSS.mock.calls[0]?.[1]).toEqual({ cssOrigin: "user" });
-		expect(css).toContain("::-webkit-scrollbar");
-		expect(css).toContain("::-webkit-scrollbar-thumb");
-		expect(css).toContain("::-webkit-scrollbar-corner");
+		expect(css).toContain("scrollbar-width: thin");
+		expect(css).toContain("scrollbar-color:");
+		expect(css).not.toContain("::-webkit-scrollbar");
 		expect(css).not.toContain("min-height");
 		expect(css).not.toContain("min-width");
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -228,6 +228,8 @@ describe("browser scrollbar styling", () => {
 		expect(css).toContain("::-webkit-scrollbar");
 		expect(css).toContain("::-webkit-scrollbar-thumb");
 		expect(css).toContain("::-webkit-scrollbar-corner");
+		expect(css).not.toContain("min-height");
+		expect(css).not.toContain("min-width");
 
 		webContentsListeners.get("dom-ready")?.();
 		expect(insertCSS).toHaveBeenCalledTimes(2);

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -29,6 +29,9 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 	const openDevTools = vi.fn();
 	const closeDevTools = vi.fn();
 	const insertCSS = vi.fn(async (_css: string, _options?: { cssOrigin?: "author" | "user" }) => "ao-browser-scrollbars");
+	let insertedStyleNumber = 0;
+	insertCSS.mockImplementation(async () => `ao-browser-scrollbars-${++insertedStyleNumber}`);
+	const removeInsertedCSS = vi.fn(async (_key: string) => undefined);
 	const debuggerSendCommand = vi.fn(async (method: string, params?: Record<string, unknown>): Promise<unknown> => {
 		if (method === "Page.navigate" && typeof params?.url === "string") currentURL = params.url;
 		return {};
@@ -66,6 +69,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 		goForward: () => undefined,
 		isLoading: () => false,
 		insertCSS,
+		removeInsertedCSS,
 		loadURL: vi.fn(async (url: string) => {
 			currentURL = url;
 		}),
@@ -209,6 +213,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 		openDevTools,
 		closeDevTools,
 		insertCSS,
+		removeInsertedCSS,
 		setBrowserZoomFactor: (zoomFactor: number) => {
 			browserZoomFactor = zoomFactor;
 		},
@@ -222,12 +227,12 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 
 describe("browser scrollbar styling", () => {
 	it("injects AO-styled horizontal and vertical scrollbars whenever a browser page becomes ready", async () => {
-		const { insertCSS, invoke, setBrowserZoomFactor, webContentsListeners } = setupHost();
+		const { insertCSS, invoke, removeInsertedCSS, setBrowserZoomFactor, webContentsListeners } = setupHost();
 
 		await invoke("browser:ensure", "sess-1");
 		webContentsListeners.get("dom-ready")?.();
 
-		expect(insertCSS).toHaveBeenCalledOnce();
+		await vi.waitFor(() => expect(insertCSS).toHaveBeenCalledOnce());
 		const css = insertCSS.mock.calls[0]?.[0] ?? "";
 		expect(insertCSS.mock.calls[0]?.[1]).toEqual({ cssOrigin: "user" });
 		expect(css).toContain("::-webkit-scrollbar-thumb");
@@ -241,14 +246,15 @@ describe("browser scrollbar styling", () => {
 		expect(css).not.toContain("min-width");
 
 		webContentsListeners.get("dom-ready")?.();
-		expect(insertCSS).toHaveBeenCalledTimes(2);
+		await vi.waitFor(() => expect(insertCSS).toHaveBeenCalledTimes(2));
 
 		setBrowserZoomFactor(4);
 		webContentsListeners.get("zoom-changed")?.();
-		expect(insertCSS).toHaveBeenCalledTimes(3);
+		await vi.waitFor(() => expect(insertCSS).toHaveBeenCalledTimes(3));
 		const zoomedCss = insertCSS.mock.calls[2]?.[0] ?? "";
 		expect(zoomedCss).toContain("width: 2px");
 		expect(zoomedCss).toContain("height: 2px");
+		await vi.waitFor(() => expect(removeInsertedCSS).toHaveBeenCalledWith("ao-browser-scrollbars-2"));
 	});
 });
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -27,6 +27,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 	let debuggerAttached = false;
 	const openDevTools = vi.fn();
 	const closeDevTools = vi.fn();
+	const insertCSS = vi.fn(async (_css: string, _options?: { cssOrigin?: "author" | "user" }) => "ao-browser-scrollbars");
 	const debuggerSendCommand = vi.fn(async (method: string, params?: Record<string, unknown>): Promise<unknown> => {
 		if (method === "Page.navigate" && typeof params?.url === "string") currentURL = params.url;
 		return {};
@@ -62,6 +63,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 		goBack: () => undefined,
 		goForward: () => undefined,
 		isLoading: () => false,
+		insertCSS,
 		loadURL: vi.fn(async (url: string) => {
 			currentURL = url;
 		}),
@@ -204,6 +206,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 		shellSend,
 		openDevTools,
 		closeDevTools,
+		insertCSS,
 		view,
 		webContents,
 		webContentsListeners,
@@ -211,6 +214,25 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 		debuggerSendCommand,
 	};
 }
+
+describe("browser scrollbar styling", () => {
+	it("injects AO-styled horizontal and vertical scrollbars whenever a browser page becomes ready", async () => {
+		const { insertCSS, invoke, webContentsListeners } = setupHost();
+
+		await invoke("browser:ensure", "sess-1");
+		webContentsListeners.get("dom-ready")?.();
+
+		expect(insertCSS).toHaveBeenCalledOnce();
+		const css = insertCSS.mock.calls[0]?.[0] ?? "";
+		expect(insertCSS.mock.calls[0]?.[1]).toEqual({ cssOrigin: "user" });
+		expect(css).toContain("::-webkit-scrollbar");
+		expect(css).toContain("::-webkit-scrollbar-thumb");
+		expect(css).toContain("::-webkit-scrollbar-corner");
+
+		webContentsListeners.get("dom-ready")?.();
+		expect(insertCSS).toHaveBeenCalledTimes(2);
+	});
+});
 
 function setupTabHost() {
 	const constructorOptions: Array<{ webPreferences: { partition?: string } }> = [];

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -225,10 +225,13 @@ describe("browser scrollbar styling", () => {
 		expect(insertCSS).toHaveBeenCalledOnce();
 		const css = insertCSS.mock.calls[0]?.[0] ?? "";
 		expect(insertCSS.mock.calls[0]?.[1]).toEqual({ cssOrigin: "user" });
-		expect(css).toContain("scrollbar-width: thin");
-		expect(css).toContain("scrollbar-color: rgba(232, 232, 232, 0.26) transparent");
-		expect(css).not.toContain("::-webkit-scrollbar");
-		expect(css).not.toMatch(/^\s*(?:width|height):/m);
+		expect(css).toContain("::-webkit-scrollbar-thumb");
+		expect(css).toContain("border-radius: 999px");
+		expect(css).toContain("background: rgba(232, 232, 232, 0.72)");
+		expect(css).toContain("::-webkit-scrollbar-track");
+		expect(css).toContain("background: transparent");
+		expect(css).toContain("width: 8px");
+		expect(css).toContain("height: 8px");
 		expect(css).not.toContain("min-height");
 		expect(css).not.toContain("min-width");
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -160,6 +160,7 @@ type BrowserWebContents = Pick<
 	| "loadURL"
 	| "on"
 	| "reload"
+	| "removeInsertedCSS"
 	| "send"
 	| "setWindowOpenHandler"
 	| "stop"
@@ -530,9 +531,18 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		view.setBorderRadius?.(BROWSER_VIEW_BORDER_RADIUS);
 		view.webContents.session?.setPermissionCheckHandler?.(() => false);
 		view.webContents.session?.setPermissionRequestHandler?.((_contents, _permission, callback) => callback(false));
+		let scrollbarStyleKey: string | undefined;
+		let scrollbarStyleUpdate = Promise.resolve();
 		const applyScrollbarStyle = (): void => {
-			void view.webContents
-				.insertCSS(browserScrollbarCSS(view.webContents.getZoomFactor()), { cssOrigin: "user" })
+			scrollbarStyleUpdate = scrollbarStyleUpdate
+				.then(async () => {
+					const previousKey = scrollbarStyleKey;
+					scrollbarStyleKey = await view.webContents.insertCSS(
+						browserScrollbarCSS(view.webContents.getZoomFactor()),
+						{ cssOrigin: "user" },
+					);
+					if (previousKey) await view.webContents.removeInsertedCSS(previousKey);
+				})
 				.catch(() => undefined);
 		};
 		view.webContents.on("dom-ready", applyScrollbarStyle);

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -170,9 +170,22 @@ type BrowserWebContents = Pick<
 };
 
 const BROWSER_SCROLLBAR_CSS = `
-	* {
-		scrollbar-width: thin;
-		scrollbar-color: #4b515a #16191d;
+	::-webkit-scrollbar-button {
+		display: none;
+	}
+
+	::-webkit-scrollbar-track,
+	::-webkit-scrollbar-corner {
+		background: #16191d;
+	}
+
+	::-webkit-scrollbar-thumb {
+		border-radius: 999px;
+		background: #4b515a;
+	}
+
+	::-webkit-scrollbar-thumb:hover {
+		background: #69717d;
 	}
 `;
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -187,8 +187,6 @@ const BROWSER_SCROLLBAR_CSS = `
 	}
 
 	::-webkit-scrollbar-thumb {
-		min-width: 24px;
-		min-height: 24px;
 		border: 2px solid #16191d;
 		border-radius: 999px;
 		background: #4b515a;

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -170,9 +170,27 @@ type BrowserWebContents = Pick<
 };
 
 const BROWSER_SCROLLBAR_CSS = `
-	* {
-		scrollbar-width: thin;
-		scrollbar-color: rgba(232, 232, 232, 0.26) transparent;
+	::-webkit-scrollbar {
+		width: 8px;
+		height: 8px;
+	}
+
+	::-webkit-scrollbar-button {
+		display: none;
+	}
+
+	::-webkit-scrollbar-track,
+	::-webkit-scrollbar-corner {
+		background: transparent;
+	}
+
+	::-webkit-scrollbar-thumb {
+		border-radius: 999px;
+		background: rgba(232, 232, 232, 0.72);
+	}
+
+	::-webkit-scrollbar-thumb:hover {
+		background: rgba(232, 232, 232, 0.86);
 	}
 `;
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -152,6 +152,7 @@ type BrowserWebContents = Pick<
 	| "mainFrame"
 	| "getTitle"
 	| "getURL"
+	| "getZoomFactor"
 	| "goBack"
 	| "goForward"
 	| "isLoading"
@@ -169,10 +170,13 @@ type BrowserWebContents = Pick<
 	session?: Pick<Session, "setPermissionCheckHandler" | "setPermissionRequestHandler" | "webRequest">;
 };
 
-const BROWSER_SCROLLBAR_CSS = `
+const browserScrollbarCSS = (zoomFactor: number): string => {
+	const effectiveZoom = Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
+	const thickness = Number((8 / effectiveZoom).toFixed(3));
+	return `
 	::-webkit-scrollbar {
-		width: 8px;
-		height: 8px;
+		width: ${thickness}px;
+		height: ${thickness}px;
 	}
 
 	::-webkit-scrollbar-button {
@@ -193,6 +197,7 @@ const BROWSER_SCROLLBAR_CSS = `
 		background: rgba(232, 232, 232, 0.86);
 	}
 `;
+};
 
 type BrowserViewLike = View & {
 	webContents: BrowserWebContents;
@@ -525,9 +530,13 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		view.setBorderRadius?.(BROWSER_VIEW_BORDER_RADIUS);
 		view.webContents.session?.setPermissionCheckHandler?.(() => false);
 		view.webContents.session?.setPermissionRequestHandler?.((_contents, _permission, callback) => callback(false));
-		view.webContents.on("dom-ready", () => {
-			void view.webContents.insertCSS(BROWSER_SCROLLBAR_CSS, { cssOrigin: "user" }).catch(() => undefined);
-		});
+		const applyScrollbarStyle = (): void => {
+			void view.webContents
+				.insertCSS(browserScrollbarCSS(view.webContents.getZoomFactor()), { cssOrigin: "user" })
+				.catch(() => undefined);
+		};
+		view.webContents.on("dom-ready", applyScrollbarStyle);
+		view.webContents.on("zoom-changed", applyScrollbarStyle);
 
 		const tabId = `t${session.nextTabNumber++}`;
 		const state: BrowserNavState = emptyNavState(session.viewId);

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -155,6 +155,7 @@ type BrowserWebContents = Pick<
 	| "goBack"
 	| "goForward"
 	| "isLoading"
+	| "insertCSS"
 	| "loadURL"
 	| "on"
 	| "reload"
@@ -167,6 +168,36 @@ type BrowserWebContents = Pick<
 	close?: () => void;
 	session?: Pick<Session, "setPermissionCheckHandler" | "setPermissionRequestHandler" | "webRequest">;
 };
+
+const BROWSER_SCROLLBAR_CSS = `
+	::-webkit-scrollbar {
+		width: 10px;
+		height: 10px;
+	}
+
+	::-webkit-scrollbar-button {
+		display: none;
+		width: 0;
+		height: 0;
+	}
+
+	::-webkit-scrollbar-track,
+	::-webkit-scrollbar-corner {
+		background: #16191d;
+	}
+
+	::-webkit-scrollbar-thumb {
+		min-width: 24px;
+		min-height: 24px;
+		border: 2px solid #16191d;
+		border-radius: 999px;
+		background: #4b515a;
+	}
+
+	::-webkit-scrollbar-thumb:hover {
+		background: #69717d;
+	}
+`;
 
 type BrowserViewLike = View & {
 	webContents: BrowserWebContents;
@@ -499,6 +530,9 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		view.setBorderRadius?.(BROWSER_VIEW_BORDER_RADIUS);
 		view.webContents.session?.setPermissionCheckHandler?.(() => false);
 		view.webContents.session?.setPermissionRequestHandler?.((_contents, _permission, callback) => callback(false));
+		view.webContents.on("dom-ready", () => {
+			void view.webContents.insertCSS(BROWSER_SCROLLBAR_CSS, { cssOrigin: "user" }).catch(() => undefined);
+		});
 
 		const tabId = `t${session.nextTabNumber++}`;
 		const state: BrowserNavState = emptyNavState(session.viewId);

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -170,30 +170,9 @@ type BrowserWebContents = Pick<
 };
 
 const BROWSER_SCROLLBAR_CSS = `
-	::-webkit-scrollbar {
-		width: 10px;
-		height: 10px;
-	}
-
-	::-webkit-scrollbar-button {
-		display: none;
-		width: 0;
-		height: 0;
-	}
-
-	::-webkit-scrollbar-track,
-	::-webkit-scrollbar-corner {
-		background: #16191d;
-	}
-
-	::-webkit-scrollbar-thumb {
-		border: 2px solid #16191d;
-		border-radius: 999px;
-		background: #4b515a;
-	}
-
-	::-webkit-scrollbar-thumb:hover {
-		background: #69717d;
+	* {
+		scrollbar-width: thin;
+		scrollbar-color: #4b515a #16191d;
 	}
 `;
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -170,22 +170,9 @@ type BrowserWebContents = Pick<
 };
 
 const BROWSER_SCROLLBAR_CSS = `
-	::-webkit-scrollbar-button {
-		display: none;
-	}
-
-	::-webkit-scrollbar-track,
-	::-webkit-scrollbar-corner {
-		background: #16191d;
-	}
-
-	::-webkit-scrollbar-thumb {
-		border-radius: 999px;
-		background: #4b515a;
-	}
-
-	::-webkit-scrollbar-thumb:hover {
-		background: #69717d;
+	* {
+		scrollbar-width: thin;
+		scrollbar-color: rgba(232, 232, 232, 0.26) transparent;
 	}
 `;
 


### PR DESCRIPTION
## What

Styles both horizontal and vertical scrollbars inside AO browser preview pages with a compact dark track, rounded thumb, hover state, and hidden arrow buttons.

## Why

Embedded pages currently expose Chromium default scrollbars that visually clash with AO and consume excessive space in the narrow inspector.

## How

Injects the scrollbar rules at user origin on every `dom-ready`, so each tab and navigation keeps the AO treatment while page CSS cannot override it. The change remains inside the browser host boundary.

## Testing

- `npm test -- src/main/browser-view-host.test.ts` — 76 passed
- `npm run typecheck` — passed
- Full `npm test` — 2,893 passed, 2 skipped, 34 unrelated failures on Windows from macOS-only/path assumptions, locale expectations, socket permissions, and missing landing-test dependencies

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)