### PR TITLE
fix(desktop): hide open-in-editor control for cloud sessions

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -4,7 +4,12 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useUiStore } from "../stores/ui-store";
-import type { SessionActivityState, WorkspaceSession, WorkspaceSummary } from "../types/workspace";
+import {
+	CLOUD_PROJECT_KIND,
+	type SessionActivityState,
+	type WorkspaceSession,
+	type WorkspaceSummary,
+} from "../types/workspace";
 import { ShellTopbar, TopbarKillButton } from "./ShellTopbar";
 import { TooltipProvider } from "./ui/tooltip";
 
@@ -450,9 +455,9 @@ describe("ShellTopbar open-in-editor control", () => {
 		// Cloud sessions have no local workspace: the local daemon has never
 		// heard of them, so this control's own "workspace" query would 404 with
 		// "Unknown session" and surface that raw local-daemon error in the
-		// topbar (see issue #4570). Hiding the control for kind === "cloud"
+		// topbar (see issue #4570). Hiding the control for kind === CLOUD_PROJECT_KIND
 		// avoids the query entirely.
-		renderTopbarSessions([worker], "sess-1", false, undefined, "cloud");
+		renderTopbarSessions([worker], "sess-1", false, undefined, CLOUD_PROJECT_KIND);
 
 		await waitFor(() => {
 			expect(screen.queryByRole("button", { name: "Open in Cursor" })).not.toBeInTheDocument();

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -118,6 +118,7 @@ function renderTopbarSessions(
 	sessionId: string,
 	embedded = false,
 	sessionAction?: ReactNode,
+	projectKind?: WorkspaceSummary["kind"],
 ) {
 	const data: WorkspaceSummary[] = [
 		{
@@ -125,6 +126,7 @@ function renderTopbarSessions(
 			name: sessions[0].workspaceName,
 			path: "/repo/my-app",
 			orchestratorAgent: "claude-code",
+			kind: projectKind,
 			sessions,
 		},
 	];
@@ -434,6 +436,28 @@ describe("ShellTopbar inspector state", () => {
 		expect(screen.getByTestId("session-pinned-actions-reserve")).toBe(reserve);
 		expect(reserve).toHaveAttribute("data-state", "collapsed");
 		expect(within(reserve).queryByRole("button")).not.toBeInTheDocument();
+	});
+});
+
+describe("ShellTopbar open-in-editor control", () => {
+	it("shows the open-in-editor control for a local session", async () => {
+		renderTopbarSessions([worker], "sess-1");
+
+		expect(await screen.findByRole("button", { name: "Open in Cursor" })).toBeInTheDocument();
+	});
+
+	it("hides the open-in-editor control for a cloud session instead of asking the local daemon for it", async () => {
+		// Cloud sessions have no local workspace: the local daemon has never
+		// heard of them, so this control's own "workspace" query would 404 with
+		// "Unknown session" and surface that raw local-daemon error in the
+		// topbar (see issue #4570). Hiding the control for kind === "cloud"
+		// avoids the query entirely.
+		renderTopbarSessions([worker], "sess-1", false, undefined, "cloud");
+
+		await waitFor(() => {
+			expect(screen.queryByRole("button", { name: "Open in Cursor" })).not.toBeInTheDocument();
+			expect(screen.queryByRole("button", { name: "Choose editor" })).not.toBeInTheDocument();
+		});
 	});
 });
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -352,8 +352,11 @@ export function ShellTopbar({
 						{/* Open-in-editor leads the session actions: it is the only
 						    non-destructive one, and it must sit left of Kill. Kept outside
 						    the local-actions group because Electron main independently
-						    reports whether this session has a live workspace. */}
-						{session ? (
+						    reports whether this session has a live workspace. Cloud sessions
+						    have no local workspace to hand off to an editor: the local daemon
+						    has never heard of them, so querying it just surfaces its 404 as a
+						    confusing "Unknown session" error (see workspace.ts's `kind` doc). */}
+						{session && project?.kind !== "cloud" ? (
 							// Keyed per session so a stale launch error does not carry over
 							// when switching sessions. The prefix keeps it distinct from the
 							// kill button's key: identical sibling keys make React duplicate

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "motion/react";
 import { NotificationCenter } from "./NotificationCenter";
 import {
+	CLOUD_PROJECT_KIND,
 	findProjectOrchestrator,
 	hasConfiguredOrchestratorAgent,
 	isOrchestratorSession,
@@ -167,7 +168,7 @@ export function ShellTopbar({
 		// Cloud projects carry no local orchestrator-agent config; spawn the
 		// orchestrator as a cloud session in its own sandbox instead of falling
 		// through to the project-settings page.
-		if (project?.kind === "cloud") {
+		if (project?.kind === CLOUD_PROJECT_KIND) {
 			setIsSpawning(true);
 			try {
 				const sessionId = await spawnCloudOrchestrator(queryClient, projectId);
@@ -356,7 +357,7 @@ export function ShellTopbar({
 						    have no local workspace to hand off to an editor: the local daemon
 						    has never heard of them, so querying it just surfaces its 404 as a
 						    confusing "Unknown session" error (see workspace.ts's `kind` doc). */}
-						{session && project?.kind !== "cloud" ? (
+						{session && project?.kind !== CLOUD_PROJECT_KIND ? (
 							// Keyed per session so a stale launch error does not carry over
 							// when switching sessions. The prefix keeps it distinct from the
 							// kill button's key: identical sibling keys make React duplicate

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -148,6 +148,9 @@ export function canonicalTrackerIssueId(issueId?: string): string | undefined {
 
 export type ProjectKind = "single_repo" | "workspace" | "scratch";
 
+/** Sentinel `kind` value for projects hosted by the AO cloud control plane. */
+export const CLOUD_PROJECT_KIND = "cloud" as const;
+
 const projectKinds = new Set<ProjectKind>(["single_repo", "workspace", "scratch"]);
 
 export function toProjectKind(kind?: string): ProjectKind | undefined {
@@ -277,9 +280,10 @@ export type WorkspaceSummary = {
 	/**
 	 * Discriminator for where the project lives. Local projects carry the
 	 * daemon's ProjectKind (or undefined for older daemons); projects hosted by
-	 * the AO cloud control plane carry "cloud" — branch on `kind === "cloud"`.
+	 * the AO cloud control plane carry CLOUD_PROJECT_KIND — branch on
+	 * `kind === CLOUD_PROJECT_KIND`.
 	 */
-	kind?: ProjectKind | "cloud";
+	kind?: ProjectKind | typeof CLOUD_PROJECT_KIND;
 	/** Local checkout path; empty string for cloud projects (no local folder). */
 	path: string;
 	workspaceRepos?: WorkspaceRepoSummary[];


### PR DESCRIPTION
Fixes #4570

## Summary
- Cloud sessions (PR #4434's cloud offering) run in a remote sandbox and have no row in the local daemon's session store.
- The topbar's open-in-editor control (`TopbarOpenEditorButton`) queried the local daemon's `/api/v1/desktop/sessions/{id}/workspace` for every session, so for a cloud session it always got a 404 (`SESSION_NOT_FOUND`, "Unknown session") and rendered that raw local-daemon message as a persistent red topbar error — even though the session itself was healthy and running.
- Gate the control on `project.kind !== "cloud"` in `ShellTopbar.tsx`, matching the branching convention already documented on `WorkspaceSummary.kind`, so it simply doesn't render (and doesn't query the daemon) for cloud sessions.

## Root cause
Full trace in #4570.

## Test plan
- [x] `npx vitest run src/renderer/components/ShellTopbar.test.tsx` — 35/35 passing, including two new tests: the control still renders for local sessions, and is hidden for `kind === "cloud"`.
- [x] `npm run typecheck` (frontend) — clean.
- [x] Manually verified in the desktop app against a live cloud session (staging control plane): the "Unknown session" banner no longer appears.