### PR TITLE
fix: keep terminal colors in sync with AO theme

### DIFF
--- a/backend/internal/adapters/agent/cursor/cursor.go
+++ b/backend/internal/adapters/agent/cursor/cursor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/termtheme"
 	"github.com/aoagents/agent-orchestrator/backend/pkg/agentruntime"
 )
 
@@ -63,6 +64,7 @@ func (p *Plugin) AugmentRuntimeEnv(env map[string]string, dataDir string) {
 		return
 	}
 	env[cursorDataDirEnv] = cursorDataDir(dataDir)
+	termtheme.Apply(env, dataDir)
 }
 
 // Manifest returns the adapter's static self-description.

--- a/backend/internal/adapters/agent/cursor/cursor_test.go
+++ b/backend/internal/adapters/agent/cursor/cursor_test.go
@@ -464,6 +464,21 @@ func TestAugmentRuntimeEnvUsesAODataDir(t *testing.T) {
 	}
 }
 
+func TestAugmentRuntimeEnvAdvertisesTerminalThemeHint(t *testing.T) {
+	dataDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dataDir, "terminal-theme"), []byte("dark\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{}
+	(&Plugin{resolvedBinary: "cursor-agent"}).AugmentRuntimeEnv(env, dataDir)
+	if env["TERM_THEME"] != "dark" {
+		t.Fatalf("TERM_THEME = %q, want dark", env["TERM_THEME"])
+	}
+	if env["COLORFGBG"] != "15;0" {
+		t.Fatalf("COLORFGBG = %q, want 15;0", env["COLORFGBG"])
+	}
+}
+
 func TestGetAgentHooksUsesCursorDataDirOverride(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "cursor-agent"}
 	workspace := t.TempDir()

--- a/backend/internal/termtheme/termtheme.go
+++ b/backend/internal/termtheme/termtheme.go
@@ -1,0 +1,76 @@
+// Package termtheme injects terminal appearance hints into PTY environments.
+//
+// Cursor Agent probes OSC 11 (~100ms) and defaults to the wrong prompt colors
+// when the reply does not make it back across tmux and the websocket mux. It
+// checks TERM_THEME before that probe, so setting it at spawn is the reliable
+// fix; COLORFGBG is the older portable hint the same CLIs consult next.
+package termtheme
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// FileName is written by the desktop app under AO_DATA_DIR.
+	FileName = "terminal-theme"
+
+	EnvTheme     = "TERM_THEME"
+	EnvColorFgBg = "COLORFGBG"
+)
+
+// Scheme is the resolved terminal appearance, never "system".
+type Scheme string
+
+const (
+	SchemeDark  Scheme = "dark"
+	SchemeLight Scheme = "light"
+)
+
+// Read returns the scheme written by the desktop app. Missing or unreadable
+// files return false so callers leave the PTY env alone rather than forcing
+// dark onto a light canvas.
+func Read(dataDir string) (Scheme, bool) {
+	dataDir = strings.TrimSpace(dataDir)
+	if dataDir == "" {
+		return "", false
+	}
+	raw, err := os.ReadFile(filepath.Join(dataDir, FileName))
+	if err != nil {
+		return "", false
+	}
+	switch strings.ToLower(strings.TrimSpace(string(raw))) {
+	case string(SchemeLight):
+		return SchemeLight, true
+	case string(SchemeDark):
+		return SchemeDark, true
+	default:
+		return "", false
+	}
+}
+
+// Apply writes TERM_THEME and COLORFGBG when a scheme is known and the caller
+// has not already set those keys (project env and explicit tests win).
+func Apply(env map[string]string, dataDir string) {
+	if env == nil {
+		return
+	}
+	scheme, ok := Read(dataDir)
+	if !ok {
+		return
+	}
+	if strings.TrimSpace(env[EnvTheme]) == "" {
+		env[EnvTheme] = string(scheme)
+	}
+	if strings.TrimSpace(env[EnvColorFgBg]) == "" {
+		env[EnvColorFgBg] = colorFgBg(scheme)
+	}
+}
+
+func colorFgBg(scheme Scheme) string {
+	if scheme == SchemeLight {
+		return "0;15"
+	}
+	return "15;0"
+}

--- a/backend/internal/termtheme/termtheme.go
+++ b/backend/internal/termtheme/termtheme.go
@@ -16,7 +16,9 @@ const (
 	// FileName is written by the desktop app under AO_DATA_DIR.
 	FileName = "terminal-theme"
 
-	EnvTheme     = "TERM_THEME"
+	// EnvTheme is the PTY variable Cursor Agent reads before its OSC 11 probe.
+	EnvTheme = "TERM_THEME"
+	// EnvColorFgBg is the portable COLORFGBG hint for terminal appearance.
 	EnvColorFgBg = "COLORFGBG"
 )
 
@@ -24,7 +26,9 @@ const (
 type Scheme string
 
 const (
-	SchemeDark  Scheme = "dark"
+	// SchemeDark is a dark terminal canvas.
+	SchemeDark Scheme = "dark"
+	// SchemeLight is a light terminal canvas.
 	SchemeLight Scheme = "light"
 )
 

--- a/backend/internal/termtheme/termtheme_test.go
+++ b/backend/internal/termtheme/termtheme_test.go
@@ -1,0 +1,68 @@
+package termtheme
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadRejectsMissingAndJunk(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := Read(""); ok {
+		t.Fatal("empty data dir must not report a scheme")
+	}
+	if _, ok := Read(dir); ok {
+		t.Fatal("missing file must not report a scheme")
+	}
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte("system\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := Read(dir); ok {
+		t.Fatal("unrecognized scheme must not report a scheme")
+	}
+}
+
+func TestApplySetsHintsFromFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte("light\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{"KEEP": "yes"}
+	Apply(env, dir)
+	if env[EnvTheme] != "light" {
+		t.Fatalf("TERM_THEME = %q, want light", env[EnvTheme])
+	}
+	if env[EnvColorFgBg] != "0;15" {
+		t.Fatalf("COLORFGBG = %q, want 0;15", env[EnvColorFgBg])
+	}
+	if env["KEEP"] != "yes" {
+		t.Fatalf("KEEP = %q, want yes", env["KEEP"])
+	}
+}
+
+func TestApplyPreservesExplicitOverrides(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte("light\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{EnvTheme: "dark", EnvColorFgBg: "15;0"}
+	Apply(env, dir)
+	if env[EnvTheme] != "dark" {
+		t.Fatalf("TERM_THEME = %q, want caller dark", env[EnvTheme])
+	}
+	if env[EnvColorFgBg] != "15;0" {
+		t.Fatalf("COLORFGBG = %q, want caller 15;0", env[EnvColorFgBg])
+	}
+}
+
+func TestApplyDarkHint(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte("DARK"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{}
+	Apply(env, dir)
+	if env[EnvTheme] != "dark" || env[EnvColorFgBg] != "15;0" {
+		t.Fatalf("env = %#v, want dark / 15;0", env)
+	}
+}

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -100,7 +100,10 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					isFullScreen: async () => false,
 					onFullScreen: () => () => undefined,
 				},
-				theme: { set: async () => undefined },
+				theme: {
+					set: async () => undefined,
+					persistTerminal: async () => undefined,
+				},
 				menu: { action: async () => undefined, notifyShellFocus: () => undefined },
 				clipboard: {
 					writeText: async () => undefined,
@@ -582,7 +585,10 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					isFullScreen: async () => false,
 					onFullScreen: () => () => undefined,
 				},
-				theme: { set: async () => undefined },
+				theme: {
+					set: async () => undefined,
+					persistTerminal: async () => undefined,
+				},
 				menu: { action: async () => undefined, notifyShellFocus: () => undefined },
 				clipboard: { writeText: async () => undefined, readText: async () => "" },
 				daemon: {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -246,6 +246,28 @@ function syncNativeWindowBackground(): void {
 	);
 }
 
+function resolvedDaemonDataDir(): string {
+	const override = process.env.AO_DATA_DIR?.trim();
+	if (override) return override;
+	if (isDev) return path.join(os.homedir(), ".ao", DEV_STATE_SUBDIR, "data");
+	return path.join(os.homedir(), ".ao", "data");
+}
+
+// Cursor Agent reads TERM_THEME at process start. The daemon applies it from
+// this file when spawning a PTY. The renderer writes the resolved light/dark
+// scheme here so it matches the xterm palette (not Electron nativeTheme alone).
+function persistTerminalThemeHint(scheme: "light" | "dark"): void {
+	const dir = resolvedDaemonDataDir();
+	void (async () => {
+		try {
+			await mkdir(dir, { recursive: true, mode: 0o750 });
+			await writeFile(path.join(dir, "terminal-theme"), `${scheme}\n`, { mode: 0o600 });
+		} catch (error) {
+			console.warn("AO: unable to persist terminal theme hint", error);
+		}
+	})();
+}
+
 nativeTheme.on("updated", syncNativeWindowBackground);
 
 // The packaged renderer is served from a custom standard scheme, not file://.
@@ -1681,6 +1703,12 @@ ipcMain.handle("theme:set", (_event, preference: "light" | "dark" | "system") =>
 	if (preference === "light" || preference === "dark" || preference === "system") {
 		nativeTheme.themeSource = preference;
 		syncNativeWindowBackground();
+	}
+});
+
+ipcMain.handle("theme:persist-terminal", (_event, scheme: unknown) => {
+	if (scheme === "light" || scheme === "dark") {
+		persistTerminalThemeHint(scheme);
 	}
 });
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -48,7 +48,7 @@ import {
 } from "./main/ui-settings";
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
-import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { chmod, copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -258,14 +258,15 @@ function resolvedDaemonDataDir(): string {
 // scheme here so it matches the xterm palette (not Electron nativeTheme alone).
 function persistTerminalThemeHint(scheme: "light" | "dark"): void {
 	const dir = resolvedDaemonDataDir();
-	void (async () => {
-		try {
-			await mkdir(dir, { recursive: true, mode: 0o750 });
-			await writeFile(path.join(dir, "terminal-theme"), `${scheme}\n`, { mode: 0o600 });
-		} catch (error) {
-			console.warn("AO: unable to persist terminal theme hint", error);
-		}
-	})();
+	try {
+		mkdirSync(dir, { recursive: true, mode: 0o750 });
+		const target = path.join(dir, "terminal-theme");
+		const temporary = `${target}.${process.pid}.tmp`;
+		writeFileSync(temporary, `${scheme}\n`, { mode: 0o600 });
+		renameSync(temporary, target);
+	} catch (error) {
+		console.warn("AO: unable to persist terminal theme hint", error);
+	}
 }
 
 nativeTheme.on("updated", syncNativeWindowBackground);

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -245,6 +245,8 @@ const api = {
 		// WebContentsView previews (which follow prefers-color-scheme) stay in sync
 		// with the shell. "system" lets both follow the OS.
 		set: (preference: "light" | "dark" | "system") => ipcRenderer.invoke("theme:set", preference) as Promise<void>,
+		persistTerminal: (scheme: "light" | "dark") =>
+			ipcRenderer.invoke("theme:persist-terminal", scheme) as Promise<void>,
 	},
 	menu: {
 		action: (action: string) => ipcRenderer.invoke("menu:action", action) as Promise<void>,

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -588,9 +588,12 @@ describe("CommandPalette actions", () => {
 	it("toggles the theme and closes", async () => {
 		renderPalette();
 		act(() => useUiStore.getState().setCommandPaletteOpen(true));
-		await screen.findByPlaceholderText(/search projects/i);
-		fireEvent.click(screen.getByText("Toggle theme"));
+		const input = await screen.findByPlaceholderText(/search projects/i);
+		fireEvent.change(input, { target: { value: "toggle theme" } });
+		fireEvent.keyDown(input, { key: "Enter" });
 		expect(useUiStore.getState().resolvedTheme).toBe("light");
+		expect(input).toHaveValue("toggle theme");
+		fireEvent.animationEnd(screen.getByLabelText("Command palette"));
 		await waitFor(() => expect(paletteInput()).toBeNull());
 	});
 

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -593,7 +593,6 @@ describe("CommandPalette actions", () => {
 		fireEvent.keyDown(input, { key: "Enter" });
 		expect(useUiStore.getState().resolvedTheme).toBe("light");
 		expect(input).toHaveValue("toggle theme");
-		fireEvent.animationEnd(screen.getByLabelText("Command palette"));
 		await waitFor(() => expect(paletteInput()).toBeNull());
 	});
 

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { ArrowLeft, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type AnimationEvent, type MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useCommandPaletteEnabled } from "../hooks/useCommandPaletteEnabled";
 import { useRestoreSession } from "../hooks/useRestoreSession";
@@ -74,6 +74,7 @@ export function CommandPalette() {
 	const composerBusyRef = useRef(false);
 	const viewRef = useRef(view);
 	viewRef.current = view;
+	const closeResetTimerRef = useRef<number | null>(null);
 
 	const currentSession = params.sessionId ? findSession(workspaces, params.sessionId)?.session : undefined;
 	const currentProjectId = currentSession?.workspaceId ?? params.projectId;
@@ -167,11 +168,43 @@ export function CommandPalette() {
 	}, []);
 
 	const closePalette = useCallback(() => {
+		// Keep the current query visible while Radix plays the closing animation.
+		// Clearing it here causes the palette to flash an empty search before it
+		// is removed, especially when an action also changes the theme.
+		runGenerationRef.current += 1;
 		setOpen(false);
 		setView({ mode: "root" });
 		setPendingDismiss(null);
-		resetTransient();
-	}, [setOpen, resetTransient]);
+		if (closeResetTimerRef.current !== null) window.clearTimeout(closeResetTimerRef.current);
+		// Reduced-motion mode disables the closing animation, so keep a fallback
+		// reset for environments where no animationend event will arrive.
+		closeResetTimerRef.current = window.setTimeout(() => {
+			closeResetTimerRef.current = null;
+			if (!useUiStore.getState().isCommandPaletteOpen) resetTransient();
+		}, 150);
+	}, [resetTransient, setOpen]);
+
+	const resetAfterClose = useCallback(() => {
+		if (closeResetTimerRef.current !== null) {
+			window.clearTimeout(closeResetTimerRef.current);
+			closeResetTimerRef.current = null;
+		}
+		if (!useUiStore.getState().isCommandPaletteOpen) resetTransient();
+	}, [resetTransient]);
+
+	useEffect(
+		() => () => {
+			if (closeResetTimerRef.current !== null) window.clearTimeout(closeResetTimerRef.current);
+		},
+		[],
+	);
+
+	const handlePaletteAnimationEnd = useCallback(
+		(event: AnimationEvent<HTMLDivElement>) => {
+			if (event.target === event.currentTarget) resetAfterClose();
+		},
+		[resetAfterClose],
+	);
 
 	const popToRoot = useCallback(() => {
 		setView({ mode: "root" });
@@ -474,6 +507,7 @@ export function CommandPalette() {
 				open={isOpen}
 				onOpenChange={(open) => (open ? setOpen(true) : requestDismiss("close"))}
 				contentProps={{
+					onAnimationEnd: handlePaletteAnimationEnd,
 					onEscapeKeyDown: (event) => {
 						event.preventDefault();
 						if (event.isComposing) return;

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -2348,7 +2348,7 @@ function SidebarSearchButton({ onOpen }: { onOpen: () => void }) {
 				className={cn(
 					// Filled search trigger (Cursor-style): icon + label.
 					"h-8 gap-2 rounded-lg bg-muted px-2.5 text-sm font-normal text-muted-foreground",
-					"transition-[background-color,color] duration-150 ease-out hover:bg-interactive-hover! hover:text-foreground active:bg-interactive-hover! [&_svg]:size-icon-sm!",
+					"hover:bg-interactive-hover! hover:text-foreground active:bg-interactive-hover! [&_svg]:size-icon-sm!",
 					"group-data-[collapsible=icon]:size-control-board! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:hover:bg-interactive-hover!",
 				)}
 			>

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -75,6 +75,7 @@ vi.mock("./XtermTerminal", () => ({
 				writeln: vi.fn(),
 				showLatestOutput: vi.fn(),
 				prepareForActivation: prepareForActivationMock,
+				notifyCursorColorScheme: vi.fn(),
 				onUserInput: vi.fn(() => disposable),
 				onResize: vi.fn(() => disposable),
 			});

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -1128,6 +1128,7 @@ function AttachedTerminal({
 					onToggleFullscreen={onToggleFullscreen}
 					onVisibleSize={syncVisibleSize}
 					paneScrollsByKeyboard={providerScrollsByKeyboard(provider)}
+					supportsCursorColorScheme={provider === "cursor"}
 					theme={theme}
 				/>
 				{showEmptyState && (

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1148,9 +1148,15 @@ describe("XtermTerminal", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 
-		expect(state.lastTerminal!.dataListeners.size).toBe(0);
+		// One onData hook exists for OSC 10/11/12 color replies (Cursor theme probes).
+		expect(state.lastTerminal!.dataListeners.size).toBe(1);
 		state.lastTerminal!.dataListeners.forEach((listener) => listener("\x1b[A"));
 		expect(onInput).not.toHaveBeenCalled();
+
+		state.lastTerminal!.dataListeners.forEach((listener) =>
+			listener("\x1b]11;rgb:f5f5/f5f5/f4f4\x07"),
+		);
+		expect(onInput).toHaveBeenCalledWith("\x1b]11;rgb:f5f5/f5f5/f4f4\x07", "protocol");
 	});
 
 	it("translates wheel motion into SGR wheel reports for zellij scrollback", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1166,9 +1166,34 @@ describe("XtermTerminal", () => {
 	});
 
 	it("does not install Cursor protocol handling for generic terminals", () => {
-		render(<XtermTerminal theme="dark" />);
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 
-		expect(state.lastTerminal!.dataListeners.size).toBe(0);
+		state.lastTerminal!.dataListeners.forEach((listener) =>
+			listener("\x1b]11;rgb:f5f5/f5f5/f4f4\x07"),
+		);
+		expect(onInput).not.toHaveBeenCalled();
+	});
+
+	it("updates protocol handling when a retained terminal becomes a Cursor terminal", () => {
+		const onInput = vi.fn();
+		const { rerender } = render(
+			<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />,
+		);
+		onInput.mockClear();
+		rerender(
+			<XtermTerminal
+				theme="dark"
+				supportsCursorColorScheme
+				onReady={(terminal) => terminal.onUserInput(onInput)}
+			/>,
+		);
+		onInput.mockClear();
+		state.lastTerminal!.dataListeners.forEach((listener) =>
+			listener("\x1b]11;rgb:f5f5/f5f5/f4f4\x07"),
+		);
+
+		expect(onInput).toHaveBeenCalledWith("\x1b]11;rgb:f5f5/f5f5/f4f4\x07", "protocol");
 	});
 
 	it("translates wheel motion into SGR wheel reports for zellij scrollback", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1146,7 +1146,13 @@ describe("XtermTerminal", () => {
 
 	it("does not forward raw xterm data/control bytes as user input", () => {
 		const onInput = vi.fn();
-		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+		render(
+			<XtermTerminal
+				theme="dark"
+				supportsCursorColorScheme
+				onReady={(terminal) => terminal.onUserInput(onInput)}
+			/>,
+		);
 
 		// One onData hook exists for OSC 10/11/12 color replies (Cursor theme probes).
 		expect(state.lastTerminal!.dataListeners.size).toBe(1);
@@ -1157,6 +1163,12 @@ describe("XtermTerminal", () => {
 			listener("\x1b]11;rgb:f5f5/f5f5/f4f4\x07"),
 		);
 		expect(onInput).toHaveBeenCalledWith("\x1b]11;rgb:f5f5/f5f5/f4f4\x07", "protocol");
+	});
+
+	it("does not install Cursor protocol handling for generic terminals", () => {
+		render(<XtermTerminal theme="dark" />);
+
+		expect(state.lastTerminal!.dataListeners.size).toBe(0);
 	});
 
 	it("translates wheel motion into SGR wheel reports for zellij scrollback", () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -45,7 +45,6 @@ import {
 import {
 	buildOscColorReports,
 	createOscColorReportForwarder,
-	cursorOscProbeRepliesForOutput,
 	type OscTerminalColors,
 } from "../lib/osc-color-report";
 import { buildTerminalThemes } from "../lib/terminal-themes";
@@ -84,6 +83,8 @@ export type XtermTerminalProps = {
 	onVisibleSize?: (cols: number, rows: number) => void;
 	/** Hidden retained terminals keep parsing output but expose no UI overlays. */
 	isVisible?: boolean;
+	/** Cursor Agent understands AO's terminal color protocol; generic terminals do not. */
+	supportsCursorColorScheme?: boolean;
 	/** Move keyboard focus into xterm when a controller needs human input. */
 	focusRequested?: boolean;
 	/**
@@ -380,10 +381,10 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	}, [props.theme, themeStyle]);
 
 	useEffect(() => {
-		if (!termRef.current) return;
+		if (!termRef.current || !props.supportsCursorColorScheme) return;
 		announcedCursorSchemeRef.current = null;
 		notifyCursorSchemeRef.current(props.theme, true, true);
-	}, [props.theme]);
+	}, [props.theme, props.supportsCursorColorScheme]);
 
 	useEffect(() => {
 		const term = termRef.current;
@@ -926,8 +927,10 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		// Forward OSC 10/11/12 color replies only. Cursor's theme probe issues these
 		// on stdout; xterm answers on onData. Other onData bytes must not reach the
 		// PTY or agent TUIs break (Codex, etc.).
-		const oscColorForwarder = createOscColorReportForwarder((report) => emitUserInput(report, "protocol"));
-		const oscColorInput = term.onData((data) => oscColorForwarder.push(data));
+		const oscColorForwarder = props.supportsCursorColorScheme
+			? createOscColorReportForwarder((report) => emitUserInput(report, "protocol"))
+			: null;
+		const oscColorInput = oscColorForwarder ? term.onData((data) => oscColorForwarder.push(data)) : null;
 		const keyInput = term.onKey(({ key }) => emitUserInput(key, "keyboard"));
 
 		// Translate wheel motion into SGR wheel reports for the pane (see
@@ -1114,10 +1117,9 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				}
 				if (hasEsc) {
 					const chunk = new TextDecoder().decode(data);
-					const colors = terminalColorsForScheme(callbacksRef.current.theme);
-					const oscReply = cursorOscProbeRepliesForOutput(chunk, colors);
-					if (oscReply) emitUserInput(oscReply, "protocol");
-					const reply = cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme);
+					const reply = props.supportsCursorColorScheme
+						? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)
+						: null;
 					if (reply) {
 						announcedCursorSchemeRef.current = null;
 						notifyCursorScheme(callbacksRef.current.theme, true, true);
@@ -1131,7 +1133,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			writeln: (line) => term.writeln(line, scheduleScrollbarUpdate),
 			showLatestOutput,
 			prepareForActivation,
-			notifyCursorColorScheme: () => notifyCursorScheme(callbacksRef.current.theme, false, true),
+			notifyCursorColorScheme: () => {
+				if (callbacksRef.current.supportsCursorColorScheme) {
+					notifyCursorScheme(callbacksRef.current.theme, false, true);
+				}
+			},
 			onUserInput: (listener) => {
 				userInputListeners.add(listener);
 				return { dispose: () => userInputListeners.delete(listener) };
@@ -1178,8 +1184,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			clearSuppressNativePaste();
 			for (const timer of schemeRetryTimers) window.clearTimeout(timer);
 			schemeRetryTimers = [];
-			oscColorForwarder.dispose();
-			oscColorInput.dispose();
+			oscColorForwarder?.dispose();
+			oscColorInput?.dispose();
 			keyInput.dispose();
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -38,6 +38,16 @@ import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { isWebLink, openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { isMacPlatform } from "../lib/platform";
 import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
+import {
+	buildCursorColorSchemeNotification,
+	cursorColorSchemeReplyForOutput,
+} from "../lib/cursor-color-scheme";
+import {
+	buildOscColorReports,
+	createOscColorReportForwarder,
+	cursorOscProbeRepliesForOutput,
+	type OscTerminalColors,
+} from "../lib/osc-color-report";
 import { buildTerminalThemes } from "../lib/terminal-themes";
 import { useUiStore, type Theme } from "../stores/ui-store";
 import { TerminalSearch } from "./TerminalSearch";
@@ -293,6 +303,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	const scrollbarTrackRef = useRef<HTMLDivElement | null>(null);
 	const scrollbarThumbRef = useRef<HTMLDivElement | null>(null);
 	const termRef = useRef<Terminal | null>(null);
+	const notifyCursorSchemeRef = useRef<(scheme: Theme, force?: boolean, retry?: boolean) => void>(() => {});
+	const announcedCursorSchemeRef = useRef<Theme | null>(null);
 	const searchAddonRef = useRef<SearchAddon | null>(null);
 	const fitRef = useRef<(() => void) | null>(null);
 	const contextMenuActionsRef = useRef<TerminalContextMenuActions | null>(null);
@@ -366,6 +378,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		const { dark, light } = buildTerminalThemes();
 		term.options.theme = props.theme === "dark" ? dark : light;
 	}, [props.theme, themeStyle]);
+
+	useEffect(() => {
+		if (!termRef.current) return;
+		announcedCursorSchemeRef.current = null;
+		notifyCursorSchemeRef.current(props.theme, true, true);
+	}, [props.theme]);
 
 	useEffect(() => {
 		const term = termRef.current;
@@ -607,6 +625,28 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			if (data.length === 0) return;
 			userInputListeners.forEach((listener) => listener(data, source));
 		};
+		const terminalColorsForScheme = (scheme: Theme): OscTerminalColors => {
+			const palette = buildTerminalThemes()[scheme];
+			return {
+				foreground: palette.foreground ?? "",
+				background: palette.background ?? "",
+				cursor: palette.cursor ?? palette.foreground ?? "",
+			};
+		};
+		const notifyCursorScheme = (scheme: Theme, force = false, retry = false) => {
+			if (!force && announcedCursorSchemeRef.current === scheme) return;
+			announcedCursorSchemeRef.current = scheme;
+			const bytes =
+				buildOscColorReports(terminalColorsForScheme(scheme)) +
+				buildCursorColorSchemeNotification(scheme);
+			const send = () => emitUserInput(bytes, "protocol");
+			send();
+			if (!retry) return;
+			for (const timer of schemeRetryTimers) window.clearTimeout(timer);
+			schemeRetryTimers = [50, 200].map((delayMs) => window.setTimeout(send, delayMs));
+		};
+		let schemeRetryTimers: number[] = [];
+		notifyCursorSchemeRef.current = notifyCursorScheme;
 		const pasteText = (text: string) => {
 			const prepared = preparePastedText(text);
 			const bracketed = term.modes.bracketedPasteMode && term.options.ignoreBracketedPasteMode !== true;
@@ -883,6 +923,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		// those bytes through the mux writes dirty input into the real Codex PTY and
 		// corrupts the TUI. Keyboard is the only safe generic text path here; paste,
 		// composition, shortcuts, and wheel reports are emitted explicitly below.
+		// Forward OSC 10/11/12 color replies only. Cursor's theme probe issues these
+		// on stdout; xterm answers on onData. Other onData bytes must not reach the
+		// PTY or agent TUIs break (Codex, etc.).
+		const oscColorForwarder = createOscColorReportForwarder((report) => emitUserInput(report, "protocol"));
+		const oscColorInput = term.onData((data) => oscColorForwarder.push(data));
 		const keyInput = term.onKey(({ key }) => emitUserInput(key, "keyboard"));
 
 		// Translate wheel motion into SGR wheel reports for the pane (see
@@ -1059,14 +1104,34 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// Forward xterm's write callback: it fires once THIS chunk has been
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
-			write: (data, done) =>
+			write: (data, done) => {
+				let hasEsc = false;
+				for (let i = 0; i < data.length; i++) {
+					if (data[i] === 0x1b) {
+						hasEsc = true;
+						break;
+					}
+				}
+				if (hasEsc) {
+					const chunk = new TextDecoder().decode(data);
+					const colors = terminalColorsForScheme(callbacksRef.current.theme);
+					const oscReply = cursorOscProbeRepliesForOutput(chunk, colors);
+					if (oscReply) emitUserInput(oscReply, "protocol");
+					const reply = cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme);
+					if (reply) {
+						announcedCursorSchemeRef.current = null;
+						notifyCursorScheme(callbacksRef.current.theme, true, true);
+					}
+				}
 				term.write(data, () => {
 					scheduleScrollbarUpdate();
 					done?.();
-				}),
+				});
+			},
 			writeln: (line) => term.writeln(line, scheduleScrollbarUpdate),
 			showLatestOutput,
 			prepareForActivation,
+			notifyCursorColorScheme: () => notifyCursorScheme(callbacksRef.current.theme, false, true),
 			onUserInput: (listener) => {
 				userInputListeners.add(listener);
 				return { dispose: () => userInputListeners.delete(listener) };
@@ -1111,7 +1176,13 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			contextMenuActionsRef.current = null;
 			cancelActivationPreparation?.();
 			clearSuppressNativePaste();
+			for (const timer of schemeRetryTimers) window.clearTimeout(timer);
+			schemeRetryTimers = [];
+			oscColorForwarder.dispose();
+			oscColorInput.dispose();
 			keyInput.dispose();
+			notifyCursorSchemeRef.current = () => {};
+			announcedCursorSchemeRef.current = null;
 			userInputListeners.clear();
 			try {
 				term.dispose();

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -927,10 +927,14 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		// Forward OSC 10/11/12 color replies only. Cursor's theme probe issues these
 		// on stdout; xterm answers on onData. Other onData bytes must not reach the
 		// PTY or agent TUIs break (Codex, etc.).
-		const oscColorForwarder = props.supportsCursorColorScheme
-			? createOscColorReportForwarder((report) => emitUserInput(report, "protocol"))
-			: null;
-		const oscColorInput = oscColorForwarder ? term.onData((data) => oscColorForwarder.push(data)) : null;
+		// Retained terminals can change providers without remounting. Keep the
+		// listener mounted, but consult the latest props before forwarding so a
+		// terminal that changes from Cursor to another agent never emits protocol
+		// bytes into the new agent's PTY.
+		const oscColorForwarder = createOscColorReportForwarder((report) => {
+			if (callbacksRef.current.supportsCursorColorScheme) emitUserInput(report, "protocol");
+		});
+		const oscColorInput = term.onData((data) => oscColorForwarder.push(data));
 		const keyInput = term.onKey(({ key }) => emitUserInput(key, "keyboard"));
 
 		// Translate wheel motion into SGR wheel reports for the pane (see
@@ -1117,7 +1121,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				}
 				if (hasEsc) {
 					const chunk = new TextDecoder().decode(data);
-					const reply = props.supportsCursorColorScheme
+					const reply = callbacksRef.current.supportsCursorColorScheme
 						? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)
 						: null;
 					if (reply) {
@@ -1184,8 +1188,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			clearSuppressNativePaste();
 			for (const timer of schemeRetryTimers) window.clearTimeout(timer);
 			schemeRetryTimers = [];
-			oscColorForwarder?.dispose();
-			oscColorInput?.dispose();
+			oscColorForwarder.dispose();
+			oscColorInput.dispose();
 			keyInput.dispose();
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -658,7 +658,7 @@ export function ChatComposer({
 			<form
 				onSubmit={(event) => event.preventDefault()}
 				data-attached-top={attachedTop && !queuedDock ? true : undefined}
-				className="cursor-chat-composer relative flex flex-col gap-1.5 border px-3 py-3 transition-[background,border-color,box-shadow]"
+				className="cursor-chat-composer relative flex flex-col gap-1.5 border px-3 py-3"
 			>
 				{approval}
 				{commandError ? (
@@ -696,7 +696,7 @@ export function ChatComposer({
 						editor.current?.focus();
 					}
 				}}
-				className="cursor-chat-composer relative flex cursor-text flex-col gap-1.5 border px-3 pt-3 pb-3 transition-[background,border-color,box-shadow]"
+				className="cursor-chat-composer relative flex cursor-text flex-col gap-1.5 border px-3 pt-3 pb-3"
 			>
 				{menuOpen && trigger ? (
 					<ComposerSuggestMenu

--- a/frontend/src/renderer/components/chat/HumanMessageEditor.tsx
+++ b/frontend/src/renderer/components/chat/HumanMessageEditor.tsx
@@ -61,7 +61,7 @@ export function HumanMessageEditor({
 	}
 
 	return (
-		<div className="cursor-chat-composer relative flex w-full max-w-3xl flex-col gap-1.5 border px-4 py-3 transition-[background,border-color,box-shadow]">
+		<div className="cursor-chat-composer relative flex w-full max-w-3xl flex-col gap-1.5 border px-4 py-3">
 		<textarea
 			ref={textarea}
 			value={draft}

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -96,6 +96,7 @@ type FakeTerminal = AttachableTerminal & {
 	compose(data: string): void;
 	shortcut(data: string): void;
 	wheel(data: string): void;
+	protocol(data: string): void;
 	emitResize(cols: number, rows: number): void;
 	completeWrites(): void;
 };
@@ -123,6 +124,7 @@ function createFakeTerminal(): FakeTerminal {
 			terminal.latestOutputRequests += 1;
 		},
 		prepareForActivation: async () => undefined,
+		notifyCursorColorScheme: () => undefined,
 		onUserInput: (listener) => {
 			inputListeners.add(listener);
 			return { dispose: () => inputListeners.delete(listener) };
@@ -136,6 +138,7 @@ function createFakeTerminal(): FakeTerminal {
 		compose: (data) => inputListeners.forEach((listener) => listener(data, "composition")),
 		shortcut: (data) => inputListeners.forEach((listener) => listener(data, "shortcut")),
 		wheel: (data) => inputListeners.forEach((listener) => listener(data, "wheel")),
+		protocol: (data) => inputListeners.forEach((listener) => listener(data, "protocol")),
 		emitResize: (cols, rows) => resizeListeners.forEach((listener) => listener({ cols, rows })),
 		completeWrites: () => {
 			for (const callback of terminal.pendingWriteCallbacks.splice(0)) callback();
@@ -261,6 +264,28 @@ describe("useTerminalSession", () => {
 		view.rerender({ daemonReady: true, isVisible: true, inputDisabled: false });
 		terminal.typeKeys("safe now\r");
 		expect(muxes[0].inputs).toEqual([["handle-1", "safe now\r"]]);
+	});
+
+	it("forwards protocol bytes while hidden or while a controller owns typing", () => {
+		const { view, terminal, muxes } = setup({ inputDisabled: true, isVisible: false });
+		act(() => muxes[0].emitOpened("handle-1"));
+
+		terminal.protocol("\x1b[?997;2n");
+		expect(muxes[0].inputs).toEqual([["handle-1", "\x1b[?997;2n"]]);
+
+		view.rerender({ daemonReady: true, isVisible: false, inputDisabled: true });
+		terminal.typeKeys("blocked");
+		expect(muxes[0].inputs).toEqual([["handle-1", "\x1b[?997;2n"]]);
+	});
+
+	it("queues protocol bytes until the mux opens, then flushes them", () => {
+		const { terminal, muxes } = setup();
+
+		terminal.protocol("\x1b[?997;1n");
+		expect(muxes[0].inputs).toEqual([]);
+
+		act(() => muxes[0].emitOpened("handle-1"));
+		expect(muxes[0].inputs).toEqual([["handle-1", "\x1b[?997;1n"]]);
 	});
 
 	it("keeps receiving output while hidden without accepting input or resizing the PTY", () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -24,7 +24,7 @@ import { workspaceQueryKey } from "./useWorkspaceQuery";
  * The slice of xterm's Terminal the attachment needs. Structural, so tests can
  * drive the hook with a tiny fake instead of a real xterm + DOM.
  */
-export type TerminalUserInputSource = "keyboard" | "paste" | "composition" | "shortcut" | "wheel";
+export type TerminalUserInputSource = "keyboard" | "paste" | "composition" | "shortcut" | "wheel" | "protocol";
 
 export type AttachableTerminal = {
 	cols: number;
@@ -45,6 +45,8 @@ export type AttachableTerminal = {
 	 * without exposing an intermediate row.
 	 */
 	prepareForActivation: () => Promise<void>;
+	/** Tell Cursor Agent the live light/dark scheme (private 997 notification). */
+	notifyCursorColorScheme: () => void;
 	onUserInput: (listener: (data: string, source: TerminalUserInputSource) => void) => { dispose: () => void };
 	onResize: (listener: (size: { cols: number; rows: number }) => void) => { dispose: () => void };
 };
@@ -208,6 +210,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		replayTailQuietTimer: null as ReturnType<typeof setTimeout> | null,
 		replayTailCapTimer: null as ReturnType<typeof setTimeout> | null,
 		replayTailPending: false,
+		queuedProtocolInputs: [] as string[],
 		// The current attachment's flush, published so teardown can land buffered
 		// bytes instead of discarding them (the closure lives inside connect).
 		flushReplay: null as ((preserveBeforeTeardown?: boolean) => void) | null,
@@ -262,6 +265,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		r.replayChunks = [];
 		r.replayBytes = 0;
 		r.replayTailPending = false;
+		r.queuedProtocolInputs = [];
 		r.lastPublishedGrid = null;
 		// Nothing is buffering any more, so nothing should stay covered. connect()
 		// re-arms the gate immediately after calling this, in the same tick, so
@@ -580,6 +584,8 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				setError(undefined);
 				setHasAttached(true);
 				transition("attached");
+				terminal.notifyCursorColorScheme();
+				flushQueuedProtocolInputs();
 				// Bound the gate from here: the daemon fires onOpen from setPTY and
 				// starts copyOut immediately after, so the replay is imminent and
 				// the cap now measures the burst rather than the connect handshake.
@@ -646,13 +652,31 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				}
 			}),
 		);
-		const input = terminal.onUserInput((data) => {
-			if (
-				!isCurrentAttachment(generation, handle, mux) ||
-				!r.inputReady ||
-				optionsRef.current.inputDisabled ||
-				optionsRef.current.isVisible === false
-			) {
+		const flushQueuedProtocolInputs = () => {
+			if (!isCurrentAttachment(generation, handle, mux) || !r.inputReady) return;
+			for (const queued of r.queuedProtocolInputs) {
+				mux.sendInput(handle, queued);
+			}
+			r.queuedProtocolInputs = [];
+		};
+		const input = terminal.onUserInput((data, source) => {
+			if (!isCurrentAttachment(generation, handle, mux)) {
+				return;
+			}
+			if (source === "protocol") {
+				if (!r.inputReady) {
+					r.queuedProtocolInputs.push(data);
+					return;
+				}
+				mux.sendInput(handle, data);
+				return;
+			}
+			if (!r.inputReady) {
+				return;
+			}
+			// Agent color-scheme bytes are not human input — forwarding them must not
+			// flush the replay gate or reveal the tail (that was the theme-toggle jank).
+			if (optionsRef.current.inputDisabled || optionsRef.current.isVisible === false) {
 				return;
 			}
 			// Input is accepted from `opened`, which lands before the replay — so a
@@ -890,6 +914,11 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		},
 		[teardownMux],
 	);
+
+	useEffect(() => {
+		if (!replaySettled) return;
+		runtime.current.terminal?.notifyCursorColorScheme();
+	}, [replaySettled]);
 
 	return { attach, state, error, replaySettled, hasAttached, syncVisibleSize };
 }

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -41,6 +41,7 @@ export const aoBridge: AoBridge =
 		},
 		theme: {
 			set: async () => undefined,
+			persistTerminal: async () => undefined,
 		},
 		menu: {
 			action: async () => undefined,

--- a/frontend/src/renderer/lib/cursor-color-scheme.test.ts
+++ b/frontend/src/renderer/lib/cursor-color-scheme.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCursorColorSchemeNotification,
+	cursorColorSchemeReplyForOutput,
+} from "./cursor-color-scheme";
+
+describe("buildCursorColorSchemeNotification", () => {
+	it("emits cursor-agent light/dark scheme notifications", () => {
+		expect(buildCursorColorSchemeNotification("light")).toBe("\x1b[?997;2n");
+		expect(buildCursorColorSchemeNotification("dark")).toBe("\x1b[?997;1n");
+	});
+});
+
+describe("cursorColorSchemeReplyForOutput", () => {
+	it("answers cursor-agent color-scheme probes with the live theme", () => {
+		expect(cursorColorSchemeReplyForOutput("\x1b[?997;2n", "light")).toBe("\x1b[?997;2n");
+		expect(cursorColorSchemeReplyForOutput("\x1b[?2031h", "light")).toBe("\x1b[?997;2n");
+		expect(cursorColorSchemeReplyForOutput("\x1b[?2031h", "dark")).toBe("\x1b[?997;1n");
+		expect(cursorColorSchemeReplyForOutput("hello", "light")).toBeNull();
+	});
+});

--- a/frontend/src/renderer/lib/cursor-color-scheme.ts
+++ b/frontend/src/renderer/lib/cursor-color-scheme.ts
@@ -1,0 +1,24 @@
+// Cursor Agent registers DEC mode 2031 and listens on stdin for ESC [ ? 997 ; 1 n
+// (dark) or 997 ; 2 n (light). It may also emit those sequences on stdout as
+// probes; AO must answer on stdin with the live scheme notification.
+
+export type ColorScheme = "light" | "dark";
+
+const CURSOR_COLOR_SCHEME_MODE_ON = "\x1b[?2031h";
+const CURSOR_COLOR_SCHEME_QUERY = /\x1b\[\?997;[12]n|\[\?997;[12]n/g;
+
+export function buildCursorColorSchemeNotification(scheme: ColorScheme): string {
+	return scheme === "light" ? "\x1b[?997;2n" : "\x1b[?997;1n";
+}
+
+export function cursorColorSchemeReplyForOutput(chunk: string, theme: ColorScheme): string | null {
+	if (chunk.includes(CURSOR_COLOR_SCHEME_MODE_ON) || cursorColorSchemeQueryInOutput(chunk)) {
+		return buildCursorColorSchemeNotification(theme);
+	}
+	return null;
+}
+
+function cursorColorSchemeQueryInOutput(data: string): boolean {
+	CURSOR_COLOR_SCHEME_QUERY.lastIndex = 0;
+	return CURSOR_COLOR_SCHEME_QUERY.test(data);
+}

--- a/frontend/src/renderer/lib/osc-color-report.test.ts
+++ b/frontend/src/renderer/lib/osc-color-report.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildOscColorReports,
+	createOscColorReportForwarder,
+	cursorOscProbeRepliesForOutput,
+	hexToOscRgb,
+	isOscColorReport,
+} from "./osc-color-report";
+
+const palette = {
+	foreground: "#24292f",
+	background: "#f5f5f4",
+	cursor: "#24292f",
+};
+
+describe("isOscColorReport", () => {
+	it("accepts xterm OSC 10/11/12 background reports", () => {
+		expect(isOscColorReport("\x1b]11;rgb:f5f5/f5f5/f4f4\x1b\\")).toBe(true);
+		expect(isOscColorReport("\x1b]10;rgb:2424/2929/2f2f\x07")).toBe(true);
+		expect(isOscColorReport("\x1b]12;rgb:2424/2929/2f2f\x1b\\")).toBe(true);
+	});
+
+	it("rejects other terminal-generated replies", () => {
+		expect(isOscColorReport("\x1b[?1;2c")).toBe(false);
+		expect(isOscColorReport("\x1b[6n")).toBe(false);
+		expect(isOscColorReport("\x1b[?997;1n")).toBe(false);
+		expect(isOscColorReport("\x1b]0;title\x07")).toBe(false);
+	});
+});
+
+describe("hexToOscRgb", () => {
+	it("expands hex colors into xterm rgb sequences", () => {
+		expect(hexToOscRgb("#f5f5f4")).toBe("rgb:f5f5/f5f5/f4f4");
+	});
+});
+
+describe("buildOscColorReports", () => {
+	it("emits fg/bg/cursor OSC replies for the live palette", () => {
+		expect(buildOscColorReports(palette)).toBe(
+			"\x1b]10;rgb:2424/2929/2f2f\x07\x1b]11;rgb:f5f5/f5f5/f4f4\x07\x1b]12;rgb:2424/2929/2f2f\x07",
+		);
+	});
+});
+
+describe("cursorOscProbeRepliesForOutput", () => {
+	it("answers OSC probes seen on the PTY output stream", () => {
+		expect(cursorOscProbeRepliesForOutput("\x1b]11;?\x07", palette)).toBe(
+			"\x1b]11;rgb:f5f5/f5f5/f4f4\x07",
+		);
+		expect(cursorOscProbeRepliesForOutput("\x1b]10;?\x1b]11;?\x07", palette)).toBe(
+			"\x1b]10;rgb:2424/2929/2f2f\x07\x1b]11;rgb:f5f5/f5f5/f4f4\x07",
+		);
+		expect(cursorOscProbeRepliesForOutput("hello", palette)).toBeNull();
+	});
+});
+
+describe("createOscColorReportForwarder", () => {
+	it("buffers split OSC replies before forwarding", () => {
+		const forwarded: string[] = [];
+		const forwarder = createOscColorReportForwarder((report) => forwarded.push(report));
+		forwarder.push("\x1b]11;rgb:f5f5/f5f5/f");
+		expect(forwarded).toEqual([]);
+		forwarder.push("4f4\x07");
+		expect(forwarded).toEqual(["\x1b]11;rgb:f5f5/f5f5/f4f4\x07"]);
+		forwarder.dispose();
+	});
+});

--- a/frontend/src/renderer/lib/osc-color-report.ts
+++ b/frontend/src/renderer/lib/osc-color-report.ts
@@ -1,0 +1,101 @@
+// xterm answers OSC 10/11/12 queries (fg/bg/cursor) on its onData stream.
+// Cursor Agent's theme probe issues those queries on stdout and listens on
+// stdin; AO must return the live palette or the prompt bar defaults to dark.
+
+export type OscTerminalColors = {
+	foreground: string;
+	background: string;
+	cursor: string;
+};
+
+const OSC_COLOR_REPORT = /^\u001b](?:10|11|12);[^\u0007\u001b]*(?:\u0007|\u001b\\)$/;
+const OSC_COLOR_PROBE = /\u001b\](?:10|11|12);\?/;
+
+export function isOscColorReport(data: string): boolean {
+	return OSC_COLOR_REPORT.test(data);
+}
+
+/** Convert #rrggbb or browser-resolved rgb() into xterm's rgb:RRRR/GGGG/BBBB form. */
+export function hexToOscRgb(hex: string): string {
+	const normalized = hex.replace(/^#/, "").trim();
+	if (normalized.length === 3) {
+		const [r, g, b] = normalized;
+		return `rgb:${r}${r}${r}/${g}${g}${g}/${b}${b}${b}`;
+	}
+	const r = normalized.slice(0, 2);
+	const g = normalized.slice(2, 4);
+	const b = normalized.slice(4, 6);
+	return `rgb:${r}${r}/${g}${g}/${b}${b}`;
+}
+
+function cssColorToHex(color: string): string {
+	if (!color) return "000000";
+	if (color.startsWith("#")) {
+		const hex = color.slice(1);
+		return hex.length === 3 ? hex.split("").map((c) => c + c).join("") : hex.slice(0, 6);
+	}
+	if (typeof document === "undefined") return "000000";
+	const probe = document.createElement("span");
+	probe.style.color = color;
+	document.documentElement.appendChild(probe);
+	const resolved = getComputedStyle(probe).color;
+	probe.remove();
+	const match = resolved.match(/(\d+)\D+(\d+)\D+(\d+)/);
+	if (!match) return "000000";
+	return [match[1], match[2], match[3]]
+		.map((channel) => Number(channel).toString(16).padStart(2, "0"))
+		.join("");
+}
+
+function oscColorReport(slot: 10 | 11 | 12, cssColor: string): string {
+	return `\x1b]${slot};${hexToOscRgb(cssColorToHex(cssColor))}\x07`;
+}
+
+export function buildOscColorReports(colors: OscTerminalColors): string {
+	return (
+		oscColorReport(10, colors.foreground) +
+		oscColorReport(11, colors.background) +
+		oscColorReport(12, colors.cursor)
+	);
+}
+
+/** Answer OSC 10/11/12 probes emitted on the PTY output stream. */
+export function cursorOscProbeRepliesForOutput(chunk: string, colors: OscTerminalColors): string | null {
+	if (!OSC_COLOR_PROBE.test(chunk)) return null;
+	const replies: string[] = [];
+	if (chunk.includes("]10;?")) replies.push(oscColorReport(10, colors.foreground));
+	if (chunk.includes("]11;?")) replies.push(oscColorReport(11, colors.background));
+	if (chunk.includes("]12;?")) replies.push(oscColorReport(12, colors.cursor));
+	return replies.length > 0 ? replies.join("") : null;
+}
+
+/** Buffer split xterm onData chunks and forward only complete OSC 10/11/12 replies. */
+export function createOscColorReportForwarder(emit: (report: string) => void): {
+	push: (data: string) => void;
+	dispose: () => void;
+} {
+	let buffer = "";
+	const complete = /^\u001b](?:10|11|12);[^\u0007\u001b]*(?:\u0007|\u001b\\)/;
+
+	return {
+		push(data: string) {
+			buffer += data;
+			for (;;) {
+				const match = buffer.match(complete);
+				if (!match) break;
+				emit(match[0]);
+				buffer = buffer.slice(match[0].length);
+			}
+			const oscStart = buffer.indexOf("\x1b]");
+			if (oscStart === -1) {
+				buffer = "";
+				return;
+			}
+			if (oscStart > 0) buffer = buffer.slice(oscStart);
+			if (!/^\u001b](?:10|11|12);/.test(buffer)) buffer = "";
+		},
+		dispose() {
+			buffer = "";
+		},
+	};
+}

--- a/frontend/src/renderer/lib/osc-color-report.ts
+++ b/frontend/src/renderer/lib/osc-color-report.ts
@@ -10,6 +10,7 @@ export type OscTerminalColors = {
 
 const OSC_COLOR_REPORT = /^\u001b](?:10|11|12);[^\u0007\u001b]*(?:\u0007|\u001b\\)$/;
 const OSC_COLOR_PROBE = /\u001b\](?:10|11|12);\?/;
+const MAX_OSC_BUFFER_LENGTH = 16 * 1024;
 
 export function isOscColorReport(data: string): boolean {
 	return OSC_COLOR_REPORT.test(data);
@@ -80,6 +81,12 @@ export function createOscColorReportForwarder(emit: (report: string) => void): {
 	return {
 		push(data: string) {
 			buffer += data;
+			if (buffer.length > MAX_OSC_BUFFER_LENGTH) {
+				// An unterminated OSC must not retain arbitrary PTY output forever.
+				// Keep only the newest bounded suffix; the normal start-sequence check
+				// below will discard it unless it is still a valid partial report.
+				buffer = buffer.slice(-MAX_OSC_BUFFER_LENGTH);
+			}
 			for (;;) {
 				const match = buffer.match(complete);
 				if (!match) break;

--- a/frontend/src/renderer/lib/terminal-themes.ts
+++ b/frontend/src/renderer/lib/terminal-themes.ts
@@ -16,6 +16,10 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 		: cssVar("--color-bg-terminal-opaque") || cssVar("--color-bg-terminal");
 	const terminalForeground = namedThemeActive ? cssVar("--foreground") : cssVar("--color-text-terminal");
 	const terminalCursor = namedThemeActive ? cssVar("--primary") : cssVar("--color-working");
+	// Collapse ANSI black into the plate. Agent TUIs (Cursor's prompt bar) fill
+	// rows with "black"; leaving the slot as a true dark color paints a black
+	// stripe on the light canvas. Same approach as packages/mobile/lib/theme.ts.
+	const ansiBlack = terminalBg;
 	const dark: ITheme = {
 		background: terminalBg,
 		foreground: terminalForeground,
@@ -23,7 +27,7 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-dark"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive"),
-		black: cssVar("--color-term-black"),
+		black: ansiBlack,
 		red: cssVar("--color-term-red"),
 		green: cssVar("--color-term-green"),
 		yellow: cssVar("--color-term-yellow"),
@@ -52,7 +56,7 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-light"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive-light"),
-		black: cssVar("--color-term-black"),
+		black: ansiBlack,
 		red: cssVar("--color-term-red"),
 		green: cssVar("--color-term-green"),
 		yellow: cssVar("--color-term-yellow"),

--- a/frontend/src/renderer/lib/theme.test.ts
+++ b/frontend/src/renderer/lib/theme.test.ts
@@ -10,6 +10,7 @@ describe("runThemeTransition", () => {
 		Reflect.deleteProperty(document, "startViewTransition");
 		delete document.documentElement.dataset.theme;
 		delete document.documentElement.dataset.styleTheme;
+		delete document.documentElement.dataset.themeTransition;
 		document.documentElement.style.colorScheme = "";
 	});
 
@@ -50,6 +51,20 @@ describe("runThemeTransition", () => {
 		expect(startViewTransition).toHaveBeenCalledOnce();
 		expect(update).toHaveBeenCalledOnce();
 		expect(document.documentElement.dataset.styleTheme).toBe("github");
+		expect(document.documentElement.dataset.themeTransition).toBe("active");
+	});
+
+	it("suppresses per-element transitions while the theme tokens swap", async () => {
+		Reflect.deleteProperty(document, "startViewTransition");
+		const update = vi.fn(() => {
+			applyDocumentTheme("dark");
+		});
+
+		runThemeTransition(update);
+
+		expect(document.documentElement.dataset.themeTransition).toBe("active");
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+		expect(document.documentElement.dataset.themeTransition).toBeUndefined();
 	});
 });
 

--- a/frontend/src/renderer/lib/theme.ts
+++ b/frontend/src/renderer/lib/theme.ts
@@ -83,11 +83,34 @@ export function applyDocumentThemeStyle(style: ThemeStyle): void {
  * `transition-colors` / background tweens are hidden behind a snapshot.
  * Default VT crossfade is disabled in CSS — this is an instant cut.
  * Falls back to a plain update when the API is unavailable.
+ *
+ * Also sets `data-theme-transition` so global CSS can zero out
+ * transition-duration while tokens swap; otherwise composer, search, and
+ * switch chrome tween from the old palette and look stuck white/black.
  */
 export function runThemeTransition(update: () => void): void {
-	if (typeof document === "undefined" || typeof document.startViewTransition !== "function") {
+	if (typeof document === "undefined") return;
+
+	const root = document.documentElement;
+	const finish = () => {
+		requestAnimationFrame(() => {
+			delete root.dataset.themeTransition;
+		});
+	};
+	const run = () => {
+		root.dataset.themeTransition = "active";
 		update();
+		void root.offsetHeight;
+	};
+
+	if (typeof document.startViewTransition !== "function") {
+		run();
+		finish();
 		return;
 	}
-	document.startViewTransition(update);
+
+	const transition = document.startViewTransition(() => {
+		run();
+	});
+	void transition.finished.finally(finish);
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -617,6 +617,12 @@ function ShellLayout() {
 		void aoBridge.theme?.set(themePreference);
 	}, [themePreference]);
 
+	// Cursor Agent reads TERM_THEME at spawn from this file. Persist the same
+	// resolved light/dark scheme the terminal uses, not nativeTheme alone.
+	useEffect(() => {
+		void aoBridge.theme?.persistTerminal(resolvedTheme);
+	}, [resolvedTheme]);
+
 	// Follow OS appearance while the user keeps Theme on System — updates
 	// resolvedTheme (and thus React consumers) without writing light/dark to storage.
 	useEffect(() => {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -25,6 +25,16 @@
 	animation: none;
 	mix-blend-mode: normal;
 }
+
+/* While data-theme flips, kill per-element color tweens (composer, search,
+   switches). Without this they animate for hundreds of ms and read as a
+   white box in dark mode / a black strip in light mode. */
+:root[data-theme-transition="active"] *,
+:root[data-theme-transition="active"] *::before,
+:root[data-theme-transition="active"] *::after {
+	transition-duration: 0ms !important;
+	transition-delay: 0ms !important;
+}
 @theme inline {
 	--font-sans: var(--font-family-base);
 	--font-mono: var(--font-family-mono);
@@ -2190,6 +2200,8 @@ html.sidebar-reordering * {
 	border-color: var(--composer-border);
 	background: var(--composer-bg);
 	box-shadow: none;
+	/* Border only — background must snap with the view-transition theme cut. */
+	transition: border-color 150ms ease-out;
 }
 
 .cursor-chat-composer[data-attached-top] {

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -130,6 +130,7 @@ if (typeof window !== "undefined") {
 		},
 		theme: {
 			set: async () => undefined,
+			persistTerminal: async () => undefined,
 		},
 		menu: {
 			action: async () => undefined,


### PR DESCRIPTION
## Summary

Cursor Agent can render its prompt bar with the wrong colors when AO switches between light and dark mode. This PR synchronizes the resolved AO theme with Cursor sessions at startup and while they are running.

## What changed

- Persist the resolved light/dark terminal scheme under AO's data directory.
- Inject `TERM_THEME` and `COLORFGBG` only into Cursor Agent processes.
- Answer Cursor's private color-scheme protocol and OSC 10/11/12 color probes through a dedicated protocol-input path.
- Scope protocol handling to Cursor terminals so shells, Codex, and other TUIs receive no unsolicited control bytes.
- Bound OSC response buffering and avoid duplicate OSC replies.
- Keep terminal theme-hint writes ordered and atomic.
- Prevent theme transitions from flashing terminal/composer chrome.
- Preserve the Cmd+K search query until the palette close animation completes, including reduced-motion environments.

## Root cause

Cursor probes terminal appearance through OSC and private CSI sequences. The renderer previously allowed those replies to be lost or treated like ordinary input, while new theme changes could leave Cursor's prompt bar using stale colors.

## Verification

- `go test ./internal/termtheme ./internal/adapters/agent/cursor`
- `vitest run src/renderer/lib/osc-color-report.test.ts src/renderer/lib/cursor-color-scheme.test.ts`
- `npm --prefix frontend test -- src/renderer/components/XtermTerminal.test.tsx src/renderer/components/CommandPalette.test.tsx` — 120 tests passed
- `git diff --check`

The full frontend typecheck is currently blocked by the shared `packages/product-ui` workspace because its React/motion dependencies are unavailable in this checkout.

## Manual test plan

- [ ] Start a Cursor session in light mode; prompt bar is light.
- [ ] Start a Cursor session in dark mode; prompt bar is dark.
- [ ] Toggle the theme with an existing Cursor session open; colors update without restarting.
- [ ] Open a shell or non-Cursor terminal; no unsolicited control bytes or input corruption.
- [ ] Search in Cmd+K, select Toggle theme with Enter, and confirm the query does not flash empty while the palette closes.
