### PR TITLE
fix: restore turn changed-files Review and file open actions

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -169,6 +169,7 @@ vi.mock("./TerminalSwitchAgentButton", () => ({
 vi.mock("./chat/SessionChatSurface", () => ({
 	SessionChatSurface: ({
 		onOpenShell,
+		onOpenFile,
 		headerActions,
 		reviewerTerminal,
 		onOpenReviewerTerminal,
@@ -180,6 +181,7 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		workspaceTabs,
 	}: {
 		onOpenShell?: () => void;
+		onOpenFile?: (path: string) => void;
 		headerActions?: ReactNode;
 		reviewerTerminal?: { handleId: string; harness: string };
 		onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
@@ -194,6 +196,11 @@ vi.mock("./chat/SessionChatSurface", () => ({
 			chat surface
 			{headerActions}
 			<div role="tablist">{workspaceTabs}</div>
+			{onOpenFile ? (
+				<button type="button" onClick={() => onOpenFile("notes.txt")}>
+					open chat basename
+				</button>
+			) : null}
 			{reviewerTerminal ? (
 				<button type="button" onClick={() => onOpenReviewerTerminal?.(reviewerTerminal)}>
 					Reviewer
@@ -413,6 +420,9 @@ vi.mock("./SessionInspector", () => ({
 				<button type="button" onClick={() => onOpenReviewFile?.({ path: "src/panel.tsx", line: 42 })}>
 					view review file
 				</button>
+				<button type="button" onClick={() => onOpenReviewFile?.({ path: "notes.txt" })}>
+					view review basename
+				</button>
 				{view === "files" ? filesView : null}
 			</div>
 		);
@@ -512,7 +522,22 @@ describe("SessionView", () => {
 		interfaceTransitionMock.acknowledgeNotice.mockReset();
 		interfaceTransitionState.status = undefined;
 		reviewGetMock.mockReset();
-		reviewGetMock.mockResolvedValue({ data: { reviewerHandleId: "", reviews: [], runs: [] }, error: undefined });
+		reviewGetMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+				return {
+					data: {
+						sessionId: "sess-1",
+						files: [],
+						truncated: false,
+						sections: { staged: [], unstaged: [], untracked: [], committed: [] },
+						commits: [],
+						summary: { files: 0, additions: 0, deletions: 0 },
+					},
+					error: undefined,
+				};
+			}
+			return { data: { reviewerHandleId: "", reviews: [], runs: [] }, error: undefined };
+		});
 	});
 
 	// Regression: shell terminals are an app-wide list, so without a per-session
@@ -1467,16 +1492,93 @@ describe("SessionView", () => {
 		expect(screen.getByRole("tab", { name: "App.tsx" })).toHaveAttribute("aria-selected", "false");
 	});
 
-	it("opens a review file target in a center tab and keeps the Files inspector visible", () => {
+	it("opens a review file target in a center tab and keeps the Files inspector visible", async () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
 
-		expect(screen.getByRole("tab", { name: "panel.tsx" })).toHaveAttribute("aria-selected", "true");
-		expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("src/panel.tsx");
+		await waitFor(() => {
+			expect(screen.getByRole("tab", { name: "panel.tsx" })).toHaveAttribute("aria-selected", "true");
+			expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("src/panel.tsx");
+		});
 		expect(useUiStore.getState().inspectorSessions["sess-1"]?.view).toBe("files");
 		expect(screen.queryByRole("button", { name: "files center" })).not.toBeInTheDocument();
+	});
+
+	it("resolves a basename against workspace files before opening on a cold cache", async () => {
+		reviewGetMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+				return {
+					data: {
+						sessionId: "sess-1",
+						files: [
+							{
+								path: "docs/notes.txt",
+								status: "added",
+								additions: 1,
+								deletions: 0,
+								binary: false,
+								size: 10,
+							},
+						],
+						truncated: false,
+						sections: { staged: [], unstaged: [], untracked: [], committed: [] },
+						commits: [],
+						summary: { files: 1, additions: 1, deletions: 0 },
+					},
+					error: undefined,
+				};
+			}
+			return { data: { reviewerHandleId: "", reviews: [], runs: [] }, error: undefined };
+		});
+
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "view review basename" }));
+
+		await waitFor(() => {
+			expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("docs/notes.txt");
+		});
+	});
+
+	it("resolves a chat basename against workspace files before opening on a cold cache", async () => {
+		workspaces[0].sessions[0].mode = "chat";
+		reviewGetMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+				return {
+					data: {
+						sessionId: "sess-1",
+						files: [
+							{
+								path: "docs/notes.txt",
+								status: "added",
+								additions: 1,
+								deletions: 0,
+								binary: false,
+								size: 10,
+							},
+						],
+						truncated: false,
+						sections: { staged: [], unstaged: [], untracked: [], committed: [] },
+						commits: [],
+						summary: { files: 1, additions: 1, deletions: 0 },
+					},
+					error: undefined,
+				};
+			}
+			return { data: { reviewerHandleId: "", reviews: [], runs: [] }, error: undefined };
+		});
+
+		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "open chat basename" }));
+
+		await waitFor(() => {
+			expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("docs/notes.txt");
+		});
 	});
 
 	it("maximizes files over the whole app window and returns to the rail", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { PanelRight, Plus } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import {
@@ -52,6 +52,12 @@ import {
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
+import {
+	sessionWorkspaceFilesQueryKey,
+	sessionWorkspaceFilesQueryOptions,
+	type WorkspaceFilesResponse,
+} from "../hooks/useSessionWorkspaceFiles";
+import { matchWorkspaceFilePath } from "../lib/workspace-file-path";
 import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
 import {
 	activateSessionFile,
@@ -372,7 +378,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const setInspectorOpenForSession = useUiStore((state) => state.setInspectorOpen);
 	const toggleInspector = useUiStore((state) => state.toggleInspector);
 	const setInspectorViewForSession = useUiStore((state) => state.setInspectorView);
+	const setFilesChangedOnly = useUiStore((state) => state.setFilesChangedOnly);
 	const initializeInspectorSession = useUiStore((state) => state.initializeInspectorSession);
+	const queryClient = useQueryClient();
 	const setBrowserContentRevealed = useUiStore((state) => state.setBrowserContentRevealed);
 	const setBrowserUnseen = useUiStore((state) => state.setBrowserUnseen);
 	const setSidebarWorkspaceDemand = useUiStore((state) => state.setSidebarWorkspaceDemand);
@@ -894,27 +902,61 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		return () => clearVisibleTerminalKind(sessionId);
 	}, [clearVisibleTerminalKind, routedTerminalTarget.kind, sessionId, setVisibleTerminalKind]);
 
+	const resolveWorkspaceFilePath = useCallback(
+		(rawPath: string) => {
+			const files =
+				queryClient.getQueryData<WorkspaceFilesResponse>(sessionWorkspaceFilesQueryKey(sessionId))
+					?.files ?? [];
+			return matchWorkspaceFilePath(rawPath, files);
+		},
+		[queryClient, sessionId],
+	);
+
 	const handleOpenFiles = useCallback(() => {
 		setBrowserPopOutState({ sessionId, phase: "docked" });
 		setFilesPoppedOut(false);
+		setFilesChangedOnly(sessionId, true);
 		transitionInspectorView("files");
 		setInspectorOpenForSession(sessionId, true);
-	}, [sessionId, setInspectorOpenForSession, transitionInspectorView]);
+		void queryClient.prefetchQuery(
+			sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")),
+		);
+	}, [
+		queryClient,
+		sessionId,
+		setFilesChangedOnly,
+		setInspectorOpenForSession,
+		t,
+		transitionInspectorView,
+	]);
 
 	const handleOpenReviewFile = useCallback((target: { line?: number; path: string }) => {
 		setBrowserPopOutState({ sessionId, phase: "docked" });
 		setFilesPoppedOut(false);
+		setFilesChangedOnly(sessionId, true);
 		transitionInspectorView("files");
 		setInspectorOpenForSession(sessionId, true);
-		openCenterFile(target.path);
-	}, [openCenterFile, sessionId, setInspectorOpenForSession, transitionInspectorView]);
+		openCenterFile(resolveWorkspaceFilePath(target.path));
+		void queryClient.prefetchQuery(
+			sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")),
+		);
+	}, [
+		openCenterFile,
+		queryClient,
+		resolveWorkspaceFilePath,
+		sessionId,
+		setFilesChangedOnly,
+		setInspectorOpenForSession,
+		t,
+		transitionInspectorView,
+	]);
 
 	const handleOpenFile = useCallback(
 		(path: string) => {
 			handleOpenFiles();
-			openCenterFile(path);
+			openCenterFile(resolveWorkspaceFilePath(path));
 		},
-		[handleOpenFiles, openCenterFile],
+		[handleOpenFiles, openCenterFile, resolveWorkspaceFilePath],
 	);
 
 	const handleToggleFilesPopOut = useCallback(

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -52,11 +52,7 @@ import {
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
-import {
-	sessionWorkspaceFilesQueryKey,
-	sessionWorkspaceFilesQueryOptions,
-	type WorkspaceFilesResponse,
-} from "../hooks/useSessionWorkspaceFiles";
+import { sessionWorkspaceFilesQueryOptions } from "../hooks/useSessionWorkspaceFiles";
 import { matchWorkspaceFilePath } from "../lib/workspace-file-path";
 import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
 import {
@@ -902,61 +898,47 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		return () => clearVisibleTerminalKind(sessionId);
 	}, [clearVisibleTerminalKind, routedTerminalTarget.kind, sessionId, setVisibleTerminalKind]);
 
-	const resolveWorkspaceFilePath = useCallback(
-		(rawPath: string) => {
-			const files =
-				queryClient.getQueryData<WorkspaceFilesResponse>(sessionWorkspaceFilesQueryKey(sessionId))
-					?.files ?? [];
-			return matchWorkspaceFilePath(rawPath, files);
+	const prepareFilesInspector = useCallback(() => {
+		setBrowserPopOutState({ sessionId, phase: "docked" });
+		setFilesPoppedOut(false);
+		setFilesChangedOnly(sessionId, true);
+		transitionInspectorView("files");
+		setInspectorOpenForSession(sessionId, true);
+	}, [sessionId, setFilesChangedOnly, setInspectorOpenForSession, transitionInspectorView]);
+
+	const fetchWorkspaceFiles = useCallback(async () => {
+		return queryClient.fetchQuery(
+			sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")),
+		);
+	}, [queryClient, sessionId, t]);
+
+	const openResolvedWorkspaceFile = useCallback(
+		async (rawPath: string) => {
+			const data = await fetchWorkspaceFiles();
+			openCenterFile(matchWorkspaceFilePath(rawPath, data.files ?? []));
 		},
-		[queryClient, sessionId],
+		[fetchWorkspaceFiles, openCenterFile],
 	);
 
 	const handleOpenFiles = useCallback(() => {
-		setBrowserPopOutState({ sessionId, phase: "docked" });
-		setFilesPoppedOut(false);
-		setFilesChangedOnly(sessionId, true);
-		transitionInspectorView("files");
-		setInspectorOpenForSession(sessionId, true);
-		void queryClient.prefetchQuery(
-			sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")),
-		);
-	}, [
-		queryClient,
-		sessionId,
-		setFilesChangedOnly,
-		setInspectorOpenForSession,
-		t,
-		transitionInspectorView,
-	]);
+		prepareFilesInspector();
+		void fetchWorkspaceFiles();
+	}, [fetchWorkspaceFiles, prepareFilesInspector]);
 
-	const handleOpenReviewFile = useCallback((target: { line?: number; path: string }) => {
-		setBrowserPopOutState({ sessionId, phase: "docked" });
-		setFilesPoppedOut(false);
-		setFilesChangedOnly(sessionId, true);
-		transitionInspectorView("files");
-		setInspectorOpenForSession(sessionId, true);
-		openCenterFile(resolveWorkspaceFilePath(target.path));
-		void queryClient.prefetchQuery(
-			sessionWorkspaceFilesQueryOptions(sessionId, t("files.error.loadWorkspace")),
-		);
-	}, [
-		openCenterFile,
-		queryClient,
-		resolveWorkspaceFilePath,
-		sessionId,
-		setFilesChangedOnly,
-		setInspectorOpenForSession,
-		t,
-		transitionInspectorView,
-	]);
+	const handleOpenReviewFile = useCallback(
+		(target: { line?: number; path: string }) => {
+			prepareFilesInspector();
+			void openResolvedWorkspaceFile(target.path);
+		},
+		[openResolvedWorkspaceFile, prepareFilesInspector],
+	);
 
 	const handleOpenFile = useCallback(
 		(path: string) => {
-			handleOpenFiles();
-			openCenterFile(resolveWorkspaceFilePath(path));
+			prepareFilesInspector();
+			void openResolvedWorkspaceFile(path);
 		},
-		[handleOpenFiles, openCenterFile, resolveWorkspaceFilePath],
+		[openResolvedWorkspaceFile, prepareFilesInspector],
 	);
 
 	const handleToggleFilesPopOut = useCallback(

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -2222,20 +2222,19 @@ export function TurnChangedFiles({
 					const tooltipOldPath = file.oldPath
 						? resolveTurnFilePath(file.oldPath, pathHints)
 						: undefined;
+					const openPath = turnFileOpenPath(file.path, pathHints);
+					const location = fileLocationLabel(tooltipPath, tooltipOldPath);
 
 					const body = (
 						<>
 							<span className="sr-only">{status.label}</span>
 							<FileIcon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
-							{/* Same path tooltip as mid-turn Edited rows — not a native
-							    ellipsis title of the basename. */}
-							<FileLocationLabel
-								path={file.path}
-								oldPath={file.oldPath}
-								locationPath={tooltipPath}
-								locationOldPath={tooltipOldPath}
+							<span
 								className="min-w-0 flex-1 truncate text-[12px] text-foreground/80"
-							/>
+								title=""
+							>
+								{fileBasename(file.path)}
+							</span>
 							{file.additions > 0 ? (
 								<span className="shrink-0 font-mono text-[11px] tabular-nums text-success">
 									+{file.additions}
@@ -2257,16 +2256,53 @@ export function TurnChangedFiles({
 					return (
 						<li key={`${file.status}-${file.oldPath ?? ""}-${file.path}`}>
 							{onOpenFile ? (
-								<button
-									type="button"
-									onClick={() => onOpenFile(file.path)}
-									aria-label={`Open ${file.path} in Files`}
-									className={rowClass}
-								>
-									{body}
-								</button>
+								<TooltipProvider delayDuration={200}>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={() => onOpenFile(openPath)}
+												aria-label={`Open ${openPath} in Files`}
+												className={rowClass}
+											>
+												{body}
+											</button>
+										</TooltipTrigger>
+										<TooltipContent
+											side="top"
+											className="max-w-[min(28rem,90vw)] border-border bg-popover px-2.5 py-1.5 font-mono text-[11px] font-normal text-muted-foreground shadow-none"
+										>
+											{location}
+										</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
 							) : (
-								<div className={rowClass}>{body}</div>
+								<div className={rowClass}>
+									<span className="sr-only">{status.label}</span>
+									<FileIcon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+									<FileLocationLabel
+										path={file.path}
+										oldPath={file.oldPath}
+										locationPath={tooltipPath}
+										locationOldPath={tooltipOldPath}
+										className="min-w-0 flex-1 truncate text-[12px] text-foreground/80"
+									/>
+									{file.additions > 0 ? (
+										<span className="shrink-0 font-mono text-[11px] tabular-nums text-success">
+											+{file.additions}
+										</span>
+									) : null}
+									{file.deletions > 0 ? (
+										<span className="shrink-0 font-mono text-[11px] tabular-nums text-destructive">
+											&minus;{file.deletions}
+										</span>
+									) : null}
+									{file.additions === 0 && file.deletions === 0 ? (
+										<span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground/50">
+											0
+										</span>
+									) : null}
+								</div>
 							)}
 						</li>
 					);
@@ -2394,6 +2430,15 @@ function resolveTurnFilePath(path: string, hints: TurnPathHints): string {
 		return `${hints.cwd.replace(/\/$/, "")}/${rel}`;
 	}
 	return path;
+}
+
+/** Workspace-relative path to open in the Files panel from a turn diff row. */
+function turnFileOpenPath(path: string, hints: TurnPathHints): string {
+	const normalized = path.replace(/^\.\//, "");
+	if (!looksAbsolutePath(normalized)) return normalized;
+	const resolved = resolveTurnFilePath(path, hints);
+	if (!looksAbsolutePath(resolved)) return resolved.replace(/^\.\//, "");
+	return fileBasename(resolved);
 }
 
 /** Basename only — the row is too narrow for a full path; the tooltip carries that. */

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -85,6 +85,7 @@ import {
 	type ConversationItem,
 	type TurnDiff,
 } from "../../types/conversation";
+import { resolveTurnFilePath, turnFileOpenPath, turnPathHints } from "../../lib/turn-file-open-path";
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
 	hour: "2-digit",
@@ -2379,66 +2380,6 @@ function FileLocationLabel({
 
 function fileLocationLabel(path: string, oldPath?: string): string {
 	return oldPath ? `${shortenPaths(oldPath)} → ${shortenPaths(path)}` : shortenPaths(path);
-}
-
-/**
- * Absolute paths and a worktree cwd gathered from the same turn's activities, so a
- * turn-diff basename can be shown like the Edited tooltip.
- */
-type TurnPathHints = {
-	byBase: Map<string, string | undefined>;
-	cwd?: string;
-};
-
-function rememberTurnPathHint(byBase: Map<string, string | undefined>, absolutePath: string) {
-	const base = fileBasename(absolutePath);
-	if (!byBase.has(base)) {
-		byBase.set(base, absolutePath);
-		return;
-	}
-	if (byBase.get(base) !== absolutePath) byBase.set(base, undefined);
-}
-
-function turnPathHints(items: ConversationItem[] | undefined): TurnPathHints {
-	const byBase = new Map<string, string | undefined>();
-	let cwd: string | undefined;
-	if (!items?.length) return { byBase, cwd };
-
-	for (const item of items) {
-		if (item.kind !== "activity") continue;
-		if (!cwd && item.detail?.cwd) cwd = item.detail.cwd;
-		if (item.activityKind !== "file_change") continue;
-		for (const file of fileChangeFiles(item)) {
-			if (looksAbsolutePath(file.path)) rememberTurnPathHint(byBase, file.path);
-			if (file.oldPath && looksAbsolutePath(file.oldPath)) rememberTurnPathHint(byBase, file.oldPath);
-		}
-	}
-	return { byBase, cwd };
-}
-
-function looksAbsolutePath(path: string): boolean {
-	return path.startsWith("/") || path.startsWith("~") || /^[A-Za-z]:[\\/]/.test(path);
-}
-
-/** Prefer an absolute path from the turn; otherwise join the worktree cwd. */
-function resolveTurnFilePath(path: string, hints: TurnPathHints): string {
-	if (looksAbsolutePath(path)) return path;
-	const fromBasename = hints.byBase.get(fileBasename(path));
-	if (fromBasename) return fromBasename;
-	if (hints.cwd) {
-		const rel = path.replace(/^\.\//, "");
-		return `${hints.cwd.replace(/\/$/, "")}/${rel}`;
-	}
-	return path;
-}
-
-/** Workspace-relative path to open in the Files panel from a turn diff row. */
-function turnFileOpenPath(path: string, hints: TurnPathHints): string {
-	const normalized = path.replace(/^\.\//, "");
-	if (!looksAbsolutePath(normalized)) return normalized;
-	const resolved = resolveTurnFilePath(path, hints);
-	if (!looksAbsolutePath(resolved)) return resolved.replace(/^\.\//, "");
-	return fileBasename(resolved);
 }
 
 /** Basename only — the row is too narrow for a full path; the tooltip carries that. */

--- a/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
@@ -61,6 +61,33 @@ describe("TurnChangedFiles", () => {
 		expect(onOpenFile).toHaveBeenCalledWith("src/a.ts");
 	});
 
+	it("opens a cwd-relative path from a turn diff basename", async () => {
+		const onOpenFile = vi.fn();
+		render(
+			<TurnChangedFiles
+				diff={{
+					files: [{ path: "notes.txt", additions: 1, deletions: 0, status: "added" }],
+				}}
+				items={[
+					{
+						kind: "activity",
+						id: "a-1",
+						sequence: 1,
+						revision: 0,
+						activityKind: "command",
+						status: "completed",
+						summary: "Ran command",
+						detail: { cwd: "/Users/me/.ao/dev/data/worktrees/demo/demo-1", command: "ls" },
+						createdAt: new Date().toISOString(),
+					},
+				]}
+				onOpenFile={onOpenFile}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: /Open notes\.txt in Files/ }));
+		expect(onOpenFile).toHaveBeenCalledWith("notes.txt");
+	});
+
 	it("shows the full path on basename hover", async () => {
 		const user = userEvent.setup();
 		render(<TurnChangedFiles diff={diff()} />);

--- a/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
@@ -88,6 +88,39 @@ describe("TurnChangedFiles", () => {
 		expect(onOpenFile).toHaveBeenCalledWith("notes.txt");
 	});
 
+	it("preserves duplicate-disambiguating suffixes for absolute turn diff paths", async () => {
+		const cwd = "/Users/me/.ao/dev/data/worktrees/demo/demo-1";
+		const onOpenFile = vi.fn();
+		render(
+			<TurnChangedFiles
+				diff={{
+					files: [
+						{ path: `${cwd}/frontend/index.ts`, additions: 1, deletions: 0, status: "modified" },
+						{ path: `${cwd}/backend/index.ts`, additions: 2, deletions: 0, status: "modified" },
+					],
+				}}
+				items={[
+					{
+						kind: "activity",
+						id: "a-1",
+						sequence: 1,
+						revision: 0,
+						activityKind: "command",
+						status: "completed",
+						summary: "Ran command",
+						detail: { cwd, command: "ls" },
+						createdAt: new Date().toISOString(),
+					},
+				]}
+				onOpenFile={onOpenFile}
+			/>,
+		);
+		await userEvent.click(screen.getByRole("button", { name: /Open frontend\/index\.ts in Files/ }));
+		expect(onOpenFile).toHaveBeenCalledWith("frontend/index.ts");
+		await userEvent.click(screen.getByRole("button", { name: /Open backend\/index\.ts in Files/ }));
+		expect(onOpenFile).toHaveBeenCalledWith("backend/index.ts");
+	});
+
 	it("shows the full path on basename hover", async () => {
 		const user = userEvent.setup();
 		render(<TurnChangedFiles diff={diff()} />);

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -367,9 +367,12 @@ function UpdateActions({
 			}).format(effectiveStatus.checkedAt)
 			: null;
 	const channelSwitchInFlight = channelSwitch !== null && (!status.requestId || status.requestId === channelSwitch.requestId);
+	// Use the live updater state, not displayStatus: the manual-check minimum
+	// spinner time forces displayStatus back to "checking" even after a channel
+	// switch finds an update, which would hide this guidance until the timer fires.
 	const channelSwitchMessage = channelSwitchInFlight &&
-		(displayStatus.state === "available" || displayStatus.state === "downloading" || displayStatus.state === "downloaded")
-		? t(displayStatus.state === "downloaded" ? "settings.updates.channelSwitchRestart" : "settings.updates.channelSwitchUpdate", {
+		(effectiveStatus.state === "available" || effectiveStatus.state === "downloading" || effectiveStatus.state === "downloaded")
+		? t(effectiveStatus.state === "downloaded" ? "settings.updates.channelSwitchRestart" : "settings.updates.channelSwitchUpdate", {
 			channel: channelSwitch.channel === "nightly" ? t("settings.updates.channel.nightly") : t("settings.updates.channel.stable"),
 		})
 		: null;

--- a/frontend/src/renderer/lib/turn-file-open-path.test.ts
+++ b/frontend/src/renderer/lib/turn-file-open-path.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { turnFileOpenPath, turnPathHints, workspaceRelativeOpenPath } from "./turn-file-open-path";
+
+const cwd = "/Users/me/.ao/dev/data/worktrees/demo/demo-1";
+
+describe("workspaceRelativeOpenPath", () => {
+	it("strips the worktree cwd and keeps nested path segments", () => {
+		expect(workspaceRelativeOpenPath(`${cwd}/frontend/index.ts`, cwd)).toBe("frontend/index.ts");
+		expect(workspaceRelativeOpenPath(`${cwd}/backend/index.ts`, cwd)).toBe("backend/index.ts");
+	});
+
+	it("keeps parent segments when cwd is missing", () => {
+		expect(
+			workspaceRelativeOpenPath("/Users/me/.ao/dev/data/worktrees/demo/demo-1/frontend/index.ts"),
+		).toBe("frontend/index.ts");
+	});
+});
+
+describe("turnFileOpenPath", () => {
+	it("passes through an already workspace-relative path", () => {
+		expect(turnFileOpenPath("src/a.ts", { byBase: new Map() })).toBe("src/a.ts");
+	});
+
+	it("preserves duplicate-disambiguating suffixes for relative paths", () => {
+		const hints = { byBase: new Map(), cwd };
+		expect(turnFileOpenPath("frontend/index.ts", hints)).toBe("frontend/index.ts");
+		expect(turnFileOpenPath("backend/index.ts", hints)).toBe("backend/index.ts");
+	});
+
+	it("converts an absolute turn diff path using the worktree cwd", () => {
+		const hints = { byBase: new Map(), cwd };
+		expect(turnFileOpenPath(`${cwd}/frontend/index.ts`, hints)).toBe("frontend/index.ts");
+		expect(turnFileOpenPath(`${cwd}/backend/index.ts`, hints)).toBe("backend/index.ts");
+	});
+
+	it("resolves a basename hint from the turn's file_change activity", () => {
+		const hints = turnPathHints([
+			{
+				kind: "activity",
+				id: "a-1",
+				sequence: 1,
+				revision: 0,
+				activityKind: "file_change",
+				status: "completed",
+				summary: "Edited 1 file",
+				detail: {
+					files: [
+						{
+							path: `${cwd}/docs/notes.txt`,
+							status: "added",
+							additions: 1,
+							deletions: 0,
+						},
+					],
+				},
+				createdAt: new Date().toISOString(),
+			},
+		]);
+		expect(turnFileOpenPath("notes.txt", hints)).toBe("docs/notes.txt");
+	});
+});

--- a/frontend/src/renderer/lib/turn-file-open-path.ts
+++ b/frontend/src/renderer/lib/turn-file-open-path.ts
@@ -1,0 +1,89 @@
+import { fileChangeFiles, type ConversationItem } from "../types/conversation";
+
+/**
+ * Absolute paths and a worktree cwd gathered from the same turn's activities, so a
+ * turn-diff basename can be shown like the Edited tooltip.
+ */
+export type TurnPathHints = {
+	byBase: Map<string, string | undefined>;
+	cwd?: string;
+};
+
+function fileBasename(path: string): string {
+	const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+	return slash >= 0 ? path.slice(slash + 1) : path;
+}
+
+export function looksAbsolutePath(path: string): boolean {
+	return path.startsWith("/") || path.startsWith("~") || /^[A-Za-z]:[\\/]/.test(path);
+}
+
+function rememberTurnPathHint(byBase: Map<string, string | undefined>, absolutePath: string) {
+	const base = fileBasename(absolutePath);
+	if (!byBase.has(base)) {
+		byBase.set(base, absolutePath);
+		return;
+	}
+	if (byBase.get(base) !== absolutePath) byBase.set(base, undefined);
+}
+
+export function turnPathHints(items: ConversationItem[] | undefined): TurnPathHints {
+	const byBase = new Map<string, string | undefined>();
+	let cwd: string | undefined;
+	if (!items?.length) return { byBase, cwd };
+
+	for (const item of items) {
+		if (item.kind !== "activity") continue;
+		if (!cwd && item.detail?.cwd) cwd = item.detail.cwd;
+		if (item.activityKind !== "file_change") continue;
+		for (const file of fileChangeFiles(item)) {
+			if (looksAbsolutePath(file.path)) rememberTurnPathHint(byBase, file.path);
+			if (file.oldPath && looksAbsolutePath(file.oldPath)) rememberTurnPathHint(byBase, file.oldPath);
+		}
+	}
+	return { byBase, cwd };
+}
+
+/** Prefer an absolute path from the turn; otherwise join the worktree cwd. */
+export function resolveTurnFilePath(path: string, hints: TurnPathHints): string {
+	if (looksAbsolutePath(path)) return path;
+	const fromBasename = hints.byBase.get(fileBasename(path));
+	if (fromBasename) return fromBasename;
+	if (hints.cwd) {
+		const rel = path.replace(/^\.\//, "");
+		return `${hints.cwd.replace(/\/$/, "")}/${rel}`;
+	}
+	return path;
+}
+
+/** Strip a worktree root and keep enough suffix to disambiguate duplicate basenames. */
+export function workspaceRelativeOpenPath(absolutePath: string, cwd?: string): string {
+	const normalized = absolutePath.replace(/\\/g, "/");
+	if (cwd) {
+		const root = cwd.replace(/\\/g, "/").replace(/\/$/, "");
+		if (normalized === root) return fileBasename(normalized);
+		if (normalized.startsWith(`${root}/`)) {
+			return normalized.slice(root.length + 1);
+		}
+	}
+	const segments = normalized.split("/").filter(Boolean);
+	if (segments.length >= 2) {
+		return segments.slice(-2).join("/");
+	}
+	return fileBasename(normalized);
+}
+
+/** Workspace-relative path to open in the Files panel from a turn diff row. */
+export function turnFileOpenPath(path: string, hints: TurnPathHints): string {
+	const normalized = path.replace(/^\.\//, "");
+	if (!looksAbsolutePath(normalized)) {
+		const fromBasename = hints.byBase.get(fileBasename(normalized));
+		if (fromBasename && looksAbsolutePath(fromBasename)) {
+			return workspaceRelativeOpenPath(fromBasename, hints.cwd);
+		}
+		return normalized;
+	}
+	const resolved = resolveTurnFilePath(path, hints);
+	if (!looksAbsolutePath(resolved)) return resolved.replace(/^\.\//, "");
+	return workspaceRelativeOpenPath(resolved, hints.cwd);
+}

--- a/frontend/src/renderer/lib/workspace-file-path.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-path.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { matchWorkspaceFilePath } from "./workspace-file-path";
+
+describe("matchWorkspaceFilePath", () => {
+	const files = [
+		{ path: "src/a.ts", status: "modified" as const, additions: 1, deletions: 0, binary: false, size: 12 },
+		{ path: "docs/report.md", status: "added" as const, additions: 10, deletions: 0, binary: false, size: 40 },
+	];
+
+	it("matches an exact workspace path", () => {
+		expect(matchWorkspaceFilePath("src/a.ts", files)).toBe("src/a.ts");
+	});
+
+	it("matches a basename from a turn diff", () => {
+		expect(matchWorkspaceFilePath("report.md", files)).toBe("docs/report.md");
+	});
+
+	it("matches a suffix path", () => {
+		expect(matchWorkspaceFilePath("a.ts", files)).toBe("src/a.ts");
+	});
+
+	it("normalizes leading ./", () => {
+		expect(matchWorkspaceFilePath("./src/a.ts", files)).toBe("src/a.ts");
+	});
+
+	it("falls back to the normalized request when nothing matches", () => {
+		expect(matchWorkspaceFilePath("missing.txt", files)).toBe("missing.txt");
+	});
+});

--- a/frontend/src/renderer/lib/workspace-file-path.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-path.test.ts
@@ -26,4 +26,14 @@ describe("matchWorkspaceFilePath", () => {
 	it("falls back to the normalized request when nothing matches", () => {
 		expect(matchWorkspaceFilePath("missing.txt", files)).toBe("missing.txt");
 	});
+
+	it("disambiguates duplicate basenames with a path suffix", () => {
+		const duplicateFiles = [
+			...files,
+			{ path: "frontend/index.ts", status: "modified" as const, additions: 1, deletions: 0, binary: false, size: 12 },
+			{ path: "backend/index.ts", status: "modified" as const, additions: 1, deletions: 0, binary: false, size: 12 },
+		];
+		expect(matchWorkspaceFilePath("frontend/index.ts", duplicateFiles)).toBe("frontend/index.ts");
+		expect(matchWorkspaceFilePath("backend/index.ts", duplicateFiles)).toBe("backend/index.ts");
+	});
 });

--- a/frontend/src/renderer/lib/workspace-file-path.ts
+++ b/frontend/src/renderer/lib/workspace-file-path.ts
@@ -1,0 +1,39 @@
+import type { WorkspaceFileSummary } from "../hooks/useSessionWorkspaceFiles";
+
+function normalizeWorkspacePath(path: string): string {
+	return path.trim().replace(/^\.\//, "").replace(/\\/g, "/");
+}
+
+function fileBasename(path: string): string {
+	const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+	return slash >= 0 ? path.slice(slash + 1) : path;
+}
+
+/**
+ * Map a chat/turn path onto the workspace-relative path the Files API expects.
+ * Turn diffs often carry basenames or absolute worktree paths; the workspace
+ * file list carries repo-relative paths.
+ */
+export function matchWorkspaceFilePath(
+	rawPath: string,
+	files: readonly WorkspaceFileSummary[],
+): string {
+	const normalized = normalizeWorkspacePath(rawPath);
+	if (!normalized) return rawPath;
+
+	const exact =
+		files.find((file) => file.path === rawPath) ??
+		files.find((file) => file.path === normalized);
+	if (exact) return exact.path;
+
+	const suffix = files.find(
+		(file) => file.path.endsWith(`/${normalized}`) || file.path.endsWith(`/${rawPath}`),
+	);
+	if (suffix) return suffix.path;
+
+	const base = fileBasename(normalized);
+	const byBase = files.filter((file) => fileBasename(file.path) === base);
+	if (byBase.length === 1) return byBase[0]!.path;
+
+	return normalized;
+}


### PR DESCRIPTION
## Summary
- Fix the turn-end "Files Changed" card so **Review** opens the Files inspector in changed-only mode (the diff review view), not an empty full-tree explorer.
- Fix file row clicks so they resolve turn-diff paths (basenames, relative paths) to workspace paths and open the file in a center tab.
- Move the path tooltip onto the file row button so nested tooltip triggers no longer swallow clicks.

## Context
After the file-explorer refactor (#4252), `handleOpenFiles` no longer enabled `filesChangedOnly`, so Review appeared to do nothing. File opens also passed raw turn-diff paths without the basename matching the old `focusPath` logic used.

## Test plan
- [ ] In a chat session with a turn that changed files, click **Review** → Files inspector opens on the changed-files diff list.
- [ ] Click an individual file in the turn card → file opens in a center tab with the correct diff.
- [ ] Hover a file row → path tooltip still shows the full worktree path.
- [ ] `cd frontend && npx vitest run src/renderer/lib/workspace-file-path.test.ts src/renderer/components/chat/TurnChangedFiles.test.tsx`
- [ ] `cd frontend && npm run typecheck`