### PR TITLE
fix(agy): report real auth status instead of always Unknown

### DIFF
--- a/backend/internal/adapters/agent/agy/agy_test.go
+++ b/backend/internal/adapters/agent/agy/agy_test.go
@@ -3,12 +3,14 @@ package agy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/modelcatalog"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -351,24 +353,67 @@ func assertRawJSONEqual(t *testing.T, want, got json.RawMessage) {
 }
 
 func TestAuthStatus(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", "")
-	adcPath := filepath.Join(t.TempDir(), "application-default-credentials.json")
-	if err := os.WriteFile(adcPath, []byte(`{"type":"authorized_user"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	// ADC authenticates Google Cloud clients, but is not an Antigravity CLI
-	// credential according to the official auth flow.
-	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", adcPath)
-	plugin := &Plugin{resolvedBinary: "agy"}
+	t.Cleanup(func() { discoverModels = modelcatalog.Discover })
 
-	status, err := plugin.AuthStatus(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if status != ports.AgentAuthStatusUnknown {
-		t.Errorf("AuthStatus() = %v, want AgentAuthStatusUnknown", status)
-	}
+	t.Run("authorized when model discovery succeeds", func(t *testing.T) {
+		discoverModels = func(_ context.Context, agentID, binary, _ string, _ map[string]string) (ports.AgentModelCatalog, error) {
+			if agentID != adapterID {
+				t.Fatalf("agentID = %q, want %q", agentID, adapterID)
+			}
+			if binary != "agy" {
+				t.Fatalf("binary = %q, want %q", binary, "agy")
+			}
+			return ports.AgentModelCatalog{}, nil
+		}
+		plugin := &Plugin{resolvedBinary: "agy"}
+
+		status, err := plugin.AuthStatus(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status != ports.AgentAuthStatusAuthorized {
+			t.Errorf("AuthStatus() = %v, want AgentAuthStatusAuthorized", status)
+		}
+	})
+
+	t.Run("unknown when model discovery fails, even with unrelated Google credentials present", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("XDG_CONFIG_HOME", "")
+		adcPath := filepath.Join(t.TempDir(), "application-default-credentials.json")
+		if err := os.WriteFile(adcPath, []byte(`{"type":"authorized_user"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// ADC authenticates Google Cloud clients, but is not an Antigravity CLI
+		// credential according to the official auth flow, and must not be
+		// mistaken for one.
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", adcPath)
+		discoverModels = func(context.Context, string, string, string, map[string]string) (ports.AgentModelCatalog, error) {
+			return ports.AgentModelCatalog{}, errors.New("not authenticated")
+		}
+		plugin := &Plugin{resolvedBinary: "agy"}
+
+		status, err := plugin.AuthStatus(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if status != ports.AgentAuthStatusUnknown {
+			t.Errorf("AuthStatus() = %v, want AgentAuthStatusUnknown", status)
+		}
+	})
+
+	t.Run("unknown when the binary cannot be resolved", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir()) // empty of any "agy" binary
+		t.Setenv("HOME", t.TempDir())
+		plugin := &Plugin{}
+
+		status, err := plugin.AuthStatus(context.Background())
+		if err == nil {
+			t.Fatal("expected an error when the binary cannot be resolved")
+		}
+		if status != ports.AgentAuthStatusUnknown {
+			t.Errorf("AuthStatus() = %v, want AgentAuthStatusUnknown", status)
+		}
+	})
 }
 
 func TestGetConfigSpecReportsModelField(t *testing.T) {

--- a/backend/internal/adapters/agent/agy/auth.go
+++ b/backend/internal/adapters/agent/agy/auth.go
@@ -3,18 +3,36 @@ package agy
 import (
 	"context"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/modelcatalog"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
 
+// discoverModels is a seam over modelcatalog.Discover so tests can substitute
+// a fake result instead of executing the real Antigravity CLI.
+var discoverModels = modelcatalog.Discover
+
 // AuthStatus returns the plugin's local authentication status.
+//
+// Antigravity authenticates through its OS keyring and browser sign-in, and
+// the official CLI exposes no documented non-interactive credential file or
+// status/whoami command, so auth cannot be read directly. `agy models` fetches
+// its catalog from a remote service and only succeeds when the CLI is
+// authenticated, so the same discovery AO already runs for the model catalog
+// (modelcatalog.Discover) doubles as a safe, already-exercised proxy signal: a
+// successful run proves the session is authorized. A failed run is reported as
+// Unknown rather than Unauthorized, because the failure could equally mean
+// "not logged in", "offline", or a transient CLI hiccup, and this adapter has
+// no documented way to tell those apart without guessing at the CLI's error
+// text.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	if _, err := p.ResolveBinary(ctx); err != nil {
+	binary, err := p.ResolveBinary(ctx)
+	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	// Antigravity authenticates through its OS keyring and browser sign-in. The
-	// official CLI does not expose a documented non-interactive credential file
-	// or status command, so local auth cannot safely be inferred here.
-	return ports.AgentAuthStatusUnknown, nil
+	if _, err := discoverModels(ctx, adapterID, binary, "", nil); err != nil {
+		return ports.AgentAuthStatusUnknown, nil
+	}
+	return ports.AgentAuthStatusAuthorized, nil
 }


### PR DESCRIPTION
Fixes #4639

## Summary

Antigravity's `agy` adapter has no documented status/whoami command, so `AuthStatus()` was hardcoded to always return `Unknown` regardless of actual login state. `agy models` already fetches its catalog from a remote service and only succeeds when the CLI is authenticated — and AO already runs that exact command elsewhere for the model picker (`modelcatalog.Discover`, wired up in `commandSpecs["agy"]` per #3385/PR #3386).

This reuses that same discovery call as a proxy signal:
- success → `Authorized`
- failure → stays `Unknown` (not `Unauthorized` — a failed run could mean "not logged in", "offline", or a transient CLI hiccup, and there's no documented way to tell those apart without guessing at error text, so this only ever turns a `Unknown` into a `Authorized` when it can prove it, never invents a false negative)

## Verification

Reproduced live against the real `agy` CLI (v1.1.22): `agy models` succeeds non-interactively with no login prompt when authenticated, returning a tab-separated `<id>\t<label>` list. Confirmed the fix reports `Authorized` in that case via a table-driven test with an injected `discoverModels` seam (no real subprocess/network call in the test itself, per repo test-hygiene conventions).

The existing test's original intent — unrelated `GOOGLE_APPLICATION_CREDENTIALS` (Google ADC) must never be mistaken for Antigravity auth — is preserved as its own subtest.

## Test plan

```
go build ./...
go test ./internal/adapters/agent/agy/... ./internal/adapters/agent/modelcatalog/... -v
go test ./...
go vet ./internal/adapters/agent/agy/... ./internal/adapters/agent/modelcatalog/...
gofmt -l internal/adapters/agent/agy/auth.go internal/adapters/agent/agy/agy_test.go
```
All pass; full backend suite green.

## Related

- #4639 — the bug this fixes
- #3385 / PR #3386 — merged model-catalog discovery work that already exercises `agy models`, reused here
- PR #3960 — open, separate fix for a model-discovery pipe-drain timeout bug in the same subsystem; unrelated to this auth-status change