### PR TITLE
feat: add reviewer harness model picker

### DIFF
--- a/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
+++ b/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
@@ -28,7 +28,7 @@ func Command(ctx context.Context, agent ports.Agent, inv ports.ReviewInvocation,
 		metadata[ports.MetadataKeyAgentSessionID] = agentSessionID
 	}
 	argv, ok, err := agent.GetRestoreCommand(ctx, ports.RestoreConfig{
-		Config:           inv.Config,
+		Config: inv.Config,
 		Session: ports.SessionRef{
 			ID:            inv.ReviewerID,
 			WorkspacePath: inv.WorkspacePath,

--- a/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
+++ b/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
@@ -28,6 +28,7 @@ func Command(ctx context.Context, agent ports.Agent, inv ports.ReviewInvocation,
 		metadata[ports.MetadataKeyAgentSessionID] = agentSessionID
 	}
 	argv, ok, err := agent.GetRestoreCommand(ctx, ports.RestoreConfig{
+		Config:           inv.Config,
 		Session: ports.SessionRef{
 			ID:            inv.ReviewerID,
 			WorkspacePath: inv.WorkspacePath,

--- a/backend/internal/adapters/reviewer/claudecode/claudecode.go
+++ b/backend/internal/adapters/reviewer/claudecode/claudecode.go
@@ -75,6 +75,7 @@ var reviewerDisallowedTools = []string{
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	agentSessionID := workeragent.SessionUUID(inv.ReviewerID)
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config: inv.Config,
 		// Pin the same deterministic reviewer-native id we persist. Hooks can
 		// later replace it with Claude's reported id, but restore must never start
 		// from an id that the process was not launched with.
@@ -114,6 +115,7 @@ func (r *Reviewer) PreLaunch(ctx context.Context, inv ports.ReviewInvocation) er
 		return nil
 	}
 	return pl.PreLaunch(ctx, ports.LaunchConfig{
+		Config:        inv.Config,
 		SessionID:     workeragent.SessionUUID(inv.ReviewerID),
 		WorkspacePath: inv.WorkspacePath,
 	})

--- a/backend/internal/adapters/reviewer/codex/codex.go
+++ b/backend/internal/adapters/reviewer/codex/codex.go
@@ -37,6 +37,7 @@ var _ ports.ReviewerRestorer = (*Reviewer)(nil)
 // network access for posting the review and reporting its result.
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config:           inv.Config,
 		SessionID:        inv.ReviewerID,
 		WorkspacePath:    inv.WorkspacePath,
 		Prompt:           inv.Prompt,

--- a/backend/internal/adapters/reviewer/copilot/copilot.go
+++ b/backend/internal/adapters/reviewer/copilot/copilot.go
@@ -75,6 +75,7 @@ func (r *Reviewer) PreLaunch(ctx context.Context, inv ports.ReviewInvocation) er
 // adapter maps auto to --allow-all-tools, which would defeat this policy.
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config:           inv.Config,
 		DataDir:          inv.DataDir,
 		SessionID:        inv.ReviewerID,
 		WorkspacePath:    inv.WorkspacePath,

--- a/backend/internal/adapters/reviewer/copilot/copilot_test.go
+++ b/backend/internal/adapters/reviewer/copilot/copilot_test.go
@@ -95,6 +95,7 @@ func TestReviewCommandUsesRestrictedPersistentPolicy(t *testing.T) {
 		ReviewerID:       "review-w1",
 		WorkspacePath:    "/ws/w1",
 		Prompt:           "Read the hidden task.",
+		Config:           ports.AgentConfig{Model: "gpt-5"},
 		SystemPromptFile: filepath.Join(promptRoot, "system.md"),
 		TaskPromptRoot:   promptRoot,
 	})
@@ -104,6 +105,9 @@ func TestReviewCommandUsesRestrictedPersistentPolicy(t *testing.T) {
 
 	if agent.launchConfig.Permissions != ports.PermissionModeDefault {
 		t.Fatalf("permissions = %q, want default", agent.launchConfig.Permissions)
+	}
+	if agent.launchConfig.Config.Model != "gpt-5" {
+		t.Fatalf("launch config model = %q, want gpt-5", agent.launchConfig.Config.Model)
 	}
 	if agent.launchConfig.Prompt != "Read the hidden task." ||
 		agent.launchConfig.SystemPrompt != "" ||

--- a/backend/internal/adapters/reviewer/cursor/cursor.go
+++ b/backend/internal/adapters/reviewer/cursor/cursor.go
@@ -55,6 +55,7 @@ func (r *Reviewer) PreLaunch(ctx context.Context, inv ports.ReviewInvocation) er
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	prompt := cursorPrompt(inv)
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config:        inv.Config,
 		SessionID:     inv.ReviewerID,
 		WorkspacePath: inv.WorkspacePath,
 		Prompt:        prompt,

--- a/backend/internal/adapters/reviewer/cursor/cursor_test.go
+++ b/backend/internal/adapters/reviewer/cursor/cursor_test.go
@@ -57,6 +57,7 @@ func TestReviewCommandBuildsPersistentInteractiveInvocation(t *testing.T) {
 		DataDir:          dataDir,
 		Prompt:           "complete the AO review task in `/ao/prompts/reviewer/requests/batch-1/run-1/task.md`.",
 		SystemPrompt:     "secret system content must not enter argv",
+		Config:           ports.AgentConfig{Model: "gpt-5"},
 		SystemPromptFile: "/ao/prompts/reviewer/system.md",
 		TaskPromptFile:   "/ao/prompts/reviewer/requests/batch-1/run-1/task.md",
 		TaskPromptRoot:   "/ao/prompts/reviewer",
@@ -76,6 +77,9 @@ func TestReviewCommandBuildsPersistentInteractiveInvocation(t *testing.T) {
 	}
 	if agent.got.Permissions != ports.PermissionModeDefault {
 		t.Fatalf("permissions = %q, want default", agent.got.Permissions)
+	}
+	if agent.got.Config.Model != "gpt-5" {
+		t.Fatalf("launch config model = %q, want gpt-5", agent.got.Config.Model)
 	}
 	if agent.got.WorkspacePath != "/ws/w1" || agent.got.SessionID != "review-w1" {
 		t.Fatalf("launch config = %+v", agent.got)

--- a/backend/internal/adapters/reviewer/kilocode/kilocode.go
+++ b/backend/internal/adapters/reviewer/kilocode/kilocode.go
@@ -40,6 +40,7 @@ var _ ports.ReviewerCanceller = (*Reviewer)(nil)
 // AO reuses reviewer panes and injects later review tasks into them.
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config:           inv.Config,
 		SessionID:        inv.ReviewerID,
 		WorkspacePath:    inv.WorkspacePath,
 		Prompt:           inv.Prompt,

--- a/backend/internal/adapters/reviewer/kilocode/kilocode_test.go
+++ b/backend/internal/adapters/reviewer/kilocode/kilocode_test.go
@@ -54,6 +54,7 @@ func TestReviewCommandPreservesAgentAndAppliesReadOnlyPolicy(t *testing.T) {
 		WorkspacePath:  "/ws/w1",
 		Prompt:         "review it",
 		SystemPrompt:   "review only",
+		Config:         ports.AgentConfig{Model: "gpt-5"},
 		TaskPromptRoot: filepath.Join("ao", "prompts", "reviewer"),
 	})
 	if err != nil {
@@ -62,6 +63,9 @@ func TestReviewCommandPreservesAgentAndAppliesReadOnlyPolicy(t *testing.T) {
 
 	if agent.got.Permissions != ports.PermissionModeDefault {
 		t.Fatalf("permissions = %q, want default before reviewer policy overlay", agent.got.Permissions)
+	}
+	if agent.got.Config.Model != "gpt-5" {
+		t.Fatalf("launch config model = %q, want gpt-5", agent.got.Config.Model)
 	}
 	if agent.got.WorkspacePath != "/ws/w1" || agent.got.Prompt != "review it" || agent.got.SystemPrompt != "review only" {
 		t.Fatalf("launch config = %+v", agent.got)

--- a/backend/internal/adapters/reviewer/kimchi/kimchi.go
+++ b/backend/internal/adapters/reviewer/kimchi/kimchi.go
@@ -102,6 +102,7 @@ var _ ports.ReviewerRestorer = (*Reviewer)(nil)
 // common mutation paths, but does not make the process read-only or isolated.
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config:           inv.Config,
 		SessionID:        inv.ReviewerID,
 		WorkspacePath:    inv.WorkspacePath,
 		Prompt:           inv.Prompt,

--- a/backend/internal/adapters/reviewer/kimchi/kimchi_test.go
+++ b/backend/internal/adapters/reviewer/kimchi/kimchi_test.go
@@ -50,6 +50,7 @@ func TestReviewCommandAppliesBestEffortPolicyOffBypass(t *testing.T) {
 		ReviewerID:    "review-w1",
 		WorkspacePath: "/ws/w1",
 		Prompt:        "review it",
+		Config:        ports.AgentConfig{Model: "sonnet-5"},
 		SystemPrompt:  "you are a reviewer",
 	}); err != nil {
 		t.Fatalf("ReviewCommand: %v", err)
@@ -59,6 +60,9 @@ func TestReviewCommandAppliesBestEffortPolicyOffBypass(t *testing.T) {
 	// allow/deny rules, and an empty mode would defer to Kimchi's default.
 	if agent.got.Permissions != ports.PermissionModeAuto {
 		t.Fatalf("reviewer must launch in auto permission mode; got %q", agent.got.Permissions)
+	}
+	if agent.got.Config.Model != "sonnet-5" {
+		t.Fatalf("launch config model = %q, want sonnet-5", agent.got.Config.Model)
 	}
 	if !contains(agent.got.AllowedTools, "read") || !contains(agent.got.AllowedTools, "bash(ao review submit:*)") {
 		t.Fatalf("allowlist missing read-only review tools: %#v", agent.got.AllowedTools)

--- a/backend/internal/adapters/reviewer/muse/muse.go
+++ b/backend/internal/adapters/reviewer/muse/muse.go
@@ -35,6 +35,7 @@ var _ ports.ReviewerRestorer = (*Reviewer)(nil)
 // prevents non-shell workspace file writes.
 func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, error) {
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config:           inv.Config,
 		SessionID:        inv.ReviewerID,
 		WorkspacePath:    inv.WorkspacePath,
 		Prompt:           inv.Prompt,

--- a/backend/internal/adapters/reviewer/muse/muse_test.go
+++ b/backend/internal/adapters/reviewer/muse/muse_test.go
@@ -51,6 +51,7 @@ func TestReviewCommandUsesMuseNoWriteSandbox(t *testing.T) {
 		ReviewerID:       "review-w1",
 		WorkspacePath:    "/ws/w1",
 		Prompt:           "Read the AO review task.",
+		Config:           ports.AgentConfig{Mode: "plan"},
 		SystemPromptFile: "/ao/prompts/reviewer/system.md",
 		DataDir:          "/ao/data",
 	})
@@ -66,6 +67,9 @@ func TestReviewCommandUsesMuseNoWriteSandbox(t *testing.T) {
 	}
 	if agent.got.Permissions != ports.PermissionModeAuto {
 		t.Fatalf("permissions = %q, want auto", agent.got.Permissions)
+	}
+	if agent.got.Config.Mode != "plan" {
+		t.Fatalf("launch config mode = %q, want plan", agent.got.Config.Mode)
 	}
 	if agent.got.SystemPromptFile != "/ao/prompts/reviewer/system.md" {
 		t.Fatalf("system prompt file = %q", agent.got.SystemPromptFile)

--- a/backend/internal/adapters/reviewer/opencode/opencode.go
+++ b/backend/internal/adapters/reviewer/opencode/opencode.go
@@ -44,6 +44,7 @@ func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation
 		prompt = strings.TrimSpace(inv.SystemPrompt + "\n\n" + inv.Prompt)
 	}
 	argv, err := r.agent.GetLaunchCommand(ctx, ports.LaunchConfig{
+		Config:           inv.Config,
 		SessionID:        inv.ReviewerID,
 		WorkspacePath:    inv.WorkspacePath,
 		Prompt:           prompt,

--- a/backend/internal/domain/projectconfig.go
+++ b/backend/internal/domain/projectconfig.go
@@ -84,7 +84,8 @@ type ContainerReapConfig struct {
 // the reviewer vocabulary (ReviewerHarness), which is distinct from the worker
 // AgentHarness set.
 type ReviewerConfig struct {
-	Harness ReviewerHarness `json:"harness"`
+	Harness     ReviewerHarness `json:"harness"`
+	AgentConfig AgentConfig     `json:"agentConfig,omitempty"`
 }
 
 // FallbackReviewerHarness is the reviewer used when a project configures none
@@ -194,6 +195,9 @@ func (c ProjectConfig) Validate() error {
 	for i, rv := range c.Reviewers {
 		if !rv.Harness.IsKnown() {
 			return fmt.Errorf("reviewers[%d].harness: unknown harness %q", i, rv.Harness)
+		}
+		if err := rv.AgentConfig.Validate(); err != nil {
+			return fmt.Errorf("reviewers[%d].%w", i, err)
 		}
 	}
 	if err := c.TrackerIntake.Validate(); err != nil {

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -97,6 +97,7 @@ type SessionRecord struct {
 	// ReviewerHarness is this session's preferred reviewer. Empty delegates to
 	// the project configuration.
 	ReviewerHarness   ReviewerHarness `json:"reviewerHarness,omitempty" enum:"claude-code,codex,copilot,cursor,kilocode,opencode,kiro,pi,qwen,agy,continue,goose,vibe,devin,droid,kimi,kimchi,muse,amp,aider,grok,crush,auggie,cline,autohand"`
+	ReviewerConfig    AgentConfig     `json:"reviewerConfig,omitempty"`
 	AutoReviewEnabled bool            `json:"autoReviewEnabled"`
 	DisplayName       string          `json:"displayName,omitempty"`
 	// Mode is the session's currently committed conversation controller. Every

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6309,6 +6309,8 @@ components:
           items:
             $ref: '#/components/schemas/SessionPRFacts'
           type: array
+        reviewerConfig:
+          $ref: '#/components/schemas/AgentConfig'
         reviewerHarness:
           enum:
           - claude-code
@@ -7223,6 +7225,8 @@ components:
       type: object
     DomainReviewerConfig:
       properties:
+        agentConfig:
+          $ref: '#/components/schemas/AgentConfig'
         harness:
           type: string
       required:
@@ -9119,6 +9123,8 @@ components:
       type: object
     SetSessionReviewerRequest:
       properties:
+        agentConfig:
+          $ref: '#/components/schemas/AgentConfig'
         harness:
           enum:
           - claude-code

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -9520,6 +9520,8 @@ components:
       type: object
     TriggerReviewRequest:
       properties:
+        agentConfig:
+          $ref: '#/components/schemas/AgentConfig'
         harness:
           enum:
           - claude-code

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -446,7 +446,8 @@ type RenameSessionRequest struct {
 // SetSessionReviewerRequest sets the durable reviewer preference for a session.
 // Empty clears the preference and falls back to project configuration.
 type SetSessionReviewerRequest struct {
-	Harness domain.ReviewerHarness `json:"harness,omitempty" enum:"claude-code,codex,copilot,cursor,kilocode,opencode,kiro,pi,qwen,agy,continue,goose,vibe,devin,droid,kimi,kimchi,muse,amp,aider,grok,crush,auggie,cline,autohand"`
+	Harness     domain.ReviewerHarness `json:"harness,omitempty" enum:"claude-code,codex,copilot,cursor,kilocode,opencode,kiro,pi,qwen,agy,continue,goose,vibe,devin,droid,kimi,kimchi,muse,amp,aider,grok,crush,auggie,cline,autohand"`
+	AgentConfig domain.AgentConfig     `json:"agentConfig,omitempty"`
 }
 
 // SetSessionAutoReviewRequest configures daemon-side review automation.
@@ -2064,7 +2065,8 @@ func capabilityNames(caps ports.ChatCapabilities) []string {
 // it for this pass only, without editing project config, so one session's choice
 // cannot change what another session in the project runs.
 type TriggerReviewRequest struct {
-	Harness domain.ReviewerHarness `json:"harness,omitempty" enum:"claude-code,codex,copilot,cursor,kilocode,opencode,kiro,pi,qwen,agy,continue,goose,vibe,devin,droid,kimi,kimchi,muse,amp,aider,grok,crush,auggie,cline,autohand"`
+	Harness     domain.ReviewerHarness `json:"harness,omitempty" enum:"claude-code,codex,copilot,cursor,kilocode,opencode,kiro,pi,qwen,agy,continue,goose,vibe,devin,droid,kimi,kimchi,muse,amp,aider,grok,crush,auggie,cline,autohand"`
+	AgentConfig domain.AgentConfig     `json:"agentConfig,omitempty"`
 }
 
 // ResolveReviewCommentRequest is the body of POST /api/v1/sessions/{sessionId}/reviews/comments/resolve.

--- a/backend/internal/httpd/controllers/reviews.go
+++ b/backend/internal/httpd/controllers/reviews.go
@@ -173,7 +173,7 @@ func (c *ReviewsController) trigger(w http.ResponseWriter, r *http.Request) {
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
 		return
 	}
-	res, err := c.Svc.Trigger(r.Context(), sessionID(r), in.Harness)
+	res, err := c.Svc.Trigger(r.Context(), sessionID(r), in.Harness, in.AgentConfig)
 	if err != nil {
 		writeReviewError(w, r, err)
 		return
@@ -316,7 +316,7 @@ func (c *ReviewsController) switchReviewer(w http.ResponseWriter, r *http.Reques
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
 		return
 	}
-	res, err := c.Svc.SwitchReviewer(r.Context(), sessionID(r), in.Harness)
+	res, err := c.Svc.SwitchReviewer(r.Context(), sessionID(r), in.Harness, in.AgentConfig)
 	if err != nil {
 		writeReviewError(w, r, err)
 		return

--- a/backend/internal/httpd/controllers/reviews_test.go
+++ b/backend/internal/httpd/controllers/reviews_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 type fakeReviewService struct {
-	// triggeredHarness records the override the controller forwarded.
+	// triggeredHarness/config record the override the controller forwarded.
 	triggeredHarness  domain.ReviewerHarness
+	triggeredConfig   domain.AgentConfig
 	triggerErr        error
 	cancelErr         error
 	trigger           reviewcore.TriggerResult
@@ -48,8 +49,10 @@ func (f *fakeReviewService) Trigger(
 	_ context.Context,
 	_ domain.SessionID,
 	harness domain.ReviewerHarness,
+	config domain.AgentConfig,
 ) (reviewcore.TriggerResult, error) {
 	f.triggeredHarness = harness
+	f.triggeredConfig = config
 	if f.triggerErr != nil {
 		return reviewcore.TriggerResult{}, f.triggerErr
 	}
@@ -114,7 +117,7 @@ func (f *fakeReviewService) RestoreReviewer(context.Context, domain.SessionID) e
 	return nil
 }
 
-func (f *fakeReviewService) SwitchReviewer(_ context.Context, _ domain.SessionID, harness domain.ReviewerHarness) (reviewcore.SessionReviews, error) {
+func (f *fakeReviewService) SwitchReviewer(_ context.Context, _ domain.SessionID, harness domain.ReviewerHarness, _ domain.AgentConfig) (reviewcore.SessionReviews, error) {
 	f.switchedHarness = harness
 	f.list.ReviewerHarness = harness
 	if f.list.Runs == nil {

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -98,7 +98,7 @@ type SessionService interface {
 	SetTerminateOnPRMerge(ctx context.Context, id domain.SessionID, terminate bool) (domain.Session, error)
 	SetAutoInjectReview(ctx context.Context, id domain.SessionID, autoInject bool) (domain.Session, error)
 	SetAutoInjectCI(ctx context.Context, id domain.SessionID, autoInject bool) (domain.Session, error)
-	SetReviewerHarness(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness) (domain.Session, error)
+	SetReviewerHarness(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig) (domain.Session, error)
 	SetAutoReview(ctx context.Context, id domain.SessionID, enabled bool) (domain.Session, error)
 	Send(ctx context.Context, id domain.SessionID, message string, attachment *ports.SpawnAttachment) error
 	DelegateTask(ctx context.Context, in sessionsvc.DelegateTaskInput) (sessionsvc.DelegateTaskOutcome, error)
@@ -1084,7 +1084,7 @@ func (c *SessionsController) setReviewer(w http.ResponseWriter, r *http.Request)
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
 		return
 	}
-	sess, err := c.Svc.SetReviewerHarness(r.Context(), sessionID(r), in.Harness)
+	sess, err := c.Svc.SetReviewerHarness(r.Context(), sessionID(r), in.Harness, in.AgentConfig)
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -296,12 +296,13 @@ func (f *fakeSessionService) Unpin(_ context.Context, id domain.SessionID) (doma
 	return s, nil
 }
 
-func (f *fakeSessionService) SetReviewerHarness(_ context.Context, id domain.SessionID, harness domain.ReviewerHarness) (domain.Session, error) {
+func (f *fakeSessionService) SetReviewerHarness(_ context.Context, id domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig) (domain.Session, error) {
 	s, ok := f.sessions[id]
 	if !ok {
 		return domain.Session{}, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
 	}
 	s.ReviewerHarness = harness
+	s.ReviewerConfig = config
 	f.sessions[id] = s
 	return s, nil
 }

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -301,9 +301,6 @@ func (f *fakeSessionService) SetReviewerHarness(_ context.Context, id domain.Ses
 	if !ok {
 		return domain.Session{}, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
 	}
-	if harness == "" && !config.IsZero() {
-		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": "reviewer harness is required when reviewer config is set"})
-	}
 	s.ReviewerHarness = harness
 	s.ReviewerConfig = config
 	f.sessions[id] = s
@@ -1209,14 +1206,16 @@ func TestSessionsAPI_ListSpawnGetAndActions(t *testing.T) {
 	}
 }
 
-func TestSessionsAPI_SetReviewerRejectsConfigWithoutHarness(t *testing.T) {
+func TestSessionsAPI_SetReviewerAllowsConfigWithoutHarness(t *testing.T) {
 	svc := newFakeSessionService()
 	srv := newSessionTestServer(t, svc)
 
 	body, status, _ := doRequest(t, srv, "PUT", "/api/v1/sessions/ao-1/reviewer", `{"agentConfig":{"model":"gpt-5"}}`)
-	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_REVIEWER_CONFIG")
-	if got := svc.sessions["ao-1"].ReviewerConfig; !got.IsZero() {
-		t.Fatalf("invalid reviewer update persisted config: %+v", got)
+	if status != http.StatusOK {
+		t.Fatalf("set reviewer with default harness override = %d, want 200; body=%s", status, body)
+	}
+	if got := svc.sessions["ao-1"]; got.ReviewerHarness != "" || got.ReviewerConfig.Model != "gpt-5" {
+		t.Fatalf("reviewer update persisted = (%q, %+v), want default harness with model override", got.ReviewerHarness, got.ReviewerConfig)
 	}
 }
 

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -301,6 +301,9 @@ func (f *fakeSessionService) SetReviewerHarness(_ context.Context, id domain.Ses
 	if !ok {
 		return domain.Session{}, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
 	}
+	if harness == "" && !config.IsZero() {
+		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": "reviewer harness is required when reviewer config is set"})
+	}
 	s.ReviewerHarness = harness
 	s.ReviewerConfig = config
 	f.sessions[id] = s
@@ -1203,6 +1206,17 @@ func TestSessionsAPI_ListSpawnGetAndActions(t *testing.T) {
 	body, status, _ = doRequest(t, srv, "POST", "/api/v1/orchestrators", `{"projectId":"ao"}`)
 	if status != http.StatusCreated {
 		t.Fatalf("orchestrator = %d, want 201; body=%s", status, body)
+	}
+}
+
+func TestSessionsAPI_SetReviewerRejectsConfigWithoutHarness(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "PUT", "/api/v1/sessions/ao-1/reviewer", `{"agentConfig":{"model":"gpt-5"}}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_REVIEWER_CONFIG")
+	if got := svc.sessions["ao-1"].ReviewerConfig; !got.IsZero() {
+		t.Fatalf("invalid reviewer update persisted config: %+v", got)
 	}
 }
 

--- a/backend/internal/ports/reviewer.go
+++ b/backend/internal/ports/reviewer.go
@@ -99,6 +99,8 @@ type ReviewInvocation struct {
 	ReviewQueue []ReviewTask
 	// ReviewIndex is this invocation's zero-based position in ReviewQueue.
 	ReviewIndex int
+	// Config carries the reviewer's resolved agent configuration override.
+	Config domain.AgentConfig
 	// WorkspacePath is the worker's checkout the reviewer reads.
 	WorkspacePath string
 	// DataDir is AO's owned state root. Reviewer prelaunch hooks may use it for

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -67,6 +67,7 @@ type LaunchSpec struct {
 	WorkerID        domain.SessionID
 	ProjectID       domain.ProjectID
 	Harness         domain.ReviewerHarness
+	AgentConfig     domain.AgentConfig
 	WorkspacePath   string
 	AgentSessionID  string
 	PreviousRuns    []domain.ReviewRun
@@ -246,6 +247,7 @@ func (l *agentLauncher) invocation(spec LaunchSpec) ports.ReviewInvocation {
 		TargetSHA:       spec.TargetSHA,
 		ReviewQueue:     spec.ReviewQueue,
 		ReviewIndex:     spec.ReviewIndex,
+		Config:          spec.AgentConfig,
 		WorkspacePath:   spec.WorkspacePath,
 		DataDir:         l.dataDir,
 		RunFilePath:     l.runFile,
@@ -320,6 +322,7 @@ func (l *agentLauncher) prepareIdleInvocation(spec LaunchSpec) (ports.ReviewInvo
 		ReviewerID:       reviewerHandleID(spec.WorkerID),
 		WorkerSessionID:  spec.WorkerID,
 		AgentSessionID:   spec.AgentSessionID,
+		Config:           spec.AgentConfig,
 		WorkspacePath:    spec.WorkspacePath,
 		DataDir:          l.dataDir,
 		RunFilePath:      l.runFile,

--- a/backend/internal/review/override_test.go
+++ b/backend/internal/review/override_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 func TestTriggerRejectsAnUnknownHarnessOverride(t *testing.T) {
 	eng := New(Deps{})
 
-	_, err := eng.Trigger(context.Background(), "mer-1", "not-a-reviewer")
+	_, err := eng.Trigger(context.Background(), "mer-1", "not-a-reviewer", domain.AgentConfig{})
 	if !errors.Is(err, ErrInvalid) {
 		t.Fatalf("err = %v, want ErrInvalid", err)
 	}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -256,21 +256,19 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	resolvedHarness := harness
 	resolvedConfig := config
 	hasHarnessOverride := override != ""
-	hasConfigOverride := !overrideConfig.IsZero() && (hasHarnessOverride || overrideConfig != resolvedConfig)
 	if hasHarnessOverride {
 		harness = override
-		if hasConfigOverride {
-			base := domain.AgentConfig{}
-			if override == resolvedHarness {
-				base = resolvedConfig
-			}
-			config = mergeReviewerAgentConfig(base, overrideConfig)
+		if override == resolvedHarness {
+			config = mergeReviewerAgentConfig(resolvedConfig, overrideConfig)
+		} else if !overrideConfig.IsZero() {
+			config = mergeReviewerAgentConfig(domain.AgentConfig{}, overrideConfig)
 		} else {
 			config = domain.AgentConfig{}
 		}
-	} else if hasConfigOverride {
+	} else if !overrideConfig.IsZero() {
 		config = mergeReviewerAgentConfig(config, overrideConfig)
 	}
+	hasConfigOverride := config != resolvedConfig
 	reviewRows, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
 		return TriggerResult{}, err

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -398,6 +398,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	if hasConfigOverride {
 		launchAgentSessionID = ""
 	}
+	persistedAgentSessionID := launchAgentSessionID
 	handleID := ""
 	if !hasConfigOverride && reviewRow.ReviewerHandleID != "" && reviewerPaneReusable(reviewRow, hadRunningReviewer) {
 		alive, err := e.launcher.Alive(ctx, reviewRow.ReviewerHandleID)
@@ -420,7 +421,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		}
 		handleID = launch.HandleID
 		if launch.AgentSessionID != "" {
-			reviewRow.AgentSessionID = launch.AgentSessionID
+			persistedAgentSessionID = launch.AgentSessionID
 		}
 	} else {
 		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, config, launchRun, queue, 0, reviewRow.AgentSessionID)); err != nil {
@@ -443,7 +444,15 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w", err))
 		}
 	}
-	reviewRow, err = e.upsertReview(ctx, worker, harness, handleID, reviewRow.AgentSessionID, now)
+	if hasConfigOverride && persistedAgentSessionID == "" && reviewRow.ID != "" {
+		if _, err := e.store.UpdateReviewAgentSessionID(ctx, reviewRow.ID, ""); err != nil {
+			if handleID != "" {
+				_ = e.launcher.Destroy(ctx, handleID)
+			}
+			return TriggerResult{}, failRuns(0, err)
+		}
+	}
+	reviewRow, err = e.upsertReview(ctx, worker, harness, handleID, persistedAgentSessionID, now)
 	if err != nil {
 		return TriggerResult{}, err
 	}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -32,7 +32,7 @@ var (
 // in production; tests use a fake.
 type Store interface {
 	UpsertReview(ctx stdctx.Context, r domain.Review) error
-	SetSessionReviewerHarness(ctx stdctx.Context, id domain.SessionID, harness domain.ReviewerHarness, updatedAt time.Time) (bool, error)
+	SetSessionReviewerConfig(ctx stdctx.Context, id domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig, updatedAt time.Time) (bool, error)
 	GetReviewBySession(ctx stdctx.Context, id domain.SessionID) (domain.Review, bool, error)
 	ClearReviewerHandle(ctx stdctx.Context, id domain.SessionID) error
 	GetReviewBySessionAndHarness(ctx stdctx.Context, id domain.SessionID, harness domain.ReviewerHarness) (domain.Review, bool, error)
@@ -190,12 +190,12 @@ type RestoreReviewerResult struct {
 // this pass under it without editing project config, so picking a reviewer for
 // one session cannot change what any other session in the project runs. The
 // harness-change path below already handles the swap by respawning the pane.
-func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID, override domain.ReviewerHarness) (TriggerResult, error) {
-	return e.TriggerWithSource(ctx, workerID, override, domain.ReviewTriggerManual)
+func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID, override domain.ReviewerHarness, config domain.AgentConfig) (TriggerResult, error) {
+	return e.TriggerWithSource(ctx, workerID, override, config, domain.ReviewTriggerManual)
 }
 
 // TriggerWithSource starts a review and records who initiated the pass.
-func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID, override domain.ReviewerHarness, source domain.ReviewTriggerSource) (TriggerResult, error) {
+func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID, override domain.ReviewerHarness, config domain.AgentConfig, source domain.ReviewTriggerSource) (TriggerResult, error) {
 	if workerID == "" {
 		return TriggerResult{}, fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
@@ -244,12 +244,17 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		return TriggerResult{}, err
 	}
 
-	harness, err := e.reviewerHarness(ctx, worker)
+	harness, config, err := e.reviewerSelection(ctx, worker)
 	if err != nil {
 		return TriggerResult{}, err
 	}
 	if override != "" {
 		harness = override
+		if config != (domain.AgentConfig{}) {
+			// pass-specific override wins when provided; otherwise keep the session/project default config
+		} else {
+			config = domain.AgentConfig{}
+		}
 	}
 	reviewRows, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
@@ -376,7 +381,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		if err := e.launcher.Preflight(ctx, harness, worker.Metadata.WorkspacePath); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("reviewer preflight: %w", err))
 		}
-		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, created[0], queue, 0, reviewRow.AgentSessionID))
+		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, config, created[0], queue, 0, reviewRow.AgentSessionID))
 		if err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("launch reviewer: %w", err))
 		}
@@ -385,7 +390,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			reviewRow.AgentSessionID = launch.AgentSessionID
 		}
 	} else {
-		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, created[0], queue, 0, reviewRow.AgentSessionID)); err != nil {
+		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, config, created[0], queue, 0, reviewRow.AgentSessionID)); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("notify reviewer: %w", err))
 		}
 	}
@@ -420,12 +425,20 @@ func autoReviewSessionReason(worker domain.SessionRecord, now time.Time) string 
 
 // SwitchReviewer serializes reviewer preference changes with trigger/restore
 // and returns the authoritative post-switch review state.
-func (e *Engine) SwitchReviewer(ctx stdctx.Context, workerID domain.SessionID, harness domain.ReviewerHarness) (SessionReviews, error) {
+func (e *Engine) SwitchReviewer(
+	ctx stdctx.Context,
+	workerID domain.SessionID,
+	harness domain.ReviewerHarness,
+	config domain.AgentConfig,
+) (SessionReviews, error) {
 	if workerID == "" {
 		return SessionReviews{}, fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
 	if harness != "" && !harness.IsKnown() {
 		return SessionReviews{}, fmt.Errorf("%w: unknown reviewer harness %q", ErrInvalid, harness)
+	}
+	if err := config.Validate(); err != nil {
+		return SessionReviews{}, fmt.Errorf("%w: reviewer config: %v", ErrInvalid, err)
 	}
 	unlock := e.lockWorker(workerID)
 	defer unlock()
@@ -437,13 +450,14 @@ func (e *Engine) SwitchReviewer(ctx stdctx.Context, workerID domain.SessionID, h
 	if !ok {
 		return SessionReviews{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 	}
-	if ok, err := e.store.SetSessionReviewerHarness(ctx, workerID, harness, e.clock()); err != nil {
+	if ok, err := e.store.SetSessionReviewerConfig(ctx, workerID, harness, config, e.clock()); err != nil {
 		return SessionReviews{}, err
 	} else if !ok {
 		return SessionReviews{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 	}
 	worker.ReviewerHarness = harness
-	selected, err := e.reviewerHarness(ctx, worker)
+	worker.ReviewerConfig = config
+	selected, selectedConfig, err := e.reviewerSelection(ctx, worker)
 	if err != nil {
 		return SessionReviews{}, err
 	}
@@ -454,7 +468,7 @@ func (e *Engine) SwitchReviewer(ctx stdctx.Context, workerID domain.SessionID, h
 	if err := e.destroyOtherReviewerHandles(ctx, workerID, selected, reviewRows); err != nil {
 		return SessionReviews{}, err
 	}
-	if _, err := e.restoreReviewerLocked(ctx, workerID, worker, selected); err != nil {
+	if _, err := e.restoreReviewerLocked(ctx, workerID, worker, selected, selectedConfig); err != nil {
 		return SessionReviews{}, err
 	}
 	return e.listLocked(ctx, workerID, selected)
@@ -514,14 +528,20 @@ func (e *Engine) RestoreReviewer(ctx stdctx.Context, workerID domain.SessionID) 
 	if worker.IsTerminated || worker.Metadata.WorkspacePath == "" {
 		return RestoreReviewerResult{}, nil
 	}
-	harness, err := e.reviewerHarness(ctx, worker)
+	harness, config, err := e.reviewerSelection(ctx, worker)
 	if err != nil {
 		return RestoreReviewerResult{}, err
 	}
-	return e.restoreReviewerLocked(ctx, workerID, worker, harness)
+	return e.restoreReviewerLocked(ctx, workerID, worker, harness, config)
 }
 
-func (e *Engine) restoreReviewerLocked(ctx stdctx.Context, workerID domain.SessionID, worker domain.SessionRecord, harness domain.ReviewerHarness) (RestoreReviewerResult, error) {
+func (e *Engine) restoreReviewerLocked(
+	ctx stdctx.Context,
+	workerID domain.SessionID,
+	worker domain.SessionRecord,
+	harness domain.ReviewerHarness,
+	config domain.AgentConfig,
+) (RestoreReviewerResult, error) {
 	reviewRows, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
 		return RestoreReviewerResult{}, err
@@ -564,6 +584,7 @@ func (e *Engine) restoreReviewerLocked(ctx stdctx.Context, workerID domain.Sessi
 		WorkerID:        worker.ID,
 		ProjectID:       worker.ProjectID,
 		Harness:         harness,
+		AgentConfig:     config,
 		WorkspacePath:   worker.Metadata.WorkspacePath,
 		AgentSessionID:  agentSessionID,
 		PreviousRuns:    previousRuns,
@@ -662,7 +683,15 @@ func (e *Engine) cancelStaleRunningRuns(ctx stdctx.Context, workerID domain.Sess
 	return true, nil
 }
 
-func reviewLaunchSpec(worker domain.SessionRecord, harness domain.ReviewerHarness, run domain.ReviewRun, queue []ports.ReviewTask, index int, agentSessionID string) LaunchSpec {
+func reviewLaunchSpec(
+	worker domain.SessionRecord,
+	harness domain.ReviewerHarness,
+	config domain.AgentConfig,
+	run domain.ReviewRun,
+	queue []ports.ReviewTask,
+	index int,
+	agentSessionID string,
+) LaunchSpec {
 	return LaunchSpec{
 		RunID:           run.ID,
 		BatchID:         run.BatchID,
@@ -670,6 +699,7 @@ func reviewLaunchSpec(worker domain.SessionRecord, harness domain.ReviewerHarnes
 		WorkerID:        worker.ID,
 		ProjectID:       worker.ProjectID,
 		Harness:         harness,
+		AgentConfig:     config,
 		WorkspacePath:   worker.Metadata.WorkspacePath,
 		AgentSessionID:  agentSessionID,
 		PreviousRuns:    nil,
@@ -743,7 +773,7 @@ func (e *Engine) List(ctx stdctx.Context, workerID domain.SessionID) (SessionRev
 	if !ok {
 		return SessionReviews{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 	}
-	selectedHarness, err := e.reviewerHarness(ctx, worker)
+	selectedHarness, _, err := e.reviewerSelection(ctx, worker)
 	if err != nil {
 		return SessionReviews{}, err
 	}
@@ -788,7 +818,7 @@ func (e *Engine) Cancel(ctx stdctx.Context, workerID domain.SessionID) (CancelRe
 	if !ok {
 		return CancelResult{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 	}
-	harness, err := e.reviewerHarness(ctx, worker)
+	harness, _, err := e.reviewerSelection(ctx, worker)
 	if err != nil {
 		return CancelResult{}, err
 	}
@@ -948,19 +978,40 @@ func (e *Engine) TerminateReviewer(ctx stdctx.Context, workerID domain.SessionID
 // reviewerHarness resolves which harness reviews the worker's PR: a persisted
 // session preference wins, then project configuration, then the worker's own
 // harness when supported, otherwise claude-code.
-func (e *Engine) reviewerHarness(ctx stdctx.Context, worker domain.SessionRecord) (domain.ReviewerHarness, error) {
-	if worker.ReviewerHarness != "" {
-		return worker.ReviewerHarness, nil
+func (e *Engine) reviewerSelection(
+	ctx stdctx.Context,
+	worker domain.SessionRecord,
+) (domain.ReviewerHarness, domain.AgentConfig, error) {
+	if worker.ReviewerHarness != "" || !worker.ReviewerConfig.IsZero() {
+		harness := worker.ReviewerHarness
+		if harness == "" {
+			var err error
+			harness, _, err = e.projectReviewerSelection(ctx, worker)
+			if err != nil {
+				return "", domain.AgentConfig{}, err
+			}
+		}
+		return harness, worker.ReviewerConfig, nil
 	}
+	return e.projectReviewerSelection(ctx, worker)
+}
+
+func (e *Engine) projectReviewerSelection(
+	ctx stdctx.Context,
+	worker domain.SessionRecord,
+) (domain.ReviewerHarness, domain.AgentConfig, error) {
 	var cfg domain.ProjectConfig
 	if e.projects != nil {
 		if proj, ok, err := e.projects.GetProject(ctx, string(worker.ProjectID)); err != nil {
-			return "", err
+			return "", domain.AgentConfig{}, err
 		} else if ok {
 			cfg = proj.Config
 		}
 	}
-	return cfg.ResolveReviewerHarness(worker.Harness), nil
+	if len(cfg.Reviewers) > 0 {
+		return cfg.Reviewers[0].Harness, cfg.Reviewers[0].AgentConfig, nil
+	}
+	return cfg.ResolveReviewerHarness(worker.Harness), domain.AgentConfig{}, nil
 }
 
 func (e *Engine) upsertReview(ctx stdctx.Context, worker domain.SessionRecord, harness domain.ReviewerHarness, handleID, agentSessionID string, now time.Time) (domain.Review, error) {

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -259,12 +259,12 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	if hasHarnessOverride {
 		harness = override
 		if hasConfigOverride {
-			config = overrideConfig
+			config = mergeReviewerAgentConfig(domain.AgentConfig{}, overrideConfig)
 		} else {
 			config = domain.AgentConfig{}
 		}
 	} else if hasConfigOverride {
-		config = overrideConfig
+		config = mergeReviewerAgentConfig(config, overrideConfig)
 	}
 	reviewRows, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
@@ -1035,16 +1035,33 @@ func (e *Engine) reviewerSelection(
 ) (domain.ReviewerHarness, domain.AgentConfig, error) {
 	if worker.ReviewerHarness != "" || !worker.ReviewerConfig.IsZero() {
 		harness := worker.ReviewerHarness
-		if harness == "" {
-			var err error
-			harness, _, err = e.projectReviewerSelection(ctx, worker)
-			if err != nil {
-				return "", domain.AgentConfig{}, err
-			}
+		projectHarness, projectConfig, err := e.projectReviewerSelection(ctx, worker)
+		if err != nil {
+			return "", domain.AgentConfig{}, err
 		}
-		return harness, worker.ReviewerConfig, nil
+		if harness == "" {
+			harness = projectHarness
+		}
+		baseConfig := domain.AgentConfig{}
+		if harness == projectHarness {
+			baseConfig = projectConfig
+		}
+		return harness, mergeReviewerAgentConfig(baseConfig, worker.ReviewerConfig), nil
 	}
 	return e.projectReviewerSelection(ctx, worker)
+}
+
+func mergeReviewerAgentConfig(base, override domain.AgentConfig) domain.AgentConfig {
+	if override.Model != "" {
+		base.Model = override.Model
+	}
+	if override.Mode != "" {
+		base.Mode = override.Mode
+	}
+	if override.Permissions != "" {
+		base.Permissions = override.Permissions
+	}
+	return base
 }
 
 func (e *Engine) projectReviewerSelection(

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -195,7 +195,7 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID, override
 }
 
 // TriggerWithSource starts a review and records who initiated the pass.
-func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID, override domain.ReviewerHarness, config domain.AgentConfig, source domain.ReviewTriggerSource) (TriggerResult, error) {
+func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID, override domain.ReviewerHarness, overrideConfig domain.AgentConfig, source domain.ReviewTriggerSource) (TriggerResult, error) {
 	if workerID == "" {
 		return TriggerResult{}, fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
@@ -250,8 +250,8 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	}
 	if override != "" {
 		harness = override
-		if config != (domain.AgentConfig{}) {
-			// pass-specific override wins when provided; otherwise keep the session/project default config
+		if overrideConfig != (domain.AgentConfig{}) {
+			config = overrideConfig
 		} else {
 			config = domain.AgentConfig{}
 		}
@@ -438,7 +438,7 @@ func (e *Engine) SwitchReviewer(
 		return SessionReviews{}, fmt.Errorf("%w: unknown reviewer harness %q", ErrInvalid, harness)
 	}
 	if err := config.Validate(); err != nil {
-		return SessionReviews{}, fmt.Errorf("%w: reviewer config: %v", ErrInvalid, err)
+		return SessionReviews{}, fmt.Errorf("%w: reviewer config: %w", ErrInvalid, err)
 	}
 	unlock := e.lockWorker(workerID)
 	defer unlock()

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -253,13 +253,18 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	if err != nil {
 		return TriggerResult{}, err
 	}
+	resolvedHarness := harness
 	resolvedConfig := config
 	hasHarnessOverride := override != ""
 	hasConfigOverride := !overrideConfig.IsZero() && (hasHarnessOverride || overrideConfig != resolvedConfig)
 	if hasHarnessOverride {
 		harness = override
 		if hasConfigOverride {
-			config = mergeReviewerAgentConfig(domain.AgentConfig{}, overrideConfig)
+			base := domain.AgentConfig{}
+			if override == resolvedHarness {
+				base = resolvedConfig
+			}
+			config = mergeReviewerAgentConfig(base, overrideConfig)
 		} else {
 			config = domain.AgentConfig{}
 		}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -393,6 +393,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	queueRuns = append(queueRuns, created...)
 	queue := reviewQueue(queueRuns)
 	launchRun := queueRuns[0]
+	previousHandleID := reviewRow.ReviewerHandleID
 	launchAgentSessionID := reviewRow.AgentSessionID
 	if hasConfigOverride {
 		launchAgentSessionID = ""
@@ -432,6 +433,14 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 				_ = e.launcher.Destroy(ctx, handleID)
 			}
 			return TriggerResult{}, failRuns(0, err)
+		}
+	}
+	if hasConfigOverride && previousHandleID != "" && previousHandleID != handleID {
+		if err := e.launcher.Destroy(ctx, previousHandleID); err != nil {
+			if handleID != "" {
+				_ = e.launcher.Destroy(ctx, handleID)
+			}
+			return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w", err))
 		}
 	}
 	reviewRow, err = e.upsertReview(ctx, worker, harness, handleID, reviewRow.AgentSessionID, now)

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -523,16 +523,12 @@ func (e *Engine) SwitchReviewer(
 	if err != nil {
 		return SessionReviews{}, err
 	}
-	persistHarness := harness
-	if persistHarness == "" && !config.IsZero() {
-		persistHarness = previousSelected
-	}
-	if ok, err := e.store.SetSessionReviewerConfig(ctx, workerID, persistHarness, config, e.clock()); err != nil {
+	if ok, err := e.store.SetSessionReviewerConfig(ctx, workerID, harness, config, e.clock()); err != nil {
 		return SessionReviews{}, err
 	} else if !ok {
 		return SessionReviews{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 	}
-	worker.ReviewerHarness = persistHarness
+	worker.ReviewerHarness = harness
 	worker.ReviewerConfig = config
 	selected, selectedConfig, err := e.reviewerSelection(ctx, worker)
 	if err != nil {

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -244,17 +244,24 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		return TriggerResult{}, err
 	}
 
+	if err := overrideConfig.Validate(); err != nil {
+		return TriggerResult{}, fmt.Errorf("%w: reviewer config: %w", ErrInvalid, err)
+	}
+
 	harness, config, err := e.reviewerSelection(ctx, worker)
 	if err != nil {
 		return TriggerResult{}, err
 	}
+	hasConfigOverride := !overrideConfig.IsZero()
 	if override != "" {
 		harness = override
-		if overrideConfig != (domain.AgentConfig{}) {
+		if hasConfigOverride {
 			config = overrideConfig
 		} else {
 			config = domain.AgentConfig{}
 		}
+	} else if hasConfigOverride {
+		config = overrideConfig
 	}
 	reviewRows, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
@@ -312,7 +319,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		if source == domain.ReviewTriggerAuto && autoReviewHeadBlocked(runs, reviewState.PRURL, reviewState.TargetSHA, harness) {
 			eligible = false
 		}
-		if !eligible && !secondOpinionWanted(reviewState, override, harness) {
+		if !eligible && !secondOpinionWanted(reviewState, override != "", hasConfigOverride, harness) {
 			continue
 		}
 		if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, reviewState.PRURL, reviewState.TargetSHA, "superseded by a review trigger for a newer commit"); err != nil {
@@ -722,18 +729,31 @@ func reviewQueue(runs []domain.ReviewRun) []ports.ReviewTask {
 	return queue
 }
 
-// secondOpinionWanted reports whether an explicitly requested harness differs
-// from the one that already reviewed this commit, which makes an otherwise
-// up-to-date PR worth running again. Only an explicit override counts: falling
-// back to the project default must not re-review a commit on every trigger.
-func secondOpinionWanted(state PRReviewState, override, harness domain.ReviewerHarness) bool {
-	if override == "" || state.Status == ReviewStateIneligible || state.Status == ReviewStateRunning {
+// secondOpinionWanted reports whether an explicit manual override makes an
+// otherwise up-to-date PR worth running again. A config-only override (for
+// example, picking a model under the same harness) always requests another
+// pass. A harness-only override only does so when it actually changes the
+// reviewer that produced the current result; re-picking the same harness must
+// still reuse. Legacy runs may have an empty harness, which means "the same
+// resolved harness as today" for this comparison.
+func secondOpinionWanted(state PRReviewState, hasHarnessOverride, hasConfigOverride bool, harness domain.ReviewerHarness) bool {
+	if state.Status == ReviewStateIneligible || state.Status == ReviewStateRunning {
 		return false
 	}
 	if state.LatestRun == nil {
 		return false
 	}
-	return state.LatestRun.Harness != harness
+	if hasConfigOverride {
+		return true
+	}
+	if !hasHarnessOverride {
+		return false
+	}
+	latestHarness := state.LatestRun.Harness
+	if latestHarness == "" {
+		latestHarness = harness
+	}
+	return latestHarness != harness
 }
 
 func replaceReviewLatestRun(reviews []PRReviewState, prURL, targetSHA string, run domain.ReviewRun) []PRReviewState {

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -40,6 +40,7 @@ type Store interface {
 	ClearReviewerHandleByHarness(ctx stdctx.Context, id domain.SessionID, harness domain.ReviewerHarness) error
 	InsertReviewRun(ctx stdctx.Context, r domain.ReviewRun) error
 	UpdateReviewRunResult(ctx stdctx.Context, id string, status domain.ReviewRunStatus, verdict domain.ReviewVerdict, body, githubReviewID string, autoInjectReview bool) (bool, error)
+	UpdateReviewAgentSessionID(ctx stdctx.Context, id, agentSessionID string) (bool, error)
 	SupersedeStaleRunningReviewRuns(ctx stdctx.Context, sessionID domain.SessionID, prURL, targetSHA, body string) (int64, error)
 	CancelRunningReviewRunsBySession(ctx stdctx.Context, sessionID domain.SessionID, body string) (int64, error)
 	CancelRunningReviewRunsBySessionAndHarness(ctx stdctx.Context, sessionID domain.SessionID, harness domain.ReviewerHarness, body string) (int64, error)
@@ -457,6 +458,10 @@ func (e *Engine) SwitchReviewer(
 	if !ok {
 		return SessionReviews{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 	}
+	previousSelected, previousConfig, err := e.reviewerSelection(ctx, worker)
+	if err != nil {
+		return SessionReviews{}, err
+	}
 	if ok, err := e.store.SetSessionReviewerConfig(ctx, workerID, harness, config, e.clock()); err != nil {
 		return SessionReviews{}, err
 	} else if !ok {
@@ -474,6 +479,11 @@ func (e *Engine) SwitchReviewer(
 	}
 	if err := e.destroyOtherReviewerHandles(ctx, workerID, selected, reviewRows); err != nil {
 		return SessionReviews{}, err
+	}
+	if previousSelected == selected && previousConfig != selectedConfig {
+		if err := e.resetReviewerRuntimeLocked(ctx, workerID, selected); err != nil {
+			return SessionReviews{}, err
+		}
 	}
 	if _, err := e.restoreReviewerLocked(ctx, workerID, worker, selected, selectedConfig); err != nil {
 		return SessionReviews{}, err
@@ -511,6 +521,25 @@ func (e *Engine) destroyOtherReviewerHandles(ctx stdctx.Context, workerID domain
 		if _, err := e.store.CancelRunningReviewRunsBySessionAndHarness(ctx, workerID, review.Harness, "cancelled because reviewer agent was switched"); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (e *Engine) resetReviewerRuntimeLocked(ctx stdctx.Context, workerID domain.SessionID, harness domain.ReviewerHarness) error {
+	review, ok, err := e.store.GetReviewBySessionAndHarness(ctx, workerID, harness)
+	if err != nil || !ok {
+		return err
+	}
+	if review.ReviewerHandleID != "" {
+		if err := e.launcher.Destroy(ctx, review.ReviewerHandleID); err != nil {
+			return err
+		}
+		if err := e.store.ClearReviewerHandleByHarness(ctx, workerID, harness); err != nil {
+			return err
+		}
+	}
+	if _, err := e.store.UpdateReviewAgentSessionID(ctx, review.ID, ""); err != nil {
+		return err
 	}
 	return nil
 }

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -454,10 +454,14 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	}
 	if hasConfigOverride && previousHandleID != "" && previousHandleID != handleID {
 		if err := e.launcher.Destroy(ctx, previousHandleID); err != nil {
-			if handleID != "" {
-				_ = e.launcher.Destroy(ctx, handleID)
+			if _, rollbackErr := e.upsertReview(ctx, worker, harness, previousHandleID, previousAgentSessionID, now); rollbackErr != nil {
+				return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w; rollback review row: %w", err, rollbackErr))
 			}
-			_, _ = e.upsertReview(ctx, worker, harness, previousHandleID, previousAgentSessionID, now)
+			if handleID != "" {
+				if destroyNewErr := e.launcher.Destroy(ctx, handleID); destroyNewErr != nil {
+					return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w; cleanup replacement reviewer: %w", err, destroyNewErr))
+				}
+			}
 			return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w", err))
 		}
 	}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -288,6 +288,25 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			return TriggerResult{}, err
 		}
 	}
+	if hasConfigOverride {
+		if _, err := e.store.CancelRunningReviewRunsBySessionAndHarness(ctx, workerID, harness, "cancelled because reviewer config changed"); err != nil {
+			return TriggerResult{}, err
+		}
+		if err := e.resetReviewerRuntimeLocked(ctx, workerID, harness); err != nil {
+			return TriggerResult{}, err
+		}
+		reviewRow, hasReview, err = e.store.GetReviewBySessionAndHarness(ctx, workerID, harness)
+		if err != nil {
+			return TriggerResult{}, err
+		}
+		runs, err = e.store.ListReviewRunsBySession(ctx, workerID)
+		if err != nil {
+			return TriggerResult{}, err
+		}
+		if !hasReview {
+			reviewRow = domain.Review{}
+		}
+	}
 	hadRunningReviewer := reviewRunsContainRunningForHarness(runs, harness)
 	reviews := Plan(prs, runs)
 	if source == domain.ReviewTriggerAuto {

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -256,10 +256,12 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	resolvedHarness := harness
 	resolvedConfig := config
 	hasHarnessOverride := override != ""
+	hasConfigOverride := false
 	if hasHarnessOverride {
 		harness = override
 		if override == resolvedHarness {
 			config = mergeReviewerAgentConfig(resolvedConfig, overrideConfig)
+			hasConfigOverride = config != resolvedConfig
 		} else if !overrideConfig.IsZero() {
 			config = mergeReviewerAgentConfig(domain.AgentConfig{}, overrideConfig)
 		} else {
@@ -267,8 +269,8 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		}
 	} else if !overrideConfig.IsZero() {
 		config = mergeReviewerAgentConfig(config, overrideConfig)
+		hasConfigOverride = config != resolvedConfig
 	}
-	hasConfigOverride := config != resolvedConfig
 	reviewRows, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
 		return TriggerResult{}, err
@@ -823,9 +825,11 @@ func reviewQueue(runs []domain.ReviewRun) []ports.ReviewTask {
 // otherwise up-to-date PR worth running again. A config-only override (for
 // example, picking a model under the same harness) always requests another
 // pass. A harness-only override only does so when it actually changes the
-// reviewer that produced the current result; re-picking the same harness must
-// still reuse. Legacy runs may have an empty harness, which means "the same
-// resolved harness as today" for this comparison.
+// reviewer whose pass is currently authoritative; re-picking the same harness
+// must still reuse. That remains true even while another harness is already
+// running: a different reviewer is a second opinion, not a restart. Legacy
+// runs may have an empty harness, which means "the same resolved harness as
+// today" for this comparison.
 func secondOpinionWanted(state PRReviewState, hasHarnessOverride, hasConfigOverride bool, harness domain.ReviewerHarness) bool {
 	if state.Status == ReviewStateIneligible {
 		return false
@@ -835,9 +839,6 @@ func secondOpinionWanted(state PRReviewState, hasHarnessOverride, hasConfigOverr
 	}
 	if hasConfigOverride {
 		return true
-	}
-	if state.Status == ReviewStateRunning {
-		return false
 	}
 	if !hasHarnessOverride {
 		return false

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -319,6 +319,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		targetSHA string
 	}
 	var pendingSupersedes []staleSupersede
+	var restarted []domain.ReviewRun
 	batchID := ""
 	for _, reviewState := range reviews {
 		// A PR that is already up to date has nothing due — unless the caller asked
@@ -335,6 +336,10 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		}
 		if hasConfigOverride {
 			pendingSupersedes = append(pendingSupersedes, staleSupersede{prURL: reviewState.PRURL, targetSHA: reviewState.TargetSHA})
+			if reviewState.LatestRun != nil && reviewState.LatestRun.Status == domain.ReviewRunRunning && (reviewState.LatestRun.Harness == harness || reviewState.LatestRun.Harness == "") {
+				restarted = append(restarted, *reviewState.LatestRun)
+				continue
+			}
 		} else if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, reviewState.PRURL, reviewState.TargetSHA, "superseded by a review trigger for a newer commit"); err != nil {
 			return TriggerResult{}, err
 		}
@@ -371,7 +376,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		created = append(created, run)
 		reviews = replaceReviewLatestRun(reviews, reviewState.PRURL, reviewState.TargetSHA, run)
 	}
-	if len(created) == 0 {
+	if len(created) == 0 && len(restarted) == 0 {
 		return TriggerResult{Run: firstReusableRun(reviews), ReviewerHandleID: reviewRow.ReviewerHandleID, Created: false, Reviews: reviews, Runs: runs}, nil
 	}
 
@@ -384,7 +389,10 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		return err
 	}
 
-	queue := reviewQueue(created)
+	queueRuns := append([]domain.ReviewRun{}, restarted...)
+	queueRuns = append(queueRuns, created...)
+	queue := reviewQueue(queueRuns)
+	launchRun := queueRuns[0]
 	launchAgentSessionID := reviewRow.AgentSessionID
 	if hasConfigOverride {
 		launchAgentSessionID = ""
@@ -405,7 +413,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		if err := e.launcher.Preflight(ctx, harness, worker.Metadata.WorkspacePath); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("reviewer preflight: %w", err))
 		}
-		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, config, created[0], queue, 0, launchAgentSessionID))
+		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, config, launchRun, queue, 0, launchAgentSessionID))
 		if err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("launch reviewer: %w", err))
 		}
@@ -414,7 +422,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			reviewRow.AgentSessionID = launch.AgentSessionID
 		}
 	} else {
-		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, config, created[0], queue, 0, reviewRow.AgentSessionID)); err != nil {
+		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, config, launchRun, queue, 0, reviewRow.AgentSessionID)); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("notify reviewer: %w", err))
 		}
 	}
@@ -435,7 +443,9 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	}
 	triggerRuns := append([]domain.ReviewRun{}, created...)
 	triggerRuns = append(triggerRuns, runs...)
-	return TriggerResult{Run: created[0], ReviewerHandleID: handleID, Created: true, Reviews: reviews, Runs: triggerRuns, CreatedRuns: created}, nil
+	resultRun := launchRun
+	createdFlag := len(created) > 0
+	return TriggerResult{Run: resultRun, ReviewerHandleID: handleID, Created: createdFlag, Reviews: reviews, Runs: triggerRuns, CreatedRuns: created}, nil
 }
 
 func autoReviewSessionReason(worker domain.SessionRecord, now time.Time) string {
@@ -794,7 +804,7 @@ func reviewQueue(runs []domain.ReviewRun) []ports.ReviewTask {
 // still reuse. Legacy runs may have an empty harness, which means "the same
 // resolved harness as today" for this comparison.
 func secondOpinionWanted(state PRReviewState, hasHarnessOverride, hasConfigOverride bool, harness domain.ReviewerHarness) bool {
-	if state.Status == ReviewStateIneligible || state.Status == ReviewStateRunning {
+	if state.Status == ReviewStateIneligible {
 		return false
 	}
 	if state.LatestRun == nil {
@@ -802,6 +812,9 @@ func secondOpinionWanted(state PRReviewState, hasHarnessOverride, hasConfigOverr
 	}
 	if hasConfigOverride {
 		return true
+	}
+	if state.Status == ReviewStateRunning {
+		return false
 	}
 	if !hasHarnessOverride {
 		return false

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -471,7 +471,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	triggerRuns := append([]domain.ReviewRun{}, created...)
 	triggerRuns = append(triggerRuns, runs...)
 	resultRun := launchRun
-	createdFlag := len(created) > 0
+	createdFlag := len(created) > 0 || len(restarted) > 0
 	return TriggerResult{Run: resultRun, ReviewerHandleID: handleID, Created: createdFlag, Reviews: reviews, Runs: triggerRuns, CreatedRuns: created}, nil
 }
 

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -253,8 +253,10 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	if err != nil {
 		return TriggerResult{}, err
 	}
-	hasConfigOverride := !overrideConfig.IsZero()
-	if override != "" {
+	resolvedConfig := config
+	hasHarnessOverride := override != ""
+	hasConfigOverride := !overrideConfig.IsZero() && (hasHarnessOverride || overrideConfig != resolvedConfig)
+	if hasHarnessOverride {
 		harness = override
 		if hasConfigOverride {
 			config = overrideConfig
@@ -320,7 +322,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		if source == domain.ReviewTriggerAuto && autoReviewHeadBlocked(runs, reviewState.PRURL, reviewState.TargetSHA, harness) {
 			eligible = false
 		}
-		if !eligible && !secondOpinionWanted(reviewState, override != "", hasConfigOverride, harness) {
+		if !eligible && !secondOpinionWanted(reviewState, hasHarnessOverride, hasConfigOverride, harness) {
 			continue
 		}
 		if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, reviewState.PRURL, reviewState.TargetSHA, "superseded by a review trigger for a newer commit"); err != nil {

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -394,6 +394,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	queue := reviewQueue(queueRuns)
 	launchRun := queueRuns[0]
 	previousHandleID := reviewRow.ReviewerHandleID
+	previousAgentSessionID := reviewRow.AgentSessionID
 	launchAgentSessionID := reviewRow.AgentSessionID
 	if hasConfigOverride {
 		launchAgentSessionID = ""
@@ -456,7 +457,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			if handleID != "" {
 				_ = e.launcher.Destroy(ctx, handleID)
 			}
-			_, _ = e.upsertReview(ctx, worker, harness, previousHandleID, launchAgentSessionID, now)
+			_, _ = e.upsertReview(ctx, worker, harness, previousHandleID, previousAgentSessionID, now)
 			return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w", err))
 		}
 	}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -288,25 +288,6 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			return TriggerResult{}, err
 		}
 	}
-	if hasConfigOverride {
-		if _, err := e.store.CancelRunningReviewRunsBySessionAndHarness(ctx, workerID, harness, "cancelled because reviewer config changed"); err != nil {
-			return TriggerResult{}, err
-		}
-		if err := e.resetReviewerRuntimeLocked(ctx, workerID, harness); err != nil {
-			return TriggerResult{}, err
-		}
-		reviewRow, hasReview, err = e.store.GetReviewBySessionAndHarness(ctx, workerID, harness)
-		if err != nil {
-			return TriggerResult{}, err
-		}
-		runs, err = e.store.ListReviewRunsBySession(ctx, workerID)
-		if err != nil {
-			return TriggerResult{}, err
-		}
-		if !hasReview {
-			reviewRow = domain.Review{}
-		}
-	}
 	hadRunningReviewer := reviewRunsContainRunningForHarness(runs, harness)
 	reviews := Plan(prs, runs)
 	if source == domain.ReviewTriggerAuto {
@@ -333,6 +314,11 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	}
 
 	var created []domain.ReviewRun
+	type staleSupersede struct {
+		prURL     string
+		targetSHA string
+	}
+	var pendingSupersedes []staleSupersede
 	batchID := ""
 	for _, reviewState := range reviews {
 		// A PR that is already up to date has nothing due — unless the caller asked
@@ -347,7 +333,9 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		if !eligible && !secondOpinionWanted(reviewState, hasHarnessOverride, hasConfigOverride, harness) {
 			continue
 		}
-		if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, reviewState.PRURL, reviewState.TargetSHA, "superseded by a review trigger for a newer commit"); err != nil {
+		if hasConfigOverride {
+			pendingSupersedes = append(pendingSupersedes, staleSupersede{prURL: reviewState.PRURL, targetSHA: reviewState.TargetSHA})
+		} else if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, reviewState.PRURL, reviewState.TargetSHA, "superseded by a review trigger for a newer commit"); err != nil {
 			return TriggerResult{}, err
 		}
 		if batchID == "" {
@@ -397,8 +385,12 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	}
 
 	queue := reviewQueue(created)
+	launchAgentSessionID := reviewRow.AgentSessionID
+	if hasConfigOverride {
+		launchAgentSessionID = ""
+	}
 	handleID := ""
-	if reviewRow.ReviewerHandleID != "" && reviewerPaneReusable(reviewRow, hadRunningReviewer) {
+	if !hasConfigOverride && reviewRow.ReviewerHandleID != "" && reviewerPaneReusable(reviewRow, hadRunningReviewer) {
 		alive, err := e.launcher.Alive(ctx, reviewRow.ReviewerHandleID)
 		if err != nil {
 			return TriggerResult{}, failRuns(0, err)
@@ -413,7 +405,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		if err := e.launcher.Preflight(ctx, harness, worker.Metadata.WorkspacePath); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("reviewer preflight: %w", err))
 		}
-		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, config, created[0], queue, 0, reviewRow.AgentSessionID))
+		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, config, created[0], queue, 0, launchAgentSessionID))
 		if err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("launch reviewer: %w", err))
 		}
@@ -424,6 +416,14 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	} else {
 		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, config, created[0], queue, 0, reviewRow.AgentSessionID)); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("notify reviewer: %w", err))
+		}
+	}
+	for _, stale := range pendingSupersedes {
+		if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, stale.prURL, stale.targetSHA, "superseded by a review trigger for a newer commit"); err != nil {
+			if handleID != "" {
+				_ = e.launcher.Destroy(ctx, handleID)
+			}
+			return TriggerResult{}, failRuns(0, err)
 		}
 	}
 	reviewRow, err = e.upsertReview(ctx, worker, harness, handleID, reviewRow.AgentSessionID, now)

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -436,14 +436,6 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			return TriggerResult{}, failRuns(0, err)
 		}
 	}
-	if hasConfigOverride && previousHandleID != "" && previousHandleID != handleID {
-		if err := e.launcher.Destroy(ctx, previousHandleID); err != nil {
-			if handleID != "" {
-				_ = e.launcher.Destroy(ctx, handleID)
-			}
-			return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w", err))
-		}
-	}
 	if hasConfigOverride && persistedAgentSessionID == "" && reviewRow.ID != "" {
 		if _, err := e.store.UpdateReviewAgentSessionID(ctx, reviewRow.ID, ""); err != nil {
 			if handleID != "" {
@@ -454,7 +446,19 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	}
 	reviewRow, err = e.upsertReview(ctx, worker, harness, handleID, persistedAgentSessionID, now)
 	if err != nil {
+		if handleID != "" {
+			_ = e.launcher.Destroy(ctx, handleID)
+		}
 		return TriggerResult{}, err
+	}
+	if hasConfigOverride && previousHandleID != "" && previousHandleID != handleID {
+		if err := e.launcher.Destroy(ctx, previousHandleID); err != nil {
+			if handleID != "" {
+				_ = e.launcher.Destroy(ctx, handleID)
+			}
+			_, _ = e.upsertReview(ctx, worker, harness, previousHandleID, launchAgentSessionID, now)
+			return TriggerResult{}, failRuns(0, fmt.Errorf("destroy previous reviewer: %w", err))
+		}
 	}
 	for i := range created {
 		created[i].ReviewID = reviewRow.ID

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -467,12 +467,16 @@ func (e *Engine) SwitchReviewer(
 	if err != nil {
 		return SessionReviews{}, err
 	}
-	if ok, err := e.store.SetSessionReviewerConfig(ctx, workerID, harness, config, e.clock()); err != nil {
+	persistHarness := harness
+	if persistHarness == "" && !config.IsZero() {
+		persistHarness = previousSelected
+	}
+	if ok, err := e.store.SetSessionReviewerConfig(ctx, workerID, persistHarness, config, e.clock()); err != nil {
 		return SessionReviews{}, err
 	} else if !ok {
 		return SessionReviews{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 	}
-	worker.ReviewerHarness = harness
+	worker.ReviewerHarness = persistHarness
 	worker.ReviewerConfig = config
 	selected, selectedConfig, err := e.reviewerSelection(ctx, worker)
 	if err != nil {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1226,6 +1226,9 @@ func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
 	if got := launcher.gotSpec.AgentConfig.Model; got != "gpt-5-mini" {
 		t.Fatalf("spawn config model = %q, want gpt-5-mini", got)
 	}
+	if store.review.AgentSessionID != "" {
+		t.Fatalf("replacement should clear stale native session id when launch reports none, got %q", store.review.AgentSessionID)
+	}
 }
 
 func TestTriggerConfigOverridePreflightFailurePreservesRunningReviewer(t *testing.T) {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -952,6 +952,43 @@ func TestTriggerWithSameHarnessOverrideStillReuses(t *testing.T) {
 	}
 }
 
+func TestTriggerConfigOnlyOverrideUsesResolvedHarnessAndConfig(t *testing.T) {
+	store := &fakeStore{
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	launcher := &fakeLauncher{handle: "review-mer-2"}
+	projects := fakeProjects{cfg: domain.ProjectConfig{Reviewers: []domain.ReviewerConfig{{
+		Harness:     domain.ReviewerClaudeCode,
+		AgentConfig: domain.AgentConfig{Model: "claude-old"},
+	}}}}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), projects, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{Model: "claude-new"})
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !res.Created {
+		t.Fatalf("config-only override should force a new pass: %+v", res)
+	}
+	if res.Run.Harness != domain.ReviewerClaudeCode {
+		t.Fatalf("run harness = %q, want resolved claude-code", res.Run.Harness)
+	}
+	if got := launcher.gotSpec.AgentConfig; got.Model != "claude-new" {
+		t.Fatalf("spawn config = %+v, want model override preserved", got)
+	}
+}
+
+func TestTriggerRejectsInvalidReviewerConfig(t *testing.T) {
+	eng := newEngineForTest(&fakeStore{}, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, &fakeLauncher{})
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{Mode: "turbo"}); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("err = %v, want ErrInvalid", err)
+	}
+}
+
 func TestTriggerReusesRunningRowWithNoVerdict(t *testing.T) {
 	store := &fakeStore{
 		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1407,8 +1407,8 @@ func TestTriggerConfigOverrideWhileSameCommitRunningRestartsReview(t *testing.T)
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
-	if res.Created || res.Run.ID != "run-1" {
-		t.Fatalf("expected running same-commit config override to restart the existing run: %+v", res)
+	if !res.Created || res.Run.ID != "run-1" {
+		t.Fatalf("expected running same-commit config override to restart the existing run as a fresh pass: %+v", res)
 	}
 	if !launcher.spawned || launcher.notified {
 		t.Fatalf("config override should relaunch, not reuse running pane: %+v", launcher)

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -20,6 +20,7 @@ type fakeStore struct {
 	reviews              map[domain.ReviewerHarness]domain.Review
 	runs                 []domain.ReviewRun
 	listAllReviewRunHits int
+	agentSessionUpdates  []struct{ id, agentSessionID string }
 	// insertErr, when set, makes the next InsertReviewRun model a concurrent
 	// writer that already recorded a run for this commit: it records that
 	// winner (so a follow-up GetReviewRunBySessionAndSHA finds it) and returns
@@ -130,6 +131,20 @@ func (f *fakeStore) InsertReviewRun(_ context.Context, r domain.ReviewRun) error
 	f.runs = append(f.runs, r)
 	return nil
 }
+func (f *fakeStore) UpdateReviewAgentSessionID(_ context.Context, id, agentSessionID string) (bool, error) {
+	f.agentSessionUpdates = append(f.agentSessionUpdates, struct{ id, agentSessionID string }{id: id, agentSessionID: agentSessionID})
+	if f.review != nil && f.review.ID == id {
+		f.review.AgentSessionID = agentSessionID
+	}
+	for harness, review := range f.reviews {
+		if review.ID == id {
+			review.AgentSessionID = agentSessionID
+			f.reviews[harness] = review
+		}
+	}
+	return true, nil
+}
+
 func (f *fakeStore) UpdateReviewRunResult(_ context.Context, id string, status domain.ReviewRunStatus, verdict domain.ReviewVerdict, body, githubReviewID string, autoInjectReview bool) (bool, error) {
 	for i := range f.runs {
 		if f.runs[i].ID == id {
@@ -614,6 +629,38 @@ func TestRestoreReviewerUsesSelectedHarnessSessionAndKillsOtherActivePane(t *tes
 	}
 	if store.review.Harness != domain.ReviewerOpenCode || store.review.ReviewerHandleID != "opencode-pane" || store.review.AgentSessionID != "opencode-native" {
 		t.Fatalf("active review row = %+v, want restored opencode", store.review)
+	}
+}
+
+func TestSwitchReviewerRestartsLivePaneWhenOnlyConfigChanges(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "codex-pane", AgentSessionID: "codex-native"},
+		reviews: map[domain.ReviewerHarness]domain.Review{
+			domain.ReviewerCodex: {ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "codex-pane", AgentSessionID: "codex-native"},
+		},
+		runs: []domain.ReviewRun{{ID: "codex-run", ReviewID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerCodex
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-old"}
+	launcher := &fakeLauncher{alive: true, handle: "codex-pane-2"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.SwitchReviewer(context.Background(), "mer-1", domain.ReviewerCodex, domain.AgentConfig{Model: "gpt-new"})
+	if err != nil {
+		t.Fatalf("SwitchReviewer: %v", err)
+	}
+	if !launcher.destroyed || launcher.destroyedHandle != "codex-pane" {
+		t.Fatalf("expected active pane destroyed: %+v", launcher)
+	}
+	if !launcher.restored || launcher.gotSpec.AgentConfig.Model != "gpt-new" || launcher.gotSpec.AgentSessionID != "" {
+		t.Fatalf("restore spec = %+v, want restarted with new config and no native session", launcher.gotSpec)
+	}
+	if len(store.agentSessionUpdates) != 1 || store.agentSessionUpdates[0].agentSessionID != "" {
+		t.Fatalf("agent session updates = %+v, want cleared native session", store.agentSessionUpdates)
+	}
+	if res.ReviewerHandleID != "codex-pane-2" || res.ReviewerHarness != domain.ReviewerCodex {
+		t.Fatalf("result = %+v", res)
 	}
 }
 

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -45,7 +45,7 @@ func (f *fakeStore) UpsertReview(_ context.Context, r domain.Review) error {
 	f.reviews[r.Harness] = cp
 	return nil
 }
-func (f *fakeStore) SetSessionReviewerHarness(_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ time.Time) (bool, error) {
+func (f *fakeStore) SetSessionReviewerConfig(_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ time.Time) (bool, error) {
 	return true, nil
 }
 func (f *fakeStore) GetReviewBySession(_ context.Context, _ domain.SessionID) (domain.Review, bool, error) {
@@ -368,7 +368,7 @@ func TestTriggerSpawnsNewReviewerAndRecordsRunAfterLaunch(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -671,7 +671,7 @@ func TestTerminateReviewerWaitsForInFlightTriggerSpawn(t *testing.T) {
 
 	triggerDone := make(chan error, 1)
 	go func() {
-		_, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerCodex)
+		_, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerCodex, domain.AgentConfig{})
 		triggerDone <- err
 	}()
 	<-spawnStarted
@@ -757,7 +757,7 @@ func TestTriggerConcurrentSameWorkerSpawnsOnce(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func(i int) {
 			defer wg.Done()
-			results[i], errs[i] = eng.Trigger(context.Background(), "mer-1", "")
+			results[i], errs[i] = eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 		}(i)
 	}
 	wg.Wait()
@@ -790,7 +790,7 @@ func TestTriggerSnapshotsDisabledInjectionPolicy(t *testing.T) {
 	worker.AutoInjectReview = false
 	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, &fakeLauncher{handle: "review-mer-1"})
 
-	result, err := eng.Trigger(context.Background(), worker.ID, "")
+	result, err := eng.Trigger(context.Background(), worker.ID, "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -806,7 +806,7 @@ func TestTriggerFallsBackToExistingRunOnUniqueConflict(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -834,7 +834,7 @@ func TestTriggerDuplicateFallbackUsesRequestedHarness(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerCodex)
+	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerCodex, domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -860,7 +860,7 @@ func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -891,7 +891,7 @@ func TestTriggerRunsAnotherHarnessOnAnAlreadyApprovedCommit(t *testing.T) {
 	launcher := &fakeLauncher{alive: true}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerCodex)
+	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerCodex, domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -920,7 +920,7 @@ func TestTriggerWithoutOverrideStillSkipsAnApprovedCommit(t *testing.T) {
 	launcher := &fakeLauncher{alive: true}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -943,7 +943,7 @@ func TestTriggerWithSameHarnessOverrideStillReuses(t *testing.T) {
 	launcher := &fakeLauncher{alive: true}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode)
+	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -960,7 +960,7 @@ func TestTriggerReusesRunningRowWithNoVerdict(t *testing.T) {
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-2"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -983,7 +983,7 @@ func TestTriggerRetriesRunningRowWhenReviewerDead(t *testing.T) {
 	launcher := &fakeLauncher{alive: false, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1012,7 +1012,7 @@ func TestTriggerRetriesTerminalRowWithNoVerdict(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-2"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1032,7 +1032,7 @@ func TestTriggerReusesReviewerOnNewCommit(t *testing.T) {
 	launcher := &fakeLauncher{alive: true}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1055,7 +1055,7 @@ func TestTriggerSupersedesOlderRunningRunOnNewCommit(t *testing.T) {
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1078,7 +1078,7 @@ func TestTriggerReusesRunningReviewerBeforeAgentSessionIDRecorded(t *testing.T) 
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	if _, err := eng.Trigger(context.Background(), "mer-1", ""); err != nil {
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
 	if !launcher.notified || launcher.spawned {
@@ -1094,7 +1094,7 @@ func TestTriggerRestoresWhenRecordedReviewerDead(t *testing.T) {
 	launcher := &fakeLauncher{alive: false, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	if _, err := eng.Trigger(context.Background(), "mer-1", ""); err != nil {
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
 	if !launcher.spawned || launcher.restored || launcher.notified {
@@ -1111,7 +1111,7 @@ func TestTriggerSpawnsFreshPassForNonReusableReviewer(t *testing.T) {
 	projects := fakeProjects{cfg: domain.ProjectConfig{Reviewers: []domain.ReviewerConfig{{Harness: domain.ReviewerAuggie}}}}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), projects, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1134,7 +1134,7 @@ func TestTriggerRespawnsLivePaneWithoutReviewerAgentSession(t *testing.T) {
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	if _, err := eng.Trigger(context.Background(), "mer-1", ""); err != nil {
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
 	if !launcher.spawned || launcher.notified {
@@ -1156,7 +1156,7 @@ func TestTriggerRespawnsWhenReviewerHarnessChanged(t *testing.T) {
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1188,7 +1188,7 @@ func TestTriggerSwitchKillsOldReviewerWhenNothingCreated(t *testing.T) {
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1219,7 +1219,7 @@ func TestTriggerRespawnsOnNextCommitAfterHarnessSwitchWithNoRun(t *testing.T) {
 	// the worker now resolves to claude-code but the live pane is still codex.
 	l1 := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng1 := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, l1)
-	if _, err := eng1.Trigger(context.Background(), "mer-1", ""); err != nil {
+	if _, err := eng1.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); err != nil {
 		t.Fatalf("trigger 1: %v", err)
 	}
 	if l1.spawned || l1.notified {
@@ -1230,7 +1230,7 @@ func TestTriggerRespawnsOnNextCommitAfterHarnessSwitchWithNoRun(t *testing.T) {
 	// respawn under claude-code, not Notify the stale codex pane.
 	l2 := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng2 := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha2"), fakeProjects{}, l2)
-	res, err := eng2.Trigger(context.Background(), "mer-1", "")
+	res, err := eng2.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("trigger 2: %v", err)
 	}
@@ -1247,7 +1247,7 @@ func TestTriggerLaunchFailureRecordsFailedRun(t *testing.T) {
 	launcher := &fakeLauncher{spawnErr: fmt.Errorf("claude: %w", ports.ErrAgentBinaryNotFound)}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	if _, err := eng.Trigger(context.Background(), "mer-1", ""); !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); !errors.Is(err, ports.ErrAgentBinaryNotFound) {
 		t.Fatalf("err = %v, want ports.ErrAgentBinaryNotFound", err)
 	}
 	if store.review == nil || len(store.runs) != 1 {
@@ -1270,7 +1270,7 @@ func TestTriggerRetriesAfterFailedRunForSameCommit(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1290,7 +1290,7 @@ func TestTriggerRetriesAfterCancelledRunForSameCommit(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1310,7 +1310,7 @@ func TestAutoTriggerWaitsForNewCommitAfterCancelledRun(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.ReviewTriggerAuto)
+	res, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{}, domain.ReviewTriggerAuto)
 	if err != nil {
 		t.Fatalf("TriggerWithSource: %v", err)
 	}
@@ -1336,7 +1336,7 @@ func TestAutoTriggerDoesNotAppendPRToLiveRunningReviewer(t *testing.T) {
 	}}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prs, fakeProjects{}, launcher)
 
-	res, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.ReviewTriggerAuto)
+	res, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{}, domain.ReviewTriggerAuto)
 	if err != nil {
 		t.Fatalf("TriggerWithSource: %v", err)
 	}
@@ -1365,7 +1365,7 @@ func TestAutoTriggerReconcilesDeadReviewerBeforeRunningGate(t *testing.T) {
 	}}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prs, fakeProjects{}, launcher)
 
-	res, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.ReviewTriggerAuto)
+	res, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{}, domain.ReviewTriggerAuto)
 	if err != nil {
 		t.Fatalf("TriggerWithSource: %v", err)
 	}
@@ -1398,7 +1398,7 @@ func TestAutoTriggerRevalidatesSessionPolicyUnderLock(t *testing.T) {
 			launcher := &fakeLauncher{handle: "review-mer-1"}
 			eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-			result, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.ReviewTriggerAuto)
+			result, err := eng.TriggerWithSource(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{}, domain.ReviewTriggerAuto)
 			if err != nil {
 				t.Fatalf("TriggerWithSource: %v", err)
 			}
@@ -1418,7 +1418,7 @@ func TestTriggerCreatesRunsForMultipleEligiblePRsWithOneReviewer(t *testing.T) {
 	}}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prs, fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1458,7 +1458,7 @@ func TestTriggerAllowsTwoPRsWithSameHeadSHA(t *testing.T) {
 	}}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prs, fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1485,7 +1485,7 @@ func TestTriggerRerunsApprovedAndReusesRunningCurrentHead(t *testing.T) {
 	}}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prs, fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1514,7 +1514,7 @@ func TestTriggerRerunsChangesRequestedCurrentHead(t *testing.T) {
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1532,7 +1532,7 @@ func TestTriggerUsesConfiguredReviewerHarness(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), projects, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1549,7 +1549,7 @@ func TestTriggerUsesSessionReviewerHarnessBeforeProjectDefault(t *testing.T) {
 	worker.ReviewerHarness = domain.ReviewerOpenCode
 	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), projects, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
@@ -1561,13 +1561,13 @@ func TestTriggerUsesSessionReviewerHarnessBeforeProjectDefault(t *testing.T) {
 func TestTriggerRejectsBadWorkerState(t *testing.T) {
 	t.Run("unknown worker", func(t *testing.T) {
 		eng := newEngineForTest(&fakeStore{}, fakeSessions{ok: false}, prAt("sha1"), fakeProjects{}, &fakeLauncher{})
-		if _, err := eng.Trigger(context.Background(), "mer-1", ""); !errors.Is(err, ErrNotFound) {
+		if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); !errors.Is(err, ErrNotFound) {
 			t.Fatalf("err = %v, want ErrNotFound", err)
 		}
 	})
 	t.Run("no pr", func(t *testing.T) {
 		eng := newEngineForTest(&fakeStore{}, fakeSessions{rec: liveWorker(), ok: true}, fakePRs{}, fakeProjects{}, &fakeLauncher{})
-		if _, err := eng.Trigger(context.Background(), "mer-1", ""); !errors.Is(err, ErrInvalid) {
+		if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); !errors.Is(err, ErrInvalid) {
 			t.Fatalf("err = %v, want ErrInvalid", err)
 		}
 	})
@@ -1618,7 +1618,7 @@ func TestTriggerPreflightFailureRecordsFailedRun(t *testing.T) {
 	launcher := &fakeLauncher{preflightErr: fmt.Errorf("codex: %w", ports.ErrAgentBinaryNotFound)}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	_, err := eng.Trigger(context.Background(), "mer-1", "")
+	_, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err == nil {
 		t.Fatal("expected error from preflight, got nil")
 	}
@@ -1648,7 +1648,7 @@ func TestTriggerProceedsNormallyAfterSuccessfulPreflight(t *testing.T) {
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	res, err := eng.Trigger(context.Background(), "mer-1", "")
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1079,6 +1079,29 @@ func TestTriggerConfigOnlyOverrideMergesResolvedConfig(t *testing.T) {
 	}
 }
 
+func TestTriggerSameHarnessOverrideMergesResolvedConfig(t *testing.T) {
+	store := &fakeStore{
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	launcher := &fakeLauncher{handle: "review-mer-2"}
+	projects := fakeProjects{cfg: domain.ProjectConfig{Reviewers: []domain.ReviewerConfig{{
+		Harness:     domain.ReviewerClaudeCode,
+		AgentConfig: domain.AgentConfig{Model: "claude-old", Permissions: domain.PermissionModeBypassPermissions},
+	}}}}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), projects, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "claude-new"}); err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if got := launcher.gotSpec.AgentConfig; got.Model != "claude-new" || got.Permissions != domain.PermissionModeBypassPermissions {
+		t.Fatalf("spawn config = %+v, want explicit same-harness override merged with inherited permissions", got)
+	}
+}
+
 func TestReviewerSelectionMergesSessionConfigWithProjectReviewerConfig(t *testing.T) {
 	worker := liveWorker()
 	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1217,8 +1217,8 @@ func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
 	if !res.Created {
 		t.Fatalf("expected new run for config override: %+v", res)
 	}
-	if !launcher.destroyed || launcher.destroyedHandle != "review-mer-1" {
-		t.Fatalf("expected existing reviewer pane destroyed: %+v", launcher)
+	if launcher.destroyed {
+		t.Fatalf("engine should not destroy the existing pane before replacement spawn succeeds: %+v", launcher)
 	}
 	if !launcher.spawned || launcher.notified {
 		t.Fatalf("config override should relaunch, not notify existing pane: %+v", launcher)
@@ -1226,8 +1226,63 @@ func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
 	if got := launcher.gotSpec.AgentConfig.Model; got != "gpt-5-mini" {
 		t.Fatalf("spawn config model = %q, want gpt-5-mini", got)
 	}
-	if len(store.agentSessionUpdates) != 1 || store.agentSessionUpdates[0].agentSessionID != "" {
-		t.Fatalf("agent session updates = %+v, want cleared native session", store.agentSessionUpdates)
+}
+
+func TestTriggerConfigOverridePreflightFailurePreservesRunningReviewer(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunRunning, Verdict: domain.VerdictNone,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, preflightErr: errors.New("missing binary")}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha2"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5-mini"}); err == nil || !strings.Contains(err.Error(), "reviewer preflight") {
+		t.Fatalf("Trigger error = %v, want reviewer preflight failure", err)
+	}
+	if !launcher.preflighted || launcher.destroyed || launcher.notified || launcher.spawned {
+		t.Fatalf("replacement should fail before touching the live reviewer: %+v", launcher)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunRunning {
+		t.Fatalf("running review should remain active, got %+v", got)
+	}
+	if len(store.runs) != 2 || store.runs[1].Status != domain.ReviewRunFailed {
+		t.Fatalf("runs = %+v, want old running run plus failed replacement run", store.runs)
+	}
+}
+
+func TestTriggerConfigOverrideLaunchFailurePreservesRunningReviewer(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunRunning, Verdict: domain.VerdictNone,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, spawnErr: errors.New("create failed")}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha2"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5-mini"}); err == nil || !strings.Contains(err.Error(), "launch reviewer") {
+		t.Fatalf("Trigger error = %v, want launch failure", err)
+	}
+	if !launcher.preflighted || !launcher.spawned || launcher.destroyed || launcher.notified {
+		t.Fatalf("replacement should fail without cancelling the live reviewer state first: %+v", launcher)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunRunning {
+		t.Fatalf("running review should remain active, got %+v", got)
+	}
+	if len(store.runs) != 2 || store.runs[1].Status != domain.ReviewRunFailed {
+		t.Fatalf("runs = %+v, want old running run plus failed replacement run", store.runs)
 	}
 }
 

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -292,6 +292,8 @@ type fakeLauncher struct {
 	destroyed        bool
 	destroyedHandle  string
 	destroyErr       error
+	destroyErrCall   int
+	destroyCalls     int
 	specs            []LaunchSpec
 	handles          []string
 	aliveChecked     bool
@@ -354,10 +356,14 @@ func (f *fakeLauncher) Cancel(_ context.Context, handleID string, harness domain
 func (f *fakeLauncher) Destroy(_ context.Context, handleID string) error {
 	f.destroyed = true
 	f.destroyedHandle = handleID
+	f.destroyCalls++
 	if f.destroyCalled != nil {
 		f.destroyCalled <- handleID
 	}
-	return f.destroyErr
+	if f.destroyErr != nil && (f.destroyErrCall == 0 || f.destroyErrCall == f.destroyCalls) {
+		return f.destroyErr
+	}
+	return nil
 }
 func (f *fakeLauncher) Preflight(_ context.Context, _ domain.ReviewerHarness, _ string) error {
 	f.preflighted = true
@@ -1235,6 +1241,29 @@ func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
 	}
 	if store.review.AgentSessionID != "" {
 		t.Fatalf("replacement should clear stale native session id when launch reports none, got %q", store.review.AgentSessionID)
+	}
+}
+
+func TestTriggerConfigOverrideDestroyPreviousFailureRestoresOldNativeSessionID(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-2", destroyErr: errors.New("destroy old failed"), destroyErrCall: 1}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5-mini"}); err == nil || !strings.Contains(err.Error(), "destroy previous reviewer") {
+		t.Fatalf("Trigger error = %v, want destroy previous reviewer failure", err)
+	}
+	if store.review == nil || store.review.ReviewerHandleID != "review-mer-1" || store.review.AgentSessionID != "native-reviewer-1" {
+		t.Fatalf("stored review row = %+v, want rollback to old handle and native session id", store.review)
 	}
 }
 

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1003,6 +1003,33 @@ func TestTriggerWithPersistedReviewerConfigStillReusesSameCommit(t *testing.T) {
 	}
 }
 
+func TestTriggerWithPersistedReviewerConfigAndSameHarnessOverrideStillReusesSameCommit(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if res.Created || res.Run.ID != "run-1" || len(store.runs) != 1 {
+		t.Fatalf("same persisted config with same harness override should reuse existing pass: %+v runs=%+v", res, store.runs)
+	}
+	if launcher.spawned || launcher.notified {
+		t.Fatalf("should not relaunch for unchanged persisted reviewer config with same harness override: %+v", launcher)
+	}
+}
+
 // Re-picking the harness that already reviewed this commit is not a second
 // opinion, so it must still reuse rather than run the same agent twice.
 func TestTriggerWithSameHarnessOverrideStillReuses(t *testing.T) {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -16,11 +16,16 @@ import (
 // --- fakes ---
 
 type fakeStore struct {
-	review               *domain.Review
-	reviews              map[domain.ReviewerHarness]domain.Review
-	runs                 []domain.ReviewRun
-	listAllReviewRunHits int
-	agentSessionUpdates  []struct{ id, agentSessionID string }
+	review                *domain.Review
+	reviews               map[domain.ReviewerHarness]domain.Review
+	runs                  []domain.ReviewRun
+	listAllReviewRunHits  int
+	agentSessionUpdates   []struct{ id, agentSessionID string }
+	reviewerConfigUpdates []struct {
+		sessionID domain.SessionID
+		harness   domain.ReviewerHarness
+		config    domain.AgentConfig
+	}
 	// insertErr, when set, makes the next InsertReviewRun model a concurrent
 	// writer that already recorded a run for this commit: it records that
 	// winner (so a follow-up GetReviewRunBySessionAndSHA finds it) and returns
@@ -46,7 +51,12 @@ func (f *fakeStore) UpsertReview(_ context.Context, r domain.Review) error {
 	f.reviews[r.Harness] = cp
 	return nil
 }
-func (f *fakeStore) SetSessionReviewerConfig(_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ time.Time) (bool, error) {
+func (f *fakeStore) SetSessionReviewerConfig(_ context.Context, id domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig, _ time.Time) (bool, error) {
+	f.reviewerConfigUpdates = append(f.reviewerConfigUpdates, struct {
+		sessionID domain.SessionID
+		harness   domain.ReviewerHarness
+		config    domain.AgentConfig
+	}{sessionID: id, harness: harness, config: config})
 	return true, nil
 }
 func (f *fakeStore) GetReviewBySession(_ context.Context, _ domain.SessionID) (domain.Review, bool, error) {
@@ -661,6 +671,42 @@ func TestSwitchReviewerRestartsLivePaneWhenOnlyConfigChanges(t *testing.T) {
 	}
 	if res.ReviewerHandleID != "codex-pane-2" || res.ReviewerHarness != domain.ReviewerCodex {
 		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestSwitchReviewerPinsResolvedHarnessWhenSavingDefaultReviewerConfig(t *testing.T) {
+	store := &fakeStore{}
+	worker := liveWorker()
+	launcher := &fakeLauncher{handle: "review-mer-2"}
+	projects := fakeProjects{cfg: domain.ProjectConfig{Reviewers: []domain.ReviewerConfig{{
+		Harness: domain.ReviewerClaudeCode,
+	}}}}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), projects, launcher)
+
+	res, err := eng.SwitchReviewer(context.Background(), "mer-1", "", domain.AgentConfig{Model: "claude-3.7"})
+	if err != nil {
+		t.Fatalf("SwitchReviewer: %v", err)
+	}
+	if len(store.reviewerConfigUpdates) != 1 {
+		t.Fatalf("reviewer config updates = %+v, want one", store.reviewerConfigUpdates)
+	}
+	if got := store.reviewerConfigUpdates[0]; got.harness != domain.ReviewerClaudeCode || got.config.Model != "claude-3.7" {
+		t.Fatalf("persisted reviewer config = %+v, want pinned claude-code + model", got)
+	}
+	if res.ReviewerHarness != domain.ReviewerClaudeCode {
+		t.Fatalf("result reviewer harness = %q, want claude-code", res.ReviewerHarness)
+	}
+	worker.ReviewerHarness = store.reviewerConfigUpdates[0].harness
+	worker.ReviewerConfig = store.reviewerConfigUpdates[0].config
+	eng.projects = fakeProjects{cfg: domain.ProjectConfig{Reviewers: []domain.ReviewerConfig{{
+		Harness: domain.ReviewerOpenCode,
+	}}}}
+	selected, selectedConfig, err := eng.reviewerSelection(context.Background(), worker)
+	if err != nil {
+		t.Fatalf("reviewerSelection after project change: %v", err)
+	}
+	if selected != domain.ReviewerClaudeCode || selectedConfig.Model != "claude-3.7" {
+		t.Fatalf("selection after project reviewer change = (%q, %+v), want pinned claude-code config", selected, selectedConfig)
 	}
 }
 

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1293,6 +1293,42 @@ func TestTriggerRejectsInvalidReviewerConfig(t *testing.T) {
 	}
 }
 
+func TestTriggerConfigOverrideWhileSameCommitRunningRestartsReview(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunRunning, Verdict: domain.VerdictNone,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-2"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5-mini"})
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if res.Created || res.Run.ID != "run-1" {
+		t.Fatalf("expected running same-commit config override to restart the existing run: %+v", res)
+	}
+	if !launcher.spawned || launcher.notified {
+		t.Fatalf("config override should relaunch, not reuse running pane: %+v", launcher)
+	}
+	if got := launcher.gotSpec.AgentConfig.Model; got != "gpt-5-mini" {
+		t.Fatalf("spawn config model = %q, want gpt-5-mini", got)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunRunning {
+		t.Fatalf("running run should stay active in storage while the pane restarts, got %+v", got)
+	}
+	if len(store.runs) != 1 {
+		t.Fatalf("runs = %+v, want the existing running run to be reused", store.runs)
+	}
+}
+
 func TestTriggerReusesRunningRowWithNoVerdict(t *testing.T) {
 	store := &fakeStore{
 		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1244,6 +1244,34 @@ func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
 	}
 }
 
+func TestTriggerConfigOverrideRollbackUpsertFailureKeepsReplacementHandleTracked(t *testing.T) {
+	store := &fakeStore{
+		review:        &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		upsertErr:     errors.New("rollback failed"),
+		upsertErrCall: 3,
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-2", destroyErr: errors.New("destroy old failed"), destroyErrCall: 1}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5-mini"}); err == nil || !strings.Contains(err.Error(), "rollback review row") {
+		t.Fatalf("Trigger error = %v, want rollback review row failure", err)
+	}
+	if store.review == nil || store.review.ReviewerHandleID != "review-mer-2" || store.review.AgentSessionID != "" {
+		t.Fatalf("stored review row = %+v, want replacement handle to remain authoritative", store.review)
+	}
+	if launcher.destroyCalls != 1 || launcher.destroyedHandle != "review-mer-1" {
+		t.Fatalf("launcher destroy calls = %d handle=%q, want only failed old-handle destroy", launcher.destroyCalls, launcher.destroyedHandle)
+	}
+}
+
 func TestTriggerConfigOverrideDestroyPreviousFailureRestoresOldNativeSessionID(t *testing.T) {
 	store := &fakeStore{
 		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1056,6 +1056,49 @@ func TestTriggerConfigOnlyOverrideUsesResolvedHarnessAndConfig(t *testing.T) {
 	}
 }
 
+func TestTriggerConfigOnlyOverrideMergesResolvedConfig(t *testing.T) {
+	store := &fakeStore{
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	launcher := &fakeLauncher{handle: "review-mer-2"}
+	projects := fakeProjects{cfg: domain.ProjectConfig{Reviewers: []domain.ReviewerConfig{{
+		Harness:     domain.ReviewerClaudeCode,
+		AgentConfig: domain.AgentConfig{Model: "claude-old", Permissions: domain.PermissionModeBypassPermissions},
+	}}}}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), projects, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{Model: "claude-new"}); err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if got := launcher.gotSpec.AgentConfig; got.Model != "claude-new" || got.Permissions != domain.PermissionModeBypassPermissions {
+		t.Fatalf("spawn config = %+v, want merged override plus inherited permissions", got)
+	}
+}
+
+func TestReviewerSelectionMergesSessionConfigWithProjectReviewerConfig(t *testing.T) {
+	worker := liveWorker()
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	eng := newEngineForTest(&fakeStore{}, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{cfg: domain.ProjectConfig{Reviewers: []domain.ReviewerConfig{{
+		Harness:     domain.ReviewerClaudeCode,
+		AgentConfig: domain.AgentConfig{Permissions: domain.PermissionModeBypassPermissions},
+	}}}}, &fakeLauncher{})
+
+	harness, config, err := eng.reviewerSelection(context.Background(), worker)
+	if err != nil {
+		t.Fatalf("reviewerSelection: %v", err)
+	}
+	if harness != domain.ReviewerClaudeCode {
+		t.Fatalf("harness = %q, want claude-code", harness)
+	}
+	if config.Model != "gpt-5" || config.Permissions != domain.PermissionModeBypassPermissions {
+		t.Fatalf("config = %+v, want merged session override + project permissions", config)
+	}
+}
+
 func TestTriggerRejectsInvalidReviewerConfig(t *testing.T) {
 	eng := newEngineForTest(&fakeStore{}, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, &fakeLauncher{})
 	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{Mode: "turbo"}); !errors.Is(err, ErrInvalid) {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1012,6 +1012,45 @@ func TestTriggerRunsAnotherHarnessOnAnAlreadyApprovedCommit(t *testing.T) {
 	}
 }
 
+func TestTriggerHarnessOverrideDoesNotRestartRunningReviewJustBecauseResolvedConfigIsNonEmpty(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "codex-pane"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunRunning, Verdict: domain.VerdictNone,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "codex-pane"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerCodex, domain.AgentConfig{})
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !res.Created {
+		t.Fatalf("different harness should still create a second-opinion run: %+v", res)
+	}
+	if len(store.runs) != 2 {
+		t.Fatalf("runs = %+v, want original running pass plus new second-opinion run", store.runs)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunRunning || got.Harness != domain.ReviewerClaudeCode {
+		t.Fatalf("original run = %+v, want unchanged running claude-code pass", got)
+	}
+	if got := store.runs[1]; got.Harness != domain.ReviewerCodex || got.Status != domain.ReviewRunRunning {
+		t.Fatalf("new run = %+v, want running codex second-opinion pass", got)
+	}
+	if launcher.notified {
+		t.Fatalf("different harness should spawn a second-opinion reviewer, not notify existing pane: %+v", launcher)
+	}
+	if !launcher.spawned {
+		t.Fatalf("expected a new reviewer process for the different harness: %+v", launcher)
+	}
+}
+
 // The project default must not re-review an approved commit on every trigger.
 // Only an explicit pick counts as asking for a second opinion.
 func TestTriggerWithoutOverrideStillSkipsAnApprovedCommit(t *testing.T) {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -26,6 +26,9 @@ type fakeStore struct {
 		harness   domain.ReviewerHarness
 		config    domain.AgentConfig
 	}
+	upsertErr     error
+	upsertErrCall int
+	upsertCalls   int
 	// insertErr, when set, makes the next InsertReviewRun model a concurrent
 	// writer that already recorded a run for this commit: it records that
 	// winner (so a follow-up GetReviewRunBySessionAndSHA finds it) and returns
@@ -35,6 +38,10 @@ type fakeStore struct {
 }
 
 func (f *fakeStore) UpsertReview(_ context.Context, r domain.Review) error {
+	f.upsertCalls++
+	if f.upsertErr != nil && f.upsertCalls == f.upsertErrCall {
+		return f.upsertErr
+	}
 	cp := r
 	f.review = &cp
 	if f.reviews == nil {
@@ -1228,6 +1235,34 @@ func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
 	}
 	if store.review.AgentSessionID != "" {
 		t.Fatalf("replacement should clear stale native session id when launch reports none, got %q", store.review.AgentSessionID)
+	}
+}
+
+func TestTriggerConfigOverrideFinalUpsertFailurePreservesStoredReviewerHandle(t *testing.T) {
+	store := &fakeStore{
+		review:        &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		upsertErr:     errors.New("write failed"),
+		upsertErrCall: 2,
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-2"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5-mini"}); err == nil || !strings.Contains(err.Error(), "write failed") {
+		t.Fatalf("Trigger error = %v, want final upsert failure", err)
+	}
+	if !launcher.spawned || !launcher.destroyed || launcher.destroyedHandle != "review-mer-2" {
+		t.Fatalf("replacement reviewer should be cleaned up after upsert failure: %+v", launcher)
+	}
+	if store.review == nil || store.review.ReviewerHandleID != "review-mer-1" || store.review.AgentSessionID != "" {
+		t.Fatalf("stored review row = %+v, want old handle retained with cleared stale native id", store.review)
 	}
 }
 

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -976,6 +976,33 @@ func TestTriggerWithoutOverrideStillSkipsAnApprovedCommit(t *testing.T) {
 	}
 }
 
+func TestTriggerWithPersistedReviewerConfigStillReusesSameCommit(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if res.Created || res.Run.ID != "run-1" || len(store.runs) != 1 {
+		t.Fatalf("same persisted config should reuse existing pass: %+v runs=%+v", res, store.runs)
+	}
+	if launcher.spawned || launcher.notified {
+		t.Fatalf("should not relaunch for unchanged persisted reviewer config: %+v", launcher)
+	}
+}
+
 // Re-picking the harness that already reviewed this commit is not a second
 // opinion, so it must still reuse rather than run the same agent twice.
 func TestTriggerWithSameHarnessOverrideStillReuses(t *testing.T) {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -687,7 +687,7 @@ func TestSwitchReviewerRestartsLivePaneWhenOnlyConfigChanges(t *testing.T) {
 	}
 }
 
-func TestSwitchReviewerPinsResolvedHarnessWhenSavingDefaultReviewerConfig(t *testing.T) {
+func TestSwitchReviewerKeepsDefaultReviewerInheritanceWhenSavingConfig(t *testing.T) {
 	store := &fakeStore{}
 	worker := liveWorker()
 	launcher := &fakeLauncher{handle: "review-mer-2"}
@@ -703,8 +703,8 @@ func TestSwitchReviewerPinsResolvedHarnessWhenSavingDefaultReviewerConfig(t *tes
 	if len(store.reviewerConfigUpdates) != 1 {
 		t.Fatalf("reviewer config updates = %+v, want one", store.reviewerConfigUpdates)
 	}
-	if got := store.reviewerConfigUpdates[0]; got.harness != domain.ReviewerClaudeCode || got.config.Model != "claude-3.7" {
-		t.Fatalf("persisted reviewer config = %+v, want pinned claude-code + model", got)
+	if got := store.reviewerConfigUpdates[0]; got.harness != "" || got.config.Model != "claude-3.7" {
+		t.Fatalf("persisted reviewer config = %+v, want default reviewer + model", got)
 	}
 	if res.ReviewerHarness != domain.ReviewerClaudeCode {
 		t.Fatalf("result reviewer harness = %q, want claude-code", res.ReviewerHarness)
@@ -718,8 +718,8 @@ func TestSwitchReviewerPinsResolvedHarnessWhenSavingDefaultReviewerConfig(t *tes
 	if err != nil {
 		t.Fatalf("reviewerSelection after project change: %v", err)
 	}
-	if selected != domain.ReviewerClaudeCode || selectedConfig.Model != "claude-3.7" {
-		t.Fatalf("selection after project reviewer change = (%q, %+v), want pinned claude-code config", selected, selectedConfig)
+	if selected != domain.ReviewerOpenCode || selectedConfig.Model != "claude-3.7" {
+		t.Fatalf("selection after project reviewer change = (%q, %+v), want inherited opencode config", selected, selectedConfig)
 	}
 }
 

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1195,6 +1195,42 @@ func TestReviewerSelectionMergesSessionConfigWithProjectReviewerConfig(t *testin
 	}
 }
 
+func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1", AgentSessionID: "native-reviewer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Harness: domain.ReviewerClaudeCode,
+			Status:  domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	worker.ReviewerConfig = domain.AgentConfig{Model: "gpt-5"}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-2"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1", domain.ReviewerClaudeCode, domain.AgentConfig{Model: "gpt-5-mini"})
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !res.Created {
+		t.Fatalf("expected new run for config override: %+v", res)
+	}
+	if !launcher.destroyed || launcher.destroyedHandle != "review-mer-1" {
+		t.Fatalf("expected existing reviewer pane destroyed: %+v", launcher)
+	}
+	if !launcher.spawned || launcher.notified {
+		t.Fatalf("config override should relaunch, not notify existing pane: %+v", launcher)
+	}
+	if got := launcher.gotSpec.AgentConfig.Model; got != "gpt-5-mini" {
+		t.Fatalf("spawn config model = %q, want gpt-5-mini", got)
+	}
+	if len(store.agentSessionUpdates) != 1 || store.agentSessionUpdates[0].agentSessionID != "" {
+		t.Fatalf("agent session updates = %+v, want cleared native session", store.agentSessionUpdates)
+	}
+}
+
 func TestTriggerRejectsInvalidReviewerConfig(t *testing.T) {
 	eng := newEngineForTest(&fakeStore{}, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, &fakeLauncher{})
 	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{Mode: "turbo"}); !errors.Is(err, ErrInvalid) {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1217,8 +1217,8 @@ func TestTriggerConfigOverrideRestartsAliveReviewerPane(t *testing.T) {
 	if !res.Created {
 		t.Fatalf("expected new run for config override: %+v", res)
 	}
-	if launcher.destroyed {
-		t.Fatalf("engine should not destroy the existing pane before replacement spawn succeeds: %+v", launcher)
+	if !launcher.destroyed || launcher.destroyedHandle != "review-mer-1" {
+		t.Fatalf("expected old reviewer pane destroyed after replacement launch: %+v", launcher)
 	}
 	if !launcher.spawned || launcher.notified {
 		t.Fatalf("config override should relaunch, not notify existing pane: %+v", launcher)

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -52,7 +52,7 @@ func reviewErrorKind(err error) string {
 
 // Manager is the reviews surface the HTTP controller depends on.
 type Manager interface {
-	Trigger(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness) (reviewcore.TriggerResult, error)
+	Trigger(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig) (reviewcore.TriggerResult, error)
 	RequestRereview(ctx context.Context, workerID domain.SessionID, prURL, reviewer string) error
 	ResolveReviewComment(ctx context.Context, workerID domain.SessionID, prURL, commentURL string) error
 	TriggerAuto(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness) (reviewcore.TriggerResult, error)
@@ -60,7 +60,7 @@ type Manager interface {
 	TerminateReviewer(ctx context.Context, workerID domain.SessionID, body string) error
 	TeardownReviewerTerminal(ctx context.Context, workerID domain.SessionID) error
 	RestoreReviewer(ctx context.Context, workerID domain.SessionID) error
-	SwitchReviewer(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness) (reviewcore.SessionReviews, error)
+	SwitchReviewer(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig) (reviewcore.SessionReviews, error)
 	ApplyReviewActivitySignal(ctx context.Context, reviewSessionID string, signal ActivitySignal) error
 	Submit(ctx context.Context, workerID domain.SessionID, runID string, verdict domain.ReviewVerdict, body, githubReviewID string) (domain.ReviewRun, error)
 	SubmitMany(ctx context.Context, workerID domain.SessionID, reviews []SubmittedReview) ([]domain.ReviewRun, error)
@@ -79,7 +79,7 @@ type Service struct {
 	// engineTrigger indirects the engine's source-tagged trigger so the
 	// instrumented path can be exercised without standing up a full engine and
 	// its eighteen-method store. Defaulted in New; only tests replace it.
-	engineTrigger func(context.Context, domain.SessionID, domain.ReviewerHarness, domain.ReviewTriggerSource) (reviewcore.TriggerResult, error)
+	engineTrigger func(context.Context, domain.SessionID, domain.ReviewerHarness, domain.AgentConfig, domain.ReviewTriggerSource) (reviewcore.TriggerResult, error)
 }
 
 var _ Manager = (*Service)(nil)
@@ -174,9 +174,10 @@ func New(engine *reviewcore.Engine, store Store, opts ...Option) *Service {
 			ctx context.Context,
 			workerID domain.SessionID,
 			harness domain.ReviewerHarness,
+			config domain.AgentConfig,
 			source domain.ReviewTriggerSource,
 		) (reviewcore.TriggerResult, error) {
-			return s.engine.TriggerWithSource(ctx, workerID, harness, source)
+			return s.engine.TriggerWithSource(ctx, workerID, harness, config, source)
 		}
 	}
 	return s
@@ -392,13 +393,14 @@ func (s *Service) Trigger(
 	ctx context.Context,
 	workerID domain.SessionID,
 	harness domain.ReviewerHarness,
+	config domain.AgentConfig,
 ) (reviewcore.TriggerResult, error) {
-	return s.triggerWithSource(ctx, workerID, harness, domain.ReviewTriggerManual)
+	return s.triggerWithSource(ctx, workerID, harness, config, domain.ReviewTriggerManual)
 }
 
 // TriggerAuto starts a daemon-initiated review pass.
 func (s *Service) TriggerAuto(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness) (reviewcore.TriggerResult, error) {
-	return s.triggerWithSource(ctx, workerID, harness, domain.ReviewTriggerAuto)
+	return s.triggerWithSource(ctx, workerID, harness, domain.AgentConfig{}, domain.ReviewTriggerAuto)
 }
 
 // triggerWithSource is the single instrumented trigger path. Both entry points
@@ -410,9 +412,10 @@ func (s *Service) triggerWithSource(
 	ctx context.Context,
 	workerID domain.SessionID,
 	harness domain.ReviewerHarness,
+	config domain.AgentConfig,
 	source domain.ReviewTriggerSource,
 ) (reviewcore.TriggerResult, error) {
-	result, err := s.engineTrigger(ctx, workerID, harness, source)
+	result, err := s.engineTrigger(ctx, workerID, harness, config, source)
 	if err != nil {
 		s.emit(ctx, "ao.review.trigger_failed", workerID, map[string]any{
 			"error_kind": reviewErrorKind(err),
@@ -477,8 +480,8 @@ func (s *Service) RestoreReviewer(ctx context.Context, workerID domain.SessionID
 
 // SwitchReviewer atomically persists a worker's reviewer preference and returns
 // the authoritative post-switch review state.
-func (s *Service) SwitchReviewer(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness) (reviewcore.SessionReviews, error) {
-	return s.engine.SwitchReviewer(ctx, workerID, harness)
+func (s *Service) SwitchReviewer(ctx context.Context, workerID domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig) (reviewcore.SessionReviews, error) {
+	return s.engine.SwitchReviewer(ctx, workerID, harness, config)
 }
 
 // ActivitySignal is reviewer-owned hook metadata. It deliberately does not

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -417,7 +417,7 @@ func (s *Service) triggerWithSource(
 ) (reviewcore.TriggerResult, error) {
 	if err := config.Validate(); err != nil {
 		err = fmt.Errorf("%w: reviewer config: %w", ErrInvalid, err)
-		s.emit("ao.review.trigger_failed", workerID, map[string]any{
+		s.emit(ctx, "ao.review.trigger_failed", workerID, map[string]any{
 			"error_kind": reviewErrorKind(err),
 			"trigger":    string(source),
 		})

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -442,14 +442,16 @@ func (s *Service) triggerWithSource(
 	if source == domain.ReviewTriggerAuto && (result.SkipReason != "" || len(result.CreatedRuns) == 0) {
 		return result, nil
 	}
-	// created_runs distinguishes a genuinely new pass from a reuse of a running
-	// or up-to-date one, which the engine also reports as success. harness is the
-	// one actually used, resolved by the engine, not the caller's override, which
-	// may be empty.
+	// created_runs counts brand-new rows, while Created also covers restart flows
+	// that relaunch a pass against an existing row after a reviewer config change.
+	// reused must stay false for those restarts even though created_runs is zero.
+	// harness is the one actually used, resolved by the engine, not the caller's
+	// override, which may be empty.
+	createdOrRestarted := result.Created || len(result.CreatedRuns) > 0
 	s.emit(ctx, "ao.review.triggered", workerID, map[string]any{
 		"harness":      string(result.Run.Harness),
 		"created_runs": len(result.CreatedRuns),
-		"reused":       len(result.CreatedRuns) == 0,
+		"reused":       !createdOrRestarted,
 		"trigger":      string(source),
 	})
 	return result, nil

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -415,6 +415,14 @@ func (s *Service) triggerWithSource(
 	config domain.AgentConfig,
 	source domain.ReviewTriggerSource,
 ) (reviewcore.TriggerResult, error) {
+	if err := config.Validate(); err != nil {
+		err = fmt.Errorf("%w: reviewer config: %w", ErrInvalid, err)
+		s.emit("ao.review.trigger_failed", workerID, map[string]any{
+			"error_kind": reviewErrorKind(err),
+			"trigger":    string(source),
+		})
+		return reviewcore.TriggerResult{}, err
+	}
 	result, err := s.engineTrigger(ctx, workerID, harness, config, source)
 	if err != nil {
 		s.emit(ctx, "ao.review.trigger_failed", workerID, map[string]any{

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -748,6 +748,32 @@ func TestTriggerFailureReportsWhichPassFailed(t *testing.T) {
 	}
 }
 
+func TestTriggerRejectsInvalidReviewerConfigBeforeEngine(t *testing.T) {
+	sink := &recordingSink{}
+	svc := New(nil, &fakeStore{}, WithTelemetry(sink))
+	called := false
+	svc.engineTrigger = func(
+		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ domain.ReviewTriggerSource,
+	) (reviewcore.TriggerResult, error) {
+		called = true
+		return reviewcore.TriggerResult{}, nil
+	}
+
+	if _, err := svc.Trigger(context.Background(), "worker-1", "", domain.AgentConfig{Mode: "turbo"}); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("err = %v, want ErrInvalid", err)
+	}
+	if called {
+		t.Fatal("engineTrigger should not run for invalid config")
+	}
+	got := sink.named("ao.review.trigger_failed")
+	if len(got) != 1 {
+		t.Fatalf("ao.review.trigger_failed count = %d, want 1", len(got))
+	}
+	if got[0].Payload["error_kind"] != "invalid" || got[0].Payload["trigger"] != "manual" {
+		t.Fatalf("payload = %#v, want error_kind=invalid trigger=manual", got[0].Payload)
+	}
+}
+
 // The submitted event has to carry enough to tell a shallow automatic approval
 // apart from a substantial manual changes-requested pass.
 func TestSubmitReportsPassShapeNotItsContents(t *testing.T) {

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -805,6 +805,27 @@ func TestSubmitReportsPassShapeNotItsContents(t *testing.T) {
 		t.Fatalf("auto_inject = %#v, want false for a session with the policy off", p["auto_inject"])
 	}
 }
+func TestRestartedManualPassIsNotReportedAsReused(t *testing.T) {
+	sink := &recordingSink{}
+	svc := New(nil, &fakeStore{}, WithTelemetry(sink))
+	svc.engineTrigger = func(
+		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ domain.ReviewTriggerSource,
+	) (reviewcore.TriggerResult, error) {
+		return reviewcore.TriggerResult{Run: domain.ReviewRun{Harness: "codex"}, Created: true, CreatedRuns: nil}, nil
+	}
+
+	if _, err := svc.Trigger(context.Background(), "worker-1", "", domain.AgentConfig{Model: "gpt-5-mini"}); err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	got := sink.named("ao.review.triggered")
+	if len(got) != 1 {
+		t.Fatalf("ao.review.triggered count = %d, want 1", len(got))
+	}
+	if got[0].Payload["reused"] != false || got[0].Payload["created_runs"] != 0 {
+		t.Fatalf("payload = %#v, want reused=false created_runs=0 for a restart", got[0].Payload)
+	}
+}
+
 func TestReusedManualPassStaysATrigger(t *testing.T) {
 	sink := &recordingSink{}
 	svc := New(nil, &fakeStore{}, WithTelemetry(sink))

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -690,7 +690,7 @@ func TestTriggerReportsWhoStartedThePass(t *testing.T) {
 		want string
 	}{
 		{"manual", func(s *Service) error {
-			_, err := s.Trigger(context.Background(), "worker-1", "")
+			_, err := s.Trigger(context.Background(), "worker-1", "", domain.AgentConfig{})
 			return err
 		}, "manual"},
 		{"auto", func(s *Service) error {
@@ -703,7 +703,7 @@ func TestTriggerReportsWhoStartedThePass(t *testing.T) {
 			sink := &recordingSink{}
 			svc := New(nil, &fakeStore{}, WithTelemetry(sink))
 			svc.engineTrigger = func(
-				_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.ReviewTriggerSource,
+				_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ domain.ReviewTriggerSource,
 			) (reviewcore.TriggerResult, error) {
 				return reviewcore.TriggerResult{
 					Run:         domain.ReviewRun{Harness: "claude-code"},
@@ -731,7 +731,7 @@ func TestTriggerFailureReportsWhichPassFailed(t *testing.T) {
 	sink := &recordingSink{}
 	svc := New(nil, &fakeStore{}, WithTelemetry(sink))
 	svc.engineTrigger = func(
-		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.ReviewTriggerSource,
+		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ domain.ReviewTriggerSource,
 	) (reviewcore.TriggerResult, error) {
 		return reviewcore.TriggerResult{}, fmt.Errorf("%w: no PR", reviewcore.ErrInvalid)
 	}
@@ -783,12 +783,12 @@ func TestReusedManualPassStaysATrigger(t *testing.T) {
 	sink := &recordingSink{}
 	svc := New(nil, &fakeStore{}, WithTelemetry(sink))
 	svc.engineTrigger = func(
-		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.ReviewTriggerSource,
+		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ domain.ReviewTriggerSource,
 	) (reviewcore.TriggerResult, error) {
 		return reviewcore.TriggerResult{Run: domain.ReviewRun{Harness: "codex"}, CreatedRuns: nil}, nil
 	}
 
-	if _, err := svc.Trigger(context.Background(), "worker-1", ""); err != nil {
+	if _, err := svc.Trigger(context.Background(), "worker-1", "", domain.AgentConfig{}); err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
 	got := sink.named("ao.review.triggered")
@@ -827,7 +827,7 @@ func TestReusedOrSkippedAutoPassReportsNothing(t *testing.T) {
 			sink := &recordingSink{}
 			svc := New(nil, &fakeStore{}, WithTelemetry(sink))
 			svc.engineTrigger = func(
-				_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.ReviewTriggerSource,
+				_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ domain.ReviewTriggerSource,
 			) (reviewcore.TriggerResult, error) {
 				return c.result, nil
 			}

--- a/backend/internal/service/review/telemetry_wire_test.go
+++ b/backend/internal/service/review/telemetry_wire_test.go
@@ -121,7 +121,7 @@ func TestReviewFunnelReachesTheWireWithItsProperties(t *testing.T) {
 		WithClock(func() time.Time { return created.Add(90 * time.Second) }),
 	)
 	svc.engineTrigger = func(
-		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.ReviewTriggerSource,
+		_ context.Context, _ domain.SessionID, _ domain.ReviewerHarness, _ domain.AgentConfig, _ domain.ReviewTriggerSource,
 	) (reviewcore.TriggerResult, error) {
 		return reviewcore.TriggerResult{
 			Run:         domain.ReviewRun{Harness: "claude-code"},

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -33,7 +33,7 @@ type Store interface {
 	SetSessionAutoInjectReview(ctx context.Context, id domain.SessionID, autoInject bool, updatedAt time.Time) (bool, error)
 	SetSessionAutoInjectCI(ctx context.Context, id domain.SessionID, autoInject bool, updatedAt time.Time) (bool, error)
 	SetSessionPinned(ctx context.Context, id domain.SessionID, isPinned bool, pinnedAt *time.Time, updatedAt time.Time) (bool, error)
-	SetSessionReviewerHarness(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness, updatedAt time.Time) (bool, error)
+	SetSessionReviewerConfig(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig, updatedAt time.Time) (bool, error)
 	SetSessionAutoReview(ctx context.Context, id domain.SessionID, enabled bool, updatedAt time.Time) (bool, error)
 	GetDisplayPRFactsForSession(ctx context.Context, id domain.SessionID) (domain.PRFacts, bool, error)
 	ListPRFactsForSession(ctx context.Context, id domain.SessionID) ([]domain.PRFacts, error)
@@ -751,13 +751,16 @@ func (s *Service) Unpin(ctx context.Context, id domain.SessionID) (domain.Sessio
 
 // SetReviewerHarness persists the reviewer selected for this session. Empty
 // clears the preference and restores the project-level fallback.
-func (s *Service) SetReviewerHarness(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness) (domain.Session, error) {
+func (s *Service) SetReviewerHarness(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig) (domain.Session, error) {
 	if harness != "" && !harness.IsKnown() {
 		return domain.Session{}, apierr.Invalid("UNKNOWN_REVIEWER_HARNESS", "Unknown reviewer harness", nil)
 	}
-	updated, err := s.store.SetSessionReviewerHarness(ctx, id, harness, time.Now().UTC())
+	if err := config.Validate(); err != nil {
+		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": err.Error()})
+	}
+	updated, err := s.store.SetSessionReviewerConfig(ctx, id, harness, config, time.Now().UTC())
 	if err != nil {
-		return domain.Session{}, fmt.Errorf("set reviewer harness %s: %w", id, err)
+		return domain.Session{}, fmt.Errorf("set reviewer config %s: %w", id, err)
 	}
 	if !updated {
 		return domain.Session{}, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -758,6 +758,9 @@ func (s *Service) SetReviewerHarness(ctx context.Context, id domain.SessionID, h
 	if err := config.Validate(); err != nil {
 		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": err.Error()})
 	}
+	if harness == "" && !config.IsZero() {
+		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": "reviewer harness is required when reviewer config is set"})
+	}
 	updated, err := s.store.SetSessionReviewerConfig(ctx, id, harness, config, time.Now().UTC())
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("set reviewer config %s: %w", id, err)

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -758,9 +758,6 @@ func (s *Service) SetReviewerHarness(ctx context.Context, id domain.SessionID, h
 	if err := config.Validate(); err != nil {
 		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": err.Error()})
 	}
-	if harness == "" && !config.IsZero() {
-		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": "reviewer harness is required when reviewer config is set"})
-	}
 	updated, err := s.store.SetSessionReviewerConfig(ctx, id, harness, config, time.Now().UTC())
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("set reviewer config %s: %w", id, err)

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -261,12 +261,13 @@ func (f *fakeStore) SetSessionAutoInjectCI(_ context.Context, id domain.SessionI
 	return true, nil
 }
 
-func (f *fakeStore) SetSessionReviewerHarness(_ context.Context, id domain.SessionID, harness domain.ReviewerHarness, updatedAt time.Time) (bool, error) {
+func (f *fakeStore) SetSessionReviewerConfig(_ context.Context, id domain.SessionID, harness domain.ReviewerHarness, config domain.AgentConfig, updatedAt time.Time) (bool, error) {
 	r, ok := f.sessions[id]
 	if !ok {
 		return false, nil
 	}
 	r.ReviewerHarness = harness
+	r.ReviewerConfig = config
 	r.UpdatedAt = updatedAt
 	f.sessions[id] = r
 	return true, nil
@@ -573,7 +574,7 @@ func TestSessionSetReviewerHarnessPersistsPerSession(t *testing.T) {
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}
 	st.sessions["mer-2"] = domain.SessionRecord{ID: "mer-2", ProjectID: "mer", Kind: domain.KindWorker}
 
-	sess, err := (&Service{store: st}).SetReviewerHarness(context.Background(), "mer-1", domain.ReviewerOpenCode)
+	sess, err := (&Service{store: st}).SetReviewerHarness(context.Background(), "mer-1", domain.ReviewerOpenCode, domain.AgentConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -588,7 +589,7 @@ func TestSessionSetReviewerHarnessPersistsPerSession(t *testing.T) {
 func TestSessionSetReviewerHarnessRejectsUnknownHarness(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1"}
-	if _, err := (&Service{store: st}).SetReviewerHarness(context.Background(), "mer-1", "unknown"); err == nil {
+	if _, err := (&Service{store: st}).SetReviewerHarness(context.Background(), "mer-1", "unknown", domain.AgentConfig{}); err == nil {
 		t.Fatal("expected invalid harness error")
 	}
 }

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -594,11 +594,19 @@ func TestSessionSetReviewerHarnessRejectsUnknownHarness(t *testing.T) {
 	}
 }
 
-func TestSessionSetReviewerHarnessRejectsConfigWithoutHarness(t *testing.T) {
+func TestSessionSetReviewerHarnessAllowsConfigWithoutHarness(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1"}
-	if _, err := (&Service{store: st}).SetReviewerHarness(context.Background(), "mer-1", "", domain.AgentConfig{Model: "gpt-5"}); err == nil {
-		t.Fatal("expected invalid reviewer config error")
+
+	sess, err := (&Service{store: st}).SetReviewerHarness(context.Background(), "mer-1", "", domain.AgentConfig{Model: "gpt-5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.ReviewerHarness != "" || sess.ReviewerConfig.Model != "gpt-5" {
+		t.Fatalf("session reviewer override = (%q, %+v), want default harness with model override", sess.ReviewerHarness, sess.ReviewerConfig)
+	}
+	if stored := st.sessions["mer-1"]; stored.ReviewerHarness != "" || stored.ReviewerConfig.Model != "gpt-5" {
+		t.Fatalf("stored reviewer override = (%q, %+v), want default harness with model override", stored.ReviewerHarness, stored.ReviewerConfig)
 	}
 }
 

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -594,6 +594,14 @@ func TestSessionSetReviewerHarnessRejectsUnknownHarness(t *testing.T) {
 	}
 }
 
+func TestSessionSetReviewerHarnessRejectsConfigWithoutHarness(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1"}
+	if _, err := (&Service{store: st}).SetReviewerHarness(context.Background(), "mer-1", "", domain.AgentConfig{Model: "gpt-5"}); err == nil {
+		t.Fatal("expected invalid reviewer config error")
+	}
+}
+
 func TestSessionSetAutoReviewPersistsToggle(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}

--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -161,6 +161,9 @@ func migrate(db *sql.DB) error {
 	if err := prepareQueuedTurnPromotionMigration(db); err != nil {
 		return fmt.Errorf("prepare queued-turn promotion migration: %w", err)
 	}
+	if err := prepareSessionReviewerAgentConfigMigration(db); err != nil {
+		return fmt.Errorf("prepare session reviewer agent-config migration: %w", err)
+	}
 	// Builds can advance a database past a migration that is added or
 	// renumbered later (notably across fast-moving Nightly releases). Apply
 	// those embedded migrations instead of permanently wedging daemon startup
@@ -320,6 +323,41 @@ SELECT COALESCE((
 // owns both numbers, so record the promotion schema as version 89. If version 88
 // came from the old promotion migration, remove that ledger entry so goose can
 // apply upstream's auto-inject-CI migration at its canonical version.
+// prepareSessionReviewerAgentConfigMigration preserves databases that
+// already have sessions.reviewer_agent_config from an in-flight local run but
+// do not yet record the canonical 0118 migration version. Recording that
+// physically present effect prevents goose from replaying the ALTER TABLE over
+// the existing column on the next startup.
+func prepareSessionReviewerAgentConfigMigration(db *sql.DB) error {
+	var gooseTable int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'goose_db_version'`,
+	).Scan(&gooseTable); err != nil {
+		return err
+	}
+	if gooseTable == 0 {
+		return nil
+	}
+
+	var applied, reviewerConfigColumn int
+	if err := db.QueryRow(`
+SELECT
+    COALESCE((
+        SELECT is_applied FROM goose_db_version
+        WHERE version_id = 118 ORDER BY id DESC LIMIT 1
+    ), 0),
+    (SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'reviewer_agent_config')
+`).Scan(&applied, &reviewerConfigColumn); err != nil {
+		return err
+	}
+	if applied != 0 || reviewerConfigColumn == 0 {
+		return nil
+	}
+
+	_, err := db.Exec(`INSERT INTO goose_db_version (version_id, is_applied) VALUES (118, 1)`)
+	return err
+}
+
 func prepareQueuedTurnPromotionMigration(db *sql.DB) error {
 	tx, err := db.Begin()
 	if err != nil {

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -425,6 +425,7 @@ type Session struct {
 	AgentSessionIDLaunchID    string
 	Model                     string
 	LatestUserPromptAt        sql.NullTime
+	ReviewerAgentConfig       string
 }
 
 type SessionCleanupFact struct {

--- a/backend/internal/storage/sqlite/gen/sessions.sql.go
+++ b/backend/internal/storage/sqlite/gen/sessions.sql.go
@@ -114,7 +114,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
     created_at, updated_at, display_name, first_signal_at, preview_url,
     preview_revision, cleanup_generation, runtime_launch_id,
     workspace_repo_path, terminate_on_pr_merge, diff_base_sha, diff_base_ref,
-    reviewer_harness, is_pinned, pinned_at,
+    reviewer_harness, reviewer_agent_config, is_pinned, pinned_at,
     session_mode, provider_conversation_id, controller_generation, browser_capability_verifier,
     latest_user_prompt, latest_user_prompt_at, latest_assistant_update, native_transcript_path, auto_inject_review, auto_inject_ci, auto_review_enabled, model
 FROM sessions WHERE id = ?
@@ -149,6 +149,7 @@ type GetSessionRow struct {
 	DiffBaseSha               string
 	DiffBaseRef               string
 	ReviewerHarness           domain.ReviewerHarness
+	ReviewerAgentConfig       string
 	IsPinned                  bool
 	PinnedAt                  sql.NullTime
 	SessionMode               domain.SessionMode
@@ -197,6 +198,7 @@ func (q *Queries) GetSession(ctx context.Context, id domain.SessionID) (GetSessi
 		&i.DiffBaseSha,
 		&i.DiffBaseRef,
 		&i.ReviewerHarness,
+		&i.ReviewerAgentConfig,
 		&i.IsPinned,
 		&i.PinnedAt,
 		&i.SessionMode,
@@ -217,7 +219,7 @@ func (q *Queries) GetSession(ctx context.Context, id domain.SessionID) (GetSessi
 
 const insertSession = `-- name: InsertSession :exec
 INSERT INTO sessions (
-    id, project_id, num, issue_id, kind, harness, reviewer_harness, auto_review_enabled, display_name,
+    id, project_id, num, issue_id, kind, harness, reviewer_harness, reviewer_agent_config, auto_review_enabled, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, workspace_repo_path, diff_base_sha, diff_base_ref, runtime_handle_id,
     runtime_launch_id, agent_session_id, agent_session_id_launch_id, prompt,
@@ -229,7 +231,7 @@ INSERT INTO sessions (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
 `
 
@@ -241,6 +243,7 @@ type InsertSessionParams struct {
 	Kind                      domain.SessionKind
 	Harness                   domain.AgentHarness
 	ReviewerHarness           domain.ReviewerHarness
+	ReviewerAgentConfig       string
 	AutoReviewEnabled         bool
 	DisplayName               string
 	ActivityState             domain.ActivityState
@@ -287,6 +290,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 		arg.Kind,
 		arg.Harness,
 		arg.ReviewerHarness,
+		arg.ReviewerAgentConfig,
 		arg.AutoReviewEnabled,
 		arg.DisplayName,
 		arg.ActivityState,
@@ -333,7 +337,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
     created_at, updated_at, display_name, first_signal_at, preview_url,
     preview_revision, cleanup_generation, runtime_launch_id,
     workspace_repo_path, terminate_on_pr_merge, diff_base_sha, diff_base_ref,
-    reviewer_harness, is_pinned, pinned_at,
+    reviewer_harness, reviewer_agent_config, is_pinned, pinned_at,
     session_mode, provider_conversation_id, controller_generation, browser_capability_verifier,
     latest_user_prompt, latest_user_prompt_at, latest_assistant_update, native_transcript_path, auto_inject_review, auto_inject_ci, auto_review_enabled, model
 FROM sessions ORDER BY project_id, num
@@ -368,6 +372,7 @@ type ListAllSessionsRow struct {
 	DiffBaseSha               string
 	DiffBaseRef               string
 	ReviewerHarness           domain.ReviewerHarness
+	ReviewerAgentConfig       string
 	IsPinned                  bool
 	PinnedAt                  sql.NullTime
 	SessionMode               domain.SessionMode
@@ -422,6 +427,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]ListAllSessionsRow, er
 			&i.DiffBaseSha,
 			&i.DiffBaseRef,
 			&i.ReviewerHarness,
+			&i.ReviewerAgentConfig,
 			&i.IsPinned,
 			&i.PinnedAt,
 			&i.SessionMode,
@@ -457,7 +463,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
     created_at, updated_at, display_name, first_signal_at, preview_url,
     preview_revision, cleanup_generation, runtime_launch_id,
     workspace_repo_path, terminate_on_pr_merge, diff_base_sha, diff_base_ref,
-    reviewer_harness, is_pinned, pinned_at,
+    reviewer_harness, reviewer_agent_config, is_pinned, pinned_at,
     session_mode, provider_conversation_id, controller_generation, browser_capability_verifier,
     latest_user_prompt, latest_user_prompt_at, latest_assistant_update, native_transcript_path, auto_inject_review, auto_inject_ci, auto_review_enabled, model
 FROM sessions WHERE project_id = ? ORDER BY num
@@ -492,6 +498,7 @@ type ListSessionsByProjectRow struct {
 	DiffBaseSha               string
 	DiffBaseRef               string
 	ReviewerHarness           domain.ReviewerHarness
+	ReviewerAgentConfig       string
 	IsPinned                  bool
 	PinnedAt                  sql.NullTime
 	SessionMode               domain.SessionMode
@@ -546,6 +553,7 @@ func (q *Queries) ListSessionsByProject(ctx context.Context, projectID domain.Pr
 			&i.DiffBaseSha,
 			&i.DiffBaseRef,
 			&i.ReviewerHarness,
+			&i.ReviewerAgentConfig,
 			&i.IsPinned,
 			&i.PinnedAt,
 			&i.SessionMode,
@@ -780,18 +788,24 @@ func (q *Queries) SetSessionPreviewURL(ctx context.Context, arg SetSessionPrevie
 	return result.RowsAffected()
 }
 
-const setSessionReviewerHarness = `-- name: SetSessionReviewerHarness :execrows
-UPDATE sessions SET reviewer_harness = ?, updated_at = ? WHERE id = ?
+const setSessionReviewerConfig = `-- name: SetSessionReviewerConfig :execrows
+UPDATE sessions SET reviewer_harness = ?, reviewer_agent_config = ?, updated_at = ? WHERE id = ?
 `
 
-type SetSessionReviewerHarnessParams struct {
-	ReviewerHarness domain.ReviewerHarness
-	UpdatedAt       time.Time
-	ID              domain.SessionID
+type SetSessionReviewerConfigParams struct {
+	ReviewerHarness     domain.ReviewerHarness
+	ReviewerAgentConfig string
+	UpdatedAt           time.Time
+	ID                  domain.SessionID
 }
 
-func (q *Queries) SetSessionReviewerHarness(ctx context.Context, arg SetSessionReviewerHarnessParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, setSessionReviewerHarness, arg.ReviewerHarness, arg.UpdatedAt, arg.ID)
+func (q *Queries) SetSessionReviewerConfig(ctx context.Context, arg SetSessionReviewerConfigParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setSessionReviewerConfig,
+		arg.ReviewerHarness,
+		arg.ReviewerAgentConfig,
+		arg.UpdatedAt,
+		arg.ID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -870,7 +884,7 @@ func (q *Queries) UpdateBrowserCapabilityVerifier(ctx context.Context, arg Updat
 
 const updateSession = `-- name: UpdateSession :exec
 UPDATE sessions SET
-    issue_id = ?, kind = ?, harness = ?, reviewer_harness = ?, auto_review_enabled = ?, display_name = ?,
+    issue_id = ?, kind = ?, harness = ?, reviewer_harness = ?, reviewer_agent_config = ?, auto_review_enabled = ?, display_name = ?,
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, workspace_repo_path = ?, diff_base_sha = ?, diff_base_ref = ?, runtime_handle_id = ?,
     runtime_launch_id = ?, agent_session_id = ?, agent_session_id_launch_id = ?, prompt = ?,
@@ -887,6 +901,7 @@ type UpdateSessionParams struct {
 	Kind                      domain.SessionKind
 	Harness                   domain.AgentHarness
 	ReviewerHarness           domain.ReviewerHarness
+	ReviewerAgentConfig       string
 	AutoReviewEnabled         bool
 	DisplayName               string
 	ActivityState             domain.ActivityState
@@ -929,6 +944,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) er
 		arg.Kind,
 		arg.Harness,
 		arg.ReviewerHarness,
+		arg.ReviewerAgentConfig,
 		arg.AutoReviewEnabled,
 		arg.DisplayName,
 		arg.ActivityState,

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -125,6 +125,7 @@ var shippedMigrations = map[int64]string{
 	118: "0118_cancelled_conversation_turns.sql",
 	119: "0119_finalize_completed_conversation_plans.sql",
 	120: "0120_normalize_activity_last_at.sql",
+	121: "0121_session_reviewer_agent_config.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0121_session_reviewer_agent_config.sql
+++ b/backend/internal/storage/sqlite/migrations/0121_session_reviewer_agent_config.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN reviewer_agent_config TEXT NOT NULL DEFAULT '';
+
+-- +goose Down

--- a/backend/internal/storage/sqlite/queries/sessions.sql
+++ b/backend/internal/storage/sqlite/queries/sessions.sql
@@ -3,7 +3,7 @@ SELECT COALESCE(MAX(num), 0) + 1 AS next FROM sessions WHERE project_id = ?;
 
 -- name: InsertSession :exec
 INSERT INTO sessions (
-    id, project_id, num, issue_id, kind, harness, reviewer_harness, auto_review_enabled, display_name,
+    id, project_id, num, issue_id, kind, harness, reviewer_harness, reviewer_agent_config, auto_review_enabled, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, workspace_repo_path, diff_base_sha, diff_base_ref, runtime_handle_id,
     runtime_launch_id, agent_session_id, agent_session_id_launch_id, prompt,
@@ -15,12 +15,12 @@ INSERT INTO sessions (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 );
 
 -- name: UpdateSession :exec
 UPDATE sessions SET
-    issue_id = ?, kind = ?, harness = ?, reviewer_harness = ?, auto_review_enabled = ?, display_name = ?,
+    issue_id = ?, kind = ?, harness = ?, reviewer_harness = ?, reviewer_agent_config = ?, auto_review_enabled = ?, display_name = ?,
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, workspace_repo_path = ?, diff_base_sha = ?, diff_base_ref = ?, runtime_handle_id = ?,
     runtime_launch_id = ?, agent_session_id = ?, agent_session_id_launch_id = ?, prompt = ?,
@@ -107,7 +107,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
     created_at, updated_at, display_name, first_signal_at, preview_url,
     preview_revision, cleanup_generation, runtime_launch_id,
     workspace_repo_path, terminate_on_pr_merge, diff_base_sha, diff_base_ref,
-    reviewer_harness, is_pinned, pinned_at,
+    reviewer_harness, reviewer_agent_config, is_pinned, pinned_at,
     session_mode, provider_conversation_id, controller_generation, browser_capability_verifier,
     latest_user_prompt, latest_user_prompt_at, latest_assistant_update, native_transcript_path, auto_inject_review, auto_inject_ci, auto_review_enabled, model
 FROM sessions WHERE id = ?;
@@ -119,7 +119,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
     created_at, updated_at, display_name, first_signal_at, preview_url,
     preview_revision, cleanup_generation, runtime_launch_id,
     workspace_repo_path, terminate_on_pr_merge, diff_base_sha, diff_base_ref,
-    reviewer_harness, is_pinned, pinned_at,
+    reviewer_harness, reviewer_agent_config, is_pinned, pinned_at,
     session_mode, provider_conversation_id, controller_generation, browser_capability_verifier,
     latest_user_prompt, latest_user_prompt_at, latest_assistant_update, native_transcript_path, auto_inject_review, auto_inject_ci, auto_review_enabled, model
 FROM sessions WHERE project_id = ? ORDER BY num;
@@ -131,7 +131,7 @@ SELECT id, project_id, num, issue_id, kind, harness,
     created_at, updated_at, display_name, first_signal_at, preview_url,
     preview_revision, cleanup_generation, runtime_launch_id,
     workspace_repo_path, terminate_on_pr_merge, diff_base_sha, diff_base_ref,
-    reviewer_harness, is_pinned, pinned_at,
+    reviewer_harness, reviewer_agent_config, is_pinned, pinned_at,
     session_mode, provider_conversation_id, controller_generation, browser_capability_verifier,
     latest_user_prompt, latest_user_prompt_at, latest_assistant_update, native_transcript_path, auto_inject_review, auto_inject_ci, auto_review_enabled, model
 FROM sessions ORDER BY project_id, num;
@@ -158,8 +158,8 @@ UPDATE sessions SET auto_inject_ci = ?, updated_at = ? WHERE id = ?;
 -- name: SetSessionPinned :execrows
 UPDATE sessions SET is_pinned = ?, pinned_at = ?, updated_at = ? WHERE id = ?;
 
--- name: SetSessionReviewerHarness :execrows
-UPDATE sessions SET reviewer_harness = ?, updated_at = ? WHERE id = ?;
+-- name: SetSessionReviewerConfig :execrows
+UPDATE sessions SET reviewer_harness = ?, reviewer_agent_config = ?, updated_at = ? WHERE id = ?;
 
 -- name: SetSessionAutoReview :execrows
 UPDATE sessions SET auto_review_enabled = ?, updated_at = ? WHERE id = ?;

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -259,7 +259,7 @@ func (s *Store) SetSessionAutoInjectCI(ctx context.Context, id domain.SessionID,
 	return updated, nil
 }
 
-// SetSessionReviewerHarness persists the reviewer preference for one session.
+// SetSessionReviewerConfig persists the reviewer preference for one session.
 func (s *Store) SetSessionReviewerConfig(
 	ctx context.Context,
 	id domain.SessionID,

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -259,16 +260,27 @@ func (s *Store) SetSessionAutoInjectCI(ctx context.Context, id domain.SessionID,
 }
 
 // SetSessionReviewerHarness persists the reviewer preference for one session.
-func (s *Store) SetSessionReviewerHarness(ctx context.Context, id domain.SessionID, harness domain.ReviewerHarness, updatedAt time.Time) (bool, error) {
+func (s *Store) SetSessionReviewerConfig(
+	ctx context.Context,
+	id domain.SessionID,
+	harness domain.ReviewerHarness,
+	config domain.AgentConfig,
+	updatedAt time.Time,
+) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	rows, err := s.qw.SetSessionReviewerHarness(ctx, gen.SetSessionReviewerHarnessParams{
-		ReviewerHarness: harness,
-		UpdatedAt:       updatedAt,
-		ID:              id,
+	encoded, err := marshalAgentConfig(config)
+	if err != nil {
+		return false, fmt.Errorf("set reviewer config for %s: %w", id, err)
+	}
+	rows, err := s.qw.SetSessionReviewerConfig(ctx, gen.SetSessionReviewerConfigParams{
+		ReviewerHarness:     harness,
+		ReviewerAgentConfig: encoded,
+		UpdatedAt:           updatedAt,
+		ID:                  id,
 	})
 	if err != nil {
-		return false, fmt.Errorf("set reviewer harness for %s: %w", id, err)
+		return false, fmt.Errorf("set reviewer config for %s: %w", id, err)
 	}
 	return rows > 0, nil
 }
@@ -419,6 +431,7 @@ func rowToRecord(row gen.GetSessionRow) domain.SessionRecord {
 		Kind:              row.Kind,
 		Harness:           row.Harness,
 		ReviewerHarness:   row.ReviewerHarness,
+		ReviewerConfig:    unmarshalAgentConfig(row.ReviewerAgentConfig),
 		AutoReviewEnabled: row.AutoReviewEnabled,
 		DisplayName:       row.DisplayName,
 		Mode:              domain.NormalizeSessionMode(row.SessionMode),
@@ -483,6 +496,7 @@ func recordToInsert(rec domain.SessionRecord, num int64) gen.InsertSessionParams
 		Kind:                      rec.Kind,
 		Harness:                   rec.Harness,
 		ReviewerHarness:           rec.ReviewerHarness,
+		ReviewerAgentConfig:       mustMarshalAgentConfig(rec.ReviewerConfig),
 		AutoReviewEnabled:         rec.AutoReviewEnabled,
 		DisplayName:               rec.DisplayName,
 		ActivityState:             activity.State,
@@ -529,6 +543,7 @@ func recordToUpdate(rec domain.SessionRecord) gen.UpdateSessionParams {
 		Kind:                      rec.Kind,
 		Harness:                   rec.Harness,
 		ReviewerHarness:           rec.ReviewerHarness,
+		ReviewerAgentConfig:       mustMarshalAgentConfig(rec.ReviewerConfig),
 		AutoReviewEnabled:         rec.AutoReviewEnabled,
 		DisplayName:               rec.DisplayName,
 		ActivityState:             activity.State,
@@ -563,6 +578,36 @@ func recordToUpdate(rec domain.SessionRecord) gen.UpdateSessionParams {
 		Model:                     rec.Metadata.Model,
 		UpdatedAt:                 rec.UpdatedAt,
 	}
+}
+
+func marshalAgentConfig(cfg domain.AgentConfig) (string, error) {
+	if cfg.IsZero() {
+		return "", nil
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("marshal agent config: %w", err)
+	}
+	return string(data), nil
+}
+
+func mustMarshalAgentConfig(cfg domain.AgentConfig) string {
+	data, err := marshalAgentConfig(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func unmarshalAgentConfig(data string) domain.AgentConfig {
+	if data == "" {
+		return domain.AgentConfig{}
+	}
+	var cfg domain.AgentConfig
+	if err := json.Unmarshal([]byte(data), &cfg); err != nil {
+		return domain.AgentConfig{}
+	}
+	return cfg
 }
 
 // nullTimeToTime / timeToNullTime bridge the nullable first_signal_at column

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -76,8 +76,8 @@ func TestSessionPersistsReviewerHarness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok, err := s.SetSessionReviewerHarness(ctx, rec.ID, domain.ReviewerCodex, time.Now().UTC()); err != nil || !ok {
-		t.Fatalf("set reviewer harness = %v, %v", ok, err)
+	if ok, err := s.SetSessionReviewerConfig(ctx, rec.ID, domain.ReviewerCodex, domain.AgentConfig{}, time.Now().UTC()); err != nil || !ok {
+		t.Fatalf("set reviewer config = %v, %v", ok, err)
 	}
 	got, ok, err := s.GetSession(ctx, rec.ID)
 	if err != nil || !ok {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3365,6 +3365,7 @@ export interface components {
             repo?: string;
         };
         TriggerReviewRequest: {
+            agentConfig?: components["schemas"]["AgentConfig"];
             /** @enum {string} */
             harness?: "claude-code" | "codex" | "copilot" | "cursor" | "kilocode" | "opencode" | "kiro" | "pi" | "qwen" | "agy" | "continue" | "goose" | "vibe" | "devin" | "droid" | "kimi" | "kimchi" | "muse" | "amp" | "aider" | "grok" | "crush" | "auggie" | "cline" | "autohand";
         };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2142,6 +2142,7 @@ export interface components {
             previewUrl?: string;
             projectId: string;
             prs: components["schemas"]["SessionPRFacts"][];
+            reviewerConfig?: components["schemas"]["AgentConfig"];
             /** @enum {string} */
             reviewerHarness?: "claude-code" | "codex" | "copilot" | "cursor" | "kilocode" | "opencode" | "kiro" | "pi" | "qwen" | "agy" | "continue" | "goose" | "vibe" | "devin" | "droid" | "kimi" | "kimchi" | "muse" | "amp" | "aider" | "grok" | "crush" | "auggie" | "cline" | "autohand";
             /** @enum {string} */
@@ -2461,6 +2462,7 @@ export interface components {
             state: string;
         };
         DomainReviewerConfig: {
+            agentConfig?: components["schemas"]["AgentConfig"];
             harness: string;
         };
         EditConversationMessageRequest: {
@@ -3208,6 +3210,7 @@ export interface components {
             url?: string;
         };
         SetSessionReviewerRequest: {
+            agentConfig?: components["schemas"]["AgentConfig"];
             /** @enum {string} */
             harness?: "claude-code" | "codex" | "copilot" | "cursor" | "kilocode" | "opencode" | "kiro" | "pi" | "qwen" | "agy" | "continue" | "goose" | "vibe" | "devin" | "droid" | "kimi" | "kimchi" | "muse" | "amp" | "aider" | "grok" | "crush" | "auggie" | "cline" | "autohand";
         };

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -636,6 +636,55 @@ describe("ProjectSettingsForm", () => {
 	});
 
 
+	it("preserves existing reviewer-only config fields when saving project settings", async () => {
+		getMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/agents") return agentCatalogResponse;
+			return {
+				data: {
+					status: "ok",
+					project: {
+						id: "proj-1",
+						name: "Project One",
+						kind: "single_repo",
+						path: "/repo/project-one",
+						repo: "",
+						defaultBranch: "main",
+						config: {
+							worker: { agent: "codex" },
+							orchestrator: { agent: "claude-code" },
+							reviewers: [
+								{ harness: "codex", agentConfig: { model: "gpt-5", permissions: "bypass-permissions" } },
+							],
+						},
+					},
+				},
+				error: undefined,
+			};
+		});
+
+		renderSettings("proj-1");
+		await screen.findByRole("button", { name: "Edit Project name" });
+		submitSettings();
+
+		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+		expect(putMock).toHaveBeenCalledWith("/api/v1/projects/{id}", {
+			params: { path: { id: "proj-1" } },
+			body: expect.objectContaining({
+				config: expect.objectContaining({
+					reviewers: [
+						expect.objectContaining({
+							harness: "codex",
+							agentConfig: expect.objectContaining({
+								model: "gpt-5",
+								permissions: "bypass-permissions",
+							}),
+						}),
+					],
+				}),
+			}),
+		});
+	});
+
 	it("clears the saved reviewer model when switching the project reviewer harness", async () => {
 		getMock.mockImplementation(async (path: string, init?: { params?: { path?: { agent?: string } } }) => {
 			if (path === "/api/v1/agents") return agentCatalogResponse;

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -685,7 +685,7 @@ describe("ProjectSettingsForm", () => {
 		});
 	});
 
-	it("clears the saved reviewer model when switching the project reviewer harness", async () => {
+	it("clears the saved reviewer model and reviewer-only config when switching the project reviewer harness", async () => {
 		getMock.mockImplementation(async (path: string, init?: { params?: { path?: { agent?: string } } }) => {
 			if (path === "/api/v1/agents") return agentCatalogResponse;
 			if (path === "/api/v1/agents/{agent}/models") {
@@ -733,6 +733,9 @@ describe("ProjectSettingsForm", () => {
 						config: {
 							worker: { agent: "codex" },
 							orchestrator: { agent: "claude-code" },
+							reviewers: [
+								{ harness: "codex", agentConfig: { permissions: "bypass-permissions" } },
+							],
 						},
 					},
 				},
@@ -759,7 +762,14 @@ describe("ProjectSettingsForm", () => {
 		expect(putMock).toHaveBeenCalledWith("/api/v1/projects/{id}", {
 			params: { path: { id: "proj-1" } },
 			body: expect.objectContaining({
-				config: expect.objectContaining({ reviewers: [{ harness: "opencode" }] }),
+				config: expect.objectContaining({
+					reviewers: [
+						expect.objectContaining({
+							harness: "opencode",
+							agentConfig: undefined,
+						}),
+					],
+				}),
 			}),
 		});
 	});

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -1099,7 +1099,7 @@ describe("ProjectSettingsForm", () => {
 		await userEvent.click(await screen.findByRole("button", { name: "Default reviewer agent" }));
 		const reviewerLabels = (await screen.findAllByRole("menuitem"))
 			.map((option) => option.textContent)
-			.filter((label) => label !== "Project default");
+			.filter((label) => label !== "Project default" && label !== "Custom model…");
 
 		expect(reviewerLabels).toEqual([
 			"Claude Code",

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -635,6 +635,86 @@ describe("ProjectSettingsForm", () => {
 		expect(screen.getByRole("menuitem", { name: "Custom model…" })).toBeInTheDocument();
 	});
 
+
+	it("clears the saved reviewer model when switching the project reviewer harness", async () => {
+		getMock.mockImplementation(async (path: string, init?: { params?: { path?: { agent?: string } } }) => {
+			if (path === "/api/v1/agents") return agentCatalogResponse;
+			if (path === "/api/v1/agents/{agent}/models") {
+				const agent = init?.params?.path?.agent;
+				if (agent === "codex") {
+					return {
+						data: {
+							agentId: "codex",
+							selectionMode: "catalog",
+							models: [
+								{ id: "gpt-5", label: "GPT-5", isDefault: true },
+								{ id: "gpt-5-mini", label: "GPT-5 Mini" },
+							],
+							allowCustom: true,
+							source: "official-catalog",
+							fetchedAt: "2026-08-30T00:00:00Z",
+							stale: false,
+						},
+						error: undefined,
+					};
+				}
+				return {
+					data: {
+						agentId: agent ?? "unknown",
+						selectionMode: "text",
+						models: [],
+						allowCustom: true,
+						source: "manual",
+						fetchedAt: "2026-08-30T00:00:00Z",
+						stale: false,
+					},
+					error: undefined,
+				};
+			}
+			return {
+				data: {
+					status: "ok",
+					project: {
+						id: "proj-1",
+						name: "Project One",
+						kind: "single_repo",
+						path: "/repo/project-one",
+						repo: "",
+						defaultBranch: "main",
+						config: {
+							worker: { agent: "codex" },
+							orchestrator: { agent: "claude-code" },
+						},
+					},
+				},
+				error: undefined,
+			};
+		});
+
+		renderSettings("proj-1", undefined, "agents");
+
+		const reviewer = await screen.findByRole("button", { name: "Default reviewer agent" });
+		await userEvent.click(reviewer);
+		const codexOption = (await screen.findAllByRole("menuitem")).find((option) => option.textContent?.includes("Codex"));
+		expect(codexOption).toBeTruthy();
+		await userEvent.click(codexOption!);
+		await userEvent.click(await screen.findByRole("menuitem", { name: /GPT-5 Mini/i }));
+		expect(reviewer).toHaveTextContent("Codex · GPT-5 Mini");
+
+		await chooseOption(reviewer, "OpenCode");
+		expect(reviewer).toHaveTextContent("OpenCode · Agent default");
+
+		submitSettings();
+
+		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+		expect(putMock).toHaveBeenCalledWith("/api/v1/projects/{id}", {
+			params: { path: { id: "proj-1" } },
+			body: expect.objectContaining({
+				config: expect.objectContaining({ reviewers: [{ harness: "opencode" }] }),
+			}),
+		});
+	});
+
 	it("shows a warning when background model revalidation fails", async () => {
 		getMock.mockImplementation(async (path: string) => {
 			if (path === "/api/v1/agents") return agentCatalogResponse;

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -256,7 +256,7 @@ function SettingsBody({
 							? [
 									{
 										harness: form.reviewerHarness,
-										agentConfig: buildRoleAgentConfig(undefined, form.reviewerModel, form.reviewerMode),
+										agentConfig: buildRoleAgentConfig(config.reviewers?.[0]?.agentConfig, form.reviewerModel, form.reviewerMode),
 									},
 								]
 							: undefined,

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -149,6 +149,8 @@ function SettingsBody({
 		orchestratorMode: config.orchestrator?.agentConfig?.mode ?? config.agentConfig?.mode ?? "",
 		permissions: config.agentConfig?.permissions ?? "",
 		reviewerHarness: config.reviewers?.[0]?.harness ?? "",
+		reviewerModel: config.reviewers?.[0]?.agentConfig?.model ?? "",
+		reviewerMode: config.reviewers?.[0]?.agentConfig?.mode ?? "",
 		autoReview: config.autoReview ?? false,
 		intakeEnabled: intake.enabled ?? false,
 		intakeRepo: intake.repo ?? "",
@@ -160,6 +162,8 @@ function SettingsBody({
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const initialOrchestratorAgent = config.orchestrator?.agent ?? "";
 	const initialReviewerHarness = config.reviewers?.[0]?.harness ?? "";
+	const initialReviewerModel = config.reviewers?.[0]?.agentConfig?.model ?? "";
+	const initialReviewerMode = config.reviewers?.[0]?.agentConfig?.mode ?? "";
 	const initialAutoReview = config.autoReview ?? false;
 	const missingRequiredAgent = form.workerAgent === "" || form.orchestratorAgent === "";
 	const agentsQuery = useQuery(agentsQueryOptions);
@@ -187,7 +191,10 @@ function SettingsBody({
 	// Compared against the values this form opened with, so a save that leaves the
 	// review controls alone is not reported as a review decision.
 	const reviewSettingsChanged =
-		form.autoReview !== initialAutoReview || form.reviewerHarness !== initialReviewerHarness;
+		form.autoReview !== initialAutoReview ||
+		form.reviewerHarness !== initialReviewerHarness ||
+		form.reviewerModel !== initialReviewerModel ||
+		form.reviewerMode !== initialReviewerMode;
 
 	const mutation = useMutation({
 		mutationFn: async () => {
@@ -245,7 +252,14 @@ function SettingsBody({
 							...sharedAgentConfig,
 							permissions: form.permissions || undefined,
 						}),
-						reviewers: form.reviewerHarness ? [{ harness: form.reviewerHarness }] : undefined,
+						reviewers: form.reviewerHarness
+							? [
+									{
+										harness: form.reviewerHarness,
+										agentConfig: buildRoleAgentConfig(undefined, form.reviewerModel, form.reviewerMode),
+									},
+								]
+							: undefined,
 						trackerIntake: buildIntake(intakeForm),
 						autoReview: form.autoReview,
 					};
@@ -511,6 +525,16 @@ function SettingsBody({
 							<ReviewerSelect
 								value={form.reviewerHarness}
 								onChange={(v) => setForm((f) => ({ ...f, reviewerHarness: v }))}
+								onConfigChange={(agentConfig) =>
+									setForm((f) => ({
+										...f,
+										reviewerModel: agentConfig.model ?? "",
+										reviewerMode: agentConfig.mode ?? "",
+									}))
+								}
+								model={form.reviewerModel}
+								mode={form.reviewerMode}
+								projectId={projectId}
 								ariaLabel={t("settings.project.defaultReviewer")}
 								authorized={agentCatalog?.authorized}
 								defaultOptionLabel={t("settings.project.default")}

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -524,7 +524,13 @@ function SettingsBody({
 						<SettingsRow label={t("settings.project.defaultReviewer")}>
 							<ReviewerSelect
 								value={form.reviewerHarness}
-								onChange={(v) => setForm((f) => ({ ...f, reviewerHarness: v }))}
+								onChange={(v) =>
+									setForm((f) => ({
+										...f,
+										reviewerHarness: v,
+										...(v !== f.reviewerHarness ? { reviewerModel: "", reviewerMode: "" } : {}),
+									}))
+								}
 								onConfigChange={(_harness, agentConfig) =>
 									setForm((f) => ({
 										...f,

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -525,7 +525,7 @@ function SettingsBody({
 							<ReviewerSelect
 								value={form.reviewerHarness}
 								onChange={(v) => setForm((f) => ({ ...f, reviewerHarness: v }))}
-								onConfigChange={(agentConfig) =>
+								onConfigChange={(_harness, agentConfig) =>
 									setForm((f) => ({
 										...f,
 										reviewerModel: agentConfig.model ?? "",

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -205,6 +205,9 @@ function SettingsBody({
 				mode: _legacyMode,
 				...sharedAgentConfig
 			} = config.agentConfig ?? {};
+			const existingReviewer = config.reviewers?.[0];
+			const existingReviewerAgentConfig =
+				existingReviewer?.harness === form.reviewerHarness ? existingReviewer.agentConfig : undefined;
 			const next: ProjectConfig = isScratchProject
 				? {
 						...scratchSupportedConfig(config),
@@ -256,7 +259,7 @@ function SettingsBody({
 							? [
 									{
 										harness: form.reviewerHarness,
-										agentConfig: buildRoleAgentConfig(config.reviewers?.[0]?.agentConfig, form.reviewerModel, form.reviewerMode),
+										agentConfig: buildRoleAgentConfig(existingReviewerAgentConfig, form.reviewerModel, form.reviewerMode),
 									},
 								]
 							: undefined,

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { components } from "../../api/schema";
@@ -81,6 +81,8 @@ export function ReviewerSelect({
 	excludedHarness?: string;
 }) {
 	const { t } = useTranslation();
+	const queryClient = useQueryClient();
+	const [menuOpen, setMenuOpen] = useState(false);
 	const fallbackAgents: AgentInfo[] = [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({ id, label: agentLabel(id) }));
 	const filteredSupported = (supported ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
 	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;
@@ -97,14 +99,28 @@ export function ReviewerSelect({
 		return true;
 	});
 	const effectiveHarness = value || defaultHarness || "";
-	const triggerCatalog = useQuery(agentModelsQueryOptions(effectiveHarness, projectId ?? ""));
+	const menuProjectID = projectId ?? "";
+	const triggerCatalog = useQuery(agentModelsQueryOptions(effectiveHarness, menuProjectID));
+
+	useEffect(() => {
+		if (!menuOpen) return;
+		const harnesses = new Set<string>();
+		if (defaultHarness) harnesses.add(defaultHarness);
+		for (const agent of selectableOptions) {
+			harnesses.add(agent.id);
+		}
+		for (const harness of harnesses) {
+			if (!harness) continue;
+			void queryClient.prefetchQuery(agentModelsQueryOptions(harness, menuProjectID));
+		}
+	}, [defaultHarness, menuOpen, menuProjectID, queryClient, selectableOptions]);
 	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
 	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
 		.filter(Boolean)
 		.join(" · ");
 
 	return (
-		<OptionMenu>
+		<OptionMenu open={menuOpen} onOpenChange={setMenuOpen}>
 			<OptionMenuTrigger
 				className={cn(
 					"w-auto min-w-0 max-w-full justify-between gap-2 px-2 text-left",
@@ -130,7 +146,7 @@ export function ReviewerSelect({
 							onChange(nextHarness);
 							onConfigChange?.(nextHarness, nextConfig);
 						}}
-						projectId={projectId ?? ""}
+						projectId={menuProjectID}
 						resolvedHarness={defaultHarness}
 						persistHarness=""
 					/>
@@ -146,7 +162,7 @@ export function ReviewerSelect({
 							onChange(nextHarness);
 							onConfigChange?.(nextHarness, nextConfig);
 						}}
-						projectId={projectId ?? ""}
+						projectId={menuProjectID}
 						resolvedHarness={agent.id}
 						persistHarness={agent.id}
 					/>
@@ -179,7 +195,7 @@ function ReviewerHarnessOption({
 	const [open, setOpen] = useState(false);
 	const catalogQuery = useQuery({
 		...agentModelsQueryOptions(resolvedHarness ?? "", projectId),
-		enabled: open && Boolean(resolvedHarness),
+		enabled: false,
 	});
 	const catalog = catalogQuery.data;
 	const isCurrent = currentHarness === persistHarness;
@@ -199,7 +215,8 @@ function ReviewerHarnessOption({
 	}
 
 	const hasChoices = hasModelChoices(catalog);
-	if (!hasChoices) {
+	const catalogKnown = catalogQuery.data !== undefined || catalogQuery.isFetched;
+	if (catalogKnown && !hasChoices) {
 		return (
 			<OptionMenuItem
 				onSelect={() => onSelect(persistHarness, {})}
@@ -246,6 +263,9 @@ function ReviewerHarnessOption({
 						{isCurrent && currentModel === "" && currentMode === "" ? <Check aria-hidden="true" className="size-4" /> : null}
 					</span>
 				</OptionMenuItem>
+				{!catalogKnown ? (
+					<OptionMenuItem disabled>{t("common.loading", { defaultValue: "Loading…" })}</OptionMenuItem>
+				) : null}
 				{modelOptions(catalog).map((option) => {
 					const selected = isCurrent && ((option.kind === "mode" && currentMode === option.value) || (option.kind === "model" && currentModel === option.value));
 					return (

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -83,6 +83,7 @@ export function ReviewerSelect({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [menuOpen, setMenuOpen] = useState(false);
+	const [customModel, setCustomModel] = useState("");
 	const fallbackAgents: AgentInfo[] = [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({ id, label: agentLabel(id) }));
 	const filteredSupported = (supported ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
 	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;
@@ -114,7 +115,16 @@ export function ReviewerSelect({
 			void queryClient.prefetchQuery(agentModelsQueryOptions(harness, menuProjectID));
 		}
 	}, [defaultHarness, menuOpen, menuProjectID, queryClient, selectableOptions]);
+	useEffect(() => {
+		if (!menuOpen) setCustomModel("");
+	}, [menuOpen]);
 	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
+	const customModelActionLabel = useMemo(() => {
+		const nextModel = customModel.trim();
+		return nextModel !== ""
+			? t("settings.models.useCustom", { model: nextModel })
+			: t("settings.models.custom");
+	}, [customModel, t]);
 	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
 		.filter(Boolean)
 		.join(" · ");
@@ -167,6 +177,37 @@ export function ReviewerSelect({
 						persistHarness={agent.id}
 					/>
 				))}
+				{supportsReviewerCustomModel(triggerCatalog.data) && effectiveHarness ? (
+					<>
+						<div className="p-1" onKeyDown={(event) => event.stopPropagation()}>
+							<input
+								type="text"
+								aria-label={`Custom ${agentLabel(effectiveHarness)} model`}
+								value={customModel}
+								onChange={(event) => setCustomModel(event.target.value)}
+								placeholder={model || t("settings.models.custom")}
+								className="settings-inline-input w-full"
+								onKeyDown={(event) => {
+									if (event.key !== "Enter") return;
+									const nextModel = customModel.trim();
+									if (nextModel === "") return;
+									event.preventDefault();
+									onConfigChange?.(value, { model: nextModel });
+								}}
+							/>
+						</div>
+						<OptionMenuItem
+							onSelect={() => {
+								const nextModel = customModel.trim();
+								if (nextModel === "") return;
+								onConfigChange?.(value, { model: nextModel });
+							}}
+							disabled={customModel.trim() === ""}
+						>
+							<span className="min-w-0 truncate">{customModelActionLabel}</span>
+						</OptionMenuItem>
+					</>
+				) : null}
 			</OptionMenuContent>
 		</OptionMenu>
 	);
@@ -238,7 +279,7 @@ function ReviewerHarnessOption({
 
 	return (
 		<OptionMenuSub open={open} onOpenChange={setOpen}>
-			<OptionMenuSubTrigger disabled={agent.disabled}>
+			<OptionMenuSubTrigger disabled={agent.disabled} aria-label={agent.status ? `${agent.label}${agent.status}` : agent.label}>
 				<div className="flex min-w-0 items-center justify-between gap-3">
 					<div className="min-w-0">
 						<AgentSelectMenuItem
@@ -250,7 +291,9 @@ function ReviewerHarnessOption({
 							disabled={agent.disabled}
 						/>
 					</div>
-					<span className="min-w-0 truncate text-muted-foreground">{currentLabel || t("settings.models.agentDefault")}</span>
+					<span aria-hidden="true" className="min-w-0 truncate text-muted-foreground">
+						{currentLabel || t("settings.models.agentDefault")}
+					</span>
 				</div>
 			</OptionMenuSubTrigger>
 			<OptionMenuSubContent className="w-[15rem]">
@@ -279,11 +322,15 @@ function ReviewerHarnessOption({
 								{selected ? <Check aria-hidden="true" className="size-4" /> : null}
 							</span>
 						</OptionMenuItem>
-					);
+						);
 				})}
 			</OptionMenuSubContent>
 		</OptionMenuSub>
 	);
+}
+
+function supportsReviewerCustomModel(catalog?: AgentModelCatalog): boolean {
+	return catalog?.selectionMode === "text" && catalog.allowCustom === true;
 }
 
 function hasModelChoices(catalog?: AgentModelCatalog): boolean {

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -221,7 +221,7 @@ function ReviewerHarnessOption({
 
 	return (
 		<OptionMenuSub open={open} onOpenChange={setOpen}>
-			<OptionMenuSubTrigger onClick={() => onSelect(persistHarness, {})} disabled={agent.disabled}>
+			<OptionMenuSubTrigger disabled={agent.disabled}>
 				<div className="flex min-w-0 items-center justify-between gap-3">
 					<div className="min-w-0">
 						<AgentSelectMenuItem

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,10 +1,24 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Check } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import type { components } from "../../api/schema";
+import { agentModelsQueryOptions, type AgentModelCatalog } from "../hooks/useAgentModelsQuery";
 import { agentLabel } from "../lib/agent-options";
-import { buildRankedAgentOptions } from "../lib/agent-select-options";
+import { buildRankedAgentOptions, type RankedAgentOption } from "../lib/agent-select-options";
 import { KNOWN_REVIEWER_HARNESS_IDS } from "../lib/reviewer-harnesses";
+import { cn } from "../lib/utils";
 import { AgentAvatar } from "./AgentAvatar";
 import { AgentSelectMenuItem } from "./settings/AgentSelectMenuItem";
-import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
+import {
+	OptionMenu,
+	OptionMenuContent,
+	OptionMenuItem,
+	OptionMenuSub,
+	OptionMenuSubContent,
+	OptionMenuSubTrigger,
+	OptionMenuTrigger,
+} from "./ui/option-menu";
 
 const REVIEWER_AGENT_PRIORITY = ["claude-code", "codex", "cursor", "opencode", "muse", "aider"] as const;
 const REVIEWER_AGENT_PRIORITY_RANK = new Map<string, number>(
@@ -13,6 +27,9 @@ const REVIEWER_AGENT_PRIORITY_RANK = new Map<string, number>(
 
 const HOST_TRUSTED_REVIEWERS = new Set(["agy", "continue", "devin", "droid", "goose", "kimchi", "kimi", "qwen", "vibe"]);
 const USER_APPROVED_REVIEWERS = new Set(["auggie", "autohand", "cline", "crush", "grok"]);
+
+type ReviewerAgentConfig = components["schemas"]["AgentConfig"];
+type AgentInfo = components["schemas"]["AgentInfo"];
 
 export function reviewerTrustWarning(harness: string): string | null {
 	if (HOST_TRUSTED_REVIEWERS.has(harness)) {
@@ -27,12 +44,12 @@ export function reviewerTrustWarning(harness: string): string | null {
 export function ReviewerSelect({
 	value,
 	onChange,
+	onConfigChange,
+	model = "",
+	mode = "",
+	projectId,
 	triggerClassName,
-	// The same picker serves the project default and a one-off override for the
-	// next run, so the caller names it.
 	ariaLabel = "Default reviewer agent",
-	// Naming what "project default" resolves to matters when nothing has run yet,
-	// so the picker can say which agent that actually is.
 	defaultHarness,
 	defaultOptionLabel,
 	defaultTriggerLabel,
@@ -46,6 +63,10 @@ export function ReviewerSelect({
 }: {
 	value: string;
 	onChange: (value: string) => void;
+	onConfigChange?: (config: ReviewerAgentConfig) => void;
+	model?: string;
+	mode?: string;
+	projectId?: string;
 	triggerClassName?: string;
 	ariaLabel?: string;
 	defaultHarness?: string;
@@ -54,18 +75,13 @@ export function ReviewerSelect({
 	showDefaultOption?: boolean;
 	contentAlign?: "start" | "end";
 	disabled?: boolean;
-	authorized?: components["schemas"]["AgentInfo"][];
-	installed?: components["schemas"]["AgentInfo"][];
-	supported?: components["schemas"]["AgentInfo"][];
+	authorized?: AgentInfo[];
+	installed?: AgentInfo[];
+	supported?: AgentInfo[];
 	excludedHarness?: string;
 }) {
-	// Until the daemon's catalog arrives these entries carry the whole menu, so
-	// label them the way the catalog would rather than printing bare ids: without
-	// this the same row reads "claude-code" now and "Claude Code" a moment later.
-	const fallbackAgents: components["schemas"]["AgentInfo"][] = [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({
-		id,
-		label: agentLabel(id),
-	}));
+	const { t } = useTranslation();
+	const fallbackAgents: AgentInfo[] = [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({ id, label: agentLabel(id) }));
 	const filteredSupported = (supported ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
 	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;
 	const options = buildRankedAgentOptions({
@@ -75,56 +91,197 @@ export function ReviewerSelect({
 		priorityRank: REVIEWER_AGENT_PRIORITY_RANK,
 		fallbackAgents,
 	});
-	const selectableOptions = options.filter((agent) => agent.id !== excludedHarness);
-
-	const menuOptions = [
-		...(showDefaultOption && defaultOptionLabel ? [{ value: "__default__", label: defaultOptionLabel }] : []),
-		...selectableOptions.map((agent) => ({ value: agent.id, label: agent.label, disabled: agent.disabled })),
-	];
-	const selectedValue = value && value !== excludedHarness ? value : "__default__";
+	const selectableOptions = options.filter((agent) => {
+		if (agent.id === excludedHarness) return false;
+		if (showDefaultOption && defaultHarness && agent.id === defaultHarness) return false;
+		return true;
+	});
+	const effectiveHarness = value || defaultHarness || "";
+	const triggerCatalog = useQuery(agentModelsQueryOptions(effectiveHarness, projectId ?? ""));
+	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
+	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
+		.filter(Boolean)
+		.join(" · ");
 
 	return (
-		<SettingsOptionMenu
-			aria-label={ariaLabel}
-			value={selectedValue}
-			options={menuOptions}
-			disabled={disabled}
-			menuClassName="reviews-agent-menu-surface"
-			menuItemClassName="reviews-agent-menu-item"
-			menuAlign={contentAlign}
-			triggerClassName={triggerClassName}
-			onChange={(v) => onChange(v === "__default__" ? "" : v)}
-			renderTrigger={(selected) => (
-				<>
-					{selected && selected.value !== "__default__" ? (
-						<AgentAvatar provider={selected.value} className="size-icon-lg" />
-					) : defaultHarness ? (
-						<AgentAvatar provider={defaultHarness} className="size-icon-lg" />
-					) : null}
-					<span className={contentAlign === "end" ? "min-w-0 truncate text-right" : "min-w-0 truncate"}>
-						{selected && selected.value !== "__default__"
-							? selected.label
-							: (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness)}
-					</span>
-				</>
-			)}
-			renderMenuItem={(option, selected) => {
-				if (option.value === "__default__") {
-					return <AgentSelectMenuItem label={option.label} selected={selected} />;
-				}
-				const agent = selectableOptions.find((entry) => entry.id === option.value);
-				if (!agent) return option.label;
-				return (
-					<AgentSelectMenuItem
-						agentId={agent.id}
-						label={agent.label}
-						selected={selected}
-						status={agent.status}
-						statusTone={agent.statusTone}
-						disabled={agent.disabled}
+		<OptionMenu>
+			<OptionMenuTrigger
+				className={cn(
+					"w-auto min-w-0 max-w-full justify-between gap-2 px-2 text-left",
+					contentAlign === "end" && "justify-end text-right",
+					triggerClassName,
+				)}
+				aria-label={ariaLabel}
+				disabled={disabled}
+			>
+				<span className="flex min-w-0 items-center gap-2">
+					{effectiveHarness ? <AgentAvatar provider={effectiveHarness} className="size-icon-lg shrink-0" /> : null}
+					<span className={cn("min-w-0 truncate", contentAlign === "end" && "text-right")}>{triggerLabel}</span>
+				</span>
+			</OptionMenuTrigger>
+			<OptionMenuContent align={contentAlign === "end" ? "end" : "start"} className="reviews-agent-menu-surface w-[18rem]">
+				{showDefaultOption && defaultOptionLabel ? (
+					<ReviewerHarnessOption
+						agent={{ id: "__default__", label: defaultOptionLabel, disabled: false, status: "", statusTone: "success" }}
+						currentHarness={value}
+						currentModel={model}
+						currentMode={mode}
+						onSelect={(nextHarness, nextConfig) => {
+							onChange(nextHarness);
+							onConfigChange?.(nextConfig);
+						}}
+						projectId={projectId ?? ""}
+						resolvedHarness={defaultHarness}
+						persistHarness=""
 					/>
-				);
-			}}
-		/>
+				) : null}
+				{selectableOptions.map((agent) => (
+					<ReviewerHarnessOption
+						key={agent.id}
+						agent={agent}
+						currentHarness={value}
+						currentModel={model}
+						currentMode={mode}
+						onSelect={(nextHarness, nextConfig) => {
+							onChange(nextHarness);
+							onConfigChange?.(nextConfig);
+						}}
+						projectId={projectId ?? ""}
+						resolvedHarness={agent.id}
+						persistHarness={agent.id}
+					/>
+				))}
+			</OptionMenuContent>
+		</OptionMenu>
 	);
+}
+
+function ReviewerHarnessOption({
+	agent,
+	currentHarness,
+	currentModel,
+	currentMode,
+	onSelect,
+	projectId,
+	resolvedHarness,
+	persistHarness,
+}: {
+	agent: Pick<RankedAgentOption, "id" | "label" | "status" | "statusTone" | "disabled">;
+	currentHarness: string;
+	currentModel: string;
+	currentMode: string;
+	onSelect: (harness: string, config: ReviewerAgentConfig) => void;
+	projectId: string;
+	resolvedHarness?: string;
+	persistHarness: string;
+}) {
+	const { t } = useTranslation();
+	const [open, setOpen] = useState(false);
+	const catalogQuery = useQuery({
+		...agentModelsQueryOptions(resolvedHarness ?? "", projectId),
+		enabled: open && Boolean(resolvedHarness),
+	});
+	const catalog = catalogQuery.data;
+	const isCurrent = currentHarness === persistHarness;
+	const currentLabel = isCurrent
+		? modelOrModeLabel(catalog, currentModel, currentMode, t("settings.models.agentDefault"))
+		: "";
+
+	if (!resolvedHarness) {
+		return (
+			<OptionMenuItem onSelect={() => onSelect("", {})} active={currentHarness === "" && currentModel === "" && currentMode === ""}>
+				<span className="flex min-w-0 items-center justify-between gap-3">
+					<span>{agent.label}</span>
+					{currentHarness === "" && currentModel === "" && currentMode === "" ? <Check aria-hidden="true" className="size-4" /> : null}
+				</span>
+			</OptionMenuItem>
+		);
+	}
+
+	const hasChoices = hasModelChoices(catalog);
+	if (!hasChoices) {
+		return (
+			<OptionMenuItem
+				onSelect={() => onSelect(persistHarness, {})}
+				active={isCurrent && currentModel === "" && currentMode === ""}
+				className="reviews-agent-menu-item"
+			>
+				<AgentSelectMenuItem
+					agentId={resolvedHarness}
+					label={agent.label}
+					selected={isCurrent}
+					status={agent.status}
+					statusTone={agent.statusTone}
+					disabled={agent.disabled}
+				/>
+			</OptionMenuItem>
+		);
+	}
+
+	return (
+		<OptionMenuSub open={open} onOpenChange={setOpen}>
+			<OptionMenuSubTrigger onClick={() => onSelect(persistHarness, {})}>
+				<div className="flex min-w-0 items-center justify-between gap-3">
+					<div className="min-w-0">
+						<AgentSelectMenuItem
+							agentId={resolvedHarness}
+							label={agent.label}
+							selected={isCurrent}
+							status={agent.status}
+							statusTone={agent.statusTone}
+							disabled={agent.disabled}
+						/>
+					</div>
+					<span className="min-w-0 truncate text-muted-foreground">{currentLabel || t("settings.models.agentDefault")}</span>
+				</div>
+			</OptionMenuSubTrigger>
+			<OptionMenuSubContent className="w-[15rem]">
+				<OptionMenuItem
+					onSelect={() => onSelect(persistHarness, {})}
+					active={isCurrent && currentModel === "" && currentMode === ""}
+				>
+					<span className="flex min-w-0 items-center justify-between gap-3">
+						<span>{t("settings.models.agentDefault")}</span>
+						{isCurrent && currentModel === "" && currentMode === "" ? <Check aria-hidden="true" className="size-4" /> : null}
+					</span>
+				</OptionMenuItem>
+				{modelOptions(catalog).map((option) => {
+					const selected = isCurrent && ((option.kind === "mode" && currentMode === option.value) || (option.kind === "model" && currentModel === option.value));
+					return (
+						<OptionMenuItem
+							key={`${option.kind}:${option.value}`}
+							onSelect={() => onSelect(persistHarness, option.kind === "mode" ? { mode: option.value } : { model: option.value })}
+							active={selected}
+						>
+							<span className="flex min-w-0 items-center justify-between gap-3">
+								<span className="min-w-0 truncate">{option.label}</span>
+								{selected ? <Check aria-hidden="true" className="size-4" /> : null}
+							</span>
+						</OptionMenuItem>
+					);
+				})}
+			</OptionMenuSubContent>
+		</OptionMenuSub>
+	);
+}
+
+function hasModelChoices(catalog?: AgentModelCatalog): boolean {
+	return modelOptions(catalog).length > 0;
+}
+
+function modelOptions(catalog?: AgentModelCatalog): Array<{ kind: "model" | "mode"; label: string; value: string }> {
+	if (!catalog) return [];
+	if (catalog.selectionMode !== "catalog" && catalog.selectionMode !== "mode") return [];
+	return (catalog.models ?? []).map((item) => ({
+		kind: catalog.selectionMode === "mode" ? "mode" : "model",
+		label: item.label,
+		value: item.id,
+	}));
+}
+
+function modelOrModeLabel(catalog: AgentModelCatalog | undefined, model: string, mode: string, emptyLabel: string): string {
+	const value = mode || model;
+	if (!value) return emptyLabel;
+	const match = catalog?.models?.find((item) => item.id === value);
+	return match?.label || value;
 }

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -63,7 +63,7 @@ export function ReviewerSelect({
 }: {
 	value: string;
 	onChange: (value: string) => void;
-	onConfigChange?: (config: ReviewerAgentConfig) => void;
+	onConfigChange?: (harness: string, config: ReviewerAgentConfig) => void;
 	model?: string;
 	mode?: string;
 	projectId?: string;
@@ -128,7 +128,7 @@ export function ReviewerSelect({
 						currentMode={mode}
 						onSelect={(nextHarness, nextConfig) => {
 							onChange(nextHarness);
-							onConfigChange?.(nextConfig);
+							onConfigChange?.(nextHarness, nextConfig);
 						}}
 						projectId={projectId ?? ""}
 						resolvedHarness={defaultHarness}
@@ -144,7 +144,7 @@ export function ReviewerSelect({
 						currentMode={mode}
 						onSelect={(nextHarness, nextConfig) => {
 							onChange(nextHarness);
-							onConfigChange?.(nextConfig);
+							onConfigChange?.(nextHarness, nextConfig);
 						}}
 						projectId={projectId ?? ""}
 						resolvedHarness={agent.id}
@@ -205,6 +205,7 @@ function ReviewerHarnessOption({
 				onSelect={() => onSelect(persistHarness, {})}
 				active={isCurrent && currentModel === "" && currentMode === ""}
 				className="reviews-agent-menu-item"
+				disabled={agent.disabled}
 			>
 				<AgentSelectMenuItem
 					agentId={resolvedHarness}
@@ -220,7 +221,7 @@ function ReviewerHarnessOption({
 
 	return (
 		<OptionMenuSub open={open} onOpenChange={setOpen}>
-			<OptionMenuSubTrigger onClick={() => onSelect(persistHarness, {})}>
+			<OptionMenuSubTrigger onClick={() => onSelect(persistHarness, {})} disabled={agent.disabled}>
 				<div className="flex min-w-0 items-center justify-between gap-3">
 					<div className="min-w-0">
 						<AgentSelectMenuItem

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -83,7 +83,6 @@ export function ReviewerSelect({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [menuOpen, setMenuOpen] = useState(false);
-	const [customModel, setCustomModel] = useState("");
 	const fallbackAgents: AgentInfo[] = [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({ id, label: agentLabel(id) }));
 	const filteredSupported = (supported ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
 	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;
@@ -115,16 +114,7 @@ export function ReviewerSelect({
 			void queryClient.prefetchQuery(agentModelsQueryOptions(harness, menuProjectID));
 		}
 	}, [defaultHarness, menuOpen, menuProjectID, queryClient, selectableOptions]);
-	useEffect(() => {
-		if (!menuOpen) setCustomModel("");
-	}, [menuOpen]);
 	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
-	const customModelActionLabel = useMemo(() => {
-		const nextModel = customModel.trim();
-		return nextModel !== ""
-			? t("settings.models.useCustom", { model: nextModel })
-			: t("settings.models.custom");
-	}, [customModel, t]);
 	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
 		.filter(Boolean)
 		.join(" · ");
@@ -177,37 +167,6 @@ export function ReviewerSelect({
 						persistHarness={agent.id}
 					/>
 				))}
-				{supportsReviewerCustomModel(triggerCatalog.data) && effectiveHarness ? (
-					<>
-						<div className="p-1" onKeyDown={(event) => event.stopPropagation()}>
-							<input
-								type="text"
-								aria-label={`Custom ${agentLabel(effectiveHarness)} model`}
-								value={customModel}
-								onChange={(event) => setCustomModel(event.target.value)}
-								placeholder={model || t("settings.models.custom")}
-								className="settings-inline-input w-full"
-								onKeyDown={(event) => {
-									if (event.key !== "Enter") return;
-									const nextModel = customModel.trim();
-									if (nextModel === "") return;
-									event.preventDefault();
-									onConfigChange?.(value, { model: nextModel });
-								}}
-							/>
-						</div>
-						<OptionMenuItem
-							onSelect={() => {
-								const nextModel = customModel.trim();
-								if (nextModel === "") return;
-								onConfigChange?.(value, { model: nextModel });
-							}}
-							disabled={customModel.trim() === ""}
-						>
-							<span className="min-w-0 truncate">{customModelActionLabel}</span>
-						</OptionMenuItem>
-					</>
-				) : null}
 			</OptionMenuContent>
 		</OptionMenu>
 	);
@@ -240,9 +199,6 @@ function ReviewerHarnessOption({
 	});
 	const catalog = catalogQuery.data;
 	const isCurrent = currentHarness === persistHarness;
-	const currentLabel = isCurrent
-		? modelOrModeLabel(catalog, currentModel, currentMode, t("settings.models.agentDefault"))
-		: "";
 
 	if (!resolvedHarness) {
 		return (
@@ -256,15 +212,50 @@ function ReviewerHarnessOption({
 	}
 
 	const hasChoices = hasModelChoices(catalog);
+	const supportsCustomModel = supportsReviewerCustomModel(catalog);
 	const catalogKnown = catalogQuery.data !== undefined || catalogQuery.isFetched;
+
 	if (catalogKnown && !hasChoices) {
 		return (
-			<OptionMenuItem
-				onSelect={() => onSelect(persistHarness, {})}
-				active={isCurrent && currentModel === "" && currentMode === ""}
-				className="reviews-agent-menu-item"
-				disabled={agent.disabled}
-			>
+			<>
+				<OptionMenuItem
+					onSelect={() => onSelect(persistHarness, {})}
+					active={isCurrent && currentModel === "" && currentMode === ""}
+					className="reviews-agent-menu-item"
+					disabled={agent.disabled}
+				>
+					<AgentSelectMenuItem
+						agentId={resolvedHarness}
+						label={agent.label}
+						selected={isCurrent}
+						status={agent.status}
+						statusTone={agent.statusTone}
+						disabled={agent.disabled}
+					/>
+				</OptionMenuItem>
+				{supportsCustomModel ? (
+					<OptionMenuSub>
+						<OptionMenuSubTrigger
+							className="pl-8 text-sm text-settings-muted"
+							aria-label={`Custom ${agent.label} model`}
+							label={t("settings.models.custom")}
+						/>
+						<OptionMenuSubContent className="w-[15rem]">
+							<ReviewerCustomModelOption
+								label={agent.label}
+								currentModel={isCurrent ? currentModel : ""}
+								onSelect={(nextModel) => onSelect(persistHarness, { model: nextModel })}
+							/>
+						</OptionMenuSubContent>
+					</OptionMenuSub>
+				) : null}
+			</>
+		);
+	}
+
+	return (
+		<OptionMenuSub open={open} onOpenChange={setOpen}>
+			<OptionMenuSubTrigger disabled={agent.disabled} aria-label={agent.status ? `${agent.label}${agent.status}` : agent.label}>
 				<AgentSelectMenuItem
 					agentId={resolvedHarness}
 					label={agent.label}
@@ -273,28 +264,6 @@ function ReviewerHarnessOption({
 					statusTone={agent.statusTone}
 					disabled={agent.disabled}
 				/>
-			</OptionMenuItem>
-		);
-	}
-
-	return (
-		<OptionMenuSub open={open} onOpenChange={setOpen}>
-			<OptionMenuSubTrigger disabled={agent.disabled} aria-label={agent.status ? `${agent.label}${agent.status}` : agent.label}>
-				<div className="flex min-w-0 items-center justify-between gap-3">
-					<div className="min-w-0">
-						<AgentSelectMenuItem
-							agentId={resolvedHarness}
-							label={agent.label}
-							selected={isCurrent}
-							status={agent.status}
-							statusTone={agent.statusTone}
-							disabled={agent.disabled}
-						/>
-					</div>
-					<span aria-hidden="true" className="min-w-0 truncate text-muted-foreground">
-						{currentLabel || t("settings.models.agentDefault")}
-					</span>
-				</div>
 			</OptionMenuSubTrigger>
 			<OptionMenuSubContent className="w-[15rem]">
 				<OptionMenuItem
@@ -310,7 +279,10 @@ function ReviewerHarnessOption({
 					<OptionMenuItem disabled>{t("common.loading", { defaultValue: "Loading…" })}</OptionMenuItem>
 				) : null}
 				{modelOptions(catalog).map((option) => {
-					const selected = isCurrent && ((option.kind === "mode" && currentMode === option.value) || (option.kind === "model" && currentModel === option.value));
+					const selected =
+						isCurrent &&
+						((option.kind === "mode" && currentMode === option.value) ||
+							(option.kind === "model" && currentModel === option.value));
 					return (
 						<OptionMenuItem
 							key={`${option.kind}:${option.value}`}
@@ -322,10 +294,61 @@ function ReviewerHarnessOption({
 								{selected ? <Check aria-hidden="true" className="size-4" /> : null}
 							</span>
 						</OptionMenuItem>
-						);
+					);
 				})}
 			</OptionMenuSubContent>
 		</OptionMenuSub>
+	);
+}
+
+function ReviewerCustomModelOption({
+	label,
+	currentModel,
+	onSelect,
+}: {
+	label: string;
+	currentModel: string;
+	onSelect: (model: string) => void;
+}) {
+	const { t } = useTranslation();
+	const [customModel, setCustomModel] = useState("");
+	const customModelActionLabel = useMemo(() => {
+		const nextModel = customModel.trim();
+		return nextModel !== ""
+			? t("settings.models.useCustom", { model: nextModel })
+			: t("settings.models.custom");
+	}, [customModel, t]);
+
+	return (
+		<>
+			<div className="p-1" onKeyDown={(event) => event.stopPropagation()}>
+				<input
+					type="text"
+					aria-label={`Custom ${label} model`}
+					value={customModel}
+					onChange={(event) => setCustomModel(event.target.value)}
+					placeholder={currentModel || t("settings.models.custom")}
+					className="settings-inline-input w-full"
+					onKeyDown={(event) => {
+						if (event.key !== "Enter") return;
+						const nextModel = customModel.trim();
+						if (nextModel === "") return;
+						event.preventDefault();
+						onSelect(nextModel);
+					}}
+				/>
+			</div>
+			<OptionMenuItem
+				onSelect={() => {
+					const nextModel = customModel.trim();
+					if (nextModel === "") return;
+					onSelect(nextModel);
+				}}
+				disabled={customModel.trim() === ""}
+			>
+				<span className="min-w-0 truncate">{customModelActionLabel}</span>
+			</OptionMenuItem>
+		</>
 	);
 }
 

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -378,7 +378,7 @@ function hasModelChoices(catalog?: AgentModelCatalog): boolean {
 
 function modelOptions(catalog?: AgentModelCatalog): Array<{ kind: "model" | "mode"; label: string; value: string }> {
 	if (!catalog) return [];
-	if (catalog.selectionMode !== "catalog" && catalog.selectionMode !== "mode") return [];
+	if (catalog.selectionMode !== "catalog" && catalog.selectionMode !== "mode" && catalog.selectionMode !== "text") return [];
 	return (catalog.models ?? []).map((item) => ({
 		kind: catalog.selectionMode === "mode" ? "mode" : "model",
 		label: item.label,

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -237,7 +237,7 @@ function ReviewerHarnessOption({
 					<OptionMenuSub>
 						<OptionMenuSubTrigger
 							className="pl-8 text-sm text-settings-muted"
-							aria-label={`Custom ${agent.label} model`}
+							aria-label={t("settings.models.customAgentModelAria", { label: agent.label })}
 							label={t("settings.models.custom")}
 						/>
 						<OptionMenuSubContent className="w-[15rem]">
@@ -282,7 +282,7 @@ function ReviewerHarnessOption({
 					<OptionMenuSub>
 						<OptionMenuSubTrigger
 							className="text-sm text-settings-muted"
-							aria-label={`Custom ${agent.label} model`}
+							aria-label={t("settings.models.customAgentModelAria", { label: agent.label })}
 							label={t("settings.models.custom")}
 						/>
 						<OptionMenuSubContent className="w-[15rem]">
@@ -340,7 +340,7 @@ function ReviewerCustomModelOption({
 			<div className="p-1" onKeyDown={(event) => event.stopPropagation()}>
 				<input
 					type="text"
-					aria-label={`Custom ${label} model`}
+					aria-label={t("settings.models.customAgentModelAria", { label })}
 					value={customModel}
 					onChange={(event) => setCustomModel(event.target.value)}
 					placeholder={currentModel || t("settings.models.custom")}

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -278,6 +278,22 @@ function ReviewerHarnessOption({
 				{!catalogKnown ? (
 					<OptionMenuItem disabled>{t("common.loading", { defaultValue: "Loading…" })}</OptionMenuItem>
 				) : null}
+				{catalogKnown && supportsCustomModel ? (
+					<OptionMenuSub>
+						<OptionMenuSubTrigger
+							className="text-sm text-settings-muted"
+							aria-label={`Custom ${agent.label} model`}
+							label={t("settings.models.custom")}
+						/>
+						<OptionMenuSubContent className="w-[15rem]">
+							<ReviewerCustomModelOption
+								label={agent.label}
+								currentModel={isCurrent ? currentModel : ""}
+								onSelect={(nextModel) => onSelect(persistHarness, { model: nextModel })}
+							/>
+						</OptionMenuSubContent>
+					</OptionMenuSub>
+				) : null}
 				{modelOptions(catalog).map((option) => {
 					const selected =
 						isCurrent &&

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2938,6 +2938,61 @@ describe("SessionInspector summary reviews", () => {
     );
   });
 
+  it("preserves hidden reviewer config fields when saving a session reviewer model", async () => {
+    getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
+      if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "codex") {
+        return {
+          data: {
+            agentId: "codex",
+            selectionMode: "catalog",
+            models: [
+              { id: "gpt-5", label: "GPT-5", isDefault: true },
+              { id: "gpt-5-mini", label: "GPT-5 Mini" },
+            ],
+            allowCustom: false,
+            source: "official-catalog",
+            fetchedAt: "2026-08-30T00:00:00Z",
+            stale: false,
+          },
+          error: undefined,
+        };
+      }
+      return commonGetsResponder([], "reviewer-pane", [reviewState(3, "needs_review", "sha-1")])(path);
+    });
+    postMock.mockResolvedValue({
+      data: { reviewerHandleId: "", reviews: [] },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    renderWithQuery(
+      <SessionInspector
+        session={session([pr(3, "open")], {
+          reviewerHarness: "codex",
+          reviewerConfig: { model: "gpt-5", permissions: "bypass-permissions" },
+        })}
+      />,
+    );
+    await openReviewsSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "GPT-5 Mini" })).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5 Mini" }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { agentConfig: { model: "gpt-5-mini", permissions: "bypass-permissions" } },
+        },
+      ),
+    );
+  });
+
   it("does not save an empty reviewer config just by opening a harness submenu", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "codex") {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -3040,6 +3040,68 @@ describe("SessionInspector summary reviews", () => {
     expect(postMock).toHaveBeenCalledTimes(1);
   });
 
+  it("allows custom reviewer models for text-selection catalogs with suggested models", async () => {
+    getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
+      if (path === "/api/v1/agents/{agent}/models") {
+        const agent = options?.params?.path?.agent ?? "";
+        if (agent === "opencode") {
+          return {
+            data: {
+              agentId: agent,
+              selectionMode: "text",
+              models: [
+                { id: "suggested-a", label: "Suggested A" },
+                { id: "suggested-b", label: "Suggested B" },
+              ],
+              allowCustom: true,
+              source: "manual",
+              fetchedAt: "2026-08-30T00:00:00Z",
+              stale: false,
+            },
+            error: undefined,
+          };
+        }
+        return {
+          data: {
+            agentId: agent,
+            selectionMode: "catalog",
+            models: [],
+            allowCustom: false,
+            source: "manual",
+            fetchedAt: "2026-08-30T00:00:00Z",
+            stale: false,
+          },
+          error: undefined,
+        };
+      }
+      return commonGetsResponder([], "reviewer-pane", [reviewState(3, "needs_review", "sha-1")])(path);
+    });
+    postMock.mockResolvedValue({
+      data: { reviewerHandleId: "", reviews: [] },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+    await openReviewsSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^custom opencode model$/i }));
+    const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
+    await userEvent.type(customInput, "private/custom-model");
+    await userEvent.click(screen.getByRole("menuitem", { name: /use “private\/custom-model” as a custom model/i }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { harness: "opencode", agentConfig: { model: "private/custom-model" } },
+        },
+      ),
+    );
+  });
+
   it("allows a custom reviewer model for text-selection harnesses", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models") {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -3044,6 +3044,41 @@ describe("SessionInspector summary reviews", () => {
     expect(postMock).toHaveBeenCalledTimes(1);
   });
 
+  it("clears hidden session reviewer config when returning an explicit default-matching reviewer to project default", async () => {
+    mockCommonGets([], "reviewer-pane", [reviewState(3, "needs_review", "sha-1")]);
+    postMock.mockResolvedValue({
+      data: { reviewerHandleId: "", reviews: [] },
+      response: { status: 200 },
+    });
+
+    renderWithQuery(
+      <SessionInspector
+        session={session([pr(3, "open")], {
+          provider: "codex",
+          reviewerHarness: "codex",
+          reviewerConfig: { permissions: "bypass-permissions" },
+        })}
+      />,
+    );
+    await openReviewsSection();
+
+    const picker = await screen.findByRole("button", {
+      name: /Select reviewer agent/,
+    });
+    await userEvent.click(picker);
+    await userEvent.click(screen.getByRole("menuitem", { name: /codex/i }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenLastCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { harness: undefined, agentConfig: undefined },
+        },
+      ),
+    );
+  });
+
   it("keeps an explicit reviewer visible and lets it return to the resolved default", async () => {
     mockCommonGets([], "reviewer-pane", [
       reviewState(3, "needs_review", "sha-1"),

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -3086,6 +3086,8 @@ describe("SessionInspector summary reviews", () => {
     await openReviewsSection();
 
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^opencode$/i }));
+    expect(await screen.findByRole("menuitem", { name: "Suggested A" })).toBeInTheDocument();
     await userEvent.click(await screen.findByRole("menuitem", { name: /^custom opencode model$/i }));
     const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
     await userEvent.type(customInput, "private/custom-model");

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -170,12 +170,12 @@ function renderWithQuery(
   };
 }
 
-function mockCommonGets(
+function commonGetsResponder(
   _unusedRuns: unknown[] = [],
   reviewerHandleId = "",
   reviews: unknown[] = [],
 ) {
-  getMock.mockImplementation(async (path: string) => {
+  return async (path: string) => {
     if (path === "/api/v1/agents") {
       const agents = ["claude-code", "codex", "opencode"].map((id) => ({
         id,
@@ -211,7 +211,15 @@ function mockCommonGets(
       };
     }
     return { data: undefined };
-  });
+  };
+}
+
+function mockCommonGets(
+  _unusedRuns: unknown[] = [],
+  reviewerHandleId = "",
+  reviews: unknown[] = [],
+) {
+  getMock.mockImplementation(commonGetsResponder(_unusedRuns, reviewerHandleId, reviews));
 }
 
 const approvedReview = {
@@ -2927,6 +2935,56 @@ describe("SessionInspector summary reviews", () => {
         params: { path: { sessionId: "sess-1" } },
         body: { harness: "opencode" },
       },
+    );
+  });
+
+  it("does not save an empty reviewer config just by opening a harness submenu", async () => {
+    getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
+      if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "codex") {
+        return {
+          data: {
+            agentId: "codex",
+            selectionMode: "catalog",
+            models: [
+              { id: "gpt-5", label: "GPT-5", isDefault: true },
+              { id: "gpt-5-mini", label: "GPT-5 Mini" },
+            ],
+            allowCustom: false,
+            source: "official-catalog",
+            fetchedAt: "2026-08-29T00:00:00Z",
+            stale: false,
+          },
+          error: undefined,
+        };
+      }
+      return commonGetsResponder([], "reviewer-pane", [reviewState(3, "needs_review", "sha-1")])(path);
+    });
+    postMock.mockResolvedValue({
+      data: { reviewerHandleId: "", reviews: [] },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+    await openReviewsSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "GPT-5 Mini" })).toBeInTheDocument(),
+    );
+    expect(postMock).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5 Mini" }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { agentConfig: { model: "gpt-5-mini" } },
+        },
+      ),
     );
   });
 

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2993,6 +2993,61 @@ describe("SessionInspector summary reviews", () => {
     );
   });
 
+  it("allows a custom reviewer model for text-selection harnesses", async () => {
+    getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
+      if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "opencode") {
+        return {
+          data: {
+            agentId: "opencode",
+            selectionMode: "text",
+            models: [],
+            allowCustom: true,
+            source: "manual",
+            fetchedAt: "2026-08-30T00:00:00Z",
+            stale: false,
+          },
+          error: undefined,
+        };
+      }
+      return commonGetsResponder([], "reviewer-pane", [reviewState(3, "needs_review", "sha-1")])(path);
+    });
+    postMock.mockResolvedValue({
+      data: { reviewerHandleId: "", reviews: [] },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+    await openReviewsSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /opencode/i }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { harness: "opencode" },
+        },
+      ),
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
+    await userEvent.type(customInput, "private/custom-model");
+    await userEvent.click(screen.getByRole("menuitem", { name: /use “private\/custom-model” as a custom model/i }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenLastCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { harness: "opencode", agentConfig: { model: "private/custom-model" } },
+        },
+      ),
+    );
+  });
+
   it("does not save an empty reviewer config just by opening a harness submenu", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "codex") {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2993,15 +2993,16 @@ describe("SessionInspector summary reviews", () => {
     );
   });
 
-  it("allows a custom reviewer model for text-selection harnesses", async () => {
+  it("allows setting a custom reviewer model from another text-reviewer row before selecting it", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
-      if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "opencode") {
+      if (path === "/api/v1/agents/{agent}/models") {
+        const agent = options?.params?.path?.agent ?? "";
         return {
           data: {
-            agentId: "opencode",
-            selectionMode: "text",
+            agentId: agent,
+            selectionMode: agent === "opencode" ? "text" : "catalog",
             models: [],
-            allowCustom: true,
+            allowCustom: agent === "opencode",
             source: "manual",
             fetchedAt: "2026-08-30T00:00:00Z",
             stale: false,
@@ -3021,7 +3022,54 @@ describe("SessionInspector summary reviews", () => {
     await openReviewsSection();
 
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
-    await userEvent.click(await screen.findByRole("menuitem", { name: /opencode/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^custom opencode model$/i }));
+
+    const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
+    await userEvent.type(customInput, "private/custom-model");
+    await userEvent.click(screen.getByRole("menuitem", { name: /use “private\/custom-model” as a custom model/i }));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { harness: "opencode", agentConfig: { model: "private/custom-model" } },
+        },
+      ),
+    );
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a custom reviewer model for text-selection harnesses", async () => {
+    getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
+      if (path === "/api/v1/agents/{agent}/models") {
+        const agent = options?.params?.path?.agent ?? "";
+        return {
+          data: {
+            agentId: agent,
+            selectionMode: agent === "opencode" ? "text" : "catalog",
+            models: [],
+            allowCustom: agent === "opencode",
+            source: "manual",
+            fetchedAt: "2026-08-30T00:00:00Z",
+            stale: false,
+          },
+          error: undefined,
+        };
+      }
+      return commonGetsResponder([], "reviewer-pane", [reviewState(3, "needs_review", "sha-1")])(path);
+    });
+    postMock.mockResolvedValue({
+      data: { reviewerHandleId: "", reviews: [] },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+    await openReviewsSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^opencode$/i }));
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith(
         "/api/v1/sessions/{sessionId}/reviews/switch",
@@ -3033,6 +3081,7 @@ describe("SessionInspector summary reviews", () => {
     );
 
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^custom opencode model$/i }));
     const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
     await userEvent.type(customInput, "private/custom-model");
     await userEvent.click(screen.getByRole("menuitem", { name: /use “private\/custom-model” as a custom model/i }));

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2986,6 +2986,7 @@ describe("SessionInspector summary reviews", () => {
         },
       ),
     );
+    expect(postMock).toHaveBeenCalledTimes(1);
   });
 
   it("keeps an explicit reviewer visible and lets it return to the resolved default", async () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1511,10 +1511,13 @@ function ReviewsSection({
 	}, [session.id, session.reviewerConfig?.mode, session.reviewerConfig?.model, session.reviewerHarness]);
 	const saveReviewer = useMutation({
 		mutationFn: async ({ harness, model, mode }: { harness: ReviewerHarness | ""; model: string; mode: string }) => {
+			const clearingToProjectDefault = harness === "" && model === "" && mode === "";
 			const currentEffectiveReviewerHarness = (session.reviewerHarness ?? "") || currentDefaultReviewerHarness;
 			const nextEffectiveReviewerHarness = harness || currentDefaultReviewerHarness;
 			const existingReviewerConfig =
-				currentEffectiveReviewerHarness === nextEffectiveReviewerHarness ? session.reviewerConfig : undefined;
+				!clearingToProjectDefault && currentEffectiveReviewerHarness === nextEffectiveReviewerHarness
+					? session.reviewerConfig
+					: undefined;
 			const nextReviewerConfig = buildReviewerAgentConfig(existingReviewerConfig, model, mode);
 			const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/switch", {
 				params: { path: { sessionId: session.id } },

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1501,14 +1501,21 @@ function ReviewsSection({
 	const [reviewerOverride, setReviewerOverride] = useState<ReviewerHarness | "">(
 		session.reviewerHarness ?? "",
 	);
+	const [reviewerModel, setReviewerModel] = useState(session.reviewerConfig?.model ?? "");
+	const [reviewerMode, setReviewerMode] = useState(session.reviewerConfig?.mode ?? "");
 	useEffect(() => {
 		setReviewerOverride(session.reviewerHarness ?? "");
-	}, [session.id, session.reviewerHarness]);
+		setReviewerModel(session.reviewerConfig?.model ?? "");
+		setReviewerMode(session.reviewerConfig?.mode ?? "");
+	}, [session.id, session.reviewerConfig?.mode, session.reviewerConfig?.model, session.reviewerHarness]);
 	const saveReviewer = useMutation({
-		mutationFn: async (harness: ReviewerHarness | "") => {
+		mutationFn: async ({ harness, model, mode }: { harness: ReviewerHarness | ""; model: string; mode: string }) => {
 			const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/switch", {
 				params: { path: { sessionId: session.id } },
-				body: { harness: harness || undefined },
+				body: {
+					harness: harness || undefined,
+					agentConfig: model || mode ? { ...(model ? { model } : {}), ...(mode ? { mode } : {}) } : undefined,
+				},
 			});
 			if (error) throw new Error(apiErrorMessage(error, "Unable to save reviewer"));
 			if (data) queryClient.setQueryData(["session-reviews", session.id], data);
@@ -1544,9 +1551,12 @@ function ReviewsSection({
 			});
 			// No override sends no body at all, leaving the default path on the wire
 			// exactly as it was.
+			const reviewerConfig = reviewerModel || reviewerMode
+				? { ...(reviewerModel ? { model: reviewerModel } : {}), ...(reviewerMode ? { mode: reviewerMode } : {}) }
+				: undefined;
 			const { data, error, response } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/trigger", {
 				params: { path: { sessionId: session.id } },
-				...(reviewerOverride ? { body: { harness: reviewerOverride } } : {}),
+				...(reviewerOverride || reviewerConfig ? { body: { ...(reviewerOverride ? { harness: reviewerOverride } : {}), ...(reviewerConfig ? { agentConfig: reviewerConfig } : {}) } } : {}),
 			});
 			if (error) throw new Error(apiErrorMessage(error, t("inspector.unableStartReview")));
 			return { data, reused: response?.status === 200 };
@@ -1636,9 +1646,13 @@ function ReviewsSection({
 				notice={reviewNotice}
 				agentCatalog={agentsQuery.data}
 				reviewerOverride={reviewerOverride}
-				onReviewerOverrideChange={(next) => {
+				reviewerModel={reviewerModel}
+				reviewerMode={reviewerMode}
+				onReviewerOverrideChange={(next, config) => {
 					setReviewerOverride(next);
-					saveReviewer.mutate(next);
+					setReviewerModel(config.model ?? "");
+					setReviewerMode(config.mode ?? "");
+					saveReviewer.mutate({ harness: next, model: config.model ?? "", mode: config.mode ?? "" });
 				}}
 				session={session}
 			/>
@@ -2085,6 +2099,8 @@ function ReviewPanel({
 	notice,
 	agentCatalog,
 	reviewerOverride,
+	reviewerModel,
+	reviewerMode,
 	onReviewerOverrideChange,
 	onTrigger,
 	onCancel,
@@ -2105,7 +2121,9 @@ function ReviewPanel({
 	notice: string | null;
 	agentCatalog?: AgentCatalog;
 	reviewerOverride: ReviewerHarness | "";
-	onReviewerOverrideChange: (next: ReviewerHarness | "") => void;
+	reviewerModel: string;
+	reviewerMode: string;
+	onReviewerOverrideChange: (next: ReviewerHarness | "", config: { model?: string; mode?: string }) => void;
 	onTrigger: () => void;
 	onCancel: () => void;
 	onAutoReviewChange: (enabled: boolean) => void;
@@ -2223,11 +2241,14 @@ function ReviewPanel({
 							defaultOptionLabel={agentLabel(resolvedDefaultHarness)}
 							disabled={reviewRunning || autoReviewEnabled || isKilling || isSwitchingReviewer || isTriggering || isCancelling}
 							installed={agentCatalog?.installed}
-							onChange={(next) => onReviewerOverrideChange(next as ReviewerHarness | "")}
+							onChange={(next) => onReviewerOverrideChange(next as ReviewerHarness | "", {})}
+							onConfigChange={(config) => onReviewerOverrideChange(reviewerOverride, config)}
+							model={reviewerModel}
+							mode={reviewerMode}
+							projectId={session.workspaceId}
 							supported={agentCatalog?.supported}
 							triggerClassName="review-run-agent-select ml-auto h-control-md w-auto min-w-0 max-w-[11rem] shrink-0 justify-end px-2 text-right text-xs"
 							value={reviewerOverride}
-							excludedHarness={resolvedDefaultHarness}
 							showDefaultOption
 						/>
 					</div>

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -2242,7 +2242,7 @@ function ReviewPanel({
 							disabled={reviewRunning || autoReviewEnabled || isKilling || isSwitchingReviewer || isTriggering || isCancelling}
 							installed={agentCatalog?.installed}
 							onChange={(next) => onReviewerOverrideChange(next as ReviewerHarness | "", {})}
-							onConfigChange={(config) => onReviewerOverrideChange(reviewerOverride, config)}
+							onConfigChange={(harness, config) => onReviewerOverrideChange(harness as ReviewerHarness | "", config)}
 							model={reviewerModel}
 							mode={reviewerMode}
 							projectId={session.workspaceId}

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1654,6 +1654,11 @@ function ReviewsSection({
 					setReviewerMode(config.mode ?? "");
 					saveReviewer.mutate({ harness: next, model: config.model ?? "", mode: config.mode ?? "" });
 				}}
+				onReviewerHarnessPreviewChange={(next) => {
+					setReviewerOverride(next);
+					setReviewerModel("");
+					setReviewerMode("");
+				}}
 				session={session}
 			/>
 			<MergedReviewsSection
@@ -2102,6 +2107,7 @@ function ReviewPanel({
 	reviewerModel,
 	reviewerMode,
 	onReviewerOverrideChange,
+	onReviewerHarnessPreviewChange,
 	onTrigger,
 	onCancel,
 	onAutoReviewChange,
@@ -2124,6 +2130,7 @@ function ReviewPanel({
 	reviewerModel: string;
 	reviewerMode: string;
 	onReviewerOverrideChange: (next: ReviewerHarness | "", config: { model?: string; mode?: string }) => void;
+	onReviewerHarnessPreviewChange: (next: ReviewerHarness | "") => void;
 	onTrigger: () => void;
 	onCancel: () => void;
 	onAutoReviewChange: (enabled: boolean) => void;
@@ -2241,7 +2248,7 @@ function ReviewPanel({
 							defaultOptionLabel={agentLabel(resolvedDefaultHarness)}
 							disabled={reviewRunning || autoReviewEnabled || isKilling || isSwitchingReviewer || isTriggering || isCancelling}
 							installed={agentCatalog?.installed}
-							onChange={(next) => onReviewerOverrideChange(next as ReviewerHarness | "", {})}
+							onChange={(next) => onReviewerHarnessPreviewChange(next as ReviewerHarness | "")}
 							onConfigChange={(harness, config) => onReviewerOverrideChange(harness as ReviewerHarness | "", config)}
 							model={reviewerModel}
 							mode={reviewerMode}

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1498,6 +1498,7 @@ function ReviewsSection({
 	// The reviewer preference belongs to the worker session, not this component
 	// or the whole project. Keep local state responsive while the daemon persists
 	// it, and resync when the inspector moves to another session.
+	const currentDefaultReviewerHarness = resolveDefaultReviewerHarness(projectConfigQuery.data, session.provider);
 	const [reviewerOverride, setReviewerOverride] = useState<ReviewerHarness | "">(
 		session.reviewerHarness ?? "",
 	);
@@ -1510,11 +1511,16 @@ function ReviewsSection({
 	}, [session.id, session.reviewerConfig?.mode, session.reviewerConfig?.model, session.reviewerHarness]);
 	const saveReviewer = useMutation({
 		mutationFn: async ({ harness, model, mode }: { harness: ReviewerHarness | ""; model: string; mode: string }) => {
+			const currentEffectiveReviewerHarness = (session.reviewerHarness ?? "") || currentDefaultReviewerHarness;
+			const nextEffectiveReviewerHarness = harness || currentDefaultReviewerHarness;
+			const existingReviewerConfig =
+				currentEffectiveReviewerHarness === nextEffectiveReviewerHarness ? session.reviewerConfig : undefined;
+			const nextReviewerConfig = buildReviewerAgentConfig(existingReviewerConfig, model, mode);
 			const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/switch", {
 				params: { path: { sessionId: session.id } },
 				body: {
 					harness: harness || undefined,
-					agentConfig: model || mode ? { ...(model ? { model } : {}), ...(mode ? { mode } : {}) } : undefined,
+					agentConfig: nextReviewerConfig,
 				},
 			});
 			if (error) throw new Error(apiErrorMessage(error, "Unable to save reviewer"));
@@ -2032,6 +2038,19 @@ function renderReviewMarkdown(body: string) {
 			{body}
 		</ReactMarkdown>
 	);
+}
+
+function buildReviewerAgentConfig(
+	existing: WorkspaceSession["reviewerConfig"] | undefined,
+	model: string,
+	mode: string,
+): { model?: string; mode?: string; permissions?: string } | undefined {
+	const next = { ...existing };
+	if (model) next.model = model;
+	else delete next.model;
+	if (mode) next.mode = mode;
+	else delete next.mode;
+	return Object.keys(next).length > 0 ? next : undefined;
 }
 
 function formatInlineReviewCommentMessage(comment: InspectorInlineComment & { reviewerId?: string }): string {

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -115,6 +115,9 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 						issueId: session.issueId,
 						provider: toAgentProvider(session.harness),
 						reviewerHarness: toReviewerHarnessId(session.reviewerHarness),
+						reviewerConfig: session.reviewerConfig
+							? { model: session.reviewerConfig.model ?? undefined, mode: session.reviewerConfig.mode ?? undefined }
+							: undefined,
 						autoReviewEnabled: session.autoReviewEnabled ?? false,
 						kind: session.kind === "orchestrator" ? "orchestrator" : session.kind === "worker" ? "worker" : undefined,
 						// Carried through verbatim: the session surface must render from

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -116,7 +116,11 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 						provider: toAgentProvider(session.harness),
 						reviewerHarness: toReviewerHarnessId(session.reviewerHarness),
 						reviewerConfig: session.reviewerConfig
-							? { model: session.reviewerConfig.model ?? undefined, mode: session.reviewerConfig.mode ?? undefined }
+							? {
+								model: session.reviewerConfig.model ?? undefined,
+								mode: session.reviewerConfig.mode ?? undefined,
+								permissions: session.reviewerConfig.permissions ?? undefined,
+							}
 							: undefined,
 						autoReviewEnabled: session.autoReviewEnabled ?? false,
 						kind: session.kind === "orchestrator" ? "orchestrator" : session.kind === "worker" ? "worker" : undefined,

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1426,5 +1426,6 @@
 	"settings.project.autoReview": "Auto review",
 	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "Benutzerdefiniertes Modell für {{label}}"
 }

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1408,5 +1408,6 @@
 	"inspector.usage.processedTokens": "Tokens processed",
 	"inspector.usage.processedTokensAria": "{{count}} tokens processed",
 	"inspector.usage.processedTokensUnavailable": "Processed tokens unavailable",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "Custom {{label}} model"
 }

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1443,5 +1443,6 @@
 	"settings.project.autoReview": "Auto review",
 	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "Modelo personalizado de {{label}}"
 }

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1443,5 +1443,6 @@
 	"settings.project.autoReview": "Auto review",
 	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "Modèle personnalisé de {{label}}"
 }

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1426,5 +1426,6 @@
 	"settings.project.autoReview": "Auto review",
 	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "{{label}} のカスタムモデル"
 }

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1426,5 +1426,6 @@
 	"settings.project.autoReview": "Auto review",
 	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "{{label}} 사용자 지정 모델"
 }

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1443,5 +1443,6 @@
 	"settings.project.autoReview": "Auto review",
 	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "Modelo personalizado de {{label}}"
 }

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1408,5 +1408,6 @@
 	"settings.project.autoReview": "Auto review",
 	"settings.project.autoReviewToggle": "Auto review PRs",
 	"settings.project.autoReviewDescription": "When enabled, new worker sessions will automatically review their pull requests. This can still be toggled per session after spawn.",
-	"settings.project.reviewer": "Reviewer"
+	"settings.project.reviewer": "Reviewer",
+	"settings.models.customAgentModelAria": "{{label}} 自定义模型"
 }

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -71,10 +71,11 @@ export type WorkspaceSession = {
 	provider: AgentProvider;
 	/** Reviewer selected for this session; absent means use the project default. */
 	reviewerHarness?: ReviewerHarnessId;
-	/** Per-session reviewer model or mode override. */
+	/** Per-session reviewer override, including hidden fields preserved across saves. */
 	reviewerConfig?: {
 		model?: string;
 		mode?: string;
+		permissions?: string;
 	};
 	/** Whether the daemon may automatically review this session after it becomes idle. */
 	autoReviewEnabled?: boolean;

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -71,6 +71,11 @@ export type WorkspaceSession = {
 	provider: AgentProvider;
 	/** Reviewer selected for this session; absent means use the project default. */
 	reviewerHarness?: ReviewerHarnessId;
+	/** Per-session reviewer model or mode override. */
+	reviewerConfig?: {
+		model?: string;
+		mode?: string;
+	};
 	/** Whether the daemon may automatically review this session after it becomes idle. */
 	autoReviewEnabled?: boolean;
 	kind?: SessionKind;

--- a/frontend/src/shared/shell-env.test.ts
+++ b/frontend/src/shared/shell-env.test.ts
@@ -104,15 +104,6 @@ describe("buildDaemonEnv", () => {
 		expect(env.TERM).toBe("xterm-256color");
 	});
 
-	it("drops broken terminfo overrides inherited by Electron", () => {
-		const env = buildDaemonEnv(
-			{ ...minimalProcessEnv, TERMINFO: "/tmp/missing", TERMINFO_DIRS: "/tmp/missing" },
-			null,
-			{},
-		);
-		expect(env.TERMINFO).toBeUndefined();
-		expect(env.TERMINFO_DIRS).toBeUndefined();
-	});
 });
 
 describe("resolveShellPath", () => {

--- a/frontend/src/shared/shell-env.test.ts
+++ b/frontend/src/shared/shell-env.test.ts
@@ -103,6 +103,16 @@ describe("buildDaemonEnv", () => {
 		const env = buildDaemonEnv({ ...minimalProcessEnv, TERM: "dumb" }, null, {});
 		expect(env.TERM).toBe("xterm-256color");
 	});
+
+	it("drops broken terminfo overrides inherited by Electron", () => {
+		const env = buildDaemonEnv(
+			{ ...minimalProcessEnv, TERMINFO: "/tmp/missing", TERMINFO_DIRS: "/tmp/missing" },
+			null,
+			{},
+		);
+		expect(env.TERMINFO).toBeUndefined();
+		expect(env.TERMINFO_DIRS).toBeUndefined();
+	});
 });
 
 describe("resolveShellPath", () => {

--- a/frontend/src/shared/shell-env.ts
+++ b/frontend/src/shared/shell-env.ts
@@ -188,6 +188,8 @@ export function buildDaemonEnv(
 	const merged: NodeJS.ProcessEnv = { TERM: "xterm-256color", ...(shellEnv ?? {}), ...processEnv };
 	merged.PATH = withFallbackPath(shellEnv?.PATH ?? processEnv.PATH);
 	merged.TERM = normalizeTerm(merged.TERM);
+	delete merged.TERMINFO;
+	delete merged.TERMINFO_DIRS;
 	return { ...merged, ...overrides };
 }
 

--- a/frontend/src/shared/shell-env.ts
+++ b/frontend/src/shared/shell-env.ts
@@ -188,8 +188,6 @@ export function buildDaemonEnv(
 	const merged: NodeJS.ProcessEnv = { TERM: "xterm-256color", ...(shellEnv ?? {}), ...processEnv };
 	merged.PATH = withFallbackPath(shellEnv?.PATH ?? processEnv.PATH);
 	merged.TERM = normalizeTerm(merged.TERM);
-	delete merged.TERMINFO;
-	delete merged.TERMINFO_DIRS;
 	return { ...merged, ...overrides };
 }
 


### PR DESCRIPTION
## Summary
- add a combined reviewer harness/model picker for project and session config using the Pattern 2 flow
- persist reviewer agent config so harness, model, and mode follow review launches and trigger overrides end to end

## Testing
- npm run frontend:typecheck
- cd backend && go test ./internal/httpd/controllers ./internal/service/review ./internal/review ./internal/storage/sqlite/...
- cd frontend && npm run test -- src/shared/shell-env.test.ts

## Risks / follow-ups
- real-data AO startup still shows some unrelated historical session reconcile/log noise in the local daemon
- reviewer model availability depends on the selected harness catalog, so any future harness catalog shape changes should be kept in sync with ReviewerSelect
