### PR TITLE
fix: align session usage costs and card metrics

### DIFF
--- a/backend/internal/domain/usage.go
+++ b/backend/internal/domain/usage.go
@@ -340,18 +340,17 @@ type UsageModelAggregate struct {
 // CompactSessionUsageAggregate is one batched storage row before checked token
 // and cost derivation.
 type CompactSessionUsageAggregate struct {
-	SessionID       SessionID
-	ProcessedTokens *int64
-	Incomplete      bool
-	Cost            UsageCostAggregate
+	SessionID  SessionID
+	Tokens     UsageTokenMetrics
+	Incomplete bool
+	Cost       UsageCostAggregate
 }
 
 // CompactSessionUsage is the dashboard usage read model.
 type CompactSessionUsage struct {
-	SessionID       SessionID
-	ProcessedTokens *int64
-	Incomplete      bool
-	EstimatedCost   *EstimatedCost
+	SessionID  SessionID
+	Incomplete bool
+	Totals     UsageMetricTotals
 }
 
 // UsageMetricTotals is the aggregate metric block used by session, harness,

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6030,12 +6030,17 @@ components:
           format: int64
           minimum: 0
           type: integer
+        totals:
+          $ref: '#/components/schemas/UsageTotalsResponse'
+          description: Canonical token categories and estimated cost used by card
+            detail disclosures.
       required:
       - sessionId
       - processedTokens
       - totalTokens
       - incomplete
       - estimatedCost
+      - totals
       type: object
     ContainerReapConfig:
       properties:
@@ -9473,7 +9478,6 @@ components:
           anyOf:
           - type: "null"
           - $ref: '#/components/schemas/EstimatedCostResponse'
-            type: object
         inputTokens:
           description: Total input, including cached and uncached input.
           minimum: 0

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1088,6 +1088,7 @@ type CompactSessionUsageResponse struct {
 	TotalTokens     int64                  `json:"totalTokens" minimum:"0" description:"Deprecated compatibility alias for processedTokens."`
 	Incomplete      bool                   `json:"incomplete"`
 	EstimatedCost   *EstimatedCostResponse `json:"estimatedCost"`
+	Totals          UsageTotalsResponse    `json:"totals" description:"Canonical token categories and estimated cost used by card detail disclosures."`
 }
 
 // ListCompactSessionUsageResponse is the batch dashboard usage response.

--- a/backend/internal/httpd/controllers/usage.go
+++ b/backend/internal/httpd/controllers/usage.go
@@ -41,13 +41,14 @@ func (c *UsageController) listSessions(w http.ResponseWriter, r *http.Request) {
 	out := make([]CompactSessionUsageResponse, 0, len(items))
 	for _, item := range items {
 		var totalTokens int64
-		if item.ProcessedTokens != nil {
-			totalTokens = *item.ProcessedTokens
+		if item.Totals.ProcessedTokens != nil {
+			totalTokens = *item.Totals.ProcessedTokens
 		}
 		out = append(out, CompactSessionUsageResponse{
-			SessionID: item.SessionID, ProcessedTokens: item.ProcessedTokens,
+			SessionID: item.SessionID, ProcessedTokens: item.Totals.ProcessedTokens,
 			TotalTokens: totalTokens, Incomplete: item.Incomplete,
-			EstimatedCost: estimatedCostResponse(item.EstimatedCost),
+			EstimatedCost: estimatedCostResponse(item.Totals.EstimatedCost),
+			Totals:        usageTotalsResponse(item.Totals),
 		})
 	}
 	envelope.WriteJSON(w, http.StatusOK, ListCompactSessionUsageResponse{Sessions: out})

--- a/backend/internal/httpd/controllers/usage_test.go
+++ b/backend/internal/httpd/controllers/usage_test.go
@@ -43,18 +43,26 @@ func newUsageTestServer(t *testing.T, svc *fakeUsageSummaryService) *httptest.Se
 
 func TestUsageAPIListsCompactProjectUsage(t *testing.T) {
 	inputCost := int64(300000000)
+	input := int64(10_000)
+	cachedInput := int64(4_000)
+	uncachedInput := int64(6_000)
+	output := int64(2_300)
 	processed := int64(12300)
 	unavailableProcessed := int64(3)
 	svc := &fakeUsageSummaryService{items: []domain.CompactSessionUsage{
 		{
-			SessionID: "reverb-12", ProcessedTokens: &processed, Incomplete: true,
-			EstimatedCost: &domain.EstimatedCost{
-				TotalNanos: 420000000, InputNanos: &inputCost,
-				Coverage:            domain.EstimatedCostCoveragePartial,
-				ProviderAttribution: domain.EstimatedCostProviderAttributionInferred,
+			SessionID: "reverb-12", Incomplete: true,
+			Totals: domain.UsageMetricTotals{
+				InputTokens: &input, CachedInputTokens: &cachedInput, UncachedInputTokens: &uncachedInput,
+				OutputTokens: &output, ProcessedTokens: &processed,
+				EstimatedCost: &domain.EstimatedCost{
+					TotalNanos: 420000000, InputNanos: &inputCost,
+					Coverage:            domain.EstimatedCostCoveragePartial,
+					ProviderAttribution: domain.EstimatedCostProviderAttributionInferred,
+				},
 			},
 		},
-		{SessionID: "unavailable", ProcessedTokens: &unavailableProcessed},
+		{SessionID: "unavailable", Totals: domain.UsageMetricTotals{ProcessedTokens: &unavailableProcessed}},
 	}}
 	srv := newUsageTestServer(t, svc)
 
@@ -72,12 +80,21 @@ func TestUsageAPIListsCompactProjectUsage(t *testing.T) {
 			TotalTokens     int64           `json:"totalTokens"`
 			Incomplete      bool            `json:"incomplete"`
 			EstimatedCost   json.RawMessage `json:"estimatedCost"`
+			Totals          struct {
+				InputTokens         int64 `json:"inputTokens"`
+				CachedInputTokens   int64 `json:"cachedInputTokens"`
+				UncachedInputTokens int64 `json:"uncachedInputTokens"`
+				OutputTokens        int64 `json:"outputTokens"`
+				ProcessedTokens     int64 `json:"processedTokens"`
+			} `json:"totals"`
 		} `json:"sessions"`
 	}
 	mustJSON(t, body, &got)
 	if len(got.Sessions) != 2 || got.Sessions[0].SessionID != "reverb-12" ||
 		got.Sessions[0].ProcessedTokens != 12300 || got.Sessions[0].TotalTokens != 12300 ||
-		!got.Sessions[0].Incomplete {
+		!got.Sessions[0].Incomplete || got.Sessions[0].Totals.InputTokens != 10000 ||
+		got.Sessions[0].Totals.CachedInputTokens != 4000 || got.Sessions[0].Totals.UncachedInputTokens != 6000 ||
+		got.Sessions[0].Totals.OutputTokens != 2300 || got.Sessions[0].Totals.ProcessedTokens != 12300 {
 		t.Fatalf("response = %+v", got)
 	}
 	var cost struct {

--- a/backend/internal/observe/usage/ingestor.go
+++ b/backend/internal/observe/usage/ingestor.go
@@ -317,13 +317,19 @@ func (i *Ingestor) Ingest(ctx context.Context, sourceID int64) (IngestResult, er
 		apply = func() error {
 			return i.pricing.WithSnapshot(ctx, func(snapshot *pricing.Snapshot) error {
 				for index := range parsed.Events {
-					// Live ingestion prices only what the transcript or the
-					// binding's route hint named outright. Resolving the model
-					// against the catalog would turn "one catalog lists this
-					// name" into a billed provider and a dollar amount in the
-					// same write, for a session whose route may simply not have
-					// been recorded yet. Deriving it is the legacy repairer's
-					// job, once no hook is coming.
+					// A unique catalog owner is reliable fallback evidence when a
+					// provider-native record omitted its billing route. Persist it
+					// explicitly as inferred so a later observed route can still
+					// replace both attribution and cost. An unidentified Claude
+					// proxy is different: its hook proved that model ownership is
+					// not the billing route, so it must stay honestly unpriced.
+					if parsed.Events[index].BillingProviderID == "" &&
+						strings.TrimSpace(source.ProviderHint) != pricing.UnidentifiedBillingRoute {
+						if providerID := snapshot.ProviderForModel(parsed.Events[index].ModelID); providerID != "" {
+							parsed.Events[index].BillingProviderID = providerID
+							parsed.Events[index].BillingProviderSource = domain.UsageBillingProviderInferred
+						}
+					}
 					estimate, estimateErr := snapshot.Estimate(parsed.Events[index])
 					if estimateErr != nil {
 						parsed.Events[index].Costs.PricingVersion = snapshot.ProviderVersion(parsed.Events[index].BillingProviderID)

--- a/backend/internal/observe/usage/ingestor_integration_test.go
+++ b/backend/internal/observe/usage/ingestor_integration_test.go
@@ -19,6 +19,72 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
+func TestIngestorInfersUniqueBillingProviderForFreshHarnessUsage(t *testing.T) {
+	t.Run("Claude Code", func(t *testing.T) {
+		dataDir := t.TempDir()
+		store, source, path, now := seedClaudeIngestionSource(t, dataDir, "")
+		mustNoError(t, os.WriteFile(path, []byte(legacyClaudeTranscript("claude-test")), 0o600))
+
+		ingestSourceFully(context.Background(), t, NewIngestor(store, IngestorConfig{
+			Clock: func() time.Time { return now }, Pricing: pricing.NewManager(claudePricingSnapshot(t)),
+		}), source.ID)
+
+		assertIngestedBilling(t, dataDir, source.ID, "anthropic", domain.UsageBillingProviderInferred, 795_000, true)
+	})
+
+	t.Run("Codex", func(t *testing.T) {
+		dataDir := t.TempDir()
+		store, source, path, now := seedCodexIngestionSource(t, dataDir)
+		content := `{"type":"turn_context","payload":{"model":"gpt-test"}}` + "\n" +
+			string(codexTokenLine("fresh", 100, 60, 0, 20, 5)) + "\n"
+		mustNoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		ingestSourceFully(context.Background(), t, NewIngestor(store, IngestorConfig{
+			Clock: func() time.Time { return now }, Pricing: pricing.NewManager(testPricingSnapshot(t, "0.000001")),
+		}), source.ID)
+
+		assertIngestedBilling(t, dataDir, source.ID, "openai", domain.UsageBillingProviderInferred, 86_000, true)
+	})
+
+	t.Run("Kimi", func(t *testing.T) {
+		dataDir := t.TempDir()
+		store, source, path, now := seedKimiIngestionSource(t, dataDir)
+		content := `{"id":"usage-1","time":"2026-08-09T10:00:00Z","type":"usage.record",` +
+			`"model":"glm-test","usage":{"inputOther":13,"inputCacheRead":21,"inputCacheCreation":8,"output":5}}` + "\n"
+		mustNoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		ingestSourceFully(context.Background(), t, NewIngestor(store, IngestorConfig{
+			Clock: func() time.Time { return now }, Pricing: pricing.NewManager(testPricingSnapshot(t, "0.000001")),
+		}), source.ID)
+
+		assertIngestedBilling(t, dataDir, source.ID, "zai", domain.UsageBillingProviderInferred, 83_000, true)
+	})
+}
+
+func TestIngestorLeavesUnidentifiedClaudeRouteUnpriced(t *testing.T) {
+	dataDir := t.TempDir()
+	store, source, path, now := seedClaudeIngestionSource(t, dataDir, pricing.UnidentifiedBillingRoute)
+	mustNoError(t, os.WriteFile(path, []byte(legacyClaudeTranscript("claude-test")), 0o600))
+
+	ingestSourceFully(context.Background(), t, NewIngestor(store, IngestorConfig{
+		Clock: func() time.Time { return now }, Pricing: pricing.NewManager(claudePricingSnapshot(t)),
+	}), source.ID)
+
+	assertIngestedBilling(t, dataDir, source.ID, "", "", 0, false)
+}
+
+func TestIngestorLeavesUnknownCatalogModelUnpriced(t *testing.T) {
+	dataDir := t.TempDir()
+	store, source, path, now := seedClaudeIngestionSource(t, dataDir, "")
+	mustNoError(t, os.WriteFile(path, []byte(legacyClaudeTranscript("private-model")), 0o600))
+
+	ingestSourceFully(context.Background(), t, NewIngestor(store, IngestorConfig{
+		Clock: func() time.Time { return now }, Pricing: pricing.NewManager(claudePricingSnapshot(t)),
+	}), source.ID)
+
+	assertIngestedBilling(t, dataDir, source.ID, "", "", 0, false)
+}
+
 // Break caught: activating a new catalog after estimation but before the
 // source event commit could leave an old-version event behind after the new
 // provider backfill had already passed it.
@@ -530,6 +596,54 @@ func seedCodexIngestionSource(t *testing.T, dataDir string) (*sqlite.Store, doma
 	})
 	mustNoError(t, err)
 	return store, source, path, now
+}
+
+func seedKimiIngestionSource(t *testing.T, dataDir string) (*sqlite.Store, domain.UsageSourceRecord, string, time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Unix(1700000000, 0).UTC()
+	store, session := seedUsageTestSession(
+		t, dataDir, "usage", domain.HarnessKimi, domain.ActivityIdle, "", now,
+	)
+	binding, err := store.UpsertUsageBinding(ctx, domain.UsageBindingRecord{
+		SessionID: session.ID, Harness: domain.HarnessKimi, NativeRootID: "kimi-root",
+		State: domain.UsageBindingActive, UpdatedAt: now,
+	})
+	mustNoError(t, err)
+	path := filepath.Join(t.TempDir(), "wire.jsonl")
+	mustNoError(t, os.WriteFile(path, nil, 0o600))
+	path = canonicalTranscriptPath(path)
+	identity, err := usagesvc.SourceIdentity(ctx, path)
+	mustNoError(t, err)
+	source, err := store.InsertUsageSource(ctx, domain.UsageSourceRecord{
+		BindingID: binding.ID, Kind: domain.UsageSourceKimiWire, NativeSessionID: "kimi-root",
+		ArtifactPath: path, FileIdentity: identity, State: domain.UsageSourcePending, UpdatedAt: now,
+	})
+	mustNoError(t, err)
+	return store, source, path, now
+}
+
+func assertIngestedBilling(
+	t *testing.T,
+	dataDir string,
+	sourceID int64,
+	provider string,
+	source domain.UsageBillingProviderSource,
+	total int64,
+	costKnown bool,
+) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(dataDir, "ao.db"))
+	mustNoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	var gotProvider, gotSource sql.NullString
+	var gotTotal sql.NullInt64
+	mustNoError(t, db.QueryRow(`SELECT billing_provider_id, billing_provider_source, estimated_cost_nanos
+FROM model_usage_events WHERE usage_source_id = ?`, sourceID).Scan(&gotProvider, &gotSource, &gotTotal))
+	if gotProvider.String != provider || domain.UsageBillingProviderSource(gotSource.String) != source ||
+		gotTotal.Valid != costKnown || (costKnown && gotTotal.Int64 != total) {
+		t.Fatalf("billing = provider %+v source %+v total %+v", gotProvider, gotSource, gotTotal)
+	}
 }
 
 func readParserStateJSON(t *testing.T, dataDir string, sourceID int64) string {
@@ -1170,8 +1284,9 @@ func testPricingSnapshot(t *testing.T, openAIInputRate string) *pricing.Snapshot
   "zai/glm-test": {
     "litellm_provider": "zai",
     "mode": "chat",
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0
+    "input_cost_per_token": 0.000002,
+    "cache_read_input_token_cost": 0.000001,
+    "output_cost_per_token": 0.000004
   }
 }`)
 	_, err := catalogsync.Sync(root, upstream, catalogsync.Source{

--- a/backend/internal/observe/usage/legacy_repair_test.go
+++ b/backend/internal/observe/usage/legacy_repair_test.go
@@ -187,6 +187,7 @@ func makeLegacyProviderNull(t *testing.T, dataDir string, sourceID int64) {
 	// too: refilling it from the durable transcript is part of the repair.
 	_, err := db.Exec(`UPDATE model_usage_events
 SET billing_provider_id = NULL, provider_usage_json = NULL,
+    billing_provider_source = NULL,
     input_cost_nanos = NULL, cached_input_cost_nanos = NULL,
     output_cost_nanos = NULL, estimated_cost_nanos = NULL,
     pricing_version = ''
@@ -320,9 +321,8 @@ func TestLegacyRepairerAttributesClaudeHistoryFromTheBindingRouteHint(t *testing
 func TestLegacyRepairerLetsAnObservationCorrectAnInference(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()
-	// No hook has run, so ingestion leaves the row unattributed and the first
-	// repair pass — the point at which no hook is coming — infers the provider
-	// from the model that answered.
+	// No hook has run, so live ingestion uses the catalog's unique model owner
+	// as explicitly inferred attribution.
 	store, source, path, now := seedClaudeIngestionSource(t, dataDir, "")
 	mustNoError(t, os.WriteFile(path, []byte(legacyClaudeTranscript("claude-test")), 0o600))
 	snapshot := claudePricingSnapshot(t)
@@ -330,10 +330,6 @@ func TestLegacyRepairerLetsAnObservationCorrectAnInference(t *testing.T) {
 		Clock:   func() time.Time { return now },
 		Pricing: pricing.NewManager(snapshot),
 	}), source.ID)
-	assertLegacyStillNull(t, dataDir, source.ID)
-	mustNoError(t, NewLegacyRepairer(store, pricing.NewManager(snapshot), LegacyRepairerConfig{
-		Clock: func() time.Time { return now.Add(time.Minute) },
-	}).Run(ctx))
 	assertLegacyRepair(t, dataDir, source.ID, "anthropic", domain.UsageBillingProviderInferred,
 		795_000, snapshot.ProviderVersion("anthropic"))
 
@@ -413,9 +409,10 @@ func TestIngestorRequestsRepairWhenARouteLandsMidChunk(t *testing.T) {
 	mustNoError(t, os.WriteFile(path, []byte(legacyClaudeTranscript("claude-test")), 0o600))
 
 	requested := 0
+	snapshot := claudePricingSnapshot(t)
 	ingestor := NewIngestor(store, IngestorConfig{
 		Clock:                    func() time.Time { return now },
-		Pricing:                  pricing.NewManager(claudePricingSnapshot(t)),
+		Pricing:                  pricing.NewManager(snapshot),
 		RequestAttributionRepair: func() { requested++ },
 	})
 	// The chunk has been read against a binding with no route; the hook lands
@@ -429,7 +426,8 @@ func TestIngestorRequestsRepairWhenARouteLandsMidChunk(t *testing.T) {
 	}
 	ingestSourceFully(ctx, t, ingestor, source.ID)
 
-	assertLegacyStillNull(t, dataDir, source.ID)
+	assertLegacyRepair(t, dataDir, source.ID, "anthropic", domain.UsageBillingProviderInferred,
+		795_000, snapshot.ProviderVersion("anthropic"))
 	if requested == 0 {
 		t.Fatal("no repair requested for rows the route-resolved pass could not have seen")
 	}
@@ -489,6 +487,7 @@ func TestLegacyRepairerRunsAgainAfterStartupIngestionSettles(t *testing.T) {
 		Clock:   func() time.Time { return now },
 		Pricing: pricing.NewManager(snapshot),
 	}), source.ID)
+	makeLegacyProviderNull(t, dataDir, source.ID)
 	assertLegacyStillNull(t, dataDir, source.ID)
 	close(ordered.ingestDone)
 

--- a/backend/internal/service/usage/collector_budget_test.go
+++ b/backend/internal/service/usage/collector_budget_test.go
@@ -430,7 +430,7 @@ func testCollectorCodexBudgetFinalizationWaitsThenPersistsPartialAcrossRestart(t
 	if err != nil || len(compact) != 1 {
 		t.Fatalf("compact=%+v err=%v", compact, err)
 	}
-	if compact[0].ProcessedTokens == nil || *compact[0].ProcessedTokens != 12 || !compact[0].Incomplete {
+	if compact[0].Totals.ProcessedTokens == nil || *compact[0].Totals.ProcessedTokens != 12 || !compact[0].Incomplete {
 		t.Fatalf("compact summary=%+v", compact[0])
 	}
 	detail, err := reader.Get(ctx, session.ID)

--- a/backend/internal/service/usage/summary.go
+++ b/backend/internal/service/usage/summary.go
@@ -39,9 +39,17 @@ func (r *SummaryReader) ListCompact(ctx context.Context, projectID domain.Projec
 		if err != nil {
 			return nil, err
 		}
+		totals := domain.UsageMetricTotals{
+			InputTokens: row.Tokens.InputTokens, CachedInputTokens: row.Tokens.CachedInputTokens,
+			UncachedInputTokens: row.Tokens.UncachedInputTokens, OutputTokens: row.Tokens.OutputTokens,
+			EstimatedCost: estimatedCost,
+		}
+		if totals.InputTokens != nil && totals.OutputTokens != nil {
+			processed := *totals.InputTokens + *totals.OutputTokens
+			totals.ProcessedTokens = &processed
+		}
 		out = append(out, domain.CompactSessionUsage{
-			SessionID: row.SessionID, ProcessedTokens: row.ProcessedTokens,
-			Incomplete: row.Incomplete, EstimatedCost: estimatedCost,
+			SessionID: row.SessionID, Incomplete: row.Incomplete, Totals: totals,
 		})
 	}
 	return out, nil

--- a/backend/internal/service/usage/summary_test.go
+++ b/backend/internal/service/usage/summary_test.go
@@ -36,14 +36,13 @@ func (s *usageSummaryStoreStub) GetUsageSessionIncomplete(context.Context, domai
 }
 
 func TestSummaryReaderListCompactUsesOneBatchRead(t *testing.T) {
-	zeroProcessed, partialProcessed := int64(0), int64(120)
 	store := &usageSummaryStoreStub{rows: []domain.CompactSessionUsageAggregate{
 		{
-			SessionID: "zero", ProcessedTokens: &zeroProcessed,
+			SessionID: "zero", Tokens: testUsageMetrics(0, 0, 0, 0),
 			Cost: completeCostAggregate(1, 0, 0, 0, 0),
 		},
 		{
-			SessionID: "partial", ProcessedTokens: &partialProcessed, Incomplete: true,
+			SessionID: "partial", Tokens: testUsageMetrics(100, 20, 80, 20), Incomplete: true,
 			Cost: domain.UsageCostAggregate{
 				EventCount:                    1,
 				ObservedCostEventCount:        1,
@@ -58,24 +57,34 @@ func TestSummaryReaderListCompactUsesOneBatchRead(t *testing.T) {
 				UnpricedKnownOutputNanos:      5,
 			},
 		},
+		{
+			SessionID: "unknown", Tokens: domain.UsageTokenMetrics{
+				InputTokens: testUsageMetrics(100, 0, 100, 0).InputTokens,
+			},
+		},
 	}}
 
 	got, err := NewSummaryReader(store).ListCompact(context.Background(), "reverb")
 	mustNoError(t, err)
-	if store.calls[0] != 1 || store.projectID != "reverb" || len(got) != 2 {
+	if store.calls[0] != 1 || store.projectID != "reverb" || len(got) != 3 {
 		t.Fatalf("read=%d project=%q items=%+v", store.calls[0], store.projectID, got)
 	}
-	if got[0].EstimatedCost == nil || got[0].EstimatedCost.Coverage != domain.EstimatedCostCoverageComplete || got[0].EstimatedCost.TotalNanos != 0 {
-		t.Fatalf("zero cost = %+v, want complete zero", got[0].EstimatedCost)
+	if got[0].Totals.EstimatedCost == nil || got[0].Totals.EstimatedCost.Coverage != domain.EstimatedCostCoverageComplete || got[0].Totals.EstimatedCost.TotalNanos != 0 {
+		t.Fatalf("zero cost = %+v, want complete zero", got[0].Totals.EstimatedCost)
 	}
-	if got[1].ProcessedTokens == nil || *got[1].ProcessedTokens != 120 || !got[1].Incomplete ||
-		got[1].EstimatedCost == nil ||
-		got[1].EstimatedCost.Coverage != domain.EstimatedCostCoveragePartial || got[1].EstimatedCost.TotalNanos != 35 {
+	if got[1].Totals.ProcessedTokens == nil || *got[1].Totals.ProcessedTokens != 120 || !got[1].Incomplete ||
+		got[1].Totals.EstimatedCost == nil ||
+		got[1].Totals.EstimatedCost.Coverage != domain.EstimatedCostCoveragePartial || got[1].Totals.EstimatedCost.TotalNanos != 35 {
 		t.Fatalf("partial compact summary = %+v", got[1])
 	}
-	if got[1].EstimatedCost.InputNanos == nil || *got[1].EstimatedCost.InputNanos != 30 ||
-		got[1].EstimatedCost.CachedInputNanos == nil || *got[1].EstimatedCost.CachedInputNanos != 0 {
-		t.Fatalf("partial components = %+v", got[1].EstimatedCost)
+	if got[1].Totals.EstimatedCost.InputNanos == nil || *got[1].Totals.EstimatedCost.InputNanos != 30 ||
+		got[1].Totals.EstimatedCost.CachedInputNanos == nil || *got[1].Totals.EstimatedCost.CachedInputNanos != 0 {
+		t.Fatalf("partial components = %+v", got[1].Totals.EstimatedCost)
+	}
+	if got[2].Totals.InputTokens == nil || *got[2].Totals.InputTokens != 100 ||
+		got[2].Totals.OutputTokens != nil || got[2].Totals.ProcessedTokens != nil ||
+		got[2].Totals.EstimatedCost != nil {
+		t.Fatalf("unknown compact summary = %+v", got[2])
 	}
 }
 
@@ -201,7 +210,7 @@ func TestSummaryReaderReturnsUnavailableCostForZeroPartialLowerBound(t *testing.
 	}}}
 	got, err := NewSummaryReader(store).ListCompact(context.Background(), "")
 	mustNoError(t, err)
-	if len(got) != 1 || got[0].EstimatedCost != nil {
+	if len(got) != 1 || got[0].Totals.EstimatedCost != nil {
 		t.Fatalf("cost = %+v, want unavailable", got)
 	}
 }

--- a/backend/internal/storage/sqlite/gen/usage.sql.go
+++ b/backend/internal/storage/sqlite/gen/usage.sql.go
@@ -673,8 +673,14 @@ func (q *Queries) InsertUsageSource(ctx context.Context, arg InsertUsageSourcePa
 const listCompactSessionUsage = `-- name: ListCompactSessionUsage :many
 SELECT
     ub.session_id,
-    CAST(COALESCE(SUM(mue.input_tokens) + SUM(mue.output_tokens), 0) AS INTEGER) AS processed_tokens,
-    CAST(COUNT(mue.input_tokens) = COUNT(*) AND COUNT(mue.output_tokens) = COUNT(*) AS INTEGER) AS processed_tokens_known,
+    CAST(COALESCE(SUM(mue.input_tokens), 0) AS INTEGER) AS input_tokens,
+    CAST(COUNT(mue.input_tokens) = COUNT(*) AS INTEGER) AS input_tokens_known,
+    CAST(COALESCE(SUM(mue.cached_input_tokens), 0) AS INTEGER) AS cached_input_tokens,
+    CAST(COUNT(mue.cached_input_tokens) = COUNT(*) AS INTEGER) AS cached_input_tokens_known,
+    CAST(COALESCE(SUM(mue.uncached_input_tokens), 0) AS INTEGER) AS uncached_input_tokens,
+    CAST(COUNT(mue.uncached_input_tokens) = COUNT(*) AS INTEGER) AS uncached_input_tokens_known,
+    CAST(COALESCE(SUM(mue.output_tokens), 0) AS INTEGER) AS output_tokens,
+    CAST(COUNT(mue.output_tokens) = COUNT(*) AS INTEGER) AS output_tokens_known,
     CAST(COALESCE(integrity.incomplete, 0) AS INTEGER) AS incomplete,
     CAST(COUNT(*) AS INTEGER) AS event_count,
     CAST(COUNT(mue.estimated_cost_nanos) AS INTEGER) AS priced_event_count,
@@ -707,8 +713,14 @@ ORDER BY s.project_id, s.num
 
 type ListCompactSessionUsageRow struct {
 	SessionID                     domain.SessionID
-	ProcessedTokens               int64
-	ProcessedTokensKnown          int64
+	InputTokens                   int64
+	InputTokensKnown              int64
+	CachedInputTokens             int64
+	CachedInputTokensKnown        int64
+	UncachedInputTokens           int64
+	UncachedInputTokensKnown      int64
+	OutputTokens                  int64
+	OutputTokensKnown             int64
 	Incomplete                    int64
 	EventCount                    int64
 	PricedEventCount              int64
@@ -737,8 +749,14 @@ func (q *Queries) ListCompactSessionUsage(ctx context.Context, projectID interfa
 		var i ListCompactSessionUsageRow
 		if err := rows.Scan(
 			&i.SessionID,
-			&i.ProcessedTokens,
-			&i.ProcessedTokensKnown,
+			&i.InputTokens,
+			&i.InputTokensKnown,
+			&i.CachedInputTokens,
+			&i.CachedInputTokensKnown,
+			&i.UncachedInputTokens,
+			&i.UncachedInputTokensKnown,
+			&i.OutputTokens,
+			&i.OutputTokensKnown,
 			&i.Incomplete,
 			&i.EventCount,
 			&i.PricedEventCount,

--- a/backend/internal/storage/sqlite/queries/usage.sql
+++ b/backend/internal/storage/sqlite/queries/usage.sql
@@ -605,8 +605,14 @@ SELECT CAST(COALESCE((
 -- name: ListCompactSessionUsage :many
 SELECT
     ub.session_id,
-    CAST(COALESCE(SUM(mue.input_tokens) + SUM(mue.output_tokens), 0) AS INTEGER) AS processed_tokens,
-    CAST(COUNT(mue.input_tokens) = COUNT(*) AND COUNT(mue.output_tokens) = COUNT(*) AS INTEGER) AS processed_tokens_known,
+    CAST(COALESCE(SUM(mue.input_tokens), 0) AS INTEGER) AS input_tokens,
+    CAST(COUNT(mue.input_tokens) = COUNT(*) AS INTEGER) AS input_tokens_known,
+    CAST(COALESCE(SUM(mue.cached_input_tokens), 0) AS INTEGER) AS cached_input_tokens,
+    CAST(COUNT(mue.cached_input_tokens) = COUNT(*) AS INTEGER) AS cached_input_tokens_known,
+    CAST(COALESCE(SUM(mue.uncached_input_tokens), 0) AS INTEGER) AS uncached_input_tokens,
+    CAST(COUNT(mue.uncached_input_tokens) = COUNT(*) AS INTEGER) AS uncached_input_tokens_known,
+    CAST(COALESCE(SUM(mue.output_tokens), 0) AS INTEGER) AS output_tokens,
+    CAST(COUNT(mue.output_tokens) = COUNT(*) AS INTEGER) AS output_tokens_known,
     CAST(COALESCE(integrity.incomplete, 0) AS INTEGER) AS incomplete,
     CAST(COUNT(*) AS INTEGER) AS event_count,
     CAST(COUNT(mue.estimated_cost_nanos) AS INTEGER) AS priced_event_count,

--- a/backend/internal/storage/sqlite/store/usage_store.go
+++ b/backend/internal/storage/sqlite/store/usage_store.go
@@ -778,9 +778,14 @@ func (s *Store) ListCompactSessionUsageAggregates(ctx context.Context, projectID
 	out := make([]domain.CompactSessionUsageAggregate, 0, len(rows))
 	for _, row := range rows {
 		out = append(out, domain.CompactSessionUsageAggregate{
-			SessionID:       row.SessionID,
-			ProcessedTokens: int64PtrWhen(row.ProcessedTokens, row.ProcessedTokensKnown != 0),
-			Incomplete:      row.Incomplete != 0,
+			SessionID: row.SessionID,
+			Tokens: domain.UsageTokenMetrics{
+				InputTokens:         int64PtrWhen(row.InputTokens, row.InputTokensKnown != 0),
+				CachedInputTokens:   int64PtrWhen(row.CachedInputTokens, row.CachedInputTokensKnown != 0),
+				UncachedInputTokens: int64PtrWhen(row.UncachedInputTokens, row.UncachedInputTokensKnown != 0),
+				OutputTokens:        int64PtrWhen(row.OutputTokens, row.OutputTokensKnown != 0),
+			},
+			Incomplete: row.Incomplete != 0,
 			Cost: domain.UsageCostAggregate{
 				EventCount: row.EventCount, PricedEventCount: row.PricedEventCount, PricedTotalNanos: row.PricedTotalNanos,
 				ObservedCostEventCount: row.ObservedCostEventCount, InferredCostEventCount: row.InferredCostEventCount,

--- a/backend/internal/storage/sqlite/store/usage_store_test.go
+++ b/backend/internal/storage/sqlite/store/usage_store_test.go
@@ -1475,7 +1475,7 @@ func TestUsageAggregatesMergeProvidersPerModelAndPreserveCostCoverageFacts(t *te
 
 	compact, err := s.ListCompactSessionUsageAggregates(ctx, sess.ProjectID)
 	mustNoError(t, err)
-	if len(compact) != 1 || usageTokenValue(compact[0].ProcessedTokens) != 18 {
+	if len(compact) != 1 || compactProcessedTokens(compact[0]) != 18 {
 		t.Fatalf("compact rows = %+v", compact)
 	}
 	// The dashboard row already summed across providers, so it is unchanged by
@@ -1557,7 +1557,11 @@ func TestListCompactSessionUsageAggregatesAndFiltersByProject(t *testing.T) {
 		t.Fatalf("filtered rows = %+v, want only %s (not %s)", got, usageSession.ID, otherSession.ID)
 	}
 	row := got[0]
-	if usageTokenValue(row.ProcessedTokens) != 180 || row.Incomplete {
+	if compactProcessedTokens(row) != 180 ||
+		usageTokenValue(row.Tokens.InputTokens) != 150 ||
+		usageTokenValue(row.Tokens.CachedInputTokens) != 70 ||
+		usageTokenValue(row.Tokens.UncachedInputTokens) != 80 ||
+		usageTokenValue(row.Tokens.OutputTokens) != 30 || row.Incomplete {
 		t.Fatalf("aggregate = %+v", row)
 	}
 	all, err := s.ListCompactSessionUsageAggregates(ctx, "")
@@ -1694,7 +1698,11 @@ func TestUsageSessionAggregatesParentChildAndMultipleBindingsExactlyOnce(t *test
 		t.Fatalf("compact rows = %+v, want one", compact)
 	}
 	row := compact[0]
-	if usageTokenValue(row.ProcessedTokens) != 215 || row.Incomplete {
+	if compactProcessedTokens(row) != 215 ||
+		usageTokenValue(row.Tokens.InputTokens) != 180 ||
+		usageTokenValue(row.Tokens.CachedInputTokens) != 0 ||
+		usageTokenValue(row.Tokens.UncachedInputTokens) != 180 ||
+		usageTokenValue(row.Tokens.OutputTokens) != 35 || row.Incomplete {
 		t.Fatalf("compact aggregate = %+v", row)
 	}
 }
@@ -1878,6 +1886,10 @@ func usageTokenValue(value *int64) int64 {
 		return -1
 	}
 	return *value
+}
+
+func compactProcessedTokens(row domain.CompactSessionUsageAggregate) int64 {
+	return usageTokenValue(row.Tokens.InputTokens) + usageTokenValue(row.Tokens.OutputTokens)
 }
 
 func assertUsageSourceOffset(t *testing.T, s *sqlite.Store, sourceID int64, want int64) {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2012,6 +2012,8 @@ export interface components {
              * @description Deprecated compatibility alias for processedTokens.
              */
             totalTokens: number;
+            /** @description Canonical token categories and estimated cost used by card detail disclosures. */
+            totals: components["schemas"]["UsageTotalsResponse"];
         };
         ContainerReapConfig: {
             disabled?: boolean;

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -70,6 +70,7 @@ import { agentLabel } from "../lib/agent-options";
 import { agentsQueryOptions } from "../hooks/useAgentsQuery";
 import { Switch } from "./ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
+import { EstimatedCostExplanation, UsageBreakdown } from "./UsageBreakdown";
 import { appI18n } from "../i18n";
 import type { MessageKey } from "../i18n";
 import { usesPreviewWorkspaceData as usePreviewData } from "../lib/preview-mode";
@@ -437,7 +438,7 @@ function UsageCostTelemetry({ usage }: { usage: SessionUsage }) {
 					className="rounded-lg border border-(--color-border-settings-input) bg-(--color-bg-settings-input) px-2.5 py-2.5"
 					data-testid="session-usage-metrics"
 				>
-					<UsageMetrics totals={usage.totals} />
+					<UsageBreakdown totals={usage.totals} />
 				</div>
 			</div>
 
@@ -715,7 +716,7 @@ function UsageModelRow({
 			showCost={showCost}
 			totals={model.totals}
 		>
-			<UsageMetrics totals={model.totals} />
+			<UsageBreakdown totals={model.totals} />
 		</UsageDisclosureRow>
 	);
 }
@@ -820,11 +821,6 @@ function UsageCostValue({ cost }: { cost: EstimatedCost | null }) {
 function EstimatedCostInfo({ cost }: { cost: EstimatedCost | null }) {
 	const { t } = useTranslation();
 	const label = t("usage.estimatedCostInfoLabel");
-	const providerInfoKey = cost?.providerAttribution === "inferred"
-		? "usage.estimatedCostInfoInferred"
-		: cost?.providerAttribution === "mixed"
-			? "usage.estimatedCostInfoMixed"
-			: "usage.estimatedCostInfo";
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
@@ -839,90 +835,10 @@ function EstimatedCostInfo({ cost }: { cost: EstimatedCost | null }) {
 			{/* Opens upward: the figure it explains sits directly under the heading,
 			    so a downward tooltip covers the very number the reader came for. */}
 			<TooltipContent className="max-w-64 text-left" side="top">
-				<p>{t(providerInfoKey)}</p>
-				{cost?.coverage === "partial" ? (
-					<p className="mt-1.5">{t("usage.estimatedCostInfoPartial")}</p>
-				) : null}
+				{cost ? <EstimatedCostExplanation cost={cost} /> : <p>{t("usage.estimatedCostInfo")}</p>}
 			</TooltipContent>
 		</Tooltip>
 	);
-}
-
-function UsageMetrics({ totals }: { totals: SessionUsage["totals"] }) {
-	const { t } = useTranslation();
-	const cacheHitRate = formatCacheHitRate(totals.cachedInputTokens, totals.inputTokens);
-	return (
-		<dl className="grid grid-cols-2 gap-x-4 gap-y-2 @max-[300px]/inspector:grid-cols-1" data-testid="session-usage-metrics">
-			<UsageMetric label={t("inspector.usage.uncachedInputTokens")} metric={totals.uncachedInputTokens} />
-			<UsageMetric label={t("inspector.usage.cachedInputTokens")} metric={totals.cachedInputTokens} />
-			<UsageMetric label={t("inspector.usage.outputTokens")} metric={totals.outputTokens} />
-			<UsageRateMetric rate={cacheHitRate} />
-		</dl>
-	);
-}
-
-function UsageRateMetric({ rate }: { rate: string | null }) {
-	const { t } = useTranslation();
-	const label = t("inspector.usage.cacheHitRate");
-	const description =
-		rate === null
-			? t("inspector.usage.metricUnavailable", { label })
-			: t("inspector.usage.cacheHitRateDescription", { rate });
-	return (
-		<div className="min-w-0">
-			<dt className="truncate text-2xs text-settings-muted">{label}</dt>
-			<dd
-				aria-label={description}
-				className="mt-0.5 truncate font-mono text-sm-md text-settings-label"
-				title={description}
-			>
-				{rate === null ? "—" : `${rate}%`}
-			</dd>
-		</div>
-	);
-}
-
-function UsageMetric({ label, metric }: { label: string; metric: number | null | undefined }) {
-	const { t } = useTranslation();
-	const value = typeof metric === "number" && Number.isFinite(metric) ? metric : null;
-	const exactValue = value?.toLocaleString("en-US");
-	const accessibleLabel =
-		value === null
-			? t("inspector.usage.metricUnavailable", { label })
-			: t("inspector.usage.metricAria", { label, count: exactValue });
-	return (
-		<div className="min-w-0">
-			<dt className="truncate text-2xs text-settings-muted">{label}</dt>
-			<dd
-				aria-label={accessibleLabel}
-				className="mt-0.5 truncate font-mono text-sm-md text-settings-label"
-				title={
-					value === null
-						? t("inspector.usage.metricUnavailable", { label })
-						: t("inspector.usage.tokensExact", { count: exactValue })
-				}
-			>
-				{value === null ? "—" : formatTelemetryTokenValue(value)}
-			</dd>
-		</div>
-	);
-}
-
-function formatCacheHitRate(
-	cachedInputTokens: number | null | undefined,
-	inputTokens: number | null | undefined,
-): string | null {
-	if (
-		typeof cachedInputTokens !== "number" ||
-		!Number.isFinite(cachedInputTokens) ||
-		typeof inputTokens !== "number" ||
-		!Number.isFinite(inputTokens) ||
-		inputTokens <= 0
-	) {
-		return null;
-	}
-	const percentage = Math.min(100, Math.max(0, (cachedInputTokens / inputTokens) * 100));
-	return percentage.toFixed(1).replace(/\.0$/, "");
 }
 
 const usageMetricKeys = [

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { toKanbanColumn } from "@aoagents/product-ui";
 import { appI18n } from "../i18n";
@@ -309,12 +310,18 @@ describe("SessionsBoard", () => {
 		expect(within(idleCard).getByText("brand-font-pipeline")).toHaveClass("font-semibold", "line-clamp-2");
 	});
 
-	it("shows coverage-aware cost with tokens on active and archived cards", async () => {
+	it("shows only cost, only tokens, or no usage metric on active and archived cards", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				workspaceWithSessions([
 					boardSession({ id: "s-active", title: "active worker", status: "idle" }),
-					boardSession({ id: "s-empty", title: "empty worker", status: "idle" }),
+					boardSession({ id: "s-zero", title: "zero cost worker", status: "idle" }),
+					boardSession({
+						id: "s-empty",
+						lastUserMessageAt: "2026-01-01T00:00:00Z",
+						title: "empty worker",
+						status: "idle",
+					}),
 					boardSession({ id: "s-tokens", title: "tokens worker", status: "idle" }),
 					terminatedSession(),
 				]),
@@ -339,6 +346,39 @@ describe("SessionsBoard", () => {
 						processedTokens: 12_300,
 						totalTokens: 12_400,
 						incomplete: false,
+						totals: usageTotals(12_300, {
+							cachedInputNanos: 100_000_000,
+							coverage: "complete",
+							inputNanos: 540_000_000,
+							outputNanos: 600_000_000,
+							providerAttribution: "observed",
+							totalNanos: 1_240_000_000,
+						}),
+					},
+				],
+				[
+					"s-zero",
+					{
+						estimatedCost: {
+							cachedInputNanos: 0,
+							coverage: "complete",
+							inputNanos: 0,
+							outputNanos: 0,
+							providerAttribution: "observed",
+							totalNanos: 0,
+						},
+						incomplete: false,
+						processedTokens: 0,
+						sessionId: "s-zero",
+						totalTokens: 0,
+						totals: usageTotals(0, {
+							cachedInputNanos: 0,
+							coverage: "complete",
+							inputNanos: 0,
+							outputNanos: 0,
+							providerAttribution: "observed",
+							totalNanos: 0,
+						}),
 					},
 				],
 				[
@@ -349,6 +389,7 @@ describe("SessionsBoard", () => {
 						processedTokens: 0,
 						totalTokens: 0,
 						incomplete: false,
+						totals: usageTotals(0, null),
 					},
 				],
 				[
@@ -359,6 +400,7 @@ describe("SessionsBoard", () => {
 						processedTokens: 800,
 						totalTokens: 800,
 						incomplete: false,
+						totals: usageTotals(800, null),
 					},
 				],
 				[
@@ -376,6 +418,14 @@ describe("SessionsBoard", () => {
 						processedTokens: 1_900,
 						totalTokens: 2_000,
 						incomplete: true,
+						totals: usageTotals(1_900, {
+							cachedInputNanos: null,
+							coverage: "partial",
+							inputNanos: 5_000_000,
+							outputNanos: 15_000_000,
+							providerAttribution: "inferred",
+							totalNanos: 20_000_000,
+						}),
 					},
 				],
 			]),
@@ -387,24 +437,32 @@ describe("SessionsBoard", () => {
 		// hover tooltip and accessible label.
 		const activeUsage = screen.getByText("$1.24", { selector: "span" });
 		expect(activeUsage).toHaveAttribute("aria-hidden", "true");
-		expect(screen.getByText("$1.24 · 12,300 tokens")).toHaveClass("sr-only");
+		expect(within(activeUsage.closest("button") as HTMLElement).getByText("Estimated cost: $1.24")).toHaveClass(
+			"sr-only",
+		);
+		expect(screen.queryByText("12.3K")).not.toBeInTheDocument();
 		expect(screen.queryByText(/processed/i)).not.toBeInTheDocument();
-		// Sessions without a dollar estimate stay visible if they still have
-		// token usage; sessions with no cost and no tokens still show nothing.
+		const zeroCostCard = screen
+			.getByText("zero cost worker")
+			.closest('[data-testid="board-session-card"]') as HTMLElement;
+		expect(within(zeroCostCard).getByText("$0.00")).toHaveAttribute("aria-hidden", "true");
 		const emptyCard = screen.getByText("empty worker").closest('[data-testid="board-session-card"]') as HTMLElement;
-		expect(within(emptyCard).queryByText("Unavailable")).not.toBeInTheDocument();
-		expect(within(emptyCard).queryByText("0 tokens")).not.toBeInTheDocument();
+		expect(within(emptyCard).queryByText(/unavailable/i)).not.toBeInTheDocument();
+		expect(within(emptyCard).queryByRole("button", { name: /tokens|estimated cost/i })).not.toBeInTheDocument();
+		expect(within(emptyCard).queryByText("·")).not.toBeInTheDocument();
 		const tokensOnlyCard = screen.getByText("tokens worker").closest('[data-testid="board-session-card"]') as HTMLElement;
-		expect(within(tokensOnlyCard).getByText("800", { selector: "span" })).toHaveAttribute("aria-hidden", "true");
+		expect(within(tokensOnlyCard).getByText("800")).toHaveAttribute("aria-hidden", "true");
 		expect(within(tokensOnlyCard).getByText("800 tokens")).toHaveClass("sr-only");
+		expect(within(tokensOnlyCard).queryByText(/unavailable/i)).not.toBeInTheDocument();
+		expect(tokensOnlyCard).not.toHaveTextContent(/[≈≥]\$/);
 		expect(usageQueryMock).toHaveBeenCalledWith("p1");
 
 		const archive = await expandArchive();
-		expect(within(archive).getByText("$0.02")).toHaveAttribute("aria-hidden", "true");
-		expect(within(archive).getByText("$0.02 · 1,900 tokens")).toHaveClass("sr-only");
+		expect(within(archive).getByText("Estimated cost: $0.02")).toHaveClass("sr-only");
+		expect(within(archive).queryByText("1.9K")).not.toBeInTheDocument();
 	});
 
-	it("shows cost by default and cost plus tokens on hover without a tab stop", async () => {
+	it("reveals the shared usage and cost breakdown on metric focus and hover", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				workspaceWithSessions([
@@ -431,6 +489,14 @@ describe("SessionsBoard", () => {
 						sessionId: "s-keyboard",
 						processedTokens: 12_400,
 						totalTokens: 12_400,
+						totals: usageTotals(12_400, {
+							cachedInputNanos: 100_000_000,
+							coverage: "complete",
+							inputNanos: 540_000_000,
+							outputNanos: 600_000_000,
+							providerAttribution: "observed",
+							totalNanos: 1_240_000_000,
+						}),
 					},
 				],
 			]),
@@ -440,19 +506,20 @@ describe("SessionsBoard", () => {
 
 		const card = screen.getByText("keyboard worker").closest('[data-testid="board-session-card"]') as HTMLElement;
 		const usage = within(card).getByText("$1.24", { selector: "span" });
-		expect(usage.tagName).toBe("SPAN");
-		// The compact text is decorative; the full label is real off-screen text
-		// rather than an aria-label on a generic span, which is not reliably
-		// exposed. The hover trigger is not a tab stop.
 		expect(usage).toHaveAttribute("aria-hidden", "true");
-		expect(within(card).getByText("$1.24 · 12,400 tokens")).toHaveClass("sr-only");
+		const usageButton = within(card).getByRole("button", { name: "Estimated cost: $1.24" });
 
-		within(card).getByRole("button", { name: "keyboard worker" }).focus();
-		await userEvent.tab();
-		expect(within(card).getByRole("button", { name: "Terminate keyboard worker" })).toHaveFocus();
+		act(() => usageButton.focus());
+		const focusedTooltip = await screen.findByRole("tooltip");
+		expect(within(focusedTooltip).getByText("Fresh Input")).toBeInTheDocument();
+		expect(within(focusedTooltip).getByText("Cache Reads")).toBeInTheDocument();
+		expect(within(focusedTooltip).getByText("$0.54")).toBeInTheDocument();
+		expect(within(focusedTooltip).getByText("$0.10")).toBeInTheDocument();
+		expect(within(focusedTooltip).getByText("$0.60")).toBeInTheDocument();
 
+		act(() => usageButton.blur());
 		await userEvent.hover(usage);
-		expect(await screen.findByRole("tooltip")).toHaveTextContent("$1.24 · 12,400 tokens");
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Calculated using published API list prices");
 	});
 
 	it("shows token-only usage when pricing is unavailable", async () => {
@@ -475,6 +542,7 @@ describe("SessionsBoard", () => {
 						sessionId: "s-tokens",
 						processedTokens: 12_400,
 						totalTokens: 12_400,
+						totals: usageTotals(12_400, null),
 					},
 				],
 			]),
@@ -488,7 +556,11 @@ describe("SessionsBoard", () => {
 		expect(within(card).getByText("12,400 tokens")).toHaveClass("sr-only");
 
 		await userEvent.hover(usage);
-		expect(await screen.findByRole("tooltip")).toHaveTextContent("12,400 tokens");
+		const tooltip = await screen.findByRole("tooltip");
+		expect(within(tooltip).getByText("Fresh Input")).toBeInTheDocument();
+		expect(within(tooltip).getByText("11K")).toBeInTheDocument();
+		expect(within(tooltip).getByText("Output")).toBeInTheDocument();
+		expect(within(tooltip).getByText("400")).toBeInTheDocument();
 	});
 
 	it("styles a working card from its building lane without inferring from runtime activity", () => {
@@ -1438,6 +1510,24 @@ function workspaceWithSessions(sessions: WorkspaceSession[]): WorkspaceSummary {
 		name: "radic",
 		path: "/tmp/radic",
 		sessions,
+	};
+}
+
+function usageTotals(
+	processedTokens: number,
+	estimatedCost: components["schemas"]["EstimatedCostResponse"] | null,
+): components["schemas"]["UsageTotalsResponse"] {
+	const outputTokens = processedTokens > 0 ? Math.min(400, Math.floor(processedTokens / 10)) : 0;
+	const inputTokens = processedTokens - outputTokens;
+	const cachedInputTokens = inputTokens > 0 ? Math.min(1_000, Math.floor(inputTokens / 2)) : 0;
+	return {
+		cacheReadTokens: cachedInputTokens,
+		cachedInputTokens,
+		estimatedCost,
+		inputTokens,
+		outputTokens,
+		processedTokens,
+		uncachedInputTokens: inputTokens - cachedInputTokens,
 	};
 }
 

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -102,16 +102,28 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 		: liveSessions;
 	const usageBySession = usesPreviewWorkspaceData
 		? new Map<string, SessionUsageSummary>(
-				sessions.map((session, index) => [
+				sessions.map((session, index) => {
+					const processedTokens = [18_400, 46_700, 12_900, 81_200, 3_100][index % 5];
+					return [
 						session.id,
 						liveUsageBySession.get(session.id) ?? {
 							estimatedCost: null,
 							sessionId: session.id,
-							processedTokens: [18_400, 46_700, 12_900, 81_200, 3_100][index % 5],
+							processedTokens,
 							totalTokens: 100_000,
 							incomplete: false,
-					},
-				]),
+							totals: {
+								cacheReadTokens: 0,
+								cachedInputTokens: 0,
+								estimatedCost: null,
+								inputTokens: processedTokens,
+								outputTokens: 0,
+								processedTokens,
+								uncachedInputTokens: processedTokens,
+							},
+						},
+					] as const;
+				}),
 			)
 		: liveUsageBySession;
 	const orchestrator = projectId ? newestActiveOrchestrator(workspaces[0]?.sessions ?? []) : undefined;

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -35,6 +35,7 @@ import { AgentAvatar } from "./AgentAvatar";
 import { ProductExternalLink } from "./ProductExternalLink";
 import { SessionTerminationPopover } from "./SessionTerminationPopover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import { EstimatedCostExplanation, UsageBreakdown } from "./UsageBreakdown";
 
 export function toBoardSessionPresentation(
 	session: WorkspaceSession,
@@ -227,15 +228,12 @@ function DesktopSessionCard({
 			renderAvatar={(provider) => <AgentAvatar className="mt-0.5" provider={provider} />}
 			session={toBoardSessionPresentation(session, t)}
 			translate={translate}
-			renderUsage={(usage) => (
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<SessionUsageMetricView usage={usage} />
-					</TooltipTrigger>
-					<TooltipContent side="top">{usage.accessibleLabel}</TooltipContent>
-				</Tooltip>
-			)}
 			usage={usagePresentation}
+			renderUsage={
+				usage
+					? (presentation) => <BoardUsageMetric presentation={presentation} usage={usage} />
+					: undefined
+			}
 		/>
 	);
 }
@@ -266,40 +264,69 @@ function reviewerAvatarUrl(pr: SessionPRSummary, reviewerId: string): string | u
 	return undefined;
 }
 
-// Keep the board metric scannable by showing cost only. The full cost/token
-// summary remains available from the hover tooltip and to screen readers.
+// A card carries exactly one scan metric. Cost wins when it is known; otherwise
+// reliable tokens are the fallback. Unknown data is represented by absence,
+// never by a placeholder that competes with the session itself.
 function toUsagePresentation(
 	usage: SessionUsageSummary | undefined,
 	t: TFunction,
 ): BoardUsagePresentation | undefined {
-	const processedTokens = usage?.processedTokens ?? null;
 	if (!usage) {
 		return undefined;
 	}
-	const cost = formatEstimatedCost(usage.estimatedCost);
-	if (!cost) {
-		if (processedTokens === null || processedTokens <= 0) {
-			return undefined;
-		}
-		const compactTokens = formatTokenCount(processedTokens).replace(/ tok$/, "");
-		const accessibleTokens = t("shell.usageTokens", {
-			count: processedTokens.toLocaleString("en-US"),
-		});
+	const cost = formatEstimatedCost(usage.totals.estimatedCost);
+	if (cost) {
 		return {
-			accessibleLabel: accessibleTokens,
-			compactLabel: compactTokens,
+			accessibleLabel: `${t("usage.estimatedCost")}: ${cost}`,
+			compactLabel: cost,
 		};
 	}
-	if (processedTokens === null) {
-		return { accessibleLabel: cost, compactLabel: cost };
+	const processedTokens = usage.totals.processedTokens;
+	if (processedTokens === null || processedTokens <= 0) {
+		return undefined;
 	}
+	const compactTokens = formatTokenCount(processedTokens).replace(/ tok$/, "");
 	const accessibleTokens = t("shell.usageTokens", {
 		count: processedTokens.toLocaleString("en-US"),
 	});
 	return {
-		accessibleLabel: `${cost} · ${accessibleTokens}`,
-		compactLabel: cost,
+		accessibleLabel: accessibleTokens,
+		compactLabel: compactTokens,
 	};
+}
+
+function BoardUsageMetric({
+	presentation,
+	usage,
+}: {
+	presentation: BoardUsagePresentation;
+	usage: SessionUsageSummary;
+}) {
+	const { t } = useTranslation();
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					aria-label={presentation.accessibleLabel}
+					className="relative z-10 rounded-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+					onClick={(event) => event.stopPropagation()}
+					onPointerDown={(event) => event.stopPropagation()}
+					type="button"
+				>
+					<SessionUsageMetricView usage={presentation} />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent className="w-72 p-3 text-left" side="top">
+				<p className="mb-2 font-medium text-popover-foreground">{t("inspector.usage.title")}</p>
+				<UsageBreakdown totals={usage.totals} />
+				{usage.totals.estimatedCost ? (
+					<div className="mt-2.5 border-t border-border/70 pt-2 text-2xs leading-normal text-muted-foreground">
+						<EstimatedCostExplanation cost={usage.totals.estimatedCost} />
+					</div>
+				) : null}
+			</TooltipContent>
+		</Tooltip>
+	);
 }
 
 function ArchiveRestoreButton({

--- a/frontend/src/renderer/components/UsageBreakdown.tsx
+++ b/frontend/src/renderer/components/UsageBreakdown.tsx
@@ -1,0 +1,137 @@
+import { useTranslation } from "react-i18next";
+import type { components } from "../../api/schema";
+import { formatCostNanos } from "../lib/format-cost";
+import { formatTokenCount } from "../lib/format-token-count";
+import { cn } from "../lib/utils";
+
+export type UsageTotals = components["schemas"]["UsageTotalsResponse"];
+type EstimatedCost = components["schemas"]["EstimatedCostResponse"];
+
+export function UsageBreakdown({
+	className,
+	totals,
+}: {
+	className?: string;
+	totals: UsageTotals;
+}) {
+	const { t } = useTranslation();
+	const cacheHitRate = formatCacheHitRate(totals.cachedInputTokens, totals.inputTokens);
+	return (
+		<div className={cn("space-y-2.5", className)}>
+			<dl
+				className="grid grid-cols-2 gap-x-4 gap-y-2 @max-[300px]/inspector:grid-cols-1"
+				data-testid="session-usage-metrics"
+			>
+				<TokenMetric label={t("inspector.usage.uncachedInputTokens")} metric={totals.uncachedInputTokens} />
+				<TokenMetric label={t("inspector.usage.cachedInputTokens")} metric={totals.cachedInputTokens} />
+				<TokenMetric label={t("inspector.usage.outputTokens")} metric={totals.outputTokens} />
+				<RateMetric rate={cacheHitRate} />
+			</dl>
+			{totals.estimatedCost ? (
+				<dl className="grid grid-cols-3 gap-x-3 border-t border-border/70 pt-2">
+					<CostMetric label={t("usage.input")} nanos={totals.estimatedCost.inputNanos} />
+					<CostMetric label={t("usage.cachedInput")} nanos={totals.estimatedCost.cachedInputNanos} />
+					<CostMetric label={t("usage.output")} nanos={totals.estimatedCost.outputNanos} />
+				</dl>
+			) : null}
+		</div>
+	);
+}
+
+export function EstimatedCostExplanation({ cost }: { cost: EstimatedCost }) {
+	const { t } = useTranslation();
+	const providerInfoKey =
+		cost.providerAttribution === "inferred"
+			? "usage.estimatedCostInfoInferred"
+			: cost.providerAttribution === "mixed"
+				? "usage.estimatedCostInfoMixed"
+				: "usage.estimatedCostInfo";
+	return (
+		<>
+			<p>{t(providerInfoKey)}</p>
+			{cost.coverage === "partial" ? <p className="mt-1.5">{t("usage.estimatedCostInfoPartial")}</p> : null}
+		</>
+	);
+}
+
+function TokenMetric({ label, metric }: { label: string; metric: number | null | undefined }) {
+	const { t } = useTranslation();
+	const value = typeof metric === "number" && Number.isFinite(metric) ? metric : null;
+	const exactValue = value?.toLocaleString("en-US");
+	const accessibleLabel =
+		value === null
+			? t("inspector.usage.metricUnavailable", { label })
+			: t("inspector.usage.metricAria", { label, count: exactValue });
+	return (
+		<div className="min-w-0">
+			<dt className="truncate text-2xs text-settings-muted">{label}</dt>
+			<dd
+				aria-label={accessibleLabel}
+				className="mt-0.5 truncate font-mono text-sm-md text-settings-label"
+				title={
+					value === null
+						? t("inspector.usage.metricUnavailable", { label })
+						: t("inspector.usage.tokensExact", { count: exactValue })
+				}
+			>
+				{value === null ? "—" : formatTokenCount(value).replace(/ tok$/, "")}
+			</dd>
+		</div>
+	);
+}
+
+function RateMetric({ rate }: { rate: string | null }) {
+	const { t } = useTranslation();
+	const label = t("inspector.usage.cacheHitRate");
+	const description =
+		rate === null
+			? t("inspector.usage.metricUnavailable", { label })
+			: t("inspector.usage.cacheHitRateDescription", { rate });
+	return (
+		<div className="min-w-0">
+			<dt className="truncate text-2xs text-settings-muted">{label}</dt>
+			<dd
+				aria-label={description}
+				className="mt-0.5 truncate font-mono text-sm-md text-settings-label"
+				title={description}
+			>
+				{rate === null ? "—" : `${rate}%`}
+			</dd>
+		</div>
+	);
+}
+
+function CostMetric({ label, nanos }: { label: string; nanos: number | null | undefined }) {
+	const { t } = useTranslation();
+	const value = formatCostNanos(nanos);
+	const accessibleLabel = value ? `${label}: ${value}` : t("inspector.usage.metricUnavailable", { label });
+	return (
+		<div className="min-w-0">
+			<dt className="truncate text-2xs text-settings-muted">{label}</dt>
+			<dd
+				aria-label={accessibleLabel}
+				className="mt-0.5 truncate font-mono text-2xs text-settings-label"
+				title={accessibleLabel}
+			>
+				{value ?? "—"}
+			</dd>
+		</div>
+	);
+}
+
+function formatCacheHitRate(
+	cachedInputTokens: number | null | undefined,
+	inputTokens: number | null | undefined,
+): string | null {
+	if (
+		typeof cachedInputTokens !== "number" ||
+		!Number.isFinite(cachedInputTokens) ||
+		typeof inputTokens !== "number" ||
+		!Number.isFinite(inputTokens) ||
+		inputTokens <= 0
+	) {
+		return null;
+	}
+	const percentage = Math.min(100, Math.max(0, (cachedInputTokens / inputTokens) * 100));
+	return percentage.toFixed(1).replace(/\.0$/, "");
+}


### PR DESCRIPTION
## Summary

- price fresh provider-native usage when the active catalog has exactly one owner for the reported model, recording the route as `inferred` so later observed Claude routing can still replace attribution and cost
- preserve honest unknowns: unidentified Claude proxy routes and models absent from the catalog remain unpriced
- extend the compact usage API with the canonical token/category totals already used by the detailed session view
- render exactly one Kanban scan metric: reliable dollar cost, otherwise reliable compact tokens, otherwise nothing (including no orphan separator)
- share the detailed token and cost-category breakdown between the developer-mode session inspector and the card's hover/focus tooltip

## Root cause and harness coverage

Fresh Claude Code records can carry native token counters before a billing route is observed. Live ingestion deliberately left those rows unattributed and relied on legacy repair, but repair runs at startup/settle or when route evidence changes. A newly spawned, continuously active worker could therefore accumulate reliable tokens while remaining unpriced until a later repair pass, producing `Unavailable · 5.2M` on its card.

Live ingestion now uses unique catalog ownership as explicitly inferred evidence. This is covered end-to-end for Claude Code, Codex records missing provider metadata, and Kimi wire usage. Provider-specific counters remain intact. Observed routes still win; unknown catalog models and the explicit unidentified-proxy sentinel do not receive fabricated costs.

## UI rules covered

- reliable estimate: `$1.24` only, including reliable `$0.00`
- no estimate + reliable usage: `5.2M` only
- neither: no metric and no separator
- no literal `Unavailable` card placeholder
- hover and keyboard focus disclose fresh input, cache reads, output, cache-hit rate, input/cache/output costs, coverage, and observed/inferred attribution context

## Tests

- `go test ./internal/observe/usage ./internal/service/usage ./internal/storage/sqlite/store ./internal/httpd/...`
- sanitized worker environment: `go test ./...`
- `npm run frontend:typecheck`
- `npx vitest run --config vite.renderer.config.ts src/renderer/components/SessionsBoard.test.tsx src/renderer/components/SessionInspector.test.tsx --reporter=verbose` (144 passed)

## Preview evidence

Opened and kept the completed browser-preview target available for human inspection in this AO session with:

`go run ./backend/cmd/ao preview http://127.0.0.1:5174/`

Automated inspection through the AO Browser panel was blocked because this worker was provisioned with an empty browser capability and empty persisted verifier. The capability cannot be safely reconstructed for a running worker, so no direct Browser API fallback or relaunch was attempted.

Separate non-panel visual QA against the same preview build at 1440×1000 reproduced all three branches together: `$1.24`, `5.2M`, and omitted; zero visible `Unavailable` placeholders. Hovering `$1.24` showed the shared token/category and dollar-component breakdown with the provider-pricing explanation.
