### PR TITLE
fix: fixed stuck composer spinner from queue dock undefined compare

### DIFF
--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -905,6 +905,20 @@ describe("unavailable states", () => {
 		expect(onSend).not.toHaveBeenCalled();
 	});
 
+	it("does not show a loading spinner when no queued edit is saving", () => {
+		renderComposer();
+		expect(
+			screen.getByRole("button", { name: "Send message" }).querySelector(".animate-spin"),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows a loading spinner only while the queued edit being edited is saving", () => {
+		renderComposer({ editingQueuedTurnId: "turn-1", savingQueuedEditPending: true });
+		expect(
+			screen.getByRole("button", { name: "Send message" }).querySelector(".animate-spin"),
+		).toBeInTheDocument();
+	});
+
 	it("says a mid-turn message will be held", () => {
 		const { field } = renderComposer({ willQueue: true });
 		expect(field).toHaveAttribute(
@@ -934,5 +948,21 @@ describe("unavailable states", () => {
 
 		expect(onSend).toHaveBeenCalledWith("follow up");
 		expect(onInterrupt).not.toHaveBeenCalled();
+	});
+
+	it("explains when a send is blocked by the previous in-flight message", async () => {
+		const onSend = vi.fn().mockImplementation(
+			() => new Promise<void>(() => {
+				/* keep pending */
+			}),
+		);
+		render(<ChatComposer busy onSend={onSend} willQueue />);
+		const field = screen.getByLabelText("Message the agent");
+
+		await typeInComposer(field, "follow up");
+		await userEvent.keyboard("{Enter}");
+
+		expect(onSend).not.toHaveBeenCalled();
+		expect(screen.getByRole("alert")).toHaveTextContent(/still sending the previous message/i);
 	});
 });

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -88,6 +88,7 @@ export function ChatComposer({
 	onSteer,
 	onInterrupt,
 	canSteer,
+	sendPending,
 	steerPending,
 	steerRefusal,
 	draftSeed,
@@ -136,6 +137,8 @@ export function ChatComposer({
 	onInterrupt?: () => void;
 	/** A turn is actually running, so there is something to steer into. */
 	canSteer?: boolean;
+	/** A send mutation is in flight for this session. */
+	sendPending?: boolean;
 	steerPending?: boolean;
 	/** Why the last steer was refused. */
 	steerRefusal?: string;
@@ -451,7 +454,19 @@ export function ChatComposer({
 			!steerPending &&
 			!savingQueuedEditPending &&
 			(editingQueuedTurnId || !busy);
-		if (!canSubmitNow) return;
+		if (!canSubmitNow) {
+			if (
+				(currentText.trim().length > 0 || staged) &&
+				busy &&
+				!disabled &&
+				!steerPending &&
+				!savingQueuedEditPending &&
+				!editingQueuedTurnId
+			) {
+				setSendError("Still sending the previous message. Try again in a moment.");
+			}
+			return;
+		}
 		setSendError(null);
 
 		const shouldSteer = forceSteer ?? false;
@@ -829,7 +844,7 @@ export function ChatComposer({
 						>
 							{canStopTurn ? (
 								<Square aria-hidden="true" className="size-2.5 fill-current" />
-							) : steerPending || savingQueuedEditPending ? (
+							) : steerPending || savingQueuedEditPending || sendPending ? (
 								<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
 							) : (
 								<ArrowUp aria-hidden="true" className="size-3.5" />

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -276,6 +276,7 @@ export interface ChatWorkspaceProps {
 	 * is worse than none.
 	 */
 	onSteer?: (text: string) => Promise<unknown>;
+	sendPending?: boolean;
 	steerPending?: boolean;
 	/** Why the last steer was refused, from the daemon's typed answer. */
 	steerRefusal?: string;
@@ -357,6 +358,7 @@ export function ChatWorkspace({
 	onStageAttachments,
 	nativeImages,
 	onSteer,
+	sendPending,
 	steerPending,
 	steerRefusal,
 	onPromoteQueuedTurn,
@@ -924,7 +926,10 @@ export function ChatWorkspace({
 										queueEdit ? { id: queueEdit.turnId, text: queueEdit.text } : undefined
 									}
 									editingQueuedTurnId={queueEdit?.turnId}
-									savingQueuedEditPending={editQueuedTurnPendingTurnId === queueEdit?.turnId}
+									savingQueuedEditPending={Boolean(
+										queueEdit?.turnId &&
+											editQueuedTurnPendingTurnId === queueEdit.turnId,
+									)}
 									onCancelQueuedEdit={() => setQueueEdit(undefined)}
 									onInterrupt={turn && !newWorkDisabled ? onInterrupt : undefined}
 									commandError={commandError}
@@ -961,6 +966,7 @@ export function ChatWorkspace({
 									// has not reached the provider, so there is nothing to steer.
 									onSteer={newWorkDisabled ? undefined : onSteer}
 									canSteer={Boolean(onSteer) && turn?.state === "running"}
+									sendPending={sendPending}
 									steerPending={steerPending}
 									steerRefusal={steerRefusal}
 									onCompact={newWorkDisabled ? undefined : onCompact}

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -363,6 +363,7 @@ export function SessionChatSurface({
 				// covers the window before the controller reports, and it is the last word
 				// afterwards, since the capability is a property of the driver.
 				onSteer={can(renderSnapshot, "steer") && !commands.steerUnsupported ? commands.steer : undefined}
+				sendPending={commands.sendPending}
 				steerPending={commands.steerPending}
 				steerRefusal={commands.steerRefusal}
 				onPromoteQueuedTurn={

--- a/frontend/src/renderer/hooks/useConversation.test.tsx
+++ b/frontend/src/renderer/hooks/useConversation.test.tsx
@@ -256,7 +256,40 @@ describe("accepted conversation sends", () => {
 			wrapper: HookWrapper,
 		});
 		expect(secondMount.result.current.pendingAcceptedTurnId).toBe("turn-refresh-failed");
-		expect(secondMount.result.current.busy).toBe(true);
+		expect(secondMount.result.current.busy).toBe(false);
+	});
+
+	it("releases the dispatch sentinel immediately when the daemon queues mid-turn", async () => {
+		postMock
+			.mockResolvedValueOnce({
+				data: { duplicate: false, turnId: "turn-queued-1", state: "queued" as const },
+				error: undefined,
+			})
+			.mockResolvedValueOnce({
+				data: { duplicate: false, turnId: "turn-queued-2", state: "queued" as const },
+				error: undefined,
+			});
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+		const HookWrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useConversationCommands("ao-queue-chain"), {
+			wrapper: HookWrapper,
+		});
+
+		await act(async () => {
+			await result.current.send("first queued");
+		});
+		await waitFor(() => expect(result.current.busy).toBe(false));
+		expect(result.current.pendingAcceptedTurnId).toBeUndefined();
+
+		await act(async () => {
+			await result.current.send("second queued");
+		});
+
+		expect(postMock).toHaveBeenCalledTimes(2);
 	});
 
 	it("admits only one same-session send before React can publish busy state", async () => {
@@ -479,11 +512,11 @@ describe("session-scoped conversation commands", () => {
 			expect(result.current.pendingAcceptedTurnId).toBeUndefined();
 
 			rerender({ sessionId: "ao-turn-a" });
-			expect(result.current.busy).toBe(true);
+			expect(result.current.busy).toBe(false);
 			expect(result.current.pendingAcceptedTurnId).toBe(acceptedTurnId);
 
 			act(() => result.current.acknowledgeAcceptedTurn("turn-from-another-session"));
-			expect(result.current.busy).toBe(true);
+			expect(result.current.busy).toBe(false);
 			expect(result.current.pendingAcceptedTurnId).toBe(acceptedTurnId);
 
 			act(() => result.current.acknowledgeAcceptedTurn(acceptedTurnId));
@@ -704,6 +737,40 @@ describe("conversation branching commands", () => {
 });
 
 describe("steering refusals", () => {
+	it("clears steer pending before a slow conversation refresh finishes", async () => {
+		const refresh = deferred<void>();
+		const steerResponse = deferred<{
+			data: { sourceTurnId: string; providerTurnId: string; activityId: string };
+			error: undefined;
+		}>();
+		postMock.mockImplementationOnce(() => steerResponse.promise);
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+		vi.spyOn(queryClient, "invalidateQueries").mockImplementation(() => refresh.promise);
+		const HookWrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useConversationCommands("ao-1"), { wrapper: HookWrapper });
+
+		let steerDone!: Promise<unknown>;
+		act(() => {
+			steerDone = result.current.steer("go left");
+		});
+		await waitFor(() => expect(result.current.steerPending).toBe(true));
+
+		steerResponse.resolve({
+			data: { sourceTurnId: "turn-1", providerTurnId: "provider-1", activityId: "activity-1" },
+			error: undefined,
+		});
+		await act(async () => {
+			await steerDone;
+		});
+
+		await waitFor(() => expect(result.current.steerPending).toBe(false));
+		refresh.resolve();
+	});
+
 	it("promotes the selected durable queued turn through the turn-scoped route", async () => {
 		postMock.mockResolvedValue({
 			data: { sourceTurnId: "queued-2", providerTurnId: "provider-1", activityId: "activity-1" },

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -114,7 +114,7 @@ function claimConversationDispatch(
 		queryClient.getQueryData<ConversationDispatchTrackingBySession>(
 			conversationDispatchTrackingQueryKey,
 		) ?? {};
-	if (current[targetSessionId]) return false;
+	if (current[targetSessionId]?.state === "pending") return false;
 	queryClient.setQueryData<ConversationDispatchTrackingBySession>(
 		conversationDispatchTrackingQueryKey,
 		{
@@ -279,14 +279,20 @@ export function useConversationCommands(sessionId: string | undefined) {
 		},
 		[queryClient],
 	);
-	const invalidate = useCallback(async () => {
+	const invalidate = useCallback(() => {
 		if (sessionId) {
-			// Keep the mutation pending until the active conversation has refreshed. A
-			// queued message or landed steer should be visible before the composer clears,
-			// otherwise the action looks dropped even though the daemon accepted it.
-			await invalidateSession(sessionId);
+			// Refresh in the background. Awaiting the refetch in mutation onSuccess kept
+			// steer, queue, and approval mutations pending after the daemon had already
+			// answered, which left the composer spinner stuck and blocked further sends.
+			void invalidateSession(sessionId).catch(() => {});
 		}
 	}, [invalidateSession, sessionId]);
+	const refreshSessionInBackground = useCallback(
+		(targetSessionId: string) => {
+			void invalidateSession(targetSessionId).catch(() => {});
+		},
+		[invalidateSession],
+	);
 
 	const send = useMutation({
 		onMutate: (variables: ConversationSendMutationInput) => {
@@ -323,17 +329,29 @@ export function useConversationCommands(sessionId: string | undefined) {
 			if (error) throw error;
 			return data;
 		},
-		onSuccess: async (data, variables) => {
+		onSuccess: (data, variables) => {
 			const acceptedTurnId = data?.turnId;
 			if (acceptedTurnId) {
-				// A refetch can briefly return the pre-send snapshot. Keep the accepted
-				// turn locally visible as pending until that exact durable row arrives.
-				acceptConversationDispatch(
-					queryClient,
-					variables.targetSessionId,
-					variables.clientMessageId,
-					acceptedTurnId,
-				);
+				if (data.state === "queued") {
+					// A queued row is already durable and did not start a new provider turn,
+					// so keeping the accepted-turn safety marker would block the next queue
+					// entry until a refetch observes this id — and the composer would swallow
+					// further Enter presses with no error.
+					releaseConversationDispatch(
+						queryClient,
+						variables.targetSessionId,
+						variables.clientMessageId,
+					);
+				} else {
+					// A refetch can briefly return the pre-send snapshot. Keep the accepted
+					// turn locally visible as pending until that exact durable row arrives.
+					acceptConversationDispatch(
+						queryClient,
+						variables.targetSessionId,
+						variables.clientMessageId,
+						acceptedTurnId,
+					);
+				}
 			} else {
 				// A duplicate response intentionally has no turn id: the daemon already
 				// delivered this idempotency key, so there is no exact new row this
@@ -344,10 +362,11 @@ export function useConversationCommands(sessionId: string | undefined) {
 					variables.clientMessageId,
 				);
 			}
-			// Delivery is already authoritative at this point. A failed follow-up
-			// refresh must not reject the mutation: TanStack would then run onError
-			// and misclassify transport success, clearing the accepted safety marker.
-			await invalidateSession(variables.targetSessionId).catch(() => {});
+			// Delivery is already authoritative at this point. Refresh in the
+			// background so a slow conversation refetch cannot keep send.isPending
+			// true and leave the composer disabled or spinning after the daemon
+			// accepted the message.
+			void refreshSessionInBackground(variables.targetSessionId);
 		},
 		onError: (_error, variables) => {
 			releaseConversationDispatch(
@@ -408,11 +427,11 @@ export function useConversationCommands(sessionId: string | undefined) {
 			);
 			if (error) throw error;
 		},
-		onSuccess: (_data, variables) => invalidateSession(variables.targetSessionId),
+		onSuccess: (_data, variables) => refreshSessionInBackground(variables.targetSessionId),
 		// A failed interrupt (e.g. CHAT_NO_ACTIVE_TURN) means the cached turn
 		// state is wrong. Refetch so the UI discovers the real state instead of
 		// keeping a Working bar the user cannot dismiss.
-		onError: (_error, variables) => invalidateSession(variables.targetSessionId),
+		onError: (_error, variables) => refreshSessionInBackground(variables.targetSessionId),
 	});
 
 	const resume = useMutation({
@@ -608,7 +627,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 			if (error) throw error;
 			return data;
 		},
-		onSuccess: async (data, variables) => {
+		onSuccess: (data, variables) => {
 			if (data?.turnId) {
 				acceptConversationDispatch(
 					queryClient,
@@ -619,7 +638,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 			} else {
 				releaseConversationDispatch(queryClient, variables.targetSessionId, variables.requestId);
 			}
-			await invalidateSession(variables.targetSessionId).catch(() => {});
+			void refreshSessionInBackground(variables.targetSessionId);
 		},
 		onError: (_error, variables) => {
 			releaseConversationDispatch(queryClient, variables.targetSessionId, variables.requestId);
@@ -645,7 +664,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 			if (error) throw error;
 			return data;
 		},
-		onSuccess: async (data, variables) => {
+		onSuccess: (data, variables) => {
 			if (data?.turnId) {
 				acceptConversationDispatch(
 					queryClient,
@@ -656,7 +675,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 			} else {
 				releaseConversationDispatch(queryClient, variables.targetSessionId, variables.requestId);
 			}
-			await invalidateSession(variables.targetSessionId).catch(() => {});
+			void refreshSessionInBackground(variables.targetSessionId);
 		},
 		onError: (_error, variables) => {
 			releaseConversationDispatch(queryClient, variables.targetSessionId, variables.requestId);
@@ -810,6 +829,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 			: undefined,
 		cancelQueuedTurnPendingTurnId: cancelQueuedTurn.isPending ? cancelQueuedTurn.variables : undefined,
 		editQueuedTurnPendingTurnId: editQueuedTurn.isPending ? editQueuedTurn.variables?.turnId : undefined,
+		sendPending: send.isPending && sendTargetsCurrentSession,
 		steerPending: steer.isPending,
 		/**
 		 * Why the last steer was refused, or undefined. Only the retryable and
@@ -831,7 +851,7 @@ export function useConversationCommands(sessionId: string | undefined) {
 				? apiErrorMessage(reloadMcp.error)
 				: undefined,
 		busy:
-			Boolean(trackedDispatch) ||
+			trackedDispatch?.state === "pending" ||
 			(send.isPending && sendTargetsCurrentSession) ||
 			resolve.isPending ||
 			resolveInput.isPending ||


### PR DESCRIPTION
## Summary

- Fix the send button stuck on the loading spinner after [#4649](https://github.com/Untrivial-ai/agent-orchestrator/pull/4649): `editQueuedTurnPendingTurnId === queueEdit?.turnId` evaluated to `true` when both were `undefined`, so `savingQueuedEditPending` was permanently true and the composer could not send.
- Harden dispatch/`busy` handling introduced in [#4457](https://github.com/Untrivial-ai/agent-orchestrator/pull/4457): only treat `"pending"` dispatch as busy, release the sentinel immediately for queued sends, and refresh conversation snapshots in the background instead of awaiting refetch in mutation `onSuccess` (steer, send, queue ops).
- Surface `sendPending` on the composer send control and show a clear error when a send is blocked by an in-flight message.

## Root cause

| PR | Regression |
|---|---|
| **#4649** | `savingQueuedEditPending={editQueuedTurnPendingTurnId === queueEdit?.turnId}` → `undefined === undefined` → always loading, always blocked |
| **#4457 + #4649** | Accepted dispatch + awaited refetch kept `busy` / mutation pending after the daemon had already accepted work |

## Test plan

- [ ] Open a chat session on a build with this fix — send button shows arrow (not spinner) on idle empty composer
- [ ] Type and send a message while the agent is idle — message sends normally
- [ ] While the agent is working, queue two messages back-to-back — second send is not swallowed
- [ ] Edit a queued message from the dock — spinner only while save is in flight
- [ ] Steer a running turn (⌘⏎) — spinner clears after daemon accepts, does not hang on slow refetch
- [x] `cd frontend && npm test -- useConversation.test.tsx ChatComposer.test.tsx`
- [x] `cd frontend && npm run typecheck`