### PR TITLE
fix(frontend): restore meaningful primary session labels

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -179,9 +179,10 @@ describe("CenterPane toolbar session label", () => {
 			createdAt: "2026-07-22T00:00:00Z",
 		}));
 
-	it("shows the agent surface name for a worker", () => {
+	it("shows the session display name while naming the harness accessibly", () => {
 		renderCenterPane({ session: worker });
-		expect(screen.getByText("Claude Code")).toBeInTheDocument();
+		expect(screen.getByText("do the thing")).toBeInTheDocument();
+		expect(screen.queryByText("Claude Code")).not.toBeInTheDocument();
 		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
 		expect(screen.getByTestId("terminal-interaction-surface")).not.toHaveAttribute("inert");
 		expect(screen.queryByTestId("agent-switch-terminal-overlay")).not.toBeInTheDocument();
@@ -324,7 +325,7 @@ describe("CenterPane toolbar session label", () => {
 		const status = screen.getByRole("status", { name: "Switching from Claude Code to Codex" });
 		expect(within(status).getByText("Switching from Claude Code to Codex")).toBeInTheDocument();
 		expect(within(status).getAllByText(description).length).toBeGreaterThan(0);
-		expect(screen.getByRole("tab", { name: "Claude Code · Working" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "do the thing · Claude Code · Working" })).toBeInTheDocument();
 	});
 
 	it("keeps the preparation stage active while the source handoff is requested", () => {
@@ -572,7 +573,7 @@ describe("CenterPane toolbar session label", () => {
 	it("renders only this session's own tab, never a sibling session", () => {
 		renderCenterPane({ session: worker });
 
-		const sessionTab = screen.getByRole("tab", { name: /^Claude Code/ });
+		const sessionTab = screen.getByRole("tab", { name: /^do the thing/ });
 		const sessionFrame = sessionTab.closest("[data-terminal-tab-frame]");
 		expect(sessionTab).toHaveAttribute("aria-selected", "true");
 		expect(sessionFrame).toHaveClass(
@@ -581,7 +582,7 @@ describe("CenterPane toolbar session label", () => {
 			"bg-overlay",
 		);
 		expect(sessionFrame).not.toHaveClass("session-primary-tab", "rounded-md");
-		expect(sessionTab).toHaveAccessibleName("Claude Code · Working");
+		expect(sessionTab).toHaveAccessibleName("do the thing · Claude Code · Working");
 		expect(sessionTab.querySelector('[title="Working"]')).not.toBeInTheDocument();
 		expect(sessionTab.querySelector('img[aria-hidden="true"]')).toBeInTheDocument();
 		expect(screen.queryByRole("tab", { name: "review the change" })).not.toBeInTheDocument();
@@ -594,7 +595,7 @@ describe("CenterPane toolbar session label", () => {
 		expect(indicator).toHaveClass("bottom-0", "h-0.5");
 	});
 
-	it("keeps the main agent tab permanent, prominent, and solely branded by the harness", () => {
+	it("keeps the main agent tab permanent while the avatar visually signals the harness", () => {
 		const [shell] = makeShells(1);
 		renderCenterPane({
 			session: worker,
@@ -607,7 +608,7 @@ describe("CenterPane toolbar session label", () => {
 			},
 		});
 
-		const mainTab = screen.getByRole("tab", { name: /^Claude Code/ });
+		const mainTab = screen.getByRole("tab", { name: /^do the thing/ });
 		const mainContainer = mainTab.closest("[data-terminal-tab-frame]");
 		expect(mainContainer).toHaveAttribute("data-terminal-role", "primary");
 		expect(mainContainer).toHaveClass("self-stretch", "w-shell-tab-connected");
@@ -633,7 +634,7 @@ describe("CenterPane toolbar session label", () => {
 		const [shell] = makeShells(1);
 		renderCenterPane({ session: worker, shellTerminals: [shell] });
 
-		const ownerTab = screen.getByRole("tab", { name: /^Claude Code/ });
+		const ownerTab = screen.getByRole("tab", { name: /^do the thing/ });
 		const ownerCard = ownerTab.closest("[data-terminal-tab-frame]");
 		const scrollRegion = document.querySelector(".session-tab-scroll-region");
 		const avatar = ownerCard?.querySelector('img[aria-hidden="true"]');
@@ -743,7 +744,7 @@ describe("CenterPane toolbar session label", () => {
 		);
 		expect(shellTab.closest("[data-terminal-tab-frame]")).not.toHaveClass("w-shell-tab-connected");
 		expect(reviewerTab.closest("[data-terminal-tab-frame]")).not.toHaveAttribute("data-terminal-role", "primary");
-		expect(screen.getByRole("tab", { name: /^Claude Code/ })).not.toHaveAttribute("aria-current", "true");
+		expect(screen.getByRole("tab", { name: /^do the thing/ })).not.toHaveAttribute("aria-current", "true");
 		expect(reviewerTab.querySelector("img")).toHaveAttribute("src");
 		expect(screen.queryByRole("button", { name: "Back to agent" })).not.toBeInTheDocument();
 	});
@@ -772,11 +773,14 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.queryByRole("button", { name: "New terminal" })).toBeNull();
 	});
 
-	it("shows 'Orchestrator' for an orchestrator session", () => {
+	it("uses the localized orchestrator label with provider and activity context", () => {
 		renderCenterPane({
 			session: { ...worker, id: "sess-orch", kind: "orchestrator" },
 		});
-		expect(screen.getByText("Orchestrator")).toBeInTheDocument();
+		const orchestratorTab = screen.getByRole("tab", { name: "Orchestrator · Claude Code · Working" });
+		expect(orchestratorTab).toHaveTextContent("Orchestrator");
+		expect(orchestratorTab).not.toHaveTextContent(worker.title);
+		expect(orchestratorTab.querySelector('img[aria-hidden="true"]')).toBeInTheDocument();
 	});
 
 	it("shows 'No session' when there is no session", () => {
@@ -810,7 +814,7 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.queryByRole("toolbar", { name: "Terminal display controls" })).not.toBeInTheDocument();
 		expect(terminalRegion).toContainElement(screen.getByRole("button", { name: "Session tab action" }));
 		expect(screen.getByTestId("session-tab-action").parentElement).toHaveClass("absolute", "right-1", "inset-y-0");
-		expect(screen.getByRole("tab", { name: /^Claude Code/ })).toHaveClass("h-full", "flex-1");
+		expect(screen.getByRole("tab", { name: /^do the thing/ })).toHaveClass("h-full", "flex-1");
 		expect(terminalRegion).not.toContainElement(screen.getByTestId("session-action-region"));
 		const actionRegion = screen.getByTestId("session-action-region");
 		expect(actionRegion).not.toHaveClass("border-l");
@@ -864,7 +868,7 @@ describe("CenterPane toolbar session label", () => {
 		expect(scrollRegion?.classList.contains("terminal-tabs-scrollbar")).toBe(false);
 		expect(scrollRegion?.classList.contains("min-w-flex-min")).toBe(true);
 		expect(scrollRegion?.classList.contains("h-full")).toBe(true);
-		expect(scrollRegion?.contains(screen.getByRole("tab", { name: /^Claude Code/ }).parentElement)).toBe(true);
+		expect(scrollRegion?.contains(screen.getByRole("tab", { name: /^do the thing/ }).parentElement)).toBe(true);
 		for (const tab of screen.getAllByTitle(/^\/tmp\/ws/)) {
 			const frame = tab.closest("[data-terminal-tab-frame]");
 			expect(frame?.classList.contains("max-w-shell-tab-max")).toBe(true);
@@ -915,12 +919,12 @@ describe("CenterPane toolbar session label", () => {
 			Array.from(screen.getByRole("tablist", { name: "Open terminals" }).querySelectorAll('[role="tab"]')).map(
 				(tab) => tab.textContent,
 			);
-		expect(tabLabels()).toEqual(["Claude Code", "Reviewer", "agent-orchestrator-0", "agent-orchestrator-1"]);
+		expect(tabLabels()).toEqual(["do the thing", "Reviewer", "agent-orchestrator-0", "agent-orchestrator-1"]);
 		expect(reorderMocks.onReorder).toBeTypeOf("function");
 
 		act(() => reorderMocks.onReorder?.(["h-0", "reviewer:review-sess-1", "h-1"]));
 
-		expect(tabLabels()).toEqual(["Claude Code", "agent-orchestrator-0", "Reviewer", "agent-orchestrator-1"]);
+		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-0", "Reviewer", "agent-orchestrator-1"]);
 	});
 
 	it("drops a session's remembered terminal order after navigating away", () => {
@@ -932,7 +936,7 @@ describe("CenterPane toolbar session label", () => {
 			);
 
 		act(() => reorderMocks.onReorder?.(["h-1", "h-0"]));
-		expect(tabLabels()).toEqual(["Claude Code", "agent-orchestrator-1", "agent-orchestrator-0"]);
+		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-1", "agent-orchestrator-0"]);
 
 		view.rerender(
 			<TooltipProvider>
@@ -945,7 +949,7 @@ describe("CenterPane toolbar session label", () => {
 			</TooltipProvider>,
 		);
 
-		expect(tabLabels()).toEqual(["Claude Code", "agent-orchestrator-0", "agent-orchestrator-1"]);
+		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-0", "agent-orchestrator-1"]);
 	});
 
 	it("scrolls the tab strip horizontally with the mouse wheel", () => {
@@ -1029,7 +1033,7 @@ describe("CenterPane toolbar session label", () => {
 			onRenameShellTerminal,
 		});
 
-		const sessionTab = screen.getByRole("tab", { name: /^Claude Code/ });
+		const sessionTab = screen.getByRole("tab", { name: /^do the thing/ });
 		const firstShellTab = screen.getByRole("tab", {
 			name: "agent-orchestrator-0",
 		});

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -290,7 +290,7 @@ export function CenterPane({
 	const sessionTabLabel = session
 		? isOrchestratorSession(session)
 			? t("shell.orchestrator")
-			: agentLabel(session.provider)
+			: session.title
 		: t("terminal.noSession");
 	const activeTerminalLabel =
 		target.kind === "shell"
@@ -882,6 +882,7 @@ export function SessionPaneTab({
 	const { t } = useTranslation();
 	const { ref, isTruncated } = useTruncatedText<HTMLButtonElement>(label);
 	const activityLabel = session ? getAgentActivityView(session.activity, t).label : undefined;
+	const providerLabel = session ? agentLabel(session.provider) : undefined;
 	const tabIcon = session ? <AgentAvatar className="size-terminal-agent-icon" decorative provider={session.provider} /> : icon;
 	const connected = appearance === "connected";
 	return (
@@ -890,7 +891,7 @@ export function SessionPaneTab({
 			active={isActive}
 			buttonProps={{
 				"aria-current": isActive,
-				"aria-label": activityLabel ? `${label} · ${activityLabel}` : label,
+				"aria-label": [label, providerLabel, activityLabel].filter(Boolean).join(" · "),
 				"aria-selected": isActive,
 				onClick: onSelect,
 				role: "tab",

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -171,6 +171,7 @@ const chatSession = {
 	mode: "chat",
 	status: "working",
 	updatedAt: "2026-08-15T00:00:00Z",
+	activity: { state: "active", lastActivityAt: "2026-08-15T00:00:00Z" },
 	prs: [],
 } satisfies WorkspaceSession;
 
@@ -350,21 +351,39 @@ describe("ChatWorkspace timeline", () => {
 		expect(onDecide).toHaveBeenCalledWith("drain-approval", "allow_once");
 	});
 
-	it("uses the shared session topbar chrome for workers and orchestrators", () => {
-		const view = render(<ChatWorkspace snapshot={chatFixture} sessionRole="worker" />);
+	it("labels worker and orchestrator primary tabs with accessible provider context", () => {
+		const view = render(<ChatWorkspace snapshot={chatFixture} session={chatSession} sessionRole="worker" />);
 
 		expect(screen.getByLabelText("Chat")).toHaveAttribute("data-session-role", "worker");
 		expect(screen.getByTestId("session-workspace-topbar")).toBeInTheDocument();
 		expect(screen.getByTestId("session-terminal-region")).toBeInTheDocument();
-		expect(screen.getByRole("tab", { name: chatFixture.title })).toBeInTheDocument();
+		const workerTab = screen.getByRole("tab", { name: "Reviewer chat · Codex · Working" });
+		expect(workerTab).toHaveTextContent(chatSession.title);
+		expect(workerTab).not.toHaveTextContent("Codex");
+		expect(workerTab.querySelector('img[aria-hidden="true"]')).toBeInTheDocument();
 
-		view.rerender(<ChatWorkspace snapshot={chatFixture} sessionRole="orchestrator" />);
+		view.rerender(
+			<ChatWorkspace
+				snapshot={chatFixture}
+				session={{ ...chatSession, id: "ao-demo-orchestrator", kind: "orchestrator" }}
+				sessionRole="orchestrator"
+			/>,
+		);
 
 		expect(screen.getByLabelText("Chat")).toHaveAttribute("data-session-role", "orchestrator");
 		expect(screen.getByTestId("session-workspace-topbar")).toBeInTheDocument();
 		const actionRegion = screen.getByTestId("session-action-region");
 		expect(actionRegion).toHaveClass("pl-2", "pr-3");
 		expect(actionRegion).not.toHaveClass("px-3");
+		expect(screen.getByRole("tab", { name: "Orchestrator · Codex · Working" })).toBeInTheDocument();
+
+		view.rerender(
+			<ChatWorkspace
+				snapshot={chatFixture}
+				session={{ ...chatSession, id: "legacy-orchestrator", kind: undefined }}
+			/>,
+		);
+		expect(screen.getByRole("tab", { name: "Orchestrator · Codex · Working" })).toBeInTheDocument();
 	});
 
 	it("clears the fixed titlebar nav when the sidebar is collapsed, like the terminal session", () => {
@@ -394,7 +413,7 @@ describe("ChatWorkspace timeline", () => {
 		);
 
 		const terminalRegion = screen.getByTestId("session-terminal-region");
-		expect(terminalRegion).toContainElement(screen.getByRole("tab", { name: /^Codex/ }));
+		expect(terminalRegion).toContainElement(screen.getByRole("tab", { name: /^Reviewer chat/ }));
 		expect(terminalRegion).toContainElement(screen.getByRole("button", { name: "Session tab action" }));
 		expect(screen.getByTestId("session-tab-action")).toContainElement(
 			screen.getByRole("button", { name: "Session tab action" }),
@@ -1857,7 +1876,7 @@ describe("ChatWorkspace reviewer tabs", () => {
 			/>,
 		);
 
-		const chatTab = screen.getByRole("tab", { name: /^Codex/ });
+		const chatTab = screen.getByRole("tab", { name: /^Reviewer chat/ });
 		const reviewerTab = screen.getByRole("tab", { name: "Reviewer" });
 		expect(chatTab).toHaveClass("px-2", "cursor-pointer");
 		expect(chatTab.closest("[data-terminal-tab-frame]")).toHaveClass("self-stretch");
@@ -2000,7 +2019,7 @@ describe("ChatWorkspace reviewer tabs", () => {
 		};
 		const view = render(<ChatWorkspace {...common} />);
 		const chatTab = screen.getByRole("tab", {
-			name: /^Codex/,
+			name: /^Reviewer chat/,
 		});
 		const reviewerTab = screen.getByRole("tab", { name: "Reviewer" });
 		expect(chatTab).toHaveAttribute("tabindex", "0");
@@ -2024,7 +2043,7 @@ describe("ChatWorkspace reviewer tabs", () => {
 
 		view.rerender(<ChatWorkspace {...common} reviewerTarget={reviewerTarget} />);
 		const activeReviewerTab = screen.getByRole("tab", { name: "Reviewer" });
-		expect(screen.getByRole("tab", { name: /^Codex/ })).toHaveAttribute(
+		expect(screen.getByRole("tab", { name: /^Reviewer chat/ })).toHaveAttribute(
 			"tabindex",
 			"-1",
 		);
@@ -2033,7 +2052,7 @@ describe("ChatWorkspace reviewer tabs", () => {
 		activeReviewerTab.focus();
 		fireEvent.keyDown(activeReviewerTab, { key: "Home" });
 		expect(onSelectChat).toHaveBeenCalledOnce();
-		expect(screen.getByRole("tab", { name: /^Codex/ })).toHaveFocus();
+		expect(screen.getByRole("tab", { name: /^Reviewer chat/ })).toHaveFocus();
 
 		onSelectChat.mockClear();
 		activeReviewerTab.focus();
@@ -2203,7 +2222,7 @@ describe("ChatWorkspace shell tabs", () => {
 			/>,
 		);
 
-		const workerTab = screen.getByRole("tab", { name: /^Codex/ });
+		const workerTab = screen.getByRole("tab", { name: /^Reviewer chat/ });
 		workerTab.focus();
 		fireEvent.keyDown(workerTab, { key: "Tab", ctrlKey: true });
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -29,6 +29,7 @@ import {
 	type WheelEvent as ReactWheelEvent,
 } from "react";
 import { ArrowDown, Loader2, TriangleAlert, Undo2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { cn } from "../../lib/utils";
 import { sameContent, useStableList } from "../../lib/stable-list";
 import { useTabScrollEdges } from "../../hooks/useTabScrollEdges";
@@ -46,7 +47,11 @@ import { agentLabel } from "../../lib/agent-options";
 import type { ShellTerminal } from "../../hooks/useShellTerminals";
 import { sidebarOccupiesLayout, useUiStore } from "../../stores/ui-store";
 import type { TerminalTarget } from "../../types/terminal";
-import type { SessionKind, WorkspaceSession } from "../../types/workspace";
+import {
+	isOrchestratorSession,
+	type SessionKind,
+	type WorkspaceSession,
+} from "../../types/workspace";
 import { AgentAvatar } from "../AgentAvatar";
 import { SessionPaneTab } from "../CenterPane";
 import { Button } from "../ui/button";
@@ -294,6 +299,7 @@ export interface ChatWorkspaceProps {
 
 export function ChatWorkspace({
 	snapshot,
+	sessionTitle,
 	sessionRole = "worker",
 	headerActions,
 	sessionTabAction,
@@ -753,6 +759,8 @@ export function ChatWorkspace({
 		>
 			<ChatHeader
 				snapshot={snapshot}
+				sessionTitle={sessionTitle}
+				sessionRole={sessionRole}
 				reviewerTerminal={reviewerTerminal}
 				onOpenReviewerTerminal={onOpenReviewerTerminal}
 				reviewerActive={reviewerActive}
@@ -1125,6 +1133,8 @@ function readableItems(snapshot: ConversationSnapshot): ConversationItem[] {
 
 function ChatHeader({
 	snapshot,
+	sessionTitle,
+	sessionRole,
 	reviewerTerminal,
 	onOpenReviewerTerminal,
 	reviewerActive,
@@ -1145,6 +1155,8 @@ function ChatHeader({
 	session,
 }: {
 	snapshot: ConversationSnapshot;
+	sessionTitle?: string;
+	sessionRole: SessionKind;
 	reviewerTerminal?: { handleId: string; harness: string };
 	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 	/** The reviewer tab is selected; the chat tab is the clickable alternative. */
@@ -1169,7 +1181,14 @@ function ChatHeader({
 	inline?: boolean;
 	topbarBounds: TopbarBounds;
 }) {
-	const label = agentLabel(snapshot.harness);
+	const { t } = useTranslation();
+	const providerLabel = agentLabel(snapshot.harness);
+	const sessionIsOrchestrator = session
+		? isOrchestratorSession(session)
+		: sessionRole === "orchestrator";
+	const label = sessionIsOrchestrator
+		? t("shell.orchestrator")
+		: (sessionTitle || session?.title || snapshot.title || snapshot.sessionId);
 	const tabScrollWatch = `${session?.id ?? ""}|${reviewerTerminal?.handleId ?? ""}|${(shellTerminals ?? []).map((shell) => shell.handleId).join("|")}`;
 	const {
 		scrollRef: tabsOverflowRef,
@@ -1223,7 +1242,7 @@ function ChatHeader({
 						) : (
 							<button
 								aria-current={timelineActive ? true : undefined}
-								aria-label={label}
+								aria-label={`${label} · ${providerLabel}`}
 								aria-selected={timelineActive}
 								data-terminal-role="primary"
 								className={cn(

--- a/frontend/src/renderer/components/chat/ChatWorkspaceRollback.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspaceRollback.test.tsx
@@ -127,16 +127,16 @@ describe("ChatWorkspace rollback", () => {
 		expect(screen.getByRole("alert").textContent).toContain("stop the agent");
 	});
 
-	it("shows the agent surface in the header when the thread has a title", () => {
+	it("shows the thread title in the primary agent tab when there is one", () => {
 		render(<ChatWorkspace snapshot={{ ...chatFixture, title: "Fix OAuth Return URL Loss" }} />);
-		expect(screen.getByText("Codex")).toBeInTheDocument();
-		expect(screen.queryByText("Fix OAuth Return URL Loss")).toBeNull();
+		expect(screen.getByRole("tab", { name: "Fix OAuth Return URL Loss · Codex" })).toBeInTheDocument();
+		expect(screen.queryByText("Codex")).toBeNull();
 		expect(screen.queryByText(chatFixture.sessionId)).toBeNull();
 	});
 
-	it("shows the agent surface when the thread has no name", () => {
+	it("falls back to the session id when the thread has no name", () => {
 		render(<ChatWorkspace snapshot={chatFixture} />);
-		expect(screen.getByText("Codex")).toBeInTheDocument();
-		expect(screen.queryByText(chatFixture.sessionId)).toBeNull();
+		expect(screen.getByRole("tab", { name: `${chatFixture.sessionId} · Codex` })).toBeInTheDocument();
+		expect(screen.queryByText("Codex")).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
- restore worker primary agent tabs to the session display name/title in both terminal and chat session surfaces
- keep the provider avatar as the harness signal without repeating the harness name as tab text
- retain the established localized `shell.orchestrator` label for orchestrator primary tabs
- compose primary-tab accessibility names from session title, provider, and activity state, such as `Build screenshot-ready dashboard data · Cursor · Working`

## Regression history
This behavior changed in PR #4252, not in a dedicated tab-label change:

- Before #4252, `CenterPane` used `session.title`, while `ChatWorkspace` used `sessionTitle || snapshot.title || snapshot.sessionId`.
- The file-tabs design added in that PR described the permanent tab as the “active agent surface” and gave examples such as “Terminal or Claude.”
- During review on **2026-08-27**, [the CenterPane review comment](https://github.com/Untrivial-ai/agent-orchestrator/pull/4252#discussion_r3869593014) and [the parallel ChatWorkspace comment](https://github.com/Untrivial-ai/agent-orchestrator/pull/4252#discussion_r3869593020) asked for the provider/agent surface label instead of the task title.
- Unsquashed merge commit `82117fbae` implemented those requests by changing both labels to the harness display name; squash merge `1239474e5` landed the change on `main` later that day.

That interpretation made the permanent tab less useful: the existing provider avatar already communicates the harness, so text such as “Claude Code” or “Codex” repeated the same signal and removed the session identity. This PR restores the earlier meaningful identity without changing the file tabs, topbar, branch UI, or provider avatar.

## Tests
- `npm test -- --run src/renderer/components/CenterPane.test.tsx src/renderer/components/chat/ChatWorkspace.test.tsx src/renderer/components/chat/ChatWorkspaceRollback.test.tsx` (143 passed)
- `npm run typecheck`
- `git diff --check`

## Preview verification
Opened `dev:web` through `ao preview` in the session-owned AO Browser panel and verified:

- worker: visible `Build screenshot-ready dashboard data`, announced as `Build screenshot-ready dashboard data · Cursor · Working`, with no visible `Cursor` label beside its avatar
- orchestrator: visible `Orchestrator`, announced with provider and activity context, with no session title or `Codex` label beside its avatar

No new browser console errors were introduced. The preview fixture's existing aborted notification SSE requests appeared during navigation and are unrelated to this change.

