### PR TITLE
feat(omp): track TUI session activity

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/fake"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimchi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/muse"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/omp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/primeagent"
@@ -41,6 +42,7 @@ var Derivers = map[string]DeriveFunc{
 	"claude-code": claudecode.DeriveActivityState,
 	"grok":        claudecode.DeriveActivityState,
 	"muse":        muse.DeriveActivityState,
+	"omp":         omp.DeriveActivityState,
 	"codex":       codex.DeriveActivityState,
 	"continue":    continueagent.DeriveActivityState,
 	"droid":       droid.DeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -22,7 +22,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessMuse, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe, domain.HarnessPrimeAgent, domain.HarnessAmp, domain.HarnessPi, domain.HarnessAuggie, domain.HarnessContinue, domain.HarnessAider} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessMuse, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe, domain.HarnessPrimeAgent, domain.HarnessAmp, domain.HarnessPi, domain.HarnessAuggie, domain.HarnessContinue, domain.HarnessAider, domain.HarnessOMP} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}
@@ -32,6 +32,13 @@ func TestSupportsHarness(t *testing.T) {
 		if SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = true, want false", h)
 		}
+	}
+}
+
+func TestOMPDispatchesManagedExtensionActivity(t *testing.T) {
+	got, ok := Derive("omp", "permission-request", []byte(`{"tool_name":"bash"}`))
+	if !ok || got != domain.ActivityWaitingInput {
+		t.Fatalf("Derive(omp, permission-request) = (%q, %v), want (%q, true)", got, ok, domain.ActivityWaitingInput)
 	}
 }
 

--- a/backend/internal/adapters/agent/omp/activity.go
+++ b/backend/internal/adapters/agent/omp/activity.go
@@ -1,0 +1,20 @@
+package omp
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// DeriveActivityState maps callbacks from AO's managed OMP extension onto the
+// durable activity states used by session status derivation.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start", "stop":
+		return domain.ActivityIdle, true
+	case "user-prompt-submit", "permission-resolved":
+		return domain.ActivityActive, true
+	case "permission-request":
+		return domain.ActivityWaitingInput, true
+	case "session-end":
+		return domain.ActivityExited, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/omp/hooks.go
+++ b/backend/internal/adapters/agent/omp/hooks.go
@@ -1,0 +1,124 @@
+package omp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	ompExtensionsDirName = "extensions"
+	ompExtensionFileName = "ao-activity.ts"
+	ompExtensionSentinel = "agent-orchestrator: managed omp activity extension"
+)
+
+func ompExtensionPath(workspacePath string) string {
+	return filepath.Join(workspacePath, ".omp", ompExtensionsDirName, ompExtensionFileName)
+}
+
+// GetAgentHooks installs AO's project-local OMP activity extension. Launch and
+// restore also pass this exact file explicitly, so status tracking does not
+// depend on extension auto-discovery.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("omp.GetAgentHooks: WorkspacePath is required")
+	}
+
+	path := ompExtensionPath(cfg.WorkspacePath)
+	if data, err := os.ReadFile(path); err == nil { //nolint:gosec // caller-owned workspace path
+		if !strings.Contains(string(data), ompExtensionSentinel) {
+			return fmt.Errorf("omp.GetAgentHooks: refusing to overwrite non-AO file at %s", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("omp.GetAgentHooks: read managed extension: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("omp.GetAgentHooks: create extension dir: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(path, []byte(ompActivityExtensionSource()), 0o600); err != nil {
+		return fmt.Errorf("omp.GetAgentHooks: write extension: %w", err)
+	}
+	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(path), ompExtensionFileName); err != nil {
+		return fmt.Errorf("omp.GetAgentHooks: gitignore: %w", err)
+	}
+	return nil
+}
+
+func appendOMPExtensionFlag(cmd *[]string, workspacePath string) {
+	if strings.TrimSpace(workspacePath) == "" {
+		return
+	}
+	*cmd = append(*cmd, "--extension", ompExtensionPath(workspacePath))
+}
+
+func ompActivityExtensionSource() string {
+	return `// ` + ompExtensionSentinel + ` (do not edit)
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import { spawnSync } from "node:child_process";
+
+const HOOK_TIMEOUT_MS = 5_000;
+
+function callHookSync(hookName: string, payload: Record<string, unknown>) {
+  try {
+    const result = spawnSync("ao", ["hooks", "omp", hookName], {
+      input: JSON.stringify(payload) + "\n",
+      encoding: "utf8",
+      stdio: ["pipe", "ignore", "pipe"],
+      timeout: HOOK_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    // The hook command records daemon delivery failures itself. Reporting is
+    // best-effort and must never interrupt the OMP session.
+    void result;
+  } catch {
+    // A missing AO executable or timeout must not interrupt OMP.
+  }
+}
+
+function sessionID(ctx: any): string {
+  return ctx.sessionManager.getSessionId() ?? "";
+}
+
+export default function (omp: ExtensionAPI) {
+  omp.on("session_start", async (_event, ctx) => {
+    callHookSync("session-start", { session_id: sessionID(ctx) });
+  });
+  omp.on("before_agent_start", async (event, ctx) => {
+    callHookSync("user-prompt-submit", { session_id: sessionID(ctx), prompt: event.prompt });
+  });
+  omp.on("tool_approval_requested", async (event, ctx) => {
+    callHookSync("permission-request", {
+      session_id: sessionID(ctx),
+      tool_name: event.toolName,
+      tool_use_id: event.toolCallId,
+    });
+  });
+  omp.on("tool_approval_resolved", async (event, ctx) => {
+    callHookSync("permission-resolved", {
+      session_id: sessionID(ctx),
+      tool_name: event.toolName,
+      tool_use_id: event.toolCallId,
+      approved: event.approved,
+    });
+  });
+  omp.on("agent_end", async (event, ctx) => {
+    if (!event.willContinue) {
+      callHookSync("stop", { session_id: sessionID(ctx) });
+    }
+  });
+  omp.on("session_shutdown", async (_event, ctx) => {
+    callHookSync("session-end", { session_id: sessionID(ctx) });
+  });
+}
+`
+}

--- a/backend/internal/adapters/agent/omp/hooks.go
+++ b/backend/internal/adapters/agent/omp/hooks.go
@@ -5,18 +5,25 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 const (
-	ompExtensionsDirName = "extensions"
-	ompExtensionFileName = "ao-activity.ts"
-	ompExtensionSentinel = "agent-orchestrator: managed omp activity extension"
+	ompExtensionsDirName  = "extensions"
+	ompExtensionFileName  = "ao-activity.ts"
+	ompExtensionSentinel  = "agent-orchestrator: managed omp activity extension"
+	minOMPActivityVersion = "17.1.0"
 )
+
+var ompVersionPattern = regexp.MustCompile(`\b(\d+)\.(\d+)\.(\d+)\b`)
 
 func ompExtensionPath(workspacePath string) string {
 	return filepath.Join(workspacePath, ".omp", ompExtensionsDirName, ompExtensionFileName)
@@ -41,6 +48,9 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("omp.GetAgentHooks: read managed extension: %w", err)
 	}
+	if err := p.requireActivityContract(ctx); err != nil {
+		return err
+	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("omp.GetAgentHooks: create extension dir: %w", err)
@@ -52,6 +62,62 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 		return fmt.Errorf("omp.GetAgentHooks: gitignore: %w", err)
 	}
 	return nil
+}
+
+func (p *Plugin) requireActivityContract(ctx context.Context) error {
+	binary, err := p.ompBinary(ctx)
+	if err != nil {
+		return err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(probeCtx, binary, "--version").CombinedOutput() //nolint:gosec // binary is adapter-resolved, args are static.
+	if err != nil {
+		return fmt.Errorf("omp.GetAgentHooks: probe omp --version: %w", err)
+	}
+	version, ok := parseOMPVersion(string(out))
+	if !ok {
+		return fmt.Errorf("omp.GetAgentHooks: parse omp --version output %q", strings.TrimSpace(string(out)))
+	}
+	minimum, _ := parseOMPVersion(minOMPActivityVersion)
+	if version.less(minimum) {
+		return fmt.Errorf("omp.GetAgentHooks: activity tracking requires OMP %s or newer (found %s)", minOMPActivityVersion, version)
+	}
+	return nil
+}
+
+type ompVersion [3]int
+
+func parseOMPVersion(output string) (ompVersion, bool) {
+	match := ompVersionPattern.FindStringSubmatch(output)
+	if match == nil {
+		return ompVersion{}, false
+	}
+	var version ompVersion
+	for i := range version {
+		n, err := strconv.Atoi(match[i+1])
+		if err != nil {
+			return ompVersion{}, false
+		}
+		version[i] = n
+	}
+	return version, true
+}
+
+func (v ompVersion) less(other ompVersion) bool {
+	for i := range v {
+		if v[i] < other[i] {
+			return true
+		}
+		if v[i] > other[i] {
+			return false
+		}
+	}
+	return false
+}
+
+func (v ompVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2])
 }
 
 func appendOMPExtensionFlag(cmd *[]string, workspacePath string) {
@@ -91,14 +157,25 @@ function sessionID(ctx: any): string {
   return ctx.sessionManager.getSessionId() ?? "";
 }
 
+function isRootSession(ctx: any): boolean {
+  return ctx.hasUI === true;
+}
+
 export default function (omp: ExtensionAPI) {
   omp.on("session_start", async (_event, ctx) => {
+    if (!isRootSession(ctx)) return;
+    callHookSync("session-start", { session_id: sessionID(ctx) });
+  });
+  omp.on("session_switch", async (_event, ctx) => {
+    if (!isRootSession(ctx)) return;
     callHookSync("session-start", { session_id: sessionID(ctx) });
   });
   omp.on("before_agent_start", async (event, ctx) => {
+    if (!isRootSession(ctx)) return;
     callHookSync("user-prompt-submit", { session_id: sessionID(ctx), prompt: event.prompt });
   });
   omp.on("tool_approval_requested", async (event, ctx) => {
+    if (!isRootSession(ctx)) return;
     callHookSync("permission-request", {
       session_id: sessionID(ctx),
       tool_name: event.toolName,
@@ -106,6 +183,7 @@ export default function (omp: ExtensionAPI) {
     });
   });
   omp.on("tool_approval_resolved", async (event, ctx) => {
+    if (!isRootSession(ctx)) return;
     callHookSync("permission-resolved", {
       session_id: sessionID(ctx),
       tool_name: event.toolName,
@@ -114,11 +192,13 @@ export default function (omp: ExtensionAPI) {
     });
   });
   omp.on("agent_end", async (event, ctx) => {
+    if (!isRootSession(ctx)) return;
     if (!event.willContinue) {
       callHookSync("stop", { session_id: sessionID(ctx) });
     }
   });
   omp.on("session_shutdown", async (_event, ctx) => {
+    if (!isRootSession(ctx)) return;
     callHookSync("session-end", { session_id: sessionID(ctx) });
   });
 }

--- a/backend/internal/adapters/agent/omp/hooks.go
+++ b/backend/internal/adapters/agent/omp/hooks.go
@@ -66,7 +66,9 @@ func ompActivityExtensionSource() string {
 import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
 import { spawnSync } from "node:child_process";
 
-const HOOK_TIMEOUT_MS = 5_000;
+// OMP caps session_shutdown handlers at 2s. Keep the synchronous AO delivery
+// comfortably below that budget so a hung hook cannot hold TUI teardown open.
+const HOOK_TIMEOUT_MS = 1_250;
 
 function callHookSync(hookName: string, payload: Record<string, unknown>) {
   try {

--- a/backend/internal/adapters/agent/omp/hooks_test.go
+++ b/backend/internal/adapters/agent/omp/hooks_test.go
@@ -24,7 +24,11 @@ func TestManagedExtensionEmitsOMPLifecycleHooksAndIgnoresHookFailures(t *testing
 	}
 
 	fixtureDir := t.TempDir()
-	modulePath := writeExecutableOMPExtension(t, fixtureDir, ompActivityExtensionSource())
+	// This test validates lifecycle ordering and payloads, not the production
+	// delivery deadline. Give the fixture headroom under parallel CI load; the
+	// dedicated timeout test below exercises the unmodified production value.
+	source := strings.Replace(ompActivityExtensionSource(), "const HOOK_TIMEOUT_MS = 1_250;", "const HOOK_TIMEOUT_MS = 10_000;", 1)
+	modulePath := writeExecutableOMPExtension(t, fixtureDir, source)
 	capturePath := filepath.Join(fixtureDir, "calls.jsonl")
 	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), `#!/bin/sh
 {
@@ -41,9 +45,11 @@ exit 9
 const handlers = new Map();
 const loaded = await import(pathToFileURL(process.argv[2]).href);
 loaded.default({ on(name, handler) { handlers.set(name, handler); } });
-const ctx = { sessionManager: { getSessionId() { return "omp-native-123"; } } };
+let nativeSessionID = "omp-native-123";
+const ctx = { hasUI: true, sessionManager: { getSessionId() { return nativeSessionID; } } };
 for (const [name, event] of [
   ["session_start", {}],
+  ["session_switch", {}],
   ["before_agent_start", { prompt: "fix the status tracker" }],
   ["tool_approval_requested", { toolName: "bash", toolCallId: "tool-7" }],
   ["tool_approval_resolved", { toolName: "bash", toolCallId: "tool-7", approved: true }],
@@ -51,6 +57,7 @@ for (const [name, event] of [
   ["agent_end", { willContinue: false }],
   ["session_shutdown", {}],
 ]) {
+  if (name === "session_switch") nativeSessionID = "omp-native-switched";
   await handlers.get(name)(event, ctx);
 }
 `, 0o600)
@@ -66,6 +73,7 @@ for (const [name, event] of [
 
 	calls := readOMPHookCalls(t, capturePath)
 	wantEvents := []string{
+		"session-start",
 		"session-start",
 		"user-prompt-submit",
 		"permission-request",
@@ -84,15 +92,19 @@ for (const [name, event] of [
 		if err := json.Unmarshal([]byte(strings.TrimSpace(calls[i].Input)), &payload); err != nil {
 			t.Fatalf("call %d payload is not JSON: %v", i, err)
 		}
-		if payload["session_id"] != "omp-native-123" {
-			t.Fatalf("call %d session_id = %#v, want omp-native-123", i, payload["session_id"])
+		wantSessionID := "omp-native-switched"
+		if i == 0 {
+			wantSessionID = "omp-native-123"
+		}
+		if payload["session_id"] != wantSessionID {
+			t.Fatalf("call %d session_id = %#v, want %s", i, payload["session_id"], wantSessionID)
 		}
 	}
 
 	var promptPayload struct {
 		Prompt string `json:"prompt"`
 	}
-	if err := json.Unmarshal([]byte(calls[1].Input), &promptPayload); err != nil {
+	if err := json.Unmarshal([]byte(calls[2].Input), &promptPayload); err != nil {
 		t.Fatal(err)
 	}
 	if promptPayload.Prompt != "fix the status tracker" {
@@ -103,7 +115,7 @@ for (const [name, event] of [
 		ToolUseID string `json:"tool_use_id"`
 		Approved  bool   `json:"approved"`
 	}
-	if err := json.Unmarshal([]byte(calls[3].Input), &approvalPayload); err != nil {
+	if err := json.Unmarshal([]byte(calls[4].Input), &approvalPayload); err != nil {
 		t.Fatal(err)
 	}
 	if approvalPayload.ToolName != "bash" || approvalPayload.ToolUseID != "tool-7" || !approvalPayload.Approved {
@@ -117,6 +129,54 @@ for (const [name, event] of [
 	missingCmd.Env = append(envWithoutOMPPath(os.Environ()), "PATH="+missingDir, "AO_TEST_CAPTURE="+capturePath)
 	if output, err := missingCmd.CombinedOutput(); err != nil {
 		t.Fatalf("extension harness failed with ao missing: %v\n%s", err, output)
+	}
+}
+
+func TestManagedExtensionIgnoresInheritedChildContexts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ao executable fixture uses a Unix shebang")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the OMP extension fixture")
+	}
+
+	fixtureDir := t.TempDir()
+	modulePath := writeExecutableOMPExtension(t, fixtureDir, ompActivityExtensionSource())
+	capturePath := filepath.Join(fixtureDir, "child-calls")
+	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), "#!/bin/sh\nprintf 'called\\n' >> \"$AO_TEST_CAPTURE\"\n", 0o755)
+	harnessPath := filepath.Join(fixtureDir, "child-harness.mjs")
+	writeOMPFixtureFile(t, harnessPath, `import { pathToFileURL } from "node:url";
+const handlers = new Map();
+const loaded = await import(pathToFileURL(process.argv[2]).href);
+loaded.default({ on(name, handler) { handlers.set(name, handler); } });
+const childCtx = { hasUI: false, sessionManager: { getSessionId() { return "omp-child-native"; } } };
+const events = {
+  session_start: {},
+  session_switch: {},
+  before_agent_start: { prompt: "child prompt" },
+  tool_approval_requested: { toolName: "bash", toolCallId: "child-tool" },
+  tool_approval_resolved: { toolName: "bash", toolCallId: "child-tool", approved: true },
+  agent_end: { willContinue: false },
+  session_shutdown: {},
+};
+for (const [name, event] of Object.entries(events)) {
+  await handlers.get(name)(event, childCtx);
+}
+`, 0o600)
+
+	cmd := exec.CommandContext(context.Background(), node, harnessPath, modulePath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+fixtureDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AO_TEST_CAPTURE="+capturePath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("child-context extension harness failed: %v\n%s", err, output)
+	}
+	if data, err := os.ReadFile(capturePath); err == nil {
+		t.Fatalf("inherited child extension published AO hooks:\n%s", data)
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
 	}
 }
 
@@ -138,7 +198,7 @@ const handlers = new Map();
 const loaded = await import(pathToFileURL(process.argv[2]).href);
 loaded.default({ on(name, handler) { handlers.set(name, handler); } });
 const started = Date.now();
-await handlers.get("session_start")({}, { sessionManager: { getSessionId() { return "omp-native-timeout"; } } });
+await handlers.get("session_start")({}, { hasUI: true, sessionManager: { getSessionId() { return "omp-native-timeout"; } } });
 console.log(Date.now() - started);
 `, 0o600)
 
@@ -164,6 +224,7 @@ func writeExecutableOMPExtension(t *testing.T, dir, source string) string {
 		`import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";`+"\n", "",
 		`function callHookSync(hookName: string, payload: Record<string, unknown>)`, `function callHookSync(hookName, payload)`,
 		`function sessionID(ctx: any): string`, `function sessionID(ctx)`,
+		`function isRootSession(ctx: any): boolean`, `function isRootSession(ctx)`,
 		`export default function (omp: ExtensionAPI)`, `export default function (omp)`,
 	).Replace(source)
 	writeOMPFixtureFile(t, modulePath, source, 0o600)

--- a/backend/internal/adapters/agent/omp/hooks_test.go
+++ b/backend/internal/adapters/agent/omp/hooks_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -25,15 +26,15 @@ func TestManagedExtensionEmitsOMPLifecycleHooksAndIgnoresHookFailures(t *testing
 	fixtureDir := t.TempDir()
 	modulePath := writeExecutableOMPExtension(t, fixtureDir, ompActivityExtensionSource())
 	capturePath := filepath.Join(fixtureDir, "calls.jsonl")
-	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), `#!/usr/bin/env node
-const fs = require("node:fs");
-let input = "";
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", chunk => { input += chunk; });
-process.stdin.on("end", () => {
-  fs.appendFileSync(process.env.AO_TEST_CAPTURE, JSON.stringify({args: process.argv.slice(2), input}) + "\n");
-  process.exit(9);
-});
+	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), `#!/bin/sh
+{
+  printf '%s\n' "$1"
+  printf '%s\n' "$2"
+  printf '%s\n' "$3"
+  IFS= read -r input
+  printf '%s\n' "$input"
+} >> "$AO_TEST_CAPTURE"
+exit 9
 `, 0o755)
 	harnessPath := filepath.Join(fixtureDir, "harness.mjs")
 	writeOMPFixtureFile(t, harnessPath, `import { pathToFileURL } from "node:url";
@@ -129,21 +130,30 @@ func TestManagedExtensionIgnoresHookTimeout(t *testing.T) {
 	}
 
 	fixtureDir := t.TempDir()
-	source := strings.Replace(ompActivityExtensionSource(), "const HOOK_TIMEOUT_MS = 5_000;", "const HOOK_TIMEOUT_MS = 20;", 1)
-	modulePath := writeExecutableOMPExtension(t, fixtureDir, source)
-	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), "#!/usr/bin/env sh\nsleep 1\n", 0o755)
+	modulePath := writeExecutableOMPExtension(t, fixtureDir, ompActivityExtensionSource())
+	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), "#!/bin/sh\nexec sleep 5\n", 0o755)
 	harnessPath := filepath.Join(fixtureDir, "timeout-harness.mjs")
 	writeOMPFixtureFile(t, harnessPath, `import { pathToFileURL } from "node:url";
 const handlers = new Map();
 const loaded = await import(pathToFileURL(process.argv[2]).href);
 loaded.default({ on(name, handler) { handlers.set(name, handler); } });
+const started = Date.now();
 await handlers.get("session_start")({}, { sessionManager: { getSessionId() { return "omp-native-timeout"; } } });
+console.log(Date.now() - started);
 `, 0o600)
 
 	cmd := exec.CommandContext(context.Background(), node, harnessPath, modulePath)
 	cmd.Env = append(os.Environ(), "PATH="+fixtureDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	if output, err := cmd.CombinedOutput(); err != nil {
+	output, err := cmd.CombinedOutput()
+	if err != nil {
 		t.Fatalf("extension harness failed on hook timeout: %v\n%s", err, output)
+	}
+	elapsedMS, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	if err != nil {
+		t.Fatalf("parse extension handler duration %q: %v", output, err)
+	}
+	if elapsedMS >= 2_000 {
+		t.Fatalf("hung AO hook blocked OMP shutdown for %dms, want less than OMP's 2s shutdown budget", elapsedMS)
 	}
 }
 
@@ -173,16 +183,20 @@ func readOMPHookCalls(t *testing.T, path string) []ompHookCall {
 	}
 	defer file.Close()
 	var calls []ompHookCall
+	var record []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		var call ompHookCall
-		if err := json.Unmarshal(scanner.Bytes(), &call); err != nil {
-			t.Fatal(err)
+		record = append(record, scanner.Text())
+		if len(record) == 4 {
+			calls = append(calls, ompHookCall{Args: append([]string(nil), record[:3]...), Input: record[3] + "\n"})
+			record = record[:0]
 		}
-		calls = append(calls, call)
 	}
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
+	}
+	if len(record) != 0 {
+		t.Fatalf("incomplete hook capture record: %#v", record)
 	}
 	return calls
 }

--- a/backend/internal/adapters/agent/omp/hooks_test.go
+++ b/backend/internal/adapters/agent/omp/hooks_test.go
@@ -1,0 +1,205 @@
+package omp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestManagedExtensionEmitsOMPLifecycleHooksAndIgnoresHookFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ao executable fixture uses a Unix shebang")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the OMP extension fixture")
+	}
+
+	fixtureDir := t.TempDir()
+	modulePath := writeExecutableOMPExtension(t, fixtureDir, ompActivityExtensionSource())
+	capturePath := filepath.Join(fixtureDir, "calls.jsonl")
+	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), `#!/usr/bin/env node
+const fs = require("node:fs");
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", chunk => { input += chunk; });
+process.stdin.on("end", () => {
+  fs.appendFileSync(process.env.AO_TEST_CAPTURE, JSON.stringify({args: process.argv.slice(2), input}) + "\n");
+  process.exit(9);
+});
+`, 0o755)
+	harnessPath := filepath.Join(fixtureDir, "harness.mjs")
+	writeOMPFixtureFile(t, harnessPath, `import { pathToFileURL } from "node:url";
+const handlers = new Map();
+const loaded = await import(pathToFileURL(process.argv[2]).href);
+loaded.default({ on(name, handler) { handlers.set(name, handler); } });
+const ctx = { sessionManager: { getSessionId() { return "omp-native-123"; } } };
+for (const [name, event] of [
+  ["session_start", {}],
+  ["before_agent_start", { prompt: "fix the status tracker" }],
+  ["tool_approval_requested", { toolName: "bash", toolCallId: "tool-7" }],
+  ["tool_approval_resolved", { toolName: "bash", toolCallId: "tool-7", approved: true }],
+  ["agent_end", { willContinue: true }],
+  ["agent_end", { willContinue: false }],
+  ["session_shutdown", {}],
+]) {
+  await handlers.get(name)(event, ctx);
+}
+`, 0o600)
+
+	cmd := exec.CommandContext(context.Background(), node, harnessPath, modulePath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+fixtureDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AO_TEST_CAPTURE="+capturePath,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("extension harness failed despite hook exit 9: %v\n%s", err, output)
+	}
+
+	calls := readOMPHookCalls(t, capturePath)
+	wantEvents := []string{
+		"session-start",
+		"user-prompt-submit",
+		"permission-request",
+		"permission-resolved",
+		"stop",
+		"session-end",
+	}
+	if len(calls) != len(wantEvents) {
+		t.Fatalf("hook calls = %#v, want %d", calls, len(wantEvents))
+	}
+	for i, event := range wantEvents {
+		if !reflect.DeepEqual(calls[i].Args, []string{"hooks", "omp", event}) {
+			t.Fatalf("call %d args = %#v, want hooks/omp/%s", i, calls[i].Args, event)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimSpace(calls[i].Input)), &payload); err != nil {
+			t.Fatalf("call %d payload is not JSON: %v", i, err)
+		}
+		if payload["session_id"] != "omp-native-123" {
+			t.Fatalf("call %d session_id = %#v, want omp-native-123", i, payload["session_id"])
+		}
+	}
+
+	var promptPayload struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.Unmarshal([]byte(calls[1].Input), &promptPayload); err != nil {
+		t.Fatal(err)
+	}
+	if promptPayload.Prompt != "fix the status tracker" {
+		t.Fatalf("prompt = %q, want exact submitted prompt", promptPayload.Prompt)
+	}
+	var approvalPayload struct {
+		ToolName  string `json:"tool_name"`
+		ToolUseID string `json:"tool_use_id"`
+		Approved  bool   `json:"approved"`
+	}
+	if err := json.Unmarshal([]byte(calls[3].Input), &approvalPayload); err != nil {
+		t.Fatal(err)
+	}
+	if approvalPayload.ToolName != "bash" || approvalPayload.ToolUseID != "tool-7" || !approvalPayload.Approved {
+		t.Fatalf("approval payload = %#v", approvalPayload)
+	}
+
+	// Removing ao from PATH exercises spawnSync's command-not-found result. The
+	// extension must still resolve every handler without rejecting the session.
+	missingDir := t.TempDir()
+	missingCmd := exec.CommandContext(context.Background(), node, harnessPath, modulePath)
+	missingCmd.Env = append(envWithoutOMPPath(os.Environ()), "PATH="+missingDir, "AO_TEST_CAPTURE="+capturePath)
+	if output, err := missingCmd.CombinedOutput(); err != nil {
+		t.Fatalf("extension harness failed with ao missing: %v\n%s", err, output)
+	}
+}
+
+func TestManagedExtensionIgnoresHookTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ao executable fixture uses a Unix shebang")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the OMP extension fixture")
+	}
+
+	fixtureDir := t.TempDir()
+	source := strings.Replace(ompActivityExtensionSource(), "const HOOK_TIMEOUT_MS = 5_000;", "const HOOK_TIMEOUT_MS = 20;", 1)
+	modulePath := writeExecutableOMPExtension(t, fixtureDir, source)
+	writeOMPFixtureFile(t, filepath.Join(fixtureDir, "ao"), "#!/usr/bin/env sh\nsleep 1\n", 0o755)
+	harnessPath := filepath.Join(fixtureDir, "timeout-harness.mjs")
+	writeOMPFixtureFile(t, harnessPath, `import { pathToFileURL } from "node:url";
+const handlers = new Map();
+const loaded = await import(pathToFileURL(process.argv[2]).href);
+loaded.default({ on(name, handler) { handlers.set(name, handler); } });
+await handlers.get("session_start")({}, { sessionManager: { getSessionId() { return "omp-native-timeout"; } } });
+`, 0o600)
+
+	cmd := exec.CommandContext(context.Background(), node, harnessPath, modulePath)
+	cmd.Env = append(os.Environ(), "PATH="+fixtureDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("extension harness failed on hook timeout: %v\n%s", err, output)
+	}
+}
+
+func writeExecutableOMPExtension(t *testing.T, dir, source string) string {
+	t.Helper()
+	modulePath := filepath.Join(dir, "ao-activity.mjs")
+	source = strings.NewReplacer(
+		`import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";`+"\n", "",
+		`function callHookSync(hookName: string, payload: Record<string, unknown>)`, `function callHookSync(hookName, payload)`,
+		`function sessionID(ctx: any): string`, `function sessionID(ctx)`,
+		`export default function (omp: ExtensionAPI)`, `export default function (omp)`,
+	).Replace(source)
+	writeOMPFixtureFile(t, modulePath, source, 0o600)
+	return modulePath
+}
+
+type ompHookCall struct {
+	Args  []string `json:"args"`
+	Input string   `json:"input"`
+}
+
+func readOMPHookCalls(t *testing.T, path string) []ompHookCall {
+	t.Helper()
+	file, err := os.Open(path) //nolint:gosec // test-owned fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	var calls []ompHookCall
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var call ompHookCall
+		if err := json.Unmarshal(scanner.Bytes(), &call); err != nil {
+			t.Fatal(err)
+		}
+		calls = append(calls, call)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return calls
+}
+
+func writeOMPFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func envWithoutOMPPath(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, "PATH=") {
+			out = append(out, entry)
+		}
+	}
+	return out
+}

--- a/backend/internal/adapters/agent/omp/omp.go
+++ b/backend/internal/adapters/agent/omp/omp.go
@@ -64,6 +64,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd := make([]string, 0, 5)
 	cmd = append(cmd, binary)
+	appendOMPExtensionFlag(&cmd, cfg.WorkspacePath)
 	if err := appendSystemPrompt(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
 		return nil, err
 	}
@@ -92,6 +93,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	}
 	cmd := make([]string, 0, 5)
 	cmd = append(cmd, binary)
+	appendOMPExtensionFlag(&cmd, cfg.Session.WorkspacePath)
 	if err := appendSystemPrompt(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile); err != nil {
 		return nil, false, err
 	}

--- a/backend/internal/adapters/agent/omp/omp_test.go
+++ b/backend/internal/adapters/agent/omp/omp_test.go
@@ -2,12 +2,15 @@ package omp
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -64,6 +67,22 @@ func TestGetLaunchCommandStartsInteractiveTUIWithPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{"omp", "add a health check"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandExplicitlyLoadsManagedExtension(t *testing.T) {
+	workspace := t.TempDir()
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		WorkspacePath: workspace,
+		Prompt:        "add a health check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"omp", "--extension", filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts"), "add a health check"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -126,6 +145,27 @@ func TestGetRestoreCommandUsesNativeSessionID(t *testing.T) {
 	}
 }
 
+func TestGetRestoreCommandExplicitlyLoadsManagedExtension(t *testing.T) {
+	workspace := t.TempDir()
+	p := &Plugin{resolvedBinary: "omp"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			WorkspacePath: workspace,
+			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "native-omp-1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"omp", "--extension", filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts"), "--resume", "native-omp-1"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
 func TestGetRestoreCommandWithoutNativeSessionIDReturnsNotOK(t *testing.T) {
 	p := &Plugin{resolvedBinary: "omp"}
 	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{})
@@ -134,5 +174,100 @@ func TestGetRestoreCommandWithoutNativeSessionIDReturnsNotOK(t *testing.T) {
 	}
 	if ok || cmd != nil {
 		t.Fatalf("cmd=%#v ok=%v, want nil false", cmd, ok)
+	}
+}
+
+func TestGetAgentHooksInstallsManagedActivityExtension(t *testing.T) {
+	workspace := t.TempDir()
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	extensionPath := filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts")
+	data, err := os.ReadFile(extensionPath)
+	if err != nil {
+		t.Fatalf("read managed extension: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"agent-orchestrator: managed omp activity extension",
+		`omp.on("session_start"`,
+		`omp.on("before_agent_start"`,
+		`omp.on("agent_end"`,
+		`omp.on("tool_approval_requested"`,
+		`omp.on("tool_approval_resolved"`,
+		`omp.on("session_shutdown"`,
+		`"hooks", "omp", hookName`,
+		"getSessionId()",
+		"if (!event.willContinue)",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("managed extension missing %q:\n%s", want, text)
+		}
+	}
+
+	gitignore, err := os.ReadFile(filepath.Join(workspace, ".omp", "extensions", ".gitignore"))
+	if err != nil {
+		t.Fatalf("read extension .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignore), "/ao-activity.ts") {
+		t.Fatalf("extension .gitignore does not ignore AO file:\n%s", gitignore)
+	}
+}
+
+func TestGetAgentHooksRefusesForeignManagedPath(t *testing.T) {
+	workspace := t.TempDir()
+	extensionPath := filepath.Join(workspace, ".omp", "extensions", "ao-activity.ts")
+	want := "export default function userExtension() {}\n"
+	if err := os.MkdirAll(filepath.Dir(extensionPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(extensionPath, []byte(want), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace})
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Fatalf("GetAgentHooks err = %v, want foreign-file refusal", err)
+	}
+	got, readErr := os.ReadFile(extensionPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != want {
+		t.Fatalf("foreign extension changed to %q", got)
+	}
+}
+
+func TestDeriveActivityState(t *testing.T) {
+	tests := []struct {
+		event string
+		want  domain.ActivityState
+	}{
+		{"session-start", domain.ActivityIdle},
+		{"user-prompt-submit", domain.ActivityActive},
+		{"permission-request", domain.ActivityWaitingInput},
+		{"permission-resolved", domain.ActivityActive},
+		{"stop", domain.ActivityIdle},
+		{"session-end", domain.ActivityExited},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := DeriveActivityState(tt.event, nil)
+			if !ok || got != tt.want {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, true)", tt.event, got, ok, tt.want)
+			}
+		})
+	}
+	if got, ok := DeriveActivityState("unknown", nil); ok {
+		t.Fatalf("DeriveActivityState(unknown) = (%q, true), want no signal", got)
+	}
+}
+
+func TestGetAgentHooksHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
 	}
 }

--- a/backend/internal/adapters/agent/omp/omp_test.go
+++ b/backend/internal/adapters/agent/omp/omp_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -178,8 +179,12 @@ func TestGetRestoreCommandWithoutNativeSessionIDReturnsNotOK(t *testing.T) {
 }
 
 func TestGetAgentHooksInstallsManagedActivityExtension(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake OMP version binary uses a Unix shebang")
+	}
 	workspace := t.TempDir()
-	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+	plugin := &Plugin{resolvedBinary: fakeOMPVersionBinary(t, "17.1.0")}
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
 		t.Fatalf("GetAgentHooks err = %v", err)
 	}
 
@@ -192,6 +197,7 @@ func TestGetAgentHooksInstallsManagedActivityExtension(t *testing.T) {
 	for _, want := range []string{
 		"agent-orchestrator: managed omp activity extension",
 		`omp.on("session_start"`,
+		`omp.on("session_switch"`,
 		`omp.on("before_agent_start"`,
 		`omp.on("agent_end"`,
 		`omp.on("tool_approval_requested"`,
@@ -212,6 +218,35 @@ func TestGetAgentHooksInstallsManagedActivityExtension(t *testing.T) {
 	}
 	if !strings.Contains(string(gitignore), "/ao-activity.ts") {
 		t.Fatalf("extension .gitignore does not ignore AO file:\n%s", gitignore)
+	}
+}
+
+func TestGetAgentHooksRequiresOMP171LifecycleContract(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake OMP version binary uses a Unix shebang")
+	}
+	for _, tc := range []struct {
+		version string
+		wantErr bool
+	}{
+		{version: "16.9.9", wantErr: true},
+		{version: "17.0.0", wantErr: true},
+		{version: "17.1.0", wantErr: false},
+		{version: "18.1.0", wantErr: false},
+	} {
+		t.Run(tc.version, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: fakeOMPVersionBinary(t, tc.version)}
+			err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()})
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "requires OMP 17.1.0 or newer") {
+					t.Fatalf("GetAgentHooks with OMP %s error = %v, want minimum-version error", tc.version, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetAgentHooks with OMP %s: %v", tc.version, err)
+			}
+		})
 	}
 }
 
@@ -270,4 +305,14 @@ func TestGetAgentHooksHonorsContextCancellation(t *testing.T) {
 	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
 	}
+}
+
+func fakeOMPVersionBinary(t *testing.T, version string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "omp")
+	script := "#!/bin/sh\nif [ \"${1:-}\" = \"--version\" ]; then\n  echo \"omp/" + version + "\"\n  exit 0\nfi\nexit 2\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/backend/internal/adapters/agent/registry/registry_test.go
+++ b/backend/internal/adapters/agent/registry/registry_test.go
@@ -164,7 +164,11 @@ func ensureAgentBinary(t *testing.T, name string) {
 	t.Helper()
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, name)
-	script := "#!/usr/bin/env sh\nif [ \"${1:-}\" = \"--version\" ]; then\n  echo \"" + name + " 0.80.6\"\nfi\nexit 0\n"
+	version := "0.80.6"
+	if name == "omp" {
+		version = "17.1.0"
+	}
+	script := "#!/usr/bin/env sh\nif [ \"${1:-}\" = \"--version\" ]; then\n  echo \"" + name + " " + version + "\"\nfi\nexit 0\n"
 	if err := os.WriteFile(binPath, []byte(script), 0755); err != nil {
 		t.Fatalf("write fake agent binary %q: %v", binPath, err)
 	}

--- a/docs/harnesses/omp.md
+++ b/docs/harnesses/omp.md
@@ -1,8 +1,8 @@
 # OMP Adapter
 
-OMP is integrated into Agent Orchestrator as an interactive Terminal UI
-harness. AO launches the `omp` binary inside the session worktree and streams
-the TUI through the existing terminal runtime.
+OMP is integrated into Agent Orchestrator as both an interactive Terminal UI
+harness and a structured Chat harness. AO launches the user's own `omp` binary
+inside the session worktree in either mode.
 
 ## Install
 
@@ -48,6 +48,30 @@ When configured, AO forwards:
 The process remains interactive after the initial prompt, so users can keep
 working directly in the OMP TUI.
 
+## Activity Tracking
+
+AO installs one managed extension at `.omp/extensions/ao-activity.ts` inside
+the session worktree and passes it explicitly with `--extension` on launches
+and restores. The extension reports OMP's native session, agent, and approval
+lifecycle through AO's existing hook pipeline:
+
+- session startup and turn completion report `idle`
+- prompt submission reports `active`
+- approval requests report `waiting_input`
+- approval resolution reports `active`
+- process shutdown reports `exited`
+
+Hook delivery is best-effort. A missing AO executable, an unavailable daemon,
+or a hook timeout never interrupts the OMP session. AO refuses to overwrite a
+user-owned file at the managed extension path and preserves all other OMP
+extensions.
+
+## Chat Mode
+
+OMP 15.0.0 and newer can run through its native `omp acp` command in AO's Chat
+interface. Chat activity is derived directly from structured turn, approval,
+input, and controller events rather than from the TUI extension.
+
 ## Restore
 
 When AO has captured an OMP native session id in session metadata, restore uses:
@@ -70,12 +94,7 @@ AO checks OMP auth using local-only signals:
 These probes are advisory. A later model call can still fail because of quota,
 provider configuration, or selected model availability.
 
-## Not Supported In This Adapter
+## Not Supported
 
-- ACP editor integration (`omp acp`)
 - RPC mode (`omp --mode rpc`)
-- Chat UI handoff
-- AO-managed OMP extensions or hooks
-
-Those surfaces would require a separate structured protocol driver rather than
-the terminal harness adapter.
+- TUI-to-Chat or Chat-to-TUI handoff of an existing OMP session

--- a/docs/harnesses/omp.md
+++ b/docs/harnesses/omp.md
@@ -23,6 +23,11 @@ Verify the install:
 omp --version
 ```
 
+OMP 17.1.0 or newer is required for Terminal UI sessions. AO verifies this
+before installing its activity extension because the tracking contract depends
+on OMP 17 lifecycle and approval events. Older OMP versions must be upgraded
+rather than running with incomplete or misleading Kanban status.
+
 AO resolves `omp` from:
 
 - `PATH`
@@ -56,6 +61,8 @@ and restores. The extension reports OMP's native session, agent, and approval
 lifecycle through AO's existing hook pipeline:
 
 - session startup and turn completion report `idle`
+- `/new`, `/resume`, and `/fork` session switches immediately refresh the
+  native resume ID and report `idle`
 - prompt submission reports `active`
 - approval requests report `waiting_input`
 - approval resolution reports `active`
@@ -65,6 +72,11 @@ Hook delivery is best-effort. A missing AO executable, an unavailable daemon,
 or a hook timeout never interrupts the OMP session. AO refuses to overwrite a
 user-owned file at the managed extension path and preserves all other OMP
 extensions.
+
+Only the top-level interactive TUI extension reports activity. OMP subagents
+inherit extension paths, but their non-UI extension contexts are ignored so a
+child cannot replace the root session's resume ID or mark the live root session
+exited.
 
 ## Chat Mode
 


### PR DESCRIPTION
## What

Add AO-managed OMP TUI lifecycle hooks so Kanban session status reflects active work, idle turns, approval waits, session switches, and process exit.

## Why

OMP TUI sessions had no structured activity integration, so their Kanban status could remain idle while the agent was working or waiting for user approval.

## How

- Install a project-local `.omp/extensions/ao-activity.ts` extension and load it explicitly for launch and restore.
- Map OMP lifecycle and approval events into the existing AO hook pipeline and activity-state derivation.
- Filter every callback to the top-level UI context so inherited subagent extension runners cannot alter the root AO session.
- Handle `session_switch` so `/new`, `/resume`, and `/fork` immediately refresh the native resume ID while preserving idle state.
- Require OMP 17.1.0+, the first release with the complete lifecycle contract used here, including `AgentEndEvent.willContinue`.
- Keep hook delivery best-effort and bounded below OMP's shutdown budget.
- Refuse to overwrite user-owned files at the managed extension path and preserve all other OMP extensions.
- Keep ACP Chat activity tracking unchanged; this change is focused on the TUI adapter.

## Testing

- `cd backend && go test ./internal/adapters/agent/omp ./internal/adapters/agent/activitydispatch ./internal/adapters/agent/registry -count=1`
- `cd backend && go test -p 1 ./...`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs`
- Executable Node fixtures validate lifecycle ordering, switched native IDs, root-versus-child contexts, continuation behavior, missing AO handling, nonzero exits, and timeout handling.
- Version fixtures reject OMP 16.9.9 and 17.0.0 and accept OMP 17.1.0 and 18.1.0.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
