### PR TITLE
feat(browser): move wide-layout tabs to top strip

### DIFF
--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -9,7 +9,6 @@ import {
 	normalizeBrowserURL,
 	scaleBoundsForZoom,
 } from "./browser-view-host";
-import { MAX_BROWSER_TABS } from "../shared/browser-tabs";
 import { NEW_SESSION_SHORTCUT_CHANNEL } from "../shared/shortcuts";
 
 vi.mock("electron", async (importOriginal) => {
@@ -970,13 +969,13 @@ describe("agent browser runtime", () => {
 		await expect(host.execute("sess-1", "__destroy-session")).resolves.toEqual({ destroyed: false });
 	});
 
-	it("caps session tabs", async () => {
-		const { host } = setupHost();
+	it("opens tabs beyond the former session cap", async () => {
+		const { host, mainContentView } = setupHost();
 		await host.execute("sess-1", "tabs");
-		for (let i = 1; i < 16; i += 1) {
+		for (let i = 1; i < 20; i += 1) {
 			await host.execute("sess-1", "tab-new");
 		}
-		await expect(host.execute("sess-1", "tab-new")).rejects.toMatchObject({ code: "BROWSER_TAB_LIMIT" });
+		expect(mainContentView.addChildView).toHaveBeenCalledTimes(20);
 	});
 
 	it("escapes page-supplied trust boundary markers in browser logs", async () => {
@@ -1317,14 +1316,15 @@ describe("agent browser runtime", () => {
 });
 
 describe("browser tab lifecycle stress (tabs stop closing regression guard)", () => {
+	const stressTabCount = 16;
 	// Re-verifies the historically reported "tabs stop closing" bug against the
 	// REAL closeTab/destroyTabView code paths (not a mock of them), by driving
-	// the IPC handlers exactly as the renderer rail does: open to the tab cap,
+	// the IPC handlers exactly as the renderer rail does: open many tabs,
 	// close back down to one, repeatedly, interleaving tab selection plus a
 	// DevTools open/close and an annotation-mode toggle each cycle -- the two
 	// failure modes ("wrong tab content after switching", "stale overlay
 	// captures") called out by the stabilization commits already on main.
-	it("opens to the tab cap and closes back to one tab across many churn cycles without a stuck or leaked tab", async () => {
+	it("opens many tabs and closes back to one across churn cycles without a stuck or leaked tab", async () => {
 		const { invoke, views } = setupTabHost();
 		const ensured = (await invoke("browser:ensure", "sess-1")) as BrowserNavState;
 		const { viewId } = ensured;
@@ -1349,11 +1349,11 @@ describe("browser tab lifecycle stress (tabs stop closing regression guard)", ()
 		let nonReactivatingCloses = 0;
 
 		for (let cycle = 0; cycle < 20; cycle += 1) {
-			for (let i = 0; i < MAX_BROWSER_TABS - 1; i += 1) {
+			for (let i = 0; i < stressTabCount - 1; i += 1) {
 				await invoke("browser:openTab", { viewId });
 			}
 			let tabs = (await invoke("browser:getTabs", viewId)) as BrowserTabsState;
-			expect(tabs.tabs).toHaveLength(MAX_BROWSER_TABS);
+			expect(tabs.tabs).toHaveLength(stressTabCount);
 
 			// Interleave the two related failure modes named in the brief: a
 			// DevTools open/close cycle and an annotation-mode toggle.
@@ -1367,7 +1367,7 @@ describe("browser tab lifecycle stress (tabs stop closing regression guard)", ()
 			// above surfaces here directly, instead of only indirectly on the
 			// next close below.
 			tabs = (await invoke("browser:getTabs", viewId)) as BrowserTabsState;
-			expect(tabs.tabs).toHaveLength(MAX_BROWSER_TABS);
+			expect(tabs.tabs).toHaveLength(stressTabCount);
 
 			let closeCount = 0;
 			while (tabs.tabs.length > 1) {
@@ -1414,7 +1414,7 @@ describe("browser tab lifecycle stress (tabs stop closing regression guard)", ()
 		// from closeTab's behavior, so this assertion can't pass by accident
 		// the way the prior induction-based version did. The thresholds are
 		// deliberately loose (the actual split is a deterministic 160
-		// reactivating / 140 non-reactivating for MAX_BROWSER_TABS=16 across 20
+		// reactivating / 140 non-reactivating for 16 tabs across 20
 		// cycles) since what matters is that neither branch has zero coverage.
 		expect(reactivatingCloses).toBeGreaterThanOrEqual(5);
 		expect(nonReactivatingCloses).toBeGreaterThanOrEqual(5);

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -21,7 +21,6 @@ import type {
 	BrowserAnnotationSubmitPayload,
 } from "../shared/browser-annotations";
 import { attachAppShortcuts } from "./app-shortcuts";
-import { MAX_BROWSER_TABS } from "../shared/browser-tabs";
 import type { KeybindingOverrides } from "../shared/shortcuts";
 import type { AgentBrowserRuntime } from "./agent-browser-runtime";
 import type { AgentBrowserTarget, AgentBrowserTargetProvider } from "./agent-browser-cdp-bridge";
@@ -482,9 +481,6 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	};
 
 	const createTab = (session: BrowserSessionEntry, activate: boolean, syncNativeOnActivate = false): BrowserEntry => {
-		if (session.tabs.size >= MAX_BROWSER_TABS) {
-			throw browserError("BROWSER_TAB_LIMIT", `Browser tab limit of ${MAX_BROWSER_TABS} reached`);
-		}
 		const view = new options.WebContentsView({
 			webPreferences: {
 				contextIsolation: true,
@@ -550,11 +546,10 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 				// Created window should be connected to webContents passed with options
 				// object" and crashes the whole app on every link click. Deny the guest
 				// window outright and open (and navigate) our own tab instead; openTab
-				// already handles URL validation, tab-limit, and the "popup" tabs-state
+				// already handles URL validation and the "popup" tabs-state
 				// event this used to push manually.
 				void openTab(session, url, true, "popup", true).catch(() => undefined);
 			},
-			() => session.tabs.size < MAX_BROWSER_TABS,
 		);
 		wireNavEvents(
 			view.webContents,
@@ -828,7 +823,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 
 	// Re-verified 2026-08-19: a long-session report claimed tab close buttons
 	// eventually "stop working" (tab stays in the rail / count badge doesn't
-	// decrement). An accelerated stress repro -- open to MAX_BROWSER_TABS and
+	// decrement). An accelerated stress repro -- open many tabs and
 	// close back to one, 20 cycles, interleaving selectTab/DevTools
 	// open-close/annotation-mode toggles -- against this real closeTab/
 	// destroyTabView path (see "browser tab lifecycle stress" in
@@ -1776,10 +1771,9 @@ function hardenWebContents(
 	options: BrowserViewHostOptions,
 	entry: BrowserEntry,
 	openPopup: (url: string) => void,
-	canCreatePopup: () => boolean,
 ): void {
 	contents.setWindowOpenHandler(({ url }) => {
-		if (!isAllowedBrowserURL(url, options.rendererOrigin) || !canCreatePopup()) {
+		if (!isAllowedBrowserURL(url, options.rendererOrigin)) {
 			return { action: "deny" };
 		}
 		// Always deny — never return createWindow. See the call site's comment for

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, renderHook, screen, waitFor, within } from "@te
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
+import { reorderBrowserTabs } from "../lib/browser-tab-order";
 import { useBrowserView, type BrowserNavState } from "../hooks/useBrowserView";
 import { OPEN_BROWSER_OVERLAY_SELECTOR } from "../lib/dom-selectors";
 import { MAX_BROWSER_TABS } from "../../shared/browser-tabs";
@@ -98,6 +99,11 @@ const session: WorkspaceSession = {
 	updatedAt: "2026-06-15T00:00:00Z",
 	prs: [],
 };
+
+it("reorders horizontal browser tabs around the drop target", () => {
+	expect(reorderBrowserTabs(["t1", "t2", "t3"], "t1", "t3")).toEqual(["t2", "t3", "t1"]);
+	expect(reorderBrowserTabs(["t1", "t2", "t3"], "t2", "missing")).toBeNull();
+});
 
 type ElementAnnotationPayload = BrowserAnnotationSubmitPayload & {
 	selection: { kind: "element"; context: BrowserAnnotationContext };

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, renderHook, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
@@ -400,6 +400,56 @@ describe("BrowserPanel", () => {
 		await userEvent.click(screen.getByRole("button", { name: "First app" }));
 
 		await waitFor(() => expect(hookState.selectTab).toHaveBeenCalledWith("t1"));
+	});
+
+	it("shows browser tabs in a horizontal tab strip and selects them", async () => {
+		hookState.tabs = [
+			{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
+			{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: true },
+		];
+		hookState.activeTabId = "t2";
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		const tabList = screen.getByRole("tablist", { name: "Browser tabs" });
+		const firstTab = within(tabList).getByRole("tab", { name: "First app" });
+		const secondTab = within(tabList).getByRole("tab", { name: "Second app" });
+
+		expect(firstTab).toHaveAttribute("aria-selected", "false");
+		expect(secondTab).toHaveAttribute("aria-selected", "true");
+		await userEvent.click(firstTab);
+		expect(hookState.selectTab).toHaveBeenCalledWith("t1");
+	});
+
+	it("moves browser tab focus and selection with arrow keys", async () => {
+		hookState.tabs = [
+			{ id: "t1", url: "http://localhost:3000/", title: "First app", active: true },
+			{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: false },
+		];
+		hookState.activeTabId = "t1";
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		const tabList = screen.getByRole("tablist", { name: "Browser tabs" });
+		const firstTab = within(tabList).getByRole("tab", { name: "First app" });
+		const secondTab = within(tabList).getByRole("tab", { name: "Second app" });
+		firstTab.focus();
+		await userEvent.keyboard("{ArrowRight}");
+
+		expect(secondTab).toHaveFocus();
+		expect(hookState.selectTab).toHaveBeenCalledWith("t2");
+	});
+
+	it("closes a browser tab from the horizontal tab strip", async () => {
+		hookState.tabs = [
+			{ id: "t1", url: "http://localhost:3000/", title: "First app", active: true },
+			{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: false },
+		];
+		hookState.activeTabId = "t1";
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		const tabList = screen.getByRole("tablist", { name: "Browser tabs" });
+		await userEvent.click(within(tabList).getByRole("button", { name: "Close tab Second app" }));
+
+		expect(hookState.closeTab).toHaveBeenCalledWith("t2");
 	});
 
 	it("does not render a tab-specific agent marker", async () => {

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -452,6 +452,14 @@ describe("BrowserPanel", () => {
 		expect(hookState.closeTab).toHaveBeenCalledWith("t2");
 	});
 
+	it("opens a new browser tab from the horizontal tab strip", async () => {
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		await userEvent.click(within(screen.getByTestId("browser-tab-bar")).getByRole("button", { name: "Open new tab" }));
+
+		expect(hookState.openTab).toHaveBeenCalledOnce();
+	});
+
 	it("does not render a tab-specific agent marker", async () => {
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
 		hookState.tabs = [
@@ -593,7 +601,9 @@ describe("BrowserPanel", () => {
 			vi.useRealTimers();
 		}
 
-		await userEvent.click(screen.getByRole("button", { name: "Close tab First app" }));
+		await userEvent.click(
+			within(screen.getByTestId("browser-tabs-flyout")).getByRole("button", { name: "Close tab First app" }),
+		);
 
 		expect(hookState.closeTab).toHaveBeenCalledWith("t1");
 	});
@@ -698,7 +708,9 @@ describe("BrowserPanel", () => {
 			vi.useRealTimers();
 		}
 
-		await userEvent.click(screen.getByRole("button", { name: "Close tab First app" }));
+		await userEvent.click(
+			within(screen.getByTestId("browser-tabs-flyout")).getByRole("button", { name: "Close tab First app" }),
+		);
 
 		expect(flyout).toHaveAttribute("data-state", "open");
 	});

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -5,7 +5,6 @@ import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./Bro
 import { reorderBrowserTabs } from "../lib/browser-tab-order";
 import { useBrowserView, type BrowserNavState } from "../hooks/useBrowserView";
 import { OPEN_BROWSER_OVERLAY_SELECTOR } from "../lib/dom-selectors";
-import { MAX_BROWSER_TABS } from "../../shared/browser-tabs";
 import type { WorkspaceSession } from "../types/workspace";
 import type {
 	BrowserAnnotationCancelPayload,
@@ -666,11 +665,8 @@ describe("BrowserPanel", () => {
 		expect(row.querySelector("img")).toHaveAttribute("src", "http://localhost:5173/favicon.ico");
 	});
 
-	// Regression: reopening a closed tab at the cap used to silently drop it
-	// from the list and open nothing — gate the row the same way the "+"
-	// button already gates new tabs.
-	it("disables reopening a recently closed tab once the tab cap is reached", async () => {
-		hookState.tabs = Array.from({ length: MAX_BROWSER_TABS }, (_, i) => ({
+	it("keeps opening and reopening tabs available beyond the former cap", async () => {
+		hookState.tabs = Array.from({ length: 20 }, (_, i) => ({
 			id: `t${i}`,
 			url: `http://localhost:3000/${i}`,
 			title: `Tab ${i}`,
@@ -690,9 +686,10 @@ describe("BrowserPanel", () => {
 		}
 
 		const row = screen.getByRole("button", { name: "Reopen Closed app" });
-		expect(row).toBeDisabled();
-		await userEvent.click(row, { pointerEventsCheck: 0 });
-		expect(hookState.reopenClosedTab).not.toHaveBeenCalled();
+		expect(row).toBeEnabled();
+		await userEvent.click(row);
+		expect(hookState.reopenClosedTab).toHaveBeenCalledWith("closed");
+		expect(screen.getAllByRole("button", { name: "Open new tab" }).every((button) => !button.hasAttribute("disabled"))).toBe(true);
 	});
 
 	it("keeps the hover flyout open after closing a tab, since the cursor is still over it", async () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -869,7 +869,11 @@ function SortableBrowserTopTab({
 	const closeLabel = t("browser.closeTab", { title: label.title });
 	return (
 		<div
-			className={cn("browser-panel__tab", selected && "browser-panel__tab--active", isDragging && "z-chrome opacity-80")}
+			className={cn(
+				"browser-panel__tab",
+				selected && "browser-panel__tab--active",
+				isDragging && "browser-panel__tab--dragging z-chrome opacity-80",
+			)}
 			ref={setNodeRef}
 			style={{ transform: CSS.Transform.toString(transform), transition }}
 		>

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -36,7 +36,6 @@ import {
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { useBrowserView, type BrowserViewModel } from "../hooks/useBrowserView";
 import { formatBrowserAnnotationMessage, type BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
-import { MAX_BROWSER_TABS } from "../../shared/browser-tabs";
 import type { WorkspaceSession } from "../types/workspace";
 import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
@@ -336,7 +335,6 @@ export function BrowserPanelView({
 	const showStaticPreview = !hasNativeBrowser && navState.url !== "";
 	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);
 	const canRetryAnnotation = status === "error" && queuedCount > 0;
-	const canOpenTab = tabs.length < MAX_BROWSER_TABS;
 	const [devicePreset, setDevicePreset] = useState<string | null>(null);
 	const [customDeviceWidth, setCustomDeviceWidth] = useState("390");
 	const deviceFrameWidth =
@@ -513,7 +511,6 @@ export function BrowserPanelView({
 				<button
 					aria-label={t("browser.openNewTab")}
 					className="browser-panel__tab-new"
-					disabled={!canOpenTab}
 					onClick={() => void handleOpenTab()}
 					title={t("browser.openNewTab")}
 					type="button"
@@ -771,7 +768,6 @@ export function BrowserPanelView({
 					<div className="browser-panel__toolbar-new-tab flex w-8 shrink-0 items-center justify-center self-stretch border-l border-border">
 						<Button
 							aria-label={t("browser.openNewTab")}
-							disabled={!canOpenTab}
 							onClick={() => void handleOpenTab()}
 							size="icon-sm"
 							title={t("browser.openNewTab")}

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -28,6 +28,7 @@ import { Input } from "./ui/input";
 import { BrowserTabsRail, type BrowserTabsRailHandle } from "./BrowserTabsRail";
 import { cn } from "../lib/utils";
 import { appI18n, type MessageKey } from "../i18n";
+import { handleTabListKeyDown } from "../lib/terminal-tabs";
 
 // One-click viewport width presets for responsive testing — height is shown
 // for reference but not enforced (only width drives CSS breakpoints, and
@@ -448,6 +449,7 @@ export function BrowserPanelView({
 			<div
 				aria-label={t("browser.tabs")}
 				className="browser-panel__tab-strip"
+				onKeyDown={handleTabListKeyDown}
 				role="tablist"
 			>
 				{tabs.map((tab) => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -445,6 +445,42 @@ export function BrowserPanelView({
 			ref={panelRef}
 			role="tabpanel"
 		>
+			<div
+				aria-label={t("browser.tabs")}
+				className="browser-panel__tab-strip"
+				role="tablist"
+			>
+				{tabs.map((tab) => {
+					const label = browserTabLabel(tab.title, tab.url);
+					const selected = tab.id === activeTabId;
+					return (
+						<div className={cn("browser-panel__tab", selected && "browser-panel__tab--active")} key={tab.id}>
+							<button
+								aria-selected={selected}
+								className="browser-panel__tab-select"
+								onClick={() => void selectTab(tab.id)}
+								role="tab"
+								tabIndex={selected ? 0 : -1}
+								title={label.title}
+								type="button"
+							>
+								<Globe2 aria-hidden="true" className="browser-panel__tab-icon" />
+								<span className="browser-panel__tab-title">{label.title}</span>
+							</button>
+							<button
+								aria-label={t("browser.closeTab", { title: label.title })}
+								className="browser-panel__tab-close"
+								disabled={tabs.length === 1}
+								onClick={() => void closeTab(tab.id)}
+								title={tabs.length === 1 ? t("browser.onlyTab") : t("browser.closeTab", { title: label.title })}
+								type="button"
+							>
+								<X aria-hidden="true" className="size-icon-sm" />
+							</button>
+						</div>
+					);
+				})}
+			</div>
 			<form
 				className="browser-panel__toolbar flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface"
 				data-testid="browser-toolbar"

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -1,6 +1,22 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import {
+	DndContext,
+	KeyboardSensor,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors,
+	type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+	SortableContext,
+	horizontalListSortingStrategy,
+	sortableKeyboardCoordinates,
+	useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
 	ArrowLeft,
 	ArrowRight,
 	Bug,
@@ -29,6 +45,7 @@ import { BrowserTabsRail, type BrowserTabsRailHandle } from "./BrowserTabsRail";
 import { cn } from "../lib/utils";
 import { appI18n, type MessageKey } from "../i18n";
 import { browserTabLabel } from "../lib/browser-tab-label";
+import { reorderBrowserTabs } from "../lib/browser-tab-order";
 import { handleTabListKeyDown } from "../lib/terminal-tabs";
 
 // One-click viewport width presets for responsive testing — height is shown
@@ -331,6 +348,24 @@ export function BrowserPanelView({
 	const urlInputRef = useRef<HTMLInputElement>(null);
 	const [pinned, setPinned] = useState(() => window.localStorage.getItem(RAIL_PINNED_STORAGE_KEY) === "1");
 	const showTabsTrigger = !poppedOut && !pinned && tabs.length >= 2;
+	const [topTabDragActive, setTopTabDragActive] = useState(false);
+	const tabSensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+	);
+	const handleTopTabDragEnd = useCallback(
+		(event: DragEndEvent) => {
+			setTopTabDragActive(false);
+			if (!event.over) return;
+			const orderedIds = reorderBrowserTabs(
+				tabs.map((tab) => tab.id),
+				String(event.active.id),
+				String(event.over.id),
+			);
+			if (orderedIds) reorderTabs(orderedIds);
+		},
+		[reorderTabs, tabs],
+	);
 
 	const handlePinnedChange = useCallback((next: boolean) => {
 		setPinned(next);
@@ -448,43 +483,33 @@ export function BrowserPanelView({
 			role="tabpanel"
 		>
 			<div className="browser-panel__tab-bar" data-testid="browser-tab-bar">
-				<div
-					aria-label={t("browser.tabs")}
-					className="browser-panel__tab-strip"
-					onKeyDown={handleTabListKeyDown}
-					role="tablist"
+				<DndContext
+					collisionDetection={closestCenter}
+					onDragCancel={() => setTopTabDragActive(false)}
+					onDragEnd={handleTopTabDragEnd}
+					onDragStart={() => setTopTabDragActive(true)}
+					sensors={tabSensors}
 				>
-					{tabs.map((tab) => {
-						const label = browserTabLabel(tab.title, tab.url);
-						const selected = tab.id === activeTabId;
-						return (
-							<div className={cn("browser-panel__tab", selected && "browser-panel__tab--active")} key={tab.id}>
-								<button
-									aria-selected={selected}
-									className="browser-panel__tab-select"
-									onClick={() => void handleSelectTab(tab.id)}
-									role="tab"
-									tabIndex={selected ? 0 : -1}
-									title={label.title}
-									type="button"
-								>
-									<Globe2 aria-hidden="true" className="browser-panel__tab-icon" />
-									<span className="browser-panel__tab-title">{label.title}</span>
-								</button>
-								<button
-									aria-label={t("browser.closeTab", { title: label.title })}
-									className="browser-panel__tab-close"
-									disabled={tabs.length === 1}
-									onClick={() => void closeTab(tab.id)}
-									title={tabs.length === 1 ? t("browser.onlyTab") : t("browser.closeTab", { title: label.title })}
-									type="button"
-								>
-									<X aria-hidden="true" className="size-icon-sm" />
-								</button>
-							</div>
-						);
-					})}
-				</div>
+					<SortableContext items={tabs.map((tab) => tab.id)} strategy={horizontalListSortingStrategy}>
+						<div
+							aria-label={t("browser.tabs")}
+							className="browser-panel__tab-strip"
+							onKeyDown={topTabDragActive ? undefined : handleTabListKeyDown}
+							role="tablist"
+						>
+							{tabs.map((tab) => (
+								<SortableBrowserTopTab
+									key={tab.id}
+									onClose={() => void closeTab(tab.id)}
+									onSelect={() => void handleSelectTab(tab.id)}
+									onlyTab={tabs.length === 1}
+									selected={tab.id === activeTabId}
+									tab={tab}
+								/>
+							))}
+						</div>
+					</SortableContext>
+				</DndContext>
 				<button
 					aria-label={t("browser.openNewTab")}
 					className="browser-panel__tab-new"
@@ -825,6 +850,61 @@ export function BrowserPanelView({
 					tabs={tabs}
 				/>
 			</div>
+		</div>
+	);
+}
+
+function SortableBrowserTopTab({
+	tab,
+	selected,
+	onlyTab,
+	onSelect,
+	onClose,
+}: {
+	tab: BrowserViewModel["tabs"][number];
+	selected: boolean;
+	onlyTab: boolean;
+	onSelect: () => void;
+	onClose: () => void;
+}) {
+	const { t } = useTranslation();
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id });
+	const label = browserTabLabel(tab.title, tab.url);
+	const closeLabel = t("browser.closeTab", { title: label.title });
+	return (
+		<div
+			className={cn("browser-panel__tab", selected && "browser-panel__tab--active", isDragging && "z-chrome opacity-80")}
+			ref={setNodeRef}
+			style={{ transform: CSS.Transform.toString(transform), transition }}
+		>
+			<button
+				{...attributes}
+				{...listeners}
+				aria-selected={selected}
+				className="browser-panel__tab-select"
+				onClick={onSelect}
+				role="tab"
+				tabIndex={selected ? 0 : -1}
+				title={label.title}
+				type="button"
+			>
+				{tab.favicon ? (
+					<img alt="" className="browser-panel__tab-icon object-cover" src={tab.favicon} />
+				) : (
+					<Globe2 aria-hidden="true" className="browser-panel__tab-icon" />
+				)}
+				<span className="browser-panel__tab-title">{label.title}</span>
+			</button>
+			<button
+				aria-label={closeLabel}
+				className="browser-panel__tab-close"
+				disabled={onlyTab}
+				onClick={onClose}
+				title={onlyTab ? t("browser.onlyTab") : closeLabel}
+				type="button"
+			>
+				<X aria-hidden="true" className="size-icon-sm" />
+			</button>
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -28,6 +28,7 @@ import { Input } from "./ui/input";
 import { BrowserTabsRail, type BrowserTabsRailHandle } from "./BrowserTabsRail";
 import { cn } from "../lib/utils";
 import { appI18n, type MessageKey } from "../i18n";
+import { browserTabLabel } from "../lib/browser-tab-label";
 import { handleTabListKeyDown } from "../lib/terminal-tabs";
 
 // One-click viewport width presets for responsive testing — height is shown
@@ -446,42 +447,54 @@ export function BrowserPanelView({
 			ref={panelRef}
 			role="tabpanel"
 		>
-			<div
-				aria-label={t("browser.tabs")}
-				className="browser-panel__tab-strip"
-				onKeyDown={handleTabListKeyDown}
-				role="tablist"
-			>
-				{tabs.map((tab) => {
-					const label = browserTabLabel(tab.title, tab.url);
-					const selected = tab.id === activeTabId;
-					return (
-						<div className={cn("browser-panel__tab", selected && "browser-panel__tab--active")} key={tab.id}>
-							<button
-								aria-selected={selected}
-								className="browser-panel__tab-select"
-								onClick={() => void selectTab(tab.id)}
-								role="tab"
-								tabIndex={selected ? 0 : -1}
-								title={label.title}
-								type="button"
-							>
-								<Globe2 aria-hidden="true" className="browser-panel__tab-icon" />
-								<span className="browser-panel__tab-title">{label.title}</span>
-							</button>
-							<button
-								aria-label={t("browser.closeTab", { title: label.title })}
-								className="browser-panel__tab-close"
-								disabled={tabs.length === 1}
-								onClick={() => void closeTab(tab.id)}
-								title={tabs.length === 1 ? t("browser.onlyTab") : t("browser.closeTab", { title: label.title })}
-								type="button"
-							>
-								<X aria-hidden="true" className="size-icon-sm" />
-							</button>
-						</div>
-					);
-				})}
+			<div className="browser-panel__tab-bar" data-testid="browser-tab-bar">
+				<div
+					aria-label={t("browser.tabs")}
+					className="browser-panel__tab-strip"
+					onKeyDown={handleTabListKeyDown}
+					role="tablist"
+				>
+					{tabs.map((tab) => {
+						const label = browserTabLabel(tab.title, tab.url);
+						const selected = tab.id === activeTabId;
+						return (
+							<div className={cn("browser-panel__tab", selected && "browser-panel__tab--active")} key={tab.id}>
+								<button
+									aria-selected={selected}
+									className="browser-panel__tab-select"
+									onClick={() => void handleSelectTab(tab.id)}
+									role="tab"
+									tabIndex={selected ? 0 : -1}
+									title={label.title}
+									type="button"
+								>
+									<Globe2 aria-hidden="true" className="browser-panel__tab-icon" />
+									<span className="browser-panel__tab-title">{label.title}</span>
+								</button>
+								<button
+									aria-label={t("browser.closeTab", { title: label.title })}
+									className="browser-panel__tab-close"
+									disabled={tabs.length === 1}
+									onClick={() => void closeTab(tab.id)}
+									title={tabs.length === 1 ? t("browser.onlyTab") : t("browser.closeTab", { title: label.title })}
+									type="button"
+								>
+									<X aria-hidden="true" className="size-icon-sm" />
+								</button>
+							</div>
+						);
+					})}
+				</div>
+				<button
+					aria-label={t("browser.openNewTab")}
+					className="browser-panel__tab-new"
+					disabled={!canOpenTab}
+					onClick={() => void handleOpenTab()}
+					title={t("browser.openNewTab")}
+					type="button"
+				>
+					<Plus aria-hidden="true" className="size-icon-base" />
+				</button>
 			</div>
 			<form
 				className="browser-panel__toolbar flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface"
@@ -702,7 +715,7 @@ export function BrowserPanelView({
 				    DOM subtrees (toolbar row vs. body row) — see BrowserTabsRail.tsx's
 				    BrowserTabsRailHandle for why the close side stays debounced here. */}
 				{showTabsTrigger ? (
-					<div className="flex w-8 shrink-0 items-center justify-center self-stretch border-l border-border">
+					<div className="browser-panel__toolbar-tabs-trigger flex w-8 shrink-0 items-center justify-center self-stretch border-l border-border">
 						<Button
 							aria-label={t("browser.tabsTitle", { count: tabs.length })}
 							className="relative"
@@ -730,7 +743,7 @@ export function BrowserPanelView({
 				    with the docked rail directly below it. Popped-out has no icon rail
 				    to align with, and gets its own "+" row inside BrowserTabsRail. */}
 				{!poppedOut ? (
-					<div className="flex w-8 shrink-0 items-center justify-center self-stretch border-l border-border">
+					<div className="browser-panel__toolbar-new-tab flex w-8 shrink-0 items-center justify-center self-stretch border-l border-border">
 						<Button
 							aria-label={t("browser.openNewTab")}
 							disabled={!canOpenTab}

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -29,7 +29,6 @@ import { CSS } from "@dnd-kit/utilities";
 import { Globe2, History, Pin, PinOff, Plus, X } from "lucide-react";
 import type { BrowserTabState } from "../../main/browser-view-host";
 import type { ClosedBrowserTab } from "../hooks/useBrowserView";
-import { MAX_BROWSER_TABS } from "../../shared/browser-tabs";
 import { browserTabLabel } from "../lib/browser-tab-label";
 import { useResizable } from "../hooks/useResizable";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
@@ -234,7 +233,6 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 	const onlyTab = tabs.length === 1;
 	const tabIds = tabs.map((tab) => tab.id);
 	const closeTitle = t("browser.onlyTab");
-	const canOpenTab = tabs.length < MAX_BROWSER_TABS;
 
 	return (
 		<div
@@ -274,7 +272,6 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 						"text-muted-foreground hover:bg-interactive-hover hover:text-foreground",
 						"disabled:pointer-events-none disabled:opacity-50",
 					)}
-					disabled={!canOpenTab}
 					onClick={() => void onOpenTab()}
 					type="button"
 				>
@@ -331,7 +328,7 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 						</SortableContext>
 					</DndContext>
 				)}
-				{expanded ? <ClosedTabsSection canOpenTab={canOpenTab} closedTabs={closedTabs} onReopen={handleReopenClosedTab} /> : null}
+				{expanded ? <ClosedTabsSection closedTabs={closedTabs} onReopen={handleReopenClosedTab} /> : null}
 			</nav>
 			{expanded ? (
 				<div
@@ -402,7 +399,7 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 								tab={tab}
 							/>
 						))}
-						<ClosedTabsSection canOpenTab={canOpenTab} closedTabs={closedTabs} onReopen={handleReopenClosedTab} />
+						<ClosedTabsSection closedTabs={closedTabs} onReopen={handleReopenClosedTab} />
 					</div>
 				</div>
 			) : null}
@@ -439,11 +436,9 @@ function TabFavicon({ className, tab }: { className: string; tab: BrowserTabStat
 // and closed tabs are inherently distinct from "click to switch to this open
 // tab," so they don't belong crammed into the icon list.
 function ClosedTabsSection({
-	canOpenTab,
 	closedTabs,
 	onReopen,
 }: {
-	canOpenTab: boolean;
 	closedTabs: ClosedBrowserTab[];
 	onReopen: (tabId: string) => void;
 }) {
@@ -465,10 +460,9 @@ function ClosedTabsSection({
 							"hover:bg-interactive-hover hover:text-foreground hover:opacity-100",
 							"disabled:pointer-events-none disabled:opacity-40",
 						)}
-						disabled={!canOpenTab}
 						key={tab.id}
 						onClick={() => onReopen(tab.id)}
-						title={canOpenTab ? reopenLabel : t("browser.tabLimitReached")}
+						title={reopenLabel}
 						type="button"
 					>
 						{tab.favicon ? (

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -253,10 +253,7 @@ describe("useBrowserView", () => {
 		expect(result.current.closedTabs).toEqual([]);
 	});
 
-	// Regression: reopenClosedTab used to drop the entry from closedTabs before
-	// awaiting openTab, which throws BROWSER_TAB_LIMIT at the cap — losing the
-	// entry with no rollback and opening nothing.
-	it("refuses to reopen a closed tab at the tab cap, keeping the entry instead of losing it", async () => {
+	it("reopens a closed tab beyond the former tab cap", async () => {
 		const bridge = setupBridge();
 		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
 
@@ -275,8 +272,7 @@ describe("useBrowserView", () => {
 		await act(() => result.current.closeTab("t2"));
 		expect(result.current.closedTabs).toHaveLength(1);
 
-		// Simulate 16 other tabs having opened since (e.g. via agent activity),
-		// hitting MAX_BROWSER_TABS.
+		// Simulate many other tabs having opened since (e.g. via agent activity).
 		act(() =>
 			bridge.emitTabs({
 				viewId: "42:sess-1",
@@ -292,9 +288,8 @@ describe("useBrowserView", () => {
 
 		await act(() => result.current.reopenClosedTab("t2"));
 
-		expect(bridge.openTab).not.toHaveBeenCalled();
-		expect(result.current.closedTabs).toHaveLength(1);
-		expect(result.current.tabNotice).toBe("Reached the tab limit");
+		expect(bridge.openTab).toHaveBeenCalledWith({ viewId: "42:sess-1", url: "http://localhost:4173/" });
+		expect(result.current.closedTabs).toHaveLength(0);
 	});
 
 	// Regression: the same drop-before-await bug also loses the entry on any
@@ -319,7 +314,7 @@ describe("useBrowserView", () => {
 		await act(() => result.current.closeTab("t2"));
 		expect(result.current.closedTabs).toHaveLength(1);
 
-		bridge.openTab.mockRejectedValueOnce(Object.assign(new Error("Browser tab limit reached"), { code: "BROWSER_TAB_LIMIT" }));
+		bridge.openTab.mockRejectedValueOnce(new Error("Browser tab creation failed"));
 		await act(() => result.current.reopenClosedTab("t2"));
 
 		expect(result.current.closedTabs).toHaveLength(1);

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -9,7 +9,6 @@ import type {
 	BrowserTabsState,
 } from "../../main/browser-view-host";
 import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
-import { MAX_BROWSER_TABS } from "../../shared/browser-tabs";
 import { OPEN_BROWSER_OVERLAY_SELECTOR } from "../lib/dom-selectors";
 
 export type { BrowserNavState };
@@ -658,19 +657,11 @@ export function useBrowserView({
 		async (tabId: string) => {
 			const entry = closedTabs.find((tab) => tab.id === tabId);
 			if (!entry) return;
-			// Gate on the same cap the "+" button already respects, instead of
-			// discovering BROWSER_TAB_LIMIT only after the entry is gone.
-			if (tabsStateRef.current.tabs.length >= MAX_BROWSER_TABS) {
-				showTabNotice("Reached the tab limit");
-				return;
-			}
 			updateClosedTabs((current) => current.filter((tab) => tab.id !== tabId));
 			try {
 				await openTab(entry.url);
 			} catch {
-				// Still possible to race the cap (e.g. the agent opens a tab between
-				// this row rendering and the click) — restore instead of losing the
-				// entry silently.
+				// Restore the entry instead of losing it when tab creation fails.
 				updateClosedTabs((current) => [entry, ...current.filter((tab) => tab.id !== tabId)].slice(0, MAX_CLOSED_TABS));
 				showTabNotice("Couldn't reopen that tab");
 			}

--- a/frontend/src/renderer/lib/browser-tab-order.ts
+++ b/frontend/src/renderer/lib/browser-tab-order.ts
@@ -1,0 +1,8 @@
+import { arrayMove } from "@dnd-kit/sortable";
+
+export function reorderBrowserTabs(ids: string[], activeId: string, overId: string): string[] | null {
+	const oldIndex = ids.indexOf(activeId);
+	const newIndex = ids.indexOf(overId);
+	if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return null;
+	return arrayMove(ids, oldIndex, newIndex);
+}

--- a/frontend/src/renderer/lib/terminal-tabs.ts
+++ b/frontend/src/renderer/lib/terminal-tabs.ts
@@ -4,7 +4,7 @@ import type { KeyboardEvent } from "react";
  * Implements the arrow/Home/End behavior expected of a horizontal tablist.
  * Selection follows focus so terminal tabs remain fast to switch by keyboard.
  */
-export function handleTerminalTabListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+export function handleTabListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
 	if (!(event.target instanceof HTMLElement) || event.target.getAttribute("role") !== "tab") return;
 	if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
 
@@ -22,3 +22,5 @@ export function handleTerminalTabListKeyDown(event: KeyboardEvent<HTMLDivElement
 	tabs[nextIndex]?.focus();
 	tabs[nextIndex]?.click();
 }
+
+export const handleTerminalTabListKeyDown = handleTabListKeyDown;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4006,6 +4006,7 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 }
 
 .browser-panel__tab {
+	position: relative;
 	display: flex;
 	width: 220px;
 	min-width: 52px;
@@ -4018,6 +4019,27 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	border-radius: 7px 7px 0 0;
 	color: var(--fg-muted);
 	background: transparent;
+}
+
+.browser-panel__tab:not(:last-child)::after {
+	position: absolute;
+	top: 8px;
+	right: -2px;
+	width: 1px;
+	height: 16px;
+	background: color-mix(in srgb, var(--color-border) 68%, transparent);
+	content: "";
+	opacity: 0.82;
+	transition: opacity 120ms ease-out;
+}
+
+.browser-panel__tab--active::after,
+.browser-panel__tab:has(+ .browser-panel__tab--active)::after,
+.browser-panel__tab:hover::after,
+.browser-panel__tab:has(+ .browser-panel__tab:hover)::after,
+.browser-panel__tab--dragging::after,
+.browser-panel__tab:has(+ .browser-panel__tab--dragging)::after {
+	opacity: 0;
 }
 
 .browser-panel__tab:hover {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -3973,6 +3973,119 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	backdrop-filter: blur(10px);
 }
 
+.browser-panel {
+	container-name: browser-panel;
+	container-type: inline-size;
+}
+
+.browser-panel__tab-strip {
+	display: none;
+	height: 38px;
+	min-width: 0;
+	align-items: end;
+	gap: 2px;
+	padding: 6px 8px 0;
+	overflow-x: auto;
+	overflow-y: hidden;
+	border-bottom: 1px solid color-mix(in srgb, var(--color-border) 72%, transparent);
+	background: color-mix(in srgb, var(--surface) 92%, var(--bg));
+	scrollbar-width: thin;
+}
+
+.browser-panel__tab {
+	display: flex;
+	min-width: 112px;
+	max-width: 220px;
+	height: 32px;
+	align-items: center;
+	flex: 1 1 180px;
+	border: 1px solid transparent;
+	border-bottom: 0;
+	border-radius: 7px 7px 0 0;
+	color: var(--fg-muted);
+	background: transparent;
+}
+
+.browser-panel__tab:hover {
+	color: var(--fg);
+	background: color-mix(in srgb, var(--surface-hover) 72%, transparent);
+}
+
+.browser-panel__tab--active {
+	color: var(--fg);
+	border-color: color-mix(in srgb, var(--color-border) 72%, transparent);
+	background: var(--surface);
+	box-shadow: inset 0 1px 0 color-mix(in srgb, white 7%, transparent);
+}
+
+.browser-panel__tab-select {
+	display: flex;
+	min-width: 0;
+	height: 100%;
+	align-items: center;
+	gap: 7px;
+	flex: 1;
+	padding: 0 4px 0 10px;
+	border: 0;
+	color: inherit;
+	background: transparent;
+	font-size: 12px;
+	text-align: left;
+}
+
+.browser-panel__tab-select:focus-visible,
+.browser-panel__tab-close:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: -2px;
+}
+
+.browser-panel__tab-icon {
+	width: 14px;
+	height: 14px;
+	flex: none;
+	color: var(--fg-passive);
+}
+
+.browser-panel__tab-title {
+	min-width: 0;
+	overflow: hidden;
+	font-weight: 550;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.browser-panel__tab-close {
+	display: grid;
+	width: 26px;
+	height: 26px;
+	place-items: center;
+	flex: none;
+	margin-right: 3px;
+	border: 0;
+	border-radius: 5px;
+	color: var(--fg-muted);
+	background: transparent;
+}
+
+.browser-panel__tab-close:not(:disabled):hover {
+	color: var(--fg);
+	background: var(--surface-hover);
+}
+
+.browser-panel__tab-close:disabled {
+	display: none;
+}
+
+@container browser-panel (min-width: 640px) {
+	.browser-panel__tab-strip {
+		display: flex;
+	}
+
+	.browser-panel__tabs-trigger {
+		display: none;
+	}
+}
+
 .browser-panel__url,
 .browser-panel__url-wrap {
 	display: flex;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -3990,22 +3990,29 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 
 .browser-panel__tab-strip {
 	display: flex;
+	width: fit-content;
+	max-width: calc(100% - 34px);
 	min-width: 0;
 	align-items: end;
 	gap: 2px;
-	flex: 1;
+	flex: 0 1 auto;
 	overflow-x: auto;
 	overflow-y: hidden;
-	scrollbar-width: thin;
+	scrollbar-width: none;
+}
+
+.browser-panel__tab-strip::-webkit-scrollbar {
+	display: none;
 }
 
 .browser-panel__tab {
 	display: flex;
-	min-width: 112px;
+	width: 220px;
+	min-width: 52px;
 	max-width: 220px;
 	height: 32px;
 	align-items: center;
-	flex: 1 1 180px;
+	flex: 1 1 220px;
 	border: 1px solid transparent;
 	border-bottom: 0;
 	border-radius: 7px 7px 0 0;
@@ -4081,6 +4088,14 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 
 .browser-panel__tab-close:disabled {
 	display: none;
+}
+
+.browser-panel__tab-strip:has(.browser-panel__tab:nth-child(8)) .browser-panel__tab-close {
+	display: none;
+}
+
+.browser-panel__tab-strip:has(.browser-panel__tab:nth-child(8)) .browser-panel__tab--active .browser-panel__tab-close {
+	display: grid;
 }
 
 .browser-panel__tab-new {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -3978,17 +3978,24 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	container-type: inline-size;
 }
 
-.browser-panel__tab-strip {
+.browser-panel__tab-bar {
 	display: none;
 	height: 38px;
 	min-width: 0;
 	align-items: end;
-	gap: 2px;
 	padding: 6px 8px 0;
-	overflow-x: auto;
-	overflow-y: hidden;
 	border-bottom: 1px solid color-mix(in srgb, var(--color-border) 72%, transparent);
 	background: color-mix(in srgb, var(--surface) 92%, var(--bg));
+}
+
+.browser-panel__tab-strip {
+	display: flex;
+	min-width: 0;
+	align-items: end;
+	gap: 2px;
+	flex: 1;
+	overflow-x: auto;
+	overflow-y: hidden;
 	scrollbar-width: thin;
 }
 
@@ -4076,12 +4083,37 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	display: none;
 }
 
+.browser-panel__tab-new {
+	display: grid;
+	width: 30px;
+	height: 30px;
+	place-items: center;
+	flex: none;
+	margin: 0 0 1px 4px;
+	border: 0;
+	border-radius: 7px;
+	color: var(--fg-muted);
+	background: transparent;
+}
+
+.browser-panel__tab-new:not(:disabled):hover {
+	color: var(--fg);
+	background: var(--surface-hover);
+}
+
+.browser-panel__tab-new:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: -2px;
+}
+
 @container browser-panel (min-width: 640px) {
-	.browser-panel__tab-strip {
+	.browser-panel__tab-bar {
 		display: flex;
 	}
 
-	.browser-panel__tabs-trigger {
+	.browser-panel__toolbar-new-tab,
+	.browser-panel__toolbar-tabs-trigger,
+	.browser-tabs-rail {
 		display: none;
 	}
 }

--- a/frontend/src/shared/browser-tabs.ts
+++ b/frontend/src/shared/browser-tabs.ts
@@ -1,1 +1,0 @@
-export const MAX_BROWSER_TABS = 16;


### PR DESCRIPTION
## What

Adds an AO-styled horizontal browser tab strip above the navigation toolbar when the Browser panel is at least 640px wide. Narrow panels retain the existing compact rail and flyout.

## Why

Maximized browser sessions currently dedicate a large right-side rail to tabs. A top strip matches familiar desktop-browser navigation and gives the page more horizontal room.

## How

- Uses a BrowserPanel container query rather than window-maximized state.
- Reuses existing select, close, and new-tab actions.
- Keeps the final-tab protection and narrow-layout rail behavior.
- Reuses AO surface, text, border, hover, focus, radius, and timing tokens.
- Adds roving Arrow, Home, and End keyboard navigation via the shared tablist handler.
- Intentionally leaves recently closed tabs in the existing narrow rail/flyout; the wide strip focuses on active tabs and the new-tab action.

## Testing

- npm test -- BrowserPanel.test.tsx (57 passed)
- npm test -- BrowserPanel.test.tsx CenterPane.test.tsx ShellTerminalsView.test.tsx (107 passed)
- npm run frontend:typecheck
- git diff --check
- Native visual verification is deferred until the existing AO dev instance from another worktree releases port 3002 and the shared dev Electron profile.

## Checklist

- [x] Branched from main
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant focused frontend checks pass