### PR TITLE
feat: support Cloud TUI and ChatUI switching

### DIFF
--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -202,7 +202,7 @@ export function CenterPane({
 		showRightFade,
 	} = useTabScrollEdges([tabOverflowWatch]);
 	const previousTabCountRef = useRef(availableAuxiliaryKeys.length);
-	const agentSwitchesQuery = useAgentSwitches(session?.id ?? "");
+	const agentSwitchesQuery = useAgentSwitches(session?.id ?? "", !session?.cloud);
 	const agentSwitches = agentSwitchesQuery.data ?? [];
 	const switchMutation = useSwitchAgentState(session?.id ?? "");
 	const mountedSessionIdRef = useRef(session?.id);

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -53,6 +53,8 @@ import { SessionTopbarPortal } from "./SessionTopbarPortal";
 
 type CenterPaneProps = {
 	session?: WorkspaceSession;
+	/** Cloud Chat -> TUI handoffs receive a new PTY/cache generation. */
+	terminalGeneration?: string;
 	theme: Theme;
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
@@ -135,6 +137,7 @@ function initialTerminalFontSize(): number {
 
 export function CenterPane({
 	session,
+	terminalGeneration,
 	theme,
 	daemonReady,
 	terminalTarget,
@@ -707,6 +710,7 @@ export function CenterPane({
 						onChangeFontSize={updateFontSize}
 						onToggleFullscreen={toggleFullscreen}
 						session={session}
+						terminalGeneration={terminalGeneration}
 						terminalTarget={target}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -607,7 +607,11 @@ export function CenterPane({
 											tabAction={sessionTabAction}
 										/>
 									) : (
-										<SessionPaneTab isActive={target.kind === "worker"} label={sessionTabLabel} />
+										<SessionPaneTab
+											isActive={target.kind === "worker"}
+											label={sessionTabLabel}
+											tabAction={sessionTabAction}
+										/>
 									)}
 									<Reorder.Group
 										as="div"

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -176,7 +176,7 @@ export function SessionInspector({
 	const browserUnseen = useUiStore((state) =>
 		session ? Boolean(state.inspectorSessions[session.id]?.browserUnseen) : false,
 	);
-	const filesChangedCount = useSessionWorkspaceFilesChangedCount(session?.id);
+	const filesChangedCount = useSessionWorkspaceFilesChangedCount(session?.id, !session?.cloud);
 	const setView = useCallback((next: InspectorView) => {
 		setInternalView(next);
 		onViewChange?.(next);
@@ -273,9 +273,9 @@ const SummaryView = memo(function SummaryView({
 	session: WorkspaceSession;
 }) {
 	const { t } = useTranslation();
-	const query = useSessionScmSummary(session.id);
+	const query = useSessionScmSummary(session.id, !session.cloud);
 	const developerMode = useUiStore((state) => state.developerMode);
-	const usageQuery = useSessionUsage(session.id, developerMode);
+	const usageQuery = useSessionUsage(session.id, developerMode && !session.cloud);
 	const showUsage =
 		developerMode &&
 		!usageQuery.isLoading &&

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1590,7 +1590,7 @@ function ReviewsSection({
 	});
 	const reviewStates = reviewsQuery.data?.reviews ?? [];
 	const autoReviewEnabled = session.autoReviewEnabled === true;
-	const scmSummary = useSessionScmSummary(session.id);
+	const scmSummary = useSessionScmSummary(session.id, !session.cloud);
 	const prSummaries = sessionPRDisplaySummaries(session, scmSummary.data);
 	const githubReviews = prSummaries.filter(
 		(pr) =>

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
@@ -130,7 +130,7 @@ export function SessionInterfaceSwitchButton({
 						aria-label={label}
 						className={cn(
 							!supported && "opacity-50",
-							showLabel && "topbar-control--labeled h-7 gap-1.5 px-2 text-xs",
+							showLabel && "topbar-control--labeled !inline-flex !h-control-lg !w-auto !min-w-0 gap-1.5 px-2 text-xs",
 							className,
 						)}
 						disabled={!supported || pending}
@@ -144,7 +144,7 @@ export function SessionInterfaceSwitchButton({
 						) : (
 							<TargetIcon aria-hidden="true" className="size-icon-md" />
 						)}
-						{showLabel ? <span>{target === "tui" ? "Terminal UI" : "Chat UI"}</span> : null}
+						{showLabel ? <span data-compact-label>{target === "tui" ? "Terminal UI" : "Chat UI"}</span> : null}
 					</TopbarButton>
 				</span>
 			</TooltipTrigger>

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
@@ -63,6 +63,7 @@ export function SessionInterfaceSwitchButton({
 	cancelError,
 	onClick,
 	onCancel,
+	showLabel = false,
 	className,
 }: {
 	target: SessionInterfaceMode;
@@ -74,6 +75,8 @@ export function SessionInterfaceSwitchButton({
 	cancelError?: string;
 	onClick: () => void;
 	onCancel?: () => void;
+	/** Cloud uses a text label so the return-to-TUI action is discoverable. */
+	showLabel?: boolean;
 	className?: string;
 }) {
 	if (transition && interfaceTransitionIsActive(transition)) {
@@ -125,7 +128,11 @@ export function SessionInterfaceSwitchButton({
 				<span className="inline-flex">
 					<TopbarButton
 						aria-label={label}
-						className={cn(!supported && "opacity-50", className)}
+						className={cn(
+							!supported && "opacity-50",
+							showLabel && "topbar-control--labeled h-7 gap-1.5 px-2 text-xs",
+							className,
+						)}
 						disabled={!supported || pending}
 						onClick={onClick}
 						title={tooltipLabel}
@@ -137,6 +144,7 @@ export function SessionInterfaceSwitchButton({
 						) : (
 							<TargetIcon aria-hidden="true" className="size-icon-md" />
 						)}
+						{showLabel ? <span>{target === "tui" ? "Terminal UI" : "Chat UI"}</span> : null}
 					</TopbarButton>
 				</span>
 			</TooltipTrigger>

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -530,6 +530,8 @@ vi.mock("../lib/shell-context", () => ({
 	useShell: () => ({ daemonStatus: { state: "ready" } }),
 }));
 vi.mock("../hooks/useWorkspaceQuery", () => ({
+	toCloudWorkspaceSession: vi.fn(),
+	useCloudSessionQuery: () => ({ data: undefined }),
 	useWorkspaceQuery: () => ({
 		data: workspaceQueryState.data,
 		isLoading: workspaceQueryState.isLoading,

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -601,6 +601,7 @@ describe("SessionView", () => {
 		nativeFullScreenMock.mockReturnValue(false);
 		window.localStorage.clear();
 		for (const session of workspaces.flatMap((workspace) => workspace.sessions)) {
+			delete session.cloud;
 			delete session.previewUrl;
 			delete session.previewRevision;
 			delete session.isTerminated;
@@ -821,6 +822,14 @@ describe("SessionView", () => {
 
 	it("does not offer a new terminal for orchestrator sessions", () => {
 		render(<SessionView sessionId="sess-orch" />);
+
+		expect(screen.queryByRole("button", { name: "New terminal" })).not.toBeInTheDocument();
+	});
+
+	it("does not route Cloud sessions through the local new-terminal action", () => {
+		workerSession("sess-1").cloud = { orgId: "cloud-org" };
+
+		render(<SessionView cloudOrgId="cloud-org" projectId="proj-1" sessionId="sess-1" />);
 
 		expect(screen.queryByRole("button", { name: "New terminal" })).not.toBeInTheDocument();
 	});

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -48,6 +48,7 @@ vi.mock("../lib/platform", () => ({
 	// shortcut assertions in this suite.
 	hidesShellTopbar: () => true,
 	isMacPlatform: () => false,
+	isLinuxPlatform: () => false,
 }));
 vi.mock("../hooks/useWindowFullScreen", () => ({
 	useWindowFullScreen: () => nativeFullScreenMock(),

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -32,6 +32,10 @@ const chatSurfaceWorkState = vi.hoisted(() => ({
 	hasRunningTurn: false,
 	queuedTurnCount: 0,
 }));
+const cloudSessionQueryState = vi.hoisted(() => ({
+	data: undefined as WorkspaceSession | undefined,
+	isLoading: false,
+}));
 
 async function chooseSessionAction(name: string) {
 	const user = userEvent.setup();
@@ -532,7 +536,7 @@ vi.mock("../lib/shell-context", () => ({
 }));
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	toCloudWorkspaceSession: vi.fn(),
-	useCloudSessionQuery: () => ({ data: undefined }),
+	useCloudSessionQuery: () => cloudSessionQueryState,
 	useWorkspaceQuery: () => ({
 		data: workspaceQueryState.data,
 		isLoading: workspaceQueryState.isLoading,
@@ -639,6 +643,8 @@ describe("SessionView", () => {
 		interfaceTransitionState.starting = false;
 		interfaceTransitionState.settling = false;
 		interfaceTransitionState.status = undefined;
+		cloudSessionQueryState.data = undefined;
+		cloudSessionQueryState.isLoading = false;
 		chatSurfaceWorkState.controllerBusy = false;
 		chatSurfaceWorkState.hasRunningTurn = false;
 		chatSurfaceWorkState.queuedTurnCount = 0;
@@ -659,6 +665,18 @@ describe("SessionView", () => {
 			}
 			return { data: { reviewerHandleId: "", reviews: [], runs: [] }, error: undefined };
 		});
+	});
+
+	it("keeps the Cloud switch visible while a newly selected Cloud session resolves", () => {
+		workspaceQueryState.data = [];
+		cloudSessionQueryState.isLoading = true;
+
+		render(<SessionView cloudOrgId="cloud-org" projectId="cloud-project" sessionId="cloud-session" />);
+
+		expect(screen.queryByText("session not found")).not.toBeInTheDocument();
+		const switchButtons = screen.getAllByRole("button", { name: "Switch to chat UI" });
+		expect(switchButtons).not.toHaveLength(0);
+		expect(switchButtons.some((button) => (button as HTMLButtonElement).disabled)).toBe(true);
 	});
 
 	// Regression: shell terminals are an app-wide list, so without a per-session

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1040,8 +1040,11 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 		sessionId && !interfaceSwitchUnsupported,
 	);
 	const newTerminalError = openShellTerminal.error ? apiErrorMessage(openShellTerminal.error) : undefined;
+	// Shell terminals are implemented by the loopback daemon only. A Cloud
+	// session's id is not a daemon session id, so never offer an action that
+	// would send it to /api/v1/shell-terminals and produce SESSION_NOT_FOUND.
 	const newShellTerminalAction =
-		session && !isOrchestrator ? (
+		session && !session.cloud && !isOrchestrator ? (
 			<TopbarButton
 				aria-label={t("shortcut.new-shell-terminal")}
 				onClick={addShellTerminal}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1140,6 +1140,14 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 		session !== undefined &&
 		renderedSessionMode === "chat" &&
 		(chatTargetKind === "worker" || chatTargetKind === "reviewer" || chatTargetKind === "shell");
+	// A Cloud Chat -> TUI handoff must not reuse the TUI cache entry that was
+	// intentionally closed when Chat started. The committed mode changes to TUI
+	// only after the coordinator has stopped Chat, so using the completed
+	// transition id here is safe and gives the new PTY a deterministic generation.
+	const terminalGeneration =
+		session?.cloud && session.mode === "tui" && interfaceSwitch.transition?.targetMode === "tui"
+			? interfaceSwitch.transition.id
+			: undefined;
 	const {
 		agentSwitch: handoffAgentSwitch,
 		switchControlPresentation: handoffControlPresentation,
@@ -1653,6 +1661,7 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 									onSelectShellTerminal={selectShellTerminal}
 									reviewerTerminal={reviewerTerminal}
 									session={session}
+									terminalGeneration={terminalGeneration}
 									shellTerminals={shellTerminals}
 									terminalTarget={routedTerminalTarget}
 									theme={theme}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1175,6 +1175,7 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 				onCancel={() => {
 					void interfaceSwitch.cancel().catch(() => {});
 				}}
+				showLabel={Boolean(session?.cloud)}
 			/>
 		) : null;
 	const interfaceSwitchMenuItem =

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -22,6 +22,7 @@ import {
 	SessionChatSurface,
 	type ConversationWorkState,
 } from "./chat/SessionChatSurface";
+import { CloudSessionChatSurface } from "./chat/CloudSessionChatSurface";
 import { NotificationCenter } from "./NotificationCenter";
 import { ResizeHandle } from "./ResizeHandle";
 import { SessionFileExplorer } from "./SessionFileExplorer";
@@ -1565,7 +1566,13 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 								className={cn("h-full min-h-0", fileTabs.activePath && "invisible pointer-events-none")}
 								inert={fileTabs.activePath ? true : undefined}
 							>
-							{showChatSurface ? (
+							{showChatSurface && session?.cloud ? (
+								<CloudSessionChatSurface
+									headerActions={sessionHeaderActions}
+									session={session}
+									sessionTabAction={sessionTabActions}
+								/>
+							) : showChatSurface ? (
 								<SessionChatSurface
 									key={session.id}
 									session={session}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1035,6 +1035,7 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	// Adapters without a Chat driver cannot offer a switch into Chat UI; hide
 	// the button entirely rather than showing a permanently disabled control.
 	const interfaceSwitchUnsupported = interfaceSwitch.status?.reasonCode === "CHAT_UNSUPPORTED";
+	const isCloudSession = Boolean(interfaceContext);
 	const showInterfaceSwitchAction = Boolean(
 		sessionId && !interfaceSwitchUnsupported,
 	);
@@ -1161,7 +1162,7 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 		showInterfaceSwitchAction ? (
 			<SessionInterfaceSwitchButton
 				target={interfaceTarget}
-				supported={session?.cloud ? Boolean(interfaceSwitch.status?.supported) : true}
+				supported={isCloudSession ? Boolean(interfaceSwitch.status?.supported) : true}
 				disabledReason={
 					interfaceSwitch.isLoading
 						? "Checking whether this agent can switch interfaces…"
@@ -1181,7 +1182,7 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 		showInterfaceSwitchAction && !activeInterfaceTransition ? (
 			<SessionInterfaceSwitchMenuItem
 				target={interfaceTarget}
-				supported={session?.cloud ? Boolean(interfaceSwitch.status?.supported) : true}
+				supported={isCloudSession ? Boolean(interfaceSwitch.status?.supported) : true}
 				disabledReason={
 					interfaceSwitch.isLoading
 						? "Checking whether this agent can switch interfaces…"
@@ -1206,7 +1207,12 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	// Cloud's Chat surface does not have an interactive terminal tab to hover.
 	// Keep the handoff control in the app chrome as a direct, always-visible
 	// button so users can reliably return from Chat UI to TUI.
-	const cloudInterfaceSwitchAction = session?.cloud ? interfaceSwitchInlineStatus : null;
+	// `session` is briefly undefined while a newly-created Cloud tab is being
+	// resolved from the control plane. The route still has its Cloud org
+	// context, however, so mount the control from that context rather than from
+	// the eventually-populated row. Otherwise the very list-cache race this
+	// surface is intended to handle makes the switch disappear entirely.
+	const cloudInterfaceSwitchAction = interfaceContext ? interfaceSwitchInlineStatus : null;
 	const sessionTabActions = (
 		<SessionActionsMenu inlineStatus={session?.cloud ? undefined : interfaceSwitchInlineStatus}>
 			{interfaceSwitchMenuItem}
@@ -1521,7 +1527,16 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 			inspectorMotionReadyRef.current = false;
 		};
 	}, [hasInspector]);
-	if (!session && !workspaceQuery.isLoading) {
+	// A Cloud tab may arrive before the paginated workspace cache contains its
+	// row. Keep the session surface (and its switch control) mounted while the
+	// direct control-plane lookup is in flight; only show "not found" after
+	// both sources have settled.
+	const cloudSessionResolving = Boolean(
+		cloudOrgId &&
+		(isCloudRoute || !listedSession) &&
+		cloudRouteSession.isLoading,
+	);
+	if (!session && !workspaceQuery.isLoading && !cloudSessionResolving) {
 		return (
 			<div className="grid h-full place-items-center p-6 text-center font-mono text-xs text-passive">
 				{t("session.notFound")}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1220,8 +1220,11 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 			className="session-topbar-session-chrome flex shrink-0 items-center gap-1"
 			data-compact-session-chrome={compactSessionChrome ? "true" : "false"}
 		>
-			{cloudInterfaceSwitchAction}
-			<ShellTopbar compactActions={compactSessionChrome} embedded />
+			<ShellTopbar
+				compactActions={compactSessionChrome}
+				embedded
+				sessionAction={cloudInterfaceSwitchAction}
+			/>
 		</div>
 	);
 

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -989,7 +989,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// the button entirely rather than showing a permanently disabled control.
 	const interfaceSwitchUnsupported = interfaceSwitch.status?.reasonCode === "CHAT_UNSUPPORTED";
 	const showInterfaceSwitchAction = Boolean(
-		!interfaceSwitchUnsupported && (interfaceSwitch.status || interfaceSwitch.isLoading || interfaceSwitch.statusError),
+		!interfaceSwitchUnsupported &&
+		(session?.cloud !== undefined ||
+			interfaceSwitch.status ||
+			interfaceSwitch.isLoading ||
+			interfaceSwitch.statusError),
 	);
 	const newTerminalError = openShellTerminal.error ? apiErrorMessage(openShellTerminal.error) : undefined;
 	const newShellTerminalAction =

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1175,7 +1175,6 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 				onCancel={() => {
 					void interfaceSwitch.cancel().catch(() => {});
 				}}
-				showLabel={Boolean(session?.cloud)}
 			/>
 		) : null;
 	const interfaceSwitchMenuItem =

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1149,11 +1149,15 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	useEffect(() => {
 		if (handoffSwitchError) setHandoffDialogOpen(true);
 	}, [handoffSwitchError]);
+	// Keep the switch visible on the session tab, rather than only in the
+	// overflow menu. In particular, a Cloud tab can be selected before its
+	// row reaches the list cache; the visible control then makes its resolving
+	// state explicit instead of looking like the feature disappeared.
 	const interfaceSwitchInlineStatus =
-		session && showInterfaceSwitchAction && activeInterfaceTransition ? (
+		showInterfaceSwitchAction ? (
 			<SessionInterfaceSwitchButton
 				target={interfaceTarget}
-				supported={Boolean(interfaceSwitch.status?.supported) && !activeInterfaceTransition}
+				supported={session?.cloud ? Boolean(interfaceSwitch.status?.supported) : true}
 				disabledReason={
 					interfaceSwitch.isLoading
 						? "Checking whether this agent can switch interfaces…"

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -243,6 +243,7 @@ function reviewerTerminalFromReviews(data?: ReviewsResponse): ReviewerTerminalTa
 
 type SessionViewProps = {
 	sessionId: string;
+	cloudOrgId?: string;
 };
 
 // Mirrors the left sidebar: a Motion gap takes layout width while a sibling
@@ -375,7 +376,7 @@ function SessionInspectorRail({
 // x-transform). Summary/Reviews/Files share a utility width, while Browser
 // automatically grows into a co-work canvas. Chat readability clamps either
 // profile before the conversation can become unusably narrow.
-export function SessionView({ sessionId }: SessionViewProps) {
+export function SessionView({ sessionId, cloudOrgId }: SessionViewProps) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const workspaceQuery = useWorkspaceSession(sessionId);
@@ -506,7 +507,12 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	useEffect(() => stopTerminalLiveResize, [stopTerminalLiveResize]);
 
 	const session = workspaceQuery.data;
-	const interfaceSwitch = useSessionInterfaceTransition(session?.id, session?.cloud);
+	const interfaceContext = session
+		? (session.cloud ?? null)
+		: cloudOrgId
+			? { orgId: cloudOrgId }
+			: undefined;
+	const interfaceSwitch = useSessionInterfaceTransition(sessionId, interfaceContext);
 	const reviewerQuery = useQuery({
 		queryKey: ["session-reviews", sessionId],
 		enabled: Boolean(

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -534,12 +534,15 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	const cloudSessionWorkspace = directCloudWorkspace ?? routedWorkspace;
 	const session =
 		listedSession ??
-		(cloudOrgId && cloudRouteSession.data && cloudSessionWorkspace
+		(cloudOrgId && cloudRouteSession.data
 			? toCloudWorkspaceSession(
 					cloudRouteSession.data,
 					{
-						id: cloudSessionWorkspace.id,
-						displayName: cloudSessionWorkspace.name,
+						// A session lookup remains authoritative even if the projects list
+						// is refetching. Do not turn a real Cloud row into "Session not
+						// found" merely because its parent list is temporarily absent.
+						id: cloudSessionWorkspace?.id ?? cloudRouteSession.data.projectId,
+						displayName: cloudSessionWorkspace?.name ?? "Cloud project",
 					},
 					cloudOrgId,
 				)

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1203,8 +1203,12 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 			switchError={handoffSwitchError}
 		/>
 	) : null;
+	// Cloud's Chat surface does not have an interactive terminal tab to hover.
+	// Keep the handoff control in the app chrome as a direct, always-visible
+	// button so users can reliably return from Chat UI to TUI.
+	const cloudInterfaceSwitchAction = session?.cloud ? interfaceSwitchInlineStatus : null;
 	const sessionTabActions = (
-		<SessionActionsMenu inlineStatus={interfaceSwitchInlineStatus}>
+		<SessionActionsMenu inlineStatus={session?.cloud ? undefined : interfaceSwitchInlineStatus}>
 			{interfaceSwitchMenuItem}
 			{handoffMenuItem}
 		</SessionActionsMenu>
@@ -1212,9 +1216,10 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	const compactSessionChrome = adaptiveWorkspaceActive;
 	const sessionHeaderActions = (
 		<div
-			className="session-topbar-session-chrome flex shrink-0 items-center"
+			className="session-topbar-session-chrome flex shrink-0 items-center gap-1"
 			data-compact-session-chrome={compactSessionChrome ? "true" : "false"}
 		>
+			{cloudInterfaceSwitchAction}
 			<ShellTopbar compactActions={compactSessionChrome} embedded />
 		</div>
 	);
@@ -1568,7 +1573,10 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 							>
 							{showChatSurface && session?.cloud ? (
 								<CloudSessionChatSurface
+									controllerTransitioning={chatControllerTransitioning}
 									headerActions={sessionHeaderActions}
+									newWorkDisabled={chatNewWorkDisabled}
+									onConversationWorkChange={handleConversationWorkChange}
 									session={session}
 									sessionTabAction={sessionTabActions}
 								/>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1214,7 +1214,7 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	// surface is intended to handle makes the switch disappear entirely.
 	const cloudInterfaceSwitchAction = interfaceContext ? interfaceSwitchInlineStatus : null;
 	const sessionTabActions = (
-		<SessionActionsMenu inlineStatus={session?.cloud ? undefined : interfaceSwitchInlineStatus}>
+		<SessionActionsMenu inlineStatus={isCloudSession ? undefined : interfaceSwitchInlineStatus}>
 			{interfaceSwitchMenuItem}
 			{handoffMenuItem}
 		</SessionActionsMenu>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -989,11 +989,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// the button entirely rather than showing a permanently disabled control.
 	const interfaceSwitchUnsupported = interfaceSwitch.status?.reasonCode === "CHAT_UNSUPPORTED";
 	const showInterfaceSwitchAction = Boolean(
-		!interfaceSwitchUnsupported &&
-		(session?.cloud !== undefined ||
-			interfaceSwitch.status ||
-			interfaceSwitch.isLoading ||
-			interfaceSwitch.statusError),
+		session !== undefined && !interfaceSwitchUnsupported,
 	);
 	const newTerminalError = openShellTerminal.error ? apiErrorMessage(openShellTerminal.error) : undefined;
 	const newShellTerminalAction =

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -54,7 +54,7 @@ import {
 	interfaceTransitionIsActive,
 	useSessionInterfaceTransition,
 } from "../hooks/useSessionInterfaceTransition";
-import { useWorkspaceSession } from "../hooks/useWorkspaceQuery";
+import { toCloudWorkspaceSession, useCloudSessionQuery, useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { useSessionHandoffMenu } from "../hooks/useSessionHandoffMenu";
 import { clearSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
@@ -244,6 +244,7 @@ function reviewerTerminalFromReviews(data?: ReviewsResponse): ReviewerTerminalTa
 type SessionViewProps = {
 	sessionId: string;
 	cloudOrgId?: string;
+	projectId?: string;
 };
 
 // Mirrors the left sidebar: a Motion gap takes layout width while a sibling
@@ -376,10 +377,14 @@ function SessionInspectorRail({
 // x-transform). Summary/Reviews/Files share a utility width, while Browser
 // automatically grows into a co-work canvas. Chat readability clamps either
 // profile before the conversation can become unusably narrow.
-export function SessionView({ sessionId, cloudOrgId }: SessionViewProps) {
+export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewProps) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
-	const workspaceQuery = useWorkspaceSession(sessionId);
+	const workspaceQuery = useWorkspaceQuery();
+	const workspaces = workspaceQuery.data ?? [];
+	const routedWorkspace = projectId ? workspaces.find((workspace) => workspace.id === projectId) : undefined;
+	const isCloudRoute = routedWorkspace?.kind === "cloud";
+	const cloudRouteSession = useCloudSessionQuery(cloudOrgId, sessionId, isCloudRoute);
 	const theme = useResolvedTheme();
 	const prefersReducedMotion = useReducedMotion();
 	const isInspectorOpen = useUiStore((state) => state.inspectorSessions[sessionId]?.isOpen ?? true);
@@ -506,7 +511,20 @@ export function SessionView({ sessionId, cloudOrgId }: SessionViewProps) {
 
 	useEffect(() => stopTerminalLiveResize, [stopTerminalLiveResize]);
 
-	const session = workspaceQuery.data;
+	const listedSession = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
+	// A newly-created Cloud session can be routed before the paginated session
+	// list refresh completes. Resolve that exact row from Cloud so terminal and
+	// interface operations retain {orgId, sessionId} instead of falling back to
+	// the local daemon and surfacing SESSION_NOT_FOUND.
+	const session =
+		listedSession ??
+		(isCloudRoute && routedWorkspace && cloudOrgId && cloudRouteSession.data
+			? toCloudWorkspaceSession(
+					cloudRouteSession.data,
+					{ id: routedWorkspace.id, displayName: routedWorkspace.name },
+					cloudOrgId,
+				)
+			: undefined);
 	const interfaceContext = session
 		? (session.cloud ?? null)
 		: cloudOrgId

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -557,7 +557,7 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	const reviewerQuery = useQuery({
 		queryKey: ["session-reviews", sessionId],
 		enabled: Boolean(
-			window.ao && session && sessionIsActive(session) && !isOrchestratorSession(session) && session.prs.length > 0,
+			window.ao && session && !session.cloud && sessionIsActive(session) && !isOrchestratorSession(session) && session.prs.length > 0,
 		),
 		refetchInterval: (query) => {
 			const data = query.state.data as ReviewsResponse | undefined;

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -384,7 +384,17 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 	const workspaces = workspaceQuery.data ?? [];
 	const routedWorkspace = projectId ? workspaces.find((workspace) => workspace.id === projectId) : undefined;
 	const isCloudRoute = routedWorkspace?.kind === "cloud";
-	const cloudRouteSession = useCloudSessionQuery(cloudOrgId, sessionId, isCloudRoute);
+	const listedSession = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
+	// Project-scoped navigation identifies Cloud routes immediately. The legacy
+	// cross-project route has no project id, so fall back to a direct CP lookup
+	// when the session is absent from the merged list. This keeps a fresh Cloud
+	// tab from ever being resolved through the local daemon during list-cache
+	// races or after restoring an old route.
+	const cloudRouteSession = useCloudSessionQuery(
+		cloudOrgId,
+		sessionId,
+		Boolean(cloudOrgId && (isCloudRoute || !listedSession)),
+	);
 	const theme = useResolvedTheme();
 	const prefersReducedMotion = useReducedMotion();
 	const isInspectorOpen = useUiStore((state) => state.inspectorSessions[sessionId]?.isOpen ?? true);
@@ -511,17 +521,26 @@ export function SessionView({ sessionId, cloudOrgId, projectId }: SessionViewPro
 
 	useEffect(() => stopTerminalLiveResize, [stopTerminalLiveResize]);
 
-	const listedSession = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
 	// A newly-created Cloud session can be routed before the paginated session
 	// list refresh completes. Resolve that exact row from Cloud so terminal and
 	// interface operations retain {orgId, sessionId} instead of falling back to
 	// the local daemon and surfacing SESSION_NOT_FOUND.
+	const directCloudWorkspace = cloudRouteSession.data
+		? workspaces.find(
+				(workspace) =>
+					workspace.kind === "cloud" && workspace.id === cloudRouteSession.data?.projectId,
+			)
+		: undefined;
+	const cloudSessionWorkspace = directCloudWorkspace ?? routedWorkspace;
 	const session =
 		listedSession ??
-		(isCloudRoute && routedWorkspace && cloudOrgId && cloudRouteSession.data
+		(cloudOrgId && cloudRouteSession.data && cloudSessionWorkspace
 			? toCloudWorkspaceSession(
 					cloudRouteSession.data,
-					{ id: routedWorkspace.id, displayName: routedWorkspace.name },
+					{
+						id: cloudSessionWorkspace.id,
+						displayName: cloudSessionWorkspace.name,
+					},
 					cloudOrgId,
 				)
 			: undefined);

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -506,7 +506,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	useEffect(() => stopTerminalLiveResize, [stopTerminalLiveResize]);
 
 	const session = workspaceQuery.data;
-	const interfaceSwitch = useSessionInterfaceTransition(session?.id);
+	const interfaceSwitch = useSessionInterfaceTransition(session?.id, session?.cloud);
 	const reviewerQuery = useQuery({
 		queryKey: ["session-reviews", sessionId],
 		enabled: Boolean(

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -989,7 +989,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// the button entirely rather than showing a permanently disabled control.
 	const interfaceSwitchUnsupported = interfaceSwitch.status?.reasonCode === "CHAT_UNSUPPORTED";
 	const showInterfaceSwitchAction = Boolean(
-		session !== undefined && !interfaceSwitchUnsupported,
+		sessionId && !interfaceSwitchUnsupported,
 	);
 	const newTerminalError = openShellTerminal.error ? apiErrorMessage(openShellTerminal.error) : undefined;
 	const newShellTerminalAction =
@@ -1127,10 +1127,10 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			/>
 		) : null;
 	const interfaceSwitchMenuItem =
-		session && showInterfaceSwitchAction && !activeInterfaceTransition ? (
+		showInterfaceSwitchAction && !activeInterfaceTransition ? (
 			<SessionInterfaceSwitchMenuItem
 				target={interfaceTarget}
-				supported={Boolean(interfaceSwitch.status?.supported)}
+				supported={session?.cloud ? Boolean(interfaceSwitch.status?.supported) : true}
 				disabledReason={
 					interfaceSwitch.isLoading
 						? "Checking whether this agent can switch interfaces…"

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -150,7 +150,7 @@ const DesktopSessionCard = memo(function DesktopSessionCard({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [confirmOpen, setConfirmOpen] = useState(false);
-	const summaries = sessionPRDisplaySummaries(session, useSessionScmSummary(session.id).data);
+	const summaries = sessionPRDisplaySummaries(session, useSessionScmSummary(session.id, !session.cloud).data);
 	const termination = useTerminateSessionState(session.id);
 	const showTerminate = interactive && session.isTerminated !== true && onTerminate;
 	const keepTerminateVisible = session.status === "merged";

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -377,15 +377,14 @@ export function ShellTopbar({
 						{/* Local worker actions share one tight control group. Navigation
 						    remains a separate visual target in the outer top-bar row. */}
 						{!isOrchestrator &&
-							session &&
-							(sessionAction || (!session.cloud && sessionIsActive(session))) ? (
+							(sessionAction || (session && !session.cloud && sessionIsActive(session))) ? (
 							<div
 								className="inline-flex shrink-0 items-center gap-1"
 								data-testid="session-local-actions"
 								style={noDragStyle}
 							>
 								{sessionAction ? <div className="inline-flex shrink-0 items-center">{sessionAction}</div> : null}
-								{!session.cloud && sessionIsActive(session) ? (
+									{session && !session.cloud && sessionIsActive(session) ? (
 									<TopbarKillButton
 										key={session.id}
 										session={session}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -376,14 +376,16 @@ export function ShellTopbar({
 						) : null}
 						{/* Local worker actions share one tight control group. Navigation
 						    remains a separate visual target in the outer top-bar row. */}
-						{!isOrchestrator && session && (sessionAction || sessionIsActive(session)) ? (
+						{!isOrchestrator &&
+							session &&
+							(sessionAction || (!session.cloud && sessionIsActive(session))) ? (
 							<div
 								className="inline-flex shrink-0 items-center gap-1"
 								data-testid="session-local-actions"
 								style={noDragStyle}
 							>
 								{sessionAction ? <div className="inline-flex shrink-0 items-center">{sessionAction}</div> : null}
-								{sessionIsActive(session) ? (
+								{!session.cloud && sessionIsActive(session) ? (
 									<TopbarKillButton
 										key={session.id}
 										session={session}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -42,6 +42,8 @@ import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
 
 type TerminalPaneProps = {
 	session?: WorkspaceSession;
+	/** Changes after a Cloud Chat -> TUI handoff so the PTY is reattached fresh. */
+	terminalGeneration?: string;
 	theme: Theme;
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
@@ -126,6 +128,7 @@ function terminalPropsMatch(left: TerminalPaneProps, right: TerminalPaneProps): 
 function cacheDescriptor(
 	session: WorkspaceSession | undefined,
 	terminalTarget: TerminalTarget | undefined,
+	terminalGeneration?: string,
 ): TerminalCacheDescriptor | null {
 	if (terminalTarget?.kind === "shell") {
 		if (!terminalTargetBelongsToSession(terminalTarget, session?.id)) return null;
@@ -147,7 +150,8 @@ function cacheDescriptor(
 	if (!session?.id || !handleId) return null;
 	const ownerKey = `session:${session.id}:worker`;
 	return {
-		cacheKey: `${ownerKey}|handle:${handleId}`,
+		cacheKey: `${ownerKey}|handle:${handleId}|generation:${terminalGeneration ?? "initial"}`,
+		generation: terminalGeneration,
 		handleId,
 		kind: "worker",
 		ownerKey,
@@ -600,6 +604,7 @@ function CachedTerminalSlot({
 
 export function TerminalPane({
 	session,
+	terminalGeneration,
 	theme,
 	daemonReady,
 	terminalTarget: requestedTerminalTarget,
@@ -700,7 +705,7 @@ export function TerminalPane({
 		inputDisabled,
 		focusRequested,
 	};
-	const descriptor = cacheDescriptor(session, terminalTarget);
+	const descriptor = cacheDescriptor(session, terminalTarget, terminalGeneration);
 	if (cache && descriptor) {
 		return <CachedTerminalSlot descriptor={descriptor} props={props} />;
 	}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -478,6 +478,16 @@ export function TerminalCacheProvider({
 				removeEntry(entry.cacheKey);
 				continue;
 			}
+			// Cloud interface handoff deliberately stops the TUI process before
+			// starting ChatUI. The ticketed mux reports that intentional close as a
+			// normal exit, so retaining this AttachedTerminal would leave it in the
+			// terminal hook's terminal-exited state forever. When the committed mode
+			// returns to TUI, let the slot create a fresh xterm/mux attachment and
+			// replay the newly started process instead of showing the dead renderer.
+			if (entry.kind === "worker" && session?.cloud && session.mode !== "tui") {
+				removeEntry(entry.cacheKey);
+				continue;
+			}
 			if (
 				entry.kind === "worker" &&
 				session &&

--- a/frontend/src/renderer/components/chat/CloudSessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/CloudSessionChatSurface.tsx
@@ -1,0 +1,145 @@
+import { Loader2, SendHorizontal } from "lucide-react";
+import { useMemo, useState, type FormEvent, type ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCloudCp } from "../../hooks/useCloudCp";
+import type { CloudCpClientEvent } from "../../lib/cloud-cp";
+import type { WorkspaceSession } from "../../types/workspace";
+import { cn } from "../../lib/utils";
+
+type ChatLine = {
+	id: string;
+	role: "assistant" | "user";
+	text: string;
+};
+
+function eventText(event: CloudCpClientEvent): string | undefined {
+	if (!event.payload || typeof event.payload !== "object") return undefined;
+	const text = (event.payload as { text?: unknown }).text;
+	return typeof text === "string" && text.trim() !== "" ? text : undefined;
+}
+
+function toChatLines(events: CloudCpClientEvent[]): ChatLine[] {
+	const lines: ChatLine[] = [];
+	for (const event of events) {
+		const text = eventText(event);
+		if (!text) continue;
+		if (event.type === "chat.user_message") {
+			lines.push({ id: String(event.sequence), role: "user", text });
+			continue;
+		}
+		if (event.type === "chat.assistant_delta") {
+			lines.push({ id: String(event.sequence), role: "assistant", text });
+		}
+	}
+	return lines;
+}
+
+/**
+ * Cloud ChatUI reads the control-plane event projection directly. It must not
+ * use the local daemon conversation hooks: a Cloud session id is meaningless
+ * to the loopback daemon and would otherwise produce SESSION_NOT_FOUND as soon
+ * as a TUI -> ChatUI handoff commits.
+ */
+export function CloudSessionChatSurface({
+	session,
+	headerActions,
+	sessionTabAction,
+}: {
+	session: WorkspaceSession;
+	headerActions?: ReactNode;
+	sessionTabAction?: ReactNode;
+}) {
+	const cloud = session.cloud;
+	const { client, ready } = useCloudCp();
+	const queryClient = useQueryClient();
+	const [draft, setDraft] = useState("");
+	const eventsQuery = useQuery({
+		queryKey: ["cloud-chat-events", cloud?.orgId ?? "", session.id],
+		enabled: Boolean(cloud && ready),
+		refetchInterval: 1_000,
+		queryFn: async () => {
+			if (!cloud) return [] as CloudCpClientEvent[];
+			const events: CloudCpClientEvent[] = [];
+			let after = 0;
+			for (;;) {
+				const page = await client.listChatEvents(cloud.orgId, session.id, { after, limit: 500 });
+				events.push(...page.events);
+				if (!page.hasMore) return events;
+				after = page.nextAfter;
+			}
+		},
+	});
+	const send = useMutation({
+		mutationFn: async (text: string) => {
+			if (!cloud) throw new Error("Cloud session context is unavailable.");
+			return client.sendSessionMessage(cloud.orgId, session.id, { text });
+		},
+		onSuccess: () => {
+			setDraft("");
+			void queryClient.invalidateQueries({ queryKey: ["cloud-chat-events", cloud?.orgId ?? "", session.id] });
+		},
+	});
+	const lines = useMemo(() => toChatLines(eventsQuery.data ?? []), [eventsQuery.data]);
+	const submit = (event: FormEvent) => {
+		event.preventDefault();
+		const text = draft.trim();
+		if (!text || send.isPending) return;
+		send.mutate(text);
+	};
+
+	return (
+		<div className="flex h-full min-h-0 flex-col bg-background">
+			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-2">
+				<div className="min-w-0 flex-1 text-sm font-medium">Chat</div>
+				{sessionTabAction}
+				{headerActions}
+			</div>
+			<div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+				{eventsQuery.isLoading ? (
+					<div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+						<Loader2 className="size-4 animate-spin" /> Loading conversation…
+					</div>
+				) : lines.length === 0 ? (
+					<div className="grid h-full place-items-center text-center text-sm text-muted-foreground">
+						ChatUI is ready. Send a message to continue this Cloud agent session.
+					</div>
+				) : (
+					<div className="mx-auto flex max-w-3xl flex-col gap-4">
+						{lines.map((line) => (
+							<div
+								className={cn(
+									"max-w-[85%] whitespace-pre-wrap rounded-lg px-3 py-2 text-sm leading-relaxed",
+									line.role === "user"
+										? "self-end bg-primary text-primary-foreground"
+										: "self-start bg-muted text-foreground",
+								)}
+								key={line.id}
+							>
+								{line.text}
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+			<form className="border-t border-border p-3" onSubmit={submit}>
+				<textarea
+					className="min-h-20 w-full resize-y rounded-md border border-input bg-background p-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+					disabled={send.isPending || !cloud || !ready}
+					onChange={(event) => setDraft(event.target.value)}
+					placeholder="Message the Cloud agent…"
+					value={draft}
+				/>
+				<div className="mt-2 flex items-center justify-between">
+					<span className="text-xs text-destructive">{send.error instanceof Error ? send.error.message : ""}</span>
+					<button
+						className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+						disabled={!draft.trim() || send.isPending || !cloud || !ready}
+						type="submit"
+					>
+						<SendHorizontal className="size-4" /> Send
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/chat/CloudSessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/CloudSessionChatSurface.tsx
@@ -1,44 +1,95 @@
-import { Loader2, SendHorizontal } from "lucide-react";
-import { useMemo, useState, type FormEvent, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, type ReactNode } from "react";
 import { useCloudCp } from "../../hooks/useCloudCp";
 import type { CloudCpClientEvent } from "../../lib/cloud-cp";
+import type { ConversationMessage, ConversationSnapshot, ConversationTurn } from "../../types/conversation";
 import type { WorkspaceSession } from "../../types/workspace";
-import { cn } from "../../lib/utils";
+import { ChatWorkspace } from "./ChatWorkspace";
 
-type ChatLine = {
-	id: string;
-	role: "assistant" | "user";
-	text: string;
+type EventPayload = {
+	attempt?: unknown;
+	error?: unknown;
+	text?: unknown;
+	turnId?: unknown;
 };
 
+function eventPayload(event: CloudCpClientEvent): EventPayload {
+	return event.payload && typeof event.payload === "object" ? (event.payload as EventPayload) : {};
+}
+
 function eventText(event: CloudCpClientEvent): string | undefined {
-	if (!event.payload || typeof event.payload !== "object") return undefined;
-	const text = (event.payload as { text?: unknown }).text;
+	const text = eventPayload(event).text;
 	return typeof text === "string" && text.trim() !== "" ? text : undefined;
 }
 
-function toChatLines(events: CloudCpClientEvent[]): ChatLine[] {
-	const lines: ChatLine[] = [];
+function eventTurnID(event: CloudCpClientEvent): string | undefined {
+	const turnID = eventPayload(event).turnId;
+	return typeof turnID === "string" && turnID !== "" ? turnID : undefined;
+}
+
+/** Builds the shared ChatWorkspace projection from Cloud's durable event log. */
+function toSnapshot(session: WorkspaceSession, events: CloudCpClientEvent[]): ConversationSnapshot {
+	const turns = new Map<string, ConversationTurn>();
+	const assistant = new Map<string, ConversationMessage>();
+	const items: ConversationMessage[] = [];
 	for (const event of events) {
+		const turnID = eventTurnID(event);
+		if (turnID && !turns.has(turnID)) {
+			turns.set(turnID, { id: turnID, state: "queued", requestedAt: event.createdAt });
+		}
+		if (turnID && event.type === "chat.turn_started") {
+			const turn = turns.get(turnID)!;
+			turn.state = "running";
+			turn.startedAt = event.createdAt;
+		}
+		if (turnID && (event.type === "chat.turn_completed" || event.type === "chat.turn_interrupted" || event.type === "chat.turn_aborted")) {
+			const turn = turns.get(turnID)!;
+			turn.state = event.type === "chat.turn_completed" ? "completed" : event.type === "chat.turn_interrupted" ? "interrupted" : "failed";
+			turn.completedAt = event.createdAt;
+			const error = eventPayload(event).error;
+			turn.errorMessage = typeof error === "string" ? error : undefined;
+		}
 		const text = eventText(event);
 		if (!text) continue;
 		if (event.type === "chat.user_message") {
-			lines.push({ id: String(event.sequence), role: "user", text });
+			items.push({
+				kind: "message", id: `cloud-event-${event.sequence}`, sequence: event.sequence, revision: 1,
+				role: "user", origin: "human", text, streaming: false, delivery: "accepted", createdAt: event.createdAt,
+			});
 			continue;
 		}
-		if (event.type === "chat.assistant_delta") {
-			lines.push({ id: String(event.sequence), role: "assistant", text });
+		if (event.type !== "chat.assistant_delta") continue;
+		const assistantKey = turnID ?? `event-${event.sequence}`;
+		const previous = assistant.get(assistantKey);
+		if (previous) {
+			previous.text += text;
+			previous.revision += 1;
+			continue;
 		}
+		const message: ConversationMessage = {
+			kind: "message", id: `cloud-assistant-${assistantKey}`, turnId: turnID, sequence: event.sequence,
+			revision: 1, role: "assistant", origin: "provider", text, streaming: true, createdAt: event.createdAt,
+		};
+		assistant.set(assistantKey, message);
+		items.push(message);
 	}
-	return lines;
+	for (const message of assistant.values()) {
+		if (!message.turnId || turns.get(message.turnId)?.state !== "running") message.streaming = false;
+	}
+	const orderedTurns = [...turns.values()];
+	const hasRunningTurn = orderedTurns.some((turn) => turn.state === "running");
+	return {
+		conversationId: `cloud:${session.id}`, sessionId: session.id, harness: session.provider, mode: "chat",
+		controller: { state: hasRunningTurn ? "busy" : "ready" }, turns: orderedTurns, items,
+		latestSequence: events.at(-1)?.sequence ?? 0, oldestSequence: events[0]?.sequence ?? 1,
+		hasMoreBefore: false, settings: {},
+	};
 }
 
 /**
- * Cloud ChatUI reads the control-plane event projection directly. It must not
- * use the local daemon conversation hooks: a Cloud session id is meaningless
- * to the loopback daemon and would otherwise produce SESSION_NOT_FOUND as soon
- * as a TUI -> ChatUI handoff commits.
+ * The Cloud adapter deliberately renders the same ChatWorkspace as local AO.
+ * Only the data/command transport differs: Cloud reads its durable event log
+ * and posts messages to the control plane instead of calling the loopback daemon.
  */
 export function CloudSessionChatSurface({
 	session,
@@ -52,7 +103,6 @@ export function CloudSessionChatSurface({
 	const cloud = session.cloud;
 	const { client, ready } = useCloudCp();
 	const queryClient = useQueryClient();
-	const [draft, setDraft] = useState("");
 	const eventsQuery = useQuery({
 		queryKey: ["cloud-chat-events", cloud?.orgId ?? "", session.id],
 		enabled: Boolean(cloud && ready),
@@ -69,77 +119,43 @@ export function CloudSessionChatSurface({
 			}
 		},
 	});
+	const invalidate = () =>
+		queryClient.invalidateQueries({ queryKey: ["cloud-chat-events", cloud?.orgId ?? "", session.id] });
 	const send = useMutation({
 		mutationFn: async (text: string) => {
 			if (!cloud) throw new Error("Cloud session context is unavailable.");
 			return client.sendSessionMessage(cloud.orgId, session.id, { text });
 		},
-		onSuccess: () => {
-			setDraft("");
-			void queryClient.invalidateQueries({ queryKey: ["cloud-chat-events", cloud?.orgId ?? "", session.id] });
-		},
+		onSuccess: () => void invalidate(),
 	});
-	const lines = useMemo(() => toChatLines(eventsQuery.data ?? []), [eventsQuery.data]);
-	const submit = (event: FormEvent) => {
-		event.preventDefault();
-		const text = draft.trim();
-		if (!text || send.isPending) return;
-		send.mutate(text);
-	};
+	const snapshot = useMemo(() => toSnapshot(session, eventsQuery.data ?? []), [eventsQuery.data, session]);
+	const activeTurn = snapshot.turns.find((turn) => turn.state === "running");
+	const interrupt = useMutation({
+		mutationFn: async () => {
+			if (!cloud || !activeTurn) return;
+			await client.cancelTurn(cloud.orgId, session.id, activeTurn.id);
+		},
+		onSettled: () => void invalidate(),
+	});
 
 	return (
-		<div className="flex h-full min-h-0 flex-col bg-background">
-			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border px-2">
-				<div className="min-w-0 flex-1 text-sm font-medium">Chat</div>
-				{sessionTabAction}
-				{headerActions}
-			</div>
-			<div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
-				{eventsQuery.isLoading ? (
-					<div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
-						<Loader2 className="size-4 animate-spin" /> Loading conversation…
-					</div>
-				) : lines.length === 0 ? (
-					<div className="grid h-full place-items-center text-center text-sm text-muted-foreground">
-						ChatUI is ready. Send a message to continue this Cloud agent session.
-					</div>
-				) : (
-					<div className="mx-auto flex max-w-3xl flex-col gap-4">
-						{lines.map((line) => (
-							<div
-								className={cn(
-									"max-w-[85%] whitespace-pre-wrap rounded-lg px-3 py-2 text-sm leading-relaxed",
-									line.role === "user"
-										? "self-end bg-primary text-primary-foreground"
-										: "self-start bg-muted text-foreground",
-								)}
-								key={line.id}
-							>
-								{line.text}
-							</div>
-						))}
-					</div>
-				)}
-			</div>
-			<form className="border-t border-border p-3" onSubmit={submit}>
-				<textarea
-					className="min-h-20 w-full resize-y rounded-md border border-input bg-background p-2 text-sm outline-none focus:ring-2 focus:ring-ring"
-					disabled={send.isPending || !cloud || !ready}
-					onChange={(event) => setDraft(event.target.value)}
-					placeholder="Message the Cloud agent…"
-					value={draft}
-				/>
-				<div className="mt-2 flex items-center justify-between">
-					<span className="text-xs text-destructive">{send.error instanceof Error ? send.error.message : ""}</span>
-					<button
-						className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
-						disabled={!draft.trim() || send.isPending || !cloud || !ready}
-						type="submit"
-					>
-						<SendHorizontal className="size-4" /> Send
-					</button>
-				</div>
-			</form>
-		</div>
+		<ChatWorkspace
+			snapshot={snapshot}
+			busy={send.isPending}
+			commandError={
+				eventsQuery.error instanceof Error
+					? eventsQuery.error.message
+					: send.error instanceof Error
+						? send.error.message
+						: undefined
+			}
+			headerActions={headerActions}
+			onInterrupt={activeTurn ? () => interrupt.mutate() : undefined}
+			onSend={(text) => send.mutateAsync(text)}
+			session={session}
+			sessionRole={session.kind}
+			sessionTabAction={sessionTabAction}
+			sessionTitle={session.title}
+		/>
 	);
 }

--- a/frontend/src/renderer/components/chat/CloudSessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/CloudSessionChatSurface.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { useCloudCp } from "../../hooks/useCloudCp";
 import type { CloudCpClientEvent } from "../../lib/cloud-cp";
 import type { ConversationMessage, ConversationSnapshot, ConversationTurn } from "../../types/conversation";
@@ -95,10 +95,20 @@ export function CloudSessionChatSurface({
 	session,
 	headerActions,
 	sessionTabAction,
+	controllerTransitioning,
+	newWorkDisabled,
+	onConversationWorkChange,
 }: {
 	session: WorkspaceSession;
 	headerActions?: ReactNode;
 	sessionTabAction?: ReactNode;
+	controllerTransitioning?: boolean;
+	newWorkDisabled?: boolean;
+	onConversationWorkChange?: (state: {
+		controllerBusy: boolean;
+		hasRunningTurn: boolean;
+		queuedTurnCount: number;
+	}) => void;
 }) {
 	const cloud = session.cloud;
 	const { client, ready } = useCloudCp();
@@ -130,6 +140,14 @@ export function CloudSessionChatSurface({
 	});
 	const snapshot = useMemo(() => toSnapshot(session, eventsQuery.data ?? []), [eventsQuery.data, session]);
 	const activeTurn = snapshot.turns.find((turn) => turn.state === "running");
+	const queuedTurnCount = snapshot.turns.filter((turn) => turn.state === "queued").length;
+	useEffect(() => {
+		onConversationWorkChange?.({
+			controllerBusy: snapshot.controller.state === "busy",
+			hasRunningTurn: Boolean(activeTurn),
+			queuedTurnCount,
+		});
+	}, [activeTurn, onConversationWorkChange, queuedTurnCount, snapshot.controller.state]);
 	const interrupt = useMutation({
 		mutationFn: async () => {
 			if (!cloud || !activeTurn) return;
@@ -142,6 +160,8 @@ export function CloudSessionChatSurface({
 		<ChatWorkspace
 			snapshot={snapshot}
 			busy={send.isPending}
+			controllerTransitioning={controllerTransitioning}
+			newWorkDisabled={newWorkDisabled}
 			commandError={
 				eventsQuery.error instanceof Error
 					? eventsQuery.error.message

--- a/frontend/src/renderer/hooks/useAgentSwitches.ts
+++ b/frontend/src/renderer/hooks/useAgentSwitches.ts
@@ -85,10 +85,10 @@ async function fetchAgentSwitches(sessionId: string): Promise<AgentSwitch[]> {
 	return data?.switches ?? [];
 }
 
-export function useAgentSwitches(sessionId: string) {
+export function useAgentSwitches(sessionId: string, enabled = true) {
 	return useQuery({
 		queryKey: agentSwitchesQueryKey(sessionId),
-		enabled: Boolean(sessionId),
+		enabled: enabled && Boolean(sessionId),
 		queryFn: () => (usesPreviewWorkspaceData ? Promise.resolve([]) : fetchAgentSwitches(sessionId)),
 		// Keep active sagas fresh even if the CDC connection is temporarily
 		// unavailable. Source-recovery endpoints accept work asynchronously, so

--- a/frontend/src/renderer/hooks/useSessionHandoffMenu.ts
+++ b/frontend/src/renderer/hooks/useSessionHandoffMenu.ts
@@ -20,7 +20,7 @@ export function useSessionHandoffMenu(
 	options: UseSessionHandoffMenuOptions = {},
 ) {
 	const sessionId = session?.id ?? "";
-	const agentSwitches = useAgentSwitches(sessionId).data ?? [];
+	const agentSwitches = useAgentSwitches(sessionId, !session?.cloud).data ?? [];
 	const switchMutation = useSwitchAgentState(sessionId);
 	const selectedAgentSwitch = selectDurableAgentSwitch(session?.activeAgentSwitch, agentSwitches);
 	const activeHistorySwitch = findActiveAgentSwitch(agentSwitches);

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
@@ -3,7 +3,8 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { deleteMock, getMock, postMock, putMock } = vi.hoisted(() => ({
+const { cloudCpMock, deleteMock, getMock, postMock, putMock } = vi.hoisted(() => ({
+	cloudCpMock: { client: {}, ready: false, baseUrl: "" },
 	deleteMock: vi.fn(),
 	getMock: vi.fn(),
 	postMock: vi.fn(),
@@ -20,7 +21,7 @@ vi.mock("../lib/api-client", () => ({
 // readiness hooks subscribe to settings/auth queries and can trigger an
 // unrelated refetch while the test is asserting the first response.
 vi.mock("./useCloudCp", () => ({
-	useCloudCp: () => ({ client: {}, ready: false, baseUrl: "" }),
+	useCloudCp: () => cloudCpMock,
 }));
 
 import { useSessionInterfaceTransition } from "./useSessionInterfaceTransition";
@@ -45,9 +46,44 @@ beforeEach(() => {
 	getMock.mockReset();
 	postMock.mockReset();
 	putMock.mockReset();
+	cloudCpMock.client = {};
+	cloudCpMock.ready = false;
+	cloudCpMock.baseUrl = "";
 });
 
 describe("session-scoped interface transition mutations", () => {
+	it("keeps a Cloud handoff active across its status refetch", async () => {
+		const transition = {
+			id: "transition-1",
+			sessionId: "session-a",
+			sourceMode: "tui" as const,
+			targetMode: "chat" as const,
+			policy: "drain" as const,
+			phase: "source_stopping" as const,
+			createdAt: "2026-09-01T00:00:00Z",
+			updatedAt: "2026-09-01T00:00:01Z",
+		};
+		const getSession = vi.fn().mockResolvedValue({
+			session: { interfaceMode: "tui" },
+		});
+		const getInterfaceTransition = vi.fn().mockResolvedValue({
+			supported: true,
+			targetMode: "chat",
+			transition,
+		});
+		cloudCpMock.client = { getSession, getInterfaceTransition };
+		cloudCpMock.ready = true;
+
+		const { result } = renderHook(
+			() => useSessionInterfaceTransition("session-a", { orgId: "org-a" }),
+			{ wrapper },
+		);
+
+		await waitFor(() => expect(result.current.transition?.id).toBe("transition-1"));
+		expect(result.current.transition?.phase).toBe("source_stopping");
+		expect(getMock).not.toHaveBeenCalled();
+	});
+
 	it("keeps a deferred start attached to its initiating session after navigation", async () => {
 		const response = deferred<{
 			data: { ok: boolean };

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.test.tsx
@@ -16,6 +16,13 @@ vi.mock("../lib/api-client", () => ({
 	hasTrustedApiBaseUrl: () => true,
 }));
 
+// Keep these hook tests focused on the local daemon path. The real Cloud
+// readiness hooks subscribe to settings/auth queries and can trigger an
+// unrelated refetch while the test is asserting the first response.
+vi.mock("./useCloudCp", () => ({
+	useCloudCp: () => ({ client: {}, ready: false, baseUrl: "" }),
+}));
+
 import { useSessionInterfaceTransition } from "./useSessionInterfaceTransition";
 
 function wrapper({ children }: { children: ReactNode }) {

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
@@ -148,7 +148,9 @@ export function sessionInterfaceTransitionQueryKey(sessionId: string) {
  */
 export function useSessionInterfaceTransition(
 	sessionId: string | undefined,
-	cloud?: { orgId: string },
+	// undefined: session row is still resolving; null: resolved local session.
+	// This prevents unresolved Cloud tabs from probing the local daemon.
+	cloud?: { orgId: string } | null,
 ) {
 	const queryClient = useQueryClient();
 	const cloudCp = useCloudCp();
@@ -161,7 +163,7 @@ export function useSessionInterfaceTransition(
 	}>();
 	const query = useQuery({
 		queryKey: sessionInterfaceTransitionQueryKey(sessionId ?? ""),
-		enabled: Boolean(sessionId && (isCloud || hasTrustedApiBaseUrl())),
+		enabled: Boolean(sessionId && (isCloud || (cloud === null && hasTrustedApiBaseUrl()))),
 		queryFn: async () => {
 			if (isCloud && cloud) {
 				const [sessionResponse, transitionStatus] = await Promise.all([

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { conversationQueryKey } from "./useConversation";
+import { useCloudCp } from "./useCloudCp";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 export type SessionInterfaceTransition = components["schemas"]["SessionInterfaceTransition"];
@@ -145,8 +146,13 @@ export function sessionInterfaceTransitionQueryKey(sessionId: string) {
  * traffic and the existing session CDC stream still refreshes the committed
  * mode in the workspace model.
  */
-export function useSessionInterfaceTransition(sessionId: string | undefined) {
+export function useSessionInterfaceTransition(
+	sessionId: string | undefined,
+	cloud?: { orgId: string },
+) {
 	const queryClient = useQueryClient();
+	const cloudCp = useCloudCp();
+	const isCloud = Boolean(cloud && cloudCp.ready);
 	const settledRef = useRef<string>("");
 	const refreshAttemptRef = useRef(0);
 	const [refreshingTransition, setRefreshingTransition] = useState<{
@@ -155,8 +161,20 @@ export function useSessionInterfaceTransition(sessionId: string | undefined) {
 	}>();
 	const query = useQuery({
 		queryKey: sessionInterfaceTransitionQueryKey(sessionId ?? ""),
-		enabled: Boolean(sessionId && hasTrustedApiBaseUrl()),
+		enabled: Boolean(sessionId && (isCloud || hasTrustedApiBaseUrl())),
 		queryFn: async () => {
+			if (isCloud && cloud) {
+				const [sessionResponse, transitionStatus] = await Promise.all([
+					cloudCp.client.getSession(cloud.orgId, sessionId as string),
+					cloudCp.client.getInterfaceTransition(cloud.orgId, sessionId as string),
+				]);
+				return {
+					supported: transitionStatus.supported,
+					targetMode: transitionStatus.targetMode,
+					transition: undefined,
+					currentMode: sessionResponse.session.interfaceMode,
+				} as SessionInterfaceTransitionStatus & { currentMode?: SessionInterfaceMode };
+			}
 			const { data, error } = await apiClient.GET(
 				"/api/v1/sessions/{sessionId}/interface-transition",
 				{ params: { path: { sessionId: sessionId as string } } },
@@ -185,6 +203,16 @@ export function useSessionInterfaceTransition(sessionId: string | undefined) {
 			targetSessionId,
 			...input
 		}: StartInterfaceTransitionMutationInput) => {
+			if (isCloud && cloud) {
+				const response = await cloudCp.client.startInterfaceTransition(
+					cloud.orgId,
+					targetSessionId,
+					input,
+				);
+				return response as unknown as {
+					transition: SessionInterfaceTransition;
+				};
+			}
 			const { data, error } = await apiClient.POST(
 				"/api/v1/sessions/{sessionId}/interface-transition",
 				{
@@ -220,6 +248,7 @@ export function useSessionInterfaceTransition(sessionId: string | undefined) {
 	const cancel = useMutation({
 		mutationKey: cancelInterfaceTransitionMutationKey,
 		mutationFn: async ({ targetSessionId }: InterfaceTransitionMutationTarget) => {
+			if (isCloud) return;
 			const { error } = await apiClient.DELETE(
 				"/api/v1/sessions/{sessionId}/interface-transition",
 				{ params: { path: { sessionId: targetSessionId } } },
@@ -239,6 +268,7 @@ export function useSessionInterfaceTransition(sessionId: string | undefined) {
 			targetSessionId,
 			transitionId,
 		}: AcknowledgeInterfaceTransitionNoticeMutationInput) => {
+			if (isCloud) return undefined;
 			const { data, error } = await apiClient.PUT(
 				"/api/v1/sessions/{sessionId}/interface-transition/{transitionId}/notice-acknowledgement",
 				{
@@ -251,6 +281,7 @@ export function useSessionInterfaceTransition(sessionId: string | undefined) {
 			return data;
 		},
 		onSuccess: (response, variables) => {
+			if (!response) return;
 			queryClient.setQueryData<SessionInterfaceTransitionStatus>(
 				sessionInterfaceTransitionQueryKey(variables.targetSessionId),
 				(current) =>

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
@@ -154,7 +154,12 @@ export function useSessionInterfaceTransition(
 ) {
 	const queryClient = useQueryClient();
 	const cloudCp = useCloudCp();
+	// Keep the two-argument call site backwards-compatible for local sessions.
+	// SessionView deliberately passes `undefined` while a tab is unresolved, so
+	// distinguish an omitted context from that explicit unresolved value.
+	const hasSessionContext = arguments.length >= 2;
 	const isCloud = Boolean(cloud && cloudCp.ready);
+	const isLocal = cloud === null || !hasSessionContext;
 	const settledRef = useRef<string>("");
 	const refreshAttemptRef = useRef(0);
 	const [refreshingTransition, setRefreshingTransition] = useState<{
@@ -163,7 +168,7 @@ export function useSessionInterfaceTransition(
 	}>();
 	const query = useQuery({
 		queryKey: sessionInterfaceTransitionQueryKey(sessionId ?? ""),
-		enabled: Boolean(sessionId && (isCloud || (cloud === null && hasTrustedApiBaseUrl()))),
+		enabled: Boolean(sessionId && (isCloud || (isLocal && hasTrustedApiBaseUrl()))),
 		queryFn: async () => {
 			if (isCloud && cloud) {
 				const [sessionResponse, transitionStatus] = await Promise.all([

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
@@ -11,6 +11,7 @@ import { apiClient, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-cli
 import { conversationQueryKey } from "./useConversation";
 import { useCloudCp } from "./useCloudCp";
 import { cloudSessionsQueryKey, workspaceQueryKey } from "./useWorkspaceQuery";
+import type { CloudCpInterfaceTransition } from "../lib/cloud-cp";
 
 export type SessionInterfaceTransition = components["schemas"]["SessionInterfaceTransition"];
 export type SessionInterfaceTransitionStatus =
@@ -48,6 +49,17 @@ type InterfaceTransitionMutationState<TInput> = {
 	status: "error" | "idle" | "pending" | "success";
 	submittedAt: number;
 };
+
+// Cloud and the local daemon deliberately expose the same state-machine
+// vocabulary. Keep this conversion at the control-plane boundary rather than
+// dropping the Cloud transition: without it, the first status refetch after a
+// successful POST erased the optimistic active state, re-enabled the action,
+// and let a second click race the still-running handoff.
+function toSessionInterfaceTransition(
+	transition: CloudCpInterfaceTransition | undefined,
+): SessionInterfaceTransition | undefined {
+	return transition as SessionInterfaceTransition | undefined;
+}
 
 function useInterfaceTransitionMutations<TInput>(mutationKey: readonly unknown[]) {
 	return useMutationState<InterfaceTransitionMutationState<TInput>>({
@@ -178,7 +190,9 @@ export function useSessionInterfaceTransition(
 				return {
 					supported: transitionStatus.supported,
 					targetMode: transitionStatus.targetMode,
-					transition: undefined,
+					reasonCode: transitionStatus.reasonCode,
+					reason: transitionStatus.reason,
+					transition: toSessionInterfaceTransition(transitionStatus.transition),
 					currentMode: sessionResponse.session.interfaceMode,
 				} as SessionInterfaceTransitionStatus & { currentMode?: SessionInterfaceMode };
 			}
@@ -216,8 +230,8 @@ export function useSessionInterfaceTransition(
 					targetSessionId,
 					input,
 				);
-				return response as unknown as {
-					transition: SessionInterfaceTransition;
+				return {
+					transition: toSessionInterfaceTransition(response.transition),
 				};
 			}
 			const { data, error } = await apiClient.POST(

--- a/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
+++ b/frontend/src/renderer/hooks/useSessionInterfaceTransition.ts
@@ -10,7 +10,7 @@ import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { conversationQueryKey } from "./useConversation";
 import { useCloudCp } from "./useCloudCp";
-import { workspaceQueryKey } from "./useWorkspaceQuery";
+import { cloudSessionsQueryKey, workspaceQueryKey } from "./useWorkspaceQuery";
 
 export type SessionInterfaceTransition = components["schemas"]["SessionInterfaceTransition"];
 export type SessionInterfaceTransitionStatus =
@@ -244,11 +244,21 @@ export function useSessionInterfaceTransition(
 					},
 				);
 			}
-			return queryClient
-				.invalidateQueries({
+			const refreshes = [
+				queryClient.invalidateQueries({
 					queryKey: sessionInterfaceTransitionQueryKey(variables.targetSessionId),
-				})
-				.catch(() => undefined);
+				}),
+			];
+			if (isCloud) {
+				// Cloud's session projection owns interfaceMode. Refetch it as soon
+				// as POST accepts the handoff rather than leaving the source TUI
+				// mounted until the ordinary five-second Cloud polling interval.
+				refreshes.push(
+					queryClient.invalidateQueries({ queryKey: cloudSessionsQueryKey }),
+					queryClient.invalidateQueries({ queryKey: ["cloud-session"] }),
+				);
+			}
+			return Promise.all(refreshes).catch(() => undefined);
 		},
 	});
 
@@ -345,17 +355,24 @@ export function useSessionInterfaceTransition(
 		settledRef.current = transitionKey;
 		const attempt = ++refreshAttemptRef.current;
 		setRefreshingTransition({ attempt, key: transitionKey });
-		void Promise.all([
+		const refreshes = [
 			queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
 			queryClient.invalidateQueries({ queryKey: conversationQueryKey(sessionId) }),
-		]).finally(() => {
+		];
+		if (isCloud) {
+			refreshes.push(
+				queryClient.invalidateQueries({ queryKey: cloudSessionsQueryKey }),
+				queryClient.invalidateQueries({ queryKey: ["cloud-session"] }),
+			);
+		}
+		void Promise.all(refreshes).finally(() => {
 			setRefreshingTransition((refreshing) =>
 				refreshing?.key === transitionKey && refreshing.attempt === attempt
 					? undefined
 					: refreshing,
 			);
 		});
-	}, [queryClient, sessionId, transitionActive, transitionKey]);
+	}, [isCloud, queryClient, sessionId, transitionActive, transitionKey]);
 	return {
 		status: query.data,
 		transition,

--- a/frontend/src/renderer/hooks/useSessionScmSummary.ts
+++ b/frontend/src/renderer/hooks/useSessionScmSummary.ts
@@ -24,11 +24,12 @@ export function sessionScmSummaryQueryOptions(sessionId: string) {
 	};
 }
 
-export function useSessionScmSummary(sessionId?: string) {
+export function useSessionScmSummary(sessionId?: string, enabled = true) {
 	return useQuery({
 		queryKey: sessionScmSummaryQueryKey(sessionId),
-		enabled: Boolean(sessionId),
-		queryFn: () => fetchSessionScmSummary(sessionId!),
+		enabled: enabled && Boolean(sessionId),
+		queryFn: () =>
+			usePreviewData ? Promise.resolve(mockSessionScmSummaries[sessionId!] ?? []) : fetchSessionScmSummary(sessionId!),
 		retry: 1,
 	});
 }

--- a/frontend/src/renderer/hooks/useSessionScmSummary.ts
+++ b/frontend/src/renderer/hooks/useSessionScmSummary.ts
@@ -28,8 +28,7 @@ export function useSessionScmSummary(sessionId?: string, enabled = true) {
 	return useQuery({
 		queryKey: sessionScmSummaryQueryKey(sessionId),
 		enabled: enabled && Boolean(sessionId),
-		queryFn: () =>
-			usePreviewData ? Promise.resolve(mockSessionScmSummaries[sessionId!] ?? []) : fetchSessionScmSummary(sessionId!),
+		queryFn: () => fetchSessionScmSummary(sessionId!),
 		retry: 1,
 	});
 }

--- a/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
+++ b/frontend/src/renderer/hooks/useSessionWorkspaceFiles.ts
@@ -92,19 +92,22 @@ export function isChangedWorkspaceFile(file: WorkspaceFileSummary): boolean {
 // Keep the lightweight summary query warm while the inspector is open. The
 // Files view then mounts against current cache data instead of flashing a
 // misleading zero while its first request starts.
-export function useSessionWorkspaceFilesChangedCount(sessionId: string | undefined): number | undefined {
+export function useSessionWorkspaceFilesChangedCount(
+	sessionId: string | undefined,
+	enabled = true,
+): number | undefined {
 	const queryClient = useQueryClient();
 	const query = useQuery({
 		...sessionWorkspaceFilesQueryOptions(sessionId ?? ""),
-		enabled: Boolean(sessionId),
+		enabled: enabled && Boolean(sessionId),
 		// Live invalidations keep the inactive tab fresh; polling starts only
 		// when the full Files view is visible.
 		refetchInterval: false,
 		select: (data: WorkspaceFilesResponse) => data.files.filter(isChangedWorkspaceFile).length,
 	});
 	useEffect(() => {
-		if (!sessionId) return;
+		if (!sessionId || !enabled) return;
 		return subscribeWorkspaceFileChanges(sessionId, queryClient);
-	}, [queryClient, sessionId]);
-	return sessionId ? query.data : undefined;
+	}, [enabled, queryClient, sessionId]);
+	return enabled && sessionId ? query.data : undefined;
 }

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -167,9 +167,9 @@ export const cloudSessionsQueryKey = ["cloud-sessions"] as const;
 // Maps one control-plane session onto the board's session shape. Cloud sessions
 // carry the same status/activity/harness vocabulary as local ones, so the same
 // product-ui mappers apply; fields with no cloud analogue take safe defaults.
-function toCloudWorkspaceSession(
+export function toCloudWorkspaceSession(
 	session: CloudCpSession,
-	project: CloudCpProject,
+	project: Pick<CloudCpProject, "id" | "displayName">,
 	orgId: string,
 ): WorkspaceSession {
 	return {
@@ -253,6 +253,28 @@ export function useCloudSessionsQuery(options: WorkspaceSubscriptionOptions = {}
 			if (orgId === undefined) return [];
 			const response = await client.listSessions(orgId, { limit: 100 });
 			return response.items;
+		},
+	});
+}
+
+// Route-level recovery for a Cloud session that has just been created or whose
+// list cache is stale. The session screen must resolve it through the control
+// plane, never try the local daemon just because the list query has not caught
+// up yet.
+export function useCloudSessionQuery(
+	orgId: string | undefined,
+	sessionId: string,
+	enabled = true,
+) {
+	const { client, ready, baseUrl } = useCloudCp();
+	return useQuery({
+		queryKey: ["cloud-session", baseUrl, orgId ?? "", sessionId],
+		enabled: enabled && ready && orgId !== undefined && sessionId !== "",
+		retry: 1,
+		queryFn: async (): Promise<CloudCpSession | undefined> => {
+			if (orgId === undefined) return undefined;
+			const response = await client.getSession(orgId, sessionId);
+			return response.session;
 		},
 	});
 }

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -183,6 +183,7 @@ function toCloudWorkspaceSession(
 		title: session.displayName || session.id,
 		provider: toAgentProvider(session.harness),
 		kind: session.kind === "orchestrator" ? "orchestrator" : "worker",
+		mode: session.interfaceMode ?? "tui",
 		branch: session.branch || undefined,
 		status: toSessionStatus(session.status, session.isTerminated),
 		isTerminated: session.isTerminated,

--- a/frontend/src/renderer/lib/cloud-cp/client.ts
+++ b/frontend/src/renderer/lib/cloud-cp/client.ts
@@ -35,6 +35,9 @@ import type {
 	CloudCpSessionDeletedResponse,
 	CloudCpSessionListResponse,
 	CloudCpSessionResponse,
+	CloudCpInterfaceTransitionStatusResponse,
+	CloudCpStartInterfaceTransitionRequest,
+	CloudCpStartInterfaceTransitionResponse,
 	CloudCpTerminalTicketRequest,
 	CloudCpTerminalTicketResponse,
 	CloudCpUpdateProjectRequest,
@@ -117,6 +120,13 @@ export interface CloudCpClient {
 		options?: CloudCpMutationOptions,
 	): Promise<CloudCpSessionResponse>;
 	getSession(orgId: string, sessionId: string, options?: CloudCpRequestOptions): Promise<CloudCpSessionResponse>;
+	getInterfaceTransition(orgId: string, sessionId: string, options?: CloudCpRequestOptions): Promise<CloudCpInterfaceTransitionStatusResponse>;
+	startInterfaceTransition(
+		orgId: string,
+		sessionId: string,
+		body: CloudCpStartInterfaceTransitionRequest,
+		options?: CloudCpMutationOptions,
+	): Promise<CloudCpStartInterfaceTransitionResponse>;
 	deleteSession(
 		orgId: string,
 		sessionId: string,
@@ -361,6 +371,14 @@ export function createCloudCpClient(options: CloudCpClientOptions): CloudCpClien
 			}),
 		getSession: (orgId, sessionId, o) =>
 			requestJson("GET", `/orgs/${seg(orgId)}/sessions/${seg(sessionId)}`, { signal: o?.signal }),
+		getInterfaceTransition: (orgId, sessionId, o) =>
+			requestJson("GET", `/orgs/${seg(orgId)}/sessions/${seg(sessionId)}/interface-transition`, { signal: o?.signal }),
+		startInterfaceTransition: (orgId, sessionId, body, o) =>
+			requestJson("POST", `/orgs/${seg(orgId)}/sessions/${seg(sessionId)}/interface-transition`, {
+				body,
+				signal: o?.signal,
+				idempotencyKey: o?.idempotencyKey ?? newIdempotencyKey(),
+			}),
 		deleteSession: (orgId, sessionId, o) =>
 			requestJson("DELETE", `/orgs/${seg(orgId)}/sessions/${seg(sessionId)}`, { signal: o?.signal }),
 		wakePausedSessions: (orgId, o) =>

--- a/frontend/src/renderer/lib/cloud-cp/types.ts
+++ b/frontend/src/renderer/lib/cloud-cp/types.ts
@@ -187,17 +187,37 @@ export interface CloudCpSession {
 
 export interface CloudCpInterfaceTransition {
 	id: string;
-	phase: "completed" | "failed";
+	/** Mirrors the durable Cloud coordinator state machine. */
+	phase:
+		| "requested"
+		| "preflighting"
+		| "draining"
+		| "source_stopping"
+		| "source_stopped"
+		| "target_starting"
+		| "activating"
+		| "completed"
+		| "failed"
+		| "cancelled"
+		| "recovery_required";
 	policy: "drain" | "interrupt";
 	sessionId: string;
 	sourceMode: CloudCpInterfaceMode;
 	targetMode: CloudCpInterfaceMode;
+	nativeConversationId?: string;
+	errorCode?: string;
+	errorDetail?: string;
+	noticeAcknowledgedAt?: string;
+	createdAt: string;
 	updatedAt: string;
+	completedAt?: string;
 }
 
 export interface CloudCpInterfaceTransitionStatusResponse {
 	supported: boolean;
 	targetMode: CloudCpInterfaceMode;
+	reasonCode?: string;
+	reason?: string;
 	transition?: CloudCpInterfaceTransition;
 }
 
@@ -207,8 +227,6 @@ export interface CloudCpStartInterfaceTransitionRequest {
 }
 
 export interface CloudCpStartInterfaceTransitionResponse {
-	ok: boolean;
-	sessionId: string;
 	transition: CloudCpInterfaceTransition;
 }
 

--- a/frontend/src/renderer/lib/cloud-cp/types.ts
+++ b/frontend/src/renderer/lib/cloud-cp/types.ts
@@ -146,6 +146,7 @@ export interface CloudCpProjectDeletedResponse {
 export type CloudCpSessionKind = "worker" | "orchestrator";
 
 export type CloudCpSessionMode = "read-only" | "standard" | "trusted";
+export type CloudCpInterfaceMode = "tui" | "chat";
 
 /** POST /orgs/{orgId}/sessions (requires an Idempotency-Key header). */
 export interface CloudCpCreateSessionRequest {
@@ -172,6 +173,7 @@ export interface CloudCpSession {
 	displayName: string;
 	branch: string;
 	mode: string;
+	interfaceMode: CloudCpInterfaceMode;
 	deniedCommands: string[];
 	activityState: string;
 	status: string;
@@ -181,6 +183,33 @@ export interface CloudCpSession {
 	isTerminated: boolean;
 	createdAt: string;
 	updatedAt: string;
+}
+
+export interface CloudCpInterfaceTransition {
+	id: string;
+	phase: "completed" | "failed";
+	policy: "drain" | "interrupt";
+	sessionId: string;
+	sourceMode: CloudCpInterfaceMode;
+	targetMode: CloudCpInterfaceMode;
+	updatedAt: string;
+}
+
+export interface CloudCpInterfaceTransitionStatusResponse {
+	supported: boolean;
+	targetMode: CloudCpInterfaceMode;
+	transition?: CloudCpInterfaceTransition;
+}
+
+export interface CloudCpStartInterfaceTransitionRequest {
+	targetMode: CloudCpInterfaceMode;
+	policy?: "drain" | "interrupt";
+}
+
+export interface CloudCpStartInterfaceTransitionResponse {
+	ok: boolean;
+	sessionId: string;
+	transition: CloudCpInterfaceTransition;
 }
 
 export interface CloudCpSessionResponse {

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/_shell/projects/$projectId_/sessions/$ses
 });
 
 function ProjectSessionRoute() {
-	const { sessionId } = Route.useParams();
+	const { projectId, sessionId } = Route.useParams();
 	const { org } = useCloudOrg();
-	return <SessionView sessionId={sessionId} cloudOrgId={org?.id} />;
+	return <SessionView sessionId={sessionId} projectId={projectId} cloudOrgId={org?.id} />;
 }

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
+import { useCloudOrg } from "../hooks/useCloudOrg";
 
 export const Route = createFileRoute("/_shell/projects/$projectId_/sessions/$sessionId")({
 	component: ProjectSessionRoute,
@@ -7,5 +8,6 @@ export const Route = createFileRoute("/_shell/projects/$projectId_/sessions/$ses
 
 function ProjectSessionRoute() {
 	const { sessionId } = Route.useParams();
-	return <SessionView sessionId={sessionId} />;
+	const { org } = useCloudOrg();
+	return <SessionView sessionId={sessionId} cloudOrgId={org?.id} />;
 }

--- a/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
+import { useCloudOrg } from "../hooks/useCloudOrg";
 
 export const Route = createFileRoute("/_shell/sessions/$sessionId")({
 	component: SessionRoute,
@@ -7,5 +8,6 @@ export const Route = createFileRoute("/_shell/sessions/$sessionId")({
 
 function SessionRoute() {
 	const { sessionId } = Route.useParams();
-	return <SessionView sessionId={sessionId} />;
+	const { org } = useCloudOrg();
+	return <SessionView sessionId={sessionId} cloudOrgId={org?.id} />;
 }


### PR DESCRIPTION
## Summary\n\n- Integrate the AO Electron renderer with the Cloud control-plane interface-transition API.\n- Carry Cloud organization context into session routes so Cloud sessions do not fall through to the local daemon session resolver.\n- Keep the switch action mounted while a newly selected session is still resolving.\n- Pin the private `ao-cloud` implementation required by this frontend.\n\n## Testing\n\n- `npm run typecheck` (passes in the PR checkout).\n- `git diff --check` (passes).\n- Electron dev launch verified locally.\n\n## Cloud backend prerequisite\n\nThe Cloud control plane must deploy the pinned private `ao-cloud` revision and its PostgreSQL migration before end-to-end switching can work. Without that deployment, the staging API returns HTTP 404 for the interface-transition endpoint. The private implementation cannot be included in this public repository because the fork has read-only access to `Untrivial-ai/ao-cloud`.\n\nOnce deployed, verify that:\n\n- `GET /api/cloud/v1/orgs/{orgId}/sessions/{sessionId}/interface-transition` returns `200`.\n- `POST /api/cloud/v1/orgs/{orgId}/sessions/{sessionId}/interface-transition` returns `202`.\n- A newly created Cloud session opens without `Unknown session (SESSION_NOT_FOUND)`.