### PR TITLE
fix(desktop): keep update status reactive across settings and sidebar

### DIFF
--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -471,6 +471,33 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.getByRole("status")).toHaveTextContent("You're on the latest version.");
 	});
 
+	it("refreshes Last checked immediately and does not let a stale IPC snapshot roll it back", async () => {
+		let resolveInitialStatus: (status: { state: "idle" }) => void = () => undefined;
+		let emit: (status: { state: string; checkedAt?: number; requestId?: string }) => void = () => undefined;
+		updGetStatus.mockReturnValue(new Promise((resolve) => {
+			resolveInitialStatus = resolve;
+		}));
+		updOnStatus.mockImplementation((listener: (status: unknown) => void) => {
+			emit = listener as typeof emit;
+			return () => undefined;
+		});
+		renderForm();
+		const button = await screen.findByRole("button", { name: "Check for updates" });
+
+		await userEvent.click(button);
+		const requestId = updCheck.mock.calls.at(-1)?.[0]?.requestId;
+		const checkedAt = new Date("2026-08-29T16:42:00.000Z").getTime();
+		act(() => emit({ state: "not-available", checkedAt, requestId }));
+
+		const formatted = new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short" }).format(checkedAt);
+		expect(await screen.findByTestId("update-checked-at")).toHaveTextContent(`Last checked ${formatted}`);
+
+		// This is the mount-time response arriving after the completed-check push.
+		// Reopening Settings used to be the only way to recover from this rollback.
+		await act(async () => resolveInitialStatus({ state: "idle" }));
+		expect(screen.getByTestId("update-checked-at")).toHaveTextContent(`Last checked ${formatted}`);
+	});
+
 	it("offers an Update button when an update is available and downloads it", async () => {
 		let emit: (s: { state: string; version?: string; requestId?: string }) => void = () => undefined;
 		updOnStatus.mockImplementation((cb: (s: unknown) => void) => {

--- a/frontend/src/renderer/hooks/useUpdateStatus.ts
+++ b/frontend/src/renderer/hooks/useUpdateStatus.ts
@@ -1,11 +1,62 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import type { UpdateStatus } from "../../main/update-settings";
 import { aoBridge } from "../lib/bridge";
 
+const IDLE_STATUS: UpdateStatus = { state: "idle" };
+let currentStatus = IDLE_STATUS;
+let statusEventRevision = 0;
+let connectionRevision = 0;
+let removeStatusListener: (() => void) | undefined;
+const storeListeners = new Set<() => void>();
+const eventListeners = new Set<(status: UpdateStatus) => void>();
+
+function publishStatus(status: UpdateStatus): void {
+	currentStatus = status;
+	for (const listener of eventListeners) listener(status);
+	for (const listener of storeListeners) listener();
+}
+
+function connect(): void {
+	if (removeStatusListener) return;
+	const connection = ++connectionRevision;
+	const snapshotRevision = statusEventRevision;
+	removeStatusListener = aoBridge.updates.onStatus((status) => {
+		if (connection !== connectionRevision) return;
+		statusEventRevision += 1;
+		publishStatus(status);
+	});
+	void aoBridge.updates.getStatus().then((status) => {
+		// The IPC snapshot is requested after the push listener is installed. If
+		// a newer push wins while that request is in flight, never let the older
+		// snapshot roll the shared store (and Last checked) backward.
+		if (connection !== connectionRevision || statusEventRevision !== snapshotRevision) return;
+		publishStatus(status);
+	});
+}
+
+function subscribe(listener: () => void): () => void {
+	storeListeners.add(listener);
+	connect();
+	return () => {
+		storeListeners.delete(listener);
+		if (storeListeners.size !== 0) return;
+		connectionRevision += 1;
+		removeStatusListener?.();
+		removeStatusListener = undefined;
+		statusEventRevision = 0;
+		currentStatus = IDLE_STATUS;
+	};
+}
+
+function getSnapshot(): UpdateStatus {
+	return currentStatus;
+}
+
 /**
- * Live desktop update status: seeded from updates.getStatus, then streamed via
- * the updates:status push channel. Used by the sidebar restart-to-update row
- * and the Global Settings Updates section.
+ * Live desktop update status, shared by Settings and the sidebar. The store
+ * subscribes before requesting its initial IPC snapshot and rejects that
+ * snapshot if a newer push arrives first, so async hydration cannot overwrite
+ * a completed check/download event with stale state.
  *
  * Deliberately carries no telemetry. Two components mount this hook, so each
  * would report the same outcome, and the statuses it sees are the UI's view:
@@ -13,24 +64,13 @@ import { aoBridge } from "../lib/bridge";
  * owned by the main process and subscribed once in lib/update-telemetry.ts.
  */
 export function useUpdateStatus(onStatusEvent?: (status: UpdateStatus) => void): UpdateStatus {
-	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
 	const onStatusEventRef = useRef(onStatusEvent);
 	onStatusEventRef.current = onStatusEvent;
+	const status = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 	useEffect(() => {
-		let live = true;
-		void aoBridge.updates.getStatus().then((s) => {
-			if (!live) return;
-			onStatusEventRef.current?.(s);
-			setStatus(s);
-		});
-		const off = aoBridge.updates.onStatus((next) => {
-			onStatusEventRef.current?.(next);
-			setStatus(next);
-		});
-		return () => {
-			live = false;
-			off?.();
-		};
+		const listener = (next: UpdateStatus) => onStatusEventRef.current?.(next);
+		eventListeners.add(listener);
+		return () => void eventListeners.delete(listener);
 	}, []);
 	return status;
 }


### PR DESCRIPTION
## Reproduction

1. Open Settings → Updates.
2. Click Check for updates.
3. Let the check complete.
4. The visible Last checked timestamp can retain the mount-time value until Settings is closed and reopened.

The regression test reproduces the ordering directly: a completed-check push arrives first, then the older mount-time IPC snapshot resolves.

## Root cause

Each `useUpdateStatus` caller owned an independent `getStatus` request and `updates:status` listener. Snapshot hydration started before the listener was registered, and a late snapshot was always applied. An older response could therefore overwrite a newer pushed status, including `checkedAt`; Settings and the sidebar could also hydrate divergent local copies.

The renderer now uses one shared external updater store. It subscribes before requesting the initial snapshot and revision-gates that snapshot so a newer push wins. This remains a projection of the existing main-process updater state machine.

## Latest-main relevance audit (2026-09-01)

Rebased onto `main` at `8a88be0c7`.

`main` now includes #4729, which independently added the proactive sidebar update affordance, download/restart/retry states, tests, and per-version dismissal. Those older UI changes from this PR were intentionally dropped during conflict resolution so the newer product behavior remains authoritative.

The underlying reactivity bug is still present on latest `main`: `useUpdateStatus` still creates per-consumer state, starts independent snapshots, and permits a late snapshot to roll back a newer status push. The shared store fix remains relevant and now keeps the existing Settings and #4729 sidebar surfaces synchronized.

## Tests

- `npm test -- --run src/renderer/components/GlobalSettingsForm.test.tsx src/renderer/components/Sidebar.test.tsx` — 123 passed
- `npm run typecheck`
- `npm run typecheck:e2e`

## Scope

After the rebase this is a focused two-file change: the shared updater status store plus the immediate Last checked regression test. The current sidebar UX from `main` is unchanged.