### PR TITLE
feat(mobile): prompt when a newer native build is on the store

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -242,6 +242,71 @@ restarts into a pending update and shows what is running. Dev builds
   inputs. `eas update:list --channel production` shows what is live,
   `eas update:insights` shows adoption, and `eas update:rollback` reverts.
 
+## Store updates
+
+OTA covers JS only. A native change mints a new fingerprint runtime, so a build
+in the field stops being offered updates the moment a newer binary ships — silently.
+This is the other half: when a newer **native binary** is live on a store, the app
+says so once per launch and takes the user there. **Settings → About → App Store /
+Play Store** checks on demand.
+
+- **Android** uses [Play In-App Updates](https://developer.android.com/guide/playcore/in-app-updates)
+  via `expo-in-app-updates`. Play compares the installed `versionCode` itself, so the
+  app never reads or configures a version. Only works for builds installed from Play;
+  sideloaded and dev builds fail the check silently.
+- **iOS** queries the iTunes Search API by bundle id in plain JS. The response carries
+  the App Store id, so nothing has to be configured. It is inert until the app is
+  actually on the App Store.
+- `expo-in-app-updates` is therefore **excluded from Apple autolinking**
+  (`package.json` → `expo.autolinking.apple.exclude`) — it is Android-only code here.
+  Keep it that way: linking the unused pod puts the package into the iOS fingerprint,
+  which would change the iOS runtime version on every dependency bump and force a
+  native release for changes that are pure JS. `lib/inAppUpdates.ts` binds the native
+  module with `requireOptionalNativeModule`, which answers `null` on iOS instead of
+  throwing the way a plain import would.
+- **Two tiers.** The nudge is a dismissible sheet, shown at most once a day and three
+  times per store version (a swipe counts as a dismissal). The insistent tier is Play's
+  own fullscreen updater — note it is still cancellable: `startUpdateFlowForResult`
+  resolves as soon as the dialog opens, and cancelling leaves the app running. It is
+  entered only when Play asks for it — publish the release with `inAppUpdatePriority`
+  4 or 5 in `Edits.tracks.releases` through the Play Developer API. Priority can only
+  be set while rolling a release out and **can never be changed afterwards**. Raise it
+  only once the new build is *live* on the store, not merely approved. iOS has no
+  equivalent channel and Apple discourages blocking, so iOS is nudge-only.
+- **Version floor.** Two EAS environment variables let a release be declared
+  without shipping app code: `EXPO_PUBLIC_AO_MIN_APP_VERSION` (below it, the
+  update stops being optional) and `EXPO_PUBLIC_AO_LATEST_APP_VERSION` (below it,
+  the usual once-a-day nudge). Both unset means the floor is inert, which is how
+  it ships. Move one and publish:
+
+  ```bash
+  eas env:create --environment production --name EXPO_PUBLIC_AO_MIN_APP_VERSION --value 1.3.0 --visibility plaintext
+  eas update --channel production --environment production -m "raise the floor to 1.3.0" --rollout-percentage 10
+  ```
+
+  Four things to know before you do:
+  - **`min` can only escalate an update the store already confirmed exists.** It
+    can raise a confirmed update from dismissible to blocking; it can never invent
+    one. So a mistyped floor cannot strand anyone, and iOS stays nudge-only until
+    the App Store listing exists — then starts blocking on its own, no code change.
+  - **Visibility must be `plaintext`.** Secret variables are not readable outside
+    EAS servers, so they do not resolve during `eas update` and the floor silently
+    falls back to inert.
+  - **One publish per runtime you want to reach.** Values are inlined into the JS
+    bundle. A `version` stamp changes the fingerprint, so after one, `main` only
+    reaches the new runtime — publish from the older release's tag to reach that
+    cohort. The EAS values are read at publish time, so no code edit on that tag.
+  - **It only distinguishes versions you actually stamp.** `eas.json`
+    `autoIncrement` moves the build number, not `version`.
+- **Flexible updates are never started, deliberately.** `expo-in-app-updates` calls
+  `completeUpdate()` as soon as a flexible download finishes, which restarts the app
+  unannounced; Google's own contract is that a flexible update restarts only when the
+  user chooses to. A surprise restart is wrong for a remote control over long-running
+  agents, so the dismissible sheet is the soft tier and opting in goes straight to the
+  immediate flow.
+- Everything fails open: an unreachable store, an unpublished bundle id or a non-Play
+  install all read as "no update" rather than an error.
+
 ## Troubleshooting
 
 | Symptom                                           | Fix                                                                                                                                                          |

--- a/packages/mobile/app/(tabs)/settings.tsx
+++ b/packages/mobile/app/(tabs)/settings.tsx
@@ -17,8 +17,10 @@ import { preferenceLabel } from "../../lib/themePreference";
 import { getPushStatus, openNotificationSettings, registerForPush, unregisterFromPush } from "../../lib/push";
 import { describePushToggle, describeRegisterFailure, type PushStatus } from "../../lib/pushStatus";
 import { openGitHub } from "../../lib/openGitHub";
+import { checkStore, openOrStartUpdate } from "../../lib/inAppUpdates";
 import { useApp } from "../../lib/store";
 import { checkAndDownload, describeUpdateRow, type UpdateOutcome } from "../../lib/updates";
+import { describeStoreRow, type StoreCheck, type StoreRowResult } from "../../lib/storeUpdate";
 import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
 import { Dot, ScreenHeader, SettingsGroup, SettingsRow, SettingsToggle } from "../../lib/ui";
 import { useTheme, useThemedStyles, useThemeState } from "../../lib/ThemeProvider";
@@ -307,6 +309,7 @@ function AboutSection({ onForget }: { onForget: () => Promise<void> }) {
 		<SettingsGroup title="About">
 			<SettingsRow icon="info" label="Version" value={formatVersionLine(build)} />
 			<UpdateRow />
+			<StoreUpdateRow />
 			<SettingsRow icon="mail" label="Report a problem" onPress={report} />
 			<SettingsRow
 				icon="power"
@@ -358,6 +361,53 @@ function UpdateRow() {
 		<SettingsRow
 			icon="download-cloud"
 			label="App updates"
+			value={row.value}
+			valueColor={row.tone === "good" ? t.green : row.tone === "bad" ? t.red : undefined}
+			loading={row.busy}
+			onPress={row.action ? onPress : undefined}
+		/>
+	);
+}
+
+// Whether a newer **native binary** is on the store. The row above covers the JS
+// half (OTA), which by design can never carry a native change. Named after the
+// store rather than "App version" so it is not confused with the Version row.
+function StoreUpdateRow() {
+	const t = useTheme();
+	const [checking, setChecking] = useState(false);
+	const [last, setLast] = useState<StoreRowResult | null>(null);
+	const [check, setCheck] = useState<StoreCheck | null>(null);
+
+	// `__DEV__`, not `Updates.isEnabled`: this row reports the store, not OTA.
+	const row = describeStoreRow({ enabled: !__DEV__, checking, last });
+
+	async function onPress() {
+		if (row.action === "open") {
+			await openOrStartUpdate(check);
+			return;
+		}
+		setChecking(true);
+		try {
+			const result = await checkStore();
+			setCheck(result);
+			// An unreachable store surfaces as an error here, where at launch it stays
+			// silent: the user asked for this one.
+			if (result === null) {
+				setLast({ kind: "error" });
+				haptics.error();
+			} else {
+				setLast({ kind: result.updateAvailable ? "available" : "up-to-date" });
+				haptics.success();
+			}
+		} finally {
+			setChecking(false);
+		}
+	}
+
+	return (
+		<SettingsRow
+			icon="package"
+			label={Platform.OS === "ios" ? "App Store" : "Play Store"}
 			value={row.value}
 			valueColor={row.tone === "good" ? t.green : row.tone === "bad" ? t.red : undefined}
 			loading={row.busy}

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -6,6 +6,7 @@ import { OnboardingGate } from "../lib/OnboardingGate";
 import { TelemetryManager } from "../lib/TelemetryManager";
 import { PushManager } from "../lib/PushManager";
 import { UpdatesManager } from "../lib/UpdatesManager";
+import { StoreUpdateManager } from "../lib/StoreUpdateManager";
 import { MinimalBackButton } from "../lib/MinimalBackButton";
 import { AppProvider } from "../lib/store";
 import { ThemeProvider, useTheme, useThemeState } from "../lib/ThemeProvider";
@@ -26,6 +27,7 @@ const SHEET_ROUTES = [
 	{ name: "sheets/conversation-map", detents: [0.5, 0.95] },
 	{ name: "sheets/composer-picker", detents: [0.6, 0.95] },
 	{ name: "sheets/theme", detents: "fitToContents" },
+	{ name: "sheets/store-update", detents: "fitToContents" },
 ] as const;
 
 // The manual-connect form — the only sheet with text inputs, and the only one
@@ -75,6 +77,7 @@ function Shell() {
 			<TelemetryManager />
 			<PushManager />
 			<UpdatesManager />
+			<StoreUpdateManager />
 			<OnboardingGate />
 			<Stack
 				screenOptions={{

--- a/packages/mobile/app/sheets/store-update.tsx
+++ b/packages/mobile/app/sheets/store-update.tsx
@@ -1,0 +1,41 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useRef } from "react";
+import { releaseSheetResult, takeSheetResult } from "../../lib/sheetResult";
+import { StoreUpdateSheet } from "../../lib/StoreUpdateSheet";
+
+// The store-update nudge, as a native form sheet.
+//
+// Both outcomes dismiss before reporting, unlike the theme sheet: taking the
+// update leaves the app, and `onClose` is `router.back()`. A swipe counts as
+// "Not now" — the sheet shows a grabber, so without that the snooze is only ever
+// written by people who tap the button and the nudge returns every launch.
+export default function StoreUpdateSheetRoute() {
+	const router = useRouter();
+	const { resultKey, version, storeConfirmed } = useLocalSearchParams<{ resultKey?: string; version?: string; storeConfirmed?: string }>();
+
+	const decided = useRef(false);
+
+	useEffect(
+		() => () => {
+			if (!decided.current) takeSheetResult<"update" | "dismiss">(resultKey)?.("dismiss");
+			releaseSheetResult(resultKey);
+		},
+		[resultKey],
+	);
+
+	function finish(action: "update" | "dismiss") {
+		decided.current = true;
+		const handler = takeSheetResult<"update" | "dismiss">(resultKey);
+		router.back();
+		handler?.(action);
+	}
+
+	return (
+		<StoreUpdateSheet
+			version={version}
+			storeConfirmed={storeConfirmed === "1"}
+			onUpdate={() => finish("update")}
+			onDismiss={() => finish("dismiss")}
+		/>
+	);
+}

--- a/packages/mobile/lib/StoreUpdateManager.tsx
+++ b/packages/mobile/lib/StoreUpdateManager.tsx
@@ -1,0 +1,137 @@
+import { usePathname, useRootNavigationState, useRouter } from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import * as Application from "expo-application";
+import { AppState, Platform } from "react-native";
+import { checkStore, openOrStartUpdate, openStore, startPlayUpdate } from "./inAppUpdates";
+import { storeUpdateSheetRoute } from "./sheetResult";
+import { floorSignal, floorTarget, nextSnooze, shouldPrompt, tierOf, type Snooze, type StoreCheck } from "./storeUpdate";
+import { VERSION_FLOOR } from "./versionFloor";
+import { loadSnooze, saveSnooze } from "./storeUpdateStore";
+import { useApp } from "./store";
+
+// Headless. Mounted beside UpdatesManager in `app/_layout.tsx`; asks the store
+// once per launch whether a newer **native binary** exists, and either nudges
+// (dismissible sheet) or hands over to Play's own fullscreen updater. Decision
+// logic lives in `storeUpdate.ts` so it is unit-testable.
+//
+// The OTA manager next door covers JS updates. A new native build mints a new
+// fingerprint runtime, which is the case OTA does not reach on its own — short of
+// deliberately publishing from that older release's tag.
+export function StoreUpdateManager(): null {
+	const router = useRouter();
+	const pathname = usePathname();
+	const navState = useRootNavigationState();
+	const { config } = useApp();
+	const [snooze, setSnooze] = useState<Snooze | null | undefined>(undefined);
+	// Runs once per launch, like OnboardingGate: a second prompt in one session
+	// is nagging, not helpfulness.
+	const ran = useRef(false);
+	// Armed only by a handover Play actually accepted, and disarmed by the first
+	// recovery: Play reports DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS for the whole
+	// download, so without this a resume would bounce the user to the store every
+	// time they came back to the app.
+	const started = useRef(false);
+	// `pathname` read at push time rather than at check time — see prompt().
+	const pathnameRef = useRef(pathname);
+	pathnameRef.current = pathname;
+
+	useEffect(() => {
+		loadSnooze().then(setSnooze);
+	}, []);
+
+	useEffect(() => {
+		if (ran.current) return;
+		// Dev builds are loaded from Metro, not installed from a store, so Play
+		// rejects every call and the App Store has nothing to answer about.
+		// Deliberately not `Updates.isEnabled`, which means "expo-updates is
+		// configured" — a different axis that would also switch this off in a
+		// release build that happened to ship without OTA.
+		if (__DEV__) return;
+		if (snooze === undefined) return; // still loading; deciding now could skip a due prompt
+		if (!navState?.key) return; // wait until navigation can accept routes
+		// Never on top of onboarding: `config` is null until the store's first load
+		// resolves, and an unconfigured user is being redirected to /onboarding by
+		// OnboardingGate right now.
+		if (config === null || config.host.trim().length === 0) return;
+		// Don't interrupt someone who navigated somewhere deliberately.
+		if (pathname !== "/") return;
+		ran.current = true;
+		void prompt();
+	}, [snooze, navState?.key, config, pathname, router]);
+
+	async function prompt() {
+		// Deliberately no pre-gate on the snooze before this call, tempting as the
+		// saved round trip is: `shouldPrompt` prompts immediately when the store
+		// version changes, so skipping the lookup would mean never noticing a new
+		// release. One GET per cold start is the cheaper side of that trade.
+		const check = await checkStore();
+		const floor = floorSignal(Application.nativeApplicationVersion, VERSION_FLOOR);
+		let tier = tierOf(check, Platform.OS, floor);
+		if (tier === "none") return;
+
+		if (tier === "required") {
+			started.current = await startPlayUpdate();
+			if (started.current) return;
+			// Play would not take over, so in practice this is a nudge. Say that
+			// honestly and let the snooze apply, rather than reprompting every
+			// launch with a sheet the user can dismiss anyway.
+			tier = "recommended";
+		}
+		// The version we are nudging toward: the store's when it answered, otherwise
+		// the floor's — which is constant, so a device with flaky Play access does
+		// not reset its own dismissal count every launch.
+		const confirmed = check?.updateAvailable === true;
+		const target = confirmed ? check?.storeVersion : floorTarget(VERSION_FLOOR);
+		const args = { tier, version: target, snooze: snooze ?? null, now: Date.now() };
+		if (!shouldPrompt({ ...args, stalenessDays: check?.playStalenessDays })) return;
+		openSheet(check, target, confirmed);
+	}
+
+	function openSheet(check: StoreCheck | null, target: string | undefined, confirmed: boolean) {
+		// The check above is allowed 12s; if the user opened something in the
+		// meantime, don't land a sheet on top of it. Leaving `ran` false gives the
+		// prompt another chance when they come back to the board.
+		if (pathnameRef.current !== "/") {
+			ran.current = false;
+			return;
+		}
+		router.push(
+			storeUpdateSheetRoute({
+				// A store-confirmed version is only nameable on iOS — Android's is a
+				// versionCode. A floor version is a real version string either way.
+				version: confirmed && Platform.OS !== "ios" ? undefined : target,
+				storeConfirmed: confirmed,
+				onAction: (action) => {
+					if (action === "update") {
+						// Only Play's flow leaves a download to recover; a listing does not.
+						void openOrStartUpdate(check).then((via) => {
+							started.current = via === "play";
+						});
+						return;
+					}
+					const next = nextSnooze(snooze ?? null, target, Date.now());
+					setSnooze(next);
+					void saveSnooze(next);
+				},
+			}),
+		);
+	}
+
+	useEffect(() => {
+		if (__DEV__ || Platform.OS !== "android") return;
+		const sub = AppState.addEventListener("change", (state) => {
+			if (state !== "active" || !started.current) return;
+			started.current = false; // one recovery per handover
+			// Google asks that a stalled immediate update be picked up again when
+			// the app returns. `expo-in-app-updates` cannot — its startUpdate bails
+			// while Play reports DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS — so the
+			// listing is the only recovery left, and beats stranding the user.
+			void checkStore().then((check) => {
+				if (check?.updateInProgress) void openStore(check);
+			});
+		});
+		return () => sub.remove();
+	}, []);
+
+	return null;
+}

--- a/packages/mobile/lib/StoreUpdateSheet.tsx
+++ b/packages/mobile/lib/StoreUpdateSheet.tsx
@@ -1,0 +1,47 @@
+import { Platform, StyleSheet, Text, View } from "react-native";
+import { describePrompt } from "./storeUpdate";
+import type { Theme } from "./theme";
+import { useThemedStyles } from "./ThemeProvider";
+import { Button, SheetScreen } from "./ui";
+
+// The soft tier of the store-update prompt: dismissible, rate-limited by
+// `storeUpdate.ts`, and the only tier iOS has. The insistent tier is Play's own
+// fullscreen updater, which Google renders — there is no custom screen for it.
+
+export function StoreUpdateSheet({
+	version,
+	storeConfirmed,
+	onUpdate,
+	onDismiss,
+}: {
+	/**
+	 * The version to name. Absent on Android when it came from the store, where
+	 * the answer is a versionCode — an internal number that means nothing here.
+	 */
+	version?: string;
+	/** Whether the store itself reported the update; false when only the floor did. */
+	storeConfirmed: boolean;
+	onUpdate: () => void;
+	onDismiss: () => void;
+}) {
+	const s = useThemedStyles(makeStyles);
+	const storeName = Platform.OS === "ios" ? "App Store" : "Play Store";
+
+	return (
+		<SheetScreen title="Update available" subtitle={describePrompt({ version, storeConfirmed, storeName })}>
+			<View style={s.body}>
+				<Text style={s.blurb}>
+					New fixes ship against the newer build, so this one stops receiving over-the-air updates.
+				</Text>
+				<Button title="Update" icon="download" onPress={onUpdate} />
+				<Button title="Not now" variant="ghost" onPress={onDismiss} />
+			</View>
+		</SheetScreen>
+	);
+}
+
+const makeStyles = (t: Theme) =>
+	StyleSheet.create({
+		body: { paddingTop: 12, gap: 12 },
+		blurb: { color: t.textSecondary, fontSize: 14, lineHeight: 20 },
+	});

--- a/packages/mobile/lib/inAppUpdates.ts
+++ b/packages/mobile/lib/inAppUpdates.ts
@@ -1,0 +1,157 @@
+import { requireOptionalNativeModule } from "expo";
+import * as Application from "expo-application";
+import { Linking, Platform } from "react-native";
+import { lookupUrl, parseLookup, playStoreUrls, type StoreCheck } from "./storeUpdate";
+
+// The effect side of `storeUpdate.ts`: ask the stores, and open them. Split out
+// so the policy stays unit-testable, like `githubLink.ts`/`openGitHub.ts`.
+//
+// Android goes through Play In-App Updates — there is no public Play version API.
+// iOS uses the iTunes lookup, a plain HTTPS GET needing no native code, which is
+// why `expo-in-app-updates` is excluded from Apple autolinking (package.json) and
+// stays out of the iOS fingerprint. Nothing here throws: a store we cannot reach
+// has to be indistinguishable from a store with no update.
+
+/**
+ * `expo-in-app-updates`, bound to its native module rather than through the
+ * package's JS wrapper: that wrapper calls `requireNativeModule` at import,
+ * which throws on iOS where the pod is not linked. This answers `null` there.
+ */
+type PlayUpdates = {
+	readonly IMMEDIATE: number;
+	checkForUpdate(): Promise<StoreCheck>;
+	startUpdate(updateType?: number): Promise<boolean>;
+};
+
+const play = requireOptionalNativeModule<PlayUpdates>("ExpoInAppUpdates");
+
+const LOOKUP_TIMEOUT_MS = 12_000;
+
+let inflight: Promise<StoreCheck | null> | null = null;
+
+/** Ask the store whether a newer native binary exists. Never throws; `null` means "could not tell". */
+export function checkStore(): Promise<StoreCheck | null> {
+	if (inflight) return inflight;
+	inflight = run().finally(() => {
+		inflight = null;
+	});
+	return inflight;
+}
+
+async function run(): Promise<StoreCheck | null> {
+	try {
+		if (Platform.OS === "ios") return await lookupAppStore();
+		// Play rejects on anything not installed from the Play Store — dev builds,
+		// sideloads, emulators without Play — which is the common local case and
+		// has to stay silent.
+		if (!play) return null;
+		const answer = await play.checkForUpdate();
+		// The library calls it `daysSinceRelease`, which it is not: it counts days
+		// since this device's Play Store learned of the update.
+		return { ...answer, playStalenessDays: (answer as { daysSinceRelease?: number | null }).daysSinceRelease ?? null };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * The device's storefront, or null when the locale does not name one. Locale
+ * source matches `lib/voice/deviceProvider.ts`.
+ *
+ * Only a real region subtag counts: a bare "en" has no region, and its last
+ * segment is the language — sending that as `country` would ask for a storefront
+ * that does not exist.
+ */
+function storefront(): string | null {
+	try {
+		const parts = Intl.DateTimeFormat().resolvedOptions().locale.split("-");
+		const region = parts.length > 1 ? parts[parts.length - 1] : null;
+		return region && /^[A-Za-z]{2}$/.test(region) ? region : null;
+	} catch {
+		return null;
+	}
+}
+
+async function lookupAppStore(): Promise<StoreCheck | null> {
+	const bundleId = Application.applicationId;
+	if (!bundleId) return null;
+	// Same reason as `api.ts`: without a timeout an unreachable host hangs for the
+	// OS TCP timeout. This runs at launch, so it must never hold anything up.
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), LOOKUP_TIMEOUT_MS);
+	try {
+		// `no-store`: the answer changes the moment a release goes live, and a
+		// cached "no update" would outlast the release we are trying to announce.
+		const res = await fetch(lookupUrl(bundleId, storefront()), { signal: controller.signal, cache: "no-store" });
+		if (!res.ok) return null;
+		// `nativeApplicationVersion` is CFBundleShortVersionString, read from the
+		// binary. Deliberately not `Constants.expoConfig.version`, which is the JS
+		// bundle's number and can be swapped by an OTA update independently of the
+		// binary — exactly the case this check exists to catch.
+		return parseLookup(await res.json(), Application.nativeApplicationVersion);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Hand over to Play's immediate flow, reporting whether it took over. Android
+ * only — iOS has no in-app update flow, so there is nothing to hand over to.
+ *
+ * Note this is insistent, not a lock: `startUpdateFlowForResult` resolves as
+ * soon as the dialog opens, and cancelling leaves the app running.
+ *
+ * We never ask for the flexible flow: `expo-in-app-updates` calls
+ * `completeUpdate()` as soon as the download lands, restarting the app
+ * unannounced, where Google's contract is that a flexible update restarts only
+ * when the user chooses to. The dismissible sheet is our soft tier instead.
+ */
+export async function startPlayUpdate(): Promise<boolean> {
+	if (Platform.OS !== "android" || !play) return false;
+	try {
+		return await play.startUpdate(play.IMMEDIATE);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The one way to send a user to their update: Play's in-app flow when it will
+ * start, the store listing otherwise. Callers should not reach for the two parts
+ * separately — a button wired straight to the Play flow silently does nothing
+ * whenever Play declines, which is most of the time on a floor-driven prompt.
+ *
+ * Reports which path it took rather than just "something happened": only the
+ * Play flow leaves a download in progress worth recovering on the next resume,
+ * and a caller that cannot tell the two apart will chase a listing that is not
+ * downloading anything.
+ */
+export async function openOrStartUpdate(check: StoreCheck | null): Promise<"play" | "store" | "none"> {
+	if (await startPlayUpdate()) return "play";
+	return (await openStore(check)) ? "store" : "none";
+}
+
+/** Open the store listing. Never rejects; returns whether a URL actually opened. */
+export async function openStore(check: StoreCheck | null): Promise<boolean> {
+	if (Platform.OS === "ios") {
+		// The lookup carries the app's own store page, so there is no id to
+		// configure. Before the listing exists there is no page to send anyone to,
+		// and the build they need is in TestFlight — which `itms-beta://` opens.
+		return check?.storeUrl ? await open(check.storeUrl) : await open("itms-beta://");
+	}
+	const pkg = Application.applicationId;
+	if (!pkg) return false;
+	// market:// opens the Play app directly; the https form is what a device
+	// without it can still handle.
+	const { app, web } = playStoreUrls(pkg);
+	return (await open(app)) || (await open(web));
+}
+
+async function open(url: string): Promise<boolean> {
+	try {
+		await Linking.openURL(url);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/mobile/lib/sheetResult.ts
+++ b/packages/mobile/lib/sheetResult.ts
@@ -85,3 +85,25 @@ export function modelSheetRoute(opts: { agentId: string; projectId: string; sele
 export function connectSheetRoute(onConnected: () => void) {
 	return { pathname: "/sheets/connect" as const, params: { resultKey: parkSheetResult(onConnected) } };
 }
+
+/**
+ * Route + params for the store-update nudge. One parked callback carries both
+ * outcomes: taking the update, or dismissing it (which is what the snooze
+ * counter counts, so the opener has to hear about it).
+ */
+export function storeUpdateSheetRoute(opts: {
+	version?: string;
+	storeConfirmed: boolean;
+	onAction: (action: "update" | "dismiss") => void;
+}) {
+	return {
+		pathname: "/sheets/store-update" as const,
+		params: {
+			resultKey: parkSheetResult(opts.onAction),
+			// Route params are strings, so the flag is encoded here rather than at
+			// the call site — same reason as projectSheetRoute's "0"/"1".
+			storeConfirmed: opts.storeConfirmed ? "1" : "0",
+			...(opts.version ? { version: opts.version } : {}),
+		},
+	};
+}

--- a/packages/mobile/lib/storeUpdate.test.ts
+++ b/packages/mobile/lib/storeUpdate.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "vitest";
+import {
+	compareVersions,
+	DAYS_FOR_FLEXIBLE_UPDATE,
+	describePrompt,
+	floorSignal,
+	floorTarget,
+	describeStoreRow,
+	lookupUrl,
+	MAX_DISMISSALS,
+	nextSnooze,
+	parseLookup,
+	playStoreUrls,
+	PROMPT_INTERVAL_MS,
+	shouldPrompt,
+	type Snooze,
+	type StoreCheck,
+	tierOf,
+} from "./storeUpdate";
+
+function lookup(over: Record<string, unknown> = {}) {
+	return { resultCount: 1, results: [{ version: "1.3.0", trackId: 123, trackViewUrl: "https://apps.apple.com/app/id123", ...over }] };
+}
+
+describe("compareVersions", () => {
+	it("orders numerically, not lexically", () => {
+		expect(compareVersions("1.10.0", "1.9.0")).toBeGreaterThan(0);
+		expect(compareVersions("1.9.0", "1.10.0")).toBeLessThan(0);
+		expect(compareVersions("2.0.0", "1.99.99")).toBeGreaterThan(0);
+	});
+
+	it("treats missing segments as zero", () => {
+		expect(compareVersions("1.2", "1.2.0")).toBe(0);
+		expect(compareVersions("1.2.1", "1.2")).toBeGreaterThan(0);
+	});
+
+	// A garbled store answer must never read as "newer", or the app nags forever.
+	it("treats non-numeric segments as zero rather than NaN", () => {
+		expect(compareVersions("1.2.0-beta", "1.2.0")).toBe(0);
+		expect(compareVersions("oops", "1.2.0")).toBeLessThan(0);
+	});
+});
+
+describe("lookupUrl", () => {
+	it("queries by bundle id, so no App Store id has to be configured", () => {
+		expect(lookupUrl("aoagents.ao")).toBe("https://itunes.apple.com/lookup?bundleId=aoagents.ao");
+	});
+
+	// Without a storefront the API answers for the US store only, so a user
+	// elsewhere reads as "no update" while their own store has one.
+	it("adds the storefront when one is known", () => {
+		expect(lookupUrl("aoagents.ao", "GB")).toBe("https://itunes.apple.com/lookup?bundleId=aoagents.ao&country=gb");
+	});
+
+	it("drops a region it cannot use rather than guessing", () => {
+		for (const bad of [undefined, null, "", "  ", "eng", "1"]) {
+			expect(lookupUrl("aoagents.ao", bad)).toBe("https://itunes.apple.com/lookup?bundleId=aoagents.ao");
+		}
+	});
+});
+
+describe("parseLookup", () => {
+	it("reports an update when the store is ahead", () => {
+		expect(parseLookup(lookup(), "1.2.1")).toEqual({
+			updateAvailable: true,
+			storeVersion: "1.3.0",
+			storeUrl: "https://apps.apple.com/app/id123",
+		});
+	});
+
+	it("reports none when the installed build matches or leads the store", () => {
+		expect(parseLookup(lookup(), "1.3.0").updateAvailable).toBe(false);
+		expect(parseLookup(lookup(), "1.4.0").updateAvailable).toBe(false);
+	});
+
+	// This is today's real answer for aoagents.ao: not on the App Store yet.
+	it("treats an empty result set as no update, not an error", () => {
+		expect(parseLookup({ resultCount: 0, results: [] }, "1.2.1")).toEqual({ updateAvailable: false });
+	});
+
+	it("fails open on a body it cannot read", () => {
+		expect(parseLookup(null, "1.2.1").updateAvailable).toBe(false);
+		expect(parseLookup({ results: "nope" }, "1.2.1").updateAvailable).toBe(false);
+		expect(parseLookup(lookup({ version: 13 }), "1.2.1").updateAvailable).toBe(false);
+	});
+
+	it("fails open when the installed version is unknown", () => {
+		expect(parseLookup(lookup(), null).updateAvailable).toBe(false);
+		expect(parseLookup(lookup(), undefined).updateAvailable).toBe(false);
+	});
+
+	it("rebuilds the store URL from trackId when trackViewUrl is missing", () => {
+		expect(parseLookup(lookup({ trackViewUrl: undefined }), "1.2.1").storeUrl).toBe("https://apps.apple.com/app/id123");
+		expect(parseLookup(lookup({ trackViewUrl: undefined, trackId: undefined }), "1.2.1").storeUrl).toBeUndefined();
+	});
+});
+
+describe("tierOf", () => {
+	const available: StoreCheck = { updateAvailable: true };
+
+	it("says nothing when there is no update or no answer", () => {
+		expect(tierOf(null, "android")).toBe("none");
+		expect(tierOf({ updateAvailable: false }, "android")).toBe("none");
+		expect(tierOf(null, "ios")).toBe("none");
+	});
+
+	it("blocks on Android only when Play itself asks for the immediate flow", () => {
+		expect(tierOf({ ...available, serverUpdateType: "IMMEDIATE", immediateAllowed: true }, "android")).toBe("required");
+		expect(tierOf({ ...available, serverUpdateType: "FLEXIBLE", immediateAllowed: true }, "android")).toBe("recommended");
+		// Play asked, but the device will not allow it — degrade rather than dead-end.
+		expect(tierOf({ ...available, serverUpdateType: "IMMEDIATE", immediateAllowed: false }, "android")).toBe("recommended");
+	});
+
+	// Apple offers no priority channel and discourages hard-blocking.
+	it("never blocks on iOS", () => {
+		expect(tierOf({ ...available, serverUpdateType: "IMMEDIATE", immediateAllowed: true }, "ios")).toBe("recommended");
+	});
+});
+
+describe("shouldPrompt", () => {
+	const now = 1_700_000_000_000;
+	const snooze = (over: Partial<Snooze> = {}): Snooze => ({ version: "1.3.0", dismissals: 1, lastPromptAt: now, ...over });
+
+	it("always prompts for a critical release, however often it was dismissed", () => {
+		const args = { tier: "required" as const, version: "1.3.0", now };
+		expect(shouldPrompt({ ...args, snooze: snooze({ dismissals: 99 }) })).toBe(true);
+	});
+
+	it("says nothing when there is no update", () => {
+		expect(shouldPrompt({ tier: "none", version: "1.3.0", snooze: null, now })).toBe(false);
+	});
+
+	it("prompts the first time, then holds for a day", () => {
+		const args = { tier: "recommended" as const, version: "1.3.0", now };
+		expect(shouldPrompt({ ...args, snooze: null })).toBe(true);
+		expect(shouldPrompt({ ...args, snooze: snooze() })).toBe(false);
+		expect(shouldPrompt({ ...args, snooze: snooze({ lastPromptAt: now - PROMPT_INTERVAL_MS }) })).toBe(true);
+	});
+
+	it("gives up after enough dismissals of the same version", () => {
+		const args = { tier: "recommended" as const, version: "1.3.0", now };
+		const stale = { lastPromptAt: now - PROMPT_INTERVAL_MS };
+		expect(shouldPrompt({ ...args, snooze: snooze({ ...stale, dismissals: MAX_DISMISSALS - 1 }) })).toBe(true);
+		expect(shouldPrompt({ ...args, snooze: snooze({ ...stale, dismissals: MAX_DISMISSALS }) })).toBe(false);
+	});
+
+	// A newer build on the store is a new ask, so the count starts over.
+	it("starts over when the store moves on", () => {
+		const spent = snooze({ dismissals: MAX_DISMISSALS });
+		expect(shouldPrompt({ tier: "recommended", version: "1.4.0", snooze: spent, now })).toBe(true);
+	});
+});
+
+describe("nextSnooze", () => {
+	const now = 1_700_000_000_000;
+
+	it("counts dismissals of the same version", () => {
+		expect(nextSnooze(null, "1.3.0", now)).toEqual({ version: "1.3.0", dismissals: 1, lastPromptAt: now });
+		const once = nextSnooze(null, "1.3.0", now);
+		expect(nextSnooze(once, "1.3.0", now + 1)).toEqual({ version: "1.3.0", dismissals: 2, lastPromptAt: now + 1 });
+	});
+
+	it("resets the count for a different version", () => {
+		const spent: Snooze = { version: "1.3.0", dismissals: 3, lastPromptAt: now };
+		expect(nextSnooze(spent, "1.4.0", now)).toEqual({ version: "1.4.0", dismissals: 1, lastPromptAt: now });
+	});
+});
+
+describe("floorTarget", () => {
+	it("points at latest, falls back to min, and is undefined when the floor is empty", () => {
+		expect(floorTarget({ latest: "1.4.0", min: "1.2.0" })).toBe("1.4.0");
+		expect(floorTarget({ min: "1.2.0" })).toBe("1.2.0");
+		expect(floorTarget({ min: "", latest: "" })).toBeUndefined();
+		expect(floorTarget({})).toBeUndefined();
+	});
+});
+
+describe("playStoreUrls", () => {
+	it("prefers the Play app and keeps a browsable fallback", () => {
+		expect(playStoreUrls("aoagents.dev")).toEqual({
+			app: "market://details?id=aoagents.dev",
+			web: "https://play.google.com/store/apps/details?id=aoagents.dev",
+		});
+	});
+});
+
+describe("describeStoreRow", () => {
+	const idle = { enabled: true, checking: false, last: null };
+
+	it("goes inert in development builds", () => {
+		expect(describeStoreRow({ ...idle, enabled: false })).toEqual({
+			value: "Off in development builds",
+			tone: "default",
+			busy: false,
+			action: null,
+		});
+	});
+
+	it("shows progress while checking", () => {
+		expect(describeStoreRow({ ...idle, checking: true })).toEqual({
+			value: "Checking…",
+			tone: "default",
+			busy: true,
+			action: null,
+		});
+	});
+
+	it("offers the store when an update is waiting", () => {
+		expect(describeStoreRow({ ...idle, last: { kind: "available" } })).toEqual({
+			value: "Update available",
+			tone: "good",
+			busy: false,
+			action: "open",
+		});
+	});
+
+	it("reports a failed or successful check, and stays re-checkable", () => {
+		expect(describeStoreRow({ ...idle, last: { kind: "error" } })).toEqual({
+			value: "Couldn't check",
+			tone: "bad",
+			busy: false,
+			action: "check",
+		});
+		expect(describeStoreRow({ ...idle, last: { kind: "up-to-date" } })).toEqual({
+			value: "Up to date",
+			tone: "good",
+			busy: false,
+			action: "check",
+		});
+	});
+
+	it("invites a first check before anything has run", () => {
+		expect(describeStoreRow(idle)).toEqual({ value: "Check now", tone: "default", busy: false, action: "check" });
+	});
+});
+
+
+describe("floorSignal", () => {
+	it("requires below min, recommends below latest, and is quiet above both", () => {
+		const floor = { min: "1.2.0", latest: "1.4.0" };
+		expect(floorSignal("1.1.0", floor)).toBe("required");
+		expect(floorSignal("1.3.0", floor)).toBe("recommended");
+		expect(floorSignal("1.4.0", floor)).toBe("none");
+	});
+
+	it("works with either value alone", () => {
+		expect(floorSignal("1.1.0", { min: "1.2.0" })).toBe("required");
+		expect(floorSignal("1.1.0", { latest: "1.2.0" })).toBe("recommended");
+		expect(floorSignal("1.1.0", {})).toBe("none");
+	});
+
+	// A floor an operator typed wrong must do nothing, never something.
+	it("treats anything that is not a plain dotted number as absent", () => {
+		for (const bad of ["", "  ", "v1.3.0", "1.3.0-rc.1", "1.2.3.4", "abc", "10300"]) {
+			expect(floorSignal("1.2.1", { min: bad, latest: bad })).toBe("none");
+		}
+	});
+
+	it("does nothing when the installed version is unknown or unusable", () => {
+		expect(floorSignal(null, { min: "9.9.9" })).toBe("none");
+		expect(floorSignal("v1.2.1", { min: "9.9.9" })).toBe("none");
+	});
+});
+
+// THE INTERLOCK. Asserted directly rather than left to the order of statements
+// inside tierOf: this is the property that stops the floor from becoming a
+// unilateral kill switch, and it must survive any refactor of that function.
+describe("tierOf — the floor may only escalate a store-confirmed update", () => {
+	const confirmed: StoreCheck = { updateAvailable: true };
+
+	// Degrades to a nudge rather than going silent: the floor is still a real
+	// opinion about this build, it just may not lock anyone out on its own.
+	it("never blocks on a floor the store has not corroborated", () => {
+		expect(tierOf(null, "android", "required")).toBe("recommended");
+		expect(tierOf({ updateAvailable: false }, "android", "required")).toBe("recommended");
+		expect(tierOf(null, "ios", "required")).toBe("recommended");
+	});
+
+	it("blocks only once the store confirms the update exists", () => {
+		expect(tierOf(confirmed, "android", "required")).toBe("required");
+		expect(tierOf(confirmed, "ios", "required")).toBe("required");
+	});
+
+	// The soft tier deliberately does NOT need corroboration — it is the only way
+	// to surface anything on iOS before the App Store listing exists.
+	it("still nudges from the floor alone", () => {
+		expect(tierOf(null, "ios", "recommended")).toBe("recommended");
+		expect(tierOf({ updateAvailable: false }, "ios", "recommended")).toBe("recommended");
+	});
+
+	it("leaves the no-floor behaviour exactly as it was", () => {
+		expect(tierOf(confirmed, "android")).toBe("recommended");
+		expect(tierOf(null, "android")).toBe("none");
+	});
+});
+
+describe("shouldPrompt — staleness", () => {
+	const now = 1_700_000_000_000;
+	const args = { tier: "recommended" as const, version: "1.3.0", snooze: null, now };
+
+	it("holds the first ask until the update has been on Play a few days", () => {
+		expect(shouldPrompt({ ...args, stalenessDays: 0 })).toBe(false);
+		expect(shouldPrompt({ ...args, stalenessDays: DAYS_FOR_FLEXIBLE_UPDATE - 1 })).toBe(false);
+		expect(shouldPrompt({ ...args, stalenessDays: DAYS_FOR_FLEXIBLE_UPDATE })).toBe(true);
+	});
+
+	// Play not knowing must never read as "too fresh" — iOS never sets this.
+	it("does not suppress when staleness is unknown", () => {
+		expect(shouldPrompt({ ...args, stalenessDays: null })).toBe(true);
+		expect(shouldPrompt(args)).toBe(true);
+	});
+
+	it("only gates the first ask; after that the snooze governs", () => {
+		const asked = { version: "1.3.0", dismissals: 1, lastPromptAt: now - PROMPT_INTERVAL_MS };
+		expect(shouldPrompt({ ...args, snooze: asked, stalenessDays: 0 })).toBe(true);
+	});
+
+	it("never delays a required update", () => {
+		expect(shouldPrompt({ ...args, tier: "required", stalenessDays: 0 })).toBe(true);
+	});
+});
+
+describe("describePrompt", () => {
+	it("names the store only when the store actually answered", () => {
+		expect(describePrompt({ version: "1.3.0", storeConfirmed: true, storeName: "App Store" })).toBe(
+			"Version 1.3.0 is on the App Store.",
+		);
+		expect(describePrompt({ storeConfirmed: true, storeName: "Play Store" })).toBe("A newer version is on the Play Store.");
+	});
+
+	// During the TestFlight window the floor is the only signal, and there is no
+	// App Store page to point at — the copy must not imply one.
+	it("stays vague when only the floor fired", () => {
+		expect(describePrompt({ version: "1.3.0", storeConfirmed: false, storeName: "App Store" })).toBe("Version 1.3.0 is available.");
+		expect(describePrompt({ storeConfirmed: false, storeName: "App Store" })).toBe("A newer version is available.");
+	});
+});

--- a/packages/mobile/lib/storeUpdate.ts
+++ b/packages/mobile/lib/storeUpdate.ts
@@ -1,0 +1,250 @@
+// Store-update policy: whether to tell the user a newer native binary is on the
+// store, and how hard to push. No React Native or Expo imports so vitest can run
+// it; callers pass the store's answer in, the way `updates.ts` pairs with
+// `UpdatesManager.tsx`.
+//
+// `updates.ts` is the JS half of updating and cannot cross the native boundary:
+// a fingerprint runtime means a native change leaves old binaries with no
+// updates and no signal. This is that signal.
+
+/** What a store told us. Android fields come from Play, iOS from the iTunes lookup. */
+export type StoreCheck = {
+	updateAvailable: boolean;
+	/** Play only: an update this app started is downloading or waiting to install. */
+	updateInProgress?: boolean;
+	/**
+	 * iOS: the App Store's version string. Android: the available `versionCode`.
+	 * The two are not the same kind of thing, so this is only ever compared to
+	 * itself (to notice the store moved) and never parsed as a version here.
+	 */
+	storeVersion?: string;
+	/** iOS: the app's own App Store page, straight from the lookup. */
+	storeUrl?: string;
+	/** Play only: whether the immediate (blocking) flow can start right now. */
+	immediateAllowed?: boolean;
+	/**
+	 * Play only: days since THIS device's Play Store learned of the update — not
+	 * days since release, so a staged rollout makes it per-device. Null when Play
+	 * does not know.
+	 */
+	playStalenessDays?: number | null;
+	/** Play only: "IMMEDIATE" once a release was published with inAppUpdatePriority >= 4. */
+	serverUpdateType?: "FLEXIBLE" | "IMMEDIATE";
+};
+
+export type StoreTier = "none" | "recommended" | "required";
+
+/** How often a dismissed nudge may come back, and how many times in total. */
+export const PROMPT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+export const MAX_DISMISSALS = 3;
+
+/**
+ * A version we require (`min`) or would like people on (`latest`), carried in the
+ * JS bundle so it can be moved with an `eas update` rather than a store release.
+ */
+export type Floor = { min?: string; latest?: string };
+
+/** How long an update must have been on Play before the first nudge. */
+export const DAYS_FOR_FLEXIBLE_UPDATE = 3;
+
+/** Persisted nudge state. `version` is whichever version the count belongs to. */
+export type Snooze = { version: string; dismissals: number; lastPromptAt: number };
+
+/**
+ * Compares dotted numeric versions: <0, 0, >0. Missing segments count as zero,
+ * so "1.2" equals "1.2.0". A non-numeric segment counts as zero rather than NaN
+ * so a malformed store answer can never read as "newer" and nag every launch.
+ */
+export function compareVersions(a: string, b: string): number {
+	const left = a.split(".");
+	const right = b.split(".");
+	for (let i = 0; i < Math.max(left.length, right.length); i++) {
+		const na = Number.parseInt(left[i] ?? "0", 10) || 0;
+		const nb = Number.parseInt(right[i] ?? "0", 10) || 0;
+		if (na !== nb) return na - nb;
+	}
+	return 0;
+}
+
+/**
+ * A version string we are willing to compare, or null.
+ *
+ * `compareVersions` coerces non-numeric segments to 0, so it can never report
+ * that a value was unparseable — it just answers. That is the wrong failure for
+ * an operator-supplied floor: "v1.3.0" would silently become 0.3.0 and do
+ * nothing, while a pasted versionCode like "10300" would sit above every version
+ * that will ever exist. Anything that is not a plain dotted number is absent.
+ */
+function usableVersion(v: string | null | undefined): string | null {
+	const trimmed = v?.trim();
+	return trimmed && /^\d{1,4}(\.\d{1,4}){0,2}$/.test(trimmed) ? trimmed : null;
+}
+
+/** The version a floor is pointing at, for copy and for keying the snooze. */
+export function floorTarget(floor: Floor): string | undefined {
+	return floor.latest || floor.min || undefined;
+}
+
+/** What the floor alone would ask for, before the store gets a say. */
+export function floorSignal(installed: string | null | undefined, floor: Floor): StoreTier {
+	const have = usableVersion(installed);
+	if (!have) return "none";
+	const min = usableVersion(floor.min);
+	if (min && compareVersions(have, min) < 0) return "required";
+	const latest = usableVersion(floor.latest);
+	if (latest && compareVersions(have, latest) < 0) return "recommended";
+	return "none";
+}
+
+/**
+ * The iTunes Search API lookup for a bundle id. Public, unauthenticated, no key.
+ *
+ * `region` is the two-letter storefront. Without it the API answers for the US
+ * store only, so a user in a country the app has not launched in — or one where
+ * the release rolls out later — reads as "no update" while their own store has
+ * one. Unknown or malformed regions are dropped rather than guessed.
+ */
+export function lookupUrl(bundleId: string, region?: string | null): string {
+	const url = `https://itunes.apple.com/lookup?bundleId=${encodeURIComponent(bundleId)}`;
+	const country = region?.trim().toLowerCase();
+	return country && /^[a-z]{2}$/.test(country) ? `${url}&country=${country}` : url;
+}
+
+/**
+ * Reads an iTunes lookup body. `resultCount: 0` is what the API returns for an
+ * app that is not on the App Store, so it has to read as "no update" rather than
+ * an error — as does a body we cannot parse. The check is advisory; failing open
+ * is the only safe way to be wrong.
+ */
+export function parseLookup(body: unknown, installed: string | null | undefined): StoreCheck {
+	if (!installed) return { updateAvailable: false };
+	const results = (body as { results?: unknown })?.results;
+	const first = Array.isArray(results) ? (results[0] as Record<string, unknown> | undefined) : undefined;
+	const version = typeof first?.version === "string" ? first.version : null;
+	if (!version) return { updateAvailable: false };
+	// trackViewUrl is the app's own store page; trackId reconstructs it if the
+	// field is ever missing. Either way the App Store id never has to be
+	// configured in the app — the lookup carries it.
+	const storeUrl =
+		typeof first?.trackViewUrl === "string"
+			? first.trackViewUrl
+			: typeof first?.trackId === "number"
+				? `https://apps.apple.com/app/id${first.trackId}`
+				: undefined;
+	return { updateAvailable: compareVersions(version, installed) > 0, storeVersion: version, storeUrl };
+}
+
+/**
+ * How hard to push, from the store's answer and the floor together.
+ *
+ * **The interlock: `required` needs the store to independently confirm that an
+ * update exists.** The floor can raise a confirmed update from dismissible to
+ * blocking; it can never invent one. That is what makes a mistyped floor
+ * harmless — the worst it can do is force an update already being offered — and
+ * it is why iOS is nudge-only while unlisted and starts blocking by itself once
+ * listed, with no platform special-case here.
+ *
+ * This is asserted directly in the tests rather than left to the order of the
+ * statements below, because it is the property that stops the floor becoming a
+ * unilateral kill switch.
+ *
+ * `recommended` deliberately does NOT need confirmation: the floor is the only
+ * way to surface anything on iOS before the App Store listing exists.
+ */
+export function tierOf(check: StoreCheck | null, platform: string, floor: StoreTier = "none"): StoreTier {
+	const confirmed = check?.updateAvailable === true;
+	// Play's own policy channel: inAppUpdatePriority >= 4 on the release.
+	if (confirmed && platform === "android" && check.serverUpdateType === "IMMEDIATE" && check.immediateAllowed) return "required";
+	if (confirmed && floor === "required") return "required";
+	if (confirmed || floor !== "none") return "recommended";
+	return "none";
+}
+
+/**
+ * The sheet's subtitle. Only claims the store has a build when the store said so
+ * — a floor-driven nudge during the TestFlight window would otherwise point at
+ * an App Store page that does not exist yet.
+ */
+export function describePrompt(input: { version?: string; storeConfirmed: boolean; storeName: string }): string {
+	const where = input.storeConfirmed ? `on the ${input.storeName}` : "available";
+	return input.version ? `Version ${input.version} is ${where}.` : `A newer version is ${where}.`;
+}
+
+/**
+ * Whether to interrupt the user now. A critical release ignores the snooze —
+ * that is the whole point of the tier. Everything else is rate limited, and a
+ * different version on the store is a different ask, so the count starts over.
+ */
+export function shouldPrompt({
+	tier,
+	version,
+	snooze,
+	now,
+	stalenessDays,
+}: {
+	tier: StoreTier;
+	/** What we are nudging toward — the store's version, or the floor's. */
+	version: string | undefined;
+	snooze: Snooze | null;
+	now: number;
+	/** Play's `clientVersionStalenessDays`, when it knows. */
+	stalenessDays?: number | null;
+}): boolean {
+	if (tier === "required") return true;
+	if (tier !== "recommended") return false;
+	// Don't nag on day zero of a release: Play may be minutes from installing it
+	// by itself. Only the first ask waits — once we have prompted, the snooze
+	// below governs. A null staleness means Play does not know, so never suppress.
+	if (!snooze && typeof stalenessDays === "number" && stalenessDays < DAYS_FOR_FLEXIBLE_UPDATE) return false;
+	if (!snooze || snooze.version !== (version ?? "")) return true;
+	if (snooze.dismissals >= MAX_DISMISSALS) return false;
+	return now - snooze.lastPromptAt >= PROMPT_INTERVAL_MS;
+}
+
+/** The snooze record after the user dismisses a nudge for `storeVersion`. */
+export function nextSnooze(prev: Snooze | null, target: string | undefined, now: number): Snooze {
+	const version = target ?? "";
+	const carried = prev && prev.version === version ? prev.dismissals : 0;
+	return { version, dismissals: carried + 1, lastPromptAt: now };
+}
+
+/**
+ * Play Store links. `market://` opens the Play app directly; the https form is
+ * the fallback for a device without it (and the one a browser can handle).
+ */
+export function playStoreUrls(packageName: string): { app: string; web: string } {
+	return {
+		app: `market://details?id=${packageName}`,
+		web: `https://play.google.com/store/apps/details?id=${packageName}`,
+	};
+}
+
+export type StoreRowResult = { kind: "error" } | { kind: "up-to-date" } | { kind: "available" };
+
+export type StoreRowInput = {
+	/** False in dev builds, where there is no store install to compare against. */
+	enabled: boolean;
+	checking: boolean;
+	last: StoreRowResult | null;
+};
+
+export type StoreRow = {
+	value: string;
+	tone: "default" | "good" | "bad";
+	busy: boolean;
+	action: "check" | "open" | null;
+};
+
+/**
+ * What the Settings store row shows and does. Worded to match the OTA row right
+ * above it (`describeUpdateRow`): two adjacent rows reporting the same kind of
+ * state should say it the same way.
+ */
+export function describeStoreRow(input: StoreRowInput): StoreRow {
+	if (!input.enabled) return { value: "Off in development builds", tone: "default", busy: false, action: null };
+	if (input.checking) return { value: "Checking…", tone: "default", busy: true, action: null };
+	if (input.last?.kind === "available") return { value: "Update available", tone: "good", busy: false, action: "open" };
+	if (input.last?.kind === "error") return { value: "Couldn't check", tone: "bad", busy: false, action: "check" };
+	if (input.last?.kind === "up-to-date") return { value: "Up to date", tone: "good", busy: false, action: "check" };
+	return { value: "Check now", tone: "default", busy: false, action: "check" };
+}

--- a/packages/mobile/lib/storeUpdateStore.ts
+++ b/packages/mobile/lib/storeUpdateStore.ts
@@ -1,0 +1,34 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { Snooze } from "./storeUpdate";
+
+// Storage side of the store-update nudge. Split from `storeUpdate.ts` so the
+// decision logic there stays free of React Native imports and unit-testable —
+// the same split as `onboardingStore.ts` / `onboarding.ts`.
+//
+// Nothing here is a secret, so AsyncStorage (plaintext app sandbox) is right;
+// SecureStore stays reserved for the connection password.
+
+export const STORE_UPDATE_KEY = "ao.storeUpdate";
+
+/** How often the nudge was dismissed, and for which store version. Never throws. */
+export async function loadSnooze(): Promise<Snooze | null> {
+	try {
+		const raw = await AsyncStorage.getItem(STORE_UPDATE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as Partial<Snooze>;
+		// A record written by an older build (or a corrupted one) reads as "never
+		// asked", which errs towards showing the nudge rather than swallowing it.
+		if (typeof parsed?.version !== "string" || typeof parsed?.dismissals !== "number") return null;
+		return { version: parsed.version, dismissals: parsed.dismissals, lastPromptAt: parsed.lastPromptAt ?? 0 };
+	} catch {
+		return null;
+	}
+}
+
+export async function saveSnooze(snooze: Snooze): Promise<void> {
+	try {
+		await AsyncStorage.setItem(STORE_UPDATE_KEY, JSON.stringify(snooze));
+	} catch {
+		/* a lost record only means the nudge may come back a launch early */
+	}
+}

--- a/packages/mobile/lib/versionFloor.ts
+++ b/packages/mobile/lib/versionFloor.ts
@@ -1,0 +1,20 @@
+// The version floor, carried in the JS bundle so it can be moved with an
+// `eas update` instead of a store release. The values are EAS environment
+// variables, so the dashboard is the source of truth and `--environment`
+// re-inlines them on every publish. Unset means inert, which is how this ships.
+//
+// Two ways to silently disable it, both worth knowing before touching this:
+// Metro only inlines a literal `process.env.X` dot access, so destructuring or
+// bracket access reads as undefined in a build (same reason as
+// `telemetry/config.ts`); and a variable set to secret visibility is not
+// readable outside EAS servers, so it does not resolve during `eas update` and
+// falls through to "" here without any error.
+
+import type { Floor } from "./storeUpdate";
+
+export const VERSION_FLOOR: Floor = {
+	/** Below this the update stops being optional — see the interlock in `tierOf`. */
+	min: process.env.EXPO_PUBLIC_AO_MIN_APP_VERSION ?? "",
+	/** Below this we mention it once a day. The only lever iOS has before listing. */
+	latest: process.env.EXPO_PUBLIC_AO_LATEST_APP_VERSION ?? "",
+};

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -24,6 +24,7 @@
 				"expo-font": "~57.0.1",
 				"expo-haptics": "~57.0.1",
 				"expo-image-picker": "~57.0.12",
+				"expo-in-app-updates": "^0.12.0",
 				"expo-linking": "~57.0.7",
 				"expo-notifications": "~57.0.13",
 				"expo-router": "~57.0.15",
@@ -4348,6 +4349,15 @@
 			"dependencies": {
 				"expo-image-loader": "~57.0.1"
 			},
+			"peerDependencies": {
+				"expo": "*"
+			}
+		},
+		"node_modules/expo-in-app-updates": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/expo-in-app-updates/-/expo-in-app-updates-0.12.0.tgz",
+			"integrity": "sha512-RqqT0KEqZNbOk5Zxq+JQ7ph7mH/ZNfKOowPyZI8K2YnYBjjNIOyt5PlSZz5/JtmPsBGe6/oKiu1QY+4rGfY+Eg==",
+			"license": "MIT",
 			"peerDependencies": {
 				"expo": "*"
 			}

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -30,6 +30,7 @@
 		"expo-font": "~57.0.1",
 		"expo-haptics": "~57.0.1",
 		"expo-image-picker": "~57.0.12",
+		"expo-in-app-updates": "^0.12.0",
 		"expo-linking": "~57.0.7",
 		"expo-notifications": "~57.0.13",
 		"expo-router": "~57.0.15",
@@ -44,6 +45,13 @@
 		"react-native-safe-area-context": "~5.7.0",
 		"react-native-screens": "~4.26.0",
 		"react-native-webview": "13.16.1"
+	},
+	"expo": {
+		"autolinking": {
+			"apple": {
+				"exclude": ["expo-in-app-updates"]
+			}
+		}
 	},
 	"devDependencies": {
 		"@types/node": "^26.2.0",


### PR DESCRIPTION
## What

OTA covers JS only — with `policy: fingerprint` a native change mints a new runtime, so a build in the field silently stops being offered updates the moment a newer binary ships. This says so and takes the user to the store.

- Cold start, once, after pairing. Android asks Play In-App Updates, so Play compares the installed `versionCode` itself. iOS has no such API, so it queries the iTunes lookup by bundle id against `CFBundleShortVersionString` from the binary — not the JS bundle's version, which OTA can change independently.
- Two tiers: `inAppUpdatePriority >= 4` hands over to Google's updater (still cancellable, so an insistent nudge rather than a lock); everything else is a dismissible sheet, once a day and three dismissals per store version, a swipe counting as one. The first ask waits until Play has known about the update for three days.
- Settings → About → App Store / Play Store checks on demand. Sideloaded, offline or not yet listed all read as "no update"; dev builds are inert.

## Version floor

`EXPO_PUBLIC_AO_MIN_APP_VERSION` and `EXPO_PUBLIC_AO_LATEST_APP_VERSION`, both unset so they ship inert. They are EAS environment variables, so moving one is an `eas update` rather than a store release, and app JS is not a fingerprint input, so it reaches builds already in the field. This exists because iOS cannot be asked at all while unlisted, and because `inAppUpdatePriority` is immutable once a release has rolled out.

**The floor may only escalate an update the store independently confirmed.** It can raise a confirmed update from dismissible to blocking; it can never invent one. So a mistyped floor cannot strand anyone, iOS stays nudge-only while unlisted, and it starts blocking on its own once listed. That is asserted directly in the tests, not left to statement order in `tierOf`. The soft tier needs no confirmation — the only way to surface anything on iOS during TestFlight — and the copy follows the source, so a floor-driven prompt reads "Version 1.3.0 is available." rather than naming a store page that doesn't exist.

`expo-in-app-updates` is **excluded from Apple autolinking**: Android-only code here, and linking the unused pod would put it in the iOS fingerprint, changing the iOS runtime on every dependency bump. It binds via `requireOptionalNativeModule`, which answers `null` on iOS instead of throwing. Play's flexible flow is never started — it calls `completeUpdate()` the moment the download lands and restarts the app unannounced.

## Activation

No CI, no secret, nothing automatic. The floor does nothing until someone creates the two EAS variables with **plaintext** visibility — secret ones aren't readable outside EAS servers and would silently resolve to empty. It is also only as granular as our version stamping: `version` has read `1.2.1` across several commits, and `autoIncrement` moves the build number instead.

## Verification

- `npm run typecheck`; `npm test` (538, 43 new); `npx expo export` both platforms
- `npx expo-doctor` 20/21 — measured on the base commit too, where it is also 20/21 with the same three packages, so the failure is `main`'s and not this branch's
- `npx expo prebuild --clean` then real native builds on both platforms
- `runtimeversion:resolve` twice per platform, stable. iOS unchanged from base (`e259e922…`) — the autolinking exclusion holding — while Android moves, as a native module must. The floor moves neither, being pure JS
- Lockfile is `main`'s plus one dependency, **zero re-resolutions**, verified by diffing every package version
- On device, both platforms: module linked on Android; `checkStore()` fails open silently on a Play-less emulator; iOS launches with the pod excluded; sheet in light and dark; snooze written, honoured and reset when the version moves. With a floor set, both read "Version 9.9.9 is available." — the value inlined, the store confirming nothing
- Not exercised: the real Play update flow (needs internal app sharing), iOS against a real listing (we have none — the lookup was tested against the live iTunes API with a published bundle id), the stalled-update resume path, and a real `eas update` carrying a floor
