### PR TITLE
fix(chat): settle streamed messages with completed turns

### DIFF
--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -2824,6 +2824,29 @@ func (q *Queries) SettleRunningConversationActivitiesForTurn(ctx context.Context
 	return err
 }
 
+const settleStreamingConversationMessagesForTurn = `-- name: SettleStreamingConversationMessagesForTurn :exec
+UPDATE conversation_messages
+SET streaming = 0, revision = revision + 1, updated_at = ?1
+WHERE conversation_id = ?2
+  AND turn_id = ?3
+  AND role = 'assistant'
+  AND streaming = 1
+`
+
+type SettleStreamingConversationMessagesForTurnParams struct {
+	UpdatedAt      time.Time
+	ConversationID string
+	TurnID         sql.NullString
+}
+
+// A streamed assistant item may not receive item/completed when steering causes
+// the provider to finish the turn without replaying it: the accumulated text is
+// still the durable answer, and the enclosing turn is the terminal boundary.
+func (q *Queries) SettleStreamingConversationMessagesForTurn(ctx context.Context, arg SettleStreamingConversationMessagesForTurnParams) error {
+	_, err := q.db.ExecContext(ctx, settleStreamingConversationMessagesForTurn, arg.UpdatedAt, arg.ConversationID, arg.TurnID)
+	return err
+}
+
 const updateConversationAccount = `-- name: UpdateConversationAccount :exec
 UPDATE conversations
 SET account_json = ?, updated_at = ?

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -481,6 +481,17 @@ UPDATE conversation_turns
 SET state = ?, error_message = ?, completed_at = COALESCE(completed_at, ?)
 WHERE id = ?;
 
+-- A streamed assistant item may not receive item/completed when steering causes
+-- the provider to finish the turn without replaying it: the accumulated text is
+-- still the durable answer, and the enclosing turn is the terminal boundary.
+-- name: SettleStreamingConversationMessagesForTurn :exec
+UPDATE conversation_messages
+SET streaming = 0, revision = revision + 1, updated_at = sqlc.arg(updated_at)
+WHERE conversation_id = sqlc.arg(conversation_id)
+  AND turn_id = sqlc.arg(turn_id)
+  AND role = 'assistant'
+  AND streaming = 1;
+
 -- A provider can acknowledge an interrupted/failed turn without first emitting
 -- item/completed for the command it killed. Settle those rows with the enclosing
 -- turn so clients never show a permanent live spinner for work that has stopped.

--- a/backend/internal/storage/sqlite/store/conversation_history_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_history_store_test.go
@@ -676,6 +676,42 @@ func seedTurn(t *testing.T, s *sqlite.Store, conversationID string, session doma
 	}
 }
 
+func TestSettleTurnStopsStreamingAssistantMessages(t *testing.T) {
+	s, session, conversation := conversationFixture(t)
+	ctx := context.Background()
+	turnID := "turn-streaming"
+	providerTurnID := "provider-" + turnID
+
+	created, err := s.AppendUserMessage(ctx, conversation, session, "gen-1", domain.ConversationMessage{
+		ID: turnID + "-msg", Text: "do the work", Origin: domain.MessageOriginHuman,
+	}, turnID, histClock)
+	if err != nil || !created {
+		t.Fatalf("append user message: created=%v err=%v", created, err)
+	}
+	if err := s.BindTurnToProvider(ctx, turnID, providerTurnID, histClock); err != nil {
+		t.Fatalf("bind turn: %v", err)
+	}
+	if err := s.AppendAssistantDelta(ctx, conversation, "assistant-item", providerTurnID, "the answer so far", "delta-1", histClock); err != nil {
+		t.Fatalf("append assistant delta: %v", err)
+	}
+
+	if err := s.SettleTurn(ctx, conversation, providerTurnID, domain.TurnStateCompleted, "", histClock.Add(time.Minute)); err != nil {
+		t.Fatalf("settle turn: %v", err)
+	}
+	snapshot, err := s.LoadConversationSnapshot(ctx, conversation)
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+	if len(snapshot.Messages) != 2 {
+		t.Fatalf("messages = %+v, want user and assistant", snapshot.Messages)
+	}
+	for _, message := range snapshot.Messages {
+		if message.Role == domain.MessageRoleAssistant && message.Streaming {
+			t.Fatal("assistant message remained streaming after its turn completed")
+		}
+	}
+}
+
 // The core of the model: rollback hides what the agent forgot without destroying it.
 // A turn's rows stay, marked; its prose leaves the timeline.
 func TestRollbackHidesDiscardedProseAndKeepsTheTurnRows(t *testing.T) {

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -1017,6 +1017,14 @@ func (s *Store) SettleTurn(
 	}); err != nil {
 		return fmt.Errorf("settle turn %s: %w", turn.ID, err)
 	}
+	if err := q.SettleStreamingConversationMessagesForTurn(ctx,
+		gen.SettleStreamingConversationMessagesForTurnParams{
+			UpdatedAt:      now,
+			ConversationID: conversationID,
+			TurnID:         sql.NullString{String: turn.ID, Valid: true},
+		}); err != nil {
+		return fmt.Errorf("settle streaming messages for turn %s: %w", turn.ID, err)
+	}
 	if err := q.SettleRunningConversationActivitiesForTurn(ctx,
 		gen.SettleRunningConversationActivitiesForTurnParams{
 			Status:         terminalActivityStatus(state),


### PR DESCRIPTION
## Summary

- settle streamed assistant messages when their enclosing conversation turn reaches a terminal state
- cover providers that emit `turn/completed` without a separate assistant `item/completed` event (including steering flows)
- add a storage regression test and regenerate sqlc output

## Root cause

The shared turn settlement path finalized the turn and running activities, but left assistant messages with `streaming = 1` when a provider ended the turn without sending an item completion event. The renderer then kept showing the response as live indefinitely.

## Verification

- `go test ./internal/storage/sqlite/store ./internal/service/chat`
- frontend conversation and steering tests: 50 passed
- `go test ./...` (changed packages pass; unrelated environment-dependent failures remain in Crush auth, provider conformance, and tmux integration tests)
