### PR TITLE
fix(frontend): improve session name display in topbar

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -223,14 +223,14 @@ export function ShellTopbar({
 				{isSessionRoute && session ? (
 					<div className="flex min-w-0 items-center gap-2.5" data-testid="session-topbar-identity">
 						{isOrchestrator ? (
-							<span className={cn(topbarProjectLabelClass, "inline-flex min-w-0 items-center gap-1.5")}>
+							<span className={cn(topbarProjectLabelClass, "inline-flex min-w-0 items-center gap-1.5")} title={projectLabel}>
 								<Folder aria-hidden="true" className="size-icon-md shrink-0 text-muted-foreground" />
-								<span className="max-w-content-max truncate">{projectLabel}</span>
+								<span className="min-w-0 truncate">{projectLabel}</span>
 							</span>
 						) : (
-							<span className={cn(topbarProjectLabelClass, "max-w-content-max truncate")}>{session.title}</span>
+							<span className={cn(topbarProjectLabelClass, "min-w-0 truncate")} title={session.title}>{session.title}</span>
 						)}
-						<span aria-hidden="true" className="workspace-topbar__identity-separator" />
+						<span aria-hidden="true" className="workspace-topbar__identity-separator mx-0.5" />
 						<SessionStatusPill session={session} />
 					</div>
 				) : (isProjectBoardRoute && boardActionsInPanel) ||


### PR DESCRIPTION
## Summary

Fixes #3173

The session name in the topbar was cropped on narrower windows and visually appeared as a clickable button due to its proximity to the StatusPill.

### Changes

**`frontend/src/renderer/components/ShellTopbar.tsx`:**

1. **Replace `max-w-content-max` with `min-w-0`** — the hard max-width was the primary cause of aggressive truncation. `min-w-0` lets the flex container naturally allocate space and only truncates as a last resort when the window is genuinely too narrow.

2. **Add `title` attribute** — when the name is truncated, hovering reveals the full session name in a native tooltip.

3. **Add `mx-0.5` to the identity separator** — increases the visual gap between the session title and the StatusPill, making it clear they are separate elements rather than one interactive chip.

### Before
- Session name aggressively truncated with hard max-width cap
- Title + separator + StatusPill appear as one interactive element

### After
- Session name uses natural flex allocation, truncates only when necessary
- Clear visual separation between title and status pill
- Full name available on hover via tooltip

## Test plan

- [x] Session name displays fully on normal-width windows
- [x] Session name truncates gracefully (with ellipsis) on narrow windows
- [x] Full session name visible on hover via title tooltip
- [x] Session title and StatusPill are visually distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)