### PR TITLE
feat(scm): OneDev SCM provider

### DIFF
--- a/backend/internal/adapters/scm/onedev/auth.go
+++ b/backend/internal/adapters/scm/onedev/auth.go
@@ -1,0 +1,277 @@
+package onedev
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+// ErrNoToken is returned when no token source could yield a usable credential.
+// internal/daemon/scm_wiring.go matches this sentinel to log the provider as
+// "disabled: no credentials" rather than as a failure.
+var ErrNoToken = errors.New("onedev scm: no credentials configured")
+
+// ErrAuthFailed is returned when OneDev rejects the supplied credential
+// (HTTP 401/403).
+var ErrAuthFailed = errors.New("onedev scm: authentication failed")
+
+// Credential is a resolved OneDev credential. OneDev accepts either a bearer
+// access token or HTTP basic auth, and self-hosted estates commonly hold the
+// latter (a service account's password in a keyring), so both are modelled
+// here rather than forcing every deployment onto access tokens.
+//
+// Token wins when both are populated.
+type Credential struct {
+	// Token is a OneDev access token, sent as "Authorization: Bearer <token>".
+	Token string
+	// Username and Password are HTTP basic-auth credentials, used only when
+	// Token is empty.
+	Username string
+	Password string
+}
+
+// BearerCredential builds a Credential from an access token.
+func BearerCredential(token string) Credential {
+	return Credential{Token: strings.TrimSpace(token)}
+}
+
+// BasicCredential builds a Credential from a username and password.
+func BasicCredential(username, password string) Credential {
+	return Credential{Username: strings.TrimSpace(username), Password: password}
+}
+
+// Empty reports whether the credential carries neither a token nor a username.
+func (c Credential) Empty() bool {
+	return strings.TrimSpace(c.Token) == "" && strings.TrimSpace(c.Username) == ""
+}
+
+// apply attaches the credential to req. An empty credential is an error
+// rather than an unauthenticated request: OneDev has no anonymous API mode
+// worth reaching, and a silent anonymous call would surface as a confusing
+// 401 far from its cause.
+func (c Credential) apply(req *http.Request) error {
+	if tok := strings.TrimSpace(c.Token); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+		return nil
+	}
+	if user := strings.TrimSpace(c.Username); user != "" {
+		req.SetBasicAuth(user, c.Password)
+		return nil
+	}
+	return ErrNoToken
+}
+
+// TokenSource yields a OneDev credential on demand. Production wires this to
+// EnvTokenSource with an optional CommandTokenSource fallback; tests inject
+// StaticTokenSource or StaticBasicAuthSource.
+type TokenSource interface {
+	Token(ctx context.Context) (Credential, error)
+}
+
+// tokenInvalidator is the optional capability of dropping a cached credential
+// so the next call re-fetches it. The Client invokes this whenever OneDev
+// responds with an auth-class failure.
+type tokenInvalidator interface {
+	InvalidateToken()
+}
+
+// StaticTokenSource is a literal access token, typically used in tests and to
+// carry per-host overrides from AO_ONEDEV_HOST_TOKENS.
+type StaticTokenSource string
+
+// Token returns the literal token value, trimmed of whitespace.
+func (s StaticTokenSource) Token(context.Context) (Credential, error) {
+	c := BearerCredential(string(s))
+	if c.Empty() {
+		return Credential{}, ErrNoToken
+	}
+	return c, nil
+}
+
+// StaticBasicAuthSource is a literal username/password pair for instances
+// that authenticate with HTTP basic auth rather than an access token.
+type StaticBasicAuthSource struct {
+	Username string
+	Password string
+}
+
+// Token returns the literal basic-auth credential.
+func (s StaticBasicAuthSource) Token(context.Context) (Credential, error) {
+	c := BasicCredential(s.Username, s.Password)
+	if c.Empty() {
+		return Credential{}, ErrNoToken
+	}
+	return c, nil
+}
+
+// EnvTokenSource reads the first non-empty access token from the listed env
+// vars, falling back to ONEDEV_TOKEN. Order matters: the AO-scoped variable
+// (AO_ONEDEV_TOKEN) should win over the global default.
+type EnvTokenSource struct {
+	EnvVars []string
+}
+
+// Token returns the first non-empty value from the configured env vars,
+// falling back to ONEDEV_TOKEN.
+func (s EnvTokenSource) Token(context.Context) (Credential, error) {
+	for _, name := range s.EnvVars {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return BearerCredential(v), nil
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("ONEDEV_TOKEN")); v != "" {
+		return BearerCredential(v), nil
+	}
+	return Credential{}, ErrNoToken
+}
+
+// FallbackTokenSource tries each source in order, returning the first
+// credential. A source reporting ErrNoToken is skipped; any other error is
+// remembered and returned only if no later source succeeds, so a broken
+// credential helper does not mask a working env var.
+type FallbackTokenSource []TokenSource
+
+// Token tries each source in order, returning the first successful credential.
+func (s FallbackTokenSource) Token(ctx context.Context) (Credential, error) {
+	var firstErr error
+	for _, src := range s {
+		if src == nil {
+			continue
+		}
+		cred, err := src.Token(ctx)
+		if err == nil {
+			return cred, nil
+		}
+		if errors.Is(err, ErrNoToken) {
+			continue
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
+		return Credential{}, firstErr
+	}
+	return Credential{}, ErrNoToken
+}
+
+// InvalidateToken clears cached credentials in all sub-sources that support it.
+func (s FallbackTokenSource) InvalidateToken() {
+	for _, src := range s {
+		if inv, ok := src.(tokenInvalidator); ok {
+			inv.InvalidateToken()
+		}
+	}
+}
+
+// defaultCommandTokenCacheTTL bounds how long a credential-helper result is
+// reused before the command is run again.
+const defaultCommandTokenCacheTTL = 5 * time.Minute
+
+// CommandTokenSource shells out to an operator-configured credential helper
+// when no env var is set, memoizing the result for TokenTTL.
+//
+// GitLab's equivalent fallback shells out to `glab`, but OneDev ships no
+// first-party CLI to borrow a token from, so this source is deliberately
+// generic: the operator names the command (for example a keyring reader such
+// as `secret-tool lookup ...`) and its trimmed stdout becomes the token.
+// A source with no Command configured reports ErrNoToken, which disables the
+// provider quietly instead of erroring on every poll — the same failure mode
+// as an uninstalled `glab`.
+type CommandTokenSource struct {
+	// Command is the argv of the credential helper. Empty disables the source.
+	Command []string
+	// Username, when set, makes the command's output a basic-auth password
+	// for this user rather than a bearer access token.
+	Username string
+	// TokenTTL is how long a resolved credential is cached. Zero means
+	// defaultCommandTokenCacheTTL.
+	TokenTTL time.Duration
+	// Run overrides command execution; tests inject a stub.
+	Run func(ctx context.Context, argv []string) (string, error)
+	// Clock overrides time.Now; tests inject a fake to assert TTL expiry
+	// without sleeping.
+	Clock func() time.Time
+
+	mu        sync.Mutex
+	cred      Credential
+	expiresAt time.Time
+}
+
+// Token returns the cached credential, re-running the configured command when
+// the cache expires.
+func (s *CommandTokenSource) Token(ctx context.Context) (Credential, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.Command) == 0 {
+		return Credential{}, ErrNoToken
+	}
+	now := s.now()
+	if !s.cred.Empty() && now.Before(s.expiresAt) {
+		return s.cred, nil
+	}
+	run := s.Run
+	if run == nil {
+		run = runCredentialCommand
+	}
+	out, err := run(ctx, s.Command)
+	if err != nil {
+		return Credential{}, err
+	}
+	secret := strings.TrimSpace(out)
+	if secret == "" {
+		return Credential{}, ErrNoToken
+	}
+	cred := BearerCredential(secret)
+	if user := strings.TrimSpace(s.Username); user != "" {
+		cred = BasicCredential(user, secret)
+	}
+	s.cred = cred
+	s.expiresAt = now.Add(s.ttl())
+	return cred, nil
+}
+
+// InvalidateToken clears the cached credential so the next call re-runs the
+// command.
+func (s *CommandTokenSource) InvalidateToken() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cred = Credential{}
+	s.expiresAt = time.Time{}
+}
+
+func (s *CommandTokenSource) now() time.Time {
+	if s.Clock != nil {
+		return s.Clock()
+	}
+	return time.Now()
+}
+
+func (s *CommandTokenSource) ttl() time.Duration {
+	if s.TokenTTL > 0 {
+		return s.TokenTTL
+	}
+	return defaultCommandTokenCacheTTL
+}
+
+// runCredentialCommand executes the helper and returns its stdout. Any
+// failure (missing binary, non-zero exit, locked keyring) maps to ErrNoToken
+// so the provider is disabled rather than erroring on every poll. Only stdout
+// is read: a helper that prints diagnostics on stderr must not have them
+// mistaken for the secret.
+func runCredentialCommand(ctx context.Context, argv []string) (string, error) {
+	if len(argv) == 0 {
+		return "", ErrNoToken
+	}
+	out, err := aoprocess.CommandContext(ctx, argv[0], argv[1:]...).Output()
+	if err != nil {
+		return "", ErrNoToken
+	}
+	return string(out), nil
+}

--- a/backend/internal/adapters/scm/onedev/auth_test.go
+++ b/backend/internal/adapters/scm/onedev/auth_test.go
@@ -1,0 +1,372 @@
+package onedev
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCredentialApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		cred     Credential
+		wantErr  error
+		wantAuth string
+		wantUser string
+		wantPass string
+	}{
+		{
+			name: "bearer token", cred: BearerCredential("od-token"),
+			wantAuth: "Bearer od-token",
+		},
+		{
+			name: "bearer token is trimmed", cred: BearerCredential("  od-token\n"),
+			wantAuth: "Bearer od-token",
+		},
+		{
+			name: "basic auth", cred: BasicCredential("johnkattenhorn", "s3cret"),
+			wantUser: "johnkattenhorn", wantPass: "s3cret",
+		},
+		{
+			// A password may legitimately be blank-looking; only the username
+			// decides whether basic auth applies.
+			name: "basic auth with empty password", cred: BasicCredential("svc", ""),
+			wantUser: "svc", wantPass: "",
+		},
+		{
+			name:     "token wins over basic auth",
+			cred:     Credential{Token: "od-token", Username: "svc", Password: "pw"},
+			wantAuth: "Bearer od-token",
+		},
+		{name: "empty credential", cred: Credential{}, wantErr: ErrNoToken},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.test/~api/projects", http.NoBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = tt.cred.apply(req)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("apply() err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("apply(): %v", err)
+			}
+			if tt.wantAuth != "" {
+				if got := req.Header.Get("Authorization"); got != tt.wantAuth {
+					t.Fatalf("Authorization = %q, want %q", got, tt.wantAuth)
+				}
+				return
+			}
+			user, pass, ok := req.BasicAuth()
+			if !ok {
+				t.Fatalf("BasicAuth not set; Authorization = %q", req.Header.Get("Authorization"))
+			}
+			if user != tt.wantUser || pass != tt.wantPass {
+				t.Fatalf("BasicAuth = (%q, %q), want (%q, %q)", user, pass, tt.wantUser, tt.wantPass)
+			}
+		})
+	}
+}
+
+func TestStaticSources(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     TokenSource
+		want    Credential
+		wantErr error
+	}{
+		{name: "static token", src: StaticTokenSource("od-abc"), want: Credential{Token: "od-abc"}},
+		{name: "static token trims", src: StaticTokenSource("  od-abc  "), want: Credential{Token: "od-abc"}},
+		{name: "static token empty", src: StaticTokenSource("   "), wantErr: ErrNoToken},
+		{
+			name: "static basic auth",
+			src:  StaticBasicAuthSource{Username: "svc", Password: "pw"},
+			want: Credential{Username: "svc", Password: "pw"},
+		},
+		{
+			name:    "static basic auth without username",
+			src:     StaticBasicAuthSource{Password: "pw"},
+			wantErr: ErrNoToken,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.src.Token(context.Background())
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Token() err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Token(): %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Token() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnvTokenSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars []string
+		set     map[string]string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "reads the configured var", envVars: []string{"AO_ONEDEV_TOKEN"},
+			set: map[string]string{"AO_ONEDEV_TOKEN": "od-scoped"}, want: "od-scoped",
+		},
+		{
+			name: "scoped var wins over the global default", envVars: []string{"AO_ONEDEV_TOKEN"},
+			set:  map[string]string{"AO_ONEDEV_TOKEN": "od-scoped", "ONEDEV_TOKEN": "od-global"},
+			want: "od-scoped",
+		},
+		{
+			name: "falls back to ONEDEV_TOKEN", envVars: []string{"AO_ONEDEV_TOKEN"},
+			set: map[string]string{"ONEDEV_TOKEN": "od-global"}, want: "od-global",
+		},
+		{
+			name: "first non-empty of several", envVars: []string{"AO_ONEDEV_TOKEN", "AO_ONEDEV_TOKEN_ALT"},
+			set:  map[string]string{"AO_ONEDEV_TOKEN": "  ", "AO_ONEDEV_TOKEN_ALT": "od-alt"},
+			want: "od-alt",
+		},
+		{
+			name: "whitespace is trimmed", envVars: []string{"AO_ONEDEV_TOKEN"},
+			set: map[string]string{"AO_ONEDEV_TOKEN": "  od-padded\n"}, want: "od-padded",
+		},
+		{
+			name: "nothing set", envVars: []string{"AO_ONEDEV_TOKEN"},
+			set: map[string]string{}, wantErr: ErrNoToken,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, name := range []string{"AO_ONEDEV_TOKEN", "AO_ONEDEV_TOKEN_ALT", "ONEDEV_TOKEN"} {
+				t.Setenv(name, "")
+			}
+			for name, val := range tt.set {
+				t.Setenv(name, val)
+			}
+			got, err := EnvTokenSource{EnvVars: tt.envVars}.Token(context.Background())
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Token() err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Token(): %v", err)
+			}
+			if got.Token != tt.want {
+				t.Fatalf("token = %q, want %q", got.Token, tt.want)
+			}
+		})
+	}
+}
+
+// errSource is a TokenSource that always fails with a non-ErrNoToken error.
+type errSource struct{ err error }
+
+func (s errSource) Token(context.Context) (Credential, error) { return Credential{}, s.err }
+
+func TestFallbackTokenSource(t *testing.T) {
+	boom := errors.New("credential helper exploded")
+	tests := []struct {
+		name    string
+		src     FallbackTokenSource
+		want    Credential
+		wantErr error
+	}{
+		{
+			name: "first usable source wins",
+			src:  FallbackTokenSource{StaticTokenSource("first"), StaticTokenSource("second")},
+			want: Credential{Token: "first"},
+		},
+		{
+			name: "skips sources reporting ErrNoToken",
+			src:  FallbackTokenSource{StaticTokenSource(""), StaticTokenSource("second")},
+			want: Credential{Token: "second"},
+		},
+		{
+			name: "nil entries are skipped",
+			src:  FallbackTokenSource{nil, StaticTokenSource("second")},
+			want: Credential{Token: "second"},
+		},
+		{
+			// A broken helper must not mask a working env var later in the chain.
+			name: "a later success beats an earlier hard failure",
+			src:  FallbackTokenSource{errSource{boom}, StaticTokenSource("second")},
+			want: Credential{Token: "second"},
+		},
+		{
+			name:    "hard failure surfaces when nothing else works",
+			src:     FallbackTokenSource{errSource{boom}, StaticTokenSource("")},
+			wantErr: boom,
+		},
+		{name: "empty chain", src: FallbackTokenSource{}, wantErr: ErrNoToken},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.src.Token(context.Background())
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Token() err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Token(): %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Token() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandTokenSource(t *testing.T) {
+	t.Run("disabled without a command", func(t *testing.T) {
+		src := &CommandTokenSource{}
+		if _, err := src.Token(context.Background()); !errors.Is(err, ErrNoToken) {
+			t.Fatalf("err = %v, want ErrNoToken", err)
+		}
+	})
+
+	t.Run("caches within the TTL", func(t *testing.T) {
+		calls := 0
+		src := &CommandTokenSource{
+			Command:  []string{"helper"},
+			TokenTTL: time.Hour,
+			Run: func(context.Context, []string) (string, error) {
+				calls++
+				return "od-from-helper\n", nil
+			},
+		}
+		for i := 0; i < 2; i++ {
+			got, err := src.Token(context.Background())
+			if err != nil {
+				t.Fatalf("Token(): %v", err)
+			}
+			if got.Token != "od-from-helper" {
+				t.Fatalf("token = %q, want od-from-helper", got.Token)
+			}
+		}
+		if calls != 1 {
+			t.Fatalf("helper ran %d times, want 1 (cached)", calls)
+		}
+	})
+
+	t.Run("re-runs after the TTL expires", func(t *testing.T) {
+		calls := 0
+		now := time.Unix(1_700_000_000, 0)
+		src := &CommandTokenSource{
+			Command:  []string{"helper"},
+			TokenTTL: time.Minute,
+			Clock:    func() time.Time { return now },
+			Run: func(context.Context, []string) (string, error) {
+				calls++
+				return "od-from-helper", nil
+			},
+		}
+		if _, err := src.Token(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		now = now.Add(2 * time.Minute)
+		if _, err := src.Token(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if calls != 2 {
+			t.Fatalf("helper ran %d times, want 2 (TTL expired)", calls)
+		}
+	})
+
+	t.Run("InvalidateToken clears the cache", func(t *testing.T) {
+		calls := 0
+		src := &CommandTokenSource{
+			Command:  []string{"helper"},
+			TokenTTL: time.Hour,
+			Run: func(context.Context, []string) (string, error) {
+				calls++
+				return "od-from-helper", nil
+			},
+		}
+		if _, err := src.Token(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		src.InvalidateToken()
+		if _, err := src.Token(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if calls != 2 {
+			t.Fatalf("helper ran %d times, want 2 (cache invalidated)", calls)
+		}
+	})
+
+	t.Run("username makes the output a basic-auth password", func(t *testing.T) {
+		src := &CommandTokenSource{
+			Command:  []string{"helper"},
+			Username: "svc",
+			Run:      func(context.Context, []string) (string, error) { return "keyring-secret\n", nil },
+		}
+		got, err := src.Token(context.Background())
+		if err != nil {
+			t.Fatalf("Token(): %v", err)
+		}
+		want := Credential{Username: "svc", Password: "keyring-secret"}
+		if got != want {
+			t.Fatalf("Token() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("empty output is ErrNoToken", func(t *testing.T) {
+		src := &CommandTokenSource{
+			Command: []string{"helper"},
+			Run:     func(context.Context, []string) (string, error) { return "  \n", nil },
+		}
+		if _, err := src.Token(context.Background()); !errors.Is(err, ErrNoToken) {
+			t.Fatalf("err = %v, want ErrNoToken", err)
+		}
+	})
+
+	t.Run("run error propagates", func(t *testing.T) {
+		boom := errors.New("boom")
+		src := &CommandTokenSource{
+			Command: []string{"helper"},
+			Run:     func(context.Context, []string) (string, error) { return "", boom },
+		}
+		if _, err := src.Token(context.Background()); !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want boom", err)
+		}
+	})
+}
+
+// TestRunCredentialCommandMissingBinary pins the "disable, don't error"
+// contract: an unavailable helper must look like an absent credential so the
+// provider goes quiet rather than failing every poll.
+func TestRunCredentialCommandMissingBinary(t *testing.T) {
+	_, err := runCredentialCommand(context.Background(), []string{"ao-onedev-no-such-helper-binary"})
+	if !errors.Is(err, ErrNoToken) {
+		t.Fatalf("err = %v, want ErrNoToken", err)
+	}
+}
+
+// newTestServer is shared by the client and provider tests: it records the
+// last request and replies with the supplied handler.
+func newTestServer(t *testing.T, h http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/backend/internal/adapters/scm/onedev/buildlog.go
+++ b/backend/internal/adapters/scm/onedev/buildlog.go
@@ -1,0 +1,167 @@
+package onedev
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// buildLogTailLines is how many trailing log lines a failed check
+	// contributes to an observation. It matches the GitHub and GitLab
+	// adapters so the agent-facing failure context is the same size
+	// whichever provider produced it.
+	buildLogTailLines = 20
+
+	// buildLogMaxFrameBytes rejects an implausible frame length. The stream is
+	// length-prefixed, so a corrupt or non-OneDev response could otherwise ask
+	// the reader to allocate gigabytes from four bytes of input.
+	buildLogMaxFrameBytes = 1 << 20
+
+	// buildLogMaxStreamBytes bounds how much of a log the reader consumes
+	// before giving up on reaching the end. A finished build's log is
+	// typically well under a megabyte; this is a backstop against a
+	// pathological (or still-running, hence endless) stream, not a normal
+	// operating limit.
+	buildLogMaxStreamBytes = 32 << 20
+)
+
+// errBuildLogFraming reports that the response did not follow OneDev's
+// length-prefixed build-log framing.
+var errBuildLogFraming = errors.New("onedev scm: malformed build log stream")
+
+// tailBuildLog decodes OneDev's streaming build-log format and returns the
+// last maxLines rendered lines.
+//
+// GET /~api/streaming/build-logs/{buildId} does not return JSON or plain text.
+// It returns a sequence of frames, each a big-endian int32 length followed by
+// that many bytes:
+//
+//   - a positive length introduces one JSON log entry,
+//     {"date":..., "messages":[{"style":..., "text":"..."}]}
+//   - a negative length introduces a status marker of abs(n) bytes, the build
+//     status as a bare string ("SUCCESSFUL", "FAILED"). One is emitted before
+//     the first entry and one after the last.
+//
+// Verified against OneDev 16.5.6: a successful build's stream opens with
+// 0xFFFFFFF6 ("SUCCESSFUL", 10 bytes) and a failed build's with 0xFFFFFFFA
+// ("FAILED", 6 bytes).
+//
+// The decoder keeps only a maxLines ring buffer, so a large log costs bounded
+// memory however long the stream runs. Frames are read in order — the tail is
+// what survives in the ring — which is why the whole stream is consumed rather
+// than a prefix: a prefix would yield the head of the log, which is the least
+// useful part of a failure.
+//
+// A framing error after at least one decoded line returns the lines collected
+// so far rather than nothing: a truncated tail is still actionable, and a
+// still-writing build can legitimately cut a frame short.
+func tailBuildLog(r io.Reader, maxLines int) (string, error) {
+	if maxLines <= 0 {
+		maxLines = buildLogTailLines
+	}
+	br := bufio.NewReader(r)
+	ring := make([]string, 0, maxLines)
+	appendLine := func(line string) {
+		if len(ring) == maxLines {
+			ring = append(ring[:0], ring[1:]...)
+		}
+		ring = append(ring, line)
+	}
+
+	var consumed int
+	var header [4]byte
+	for consumed < buildLogMaxStreamBytes {
+		if _, err := io.ReadFull(br, header[:]); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return finishTail(ring), readErr(err, len(ring))
+		}
+		consumed += len(header)
+
+		n := int32(binary.BigEndian.Uint32(header[:])) //nolint:gosec // the wire format is a signed length
+		if n < 0 {
+			// Status marker: abs(n) bytes of a bare status string. It carries
+			// no log content, so it is skipped rather than rendered.
+			size := -int(n)
+			if size > buildLogMaxFrameBytes {
+				return finishTail(ring), framingErr(len(ring))
+			}
+			if _, err := io.CopyN(io.Discard, br, int64(size)); err != nil {
+				return finishTail(ring), readErr(err, len(ring))
+			}
+			consumed += size
+			continue
+		}
+		if n == 0 {
+			continue
+		}
+		if int(n) > buildLogMaxFrameBytes {
+			return finishTail(ring), framingErr(len(ring))
+		}
+		payload := make([]byte, n)
+		if _, err := io.ReadFull(br, payload); err != nil {
+			return finishTail(ring), readErr(err, len(ring))
+		}
+		consumed += int(n)
+
+		var entry buildLogEntry
+		if err := json.Unmarshal(payload, &entry); err != nil {
+			// One unparseable entry in an otherwise well-framed stream is not
+			// worth discarding the rest of the log for; the frame length told
+			// us exactly where the next entry starts.
+			continue
+		}
+		appendLine(entry.line())
+	}
+	return finishTail(ring), nil
+}
+
+// readErr converts a mid-stream read failure into either a hard error or a
+// tolerated truncation, depending on whether anything usable was decoded.
+func readErr(err error, lines int) error {
+	if lines > 0 {
+		return nil
+	}
+	return fmt.Errorf("onedev scm: read build log: %w", err)
+}
+
+// framingErr reports a frame length the format cannot produce, tolerating it
+// once a usable tail has already been decoded.
+func framingErr(lines int) error {
+	if lines > 0 {
+		return nil
+	}
+	return errBuildLogFraming
+}
+
+func finishTail(lines []string) string {
+	return strings.Join(lines, "\n")
+}
+
+// buildLogEntry is one decoded log frame. Only the rendered text is kept:
+// OneDev carries per-message ANSI styling that would be noise in an agent's
+// failure context.
+type buildLogEntry struct {
+	Date     string `json:"date"`
+	Messages []struct {
+		Text string `json:"text"`
+	} `json:"messages"`
+}
+
+// line renders an entry's messages as a single log line.
+func (e buildLogEntry) line() string {
+	if len(e.Messages) == 1 {
+		return e.Messages[0].Text
+	}
+	parts := make([]string, 0, len(e.Messages))
+	for _, m := range e.Messages {
+		parts = append(parts, m.Text)
+	}
+	return strings.Join(parts, "")
+}

--- a/backend/internal/adapters/scm/onedev/cache.go
+++ b/backend/internal/adapters/scm/onedev/cache.go
@@ -1,0 +1,126 @@
+package onedev
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// userCacheTTL is the freshness window for a resolved user login. OneDev
+	// exposes authors as numeric ids, so every listing would otherwise cost
+	// one /users/{id} round-trip per author. Logins change rarely (an account
+	// rename), so an hour of staleness is cheap insurance against re-fetching
+	// the same handful of ids on every poll.
+	userCacheTTL = time.Hour
+
+	// projectCacheTTL is the freshness window for a project id's path. Paths
+	// change only when a project is renamed or moved in the project tree, so
+	// the same reasoning as userCacheTTL applies.
+	projectCacheTTL = time.Hour
+
+	// cacheMaxEntries bounds each cache map. OneDev PR numbers are never
+	// reused, so requestIDs would otherwise grow without limit across a
+	// long-lived daemon. On overflow the map is emptied wholesale rather than
+	// evicted entry-by-entry: the cost of a miss is one cheap query, and a
+	// simple reset keeps the cache free of the bookkeeping an LRU would need.
+	cacheMaxEntries = 4096
+)
+
+// cacheEntry stores a value alongside the instant it was fetched. Lookups
+// compare fetchedAt against the domain's TTL; an expired entry is a miss and
+// is left in place until overwritten.
+type cacheEntry[T any] struct {
+	value     T
+	fetchedAt time.Time
+}
+
+// cache memoizes the three id-to-name lookups the observer methods would
+// otherwise repeat on every poll: a PR number's internal request id, a user
+// id's login, and a project id's path.
+//
+// It is internal to this adapter and is not part of the scm.Provider port.
+type cache struct {
+	mu sync.Mutex
+
+	// now supplies the current time. Defaults to time.Now; tests override it
+	// so TTL expiry can be asserted without sleeping.
+	now func() time.Time
+
+	// requestIDs maps "host|project|number" to the internal pull-request id
+	// OneDev's /pulls/{requestId} routes are keyed by. The mapping is
+	// immutable — OneDev never reassigns a PR number within a project — so
+	// entries carry no TTL.
+	requestIDs map[string]int64
+
+	// users maps "host|userId" to the account's login name.
+	users map[string]cacheEntry[string]
+
+	// projects maps "host|projectId" to the project's full path.
+	projects map[string]cacheEntry[string]
+}
+
+// newCache returns an initialized cache ready for use.
+func newCache() *cache {
+	return &cache{
+		now:        time.Now,
+		requestIDs: map[string]int64{},
+		users:      map[string]cacheEntry[string]{},
+		projects:   map[string]cacheEntry[string]{},
+	}
+}
+
+func cacheKey(parts ...string) string { return strings.Join(parts, "|") }
+
+func (c *cache) getRequestID(host, project string, number int) (int64, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id, ok := c.requestIDs[cacheKey(host, project, strconv.Itoa(number))]
+	return id, ok
+}
+
+func (c *cache) setRequestID(host, project string, number int, id int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.requestIDs) >= cacheMaxEntries {
+		c.requestIDs = map[string]int64{}
+	}
+	c.requestIDs[cacheKey(host, project, strconv.Itoa(number))] = id
+}
+
+func (c *cache) getUser(host string, userID int64) (string, bool) {
+	return getTTL(c, c.users, cacheKey(host, strconv.FormatInt(userID, 10)), userCacheTTL)
+}
+
+func (c *cache) setUser(host string, userID int64, login string) {
+	setTTL(c, c.users, cacheKey(host, strconv.FormatInt(userID, 10)), login)
+}
+
+func (c *cache) getProjectPath(host string, projectID int64) (string, bool) {
+	return getTTL(c, c.projects, cacheKey(host, strconv.FormatInt(projectID, 10)), projectCacheTTL)
+}
+
+func (c *cache) setProjectPath(host string, projectID int64, path string) {
+	setTTL(c, c.projects, cacheKey(host, strconv.FormatInt(projectID, 10)), path)
+}
+
+func getTTL[T any](c *cache, m map[string]cacheEntry[T], key string, ttl time.Duration) (T, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := m[key]
+	if !ok || c.now().Sub(entry.fetchedAt) > ttl {
+		var zero T
+		return zero, false
+	}
+	return entry.value, true
+}
+
+func setTTL[T any](c *cache, m map[string]cacheEntry[T], key string, value T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(m) >= cacheMaxEntries {
+		clear(m)
+	}
+	m[key] = cacheEntry[T]{value: value, fetchedAt: c.now()}
+}

--- a/backend/internal/adapters/scm/onedev/client.go
+++ b/backend/internal/adapters/scm/onedev/client.go
@@ -184,6 +184,32 @@ func (c *Client) doGET(ctx context.Context, path string, q url.Values) (APIRespo
 	return APIResponse{StatusCode: resp.StatusCode, Body: body}, nil
 }
 
+// doGETStream performs an authenticated GET and hands the caller the still-open
+// response body.
+//
+// It exists for /~api/streaming/build-logs/{buildId}, whose response is an
+// unbounded length-prefixed frame stream rather than a document. doGET would
+// buffer the whole thing before the caller saw a byte; here the caller decodes
+// incrementally and closes the body when it has what it needs. The caller owns
+// the returned ReadCloser and must close it.
+func (c *Client) doGETStream(ctx context.Context, path string, q url.Values) (io.ReadCloser, error) {
+	req, err := c.newRequest(ctx, path, q)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "*/*")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("onedev scm: GET %s: %w", path, err)
+	}
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyMaxBytes))
+		_ = resp.Body.Close()
+		return nil, c.noteAuthFailure(classifyError(resp, body))
+	}
+	return resp.Body, nil
+}
+
 // doGETPaginated walks a OneDev listing endpoint with offset/count paging,
 // invoking handler once per page with that page's raw JSON body. The handler
 // returns how many items the page held; a page shorter than the requested

--- a/backend/internal/adapters/scm/onedev/client.go
+++ b/backend/internal/adapters/scm/onedev/client.go
@@ -1,0 +1,347 @@
+package onedev
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+var (
+	// ErrNotFound is returned when a OneDev API resource does not exist.
+	ErrNotFound = ports.ErrSCMNotFound
+	// ErrRateLimited is returned when OneDev responds with HTTP 429. Callers
+	// needing structured retry hints should use errors.As to extract a
+	// *RateLimitError.
+	ErrRateLimited = errors.New("onedev scm: rate limited")
+	// ErrNoAPIBase is returned by NewClient when no API base URL was supplied.
+	// OneDev is always self-hosted, so there is no default to fall back on.
+	ErrNoAPIBase = errors.New("onedev scm: no API base URL configured")
+)
+
+const (
+	// defaultUserAgent identifies AO's OneDev traffic in instance logs.
+	defaultUserAgent = "ao-onedev-scm/1"
+	// defaultHTTPTimeout bounds every API call so a hung OneDev instance
+	// cannot block the observer's polling goroutine indefinitely.
+	defaultHTTPTimeout = 30 * time.Second
+	// maxPageCount is OneDev's per-page ceiling. A larger count is rejected
+	// with HTTP 406 ("Count should not be greater than 100"), so the client
+	// clamps rather than letting the server reject the request.
+	maxPageCount = 100
+	// maxPaginationPages bounds a single paginated walk so a pathological
+	// result set cannot spin forever. Hitting it marks the result truncated.
+	maxPaginationPages = 10
+	// errorBodyMaxBytes caps how much of an error response body is read
+	// before classification. OneDev's error bodies are short plain-text
+	// strings, but a proxy in front of it may return a large HTML page.
+	errorBodyMaxBytes = 4096
+	// messageMaxRunes bounds the error text carried into a wrapped error, so
+	// one malformed response cannot produce a log line of unbounded width.
+	messageMaxRunes = 200
+)
+
+// RateLimitError carries the backoff hints from a 429 response. Callers that
+// only need the category use errors.Is(err, ErrRateLimited); callers needing
+// the exact backoff use errors.As. The getters match the shape the
+// provider-neutral observer's cooldown helper expects.
+type RateLimitError struct {
+	ResetAt    time.Time
+	RetryAfter time.Duration
+	Message    string
+}
+
+// Error formats the rate-limit error for logs.
+func (e *RateLimitError) Error() string {
+	if e == nil {
+		return ErrRateLimited.Error()
+	}
+	if e.Message != "" {
+		return "onedev scm: rate limited: " + e.Message
+	}
+	return ErrRateLimited.Error()
+}
+
+// Is lets errors.Is match a *RateLimitError against ErrRateLimited.
+func (e *RateLimitError) Is(target error) bool { return target == ErrRateLimited }
+
+// GetRetryAfter exposes the Retry-After hint.
+func (e *RateLimitError) GetRetryAfter() time.Duration {
+	if e == nil {
+		return 0
+	}
+	return e.RetryAfter
+}
+
+// GetResetAt exposes the reset-time hint.
+func (e *RateLimitError) GetResetAt() time.Time {
+	if e == nil {
+		return time.Time{}
+	}
+	return e.ResetAt
+}
+
+// APIResponse is the normalised result of a OneDev API call.
+//
+// Unlike the GitHub and GitLab adapters there is no ETag or NotModified
+// field: OneDev sends neither ETag nor Last-Modified, so there is no
+// transport-level validator to carry. See the package doc.
+type APIResponse struct {
+	StatusCode int
+	Body       []byte
+}
+
+// ClientOptions configures the OneDev HTTP client.
+type ClientOptions struct {
+	HTTPClient *http.Client
+	Token      TokenSource
+	// APIBase is the full REST root of one instance, including the "/~api"
+	// suffix — e.g. "http://10.0.0.30:6610/~api". Required.
+	APIBase   string
+	UserAgent string
+}
+
+// Client wraps one OneDev instance's REST API. It handles auth and error
+// classification. Each instance gets its own Client so a credential is never
+// carried across hosts.
+type Client struct {
+	http      *http.Client
+	tokens    TokenSource
+	apiBase   string
+	userAgent string
+}
+
+// NewClient creates a OneDev API client. APIBase is required: OneDev has no
+// public instance, so there is no sensible default and guessing one would
+// point traffic at a host the operator never configured.
+func NewClient(opts ClientOptions) (*Client, error) {
+	base := strings.TrimRight(strings.TrimSpace(opts.APIBase), "/")
+	if base == "" {
+		return nil, ErrNoAPIBase
+	}
+	hc := opts.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	ua := strings.TrimSpace(opts.UserAgent)
+	if ua == "" {
+		ua = defaultUserAgent
+	}
+	return &Client{http: hc, tokens: opts.Token, apiBase: base, userAgent: ua}, nil
+}
+
+// APIBase returns the REST root this client talks to.
+func (c *Client) APIBase() string { return c.apiBase }
+
+// Preflight verifies the configured credential against this instance by
+// listing a single project. GET /~api/projects is cheap, requires
+// authentication, and is available to every account, which makes it a good
+// liveness-plus-auth check.
+//
+// The returned error is classified: ErrNoToken when nothing is configured,
+// ErrAuthFailed when OneDev rejects the credential, and a wrapped transport
+// error otherwise — so the daemon's wiring can distinguish "not configured"
+// from "configured wrongly" from "instance unreachable".
+func (c *Client) Preflight(ctx context.Context) error {
+	q := url.Values{"offset": {"0"}, "count": {"1"}}
+	if _, err := c.doGET(ctx, "/projects", q); err != nil {
+		return fmt.Errorf("onedev scm: preflight %s/projects: %w", c.apiBase, err)
+	}
+	return nil
+}
+
+// doGET performs an authenticated GET and returns the decoded-ready body.
+//
+// There is no conditional-request path: OneDev emits no ETag or
+// Last-Modified, so every call is a full fetch.
+func (c *Client) doGET(ctx context.Context, path string, q url.Values) (APIResponse, error) {
+	req, err := c.newRequest(ctx, path, q)
+	if err != nil {
+		return APIResponse{}, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return APIResponse{}, fmt.Errorf("onedev scm: GET %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyMaxBytes))
+		return APIResponse{StatusCode: resp.StatusCode}, c.noteAuthFailure(classifyError(resp, body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return APIResponse{StatusCode: resp.StatusCode}, fmt.Errorf("onedev scm: read %s body: %w", path, err)
+	}
+	return APIResponse{StatusCode: resp.StatusCode, Body: body}, nil
+}
+
+// doGETPaginated walks a OneDev listing endpoint with offset/count paging,
+// invoking handler once per page with that page's raw JSON body. The handler
+// returns how many items the page held; a page shorter than the requested
+// count ends the walk, since OneDev sends no Link header to follow.
+//
+// count is clamped to maxPageCount because OneDev rejects a larger value with
+// HTTP 406. The bool result reports that maxPaginationPages was reached and
+// the result is therefore truncated.
+func (c *Client) doGETPaginated(ctx context.Context, path string, q url.Values, handler func(body []byte) (int, error)) (bool, error) {
+	page := url.Values{}
+	for k, vs := range q {
+		page[k] = append([]string(nil), vs...)
+	}
+	count := maxPageCount
+	if raw := page.Get("count"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n < maxPageCount {
+			count = n
+		}
+	}
+	offset := 0
+	if raw := page.Get("offset"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			offset = n
+		}
+	}
+	page.Set("count", strconv.Itoa(count))
+
+	for i := 0; i < maxPaginationPages; i++ {
+		page.Set("offset", strconv.Itoa(offset))
+		resp, err := c.doGET(ctx, path, page)
+		if err != nil {
+			return false, err
+		}
+		n, err := handler(resp.Body)
+		if err != nil {
+			return false, err
+		}
+		if n < count {
+			return false, nil
+		}
+		offset += n
+	}
+	return true, nil
+}
+
+func (c *Client) newRequest(ctx context.Context, path string, q url.Values) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiURL(path, q), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("onedev scm: build %s request: %w", path, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+	if err := c.authorize(ctx, req); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// authorize resolves and attaches the credential. A client with no token
+// source is an error rather than an anonymous request: OneDev's API requires
+// authentication, so an unauthenticated call only produces a confusing 401.
+func (c *Client) authorize(ctx context.Context, req *http.Request) error {
+	if c.tokens == nil {
+		return ErrNoToken
+	}
+	cred, err := c.tokens.Token(ctx)
+	if err != nil {
+		return err
+	}
+	return cred.apply(req)
+}
+
+// noteAuthFailure drops the cached credential when OneDev rejects it, so a
+// rotated token is picked up on the next call instead of failing until
+// restart.
+func (c *Client) noteAuthFailure(err error) error {
+	if !errors.Is(err, ErrAuthFailed) {
+		return err
+	}
+	if inv, ok := c.tokens.(tokenInvalidator); ok {
+		inv.InvalidateToken()
+	}
+	return err
+}
+
+func (c *Client) apiURL(path string, q url.Values) string {
+	u := c.apiBase + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	return u
+}
+
+// classifyError maps a OneDev error response onto this package's sentinels.
+func classifyError(resp *http.Response, body []byte) error {
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusUnauthorized, http.StatusForbidden:
+		if msg := errorMessage(body); msg != "" {
+			return fmt.Errorf("%w: %s", ErrAuthFailed, msg)
+		}
+		return ErrAuthFailed
+	case http.StatusTooManyRequests:
+		return rateLimited(resp, body)
+	default:
+		msg := errorMessage(body)
+		if msg == "" {
+			msg = resp.Status
+		}
+		return fmt.Errorf("onedev scm: %s", msg)
+	}
+}
+
+// rateLimited builds a *RateLimitError from a 429, parsing Retry-After
+// (seconds or an HTTP date) so a caller can apply a cooldown instead of
+// hammering the instance.
+func rateLimited(resp *http.Response, body []byte) error {
+	e := &RateLimitError{Message: errorMessage(body)}
+	if ra := strings.TrimSpace(resp.Header.Get("Retry-After")); ra != "" {
+		if sec, err := strconv.Atoi(ra); err == nil && sec >= 0 {
+			e.RetryAfter = time.Duration(sec) * time.Second
+		} else if when, err := http.ParseTime(ra); err == nil {
+			e.ResetAt = when
+		}
+	}
+	return e
+}
+
+// errorMessage extracts a short human-readable message from an error body.
+// OneDev returns plain text for most failures (for example "Invalid account
+// or incorrect credentials") but JSON for some, so both are handled. The
+// result is truncated so a stray HTML page cannot widen a log line without
+// bound.
+func errorMessage(body []byte) string {
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return ""
+	}
+	var v struct {
+		ErrorMessage string `json:"errorMessage"`
+		Message      string `json:"message"`
+		Error        string `json:"error"`
+	}
+	if json.Unmarshal(body, &v) == nil {
+		for _, cand := range []string{v.ErrorMessage, v.Message, v.Error} {
+			if cand = strings.TrimSpace(cand); cand != "" {
+				return truncate(cand)
+			}
+		}
+	}
+	return truncate(strings.Join(strings.Fields(trimmed), " "))
+}
+
+func truncate(s string) string {
+	runes := []rune(s)
+	if len(runes) <= messageMaxRunes {
+		return s
+	}
+	return string(runes[:messageMaxRunes]) + "..."
+}

--- a/backend/internal/adapters/scm/onedev/client_test.go
+++ b/backend/internal/adapters/scm/onedev/client_test.go
@@ -1,0 +1,434 @@
+package onedev
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestClient(t *testing.T, apiBase string, tokens TokenSource) *Client {
+	t.Helper()
+	c, err := NewClient(ClientOptions{APIBase: apiBase, Token: tokens})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestNewClientRequiresAPIBase(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		wantErr error
+		want    string
+	}{
+		{name: "empty", base: "", wantErr: ErrNoAPIBase},
+		{name: "whitespace", base: "   ", wantErr: ErrNoAPIBase},
+		{name: "trailing slash trimmed", base: "http://od.test:6610/~api/", want: "http://od.test:6610/~api"},
+		{name: "kept as given", base: "http://od.test:6610/~api", want: "http://od.test:6610/~api"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(ClientOptions{APIBase: tt.base})
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("NewClient err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+			if c.APIBase() != tt.want {
+				t.Fatalf("APIBase() = %q, want %q", c.APIBase(), tt.want)
+			}
+		})
+	}
+}
+
+// TestPreflightSendsAuthenticatedProjectsRequest pins the preflight contract:
+// GET against the /~api root (not /api), with the credential attached.
+func TestPreflightSendsAuthenticatedProjectsRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		tokens   TokenSource
+		wantAuth func(t *testing.T, r *http.Request)
+	}{
+		{
+			name:   "bearer token",
+			tokens: StaticTokenSource("od-token"),
+			wantAuth: func(t *testing.T, r *http.Request) {
+				if got := r.Header.Get("Authorization"); got != "Bearer od-token" {
+					t.Errorf("Authorization = %q, want Bearer od-token", got)
+				}
+			},
+		},
+		{
+			name:   "basic auth",
+			tokens: StaticBasicAuthSource{Username: "svc", Password: "pw"},
+			wantAuth: func(t *testing.T, r *http.Request) {
+				user, pass, ok := r.BasicAuth()
+				if !ok || user != "svc" || pass != "pw" {
+					t.Errorf("BasicAuth = (%q, %q, %v), want (svc, pw, true)", user, pass, ok)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotQuery string
+			srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+				tt.wantAuth(t, r)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[{"id":1,"path":"Homelab"}]`))
+			})
+			c := newTestClient(t, srv.URL+APIBasePath, tt.tokens)
+			if err := c.Preflight(context.Background()); err != nil {
+				t.Fatalf("Preflight: %v", err)
+			}
+			if gotPath != "/~api/projects" {
+				t.Errorf("path = %q, want /~api/projects", gotPath)
+			}
+			q, _ := url.ParseQuery(gotQuery)
+			if q.Get("count") != "1" || q.Get("offset") != "0" {
+				t.Errorf("query = %q, want offset=0&count=1", gotQuery)
+			}
+		})
+	}
+}
+
+func TestPreflightErrorClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		tokens     TokenSource
+		wantErr    error
+		wantSubstr string
+	}{
+		{
+			// Verified against a live instance: OneDev answers a bad token with
+			// 401 and a plain-text body.
+			name:   "bad credential is ErrAuthFailed",
+			status: http.StatusUnauthorized, body: "Invalid account or incorrect credentials",
+			tokens: StaticTokenSource("od-bad"), wantErr: ErrAuthFailed,
+			wantSubstr: "Invalid account or incorrect credentials",
+		},
+		{
+			name:   "forbidden is ErrAuthFailed",
+			status: http.StatusForbidden, body: "", tokens: StaticTokenSource("od-token"),
+			wantErr: ErrAuthFailed,
+		},
+		{
+			name:   "not found",
+			status: http.StatusNotFound, body: "", tokens: StaticTokenSource("od-token"),
+			wantErr: ErrNotFound,
+		},
+		{
+			name:   "rate limited",
+			status: http.StatusTooManyRequests, body: "slow down", tokens: StaticTokenSource("od-token"),
+			wantErr: ErrRateLimited,
+		},
+		{
+			name:   "other errors carry the server message",
+			status: http.StatusNotAcceptable, body: "Count should not be greater than 100",
+			tokens: StaticTokenSource("od-token"), wantSubstr: "Count should not be greater than 100",
+		},
+		{
+			name:   "no credential configured",
+			status: http.StatusOK, body: "[]", tokens: nil, wantErr: ErrNoToken,
+		},
+		{
+			name:   "token source yields nothing",
+			status: http.StatusOK, body: "[]", tokens: StaticTokenSource(""), wantErr: ErrNoToken,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			})
+			c := newTestClient(t, srv.URL+APIBasePath, tt.tokens)
+			err := c.Preflight(context.Background())
+			if err == nil {
+				t.Fatal("Preflight succeeded, want error")
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantSubstr != "" && !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("err = %v, want it to mention %q", err, tt.wantSubstr)
+			}
+			// Every preflight failure names the instance it failed against.
+			if !strings.Contains(err.Error(), srv.URL) {
+				t.Fatalf("err = %v, want it to name the API base %q", err, srv.URL)
+			}
+		})
+	}
+}
+
+// TestAuthFailureInvalidatesCachedCredential covers the rotated-token case: a
+// 401 must drop the cached credential so the next call re-reads it, rather
+// than failing until the daemon restarts.
+func TestAuthFailureInvalidatesCachedCredential(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer good" {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("Invalid account or incorrect credentials"))
+	})
+
+	secrets := []string{"stale", "good"}
+	calls := 0
+	src := &CommandTokenSource{
+		Command:  []string{"helper"},
+		TokenTTL: time.Hour,
+		Run: func(context.Context, []string) (string, error) {
+			s := secrets[calls]
+			calls++
+			return s, nil
+		},
+	}
+	c := newTestClient(t, srv.URL+APIBasePath, src)
+
+	if err := c.Preflight(context.Background()); !errors.Is(err, ErrAuthFailed) {
+		t.Fatalf("first Preflight err = %v, want ErrAuthFailed", err)
+	}
+	if err := c.Preflight(context.Background()); err != nil {
+		t.Fatalf("second Preflight: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("helper ran %d times, want 2 (credential re-read after 401)", calls)
+	}
+}
+
+// TestNoConditionalRequestHeaders pins the verified fact that OneDev sends no
+// ETag or Last-Modified: the client must not send validators the server will
+// ignore, and must not grow a 304 path that can never fire.
+func TestNoConditionalRequestHeaders(t *testing.T) {
+	var got http.Header
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		_, _ = w.Write([]byte("[]"))
+	})
+	c := newTestClient(t, srv.URL+APIBasePath, StaticTokenSource("od-token"))
+	if err := c.Preflight(context.Background()); err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+	for _, h := range []string{"If-None-Match", "If-Modified-Since"} {
+		if v := got.Get(h); v != "" {
+			t.Errorf("request carried %s = %q; OneDev supports no conditional requests", h, v)
+		}
+	}
+	if got.Get("User-Agent") != defaultUserAgent {
+		t.Errorf("User-Agent = %q, want %q", got.Get("User-Agent"), defaultUserAgent)
+	}
+}
+
+// projectPage renders a page of n synthetic project records.
+func projectPage(offset, n int) []byte {
+	items := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		items = append(items, map[string]any{"id": offset + i, "path": fmt.Sprintf("p%d", offset+i)})
+	}
+	b, _ := json.Marshal(items)
+	return b
+}
+
+func TestDoGETPaginated(t *testing.T) {
+	tests := []struct {
+		name          string
+		total         int
+		query         url.Values
+		wantItems     int
+		wantPages     int
+		wantCount     string
+		wantTruncated bool
+	}{
+		{
+			name: "single short page ends the walk", total: 7,
+			wantItems: 7, wantPages: 1, wantCount: "100",
+		},
+		{
+			name: "exact page boundary needs one more request", total: 100,
+			wantItems: 100, wantPages: 2, wantCount: "100",
+		},
+		{
+			name: "multiple pages", total: 250,
+			wantItems: 250, wantPages: 3, wantCount: "100",
+		},
+		{
+			name: "empty result", total: 0,
+			wantItems: 0, wantPages: 1, wantCount: "100",
+		},
+		{
+			// OneDev rejects count > 100 with HTTP 406, so the client clamps
+			// rather than letting the server refuse the request.
+			name: "oversized count is clamped", total: 5, query: url.Values{"count": {"5000"}},
+			wantItems: 5, wantPages: 1, wantCount: "100",
+		},
+		{
+			name: "smaller count is respected", total: 5, query: url.Values{"count": {"2"}},
+			wantItems: 5, wantPages: 3, wantCount: "2",
+		},
+		{
+			name: "page cap marks the result truncated", total: 100 * (maxPaginationPages + 2),
+			wantItems: 100 * maxPaginationPages, wantPages: maxPaginationPages,
+			wantCount: "100", wantTruncated: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pages, counts := 0, map[string]bool{}
+			srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				pages++
+				q := r.URL.Query()
+				counts[q.Get("count")] = true
+				offset, _ := strconv.Atoi(q.Get("offset"))
+				count, _ := strconv.Atoi(q.Get("count"))
+				n := tt.total - offset
+				if n > count {
+					n = count
+				}
+				if n < 0 {
+					n = 0
+				}
+				_, _ = w.Write(projectPage(offset, n))
+			})
+			c := newTestClient(t, srv.URL+APIBasePath, StaticTokenSource("od-token"))
+
+			items := 0
+			truncated, err := c.doGETPaginated(context.Background(), "/projects", tt.query, func(body []byte) (int, error) {
+				var page []map[string]any
+				if err := json.Unmarshal(body, &page); err != nil {
+					return 0, err
+				}
+				items += len(page)
+				return len(page), nil
+			})
+			if err != nil {
+				t.Fatalf("doGETPaginated: %v", err)
+			}
+			if truncated != tt.wantTruncated {
+				t.Errorf("truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+			if items != tt.wantItems {
+				t.Errorf("items = %d, want %d", items, tt.wantItems)
+			}
+			if pages != tt.wantPages {
+				t.Errorf("pages = %d, want %d", pages, tt.wantPages)
+			}
+			if len(counts) != 1 || !counts[tt.wantCount] {
+				t.Errorf("count params = %v, want only %q", counts, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestDoGETPaginatedPropagatesErrors(t *testing.T) {
+	t.Run("transport error", func(t *testing.T) {
+		srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+		c := newTestClient(t, srv.URL+APIBasePath, StaticTokenSource("od-token"))
+		_, err := c.doGETPaginated(context.Background(), "/projects", nil, func([]byte) (int, error) {
+			t.Fatal("handler must not run on an error response")
+			return 0, nil
+		})
+		if !errors.Is(err, ErrAuthFailed) {
+			t.Fatalf("err = %v, want ErrAuthFailed", err)
+		}
+	})
+
+	t.Run("handler error", func(t *testing.T) {
+		boom := errors.New("decode failed")
+		srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(projectPage(0, 100))
+		})
+		c := newTestClient(t, srv.URL+APIBasePath, StaticTokenSource("od-token"))
+		_, err := c.doGETPaginated(context.Background(), "/projects", nil, func([]byte) (int, error) {
+			return 0, boom
+		})
+		if !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want boom", err)
+		}
+	})
+}
+
+func TestRateLimitErrorHints(t *testing.T) {
+	reset := time.Date(2026, 8, 27, 18, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		retryAfter     string
+		wantRetryAfter time.Duration
+		wantResetAt    time.Time
+	}{
+		{name: "no header", retryAfter: ""},
+		{name: "seconds", retryAfter: "30", wantRetryAfter: 30 * time.Second},
+		{name: "zero seconds", retryAfter: "0", wantRetryAfter: 0},
+		{name: "http date", retryAfter: reset.Format(http.TimeFormat), wantResetAt: reset},
+		{name: "junk is ignored", retryAfter: "soon"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if tt.retryAfter != "" {
+					w.Header().Set("Retry-After", tt.retryAfter)
+				}
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte("too many requests"))
+			})
+			c := newTestClient(t, srv.URL+APIBasePath, StaticTokenSource("od-token"))
+			err := c.Preflight(context.Background())
+			if !errors.Is(err, ErrRateLimited) {
+				t.Fatalf("err = %v, want ErrRateLimited", err)
+			}
+			var rl *RateLimitError
+			if !errors.As(err, &rl) {
+				t.Fatalf("err = %v, want a *RateLimitError", err)
+			}
+			if rl.GetRetryAfter() != tt.wantRetryAfter {
+				t.Errorf("RetryAfter = %v, want %v", rl.GetRetryAfter(), tt.wantRetryAfter)
+			}
+			if !rl.GetResetAt().Equal(tt.wantResetAt) {
+				t.Errorf("ResetAt = %v, want %v", rl.GetResetAt(), tt.wantResetAt)
+			}
+		})
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "empty", body: "", want: ""},
+		{name: "whitespace", body: "  \n ", want: ""},
+		{name: "plain text", body: "Invalid account or incorrect credentials", want: "Invalid account or incorrect credentials"},
+		{name: "plain text is collapsed", body: "Count should not\n  be greater than 100", want: "Count should not be greater than 100"},
+		{name: "json errorMessage", body: `{"errorMessage":"no such project"}`, want: "no such project"},
+		{name: "json message", body: `{"message":"nope"}`, want: "nope"},
+		{name: "json error", body: `{"error":"nope"}`, want: "nope"},
+		{name: "json without a known field falls back to raw", body: `{"x":1}`, want: `{"x":1}`},
+		{name: "long body is truncated", body: strings.Repeat("a", messageMaxRunes+50), want: strings.Repeat("a", messageMaxRunes) + "..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := errorMessage([]byte(tt.body)); got != tt.want {
+				t.Fatalf("errorMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/scm/onedev/doc.go
+++ b/backend/internal/adapters/scm/onedev/doc.go
@@ -83,6 +83,26 @@
 // deployment that path never fires. It is defence for the proxy case, not a
 // claim that OneDev reports quota.
 //
+// # Identity is host-scoped
+//
+// OneDev's user database is per-instance, so identity is host-scoped:
+// AuthenticatedIdentityForHost is the primary method and the multi provider
+// prefers it, exactly as it does for self-managed GitLab. The unscoped
+// AuthenticatedIdentity resolves only when the allowlist names one instance;
+// with several configured it refuses rather than guessing which account the
+// caller meant. GET /~api/users/me is the lookup — /~api/users/{id} needs an
+// id the caller does not have, and listing /~api/users is admin-only.
+//
+// # Merging is deliberately unsupported
+//
+// The adapter is read-only. MergePullRequest exists only to return
+// ports.ErrSCMUnsupported, because OneDev's merge endpoint has no
+// compare-and-swap: POST /~api/pulls/{requestId}/merge takes an optional note,
+// accepts no expected-head precondition, and returns no merge commit. Honouring
+// SCMMergeRequest.ExpectedHeadSHA would mean checking the head and then
+// merging, and a push landing in that window would have AO merge an unreviewed
+// revision. See merge.go for the full reasoning before implementing it.
+//
 // # Inline review threads are not available
 //
 // OneDev exposes code comments only as GET /~api/code-comments/{commentId}:

--- a/backend/internal/adapters/scm/onedev/doc.go
+++ b/backend/internal/adapters/scm/onedev/doc.go
@@ -1,10 +1,10 @@
 // Package onedev observes OneDev pull requests for AO's SCM integrations.
 //
-// This package is being built in slices. Slice 1 (this code) provides the
-// foundation only: configuration, credential resolution, the HTTP client, an
-// authenticated preflight, and repository-URL parsing. The seven
-// scm.Provider observer methods and the daemon wiring land in Slice 2, so
-// nothing here is registered with the observer yet.
+// The package satisfies the observer's scm.Provider contract: repository-URL
+// parsing, the pull-request list and its guard, the commit-checks guard,
+// batched pull-request fetches, failed-build log tails, and review threads.
+// The daemon registers it alongside the GitHub and GitLab providers in
+// internal/daemon/scm_wiring.go.
 //
 // # Always self-hosted
 //
@@ -32,14 +32,62 @@
 // Link header, and count is capped at 100 (a larger value is rejected with
 // HTTP 406), so doGETPaginated walks pages until one comes back short.
 //
-// # No conditional requests
+// Three shapes of OneDev's query language are easy to get wrong and are
+// pinned by tests:
+//
+//   - The date operator is "since", not "after". `"Last Activity Date" is
+//     after "..."` is rejected with HTTP 406 "Invalid query".
+//   - A pull-request reference in a build query must be project-qualified —
+//     "productone#106". A bare number is rejected with "Reference project not
+//     specified" even when the query already names the project.
+//   - Ids in paths are internal entity ids, not the numbers users see. A
+//     pull request's /pulls/{requestId} routes take its "id"; its "number" is
+//     per-project. resolveRequestID maps between them and caches the result.
+//
+// # No conditional requests, and what the guards do instead
 //
 // OneDev returns neither ETag nor Last-Modified on API responses. This was
 // verified against a live instance. The client therefore has no
 // If-None-Match / If-Modified-Since plumbing at all — adding it would send
-// headers the server ignores and invite callers to assume a 304 path that
-// can never fire. A future guard for the observer must be synthesised from a
-// cheap query (for example the newest pull-request update timestamp in a
-// project) rather than from a transport-level validator; that logic belongs
-// with the observer methods in Slice 2.
+// headers the server ignores and invite callers to assume a 304 path that can
+// never fire.
+//
+// Both guard methods synthesise their own validator instead, hashing a cheap
+// query's result into the token the observer round-trips. They degrade towards
+// reporting "changed": an empty caller token, an unavailable probe, or an
+// ambiguous result all lead to a full fetch rather than a claim of freshness
+// the transport cannot back.
+//
+// The two guards are not equally strong, and the difference is documented on
+// each method. RepoPRListGuard's token is sound — every change to a pull
+// request bumps its last-activity date, so the newest request's identity and
+// timestamp cannot stay fixed across a change. CommitChecksGuard's is an
+// optimisation only: OneDev has no per-commit build lookup AO can rely on (the
+// global build query's "Commit" criterion answers HTTP 404 "Unable to find
+// revision" even for commits that exist) and builds carry no last-activity
+// field, so the guard hashes a bounded window of the project's recent builds.
+// The observer's DefaultPRMaxAge backstop, not this guard, is what bounds CI
+// staleness.
+//
+// This is a deliberate trade rather than a gap. GitHub needs conditional
+// requests because it is rate-limited and bills every unconditional call; a
+// self-hosted OneDev generally is not, so polling it is cheap and correctness
+// is worth more than the round-trips saved.
+//
+// # No rate-limit signal
+//
+// The client models a 429 (RateLimitError, satisfying the observer's
+// GetRetryAfter/GetResetAt capability) so that a reverse proxy or WAF in front
+// of an instance is handled correctly. OneDev itself does not throttle the
+// REST API and emits no rate-limit headers of its own, so in a direct
+// deployment that path never fires. It is defence for the proxy case, not a
+// claim that OneDev reports quota.
+//
+// # Inline review threads are not available
+//
+// OneDev exposes code comments only as GET /~api/code-comments/{commentId}:
+// there is no per-request listing and no query resource, so an inline thread
+// cannot be enumerated from a pull request. FetchReviewThreads returns review
+// verdicts and request-level comments, and marks the observation Partial so
+// the store merges those rows rather than deleting the threads AO cannot see.
 package onedev

--- a/backend/internal/adapters/scm/onedev/doc.go
+++ b/backend/internal/adapters/scm/onedev/doc.go
@@ -1,0 +1,45 @@
+// Package onedev observes OneDev pull requests for AO's SCM integrations.
+//
+// This package is being built in slices. Slice 1 (this code) provides the
+// foundation only: configuration, credential resolution, the HTTP client, an
+// authenticated preflight, and repository-URL parsing. The seven
+// scm.Provider observer methods and the daemon wiring land in Slice 2, so
+// nothing here is registered with the observer yet.
+//
+// # Always self-hosted
+//
+// Unlike GitHub and GitLab there is no public OneDev SaaS instance — every
+// deployment is self-hosted. There is therefore no default host and no
+// default API base: the host allowlist (AO_ONEDEV_ALLOWED_HOSTS) is required
+// configuration, and NewProvider fails with ErrNoAllowedHosts when it is
+// empty rather than silently defaulting to some public endpoint.
+//
+// Allowlist entries may carry an explicit scheme because self-hosted OneDev
+// is commonly reached over plain HTTP on a private network:
+//
+//	onedev.example.com           -> https://onedev.example.com/~api
+//	onedev.example.com:6610      -> https://onedev.example.com:6610/~api
+//	http://10.0.0.30:6610        -> http://10.0.0.30:6610/~api
+//
+// # API surface
+//
+// OneDev's REST root is "/~api", not "/api". Authentication is either a
+// bearer access token or HTTP basic auth; both are modelled by Credential.
+// GET /~api/projects is the preflight target — it is cheap, requires
+// authentication, and returns 401 for a bad or missing credential.
+//
+// Listing endpoints paginate with offset/count query parameters. There is no
+// Link header, and count is capped at 100 (a larger value is rejected with
+// HTTP 406), so doGETPaginated walks pages until one comes back short.
+//
+// # No conditional requests
+//
+// OneDev returns neither ETag nor Last-Modified on API responses. This was
+// verified against a live instance. The client therefore has no
+// If-None-Match / If-Modified-Since plumbing at all — adding it would send
+// headers the server ignores and invite callers to assume a 304 path that
+// can never fire. A future guard for the observer must be synthesised from a
+// cheap query (for example the newest pull-request update timestamp in a
+// project) rather than from a transport-level validator; that logic belongs
+// with the observer methods in Slice 2.
+package onedev

--- a/backend/internal/adapters/scm/onedev/host.go
+++ b/backend/internal/adapters/scm/onedev/host.go
@@ -1,0 +1,115 @@
+package onedev
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+const (
+	// ProviderKey is the normalized provider name stamped on every
+	// ports.SCMRepo this adapter produces.
+	ProviderKey = "onedev"
+
+	// APIBasePath is OneDev's REST root. Note it is "/~api", not "/api" —
+	// OneDev reserves the "~" prefix for its own non-project routes so that
+	// no project path can shadow the API.
+	APIBasePath = "/~api"
+
+	// defaultScheme is applied to an allowlist entry written as a bare
+	// authority ("onedev.example.com:6610"). Operators running OneDev over
+	// plain HTTP on a private network write the scheme explicitly.
+	defaultScheme = "https"
+)
+
+// NormalizeHost lowercases and trims a host string. This is the canonical
+// normalization used for allowlist lookup and repository-identity comparison.
+func NormalizeHost(host string) string {
+	return strings.ToLower(strings.TrimSpace(host))
+}
+
+// allowedHost is one entry of the configured OneDev host allowlist: the
+// scheme and authority (host, optionally with a port) of an instance the
+// provider is permitted to talk to. Because OneDev is always self-hosted
+// there is no implicitly-allowed host — every instance must appear here
+// before any credential is attached to a request for it.
+type allowedHost struct {
+	// scheme is "http" or "https", lowercased.
+	scheme string
+	// authority is host[:port], lowercased — e.g. "10.0.0.30:6610".
+	authority string
+}
+
+// apiBase returns the REST base URL for this host, e.g.
+// "http://10.0.0.30:6610/~api".
+func (h allowedHost) apiBase() string {
+	return h.scheme + "://" + h.authority + APIBasePath
+}
+
+// hostname returns the authority with any port stripped, so an SSH remote
+// (OneDev's git SSH port, commonly 6611) can be matched against an allowlist
+// entry written with the HTTP API port (commonly 6610).
+func (h allowedHost) hostname() string {
+	return hostnameOf(h.authority)
+}
+
+// String renders the entry the way an operator would write it in
+// AO_ONEDEV_ALLOWED_HOSTS.
+func (h allowedHost) String() string {
+	return h.scheme + "://" + h.authority
+}
+
+// parseAllowedHost parses one AO_ONEDEV_ALLOWED_HOSTS entry. An entry without
+// a scheme is treated as https. Entries carrying a path, query, fragment, or
+// userinfo are rejected: an allowlist entry names an instance, not a URL, and
+// silently discarding the extra parts would make the allowlist read as more
+// specific than it is.
+func parseAllowedHost(raw string) (allowedHost, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return allowedHost{}, fmt.Errorf("onedev scm: empty host entry")
+	}
+	if !strings.Contains(s, "://") {
+		s = defaultScheme + "://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return allowedHost{}, fmt.Errorf("onedev scm: invalid host entry %q: %w", raw, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return allowedHost{}, fmt.Errorf("onedev scm: host entry %q: scheme must be http or https", raw)
+	}
+	if u.Host == "" {
+		return allowedHost{}, fmt.Errorf("onedev scm: host entry %q: missing host", raw)
+	}
+	if u.User != nil {
+		return allowedHost{}, fmt.Errorf("onedev scm: host entry %q must not contain credentials", raw)
+	}
+	if strings.Trim(u.Path, "/") != "" || u.RawQuery != "" || u.Fragment != "" {
+		return allowedHost{}, fmt.Errorf("onedev scm: host entry %q must be host[:port] only", raw)
+	}
+	return allowedHost{scheme: scheme, authority: NormalizeHost(u.Host)}, nil
+}
+
+// normalizeHostKey reduces a host string that may carry a scheme (as
+// AO_ONEDEV_HOST_TOKENS entries and ports.SCMRepo.Host both may) to the bare
+// lowercased authority used as the allowlist map key.
+func normalizeHostKey(raw string) string {
+	h, err := parseAllowedHost(raw)
+	if err != nil {
+		return NormalizeHost(raw)
+	}
+	return h.authority
+}
+
+// hostnameOf strips the port from an authority, handling bracketed IPv6
+// literals. "10.0.0.30:6610" -> "10.0.0.30", "[::1]:6610" -> "::1".
+func hostnameOf(authority string) string {
+	authority = NormalizeHost(authority)
+	if h, _, err := net.SplitHostPort(authority); err == nil {
+		return h
+	}
+	return strings.Trim(authority, "[]")
+}

--- a/backend/internal/adapters/scm/onedev/host_test.go
+++ b/backend/internal/adapters/scm/onedev/host_test.go
@@ -1,0 +1,124 @@
+package onedev
+
+import "testing"
+
+func TestParseAllowedHost(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantOK    bool
+		scheme    string
+		authority string
+		apiBase   string
+	}{
+		{
+			name: "bare hostname defaults to https", raw: "onedev.example.com", wantOK: true,
+			scheme: "https", authority: "onedev.example.com",
+			apiBase: "https://onedev.example.com/~api",
+		},
+		{
+			name: "hostname with port defaults to https", raw: "onedev.example.com:6610", wantOK: true,
+			scheme: "https", authority: "onedev.example.com:6610",
+			apiBase: "https://onedev.example.com:6610/~api",
+		},
+		{
+			name: "explicit http is preserved", raw: "http://10.0.0.30:6610", wantOK: true,
+			scheme: "http", authority: "10.0.0.30:6610",
+			apiBase: "http://10.0.0.30:6610/~api",
+		},
+		{
+			name: "explicit https", raw: "https://git.example.com", wantOK: true,
+			scheme: "https", authority: "git.example.com",
+			apiBase: "https://git.example.com/~api",
+		},
+		{
+			name: "case and whitespace are normalized", raw: "  HTTP://OneDev.Example.COM:6610  ", wantOK: true,
+			scheme: "http", authority: "onedev.example.com:6610",
+			apiBase: "http://onedev.example.com:6610/~api",
+		},
+		{
+			name: "ipv6 literal", raw: "http://[::1]:6610", wantOK: true,
+			scheme: "http", authority: "[::1]:6610",
+			apiBase: "http://[::1]:6610/~api",
+		},
+		{
+			name: "trailing slash is tolerated", raw: "http://10.0.0.30:6610/", wantOK: true,
+			scheme: "http", authority: "10.0.0.30:6610",
+			apiBase: "http://10.0.0.30:6610/~api",
+		},
+		{name: "empty", raw: "", wantOK: false},
+		{name: "whitespace only", raw: "   ", wantOK: false},
+		{name: "unsupported scheme", raw: "ssh://onedev.example.com:6611", wantOK: false},
+		{name: "path is rejected", raw: "http://10.0.0.30:6610/~api", wantOK: false},
+		{name: "query is rejected", raw: "http://10.0.0.30:6610?a=b", wantOK: false},
+		{name: "credentials are rejected", raw: "http://user:pw@10.0.0.30:6610", wantOK: false},
+		{name: "missing host", raw: "http://", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAllowedHost(tt.raw)
+			if !tt.wantOK {
+				if err == nil {
+					t.Fatalf("parseAllowedHost(%q) = %+v, want error", tt.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAllowedHost(%q): %v", tt.raw, err)
+			}
+			if got.scheme != tt.scheme {
+				t.Errorf("scheme = %q, want %q", got.scheme, tt.scheme)
+			}
+			if got.authority != tt.authority {
+				t.Errorf("authority = %q, want %q", got.authority, tt.authority)
+			}
+			if got.apiBase() != tt.apiBase {
+				t.Errorf("apiBase() = %q, want %q", got.apiBase(), tt.apiBase)
+			}
+		})
+	}
+}
+
+func TestHostnameOf(t *testing.T) {
+	tests := []struct {
+		authority string
+		want      string
+	}{
+		{"onedev.example.com:6610", "onedev.example.com"},
+		{"onedev.example.com", "onedev.example.com"},
+		{"10.0.0.30:6611", "10.0.0.30"},
+		{"[::1]:6610", "::1"},
+		{"[::1]", "::1"},
+		{"OneDev.Example.COM:6610", "onedev.example.com"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.authority, func(t *testing.T) {
+			if got := hostnameOf(tt.authority); got != tt.want {
+				t.Fatalf("hostnameOf(%q) = %q, want %q", tt.authority, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeHostKey(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{"http://10.0.0.30:6610", "10.0.0.30:6610"},
+		{"10.0.0.30:6610", "10.0.0.30:6610"},
+		{"OneDev.Example.COM", "onedev.example.com"},
+		// A value that is not a parseable host entry falls back to plain
+		// normalization rather than erroring, so a malformed AO_ONEDEV_HOST_TOKENS
+		// key simply never matches.
+		{"not a host!!", "not a host!!"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			if got := normalizeHostKey(tt.raw); got != tt.want {
+				t.Fatalf("normalizeHostKey(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/scm/onedev/identity.go
+++ b/backend/internal/adapters/scm/onedev/identity.go
@@ -1,0 +1,105 @@
+package onedev
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// currentUserPath is OneDev's "who am I" resource. It is the only route that
+// answers for the authenticated account without knowing its numeric id:
+// /~api/users/{id} needs the id, and GET /~api/users is admin-only (a normal
+// account gets HTTP 403), so neither can stand in for it.
+const currentUserPath = "/users/me"
+
+// AuthenticatedIdentity resolves the account the configured credential
+// belongs to.
+//
+// OneDev identity is per-instance — two allowlisted hosts are two unrelated
+// user databases — so this unscoped form is only meaningful when exactly one
+// host is configured, which is the common single-instance deployment. With
+// several hosts configured it refuses rather than picking one, because
+// silently answering for the wrong instance would attribute another
+// instance's pull requests to this account. Callers that know the host (the
+// observer, via ports.ScopedIdentityResolver) use
+// AuthenticatedIdentityForHost instead.
+func (p *Provider) AuthenticatedIdentity(ctx context.Context) (ports.SCMIdentity, error) {
+	return p.AuthenticatedIdentityForHost(ctx, "")
+}
+
+// AuthenticatedIdentityForHost resolves the account the credential for one
+// allowlisted instance belongs to. It is the host-scoped identity method the
+// multi provider prefers, and it is what lets the observer attribute a OneDev
+// pull request to the authenticated user instead of falling back to
+// branch-based discovery.
+//
+// The host is resolved through the same allowlist as a git remote, so a
+// repository's SCMRepo.Host — which may carry OneDev's SSH port rather than
+// its HTTP one — selects the right instance and the right credential. A host
+// outside the allowlist is rejected before any credential is attached.
+//
+// Successful results are cached per host for the provider's lifetime, matching
+// the GitLab adapter: the observer asks once per poll and a login changes only
+// when an account is renamed.
+func (p *Provider) AuthenticatedIdentityForHost(ctx context.Context, host string) (ports.SCMIdentity, error) {
+	h, err := p.identityHost(host)
+	if err != nil {
+		return ports.SCMIdentity{}, err
+	}
+
+	p.identityMu.Lock()
+	defer p.identityMu.Unlock()
+	if ident, ok := p.identities[h.authority]; ok {
+		return ident, nil
+	}
+
+	client, err := p.clientForAuthority(h.authority)
+	if err != nil {
+		return ports.SCMIdentity{}, err
+	}
+	resp, err := client.doGET(ctx, currentUserPath, nil)
+	if err != nil {
+		return ports.SCMIdentity{}, fmt.Errorf("onedev scm: authenticated identity for %s: %w", h.authority, err)
+	}
+	var user restUser
+	if err := json.Unmarshal(resp.Body, &user); err != nil {
+		return ports.SCMIdentity{}, fmt.Errorf("onedev scm: decode authenticated user for %s: %w", h.authority, err)
+	}
+	login := strings.TrimSpace(user.Name)
+	if login == "" {
+		return ports.SCMIdentity{}, fmt.Errorf("onedev scm: authenticated user for %s has no name", h.authority)
+	}
+
+	// Human/bot classification reuses isBotAuthor, the same signal the adapter
+	// applies to pull-request and review authors. OneDev exposes no
+	// human/bot flag, and using a different rule here than for authors would
+	// let the same account read as a bot in one place and a human in another.
+	ident := ports.SCMIdentity{Login: login, Human: !isBotAuthor(login)}
+	if p.identities == nil {
+		p.identities = map[string]ports.SCMIdentity{}
+	}
+	p.identities[h.authority] = ident
+	return ident, nil
+}
+
+// identityHost selects the allowlist entry an identity lookup targets. An
+// empty host is the unscoped call: it resolves only when the allowlist names a
+// single instance.
+func (p *Provider) identityHost(host string) (allowedHost, error) {
+	if strings.TrimSpace(host) == "" {
+		if len(p.order) != 1 {
+			return allowedHost{}, fmt.Errorf(
+				"onedev scm: authenticated identity needs a host; %d instances are configured (%v)",
+				len(p.order), p.AllowedHosts())
+		}
+		return p.allowed[p.order[0]], nil
+	}
+	h, ok := p.resolveHost(host)
+	if !ok {
+		return allowedHost{}, fmt.Errorf("onedev scm: host %q: %w", host, ErrHostNotAllowed)
+	}
+	return h, nil
+}

--- a/backend/internal/adapters/scm/onedev/identity_test.go
+++ b/backend/internal/adapters/scm/onedev/identity_test.go
@@ -1,0 +1,169 @@
+package onedev
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// TestProviderSatisfiesIdentityResolvers pins the interfaces the multi
+// provider type-asserts on. Without the host-scoped one the daemon logged
+// `scm multi: provider "onedev" does not implement AuthenticatedIdentity` and
+// the observer silently fell back to branch-based PR discovery.
+func TestProviderSatisfiesIdentityResolvers(t *testing.T) {
+	p := newTestProvider(t, []string{"od.test:6610"})
+	var _ ports.SCMIdentityResolver = p
+	var _ interface {
+		AuthenticatedIdentityForHost(context.Context, string) (ports.SCMIdentity, error)
+	} = p
+}
+
+func TestAuthenticatedIdentityForHost(t *testing.T) {
+	var calls atomic.Int64
+	var path atomic.Value
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		path.Store(r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":4,"name":"johnkattenhorn","fullName":"John Kattenhorn","type":"ORDINARY"}`))
+	})
+	p := newTestProvider(t, []string{srv.URL})
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	ident, err := p.AuthenticatedIdentityForHost(context.Background(), host)
+	if err != nil {
+		t.Fatalf("AuthenticatedIdentityForHost: %v", err)
+	}
+	if ident.Login != "johnkattenhorn" {
+		t.Errorf("Login = %q, want johnkattenhorn", ident.Login)
+	}
+	if !ident.Human {
+		t.Error("Human = false, want true for an ordinary account")
+	}
+	if got := path.Load().(string); got != APIBasePath+currentUserPath {
+		t.Errorf("probed %q, want %q", got, APIBasePath+currentUserPath)
+	}
+
+	// Cached for the provider's lifetime: the observer resolves identity once
+	// per poll, and a login only changes when an account is renamed.
+	if _, err := p.AuthenticatedIdentityForHost(context.Background(), host); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("API calls = %d, want 1 (identity must be cached)", got)
+	}
+}
+
+// TestAuthenticatedIdentityResolvesSSHPortHost covers the path the observer
+// actually takes: a repository cloned over OneDev's git SSH port carries that
+// port in SCMRepo.Host, which must still resolve to the allowlisted HTTP
+// instance rather than being rejected.
+func TestAuthenticatedIdentityResolvesSSHPortHost(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":4,"name":"ao-bot"}`))
+	})
+	p := newTestProvider(t, []string{srv.URL})
+	hostname := hostnameOf(strings.TrimPrefix(srv.URL, "http://"))
+
+	ident, err := p.AuthenticatedIdentityForHost(context.Background(), hostname+":6611")
+	if err != nil {
+		t.Fatalf("AuthenticatedIdentityForHost: %v", err)
+	}
+	if ident.Login != "ao-bot" {
+		t.Errorf("Login = %q, want ao-bot", ident.Login)
+	}
+	if ident.Human {
+		t.Error("Human = true, want false for a -bot account")
+	}
+}
+
+// TestAuthenticatedIdentityIsPerHost: two instances are two unrelated user
+// databases, so one host's identity must never be served for another.
+func TestAuthenticatedIdentityIsPerHost(t *testing.T) {
+	a := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":1,"name":"alice"}`))
+	})
+	b := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":2,"name":"bob"}`))
+	})
+	p := newTestProvider(t, []string{a.URL, b.URL})
+
+	identA, err := p.AuthenticatedIdentityForHost(context.Background(), strings.TrimPrefix(a.URL, "http://"))
+	if err != nil {
+		t.Fatalf("host a: %v", err)
+	}
+	identB, err := p.AuthenticatedIdentityForHost(context.Background(), strings.TrimPrefix(b.URL, "http://"))
+	if err != nil {
+		t.Fatalf("host b: %v", err)
+	}
+	if identA.Login != "alice" || identB.Login != "bob" {
+		t.Fatalf("identities = %q/%q, want alice/bob (identity cache is not host-scoped)", identA.Login, identB.Login)
+	}
+}
+
+// TestAuthenticatedIdentityUnscoped: the host-less form is only meaningful for
+// a single-instance deployment. With several configured it must refuse rather
+// than attribute one instance's pull requests to another's account.
+func TestAuthenticatedIdentityUnscoped(t *testing.T) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":4,"name":"solo"}`))
+	})
+	single := newTestProvider(t, []string{srv.URL})
+	ident, err := single.AuthenticatedIdentity(context.Background())
+	if err != nil {
+		t.Fatalf("AuthenticatedIdentity: %v", err)
+	}
+	if ident.Login != "solo" {
+		t.Errorf("Login = %q, want solo", ident.Login)
+	}
+
+	multi := newTestProvider(t, []string{srv.URL, "other.test:6610"})
+	if _, err := multi.AuthenticatedIdentity(context.Background()); err == nil {
+		t.Fatal("expected an error when several instances are configured, got nil")
+	}
+}
+
+func TestAuthenticatedIdentityErrors(t *testing.T) {
+	t.Run("host not allowed", func(t *testing.T) {
+		p := newTestProvider(t, []string{"od.test:6610"})
+		_, err := p.AuthenticatedIdentityForHost(context.Background(), "elsewhere.test:6610")
+		if !errors.Is(err, ErrHostNotAllowed) {
+			t.Fatalf("err = %v, want ErrHostNotAllowed", err)
+		}
+	})
+
+	t.Run("credential rejected", func(t *testing.T) {
+		srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("Invalid account or incorrect credentials"))
+		})
+		p := newTestProvider(t, []string{srv.URL})
+		_, err := p.AuthenticatedIdentityForHost(context.Background(), strings.TrimPrefix(srv.URL, "http://"))
+		if !errors.Is(err, ErrAuthFailed) {
+			t.Fatalf("err = %v, want ErrAuthFailed", err)
+		}
+	})
+
+	t.Run("nameless account is not cached as a valid identity", func(t *testing.T) {
+		var calls atomic.Int64
+		srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			_, _ = w.Write([]byte(`{"id":4,"name":""}`))
+		})
+		p := newTestProvider(t, []string{srv.URL})
+		host := strings.TrimPrefix(srv.URL, "http://")
+		if _, err := p.AuthenticatedIdentityForHost(context.Background(), host); err == nil {
+			t.Fatal("expected an error for an account with no name, got nil")
+		}
+		if _, err := p.AuthenticatedIdentityForHost(context.Background(), host); err == nil {
+			t.Fatal("second call: expected an error, got nil")
+		}
+		if got := calls.Load(); got != 2 {
+			t.Errorf("API calls = %d, want 2 (a failed lookup must not be cached)", got)
+		}
+	})
+}

--- a/backend/internal/adapters/scm/onedev/merge.go
+++ b/backend/internal/adapters/scm/onedev/merge.go
@@ -1,0 +1,39 @@
+package onedev
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// MergePullRequest reports that AO does not merge OneDev pull requests. It
+// satisfies ports.SCMMerger so the daemon can register this adapter in the
+// multi-merger: without it, `ao pr merge` on a OneDev pull request fails with
+// "unknown provider" wrapped as a generic SCM failure, which reads as a
+// misconfiguration rather than as a capability this provider does not have.
+//
+// # Why this is unsupported rather than unimplemented
+//
+// ports.SCMMergeRequest carries ExpectedHeadSHA as a compare-and-swap guard,
+// and its contract is explicit: "Provider implementations must reject the
+// mutation if the live head has advanced." OneDev cannot honour that.
+// POST /~api/pulls/{requestId}/merge takes an optional note and nothing else —
+// there is no head-SHA precondition, no if-match header, and the response
+// carries no merge commit to reconcile against afterwards.
+//
+// The only way to emulate the guard is to read the head, compare it, and then
+// merge — which leaves a real time-of-check-to-time-of-use window. A push
+// landing inside that window would have AO merge a revision that was never
+// reviewed and never passed CI, and a merge is not reversible by AO. Failing
+// closed on an irreversible action is the better trade: the operator merges in
+// the OneDev UI, where they can see what they are merging.
+//
+// If OneDev later grows a head-SHA precondition on its merge endpoint, this is
+// the method to implement — not the check-then-merge sequence, which is what
+// this comment exists to stop being reintroduced as an obvious fix.
+func (p *Provider) MergePullRequest(_ context.Context, request ports.SCMMergeRequest) (ports.SCMMergeResult, error) {
+	return ports.SCMMergeResult{}, fmt.Errorf(
+		"%w: onedev cannot merge %s#%d safely from AO (its merge API has no expected-head precondition); merge it in the OneDev UI",
+		ports.ErrSCMUnsupported, request.PR.Repo.Repo, request.PR.Number)
+}

--- a/backend/internal/adapters/scm/onedev/merge_test.go
+++ b/backend/internal/adapters/scm/onedev/merge_test.go
@@ -1,0 +1,48 @@
+package onedev
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// TestMergePullRequestIsUnsupported pins the decision documented in merge.go:
+// the adapter registers as a merger so `ao pr merge` can report a capability
+// answer, but it never merges — OneDev's merge endpoint has no expected-head
+// precondition, so honouring SCMMergeRequest.ExpectedHeadSHA is impossible
+// without a check-then-merge race on an irreversible action.
+func TestMergePullRequestIsUnsupported(t *testing.T) {
+	// A server that must never be called: an unsupported capability is
+	// answered locally, not by attempting the merge and hoping.
+	srv := newTestServer(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("MergePullRequest contacted the OneDev instance; it must not")
+	})
+	p := newTestProvider(t, []string{srv.URL})
+
+	var merger ports.SCMMerger = p
+	res, err := merger.MergePullRequest(context.Background(), ports.SCMMergeRequest{
+		PR: ports.SCMPRRef{
+			Repo:   ports.SCMRepo{Provider: ProviderKey, Host: strings.TrimPrefix(srv.URL, "http://"), Repo: "Homelab/curatarr"},
+			Number: 106,
+		},
+		ExpectedHeadSHA: "0123456789abcdef0123456789abcdef01234567",
+		Method:          ports.SCMMergeSquash,
+	})
+	if !errors.Is(err, ports.ErrSCMUnsupported) {
+		t.Fatalf("err = %v, want ports.ErrSCMUnsupported", err)
+	}
+	if res.MergeCommitSHA != "" {
+		t.Errorf("MergeCommitSHA = %q, want empty", res.MergeCommitSHA)
+	}
+	// The message has to point somewhere useful: an operator who hits this
+	// needs to know where to go instead.
+	for _, want := range []string{"Homelab/curatarr", "106", "OneDev UI"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to mention %q", err.Error(), want)
+		}
+	}
+}

--- a/backend/internal/adapters/scm/onedev/observer_provider.go
+++ b/backend/internal/adapters/scm/onedev/observer_provider.go
@@ -1,0 +1,1114 @@
+package onedev
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	// fetchConcurrency bounds the parallel per-PR detail fetches inside one
+	// FetchPullRequests batch, matching the GitLab adapter.
+	fetchConcurrency = 5
+	// batchLimit is the largest ref batch FetchPullRequests accepts. It
+	// mirrors the observer's own BatchSize so an oversized batch is a
+	// programming error, not a silent partial fetch.
+	batchLimit = 25
+	// prListPageSize is the per-page count for PR listings. The client clamps
+	// to OneDev's ceiling, above which the server answers HTTP 406.
+	prListPageSize = 100
+	// prBuildsPageCount bounds how many of a pull request's builds are
+	// considered when assembling its CI snapshot. Only the builds matching the
+	// PR's current build commit survive the filter, and OneDev submits one
+	// build per job per commit, so this is generous even for a PR that has
+	// been retried repeatedly.
+	prBuildsPageCount = 50
+	// checksGuardWindow is how many of a project's most recent builds
+	// CommitChecksGuard hashes. See that method for why the window exists and
+	// what it bounds.
+	checksGuardWindow = 20
+)
+
+// ---------------------------------------------------------------------------
+// Query construction
+// ---------------------------------------------------------------------------
+
+// quoteQueryValue renders a value for OneDev's query DSL, which quotes values
+// with double quotes and escapes with a backslash. Project paths and branch
+// names do not normally contain either, but a value is interpolated into a
+// query the server parses, so it is escaped rather than trusted.
+func quoteQueryValue(s string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
+}
+
+// queryDate formats a timestamp for OneDev's date criteria. OneDev parses the
+// value in UTC whether or not an offset is present, so the timestamp is always
+// converted to UTC first: sending a local-zone wall-clock time would shift the
+// cursor by the offset and silently drop updates inside that window.
+func queryDate(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
+// projectRef renders a project path for a query. OneDev identifies a project
+// by its full path ("Homelab/curatarr"), which is exactly SCMRepo.Repo for
+// this adapter — see ParseRepository.
+func projectRef(repo ports.SCMRepo) string { return repo.Repo }
+
+// pullRequestRef renders the project-qualified pull-request reference OneDev's
+// build query requires, e.g. "productone#106". A bare number is rejected with
+// "Reference project not specified" even when the surrounding query already
+// constrains the project, so the project path is always included.
+func pullRequestRef(repo ports.SCMRepo, number int) string {
+	return projectRef(repo) + "#" + strconv.Itoa(number)
+}
+
+// ---------------------------------------------------------------------------
+// REST payloads
+// ---------------------------------------------------------------------------
+
+// restPullRequest is the subset of OneDev's pull-request payload AO consumes.
+// Note that "id" (the internal request id every /pulls/{requestId} route is
+// keyed by) is distinct from "number" (the per-project number users see).
+type restPullRequest struct {
+	ID              int64             `json:"id"`
+	Number          int               `json:"number"`
+	Status          string            `json:"status"`
+	Title           string            `json:"title"`
+	TargetBranch    string            `json:"targetBranch"`
+	SourceBranch    string            `json:"sourceBranch"`
+	BaseCommitHash  string            `json:"baseCommitHash"`
+	BuildCommitHash string            `json:"buildCommitHash"`
+	MergeStrategy   string            `json:"mergeStrategy"`
+	CheckError      string            `json:"checkError"`
+	SubmitDate      *time.Time        `json:"submitDate"`
+	CloseDate       *time.Time        `json:"closeDate"`
+	LastActivity    *restLastActivity `json:"lastActivity"`
+	SubmitterID     int64             `json:"submitterId"`
+	TargetProjectID int64             `json:"targetProjectId"`
+	SourceProjectID int64             `json:"sourceProjectId"`
+}
+
+type restLastActivity struct {
+	Date        *time.Time `json:"date"`
+	Description string     `json:"description"`
+	UserID      int64      `json:"userId"`
+}
+
+// restMergePreview is OneDev's precomputed merge of a request into its target.
+// A null mergeCommitHash means the merge conflicts; an absent preview means
+// OneDev has not computed one yet.
+type restMergePreview struct {
+	TargetHeadCommitHash string `json:"targetHeadCommitHash"`
+	HeadCommitHash       string `json:"headCommitHash"`
+	MergeStrategy        string `json:"mergeStrategy"`
+	MergeCommitHash      string `json:"mergeCommitHash"`
+}
+
+type restPullRequestUpdate struct {
+	ID                   int64      `json:"id"`
+	HeadCommitHash       string     `json:"headCommitHash"`
+	TargetHeadCommitHash string     `json:"targetHeadCommitHash"`
+	Date                 *time.Time `json:"date"`
+}
+
+type restBuild struct {
+	ID         int64      `json:"id"`
+	Number     int        `json:"number"`
+	JobName    string     `json:"jobName"`
+	Status     string     `json:"status"`
+	CommitHash string     `json:"commitHash"`
+	RefName    string     `json:"refName"`
+	SubmitDate *time.Time `json:"submitDate"`
+	FinishDate *time.Time `json:"finishDate"`
+	ProjectID  int64      `json:"projectId"`
+	RequestID  *int64     `json:"requestId"`
+}
+
+// restReview is one reviewer's verdict. status is OneDev's
+// PullRequestReview.Status enum: PENDING, APPROVED, REQUESTED_FOR_CHANGES or
+// EXCLUDED.
+type restReview struct {
+	ID         int64      `json:"id"`
+	Status     string     `json:"status"`
+	StatusDate *time.Time `json:"statusDate"`
+	UserID     int64      `json:"userId"`
+	RequestID  int64      `json:"requestId"`
+}
+
+type restPullRequestComment struct {
+	ID        int64      `json:"id"`
+	Date      *time.Time `json:"date"`
+	Content   string     `json:"content"`
+	UserID    int64      `json:"userId"`
+	RequestID int64      `json:"requestId"`
+}
+
+type restUser struct {
+	ID       int64  `json:"id"`
+	Name     string `json:"name"`
+	FullName string `json:"fullName"`
+	Disabled bool   `json:"disabled"`
+	Type     string `json:"type"`
+}
+
+type restProject struct {
+	ID   int64  `json:"id"`
+	Path string `json:"path"`
+	Name string `json:"name"`
+}
+
+// ---------------------------------------------------------------------------
+// Host and URL helpers
+// ---------------------------------------------------------------------------
+
+// hostForRepo resolves a repository's allowlist entry, so a caller can build
+// browser URLs against the instance AO is actually configured to talk to
+// rather than the authority written in a git remote.
+func (p *Provider) hostForRepo(repo ports.SCMRepo) (allowedHost, error) {
+	h, ok := p.resolveHost(repo.Host)
+	if !ok {
+		return allowedHost{}, fmt.Errorf("onedev scm: host %q: %w", repo.Host, ErrHostNotAllowed)
+	}
+	return h, nil
+}
+
+// webURL builds a browser URL for one of OneDev's per-project views. OneDev
+// reserves the "~" prefix for its own routes, so a project path can never
+// shadow "~pulls" or "~builds".
+func webURL(h allowedHost, projectPath, view string, number int) string {
+	return h.scheme + "://" + h.authority + "/" + projectPath + "/~" + view + "/" + strconv.Itoa(number)
+}
+
+// ---------------------------------------------------------------------------
+// ListPRsByRepo
+// ---------------------------------------------------------------------------
+
+// ListPRsByRepo lists a project's pull requests, optionally narrowed to those
+// touched since updatedAfter (a zero time lists everything).
+//
+// The listing is not filtered to open requests: the observer relies on seeing
+// merged and discarded requests so a tracked PR's terminal transition is
+// observed rather than inferred from its disappearance.
+//
+// Three details of OneDev's query language are load-bearing here and are
+// pinned by TestListPRsByRepoQuery:
+//
+//   - The date operator is "since". "is after" is rejected with HTTP 406
+//     "Invalid query" — OneDev spells the exclusive-lower-bound operator
+//     differently from every other provider AO talks to.
+//   - The project criterion is "Target Project", matched on the project's full
+//     path.
+//   - Results are ordered by last activity descending, which is also what
+//     makes RepoPRListGuard's synthesised token sound.
+func (p *Provider) ListPRsByRepo(ctx context.Context, repo ports.SCMRepo, updatedAfter time.Time) ([]ports.SCMPRObservation, error) {
+	client, err := p.clientForRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	host, err := p.hostForRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	criteria := []string{`"Target Project" is ` + quoteQueryValue(projectRef(repo))}
+	if !updatedAfter.IsZero() {
+		criteria = append(criteria, `"Last Activity Date" is since `+quoteQueryValue(queryDate(updatedAfter)))
+	}
+	q := url.Values{
+		"query": {strings.Join(criteria, " and ") + ` order by "Last Activity Date" desc`},
+		"count": {strconv.Itoa(prListPageSize)},
+	}
+
+	var result []ports.SCMPRObservation
+	_, err = client.doGETPaginated(ctx, "/pulls", q, func(body []byte) (int, error) {
+		var page []restPullRequest
+		if err := json.Unmarshal(body, &page); err != nil {
+			return 0, fmt.Errorf("onedev scm: unmarshal pull request list: %w", err)
+		}
+		for i := range page {
+			pr := &page[i]
+			p.cache.setRequestID(repo.Host, repo.Repo, pr.Number, pr.ID)
+			result = append(result, p.prObservation(ctx, client, host, repo, pr))
+		}
+		return len(page), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// prObservation normalizes one OneDev pull request.
+//
+// Author and head-repository resolution are best-effort: both need a second
+// lookup (user id to login, project id to path) and neither is worth failing a
+// whole listing over. A missing author simply leaves the observer's
+// author-match check without an opinion, which falls back to branch-based
+// attribution.
+func (p *Provider) prObservation(ctx context.Context, client *Client, host allowedHost, repo ports.SCMRepo, pr *restPullRequest) ports.SCMPRObservation {
+	state, merged, closed := normalizePRStatus(pr.Status)
+	prURL := webURL(host, repo.Repo, "pulls", pr.Number)
+
+	obs := ports.SCMPRObservation{
+		ProviderID:        strconv.FormatInt(pr.ID, 10),
+		URL:               prURL,
+		HTMLURL:           prURL,
+		Number:            pr.Number,
+		State:             string(state),
+		Merged:            merged,
+		Closed:            closed,
+		SourceBranch:      pr.SourceBranch,
+		TargetBranch:      pr.TargetBranch,
+		HeadRepo:          repo.Repo,
+		Title:             pr.Title,
+		BaseSHA:           pr.BaseCommitHash,
+		Author:            p.resolveUserLogin(ctx, client, repo.Host, pr.SubmitterID),
+		ProviderState:     pr.Status,
+		CreatedAtProvider: safeTime(pr.SubmitDate),
+	}
+	if pr.LastActivity != nil {
+		obs.UpdatedAtProvider = safeTime(pr.LastActivity.Date)
+	}
+	if merged {
+		obs.MergedAtProvider = safeTime(pr.CloseDate)
+	}
+	if closed {
+		obs.ClosedAtProvider = safeTime(pr.CloseDate)
+	}
+	// OneDev pull requests may be raised from a different project in the tree
+	// (its equivalent of a fork). The head repository decides which sessions
+	// may claim the PR by branch prefix, so it must name the project the
+	// source branch actually lives in.
+	if pr.SourceProjectID != 0 && pr.SourceProjectID != pr.TargetProjectID {
+		if path := p.resolveProjectPath(ctx, client, repo.Host, pr.SourceProjectID); path != "" {
+			obs.HeadRepo = path
+		}
+	}
+	return obs
+}
+
+// normalizePRStatus maps OneDev's PullRequest.Status enum (OPEN, MERGED,
+// DISCARDED) onto AO's normalized PR state. OneDev has no draft concept, so
+// no request ever normalizes to "draft".
+func normalizePRStatus(status string) (state domain.PRState, merged, closed bool) {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "OPEN":
+		return domain.PRStateOpen, false, false
+	case "MERGED":
+		return domain.PRStateMerged, true, false
+	case "DISCARDED":
+		return domain.PRStateClosed, false, true
+	default:
+		// An unrecognised status is treated as closed rather than open: AO
+		// acts on open PRs, so guessing "open" for a state this adapter does
+		// not understand is the more damaging of the two errors.
+		return domain.PRStateClosed, false, true
+	}
+}
+
+func safeTime(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// ---------------------------------------------------------------------------
+// Id resolution
+// ---------------------------------------------------------------------------
+
+// resolveRequestID maps a project-scoped PR number onto the internal request
+// id OneDev's /pulls/{requestId} routes need. The two are different numbers
+// and OneDev exposes no by-number route, so the mapping is looked up through
+// the query API and cached — it never changes, since OneDev does not reuse a
+// PR number within a project.
+func (p *Provider) resolveRequestID(ctx context.Context, client *Client, repo ports.SCMRepo, number int) (int64, error) {
+	if number <= 0 {
+		return 0, fmt.Errorf("onedev scm: pull request number %d: %w", number, ErrNotFound)
+	}
+	if id, ok := p.cache.getRequestID(repo.Host, repo.Repo, number); ok {
+		return id, nil
+	}
+	q := url.Values{
+		"query": {`"Target Project" is ` + quoteQueryValue(projectRef(repo)) +
+			` and "Number" is ` + quoteQueryValue(strconv.Itoa(number))},
+		"offset": {"0"},
+		"count":  {"1"},
+	}
+	resp, err := client.doGET(ctx, "/pulls", q)
+	if err != nil {
+		return 0, err
+	}
+	var matches []restPullRequest
+	if err := json.Unmarshal(resp.Body, &matches); err != nil {
+		return 0, fmt.Errorf("onedev scm: unmarshal pull request lookup: %w", err)
+	}
+	if len(matches) == 0 {
+		return 0, fmt.Errorf("onedev scm: %s#%d: %w", repo.Repo, number, ErrNotFound)
+	}
+	p.cache.setRequestID(repo.Host, repo.Repo, number, matches[0].ID)
+	return matches[0].ID, nil
+}
+
+// resolveUserLogin resolves a OneDev user id to a login, returning "" when it
+// cannot. OneDev uses -1 for system-generated activity, and a deleted account
+// answers 404; neither is a failure worth propagating, because the login is
+// display and attribution metadata rather than a fact the observation's
+// correctness rests on.
+func (p *Provider) resolveUserLogin(ctx context.Context, client *Client, host string, userID int64) string {
+	if userID <= 0 {
+		return ""
+	}
+	if login, ok := p.cache.getUser(host, userID); ok {
+		return login
+	}
+	resp, err := client.doGET(ctx, "/users/"+strconv.FormatInt(userID, 10), nil)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			// A deleted account will not reappear; cache the miss so the
+			// lookup is not retried on every poll.
+			p.cache.setUser(host, userID, "")
+		}
+		return ""
+	}
+	var user restUser
+	if err := json.Unmarshal(resp.Body, &user); err != nil {
+		return ""
+	}
+	p.cache.setUser(host, userID, user.Name)
+	return user.Name
+}
+
+// resolveProjectPath resolves a OneDev project id to its full path, returning
+// "" when it cannot. Like resolveUserLogin this is best-effort: the caller
+// falls back to the repository it already knows.
+func (p *Provider) resolveProjectPath(ctx context.Context, client *Client, host string, projectID int64) string {
+	if projectID <= 0 {
+		return ""
+	}
+	if path, ok := p.cache.getProjectPath(host, projectID); ok {
+		return path
+	}
+	resp, err := client.doGET(ctx, "/projects/"+strconv.FormatInt(projectID, 10), nil)
+	if err != nil {
+		return ""
+	}
+	var project restProject
+	if err := json.Unmarshal(resp.Body, &project); err != nil {
+		return ""
+	}
+	p.cache.setProjectPath(host, projectID, project.Path)
+	return project.Path
+}
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+// RepoPRListGuard reports whether a project's pull requests can have changed
+// since the caller's token.
+//
+// OneDev sends neither ETag nor Last-Modified — verified against a live
+// instance by inspecting response headers — so there is no conditional request
+// to make and no 304 to receive. Rather than pretend otherwise, the guard
+// synthesises its own validator: it asks for the single most recently active
+// pull request in the project and hashes that request's identity and activity
+// timestamp into a token.
+//
+// That token is sound for this endpoint. Every change to any pull request in
+// the project (opening, updating, commenting, merging, discarding) bumps that
+// request's last-activity date, which makes it the newest and so changes the
+// hash. A tie or a deletion changes the identity half of the hash, which
+// errs towards reporting a change.
+//
+// A guard with no prior token always reports changed, so a cold start does a
+// full listing.
+func (p *Provider) RepoPRListGuard(ctx context.Context, repo ports.SCMRepo, etag string) (ports.SCMGuardResult, error) {
+	client, err := p.clientForRepo(repo)
+	if err != nil {
+		return ports.SCMGuardResult{}, err
+	}
+	q := url.Values{
+		"query":  {`"Target Project" is ` + quoteQueryValue(projectRef(repo)) + ` order by "Last Activity Date" desc`},
+		"offset": {"0"},
+		"count":  {"1"},
+	}
+	resp, err := client.doGET(ctx, "/pulls", q)
+	if err != nil {
+		return ports.SCMGuardResult{}, err
+	}
+	var newest []restPullRequest
+	if err := json.Unmarshal(resp.Body, &newest); err != nil {
+		return ports.SCMGuardResult{}, fmt.Errorf("onedev scm: unmarshal pull request guard: %w", err)
+	}
+
+	parts := []string{"onedev-prlist/1", repo.Host, repo.Repo, strconv.Itoa(len(newest))}
+	for _, pr := range newest {
+		activity := time.Time{}
+		if pr.LastActivity != nil {
+			activity = safeTime(pr.LastActivity.Date)
+		}
+		parts = append(parts,
+			strconv.FormatInt(pr.ID, 10),
+			strconv.Itoa(pr.Number),
+			pr.Status,
+			activity.UTC().Format(time.RFC3339Nano),
+		)
+	}
+	return guardResult(etag, parts), nil
+}
+
+// CommitChecksGuard reports whether a commit's CI state can have changed since
+// the caller's token.
+//
+// This guard is weaker than RepoPRListGuard's and deliberately so. OneDev has
+// no queryable per-commit build lookup that AO can rely on: the global build
+// query's "Commit" criterion resolves the revision against no project context
+// and answers HTTP 404 "Unable to find revision" even for a commit that
+// exists, and pull-request builds run against the merge-preview commit rather
+// than the branch head the observer passes in. Builds also carry no
+// last-activity field, so there is no single cheap value that moves whenever a
+// build's status does.
+//
+// What the guard does instead is hash a bounded window of the project's most
+// recently submitted builds, including each one's status and finish time. Any
+// status transition inside that window changes the token, which is what the
+// observer uses to promote a pull request to a full refresh. A build that
+// falls out of the window while still running would not, which is why the
+// window exists rather than a count=1 probe — and why this is a
+// promote-earlier optimisation rather than a correctness dependency. The
+// observer already forces an unconditional refresh once a tracked PR's
+// snapshot passes DefaultPRMaxAge, so the worst case is a delayed CI update,
+// not a lost one.
+//
+// The guard never reports NotModified against an empty caller token, so a cold
+// cache always fetches.
+func (p *Provider) CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, headSHA, etag string) (ports.SCMGuardResult, error) {
+	if strings.TrimSpace(headSHA) == "" {
+		return ports.SCMGuardResult{}, fmt.Errorf("onedev scm: empty head SHA: %w", ErrNotFound)
+	}
+	client, err := p.clientForRepo(repo)
+	if err != nil {
+		return ports.SCMGuardResult{}, err
+	}
+	q := url.Values{
+		"query":  {`"Project" is ` + quoteQueryValue(projectRef(repo)) + ` order by "Submit Date" desc`},
+		"offset": {"0"},
+		"count":  {strconv.Itoa(checksGuardWindow)},
+	}
+	resp, err := client.doGET(ctx, "/builds", q)
+	if err != nil {
+		return ports.SCMGuardResult{}, err
+	}
+	var builds []restBuild
+	if err := json.Unmarshal(resp.Body, &builds); err != nil {
+		return ports.SCMGuardResult{}, fmt.Errorf("onedev scm: unmarshal build guard: %w", err)
+	}
+
+	parts := []string{"onedev-checks/1", repo.Host, repo.Repo, headSHA, strconv.Itoa(len(builds))}
+	for _, b := range builds {
+		parts = append(parts,
+			strconv.FormatInt(b.ID, 10),
+			b.Status,
+			b.CommitHash,
+			safeTime(b.FinishDate).UTC().Format(time.RFC3339Nano),
+		)
+	}
+	return guardResult(etag, parts), nil
+}
+
+// guardResult hashes a guard's inputs into a token and compares it with the
+// caller's. An empty caller token never matches, so the first poll after a
+// restart always reports changed.
+func guardResult(previous string, parts []string) ports.SCMGuardResult {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	token := hex.EncodeToString(sum[:])
+	return ports.SCMGuardResult{
+		ETag:        token,
+		NotModified: previous != "" && previous == token,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchPullRequests
+// ---------------------------------------------------------------------------
+
+// FetchPullRequests fetches a detailed observation per ref: request metadata,
+// merge preview, CI builds, and reviews.
+//
+// Results are positionally aligned with refs — result[i] answers refs[i] — and
+// a ref that could not be fetched leaves a Fetched=false placeholder carrying
+// its error. The observer attributes each observation to the subject it was
+// requested for by position, so an observation must never move.
+func (p *Provider) FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
+	if len(refs) > batchLimit {
+		return nil, fmt.Errorf("onedev scm: batch size %d exceeds limit %d", len(refs), batchLimit)
+	}
+	results := make([]ports.SCMObservation, len(refs))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, fetchConcurrency)
+	var firstErr error
+
+	for i, ref := range refs {
+		wg.Add(1)
+		go func(idx int, r ports.SCMPRRef) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			obs, err := p.fetchSinglePR(ctx, r)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				p.logger.Warn("onedev scm: fetch pull request failed", "repo", r.Repo.Repo, "pr", r.Number, "err", err)
+				if firstErr == nil {
+					firstErr = err
+				}
+				results[idx] = ports.SCMObservation{
+					Fetched:  false,
+					Provider: ProviderKey,
+					Host:     r.Repo.Host,
+					Repo:     r.Repo.Repo,
+					PR:       ports.SCMPRObservation{Number: r.Number, URL: r.URL},
+					Error:    err,
+				}
+				return
+			}
+			results[idx] = obs
+		}(i, ref)
+	}
+	wg.Wait()
+	return results, firstErr
+}
+
+// fetchSinglePR assembles one pull request's observation. Every sub-fetch
+// failure propagates: the observer preserves the last durable state for a
+// Fetched=false observation, which is strictly better than overwriting good
+// CI or review facts with an empty snapshot.
+func (p *Provider) fetchSinglePR(ctx context.Context, ref ports.SCMPRRef) (ports.SCMObservation, error) {
+	repo := ref.Repo
+	client, err := p.clientForRepo(repo)
+	if err != nil {
+		return ports.SCMObservation{}, err
+	}
+	host, err := p.hostForRepo(repo)
+	if err != nil {
+		return ports.SCMObservation{}, err
+	}
+	requestID, err := p.resolveRequestID(ctx, client, repo, ref.Number)
+	if err != nil {
+		return ports.SCMObservation{}, err
+	}
+
+	resp, err := client.doGET(ctx, prPath(requestID), nil)
+	if err != nil {
+		return ports.SCMObservation{}, err
+	}
+	var pr restPullRequest
+	if err := json.Unmarshal(resp.Body, &pr); err != nil {
+		return ports.SCMObservation{}, fmt.Errorf("onedev scm: unmarshal pull request %d: %w", ref.Number, err)
+	}
+
+	preview, hasPreview, err := p.fetchMergePreview(ctx, client, requestID)
+	if err != nil {
+		return ports.SCMObservation{}, err
+	}
+	headSHA := preview.HeadCommitHash
+	if headSHA == "" {
+		// No merge preview yet (OneDev computes it asynchronously). The head
+		// commit is still recoverable from the request's update history, and
+		// the observer needs it to guard CI at all.
+		headSHA, err = p.fetchHeadCommit(ctx, client, requestID)
+		if err != nil {
+			return ports.SCMObservation{}, err
+		}
+	}
+
+	ci, err := p.fetchCI(ctx, client, host, repo, &pr, headSHA)
+	if err != nil {
+		return ports.SCMObservation{}, err
+	}
+	reviews, err := p.fetchReviews(ctx, client, requestID)
+	if err != nil {
+		return ports.SCMObservation{}, err
+	}
+	decision := reviewDecision(reviews)
+
+	prObs := p.prObservation(ctx, client, host, repo, &pr)
+	prObs.HeadSHA = headSHA
+	prObs.MergeCommitSHA = preview.MergeCommitHash
+	prObs.ProviderMergeable = pr.MergeStrategy
+	prObs.ProviderMergeStateStatus = pr.CheckError
+	if requested := strings.TrimSpace(ref.URL); requested != "" && requested != strings.TrimSpace(prObs.URL) {
+		prObs.URLAlias = requested
+	}
+
+	return ports.SCMObservation{
+		Fetched:      true,
+		ObservedAt:   time.Now(),
+		Provider:     ProviderKey,
+		Host:         repo.Host,
+		Repo:         repo.Repo,
+		PR:           prObs,
+		CI:           ci,
+		Review:       ports.SCMReviewObservation{Decision: string(decision)},
+		Mergeability: mergeability(&pr, preview, hasPreview, ci.Summary, string(decision)),
+	}, nil
+}
+
+func prPath(requestID int64, sub ...string) string {
+	path := "/pulls/" + strconv.FormatInt(requestID, 10)
+	if len(sub) > 0 {
+		path += "/" + strings.Join(sub, "/")
+	}
+	return path
+}
+
+// fetchMergePreview reads OneDev's precomputed merge of a request into its
+// target. The preview is computed asynchronously, so an absent one is a normal
+// transient state reported as hasPreview=false rather than an error — the
+// caller renders that as "mergeability unknown" instead of guessing.
+func (p *Provider) fetchMergePreview(ctx context.Context, client *Client, requestID int64) (restMergePreview, bool, error) {
+	resp, err := client.doGET(ctx, prPath(requestID, "merge-preview"), nil)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return restMergePreview{}, false, nil
+		}
+		return restMergePreview{}, false, err
+	}
+	body := strings.TrimSpace(string(resp.Body))
+	if body == "" || body == "null" {
+		return restMergePreview{}, false, nil
+	}
+	var preview restMergePreview
+	if err := json.Unmarshal(resp.Body, &preview); err != nil {
+		return restMergePreview{}, false, fmt.Errorf("onedev scm: unmarshal merge preview: %w", err)
+	}
+	return preview, true, nil
+}
+
+// fetchHeadCommit returns the head commit of a request's most recent update.
+// OneDev's pull-request payload carries the base and build commits but not the
+// head, so the update history is the only place it can be read when no merge
+// preview exists.
+func (p *Provider) fetchHeadCommit(ctx context.Context, client *Client, requestID int64) (string, error) {
+	resp, err := client.doGET(ctx, prPath(requestID, "updates"), nil)
+	if err != nil {
+		return "", err
+	}
+	var updates []restPullRequestUpdate
+	if err := json.Unmarshal(resp.Body, &updates); err != nil {
+		return "", fmt.Errorf("onedev scm: unmarshal pull request updates: %w", err)
+	}
+	newest := ""
+	var newestID int64
+	for _, u := range updates {
+		if u.HeadCommitHash != "" && (newest == "" || u.ID >= newestID) {
+			newest, newestID = u.HeadCommitHash, u.ID
+		}
+	}
+	return newest, nil
+}
+
+// ---------------------------------------------------------------------------
+// CI
+// ---------------------------------------------------------------------------
+
+// fetchCI assembles a pull request's CI snapshot from its builds.
+//
+// The builds are found with the project-qualified pull-request criterion —
+// "Pull Request" is "productone#106". The project qualifier is mandatory: a
+// bare number is rejected with "Reference project not specified" even when the
+// query already names the project.
+//
+// That query returns every build the request has ever produced, including
+// those for superseded commits, so the results are narrowed to the commit CI
+// actually built. For a pull request that is the merge-preview commit OneDev
+// records as buildCommitHash; a project configured to build the source branch
+// directly uses the head commit instead, so both are accepted. Retries produce
+// several builds for one job name, and the query is ordered newest-first, so
+// the first build seen for a job name wins.
+func (p *Provider) fetchCI(ctx context.Context, client *Client, host allowedHost, repo ports.SCMRepo, pr *restPullRequest, headSHA string) (ports.SCMCIObservation, error) {
+	q := url.Values{
+		"query":  {`"Pull Request" is ` + quoteQueryValue(pullRequestRef(repo, pr.Number)) + ` order by "Submit Date" desc`},
+		"offset": {"0"},
+		"count":  {strconv.Itoa(prBuildsPageCount)},
+	}
+	resp, err := client.doGET(ctx, "/builds", q)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			// OneDev answers 404 when the pull-request reference itself
+			// cannot be resolved. A request AO is actively observing does
+			// exist, so this is the "no builds" shape rather than a failure.
+			return ports.SCMCIObservation{Summary: string(domain.CIUnknown), HeadSHA: headSHA}, nil
+		}
+		return ports.SCMCIObservation{}, fmt.Errorf("onedev scm: fetch builds: %w", err)
+	}
+	var builds []restBuild
+	if err := json.Unmarshal(resp.Body, &builds); err != nil {
+		return ports.SCMCIObservation{}, fmt.Errorf("onedev scm: unmarshal builds: %w", err)
+	}
+
+	current := map[string]bool{}
+	for _, sha := range []string{pr.BuildCommitHash, headSHA} {
+		if sha != "" {
+			current[sha] = true
+		}
+	}
+
+	seenJobs := map[string]bool{}
+	var checks, failed []ports.SCMCheckObservation
+	for _, b := range builds {
+		if len(current) > 0 && b.CommitHash != "" && !current[b.CommitHash] {
+			continue
+		}
+		if seenJobs[b.JobName] {
+			continue
+		}
+		seenJobs[b.JobName] = true
+
+		status := buildStatusToCheckStatus(b.Status)
+		check := ports.SCMCheckObservation{
+			Name:       b.JobName,
+			Status:     string(status),
+			Conclusion: b.Status,
+			URL:        webURL(host, repo.Repo, "builds", b.Number),
+			ProviderID: strconv.FormatInt(b.ID, 10),
+		}
+		checks = append(checks, check)
+		if isFailingCheckStatus(status) {
+			failed = append(failed, check)
+		}
+	}
+
+	return ports.SCMCIObservation{
+		Summary:           string(ciSummary(checks)),
+		HeadSHA:           headSHA,
+		FailedFingerprint: failedFingerprint(headSHA, failed),
+		Checks:            checks,
+		FailedChecks:      failed,
+		// The build query is bounded by prBuildsPageCount but narrowed to one
+		// build per job name at the current commit, so the snapshot is
+		// complete for the commit rather than a truncated window.
+		Partial: false,
+	}, nil
+}
+
+// buildStatusToCheckStatus maps OneDev's Build.Status enum onto AO's check
+// status. The enum is WAITING, PENDING, RUNNING, FAILED, CANCELLED, TIMED_OUT
+// and SUCCESSFUL.
+func buildStatusToCheckStatus(status string) domain.PRCheckStatus {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "SUCCESSFUL":
+		return domain.PRCheckPassed
+	case "FAILED", "TIMED_OUT":
+		return domain.PRCheckFailed
+	case "CANCELLED":
+		return domain.PRCheckCancelled
+	case "RUNNING":
+		return domain.PRCheckInProgress
+	case "WAITING", "PENDING":
+		return domain.PRCheckQueued
+	default:
+		return domain.PRCheckUnknown
+	}
+}
+
+func isFailingCheckStatus(s domain.PRCheckStatus) bool {
+	return s == domain.PRCheckFailed || s == domain.PRCheckCancelled
+}
+
+// ciSummary rolls per-check statuses up into AO's aggregate CI state. A
+// failure anywhere dominates, then anything still in flight, and only an
+// all-finished, all-passing set reports passing.
+func ciSummary(checks []ports.SCMCheckObservation) domain.CIState {
+	if len(checks) == 0 {
+		return domain.CIUnknown
+	}
+	pending, passed := false, false
+	for _, c := range checks {
+		switch domain.PRCheckStatus(c.Status) {
+		case domain.PRCheckFailed, domain.PRCheckCancelled:
+			return domain.CIFailing
+		case domain.PRCheckQueued, domain.PRCheckInProgress:
+			pending = true
+		case domain.PRCheckPassed:
+			passed = true
+		}
+	}
+	switch {
+	case pending:
+		return domain.CIPending
+	case passed:
+		return domain.CIPassing
+	default:
+		return domain.CIUnknown
+	}
+}
+
+// failedFingerprint is a stable signature of the current failing checks, used
+// by the observer to notice that a failure set changed without diffing it.
+func failedFingerprint(headSHA string, checks []ports.SCMCheckObservation) string {
+	if len(checks) == 0 {
+		return ""
+	}
+	parts := make([]string, len(checks))
+	for i, c := range checks {
+		parts[i] = strings.Join([]string{headSHA, c.Name, c.Status, c.Conclusion, c.URL, c.ProviderID}, "\x00")
+	}
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x1e")))
+	return hex.EncodeToString(sum[:])
+}
+
+// ---------------------------------------------------------------------------
+// Reviews
+// ---------------------------------------------------------------------------
+
+func (p *Provider) fetchReviews(ctx context.Context, client *Client, requestID int64) ([]restReview, error) {
+	resp, err := client.doGET(ctx, prPath(requestID, "reviews"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("onedev scm: fetch reviews: %w", err)
+	}
+	var reviews []restReview
+	if err := json.Unmarshal(resp.Body, &reviews); err != nil {
+		return nil, fmt.Errorf("onedev scm: unmarshal reviews: %w", err)
+	}
+	return reviews, nil
+}
+
+// reviewDecision derives AO's normalized review decision from OneDev's
+// per-reviewer statuses. A requested change dominates an approval — a reviewer
+// asking for changes is the signal AO must not lose — and a still-pending
+// reviewer means the review is required but not yet given. EXCLUDED reviewers
+// (removed from the request) carry no signal.
+func reviewDecision(reviews []restReview) domain.ReviewDecision {
+	pending, approved := false, false
+	for _, r := range reviews {
+		switch normalizeReviewStatus(r.Status) {
+		case domain.ReviewChangesRequest:
+			return domain.ReviewChangesRequest
+		case domain.ReviewRequired:
+			pending = true
+		case domain.ReviewApproved:
+			approved = true
+		}
+	}
+	switch {
+	case pending:
+		return domain.ReviewRequired
+	case approved:
+		return domain.ReviewApproved
+	default:
+		return domain.ReviewNone
+	}
+}
+
+// normalizeReviewStatus maps OneDev's PullRequestReview.Status enum onto AO's
+// review decision vocabulary.
+func normalizeReviewStatus(status string) domain.ReviewDecision {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "APPROVED":
+		return domain.ReviewApproved
+	case "REQUESTED_FOR_CHANGES":
+		return domain.ReviewChangesRequest
+	case "PENDING":
+		return domain.ReviewRequired
+	default:
+		// EXCLUDED, and anything a later OneDev release adds.
+		return domain.ReviewNone
+	}
+}
+
+// FetchReviewThreads fetches a pull request's review verdicts and its
+// request-level comments.
+//
+// OneDev's inline (code) comments are deliberately absent. Its REST API
+// exposes code comments only as GET /~api/code-comments/{commentId} — there is
+// no per-request listing and no query resource — so an inline thread cannot be
+// enumerated from a pull request. Request-level comments therefore each become
+// a single-comment thread with no file anchor, and the observation is marked
+// Partial so the store merges these rows rather than treating them as a
+// complete replacement snapshot that would delete threads AO cannot see.
+func (p *Provider) FetchReviewThreads(ctx context.Context, ref ports.SCMPRRef) (ports.SCMReviewObservation, error) {
+	repo := ref.Repo
+	client, err := p.clientForRepo(repo)
+	if err != nil {
+		return ports.SCMReviewObservation{}, err
+	}
+	host, err := p.hostForRepo(repo)
+	if err != nil {
+		return ports.SCMReviewObservation{}, err
+	}
+	requestID, err := p.resolveRequestID(ctx, client, repo, ref.Number)
+	if err != nil {
+		return ports.SCMReviewObservation{}, err
+	}
+
+	reviews, err := p.fetchReviews(ctx, client, requestID)
+	if err != nil {
+		return ports.SCMReviewObservation{}, err
+	}
+	prURL := webURL(host, repo.Repo, "pulls", ref.Number)
+
+	summaries := make([]ports.SCMReviewSummaryObservation, 0, len(reviews))
+	for _, r := range reviews {
+		state := normalizeReviewStatus(r.Status)
+		if state == domain.ReviewNone {
+			continue
+		}
+		author := p.resolveUserLogin(ctx, client, repo.Host, r.UserID)
+		summaries = append(summaries, ports.SCMReviewSummaryObservation{
+			ID:          "review:" + strconv.FormatInt(r.ID, 10),
+			Author:      author,
+			State:       string(state),
+			URL:         prURL,
+			IsBot:       isBotAuthor(author),
+			SubmittedAt: safeTime(r.StatusDate),
+		})
+	}
+
+	resp, err := client.doGET(ctx, prPath(requestID, "comments"), nil)
+	if err != nil {
+		return ports.SCMReviewObservation{}, fmt.Errorf("onedev scm: fetch comments: %w", err)
+	}
+	var comments []restPullRequestComment
+	if err := json.Unmarshal(resp.Body, &comments); err != nil {
+		return ports.SCMReviewObservation{}, fmt.Errorf("onedev scm: unmarshal comments: %w", err)
+	}
+
+	threads := make([]ports.SCMReviewThreadObservation, 0, len(comments))
+	for _, c := range comments {
+		author := p.resolveUserLogin(ctx, client, repo.Host, c.UserID)
+		id := strconv.FormatInt(c.ID, 10)
+		bot := isBotAuthor(author)
+		threads = append(threads, ports.SCMReviewThreadObservation{
+			ID: "comment:" + id,
+			// A request-level comment is not anchored to a file, and OneDev
+			// has no resolve state for one, so it is never reported resolved.
+			Resolved: false,
+			IsBot:    bot,
+			Comments: []ports.SCMReviewCommentObservation{{
+				ID:     id,
+				Author: author,
+				Body:   c.Content,
+				URL:    prURL,
+				IsBot:  bot,
+			}},
+		})
+	}
+
+	return ports.SCMReviewObservation{
+		Decision: string(reviewDecision(reviews)),
+		Reviews:  summaries,
+		Threads:  threads,
+		Partial:  true,
+	}, nil
+}
+
+// isBotAuthor recognises the conventional bot-account naming AO's other
+// adapters key off. OneDev has no account-type flag for bots, so naming is the
+// only signal available.
+func isBotAuthor(login string) bool {
+	login = strings.ToLower(strings.TrimSpace(login))
+	if login == "" {
+		return false
+	}
+	return strings.HasSuffix(login, "[bot]") || strings.HasSuffix(login, "-bot") || strings.HasPrefix(login, "bot-")
+}
+
+// ---------------------------------------------------------------------------
+// Mergeability
+// ---------------------------------------------------------------------------
+
+// mergeability turns OneDev's merge preview into AO's normalized verdict.
+//
+// The preview is authoritative about conflicts and nothing else: OneDev
+// documents a null mergeCommitHash as "there are conflicts". Everything else
+// that blocks a merge — failing CI, an outstanding review, a failed merge
+// check — is layered on top the same way the GitLab adapter layers it.
+func mergeability(pr *restPullRequest, preview restMergePreview, hasPreview bool, ciState, reviewDecision string) ports.SCMMergeabilityObservation {
+	state, _, _ := normalizePRStatus(pr.Status)
+	if state != domain.PRStateOpen {
+		return ports.SCMMergeabilityObservation{
+			State:    string(domain.MergeBlocked),
+			Blockers: []string{"blocked_by_provider"},
+		}
+	}
+	if !hasPreview {
+		// OneDev computes the preview asynchronously; until it exists nothing
+		// is known about whether the merge would apply.
+		return ports.SCMMergeabilityObservation{State: string(domain.MergeUnknown)}
+	}
+	if preview.MergeCommitHash == "" {
+		return ports.SCMMergeabilityObservation{
+			State:    string(domain.MergeConflicting),
+			Conflict: true,
+			Blockers: []string{"conflicts"},
+		}
+	}
+
+	var blockers []string
+	if strings.TrimSpace(pr.CheckError) != "" {
+		blockers = append(blockers, "blocked_by_provider")
+	}
+	if ciState == string(domain.CIFailing) {
+		blockers = append(blockers, "ci_failing")
+	}
+	switch reviewDecision {
+	case string(domain.ReviewChangesRequest):
+		blockers = append(blockers, "changes_requested")
+	case string(domain.ReviewRequired):
+		blockers = append(blockers, "review_required")
+	}
+	if len(blockers) > 0 {
+		return ports.SCMMergeabilityObservation{
+			State:    string(domain.MergeBlocked),
+			Blockers: blockers,
+		}
+	}
+	return ports.SCMMergeabilityObservation{
+		State:     string(domain.MergeMergeable),
+		Mergeable: true,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchFailedCheckLogTail
+// ---------------------------------------------------------------------------
+
+// FetchFailedCheckLogTail returns the tail of a failed build's log.
+//
+// GET /~api/streaming/build-logs/{buildId} streams length-prefixed frames
+// rather than returning a document, so the body is decoded incrementally and
+// only a fixed number of trailing lines is retained — see tailBuildLog. The
+// build id comes from the check's ProviderID, which fetchCI stamped.
+func (p *Provider) FetchFailedCheckLogTail(ctx context.Context, repo ports.SCMRepo, check ports.SCMCheckObservation) (string, error) {
+	buildID := strings.TrimSpace(check.ProviderID)
+	if buildID == "" {
+		return "", fmt.Errorf("onedev scm: check %q has no build id", check.Name)
+	}
+	client, err := p.clientForRepo(repo)
+	if err != nil {
+		return "", err
+	}
+	body, err := client.doGETStream(ctx, "/streaming/build-logs/"+url.PathEscape(buildID), nil)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = body.Close() }()
+	return tailBuildLog(body, buildLogTailLines)
+}

--- a/backend/internal/adapters/scm/onedev/observer_provider_test.go
+++ b/backend/internal/adapters/scm/onedev/observer_provider_test.go
@@ -1,0 +1,1174 @@
+package onedev
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// newObserverProvider builds a provider allowlisted for one httptest server
+// and returns the repository identity for a project on it.
+func newObserverProvider(t *testing.T, project string, h http.HandlerFunc) (*Provider, ports.SCMRepo, *httptest.Server) {
+	t.Helper()
+	srv := newTestServer(t, h)
+	p, err := NewProvider(ProviderOptions{
+		AllowedHosts: []string{srv.URL},
+		Token:        StaticTokenSource("od-token"),
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	repo, ok := p.ParseRepository(srv.URL + "/" + project + ".git")
+	if !ok {
+		t.Fatalf("ParseRepository rejected %s/%s.git", srv.URL, project)
+	}
+	return p, repo, srv
+}
+
+// recorder captures the query strings the provider sent, per API path.
+type recorder struct {
+	mu sync.Mutex
+	// queries maps an API path to every "query" parameter sent to it.
+	queries map[string][]string
+	// hits counts requests per API path.
+	hits map[string]int
+}
+
+func newRecorder() *recorder {
+	return &recorder{queries: map[string][]string{}, hits: map[string]int{}}
+}
+
+func (r *recorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	path := strings.TrimPrefix(req.URL.Path, APIBasePath)
+	r.hits[path]++
+	r.queries[path] = append(r.queries[path], req.URL.Query().Get("query"))
+}
+
+func (r *recorder) first(path string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.queries[path]) == 0 {
+		return ""
+	}
+	return r.queries[path][0]
+}
+
+func (r *recorder) count(path string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.hits[path]
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("encode response: %v", err)
+	}
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return parsed
+}
+
+// ---------------------------------------------------------------------------
+// Query construction
+// ---------------------------------------------------------------------------
+
+func TestQuoteQueryValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain", in: "productone", want: `"productone"`},
+		{name: "nested path", in: "Homelab/curatarr", want: `"Homelab/curatarr"`},
+		{name: "embedded quote", in: `odd"name`, want: `"odd\"name"`},
+		{name: "embedded backslash", in: `odd\name`, want: `"odd\\name"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quoteQueryValue(tt.in); got != tt.want {
+				t.Fatalf("quoteQueryValue(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestListPRsByRepoQuery pins the three parts of OneDev's query language this
+// adapter cannot get wrong: the project criterion, the "since" date operator
+// (OneDev rejects "is after" with HTTP 406), and the last-activity ordering
+// that RepoPRListGuard's token depends on.
+func TestListPRsByRepoQuery(t *testing.T) {
+	since := mustTime(t, "2026-08-22T16:55:46Z")
+	tests := []struct {
+		name         string
+		updatedAfter time.Time
+		want         string
+	}{
+		{
+			name:         "no cursor lists everything",
+			updatedAfter: time.Time{},
+			want:         `"Target Project" is "productone" order by "Last Activity Date" desc`,
+		},
+		{
+			name:         "cursor uses the since operator",
+			updatedAfter: since,
+			want:         `"Target Project" is "productone" and "Last Activity Date" is since "2026-08-22T16:55:46Z" order by "Last Activity Date" desc`,
+		},
+		{
+			// A non-UTC cursor must still be sent as UTC: OneDev parses the
+			// value in UTC regardless of any offset, so a local wall-clock
+			// time would move the cursor by the offset and drop updates.
+			name:         "cursor is normalized to UTC",
+			updatedAfter: since.In(time.FixedZone("UTC+5", 5*60*60)),
+			want:         `"Target Project" is "productone" and "Last Activity Date" is since "2026-08-22T16:55:46Z" order by "Last Activity Date" desc`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := newRecorder()
+			p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+				rec.record(r)
+				writeJSON(t, w, []restPullRequest{})
+			})
+			if _, err := p.ListPRsByRepo(context.Background(), repo, tt.updatedAfter); err != nil {
+				t.Fatalf("ListPRsByRepo: %v", err)
+			}
+			if got := rec.first("/pulls"); got != tt.want {
+				t.Fatalf("query = %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListPRsByRepoObservations(t *testing.T) {
+	submitted := mustTime(t, "2026-08-20T09:00:00Z")
+	activity := mustTime(t, "2026-08-22T16:55:46Z")
+	closed := mustTime(t, "2026-08-23T10:00:00Z")
+
+	rec := newRecorder()
+	p, repo, srv := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls"):
+			writeJSON(t, w, []restPullRequest{
+				{
+					ID: 241, Number: 106, Status: "OPEN", Title: "docs: changelog",
+					TargetBranch: "main", SourceBranch: "chore/backlog",
+					BaseCommitHash: "d3b7cc6", SubmitDate: &submitted,
+					LastActivity: &restLastActivity{Date: &activity},
+					SubmitterID:  4, TargetProjectID: 33, SourceProjectID: 33,
+				},
+				{
+					ID: 159, Number: 105, Status: "MERGED", Title: "fix: shell",
+					TargetBranch: "main", SourceBranch: "fix/shell",
+					SubmitDate: &submitted, CloseDate: &closed,
+					LastActivity: &restLastActivity{Date: &closed},
+					SubmitterID:  4, TargetProjectID: 33, SourceProjectID: 41,
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/users/4"):
+			writeJSON(t, w, restUser{ID: 4, Name: "johnkattenhorn", FullName: "John Kattenhorn"})
+		case strings.HasSuffix(r.URL.Path, "/projects/41"):
+			writeJSON(t, w, restProject{ID: 41, Path: "Homelab/fork", Name: "fork"})
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	got, err := p.ListPRsByRepo(context.Background(), repo, time.Time{})
+	if err != nil {
+		t.Fatalf("ListPRsByRepo: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d observations, want 2", len(got))
+	}
+
+	open := got[0]
+	if open.State != string(domain.PRStateOpen) || open.Merged || open.Closed {
+		t.Errorf("open PR = state %q merged %v closed %v", open.State, open.Merged, open.Closed)
+	}
+	if open.ProviderID != "241" {
+		t.Errorf("ProviderID = %q, want 241 (the internal id, not the number)", open.ProviderID)
+	}
+	if want := srv.URL + "/productone/~pulls/106"; open.URL != want {
+		t.Errorf("URL = %q, want %q", open.URL, want)
+	}
+	if open.Author != "johnkattenhorn" {
+		t.Errorf("Author = %q, want johnkattenhorn", open.Author)
+	}
+	if !open.UpdatedAtProvider.Equal(activity) {
+		t.Errorf("UpdatedAtProvider = %v, want %v", open.UpdatedAtProvider, activity)
+	}
+	if open.HeadRepo != "productone" {
+		t.Errorf("HeadRepo = %q, want productone for a same-project PR", open.HeadRepo)
+	}
+
+	merged := got[1]
+	if merged.State != string(domain.PRStateMerged) || !merged.Merged {
+		t.Errorf("merged PR = state %q merged %v", merged.State, merged.Merged)
+	}
+	if !merged.MergedAtProvider.Equal(closed) || !merged.ClosedAtProvider.IsZero() {
+		t.Errorf("merged PR timestamps = merged %v closed %v", merged.MergedAtProvider, merged.ClosedAtProvider)
+	}
+	// A PR raised from another project in the tree must name that project as
+	// its head repo, or branch-prefix attribution would claim it for a session
+	// in the target project.
+	if merged.HeadRepo != "Homelab/fork" {
+		t.Errorf("HeadRepo = %q, want Homelab/fork for a cross-project PR", merged.HeadRepo)
+	}
+
+	// The author lookup is memoized: two PRs by the same submitter cost one
+	// /users round-trip, not two.
+	if n := rec.count("/users/4"); n != 1 {
+		t.Errorf("/users/4 fetched %d times, want 1", n)
+	}
+}
+
+// TestListPRsByRepoTolerablesMissingAuthor: author resolution is display
+// metadata. A deleted account (404) or system activity (userId -1) must leave
+// the author empty rather than fail the whole listing.
+func TestListPRsByRepoToleratesMissingAuthor(t *testing.T) {
+	tests := []struct {
+		name        string
+		submitterID int64
+		userStatus  int
+		wantHits    int
+	}{
+		{name: "system activity is not looked up", submitterID: -1, userStatus: http.StatusOK, wantHits: 0},
+		{name: "deleted account", submitterID: 7, userStatus: http.StatusNotFound, wantHits: 1},
+		{name: "server error", submitterID: 7, userStatus: http.StatusInternalServerError, wantHits: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := newRecorder()
+			p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+				rec.record(r)
+				if strings.Contains(r.URL.Path, "/users/") {
+					w.WriteHeader(tt.userStatus)
+					return
+				}
+				writeJSON(t, w, []restPullRequest{{
+					ID: 1, Number: 1, Status: "OPEN", SourceBranch: "topic",
+					SubmitterID: tt.submitterID,
+				}})
+			})
+			got, err := p.ListPRsByRepo(context.Background(), repo, time.Time{})
+			if err != nil {
+				t.Fatalf("ListPRsByRepo: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d observations, want 1", len(got))
+			}
+			if got[0].Author != "" {
+				t.Errorf("Author = %q, want empty", got[0].Author)
+			}
+			if n := rec.count(fmt.Sprintf("/users/%d", tt.submitterID)); n != tt.wantHits {
+				t.Errorf("user lookups = %d, want %d", n, tt.wantHits)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guards — the absent-ETag path
+// ---------------------------------------------------------------------------
+
+// TestRepoPRListGuardSynthesisesValidatorWithoutETag is the regression test for
+// the guard fallback. OneDev sends neither ETag nor Last-Modified, so the
+// guard must synthesise its own token rather than depend on a validator that
+// never arrives: with no header at all it still reports changed on a cold
+// cache, unchanged when the project's newest activity is identical, and
+// changed again the moment that activity moves.
+func TestRepoPRListGuardSynthesisesValidatorWithoutETag(t *testing.T) {
+	activity := mustTime(t, "2026-08-22T16:55:46Z")
+	later := activity.Add(time.Hour)
+
+	var newest []restPullRequest
+	var mu sync.Mutex
+	rec := newRecorder()
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		// Deliberately no ETag and no Last-Modified: this is what a real
+		// OneDev instance sends, verified against 16.5.6.
+		if got := w.Header().Get("ETag"); got != "" {
+			t.Errorf("test server set an ETag (%q); the fallback would not be exercised", got)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		writeJSON(t, w, newest)
+	})
+
+	mu.Lock()
+	newest = []restPullRequest{{ID: 241, Number: 106, Status: "OPEN", LastActivity: &restLastActivity{Date: &activity}}}
+	mu.Unlock()
+
+	// Cold cache: an empty caller token can never match, so the guard reports
+	// changed and the observer does a full listing.
+	first, err := p.RepoPRListGuard(context.Background(), repo, "")
+	if err != nil {
+		t.Fatalf("RepoPRListGuard: %v", err)
+	}
+	if first.ETag == "" {
+		t.Fatal("ETag is empty; the guard must synthesise a token when the server sends none")
+	}
+	if first.NotModified {
+		t.Error("NotModified = true on a cold cache, want false")
+	}
+
+	// Same data, token round-tripped: nothing can have changed.
+	second, err := p.RepoPRListGuard(context.Background(), repo, first.ETag)
+	if err != nil {
+		t.Fatalf("RepoPRListGuard: %v", err)
+	}
+	if !second.NotModified || second.ETag != first.ETag {
+		t.Errorf("unchanged data = %+v, want NotModified with the same token", second)
+	}
+
+	// Any change bumps the newest request's last-activity date, which is
+	// exactly what makes the synthesised token move.
+	mu.Lock()
+	newest = []restPullRequest{{ID: 241, Number: 106, Status: "OPEN", LastActivity: &restLastActivity{Date: &later}}}
+	mu.Unlock()
+	third, err := p.RepoPRListGuard(context.Background(), repo, second.ETag)
+	if err != nil {
+		t.Fatalf("RepoPRListGuard: %v", err)
+	}
+	if third.NotModified {
+		t.Error("NotModified = true after activity moved, want false")
+	}
+	if third.ETag == second.ETag {
+		t.Error("token did not change after activity moved")
+	}
+
+	// An emptied project is a change too, not an ambiguous no-op.
+	mu.Lock()
+	newest = nil
+	mu.Unlock()
+	fourth, err := p.RepoPRListGuard(context.Background(), repo, third.ETag)
+	if err != nil {
+		t.Fatalf("RepoPRListGuard: %v", err)
+	}
+	if fourth.NotModified || fourth.ETag == third.ETag {
+		t.Errorf("emptied project = %+v, want a changed token", fourth)
+	}
+
+	if want := `"Target Project" is "productone" order by "Last Activity Date" desc`; rec.first("/pulls") != want {
+		t.Errorf("guard query = %s\nwant %s", rec.first("/pulls"), want)
+	}
+}
+
+func TestCommitChecksGuardSynthesisesValidatorWithoutETag(t *testing.T) {
+	finished := mustTime(t, "2026-08-27T07:38:18Z")
+
+	var builds []restBuild
+	var mu sync.Mutex
+	rec := newRecorder()
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		if got := w.Header().Get("ETag"); got != "" {
+			t.Errorf("test server set an ETag (%q); the fallback would not be exercised", got)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		writeJSON(t, w, builds)
+	})
+
+	mu.Lock()
+	builds = []restBuild{{ID: 1416, Number: 365, JobName: "CI", Status: "RUNNING", CommitHash: "d3b802d"}}
+	mu.Unlock()
+
+	first, err := p.CommitChecksGuard(context.Background(), repo, "e638a69", "")
+	if err != nil {
+		t.Fatalf("CommitChecksGuard: %v", err)
+	}
+	if first.ETag == "" || first.NotModified {
+		t.Fatalf("cold cache = %+v, want a synthesised token and NotModified=false", first)
+	}
+
+	second, err := p.CommitChecksGuard(context.Background(), repo, "e638a69", first.ETag)
+	if err != nil {
+		t.Fatalf("CommitChecksGuard: %v", err)
+	}
+	if !second.NotModified {
+		t.Error("NotModified = false with identical builds, want true")
+	}
+
+	// A build finishing is the transition the guard exists to notice.
+	mu.Lock()
+	builds = []restBuild{{ID: 1416, Number: 365, JobName: "CI", Status: "SUCCESSFUL", CommitHash: "d3b802d", FinishDate: &finished}}
+	mu.Unlock()
+	third, err := p.CommitChecksGuard(context.Background(), repo, "e638a69", second.ETag)
+	if err != nil {
+		t.Fatalf("CommitChecksGuard: %v", err)
+	}
+	if third.NotModified || third.ETag == second.ETag {
+		t.Errorf("finished build = %+v, want a changed token", third)
+	}
+
+	// The token is scoped to the commit, so two PRs on different heads never
+	// share a guard entry.
+	other, err := p.CommitChecksGuard(context.Background(), repo, "0000000", "")
+	if err != nil {
+		t.Fatalf("CommitChecksGuard: %v", err)
+	}
+	if other.ETag == third.ETag {
+		t.Error("token is identical for a different head SHA")
+	}
+
+	if want := `"Project" is "productone" order by "Submit Date" desc`; rec.first("/builds") != want {
+		t.Errorf("guard query = %s\nwant %s", rec.first("/builds"), want)
+	}
+}
+
+func TestCommitChecksGuardRejectsEmptyHeadSHA(t *testing.T) {
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request %s: an empty head SHA must not reach the API", r.URL.Path)
+	})
+	if _, err := p.CommitChecksGuard(context.Background(), repo, "  ", "token"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGuardsRejectUnallowlistedHost(t *testing.T) {
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request %s to a host outside the allowlist", r.URL.Path)
+	})
+	stranger := repo
+	stranger.Host = "onedev.stranger.test:6610"
+
+	if _, err := p.RepoPRListGuard(context.Background(), stranger, ""); !errors.Is(err, ErrHostNotAllowed) {
+		t.Errorf("RepoPRListGuard err = %v, want ErrHostNotAllowed", err)
+	}
+	if _, err := p.CommitChecksGuard(context.Background(), stranger, "abc", ""); !errors.Is(err, ErrHostNotAllowed) {
+		t.Errorf("CommitChecksGuard err = %v, want ErrHostNotAllowed", err)
+	}
+	if _, err := p.ListPRsByRepo(context.Background(), stranger, time.Time{}); !errors.Is(err, ErrHostNotAllowed) {
+		t.Errorf("ListPRsByRepo err = %v, want ErrHostNotAllowed", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchPullRequests
+// ---------------------------------------------------------------------------
+
+// prServer serves the endpoints one pull-request fetch touches. Numbers listed
+// in broken answer HTTP 500 on their detail fetch.
+func prServer(t *testing.T, rec *recorder, broken map[int]bool) http.HandlerFunc {
+	t.Helper()
+	activity := mustTime(t, "2026-08-22T16:55:46Z")
+	return func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		path := strings.TrimPrefix(r.URL.Path, APIBasePath)
+		query := r.URL.Query().Get("query")
+		switch {
+		case path == "/pulls" && strings.Contains(query, `"Number" is`):
+			// Number lookup: map 10x -> request id 20x.
+			var number int
+			if _, err := fmt.Sscanf(query[strings.LastIndex(query, `"Number" is "`)+len(`"Number" is "`):], "%d", &number); err != nil {
+				t.Errorf("parse number from %q: %v", query, err)
+			}
+			writeJSON(t, w, []restPullRequest{{ID: int64(100 + number), Number: number}})
+		case strings.HasSuffix(path, "/merge-preview"):
+			writeJSON(t, w, restMergePreview{
+				TargetHeadCommitHash: "d3b7cc6",
+				HeadCommitHash:       "e638a69",
+				MergeCommitHash:      "d3b802d",
+			})
+		case strings.HasSuffix(path, "/reviews"):
+			writeJSON(t, w, []restReview{})
+		case path == "/builds":
+			writeJSON(t, w, []restBuild{{ID: 1416, Number: 365, JobName: "CI", Status: "SUCCESSFUL", CommitHash: "d3b802d"}})
+		case strings.HasPrefix(path, "/pulls/"):
+			var id int
+			if _, err := fmt.Sscanf(strings.TrimPrefix(path, "/pulls/"), "%d", &id); err != nil {
+				t.Errorf("parse request id from %q: %v", path, err)
+			}
+			if broken[id-100] {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("boom"))
+				return
+			}
+			writeJSON(t, w, restPullRequest{
+				ID: int64(id), Number: id - 100, Status: "OPEN", Title: "t",
+				SourceBranch: "topic", TargetBranch: "main",
+				BuildCommitHash: "d3b802d",
+				LastActivity:    &restLastActivity{Date: &activity},
+			})
+		default:
+			t.Errorf("unexpected request %s", path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+// TestFetchPullRequestsAlignment pins the contract the observer depends on:
+// result[i] answers refs[i], and a ref that could not be fetched leaves a
+// Fetched=false placeholder carrying its error rather than shifting the
+// results of its neighbours.
+func TestFetchPullRequestsAlignment(t *testing.T) {
+	rec := newRecorder()
+	p, repo, _ := newObserverProvider(t, "productone", prServer(t, rec, map[int]bool{2: true}))
+
+	refs := []ports.SCMPRRef{
+		{Repo: repo, Number: 1},
+		{Repo: repo, Number: 2},
+		{Repo: repo, Number: 3},
+	}
+	got, err := p.FetchPullRequests(context.Background(), refs)
+	if err == nil {
+		t.Fatal("err = nil, want the failing ref's error surfaced")
+	}
+	if len(got) != len(refs) {
+		t.Fatalf("got %d observations, want %d", len(got), len(refs))
+	}
+	for i, obs := range got {
+		if obs.PR.Number != refs[i].Number {
+			t.Fatalf("result[%d] answers PR %d, want %d", i, obs.PR.Number, refs[i].Number)
+		}
+	}
+	if !got[0].Fetched || !got[2].Fetched {
+		t.Errorf("healthy refs = %v/%v, want both fetched", got[0].Fetched, got[2].Fetched)
+	}
+	if got[1].Fetched {
+		t.Error("failed ref reported Fetched=true")
+	}
+	if got[1].Error == nil {
+		t.Error("failed ref carries no error")
+	}
+	if got[1].Provider != ProviderKey || got[1].Host != repo.Host || got[1].Repo != repo.Repo {
+		t.Errorf("placeholder lost its repo context: %+v", got[1])
+	}
+}
+
+func TestFetchPullRequestsObservation(t *testing.T) {
+	rec := newRecorder()
+	p, repo, srv := newObserverProvider(t, "productone", prServer(t, rec, nil))
+
+	got, err := p.FetchPullRequests(context.Background(), []ports.SCMPRRef{{Repo: repo, Number: 6, URL: "http://stale.example/pr/6"}})
+	if err != nil {
+		t.Fatalf("FetchPullRequests: %v", err)
+	}
+	obs := got[0]
+	if !obs.Fetched {
+		t.Fatalf("Fetched = false: %+v", obs)
+	}
+	if obs.PR.HeadSHA != "e638a69" {
+		t.Errorf("HeadSHA = %q, want e638a69 (the merge preview's head commit)", obs.PR.HeadSHA)
+	}
+	if obs.PR.MergeCommitSHA != "d3b802d" {
+		t.Errorf("MergeCommitSHA = %q, want d3b802d", obs.PR.MergeCommitSHA)
+	}
+	if obs.PR.URLAlias != "http://stale.example/pr/6" {
+		t.Errorf("URLAlias = %q, want the requested URL preserved", obs.PR.URLAlias)
+	}
+	if want := srv.URL + "/productone/~pulls/6"; obs.PR.URL != want {
+		t.Errorf("URL = %q, want %q", obs.PR.URL, want)
+	}
+	if obs.CI.Summary != string(domain.CIPassing) || obs.CI.HeadSHA != "e638a69" {
+		t.Errorf("CI = %+v, want passing at e638a69", obs.CI)
+	}
+	if len(obs.CI.Checks) != 1 || obs.CI.Checks[0].ProviderID != "1416" {
+		t.Errorf("checks = %+v, want one check carrying the build id", obs.CI.Checks)
+	}
+	if want := srv.URL + "/productone/~builds/365"; obs.CI.Checks[0].URL != want {
+		t.Errorf("check URL = %q, want %q", obs.CI.Checks[0].URL, want)
+	}
+	if obs.Mergeability.State != string(domain.MergeMergeable) || !obs.Mergeability.Mergeable {
+		t.Errorf("Mergeability = %+v, want mergeable", obs.Mergeability)
+	}
+	// The build query must carry a project-qualified pull-request reference; a
+	// bare number is rejected by OneDev with "Reference project not specified".
+	if want := `"Pull Request" is "productone#6" order by "Submit Date" desc`; rec.first("/builds") != want {
+		t.Errorf("build query = %s\nwant %s", rec.first("/builds"), want)
+	}
+}
+
+func TestFetchPullRequestsRejectsOversizedBatch(t *testing.T) {
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request %s: an oversized batch must be rejected locally", r.URL.Path)
+	})
+	refs := make([]ports.SCMPRRef, batchLimit+1)
+	for i := range refs {
+		refs[i] = ports.SCMPRRef{Repo: repo, Number: i + 1}
+	}
+	if _, err := p.FetchPullRequests(context.Background(), refs); err == nil {
+		t.Fatal("err = nil, want an oversized-batch error")
+	}
+}
+
+// TestFetchPullRequestsFallsBackToUpdatesForHeadSHA: OneDev computes the merge
+// preview asynchronously, and its pull-request payload carries no head commit.
+// Until the preview exists the head must come from the update history, or the
+// observer has nothing to guard CI with.
+func TestFetchPullRequestsFallsBackToUpdatesForHeadSHA(t *testing.T) {
+	rec := newRecorder()
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		path := strings.TrimPrefix(r.URL.Path, APIBasePath)
+		switch {
+		case path == "/pulls":
+			writeJSON(t, w, []restPullRequest{{ID: 241, Number: 106}})
+		case strings.HasSuffix(path, "/merge-preview"):
+			// OneDev has not computed one yet.
+			w.WriteHeader(http.StatusNotFound)
+		case strings.HasSuffix(path, "/updates"):
+			writeJSON(t, w, []restPullRequestUpdate{
+				{ID: 300, HeadCommitHash: "older"},
+				{ID: 326, HeadCommitHash: "newest"},
+			})
+		case strings.HasSuffix(path, "/reviews"):
+			writeJSON(t, w, []restReview{})
+		case path == "/builds":
+			writeJSON(t, w, []restBuild{})
+		default:
+			writeJSON(t, w, restPullRequest{ID: 241, Number: 106, Status: "OPEN", SourceBranch: "topic"})
+		}
+	})
+
+	got, err := p.FetchPullRequests(context.Background(), []ports.SCMPRRef{{Repo: repo, Number: 106}})
+	if err != nil {
+		t.Fatalf("FetchPullRequests: %v", err)
+	}
+	if got[0].PR.HeadSHA != "newest" {
+		t.Errorf("HeadSHA = %q, want newest", got[0].PR.HeadSHA)
+	}
+	if got[0].Mergeability.State != string(domain.MergeUnknown) {
+		t.Errorf("Mergeability = %q, want unknown while no preview exists", got[0].Mergeability.State)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CI
+// ---------------------------------------------------------------------------
+
+func TestFetchCI(t *testing.T) {
+	tests := []struct {
+		name        string
+		builds      []restBuild
+		wantSummary domain.CIState
+		wantChecks  []string
+		wantFailed  []string
+	}{
+		{
+			name:        "no builds",
+			builds:      nil,
+			wantSummary: domain.CIUnknown,
+		},
+		{
+			name: "stale commits are excluded",
+			builds: []restBuild{
+				{ID: 2, Number: 2, JobName: "CI", Status: "FAILED", CommitHash: "older"},
+				{ID: 1, Number: 1, JobName: "CI", Status: "SUCCESSFUL", CommitHash: "build-commit"},
+			},
+			wantSummary: domain.CIPassing,
+			wantChecks:  []string{"CI"},
+		},
+		{
+			name: "retries collapse to the newest build per job",
+			builds: []restBuild{
+				{ID: 3, Number: 3, JobName: "CI", Status: "SUCCESSFUL", CommitHash: "build-commit"},
+				{ID: 2, Number: 2, JobName: "CI", Status: "FAILED", CommitHash: "build-commit"},
+				{ID: 1, Number: 1, JobName: "Lint", Status: "FAILED", CommitHash: "build-commit"},
+			},
+			wantSummary: domain.CIFailing,
+			wantChecks:  []string{"CI", "Lint"},
+			wantFailed:  []string{"Lint"},
+		},
+		{
+			name: "a running job keeps the rollup pending",
+			builds: []restBuild{
+				{ID: 2, Number: 2, JobName: "CI", Status: "RUNNING", CommitHash: "build-commit"},
+				{ID: 1, Number: 1, JobName: "Lint", Status: "SUCCESSFUL", CommitHash: "build-commit"},
+			},
+			wantSummary: domain.CIPending,
+			wantChecks:  []string{"CI", "Lint"},
+		},
+		{
+			name: "a timed-out job fails the rollup",
+			builds: []restBuild{
+				{ID: 1, Number: 1, JobName: "CI", Status: "TIMED_OUT", CommitHash: "build-commit"},
+			},
+			wantSummary: domain.CIFailing,
+			wantChecks:  []string{"CI"},
+			wantFailed:  []string{"CI"},
+		},
+		{
+			name: "a build on the head commit counts when the project builds the branch directly",
+			builds: []restBuild{
+				{ID: 1, Number: 1, JobName: "CI", Status: "SUCCESSFUL", CommitHash: "head-commit"},
+			},
+			wantSummary: domain.CIPassing,
+			wantChecks:  []string{"CI"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(t, w, tt.builds)
+			})
+			client, err := p.clientForRepo(repo)
+			if err != nil {
+				t.Fatalf("clientForRepo: %v", err)
+			}
+			host, err := p.hostForRepo(repo)
+			if err != nil {
+				t.Fatalf("hostForRepo: %v", err)
+			}
+			pr := &restPullRequest{Number: 106, BuildCommitHash: "build-commit"}
+
+			ci, err := p.fetchCI(context.Background(), client, host, repo, pr, "head-commit")
+			if err != nil {
+				t.Fatalf("fetchCI: %v", err)
+			}
+			if ci.Summary != string(tt.wantSummary) {
+				t.Errorf("Summary = %q, want %q", ci.Summary, tt.wantSummary)
+			}
+			if got := checkNames(ci.Checks); !reflect.DeepEqual(got, tt.wantChecks) {
+				t.Errorf("Checks = %v, want %v", got, tt.wantChecks)
+			}
+			if got := checkNames(ci.FailedChecks); !reflect.DeepEqual(got, tt.wantFailed) {
+				t.Errorf("FailedChecks = %v, want %v", got, tt.wantFailed)
+			}
+			if len(ci.FailedChecks) == 0 && ci.FailedFingerprint != "" {
+				t.Errorf("FailedFingerprint = %q with no failures, want empty", ci.FailedFingerprint)
+			}
+			if len(ci.FailedChecks) > 0 && ci.FailedFingerprint == "" {
+				t.Error("FailedFingerprint is empty despite failing checks")
+			}
+		})
+	}
+}
+
+func checkNames(checks []ports.SCMCheckObservation) []string {
+	if len(checks) == 0 {
+		return nil
+	}
+	out := make([]string, len(checks))
+	for i, c := range checks {
+		out[i] = c.Name
+	}
+	return out
+}
+
+func TestBuildStatusToCheckStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   domain.PRCheckStatus
+	}{
+		{status: "SUCCESSFUL", want: domain.PRCheckPassed},
+		{status: "FAILED", want: domain.PRCheckFailed},
+		{status: "TIMED_OUT", want: domain.PRCheckFailed},
+		{status: "CANCELLED", want: domain.PRCheckCancelled},
+		{status: "RUNNING", want: domain.PRCheckInProgress},
+		{status: "PENDING", want: domain.PRCheckQueued},
+		{status: "WAITING", want: domain.PRCheckQueued},
+		{status: "SOMETHING_NEW", want: domain.PRCheckUnknown},
+		{status: "", want: domain.PRCheckUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := buildStatusToCheckStatus(tt.status); got != tt.want {
+				t.Fatalf("buildStatusToCheckStatus(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePRStatus(t *testing.T) {
+	tests := []struct {
+		status     string
+		wantState  domain.PRState
+		wantMerged bool
+		wantClosed bool
+	}{
+		{status: "OPEN", wantState: domain.PRStateOpen},
+		{status: "MERGED", wantState: domain.PRStateMerged, wantMerged: true},
+		{status: "DISCARDED", wantState: domain.PRStateClosed, wantClosed: true},
+		// An unknown status must not be mistaken for open: AO acts on open
+		// PRs, so guessing open is the more damaging error.
+		{status: "SOMETHING_NEW", wantState: domain.PRStateClosed, wantClosed: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			state, merged, closed := normalizePRStatus(tt.status)
+			if state != tt.wantState || merged != tt.wantMerged || closed != tt.wantClosed {
+				t.Fatalf("normalizePRStatus(%q) = %q/%v/%v, want %q/%v/%v",
+					tt.status, state, merged, closed, tt.wantState, tt.wantMerged, tt.wantClosed)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reviews and mergeability
+// ---------------------------------------------------------------------------
+
+func TestReviewDecision(t *testing.T) {
+	tests := []struct {
+		name    string
+		reviews []restReview
+		want    domain.ReviewDecision
+	}{
+		{name: "no reviewers", reviews: nil, want: domain.ReviewNone},
+		{name: "approved", reviews: []restReview{{Status: "APPROVED"}}, want: domain.ReviewApproved},
+		{name: "pending", reviews: []restReview{{Status: "PENDING"}}, want: domain.ReviewRequired},
+		{
+			name:    "an outstanding reviewer outranks an approval",
+			reviews: []restReview{{Status: "APPROVED"}, {Status: "PENDING"}},
+			want:    domain.ReviewRequired,
+		},
+		{
+			// A reviewer asking for changes is the signal AO must not lose,
+			// so it dominates every other verdict.
+			name:    "requested changes dominates",
+			reviews: []restReview{{Status: "APPROVED"}, {Status: "PENDING"}, {Status: "REQUESTED_FOR_CHANGES"}},
+			want:    domain.ReviewChangesRequest,
+		},
+		{
+			name:    "excluded reviewers carry no signal",
+			reviews: []restReview{{Status: "EXCLUDED"}, {Status: "APPROVED"}},
+			want:    domain.ReviewApproved,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewDecision(tt.reviews); got != tt.want {
+				t.Fatalf("reviewDecision = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeability(t *testing.T) {
+	tests := []struct {
+		name         string
+		pr           restPullRequest
+		preview      restMergePreview
+		hasPreview   bool
+		ci           string
+		review       string
+		wantState    domain.Mergeability
+		wantConflict bool
+		wantBlockers []string
+	}{
+		{
+			name:       "clean",
+			pr:         restPullRequest{Status: "OPEN"},
+			preview:    restMergePreview{MergeCommitHash: "abc"},
+			hasPreview: true,
+			ci:         string(domain.CIPassing),
+			review:     string(domain.ReviewApproved),
+			wantState:  domain.MergeMergeable,
+		},
+		{
+			name:       "no preview yet",
+			pr:         restPullRequest{Status: "OPEN"},
+			hasPreview: false,
+			wantState:  domain.MergeUnknown,
+		},
+		{
+			// OneDev documents a null mergeCommitHash as "there are conflicts".
+			name:         "null merge commit means conflicts",
+			pr:           restPullRequest{Status: "OPEN"},
+			preview:      restMergePreview{},
+			hasPreview:   true,
+			wantState:    domain.MergeConflicting,
+			wantConflict: true,
+			wantBlockers: []string{"conflicts"},
+		},
+		{
+			name:         "failing ci blocks",
+			pr:           restPullRequest{Status: "OPEN"},
+			preview:      restMergePreview{MergeCommitHash: "abc"},
+			hasPreview:   true,
+			ci:           string(domain.CIFailing),
+			wantState:    domain.MergeBlocked,
+			wantBlockers: []string{"ci_failing"},
+		},
+		{
+			name:         "requested changes blocks",
+			pr:           restPullRequest{Status: "OPEN"},
+			preview:      restMergePreview{MergeCommitHash: "abc"},
+			hasPreview:   true,
+			ci:           string(domain.CIPassing),
+			review:       string(domain.ReviewChangesRequest),
+			wantState:    domain.MergeBlocked,
+			wantBlockers: []string{"changes_requested"},
+		},
+		{
+			name:         "a failed merge check blocks",
+			pr:           restPullRequest{Status: "OPEN", CheckError: "Some builds are required"},
+			preview:      restMergePreview{MergeCommitHash: "abc"},
+			hasPreview:   true,
+			ci:           string(domain.CIPassing),
+			wantState:    domain.MergeBlocked,
+			wantBlockers: []string{"blocked_by_provider"},
+		},
+		{
+			name:         "a closed request is not mergeable",
+			pr:           restPullRequest{Status: "DISCARDED"},
+			preview:      restMergePreview{MergeCommitHash: "abc"},
+			hasPreview:   true,
+			wantState:    domain.MergeBlocked,
+			wantBlockers: []string{"blocked_by_provider"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeability(&tt.pr, tt.preview, tt.hasPreview, tt.ci, tt.review)
+			if got.State != string(tt.wantState) {
+				t.Errorf("State = %q, want %q", got.State, tt.wantState)
+			}
+			if got.Conflict != tt.wantConflict {
+				t.Errorf("Conflict = %v, want %v", got.Conflict, tt.wantConflict)
+			}
+			if !reflect.DeepEqual(got.Blockers, tt.wantBlockers) {
+				t.Errorf("Blockers = %v, want %v", got.Blockers, tt.wantBlockers)
+			}
+			if got.Mergeable != (tt.wantState == domain.MergeMergeable) {
+				t.Errorf("Mergeable = %v for state %q", got.Mergeable, got.State)
+			}
+		})
+	}
+}
+
+// TestFetchReviewThreads pins what OneDev can and cannot tell AO about review
+// discussion: verdicts and request-level comments are available, inline code
+// comments are not reachable per request, and the observation says so by
+// reporting itself Partial.
+func TestFetchReviewThreads(t *testing.T) {
+	submitted := mustTime(t, "2026-08-23T09:00:00Z")
+	p, repo, srv := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, APIBasePath)
+		switch {
+		case path == "/pulls":
+			writeJSON(t, w, []restPullRequest{{ID: 241, Number: 106}})
+		case strings.HasSuffix(path, "/reviews"):
+			writeJSON(t, w, []restReview{
+				{ID: 9, Status: "APPROVED", UserID: 4, StatusDate: &submitted},
+				{ID: 10, Status: "EXCLUDED", UserID: 5},
+			})
+		case strings.HasSuffix(path, "/comments"):
+			writeJSON(t, w, []restPullRequestComment{
+				{ID: 1, Content: "Source branch no longer exists", UserID: 4},
+				{ID: 2, Content: "beep boop", UserID: 6},
+			})
+		case strings.HasSuffix(path, "/users/4"):
+			writeJSON(t, w, restUser{ID: 4, Name: "johnkattenhorn"})
+		case strings.HasSuffix(path, "/users/6"):
+			writeJSON(t, w, restUser{ID: 6, Name: "release-bot"})
+		default:
+			t.Errorf("unexpected request %s", path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	got, err := p.FetchReviewThreads(context.Background(), ports.SCMPRRef{Repo: repo, Number: 106})
+	if err != nil {
+		t.Fatalf("FetchReviewThreads: %v", err)
+	}
+	if got.Decision != string(domain.ReviewApproved) {
+		t.Errorf("Decision = %q, want approved", got.Decision)
+	}
+	// An excluded reviewer is not a verdict, so it must not become a summary.
+	if len(got.Reviews) != 1 {
+		t.Fatalf("Reviews = %+v, want one summary", got.Reviews)
+	}
+	if got.Reviews[0].ID != "review:9" || got.Reviews[0].Author != "johnkattenhorn" {
+		t.Errorf("review summary = %+v", got.Reviews[0])
+	}
+	if !got.Reviews[0].SubmittedAt.Equal(submitted) {
+		t.Errorf("SubmittedAt = %v, want %v", got.Reviews[0].SubmittedAt, submitted)
+	}
+	if len(got.Threads) != 2 {
+		t.Fatalf("Threads = %+v, want two", got.Threads)
+	}
+	if got.Threads[0].ID != "comment:1" || got.Threads[0].Path != "" {
+		t.Errorf("thread = %+v, want an unanchored comment thread", got.Threads[0])
+	}
+	if want := srv.URL + "/productone/~pulls/106"; got.Threads[0].Comments[0].URL != want {
+		t.Errorf("comment URL = %q, want %q", got.Threads[0].Comments[0].URL, want)
+	}
+	if !got.Threads[1].IsBot || !got.Threads[1].Comments[0].IsBot {
+		t.Error("release-bot's comment was not flagged as a bot comment")
+	}
+	// OneDev exposes code comments only by id, so the thread set is never a
+	// complete snapshot and must be merged rather than replace what is stored.
+	if !got.Partial {
+		t.Error("Partial = false; the thread set cannot include inline comments")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Build log tail
+// ---------------------------------------------------------------------------
+
+// frameStatus encodes OneDev's status marker: a negative big-endian int32
+// length followed by that many bytes of status text.
+func frameStatus(status string) []byte {
+	frame := make([]byte, 4+len(status))
+	binary.BigEndian.PutUint32(frame[:4], uint32(int32(-len(status)))) //nolint:gosec // mirrors the wire format
+	copy(frame[4:], status)
+	return frame
+}
+
+// frameEntry encodes one log entry: a positive length followed by that many
+// bytes of JSON.
+func frameEntry(t *testing.T, text string) []byte {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"date":     "2026-08-27T07:38:12.461+00:00",
+		"messages": []map[string]any{{"text": text}},
+	})
+	if err != nil {
+		t.Fatalf("marshal log entry: %v", err)
+	}
+	frame := make([]byte, 4+len(payload))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(payload))) //nolint:gosec // length fits by construction
+	copy(frame[4:], payload)
+	return frame
+}
+
+func buildLogStream(t *testing.T, status string, lines ...string) []byte {
+	t.Helper()
+	out := frameStatus(status)
+	for _, line := range lines {
+		out = append(out, frameEntry(t, line)...)
+	}
+	return append(out, frameStatus(status)...)
+}
+
+func TestTailBuildLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		stream   func(t *testing.T) []byte
+		maxLines int
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "status markers are not log lines",
+			stream:   func(t *testing.T) []byte { return buildLogStream(t, "SUCCESSFUL", "one", "two") },
+			maxLines: 5,
+			want:     "one\ntwo",
+		},
+		{
+			name: "only the tail is kept",
+			stream: func(t *testing.T) []byte {
+				return buildLogStream(t, "FAILED", "one", "two", "three", "four")
+			},
+			maxLines: 2,
+			want:     "three\nfour",
+		},
+		{
+			name:     "an empty log yields an empty tail",
+			stream:   func(t *testing.T) []byte { return buildLogStream(t, "SUCCESSFUL") },
+			maxLines: 5,
+			want:     "",
+		},
+		{
+			// A stream cut mid-frame after usable output (a build still
+			// writing, a dropped connection) returns what was decoded.
+			name: "truncation after usable output is tolerated",
+			stream: func(t *testing.T) []byte {
+				full := buildLogStream(t, "FAILED", "one", "two")
+				return full[:len(full)-3]
+			},
+			maxLines: 5,
+			want:     "one\ntwo",
+		},
+		{
+			name: "an implausible frame length with no output is an error",
+			stream: func(t *testing.T) []byte {
+				return []byte{0x7f, 0xff, 0xff, 0xff}
+			},
+			maxLines: 5,
+			wantErr:  true,
+		},
+		{
+			// One unparseable entry does not cost the rest of the log: the
+			// frame length says exactly where the next entry begins.
+			name: "an unparseable entry is skipped",
+			stream: func(t *testing.T) []byte {
+				out := frameStatus("FAILED")
+				out = append(out, frameEntry(t, "one")...)
+				bad := []byte("{not json")
+				header := make([]byte, 4)
+				binary.BigEndian.PutUint32(header, uint32(len(bad))) //nolint:gosec // test fixture
+				out = append(out, header...)
+				out = append(out, bad...)
+				return append(out, frameEntry(t, "two")...)
+			},
+			maxLines: 5,
+			want:     "one\ntwo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tailBuildLog(strings.NewReader(string(tt.stream(t))), tt.maxLines)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("err = nil, want a framing error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("tailBuildLog: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("tail = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchFailedCheckLogTail(t *testing.T) {
+	var gotPath string
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = strings.TrimPrefix(r.URL.Path, APIBasePath)
+		_, _ = w.Write(buildLogStream(t, "FAILED", "step one", "step two failed"))
+	})
+
+	got, err := p.FetchFailedCheckLogTail(context.Background(), repo, ports.SCMCheckObservation{Name: "CI", ProviderID: "1020"})
+	if err != nil {
+		t.Fatalf("FetchFailedCheckLogTail: %v", err)
+	}
+	if got != "step one\nstep two failed" {
+		t.Errorf("tail = %q", got)
+	}
+	if gotPath != "/streaming/build-logs/1020" {
+		t.Errorf("path = %q, want /streaming/build-logs/1020", gotPath)
+	}
+}
+
+func TestFetchFailedCheckLogTailRequiresBuildID(t *testing.T) {
+	p, repo, _ := newObserverProvider(t, "productone", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request %s: a check with no build id must not reach the API", r.URL.Path)
+	})
+	if _, err := p.FetchFailedCheckLogTail(context.Background(), repo, ports.SCMCheckObservation{Name: "CI"}); err == nil {
+		t.Fatal("err = nil, want an error naming the missing build id")
+	}
+}

--- a/backend/internal/adapters/scm/onedev/provider.go
+++ b/backend/internal/adapters/scm/onedev/provider.go
@@ -84,6 +84,13 @@ type Provider struct {
 	mu      sync.Mutex
 	clients map[string]*Client
 
+	// identityMu guards identities, which memoizes the authenticated account
+	// per instance. OneDev identity is per-host — two allowlisted instances
+	// are two unrelated user databases — so the cache is keyed by authority
+	// rather than held as a single value. See identity.go.
+	identityMu sync.Mutex
+	identities map[string]ports.SCMIdentity
+
 	// cache memoizes OneDev's id lookups (PR number to request id, user id to
 	// login, project id to path) that the observer methods would otherwise
 	// repeat on every poll.
@@ -194,6 +201,7 @@ func NewProvider(opts ProviderOptions) (*Provider, error) {
 		httpClient:   opts.HTTPClient,
 		userAgent:    opts.UserAgent,
 		clients:      map[string]*Client{},
+		identities:   map[string]ports.SCMIdentity{},
 		cache:        newCache(),
 	}, nil
 }

--- a/backend/internal/adapters/scm/onedev/provider.go
+++ b/backend/internal/adapters/scm/onedev/provider.go
@@ -52,12 +52,9 @@ type ProviderOptions struct {
 	HostTokens map[string]TokenSource
 }
 
-// Provider is the OneDev SCM adapter.
-//
-// Slice 1 provides construction, host resolution, repository-URL parsing, and
-// an authenticated preflight. It does not yet implement the seven
-// scm.Provider observer methods, and is not registered with the daemon's
-// observer — that is Slice 2.
+// Provider is the OneDev SCM adapter. It satisfies the observer's
+// scm.Provider contract; see observer_provider.go for those methods and
+// doc.go for the API-shape decisions behind them.
 //
 // Every host the provider talks to must appear in the configured allowlist. A
 // host that is not in the allowlist is rejected before any credential is
@@ -86,6 +83,11 @@ type Provider struct {
 
 	mu      sync.Mutex
 	clients map[string]*Client
+
+	// cache memoizes OneDev's id lookups (PR number to request id, user id to
+	// login, project id to path) that the observer methods would otherwise
+	// repeat on every poll.
+	cache *cache
 }
 
 // NewProvider creates a OneDev SCM provider.
@@ -192,6 +194,7 @@ func NewProvider(opts ProviderOptions) (*Provider, error) {
 		httpClient:   opts.HTTPClient,
 		userAgent:    opts.UserAgent,
 		clients:      map[string]*Client{},
+		cache:        newCache(),
 	}, nil
 }
 

--- a/backend/internal/adapters/scm/onedev/provider.go
+++ b/backend/internal/adapters/scm/onedev/provider.go
@@ -109,7 +109,17 @@ func NewProvider(opts ProviderOptions) (*Provider, error) {
 		if err != nil {
 			return nil, err
 		}
-		if _, dup := allowed[h.authority]; dup {
+		if prev, dup := allowed[h.authority]; dup {
+			// The same instance listed twice is harmless, but listed twice
+			// under different schemes it is not: whichever entry came first
+			// would decide the transport, so config order would silently
+			// decide whether the connection is encrypted. Refuse rather than
+			// pick.
+			if prev.scheme != h.scheme {
+				return nil, fmt.Errorf(
+					"onedev scm: host %q is listed with conflicting schemes %q and %q; list it once",
+					h.authority, prev.scheme, h.scheme)
+			}
 			continue
 		}
 		allowed[h.authority] = h
@@ -129,18 +139,41 @@ func NewProvider(opts ProviderOptions) (*Provider, error) {
 		sort.Strings(byHostname[name])
 	}
 
-	hostTokens := make(map[string]TokenSource, len(opts.HostTokens))
-	for host, src := range opts.HostTokens {
-		key := normalizeHostKey(host)
-		if key == "" || src == nil {
-			continue
-		}
-		hostTokens[key] = src
-	}
-
 	logger := opts.Logger
 	if logger == nil {
 		logger = slog.Default()
+	}
+
+	// Per-host token keys go through the same resolution as a git remote, so
+	// an entry written as "10.0.0.30" still selects the allowlisted
+	// "10.0.0.30:6610". Matching exactly here while tolerating a port
+	// mismatch everywhere else would turn a near-miss into a silently
+	// dropped override, surfacing much later as ErrNoToken with nothing
+	// pointing at the typo.
+	hostTokens := make(map[string]TokenSource, len(opts.HostTokens))
+	claimedBy := make(map[string]string, len(opts.HostTokens))
+	for _, raw := range sortedKeys(opts.HostTokens) {
+		src := opts.HostTokens[raw]
+		if src == nil {
+			continue
+		}
+		h, ok := resolveAllowedHost(allowed, byHostname, raw)
+		if !ok {
+			// Not fatal — a surplus entry for a host this daemon does not
+			// serve is a normal way to share one environment across
+			// deployments — but it is never what a typo'd key looks like from
+			// the outside, so say so once at construction.
+			logger.Warn("onedev scm: per-host token names no configured host; the override will not be used",
+				"host", raw, "allowed_hosts", allowedHostStrings(allowed, order))
+			continue
+		}
+		if prev, dup := claimedBy[h.authority]; dup {
+			return nil, fmt.Errorf(
+				"onedev scm: per-host tokens %q and %q both resolve to host %q; keep one",
+				prev, raw, h.authority)
+		}
+		claimedBy[h.authority] = raw
+		hostTokens[h.authority] = src
 	}
 
 	if !opts.SkipTokenPreflight {
@@ -163,37 +196,49 @@ func NewProvider(opts ProviderOptions) (*Provider, error) {
 }
 
 // anyCredential reports whether the default source or any per-host source can
-// yield a credential. A source failing with anything other than ErrNoToken is
-// surfaced immediately: that is a misconfiguration the operator should see,
-// not an absent credential.
+// yield a credential. The default source is tried first, then the per-host
+// sources in sorted order, so the outcome does not depend on map iteration
+// order — this gates construction, and a coin-flipping daemon start is worse
+// than either verdict.
+//
+// A source failing with anything other than ErrNoToken is remembered and
+// returned only if no later source succeeds, so one broken credential helper
+// does not mask a working token elsewhere.
 func anyCredential(ctx context.Context, def TokenSource, hostTokens map[string]TokenSource) error {
-	sources := make([]TokenSource, 0, len(hostTokens)+1)
+	chain := make(FallbackTokenSource, 0, len(hostTokens)+1)
 	if def != nil {
-		sources = append(sources, def)
+		chain = append(chain, def)
 	}
-	for _, src := range hostTokens {
-		sources = append(sources, src)
+	for _, key := range sortedKeys(hostTokens) {
+		chain = append(chain, hostTokens[key])
 	}
-	for _, src := range sources {
-		_, err := src.Token(ctx)
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, ErrNoToken) {
-			return err
-		}
+	_, err := chain.Token(ctx)
+	return err
+}
+
+// sortedKeys returns a map's keys in a deterministic order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
 	}
-	return ErrNoToken
+	sort.Strings(keys)
+	return keys
+}
+
+// allowedHostStrings renders the allowlist for a log line.
+func allowedHostStrings(allowed map[string]allowedHost, order []string) []string {
+	out := make([]string, 0, len(order))
+	for _, authority := range order {
+		out = append(out, allowed[authority].String())
+	}
+	return out
 }
 
 // AllowedHosts returns the configured allowlist in stable order, rendered as
 // scheme-qualified entries.
 func (p *Provider) AllowedHosts() []string {
-	out := make([]string, 0, len(p.order))
-	for _, authority := range p.order {
-		out = append(out, p.allowed[authority].String())
-	}
-	return out
+	return allowedHostStrings(p.allowed, p.order)
 }
 
 // SCMCredentialsAvailable reports whether usable OneDev credentials exist,
@@ -241,18 +286,24 @@ func (p *Provider) Preflight(ctx context.Context) error {
 // entry is an allowlisted instance, and it — not the remote's authority — is
 // what the credential is ever sent to.
 func (p *Provider) resolveHost(authority string) (allowedHost, bool) {
+	return resolveAllowedHost(p.allowed, p.byHostname, authority)
+}
+
+// resolveAllowedHost is resolveHost's logic as a free function, so NewProvider
+// can resolve per-host token keys the same way before the Provider exists.
+func resolveAllowedHost(allowed map[string]allowedHost, byHostname map[string][]string, authority string) (allowedHost, bool) {
 	key := normalizeHostKey(authority)
 	if key == "" {
 		return allowedHost{}, false
 	}
-	if h, ok := p.allowed[key]; ok {
+	if h, ok := allowed[key]; ok {
 		return h, true
 	}
-	matches := p.byHostname[hostnameOf(key)]
+	matches := byHostname[hostnameOf(key)]
 	if len(matches) != 1 {
 		return allowedHost{}, false
 	}
-	return p.allowed[matches[0]], true
+	return allowed[matches[0]], true
 }
 
 // clientForRepo returns the client for a repository's host, or an error when

--- a/backend/internal/adapters/scm/onedev/provider.go
+++ b/backend/internal/adapters/scm/onedev/provider.go
@@ -196,14 +196,22 @@ func NewProvider(opts ProviderOptions) (*Provider, error) {
 }
 
 // anyCredential reports whether the default source or any per-host source can
-// yield a credential. The default source is tried first, then the per-host
-// sources in sorted order, so the outcome does not depend on map iteration
-// order — this gates construction, and a coin-flipping daemon start is worse
-// than either verdict.
+// yield a credential. It gates NewProvider, so its verdict must not vary
+// between runs on identical configuration.
 //
-// A source failing with anything other than ErrNoToken is remembered and
-// returned only if no later source succeeds, so one broken credential helper
-// does not mask a working token elsewhere.
+// The default source is tried first, then the per-host sources in sorted key
+// order. FallbackTokenSource.Token then does the rest: it returns the first
+// success wherever it appears, and remembers a hard (non-ErrNoToken) failure
+// but returns it only if nothing later succeeds — so one broken credential
+// helper cannot mask a working token elsewhere, whatever the order.
+//
+// Sorting is therefore not what makes a working source win; that holds
+// regardless. What it decides is *which* hard failure is reported when several
+// sources fail and none succeeds. Without it that error is chosen by Go's map
+// iteration order, and a daemon that refuses to start with a different reason
+// each time is far harder to diagnose than one that always names the same
+// host. TestCredentialResolutionIsOrderIndependent pins this; it fails if
+// sortedKeys stops sorting.
 func anyCredential(ctx context.Context, def TokenSource, hostTokens map[string]TokenSource) error {
 	chain := make(FallbackTokenSource, 0, len(hostTokens)+1)
 	if def != nil {
@@ -216,7 +224,8 @@ func anyCredential(ctx context.Context, def TokenSource, hostTokens map[string]T
 	return err
 }
 
-// sortedKeys returns a map's keys in a deterministic order.
+// sortedKeys returns a map's keys in a deterministic order. Load-bearing, not
+// cosmetic: see anyCredential for what varies without it.
 func sortedKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/backend/internal/adapters/scm/onedev/provider.go
+++ b/backend/internal/adapters/scm/onedev/provider.go
@@ -1,0 +1,408 @@
+package onedev
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// ErrNoAllowedHosts is returned by NewProvider when the host allowlist is
+// empty. OneDev is always self-hosted — there is no onedev.com to fall back
+// on — so an empty allowlist means the provider has nowhere to talk to and
+// construction fails loudly rather than yielding a provider that rejects
+// every remote it is later handed.
+var ErrNoAllowedHosts = errors.New("onedev scm: no allowed hosts configured (set AO_ONEDEV_ALLOWED_HOSTS)")
+
+// ErrHostNotAllowed is returned when a remote's host is not in the configured
+// allowlist. The provider rejects such hosts before attaching any credential.
+var ErrHostNotAllowed = errors.New("onedev scm: host not in allowlist")
+
+// ProviderOptions configures the OneDev SCM provider.
+type ProviderOptions struct {
+	HTTPClient *http.Client
+	// Token is the default credential source, applied to any allowed host
+	// without an entry in HostTokens.
+	Token TokenSource
+	// SkipTokenPreflight disables the local credential check in NewProvider.
+	// It does not affect Provider.Preflight, which is the network check.
+	SkipTokenPreflight bool
+	UserAgent          string
+	Logger             *slog.Logger
+
+	// AllowedHosts lists the OneDev instances the provider may talk to. This
+	// is required configuration. An entry is "host", "host:port", or a
+	// scheme-qualified "http://host:port" / "https://host" — plain HTTP must
+	// be written explicitly because self-hosted OneDev is frequently reached
+	// over HTTP on a private network, and silently upgrading to HTTPS would
+	// make every request fail with a TLS error instead of working.
+	AllowedHosts []string
+
+	// HostTokens maps an allowed host to a credential override. Hosts without
+	// an entry fall back to Token. The per-host selection keeps one
+	// instance's credential from being attached to another instance.
+	HostTokens map[string]TokenSource
+}
+
+// Provider is the OneDev SCM adapter.
+//
+// Slice 1 provides construction, host resolution, repository-URL parsing, and
+// an authenticated preflight. It does not yet implement the seven
+// scm.Provider observer methods, and is not registered with the daemon's
+// observer — that is Slice 2.
+//
+// Every host the provider talks to must appear in the configured allowlist. A
+// host that is not in the allowlist is rejected before any credential is
+// attached, so no request is ever made to an unconfigured instance.
+type Provider struct {
+	logger *slog.Logger
+
+	// allowed maps an authority ("10.0.0.30:6610") to its allowlist entry.
+	allowed map[string]allowedHost
+	// order is the allowlist in stable sorted order, for AllowedHosts and
+	// Preflight so their output does not depend on map iteration.
+	order []string
+
+	// byHostname indexes allowlist entries by port-less hostname, so a remote
+	// cloned over SSH (OneDev's git SSH port, commonly 6611) resolves to the
+	// same instance as one cloned over HTTP (commonly 6610). A hostname
+	// present more than once is ambiguous and is recorded as such rather than
+	// resolved arbitrarily.
+	byHostname map[string][]string
+
+	defaultToken TokenSource
+	hostTokens   map[string]TokenSource
+
+	httpClient *http.Client
+	userAgent  string
+
+	mu      sync.Mutex
+	clients map[string]*Client
+}
+
+// NewProvider creates a OneDev SCM provider.
+//
+// It fails when no allowed hosts are configured, when an allowlist entry is
+// malformed, or — unless SkipTokenPreflight is set — when no usable
+// credential is configured. All three are local checks; no network call is
+// made here. Use Preflight for the authenticated round-trip.
+func NewProvider(opts ProviderOptions) (*Provider, error) {
+	if len(opts.AllowedHosts) == 0 {
+		return nil, ErrNoAllowedHosts
+	}
+
+	allowed := make(map[string]allowedHost, len(opts.AllowedHosts))
+	byHostname := map[string][]string{}
+	for _, raw := range opts.AllowedHosts {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		h, err := parseAllowedHost(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := allowed[h.authority]; dup {
+			continue
+		}
+		allowed[h.authority] = h
+		name := h.hostname()
+		byHostname[name] = append(byHostname[name], h.authority)
+	}
+	if len(allowed) == 0 {
+		return nil, ErrNoAllowedHosts
+	}
+
+	order := make([]string, 0, len(allowed))
+	for authority := range allowed {
+		order = append(order, authority)
+	}
+	sort.Strings(order)
+	for name := range byHostname {
+		sort.Strings(byHostname[name])
+	}
+
+	hostTokens := make(map[string]TokenSource, len(opts.HostTokens))
+	for host, src := range opts.HostTokens {
+		key := normalizeHostKey(host)
+		if key == "" || src == nil {
+			continue
+		}
+		hostTokens[key] = src
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	if !opts.SkipTokenPreflight {
+		if err := anyCredential(context.Background(), opts.Token, hostTokens); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Provider{
+		logger:       logger,
+		allowed:      allowed,
+		order:        order,
+		byHostname:   byHostname,
+		defaultToken: opts.Token,
+		hostTokens:   hostTokens,
+		httpClient:   opts.HTTPClient,
+		userAgent:    opts.UserAgent,
+		clients:      map[string]*Client{},
+	}, nil
+}
+
+// anyCredential reports whether the default source or any per-host source can
+// yield a credential. A source failing with anything other than ErrNoToken is
+// surfaced immediately: that is a misconfiguration the operator should see,
+// not an absent credential.
+func anyCredential(ctx context.Context, def TokenSource, hostTokens map[string]TokenSource) error {
+	sources := make([]TokenSource, 0, len(hostTokens)+1)
+	if def != nil {
+		sources = append(sources, def)
+	}
+	for _, src := range hostTokens {
+		sources = append(sources, src)
+	}
+	for _, src := range sources {
+		_, err := src.Token(ctx)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrNoToken) {
+			return err
+		}
+	}
+	return ErrNoToken
+}
+
+// AllowedHosts returns the configured allowlist in stable order, rendered as
+// scheme-qualified entries.
+func (p *Provider) AllowedHosts() []string {
+	out := make([]string, 0, len(p.order))
+	for _, authority := range p.order {
+		out = append(out, p.allowed[authority].String())
+	}
+	return out
+}
+
+// SCMCredentialsAvailable reports whether usable OneDev credentials exist,
+// checking the default source and then every per-host source. A deployment
+// that configures only per-host tokens is still usable.
+func (p *Provider) SCMCredentialsAvailable(ctx context.Context) (bool, error) {
+	err := anyCredential(ctx, p.defaultToken, p.hostTokens)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, ErrNoToken) {
+		return false, nil
+	}
+	return false, err
+}
+
+// Preflight performs an authenticated GET /~api/projects against every
+// configured host, so a bad credential or an unreachable instance is reported
+// at startup rather than on the first poll. Errors from all hosts are joined
+// so one broken instance's message is not hidden by another's.
+func (p *Provider) Preflight(ctx context.Context) error {
+	var errs []error
+	for _, authority := range p.order {
+		client, err := p.clientForAuthority(authority)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if err := client.Preflight(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// resolveHost maps a git remote's authority onto a configured allowlist
+// entry. An exact authority match wins. Failing that, the port-less hostname
+// is matched: OneDev serves git over SSH and HTTP on different ports (6611
+// and 6610 in a default install), so the authority of an SSH remote never
+// equals the authority of the HTTP API. When a hostname appears in the
+// allowlist more than once the match is ambiguous and is rejected rather than
+// guessed.
+//
+// Rewriting the port this way does not widen the trust boundary: the returned
+// entry is an allowlisted instance, and it — not the remote's authority — is
+// what the credential is ever sent to.
+func (p *Provider) resolveHost(authority string) (allowedHost, bool) {
+	key := normalizeHostKey(authority)
+	if key == "" {
+		return allowedHost{}, false
+	}
+	if h, ok := p.allowed[key]; ok {
+		return h, true
+	}
+	matches := p.byHostname[hostnameOf(key)]
+	if len(matches) != 1 {
+		return allowedHost{}, false
+	}
+	return p.allowed[matches[0]], true
+}
+
+// clientForRepo returns the client for a repository's host, or an error when
+// the host is not allowlisted.
+func (p *Provider) clientForRepo(repo ports.SCMRepo) (*Client, error) {
+	h, ok := p.resolveHost(repo.Host)
+	if !ok {
+		return nil, fmt.Errorf("onedev scm: host %q: %w", repo.Host, ErrHostNotAllowed)
+	}
+	return p.clientForAuthority(h.authority)
+}
+
+// clientForAuthority lazily builds (and memoizes) the client for one
+// allowlisted instance, selecting that host's credential override if one is
+// configured.
+func (p *Provider) clientForAuthority(authority string) (*Client, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if c, ok := p.clients[authority]; ok {
+		return c, nil
+	}
+	h, ok := p.allowed[authority]
+	if !ok {
+		return nil, fmt.Errorf("onedev scm: host %q: %w", authority, ErrHostNotAllowed)
+	}
+	token := p.defaultToken
+	if src, ok := p.hostTokens[authority]; ok {
+		token = src
+	}
+	c, err := NewClient(ClientOptions{
+		HTTPClient: p.httpClient,
+		Token:      token,
+		APIBase:    h.apiBase(),
+		UserAgent:  p.userAgent,
+	})
+	if err != nil {
+		return nil, err
+	}
+	p.clients[authority] = c
+	return c, nil
+}
+
+// scpRemoteRe matches the scp-style SSH remote form, e.g.
+// "git@onedev.example.com:Homelab/curatarr.git". OneDev installs normally
+// hand out an ssh:// URL because their SSH port is not 22, but a hand-written
+// scp-style remote is still valid git and is accepted here.
+var scpRemoteRe = regexp.MustCompile(`^[^@/]+@([^:/]+):(.+)$`)
+
+// ParseRepository normalizes a git remote into a OneDev repository identity,
+// reporting false for anything that is not a remote of an allowlisted OneDev
+// instance. Recognised forms:
+//
+//	ssh://git@host:6611/Homelab/curatarr.git
+//	http://host:6610/Homelab/curatarr.git
+//	https://host/curatarr.git
+//	git@host:Homelab/curatarr.git
+//
+// A OneDev project path may be a single segment ("curatarr") or nested to any
+// depth ("Homelab/curatarr", "Homelab/tools/curatarr"), because OneDev
+// projects form a tree rather than GitLab's owner/repo pair. Repo therefore
+// carries the full project path, Name the final segment, and Owner the parent
+// path — empty for a root project.
+//
+// Host is normalized to the allowlisted API authority, not the authority
+// written in the remote. That way the same project cloned over SSH (port
+// 6611) and over HTTP (port 6610) yields one identity, so claim validation
+// and PR tracking do not fork by protocol.
+func (p *Provider) ParseRepository(remote string) (ports.SCMRepo, bool) {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return ports.SCMRepo{}, false
+	}
+
+	authority, rawPath, ok := splitRemote(remote)
+	if !ok {
+		return ports.SCMRepo{}, false
+	}
+	host, ok := p.resolveHost(authority)
+	if !ok {
+		return ports.SCMRepo{}, false
+	}
+	owner, name, ok := splitProjectPath(rawPath)
+	if !ok {
+		return ports.SCMRepo{}, false
+	}
+	return makeRepo(host.authority, owner, name), true
+}
+
+// splitRemote extracts the authority and project path from a git remote in
+// any of the supported forms.
+func splitRemote(remote string) (authority, path string, ok bool) {
+	// ssh://git@host[:port]/project.git
+	if strings.HasPrefix(remote, "ssh://") {
+		u, err := url.Parse(remote)
+		if err != nil || u.Host == "" {
+			return "", "", false
+		}
+		return u.Host, u.Path, true
+	}
+
+	// scp-style: git@host:project.git
+	if m := scpRemoteRe.FindStringSubmatch(remote); m != nil {
+		return m[1], m[2], true
+	}
+
+	// http(s)://host[:port]/project.git
+	u, err := url.Parse(remote)
+	if err != nil || u.Host == "" {
+		return "", "", false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", "", false
+	}
+	return u.Host, u.Path, true
+}
+
+// splitProjectPath splits a OneDev project path into its parent path and
+// final segment, stripping the optional ".git" suffix. Empty, "." and ".."
+// segments are rejected so a traversal-shaped path cannot become a repository
+// identity that is later interpolated into an API URL.
+func splitProjectPath(raw string) (owner, name string, ok bool) {
+	p := strings.Trim(strings.TrimSpace(raw), "/")
+	p = strings.TrimSuffix(p, ".git")
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return "", "", false
+	}
+	parts := strings.Split(p, "/")
+	for _, seg := range parts {
+		if seg == "" || seg == "." || seg == ".." {
+			return "", "", false
+		}
+	}
+	name = parts[len(parts)-1]
+	owner = strings.Join(parts[:len(parts)-1], "/")
+	return owner, name, true
+}
+
+// makeRepo builds the normalized repository identity. Repo is the full
+// project path; for a root project (no parent) it equals Name.
+func makeRepo(host, owner, name string) ports.SCMRepo {
+	full := name
+	if owner != "" {
+		full = owner + "/" + name
+	}
+	return ports.SCMRepo{
+		Provider: ProviderKey,
+		Host:     host,
+		Owner:    owner,
+		Name:     name,
+		Repo:     full,
+	}
+}

--- a/backend/internal/adapters/scm/onedev/provider_test.go
+++ b/backend/internal/adapters/scm/onedev/provider_test.go
@@ -610,3 +610,52 @@ func TestAnyCredentialIsOrderIndependent(t *testing.T) {
 		t.Fatalf("anyCredential = %v, want ErrNoToken", err)
 	}
 }
+
+// TestNewProviderFailsWhenOnlyCredentialIsMisKeyed covers the second half of
+// the mis-keyed per-host token problem: a deployment whose only credential
+// names no configured host must fail at construction, naming the cause, rather
+// than constructing fine and returning ErrNoToken on its first request.
+func TestNewProviderFailsWhenOnlyCredentialIsMisKeyed(t *testing.T) {
+	tests := []struct {
+		name     string
+		tokenKey string
+		wantErr  bool
+	}{
+		{
+			// A key that merely omits the API port is not mis-keyed — it
+			// resolves, and construction succeeds.
+			name: "port omitted still resolves", tokenKey: "10.0.0.30", wantErr: false,
+		},
+		{
+			name: "key names the git ssh port", tokenKey: "10.0.0.30:6611", wantErr: false,
+		},
+		{
+			name: "key names no configured host", tokenKey: "10.0.0.99:6610", wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs strings.Builder
+			logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			_, err := NewProvider(ProviderOptions{
+				AllowedHosts: []string{"http://10.0.0.30:6610"},
+				Logger:       logger,
+				// No default token: the per-host entry is the only credential.
+				HostTokens: map[string]TokenSource{tt.tokenKey: StaticTokenSource("host-token")},
+			})
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("NewProvider: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, ErrNoToken) {
+				t.Fatalf("err = %v, want ErrNoToken at construction", err)
+			}
+			if !strings.Contains(logs.String(), tt.tokenKey) {
+				t.Fatalf("nothing named the offending key %q: %s", tt.tokenKey, logs.String())
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/scm/onedev/provider_test.go
+++ b/backend/internal/adapters/scm/onedev/provider_test.go
@@ -1,0 +1,415 @@
+package onedev
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func newTestProvider(t *testing.T, hosts []string) *Provider {
+	t.Helper()
+	p, err := NewProvider(ProviderOptions{
+		AllowedHosts: hosts,
+		Token:        StaticTokenSource("od-token"),
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	return p
+}
+
+func TestNewProvider(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       ProviderOptions
+		wantErr    error
+		wantHosts  []string
+		wantSubstr string
+	}{
+		{
+			// OneDev has no public instance, so an empty allowlist leaves the
+			// provider with nowhere to talk to. Fail loudly at construction.
+			name:    "no allowed hosts",
+			opts:    ProviderOptions{Token: StaticTokenSource("od-token")},
+			wantErr: ErrNoAllowedHosts,
+		},
+		{
+			name: "allowlist of only blanks",
+			opts: ProviderOptions{
+				AllowedHosts: []string{"", "   "},
+				Token:        StaticTokenSource("od-token"),
+			},
+			wantErr: ErrNoAllowedHosts,
+		},
+		{
+			name: "malformed allowlist entry",
+			opts: ProviderOptions{
+				AllowedHosts: []string{"ssh://od.test:6611"},
+				Token:        StaticTokenSource("od-token"),
+			},
+			wantSubstr: "scheme must be http or https",
+		},
+		{
+			name:    "no credentials",
+			opts:    ProviderOptions{AllowedHosts: []string{"od.test:6610"}},
+			wantErr: ErrNoToken,
+		},
+		{
+			name: "no credentials is tolerated when the preflight is skipped",
+			opts: ProviderOptions{
+				AllowedHosts:       []string{"od.test:6610"},
+				SkipTokenPreflight: true,
+			},
+			wantHosts: []string{"https://od.test:6610"},
+		},
+		{
+			// A deployment may configure only per-host tokens.
+			name: "per-host token alone is enough",
+			opts: ProviderOptions{
+				AllowedHosts: []string{"od.test:6610"},
+				HostTokens:   map[string]TokenSource{"od.test:6610": StaticTokenSource("od-host")},
+			},
+			wantHosts: []string{"https://od.test:6610"},
+		},
+		{
+			name: "hosts are normalized, deduped and ordered",
+			opts: ProviderOptions{
+				AllowedHosts: []string{"  B.test  ", "http://a.test:6610", "b.test", "https://B.TEST"},
+				Token:        StaticTokenSource("od-token"),
+			},
+			wantHosts: []string{"http://a.test:6610", "https://b.test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewProvider(tt.opts)
+			if tt.wantErr != nil || tt.wantSubstr != "" {
+				if err == nil {
+					t.Fatal("NewProvider succeeded, want error")
+				}
+				if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tt.wantErr)
+				}
+				if tt.wantSubstr != "" && !strings.Contains(err.Error(), tt.wantSubstr) {
+					t.Fatalf("err = %v, want it to mention %q", err, tt.wantSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+			if got := p.AllowedHosts(); !reflect.DeepEqual(got, tt.wantHosts) {
+				t.Fatalf("AllowedHosts() = %v, want %v", got, tt.wantHosts)
+			}
+		})
+	}
+}
+
+// TestNewProviderSurfacesBrokenCredentialHelper distinguishes "no credential
+// configured" from "credential source is broken" — the daemon logs the former
+// as disabled and the latter as a failure.
+func TestNewProviderSurfacesBrokenCredentialHelper(t *testing.T) {
+	boom := errors.New("keyring is locked")
+	_, err := NewProvider(ProviderOptions{
+		AllowedHosts: []string{"od.test:6610"},
+		Token:        errSource{boom},
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+}
+
+func TestParseRepository(t *testing.T) {
+	// The estate's real shape: OneDev serves git over SSH on 6611 and HTTP on
+	// 6610, and the allowlist names the HTTP API endpoint.
+	hosts := []string{"http://192.168.1.30:6610", "https://git.example.com"}
+
+	tests := []struct {
+		name   string
+		remote string
+		want   ports.SCMRepo
+		wantOK bool
+	}{
+		{
+			name:   "ssh url with the git ssh port",
+			remote: "ssh://git@192.168.1.30:6611/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "", Name: "curatarr", Repo: "curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "ssh url with a nested project path",
+			remote: "ssh://git@192.168.1.30:6611/Homelab/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "Homelab", Name: "curatarr", Repo: "Homelab/curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "http url with the api port",
+			remote: "http://192.168.1.30:6610/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "", Name: "curatarr", Repo: "curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "http url with a nested project path",
+			remote: "http://192.168.1.30:6610/Homelab/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "Homelab", Name: "curatarr", Repo: "Homelab/curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "deeply nested project path",
+			remote: "http://192.168.1.30:6610/Homelab/tools/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "Homelab/tools", Name: "curatarr", Repo: "Homelab/tools/curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "the .git suffix is optional",
+			remote: "http://192.168.1.30:6610/Homelab/curatarr",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "Homelab", Name: "curatarr", Repo: "Homelab/curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "https remote on a default-port host",
+			remote: "https://git.example.com/Homelab/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "git.example.com", Owner: "Homelab", Name: "curatarr", Repo: "Homelab/curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "scp-style remote",
+			remote: "git@git.example.com:Homelab/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "git.example.com", Owner: "Homelab", Name: "curatarr", Repo: "Homelab/curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "host case is normalized",
+			remote: "https://GIT.Example.COM/curatarr.git",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "git.example.com", Owner: "", Name: "curatarr", Repo: "curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "trailing slash",
+			remote: "http://192.168.1.30:6610/Homelab/curatarr.git/",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "Homelab", Name: "curatarr", Repo: "Homelab/curatarr"},
+			wantOK: true,
+		},
+		{
+			name:   "surrounding whitespace",
+			remote: "  http://192.168.1.30:6610/curatarr.git  ",
+			want:   ports.SCMRepo{Provider: "onedev", Host: "192.168.1.30:6610", Owner: "", Name: "curatarr", Repo: "curatarr"},
+			wantOK: true,
+		},
+		{name: "empty remote", remote: ""},
+		{name: "whitespace remote", remote: "   "},
+		{name: "host not in the allowlist", remote: "http://onedev.attacker.example:6610/curatarr.git"},
+		{name: "github remote", remote: "git@github.com:aoagents/agent-orchestrator.git"},
+		{name: "gitlab remote", remote: "https://gitlab.com/group/project.git"},
+		{name: "no project path", remote: "http://192.168.1.30:6610/"},
+		{name: "only a .git suffix", remote: "http://192.168.1.30:6610/.git"},
+		{name: "empty path segment", remote: "http://192.168.1.30:6610/Homelab//curatarr.git"},
+		{name: "traversal segment", remote: "http://192.168.1.30:6610/Homelab/../curatarr.git"},
+		{name: "dot segment", remote: "http://192.168.1.30:6610/./curatarr.git"},
+		{name: "unsupported scheme", remote: "file:///srv/git/curatarr.git"},
+		{name: "not a url", remote: "just some text"},
+		{name: "local path", remote: "/srv/git/curatarr.git"},
+	}
+
+	p := newTestProvider(t, hosts)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := p.ParseRepository(tt.remote)
+			if ok != tt.wantOK {
+				t.Fatalf("ParseRepository(%q) ok = %v, want %v (repo %+v)", tt.remote, ok, tt.wantOK, got)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("ParseRepository(%q) = %+v, want %+v", tt.remote, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseRepositoryAmbiguousHostnameRejected covers the one case where the
+// SSH-port fallback cannot decide: two allowlisted instances share a hostname
+// on different ports, so a remote on a third port matches neither uniquely.
+func TestParseRepositoryAmbiguousHostnameRejected(t *testing.T) {
+	p := newTestProvider(t, []string{"http://od.test:6610", "http://od.test:7610"})
+
+	if _, ok := p.ParseRepository("ssh://git@od.test:6611/curatarr.git"); ok {
+		t.Fatal("ambiguous hostname resolved; want rejection")
+	}
+	// An exact authority match is still unambiguous.
+	got, ok := p.ParseRepository("http://od.test:7610/curatarr.git")
+	if !ok {
+		t.Fatal("exact authority match rejected")
+	}
+	if got.Host != "od.test:7610" {
+		t.Fatalf("Host = %q, want od.test:7610", got.Host)
+	}
+}
+
+func TestSCMCredentialsAvailable(t *testing.T) {
+	boom := errors.New("keyring is locked")
+	tests := []struct {
+		name    string
+		opts    ProviderOptions
+		want    bool
+		wantErr error
+	}{
+		{
+			name: "default token",
+			opts: ProviderOptions{AllowedHosts: []string{"od.test"}, Token: StaticTokenSource("od-token")},
+			want: true,
+		},
+		{
+			name: "per-host token only",
+			opts: ProviderOptions{
+				AllowedHosts: []string{"od.test"},
+				HostTokens:   map[string]TokenSource{"od.test": StaticTokenSource("od-host")},
+			},
+			want: true,
+		},
+		{
+			name: "nothing configured",
+			opts: ProviderOptions{AllowedHosts: []string{"od.test"}, SkipTokenPreflight: true},
+			want: false,
+		},
+		{
+			name: "broken source surfaces as an error",
+			opts: ProviderOptions{
+				AllowedHosts:       []string{"od.test"},
+				Token:              errSource{boom},
+				SkipTokenPreflight: true,
+			},
+			wantErr: boom,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewProvider(tt.opts)
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+			got, err := p.SCMCredentialsAvailable(context.Background())
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SCMCredentialsAvailable: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("SCMCredentialsAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPreflightPerHostCredentials checks that each instance is preflighted
+// with its own credential and that a per-host override is not applied to
+// another host.
+func TestPreflightPerHostCredentials(t *testing.T) {
+	seen := map[string]string{}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		seen[r.Host] = r.Header.Get("Authorization")
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte("[]"))
+	}
+	a := newTestServer(t, handler)
+	b := newTestServer(t, handler)
+
+	p, err := NewProvider(ProviderOptions{
+		AllowedHosts: []string{a.URL, b.URL},
+		Token:        StaticTokenSource("default-token"),
+		HostTokens: map[string]TokenSource{
+			b.URL: StaticTokenSource("b-token"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if err := p.Preflight(context.Background()); err != nil {
+		t.Fatalf("Preflight: %v", err)
+	}
+
+	aHost := strings.TrimPrefix(a.URL, "http://")
+	bHost := strings.TrimPrefix(b.URL, "http://")
+	if got := seen[aHost]; got != "Bearer default-token" {
+		t.Errorf("host a Authorization = %q, want Bearer default-token", got)
+	}
+	if got := seen[bHost]; got != "Bearer b-token" {
+		t.Errorf("host b Authorization = %q, want Bearer b-token", got)
+	}
+}
+
+// TestPreflightJoinsPerHostErrors: one broken instance must not hide another's
+// message, and a healthy instance must not mask a broken one.
+func TestPreflightJoinsPerHostErrors(t *testing.T) {
+	ok := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("[]"))
+	})
+	bad := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("Invalid account or incorrect credentials"))
+	})
+
+	p, err := NewProvider(ProviderOptions{
+		AllowedHosts: []string{ok.URL, bad.URL},
+		Token:        StaticTokenSource("od-token"),
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	err = p.Preflight(context.Background())
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Fatalf("err = %v, want ErrAuthFailed", err)
+	}
+	if !strings.Contains(err.Error(), bad.URL) {
+		t.Fatalf("err = %v, want it to name the failing instance %q", err, bad.URL)
+	}
+	if strings.Contains(err.Error(), ok.URL) {
+		t.Fatalf("err = %v, want it to omit the healthy instance %q", err, ok.URL)
+	}
+}
+
+func TestClientForRepo(t *testing.T) {
+	p := newTestProvider(t, []string{"http://192.168.1.30:6610"})
+
+	t.Run("allowed host", func(t *testing.T) {
+		repo, ok := p.ParseRepository("ssh://git@192.168.1.30:6611/Homelab/curatarr.git")
+		if !ok {
+			t.Fatal("ParseRepository rejected a valid remote")
+		}
+		c, err := p.clientForRepo(repo)
+		if err != nil {
+			t.Fatalf("clientForRepo: %v", err)
+		}
+		if got := c.APIBase(); got != "http://192.168.1.30:6610/~api" {
+			t.Fatalf("APIBase() = %q, want http://192.168.1.30:6610/~api", got)
+		}
+		// The client is memoized per instance.
+		again, err := p.clientForRepo(repo)
+		if err != nil {
+			t.Fatalf("clientForRepo (second): %v", err)
+		}
+		if again != c {
+			t.Fatal("clientForRepo returned a fresh client; want the memoized one")
+		}
+	})
+
+	t.Run("host not in the allowlist", func(t *testing.T) {
+		_, err := p.clientForRepo(ports.SCMRepo{Provider: ProviderKey, Host: "onedev.attacker.example:6610"})
+		if !errors.Is(err, ErrHostNotAllowed) {
+			t.Fatalf("err = %v, want ErrHostNotAllowed", err)
+		}
+	})
+}

--- a/backend/internal/adapters/scm/onedev/provider_test.go
+++ b/backend/internal/adapters/scm/onedev/provider_test.go
@@ -3,6 +3,7 @@ package onedev
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -412,4 +413,200 @@ func TestClientForRepo(t *testing.T) {
 			t.Fatalf("err = %v, want ErrHostNotAllowed", err)
 		}
 	})
+}
+
+// TestNewProviderRejectsConflictingSchemes: the same instance listed twice is
+// harmless, but listed twice under different schemes it would let config order
+// decide whether the connection is encrypted.
+func TestNewProviderRejectsConflictingSchemes(t *testing.T) {
+	tests := []struct {
+		name       string
+		hosts      []string
+		wantHosts  []string
+		wantSubstr string
+	}{
+		{
+			name:      "exact duplicate is deduped",
+			hosts:     []string{"od.test:6610", "od.test:6610"},
+			wantHosts: []string{"https://od.test:6610"},
+		},
+		{
+			name:      "duplicate differing only in case",
+			hosts:     []string{"OD.test:6610", "od.TEST:6610"},
+			wantHosts: []string{"https://od.test:6610"},
+		},
+		{
+			name:      "same scheme written explicitly and implicitly",
+			hosts:     []string{"od.test:6610", "https://od.test:6610"},
+			wantHosts: []string{"https://od.test:6610"},
+		},
+		{
+			name:       "conflicting schemes",
+			hosts:      []string{"od.test:6610", "http://od.test:6610"},
+			wantSubstr: "conflicting schemes",
+		},
+		{
+			// The same conflict in the other order must be rejected too —
+			// that is the whole point.
+			name:       "conflicting schemes, reversed",
+			hosts:      []string{"http://od.test:6610", "od.test:6610"},
+			wantSubstr: "conflicting schemes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewProvider(ProviderOptions{
+				AllowedHosts: tt.hosts,
+				Token:        StaticTokenSource("od-token"),
+			})
+			if tt.wantSubstr != "" {
+				if err == nil {
+					t.Fatalf("NewProvider(%v) succeeded, want error", tt.hosts)
+				}
+				if !strings.Contains(err.Error(), tt.wantSubstr) {
+					t.Fatalf("err = %v, want it to mention %q", err, tt.wantSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+			if got := p.AllowedHosts(); !reflect.DeepEqual(got, tt.wantHosts) {
+				t.Fatalf("AllowedHosts() = %v, want %v", got, tt.wantHosts)
+			}
+		})
+	}
+}
+
+// TestPerHostTokenKeyResolution: a per-host token key is resolved the same way
+// a git remote is, so a key that omits the port (or names the SSH port) still
+// selects the allowlisted instance instead of being silently dropped.
+func TestPerHostTokenKeyResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowed    string
+		tokenKey   string
+		wantAuth   string
+		wantWarn   bool
+		wantSubstr string
+	}{
+		{
+			name: "exact authority", allowed: "http://od.test:6610", tokenKey: "od.test:6610",
+			wantAuth: "Bearer host-token",
+		},
+		{
+			name: "key omits the port", allowed: "http://od.test:6610", tokenKey: "od.test",
+			wantAuth: "Bearer host-token",
+		},
+		{
+			name: "key names the git ssh port", allowed: "http://od.test:6610", tokenKey: "od.test:6611",
+			wantAuth: "Bearer host-token",
+		},
+		{
+			name: "scheme-qualified key", allowed: "http://od.test:6610", tokenKey: "http://od.test:6610",
+			wantAuth: "Bearer host-token",
+		},
+		{
+			name: "key case is normalized", allowed: "http://od.test:6610", tokenKey: "OD.TEST:6610",
+			wantAuth: "Bearer host-token",
+		},
+		{
+			// A surplus entry is not fatal, but it must not pass unremarked:
+			// that is exactly what a typo looks like from the outside.
+			name: "key names no configured host", allowed: "http://od.test:6610", tokenKey: "other.test",
+			wantAuth: "Bearer default-token", wantWarn: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs strings.Builder
+			logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			p, err := NewProvider(ProviderOptions{
+				AllowedHosts: []string{tt.allowed},
+				Logger:       logger,
+				Token:        StaticTokenSource("default-token"),
+				HostTokens:   map[string]TokenSource{tt.tokenKey: StaticTokenSource("host-token")},
+			})
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+
+			c, err := p.clientForAuthority("od.test:6610")
+			if err != nil {
+				t.Fatalf("clientForAuthority: %v", err)
+			}
+			req, err := c.newRequest(context.Background(), "/projects", nil)
+			if err != nil {
+				t.Fatalf("newRequest: %v", err)
+			}
+			if got := req.Header.Get("Authorization"); got != tt.wantAuth {
+				t.Fatalf("Authorization = %q, want %q", got, tt.wantAuth)
+			}
+
+			warned := strings.Contains(logs.String(), "names no configured host")
+			if warned != tt.wantWarn {
+				t.Fatalf("warning logged = %v, want %v (logs: %s)", warned, tt.wantWarn, logs.String())
+			}
+			if tt.wantWarn && !strings.Contains(logs.String(), tt.tokenKey) {
+				t.Fatalf("warning does not name the offending key %q: %s", tt.tokenKey, logs.String())
+			}
+		})
+	}
+}
+
+// TestNewProviderRejectsCollidingPerHostTokens: two keys resolving to one
+// instance means one of the two overrides would be discarded, and which one
+// is not something to decide by map order.
+func TestNewProviderRejectsCollidingPerHostTokens(t *testing.T) {
+	_, err := NewProvider(ProviderOptions{
+		AllowedHosts: []string{"http://od.test:6610"},
+		HostTokens: map[string]TokenSource{
+			"od.test":      StaticTokenSource("a"),
+			"od.test:6610": StaticTokenSource("b"),
+		},
+	})
+	if err == nil {
+		t.Fatal("NewProvider succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "both resolve to host") {
+		t.Fatalf("err = %v, want it to report the collision", err)
+	}
+}
+
+// TestAnyCredentialIsOrderIndependent pins that construction does not depend
+// on map iteration order: with one working and one broken per-host source the
+// result must be the same every time, and a working source must win.
+func TestAnyCredentialIsOrderIndependent(t *testing.T) {
+	boom := errors.New("keyring is locked")
+	hostTokens := map[string]TokenSource{
+		"a.test": errSource{boom},
+		"b.test": StaticTokenSource("od-token"),
+		"c.test": errSource{boom},
+		"d.test": StaticTokenSource(""),
+	}
+	for i := 0; i < 50; i++ {
+		if err := anyCredential(context.Background(), nil, hostTokens); err != nil {
+			t.Fatalf("iteration %d: anyCredential = %v, want nil (a working source exists)", i, err)
+		}
+	}
+
+	// With nothing working, the hard error is what surfaces — every time.
+	onlyBroken := map[string]TokenSource{
+		"a.test": errSource{boom},
+		"b.test": StaticTokenSource(""),
+		"c.test": errSource{boom},
+	}
+	for i := 0; i < 50; i++ {
+		if err := anyCredential(context.Background(), nil, onlyBroken); !errors.Is(err, boom) {
+			t.Fatalf("iteration %d: anyCredential = %v, want boom", i, err)
+		}
+	}
+
+	// And with nothing configured at all it is ErrNoToken, not a hard error.
+	if err := anyCredential(context.Background(), nil, map[string]TokenSource{
+		"a.test": StaticTokenSource(""),
+	}); !errors.Is(err, ErrNoToken) {
+		t.Fatalf("anyCredential = %v, want ErrNoToken", err)
+	}
 }

--- a/backend/internal/adapters/scm/onedev/provider_test.go
+++ b/backend/internal/adapters/scm/onedev/provider_test.go
@@ -574,88 +574,180 @@ func TestNewProviderRejectsCollidingPerHostTokens(t *testing.T) {
 	}
 }
 
-// TestAnyCredentialIsOrderIndependent pins that construction does not depend
-// on map iteration order: with one working and one broken per-host source the
-// result must be the same every time, and a working source must win.
-func TestAnyCredentialIsOrderIndependent(t *testing.T) {
+// TestAnyCredentialVerdict covers what anyCredential reports, independent of
+// ordering (which TestCredentialResolutionIsOrderIndependent owns): a working
+// source wins, a hard failure surfaces only when nothing worked, and an
+// entirely unconfigured chain is ErrNoToken rather than a hard error.
+func TestAnyCredentialVerdict(t *testing.T) {
 	boom := errors.New("keyring is locked")
-	hostTokens := map[string]TokenSource{
-		"a.test": errSource{boom},
-		"b.test": StaticTokenSource("od-token"),
-		"c.test": errSource{boom},
-		"d.test": StaticTokenSource(""),
-	}
-	for i := 0; i < 50; i++ {
-		if err := anyCredential(context.Background(), nil, hostTokens); err != nil {
-			t.Fatalf("iteration %d: anyCredential = %v, want nil (a working source exists)", i, err)
-		}
-	}
-
-	// With nothing working, the hard error is what surfaces — every time.
-	onlyBroken := map[string]TokenSource{
-		"a.test": errSource{boom},
-		"b.test": StaticTokenSource(""),
-		"c.test": errSource{boom},
-	}
-	for i := 0; i < 50; i++ {
-		if err := anyCredential(context.Background(), nil, onlyBroken); !errors.Is(err, boom) {
-			t.Fatalf("iteration %d: anyCredential = %v, want boom", i, err)
-		}
-	}
-
-	// And with nothing configured at all it is ErrNoToken, not a hard error.
-	if err := anyCredential(context.Background(), nil, map[string]TokenSource{
-		"a.test": StaticTokenSource(""),
-	}); !errors.Is(err, ErrNoToken) {
-		t.Fatalf("anyCredential = %v, want ErrNoToken", err)
-	}
-}
-
-// TestNewProviderFailsWhenOnlyCredentialIsMisKeyed covers the second half of
-// the mis-keyed per-host token problem: a deployment whose only credential
-// names no configured host must fail at construction, naming the cause, rather
-// than constructing fine and returning ErrNoToken on its first request.
-func TestNewProviderFailsWhenOnlyCredentialIsMisKeyed(t *testing.T) {
 	tests := []struct {
-		name     string
-		tokenKey string
-		wantErr  bool
+		name       string
+		def        TokenSource
+		hostTokens map[string]TokenSource
+		wantErr    error
 	}{
 		{
-			// A key that merely omits the API port is not mis-keyed — it
-			// resolves, and construction succeeds.
-			name: "port omitted still resolves", tokenKey: "10.0.0.30", wantErr: false,
+			name: "default source alone",
+			def:  StaticTokenSource("od-token"),
 		},
 		{
-			name: "key names the git ssh port", tokenKey: "10.0.0.30:6611", wantErr: false,
+			name:       "per-host source alone",
+			hostTokens: map[string]TokenSource{"a.test": StaticTokenSource("od-token")},
 		},
 		{
-			name: "key names no configured host", tokenKey: "10.0.0.99:6610", wantErr: true,
+			name: "a working source outweighs broken ones",
+			hostTokens: map[string]TokenSource{
+				"a.test": errSource{boom},
+				"b.test": StaticTokenSource("od-token"),
+				"c.test": errSource{boom},
+			},
+		},
+		{
+			name: "a broken default does not mask a working per-host source",
+			def:  errSource{boom},
+			hostTokens: map[string]TokenSource{
+				"a.test": StaticTokenSource("od-token"),
+			},
+		},
+		{
+			name: "hard failure surfaces when nothing works",
+			hostTokens: map[string]TokenSource{
+				"a.test": errSource{boom},
+				"b.test": StaticTokenSource(""),
+			},
+			wantErr: boom,
+		},
+		{
+			name:       "nothing configured",
+			hostTokens: map[string]TokenSource{"a.test": StaticTokenSource("")},
+			wantErr:    ErrNoToken,
+		},
+		{
+			name:    "empty chain",
+			wantErr: ErrNoToken,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var logs strings.Builder
-			logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
-
-			_, err := NewProvider(ProviderOptions{
-				AllowedHosts: []string{"http://10.0.0.30:6610"},
-				Logger:       logger,
-				// No default token: the per-host entry is the only credential.
-				HostTokens: map[string]TokenSource{tt.tokenKey: StaticTokenSource("host-token")},
-			})
-			if !tt.wantErr {
+			err := anyCredential(context.Background(), tt.def, tt.hostTokens)
+			if tt.wantErr == nil {
 				if err != nil {
-					t.Fatalf("NewProvider: %v", err)
+					t.Fatalf("anyCredential = %v, want nil", err)
 				}
 				return
 			}
-			if !errors.Is(err, ErrNoToken) {
-				t.Fatalf("err = %v, want ErrNoToken at construction", err)
-			}
-			if !strings.Contains(logs.String(), tt.tokenKey) {
-				t.Fatalf("nothing named the offending key %q: %s", tt.tokenKey, logs.String())
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("anyCredential = %v, want %v", err, tt.wantErr)
 			}
 		})
 	}
+}
+
+// orderProbeIterations is how many times an order-sensitivity check repeats.
+// Go randomises map iteration order per range statement, not per process, so
+// detection needs many ranges rather than many test binaries. With two
+// entries each iteration has a ~1/2 chance of exposing an unsorted pass, so
+// 300 makes a false pass vanishingly unlikely.
+const orderProbeIterations = 300
+
+// TestCredentialResolutionIsOrderIndependent pins that credential resolution
+// does not depend on Go's map iteration order. It gates NewProvider, so an
+// order-sensitive implementation is a daemon that starts or fails at random.
+//
+// The second and third subtests are the ones that fail if sortedKeys stops
+// sorting. The first cannot: FallbackTokenSource.Token returns the first
+// *success* wherever it appears in the chain, so a working source beats a
+// broken one regardless of order. What ordering actually decides is *which*
+// hard error surfaces when several sources fail and none succeeds — that is
+// the property the sort exists for, and the property worth pinning.
+func TestCredentialResolutionIsOrderIndependent(t *testing.T) {
+	locked := errors.New("keyring is locked")
+	exited := errors.New("credential helper exited 127")
+
+	// collect runs fn orderProbeIterations times and returns the distinct
+	// outcomes it saw, so a failure reports the split rather than just "not
+	// equal".
+	collect := func(fn func() error) map[string]int {
+		seen := map[string]int{}
+		for i := 0; i < orderProbeIterations; i++ {
+			out := "<nil>"
+			if err := fn(); err != nil {
+				out = err.Error()
+			}
+			seen[out]++
+		}
+		return seen
+	}
+
+	t.Run("a working source beats a broken one", func(t *testing.T) {
+		// The default source is absent, so only the per-host sources decide.
+		seen := collect(func() error {
+			return anyCredential(context.Background(), nil, map[string]TokenSource{
+				"a.test": errSource{locked},
+				"b.test": StaticTokenSource("od-token"),
+				"c.test": errSource{exited},
+				"d.test": StaticTokenSource(""), // reports ErrNoToken
+			})
+		})
+		if len(seen) != 1 {
+			t.Fatalf("outcome depends on map order: %v", seen)
+		}
+		if seen["<nil>"] != orderProbeIterations {
+			t.Fatalf("outcomes = %v, want nil every time (a working source exists)", seen)
+		}
+	})
+
+	t.Run("which hard error surfaces is stable", func(t *testing.T) {
+		// No source succeeds, and the two failures are distinguishable, so the
+		// returned error is decided purely by the order the sources are tried
+		// in. This is what sortedKeys protects.
+		seen := collect(func() error {
+			return anyCredential(context.Background(), nil, map[string]TokenSource{
+				"a.test": errSource{locked},
+				"b.test": errSource{exited},
+			})
+		})
+		if len(seen) != 1 {
+			t.Fatalf("returned error depends on map order: %v", seen)
+		}
+		if seen[locked.Error()] != orderProbeIterations {
+			t.Fatalf("outcomes = %v, want %q every time (a.test sorts first)", seen, locked)
+		}
+	})
+
+	t.Run("NewProvider verdict is stable", func(t *testing.T) {
+		// The same nondeterminism seen through the constructor it gates.
+		seen := collect(func() error {
+			_, err := NewProvider(ProviderOptions{
+				AllowedHosts: []string{"a.test", "b.test"},
+				HostTokens: map[string]TokenSource{
+					"a.test": errSource{locked},
+					"b.test": errSource{exited},
+				},
+			})
+			return err
+		})
+		if len(seen) != 1 {
+			t.Fatalf("NewProvider verdict depends on map order: %v", seen)
+		}
+		if seen[locked.Error()] != orderProbeIterations {
+			t.Fatalf("outcomes = %v, want %q every time", seen, locked)
+		}
+	})
+
+	t.Run("NewProvider succeeds whenever any source works", func(t *testing.T) {
+		seen := collect(func() error {
+			_, err := NewProvider(ProviderOptions{
+				AllowedHosts: []string{"a.test", "b.test"},
+				HostTokens: map[string]TokenSource{
+					"a.test": errSource{locked},
+					"b.test": StaticTokenSource("od-token"),
+				},
+			})
+			return err
+		})
+		if len(seen) != 1 || seen["<nil>"] != orderProbeIterations {
+			t.Fatalf("NewProvider outcomes = %v, want nil every time", seen)
+		}
+	})
 }

--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	scmonedev "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/onedev"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/tmuxbin"
 )
@@ -50,9 +52,11 @@ const (
 	doctorSectionAgents         = "Agent harnesses"
 	doctorSectionGitHub         = "GitHub"
 	doctorSectionGitLab         = "GitLab"
+	doctorSectionOneDev         = "OneDev"
 	minGitVersion               = "2.25.0"
 	githubDoctorUserAgent       = "ao-agent-orchestrator/doctor"
 	gitlabDoctorUserAgent       = "ao-agent-orchestrator/doctor"
+	onedevDoctorUserAgent       = "ao-agent-orchestrator/doctor"
 	defaultDoctorGitHubRESTBase = "https://api.github.com"
 	defaultDoctorGitLabRESTBase = "https://gitlab.com/api/v4"
 )
@@ -181,6 +185,7 @@ func (c *commandContext) runDoctor(ctx context.Context) []doctorCheck {
 		checks = append(checks, c.checkHarness(ctx, harness))
 	}
 	checks = append(checks, c.checkCodexLaunchFlags(ctx), c.checkGitHubToken(ctx), c.checkGitLabToken(ctx))
+	checks = append(checks, c.checkOneDev(ctx, cfg.OneDev)...)
 	return checks
 }
 
@@ -574,6 +579,120 @@ func (c *commandContext) gitlabToken(ctx context.Context) (token, source string,
 		return "", "", errors.New("glab is installed but returned no auth token")
 	}
 	return token, "glab", nil
+}
+
+// checkOneDev reports OneDev provider health as three checks: an instance
+// allowlist is configured, a credential resolves for it, and that credential
+// authenticates against each configured instance.
+//
+// Unlike the GitHub and GitLab probes there is no fixed REST base to point at:
+// OneDev is always self-hosted, so the instances come from configuration. The
+// check therefore builds the real adapter and asks it, rather than
+// re-implementing host parsing, credential resolution and API-base
+// construction in the CLI — a doctor that probes differently from the daemon
+// can pass while the daemon fails.
+func (c *commandContext) checkOneDev(ctx context.Context, cfg config.OneDevConfig) []doctorCheck {
+	if len(cfg.AllowedHosts) == 0 {
+		// The common case: OneDev has no public instance, so a deployment that
+		// does not use OneDev never sets the allowlist. That is not a failure.
+		return []doctorCheck{{
+			Level: doctorWarn, Section: doctorSectionOneDev, Name: "onedev-hosts",
+			Message: "no OneDev hosts configured (set AO_ONEDEV_ALLOWED_HOSTS); OneDev observation is off",
+		}}
+	}
+
+	provider, err := c.onedevProvider(cfg)
+	if err != nil {
+		return []doctorCheck{{
+			Level: doctorFail, Section: doctorSectionOneDev, Name: "onedev-hosts", Message: err.Error(),
+		}}
+	}
+	hosts := provider.AllowedHosts()
+	checks := []doctorCheck{{
+		Level: doctorPass, Section: doctorSectionOneDev, Name: "onedev-hosts",
+		Message: fmt.Sprintf("%d host(s) allowed: %s", len(hosts), strings.Join(hosts, ", ")),
+	}}
+
+	// Credential resolution is local — no instance is contacted — so it is
+	// reported separately from the authenticated probe below. That way a
+	// missing token and a rejected token do not read the same.
+	credCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	available, err := provider.SCMCredentialsAvailable(credCtx)
+	cancel()
+	switch {
+	case err != nil:
+		return append(checks, doctorCheck{
+			Level: doctorFail, Section: doctorSectionOneDev, Name: "onedev-token",
+			Message: fmt.Sprintf("credential lookup failed: %v", err),
+		})
+	case !available:
+		return append(checks, doctorCheck{
+			Level: doctorWarn, Section: doctorSectionOneDev, Name: "onedev-token",
+			Message: "no OneDev credential found (set AO_ONEDEV_TOKEN, AO_ONEDEV_HOST_TOKENS or ONEDEV_TOKEN)",
+		})
+	}
+	checks = append(checks, doctorCheck{
+		Level: doctorPass, Section: doctorSectionOneDev, Name: "onedev-token",
+		Message: "credential resolved",
+	})
+
+	for _, host := range hosts {
+		checks = append(checks, c.checkOneDevHost(ctx, provider, host))
+	}
+	return checks
+}
+
+// checkOneDevHost performs the authenticated round-trip against one instance,
+// reporting the account the credential belongs to.
+//
+// A rejected credential is a FAIL — that is always an AO misconfiguration. An
+// instance that cannot be reached is only a WARN: a self-hosted OneDev
+// commonly lives on a private network, so running `ao doctor` off that network
+// says nothing about whether the daemon is configured correctly.
+func (c *commandContext) checkOneDevHost(ctx context.Context, provider *scmonedev.Provider, host string) doctorCheck {
+	name := "onedev-api:" + host
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	identity, err := provider.AuthenticatedIdentityForHost(reqCtx, host)
+	if err != nil {
+		if errors.Is(err, scmonedev.ErrAuthFailed) {
+			return doctorCheck{Level: doctorFail, Section: doctorSectionOneDev, Name: name, Message: fmt.Sprintf("credential rejected by OneDev: %v", err)}
+		}
+		return doctorCheck{Level: doctorWarn, Section: doctorSectionOneDev, Name: name, Message: fmt.Sprintf("probe failed: %v", err)}
+	}
+	return doctorCheck{Level: doctorPass, Section: doctorSectionOneDev, Name: name, Message: fmt.Sprintf("credential valid for %s", identity.Login)}
+}
+
+// onedevProvider builds the OneDev adapter exactly as the daemon does (see
+// newOneDevSCMProvider in internal/daemon/scm_wiring.go), so doctor exercises
+// the same host resolution and credential chain the daemon will.
+//
+// SkipTokenPreflight is set for the same reason as in the daemon and one more:
+// a missing credential must surface as its own check rather than as a
+// construction error that would also hide the allowlist result.
+//
+// The provider's logger is discarded because its only startup warning (a
+// per-host token naming no configured host) would otherwise interleave a raw
+// slog line into the doctor report; the daemon logs it at boot.
+func (c *commandContext) onedevProvider(cfg config.OneDevConfig) (*scmonedev.Provider, error) {
+	tokens := scmonedev.FallbackTokenSource{
+		scmonedev.StaticTokenSource(cfg.Token),
+		scmonedev.EnvTokenSource{EnvVars: []string{"AO_ONEDEV_TOKEN"}},
+	}
+	hostTokens := make(map[string]scmonedev.TokenSource, len(cfg.HostTokens))
+	for host, token := range cfg.HostTokens {
+		hostTokens[host] = scmonedev.StaticTokenSource(token)
+	}
+	return scmonedev.NewProvider(scmonedev.ProviderOptions{
+		HTTPClient:         c.deps.HTTPClient,
+		Token:              tokens,
+		SkipTokenPreflight: true,
+		UserAgent:          onedevDoctorUserAgent,
+		Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		AllowedHosts:       cfg.AllowedHosts,
+		HostTokens:         hostTokens,
+	})
 }
 
 // parseGLabTokenLine extracts the token value from `glab auth status --show-token`

--- a/backend/internal/cli/doctor_test.go
+++ b/backend/internal/cli/doctor_test.go
@@ -392,6 +392,7 @@ func TestDoctorJSONOutputIsDecodable(t *testing.T) {
 	setConfigEnv(t)
 	clearDoctorGitHubEnv(t)
 	clearDoctorGitLabEnv(t)
+	clearDoctorOneDevEnv(t)
 	out, errOut, err := executeCLI(t, Deps{
 		LookPath: func(name string) (string, error) {
 			switch name {
@@ -429,6 +430,7 @@ func TestDoctorTextOutputIsGrouped(t *testing.T) {
 	setConfigEnv(t)
 	clearDoctorGitHubEnv(t)
 	clearDoctorGitLabEnv(t)
+	clearDoctorOneDevEnv(t)
 	out, errOut, err := executeCLI(t, Deps{
 		LookPath: func(name string) (string, error) {
 			switch name {
@@ -450,7 +452,7 @@ func TestDoctorTextOutputIsGrouped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("doctor failed: %v\nstderr=%s\nstdout=%s", err, errOut, out)
 	}
-	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "WARN muse:", "GitHub:\nWARN github-token:", "GitLab:\nWARN gitlab-token:"} {
+	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "WARN muse:", "GitHub:\nWARN github-token:", "GitLab:\nWARN gitlab-token:", "OneDev:\nWARN onedev-hosts:"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, out)
 		}
@@ -468,6 +470,14 @@ func clearDoctorGitLabEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("AO_GITLAB_TOKEN", "")
 	t.Setenv("GITLAB_TOKEN", "")
+}
+
+func clearDoctorOneDevEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", "")
+	t.Setenv("AO_ONEDEV_HOST_TOKENS", "")
+	t.Setenv("AO_ONEDEV_TOKEN", "")
+	t.Setenv("ONEDEV_TOKEN", "")
 }
 
 // TestDoctorChecksAOBinaryIdentity covers the `ao-binary` check: workspace
@@ -539,6 +549,7 @@ func doctorContext(t *testing.T, paths map[string]string, commandOutput func(con
 	t.Setenv("AO_TMUX_BINARY", "")
 	clearDoctorGitHubEnv(t)
 	clearDoctorGitLabEnv(t)
+	clearDoctorOneDevEnv(t)
 	deps := Deps{
 		LookPath: func(name string) (string, error) {
 			path, ok := paths[name]
@@ -694,4 +705,143 @@ func writeHooksLogLines(t *testing.T, dataDir string, lines ...string) {
 	if err := os.WriteFile(filepath.Join(dataDir, hooksLogName), []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestDoctorWarnsWhenOneDevUnconfigured: OneDev has no public instance, so a
+// deployment that does not use it never sets AO_ONEDEV_ALLOWED_HOSTS. That is
+// the common case and must read as "off", not as a failure.
+func TestDoctorWarnsWhenOneDevUnconfigured(t *testing.T) {
+	setConfigEnv(t)
+	c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitVersionOnly)
+
+	check := findDoctorCheck(t, c.runDoctor(context.Background()), "onedev-hosts")
+	if check.Level != doctorWarn || !strings.Contains(check.Message, "AO_ONEDEV_ALLOWED_HOSTS") {
+		t.Fatalf("onedev-hosts check = %+v, want WARN naming the env var", check)
+	}
+	if check.Section != doctorSectionOneDev {
+		t.Fatalf("onedev-hosts section = %q, want %q", check.Section, doctorSectionOneDev)
+	}
+}
+
+// TestDoctorChecksOneDevToken covers the happy path end to end: hosts
+// configured, credential resolved, credential accepted by the instance.
+func TestDoctorChecksOneDevToken(t *testing.T) {
+	setConfigEnv(t)
+	srv := onedevDoctorServer(t, http.StatusOK, `{"id":4,"name":"johnkattenhorn"}`)
+	c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitVersionOnly)
+	t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", srv.URL)
+	t.Setenv("AO_ONEDEV_TOKEN", "od-token")
+	c.deps.HTTPClient = srv.Client()
+
+	checks := c.runDoctor(context.Background())
+	if hosts := findDoctorCheck(t, checks, "onedev-hosts"); hosts.Level != doctorPass || !strings.Contains(hosts.Message, srv.URL) {
+		t.Fatalf("onedev-hosts check = %+v, want PASS naming the instance", hosts)
+	}
+	if token := findDoctorCheck(t, checks, "onedev-token"); token.Level != doctorPass {
+		t.Fatalf("onedev-token check = %+v, want PASS", token)
+	}
+	api := findDoctorCheck(t, checks, "onedev-api:"+srv.URL)
+	if api.Level != doctorPass || !strings.Contains(api.Message, "johnkattenhorn") {
+		t.Fatalf("onedev-api check = %+v, want PASS naming the authenticated account", api)
+	}
+}
+
+// TestDoctorWarnsWhenOneDevTokenMissing: a configured instance with no
+// credential is reported before any request is attempted, so it does not read
+// as an unreachable instance.
+func TestDoctorWarnsWhenOneDevTokenMissing(t *testing.T) {
+	setConfigEnv(t)
+	c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitVersionOnly)
+	t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", "http://onedev.test:6610")
+
+	checks := c.runDoctor(context.Background())
+	if hosts := findDoctorCheck(t, checks, "onedev-hosts"); hosts.Level != doctorPass {
+		t.Fatalf("onedev-hosts check = %+v, want PASS", hosts)
+	}
+	token := findDoctorCheck(t, checks, "onedev-token")
+	if token.Level != doctorWarn || !strings.Contains(token.Message, "AO_ONEDEV_TOKEN") {
+		t.Fatalf("onedev-token check = %+v, want WARN naming the env var", token)
+	}
+	for _, check := range checks {
+		if strings.HasPrefix(check.Name, "onedev-api") {
+			t.Fatalf("probed the instance without a credential: %+v", check)
+		}
+	}
+}
+
+// TestDoctorReadsOneDevPerHostToken: a deployment may configure only
+// AO_ONEDEV_HOST_TOKENS, with no default token. That must still authenticate.
+func TestDoctorReadsOneDevPerHostToken(t *testing.T) {
+	setConfigEnv(t)
+	srv := onedevDoctorServer(t, http.StatusOK, `{"id":4,"name":"per-host-user"}`)
+	c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitVersionOnly)
+	t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", srv.URL)
+	t.Setenv("AO_ONEDEV_HOST_TOKENS", srv.URL+"=host-token")
+	c.deps.HTTPClient = srv.Client()
+
+	api := findDoctorCheck(t, c.runDoctor(context.Background()), "onedev-api:"+srv.URL)
+	if api.Level != doctorPass || !strings.Contains(api.Message, "per-host-user") {
+		t.Fatalf("onedev-api check = %+v, want PASS from the per-host token", api)
+	}
+}
+
+// TestDoctorFailsRejectedOneDevToken: a credential the instance refuses is
+// always an AO misconfiguration, so it is a FAIL rather than a WARN.
+func TestDoctorFailsRejectedOneDevToken(t *testing.T) {
+	setConfigEnv(t)
+	srv := onedevDoctorServer(t, http.StatusUnauthorized, "Invalid account or incorrect credentials")
+	c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitVersionOnly)
+	t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", srv.URL)
+	t.Setenv("AO_ONEDEV_TOKEN", "expired-token")
+	c.deps.HTTPClient = srv.Client()
+
+	api := findDoctorCheck(t, c.runDoctor(context.Background()), "onedev-api:"+srv.URL)
+	if api.Level != doctorFail || !strings.Contains(api.Message, "rejected") {
+		t.Fatalf("onedev-api check = %+v, want FAIL for a rejected credential", api)
+	}
+}
+
+// TestDoctorWarnsWhenOneDevUnreachable: a self-hosted instance is commonly on
+// a private network, so running doctor off that network says nothing about
+// whether AO is configured correctly. That must not fail the whole report.
+func TestDoctorWarnsWhenOneDevUnreachable(t *testing.T) {
+	setConfigEnv(t)
+	srv := onedevDoctorServer(t, http.StatusOK, `{"id":4,"name":"unused"}`)
+	client := srv.Client()
+	srv.Close() // nothing is listening now
+
+	c := doctorContext(t, map[string]string{"git": "/bin/git"}, gitVersionOnly)
+	t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", srv.URL)
+	t.Setenv("AO_ONEDEV_TOKEN", "od-token")
+	c.deps.HTTPClient = client
+
+	api := findDoctorCheck(t, c.runDoctor(context.Background()), "onedev-api:"+srv.URL)
+	if api.Level != doctorWarn {
+		t.Fatalf("onedev-api check = %+v, want WARN for an unreachable instance", api)
+	}
+}
+
+func onedevDoctorServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// OneDev's REST root is "/~api", and "who am I" is /users/me — the
+		// other user routes need an id the doctor does not have.
+		if r.Method != http.MethodGet || r.URL.Path != "/~api/users/me" {
+			t.Errorf("unexpected onedev probe: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "Bearer ") {
+			t.Errorf("missing bearer auth header: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func gitVersionOnly(context.Context, string, ...string) ([]byte, error) {
+	return []byte("git version 2.43.0\n"), nil
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -98,6 +98,30 @@ type GitLabConfig struct {
 	HostTokens map[string]string
 }
 
+// OneDevConfig carries the OneDev host allowlist, the default access token,
+// and per-host token overrides. Like GitLabConfig it is loaded once at daemon
+// boot from environment variables (no hot-reload).
+//
+// Unlike GitHub and GitLab there is no public OneDev instance, so there is no
+// implicitly-allowed host: AllowedHosts is required configuration, and the
+// OneDev provider fails construction when it is empty rather than defaulting
+// to some public endpoint.
+type OneDevConfig struct {
+	// Token is the default OneDev access token (AO_ONEDEV_TOKEN), applied to
+	// any allowed host without an entry in HostTokens. Empty means the
+	// adapter falls back to its own credential resolution (ONEDEV_TOKEN, then
+	// any configured credential helper).
+	Token string
+	// AllowedHosts is the list of OneDev instances the provider may talk to.
+	// Each entry is "host", "host:port", or a scheme-qualified
+	// "http://host:port" — plain HTTP must be written explicitly, because a
+	// self-hosted OneDev is commonly reached over HTTP on a private network.
+	AllowedHosts []string
+	// HostTokens maps an allowed host to an access-token override. Hosts
+	// without an explicit entry fall back to Token.
+	HostTokens map[string]string
+}
+
 // DefaultAllowedOrigins are the browser origins the daemon's CORS boundary
 // trusts, beyond loopback-served content (which the middleware always trusts —
 // local pages can reach the no-auth daemon directly anyway). The daemon has no
@@ -167,6 +191,9 @@ type Config struct {
 	// (AO_CLOUD_CONTROL_PLANE_URL). When set it must be an http(s) URL; empty
 	// means no control plane is configured, which keeps the cloud offering off.
 	CloudControlPlaneURL string
+	// OneDev carries the OneDev host allowlist, default token, and per-host
+	// token overrides, loaded once at boot from environment variables.
+	OneDev OneDevConfig
 }
 
 // Addr returns the host:port the HTTP server binds. It uses net.JoinHostPort so
@@ -201,6 +228,9 @@ func (c Config) Addr() string {
 //	AO_CLOUD_OFFERING          cloud offering flag off|on (default off)
 //	AO_LOCAL_OFFERING          local offering off|on (default on)
 //	AO_CLOUD_CONTROL_PLANE_URL cloud control plane base URL (trimmed, must be http(s))
+//	AO_ONEDEV_TOKEN            default OneDev access token
+//	AO_ONEDEV_ALLOWED_HOSTS    comma-separated OneDev hosts (host[:port] or http://host:port)
+//	AO_ONEDEV_HOST_TOKENS      host=token,host=token per-host token overrides
 //
 // The bind host is not configurable: the daemon is loopback-only by design.
 func Load() (Config, error) {
@@ -363,6 +393,21 @@ func Load() (Config, error) {
 		}
 		cfg.CloudControlPlaneURL = u
 	}
+	if raw, ok := os.LookupEnv("AO_ONEDEV_TOKEN"); ok {
+		cfg.OneDev.Token = strings.TrimSpace(raw)
+	}
+
+	if raw, ok := os.LookupEnv("AO_ONEDEV_ALLOWED_HOSTS"); ok && raw != "" {
+		cfg.OneDev.AllowedHosts = parseHostList(raw)
+	}
+
+	if raw, ok := os.LookupEnv("AO_ONEDEV_HOST_TOKENS"); ok && raw != "" {
+		tokens, err := parseHostTokenMap("AO_ONEDEV_HOST_TOKENS", raw)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.OneDev.HostTokens = tokens
+	}
 
 	runFile, err := resolveRunFilePath()
 	if err != nil {
@@ -414,6 +459,22 @@ func parseTelemetryDisabledEvents(raw string) []string {
 		}
 	}
 	return names
+}
+
+// parseHostList parses a comma-separated host list, trimming whitespace and
+// dropping empty entries. It returns nil when no entry survives, so an
+// all-whitespace value reads the same as an unset one.
+func parseHostList(raw string) []string {
+	hosts := make([]string, 0, 4)
+	for _, h := range strings.Split(raw, ",") {
+		if h = strings.TrimSpace(h); h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	if len(hosts) == 0 {
+		return nil
+	}
+	return hosts
 }
 
 // parseHostTokenMap parses a host=token,host=token map. Whitespace around

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -345,15 +345,7 @@ func Load() (Config, error) {
 	}
 
 	if raw, ok := os.LookupEnv("AO_GITLAB_ALLOWED_HOSTS"); ok && raw != "" {
-		hosts := make([]string, 0, 4)
-		for _, h := range strings.Split(raw, ",") {
-			h = strings.TrimSpace(h)
-			if h == "" {
-				continue
-			}
-			hosts = append(hosts, h)
-		}
-		cfg.GitLab.AllowedHosts = hosts
+		cfg.GitLab.AllowedHosts = parseHostList(raw)
 	}
 
 	if raw, ok := os.LookupEnv("AO_GITLAB_HOST_TOKENS"); ok && raw != "" {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -456,3 +456,146 @@ func TestLoadGitLabInvalidHostTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadOneDevDefaults(t *testing.T) {
+	// Clear the OneDev config vars so we observe pure defaults. OneDev is
+	// always self-hosted, so an unconfigured allowlist is the normal state and
+	// must stay nil — the adapter, not Load, decides that empty is fatal.
+	for _, k := range []string{"AO_ONEDEV_TOKEN", "AO_ONEDEV_ALLOWED_HOSTS", "AO_ONEDEV_HOST_TOKENS"} {
+		t.Setenv(k, "")
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.OneDev.Token != "" {
+		t.Errorf("OneDev.Token = %q, want empty", cfg.OneDev.Token)
+	}
+	if cfg.OneDev.AllowedHosts != nil {
+		t.Errorf("OneDev.AllowedHosts = %v, want nil", cfg.OneDev.AllowedHosts)
+	}
+	if cfg.OneDev.HostTokens != nil {
+		t.Errorf("OneDev.HostTokens = %v, want nil", cfg.OneDev.HostTokens)
+	}
+}
+
+func TestLoadOneDevToken(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"plain token", "od-token", "od-token"},
+		{"trimmed whitespace", "  od-token \n", "od-token"},
+		{"blank stays empty", "   ", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AO_ONEDEV_TOKEN", tc.env)
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.OneDev.Token != tc.want {
+				t.Fatalf("OneDev.Token = %q, want %q", cfg.OneDev.Token, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadOneDevAllowedHosts(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{"single host", "onedev.mycompany.com", []string{"onedev.mycompany.com"}},
+		{"with port", "onedev.internal:6610", []string{"onedev.internal:6610"}},
+		// Self-hosted OneDev is commonly reached over plain HTTP on a private
+		// network, so a scheme-qualified entry must survive Load unchanged.
+		{"scheme qualified", "http://192.168.1.30:6610", []string{"http://192.168.1.30:6610"}},
+		{
+			"comma-separated",
+			"http://192.168.1.30:6610,onedev.internal:6610",
+			[]string{"http://192.168.1.30:6610", "onedev.internal:6610"},
+		},
+		{"trimmed whitespace", " a.test , b.test ", []string{"a.test", "b.test"}},
+		{"empty entries skipped", "a.test,,b.test,", []string{"a.test", "b.test"}},
+		{"only separators yields nil", ",,,", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", tc.env)
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if len(cfg.OneDev.AllowedHosts) != len(tc.want) {
+				t.Fatalf("AllowedHosts = %v, want %v", cfg.OneDev.AllowedHosts, tc.want)
+			}
+			for i, h := range tc.want {
+				if cfg.OneDev.AllowedHosts[i] != h {
+					t.Errorf("AllowedHosts[%d] = %q, want %q", i, cfg.OneDev.AllowedHosts[i], h)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadOneDevHostTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "single host=token",
+			env:  "onedev.mycompany.com=token-1",
+			want: map[string]string{"onedev.mycompany.com": "token-1"},
+		},
+		{
+			name: "multiple pairs",
+			env:  "a.test=token-1,b.test:6610=token-2",
+			want: map[string]string{"a.test": "token-1", "b.test:6610": "token-2"},
+		},
+		{
+			name: "scheme-qualified host key",
+			env:  "http://192.168.1.30:6610=token-1",
+			want: map[string]string{"http://192.168.1.30:6610": "token-1"},
+		},
+		{
+			name: "trimmed whitespace",
+			env:  " a.test = token-1 ",
+			want: map[string]string{"a.test": "token-1"},
+		},
+		{
+			name:    "token containing an equals sign is rejected",
+			env:     "a.test=token=with=equals",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AO_ONEDEV_HOST_TOKENS", tc.env)
+			cfg, err := Load()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Load() = nil error, want error for malformed AO_ONEDEV_HOST_TOKENS")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if len(cfg.OneDev.HostTokens) != len(tc.want) {
+				t.Fatalf("HostTokens = %v, want %v", cfg.OneDev.HostTokens, tc.want)
+			}
+			for h, tok := range tc.want {
+				if cfg.OneDev.HostTokens[h] != tok {
+					t.Errorf("HostTokens[%q] = %q, want %q", h, cfg.OneDev.HostTokens[h], tok)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -595,6 +596,44 @@ func TestLoadOneDevHostTokens(t *testing.T) {
 				if cfg.OneDev.HostTokens[h] != tok {
 					t.Errorf("HostTokens[%q] = %q, want %q", h, cfg.OneDev.HostTokens[h], tok)
 				}
+			}
+		})
+	}
+}
+
+// TestParseHostListSharedByProviders pins the contract of the helper that both
+// AO_GITLAB_ALLOWED_HOSTS and AO_ONEDEV_ALLOWED_HOSTS parse through, so the
+// two cannot drift apart again.
+func TestParseHostListSharedByProviders(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"single", "a.test", []string{"a.test"}},
+		{"comma-separated", "a.test,b.test", []string{"a.test", "b.test"}},
+		{"trimmed", " a.test , b.test ", []string{"a.test", "b.test"}},
+		{"empty entries skipped", "a.test,,b.test,", []string{"a.test", "b.test"}},
+		{"only separators yields nil", ",,,", nil},
+		{"only whitespace yields nil", "  ,  ", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseHostList(tc.raw); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseHostList(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+			// Both providers must observe that same result.
+			t.Setenv("AO_GITLAB_ALLOWED_HOSTS", tc.raw)
+			t.Setenv("AO_ONEDEV_ALLOWED_HOSTS", tc.raw)
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if !reflect.DeepEqual(cfg.GitLab.AllowedHosts, tc.want) {
+				t.Errorf("GitLab.AllowedHosts = %#v, want %#v", cfg.GitLab.AllowedHosts, tc.want)
+			}
+			if !reflect.DeepEqual(cfg.OneDev.AllowedHosts, tc.want) {
+				t.Errorf("OneDev.AllowedHosts = %#v, want %#v", cfg.OneDev.AllowedHosts, tc.want)
 			}
 		})
 	}

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -394,7 +394,7 @@ func Run() error {
 		})
 		lcStack.LCM.SetUsageFinalizer(usageCollector)
 	}
-	lcStack.scmDone = startSCMObserver(ctx, store, lcStack.LCM, cfg.GitLab, log)
+	lcStack.scmDone = startSCMObserver(ctx, store, lcStack.LCM, cfg.GitLab, cfg.OneDev, log)
 	var prActions prsvc.ActionManager
 	prReader := newMultiSCMProvider(cfg.GitLab, log)
 	prMerger := newMultiSCMMerger(cfg.GitLab, log)

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -396,8 +396,8 @@ func Run() error {
 	}
 	lcStack.scmDone = startSCMObserver(ctx, store, lcStack.LCM, cfg.GitLab, cfg.OneDev, log)
 	var prActions prsvc.ActionManager
-	prReader := newMultiSCMProvider(cfg.GitLab, log)
-	prMerger := newMultiSCMMerger(cfg.GitLab, log)
+	prReader := newMultiSCMProvider(cfg.GitLab, cfg.OneDev, log)
+	prMerger := newMultiSCMMerger(cfg.GitLab, cfg.OneDev, log)
 	if prReader != nil && prMerger != nil {
 		prActions = prsvc.NewActionService(prsvc.ActionDeps{Store: store, Merger: prMerger, Reader: prReader})
 	} else {

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -229,7 +229,7 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		Logger:              log,
 		ReconcileWorkers:    startupReconcileWorkers,
 	})
-	scmProvider := newMultiSCMProvider(cfg.GitLab, log)
+	scmProvider := newMultiSCMProvider(cfg.GitLab, cfg.OneDev, log)
 	// Build the multi-tracker dispatching to both GitHub and GitLab. The
 	// multi-tracker returns a true nil ports.Tracker when no provider has
 	// usable credentials, preserving the `s.tracker == nil` guard in

--- a/backend/internal/daemon/scm_wiring.go
+++ b/backend/internal/daemon/scm_wiring.go
@@ -8,17 +8,18 @@ import (
 	scmgithub "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/github"
 	scmgitlab "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/gitlab"
 	scmmulti "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/multi"
+	scmonedev "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/onedev"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	scmobserve "github.com/aoagents/agent-orchestrator/backend/internal/observe/scm"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
-// startSCMObserver wires the provider-neutral SCM observer with both GitHub
-// and GitLab providers via a multi Provider dispatcher. Missing credentials
-// for one provider do not prevent the other from starting; the observer is
-// disabled only when no provider has usable credentials.
-func startSCMObserver(ctx context.Context, store *sqlite.Store, lcm *lifecycle.Manager, gitlabCfg config.GitLabConfig, logger *slog.Logger) <-chan struct{} {
+// startSCMObserver wires the provider-neutral SCM observer with the GitHub,
+// GitLab and OneDev providers via a multi Provider dispatcher. Missing
+// credentials for one provider do not prevent the others from starting; the
+// observer is disabled only when no provider has usable credentials.
+func startSCMObserver(ctx context.Context, store *sqlite.Store, lcm *lifecycle.Manager, gitlabCfg config.GitLabConfig, onedevCfg config.OneDevConfig, logger *slog.Logger) <-chan struct{} {
 	var named []scmmulti.NamedProvider
 
 	ghProvider, ghErr := newGitHubSCMProvider(logger)
@@ -33,6 +34,13 @@ func startSCMObserver(ctx context.Context, store *sqlite.Store, lcm *lifecycle.M
 		logSCMProviderDisabled(logger, "gitlab", glErr)
 	} else {
 		named = append(named, scmmulti.NamedProvider{Key: "gitlab", Provider: glProvider})
+	}
+
+	odProvider, odErr := newOneDevSCMProvider(onedevCfg, logger)
+	if odErr != nil {
+		logSCMProviderDisabled(logger, "onedev", odErr)
+	} else {
+		named = append(named, scmmulti.NamedProvider{Key: scmonedev.ProviderKey, Provider: odProvider})
 	}
 
 	if len(named) == 0 {
@@ -70,11 +78,47 @@ func newGitLabSCMProvider(gitlabCfg config.GitLabConfig, logger *slog.Logger) (*
 	})
 }
 
+// newOneDevSCMProvider builds the OneDev provider from its boot configuration.
+//
+// OneDev is always self-hosted, so an operator who has not set
+// AO_ONEDEV_ALLOWED_HOSTS has no OneDev instance for AO to observe. That is
+// the common case, and NewProvider reports it as ErrNoAllowedHosts — which the
+// caller logs and steps over, exactly as it does a missing GitHub or GitLab
+// token, so an unconfigured OneDev never blocks the other providers.
+//
+// SkipTokenPreflight matches the GitHub and GitLab wiring: the credential is
+// resolved lazily on first use rather than at construction, so a credential
+// helper that is momentarily unavailable at daemon boot does not disable the
+// provider for the life of the process.
+func newOneDevSCMProvider(onedevCfg config.OneDevConfig, logger *slog.Logger) (*scmonedev.Provider, error) {
+	tokens := scmonedev.FallbackTokenSource{
+		scmonedev.StaticTokenSource(onedevCfg.Token),
+		scmonedev.EnvTokenSource{EnvVars: []string{"AO_ONEDEV_TOKEN"}},
+	}
+	hostTokens := make(map[string]scmonedev.TokenSource, len(onedevCfg.HostTokens))
+	for host, token := range onedevCfg.HostTokens {
+		hostTokens[host] = scmonedev.StaticTokenSource(token)
+	}
+	return scmonedev.NewProvider(scmonedev.ProviderOptions{
+		Token:              tokens,
+		SkipTokenPreflight: true,
+		Logger:             logger,
+		AllowedHosts:       onedevCfg.AllowedHosts,
+		HostTokens:         hostTokens,
+	})
+}
+
 func logSCMProviderDisabled(logger *slog.Logger, provider string, err error) {
-	if errors.Is(err, scmgithub.ErrNoToken) || errors.Is(err, scmgithub.ErrAuthFailed) ||
-		errors.Is(err, scmgitlab.ErrNoToken) || errors.Is(err, scmgitlab.ErrAuthFailed) {
+	switch {
+	case errors.Is(err, scmgithub.ErrNoToken) || errors.Is(err, scmgithub.ErrAuthFailed) ||
+		errors.Is(err, scmgitlab.ErrNoToken) || errors.Is(err, scmgitlab.ErrAuthFailed) ||
+		errors.Is(err, scmonedev.ErrNoToken) || errors.Is(err, scmonedev.ErrAuthFailed):
 		logger.Warn("scm provider disabled: no usable token", "provider", provider, "err", err)
-	} else {
+	case errors.Is(err, scmonedev.ErrNoAllowedHosts):
+		// Not a misconfiguration: OneDev has no public instance, so a
+		// deployment that does not use OneDev simply never sets the allowlist.
+		logger.Debug("scm provider disabled: no hosts configured", "provider", provider, "err", err)
+	default:
 		logger.Warn("scm provider disabled: setup failed", "provider", provider, "err", err)
 	}
 }

--- a/backend/internal/daemon/scm_wiring.go
+++ b/backend/internal/daemon/scm_wiring.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	scmobserve "github.com/aoagents/agent-orchestrator/backend/internal/observe/scm"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
@@ -20,36 +21,88 @@ import (
 // credentials for one provider do not prevent the others from starting; the
 // observer is disabled only when no provider has usable credentials.
 func startSCMObserver(ctx context.Context, store *sqlite.Store, lcm *lifecycle.Manager, gitlabCfg config.GitLabConfig, onedevCfg config.OneDevConfig, logger *slog.Logger) <-chan struct{} {
-	var named []scmmulti.NamedProvider
-
-	ghProvider, ghErr := newGitHubSCMProvider(logger)
-	if ghErr != nil {
-		logSCMProviderDisabled(logger, "github", ghErr)
-	} else {
-		named = append(named, scmmulti.NamedProvider{Key: "github", Provider: ghProvider})
-	}
-
-	glProvider, glErr := newGitLabSCMProvider(gitlabCfg, logger)
-	if glErr != nil {
-		logSCMProviderDisabled(logger, "gitlab", glErr)
-	} else {
-		named = append(named, scmmulti.NamedProvider{Key: "gitlab", Provider: glProvider})
-	}
-
-	odProvider, odErr := newOneDevSCMProvider(onedevCfg, logger)
-	if odErr != nil {
-		logSCMProviderDisabled(logger, "onedev", odErr)
-	} else {
-		named = append(named, scmmulti.NamedProvider{Key: scmonedev.ProviderKey, Provider: odProvider})
-	}
-
-	if len(named) == 0 {
+	// This is the only construction path that logs. The other two run at the
+	// same daemon boot from the same configuration, so logging there would
+	// repeat every "provider disabled" line three times.
+	subs := scmSubProviders(gitlabCfg, onedevCfg, logger, func(key string, err error) {
+		logSCMProviderDisabled(logger, key, err)
+	})
+	if len(subs) == 0 {
 		logger.Warn("scm observer disabled: no usable SCM provider")
 		return closedDone()
 	}
-	provider := scmmulti.New(named...)
+	provider := scmmulti.New(namedSCMProviders(subs)...)
 	observer := scmobserve.New(provider, store, lcm, scmobserve.Config{Logger: logger, ScopedIdentityResolver: provider})
 	return observer.Start(ctx)
+}
+
+// scmSubProvider is the capability set every AO SCM adapter satisfies: the
+// observer's Provider contract, plus merge dispatch for `ao pr merge`. A
+// provider that cannot merge (OneDev) still satisfies ports.SCMMerger by
+// returning ports.ErrSCMUnsupported, so "cannot merge" reaches the caller as a
+// capability answer rather than as an unknown-provider failure.
+type scmSubProvider interface {
+	scmobserve.Provider
+	ports.SCMMerger
+}
+
+// namedSCMSubProvider pairs an SCM adapter with the routing key its
+// ParseRepository stamps on repositories.
+type namedSCMSubProvider struct {
+	Key      string
+	Provider scmSubProvider
+}
+
+// scmSubProviders builds every configured SCM adapter, in a stable order.
+//
+// All three multi-provider constructors go through here so they cannot drift
+// apart: OneDev shipped registered in the observer but missing from the
+// session PR claimer and the merger, which surfaced live as `ao session
+// claim-pr` failing with SCM_UNAVAILABLE on a OneDev pull request. Adding a
+// provider is now one edit, not three.
+//
+// A provider whose credentials or configuration are missing is reported to
+// onDisabled (which may be nil) and omitted; it never blocks the others.
+func scmSubProviders(gitlabCfg config.GitLabConfig, onedevCfg config.OneDevConfig, logger *slog.Logger, onDisabled func(key string, err error)) []namedSCMSubProvider {
+	disabled := func(key string, err error) {
+		if onDisabled != nil {
+			onDisabled(key, err)
+		}
+	}
+
+	var subs []namedSCMSubProvider
+	if gh, err := newGitHubSCMProvider(logger); err != nil {
+		disabled("github", err)
+	} else {
+		subs = append(subs, namedSCMSubProvider{Key: "github", Provider: gh})
+	}
+	if gl, err := newGitLabSCMProvider(gitlabCfg, logger); err != nil {
+		disabled("gitlab", err)
+	} else {
+		subs = append(subs, namedSCMSubProvider{Key: "gitlab", Provider: gl})
+	}
+	if od, err := newOneDevSCMProvider(onedevCfg, logger); err != nil {
+		disabled(scmonedev.ProviderKey, err)
+	} else {
+		subs = append(subs, namedSCMSubProvider{Key: scmonedev.ProviderKey, Provider: od})
+	}
+	return subs
+}
+
+func namedSCMProviders(subs []namedSCMSubProvider) []scmmulti.NamedProvider {
+	named := make([]scmmulti.NamedProvider, 0, len(subs))
+	for _, sub := range subs {
+		named = append(named, scmmulti.NamedProvider{Key: sub.Key, Provider: sub.Provider})
+	}
+	return named
+}
+
+func namedSCMMergers(subs []namedSCMSubProvider) []scmmulti.NamedMerger {
+	named := make([]scmmulti.NamedMerger, 0, len(subs))
+	for _, sub := range subs {
+		named = append(named, scmmulti.NamedMerger{Key: sub.Key, Merger: sub.Provider})
+	}
+	return named
 }
 
 func newGitHubSCMProvider(logger *slog.Logger) (*scmgithub.Provider, error) {
@@ -124,39 +177,34 @@ func logSCMProviderDisabled(logger *slog.Logger, provider string, err error) {
 }
 
 // newMultiSCMProvider builds a multi-provider for use outside the polling
-// observer (e.g. session service PR claiming). Returns nil when no provider
-// has usable credentials — callers must tolerate a nil SCM.
-func newMultiSCMProvider(gitlabCfg config.GitLabConfig, logger *slog.Logger) *scmmulti.Provider {
-	var named []scmmulti.NamedProvider
-	if gh, err := newGitHubSCMProvider(logger); err == nil {
-		named = append(named, scmmulti.NamedProvider{Key: "github", Provider: gh})
-	}
-	if gl, err := newGitLabSCMProvider(gitlabCfg, logger); err == nil {
-		named = append(named, scmmulti.NamedProvider{Key: "gitlab", Provider: gl})
-	}
-	if len(named) == 0 {
+// observer (e.g. session service PR claiming), registering the same providers
+// the observer gets. Returns nil when no provider has usable credentials —
+// callers must tolerate a nil SCM.
+func newMultiSCMProvider(gitlabCfg config.GitLabConfig, onedevCfg config.OneDevConfig, logger *slog.Logger) *scmmulti.Provider {
+	subs := scmSubProviders(gitlabCfg, onedevCfg, logger, nil)
+	if len(subs) == 0 {
 		return nil
 	}
-	return scmmulti.New(named...)
+	return scmmulti.New(namedSCMProviders(subs)...)
 }
 
 // newMultiSCMMerger builds a multi-merger for PR merge actions, registering
-// both GitHub and GitLab providers. When one provider is unavailable (missing
-// token), the multi-merger still routes to the healthy one — same
+// the same providers the observer gets. When one provider is unavailable
+// (missing token), the multi-merger still routes to the healthy one — same
 // degrade-gracefully pattern as newMultiSCMProvider. Returns nil when no
 // provider has usable credentials.
-func newMultiSCMMerger(gitlabCfg config.GitLabConfig, logger *slog.Logger) *scmmulti.Merger {
-	var named []scmmulti.NamedMerger
-	if gh, err := newGitHubSCMProvider(logger); err == nil {
-		named = append(named, scmmulti.NamedMerger{Key: "github", Merger: gh})
-	}
-	if gl, err := newGitLabSCMProvider(gitlabCfg, logger); err == nil {
-		named = append(named, scmmulti.NamedMerger{Key: "gitlab", Merger: gl})
-	}
-	if len(named) == 0 {
+//
+// OneDev is registered here even though it cannot merge. Its
+// MergePullRequest returns ports.ErrSCMUnsupported, so a merge attempt on a
+// OneDev pull request reports that OneDev does not support the operation
+// rather than "unknown provider" — see the OneDev adapter's merge.go for why
+// it cannot merge safely.
+func newMultiSCMMerger(gitlabCfg config.GitLabConfig, onedevCfg config.OneDevConfig, logger *slog.Logger) *scmmulti.Merger {
+	subs := scmSubProviders(gitlabCfg, onedevCfg, logger, nil)
+	if len(subs) == 0 {
 		return nil
 	}
-	return scmmulti.NewMerger(named...)
+	return scmmulti.NewMerger(namedSCMMergers(subs)...)
 }
 
 func closedDone() <-chan struct{} {

--- a/backend/internal/daemon/scm_wiring_test.go
+++ b/backend/internal/daemon/scm_wiring_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 
 	scmmulti "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/multi"
@@ -45,7 +46,7 @@ func TestSCMWiring_MultiProviderSatisfiesScopedIdentityResolver(t *testing.T) {
 // newMultiSCMProvider helper (used outside the observer) also returns a value
 // that satisfies ScopedIdentityResolver.
 func TestSCMWiring_NewMultiSCMProviderReturnsScopedResolver(t *testing.T) {
-	multi := newMultiSCMProvider(testGitLabConfig(), slog.Default())
+	multi := newMultiSCMProvider(testGitLabConfig(), testOneDevConfig(), slog.Default())
 	if multi == nil {
 		t.Skip("no SCM provider available (missing tokens)")
 	}
@@ -150,4 +151,101 @@ func TestSCMWiring_OneDevPerHostTokenOverride(t *testing.T) {
 	if !ok {
 		t.Fatal("credentials unavailable; the per-host token did not reach the provider")
 	}
+}
+
+// TestSCMWiring_AllConstructorsRegisterOneDev is the regression test for the
+// gap this file's helpers used to have: OneDev was registered by
+// startSCMObserver only, so `ao session claim-pr` (newMultiSCMProvider) and
+// `ao pr merge` (newMultiSCMMerger) failed on a OneDev pull request even
+// though the observer was polling it happily. A test that covered the
+// observer alone is exactly what let that through, so every construction path
+// is asserted here.
+func TestSCMWiring_AllConstructorsRegisterOneDev(t *testing.T) {
+	glCfg, odCfg := testGitLabConfig(), testOneDevConfig()
+	logger := slog.Default()
+
+	t.Run("scmSubProviders", func(t *testing.T) {
+		// startSCMObserver builds its multi provider from this list, so a key
+		// present here is a key the observer dispatches on.
+		subs := scmSubProviders(glCfg, odCfg, logger, nil)
+		if !hasSubProvider(subs, scmonedev.ProviderKey) {
+			t.Fatalf("scmSubProviders registered %v, want it to include %q", subProviderKeys(subs), scmonedev.ProviderKey)
+		}
+	})
+
+	t.Run("newMultiSCMProvider", func(t *testing.T) {
+		multi := newMultiSCMProvider(glCfg, odCfg, logger)
+		if multi == nil {
+			t.Fatal("newMultiSCMProvider returned nil despite a configured OneDev instance")
+		}
+		repo, ok := multi.ParseRepository(testOneDevRemote)
+		if !ok {
+			t.Fatalf("multi provider did not recognise %q; onedev is not registered", testOneDevRemote)
+		}
+		if repo.Provider != scmonedev.ProviderKey {
+			t.Fatalf("repo.Provider = %q, want %q", repo.Provider, scmonedev.ProviderKey)
+		}
+	})
+
+	t.Run("newMultiSCMMerger", func(t *testing.T) {
+		merger := newMultiSCMMerger(glCfg, odCfg, logger)
+		if merger == nil {
+			t.Fatal("newMultiSCMMerger returned nil despite a configured OneDev instance")
+		}
+		_, err := merger.MergePullRequest(context.Background(), ports.SCMMergeRequest{
+			PR: ports.SCMPRRef{
+				Repo:   ports.SCMRepo{Provider: scmonedev.ProviderKey, Host: "onedev.test:6610", Repo: "Homelab/curatarr"},
+				Number: 7,
+			},
+			ExpectedHeadSHA: "0123456789abcdef0123456789abcdef01234567",
+			Method:          ports.SCMMergeSquash,
+		})
+		// Registered but unsupported: the caller learns OneDev cannot merge,
+		// not that AO has never heard of the provider.
+		if !errors.Is(err, ports.ErrSCMUnsupported) {
+			t.Fatalf("MergePullRequest err = %v, want ports.ErrSCMUnsupported", err)
+		}
+		if strings.Contains(err.Error(), "unknown provider") {
+			t.Fatalf("onedev is not registered in the merger: %v", err)
+		}
+	})
+}
+
+// TestSCMWiring_UnconfiguredOneDevLeavesOtherProvidersRegistered pins the
+// degrade-gracefully contract across the shared builder: an absent OneDev
+// allowlist must not remove GitHub or GitLab from any construction path.
+func TestSCMWiring_UnconfiguredOneDevLeavesOtherProvidersRegistered(t *testing.T) {
+	withOneDev := scmSubProviders(testGitLabConfig(), testOneDevConfig(), slog.Default(), nil)
+	withoutOneDev := scmSubProviders(testGitLabConfig(), config.OneDevConfig{}, slog.Default(), nil)
+
+	if hasSubProvider(withoutOneDev, scmonedev.ProviderKey) {
+		t.Fatal("onedev registered without a configured allowlist")
+	}
+	for _, sub := range withOneDev {
+		if sub.Key == scmonedev.ProviderKey {
+			continue
+		}
+		if !hasSubProvider(withoutOneDev, sub.Key) {
+			t.Fatalf("provider %q disappeared when OneDev was unconfigured; got %v", sub.Key, subProviderKeys(withoutOneDev))
+		}
+	}
+}
+
+const testOneDevRemote = "http://onedev.test:6610/Homelab/curatarr.git"
+
+func subProviderKeys(subs []namedSCMSubProvider) []string {
+	keys := make([]string, 0, len(subs))
+	for _, sub := range subs {
+		keys = append(keys, sub.Key)
+	}
+	return keys
+}
+
+func hasSubProvider(subs []namedSCMSubProvider, key string) bool {
+	for _, sub := range subs {
+		if sub.Key == key {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/daemon/scm_wiring_test.go
+++ b/backend/internal/daemon/scm_wiring_test.go
@@ -2,10 +2,12 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
 	scmmulti "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/multi"
+	scmonedev "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/onedev"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	scmobserve "github.com/aoagents/agent-orchestrator/backend/internal/observe/scm"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -84,4 +86,68 @@ func TestSCMWiring_ObserverConfigHasScopedResolver(t *testing.T) {
 
 func testGitLabConfig() config.GitLabConfig {
 	return config.GitLabConfig{}
+}
+
+func testOneDevConfig() config.OneDevConfig {
+	return config.OneDevConfig{
+		Token:        "od-token",
+		AllowedHosts: []string{"http://onedev.test:6610"},
+	}
+}
+
+// TestSCMWiring_OneDevProviderRegisters checks that a configured OneDev
+// instance yields a provider the observer can dispatch to: it must satisfy the
+// observer's Provider contract and route by the "onedev" key that
+// ParseRepository stamps on repositories.
+func TestSCMWiring_OneDevProviderRegisters(t *testing.T) {
+	od, err := newOneDevSCMProvider(testOneDevConfig(), slog.Default())
+	if err != nil {
+		t.Fatalf("newOneDevSCMProvider: %v", err)
+	}
+	var provider scmobserve.Provider = od
+
+	multi := scmmulti.New(scmmulti.NamedProvider{Key: scmonedev.ProviderKey, Provider: provider})
+	repo, ok := multi.ParseRepository("http://onedev.test:6610/Homelab/curatarr.git")
+	if !ok {
+		t.Fatal("multi provider did not recognise a OneDev remote")
+	}
+	if repo.Provider != scmonedev.ProviderKey {
+		t.Fatalf("repo.Provider = %q, want %q", repo.Provider, scmonedev.ProviderKey)
+	}
+}
+
+// TestSCMWiring_OneDevUnconfiguredDegradesGracefully pins the
+// degrade-gracefully contract: OneDev is always self-hosted, so most
+// deployments never set AO_ONEDEV_ALLOWED_HOSTS. That must read as "this
+// provider is not in use", not as a failure that stops GitHub and GitLab from
+// being registered.
+func TestSCMWiring_OneDevUnconfiguredDegradesGracefully(t *testing.T) {
+	_, err := newOneDevSCMProvider(config.OneDevConfig{}, slog.Default())
+	if !errors.Is(err, scmonedev.ErrNoAllowedHosts) {
+		t.Fatalf("err = %v, want ErrNoAllowedHosts", err)
+	}
+	// startSCMObserver logs and steps over this error rather than returning,
+	// so a multi provider built from the other sub-providers is unaffected.
+	logSCMProviderDisabled(slog.Default(), "onedev", err)
+}
+
+// TestSCMWiring_OneDevPerHostTokenOverride verifies that per-host tokens from
+// AO_ONEDEV_HOST_TOKENS reach the provider. A mis-keyed entry is a warning, not
+// a construction failure, so the wiring only has to pass them through.
+func TestSCMWiring_OneDevPerHostTokenOverride(t *testing.T) {
+	cfg := testOneDevConfig()
+	cfg.Token = ""
+	cfg.HostTokens = map[string]string{"http://onedev.test:6610": "per-host-token"}
+
+	od, err := newOneDevSCMProvider(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("newOneDevSCMProvider: %v", err)
+	}
+	ok, err := od.SCMCredentialsAvailable(context.Background())
+	if err != nil {
+		t.Fatalf("SCMCredentialsAvailable: %v", err)
+	}
+	if !ok {
+		t.Fatal("credentials unavailable; the per-host token did not reach the provider")
+	}
 }


### PR DESCRIPTION
## What

A OneDev SCM provider, so AO can observe and act on pull requests hosted on a self-hosted OneDev instance the way it already does for GitHub and GitLab.

Eight commits: provider foundation and credential/host resolution, the observer implementation (PR state, CI builds, build logs, review state, with a small cache), authenticated-identity resolution, registration in every SCM constructor, and a `ao doctor` section.

## Why

Fixes #4556.

OneDev is a common self-hosted choice for people who cannot put their code on github.com, and today AO simply has nothing for it — a OneDev repo is invisible to the board, so none of the session/PR/CI lifecycle works.

## How

Points reviewers may want to push back on, stated rather than buried:

- **`MergePullRequest` deliberately returns unsupported.** OneDev's merge API has no compare-and-swap — no expected-head parameter — so a merge cannot be made safe against a racing push the way the GitHub and GitLab paths are. Rather than implement a merge that can silently land the wrong head, the adapter declines and the user merges in the OneDev UI. That is the one capability gap versus the other providers, and it is a design decision, not an oversight.
- **Hosts come from configuration, not a fixed base URL.** OneDev is always self-hosted, so there is no public API root to assume. Instances are read from an allowlist and credentials resolved per host. `ebfa1df26` tightened that resolution after a mis-keyed per-host token resolved to the wrong credential; the two `test(scm)` commits are the regression tests for it, including credential *ordering*.
- **`doctor` builds the real adapter rather than re-implementing its checks.** Otherwise doctor can pass while the daemon fails. An unconfigured allowlist and an unreachable instance are WARN (self-hosted instances are commonly on private networks, and most deployments never set the allowlist); a *rejected* credential is a FAIL.
- **`fix(daemon): register OneDev in every SCM constructor`** is a genuine bug in the shape of the wiring: `scm_wiring.go` built providers in three places and only `startSCMObserver` registered OneDev, so `ao session claim-pr` on a OneDev PR failed with `SCM_UNAVAILABLE`. Worth a look as a pattern question — three constructors that must be kept in sync will drift again.
- **`golangci-lint` fixes are folded in, not bolted on.** v2.12.2 flags `gocritic ptrToRefParam` on a `*map` parameter (the pointer existed only so an overflow reset could rebind the map; `clear()` does it in place) and `makezero` on two build-log frame helpers (sizing the frame once and copying into it is lint-clean and one allocation instead of two). Both are fixed in the commits that introduce that code rather than in a trailing cleanup commit. No behaviour change.

Tests are in the same commits as the code they cover. No changes outside the OneDev adapter, its wiring, config resolution, and doctor.

## Testing

Rebased onto current `main` and verified from `backend/`:

```
go build ./...   # clean
go vet ./...     # clean
go test ./...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs   # 0 issues
```

The full backend suite passes — no failures, no skips I introduced.

Two tests needed the host set up the way CI has it, and neither is related to this branch (both behave identically on unmodified `main`, which I checked against a clean worktree):

- `TestCopilotClassicPATIsNotAnAuthorizationSignal` isolates env vars and `HOME` but not the `gh` binary. `copilotGHAuthStatus` shells out to `gh auth status`, so on a developer machine with a logged-in `gh` the probe reports authorized and the assertion inverts. Worth tightening the test's isolation upstream — happy to send that separately.
- The tmux integration tests need a running tmux server whose `base-index`/`pane-base-index` are 0. `respawnPaneArgs` and the pane-pid probe target `<session>:0.0` (`commands.go:24`, `:61`) and nothing reads those options, so on the very common `base-index 1` config `Restart` fails with `can't find pane: 0`. That looks like a real bug in the runtime rather than a test artifact — it would hit session restore in normal use — but it is out of scope here, so I have left it alone and will raise it on its own.

Beyond the test suite, this branch is what my daily AO runs against a real OneDev instance: it observes PRs, reports CI status, feeds back build logs and resolves identity correctly.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)

---

@illegalcall @somewherelostt — tagging you as the on-call pair per your note on #4556. Happy to split this smaller, reorder it, or rework any of the decisions above. #4655 covers #4557 (OneDev issue tracker + multi-provider intake) and is stacked on this branch — its first eight commits are this PR, so review this one first and it will shrink to four commits once this lands.
