### PR TITLE
feat(chat): refine queued message dock

### DIFF
--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -27,12 +27,14 @@
  */
 
 import {
+	cloneElement,
 	useCallback,
 	useEffect,
 	useId,
 	useMemo,
 	useRef,
 	useState,
+	isValidElement,
 	type ClipboardEvent,
 	type DragEvent,
 	type FormEvent,
@@ -180,6 +182,7 @@ export function ChatComposer({
 	const [isComposing, setIsComposing] = useState(false);
 	const [dragging, setDragging] = useState(false);
 	const [sendError, setSendError] = useState<string | null>(null);
+	const [steerNextRequest, setSteerNextRequest] = useState(0);
 	// The DOM event is the source of truth while React catches up with the draft
 	// transition. This keeps Enter-after-fast-typing from observing stale state.
 	const textRef = useRef("");
@@ -249,18 +252,32 @@ export function ChatComposer({
 	// path. Treating it as unavailable — rather than steering the text and
 	// dropping the files, or refusing on an empty body with attachments staged —
 	// keeps the armed state something the composer can actually honour.
-	const canSteerDraft = Boolean(canSteer && onSteer) && !staged && !savingQueuedEdit;
+	const canSteerNext =
+		Boolean(canSteer && onSteer) &&
+		!disabled &&
+		!hasDraft &&
+		!savingQueuedEdit &&
+		Boolean(queuedDock);
 	const sendHint = menuOpen
 		? "Enter to insert"
 		: savingQueuedEdit
 			? "⏎ save edit"
-			: willQueue && canSteerDraft
-				? "⏎ queue · ⌘⏎ steer"
+			: willQueue && canSteerNext
+				? "⏎ queue · Enter steer"
 				: willQueue
 					? "⏎ queue"
 					: "Enter to send";
 	const draftSeedId = draftSeed?.id;
 	const draftSeedText = draftSeed?.text;
+	const queuedDockWithSteer = isValidElement(queuedDock)
+		? cloneElement(
+				queuedDock as ReactElement<{
+					canSteerNext?: boolean;
+					steerNextRequest?: number;
+				}>,
+				{ canSteerNext, steerNextRequest },
+			)
+		: queuedDock;
 
 	const focusEditor = useCallback(() => {
 		if (!autoFocus || disabled) return;
@@ -536,7 +553,7 @@ export function ChatComposer({
 	}
 
 	const handleEnterKey = useCallback(
-		(event: globalThis.KeyboardEvent): boolean => {
+		(_event: globalThis.KeyboardEvent): boolean => {
 			const liveSnapshot = editor.current?.getSnapshot();
 			if (liveSnapshot) textRef.current = liveSnapshot.text;
 			const liveTrigger = liveSnapshot?.trigger;
@@ -552,11 +569,14 @@ export function ChatComposer({
 				return true;
 			}
 
-			const wantsSteer = (event.metaKey || event.ctrlKey) && canSteerDraft;
-			void submit(undefined, wantsSteer);
+			if (canSteerNext) {
+				setSteerNextRequest((request) => request + 1);
+				return true;
+			}
+			void submit();
 			return true;
 		},
-		[canSteerDraft, onCompact, pick, suggestionsFor],
+		[canSteerNext, onCompact, pick, suggestionsFor],
 	);
 
 	function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
@@ -617,26 +637,6 @@ export function ChatComposer({
 		void fileAttachments.addFiles(files);
 	}
 
-	// Track Cmd/Ctrl for the send-button click path without re-rendering the composer
-	// on every modifier key event.
-	const modifierHeldRef = useRef(false);
-	useEffect(() => {
-		const onKey = (event: globalThis.KeyboardEvent) => {
-			modifierHeldRef.current = event.metaKey || event.ctrlKey;
-		};
-		const onBlur = () => {
-			modifierHeldRef.current = false;
-		};
-		window.addEventListener("keydown", onKey);
-		window.addEventListener("keyup", onKey);
-		window.addEventListener("blur", onBlur);
-		return () => {
-			window.removeEventListener("keydown", onKey);
-			window.removeEventListener("keyup", onKey);
-			window.removeEventListener("blur", onBlur);
-		};
-	}, []);
-
 	const attachmentError = fileAttachments.error ?? sendError ?? commandError;
 	const withQueueStack = (form: ReactElement) =>
 		queuedDock ? (
@@ -645,7 +645,7 @@ export function ChatComposer({
 					className="cursor-chat-composer-queue queue-dock-enter relative z-10 mx-auto mb-2 w-[calc(100%-2rem)]"
 					data-testid="queued-composer-dock"
 				>
-					{queuedDock}
+					{queuedDockWithSteer}
 				</div>
 				{form}
 			</div>
@@ -672,10 +672,9 @@ export function ChatComposer({
 
 	return withQueueStack(
 		<form
-				// Clicking send while Cmd/Ctrl is held has to mean what the indicator
-				// beside it says. Reading the same armed state the chip paints keeps the
-				// pointer and keyboard paths from disagreeing about where the message goes.
-				onSubmit={(event) => void submit(event, modifierHeldRef.current && canSteerDraft)}
+				// The send button always submits the typed draft. Steering is reserved for
+				// the empty-input Enter path handled by the editor above.
+			onSubmit={(event) => void submit(event)}
 				onDragOver={(event) => {
 					if (!canAttach) return;
 					event.preventDefault();

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -31,6 +31,7 @@ import {
 	useCallback,
 	useEffect,
 	useId,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -199,6 +200,7 @@ export function ChatComposer({
 	const stagedDelivery = useRef<{ signature: string; paths: string[] } | null>(null);
 	const submitInFlight = useRef<Promise<void> | null>(null);
 	const menuId = useId();
+	const hadQueuedDockRef = useRef(Boolean(queuedDock));
 	const previousTrigger = useRef<ComposerTrigger | undefined>(undefined);
 	const triggerRef = useRef<ComposerTrigger | undefined>(undefined);
 
@@ -284,6 +286,17 @@ export function ChatComposer({
 	useEffect(() => {
 		focusEditor();
 	}, [autoFocusKey, focusEditor]);
+
+	const hasQueuedDock = Boolean(queuedDock);
+	const restoreFocusAfterQueueAppears =
+		hasQueuedDock &&
+		!hadQueuedDockRef.current &&
+		typeof document !== "undefined" &&
+		document.activeElement?.getAttribute("aria-label") === "Message the agent";
+	useLayoutEffect(() => {
+		hadQueuedDockRef.current = hasQueuedDock;
+		if (restoreFocusAfterQueueAppears) editor.current?.focus();
+	}, [hasQueuedDock, restoreFocusAfterQueueAppears]);
 
 	useEffect(() => {
 		if (!autoFocus) return;

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -671,7 +671,7 @@ export function ChatComposer({
 	const attachmentError = fileAttachments.error ?? sendError ?? commandError;
 	const withQueueStack = (form: ReactElement) =>
 		(
-			<div className="relative flex w-full flex-col">
+			<div className="relative mx-auto flex w-full max-w-3xl flex-col">
 				{queuedDock ? (
 				<div
 					className="cursor-chat-composer-queue queue-dock-enter relative z-10 mx-auto mb-2 w-[calc(100%-2rem)]"

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -27,20 +27,18 @@
  */
 
 import {
-  cloneElement,
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-  isValidElement,
-  type ClipboardEvent,
-  type DragEvent,
-  type FormEvent,
-  type KeyboardEvent,
-  type ReactElement,
-  type ReactNode,
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+	type ClipboardEvent,
+	type DragEvent,
+	type FormEvent,
+	type KeyboardEvent,
+	type ReactElement,
+	type ReactNode,
 } from "react";
 import { ArrowUp, Loader2, Plus, Square, X } from "lucide-react";
 import { Button } from "../ui/button";
@@ -48,21 +46,16 @@ import { cn } from "../../lib/utils";
 import { apiErrorMessage } from "../../lib/api-client";
 import { ComposerSuggestMenu } from "./ComposerSuggestMenu";
 import {
-  ComposerEditor,
-  type ComposerEditorHandle,
-  type ComposerEditorSnapshot,
-  type ComposerTrigger,
+	ComposerEditor,
+	type ComposerEditorHandle,
+	type ComposerEditorSnapshot,
+	type ComposerTrigger,
 } from "./ComposerEditor";
+import { moveHighlight, rankFiles, rankSkills, type Suggestion } from "./composerSuggest";
 import {
-  moveHighlight,
-  rankFiles,
-  rankSkills,
-  type Suggestion,
-} from "./composerSuggest";
-import {
-  isSupportedImageAttachment,
-  useFileAttachments,
-  type FileAttachmentPayload,
+	isSupportedImageAttachment,
+	useFileAttachments,
+	type FileAttachmentPayload,
 } from "../../hooks/useFileAttachments";
 import { File } from "lucide-react";
 import type { ChatSkill } from "../../types/conversation";
@@ -73,849 +66,781 @@ import type { ChatSkill } from "../../types/conversation";
  * spawn or mid-conversation.
  */
 function withAttachmentReferences(text: string, paths: string[]): string {
-  if (paths.length === 0) return text;
-  const lead = text.trim() === "" ? "" : `${text}\n\n`;
-  return `${lead}Attached files (read these files in the workspace):\n${paths.map((path) => `- ${path}`).join("\n")}`;
+	if (paths.length === 0) return text;
+	const lead = text.trim() === "" ? "" : `${text}\n\n`;
+	return `${lead}Attached files (read these files in the workspace):\n${paths.map((path) => `- ${path}`).join("\n")}`;
 }
 
 export function ChatComposer({
-  onSend,
-  busy,
-  willQueue,
-  disabled,
-  settings,
-  approval,
-  skills = [],
-  filePaths = [],
-  filePathsTruncated,
-  onStageAttachments,
-  nativeImages,
-  onSteer,
-  onInterrupt,
-  canSteer,
-  sendPending,
-  steerPending,
-  steerRefusal,
-  draftSeed,
-  editingQueuedTurnId,
-  onCancelQueuedEdit,
-  savingQueuedEditPending,
-  commandError,
-  attachedTop = false,
-  queuedDock,
-  onCompact,
-  compacting,
-  compactUnavailable,
-  compactBlocked,
-  autoFocusKey,
-  autoFocus = true,
+	onSend,
+	busy,
+	willQueue,
+	disabled,
+	settings,
+	approval,
+	skills = [],
+	filePaths = [],
+	filePathsTruncated,
+	onStageAttachments,
+	nativeImages,
+	onSteer,
+	onInterrupt,
+	canSteer,
+	sendPending,
+	steerPending,
+	steerRefusal,
+	draftSeed,
+	editingQueuedTurnId,
+	onCancelQueuedEdit,
+	savingQueuedEditPending,
+	commandError,
+	attachedTop = false,
+	queuedDock,
+	onCompact,
+	compacting,
+	compactUnavailable,
+	compactBlocked,
+	autoFocusKey,
+	autoFocus = true,
 }: {
-  onSend: (
-    text: string,
-    attachments?: FileAttachmentPayload[],
-  ) => void | Promise<unknown>;
-  settings?: ReactNode;
-  /** A provider decision that temporarily replaces ordinary message entry. */
-  approval?: ReactNode;
-  /** A send is in flight. */
-  busy?: boolean;
-  /** The agent is mid-turn, so this message is held until the turn ends. */
-  willQueue?: boolean;
-  disabled?: boolean;
-  /** The provider's skills. Empty leaves `/` an ordinary character. */
-  skills?: ChatSkill[];
-  /** Worktree-relative paths offered for `@`. Empty leaves `@` ordinary. */
-  filePaths?: string[];
-  /** The path list was capped, so the menu says so rather than implying it is all. */
-  filePathsTruncated?: boolean;
-  /**
-   * Writes staged files into the worktree and answers with the paths the agent
-   * can open. Absent means files cannot be delivered, and no attach control is
-   * offered at all.
-   */
-  onStageAttachments?: (
-    attachments: FileAttachmentPayload[],
-  ) => Promise<string[]>;
-  /** Send the same staged bytes as native ACP image blocks when negotiated. */
-  nativeImages?: boolean;
-  /**
-   * Deliver this text into the turn already running. Absent means the harness
-   * cannot steer and the choice is never offered.
-   */
-  onSteer?: (text: string) => Promise<unknown>;
-  /** Stop the turn already running when there is no draft to send. */
-  onInterrupt?: () => void;
-  /** A turn is actually running, so there is something to steer into. */
-  canSteer?: boolean;
-  /** A send mutation is in flight for this session. */
-  sendPending?: boolean;
-  steerPending?: boolean;
-  /** Why the last steer was refused. */
-  steerRefusal?: string;
-  /** A selected history message to load into the composer as a new draft. */
-  draftSeed?: { id: string; text: string };
-  /** A queued turn being edited in the composer instead of the dock. */
-  editingQueuedTurnId?: string;
-  onCancelQueuedEdit?: () => void;
-  /** The queued edit mutation is in flight for the turn being edited. */
-  savingQueuedEditPending?: boolean;
-  /** A failed send, approval, interrupt, or settings mutation. */
-  commandError?: string;
-  /** A queued-message dock owns the shared rounded top edge. */
-  attachedTop?: boolean;
-  /** Queued messages rendered above the composer. */
-  queuedDock?: ReactNode;
-  /** Run AO's built-in `/compact` command instead of sending it to the agent. */
-  onCompact?: () => void | Promise<unknown>;
-  /** The provider is already compacting this conversation. */
-  compacting?: boolean;
-  /** A typed provider refusal from the last compaction attempt. */
-  compactUnavailable?: string;
-  /** A running turn must be stopped before its history can be compacted. */
-  compactBlocked?: boolean;
-  /** Changes when the owning chat surface should reclaim composer focus. */
-  autoFocusKey?: string;
-  /** Whether this composer is currently visible and should take focus. */
-  autoFocus?: boolean;
+	onSend: (text: string, attachments?: FileAttachmentPayload[]) => void | Promise<unknown>;
+	settings?: ReactNode;
+	/** A provider decision that temporarily replaces ordinary message entry. */
+	approval?: ReactNode;
+	/** A send is in flight. */
+	busy?: boolean;
+	/** The agent is mid-turn, so this message is held until the turn ends. */
+	willQueue?: boolean;
+	disabled?: boolean;
+	/** The provider's skills. Empty leaves `/` an ordinary character. */
+	skills?: ChatSkill[];
+	/** Worktree-relative paths offered for `@`. Empty leaves `@` ordinary. */
+	filePaths?: string[];
+	/** The path list was capped, so the menu says so rather than implying it is all. */
+	filePathsTruncated?: boolean;
+	/**
+	 * Writes staged files into the worktree and answers with the paths the agent
+	 * can open. Absent means files cannot be delivered, and no attach control is
+	 * offered at all.
+	 */
+	onStageAttachments?: (attachments: FileAttachmentPayload[]) => Promise<string[]>;
+	/** Send the same staged bytes as native ACP image blocks when negotiated. */
+	nativeImages?: boolean;
+	/**
+	 * Deliver this text into the turn already running. Absent means the harness
+	 * cannot steer and the choice is never offered.
+	 */
+	onSteer?: (text: string) => Promise<unknown>;
+	/** Stop the turn already running when there is no draft to send. */
+	onInterrupt?: () => void;
+	/** A turn is actually running, so there is something to steer into. */
+	canSteer?: boolean;
+	/** A send mutation is in flight for this session. */
+	sendPending?: boolean;
+	steerPending?: boolean;
+	/** Why the last steer was refused. */
+	steerRefusal?: string;
+	/** A selected history message to load into the composer as a new draft. */
+	draftSeed?: { id: string; text: string };
+	/** A queued turn being edited in the composer instead of the dock. */
+	editingQueuedTurnId?: string;
+	onCancelQueuedEdit?: () => void;
+	/** The queued edit mutation is in flight for the turn being edited. */
+	savingQueuedEditPending?: boolean;
+	/** A failed send, approval, interrupt, or settings mutation. */
+	commandError?: string;
+	/** A queued-message dock owns the shared rounded top edge. */
+	attachedTop?: boolean;
+	/** Queued messages rendered above the composer. */
+	queuedDock?: ReactNode;
+	/** Run AO's built-in `/compact` command instead of sending it to the agent. */
+	onCompact?: () => void | Promise<unknown>;
+	/** The provider is already compacting this conversation. */
+	compacting?: boolean;
+	/** A typed provider refusal from the last compaction attempt. */
+	compactUnavailable?: string;
+	/** A running turn must be stopped before its history can be compacted. */
+	compactBlocked?: boolean;
+	/** Changes when the owning chat surface should reclaim composer focus. */
+	autoFocusKey?: string;
+	/** Whether this composer is currently visible and should take focus. */
+	autoFocus?: boolean;
 }) {
-  const [hasText, setHasText] = useState(false);
-  const hasTextRef = useRef(false);
-  const [trigger, setTrigger] = useState<ComposerTrigger>();
-  /**
-   * The trigger position the user dismissed with Escape. Held so the menu stays
-   * shut for the completion they rejected, while a new `/` or `@` still opens one.
-   */
-  const [dismissedKey, setDismissedKey] = useState<string | null>(null);
-  const dismissedKeyRef = useRef<string | null>(null);
-  const [highlighted, setHighlighted] = useState(0);
-  const highlightedRef = useRef(0);
-  const [isComposing, setIsComposing] = useState(false);
-  const [dragging, setDragging] = useState(false);
-  const [sendError, setSendError] = useState<string | null>(null);
-  const [steerNextRequest, setSteerNextRequest] = useState(0);
-  // The DOM event is the source of truth while React catches up with the draft
-  // transition. This keeps Enter-after-fast-typing from observing stale state.
-  const textRef = useRef("");
-  /**
-   * What Enter does while the agent is working.
-   *
-   * Queueing is the safe default and matches `ao send`: the daemon records the
-   * message durably and dispatches it when the current turn finishes. Steering is
-   * timing-sensitive and changes the running turn, so it stays an explicit choice.
-   */
+	const [hasText, setHasText] = useState(false);
+	const hasTextRef = useRef(false);
+	const [trigger, setTrigger] = useState<ComposerTrigger>();
+	/**
+	 * The trigger position the user dismissed with Escape. Held so the menu stays
+	 * shut for the completion they rejected, while a new `/` or `@` still opens one.
+	 */
+	const [dismissedKey, setDismissedKey] = useState<string | null>(null);
+	const dismissedKeyRef = useRef<string | null>(null);
+	const [highlighted, setHighlighted] = useState(0);
+	const highlightedRef = useRef(0);
+	const [isComposing, setIsComposing] = useState(false);
+	const [dragging, setDragging] = useState(false);
+	const [sendError, setSendError] = useState<string | null>(null);
+	// The DOM event is the source of truth while React catches up with the draft
+	// transition. This keeps Enter-after-fast-typing from observing stale state.
+	const textRef = useRef("");
+	/**
+	 * What Enter does while the agent is working.
+	 *
+	 * Queueing is the safe default and matches `ao send`: the daemon records the
+	 * message durably and dispatches it when the current turn finishes. Steering is
+	 * timing-sensitive and changes the running turn, so it stays an explicit choice.
+	 */
 
-  const editor = useRef<ComposerEditorHandle>(null);
-  const filePicker = useRef<HTMLInputElement>(null);
-  const stagedDelivery = useRef<{ signature: string; paths: string[] } | null>(
-    null,
-  );
-  const submitInFlight = useRef<Promise<void> | null>(null);
-  const menuId = useId();
-  const previousTrigger = useRef<ComposerTrigger | undefined>(undefined);
-  const triggerRef = useRef<ComposerTrigger | undefined>(undefined);
+	const editor = useRef<ComposerEditorHandle>(null);
+	const filePicker = useRef<HTMLInputElement>(null);
+	const stagedDelivery = useRef<{ signature: string; paths: string[] } | null>(null);
+	const submitInFlight = useRef<Promise<void> | null>(null);
+	const menuId = useId();
+	const previousTrigger = useRef<ComposerTrigger | undefined>(undefined);
+	const triggerRef = useRef<ComposerTrigger | undefined>(undefined);
 
-  const fileAttachments = useFileAttachments();
-  const canAttach = Boolean(onStageAttachments);
+	const fileAttachments = useFileAttachments();
+	const canAttach = Boolean(onStageAttachments);
 
-  const slashCommands = useMemo<ChatSkill[]>(() => {
-    if (
-      !onCompact ||
-      compactUnavailable === "This agent cannot compact its history"
-    )
-      return skills;
-    return [
-      {
-        name: "compact",
-        displayName: "compact",
-        description: "Summarize earlier history to reclaim context",
-        source: "AO",
-      },
-      ...skills.filter((skill) => skill.name !== "compact"),
-    ];
-  }, [compactUnavailable, onCompact, skills]);
+	const slashCommands = useMemo<ChatSkill[]>(() => {
+		if (!onCompact || compactUnavailable === "This agent cannot compact its history") return skills;
+		return [
+			{
+				name: "compact",
+				displayName: "compact",
+				description: "Summarize earlier history to reclaim context",
+				source: "AO",
+			},
+			...skills.filter((skill) => skill.name !== "compact"),
+		];
+	}, [compactUnavailable, onCompact, skills]);
 
-  const suggestionsFor = useCallback(
-    (currentTrigger?: ComposerTrigger): Suggestion[] => {
-      if (!currentTrigger || currentTrigger.key === dismissedKeyRef.current)
-        return [];
-      // An empty candidate list is the whole reason the sigil stays ordinary: with
-      // no commands or skills there is nothing to open, so `/` types a slash.
-      if (currentTrigger.kind === "skill") {
-        return rankSkills(slashCommands, currentTrigger.query);
-      }
-      return rankFiles(filePaths, currentTrigger.query);
-    },
-    [slashCommands, filePaths],
-  );
+	const suggestionsFor = useCallback((currentTrigger?: ComposerTrigger): Suggestion[] => {
+		if (!currentTrigger || currentTrigger.key === dismissedKeyRef.current) return [];
+		// An empty candidate list is the whole reason the sigil stays ordinary: with
+		// no commands or skills there is nothing to open, so `/` types a slash.
+		if (currentTrigger.kind === "skill") {
+			return rankSkills(slashCommands, currentTrigger.query);
+		}
+		return rankFiles(filePaths, currentTrigger.query);
+	}, [slashCommands, filePaths]);
 
-  const suggestions: Suggestion[] = useMemo(
-    () => suggestionsFor(trigger),
-    [trigger, dismissedKey, suggestionsFor],
-  );
+	const suggestions: Suggestion[] = useMemo(
+		() => suggestionsFor(trigger),
+		[trigger, dismissedKey, suggestionsFor],
+	);
 
-  const menuOpen = suggestions.length > 0;
-  // Clamped rather than trusted: the list re-ranks on every keystroke, so the
-  // index from the previous list can point past the end of this one.
-  const activeIndex = Math.min(highlighted, suggestions.length - 1);
+	const menuOpen = suggestions.length > 0;
+	// Clamped rather than trusted: the list re-ranks on every keystroke, so the
+	// index from the previous list can point past the end of this one.
+	const activeIndex = Math.min(highlighted, suggestions.length - 1);
 
-  const staged = fileAttachments.attachments.length > 0;
-  const hasDraft = hasText || staged;
-  const savingQueuedEdit = Boolean(editingQueuedTurnId);
-  const canSend =
-    (hasText || staged) &&
-    !disabled &&
-    !steerPending &&
-    !savingQueuedEditPending &&
-    (savingQueuedEdit || !busy);
-  const canStopTurn = Boolean(
-    willQueue && onInterrupt && !disabled && !hasDraft && !savingQueuedEdit,
-  );
-  const canSteerNext =
-    Boolean(canSteer && onSteer) &&
-    !disabled &&
-    !hasDraft &&
-    !savingQueuedEdit &&
-    Boolean(queuedDock);
-  const sendHint = menuOpen
-    ? "Enter to insert"
-    : savingQueuedEdit
-      ? "⏎ save edit"
-      : willQueue && canSteerNext
-        ? "⏎ queue · Enter steer"
-        : willQueue
-          ? "⏎ queue"
-          : "Enter to send";
-  const draftSeedId = draftSeed?.id;
-  const draftSeedText = draftSeed?.text;
-  const queuedDockWithSteer = isValidElement(queuedDock)
-    ? cloneElement(
-        queuedDock as ReactElement<{
-          canSteerNext?: boolean;
-          steerNextRequest?: number;
-        }>,
-        { canSteerNext, steerNextRequest },
-      )
-    : queuedDock;
+	const staged = fileAttachments.attachments.length > 0;
+	const hasDraft = hasText || staged;
+	const savingQueuedEdit = Boolean(editingQueuedTurnId);
+	const canSend =
+		(hasText || staged) &&
+		!disabled &&
+		!steerPending &&
+		!savingQueuedEditPending &&
+		(savingQueuedEdit || !busy);
+	const canStopTurn = Boolean(willQueue && onInterrupt && !disabled && !hasDraft && !savingQueuedEdit);
+	// Steering delivers text only, so a draft carrying files cannot take that
+	// path. Treating it as unavailable — rather than steering the text and
+	// dropping the files, or refusing on an empty body with attachments staged —
+	// keeps the armed state something the composer can actually honour.
+	const canSteerDraft = Boolean(canSteer && onSteer) && !staged && !savingQueuedEdit;
+	const sendHint = menuOpen
+		? "Enter to insert"
+		: savingQueuedEdit
+			? "⏎ save edit"
+			: willQueue && canSteerDraft
+				? "⏎ queue · ⌘⏎ steer"
+				: willQueue
+					? "⏎ queue"
+					: "Enter to send";
+	const draftSeedId = draftSeed?.id;
+	const draftSeedText = draftSeed?.text;
 
-  const focusEditor = useCallback(() => {
-    if (!autoFocus || disabled) return;
-    editor.current?.focus();
-  }, [autoFocus, disabled]);
+	const focusEditor = useCallback(() => {
+		if (!autoFocus || disabled) return;
+		editor.current?.focus();
+	}, [autoFocus, disabled]);
 
-  useEffect(() => {
-    focusEditor();
-  }, [autoFocusKey, focusEditor]);
+	useEffect(() => {
+		focusEditor();
+	}, [autoFocusKey, focusEditor]);
 
-  useEffect(() => {
-    if (!autoFocus) return;
+	useEffect(() => {
+		if (!autoFocus) return;
 
-    const onWindowFocus = () => focusEditor();
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") focusEditor();
-    };
+		const onWindowFocus = () => focusEditor();
+		const onVisibilityChange = () => {
+			if (document.visibilityState === "visible") focusEditor();
+		};
 
-    window.addEventListener("focus", onWindowFocus);
-    document.addEventListener("visibilitychange", onVisibilityChange);
-    return () => {
-      window.removeEventListener("focus", onWindowFocus);
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-    };
-  }, [autoFocus, focusEditor]);
+		window.addEventListener("focus", onWindowFocus);
+		document.addEventListener("visibilitychange", onVisibilityChange);
+		return () => {
+			window.removeEventListener("focus", onWindowFocus);
+			document.removeEventListener("visibilitychange", onVisibilityChange);
+		};
+	}, [autoFocus, focusEditor]);
 
-  const clearEditor = useCallback(() => {
-    textRef.current = "";
-    hasTextRef.current = false;
-    setHasText(false);
-    setTrigger(undefined);
-    triggerRef.current = undefined;
-    previousTrigger.current = undefined;
-    dismissedKeyRef.current = null;
-    setDismissedKey(null);
-    highlightedRef.current = 0;
-    setHighlighted(0);
-    editor.current?.clear();
-  }, []);
+	const clearEditor = useCallback(() => {
+		textRef.current = "";
+		hasTextRef.current = false;
+		setHasText(false);
+		setTrigger(undefined);
+		triggerRef.current = undefined;
+		previousTrigger.current = undefined;
+		dismissedKeyRef.current = null;
+		setDismissedKey(null);
+		highlightedRef.current = 0;
+		setHighlighted(0);
+		editor.current?.clear();
+	}, []);
 
-  useEffect(() => {
-    if (draftSeedText === undefined) return;
-    textRef.current = draftSeedText;
-    hasTextRef.current = draftSeedText.trim().length > 0;
-    setHasText(hasTextRef.current);
-    editor.current?.setText(draftSeedText);
-    dismissedKeyRef.current = null;
-    setDismissedKey(null);
-    highlightedRef.current = 0;
-    setHighlighted(0);
-    setSendError(null);
-  }, [draftSeedId, draftSeedText]);
+	useEffect(() => {
+		if (draftSeedText === undefined) return;
+		textRef.current = draftSeedText;
+		hasTextRef.current = draftSeedText.trim().length > 0;
+		setHasText(hasTextRef.current);
+		editor.current?.setText(draftSeedText);
+		dismissedKeyRef.current = null;
+		setDismissedKey(null);
+		highlightedRef.current = 0;
+		setHighlighted(0);
+		setSendError(null);
+	}, [draftSeedId, draftSeedText]);
 
-  const previousEditingQueuedTurnIdRef = useRef(editingQueuedTurnId);
-  useEffect(() => {
-    const previous = previousEditingQueuedTurnIdRef.current;
-    previousEditingQueuedTurnIdRef.current = editingQueuedTurnId;
-    if (previous && !editingQueuedTurnId) {
-      clearEditor();
-    }
-  }, [clearEditor, editingQueuedTurnId]);
+	const previousEditingQueuedTurnIdRef = useRef(editingQueuedTurnId);
+	useEffect(() => {
+		const previous = previousEditingQueuedTurnIdRef.current;
+		previousEditingQueuedTurnIdRef.current = editingQueuedTurnId;
+		if (previous && !editingQueuedTurnId) {
+			clearEditor();
+		}
+	}, [clearEditor, editingQueuedTurnId]);
 
-  const onEditorChange = useCallback((snapshot: ComposerEditorSnapshot) => {
-    textRef.current = snapshot.text;
-    if (hasTextRef.current !== snapshot.hasText) {
-      hasTextRef.current = snapshot.hasText;
-      setHasText(snapshot.hasText);
-    }
+	const onEditorChange = useCallback((snapshot: ComposerEditorSnapshot) => {
+		textRef.current = snapshot.text;
+		if (hasTextRef.current !== snapshot.hasText) {
+			hasTextRef.current = snapshot.hasText;
+			setHasText(snapshot.hasText);
+		}
 
-    const previous = previousTrigger.current;
-    const next = snapshot.trigger;
-    triggerRef.current = next;
-    if (
-      previous?.key !== next?.key ||
-      previous?.end !== next?.end ||
-      previous?.query !== next?.query ||
-      previous?.kind !== next?.kind
-    ) {
-      highlightedRef.current = 0;
-      setHighlighted(0);
-      previousTrigger.current = next;
-      setTrigger(next);
-    }
-    if (dismissedKeyRef.current && next?.key !== dismissedKeyRef.current) {
-      dismissedKeyRef.current = null;
-      setDismissedKey(null);
-    }
-  }, []);
+		const previous = previousTrigger.current;
+		const next = snapshot.trigger;
+		triggerRef.current = next;
+		if (
+			previous?.key !== next?.key ||
+			previous?.end !== next?.end ||
+			previous?.query !== next?.query ||
+			previous?.kind !== next?.kind
+		) {
+			highlightedRef.current = 0;
+			setHighlighted(0);
+			previousTrigger.current = next;
+			setTrigger(next);
+		}
+		if (dismissedKeyRef.current && next?.key !== dismissedKeyRef.current) {
+			dismissedKeyRef.current = null;
+			setDismissedKey(null);
+		}
+	}, []);
 
-  const pick = useCallback((value: string) => {
-    const currentTrigger = triggerRef.current;
-    if (!currentTrigger) return;
-    editor.current?.insertToken(currentTrigger, value);
-    triggerRef.current = undefined;
-    previousTrigger.current = undefined;
-    setTrigger(undefined);
-    highlightedRef.current = 0;
-    setHighlighted(0);
-    dismissedKeyRef.current = null;
-    setDismissedKey(null);
-  }, []);
+	const pick = useCallback((value: string) => {
+		const currentTrigger = triggerRef.current;
+		if (!currentTrigger) return;
+		editor.current?.insertToken(currentTrigger, value);
+		triggerRef.current = undefined;
+		previousTrigger.current = undefined;
+		setTrigger(undefined);
+		highlightedRef.current = 0;
+		setHighlighted(0);
+		dismissedKeyRef.current = null;
+		setDismissedKey(null);
+	}, []);
 
-  useEffect(() => {
-    if (
-      isComposing ||
-      !trigger ||
-      trigger.kind !== "skill" ||
-      trigger.key === dismissedKey
-    )
-      return;
-    const query = trigger.query.toLowerCase();
-    if (!query) return;
-    const exact = slashCommands.find(
-      (skill) => skill.name.toLowerCase() === query,
-    );
-    if (!exact) return;
+	useEffect(() => {
+		if (isComposing || !trigger || trigger.kind !== "skill" || trigger.key === dismissedKey) return;
+		const query = trigger.query.toLowerCase();
+		if (!query) return;
+		const exact = slashCommands.find((skill) => skill.name.toLowerCase() === query);
+		if (!exact) return;
 
-    // Do not eagerly accept a skill whose full name is also the start of another
-    // skill. The user must still be able to type `/review-pr` when `/review`
-    // exists; Enter remains available to accept the shorter exact match.
-    const hasLongerPrefix = slashCommands.some((skill) => {
-      const name = skill.name.toLowerCase();
-      return name.length > query.length && name.startsWith(query);
-    });
-    if (!hasLongerPrefix) pick(exact.name);
-  }, [dismissedKey, isComposing, pick, slashCommands, trigger]);
+		// Do not eagerly accept a skill whose full name is also the start of another
+		// skill. The user must still be able to type `/review-pr` when `/review`
+		// exists; Enter remains available to accept the shorter exact match.
+		const hasLongerPrefix = slashCommands.some((skill) => {
+			const name = skill.name.toLowerCase();
+			return name.length > query.length && name.startsWith(query);
+		});
+		if (!hasLongerPrefix) pick(exact.name);
+	}, [dismissedKey, isComposing, pick, slashCommands, trigger]);
 
-  const completeFromEditor = useCallback(
-    (
-      snapshot: ComposerEditorSnapshot,
-      key: "Enter" | "Tab",
-    ): string | undefined => {
-      const currentTrigger = snapshot.trigger;
-      if (!currentTrigger) return undefined;
-      if (key === "Enter" && snapshot.text.trim() === "/compact" && onCompact) {
-        return undefined;
-      }
-      const matches = suggestionsFor(currentTrigger);
-      const chosen =
-        matches[Math.min(highlightedRef.current, matches.length - 1)];
-      if (!chosen) return undefined;
-      triggerRef.current = currentTrigger;
-      highlightedRef.current = 0;
-      dismissedKeyRef.current = null;
-      return chosen.value;
-    },
-    [onCompact, suggestionsFor],
-  );
+	const completeFromEditor = useCallback(
+		(snapshot: ComposerEditorSnapshot, key: "Enter" | "Tab"): string | undefined => {
+			const currentTrigger = snapshot.trigger;
+			if (!currentTrigger) return undefined;
+			if (key === "Enter" && snapshot.text.trim() === "/compact" && onCompact) {
+				return undefined;
+			}
+			const matches = suggestionsFor(currentTrigger);
+			const chosen = matches[Math.min(highlightedRef.current, matches.length - 1)];
+			if (!chosen) return undefined;
+			triggerRef.current = currentTrigger;
+			highlightedRef.current = 0;
+			dismissedKeyRef.current = null;
+			return chosen.value;
+		},
+		[onCompact, suggestionsFor],
+	);
 
-  function submit(event?: FormEvent, forceSteer?: boolean): Promise<void> {
-    event?.preventDefault();
-    // React cannot publish the next busy prop until after this event returns. A
-    // second Enter in that gap joins the accepted submission instead of opening a
-    // second transport whose local admission rejection would look like a real
-    // provider failure.
-    if (submitInFlight.current) return submitInFlight.current;
-    const pending = performSubmit(forceSteer);
-    submitInFlight.current = pending;
-    const release = () => {
-      if (submitInFlight.current === pending) submitInFlight.current = null;
-    };
-    void pending.then(release, release);
-    return pending;
-  }
+	function submit(event?: FormEvent, forceSteer?: boolean): Promise<void> {
+		event?.preventDefault();
+		// React cannot publish the next busy prop until after this event returns. A
+		// second Enter in that gap joins the accepted submission instead of opening a
+		// second transport whose local admission rejection would look like a real
+		// provider failure.
+		if (submitInFlight.current) return submitInFlight.current;
+		const pending = performSubmit(forceSteer);
+		submitInFlight.current = pending;
+		const release = () => {
+			if (submitInFlight.current === pending) submitInFlight.current = null;
+		};
+		void pending.then(release, release);
+		return pending;
+	}
 
-  async function performSubmit(forceSteer?: boolean) {
-    const currentText = textRef.current;
-    const body = currentText.trim();
+	async function performSubmit(forceSteer?: boolean) {
+		const currentText = textRef.current;
+		const body = currentText.trim();
 
-    // `/compact` is a local AO command. It must refuse while a turn is running
-    // without being blocked by the ordinary busy send gate.
-    if (body === "/compact" && onCompact) {
-      setSendError(null);
-      if (compactBlocked) {
-        setSendError("Stop the current turn before compacting.");
-        return;
-      }
-      if (compacting) {
-        setSendError("Conversation history is already being compacted.");
-        return;
-      }
-      if (compactUnavailable) {
-        setSendError(compactUnavailable);
-        return;
-      }
-      try {
-        await onCompact();
-      } catch {
-        setSendError("Conversation history could not be compacted. Try again.");
-        return;
-      }
-      clearEditor();
-      setDismissedKey(null);
-      setHighlighted(0);
-      return;
-    }
+		// `/compact` is a local AO command. It must refuse while a turn is running
+		// without being blocked by the ordinary busy send gate.
+		if (body === "/compact" && onCompact) {
+			setSendError(null);
+			if (compactBlocked) {
+				setSendError("Stop the current turn before compacting.");
+				return;
+			}
+			if (compacting) {
+				setSendError("Conversation history is already being compacted.");
+				return;
+			}
+			if (compactUnavailable) {
+				setSendError(compactUnavailable);
+				return;
+			}
+			try {
+				await onCompact();
+			} catch {
+				setSendError("Conversation history could not be compacted. Try again.");
+				return;
+			}
+			clearEditor();
+			setDismissedKey(null);
+			setHighlighted(0);
+			return;
+		}
 
-    const canSubmitNow =
-      (currentText.trim().length > 0 || staged) &&
-      !disabled &&
-      !steerPending &&
-      !savingQueuedEditPending &&
-      (editingQueuedTurnId || !busy);
-    if (!canSubmitNow) {
-      if (
-        (currentText.trim().length > 0 || staged) &&
-        busy &&
-        !disabled &&
-        !steerPending &&
-        !savingQueuedEditPending &&
-        !editingQueuedTurnId
-      ) {
-        setSendError(
-          "Still sending the previous message. Try again in a moment.",
-        );
-      }
-      return;
-    }
-    setSendError(null);
+		const canSubmitNow =
+			(currentText.trim().length > 0 || staged) &&
+			!disabled &&
+			!steerPending &&
+			!savingQueuedEditPending &&
+			(editingQueuedTurnId || !busy);
+		if (!canSubmitNow) {
+			if (
+				(currentText.trim().length > 0 || staged) &&
+				busy &&
+				!disabled &&
+				!steerPending &&
+				!savingQueuedEditPending &&
+				!editingQueuedTurnId
+			) {
+				setSendError("Still sending the previous message. Try again in a moment.");
+			}
+			return;
+		}
+		setSendError(null);
 
-    const shouldSteer = forceSteer ?? false;
+		const shouldSteer = forceSteer ?? false;
 
-    // Steering keeps the text in the box until the provider has taken it. The turn
-    // is already running, so a refusal is a real possibility — and a refusal that
-    // had already cleared the composer would lose what the user typed.
-    if (shouldSteer && onSteer && !editingQueuedTurnId) {
-      if (body === "") return;
-      try {
-        await onSteer(body);
-      } catch {
-        // The refusal is the daemon's typed answer and the surface renders it from
-        // `steerRefusal`; keep the draft, but arm the reliable queue path for the
-        // next Enter in case the turn ended while the user was typing.
-        return;
-      }
-      clearEditor();
-      setDismissedKey(null);
-      setHighlighted(0);
-      return;
-    }
+		// Steering keeps the text in the box until the provider has taken it. The turn
+		// is already running, so a refusal is a real possibility — and a refusal that
+		// had already cleared the composer would lose what the user typed.
+		if (shouldSteer && onSteer && !editingQueuedTurnId) {
+			if (body === "") return;
+			try {
+				await onSteer(body);
+			} catch {
+				// The refusal is the daemon's typed answer and the surface renders it from
+				// `steerRefusal`; keep the draft, but arm the reliable queue path for the
+				// next Enter in case the turn ended while the user was typing.
+				return;
+			}
+			clearEditor();
+			setDismissedKey(null);
+			setHighlighted(0);
+			return;
+		}
 
-    if (staged && onStageAttachments) {
-      // Staged before the send so a failed write is reported instead of a
-      // message that claims attachments the agent cannot open.
-      let paths: string[];
-      const signature = fileAttachments.attachments
-        .map((file) => file.id)
-        .join(":");
-      try {
-        if (stagedDelivery.current?.signature === signature) {
-          paths = stagedDelivery.current.paths;
-        } else {
-          paths = await onStageAttachments(fileAttachments.toPayload());
-          stagedDelivery.current = { signature, paths };
-        }
-      } catch {
-        setSendError("The files could not be attached. Nothing was sent.");
-        return;
-      }
-      try {
-        const message = withAttachmentReferences(body, paths);
-        const nativePayloads = fileAttachments
-          .toPayload()
-          .filter((attachment) =>
-            isSupportedImageAttachment(attachment.mimeType),
-          );
-        if (nativeImages && nativePayloads.length > 0)
-          await onSend(message, nativePayloads);
-        else await onSend(message);
-      } catch {
-        setSendError(
-          "Message not sent. Your draft and attachments were kept so you can retry.",
-        );
-        return;
-      }
-      stagedDelivery.current = null;
-      fileAttachments.clear();
-    } else {
-      try {
-        await onSend(body);
-      } catch (error) {
-        setSendError(
-          editingQueuedTurnId
-            ? apiErrorMessage(
-                error,
-                "Could not save that queued message edit. Your draft was kept.",
-              )
-            : "Message not sent. Your draft was kept so you can retry.",
-        );
-        return;
-      }
-    }
+		if (staged && onStageAttachments) {
+			// Staged before the send so a failed write is reported instead of a
+			// message that claims attachments the agent cannot open.
+			let paths: string[];
+			const signature = fileAttachments.attachments.map((file) => file.id).join(":");
+			try {
+				if (stagedDelivery.current?.signature === signature) {
+					paths = stagedDelivery.current.paths;
+				} else {
+					paths = await onStageAttachments(fileAttachments.toPayload());
+					stagedDelivery.current = { signature, paths };
+				}
+			} catch {
+				setSendError("The files could not be attached. Nothing was sent.");
+				return;
+			}
+			try {
+				const message = withAttachmentReferences(body, paths);
+				const nativePayloads = fileAttachments
+					.toPayload()
+					.filter((attachment) => isSupportedImageAttachment(attachment.mimeType));
+				if (nativeImages && nativePayloads.length > 0) await onSend(message, nativePayloads);
+				else await onSend(message);
+			} catch {
+				setSendError("Message not sent. Your draft and attachments were kept so you can retry.");
+				return;
+			}
+			stagedDelivery.current = null;
+			fileAttachments.clear();
+		} else {
+			try {
+				await onSend(body);
+			} catch (error) {
+				setSendError(
+					editingQueuedTurnId
+						? apiErrorMessage(error, "Could not save that queued message edit. Your draft was kept.")
+						: "Message not sent. Your draft was kept so you can retry.",
+				);
+				return;
+			}
+		}
 
-    clearEditor();
-    setDismissedKey(null);
-    setHighlighted(0);
-  }
+		clearEditor();
+		setDismissedKey(null);
+		setHighlighted(0);
+	}
 
-  const handleEnterKey = useCallback(
-    (_event: globalThis.KeyboardEvent): boolean => {
-      const liveSnapshot = editor.current?.getSnapshot();
-      if (liveSnapshot) textRef.current = liveSnapshot.text;
-      const liveTrigger = liveSnapshot?.trigger;
-      const liveSuggestions = suggestionsFor(liveTrigger);
-      if (liveSuggestions.length > 0) {
-        if (textRef.current.trim() === "/compact" && onCompact) {
-          void submit();
-          return true;
-        }
-        triggerRef.current = liveTrigger;
-        const chosen =
-          liveSuggestions[
-            Math.min(highlightedRef.current, liveSuggestions.length - 1)
-          ];
-        if (chosen) pick(chosen.value);
-        return true;
-      }
+	const handleEnterKey = useCallback(
+		(event: globalThis.KeyboardEvent): boolean => {
+			const liveSnapshot = editor.current?.getSnapshot();
+			if (liveSnapshot) textRef.current = liveSnapshot.text;
+			const liveTrigger = liveSnapshot?.trigger;
+			const liveSuggestions = suggestionsFor(liveTrigger);
+			if (liveSuggestions.length > 0) {
+				if (textRef.current.trim() === "/compact" && onCompact) {
+					void submit();
+					return true;
+				}
+				triggerRef.current = liveTrigger;
+				const chosen = liveSuggestions[Math.min(highlightedRef.current, liveSuggestions.length - 1)];
+				if (chosen) pick(chosen.value);
+				return true;
+			}
 
-      if (canSteerNext) {
-        setSteerNextRequest((request) => request + 1);
-        return true;
-      }
-      void submit();
-      return true;
-    },
-    [canSteerNext, onCompact, pick, suggestionsFor],
-  );
+			const wantsSteer = (event.metaKey || event.ctrlKey) && canSteerDraft;
+			void submit(undefined, wantsSteer);
+			return true;
+		},
+		[canSteerDraft, onCompact, pick, suggestionsFor],
+	);
 
-  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (event.nativeEvent.isComposing) return;
-    // Enter is handled in Lexical before a newline is inserted; this handler is
-    // only for menu navigation and escape while a completion menu is open.
-    const liveSnapshot = editor.current?.getSnapshot();
-    if (liveSnapshot) textRef.current = liveSnapshot.text;
-    const liveTrigger = liveSnapshot?.trigger;
-    const liveSuggestions = suggestionsFor(liveTrigger);
-    if (liveSuggestions.length > 0) {
-      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-        event.preventDefault();
-        const next = moveHighlight(
-          Math.min(highlightedRef.current, liveSuggestions.length - 1),
-          event.key === "ArrowDown" ? 1 : -1,
-          liveSuggestions.length,
-        );
-        highlightedRef.current = next;
-        setHighlighted(next);
-        return;
-      }
-      if (event.key === "Escape") {
-        event.preventDefault();
-        event.stopPropagation();
-        dismissedKeyRef.current = liveTrigger?.key ?? null;
-        setDismissedKey(dismissedKeyRef.current);
-        return;
-      }
-    }
+	function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+		if (event.nativeEvent.isComposing) return;
+		// Enter is handled in Lexical before a newline is inserted; this handler is
+		// only for menu navigation and escape while a completion menu is open.
+		const liveSnapshot = editor.current?.getSnapshot();
+		if (liveSnapshot) textRef.current = liveSnapshot.text;
+		const liveTrigger = liveSnapshot?.trigger;
+		const liveSuggestions = suggestionsFor(liveTrigger);
+		if (liveSuggestions.length > 0) {
+			if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+				event.preventDefault();
+				const next = moveHighlight(
+					Math.min(highlightedRef.current, liveSuggestions.length - 1),
+					event.key === "ArrowDown" ? 1 : -1,
+					liveSuggestions.length,
+				);
+				highlightedRef.current = next;
+				setHighlighted(next);
+				return;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				event.stopPropagation();
+				dismissedKeyRef.current = liveTrigger?.key ?? null;
+				setDismissedKey(dismissedKeyRef.current);
+				return;
+			}
+		}
 
-    if (event.key === "Escape" && editingQueuedTurnId && onCancelQueuedEdit) {
-      event.preventDefault();
-      clearEditor();
-      onCancelQueuedEdit();
-    }
-  }
+		if (event.key === "Escape" && editingQueuedTurnId && onCancelQueuedEdit) {
+			event.preventDefault();
+			clearEditor();
+			onCancelQueuedEdit();
+		}
+	}
 
-  function onPaste(event: ClipboardEvent<HTMLDivElement>) {
-    if (!canAttach) return;
-    const clipboard = event.clipboardData;
-    const files = Array.from(clipboard?.files ?? []);
-    if (files.length === 0) return;
-    // The paste is only claimed when there is no text alongside the image: a copy
-    // carrying both should still paste its text.
-    const hasText =
-      typeof clipboard?.getData === "function" &&
-      clipboard.getData("text/plain") !== "";
-    if (!hasText) event.preventDefault();
-    void fileAttachments.addFiles(files);
-  }
+	function onPaste(event: ClipboardEvent<HTMLDivElement>) {
+		if (!canAttach) return;
+		const clipboard = event.clipboardData;
+		const files = Array.from(clipboard?.files ?? []);
+		if (files.length === 0) return;
+		// The paste is only claimed when there is no text alongside the image: a copy
+		// carrying both should still paste its text.
+		const hasText = typeof clipboard?.getData === "function" && clipboard.getData("text/plain") !== "";
+		if (!hasText) event.preventDefault();
+		void fileAttachments.addFiles(files);
+	}
 
-  function onDrop(event: DragEvent<HTMLFormElement>) {
-    setDragging(false);
-    if (!canAttach) return;
-    const files = Array.from(event.dataTransfer?.files ?? []);
-    if (files.length === 0) return;
-    event.preventDefault();
-    event.stopPropagation();
-    void fileAttachments.addFiles(files);
-  }
+	function onDrop(event: DragEvent<HTMLFormElement>) {
+		setDragging(false);
+		if (!canAttach) return;
+		const files = Array.from(event.dataTransfer?.files ?? []);
+		if (files.length === 0) return;
+		event.preventDefault();
+		event.stopPropagation();
+		void fileAttachments.addFiles(files);
+	}
 
-  const attachmentError = fileAttachments.error ?? sendError ?? commandError;
-  const withQueueStack = (form: ReactElement) =>
-    queuedDock ? (
-      <div className="relative flex w-full flex-col">
-        <div
-          className="cursor-chat-composer-queue queue-dock-enter relative z-10 mx-auto mb-2 w-[calc(100%-2rem)]"
-          data-testid="queued-composer-dock"
-        >
-          {queuedDockWithSteer}
-        </div>
-        {form}
-      </div>
-    ) : (
-      form
-    );
+	// Track Cmd/Ctrl for the send-button click path without re-rendering the composer
+	// on every modifier key event.
+	const modifierHeldRef = useRef(false);
+	useEffect(() => {
+		const onKey = (event: globalThis.KeyboardEvent) => {
+			modifierHeldRef.current = event.metaKey || event.ctrlKey;
+		};
+		const onBlur = () => {
+			modifierHeldRef.current = false;
+		};
+		window.addEventListener("keydown", onKey);
+		window.addEventListener("keyup", onKey);
+		window.addEventListener("blur", onBlur);
+		return () => {
+			window.removeEventListener("keydown", onKey);
+			window.removeEventListener("keyup", onKey);
+			window.removeEventListener("blur", onBlur);
+		};
+	}, []);
 
-  if (approval) {
-    return withQueueStack(
-      <form
-        onSubmit={(event) => event.preventDefault()}
-        data-attached-top={attachedTop && !queuedDock ? true : undefined}
-        className="cursor-chat-composer relative flex flex-col gap-1.5 border px-3 py-3 transition-[background,border-color,box-shadow]"
-      >
-        {approval}
-        {commandError ? (
-          <p
-            role="alert"
-            className="px-1.5 text-[11px] leading-snug text-destructive"
-          >
-            {commandError}
-          </p>
-        ) : null}
-      </form>,
-    );
-  }
+	const attachmentError = fileAttachments.error ?? sendError ?? commandError;
+	const withQueueStack = (form: ReactElement) =>
+		queuedDock ? (
+			<div className="relative flex w-full flex-col">
+				<div
+					className="cursor-chat-composer-queue queue-dock-enter relative z-10 mx-auto mb-2 w-[calc(100%-2rem)]"
+					data-testid="queued-composer-dock"
+				>
+					{queuedDock}
+				</div>
+				{form}
+			</div>
+		) : (
+			form
+		);
 
-  return withQueueStack(
-    <form
-				// The send button always submits the typed draft. Steering is reserved for
-				// the empty-input Enter path handled by the editor above.
-      onSubmit={(event) => void submit(event)}
-      onDragOver={(event) => {
-        if (!canAttach) return;
-        event.preventDefault();
-        setDragging(true);
-      }}
-      onDragLeave={() => setDragging(false)}
-      onDropCapture={onDrop}
-      // The border colors for rest, hover, focus and drag are one set of states
-      // on one surface, so they are declared together in CSS rather than half
-      // here and half there.
-      data-dragging={dragging || undefined}
-      data-attached-top={attachedTop && !queuedDock ? true : undefined}
-      onClick={(e) => {
-        if (
-          e.target === e.currentTarget ||
-          !(e.target as HTMLElement).closest("button, a, [role='option'], ul")
-        ) {
-          editor.current?.focus();
-        }
-      }}
-      className="cursor-chat-composer relative flex cursor-text flex-col gap-1.5 border px-3 pt-3 pb-3 transition-[background,border-color,box-shadow]"
-    >
-      {menuOpen && trigger ? (
-        <ComposerSuggestMenu
-          id={menuId}
-          kind={trigger.kind}
-          items={suggestions}
-          highlighted={activeIndex}
-          onPick={pick}
-          truncated={trigger?.kind === "file" && filePathsTruncated}
-        />
-      ) : null}
+	if (approval) {
+		return withQueueStack(
+			<form
+				onSubmit={(event) => event.preventDefault()}
+				data-attached-top={attachedTop && !queuedDock ? true : undefined}
+				className="cursor-chat-composer relative flex flex-col gap-1.5 border px-3 py-3 transition-[background,border-color,box-shadow]"
+			>
+				{approval}
+				{commandError ? (
+					<p role="alert" className="px-1.5 text-[11px] leading-snug text-destructive">
+						{commandError}
+					</p>
+				) : null}
+			</form>,
+		);
+	}
 
-      {staged ? (
-        <ul className="flex flex-wrap gap-1.5" aria-label="Attached files">
-          {fileAttachments.attachments.map((file) => (
-            <li
-              key={file.id}
-              className="flex items-center gap-1.5 rounded border border-border bg-background py-0.5 pl-0.5 pr-1"
-            >
-              {file.dataUrl ? (
-                <img
-                  src={file.dataUrl}
-                  alt=""
-                  className="size-6 rounded-sm object-cover"
-                />
-              ) : (
-                <div className="flex size-6 items-center justify-center rounded-sm bg-surface">
-                  <File
-                    aria-hidden="true"
-                    className="size-3.5 text-muted-foreground"
-                  />
-                </div>
-              )}
-              <span
-                className="max-w-[120px] truncate text-[11px] text-muted-foreground"
-                title={file.name}
-              >
-                {file.name}
-              </span>
-              <button
-                type="button"
-                onClick={() => fileAttachments.remove(file.id)}
-                aria-label={`Remove ${file.name}`}
-                className="text-muted-foreground hover:text-foreground"
-              >
-                <X aria-hidden="true" className="size-3" />
-              </button>
-            </li>
-          ))}
-        </ul>
-      ) : null}
+	return withQueueStack(
+		<form
+				// Clicking send while Cmd/Ctrl is held has to mean what the indicator
+				// beside it says. Reading the same armed state the chip paints keeps the
+				// pointer and keyboard paths from disagreeing about where the message goes.
+				onSubmit={(event) => void submit(event, modifierHeldRef.current && canSteerDraft)}
+				onDragOver={(event) => {
+					if (!canAttach) return;
+					event.preventDefault();
+					setDragging(true);
+				}}
+				onDragLeave={() => setDragging(false)}
+				onDropCapture={onDrop}
+				// The border colors for rest, hover, focus and drag are one set of states
+				// on one surface, so they are declared together in CSS rather than half
+				// here and half there.
+				data-dragging={dragging || undefined}
+				data-attached-top={attachedTop && !queuedDock ? true : undefined}
+				onClick={(e) => {
+					if (
+						e.target === e.currentTarget ||
+						!(e.target as HTMLElement).closest("button, a, [role='option'], ul")
+					) {
+						editor.current?.focus();
+					}
+				}}
+				className="cursor-chat-composer relative flex cursor-text flex-col gap-1.5 border px-3 pt-3 pb-3 transition-[background,border-color,box-shadow]"
+			>
+				{menuOpen && trigger ? (
+					<ComposerSuggestMenu
+						id={menuId}
+						kind={trigger.kind}
+						items={suggestions}
+						highlighted={activeIndex}
+						onPick={pick}
+						truncated={trigger?.kind === "file" && filePathsTruncated}
+					/>
+				) : null}
 
-      <ComposerEditor
-        ref={editor}
-        disabled={disabled}
-        label="Message the agent"
-        placeholder={
-          disabled
-            ? "The controller is not connected"
-            : willQueue
-              ? "Agent is working — this sends when it finishes"
-              : "Message the agent…"
-        }
-        menuOpen={menuOpen}
-        menuId={menuId}
-        activeIndex={activeIndex}
-        onChange={onEditorChange}
-        onComplete={completeFromEditor}
-        onEnterKey={handleEnterKey}
-        onCompositionChange={setIsComposing}
-        onKeyDown={onKeyDown}
-        onPaste={onPaste}
-      />
+				{staged ? (
+					<ul className="flex flex-wrap gap-1.5" aria-label="Attached files">
+						{fileAttachments.attachments.map((file) => (
+							<li
+								key={file.id}
+								className="flex items-center gap-1.5 rounded border border-border bg-background py-0.5 pl-0.5 pr-1"
+							>
+								{file.dataUrl ? (
+									<img src={file.dataUrl} alt="" className="size-6 rounded-sm object-cover" />
+								) : (
+									<div className="flex size-6 items-center justify-center rounded-sm bg-surface">
+										<File aria-hidden="true" className="size-3.5 text-muted-foreground" />
+									</div>
+								)}
+								<span
+									className="max-w-[120px] truncate text-[11px] text-muted-foreground"
+									title={file.name}
+								>
+									{file.name}
+								</span>
+								<button
+									type="button"
+									onClick={() => fileAttachments.remove(file.id)}
+									aria-label={`Remove ${file.name}`}
+									className="text-muted-foreground hover:text-foreground"
+								>
+									<X aria-hidden="true" className="size-3" />
+								</button>
+							</li>
+						))}
+					</ul>
+				) : null}
 
-      {attachmentError ? (
-        <p
-          role="alert"
-          className="px-1.5 text-[11px] leading-snug text-destructive"
-        >
-          {attachmentError}
-        </p>
-      ) : null}
+				<ComposerEditor
+					ref={editor}
+					disabled={disabled}
+					label="Message the agent"
+					placeholder={
+						disabled
+							? "The controller is not connected"
+							: willQueue
+								? "Agent is working — this sends when it finishes"
+								: "Message the agent…"
+					}
+					menuOpen={menuOpen}
+					menuId={menuId}
+					activeIndex={activeIndex}
+					onChange={onEditorChange}
+					onComplete={completeFromEditor}
+					onEnterKey={handleEnterKey}
+					onCompositionChange={setIsComposing}
+					onKeyDown={onKeyDown}
+					onPaste={onPaste}
+				/>
 
-      {/* A refused steer is an ordinary outcome, not a failure: the text is still
+				{attachmentError ? (
+					<p role="alert" className="px-1.5 text-[11px] leading-snug text-destructive">
+						{attachmentError}
+					</p>
+				) : null}
+
+				{/* A refused steer is an ordinary outcome, not a failure: the text is still
 			    in the box and the message says which of "send it instead" and "try again
 			    in a moment" applies. */}
-      {steerRefusal ? (
-        <p
-          role="status"
-          className="px-1.5 text-[11px] leading-snug text-warning"
-        >
-          {steerRefusal}
-        </p>
-      ) : null}
+				{steerRefusal ? (
+					<p role="status" className="px-1.5 text-[11px] leading-snug text-warning">
+						{steerRefusal}
+					</p>
+				) : null}
 
-      <div className="flex h-7 items-center gap-1.5">
-        <div
-          role="group"
-          aria-label="Message tools"
-          className="flex min-w-0 flex-1 items-center gap-0.5"
-        >
-          {canAttach ? (
-            <>
-              <input
-                ref={filePicker}
-                type="file"
-                multiple
-                hidden
-                onChange={(event) => {
-                  void fileAttachments.addFiles(
-                    Array.from(event.target.files ?? []),
-                  );
-                  // Cleared so picking the same file twice still fires a change.
-                  event.target.value = "";
-                }}
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                disabled={disabled}
-                onClick={() => filePicker.current?.click()}
-                aria-label="Attach a file"
-                title="Attach a file"
-                className="size-7 shrink-0 rounded-full p-0 text-muted-foreground hover:bg-white/5! hover:text-foreground"
-              >
-                <Plus
-                  aria-hidden="true"
-                  className="size-3.5 text-muted-foreground"
-                />
-              </Button>
-            </>
-          ) : null}
-          {settings}
-        </div>
+				<div className="flex h-7 items-center gap-1.5">
+					<div role="group" aria-label="Message tools" className="flex min-w-0 flex-1 items-center gap-0.5">
+						{canAttach ? (
+							<>
+								<input
+									ref={filePicker}
+									type="file"
+									multiple
+									hidden
+									onChange={(event) => {
+										void fileAttachments.addFiles(Array.from(event.target.files ?? []));
+										// Cleared so picking the same file twice still fires a change.
+										event.target.value = "";
+									}}
+								/>
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon-sm"
+									disabled={disabled}
+									onClick={() => filePicker.current?.click()}
+									aria-label="Attach a file"
+									title="Attach a file"
+									className="size-7 shrink-0 rounded-full p-0 text-muted-foreground hover:bg-white/5! hover:text-foreground"
+								>
+									<Plus aria-hidden="true" className="size-3.5 text-muted-foreground" />
+								</Button>
+							</>
+						) : null}
+						{settings}
+					</div>
 
-        <div
-          role="group"
-          aria-label="Send message controls"
-          className="flex h-7 shrink-0 items-center"
-        >
-          <Button
-            type={canStopTurn ? "button" : "submit"}
-            variant="ghost"
-            size="icon-sm"
-            disabled={canStopTurn ? false : !canSend}
-            onClick={canStopTurn ? onInterrupt : undefined}
-            aria-label={canStopTurn ? "Stop turn" : "Send message"}
-            // The destination Enter is armed with used to be spelled out beside
-            // the button. The row reads better without a line of prose in it, but
-            // the fact is not decoration, so it moves onto the control it
-            // describes rather than being dropped.
-            title={canStopTurn ? "Stop turn" : sendHint}
-            className={cn(
-              "size-7 rounded-full border-transparent focus-visible:ring-ring/40",
-              canStopTurn || canSend
-                ? "bg-foreground text-background hover:bg-foreground/90 hover:text-background dark:hover:bg-foreground/90 dark:hover:text-background"
-                : "bg-primary text-primary-foreground",
-            )}
-          >
-            {canStopTurn ? (
-              <Square aria-hidden="true" className="size-2.5 fill-current" />
-            ) : steerPending || savingQueuedEditPending || sendPending ? (
-              <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
-            ) : (
-              <ArrowUp aria-hidden="true" className="size-3.5" />
-            )}
-          </Button>
-        </div>
-      </div>
-    </form>,
-  );
+					<div role="group" aria-label="Send message controls" className="flex h-7 shrink-0 items-center">
+						<Button
+							type={canStopTurn ? "button" : "submit"}
+							variant="ghost"
+							size="icon-sm"
+							disabled={canStopTurn ? false : !canSend}
+							onClick={canStopTurn ? onInterrupt : undefined}
+							aria-label={canStopTurn ? "Stop turn" : "Send message"}
+							// The destination Enter is armed with used to be spelled out beside
+							// the button. The row reads better without a line of prose in it, but
+							// the fact is not decoration, so it moves onto the control it
+							// describes rather than being dropped.
+							title={canStopTurn ? "Stop turn" : sendHint}
+							className={cn(
+								"size-7 rounded-full border-transparent focus-visible:ring-ring/40",
+								canStopTurn || canSend
+									? "bg-foreground text-background hover:bg-foreground/90 hover:text-background dark:hover:bg-foreground/90 dark:hover:text-background"
+									: "bg-primary text-primary-foreground",
+							)}
+						>
+							{canStopTurn ? (
+								<Square aria-hidden="true" className="size-2.5 fill-current" />
+							) : steerPending || savingQueuedEditPending || sendPending ? (
+								<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+							) : (
+								<ArrowUp aria-hidden="true" className="size-3.5" />
+							)}
+						</Button>
+					</div>
+				</div>
+			</form>,
+	);
 }

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -27,18 +27,20 @@
  */
 
 import {
-	useCallback,
-	useEffect,
-	useId,
-	useMemo,
-	useRef,
-	useState,
-	type ClipboardEvent,
-	type DragEvent,
-	type FormEvent,
-	type KeyboardEvent,
-	type ReactElement,
-	type ReactNode,
+  cloneElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  isValidElement,
+  type ClipboardEvent,
+  type DragEvent,
+  type FormEvent,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode,
 } from "react";
 import { ArrowUp, Loader2, Plus, Square, X } from "lucide-react";
 import { Button } from "../ui/button";
@@ -46,16 +48,21 @@ import { cn } from "../../lib/utils";
 import { apiErrorMessage } from "../../lib/api-client";
 import { ComposerSuggestMenu } from "./ComposerSuggestMenu";
 import {
-	ComposerEditor,
-	type ComposerEditorHandle,
-	type ComposerEditorSnapshot,
-	type ComposerTrigger,
+  ComposerEditor,
+  type ComposerEditorHandle,
+  type ComposerEditorSnapshot,
+  type ComposerTrigger,
 } from "./ComposerEditor";
-import { moveHighlight, rankFiles, rankSkills, type Suggestion } from "./composerSuggest";
 import {
-	isSupportedImageAttachment,
-	useFileAttachments,
-	type FileAttachmentPayload,
+  moveHighlight,
+  rankFiles,
+  rankSkills,
+  type Suggestion,
+} from "./composerSuggest";
+import {
+  isSupportedImageAttachment,
+  useFileAttachments,
+  type FileAttachmentPayload,
 } from "../../hooks/useFileAttachments";
 import { File } from "lucide-react";
 import type { ChatSkill } from "../../types/conversation";
@@ -66,781 +73,849 @@ import type { ChatSkill } from "../../types/conversation";
  * spawn or mid-conversation.
  */
 function withAttachmentReferences(text: string, paths: string[]): string {
-	if (paths.length === 0) return text;
-	const lead = text.trim() === "" ? "" : `${text}\n\n`;
-	return `${lead}Attached files (read these files in the workspace):\n${paths.map((path) => `- ${path}`).join("\n")}`;
+  if (paths.length === 0) return text;
+  const lead = text.trim() === "" ? "" : `${text}\n\n`;
+  return `${lead}Attached files (read these files in the workspace):\n${paths.map((path) => `- ${path}`).join("\n")}`;
 }
 
 export function ChatComposer({
-	onSend,
-	busy,
-	willQueue,
-	disabled,
-	settings,
-	approval,
-	skills = [],
-	filePaths = [],
-	filePathsTruncated,
-	onStageAttachments,
-	nativeImages,
-	onSteer,
-	onInterrupt,
-	canSteer,
-	sendPending,
-	steerPending,
-	steerRefusal,
-	draftSeed,
-	editingQueuedTurnId,
-	onCancelQueuedEdit,
-	savingQueuedEditPending,
-	commandError,
-	attachedTop = false,
-	queuedDock,
-	onCompact,
-	compacting,
-	compactUnavailable,
-	compactBlocked,
-	autoFocusKey,
-	autoFocus = true,
+  onSend,
+  busy,
+  willQueue,
+  disabled,
+  settings,
+  approval,
+  skills = [],
+  filePaths = [],
+  filePathsTruncated,
+  onStageAttachments,
+  nativeImages,
+  onSteer,
+  onInterrupt,
+  canSteer,
+  sendPending,
+  steerPending,
+  steerRefusal,
+  draftSeed,
+  editingQueuedTurnId,
+  onCancelQueuedEdit,
+  savingQueuedEditPending,
+  commandError,
+  attachedTop = false,
+  queuedDock,
+  onCompact,
+  compacting,
+  compactUnavailable,
+  compactBlocked,
+  autoFocusKey,
+  autoFocus = true,
 }: {
-	onSend: (text: string, attachments?: FileAttachmentPayload[]) => void | Promise<unknown>;
-	settings?: ReactNode;
-	/** A provider decision that temporarily replaces ordinary message entry. */
-	approval?: ReactNode;
-	/** A send is in flight. */
-	busy?: boolean;
-	/** The agent is mid-turn, so this message is held until the turn ends. */
-	willQueue?: boolean;
-	disabled?: boolean;
-	/** The provider's skills. Empty leaves `/` an ordinary character. */
-	skills?: ChatSkill[];
-	/** Worktree-relative paths offered for `@`. Empty leaves `@` ordinary. */
-	filePaths?: string[];
-	/** The path list was capped, so the menu says so rather than implying it is all. */
-	filePathsTruncated?: boolean;
-	/**
-	 * Writes staged files into the worktree and answers with the paths the agent
-	 * can open. Absent means files cannot be delivered, and no attach control is
-	 * offered at all.
-	 */
-	onStageAttachments?: (attachments: FileAttachmentPayload[]) => Promise<string[]>;
-	/** Send the same staged bytes as native ACP image blocks when negotiated. */
-	nativeImages?: boolean;
-	/**
-	 * Deliver this text into the turn already running. Absent means the harness
-	 * cannot steer and the choice is never offered.
-	 */
-	onSteer?: (text: string) => Promise<unknown>;
-	/** Stop the turn already running when there is no draft to send. */
-	onInterrupt?: () => void;
-	/** A turn is actually running, so there is something to steer into. */
-	canSteer?: boolean;
-	/** A send mutation is in flight for this session. */
-	sendPending?: boolean;
-	steerPending?: boolean;
-	/** Why the last steer was refused. */
-	steerRefusal?: string;
-	/** A selected history message to load into the composer as a new draft. */
-	draftSeed?: { id: string; text: string };
-	/** A queued turn being edited in the composer instead of the dock. */
-	editingQueuedTurnId?: string;
-	onCancelQueuedEdit?: () => void;
-	/** The queued edit mutation is in flight for the turn being edited. */
-	savingQueuedEditPending?: boolean;
-	/** A failed send, approval, interrupt, or settings mutation. */
-	commandError?: string;
-	/** A queued-message dock owns the shared rounded top edge. */
-	attachedTop?: boolean;
-	/** Queued messages rendered above the composer. */
-	queuedDock?: ReactNode;
-	/** Run AO's built-in `/compact` command instead of sending it to the agent. */
-	onCompact?: () => void | Promise<unknown>;
-	/** The provider is already compacting this conversation. */
-	compacting?: boolean;
-	/** A typed provider refusal from the last compaction attempt. */
-	compactUnavailable?: string;
-	/** A running turn must be stopped before its history can be compacted. */
-	compactBlocked?: boolean;
-	/** Changes when the owning chat surface should reclaim composer focus. */
-	autoFocusKey?: string;
-	/** Whether this composer is currently visible and should take focus. */
-	autoFocus?: boolean;
+  onSend: (
+    text: string,
+    attachments?: FileAttachmentPayload[],
+  ) => void | Promise<unknown>;
+  settings?: ReactNode;
+  /** A provider decision that temporarily replaces ordinary message entry. */
+  approval?: ReactNode;
+  /** A send is in flight. */
+  busy?: boolean;
+  /** The agent is mid-turn, so this message is held until the turn ends. */
+  willQueue?: boolean;
+  disabled?: boolean;
+  /** The provider's skills. Empty leaves `/` an ordinary character. */
+  skills?: ChatSkill[];
+  /** Worktree-relative paths offered for `@`. Empty leaves `@` ordinary. */
+  filePaths?: string[];
+  /** The path list was capped, so the menu says so rather than implying it is all. */
+  filePathsTruncated?: boolean;
+  /**
+   * Writes staged files into the worktree and answers with the paths the agent
+   * can open. Absent means files cannot be delivered, and no attach control is
+   * offered at all.
+   */
+  onStageAttachments?: (
+    attachments: FileAttachmentPayload[],
+  ) => Promise<string[]>;
+  /** Send the same staged bytes as native ACP image blocks when negotiated. */
+  nativeImages?: boolean;
+  /**
+   * Deliver this text into the turn already running. Absent means the harness
+   * cannot steer and the choice is never offered.
+   */
+  onSteer?: (text: string) => Promise<unknown>;
+  /** Stop the turn already running when there is no draft to send. */
+  onInterrupt?: () => void;
+  /** A turn is actually running, so there is something to steer into. */
+  canSteer?: boolean;
+  /** A send mutation is in flight for this session. */
+  sendPending?: boolean;
+  steerPending?: boolean;
+  /** Why the last steer was refused. */
+  steerRefusal?: string;
+  /** A selected history message to load into the composer as a new draft. */
+  draftSeed?: { id: string; text: string };
+  /** A queued turn being edited in the composer instead of the dock. */
+  editingQueuedTurnId?: string;
+  onCancelQueuedEdit?: () => void;
+  /** The queued edit mutation is in flight for the turn being edited. */
+  savingQueuedEditPending?: boolean;
+  /** A failed send, approval, interrupt, or settings mutation. */
+  commandError?: string;
+  /** A queued-message dock owns the shared rounded top edge. */
+  attachedTop?: boolean;
+  /** Queued messages rendered above the composer. */
+  queuedDock?: ReactNode;
+  /** Run AO's built-in `/compact` command instead of sending it to the agent. */
+  onCompact?: () => void | Promise<unknown>;
+  /** The provider is already compacting this conversation. */
+  compacting?: boolean;
+  /** A typed provider refusal from the last compaction attempt. */
+  compactUnavailable?: string;
+  /** A running turn must be stopped before its history can be compacted. */
+  compactBlocked?: boolean;
+  /** Changes when the owning chat surface should reclaim composer focus. */
+  autoFocusKey?: string;
+  /** Whether this composer is currently visible and should take focus. */
+  autoFocus?: boolean;
 }) {
-	const [hasText, setHasText] = useState(false);
-	const hasTextRef = useRef(false);
-	const [trigger, setTrigger] = useState<ComposerTrigger>();
-	/**
-	 * The trigger position the user dismissed with Escape. Held so the menu stays
-	 * shut for the completion they rejected, while a new `/` or `@` still opens one.
-	 */
-	const [dismissedKey, setDismissedKey] = useState<string | null>(null);
-	const dismissedKeyRef = useRef<string | null>(null);
-	const [highlighted, setHighlighted] = useState(0);
-	const highlightedRef = useRef(0);
-	const [isComposing, setIsComposing] = useState(false);
-	const [dragging, setDragging] = useState(false);
-	const [sendError, setSendError] = useState<string | null>(null);
-	// The DOM event is the source of truth while React catches up with the draft
-	// transition. This keeps Enter-after-fast-typing from observing stale state.
-	const textRef = useRef("");
-	/**
-	 * What Enter does while the agent is working.
-	 *
-	 * Queueing is the safe default and matches `ao send`: the daemon records the
-	 * message durably and dispatches it when the current turn finishes. Steering is
-	 * timing-sensitive and changes the running turn, so it stays an explicit choice.
-	 */
+  const [hasText, setHasText] = useState(false);
+  const hasTextRef = useRef(false);
+  const [trigger, setTrigger] = useState<ComposerTrigger>();
+  /**
+   * The trigger position the user dismissed with Escape. Held so the menu stays
+   * shut for the completion they rejected, while a new `/` or `@` still opens one.
+   */
+  const [dismissedKey, setDismissedKey] = useState<string | null>(null);
+  const dismissedKeyRef = useRef<string | null>(null);
+  const [highlighted, setHighlighted] = useState(0);
+  const highlightedRef = useRef(0);
+  const [isComposing, setIsComposing] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [steerNextRequest, setSteerNextRequest] = useState(0);
+  // The DOM event is the source of truth while React catches up with the draft
+  // transition. This keeps Enter-after-fast-typing from observing stale state.
+  const textRef = useRef("");
+  /**
+   * What Enter does while the agent is working.
+   *
+   * Queueing is the safe default and matches `ao send`: the daemon records the
+   * message durably and dispatches it when the current turn finishes. Steering is
+   * timing-sensitive and changes the running turn, so it stays an explicit choice.
+   */
 
-	const editor = useRef<ComposerEditorHandle>(null);
-	const filePicker = useRef<HTMLInputElement>(null);
-	const stagedDelivery = useRef<{ signature: string; paths: string[] } | null>(null);
-	const submitInFlight = useRef<Promise<void> | null>(null);
-	const menuId = useId();
-	const previousTrigger = useRef<ComposerTrigger | undefined>(undefined);
-	const triggerRef = useRef<ComposerTrigger | undefined>(undefined);
+  const editor = useRef<ComposerEditorHandle>(null);
+  const filePicker = useRef<HTMLInputElement>(null);
+  const stagedDelivery = useRef<{ signature: string; paths: string[] } | null>(
+    null,
+  );
+  const submitInFlight = useRef<Promise<void> | null>(null);
+  const menuId = useId();
+  const previousTrigger = useRef<ComposerTrigger | undefined>(undefined);
+  const triggerRef = useRef<ComposerTrigger | undefined>(undefined);
 
-	const fileAttachments = useFileAttachments();
-	const canAttach = Boolean(onStageAttachments);
+  const fileAttachments = useFileAttachments();
+  const canAttach = Boolean(onStageAttachments);
 
-	const slashCommands = useMemo<ChatSkill[]>(() => {
-		if (!onCompact || compactUnavailable === "This agent cannot compact its history") return skills;
-		return [
-			{
-				name: "compact",
-				displayName: "compact",
-				description: "Summarize earlier history to reclaim context",
-				source: "AO",
-			},
-			...skills.filter((skill) => skill.name !== "compact"),
-		];
-	}, [compactUnavailable, onCompact, skills]);
+  const slashCommands = useMemo<ChatSkill[]>(() => {
+    if (
+      !onCompact ||
+      compactUnavailable === "This agent cannot compact its history"
+    )
+      return skills;
+    return [
+      {
+        name: "compact",
+        displayName: "compact",
+        description: "Summarize earlier history to reclaim context",
+        source: "AO",
+      },
+      ...skills.filter((skill) => skill.name !== "compact"),
+    ];
+  }, [compactUnavailable, onCompact, skills]);
 
-	const suggestionsFor = useCallback((currentTrigger?: ComposerTrigger): Suggestion[] => {
-		if (!currentTrigger || currentTrigger.key === dismissedKeyRef.current) return [];
-		// An empty candidate list is the whole reason the sigil stays ordinary: with
-		// no commands or skills there is nothing to open, so `/` types a slash.
-		if (currentTrigger.kind === "skill") {
-			return rankSkills(slashCommands, currentTrigger.query);
-		}
-		return rankFiles(filePaths, currentTrigger.query);
-	}, [slashCommands, filePaths]);
+  const suggestionsFor = useCallback(
+    (currentTrigger?: ComposerTrigger): Suggestion[] => {
+      if (!currentTrigger || currentTrigger.key === dismissedKeyRef.current)
+        return [];
+      // An empty candidate list is the whole reason the sigil stays ordinary: with
+      // no commands or skills there is nothing to open, so `/` types a slash.
+      if (currentTrigger.kind === "skill") {
+        return rankSkills(slashCommands, currentTrigger.query);
+      }
+      return rankFiles(filePaths, currentTrigger.query);
+    },
+    [slashCommands, filePaths],
+  );
 
-	const suggestions: Suggestion[] = useMemo(
-		() => suggestionsFor(trigger),
-		[trigger, dismissedKey, suggestionsFor],
-	);
+  const suggestions: Suggestion[] = useMemo(
+    () => suggestionsFor(trigger),
+    [trigger, dismissedKey, suggestionsFor],
+  );
 
-	const menuOpen = suggestions.length > 0;
-	// Clamped rather than trusted: the list re-ranks on every keystroke, so the
-	// index from the previous list can point past the end of this one.
-	const activeIndex = Math.min(highlighted, suggestions.length - 1);
+  const menuOpen = suggestions.length > 0;
+  // Clamped rather than trusted: the list re-ranks on every keystroke, so the
+  // index from the previous list can point past the end of this one.
+  const activeIndex = Math.min(highlighted, suggestions.length - 1);
 
-	const staged = fileAttachments.attachments.length > 0;
-	const hasDraft = hasText || staged;
-	const savingQueuedEdit = Boolean(editingQueuedTurnId);
-	const canSend =
-		(hasText || staged) &&
-		!disabled &&
-		!steerPending &&
-		!savingQueuedEditPending &&
-		(savingQueuedEdit || !busy);
-	const canStopTurn = Boolean(willQueue && onInterrupt && !disabled && !hasDraft && !savingQueuedEdit);
-	// Steering delivers text only, so a draft carrying files cannot take that
-	// path. Treating it as unavailable — rather than steering the text and
-	// dropping the files, or refusing on an empty body with attachments staged —
-	// keeps the armed state something the composer can actually honour.
-	const canSteerDraft = Boolean(canSteer && onSteer) && !staged && !savingQueuedEdit;
-	const sendHint = menuOpen
-		? "Enter to insert"
-		: savingQueuedEdit
-			? "⏎ save edit"
-			: willQueue && canSteerDraft
-				? "⏎ queue · ⌘⏎ steer"
-				: willQueue
-					? "⏎ queue"
-					: "Enter to send";
-	const draftSeedId = draftSeed?.id;
-	const draftSeedText = draftSeed?.text;
+  const staged = fileAttachments.attachments.length > 0;
+  const hasDraft = hasText || staged;
+  const savingQueuedEdit = Boolean(editingQueuedTurnId);
+  const canSend =
+    (hasText || staged) &&
+    !disabled &&
+    !steerPending &&
+    !savingQueuedEditPending &&
+    (savingQueuedEdit || !busy);
+  const canStopTurn = Boolean(
+    willQueue && onInterrupt && !disabled && !hasDraft && !savingQueuedEdit,
+  );
+  const canSteerNext =
+    Boolean(canSteer && onSteer) &&
+    !disabled &&
+    !hasDraft &&
+    !savingQueuedEdit &&
+    Boolean(queuedDock);
+  const sendHint = menuOpen
+    ? "Enter to insert"
+    : savingQueuedEdit
+      ? "⏎ save edit"
+      : willQueue && canSteerNext
+        ? "⏎ queue · Enter steer"
+        : willQueue
+          ? "⏎ queue"
+          : "Enter to send";
+  const draftSeedId = draftSeed?.id;
+  const draftSeedText = draftSeed?.text;
+  const queuedDockWithSteer = isValidElement(queuedDock)
+    ? cloneElement(
+        queuedDock as ReactElement<{
+          canSteerNext?: boolean;
+          steerNextRequest?: number;
+        }>,
+        { canSteerNext, steerNextRequest },
+      )
+    : queuedDock;
 
-	const focusEditor = useCallback(() => {
-		if (!autoFocus || disabled) return;
-		editor.current?.focus();
-	}, [autoFocus, disabled]);
+  const focusEditor = useCallback(() => {
+    if (!autoFocus || disabled) return;
+    editor.current?.focus();
+  }, [autoFocus, disabled]);
 
-	useEffect(() => {
-		focusEditor();
-	}, [autoFocusKey, focusEditor]);
+  useEffect(() => {
+    focusEditor();
+  }, [autoFocusKey, focusEditor]);
 
-	useEffect(() => {
-		if (!autoFocus) return;
+  useEffect(() => {
+    if (!autoFocus) return;
 
-		const onWindowFocus = () => focusEditor();
-		const onVisibilityChange = () => {
-			if (document.visibilityState === "visible") focusEditor();
-		};
+    const onWindowFocus = () => focusEditor();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") focusEditor();
+    };
 
-		window.addEventListener("focus", onWindowFocus);
-		document.addEventListener("visibilitychange", onVisibilityChange);
-		return () => {
-			window.removeEventListener("focus", onWindowFocus);
-			document.removeEventListener("visibilitychange", onVisibilityChange);
-		};
-	}, [autoFocus, focusEditor]);
+    window.addEventListener("focus", onWindowFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("focus", onWindowFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [autoFocus, focusEditor]);
 
-	const clearEditor = useCallback(() => {
-		textRef.current = "";
-		hasTextRef.current = false;
-		setHasText(false);
-		setTrigger(undefined);
-		triggerRef.current = undefined;
-		previousTrigger.current = undefined;
-		dismissedKeyRef.current = null;
-		setDismissedKey(null);
-		highlightedRef.current = 0;
-		setHighlighted(0);
-		editor.current?.clear();
-	}, []);
+  const clearEditor = useCallback(() => {
+    textRef.current = "";
+    hasTextRef.current = false;
+    setHasText(false);
+    setTrigger(undefined);
+    triggerRef.current = undefined;
+    previousTrigger.current = undefined;
+    dismissedKeyRef.current = null;
+    setDismissedKey(null);
+    highlightedRef.current = 0;
+    setHighlighted(0);
+    editor.current?.clear();
+  }, []);
 
-	useEffect(() => {
-		if (draftSeedText === undefined) return;
-		textRef.current = draftSeedText;
-		hasTextRef.current = draftSeedText.trim().length > 0;
-		setHasText(hasTextRef.current);
-		editor.current?.setText(draftSeedText);
-		dismissedKeyRef.current = null;
-		setDismissedKey(null);
-		highlightedRef.current = 0;
-		setHighlighted(0);
-		setSendError(null);
-	}, [draftSeedId, draftSeedText]);
+  useEffect(() => {
+    if (draftSeedText === undefined) return;
+    textRef.current = draftSeedText;
+    hasTextRef.current = draftSeedText.trim().length > 0;
+    setHasText(hasTextRef.current);
+    editor.current?.setText(draftSeedText);
+    dismissedKeyRef.current = null;
+    setDismissedKey(null);
+    highlightedRef.current = 0;
+    setHighlighted(0);
+    setSendError(null);
+  }, [draftSeedId, draftSeedText]);
 
-	const previousEditingQueuedTurnIdRef = useRef(editingQueuedTurnId);
-	useEffect(() => {
-		const previous = previousEditingQueuedTurnIdRef.current;
-		previousEditingQueuedTurnIdRef.current = editingQueuedTurnId;
-		if (previous && !editingQueuedTurnId) {
-			clearEditor();
-		}
-	}, [clearEditor, editingQueuedTurnId]);
+  const previousEditingQueuedTurnIdRef = useRef(editingQueuedTurnId);
+  useEffect(() => {
+    const previous = previousEditingQueuedTurnIdRef.current;
+    previousEditingQueuedTurnIdRef.current = editingQueuedTurnId;
+    if (previous && !editingQueuedTurnId) {
+      clearEditor();
+    }
+  }, [clearEditor, editingQueuedTurnId]);
 
-	const onEditorChange = useCallback((snapshot: ComposerEditorSnapshot) => {
-		textRef.current = snapshot.text;
-		if (hasTextRef.current !== snapshot.hasText) {
-			hasTextRef.current = snapshot.hasText;
-			setHasText(snapshot.hasText);
-		}
+  const onEditorChange = useCallback((snapshot: ComposerEditorSnapshot) => {
+    textRef.current = snapshot.text;
+    if (hasTextRef.current !== snapshot.hasText) {
+      hasTextRef.current = snapshot.hasText;
+      setHasText(snapshot.hasText);
+    }
 
-		const previous = previousTrigger.current;
-		const next = snapshot.trigger;
-		triggerRef.current = next;
-		if (
-			previous?.key !== next?.key ||
-			previous?.end !== next?.end ||
-			previous?.query !== next?.query ||
-			previous?.kind !== next?.kind
-		) {
-			highlightedRef.current = 0;
-			setHighlighted(0);
-			previousTrigger.current = next;
-			setTrigger(next);
-		}
-		if (dismissedKeyRef.current && next?.key !== dismissedKeyRef.current) {
-			dismissedKeyRef.current = null;
-			setDismissedKey(null);
-		}
-	}, []);
+    const previous = previousTrigger.current;
+    const next = snapshot.trigger;
+    triggerRef.current = next;
+    if (
+      previous?.key !== next?.key ||
+      previous?.end !== next?.end ||
+      previous?.query !== next?.query ||
+      previous?.kind !== next?.kind
+    ) {
+      highlightedRef.current = 0;
+      setHighlighted(0);
+      previousTrigger.current = next;
+      setTrigger(next);
+    }
+    if (dismissedKeyRef.current && next?.key !== dismissedKeyRef.current) {
+      dismissedKeyRef.current = null;
+      setDismissedKey(null);
+    }
+  }, []);
 
-	const pick = useCallback((value: string) => {
-		const currentTrigger = triggerRef.current;
-		if (!currentTrigger) return;
-		editor.current?.insertToken(currentTrigger, value);
-		triggerRef.current = undefined;
-		previousTrigger.current = undefined;
-		setTrigger(undefined);
-		highlightedRef.current = 0;
-		setHighlighted(0);
-		dismissedKeyRef.current = null;
-		setDismissedKey(null);
-	}, []);
+  const pick = useCallback((value: string) => {
+    const currentTrigger = triggerRef.current;
+    if (!currentTrigger) return;
+    editor.current?.insertToken(currentTrigger, value);
+    triggerRef.current = undefined;
+    previousTrigger.current = undefined;
+    setTrigger(undefined);
+    highlightedRef.current = 0;
+    setHighlighted(0);
+    dismissedKeyRef.current = null;
+    setDismissedKey(null);
+  }, []);
 
-	useEffect(() => {
-		if (isComposing || !trigger || trigger.kind !== "skill" || trigger.key === dismissedKey) return;
-		const query = trigger.query.toLowerCase();
-		if (!query) return;
-		const exact = slashCommands.find((skill) => skill.name.toLowerCase() === query);
-		if (!exact) return;
+  useEffect(() => {
+    if (
+      isComposing ||
+      !trigger ||
+      trigger.kind !== "skill" ||
+      trigger.key === dismissedKey
+    )
+      return;
+    const query = trigger.query.toLowerCase();
+    if (!query) return;
+    const exact = slashCommands.find(
+      (skill) => skill.name.toLowerCase() === query,
+    );
+    if (!exact) return;
 
-		// Do not eagerly accept a skill whose full name is also the start of another
-		// skill. The user must still be able to type `/review-pr` when `/review`
-		// exists; Enter remains available to accept the shorter exact match.
-		const hasLongerPrefix = slashCommands.some((skill) => {
-			const name = skill.name.toLowerCase();
-			return name.length > query.length && name.startsWith(query);
-		});
-		if (!hasLongerPrefix) pick(exact.name);
-	}, [dismissedKey, isComposing, pick, slashCommands, trigger]);
+    // Do not eagerly accept a skill whose full name is also the start of another
+    // skill. The user must still be able to type `/review-pr` when `/review`
+    // exists; Enter remains available to accept the shorter exact match.
+    const hasLongerPrefix = slashCommands.some((skill) => {
+      const name = skill.name.toLowerCase();
+      return name.length > query.length && name.startsWith(query);
+    });
+    if (!hasLongerPrefix) pick(exact.name);
+  }, [dismissedKey, isComposing, pick, slashCommands, trigger]);
 
-	const completeFromEditor = useCallback(
-		(snapshot: ComposerEditorSnapshot, key: "Enter" | "Tab"): string | undefined => {
-			const currentTrigger = snapshot.trigger;
-			if (!currentTrigger) return undefined;
-			if (key === "Enter" && snapshot.text.trim() === "/compact" && onCompact) {
-				return undefined;
-			}
-			const matches = suggestionsFor(currentTrigger);
-			const chosen = matches[Math.min(highlightedRef.current, matches.length - 1)];
-			if (!chosen) return undefined;
-			triggerRef.current = currentTrigger;
-			highlightedRef.current = 0;
-			dismissedKeyRef.current = null;
-			return chosen.value;
-		},
-		[onCompact, suggestionsFor],
-	);
+  const completeFromEditor = useCallback(
+    (
+      snapshot: ComposerEditorSnapshot,
+      key: "Enter" | "Tab",
+    ): string | undefined => {
+      const currentTrigger = snapshot.trigger;
+      if (!currentTrigger) return undefined;
+      if (key === "Enter" && snapshot.text.trim() === "/compact" && onCompact) {
+        return undefined;
+      }
+      const matches = suggestionsFor(currentTrigger);
+      const chosen =
+        matches[Math.min(highlightedRef.current, matches.length - 1)];
+      if (!chosen) return undefined;
+      triggerRef.current = currentTrigger;
+      highlightedRef.current = 0;
+      dismissedKeyRef.current = null;
+      return chosen.value;
+    },
+    [onCompact, suggestionsFor],
+  );
 
-	function submit(event?: FormEvent, forceSteer?: boolean): Promise<void> {
-		event?.preventDefault();
-		// React cannot publish the next busy prop until after this event returns. A
-		// second Enter in that gap joins the accepted submission instead of opening a
-		// second transport whose local admission rejection would look like a real
-		// provider failure.
-		if (submitInFlight.current) return submitInFlight.current;
-		const pending = performSubmit(forceSteer);
-		submitInFlight.current = pending;
-		const release = () => {
-			if (submitInFlight.current === pending) submitInFlight.current = null;
-		};
-		void pending.then(release, release);
-		return pending;
-	}
+  function submit(event?: FormEvent, forceSteer?: boolean): Promise<void> {
+    event?.preventDefault();
+    // React cannot publish the next busy prop until after this event returns. A
+    // second Enter in that gap joins the accepted submission instead of opening a
+    // second transport whose local admission rejection would look like a real
+    // provider failure.
+    if (submitInFlight.current) return submitInFlight.current;
+    const pending = performSubmit(forceSteer);
+    submitInFlight.current = pending;
+    const release = () => {
+      if (submitInFlight.current === pending) submitInFlight.current = null;
+    };
+    void pending.then(release, release);
+    return pending;
+  }
 
-	async function performSubmit(forceSteer?: boolean) {
-		const currentText = textRef.current;
-		const body = currentText.trim();
+  async function performSubmit(forceSteer?: boolean) {
+    const currentText = textRef.current;
+    const body = currentText.trim();
 
-		// `/compact` is a local AO command. It must refuse while a turn is running
-		// without being blocked by the ordinary busy send gate.
-		if (body === "/compact" && onCompact) {
-			setSendError(null);
-			if (compactBlocked) {
-				setSendError("Stop the current turn before compacting.");
-				return;
-			}
-			if (compacting) {
-				setSendError("Conversation history is already being compacted.");
-				return;
-			}
-			if (compactUnavailable) {
-				setSendError(compactUnavailable);
-				return;
-			}
-			try {
-				await onCompact();
-			} catch {
-				setSendError("Conversation history could not be compacted. Try again.");
-				return;
-			}
-			clearEditor();
-			setDismissedKey(null);
-			setHighlighted(0);
-			return;
-		}
+    // `/compact` is a local AO command. It must refuse while a turn is running
+    // without being blocked by the ordinary busy send gate.
+    if (body === "/compact" && onCompact) {
+      setSendError(null);
+      if (compactBlocked) {
+        setSendError("Stop the current turn before compacting.");
+        return;
+      }
+      if (compacting) {
+        setSendError("Conversation history is already being compacted.");
+        return;
+      }
+      if (compactUnavailable) {
+        setSendError(compactUnavailable);
+        return;
+      }
+      try {
+        await onCompact();
+      } catch {
+        setSendError("Conversation history could not be compacted. Try again.");
+        return;
+      }
+      clearEditor();
+      setDismissedKey(null);
+      setHighlighted(0);
+      return;
+    }
 
-		const canSubmitNow =
-			(currentText.trim().length > 0 || staged) &&
-			!disabled &&
-			!steerPending &&
-			!savingQueuedEditPending &&
-			(editingQueuedTurnId || !busy);
-		if (!canSubmitNow) {
-			if (
-				(currentText.trim().length > 0 || staged) &&
-				busy &&
-				!disabled &&
-				!steerPending &&
-				!savingQueuedEditPending &&
-				!editingQueuedTurnId
-			) {
-				setSendError("Still sending the previous message. Try again in a moment.");
-			}
-			return;
-		}
-		setSendError(null);
+    const canSubmitNow =
+      (currentText.trim().length > 0 || staged) &&
+      !disabled &&
+      !steerPending &&
+      !savingQueuedEditPending &&
+      (editingQueuedTurnId || !busy);
+    if (!canSubmitNow) {
+      if (
+        (currentText.trim().length > 0 || staged) &&
+        busy &&
+        !disabled &&
+        !steerPending &&
+        !savingQueuedEditPending &&
+        !editingQueuedTurnId
+      ) {
+        setSendError(
+          "Still sending the previous message. Try again in a moment.",
+        );
+      }
+      return;
+    }
+    setSendError(null);
 
-		const shouldSteer = forceSteer ?? false;
+    const shouldSteer = forceSteer ?? false;
 
-		// Steering keeps the text in the box until the provider has taken it. The turn
-		// is already running, so a refusal is a real possibility — and a refusal that
-		// had already cleared the composer would lose what the user typed.
-		if (shouldSteer && onSteer && !editingQueuedTurnId) {
-			if (body === "") return;
-			try {
-				await onSteer(body);
-			} catch {
-				// The refusal is the daemon's typed answer and the surface renders it from
-				// `steerRefusal`; keep the draft, but arm the reliable queue path for the
-				// next Enter in case the turn ended while the user was typing.
-				return;
-			}
-			clearEditor();
-			setDismissedKey(null);
-			setHighlighted(0);
-			return;
-		}
+    // Steering keeps the text in the box until the provider has taken it. The turn
+    // is already running, so a refusal is a real possibility — and a refusal that
+    // had already cleared the composer would lose what the user typed.
+    if (shouldSteer && onSteer && !editingQueuedTurnId) {
+      if (body === "") return;
+      try {
+        await onSteer(body);
+      } catch {
+        // The refusal is the daemon's typed answer and the surface renders it from
+        // `steerRefusal`; keep the draft, but arm the reliable queue path for the
+        // next Enter in case the turn ended while the user was typing.
+        return;
+      }
+      clearEditor();
+      setDismissedKey(null);
+      setHighlighted(0);
+      return;
+    }
 
-		if (staged && onStageAttachments) {
-			// Staged before the send so a failed write is reported instead of a
-			// message that claims attachments the agent cannot open.
-			let paths: string[];
-			const signature = fileAttachments.attachments.map((file) => file.id).join(":");
-			try {
-				if (stagedDelivery.current?.signature === signature) {
-					paths = stagedDelivery.current.paths;
-				} else {
-					paths = await onStageAttachments(fileAttachments.toPayload());
-					stagedDelivery.current = { signature, paths };
-				}
-			} catch {
-				setSendError("The files could not be attached. Nothing was sent.");
-				return;
-			}
-			try {
-				const message = withAttachmentReferences(body, paths);
-				const nativePayloads = fileAttachments
-					.toPayload()
-					.filter((attachment) => isSupportedImageAttachment(attachment.mimeType));
-				if (nativeImages && nativePayloads.length > 0) await onSend(message, nativePayloads);
-				else await onSend(message);
-			} catch {
-				setSendError("Message not sent. Your draft and attachments were kept so you can retry.");
-				return;
-			}
-			stagedDelivery.current = null;
-			fileAttachments.clear();
-		} else {
-			try {
-				await onSend(body);
-			} catch (error) {
-				setSendError(
-					editingQueuedTurnId
-						? apiErrorMessage(error, "Could not save that queued message edit. Your draft was kept.")
-						: "Message not sent. Your draft was kept so you can retry.",
-				);
-				return;
-			}
-		}
+    if (staged && onStageAttachments) {
+      // Staged before the send so a failed write is reported instead of a
+      // message that claims attachments the agent cannot open.
+      let paths: string[];
+      const signature = fileAttachments.attachments
+        .map((file) => file.id)
+        .join(":");
+      try {
+        if (stagedDelivery.current?.signature === signature) {
+          paths = stagedDelivery.current.paths;
+        } else {
+          paths = await onStageAttachments(fileAttachments.toPayload());
+          stagedDelivery.current = { signature, paths };
+        }
+      } catch {
+        setSendError("The files could not be attached. Nothing was sent.");
+        return;
+      }
+      try {
+        const message = withAttachmentReferences(body, paths);
+        const nativePayloads = fileAttachments
+          .toPayload()
+          .filter((attachment) =>
+            isSupportedImageAttachment(attachment.mimeType),
+          );
+        if (nativeImages && nativePayloads.length > 0)
+          await onSend(message, nativePayloads);
+        else await onSend(message);
+      } catch {
+        setSendError(
+          "Message not sent. Your draft and attachments were kept so you can retry.",
+        );
+        return;
+      }
+      stagedDelivery.current = null;
+      fileAttachments.clear();
+    } else {
+      try {
+        await onSend(body);
+      } catch (error) {
+        setSendError(
+          editingQueuedTurnId
+            ? apiErrorMessage(
+                error,
+                "Could not save that queued message edit. Your draft was kept.",
+              )
+            : "Message not sent. Your draft was kept so you can retry.",
+        );
+        return;
+      }
+    }
 
-		clearEditor();
-		setDismissedKey(null);
-		setHighlighted(0);
-	}
+    clearEditor();
+    setDismissedKey(null);
+    setHighlighted(0);
+  }
 
-	const handleEnterKey = useCallback(
-		(event: globalThis.KeyboardEvent): boolean => {
-			const liveSnapshot = editor.current?.getSnapshot();
-			if (liveSnapshot) textRef.current = liveSnapshot.text;
-			const liveTrigger = liveSnapshot?.trigger;
-			const liveSuggestions = suggestionsFor(liveTrigger);
-			if (liveSuggestions.length > 0) {
-				if (textRef.current.trim() === "/compact" && onCompact) {
-					void submit();
-					return true;
-				}
-				triggerRef.current = liveTrigger;
-				const chosen = liveSuggestions[Math.min(highlightedRef.current, liveSuggestions.length - 1)];
-				if (chosen) pick(chosen.value);
-				return true;
-			}
+  const handleEnterKey = useCallback(
+    (_event: globalThis.KeyboardEvent): boolean => {
+      const liveSnapshot = editor.current?.getSnapshot();
+      if (liveSnapshot) textRef.current = liveSnapshot.text;
+      const liveTrigger = liveSnapshot?.trigger;
+      const liveSuggestions = suggestionsFor(liveTrigger);
+      if (liveSuggestions.length > 0) {
+        if (textRef.current.trim() === "/compact" && onCompact) {
+          void submit();
+          return true;
+        }
+        triggerRef.current = liveTrigger;
+        const chosen =
+          liveSuggestions[
+            Math.min(highlightedRef.current, liveSuggestions.length - 1)
+          ];
+        if (chosen) pick(chosen.value);
+        return true;
+      }
 
-			const wantsSteer = (event.metaKey || event.ctrlKey) && canSteerDraft;
-			void submit(undefined, wantsSteer);
-			return true;
-		},
-		[canSteerDraft, onCompact, pick, suggestionsFor],
-	);
+      if (canSteerNext) {
+        setSteerNextRequest((request) => request + 1);
+        return true;
+      }
+      void submit();
+      return true;
+    },
+    [canSteerNext, onCompact, pick, suggestionsFor],
+  );
 
-	function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-		if (event.nativeEvent.isComposing) return;
-		// Enter is handled in Lexical before a newline is inserted; this handler is
-		// only for menu navigation and escape while a completion menu is open.
-		const liveSnapshot = editor.current?.getSnapshot();
-		if (liveSnapshot) textRef.current = liveSnapshot.text;
-		const liveTrigger = liveSnapshot?.trigger;
-		const liveSuggestions = suggestionsFor(liveTrigger);
-		if (liveSuggestions.length > 0) {
-			if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-				event.preventDefault();
-				const next = moveHighlight(
-					Math.min(highlightedRef.current, liveSuggestions.length - 1),
-					event.key === "ArrowDown" ? 1 : -1,
-					liveSuggestions.length,
-				);
-				highlightedRef.current = next;
-				setHighlighted(next);
-				return;
-			}
-			if (event.key === "Escape") {
-				event.preventDefault();
-				event.stopPropagation();
-				dismissedKeyRef.current = liveTrigger?.key ?? null;
-				setDismissedKey(dismissedKeyRef.current);
-				return;
-			}
-		}
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.nativeEvent.isComposing) return;
+    // Enter is handled in Lexical before a newline is inserted; this handler is
+    // only for menu navigation and escape while a completion menu is open.
+    const liveSnapshot = editor.current?.getSnapshot();
+    if (liveSnapshot) textRef.current = liveSnapshot.text;
+    const liveTrigger = liveSnapshot?.trigger;
+    const liveSuggestions = suggestionsFor(liveTrigger);
+    if (liveSuggestions.length > 0) {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const next = moveHighlight(
+          Math.min(highlightedRef.current, liveSuggestions.length - 1),
+          event.key === "ArrowDown" ? 1 : -1,
+          liveSuggestions.length,
+        );
+        highlightedRef.current = next;
+        setHighlighted(next);
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        dismissedKeyRef.current = liveTrigger?.key ?? null;
+        setDismissedKey(dismissedKeyRef.current);
+        return;
+      }
+    }
 
-		if (event.key === "Escape" && editingQueuedTurnId && onCancelQueuedEdit) {
-			event.preventDefault();
-			clearEditor();
-			onCancelQueuedEdit();
-		}
-	}
+    if (event.key === "Escape" && editingQueuedTurnId && onCancelQueuedEdit) {
+      event.preventDefault();
+      clearEditor();
+      onCancelQueuedEdit();
+    }
+  }
 
-	function onPaste(event: ClipboardEvent<HTMLDivElement>) {
-		if (!canAttach) return;
-		const clipboard = event.clipboardData;
-		const files = Array.from(clipboard?.files ?? []);
-		if (files.length === 0) return;
-		// The paste is only claimed when there is no text alongside the image: a copy
-		// carrying both should still paste its text.
-		const hasText = typeof clipboard?.getData === "function" && clipboard.getData("text/plain") !== "";
-		if (!hasText) event.preventDefault();
-		void fileAttachments.addFiles(files);
-	}
+  function onPaste(event: ClipboardEvent<HTMLDivElement>) {
+    if (!canAttach) return;
+    const clipboard = event.clipboardData;
+    const files = Array.from(clipboard?.files ?? []);
+    if (files.length === 0) return;
+    // The paste is only claimed when there is no text alongside the image: a copy
+    // carrying both should still paste its text.
+    const hasText =
+      typeof clipboard?.getData === "function" &&
+      clipboard.getData("text/plain") !== "";
+    if (!hasText) event.preventDefault();
+    void fileAttachments.addFiles(files);
+  }
 
-	function onDrop(event: DragEvent<HTMLFormElement>) {
-		setDragging(false);
-		if (!canAttach) return;
-		const files = Array.from(event.dataTransfer?.files ?? []);
-		if (files.length === 0) return;
-		event.preventDefault();
-		event.stopPropagation();
-		void fileAttachments.addFiles(files);
-	}
+  function onDrop(event: DragEvent<HTMLFormElement>) {
+    setDragging(false);
+    if (!canAttach) return;
+    const files = Array.from(event.dataTransfer?.files ?? []);
+    if (files.length === 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    void fileAttachments.addFiles(files);
+  }
 
-	// Track Cmd/Ctrl for the send-button click path without re-rendering the composer
-	// on every modifier key event.
-	const modifierHeldRef = useRef(false);
-	useEffect(() => {
-		const onKey = (event: globalThis.KeyboardEvent) => {
-			modifierHeldRef.current = event.metaKey || event.ctrlKey;
-		};
-		const onBlur = () => {
-			modifierHeldRef.current = false;
-		};
-		window.addEventListener("keydown", onKey);
-		window.addEventListener("keyup", onKey);
-		window.addEventListener("blur", onBlur);
-		return () => {
-			window.removeEventListener("keydown", onKey);
-			window.removeEventListener("keyup", onKey);
-			window.removeEventListener("blur", onBlur);
-		};
-	}, []);
+  const attachmentError = fileAttachments.error ?? sendError ?? commandError;
+  const withQueueStack = (form: ReactElement) =>
+    queuedDock ? (
+      <div className="relative flex w-full flex-col">
+        <div
+          className="cursor-chat-composer-queue queue-dock-enter relative z-10 mx-auto mb-2 w-[calc(100%-2rem)]"
+          data-testid="queued-composer-dock"
+        >
+          {queuedDockWithSteer}
+        </div>
+        {form}
+      </div>
+    ) : (
+      form
+    );
 
-	const attachmentError = fileAttachments.error ?? sendError ?? commandError;
-	const withQueueStack = (form: ReactElement) =>
-		queuedDock ? (
-			<div className="relative flex w-full flex-col">
-				<div
-					className="cursor-chat-composer-queue queue-dock-enter relative z-10 mx-auto mb-2 w-[calc(100%-2rem)]"
-					data-testid="queued-composer-dock"
-				>
-					{queuedDock}
-				</div>
-				{form}
-			</div>
-		) : (
-			form
-		);
+  if (approval) {
+    return withQueueStack(
+      <form
+        onSubmit={(event) => event.preventDefault()}
+        data-attached-top={attachedTop && !queuedDock ? true : undefined}
+        className="cursor-chat-composer relative flex flex-col gap-1.5 border px-3 py-3 transition-[background,border-color,box-shadow]"
+      >
+        {approval}
+        {commandError ? (
+          <p
+            role="alert"
+            className="px-1.5 text-[11px] leading-snug text-destructive"
+          >
+            {commandError}
+          </p>
+        ) : null}
+      </form>,
+    );
+  }
 
-	if (approval) {
-		return withQueueStack(
-			<form
-				onSubmit={(event) => event.preventDefault()}
-				data-attached-top={attachedTop && !queuedDock ? true : undefined}
-				className="cursor-chat-composer relative flex flex-col gap-1.5 border px-3 py-3 transition-[background,border-color,box-shadow]"
-			>
-				{approval}
-				{commandError ? (
-					<p role="alert" className="px-1.5 text-[11px] leading-snug text-destructive">
-						{commandError}
-					</p>
-				) : null}
-			</form>,
-		);
-	}
+  return withQueueStack(
+    <form
+				// The send button always submits the typed draft. Steering is reserved for
+				// the empty-input Enter path handled by the editor above.
+      onSubmit={(event) => void submit(event)}
+      onDragOver={(event) => {
+        if (!canAttach) return;
+        event.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={() => setDragging(false)}
+      onDropCapture={onDrop}
+      // The border colors for rest, hover, focus and drag are one set of states
+      // on one surface, so they are declared together in CSS rather than half
+      // here and half there.
+      data-dragging={dragging || undefined}
+      data-attached-top={attachedTop && !queuedDock ? true : undefined}
+      onClick={(e) => {
+        if (
+          e.target === e.currentTarget ||
+          !(e.target as HTMLElement).closest("button, a, [role='option'], ul")
+        ) {
+          editor.current?.focus();
+        }
+      }}
+      className="cursor-chat-composer relative flex cursor-text flex-col gap-1.5 border px-3 pt-3 pb-3 transition-[background,border-color,box-shadow]"
+    >
+      {menuOpen && trigger ? (
+        <ComposerSuggestMenu
+          id={menuId}
+          kind={trigger.kind}
+          items={suggestions}
+          highlighted={activeIndex}
+          onPick={pick}
+          truncated={trigger?.kind === "file" && filePathsTruncated}
+        />
+      ) : null}
 
-	return withQueueStack(
-		<form
-				// Clicking send while Cmd/Ctrl is held has to mean what the indicator
-				// beside it says. Reading the same armed state the chip paints keeps the
-				// pointer and keyboard paths from disagreeing about where the message goes.
-				onSubmit={(event) => void submit(event, modifierHeldRef.current && canSteerDraft)}
-				onDragOver={(event) => {
-					if (!canAttach) return;
-					event.preventDefault();
-					setDragging(true);
-				}}
-				onDragLeave={() => setDragging(false)}
-				onDropCapture={onDrop}
-				// The border colors for rest, hover, focus and drag are one set of states
-				// on one surface, so they are declared together in CSS rather than half
-				// here and half there.
-				data-dragging={dragging || undefined}
-				data-attached-top={attachedTop && !queuedDock ? true : undefined}
-				onClick={(e) => {
-					if (
-						e.target === e.currentTarget ||
-						!(e.target as HTMLElement).closest("button, a, [role='option'], ul")
-					) {
-						editor.current?.focus();
-					}
-				}}
-				className="cursor-chat-composer relative flex cursor-text flex-col gap-1.5 border px-3 pt-3 pb-3 transition-[background,border-color,box-shadow]"
-			>
-				{menuOpen && trigger ? (
-					<ComposerSuggestMenu
-						id={menuId}
-						kind={trigger.kind}
-						items={suggestions}
-						highlighted={activeIndex}
-						onPick={pick}
-						truncated={trigger?.kind === "file" && filePathsTruncated}
-					/>
-				) : null}
+      {staged ? (
+        <ul className="flex flex-wrap gap-1.5" aria-label="Attached files">
+          {fileAttachments.attachments.map((file) => (
+            <li
+              key={file.id}
+              className="flex items-center gap-1.5 rounded border border-border bg-background py-0.5 pl-0.5 pr-1"
+            >
+              {file.dataUrl ? (
+                <img
+                  src={file.dataUrl}
+                  alt=""
+                  className="size-6 rounded-sm object-cover"
+                />
+              ) : (
+                <div className="flex size-6 items-center justify-center rounded-sm bg-surface">
+                  <File
+                    aria-hidden="true"
+                    className="size-3.5 text-muted-foreground"
+                  />
+                </div>
+              )}
+              <span
+                className="max-w-[120px] truncate text-[11px] text-muted-foreground"
+                title={file.name}
+              >
+                {file.name}
+              </span>
+              <button
+                type="button"
+                onClick={() => fileAttachments.remove(file.id)}
+                aria-label={`Remove ${file.name}`}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X aria-hidden="true" className="size-3" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
 
-				{staged ? (
-					<ul className="flex flex-wrap gap-1.5" aria-label="Attached files">
-						{fileAttachments.attachments.map((file) => (
-							<li
-								key={file.id}
-								className="flex items-center gap-1.5 rounded border border-border bg-background py-0.5 pl-0.5 pr-1"
-							>
-								{file.dataUrl ? (
-									<img src={file.dataUrl} alt="" className="size-6 rounded-sm object-cover" />
-								) : (
-									<div className="flex size-6 items-center justify-center rounded-sm bg-surface">
-										<File aria-hidden="true" className="size-3.5 text-muted-foreground" />
-									</div>
-								)}
-								<span
-									className="max-w-[120px] truncate text-[11px] text-muted-foreground"
-									title={file.name}
-								>
-									{file.name}
-								</span>
-								<button
-									type="button"
-									onClick={() => fileAttachments.remove(file.id)}
-									aria-label={`Remove ${file.name}`}
-									className="text-muted-foreground hover:text-foreground"
-								>
-									<X aria-hidden="true" className="size-3" />
-								</button>
-							</li>
-						))}
-					</ul>
-				) : null}
+      <ComposerEditor
+        ref={editor}
+        disabled={disabled}
+        label="Message the agent"
+        placeholder={
+          disabled
+            ? "The controller is not connected"
+            : willQueue
+              ? "Agent is working — this sends when it finishes"
+              : "Message the agent…"
+        }
+        menuOpen={menuOpen}
+        menuId={menuId}
+        activeIndex={activeIndex}
+        onChange={onEditorChange}
+        onComplete={completeFromEditor}
+        onEnterKey={handleEnterKey}
+        onCompositionChange={setIsComposing}
+        onKeyDown={onKeyDown}
+        onPaste={onPaste}
+      />
 
-				<ComposerEditor
-					ref={editor}
-					disabled={disabled}
-					label="Message the agent"
-					placeholder={
-						disabled
-							? "The controller is not connected"
-							: willQueue
-								? "Agent is working — this sends when it finishes"
-								: "Message the agent…"
-					}
-					menuOpen={menuOpen}
-					menuId={menuId}
-					activeIndex={activeIndex}
-					onChange={onEditorChange}
-					onComplete={completeFromEditor}
-					onEnterKey={handleEnterKey}
-					onCompositionChange={setIsComposing}
-					onKeyDown={onKeyDown}
-					onPaste={onPaste}
-				/>
+      {attachmentError ? (
+        <p
+          role="alert"
+          className="px-1.5 text-[11px] leading-snug text-destructive"
+        >
+          {attachmentError}
+        </p>
+      ) : null}
 
-				{attachmentError ? (
-					<p role="alert" className="px-1.5 text-[11px] leading-snug text-destructive">
-						{attachmentError}
-					</p>
-				) : null}
-
-				{/* A refused steer is an ordinary outcome, not a failure: the text is still
+      {/* A refused steer is an ordinary outcome, not a failure: the text is still
 			    in the box and the message says which of "send it instead" and "try again
 			    in a moment" applies. */}
-				{steerRefusal ? (
-					<p role="status" className="px-1.5 text-[11px] leading-snug text-warning">
-						{steerRefusal}
-					</p>
-				) : null}
+      {steerRefusal ? (
+        <p
+          role="status"
+          className="px-1.5 text-[11px] leading-snug text-warning"
+        >
+          {steerRefusal}
+        </p>
+      ) : null}
 
-				<div className="flex h-7 items-center gap-1.5">
-					<div role="group" aria-label="Message tools" className="flex min-w-0 flex-1 items-center gap-0.5">
-						{canAttach ? (
-							<>
-								<input
-									ref={filePicker}
-									type="file"
-									multiple
-									hidden
-									onChange={(event) => {
-										void fileAttachments.addFiles(Array.from(event.target.files ?? []));
-										// Cleared so picking the same file twice still fires a change.
-										event.target.value = "";
-									}}
-								/>
-								<Button
-									type="button"
-									variant="ghost"
-									size="icon-sm"
-									disabled={disabled}
-									onClick={() => filePicker.current?.click()}
-									aria-label="Attach a file"
-									title="Attach a file"
-									className="size-7 shrink-0 rounded-full p-0 text-muted-foreground hover:bg-white/5! hover:text-foreground"
-								>
-									<Plus aria-hidden="true" className="size-3.5 text-muted-foreground" />
-								</Button>
-							</>
-						) : null}
-						{settings}
-					</div>
+      <div className="flex h-7 items-center gap-1.5">
+        <div
+          role="group"
+          aria-label="Message tools"
+          className="flex min-w-0 flex-1 items-center gap-0.5"
+        >
+          {canAttach ? (
+            <>
+              <input
+                ref={filePicker}
+                type="file"
+                multiple
+                hidden
+                onChange={(event) => {
+                  void fileAttachments.addFiles(
+                    Array.from(event.target.files ?? []),
+                  );
+                  // Cleared so picking the same file twice still fires a change.
+                  event.target.value = "";
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                disabled={disabled}
+                onClick={() => filePicker.current?.click()}
+                aria-label="Attach a file"
+                title="Attach a file"
+                className="size-7 shrink-0 rounded-full p-0 text-muted-foreground hover:bg-white/5! hover:text-foreground"
+              >
+                <Plus
+                  aria-hidden="true"
+                  className="size-3.5 text-muted-foreground"
+                />
+              </Button>
+            </>
+          ) : null}
+          {settings}
+        </div>
 
-					<div role="group" aria-label="Send message controls" className="flex h-7 shrink-0 items-center">
-						<Button
-							type={canStopTurn ? "button" : "submit"}
-							variant="ghost"
-							size="icon-sm"
-							disabled={canStopTurn ? false : !canSend}
-							onClick={canStopTurn ? onInterrupt : undefined}
-							aria-label={canStopTurn ? "Stop turn" : "Send message"}
-							// The destination Enter is armed with used to be spelled out beside
-							// the button. The row reads better without a line of prose in it, but
-							// the fact is not decoration, so it moves onto the control it
-							// describes rather than being dropped.
-							title={canStopTurn ? "Stop turn" : sendHint}
-							className={cn(
-								"size-7 rounded-full border-transparent focus-visible:ring-ring/40",
-								canStopTurn || canSend
-									? "bg-foreground text-background hover:bg-foreground/90 hover:text-background dark:hover:bg-foreground/90 dark:hover:text-background"
-									: "bg-primary text-primary-foreground",
-							)}
-						>
-							{canStopTurn ? (
-								<Square aria-hidden="true" className="size-2.5 fill-current" />
-							) : steerPending || savingQueuedEditPending || sendPending ? (
-								<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
-							) : (
-								<ArrowUp aria-hidden="true" className="size-3.5" />
-							)}
-						</Button>
-					</div>
-				</div>
-			</form>,
-	);
+        <div
+          role="group"
+          aria-label="Send message controls"
+          className="flex h-7 shrink-0 items-center"
+        >
+          <Button
+            type={canStopTurn ? "button" : "submit"}
+            variant="ghost"
+            size="icon-sm"
+            disabled={canStopTurn ? false : !canSend}
+            onClick={canStopTurn ? onInterrupt : undefined}
+            aria-label={canStopTurn ? "Stop turn" : "Send message"}
+            // The destination Enter is armed with used to be spelled out beside
+            // the button. The row reads better without a line of prose in it, but
+            // the fact is not decoration, so it moves onto the control it
+            // describes rather than being dropped.
+            title={canStopTurn ? "Stop turn" : sendHint}
+            className={cn(
+              "size-7 rounded-full border-transparent focus-visible:ring-ring/40",
+              canStopTurn || canSend
+                ? "bg-foreground text-background hover:bg-foreground/90 hover:text-background dark:hover:bg-foreground/90 dark:hover:text-background"
+                : "bg-primary text-primary-foreground",
+            )}
+          >
+            {canStopTurn ? (
+              <Square aria-hidden="true" className="size-2.5 fill-current" />
+            ) : steerPending || savingQueuedEditPending || sendPending ? (
+              <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+            ) : (
+              <ArrowUp aria-hidden="true" className="size-3.5" />
+            )}
+          </Button>
+        </div>
+      </div>
+    </form>,
+  );
 }

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -248,10 +248,9 @@ export function ChatComposer({
 		!savingQueuedEditPending &&
 		(savingQueuedEdit || !busy);
 	const canStopTurn = Boolean(willQueue && onInterrupt && !disabled && !hasDraft && !savingQueuedEdit);
-	// Steering delivers text only, so a draft carrying files cannot take that
-	// path. Treating it as unavailable — rather than steering the text and
-	// dropping the files, or refusing on an empty body with attachments staged —
-	// keeps the armed state something the composer can actually honour.
+	// Cmd/Ctrl+Enter remains an intentionally quiet power-user path for steering
+	// typed text into the running turn. The visible hint stays queue-only.
+	const canSteerDraft = Boolean(canSteer && onSteer) && !staged && !savingQueuedEdit;
 	const canSteerNext =
 		Boolean(canSteer && onSteer) &&
 		!disabled &&
@@ -262,11 +261,9 @@ export function ChatComposer({
 		? "Enter to insert"
 		: savingQueuedEdit
 			? "⏎ save edit"
-			: willQueue && canSteerNext
-				? "⏎ queue · Enter steer"
-				: willQueue
-					? "⏎ queue"
-					: "Enter to send";
+			: willQueue
+				? "⏎ queue"
+				: "Enter to send";
 	const draftSeedId = draftSeed?.id;
 	const draftSeedText = draftSeed?.text;
 	const queuedDockWithSteer = isValidElement(queuedDock)
@@ -553,7 +550,7 @@ export function ChatComposer({
 	}
 
 	const handleEnterKey = useCallback(
-		(_event: globalThis.KeyboardEvent): boolean => {
+		(event: globalThis.KeyboardEvent): boolean => {
 			const liveSnapshot = editor.current?.getSnapshot();
 			if (liveSnapshot) textRef.current = liveSnapshot.text;
 			const liveTrigger = liveSnapshot?.trigger;
@@ -569,14 +566,15 @@ export function ChatComposer({
 				return true;
 			}
 
-			if (canSteerNext) {
+			if (canSteerNext && !textRef.current.trim()) {
 				setSteerNextRequest((request) => request + 1);
 				return true;
 			}
-			void submit();
+			const wantsSteer = (event.metaKey || event.ctrlKey) && canSteerDraft;
+			void submit(undefined, wantsSteer);
 			return true;
 		},
-		[canSteerNext, onCompact, pick, suggestionsFor],
+		[canSteerDraft, canSteerNext, onCompact, pick, suggestionsFor],
 	);
 
 	function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
@@ -637,6 +635,26 @@ export function ChatComposer({
 		void fileAttachments.addFiles(files);
 	}
 
+	// Keep the hidden Cmd/Ctrl steering shortcut available for the send-button path
+	// without rerendering the composer for every modifier key event.
+	const modifierHeldRef = useRef(false);
+	useEffect(() => {
+		const onKey = (event: globalThis.KeyboardEvent) => {
+			modifierHeldRef.current = event.metaKey || event.ctrlKey;
+		};
+		const onBlur = () => {
+			modifierHeldRef.current = false;
+		};
+		window.addEventListener("keydown", onKey);
+		window.addEventListener("keyup", onKey);
+		window.addEventListener("blur", onBlur);
+		return () => {
+			window.removeEventListener("keydown", onKey);
+			window.removeEventListener("keyup", onKey);
+			window.removeEventListener("blur", onBlur);
+		};
+	}, []);
+
 	const attachmentError = fileAttachments.error ?? sendError ?? commandError;
 	const withQueueStack = (form: ReactElement) =>
 		queuedDock ? (
@@ -672,9 +690,8 @@ export function ChatComposer({
 
 	return withQueueStack(
 		<form
-				// The send button always submits the typed draft. Steering is reserved for
-				// the empty-input Enter path handled by the editor above.
-			onSubmit={(event) => void submit(event)}
+			// Cmd/Ctrl steering remains available as a quiet power-user action.
+			onSubmit={(event) => void submit(event, modifierHeldRef.current && canSteerDraft)}
 				onDragOver={(event) => {
 					if (!canAttach) return;
 					event.preventDefault();

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -670,18 +670,18 @@ export function ChatComposer({
 
 	const attachmentError = fileAttachments.error ?? sendError ?? commandError;
 	const withQueueStack = (form: ReactElement) =>
-		queuedDock ? (
+		(
 			<div className="relative flex w-full flex-col">
+				{queuedDock ? (
 				<div
 					className="cursor-chat-composer-queue queue-dock-enter relative z-10 mx-auto mb-2 w-[calc(100%-2rem)]"
 					data-testid="queued-composer-dock"
 				>
 					{queuedDockWithSteer}
 				</div>
+				) : null}
 				{form}
 			</div>
-		) : (
-			form
 		);
 
 	if (approval) {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -163,6 +163,54 @@ describe("ChatWorkspace steering", () => {
 		expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1");
 	});
 
+	it("keeps the next queued message visible when the dock is collapsed", async () => {
+		render(
+			<QueuedMessageDock
+				messages={[
+					{
+						turnId: "queued-1",
+						message: {
+							kind: "message",
+							id: "queued-message-1",
+							turnId: "queued-1",
+							sequence: 100,
+							revision: 0,
+							role: "user",
+							origin: "human",
+							text: "first queued",
+							streaming: false,
+							createdAt: "2026-08-11T10:01:00Z",
+						},
+					},
+					{
+						turnId: "queued-2",
+						message: {
+							kind: "message",
+							id: "queued-message-2",
+							turnId: "queued-2",
+							sequence: 101,
+							revision: 0,
+							role: "user",
+							origin: "human",
+							text: "second queued",
+							streaming: false,
+							createdAt: "2026-08-11T10:02:00Z",
+						},
+					},
+				]}
+			/>,
+		);
+
+		const dock = screen.getByTestId("queued-message-dock");
+		expect(within(dock).getByText("first queued")).toBeVisible();
+		expect(within(dock).getByText("second queued")).toBeVisible();
+
+		await userEvent.click(screen.getByRole("button", { expanded: true }));
+		expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
+		expect(within(dock).getByText("first queued")).toBeVisible();
+		expect(within(dock).getByTestId("queued-message-queued-2")).toHaveAttribute("aria-hidden", "true");
+	});
+
 	it("hides a cancelled queued message from the timeline", () => {
 		const base = withQueuedMessages();
 		const snapshot = {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -215,7 +215,6 @@ describe("ChatWorkspace steering", () => {
 		const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
 		expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
 		expect(hiddenRow).toHaveAttribute("inert");
-		expect(screen.getByTestId("queued-message-toggle")).toHaveClass("active:scale-[0.999]");
 	});
 
 	it("hides a cancelled queued message from the timeline", () => {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -153,13 +153,17 @@ describe("ChatWorkspace steering", () => {
 		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
 		expect(screen.getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(2);
 
-		await userEvent.click(screen.getAllByRole("button", { name: "Steer this queued message into the running turn" })[0]);
+		await userEvent.click(
+			within(screen.getByTestId("queued-message-queued-1")).getByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		);
 		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1");
 
-		await userEvent.click(screen.getAllByRole("button", { name: "Edit queued message" })[0]);
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
 		expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");
 
-		await userEvent.click(screen.getAllByRole("button", { name: "Delete queued message" })[0]);
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Delete queued message" }));
 		expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1");
 	});
 
@@ -246,10 +250,10 @@ describe("ChatWorkspace steering", () => {
 			/>,
 		);
 
-		await userEvent.click(screen.getAllByRole("button", { name: "Edit queued message" })[0]);
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
 		await waitFor(() => expect(screen.getByText(/editing/i)).toBeInTheDocument());
 
-		await userEvent.click(screen.getAllByRole("button", { name: "Delete queued message" })[0]);
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Delete queued message" }));
 		await waitFor(() => expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1"));
 		await waitFor(() => expect(screen.queryByText(/editing/i)).not.toBeInTheDocument());
 	});

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -151,14 +151,19 @@ describe("ChatWorkspace steering", () => {
 		);
 
 		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-		expect(screen.getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(1);
+		expect(
+			within(screen.getByTestId("queued-message-queued-1")).getAllByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		).toHaveLength(1);
 
 		await userEvent.click(
-			within(screen.getByTestId("queued-message-queued-1")).getByRole("button", {
+			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
 				name: "Steer this queued message into the running turn",
 			}),
 		);
-		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1");
+		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-2");
+		expect(screen.queryByTestId("queued-message-queued-2")).not.toBeInTheDocument();
 
 		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
 		expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");
@@ -282,7 +287,7 @@ describe("ChatWorkspace steering", () => {
 		expect(within(dock).getByText("second queued")).toBeVisible();
 	});
 
-	it("shows steer action only on the latest queued message while a turn is running", () => {
+	it("shows the standard steer action on the next row and hover steer on later rows", () => {
 		render(
 			<ChatWorkspace
 				snapshot={withQueuedMessages()}
@@ -293,7 +298,16 @@ describe("ChatWorkspace steering", () => {
 
 		const dock = screen.getByTestId("queued-message-dock");
 		expect(within(dock).queryByText("Queue")).not.toBeInTheDocument();
-		expect(within(dock).getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(1);
+		expect(
+			within(screen.getByTestId("queued-message-queued-1")).getByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		).toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		).toBeInTheDocument();
 	});
 
 	it("does not show delivery indicators in the composer for a running turn without a pending approval", () => {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -52,6 +52,17 @@ describe("ChatComposer steering", () => {
 		expect(onSteer).not.toHaveBeenCalled();
 	});
 
+	it("keeps Cmd/Ctrl+Enter steering available without advertising it", async () => {
+		const onSteer = vi.fn().mockResolvedValue(undefined);
+		composer({ onSteer });
+
+		await typeInLexicalEditor(screen.getByRole("combobox"), "steer this draft");
+		await userEvent.keyboard("{Control>}{Enter}{/Control}");
+
+		expect(onSteer).toHaveBeenCalledWith("steer this draft");
+		expect(screen.queryByText(/steer/i)).not.toBeInTheDocument();
+	});
+
 	it("steers the next queued message on empty Enter and removes it immediately", async () => {
 		const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
 		render(

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -12,373 +12,522 @@ import { typeInLexicalEditor } from "../../test/lexical";
 // silently would be worse than the queueing it replaces.
 
 describe("ChatComposer steering", () => {
-	function composer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
-		return render(
-			<ChatComposer onSend={vi.fn()} willQueue onSteer={vi.fn()} canSteer {...props} />,
-		);
-	}
+  const queuedMessage = (turnId: string, text: string) => ({
+    turnId,
+    message: {
+      kind: "message" as const,
+      id: `message-${turnId}`,
+      turnId,
+      sequence: 1,
+      revision: 0,
+      role: "user" as const,
+      origin: "human" as const,
+      text,
+      streaming: false,
+      createdAt: "2026-08-11T10:01:00Z",
+    },
+  });
 
-	it("does not show delivery indicators in the composer while a turn is running", () => {
-		composer();
-		expect(screen.queryByRole("group", { name: /where this message goes/i })).not.toBeInTheDocument();
-		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-	});
+  function composer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
+    return render(
+      <ChatComposer
+        onSend={vi.fn()}
+        willQueue
+        onSteer={vi.fn()}
+        canSteer
+        {...props}
+      />,
+    );
+  }
 
-	it("queues by default while a turn is running", async () => {
-		const onSteer = vi.fn().mockResolvedValue(undefined);
-		const onSend = vi.fn();
-		composer({ onSteer, onSend });
+  it("does not show delivery indicators in the composer while a turn is running", () => {
+    composer();
+    expect(
+      screen.queryByRole("group", { name: /where this message goes/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Queue")).not.toBeInTheDocument();
+    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+  });
 
-		await typeInLexicalEditor(screen.getByRole("combobox"), "use the unit tests only");
-		await userEvent.keyboard("{Enter}");
-		expect(onSend).toHaveBeenCalledWith("use the unit tests only");
-		expect(onSteer).not.toHaveBeenCalled();
-	});
+  it("queues by default while a turn is running", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onSend = vi.fn();
+    composer({ onSteer, onSend });
 
-	it("reports the daemon's refusal without a second message of its own", () => {
-		composer({ steerRefusal: "A compaction turn is running. Try again once it finishes." });
-		expect(screen.getByRole("status")).toHaveTextContent(/compaction turn is running/);
-	});
+    await typeInLexicalEditor(
+      screen.getByRole("combobox"),
+      "use the unit tests only",
+    );
+    await userEvent.keyboard("{Enter}");
+    expect(onSend).toHaveBeenCalledWith("use the unit tests only");
+    expect(onSteer).not.toHaveBeenCalled();
+  });
 
-	it("hides delivery indicators in the composer when the harness cannot steer", () => {
-		composer({ onSteer: undefined, canSteer: false });
-		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-	});
+  it("steers the next queued message on empty Enter and removes it immediately", async () => {
+    const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ChatComposer
+        onSend={vi.fn()}
+        willQueue
+        onSteer={vi.fn()}
+        canSteer
+        queuedDock={
+          <QueuedMessageDock
+            messages={[
+              queuedMessage("queued-1", "first"),
+              queuedMessage("queued-2", "next"),
+            ]}
+            canSteer
+            onPromoteQueuedTurn={onPromoteQueuedTurn}
+          />
+        }
+      />,
+    );
 
-	it("hides delivery indicators in the composer when no turn is in flight", () => {
-		composer({ canSteer: false, willQueue: false });
-		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-	});
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1"),
+    );
+    expect(
+      screen.queryByTestId("queued-message-queued-1"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports the daemon's refusal without a second message of its own", () => {
+    composer({
+      steerRefusal: "A compaction turn is running. Try again once it finishes.",
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /compaction turn is running/,
+    );
+  });
+
+  it("hides delivery indicators in the composer when the harness cannot steer", () => {
+    composer({ onSteer: undefined, canSteer: false });
+    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+  });
+
+  it("hides delivery indicators in the composer when no turn is in flight", () => {
+    composer({ canSteer: false, willQueue: false });
+    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+  });
 });
 
 describe("ChatWorkspace steering", () => {
-	function withQueuedMessages() {
-		return {
-			...chatFixture,
-			turns: [
-				...chatFixture.turns,
-				{ id: "queued-1", state: "queued" as const, requestedAt: "2026-08-11T10:01:00Z" },
-				{ id: "queued-2", state: "queued" as const, requestedAt: "2026-08-11T10:02:00Z" },
-			],
-			items: [
-				...chatFixture.items,
-				{
-					kind: "message" as const,
-					id: "queued-message-1",
-					turnId: "queued-1",
-					sequence: 100,
-					revision: 0,
-					role: "user" as const,
-					origin: "human" as const,
-					text: "first queued",
-					streaming: false,
-					createdAt: "2026-08-11T10:01:00Z",
-				},
-				{
-					kind: "message" as const,
-					id: "queued-message-2",
-					turnId: "queued-2",
-					sequence: 101,
-					revision: 0,
-					role: "user" as const,
-					origin: "human" as const,
-					text: "second queued",
-					streaming: false,
-					createdAt: "2026-08-11T10:02:00Z",
-				},
-			],
-		};
-	}
+  function withQueuedMessages() {
+    return {
+      ...chatFixture,
+      turns: [
+        ...chatFixture.turns,
+        {
+          id: "queued-1",
+          state: "queued" as const,
+          requestedAt: "2026-08-11T10:01:00Z",
+        },
+        {
+          id: "queued-2",
+          state: "queued" as const,
+          requestedAt: "2026-08-11T10:02:00Z",
+        },
+      ],
+      items: [
+        ...chatFixture.items,
+        {
+          kind: "message" as const,
+          id: "queued-message-1",
+          turnId: "queued-1",
+          sequence: 100,
+          revision: 0,
+          role: "user" as const,
+          origin: "human" as const,
+          text: "first queued",
+          streaming: false,
+          createdAt: "2026-08-11T10:01:00Z",
+        },
+        {
+          kind: "message" as const,
+          id: "queued-message-2",
+          turnId: "queued-2",
+          sequence: 101,
+          revision: 0,
+          role: "user" as const,
+          origin: "human" as const,
+          text: "second queued",
+          streaming: false,
+          createdAt: "2026-08-11T10:02:00Z",
+        },
+      ],
+    };
+  }
 
-	it("docks queued messages above the composer", () => {
-		render(
-			<ChatWorkspace
-				snapshot={withQueuedMessages()}
-				onSteer={vi.fn()}
-			/>,
-		);
-		const dock = screen.getByTestId("queued-message-dock");
-		expect(within(dock).getByText("2 Queued Messages")).toBeVisible();
-		expect(within(dock).getByText("first queued")).toBeVisible();
-		expect(within(dock).getByText("second queued")).toBeVisible();
-		expect(screen.queryByText("Queued · sends when the agent finishes")).not.toBeInTheDocument();
-	});
+  it("docks queued messages above the composer", () => {
+    render(<ChatWorkspace snapshot={withQueuedMessages()} onSteer={vi.fn()} />);
+    const dock = screen.getByTestId("queued-message-dock");
+    expect(within(dock).getByText("2 Queued Messages")).toBeVisible();
+    expect(within(dock).getByText("first queued")).toBeVisible();
+    expect(within(dock).getByText("second queued")).toBeVisible();
+    expect(
+      screen.queryByText("Queued · sends when the agent finishes"),
+    ).not.toBeInTheDocument();
+  });
 
-	it("steers, edits, and deletes queued messages from the dock", async () => {
-		const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
-		const onBeginQueuedEdit = vi.fn();
-		const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
-		render(
-			<QueuedMessageDock
-				messages={[
-					{
-						turnId: "queued-1",
-						message: {
-							kind: "message",
-							id: "queued-message-1",
-							turnId: "queued-1",
-							sequence: 100,
-							revision: 0,
-							role: "user",
-							origin: "human",
-							text: "first queued",
-							streaming: false,
-							createdAt: "2026-08-11T10:01:00Z",
-						},
-					},
-					{
-						turnId: "queued-2",
-						message: {
-							kind: "message",
-							id: "queued-message-2",
-							turnId: "queued-2",
-							sequence: 101,
-							revision: 0,
-							role: "user",
-							origin: "human",
-							text: "second queued",
-							streaming: false,
-							createdAt: "2026-08-11T10:02:00Z",
-						},
-					},
-				]}
-				canSteer
-				onPromoteQueuedTurn={onPromoteQueuedTurn}
-				onBeginQueuedEdit={onBeginQueuedEdit}
-				onCancelQueuedTurn={onCancelQueuedTurn}
-			/>,
-		);
+  it("steers, edits, and deletes queued messages from the dock", async () => {
+    const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
+    const onBeginQueuedEdit = vi.fn();
+    const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
+    render(
+      <QueuedMessageDock
+        messages={[
+          {
+            turnId: "queued-1",
+            message: {
+              kind: "message",
+              id: "queued-message-1",
+              turnId: "queued-1",
+              sequence: 100,
+              revision: 0,
+              role: "user",
+              origin: "human",
+              text: "first queued",
+              streaming: false,
+              createdAt: "2026-08-11T10:01:00Z",
+            },
+          },
+          {
+            turnId: "queued-2",
+            message: {
+              kind: "message",
+              id: "queued-message-2",
+              turnId: "queued-2",
+              sequence: 101,
+              revision: 0,
+              role: "user",
+              origin: "human",
+              text: "second queued",
+              streaming: false,
+              createdAt: "2026-08-11T10:02:00Z",
+            },
+          },
+        ]}
+        canSteer
+        onPromoteQueuedTurn={onPromoteQueuedTurn}
+        onBeginQueuedEdit={onBeginQueuedEdit}
+        onCancelQueuedTurn={onCancelQueuedTurn}
+      />,
+    );
 
-		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-		expect(
-			within(screen.getByTestId("queued-message-queued-1")).getAllByRole("button", {
-				name: "Steer this queued message into the running turn",
-			}),
-		).toHaveLength(1);
+    expect(screen.queryByText("Queue")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("queued-message-queued-1")).getAllByRole(
+        "button",
+        {
+          name: "Steer this queued message into the running turn",
+        },
+      ),
+    ).toHaveLength(1);
 
-		await userEvent.click(
-			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
-				name: "Steer this queued message into the running turn",
-			}),
-		);
-		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-2");
-		expect(screen.queryByTestId("queued-message-queued-2")).not.toBeInTheDocument();
+    await userEvent.click(
+      within(screen.getByTestId("queued-message-queued-2")).getByRole(
+        "button",
+        {
+          name: "Steer this queued message into the running turn",
+        },
+      ),
+    );
+    expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-2");
+    expect(
+      screen.queryByTestId("queued-message-queued-2"),
+    ).not.toBeInTheDocument();
 
-		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
-		expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");
+    await userEvent.click(
+      within(screen.getByTestId("queued-message-queued-1")).getByRole(
+        "button",
+        { name: "Edit queued message" },
+      ),
+    );
+    expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");
 
-		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Delete queued message" }));
-		expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1");
-	});
+    await userEvent.click(
+      within(screen.getByTestId("queued-message-queued-1")).getByRole(
+        "button",
+        { name: "Delete queued message" },
+      ),
+    );
+    expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1");
+  });
 
-	it("keeps the next queued message visible when the dock is collapsed", async () => {
-		render(
-			<QueuedMessageDock
-				messages={[
-					{
-						turnId: "queued-1",
-						message: {
-							kind: "message",
-							id: "queued-message-1",
-							turnId: "queued-1",
-							sequence: 100,
-							revision: 0,
-							role: "user",
-							origin: "human",
-							text: "first queued",
-							streaming: false,
-							createdAt: "2026-08-11T10:01:00Z",
-						},
-					},
-					{
-						turnId: "queued-2",
-						message: {
-							kind: "message",
-							id: "queued-message-2",
-							turnId: "queued-2",
-							sequence: 101,
-							revision: 0,
-							role: "user",
-							origin: "human",
-							text: "second queued",
-							streaming: false,
-							createdAt: "2026-08-11T10:02:00Z",
-						},
-					},
-				]}
-			/>,
-		);
+  it("keeps the next queued message visible when the dock is collapsed", async () => {
+    render(
+      <QueuedMessageDock
+        messages={[
+          {
+            turnId: "queued-1",
+            message: {
+              kind: "message",
+              id: "queued-message-1",
+              turnId: "queued-1",
+              sequence: 100,
+              revision: 0,
+              role: "user",
+              origin: "human",
+              text: "first queued",
+              streaming: false,
+              createdAt: "2026-08-11T10:01:00Z",
+            },
+          },
+          {
+            turnId: "queued-2",
+            message: {
+              kind: "message",
+              id: "queued-message-2",
+              turnId: "queued-2",
+              sequence: 101,
+              revision: 0,
+              role: "user",
+              origin: "human",
+              text: "second queued",
+              streaming: false,
+              createdAt: "2026-08-11T10:02:00Z",
+            },
+          },
+        ]}
+      />,
+    );
 
-		const dock = screen.getByTestId("queued-message-dock");
-		expect(within(dock).getByText("first queued")).toBeVisible();
-		expect(within(dock).getByText("second queued")).toBeVisible();
+    const dock = screen.getByTestId("queued-message-dock");
+    expect(within(dock).getByText("first queued")).toBeVisible();
+    expect(within(dock).getByText("second queued")).toBeVisible();
 
-		await userEvent.click(screen.getByRole("button", { expanded: true }));
-		expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
-		expect(within(dock).getByText("first queued")).toBeVisible();
-		const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
-		expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
-		expect(hiddenRow).toHaveAttribute("inert");
-	});
+    await userEvent.click(screen.getByRole("button", { expanded: true }));
+    expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
+    expect(within(dock).getByText("first queued")).toBeVisible();
+    const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
+    expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
+    expect(hiddenRow).toHaveAttribute("inert");
+  });
 
-	it("hides a cancelled queued message from the timeline", () => {
-		const base = withQueuedMessages();
-		const snapshot = {
-			...base,
-			turns: base.turns.map((turn) =>
-				turn.id === "queued-1"
-					? {
-							...turn,
-							state: "cancelled" as const,
-							completedAt: "2026-08-11T10:03:00Z",
-						}
-					: turn,
-			),
-			items: base.items.filter((item) => item.kind !== "message" || item.turnId !== "queued-1"),
-		};
-		render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
+  it("hides a cancelled queued message from the timeline", () => {
+    const base = withQueuedMessages();
+    const snapshot = {
+      ...base,
+      turns: base.turns.map((turn) =>
+        turn.id === "queued-1"
+          ? {
+              ...turn,
+              state: "cancelled" as const,
+              completedAt: "2026-08-11T10:03:00Z",
+            }
+          : turn,
+      ),
+      items: base.items.filter(
+        (item) => item.kind !== "message" || item.turnId !== "queued-1",
+      ),
+    };
+    render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
 
-		expect(screen.queryByText("first queued")).not.toBeInTheDocument();
-		expect(within(screen.getByTestId("queued-message-dock")).getByText("second queued")).toBeVisible();
-	});
+    expect(screen.queryByText("first queued")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("queued-message-dock")).getByText(
+        "second queued",
+      ),
+    ).toBeVisible();
+  });
 
-	it("clears a queued edit when that message is deleted from the dock", async () => {
-		const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
-		render(
-			<ChatWorkspace
-				snapshot={withQueuedMessages()}
-				onSteer={vi.fn()}
-				onEditQueuedTurn={vi.fn()}
-				onCancelQueuedTurn={onCancelQueuedTurn}
-			/>,
-		);
+  it("clears a queued edit when that message is deleted from the dock", async () => {
+    const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ChatWorkspace
+        snapshot={withQueuedMessages()}
+        onSteer={vi.fn()}
+        onEditQueuedTurn={vi.fn()}
+        onCancelQueuedTurn={onCancelQueuedTurn}
+      />,
+    );
 
-		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
-		await waitFor(() => expect(screen.getByText(/editing/i)).toBeInTheDocument());
+    await userEvent.click(
+      within(screen.getByTestId("queued-message-queued-1")).getByRole(
+        "button",
+        { name: "Edit queued message" },
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/editing/i)).toBeInTheDocument(),
+    );
 
-		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Delete queued message" }));
-		await waitFor(() => expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1"));
-		await waitFor(() => expect(screen.queryByText(/editing/i)).not.toBeInTheDocument());
-	});
+    await userEvent.click(
+      within(screen.getByTestId("queued-message-queued-1")).getByRole(
+        "button",
+        { name: "Delete queued message" },
+      ),
+    );
+    await waitFor(() =>
+      expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1"),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText(/editing/i)).not.toBeInTheDocument(),
+    );
+  });
 
-	it("shows the queued dock while messages are still queued between turns", () => {
-		const snapshot = {
-			...withQueuedMessages(),
-			turns: withQueuedMessages().turns.map((turn) =>
-				turn.state === "running" ? { ...turn, state: "completed" as const } : turn,
-			),
-		};
-		render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
-		expect(screen.getByTestId("queued-message-dock")).toBeInTheDocument();
-		expect(within(screen.getByTestId("queued-message-dock")).getByText("first queued")).toBeVisible();
-	});
+  it("shows the queued dock while messages are still queued between turns", () => {
+    const snapshot = {
+      ...withQueuedMessages(),
+      turns: withQueuedMessages().turns.map((turn) =>
+        turn.state === "running"
+          ? { ...turn, state: "completed" as const }
+          : turn,
+      ),
+    };
+    render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
+    expect(screen.getByTestId("queued-message-dock")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("queued-message-dock")).getByText(
+        "first queued",
+      ),
+    ).toBeVisible();
+  });
 
-	it("keeps queued messages docked after the conversation branches", () => {
-		render(
-			<ChatWorkspace
-				snapshot={{ ...withQueuedMessages(), branchedFromEarlierMessage: true }}
-				onSteer={vi.fn()}
-			/>,
-		);
+  it("keeps queued messages docked after the conversation branches", () => {
+    render(
+      <ChatWorkspace
+        snapshot={{ ...withQueuedMessages(), branchedFromEarlierMessage: true }}
+        onSteer={vi.fn()}
+      />,
+    );
 
-		const dock = screen.getByTestId("queued-message-dock");
-		expect(within(dock).getByText("first queued")).toBeVisible();
-		expect(within(dock).getByText("second queued")).toBeVisible();
-	});
+    const dock = screen.getByTestId("queued-message-dock");
+    expect(within(dock).getByText("first queued")).toBeVisible();
+    expect(within(dock).getByText("second queued")).toBeVisible();
+  });
 
-	it("shows the standard steer action on the next row and hover steer on later rows", () => {
-		render(
-			<ChatWorkspace
-				snapshot={withQueuedMessages()}
-				onSteer={vi.fn()}
-				onPromoteQueuedTurn={vi.fn()}
-			/>,
-		);
+  it("shows the standard steer action on the next row and hover steer on later rows", () => {
+    render(
+      <ChatWorkspace
+        snapshot={withQueuedMessages()}
+        onSteer={vi.fn()}
+        onPromoteQueuedTurn={vi.fn()}
+      />,
+    );
 
-		const dock = screen.getByTestId("queued-message-dock");
-		expect(within(dock).queryByText("Queue")).not.toBeInTheDocument();
-		expect(
-			within(screen.getByTestId("queued-message-queued-1")).getByRole("button", {
-				name: "Steer this queued message into the running turn",
-			}),
-		).toBeInTheDocument();
-		expect(
-			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
-				name: "Steer this queued message into the running turn",
-			}),
-		).toBeInTheDocument();
-	});
+    const dock = screen.getByTestId("queued-message-dock");
+    expect(within(dock).queryByText("Queue")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("queued-message-queued-1")).getByRole(
+        "button",
+        {
+          name: "Steer this queued message into the running turn",
+        },
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("queued-message-queued-2")).getByRole(
+        "button",
+        {
+          name: "Steer this queued message into the running turn",
+        },
+      ),
+    ).toBeInTheDocument();
+  });
 
-	it("does not show delivery indicators in the composer for a running turn without a pending approval", () => {
-		const snapshot = {
-			...chatFixture,
-			items: chatFixture.items.filter(
-				(item) =>
-					!(item.kind === "activity" && item.activityKind === "approval" && item.status === "pending"),
-			),
-		};
-		render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
-		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-	});
+  it("does not show delivery indicators in the composer for a running turn without a pending approval", () => {
+    const snapshot = {
+      ...chatFixture,
+      items: chatFixture.items.filter(
+        (item) =>
+          !(
+            item.kind === "activity" &&
+            item.activityKind === "approval" &&
+            item.status === "pending"
+          ),
+      ),
+    };
+    render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
+    expect(screen.queryByText("Queue")).not.toBeInTheDocument();
+    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+  });
 
-	it("does not show delivery indicator on a settled conversation", () => {
-		render(
-			<ChatWorkspace
-				snapshot={{ ...chatFixture, turns: chatFixture.turns.map((t) => ({ ...t, state: "completed" as const })) }}
-				onSteer={vi.fn()}
-			/>,
-		);
-		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-		expect(screen.queryByTestId("queued-message-dock")).not.toBeInTheDocument();
-	});
+  it("does not show delivery indicator on a settled conversation", () => {
+    render(
+      <ChatWorkspace
+        snapshot={{
+          ...chatFixture,
+          turns: chatFixture.turns.map((t) => ({
+            ...t,
+            state: "completed" as const,
+          })),
+        }}
+        onSteer={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("queued-message-dock")).not.toBeInTheDocument();
+  });
 
-	// A queued turn has not reached the provider, so there is nothing to steer.
-	it("does not offer steering into a turn that is only queued", () => {
-		render(
-			<ChatWorkspace
-				snapshot={{
-					...chatFixture,
-					turns: chatFixture.turns.map((t) =>
-						t.state === "running" ? { ...t, state: "queued" as const } : t,
-					),
-				}}
-				onSteer={vi.fn()}
-			/>,
-		);
-		expect(screen.queryByRole("button", { name: "Steer this turn" })).not.toBeInTheDocument();
-	});
+  // A queued turn has not reached the provider, so there is nothing to steer.
+  it("does not offer steering into a turn that is only queued", () => {
+    render(
+      <ChatWorkspace
+        snapshot={{
+          ...chatFixture,
+          turns: chatFixture.turns.map((t) =>
+            t.state === "running" ? { ...t, state: "queued" as const } : t,
+          ),
+        }}
+        onSteer={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Steer this turn" }),
+    ).not.toBeInTheDocument();
+  });
 
-	it("renders a landed steer as the user's own words", () => {
-		render(<ChatWorkspace snapshot={chatFixture} />);
-		expect(screen.getByText(/Steered into the running turn/)).toBeInTheDocument();
-	});
+  it("renders a landed steer as the user's own words", () => {
+    render(<ChatWorkspace snapshot={chatFixture} />);
+    expect(
+      screen.getByText(/Steered into the running turn/),
+    ).toBeInTheDocument();
+  });
 
-	it("renders every promoted steer content block on the running turn", () => {
-		const snapshot = {
-			...chatFixture,
-			items: chatFixture.items.map((item) =>
-				item.kind === "activity" && item.id === "a-steer-1"
-					? {
-							...item,
-							detail: {
-								...item.detail,
-								content: [
-									{ type: "image", data: "aGVsbG8=", mimeType: "image/png" },
-									{ type: "resource_link", name: "reference.md", uri: "file:///reference.md" },
-									{ type: "resource", name: "notes.md", uri: "file:///notes.md", text: "details" },
-								],
-							},
-						}
-					: item,
-			),
-		};
-		render(<ChatWorkspace snapshot={snapshot} />);
-		const image = screen.getByRole("img", { name: "Steered attachment 1" });
-		expect(image).toHaveAttribute("src", "data:image/png;base64,aGVsbG8=");
-		const attachments = screen.getByRole("list", { name: "Steered attachments" });
-		expect(within(attachments).getByTitle("file:///reference.md")).toHaveTextContent("reference.md");
-		expect(within(attachments).getByTitle("file:///notes.md")).toHaveTextContent("notes.md");
-	});
+  it("renders every promoted steer content block on the running turn", () => {
+    const snapshot = {
+      ...chatFixture,
+      items: chatFixture.items.map((item) =>
+        item.kind === "activity" && item.id === "a-steer-1"
+          ? {
+              ...item,
+              detail: {
+                ...item.detail,
+                content: [
+                  { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+                  {
+                    type: "resource_link",
+                    name: "reference.md",
+                    uri: "file:///reference.md",
+                  },
+                  {
+                    type: "resource",
+                    name: "notes.md",
+                    uri: "file:///notes.md",
+                    text: "details",
+                  },
+                ],
+              },
+            }
+          : item,
+      ),
+    };
+    render(<ChatWorkspace snapshot={snapshot} />);
+    const image = screen.getByRole("img", { name: "Steered attachment 1" });
+    expect(image).toHaveAttribute("src", "data:image/png;base64,aGVsbG8=");
+    const attachments = screen.getByRole("list", {
+      name: "Steered attachments",
+    });
+    expect(
+      within(attachments).getByTitle("file:///reference.md"),
+    ).toHaveTextContent("reference.md");
+    expect(
+      within(attachments).getByTitle("file:///notes.md"),
+    ).toHaveTextContent("notes.md");
+  });
 });

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -211,6 +211,7 @@ describe("ChatWorkspace steering", () => {
 		const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
 		expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
 		expect(hiddenRow).toHaveAttribute("inert");
+		expect(screen.getByTestId("queued-message-toggle")).toHaveClass("active:scale-[0.999]");
 	});
 
 	it("hides a cancelled queued message from the timeline", () => {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -212,7 +212,6 @@ describe("ChatWorkspace steering", () => {
 		await userEvent.click(screen.getByRole("button", { expanded: true }));
 		expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
 		expect(within(dock).getByText("first queued")).toBeVisible();
-		expect(within(dock).getByText("Next Up")).toBeVisible();
 		const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
 		expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
 		expect(hiddenRow).toHaveAttribute("inert");

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -12,6 +12,22 @@ import { typeInLexicalEditor } from "../../test/lexical";
 // silently would be worse than the queueing it replaces.
 
 describe("ChatComposer steering", () => {
+	const queuedMessage = (turnId: string, text: string) => ({
+		turnId,
+		message: {
+			kind: "message" as const,
+			id: `message-${turnId}`,
+			turnId,
+			sequence: 1,
+			revision: 0,
+			role: "user" as const,
+			origin: "human" as const,
+			text,
+			streaming: false,
+			createdAt: "2026-08-11T10:01:00Z",
+		},
+	});
+
 	function composer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
 		return render(
 			<ChatComposer onSend={vi.fn()} willQueue onSteer={vi.fn()} canSteer {...props} />,
@@ -34,6 +50,31 @@ describe("ChatComposer steering", () => {
 		await userEvent.keyboard("{Enter}");
 		expect(onSend).toHaveBeenCalledWith("use the unit tests only");
 		expect(onSteer).not.toHaveBeenCalled();
+	});
+
+	it("steers the next queued message on empty Enter and removes it immediately", async () => {
+		const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
+		render(
+			<ChatComposer
+				onSend={vi.fn()}
+				willQueue
+				onSteer={vi.fn()}
+				canSteer
+				queuedDock={
+					<QueuedMessageDock
+						messages={[queuedMessage("queued-1", "first"), queuedMessage("queued-2", "next")]}
+						canSteer
+						onPromoteQueuedTurn={onPromoteQueuedTurn}
+					/>
+				}
+			/>,
+		);
+
+		await userEvent.click(screen.getByRole("combobox"));
+		await userEvent.keyboard("{Enter}");
+
+		await waitFor(() => expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1"));
+		expect(screen.queryByTestId("queued-message-queued-1")).not.toBeInTheDocument();
 	});
 
 	it("reports the daemon's refusal without a second message of its own", () => {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -212,6 +212,7 @@ describe("ChatWorkspace steering", () => {
 		await userEvent.click(screen.getByRole("button", { expanded: true }));
 		expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
 		expect(within(dock).getByText("first queued")).toBeVisible();
+		expect(within(dock).getByText("Next Up")).toBeVisible();
 		const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
 		expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
 		expect(hiddenRow).toHaveAttribute("inert");

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -208,7 +208,9 @@ describe("ChatWorkspace steering", () => {
 		await userEvent.click(screen.getByRole("button", { expanded: true }));
 		expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
 		expect(within(dock).getByText("first queued")).toBeVisible();
-		expect(within(dock).getByTestId("queued-message-queued-2")).toHaveAttribute("aria-hidden", "true");
+		const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
+		expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
+		expect(hiddenRow).toHaveAttribute("inert");
 	});
 
 	it("hides a cancelled queued message from the timeline", () => {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -154,11 +154,11 @@ describe("ChatWorkspace steering", () => {
 		expect(screen.getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(1);
 
 		await userEvent.click(
-			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
+			within(screen.getByTestId("queued-message-queued-1")).getByRole("button", {
 				name: "Steer this queued message into the running turn",
 			}),
 		);
-		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-2");
+		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1");
 
 		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
 		expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -151,14 +151,14 @@ describe("ChatWorkspace steering", () => {
 		);
 
 		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-		expect(screen.getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(2);
+		expect(screen.getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(1);
 
 		await userEvent.click(
-			within(screen.getByTestId("queued-message-queued-1")).getByRole("button", {
+			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
 				name: "Steer this queued message into the running turn",
 			}),
 		);
-		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1");
+		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-2");
 
 		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
 		expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");
@@ -283,7 +283,7 @@ describe("ChatWorkspace steering", () => {
 		expect(within(dock).getByText("second queued")).toBeVisible();
 	});
 
-	it("shows steer action on each queued message while a turn is running", () => {
+	it("shows steer action only on the latest queued message while a turn is running", () => {
 		render(
 			<ChatWorkspace
 				snapshot={withQueuedMessages()}
@@ -294,7 +294,7 @@ describe("ChatWorkspace steering", () => {
 
 		const dock = screen.getByTestId("queued-message-dock");
 		expect(within(dock).queryByText("Queue")).not.toBeInTheDocument();
-		expect(within(dock).getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(2);
+		expect(within(dock).getAllByRole("button", { name: "Steer this queued message into the running turn" })).toHaveLength(1);
 	});
 
 	it("does not show delivery indicators in the composer for a running turn without a pending approval", () => {

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -12,522 +12,373 @@ import { typeInLexicalEditor } from "../../test/lexical";
 // silently would be worse than the queueing it replaces.
 
 describe("ChatComposer steering", () => {
-  const queuedMessage = (turnId: string, text: string) => ({
-    turnId,
-    message: {
-      kind: "message" as const,
-      id: `message-${turnId}`,
-      turnId,
-      sequence: 1,
-      revision: 0,
-      role: "user" as const,
-      origin: "human" as const,
-      text,
-      streaming: false,
-      createdAt: "2026-08-11T10:01:00Z",
-    },
-  });
+	function composer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
+		return render(
+			<ChatComposer onSend={vi.fn()} willQueue onSteer={vi.fn()} canSteer {...props} />,
+		);
+	}
 
-  function composer(props: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
-    return render(
-      <ChatComposer
-        onSend={vi.fn()}
-        willQueue
-        onSteer={vi.fn()}
-        canSteer
-        {...props}
-      />,
-    );
-  }
+	it("does not show delivery indicators in the composer while a turn is running", () => {
+		composer();
+		expect(screen.queryByRole("group", { name: /where this message goes/i })).not.toBeInTheDocument();
+		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
+		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+	});
 
-  it("does not show delivery indicators in the composer while a turn is running", () => {
-    composer();
-    expect(
-      screen.queryByRole("group", { name: /where this message goes/i }),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-  });
+	it("queues by default while a turn is running", async () => {
+		const onSteer = vi.fn().mockResolvedValue(undefined);
+		const onSend = vi.fn();
+		composer({ onSteer, onSend });
 
-  it("queues by default while a turn is running", async () => {
-    const onSteer = vi.fn().mockResolvedValue(undefined);
-    const onSend = vi.fn();
-    composer({ onSteer, onSend });
+		await typeInLexicalEditor(screen.getByRole("combobox"), "use the unit tests only");
+		await userEvent.keyboard("{Enter}");
+		expect(onSend).toHaveBeenCalledWith("use the unit tests only");
+		expect(onSteer).not.toHaveBeenCalled();
+	});
 
-    await typeInLexicalEditor(
-      screen.getByRole("combobox"),
-      "use the unit tests only",
-    );
-    await userEvent.keyboard("{Enter}");
-    expect(onSend).toHaveBeenCalledWith("use the unit tests only");
-    expect(onSteer).not.toHaveBeenCalled();
-  });
+	it("reports the daemon's refusal without a second message of its own", () => {
+		composer({ steerRefusal: "A compaction turn is running. Try again once it finishes." });
+		expect(screen.getByRole("status")).toHaveTextContent(/compaction turn is running/);
+	});
 
-  it("steers the next queued message on empty Enter and removes it immediately", async () => {
-    const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
-    render(
-      <ChatComposer
-        onSend={vi.fn()}
-        willQueue
-        onSteer={vi.fn()}
-        canSteer
-        queuedDock={
-          <QueuedMessageDock
-            messages={[
-              queuedMessage("queued-1", "first"),
-              queuedMessage("queued-2", "next"),
-            ]}
-            canSteer
-            onPromoteQueuedTurn={onPromoteQueuedTurn}
-          />
-        }
-      />,
-    );
+	it("hides delivery indicators in the composer when the harness cannot steer", () => {
+		composer({ onSteer: undefined, canSteer: false });
+		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+	});
 
-    await userEvent.click(screen.getByRole("combobox"));
-    await userEvent.keyboard("{Enter}");
-
-    await waitFor(() =>
-      expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1"),
-    );
-    expect(
-      screen.queryByTestId("queued-message-queued-1"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("reports the daemon's refusal without a second message of its own", () => {
-    composer({
-      steerRefusal: "A compaction turn is running. Try again once it finishes.",
-    });
-    expect(screen.getByRole("status")).toHaveTextContent(
-      /compaction turn is running/,
-    );
-  });
-
-  it("hides delivery indicators in the composer when the harness cannot steer", () => {
-    composer({ onSteer: undefined, canSteer: false });
-    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-  });
-
-  it("hides delivery indicators in the composer when no turn is in flight", () => {
-    composer({ canSteer: false, willQueue: false });
-    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-  });
+	it("hides delivery indicators in the composer when no turn is in flight", () => {
+		composer({ canSteer: false, willQueue: false });
+		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+	});
 });
 
 describe("ChatWorkspace steering", () => {
-  function withQueuedMessages() {
-    return {
-      ...chatFixture,
-      turns: [
-        ...chatFixture.turns,
-        {
-          id: "queued-1",
-          state: "queued" as const,
-          requestedAt: "2026-08-11T10:01:00Z",
-        },
-        {
-          id: "queued-2",
-          state: "queued" as const,
-          requestedAt: "2026-08-11T10:02:00Z",
-        },
-      ],
-      items: [
-        ...chatFixture.items,
-        {
-          kind: "message" as const,
-          id: "queued-message-1",
-          turnId: "queued-1",
-          sequence: 100,
-          revision: 0,
-          role: "user" as const,
-          origin: "human" as const,
-          text: "first queued",
-          streaming: false,
-          createdAt: "2026-08-11T10:01:00Z",
-        },
-        {
-          kind: "message" as const,
-          id: "queued-message-2",
-          turnId: "queued-2",
-          sequence: 101,
-          revision: 0,
-          role: "user" as const,
-          origin: "human" as const,
-          text: "second queued",
-          streaming: false,
-          createdAt: "2026-08-11T10:02:00Z",
-        },
-      ],
-    };
-  }
+	function withQueuedMessages() {
+		return {
+			...chatFixture,
+			turns: [
+				...chatFixture.turns,
+				{ id: "queued-1", state: "queued" as const, requestedAt: "2026-08-11T10:01:00Z" },
+				{ id: "queued-2", state: "queued" as const, requestedAt: "2026-08-11T10:02:00Z" },
+			],
+			items: [
+				...chatFixture.items,
+				{
+					kind: "message" as const,
+					id: "queued-message-1",
+					turnId: "queued-1",
+					sequence: 100,
+					revision: 0,
+					role: "user" as const,
+					origin: "human" as const,
+					text: "first queued",
+					streaming: false,
+					createdAt: "2026-08-11T10:01:00Z",
+				},
+				{
+					kind: "message" as const,
+					id: "queued-message-2",
+					turnId: "queued-2",
+					sequence: 101,
+					revision: 0,
+					role: "user" as const,
+					origin: "human" as const,
+					text: "second queued",
+					streaming: false,
+					createdAt: "2026-08-11T10:02:00Z",
+				},
+			],
+		};
+	}
 
-  it("docks queued messages above the composer", () => {
-    render(<ChatWorkspace snapshot={withQueuedMessages()} onSteer={vi.fn()} />);
-    const dock = screen.getByTestId("queued-message-dock");
-    expect(within(dock).getByText("2 Queued Messages")).toBeVisible();
-    expect(within(dock).getByText("first queued")).toBeVisible();
-    expect(within(dock).getByText("second queued")).toBeVisible();
-    expect(
-      screen.queryByText("Queued · sends when the agent finishes"),
-    ).not.toBeInTheDocument();
-  });
+	it("docks queued messages above the composer", () => {
+		render(
+			<ChatWorkspace
+				snapshot={withQueuedMessages()}
+				onSteer={vi.fn()}
+			/>,
+		);
+		const dock = screen.getByTestId("queued-message-dock");
+		expect(within(dock).getByText("2 Queued Messages")).toBeVisible();
+		expect(within(dock).getByText("first queued")).toBeVisible();
+		expect(within(dock).getByText("second queued")).toBeVisible();
+		expect(screen.queryByText("Queued · sends when the agent finishes")).not.toBeInTheDocument();
+	});
 
-  it("steers, edits, and deletes queued messages from the dock", async () => {
-    const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
-    const onBeginQueuedEdit = vi.fn();
-    const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
-    render(
-      <QueuedMessageDock
-        messages={[
-          {
-            turnId: "queued-1",
-            message: {
-              kind: "message",
-              id: "queued-message-1",
-              turnId: "queued-1",
-              sequence: 100,
-              revision: 0,
-              role: "user",
-              origin: "human",
-              text: "first queued",
-              streaming: false,
-              createdAt: "2026-08-11T10:01:00Z",
-            },
-          },
-          {
-            turnId: "queued-2",
-            message: {
-              kind: "message",
-              id: "queued-message-2",
-              turnId: "queued-2",
-              sequence: 101,
-              revision: 0,
-              role: "user",
-              origin: "human",
-              text: "second queued",
-              streaming: false,
-              createdAt: "2026-08-11T10:02:00Z",
-            },
-          },
-        ]}
-        canSteer
-        onPromoteQueuedTurn={onPromoteQueuedTurn}
-        onBeginQueuedEdit={onBeginQueuedEdit}
-        onCancelQueuedTurn={onCancelQueuedTurn}
-      />,
-    );
+	it("steers, edits, and deletes queued messages from the dock", async () => {
+		const onPromoteQueuedTurn = vi.fn().mockResolvedValue(undefined);
+		const onBeginQueuedEdit = vi.fn();
+		const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
+		render(
+			<QueuedMessageDock
+				messages={[
+					{
+						turnId: "queued-1",
+						message: {
+							kind: "message",
+							id: "queued-message-1",
+							turnId: "queued-1",
+							sequence: 100,
+							revision: 0,
+							role: "user",
+							origin: "human",
+							text: "first queued",
+							streaming: false,
+							createdAt: "2026-08-11T10:01:00Z",
+						},
+					},
+					{
+						turnId: "queued-2",
+						message: {
+							kind: "message",
+							id: "queued-message-2",
+							turnId: "queued-2",
+							sequence: 101,
+							revision: 0,
+							role: "user",
+							origin: "human",
+							text: "second queued",
+							streaming: false,
+							createdAt: "2026-08-11T10:02:00Z",
+						},
+					},
+				]}
+				canSteer
+				onPromoteQueuedTurn={onPromoteQueuedTurn}
+				onBeginQueuedEdit={onBeginQueuedEdit}
+				onCancelQueuedTurn={onCancelQueuedTurn}
+			/>,
+		);
 
-    expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-    expect(
-      within(screen.getByTestId("queued-message-queued-1")).getAllByRole(
-        "button",
-        {
-          name: "Steer this queued message into the running turn",
-        },
-      ),
-    ).toHaveLength(1);
+		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("queued-message-queued-1")).getAllByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		).toHaveLength(1);
 
-    await userEvent.click(
-      within(screen.getByTestId("queued-message-queued-2")).getByRole(
-        "button",
-        {
-          name: "Steer this queued message into the running turn",
-        },
-      ),
-    );
-    expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-2");
-    expect(
-      screen.queryByTestId("queued-message-queued-2"),
-    ).not.toBeInTheDocument();
+		await userEvent.click(
+			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		);
+		expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-2");
+		expect(screen.queryByTestId("queued-message-queued-2")).not.toBeInTheDocument();
 
-    await userEvent.click(
-      within(screen.getByTestId("queued-message-queued-1")).getByRole(
-        "button",
-        { name: "Edit queued message" },
-      ),
-    );
-    expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
+		expect(onBeginQueuedEdit).toHaveBeenCalledWith("queued-1", "first queued");
 
-    await userEvent.click(
-      within(screen.getByTestId("queued-message-queued-1")).getByRole(
-        "button",
-        { name: "Delete queued message" },
-      ),
-    );
-    expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1");
-  });
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Delete queued message" }));
+		expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1");
+	});
 
-  it("keeps the next queued message visible when the dock is collapsed", async () => {
-    render(
-      <QueuedMessageDock
-        messages={[
-          {
-            turnId: "queued-1",
-            message: {
-              kind: "message",
-              id: "queued-message-1",
-              turnId: "queued-1",
-              sequence: 100,
-              revision: 0,
-              role: "user",
-              origin: "human",
-              text: "first queued",
-              streaming: false,
-              createdAt: "2026-08-11T10:01:00Z",
-            },
-          },
-          {
-            turnId: "queued-2",
-            message: {
-              kind: "message",
-              id: "queued-message-2",
-              turnId: "queued-2",
-              sequence: 101,
-              revision: 0,
-              role: "user",
-              origin: "human",
-              text: "second queued",
-              streaming: false,
-              createdAt: "2026-08-11T10:02:00Z",
-            },
-          },
-        ]}
-      />,
-    );
+	it("keeps the next queued message visible when the dock is collapsed", async () => {
+		render(
+			<QueuedMessageDock
+				messages={[
+					{
+						turnId: "queued-1",
+						message: {
+							kind: "message",
+							id: "queued-message-1",
+							turnId: "queued-1",
+							sequence: 100,
+							revision: 0,
+							role: "user",
+							origin: "human",
+							text: "first queued",
+							streaming: false,
+							createdAt: "2026-08-11T10:01:00Z",
+						},
+					},
+					{
+						turnId: "queued-2",
+						message: {
+							kind: "message",
+							id: "queued-message-2",
+							turnId: "queued-2",
+							sequence: 101,
+							revision: 0,
+							role: "user",
+							origin: "human",
+							text: "second queued",
+							streaming: false,
+							createdAt: "2026-08-11T10:02:00Z",
+						},
+					},
+				]}
+			/>,
+		);
 
-    const dock = screen.getByTestId("queued-message-dock");
-    expect(within(dock).getByText("first queued")).toBeVisible();
-    expect(within(dock).getByText("second queued")).toBeVisible();
+		const dock = screen.getByTestId("queued-message-dock");
+		expect(within(dock).getByText("first queued")).toBeVisible();
+		expect(within(dock).getByText("second queued")).toBeVisible();
 
-    await userEvent.click(screen.getByRole("button", { expanded: true }));
-    expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
-    expect(within(dock).getByText("first queued")).toBeVisible();
-    const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
-    expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
-    expect(hiddenRow).toHaveAttribute("inert");
-  });
+		await userEvent.click(screen.getByRole("button", { expanded: true }));
+		expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
+		expect(within(dock).getByText("first queued")).toBeVisible();
+		const hiddenRow = within(dock).getByTestId("queued-message-queued-2");
+		expect(hiddenRow).toHaveAttribute("aria-hidden", "true");
+		expect(hiddenRow).toHaveAttribute("inert");
+	});
 
-  it("hides a cancelled queued message from the timeline", () => {
-    const base = withQueuedMessages();
-    const snapshot = {
-      ...base,
-      turns: base.turns.map((turn) =>
-        turn.id === "queued-1"
-          ? {
-              ...turn,
-              state: "cancelled" as const,
-              completedAt: "2026-08-11T10:03:00Z",
-            }
-          : turn,
-      ),
-      items: base.items.filter(
-        (item) => item.kind !== "message" || item.turnId !== "queued-1",
-      ),
-    };
-    render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
+	it("hides a cancelled queued message from the timeline", () => {
+		const base = withQueuedMessages();
+		const snapshot = {
+			...base,
+			turns: base.turns.map((turn) =>
+				turn.id === "queued-1"
+					? {
+							...turn,
+							state: "cancelled" as const,
+							completedAt: "2026-08-11T10:03:00Z",
+						}
+					: turn,
+			),
+			items: base.items.filter((item) => item.kind !== "message" || item.turnId !== "queued-1"),
+		};
+		render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
 
-    expect(screen.queryByText("first queued")).not.toBeInTheDocument();
-    expect(
-      within(screen.getByTestId("queued-message-dock")).getByText(
-        "second queued",
-      ),
-    ).toBeVisible();
-  });
+		expect(screen.queryByText("first queued")).not.toBeInTheDocument();
+		expect(within(screen.getByTestId("queued-message-dock")).getByText("second queued")).toBeVisible();
+	});
 
-  it("clears a queued edit when that message is deleted from the dock", async () => {
-    const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
-    render(
-      <ChatWorkspace
-        snapshot={withQueuedMessages()}
-        onSteer={vi.fn()}
-        onEditQueuedTurn={vi.fn()}
-        onCancelQueuedTurn={onCancelQueuedTurn}
-      />,
-    );
+	it("clears a queued edit when that message is deleted from the dock", async () => {
+		const onCancelQueuedTurn = vi.fn().mockResolvedValue(undefined);
+		render(
+			<ChatWorkspace
+				snapshot={withQueuedMessages()}
+				onSteer={vi.fn()}
+				onEditQueuedTurn={vi.fn()}
+				onCancelQueuedTurn={onCancelQueuedTurn}
+			/>,
+		);
 
-    await userEvent.click(
-      within(screen.getByTestId("queued-message-queued-1")).getByRole(
-        "button",
-        { name: "Edit queued message" },
-      ),
-    );
-    await waitFor(() =>
-      expect(screen.getByText(/editing/i)).toBeInTheDocument(),
-    );
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Edit queued message" }));
+		await waitFor(() => expect(screen.getByText(/editing/i)).toBeInTheDocument());
 
-    await userEvent.click(
-      within(screen.getByTestId("queued-message-queued-1")).getByRole(
-        "button",
-        { name: "Delete queued message" },
-      ),
-    );
-    await waitFor(() =>
-      expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1"),
-    );
-    await waitFor(() =>
-      expect(screen.queryByText(/editing/i)).not.toBeInTheDocument(),
-    );
-  });
+		await userEvent.click(within(screen.getByTestId("queued-message-queued-1")).getByRole("button", { name: "Delete queued message" }));
+		await waitFor(() => expect(onCancelQueuedTurn).toHaveBeenCalledWith("queued-1"));
+		await waitFor(() => expect(screen.queryByText(/editing/i)).not.toBeInTheDocument());
+	});
 
-  it("shows the queued dock while messages are still queued between turns", () => {
-    const snapshot = {
-      ...withQueuedMessages(),
-      turns: withQueuedMessages().turns.map((turn) =>
-        turn.state === "running"
-          ? { ...turn, state: "completed" as const }
-          : turn,
-      ),
-    };
-    render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
-    expect(screen.getByTestId("queued-message-dock")).toBeInTheDocument();
-    expect(
-      within(screen.getByTestId("queued-message-dock")).getByText(
-        "first queued",
-      ),
-    ).toBeVisible();
-  });
+	it("shows the queued dock while messages are still queued between turns", () => {
+		const snapshot = {
+			...withQueuedMessages(),
+			turns: withQueuedMessages().turns.map((turn) =>
+				turn.state === "running" ? { ...turn, state: "completed" as const } : turn,
+			),
+		};
+		render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
+		expect(screen.getByTestId("queued-message-dock")).toBeInTheDocument();
+		expect(within(screen.getByTestId("queued-message-dock")).getByText("first queued")).toBeVisible();
+	});
 
-  it("keeps queued messages docked after the conversation branches", () => {
-    render(
-      <ChatWorkspace
-        snapshot={{ ...withQueuedMessages(), branchedFromEarlierMessage: true }}
-        onSteer={vi.fn()}
-      />,
-    );
+	it("keeps queued messages docked after the conversation branches", () => {
+		render(
+			<ChatWorkspace
+				snapshot={{ ...withQueuedMessages(), branchedFromEarlierMessage: true }}
+				onSteer={vi.fn()}
+			/>,
+		);
 
-    const dock = screen.getByTestId("queued-message-dock");
-    expect(within(dock).getByText("first queued")).toBeVisible();
-    expect(within(dock).getByText("second queued")).toBeVisible();
-  });
+		const dock = screen.getByTestId("queued-message-dock");
+		expect(within(dock).getByText("first queued")).toBeVisible();
+		expect(within(dock).getByText("second queued")).toBeVisible();
+	});
 
-  it("shows the standard steer action on the next row and hover steer on later rows", () => {
-    render(
-      <ChatWorkspace
-        snapshot={withQueuedMessages()}
-        onSteer={vi.fn()}
-        onPromoteQueuedTurn={vi.fn()}
-      />,
-    );
+	it("shows the standard steer action on the next row and hover steer on later rows", () => {
+		render(
+			<ChatWorkspace
+				snapshot={withQueuedMessages()}
+				onSteer={vi.fn()}
+				onPromoteQueuedTurn={vi.fn()}
+			/>,
+		);
 
-    const dock = screen.getByTestId("queued-message-dock");
-    expect(within(dock).queryByText("Queue")).not.toBeInTheDocument();
-    expect(
-      within(screen.getByTestId("queued-message-queued-1")).getByRole(
-        "button",
-        {
-          name: "Steer this queued message into the running turn",
-        },
-      ),
-    ).toBeInTheDocument();
-    expect(
-      within(screen.getByTestId("queued-message-queued-2")).getByRole(
-        "button",
-        {
-          name: "Steer this queued message into the running turn",
-        },
-      ),
-    ).toBeInTheDocument();
-  });
+		const dock = screen.getByTestId("queued-message-dock");
+		expect(within(dock).queryByText("Queue")).not.toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("queued-message-queued-1")).getByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		).toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("queued-message-queued-2")).getByRole("button", {
+				name: "Steer this queued message into the running turn",
+			}),
+		).toBeInTheDocument();
+	});
 
-  it("does not show delivery indicators in the composer for a running turn without a pending approval", () => {
-    const snapshot = {
-      ...chatFixture,
-      items: chatFixture.items.filter(
-        (item) =>
-          !(
-            item.kind === "activity" &&
-            item.activityKind === "approval" &&
-            item.status === "pending"
-          ),
-      ),
-    };
-    render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
-    expect(screen.queryByText("Queue")).not.toBeInTheDocument();
-    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-  });
+	it("does not show delivery indicators in the composer for a running turn without a pending approval", () => {
+		const snapshot = {
+			...chatFixture,
+			items: chatFixture.items.filter(
+				(item) =>
+					!(item.kind === "activity" && item.activityKind === "approval" && item.status === "pending"),
+			),
+		};
+		render(<ChatWorkspace snapshot={snapshot} onSteer={vi.fn()} />);
+		expect(screen.queryByText("Queue")).not.toBeInTheDocument();
+		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+	});
 
-  it("does not show delivery indicator on a settled conversation", () => {
-    render(
-      <ChatWorkspace
-        snapshot={{
-          ...chatFixture,
-          turns: chatFixture.turns.map((t) => ({
-            ...t,
-            state: "completed" as const,
-          })),
-        }}
-        onSteer={vi.fn()}
-      />,
-    );
-    expect(screen.queryByText("Steer")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("queued-message-dock")).not.toBeInTheDocument();
-  });
+	it("does not show delivery indicator on a settled conversation", () => {
+		render(
+			<ChatWorkspace
+				snapshot={{ ...chatFixture, turns: chatFixture.turns.map((t) => ({ ...t, state: "completed" as const })) }}
+				onSteer={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByText("Steer")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("queued-message-dock")).not.toBeInTheDocument();
+	});
 
-  // A queued turn has not reached the provider, so there is nothing to steer.
-  it("does not offer steering into a turn that is only queued", () => {
-    render(
-      <ChatWorkspace
-        snapshot={{
-          ...chatFixture,
-          turns: chatFixture.turns.map((t) =>
-            t.state === "running" ? { ...t, state: "queued" as const } : t,
-          ),
-        }}
-        onSteer={vi.fn()}
-      />,
-    );
-    expect(
-      screen.queryByRole("button", { name: "Steer this turn" }),
-    ).not.toBeInTheDocument();
-  });
+	// A queued turn has not reached the provider, so there is nothing to steer.
+	it("does not offer steering into a turn that is only queued", () => {
+		render(
+			<ChatWorkspace
+				snapshot={{
+					...chatFixture,
+					turns: chatFixture.turns.map((t) =>
+						t.state === "running" ? { ...t, state: "queued" as const } : t,
+					),
+				}}
+				onSteer={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByRole("button", { name: "Steer this turn" })).not.toBeInTheDocument();
+	});
 
-  it("renders a landed steer as the user's own words", () => {
-    render(<ChatWorkspace snapshot={chatFixture} />);
-    expect(
-      screen.getByText(/Steered into the running turn/),
-    ).toBeInTheDocument();
-  });
+	it("renders a landed steer as the user's own words", () => {
+		render(<ChatWorkspace snapshot={chatFixture} />);
+		expect(screen.getByText(/Steered into the running turn/)).toBeInTheDocument();
+	});
 
-  it("renders every promoted steer content block on the running turn", () => {
-    const snapshot = {
-      ...chatFixture,
-      items: chatFixture.items.map((item) =>
-        item.kind === "activity" && item.id === "a-steer-1"
-          ? {
-              ...item,
-              detail: {
-                ...item.detail,
-                content: [
-                  { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
-                  {
-                    type: "resource_link",
-                    name: "reference.md",
-                    uri: "file:///reference.md",
-                  },
-                  {
-                    type: "resource",
-                    name: "notes.md",
-                    uri: "file:///notes.md",
-                    text: "details",
-                  },
-                ],
-              },
-            }
-          : item,
-      ),
-    };
-    render(<ChatWorkspace snapshot={snapshot} />);
-    const image = screen.getByRole("img", { name: "Steered attachment 1" });
-    expect(image).toHaveAttribute("src", "data:image/png;base64,aGVsbG8=");
-    const attachments = screen.getByRole("list", {
-      name: "Steered attachments",
-    });
-    expect(
-      within(attachments).getByTitle("file:///reference.md"),
-    ).toHaveTextContent("reference.md");
-    expect(
-      within(attachments).getByTitle("file:///notes.md"),
-    ).toHaveTextContent("notes.md");
-  });
+	it("renders every promoted steer content block on the running turn", () => {
+		const snapshot = {
+			...chatFixture,
+			items: chatFixture.items.map((item) =>
+				item.kind === "activity" && item.id === "a-steer-1"
+					? {
+							...item,
+							detail: {
+								...item.detail,
+								content: [
+									{ type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+									{ type: "resource_link", name: "reference.md", uri: "file:///reference.md" },
+									{ type: "resource", name: "notes.md", uri: "file:///notes.md", text: "details" },
+								],
+							},
+						}
+					: item,
+			),
+		};
+		render(<ChatWorkspace snapshot={snapshot} />);
+		const image = screen.getByRole("img", { name: "Steered attachment 1" });
+		expect(image).toHaveAttribute("src", "data:image/png;base64,aGVsbG8=");
+		const attachments = screen.getByRole("list", { name: "Steered attachments" });
+		expect(within(attachments).getByTitle("file:///reference.md")).toHaveTextContent("reference.md");
+		expect(within(attachments).getByTitle("file:///notes.md")).toHaveTextContent("notes.md");
+	});
 });

--- a/frontend/src/renderer/components/chat/ChatSteer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatSteer.test.tsx
@@ -88,6 +88,41 @@ describe("ChatComposer steering", () => {
 		expect(screen.queryByTestId("queued-message-queued-1")).not.toBeInTheDocument();
 	});
 
+	it("drains every queued steer request that arrives while a promotion is pending", async () => {
+		let resolveFirstPromotion: (() => void) | undefined;
+		const firstPromotion = new Promise<void>((resolve) => {
+			resolveFirstPromotion = resolve;
+		});
+		const onPromoteQueuedTurn = vi
+			.fn()
+			.mockImplementationOnce(() => firstPromotion)
+			.mockResolvedValueOnce(undefined);
+		const messages = [queuedMessage("queued-1", "first"), queuedMessage("queued-2", "next")];
+		const { rerender } = render(
+			<QueuedMessageDock
+				messages={messages}
+				canSteer
+				canSteerNext
+				steerNextRequest={0}
+				onPromoteQueuedTurn={onPromoteQueuedTurn}
+			/>,
+		);
+
+		rerender(
+			<QueuedMessageDock
+				messages={messages}
+				canSteer
+				canSteerNext
+				steerNextRequest={2}
+				onPromoteQueuedTurn={onPromoteQueuedTurn}
+			/>,
+		);
+
+		await waitFor(() => expect(onPromoteQueuedTurn).toHaveBeenCalledWith("queued-1"));
+		resolveFirstPromotion?.();
+		await waitFor(() => expect(onPromoteQueuedTurn).toHaveBeenNthCalledWith(2, "queued-2"));
+	});
+
 	it("reports the daemon's refusal without a second message of its own", () => {
 		composer({ steerRefusal: "A compaction turn is running. Try again once it finishes." });
 		expect(screen.getByRole("status")).toHaveTextContent(/compaction turn is running/);

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -182,7 +182,7 @@ export function QueuedMessageDock({
 				disabled={!hasMore}
 				className={cn(
 					"flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
-					hasMore && "cursor-pointer active:scale-[0.999] transition-transform duration-150 ease-out",
+					hasMore && "cursor-pointer",
 					!hasMore && "cursor-default",
 				)}
 				aria-expanded={hasMore ? expanded : undefined}
@@ -200,7 +200,11 @@ export function QueuedMessageDock({
 					<span aria-hidden="true" className="size-3.5 shrink-0" />
 				)}
 				<span className="text-xs font-medium text-muted-foreground">
-					{count} Queued {count === 1 ? "Message" : "Messages"}
+					<span
+						className="inline-block w-fit"
+					>
+						{count} Queued {count === 1 ? "Message" : "Messages"}
+					</span>
 					{editingTurnId ? " · editing" : ""}
 				</span>
 			</button>

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -11,6 +11,7 @@ function QueuedMessageRow({
 	turnId,
 	message,
 	hiddenFromView,
+	showNextUp,
 	canSteer,
 	onPromoteQueuedTurn,
 	onBeginQueuedEdit,
@@ -22,6 +23,7 @@ function QueuedMessageRow({
 	turnId: string;
 	message: ConversationMessage;
 	hiddenFromView?: boolean;
+	showNextUp?: boolean;
 	canSteer?: boolean;
 	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
 	onBeginQueuedEdit?: (turnId: string, text: string) => void;
@@ -42,6 +44,9 @@ function QueuedMessageRow({
 					className="size-3 shrink-0 text-muted-foreground/60"
 					strokeWidth={1.5}
 				/>
+				{showNextUp ? (
+					<span className="shrink-0 text-[11px] font-normal text-muted-foreground/60">Next Up</span>
+				) : null}
 				<p
 					className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
 					title={message.text}
@@ -199,7 +204,6 @@ export function QueuedMessageDock({
 					<span aria-hidden="true" className="size-3.5 shrink-0" />
 				)}
 				<span className="text-xs font-medium text-muted-foreground">
-					<span className="mr-2 text-[11px] font-normal text-muted-foreground/60">Next Up</span>
 					{count} Queued {count === 1 ? "Message" : "Messages"}
 					{editingTurnId ? " · editing" : ""}
 				</span>
@@ -228,6 +232,7 @@ export function QueuedMessageDock({
 									turnId={turnId}
 									message={message}
 									hiddenFromView={!isOpen && index > 0}
+									showNextUp={!isOpen && index === 0}
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -1,5 +1,17 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
-import { ChevronDown, Circle, Command, CornerDownLeft, Pencil, Trash2 } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import {
+  ChevronDown,
+  Circle,
+  CornerDownLeft,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { ConversationMessage } from "../../types/conversation";
 
@@ -8,279 +20,338 @@ export type QueuedMessage = { turnId: string; message: ConversationMessage };
 const QUEUE_DOCK_VISIBLE_ROWS = 5;
 
 function QueuedMessageRow({
-	turnId,
-	message,
-	hiddenFromView,
-	showHoverSteer,
-	canSteer,
-	onPromoteQueuedTurn,
-	onBeginQueuedEdit,
-	onCancelQueuedTurn,
-	busy,
-	error,
-	onRunAction,
+  turnId,
+  message,
+  hiddenFromView,
+  showHoverSteer,
+  canSteer,
+  onPromoteQueuedTurn,
+  onBeginQueuedEdit,
+  onCancelQueuedTurn,
+  busy,
+  error,
+  onRunAction,
 }: {
-	turnId: string;
-	message: ConversationMessage;
-	hiddenFromView?: boolean;
-	showHoverSteer?: boolean;
-	canSteer?: boolean;
-	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
-	onBeginQueuedEdit?: (turnId: string, text: string) => void;
-	onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
-	busy?: boolean;
-	error?: string;
-	onRunAction: (turnId: string, action: () => Promise<unknown>) => void;
+  turnId: string;
+  message: ConversationMessage;
+  hiddenFromView?: boolean;
+  showHoverSteer?: boolean;
+  canSteer?: boolean;
+  onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
+  onBeginQueuedEdit?: (turnId: string, text: string) => void;
+  onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
+  busy?: boolean;
+  error?: string;
+  onRunAction: (turnId: string, action: () => Promise<unknown>) => void;
 }) {
-	return (
-		<div
-			className="queue-dock-row group/queued-row"
-			data-testid={`queued-message-${turnId}`}
-			aria-hidden={hiddenFromView ? true : undefined}
-			inert={hiddenFromView ? true : undefined}
-		>
-			<div className="flex min-h-9 min-w-0 items-center gap-2.5 px-3 py-1.5">
-				<Circle
-					aria-hidden="true"
-					className="size-3 shrink-0 text-muted-foreground/60"
-					strokeWidth={1.5}
-				/>
-				<p
-					className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
-					title={message.text}
-				>
-					{message.text}
-				</p>
-				<div className="queue-dock-actions flex shrink-0 items-center gap-0.5 whitespace-nowrap">
-					{showHoverSteer && onPromoteQueuedTurn ? (
-						<button
-							type="button"
-							disabled={busy}
-							onClick={() => {
-								void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
-							}}
-							className="inline-flex h-7 items-center rounded-lg px-2 text-[11px] leading-none text-muted-foreground opacity-0 pointer-events-none transition-[background-color,color,opacity] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground group-hover/queued-row:pointer-events-auto group-hover/queued-row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-50 motion-reduce:transition-none"
-							aria-label="Steer this queued message into the running turn"
-							title="Steer into running turn"
-						>
-							Steer
-						</button>
-					) : null}
-					{canSteer && onPromoteQueuedTurn ? (
-						<button
-							type="button"
-							disabled={busy}
-							onClick={() => {
-								void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
-							}}
-							className="inline-flex h-7 items-center gap-1.5 rounded-lg px-2 text-[11px] leading-none text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-							aria-label="Steer this queued message into the running turn"
-							title="Steer into running turn"
-						>
-							<span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
-								<Command aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
-								<CornerDownLeft aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
-							</span>
-							Steer
-						</button>
-					) : null}
-					{onBeginQueuedEdit ? (
-						<button
-							type="button"
-							disabled={busy}
-							onClick={() => onBeginQueuedEdit(turnId, message.text)}
-							className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-							aria-label="Edit queued message"
-							title="Edit"
-						>
-							<Pencil aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
-						</button>
-					) : null}
-					{onCancelQueuedTurn ? (
-						<button
-							type="button"
-							disabled={busy}
-							onClick={() => {
-								void onRunAction(turnId, () => onCancelQueuedTurn(turnId));
-							}}
-							className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-destructive active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-							aria-label="Delete queued message"
-							title="Delete"
-						>
-							<Trash2 aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
-						</button>
-					) : null}
-				</div>
-			</div>
-			{error ? (
-				<p role="status" className="px-3 pb-2 text-[11px] text-warning">
-					{error}
-				</p>
-			) : null}
-		</div>
-	);
+  return (
+    <div
+      className="queue-dock-row group/queued-row"
+      data-testid={`queued-message-${turnId}`}
+      aria-hidden={hiddenFromView ? true : undefined}
+      inert={hiddenFromView ? true : undefined}
+    >
+      <div className="flex min-h-9 min-w-0 items-center gap-2.5 px-3 py-1.5">
+        <Circle
+          aria-hidden="true"
+          className="size-3 shrink-0 text-muted-foreground/60"
+          strokeWidth={1.5}
+        />
+        <p
+          className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
+          title={message.text}
+        >
+          {message.text}
+        </p>
+        <div className="queue-dock-actions flex shrink-0 items-center gap-0.5 whitespace-nowrap">
+          {showHoverSteer && onPromoteQueuedTurn ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => {
+                void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
+              }}
+              className="inline-flex h-7 items-center rounded-lg px-2 text-[11px] leading-none text-muted-foreground opacity-0 pointer-events-none transition-[background-color,color,opacity] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground group-hover/queued-row:pointer-events-auto group-hover/queued-row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-50 motion-reduce:transition-none"
+              aria-label="Steer this queued message into the running turn"
+              title="Steer into running turn"
+            >
+              Steer
+            </button>
+          ) : null}
+          {canSteer && onPromoteQueuedTurn ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => {
+                void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
+              }}
+              className="inline-flex h-7 items-center gap-1.5 rounded-lg px-2 text-[11px] leading-none text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+              aria-label="Steer this queued message into the running turn"
+              title="Steer into running turn"
+            >
+              <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
+                <CornerDownLeft
+                  aria-hidden="true"
+                  className="shrink-0"
+                  width={12}
+                  height={12}
+                  strokeWidth={2}
+                />
+              </span>
+              Steer
+            </button>
+          ) : null}
+          {onBeginQueuedEdit ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onBeginQueuedEdit(turnId, message.text)}
+              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+              aria-label="Edit queued message"
+              title="Edit"
+            >
+              <Pencil
+                aria-hidden="true"
+                className="shrink-0"
+                width={12}
+                height={12}
+                strokeWidth={2}
+              />
+            </button>
+          ) : null}
+          {onCancelQueuedTurn ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => {
+                void onRunAction(turnId, () => onCancelQueuedTurn(turnId));
+              }}
+              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-destructive active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+              aria-label="Delete queued message"
+              title="Delete"
+            >
+              <Trash2
+                aria-hidden="true"
+                className="shrink-0"
+                width={12}
+                height={12}
+                strokeWidth={2}
+              />
+            </button>
+          ) : null}
+        </div>
+      </div>
+      {error ? (
+        <p role="status" className="px-3 pb-2 text-[11px] text-warning">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 export function QueuedMessageDock({
-	messages,
-	editingTurnId,
-	canSteer,
-	onPromoteQueuedTurn,
-	onBeginQueuedEdit,
-	onCancelQueuedTurn,
-	promotePendingTurnId,
-	cancelPendingTurnId,
+  messages,
+  editingTurnId,
+  canSteer,
+  canSteerNext,
+  steerNextRequest,
+  onPromoteQueuedTurn,
+  onBeginQueuedEdit,
+  onCancelQueuedTurn,
+  promotePendingTurnId,
+  cancelPendingTurnId,
 }: {
-	messages: QueuedMessage[];
-	editingTurnId?: string;
-	canSteer?: boolean;
-	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
-	onBeginQueuedEdit?: (turnId: string, text: string) => void;
-	onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
-	promotePendingTurnId?: string;
-	cancelPendingTurnId?: string;
+  messages: QueuedMessage[];
+  editingTurnId?: string;
+  canSteer?: boolean;
+  canSteerNext?: boolean;
+  steerNextRequest?: number;
+  onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
+  onBeginQueuedEdit?: (turnId: string, text: string) => void;
+  onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
+  promotePendingTurnId?: string;
+  cancelPendingTurnId?: string;
 }) {
-	const [expanded, setExpanded] = useState(true);
-	const [errors, setErrors] = useState<Record<string, string>>({});
-	const [optimisticallySteeredTurnIds, setOptimisticallySteeredTurnIds] = useState<Set<string>>(
-		() => new Set(),
-	);
-	const scrollRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(true);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [optimisticallySteeredTurnIds, setOptimisticallySteeredTurnIds] =
+    useState<Set<string>>(() => new Set());
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const lastSteerNextRequest = useRef(steerNextRequest ?? 0);
 
-	const runAction = useCallback(
-		async (turnId: string, action: () => Promise<unknown>) => {
-			setErrors((current) => {
-				if (!current[turnId]) return current;
-				const next = { ...current };
-				delete next[turnId];
-				return next;
-			});
-			try {
-				await action();
-			} catch (error) {
-				setErrors((current) => ({
-					...current,
-					[turnId]: error instanceof Error ? error.message : "That action failed.",
-				}));
-			}
-		},
-		[],
-	);
+  const runAction = useCallback(
+    async (turnId: string, action: () => Promise<unknown>) => {
+      setErrors((current) => {
+        if (!current[turnId]) return current;
+        const next = { ...current };
+        delete next[turnId];
+        return next;
+      });
+      try {
+        await action();
+      } catch (error) {
+        setErrors((current) => ({
+          ...current,
+          [turnId]:
+            error instanceof Error ? error.message : "That action failed.",
+        }));
+      }
+    },
+    [],
+  );
 
-	const visibleMessages = messages.filter(({ turnId }) => !optimisticallySteeredTurnIds.has(turnId));
-	const count = visibleMessages.length;
-	const hasMore = count > 1;
-	const isOpen = !hasMore || expanded;
-	const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
-	const displayMessages = [...visibleMessages].reverse();
+  const visibleMessages = messages.filter(
+    ({ turnId }) => !optimisticallySteeredTurnIds.has(turnId),
+  );
+  const count = visibleMessages.length;
+  const hasMore = count > 1;
+  const isOpen = !hasMore || expanded;
+  const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
+  const displayMessages = [...visibleMessages].reverse();
 
-	const promoteQueuedTurn = useCallback(
-		async (turnId: string) => {
-			setOptimisticallySteeredTurnIds((current) => new Set(current).add(turnId));
-			try {
-				if (!onPromoteQueuedTurn) return;
-				await onPromoteQueuedTurn(turnId);
-			} catch (error) {
-				setOptimisticallySteeredTurnIds((current) => {
-					const next = new Set(current);
-					next.delete(turnId);
-					return next;
-				});
-				throw error;
-			}
-		},
-		[onPromoteQueuedTurn],
-	);
+  const promoteQueuedTurn = useCallback(
+    async (turnId: string) => {
+      setOptimisticallySteeredTurnIds((current) =>
+        new Set(current).add(turnId),
+      );
+      try {
+        if (!onPromoteQueuedTurn) return;
+        await onPromoteQueuedTurn(turnId);
+      } catch (error) {
+        setOptimisticallySteeredTurnIds((current) => {
+          const next = new Set(current);
+          next.delete(turnId);
+          return next;
+        });
+        throw error;
+      }
+    },
+    [onPromoteQueuedTurn],
+  );
 
-	useEffect(() => {
-		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
-		const scroll = scrollRef.current;
-		if (scroll) scroll.scrollTop = scroll.scrollHeight;
-	}, [count, isOpen]);
+  useEffect(() => {
+    if (
+      steerNextRequest === undefined ||
+      steerNextRequest <= lastSteerNextRequest.current
+    )
+      return;
+    lastSteerNextRequest.current = steerNextRequest;
+    if (!canSteerNext || !onPromoteQueuedTurn) return;
 
-	const rowProps = {
-		canSteer,
-		onPromoteQueuedTurn: onPromoteQueuedTurn ? promoteQueuedTurn : undefined,
-		onBeginQueuedEdit,
-		onCancelQueuedTurn,
-		onRunAction: runAction,
-	};
+    const next = displayMessages[displayMessages.length - 1];
+    if (next) void runAction(next.turnId, () => promoteQueuedTurn(next.turnId));
+  }, [
+    canSteerNext,
+    displayMessages,
+    onPromoteQueuedTurn,
+    promoteQueuedTurn,
+    runAction,
+    steerNextRequest,
+  ]);
 
-	return (
-		<div
-			className="queue-dock overflow-hidden rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
-			data-testid="queued-message-dock"
-			data-collapsible={hasMore ? "true" : "false"}
-			data-expanded={isOpen ? "true" : "false"}
-			style={{ "--queue-dock-expanded-rows": expandedRows } as CSSProperties}
-		>
-			<button
-				type="button"
-				onClick={() => hasMore && setExpanded((open) => !open)}
-				disabled={!hasMore}
-				className={cn(
-					"queue-dock-toggle flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
-					hasMore && "cursor-pointer",
-					!hasMore && "cursor-default",
-				)}
-				aria-expanded={hasMore ? expanded : undefined}
-				data-testid="queued-message-toggle"
-			>
-				{hasMore ? (
-					<ChevronDown
-						aria-hidden="true"
-						className={cn(
-							"size-3.5 shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
-							expanded ? "rotate-0" : "-rotate-90",
-						)}
-					/>
-				) : (
-					<span aria-hidden="true" className="size-3.5 shrink-0" />
-				)}
-				<span className="queue-dock-label text-xs font-medium text-muted-foreground transition-colors duration-150">
-					<span
-						className="inline-block w-fit"
-					>
-						{count} Queued {count === 1 ? "Message" : "Messages"}
-					</span>
-					{editingTurnId ? " · editing" : ""}
-				</span>
-			</button>
-			{count > 0 ? (
-				<div
-					className="queue-dock-body bg-surface"
-					data-expanded={isOpen ? "true" : "false"}
-					data-collapsible={hasMore ? "true" : "false"}
-					style={
-						{
-							"--queue-dock-expanded-rows": expandedRows,
-						} as CSSProperties
-					}
-				>
-					<div
-						ref={scrollRef}
-						className={cn("queue-dock-scroll", isOpen && count > QUEUE_DOCK_VISIBLE_ROWS && "queue-dock-scroll-active")}
-					>
-						{displayMessages.map(({ turnId, message }, index) => {
-							const busy =
-								promotePendingTurnId === turnId || cancelPendingTurnId === turnId;
-							return (
-								<QueuedMessageRow
-									key={turnId}
-									turnId={turnId}
-									message={message}
-									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
-									showHoverSteer={canSteer && index !== displayMessages.length - 1}
-									busy={busy}
-									error={errors[turnId]}
-									{...rowProps}
-									canSteer={canSteer && index === displayMessages.length - 1}
-								/>
-							);
-						})}
-					</div>
-				</div>
-			) : null}
-		</div>
-	);
+  useEffect(() => {
+    if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
+    const scroll = scrollRef.current;
+    if (scroll) scroll.scrollTop = scroll.scrollHeight;
+  }, [count, isOpen]);
+
+  const rowProps = {
+    canSteer,
+    onPromoteQueuedTurn: onPromoteQueuedTurn ? promoteQueuedTurn : undefined,
+    onBeginQueuedEdit,
+    onCancelQueuedTurn,
+    onRunAction: runAction,
+  };
+
+  return (
+    <div
+      className="queue-dock overflow-hidden rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
+      data-testid="queued-message-dock"
+      data-collapsible={hasMore ? "true" : "false"}
+      data-expanded={isOpen ? "true" : "false"}
+      style={{ "--queue-dock-expanded-rows": expandedRows } as CSSProperties}
+    >
+      <button
+        type="button"
+        onClick={() => hasMore && setExpanded((open) => !open)}
+        disabled={!hasMore}
+        className={cn(
+          "queue-dock-toggle flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
+          hasMore && "cursor-pointer",
+          !hasMore && "cursor-default",
+        )}
+        aria-expanded={hasMore ? expanded : undefined}
+        data-testid="queued-message-toggle"
+      >
+        {hasMore ? (
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+              expanded ? "rotate-0" : "-rotate-90",
+            )}
+          />
+        ) : (
+          <span aria-hidden="true" className="size-3.5 shrink-0" />
+        )}
+        <span className="queue-dock-label text-xs font-medium text-muted-foreground transition-colors duration-150">
+          <span className="inline-block w-fit">
+            {count} Queued {count === 1 ? "Message" : "Messages"}
+          </span>
+          {editingTurnId ? " · editing" : ""}
+        </span>
+      </button>
+      {count > 0 ? (
+        <div
+          className="queue-dock-body bg-surface"
+          data-expanded={isOpen ? "true" : "false"}
+          data-collapsible={hasMore ? "true" : "false"}
+          style={
+            {
+              "--queue-dock-expanded-rows": expandedRows,
+            } as CSSProperties
+          }
+        >
+          <div
+            ref={scrollRef}
+            className={cn(
+              "queue-dock-scroll",
+              isOpen &&
+                count > QUEUE_DOCK_VISIBLE_ROWS &&
+                "queue-dock-scroll-active",
+            )}
+          >
+            {displayMessages.map(({ turnId, message }, index) => {
+              const busy =
+                promotePendingTurnId === turnId ||
+                cancelPendingTurnId === turnId;
+              return (
+                <QueuedMessageRow
+                  key={turnId}
+                  turnId={turnId}
+                  message={message}
+                  hiddenFromView={
+                    !isOpen && index !== displayMessages.length - 1
+                  }
+                  showHoverSteer={
+                    canSteer &&
+                    (index !== displayMessages.length - 1 || !canSteerNext)
+                  }
+                  busy={busy}
+                  error={errors[turnId]}
+                  {...rowProps}
+                  canSteer={
+                    canSteer &&
+                    canSteerNext &&
+                    index === displayMessages.length - 1
+                  }
+                />
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -161,7 +161,7 @@ export function QueuedMessageDock({
 
 	return (
 		<div
-			className="overflow-hidden rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
+			className="queue-dock rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
 			data-testid="queued-message-dock"
 		>
 			<button
@@ -170,10 +170,11 @@ export function QueuedMessageDock({
 				disabled={!hasMore}
 				className={cn(
 					"flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
-					hasMore && "cursor-pointer active:scale-[0.995] transition-transform duration-150 ease-out",
+					hasMore && "cursor-pointer active:scale-[0.999] transition-transform duration-150 ease-out",
 					!hasMore && "cursor-default",
 				)}
 				aria-expanded={hasMore ? expanded : undefined}
+				data-testid="queued-message-toggle"
 			>
 				{hasMore ? (
 					<ChevronDown
@@ -193,7 +194,7 @@ export function QueuedMessageDock({
 			</button>
 			{count > 0 ? (
 				<div
-					className="queue-dock-body"
+					className="queue-dock-body bg-surface"
 					data-expanded={isOpen ? "true" : "false"}
 					data-collapsible={hasMore ? "true" : "false"}
 					style={

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -151,12 +151,12 @@ export function QueuedMessageDock({
 	const hasMore = count > 1;
 	const isOpen = !hasMore || expanded;
 	const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
-	const displayMessages = [...messages].reverse();
+	const displayMessages = messages;
 
 	useEffect(() => {
 		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
 		const scroll = scrollRef.current;
-		if (scroll) scroll.scrollTop = scroll.scrollHeight;
+		if (scroll) scroll.scrollTop = 0;
 	}, [count, isOpen]);
 
 	const rowProps = {
@@ -199,6 +199,7 @@ export function QueuedMessageDock({
 					<span aria-hidden="true" className="size-3.5 shrink-0" />
 				)}
 				<span className="text-xs font-medium text-muted-foreground">
+					<span className="mr-2 text-[11px] font-normal text-muted-foreground/60">Next Up</span>
 					{count} Queued {count === 1 ? "Message" : "Messages"}
 					{editingTurnId ? " · editing" : ""}
 				</span>
@@ -226,11 +227,11 @@ export function QueuedMessageDock({
 									key={turnId}
 									turnId={turnId}
 									message={message}
-									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
+									hiddenFromView={!isOpen && index > 0}
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}
-									canSteer={canSteer && index === displayMessages.length - 1}
+									canSteer={canSteer && index === 0}
 								/>
 							);
 						})}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -11,7 +11,6 @@ function QueuedMessageRow({
 	turnId,
 	message,
 	hiddenFromView,
-	showNextUp,
 	canSteer,
 	onPromoteQueuedTurn,
 	onBeginQueuedEdit,
@@ -23,7 +22,6 @@ function QueuedMessageRow({
 	turnId: string;
 	message: ConversationMessage;
 	hiddenFromView?: boolean;
-	showNextUp?: boolean;
 	canSteer?: boolean;
 	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
 	onBeginQueuedEdit?: (turnId: string, text: string) => void;
@@ -44,16 +42,13 @@ function QueuedMessageRow({
 					className="size-3 shrink-0 text-muted-foreground/60"
 					strokeWidth={1.5}
 				/>
-				{showNextUp ? (
-					<span className="shrink-0 text-[11px] font-normal text-muted-foreground/60">Next Up</span>
-				) : null}
 				<p
 					className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
 					title={message.text}
 				>
 					{message.text}
 				</p>
-				<div className="flex shrink-0 items-center gap-0.5">
+				<div className="queue-dock-actions flex shrink-0 items-center gap-0.5">
 					{canSteer && onPromoteQueuedTurn ? (
 						<button
 							type="button"
@@ -232,7 +227,6 @@ export function QueuedMessageDock({
 									turnId={turnId}
 									message={message}
 									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
-									showNextUp={!isOpen && index === displayMessages.length - 1}
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -173,6 +173,7 @@ export function QueuedMessageDock({
 			data-testid="queued-message-dock"
 			data-collapsible={hasMore ? "true" : "false"}
 			data-expanded={isOpen ? "true" : "false"}
+			style={{ "--queue-dock-expanded-rows": expandedRows } as CSSProperties}
 		>
 			<button
 				type="button"

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -1,9 +1,104 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, type CSSProperties } from "react";
 import { ChevronDown, Circle, Command, CornerDownLeft, Pencil, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { ConversationMessage } from "../../types/conversation";
 
 export type QueuedMessage = { turnId: string; message: ConversationMessage };
+
+const QUEUE_DOCK_VISIBLE_ROWS = 5;
+
+function QueuedMessageRow({
+	turnId,
+	message,
+	hiddenFromView,
+	canSteer,
+	onPromoteQueuedTurn,
+	onBeginQueuedEdit,
+	onCancelQueuedTurn,
+	busy,
+	error,
+	onRunAction,
+}: {
+	turnId: string;
+	message: ConversationMessage;
+	hiddenFromView?: boolean;
+	canSteer?: boolean;
+	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
+	onBeginQueuedEdit?: (turnId: string, text: string) => void;
+	onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
+	busy?: boolean;
+	error?: string;
+	onRunAction: (turnId: string, action: () => Promise<unknown>) => void;
+}) {
+	return (
+		<div data-testid={`queued-message-${turnId}`} aria-hidden={hiddenFromView ? true : undefined}>
+			<div className="flex min-h-9 min-w-0 items-center gap-2.5 px-3 py-1.5">
+				<Circle
+					aria-hidden="true"
+					className="size-3 shrink-0 text-muted-foreground/60"
+					strokeWidth={1.5}
+				/>
+				<p
+					className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
+					title={message.text}
+				>
+					{message.text}
+				</p>
+				<div className="flex shrink-0 items-center gap-0.5">
+					{canSteer && onPromoteQueuedTurn ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => {
+								void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
+							}}
+							className="inline-flex h-7 items-center gap-1.5 rounded-lg px-2 text-[11px] leading-none text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+							aria-label="Steer this queued message into the running turn"
+							title="Steer into running turn"
+						>
+							<span className="inline-flex items-center gap-1 text-muted-foreground">
+								<Command aria-hidden="true" className="size-2.5" />
+								<CornerDownLeft aria-hidden="true" className="size-3" />
+							</span>
+							Steer
+						</button>
+					) : null}
+					{onBeginQueuedEdit ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => onBeginQueuedEdit(turnId, message.text)}
+							className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+							aria-label="Edit queued message"
+							title="Edit"
+						>
+							<Pencil aria-hidden="true" className="size-3" />
+						</button>
+					) : null}
+					{onCancelQueuedTurn ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => {
+								void onRunAction(turnId, () => onCancelQueuedTurn(turnId));
+							}}
+							className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-destructive active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+							aria-label="Delete queued message"
+							title="Delete"
+						>
+							<Trash2 aria-hidden="true" className="size-3" />
+						</button>
+					) : null}
+				</div>
+			</div>
+			{error ? (
+				<p role="status" className="px-3 pb-2 text-[11px] text-warning">
+					{error}
+				</p>
+			) : null}
+		</div>
+	);
+}
 
 export function QueuedMessageDock({
 	messages,
@@ -48,6 +143,17 @@ export function QueuedMessageDock({
 	);
 
 	const count = messages.length;
+	const hasMore = count > 1;
+	const isOpen = !hasMore || expanded;
+	const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
+
+	const rowProps = {
+		canSteer,
+		onPromoteQueuedTurn,
+		onBeginQueuedEdit,
+		onCancelQueuedTurn,
+		onRunAction: runAction,
+	};
 
 	return (
 		<div
@@ -56,107 +162,61 @@ export function QueuedMessageDock({
 		>
 			<button
 				type="button"
-				onClick={() => setExpanded((open) => !open)}
-				className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors duration-150 ease-out hover:bg-interactive-hover motion-reduce:transition-none"
-				aria-expanded={expanded}
+				onClick={() => hasMore && setExpanded((open) => !open)}
+				disabled={!hasMore}
+				className={cn(
+					"flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
+					hasMore && "cursor-pointer active:scale-[0.995] transition-transform duration-150 ease-out",
+					!hasMore && "cursor-default",
+				)}
+				aria-expanded={hasMore ? expanded : undefined}
 			>
-				<ChevronDown
-					aria-hidden="true"
-					className={cn(
-						"size-3.5 shrink-0 text-muted-foreground transition-transform duration-200 ease-out motion-reduce:transition-none",
-						expanded ? "rotate-0" : "-rotate-90",
-					)}
-				/>
+				{hasMore ? (
+					<ChevronDown
+						aria-hidden="true"
+						className={cn(
+							"size-3.5 shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+							expanded ? "rotate-0" : "-rotate-90",
+						)}
+					/>
+				) : (
+					<span aria-hidden="true" className="size-3.5 shrink-0" />
+				)}
 				<span className="text-xs font-medium text-muted-foreground">
 					{count} Queued {count === 1 ? "Message" : "Messages"}
 					{editingTurnId ? " · editing" : ""}
 				</span>
 			</button>
-			<div
-				className={cn(
-					"grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
-					expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
-				)}
-			>
-				<div className="min-h-0 overflow-hidden">
-					{messages.length > 0 ? (
-						<div className="max-h-40 overflow-y-auto">
-							{messages.map(({ turnId, message }) => {
-								const busy =
-									promotePendingTurnId === turnId || cancelPendingTurnId === turnId;
-								return (
-									<div key={turnId} data-testid={`queued-message-${turnId}`}>
-										<div className="flex min-h-9 min-w-0 items-center gap-2.5 px-3 py-1.5">
-											<Circle
-												aria-hidden="true"
-												className="size-3 shrink-0 text-muted-foreground/60"
-												strokeWidth={1.5}
-											/>
-											<p
-												className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
-												title={message.text}
-											>
-												{message.text}
-											</p>
-											<div className="flex shrink-0 items-center gap-0.5">
-												{canSteer && onPromoteQueuedTurn ? (
-													<button
-														type="button"
-														disabled={busy}
-														onClick={() => {
-															void runAction(turnId, () => onPromoteQueuedTurn(turnId));
-														}}
-														className="inline-flex h-7 items-center gap-1.5 rounded-lg px-2 text-[11px] leading-none text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-														aria-label="Steer this queued message into the running turn"
-														title="Steer into running turn"
-													>
-														<span className="inline-flex items-center gap-1 text-muted-foreground">
-															<Command aria-hidden="true" className="size-2.5" />
-															<CornerDownLeft aria-hidden="true" className="size-3" />
-														</span>
-														Steer
-													</button>
-												) : null}
-												{onBeginQueuedEdit ? (
-													<button
-														type="button"
-														disabled={busy}
-														onClick={() => onBeginQueuedEdit(turnId, message.text)}
-														className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-														aria-label="Edit queued message"
-														title="Edit"
-													>
-														<Pencil aria-hidden="true" className="size-3" />
-													</button>
-												) : null}
-												{onCancelQueuedTurn ? (
-													<button
-														type="button"
-														disabled={busy}
-														onClick={() => {
-															void runAction(turnId, () => onCancelQueuedTurn(turnId));
-														}}
-														className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-destructive active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-														aria-label="Delete queued message"
-														title="Delete"
-													>
-														<Trash2 aria-hidden="true" className="size-3" />
-													</button>
-												) : null}
-											</div>
-										</div>
-										{errors[turnId] ? (
-											<p role="status" className="px-3 pb-2 text-[11px] text-warning">
-												{errors[turnId]}
-											</p>
-										) : null}
-									</div>
-								);
-							})}
-						</div>
-					) : null}
+			{count > 0 ? (
+				<div
+					className="queue-dock-body"
+					data-expanded={isOpen ? "true" : "false"}
+					data-collapsible={hasMore ? "true" : "false"}
+					style={
+						{
+							"--queue-dock-expanded-rows": expandedRows,
+						} as CSSProperties
+					}
+				>
+					<div className={cn("queue-dock-scroll", isOpen && count > QUEUE_DOCK_VISIBLE_ROWS && "queue-dock-scroll-active")}>
+						{messages.map(({ turnId, message }, index) => {
+							const busy =
+								promotePendingTurnId === turnId || cancelPendingTurnId === turnId;
+							return (
+								<QueuedMessageRow
+									key={turnId}
+									turnId={turnId}
+									message={message}
+									hiddenFromView={!isOpen && index > 0}
+									busy={busy}
+									error={errors[turnId]}
+									{...rowProps}
+								/>
+							);
+						})}
+					</div>
 				</div>
-			</div>
+			) : null}
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -48,7 +48,7 @@ function QueuedMessageRow({
 				>
 					{message.text}
 				</p>
-				<div className="queue-dock-actions flex shrink-0 items-center gap-0.5">
+				<div className="queue-dock-actions flex shrink-0 items-center gap-0.5 whitespace-nowrap">
 					{canSteer && onPromoteQueuedTurn ? (
 						<button
 							type="button"
@@ -60,9 +60,9 @@ function QueuedMessageRow({
 							aria-label="Steer this queued message into the running turn"
 							title="Steer into running turn"
 						>
-							<span className="inline-flex items-center gap-1 text-muted-foreground">
-								<Command aria-hidden="true" className="size-2.5" />
-								<CornerDownLeft aria-hidden="true" className="size-3" />
+							<span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
+								<Command aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
+								<CornerDownLeft aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
 							</span>
 							Steer
 						</button>
@@ -76,7 +76,7 @@ function QueuedMessageRow({
 							aria-label="Edit queued message"
 							title="Edit"
 						>
-							<Pencil aria-hidden="true" className="size-3" />
+							<Pencil aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
 						</button>
 					) : null}
 					{onCancelQueuedTurn ? (
@@ -90,7 +90,7 @@ function QueuedMessageRow({
 							aria-label="Delete queued message"
 							title="Delete"
 						>
-							<Trash2 aria-hidden="true" className="size-3" />
+							<Trash2 aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
 						</button>
 					) : null}
 				</div>

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
-import { ChevronDown, Circle, Command, CornerDownLeft, Pencil, Trash2 } from "lucide-react";
+import { ChevronDown, Circle, CornerDownLeft, Pencil, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { ConversationMessage } from "../../types/conversation";
 
@@ -78,7 +78,6 @@ function QueuedMessageRow({
 							title="Steer into running turn"
 						>
 							<span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
-								<Command aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
 								<CornerDownLeft aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
 							</span>
 							Steer
@@ -125,6 +124,8 @@ export function QueuedMessageDock({
 	messages,
 	editingTurnId,
 	canSteer,
+	canSteerNext,
+	steerNextRequest,
 	onPromoteQueuedTurn,
 	onBeginQueuedEdit,
 	onCancelQueuedTurn,
@@ -134,6 +135,8 @@ export function QueuedMessageDock({
 	messages: QueuedMessage[];
 	editingTurnId?: string;
 	canSteer?: boolean;
+	canSteerNext?: boolean;
+	steerNextRequest?: number;
 	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
 	onBeginQueuedEdit?: (turnId: string, text: string) => void;
 	onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
@@ -146,6 +149,7 @@ export function QueuedMessageDock({
 		() => new Set(),
 	);
 	const scrollRef = useRef<HTMLDivElement>(null);
+	const lastSteerNextRequest = useRef(steerNextRequest ?? 0);
 
 	const runAction = useCallback(
 		async (turnId: string, action: () => Promise<unknown>) => {
@@ -191,6 +195,15 @@ export function QueuedMessageDock({
 		},
 		[onPromoteQueuedTurn],
 	);
+
+	useEffect(() => {
+		if (steerNextRequest === undefined || steerNextRequest <= lastSteerNextRequest.current) return;
+		lastSteerNextRequest.current = steerNextRequest;
+		if (!canSteerNext || !onPromoteQueuedTurn) return;
+
+		const next = displayMessages[displayMessages.length - 1];
+		if (next) void runAction(next.turnId, () => promoteQueuedTurn(next.turnId));
+	}, [canSteerNext, displayMessages, onPromoteQueuedTurn, promoteQueuedTurn, runAction, steerNextRequest]);
 
 	useEffect(() => {
 		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
@@ -270,11 +283,11 @@ export function QueuedMessageDock({
 									turnId={turnId}
 									message={message}
 									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
-									showHoverSteer={canSteer && index !== displayMessages.length - 1}
+									showHoverSteer={canSteer && (index !== displayMessages.length - 1 || !canSteerNext)}
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}
-									canSteer={canSteer && index === displayMessages.length - 1}
+									canSteer={canSteer && canSteerNext && index === displayMessages.length - 1}
 								/>
 							);
 						})}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import { ChevronDown, Circle, Command, CornerDownLeft, Pencil, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { ConversationMessage } from "../../types/conversation";
@@ -125,6 +125,7 @@ export function QueuedMessageDock({
 }) {
 	const [expanded, setExpanded] = useState(true);
 	const [errors, setErrors] = useState<Record<string, string>>({});
+	const scrollRef = useRef<HTMLDivElement>(null);
 
 	const runAction = useCallback(
 		async (turnId: string, action: () => Promise<unknown>) => {
@@ -150,6 +151,13 @@ export function QueuedMessageDock({
 	const hasMore = count > 1;
 	const isOpen = !hasMore || expanded;
 	const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
+	const displayMessages = [...messages].reverse();
+
+	useEffect(() => {
+		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
+		const scroll = scrollRef.current;
+		if (scroll) scroll.scrollTop = scroll.scrollHeight;
+	}, [count, isOpen]);
 
 	const rowProps = {
 		canSteer,
@@ -161,8 +169,10 @@ export function QueuedMessageDock({
 
 	return (
 		<div
-			className="queue-dock rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
+			className="queue-dock overflow-hidden rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
 			data-testid="queued-message-dock"
+			data-collapsible={hasMore ? "true" : "false"}
+			data-expanded={isOpen ? "true" : "false"}
 		>
 			<button
 				type="button"
@@ -203,8 +213,11 @@ export function QueuedMessageDock({
 						} as CSSProperties
 					}
 				>
-					<div className={cn("queue-dock-scroll", isOpen && count > QUEUE_DOCK_VISIBLE_ROWS && "queue-dock-scroll-active")}>
-						{messages.map(({ turnId, message }, index) => {
+					<div
+						ref={scrollRef}
+						className={cn("queue-dock-scroll", isOpen && count > QUEUE_DOCK_VISIBLE_ROWS && "queue-dock-scroll-active")}
+					>
+						{displayMessages.map(({ turnId, message }, index) => {
 							const busy =
 								promotePendingTurnId === turnId || cancelPendingTurnId === turnId;
 							return (
@@ -212,7 +225,7 @@ export function QueuedMessageDock({
 									key={turnId}
 									turnId={turnId}
 									message={message}
-									hiddenFromView={!isOpen && index > 0}
+									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -61,8 +61,8 @@ function QueuedMessageRow({
 							title="Steer into running turn"
 						>
 							<span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
-								<Command aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
-								<CornerDownLeft aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
+								<Command aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
+								<CornerDownLeft aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
 							</span>
 							Steer
 						</button>
@@ -76,7 +76,7 @@ function QueuedMessageRow({
 							aria-label="Edit queued message"
 							title="Edit"
 						>
-							<Pencil aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
+							<Pencil aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
 						</button>
 					) : null}
 					{onCancelQueuedTurn ? (
@@ -90,7 +90,7 @@ function QueuedMessageRow({
 							aria-label="Delete queued message"
 							title="Delete"
 						>
-							<Trash2 aria-hidden="true" className="size-3 shrink-0" strokeWidth={2} />
+							<Trash2 aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
 						</button>
 					) : null}
 				</div>

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -181,7 +181,7 @@ export function QueuedMessageDock({
 				onClick={() => hasMore && setExpanded((open) => !open)}
 				disabled={!hasMore}
 				className={cn(
-					"flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
+					"queue-dock-toggle flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
 					hasMore && "cursor-pointer",
 					!hasMore && "cursor-default",
 				)}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -11,6 +11,7 @@ function QueuedMessageRow({
 	turnId,
 	message,
 	hiddenFromView,
+	showHoverSteer,
 	canSteer,
 	onPromoteQueuedTurn,
 	onBeginQueuedEdit,
@@ -22,6 +23,7 @@ function QueuedMessageRow({
 	turnId: string;
 	message: ConversationMessage;
 	hiddenFromView?: boolean;
+	showHoverSteer?: boolean;
 	canSteer?: boolean;
 	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
 	onBeginQueuedEdit?: (turnId: string, text: string) => void;
@@ -32,7 +34,7 @@ function QueuedMessageRow({
 }) {
 	return (
 		<div
-			className="queue-dock-row"
+			className="queue-dock-row group/queued-row"
 			data-testid={`queued-message-${turnId}`}
 			aria-hidden={hiddenFromView ? true : undefined}
 			inert={hiddenFromView ? true : undefined}
@@ -50,6 +52,20 @@ function QueuedMessageRow({
 					{message.text}
 				</p>
 				<div className="queue-dock-actions flex shrink-0 items-center gap-0.5 whitespace-nowrap">
+					{showHoverSteer && onPromoteQueuedTurn ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => {
+								void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
+							}}
+							className="inline-flex h-7 items-center rounded-lg px-2 text-[11px] leading-none text-muted-foreground opacity-0 pointer-events-none transition-[background-color,color,opacity] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground group-hover/queued-row:pointer-events-auto group-hover/queued-row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-50 motion-reduce:transition-none"
+							aria-label="Steer this queued message into the running turn"
+							title="Steer into running turn"
+						>
+							Steer
+						</button>
+					) : null}
 					{canSteer && onPromoteQueuedTurn ? (
 						<button
 							type="button"
@@ -126,6 +142,9 @@ export function QueuedMessageDock({
 }) {
 	const [expanded, setExpanded] = useState(true);
 	const [errors, setErrors] = useState<Record<string, string>>({});
+	const [optimisticallySteeredTurnIds, setOptimisticallySteeredTurnIds] = useState<Set<string>>(
+		() => new Set(),
+	);
 	const scrollRef = useRef<HTMLDivElement>(null);
 
 	const runAction = useCallback(
@@ -148,11 +167,30 @@ export function QueuedMessageDock({
 		[],
 	);
 
-	const count = messages.length;
+	const visibleMessages = messages.filter(({ turnId }) => !optimisticallySteeredTurnIds.has(turnId));
+	const count = visibleMessages.length;
 	const hasMore = count > 1;
 	const isOpen = !hasMore || expanded;
 	const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
-	const displayMessages = [...messages].reverse();
+	const displayMessages = [...visibleMessages].reverse();
+
+	const promoteQueuedTurn = useCallback(
+		async (turnId: string) => {
+			setOptimisticallySteeredTurnIds((current) => new Set(current).add(turnId));
+			try {
+				if (!onPromoteQueuedTurn) return;
+				await onPromoteQueuedTurn(turnId);
+			} catch (error) {
+				setOptimisticallySteeredTurnIds((current) => {
+					const next = new Set(current);
+					next.delete(turnId);
+					return next;
+				});
+				throw error;
+			}
+		},
+		[onPromoteQueuedTurn],
+	);
 
 	useEffect(() => {
 		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
@@ -162,7 +200,7 @@ export function QueuedMessageDock({
 
 	const rowProps = {
 		canSteer,
-		onPromoteQueuedTurn,
+		onPromoteQueuedTurn: onPromoteQueuedTurn ? promoteQueuedTurn : undefined,
 		onBeginQueuedEdit,
 		onCancelQueuedTurn,
 		onRunAction: runAction,
@@ -232,6 +270,7 @@ export function QueuedMessageDock({
 									turnId={turnId}
 									message={message}
 									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
+									showHoverSteer={canSteer && index !== displayMessages.length - 1}
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -31,7 +31,11 @@ function QueuedMessageRow({
 	onRunAction: (turnId: string, action: () => Promise<unknown>) => void;
 }) {
 	return (
-		<div data-testid={`queued-message-${turnId}`} aria-hidden={hiddenFromView ? true : undefined}>
+		<div
+			data-testid={`queued-message-${turnId}`}
+			aria-hidden={hiddenFromView ? true : undefined}
+			inert={hiddenFromView ? true : undefined}
+		>
 			<div className="flex min-h-9 min-w-0 items-center gap-2.5 px-3 py-1.5">
 				<Circle
 					aria-hidden="true"

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -1,17 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-} from "react";
-import {
-  ChevronDown,
-  Circle,
-  CornerDownLeft,
-  Pencil,
-  Trash2,
-} from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { ChevronDown, Circle, Command, CornerDownLeft, Pencil, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { ConversationMessage } from "../../types/conversation";
 
@@ -20,338 +8,279 @@ export type QueuedMessage = { turnId: string; message: ConversationMessage };
 const QUEUE_DOCK_VISIBLE_ROWS = 5;
 
 function QueuedMessageRow({
-  turnId,
-  message,
-  hiddenFromView,
-  showHoverSteer,
-  canSteer,
-  onPromoteQueuedTurn,
-  onBeginQueuedEdit,
-  onCancelQueuedTurn,
-  busy,
-  error,
-  onRunAction,
+	turnId,
+	message,
+	hiddenFromView,
+	showHoverSteer,
+	canSteer,
+	onPromoteQueuedTurn,
+	onBeginQueuedEdit,
+	onCancelQueuedTurn,
+	busy,
+	error,
+	onRunAction,
 }: {
-  turnId: string;
-  message: ConversationMessage;
-  hiddenFromView?: boolean;
-  showHoverSteer?: boolean;
-  canSteer?: boolean;
-  onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
-  onBeginQueuedEdit?: (turnId: string, text: string) => void;
-  onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
-  busy?: boolean;
-  error?: string;
-  onRunAction: (turnId: string, action: () => Promise<unknown>) => void;
+	turnId: string;
+	message: ConversationMessage;
+	hiddenFromView?: boolean;
+	showHoverSteer?: boolean;
+	canSteer?: boolean;
+	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
+	onBeginQueuedEdit?: (turnId: string, text: string) => void;
+	onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
+	busy?: boolean;
+	error?: string;
+	onRunAction: (turnId: string, action: () => Promise<unknown>) => void;
 }) {
-  return (
-    <div
-      className="queue-dock-row group/queued-row"
-      data-testid={`queued-message-${turnId}`}
-      aria-hidden={hiddenFromView ? true : undefined}
-      inert={hiddenFromView ? true : undefined}
-    >
-      <div className="flex min-h-9 min-w-0 items-center gap-2.5 px-3 py-1.5">
-        <Circle
-          aria-hidden="true"
-          className="size-3 shrink-0 text-muted-foreground/60"
-          strokeWidth={1.5}
-        />
-        <p
-          className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
-          title={message.text}
-        >
-          {message.text}
-        </p>
-        <div className="queue-dock-actions flex shrink-0 items-center gap-0.5 whitespace-nowrap">
-          {showHoverSteer && onPromoteQueuedTurn ? (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => {
-                void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
-              }}
-              className="inline-flex h-7 items-center rounded-lg px-2 text-[11px] leading-none text-muted-foreground opacity-0 pointer-events-none transition-[background-color,color,opacity] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground group-hover/queued-row:pointer-events-auto group-hover/queued-row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-50 motion-reduce:transition-none"
-              aria-label="Steer this queued message into the running turn"
-              title="Steer into running turn"
-            >
-              Steer
-            </button>
-          ) : null}
-          {canSteer && onPromoteQueuedTurn ? (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => {
-                void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
-              }}
-              className="inline-flex h-7 items-center gap-1.5 rounded-lg px-2 text-[11px] leading-none text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-              aria-label="Steer this queued message into the running turn"
-              title="Steer into running turn"
-            >
-              <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
-                <CornerDownLeft
-                  aria-hidden="true"
-                  className="shrink-0"
-                  width={12}
-                  height={12}
-                  strokeWidth={2}
-                />
-              </span>
-              Steer
-            </button>
-          ) : null}
-          {onBeginQueuedEdit ? (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => onBeginQueuedEdit(turnId, message.text)}
-              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-              aria-label="Edit queued message"
-              title="Edit"
-            >
-              <Pencil
-                aria-hidden="true"
-                className="shrink-0"
-                width={12}
-                height={12}
-                strokeWidth={2}
-              />
-            </button>
-          ) : null}
-          {onCancelQueuedTurn ? (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => {
-                void onRunAction(turnId, () => onCancelQueuedTurn(turnId));
-              }}
-              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-destructive active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
-              aria-label="Delete queued message"
-              title="Delete"
-            >
-              <Trash2
-                aria-hidden="true"
-                className="shrink-0"
-                width={12}
-                height={12}
-                strokeWidth={2}
-              />
-            </button>
-          ) : null}
-        </div>
-      </div>
-      {error ? (
-        <p role="status" className="px-3 pb-2 text-[11px] text-warning">
-          {error}
-        </p>
-      ) : null}
-    </div>
-  );
+	return (
+		<div
+			className="queue-dock-row group/queued-row"
+			data-testid={`queued-message-${turnId}`}
+			aria-hidden={hiddenFromView ? true : undefined}
+			inert={hiddenFromView ? true : undefined}
+		>
+			<div className="flex min-h-9 min-w-0 items-center gap-2.5 px-3 py-1.5">
+				<Circle
+					aria-hidden="true"
+					className="size-3 shrink-0 text-muted-foreground/60"
+					strokeWidth={1.5}
+				/>
+				<p
+					className="min-w-0 flex-1 truncate text-xs leading-relaxed text-foreground"
+					title={message.text}
+				>
+					{message.text}
+				</p>
+				<div className="queue-dock-actions flex shrink-0 items-center gap-0.5 whitespace-nowrap">
+					{showHoverSteer && onPromoteQueuedTurn ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => {
+								void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
+							}}
+							className="inline-flex h-7 items-center rounded-lg px-2 text-[11px] leading-none text-muted-foreground opacity-0 pointer-events-none transition-[background-color,color,opacity] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground group-hover/queued-row:pointer-events-auto group-hover/queued-row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-50 motion-reduce:transition-none"
+							aria-label="Steer this queued message into the running turn"
+							title="Steer into running turn"
+						>
+							Steer
+						</button>
+					) : null}
+					{canSteer && onPromoteQueuedTurn ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => {
+								void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
+							}}
+							className="inline-flex h-7 items-center gap-1.5 rounded-lg px-2 text-[11px] leading-none text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+							aria-label="Steer this queued message into the running turn"
+							title="Steer into running turn"
+						>
+							<span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
+								<Command aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
+								<CornerDownLeft aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
+							</span>
+							Steer
+						</button>
+					) : null}
+					{onBeginQueuedEdit ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => onBeginQueuedEdit(turnId, message.text)}
+							className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+							aria-label="Edit queued message"
+							title="Edit"
+						>
+							<Pencil aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
+						</button>
+					) : null}
+					{onCancelQueuedTurn ? (
+						<button
+							type="button"
+							disabled={busy}
+							onClick={() => {
+								void onRunAction(turnId, () => onCancelQueuedTurn(turnId));
+							}}
+							className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-[scale,background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-destructive active:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none motion-reduce:active:scale-100"
+							aria-label="Delete queued message"
+							title="Delete"
+						>
+							<Trash2 aria-hidden="true" className="shrink-0" width={12} height={12} strokeWidth={2} />
+						</button>
+					) : null}
+				</div>
+			</div>
+			{error ? (
+				<p role="status" className="px-3 pb-2 text-[11px] text-warning">
+					{error}
+				</p>
+			) : null}
+		</div>
+	);
 }
 
 export function QueuedMessageDock({
-  messages,
-  editingTurnId,
-  canSteer,
-  canSteerNext,
-  steerNextRequest,
-  onPromoteQueuedTurn,
-  onBeginQueuedEdit,
-  onCancelQueuedTurn,
-  promotePendingTurnId,
-  cancelPendingTurnId,
+	messages,
+	editingTurnId,
+	canSteer,
+	onPromoteQueuedTurn,
+	onBeginQueuedEdit,
+	onCancelQueuedTurn,
+	promotePendingTurnId,
+	cancelPendingTurnId,
 }: {
-  messages: QueuedMessage[];
-  editingTurnId?: string;
-  canSteer?: boolean;
-  canSteerNext?: boolean;
-  steerNextRequest?: number;
-  onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
-  onBeginQueuedEdit?: (turnId: string, text: string) => void;
-  onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
-  promotePendingTurnId?: string;
-  cancelPendingTurnId?: string;
+	messages: QueuedMessage[];
+	editingTurnId?: string;
+	canSteer?: boolean;
+	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
+	onBeginQueuedEdit?: (turnId: string, text: string) => void;
+	onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
+	promotePendingTurnId?: string;
+	cancelPendingTurnId?: string;
 }) {
-  const [expanded, setExpanded] = useState(true);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [optimisticallySteeredTurnIds, setOptimisticallySteeredTurnIds] =
-    useState<Set<string>>(() => new Set());
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const lastSteerNextRequest = useRef(steerNextRequest ?? 0);
+	const [expanded, setExpanded] = useState(true);
+	const [errors, setErrors] = useState<Record<string, string>>({});
+	const [optimisticallySteeredTurnIds, setOptimisticallySteeredTurnIds] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const scrollRef = useRef<HTMLDivElement>(null);
 
-  const runAction = useCallback(
-    async (turnId: string, action: () => Promise<unknown>) => {
-      setErrors((current) => {
-        if (!current[turnId]) return current;
-        const next = { ...current };
-        delete next[turnId];
-        return next;
-      });
-      try {
-        await action();
-      } catch (error) {
-        setErrors((current) => ({
-          ...current,
-          [turnId]:
-            error instanceof Error ? error.message : "That action failed.",
-        }));
-      }
-    },
-    [],
-  );
+	const runAction = useCallback(
+		async (turnId: string, action: () => Promise<unknown>) => {
+			setErrors((current) => {
+				if (!current[turnId]) return current;
+				const next = { ...current };
+				delete next[turnId];
+				return next;
+			});
+			try {
+				await action();
+			} catch (error) {
+				setErrors((current) => ({
+					...current,
+					[turnId]: error instanceof Error ? error.message : "That action failed.",
+				}));
+			}
+		},
+		[],
+	);
 
-  const visibleMessages = messages.filter(
-    ({ turnId }) => !optimisticallySteeredTurnIds.has(turnId),
-  );
-  const count = visibleMessages.length;
-  const hasMore = count > 1;
-  const isOpen = !hasMore || expanded;
-  const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
-  const displayMessages = [...visibleMessages].reverse();
+	const visibleMessages = messages.filter(({ turnId }) => !optimisticallySteeredTurnIds.has(turnId));
+	const count = visibleMessages.length;
+	const hasMore = count > 1;
+	const isOpen = !hasMore || expanded;
+	const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
+	const displayMessages = [...visibleMessages].reverse();
 
-  const promoteQueuedTurn = useCallback(
-    async (turnId: string) => {
-      setOptimisticallySteeredTurnIds((current) =>
-        new Set(current).add(turnId),
-      );
-      try {
-        if (!onPromoteQueuedTurn) return;
-        await onPromoteQueuedTurn(turnId);
-      } catch (error) {
-        setOptimisticallySteeredTurnIds((current) => {
-          const next = new Set(current);
-          next.delete(turnId);
-          return next;
-        });
-        throw error;
-      }
-    },
-    [onPromoteQueuedTurn],
-  );
+	const promoteQueuedTurn = useCallback(
+		async (turnId: string) => {
+			setOptimisticallySteeredTurnIds((current) => new Set(current).add(turnId));
+			try {
+				if (!onPromoteQueuedTurn) return;
+				await onPromoteQueuedTurn(turnId);
+			} catch (error) {
+				setOptimisticallySteeredTurnIds((current) => {
+					const next = new Set(current);
+					next.delete(turnId);
+					return next;
+				});
+				throw error;
+			}
+		},
+		[onPromoteQueuedTurn],
+	);
 
-  useEffect(() => {
-    if (
-      steerNextRequest === undefined ||
-      steerNextRequest <= lastSteerNextRequest.current
-    )
-      return;
-    lastSteerNextRequest.current = steerNextRequest;
-    if (!canSteerNext || !onPromoteQueuedTurn) return;
+	useEffect(() => {
+		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
+		const scroll = scrollRef.current;
+		if (scroll) scroll.scrollTop = scroll.scrollHeight;
+	}, [count, isOpen]);
 
-    const next = displayMessages[displayMessages.length - 1];
-    if (next) void runAction(next.turnId, () => promoteQueuedTurn(next.turnId));
-  }, [
-    canSteerNext,
-    displayMessages,
-    onPromoteQueuedTurn,
-    promoteQueuedTurn,
-    runAction,
-    steerNextRequest,
-  ]);
+	const rowProps = {
+		canSteer,
+		onPromoteQueuedTurn: onPromoteQueuedTurn ? promoteQueuedTurn : undefined,
+		onBeginQueuedEdit,
+		onCancelQueuedTurn,
+		onRunAction: runAction,
+	};
 
-  useEffect(() => {
-    if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
-    const scroll = scrollRef.current;
-    if (scroll) scroll.scrollTop = scroll.scrollHeight;
-  }, [count, isOpen]);
-
-  const rowProps = {
-    canSteer,
-    onPromoteQueuedTurn: onPromoteQueuedTurn ? promoteQueuedTurn : undefined,
-    onBeginQueuedEdit,
-    onCancelQueuedTurn,
-    onRunAction: runAction,
-  };
-
-  return (
-    <div
-      className="queue-dock overflow-hidden rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
-      data-testid="queued-message-dock"
-      data-collapsible={hasMore ? "true" : "false"}
-      data-expanded={isOpen ? "true" : "false"}
-      style={{ "--queue-dock-expanded-rows": expandedRows } as CSSProperties}
-    >
-      <button
-        type="button"
-        onClick={() => hasMore && setExpanded((open) => !open)}
-        disabled={!hasMore}
-        className={cn(
-          "queue-dock-toggle flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
-          hasMore && "cursor-pointer",
-          !hasMore && "cursor-default",
-        )}
-        aria-expanded={hasMore ? expanded : undefined}
-        data-testid="queued-message-toggle"
-      >
-        {hasMore ? (
-          <ChevronDown
-            aria-hidden="true"
-            className={cn(
-              "size-3.5 shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
-              expanded ? "rotate-0" : "-rotate-90",
-            )}
-          />
-        ) : (
-          <span aria-hidden="true" className="size-3.5 shrink-0" />
-        )}
-        <span className="queue-dock-label text-xs font-medium text-muted-foreground transition-colors duration-150">
-          <span className="inline-block w-fit">
-            {count} Queued {count === 1 ? "Message" : "Messages"}
-          </span>
-          {editingTurnId ? " · editing" : ""}
-        </span>
-      </button>
-      {count > 0 ? (
-        <div
-          className="queue-dock-body bg-surface"
-          data-expanded={isOpen ? "true" : "false"}
-          data-collapsible={hasMore ? "true" : "false"}
-          style={
-            {
-              "--queue-dock-expanded-rows": expandedRows,
-            } as CSSProperties
-          }
-        >
-          <div
-            ref={scrollRef}
-            className={cn(
-              "queue-dock-scroll",
-              isOpen &&
-                count > QUEUE_DOCK_VISIBLE_ROWS &&
-                "queue-dock-scroll-active",
-            )}
-          >
-            {displayMessages.map(({ turnId, message }, index) => {
-              const busy =
-                promotePendingTurnId === turnId ||
-                cancelPendingTurnId === turnId;
-              return (
-                <QueuedMessageRow
-                  key={turnId}
-                  turnId={turnId}
-                  message={message}
-                  hiddenFromView={
-                    !isOpen && index !== displayMessages.length - 1
-                  }
-                  showHoverSteer={
-                    canSteer &&
-                    (index !== displayMessages.length - 1 || !canSteerNext)
-                  }
-                  busy={busy}
-                  error={errors[turnId]}
-                  {...rowProps}
-                  canSteer={
-                    canSteer &&
-                    canSteerNext &&
-                    index === displayMessages.length - 1
-                  }
-                />
-              );
-            })}
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
+	return (
+		<div
+			className="queue-dock overflow-hidden rounded-[var(--radius-chat-composer)] border border-border-strong bg-surface shadow-sm"
+			data-testid="queued-message-dock"
+			data-collapsible={hasMore ? "true" : "false"}
+			data-expanded={isOpen ? "true" : "false"}
+			style={{ "--queue-dock-expanded-rows": expandedRows } as CSSProperties}
+		>
+			<button
+				type="button"
+				onClick={() => hasMore && setExpanded((open) => !open)}
+				disabled={!hasMore}
+				className={cn(
+					"queue-dock-toggle flex w-full items-center gap-2 px-3 py-2 text-left motion-reduce:transition-none",
+					hasMore && "cursor-pointer",
+					!hasMore && "cursor-default",
+				)}
+				aria-expanded={hasMore ? expanded : undefined}
+				data-testid="queued-message-toggle"
+			>
+				{hasMore ? (
+					<ChevronDown
+						aria-hidden="true"
+						className={cn(
+							"size-3.5 shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+							expanded ? "rotate-0" : "-rotate-90",
+						)}
+					/>
+				) : (
+					<span aria-hidden="true" className="size-3.5 shrink-0" />
+				)}
+				<span className="queue-dock-label text-xs font-medium text-muted-foreground transition-colors duration-150">
+					<span
+						className="inline-block w-fit"
+					>
+						{count} Queued {count === 1 ? "Message" : "Messages"}
+					</span>
+					{editingTurnId ? " · editing" : ""}
+				</span>
+			</button>
+			{count > 0 ? (
+				<div
+					className="queue-dock-body bg-surface"
+					data-expanded={isOpen ? "true" : "false"}
+					data-collapsible={hasMore ? "true" : "false"}
+					style={
+						{
+							"--queue-dock-expanded-rows": expandedRows,
+						} as CSSProperties
+					}
+				>
+					<div
+						ref={scrollRef}
+						className={cn("queue-dock-scroll", isOpen && count > QUEUE_DOCK_VISIBLE_ROWS && "queue-dock-scroll-active")}
+					>
+						{displayMessages.map(({ turnId, message }, index) => {
+							const busy =
+								promotePendingTurnId === turnId || cancelPendingTurnId === turnId;
+							return (
+								<QueuedMessageRow
+									key={turnId}
+									turnId={turnId}
+									message={message}
+									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
+									showHoverSteer={canSteer && index !== displayMessages.length - 1}
+									busy={busy}
+									error={errors[turnId]}
+									{...rowProps}
+									canSteer={canSteer && index === displayMessages.length - 1}
+								/>
+							);
+						})}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
 }

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -149,7 +149,8 @@ export function QueuedMessageDock({
 		() => new Set(),
 	);
 	const scrollRef = useRef<HTMLDivElement>(null);
-	const lastSteerNextRequest = useRef(steerNextRequest ?? 0);
+	const [handledSteerNextRequest, setHandledSteerNextRequest] = useState(steerNextRequest ?? 0);
+	const steerNextInFlight = useRef(false);
 
 	const runAction = useCallback(
 		async (turnId: string, action: () => Promise<unknown>) => {
@@ -197,13 +198,32 @@ export function QueuedMessageDock({
 	);
 
 	useEffect(() => {
-		if (steerNextRequest === undefined || steerNextRequest <= lastSteerNextRequest.current) return;
-		lastSteerNextRequest.current = steerNextRequest;
-		if (!canSteerNext || !onPromoteQueuedTurn) return;
+		if (steerNextRequest === undefined || steerNextRequest <= handledSteerNextRequest) return;
+		if (!canSteerNext || !onPromoteQueuedTurn) {
+			setHandledSteerNextRequest(steerNextRequest);
+			return;
+		}
+		if (steerNextInFlight.current) return;
 
 		const next = displayMessages[displayMessages.length - 1];
-		if (next) void runAction(next.turnId, () => promoteQueuedTurn(next.turnId));
-	}, [canSteerNext, displayMessages, onPromoteQueuedTurn, promoteQueuedTurn, runAction, steerNextRequest]);
+		if (!next) {
+			setHandledSteerNextRequest(steerNextRequest);
+			return;
+		}
+		steerNextInFlight.current = true;
+		void runAction(next.turnId, () => promoteQueuedTurn(next.turnId)).finally(() => {
+			steerNextInFlight.current = false;
+			setHandledSteerNextRequest((request) => request + 1);
+		});
+	}, [
+		canSteerNext,
+		displayMessages,
+		handledSteerNextRequest,
+		onPromoteQueuedTurn,
+		promoteQueuedTurn,
+		runAction,
+		steerNextRequest,
+	]);
 
 	useEffect(() => {
 		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -32,6 +32,7 @@ function QueuedMessageRow({
 }) {
 	return (
 		<div
+			className="queue-dock-row"
 			data-testid={`queued-message-${turnId}`}
 			aria-hidden={hiddenFromView ? true : undefined}
 			inert={hiddenFromView ? true : undefined}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -59,7 +59,7 @@ function QueuedMessageRow({
 							onClick={() => {
 								void onRunAction(turnId, () => onPromoteQueuedTurn(turnId));
 							}}
-							className="inline-flex h-7 items-center rounded-lg px-2 text-[11px] leading-none text-muted-foreground opacity-0 pointer-events-none transition-[background-color,color,opacity] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground group-hover/queued-row:pointer-events-auto group-hover/queued-row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-50 motion-reduce:transition-none"
+							className="inline-flex h-7 items-center rounded-lg px-2 text-[11px] leading-none text-muted-foreground opacity-0 pointer-events-none transition-[background-color,color] duration-150 ease-out hover:bg-interactive-hover hover:text-foreground group-hover/queued-row:pointer-events-auto group-hover/queued-row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-50 motion-reduce:transition-none"
 							aria-label="Steer this queued message into the running turn"
 							title="Steer into running turn"
 						>

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -199,7 +199,7 @@ export function QueuedMessageDock({
 				) : (
 					<span aria-hidden="true" className="size-3.5 shrink-0" />
 				)}
-				<span className="text-xs font-medium text-muted-foreground">
+				<span className="queue-dock-label text-xs font-medium text-muted-foreground transition-colors duration-150">
 					<span
 						className="inline-block w-fit"
 					>

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -229,7 +229,7 @@ export function QueuedMessageDock({
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}
-									canSteer={canSteer && index === 0}
+									canSteer={canSteer && index === displayMessages.length - 1}
 								/>
 							);
 						})}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -156,12 +156,12 @@ export function QueuedMessageDock({
 	const hasMore = count > 1;
 	const isOpen = !hasMore || expanded;
 	const expandedRows = Math.min(count, QUEUE_DOCK_VISIBLE_ROWS);
-	const displayMessages = messages;
+	const displayMessages = [...messages].reverse();
 
 	useEffect(() => {
 		if (!isOpen || count <= QUEUE_DOCK_VISIBLE_ROWS) return;
 		const scroll = scrollRef.current;
-		if (scroll) scroll.scrollTop = 0;
+		if (scroll) scroll.scrollTop = scroll.scrollHeight;
 	}, [count, isOpen]);
 
 	const rowProps = {
@@ -231,12 +231,12 @@ export function QueuedMessageDock({
 									key={turnId}
 									turnId={turnId}
 									message={message}
-									hiddenFromView={!isOpen && index > 0}
-									showNextUp={!isOpen && index === 0}
+									hiddenFromView={!isOpen && index !== displayMessages.length - 1}
+									showNextUp={!isOpen && index === displayMessages.length - 1}
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}
-									canSteer={canSteer && index === 0}
+									canSteer={canSteer && index === displayMessages.length - 1}
 								/>
 							);
 						})}

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -239,17 +239,20 @@ export function QueuedMessageDock({
 				aria-expanded={hasMore ? expanded : undefined}
 				data-testid="queued-message-toggle"
 			>
-				{hasMore ? (
+				<span
+					aria-hidden="true"
+					className={cn(
+						"grid h-3.5 shrink-0 overflow-hidden transition-[width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+						hasMore ? "w-3.5" : "w-0",
+					)}
+				>
 					<ChevronDown
-						aria-hidden="true"
 						className={cn(
 							"size-3.5 shrink-0 text-muted-foreground transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
 							expanded ? "rotate-0" : "-rotate-90",
 						)}
 					/>
-				) : (
-					<span aria-hidden="true" className="size-3.5 shrink-0" />
-				)}
+				</span>
 				<span className="queue-dock-label text-xs font-medium text-muted-foreground transition-colors duration-150">
 					<span
 						className="inline-block w-fit"

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -229,6 +229,7 @@ export function QueuedMessageDock({
 									busy={busy}
 									error={errors[turnId]}
 									{...rowProps}
+									canSteer={canSteer && index === 0}
 								/>
 							);
 						})}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2213,9 +2213,71 @@ html.sidebar-reordering * {
 	animation: queue-dock-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
+/* Clip-height collapse: one row stays visible when folded; up to five when open. */
+.queue-dock-body {
+	--queue-dock-row-height: 2.25rem;
+	--queue-dock-visible-rows: 5;
+	overflow: hidden;
+	transition: max-height 420ms cubic-bezier(0.16, 1, 0.3, 1);
+	will-change: max-height;
+}
+
+.queue-dock-body[data-collapsible="true"][data-expanded="false"] {
+	max-height: var(--queue-dock-row-height);
+}
+
+.queue-dock-body[data-collapsible="true"][data-expanded="true"] {
+	max-height: calc(var(--queue-dock-row-height) * var(--queue-dock-expanded-rows, 5));
+}
+
+.queue-dock-body[data-collapsible="false"] {
+	max-height: calc(var(--queue-dock-row-height) * var(--queue-dock-expanded-rows, 1));
+}
+
+.queue-dock-scroll {
+	overflow-y: hidden;
+}
+
+.queue-dock-scroll-active {
+	max-height: calc(var(--queue-dock-row-height) * var(--queue-dock-visible-rows));
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	scrollbar-width: thin;
+	scrollbar-color: var(--color-scrollbar-board) transparent;
+}
+
+.queue-dock-scroll::-webkit-scrollbar {
+	width: 8px;
+}
+
+.queue-dock-scroll::-webkit-scrollbar-button {
+	display: none;
+	width: 0;
+	height: 0;
+}
+
+.queue-dock-scroll::-webkit-scrollbar-track,
+.queue-dock-scroll::-webkit-scrollbar-corner {
+	background: transparent;
+}
+
+.queue-dock-scroll::-webkit-scrollbar-thumb {
+	border-radius: 999px;
+	background: var(--color-scrollbar-board);
+}
+
+.queue-dock-scroll::-webkit-scrollbar-thumb:hover {
+	background: color-mix(in oklch, var(--color-scrollbar-board) 80%, var(--color-text-muted));
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.queue-dock-enter {
 		animation: none;
+	}
+
+	.queue-dock-body {
+		transition: none;
+		will-change: auto;
 	}
 }
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2277,6 +2277,10 @@ html.sidebar-reordering * {
 	flex: none;
 }
 
+.cursor-chat-surface .queue-dock-toggle:not(:disabled):active {
+	transform: none;
+}
+
 .queue-dock-scroll {
 	display: flex;
 	min-height: 100%;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2214,15 +2214,14 @@ html.sidebar-reordering * {
 }
 
 /* The parent reserves one compact footprint; the expanded dock floats above it. */
-.queue-dock {
+.cursor-chat-composer-queue {
 	--queue-dock-header-height: 2rem;
 	--queue-dock-row-height: 2.5rem;
 	--queue-dock-collapsed-height: calc(var(--queue-dock-header-height) + var(--queue-dock-row-height));
-}
-
-.cursor-chat-composer-queue {
 	position: relative;
 	height: var(--queue-dock-collapsed-height);
+	min-height: var(--queue-dock-collapsed-height);
+	flex-shrink: 0;
 }
 
 .cursor-chat-composer-queue .queue-dock {
@@ -2240,6 +2239,18 @@ html.sidebar-reordering * {
 	overflow: hidden;
 	transition: max-height 420ms cubic-bezier(0.16, 1, 0.3, 1);
 	will-change: max-height;
+}
+
+.queue-dock {
+	max-height: var(--queue-dock-collapsed-height, 4.5rem);
+	transition: max-height 420ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.queue-dock[data-collapsible="true"][data-expanded="true"] {
+	max-height: calc(
+		var(--queue-dock-header-height, 2rem) +
+		var(--queue-dock-row-height, 2.5rem) * var(--queue-dock-visible-rows, 5)
+	);
 }
 
 .queue-dock-body[data-collapsible="true"][data-expanded="false"] {
@@ -2302,6 +2313,10 @@ html.sidebar-reordering * {
 	.queue-dock-body {
 		transition: none;
 		will-change: auto;
+	}
+
+	.queue-dock {
+		transition: none;
 	}
 }
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2298,7 +2298,10 @@ html.sidebar-reordering * {
 }
 
 .queue-dock-scroll-active {
+	min-height: 0;
+	max-height: 100%;
 	height: 100%;
+	justify-content: flex-start;
 	overflow-y: auto;
 	overscroll-behavior: contain;
 	scrollbar-width: thin;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2238,11 +2238,14 @@ html.sidebar-reordering * {
 	position: relative;
 	overflow: hidden;
 	height: var(--queue-dock-row-height);
+	flex: 0 0 auto;
 	transition: height 420ms cubic-bezier(0.16, 1, 0.3, 1);
 	will-change: height;
 }
 
 .queue-dock {
+	display: flex;
+	flex-direction: column-reverse;
 	height: var(--queue-dock-collapsed-height, 4.5rem);
 	transition: height 420ms cubic-bezier(0.16, 1, 0.3, 1);
 	will-change: height;
@@ -2268,19 +2271,22 @@ html.sidebar-reordering * {
 }
 
 .queue-dock-scroll {
+	display: flex;
+	flex-direction: column-reverse;
+	height: 100%;
 	overflow-y: hidden;
 }
 
+.queue-dock > button {
+	flex: 0 0 var(--queue-dock-header-height, 2rem);
+}
+
 .queue-dock-scroll-active {
-	height: calc(var(--queue-dock-row-height) * var(--queue-dock-visible-rows));
+	height: 100%;
 	overflow-y: auto;
 	overscroll-behavior: contain;
 	scrollbar-width: thin;
 	scrollbar-color: var(--color-scrollbar-board) transparent;
-}
-
-.queue-dock-body[data-expanded="false"] [aria-hidden="true"] {
-	display: none;
 }
 
 .queue-dock-scroll::-webkit-scrollbar {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2281,6 +2281,10 @@ html.sidebar-reordering * {
 	transform: none;
 }
 
+.cursor-chat-surface .queue-dock-toggle:hover .queue-dock-label {
+	color: var(--color-foreground);
+}
+
 .queue-dock-scroll {
 	display: flex;
 	min-height: 100%;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2289,7 +2289,7 @@ html.sidebar-reordering * {
 	scrollbar-color: var(--color-scrollbar-board) transparent;
 }
 
-.queue-dock-body[data-expanded="false"] [aria-hidden="true"] {
+.queue-dock-body[data-expanded="false"] .queue-dock-row[aria-hidden="true"] {
 	display: none;
 }
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2278,7 +2278,15 @@ html.sidebar-reordering * {
 }
 
 .queue-dock-scroll {
+	display: flex;
+	min-height: 100%;
+	flex-direction: column;
+	justify-content: flex-end;
 	overflow-y: hidden;
+}
+
+.queue-dock-scroll > .queue-dock-row {
+	flex: none;
 }
 
 .queue-dock-scroll-active {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2225,7 +2225,7 @@ html.sidebar-reordering * {
 	height: var(--queue-dock-collapsed-height);
 }
 
-.cursor-chat-composer-queue:has(.queue-dock[data-collapsible="true"][data-expanded="true"]) .queue-dock {
+.cursor-chat-composer-queue .queue-dock {
 	position: absolute;
 	right: 0;
 	bottom: 0;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2238,14 +2238,11 @@ html.sidebar-reordering * {
 	position: relative;
 	overflow: hidden;
 	height: var(--queue-dock-row-height);
-	flex: 0 0 auto;
 	transition: height 420ms cubic-bezier(0.16, 1, 0.3, 1);
 	will-change: height;
 }
 
 .queue-dock {
-	display: flex;
-	flex-direction: column-reverse;
 	height: var(--queue-dock-collapsed-height, 4.5rem);
 	transition: height 420ms cubic-bezier(0.16, 1, 0.3, 1);
 	will-change: height;
@@ -2271,14 +2268,7 @@ html.sidebar-reordering * {
 }
 
 .queue-dock-scroll {
-	display: flex;
-	flex-direction: column-reverse;
-	height: 100%;
 	overflow-y: hidden;
-}
-
-.queue-dock > button {
-	flex: 0 0 var(--queue-dock-header-height, 2rem);
 }
 
 .queue-dock-scroll-active {
@@ -2287,6 +2277,10 @@ html.sidebar-reordering * {
 	overscroll-behavior: contain;
 	scrollbar-width: thin;
 	scrollbar-color: var(--color-scrollbar-board) transparent;
+}
+
+.queue-dock-body[data-expanded="false"] [aria-hidden="true"] {
+	display: none;
 }
 
 .queue-dock-scroll::-webkit-scrollbar {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2272,6 +2272,11 @@ html.sidebar-reordering * {
 	flex-shrink: 0;
 }
 
+.queue-dock-actions svg {
+	display: block;
+	flex: none;
+}
+
 .queue-dock-scroll {
 	overflow-y: hidden;
 }

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2213,10 +2213,33 @@ html.sidebar-reordering * {
 	animation: queue-dock-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
+/* The dock reserves one compact footprint, then lets the open queue float upward. */
+.queue-dock {
+	--queue-dock-header-height: 2rem;
+	--queue-dock-collapsed-height: calc(var(--queue-dock-header-height) + var(--queue-dock-row-height, 2.25rem));
+	position: relative;
+	height: var(--queue-dock-collapsed-height);
+}
+
+.queue-dock > button {
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 2;
+	height: var(--queue-dock-header-height);
+	background: var(--color-bg-secondary);
+}
+
 /* Clip-height collapse: one row stays visible when folded; up to five when open. */
 .queue-dock-body {
 	--queue-dock-row-height: 2.25rem;
 	--queue-dock-visible-rows: 5;
+	position: absolute;
+	right: 0;
+	bottom: var(--queue-dock-header-height, 2rem);
+	left: 0;
+	z-index: 1;
 	overflow: hidden;
 	transition: max-height 420ms cubic-bezier(0.16, 1, 0.3, 1);
 	will-change: max-height;
@@ -2236,6 +2259,8 @@ html.sidebar-reordering * {
 
 .queue-dock-scroll {
 	overflow-y: hidden;
+	display: flex;
+	flex-direction: column-reverse;
 }
 
 .queue-dock-scroll-active {
@@ -2244,6 +2269,12 @@ html.sidebar-reordering * {
 	overscroll-behavior: contain;
 	scrollbar-width: thin;
 	scrollbar-color: var(--color-scrollbar-board) transparent;
+}
+
+.queue-dock-body[data-expanded="true"] {
+	border: 1px solid var(--color-border-strong);
+	border-radius: var(--radius-chat-composer);
+	box-shadow: 0 8px 24px color-mix(in srgb, black 18%, transparent);
 }
 
 .queue-dock-scroll::-webkit-scrollbar {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2267,6 +2267,11 @@ html.sidebar-reordering * {
 	height: calc(var(--queue-dock-row-height) * var(--queue-dock-expanded-rows, 1));
 }
 
+.queue-dock-actions {
+	min-width: max-content;
+	flex-shrink: 0;
+}
+
 .queue-dock-scroll {
 	overflow-y: hidden;
 }

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2237,32 +2237,34 @@ html.sidebar-reordering * {
 	--queue-dock-visible-rows: 5;
 	position: relative;
 	overflow: hidden;
-	transition: max-height 420ms cubic-bezier(0.16, 1, 0.3, 1);
-	will-change: max-height;
+	height: var(--queue-dock-row-height);
+	transition: height 420ms cubic-bezier(0.16, 1, 0.3, 1);
+	will-change: height;
 }
 
 .queue-dock {
-	max-height: var(--queue-dock-collapsed-height, 4.5rem);
-	transition: max-height 420ms cubic-bezier(0.16, 1, 0.3, 1);
+	height: var(--queue-dock-collapsed-height, 4.5rem);
+	transition: height 420ms cubic-bezier(0.16, 1, 0.3, 1);
+	will-change: height;
 }
 
 .queue-dock[data-collapsible="true"][data-expanded="true"] {
-	max-height: calc(
+	height: calc(
 		var(--queue-dock-header-height, 2rem) +
-		var(--queue-dock-row-height, 2.5rem) * var(--queue-dock-visible-rows, 5)
+		var(--queue-dock-row-height, 2.5rem) * var(--queue-dock-expanded-rows, 5)
 	);
 }
 
 .queue-dock-body[data-collapsible="true"][data-expanded="false"] {
-	max-height: var(--queue-dock-row-height);
+	height: var(--queue-dock-row-height);
 }
 
 .queue-dock-body[data-collapsible="true"][data-expanded="true"] {
-	max-height: calc(var(--queue-dock-row-height) * var(--queue-dock-expanded-rows, 5));
+	height: calc(var(--queue-dock-row-height) * var(--queue-dock-expanded-rows, 5));
 }
 
 .queue-dock-body[data-collapsible="false"] {
-	max-height: calc(var(--queue-dock-row-height) * var(--queue-dock-expanded-rows, 1));
+	height: calc(var(--queue-dock-row-height) * var(--queue-dock-expanded-rows, 1));
 }
 
 .queue-dock-scroll {
@@ -2270,7 +2272,7 @@ html.sidebar-reordering * {
 }
 
 .queue-dock-scroll-active {
-	max-height: calc(var(--queue-dock-row-height) * var(--queue-dock-visible-rows));
+	height: calc(var(--queue-dock-row-height) * var(--queue-dock-visible-rows));
 	overflow-y: auto;
 	overscroll-behavior: contain;
 	scrollbar-width: thin;
@@ -2317,6 +2319,7 @@ html.sidebar-reordering * {
 
 	.queue-dock {
 		transition: none;
+		will-change: auto;
 	}
 }
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2213,33 +2213,30 @@ html.sidebar-reordering * {
 	animation: queue-dock-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-/* The dock reserves one compact footprint, then lets the open queue float upward. */
+/* The parent reserves one compact footprint; the expanded dock floats above it. */
 .queue-dock {
 	--queue-dock-header-height: 2rem;
-	--queue-dock-collapsed-height: calc(var(--queue-dock-header-height) + var(--queue-dock-row-height, 2.25rem));
+	--queue-dock-row-height: 2.5rem;
+	--queue-dock-collapsed-height: calc(var(--queue-dock-header-height) + var(--queue-dock-row-height));
+}
+
+.cursor-chat-composer-queue {
 	position: relative;
 	height: var(--queue-dock-collapsed-height);
 }
 
-.queue-dock > button {
+.cursor-chat-composer-queue:has(.queue-dock[data-collapsible="true"][data-expanded="true"]) .queue-dock {
 	position: absolute;
 	right: 0;
 	bottom: 0;
 	left: 0;
-	z-index: 2;
-	height: var(--queue-dock-header-height);
-	background: var(--color-bg-secondary);
 }
 
 /* Clip-height collapse: one row stays visible when folded; up to five when open. */
 .queue-dock-body {
-	--queue-dock-row-height: 2.25rem;
+	--queue-dock-row-height: 2.5rem;
 	--queue-dock-visible-rows: 5;
-	position: absolute;
-	right: 0;
-	bottom: var(--queue-dock-header-height, 2rem);
-	left: 0;
-	z-index: 1;
+	position: relative;
 	overflow: hidden;
 	transition: max-height 420ms cubic-bezier(0.16, 1, 0.3, 1);
 	will-change: max-height;
@@ -2259,8 +2256,6 @@ html.sidebar-reordering * {
 
 .queue-dock-scroll {
 	overflow-y: hidden;
-	display: flex;
-	flex-direction: column-reverse;
 }
 
 .queue-dock-scroll-active {
@@ -2271,10 +2266,8 @@ html.sidebar-reordering * {
 	scrollbar-color: var(--color-scrollbar-board) transparent;
 }
 
-.queue-dock-body[data-expanded="true"] {
-	border: 1px solid var(--color-border-strong);
-	border-radius: var(--radius-chat-composer);
-	box-shadow: 0 8px 24px color-mix(in srgb, black 18%, transparent);
+.queue-dock-body[data-expanded="false"] [aria-hidden="true"] {
+	display: none;
 }
 
 .queue-dock-scroll::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- Collapse keeps the next queued message visible while the remaining queue stays out of the way
- Expanded dock shows up to five messages and scrolls for additional queued work
- Empty Enter steers the next queued message into the running turn; repeated requests drain in order without being lost
- Keep the composer mounted and focused as the dock appears or queued messages are removed
- Refine queue actions and open/close motion for a quieter, more compact dock

## Test plan
- [x] `npm --prefix frontend test -- src/renderer/components/chat/ChatSteer.test.tsx`
- [x] `npm run frontend:typecheck`
- [x] `npm --prefix packages/product-ui run typecheck`
- [ ] Queue 2+ messages while a turn is running and collapse/expand the dock
- [ ] Queue 6+ messages and confirm only five rows show before scrolling
- [ ] Confirm steer, edit, and delete actions still work on visible rows