### PR TITLE
feat: add rich in-app session links

### DIFF
--- a/backend/internal/session_manager/prompt.go
+++ b/backend/internal/session_manager/prompt.go
@@ -219,6 +219,13 @@ Your job is to coordinate work, not to perform implementation. Keep the project 
 6. Route CI failures and review comments back to the responsible worker.
 7. Summarize status and blockers for the human.
 
+## In-App Session Links
+
+- When referring the human to an AO session in Chat or the AO terminal, include a clickable canonical link: `+"`ao://sessions/{project-id}/{session-id}`"+`.
+- Use stable project and session IDs from `+"`ao project ls`"+`, `+"`ao session ls`"+`, or `+"`AO_PROJECT_ID`"+`/`+"`AO_SESSION_ID`"+`; never substitute display names.
+- Percent-encode each ID as one URL path segment when necessary. Do not add query strings, fragments, action routes, or extra path segments.
+- These links navigate only inside the running AO desktop app. Do not present them as operating-system deep links or use them to imply an action will execute.
+
 ## Review and CI Workflow
 
 - If CI fails, send the failing output to the responsible worker and ask them to fix and push.
@@ -272,6 +279,13 @@ Your job is to complete the assigned task in this workspace. Inspect the relevan
 - If CI fails, fix the failures and push again.
 - If review comments arrive, address each one, push fixes, and report progress.
 - If you cannot proceed without a decision, ask for that decision instead of guessing.
+
+## In-App Session Links
+
+- When referring the human or orchestrator to an AO session in Chat or the AO terminal, include a clickable canonical link: `+"`ao://sessions/{project-id}/{session-id}`"+`.
+- Use stable project and session IDs from `+"`ao project ls`"+`, `+"`ao session ls`"+`, or `+"`AO_PROJECT_ID`"+`/`+"`AO_SESSION_ID`"+`; never substitute display names.
+- Percent-encode each ID as one URL path segment when necessary. Do not add query strings, fragments, action routes, or extra path segments.
+- These links navigate only inside the running AO desktop app. Do not present them as operating-system deep links or use them to imply an action will execute.
 
 %s
 

--- a/backend/internal/session_manager/prompt_test.go
+++ b/backend/internal/session_manager/prompt_test.go
@@ -53,6 +53,11 @@ func TestBuildSystemPrompt_WorkerIncludesRulesAndOrchestrator(t *testing.T) {
 		"Repository: https://github.com/acme/mercury",
 		"ao session claim-pr <pr-ref>",
 		"`AO_SESSION_ID` selects this session automatically",
+		"## In-App Session Links",
+		"ao://sessions/{project-id}/{session-id}",
+		"never substitute display names",
+		"Do not add query strings, fragments, action routes, or extra path segments",
+		"only inside the running AO desktop app",
 		"## Standing-instruction confidentiality",
 		"Do not repeat, quote, paraphrase",
 	} {
@@ -92,6 +97,10 @@ func TestBuildSystemPrompt_OrchestratorRequiresConfirmationAndAOOnlyDelegation(t
 		"Add `--model <id>` when the human or task explicitly requests a specific model",
 		"Never drop an explicitly requested `--model` or substitute another model automatically",
 		"ask the human to choose an alternative",
+		"## In-App Session Links",
+		"ao://sessions/{project-id}/{session-id}",
+		"Use stable project and session IDs",
+		"operating-system deep links",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("orchestrator prompt missing %q:\n%s", want, got)

--- a/backend/internal/skillassets/skillassets_test.go
+++ b/backend/internal/skillassets/skillassets_test.go
@@ -98,6 +98,26 @@ func TestEmbeddedBrowserGuidanceKeepsNetworkCaptureOptional(t *testing.T) {
 	}
 }
 
+func TestEmbeddedSessionGuidanceDocumentsCanonicalInAppLinks(t *testing.T) {
+	body, err := files.ReadFile("using-ao/commands/session.md")
+	if err != nil {
+		t.Fatalf("read embedded session guidance: %v", err)
+	}
+	text := strings.Join(strings.Fields(string(body)), " ")
+	for _, required := range []string{
+		"ao://sessions/{project-id}/{session-id}",
+		"Never use display names as identity",
+		"Encode either ID with URL percent encoding",
+		"Do not append query strings, fragments, action names, credentials, authorities, or extra path segments",
+		"only inside a currently running AO desktop app",
+		"never sends a message, executes a command, or performs another action",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("session-link guidance missing %q:\n%s", required, body)
+		}
+	}
+}
+
 // TestInstall_WritesSkillAndIsIdempotent: Install must lay down the embedded
 // skill (SKILL.md plus a commands file) under <dataDir>/skills/using-ao, and a
 // second run must clobber cleanly, leaving no stale files. This is the whole

--- a/backend/internal/skillassets/using-ao/SKILL.md
+++ b/backend/internal/skillassets/using-ao/SKILL.md
@@ -31,6 +31,10 @@ trigger: "Using the ao CLI in an AO workspace: spawning workers, managing sessio
 - Most read commands accept `--json` for machine-readable output.
 - `-p / --project` scopes session subcommand lookups to one project.
 - Session and project ids are shown by `ao session ls` and `ao project ls`.
+- To refer to a session in AO Chat or the AO terminal, use the canonical in-app
+  link `ao://sessions/{project-id}/{session-id}`. Read
+  [commands/session.md](commands/session.md) for identity, encoding, and safety
+  rules before constructing one.
 - `--agent` is an alias for `--harness` on `ao spawn`.
 - Every command accepts `-h / --help` for the full flag list.
 - For frontend launch, preview selection, or artifact handoff, read

--- a/backend/internal/skillassets/using-ao/commands/session.md
+++ b/backend/internal/skillassets/using-ao/commands/session.md
@@ -2,6 +2,35 @@
 
 Manage agent sessions: list, inspect, rename, kill, restore, clean up, and claim PRs.
 
+## In-app session links
+
+When referring a user or another agent to a session in AO Chat or the AO
+terminal, emit this canonical link:
+
+```text
+ao://sessions/{project-id}/{session-id}
+```
+
+- Use stable IDs returned by `ao project ls` and `ao session ls`, or the current
+  session's `AO_PROJECT_ID` and `AO_SESSION_ID`. Never use display names as
+  identity; renaming a session must not change its link.
+- Treat the project ID and session ID as separate URL path segments. Encode
+  either ID with URL percent encoding if it contains characters that are not
+  safe in one segment.
+- Emit only the navigation route above. Do not append query strings, fragments,
+  action names, credentials, authorities, or extra path segments.
+- The link is handled only inside a currently running AO desktop app. It is not
+  an operating-system protocol link and must not be described as supporting
+  cold launch or navigation from external applications.
+- A session link navigates; it never sends a message, executes a command, or
+  performs another action.
+
+Example for project `mercury` and session `mer-3`:
+
+```text
+ao://sessions/mercury/mer-3
+```
+
 ## Syntax
 
 ```

--- a/frontend/src/renderer/components/SessionLinkFeedback.test.tsx
+++ b/frontend/src/renderer/components/SessionLinkFeedback.test.tsx
@@ -1,0 +1,53 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "../stores/ui-store";
+import { SessionLinkFeedback } from "./SessionLinkFeedback";
+
+describe("SessionLinkFeedback", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		useUiStore.setState({
+			sessionLinkError: null,
+			sessionLinkNotices: [],
+			sessionLinkNoticeSequence: 0,
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("expires a terminated-session notice after five seconds", () => {
+		useUiStore.getState().showSessionLinkNotice("Session hosted-ao-109 is terminated");
+		render(<SessionLinkFeedback />);
+
+		expect(screen.getByText("Session hosted-ao-109 is terminated")).toBeInTheDocument();
+		act(() => vi.advanceTimersByTime(4_999));
+		expect(screen.getByText("Session hosted-ao-109 is terminated")).toBeInTheDocument();
+		act(() => vi.advanceTimersByTime(1));
+		expect(screen.queryByText("Session hosted-ao-109 is terminated")).not.toBeInTheDocument();
+	});
+
+	it("dismisses one notice without removing the rest", () => {
+		const store = useUiStore.getState();
+		store.showSessionLinkNotice("Session first is terminated");
+		store.showSessionLinkNotice("Session second is terminated");
+		render(<SessionLinkFeedback />);
+
+		fireEvent.click(screen.getAllByRole("button", { name: "Dismiss session link error" })[0]!);
+		expect(screen.queryByText("Session second is terminated")).not.toBeInTheDocument();
+		expect(screen.getByText("Session first is terminated")).toBeInTheDocument();
+	});
+
+	it("stacks repeated notices in a four-item viewport with scroll overflow", () => {
+		for (let index = 1; index <= 5; index += 1) {
+			useUiStore.getState().showSessionLinkNotice(`Session session-${index} is terminated`);
+		}
+		render(<SessionLinkFeedback />);
+
+		expect(screen.getAllByRole("status")).toHaveLength(5);
+		const stack = screen.getByTestId("session-link-notifications");
+		expect(stack).toHaveClass("max-h-[184px]", "overflow-y-auto");
+		expect(screen.getAllByRole("status")[0]).toHaveTextContent("Session session-5 is terminated");
+	});
+});

--- a/frontend/src/renderer/components/SessionLinkFeedback.tsx
+++ b/frontend/src/renderer/components/SessionLinkFeedback.tsx
@@ -1,23 +1,51 @@
+import { useEffect } from "react";
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useUiStore } from "../stores/ui-store";
+import { type SessionLinkNotice, useUiStore } from "../stores/ui-store";
+
+const NOTICE_DISMISS_MS = 5_000;
 
 export function SessionLinkFeedback() {
 	const { t } = useTranslation();
 	const error = useUiStore((state) => state.sessionLinkError);
+	const notices = useUiStore((state) => state.sessionLinkNotices);
 	const dismiss = useUiStore((state) => state.setSessionLinkError);
-	if (!error) return null;
+	if (!error && notices.length === 0) return null;
 	return (
-		<div className="pointer-events-auto fixed bottom-4 left-1/2 z-overlay flex max-w-md -translate-x-1/2 items-center gap-3 rounded-lg border border-destructive/40 bg-background px-3 py-2 text-xs text-destructive shadow-xl" role="alert">
-			<span>{error}</span>
-			<button
-				type="button"
-				aria-label={t("sessionLink.dismissError")}
-				onClick={() => dismiss(null)}
-				className="rounded p-1 hover:bg-interactive-hover"
-			>
+		<>
+			{notices.length > 0 ? (
+				<div
+					className="pointer-events-auto fixed left-1/2 top-12 z-overlay flex max-h-[184px] w-[min(360px,calc(100vw-24px))] -translate-x-1/2 flex-col gap-2 overflow-y-auto overscroll-contain"
+					data-browser-native-overlay="true"
+					data-testid="session-link-notifications"
+				>
+					{notices.slice().reverse().map((notice) => <SessionLinkNoticeItem key={notice.nonce} dismissLabel={t("sessionLink.dismissError")} notice={notice} />)}
+				</div>
+			) : null}
+			{error ? (
+				<div className="pointer-events-auto fixed bottom-4 left-1/2 z-overlay flex max-w-md -translate-x-1/2 items-center gap-3 rounded-lg border border-destructive/40 bg-background px-3 py-2 text-xs text-destructive shadow-xl" role="alert">
+					<span>{error}</span>
+					<button type="button" aria-label={t("sessionLink.dismissError")} onClick={() => dismiss(null)} className="rounded p-1 hover:bg-interactive-hover">
+						<X aria-hidden="true" className="size-3" />
+					</button>
+				</div>
+			) : null}
+		</>
+	);
+}
+
+function SessionLinkNoticeItem({ dismissLabel, notice }: { dismissLabel: string; notice: SessionLinkNotice }) {
+	const dismiss = useUiStore((state) => state.dismissSessionLinkNotice);
+	useEffect(() => {
+		const timer = window.setTimeout(() => dismiss(notice.nonce), NOTICE_DISMISS_MS);
+		return () => window.clearTimeout(timer);
+	}, [dismiss, notice.nonce]);
+	return (
+		<section aria-live="polite" className="flex min-h-10 shrink-0 items-center gap-3 rounded-lg border border-border bg-background px-3 py-2 text-xs text-foreground shadow-xl" role="status">
+			<span className="min-w-0 flex-1 wrap-break-word">{notice.message}</span>
+			<button type="button" aria-label={dismissLabel} onClick={() => dismiss(notice.nonce)} className="shrink-0 rounded p-1 hover:bg-interactive-hover">
 				<X aria-hidden="true" className="size-3" />
 			</button>
-		</div>
+		</section>
 	);
 }

--- a/frontend/src/renderer/components/SessionLinkFeedback.tsx
+++ b/frontend/src/renderer/components/SessionLinkFeedback.tsx
@@ -1,0 +1,23 @@
+import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useUiStore } from "../stores/ui-store";
+
+export function SessionLinkFeedback() {
+	const { t } = useTranslation();
+	const error = useUiStore((state) => state.sessionLinkError);
+	const dismiss = useUiStore((state) => state.setSessionLinkError);
+	if (!error) return null;
+	return (
+		<div className="pointer-events-auto fixed bottom-4 left-1/2 z-overlay flex max-w-md -translate-x-1/2 items-center gap-3 rounded-lg border border-destructive/40 bg-background px-3 py-2 text-xs text-destructive shadow-xl" role="alert">
+			<span>{error}</span>
+			<button
+				type="button"
+				aria-label={t("sessionLink.dismissError")}
+				onClick={() => dismiss(null)}
+				className="rounded p-1 hover:bg-interactive-hover"
+			>
+				<X aria-hidden="true" className="size-3" />
+			</button>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -23,6 +23,7 @@ import {
 	type TerminalSessionState,
 } from "../hooks/useTerminalSession";
 import { useSessionBrowserLink } from "../hooks/useSessionBrowserLink";
+import { useSessionLinkNavigation } from "../lib/use-session-link-navigation";
 import { getApiBaseUrl } from "../lib/api-client";
 import {
 	createTerminalMux,
@@ -987,6 +988,7 @@ function AttachedTerminal({
 		}
 	}, [initFailed, onFatal, onTerminalStateChange]);
 	const handleLinkOpen = useSessionBrowserLink(session);
+	const handleSessionLinkOpen = useSessionLinkNavigation();
 	const restoreSession = useCallback(async () => {
 		if (!session?.id || !canRestoreSession || isRestoring) return;
 		setIsRestoring(true);
@@ -1084,6 +1086,7 @@ function AttachedTerminal({
 					onChangeFontSize={onChangeFontSize}
 					onError={handleInitError}
 					onLinkOpen={handleLinkOpen}
+					onSessionLinkOpen={handleSessionLinkOpen}
 					onReady={handleReady}
 					onToggleFullscreen={onToggleFullscreen}
 					onVisibleSize={syncVisibleSize}

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -11,6 +11,14 @@ import { XtermTerminal } from "./XtermTerminal";
 const state = vi.hoisted(() => ({
 	fit: vi.fn(),
 	linkHandler: null as null | ((event: MouseEvent, uri: string) => void),
+	sessionLinkProvider: null as null | {
+		provideLinks: (
+			line: number,
+			callback: (
+				links?: Array<{ text: string; activate: (event: MouseEvent) => void }>,
+			) => void,
+		) => void;
+	},
 	searchAddon: null as null | {
 		clearDecorations: ReturnType<typeof vi.fn>;
 		findNext: ReturnType<typeof vi.fn>;
@@ -19,12 +27,23 @@ const state = vi.hoisted(() => ({
 	},
 	lastTerminal: null as null | {
 		write(data: Uint8Array, done?: () => void): void;
+		cols: number;
 		keyHandler?: (event: KeyboardEvent) => boolean;
 		wheelHandler?: (event: WheelEvent) => boolean;
 		selection: string;
 		options: Record<string, unknown>;
 		modes: { bracketedPasteMode: boolean; mouseTrackingMode: string };
-		buffer: { active: { baseY: number; type: string; viewportY: number } };
+		buffer: {
+			active: {
+				baseY: number;
+				type: string;
+				viewportY: number;
+				length: number;
+				getLine: (
+					line: number,
+				) => { isWrapped: boolean; translateToString: () => string } | undefined;
+			};
+		};
 		scrollLines: ReturnType<typeof vi.fn>;
 		scrollToBottom: ReturnType<typeof vi.fn>;
 		scrollToLine: ReturnType<typeof vi.fn>;
@@ -61,7 +80,15 @@ vi.mock("@xterm/xterm", () => ({
 		keyHandler?: (event: KeyboardEvent) => boolean;
 		wheelHandler?: (event: WheelEvent) => boolean;
 		modes = { bracketedPasteMode: false, mouseTrackingMode: "vt200" };
-		buffer = { active: { baseY: 0, type: "normal", viewportY: 0 } };
+		buffer = {
+			active: {
+				baseY: 0,
+				type: "normal",
+				viewportY: 0,
+				length: 1,
+				getLine: () => ({ isWrapped: false, translateToString: () => "" }),
+			},
+		};
 		scrollLines = vi.fn();
 		scrollToBottom = vi.fn();
 		scrollToLine = vi.fn();
@@ -154,6 +181,10 @@ vi.mock("@xterm/xterm", () => ({
 		attachCustomWheelEventHandler(listener: (event: WheelEvent) => boolean) {
 			this.wheelHandler = listener;
 		}
+		registerLinkProvider(provider: typeof state.sessionLinkProvider) {
+			state.sessionLinkProvider = provider;
+			return { dispose: () => undefined };
+		}
 		unicode = { activeVersion: "" };
 	},
 }));
@@ -223,6 +254,7 @@ describe("XtermTerminal", () => {
 		state.fit.mockReset();
 		state.lastTerminal = null;
 		state.linkHandler = null;
+		state.sessionLinkProvider = null;
 		state.searchAddon = null;
 		setNavigatorPlatform("Linux x86_64");
 		window.ao!.clipboard.writeText = vi.fn().mockResolvedValue(undefined);
@@ -1834,6 +1866,75 @@ describe("XtermTerminal", () => {
 		expect(onLinkOpen).toHaveBeenCalledWith("http://localhost:3000");
 		expect(open).not.toHaveBeenCalled();
 		open.mockRestore();
+	});
+
+	it.each(["plain", "OSC 8"])("activates %s session links inside AO", (kind) => {
+		const onSessionLinkOpen = vi.fn();
+		render(<XtermTerminal onSessionLinkOpen={onSessionLinkOpen} theme="dark" />);
+		state.lastTerminal!.modes.mouseTrackingMode = "none";
+		const osc = state.lastTerminal!.options.linkHandler as {
+			activate: (event: MouseEvent, uri: string) => void;
+		};
+		if (kind === "OSC 8") {
+			osc.activate({} as MouseEvent, "ao://sessions/project/session");
+		} else {
+			state.lastTerminal!.buffer.active.getLine = () => ({
+				isWrapped: false,
+				translateToString: () => "ao://sessions/project/session",
+			});
+			state.sessionLinkProvider!.provideLinks(1, (links) =>
+				links![0]!.activate({} as MouseEvent),
+			);
+		}
+		expect(onSessionLinkOpen).toHaveBeenCalledWith("ao://sessions/project/session");
+	});
+
+	it("requires Ctrl for a session link while an application captures mouse input", () => {
+		const onSessionLinkOpen = vi.fn();
+		render(<XtermTerminal onSessionLinkOpen={onSessionLinkOpen} theme="dark" />);
+		state.lastTerminal!.modes.mouseTrackingMode = "any";
+		const handler = (state.lastTerminal!.options.linkHandler as {
+			activate: (event: MouseEvent, uri: string) => void;
+		}).activate;
+		handler({ ctrlKey: false } as MouseEvent, "ao://sessions/project/session");
+		expect(onSessionLinkOpen).not.toHaveBeenCalled();
+		handler({ ctrlKey: true } as MouseEvent, "ao://sessions/project/session");
+		expect(onSessionLinkOpen).toHaveBeenCalledTimes(1);
+	});
+
+	it("routes malformed AO OSC links to in-app feedback without external dispatch", () => {
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const onSessionLinkOpen = vi.fn();
+		render(<XtermTerminal onSessionLinkOpen={onSessionLinkOpen} theme="dark" />);
+		state.lastTerminal!.modes.mouseTrackingMode = "none";
+		const handler = (state.lastTerminal!.options.linkHandler as {
+			activate: (event: MouseEvent, uri: string) => void;
+		}).activate;
+		handler({} as MouseEvent, "ao://sessions/project/session/kill");
+		expect(onSessionLinkOpen).toHaveBeenCalledWith("ao://sessions/project/session/kill");
+		expect(open).not.toHaveBeenCalled();
+		open.mockRestore();
+	});
+
+	it("detects a session URL wrapped across terminal rows without consuming punctuation", () => {
+		const onSessionLinkOpen = vi.fn();
+		render(<XtermTerminal onSessionLinkOpen={onSessionLinkOpen} theme="dark" />);
+		state.lastTerminal!.modes.mouseTrackingMode = "none";
+		state.lastTerminal!.cols = 16;
+		const rows = ["ao://sessions/pr", "oject/session)."];
+		state.lastTerminal!.buffer.active.length = rows.length;
+		state.lastTerminal!.buffer.active.getLine = (line) =>
+			line >= rows.length
+				? undefined
+				: {
+						isWrapped: line === 1,
+						translateToString: () => rows[line]!,
+					};
+		state.sessionLinkProvider!.provideLinks(2, (links) => {
+			expect(links?.[0]?.text).toBe("ao://sessions/project/session");
+			links?.[0]?.activate({} as MouseEvent);
+		});
+		expect(onSessionLinkOpen).toHaveBeenCalledWith("ao://sessions/project/session");
 	});
 
 	it.each([

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -20,7 +20,7 @@
 //    fits don't spam the PTY.
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type ILink, type ILinkProvider } from "@xterm/xterm";
 import { useTranslation } from "react-i18next";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import { FitAddon } from "@xterm/addon-fit";
@@ -37,6 +37,7 @@ import { aoBridge } from "../lib/bridge";
 import { isDialogOrMenuOpen } from "../lib/dom-selectors";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { isWebLink, openLinkInSystemBrowser } from "../lib/external-link-policy";
+import { findSessionLinks } from "../lib/session-links";
 import { isMacPlatform } from "../lib/platform";
 import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
 import {
@@ -81,6 +82,8 @@ export type XtermTerminalProps = {
 	onError?: (error: unknown) => void;
 	/** Called after a terminal hyperlink is opened in the OS browser. */
 	onLinkOpen?: (uri: string) => void;
+	/** Navigate a canonical ao:// session link inside the current AO window. */
+	onSessionLinkOpen?: (uri: string) => void;
 	/** Publish the positive grid after a retained terminal becomes visible. */
 	onVisibleSize?: (cols: number, rows: number) => void;
 	/** Hidden retained terminals keep parsing output but expose no UI overlays. */
@@ -315,6 +318,42 @@ function configureScrollbarReservation(term: Terminal): void {
 	if (viewport) viewport.scrollBarWidth = isMacPlatform() ? MAC_TERMINAL_SCROLLBAR_WIDTH : 0;
 }
 
+export function sessionLinkProvider(
+	term: Terminal,
+	activate: (event: MouseEvent, uri: string) => void,
+): ILinkProvider {
+	return {
+		provideLinks(lineNumber, callback) {
+			const buffer = term.buffer.active;
+			let firstLine = lineNumber - 1;
+			while (firstLine > 0 && buffer.getLine(firstLine)?.isWrapped) firstLine -= 1;
+			const lines = [];
+			for (let line = firstLine; line < buffer.length; line += 1) {
+				if (line > firstLine && !buffer.getLine(line)?.isWrapped) break;
+				lines.push(buffer.getLine(line)?.translateToString(false) ?? "");
+			}
+			const text = lines.join("");
+			const links: ILink[] = findSessionLinks(text).flatMap((match) => {
+				const startLine = firstLine + Math.floor(match.start / term.cols);
+				const endOffset = match.end - 1;
+				const endLine = firstLine + Math.floor(endOffset / term.cols);
+				if (lineNumber - 1 < startLine || lineNumber - 1 > endLine) return [];
+				return [
+					{
+						text: match.text,
+						range: {
+							start: { x: (match.start % term.cols) + 1, y: startLine + 1 },
+							end: { x: (endOffset % term.cols) + 1, y: endLine + 1 },
+						},
+						activate: (event) => activate(event, match.text),
+					},
+				];
+			});
+			callback(links.length > 0 ? links : undefined);
+		},
+	};
+}
+
 export function XtermTerminal(props: XtermTerminalProps) {
 	const { t } = useTranslation();
 	const themeStyle = useUiStore((state) => state.themeStyle);
@@ -472,6 +511,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			callbacksRef.current.onChangeFontSize?.(delta);
 		});
 		const activateLink = (event: MouseEvent, uri: string) => {
+			if (uri.startsWith("ao:")) {
+				const modifierPressed = isMacPlatform() ? event.metaKey : event.ctrlKey;
+				if (term.modes.mouseTrackingMode !== "none" && !modifierPressed) return;
+				callbacksRef.current.onSessionLinkOpen?.(uri);
+				return;
+			}
 			// Left-click on a web link opens it inside the AO Browser panel (the
 			// parent decides how). Non-web schemes (mailto:, etc.) still go to the OS
 			// via the main process's window-open handler. Right-click to open a web
@@ -549,6 +594,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		// empty open is dropped and clicks silently no-op. Pass the matched URL to
 		// window.open directly so the main process routes it to shell.openExternal.
 		term.loadAddon(new WebLinksAddon(activateLink, { hover: trackHover, leave: clearHover }));
+		term.registerLinkProvider(sessionLinkProvider(term, activateLink));
 		const searchAddon = new SearchAddon();
 		searchAddonRef.current = searchAddon;
 		term.loadAddon(searchAddon);

--- a/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
@@ -27,6 +27,10 @@ function renderWithLinkHandler(text: string, onLinkOpen: (url: string) => void) 
 	);
 }
 
+function renderWithSessionLinkHandler(text: string, onSessionLinkOpen: (url: string) => void) {
+	return render(<ChatLinkProvider onSessionLinkOpen={onSessionLinkOpen}><ChatMarkdown text={text} /></ChatLinkProvider>);
+}
+
 describe("ChatMarkdown", () => {
 	it("renders headings as headings rather than literal hashes", () => {
 		render(<ChatMarkdown text={"## Findings\n\nTwo files changed."} />);
@@ -139,6 +143,30 @@ describe("ChatMarkdown", () => {
 		expect(onLinkOpen).toHaveBeenCalledWith("https://example.com/i/1");
 		expect(openExternal).not.toHaveBeenCalled();
 		openExternal.mockRestore();
+	});
+
+	it.each([
+		"ao://sessions/project/session",
+		"[Open session](ao://sessions/project/session)",
+	])("renders and activates a canonical session link: %s", async (text) => {
+		const onSessionLinkOpen = vi.fn();
+		renderWithSessionLinkHandler(text, onSessionLinkOpen);
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("href", "ao://sessions/project/session");
+		await userEvent.setup().click(link);
+		expect(onSessionLinkOpen).toHaveBeenCalledWith("ao://sessions/project/session");
+	});
+
+	it("does not auto-activate a session link while streaming", () => {
+		const onSessionLinkOpen = vi.fn();
+		render(<ChatLinkProvider onSessionLinkOpen={onSessionLinkOpen}><ChatMarkdown streaming text="ao://sessions/project/session" /></ChatLinkProvider>);
+		expect(screen.getByRole("link")).toBeInTheDocument();
+		expect(onSessionLinkOpen).not.toHaveBeenCalled();
+	});
+
+	it("leaves malformed session-like text inert", () => {
+		renderWithSessionLinkHandler("ao://sessions/project/session/kill", vi.fn());
+		expect(screen.queryByRole("link")).not.toBeInTheDocument();
 	});
 
 	it("opens a web link in the system browser on Option/Alt-click", () => {

--- a/frontend/src/renderer/components/chat/ChatMarkdown.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.tsx
@@ -34,7 +34,7 @@ import {
 	useState,
 	type ReactNode,
 } from "react";
-import Markdown, { type Components } from "react-markdown";
+import Markdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { WrapText } from "lucide-react";
 import { cn } from "../../lib/utils";
@@ -42,6 +42,7 @@ import { aoBridge } from "../../lib/bridge";
 import { canonicalLanguage } from "../../lib/code-highlight";
 import { fenceOf } from "../../lib/markdown-fence";
 import { isWebLink, openLinkInSystemBrowser } from "../../lib/external-link-policy";
+import { isSessionLink, remarkSessionLinks } from "../../lib/session-links";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -69,7 +70,7 @@ export const ActivityTitle = memo(function ActivityTitle({ text }: { text: strin
 });
 
 /** GitHub-flavoured markdown: tables, strikethrough, task lists, autolinks. */
-const PLUGINS = [remarkGfm];
+const PLUGINS = [remarkGfm, remarkSessionLinks];
 
 /**
  * Whether the prose is still arriving, for the fences inside it.
@@ -80,15 +81,22 @@ const PLUGINS = [remarkGfm];
  */
 const StreamingProse = createContext(false);
 const OpenChatLink = createContext<((url: string) => void) | undefined>(undefined);
+const OpenSessionLink = createContext<((url: string) => void) | undefined>(undefined);
 
 export function ChatLinkProvider({
 	onLinkOpen,
+	onSessionLinkOpen,
 	children,
 }: {
 	onLinkOpen?: (url: string) => void;
+	onSessionLinkOpen?: (url: string) => void;
 	children: ReactNode;
 }) {
-	return <OpenChatLink.Provider value={onLinkOpen}>{children}</OpenChatLink.Provider>;
+	return (
+		<OpenChatLink.Provider value={onLinkOpen}>
+			<OpenSessionLink.Provider value={onSessionLinkOpen}>{children}</OpenSessionLink.Provider>
+		</OpenChatLink.Provider>
+	);
 }
 
 export const ChatMarkdown = memo(function ChatMarkdown({
@@ -113,7 +121,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 					muted ? "text-[13px] text-muted-foreground" : "text-sm text-foreground",
 				)}
 			>
-				<Markdown remarkPlugins={PLUGINS} components={COMPONENTS}>
+				<Markdown remarkPlugins={PLUGINS} components={COMPONENTS} urlTransform={chatUrlTransform}>
 					{text}
 				</Markdown>
 			</div>
@@ -215,14 +223,20 @@ function compactEmoji(children: ReactNode): ReactNode {
 
 function MarkdownLink({ href, children }: { href?: string; children?: ReactNode }) {
 	const onLinkOpen = useContext(OpenChatLink);
+	const onSessionLinkOpen = useContext(OpenSessionLink);
+	const sessionLink = Boolean(href && isSessionLink(href));
 	const anchor = (
 		<a
 			href={href}
-			target="_blank"
+			target={sessionLink ? undefined : "_blank"}
 			rel="noreferrer noopener"
 			onClick={(event) => {
 				if (!href) return;
 				event.preventDefault();
+				if (sessionLink) {
+					onSessionLinkOpen?.(href);
+					return;
+				}
 				// Cmd/Ctrl-click (the VS Code/Slack convention) and Option/Alt-click
 				// escape the in-app panel and go straight to the system browser.
 				const toSystemBrowser = event.metaKey || event.ctrlKey || event.altKey;
@@ -244,7 +258,7 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
 			<ContextMenuContent className="min-w-44">
 				{/* Only http(s) may reach shell.openExternal from here; other schemes
 				    still get their address copied. */}
-				{isWebLink(href) ? (
+				{!sessionLink && isWebLink(href) ? (
 					<ContextMenuItem onSelect={() => void openLinkInSystemBrowser(href)}>
 						Open in system browser
 					</ContextMenuItem>
@@ -255,6 +269,10 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
 			</ContextMenuContent>
 		</ContextMenu>
 	);
+}
+
+function chatUrlTransform(url: string): string {
+	return isSessionLink(url) ? url : defaultUrlTransform(url);
 }
 
 /**

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -55,6 +55,7 @@ import { caretNotation, stripAnsi } from "../../lib/ansi";
 import { getApiBaseUrl } from "../../lib/api-client";
 import { isWebLink, openLinkInSystemBrowser } from "../../lib/external-link-policy";
 import { ActivityTitle, ChatMarkdown } from "./ChatMarkdown";
+import { findSessionLinks } from "../../lib/session-links";
 import { HighlightedCode } from "./HighlightedCode";
 import { CopyButton } from "./CopyButton";
 import { HumanMessageEditor } from "./HumanMessageEditor";
@@ -534,7 +535,13 @@ export function HumanMessage({
 							: "bg-raised text-foreground",
 					)}
 				>
-					{body ? <p className="break-words whitespace-pre-wrap text-pretty">{body}</p> : null}
+					{body ? (
+						findSessionLinks(body).length > 0 ? (
+							<ChatMarkdown text={body} />
+						) : (
+							<p className="break-words whitespace-pre-wrap text-pretty">{body}</p>
+						)
+					) : null}
 					<StagedAttachmentItems
 						paths={attachments}
 						sessionId={sessionId}
@@ -620,9 +627,15 @@ export function OriginMessage({ message }: { message: ConversationMessage }) {
 			{longReport && expanded ? (
 				<ChatMarkdown text={message.text} muted />
 			) : (
-				<p className={cn("text-sm leading-relaxed text-muted-foreground", longReport && "line-clamp-3")}>
-					{preview}
-				</p>
+				findSessionLinks(preview).length > 0 ? (
+					<div className={cn(longReport && "line-clamp-3")}>
+						<ChatMarkdown text={preview} muted />
+					</div>
+				) : (
+					<p className={cn("text-sm leading-relaxed text-muted-foreground", longReport && "line-clamp-3")}>
+						{preview}
+					</p>
+				)
 			)}
 			{longReport ? (
 				<button

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -975,6 +975,22 @@ describe("ChatWorkspace timeline", () => {
 		expect(onLinkOpen).toHaveBeenCalledWith("http://localhost:5173");
 	});
 
+	it.each([
+		["human", "user"],
+		["automation", "user"],
+		["daemon", "user"],
+		["provider", "assistant"],
+	] as const)("activates session links from %s messages", async (origin, role) => {
+		const snapshot = structuredClone(chatFixtureSettled);
+		const template = snapshot.items.find((item): item is ConversationMessage => item.kind === "message");
+		if (!template) throw new Error("fixture has no message");
+		snapshot.items = [{ ...template, id: `link-${origin}`, origin, role, text: "ao://sessions/project/session", streaming: false }];
+		const onSessionLinkOpen = vi.fn();
+		render(<ChatWorkspace snapshot={snapshot} onSessionLinkOpen={onSessionLinkOpen} />);
+		await userEvent.setup().click(screen.getByRole("link"));
+		expect(onSessionLinkOpen).toHaveBeenCalledWith("ao://sessions/project/session");
+	});
+
 	it("offers real recovery actions when the controller stops", async () => {
 		const user = userEvent.setup();
 		const resume = vi.fn();

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -272,6 +272,7 @@ export interface ChatWorkspaceProps {
 	shellError?: string;
 	/** Open an HTTP(S) link in this session's AO Browser panel. */
 	onLinkOpen?: (url: string) => void;
+	onSessionLinkOpen?: (url: string) => void;
 	/** A send or decision is in flight. */
 	busy?: boolean;
 	/** The provider's model catalog. Empty hides the model control. */
@@ -423,6 +424,7 @@ export function ChatWorkspace({
 	openingShell,
 	shellError,
 	onLinkOpen,
+	onSessionLinkOpen,
 	busy,
 	models,
 	onChooseSettings,
@@ -1133,7 +1135,7 @@ export function ChatWorkspace({
 						className={cn("flex min-h-0 flex-1 flex-col", conversationEmpty && "justify-center")}
 						data-composer-placement={conversationEmpty ? "center" : "dock"}
 					>
-						<ChatLinkProvider onLinkOpen={onLinkOpen}>
+						<ChatLinkProvider onLinkOpen={onLinkOpen} onSessionLinkOpen={onSessionLinkOpen}>
 							<Timeline
 								snapshot={snapshot}
 								hasOlder={hasOlder}

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -36,6 +36,7 @@ import {
 	type AgentSwitchPresentation,
 } from "../../lib/agent-switch-presentation";
 import { cn } from "../../lib/utils";
+import { useSessionLinkNavigation } from "../../lib/use-session-link-navigation";
 import type { Theme } from "../../stores/ui-store";
 import { can } from "../../types/conversation";
 import type { ConversationSnapshot } from "../../types/conversation";
@@ -187,6 +188,7 @@ export function SessionChatSurface({
 	const { paths, truncated } = useWorkspaceFilePaths(session.id, Boolean(snapshot));
 	const stageAttachments = useStageAttachments(session.id);
 	const openLinkInBrowser = useSessionBrowserLink(session);
+	const openSessionLink = useSessionLinkNavigation();
 	// Agent-switch presentation for the chat surface progress track and input locks.
 	const switchMutation = useSwitchAgentState(session.id);
 	const agentSwitches = useAgentSwitches(session.id).data ?? [];
@@ -329,6 +331,7 @@ export function SessionChatSurface({
 				agentInputDisabled={switchLocksChat || handoffDialogOpen}
 				newWorkDisabled={newWorkDisabled}
 				onLinkOpen={openLinkInBrowser}
+				onSessionLinkOpen={openSessionLink}
 				sessionTitle={session.title}
 				sessionRole={session.kind}
 				session={session}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -605,6 +605,7 @@
 	"newTask.unableToStart": "Aufgabe konnte nicht gestartet werden",
 	"notify.all": "Alle",
 	"notify.bell": "Benachrichtigungen",
+	"sessionLink.dismissError": "Sitzungslink-Fehler schließen",
 	"notify.couldNotMarkAllRead": "Benachrichtigungen konnten nicht als gelesen markiert werden",
 	"notify.couldNotMarkRead": "Benachrichtigung konnte nicht als gelesen markiert werden",
 	"notify.earlierLoadFailed": "Frühere Benachrichtigungen konnten nicht geladen werden.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -599,6 +599,7 @@
 	"newTask.titleRequired": "Title and brief are required.",
 	"newTask.unableToStart": "Unable to start task",
 	"notify.bell": "Notifications",
+	"sessionLink.dismissError": "Dismiss session link error",
 	"notify.couldNotMarkAllRead": "Could not mark notifications read",
 	"notify.earlierLoadFailed": "Couldn’t load earlier notifications.",
 	"notify.emptyAll": "No notifications yet.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -607,6 +607,7 @@
 	"newTask.unableToStart": "No se pudo iniciar la tarea",
 	"notify.all": "Todas",
 	"notify.bell": "Notificaciones",
+	"sessionLink.dismissError": "Cerrar el error del enlace de sesión",
 	"notify.couldNotMarkAllRead": "No se pudieron marcar las notificaciones como leídas",
 	"notify.couldNotMarkRead": "No se pudo marcar la notificación como leída",
 	"notify.earlierLoadFailed": "No se pudieron cargar las notificaciones anteriores.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -607,6 +607,7 @@
 	"newTask.unableToStart": "Impossible de démarrer la tâche",
 	"notify.all": "Toutes",
 	"notify.bell": "Notifications",
+	"sessionLink.dismissError": "Fermer l’erreur du lien de session",
 	"notify.couldNotMarkAllRead": "Impossible de marquer les notifications comme lues",
 	"notify.couldNotMarkRead": "Impossible de marquer la notification comme lue",
 	"notify.earlierLoadFailed": "Impossible de charger les notifications antérieures.",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -605,6 +605,7 @@
 	"newTask.unableToStart": "タスクを開始できません",
 	"notify.all": "すべて",
 	"notify.bell": "通知",
+	"sessionLink.dismissError": "セッションリンクのエラーを閉じる",
 	"notify.couldNotMarkAllRead": "すべての通知を既読にできませんでした",
 	"notify.couldNotMarkRead": "通知を既読にできませんでした",
 	"notify.earlierLoadFailed": "以前の通知を読み込めませんでした。",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -605,6 +605,7 @@
 	"newTask.unableToStart": "작업을 시작할 수 없습니다",
 	"notify.all": "전체",
 	"notify.bell": "알림",
+	"sessionLink.dismissError": "세션 링크 오류 닫기",
 	"notify.couldNotMarkAllRead": "모든 알림을 읽음으로 표시할 수 없습니다",
 	"notify.couldNotMarkRead": "알림을 읽음으로 표시할 수 없습니다",
 	"notify.earlierLoadFailed": "이전 알림을 불러올 수 없습니다.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -607,6 +607,7 @@
 	"newTask.unableToStart": "Não foi possível iniciar a tarefa",
 	"notify.all": "Todas",
 	"notify.bell": "Notificações",
+	"sessionLink.dismissError": "Fechar erro do link da sessão",
 	"notify.couldNotMarkAllRead": "Não foi possível marcar as notificações como lidas",
 	"notify.couldNotMarkRead": "Não foi possível marcar a notificação como lida",
 	"notify.earlierLoadFailed": "Não foi possível carregar notificações anteriores.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -604,6 +604,7 @@
 	"newTask.titleRequired": "标题和简述为必填项。",
 	"newTask.unableToStart": "无法启动任务",
 	"notify.bell": "通知",
+	"sessionLink.dismissError": "关闭会话链接错误",
 	"notify.couldNotMarkAllRead": "无法将通知全部标为已读",
 	"notify.earlierLoadFailed": "无法加载更早的通知。",
 	"notify.emptyAll": "暂无通知。",

--- a/frontend/src/renderer/lib/session-links.test.ts
+++ b/frontend/src/renderer/lib/session-links.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { findSessionLinks, parseSessionLink, resolveSessionLink } from "./session-links";
+
+describe("session links", () => {
+	it.each([
+		["ao://sessions/project/session", { projectId: "project", sessionId: "session" }],
+		["ao://sessions/project%20one/session%2Done", { projectId: "project one", sessionId: "session-one" }],
+	])("parses %s", (url, expected) => expect(parseSessionLink(url)).toEqual(expected));
+
+	it.each([
+		"AO://sessions/project/session", "a0://sessions/project/session", "ao://session/project/session",
+		"ao://sessions/project", "ao://sessions/project/session/extra", "ao://sessions//session",
+		"ao://sessions/project/session?kill=true", "ao://sessions/project/session#chat",
+		"ao://user@sessions/project/session", "ao://sessions/project/%ZZ", "ao://sessions/project/%2Faction",
+		"ao://sessions/project/session/kill",
+	])("rejects unsupported value %s", (url) => expect(parseSessionLink(url)).toBeUndefined());
+
+	it("trims adjacent punctuation while preserving encoded IDs", () => {
+		expect(findSessionLinks("See (ao://sessions/p/s), then ao://sessions/p/t.")).toEqual([
+			{ start: 5, end: 22, text: "ao://sessions/p/s" },
+			{ start: 30, end: 47, text: "ao://sessions/p/t" },
+		]);
+	});
+
+	it("resolves by stable project and session IDs regardless of title or termination", () => {
+		const workspaces = [{ id: "p", sessions: [{ id: "s", title: "renamed", isTerminated: true }] }];
+		expect(resolveSessionLink("ao://sessions/p/s", workspaces)).toEqual({ projectId: "p", sessionId: "s" });
+		expect(resolveSessionLink("ao://sessions/p/missing", workspaces)).toBeUndefined();
+	});
+});

--- a/frontend/src/renderer/lib/session-links.test.ts
+++ b/frontend/src/renderer/lib/session-links.test.ts
@@ -22,9 +22,9 @@ describe("session links", () => {
 		]);
 	});
 
-	it("resolves by stable project and session IDs regardless of title or termination", () => {
-		const workspaces = [{ id: "p", sessions: [{ id: "s", title: "renamed", isTerminated: true }] }];
-		expect(resolveSessionLink("ao://sessions/p/s", workspaces)).toEqual({ projectId: "p", sessionId: "s" });
+	it("resolves by stable project and session IDs with termination state", () => {
+		const workspaces = [{ id: "p", sessions: [{ id: "s", title: "renamed", status: "terminated" }] }];
+		expect(resolveSessionLink("ao://sessions/p/s", workspaces)).toEqual({ projectId: "p", sessionId: "s", isTerminated: true });
 		expect(resolveSessionLink("ao://sessions/p/missing", workspaces)).toBeUndefined();
 	});
 });

--- a/frontend/src/renderer/lib/session-links.ts
+++ b/frontend/src/renderer/lib/session-links.ts
@@ -1,0 +1,77 @@
+export type SessionLinkTarget = { projectId: string; sessionId: string };
+export type SessionLinkWorkspace = { id: string; sessions: Array<{ id: string }> };
+
+const SESSION_LINK_PREFIX = "ao://sessions/";
+const RAW_SESSION_LINK = /ao:\/\/sessions\/\S+/g;
+const TRAILING_PUNCTUATION = /[.,;:!?]+$/;
+
+/** Strictly parse the only in-app URL route AO supports. */
+export function parseSessionLink(value: string): SessionLinkTarget | undefined {
+	if (!value.startsWith(SESSION_LINK_PREFIX) || value.includes("?") || value.includes("#")) return undefined;
+	const segments = value.slice(SESSION_LINK_PREFIX.length).split("/");
+	if (segments.length !== 2 || segments.some((segment) => segment.length === 0)) return undefined;
+	try {
+		const [projectId, sessionId] = segments.map(decodeURIComponent);
+		if (!projectId || !sessionId || projectId.includes("/") || sessionId.includes("/")) return undefined;
+		return { projectId, sessionId };
+	} catch {
+		return undefined;
+	}
+}
+
+export function isSessionLink(value: string): boolean {
+	return parseSessionLink(value) !== undefined;
+}
+
+export function resolveSessionLink(value: string, workspaces: SessionLinkWorkspace[]): SessionLinkTarget | undefined {
+	const target = parseSessionLink(value);
+	if (!target) return undefined;
+	const project = workspaces.find((workspace) => workspace.id === target.projectId);
+	return project?.sessions.some((session) => session.id === target.sessionId) ? target : undefined;
+}
+
+/** Find raw links without swallowing prose punctuation adjacent to them. */
+export function findSessionLinks(text: string): Array<{ start: number; end: number; text: string }> {
+	const matches: Array<{ start: number; end: number; text: string }> = [];
+	for (const match of text.matchAll(RAW_SESSION_LINK)) {
+		let candidate = match[0].replace(TRAILING_PUNCTUATION, "");
+		while (candidate.endsWith(")") && count(candidate, "(") < count(candidate, ")")) candidate = candidate.slice(0, -1);
+		if (!parseSessionLink(candidate)) continue;
+		matches.push({ start: match.index, end: match.index + candidate.length, text: candidate });
+	}
+	return matches;
+}
+
+function count(value: string, character: string): number {
+	return [...value].filter((entry) => entry === character).length;
+}
+
+type MarkdownNode = { type: string; value?: string; url?: string; children?: MarkdownNode[] };
+
+/** remark plugin that linkifies only raw canonical session URLs outside code. */
+export function remarkSessionLinks() {
+	return (tree: MarkdownNode) => visitMarkdown(tree);
+}
+
+function visitMarkdown(node: MarkdownNode): void {
+	if (!node.children || node.type === "code" || node.type === "inlineCode" || node.type === "link") return;
+	for (let index = 0; index < node.children.length; index += 1) {
+		const child = node.children[index]!;
+		if (child.type !== "text" || !child.value) {
+			visitMarkdown(child);
+			continue;
+		}
+		const links = findSessionLinks(child.value);
+		if (links.length === 0) continue;
+		const replacement: MarkdownNode[] = [];
+		let cursor = 0;
+		for (const link of links) {
+			if (link.start > cursor) replacement.push({ type: "text", value: child.value.slice(cursor, link.start) });
+			replacement.push({ type: "link", url: link.text, children: [{ type: "text", value: link.text }] });
+			cursor = link.end;
+		}
+		if (cursor < child.value.length) replacement.push({ type: "text", value: child.value.slice(cursor) });
+		node.children.splice(index, 1, ...replacement);
+		index += replacement.length - 1;
+	}
+}

--- a/frontend/src/renderer/lib/session-links.ts
+++ b/frontend/src/renderer/lib/session-links.ts
@@ -1,5 +1,9 @@
 export type SessionLinkTarget = { projectId: string; sessionId: string };
-export type SessionLinkWorkspace = { id: string; sessions: Array<{ id: string }> };
+export type ResolvedSessionLink = SessionLinkTarget & { isTerminated: boolean };
+export type SessionLinkWorkspace = {
+	id: string;
+	sessions: Array<{ id: string; isTerminated?: boolean; status?: string }>;
+};
 
 const SESSION_LINK_PREFIX = "ao://sessions/";
 const RAW_SESSION_LINK = /ao:\/\/sessions\/\S+/g;
@@ -23,11 +27,13 @@ export function isSessionLink(value: string): boolean {
 	return parseSessionLink(value) !== undefined;
 }
 
-export function resolveSessionLink(value: string, workspaces: SessionLinkWorkspace[]): SessionLinkTarget | undefined {
+export function resolveSessionLink(value: string, workspaces: SessionLinkWorkspace[]): ResolvedSessionLink | undefined {
 	const target = parseSessionLink(value);
 	if (!target) return undefined;
 	const project = workspaces.find((workspace) => workspace.id === target.projectId);
-	return project?.sessions.some((session) => session.id === target.sessionId) ? target : undefined;
+	const session = project?.sessions.find((candidate) => candidate.id === target.sessionId);
+	if (!session) return undefined;
+	return { ...target, isTerminated: session.isTerminated === true || session.status === "terminated" };
 }
 
 /** Find raw links without swallowing prose punctuation adjacent to them. */

--- a/frontend/src/renderer/lib/use-session-link-navigation.test.tsx
+++ b/frontend/src/renderer/lib/use-session-link-navigation.test.tsx
@@ -10,18 +10,32 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({ useWorkspaceQuery: () => mocks.wo
 describe("useSessionLinkNavigation", () => {
 	beforeEach(() => {
 		mocks.navigate.mockReset();
-		useUiStore.setState({ sessionLinkError: null });
+		useUiStore.setState({ sessionLinkError: null, sessionLinkNotices: [], sessionLinkNoticeSequence: 0 });
 		mocks.workspace.mockReturnValue({
 			isSuccess: true,
-			data: [{ id: "project", sessions: [{ id: "session", title: "renamed", isTerminated: true }] }],
+			data: [
+				{ id: "other-project", sessions: [{ id: "other-session", isTerminated: false }] },
+				{ id: "project", sessions: [{ id: "session", title: "renamed", isTerminated: false }, { id: "terminated", isTerminated: true }] },
+			],
 		});
 	});
 
-	it("selects the exact project and retained session by stable ID", () => {
+	it("selects the exact cross-project session by stable ID", () => {
 		const { result } = renderHook(() => useSessionLinkNavigation());
-		act(() => expect(result.current("ao://sessions/project/session")).toBe(true));
-		expect(mocks.navigate).toHaveBeenCalledWith("project", "session");
+		act(() => expect(result.current("ao://sessions/other-project/other-session")).toBe(true));
+		expect(mocks.navigate).toHaveBeenCalledWith("other-project", "other-session");
 		expect(useUiStore.getState().sessionLinkError).toBeNull();
+	});
+
+	it("shows feedback instead of navigating to a terminated session", () => {
+		const { result } = renderHook(() => useSessionLinkNavigation());
+		act(() => expect(result.current("ao://sessions/project/terminated")).toBe(false));
+		act(() => expect(result.current("ao://sessions/project/terminated")).toBe(false));
+		expect(mocks.navigate).not.toHaveBeenCalled();
+		expect(useUiStore.getState().sessionLinkNotices.map((notice) => notice.message)).toEqual([
+			"Session terminated is terminated",
+			"Session terminated is terminated",
+		]);
 	});
 
 	it.each([

--- a/frontend/src/renderer/lib/use-session-link-navigation.test.tsx
+++ b/frontend/src/renderer/lib/use-session-link-navigation.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "../stores/ui-store";
+import { useSessionLinkNavigation } from "./use-session-link-navigation";
+
+const mocks = vi.hoisted(() => ({ navigate: vi.fn(), workspace: vi.fn() }));
+vi.mock("./navigate-to-session", () => ({ useNavigateToSession: () => mocks.navigate }));
+vi.mock("../hooks/useWorkspaceQuery", () => ({ useWorkspaceQuery: () => mocks.workspace() }));
+
+describe("useSessionLinkNavigation", () => {
+	beforeEach(() => {
+		mocks.navigate.mockReset();
+		useUiStore.setState({ sessionLinkError: null });
+		mocks.workspace.mockReturnValue({
+			isSuccess: true,
+			data: [{ id: "project", sessions: [{ id: "session", title: "renamed", isTerminated: true }] }],
+		});
+	});
+
+	it("selects the exact project and retained session by stable ID", () => {
+		const { result } = renderHook(() => useSessionLinkNavigation());
+		act(() => expect(result.current("ao://sessions/project/session")).toBe(true));
+		expect(mocks.navigate).toHaveBeenCalledWith("project", "session");
+		expect(useUiStore.getState().sessionLinkError).toBeNull();
+	});
+
+	it.each([
+		["ao://sessions/project/missing", "missing or is not accessible"],
+		["ao://sessions/project/session/kill", "malformed or unsupported"],
+	])("rejects %s with actionable feedback", (url, message) => {
+		const { result } = renderHook(() => useSessionLinkNavigation());
+		act(() => expect(result.current(url)).toBe(false));
+		expect(mocks.navigate).not.toHaveBeenCalled();
+		expect(useUiStore.getState().sessionLinkError).toContain(message);
+	});
+
+	it("does not navigate when the workspace cannot be verified", () => {
+		mocks.workspace.mockReturnValue({ isSuccess: false, data: undefined });
+		const { result } = renderHook(() => useSessionLinkNavigation());
+		act(() => expect(result.current("ao://sessions/project/session")).toBe(false));
+		expect(useUiStore.getState().sessionLinkError).toContain("daemon connection");
+	});
+});

--- a/frontend/src/renderer/lib/use-session-link-navigation.ts
+++ b/frontend/src/renderer/lib/use-session-link-navigation.ts
@@ -8,6 +8,7 @@ export function useSessionLinkNavigation(): (url: string) => boolean {
 	const workspaceQuery = useWorkspaceQuery();
 	const navigateToSession = useNavigateToSession();
 	const setSessionLinkError = useUiStore((state) => state.setSessionLinkError);
+	const showSessionLinkNotice = useUiStore((state) => state.showSessionLinkNotice);
 	return useCallback((url: string) => {
 		const target = parseSessionLink(url);
 		if (!target) {
@@ -24,7 +25,11 @@ export function useSessionLinkNavigation(): (url: string) => boolean {
 			return false;
 		}
 		setSessionLinkError(null);
+		if (resolved.isTerminated) {
+			showSessionLinkNotice(`Session ${resolved.sessionId} is terminated`);
+			return false;
+		}
 		navigateToSession(resolved.projectId, resolved.sessionId);
 		return true;
-	}, [navigateToSession, setSessionLinkError, workspaceQuery.data, workspaceQuery.isSuccess]);
+	}, [navigateToSession, setSessionLinkError, showSessionLinkNotice, workspaceQuery.data, workspaceQuery.isSuccess]);
 }

--- a/frontend/src/renderer/lib/use-session-link-navigation.ts
+++ b/frontend/src/renderer/lib/use-session-link-navigation.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { useUiStore } from "../stores/ui-store";
+import { useNavigateToSession } from "./navigate-to-session";
+import { parseSessionLink, resolveSessionLink } from "./session-links";
+
+export function useSessionLinkNavigation(): (url: string) => boolean {
+	const workspaceQuery = useWorkspaceQuery();
+	const navigateToSession = useNavigateToSession();
+	const setSessionLinkError = useUiStore((state) => state.setSessionLinkError);
+	return useCallback((url: string) => {
+		const target = parseSessionLink(url);
+		if (!target) {
+			setSessionLinkError("This AO session link is malformed or unsupported.");
+			return false;
+		}
+		if (!workspaceQuery.isSuccess || !workspaceQuery.data) {
+			setSessionLinkError("AO could not verify that session. Check the daemon connection and try again.");
+			return false;
+		}
+		const resolved = resolveSessionLink(url, workspaceQuery.data);
+		if (!resolved) {
+			setSessionLinkError("That session is missing or is not accessible in this AO workspace.");
+			return false;
+		}
+		setSessionLinkError(null);
+		navigateToSession(resolved.projectId, resolved.sessionId);
+		return true;
+	}, [navigateToSession, setSessionLinkError, workspaceQuery.data, workspaceQuery.isSuccess]);
+}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -16,6 +16,7 @@ import { KeyboardShortcutsDialog } from "../components/KeyboardShortcutsDialog";
 import { KeyboardShortcutsSettingsDialog } from "../components/settings/KeyboardShortcutsSettingsDialog";
 import { ShellTopbar } from "../components/ShellTopbar";
 import { SessionTopbarProvider } from "../components/SessionTopbarPortal";
+import { SessionLinkFeedback } from "../components/SessionLinkFeedback";
 import { OrchestratorReplacementDialog } from "../components/OrchestratorReplacementDialog";
 import { RestartToUpdateDialog } from "../components/RestartToUpdateDialog";
 import { Sidebar } from "../components/Sidebar";
@@ -1001,6 +1002,7 @@ function ShellLayout() {
 					</main>
 					</div>
 					<DaemonFailureBanner status={daemonStatus} />
+					<SessionLinkFeedback />
 					{/* When ShellTopbar is hidden, keep a macOS window-drag strip over
               the traffic-light band only. The fixed TitlebarNav renders after
               this strip so its no-drag buttons remain clickable. */}

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -61,6 +61,8 @@ export type GlobalToast = {
 	nonce: number;
 };
 
+export type SessionLinkNotice = { message: string; nonce: number };
+
 // Selection (which project/session is open) now lives in the URL — the router
 // is the single source of truth, read via route params. This store holds only
 // ephemeral UI: theme, sidebar collapse, command palette, per-session inspector
@@ -116,6 +118,8 @@ export type UiState = {
 	// need that distinction, and SessionView's own target is local state.
 	visibleTerminalKindBySession: Record<string, TerminalTarget["kind"]>;
 	sessionLinkError: string | null;
+	sessionLinkNotices: SessionLinkNotice[];
+	sessionLinkNoticeSequence: number;
 	setWorkbenchTab: (tab: WorkbenchTab) => void;
 	setThemePreference: (theme: ThemePreference) => void;
 	setThemeStyle: (style: ThemeStyle) => void;
@@ -159,6 +163,8 @@ export type UiState = {
 	setVisibleTerminalKind: (sessionId: string, kind: TerminalTarget["kind"]) => void;
 	clearVisibleTerminalKind: (sessionId: string) => void;
 	setSessionLinkError: (error: string | null) => void;
+	showSessionLinkNotice: (message: string) => void;
+	dismissSessionLinkNotice: (nonce: number) => void;
 };
 
 export type OrchestratorReplacementFailure = {
@@ -221,6 +227,8 @@ export const useUiStore = create<UiState>((set, get) => ({
 	activeShellTerminalHandleId: null,
 	visibleTerminalKindBySession: {},
 	sessionLinkError: null,
+	sessionLinkNotices: [],
+	sessionLinkNoticeSequence: 0,
 	setWorkbenchTab: (workbenchTab) => set({ workbenchTab }),
 	setThemePreference: (themePreference) => {
 		if (get().themePreference === themePreference) return;
@@ -412,6 +420,16 @@ export const useUiStore = create<UiState>((set, get) => ({
 				: { visibleTerminalKindBySession: { ...state.visibleTerminalKindBySession, [sessionId]: kind } },
 		),
 	setSessionLinkError: (sessionLinkError) => set({ sessionLinkError }),
+	showSessionLinkNotice: (message) =>
+		set((state) => {
+			const nonce = state.sessionLinkNoticeSequence + 1;
+			return {
+				sessionLinkNotices: [...state.sessionLinkNotices, { message, nonce }],
+				sessionLinkNoticeSequence: nonce,
+			};
+		}),
+	dismissSessionLinkNotice: (nonce) =>
+		set((state) => ({ sessionLinkNotices: state.sessionLinkNotices.filter((notice) => notice.nonce !== nonce) })),
 	clearVisibleTerminalKind: (sessionId) =>
 		set((state) => {
 			if (!(sessionId in state.visibleTerminalKindBySession)) return state;

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -115,6 +115,7 @@ export type UiState = {
 	// session. Surfaces outside the session subtree (the notification runtime)
 	// need that distinction, and SessionView's own target is local state.
 	visibleTerminalKindBySession: Record<string, TerminalTarget["kind"]>;
+	sessionLinkError: string | null;
 	setWorkbenchTab: (tab: WorkbenchTab) => void;
 	setThemePreference: (theme: ThemePreference) => void;
 	setThemeStyle: (style: ThemeStyle) => void;
@@ -157,6 +158,7 @@ export type UiState = {
 	setActiveShellTerminal: (handleId: string | null) => void;
 	setVisibleTerminalKind: (sessionId: string, kind: TerminalTarget["kind"]) => void;
 	clearVisibleTerminalKind: (sessionId: string) => void;
+	setSessionLinkError: (error: string | null) => void;
 };
 
 export type OrchestratorReplacementFailure = {
@@ -218,6 +220,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	newShellTerminalNonce: 0,
 	activeShellTerminalHandleId: null,
 	visibleTerminalKindBySession: {},
+	sessionLinkError: null,
 	setWorkbenchTab: (workbenchTab) => set({ workbenchTab }),
 	setThemePreference: (themePreference) => {
 		if (get().themePreference === themePreference) return;
@@ -408,6 +411,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 				? state
 				: { visibleTerminalKindBySession: { ...state.visibleTerminalKindBySession, [sessionId]: kind } },
 		),
+	setSessionLinkError: (sessionLinkError) => set({ sessionLinkError }),
 	clearVisibleTerminalKind: (sessionId) =>
 		set((state) => {
 			if (!(sessionId in state.visibleTerminalKindBySession)) return state;


### PR DESCRIPTION
Code changes: +329 -10
Tests: +346 -2
Others: +41 -0

Closes #4603

## Summary

- Add a strict shared parser and resolver for canonical `ao://sessions/{project-id}/{session-id}` links.
- Render raw and Markdown session links across Chat message origins and navigate inside the current AO window.
- Detect raw and OSC 8 links in xterm, including wrapped and punctuation-adjacent URLs, while preserving selection and mouse-capture modifiers.
- Surface malformed, missing, inaccessible, and unverifiable targets as in-app feedback.
- Report terminated targets in a five-second, manually dismissible top notification stack without changing the active session.
- Teach orchestrator and worker system prompts plus the installed `using-ao` skill to emit safe canonical links using stable IDs.

## Rebase

- Rebased the three Resource Links commits onto current `main` at `850df06e5a6f41336823f4c31b3f4a0161284d3d`.
- Preserved current Chat file links, image rendering, agent-switch catalogs, terminal drag selection, notifications, and locale additions while resolving conflicts.
- No database schema, migration, SQL, or generated API changes are involved.

## Verification

- Focused frontend suite: 7 files and 317 tests passed.
- Frontend TypeScript check passed.
- Focused backend session-manager prompt tests passed.
- Backend skill-assets suite passed.
- `git diff --check origin/main...HEAD` passed.
- Full frontend and backend suites were attempted. Environment-dependent local socket, bundled tmux, and system-check tests failed outside the changed session-link paths.

## Manual platform verification

- macOS: with a mouse-reporting TUI active, verify ordinary click remains app-owned and Command-click opens the AO session link. With capture off, verify ordinary click navigates and drag selects.
- Windows and Linux: repeat with Control-click while mouse capture is active. Verify ordinary click when capture is off and drag selection in both modes.
- All platforms: verify raw and OSC 8 terminal links, raw and Markdown Chat links, renamed and cross-project active targets, missing-target feedback, terminated-target stacked feedback, and restoration of the target session persisted Chat or TUI surface.

## Scope

- Canonical session identity remains stable-ID based and navigation-only.
- The canonical route retains both project and session identity.
- OS protocol registration and cold-launch behavior remain out of scope. See #4602.