### PR TITLE
fix(claude-code): normalize Windows trust paths

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -566,8 +566,15 @@ func claudeConfigPath() (string, error) {
 var claudeTrustMu sync.Mutex
 
 func ensureWorkspaceTrusted(configPath, workspacePath string) error {
+	return ensureWorkspaceTrustedForOS(configPath, workspacePath, runtime.GOOS)
+}
+
+func ensureWorkspaceTrustedForOS(configPath, workspacePath, goos string) error {
 	claudeTrustMu.Lock()
 	defer claudeTrustMu.Unlock()
+	if goos == "windows" {
+		workspacePath = strings.ReplaceAll(workspacePath, `\`, "/")
+	}
 
 	root := map[string]any{}
 	data, err := os.ReadFile(configPath)

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -942,6 +942,50 @@ func TestEnsureWorkspaceTrustedCreatesEntry(t *testing.T) {
 	}
 }
 
+func TestEnsureWorkspaceTrustedNormalizesWindowsProjectKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"projects":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	const workspacePath = `D:\dev\agent-orchestrator\.ao\worktrees\demo\worker-1`
+	const wantKey = `D:/dev/agent-orchestrator/.ao/worktrees/demo/worker-1`
+	if err := ensureWorkspaceTrustedForOS(cfgPath, workspacePath, "windows"); err != nil {
+		t.Fatalf("ensureWorkspaceTrustedForOS: %v", err)
+	}
+
+	root := readJSON(t, cfgPath)
+	projects := root["projects"].(map[string]any)
+	entry, ok := projects[wantKey].(map[string]any)
+	if !ok || entry["hasTrustDialogAccepted"] != true {
+		t.Fatalf("forward-slash trust entry = %#v, want accepted entry", projects[wantKey])
+	}
+	if _, exists := projects[workspacePath]; exists {
+		t.Fatalf("unexpected backslash-keyed trust entry: %#v", projects[workspacePath])
+	}
+}
+
+func TestEnsureWorkspaceTrustedLeavesNonWindowsProjectKeyUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"projects":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	const workspacePath = `/worktrees/project\with-backslash`
+	if err := ensureWorkspaceTrustedForOS(cfgPath, workspacePath, "linux"); err != nil {
+		t.Fatalf("ensureWorkspaceTrustedForOS: %v", err)
+	}
+
+	root := readJSON(t, cfgPath)
+	projects := root["projects"].(map[string]any)
+	entry, ok := projects[workspacePath].(map[string]any)
+	if !ok || entry["hasTrustDialogAccepted"] != true {
+		t.Fatalf("unchanged trust entry = %#v, want accepted entry", projects[workspacePath])
+	}
+}
+
 func TestEnsureWorkspaceTrustedIsIdempotentAndNoWriteWhenAlreadyTrusted(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, ".claude.json")


### PR DESCRIPTION
Fixes #3407

## Summary
- normalize Claude Code workspace trust keys to forward slashes on Windows
- preserve non-Windows project keys unchanged
- cover both behaviors with JSON-level regression tests

## Test
- go test ./internal/adapters/agent/claudecode -count=1
- go build ./...
- go vet ./...

## Full-suite note
- go test ./... still reports pre-existing Windows portability failures across unrelated packages (tracked separately); the touched Claude Code package passes