### PR TITLE
fix: sign packaged Node runtime for JIT so Chat sessions start on Intel Macs

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/driver.go
+++ b/backend/internal/adapters/chatdriver/acp/driver.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"time"
 
 	acpsdk "github.com/coder/acp-go-sdk"
@@ -346,11 +347,16 @@ func (d *Driver) connect(
 		},
 	})
 	if err != nil {
+		// Close first: stopping the process drives its stderr pipe to EOF, so the
+		// retained tail is complete before it is folded into the error.
 		_ = conv.Close()
 		if isACPAuthRequired(err) {
 			return nil, acpsdk.InitializeResponse{}, normalizeACPError("ACP initialize", err)
 		}
-		return nil, acpsdk.InitializeResponse{}, fmt.Errorf("%w: ACP initialize: %w", ports.ErrChatDriverIncompatible, err)
+		return nil, acpsdk.InitializeResponse{}, fmt.Errorf(
+			"%w: ACP initialize: %w%s",
+			ports.ErrChatDriverIncompatible, err, formatStderrTail(proc.stderrSnapshot()),
+		)
 	}
 	if d.cfg.ValidateInitialize != nil {
 		if err := d.cfg.ValidateInitialize(init); err != nil {
@@ -359,6 +365,27 @@ func (d *Driver) connect(
 		}
 	}
 	return conv, init, nil
+}
+
+// stderrTailLines caps how much adapter stderr reaches the error message. A
+// fatal runtime trace is long; the last lines carry the cause and keep the
+// surfaced error readable in the UI.
+const stderrTailLines = 12
+
+// formatStderrTail renders retained adapter stderr as an error suffix. An
+// adapter that exits before answering initialize leaves no other diagnostic,
+// which previously reduced a crashed runtime to "peer disconnected before
+// response" (#4442).
+func formatStderrTail(tail string) string {
+	tail = strings.TrimSpace(tail)
+	if tail == "" {
+		return ""
+	}
+	lines := strings.Split(tail, "\n")
+	if len(lines) > stderrTailLines {
+		lines = lines[len(lines)-stderrTailLines:]
+	}
+	return fmt.Sprintf(" (adapter stderr: %s)", strings.Join(lines, "; "))
 }
 
 func cloneCapabilities(in ports.ChatCapabilities) ports.ChatCapabilities {

--- a/backend/internal/adapters/chatdriver/acp/process.go
+++ b/backend/internal/adapters/chatdriver/acp/process.go
@@ -11,10 +11,54 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/processenv"
 )
 
+// stderrTailLimit bounds the retained adapter stderr. A runtime that dies on
+// startup prints a multi-frame fatal trace; keeping the tail captures the fatal
+// message without letting a chatty adapter grow the buffer without bound.
+const stderrTailLimit = 8 << 10
+
+// stderrTailWait bounds how long a caller blocks for the drain goroutine to see
+// EOF. The adapter has normally already exited by the time the tail is read.
+const stderrTailWait = 250 * time.Millisecond
+
 type process struct {
 	stdin  io.WriteCloser
 	stdout io.Reader
-	stop   func() error
+	// stderrTail returns the retained tail of the adapter's stderr. An adapter
+	// that dies before answering a request reports why here and nowhere else,
+	// so the handshake path folds it into the returned error.
+	stderrTail func() string
+	stop       func() error
+}
+
+// stderrSnapshot reads the retained stderr tail, tolerating the zero-value
+// process used by tests that fake the transport.
+func (p *process) stderrSnapshot() string {
+	if p == nil || p.stderrTail == nil {
+		return ""
+	}
+	return p.stderrTail()
+}
+
+// tailBuffer retains the last stderrTailLimit bytes written to it.
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > stderrTailLimit {
+		t.buf = append([]byte(nil), t.buf[len(t.buf)-stderrTailLimit:]...)
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return string(t.buf)
 }
 
 type spawnFunc func(Launch, string) (*process, error)
@@ -42,8 +86,15 @@ func spawnAgent(launch Launch, workdir string) (*process, error) {
 	}
 
 	// ACP owns stdout. Always drain stderr separately so a verbose adapter cannot
-	// fill its OS pipe and deadlock the protocol.
-	go func() { _, _ = io.Copy(io.Discard, stderr) }()
+	// fill its OS pipe and deadlock the protocol. The tail is retained rather
+	// than discarded: when the adapter crashes before completing the ACP
+	// handshake, its stderr is the only account of the failure (#4442).
+	tail := &tailBuffer{}
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		_, _ = io.Copy(tail, stderr)
+	}()
 
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
@@ -51,6 +102,13 @@ func spawnAgent(launch Launch, workdir string) (*process, error) {
 	return &process{
 		stdin:  stdin,
 		stdout: stdout,
+		stderrTail: func() string {
+			select {
+			case <-drained:
+			case <-time.After(stderrTailWait):
+			}
+			return tail.String()
+		},
 		stop: func() error {
 			var stopErr error
 			once.Do(func() {

--- a/backend/internal/adapters/chatdriver/acp/process_test.go
+++ b/backend/internal/adapters/chatdriver/acp/process_test.go
@@ -1,0 +1,71 @@
+package acp
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A runtime that dies before answering the ACP handshake reports the reason on
+// stderr and nowhere else. Discarding it reduced an aborting Node runtime to
+// "peer disconnected before response" (#4442).
+func TestSpawnAgentRetainsStderrTail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell to script the failure")
+	}
+	proc, err := spawnAgent(Launch{
+		Command: "sh",
+		Args:    []string{"-c", "echo 'fatal: v8 SetPermissions' >&2; exit 133"},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("spawnAgent: %v", err)
+	}
+	t.Cleanup(func() { _ = proc.stop() })
+
+	if tail := proc.stderrSnapshot(); !strings.Contains(tail, "fatal: v8 SetPermissions") {
+		t.Fatalf("stderr tail = %q, want it to carry the adapter's fatal message", tail)
+	}
+}
+
+// Draining must still be unbounded so a chatty adapter cannot fill its OS pipe
+// and deadlock the protocol; only what is retained is capped.
+func TestTailBufferRetainsLastBytesOnly(t *testing.T) {
+	tail := &tailBuffer{}
+	if _, err := fmt.Fprint(tail, strings.Repeat("a", stderrTailLimit)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := fmt.Fprint(tail, "TRAILING"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := tail.String()
+	if len(got) != stderrTailLimit {
+		t.Fatalf("len = %d, want %d", len(got), stderrTailLimit)
+	}
+	if !strings.HasSuffix(got, "TRAILING") {
+		t.Fatalf("tail lost the most recent output: %q", got[len(got)-32:])
+	}
+}
+
+func TestFormatStderrTail(t *testing.T) {
+	if got := formatStderrTail("   \n  "); got != "" {
+		t.Fatalf("blank stderr = %q, want no suffix", got)
+	}
+
+	lines := make([]string, 0, stderrTailLines+5)
+	for i := range stderrTailLines + 5 {
+		lines = append(lines, fmt.Sprintf("frame %d", i))
+	}
+	got := formatStderrTail(strings.Join(lines, "\n"))
+
+	if strings.Contains(got, "frame 0") {
+		t.Fatalf("expected the oldest frames to be dropped, got %q", got)
+	}
+	if !strings.Contains(got, fmt.Sprintf("frame %d", stderrTailLines+4)) {
+		t.Fatalf("expected the newest frame to survive, got %q", got)
+	}
+	if want := stderrTailLines - 1; strings.Count(got, "; ") != want {
+		t.Fatalf("joined %d separators, want %d: %q", strings.Count(got, "; "), want, got)
+	}
+}

--- a/frontend/assets/entitlements.acp-runtime.plist
+++ b/frontend/assets/entitlements.acp-runtime.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	Entitlements for the Node runtime packaged under Resources/acp-runtime.
+
+	@electron/osx-sign's default entitlements grant allow-jit but not
+	allow-unsigned-executable-memory. Electron's own Chromium build tolerates
+	that because it maps JIT pages with MAP_JIT. A stock nodejs.org build does
+	not: on x86_64 V8's baseline compiler makes its code pages executable with
+	plain mprotect, which the hardened runtime refuses without the entitlement
+	below. The process then aborts inside v8::base::OS::SetPermissions on the
+	first tier-up, which on Intel Macs killed the Claude ACP adapter before it
+	could answer the ACP handshake (#4442). arm64 was unaffected, so the crash
+	only ever reproduced on Intel hardware.
+
+	The rest of this list reproduces @electron/osx-sign's macOS defaults, which
+	this file replaces wholesale for the files it is applied to.
+	-->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.print</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+</dict>
+</plist>

--- a/frontend/forge.config.test.ts
+++ b/frontend/forge.config.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import config, { extraResourcesForPlatform } from "./forge.config";
+import path from "node:path";
+import config, {
+	extraResourcesForPlatform,
+	isPackagedNodeRuntime,
+	optionsForFile,
+} from "./forge.config";
 
 describe("native runtime resources", () => {
 	it.each(["darwin", "linux"] as const)("bundles tmux on %s", (platform) => {
@@ -33,5 +38,39 @@ describe("packaged authentication callback registration", () => {
 				"x-scheme-handler/ao-app",
 			]);
 		}
+	});
+});
+
+const signedBundle = path.join("/tmp", "Agent Orchestrator.app", "Contents", "Resources");
+const packagedNode = path.join(signedBundle, "acp-runtime", "node", "bin", "node");
+
+describe("macOS signing entitlements", () => {
+	it("matches the Node runtime AO packages for the ACP adapter", () => {
+		expect(isPackagedNodeRuntime(packagedNode)).toBe(true);
+	});
+
+	it("leaves every other signed binary on the signer's defaults", () => {
+		// Electron's helpers need @electron/osx-sign's inherit entitlements; a
+		// blanket override would break their signature.
+		for (const other of [
+			path.join(signedBundle, "acp-runtime", "node", "bin", "npx"),
+			path.join(signedBundle, "acp-runtime", "node_modules", ".bin", "node"),
+			path.join(signedBundle, "agent-browser", "node"),
+			path.join(signedBundle, "..", "Frameworks", "Electron Helper.app", "Contents", "MacOS", "Electron Helper"),
+		]) {
+			expect(isPackagedNodeRuntime(other)).toBe(false);
+		}
+	});
+
+	// Without allow-unsigned-executable-memory V8's baseline compiler aborts on
+	// Intel Macs, killing the Claude ACP adapter before the handshake (#4442).
+	it("gives the packaged Node runtime AO's entitlements", () => {
+		expect(optionsForFile(packagedNode)).toEqual({
+			entitlements: "assets/entitlements.acp-runtime.plist",
+		});
+	});
+
+	it("returns no overrides for other files", () => {
+		expect(optionsForFile(path.join(signedBundle, "agent-browser", "node"))).toEqual({});
 	});
 });

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -52,6 +52,34 @@ function parseReleaseRepo(value: string | undefined): { owner: string; name: str
 	return { owner, name };
 }
 
+// AO's packaged Node runtime, relative to the signed .app bundle. Matched by
+// path segments so an unrelated "node" binary elsewhere in the bundle keeps the
+// signer's default entitlements.
+const ACP_RUNTIME_NODE_SEGMENTS = ["acp-runtime", "node", "bin", "node"];
+
+export function isPackagedNodeRuntime(filePath: string): boolean {
+	const parts = filePath.split(path.sep);
+	const start = parts.lastIndexOf(ACP_RUNTIME_NODE_SEGMENTS[0]);
+	if (start === -1) return false;
+	const tail = parts.slice(start);
+	return (
+		tail.length === ACP_RUNTIME_NODE_SEGMENTS.length &&
+		tail.every((part, index) => part === ACP_RUNTIME_NODE_SEGMENTS[index])
+	);
+}
+
+// Per-file signing options. The packaged Node runtime needs
+// allow-unsigned-executable-memory, which @electron/osx-sign's defaults omit;
+// without it V8's baseline compiler aborts on Intel Macs and the Claude ACP
+// adapter dies before the handshake (#4442). Every other file returns {} so the
+// signer keeps applying its own defaults - notably the inherit entitlements
+// Electron's helper apps require, which a blanket override would break.
+export function optionsForFile(filePath: string) {
+	return isPackagedNodeRuntime(filePath)
+		? { entitlements: "assets/entitlements.acp-runtime.plist" }
+		: {};
+}
+
 const config: ForgeConfig = {
 	packagerConfig: {
 		asar: true,
@@ -73,9 +101,9 @@ const config: ForgeConfig = {
 		//    `notarytool store-credentials`. See ao-macos-signed-release runbook.
 		// Both are valid NotaryToolCredentials, so no cast is needed.
 		osxSign: process.env.APPLE_SIGNING_IDENTITY
-			? { identity: process.env.APPLE_SIGNING_IDENTITY }
+			? { identity: process.env.APPLE_SIGNING_IDENTITY, optionsForFile }
 			: process.env.CSC_LINK
-				? {}
+				? { optionsForFile }
 				: undefined,
 		osxNotarize: process.env.AO_NOTARY_PROFILE
 			? { keychainProfile: process.env.AO_NOTARY_PROFILE }


### PR DESCRIPTION
## What

Fixes the Chat-driven Claude Code session failing immediately on Intel Macs with `CHAT_DRIVER_INCOMPATIBLE`, and makes the next runtime failure of this shape report itself instead of surfacing as a bare disconnect.

Two commits:

1. Sign AO's packaged Node runtime with `com.apple.security.cs.allow-unsigned-executable-memory`.
2. Retain the ACP adapter's stderr tail and fold it into the initialize error.

## Why

Fixes #4442.

That issue's original diagnosis (AO spawns `claude` and expects it to speak ACP) is **wrong** — I filed it and have corrected the record [in a comment](https://github.com/Untrivial-ai/agent-orchestrator/issues/4442#issuecomment-5459101802). AO already packages `@agentclientprotocol/claude-agent-acp` and passes `CLAUDE_CODE_EXECUTABLE`; that code needed no change.

The real cause: **AO's packaged Node crashes on Intel Macs.** It aborts inside V8 on first tier-up:

```
# Fatal error in , line 0
# Check failed: 12 == (*__error()).
 3: v8::base::OS::SetPermissions(...)
15: v8::internal::GenerateBaselineCode(...)
```

`@electron/osx-sign`'s default entitlements grant `allow-jit` but not `allow-unsigned-executable-memory`. Electron's own Chromium build tolerates that because it maps JIT pages with `MAP_JIT`; a stock nodejs.org build does not. On x86_64 V8's baseline compiler makes its code pages executable with plain `mprotect`, which the hardened runtime refuses without that entitlement. arm64 maps JIT pages differently and is unaffected — which is why this shipped.

Isolating the signature alone on the shipped 0.10.3 runtime:

| Signing config | Result |
| --- | --- |
| As shipped | crash |
| Signature removed | works |
| ad-hoc + hardened runtime + `allow-jit` only | crash (exact reproduction) |
| ad-hoc + hardened runtime + `allow-jit` + `allow-unsigned-executable-memory` | works |

The second commit exists because the crash was invisible: `spawnAgent` drained the adapter's stderr into `io.Discard`, so the V8 trace was written and thrown away, leaving only `peer disconnected before response`. That is what sent diagnosis toward the wrong subsystem.

## How

**Entitlements** — `optionsForFile` scopes the override to `acp-runtime/node/bin/node` by exact path segments. Every other file returns `{}` so `@electron/osx-sign` keeps applying its own defaults, notably the inherit entitlements Electron's helper apps require; a blanket `entitlements` override would break their signature. The new plist reproduces the signer's macOS defaults plus the one missing key, so nothing the runtime had today is dropped.

**stderr** — draining stays unbounded, so a chatty adapter still cannot fill its OS pipe and deadlock the protocol. Only what is *retained* is capped (8 KiB, last 12 lines in the message). `conv.Close()` is called before reading the tail so the process has driven its stderr pipe to EOF.

Intentionally **not** in this PR, both called out in the issue comment:

- A crashed adapter is still classified `CHAT_DRIVER_INCOMPATIBLE`. It is not a protocol mismatch, but correcting the classification is a behavioural change that deserves its own PR.
- `claudeacp`'s probe runs `node --version`, which exits 0 on a runtime that cannot execute JavaScript. Tightening the probe is likewise separable.

## Testing

**The entitlements fix is verified end-to-end against the real artifact**, not just unit-tested: re-signed the shipped 0.10.3 `acp-runtime` Node with the committed plist under `--options runtime`, then drove the shipped adapter through a genuine ACP `initialize`. It returns a valid result instead of aborting.

```
backend:  go build ./...                                    OK
          gofmt -l internal/adapters/chatdriver/acp/         clean
          go vet ./internal/adapters/chatdriver/acp/          OK
          golangci-lint v2.12.2 (changed package)             0 issues
          go test -race ./internal/adapters/chatdriver/...     all ok
frontend: tsc --noEmit                                        OK
          vitest forge.config.test.ts                         8 passed
```

New tests: `process_test.go` covers stderr retention through a real spawned process, the tail cap, and the error formatting. `forge.config.test.ts` gains coverage that the predicate matches only the packaged runtime and leaves Electron's helpers alone.

Two pre-existing failures on this machine, confirmed against a clean `main` and unrelated to these changes: `TestFullLifecycleSpawnToTermination` (timing-sensitive, fails under full-suite load on slower hardware) and `src/main/browser-view-host.test.ts`.

Verification was done on the affected hardware — Intel Core i7, macOS 15.7.7.

## Checklist

- [x] Branched from `main` (rebased on `upstream/main` @ ae890182d)
- [x] One focused change; links the related issue
- [x] Follows [AGENTS.md](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend)
