### PR TITLE
fix: GitLab intake observer — nested group repo paths + multi-tracker wiring

### DIFF
--- a/backend/internal/adapters/tracker/gitlab/tracker_test.go
+++ b/backend/internal/adapters/tracker/gitlab/tracker_test.go
@@ -677,11 +677,11 @@ func TestTrackerIntakeConfig_ValidateRejectsUnknownProvider(t *testing.T) {
 	}
 }
 
-func TestTrackerIntakeConfig_WithDefaultsStillGitHub(t *testing.T) {
+func TestTrackerIntakeConfig_WithDefaultsLeavesProviderEmpty(t *testing.T) {
 	c := domain.TrackerIntakeConfig{Enabled: true, Assignee: "alice"}
 	c = c.WithDefaults()
-	if c.Provider != domain.TrackerProviderGitHub {
-		t.Fatalf("WithDefaults: Provider = %q, want %q", c.Provider, domain.TrackerProviderGitHub)
+	if c.Provider != "" {
+		t.Fatalf("WithDefaults: Provider = %q, want empty (inferred at use time)", c.Provider)
 	}
 }
 

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -330,9 +330,9 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	f.StringArrayVar(&opts.env, "env", nil, "Env var KEY=VALUE forwarded into sessions (repeatable)")
 	f.StringArrayVar(&opts.symlink, "symlink", nil, "Repo-relative path to symlink into workspaces (repeatable)")
 	f.StringArrayVar(&opts.postCreate, "post-create", nil, "Command to run after workspace creation (repeatable)")
-	f.BoolVar(&opts.trackerIntake, "tracker-intake", false, "Enable GitHub issue intake for matching issues")
-	f.StringVar(&opts.trackerRepo, "tracker-repo", "", "GitHub repo for issue intake (owner/repo; default: derive from git origin)")
-	f.StringVar(&opts.trackerAssignee, "tracker-assignee", "", "GitHub issue assignee required for intake eligibility")
+	f.BoolVar(&opts.trackerIntake, "tracker-intake", false, "Enable issue intake for matching issues (GitHub or GitLab; provider inferred from git origin)")
+	f.StringVar(&opts.trackerRepo, "tracker-repo", "", "Provider-native repo for issue intake (owner/repo or group/subgroup/repo; default: derive from git origin)")
+	f.StringVar(&opts.trackerAssignee, "tracker-assignee", "", "Issue assignee required for intake eligibility")
 	f.StringArrayVar(&opts.reviewers, "reviewer", nil, "Reviewer harness that reviews worker PRs (repeatable; e.g. claude-code)")
 	f.StringVar(&opts.configJSON, "config-json", "", "Full config as a JSON object (overrides field flags)")
 	f.BoolVar(&opts.clear, "clear", false, "Clear all config")
@@ -374,7 +374,6 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 		Orchestrator:      roleOverride{Agent: opts.orchestratorAgent},
 		TrackerIntake: trackerIntakeConfig{
 			Enabled:  opts.trackerIntake,
-			Provider: trackerProviderForFlags(opts),
 			Repo:     opts.trackerRepo,
 			Assignee: opts.trackerAssignee,
 		},
@@ -384,13 +383,6 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 		return projectConfig{}, usageError{errors.New("usage: provide at least one config flag, --config-json, or --clear")}
 	}
 	return cfg, nil
-}
-
-func trackerProviderForFlags(opts projectSetConfigOptions) string {
-	if opts.trackerIntake || opts.trackerRepo != "" || opts.trackerAssignee != "" {
-		return "github"
-	}
-	return ""
 }
 
 // reviewersForFlags turns repeated --reviewer harness values into the config

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -56,7 +56,8 @@ func TestProjectSetConfig_TrackerIntakeFlags(t *testing.T) {
 	if err := json.Unmarshal(capture.body, &got); err != nil {
 		t.Fatalf("decode request: %v\nbody=%s", err, capture.body)
 	}
-	if !got.Config.TrackerIntake.Enabled || got.Config.TrackerIntake.Provider != "github" || got.Config.TrackerIntake.Repo != "acme/demo" || got.Config.TrackerIntake.Assignee != "alice" {
+	// Provider is omitted: the daemon infers it from the project's git origin.
+	if !got.Config.TrackerIntake.Enabled || got.Config.TrackerIntake.Provider != "" || got.Config.TrackerIntake.Repo != "acme/demo" || got.Config.TrackerIntake.Assignee != "alice" {
 		t.Fatalf("tracker intake request = %#v", got.Config.TrackerIntake)
 	}
 }
@@ -93,7 +94,8 @@ func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.TrackerIntake.Enabled || got.TrackerIntake.Provider != "github" || got.TrackerIntake.Repo != "acme/demo" || got.TrackerIntake.Assignee != "alice" {
+	// Provider is omitted: the daemon infers it from the project's git origin.
+	if !got.TrackerIntake.Enabled || got.TrackerIntake.Provider != "" || got.TrackerIntake.Repo != "acme/demo" || got.TrackerIntake.Assignee != "alice" {
 		t.Fatalf("tracker intake config = %#v", got.TrackerIntake)
 	}
 }

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -285,7 +285,15 @@ func Run() error {
 		NewID:    uuid.NewString,
 	})
 
-	sessionSvc, reviewSvc, sessMgr, err := startSession(ctx, cfg, runtimeAdapter, store, lcStack.LCM, messenger, telemetrySink, agents, managedPreview, browserBroker, browserAuthority, chatLauncher{svc: chatSvc}, settingsSvc, log)
+	// Build the multi-tracker dispatching to both GitHub and GitLab once,
+	// shared between the session service and the intake observer below.
+	// Env-configured tokens are validated eagerly here; CLI credential probing
+	// (`gh auth token`) stays lazy inside the multi-tracker so boot is not
+	// blocked. May be nil (no usable credentials) — the session service's
+	// nil-guard and the intake resolver's backoff both tolerate that
+	// (issue #2685).
+	tracker := newMultiTracker(cfg.GitLab, log)
+	sessionSvc, reviewSvc, sessMgr, err := startSession(ctx, cfg, runtimeAdapter, store, lcStack.LCM, messenger, telemetrySink, agents, managedPreview, browserBroker, browserAuthority, chatLauncher{svc: chatSvc}, settingsSvc, tracker, log)
 	if err != nil {
 		stop()
 		lcStack.Stop()
@@ -309,7 +317,7 @@ func Run() error {
 		}
 		return err
 	}
-	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, newMultiTracker(cfg.GitLab, log), log)
+	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, tracker, log)
 
 	agentSvc := agentsvc.NewWithDeps(agentsvc.Deps{Cache: store, InventoryCache: store, Discoverer: modelcatalog.Discoverer{}, Projects: store, Sessions: store})
 	hostCommands := systemexec.Adapter{}

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -309,7 +309,7 @@ func Run() error {
 		}
 		return err
 	}
-	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, log)
+	lcStack.trackerDone = startTrackerIntake(ctx, store, sessionSvc, newMultiTracker(cfg.GitLab, log), log)
 
 	agentSvc := agentsvc.NewWithDeps(agentsvc.Deps{Cache: store, InventoryCache: store, Discoverer: modelcatalog.Discoverer{}, Projects: store, Sessions: store})
 	hostCommands := systemexec.Adapter{}

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -184,10 +184,13 @@ func (m sessionLifecycleMessenger) Send(ctx context.Context, id domain.SessionID
 
 // startSession builds the controller-facing session service: a session manager
 // over the selected runtime, routed git/scratch workspaces, the shared store +
-// LCM, the per-session agent resolver, and the agent messenger. The returned
-// service is mounted at httpd APIDeps.Sessions. It also returns the manager so
-// the caller can wire Reconcile into the boot sequence.
-func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.Runtime, store *sqlite.Store, lcm *lifecycle.Manager, messenger ports.AgentMessenger, telemetry ports.EventSink, agents ports.AgentResolver, previewLifecycle sessionmanager.PreviewLifecycle, browserLifecycle sessionmanager.BrowserLifecycle, browserCapabilities sessionmanager.BrowserCapabilityIssuer, chat sessionmanager.ChatLauncher, defaults sessionmanager.SessionModeDefaults, log *slog.Logger) (*sessionsvc.Service, reviewsvc.Manager, sessionLifecycle, error) {
+// LCM, the per-session agent resolver, and the agent messenger. The tracker is
+// built once by the caller (Run) and shared with the intake observer; it may
+// be nil (no usable credentials) — the service's nil-guard handles that
+// (issue #2685). The returned service is mounted at httpd APIDeps.Sessions.
+// It also returns the manager so the caller can wire Reconcile into the boot
+// sequence.
+func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.Runtime, store *sqlite.Store, lcm *lifecycle.Manager, messenger ports.AgentMessenger, telemetry ports.EventSink, agents ports.AgentResolver, previewLifecycle sessionmanager.PreviewLifecycle, browserLifecycle sessionmanager.BrowserLifecycle, browserCapabilities sessionmanager.BrowserCapabilityIssuer, chat sessionmanager.ChatLauncher, defaults sessionmanager.SessionModeDefaults, tracker ports.Tracker, log *slog.Logger) (*sessionsvc.Service, reviewsvc.Manager, sessionLifecycle, error) {
 	gitWS, err := gitworktree.New(gitworktree.Options{
 		// Per-session worktrees live under the data dir, so a single AO_DATA_DIR
 		// override moves all durable per-user state together.
@@ -230,12 +233,6 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		ReconcileWorkers:    startupReconcileWorkers,
 	})
 	scmProvider := newMultiSCMProvider(cfg.GitLab, log)
-	// Build the multi-tracker dispatching to both GitHub and GitLab. The
-	// multi-tracker returns a true nil ports.Tracker when no provider has
-	// usable credentials, preserving the `s.tracker == nil` guard in
-	// withIssueContext (issue #2685). When one provider's token is missing,
-	// the other still serves issue lookups.
-	tracker := newMultiTracker(cfg.GitLab, log)
 	sessionSvc := sessionsvc.NewWithDeps(sessionsvc.Deps{
 		Manager:           mgr,
 		Store:             store,

--- a/backend/internal/daemon/tracker_intake_wiring.go
+++ b/backend/internal/daemon/tracker_intake_wiring.go
@@ -2,131 +2,28 @@ package daemon
 
 import (
 	"context"
-	"errors"
 	"log/slog"
-	"strings"
-	"sync"
-	"time"
 
-	trackergithub "github.com/aoagents/agent-orchestrator/backend/internal/adapters/tracker/github"
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	trackerintake "github.com/aoagents/agent-orchestrator/backend/internal/observe/trackerintake"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
-// startTrackerIntake wires the opt-in GitHub issue-intake loop. The observer
-// always runs — Poll re-reads each project's config on every tick and skips
-// projects with intake disabled, so a project enabling intake after daemon
-// boot is picked up on the next tick without a restart. The adapter itself
-// stays lazy so daemon readiness is not blocked by credential probing or a gh
-// CLI call, and no token is resolved until some enabled project is actually
-// polled.
-func startTrackerIntake(ctx context.Context, store *sqlite.Store, sessions *sessionsvc.Service, logger *slog.Logger) <-chan struct{} {
+// startTrackerIntake wires the opt-in issue-intake loop. The observer always
+// runs — Poll re-reads each project's config on every tick and skips projects
+// with intake disabled, so a project enabling intake after daemon boot is
+// picked up on the next tick without a restart. The multi-tracker (supporting
+// both GitHub and GitLab) is built once and shared between the session service
+// and the intake observer.
+func startTrackerIntake(ctx context.Context, store *sqlite.Store, sessions *sessionsvc.Service, tracker ports.Tracker, logger *slog.Logger) <-chan struct{} {
+	// SingleTrackerResolver with an empty Provider matches any provider,
+	// letting the multi-tracker dispatch based on each project's configured
+	// provider. A nil tracker (no credentials) causes Resolve to return an
+	// error for every project, which triggers backoff — correct behavior.
 	resolver := trackerintake.SingleTrackerResolver{
-		Provider: domain.TrackerProviderGitHub,
-		Adapter:  newLazyGitHubTracker(logger),
+		Adapter: tracker,
 	}
 	observer := trackerintake.New(resolver, store, sessions, trackerintake.Config{Logger: logger})
 	return observer.Start(ctx)
-}
-
-// ---------------------------------------------------------------------------
-// GitHub lazy adapter (token sourced from env or gh CLI fallback)
-// ---------------------------------------------------------------------------
-
-type lazyGitHubTracker struct {
-	logger  *slog.Logger
-	tokens  *trackerTokenSource
-	mu      sync.Mutex
-	tracker ports.Tracker
-}
-
-func newLazyGitHubTracker(logger *slog.Logger) *lazyGitHubTracker {
-	return &lazyGitHubTracker{logger: logger, tokens: &trackerTokenSource{}}
-}
-
-func (t *lazyGitHubTracker) Get(ctx context.Context, id domain.TrackerID) (domain.Issue, error) {
-	tracker, err := t.resolve()
-	if err != nil {
-		return domain.Issue{}, err
-	}
-	return tracker.Get(ctx, id)
-}
-
-func (t *lazyGitHubTracker) List(ctx context.Context, repo domain.TrackerRepo, filter domain.ListFilter) ([]domain.Issue, error) {
-	tracker, err := t.resolve()
-	if err != nil {
-		return nil, err
-	}
-	return tracker.List(ctx, repo, filter)
-}
-
-func (t *lazyGitHubTracker) Preflight(ctx context.Context) error {
-	tracker, err := t.resolve()
-	if err != nil {
-		return err
-	}
-	return tracker.Preflight(ctx)
-}
-
-func (t *lazyGitHubTracker) resolve() (ports.Tracker, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.tracker != nil {
-		return t.tracker, nil
-	}
-	tracker, err := trackergithub.New(trackergithub.Options{Token: t.tokens})
-	if err != nil {
-		if errors.Is(err, trackergithub.ErrNoToken) && t.logger != nil {
-			t.logger.Warn("tracker intake disabled: no usable GitHub token", "err", err)
-		}
-		return nil, err
-	}
-	t.tracker = tracker
-	return tracker, nil
-}
-
-const (
-	trackerTokenCacheTTL       = 5 * time.Minute
-	trackerTokenCommandTimeout = 5 * time.Second
-)
-
-// trackerTokenSource mirrors the SCM credential precedence while returning the
-// tracker adapter's own ErrNoToken sentinel.
-type trackerTokenSource struct {
-	mu        sync.Mutex
-	token     string
-	expiresAt time.Time
-}
-
-func (s *trackerTokenSource) Token(ctx context.Context) (string, error) {
-	env := trackergithub.EnvTokenSource{EnvVars: []string{"AO_GITHUB_TOKEN"}}
-	if tok, err := env.Token(ctx); err == nil {
-		return tok, nil
-	} else if !errors.Is(err, trackergithub.ErrNoToken) {
-		return "", err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	now := time.Now()
-	if s.token != "" && now.Before(s.expiresAt) {
-		return s.token, nil
-	}
-	cmdCtx, cancel := context.WithTimeout(ctx, trackerTokenCommandTimeout)
-	defer cancel()
-	out, err := aoprocess.CommandContext(cmdCtx, "gh", "auth", "token").Output()
-	if err != nil {
-		return "", err
-	}
-	token := strings.TrimSpace(string(out))
-	if token == "" {
-		return "", trackergithub.ErrNoToken
-	}
-	s.token = token
-	s.expiresAt = now.Add(trackerTokenCacheTTL)
-	return token, nil
 }

--- a/backend/internal/daemon/tracker_intake_wiring.go
+++ b/backend/internal/daemon/tracker_intake_wiring.go
@@ -14,8 +14,8 @@ import (
 // runs — Poll re-reads each project's config on every tick and skips projects
 // with intake disabled, so a project enabling intake after daemon boot is
 // picked up on the next tick without a restart. The multi-tracker (supporting
-// both GitHub and GitLab) is built once and shared between the session service
-// and the intake observer.
+// both GitHub and GitLab) is built once in Run and shared between the session
+// service and the intake observer.
 func startTrackerIntake(ctx context.Context, store *sqlite.Store, sessions *sessionsvc.Service, tracker ports.Tracker, logger *slog.Logger) <-chan struct{} {
 	// SingleTrackerResolver with an empty Provider matches any provider,
 	// letting the multi-tracker dispatch based on each project's configured

--- a/backend/internal/daemon/tracker_wiring.go
+++ b/backend/internal/daemon/tracker_wiring.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"strings"
+	"sync"
+	"time"
 
 	scmgitlab "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/gitlab"
 	trackergithub "github.com/aoagents/agent-orchestrator/backend/internal/adapters/tracker/github"
@@ -11,10 +14,55 @@ import (
 	trackermulti "github.com/aoagents/agent-orchestrator/backend/internal/adapters/tracker/multi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 func newGitHubTracker() (ports.Tracker, error) {
-	return trackergithub.New(trackergithub.Options{Token: trackergithub.EnvTokenSource{EnvVars: []string{"AO_GITHUB_TOKEN"}}})
+	return trackergithub.New(trackergithub.Options{Token: &ghTokenSource{}})
+}
+
+// ghTokenSource mirrors the SCM credential precedence: AO_GITHUB_TOKEN →
+// GITHUB_TOKEN (via EnvTokenSource) → `gh auth token` CLI fallback with
+// short-lived caching. This matches the old lazyGitHubTracker's token chain
+// and the GitLab tracker's DefaultTokenSource (env → glab CLI).
+type ghTokenSource struct {
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+const (
+	ghTokenCacheTTL       = 5 * time.Minute
+	ghTokenCommandTimeout = 5 * time.Second
+)
+
+func (s *ghTokenSource) Token(ctx context.Context) (string, error) {
+	env := trackergithub.EnvTokenSource{EnvVars: []string{"AO_GITHUB_TOKEN"}}
+	if tok, err := env.Token(ctx); err == nil {
+		return tok, nil
+	} else if !errors.Is(err, trackergithub.ErrNoToken) {
+		return "", err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	if s.token != "" && now.Before(s.expiresAt) {
+		return s.token, nil
+	}
+	cmdCtx, cancel := context.WithTimeout(ctx, ghTokenCommandTimeout)
+	defer cancel()
+	out, err := aoprocess.CommandContext(cmdCtx, "gh", "auth", "token").Output()
+	if err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", trackergithub.ErrNoToken
+	}
+	s.token = token
+	s.expiresAt = now.Add(ghTokenCacheTTL)
+	return token, nil
 }
 
 // newGitLabTracker constructs a host-aware GitLab tracker. AllowedHosts and

--- a/backend/internal/daemon/tracker_wiring.go
+++ b/backend/internal/daemon/tracker_wiring.go
@@ -13,6 +13,7 @@ import (
 	trackergitlab "github.com/aoagents/agent-orchestrator/backend/internal/adapters/tracker/gitlab"
 	trackermulti "github.com/aoagents/agent-orchestrator/backend/internal/adapters/tracker/multi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
@@ -85,18 +86,30 @@ func newGitLabTracker(gitlabCfg config.GitLabConfig) (ports.Tracker, error) {
 }
 
 // newMultiTracker builds a multi-tracker dispatching to both GitHub and
-// GitLab sub-trackers. When one tracker fails to construct (missing token),
-// the other still serves issue lookups — the same degrade-gracefully pattern
-// used by newMultiSCMProvider. Returns nil when no tracker has usable
-// credentials; callers must tolerate a nil ports.Tracker (the session
-// service's nil-guard handles this).
+// GitLab sub-trackers. The daemon builds it once (in Run) and shares the
+// instance between the session service and the intake observer. A GitHub
+// token from the environment is validated eagerly at boot; without one, the
+// GitHub adapter stays lazy so the `gh auth token` CLI probe never blocks
+// daemon readiness — no CLI token is resolved until a session spawn or an
+// intake poll actually needs GitHub issue data (see lazyTracker). When one
+// tracker's token is missing, the other still serves issue lookups — the
+// same degrade-gracefully pattern used by newMultiSCMProvider. Callers must
+// tolerate a nil ports.Tracker (the session service's nil-guard handles
+// this).
 func newMultiTracker(gitlabCfg config.GitLabConfig, logger *slog.Logger) ports.Tracker {
 	var named []trackermulti.NamedTracker
 
-	if t, err := newGitHubTracker(); err != nil {
-		logTrackerDisabled(logger, "github", err)
+	// Probing the environment is a cheap read — no subprocess. Only when no
+	// env token exists do we defer to the gh CLI fallback, lazily.
+	env := trackergithub.EnvTokenSource{EnvVars: []string{"AO_GITHUB_TOKEN"}}
+	if _, err := env.Token(context.Background()); err == nil {
+		if t, err := newGitHubTracker(); err != nil {
+			logTrackerDisabled(logger, "github", err)
+		} else {
+			named = append(named, trackermulti.NamedTracker{Key: "github", Tracker: t})
+		}
 	} else {
-		named = append(named, trackermulti.NamedTracker{Key: "github", Tracker: t})
+		named = append(named, trackermulti.NamedTracker{Key: "github", Tracker: &lazyTracker{name: "github", logger: logger, build: newGitHubTracker}})
 	}
 
 	if t, err := newGitLabTracker(gitlabCfg); err != nil {
@@ -110,6 +123,65 @@ func newMultiTracker(gitlabCfg config.GitLabConfig, logger *slog.Logger) ports.T
 	}
 	return trackermulti.New(named...)
 }
+
+// lazyTracker defers adapter construction until the first tracker call, so
+// daemon readiness is not blocked by credential probing or a gh CLI call: no
+// token is resolved until a session spawn or an enabled project poll actually
+// needs issue data. Construction succeeds at most once; failures are not
+// cached, so a user who authenticates later (e.g. `gh auth login`) is picked
+// up without a daemon restart — the same retry semantics the old intake-only
+// lazyGitHubTracker had.
+type lazyTracker struct {
+	name   string
+	logger *slog.Logger
+	build  func() (ports.Tracker, error)
+
+	mu      sync.Mutex
+	tracker ports.Tracker
+}
+
+func (t *lazyTracker) Get(ctx context.Context, id domain.TrackerID) (domain.Issue, error) {
+	tracker, err := t.resolve()
+	if err != nil {
+		return domain.Issue{}, err
+	}
+	return tracker.Get(ctx, id)
+}
+
+func (t *lazyTracker) List(ctx context.Context, repo domain.TrackerRepo, filter domain.ListFilter) ([]domain.Issue, error) {
+	tracker, err := t.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return tracker.List(ctx, repo, filter)
+}
+
+func (t *lazyTracker) Preflight(ctx context.Context) error {
+	tracker, err := t.resolve()
+	if err != nil {
+		return err
+	}
+	return tracker.Preflight(ctx)
+}
+
+func (t *lazyTracker) resolve() (ports.Tracker, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.tracker != nil {
+		return t.tracker, nil
+	}
+	tracker, err := t.build()
+	if err != nil {
+		if t.logger != nil {
+			logTrackerDisabled(t.logger, t.name, err)
+		}
+		return nil, err
+	}
+	t.tracker = tracker
+	return tracker, nil
+}
+
+var _ ports.Tracker = (*lazyTracker)(nil)
 
 func logTrackerDisabled(logger *slog.Logger, provider string, err error) {
 	if errors.Is(err, trackergithub.ErrNoToken) || errors.Is(err, trackergitlab.ErrNoToken) {

--- a/backend/internal/daemon/tracker_wiring_test.go
+++ b/backend/internal/daemon/tracker_wiring_test.go
@@ -5,12 +5,16 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	trackergitlab "github.com/aoagents/agent-orchestrator/backend/internal/adapters/tracker/gitlab"
 	trackermulti "github.com/aoagents/agent-orchestrator/backend/internal/adapters/tracker/multi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 // TestNewGitLabTracker_PassesAllowedHosts verifies that AllowedHosts from
@@ -241,4 +245,124 @@ func TestNewMultiTracker_WithGitLabConfig(t *testing.T) {
 		t.Fatalf("expected *trackermulti.Tracker, got %T", tracker)
 	}
 	_ = mt // multi-tracker is non-nil and correctly typed
+}
+
+// ---------------------------------------------------------------------------
+// lazyTracker
+// ---------------------------------------------------------------------------
+
+type stubTracker struct{}
+
+func (stubTracker) Get(context.Context, domain.TrackerID) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+
+func (stubTracker) List(context.Context, domain.TrackerRepo, domain.ListFilter) ([]domain.Issue, error) {
+	return nil, nil
+}
+
+func (stubTracker) Preflight(context.Context) error { return nil }
+
+var _ ports.Tracker = stubTracker{}
+
+// TestLazyTracker_ConstructionDeferredAndStickyOnlyOnSuccess: build must not
+// run until the first tracker call; failures are not cached (a later
+// `gh auth login` is picked up without a restart); a successful construction
+// is reused.
+func TestLazyTracker_ConstructionDeferredAndStickyOnlyOnSuccess(t *testing.T) {
+	builds := 0
+	succeed := false
+	lt := &lazyTracker{
+		name:   "github",
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		build: func() (ports.Tracker, error) {
+			builds++
+			if !succeed {
+				return nil, errors.New("no token")
+			}
+			return stubTracker{}, nil
+		},
+	}
+
+	if builds != 0 {
+		t.Fatal("build ran before first tracker use")
+	}
+	if err := lt.Preflight(context.Background()); err == nil {
+		t.Fatal("Preflight err = nil, want build failure")
+	}
+	if builds != 1 {
+		t.Fatalf("builds = %d, want 1", builds)
+	}
+	if err := lt.Preflight(context.Background()); err == nil {
+		t.Fatal("Preflight err = nil, want build failure")
+	}
+	if builds != 2 {
+		t.Fatalf("builds = %d, want 2 (failures must not be sticky)", builds)
+	}
+
+	succeed = true
+	if err := lt.Preflight(context.Background()); err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if builds != 3 {
+		t.Fatalf("builds = %d, want 3", builds)
+	}
+	if err := lt.Preflight(context.Background()); err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	if builds != 3 {
+		t.Fatalf("builds = %d, want 3 (a successful construction must be reused)", builds)
+	}
+}
+
+// TestWiring_NewMultiTracker_DoesNotProbeGHCLIAtBoot is a regression test for
+// the laziness guarantee: with no env tokens configured, constructing the
+// multi-tracker must not spawn `gh auth token` — the CLI probe runs on first
+// tracker use, not at daemon boot.
+func TestWiring_NewMultiTracker_DoesNotProbeGHCLIAtBoot(t *testing.T) {
+	t.Setenv("AO_GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("AO_GITLAB_TOKEN", "")
+	t.Setenv("GITLAB_TOKEN", "")
+
+	marker := filepath.Join(t.TempDir(), "gh-called")
+	t.Setenv("GH_MARKER", marker)
+	binDir := t.TempDir()
+	writeRecordingGHExecutable(t, binDir)
+	// PATH contains only binDir: no real gh/glab can leak in. The GitLab leg
+	// fails to resolve `glab` and is omitted; the GitHub leg stays lazy.
+	t.Setenv("PATH", binDir)
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	tracker := newMultiTracker(config.GitLabConfig{}, log)
+	if tracker == nil {
+		t.Fatal("newMultiTracker = nil, want non-nil: the GitHub slot is lazily constructed and always present")
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("gh CLI invoked during newMultiTracker (marker exists); stat: %v", err)
+	}
+
+	// First use triggers the probe. It fails (fake gh exits 1) — the error is
+	// fine, the marker proves the probe happened now and not at boot.
+	_, _ = tracker.Get(context.Background(), domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#1"})
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("gh CLI not invoked on first tracker use; stat marker: %v", err)
+	}
+}
+
+// writeRecordingGHExecutable installs a fake `gh` that records every
+// invocation to $GH_MARKER and exits 1 (no token).
+func writeRecordingGHExecutable(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		content := "@echo off\r\necho called >> %GH_MARKER%\r\nexit /b 1\r\n"
+		if err := os.WriteFile(filepath.Join(dir, "gh.cmd"), []byte(content), 0o755); err != nil {
+			t.Fatalf("write fake gh.cmd: %v", err)
+		}
+		return
+	}
+	content := "#!/bin/sh\necho called >> \"$GH_MARKER\"\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
 }

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -409,6 +409,30 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	}
 }
 
+func TestGhTokenSourcePrefersAOGitHubToken(t *testing.T) {
+	t.Setenv("AO_GITHUB_TOKEN", "ao-token")
+	t.Setenv("GITHUB_TOKEN", "github-token")
+	token, err := (&ghTokenSource{}).Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "ao-token" {
+		t.Fatalf("token = %q, want AO_GITHUB_TOKEN", token)
+	}
+}
+
+func TestGhTokenSourceFallsBackToGITHUBToken(t *testing.T) {
+	t.Setenv("AO_GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "github-token")
+	token, err := (&ghTokenSource{}).Token(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "github-token" {
+		t.Fatalf("token = %q, want GITHUB_TOKEN", token)
+	}
+}
+
 type captureRuntimeSender struct {
 	handle  ports.RuntimeHandle
 	message string

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -393,7 +393,7 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	done := startTrackerIntake(ctx, store, svc, log)
+	done := startTrackerIntake(ctx, store, svc, newMultiTracker(config.GitLabConfig{}, log), log)
 
 	select {
 	case <-done:
@@ -409,17 +409,6 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	}
 }
 
-func TestTrackerTokenSourcePrefersAOGitHubToken(t *testing.T) {
-	t.Setenv("AO_GITHUB_TOKEN", "ao-token")
-	t.Setenv("GITHUB_TOKEN", "github-token")
-	token, err := (&trackerTokenSource{}).Token(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if token != "ao-token" {
-		t.Fatalf("token = %q, want AO_GITHUB_TOKEN", token)
-	}
-}
 
 type captureRuntimeSender struct {
 	handle  ports.RuntimeHandle

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -409,7 +409,6 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	}
 }
 
-
 type captureRuntimeSender struct {
 	handle  ports.RuntimeHandle
 	message string

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -212,7 +212,7 @@ func TestWiring_StartSessionBuildsSessionService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildAgentResolver: %v", err)
 	}
-	svc, reviewSvc, lc, err := startSession(context.Background(), cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, log)
+	svc, reviewSvc, lc, err := startSession(context.Background(), cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestWiring_StartSessionSpawnsScratchWithoutGitRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildAgentResolver: %v", err)
 	}
-	svc, _, _, err := startSession(context.Background(), cfg, runtime, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, log)
+	svc, _, _, err := startSession(context.Background(), cfg, runtime, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}
@@ -299,11 +299,13 @@ func TestWiring_StartSessionSpawnsScratchWithoutGitRepo(t *testing.T) {
 }
 
 // TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken is a regression test for
-// issue #2685: when no GitHub token is configured, startSession must wire a
-// true-nil ports.Tracker so Spawn's issue-context guard fires instead of
-// dereferencing a typed-nil *github.Tracker. The pre-fix wiring assigned the
-// typed-nil return of newGitHubTracker directly, and `ao spawn --issue` panicked
-// on the first lookup.
+// issue #2685: when no tracker credentials are configured, the session service
+// must tolerate a true-nil ports.Tracker so Spawn's issue-context guard fires
+// instead of dereferencing a typed-nil *github.Tracker. The pre-fix wiring
+// assigned the typed-nil return of newGitHubTracker directly, and
+// `ao spawn --issue` panicked on the first lookup. The multi-tracker is now
+// built once in Run and passed in (see newMultiTracker); this test exercises
+// the service-side nil-guard directly.
 func TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken(t *testing.T) {
 	t.Setenv("AO_GITHUB_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "")
@@ -328,7 +330,7 @@ func TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken(t *testing.T) {
 	if agentsErr != nil {
 		t.Fatalf("buildAgentResolver: %v", agentsErr)
 	}
-	svc, _, _, err := startSession(context.Background(), cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, log)
+	svc, _, _, err := startSession(context.Background(), cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}
@@ -387,7 +389,7 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	if agentsErr != nil {
 		t.Fatalf("buildAgentResolver: %v", agentsErr)
 	}
-	svc, _, _, err := startSession(context.Background(), cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, log)
+	svc, _, _, err := startSession(context.Background(), cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, agents, nil, nil, nil, nil, nil, nil, log)
 	if err != nil {
 		t.Fatalf("startSession: %v", err)
 	}
@@ -772,27 +774,22 @@ func (r *selectableRuntime) SendMessage(context.Context, ports.RuntimeHandle, st
 }
 
 // TestWiring_NewMultiTracker_NeverTypedNilWhenNoGitHubToken verifies the
-// typed-nil guard from issue #2685 at the multi-tracker wiring level. When
-// the GitHub tracker fails to construct (no token), newMultiTracker must
-// return either a true nil interface (when GitLab also has no token) or a
-// non-nil, usable ports.Tracker (when GitLab has a token via glab CLI). In
-// neither case may it return a typed-nil (non-nil interface wrapping a nil
-// pointer), which would bypass the session service's `tracker == nil` guard.
+// typed-nil guard from issue #2685 at the multi-tracker wiring level. With no
+// GitHub token the GitHub slot is lazily constructed, so newMultiTracker must
+// return a truly non-nil, usable ports.Tracker — never a typed-nil (non-nil
+// interface wrapping a nil pointer), which would bypass the session service's
+// `tracker == nil` guard and panic on first call.
 func TestWiring_NewMultiTracker_NeverTypedNilWhenNoGitHubToken(t *testing.T) {
 	t.Setenv("AO_GITHUB_TOKEN", "")
 	t.Setenv("GITHUB_TOKEN", "")
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	tracker := newMultiTracker(config.GitLabConfig{}, log)
-	// The key assertion: tracker is either truly nil or truly non-nil — never
-	// a typed-nil. Go's interface == nil check covers both cases correctly here
-	// because newMultiTracker returns a bare nil or a *trackermulti.Tracker.
 	if tracker == nil {
-		// Both trackers failed: expected when no glab CLI is available.
-		return
+		t.Fatal("newMultiTracker = nil, want non-nil: the GitHub slot is lazily constructed and always present")
 	}
-	// If GitLab succeeded via glab CLI, the tracker must be usable (not a
-	// typed-nil that panics on first call). A Preflight call should not panic.
+	// With no credentials the lazy GitHub adapter fails to resolve, so an
+	// error from Preflight is fine — it just must not panic.
 	_ = tracker.Preflight(context.Background())
 }
 

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -120,13 +120,42 @@ func TestProjectConfigWithDefaults(t *testing.T) {
 	}
 
 	got = (ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: "alice"}}).WithDefaults()
-	if got.TrackerIntake.Provider != TrackerProviderGitHub {
-		t.Fatalf("TrackerIntake.Provider = %q, want %q", got.TrackerIntake.Provider, TrackerProviderGitHub)
+	if got.TrackerIntake.Provider != "" {
+		t.Fatalf("TrackerIntake.Provider = %q, want empty (inferred at use time)", got.TrackerIntake.Provider)
 	}
 
 	got = (ProjectConfig{}).WithDefaults()
 	if got.TrackerIntake.Provider != "" {
 		t.Fatalf("disabled TrackerIntake.Provider = %q, want empty", got.TrackerIntake.Provider)
+	}
+}
+
+func TestInferTrackerProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoURL string
+		want    TrackerProvider
+	}{
+		{"empty", "", TrackerProviderGitHub},
+		{"https github", "https://github.com/acme/demo.git", TrackerProviderGitHub},
+		{"ssh github", "git@github.com:acme/demo.git", TrackerProviderGitHub},
+		{"ghe host", "https://ghe.corp.ghe.io/acme/demo.git", TrackerProviderGitHub},
+		{"github with port", "https://github.com:443/org/repo.git", TrackerProviderGitHub},
+		{"ssh github with port", "ssh://git@github.com:2222/org/repo.git", TrackerProviderGitHub},
+		{"https gitlab.com", "https://gitlab.com/group/repo.git", TrackerProviderGitLab},
+		{"ssh gitlab.com", "git@gitlab.com:group/repo.git", TrackerProviderGitLab},
+		{"self-managed gitlab", "https://gitlab.internal/group/repo.git", TrackerProviderGitLab},
+		{"ssh self-managed", "git@gitlab.internal:group/repo.git", TrackerProviderGitLab},
+		{"self-managed with port", "https://gitlab.local:8443/group/repo.git", TrackerProviderGitLab},
+		{"non-gitlab custom host", "https://dev.company.com/group/repo.git", TrackerProviderGitLab},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InferTrackerProvider(tt.repoURL)
+			if got != tt.want {
+				t.Errorf("InferTrackerProvider(%q) = %q, want %q", tt.repoURL, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/domain/tracker.go
+++ b/backend/internal/domain/tracker.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 )
 
@@ -112,22 +113,49 @@ type TrackerIntakeConfig struct {
 	Assignee string `json:"assignee,omitempty"`
 }
 
-// WithDefaults fills the provider only when intake is enabled. Disabled intake
-// leaves the zero value untouched so empty project configs still store as NULL.
+// WithDefaults leaves the provider empty when not explicitly set so the
+// caller can infer it from the project's repo origin URL at use time (see
+// InferTrackerProvider). Disabled intake leaves the zero value untouched so
+// empty project configs still store as NULL.
 func (c TrackerIntakeConfig) WithDefaults() TrackerIntakeConfig {
-	if c.Enabled && c.Provider == "" {
-		c.Provider = TrackerProviderGitHub
-	}
 	return c
 }
 
-// Validate rejects accidental broad intake and unknown providers.
+// InferTrackerProvider guesses the tracker provider from a repo origin URL.
+// GitHub hosts (github.com, *.github.com, *.ghe.io) map to github; any other
+// host maps to gitlab (self-managed GitLab uses arbitrary hostnames). The
+// empty-string fallback is github for backward compatibility.
+func InferTrackerProvider(repoURL string) TrackerProvider {
+	raw := strings.TrimSpace(repoURL)
+	if raw == "" {
+		return TrackerProviderGitHub
+	}
+	// SSH form git@host:path → normalise to https://host/path
+	if strings.HasPrefix(raw, "git@") {
+		if _, rest, ok := strings.Cut(raw, "@"); ok {
+			if host, path, ok := strings.Cut(rest, ":"); ok {
+				raw = "https://" + host + "/" + path
+			}
+		}
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return TrackerProviderGitHub
+	}
+	host := strings.TrimPrefix(strings.ToLower(parsed.Hostname()), "www.")
+	if host == "github.com" || strings.HasSuffix(host, ".github.com") || strings.HasSuffix(host, ".ghe.io") {
+		return TrackerProviderGitHub
+	}
+	return TrackerProviderGitLab
+}
+
+// Validate rejects accidental broad intake and unknown providers. An empty
+// provider is accepted here and inferred from the repo URL at use time.
 func (c TrackerIntakeConfig) Validate() error {
 	if !c.Enabled {
 		return nil
 	}
-	c = c.WithDefaults()
-	if c.Enabled && c.Provider != TrackerProviderGitHub && c.Provider != TrackerProviderGitLab {
+	if c.Provider != "" && c.Provider != TrackerProviderGitHub && c.Provider != TrackerProviderGitLab {
 		return fmt.Errorf("trackerIntake.provider: unsupported provider %q", c.Provider)
 	}
 	if err := validateNoWhitespaceField("trackerIntake.repo", c.Repo); err != nil {

--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -326,7 +326,7 @@ func truncateUTF8(s string, maxBytes int) string {
 func trackerRepo(project domain.ProjectRecord, cfg domain.TrackerIntakeConfig) (domain.TrackerRepo, bool) {
 	provider := cfg.Provider
 	if provider == "" {
-		provider = domain.TrackerProviderGitHub
+		provider = domain.InferTrackerProvider(project.RepoOriginURL)
 	}
 	native := strings.TrimSpace(cfg.Repo)
 	if native == "" {

--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -342,7 +342,7 @@ func parseRepoNative(remote string, provider domain.TrackerProvider) (string, bo
 	}
 	if strings.HasPrefix(remote, "git@") {
 		if _, rest, ok := strings.Cut(remote, ":"); ok {
-			return cleanRepoPath(rest), true
+			return cleanRepoPath(rest, provider), true
 		}
 		return "", false
 	}
@@ -350,14 +350,14 @@ func parseRepoNative(remote string, provider domain.TrackerProvider) (string, bo
 		if provider == domain.TrackerProviderGitHub {
 			host := strings.TrimPrefix(strings.ToLower(u.Host), "www.")
 			if host == "github.com" || strings.HasSuffix(host, ".github.com") || strings.HasSuffix(host, ".ghe.io") {
-				return cleanRepoPath(u.Path), true
+				return cleanRepoPath(u.Path, provider), true
 			}
 			return "", false
 		}
 		// GitLab: accept any host.
-		return cleanRepoPath(u.Path), true
+		return cleanRepoPath(u.Path, provider), true
 	}
-	return cleanRepoPath(remote), true
+	return cleanRepoPath(remote, provider), true
 }
 
 // repoHostFromOrigin extracts the host from the SCM origin URL for the given
@@ -396,15 +396,25 @@ func hostFromRemote(remote string) string {
 	return ""
 }
 
-func cleanRepoPath(path string) string {
+func cleanRepoPath(path string, provider domain.TrackerProvider) string {
 	path = strings.Trim(strings.TrimSpace(path), "/")
 	path = strings.TrimSuffix(path, ".git")
 	parts := strings.Split(path, "/")
 	if len(parts) < 2 {
 		return ""
 	}
-	// For nested namespaces (GitLab group/subgroup/repo), take the last two
-	// segments — the tracker's List endpoint only needs owner/repo.
+	// GitLab supports nested groups (group/subgroup/repo). The full namespace
+	// path is required for GraphQL's fullPath parameter and REST project lookups.
+	if provider == domain.TrackerProviderGitLab {
+		for _, p := range parts {
+			if strings.TrimSpace(p) == "" {
+				return ""
+			}
+		}
+		return strings.Join(parts, "/")
+	}
+	// GitHub: take the last two segments (owner/repo). Sub-path segments
+	// beyond owner/repo (e.g. blob/main) are ignored.
 	owner := strings.TrimSpace(parts[len(parts)-2])
 	repo := strings.TrimSpace(parts[len(parts)-1])
 	if owner == "" || repo == "" {

--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -252,7 +252,11 @@ func seenIssueIDs(sessions []domain.SessionRecord) map[domain.IssueID]bool {
 }
 
 // CanonicalIssueID stores tracker issue ids in sessions.issue_id with the
-// provider included, so future providers cannot collide on native ids.
+// provider included, so future providers cannot collide on native ids. For
+// GitLab self-managed instances the host is appended after '@' so issues
+// from different hosts with the same project path and iid are distinct
+// (e.g. gitlab.com/group/repo#7 vs gitlab.internal/group/repo#7). GitHub
+// and gitlab.com (zero-value host) produce the same format as before.
 func CanonicalIssueID(id domain.TrackerID) domain.IssueID {
 	provider := id.Provider
 	if provider == "" {
@@ -261,6 +265,10 @@ func CanonicalIssueID(id domain.TrackerID) domain.IssueID {
 	native := strings.TrimSpace(id.Native)
 	if native == "" {
 		return ""
+	}
+	host := strings.TrimSpace(id.Host)
+	if host != "" {
+		return domain.IssueID(string(provider) + ":" + native + "@" + host)
 	}
 	return domain.IssueID(string(provider) + ":" + native)
 }

--- a/backend/internal/observe/trackerintake/observer_test.go
+++ b/backend/internal/observe/trackerintake/observer_test.go
@@ -474,3 +474,120 @@ func TestTrackerRepoGitLabSelfManagedWithPort(t *testing.T) {
 		t.Errorf("Host = %q, want gitlab.local:8443", repo.Host)
 	}
 }
+
+func TestParseRepoNativeGitLabNestedGroup(t *testing.T) {
+	// GitLab nested group: full namespace path must be preserved.
+	tests := []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{
+			name:   "https nested group",
+			remote: "https://gitlab.com/group/subgroup/repo.git",
+			want:   "group/subgroup/repo",
+		},
+		{
+			name:   "ssh nested group",
+			remote: "git@gitlab.com:group/subgroup/repo.git",
+			want:   "group/subgroup/repo",
+		},
+		{
+			name:   "deeply nested",
+			remote: "https://gitlab.internal/org/team/sub/repo.git",
+			want:   "org/team/sub/repo",
+		},
+		{
+			name:   "simple two-segment",
+			remote: "https://gitlab.com/group/project.git",
+			want:   "group/project",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseRepoNative(tt.remote, domain.TrackerProviderGitLab)
+			if !ok {
+				t.Fatalf("parseRepoNative ok = false, want true")
+			}
+			if got != tt.want {
+				t.Errorf("parseRepoNative(%q, gitlab) = %q, want %q", tt.remote, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRepoNativeGitHubKeepsLastTwo(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{
+			name:   "https owner/repo",
+			remote: "https://github.com/acme/demo.git",
+			want:   "acme/demo",
+		},
+		{
+			name:   "ssh owner/repo",
+			remote: "git@github.com:acme/demo.git",
+			want:   "acme/demo",
+		},
+		{
+			name:   "ghe host",
+			remote: "https://ghe.corp.ghe.io/acme/demo.git",
+			want:   "acme/demo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseRepoNative(tt.remote, domain.TrackerProviderGitHub)
+			if !ok {
+				t.Fatalf("parseRepoNative ok = false, want true")
+			}
+			if got != tt.want {
+				t.Errorf("parseRepoNative(%q, github) = %q, want %q", tt.remote, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanRepoPathGitLabPreservesFullPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"group/subgroup/repo", "group/subgroup/repo"},
+		{"group/subgroup/repo.git", "group/subgroup/repo"},
+		{"/group/subgroup/repo/", "group/subgroup/repo"},
+		{"group/project", "group/project"},
+		{"single", ""},
+		{"", ""},
+		{"a/b/c/d/e", "a/b/c/d/e"},
+	}
+	for _, tt := range tests {
+		got := cleanRepoPath(tt.path, domain.TrackerProviderGitLab)
+		if got != tt.want {
+			t.Errorf("cleanRepoPath(%q, gitlab) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestCleanRepoPathGitHubLastTwoSegments(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"owner/repo", "owner/repo"},
+		{"owner/repo.git", "owner/repo"},
+		{"/owner/repo/", "owner/repo"},
+		{"a/b/c/d", "c/d"},
+		{"single", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := cleanRepoPath(tt.path, domain.TrackerProviderGitHub)
+		if got != tt.want {
+			t.Errorf("cleanRepoPath(%q, github) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/backend/internal/observe/trackerintake/observer_test.go
+++ b/backend/internal/observe/trackerintake/observer_test.go
@@ -591,3 +591,52 @@ func TestCleanRepoPathGitHubLastTwoSegments(t *testing.T) {
 		}
 	}
 }
+
+func TestCanonicalIssueIDGitLabHostDisambiguates(t *testing.T) {
+	tests := []struct {
+		name string
+		id   domain.TrackerID
+		want domain.IssueID
+	}{
+		{
+			name: "gitlab.com zero host",
+			id:   domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "group/repo#7"},
+			want: "gitlab:group/repo#7",
+		},
+		{
+			name: "self-managed host",
+			id:   domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "group/repo#7", Host: "gitlab.internal"},
+			want: "gitlab:group/repo#7@gitlab.internal",
+		},
+		{
+			name: "self-managed with port",
+			id:   domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "group/repo#7", Host: "gitlab.local:8443"},
+			want: "gitlab:group/repo#7@gitlab.local:8443",
+		},
+		{
+			name: "github no host",
+			id:   domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#12"},
+			want: "github:acme/demo#12",
+		},
+		{
+			name: "empty native",
+			id:   domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: ""},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalIssueID(tt.id)
+			if got != tt.want {
+				t.Errorf("CanonicalIssueID(%+v) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+
+	// The core assertion: same native, different hosts → different IDs.
+	dotCom := CanonicalIssueID(domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "group/repo#7"})
+	internal := CanonicalIssueID(domain.TrackerID{Provider: domain.TrackerProviderGitLab, Native: "group/repo#7", Host: "gitlab.internal"})
+	if dotCom == internal {
+		t.Fatalf("gitlab.com and self-managed with same native produced identical IssueID %q", dotCom)
+	}
+}

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -132,7 +132,7 @@ describe("CreateProjectAgentSheet", () => {
 		expect(onSubmit).toHaveBeenCalledWith({
 			workerAgent: "claude-code",
 			orchestratorAgent: "codex",
-			trackerIntake: { enabled: true, provider: "github", assignee: "octocat" },
+			trackerIntake: { enabled: true, assignee: "octocat" },
 		});
 	});
 

--- a/frontend/src/renderer/components/IntakeFields.tsx
+++ b/frontend/src/renderer/components/IntakeFields.tsx
@@ -19,10 +19,11 @@ export type IntakeForm = {
 	assignee: string;
 };
 
-// Only "github" is a valid TrackerIntakeConfig["provider"] today (see the
-// backend's openapi enum). Adding Linear/Jira later means: the backend enum
-// grows, IntakeFields gains a provider <Select> + per-provider scope fields,
-// and buildIntake switches the scope field it emits.
+// The provider is not set here — the daemon infers it from the project's repo
+// origin URL (github.com → github, any other host → gitlab). Adding
+// Linear/Jira later means: the backend enum grows, IntakeFields gains a
+// provider <Select> + per-provider scope fields, and buildIntake switches the
+// scope field it emits.
 
 // intakeNeedsRule mirrors the backend guard (TrackerIntakeConfig.Validate):
 // enabling intake requires an assignee so it cannot drain an entire issue
@@ -37,18 +38,19 @@ export function intakeNeedsRule(form: IntakeForm): boolean {
 export function buildIntake(form: IntakeForm): TrackerIntakeConfig | undefined {
 	const next: TrackerIntakeConfig = {
 		enabled: form.enabled || undefined,
-		provider: form.enabled ? "github" : undefined,
+		provider: undefined,
 		repo: form.repo.trim() || undefined,
 		assignee: form.assignee.trim() || undefined,
 	};
 	return Object.values(next).some((v) => v !== undefined) ? next : undefined;
 }
 
-// deriveGitHubRepo mirrors the daemon's parseGitHubRepoNative (observer.go):
-// derive "owner/repo" from a git origin URL for display only. The daemon does
-// the authoritative derivation server-side at poll time; this is purely so a
-// settings card can show which repo intake will actually poll.
-export function deriveGitHubRepo(remote?: string): string | undefined {
+// deriveRepoPath mirrors the daemon's server-side path derivation
+// (observe/trackerintake/observer.go): extract the provider-native repo path
+// from a git origin URL for display only. The daemon does the authoritative
+// derivation server-side at poll time; this is purely so a settings card can
+// show which repo intake will actually poll.
+export function deriveRepoPath(remote?: string): string | undefined {
 	const trimmed = remote?.trim();
 	if (!trimmed) return undefined;
 	let path: string | undefined;
@@ -67,9 +69,25 @@ export function deriveGitHubRepo(remote?: string): string | undefined {
 		.replace(/^\/+|\/+$/g, "")
 		.split("/");
 	if (parts.length < 2) return undefined;
-	const owner = parts[parts.length - 2].trim();
-	const repo = parts[parts.length - 1].trim();
-	return owner && repo ? `${owner}/${repo}` : undefined;
+	// Keep all segments: GitHub uses owner/repo (2 parts), GitLab uses the full
+	// namespace path (group/subgroup/repo).
+	return parts.join("/");
+}
+
+// deriveRepoHost extracts the host from a git origin URL for building repo
+// links. Returns undefined for SSH URLs without a parseable host.
+export function deriveRepoHost(remote?: string): string | undefined {
+	const trimmed = remote?.trim();
+	if (!trimmed) return undefined;
+	if (trimmed.startsWith("git@")) {
+		const afterAt = trimmed.split("@")[1];
+		return afterAt?.split(":")[0];
+	}
+	try {
+		return new URL(trimmed).host || undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 // IntakeFields renders the shared "Tracker intake" controls: an enable checkbox
@@ -78,7 +96,7 @@ export function deriveGitHubRepo(remote?: string): string | undefined {
 // however they like.
 //
 // repoPreview is only meaningful once a project exists and its git origin is
-// known: pass `{ show: true, value }` from settings to render the repo link
+// known: pass `{ value, host }` from settings to render the repo link
 // row, and omit it from the create sheet (the origin URL isn't available there,
 // and the daemon derives the repo regardless).
 export function IntakeFields({
@@ -92,7 +110,7 @@ export function IntakeFields({
 }: {
 	form: IntakeForm;
 	onChange: (patch: Partial<IntakeForm>) => void;
-	repoPreview?: { value?: string };
+	repoPreview?: { value?: string; host?: string };
 	// compact drops the descriptive/help prose and folds the explanation into an
 	// info-icon tooltip — used by the create-project sheet, which stays minimal.
 	compact?: boolean;
@@ -118,7 +136,7 @@ export function IntakeFields({
 							<SettingsRow label={t("settings.project.repository")}>
 								{repoPreview.value ? (
 									<a
-										href={`https://github.com/${repoPreview.value}`}
+										href={`https://${repoPreview.host ?? "github.com"}/${repoPreview.value}`}
 										target="_blank"
 										rel="noopener noreferrer"
 										className="settings-row-value text-settings-accent hover:underline"
@@ -187,7 +205,7 @@ export function IntakeFields({
 						<IntakeField label={t("settings.project.repository")} labelClassName={labelClassName}>
 							{repoPreview.value ? (
 								<a
-									href={`https://github.com/${repoPreview.value}`}
+									href={`https://${repoPreview.host ?? "github.com"}/${repoPreview.value}`}
 									target="_blank"
 									rel="noopener noreferrer"
 									className="text-control text-accent hover:underline"

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -363,6 +363,28 @@ describe("ProjectSettingsForm", () => {
 		expect(repoLink).toHaveAttribute("href", "https://github.com/acme/project-one");
 	});
 
+	it("renders self-managed GitLab nested-group remotes with host and full namespace", async () => {
+		mockProject({
+			id: "proj-1",
+			name: "Project One",
+			kind: "single_repo",
+			path: "/repo/project-one",
+			repo: "git@gitlab.company.com:eng/platform/agent-ops.git",
+			defaultBranch: "main",
+			config: {
+				worker: { agent: "codex" },
+				orchestrator: { agent: "claude-code" },
+			},
+		});
+
+		renderSettings();
+
+		const repoLink = await screen.findByRole("link", {
+			name: "git@gitlab.company.com:eng/platform/agent-ops.git",
+		});
+		expect(repoLink).toHaveAttribute("href", "https://gitlab.company.com/eng/platform/agent-ops");
+	});
+
 	it("renders ssh remotes as clickable https links", async () => {
 		mockProject({
 			id: "proj-1",
@@ -1350,7 +1372,6 @@ describe("ProjectSettingsForm", () => {
 		const body = putMock.mock.calls[0]?.[1]?.body;
 		expect(body.config.trackerIntake).toEqual({
 			enabled: true,
-			provider: "github",
 			assignee: "octocat",
 		});
 	});

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -28,7 +28,7 @@ import { captureRendererEvent } from "../lib/telemetry";
 import { type OrchestratorReplacementFailure, useUiStore } from "../stores/ui-store";
 import { newestActiveOrchestrator } from "../types/workspace";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
-import { buildIntake, deriveGitHubRepo, IntakeFields, type IntakeForm } from "./IntakeFields";
+import { buildIntake, deriveRepoPath, deriveRepoHost, IntakeFields, type IntakeForm } from "./IntakeFields";
 import { ProductExternalLink } from "./ProductExternalLink";
 import { ReviewerSelect, reviewerTrustWarning } from "./ReviewerSelect";
 import { AgentModelCombobox } from "./settings/AgentModelCombobox";
@@ -182,7 +182,7 @@ function SettingsBody({
 			intakeRepo: patch.repo ?? f.intakeRepo,
 			intakeAssignee: patch.assignee ?? f.intakeAssignee,
 		}));
-	const effectiveIntakeRepo = form.intakeRepo.trim() || deriveGitHubRepo(project.repo);
+	const effectiveIntakeRepo = form.intakeRepo.trim() || deriveRepoPath(project.repo);
 	const reviewerWarning = reviewerTrustWarning(form.reviewerHarness);
 	// Compared against the values this form opened with, so a save that leaves the
 	// review controls alone is not reported as a review decision.
@@ -603,7 +603,7 @@ function SettingsBody({
 								variant="settings"
 								form={intakeForm}
 								onChange={patchIntake}
-								repoPreview={{ value: effectiveIntakeRepo }}
+								repoPreview={{ value: effectiveIntakeRepo, host: deriveRepoHost(project.repo) }}
 							/>
 						</ProjectSettingsSection>
 					) : (

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1162,7 +1162,7 @@
 	"settings.project.intakeAssigneePlaceholder": "Benutzernamen eingeben oder * für alle",
 	"settings.project.intakeDescription": "Worker-Sitzungen automatisch aus passenden Tracker-Issues starten.",
 	"settings.project.intakeHelpAria": "Was bewirkt die Aktivierung des Issue-Intakes?",
-	"settings.project.intakeTooltip": "Startet automatisch eine Worker-Sitzung für jedes passende GitHub-Issue.",
+	"settings.project.intakeTooltip": "Startet automatisch eine Worker-Sitzung für jedes passende Tracker-Issue.",
 	"settings.migration.title": "Migration",
 	"settings.migration.description": "Projekte und Orchestrator-Sitzungen aus einer früheren Agent Orchestrator-Installation importieren. Ihre alten Dateien werden nie verändert, und dies kann sicher mehrmals ausgeführt werden.",
 	"settings.migration.statusLabel": "Status",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1180,7 +1180,7 @@
 	"settings.project.intakeAssigneePlaceholder": "type username or * for any",
 	"settings.project.intakeDescription": "Auto-spawn worker sessions from matching tracker issues.",
 	"settings.project.intakeHelpAria": "What does enabling issue intake do?",
-	"settings.project.intakeTooltip": "Auto-spawns a worker session for each matching GitHub issue.",
+	"settings.project.intakeTooltip": "Auto-spawns a worker session for each matching tracker issue.",
 	"settings.migration.title": "Migration",
 	"settings.migration.description": "Import projects and orchestrator sessions from an earlier Agent Orchestrator install. Your old files are never modified, and this is safe to run more than once.",
 	"settings.migration.statusLabel": "Status",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1174,7 +1174,7 @@
 	"settings.project.intakeAssigneePlaceholder": "escribe un nombre de usuario o * para cualquiera",
 	"settings.project.intakeDescription": "Crea automáticamente sesiones de trabajo a partir de issues del tracker coincidentes.",
 	"settings.project.intakeHelpAria": "¿Qué hace activar la captación de issues?",
-	"settings.project.intakeTooltip": "Crea automáticamente una sesión de trabajo por cada issue de GitHub coincidente.",
+	"settings.project.intakeTooltip": "Crea automáticamente una sesión de trabajo por cada issue del tracker coincidente.",
 	"settings.migration.title": "Migración",
 	"settings.migration.description": "Importa proyectos y sesiones del orquestador de una instalación anterior de Agent Orchestrator. Tus archivos antiguos nunca se modifican y es seguro ejecutarlo más de una vez.",
 	"settings.migration.statusLabel": "Estado",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1174,7 +1174,7 @@
 	"settings.project.intakeAssigneePlaceholder": "saisissez un nom d'utilisateur ou * pour n'importe lequel",
 	"settings.project.intakeDescription": "Crée automatiquement des sessions worker à partir des issues du tracker correspondantes.",
 	"settings.project.intakeHelpAria": "Que fait l'activation de l'intake des issues ?",
-	"settings.project.intakeTooltip": "Crée automatiquement une session worker pour chaque issue GitHub correspondante.",
+	"settings.project.intakeTooltip": "Crée automatiquement une session worker pour chaque issue du tracker correspondante.",
 	"settings.migration.title": "Migration",
 	"settings.migration.description": "Importez les projets et les sessions d'orchestrateur d'une installation antérieure d'Agent Orchestrator. Vos anciens fichiers ne sont jamais modifiés, et il est sûr d'exécuter cela plusieurs fois.",
 	"settings.migration.statusLabel": "État",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1162,7 +1162,7 @@
 	"settings.project.intakeAssigneePlaceholder": "ユーザー名を入力、または * ですべて",
 	"settings.project.intakeDescription": "一致するトラッカー Issue からワーカーセッションを自動起動します。",
 	"settings.project.intakeHelpAria": "Issue インテークを有効にするとどうなりますか？",
-	"settings.project.intakeTooltip": "一致する各 GitHub Issue に対してワーカーセッションを自動起動します。",
+	"settings.project.intakeTooltip": "一致する各Issueに対してワーカーセッションを自動起動します。",
 	"settings.migration.title": "移行",
 	"settings.migration.description": "以前の Agent Orchestrator インストールからプロジェクトとオーケストレーターセッションをインポートします。古いファイルは変更されず、何度実行しても安全です。",
 	"settings.migration.statusLabel": "ステータス",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1162,7 +1162,7 @@
 	"settings.project.intakeAssigneePlaceholder": "사용자 이름 입력, 또는 * 로 전체",
 	"settings.project.intakeDescription": "일치하는 트래커 이슈에서 워커 세션을 자동으로 시작합니다.",
 	"settings.project.intakeHelpAria": "이슈 인테이크를 사용하면 어떻게 되나요?",
-	"settings.project.intakeTooltip": "일치하는 각 GitHub 이슈에 대해 워커 세션을 자동으로 시작합니다.",
+	"settings.project.intakeTooltip": "일치하는 각 이슈에 대해 워커 세션을 자동으로 시작합니다.",
 	"settings.migration.title": "마이그레이션",
 	"settings.migration.description": "이전 Agent Orchestrator 설치에서 프로젝트와 오케스트레이터 세션을 가져옵니다. 이전 파일은 수정되지 않으며 여러 번 실행해도 안전합니다.",
 	"settings.migration.statusLabel": "상태",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1174,7 +1174,7 @@
 	"settings.project.intakeAssigneePlaceholder": "digite o nome de usuário ou * para qualquer",
 	"settings.project.intakeDescription": "Inicia sessões de worker automaticamente a partir de issues do tracker correspondentes.",
 	"settings.project.intakeHelpAria": "O que a ativação do intake de issues faz?",
-	"settings.project.intakeTooltip": "Inicia automaticamente uma sessão de worker para cada issue do GitHub correspondente.",
+	"settings.project.intakeTooltip": "Inicia automaticamente uma sessão de worker para cada issue do tracker correspondente.",
 	"settings.migration.title": "Migração",
 	"settings.migration.description": "Importe projetos e sessões do orchestrator de uma instalação anterior do Agent Orchestrator. Seus arquivos antigos nunca são modificados, e é seguro executar mais de uma vez.",
 	"settings.migration.statusLabel": "Status",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1163,7 +1163,7 @@
 	"settings.project.intakeAssigneePlaceholder": "输入用户名，或输入 * 以匹配任何人",
 	"settings.project.intakeDescription": "从匹配的跟踪器议题自动创建工作会话。",
 	"settings.project.intakeHelpAria": "启用议题接入有什么作用？",
-	"settings.project.intakeTooltip": "为每个匹配的 GitHub 议题自动创建一个工作会话。",
+	"settings.project.intakeTooltip": "为每个匹配的议题自动创建一个工作会话。",
 	"settings.migration.title": "迁移",
 	"settings.migration.description": "从旧版 Agent Orchestrator 安装中导入项目和编排器会话。旧文件绝不会被修改，并且可以安全地重复运行。",
 	"settings.migration.statusLabel": "状态",


### PR DESCRIPTION
## What

Fixes GitLab issue intake: nested group repo paths are now preserved, and the intake observer uses the multi-tracker (GitHub + GitLab) instead of a GitHub-only adapter. Also restores the `gh auth token` CLI fallback for the GitHub tracker that was accidentally dropped during the wiring refactor.

## Why

Two issues prevented GitLab issue intake from working:

1. **Nested group paths truncated** — `cleanRepoPath` took only the last two path segments (same as GitHub), dropping the full namespace for nested groups like `group/subgroup/repo`. GitLab API lookups failed with 404.

2. **Intake observer hardcoded to GitHub** — `startTrackerIntake` wired a `SingleTrackerResolver` with a GitHub-only lazy adapter. Projects with `provider: "gitlab"` always failed with "no adapter for provider gitlab" and entered an endless failure-backoff loop.

## How

- `cleanRepoPath` now takes a `provider` argument. For GitLab it preserves the full namespace path; for GitHub it keeps the last-two-segment behavior.
- `startTrackerIntake` now accepts a `ports.Tracker` and is wired with `newMultiTracker` (GitHub + GitLab), matching the session service's existing pattern. The `SingleTrackerResolver` uses an empty `Provider` so the multi-tracker dispatches by each project's configured provider.
- The GitHub tracker token source restores the full fallback chain (`AO_GITHUB_TOKEN` → `GITHUB_TOKEN` → `gh auth token` CLI with 5-min cache), mirroring the GitLab tracker's `DefaultTokenSource` (env → `glab` CLI).

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/daemon/...` passes
- [x] `go test ./internal/observe/trackerintake/...` passes
- [x] Manual verification: daemon with GitLab intake config successfully polls GitLab API, finds assigned issues, and spawns worker sessions

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)

Co-Authored-By: Kimchi <noreply@kimchi.dev>