### PR TITLE
fix(terminal): auto-scroll while selecting text

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -8,6 +8,7 @@ import { XtermTerminal } from "./XtermTerminal";
 const state = vi.hoisted(() => ({
 	fit: vi.fn(),
 	linkHandler: null as null | ((event: MouseEvent, uri: string) => void),
+	screenRows: ["one", "two"] as string[],
 	searchAddon: null as null | {
 		clearDecorations: ReturnType<typeof vi.fn>;
 		findNext: ReturnType<typeof vi.fn>;
@@ -18,9 +19,25 @@ const state = vi.hoisted(() => ({
 		keyHandler?: (event: KeyboardEvent) => boolean;
 		wheelHandler?: (event: WheelEvent) => boolean;
 		selection: string;
+		selectionPosition: { start: { x: number; y: number }; end: { x: number; y: number } } | undefined;
 		options: Record<string, unknown>;
 		modes: { bracketedPasteMode: boolean; mouseTrackingMode: string };
-		buffer: { active: { baseY: number; type: string; viewportY: number } };
+		buffer: {
+			active: {
+				baseY: number;
+				type: string;
+				viewportY: number;
+				getLine: (row: number) => {
+					getCell: (col: number) => {
+						getChars: () => string;
+						getWidth: () => number;
+						isDim: () => boolean;
+					} | undefined;
+					isWrapped: boolean;
+					translateToString: () => string;
+				} | undefined;
+			};
+		};
 		scrollLines: ReturnType<typeof vi.fn>;
 		scrollToBottom: ReturnType<typeof vi.fn>;
 		scrollToLine: ReturnType<typeof vi.fn>;
@@ -31,7 +48,9 @@ const state = vi.hoisted(() => ({
 		dataListeners: Set<(data: string) => void>;
 		keyListeners: Set<(event: { key: string }) => void>;
 		selectionListeners: Set<() => void>;
+		renderListeners: Set<() => void>;
 		scrollListeners: Set<() => void>;
+		clearSelection: ReturnType<typeof vi.fn>;
 		_core: {
 			element: { classList: { add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> } };
 			viewport: { scrollBarWidth: number };
@@ -49,10 +68,28 @@ vi.mock("@xterm/xterm", () => ({
 		cols = 80;
 		rows = 24;
 		selection = "";
+		selectionPosition = { start: { x: 0, y: 0 }, end: { x: 3, y: 1 } };
 		keyHandler?: (event: KeyboardEvent) => boolean;
 		wheelHandler?: (event: WheelEvent) => boolean;
 		modes = { bracketedPasteMode: false, mouseTrackingMode: "vt200" };
-		buffer = { active: { baseY: 0, type: "normal", viewportY: 0 } };
+		buffer = {
+			active: {
+				baseY: 0,
+				type: "normal",
+				viewportY: 0,
+				getLine: (row: number) => {
+					const text = state.screenRows[row];
+					if (text === undefined) return undefined;
+					return {
+						getCell: (col: number) => col < text.length
+							? { getChars: () => text[col] === " " ? "" : text[col], getWidth: () => 1, isDim: () => false }
+							: undefined,
+						isWrapped: false,
+						translateToString: () => text,
+					};
+				},
+			},
+		};
 		scrollLines = vi.fn();
 		scrollToBottom = vi.fn();
 		scrollToLine = vi.fn();
@@ -63,7 +100,9 @@ vi.mock("@xterm/xterm", () => ({
 		dataListeners = new Set<(data: string) => void>();
 		keyListeners = new Set<(event: { key: string }) => void>();
 		selectionListeners = new Set<() => void>();
+		renderListeners = new Set<() => void>();
 		scrollListeners = new Set<() => void>();
+		clearSelection = vi.fn(() => { this.selection = ""; });
 		_core = {
 			element: { classList: { add: vi.fn(), remove: vi.fn() } },
 			viewport: { scrollBarWidth: 15 },
@@ -80,6 +119,9 @@ vi.mock("@xterm/xterm", () => ({
 
 		loadAddon() {}
 		open(host: HTMLElement) {
+			const screen = document.createElement("div");
+			screen.className = "xterm-screen";
+			host.appendChild(screen);
 			host.appendChild(document.createElement("textarea"));
 		}
 		write() {}
@@ -92,8 +134,9 @@ vi.mock("@xterm/xterm", () => ({
 		onResize() {
 			return { dispose: () => undefined };
 		}
-		onRender() {
-			return { dispose: () => undefined };
+		onRender(listener: () => void) {
+			this.renderListeners.add(listener);
+			return { dispose: () => this.renderListeners.delete(listener) };
 		}
 		onScroll(listener: () => void) {
 			this.scrollListeners.add(listener);
@@ -113,6 +156,9 @@ vi.mock("@xterm/xterm", () => ({
 		getSelection() {
 			return this.selection;
 		}
+		getSelectionPosition() {
+			return this.selectionPosition;
+		}
 		attachCustomKeyEventHandler(listener: (event: KeyboardEvent) => boolean) {
 			this.keyHandler = listener;
 		}
@@ -127,6 +173,9 @@ vi.mock("@xterm/addon-fit", () => ({
 	FitAddon: class FakeFitAddon {
 		fit() {
 			state.fit();
+		}
+		proposeDimensions() {
+			return undefined;
 		}
 	},
 }));
@@ -189,6 +238,7 @@ describe("XtermTerminal", () => {
 		state.lastTerminal = null;
 		state.linkHandler = null;
 		state.searchAddon = null;
+		state.screenRows = ["one", "two"];
 		setNavigatorPlatform("Linux x86_64");
 		window.ao!.clipboard.writeText = vi.fn().mockResolvedValue(undefined);
 		window.ao!.clipboard.readText = vi.fn().mockResolvedValue("");
@@ -735,6 +785,77 @@ describe("XtermTerminal", () => {
 
 		expect(window.ao!.clipboard.writeText).not.toHaveBeenCalled();
 		expect(screen.queryByRole("status")).not.toBeInTheDocument();
+	});
+
+	it("keeps edge-drag text selected until an explicit context-menu copy", async () => {
+		const onInput = vi.fn();
+		const { container } = render(
+			<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />,
+		);
+		state.lastTerminal!.buffer.active.type = "alternate";
+		const terminalScreen = container.querySelector<HTMLElement>(".xterm-screen")!;
+		terminalScreen.getBoundingClientRect = () => ({
+			bottom: 500,
+			height: 400,
+			left: 0,
+			right: 800,
+			top: 100,
+			width: 800,
+			x: 0,
+			y: 100,
+			toJSON: () => undefined,
+		});
+
+		fireEvent.mouseDown(terminalScreen, { button: 0, detail: 1 });
+		state.lastTerminal!.selection = "one\ntwo";
+		fireEvent.mouseMove(document, { buttons: 1, clientX: 40, clientY: 550 });
+		state.screenRows = ["two", "three"];
+		act(() => state.lastTerminal!.renderListeners.forEach((listener) => listener()));
+		fireEvent.mouseUp(document, { button: 0 });
+
+		expect(window.ao!.clipboard.writeText).not.toHaveBeenCalled();
+		fireEvent.contextMenu(container.firstElementChild!);
+		fireEvent.click(await screen.findByText("Copy"));
+		await waitFor(() => expect(window.ao!.clipboard.writeText).toHaveBeenCalledWith("one\ntwo\nthree"));
+	});
+
+	it("maps untouched xterm gap cells when an edge selection returns inside", async () => {
+		const { container } = render(
+			<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(vi.fn())} />,
+		);
+		state.lastTerminal!.buffer.active.type = "alternate";
+		state.screenRows = ["a         b"];
+		state.lastTerminal!.selection = "a         b";
+		state.lastTerminal!.selectionPosition = { start: { x: 0, y: 0 }, end: { x: 11, y: 0 } };
+		const terminalScreen = container.querySelector<HTMLElement>(".xterm-screen")!;
+		terminalScreen.getBoundingClientRect = () => ({
+			bottom: 500,
+			height: 400,
+			left: 0,
+			right: 800,
+			top: 100,
+			width: 800,
+			x: 0,
+			y: 100,
+			toJSON: () => undefined,
+		});
+
+		fireEvent.mouseDown(terminalScreen, { button: 0, detail: 1 });
+		fireEvent.mouseMove(document, { buttons: 1, clientX: 800, clientY: 550 });
+		fireEvent.mouseMove(document, { buttons: 1, clientX: 100, clientY: 110 });
+		fireEvent.mouseUp(document, { button: 0 });
+		state.lastTerminal!.keyHandler!({
+			altKey: false,
+			ctrlKey: false,
+			key: "c",
+			metaKey: true,
+			preventDefault: vi.fn(),
+			shiftKey: false,
+			stopPropagation: vi.fn(),
+			type: "keydown",
+		} as unknown as KeyboardEvent);
+
+		await waitFor(() => expect(window.ao!.clipboard.writeText).toHaveBeenCalledWith("a         "));
 	});
 
 	it("shows a copied toast after an explicit copy", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -34,7 +34,7 @@ const state = vi.hoisted(() => ({
 						isDim: () => boolean;
 					} | undefined;
 					isWrapped: boolean;
-					translateToString: () => string;
+					translateToString: (trimRight?: boolean) => string;
 				} | undefined;
 			};
 		};
@@ -815,8 +815,85 @@ describe("XtermTerminal", () => {
 
 		expect(window.ao!.clipboard.writeText).not.toHaveBeenCalled();
 		fireEvent.contextMenu(container.firstElementChild!);
-		fireEvent.click(await screen.findByText("Copy"));
+		const copyItem = await screen.findByText("Copy");
+		fireEvent.mouseDown(copyItem, { button: 0 });
+		fireEvent.click(copyItem);
 		await waitFor(() => expect(window.ao!.clipboard.writeText).toHaveBeenCalledWith("one\ntwo\nthree"));
+	});
+
+	it("extends selection in a normal-buffer pane that routes mouse input", async () => {
+		const onInput = vi.fn();
+		const { container } = render(
+			<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />,
+		);
+		const terminalScreen = container.querySelector<HTMLElement>(".xterm-screen")!;
+		terminalScreen.getBoundingClientRect = () => ({
+			bottom: 500,
+			height: 400,
+			left: 0,
+			right: 800,
+			top: 100,
+			width: 800,
+			x: 0,
+			y: 100,
+			toJSON: () => undefined,
+		});
+
+		fireEvent.mouseDown(terminalScreen, { button: 0, detail: 1 });
+		state.lastTerminal!.selection = "one\ntwo";
+		fireEvent.mouseMove(document, { buttons: 1, clientX: 40, clientY: 550 });
+		state.screenRows = ["two", "three"];
+		act(() => state.lastTerminal!.renderListeners.forEach((listener) => listener()));
+		fireEvent.mouseUp(document, { button: 0 });
+		state.lastTerminal!.keyHandler!({
+			altKey: false,
+			ctrlKey: false,
+			key: "c",
+			metaKey: true,
+			preventDefault: vi.fn(),
+			shiftKey: false,
+			stopPropagation: vi.fn(),
+			type: "keydown",
+		} as unknown as KeyboardEvent);
+
+		await waitFor(() => expect(window.ao!.clipboard.writeText).toHaveBeenCalledWith("one\ntwo\nthree"));
+	});
+
+	it("clears a completed edge selection when another document area is clicked", () => {
+		const { container } = render(
+			<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(vi.fn())} />,
+		);
+		state.lastTerminal!.buffer.active.type = "alternate";
+		const terminalScreen = container.querySelector<HTMLElement>(".xterm-screen")!;
+		terminalScreen.getBoundingClientRect = () => ({
+			bottom: 500,
+			height: 400,
+			left: 0,
+			right: 800,
+			top: 100,
+			width: 800,
+			x: 0,
+			y: 100,
+			toJSON: () => undefined,
+		});
+
+		fireEvent.mouseDown(terminalScreen, { button: 0, detail: 1 });
+		state.lastTerminal!.selection = "one\ntwo";
+		fireEvent.mouseMove(document, { buttons: 1, clientX: 40, clientY: 550 });
+		fireEvent.mouseUp(document, { button: 0 });
+		fireEvent.mouseDown(document.body, { button: 0, detail: 1 });
+		state.lastTerminal!.keyHandler!({
+			altKey: false,
+			ctrlKey: false,
+			key: "c",
+			metaKey: true,
+			preventDefault: vi.fn(),
+			shiftKey: false,
+			stopPropagation: vi.fn(),
+			type: "keydown",
+		} as unknown as KeyboardEvent);
+
+		expect(window.ao!.clipboard.writeText).not.toHaveBeenCalled();
 	});
 
 	it("maps untouched xterm gap cells when an edge selection returns inside", async () => {
@@ -1365,6 +1442,39 @@ describe("XtermTerminal", () => {
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+	});
+
+	it("paces edge selection in keyboard-scroll panes by terminal rows", () => {
+		vi.useFakeTimers();
+		try {
+			const onInput = vi.fn();
+			const { container } = render(
+				<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />,
+			);
+			state.lastTerminal!.buffer.active.type = "alternate";
+			const terminalScreen = container.querySelector<HTMLElement>(".xterm-screen")!;
+			terminalScreen.getBoundingClientRect = () => ({
+				bottom: 500,
+				height: 400,
+				left: 0,
+				right: 800,
+				top: 100,
+				width: 800,
+				x: 0,
+				y: 100,
+				toJSON: () => undefined,
+			});
+
+			fireEvent.mouseDown(terminalScreen, { button: 0, detail: 1 });
+			state.lastTerminal!.selection = "one\ntwo";
+			fireEvent.mouseMove(document, { buttons: 1, clientX: 40, clientY: 501 });
+			act(() => vi.advanceTimersByTime(23 * 50));
+			expect(onInput).not.toHaveBeenCalled();
+			act(() => vi.advanceTimersByTime(50));
+			expect(onInput).toHaveBeenCalledWith("\x1b[6~", "wheel");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("routes web links to the AO browser and does not open the system browser", () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -38,6 +38,7 @@ import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { isWebLink, openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { isMacPlatform } from "../lib/platform";
 import {
+	isTerminalSelectionChrome,
 	TerminalSelectionAutoscroll,
 	type TerminalLiveSelectionRender,
 	type TerminalSelectionPoint,
@@ -667,6 +668,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				row: Math.min(term.rows - 1, Math.max(0, Math.floor(((event.clientY - rect.top) / rect.height) * term.rows))),
 			};
 		};
+		let keyboardSelectionScrollCarry = 0;
+		let keyboardSelectionScrollDirection: -1 | 1 = 1;
 		const extendedSelection = new TerminalSelectionAutoscroll({
 			readNativeSelection: () => {
 				const selection = term.getSelectionPosition();
@@ -685,24 +688,29 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				rows: Array.from({ length: term.rows }, (_, row) => {
 					const line = term.buffer.active.getLine(term.buffer.active.viewportY + row);
 					if (!line) return { text: "" };
-					let hasText = false;
 					let allTextIsDim = true;
+					let hasText = false;
 					let textOffset = 0;
+					let endCol = 0;
 					const cellOffsets = Array.from({ length: term.cols + 1 }, () => 0);
 					for (let col = 0; col < term.cols; col += 1) {
 						const cell = line.getCell(col);
 						cellOffsets[col] = textOffset;
 						const chars = cell?.getChars() ?? "";
 						textOffset += chars.length > 0 ? chars.length : cell?.getWidth() === 1 ? 1 : 0;
-						if (!chars.trim()) continue;
-						hasText = true;
-						allTextIsDim &&= Boolean(cell?.isDim());
+						if (chars.trim()) {
+							hasText = true;
+							allTextIsDim &&= Boolean(cell?.isDim());
+							endCol = col + Math.max(1, cell?.getWidth() ?? 1);
+						}
 					}
 					cellOffsets[term.cols] = textOffset;
+					const text = line.translateToString(true);
 					return {
-						text: line.translateToString(true),
+						text,
 						cellOffsets,
-						selectable: !hasText || !allTextIsDim,
+						endCol,
+						selectable: !isTerminalSelectionChrome(text, hasText && allTextIsDim),
 						wrapped: line.isWrapped,
 					};
 				}),
@@ -711,36 +719,52 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			scroll: (direction, lines) => {
 				const visibleLines = Math.min(lines, Math.max(1, term.rows - 1));
 				if (callbacksRef.current.paneScrollsByKeyboard) {
-					emitUserInput(pageKeyReport(direction), "wheel");
-					return;
+					if (direction !== keyboardSelectionScrollDirection) keyboardSelectionScrollCarry = 0;
+					keyboardSelectionScrollDirection = direction;
+					keyboardSelectionScrollCarry += visibleLines;
+					const pages = Math.floor(keyboardSelectionScrollCarry / Math.max(1, term.rows));
+					if (pages === 0) return false;
+					keyboardSelectionScrollCarry %= Math.max(1, term.rows);
+					emitUserInput(pageKeyReport(direction).repeat(pages), "wheel");
+					return true;
 				}
 				if (term.modes.mouseTrackingMode !== "none") {
 					const button = direction < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
 					emitUserInput(sgrWheelReport(button, visibleLines), "wheel");
-					return;
+					return true;
 				}
 				if (term.buffer.active.type === "normal") {
 					term.scrollLines(direction * visibleLines);
-					return;
+					return true;
 				}
 				emitUserInput(pageKeyReport(direction), "wheel");
+				return true;
 			},
 			render: renderExtendedSelection,
 		});
 		extendedSelectionRef.current = extendedSelection;
 		const selectionMouseDown = (event: MouseEvent) => {
 			if (event.button !== 0) return;
+			if (event.target instanceof Element && event.target.closest('[role="menu"]')) return;
+			keyboardSelectionScrollCarry = 0;
+			keyboardSelectionScrollDirection = 1;
 			const eligible =
 				event.detail === 1 &&
 				!event.altKey &&
 				!event.shiftKey &&
-				term.buffer.active.type === "alternate" &&
+				(term.buffer.active.type === "alternate" ||
+					term.modes.mouseTrackingMode !== "none" ||
+					callbacksRef.current.paneScrollsByKeyboard === true) &&
 				userInputListeners.size > 0 &&
 				Boolean(screen && event.target instanceof Node && screen.contains(event.target));
 			extendedSelection.pointerDown(eligible);
 		};
 		const selectionMouseMove = (event: MouseEvent) => {
-			if ((event.buttons & 1) === 0 || !screen) return;
+			if ((event.buttons & 1) === 0) {
+				extendedSelection.pointerUp();
+				return;
+			}
+			if (!screen) return;
 			const point = pointForMouse(event);
 			if (!point) return;
 			const rect = screen.getBoundingClientRect();
@@ -752,8 +776,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		const selectionMouseUp = (event: MouseEvent) => {
 			if (event.button === 0) extendedSelection.pointerUp();
 		};
-		const selectionBlur = () => extendedSelection.blur();
-		shell.addEventListener("mousedown", selectionMouseDown, true);
+		const selectionBlur = () => {
+			keyboardSelectionScrollCarry = 0;
+			extendedSelection.blur();
+		};
+		document.addEventListener("mousedown", selectionMouseDown, true);
 		document.addEventListener("mousemove", selectionMouseMove, true);
 		document.addEventListener("mouseup", selectionMouseUp, true);
 		window.addEventListener("blur", selectionBlur);
@@ -1274,7 +1301,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			scrollbarTrack?.removeEventListener("pointerup", scrollbarPointerUp);
 			scrollbarTrack?.removeEventListener("pointercancel", scrollbarPointerUp);
 			window.removeEventListener("resize", scheduleVisibleFit);
-			shell.removeEventListener("mousedown", selectionMouseDown, true);
+			document.removeEventListener("mousedown", selectionMouseDown, true);
 			document.removeEventListener("mousemove", selectionMouseMove, true);
 			document.removeEventListener("mouseup", selectionMouseUp, true);
 			window.removeEventListener("blur", selectionBlur);

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -37,6 +37,11 @@ import { aoBridge } from "../lib/bridge";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { isWebLink, openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { isMacPlatform } from "../lib/platform";
+import {
+	TerminalSelectionAutoscroll,
+	type TerminalLiveSelectionRender,
+	type TerminalSelectionPoint,
+} from "../lib/terminal-selection-autoscroll";
 import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
 import { buildTerminalThemes } from "../lib/terminal-themes";
 import { useUiStore, type Theme } from "../stores/ui-store";
@@ -216,6 +221,15 @@ function terminalHasFocus(host: HTMLElement): boolean {
 type XtermInternal = Terminal & {
 	_core?: {
 		element?: HTMLElement;
+		_mouseService?: {
+			getCoords: (
+				event: MouseEvent,
+				element: HTMLElement,
+				cols: number,
+				rows: number,
+				isSelection?: boolean,
+			) => [number, number] | undefined;
+		};
 		viewport?: {
 			scrollBarWidth: number;
 		};
@@ -294,6 +308,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	const scrollbarThumbRef = useRef<HTMLDivElement | null>(null);
 	const termRef = useRef<Terminal | null>(null);
 	const searchAddonRef = useRef<SearchAddon | null>(null);
+	const extendedSelectionRef = useRef<TerminalSelectionAutoscroll | null>(null);
 	const fitRef = useRef<(() => void) | null>(null);
 	const contextMenuActionsRef = useRef<TerminalContextMenuActions | null>(null);
 	const [contextMenu, setContextMenu] = useState<TerminalContextMenuState>({
@@ -588,8 +603,163 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		scrollbarTrack?.addEventListener("pointercancel", scrollbarPointerUp);
 		scheduleScrollbarUpdate();
 
+		const userInputListeners = new Set<(data: string, source: TerminalUserInputSource) => void>();
+		const emitUserInput = (data: string, source: TerminalUserInputSource) => {
+			if (data.length === 0) return;
+			userInputListeners.forEach((listener) => listener(data, source));
+		};
+		const xtermInternal = term as XtermInternal;
+		const screen = host.querySelector<HTMLElement>(".xterm-screen");
+		const selectionLayer = document.createElement("div");
+		selectionLayer.dataset.aoTerminalSelectionLayer = "true";
+		selectionLayer.setAttribute("aria-hidden", "true");
+		Object.assign(selectionLayer.style, {
+			display: "none",
+			inset: "0",
+			overflow: "hidden",
+			pointerEvents: "none",
+			position: "absolute",
+			zIndex: "10",
+		});
+		screen?.appendChild(selectionLayer);
+		const renderExtendedSelection = (state: TerminalLiveSelectionRender | null) => {
+			selectionLayer.replaceChildren();
+			if (!screen || !state || term.cols <= 0 || term.rows <= 0) {
+				selectionLayer.style.display = "none";
+				return;
+			}
+			const rect = screen.getBoundingClientRect();
+			if (rect.width <= 0 || rect.height <= 0) {
+				selectionLayer.style.display = "none";
+				return;
+			}
+			const cellWidth = rect.width / term.cols;
+			const cellHeight = rect.height / term.rows;
+			selectionLayer.style.display = "block";
+			const selectionBackground = term.options.theme?.selectionBackground ?? "rgb(77 141 255 / 0.3)";
+			for (const highlight of state.highlights) {
+				const element = document.createElement("div");
+				element.dataset.aoTerminalSelectionHighlight = "true";
+				Object.assign(element.style, {
+					background: selectionBackground,
+					height: `${cellHeight}px`,
+					left: `${highlight.startCol * cellWidth}px`,
+					position: "absolute",
+					top: `${highlight.row * cellHeight}px`,
+					width: `${(highlight.endCol - highlight.startCol) * cellWidth}px`,
+				});
+				selectionLayer.appendChild(element);
+			}
+		};
+		const pointForMouse = (event: MouseEvent): TerminalSelectionPoint | null => {
+			if (!screen) return null;
+			const coords = xtermInternal._core?._mouseService?.getCoords(event, screen, term.cols, term.rows, true);
+			if (coords) {
+				return {
+					col: Math.min(term.cols, Math.max(0, coords[0] - 1)),
+					row: Math.min(term.rows - 1, Math.max(0, coords[1] - 1)),
+				};
+			}
+			const rect = screen.getBoundingClientRect();
+			if (rect.width <= 0 || rect.height <= 0) return null;
+			return {
+				col: Math.min(term.cols, Math.max(0, Math.floor(((event.clientX - rect.left) / rect.width) * term.cols))),
+				row: Math.min(term.rows - 1, Math.max(0, Math.floor(((event.clientY - rect.top) / rect.height) * term.rows))),
+			};
+		};
+		const extendedSelection = new TerminalSelectionAutoscroll({
+			readNativeSelection: () => {
+				const selection = term.getSelectionPosition();
+				const text = term.getSelection();
+				if (!selection || !text) return null;
+				const viewportY = term.buffer.active.viewportY;
+				return {
+					text,
+					range: {
+						anchor: { row: selection.start.y - viewportY, col: selection.start.x },
+						focus: { row: selection.end.y - viewportY, col: selection.end.x },
+					},
+				};
+			},
+			readSnapshot: () => ({
+				rows: Array.from({ length: term.rows }, (_, row) => {
+					const line = term.buffer.active.getLine(term.buffer.active.viewportY + row);
+					if (!line) return { text: "" };
+					let hasText = false;
+					let allTextIsDim = true;
+					let textOffset = 0;
+					const cellOffsets = Array.from({ length: term.cols + 1 }, () => 0);
+					for (let col = 0; col < term.cols; col += 1) {
+						const cell = line.getCell(col);
+						cellOffsets[col] = textOffset;
+						const chars = cell?.getChars() ?? "";
+						textOffset += chars.length > 0 ? chars.length : cell?.getWidth() === 1 ? 1 : 0;
+						if (!chars.trim()) continue;
+						hasText = true;
+						allTextIsDim &&= Boolean(cell?.isDim());
+					}
+					cellOffsets[term.cols] = textOffset;
+					return {
+						text: line.translateToString(true),
+						cellOffsets,
+						selectable: !hasText || !allTextIsDim,
+						wrapped: line.isWrapped,
+					};
+				}),
+			}),
+			clearNativeSelection: () => term.clearSelection(),
+			scroll: (direction, lines) => {
+				const visibleLines = Math.min(lines, Math.max(1, term.rows - 1));
+				if (callbacksRef.current.paneScrollsByKeyboard) {
+					emitUserInput(pageKeyReport(direction), "wheel");
+					return;
+				}
+				if (term.modes.mouseTrackingMode !== "none") {
+					const button = direction < 0 ? SGR_WHEEL_UP : SGR_WHEEL_DOWN;
+					emitUserInput(sgrWheelReport(button, visibleLines), "wheel");
+					return;
+				}
+				if (term.buffer.active.type === "normal") {
+					term.scrollLines(direction * visibleLines);
+					return;
+				}
+				emitUserInput(pageKeyReport(direction), "wheel");
+			},
+			render: renderExtendedSelection,
+		});
+		extendedSelectionRef.current = extendedSelection;
+		const selectionMouseDown = (event: MouseEvent) => {
+			if (event.button !== 0) return;
+			const eligible =
+				event.detail === 1 &&
+				!event.altKey &&
+				!event.shiftKey &&
+				term.buffer.active.type === "alternate" &&
+				userInputListeners.size > 0 &&
+				Boolean(screen && event.target instanceof Node && screen.contains(event.target));
+			extendedSelection.pointerDown(eligible);
+		};
+		const selectionMouseMove = (event: MouseEvent) => {
+			if ((event.buttons & 1) === 0 || !screen) return;
+			const point = pointForMouse(event);
+			if (!point) return;
+			const rect = screen.getBoundingClientRect();
+			if (extendedSelection.pointerMove(point, event.clientY, rect.top, rect.height)) {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+			}
+		};
+		const selectionMouseUp = (event: MouseEvent) => {
+			if (event.button === 0) extendedSelection.pointerUp();
+		};
+		const selectionBlur = () => extendedSelection.blur();
+		shell.addEventListener("mousedown", selectionMouseDown, true);
+		document.addEventListener("mousemove", selectionMouseMove, true);
+		document.addEventListener("mouseup", selectionMouseUp, true);
+		window.addEventListener("blur", selectionBlur);
+
 		const copySelection = (options?: { clipboardData?: DataTransfer | null }) => {
-			const selection = term.getSelection();
+			const selection = extendedSelection.getText() || term.getSelection();
 			if (!selection) return false;
 			options?.clipboardData?.setData("text/plain", selection);
 			void aoBridge.clipboard
@@ -602,12 +772,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				});
 			return true;
 		};
-		const userInputListeners = new Set<(data: string, source: TerminalUserInputSource) => void>();
-		const emitUserInput = (data: string, source: TerminalUserInputSource) => {
-			if (data.length === 0) return;
-			userInputListeners.forEach((listener) => listener(data, source));
-		};
 		const pasteText = (text: string) => {
+			extendedSelection.blur();
 			const prepared = preparePastedText(text);
 			const bracketed = term.modes.bracketedPasteMode && term.options.ignoreBracketedPasteMode !== true;
 			emitUserInput(bracketPastedText(prepared, bracketed), "paste");
@@ -651,6 +817,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				focusTerminal();
 			},
 			selectAll: () => {
+				extendedSelection.blur();
 				term.selectAll();
 				focusTerminal();
 			},
@@ -659,7 +826,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			event.preventDefault();
 			event.stopPropagation();
 			setContextMenu({
-				canCopy: term.hasSelection(),
+				canCopy: extendedSelection.hasSelection() || term.hasSelection(),
 				open: true,
 				x: event.clientX,
 				y: event.clientY,
@@ -675,6 +842,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// paste, double word-delete, etc). keyup/keypress fall through to
 			// xterm's own default handling for that event type.
 			if (event.type === "keyup" || event.type === "keypress") return true;
+			const modifierOnly = event.key === "Alt" || event.key === "Control" || event.key === "Meta" || event.key === "Shift";
+			if (!modifierOnly && !isTerminalCopyShortcut(event)) extendedSelection.blur();
 			if (isTerminalSearchShortcut(event)) {
 				consumeTerminalShortcut(event);
 				setSearchOpen(true);
@@ -872,6 +1041,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			pending = null;
 			if (++stableFrames >= STABLE_FRAMES_TARGET) stabilizer.dispose();
 		});
+		const selectionRender = term.onRender(() => extendedSelection.screenRendered());
 
 		// OS window resize and monitor/DPR changes also alter the true cell box
 		// without touching the host's height:100% box, so the ResizeObserver above
@@ -897,6 +1067,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		let wheelAccumPx = 0;
 		term.attachCustomWheelEventHandler((event) => {
 			if (event.ctrlKey || event.metaKey) return false;
+			extendedSelection.blur();
 			let lines: number;
 			if (event.deltaMode === 1 /* DOM_DELTA_LINE */) {
 				lines = Math.trunc(event.deltaY) || Math.sign(event.deltaY);
@@ -949,6 +1120,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			pasteText(text);
 		};
 		const compositionInput = (event: CompositionEvent) => {
+			extendedSelection.blur();
 			emitUserInput(event.data, "composition");
 		};
 		shell.addEventListener("paste", pasteInput, true);
@@ -1092,6 +1264,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			fitSettledListeners.clear();
 			observer.disconnect();
 			stabilizer.dispose();
+			selectionRender.dispose();
 			scrollPositionChange?.dispose();
 			scrollbarResize?.dispose();
 			if (scrollbarFrame !== null) cancelAnimationFrame(scrollbarFrame);
@@ -1101,6 +1274,13 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			scrollbarTrack?.removeEventListener("pointerup", scrollbarPointerUp);
 			scrollbarTrack?.removeEventListener("pointercancel", scrollbarPointerUp);
 			window.removeEventListener("resize", scheduleVisibleFit);
+			shell.removeEventListener("mousedown", selectionMouseDown, true);
+			document.removeEventListener("mousemove", selectionMouseMove, true);
+			document.removeEventListener("mouseup", selectionMouseUp, true);
+			window.removeEventListener("blur", selectionBlur);
+			extendedSelection.dispose();
+			if (extendedSelectionRef.current === extendedSelection) extendedSelectionRef.current = null;
+			selectionLayer.remove();
 			shell.removeEventListener("copy", copyInput);
 			window.removeEventListener("keydown", copyShortcut, true);
 			shell.removeEventListener("contextmenu", openContextMenu);
@@ -1134,6 +1314,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 
 	useLayoutEffect(() => {
 		if (props.isVisible === false) {
+			extendedSelectionRef.current?.blur();
 			setSearchOpen(false);
 			searchAddonRef.current?.clearDecorations();
 			setContextMenuOpen(false);

--- a/frontend/src/renderer/lib/terminal-selection-autoscroll.test.ts
+++ b/frontend/src/renderer/lib/terminal-selection-autoscroll.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	edgeScrollLines,
+	screenSnapshotExtension,
+	SELECTION_SCROLL_INTERVAL_MS,
+	TerminalSelectionAutoscroll,
+	type TerminalScreenSnapshot,
+} from "./terminal-selection-autoscroll";
+
+describe("terminal selection edge calculations", () => {
+	it("uses the same direction and 1-to-15 row speed curve on every platform", () => {
+		expect(edgeScrollLines(100, 100, 400)).toBe(0);
+		expect(edgeScrollLines(500, 100, 400)).toBe(0);
+		expect(edgeScrollLines(99, 100, 400)).toBe(-1);
+		expect(edgeScrollLines(75, 100, 400)).toBe(-8);
+		expect(edgeScrollLines(50, 100, 400)).toBe(-15);
+		expect(edgeScrollLines(501, 100, 400)).toBe(1);
+		expect(edgeScrollLines(525, 100, 400)).toBe(8);
+		expect(edgeScrollLines(550, 100, 400)).toBe(15);
+	});
+
+	it("stitches newly revealed rows in both directions", () => {
+		expect(screenSnapshotExtension({ rows: ["two", "three"] }, { rows: ["one", "two", "three"] }, -1))
+			.toEqual(["one"]);
+		expect(screenSnapshotExtension({ rows: ["one", "two"] }, { rows: ["two", "three"] }, 1))
+			.toEqual(["three"]);
+	});
+
+	it("excludes dim thinking and transient footer rows", () => {
+		const previous = { rows: [
+			{ text: "private reasoning", selectable: false },
+			"two",
+			"three",
+			"muse-spark · high · ~/.ao/dev/data/worktrees/scratch-12",
+		] };
+		expect(screenSnapshotExtension(previous, { rows: ["one", "two", "three"] }, -1)).toEqual(["one"]);
+	});
+});
+
+function createMachine(options?: {
+	native?: string;
+	range?: { anchor: { row: number; col: number }; focus: { row: number; col: number } };
+	snapshot?: TerminalScreenSnapshot;
+	scroll?: (direction: -1 | 1, lines: number) => void;
+	render?: (state: { highlights: { row: number }[] } | null) => void;
+	setInterval?: (callback: () => void, ms: number) => ReturnType<typeof setInterval>;
+	clearInterval?: (handle: ReturnType<typeof setInterval>) => void;
+}) {
+	return new TerminalSelectionAutoscroll({
+		readNativeSelection: () => ({
+			text: options?.native ?? "one\ntwo",
+			range: options?.range ?? { anchor: { row: 0, col: 0 }, focus: { row: 1, col: 3 } },
+		}),
+		readSnapshot: () => options?.snapshot ?? { rows: ["one", "two"] },
+		clearNativeSelection: vi.fn(),
+		scroll: options?.scroll ?? vi.fn(),
+		render: options?.render ?? vi.fn(),
+		setInterval: options?.setInterval,
+		clearInterval: options?.clearInterval,
+	});
+}
+
+describe("TerminalSelectionAutoscroll", () => {
+	it("keeps ordinary in-viewport selection native", () => {
+		const render = vi.fn();
+		const machine = createMachine({ render });
+		machine.pointerDown(true);
+		expect(machine.pointerMove({ row: 1, col: 2 }, 250, 100, 400)).toBe(false);
+		machine.pointerUp();
+		expect(machine.hasSelection()).toBe(false);
+		expect(render).not.toHaveBeenCalledWith(expect.objectContaining({ highlights: expect.any(Array) }));
+	});
+
+	it.each([
+		{ name: "upward", pointerY: 50, direction: -1 as const, initial: ["two", "three"], next: ["one", "two", "three"] },
+		{ name: "downward", pointerY: 550, direction: 1 as const, initial: ["one", "two"], next: ["two", "three"] },
+	])("scrolls $name and extends the copied range", ({ pointerY, direction, initial, next }) => {
+		let tick: (() => void) | undefined;
+		const snapshot: TerminalScreenSnapshot = { rows: [...initial] };
+		const scroll = vi.fn();
+		const machine = createMachine({
+			native: initial.join("\n"),
+			snapshot,
+			scroll,
+			setInterval: (callback, ms) => {
+				expect(ms).toBe(SELECTION_SCROLL_INTERVAL_MS);
+				tick = callback;
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		expect(machine.pointerMove({ row: 0, col: 0 }, pointerY, 100, 400)).toBe(true);
+		tick?.();
+		expect(scroll).toHaveBeenCalledWith(direction, 15);
+		snapshot.rows = next;
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\ntwo\nthree");
+	});
+
+	it("retains the extended selection on mouseup for explicit copy", () => {
+		const clearTimer = vi.fn();
+		const machine = createMachine({
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: clearTimer,
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 2 }, 50, 100, 400);
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\ntwo");
+		expect(clearTimer).toHaveBeenCalled();
+	});
+
+	it("preserves exact native text and partial highlight boundaries", () => {
+		const render = vi.fn();
+		const machine = createMachine({
+			native: "  const x = 1;  ",
+			range: { anchor: { row: 0, col: 2 }, focus: { row: 0, col: 14 } },
+			render,
+			snapshot: { rows: ["  const x = 1;"] },
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 14 }, 550, 100, 400);
+		machine.pointerUp();
+		expect(machine.getText()).toBe("  const x = 1;  ");
+		expect(render).toHaveBeenCalledWith({ highlights: [{ row: 0, startCol: 2, endCol: 14 }] });
+	});
+
+	it("keeps partial native boundaries after the viewport moves", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["abcd"] };
+		const render = vi.fn();
+		const machine = createMachine({
+			native: "bc",
+			range: { anchor: { row: 0, col: 1 }, focus: { row: 0, col: 3 } },
+			render,
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 1 }, 50, 100, 400);
+		snapshot.rows = ["new", "abcd"];
+		machine.screenRendered();
+		expect(render).toHaveBeenLastCalledWith({ highlights: [
+			{ row: 0, startCol: 0, endCol: 3 },
+			{ row: 1, startCol: 1, endCol: 3 },
+		] });
+	});
+
+	it("does not add a newline before a newly revealed wrapped row", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["hello"] };
+		const machine = createMachine({
+			native: "hello",
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 5 }, 550, 100, 400);
+		snapshot.rows = ["hello", { text: " world", wrapped: true }];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("hello world");
+	});
+
+	it("preserves blank lines revealed across the viewport edge", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["one"] };
+		const machine = createMachine({
+			native: "one",
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 3 }, 550, 100, 400);
+		snapshot.rows = ["one", "", "two"];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\n\ntwo");
+	});
+
+	it("maps terminal cell columns across wide Unicode characters", () => {
+		const snapshot: TerminalScreenSnapshot = {
+			rows: [{ text: "界b", cellOffsets: [0, 1, 1, 2] }],
+		};
+		const machine = createMachine({
+			native: "界b",
+			range: { anchor: { row: 0, col: 0 }, focus: { row: 0, col: 3 } },
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 3 }, 550, 100, 400);
+		machine.pointerMove({ row: 0, col: 2 }, 300, 100, 400);
+		machine.pointerUp();
+		expect(machine.getText()).toBe("界");
+	});
+
+	it("shrinks the extended end when the pointer returns inside", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["one"] };
+		const machine = createMachine({
+			native: "one",
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 3 }, 550, 100, 400);
+		snapshot.rows = ["one", "two", "three"];
+		machine.screenRendered();
+		machine.pointerMove({ row: 1, col: 2 }, 300, 100, 400);
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\ntw");
+	});
+
+	it("restores intervening rows when a shrunken selection extends again", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["one", "two", "three"] };
+		const machine = createMachine({
+			native: "one\ntwo\nthree",
+			range: { anchor: { row: 0, col: 0 }, focus: { row: 2, col: 5 } },
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 2, col: 5 }, 550, 100, 400);
+		snapshot.rows = ["two", "three", "four"];
+		machine.screenRendered();
+		machine.pointerMove({ row: 1, col: 2 }, 300, 100, 400);
+		machine.pointerMove({ row: 2, col: 4 }, 550, 100, 400);
+		snapshot.rows = ["three", "four", "five"];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\ntwo\nthree\nfour\nfive");
+	});
+
+	it("drops the old side of the range when the edge direction reverses", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["one", "two", "three"] };
+		const machine = createMachine({
+			native: "one\ntwo\nthree",
+			range: { anchor: { row: 0, col: 0 }, focus: { row: 2, col: 5 } },
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 2, col: 5 }, 550, 100, 400);
+		snapshot.rows = ["two", "three", "four"];
+		machine.screenRendered();
+		expect(machine.getText()).toBe("one\ntwo\nthree\nfour");
+		machine.pointerMove({ row: 0, col: 0 }, 50, 100, 400);
+		snapshot.rows = ["zero", "one", "two"];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("zero");
+	});
+
+	it("shrinks the old side while reversing toward an offscreen anchor", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["one", "two", "three"] };
+		const machine = createMachine({
+			native: "one\ntwo\nthree",
+			range: { anchor: { row: 0, col: 0 }, focus: { row: 2, col: 5 } },
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 2, col: 5 }, 550, 100, 400);
+		snapshot.rows = ["two", "three", "four"];
+		machine.screenRendered();
+		snapshot.rows = ["three", "four", "five"];
+		machine.screenRendered();
+		expect(machine.getText()).toBe("one\ntwo\nthree\nfour\nfive");
+		machine.pointerMove({ row: 0, col: 2 }, 50, 100, 400);
+		snapshot.rows = ["two", "three", "four"];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one");
+	});
+
+	it("clears selection and its timer on blur", () => {
+		const clearTimer = vi.fn();
+		const render = vi.fn();
+		const machine = createMachine({
+			render,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: clearTimer,
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 0 }, 50, 100, 400);
+		machine.blur();
+		expect(machine.hasSelection()).toBe(false);
+		expect(clearTimer).toHaveBeenCalled();
+		expect(render).toHaveBeenLastCalledWith(null);
+	});
+
+	it("does not activate for ineligible panes or transient-only selections", () => {
+		const scroll = vi.fn();
+		const ineligible = createMachine({ scroll });
+		ineligible.pointerDown(false);
+		expect(ineligible.pointerMove({ row: 0, col: 0 }, 50, 100, 400)).toBe(false);
+
+		const transient = createMachine({ native: "Thinking…\nscratch footer", scroll });
+		transient.pointerDown(true);
+		expect(transient.pointerMove({ row: 0, col: 0 }, 50, 100, 400)).toBe(false);
+		expect(scroll).not.toHaveBeenCalled();
+	});
+
+	it("changes direction and speed while the pointer stays outside", () => {
+		let tick: (() => void) | undefined;
+		const scroll = vi.fn();
+		const machine = createMachine({
+			scroll,
+			setInterval: (callback) => {
+				tick = callback;
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 0 }, 99, 100, 400);
+		tick?.();
+		machine.pointerMove({ row: 1, col: 0 }, 525, 100, 400);
+		tick?.();
+		expect(scroll.mock.calls).toEqual([[-1, 1], [1, 8]]);
+	});
+});

--- a/frontend/src/renderer/lib/terminal-selection-autoscroll.test.ts
+++ b/frontend/src/renderer/lib/terminal-selection-autoscroll.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	edgeScrollLines,
+	isTerminalSelectionChrome,
 	screenSnapshotExtension,
 	SELECTION_SCROLL_INTERVAL_MS,
 	TerminalSelectionAutoscroll,
@@ -34,6 +35,39 @@ describe("terminal selection edge calculations", () => {
 			"muse-spark · high · ~/.ao/dev/data/worktrees/scratch-12",
 		] };
 		expect(screenSnapshotExtension(previous, { rows: ["one", "two", "three"] }, -1)).toEqual(["one"]);
+	});
+
+	it("preserves dividers, dim output, and prose that starts like a status", () => {
+		expect(screenSnapshotExtension(
+			{ rows: ["alpha"] },
+			{ rows: ["alpha", "---", "Working directory is dirty", "Loading state failed", "Generating report ok"] },
+			1,
+		)).toEqual(["---", "Working directory is dirty", "Loading state failed", "Generating report ok"]);
+		expect(screenSnapshotExtension(
+			{ rows: ["alpha"] },
+			{ rows: ["alpha", { text: "  at foo (bar.ts:12)" }] },
+			1,
+		)).toEqual(["  at foo (bar.ts:12)"]);
+	});
+
+	it("only treats styled terminal chrome as transient", () => {
+		expect(isTerminalSelectionChrome("Working directory is dirty", false)).toBe(false);
+		expect(isTerminalSelectionChrome("  at foo (bar.ts:12)", true)).toBe(false);
+		expect(isTerminalSelectionChrome("Thinking...", true)).toBe(true);
+		expect(isTerminalSelectionChrome("muse-spark · high · ~/.ao/session", false)).toBe(true);
+	});
+
+	it("does not mistake an in-place repaint for scroll movement", () => {
+		expect(screenSnapshotExtension(
+			{ rows: ["one", "partial"] },
+			{ rows: ["one", "partial text"] },
+			1,
+		)).toEqual([]);
+	});
+
+	it("keeps a newly revealed blank edge row", () => {
+		expect(screenSnapshotExtension({ rows: ["one", "two"] }, { rows: ["two", ""] }, 1)).toEqual([""]);
+		expect(screenSnapshotExtension({ rows: ["two", "three"] }, { rows: ["", "two"] }, -1)).toEqual([""]);
 	});
 });
 
@@ -97,6 +131,49 @@ describe("TerminalSelectionAutoscroll", () => {
 		machine.screenRendered();
 		machine.pointerUp();
 		expect(machine.getText()).toBe("one\ntwo\nthree");
+	});
+
+	it("accepts a full-page replacement only after a scroll tick", () => {
+		let tick: (() => void) | undefined;
+		const snapshot: TerminalScreenSnapshot = { rows: ["one", "two"] };
+		const machine = createMachine({
+			snapshot,
+			setInterval: (callback) => {
+				tick = callback;
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 1, col: 3 }, 550, 100, 400);
+		tick?.();
+		snapshot.rows = ["three", "four"];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\ntwo\nthree\nfour");
+	});
+
+	it("ignores a repaint when page pacing did not emit a scroll", () => {
+		let tick: (() => void) | undefined;
+		const snapshot: TerminalScreenSnapshot = { rows: ["one", "partial"] };
+		const machine = createMachine({
+			native: "one\npartial",
+			range: { anchor: { row: 0, col: 0 }, focus: { row: 1, col: 7 } },
+			snapshot,
+			scroll: () => false,
+			setInterval: (callback) => {
+				tick = callback;
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 1, col: 7 }, 550, 100, 400);
+		tick?.();
+		snapshot.rows = ["one", "partial text"];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\npartial");
 	});
 
 	it("retains the extended selection on mouseup for explicit copy", () => {
@@ -200,6 +277,21 @@ describe("TerminalSelectionAutoscroll", () => {
 		expect(machine.getText()).toBe("界");
 	});
 
+	it("highlights the full cell width of a line-ending wide character", () => {
+		const render = vi.fn();
+		const machine = createMachine({
+			native: "界",
+			range: { anchor: { row: 0, col: 0 }, focus: { row: 0, col: 2 } },
+			render,
+			snapshot: { rows: [{ text: "界", cellOffsets: [0, 1, 1], endCol: 2 }] },
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 0, col: 2 }, 550, 100, 400);
+		expect(render).toHaveBeenLastCalledWith({ highlights: [{ row: 0, startCol: 0, endCol: 2 }] });
+	});
+
 	it("shrinks the extended end when the pointer returns inside", () => {
 		const snapshot: TerminalScreenSnapshot = { rows: ["one"] };
 		const machine = createMachine({
@@ -259,6 +351,49 @@ describe("TerminalSelectionAutoscroll", () => {
 		expect(machine.getText()).toBe("zero");
 	});
 
+	it("re-enters after reversing and can extend down again without corrupting text", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["one", "two", "three"] };
+		const machine = createMachine({
+			native: "one\ntwo\nthree",
+			range: { anchor: { row: 0, col: 0 }, focus: { row: 2, col: 5 } },
+			snapshot,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 2, col: 5 }, 550, 100, 400);
+		snapshot.rows = ["two", "three", "four"];
+		machine.screenRendered();
+		machine.pointerMove({ row: 0, col: 0 }, 50, 100, 400);
+		machine.pointerMove({ row: 1, col: 5 }, 300, 100, 400);
+		machine.pointerMove({ row: 2, col: 4 }, 550, 100, 400);
+		snapshot.rows = ["three", "four", "five"];
+		machine.screenRendered();
+		machine.pointerUp();
+		expect(machine.getText()).toBe("one\ntwo\nthree\nfour\nfive");
+	});
+
+	it("remaps a completed highlight when the terminal repaints", () => {
+		const snapshot: TerminalScreenSnapshot = { rows: ["one", "two"] };
+		const render = vi.fn();
+		const machine = createMachine({
+			snapshot,
+			render,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
+		machine.pointerDown(true);
+		machine.pointerMove({ row: 1, col: 3 }, 550, 100, 400);
+		snapshot.rows = ["two", "three"];
+		machine.screenRendered();
+		machine.pointerUp();
+		render.mockClear();
+		snapshot.rows = ["three", "four"];
+		machine.screenRendered();
+		expect(render).toHaveBeenCalledWith({ highlights: [{ row: 0, startCol: 0, endCol: 5 }] });
+		expect(machine.getText()).toBe("one\ntwo\nthree");
+	});
+
 	it("shrinks the old side while reversing toward an offscreen anchor", () => {
 		const snapshot: TerminalScreenSnapshot = { rows: ["one", "two", "three"] };
 		const machine = createMachine({
@@ -298,16 +433,23 @@ describe("TerminalSelectionAutoscroll", () => {
 		expect(render).toHaveBeenLastCalledWith(null);
 	});
 
-	it("does not activate for ineligible panes or transient-only selections", () => {
+	it("does not activate for ineligible panes and preserves native status-like text", () => {
 		const scroll = vi.fn();
 		const ineligible = createMachine({ scroll });
 		ineligible.pointerDown(false);
 		expect(ineligible.pointerMove({ row: 0, col: 0 }, 50, 100, 400)).toBe(false);
 
-		const transient = createMachine({ native: "Thinking…\nscratch footer", scroll });
+		const transient = createMachine({
+			native: "Thinking…\nscratch footer",
+			scroll,
+			setInterval: () => 1 as unknown as ReturnType<typeof setInterval>,
+			clearInterval: vi.fn(),
+		});
 		transient.pointerDown(true);
-		expect(transient.pointerMove({ row: 0, col: 0 }, 50, 100, 400)).toBe(false);
+		expect(transient.pointerMove({ row: 0, col: 0 }, 50, 100, 400)).toBe(true);
+		expect(transient.getText()).toBe("Thinking…\nscratch footer");
 		expect(scroll).not.toHaveBeenCalled();
+		transient.pointerUp();
 	});
 
 	it("changes direction and speed while the pointer stays outside", () => {

--- a/frontend/src/renderer/lib/terminal-selection-autoscroll.ts
+++ b/frontend/src/renderer/lib/terminal-selection-autoscroll.ts
@@ -1,0 +1,554 @@
+export type TerminalSelectionPoint = { row: number; col: number };
+export type TerminalSelectionRange = { anchor: TerminalSelectionPoint; focus: TerminalSelectionPoint };
+export type NativeTerminalSelection = { text: string; range: TerminalSelectionRange };
+export type TerminalSelectionHighlight = { row: number; startCol: number; endCol: number };
+export type TerminalScreenRow = { text: string; cellOffsets?: number[]; selectable?: boolean; wrapped?: boolean };
+export type TerminalScreenSnapshot = { rows: Array<string | TerminalScreenRow> };
+export type TerminalLiveSelectionRender = { highlights: TerminalSelectionHighlight[] };
+
+const EDGE_MAX_DISTANCE_PX = 50;
+const EDGE_MAX_LINES = 15;
+export const SELECTION_SCROLL_INTERVAL_MS = 50;
+
+export function edgeScrollLines(pointerY: number, top: number, height: number): number {
+	let offset = pointerY - top;
+	if (offset >= 0 && offset <= height) return 0;
+	if (offset > height) offset -= height;
+	offset = Math.min(Math.max(offset, -EDGE_MAX_DISTANCE_PX), EDGE_MAX_DISTANCE_PX);
+	const normalized = offset / EDGE_MAX_DISTANCE_PX;
+	return Math.sign(normalized) + Math.round(normalized * (EDGE_MAX_LINES - 1));
+}
+
+function comparePoints(left: TerminalSelectionPoint, right: TerminalSelectionPoint): number {
+	return left.row === right.row ? left.col - right.col : left.row - right.row;
+}
+
+function screenRow(row: string | TerminalScreenRow): TerminalScreenRow {
+	return typeof row === "string" ? { text: row } : row;
+}
+
+function isTransientScreenText(text: string): boolean {
+	const trimmed = text.trim();
+	return /^[─━═_\-=]+$/u.test(trimmed) ||
+		/^(?:Pouncing|Thinking|Working|Generating|Loading|Update available|Jump to bottom)(?:…|\.\.\.|\b)/iu.test(trimmed) ||
+		/Paste again to expand for editing/iu.test(trimmed) ||
+		/^scratch(?:-\d+)? footer$/iu.test(trimmed) ||
+		/^[^·\n]+ · [^·\n]+ · (?:~|\/)\S+/u.test(trimmed);
+}
+
+type SelectableScreenRow = TerminalSelectionHighlight & { cellOffsets?: number[]; text: string; wrapped: boolean };
+
+function selectableRow(value: string | TerminalScreenRow, row: number): SelectableScreenRow | null {
+	const current = screenRow(value);
+	if (current.selectable === false || isTransientScreenText(current.text)) return null;
+	const trailing = current.text.match(/\s*$/u)?.[0].length ?? 0;
+	const textEnd = Math.max(0, current.text.length - trailing);
+	const endCol = current.cellOffsets?.findIndex((offset) => offset >= textEnd) ?? textEnd;
+	return {
+		row,
+		startCol: 0,
+		endCol: Math.max(0, endCol),
+		cellOffsets: current.cellOffsets,
+		text: current.text.slice(0, textEnd),
+		wrapped: current.wrapped === true,
+	};
+}
+
+function selectableScreenRows(snapshot: TerminalScreenSnapshot): SelectableScreenRow[] {
+	const rows = snapshot.rows.flatMap((value, row) => {
+		const selected = selectableRow(value, row);
+		return selected ? [selected] : [];
+	});
+	while (rows[0]?.text === "") rows.shift();
+	while (rows.at(-1)?.text === "") rows.pop();
+	return rows;
+}
+
+function cloneSnapshot(snapshot: TerminalScreenSnapshot): TerminalScreenSnapshot {
+	return { rows: snapshot.rows.map((value) => typeof value === "string" ? value : { ...value }) };
+}
+
+function rowKey(row: Pick<SelectableScreenRow, "text" | "wrapped">): string {
+	return `${row.wrapped ? "1" : "0"}:${row.text}`;
+}
+
+function longestPrefixOverlap(left: SelectableScreenRow[], right: SelectableScreenRow[]): number {
+	const maximum = Math.min(left.length, right.length);
+	for (let length = maximum; length > 0; length -= 1) {
+		if (left.slice(left.length - length).every((value, index) => rowKey(value) === rowKey(right[index]))) return length;
+	}
+	return 0;
+}
+
+function appendUnique(left: SelectableScreenRow[], right: SelectableScreenRow[]): SelectableScreenRow[] {
+	const overlap = longestPrefixOverlap(left, right);
+	return [...left, ...right.slice(overlap)];
+}
+
+function lastMatchingRowIndex(rows: SelectableScreenRow[], target: SelectableScreenRow): number {
+	for (let index = rows.length - 1; index >= 0; index -= 1) {
+		if (rowKey(rows[index]) === rowKey(target)) return index;
+	}
+	return -1;
+}
+
+function snapshotExtensionRows(
+	previous: TerminalScreenSnapshot,
+	next: TerminalScreenSnapshot,
+	direction: -1 | 1,
+): SelectableScreenRow[] {
+	const before = selectableScreenRows(previous);
+	const after = selectableScreenRows(next);
+	if (direction < 0) {
+		const overlap = longestPrefixOverlap(after, before);
+		return after.slice(0, after.length - overlap);
+	}
+	const overlap = longestPrefixOverlap(before, after);
+	return after.slice(overlap);
+}
+
+export function screenSnapshotExtension(
+	previous: TerminalScreenSnapshot,
+	next: TerminalScreenSnapshot,
+	direction: -1 | 1,
+): string[] {
+	return snapshotExtensionRows(previous, next, direction).map((row) => row.text);
+}
+
+function sameSnapshot(left: TerminalScreenSnapshot, right: TerminalScreenSnapshot): boolean {
+	if (left.rows.length !== right.rows.length) return false;
+	return left.rows.every((value, index) => {
+		const leftRow = screenRow(value);
+		const rightRow = screenRow(right.rows[index]);
+		return leftRow.text === rightRow.text && leftRow.selectable === rightRow.selectable && leftRow.wrapped === rightRow.wrapped;
+	});
+}
+
+function filteredNativeText(text: string): string {
+	return text.split("\n")
+		.filter((line) => line.trim().length === 0 || !isTransientScreenText(line))
+		.join("\n");
+}
+
+function textOffsetForCell(row: SelectableScreenRow, col: number): number {
+	if (!row.cellOffsets) return Math.min(row.text.length, Math.max(0, col));
+	const bounded = Math.min(row.cellOffsets.length - 1, Math.max(0, col));
+	return Math.min(row.text.length, row.cellOffsets[bounded] ?? row.text.length);
+}
+
+function joinedRows(rows: SelectableScreenRow[]): string {
+	let text = "";
+	for (const [index, row] of rows.entries()) {
+		if (index > 0 && !row.wrapped) text += "\n";
+		text += row.text.slice(textOffsetForCell(row, row.startCol), textOffsetForCell(row, row.endCol));
+	}
+	return text;
+}
+
+type TimerHandle = ReturnType<typeof setInterval>;
+
+export type TerminalSelectionAutoscrollOptions = {
+	readNativeSelection: () => NativeTerminalSelection | null;
+	readSnapshot: () => TerminalScreenSnapshot;
+	clearNativeSelection: () => void;
+	scroll: (direction: -1 | 1, lines: number) => void;
+	render: (state: TerminalLiveSelectionRender | null) => void;
+	setInterval?: (callback: () => void, ms: number) => TimerHandle;
+	clearInterval?: (handle: TimerHandle) => void;
+};
+
+export class TerminalSelectionAutoscroll {
+	private phase: "idle" | "native" | "active" | "complete" = "idle";
+	private edgeLines = 0;
+	private direction: -1 | 1 = 1;
+	private timer: TimerHandle | null = null;
+	private initialText = "";
+	private initialRows: SelectableScreenRow[] = [];
+	private initialHighlights: TerminalSelectionHighlight[] = [];
+	private initialStartsWrapped = false;
+	private baseInitialText = "";
+	private baseInitialRows: SelectableScreenRow[] = [];
+	private baseInitialHighlights: TerminalSelectionHighlight[] = [];
+	private baseInitialStartsWrapped = false;
+	private baseScreenRows: SelectableScreenRow[] = [];
+	private anchorPoint: TerminalSelectionPoint | null = null;
+	private prefix: SelectableScreenRow[] = [];
+	private suffix: SelectableScreenRow[] = [];
+	private previousSnapshot: TerminalScreenSnapshot | null = null;
+	private showInitialHighlights = false;
+	private insideFocus: TerminalSelectionPoint | null = null;
+	private trimmingToAnchor = false;
+
+	constructor(private readonly options: TerminalSelectionAutoscrollOptions) {}
+
+	pointerDown(eligible: boolean): void {
+		this.reset();
+		if (eligible) this.phase = "native";
+	}
+
+	pointerMove(point: TerminalSelectionPoint, pointerY: number, top: number, height: number): boolean {
+		if (this.phase === "idle" || this.phase === "complete") return false;
+		this.edgeLines = edgeScrollLines(pointerY, top, height);
+		if (this.phase === "native") {
+			if (this.edgeLines === 0) return false;
+			this.activate();
+			return this.isActive();
+		}
+		this.options.clearNativeSelection();
+		if (this.edgeLines === 0) {
+			this.stopTimer();
+			this.moveFocusInside(point);
+		} else {
+			const direction = Math.sign(this.edgeLines) as -1 | 1;
+			if (direction !== this.direction) {
+				this.trimmingToAnchor = true;
+				this.insideFocus = null;
+			}
+			this.direction = direction;
+			if (this.insideFocus && !this.trimmingToAnchor) {
+				this.fillVisibleGap(this.insideFocus, direction);
+				this.insideFocus = null;
+			}
+			this.startTimer();
+		}
+		return true;
+	}
+
+	pointerUp(): void {
+		if (this.phase === "native") {
+			this.phase = "idle";
+			return;
+		}
+		if (this.phase !== "active") return;
+		this.stopTimer();
+		this.phase = "complete";
+	}
+
+	screenRendered(): void {
+		if (this.phase !== "active") return;
+		const snapshot = this.options.readSnapshot();
+		if (this.previousSnapshot && !sameSnapshot(this.previousSnapshot, snapshot)) {
+			this.showInitialHighlights = false;
+			if (this.edgeLines !== 0) {
+				let extension = snapshotExtensionRows(this.previousSnapshot, snapshot, this.direction);
+				if (this.trimmingToAnchor && this.anchorPoint) {
+					const anchor = this.baseScreenRows.find((row) => row.row === this.anchorPoint?.row);
+					const visibleRows = selectableScreenRows(snapshot);
+					const anchorIndex = anchor ? visibleRows.findIndex((row) => rowKey(row) === rowKey(anchor)) : -1;
+					if (anchorIndex < 0) {
+						this.shrinkTowardAnchor(visibleRows, this.direction);
+						extension = [];
+					} else {
+						this.restoreSelectionAtAnchor(this.direction);
+						this.prefix = [];
+						this.suffix = [];
+						extension = this.direction < 0
+							? visibleRows.slice(0, anchorIndex)
+							: visibleRows.slice(anchorIndex + 1);
+						this.trimmingToAnchor = false;
+					}
+				}
+				if (this.direction < 0) this.prefix = appendUnique(extension, this.prefix);
+				else this.suffix = appendUnique(this.suffix, extension);
+			}
+		}
+		this.previousSnapshot = cloneSnapshot(snapshot);
+		this.render();
+	}
+
+	getText(): string {
+		if (this.phase !== "active" && this.phase !== "complete") return "";
+		const before = joinedRows(this.prefix);
+		const after = joinedRows(this.suffix);
+		let text = this.initialText;
+		if (this.prefix.length > 0) text = `${before}${text && !this.initialStartsWrapped ? "\n" : ""}${text}`;
+		if (this.suffix.length > 0) text = `${text}${text && !this.suffix[0]?.wrapped ? "\n" : ""}${after}`;
+		return text;
+	}
+
+	hasSelection(): boolean { return this.getText().length > 0; }
+	isActive(): boolean { return this.phase === "active"; }
+	blur(): void { this.reset(); }
+	dispose(): void { this.reset(); }
+
+	private activate(): void {
+		const nativeSelection = this.options.readNativeSelection();
+		if (!nativeSelection || nativeSelection.text.length === 0) return;
+		const initialText = filteredNativeText(nativeSelection.text);
+		if (initialText.length === 0) return;
+		const snapshot = this.options.readSnapshot();
+		const start = comparePoints(nativeSelection.range.anchor, nativeSelection.range.focus) <= 0
+			? nativeSelection.range.anchor
+			: nativeSelection.range.focus;
+		const end = start === nativeSelection.range.anchor ? nativeSelection.range.focus : nativeSelection.range.anchor;
+		this.baseScreenRows = selectableScreenRows(snapshot);
+		this.initialRows = this.baseScreenRows
+			.filter((row) => row.row >= start.row && row.row <= end.row)
+			.flatMap((row) => {
+				const startCol = row.row === start.row ? Math.max(row.startCol, start.col) : row.startCol;
+				const endCol = row.row === end.row ? Math.min(row.endCol, end.col) : row.endCol;
+				return endCol > startCol ? [{ ...row, startCol, endCol }] : [];
+			});
+		this.initialHighlights = this.initialRows.map(({ row, startCol, endCol }) => ({ row, startCol, endCol }));
+		this.initialStartsWrapped = screenRow(snapshot.rows[start.row] ?? "").wrapped === true;
+		this.initialText = initialText;
+		this.baseInitialText = this.initialText;
+		this.baseInitialRows = this.initialRows.map((row) => ({ ...row }));
+		this.baseInitialHighlights = this.initialHighlights.map((highlight) => ({ ...highlight }));
+		this.baseInitialStartsWrapped = this.initialStartsWrapped;
+		this.direction = Math.sign(this.edgeLines) as -1 | 1;
+		this.anchorPoint = this.direction > 0 ? { ...start } : { ...end };
+		this.previousSnapshot = cloneSnapshot(snapshot);
+		this.showInitialHighlights = true;
+		this.phase = "active";
+		this.options.clearNativeSelection();
+		this.render();
+		this.startTimer();
+	}
+
+	private moveFocusInside(point: TerminalSelectionPoint): void {
+		const current = selectableScreenRows(this.options.readSnapshot());
+		const target = current.find((row) => row.row === point.row);
+		if (!target) return;
+		this.insideFocus = point;
+		if (this.direction > 0) {
+			const index = lastMatchingRowIndex(this.suffix, target);
+			if (index >= 0) {
+				this.suffix = this.suffix.slice(0, index + 1);
+				const endCol = Math.min(target.endCol, Math.max(target.startCol, point.col));
+				if (endCol === target.startCol) this.suffix.pop();
+				else this.suffix[this.suffix.length - 1] = { ...this.suffix.at(-1)!, endCol };
+			} else {
+				const initialIndex = lastMatchingRowIndex(this.initialRows, target);
+				if (initialIndex >= 0) {
+					this.suffix = [];
+					this.initialRows = this.initialRows.slice(0, initialIndex + 1);
+					const endCol = Math.min(target.endCol, Math.max(target.startCol, point.col));
+					if (endCol === target.startCol) this.initialRows.pop();
+					else this.initialRows[this.initialRows.length - 1] = { ...this.initialRows.at(-1)!, endCol };
+					this.refreshInitialText();
+				}
+			}
+		} else {
+			const index = this.prefix.findIndex((row) => rowKey(row) === rowKey(target));
+			if (index >= 0) {
+				this.prefix = this.prefix.slice(index);
+				const startCol = Math.min(target.endCol, Math.max(target.startCol, point.col));
+				if (startCol === target.endCol) this.prefix.shift();
+				else this.prefix[0] = { ...this.prefix[0], startCol };
+			} else {
+				const initialIndex = this.initialRows.findIndex((row) => rowKey(row) === rowKey(target));
+				if (initialIndex >= 0) {
+					this.prefix = [];
+					this.initialRows = this.initialRows.slice(initialIndex);
+					const startCol = Math.min(target.endCol, Math.max(target.startCol, point.col));
+					if (startCol === target.endCol) this.initialRows.shift();
+					else this.initialRows[0] = { ...this.initialRows[0], startCol };
+					this.refreshInitialText();
+				}
+			}
+		}
+		this.previousSnapshot = cloneSnapshot(this.options.readSnapshot());
+		this.render();
+	}
+
+	private fillVisibleGap(point: TerminalSelectionPoint, direction: -1 | 1): void {
+		const current = selectableScreenRows(this.options.readSnapshot());
+		const targetIndex = current.findIndex((row) => row.row === point.row);
+		if (targetIndex < 0) return;
+		const target = current[targetIndex];
+		if (direction > 0) {
+			const suffixIndex = lastMatchingRowIndex(this.suffix, target);
+			if (suffixIndex >= 0) {
+				this.suffix = this.suffix.slice(0, suffixIndex + 1);
+				this.suffix[this.suffix.length - 1] = { ...this.suffix.at(-1)!, endCol: target.endCol };
+				this.suffix = appendUnique(this.suffix, current.slice(targetIndex + 1));
+			} else {
+				const baseIndex = lastMatchingRowIndex(this.baseInitialRows, target);
+				if (baseIndex >= 0) {
+					this.restoreInitialSelection();
+					this.initialRows[baseIndex] = { ...this.initialRows[baseIndex], endCol: target.endCol };
+					this.refreshInitialText();
+					const lastInitial = this.initialRows.at(-1);
+					const lastVisibleIndex = lastInitial
+						? lastMatchingRowIndex(current, lastInitial)
+						: targetIndex;
+					this.suffix = appendUnique(this.suffix, current.slice(lastVisibleIndex + 1));
+				} else {
+					this.suffix = appendUnique(this.suffix, current.slice(targetIndex + 1));
+				}
+			}
+		} else {
+			const prefixIndex = this.prefix.findIndex((row) => rowKey(row) === rowKey(target));
+			if (prefixIndex >= 0) {
+				this.prefix = this.prefix.slice(prefixIndex);
+				this.prefix[0] = { ...this.prefix[0], startCol: target.startCol };
+				this.prefix = appendUnique(current.slice(0, targetIndex), this.prefix);
+			} else {
+				const baseIndex = this.baseInitialRows.findIndex((row) => rowKey(row) === rowKey(target));
+				if (baseIndex >= 0) {
+					this.restoreInitialSelection();
+					this.initialRows[baseIndex] = { ...this.initialRows[baseIndex], startCol: target.startCol };
+					this.refreshInitialText();
+					const firstInitial = this.initialRows[0];
+					const firstVisibleIndex = firstInitial
+						? current.findIndex((row) => rowKey(row) === rowKey(firstInitial))
+						: targetIndex;
+					this.prefix = appendUnique(current.slice(0, Math.max(0, firstVisibleIndex)), this.prefix);
+				} else {
+					this.prefix = appendUnique(current.slice(0, targetIndex), this.prefix);
+				}
+			}
+		}
+		this.previousSnapshot = cloneSnapshot(this.options.readSnapshot());
+		this.render();
+	}
+
+	private restoreInitialSelection(): void {
+		this.initialText = this.baseInitialText;
+		this.initialRows = this.baseInitialRows.map((row) => ({ ...row }));
+		this.initialHighlights = this.baseInitialHighlights.map((highlight) => ({ ...highlight }));
+		this.initialStartsWrapped = this.baseInitialStartsWrapped;
+	}
+
+	private restoreSelectionAtAnchor(direction: -1 | 1): void {
+		const anchor = this.anchorPoint;
+		const row = anchor ? this.baseScreenRows.find((candidate) => candidate.row === anchor.row) : undefined;
+		if (!anchor || !row) {
+			this.initialText = "";
+			this.initialRows = [];
+			this.initialHighlights = [];
+			return;
+		}
+		const selected = direction < 0
+			? { ...row, endCol: Math.min(row.endCol, Math.max(row.startCol, anchor.col)) }
+			: { ...row, startCol: Math.min(row.endCol, Math.max(row.startCol, anchor.col)) };
+		this.initialRows = selected.endCol > selected.startCol ? [selected] : [];
+		this.refreshInitialText();
+	}
+
+	private shrinkTowardAnchor(visibleRows: SelectableScreenRow[], direction: -1 | 1): void {
+		if (direction < 0) {
+			const target = visibleRows[0];
+			if (!target) return;
+			const baseIndex = lastMatchingRowIndex(this.baseInitialRows, target);
+			if (baseIndex >= 0) {
+				this.restoreInitialSelection();
+				this.initialRows = this.initialRows.slice(0, baseIndex + 1);
+				const endCol = target.startCol;
+				if (endCol === target.startCol) this.initialRows.pop();
+				else this.initialRows[this.initialRows.length - 1] = { ...this.initialRows.at(-1)!, endCol };
+				this.suffix = [];
+				this.refreshInitialText();
+				return;
+			}
+			const suffixIndex = lastMatchingRowIndex(this.suffix, target);
+			if (suffixIndex >= 0) {
+				this.restoreInitialSelection();
+				this.suffix = this.suffix.slice(0, suffixIndex + 1);
+				const endCol = target.startCol;
+				if (endCol === target.startCol) this.suffix.pop();
+				else this.suffix[this.suffix.length - 1] = { ...this.suffix.at(-1)!, endCol };
+				return;
+			}
+			return;
+		}
+
+		const target = visibleRows.at(-1);
+		if (!target) return;
+		const baseIndex = this.baseInitialRows.findIndex((row) => rowKey(row) === rowKey(target));
+		if (baseIndex >= 0) {
+			this.restoreInitialSelection();
+			this.initialRows = this.initialRows.slice(baseIndex);
+			const startCol = target.endCol;
+			if (startCol === target.endCol) this.initialRows.shift();
+			else this.initialRows[0] = { ...this.initialRows[0], startCol };
+			this.prefix = [];
+			this.refreshInitialText();
+			return;
+		}
+		const prefixIndex = this.prefix.findIndex((row) => rowKey(row) === rowKey(target));
+		if (prefixIndex >= 0) {
+			this.restoreInitialSelection();
+			this.prefix = this.prefix.slice(prefixIndex);
+			const startCol = target.endCol;
+			if (startCol === target.endCol) this.prefix.shift();
+			else this.prefix[0] = { ...this.prefix[0], startCol };
+			return;
+		}
+	}
+
+	private refreshInitialText(): void {
+		this.initialText = joinedRows(this.initialRows);
+		this.initialStartsWrapped = this.initialRows[0]?.wrapped === true;
+		this.initialHighlights = this.initialRows.map(({ row, startCol, endCol }) => ({ row, startCol, endCol }));
+	}
+
+	private startTimer(): void {
+		if (this.timer !== null || this.edgeLines === 0 || this.phase !== "active") return;
+		const setTimer = this.options.setInterval ?? setInterval;
+		this.timer = setTimer(() => this.tick(), SELECTION_SCROLL_INTERVAL_MS);
+	}
+
+	private tick(): void {
+		if (this.phase !== "active" || this.edgeLines === 0) return;
+		this.direction = Math.sign(this.edgeLines) as -1 | 1;
+		this.options.scroll(this.direction, Math.abs(this.edgeLines));
+	}
+
+	private render(): void {
+		if (this.phase !== "active" && this.phase !== "complete") return;
+		if (this.showInitialHighlights) {
+			this.options.render({ highlights: this.initialHighlights });
+			return;
+		}
+		const selectedRows = new Map<string, SelectableScreenRow[]>();
+		for (const row of [...this.prefix, ...this.initialRows, ...this.suffix]) {
+			const key = rowKey(row);
+			const matches = selectedRows.get(key) ?? [];
+			matches.push(row);
+			selectedRows.set(key, matches);
+		}
+		const highlights = selectableScreenRows(this.previousSnapshot ?? this.options.readSnapshot()).flatMap((row) => {
+			const key = rowKey(row);
+			const selected = selectedRows.get(key)?.shift();
+			if (!selected) return [];
+			const highlight = {
+				row: row.row,
+				startCol: Math.max(row.startCol, selected.startCol),
+				endCol: Math.min(row.endCol, selected.endCol),
+			};
+			return highlight.endCol > highlight.startCol ? [highlight] : [];
+		});
+		this.options.render({ highlights });
+	}
+
+	private stopTimer(): void {
+		if (this.timer === null) return;
+		(this.options.clearInterval ?? clearInterval)(this.timer);
+		this.timer = null;
+	}
+
+	private reset(): void {
+		this.stopTimer();
+		this.phase = "idle";
+		this.edgeLines = 0;
+		this.initialText = "";
+		this.initialRows = [];
+		this.initialHighlights = [];
+		this.initialStartsWrapped = false;
+		this.baseInitialText = "";
+		this.baseInitialRows = [];
+		this.baseInitialHighlights = [];
+		this.baseInitialStartsWrapped = false;
+		this.baseScreenRows = [];
+		this.anchorPoint = null;
+		this.prefix = [];
+		this.suffix = [];
+		this.previousSnapshot = null;
+		this.showInitialHighlights = false;
+		this.insideFocus = null;
+		this.trimmingToAnchor = false;
+		this.options.render(null);
+	}
+}

--- a/frontend/src/renderer/lib/terminal-selection-autoscroll.ts
+++ b/frontend/src/renderer/lib/terminal-selection-autoscroll.ts
@@ -2,7 +2,13 @@ export type TerminalSelectionPoint = { row: number; col: number };
 export type TerminalSelectionRange = { anchor: TerminalSelectionPoint; focus: TerminalSelectionPoint };
 export type NativeTerminalSelection = { text: string; range: TerminalSelectionRange };
 export type TerminalSelectionHighlight = { row: number; startCol: number; endCol: number };
-export type TerminalScreenRow = { text: string; cellOffsets?: number[]; selectable?: boolean; wrapped?: boolean };
+export type TerminalScreenRow = {
+	text: string;
+	cellOffsets?: number[];
+	endCol?: number;
+	selectable?: boolean;
+	wrapped?: boolean;
+};
 export type TerminalScreenSnapshot = { rows: Array<string | TerminalScreenRow> };
 export type TerminalLiveSelectionRender = { highlights: TerminalSelectionHighlight[] };
 
@@ -27,23 +33,24 @@ function screenRow(row: string | TerminalScreenRow): TerminalScreenRow {
 	return typeof row === "string" ? { text: row } : row;
 }
 
-function isTransientScreenText(text: string): boolean {
+export function isTerminalSelectionChrome(text: string, allTextIsDim: boolean): boolean {
 	const trimmed = text.trim();
-	return /^[─━═_\-=]+$/u.test(trimmed) ||
-		/^(?:Pouncing|Thinking|Working|Generating|Loading|Update available|Jump to bottom)(?:…|\.\.\.|\b)/iu.test(trimmed) ||
-		/Paste again to expand for editing/iu.test(trimmed) ||
+	if (/Paste again to expand for editing/iu.test(trimmed) ||
 		/^scratch(?:-\d+)? footer$/iu.test(trimmed) ||
-		/^[^·\n]+ · [^·\n]+ · (?:~|\/)\S+/u.test(trimmed);
+		/^[^·\n]+ · [^·\n]+ · (?:~|\/)\S+/u.test(trimmed)) return true;
+	if (!allTextIsDim) return false;
+	return /^[─━═]+$/u.test(trimmed) ||
+		/^(?:Pouncing|Thinking|Working|Generating|Loading|Update available|Jump to bottom)(?:…|\.\.\.)?$/iu.test(trimmed);
 }
 
 type SelectableScreenRow = TerminalSelectionHighlight & { cellOffsets?: number[]; text: string; wrapped: boolean };
 
 function selectableRow(value: string | TerminalScreenRow, row: number): SelectableScreenRow | null {
 	const current = screenRow(value);
-	if (current.selectable === false || isTransientScreenText(current.text)) return null;
+	if (current.selectable === false) return null;
 	const trailing = current.text.match(/\s*$/u)?.[0].length ?? 0;
 	const textEnd = Math.max(0, current.text.length - trailing);
-	const endCol = current.cellOffsets?.findIndex((offset) => offset >= textEnd) ?? textEnd;
+	const endCol = current.endCol ?? current.cellOffsets?.findIndex((offset) => offset >= textEnd) ?? textEnd;
 	return {
 		row,
 		startCol: 0,
@@ -96,15 +103,30 @@ function snapshotExtensionRows(
 	previous: TerminalScreenSnapshot,
 	next: TerminalScreenSnapshot,
 	direction: -1 | 1,
+	allowNoOverlap = false,
 ): SelectableScreenRow[] {
 	const before = selectableScreenRows(previous);
 	const after = selectableScreenRows(next);
 	if (direction < 0) {
 		const overlap = longestPrefixOverlap(after, before);
-		return after.slice(0, after.length - overlap);
+		if (overlap === 0 && before.length > 0 && after.length > 0) return allowNoOverlap ? after : [];
+		const extension = after.slice(0, after.length - overlap);
+		const previousEdge = screenRow(previous.rows[0] ?? "").text;
+		const nextEdge = screenRow(next.rows[0] ?? "").text;
+		if (extension.length === 0 && previousEdge !== "" && nextEdge === "") {
+			return [{ row: 0, startCol: 0, endCol: 0, text: "", wrapped: false }];
+		}
+		return extension;
 	}
 	const overlap = longestPrefixOverlap(before, after);
-	return after.slice(overlap);
+	if (overlap === 0 && before.length > 0 && after.length > 0) return allowNoOverlap ? after : [];
+	const extension = after.slice(overlap);
+	const previousEdge = screenRow(previous.rows.at(-1) ?? "").text;
+	const nextEdge = screenRow(next.rows.at(-1) ?? "").text;
+	if (extension.length === 0 && previousEdge !== "" && nextEdge === "") {
+		return [{ row: Math.max(0, next.rows.length - 1), startCol: 0, endCol: 0, text: "", wrapped: false }];
+	}
+	return extension;
 }
 
 export function screenSnapshotExtension(
@@ -120,14 +142,11 @@ function sameSnapshot(left: TerminalScreenSnapshot, right: TerminalScreenSnapsho
 	return left.rows.every((value, index) => {
 		const leftRow = screenRow(value);
 		const rightRow = screenRow(right.rows[index]);
-		return leftRow.text === rightRow.text && leftRow.selectable === rightRow.selectable && leftRow.wrapped === rightRow.wrapped;
+		return leftRow.text === rightRow.text &&
+			leftRow.endCol === rightRow.endCol &&
+			leftRow.selectable === rightRow.selectable &&
+			leftRow.wrapped === rightRow.wrapped;
 	});
-}
-
-function filteredNativeText(text: string): string {
-	return text.split("\n")
-		.filter((line) => line.trim().length === 0 || !isTransientScreenText(line))
-		.join("\n");
 }
 
 function textOffsetForCell(row: SelectableScreenRow, col: number): number {
@@ -151,7 +170,7 @@ export type TerminalSelectionAutoscrollOptions = {
 	readNativeSelection: () => NativeTerminalSelection | null;
 	readSnapshot: () => TerminalScreenSnapshot;
 	clearNativeSelection: () => void;
-	scroll: (direction: -1 | 1, lines: number) => void;
+	scroll: (direction: -1 | 1, lines: number) => boolean | void;
 	render: (state: TerminalLiveSelectionRender | null) => void;
 	setInterval?: (callback: () => void, ms: number) => TimerHandle;
 	clearInterval?: (handle: TimerHandle) => void;
@@ -178,6 +197,7 @@ export class TerminalSelectionAutoscroll {
 	private showInitialHighlights = false;
 	private insideFocus: TerminalSelectionPoint | null = null;
 	private trimmingToAnchor = false;
+	private scrollRequested = false;
 
 	constructor(private readonly options: TerminalSelectionAutoscrollOptions) {}
 
@@ -225,12 +245,17 @@ export class TerminalSelectionAutoscroll {
 	}
 
 	screenRendered(): void {
+		if (this.phase === "complete") {
+			this.previousSnapshot = cloneSnapshot(this.options.readSnapshot());
+			this.render();
+			return;
+		}
 		if (this.phase !== "active") return;
 		const snapshot = this.options.readSnapshot();
 		if (this.previousSnapshot && !sameSnapshot(this.previousSnapshot, snapshot)) {
 			this.showInitialHighlights = false;
 			if (this.edgeLines !== 0) {
-				let extension = snapshotExtensionRows(this.previousSnapshot, snapshot, this.direction);
+				let extension = snapshotExtensionRows(this.previousSnapshot, snapshot, this.direction, this.scrollRequested);
 				if (this.trimmingToAnchor && this.anchorPoint) {
 					const anchor = this.baseScreenRows.find((row) => row.row === this.anchorPoint?.row);
 					const visibleRows = selectableScreenRows(snapshot);
@@ -252,6 +277,7 @@ export class TerminalSelectionAutoscroll {
 				else this.suffix = appendUnique(this.suffix, extension);
 			}
 		}
+		this.scrollRequested = false;
 		this.previousSnapshot = cloneSnapshot(snapshot);
 		this.render();
 	}
@@ -274,8 +300,7 @@ export class TerminalSelectionAutoscroll {
 	private activate(): void {
 		const nativeSelection = this.options.readNativeSelection();
 		if (!nativeSelection || nativeSelection.text.length === 0) return;
-		const initialText = filteredNativeText(nativeSelection.text);
-		if (initialText.length === 0) return;
+		const initialText = nativeSelection.text;
 		const snapshot = this.options.readSnapshot();
 		const start = comparePoints(nativeSelection.range.anchor, nativeSelection.range.focus) <= 0
 			? nativeSelection.range.anchor
@@ -308,9 +333,34 @@ export class TerminalSelectionAutoscroll {
 
 	private moveFocusInside(point: TerminalSelectionPoint): void {
 		const current = selectableScreenRows(this.options.readSnapshot());
-		const target = current.find((row) => row.row === point.row);
+		const targetIndex = current.findIndex((row) => row.row === point.row);
+		const target = current[targetIndex];
 		if (!target) return;
 		this.insideFocus = point;
+		if (this.trimmingToAnchor && this.anchorPoint) {
+			const baseAnchorIndex = this.baseInitialRows.findIndex((row) => row.row === this.anchorPoint?.row);
+			const knownRows = [...this.prefix, ...this.baseInitialRows, ...this.suffix];
+			const anchorIndex = baseAnchorIndex < 0 ? -1 : this.prefix.length + baseAnchorIndex;
+			let knownTargetIndex = this.prefix.findIndex((row) => rowKey(row) === rowKey(target));
+			if (knownTargetIndex < 0) {
+				const baseTargetIndex = this.baseInitialRows.findIndex((row) => rowKey(row) === rowKey(target));
+				if (baseTargetIndex >= 0) knownTargetIndex = this.prefix.length + baseTargetIndex;
+			}
+			if (knownTargetIndex < 0) {
+				const suffixTargetIndex = lastMatchingRowIndex(this.suffix, target);
+				if (suffixTargetIndex >= 0) {
+					knownTargetIndex = this.prefix.length + this.baseInitialRows.length + suffixTargetIndex;
+				}
+			}
+			if (anchorIndex >= 0 && knownTargetIndex >= 0) {
+				this.selectKnownRange(knownRows, anchorIndex, knownTargetIndex, point);
+				this.direction = knownTargetIndex < anchorIndex ? -1 : 1;
+				this.trimmingToAnchor = false;
+				this.previousSnapshot = cloneSnapshot(this.options.readSnapshot());
+				this.render();
+				return;
+			}
+		}
 		if (this.direction > 0) {
 			const index = lastMatchingRowIndex(this.suffix, target);
 			if (index >= 0) {
@@ -348,8 +398,44 @@ export class TerminalSelectionAutoscroll {
 				}
 			}
 		}
+		this.trimmingToAnchor = false;
 		this.previousSnapshot = cloneSnapshot(this.options.readSnapshot());
 		this.render();
+	}
+
+	private selectKnownRange(
+		rows: SelectableScreenRow[],
+		anchorIndex: number,
+		focusIndex: number,
+		focus: TerminalSelectionPoint,
+	): void {
+		const anchor = this.anchorPoint;
+		if (!anchor) return;
+		const firstIndex = Math.min(anchorIndex, focusIndex);
+		const lastIndex = Math.max(anchorIndex, focusIndex);
+		const selected = rows.slice(firstIndex, lastIndex + 1).map((row) => ({ ...row }));
+		if (selected.length === 0) return;
+		if (anchorIndex === focusIndex) {
+			selected[0].startCol = Math.min(anchor.col, focus.col);
+			selected[0].endCol = Math.max(anchor.col, focus.col);
+		} else if (anchorIndex < focusIndex) {
+			selected[0].startCol = Math.min(selected[0].endCol, Math.max(selected[0].startCol, anchor.col));
+			selected[selected.length - 1].endCol = Math.min(
+				selected[selected.length - 1].endCol,
+				Math.max(selected[selected.length - 1].startCol, focus.col),
+			);
+		} else {
+			selected[0].startCol = Math.min(selected[0].endCol, Math.max(selected[0].startCol, focus.col));
+			selected[selected.length - 1].endCol = Math.min(
+				selected[selected.length - 1].endCol,
+				Math.max(selected[selected.length - 1].startCol, anchor.col),
+			);
+		}
+		this.prefix = [];
+		this.suffix = [];
+		this.initialRows = selected.filter((row) => row.endCol > row.startCol);
+		this.showInitialHighlights = false;
+		this.refreshInitialText();
 	}
 
 	private fillVisibleGap(point: TerminalSelectionPoint, direction: -1 | 1): void {
@@ -493,7 +579,7 @@ export class TerminalSelectionAutoscroll {
 	private tick(): void {
 		if (this.phase !== "active" || this.edgeLines === 0) return;
 		this.direction = Math.sign(this.edgeLines) as -1 | 1;
-		this.options.scroll(this.direction, Math.abs(this.edgeLines));
+		this.scrollRequested = this.options.scroll(this.direction, Math.abs(this.edgeLines)) !== false;
 	}
 
 	private render(): void {
@@ -549,6 +635,7 @@ export class TerminalSelectionAutoscroll {
 		this.showInitialHighlights = false;
 		this.insideFocus = null;
 		this.trimmingToAnchor = false;
+		this.scrollRequested = false;
 		this.options.render(null);
 	}
 }


### PR DESCRIPTION
Fixes #4265

## What changed

Dragging a text selection past the top or bottom of a live terminal now scrolls the terminal and extends the selection.

Copy returns the full selected text. Normal selection, scrolling, keyboard input, paste, file drop, and TUI mouse input stay unchanged.

## Testing

- [x] 104 focused terminal tests
- [x] Frontend typecheck
- [x] Frontend build
- [x] Independent Claude and Sol reviews
- [x] GitHub CI
- [x] Manual live-terminal verification
