### PR TITLE
feat(gitlab-tracker): switch List and Get to GraphQL Work Items API

### DIFF
--- a/backend/internal/adapters/tracker/gitlab/doc.go
+++ b/backend/internal/adapters/tracker/gitlab/doc.go
@@ -1,21 +1,27 @@
 // Package gitlab implements the ports.Tracker outbound port for GitLab
-// Issues. v1 is read-only:
+// Work Items via the GraphQL API. v1 is read-only:
 //
-//   - Get returns a normalized snapshot of one issue (spawn-bootstrap
+//   - Get returns a normalized snapshot of one work item (spawn-bootstrap
 //     reads it to hydrate the agent prompt).
-//   - List returns a filtered slice of issues in a project, paginated via
-//     GitLab's Link-header pagination with state/labels/assignee filters.
-//   - Preflight performs a single GET /user against GitLab to verify the
-//     token is accepted; success is cached for the lifetime of the
-//     Tracker, failures are not.
+//   - List returns a filtered slice of work items in a project, paginated
+//     via cursor-based pagination (first/after with pageInfo.endCursor /
+//     hasNextPage) with state/labels/assignee filters.
+//   - Preflight performs a single REST GET /user against GitLab to verify
+//     the token is accepted; success is cached for the lifetime of the
+//     Tracker, failures are not. Preflight stays on REST because it
+//     validates token validity, not Work Items access.
+//
+// Get and List send GraphQL queries to POST /api/v4/graphql. Work item
+// details (assignees, labels) are exposed as typed widgets in the
+// response (WorkItemWidgetAssignees, WorkItemWidgetLabels).
 //
 // The adapter reuses the SCM provider's TokenSource chain
 // (AO_GITLAB_TOKEN / GITLAB_TOKEN / glab auth status --show-token).
 //
 // # State mapping
 //
-// GitLab issues have two native states: opened and closed. They map onto
-// the normalized state vocabulary as follows:
+// GitLab work items have two native states: opened and closed. They map
+// onto the normalized state vocabulary as follows:
 //
 //   - opened -> open
 //   - closed -> done

--- a/backend/internal/adapters/tracker/gitlab/tracker.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker.go
@@ -202,7 +202,7 @@ type gqlResponse struct {
 }
 
 type gqlError struct {
-	Message string `json:"message"`
+	Message    string `json:"message"`
 	Extensions struct {
 		Code string `json:"code"`
 	} `json:"extensions"`
@@ -418,7 +418,7 @@ func (t *Tracker) List(ctx context.Context, repo domain.TrackerRepo, filter doma
 
 	vars := map[string]any{
 		"fullPath": projectPath,
-		"first":   listPageSize,
+		"first":    listPageSize,
 	}
 	if stateFilter != "all" {
 		vars["state"] = stateFilter

--- a/backend/internal/adapters/tracker/gitlab/tracker.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker.go
@@ -210,9 +210,10 @@ type gqlError struct {
 
 // gqlWorkItem is the subset of fields we read off a GraphQL Work Item node.
 // Work item details (assignees, labels) are exposed as typed widgets in the
-// GraphQL response.
+// GraphQL response. The ID field (global GraphQL ID) is fetched for future
+// use but not currently surfaced to the domain.
 type gqlWorkItem struct {
-	ID          string `json:"id"`
+	ID string `json:"id"` // global GraphQL ID; not yet surfaced to domain
 	IID         string `json:"iid"`
 	Title       string `json:"title"`
 	Description string `json:"description"`
@@ -326,11 +327,18 @@ func issueFromGraphQL(projectPath string, wi gqlWorkItem) domain.Issue {
 			}
 		}
 	}
-	iid, _ := strconv.Atoi(wi.IID)
+	// IID is typed as ID! in the GraphQL schema but is always numeric in
+	// practice. If parsing fails, fall back to the raw string so the ID
+	// is still useful for debugging rather than silently becoming #0.
+	iid, err := strconv.Atoi(wi.IID)
+	nativeIID := wi.IID
+	if err == nil {
+		nativeIID = strconv.Itoa(iid)
+	}
 	out := domain.Issue{
 		ID: domain.TrackerID{
 			Provider: domain.TrackerProviderGitLab,
-			Native:   fmt.Sprintf("%s#%d", projectPath, iid),
+			Native:   fmt.Sprintf("%s#%s", projectPath, nativeIID),
 		},
 		Title:     wi.Title,
 		Body:      wi.Description,

--- a/backend/internal/adapters/tracker/gitlab/tracker.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker.go
@@ -44,7 +44,7 @@ var (
 
 // RateLimitError is an alias for httpkit.RateLimitError so existing callers
 // that use errors.As with *RateLimitError continue to work. The sentinel
-// field is set to ErrRateLimited by the adapter's classifyError.
+// field is set to ErrRateLimited by the adapter's classifyHTTPError.
 type RateLimitError = httpkit.RateLimitError
 
 // Options configures a Tracker. All fields except Token are optional —
@@ -78,7 +78,7 @@ type hostEntry struct {
 	tokens  scmgitlab.TokenSource
 }
 
-// Tracker implements ports.Tracker against the GitLab REST API v4.
+// Tracker implements ports.Tracker against the GitLab GraphQL Work Items API.
 //
 // Construction performs a fail-fast token presence check (no network call).
 // The first Preflight call validates the token against GitLab itself; a
@@ -582,19 +582,6 @@ func (t *Tracker) graphql(ctx context.Context, he hostEntry, query string, varia
 
 // classifyHTTPError maps an HTTP error response to a sentinel error.
 func classifyHTTPError(resp *http.Response, body []byte) error {
-	msg := httpkit.Message(body)
-	switch resp.StatusCode {
-	case http.StatusNotFound:
-		return fmt.Errorf("%w: %s", ErrNotFound, msg)
-	case http.StatusTooManyRequests:
-		return httpkit.BuildRateLimitError(resp, msg, ErrRateLimited)
-	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("%w: %s", ErrAuthFailed, msg)
-	}
-	return fmt.Errorf("gitlab tracker: %d %s", resp.StatusCode, msg)
-}
-
-func classifyError(resp *http.Response, body []byte) error {
 	msg := httpkit.Message(body)
 	switch resp.StatusCode {
 	case http.StatusNotFound:

--- a/backend/internal/adapters/tracker/gitlab/tracker.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -184,25 +183,81 @@ func (t *Tracker) ConfigForHost(host string) error {
 var _ ports.Tracker = (*Tracker)(nil)
 
 // ---------------------------------------------------------------------------
+// GraphQL types
+// ---------------------------------------------------------------------------
+
+// gqlRequest is the envelope for a GitLab GraphQL POST body.
+type gqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+// gqlResponse is the envelope for a GitLab GraphQL response. The Data
+// field is a generic json.RawMessage so callers can decode into the
+// specific shape they expect.
+type gqlResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []gqlError      `json:"errors"`
+}
+
+type gqlError struct {
+	Message string `json:"message"`
+	Extensions struct {
+		Code string `json:"code"`
+	} `json:"extensions"`
+}
+
+// gqlWorkItem is the subset of fields we read off a GraphQL Work Item node.
+// Work item details (assignees, labels) are exposed as typed widgets in the
+// GraphQL response.
+type gqlWorkItem struct {
+	ID          string `json:"id"`
+	IID         string `json:"iid"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	State       string `json:"state"`
+	WebURL      string `json:"webUrl"`
+	Widgets     []struct {
+		Type string `json:"type"`
+		// Assignees widget
+		Assignees struct {
+			Nodes []struct {
+				Username string `json:"username"`
+			} `json:"nodes"`
+		} `json:"assignees"`
+		// Labels widget
+		Labels struct {
+			Nodes []struct {
+				Title string `json:"title"`
+			} `json:"nodes"`
+		} `json:"labels"`
+	} `json:"widgets"`
+}
+
+// gqlWorkItemsData is the decoded shape of the project.workItems query.
+type gqlWorkItemsData struct {
+	Project *struct {
+		WorkItems struct {
+			PageInfo struct {
+				EndCursor   string `json:"endCursor"`
+				HasNextPage bool   `json:"hasNextPage"`
+			} `json:"pageInfo"`
+			Nodes []gqlWorkItem `json:"nodes"`
+		} `json:"workItems"`
+	} `json:"project"`
+}
+
+// gqlWorkItemData is the decoded shape for a single work item query.
+type gqlWorkItemData struct {
+	WorkItem *gqlWorkItem `json:"workItem"`
+}
+
+// ---------------------------------------------------------------------------
 // Get
 // ---------------------------------------------------------------------------
 
-// glIssue is the subset of fields we read off the GitLab issue payload.
-type glIssue struct {
-	IID         int      `json:"iid"`
-	Title       string   `json:"title"`
-	Description string   `json:"description"`
-	State       string   `json:"state"`
-	WebURL      string   `json:"web_url"`
-	Labels      []string `json:"labels"`
-	Assignees   []glUser `json:"assignees"`
-}
-
-type glUser struct {
-	Username string `json:"username"`
-}
-
-// Get fetches a single issue by id and maps it onto the normalized domain.Issue.
+// Get fetches a single work item by id via GraphQL and maps it onto the
+// normalized domain.Issue.
 func (t *Tracker) Get(ctx context.Context, id domain.TrackerID) (domain.Issue, error) {
 	projectPath, iid, err := t.parseID(id)
 	if err != nil {
@@ -212,41 +267,75 @@ func (t *Tracker) Get(ctx context.Context, id domain.TrackerID) (domain.Issue, e
 	if err != nil {
 		return domain.Issue{}, err
 	}
-	path := fmt.Sprintf("/projects/%s/issues/%d", url.PathEscape(projectPath), iid)
 
-	resp, err := t.do(ctx, he, http.MethodGet, path, nil)
+	query := `query($fullPath: ID!, $iid: ID!) {
+  workItem(fullPath: $fullPath, iid: $iid) {
+    iid
+    title
+    description
+    state
+    webUrl
+    widgets {
+      type
+      ... on WorkItemWidgetAssignees { assignees { nodes { username } } }
+      ... on WorkItemWidgetLabels { labels { nodes { title } } }
+    }
+  }
+}`
+	vars := map[string]any{
+		"fullPath": projectPath,
+		"iid":      strconv.Itoa(iid),
+	}
+
+	resp, err := t.graphql(ctx, he, query, vars)
 	if err != nil {
 		return domain.Issue{}, err
 	}
-	var raw glIssue
-	if err := json.Unmarshal(resp, &raw); err != nil {
-		return domain.Issue{}, fmt.Errorf("gitlab tracker: decode issue: %w", err)
+
+	var data gqlWorkItemData
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return domain.Issue{}, fmt.Errorf("gitlab tracker: decode work item: %w", err)
 	}
-	issue := issueFromGitLab(projectPath, raw)
+	if data.WorkItem == nil {
+		return domain.Issue{}, fmt.Errorf("%w: work item %s#%d not found", ErrNotFound, projectPath, iid)
+	}
+
+	issue := issueFromGraphQL(projectPath, *data.WorkItem)
 	issue.ID.Host = id.Host // preserve host for round-trip
 	return issue, nil
 }
 
-// issueFromGitLab projects a raw GitLab issue payload into the normalized
-// domain.Issue. projectPath is passed in because the TrackerID.Native
-// shape is "path/to/project#iid" and we want the returned ID to round-trip
-// through the same adapter. The caller sets Host on the returned Issue after
-// this function returns.
-func issueFromGitLab(projectPath string, raw glIssue) domain.Issue {
-	assignees := make([]string, 0, len(raw.Assignees))
-	for _, a := range raw.Assignees {
-		assignees = append(assignees, a.Username)
+// issueFromGraphQL projects a GraphQL Work Item node into the normalized
+// domain.Issue. projectPath is passed in because the TrackerID.Native shape
+// is "path/to/project#iid" and we want the returned ID to round-trip through
+// the same adapter. The caller sets Host on the returned Issue after this
+// function returns.
+func issueFromGraphQL(projectPath string, wi gqlWorkItem) domain.Issue {
+	var assignees []string
+	var labels []string
+	for _, w := range wi.Widgets {
+		switch w.Type {
+		case "ASSIGNEES":
+			for _, n := range w.Assignees.Nodes {
+				assignees = append(assignees, n.Username)
+			}
+		case "LABELS":
+			for _, n := range w.Labels.Nodes {
+				labels = append(labels, n.Title)
+			}
+		}
 	}
+	iid, _ := strconv.Atoi(wi.IID)
 	out := domain.Issue{
 		ID: domain.TrackerID{
 			Provider: domain.TrackerProviderGitLab,
-			Native:   fmt.Sprintf("%s#%d", projectPath, raw.IID),
+			Native:   fmt.Sprintf("%s#%d", projectPath, iid),
 		},
-		Title:     raw.Title,
-		Body:      raw.Description,
-		State:     mapStateFromGitLab(raw.State),
-		URL:       raw.WebURL,
-		Labels:    raw.Labels,
+		Title:     wi.Title,
+		Body:      wi.Description,
+		State:     mapStateFromGitLab(wi.State),
+		URL:       wi.WebURL,
+		Labels:    labels,
 		Assignees: assignees,
 	}
 	if len(out.Labels) == 0 {
@@ -271,9 +360,9 @@ func mapStateFromGitLab(state string) domain.NormalizedIssueState {
 // List
 // ---------------------------------------------------------------------------
 
-// List returns issues for a project, filtered by state/labels/assignee.
-// Pagination is followed via GitLab's Link-header (rel="next") until no next
-// link remains; ListFilter.Limit, when set, caps the total accumulated
+// List returns work items for a project, filtered by state/labels/assignee.
+// Pagination is cursor-based (first/after with pageInfo.endCursor/
+// hasNextPage); ListFilter.Limit, when set, caps the total accumulated
 // issue count.
 func (t *Tracker) List(ctx context.Context, repo domain.TrackerRepo, filter domain.ListFilter) ([]domain.Issue, error) {
 	if repo.Provider != domain.TrackerProviderGitLab {
@@ -288,52 +377,86 @@ func (t *Tracker) List(ctx context.Context, repo domain.TrackerRepo, filter doma
 		return nil, err
 	}
 
-	q := url.Values{}
+	var stateFilter string
 	switch filter.State {
 	case domain.ListOpen:
-		q.Set("state", "opened")
+		stateFilter = "opened"
 	case domain.ListClosed:
-		q.Set("state", "closed")
+		stateFilter = "closed"
 	default:
-		q.Set("state", "all")
+		stateFilter = "all"
 	}
-	if len(filter.Labels) > 0 {
-		q.Set("labels", strings.Join(filter.Labels, ","))
+
+	query := `query($fullPath: ID!, $state: WorkItemState, $assigneeUsernames: [String!], $labelName: [String!], $first: Int, $after: String) {
+  project(fullPath: $fullPath) {
+    workItems(state: $state, assigneeUsernames: $assigneeUsernames, labelName: $labelName, first: $first, after: $after) {
+      pageInfo { endCursor hasNextPage }
+      nodes {
+        iid
+        title
+        description
+        state
+        webUrl
+        widgets {
+          type
+          ... on WorkItemWidgetAssignees { assignees { nodes { username } } }
+          ... on WorkItemWidgetLabels { labels { nodes { title } } }
+        }
+      }
+    }
+  }
+}`
+
+	vars := map[string]any{
+		"fullPath": projectPath,
+		"first":   listPageSize,
+	}
+	if stateFilter != "all" {
+		vars["state"] = stateFilter
 	}
 	if filter.Assignee != "" {
-		q.Set("assignee_username", filter.Assignee)
+		vars["assigneeUsernames"] = []string{filter.Assignee}
 	}
-	q.Set("per_page", strconv.Itoa(listPageSize))
+	if len(filter.Labels) > 0 {
+		vars["labelName"] = filter.Labels
+	}
 
-	path := fmt.Sprintf("/projects/%s/issues?%s", url.PathEscape(projectPath), q.Encode())
 	out := make([]domain.Issue, 0)
 	if filter.Limit > 0 {
 		out = make([]domain.Issue, 0, filter.Limit)
 	}
-	for page := 0; path != ""; page++ {
+
+	for page := 0; ; page++ {
 		if page >= maxListPages {
 			return nil, fmt.Errorf("gitlab tracker: list pagination exceeded %d pages", maxListPages)
 		}
-		respBody, nextPath, err := t.roundTrip(ctx, he, http.MethodGet, path, nil)
+
+		resp, err := t.graphql(ctx, he, query, vars)
 		if err != nil {
 			return nil, err
 		}
-		var raw []glIssue
-		if err := json.Unmarshal(respBody, &raw); err != nil {
+
+		var data gqlWorkItemsData
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
 			return nil, fmt.Errorf("gitlab tracker: decode list: %w", err)
 		}
-		pageIssues := make([]domain.Issue, 0, len(raw))
-		for _, r := range raw {
-			issue := issueFromGitLab(projectPath, r)
+		if data.Project == nil {
+			return nil, fmt.Errorf("%w: project %q not found", ErrNotFound, projectPath)
+		}
+
+		nodes := data.Project.WorkItems.Nodes
+		pageIssues := make([]domain.Issue, 0, len(nodes))
+		for _, n := range nodes {
+			issue := issueFromGraphQL(projectPath, n)
 			issue.ID.Host = repo.Host // preserve host for round-trip
 			pageIssues = append(pageIssues, issue)
 		}
 		var done bool
 		out, done = httpkit.AppendIssuesWithLimit(out, pageIssues, filter.Limit)
-		if done {
+		if done || !data.Project.WorkItems.PageInfo.HasNextPage {
 			break
 		}
-		path = nextPath
+		vars["after"] = data.Project.WorkItems.PageInfo.EndCursor
 	}
 	return out, nil
 }
@@ -363,23 +486,19 @@ func (t *Tracker) Preflight(ctx context.Context) error {
 // HTTP plumbing
 // ---------------------------------------------------------------------------
 
+// do performs a REST request (used by Preflight). Returns the raw response body.
 func (t *Tracker) do(ctx context.Context, he hostEntry, method, path string, body any) ([]byte, error) {
-	respBody, _, err := t.roundTrip(ctx, he, method, path, body)
-	return respBody, err
-}
-
-func (t *Tracker) roundTrip(ctx context.Context, he hostEntry, method, path string, body any) ([]byte, string, error) {
 	var rdr io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
 		if err != nil {
-			return nil, "", fmt.Errorf("gitlab tracker: encode body: %w", err)
+			return nil, fmt.Errorf("gitlab tracker: encode body: %w", err)
 		}
 		rdr = bytes.NewReader(b)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, he.baseURL+path, rdr)
 	if err != nil {
-		return nil, "", fmt.Errorf("gitlab tracker: build request: %w", err)
+		return nil, fmt.Errorf("gitlab tracker: build request: %w", err)
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -388,24 +507,91 @@ func (t *Tracker) roundTrip(ctx context.Context, he hostEntry, method, path stri
 	req.Header.Set("User-Agent", t.userAgent)
 	tok, err := he.tokens.Token(ctx)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+tok)
 
 	resp, err := t.http.Do(req)
 	if err != nil {
-		return nil, "", fmt.Errorf("gitlab tracker: %s %s: %w", method, path, err)
+		return nil, fmt.Errorf("gitlab tracker: %s %s: %w", method, path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	nextPath := httpkit.ParseLinkNext(resp.Header.Get("Link"), he.baseURL)
 	respBody, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, "", fmt.Errorf("gitlab tracker: read response body: %w", readErr)
+		return nil, fmt.Errorf("gitlab tracker: read response body: %w", readErr)
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return respBody, nextPath, nil
+		return respBody, nil
 	}
-	return respBody, nextPath, classifyError(resp, respBody)
+	return respBody, classifyHTTPError(resp, respBody)
+}
+
+// graphql sends a GraphQL POST to /api/v4/graphql and returns the decoded
+// response envelope. GraphQL returns HTTP 200 even on query-level errors;
+// those are classified by inspecting the errors array.
+func (t *Tracker) graphql(ctx context.Context, he hostEntry, query string, variables map[string]any) (*gqlResponse, error) {
+	reqBody, err := json.Marshal(gqlRequest{Query: query, Variables: variables})
+	if err != nil {
+		return nil, fmt.Errorf("gitlab tracker: encode graphql body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, he.baseURL+"/graphql", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("gitlab tracker: build graphql request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", t.userAgent)
+	tok, err := he.tokens.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := t.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gitlab tracker: graphql request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("gitlab tracker: read graphql response: %w", readErr)
+	}
+
+	// HTTP-level errors (non-200) are classified by status code.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, classifyHTTPError(resp, respBody)
+	}
+
+	var gqlResp gqlResponse
+	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+		return nil, fmt.Errorf("gitlab tracker: decode graphql response: %w", err)
+	}
+
+	// GraphQL query-level errors: inspect extensions.code for classification.
+	if len(gqlResp.Errors) > 0 {
+		code := gqlResp.Errors[0].Extensions.Code
+		msg := gqlResp.Errors[0].Message
+		if strings.EqualFold(code, "NOT_FOUND") {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, msg)
+		}
+		return nil, fmt.Errorf("gitlab tracker: graphql error: %s", msg)
+	}
+
+	return &gqlResp, nil
+}
+
+// classifyHTTPError maps an HTTP error response to a sentinel error.
+func classifyHTTPError(resp *http.Response, body []byte) error {
+	msg := httpkit.Message(body)
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return fmt.Errorf("%w: %s", ErrNotFound, msg)
+	case http.StatusTooManyRequests:
+		return httpkit.BuildRateLimitError(resp, msg, ErrRateLimited)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("%w: %s", ErrAuthFailed, msg)
+	}
+	return fmt.Errorf("gitlab tracker: %d %s", resp.StatusCode, msg)
 }
 
 func classifyError(resp *http.Response, body []byte) error {

--- a/backend/internal/adapters/tracker/gitlab/tracker.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker.go
@@ -213,7 +213,7 @@ type gqlError struct {
 // GraphQL response. The ID field (global GraphQL ID) is fetched for future
 // use but not currently surfaced to the domain.
 type gqlWorkItem struct {
-	ID string `json:"id"` // global GraphQL ID; not yet surfaced to domain
+	ID          string `json:"id"` // global GraphQL ID; not yet surfaced to domain
 	IID         string `json:"iid"`
 	Title       string `json:"title"`
 	Description string `json:"description"`

--- a/backend/internal/adapters/tracker/gitlab/tracker.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker.go
@@ -78,7 +78,8 @@ type hostEntry struct {
 	tokens  scmgitlab.TokenSource
 }
 
-// Tracker implements ports.Tracker against the GitLab GraphQL Work Items API.
+// Tracker implements ports.Tracker against the GitLab API. List and Get use
+// GraphQL Work Items; Preflight uses REST.
 //
 // Construction performs a fail-fast token presence check (no network call).
 // The first Preflight call validates the token against GitLab itself; a

--- a/backend/internal/adapters/tracker/gitlab/tracker_test.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker_test.go
@@ -827,6 +827,66 @@ func TestList_EmptyResults(t *testing.T) {
 	}
 }
 
+func TestList_NullDescription(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		// Work item with null description in the GraphQL response
+		_, _ = w.Write([]byte(`{"data":{"project":{"workItems":{"pageInfo":{"endCursor":"","hasNextPage":false},"nodes":[{"iid":"1","title":"no desc","description":"","state":"opened","webUrl":"https://gitlab.com/o/r/-/issues/1","widgets":[]}]}}}}`))
+	})
+	tr := newTrackerForTest(t, f)
+	issues, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("len = %d, want 1", len(issues))
+	}
+	if issues[0].Body != "" {
+		t.Fatalf("Body = %q, want empty string", issues[0].Body)
+	}
+}
+
+func TestList_BothLabelsAndAssignees(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		wi := workItemJSON(1, "full", "body", "opened",
+			"https://gitlab.com/o/r/-/issues/1",
+			[]string{"bug", "critical"}, []string{"alice", "bob"})
+		_, _ = w.Write([]byte(`{"data":` + workItemsListJSON([]string{wi}, "", false) + `}`))
+	})
+	tr := newTrackerForTest(t, f)
+	issues, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("len = %d, want 1", len(issues))
+	}
+	if len(issues[0].Labels) != 2 || issues[0].Labels[0] != "bug" || issues[0].Labels[1] != "critical" {
+		t.Fatalf("Labels = %#v, want [bug critical]", issues[0].Labels)
+	}
+	if len(issues[0].Assignees) != 2 || issues[0].Assignees[0] != "alice" || issues[0].Assignees[1] != "bob" {
+		t.Fatalf("Assignees = %#v, want [alice bob]", issues[0].Assignees)
+	}
+}
+
+func TestList_FirstStaysAtPageSizeWhenLimitExceeds(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		vars := gqlVars(t, readBody(r))
+		first := vars["first"]
+		if first != float64(listPageSize) {
+			t.Errorf("first = %v, want %d (listPageSize) even when Limit > 100", first, listPageSize)
+		}
+		_, _ = w.Write([]byte(`{"data":` + workItemsListJSON(nil, "", false) + `}`))
+	})
+	tr := newTrackerForTest(t, f)
+	_, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{Limit: 9999})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Domain validation
 // ---------------------------------------------------------------------------

--- a/backend/internal/adapters/tracker/gitlab/tracker_test.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker_test.go
@@ -91,6 +91,80 @@ func newTrackerForTest(t *testing.T, f *fakeGL) *Tracker {
 
 func ctx() context.Context { return context.Background() }
 
+// gqlVars decodes the GraphQL request body's variables map for assertions.
+func gqlVars(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var req struct {
+		Variables map[string]any `json:"variables"`
+	}
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("failed to decode graphql request body: %v\nbody: %s", err, body)
+	}
+	return req.Variables
+}
+
+// gqlQueryField extracts the top-level query field name from a GraphQL
+// request body, e.g. "workItem" or "project".
+func gqlQueryField(t *testing.T, body string) string {
+	t.Helper()
+	var req struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("failed to decode graphql query: %v", err)
+	}
+	// crude: find the first query/mutation field name after the opening paren
+	s := req.Query
+	if i := strings.Index(s, "{"); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.TrimSpace(s)
+	// first identifier after {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// workItemJSON builds a GraphQL work item node JSON suitable for test responses.
+func workItemJSON(iid int, title, desc, state, webURL string, labels []string, assignees []string) string {
+	var widgets []string
+	if len(assignees) > 0 {
+		var nodes []string
+		for _, a := range assignees {
+			nodes = append(nodes, `{"username":"`+a+`"}`)
+		}
+		widgets = append(widgets, `{"type":"ASSIGNEES","assignees":{"nodes":[`+strings.Join(nodes, ",")+`]}}`)
+	}
+	if len(labels) > 0 {
+		var nodes []string
+		for _, l := range labels {
+			nodes = append(nodes, `{"title":"`+l+`"}`)
+		}
+		widgets = append(widgets, `{"type":"LABELS","labels":{"nodes":[`+strings.Join(nodes, ",")+`]}}`)
+	}
+	widgetsStr := "[]"
+	if len(widgets) > 0 {
+		widgetsStr = "[" + strings.Join(widgets, ",") + "]"
+	}
+	return `{"iid":"` + strconv.Itoa(iid) + `","title":` + jsonStr(title) + `,"description":` + jsonStr(desc) + `,"state":"` + state + `","webUrl":"` + webURL + `","widgets":` + widgetsStr + `}`
+}
+
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// workItemsListJSON wraps work item nodes into a GraphQL project.workItems response.
+func workItemsListJSON(nodes []string, endCursor string, hasNextPage bool) string {
+	nodesStr := "[]"
+	if len(nodes) > 0 {
+		nodesStr = "[" + strings.Join(nodes, ",") + "]"
+	}
+	return `{"project":{"workItems":{"pageInfo":{"endCursor":"` + endCursor + `","hasNextPage":` + strconv.FormatBool(hasNextPage) + `},"nodes":` + nodesStr + `}}}`
+}
+
 // ---------------------------------------------------------------------------
 // New / construction
 // ---------------------------------------------------------------------------
@@ -178,20 +252,21 @@ func TestParseRepo(t *testing.T) {
 
 func TestGet_HappyPath(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/octocat/hello-world/issues/42", func(w http.ResponseWriter, r *http.Request) {
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer tkn-test" {
 			t.Errorf("Authorization = %q, want Bearer tkn-test", got)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"iid": 42,
-			"title": "Found a bug",
-			"description": "It does not work",
-			"state": "opened",
-			"web_url": "https://gitlab.com/octocat/hello-world/-/issues/42",
-			"labels": ["bug","critical"],
-			"assignees": [{"username":"alice"},{"username":"bob"}]
-		}`))
+		vars := gqlVars(t, readBody(r))
+		if vars["fullPath"] != "octocat/hello-world" {
+			t.Errorf("fullPath = %v, want octocat/hello-world", vars["fullPath"])
+		}
+		if vars["iid"] != "42" {
+			t.Errorf("iid = %v, want 42", vars["iid"])
+		}
+		wi := workItemJSON(42, "Found a bug", "It does not work", "opened",
+			"https://gitlab.com/octocat/hello-world/-/issues/42",
+			[]string{"bug", "critical"}, []string{"alice", "bob"})
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 	tr := newTrackerForTest(t, f)
 
@@ -228,15 +303,9 @@ func TestGet_StateMapping(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFakeGL(t)
-			payload := map[string]any{
-				"iid":     1,
-				"title":   "t",
-				"state":   tc.glState,
-				"web_url": "https://gitlab.com/o/r/-/issues/1",
-			}
-			b, _ := json.Marshal(payload)
-			f.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write(b)
+			wi := workItemJSON(1, "t", "", tc.glState, "https://gitlab.com/o/r/-/issues/1", nil, nil)
+			f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 			})
 			tr := newTrackerForTest(t, f)
 			issue, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
@@ -252,8 +321,13 @@ func TestGet_StateMapping(t *testing.T) {
 
 func TestGet_NestedGroup(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/group/sub/project/issues/7", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"iid":7,"title":"nested","description":"d","state":"opened","web_url":"https://gitlab.com/group/sub/project/-/issues/7"}`))
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		vars := gqlVars(t, readBody(r))
+		if vars["fullPath"] != "group/sub/project" {
+			t.Errorf("fullPath = %v, want group/sub/project", vars["fullPath"])
+		}
+		wi := workItemJSON(7, "nested", "d", "opened", "https://gitlab.com/group/sub/project/-/issues/7", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 	tr := newTrackerForTest(t, f)
 	issue, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "group/sub/project#7"})
@@ -267,8 +341,20 @@ func TestGet_NestedGroup(t *testing.T) {
 
 func TestGet_NotFound(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"message":"404 Not Found"}`, http.StatusNotFound)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"workItem":null}}`))
+	})
+	tr := newTrackerForTest(t, f)
+	_, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGet_GraphQLErrorNotFound(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Not found","extensions":{"code":"NOT_FOUND"}}]}`))
 	})
 	tr := newTrackerForTest(t, f)
 	_, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
@@ -280,7 +366,7 @@ func TestGet_NotFound(t *testing.T) {
 func TestGet_RateLimited(t *testing.T) {
 	f := newFakeGL(t)
 	reset := time.Now().Add(2 * time.Minute).Unix()
-	f.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("RateLimit-Reset", strconv.FormatInt(reset, 10))
 		w.Header().Set("Retry-After", "60")
 		http.Error(w, `{"message":"Too many requests"}`, http.StatusTooManyRequests)
@@ -304,7 +390,7 @@ func TestGet_RateLimited(t *testing.T) {
 
 func TestGet_AuthFailed(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"401 Unauthorized"}`, http.StatusUnauthorized)
 	})
 	tr := newTrackerForTest(t, f)
@@ -316,7 +402,7 @@ func TestGet_AuthFailed(t *testing.T) {
 
 func TestGet_ForbiddenAuthFailed(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message":"403 Forbidden"}`, http.StatusForbidden)
 	})
 	tr := newTrackerForTest(t, f)
@@ -346,8 +432,9 @@ func TestGet_RejectsEmptyProvider(t *testing.T) {
 
 func TestGet_CanonicalizesProviderOnOutput(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"iid":1,"title":"t","description":"","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/1"}`))
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		wi := workItemJSON(1, "t", "", "opened", "https://gitlab.com/o/r/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 	tr := newTrackerForTest(t, f)
 	issue, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
@@ -364,8 +451,9 @@ func TestGet_CanonicalizesProviderOnOutput(t *testing.T) {
 
 func TestGet_EmptyLabelsAndAssigneesAreNil(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"iid":1,"title":"t","description":"","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/1"}`))
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		wi := workItemJSON(1, "t", "", "opened", "https://gitlab.com/o/r/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 	tr := newTrackerForTest(t, f)
 	issue, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
@@ -377,6 +465,22 @@ func TestGet_EmptyLabelsAndAssigneesAreNil(t *testing.T) {
 	}
 	if issue.Assignees != nil {
 		t.Fatalf("Assignees = %#v, want nil", issue.Assignees)
+	}
+}
+
+func TestGet_NoDescription(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		// Work item with null description
+		_, _ = w.Write([]byte(`{"data":{"workItem":{"iid":"1","title":"no desc","description":"","state":"opened","webUrl":"https://gitlab.com/o/r/-/issues/1","widgets":[]}}}`))
+	})
+	tr := newTrackerForTest(t, f)
+	issue, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if issue.Body != "" {
+		t.Fatalf("Body = %q, want empty", issue.Body)
 	}
 }
 
@@ -455,18 +559,20 @@ func TestPreflight_RetriesAfterFailure(t *testing.T) {
 
 func TestList_HappyPath(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
-		q := r.URL.Query()
-		if got := q.Get("state"); got != "all" {
-			t.Errorf("state = %q, want all (default)", got)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		vars := gqlVars(t, readBody(r))
+		if vars["fullPath"] != "o/r" {
+			t.Errorf("fullPath = %v, want o/r", vars["fullPath"])
 		}
-		if got := q.Get("per_page"); got != "100" {
-			t.Errorf("per_page = %q, want 100 (default)", got)
+		// Default state is "all" — the variable should not be set (omitted).
+		if _, ok := vars["state"]; ok {
+			t.Errorf("state should be omitted for ListAll, got %v", vars["state"])
 		}
-		_, _ = w.Write([]byte(`[
-			{"iid":1,"title":"first","description":"b1","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/1","labels":["bug"]},
-			{"iid":2,"title":"second","description":"b2","state":"closed","web_url":"https://gitlab.com/o/r/-/issues/2","assignees":[{"username":"alice"}]}
-		]`))
+		wi1 := workItemJSON(1, "first", "b1", "opened",
+			"https://gitlab.com/o/r/-/issues/1", []string{"bug"}, nil)
+		wi2 := workItemJSON(2, "second", "b2", "closed",
+			"https://gitlab.com/o/r/-/issues/2", nil, []string{"alice"})
+		_, _ = w.Write([]byte(`{"data":` + workItemsListJSON([]string{wi1, wi2}, "", false) + `}`))
 	})
 	tr := newTrackerForTest(t, f)
 	issues, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
@@ -479,44 +585,61 @@ func TestList_HappyPath(t *testing.T) {
 	if issues[0].ID.Native != "o/r#1" || issues[0].State != domain.IssueOpen || issues[0].Title != "first" {
 		t.Fatalf("issues[0] = %#v", issues[0])
 	}
+	if issues[0].Labels == nil || len(issues[0].Labels) != 1 || issues[0].Labels[0] != "bug" {
+		t.Fatalf("issues[0].Labels = %#v, want [bug]", issues[0].Labels)
+	}
 	if issues[1].ID.Native != "o/r#2" || issues[1].State != domain.IssueDone || len(issues[1].Assignees) != 1 || issues[1].Assignees[0] != "alice" {
 		t.Fatalf("issues[1] = %#v", issues[1])
 	}
 }
 
-func TestList_QueryEncoding(t *testing.T) {
+func TestList_FilterVariables(t *testing.T) {
 	cases := []struct {
 		name   string
 		filter domain.ListFilter
-		wantQ  map[string]string
+		check  func(t *testing.T, vars map[string]any)
 	}{
 		{
-			name:   "open + labels + assignee + limit",
+			name:   "open + labels + assignee",
 			filter: domain.ListFilter{State: domain.ListOpen, Labels: []string{"bug", "help wanted"}, Assignee: "alice", Limit: 50},
-			wantQ:  map[string]string{"state": "opened", "labels": "bug,help wanted", "assignee_username": "alice", "per_page": "100"},
+			check: func(t *testing.T, vars map[string]any) {
+				if vars["state"] != "opened" {
+					t.Errorf("state = %v, want opened", vars["state"])
+				}
+				if vars["assigneeUsernames"] == nil {
+					t.Fatalf("assigneeUsernames not set")
+				}
+				if vars["labelName"] == nil {
+					t.Fatalf("labelName not set")
+				}
+			},
 		},
 		{
 			name:   "closed only",
 			filter: domain.ListFilter{State: domain.ListClosed},
-			wantQ:  map[string]string{"state": "closed", "per_page": "100"},
+			check: func(t *testing.T, vars map[string]any) {
+				if vars["state"] != "closed" {
+					t.Errorf("state = %v, want closed", vars["state"])
+				}
+			},
 		},
 		{
-			name:   "large total limit still uses max page size",
-			filter: domain.ListFilter{Limit: 9999},
-			wantQ:  map[string]string{"state": "all", "per_page": "100"},
+			name:   "all state — state var omitted",
+			filter: domain.ListFilter{},
+			check: func(t *testing.T, vars map[string]any) {
+				if _, ok := vars["state"]; ok {
+					t.Errorf("state should be omitted for ListAll, got %v", vars["state"])
+				}
+			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFakeGL(t)
-			f.on("GET", "/projects/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
-				got := r.URL.Query()
-				for k, want := range tc.wantQ {
-					if g := got.Get(k); g != want {
-						t.Errorf("query[%q] = %q, want %q", k, g, want)
-					}
-				}
-				_, _ = w.Write([]byte(`[]`))
+			f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+				vars := gqlVars(t, readBody(r))
+				tc.check(t, vars)
+				_, _ = w.Write([]byte(`{"data":` + workItemsListJSON(nil, "", false) + `}`))
 			})
 			tr := newTrackerForTest(t, f)
 			if _, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, tc.filter); err != nil {
@@ -526,17 +649,27 @@ func TestList_QueryEncoding(t *testing.T) {
 	}
 }
 
-func TestList_PaginatesAcrossLinkNext(t *testing.T) {
+func TestList_PaginatesAcrossCursors(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Query().Get("page") {
-		case "":
-			w.Header().Set("Link", `<`+f.server.URL+`/projects/o/r/issues?state=all&per_page=100&page=2>; rel="next"`)
-			_, _ = w.Write([]byte(`[{"iid":1,"title":"first","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/1"}]`))
-		case "2":
-			_, _ = w.Write([]byte(`[{"iid":2,"title":"second","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/2"}]`))
+	var callCount int
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		vars := gqlVars(t, readBody(r))
+		switch callCount {
+		case 1:
+			if _, ok := vars["after"]; ok {
+				t.Errorf("first page should not have after, got %v", vars["after"])
+			}
+			wi1 := workItemJSON(1, "first", "", "opened", "https://gitlab.com/o/r/-/issues/1", nil, nil)
+			_, _ = w.Write([]byte(`{"data":` + workItemsListJSON([]string{wi1}, "cursor-abc", true) + `}`))
+		case 2:
+			if vars["after"] != "cursor-abc" {
+				t.Errorf("second page after = %v, want cursor-abc", vars["after"])
+			}
+			wi2 := workItemJSON(2, "second", "", "opened", "https://gitlab.com/o/r/-/issues/2", nil, nil)
+			_, _ = w.Write([]byte(`{"data":` + workItemsListJSON([]string{wi2}, "", false) + `}`))
 		default:
-			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+			t.Fatalf("unexpected call #%d", callCount)
 		}
 	})
 	tr := newTrackerForTest(t, f)
@@ -548,17 +681,18 @@ func TestList_PaginatesAcrossLinkNext(t *testing.T) {
 	if len(issues) != 2 || issues[0].ID.Native != "o/r#1" || issues[1].ID.Native != "o/r#2" {
 		t.Fatalf("issues = %#v, want both pages in order", issues)
 	}
+	if callCount != 2 {
+		t.Fatalf("callCount = %d, want 2", callCount)
+	}
 }
 
 func TestList_RespectsLimit(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Link", `<`+f.server.URL+`/projects/o/r/issues?state=all&per_page=100&page=2>; rel="next"`)
-		_, _ = w.Write([]byte(`[
-			{"iid":1,"title":"first","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/1"},
-			{"iid":2,"title":"second","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/2"},
-			{"iid":3,"title":"third","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/3"}
-		]`))
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		wi1 := workItemJSON(1, "first", "", "opened", "https://gitlab.com/o/r/-/issues/1", nil, nil)
+		wi2 := workItemJSON(2, "second", "", "opened", "https://gitlab.com/o/r/-/issues/2", nil, nil)
+		wi3 := workItemJSON(3, "third", "", "opened", "https://gitlab.com/o/r/-/issues/3", nil, nil)
+		_, _ = w.Write([]byte(`{"data":` + workItemsListJSON([]string{wi1, wi2, wi3}, "cursor-next", true) + `}`))
 	})
 	tr := newTrackerForTest(t, f)
 	issues, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{Limit: 2})
@@ -571,12 +705,21 @@ func TestList_RespectsLimit(t *testing.T) {
 	if issues[0].ID.Native != "o/r#1" || issues[1].ID.Native != "o/r#2" {
 		t.Fatalf("issues = %#v, want first 2", issues)
 	}
+	// Should not fetch a second page since limit was hit.
+	if calls := f.calls(); len(calls) != 1 {
+		t.Fatalf("HTTP calls = %d, want 1 (limit should stop early)", len(calls))
+	}
 }
 
 func TestList_NestedGroup(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/group/sub/proj/issues", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`[{"iid":1,"title":"nested","state":"opened","web_url":"https://gitlab.com/group/sub/proj/-/issues/1"}]`))
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		vars := gqlVars(t, readBody(r))
+		if vars["fullPath"] != "group/sub/proj" {
+			t.Errorf("fullPath = %v, want group/sub/proj", vars["fullPath"])
+		}
+		wi := workItemJSON(1, "nested", "", "opened", "https://gitlab.com/group/sub/proj/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":` + workItemsListJSON([]string{wi}, "", false) + `}`))
 	})
 	tr := newTrackerForTest(t, f)
 	issues, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "group/sub/proj"}, domain.ListFilter{})
@@ -621,10 +764,10 @@ func TestList_RejectsBadRepo(t *testing.T) {
 	}
 }
 
-func TestList_NotFound(t *testing.T) {
+func TestList_NotFound_GraphQLErrors(t *testing.T) {
 	f := newFakeGL(t)
-	f.on("GET", "/projects/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"message":"404 Project Not Found"}`, http.StatusNotFound)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Project not found","extensions":{"code":"NOT_FOUND"}}]}`))
 	})
 	tr := newTrackerForTest(t, f)
 	_, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
@@ -633,9 +776,56 @@ func TestList_NotFound(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// ParseLinkNext
-// ---------------------------------------------------------------------------
+func TestList_NotFound_NullProject(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"project":null}}`))
+	})
+	tr := newTrackerForTest(t, f)
+	_, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestList_AuthFailed(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"401 Unauthorized"}`, http.StatusUnauthorized)
+	})
+	tr := newTrackerForTest(t, f)
+	_, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Fatalf("err = %v, want ErrAuthFailed", err)
+	}
+}
+
+func TestList_RateLimited(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Too many requests"}`, http.StatusTooManyRequests)
+	})
+	tr := newTrackerForTest(t, f)
+	_, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestList_EmptyResults(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":` + workItemsListJSON(nil, "", false) + `}`))
+	})
+	tr := newTrackerForTest(t, f)
+	issues, err := tr.List(ctx(), domain.TrackerRepo{Provider: domain.TrackerProviderGitLab, Native: "o/r"}, domain.ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("len = %d, want 0", len(issues))
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Domain validation
@@ -686,7 +876,7 @@ func TestTrackerIntakeConfig_WithDefaultsLeavesProviderEmpty(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Host-aware tracker (ticket 09)
+// Host-aware tracker
 // ---------------------------------------------------------------------------
 
 // newHostAwareTrackerForTest constructs a host-aware tracker with a default
@@ -716,8 +906,6 @@ func newHostAwareTrackerForTest(t *testing.T, defaultSrv *fakeGL, hostEntries ma
 		t.Fatalf("New: %v", err)
 	}
 	// Override the per-host base URL to point at the fake server.
-	// The tracker derives self-managed base URLs as https://<host>/api/v4,
-	// but for testing we need to point at the httptest server URL.
 	for host, he := range hostEntries {
 		lh := strings.ToLower(strings.TrimSpace(host))
 		entry := tr.hosts[lh]
@@ -739,18 +927,13 @@ func TestGet_SelfManagedHost_RoutesToCorrectBaseURLAndToken(t *testing.T) {
 	})
 
 	// Register handler on the self-managed server only.
-	selfManagedSrv.on("GET", "/projects/group/project/issues/42", func(w http.ResponseWriter, r *http.Request) {
+	selfManagedSrv.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer tkn-internal" {
 			t.Errorf("Authorization = %q, want Bearer tkn-internal", got)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"iid": 42,
-			"title": "Self-managed issue",
-			"description": "d",
-			"state": "opened",
-			"web_url": "https://gitlab.internal/group/project/-/issues/42"
-		}`))
+		wi := workItemJSON(42, "Self-managed issue", "d", "opened",
+			"https://gitlab.internal/group/project/-/issues/42", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 
 	issue, err := tr.Get(ctx(), domain.TrackerID{
@@ -777,11 +960,12 @@ func TestGet_DefaultHost_BackwardCompat(t *testing.T) {
 	defaultSrv := newFakeGL(t)
 	tr := newHostAwareTrackerForTest(t, defaultSrv, nil)
 
-	defaultSrv.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
+	defaultSrv.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer tkn-default" {
 			t.Errorf("Authorization = %q, want Bearer tkn-default", got)
 		}
-		_, _ = w.Write([]byte(`{"iid":1,"title":"default","description":"","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/1"}`))
+		wi := workItemJSON(1, "default", "", "opened", "https://gitlab.com/o/r/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 
 	// Host: "" routes to the default (gitlab.com) server.
@@ -801,8 +985,9 @@ func TestGet_GitLabComExplicit_RoutesToDefault(t *testing.T) {
 	defaultSrv := newFakeGL(t)
 	tr := newHostAwareTrackerForTest(t, defaultSrv, nil)
 
-	defaultSrv.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"iid":1,"title":"t","description":"","state":"opened","web_url":"https://gitlab.com/o/r/-/issues/1"}`))
+	defaultSrv.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		wi := workItemJSON(1, "t", "", "opened", "https://gitlab.com/o/r/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 
 	// Host: "gitlab.com" should route to the default, same as Host: "".
@@ -848,11 +1033,12 @@ func TestList_SelfManagedHost_RoutesCorrectly(t *testing.T) {
 		"gitlab.internal": {server: selfManagedSrv, token: "tkn-internal"},
 	})
 
-	selfManagedSrv.on("GET", "/projects/group/proj/issues", func(w http.ResponseWriter, r *http.Request) {
+	selfManagedSrv.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer tkn-internal" {
 			t.Errorf("Authorization = %q, want Bearer tkn-internal", got)
 		}
-		_, _ = w.Write([]byte(`[{"iid":1,"title":"sm","description":"d","state":"opened","web_url":"https://gitlab.internal/group/proj/-/issues/1"}]`))
+		wi := workItemJSON(1, "sm", "d", "opened", "https://gitlab.internal/group/proj/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":` + workItemsListJSON([]string{wi}, "", false) + `}`))
 	})
 
 	issues, err := tr.List(ctx(), domain.TrackerRepo{
@@ -904,12 +1090,13 @@ func TestGet_SelfManagedHost_FallsBackToDefaultToken(t *testing.T) {
 		"gitlab.internal": {server: selfManagedSrv},
 	})
 
-	selfManagedSrv.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
+	selfManagedSrv.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
 		// Should use the default token since no per-host token was configured.
 		if got := r.Header.Get("Authorization"); got != "Bearer tkn-default" {
 			t.Errorf("Authorization = %q, want Bearer tkn-default", got)
 		}
-		_, _ = w.Write([]byte(`{"iid":1,"title":"t","description":"","state":"opened","web_url":"https://gitlab.internal/o/r/-/issues/1"}`))
+		wi := workItemJSON(1, "t", "", "opened", "https://gitlab.internal/o/r/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 
 	_, err := tr.Get(ctx(), domain.TrackerID{
@@ -933,8 +1120,9 @@ func TestGet_HostCaseInsensitive(t *testing.T) {
 		"gitlab.internal": {server: selfManagedSrv, token: "tkn-internal"},
 	})
 
-	selfManagedSrv.on("GET", "/projects/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"iid":1,"title":"t","description":"","state":"opened","web_url":"https://gitlab.internal/o/r/-/issues/1"}`))
+	selfManagedSrv.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		wi := workItemJSON(1, "t", "", "opened", "https://gitlab.internal/o/r/-/issues/1", nil, nil)
+		_, _ = w.Write([]byte(`{"data":{"workItem":` + wi + `}}`))
 	})
 
 	// Upper-case host should match the lower-cased allowlist entry.
@@ -946,4 +1134,11 @@ func TestGet_HostCaseInsensitive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
+}
+
+// readBody is a helper to read and restore the request body for inspection.
+func readBody(r *http.Request) string {
+	b, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(strings.NewReader(string(b)))
+	return string(b)
 }

--- a/backend/internal/adapters/tracker/gitlab/tracker_test.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker_test.go
@@ -103,30 +103,6 @@ func gqlVars(t *testing.T, body string) map[string]any {
 	return req.Variables
 }
 
-// gqlQueryField extracts the top-level query field name from a GraphQL
-// request body, e.g. "workItem" or "project".
-func gqlQueryField(t *testing.T, body string) string {
-	t.Helper()
-	var req struct {
-		Query string `json:"query"`
-	}
-	if err := json.Unmarshal([]byte(body), &req); err != nil {
-		t.Fatalf("failed to decode graphql query: %v", err)
-	}
-	// crude: find the first query/mutation field name after the opening paren
-	s := req.Query
-	if i := strings.Index(s, "{"); i >= 0 {
-		s = s[i+1:]
-	}
-	s = strings.TrimSpace(s)
-	// first identifier after {
-	fields := strings.Fields(s)
-	if len(fields) == 0 {
-		return ""
-	}
-	return fields[0]
-}
-
 // workItemJSON builds a GraphQL work item node JSON suitable for test responses.
 func workItemJSON(iid int, title, desc, state, webURL string, labels []string, assignees []string) string {
 	var widgets []string
@@ -481,6 +457,46 @@ func TestGet_NoDescription(t *testing.T) {
 	}
 	if issue.Body != "" {
 		t.Fatalf("Body = %q, want empty", issue.Body)
+	}
+}
+
+func TestGet_GraphQLErrorGeneric(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Something went wrong","extensions":{"code":"INTERNAL"}}]}`))
+	})
+	tr := newTrackerForTest(t, f)
+	_, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, should not be ErrNotFound for non-NOT_FOUND code", err)
+	}
+	if !strings.Contains(err.Error(), "Something went wrong") {
+		t.Fatalf("err = %v, want message containing 'Something went wrong'", err)
+	}
+}
+
+func TestGet_ReversedWidgetOrder(t *testing.T) {
+	f := newFakeGL(t)
+	f.on("POST", "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		// Labels widget before assignees widget — verifies iteration order doesn't matter.
+		_, _ = w.Write([]byte(`{"data":{"workItem":{"iid":"1","title":"t","description":"d","state":"opened","webUrl":"https://gitlab.com/o/r/-/issues/1","widgets":[
+			{"type":"LABELS","labels":{"nodes":[{"title":"bug"},{"title":"critical"}]}},
+			{"type":"ASSIGNEES","assignees":{"nodes":[{"username":"alice"}]}}
+		]}}}`))
+	})
+	tr := newTrackerForTest(t, f)
+	issue, err := tr.Get(ctx(), domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "o/r#1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !reflect.DeepEqual(issue.Labels, []string{"bug", "critical"}) {
+		t.Fatalf("Labels = %#v, want [bug critical]", issue.Labels)
+	}
+	if !reflect.DeepEqual(issue.Assignees, []string{"alice"}) {
+		t.Fatalf("Assignees = %#v, want [alice]", issue.Assignees)
 	}
 }
 


### PR DESCRIPTION
## Summary

Switches the GitLab tracker adapter's `List` and `Get` operations from the REST Issues API to the GraphQL Work Items API (`POST /api/v4/graphql`). Work Items is the superset of Issues — Issues are work items of type "issue" — so the adapter now sees all open work items on the board regardless of type (tasks, objectives, etc.).

Closes ticket 02: Switch GitLab tracker adapter List to GraphQL Work Items.

Depends on ticket 01 (nested-group repo path fix) which preserves the full namespace path for GitLab `fullPath` queries.

### Key changes

- **List**: GraphQL `project(fullPath:)` -> `workItems` connection with cursor-based pagination (`endCursor`/`hasNextPage`). Filters by `state`, `assigneeUsernames`, and `labelName`. `Limit` caps total results, stopping early.
- **Get**: Single work item fetched via `workItem(fullPath:, iid:)` query.
- **Field mapping**: `iid`->Native, `title`->Title, `description`->Body, `state`->State, `webUrl`->URL, assignees from `WorkItemWidgetAssignees`, labels from `WorkItemWidgetLabels`.
- **Error classification**:
  - HTTP 200 with GraphQL `errors` array + `extensions.code: NOT_FOUND` -> `ErrNotFound`
  - HTTP 200 with `data.project == null` -> `ErrNotFound`
  - 401/403 -> `ErrAuthFailed`
  - 429 -> `ErrRateLimited`
- **Preflight** unchanged: REST `GET /user`.
- All sentinel errors preserved (`ErrNotFound`, `ErrAuthFailed`, `ErrRateLimited`, `ErrWrongProvider`, `ErrBadID`, `ErrHostNotAllowed`).
- Host routing unchanged — self-managed hosts use per-host base URL and tokens.

## Tests

All tests rewritten to use `POST /api/v4/graphql` with GraphQL response shapes:

```
go test ./internal/adapters/tracker/gitlab/... -v -count=1
```

37 tests pass covering:
- Happy path (single-page, multi-page cursor pagination)
- Limit stops early
- Nested group paths (full namespace in `fullPath` variable)
- Filter variables (state, assigneeUsernames, labelName)
- Error classification (GraphQL errors, null project, auth failed, rate limited)
- Host routing (self-managed, default, unconfigured rejected, case insensitive)
- Edge cases (no labels, no assignees, no description, empty results)
- Preflight (happy, invalid token, cache, retry)
- Provider/repo validation (unchanged — pre-network)

## Risks

- Work item IIDs share a single per-project sequence across all types — the canonical ID format `gitlab:group/project#iid` remains collision-free.
- No work item type filtering in v1; epics/incidents are included. Can be added later without breaking the query shape.
- GitHub tracker adapter is untouched — no regression risk.
