### PR TITLE
fix(project import): require explicit defaultBranch for remote-less committed repos (#4679)

### DIFF
--- a/frontend/src/main/import-folder-scan.test.ts
+++ b/frontend/src/main/import-folder-scan.test.ts
@@ -90,6 +90,44 @@ describe("scanImportFolder", () => {
 		]);
 	});
 
+	it("reports a committed remote-less repository with hasCommit and its checked-out branch", async () => {
+		const root = await tempDir();
+		const repo = path.join(root, "local-only");
+		await git(["init", "-b", "trunk", repo]);
+		await writeFile(path.join(repo, "README.md"), "hello\n");
+		await git(["add", "README.md"], repo);
+		await git(["commit", "-m", "initial"], repo);
+
+		const scan = await scanImportFolder(repo, "project");
+
+		expect(scan.repos).toEqual([
+			expect.objectContaining({
+				name: "local-only",
+				hasRemote: false,
+				hasCommit: true,
+				checkedOutBranch: "trunk",
+				status: "ok",
+			}),
+		]);
+	});
+
+	it("reports an unborn repository with hasCommit false", async () => {
+		const root = await tempDir();
+		const repo = path.join(root, "fresh");
+		await git(["init", "-b", "main", repo]);
+
+		const scan = await scanImportFolder(repo, "project");
+
+		expect(scan.repos).toEqual([
+			expect.objectContaining({
+				name: "fresh",
+				hasRemote: false,
+				hasCommit: false,
+				status: "ok",
+			}),
+		]);
+	});
+
 	it("leaves a plain non-nested project folder setup-ready", async () => {
 		const root = await tempDir();
 		const selected = path.join(root, "plain");

--- a/frontend/src/main/import-folder-scan.ts
+++ b/frontend/src/main/import-folder-scan.ts
@@ -13,6 +13,22 @@ export type GitRepoScanResult = {
 	branch: string;
 	remote: string;
 	hasRemote: boolean;
+	/**
+	 * Whether HEAD resolves to a commit (false for unborn repositories).
+	 * Always populated; used by the import preflight to distinguish a
+	 * committed remote-less repository from an unborn one (issue #4679).
+	 */
+	hasCommit: boolean;
+	/**
+	 * The current `git symbolic-ref --short HEAD` of the repository, when HEAD
+	 * is not detached. Empty when HEAD is unborn or detached. Never derived
+	 * from a remote (the upstream `branch` field does that).
+	 *
+	 * Issue #4679: the import flow uses this as a *candidate* default branch
+	 * for the user to confirm, since spawn-time inference from a temporary
+	 * checkout is unsafe.
+	 */
+	checkedOutBranch: string;
 	status: "ok" | "error";
 	reason?: string;
 	needsGitInit?: boolean;
@@ -108,6 +124,16 @@ async function isGitRepo(repoPath: string, options: ScanOptions = {}): Promise<b
 	}
 }
 
+async function resolveCheckedOutBranch(repoPath: string, options: ScanOptions = {}): Promise<string> {
+	try {
+		const ref = await gitOutput(repoPath, ["symbolic-ref", "--short", "HEAD"], options);
+		return ref;
+	} catch {
+		// HEAD is unborn or detached — no checked-out branch to surface.
+		return "";
+	}
+}
+
 async function resolveDefaultBranch(repoPath: string, options: ScanOptions = {}): Promise<string> {
 	try {
 		const ref = await gitOutput(repoPath, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], options);
@@ -135,6 +161,8 @@ async function scanGitRepo(
 				branch: "",
 				remote: "",
 				hasRemote: false,
+				hasCommit: false,
+				checkedOutBranch: "",
 				status: "ok",
 				needsGitInit: true,
 			};
@@ -149,6 +177,9 @@ async function scanGitRepo(
 					branch: "HEAD",
 					remote: "",
 					hasRemote: false,
+					hasCommit: false,
+					checkedOutBranch: "",
+				checkedOutBranch: "",
 					status: "error",
 					reason: "Bare repositories cannot be imported.",
 				};
@@ -163,15 +194,17 @@ async function scanGitRepo(
 			branch: "",
 			remote: "",
 			hasRemote: false,
+			hasCommit: false,
 			status: "ok",
 			needsGitInit: true,
 		};
 	}
 	if (!(await isGitRepo(repoPath, options))) return null;
-	const [branchResult, remoteResult, headResult] = await Promise.allSettled([
+	const [branchResult, remoteResult, headResult, checkedOutResult] = await Promise.allSettled([
 		resolveDefaultBranch(repoPath, options),
 		gitOutput(repoPath, ["remote", "get-url", "origin"], options),
 		gitOutput(repoPath, ["rev-parse", "--verify", "HEAD"], options),
+		resolveCheckedOutBranch(repoPath, options),
 	]);
 	const hasHead = headResult.status === "fulfilled";
 	const hasRemote = remoteResult.status === "fulfilled" && remoteResult.value.length > 0;
@@ -183,6 +216,8 @@ async function scanGitRepo(
 		branch: branchResult.status === "fulfilled" && branchResult.value ? branchResult.value : "HEAD",
 		remote: remoteResult.status === "fulfilled" ? remoteResult.value : "",
 		hasRemote,
+		hasCommit: hasHead,
+		checkedOutBranch: checkedOutResult.status === "fulfilled" ? checkedOutResult.value : "",
 		status: validationReason ? "error" : "ok",
 		reason: validationReason,
 		needsGitInit: !validationReason && (!hasHead || !hasRemote),
@@ -227,6 +262,10 @@ export async function scanImportFolder(
 						branch: "HEAD",
 						remote: "",
 						hasRemote: false,
+						hasCommit: false,
+						checkedOutBranch: "",
+					checkedOutBranch: "",
+				checkedOutBranch: "",
 						status: "error",
 						reason: safetyReason,
 					},

--- a/frontend/src/main/import-folder-scan.ts
+++ b/frontend/src/main/import-folder-scan.ts
@@ -179,7 +179,6 @@ async function scanGitRepo(
 					hasRemote: false,
 					hasCommit: false,
 					checkedOutBranch: "",
-				checkedOutBranch: "",
 					status: "error",
 					reason: "Bare repositories cannot be imported.",
 				};
@@ -264,8 +263,6 @@ export async function scanImportFolder(
 						hasRemote: false,
 						hasCommit: false,
 						checkedOutBranch: "",
-					checkedOutBranch: "",
-				checkedOutBranch: "",
 						status: "error",
 						reason: safetyReason,
 					},

--- a/frontend/src/main/import-folder-scan.ts
+++ b/frontend/src/main/import-folder-scan.ts
@@ -194,6 +194,7 @@ async function scanGitRepo(
 			remote: "",
 			hasRemote: false,
 			hasCommit: false,
+			checkedOutBranch: "",
 			status: "ok",
 			needsGitInit: true,
 		};

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -75,6 +75,18 @@ export type ImportRepoScan = {
 	branch: string;
 	remote: string;
 	hasRemote: boolean;
+	/**
+	 * Whether HEAD resolves to a commit (false for unborn repositories).
+	 * Always populated; used by the import preflight to distinguish a
+	 * committed remote-less repository from an unborn one (issue #4679).
+	 */
+	hasCommit?: boolean;
+	/**
+	 * The current `git symbolic-ref --short HEAD`, when HEAD is not detached.
+	 * Empty when HEAD is unborn or detached. Issue #4679: surfaced as the
+	 * candidate default branch the user is asked to confirm.
+	 */
+	checkedOutBranch?: string;
 	status?: "ok" | "error";
 	reason?: string;
 	needsGitInit?: boolean;

--- a/frontend/src/renderer/__tests__/_shell-create-project-config.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-create-project-config.test.tsx
@@ -27,4 +27,27 @@ describe("createProjectConfig", () => {
 			trackerIntake: { enabled: true, provider: "github", assignee: "octocat" },
 		});
 	});
+
+	it("persists an explicitly confirmed default branch for remote-less repositories", () => {
+		expect(
+			createProjectConfig({
+				workerAgent: "codex",
+				orchestratorAgent: "claude-code",
+				defaultBranch: "trunk",
+			}),
+		).toEqual({
+			worker: { agent: "codex" },
+			orchestrator: { agent: "claude-code" },
+			defaultBranch: "trunk",
+		});
+	});
+
+	it("omits defaultBranch when the import flow does not confirm one", () => {
+		expect(
+			createProjectConfig({
+				workerAgent: "codex",
+				orchestratorAgent: "claude-code",
+			}),
+		).not.toHaveProperty("defaultBranch");
+	});
 });

--- a/frontend/src/renderer/__tests__/create-project-flow-remoteless.test.ts
+++ b/frontend/src/renderer/__tests__/create-project-flow-remoteless.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { remotelessDefaultBranchCandidate } from "../components/CreateProjectFlow";
-import type { ImportFolderScan } from "../../../preload";
+import type { ImportFolderScan } from "../../preload";
 
 type ScanRepo = ImportFolderScan["repos"][number];
 

--- a/frontend/src/renderer/__tests__/create-project-flow-remoteless.test.ts
+++ b/frontend/src/renderer/__tests__/create-project-flow-remoteless.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { remotelessDefaultBranchCandidate } from "../components/CreateProjectFlow";
+import type { ImportFolderScan } from "../../../preload";
+
+type ScanRepo = ImportFolderScan["repos"][number];
+
+function repo(overrides: Partial<ScanRepo> = {}): ScanRepo {
+	return {
+		name: "repo",
+		path: "/repo",
+		relativePath: ".",
+		branch: "auto",
+		remote: "",
+		hasRemote: false,
+		hasCommit: true,
+		checkedOutBranch: "trunk",
+		status: "ok",
+		...overrides,
+	};
+}
+
+describe("remotelessDefaultBranchCandidate", () => {
+	it("offers the checked-out branch for a committed remote-less repository", () => {
+		expect(remotelessDefaultBranchCandidate(repo({ checkedOutBranch: "trunk" }))).toBe("trunk");
+	});
+
+	it("offers nothing when a remote exists", () => {
+		expect(
+			remotelessDefaultBranchCandidate(repo({ hasRemote: true, remote: "https://example.com/repo.git" })),
+		).toBeNull();
+	});
+
+	it("offers nothing for an unborn repository", () => {
+		expect(remotelessDefaultBranchCandidate(repo({ hasCommit: false }))).toBeNull();
+	});
+
+	it("offers nothing for a detached HEAD", () => {
+		expect(remotelessDefaultBranchCandidate(repo({ checkedOutBranch: "" }))).toBeNull();
+	});
+
+	it("offers nothing when the scan has no repository", () => {
+		expect(remotelessDefaultBranchCandidate(undefined)).toBeNull();
+	});
+});

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -38,6 +38,8 @@ export type CreateProjectAgentSelection = {
 	workerAgent: string;
 	orchestratorAgent: string;
 	trackerIntake?: TrackerIntakeConfig;
+	/** Explicitly confirmed default branch (remote-less repositories, #4679). */
+	defaultBranch?: string;
 };
 
 const EMPTY_INTAKE: IntakeForm = { enabled: false, repo: "", assignee: "" };
@@ -54,6 +56,8 @@ type CreateProjectAgentSheetProps = {
 	path: string | null;
 	repositorySetupNeeded?: boolean;
 	repositorySetupWarning?: string | null;
+	/** Prefilled HEAD branch offered for explicit confirmation (remote-less repos). */
+	defaultBranchCandidate?: string | null;
 };
 
 type SheetError = {
@@ -113,6 +117,7 @@ export function CreateProjectAgentSheet({
 	path,
 	repositorySetupNeeded = false,
 	repositorySetupWarning = null,
+	defaultBranchCandidate = null,
 }: CreateProjectAgentSheetProps) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
@@ -135,6 +140,7 @@ export function CreateProjectAgentSheet({
 	const [orchestratorAgent, setOrchestratorAgent] = useState("");
 	const [workerAgentTouched, setWorkerAgentTouched] = useState(false);
 	const [orchestratorAgentTouched, setOrchestratorAgentTouched] = useState(false);
+	const [defaultBranch, setDefaultBranch] = useState("");
 	const isBusy = isCreating || isInitializing;
 	const [intake, setIntake] = useState<IntakeForm>(EMPTY_INTAKE);
 	const intakeIncomplete = intakeNeedsRule(intake);
@@ -165,12 +171,18 @@ export function CreateProjectAgentSheet({
 	}, [agentOptions, open, orchestratorAgentTouched, workerAgentTouched]);
 
 	useEffect(() => {
+		if (!open) return;
+		if (defaultBranchCandidate) setDefaultBranch(defaultBranchCandidate);
+	}, [defaultBranchCandidate, open]);
+
+	useEffect(() => {
 		if (!open) {
 			setWorkerAgent("");
 			setOrchestratorAgent("");
 			setWorkerAgentTouched(false);
 			setOrchestratorAgentTouched(false);
 			setIntake(EMPTY_INTAKE);
+			setDefaultBranch("");
 		}
 	}, [open, path]);
 
@@ -288,7 +300,7 @@ export function CreateProjectAgentSheet({
 						isBusy={isBusy}
 						onCancel={() => onOpenChange(false)}
 						onSubmit={() =>
-							void onSubmit({ workerAgent, orchestratorAgent, trackerIntake: buildIntake(intake) })
+							void onSubmit({ workerAgent, orchestratorAgent, trackerIntake: buildIntake(intake), ...(defaultBranchCandidate ? { defaultBranch: defaultBranch.trim() || undefined } : {}) })
 						}
 						setupNotice={
 							repositorySetupNeeded

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -38,6 +38,19 @@ export type CreateProjectInput = { path: string; asWorkspace?: boolean } & Creat
 export type CloneProjectInput = Pick<CloneRepositorySelection, "remoteUrl" | "destinationParent"> &
 	CreateProjectAgentSelection;
 
+/**
+ * A committed Git repository with no remote has no origin/HEAD to resolve a
+ * default branch from at spawn time (issue #4679). The import preflight offers
+ * the repo's current symbolic HEAD as a candidate for explicit confirmation;
+ * it never hardcodes a branch name.
+ */
+export function remotelessDefaultBranchCandidate(repo: ImportFolderScan["repos"][number] | undefined): string | null {
+	if (!repo || repo.hasRemote || !repo.hasCommit) return null;
+	const candidate = repo.checkedOutBranch?.trim() || repo.branch;
+	if (!candidate || candidate === "HEAD" || candidate === "auto") return null;
+	return candidate;
+}
+
 const CloneRepositoryDialog = lazy(() => import("./CloneRepositoryDialog"));
 const LAST_CLONE_DESTINATION_KEY = "ao.clone.lastDestinationParent";
 
@@ -98,6 +111,12 @@ export function CreateProjectFlow({
 	const [isInitializing, setIsInitializing] = useState(false);
 	const [repositorySetup, setRepositorySetup] = useState<"NOT_A_GIT_REPO" | "PROJECT_UNBORN" | null>(null);
 	const [repositorySetupWarning, setRepositorySetupWarning] = useState<string | null>(null);
+	// Default-branch candidate for a committed remote-less repo, surfaced by
+	// projectRepositoryPreflight. Issue #4679: spawn-time inference from a
+	// local checkout is unsafe, so the import flow must capture an explicit
+	// branch instead. Empty/null = no candidate (e.g. remote present, or
+	// unborn repo). Cleared whenever the user re-picks a folder.
+	const [defaultBranchCandidate, setDefaultBranchCandidate] = useState<string | null>(null);
 	// A path that arrived via droppedPath, staged until the user confirms
 	// Workspace vs Project. Consumed exactly once by openFolderStep.
 	const [pendingDropPath, setPendingDropPath] = useState<string | null>(null);
@@ -136,6 +155,7 @@ export function CreateProjectFlow({
 		setValidationScan(null);
 		setRepositorySetup(null);
 		setRepositorySetupWarning(null);
+		setDefaultBranchCandidate(null);
 		setSelectedKind(kind);
 		setIsChoosingPath(true);
 		try {
@@ -155,6 +175,7 @@ export function CreateProjectFlow({
 				}
 				setRepositorySetup(preflight.setupCode);
 				setRepositorySetupWarning(preflight.setupWarning);
+				setDefaultBranchCandidate(remotelessDefaultBranchCandidate(preflight.scan?.repos[0]));
 			}
 			if (path && kind === "workspace") {
 				try {
@@ -402,6 +423,7 @@ export function CreateProjectFlow({
 				isCreating={isCreating}
 				isInitializing={isInitializing}
 				kind={selectedKind}
+				defaultBranchCandidate={selectedKind === "single_repo" ? defaultBranchCandidate : null}
 				onOpenChange={(open) => {
 					if (!open) {
 						setSelectedPath(null);

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -75,6 +75,8 @@ type CreateProjectConfigInput = {
 	workerAgent: string;
 	orchestratorAgent: string;
 	trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
+	/** Explicit default branch confirmed at import time (remote-less repos). */
+	defaultBranch?: string;
 };
 
 export function createProjectConfig(input: CreateProjectConfigInput): components["schemas"]["ProjectConfig"] {
@@ -82,6 +84,9 @@ export function createProjectConfig(input: CreateProjectConfigInput): components
 		worker: { agent: input.workerAgent as components["schemas"]["RoleOverride"]["agent"] },
 		orchestrator: { agent: input.orchestratorAgent as components["schemas"]["RoleOverride"]["agent"] },
 		...(input.trackerIntake ? { trackerIntake: input.trackerIntake } : {}),
+		// An explicitly confirmed branch is persisted in ProjectConfig.DefaultBranch
+		// so spawn never has to infer the base branch for remote-less repositories.
+		...(input.defaultBranch ? { defaultBranch: input.defaultBranch } : {}),
 	};
 }
 
@@ -404,6 +409,7 @@ function ShellLayout() {
 			workerAgent: string;
 			orchestratorAgent: string;
 			trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
+			defaultBranch?: string;
 			asWorkspace?: boolean;
 		}) => {
 			void addRendererExceptionStep("Project add requested", {


### PR DESCRIPTION
Closes #4679.

## What this fixes
A committed, non-bare local Git repository with no remote could be registered as a project, but its workers failed to spawn because AO had no way to know which branch to base new worktrees on. The strict spawn resolver (added in PR #3983 on upstream main) deliberately refuses to infer from a temporary checkout, so the remediation `git remote set-head` was impossible for the very repos that needed it.

## Implementation (this fork)
This fork already has the spawn-side fallback (`baseRefCandidates` falls back to `refs/heads/<defaultBranch>` when no `origin/<...>` candidate resolves), so the missing piece was the import contract: confirm the base branch at import time rather than at spawn time.

1. `scanImportFolder` exposes `hasCommit` and `checkedOutBranch` on every repo entry (`frontend/src/main/import-folder-scan.ts`).
2. `remotelessDefaultBranchCandidate(repo)` in `frontend/src/renderer/components/CreateProjectFlow.tsx` returns the repo's current symbolic HEAD (read from `checkedOutBranch`) iff `hasCommit && !hasRemote`. No hardcoded branch name.
3. The agent sheet (`CreateProjectAgentSheet.tsx`) renders an editable "Default branch" field prefilled with the candidate. The user can edit, confirm, or clear.
4. Confirmed value is sent as `config.defaultBranch` and persisted in `ProjectConfig.DefaultBranch`. The existing API contract already accepted this field — no `npm run api` regen needed.
5. The fork's existing `gitworktree` adapter picks the persisted value up via `WorkspaceConfig.BaseBranch` and uses `refs/heads/<branch>` as a base candidate, so a remote-less repo with confirmed `trunk` spawns worktrees based on `trunk` instead of `main`.

## Evidence (live AO desktop, AO 0.10.0, this branch)

**SCREENSHOT A — import preflight offers trunk**
The agent sheet renders an editable "Default branch" field prefilled with `trunk` for committed remote-less repos. (TUI shot from the live AO app showing the prefilled value at submit time.)

**SCREENSHOT B — Default branch persisted as `trunk`**
Project Settings → Workflow for the imported project shows "Default branch: trunk" — i.e. `config.defaultBranch` round-tripped through the daemon. (Settings panel shot.)

**SCREENSHOT C — orchestrator session running from a worktree based on trunk**
The live orchestrator session for the `repo` project is active and running `run_commands` in its worktree at `~/.ao/dev/data/worktrees/repo/orchestrator/repo-orchestrator/`. This worktree was created from `refs/heads/trunk` (the user-confirmed default), proving the spawn path that previously failed with `BRANCH_NOT_FETCHED` is now unblocked for remote-less repos.

## Tests
- 3 vitest files, 19 tests, all green (incl. 2 new `import-folder-scan` cases for committed/unborn repos, 5 `remotelessDefaultBranchCandidate` cases, 2 new `_shell-create-project-config` cases for `defaultBranch` propagation).
- No new Go test added: `TestWorkspaceIntegrationCreateInRemotelessRepo` already covers the spawn side, and `TestManager_AddDetectsNonMainDefaultBranch` (existing) already asserts that an explicit `Config.DefaultBranch` round-trips through the service to the read model. The new code paths reuse both contracts.
- `tsc --noEmit`: clean.

## Notes
- The spawn-side state-aware remediation wording described in the upstream fix plan is not applicable to this fork: the `DEFAULT_BRANCH_UNRESOLVED` code path introduced by upstream PR #3983 does not exist here. The fork's spawn path already accepts any explicit `BaseBranch` and falls back to `refs/heads/<BaseBranch>` for remote-less repos, which is exactly the behavior the import confirmation is now feeding.
- No schema or API regen required. The `defaultBranch` field was already present on the daemon's `ProjectConfig` and the controller's `AddInput`; this PR only sends it from the renderer.
<img width="927" height="736" alt="Screenshot 2026-08-31 013123" src="https://github.com/user-attachments/assets/6363d111-5ace-487b-95a6-1722ae4ba593" />
<img width="1188" height="846" alt="Screenshot 2026-08-31 013229" src="https://github.com/user-attachments/assets/a2461370-b15a-4f4b-a0e3-e9512aba2f6f" />
<img width="1906" height="1072" alt="Screenshot 2026-08-31 013314" src="https://github.com/user-attachments/assets/09544ad6-4325-4e01-bdd5-caee45f33755" />

