### PR TITLE
fix(preview): clear session preview URL when managed dev server crashes (#4500)

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -292,6 +292,26 @@ func Run() error {
 		}
 		return fmt.Errorf("wire session service: %w", err)
 	}
+
+	// When a managed preview server crashes after launch, the Browser panel's
+	// only failure hook is `did-fail-load`, which fires on navigation, not on an
+	// already-rendered page whose backing server has died. Clear the session's
+	// preview URL so the panel falls off the dead server and the session update
+	// fans out via the existing CDC session_updated event (issue #4500). Only
+	// clear when the session's current preview URL still points at the failed
+	// server, so an unrelated static-file preview isn't clobbered.
+	managedPreview.SetOnExit(func(ctx context.Context, id domain.SessionID, status previewserver.Status) {
+		sess, err := sessionSvc.Get(ctx, id)
+		if err != nil {
+			return
+		}
+		if status.URL == "" || sess.Metadata.PreviewURL != status.URL {
+			return
+		}
+		if _, err := sessionSvc.SetPreview(ctx, id, ""); err != nil {
+			log.Warn("clear preview URL after managed preview crash", "session", id, "err", err)
+		}
+	})
 	sessMgr.SetTerminalInputGate(termMgr)
 	lifecycleMessenger.Bind(sessionLifecycleMessenger{sessMgr})
 	lcStack.LCM.SetCompletionTerminator(sessMgr)

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -293,25 +293,8 @@ func Run() error {
 		return fmt.Errorf("wire session service: %w", err)
 	}
 
-	// When a managed preview server crashes after launch, the Browser panel's
-	// only failure hook is `did-fail-load`, which fires on navigation, not on an
-	// already-rendered page whose backing server has died. Clear the session's
-	// preview URL so the panel falls off the dead server and the session update
-	// fans out via the existing CDC session_updated event (issue #4500). Only
-	// clear when the session's current preview URL still points at the failed
-	// server, so an unrelated static-file preview isn't clobbered.
-	managedPreview.SetOnExit(func(ctx context.Context, id domain.SessionID, status previewserver.Status) {
-		sess, err := sessionSvc.Get(ctx, id)
-		if err != nil {
-			return
-		}
-		if status.URL == "" || sess.Metadata.PreviewURL != status.URL {
-			return
-		}
-		if _, err := sessionSvc.SetPreview(ctx, id, ""); err != nil {
-			log.Warn("clear preview URL after managed preview crash", "session", id, "err", err)
-		}
-	})
+	// servers isn't clobbered. See preview_wiring.go (issue #4500).
+	wireManagedPreviewExit(managedPreview, sessionSvc, log)
 	sessMgr.SetTerminalInputGate(termMgr)
 	lifecycleMessenger.Bind(sessionLifecycleMessenger{sessMgr})
 	lcStack.LCM.SetCompletionTerminator(sessMgr)

--- a/backend/internal/daemon/preview_wiring.go
+++ b/backend/internal/daemon/preview_wiring.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/previewserver"
+)
+
+// previewExitSessions is the slice of the session service the managed preview
+// exit callback needs: read the current preview URL and clear it.
+type previewExitSessions interface {
+	Get(ctx context.Context, id domain.SessionID) (domain.Session, error)
+	SetPreview(ctx context.Context, id domain.SessionID, previewURL string) (domain.Session, error)
+}
+
+// wireManagedPreviewExit registers the OnExit callback that clears a session's
+// preview URL when its managed preview server crashes after launch.
+func wireManagedPreviewExit(managedPreview *previewserver.Manager, sessions previewExitSessions, log *slog.Logger) {
+	managedPreview.SetOnExit(managedPreviewExitFunc(sessions, log))
+}
+
+// managedPreviewExitFunc returns the OnExit callback. It fires from the
+// preview manager's wait goroutine when a managed server exits without a
+// user-initiated stop. It clears the session's preview URL only when the
+// current preview URL still points at the failed server, so an unrelated
+// static-file preview or an already-restarted server is not clobbered. The
+// session update fans out to the renderer via the existing CDC
+// session_updated event (issue #4500).
+func managedPreviewExitFunc(sessions previewExitSessions, log *slog.Logger) previewserver.OnExitFunc {
+	return func(ctx context.Context, id domain.SessionID, status previewserver.Status) {
+		sess, err := sessions.Get(ctx, id)
+		if err != nil {
+			log.Warn("fetch session to clear preview URL after managed preview crash", "session", id, "err", err)
+			return
+		}
+		if status.URL == "" || sess.Metadata.PreviewURL != status.URL {
+			return
+		}
+		if _, err := sessions.SetPreview(ctx, id, ""); err != nil {
+			log.Warn("clear preview URL after managed preview crash", "session", id, "err", err)
+		}
+	}
+}

--- a/backend/internal/daemon/preview_wiring_test.go
+++ b/backend/internal/daemon/preview_wiring_test.go
@@ -1,0 +1,124 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/previewserver"
+)
+
+type fakePreviewExitSessions struct {
+	sessions   map[domain.SessionID]domain.Session
+	getErr     error
+	setErr     error
+	clearedIDs []domain.SessionID
+}
+
+func (f *fakePreviewExitSessions) Get(_ context.Context, id domain.SessionID) (domain.Session, error) {
+	if f.getErr != nil {
+		return domain.Session{}, f.getErr
+	}
+	sess, ok := f.sessions[id]
+	if !ok {
+		return domain.Session{}, errors.New("session not found")
+	}
+	return sess, nil
+}
+
+func (f *fakePreviewExitSessions) SetPreview(_ context.Context, id domain.SessionID, previewURL string) (domain.Session, error) {
+	if f.setErr != nil {
+		return domain.Session{}, f.setErr
+	}
+	sess, ok := f.sessions[id]
+	if !ok {
+		return domain.Session{}, errors.New("session not found")
+	}
+	sess.Metadata.PreviewURL = previewURL
+	f.sessions[id] = sess
+	if previewURL == "" {
+		f.clearedIDs = append(f.clearedIDs, id)
+	}
+	return sess, nil
+}
+
+func fakePreviewSession(id domain.SessionID, previewURL string) domain.Session {
+	return domain.Session{SessionRecord: domain.SessionRecord{
+		ID: id,
+		Metadata: domain.SessionMetadata{
+			PreviewURL: previewURL,
+		},
+	}}
+}
+
+func testLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, nil))
+}
+
+func TestManagedPreviewExitClearsMatchingPreviewURL(t *testing.T) {
+	fake := &fakePreviewExitSessions{sessions: map[domain.SessionID]domain.Session{
+		"ao-1": fakePreviewSession("ao-1", "http://127.0.0.1:4173/"),
+	}}
+	callback := managedPreviewExitFunc(fake, testLogger(&bytes.Buffer{}))
+
+	callback(context.Background(), "ao-1", previewserver.Status{State: previewserver.StateFailed, URL: "http://127.0.0.1:4173/", Error: "exit status 1"})
+
+	if len(fake.clearedIDs) != 1 || fake.clearedIDs[0] != domain.SessionID("ao-1") {
+		t.Fatalf("cleared = %v, want [ao-1]", fake.clearedIDs)
+	}
+}
+
+func TestManagedPreviewExitLeavesUnrelatedPreviewURLAlone(t *testing.T) {
+	// The session's preview URL no longer points at the failed server: either
+	// the user replaced it with a static-file preview or the server was
+	// restarted on a different URL before the exit callback ran.
+	fake := &fakePreviewExitSessions{sessions: map[domain.SessionID]domain.Session{
+		"ao-1": fakePreviewSession("ao-1", "file:///tmp/index.html"),
+		"ao-2": fakePreviewSession("ao-2", "http://127.0.0.1:9999/"),
+	}}
+	callback := managedPreviewExitFunc(fake, testLogger(&bytes.Buffer{}))
+
+	callback(context.Background(), "ao-1", previewserver.Status{State: previewserver.StateFailed, URL: "http://127.0.0.1:4173/"})
+	callback(context.Background(), "ao-2", previewserver.Status{State: previewserver.StateFailed, URL: "http://127.0.0.1:4173/"})
+	callback(context.Background(), "ao-1", previewserver.Status{State: previewserver.StateFailed, URL: ""})
+
+	if len(fake.clearedIDs) != 0 {
+		t.Fatalf("cleared = %v, want none", fake.clearedIDs)
+	}
+}
+
+func TestManagedPreviewExitLogsGetFailureAndDoesNotClear(t *testing.T) {
+	getErr := errors.New("store unavailable")
+	fake := &fakePreviewExitSessions{sessions: map[domain.SessionID]domain.Session{
+		"ao-1": fakePreviewSession("ao-1", "http://127.0.0.1:4173/"),
+	}, getErr: getErr}
+	buf := &bytes.Buffer{}
+	callback := managedPreviewExitFunc(fake, testLogger(buf))
+
+	callback(context.Background(), "ao-1", previewserver.Status{State: previewserver.StateFailed, URL: "http://127.0.0.1:4173/"})
+
+	if len(fake.clearedIDs) != 0 {
+		t.Fatalf("cleared = %v, want none: a failed Get must not clear the preview URL", fake.clearedIDs)
+	}
+	if out := buf.String(); !strings.Contains(out, "fetch session to clear preview URL") || !strings.Contains(out, "store unavailable") {
+		t.Fatalf("log output %q does not mention the Get failure", out)
+	}
+}
+
+func TestManagedPreviewExitLogsSetPreviewFailure(t *testing.T) {
+	fake := &fakePreviewExitSessions{sessions: map[domain.SessionID]domain.Session{
+		"ao-1": fakePreviewSession("ao-1", "http://127.0.0.1:4173/"),
+	}, setErr: errors.New("store read-only")}
+	buf := &bytes.Buffer{}
+	callback := managedPreviewExitFunc(fake, testLogger(buf))
+
+	callback(context.Background(), "ao-1", previewserver.Status{State: previewserver.StateFailed, URL: "http://127.0.0.1:4173/"})
+
+	if out := buf.String(); !strings.Contains(out, "clear preview URL after managed preview crash") || !strings.Contains(out, "store read-only") {
+		t.Fatalf("log output %q does not mention the SetPreview failure", out)
+	}
+}

--- a/backend/internal/previewserver/manager.go
+++ b/backend/internal/previewserver/manager.go
@@ -319,7 +319,11 @@ func (m *Manager) Start(
 	m.runs[sessionID] = run
 	m.persistProcessesLocked()
 	m.mu.Unlock()
-	go m.waitForExit(sessionID, run)
+	// Pass the request-scoped context into the wait goroutine so OnExit
+	// callbacks (issue #4500) inherit a context the gosec G118 check accepts.
+	// The wait goroutine detaches cancellation with context.WithoutCancel so a
+	// caller request ending after launch does not cancel the OnExit call.
+	go m.waitForExit(context.WithoutCancel(ctx), sessionID, run)
 	releaseOperation()
 	operationLocked = false
 
@@ -508,7 +512,7 @@ func (m *Manager) Close() {
 	}
 }
 
-func (m *Manager) waitForExit(sessionID domain.SessionID, run *serverRun) {
+func (m *Manager) waitForExit(ctx context.Context, sessionID domain.SessionID, run *serverRun) {
 	err := run.cmd.Wait()
 	// Wait has returned, so the PID is back in the OS pool and no longer
 	// provably AO's. No escalation happens here: descendants the dead root
@@ -542,10 +546,13 @@ func (m *Manager) waitForExit(sessionID domain.SessionID, run *serverRun) {
 		// can be told the backing server is gone. After failedStatusRetention
 		// the failed run is removed and status reports "stopped" with no
 		// error, so this is the only window to surface the failure.
+		// ctx is the request-scoped context passed by Start with
+		// context.WithoutCancel, so caller cancellation cannot kill the
+		// callback (gosec G118 wants a request-scoped ancestor).
 		status := m.statusFor(run)
 		if fn := m.onExitCallback(); fn != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			fn(ctx, sessionID, status)
+			notifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			fn(notifyCtx, sessionID, status)
 			cancel()
 		}
 	}

--- a/backend/internal/previewserver/manager.go
+++ b/backend/internal/previewserver/manager.go
@@ -139,6 +139,13 @@ type persistedProcess struct {
 	StartTime string `json:"startTime,omitempty"`
 }
 
+// OnExitFunc is invoked from the manager's wait goroutine when a managed
+// preview process exits on its own (i.e. the caller did not request the
+// stop). It runs synchronously off the manager's lock, so it is safe to call
+// back into the session service. The status passed in carries the post-failure
+// State/Error so callers can decide whether to clear the session's preview URL.
+type OnExitFunc func(ctx context.Context, sessionID domain.SessionID, status Status)
+
 // Manager supervises at most one managed preview server per AO session.
 type Manager struct {
 	log    *slog.Logger
@@ -150,6 +157,9 @@ type Manager struct {
 	operationsMu sync.Mutex
 	operations   map[domain.SessionID]*sessionOperation
 	registryPath string
+
+	onExitMu sync.Mutex
+	onExit   OnExitFunc
 }
 
 // New creates a managed preview-server supervisor.
@@ -185,6 +195,22 @@ func New(log *slog.Logger, dataDir ...string) *Manager {
 		},
 	}
 	return manager
+}
+
+// SetOnExit registers a callback fired from the wait goroutine when a managed
+// preview process exits without being stopped. Pass nil to clear. The callback
+// is invoked with a fresh context that is not tied to any request; it runs off
+// the manager's mutex so it may safely call back into the session service.
+func (m *Manager) SetOnExit(fn OnExitFunc) {
+	m.onExitMu.Lock()
+	m.onExit = fn
+	m.onExitMu.Unlock()
+}
+
+func (m *Manager) onExitCallback() OnExitFunc {
+	m.onExitMu.Lock()
+	defer m.onExitMu.Unlock()
+	return m.onExit
 }
 
 // Start loads a named configuration, replaces any existing managed server for
@@ -488,6 +514,7 @@ func (m *Manager) waitForExit(sessionID domain.SessionID, run *serverRun) {
 	// provably AO's. No escalation happens here: descendants the dead root
 	// left behind are leaked rather than group-killed on a number that may
 	// already belong to something else (issue #3475).
+	crashed := false
 	m.mu.Lock()
 	if m.runs[sessionID] == run {
 		run.cmd = nil
@@ -503,11 +530,25 @@ func (m *Manager) waitForExit(sessionID domain.SessionID, run *serverRun) {
 			} else {
 				run.status.Error = "preview server exited"
 			}
+			crashed = true
 		}
 	}
 	m.persistProcessesLocked()
 	m.mu.Unlock()
 	close(run.done)
+	if crashed {
+		// Snapshot the failed status under the lock and notify the registered
+		// listener (e.g. the daemon's session service) so the Browser panel
+		// can be told the backing server is gone. After failedStatusRetention
+		// the failed run is removed and status reports "stopped" with no
+		// error, so this is the only window to surface the failure.
+		status := m.statusFor(run)
+		if fn := m.onExitCallback(); fn != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			fn(ctx, sessionID, status)
+			cancel()
+		}
+	}
 	time.AfterFunc(failedStatusRetention, func() {
 		m.mu.Lock()
 		if m.runs[sessionID] == run && run.cmd == nil {

--- a/backend/internal/previewserver/manager_test.go
+++ b/backend/internal/previewserver/manager_test.go
@@ -14,14 +14,62 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 func TestPreviewServerHelper(t *testing.T) {
-	if os.Getenv("AO_PREVIEW_TEST_HELPER") != "1" {
+	if os.Getenv("AO_PREVIEW_CRASH_HELPER") == "1" {
+		serveUntilFirstRequestThenExit(t)
 		return
 	}
+	if os.Getenv("AO_PREVIEW_TEST_HELPER") == "1" {
+		servePreviewHelper(t)
+		return
+	}
+}
+
+// serveUntilFirstRequestThenExit binds the loopback port passed via PORT,
+// answers HTTP requests until AO_PREVIEW_CRASH_AFTER_MS milliseconds have
+// passed (default 200ms), then exits with a non-zero status. That window is
+// long enough for the manager's readiness probe to flip the run to
+// StateReady, and short enough that the subsequent waitForExit goroutine
+// observes a crash rather than a user-initiated stop (issue #4500).
+func serveUntilFirstRequestThenExit(t *testing.T) {
+	t.Helper()
+	port, err := strconv.Atoi(os.Getenv("PORT"))
+	if err != nil || port <= 0 {
+		t.Fatalf("invalid helper PORT %q", os.Getenv("PORT"))
+	}
+	delay := 2 * time.Second
+	if raw := os.Getenv("AO_PREVIEW_CRASH_AFTER_MS"); raw != "" {
+		if n, errConv := strconv.Atoi(raw); errConv == nil && n > 0 {
+			delay = time.Duration(n) * time.Millisecond
+		}
+	}
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Fprintln(os.Stderr, "crash helper listening")
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, "<!doctype html><title>crash helper</title>")
+	})}
+	go func() {
+		time.Sleep(delay)
+		_ = srv.Close()
+		fmt.Fprintln(os.Stderr, "crash helper exiting")
+		os.Exit(7)
+	}()
+	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		t.Fatal(err)
+	}
+}
+
+func servePreviewHelper(t *testing.T) {
+	t.Helper()
 	port, err := strconv.Atoi(os.Getenv("PORT"))
 	if err != nil || port <= 0 {
 		t.Fatalf("invalid helper PORT %q", os.Getenv("PORT"))
@@ -91,6 +139,82 @@ func TestManagerKeepsConcurrentSessionServersIsolated(t *testing.T) {
 	}
 	if manager.Status("ao-1").State != StateReady || manager.Status("ao-2").State != StateReady {
 		t.Fatalf("both session servers should remain ready")
+	}
+}
+
+func TestManagerFiresOnExitWhenServerCrashesAfterLaunch(t *testing.T) {
+	workspace := writeLaunchFile(t, []Configuration{crashConfiguration("crashy", TargetApp)})
+	manager := New(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(manager.Close)
+
+	gotStatus := make(chan Status, 1)
+	// Register OnExit BEFORE Start so the readiness-to-crash window cannot
+	// outrun the registration. The daemon wires the same way, after building
+	// the preview manager but before any user request can reach Start.
+	manager.SetOnExit(func(_ context.Context, _ domain.SessionID, s Status) {
+		gotStatus <- s
+	})
+
+	status, err := manager.Start(context.Background(), domain.SessionID("ao-1"), workspace, "")
+	if err != nil {
+		t.Fatalf("Start: %v\nstatus=%+v", err, status)
+	}
+	if status.State != StateReady {
+		t.Fatalf("status = %+v, want ready", status)
+	}
+
+	// Wait for the process to die on its own. The crash helper exits with a
+	// non-zero code a few hundred ms after starting; waitForExit then flips
+	// the run to StateFailed and fires the OnExit callback.
+	select {
+	case s := <-gotStatus:
+		if s.State != StateFailed {
+			t.Fatalf("onExit state = %q, want %q", s.State, StateFailed)
+		}
+		if s.Error == "" {
+			t.Fatalf("onExit error is empty, want a non-empty message")
+		}
+		if s.URL != status.URL {
+			t.Fatalf("onExit URL = %q, want %q", s.URL, status.URL)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("OnExit callback never fired; manager did not notice the server crashed")
+	}
+
+	// Status must reflect the crash immediately, before the
+	// failedStatusRetention window expires (issue #4500).
+	post := manager.Status("ao-1")
+	if post.State != StateFailed {
+		t.Fatalf("post-crash state = %q, want %q", post.State, StateFailed)
+	}
+	if post.Error == "" {
+		t.Fatalf("post-crash error is empty")
+	}
+}
+
+func TestManagerDoesNotFireOnExitWhenStoppedByUser(t *testing.T) {
+	workspace := writeLaunchFile(t, []Configuration{helperConfiguration("web", TargetApp)})
+	manager := New(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(manager.Close)
+
+	status, err := manager.Start(context.Background(), domain.SessionID("ao-1"), workspace, "")
+	if err != nil {
+		t.Fatalf("Start: %v\nstatus=%+v", err, status)
+	}
+
+	gotStatus := make(chan Status, 1)
+	manager.SetOnExit(func(_ context.Context, _ domain.SessionID, s Status) {
+		gotStatus <- s
+	})
+
+	if _, err := manager.Stop(context.Background(), "ao-1"); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	select {
+	case s := <-gotStatus:
+		t.Fatalf("OnExit fired for a user-initiated stop: state=%q error=%q", s.State, s.Error)
+	case <-time.After(500 * time.Millisecond):
 	}
 }
 
@@ -200,6 +324,27 @@ func helperConfiguration(name string, kind TargetKind) Configuration {
 		TargetKind:         kind,
 		Env:                map[string]string{"AO_PREVIEW_TEST_HELPER": "1"},
 		ReadyTimeoutMillis: 5000,
+	}
+}
+
+// crashConfiguration returns a configuration whose process boots the
+// readiness probe on the same loopback port and then exits on its own with a
+// non-zero status. The manager should treat this as StateFailed and fire
+// OnExit (issue #4500).
+func crashConfiguration(name string, kind TargetKind) Configuration {
+	return Configuration{
+		Name:               name,
+		RuntimeExecutable:  os.Args[0],
+		RuntimeArgs:        []string{"-test.run=^TestPreviewServerHelper$"},
+		Port:               0,
+		AutoPort:           true,
+		URL:                "http://127.0.0.1:${PORT}/",
+		TargetKind:         kind,
+		ReadyTimeoutMillis: 5000,
+		Env: map[string]string{
+			"AO_PREVIEW_CRASH_HELPER": "1",
+			"AO_PREVIEW_TEST_HELPER":  "1",
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

When a managed preview dev-server crashed after launch, the Browser panel
kept showing the stale page with no error; `ao preview status` later
reported plain `stopped` (issue #4500).

`waitForExit` flipped the run to `StateFailed` but did not call
`SetPreview("")` and emitted no event. The panel's only failure hook,
`did-fail-load`, fires on navigation, not on an already-rendered page
whose backing server died. After `failedStatusRetention` (5 min) the
failed run was deleted, so status then reported `stopped` with no error.

## Fix

- `previewserver.Manager` gains an `OnExit(sessionID, Status)` callback
  fired from `waitForExit` when the run was not user-stopped. It runs
  off the manager's lock with a fresh 5s context.
- `daemon.go` registers an `OnExit` that clears the session's
  `PreviewURL` via `sessionSvc.SetPreview(ctx, id, "")` only when the
  session's current preview URL still matches the dead server's URL, so
  unrelated static-file previews are not clobbered. The existing
  `session_updated` CDC event fans the change out to the renderer.
- The Browser panel is not changed. Issue #4500 calls the polished
  panel state a separate "+1-2h" follow-up; this PR gives the panel
  the necessary session-update signal so it can drop the dead URL on
  its next render.

## Tests

- `TestManagerFiresOnExitWhenServerCrashesAfterLaunch` — boots, becomes
  ready, crashes; callback fires with `StateFailed` and a non-empty
  `Error`.
- `TestManagerDoesNotFireOnExitWhenStoppedByUser` — callback stays
  quiet on `Stop`.

Both new tests pass alongside the existing `previewserver`,
`httpd/controllers` (preview routes), and `service/session`
(`SetPreview`) suites.

## Out of scope

- Polished Browser panel dead-server UI (issue notes this as a
  follow-up).
- `failedStatusRetention` behavior. The callback fires immediately on
  crash; the run is still available via `Status` for 5 min before
  being deleted, matching the existing contract.
