### PR TITLE
fix(lifecycle): reconcile project orchestrator ownership

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -551,6 +551,16 @@ func sessionNewer(a, b domain.SessionRecord) bool {
 }
 
 func (s *Service) lockOrchestratorProject(projectID domain.ProjectID) func() {
+	// Production Session Manager owns the lock so startup reconciliation and
+	// HTTP operations share one project-scoped ownership boundary. Focused
+	// service fakes need not implement that optional capability; retain a local
+	// lock for them.
+	if locker, ok := s.manager.(interface {
+		LockOrchestratorProject(domain.ProjectID) func()
+	}); ok {
+		return locker.LockOrchestratorProject(projectID)
+	}
+
 	s.orchestratorLocksMu.Lock()
 	if s.orchestratorLocks == nil {
 		s.orchestratorLocks = make(map[domain.ProjectID]*sync.Mutex)
@@ -568,6 +578,28 @@ func (s *Service) lockOrchestratorProject(projectID domain.ProjectID) func() {
 
 // Restore relaunches a terminated session and returns the API-facing read model.
 func (s *Service) Restore(ctx context.Context, id domain.SessionID) (RestoreOutcome, error) {
+	if s.store != nil {
+		rec, found, err := s.store.GetSession(ctx, id)
+		if err != nil {
+			return RestoreOutcome{}, fmt.Errorf("get session %s before restore: %w", id, err)
+		}
+		if found && rec.Kind == domain.KindOrchestrator {
+			unlock := s.lockOrchestratorProject(rec.ProjectID)
+			defer unlock()
+
+			active, err := s.activeOrchestrators(ctx, rec.ProjectID)
+			if err != nil {
+				return RestoreOutcome{}, err
+			}
+			for _, orchestrator := range active {
+				if orchestrator.ID != id {
+					return RestoreOutcome{}, toAPIError(fmt.Errorf(
+						"restore %s while %s is live: %w", id, orchestrator.ID, sessionmanager.ErrOrchestratorAlreadyActive,
+					))
+				}
+			}
+		}
+	}
 	res, err := s.manager.RestoreWithMode(ctx, id)
 	if err != nil {
 		return RestoreOutcome{}, toAPIError(err)
@@ -1010,6 +1042,9 @@ func toAPIError(err error) error {
 		return apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
 	case errors.Is(err, sessionmanager.ErrNotRestorable):
 		return apierr.Conflict("SESSION_NOT_RESTORABLE", "Session is not restorable", nil)
+	case errors.Is(err, sessionmanager.ErrOrchestratorAlreadyActive):
+		return apierr.Conflict("ORCHESTRATOR_ALREADY_ACTIVE",
+			"Another orchestrator is already active for this project; AO will not restore a second one", nil)
 	case errors.Is(err, sessionmanager.ErrTerminated):
 		return apierr.Conflict("SESSION_TERMINATED", "Session is terminated", nil)
 	case errors.Is(err, sessionmanager.ErrAgentExited):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2202,7 +2202,18 @@ type fakeCommander struct {
 	killsAtSpawn    int
 	restoreErr      error
 	restoreResult   sessionmanager.RestoreResult
+	restoreCalls    []domain.SessionID
 	readyErr        error
+}
+
+type projectLockCommander struct {
+	*fakeCommander
+	lockCalls []domain.ProjectID
+}
+
+func (f *projectLockCommander) LockOrchestratorProject(projectID domain.ProjectID) func() {
+	f.lockCalls = append(f.lockCalls, projectID)
+	return func() {}
 }
 
 func (f *fakeCommander) Spawn(_ context.Context, cfg ports.SpawnConfig) (domain.SessionRecord, int, int, error) {
@@ -2234,7 +2245,8 @@ func (*fakeCommander) ListAgentSwitches(context.Context, domain.SessionID) ([]do
 func (*fakeCommander) SubmitAgentHandoff(context.Context, domain.SessionID, domain.AgentSwitchID, domain.AgentGenerationID, json.RawMessage) (domain.AgentSwitch, error) {
 	return domain.AgentSwitch{}, nil
 }
-func (f *fakeCommander) RestoreWithMode(context.Context, domain.SessionID) (sessionmanager.RestoreResult, error) {
+func (f *fakeCommander) RestoreWithMode(_ context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error) {
+	f.restoreCalls = append(f.restoreCalls, id)
 	if f.restoreErr != nil {
 		return sessionmanager.RestoreResult{}, f.restoreErr
 	}
@@ -3292,6 +3304,38 @@ func TestRestoreMapsManagerModeToServiceView(t *testing.T) {
 	}
 	if got.Mode != RestoreModeViewSavedPrompt {
 		t.Fatalf("mode = %q, want %q", got.Mode, RestoreModeViewSavedPrompt)
+	}
+}
+
+func TestRestoreRejectsHistoricalOrchestratorWhileReplacementIsLive(t *testing.T) {
+	st := newFakeStore()
+	target := domain.SessionRecord{
+		ID:           "mer-old",
+		ProjectID:    "mer",
+		Kind:         domain.KindOrchestrator,
+		IsTerminated: true,
+		Activity:     domain.Activity{State: domain.ActivityExited},
+	}
+	st.sessions[target.ID] = target
+	st.sessions["mer-new"] = domain.SessionRecord{
+		ID:        "mer-new",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Activity:  domain.Activity{State: domain.ActivityIdle},
+	}
+	fc := &projectLockCommander{fakeCommander: &fakeCommander{}}
+	svc := &Service{manager: fc, store: st}
+
+	_, err := svc.Restore(context.Background(), target.ID)
+	var apiError *apierr.Error
+	if !errors.As(err, &apiError) || apiError.Kind != apierr.KindConflict || apiError.Code != "ORCHESTRATOR_ALREADY_ACTIVE" {
+		t.Fatalf("Restore error = %v, want conflict ORCHESTRATOR_ALREADY_ACTIVE", err)
+	}
+	if len(fc.restoreCalls) != 0 {
+		t.Fatalf("manager restore calls = %v, want none", fc.restoreCalls)
+	}
+	if len(fc.lockCalls) != 1 || fc.lockCalls[0] != "mer" {
+		t.Fatalf("manager project lock calls = %v, want [mer]", fc.lockCalls)
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -38,6 +38,9 @@ var (
 	ErrAgentNotExited      = errors.New("session: agent has not exited")
 	ErrAgentExitInProgress = errors.New("session: agent exit is already in progress")
 	ErrIncompleteHandle    = errors.New("session: incomplete teardown handle")
+	// ErrOrchestratorAlreadyActive prevents an ordinary per-session restore from
+	// bypassing the project-scoped single-orchestrator ownership boundary.
+	ErrOrchestratorAlreadyActive = errors.New("session: another project orchestrator is already active")
 	// ErrProjectNotResolvable means the spawn's project has no usable repo
 	// (unregistered, archived, or missing a path). The API maps it to a 400.
 	ErrProjectNotResolvable = errors.New("session: project repo not resolvable")
@@ -357,6 +360,14 @@ type Store interface {
 	DeleteSessionWorktrees(ctx context.Context, id domain.SessionID) error
 }
 
+// projectConversationOwnerStore exposes the durable owner of a project's Chat
+// narrative. Startup restore uses this narrower optional read to prefer the
+// orchestrator that already owns the project conversation over a newer
+// duplicate created by an older release.
+type projectConversationOwnerStore interface {
+	ConversationForSession(context.Context, domain.SessionID) (domain.ConversationRecord, error)
+}
+
 // Manager coordinates internal session spawn, restore, kill, and cleanup over
 // the outbound ports. User-facing read-model assembly lives in the service package.
 type Manager struct {
@@ -414,6 +425,13 @@ type Manager struct {
 	startupBackgroundReconcileOnce  sync.Once
 	agentOpMu                       sync.Mutex
 	agentOperations                 map[domain.SessionID]agentOperationKind
+	// orchestratorProjectLocks serializes every project-scoped orchestrator
+	// ownership decision in this daemon. The session service uses the same lock
+	// for spawn/replacement/restore, while startup reconciliation holds it from
+	// its final liveness read through controller publication. The supervisor's
+	// single-daemon ownership keeps this process-local boundary authoritative.
+	orchestratorProjectLocksMu sync.Mutex
+	orchestratorProjectLocks   map[domain.ProjectID]*sync.Mutex
 	// switchDecisionInput opens a narrow human-only terminal lane while the
 	// source is blocked on permission during a mandatory switch.
 	switchDecisionInput map[domain.SessionID]domain.AgentSwitchID
@@ -757,6 +775,7 @@ func New(d Deps) *Manager {
 		backgroundContext:              d.BackgroundContext,
 		startupBackgroundReconcileDone: make(chan struct{}),
 		agentOperations:                make(map[domain.SessionID]agentOperationKind),
+		orchestratorProjectLocks:       make(map[domain.ProjectID]*sync.Mutex),
 		switchDecisionInput:            make(map[domain.SessionID]domain.AgentSwitchID),
 		retainedSwitches:               make(map[domain.SessionID]struct{}),
 		inputLeases:                    make(map[domain.SessionID]int),
@@ -1962,6 +1981,27 @@ func (m *Manager) RestoreWithMode(ctx context.Context, id domain.SessionID) (Res
 	return m.relaunchRestoredSession(ctx, rec, project, ws)
 }
 
+// LockOrchestratorProject acquires this daemon's project-scoped orchestrator
+// ownership lock. Callers must hold it across the last durable ownership read,
+// any external controller/workspace work, and the final session activation.
+// The session service deliberately shares this lock with startup reconciliation
+// so the API cannot create a replacement in the middle of a saved restore.
+func (m *Manager) LockOrchestratorProject(projectID domain.ProjectID) func() {
+	m.orchestratorProjectLocksMu.Lock()
+	if m.orchestratorProjectLocks == nil {
+		m.orchestratorProjectLocks = make(map[domain.ProjectID]*sync.Mutex)
+	}
+	mu := m.orchestratorProjectLocks[projectID]
+	if mu == nil {
+		mu = &sync.Mutex{}
+		m.orchestratorProjectLocks[projectID] = mu
+	}
+	m.orchestratorProjectLocksMu.Unlock()
+
+	mu.Lock()
+	return mu.Unlock
+}
+
 func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo) (RestoreResult, error) {
 	result, err := m.relaunchSession(ctx, "restore", rec, project, ws, nil)
 	if err != nil {
@@ -2691,6 +2731,13 @@ func (m *Manager) ReconcileBackground(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("reconcile: list sessions: %w", err)
 	}
+	m.reconcileProjectOrchestratorOwnership(ctx, recs)
+	// Ownership repair may have parked a duplicate live controller so a saved
+	// durable owner can restore. Every later pass must consume fresh facts.
+	recs, err = m.store.ListAllSessions(ctx)
+	if err != nil {
+		return fmt.Errorf("reconcile: refresh sessions after orchestrator ownership: %w", err)
+	}
 	m.reconcileLivePass(ctx, recs)
 	for _, rec := range recs {
 		if !rec.IsTerminated {
@@ -2707,6 +2754,132 @@ func (m *Manager) ReconcileBackground(ctx context.Context) error {
 		m.logger.Error("reconcile: transition-message delivery deferred for retry", "error", err)
 	}
 	m.wakeTransitionMessageDispatcher()
+	return nil
+}
+
+// reconcileProjectOrchestratorOwnership repairs only duplicate states for
+// which AO has an exact durable winner: the session currently bound to the
+// project's Chat narrative. It stops and terminates competing controllers but
+// deliberately leaves their native ids, session rows, and shared canonical
+// workspace untouched. Without that ownership proof it does nothing.
+func (m *Manager) reconcileProjectOrchestratorOwnership(ctx context.Context, recs []domain.SessionRecord) {
+	byProject := make(map[domain.ProjectID][]domain.SessionRecord)
+	for _, rec := range recs {
+		if rec.Kind != domain.KindOrchestrator {
+			continue
+		}
+		if rec.IsTerminated {
+			rows, err := m.store.ListSessionWorktrees(ctx, rec.ID)
+			if err != nil {
+				m.logger.Error("reconcile: inspect saved orchestrator ownership failed", "sessionID", rec.ID, "error", err)
+				continue
+			}
+			if len(restorableWorktreeRows(rows)) == 0 {
+				continue
+			}
+		}
+		byProject[rec.ProjectID] = append(byProject[rec.ProjectID], rec)
+	}
+	contested := make([]domain.SessionRecord, 0)
+	for _, candidates := range byProject {
+		if len(candidates) > 1 {
+			contested = append(contested, candidates...)
+		}
+	}
+	owners, blocked := m.durableProjectConversationOwners(ctx, contested)
+	for projectID, candidates := range byProject {
+		if len(candidates) < 2 || blocked[projectID] {
+			continue
+		}
+		owner, proven := owners[projectID]
+		if !proven {
+			m.logger.Warn("reconcile: duplicate project orchestrators have no durable conversation owner; leaving them unchanged",
+				"projectID", projectID)
+			continue
+		}
+
+		unlock := m.LockOrchestratorProject(projectID)
+		m.reconcileProjectOrchestratorOwnerLocked(ctx, owner)
+		unlock()
+	}
+}
+
+func (m *Manager) reconcileProjectOrchestratorOwnerLocked(ctx context.Context, owner domain.SessionRecord) {
+	currentOwner, found, err := m.store.GetSession(ctx, owner.ID)
+	if err != nil || !found || currentOwner.Kind != domain.KindOrchestrator {
+		m.logger.Error("reconcile: refresh durable orchestrator owner failed", "sessionID", owner.ID, "error", err)
+		return
+	}
+	if currentOwner.IsTerminated {
+		rows, rowErr := m.store.ListSessionWorktrees(ctx, currentOwner.ID)
+		if rowErr != nil || len(restorableWorktreeRows(rows)) == 0 {
+			m.logger.Warn("reconcile: durable orchestrator owner is no longer restorable; leaving competitors unchanged",
+				"sessionID", currentOwner.ID, "error", rowErr)
+			return
+		}
+	}
+	ownerStore, ok := m.store.(projectConversationOwnerStore)
+	if !ok {
+		return
+	}
+	conversation, err := ownerStore.ConversationForSession(ctx, currentOwner.ID)
+	if err != nil || conversation.Scope != domain.ConversationScopeProject ||
+		conversation.ProjectID != currentOwner.ProjectID || conversation.SessionID != currentOwner.ID {
+		m.logger.Warn("reconcile: durable orchestrator owner changed before cleanup; leaving competitors unchanged",
+			"sessionID", currentOwner.ID, "error", err)
+		return
+	}
+
+	projectSessions, err := m.store.ListSessions(ctx, currentOwner.ProjectID)
+	if err != nil {
+		m.logger.Error("reconcile: refresh project orchestrators failed", "projectID", currentOwner.ProjectID, "error", err)
+		return
+	}
+	for _, other := range projectSessions {
+		if other.ID == currentOwner.ID || other.Kind != domain.KindOrchestrator || other.IsTerminated {
+			continue
+		}
+		if err := m.beginAgentOperation(ctx, other.ID, agentOperationReconcile); err != nil {
+			m.logger.Warn("reconcile: duplicate orchestrator mutation already in progress; leaving it live",
+				"sessionID", other.ID, "error", err)
+			continue
+		}
+		err := m.parkDuplicateOrchestrator(ctx, other)
+		m.endAgentOperation(other.ID, agentOperationReconcile)
+		if err != nil {
+			m.logger.Error("reconcile: park duplicate orchestrator failed; leaving durable state recoverable",
+				"sessionID", other.ID, "ownerSessionID", currentOwner.ID, "error", err)
+		}
+	}
+}
+
+func (m *Manager) parkDuplicateOrchestrator(ctx context.Context, rec domain.SessionRecord) error {
+	current, found, err := m.store.GetSession(ctx, rec.ID)
+	if err != nil || !found {
+		return err
+	}
+	if current.IsTerminated {
+		return nil
+	}
+	if domain.NormalizeSessionMode(current.Mode) == domain.SessionModeChat {
+		if m.chat != nil {
+			if err := m.chat.StopChat(ctx, current.ID); err != nil {
+				return fmt.Errorf("stop Chat controller: %w", err)
+			}
+		}
+	} else if handle := runtimeHandle(current.Metadata); handle.ID != "" {
+		if err := m.runtime.Destroy(ctx, handle); err != nil {
+			return fmt.Errorf("stop runtime: %w", err)
+		}
+	}
+	if err := m.store.DeleteSessionWorktrees(ctx, current.ID); err != nil {
+		return fmt.Errorf("clear restore marker: %w", err)
+	}
+	if err := m.lcm.MarkTerminated(ctx, current.ID); err != nil {
+		return fmt.Errorf("mark terminated: %w", err)
+	}
+	m.stopPreviewBestEffort(ctx, current.ID)
+	m.destroyBrowserBestEffort(ctx, current.ID)
 	return nil
 }
 
@@ -2774,16 +2947,18 @@ func (m *Manager) reconcileLivePass(ctx context.Context, recs []domain.SessionRe
 	wg.Wait()
 }
 
-// RestoreAll relaunches every terminated session that was saved by the last
+// RestoreAll relaunches terminated sessions saved by the last
 // SaveAndTeardownAll. The "shutdown-saved" marker is the presence of a
 // session_worktrees row for the session; sessions the user killed before
-// shutdown have no such row and are left terminated.
+// shutdown have no such row and are left terminated. Workers restore
+// independently. At most one saved orchestrator is selected per project, and a
+// live orchestrator found under the shared project lock always wins.
 //
 // For each saved session:
 //  1. Ensure the worktree exists via workspace.Restore.
 //  2. If a preserve ref is recorded, replay it via ApplyPreserved; on conflict
 //     log and continue (still relaunch the agent, never delete the ref).
-//  3. Relaunch via the existing Restore method.
+//  3. Relaunch through the same mode-specific controller path as Restore.
 //
 // Failures on individual sessions are logged and do not abort the loop.
 func (m *Manager) RestoreAll(ctx context.Context) error {
@@ -2791,133 +2966,277 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("restore-all: list sessions: %w", err)
 	}
+
+	// Restore markers are per-session legacy facts, but orchestrator ownership
+	// is project-scoped. Select at most one saved orchestrator before any
+	// provider or runtime work, preferring the durable project-conversation
+	// owner over a later duplicate. The final ownership read is repeated under the
+	// shared project lock in restoreSavedSession, so an API spawn/restore cannot
+	// race this snapshot into publishing a second orchestrator.
+	candidates := make([]domain.SessionRecord, 0)
 	for _, rec := range recs {
 		if !rec.IsTerminated {
 			continue
 		}
-		// Check the shutdown-saved marker: is there a session_worktrees row?
 		rows, err := m.store.ListSessionWorktrees(ctx, rec.ID)
 		if err != nil {
 			m.logger.Error("restore-all: list worktrees failed", "sessionID", rec.ID, "error", err)
 			continue
 		}
-		if len(rows) == 0 {
+		if len(restorableWorktreeRows(rows)) == 0 {
 			// No marker: this session was killed by the user before shutdown.
 			continue
 		}
-		rows = restorableWorktreeRows(rows)
-		if len(rows) == 0 {
+		candidates = append(candidates, rec)
+	}
+	selectedOrchestrators := m.selectSavedOrchestrators(ctx, candidates)
+
+	for _, rec := range candidates {
+		if rec.Kind == domain.KindOrchestrator {
+			selected, ok := selectedOrchestrators[rec.ProjectID]
+			if !ok {
+				continue
+			}
+			if selected.ID != rec.ID {
+				m.logger.Warn("restore-all: saved orchestrator left terminated because another candidate owns project recovery",
+					"sessionID", rec.ID, "selectedOrchestratorID", selected.ID, "projectID", rec.ProjectID)
+				continue
+			}
+		}
+		m.restoreSavedSession(ctx, rec)
+	}
+	return nil
+}
+
+func (m *Manager) selectSavedOrchestrators(
+	ctx context.Context,
+	candidates []domain.SessionRecord,
+) map[domain.ProjectID]domain.SessionRecord {
+	selected := make(map[domain.ProjectID]domain.SessionRecord)
+	for _, rec := range candidates {
+		if rec.Kind != domain.KindOrchestrator {
 			continue
 		}
+		if current, ok := selected[rec.ProjectID]; !ok || restoreRecordNewer(rec, current) {
+			selected[rec.ProjectID] = rec
+		}
+	}
 
-		// Step 1: ensure the worktree exists. workspace.Restore re-creates it
-		// if it was removed by SaveAndTeardownAll.
-		project, err := m.loadProject(ctx, rec.ProjectID)
+	owners, blocked := m.durableProjectConversationOwners(ctx, candidates)
+	for projectID := range blocked {
+		delete(selected, projectID)
+	}
+	for projectID, owner := range owners {
+		selected[projectID] = owner
+	}
+	return selected
+}
+
+func (m *Manager) durableProjectConversationOwners(
+	ctx context.Context,
+	candidates []domain.SessionRecord,
+) (map[domain.ProjectID]domain.SessionRecord, map[domain.ProjectID]bool) {
+	owners := make(map[domain.ProjectID]domain.SessionRecord)
+	blocked := make(map[domain.ProjectID]bool)
+	ownerStore, ok := m.store.(projectConversationOwnerStore)
+	if !ok {
+		return owners, blocked
+	}
+	for _, rec := range candidates {
+		if rec.Kind != domain.KindOrchestrator || blocked[rec.ProjectID] {
+			continue
+		}
+		conversation, err := ownerStore.ConversationForSession(ctx, rec.ID)
+		if errors.Is(err, domain.ErrNoConversation) {
+			continue
+		}
 		if err != nil {
-			m.logger.Error("restore-all: load project failed", "sessionID", rec.ID, "error", err)
+			m.logger.Error("reconcile: project conversation owner lookup failed; leaving orchestrators unchanged",
+				"sessionID", rec.ID, "projectID", rec.ProjectID, "error", err)
+			blocked[rec.ProjectID] = true
+			delete(owners, rec.ProjectID)
 			continue
 		}
-		var ws ports.WorkspaceInfo
-		restoredWorkspaceProject := project.Kind.WithDefault() == domain.ProjectKindWorkspace
-		var projectRows []ports.WorkspaceRepoInfo
-		if restoredWorkspaceProject {
-			var rowErr error
-			projectRows, rowErr = m.workspaceProjectRestoreRowsFromMarkers(ctx, project, rec, rows)
-			if rowErr != nil {
-				m.logger.Error("restore-all: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
-				continue
-			}
-			root, restoreErr := m.restoreWorkspaceProjectRows(ctx, projectRows)
-			if restoreErr != nil {
-				m.logger.Error("restore-all: workspace project restore failed", "sessionID", rec.ID, "error", restoreErr)
-				continue
-			}
-			ws = workspaceInfoFromRepoInfo(root)
-		} else {
-			var restoreErr error
-			ws, restoreErr = m.workspace.Restore(ctx, ports.WorkspaceConfig{
-				ProjectID:     rec.ProjectID,
-				SessionID:     rec.ID,
-				Kind:          rec.Kind,
-				SessionPrefix: sessionPrefix(project),
-				Branch:        rec.Metadata.Branch,
-				BaseBranch:    project.Config.WorktreeBaseBranch(),
-				BaseRef:       rec.Metadata.DiffBaseRef,
-				Path:          rec.Metadata.WorkspacePath,
-			})
-			if restoreErr != nil {
-				m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", restoreErr)
-				continue
-			}
-		}
-		if ws.Path == "" {
-			m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", "empty restored root path")
+		if conversation.Scope != domain.ConversationScopeProject ||
+			conversation.ProjectID != rec.ProjectID || conversation.SessionID != rec.ID {
 			continue
 		}
-		if err := m.restoreAttachments(ctx, rec.ID, ws); err != nil {
-			m.logger.Error("restore-all: restore attachments failed", "sessionID", rec.ID, "error", err)
+		if owner, exists := owners[rec.ProjectID]; exists && owner.ID != rec.ID {
+			m.logger.Error("reconcile: multiple orchestrators claim the project conversation; leaving all unchanged",
+				"projectID", rec.ProjectID, "firstSessionID", owner.ID, "secondSessionID", rec.ID)
+			blocked[rec.ProjectID] = true
+			delete(owners, rec.ProjectID)
 			continue
 		}
+		owners[rec.ProjectID] = rec
+	}
+	return owners, blocked
+}
 
-		// Step 2: replay preserve ref when one was recorded.
-		if restoredWorkspaceProject {
-			m.applyWorkspaceProjectPreserved(ctx, projectRows)
-		} else {
-			var preserveRef string
-			for _, r := range rows {
-				if r.PreservedRef != "" {
-					preserveRef = r.PreservedRef
-					break
-				}
-			}
-			if preserveRef != "" {
-				if applyErr := m.workspace.ApplyPreserved(ctx, ws, preserveRef); applyErr != nil {
-					if errors.Is(applyErr, ports.ErrPreservedConflict) {
-						m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
-							"sessionID", rec.ID, "ref", preserveRef, "error", applyErr)
-					} else {
-						m.logger.Error("restore-all: apply preserved failed", "sessionID", rec.ID, "error", applyErr)
-					}
-					// Continue: always relaunch even on conflict (never delete the ref here).
-				}
-			}
-		}
+func (m *Manager) restoreSavedSession(ctx context.Context, snapshot domain.SessionRecord) {
+	rec := snapshot
+	if rec.Kind == domain.KindOrchestrator {
+		unlock := m.LockOrchestratorProject(rec.ProjectID)
+		defer unlock()
+	}
+	if err := m.beginAgentOperation(ctx, rec.ID, agentOperationRestore); err != nil {
+		m.logger.Warn("restore-all: session mutation already in progress; leaving restore marker for retry",
+			"sessionID", rec.ID, "error", err)
+		return
+	}
+	defer m.endAgentOperation(rec.ID, agentOperationRestore)
 
-		// Step 3: relaunch the agent in the restored workspace.
-		if _, err := m.relaunchRestoredSession(ctx, rec, project, ws); err != nil {
-			switch {
-			case errors.Is(err, ErrNotResumable):
-				// A promptless, unresumable worker is intentionally left terminated:
-				// expected, not an operational failure, so log it quietly.
-				m.logger.Warn("restore-all: session left terminated (nothing to resume)", "sessionID", rec.ID)
-			case errors.Is(err, ErrNotFound):
-				// The row was reaped between listing and relaunch (a stale id during
-				// reconciliation): skip it and keep restoring the rest.
-				m.logger.Warn("restore-all: session vanished before relaunch, skipping", "sessionID", rec.ID)
-			default:
-				m.logger.Error("restore-all: relaunch failed", "sessionID", rec.ID, "error", err)
-			}
-			continue
+	// Re-read every ownership fact after acquiring the operation fences. Startup
+	// reconciliation runs after the API is available, so discovery snapshots are
+	// never authoritative enough to launch from.
+	current, found, err := m.store.GetSession(ctx, rec.ID)
+	if err != nil {
+		m.logger.Error("restore-all: refresh session failed", "sessionID", rec.ID, "error", err)
+		return
+	}
+	if !found || !current.IsTerminated {
+		return
+	}
+	rec = current
+	if rec.Kind == domain.KindOrchestrator {
+		projectSessions, err := m.store.ListSessions(ctx, rec.ProjectID)
+		if err != nil {
+			m.logger.Error("restore-all: list project sessions failed", "sessionID", rec.ID, "error", err)
+			return
 		}
-
-		// One-shot: drop the consumed marker so it never outlives one restart
-		// (#2319). A still-live session re-acquires it at the next quit.
-		if restoredWorkspaceProject {
-			for _, row := range projectRows {
-				if err := m.upsertWorkspaceProjectRowState(ctx, row, "active"); err != nil {
-					m.logger.Warn("restore-all: marking workspace repo active failed", "sessionID", rec.ID, "repo", row.RepoName, "error", err)
-				}
-			}
-		} else {
-			if err := m.markSessionWorktreesActive(ctx, rows); err != nil {
-				m.logger.Warn("restore-all: marking worktrees active failed", "sessionID", rec.ID, "error", err)
-			}
-			if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
-				m.logger.Warn("restore-all: delete restore marker failed", "sessionID", rec.ID, "error", err)
+		for _, other := range projectSessions {
+			if other.ID != rec.ID && other.Kind == domain.KindOrchestrator && !other.IsTerminated {
+				m.logger.Warn("restore-all: historical orchestrator left terminated because project already has a live orchestrator",
+					"sessionID", rec.ID, "activeOrchestratorID", other.ID, "projectID", rec.ProjectID)
+				return
 			}
 		}
 	}
-	return nil
+	rows, err := m.store.ListSessionWorktrees(ctx, rec.ID)
+	if err != nil {
+		m.logger.Error("restore-all: refresh worktrees failed", "sessionID", rec.ID, "error", err)
+		return
+	}
+	rows = restorableWorktreeRows(rows)
+	if len(rows) == 0 {
+		return
+	}
+
+	// Step 1: ensure the worktree exists. workspace.Restore re-creates it
+	// if it was removed by SaveAndTeardownAll.
+	project, err := m.loadProject(ctx, rec.ProjectID)
+	if err != nil {
+		m.logger.Error("restore-all: load project failed", "sessionID", rec.ID, "error", err)
+		return
+	}
+	var ws ports.WorkspaceInfo
+	restoredWorkspaceProject := project.Kind.WithDefault() == domain.ProjectKindWorkspace
+	var projectRows []ports.WorkspaceRepoInfo
+	if restoredWorkspaceProject {
+		var rowErr error
+		projectRows, rowErr = m.workspaceProjectRestoreRowsFromMarkers(ctx, project, rec, rows)
+		if rowErr != nil {
+			m.logger.Error("restore-all: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
+			return
+		}
+		root, restoreErr := m.restoreWorkspaceProjectRows(ctx, projectRows)
+		if restoreErr != nil {
+			m.logger.Error("restore-all: workspace project restore failed", "sessionID", rec.ID, "error", restoreErr)
+			return
+		}
+		ws = workspaceInfoFromRepoInfo(root)
+	} else {
+		var restoreErr error
+		ws, restoreErr = m.workspace.Restore(ctx, ports.WorkspaceConfig{
+			ProjectID:     rec.ProjectID,
+			SessionID:     rec.ID,
+			Kind:          rec.Kind,
+			SessionPrefix: sessionPrefix(project),
+			Branch:        rec.Metadata.Branch,
+			BaseBranch:    project.Config.WorktreeBaseBranch(),
+			BaseRef:       rec.Metadata.DiffBaseRef,
+			Path:          rec.Metadata.WorkspacePath,
+		})
+		if restoreErr != nil {
+			m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", restoreErr)
+			return
+		}
+	}
+	if ws.Path == "" {
+		m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", "empty restored root path")
+		return
+	}
+	if err := m.restoreAttachments(ctx, rec.ID, ws); err != nil {
+		m.logger.Error("restore-all: restore attachments failed", "sessionID", rec.ID, "error", err)
+		return
+	}
+
+	// Step 2: replay preserve ref when one was recorded.
+	if restoredWorkspaceProject {
+		m.applyWorkspaceProjectPreserved(ctx, projectRows)
+	} else {
+		var preserveRef string
+		for _, r := range rows {
+			if r.PreservedRef != "" {
+				preserveRef = r.PreservedRef
+				break
+			}
+		}
+		if preserveRef != "" {
+			if applyErr := m.workspace.ApplyPreserved(ctx, ws, preserveRef); applyErr != nil {
+				if errors.Is(applyErr, ports.ErrPreservedConflict) {
+					m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
+						"sessionID", rec.ID, "ref", preserveRef, "error", applyErr)
+				} else {
+					m.logger.Error("restore-all: apply preserved failed", "sessionID", rec.ID, "error", applyErr)
+				}
+				// Continue: always relaunch even on conflict (never delete the ref here).
+			}
+		}
+	}
+
+	// Step 3: relaunch the agent in the restored workspace.
+	if _, err := m.relaunchRestoredSession(ctx, rec, project, ws); err != nil {
+		switch {
+		case errors.Is(err, ErrNotResumable):
+			// A promptless, unresumable worker is intentionally left terminated:
+			// expected, not an operational failure, so log it quietly.
+			m.logger.Warn("restore-all: session left terminated (nothing to resume)", "sessionID", rec.ID)
+		case errors.Is(err, ErrNotFound):
+			// The row was reaped between listing and relaunch (a stale id during
+			// reconciliation): skip it and keep restoring the rest.
+			m.logger.Warn("restore-all: session vanished before relaunch, skipping", "sessionID", rec.ID)
+		default:
+			m.logger.Error("restore-all: relaunch failed", "sessionID", rec.ID, "error", err)
+		}
+		return
+	}
+	// One-shot: drop the consumed marker so it never outlives one restart
+	// (#2319). A still-live session re-acquires it at the next quit.
+	if restoredWorkspaceProject {
+		for _, row := range projectRows {
+			if err := m.upsertWorkspaceProjectRowState(ctx, row, "active"); err != nil {
+				m.logger.Warn("restore-all: marking workspace repo active failed", "sessionID", rec.ID, "repo", row.RepoName, "error", err)
+			}
+		}
+	} else {
+		if err := m.markSessionWorktreesActive(ctx, rows); err != nil {
+			m.logger.Warn("restore-all: marking worktrees active failed", "sessionID", rec.ID, "error", err)
+		}
+		if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
+			m.logger.Warn("restore-all: delete restore marker failed", "sessionID", rec.ID, "error", err)
+		}
+	}
+}
+
+func restoreRecordNewer(a, b domain.SessionRecord) bool {
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.After(b.CreatedAt)
+	}
+	if !a.UpdatedAt.Equal(b.UpdatedAt) {
+		return a.UpdatedAt.After(b.UpdatedAt)
+	}
+	return a.ID > b.ID
 }
 
 func restorableWorktreeRows(rows []domain.SessionWorktreeRecord) []domain.SessionWorktreeRecord {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1628,6 +1628,14 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	if (rec.Harness == domain.HarnessCodex || rec.ReviewerHarness == domain.ReviewerCodex) && m.codexAccountSwitchIsActive() {
 		return false, fmt.Errorf("kill %s: %w", id, ErrCodexAccountSwitchInProgress)
 	}
+	// Kill is idempotent. In particular, historical orchestrators can retain the
+	// same canonical workspace identity as their live replacement. Re-running
+	// Kill on that already-terminated row must not tear the shared worktree out
+	// from under the current owner. Cleanup separately refuses reclamation while
+	// a live orchestrator still owns the same path.
+	if rec.IsTerminated {
+		return false, nil
+	}
 	m.stopPreviewBestEffort(ctx, id)
 	m.destroyBrowserBestEffort(ctx, id)
 	handle := runtimeHandle(rec.Metadata)
@@ -2872,9 +2880,11 @@ func (m *Manager) parkDuplicateOrchestrator(ctx context.Context, rec domain.Sess
 			return fmt.Errorf("stop runtime: %w", err)
 		}
 	}
-	if err := m.store.DeleteSessionWorktrees(ctx, current.ID); err != nil {
-		return fmt.Errorf("clear restore marker: %w", err)
-	}
+	// Keep session_worktrees inventory. Active rows are not startup-restore
+	// markers (RestoreAll only consumes removed/legacy rows), and workspace
+	// projects need the per-repo rows for an explicit restore or later Cleanup.
+	// Deleting them here would orphan child worktrees even though parking is
+	// deliberately non-destructive.
 	if err := m.lcm.MarkTerminated(ctx, current.ID); err != nil {
 		return fmt.Errorf("mark terminated: %w", err)
 	}
@@ -3013,16 +3023,26 @@ func (m *Manager) selectSavedOrchestrators(
 	candidates []domain.SessionRecord,
 ) map[domain.ProjectID]domain.SessionRecord {
 	selected := make(map[domain.ProjectID]domain.SessionRecord)
+	counts := make(map[domain.ProjectID]int)
 	for _, rec := range candidates {
 		if rec.Kind != domain.KindOrchestrator {
 			continue
 		}
+		counts[rec.ProjectID]++
 		if current, ok := selected[rec.ProjectID]; !ok || restoreRecordNewer(rec, current) {
 			selected[rec.ProjectID] = rec
 		}
 	}
 
-	owners, blocked := m.durableProjectConversationOwners(ctx, candidates)
+	// Conversation ownership only disambiguates contested projects. A transient
+	// read failure must not suppress the sole saved orchestrator for a project.
+	contested := make([]domain.SessionRecord, 0)
+	for _, rec := range candidates {
+		if rec.Kind == domain.KindOrchestrator && counts[rec.ProjectID] > 1 {
+			contested = append(contested, rec)
+		}
+	}
+	owners, blocked := m.durableProjectConversationOwners(ctx, contested)
 	for projectID := range blocked {
 		delete(selected, projectID)
 	}
@@ -3925,6 +3945,32 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 // call) — most commonly because a scoped shell terminal could not be
 // confirmed closed, so reclaiming would pull the ground out from under it.
 func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo) (skipReason string) {
+	if rec.Kind == domain.KindOrchestrator {
+		unlock := m.LockOrchestratorProject(rec.ProjectID)
+		defer unlock()
+
+		// Cleanup runs while the API is serving. Re-read termination under the
+		// same ownership lock used by restore/spawn before touching the canonical
+		// worktree, and never reclaim a path still owned by a live orchestrator.
+		current, found, err := m.store.GetSession(ctx, rec.ID)
+		if err != nil {
+			m.logger.Warn("cleanup: refresh orchestrator failed", "sessionID", rec.ID, "error", err)
+			return "workspace ownership check failed"
+		}
+		if !found || !current.IsTerminated {
+			return "session is no longer terminated"
+		}
+		rec = current
+		ws = workspaceInfo(current)
+		shared, err := m.liveOrchestratorSharesWorkspace(ctx, current)
+		if err != nil {
+			m.logger.Warn("cleanup: shared orchestrator workspace check failed", "sessionID", rec.ID, "error", err)
+			return "workspace ownership check failed"
+		}
+		if shared {
+			return "workspace is owned by active orchestrator"
+		}
+	}
 	release, closeErr := m.beginShellTerminalTeardown(ctx, rec.ID)
 	if closeErr != nil {
 		m.logger.Warn("cleanup: shell terminal still open", "sessionID", rec.ID, "error", closeErr)
@@ -3961,6 +4007,26 @@ func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws p
 	}
 	m.cleanupAgentWorkspace(ctx, rec, ws.Path)
 	return ""
+}
+
+func (m *Manager) liveOrchestratorSharesWorkspace(ctx context.Context, rec domain.SessionRecord) (bool, error) {
+	if rec.Kind != domain.KindOrchestrator || rec.Metadata.WorkspacePath == "" {
+		return false, nil
+	}
+	recs, err := m.store.ListSessions(ctx, rec.ProjectID)
+	if err != nil {
+		return false, err
+	}
+	path := filepath.Clean(rec.Metadata.WorkspacePath)
+	for _, other := range recs {
+		if other.ID == rec.ID || other.Kind != domain.KindOrchestrator || other.IsTerminated || other.Metadata.WorkspacePath == "" {
+			continue
+		}
+		if filepath.Clean(other.Metadata.WorkspacePath) == path {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // cleanupSkipReason renders a workspace teardown refusal as a short

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1603,7 +1603,11 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 // A session whose runtime handle or workspace path is missing (e.g. spawn
 // failed partway, handle lost after a crash) is still terminated after the
 // available destroy steps are skipped so it can be cleaned up from the
-// dashboard.
+// dashboard. Calling Kill again for an already-terminated row is idempotent:
+// it clears only session-scoped preview/browser/prompt artifacts and leaves
+// runtime/workspace reclamation to Cleanup. That distinction matters for
+// historical orchestrators whose canonical workspace is shared by the live
+// replacement.
 func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	if err := m.beginAgentOperation(ctx, id, agentOperationKill); err != nil {
 		if errors.Is(err, errAgentOperationInProgress) {
@@ -1634,6 +1638,9 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	// from under the current owner. Cleanup separately refuses reclamation while
 	// a live orchestrator still owns the same path.
 	if rec.IsTerminated {
+		m.stopPreviewBestEffort(ctx, id)
+		m.destroyBrowserBestEffort(ctx, id)
+		m.cleanupSystemPromptDir(id)
 		return false, nil
 	}
 	m.stopPreviewBestEffort(ctx, id)
@@ -3923,9 +3930,6 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 			m.cleanupSystemPromptDir(rec.ID)
 			continue
 		}
-		if h := runtimeHandle(rec.Metadata); h.ID != "" {
-			_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
-		}
 		if reason := m.cleanupOne(ctx, rec, ws); reason != "" {
 			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: reason})
 			continue
@@ -3970,6 +3974,13 @@ func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws p
 		if shared {
 			return "workspace is owned by active orchestrator"
 		}
+	}
+	// Runtime teardown belongs inside the same fenced operation as workspace
+	// reclamation. In particular, an orchestrator restored after Cleanup's list
+	// snapshot can reuse its deterministic runtime handle; destroying the stale
+	// snapshot's handle before the locked re-read would kill the new controller.
+	if h := runtimeHandle(rec.Metadata); h.ID != "" {
+		_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
 	}
 	release, closeErr := m.beginShellTerminalTeardown(ctx, rec.ID)
 	if closeErr != nil {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -40,6 +40,7 @@ type fakeStore struct {
 	updateSessionErr   error
 	conversationErr    error
 	conversationOwners map[domain.SessionID]domain.ConversationRecord
+	listSessionsAfter  func()
 	// agentSwitchStore is wired only by agent-switch tests so fakeLCM can model
 	// Lifecycle Manager's atomic ownership-boundary commands.
 	agentSwitchStore any
@@ -132,6 +133,10 @@ func (f *fakeStore) ListSessions(_ context.Context, p domain.ProjectID) ([]domai
 		if r.ProjectID == p {
 			out = append(out, r)
 		}
+	}
+	if after := f.listSessionsAfter; after != nil {
+		f.listSessionsAfter = nil
+		after()
 	}
 	return out, nil
 }
@@ -2691,6 +2696,11 @@ func TestKill_TearsDownRuntimeAndWorkspace(t *testing.T) {
 
 func TestKill_AlreadyTerminatedIsNoopAndPreservesWorkspace(t *testing.T) {
 	m, st, rt, ws := newManager()
+	preview := &fakePreviewLifecycle{}
+	browser := &fakeBrowserLifecycle{}
+	m.preview = preview
+	m.browser = browser
+	m.dataDir = t.TempDir()
 	rec := mkLive("mer-1")
 	rec.IsTerminated = true
 	rec.Activity.State = domain.ActivityExited
@@ -2699,6 +2709,9 @@ func TestKill_AlreadyTerminatedIsNoopAndPreservesWorkspace(t *testing.T) {
 		SessionID: rec.ID, RepoName: domain.RootWorkspaceRepoName,
 		Branch: rec.Metadata.Branch, WorktreePath: rec.Metadata.WorkspacePath, State: "active",
 	}}
+	if _, err := m.writeSystemPromptFile(rec.ID, "historical prompt"); err != nil {
+		t.Fatal(err)
+	}
 
 	freed, err := m.Kill(ctx, rec.ID)
 	if err != nil || freed {
@@ -2707,6 +2720,13 @@ func TestKill_AlreadyTerminatedIsNoopAndPreservesWorkspace(t *testing.T) {
 	if rt.destroyed != 0 || ws.destroyed != 0 {
 		t.Fatalf("terminated session teardown = runtime:%d workspace:%d, want none", rt.destroyed, ws.destroyed)
 	}
+	if !reflect.DeepEqual(preview.stopped, []domain.SessionID{rec.ID}) {
+		t.Fatalf("preview stops = %v, want [%s]", preview.stopped, rec.ID)
+	}
+	if !reflect.DeepEqual(browser.destroyed, []domain.SessionID{rec.ID}) {
+		t.Fatalf("browser destroys = %v, want [%s]", browser.destroyed, rec.ID)
+	}
+	requireNoPromptDir(t, m.dataDir, rec.ID)
 	if rows := st.worktrees[rec.ID]; len(rows) != 1 || rows[0].WorktreePath != rec.Metadata.WorkspacePath {
 		t.Fatalf("terminated session worktree inventory = %+v, want preserved", rows)
 	}
@@ -3336,6 +3356,35 @@ func TestCleanup_ReclaimsTerminalWorkspaces(t *testing.T) {
 	}
 	if ws.destroyed != 1 {
 		t.Fatal("live workspace must not be destroyed")
+	}
+}
+
+func TestCleanup_DoesNotDestroyRuntimeRestoredAfterOrchestratorSnapshot(t *testing.T) {
+	m, st, rt, ws := newManager()
+	rec := mkLive("mer-1")
+	rec.Kind = domain.KindOrchestrator
+	rec.IsTerminated = true
+	rec.Activity.State = domain.ActivityExited
+	st.sessions[rec.ID] = rec
+	st.listSessionsAfter = func() {
+		current := st.sessions[rec.ID]
+		current.IsTerminated = false
+		current.Activity.State = domain.ActivityIdle
+		st.sessions[rec.ID] = current
+	}
+
+	res, err := m.Cleanup(ctx, rec.ProjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Cleaned) != 0 || len(res.Skipped) != 1 || res.Skipped[0].SessionID != rec.ID {
+		t.Fatalf("Cleanup result = %+v, want restored orchestrator skipped", res)
+	}
+	if res.Skipped[0].Reason != "session is no longer terminated" {
+		t.Fatalf("Cleanup skip reason = %q", res.Skipped[0].Reason)
+	}
+	if rt.destroyed != 0 || ws.destroyed != 0 {
+		t.Fatalf("restored orchestrator teardown = runtime:%d workspace:%d, want none", rt.destroyed, ws.destroyed)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2689,6 +2689,32 @@ func TestKill_TearsDownRuntimeAndWorkspace(t *testing.T) {
 	requireNoPromptDir(t, dataDir, "mer-1")
 }
 
+func TestKill_AlreadyTerminatedIsNoopAndPreservesWorkspace(t *testing.T) {
+	m, st, rt, ws := newManager()
+	rec := mkLive("mer-1")
+	rec.IsTerminated = true
+	rec.Activity.State = domain.ActivityExited
+	st.sessions[rec.ID] = rec
+	st.worktrees[rec.ID] = []domain.SessionWorktreeRecord{{
+		SessionID: rec.ID, RepoName: domain.RootWorkspaceRepoName,
+		Branch: rec.Metadata.Branch, WorktreePath: rec.Metadata.WorkspacePath, State: "active",
+	}}
+
+	freed, err := m.Kill(ctx, rec.ID)
+	if err != nil || freed {
+		t.Fatalf("Kill terminated session = freed:%v err:%v, want benign no-op", freed, err)
+	}
+	if rt.destroyed != 0 || ws.destroyed != 0 {
+		t.Fatalf("terminated session teardown = runtime:%d workspace:%d, want none", rt.destroyed, ws.destroyed)
+	}
+	if rows := st.worktrees[rec.ID]; len(rows) != 1 || rows[0].WorktreePath != rec.Metadata.WorkspacePath {
+		t.Fatalf("terminated session worktree inventory = %+v, want preserved", rows)
+	}
+	if st.sessions[rec.ID].UpdatedAt != rec.UpdatedAt {
+		t.Fatalf("terminated session updated_at changed: got %v want %v", st.sessions[rec.ID].UpdatedAt, rec.UpdatedAt)
+	}
+}
+
 func TestKill_NativeTerminationFailurePreservesRuntimeAndWorkspace(t *testing.T) {
 	m, st, rt, ws := newManager()
 	agent := &nativeTerminatingAgent{wantID: "native-7", err: errors.New("prime stop failed")}
@@ -7112,6 +7138,84 @@ func TestReconcileBackgroundRestoresDurableOwnerAndParksLiveDuplicate(t *testing
 	}
 }
 
+func TestReconcileBackgroundParkDuplicatePreservesWorkspaceProjectInventory(t *testing.T) {
+	launcher := &recordingLauncher{}
+	m, st, rt := newChatManager(launcher)
+	project := st.projects["mer"]
+	project.Kind = domain.ProjectKindWorkspace
+	project.Path = "/repo/mer"
+	st.projects["mer"] = project
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	owner := domain.SessionRecord{
+		ID: "mer-owner", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessCodex, Mode: domain.SessionModeChat, IsTerminated: true,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator", ProviderConversationID: "thread-1",
+		},
+		Activity: domain.Activity{State: domain.ActivityExited},
+	}
+	duplicate := domain.SessionRecord{
+		ID: "mer-duplicate", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessCodex,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator", RuntimeHandleID: "runtime-duplicate",
+		},
+		Activity: domain.Activity{State: domain.ActivityIdle},
+	}
+	st.sessions[owner.ID] = owner
+	st.sessions[duplicate.ID] = duplicate
+	st.worktrees[owner.ID] = []domain.SessionWorktreeRecord{{
+		SessionID: owner.ID, RepoName: domain.RootWorkspaceRepoName,
+		Branch: owner.Metadata.Branch, WorktreePath: owner.Metadata.WorkspacePath, State: "removed",
+	}}
+	st.worktrees[duplicate.ID] = []domain.SessionWorktreeRecord{
+		{SessionID: duplicate.ID, RepoName: domain.RootWorkspaceRepoName, Branch: duplicate.Metadata.Branch, WorktreePath: duplicate.Metadata.WorkspacePath, State: "active"},
+		{SessionID: duplicate.ID, RepoName: "api", Branch: duplicate.Metadata.Branch, WorktreePath: "/ws/mer-orchestrator/api", State: "active"},
+	}
+	st.conversationOwners[owner.ID] = domain.ConversationRecord{
+		ID: "project-conversation", Scope: domain.ConversationScopeProject,
+		ProjectID: owner.ProjectID, SessionID: owner.ID,
+	}
+	rt.aliveByHandle = map[string]bool{"runtime-duplicate": true}
+
+	if err := m.ReconcileBackground(ctx); err != nil {
+		t.Fatalf("ReconcileBackground err = %v", err)
+	}
+	if !st.sessions[duplicate.ID].IsTerminated {
+		t.Fatal("workspace-project duplicate must be parked")
+	}
+	rows := st.worktrees[duplicate.ID]
+	if len(rows) != 2 {
+		t.Fatalf("parked workspace-project inventory = %+v, want root and child", rows)
+	}
+	states := map[string]string{}
+	for _, row := range rows {
+		states[row.RepoName] = row.State
+	}
+	if states[domain.RootWorkspaceRepoName] != "active" || states["api"] != "active" {
+		t.Fatalf("parked workspace-project states = %v, want active inventory", states)
+	}
+	cleanup, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatalf("Cleanup err = %v", err)
+	}
+	if len(cleanup.Cleaned) != 0 || len(cleanup.Skipped) != 1 || cleanup.Skipped[0].SessionID != duplicate.ID {
+		t.Fatalf("Cleanup parked duplicate = %+v, want duplicate skipped", cleanup)
+	}
+	if cleanup.Skipped[0].Reason != "workspace is owned by active orchestrator" {
+		t.Fatalf("Cleanup parked duplicate reason = %q", cleanup.Skipped[0].Reason)
+	}
+	if rows := st.worktrees[duplicate.ID]; len(rows) != 2 {
+		t.Fatalf("Cleanup dropped parked workspace-project inventory: %+v", rows)
+	}
+	ws := m.workspace.(*fakeWorkspace)
+	for _, call := range ws.calls {
+		if strings.HasPrefix(call, "ForceDestroy:") || strings.HasPrefix(call, "Destroy:") {
+			t.Fatalf("parking or cleanup destroyed shared workspace-project repo: calls=%v", ws.calls)
+		}
+	}
+}
+
 func TestReconcileBackgroundDoesNotParkDuplicateWhenControllerStopFails(t *testing.T) {
 	m, st, rt, _ := newLifecycleManager()
 	owner := domain.SessionRecord{
@@ -7302,7 +7406,7 @@ func TestRestoreAllPrefersDurableProjectConversationOwnerOverNewerDuplicate(t *t
 	}
 }
 
-func TestRestoreAllLeavesSavedOrchestratorTerminatedWhenConversationOwnershipIsUnknown(t *testing.T) {
+func TestRestoreAllRestoresSoleSavedOrchestratorWhenConversationOwnershipReadFails(t *testing.T) {
 	m, st, rt, _ := newLifecycleManager()
 	st.sessions["mer-1"] = domain.SessionRecord{
 		ID: "mer-1", ProjectID: "mer", Kind: domain.KindOrchestrator,
@@ -7321,8 +7425,35 @@ func TestRestoreAllLeavesSavedOrchestratorTerminatedWhenConversationOwnershipIsU
 	if err := m.RestoreAll(ctx); err != nil {
 		t.Fatalf("RestoreAll err = %v", err)
 	}
-	if rt.created != 0 || !st.sessions["mer-1"].IsTerminated {
-		t.Fatalf("unknown ownership restored session: runtime calls=%d session=%+v", rt.created, st.sessions["mer-1"])
+	if rt.created != 1 || st.sessions["mer-1"].IsTerminated {
+		t.Fatalf("sole saved orchestrator not restored: runtime calls=%d session=%+v", rt.created, st.sessions["mer-1"])
+	}
+}
+
+func TestRestoreAllLeavesContestedOrchestratorsTerminatedWhenConversationOwnershipIsUnknown(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	for _, id := range []domain.SessionID{"mer-1", "mer-2"} {
+		st.sessions[id] = domain.SessionRecord{
+			ID: id, ProjectID: "mer", Kind: domain.KindOrchestrator,
+			Harness: domain.HarnessClaudeCode, IsTerminated: true,
+			Metadata: domain.SessionMetadata{
+				WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator", AgentSessionID: "native-" + string(id),
+			},
+			Activity: domain.Activity{State: domain.ActivityExited},
+		}
+		st.worktrees[id] = []domain.SessionWorktreeRecord{{
+			SessionID: id, RepoName: domain.RootWorkspaceRepoName,
+			Branch: "ao/mer-orchestrator", WorktreePath: "/ws/mer-orchestrator", State: "removed",
+		}}
+	}
+	st.conversationErr = errors.New("sqlite busy")
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 0 || !st.sessions["mer-1"].IsTerminated || !st.sessions["mer-2"].IsTerminated {
+		t.Fatalf("unknown contested ownership changed sessions: runtime calls=%d mer-1=%+v mer-2=%+v",
+			rt.created, st.sessions["mer-1"], st.sessions["mer-2"])
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -27,17 +27,19 @@ import (
 var ctx = context.Background()
 
 type fakeStore struct {
-	sessions         map[domain.SessionID]domain.SessionRecord
-	pr               map[domain.SessionID]domain.PRFacts
-	projects         map[string]domain.ProjectRecord
-	workspaceRepo    map[string][]domain.WorkspaceRepoRecord
-	num              int
-	deleteErr        error
-	upsertWTErr      error
-	listAllErr       error
-	getProjectErr    error
-	getSessionErr    error
-	updateSessionErr error
+	sessions           map[domain.SessionID]domain.SessionRecord
+	pr                 map[domain.SessionID]domain.PRFacts
+	projects           map[string]domain.ProjectRecord
+	workspaceRepo      map[string][]domain.WorkspaceRepoRecord
+	num                int
+	deleteErr          error
+	upsertWTErr        error
+	listAllErr         error
+	getProjectErr      error
+	getSessionErr      error
+	updateSessionErr   error
+	conversationErr    error
+	conversationOwners map[domain.SessionID]domain.ConversationRecord
 	// agentSwitchStore is wired only by agent-switch tests so fakeLCM can model
 	// Lifecycle Manager's atomic ownership-boundary commands.
 	agentSwitchStore any
@@ -50,11 +52,12 @@ type fakeStore struct {
 
 func newFakeStore() *fakeStore {
 	return &fakeStore{
-		sessions:      map[domain.SessionID]domain.SessionRecord{},
-		pr:            map[domain.SessionID]domain.PRFacts{},
-		projects:      map[string]domain.ProjectRecord{},
-		workspaceRepo: map[string][]domain.WorkspaceRepoRecord{},
-		worktrees:     map[domain.SessionID][]domain.SessionWorktreeRecord{},
+		sessions:           map[domain.SessionID]domain.SessionRecord{},
+		pr:                 map[domain.SessionID]domain.PRFacts{},
+		projects:           map[string]domain.ProjectRecord{},
+		workspaceRepo:      map[string][]domain.WorkspaceRepoRecord{},
+		worktrees:          map[domain.SessionID][]domain.SessionWorktreeRecord{},
+		conversationOwners: map[domain.SessionID]domain.ConversationRecord{},
 	}
 }
 func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
@@ -112,6 +115,16 @@ func (f *fakeStore) GetSession(_ context.Context, id domain.SessionID) (domain.S
 	}
 	r, ok := f.sessions[id]
 	return r, ok, nil
+}
+func (f *fakeStore) ConversationForSession(_ context.Context, id domain.SessionID) (domain.ConversationRecord, error) {
+	if f.conversationErr != nil {
+		return domain.ConversationRecord{}, f.conversationErr
+	}
+	conversation, ok := f.conversationOwners[id]
+	if !ok {
+		return domain.ConversationRecord{}, domain.ErrNoConversation
+	}
+	return conversation, nil
 }
 func (f *fakeStore) ListSessions(_ context.Context, p domain.ProjectID) ([]domain.SessionRecord, error) {
 	var out []domain.SessionRecord
@@ -6976,6 +6989,340 @@ func TestRestoreAll_RestoresBothWorkerAndOrchestrator(t *testing.T) {
 	}
 	if st.sessions["mer-2"].IsTerminated {
 		t.Error("orchestrator session mer-2 must be live after RestoreAll")
+	}
+}
+
+func TestRestoreAllLeavesHistoricalOrchestratorTerminatedWhenReplacementIsLive(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	now := time.Date(2026, time.August, 28, 9, 0, 0, 0, time.UTC)
+	st.sessions["mer-old"] = domain.SessionRecord{
+		ID:           "mer-old",
+		ProjectID:    "mer",
+		Kind:         domain.KindOrchestrator,
+		Harness:      domain.HarnessCodex,
+		Mode:         domain.SessionModeChat,
+		IsTerminated: true,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath:          "/ws/mer-orchestrator",
+			Branch:                 "ao/mer-orchestrator",
+			ProviderConversationID: "native-old",
+		},
+		Activity:  domain.Activity{State: domain.ActivityExited},
+		CreatedAt: now.Add(-time.Hour),
+		UpdatedAt: now.Add(-time.Minute),
+	}
+	st.sessions["mer-new"] = domain.SessionRecord{
+		ID:        "mer-new",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Harness:   domain.HarnessCodex,
+		Mode:      domain.SessionModeTUI,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath:   "/ws/mer-orchestrator",
+			Branch:          "ao/mer-orchestrator",
+			RuntimeHandleID: "runtime-new",
+		},
+		Activity:  domain.Activity{State: domain.ActivityIdle},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	st.worktrees["mer-old"] = []domain.SessionWorktreeRecord{{
+		SessionID:    "mer-old",
+		RepoName:     domain.RootWorkspaceRepoName,
+		Branch:       "ao/mer-orchestrator",
+		WorktreePath: "/ws/mer-orchestrator",
+		State:        "removed",
+	}}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 0 {
+		t.Fatalf("runtime.Create calls = %d, want 0", rt.created)
+	}
+	if !st.sessions["mer-old"].IsTerminated {
+		t.Fatal("historical orchestrator must remain terminated while its replacement is live")
+	}
+	if rows := st.worktrees["mer-old"]; len(rows) != 1 || rows[0].State != "removed" {
+		t.Fatalf("historical restore marker = %+v, want preserved for an explicit decision", rows)
+	}
+	if st.sessions["mer-new"].IsTerminated {
+		t.Fatal("live replacement must remain live")
+	}
+}
+
+func TestReconcileBackgroundRestoresDurableOwnerAndParksLiveDuplicate(t *testing.T) {
+	launcher := &recordingLauncher{}
+	m, st, rt := newChatManager(launcher)
+	now := time.Date(2026, time.August, 28, 9, 0, 0, 0, time.UTC)
+	owner := domain.SessionRecord{
+		ID: "mer-owner", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessCodex, Mode: domain.SessionModeChat, IsTerminated: true,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator", ProviderConversationID: "thread-1",
+		},
+		Activity: domain.Activity{State: domain.ActivityExited}, CreatedAt: now.Add(-time.Hour), UpdatedAt: now.Add(-time.Minute),
+	}
+	duplicate := domain.SessionRecord{
+		ID: "mer-duplicate", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessCodex,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator",
+			RuntimeHandleID: "runtime-duplicate", AgentSessionID: "native-duplicate",
+		},
+		Activity: domain.Activity{State: domain.ActivityIdle}, CreatedAt: now, UpdatedAt: now,
+	}
+	st.sessions[owner.ID] = owner
+	st.sessions[duplicate.ID] = duplicate
+	st.worktrees[owner.ID] = []domain.SessionWorktreeRecord{{
+		SessionID: owner.ID, RepoName: domain.RootWorkspaceRepoName,
+		Branch: owner.Metadata.Branch, WorktreePath: owner.Metadata.WorkspacePath, State: "removed",
+	}}
+	st.conversationOwners[owner.ID] = domain.ConversationRecord{
+		ID: "project-conversation", Scope: domain.ConversationScopeProject,
+		ProjectID: owner.ProjectID, SessionID: owner.ID,
+	}
+	rt.aliveByHandle = map[string]bool{"runtime-duplicate": true}
+
+	if err := m.ReconcileBackground(ctx); err != nil {
+		t.Fatalf("ReconcileBackground err = %v", err)
+	}
+	if st.sessions[owner.ID].IsTerminated {
+		t.Fatal("durable project conversation owner must be restored")
+	}
+	if !st.sessions[duplicate.ID].IsTerminated {
+		t.Fatal("competing live orchestrator must be parked as recoverable terminated history")
+	}
+	if st.sessions[duplicate.ID].Metadata.AgentSessionID != "native-duplicate" ||
+		st.sessions[duplicate.ID].Metadata.WorkspacePath != owner.Metadata.WorkspacePath {
+		t.Fatalf("parked duplicate lost recoverable identity: %+v", st.sessions[duplicate.ID].Metadata)
+	}
+	if rt.destroyed != 1 || len(rt.destroyedIDs) != 1 || rt.destroyedIDs[0] != "runtime-duplicate" {
+		t.Fatalf("destroyed runtimes = count:%d ids:%v, want duplicate only", rt.destroyed, rt.destroyedIDs)
+	}
+	if rt.created != 0 || len(launcher.started) != 1 || launcher.started[0].SessionID != owner.ID ||
+		launcher.started[0].ProviderConversationID != "thread-1" {
+		t.Fatalf("restored Chat owner = runtime calls:%d starts:%+v", rt.created, launcher.started)
+	}
+	if st.sessions[owner.ID].Metadata.ProviderConversationID != "thread-1" {
+		t.Fatalf("owner provider conversation = %q, want thread-1", st.sessions[owner.ID].Metadata.ProviderConversationID)
+	}
+	if rows := st.worktrees[owner.ID]; len(rows) != 0 {
+		t.Fatalf("owner restore marker = %+v, want consumed", rows)
+	}
+}
+
+func TestReconcileBackgroundDoesNotParkDuplicateWhenControllerStopFails(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	owner := domain.SessionRecord{
+		ID: "mer-owner", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessClaudeCode, IsTerminated: true,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator", AgentSessionID: "native-owner",
+		},
+		Activity: domain.Activity{State: domain.ActivityExited},
+	}
+	duplicate := domain.SessionRecord{
+		ID: "mer-duplicate", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessCodex,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator", RuntimeHandleID: "runtime-duplicate",
+		},
+		Activity: domain.Activity{State: domain.ActivityIdle},
+	}
+	st.sessions[owner.ID] = owner
+	st.sessions[duplicate.ID] = duplicate
+	st.worktrees[owner.ID] = []domain.SessionWorktreeRecord{{
+		SessionID: owner.ID, RepoName: domain.RootWorkspaceRepoName,
+		Branch: owner.Metadata.Branch, WorktreePath: owner.Metadata.WorkspacePath, State: "removed",
+	}}
+	st.conversationOwners[owner.ID] = domain.ConversationRecord{
+		ID: "project-conversation", Scope: domain.ConversationScopeProject,
+		ProjectID: owner.ProjectID, SessionID: owner.ID,
+	}
+	rt.destroyErr = errors.New("runtime still attached")
+	rt.aliveByHandle = map[string]bool{"runtime-duplicate": true}
+
+	if err := m.ReconcileBackground(ctx); err != nil {
+		t.Fatalf("ReconcileBackground err = %v", err)
+	}
+	if st.sessions[duplicate.ID].IsTerminated {
+		t.Fatal("failed controller stop must not publish terminated ownership")
+	}
+	if !st.sessions[owner.ID].IsTerminated {
+		t.Fatal("saved owner must remain terminated while competing controller is still live")
+	}
+}
+
+type restoreDiscoveryStore struct {
+	*fakeStore
+	listed chan struct{}
+	once   sync.Once
+}
+
+func (s *restoreDiscoveryStore) ListSessionWorktrees(ctx context.Context, id domain.SessionID) ([]domain.SessionWorktreeRecord, error) {
+	rows, err := s.fakeStore.ListSessionWorktrees(ctx, id)
+	s.once.Do(func() { close(s.listed) })
+	return rows, err
+}
+
+func TestRestoreAllRechecksOrchestratorOwnershipUnderSharedProjectLock(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	now := time.Date(2026, time.August, 28, 9, 0, 0, 0, time.UTC)
+	target := domain.SessionRecord{
+		ID:           "mer-old",
+		ProjectID:    "mer",
+		Kind:         domain.KindOrchestrator,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath:  "/ws/mer-orchestrator",
+			Branch:         "ao/mer-orchestrator",
+			AgentSessionID: "native-old",
+		},
+		Activity:  domain.Activity{State: domain.ActivityExited},
+		CreatedAt: now.Add(-time.Hour),
+		UpdatedAt: now.Add(-time.Minute),
+	}
+	st.sessions[target.ID] = target
+	st.worktrees[target.ID] = []domain.SessionWorktreeRecord{{
+		SessionID: target.ID, RepoName: domain.RootWorkspaceRepoName,
+		Branch: target.Metadata.Branch, WorktreePath: target.Metadata.WorkspacePath, State: "removed",
+	}}
+	discovery := &restoreDiscoveryStore{fakeStore: st, listed: make(chan struct{})}
+	m.store = discovery
+
+	// Model an API orchestrator operation that wins the shared project lock
+	// after RestoreAll's discovery snapshot but before its authoritative read.
+	unlock := m.LockOrchestratorProject(target.ProjectID)
+	done := make(chan error, 1)
+	go func() { done <- m.RestoreAll(ctx) }()
+	<-discovery.listed
+	st.sessions["mer-new"] = domain.SessionRecord{
+		ID: "mer-new", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Activity: domain.Activity{State: domain.ActivityIdle}, CreatedAt: now, UpdatedAt: now,
+	}
+	unlock()
+
+	if err := <-done; err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 0 {
+		t.Fatalf("runtime.Create calls = %d, want 0 after ownership changed", rt.created)
+	}
+	if !st.sessions[target.ID].IsTerminated {
+		t.Fatal("historical orchestrator must remain terminated after a concurrent replacement wins ownership")
+	}
+	if rows := st.worktrees[target.ID]; len(rows) != 1 {
+		t.Fatalf("historical restore marker = %+v, want preserved", rows)
+	}
+}
+
+func TestRestoreAllRestoresOnlyNewestSavedOrchestratorPerProject(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	now := time.Date(2026, time.August, 28, 9, 0, 0, 0, time.UTC)
+	for i, id := range []domain.SessionID{"mer-old", "mer-new"} {
+		st.sessions[id] = domain.SessionRecord{
+			ID:           id,
+			ProjectID:    "mer",
+			Kind:         domain.KindOrchestrator,
+			Harness:      domain.HarnessClaudeCode,
+			IsTerminated: true,
+			Metadata: domain.SessionMetadata{
+				WorkspacePath:  "/ws/" + string(id),
+				Branch:         "ao/mer-orchestrator",
+				AgentSessionID: "native-" + string(id),
+			},
+			Activity:  domain.Activity{State: domain.ActivityExited},
+			CreatedAt: now.Add(time.Duration(i) * time.Minute),
+			UpdatedAt: now.Add(time.Duration(i) * time.Minute),
+		}
+		st.worktrees[id] = []domain.SessionWorktreeRecord{{
+			SessionID: id,
+			RepoName:  domain.RootWorkspaceRepoName,
+			State:     "removed",
+		}}
+	}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 1 {
+		t.Fatalf("runtime.Create calls = %d, want 1", rt.created)
+	}
+	if !st.sessions["mer-old"].IsTerminated {
+		t.Fatal("older saved orchestrator must remain terminated")
+	}
+	if st.sessions["mer-new"].IsTerminated {
+		t.Fatal("newest saved orchestrator must be restored")
+	}
+	if rows := st.worktrees["mer-old"]; len(rows) != 1 {
+		t.Fatalf("older restore marker = %+v, want preserved", rows)
+	}
+	if rows := st.worktrees["mer-new"]; len(rows) != 0 {
+		t.Fatalf("selected restore marker = %+v, want consumed", rows)
+	}
+}
+
+func TestRestoreAllPrefersDurableProjectConversationOwnerOverNewerDuplicate(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	now := time.Date(2026, time.August, 28, 9, 0, 0, 0, time.UTC)
+	for i, id := range []domain.SessionID{"mer-owner", "mer-newer"} {
+		st.sessions[id] = domain.SessionRecord{
+			ID: id, ProjectID: "mer", Kind: domain.KindOrchestrator,
+			Harness: domain.HarnessClaudeCode, IsTerminated: true,
+			Metadata: domain.SessionMetadata{
+				WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator",
+				AgentSessionID: "native-" + string(id),
+			},
+			Activity:  domain.Activity{State: domain.ActivityExited},
+			CreatedAt: now.Add(time.Duration(i) * time.Minute), UpdatedAt: now.Add(time.Duration(i) * time.Minute),
+		}
+		st.worktrees[id] = []domain.SessionWorktreeRecord{{
+			SessionID: id, RepoName: domain.RootWorkspaceRepoName,
+			Branch: "ao/mer-orchestrator", WorktreePath: "/ws/mer-orchestrator", State: "removed",
+		}}
+	}
+	st.conversationOwners["mer-owner"] = domain.ConversationRecord{
+		ID: "project-conversation", Scope: domain.ConversationScopeProject,
+		ProjectID: "mer", SessionID: "mer-owner",
+	}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 1 || rt.lastCfg.SessionID != "mer-owner" {
+		t.Fatalf("restored runtime = calls:%d session:%q, want one for durable owner mer-owner", rt.created, rt.lastCfg.SessionID)
+	}
+	if st.sessions["mer-owner"].IsTerminated {
+		t.Fatal("durable project conversation owner must be restored")
+	}
+	if !st.sessions["mer-newer"].IsTerminated {
+		t.Fatal("newer duplicate must remain terminated when it does not own the project conversation")
+	}
+}
+
+func TestRestoreAllLeavesSavedOrchestratorTerminatedWhenConversationOwnershipIsUnknown(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Harness: domain.HarnessClaudeCode, IsTerminated: true,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-orchestrator", Branch: "ao/mer-orchestrator", AgentSessionID: "native-1",
+		},
+		Activity: domain.Activity{State: domain.ActivityExited},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{
+		SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName,
+		Branch: "ao/mer-orchestrator", WorktreePath: "/ws/mer-orchestrator", State: "removed",
+	}}
+	st.conversationErr = errors.New("sqlite busy")
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 0 || !st.sessions["mer-1"].IsTerminated {
+		t.Fatalf("unknown ownership restored session: runtime calls=%d session=%+v", rt.created, st.sessions["mer-1"])
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -368,6 +368,22 @@ the message for retry; Chat retries carry a stable idempotency key. Old Chat
 events are fenced by controller generation; old TUI hooks are fenced by runtime
 launch id.
 
+Orchestrator execution ownership is also project-scoped: no operation may
+activate a second live orchestrator for one project. Spawn, replacement,
+explicit restore, and startup restore share a per-project daemon lock from
+their final ownership read through controller publication. The daemon
+supervisor remains the process-level ownership boundary. Shutdown restore
+markers remain per-session for backward compatibility, but startup selects at
+most one marked orchestrator per project and never restores a historical marker
+while another orchestrator is live. When an older release left several saved
+candidates, the session bound as the durable project-conversation owner wins;
+creation time is only the fallback when no such Chat ownership exists. Existing
+live duplicates are repaired only when that exact conversation-owner proof is
+available: competing controllers are stopped and their rows are parked as
+recoverable history without touching the shared workspace or native ids. An
+ambiguous duplicate set is preserved for an explicit user decision rather than
+being destructively "cleaned up" by a timestamp heuristic.
+
 `drain` is loss-minimizing and may wait on an approval or user-input request;
 `interrupt` synchronously closes source intake and queue dispatch at transition
 acceptance. After target preflight succeeds, it settles queued Chat turns and

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -257,6 +257,40 @@ describe("SessionsBoard", () => {
 		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");
 	});
 
+	it("does not offer destructive restart as automatic duplicate-orchestrator cleanup", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				workspaceWithSessions([
+					boardSession({
+						id: "orch-old",
+						title: "old orchestrator",
+						kind: "orchestrator",
+						status: "idle",
+						createdAt: "2026-01-01T00:00:00Z",
+					}),
+					boardSession({
+						id: "orch-new",
+						title: "new orchestrator",
+						kind: "orchestrator",
+						status: "idle",
+						createdAt: "2026-01-02T00:00:00Z",
+					}),
+				]),
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		expect(
+			screen.getByText(
+				"Multiple orchestrators are active. AO could not safely determine which one owns this project, so automatic cleanup is disabled.",
+			),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Restart" })).not.toBeInTheDocument();
+	});
+
 	it("shows the Board crumb on the root board when actions live in the panel", () => {
 		boardActionsInPanelMock.mockReturnValue(true);
 		workspaceQueryMock.mockReturnValue({

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -364,7 +364,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 					<div className="mx-3 my-3 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2 text-xs text-muted-foreground">
 						<AlertTriangle className="size-icon-base shrink-0 text-warning" aria-hidden="true" />
 						<span className="min-w-0 flex-1">{health.message}</span>
-						{health.state === "restart_needed" || health.state === "duplicates" ? (
+						{health.state === "restart_needed" ? (
 							<TopbarButton disabled={isProjectRestarting} onClick={() => void restartOrchestrator()} variant="primary">
 								<RotateCw className="size-3.5" aria-hidden="true" />
 								{t("shell.restart")}

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -242,7 +242,7 @@ describe("orchestratorHealth", () => {
 		).toEqual({
 			state: "duplicates",
 			message:
-				"Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
+				"Multiple orchestrators are active. AO could not safely determine which one owns this project, so automatic cleanup is disabled.",
 		});
 
 		expect(

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -355,7 +355,7 @@ export function orchestratorHealth(workspace: WorkspaceSummary, restarting = fal
 		return {
 			state: "duplicates",
 			message:
-				"Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
+				"Multiple orchestrators are active. AO could not safely determine which one owns this project, so automatic cleanup is disabled.",
 		};
 	}
 	const orchestrator = newestActiveOrchestrator(workspace.sessions);


### PR DESCRIPTION
## Summary

Fixes #4590.

- make project-orchestrator ownership a shared Session Manager boundary used by startup reconciliation, spawn/replacement, and explicit restore
- restore at most one saved orchestrator per project, preferring the durable project-conversation owner over timestamp recency
- when the durable owner is exact and a competing controller is live, stop only the competing controller and park its session as recoverable history; do not remove the shared workspace or native provider/session identity
- fail closed when ownership is absent, ambiguous, or changes during reconciliation
- replace the misleading duplicate-orchestrator Restart action with a truthful non-destructive warning

## Root cause and reproduction

`RestoreAll` treated shutdown restore markers as independent per-session facts. Project-scoped orchestrator ownership was enforced separately in the session service and was not rechecked under the same lock before startup controller publication. An older terminated Chat orchestrator could therefore retain the durable project conversation while a replacement TUI orchestrator remained live on the same canonical branch/worktree. Startup either restored both ownership histories or left the wrong one active depending on timing; the UI then promised that a later daemon reconcile would clean up duplicates even though no such ownership repair existed.

The regression tests model the nightly incident without reading or modifying `~/.ao`: a terminated Chat owner with its original provider conversation and restore marker, plus a live TUI duplicate sharing the canonical workspace. Reconciliation proves the Chat session from the durable project conversation, stops and parks only the TUI controller, then restores the Chat owner in place with the same AO session ID, workspace, branch, and provider conversation.

## State-machine / safety boundary

All project-orchestrator admission paths now share the Session Manager's project lock. Startup performs fresh session, liveness, marker, and conversation-owner reads after acquiring the relevant project/session fences. A live sibling blocks ordinary restore. Exact durable ownership may repair a legacy duplicate by stopping its controller and marking that row terminated, but cleanup deliberately does not destroy its workspace or erase native identity. If controller stop fails, the competing row remains live and owner restore remains blocked. If ownership cannot be proved, AO leaves every session untouched for an explicit decision.

No schema, migration, generated-code, or stored-session rewrite is involved.

## Recovery notes

After installing a build containing this change, the observed shape (historical terminated Chat owner plus a live TUI replacement on the same project workspace) is repaired on startup only if the project conversation still proves the historical Chat owner. The replacement controller is parked as a recoverable terminated session and the owner is resumed through the existing Chat restore path, preserving its native thread and transcript. If that proof is missing or ambiguous, automatic cleanup is disabled and the UI reports that manual resolution is required.

This recovery path is covered with fakes and production-shaped durable ownership facts. I did **not** run it against or mutate the user's live `~/.ao` data.

## Tests

- `cd backend && env -i HOME="$HOME" PATH="$PATH" TMPDIR="$TMPDIR" go test ./...`
- `cd backend && env -i HOME="$HOME" PATH="$PATH" TMPDIR="$TMPDIR" go test -race ./internal/session_manager ./internal/service/session`
- `cd backend && go build ./...`
- `cd backend && go vet ./...`
- `golangci-lint run` (v2.12.2)
- `cd frontend && npm run typecheck`
- `cd frontend && npx vitest run src/renderer/components/SessionsBoard.test.tsx src/renderer/types/workspace.test.ts`
- full frontend suite: 230 files passed, 3,019 tests passed, 1 skipped
