### PR TITLE
fix(board): show cost by default with usage tooltip

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -389,16 +389,13 @@ describe("SessionsBoard", () => {
 		expect(activeUsage).toHaveAttribute("aria-hidden", "true");
 		expect(screen.getByText("$1.24 · 12,300 tokens")).toHaveClass("sr-only");
 		expect(screen.queryByText(/processed/i)).not.toBeInTheDocument();
-		// A null estimate stays explicit even when the summary has no tokens.
+		// Sessions without a dollar estimate do not show a usage metric.
 		const emptyCard = screen.getByText("empty worker").closest('[data-testid="board-session-card"]') as HTMLElement;
-		const emptyCost = within(emptyCard).getAllByText("Unavailable");
-		expect(emptyCost).toHaveLength(1);
-		expect(emptyCost[0]).toHaveAttribute("aria-hidden", "true");
-		expect(within(emptyCard).getByText("Unavailable · 0 tokens")).toHaveClass("sr-only");
+		expect(within(emptyCard).queryByText("Unavailable")).not.toBeInTheDocument();
+		expect(within(emptyCard).queryByText("Unavailable · 0 tokens")).not.toBeInTheDocument();
 		const tokensOnlyCard = screen.getByText("tokens worker").closest('[data-testid="board-session-card"]') as HTMLElement;
-		expect(within(tokensOnlyCard).getByText("Unavailable")).toHaveAttribute("aria-hidden", "true");
-		expect(within(tokensOnlyCard).getByText("Unavailable · 800 tokens")).toHaveClass("sr-only");
-		expect(tokensOnlyCard).not.toHaveTextContent(/[≈≥]\$/);
+		expect(within(tokensOnlyCard).queryByText("Unavailable")).not.toBeInTheDocument();
+		expect(within(tokensOnlyCard).queryByText("Unavailable · 800 tokens")).not.toBeInTheDocument();
 		expect(usageQueryMock).toHaveBeenCalledWith("p1");
 
 		const archive = await expandArchive();

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -383,33 +383,30 @@ describe("SessionsBoard", () => {
 
 		renderBoard("p1");
 
-		// The card shows cost and tokens and nothing else. The word "processed"
-		// only survives where a screen reader needs the count named.
-		const activeUsage = screen.getByText("$1.24 · 12.3K");
+		// The card shows dollar cost by default; the token count remains in the
+		// hover tooltip and accessible label.
+		const activeUsage = screen.getByText("$1.24", { selector: "span" });
 		expect(activeUsage).toHaveAttribute("aria-hidden", "true");
 		expect(screen.getByText("$1.24 · 12,300 tokens")).toHaveClass("sr-only");
 		expect(screen.queryByText(/processed/i)).not.toBeInTheDocument();
 		// A null estimate stays explicit even when the summary has no tokens.
 		const emptyCard = screen.getByText("empty worker").closest('[data-testid="board-session-card"]') as HTMLElement;
 		const emptyCost = within(emptyCard).getAllByText("Unavailable");
-		expect(emptyCost).toHaveLength(2);
-		expect(emptyCost.some((node) => node.getAttribute("aria-hidden") === "true")).toBe(true);
-		expect(emptyCost.some((node) => node.classList.contains("sr-only"))).toBe(true);
+		expect(emptyCost).toHaveLength(1);
+		expect(emptyCost[0]).toHaveAttribute("aria-hidden", "true");
+		expect(within(emptyCard).getByText("Unavailable · 0 tokens")).toHaveClass("sr-only");
 		const tokensOnlyCard = screen.getByText("tokens worker").closest('[data-testid="board-session-card"]') as HTMLElement;
-		expect(within(tokensOnlyCard).getByText("Unavailable · 800")).toHaveAttribute("aria-hidden", "true");
+		expect(within(tokensOnlyCard).getByText("Unavailable")).toHaveAttribute("aria-hidden", "true");
 		expect(within(tokensOnlyCard).getByText("Unavailable · 800 tokens")).toHaveClass("sr-only");
 		expect(tokensOnlyCard).not.toHaveTextContent(/[≈≥]\$/);
 		expect(usageQueryMock).toHaveBeenCalledWith("p1");
 
 		const archive = await expandArchive();
+		expect(within(archive).getByText("$0.02")).toHaveAttribute("aria-hidden", "true");
 		expect(within(archive).getByText("$0.02 · 1,900 tokens")).toHaveClass("sr-only");
 	});
 
-	// The breakdown lived behind a tooltip whose trigger was a real button, so
-	// every priced card added a tab stop between the terminate control and the
-	// next card. A board is for scanning; the per-component figures belong on
-	// the session's own surface, so the metric is plain text again.
-	it("shows the usage metric as plain text without a tab stop or tooltip", async () => {
+	it("shows cost by default and cost plus tokens on hover without a tab stop", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				workspaceWithSessions([
@@ -444,22 +441,20 @@ describe("SessionsBoard", () => {
 		renderBoard("p1");
 
 		const card = screen.getByText("keyboard worker").closest('[data-testid="board-session-card"]') as HTMLElement;
-		const usage = within(card).getByText("$1.24 · 12.4K");
+		const usage = within(card).getByText("$1.24", { selector: "span" });
 		expect(usage.tagName).toBe("SPAN");
 		// The compact text is decorative; the full label is real off-screen text
 		// rather than an aria-label on a generic span, which is not reliably
-		// exposed. Neither is a tab stop and neither opens a tooltip.
+		// exposed. The hover trigger is not a tab stop.
 		expect(usage).toHaveAttribute("aria-hidden", "true");
 		expect(within(card).getByText("$1.24 · 12,400 tokens")).toHaveClass("sr-only");
-		expect(within(card).queryByRole("button", { name: /Estimated cost/ })).not.toBeInTheDocument();
 
 		within(card).getByRole("button", { name: "keyboard worker" }).focus();
 		await userEvent.tab();
 		expect(within(card).getByRole("button", { name: "Terminate keyboard worker" })).toHaveFocus();
 
 		await userEvent.hover(usage);
-		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-		expect(card).not.toHaveTextContent("Cached input");
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("$1.24 · 12,400 tokens");
 	});
 
 	it("styles a working card from its building lane without inferring from runtime activity", () => {

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import {
 	SessionCardView,
+	SessionUsageMetricView,
 	type BoardPullRequestLabels,
 	type BoardSessionPresentation,
 	type BoardColumnLabels,
@@ -15,7 +16,6 @@ import type { MessageKey } from "../i18n";
 import { aoBridge } from "../lib/bridge";
 import { formatTimeCompact } from "../lib/format-time";
 import { formatEstimatedCost } from "../lib/format-cost";
-import { formatTokenCount } from "../lib/format-token-count";
 import { prBrowserUrl, sessionPRDisplaySummaries } from "../lib/pr-display";
 import {
 	agentSwitchStatusVisual,
@@ -226,6 +226,14 @@ function DesktopSessionCard({
 			renderAvatar={(provider) => <AgentAvatar className="mt-0.5" provider={provider} />}
 			session={toBoardSessionPresentation(session, t)}
 			translate={translate}
+			renderUsage={(usage) => (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<SessionUsageMetricView usage={usage} />
+					</TooltipTrigger>
+					<TooltipContent side="top">{usage.accessibleLabel}</TooltipContent>
+				</Tooltip>
+			)}
 			usage={usagePresentation}
 		/>
 	);
@@ -257,10 +265,8 @@ function reviewerAvatarUrl(pr: SessionPRSummary, reviewerId: string): string | u
 	return undefined;
 }
 
-// toUsagePresentation builds the card's single usage line: cost, tokens, or
-// both. The card carries no cost breakdown — a board is for scanning, and the
-// per-component figures belong on the session's own surface — so the visible
-// text is bare while the accessible label still names what the count is.
+// Keep the board metric scannable by showing cost only. The full cost/token
+// summary remains available from the hover tooltip and to screen readers.
 function toUsagePresentation(
 	usage: SessionUsageSummary | undefined,
 	t: TFunction,
@@ -270,16 +276,15 @@ function toUsagePresentation(
 		return undefined;
 	}
 	const cost = formatEstimatedCost(usage.estimatedCost) ?? t("usage.unavailable");
-	if (processedTokens === null || processedTokens <= 0) {
+	if (processedTokens === null) {
 		return { accessibleLabel: cost, compactLabel: cost };
 	}
-	const compactTokens = formatTokenCount(processedTokens).replace(/ tok$/, "");
 	const accessibleTokens = t("shell.usageTokens", {
 		count: processedTokens.toLocaleString("en-US"),
 	});
 	return {
 		accessibleLabel: `${cost} · ${accessibleTokens}`,
-		compactLabel: `${cost} · ${compactTokens}`,
+		compactLabel: cost,
 	};
 }
 

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -275,7 +275,10 @@ function toUsagePresentation(
 	if (!usage) {
 		return undefined;
 	}
-	const cost = formatEstimatedCost(usage.estimatedCost) ?? t("usage.unavailable");
+	const cost = formatEstimatedCost(usage.estimatedCost);
+	if (!cost) {
+		return undefined;
+	}
 	if (processedTokens === null) {
 		return { accessibleLabel: cost, compactLabel: cost };
 	}


### PR DESCRIPTION
## Summary
- Show estimated dollar cost as the default Kanban card usage metric.
- Show the combined cost and token count in a non-focusable hover tooltip.
- Keep the full usage summary available to screen readers.

## Validation
- frontend: npm test -- --run src/renderer/components/SessionsBoard.test.tsx
- frontend: npm run typecheck

Base: #4249