### PR TITLE
fix(reviewer): resume Claude after dead-pane relaunch

### DIFF
--- a/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
+++ b/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
@@ -44,5 +44,9 @@ func Command(ctx context.Context, agent ports.Agent, inv ports.ReviewInvocation,
 	if err != nil || !ok {
 		return ports.ReviewCommandSpec{}, ok, err
 	}
-	return ports.ReviewCommandSpec{Argv: argv, AgentSessionID: strings.TrimSpace(inv.AgentSessionID)}, true, nil
+	return ports.ReviewCommandSpec{
+		Argv:           argv,
+		AgentSessionID: strings.TrimSpace(inv.AgentSessionID),
+		NativeResumed:  true,
+	}, true, nil
 }

--- a/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
+++ b/backend/internal/adapters/reviewer/agentrestore/agentrestore.go
@@ -23,6 +23,13 @@ type Options struct {
 // still get the call when no hook-captured id is present.
 func Command(ctx context.Context, agent ports.Agent, inv ports.ReviewInvocation, opts Options) (ports.ReviewCommandSpec, bool, error) {
 	agentSessionID := strings.TrimSpace(inv.AgentSessionID)
+	prompt := ""
+	if strings.TrimSpace(inv.RunID) != "" {
+		// A dead reviewer relaunched for an active run must receive that run's
+		// task as the resume-time user turn. Idle terminal restoration leaves
+		// the existing conversation untouched until the next review trigger.
+		prompt = inv.Prompt
+	}
 	metadata := map[string]string{}
 	if agentSessionID != "" {
 		metadata[ports.MetadataKeyAgentSessionID] = agentSessionID
@@ -38,6 +45,7 @@ func Command(ctx context.Context, agent ports.Agent, inv ports.ReviewInvocation,
 		Permissions:      opts.Permissions,
 		AllowedTools:     opts.AllowedTools,
 		DisallowedTools:  opts.DisallowedTools,
+		Prompt:           prompt,
 		SystemPrompt:     inv.SystemPrompt,
 		SystemPromptFile: inv.SystemPromptFile,
 	})

--- a/backend/internal/adapters/reviewer/claudecode/claudecode.go
+++ b/backend/internal/adapters/reviewer/claudecode/claudecode.go
@@ -8,6 +8,7 @@ package claudecode
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	workeragent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
@@ -78,7 +79,8 @@ func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation
 		// Pin the same deterministic reviewer-native id we persist. Hooks can
 		// later replace it with Claude's reported id, but restore must never start
 		// from an id that the process was not launched with.
-		SessionID:        agentSessionID,
+		SessionID:        inv.ReviewerID,
+		NativeSessionID:  agentSessionID,
 		WorkspacePath:    inv.WorkspacePath,
 		Prompt:           inv.Prompt,
 		SystemPrompt:     inv.SystemPrompt,
@@ -128,6 +130,13 @@ func (r *Reviewer) ReviewMessage(_ context.Context, inv ports.ReviewInvocation) 
 // ReviewRestoreCommand resumes the reviewer Claude Code conversation captured
 // from hooks, reapplying the same read-only tool policy as a fresh review launch.
 func (r *Reviewer) ReviewRestoreCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, bool, error) {
+	if migratedID, ok, err := r.restoreSessionID(ctx, inv); err != nil {
+		return ports.ReviewCommandSpec{}, false, err
+	} else if !ok {
+		return ports.ReviewCommandSpec{}, false, nil
+	} else if migratedID != "" {
+		inv.AgentSessionID = migratedID
+	}
 	cmd, ok, err := agentrestore.Command(ctx, r.agent, inv, agentrestore.Options{
 		Permissions:     ports.PermissionModeAuto,
 		AllowedTools:    reviewerAllowedTools,
@@ -140,6 +149,44 @@ func (r *Reviewer) ReviewRestoreCommand(ctx context.Context, inv ports.ReviewInv
 		cmd.AgentSessionID = workeragent.SessionUUID(inv.ReviewerID)
 	}
 	return cmd, true, nil
+}
+
+// restoreSessionID verifies an explicitly persisted Claude conversation before
+// asking Claude to resume it. Reviewer builds affected by #4658 persisted the
+// single-derived UUID but launched Claude with that UUID derived a second time.
+// Prefer the persisted identity when its transcript exists; otherwise migrate
+// only that exact legacy shape when the double-derived transcript is present.
+// Returning ok=false lets the launcher recreate an idle reviewer instead of
+// starting a doomed `claude --resume` command.
+func (r *Reviewer) restoreSessionID(ctx context.Context, inv ports.ReviewInvocation) (string, bool, error) {
+	persistedID := strings.TrimSpace(inv.AgentSessionID)
+	if persistedID == "" {
+		return "", true, nil
+	}
+	probe, ok := r.agent.(ports.AgentInterfaceHandoffHistoryProbe)
+	if !ok {
+		return persistedID, true, nil
+	}
+	session := ports.SessionRef{ID: inv.ReviewerID, WorkspacePath: inv.WorkspacePath}
+	exists, err := probe.NativeConversationExists(ctx, session, persistedID, nil)
+	if err != nil {
+		return "", false, err
+	}
+	if exists {
+		return persistedID, true, nil
+	}
+	if persistedID != workeragent.SessionUUID(inv.ReviewerID) {
+		return "", false, nil
+	}
+	legacyID := workeragent.SessionUUID(persistedID)
+	exists, err = probe.NativeConversationExists(ctx, session, legacyID, nil)
+	if err != nil {
+		return "", false, err
+	}
+	if exists {
+		return legacyID, true, nil
+	}
+	return "", false, nil
 }
 
 // ReviewCancel stops the active Claude Code reviewer turn while preserving the

--- a/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
@@ -2,10 +2,14 @@ package claudecode
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	workeragent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -17,6 +21,18 @@ type captureAgent struct {
 	gotRestore ports.RestoreConfig
 	hooks      []ports.WorkspaceHookConfig
 	prelaunch  []ports.LaunchConfig
+}
+
+type captureHistoryAgent struct {
+	captureAgent
+	existing map[string]bool
+	probed   []string
+	err      error
+}
+
+func (a *captureHistoryAgent) NativeConversationExists(_ context.Context, _ ports.SessionRef, id string, _ map[string]string) (bool, error) {
+	a.probed = append(a.probed, id)
+	return a.existing[id], a.err
 }
 
 func (a *captureAgent) GetConfigSpec(context.Context) (ports.ConfigSpec, error) {
@@ -73,10 +89,13 @@ func TestReviewCommandLaunchesReadOnlyOffBypass(t *testing.T) {
 		t.Fatalf("reviewer must launch in auto permission mode; got %q", agent.got.Permissions)
 	}
 	if agent.got.SessionID == "" {
-		t.Fatal("reviewer must pin the persisted Claude session id")
+		t.Fatal("reviewer must pass its stable AO session id")
 	}
-	if spec.AgentSessionID != agent.got.SessionID {
-		t.Fatalf("persisted agent session id = %q, launched session id = %q", spec.AgentSessionID, agent.got.SessionID)
+	if spec.AgentSessionID != agent.got.NativeSessionID {
+		t.Fatalf("persisted agent session id = %q, requested native session id = %q", spec.AgentSessionID, agent.got.NativeSessionID)
+	}
+	if agent.got.SessionID != "review-w1" {
+		t.Fatalf("AO session id = %q, want review-w1", agent.got.SessionID)
 	}
 	if !contains(agent.got.AllowedTools, "Read") || !contains(agent.got.AllowedTools, "Bash(ao review submit:*)") {
 		t.Fatalf("allowlist missing read-only review tools: %#v", agent.got.AllowedTools)
@@ -85,6 +104,39 @@ func TestReviewCommandLaunchesReadOnlyOffBypass(t *testing.T) {
 		if !contains(agent.got.DisallowedTools, denied) {
 			t.Fatalf("disallow list missing %q: %#v", denied, agent.got.DisallowedTools)
 		}
+	}
+}
+
+func TestReviewCommandEmitsPersistedNativeSessionID(t *testing.T) {
+	binDir := t.TempDir()
+	binaryName := "claude"
+	if runtime.GOOS == "windows" {
+		binaryName = "claude.exe"
+	}
+	if err := os.WriteFile(filepath.Join(binDir, binaryName), []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	spec, err := New().ReviewCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID: "review-w1",
+		Prompt:     "review it",
+	})
+	if err != nil {
+		t.Fatalf("ReviewCommand: %v", err)
+	}
+	emittedID := flagValue(spec.Argv, "--session-id")
+	if emittedID == "" {
+		t.Fatalf("argv missing --session-id: %#v", spec.Argv)
+	}
+	if emittedID != spec.AgentSessionID {
+		t.Fatalf("emitted session id = %q, persisted session id = %q", emittedID, spec.AgentSessionID)
+	}
+	if emittedID != workeragent.SessionUUID("review-w1") {
+		t.Fatalf("emitted session id = %q, want single-derived reviewer id", emittedID)
+	}
+	if emittedID == workeragent.SessionUUID(spec.AgentSessionID) {
+		t.Fatalf("emitted session id was derived twice: %q", emittedID)
 	}
 }
 
@@ -209,6 +261,47 @@ func TestReviewRestoreCommandAllowsAdapterFallbackWithoutNativeSessionID(t *test
 	}
 }
 
+func TestReviewRestoreCommandMigratesLegacyDoubleHashedSession(t *testing.T) {
+	persistedID := workeragent.SessionUUID("review-w1")
+	legacyID := workeragent.SessionUUID(persistedID)
+	agent := &captureHistoryAgent{existing: map[string]bool{legacyID: true}}
+	r := &Reviewer{agent: agent}
+
+	got, ok, err := r.ReviewRestoreCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:     "review-w1",
+		AgentSessionID: persistedID,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ReviewRestoreCommand = (ok=%v, err=%v), want legacy restore", ok, err)
+	}
+	if strings.Join(got.Argv, " ") != "claude --resume "+legacyID {
+		t.Fatalf("argv = %#v, want legacy session %q", got.Argv, legacyID)
+	}
+	if got.AgentSessionID != legacyID {
+		t.Fatalf("migrated agent session id = %q, want %q", got.AgentSessionID, legacyID)
+	}
+	if strings.Join(agent.probed, ",") != persistedID+","+legacyID {
+		t.Fatalf("probed ids = %#v", agent.probed)
+	}
+}
+
+func TestReviewRestoreCommandFallsBackWhenPersistedConversationIsMissing(t *testing.T) {
+	persistedID := workeragent.SessionUUID("review-w1")
+	agent := &captureHistoryAgent{existing: map[string]bool{}}
+	r := &Reviewer{agent: agent}
+
+	got, ok, err := r.ReviewRestoreCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:     "review-w1",
+		AgentSessionID: persistedID,
+	})
+	if err != nil {
+		t.Fatalf("ReviewRestoreCommand: %v", err)
+	}
+	if ok || len(got.Argv) != 0 {
+		t.Fatalf("ReviewRestoreCommand = (%#v, %v), want fresh-launch fallback", got, ok)
+	}
+}
+
 func TestReviewCancelSendsDoubleEscapeInput(t *testing.T) {
 	spec, err := (&Reviewer{}).ReviewCancel(context.Background())
 	if err != nil {
@@ -269,4 +362,13 @@ func contains(values []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+func flagValue(argv []string, flag string) string {
+	for i := 0; i+1 < len(argv); i++ {
+		if argv[i] == flag {
+			return argv[i+1]
+		}
+	}
+	return ""
 }

--- a/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
@@ -221,6 +221,9 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlyPolicy(t *testing.T) 
 	if !ok {
 		t.Fatal("ReviewRestoreCommand ok = false, want true")
 	}
+	if !got.NativeResumed {
+		t.Fatal("ReviewRestoreCommand did not report native resume")
+	}
 	if strings.Join(got.Argv, " ") != "claude --resume claude-native-1" {
 		t.Fatalf("argv = %#v", got.Argv)
 	}

--- a/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
@@ -211,8 +211,10 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlyPolicy(t *testing.T) 
 
 	got, ok, err := r.ReviewRestoreCommand(context.Background(), ports.ReviewInvocation{
 		ReviewerID:       "review-w1",
+		RunID:            "run-2",
 		AgentSessionID:   "claude-native-1",
 		WorkspacePath:    "/ws/w1",
+		Prompt:           "read the new review task",
 		SystemPromptFile: "/ao/prompts/reviewer/system.md",
 	})
 	if err != nil {
@@ -233,8 +235,105 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlyPolicy(t *testing.T) 
 	if agent.gotRestore.Permissions != ports.PermissionModeAuto {
 		t.Fatalf("restore permissions = %q, want auto", agent.gotRestore.Permissions)
 	}
+	if agent.gotRestore.Prompt != "read the new review task" || agent.gotRestore.SystemPromptFile != "/ao/prompts/reviewer/system.md" {
+		t.Fatalf("restore prompt configuration = %+v", agent.gotRestore)
+	}
 	if !contains(agent.gotRestore.AllowedTools, "Read") || !contains(agent.gotRestore.DisallowedTools, "Write") {
 		t.Fatalf("restore tool policy allowed=%#v disallowed=%#v", agent.gotRestore.AllowedTools, agent.gotRestore.DisallowedTools)
+	}
+}
+
+func TestReviewRestoreCommandDetectsExistingTranscript(t *testing.T) {
+	persistedID := workeragent.SessionUUID("review-w1")
+	agent := &captureHistoryAgent{existing: map[string]bool{persistedID: true}}
+	r := &Reviewer{agent: agent}
+
+	got, ok, err := r.ReviewRestoreCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:     "review-w1",
+		RunID:          "run-2",
+		AgentSessionID: persistedID,
+		Prompt:         "review the new commit",
+	})
+	if err != nil || !ok {
+		t.Fatalf("ReviewRestoreCommand = (ok=%v, err=%v), want existing transcript resume", ok, err)
+	}
+	if len(agent.probed) != 1 || agent.probed[0] != persistedID {
+		t.Fatalf("probed ids = %#v, want %q", agent.probed, persistedID)
+	}
+	if got.AgentSessionID != persistedID || agent.gotRestore.Prompt != "review the new commit" {
+		t.Fatalf("restore result = %+v config=%+v", got, agent.gotRestore)
+	}
+}
+
+func TestReviewRestoreCommandEmitsResumeWithPolicySystemPromptAndTask(t *testing.T) {
+	home := t.TempDir()
+	binDir := t.TempDir()
+	binaryName := "claude"
+	if runtime.GOOS == "windows" {
+		binaryName = "claude.exe"
+	}
+	binary := filepath.Join(binDir, binaryName)
+	if err := os.WriteFile(binary, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("PATH", binDir)
+
+	persistedID := workeragent.SessionUUID("review-w1")
+	transcript := filepath.Join(home, ".claude", "projects", "workspace", persistedID+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	systemPromptFile := filepath.Join(t.TempDir(), "system.md")
+	if err := os.WriteFile(systemPromptFile, []byte("review read-only"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := New().ReviewRestoreCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:       "review-w1",
+		RunID:            "run-2",
+		AgentSessionID:   persistedID,
+		Prompt:           "read the new task file",
+		SystemPromptFile: systemPromptFile,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ReviewRestoreCommand = (ok=%v, err=%v), want command", ok, err)
+	}
+	for _, want := range [][]string{
+		{"--permission-mode", "auto"},
+		{"--allowedTools", strings.Join(reviewerAllowedTools, ",")},
+		{"--disallowedTools", strings.Join(reviewerDisallowedTools, ",")},
+		{"--append-system-prompt-file", systemPromptFile},
+		{"--resume", persistedID},
+		{"--", "read the new task file"},
+	} {
+		if !containsSubsequence(got.Argv, want) {
+			t.Fatalf("argv %#v missing %#v", got.Argv, want)
+		}
+	}
+	if contains(got.Argv, "--session-id") {
+		t.Fatalf("resume argv unexpectedly starts a fresh session: %#v", got.Argv)
+	}
+}
+
+func TestReviewRestoreCommandPropagatesTranscriptProbeError(t *testing.T) {
+	persistedID := workeragent.SessionUUID("review-w1")
+	agent := &captureHistoryAgent{existing: map[string]bool{}, err: os.ErrPermission}
+	r := &Reviewer{agent: agent}
+
+	got, ok, err := r.ReviewRestoreCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:     "review-w1",
+		AgentSessionID: persistedID,
+	})
+	if err == nil || !os.IsPermission(err) || ok || len(got.Argv) != 0 {
+		t.Fatalf("ReviewRestoreCommand = (%+v, %v, %v), want probe error", got, ok, err)
+	}
+	if agent.gotRestore.Session.ID != "" {
+		t.Fatalf("probe error was masked by restore command: %+v", agent.gotRestore)
 	}
 }
 
@@ -361,6 +460,22 @@ func bashSegmentCovered(allowedTools []string, segment string) bool {
 func contains(values []string, needle string) bool {
 	for _, v := range values {
 		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubsequence(values, subsequence []string) bool {
+	for i := 0; i+len(subsequence) <= len(values); i++ {
+		match := true
+		for j := range subsequence {
+			if values[i+j] != subsequence[j] {
+				match = false
+				break
+			}
+		}
+		if match {
 			return true
 		}
 	}

--- a/backend/internal/adapters/reviewer/codex/codex_test.go
+++ b/backend/internal/adapters/reviewer/codex/codex_test.go
@@ -133,6 +133,9 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlySandbox(t *testing.T)
 	if !ok {
 		t.Fatal("ReviewRestoreCommand ok = false, want true")
 	}
+	if !got.NativeResumed {
+		t.Fatal("ReviewRestoreCommand did not report native resume")
+	}
 	want := []string{
 		"agent", "resume",
 		"--sandbox", "read-only",

--- a/backend/internal/adapters/reviewer/cursor/cursor_test.go
+++ b/backend/internal/adapters/reviewer/cursor/cursor_test.go
@@ -149,6 +149,27 @@ func TestReviewMessageReturnsTaskPrompt(t *testing.T) {
 	}
 }
 
+func TestReviewRestoreCommandRelaunchDoesNotReportNativeResume(t *testing.T) {
+	agent := &captureAgent{}
+	got, ok, err := (&Reviewer{agent: agent}).ReviewRestoreCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID:       "review-w1",
+		WorkspacePath:    "/ws/w1",
+		DataDir:          t.TempDir(),
+		Prompt:           "complete the AO review task in `/ao/task.md`.",
+		SystemPromptFile: "/ao/prompts/reviewer/system.md",
+		TaskPromptRoot:   "/ao/prompts/reviewer",
+	})
+	if err != nil {
+		t.Fatalf("ReviewRestoreCommand: %v", err)
+	}
+	if !ok {
+		t.Fatal("ReviewRestoreCommand ok = false, want true")
+	}
+	if got.NativeResumed {
+		t.Fatal("ReviewRestoreCommand reported native resume for a relaunch")
+	}
+}
+
 func TestReviewCancelUsesTwoInterrupts(t *testing.T) {
 	got, err := (&Reviewer{}).ReviewCancel(context.Background())
 	if err != nil {

--- a/backend/internal/adapters/reviewer/kimchi/kimchi_test.go
+++ b/backend/internal/adapters/reviewer/kimchi/kimchi_test.go
@@ -181,6 +181,9 @@ func TestReviewRestoreCommandUsesNativeSessionAndReappliesPolicy(t *testing.T) {
 	if !ok {
 		t.Fatal("ReviewRestoreCommand ok = false, want true")
 	}
+	if !spec.NativeResumed {
+		t.Fatal("ReviewRestoreCommand did not report native resume")
+	}
 	if strings.Join(spec.Argv, " ") != "kimchi --session kimchi-native-1" {
 		t.Fatalf("argv = %#v", spec.Argv)
 	}

--- a/backend/internal/adapters/reviewer/muse/muse_test.go
+++ b/backend/internal/adapters/reviewer/muse/muse_test.go
@@ -92,6 +92,9 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndNoWriteSandbox(t *testing.T) 
 	if !ok {
 		t.Fatal("ReviewRestoreCommand ok = false, want true")
 	}
+	if !got.NativeResumed {
+		t.Fatal("ReviewRestoreCommand did not report native resume")
+	}
 	want := []string{"muse", "--trust-workspace", "--approval-mode", "never", "--disable-write", "resume", "muse-native-1"}
 	if !slices.Equal(got.Argv, want) {
 		t.Fatalf("argv = %#v, want %#v", got.Argv, want)

--- a/backend/internal/adapters/reviewer/opencode/opencode_test.go
+++ b/backend/internal/adapters/reviewer/opencode/opencode_test.go
@@ -125,6 +125,9 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlyPolicy(t *testing.T) 
 	if !ok {
 		t.Fatal("ReviewRestoreCommand ok = false, want true")
 	}
+	if !got.NativeResumed {
+		t.Fatal("ReviewRestoreCommand did not report native resume")
+	}
 	if strings.Join(got.Argv, " ") != "agent --session opencode-native-1" {
 		t.Fatalf("argv = %#v", got.Argv)
 	}

--- a/backend/internal/ports/reviewer.go
+++ b/backend/internal/ports/reviewer.go
@@ -144,6 +144,9 @@ type ReviewCommandSpec struct {
 	Argv           []string
 	Env            map[string]string
 	AgentSessionID string
+	// NativeResumed reports whether this command resumes an existing provider-
+	// native conversation rather than relaunching a fresh reviewer process.
+	NativeResumed bool
 	// InitialMessage is injected after the process starts. Interactive-only
 	// reviewers use this instead of placing a task on the command line.
 	InitialMessage string

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -80,8 +80,8 @@ type LaunchSpec struct {
 type LaunchResult struct {
 	HandleID       string
 	AgentSessionID string
-	// NativeResumed reports whether RestoreTerminal resumed the provider-native
-	// conversation instead of falling back to a fresh idle reviewer process.
+	// NativeResumed reports whether the launch resumed the provider-native
+	// conversation instead of falling back to a fresh reviewer process.
 	NativeResumed bool
 }
 
@@ -378,7 +378,11 @@ func (l *agentLauncher) Spawn(ctx context.Context, spec LaunchSpec) (LaunchResul
 	if err != nil {
 		return LaunchResult{}, err
 	}
-	return l.launchReviewerTerminal(ctx, spec, inv)
+	// A retained native id means this stable reviewer has provider-owned
+	// history even though its terminal process is gone. Recreate the pane by
+	// resuming that conversation; a first launch has no id and still pins the
+	// adapter's deterministic fresh identity through ReviewCommand.
+	return l.launchReviewerTerminalWithMode(ctx, spec, inv, strings.TrimSpace(spec.AgentSessionID) != "")
 }
 
 func (l *agentLauncher) RestoreTerminal(ctx context.Context, spec LaunchSpec) (LaunchResult, error) {
@@ -387,10 +391,6 @@ func (l *agentLauncher) RestoreTerminal(ctx context.Context, spec LaunchSpec) (L
 		return LaunchResult{}, err
 	}
 	return l.launchReviewerTerminalWithMode(ctx, spec, inv, true)
-}
-
-func (l *agentLauncher) launchReviewerTerminal(ctx context.Context, spec LaunchSpec, inv ports.ReviewInvocation) (LaunchResult, error) {
-	return l.launchReviewerTerminalWithMode(ctx, spec, inv, false)
 }
 
 func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec LaunchSpec, inv ports.ReviewInvocation, restoring bool) (LaunchResult, error) {

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -80,6 +80,9 @@ type LaunchSpec struct {
 type LaunchResult struct {
 	HandleID       string
 	AgentSessionID string
+	// NativeResumed reports whether RestoreTerminal resumed the provider-native
+	// conversation instead of falling back to a fresh idle reviewer process.
+	NativeResumed bool
 }
 
 // reviewerRuntime is the runtime surface the launcher needs: create a pane,
@@ -401,6 +404,7 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 		}
 	}
 	var cmd ports.ReviewCommandSpec
+	nativeResumed := false
 	if restoring {
 		if restorer, ok := reviewer.(ports.ReviewerRestorer); ok {
 			restoreCmd, restoreOK, err := restorer.ReviewRestoreCommand(ctx, inv)
@@ -409,6 +413,7 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 			}
 			if restoreOK {
 				cmd = restoreCmd
+				nativeResumed = len(restoreCmd.Argv) > 0
 			}
 		}
 	}
@@ -454,7 +459,7 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 	if agentSessionID == "" {
 		agentSessionID = strings.TrimSpace(spec.AgentSessionID)
 	}
-	return LaunchResult{HandleID: handle.ID, AgentSessionID: agentSessionID}, nil
+	return LaunchResult{HandleID: handle.ID, AgentSessionID: agentSessionID, NativeResumed: nativeResumed}, nil
 }
 
 func (l *agentLauncher) waitForPromptReadiness(ctx context.Context, reviewer ports.Reviewer, handle ports.RuntimeHandle) error {

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -413,7 +413,7 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 			}
 			if restoreOK {
 				cmd = restoreCmd
-				nativeResumed = len(restoreCmd.Argv) > 0
+				nativeResumed = restoreCmd.NativeResumed
 			}
 		}
 	}

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -247,11 +247,15 @@ type fakeRestoringReviewer struct {
 	gotRestore  ports.ReviewInvocation
 	restoreSpec ports.ReviewCommandSpec
 	restoreOK   bool
+	restoreErr  error
 }
 
 func (f *fakeRestoringReviewer) ReviewRestoreCommand(_ context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, bool, error) {
 	f.restored = true
 	f.gotRestore = inv
+	if f.restoreErr != nil {
+		return ports.ReviewCommandSpec{}, false, f.restoreErr
+	}
 	if !f.restoreOK {
 		return ports.ReviewCommandSpec{}, false, nil
 	}
@@ -613,6 +617,71 @@ func TestLauncherRestoreTerminalFallsBackToFreshCommand(t *testing.T) {
 	}
 	if launch.NativeResumed {
 		t.Fatal("fresh-command fallback reported a native resume")
+	}
+}
+
+func TestLauncherSpawnResumesRecordedNativeConversationWithNewTask(t *testing.T) {
+	reviewer := &fakeRestoringReviewer{
+		restoreOK: true,
+		restoreSpec: ports.ReviewCommandSpec{
+			Argv:           []string{"agent", "resume", "native-reviewer-1", "--", "new task"},
+			AgentSessionID: "native-reviewer-1",
+			NativeResumed:  true,
+		},
+	}
+	rt := &fakeRuntime{}
+	l := newTestLauncher(t, reviewer, rt)
+	spec := launchSpec()
+	spec.AgentSessionID = "native-reviewer-1"
+
+	launch, err := l.Spawn(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if !reviewer.restored || !launch.NativeResumed {
+		t.Fatalf("recorded conversation was not resumed: reviewer=%+v launch=%+v", reviewer, launch)
+	}
+	if reviewer.gotRestore.RunID != spec.RunID || !strings.HasPrefix(reviewer.gotRestore.Prompt, reviewerTaskMessagePrefix) {
+		t.Fatalf("restore invocation lost new review task: %+v", reviewer.gotRestore)
+	}
+	if got := strings.Join(rt.createCfg.Argv, " "); got != "agent resume native-reviewer-1 -- new task" {
+		t.Fatalf("runtime argv = %q", got)
+	}
+}
+
+func TestLauncherSpawnWithoutNativeConversationUsesFreshCommand(t *testing.T) {
+	reviewer := &fakeRestoringReviewer{restoreOK: true}
+	rt := &fakeRuntime{}
+	l := newTestLauncher(t, reviewer, rt)
+
+	launch, err := l.Spawn(context.Background(), launchSpec())
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if reviewer.restored {
+		t.Fatal("first launch attempted a native restore")
+	}
+	if launch.NativeResumed {
+		t.Fatal("first launch reported a native resume")
+	}
+	if got := rt.createCfg.Argv; len(got) != 2 || got[0] != "greptile" || got[1] != "review" {
+		t.Fatalf("fresh argv = %#v", got)
+	}
+}
+
+func TestLauncherSpawnPropagatesRestoreErrorWithoutFreshFallback(t *testing.T) {
+	reviewer := &fakeRestoringReviewer{restoreErr: errors.New("Session ID is already in use")}
+	rt := &fakeRuntime{}
+	l := newTestLauncher(t, reviewer, rt)
+	spec := launchSpec()
+	spec.AgentSessionID = "native-reviewer-1"
+
+	_, err := l.Spawn(context.Background(), spec)
+	if err == nil || !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("Spawn error = %v, want live-duplicate error", err)
+	}
+	if rt.created {
+		t.Fatal("restore error was masked by a fresh reviewer launch")
 	}
 }
 

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -565,6 +565,9 @@ func TestLauncherRestoreTerminalUsesReviewerRestoreCommandWhenAvailable(t *testi
 	if launch.HandleID != "review-mer-1" {
 		t.Fatalf("handle = %q, want review-mer-1", launch.HandleID)
 	}
+	if !launch.NativeResumed {
+		t.Fatal("native reviewer restore was not reported")
+	}
 	if !reviewer.restored {
 		t.Fatal("restore command was not used")
 	}
@@ -594,7 +597,8 @@ func TestLauncherRestoreTerminalFallsBackToFreshCommand(t *testing.T) {
 	rt := &fakeRuntime{}
 	l := newTestLauncher(t, reviewer, rt)
 
-	if _, err := l.RestoreTerminal(context.Background(), launchSpec()); err != nil {
+	launch, err := l.RestoreTerminal(context.Background(), launchSpec())
+	if err != nil {
 		t.Fatalf("RestoreTerminal: %v", err)
 	}
 	if !reviewer.restored {
@@ -602,6 +606,9 @@ func TestLauncherRestoreTerminalFallsBackToFreshCommand(t *testing.T) {
 	}
 	if got := rt.createCfg.Argv; len(got) != 2 || got[0] != "greptile" || got[1] != "review" {
 		t.Fatalf("fallback argv = %#v", got)
+	}
+	if launch.NativeResumed {
+		t.Fatal("fresh-command fallback reported a native resume")
 	}
 }
 

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -255,10 +255,13 @@ func (f *fakeRestoringReviewer) ReviewRestoreCommand(_ context.Context, inv port
 	if !f.restoreOK {
 		return ports.ReviewCommandSpec{}, false, nil
 	}
-	if len(f.restoreSpec.Argv) > 0 || f.restoreSpec.InitialMessage != "" || f.restoreSpec.AgentSessionID != "" {
+	if len(f.restoreSpec.Argv) > 0 || f.restoreSpec.InitialMessage != "" || f.restoreSpec.AgentSessionID != "" || f.restoreSpec.NativeResumed {
 		return f.restoreSpec, true, nil
 	}
-	return ports.ReviewCommandSpec{Argv: []string{"agent", "resume", inv.AgentSessionID}}, true, nil
+	return ports.ReviewCommandSpec{
+		Argv:          []string{"agent", "resume", inv.AgentSessionID},
+		NativeResumed: true,
+	}, true, nil
 }
 
 func (f *fakeCancellableReviewer) ReviewCancel(context.Context) (ports.ReviewCancelSpec, error) {
@@ -542,6 +545,7 @@ func TestLauncherRestoreTerminalUsesReviewerRestoreCommandWhenAvailable(t *testi
 		restoreSpec: ports.ReviewCommandSpec{
 			Argv:           []string{"agent", "resume", "native-reviewer-1"},
 			Env:            map[string]string{"PATH": "/restore/bin"},
+			NativeResumed:  true,
 			InitialMessage: "restored task",
 		},
 	}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -569,7 +569,18 @@ func (e *Engine) restoreReviewerLocked(ctx stdctx.Context, workerID domain.Sessi
 		PreviousRuns:    previousRuns,
 	})
 	if err != nil {
-		return RestoreReviewerResult{}, fmt.Errorf("restore reviewer: %w", err)
+		restoreErr := fmt.Errorf("restore reviewer: %w", err)
+		if failErr := e.failRunningRestoredRuns(ctx, previousRuns, restoreErr.Error()); failErr != nil {
+			return RestoreReviewerResult{}, errors.Join(restoreErr, failErr)
+		}
+		return RestoreReviewerResult{}, restoreErr
+	}
+	if !launch.NativeResumed {
+		const reason = "reviewer native conversation was unavailable during restore; retry the review"
+		if err := e.failRunningRestoredRuns(ctx, previousRuns, reason); err != nil {
+			_ = e.launcher.Destroy(ctx, launch.HandleID)
+			return RestoreReviewerResult{}, err
+		}
 	}
 	if launch.AgentSessionID != "" {
 		agentSessionID = launch.AgentSessionID
@@ -579,6 +590,18 @@ func (e *Engine) restoreReviewerLocked(ctx stdctx.Context, workerID domain.Sessi
 		return RestoreReviewerResult{}, err
 	}
 	return RestoreReviewerResult{ReviewerHandleID: launch.HandleID, Restored: true}, nil
+}
+
+func (e *Engine) failRunningRestoredRuns(ctx stdctx.Context, runs []domain.ReviewRun, body string) error {
+	for _, run := range runs {
+		if run.Status != domain.ReviewRunRunning {
+			continue
+		}
+		if _, err := e.store.UpdateReviewRunResult(ctx, run.ID, domain.ReviewRunFailed, domain.VerdictNone, body, "", run.AutoInjectReview); err != nil {
+			return fmt.Errorf("fail review run %q after reviewer restore: %w", run.ID, err)
+		}
+	}
+	return nil
 }
 
 // TeardownReviewerTerminal destroys reviewer panes before shutdown removes the

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -265,6 +265,7 @@ type fakeLauncher struct {
 	aliveChecked     bool
 	preflightErr     error
 	preflighted      bool
+	restoreFallback  bool
 	spawnStarted     chan struct{}
 	unblockSpawn     <-chan struct{}
 	destroyCalled    chan string
@@ -293,7 +294,7 @@ func (f *fakeLauncher) RestoreTerminal(_ context.Context, spec LaunchSpec) (Laun
 	if f.spawnErr != nil {
 		return LaunchResult{}, f.spawnErr
 	}
-	return LaunchResult{HandleID: f.handle, AgentSessionID: f.agentSessionID}, nil
+	return LaunchResult{HandleID: f.handle, AgentSessionID: f.agentSessionID, NativeResumed: !f.restoreFallback}, nil
 }
 func (f *fakeLauncher) Notify(_ context.Context, handleID string, spec LaunchSpec) error {
 	f.notified = true
@@ -428,6 +429,61 @@ func TestRestoreReviewerRestoresDeadReviewerFromHistory(t *testing.T) {
 	}
 	if store.review.ReviewerHandleID != "review-mer-1" {
 		t.Fatalf("stored reviewer handle = %q", store.review.ReviewerHandleID)
+	}
+}
+
+func TestRestoreReviewerFailsRunningRunWhenNativeConversationIsUnavailable(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{
+			ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode,
+			ReviewerHandleID: "review-mer-1", AgentSessionID: "missing-native",
+		},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", ReviewID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode,
+			PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunRunning,
+		}},
+	}
+	launcher := &fakeLauncher{alive: false, handle: "review-mer-1", restoreFallback: true}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.RestoreReviewer(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("RestoreReviewer: %v", err)
+	}
+	if !res.Restored || res.ReviewerHandleID != "review-mer-1" {
+		t.Fatalf("restore result = %+v", res)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunFailed || !strings.Contains(got.Body, "retry") {
+		t.Fatalf("run after fresh fallback = %+v, want retryable failure", got)
+	}
+	if store.review.ReviewerHandleID != "review-mer-1" {
+		t.Fatalf("fresh idle reviewer handle = %q", store.review.ReviewerHandleID)
+	}
+}
+
+func TestRestoreReviewerFailsRunningRunWhenTerminalRestoreErrors(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{
+			ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode,
+			ReviewerHandleID: "review-mer-1", AgentSessionID: "native-1",
+		},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", ReviewID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode,
+			Status: domain.ReviewRunRunning,
+		}},
+	}
+	launcher := &fakeLauncher{alive: false, spawnErr: errors.New("resume failed")}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerClaudeCode
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.RestoreReviewer(context.Background(), "mer-1"); err == nil || !strings.Contains(err.Error(), "resume failed") {
+		t.Fatalf("RestoreReviewer error = %v, want resume failure", err)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunFailed || !strings.Contains(got.Body, "resume failed") {
+		t.Fatalf("run after restore error = %+v", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #4658
Supersedes #4659

## Summary
- keep first-launch Claude reviewer identity ownership exact: AO persists the same deterministic native UUID emitted through `--session-id`, including migration of the legacy double-derived transcript identity
- when a reviewer pane/process is dead but its native conversation is retained, route a new review launch through the reviewer restore boundary so Claude uses `--resume` instead of colliding on `--session-id`
- detect the existing Claude transcript before resuming, preserve the reviewer read-only tool policy and system prompt, and deliver the new review task as the resume-time user turn
- propagate transcript/restore failures instead of silently fresh-launching; the engine's existing liveness gate still notifies a genuinely live reviewer rather than starting a duplicate
- keep idle restore fallback explicit and mark interrupted running runs retryable when native history is unavailable

## Root cause
Commit `d15fd8277c1b63a1a7ebdb55735b9ed6091cf118` introduced deterministic reviewer identity persistence and a native restore adapter, but ordinary review reruns continued through `Launcher.Spawn`, which hard-coded fresh command construction. After cancellation or process exit, the durable `review.agent_session_id` survived while the pane did not, so the next task launched Claude with `--session-id <existing-id>` and Claude rejected the already-owned transcript.

The related `No conversation found` symptom had the same identity-ownership regression: the first implementation passed an already-derived Claude UUID as an AO `SessionID`, causing the command builder to derive it a second time. AO persisted the single-derived ID while Claude owned the double-derived transcript.

## Tests
- `go test ./internal/adapters/reviewer/... ./internal/review/...`
- `go build ./...`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID -u AO_TMUX_BINARY -u AO_TMUX_SOCKET_NAME -u AO_DATA_DIR -u AO_RUN_FILE go test ./...`
- isolated-cache `golangci-lint v2.12.2 run --path-mode=abs` (`0 issues`)

## Risk
Low and scoped to reviewer launch/restore selection. A native restore is attempted only when a durable reviewer-native ID exists; first launch remains fresh. Missing transcripts fall back through the existing adapter behavior, while probe/restore errors are surfaced and never converted into a second fresh launch.
