### PR TITLE
 fix  : invoke Windows hook executable with PowerShell call operator

### DIFF
--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -150,7 +150,7 @@ func sessionHookFlags(t *testing.T) []string {
 		}
 	}
 	if runtime.GOOS == "windows" {
-		executable = `"` + executable + `"`
+		executable = `& "` + executable + `"`
 	} else {
 		executable = `'` + strings.ReplaceAll(executable, `'`, `'"'"'`) + `'`
 	}

--- a/backend/internal/adapters/agent/codex/hooks.go
+++ b/backend/internal/adapters/agent/codex/hooks.go
@@ -106,7 +106,12 @@ func appendSessionHookFlagsForExecutable(cmd *[]string, executable string) {
 
 func shellQuoteHookExecutable(executable string) string {
 	if runtime.GOOS == "windows" {
-		return `"` + executable + `"`
+		// Codex invokes command hooks through PowerShell on Windows. A bare quoted
+		// path (`"C:\...\ao.exe"`) parses as a string expression, not an invocation,
+		// so SessionStart/UserPromptSubmit/Stop all fail before ao.exe runs
+		// ("Unexpected token 'hooks'"). Prefixing the quoted path with the call
+		// operator `& ` turns it into a command invocation that runs the binary.
+		return `& "` + executable + `"`
 	}
 	return `'` + strings.ReplaceAll(executable, `'`, `'"'"'`) + `'`
 }


### PR DESCRIPTION
Fixes #4596

## Problem

On Windows, AO injects Codex hook commands that begin with a quoted absolute path but no PowerShell call operator. Codex executes command hooks through PowerShell, so `SessionStart`, `UserPromptSubmit`, and `Stop` all fail before `ao.exe` ever starts:

```
"<AO executable path>" hooks codex stop
# PowerShell: Unexpected token 'hooks' in expression or statement. (exit 1)
```

## Root cause

`shellQuoteHookExecutable` in `backend/internal/adapters/agent/codex/hooks.go` returned `"<path>"` on Windows. In PowerShell a bare quoted string is a string expression, not an invocation.

## Fix

Generate the Windows prefix with the PowerShell call operator:

```
& "<AO executable path>" hooks codex stop
```

Non-Windows quoting is unchanged. The literal-assertion test helper `sessionHookFlags` (which mirrors the emitted `-c` flags so format drift fails loudly) was updated to match.

## Verification

- On Windows, the old literal form reproducibly fails with "Unexpected token" (exit 1); the `&` form invokes the binary successfully.
- `go test ./internal/adapters/agent/codex/ -count=1` passes (Windows host, so the Windows path is exercised).
- `go build ./...` and `go vet ./internal/adapters/agent/codex/` clean.
- Pre-existing `primeagent`/`registry` test failures on this host were confirmed to fail on the base commit too (environmental, unrelated).

## Notes

- Legacy `.codex/hooks.json` cleanup is unaffected: it matches on the `ao hooks codex ` prefix, independent of the executable quoting.
- No API/frontend surface touched; no regeneration needed.
