### PR TITLE
feat: add sidebar hover preview

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -18,6 +18,7 @@ import {
 	SIDEBAR_DEFAULT_WIDTH,
 	SIDEBAR_MIN_WIDTH,
 } from "./Sidebar";
+import { TitlebarNav } from "./TitlebarNav";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
 import { useUiStore } from "../stores/ui-store";
@@ -134,7 +135,8 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 	};
 });
 
-vi.mock("./TitlebarNav", () => ({
+vi.mock("./TitlebarNav", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./TitlebarNav")>()),
 	useCanGoForward: () => compactRailCanGoForward.current,
 }));
 
@@ -241,6 +243,7 @@ function renderSidebar({
 	autoCompact = false,
 	topbarOffset = "toolbar",
 	expandedProjectIds,
+	includeTitlebarNav = false,
 }: {
 	onCloneProject?: CloneProjectHandler;
 	onCreateProject?: CreateProjectHandler;
@@ -252,6 +255,7 @@ function renderSidebar({
 	autoCompact?: boolean;
 	topbarOffset?: "toolbar" | "titlebar" | "trafficLights" | "session";
 	expandedProjectIds?: string[];
+	includeTitlebarNav?: boolean;
 } = {}) {
 	// Most legacy sidebar tests exercise session rows and assume their fixture
 	// project was previously open. Tests for the empty-store behavior opt out.
@@ -290,6 +294,7 @@ function renderSidebar({
 					onRemoveProject={onRemoveProject}
 					workspaces={workspaces}
 				/>
+				{includeTitlebarNav ? <TitlebarNav /> : null}
 			</SidebarProvider>
 		</QueryClientProvider>,
 	);
@@ -1651,6 +1656,227 @@ describe("Sidebar", () => {
 
 		expect(historyBackMock).toHaveBeenCalledTimes(1);
 		expect(historyForwardMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("opens the adaptive collapsed rail after an edge dwell and dismisses after leaving", () => {
+		vi.useFakeTimers();
+		try {
+			renderSidebar({ autoCompact: true, initialOpen: false });
+			const sidebar = document.querySelector('[data-slot="sidebar"]');
+			const container = document.querySelector('[data-slot="sidebar-container"]');
+			const gap = document.querySelector('[data-slot="sidebar-gap"]');
+
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(249));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+
+			act(() => vi.advanceTimersByTime(1));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+			expect(sidebar).not.toHaveAttribute("data-collapsible", "icon");
+			expect(gap).toHaveStyle({ width: "var(--sidebar-width-icon)" });
+			const expandedSettings = Array.from(document.querySelectorAll<HTMLButtonElement>('button[aria-label="Settings"]'))
+				.find((button) => button.textContent?.includes("Settings"));
+			const collapsedSettings = Array.from(document.querySelectorAll<HTMLButtonElement>('button[aria-label="Settings"]'))
+				.find((button) => !button.textContent?.includes("Settings"));
+			expect(expandedSettings).toHaveAttribute("tabindex", "0");
+			expect(collapsedSettings).toHaveAttribute("tabindex", "-1");
+
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 140, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(1000));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+
+			fireEvent.pointerLeave(container!, { pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(54));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+			fireEvent.pointerEnter(container!, { pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(54));
+			act(() => vi.advanceTimersByTime(1));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+			fireEvent.pointerLeave(container!, { pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(54));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+			act(() => vi.advanceTimersByTime(1));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+			expect(container).not.toHaveClass("opacity-0");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("cancels edge dwell when the pointer moves away or uses touch", () => {
+		vi.useFakeTimers();
+		try {
+			renderSidebar({ autoCompact: true, initialOpen: false });
+			const sidebar = document.querySelector('[data-slot="sidebar"]');
+
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(249));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 20, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(1));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "touch" });
+			act(() => vi.advanceTimersByTime(250));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps the titlebar peek open through the trigger-to-sidebar route", async () => {
+		useUiStore.setState({ isSidebarOpen: false });
+		const peekRequest = vi.fn();
+		window.addEventListener("ao:sidebar-peek-request", peekRequest);
+		try {
+			renderSidebar({ initialOpen: false, includeTitlebarNav: true });
+			const sidebar = document.querySelector('[data-slot="sidebar"]');
+			const titlebar = document.querySelector<HTMLElement>('[data-slot="titlebar-nav"]');
+			const toggle = within(titlebar!).getByRole("button", { name: "Expand sidebar" });
+
+			expect(toggle).toBeVisible();
+			fireEvent.pointerEnter(toggle, { buttons: 1, pointerType: "mouse" });
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+			fireEvent.pointerEnter(toggle, { buttons: 0, pointerType: "touch" });
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+			fireEvent.pointerEnter(toggle, { buttons: 0, pointerType: "mouse" });
+			expect(peekRequest).toHaveBeenLastCalledWith(expect.objectContaining({
+				detail: expect.objectContaining({
+					buttons: 0,
+					pointerType: "mouse",
+					triggerZone: expect.any(Object),
+				}),
+			}));
+			await waitFor(() => expect(sidebar).toHaveAttribute("data-peek-open", "true"));
+
+			vi.useFakeTimers();
+			fireEvent.pointerLeave(sidebar!, { pointerType: "mouse" });
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 0, clientY: 0, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(100));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 140, clientY: 100, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(100));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 300, clientY: 100, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(54));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+			act(() => vi.advanceTimersByTime(1));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+		} finally {
+			vi.useRealTimers();
+			window.removeEventListener("ao:sidebar-peek-request", peekRequest);
+			useUiStore.setState({ isSidebarOpen: true });
+		}
+	});
+
+	it("edge-peeks the fully collapsed off-canvas sidebar and lets the control pin it open", () => {
+		vi.useFakeTimers();
+		try {
+			renderSidebar({ initialOpen: false });
+			const sidebar = document.querySelector('[data-slot="sidebar"]');
+			const container = document.querySelector('[data-slot="sidebar-container"]');
+			const gap = document.querySelector('[data-slot="sidebar-gap"]');
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(250));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+			expect(container).toHaveClass(
+				"opacity-100",
+				"transition-opacity",
+				"duration-normal",
+				"ease-out",
+				"motion-reduce:transition-none",
+			);
+			expect(sidebar).not.toHaveAttribute("data-collapsible", "offcanvas");
+			expect(gap).toHaveStyle({ width: "0px" });
+			const pinControl = screen.getByRole("button", { name: "Collapse sidebar" });
+			expect(pinControl).toBeVisible();
+			fireEvent.click(pinControl);
+			expect(sidebar).toHaveAttribute("data-state", "expanded");
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+		} finally {
+			vi.useRealTimers();
+		}
+
+		vi.useFakeTimers();
+		try {
+			renderSidebar({ autoCompact: true });
+			const openSidebar = document.querySelector('[data-slot="sidebar"]');
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(250));
+			expect(openSidebar).not.toHaveAttribute("data-peek-open", "true");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("uses a short reduced-motion-safe fade while dismissing a peek", () => {
+		vi.useFakeTimers();
+		try {
+			renderSidebar({ initialOpen: false });
+			const sidebar = document.querySelector('[data-slot="sidebar"]');
+			const container = document.querySelector('[data-slot="sidebar-container"]');
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(250));
+			fireEvent.pointerLeave(container!, { pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(54));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+			act(() => vi.advanceTimersByTime(1));
+
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+			expect(container).toHaveClass(
+				"opacity-0",
+				"transition-opacity",
+				"duration-fast",
+				"ease-in",
+				"motion-reduce:transition-none",
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("rejects edge activation during pointer drags or text selection", () => {
+		vi.useFakeTimers();
+		try {
+			renderSidebar({ initialOpen: false });
+			const sidebar = document.querySelector('[data-slot="sidebar"]');
+
+			fireEvent.pointerMove(window, { buttons: 1, clientX: 4, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(250));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "mouse" });
+			const selection = window.getSelection();
+			const range = document.createRange();
+			range.selectNodeContents(document.body);
+			selection?.removeAllRanges();
+			selection?.addRange(range);
+			act(() => vi.advanceTimersByTime(250));
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+			selection?.removeAllRanges();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("pins a temporary off-canvas peek open through the sidebar keyboard shortcut", () => {
+		vi.useFakeTimers();
+		try {
+			renderSidebar({ initialOpen: false });
+			const sidebar = document.querySelector('[data-slot="sidebar"]');
+			fireEvent.pointerMove(window, { buttons: 0, clientX: 4, pointerType: "mouse" });
+			act(() => vi.advanceTimersByTime(250));
+			expect(sidebar).toHaveAttribute("data-peek-open", "true");
+
+			fireEvent.keyDown(window, { key: "b", metaKey: true });
+			expect(sidebar).toHaveAttribute("data-state", "expanded");
+			expect(sidebar).not.toHaveAttribute("data-peek-open", "true");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("flushes any queued rAF frame on pointer-up and persists the clamped width", async () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -110,6 +110,9 @@ import {
 	SidebarRail,
 	SidebarMenuSub,
 	SidebarMenuSubItem,
+	SIDEBAR_PEEK_REQUEST_EVENT,
+	type SidebarPeekRequestDetail,
+	type SidebarPeekTriggerZone,
 	useSidebar,
 } from "./ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -164,6 +167,10 @@ const MAX_DISPLAY_NAME_LEN = 20;
 // distance keeps a plain navigation/disclosure click from starting a drag;
 // nested action buttons remain outside that activator surface.
 const REORDER_ACTIVATION_DISTANCE = 4;
+const SIDEBAR_PEEK_DELAY_MS = 250;
+const SIDEBAR_PEEK_DISMISS_DELAY_MS = 55;
+const SIDEBAR_PEEK_EDGE_WIDTH_PX = 8;
+const SIDEBAR_PEEK_FALLBACK_WIDTH_PX = 240;
 
 /** Stable drag-context ids: one for the project list, one per project's sessions. */
 export const PROJECT_DND_ID = "sidebar-projects";
@@ -311,6 +318,153 @@ function useGrabbingCursor(active: boolean) {
 	}, [active]);
 }
 
+function hasActiveTextSelection() {
+	const selection = window.getSelection();
+	return selection !== null && !selection.isCollapsed;
+}
+
+function isInsideSidebarPeekZone(event: PointerEvent, container: HTMLElement | null) {
+	const sidebar = container?.closest<HTMLElement>('[data-slot="sidebar"]');
+	const configuredWidth = Number.parseFloat(
+		getComputedStyle(document.documentElement).getPropertyValue("--ao-sidebar-w"),
+	);
+	const width = container?.offsetWidth || configuredWidth || SIDEBAR_PEEK_FALLBACK_WIDTH_PX;
+	const left = sidebar?.dataset.side === "right" ? window.innerWidth - width : 0;
+	return event.clientX >= left && event.clientX <= left + width && event.clientY >= 0 && event.clientY <= window.innerHeight;
+}
+
+function useSidebarPointerPeek(enabled: boolean) {
+	const { isPeeking, setPeekOpen } = useSidebar();
+	const openTimerRef = useRef<number | null>(null);
+	const dismissTimerRef = useRef<number | null>(null);
+	const lastPointerButtonsRef = useRef(0);
+	const titlebarTriggerActiveRef = useRef(false);
+	const titlebarTriggerZoneRef = useRef<SidebarPeekTriggerZone | null>(null);
+
+	const clearOpenTimer = useCallback(() => {
+		if (openTimerRef.current === null) return;
+		window.clearTimeout(openTimerRef.current);
+		openTimerRef.current = null;
+	}, []);
+	const clearDismissTimer = useCallback(() => {
+		if (dismissTimerRef.current === null) return;
+		window.clearTimeout(dismissTimerRef.current);
+		dismissTimerRef.current = null;
+	}, []);
+	const clearTitlebarTrigger = useCallback(() => {
+		titlebarTriggerActiveRef.current = false;
+		titlebarTriggerZoneRef.current = null;
+	}, []);
+
+	useEffect(() => {
+		if (enabled) return;
+		clearOpenTimer();
+		clearDismissTimer();
+		clearTitlebarTrigger();
+		if (isPeeking) setPeekOpen(false);
+	}, [clearDismissTimer, clearOpenTimer, clearTitlebarTrigger, enabled, isPeeking, setPeekOpen]);
+
+	const scheduleDismiss = useCallback(() => {
+		clearDismissTimer();
+		dismissTimerRef.current = window.setTimeout(() => {
+			dismissTimerRef.current = null;
+			setPeekOpen(false);
+		}, SIDEBAR_PEEK_DISMISS_DELAY_MS);
+	}, [clearDismissTimer, setPeekOpen]);
+	const scheduleOpen = useCallback(() => {
+		if (lastPointerButtonsRef.current !== 0 || hasActiveTextSelection() || openTimerRef.current !== null) return;
+		openTimerRef.current = window.setTimeout(() => {
+			openTimerRef.current = null;
+			if (lastPointerButtonsRef.current !== 0 || hasActiveTextSelection()) return;
+			setPeekOpen(true);
+		}, SIDEBAR_PEEK_DELAY_MS);
+	}, [setPeekOpen]);
+
+	useEffect(() => {
+		if (!enabled) return;
+		const onPointerDown = () => {
+			lastPointerButtonsRef.current = 1;
+			clearOpenTimer();
+			clearTitlebarTrigger();
+		};
+		const onSelectionChange = () => {
+			if (hasActiveTextSelection()) {
+				clearOpenTimer();
+				clearTitlebarTrigger();
+			}
+		};
+		const onTitlebarPointerEnter = (event: Event) => {
+			const { pointerType, buttons, triggerZone } = (event as CustomEvent<SidebarPeekRequestDetail>).detail;
+			clearDismissTimer();
+			lastPointerButtonsRef.current = buttons;
+			clearOpenTimer();
+			if (pointerType !== "mouse" || buttons !== 0 || hasActiveTextSelection()) {
+				clearTitlebarTrigger();
+				return;
+			}
+			titlebarTriggerActiveRef.current = triggerZone !== undefined;
+			titlebarTriggerZoneRef.current = triggerZone ?? null;
+			setPeekOpen(true);
+		};
+		const onPointerMove = (event: PointerEvent) => {
+			lastPointerButtonsRef.current = event.buttons;
+			if (event.pointerType !== "mouse" || event.buttons !== 0 || hasActiveTextSelection()) {
+				clearOpenTimer();
+				clearTitlebarTrigger();
+				return;
+			}
+			if (isPeeking) {
+				const container = document.querySelector<HTMLElement>("[data-slot=sidebar-container]");
+				const triggerZone = titlebarTriggerZoneRef.current;
+				const insideTrigger = titlebarTriggerActiveRef.current && triggerZone !== null &&
+					event.clientX >= triggerZone.left && event.clientX <= triggerZone.right &&
+					event.clientY >= triggerZone.top && event.clientY <= triggerZone.bottom;
+				if (insideTrigger) {
+					clearDismissTimer();
+					return;
+				}
+				if (titlebarTriggerActiveRef.current) clearTitlebarTrigger();
+				isInsideSidebarPeekZone(event, container) ? clearDismissTimer() : scheduleDismiss();
+				return;
+			}
+			if (event.clientX > SIDEBAR_PEEK_EDGE_WIDTH_PX) {
+				clearOpenTimer();
+				return;
+			}
+			scheduleOpen();
+		};
+
+		window.addEventListener("pointerdown", onPointerDown);
+		window.addEventListener("pointermove", onPointerMove);
+		window.addEventListener(SIDEBAR_PEEK_REQUEST_EVENT, onTitlebarPointerEnter);
+		document.addEventListener("selectionchange", onSelectionChange);
+		return () => {
+			window.removeEventListener("pointerdown", onPointerDown);
+			window.removeEventListener("pointermove", onPointerMove);
+			window.removeEventListener(SIDEBAR_PEEK_REQUEST_EVENT, onTitlebarPointerEnter);
+			document.removeEventListener("selectionchange", onSelectionChange);
+			clearOpenTimer();
+			clearTitlebarTrigger();
+		};
+	}, [clearDismissTimer, clearOpenTimer, clearTitlebarTrigger, enabled, isPeeking, scheduleDismiss, scheduleOpen]);
+
+	const onPointerEnter = useCallback(() => {
+		clearDismissTimer();
+	}, [clearDismissTimer]);
+	const onPointerLeave = useCallback(() => {
+		clearOpenTimer();
+		if (!isPeeking || titlebarTriggerActiveRef.current) return;
+		scheduleDismiss();
+	}, [clearOpenTimer, isPeeking, scheduleDismiss]);
+
+	useEffect(() => () => {
+		clearOpenTimer();
+		clearDismissTimer();
+	}, [clearDismissTimer, clearOpenTimer]);
+
+	return { isPeeking, onPointerEnter, onPointerLeave };
+}
+
 export const SIDEBAR_DEFAULT_WIDTH = 240;
 export const SIDEBAR_MIN_WIDTH = 200;
 export const SIDEBAR_MAX_WIDTH = 420;
@@ -419,13 +573,15 @@ export function Sidebar({
 }: SidebarProps) {
 	const { t } = useTranslation();
 	const selection = useSelection();
-	const { state, setOpen, toggleSidebar } = useSidebar();
+	const { isMobile, state, setOpen, toggleSidebar } = useSidebar();
 	const isCollapsed = state === "collapsed";
+	const { isPeeking, onPointerEnter, onPointerLeave } = useSidebarPointerPeek(!isMobile && isCollapsed);
+	const isCompactCollapsed = isCollapsed && !isPeeking;
 	const [expandedChromeVisible, setExpandedChromeVisible] = useState(!isCollapsed);
 	const router = useRouter();
 	const canGoBack = useCanGoBack();
 	const canGoForward = useCanGoForward();
-	const showCompactRailHistory = autoCompact && isCollapsed && (isMac || isLinux) && !isWindows;
+	const showCompactRailHistory = autoCompact && isCompactCollapsed && (isMac || isLinux) && !isWindows;
 	// One IPC subscription for both footer variants of the restart-to-update prompt.
 	const updateStatus = useUpdateStatus();
 	// Daemon status for the smoke suite's sr-only mirror in the footer. Null when
@@ -439,10 +595,10 @@ export function Sidebar({
 	useLayoutEffect(() => {
 		// Offcanvas: the panel slides off-screen on collapse — no need to hide content.
 		// Reveal immediately on expand so there's no fade-in delay.
-		if (!isCollapsed) {
+		if (!isCollapsed || isPeeking) {
 			setExpandedChromeVisible(true);
 		}
-	}, [isCollapsed]);
+	}, [isCollapsed, isPeeking]);
 
 	// Disclosure state is persisted as the IDs of projects that were expanded.
 	// An empty/missing store intentionally means all projects start collapsed.
@@ -637,8 +793,11 @@ export function Sidebar({
 		// Pinned sidebars start below shell chrome.
 		<SidebarRoot
 			collapsible={autoCompact ? "icon" : "offcanvas"}
-			data-expanded-chrome={expandedChromeVisible ? "visible" : "hidden"}
+			peekOpen={isPeeking}
+			data-expanded-chrome={expandedChromeVisible || isPeeking ? "visible" : "hidden"}
 			data-topbar-offset={underTopbar ? topbarOffset : undefined}
+			onPointerEnter={onPointerEnter}
+			onPointerLeave={onPointerLeave}
 			className={cn(
 				"sidebar-focusless",
 				hideEdgeBorder ? "border-transparent" : "border-r-0 group-data-[side=left]:border-r-0",
@@ -706,8 +865,8 @@ export function Sidebar({
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<button
-							aria-label={isCollapsed ? t("shell.expandSidebar") : t("shell.collapseSidebar")}
-							className="hidden size-control-board place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground group-data-[collapsible=icon]:grid [&_svg]:size-icon-base"
+							aria-label={isCompactCollapsed ? t("shell.expandSidebar") : t("shell.collapseSidebar")}
+							className="hidden size-control-board place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground group-data-[collapsible=icon]:grid group-data-[peek-open=true]:grid [&_svg]:size-icon-base"
 							onClick={toggleSidebar}
 							type="button"
 						>
@@ -715,7 +874,7 @@ export function Sidebar({
 						</button>
 					</TooltipTrigger>
 					<TooltipContent side="right">
-						{isCollapsed ? t("shell.expandSidebar") : t("shell.collapseSidebar")}
+						{isCompactCollapsed ? t("shell.expandSidebar") : t("shell.collapseSidebar")}
 					</TooltipContent>
 				</Tooltip>
 				{showCompactRailHistory ? (
@@ -844,13 +1003,13 @@ export function Sidebar({
 											onRemoveProject={onRemoveProject}
 										/>
 									))}
-									{isCollapsed && <CreateProjectListItem />}
+									{isCompactCollapsed && <CreateProjectListItem />}
 								</SidebarMenu>
 								<DragOverlay adjustScale={false} dropAnimation={null} modifiers={[restrictProjectOverlayToRows]} style={PROJECT_DRAG_OVERLAY_STYLE} zIndex={60}>
 									{activeDragWorkspace ? (
 										<ProjectDragPreview
 											expanded={
-												!isCollapsed &&
+												!isCompactCollapsed &&
 												(expandedIds.has(activeDragWorkspace.id) ||
 													(initialActiveSessionProjectId === activeDragWorkspace.id &&
 														!dismissedInitialActiveProjectIds.has(activeDragWorkspace.id)))
@@ -882,13 +1041,13 @@ export function Sidebar({
 					</span>
 				)}
 				<div
-					aria-hidden={isCollapsed || undefined}
-					hidden={isCollapsed}
+					aria-hidden={isCompactCollapsed || undefined}
+					hidden={isCompactCollapsed}
 					className="sidebar-expanded-chrome relative flex w-full min-w-46.5 flex-col gap-0.5"
 				>
-					<UpdateStatusRow status={updateStatus} tabIndex={isCollapsed ? -1 : 0} />
-					<CloudSignInRow tabIndex={isCollapsed ? -1 : 0} />
-					<CloudAccountRow tabIndex={isCollapsed ? -1 : 0} />
+					<UpdateStatusRow status={updateStatus} tabIndex={isCompactCollapsed ? -1 : 0} />
+					<CloudSignInRow tabIndex={isCompactCollapsed ? -1 : 0} />
+					<CloudAccountRow tabIndex={isCompactCollapsed ? -1 : 0} />
 					<button
 						aria-label={t("settings.connectMobile")}
 						className={cn(
@@ -896,7 +1055,7 @@ export function Sidebar({
 							"flex h-9 w-full items-center text-left [&_svg]:size-icon-md [&_svg]:shrink-0",
 						)}
 						onClick={() => selection.goConnectMobile()}
-						tabIndex={isCollapsed ? -1 : 0}
+						tabIndex={isCompactCollapsed ? -1 : 0}
 						type="button"
 					>
 						<Smartphone aria-hidden="true" />
@@ -909,7 +1068,7 @@ export function Sidebar({
 							"flex h-[42px] w-full items-center text-left [&_svg]:size-icon-md [&_svg]:shrink-0",
 						)}
 						onClick={() => selection.goGlobalSettings()}
-						tabIndex={isCollapsed ? -1 : 0}
+						tabIndex={isCompactCollapsed ? -1 : 0}
 						type="button"
 					>
 						<Settings aria-hidden="true" />
@@ -917,19 +1076,19 @@ export function Sidebar({
 					</button>
 				</div>
 				<div
-					aria-hidden={!isCollapsed || undefined}
+					aria-hidden={!isCompactCollapsed || undefined}
 					className="pointer-events-none absolute inset-x-1.5 bottom-0 top-auto flex min-h-row-md flex-col items-center justify-end gap-1 opacity-0 transition-opacity duration-150 ease-out group-data-[collapsible=icon]:pointer-events-auto group-data-[collapsible=icon]:!bottom-2 group-data-[collapsible=icon]:opacity-100"
 				>
-					<UpdateStatusRail status={updateStatus} tabIndex={isCollapsed ? 0 : -1} />
-					<CloudSignInRailButton tabIndex={isCollapsed ? 0 : -1} />
-					<CloudAccountRailButton tabIndex={isCollapsed ? 0 : -1} />
+					<UpdateStatusRail status={updateStatus} tabIndex={isCompactCollapsed ? 0 : -1} />
+					<CloudSignInRailButton tabIndex={isCompactCollapsed ? 0 : -1} />
+					<CloudAccountRailButton tabIndex={isCompactCollapsed ? 0 : -1} />
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<button
 								aria-label={t("settings.connectMobile")}
 								className="grid size-control-board place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-icon-base"
 								onClick={() => selection.goConnectMobile()}
-								tabIndex={isCollapsed ? 0 : -1}
+								tabIndex={isCompactCollapsed ? 0 : -1}
 								type="button"
 							>
 								<Smartphone aria-hidden="true" />
@@ -943,7 +1102,7 @@ export function Sidebar({
 								aria-label={t("shell.settings")}
 								className="grid size-control-board place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-icon-base"
 								onClick={() => selection.goGlobalSettings()}
-								tabIndex={isCollapsed ? 0 : -1}
+								tabIndex={isCompactCollapsed ? 0 : -1}
 								type="button"
 							>
 								<Settings aria-hidden="true" />
@@ -963,7 +1122,7 @@ export function Sidebar({
 			/>
 			<SidebarRail
 				aria-label={t("shell.expandSidebar")}
-				className="group-data-[state=expanded]:hidden hover:after:bg-transparent"
+				className="group-data-[state=expanded]:hidden group-data-[peek-open=true]:hidden hover:after:bg-transparent"
 				onClick={() => setOpen(true)}
 				onPointerDown={onCollapsedResizePointerDown}
 			/>
@@ -2326,8 +2485,8 @@ function SectionDisclosure({
 
 function SidebarSearchButton({ onOpen }: { onOpen: () => void }) {
 	const { t } = useTranslation();
-	const { state } = useSidebar();
-	const isCollapsed = state === "collapsed";
+	const { state, isPeeking } = useSidebar();
+	const isCollapsed = state === "collapsed" && !isPeeking;
 	const overrides = useKeybindingsStore((store) => store.overrides);
 	const paletteBinding = effectiveShortcutBindings("command-palette", isMac, overrides)[0];
 	const commandPaletteShortcutLabel = paletteBinding

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -1,9 +1,10 @@
 import { useCanGoBack, useRouter } from "@tanstack/react-router";
 import { ArrowLeft, ArrowRight, PanelLeft } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type PointerEventHandler } from "react";
 import { useTranslation } from "react-i18next";
 import { isLinuxPlatform, isMacPlatform } from "../lib/platform";
 import { sidebarIsCompact, sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "../stores/ui-store";
+import { requestSidebarPeek } from "./ui/sidebar";
 
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
@@ -97,6 +98,10 @@ export function TitlebarNav({
         label={
           isSidebarOpen ? t("shell.collapseSidebar") : t("shell.expandSidebar")
         }
+        onPointerEnter={(event) => {
+          const bounds = event.currentTarget.getBoundingClientRect();
+          requestSidebarPeek(event.pointerType, event.buttons, bounds);
+        }}
         onClick={toggleSidebar}
         title={
           isSidebarOpen
@@ -130,6 +135,7 @@ function TitlebarButton({
   label,
   title,
   disabled,
+  onPointerEnter,
   tabIndex,
   onClick,
   children,
@@ -137,6 +143,7 @@ function TitlebarButton({
   label: string;
   title: string;
   disabled?: boolean;
+  onPointerEnter?: PointerEventHandler<HTMLButtonElement>;
   tabIndex?: number;
   onClick: () => void;
   children: React.ReactNode;
@@ -147,6 +154,7 @@ function TitlebarButton({
       aria-disabled={disabled || undefined}
       className="grid size-control-md place-items-center rounded-md text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:bg-transparent disabled:hover:text-passive"
       disabled={disabled}
+      onPointerEnter={onPointerEnter}
       onClick={onClick}
       style={noDragStyle}
       tabIndex={tabIndex}

--- a/frontend/src/renderer/components/WindowTitlebar.test.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.test.tsx
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SIDEBAR_PEEK_REQUEST_EVENT } from "./ui/sidebar";
 
 const { navigateMock } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
@@ -98,6 +99,34 @@ describe("WindowTitlebar", () => {
     expect(
       screen.getByRole("button", { name: "Go forward" }),
     ).toBeInTheDocument();
+  });
+
+  it("requests an immediate temporary peek from the Windows sidebar titlebar button", async () => {
+    const peekRequest = vi.fn();
+    window.addEventListener(SIDEBAR_PEEK_REQUEST_EVENT, peekRequest);
+    try {
+      const { WindowTitlebar } = await loadWindowTitlebar();
+
+      render(<WindowTitlebar />);
+      const sidebarToggle = document.querySelector<HTMLButtonElement>(".window-titlebar__toggle");
+      expect(sidebarToggle).not.toBeNull();
+      fireEvent.pointerEnter(sidebarToggle!, {
+        buttons: 0,
+        pointerType: "mouse",
+      });
+
+      expect(peekRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            buttons: 0,
+            pointerType: "mouse",
+            triggerZone: expect.any(Object),
+          }),
+        }),
+      );
+    } finally {
+      window.removeEventListener(SIDEBAR_PEEK_REQUEST_EVENT, peekRequest);
+    }
   });
 
   it("switches the maximize control to a restore icon when the window is maximized", async () => {

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -13,6 +13,7 @@ import {
 import { useEffect, useState } from "react";
 import { sidebarIsVisible, useUiStore } from "../stores/ui-store";
 import { useCanGoForward } from "./TitlebarNav";
+import { requestSidebarPeek } from "./ui/sidebar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -188,6 +189,10 @@ export function WindowTitlebar() {
         }
         className="window-titlebar__toggle"
         onClick={toggleSidebar}
+        onPointerEnter={(event) => {
+          const bounds = event.currentTarget.getBoundingClientRect();
+          requestSidebarPeek(event.pointerType, event.buttons, bounds);
+        }}
         title={
           isSidebarOpen
             ? t("shell.collapseSidebarTitle")

--- a/frontend/src/renderer/components/ui/sidebar.tsx
+++ b/frontend/src/renderer/components/ui/sidebar.tsx
@@ -22,10 +22,33 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "var(--size-sidebar-default)";
 const SIDEBAR_WIDTH_MOBILE = "var(--size-sidebar-mobile)";
 const SIDEBAR_WIDTH_ICON = "var(--size-sidebar-icon)";
+export const SIDEBAR_PEEK_REQUEST_EVENT = "ao:sidebar-peek-request";
+export type SidebarPeekRequestDetail = {
+	pointerType: string;
+	buttons: number;
+	triggerZone?: SidebarPeekTriggerZone;
+};
+export type SidebarPeekTriggerZone = Pick<DOMRect, "bottom" | "left" | "right" | "top">;
+
+export function requestSidebarPeek(
+	pointerType: string,
+	buttons: number,
+	triggerZone?: SidebarPeekTriggerZone,
+) {
+	if (typeof window === "undefined") return;
+	window.dispatchEvent(
+		new CustomEvent<SidebarPeekRequestDetail>(SIDEBAR_PEEK_REQUEST_EVENT, {
+			detail: { pointerType, buttons, triggerZone },
+		}),
+	);
+}
+
 type SidebarContextProps = {
 	state: "expanded" | "collapsed";
 	open: boolean;
 	setOpen: (open: boolean) => void;
+	isPeeking: boolean;
+	setPeekOpen: (open: boolean) => void;
 	openMobile: boolean;
 	setOpenMobile: (open: boolean) => void;
 	isMobile: boolean;
@@ -67,6 +90,7 @@ function SidebarProvider({
 	// We use openProp and setOpenProp for control from outside the component.
 	const [_open, _setOpen] = React.useState(defaultOpen);
 	const open = openProp ?? _open;
+	const [isPeeking, setPeekOpen] = React.useState(false);
 
 	const [isReady, setIsReady] = React.useState(false);
 	React.useEffect(() => {
@@ -79,6 +103,7 @@ function SidebarProvider({
 	const setOpen = React.useCallback(
 		(value: boolean | ((value: boolean) => boolean)) => {
 			const openState = typeof value === "function" ? value(open) : value;
+			setPeekOpen(false);
 			if (setOpenProp) {
 				setOpenProp(openState);
 			} else {
@@ -119,13 +144,15 @@ function SidebarProvider({
 			state,
 			open,
 			setOpen,
+			isPeeking,
+			setPeekOpen,
 			isMobile,
 			openMobile,
 			setOpenMobile,
 			toggleSidebar,
 			isReady,
 		}),
-		[state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, isReady],
+		[state, open, setOpen, isPeeking, isMobile, openMobile, setOpenMobile, toggleSidebar, isReady],
 	);
 
 	return (
@@ -154,6 +181,7 @@ function Sidebar({
 	side = "left",
 	variant = "sidebar",
 	collapsible = "offcanvas",
+	peekOpen = false,
 	className,
 	children,
 	...props
@@ -161,10 +189,12 @@ function Sidebar({
 	side?: "left" | "right";
 	variant?: "sidebar" | "floating" | "inset";
 	collapsible?: "offcanvas" | "icon" | "none";
+	peekOpen?: boolean;
 }) {
 	const { t } = useTranslation();
 	const prefersReducedMotion = useReducedMotion();
 	const { isMobile, state, openMobile, setOpenMobile, isReady } = useSidebar();
+	const isPeeking = peekOpen && state === "collapsed" && (collapsible === "icon" || collapsible === "offcanvas");
 
 	if (collapsible === "none") {
 		return (
@@ -203,21 +233,35 @@ function Sidebar({
 		);
 	}
 
-	const isOffcanvasCollapsed = state === "collapsed" && collapsible === "offcanvas";
-	const isIconCollapsed = state === "collapsed" && collapsible === "icon";
+	const isOffcanvasCollapsed = state === "collapsed" && collapsible === "offcanvas" && !isPeeking;
+	const isOffcanvasPeeking = state === "collapsed" && collapsible === "offcanvas" && isPeeking;
+	const isIconCollapsed = state === "collapsed" && collapsible === "icon" && !isPeeking;
+	const isIconPeeking = state === "collapsed" && collapsible === "icon" && isPeeking;
+	const wasPeeking = React.useRef(isPeeking);
+	const isPeekClosing = state === "collapsed" && collapsible === "offcanvas" && !isPeeking && wasPeeking.current;
+	React.useEffect(() => {
+		wasPeeking.current = isPeeking;
+	}, [isPeeking]);
 	const containerX = isOffcanvasCollapsed ? (side === "left" ? "-100%" : "100%") : "0%";
-	const activeTransition: typeof SHELL_PANEL_SPRING | { duration: number } =
-		!isReady || prefersReducedMotion ? { duration: 0 } : SHELL_PANEL_SPRING;
+	const peekTransition = isOffcanvasPeeking
+		? { duration: 0.14, ease: "easeOut" as const }
+		: isPeekClosing
+			? { duration: 0.12, ease: "easeIn" as const }
+			: undefined;
+	const activeTransition: typeof SHELL_PANEL_SPRING | { duration: number; ease?: "easeIn" | "easeOut" } =
+		!isReady || prefersReducedMotion ? { duration: 0 } : peekTransition ?? SHELL_PANEL_SPRING;
 
 	// Target width for the gap placeholder. Animating the actual width lets the
 	// flex sibling <main> follow in real time instead of snapping separately.
 	const gapTargetWidth =
 		isOffcanvasCollapsed
 			? 0
-			: isIconCollapsed
+			: isIconCollapsed || isIconPeeking
 				? variant === "floating" || variant === "inset"
 					? "calc(var(--sidebar-width-icon) + 1rem)"
 					: "var(--sidebar-width-icon)"
+				: isOffcanvasPeeking
+					? 0
 				: "var(--sidebar-width)";
 
 	// Several React HTML event types conflict with Motion's overloaded versions.
@@ -229,7 +273,8 @@ function Sidebar({
 		<div
 			className="group peer hidden text-sidebar-foreground md:block"
 			data-state={state}
-			data-collapsible={state === "collapsed" ? collapsible : ""}
+			data-collapsible={state === "collapsed" && !isPeeking ? collapsible : undefined}
+			data-peek-open={isPeeking ? "true" : undefined}
 			data-variant={variant}
 			data-side={side}
 			data-slot="sidebar"
@@ -252,6 +297,8 @@ function Sidebar({
 				transition={activeTransition}
 				className={cn(
 					"fixed inset-y-0 z-chrome hidden h-svh w-(--sidebar-width) md:flex",
+					isOffcanvasPeeking && "opacity-100 transition-opacity duration-normal ease-out motion-reduce:transition-none",
+					(isOffcanvasCollapsed || isPeekClosing) && "opacity-0 transition-opacity duration-fast ease-in motion-reduce:transition-none",
 					side === "left" ? "left-0" : "right-0",
 					// Adjust the padding for floating and inset variants.
 					variant === "floating" || variant === "inset"
@@ -517,7 +564,7 @@ function SidebarMenuButton({
 	tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
 	const Comp = asChild ? Slot.Root : "button";
-	const { isMobile, state } = useSidebar();
+	const { isMobile, state, isPeeking } = useSidebar();
 
 	const button = (
 		<Comp
@@ -543,7 +590,7 @@ function SidebarMenuButton({
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>{button}</TooltipTrigger>
-			<TooltipContent side="right" align="center" hidden={state !== "collapsed" || isMobile} {...tooltip} />
+			<TooltipContent side="right" align="center" hidden={state !== "collapsed" || isPeeking || isMobile} {...tooltip} />
 		</Tooltip>
 	);
 }

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -497,20 +497,6 @@ describe("shell sidebar toggle", () => {
 		}
 	});
 
-	it("does not open a collapsed sidebar on titlebar hover", async () => {
-		useUiStore.setState({ isSidebarOpen: false });
-		await renderShell();
-
-		const provider = screen.getByTestId("sidebar-provider");
-		const expandTrigger = screen.getByRole("button", { name: "Expand sidebar" });
-
-		expect(provider).toHaveAttribute("data-open", "false");
-		fireEvent.pointerEnter(expandTrigger);
-
-		expect(provider).toHaveAttribute("data-open", "false");
-		expect(useUiStore.getState().isSidebarOpen).toBe(false);
-	});
-
 	it("opens the sidebar when the titlebar toggle is clicked", async () => {
 		useUiStore.setState({ isSidebarOpen: false });
 		await renderShell();


### PR DESCRIPTION
## Summary
- Add a 250 ms far-left edge dwell that temporarily opens collapsed adaptive and off-canvas sidebars without changing the main-content layout.
- Open the same temporary overlay immediately from the actual titlebar sidebar button, with stable trigger and logical sidebar pointer zones to support trigger-to-sidebar transfer.
- Keep temporary dismissal at 55 ms, preserve click-to-pin and Cmd/Ctrl+B keyboard pinning, and reject touch, drag, and text-selection activation.
- Add a short reduced-motion-safe reveal and hide transition while preserving pinned-sidebar behavior and layout gaps.

## Coverage
- Focused Sidebar, titlebar, Linux titlebar, Windows titlebar, and shell tests cover adaptive/off-canvas peek, pinning, stable hover zones, dismissal, and accessibility behavior.
- No automated AO Browser verification was performed.

Closes #4647