### PR TITLE
fix(mobile): declare the iOS privacy manifest to match the store labels

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -23,9 +23,26 @@
 			"config": {
 				"usesNonExemptEncryption": false
 			},
+			"privacyManifests": {
+				"NSPrivacyTracking": false,
+				"NSPrivacyCollectedDataTypes": [
+					{
+						"NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeProductInteraction",
+						"NSPrivacyCollectedDataTypeLinked": false,
+						"NSPrivacyCollectedDataTypeTracking": false,
+						"NSPrivacyCollectedDataTypePurposes": ["NSPrivacyCollectedDataTypePurposeAnalytics"]
+					},
+					{
+						"NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeDeviceID",
+						"NSPrivacyCollectedDataTypeLinked": false,
+						"NSPrivacyCollectedDataTypeTracking": false,
+						"NSPrivacyCollectedDataTypePurposes": ["NSPrivacyCollectedDataTypePurposeAppFunctionality"]
+					}
+				]
+			},
 			"infoPlist": {
 				"NSLocalNetworkUsageDescription": "AO connects to Agent Orchestrator running on your computer over your local network.",
-				"NSPhotoLibraryUsageDescription": "AO uses camera-related system features to help pair with your desktop.",
+				"NSPhotoLibraryUsageDescription": "AO uses your photo library so you can attach images to an agent conversation.",
 				"NSAppTransportSecurity": {
 					"NSAllowsLocalNetworking": true
 				},


### PR DESCRIPTION
Follow-up to the App Review rejection of 1.2.0 (guideline 5.1.2(i)). The privacy
labels in App Store Connect have been corrected there; this closes the matching
gap in the binary.

The generated `PrivacyInfo.xcprivacy` shipped an empty `NSPrivacyCollectedDataTypes`
while App Store Connect declares two data types. Expo merges `ios.privacyManifests`
from the app config into the generated manifest, so they are declared there now:

- **Product Interaction** — analytics, not linked, not used for tracking. The
  PostHog event stream, anonymous by construction: `personProfiles: "never"` at
  `lib/telemetry/runtime.ts` and nothing in the app calls `identify()`.
- **Device ID** — app functionality, not linked, not used for tracking. The Expo
  push token minted in `lib/push.ts` and registered with the daemon so
  notifications can be delivered.

`NSPrivacyTracking` stays `false`, which is accurate: no IDFA, no AdSupport, no
advertising or attribution SDK, and nothing shared with data brokers. Apple's
5.1.2(i) rejection was based on the store labels, not on app behaviour.

Also corrects `NSPhotoLibraryUsageDescription`, which described camera-related
pairing rather than attaching images. The `expo-image-picker` plugin's
`photosPermission` already overrode it in the built `Info.plist`, so no shipped
build carried the wrong string — this just stops the two from contradicting each
other.

Static plist declaration only; no runtime code. Takes effect on the next prebuild.