### PR TITLE
fix(frontend): focus terminal after session switch

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -580,6 +580,18 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.queryByTestId("agent-switch-terminal-overlay")).not.toBeInTheDocument();
 	});
 
+	it("requests terminal focus for a selected TUI worker", () => {
+		renderCenterPane({ session: { ...worker, mode: "tui" } });
+
+		expect(screen.getByText("terminal body")).toHaveAttribute("data-focus-requested", "true");
+	});
+
+	it("does not request worker terminal focus for a Chat session", () => {
+		renderCenterPane({ session: { ...worker, mode: "chat" } });
+
+		expect(screen.getByText("terminal body")).toHaveAttribute("data-focus-requested", "false");
+	});
+
 	it("settles a completed switch without reviving it after the target stops", () => {
 		vi.useFakeTimers();
 		const activeSwitch = switchRecord({ state: "delivering_context" });

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -723,7 +723,7 @@ export function CenterPane({
 						// switch; every other target is interactive as soon as it is on screen.
 						// Without this a worker terminal was only focused mid agent-switch, so
 						// switching sessions left keystrokes going nowhere until you clicked it.
-						focusRequested={target.kind !== "worker" || !workerInputDisabled}
+						focusRequested={target.kind !== "worker" || (session?.mode !== "chat" && !workerInputDisabled)}
 						isFullscreen={isFullscreen}
 						inputDisabled={workerInputDisabled}
 						onChangeFontSize={updateFontSize}

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -29,6 +29,7 @@ const {
 	terminalSessionOptions,
 	xtermMounts,
 	xtermUnmounts,
+	xtermFocusRequests,
 } = vi.hoisted(
 	() => ({
 		attachMock: vi.fn(() => vi.fn()),
@@ -43,6 +44,7 @@ const {
 		terminalSessionOptions: [] as Array<{ coverInitialReplay?: boolean; shellTerminalHandleId?: string }>,
 		xtermMounts: { value: 0 },
 		xtermUnmounts: { value: 0 },
+		xtermFocusRequests: { value: 0 },
 	}),
 );
 let terminalLinkHandler: ((uri: string) => void) | undefined;
@@ -60,6 +62,8 @@ vi.mock("../lib/api-client", () => ({
 
 vi.mock("./XtermTerminal", () => ({
 	XtermTerminal: (props: {
+		focusRequested?: boolean;
+		isVisible?: boolean;
 		onLinkOpen?: (uri: string) => void;
 		onReady?: (terminal: AttachableTerminal) => void;
 	}) => {
@@ -69,6 +73,9 @@ vi.mock("./XtermTerminal", () => ({
 			xtermMounts.value += 1;
 			instance.current = xtermMounts.value;
 		}
+		useEffect(() => {
+			if (props.focusRequested && props.isVisible !== false) xtermFocusRequests.value += 1;
+		}, [props.focusRequested, props.isVisible]);
 		useEffect(() => {
 			const disposable = { dispose: vi.fn() };
 			props.onReady?.({
@@ -144,6 +151,7 @@ beforeEach(() => {
 	sendUserInputMock.mockReturnValue(true);
 	xtermMounts.value = 0;
 	xtermUnmounts.value = 0;
+	xtermFocusRequests.value = 0;
 	useUiStore.setState({ inspectorSessions: {} });
 });
 
@@ -196,11 +204,13 @@ function renderCachedPane({
 	sessions,
 	shellTerminals = [],
 	terminalTarget,
+	focusRequested = false,
 }: {
 	session?: WorkspaceSession;
 	sessions: WorkspaceSession[];
 	shellTerminals?: ShellTerminal[];
 	terminalTarget?: TerminalTarget;
+	focusRequested?: boolean;
 }) {
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	queryClient.setQueryData(workspaceQueryKey, workspaceWithSessions(sessions));
@@ -219,6 +229,7 @@ function renderCachedPane({
 							session={nextSession}
 							terminalTarget={nextTarget}
 							theme="dark"
+							focusRequested={focusRequested}
 						/>
 					) : (
 						<div data-testid="away" />
@@ -545,6 +556,27 @@ describe("TerminalCacheProvider", () => {
 			view.show(sessions[0]);
 			await waitFor(() => expect(activeXterm()).toBe(oldest));
 			expect(xtermMounts.value).toBe(7);
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("focuses each retained TUI terminal when switching among TUI sessions", async () => {
+		const tuiA = { ...sessionA, mode: "tui" as const };
+		const tuiB = { ...sessionB, mode: "tui" as const };
+		const view = renderCachedPane({
+			focusRequested: true,
+			session: tuiA,
+			sessions: [tuiA, tuiB],
+		});
+		try {
+			await waitFor(() => expect(xtermFocusRequests.value).toBe(1));
+
+			view.show(tuiB);
+			await waitFor(() => expect(xtermFocusRequests.value).toBe(2));
+
+			view.show(tuiA);
+			await waitFor(() => expect(xtermFocusRequests.value).toBe(3));
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -51,7 +51,7 @@ type TerminalPaneProps = {
 	onChangeFontSize?: (delta: number) => void;
 	isFullscreen?: boolean;
 	/** Enter or exit fullscreen for the terminal pane that owns this xterm. */
-	onToggleFullscreen?: () => void;
+	onToggleFullscreen?: () => void | Promise<void>;
 	/** Refuse agent PTY input while a controller transition owns the source. */
 	inputDisabled?: boolean;
 	/** Focus the terminal when an in-flight controller asks for human input. */

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -292,6 +292,101 @@ describe("XtermTerminal", () => {
 		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
 	});
 
+	it("does not steal focus from an open dialog or another control", () => {
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		const dialog = document.createElement("div");
+		dialog.setAttribute("role", "dialog");
+		dialog.dataset.state = "open";
+		const dialogInput = document.createElement("input");
+		dialog.appendChild(dialogInput);
+		document.body.appendChild(dialog);
+		dialogInput.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		expect(state.lastTerminal!.focus).not.toHaveBeenCalled();
+
+		dialog.remove();
+		const control = document.createElement("button");
+		document.body.appendChild(control);
+		control.focus();
+		rerender(<XtermTerminal theme="dark" />);
+		state.lastTerminal!.focus.mockClear();
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		expect(state.lastTerminal!.focus).not.toHaveBeenCalled();
+		control.remove();
+	});
+
+	it("allows the session navigation button to hand focus to the destination TUI", async () => {
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		const sessionButton = document.createElement("button");
+		sessionButton.setAttribute("aria-current", "page");
+		document.body.appendChild(sessionButton);
+		sessionButton.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
+		sessionButton.remove();
+	});
+
+	it("allows an in-pane terminal tab to hand focus to the destination TUI", async () => {
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		const topbar = document.createElement("div");
+		topbar.dataset.testid = "session-workspace-topbar";
+		const tab = document.createElement("button");
+		tab.setAttribute("aria-current", "true");
+		tab.setAttribute("role", "tab");
+		topbar.appendChild(tab);
+		document.body.appendChild(topbar);
+		tab.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
+		topbar.remove();
+	});
+
+	it("retries terminal focus after a closing dialog releases focus", async () => {
+		const frames: FrameRequestCallback[] = [];
+		const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			frames.push(callback);
+			return frames.length;
+		});
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		frames.length = 0;
+		const dialog = document.createElement("div");
+		dialog.setAttribute("role", "dialog");
+		dialog.dataset.state = "open";
+		const dialogInput = document.createElement("input");
+		dialog.appendChild(dialogInput);
+		document.body.appendChild(dialog);
+		dialogInput.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+		dialogInput.blur();
+		dialog.remove();
+		expect(frames).toHaveLength(1);
+		act(() => frames.shift()?.(performance.now()));
+
+		expect(state.lastTerminal!.focus).toHaveBeenCalled();
+		requestAnimationFrameSpy.mockRestore();
+	});
+
+	it("focuses a retained terminal when it becomes visible", async () => {
+		const { rerender } = render(<XtermTerminal focusRequested isVisible={false} theme="dark" />);
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested isVisible theme="dark" />);
+
+		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
+	});
+
 	it("updates the live terminal palette when the named color theme changes", () => {
 		const style = document.createElement("style");
 		style.textContent = `
@@ -707,6 +802,62 @@ describe("XtermTerminal", () => {
 		const exitFullscreenItem = await screen.findByText("Exit fullscreen");
 		expect(pane.contains(exitFullscreenItem.closest<HTMLElement>("[role='menu']"))).toBe(true);
 		Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
+	});
+
+	it("returns focus to xterm after entering and exiting fullscreen from the menu", async () => {
+		const onToggleFullscreen = vi.fn(async () => undefined);
+		const frames: FrameRequestCallback[] = [];
+		const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			frames.push(callback);
+			return frames.length;
+		});
+		const { container, rerender } = render(
+			<div className="terminal-pane-frame">
+				<XtermTerminal onToggleFullscreen={onToggleFullscreen} theme="dark" />
+			</div>,
+		);
+		const trigger = document.createElement("button");
+		document.body.appendChild(trigger);
+		trigger.focus();
+		state.lastTerminal!.focus.mockClear();
+		frames.length = 0;
+
+		try {
+			fireEvent.contextMenu(container.querySelector(".terminal-pane-frame")!.firstElementChild!);
+			fireEvent.click(await screen.findByText("Fullscreen terminal"));
+			await act(async () => undefined);
+
+			expect(onToggleFullscreen).toHaveBeenCalledOnce();
+			expect(trigger).not.toHaveFocus();
+			expect(frames).toHaveLength(1);
+			act(() => frames.shift()?.(performance.now()));
+			expect(frames).toHaveLength(1);
+			act(() => frames.shift()?.(performance.now()));
+			expect(state.lastTerminal!.focus).toHaveBeenCalledOnce();
+
+			const pane = container.querySelector(".terminal-pane-frame")!;
+			Object.defineProperty(document, "fullscreenElement", { configurable: true, value: pane });
+			rerender(
+				<div className="terminal-pane-frame">
+					<XtermTerminal isFullscreen onToggleFullscreen={onToggleFullscreen} theme="dark" />
+				</div>,
+			);
+			frames.length = 0;
+			state.lastTerminal!.focus.mockClear();
+
+			fireEvent.contextMenu(pane.querySelector("div")!);
+			fireEvent.click(await screen.findByText("Exit fullscreen"));
+			await act(async () => undefined);
+			expect(onToggleFullscreen).toHaveBeenCalledTimes(2);
+			expect(frames).toHaveLength(1);
+			act(() => frames.shift()?.(performance.now()));
+			act(() => frames.shift()?.(performance.now()));
+			expect(state.lastTerminal!.focus).toHaveBeenCalledOnce();
+		} finally {
+			Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
+			requestAnimationFrameSpy.mockRestore();
+			trigger.remove();
+		}
 	});
 
 	it("runs context menu copy and select all against the xterm instance", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -34,6 +34,7 @@ import type {
 	TerminalUserInputSource,
 } from "../hooks/useTerminalSession";
 import { aoBridge } from "../lib/bridge";
+import { isDialogOrMenuOpen } from "../lib/dom-selectors";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { isWebLink, openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { isMacPlatform } from "../lib/platform";
@@ -67,7 +68,7 @@ export type XtermTerminalProps = {
 	/** Resize this terminal without changing application zoom. */
 	onChangeFontSize?: (delta: number) => void;
 	/** Enter or exit fullscreen for the terminal pane that owns this xterm. */
-	onToggleFullscreen?: () => void;
+	onToggleFullscreen?: () => void | Promise<void>;
 	/**
 	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
 	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
@@ -126,6 +127,7 @@ function loadRenderer(term: Terminal): void {
 const SUPPRESS_NATIVE_PASTE_MS = 100;
 /** Long enough to notice, short enough that a second copy reads as a second copy. */
 const COPY_TOAST_MS = 1400;
+const AUTOFOCUS_RETRY_FRAMES = 2;
 const COLOR_SCHEME_UPDATE_MODE = 2031;
 const COLOR_SCHEME_QUERY = 996;
 
@@ -224,6 +226,21 @@ function normalizedTerminalShortcut(event: KeyboardEvent): string | null {
 function terminalHasFocus(host: HTMLElement): boolean {
 	const activeElement = document.activeElement;
 	return !!activeElement && host.contains(activeElement);
+}
+
+function canAutoFocusTerminal(host: HTMLElement): boolean {
+	if (isDialogOrMenuOpen()) return false;
+	const activeElement = document.activeElement;
+	if (!(activeElement instanceof HTMLElement) || activeElement === document.body || !activeElement.isConnected) return true;
+	if (host.contains(activeElement)) return true;
+	// Selecting a session in the sidebar deliberately leaves its navigation
+	// button focused. Terminal tabs are the same intentional handoff within the
+	// pane. Every other focused control remains authoritative.
+	return (
+		activeElement.matches("button[aria-current='page']") ||
+		(activeElement.matches("button[role='tab'][aria-current]") &&
+			activeElement.closest('[data-testid="session-workspace-topbar"]') !== null)
+	);
 }
 
 type XtermInternal = Terminal & {
@@ -352,6 +369,20 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// A retained terminal can be parked between closing search and this frame.
 		}
 	}, []);
+	const restoreTerminalFocus = useCallback(() => {
+		const activeElement = document.activeElement;
+		if (activeElement instanceof HTMLElement) activeElement.blur();
+		requestAnimationFrame(() => {
+			requestAnimationFrame(() => focusTerminal());
+		});
+	}, [focusTerminal]);
+	const toggleFullscreenAndRestoreFocus = useCallback(async () => {
+		try {
+			await callbacksRef.current.onToggleFullscreen?.();
+		} finally {
+			restoreTerminalFocus();
+		}
+	}, [restoreTerminalFocus]);
 
 	callbacksRef.current = props;
 	showCopiedToastRef.current = () => {
@@ -1272,13 +1303,31 @@ export function XtermTerminal(props: XtermTerminalProps) {
 
 	useEffect(() => {
 		if (!props.focusRequested || props.isVisible === false) return undefined;
-		try {
-			termRef.current?.focus();
-		} catch {
-			// The retained terminal may have been parked during this effect.
-		}
-		return undefined;
-	}, [props.focusRequested, props.isVisible]);
+		let retryFrame: number | null = null;
+		let retriesRemaining = AUTOFOCUS_RETRY_FRAMES;
+		let cancelled = false;
+		const focusIfAllowed = () => {
+			if (cancelled) return;
+			const host = hostRef.current;
+			if (!host || !canAutoFocusTerminal(host)) {
+				if (retriesRemaining === 0) return;
+				retriesRemaining -= 1;
+				retryFrame = requestAnimationFrame(() => {
+					retryFrame = null;
+					focusIfAllowed();
+				});
+				return;
+			}
+			focusTerminal();
+		};
+
+		focusIfAllowed();
+
+		return () => {
+			cancelled = true;
+			if (retryFrame !== null) cancelAnimationFrame(retryFrame);
+		};
+	}, [focusTerminal, props.focusRequested, props.isVisible]);
 
 	useLayoutEffect(() => {
 		if (props.isVisible === false) {
@@ -1423,7 +1472,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 						<DropdownMenuItem
 							onSelect={() => {
 								setContextMenuOpen(false);
-								callbacksRef.current.onToggleFullscreen?.();
+								void toggleFullscreenAndRestoreFocus();
 							}}
 						>
 							{props.isFullscreen ? t("terminal.exitFullscreen") : t("terminal.fullscreen")}

--- a/frontend/src/renderer/lib/restart-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.test.ts
@@ -59,6 +59,26 @@ describe("restartProjectOrchestrator", () => {
 		expect(navigate).not.toHaveBeenCalled();
 	});
 
+	it("blurs the restart control so the replacement terminal can reclaim focus", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+		const restartButton = document.createElement("button");
+		document.body.appendChild(restartButton);
+		restartButton.focus();
+		spawnMock.mockResolvedValue("session-2");
+
+		await restartProjectOrchestrator({
+			projectId: "proj-1",
+			queryClient,
+			navigate: vi.fn(),
+			setProjectRestarting: vi.fn(),
+			setOrchestratorReplacementError: vi.fn(),
+		});
+
+		expect(restartButton).not.toHaveFocus();
+		restartButton.remove();
+	});
+
 	it("still records the replacement error when workspace invalidation fails", async () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		vi.spyOn(queryClient, "invalidateQueries").mockRejectedValue(new Error("refetch failed"));

--- a/frontend/src/renderer/lib/restart-orchestrator.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.ts
@@ -37,6 +37,8 @@ export async function restartProjectOrchestrator({
 	onError,
 	mode,
 }: RestartProjectOrchestratorOptions) {
+	const activeElement = document.activeElement;
+	if (activeElement instanceof HTMLElement) activeElement.blur();
 	setProjectRestarting(projectId, true);
 	setOrchestratorReplacementError(projectId, null);
 	try {


### PR DESCRIPTION
Fixes #2434, #1249

## Root cause

In the current rewrite, `CenterPane` requested terminal focus only for shell and special agent-switch states. Ordinary enabled non-Chat CLI/TUI worker session switches did not set `focusRequested`, so the destination xterm did not receive keyboard focus. Chat is unaffected because `ChatComposer` explicitly restores editor focus on session changes.

## Fix

- Request focus for enabled non-Chat worker sessions.
- Keep Chat sessions out of the worker-terminal focus path.
- Guard xterm autofocus when dialogs or menus are open or another deliberate control owns focus.
- Allow the selected session navigation button (`button[aria-current="page"]`) to hand focus to the destination TUI.
- Preserve retained-terminal focus when the destination becomes visible.

## Verification

- Focus suites: 3 files, 163 tests passed.
- Session/Chat regressions: `SessionView`, `ChatComposer`, and `ChatWorkspace`, 3 files, 225 tests passed.
- Frontend typecheck: passed.
- Renderer Vite build: passed, with existing large-chunk warnings only.
- `git diff --check`: passed.

Native isolated launch evidence: Electron Forge launched the checkout; the renderer reported `http://localhost:5173/`; the daemon listened on `127.0.0.1:3002`; and the isolated API returned both TUI and Chat sessions.

The reporter manually verified the implemented keyboard-focus behavior on the current rewrite.

This is a new current-rewrite implementation path and supersedes the older attach-handle architecture path in #3762. PR #3762 is intentionally unchanged and remains open.