### PR TITLE
fix(browser): preserve annotation drafts across reloads

### DIFF
--- a/frontend/src/annotate-preload.test.ts
+++ b/frontend/src/annotate-preload.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { BrowserAnnotationPageSubmitPayload } from "./shared/browser-annotations";
+import type { BrowserAnnotationDraft, BrowserAnnotationPageSubmitPayload } from "./shared/browser-annotations";
 
 const electronMocks = vi.hoisted(() => {
 	const listeners = new Map<string, (...args: unknown[]) => void>();
@@ -55,10 +55,10 @@ type Bounds = {
 	height: number;
 };
 
-function setAnnotationMode(enabled: boolean): void {
+function setAnnotationMode(enabled: boolean, draft?: BrowserAnnotationDraft): void {
 	const listener = electronMocks.listeners.get("browser:annotation:setMode");
 	if (!listener) throw new Error("annotation mode listener was not registered");
-	listener({}, { enabled });
+	listener({}, { enabled, ...(draft ? { draft } : {}) });
 }
 
 function elementWithBounds(id: string, bounds: Bounds): HTMLButtonElement {
@@ -389,6 +389,66 @@ describe("annotate preload", () => {
 
 		expect(electronMocks.send).toHaveBeenCalledWith("browser:annotation:cancel", { reason: "escape" });
 		expect(document.querySelector("[data-ao-annotation-root]")).toBeNull();
+	});
+
+	it("restores a replacement draft even when annotation mode is already enabled", async () => {
+		const first = elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		dispatchPageEvent(first, "click");
+		const draft: BrowserAnnotationDraft = {
+			instruction: "Restored while already enabled",
+			selection: {
+				kind: "element",
+				context: {
+					url: window.location.href,
+					tag: "button",
+					classes: [],
+					selector: "button#first",
+					size: { width: 120, height: 40 },
+					computedStyle: {},
+				},
+			},
+		};
+
+		setAnnotationMode(true, draft);
+
+		expect(overlayRoot().querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(draft.instruction);
+		const payload = await submitPrompt(draft.instruction);
+		expect(payload.selection).toEqual(draft.selection);
+	});
+
+	it("uses the composer-only fallback unless every multi-selection selector resolves uniquely", async () => {
+		elementWithBounds("first", { left: 12, top: 24, width: 120, height: 40 });
+		const draft: BrowserAnnotationDraft = {
+			instruction: "Keep every original target",
+			selection: {
+				kind: "elements",
+				contexts: [
+					{
+						url: window.location.href,
+						tag: "button",
+						classes: [],
+						selector: "button#first",
+						size: { width: 120, height: 40 },
+						computedStyle: {},
+					},
+					{
+						url: window.location.href,
+						tag: "button",
+						classes: [],
+						selector: "button#missing",
+						size: { width: 80, height: 30 },
+						computedStyle: {},
+					},
+				],
+			},
+		};
+
+		setAnnotationMode(true, draft);
+
+		expect(selectionBoxes()).toHaveLength(0);
+		expect(overlayRoot().querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(draft.instruction);
+		const payload = await submitPrompt(draft.instruction);
+		expect(payload.selection).toEqual(draft.selection);
 	});
 
 	it("reflows and repositions an open prompt when the browser viewport narrows", () => {

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -41,13 +41,18 @@ window.addEventListener("beforeunload", () => {
 });
 
 function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason, draft?: BrowserAnnotationDraft): void {
-	if (enabled === next) return;
+	if (enabled === next) {
+		if (next && draft) {
+			resetSelectionState();
+			cleanupOverlay();
+			ensureOverlay();
+			renderHint();
+			restoreDraft(draft);
+		}
+		return;
+	}
 	enabled = next;
-	selectedElement = null;
-	selectedContext = null;
-	multiSelectActive = false;
-	multiSelectElements = [];
-	multiSelectContexts = null;
+	resetSelectionState();
 	if (hintFadeTimer) clearTimeout(hintFadeTimer);
 	if (enabled) {
 		ensureOverlay();
@@ -59,6 +64,14 @@ function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason, 
 		cleanupOverlay();
 		if (cancelReason !== "disabled") sendCancel(cancelReason);
 	}
+}
+
+function resetSelectionState(): void {
+	selectedElement = null;
+	selectedContext = null;
+	multiSelectActive = false;
+	multiSelectElements = [];
+	multiSelectContexts = null;
 }
 
 function installListeners(): void {
@@ -614,8 +627,9 @@ function restoreDraft(draft: BrowserAnnotationDraft): void {
 			return;
 		}
 	} else {
-		const elements = draft.selection.contexts.map(resolveDraftElement).filter((item): item is Element => Boolean(item));
-		if (elements.length > 0) {
+		const resolved = draft.selection.contexts.map(resolveDraftElement);
+		if (resolved.every((item): item is Element => item !== null)) {
+			const elements = resolved;
 			multiSelectElements = elements;
 			multiSelectContexts = draft.selection.contexts;
 			renderMultiSelections();
@@ -631,7 +645,8 @@ function restoreDraft(draft: BrowserAnnotationDraft): void {
 
 function resolveDraftElement(context: BrowserAnnotationContext): Element | null {
 	try {
-		return document.querySelector(context.selector);
+		const matches = document.querySelectorAll(context.selector);
+		return matches.length === 1 ? matches[0] : null;
 	} catch {
 		return null;
 	}

--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -5,6 +5,8 @@ import {
 	createBrowserAnnotationContext,
 	type BrowserAnnotationCancelReason,
 	type BrowserAnnotationContext,
+	type BrowserAnnotationDraft,
+	type BrowserAnnotationPageMode,
 	type BrowserAnnotationPageSubmitPayload,
 } from "./shared/browser-annotations";
 import { promptPositionForRect, type AnnotationRectLike } from "./shared/browser-annotation-overlay";
@@ -29,17 +31,16 @@ const TEXTAREA_MIN_HEIGHT = 32;
 const MARKDOWN_ANNOTATION_TARGETS =
 	"h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, pre, table, th, td, figure, figcaption, img, hr, details, summary";
 
-ipcRenderer.on("browser:annotation:setMode", (_event, input: { enabled?: boolean }) => {
-	setEnabled(Boolean(input?.enabled), "disabled");
+ipcRenderer.on("browser:annotation:setMode", (_event, input: BrowserAnnotationPageMode) => {
+	setEnabled(Boolean(input?.enabled), "disabled", input?.draft);
 });
 
 window.addEventListener("beforeunload", () => {
-	if (enabled) sendCancel("navigation");
 	cleanupOverlay();
 	enabled = false;
 });
 
-function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason): void {
+function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason, draft?: BrowserAnnotationDraft): void {
 	if (enabled === next) return;
 	enabled = next;
 	selectedElement = null;
@@ -52,6 +53,7 @@ function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason):
 		ensureOverlay();
 		installListeners();
 		renderHint();
+		if (draft) restoreDraft(draft);
 	} else {
 		removeListeners();
 		cleanupOverlay();
@@ -115,7 +117,12 @@ function handleClick(event: MouseEvent): void {
 	}
 	selectedElement = target;
 	selectedContext = createBrowserAnnotationContext(target);
-	renderPrompt(target, selectedContext);
+	const draft: BrowserAnnotationDraft = {
+		instruction: "",
+		selection: { kind: "element", context: selectedContext },
+	};
+	sendDraft(draft);
+	renderPrompt(target, selectedContext, "");
 }
 
 function handleKeyDown(event: KeyboardEvent): void {
@@ -154,6 +161,11 @@ function finishMultiSelect(): void {
 		return;
 	}
 	multiSelectContexts = multiSelectElements.map(createBrowserAnnotationContext);
+	const draft: BrowserAnnotationDraft = {
+		instruction: "",
+		selection: { kind: "elements", contexts: multiSelectContexts },
+	};
+	sendDraft(draft);
 	renderMultiPrompt(multiSelectElements, multiSelectContexts);
 }
 
@@ -506,12 +518,12 @@ function renderMultiSelections(): void {
 	}
 }
 
-function renderPrompt(element: Element, context: BrowserAnnotationContext): void {
+function renderPrompt(element: Element, context: BrowserAnnotationContext, instruction = ""): void {
 	renderHighlight(element, true);
 	openPrompt(element.getBoundingClientRect(), (instruction) => ({
 		instruction,
 		selection: { kind: "element", context },
-	}));
+	}), instruction);
 }
 
 function renderMultiPrompt(elements: Element[], contexts: BrowserAnnotationContext[]): void {
@@ -519,12 +531,13 @@ function renderMultiPrompt(elements: Element[], contexts: BrowserAnnotationConte
 	openPrompt(unionRect(elements), (instruction) => ({
 		instruction,
 		selection: { kind: "elements", contexts },
-	}));
+	}), "");
 }
 
 function openPrompt(
 	rect: AnnotationRectLike,
 	buildPayload: (instruction: string) => BrowserAnnotationPageSubmitPayload,
+	instruction: string,
 ): void {
 	const root = ensureOverlay();
 	const mount = root.querySelector<HTMLDivElement>(".mount");
@@ -543,6 +556,7 @@ function openPrompt(
 	const form = mount.querySelector<HTMLFormElement>("form")!;
 	repositionPrompt(rect);
 	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
+	textarea.value = instruction;
 	const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
 	const updateSubmitState = (): void => {
 		submitButton.disabled = textarea.value.trim().length === 0;
@@ -572,7 +586,11 @@ function openPrompt(
 		event.preventDefault();
 		submitAnnotation();
 	});
-	textarea.addEventListener("input", updateSubmitState);
+	textarea.addEventListener("input", () => {
+		updateSubmitState();
+		sendDraft(buildPayload(textarea.value));
+	});
+	updateSubmitState();
 	textarea.addEventListener("keydown", (event) => {
 		event.stopPropagation();
 		if (event.key === "Escape") {
@@ -584,6 +602,39 @@ function openPrompt(
 		}
 	});
 	setTimeout(() => textarea.focus(), 0);
+}
+
+function restoreDraft(draft: BrowserAnnotationDraft): void {
+	if (draft.selection.kind === "element") {
+		const element = resolveDraftElement(draft.selection.context);
+		if (element) {
+			selectedElement = element;
+			selectedContext = draft.selection.context;
+			renderPrompt(element, draft.selection.context, draft.instruction);
+			return;
+		}
+	} else {
+		const elements = draft.selection.contexts.map(resolveDraftElement).filter((item): item is Element => Boolean(item));
+		if (elements.length > 0) {
+			multiSelectElements = elements;
+			multiSelectContexts = draft.selection.contexts;
+			renderMultiSelections();
+			openPrompt(unionRect(elements), (instruction) => ({ instruction, selection: draft.selection }), draft.instruction);
+			return;
+		}
+	}
+	openPrompt({ left: 14, top: 14, bottom: 14 }, (instruction) => ({
+		instruction,
+		selection: draft.selection,
+	}), draft.instruction);
+}
+
+function resolveDraftElement(context: BrowserAnnotationContext): Element | null {
+	try {
+		return document.querySelector(context.selector);
+	} catch {
+		return null;
+	}
 }
 
 function currentViewport(): { width: number; height: number } {
@@ -678,6 +729,10 @@ function cleanupOverlay(): void {
 
 function sendCancel(reason: BrowserAnnotationCancelReason): void {
 	ipcRenderer.send("browser:annotation:cancel", { reason });
+}
+
+function sendDraft(draft: BrowserAnnotationDraft): void {
+	ipcRenderer.send("browser:annotation:draft", draft);
 }
 
 function isOverlayEvent(event: Event): boolean {

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -1907,6 +1907,40 @@ describe("browser annotation IPC", () => {
 		expect(webContents.focus).not.toHaveBeenCalled();
 	});
 
+	it("preserves and restores an unfinished annotation when the toolbar reloads the page", async () => {
+		const { invoke, send, sent, webContents, webContentsListeners } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		const draft = {
+			instruction: "Keep this text after refresh",
+			selection: {
+				kind: "element" as const,
+				context: {
+					url: "http://localhost:4173/",
+					tag: "button",
+					classes: [],
+					selector: "button#save",
+					size: { width: 80, height: 30 },
+					computedStyle: {},
+				},
+			},
+		};
+		send("browser:annotation:draft", 99, draft);
+		webContents.send.mockClear();
+
+		await invoke("browser:reload", "1:sess-1");
+		webContentsListeners.get("did-start-loading")?.();
+		webContentsListeners.get("did-stop-loading")?.();
+
+		expect(webContents.reload).toHaveBeenCalledOnce();
+		expect(sent).not.toContainEqual({
+			channel: "browser:annotation:canceled",
+			payload: expect.anything(),
+		});
+		expect(webContents.send).toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true, draft });
+	});
+
 	it("forwards a single-element preview annotation submission to the renderer-owned view", async () => {
 		const { invoke, invokeFromTab, sent } = setupHost();
 		await invoke("browser:ensure", "sess-1");

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -1873,7 +1873,13 @@ describe("browser:setBounds", () => {
 			visible: true,
 		});
 
-		webContentsListeners.get("did-fail-load")?.({} as never, -105 as never, "Name not resolved" as never);
+		webContentsListeners.get("did-fail-load")?.(
+			{} as never,
+			-105 as never,
+			"Name not resolved" as never,
+			"http://localhost:4173/" as never,
+			true as never,
+		);
 		expect(view.setVisible).toHaveBeenLastCalledWith(false);
 
 		view.setBounds.mockClear();
@@ -1948,6 +1954,22 @@ describe("browser annotation IPC", () => {
 		expect(webContents.focus).toHaveBeenCalledOnce();
 	});
 
+	it("re-enables annotation picking after a reload before any element is selected", async () => {
+		const { invoke, sent, webContents, webContentsListeners } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		webContents.send.mockClear();
+		webContents.focus.mockClear();
+
+		await invoke("browser:reload", "1:sess-1");
+		webContentsListeners.get("did-stop-loading")?.();
+
+		expect(sent).not.toContainEqual({ channel: "browser:annotation:canceled", payload: expect.anything() });
+		expect(webContents.send).toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true });
+		expect(webContents.focus).toHaveBeenCalledOnce();
+	});
+
 	it("preserves a draft when the same URL is submitted again by preview revision or the address bar", async () => {
 		const { invoke, send, sent, webContents, webContentsListeners } = setupHost();
 		await invoke("browser:ensure", "sess-1");
@@ -2004,9 +2026,37 @@ describe("browser annotation IPC", () => {
 
 		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
 		send("browser:annotation:draft", 99, annotationDraft());
-		webContentsListeners.get("did-fail-load")?.({} as never, -105 as never, "Name not resolved" as never);
+		webContentsListeners.get("did-fail-load")?.(
+			{} as never,
+			-105 as never,
+			"Name not resolved" as never,
+			"http://localhost:4173/" as never,
+			true as never,
+		);
 
 		expect(sent.filter(({ channel }) => channel === "browser:annotation:canceled")).toHaveLength(2);
+	});
+
+	it("keeps a top-level draft when a subframe load fails", async () => {
+		const { invoke, send, sent, webContents, webContentsListeners } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		const draft = annotationDraft();
+		send("browser:annotation:draft", 99, draft);
+		webContents.send.mockClear();
+
+		webContentsListeners.get("did-fail-load")?.(
+			{} as never,
+			-105 as never,
+			"Iframe name not resolved" as never,
+			"http://invalid.test/frame" as never,
+			false as never,
+		);
+		webContentsListeners.get("did-stop-loading")?.();
+
+		expect(sent).not.toContainEqual({ channel: "browser:annotation:canceled", payload: expect.anything() });
+		expect(webContents.send).toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true, draft });
 	});
 
 	it("forwards a single-element preview annotation submission to the renderer-owned view", async () => {

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -10,6 +10,7 @@ import {
 	scaleBoundsForZoom,
 } from "./browser-view-host";
 import { NEW_SESSION_SHORTCUT_CHANNEL } from "../shared/shortcuts";
+import type { BrowserAnnotationDraft } from "../shared/browser-annotations";
 import { parseAgentBrowserJSON } from "./agent-browser-runtime";
 
 vi.mock("electron", async (importOriginal) => {
@@ -19,6 +20,23 @@ vi.mock("electron", async (importOriginal) => {
 
 type InvokeHandler = (event: unknown, ...args: unknown[]) => unknown;
 type EventHandler = (event: { sender: { id: number; getZoomFactor?: () => number } }, ...args: unknown[]) => unknown;
+
+function annotationDraft(url = "http://localhost:4173/"): BrowserAnnotationDraft {
+	return {
+		instruction: "Keep this text after refresh",
+		selection: {
+			kind: "element",
+			context: {
+				url,
+				tag: "button",
+				classes: [],
+				selector: "button#save",
+				size: { width: 80, height: 30 },
+				computedStyle: {},
+			},
+		},
+	};
+}
 
 function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").AgentBrowserRuntime) {
 	let currentURL = "";
@@ -1912,22 +1930,10 @@ describe("browser annotation IPC", () => {
 		await invoke("browser:ensure", "sess-1");
 		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
 		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
-		const draft = {
-			instruction: "Keep this text after refresh",
-			selection: {
-				kind: "element" as const,
-				context: {
-					url: "http://localhost:4173/",
-					tag: "button",
-					classes: [],
-					selector: "button#save",
-					size: { width: 80, height: 30 },
-					computedStyle: {},
-				},
-			},
-		};
+		const draft = annotationDraft();
 		send("browser:annotation:draft", 99, draft);
 		webContents.send.mockClear();
+		webContents.focus.mockClear();
 
 		await invoke("browser:reload", "1:sess-1");
 		webContentsListeners.get("did-start-loading")?.();
@@ -1939,6 +1945,68 @@ describe("browser annotation IPC", () => {
 			payload: expect.anything(),
 		});
 		expect(webContents.send).toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true, draft });
+		expect(webContents.focus).toHaveBeenCalledOnce();
+	});
+
+	it("preserves a draft when the same URL is submitted again by preview revision or the address bar", async () => {
+		const { invoke, send, sent, webContents, webContentsListeners } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		const draft = annotationDraft();
+		send("browser:annotation:draft", 99, draft);
+		webContents.send.mockClear();
+
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
+		webContentsListeners.get("did-stop-loading")?.();
+
+		expect(sent).not.toContainEqual({ channel: "browser:annotation:canceled", payload: expect.anything() });
+		expect(webContents.send).toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true, draft });
+	});
+
+	it("cancels a draft when a page-driven main-frame navigation targets another document", async () => {
+		const { invoke, send, sent, webContents, webContentsListeners } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		send("browser:annotation:draft", 99, annotationDraft());
+		webContents.send.mockClear();
+
+		webContentsListeners.get("will-navigate")?.(
+			{ preventDefault: vi.fn() } as never,
+			"http://localhost:4173/another-page" as never,
+		);
+		webContentsListeners.get("did-stop-loading")?.();
+
+		expect(sent).toContainEqual({
+			channel: "browser:annotation:canceled",
+			payload: { viewId: "1:sess-1", reason: "navigation" },
+		});
+		expect(webContents.send).not.toHaveBeenCalledWith(
+			"browser:annotation:setMode",
+			expect.objectContaining({ enabled: true }),
+		);
+	});
+
+	it("clears a draft when a reload is stopped or fails", async () => {
+		const { invoke, send, sent, webContentsListeners } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:4173/" });
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		send("browser:annotation:draft", 99, annotationDraft());
+
+		await invoke("browser:stop", "1:sess-1");
+
+		expect(sent).toContainEqual({
+			channel: "browser:annotation:canceled",
+			payload: { viewId: "1:sess-1", reason: "navigation" },
+		});
+
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+		send("browser:annotation:draft", 99, annotationDraft());
+		webContentsListeners.get("did-fail-load")?.({} as never, -105 as never, "Name not resolved" as never);
+
+		expect(sent.filter(({ channel }) => channel === "browser:annotation:canceled")).toHaveLength(2);
 	});
 
 	it("forwards a single-element preview annotation submission to the renderer-owned view", async () => {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -1975,14 +1975,17 @@ function wireNavEvents(
 		update();
 	});
 	contents.on("did-stop-loading", () => {
-		if (entry.annotationEnabled && entry.annotationDraft) {
-			contents.send("browser:annotation:setMode", { enabled: true, draft: entry.annotationDraft });
+		if (entry.annotationEnabled) {
+			contents.send("browser:annotation:setMode", {
+				enabled: true,
+				...(entry.annotationDraft ? { draft: entry.annotationDraft } : {}),
+			});
 			contents.focus();
 		}
 		update();
 	});
-	contents.on("did-fail-load", (_event, errorCode, errorDescription) => {
-		if (errorCode === -3) return;
+	contents.on("did-fail-load", (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+		if (!isMainFrame || errorCode === -3) return;
 		cancelAnnotation(options, entry, "navigation");
 		if (isActive()) entry.view.setVisible?.(false);
 		entry.state = { ...readNavState(entry), error: String(errorDescription || "Unable to load page") };

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -13,6 +13,7 @@ import { randomUUID } from "node:crypto";
 import type {
 	BrowserAnnotationCancelPayload,
 	BrowserAnnotationContext,
+	BrowserAnnotationDraft,
 	BrowserAnnotationModeInput,
 	BrowserAnnotationPageCancelPayload,
 	BrowserAnnotationPageSubmitPayload,
@@ -266,6 +267,7 @@ type BrowserEntry = {
 	ready: Promise<void>;
 	state: BrowserNavState;
 	annotationEnabled: boolean;
+	annotationDraft: BrowserAnnotationDraft | null;
 	networkCapture?: BrowserNetworkCapture;
 	favicon?: string;
 	// URL of the favicon currently applied to `favicon` (fetch succeeded).
@@ -554,6 +556,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			ready: Promise.resolve(),
 			state,
 			annotationEnabled: false,
+			annotationDraft: null,
 		};
 		session.tabs.set(tabId, entry);
 		tabsByWebContentsId.set(view.webContents.id, entry);
@@ -1235,12 +1238,15 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		viewId: string,
 		action: (contents: BrowserWebContents) => void,
 		cancelForNavigation = false,
+		reapplyBounds = false,
 	): BrowserNavState => {
 		const session = entries.get(viewId);
 		if (!session) return emptyNavState(viewId);
 		const entry = activeEntry(session);
 		if (cancelForNavigation) {
 			cancelAnnotation(options, entry, "navigation");
+		}
+		if (cancelForNavigation || reapplyBounds) {
 			applySessionBounds(session, entry);
 		}
 		action(entry.view.webContents);
@@ -1253,8 +1259,18 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		if (!session) return;
 		const entry = activeEntry(session);
 		entry.annotationEnabled = input.enabled;
-		entry.view.webContents.send("browser:annotation:setMode", { enabled: input.enabled });
+		if (!input.enabled) entry.annotationDraft = null;
+		entry.view.webContents.send("browser:annotation:setMode", {
+			enabled: input.enabled,
+			...(input.enabled && entry.annotationDraft ? { draft: entry.annotationDraft } : {}),
+		});
 		if (input.enabled) entry.view.webContents.focus();
+	};
+
+	const updateAnnotationDraft = (event: IpcMainEvent, draft: BrowserAnnotationDraft | undefined): void => {
+		const entry = tabsByWebContentsId.get(event.sender.id);
+		if (!entry?.annotationEnabled || !isValidAnnotationDraft(draft)) return;
+		entry.annotationDraft = draft;
 	};
 
 	const forwardAnnotationSubmit = async (
@@ -1273,6 +1289,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			return;
 		}
 		entry.annotationEnabled = false;
+		entry.annotationDraft = null;
 		// Captured now, before returning: the preload only tears down the
 		// highlight overlay after this handler resolves, so the frame we grab
 		// here still has the selection ring(s) on it and not the prompt box
@@ -1295,6 +1312,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		const viewId = entry?.state.viewId;
 		if (!viewId || !entry) return;
 		entry.annotationEnabled = false;
+		entry.annotationDraft = null;
 		const forwarded: BrowserAnnotationCancelPayload = {
 			viewId,
 			reason: payload?.reason ?? "cancel",
@@ -1337,7 +1355,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			: emptyNavState(viewId),
 	);
 	handle("browser:reload", (event, viewId: string) =>
-		isRendererOwned(event, viewId) ? invokeNav(viewId, (contents) => contents.reload(), true) : emptyNavState(viewId),
+		isRendererOwned(event, viewId) ? invokeNav(viewId, (contents) => contents.reload(), false, true) : emptyNavState(viewId),
 	);
 	handle("browser:stop", (event, viewId: string) =>
 		isRendererOwned(event, viewId) ? invokeNav(viewId, (contents) => contents.stop()) : emptyNavState(viewId),
@@ -1450,6 +1468,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	on("browser:annotation:cancel", (event, payload: BrowserAnnotationPageCancelPayload) =>
 		forwardAnnotationCancel(event, payload),
 	);
+	on("browser:annotation:draft", (event, draft: BrowserAnnotationDraft) => updateAnnotationDraft(event, draft));
 
 	return {
 		execute: async (sessionId, action, args = {}, signal) => {
@@ -1944,10 +1963,15 @@ function wireNavEvents(
 	contents.on("did-navigate-in-page", update);
 	contents.on("page-title-updated", update);
 	contents.on("did-start-loading", () => {
-		cancelAnnotation(options, entry, "navigation");
+		if (entry.annotationDraft && !isSameAnnotationPage(annotationDraftURL(entry.annotationDraft), contents.getURL())) {
+			cancelAnnotation(options, entry, "navigation");
+		}
 		update();
 	});
 	contents.on("did-stop-loading", () => {
+		if (entry.annotationEnabled && entry.annotationDraft) {
+			contents.send("browser:annotation:setMode", { enabled: true, draft: entry.annotationDraft });
+		}
 		update();
 	});
 	contents.on("did-fail-load", (_event, errorCode, errorDescription) => {
@@ -2044,11 +2068,34 @@ function cancelAnnotation(
 ): void {
 	if (!entry.annotationEnabled) return;
 	entry.annotationEnabled = false;
+	entry.annotationDraft = null;
 	entry.view.webContents.send("browser:annotation:setMode", { enabled: false });
 	shellContents(options).send("browser:annotation:canceled", {
 		viewId: entry.state.viewId,
 		reason,
 	});
+}
+
+function annotationDraftURL(draft: BrowserAnnotationDraft): string {
+	return draft.selection.kind === "element" ? draft.selection.context.url : (draft.selection.contexts[0]?.url ?? "");
+}
+
+function isSameAnnotationPage(source: string, destination: string): boolean {
+	try {
+		const sourceURL = new URL(source);
+		const destinationURL = new URL(destination);
+		sourceURL.hash = "";
+		destinationURL.hash = "";
+		return sourceURL.href === destinationURL.href;
+	} catch {
+		return source === destination;
+	}
+}
+
+function isValidAnnotationDraft(value: unknown): value is BrowserAnnotationDraft {
+	if (!value || typeof value !== "object") return false;
+	const draft = value as Partial<BrowserAnnotationDraft>;
+	return typeof draft.instruction === "string" && isValidAnnotationSelection(draft.selection);
 }
 
 function pushNavState(options: BrowserViewHostOptions, entry: BrowserEntry): BrowserNavState {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -1125,10 +1125,12 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 
 	const navigateEntry = async (entry: BrowserEntry, url: string): Promise<BrowserNavState> => {
 		await entry.ready;
-		cancelAnnotation(options, entry, "navigation");
 		const normalized = normalizeBrowserURL(url);
 		if (!isAllowedBrowserURL(normalized.href, options.rendererOrigin)) {
 			throw new Error("Unsupported browser URL");
+		}
+		if (!entry.annotationDraft || !isSameAnnotationPage(annotationDraftURL(entry.annotationDraft), normalized.href)) {
+			cancelAnnotation(options, entry, "navigation");
 		}
 		try {
 			await entry.view.webContents.loadURL(normalized.href);
@@ -1358,7 +1360,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		isRendererOwned(event, viewId) ? invokeNav(viewId, (contents) => contents.reload(), false, true) : emptyNavState(viewId),
 	);
 	handle("browser:stop", (event, viewId: string) =>
-		isRendererOwned(event, viewId) ? invokeNav(viewId, (contents) => contents.stop()) : emptyNavState(viewId),
+		isRendererOwned(event, viewId) ? invokeNav(viewId, (contents) => contents.stop(), true) : emptyNavState(viewId),
 	);
 	handle("browser:getTabs", (event, viewId: string) => {
 		const session = entries.get(viewId);
@@ -1937,6 +1939,10 @@ function hardenWebContents(
 			event.preventDefault();
 			entry.state = { ...entry.state, error: "Unsupported browser URL" };
 			shellContents(options).send("browser:navState", entry.state);
+			return;
+		}
+		if (entry.annotationDraft && !isSameAnnotationPage(annotationDraftURL(entry.annotationDraft), url)) {
+			cancelAnnotation(options, entry, "navigation");
 		}
 	};
 	contents.on("will-navigate", blockUnsafeNavigation);
@@ -1956,6 +1962,9 @@ function wireNavEvents(
 		if (isActive()) pushNavState(options, entry);
 	};
 	contents.on("did-navigate", (_event, url) => {
+		if (entry.annotationDraft && !isSameAnnotationPage(annotationDraftURL(entry.annotationDraft), url)) {
+			cancelAnnotation(options, entry, "navigation");
+		}
 		clearStaleFavicon(entry, url);
 		if (isActive()) syncActiveBounds();
 		update();
@@ -1963,19 +1972,18 @@ function wireNavEvents(
 	contents.on("did-navigate-in-page", update);
 	contents.on("page-title-updated", update);
 	contents.on("did-start-loading", () => {
-		if (entry.annotationDraft && !isSameAnnotationPage(annotationDraftURL(entry.annotationDraft), contents.getURL())) {
-			cancelAnnotation(options, entry, "navigation");
-		}
 		update();
 	});
 	contents.on("did-stop-loading", () => {
 		if (entry.annotationEnabled && entry.annotationDraft) {
 			contents.send("browser:annotation:setMode", { enabled: true, draft: entry.annotationDraft });
+			contents.focus();
 		}
 		update();
 	});
 	contents.on("did-fail-load", (_event, errorCode, errorDescription) => {
 		if (errorCode === -3) return;
+		cancelAnnotation(options, entry, "navigation");
 		if (isActive()) entry.view.setVisible?.(false);
 		entry.state = { ...readNavState(entry), error: String(errorDescription || "Unable to load page") };
 		if (isActive()) shellContents(options).send("browser:navState", entry.state);

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1212,6 +1212,16 @@ describe("BrowserPanel", () => {
 		expect(screen.queryByText("Pick element")).not.toBeInTheDocument();
 	});
 
+	it("uses AO orange for the active annotation status dot", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		const annotateButton = screen.getByRole("button", { name: /annotate/i });
+		await userEvent.click(annotateButton);
+
+		expect(annotateButton.querySelector('span[aria-hidden="true"]')).toHaveClass("bg-status-needs-you");
+	});
+
 	it("keeps the browser viewport transparent once a native page is loaded, so overlays don't blank it", () => {
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
 		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -584,7 +584,7 @@ export function BrowserPanelView({
 							aria-hidden="true"
 							className={cn(
 								"pointer-events-none absolute -right-0.5 -top-0.5 size-1.5 rounded-full",
-								status === "error" ? "bg-destructive" : "bg-accent",
+								status === "error" ? "bg-destructive" : "bg-status-needs-you",
 							)}
 						/>
 					) : agentStatusLabel ? (

--- a/frontend/src/shared/browser-annotations.ts
+++ b/frontend/src/shared/browser-annotations.ts
@@ -56,6 +56,13 @@ export type BrowserAnnotationSnapshot = {
 	data: string;
 };
 
+export type BrowserAnnotationDraft = BrowserAnnotationPageSubmitPayload;
+
+export type BrowserAnnotationPageMode = {
+	enabled: boolean;
+	draft?: BrowserAnnotationDraft;
+};
+
 export type BrowserAnnotationSubmitPayload = BrowserAnnotationPageSubmitPayload & {
 	viewId: string;
 	snapshot?: BrowserAnnotationSnapshot;


### PR DESCRIPTION
## Summary

- Preserve unfinished browser annotation text and selection across same-page reloads and dev-server refreshes.
- Restore single- and multi-element selections when possible, with a safe composer fallback when the original DOM target no longer exists.
- Keep real navigation and explicit cancellation clearing the draft.
- Use AO's orange status color for the active annotation indicator.

## Validation

- 152 focused frontend tests passed across annotate preload, browser view host, and Browser Panel.
- Manually verified in the Electron desktop app with real AO history that toolbar refresh retains the draft.