### PR TITLE
feat: improve browser address bar focus

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -174,6 +174,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					onTabsState: unsubscribe,
 					onAgentActivity: unsubscribe,
 					onDevToolsState: unsubscribe,
+					onPageFocus: unsubscribe,
 				},
 				notifications: {
 					show: async () => undefined,
@@ -625,6 +626,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					onTabsState: unsubscribe,
 					onAgentActivity: unsubscribe,
 					onDevToolsState: unsubscribe,
+					onPageFocus: unsubscribe,
 				},
 				notifications: {
 					show: async () => undefined,

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -2028,6 +2028,7 @@ describe("getLastFocusedPanelContents", () => {
 	// Mock that captures each panel's "focus" listener so the test can fire it.
 	function setup() {
 		let focusListener: (() => void) | undefined;
+		const shellSend = vi.fn();
 		const webContents = {
 			canGoBack: () => false,
 			canGoForward: () => false,
@@ -2055,7 +2056,7 @@ describe("getLastFocusedPanelContents", () => {
 			mainWindow: {
 				contentView: { addChildView: () => undefined, removeChildView: () => undefined },
 				getContentBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
-				webContents: { id: 1, send: () => undefined },
+				webContents: { id: 1, send: shellSend },
 			} as never,
 			ipcMain: { handle: record, on: record, removeHandler: () => undefined, off: () => undefined } as never,
 			shell: { openExternal: async () => undefined },
@@ -2067,7 +2068,7 @@ describe("getLastFocusedPanelContents", () => {
 		});
 		const call = (channel: string, ...args: unknown[]) =>
 			handlers.get(channel)!({ sender: { id: 1, getZoomFactor: () => 1 } }, ...args);
-		return { host, call, webContents, focus: () => focusListener?.() };
+		return { host, call, shellSend, webContents, focus: () => focusListener?.() };
 	}
 
 	it("is null until a panel is focused", async () => {
@@ -2077,11 +2078,12 @@ describe("getLastFocusedPanelContents", () => {
 	});
 
 	it("tracks the focused panel, then clears on hide and destroy", async () => {
-		const { host, call, webContents, focus } = setup();
+		const { host, call, shellSend, webContents, focus } = setup();
 		await call("browser:ensure", "s");
 
 		focus();
 		expect(host.getLastFocusedPanelContents()).toBe(webContents);
+		expect(shellSend).toHaveBeenCalledWith("browser:pageFocus", "1:s");
 
 		call("browser:setBounds", { viewId: "1:s", rect: { x: 0, y: 0, width: 10, height: 10 }, visible: false });
 		expect(host.getLastFocusedPanelContents()).toBeNull();

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -631,6 +631,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		);
 		view.webContents.on("focus", () => {
 			lastFocusedViewId = session.viewId;
+			shellWebContents.send("browser:pageFocus", session.viewId);
 		});
 		// A newly-created WebContentsView reports about:blank before its renderer
 		// has actually been initialized. CDP commands can hang until that initial

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -307,6 +307,13 @@ const api = {
 				ipcRenderer.off("browser:navState", wrapped);
 			};
 		},
+		onPageFocus: (listener: (viewId: string) => void) => {
+			const wrapped = (_event: Electron.IpcRendererEvent, viewId: string) => listener(viewId);
+			ipcRenderer.on("browser:pageFocus", wrapped);
+			return () => {
+				ipcRenderer.off("browser:pageFocus", wrapped);
+			};
+		},
 		onTabsState: (listener: (state: BrowserTabsState) => void) => {
 			const wrapped = (_event: Electron.IpcRendererEvent, state: BrowserTabsState) => listener(state);
 			ipcRenderer.on("browser:tabsState", wrapped);

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -160,6 +160,7 @@ function PersistentBrowserPanelView({
 describe("BrowserPanel", () => {
 	const annotationSubmitListeners = new Set<(payload: BrowserAnnotationSubmitPayload) => void>();
 	const annotationCancelListeners = new Set<(payload: BrowserAnnotationCancelPayload) => void>();
+	const pageFocusListeners = new Set<(viewId: string) => void>();
 
 	beforeEach(() => {
 		hookState.navigate.mockReset();
@@ -188,6 +189,11 @@ describe("BrowserPanel", () => {
 		postMock.mockResolvedValue({ data: {} });
 		annotationSubmitListeners.clear();
 		annotationCancelListeners.clear();
+		pageFocusListeners.clear();
+		window.ao!.browser.onPageFocus = vi.fn((listener: (viewId: string) => void) => {
+			pageFocusListeners.add(listener);
+			return () => pageFocusListeners.delete(listener);
+		});
 		window.ao!.browser.onAnnotationSubmit = vi.fn((listener: (payload: BrowserAnnotationSubmitPayload) => void) => {
 			annotationSubmitListeners.add(listener);
 			return () => {
@@ -252,7 +258,9 @@ describe("BrowserPanel", () => {
 		});
 		expect(toolbar).toHaveClass("browser-panel__toolbar--url-editing");
 
-		fireEvent.blur(input);
+		act(() => {
+			for (const listener of pageFocusListeners) listener("42:sess-1");
+		});
 
 		expect(input).toHaveValue("google.com");
 		expect(toolbar).not.toHaveClass("browser-panel__toolbar--url-editing");

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -224,6 +224,41 @@ describe("BrowserPanel", () => {
 		expect(hookState.navigate).toHaveBeenCalledWith("localhost:5173");
 	});
 
+	it("shows only the site address until the URL input is focused", () => {
+		hookState.navState = {
+			...hookState.navState,
+			url: "https://www.google.com/search?q=agent+orchestrator#results",
+		};
+
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		expect(screen.getByRole("textbox", { name: /browser url/i })).toHaveValue("google.com");
+	});
+
+	it("expands the URL input, reveals the full URL, and selects it on focus", async () => {
+		const url = "https://www.google.com/search?q=agent+orchestrator#results";
+		hookState.navState = { ...hookState.navState, url, canGoBack: true };
+		const user = userEvent.setup();
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		const toolbar = screen.getByTestId("browser-toolbar");
+		const input = screen.getByRole("textbox", { name: /browser url/i }) as HTMLInputElement;
+
+		await user.click(input);
+
+		await waitFor(() => {
+			expect(input).toHaveValue(url);
+			expect(input.selectionStart).toBe(0);
+			expect(input.selectionEnd).toBe(url.length);
+		});
+		expect(toolbar).toHaveClass("browser-panel__toolbar--url-editing");
+
+		fireEvent.blur(input);
+
+		expect(input).toHaveValue("google.com");
+		expect(toolbar).not.toHaveClass("browser-panel__toolbar--url-editing");
+		expect(within(toolbar).getByRole("button", { name: /back/i })).toBeInTheDocument();
+	});
+
 	it("constrains the device frame to a named preset's width, and clears it back to fit", async () => {
 		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		const frame = screen.getByTestId("browser-device-frame").parentElement as HTMLElement;
@@ -812,13 +847,10 @@ describe("BrowserPanel", () => {
 		expect(screen.getByTestId("browser-viewport")).toHaveClass("browser-panel__viewport");
 	});
 
-	it("keeps URL icon placement controlled by the browser shell CSS", () => {
+	it("does not render a globe icon in the URL input", () => {
 		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 
-		const icon = screen.getByTestId("browser-url-icon");
-		expect(icon).toHaveClass("browser-panel__url-icon");
-		expect(icon).not.toHaveClass("top-1/2");
-		expect(icon).not.toHaveClass("-translate-y-1/2");
+		expect(screen.queryByTestId("browser-url-icon")).not.toBeInTheDocument();
 	});
 	it("disables annotation mode when no page is loaded", () => {
 		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -256,15 +256,34 @@ describe("BrowserPanel", () => {
 			expect(input.selectionStart).toBe(0);
 			expect(input.selectionEnd).toBe(url.length);
 		});
-		expect(toolbar).toHaveClass("browser-panel__toolbar--url-editing");
+		expect(toolbar).toHaveClass("browser-panel__toolbar--url-takeover");
+		expect(within(toolbar).getByRole("button", { name: /back/i })).toHaveClass("browser-panel__navigation-btn");
+		expect(within(toolbar).getByRole("button", { name: /forward/i })).toHaveClass("browser-panel__navigation-btn");
+		expect(within(toolbar).getByRole("button", { name: /reload/i })).toHaveClass("browser-panel__navigation-btn");
 
 		act(() => {
 			for (const listener of pageFocusListeners) listener("42:sess-1");
 		});
 
 		expect(input).toHaveValue("google.com");
-		expect(toolbar).not.toHaveClass("browser-panel__toolbar--url-editing");
+		expect(toolbar).not.toHaveClass("browser-panel__toolbar--url-takeover");
 		expect(within(toolbar).getByRole("button", { name: /back/i })).toBeInTheDocument();
+	});
+
+	it("keeps the normal toolbar and full URL while maximized", async () => {
+		const url = "https://www.google.com/search?q=agent+orchestrator";
+		hookState.navState = { ...hookState.navState, url };
+		const user = userEvent.setup();
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut session={session} />);
+		const toolbar = screen.getByTestId("browser-toolbar");
+		const input = screen.getByRole("textbox", { name: /browser url/i });
+
+		expect(input).toHaveValue(url);
+		await user.click(input);
+
+		expect(toolbar).not.toHaveClass("browser-panel__toolbar--url-takeover");
+		expect(within(toolbar).getByRole("button", { name: /back/i })).toBeInTheDocument();
+		expect(within(toolbar).getByRole("button", { name: /reload/i })).toBeInTheDocument();
 	});
 
 	it("constrains the device frame to a named preset's width, and clears it back to fit", async () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -397,6 +397,16 @@ export function BrowserPanelView({
 	}, [urlEditing]);
 
 	useEffect(() => {
+		const onPageFocus = window.ao?.browser.onPageFocus;
+		if (!onPageFocus) return;
+		return onPageFocus((focusedViewId) => {
+			if (focusedViewId !== viewId) return;
+			urlInputRef.current?.blur();
+			setUrlEditing(false);
+		});
+	}, [viewId]);
+
+	useEffect(() => {
 		const offSubmit = window.ao?.browser.onAnnotationSubmit((payload) => {
 			if (payload.viewId !== viewId) return;
 			enqueue(payload);
@@ -418,6 +428,15 @@ export function BrowserPanelView({
 	};
 
 	const beginUrlEditing = () => {
+		const input = urlInputRef.current;
+		const wrapper = input?.parentElement;
+		const toolbar = input?.closest<HTMLElement>(".browser-panel__toolbar");
+		if (wrapper && toolbar) {
+			const wrapperRect = wrapper.getBoundingClientRect();
+			const toolbarRect = toolbar.getBoundingClientRect();
+			wrapper.style.setProperty("--browser-url-expand-left", `${toolbarRect.left + 4 - wrapperRect.left}px`);
+			wrapper.style.setProperty("--browser-url-expand-right", `${wrapperRect.right - toolbarRect.right + 4}px`);
+		}
 		setUrlInput(navState.url);
 		setUrlEditing(true);
 	};

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -329,6 +329,7 @@ export function BrowserPanelView({
 		setAnnotationMode,
 	} = browserView;
 	const [urlInput, setUrlInput] = useState(navState.url);
+	const [urlEditing, setUrlEditing] = useState(false);
 	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, retryQueued, status } =
 		annotationQueue;
 	const hasNativeBrowser = Boolean(window.ao?.browser);
@@ -390,6 +391,12 @@ export function BrowserPanelView({
 	}, [navState.url]);
 
 	useEffect(() => {
+		if (!urlEditing) return;
+		const frame = window.requestAnimationFrame(() => urlInputRef.current?.select());
+		return () => window.cancelAnimationFrame(frame);
+	}, [urlEditing]);
+
+	useEffect(() => {
 		const offSubmit = window.ao?.browser.onAnnotationSubmit((payload) => {
 			if (payload.viewId !== viewId) return;
 			enqueue(payload);
@@ -408,6 +415,11 @@ export function BrowserPanelView({
 		event.preventDefault();
 		const nextURL = urlInput.trim();
 		if (nextURL) void navigate(nextURL);
+	};
+
+	const beginUrlEditing = () => {
+		setUrlInput(navState.url);
+		setUrlEditing(true);
 	};
 
 	const toggleAnnotationMode = async () => {
@@ -519,7 +531,10 @@ export function BrowserPanelView({
 				</button>
 			</div>
 			<form
-				className="browser-panel__toolbar flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface"
+				className={cn(
+					"browser-panel__toolbar flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface",
+					urlEditing && "browser-panel__toolbar--url-editing",
+				)}
 				data-testid="browser-toolbar"
 				onSubmit={submit}
 			>
@@ -601,18 +616,15 @@ export function BrowserPanelView({
 					</span>
 				) : null}
 					<div className="browser-panel__url-wrap relative min-w-0 flex-1">
-						<Globe2
-							aria-hidden="true"
-							className="browser-panel__url-icon"
-							data-testid="browser-url-icon"
-						/>
 					<Input
 						aria-label={t("browser.url")}
-						className="browser-panel__url-input h-browser-url pl-browser-url font-mono text-xs"
+						className="browser-panel__url-input h-browser-url font-mono text-xs"
+						onBlur={() => setUrlEditing(false)}
 						onChange={(event) => setUrlInput(event.target.value)}
+						onFocus={beginUrlEditing}
 						placeholder={t("browser.urlPlaceholder")}
 						ref={urlInputRef}
-						value={urlInput}
+						value={urlEditing ? urlInput : compactBrowserAddress(navState.url)}
 					/>
 				</div>
 				{tabNotice ? (
@@ -907,6 +919,23 @@ function SortableBrowserTopTab({
 			</button>
 		</div>
 	);
+}
+
+function compactBrowserAddress(url: string): string {
+	if (!url) return "";
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+			return parsed.host.replace(/^www\./i, "");
+		}
+		if (parsed.protocol === "file:") {
+			const name = parsed.pathname.split("/").filter(Boolean).at(-1);
+			return name ? decodeURIComponent(name) : url;
+		}
+		return parsed.host || url;
+	} catch {
+		return url;
+	}
 }
 
 function agentActivityLabel(activity: BrowserViewModel["agentBrowserActivity"], active: boolean): string {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -330,6 +330,7 @@ export function BrowserPanelView({
 	} = browserView;
 	const [urlInput, setUrlInput] = useState(navState.url);
 	const [urlEditing, setUrlEditing] = useState(false);
+	const urlTakeover = urlEditing && !poppedOut;
 	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, retryQueued, status } =
 		annotationQueue;
 	const hasNativeBrowser = Boolean(window.ao?.browser);
@@ -431,10 +432,13 @@ export function BrowserPanelView({
 		const input = urlInputRef.current;
 		const wrapper = input?.parentElement;
 		const toolbar = input?.closest<HTMLElement>(".browser-panel__toolbar");
-		if (wrapper && toolbar) {
+		if (!poppedOut && wrapper && toolbar) {
 			const wrapperRect = wrapper.getBoundingClientRect();
 			const toolbarRect = toolbar.getBoundingClientRect();
-			wrapper.style.setProperty("--browser-url-expand-left", `${toolbarRect.left + 4 - wrapperRect.left}px`);
+			const navigationButtons = toolbar.querySelectorAll<HTMLElement>(".browser-panel__navigation-btn");
+			const lastNavigationButton = navigationButtons.item(navigationButtons.length - 1);
+			const targetLeft = lastNavigationButton?.getBoundingClientRect().right ?? toolbarRect.left + 4;
+			wrapper.style.setProperty("--browser-url-expand-left", `${targetLeft + 2 - wrapperRect.left}px`);
 			wrapper.style.setProperty("--browser-url-expand-right", `${wrapperRect.right - toolbarRect.right + 4}px`);
 		}
 		setUrlInput(navState.url);
@@ -552,13 +556,14 @@ export function BrowserPanelView({
 			<form
 				className={cn(
 					"browser-panel__toolbar flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface",
-					urlEditing && "browser-panel__toolbar--url-editing",
+					urlTakeover && "browser-panel__toolbar--url-takeover",
 				)}
 				data-testid="browser-toolbar"
 				onSubmit={submit}
 			>
 				<Button
 					aria-label={t("browser.back")}
+					className="browser-panel__navigation-btn"
 					disabled={!navState.canGoBack}
 					onClick={() => void goBack()}
 					size="icon-sm"
@@ -569,6 +574,7 @@ export function BrowserPanelView({
 				</Button>
 				<Button
 					aria-label={t("browser.forward")}
+					className="browser-panel__navigation-btn"
 					disabled={!navState.canGoForward}
 					onClick={() => void goForward()}
 					size="icon-sm"
@@ -579,6 +585,7 @@ export function BrowserPanelView({
 				</Button>
 				<Button
 					aria-label={navState.isLoading ? t("browser.stop") : t("browser.reload")}
+					className="browser-panel__navigation-btn"
 					onClick={() => void (navState.isLoading ? stop() : reload())}
 					size="icon-sm"
 					type="button"
@@ -643,7 +650,7 @@ export function BrowserPanelView({
 						onFocus={beginUrlEditing}
 						placeholder={t("browser.urlPlaceholder")}
 						ref={urlInputRef}
-						value={urlEditing ? urlInput : compactBrowserAddress(navState.url)}
+						value={urlEditing || poppedOut ? urlInput : compactBrowserAddress(navState.url)}
 					/>
 				</div>
 				{tabNotice ? (

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -105,6 +105,7 @@ function setupBridge() {
 			listeners.add(listener);
 			return () => listeners.delete(listener);
 		}),
+		onPageFocus: vi.fn(() => () => undefined),
 		onTabsState: vi.fn((listener: TabsListener) => {
 			tabsListeners.add(listener);
 			return () => tabsListeners.delete(listener);

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -150,6 +150,7 @@ export const aoBridge: AoBridge =
 			destroy: () => undefined,
 			setAnnotationMode: async () => undefined,
 			onNavState: () => () => undefined,
+			onPageFocus: () => () => undefined,
 			onTabsState: () => () => undefined,
 			onAgentActivity: () => () => undefined,
 			onDevToolsState: () => () => undefined,

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4034,7 +4034,7 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 		visibility 0s linear;
 }
 
-.browser-panel__toolbar--url-editing > :not(.browser-panel__url-wrap) {
+.browser-panel__toolbar--url-takeover > :not(.browser-panel__url-wrap):not(.browser-panel__navigation-btn) {
 	visibility: hidden;
 	opacity: 0;
 	pointer-events: none;
@@ -4284,7 +4284,7 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 		background-color var(--duration-fast) ease;
 }
 
-.browser-panel__toolbar--url-editing .browser-panel__url-input {
+.browser-panel__toolbar--url-takeover .browser-panel__url-input {
 	left: var(--browser-url-expand-left, 0);
 	right: var(--browser-url-expand-right, 0);
 	z-index: 2;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4028,7 +4028,7 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	backdrop-filter: blur(10px);
 }
 
-.browser-panel__toolbar > :not(.browser-panel__url-wrap) {
+.browser-panel__toolbar > :not(.browser-panel__url-wrap):not(button) {
 	transition:
 		opacity 140ms ease,
 		visibility 0s linear;
@@ -4242,7 +4242,9 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 		background var(--duration-fast) ease,
 		color var(--duration-fast) ease,
 		transform var(--duration-fast) ease,
-		box-shadow var(--duration-fast) ease;
+		box-shadow var(--duration-fast) ease,
+		opacity 140ms ease,
+		visibility 0s linear;
 }
 
 .browser-panel__toolbar button:not(:disabled):hover {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4028,12 +4028,17 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	backdrop-filter: blur(10px);
 }
 
-.browser-panel__toolbar--url-editing {
-	padding-right: 4px;
+.browser-panel__toolbar > :not(.browser-panel__url-wrap) {
+	transition:
+		opacity 140ms ease,
+		visibility 0s linear;
 }
 
 .browser-panel__toolbar--url-editing > :not(.browser-panel__url-wrap) {
-	display: none;
+	visibility: hidden;
+	opacity: 0;
+	pointer-events: none;
+	transition-delay: 0s, 140ms;
 }
 
 .browser-panel {
@@ -4227,6 +4232,10 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	flex: 1;
 }
 
+.browser-panel__url-wrap {
+	height: 29px;
+}
+
 .browser-panel__toolbar button {
 	border-radius: 7px;
 	transition:
@@ -4252,6 +4261,12 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 }
 
 .browser-panel__url-input {
+	position: absolute;
+	top: 0;
+	right: 0;
+	left: 0;
+	z-index: 0;
+	width: auto;
 	height: 29px;
 	border-color: color-mix(in srgb, var(--color-border) 72%, transparent);
 	border-radius: 7px;
@@ -4262,6 +4277,17 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 		0 1px 8px color-mix(in srgb, black 9%, transparent);
 	font-family: var(--font-mono);
 	font-size: 12px;
+	transition:
+		left 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+		right 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+		box-shadow var(--duration-fast) ease,
+		background-color var(--duration-fast) ease;
+}
+
+.browser-panel__toolbar--url-editing .browser-panel__url-input {
+	left: var(--browser-url-expand-left, 0);
+	right: var(--browser-url-expand-right, 0);
+	z-index: 2;
 }
 
 .browser-panel__url-input:focus {
@@ -4449,7 +4475,9 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 	}
 
 	.browser-panel,
-	.browser-panel__toolbar button {
+	.browser-panel__toolbar button,
+	.browser-panel__toolbar > :not(.browser-panel__url-wrap),
+	.browser-panel__url-input {
 		transition: none;
 	}
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4028,6 +4028,14 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	backdrop-filter: blur(10px);
 }
 
+.browser-panel__toolbar--url-editing {
+	padding-right: 4px;
+}
+
+.browser-panel__toolbar--url-editing > :not(.browser-panel__url-wrap) {
+	display: none;
+}
+
 .browser-panel {
 	container-name: browser-panel;
 	container-type: inline-size;
@@ -4243,21 +4251,8 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	color: var(--fg);
 }
 
-.browser-panel__url-icon {
-	position: absolute;
-	left: 10px;
-	top: 50%;
-	z-index: 1;
-	width: 15px;
-	height: 15px;
-	transform: translateY(-50%);
-	color: var(--fg-passive);
-	pointer-events: none;
-}
-
 .browser-panel__url-input {
 	height: 29px;
-	padding-left: 29px;
 	border-color: color-mix(in srgb, var(--color-border) 72%, transparent);
 	border-radius: 7px;
 	background:

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -237,6 +237,7 @@ if (typeof window !== "undefined") {
 			destroy: () => undefined,
 			setAnnotationMode: async () => undefined,
 			onNavState: () => () => undefined,
+			onPageFocus: () => () => undefined,
 			onTabsState: () => () => undefined,
 			onAgentActivity: () => () => undefined,
 			onDevToolsState: () => () => undefined,


### PR DESCRIPTION
## Summary

- Show a compact domain while the docked browser address field is idle, then reveal and select the full URL on focus.
- Smoothly expand the focused address field while preserving Back, Forward, and Reload/Stop controls and removing the globe icon.
- Restore the toolbar when the native page is clicked, while keeping the maximized browser toolbar layout unchanged.

## Testing

- npm test -- --run src/renderer/components/BrowserPanel.test.tsx src/main/browser-view-host.test.ts (137 tests passed)
- npm run typecheck
- Manual verification in the AO desktop app with real session data