### PR TITLE
fix(ui): show reviewer initials without avatar url

### DIFF
--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -218,9 +218,10 @@ function DesktopSessionCard({
 			prs={summaries.map((pr) => ({
 				commentCount: pr.review.unresolvedBy.reduce((count, reviewer) => count + reviewer.count, 0),
 				number: pr.number,
-				reviewerAvatars: (pr.review.reviews ?? [])
-					.map((review) => reviewerAvatarUrl(pr, review.reviewerId))
-					.filter((url): url is string => Boolean(url)),
+				reviewerAvatars: (pr.review.reviews ?? []).map((review) => ({
+					login: review.reviewerId,
+					url: reviewerAvatarUrl(pr, review.reviewerId),
+				})),
 				state: pr.state,
 				url: prBrowserUrl(pr),
 			}))}

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -336,7 +336,13 @@ describe("SessionsBoardView", () => {
 						state: "open",
 						url: "https://example.com/pull/10",
 					},
-					{ number: 11, state: "open", url: "https://example.com/pull/11" },
+					{
+						commentCount: 1,
+						number: 11,
+						reviewerAvatars: [{ login: "grace-hopper" }],
+						state: "open",
+						url: "https://example.com/pull/11",
+					},
 					{ number: 12, state: "merged", url: "https://example.com/pull/12" },
 				]}
 				renderAvatar={(provider) => <span role="img" aria-label={provider}>C</span>}
@@ -363,6 +369,8 @@ describe("SessionsBoardView", () => {
 		expect(reviewerAvatar).not.toBeNull();
 		expect(reviewerAvatar).toHaveAttribute("src", "https://avatars.githubusercontent.com/u/1?v=4");
 		expect(reviewerAvatar).toHaveAttribute("referrerpolicy", "no-referrer");
+		const fallback = screen.getByText("GH");
+		expect(fallback).toHaveAttribute("aria-hidden", "true");
 		// The full label is real text, not an aria-label on a generic span, and
 		// the compact form is hidden so it is not read out alongside it.
 		expect(screen.getByText("12,400 tokens")).toHaveClass("sr-only");

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -308,7 +308,7 @@ describe("SessionsBoardView", () => {
 
 	it("renders a neutral card with grouped multi-PR, usage, and action presentation", () => {
 		const onOpen = vi.fn();
-		render(
+		const { container } = render(
 			<SessionCardView
 				action={<button type="button">Restore</button>}
 				branchAction={<button type="button">Copy branch</button>}
@@ -327,7 +327,12 @@ describe("SessionsBoardView", () => {
 					{
 						commentCount: 1,
 						number: 10,
-						reviewerAvatars: [{ login: "ada-lovelace" }],
+						reviewerAvatars: [
+							{
+								login: "ada-lovelace",
+								url: "https://avatars.githubusercontent.com/u/1?v=4",
+							},
+						],
 						state: "open",
 						url: "https://example.com/pull/10",
 					},
@@ -352,7 +357,12 @@ describe("SessionsBoardView", () => {
 			"href",
 			"https://example.com/pull/12",
 		);
-		expect(screen.getByLabelText("ada-lovelace")).toHaveTextContent("AL");
+		const reviewerAvatar = container.querySelector(
+			'img[src="https://avatars.githubusercontent.com/u/1?v=4"]',
+		);
+		expect(reviewerAvatar).not.toBeNull();
+		expect(reviewerAvatar).toHaveAttribute("src", "https://avatars.githubusercontent.com/u/1?v=4");
+		expect(reviewerAvatar).toHaveAttribute("referrerpolicy", "no-referrer");
 		// The full label is real text, not an aria-label on a generic span, and
 		// the compact form is hidden so it is not read out alongside it.
 		expect(screen.getByText("12,400 tokens")).toHaveClass("sr-only");

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -324,7 +324,13 @@ describe("SessionsBoardView", () => {
 				}}
 				onOpen={onOpen}
 				prs={[
-					{ number: 10, state: "open", url: "https://example.com/pull/10" },
+					{
+						commentCount: 1,
+						number: 10,
+						reviewerAvatars: [{ login: "ada-lovelace" }],
+						state: "open",
+						url: "https://example.com/pull/10",
+					},
 					{ number: 11, state: "open", url: "https://example.com/pull/11" },
 					{ number: 12, state: "merged", url: "https://example.com/pull/12" },
 				]}
@@ -346,6 +352,7 @@ describe("SessionsBoardView", () => {
 			"href",
 			"https://example.com/pull/12",
 		);
+		expect(screen.getByLabelText("ada-lovelace")).toHaveTextContent("AL");
 		// The full label is real text, not an aria-label on a generic span, and
 		// the compact form is hidden so it is not read out alongside it.
 		expect(screen.getByText("12,400 tokens")).toHaveClass("sr-only");

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -70,10 +70,15 @@ export type BoardSessionStatusPresentation = {
 
 export type BoardPullRequestState = "closed" | "open" | "draft" | "merged";
 
+export type BoardReviewerAvatar = {
+	login: string;
+	url?: string;
+};
+
 export type BoardPullRequestPresentation = {
 	commentCount?: number;
 	number: number;
-	reviewerAvatars?: string[];
+	reviewerAvatars?: BoardReviewerAvatar[];
 	state: BoardPullRequestState;
 	url: string;
 };
@@ -427,11 +432,10 @@ function BoardPullRequestGroup({
 					{(pr.reviewerAvatars ?? [])
 						.slice(0, 3)
 						.map((avatar, index) => (
-							<img
-								alt=""
-								className={cn("size-5 rounded-full border-2 border-surface object-cover ring-1 ring-border", index > 0 && "-ml-1.5")}
-								key={`${avatar}-${index}`}
-								src={avatar}
+							<ReviewerAvatar
+								avatar={avatar}
+								className={index > 0 ? "-ml-1.5" : undefined}
+								key={`${avatar.login}-${index}`}
 							/>
 						))}
 				</div>
@@ -453,6 +457,26 @@ function BoardPullRequestGroup({
 			})}
 		</div>
 	);
+}
+
+function reviewerInitials(login: string): string {
+	return login
+		.replace(/^@/, "")
+		.trim()
+		.split(/[-_\s]+/)
+		.filter(Boolean)
+		.slice(0, 2)
+		.map((part) => part[0]?.toUpperCase() ?? "")
+		.join("") || "?";
+}
+
+function ReviewerAvatar({ avatar, className }: { avatar: BoardReviewerAvatar; className?: string }) {
+	const [failed, setFailed] = useState(false);
+	const commonClassName = cn("size-5 rounded-full border-2 border-surface ring-1 ring-border", className);
+	if (avatar.url && !failed) {
+		return <img alt="" className={cn(commonClassName, "object-cover")} onError={() => setFailed(true)} src={avatar.url} />;
+	}
+	return <span aria-label={avatar.login} className={cn(commonClassName, "inline-flex items-center justify-center bg-muted text-[9px] font-semibold text-muted-foreground")}>{reviewerInitials(avatar.login)}</span>;
 }
 
 function PullRequestLifecycleIcon({ state }: { state: BoardPullRequestState }) {

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -484,7 +484,7 @@ function ReviewerAvatar({ avatar, className }: { avatar: BoardReviewerAvatar; cl
 			/>
 		);
 	}
-	return <span aria-label={avatar.login} className={cn(commonClassName, "inline-flex items-center justify-center bg-muted text-[9px] font-semibold text-muted-foreground")}>{reviewerInitials(avatar.login)}</span>;
+	return <span aria-hidden="true" className={cn(commonClassName, "inline-flex items-center justify-center bg-muted text-[9px] font-semibold text-muted-foreground")}>{reviewerInitials(avatar.login)}</span>;
 }
 
 function PullRequestLifecycleIcon({ state }: { state: BoardPullRequestState }) {

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -474,7 +474,15 @@ function ReviewerAvatar({ avatar, className }: { avatar: BoardReviewerAvatar; cl
 	const [failed, setFailed] = useState(false);
 	const commonClassName = cn("size-5 rounded-full border-2 border-surface ring-1 ring-border", className);
 	if (avatar.url && !failed) {
-		return <img alt="" className={cn(commonClassName, "object-cover")} onError={() => setFailed(true)} src={avatar.url} />;
+		return (
+			<img
+				alt=""
+				className={cn(commonClassName, "object-cover")}
+				onError={() => setFailed(true)}
+				referrerPolicy="no-referrer"
+				src={avatar.url}
+			/>
+		);
 	}
 	return <span aria-label={avatar.login} className={cn(commonClassName, "inline-flex items-center justify-center bg-muted text-[9px] font-semibold text-muted-foreground")}>{reviewerInitials(avatar.login)}</span>;
 }


### PR DESCRIPTION
## Summary

- preserve reviewer identities when no avatar URL can be built
- render initials placeholders for missing or failed reviewer images
- cover the missing-URL fallback in product-ui tests

## Validation

- `git diff --check`
- frontend/product-ui tests could not run in this checkout because shared package dependencies are not installed; frontend typecheck is also blocked by missing shared-package React/Vitest resolution.