### PR TITLE
fix(sqlc): repair the hand-written go_type overrides in sqlc.yaml

### DIFF
--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -241,8 +241,9 @@ sql:
             go_type:
               import: "github.com/aoagents/agent-orchestrator/backend/internal/domain"
               type: "SessionMode"
-	          - column: "agent_switch_failure_policy.enabled"
-	          - column: "app_settings.cloud_offering"
+          - column: "agent_switch_failure_policy.enabled"
+            go_type: "bool"
+          - column: "app_settings.cloud_offering"
             go_type: "bool"
           - column: "sessions.session_mode"
             go_type:


### PR DESCRIPTION
## Problem

`sqlc generate` on a pristine `main` is broken twice over:

1. **sqlc.yaml doesn't parse.** `cf350730b` (#4598) hand-wrote the `go_type` overrides for `agent_switch_failure_policy.enabled` and `app_settings.cloud_offering` with a leading tab on each column line:

   ```
   $ cd backend && go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate
   error parsing sqlc.yaml: yaml: line 244: found character that cannot start any token
   ```

2. **The new entry carries no `go_type` at all.** Even with the tabs fixed, `agent_switch_failure_policy.enabled` is a bare list item — a generator run would type it `int64`, while the committed `gen/` and every consumer (`agent_switch_failure_store.go` uses `!policy.Enabled`) expect `bool`. `app_settings.cloud_offering` (#4621) is the same story: a plain `INTEGER NOT NULL DEFAULT 0 CHECK (cloud_offering IN (0, 1))` column, typed `bool` in the committed `gen/` by hand — its sibling boolean-ish columns (`pr_comment.resolved`, `sessions.auto_review_enabled`, `agent_switches.semantic_handoff_included`) all carry an explicit override, that one didn't.

## Fix

- Repair the indentation (same alignment as the sibling entries).
- Give both entries `go_type: "bool"` — the type the committed `gen/` already uses and the only one the store code compiles against.

## What this PR intentionally does not include

A regenerated `gen/` (or a `sqlc-drift` CI job, as sketched in an earlier revision of this PR): after #4598 the committed `agent_switching.sql.go` is itself hand-written — sqlc now emits named `GetAgentSwitch*Row` structs the store code doesn't use, so a generator run diverges from `gen/` no matter what `sqlc.yaml` says. Reproducible `gen/` remains the bigger ask tracked in #4621; this PR restores the config to a parseable, semantically correct state so the next attempt starts from a working generator.

## Testing

- `cd backend && go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate` — parses and completes
- `go build ./...` — passes (with the committed, untouched `gen/`)
- `gofmt -l .` — clean

Fixes #4621