### PR TITLE
fix: make CI injection a session policy

### DIFF
--- a/backend/internal/adapters/agent/fake/fake_test.go
+++ b/backend/internal/adapters/agent/fake/fake_test.go
@@ -231,10 +231,6 @@ func (s *lifecycleStore) ListPRsBySession(_ context.Context, _ domain.SessionID)
 	return nil, nil
 }
 
-func (s *lifecycleStore) GetPR(_ context.Context, prURL string) (domain.PullRequest, bool, error) {
-	return domain.PullRequest{URL: prURL, AutoInjectCI: true}, true, nil
-}
-
 func (s *lifecycleStore) ListPRReviews(_ context.Context, _ string) ([]domain.PullRequestReview, error) {
 	return nil, nil
 }

--- a/backend/internal/domain/pr.go
+++ b/backend/internal/domain/pr.go
@@ -90,7 +90,6 @@ type PullRequest struct {
 	ObservedAt       time.Time
 	CIObservedAt     time.Time
 	ReviewObservedAt time.Time
-	AutoInjectCI     bool
 }
 
 // PullRequestCheck is one normalized CI check run for a pull request.

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -34,7 +34,6 @@ type sessionStore interface {
 	// when no open PR remains and at least one merged) and to suppress
 	// merge-conflict nudges on PRs stacked behind an open parent.
 	ListPRsBySession(ctx context.Context, id domain.SessionID) ([]domain.PullRequest, error)
-	GetPR(ctx context.Context, prURL string) (domain.PullRequest, bool, error)
 	// ListPRReviews and ListPRComments return the effective rows committed by
 	// the SCM observer, including each item's preserved injection decision.
 	ListPRReviews(ctx context.Context, prURL string) ([]domain.PullRequestReview, error)

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -22,7 +22,6 @@ type fakeStore struct {
 	prs        map[domain.SessionID][]domain.PullRequest
 	reviews    map[string][]domain.PullRequestReview
 	comments   map[string][]domain.PullRequestComment
-	prPolicies map[string]bool
 	signatures map[string]string
 
 	listPRsErr        error
@@ -40,7 +39,6 @@ func newFakeStore() *fakeStore {
 		prs:        map[domain.SessionID][]domain.PullRequest{},
 		reviews:    map[string][]domain.PullRequestReview{},
 		comments:   map[string][]domain.PullRequestComment{},
-		prPolicies: map[string]bool{},
 		signatures: map[string]string{},
 	}
 }
@@ -55,27 +53,6 @@ func (f *fakeStore) ListPRsBySession(_ context.Context, id domain.SessionID) ([]
 		return nil, f.listPRsErr
 	}
 	return f.prs[id], nil
-}
-
-func (f *fakeStore) GetPR(_ context.Context, prURL string) (domain.PullRequest, bool, error) {
-	for _, prs := range f.prs {
-		for _, pr := range prs {
-			if pr.URL != prURL {
-				continue
-			}
-			if policy, ok := f.prPolicies[prURL]; ok {
-				pr.AutoInjectCI = policy
-			} else {
-				pr.AutoInjectCI = true
-			}
-			return pr, true, nil
-		}
-	}
-	policy, explicitlySet := f.prPolicies[prURL]
-	if !explicitlySet {
-		policy = true
-	}
-	return domain.PullRequest{URL: prURL, AutoInjectCI: policy}, true, nil
 }
 
 func (f *fakeStore) ListPRReviews(_ context.Context, prURL string) ([]domain.PullRequestReview, error) {
@@ -398,6 +375,7 @@ func working(id domain.SessionID) domain.SessionRecord {
 		ID: id, ProjectID: "mer",
 		Activity:         domain.Activity{State: domain.ActivityActive, LastActivityAt: time.Now()},
 		AutoInjectReview: true,
+		AutoInjectCI:     true,
 		FirstSignalAt:    time.Now(),
 	}
 }
@@ -1815,10 +1793,11 @@ func TestPRObservation_CancelledChecksDoNotNudge(t *testing.T) {
 	}
 }
 
-func TestPRObservation_CIFailureNotInjectedWhenPRPolicyDisabled(t *testing.T) {
+func TestPRObservation_CIFailureNotInjectedWhenSessionPolicyDisabled(t *testing.T) {
 	m, st, msg := newManager()
-	st.sessions["mer-1"] = working("mer-1")
-	st.prPolicies["pr1"] = false
+	rec := working("mer-1")
+	rec.AutoInjectCI = false
+	st.sessions["mer-1"] = rec
 	o := ports.PRObservation{Fetched: true, URL: "pr1", CI: domain.CIFailing, Checks: []ports.PRCheckObservation{
 		{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "boom"},
 	}}
@@ -1827,7 +1806,34 @@ func TestPRObservation_CIFailureNotInjectedWhenPRPolicyDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(msg.msgs) != 0 {
-		t.Fatalf("CI failure was injected with PR policy disabled: %v", msg.msgs)
+		t.Fatalf("CI failure was injected with session policy disabled: %v", msg.msgs)
+	}
+}
+
+func TestPRObservation_DisablingSessionPolicyStopsInjectionForExistingPR(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	first := ports.PRObservation{Fetched: true, URL: "pr1", CI: domain.CIFailing, Checks: []ports.PRCheckObservation{
+		{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "first failure"},
+	}}
+	if err := m.ApplyPRObservation(ctx, "mer-1", first); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("enabled session policy sent %d nudges, want 1", len(msg.msgs))
+	}
+
+	rec := st.sessions["mer-1"]
+	rec.AutoInjectCI = false
+	st.sessions["mer-1"] = rec
+	second := ports.PRObservation{Fetched: true, URL: "pr1", CI: domain.CIFailing, Checks: []ports.PRCheckObservation{
+		{Name: "build", CommitHash: "c2", Status: domain.PRCheckFailed, LogTail: "new failure after toggle"},
+	}}
+	if err := m.ApplyPRObservation(ctx, "mer-1", second); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("disabled session policy injected a new failure for existing PR: %v", msg.msgs)
 	}
 }
 

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -190,27 +190,18 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	// persisted their own dedup signature so the next poll retries only the rest.
 	ident := prIdentity(o)
 	var nudges []pendingNudge
-	var ciPolicyErr error
 
-	if o.CI == domain.CIFailing {
-		pr, ok, err := m.store.GetPR(ctx, o.URL)
-		switch {
-		case err != nil:
-			ciPolicyErr = fmt.Errorf("load CI injection policy for %s: %w", o.URL, err)
-		case !ok:
-			ciPolicyErr = fmt.Errorf("load CI injection policy for %s: PR not found", o.URL)
-		case pr.AutoInjectCI:
-			checks := failedPRChecks(o.Checks)
-			if len(checks) > 0 {
-				msg := formatCIFailureMessage(checks)
-				if ident != "your PR" {
-					msg = strings.Replace(msg, "your PR", ident, 1)
-				}
-				if o.URL != "" {
-					msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
-				}
-				nudges = append(nudges, pendingNudge{key: "ci:" + o.URL, sig: ciFailureSignature(checks), msg: msg, maxAttempts: 0})
+	if o.CI == domain.CIFailing && rec.AutoInjectCI {
+		checks := failedPRChecks(o.Checks)
+		if len(checks) > 0 {
+			msg := formatCIFailureMessage(checks)
+			if ident != "your PR" {
+				msg = strings.Replace(msg, "your PR", ident, 1)
 			}
+			if o.URL != "" {
+				msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
+			}
+			nudges = append(nudges, pendingNudge{key: "ci:" + o.URL, sig: ciFailureSignature(checks), msg: msg, maxAttempts: 0})
 		}
 	}
 
@@ -284,11 +275,8 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			return err
 		}
 	}
-	// Surface deferred policy/parent-stack read errors only after independent
+	// Surface deferred parent-stack read errors only after independent
 	// nudges have been sent, so one failed lookup cannot hide another reaction.
-	if ciPolicyErr != nil {
-		return ciPolicyErr
-	}
 	return blockedCheckErr
 }
 

--- a/backend/internal/service/session/pr_summary.go
+++ b/backend/internal/service/session/pr_summary.go
@@ -43,7 +43,8 @@ type PRConflictFile = contract.PullRequestConflictFile
 // ListPRSummaries returns all PRs owned by a session with concise SCM details
 // assembled from persisted PR/check/review facts.
 func (s *Service) ListPRSummaries(ctx context.Context, id domain.SessionID) ([]PRSummary, error) {
-	if _, ok, err := s.store.GetSession(ctx, id); err != nil {
+	session, ok, err := s.store.GetSession(ctx, id)
+	if err != nil {
 		return nil, fmt.Errorf("get %s: %w", id, err)
 	} else if !ok {
 		return nil, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
@@ -81,13 +82,13 @@ func (s *Service) ListPRSummaries(ctx context.Context, id domain.SessionID) ([]P
 			}
 			comments = append(comments, prComments...)
 		}
-		out = append(out, summarizePR(group.primary, checks, reviews, threads, comments))
+		out = append(out, summarizePR(group.primary, checks, reviews, threads, comments, session.AutoInjectCI))
 	}
 	sortPRSummaries(out)
 	return out, nil
 }
 
-func summarizePR(pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment) PRSummary {
+func summarizePR(pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, autoInjectCI bool) PRSummary {
 	return PRSummary{
 		URL:              pr.URL,
 		HTMLURL:          firstNonEmpty(pr.HTMLURL, pr.URL),
@@ -103,7 +104,7 @@ func summarizePR(pr domain.PullRequest, checks []domain.PullRequestCheck, review
 		Additions:        pr.Additions,
 		Deletions:        pr.Deletions,
 		ChangedFiles:     pr.ChangedFiles,
-		CI:               summarizeCI(pr, checks),
+		CI:               summarizeCI(pr, checks, autoInjectCI),
 		Review:           summarizeReview(pr, comments, reviews),
 		Mergeability:     summarizeMergeability(pr, threads),
 		StateChangedAt:   summarizePRStateChangedAt(pr),
@@ -131,9 +132,9 @@ func summarizePRStateChangedAt(pr domain.PullRequest) time.Time {
 	}
 }
 
-func summarizeCI(pr domain.PullRequest, checks []domain.PullRequestCheck) PRCISummary {
+func summarizeCI(pr domain.PullRequest, checks []domain.PullRequestCheck, autoInjectCI bool) PRCISummary {
 	state := ciOrUnknown(pr.CI)
-	out := PRCISummary{State: state, AutoInjectCI: pr.AutoInjectCI}
+	out := PRCISummary{State: state, AutoInjectCI: autoInjectCI}
 	if state != domain.CIFailing || pr.Merged || pr.Closed {
 		return out
 	}

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -706,8 +706,8 @@ func (s *Service) SetAutoInjectReview(ctx context.Context, id domain.SessionID, 
 	return s.Get(ctx, id)
 }
 
-// SetAutoInjectCI persists the default automatic CI-failure injection policy
-// for PRs created after this update. Existing PRs keep their captured policy.
+// SetAutoInjectCI persists the automatic CI-failure injection policy for every
+// PR associated with the session.
 func (s *Service) SetAutoInjectCI(ctx context.Context, id domain.SessionID, autoInject bool) (domain.Session, error) {
 	updated, err := s.store.SetSessionAutoInjectCI(ctx, id, autoInject, time.Now().UTC())
 	if err != nil {

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -547,7 +547,7 @@ func TestSessionSetAutoInjectReviewUnknownSession(t *testing.T) {
 	}
 }
 
-func TestSessionSetAutoInjectCIPersistsDefault(t *testing.T) {
+func TestSessionSetAutoInjectCIPersistsPolicy(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, AutoInjectCI: true}
 
@@ -4095,32 +4095,38 @@ func TestListPRSummariesSuppressesFailingChecksUnlessCIFailing(t *testing.T) {
 	}
 }
 
-func TestListPRSummariesExposesPerPRAutoInjectCIPolicy(t *testing.T) {
+func TestListPRSummariesExposeCurrentSessionAutoInjectCIPolicyForEveryPR(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, AutoInjectCI: true}
 	stList := &multiPRFakeStore{fakeStore: st, prs: []domain.PullRequest{
-		{URL: "enabled-failing", SessionID: "mer-1", CI: domain.CIFailing, AutoInjectCI: true},
-		{URL: "disabled-failing", SessionID: "mer-1", CI: domain.CIFailing, AutoInjectCI: false},
-		{URL: "enabled-passing", SessionID: "mer-1", CI: domain.CIPassing, AutoInjectCI: true},
-		{URL: "enabled-merged", SessionID: "mer-1", CI: domain.CIPassing, Merged: true, AutoInjectCI: true},
+		{URL: "first-failing", SessionID: "mer-1", CI: domain.CIFailing},
+		{URL: "second-failing", SessionID: "mer-1", CI: domain.CIFailing},
+		{URL: "passing", SessionID: "mer-1", CI: domain.CIPassing},
+		{URL: "merged", SessionID: "mer-1", CI: domain.CIPassing, Merged: true},
 	}}
 
-	got, err := (&Service{store: stList}).ListPRSummaries(context.Background(), "mer-1")
+	svc := &Service{store: stList}
+	got, err := svc.ListPRSummaries(context.Background(), "mer-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	byURL := map[string]PRSummary{}
 	for _, pr := range got {
-		byURL[pr.URL] = pr
+		if !pr.CI.AutoInjectCI {
+			t.Fatalf("PR %q did not inherit enabled session policy", pr.URL)
+		}
 	}
-	if !byURL["enabled-failing"].CI.AutoInjectCI || byURL["disabled-failing"].CI.AutoInjectCI {
-		t.Fatalf("failing CI policies = enabled:%v disabled:%v", byURL["enabled-failing"].CI.AutoInjectCI, byURL["disabled-failing"].CI.AutoInjectCI)
+
+	if _, err := svc.SetAutoInjectCI(context.Background(), "mer-1", false); err != nil {
+		t.Fatal(err)
 	}
-	if !byURL["enabled-passing"].CI.AutoInjectCI {
-		t.Fatal("passing PR lost its enabled CI injection policy")
+	got, err = svc.ListPRSummaries(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !byURL["enabled-merged"].CI.AutoInjectCI {
-		t.Fatal("terminal PR lost its enabled CI injection policy")
+	for _, pr := range got {
+		if pr.CI.AutoInjectCI {
+			t.Fatalf("existing PR %q retained enabled policy after session toggle", pr.URL)
+		}
 	}
 }
 

--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -828,7 +828,7 @@ WHERE name = 'billing_provider_source'`).Scan(&providerSource); err != nil {
 		}
 	}
 
-	var latestPromptShape, branchShape, prTriggerShape, cloudShape int
+	var latestPromptShape, branchShape, prTriggerShape, prPolicyColumn, cloudShape int
 	if err := tx.QueryRow(`
 SELECT COUNT(*) FROM pragma_table_info('sessions')
 WHERE name = 'latest_user_prompt_at'`).Scan(&latestPromptShape); err != nil {
@@ -846,6 +846,11 @@ WHERE type = 'trigger' AND name = 'pr_cdc_update'
 		return err
 	}
 	if err := tx.QueryRow(`
+SELECT COUNT(*) FROM pragma_table_info('pr')
+WHERE name = 'auto_inject_ci'`).Scan(&prPolicyColumn); err != nil {
+		return err
+	}
+	if err := tx.QueryRow(`
 SELECT COUNT(*) FROM pragma_table_info('app_settings')
 WHERE name = 'cloud_offering'`).Scan(&cloudShape); err != nil {
 		return err
@@ -856,7 +861,10 @@ WHERE name = 'cloud_offering'`).Scan(&cloudShape); err != nil {
 	}{
 		{version: 109, present: latestPromptShape != 0},
 		{version: 110, present: branchShape == 4},
-		{version: 111, present: prTriggerShape != 0},
+		// Migration 0120 deliberately removes the PR policy column and replaces
+		// the trigger. In that final shape, 0111 remains historically applied
+		// even though its former trigger predicate is no longer present.
+		{version: 111, present: prTriggerShape != 0 || prPolicyColumn == 0},
 		{version: 112, present: cloudShape != 0},
 	} {
 		if migration.present {

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -280,7 +280,6 @@ type PR struct {
 	ReviewObservedAt         sql.NullTime
 	LastNudgeSignature       string
 	StateChangedAt           sql.NullTime
-	AutoInjectCI             bool
 	ProviderID               string
 }
 

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -14,9 +14,8 @@ import (
 )
 
 const claimPRForSession = `-- name: ClaimPRForSession :exec
-INSERT INTO pr (url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at, auto_inject_ci)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
-    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+INSERT INTO pr (url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     session_id = excluded.session_id,
     state_changed_at = CASE
@@ -38,7 +37,6 @@ type ClaimPRForSessionParams struct {
 	Mergeability   domain.Mergeability
 	UpdatedAt      time.Time
 	StateChangedAt sql.NullTime
-	ID             domain.SessionID
 }
 
 func (q *Queries) ClaimPRForSession(ctx context.Context, arg ClaimPRForSessionParams) error {
@@ -52,7 +50,6 @@ func (q *Queries) ClaimPRForSession(ctx context.Context, arg ClaimPRForSessionPa
 		arg.Mergeability,
 		arg.UpdatedAt,
 		arg.StateChangedAt,
-		arg.ID,
 	)
 	return err
 }
@@ -202,7 +199,7 @@ func (q *Queries) GetDisplayPRFactsBySession(ctx context.Context, sessionID doma
 }
 
 const getPR = `-- name: GetPR :one
-SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci, provider_id FROM pr WHERE url = ?
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, provider_id FROM pr WHERE url = ?
 `
 
 func (q *Queries) GetPR(ctx context.Context, url string) (PR, error) {
@@ -249,14 +246,13 @@ func (q *Queries) GetPR(ctx context.Context, url string) (PR, error) {
 		&i.ReviewObservedAt,
 		&i.LastNudgeSignature,
 		&i.StateChangedAt,
-		&i.AutoInjectCI,
 		&i.ProviderID,
 	)
 	return i, err
 }
 
 const getPRByProviderIdentity = `-- name: GetPRByProviderIdentity :one
-SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci, provider_id
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, provider_id
 FROM pr
 WHERE provider = ?1
   AND host = ?2
@@ -314,14 +310,13 @@ func (q *Queries) GetPRByProviderIdentity(ctx context.Context, arg GetPRByProvid
 		&i.ReviewObservedAt,
 		&i.LastNudgeSignature,
 		&i.StateChangedAt,
-		&i.AutoInjectCI,
 		&i.ProviderID,
 	)
 	return i, err
 }
 
 const getPRByURLOrAlias = `-- name: GetPRByURLOrAlias :one
-SELECT pr.url, pr.session_id, pr.number, pr.pr_state, pr.review_decision, pr.ci_state, pr.mergeability, pr.updated_at, pr.provider, pr.host, pr.repo, pr.source_branch, pr.target_branch, pr.head_sha, pr.title, pr.additions, pr.deletions, pr.changed_files, pr.author, pr.base_sha, pr.merge_commit_sha, pr.is_draft, pr.is_merged, pr.is_closed, pr.provider_state, pr.provider_mergeable, pr.provider_merge_state_status, pr.html_url, pr.created_at_provider, pr.updated_at_provider, pr.merged_at_provider, pr.closed_at_provider, pr.metadata_hash, pr.ci_hash, pr.review_hash, pr.observed_at, pr.ci_observed_at, pr.review_observed_at, pr.last_nudge_signature, pr.state_changed_at, pr.auto_inject_ci, pr.provider_id
+SELECT pr.url, pr.session_id, pr.number, pr.pr_state, pr.review_decision, pr.ci_state, pr.mergeability, pr.updated_at, pr.provider, pr.host, pr.repo, pr.source_branch, pr.target_branch, pr.head_sha, pr.title, pr.additions, pr.deletions, pr.changed_files, pr.author, pr.base_sha, pr.merge_commit_sha, pr.is_draft, pr.is_merged, pr.is_closed, pr.provider_state, pr.provider_mergeable, pr.provider_merge_state_status, pr.html_url, pr.created_at_provider, pr.updated_at_provider, pr.merged_at_provider, pr.closed_at_provider, pr.metadata_hash, pr.ci_hash, pr.review_hash, pr.observed_at, pr.ci_observed_at, pr.review_observed_at, pr.last_nudge_signature, pr.state_changed_at, pr.provider_id
 FROM pr
 WHERE pr.url = COALESCE(
     (SELECT canonical_url FROM pr_url_alias WHERE alias_url = ?1),
@@ -373,7 +368,6 @@ func (q *Queries) GetPRByURLOrAlias(ctx context.Context, url string) (PR, error)
 		&i.ReviewObservedAt,
 		&i.LastNudgeSignature,
 		&i.StateChangedAt,
-		&i.AutoInjectCI,
 		&i.ProviderID,
 	)
 	return i, err
@@ -724,7 +718,7 @@ func (q *Queries) ListPRFactsBySessions(ctx context.Context, jsonEach interface{
 }
 
 const listPRsBySession = `-- name: ListPRsBySession :many
-SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, auto_inject_ci, provider_id FROM pr
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature, state_changed_at, provider_id FROM pr
 WHERE pr.session_id = ?
 ORDER BY updated_at DESC
 `
@@ -779,7 +773,6 @@ func (q *Queries) ListPRsBySession(ctx context.Context, sessionID domain.Session
 			&i.ReviewObservedAt,
 			&i.LastNudgeSignature,
 			&i.StateChangedAt,
-			&i.AutoInjectCI,
 			&i.ProviderID,
 		); err != nil {
 			return nil, err
@@ -936,20 +929,6 @@ func (q *Queries) ResolveConflictingPRAliasNotifications(ctx context.Context, ar
 	return err
 }
 
-const setPRAutoInjectCIBySession = `-- name: SetPRAutoInjectCIBySession :exec
-UPDATE pr SET auto_inject_ci = ? WHERE session_id = ?
-`
-
-type SetPRAutoInjectCIBySessionParams struct {
-	AutoInjectCI bool
-	SessionID    domain.SessionID
-}
-
-func (q *Queries) SetPRAutoInjectCIBySession(ctx context.Context, arg SetPRAutoInjectCIBySessionParams) error {
-	_, err := q.db.ExecContext(ctx, setPRAutoInjectCIBySession, arg.AutoInjectCI, arg.SessionID)
-	return err
-}
-
 const updatePRLastNudgeSignature = `-- name: UpdatePRLastNudgeSignature :exec
 UPDATE pr SET last_nudge_signature = ? WHERE url = ?
 `
@@ -967,10 +946,9 @@ func (q *Queries) UpdatePRLastNudgeSignature(ctx context.Context, arg UpdatePRLa
 const upsertLegacyPR = `-- name: UpsertLegacyPR :exec
 INSERT INTO pr (
     url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at,
-    is_draft, is_merged, is_closed, auto_inject_ci
+    is_draft, is_merged, is_closed
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
     state_changed_at = CASE
@@ -1001,7 +979,6 @@ type UpsertLegacyPRParams struct {
 	IsDraft        int64
 	IsMerged       int64
 	IsClosed       int64
-	ID             domain.SessionID
 }
 
 func (q *Queries) UpsertLegacyPR(ctx context.Context, arg UpsertLegacyPRParams) error {
@@ -1018,7 +995,6 @@ func (q *Queries) UpsertLegacyPR(ctx context.Context, arg UpsertLegacyPRParams) 
 		arg.IsDraft,
 		arg.IsMerged,
 		arg.IsClosed,
-		arg.ID,
 	)
 	return err
 }
@@ -1031,10 +1007,9 @@ INSERT INTO pr (
     is_draft, is_merged, is_closed,
     provider_state, provider_mergeable, provider_merge_state_status, html_url,
     created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider,
-    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, auto_inject_ci
+    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
     state_changed_at = CASE
@@ -1126,7 +1101,6 @@ type UpsertPRParams struct {
 	ObservedAt               sql.NullTime
 	CIObservedAt             sql.NullTime
 	ReviewObservedAt         sql.NullTime
-	ID                       domain.SessionID
 }
 
 func (q *Queries) UpsertPR(ctx context.Context, arg UpsertPRParams) error {
@@ -1171,7 +1145,6 @@ func (q *Queries) UpsertPR(ctx context.Context, arg UpsertPRParams) error {
 		arg.ObservedAt,
 		arg.CIObservedAt,
 		arg.ReviewObservedAt,
-		arg.ID,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -124,6 +124,7 @@ var shippedMigrations = map[int64]string{
 	117: "0117_allow_kimi_usage.sql",
 	118: "0118_cancelled_conversation_turns.sql",
 	119: "0119_finalize_completed_conversation_plans.sql",
+	120: "0120_session_ci_injection_policy.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they
@@ -336,7 +337,6 @@ INSERT INTO projects (
 	}
 	for table, want := range map[string][]string{
 		"sessions":      {"diff_base_sha", "diff_base_ref", "reviewer_harness", "browser_capability_verifier", "auto_inject_review", "auto_inject_ci"},
-		"pr":            {"auto_inject_ci"},
 		"notifications": {"resolved_at"},
 	} {
 		for _, column := range want {

--- a/backend/internal/storage/sqlite/migrate_missing_test.go
+++ b/backend/internal/storage/sqlite/migrate_missing_test.go
@@ -223,7 +223,6 @@ func TestMigrateRepairsQueuedTurnPromotionWhenVersion88WasClaimed(t *testing.T) 
 
 	for table, column := range map[string]string{
 		"sessions": "auto_inject_ci",
-		"pr":       "auto_inject_ci",
 	} {
 		var columns int
 		if err := db.QueryRow(
@@ -234,6 +233,15 @@ func TestMigrateRepairsQueuedTurnPromotionWhenVersion88WasClaimed(t *testing.T) 
 		if columns != 1 {
 			t.Fatalf("%s.%s count = %d, want 1", table, column, columns)
 		}
+	}
+	var prPolicyColumns int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('pr') WHERE name = 'auto_inject_ci'`,
+	).Scan(&prPolicyColumns); err != nil {
+		t.Fatalf("query pr.auto_inject_ci: %v", err)
+	}
+	if prPolicyColumns != 0 {
+		t.Fatalf("pr.auto_inject_ci count = %d, want removed session-only policy", prPolicyColumns)
 	}
 	for _, version := range []int64{88, 89} {
 		var applied int

--- a/backend/internal/storage/sqlite/migrate_usage_cost_renumber_test.go
+++ b/backend/internal/storage/sqlite/migrate_usage_cost_renumber_test.go
@@ -79,8 +79,17 @@ SELECT COALESCE((
 			).Scan(&triggerSQL); err != nil {
 				t.Fatalf("read pr_cdc_update: %v", err)
 			}
-			if !strings.Contains(triggerSQL, "auto_inject_ci") {
-				t.Fatalf("pr_cdc_update was not upgraded: %s", triggerSQL)
+			if strings.Contains(triggerSQL, "auto_inject_ci") {
+				t.Fatalf("pr_cdc_update retained removed PR policy: %s", triggerSQL)
+			}
+			var prPolicyColumn int
+			if err := db.QueryRow(
+				`SELECT COUNT(*) FROM pragma_table_info('pr') WHERE name = 'auto_inject_ci'`,
+			).Scan(&prPolicyColumn); err != nil {
+				t.Fatalf("read pr.auto_inject_ci: %v", err)
+			}
+			if prPolicyColumn != 0 {
+				t.Fatalf("pr.auto_inject_ci count = %d, want session-only policy", prPolicyColumn)
 			}
 			if err := migrate(db); err != nil {
 				t.Fatalf("second migration pass: %v", err)

--- a/backend/internal/storage/sqlite/migrations/0120_session_ci_injection_policy.sql
+++ b/backend/internal/storage/sqlite/migrations/0120_session_ci_injection_policy.sql
@@ -1,0 +1,52 @@
+-- CI-failure injection is a session policy. Keeping a copied value on each PR
+-- creates a second source of truth and makes policy changes harder to reason
+-- about. PR summaries derive the value from their owning session.
+
+-- +goose Up
+DROP TRIGGER IF EXISTS pr_cdc_update;
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+ALTER TABLE pr DROP COLUMN auto_inject_ci;
+
+-- +goose Down
+ALTER TABLE pr ADD COLUMN auto_inject_ci BOOLEAN NOT NULL DEFAULT TRUE;
+UPDATE pr
+SET auto_inject_ci = COALESCE(
+    (SELECT sessions.auto_inject_ci FROM sessions WHERE sessions.id = pr.session_id),
+    TRUE
+);
+
+DROP TRIGGER IF EXISTS pr_cdc_update;
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+    OR OLD.auto_inject_ci <> NEW.auto_inject_ci
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability,
+                    'autoInjectCI', json(CASE WHEN NEW.auto_inject_ci THEN 'true' ELSE 'false' END)),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -6,10 +6,9 @@ INSERT INTO pr (
     is_draft, is_merged, is_closed,
     provider_state, provider_mergeable, provider_merge_state_status, html_url,
     created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider,
-    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, auto_inject_ci
+    metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
     state_changed_at = CASE
@@ -62,10 +61,9 @@ ON CONFLICT (url) DO UPDATE SET
 -- name: UpsertLegacyPR :exec
 INSERT INTO pr (
     url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at,
-    is_draft, is_merged, is_closed, auto_inject_ci
+    is_draft, is_merged, is_closed
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     number = excluded.number,
     state_changed_at = CASE
@@ -184,9 +182,6 @@ SELECT last_nudge_signature FROM pr WHERE url = ?;
 
 -- name: UpdatePRLastNudgeSignature :exec
 UPDATE pr SET last_nudge_signature = ? WHERE url = ?;
-
--- name: SetPRAutoInjectCIBySession :exec
-UPDATE pr SET auto_inject_ci = ? WHERE session_id = ?;
 
 -- name: GetDisplayPRFactsBySession :one
 SELECT
@@ -425,9 +420,8 @@ JOIN wanted_session ON wanted_session.session_id = pr.session_id
 ORDER BY pr.session_id, pr.updated_at DESC;
 
 -- name: ClaimPRForSession :exec
-INSERT INTO pr (url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at, auto_inject_ci)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
-    COALESCE((SELECT auto_inject_ci FROM sessions WHERE id = ?), TRUE))
+INSERT INTO pr (url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, state_changed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (url) DO UPDATE SET
     session_id = excluded.session_id,
     state_changed_at = CASE

--- a/backend/internal/storage/sqlite/store/pr_cdc_test.go
+++ b/backend/internal/storage/sqlite/store/pr_cdc_test.go
@@ -410,36 +410,6 @@ func TestClaimPR_CreatesMovesAndGuardsActiveOwner(t *testing.T) {
 	}
 }
 
-func TestClaimPRSnapshotsDisabledSessionAutoInjectCI(t *testing.T) {
-	s := newTestStore(t)
-	ctx := context.Background()
-	seedProject(t, s, "mer")
-	record := sampleRecord("mer")
-	record.AutoInjectCI = false
-	owner, err := s.CreateSession(ctx, record)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pr := domain.PullRequest{
-		URL:       "https://github.com/acme/repo/pull/124",
-		SessionID: owner.ID,
-		Number:    124,
-		CI:        domain.CIFailing,
-		UpdatedAt: time.Now().UTC(),
-	}
-
-	if _, err := s.ClaimPR(ctx, pr, nil, nil, nil, nil, ports.ReviewWritePreserve, true); err != nil {
-		t.Fatal(err)
-	}
-	got, ok, err := s.GetPR(ctx, pr.URL)
-	if err != nil || !ok {
-		t.Fatalf("get claimed PR: ok=%v err=%v", ok, err)
-	}
-	if got.AutoInjectCI {
-		t.Fatal("claimed PR did not snapshot the session's disabled CI injection policy")
-	}
-}
-
 func TestClaimPRCreatedCDCUsesClaimReviewDecision(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/backend/internal/storage/sqlite/store/pr_store.go
+++ b/backend/internal/storage/sqlite/store/pr_store.go
@@ -87,7 +87,7 @@ func (s *Store) ClaimPR(ctx context.Context, pr domain.PullRequest, checks []dom
 		if err := q.ClaimPRForSession(ctx, gen.ClaimPRForSessionParams{
 			URL: pr.URL, SessionID: pr.SessionID, Number: int64(pr.Number), PRState: prState(pr),
 			ReviewDecision: reviewOrDefault(pr.Review), CIState: ciOrDefault(pr.CI), Mergeability: mergeabilityOrDefault(pr.Mergeability), UpdatedAt: pr.UpdatedAt,
-			StateChangedAt: nullTime(initialPRStateChangedAt(pr)), ID: pr.SessionID,
+			StateChangedAt: nullTime(initialPRStateChangedAt(pr)),
 		}); err != nil {
 			return err
 		}
@@ -588,7 +588,6 @@ func genPRParams(r domain.PullRequest) gen.UpsertPRParams {
 		ObservedAt:               nullTime(r.ObservedAt),
 		CIObservedAt:             nullTime(r.CIObservedAt),
 		ReviewObservedAt:         nullTime(r.ReviewObservedAt),
-		ID:                       r.SessionID,
 	}
 }
 
@@ -606,7 +605,6 @@ func genLegacyPRParams(r domain.PullRequest) gen.UpsertLegacyPRParams {
 		IsDraft:        boolInt(r.Draft),
 		IsMerged:       boolInt(r.Merged),
 		IsClosed:       boolInt(r.Closed),
-		ID:             r.SessionID,
 	}
 }
 
@@ -688,7 +686,6 @@ func prRowFromGen(p gen.PR) domain.PullRequest {
 		ObservedAt:               timeFromNull(p.ObservedAt),
 		CIObservedAt:             timeFromNull(p.CIObservedAt),
 		ReviewObservedAt:         timeFromNull(p.ReviewObservedAt),
-		AutoInjectCI:             p.AutoInjectCI,
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -225,37 +225,19 @@ func (s *Store) SetSessionAutoInjectReview(ctx context.Context, id domain.Sessio
 }
 
 // SetSessionAutoInjectCI persists the CI-failure injection policy for the
-// session and every PR currently owned by it. Future PRs still inherit this
-// value from the session row when first observed.
+// session and therefore every PR currently or subsequently owned by it.
 func (s *Store) SetSessionAutoInjectCI(ctx context.Context, id domain.SessionID, autoInject bool, updatedAt time.Time) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	var updated bool
-	err := s.inTx(ctx, fmt.Sprintf("set auto-inject CI for session %s", id), func(q *gen.Queries) error {
-		rows, err := q.SetSessionAutoInjectCI(ctx, gen.SetSessionAutoInjectCIParams{
-			ID:           id,
-			AutoInjectCI: autoInject,
-			UpdatedAt:    updatedAt,
-		})
-		if err != nil {
-			return err
-		}
-		if rows == 0 {
-			return nil
-		}
-		updated = true
-		if err := q.SetPRAutoInjectCIBySession(ctx, gen.SetPRAutoInjectCIBySessionParams{
-			AutoInjectCI: autoInject,
-			SessionID:    id,
-		}); err != nil {
-			return err
-		}
-		return nil
+	rows, err := s.qw.SetSessionAutoInjectCI(ctx, gen.SetSessionAutoInjectCIParams{
+		ID:           id,
+		AutoInjectCI: autoInject,
+		UpdatedAt:    updatedAt,
 	})
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("set auto-inject CI for session %s: %w", id, err)
 	}
-	return updated, nil
+	return rows > 0, nil
 }
 
 // SetSessionReviewerHarness persists the reviewer preference for one session.

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -839,7 +839,6 @@ func TestPRCRUD(t *testing.T) {
 	pr := domain.PullRequest{
 		URL: "https://gh/pr/1", SessionID: r.ID, Number: 1,
 		Review: domain.ReviewRequired, CI: domain.CIFailing, Mergeability: domain.MergeBlocked, UpdatedAt: now, StateChangedAt: now,
-		AutoInjectCI: true,
 	}
 	if err := s.WritePR(ctx, pr, nil, nil); err != nil {
 		t.Fatal(err)
@@ -853,20 +852,15 @@ func TestPRCRUD(t *testing.T) {
 	}
 }
 
-func TestPRAutoInjectCITracksSessionPolicyChanges(t *testing.T) {
+func TestSessionAutoInjectCIIsIndependentOfExistingPRRows(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	seedProject(t, s, "mer")
 	owner, _ := s.CreateSession(ctx, sampleRecord("mer"))
 	now := time.Now().UTC().Truncate(time.Second)
-	first := domain.PullRequest{URL: "https://github.com/o/r/pull/1", SessionID: owner.ID, Number: 1, CI: domain.CIFailing, UpdatedAt: now}
-
-	if err := s.WritePR(ctx, first, nil, nil); err != nil {
+	pr := domain.PullRequest{URL: "https://github.com/o/r/pull/1", SessionID: owner.ID, Number: 1, CI: domain.CIFailing, UpdatedAt: now}
+	if err := s.WritePR(ctx, pr, nil, nil); err != nil {
 		t.Fatal(err)
-	}
-	got, found, err := s.GetPR(ctx, first.URL)
-	if err != nil || !found || !got.AutoInjectCI {
-		t.Fatalf("new PR policy = found:%v err:%v value:%v, want enabled", found, err, got.AutoInjectCI)
 	}
 
 	base, _ := s.LatestSeq(ctx)
@@ -884,8 +878,8 @@ func TestPRAutoInjectCITracksSessionPolicyChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(events) != 2 {
-		t.Fatalf("policy change events = %+v, want session and PR updates", events)
+	if len(events) != 1 {
+		t.Fatalf("policy change events = %+v, want one session update", events)
 	}
 	var sessionPayload []byte
 	for i := range events {
@@ -905,36 +899,14 @@ func TestPRAutoInjectCITracksSessionPolicyChanges(t *testing.T) {
 		t.Fatalf("autoInjectCI payload = %#v, want false", payload["autoInjectCI"])
 	}
 
-	// Re-observing the first PR after changing the session policy must preserve
-	// the currently selected policy.
-	first.UpdatedAt = changedAt.Add(time.Minute)
-	if err := s.WritePR(ctx, first, nil, nil); err != nil {
+	// Existing PR observations remain writable after the session-wide policy
+	// changes; there is no PR-level policy copy to reconcile.
+	pr.UpdatedAt = changedAt.Add(time.Minute)
+	if err := s.WritePR(ctx, pr, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, _, _ = s.GetPR(ctx, first.URL)
-	if got.AutoInjectCI {
-		t.Fatal("session toggle did not rewrite the first PR's enabled policy")
-	}
-
-	second := domain.PullRequest{URL: "https://github.com/o/r/pull/2", SessionID: owner.ID, Number: 2, UpdatedAt: changedAt}
-	if err := s.WritePR(ctx, second, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-	got, _, _ = s.GetPR(ctx, second.URL)
-	if got.AutoInjectCI {
-		t.Fatal("PR created while disabled did not inherit the disabled session policy")
-	}
-
-	if ok, err := s.SetSessionAutoInjectCI(ctx, owner.ID, true, changedAt.Add(time.Minute)); err != nil || !ok {
-		t.Fatalf("enable session CI policy: ok=%v err=%v", ok, err)
-	}
-	second.UpdatedAt = changedAt.Add(2 * time.Minute)
-	if err := s.WritePR(ctx, second, nil, nil); err != nil {
-		t.Fatal(err)
-	}
-	got, _, _ = s.GetPR(ctx, second.URL)
-	if !got.AutoInjectCI {
-		t.Fatal("later session enable did not rewrite the second PR's disabled policy")
+	if got, found, err := s.GetPR(ctx, pr.URL); err != nil || !found || !got.UpdatedAt.Equal(pr.UpdatedAt) {
+		t.Fatalf("existing PR after session policy change = found:%v err:%v got:%+v", found, err, got)
 	}
 }
 

--- a/backend/pkg/contract/scm.go
+++ b/backend/pkg/contract/scm.go
@@ -79,7 +79,9 @@ type PullRequestFailingCheck struct {
 type PullRequestCISummary struct {
 	State         CIState                   `json:"state"`
 	FailingChecks []PullRequestFailingCheck `json:"failingChecks"`
-	AutoInjectCI  bool                      `json:"autoInjectCI"`
+	// AutoInjectCI mirrors the owning session's policy for display alongside
+	// each PR; it is not persisted on the PR itself.
+	AutoInjectCI bool `json:"autoInjectCI"`
 }
 
 // PullRequestReviewCommentLink points to one review comment.


### PR DESCRIPTION
## Summary

- make the session row the sole source of truth for automatic CI-failure injection across every associated PR
- read the live session policy in lifecycle reactions and derive each PR summary display value from it
- remove the redundant PR policy column, propagation transaction, and PR CDC policy event via migration 0119
- preserve migration-history repair behavior after the PR policy column and its 0111 trigger predicate are removed

This follows the synchronization fix in #4543 by eliminating the duplicated per-PR state entirely. The existing `autoInjectCI` field in PR summaries remains wire-compatible, but is now derived from the owning session.

## Tests

- `go test ./internal/lifecycle ./internal/service/session ./internal/storage/sqlite/... ./internal/httpd/...`
- `env -u AO_PROJECT_ID -u AO_SESSION_ID -u AO_DATA_DIR -u AO_RUN_FILE -u AO_APP_RUN_ID -u AO_OWNER -u AO_ACP_RUNTIME_DIR -u AO_TMUX_BINARY -u AO_TMUX_SOCKET_NAME -u AO_TELEMETRY_APP_VERSION npm run lint`
- `GOLANGCI_LINT_CACHE=/tmp/ao-lint-agent-orchestrator-201 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs`
- `npm run frontend:typecheck`
- `npm run sqlc && npm run api`

## Risk

- migration 0119 replaces `pr_cdc_update` before dropping `pr.auto_inject_ci`; its down migration restores both the column values (from the owning session) and the prior trigger shape
- migration-history repair now recognizes the post-0119 schema so later startups do not attempt to replay 0111 against the removed column