### PR TITLE
fix(mobile): neutral copy on the camera pre-permission button

### DIFF
--- a/packages/mobile/app/pair.tsx
+++ b/packages/mobile/app/pair.tsx
@@ -237,7 +237,10 @@ function CameraGate({
 					: "Camera access is turned off for AO. Enable it in system settings, or enter your details manually below."}
 			</Text>
 			{canAskAgain ? (
-				<Button title="Allow camera" icon="camera" onPress={onRequest} style={{ marginTop: 18 }} />
+				// App Review 5.1.1(iv): the button ahead of the system permission
+				// prompt must read "Continue"/"Next", never "Allow ...", so the grant
+				// decision is only ever made in the system dialog itself.
+				<Button title="Continue" onPress={onRequest} style={{ marginTop: 18 }} />
 			) : (
 				<Button
 					title="Open settings"


### PR DESCRIPTION
App Review rejected 1.2.0 under guideline 5.1.1(iv):

> A custom message appears before the permission request, and to proceed users
> press a "Allow Camera" button. Use words like "Continue" or "Next" on the
> button instead.

The button ahead of the system camera prompt pre-answered the system dialog on
the user's behalf. It now reads "Continue", and the camera icon is dropped so it
does not read as a grant action either.

Copy-only. The explanatory text above the button, the denied-state "Open
settings" path, and the "Enter details manually" fallback are all unchanged.

Submission ID: 51cafdf2-3a8d-40ab-b25b-b7174308008d

This same one-line change already shipped in iOS build 1.2.1 (13), cut from the
commit that produced the current TestFlight build rather than from main. This PR
forward-ports it so main does not regress.