### PR TITLE
test(frontend): make locale-sensitive specs deterministic

### DIFF
--- a/frontend/src/renderer/components/chat/ChatTimelineItems.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.test.tsx
@@ -4,6 +4,19 @@ import { StrictMode } from "react";
 import { ActivityRow, AssistantMessage, TurnOutcome } from "./ChatTimelineItems";
 import type { ConversationMessage } from "../../types/conversation";
 
+const MESSAGE_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+};
+const MESSAGE_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+	hour: "2-digit",
+	minute: "2-digit",
+	hourCycle: "h23",
+};
+const messageDateFormatter = new Intl.DateTimeFormat(undefined, MESSAGE_DATE_FORMAT);
+const messageTimeFormatter = new Intl.DateTimeFormat(undefined, MESSAGE_TIME_FORMAT);
+
 let nextFrame = 1;
 let frames = new Map<number, FrameRequestCallback>();
 
@@ -145,14 +158,16 @@ describe("AssistantMessage streaming", () => {
 	});
 
 	it("shows the message timestamp on hover", () => {
+		const createdAt = new Date().toISOString();
+
 		render(
 			<AssistantMessage
-				message={message({ createdAt: new Date().toISOString(), text: "Timestamped answer", streaming: false })}
+				message={message({ createdAt, text: "Timestamped answer", streaming: false })}
 				showCopy
 			/>,
 		);
 
-		expect(screen.getByLabelText(/^Sent \d{2}:\d{2}$/)).toBeInTheDocument();
+		expect(screen.getByLabelText(`Sent ${messageTimeFormatter.format(new Date(createdAt))}`)).toBeInTheDocument();
 	});
 
 	it("labels yesterday and older messages by date", () => {
@@ -163,10 +178,10 @@ describe("AssistantMessage streaming", () => {
 			<AssistantMessage message={message({ createdAt: yesterday, streaming: false })} showCopy />,
 		);
 
-		expect(screen.getByLabelText(/^Sent Yesterday · \d{2}:\d{2}$/)).toBeInTheDocument();
+		expect(screen.getByLabelText(`Sent Yesterday · ${messageTimeFormatter.format(new Date(yesterday))}`)).toBeInTheDocument();
 		view.rerender(<AssistantMessage message={message({ createdAt: older, streaming: false })} showCopy />);
 		expect(screen.queryByLabelText(/^Sent Yesterday ·/)).toBeNull();
-		expect(screen.getByLabelText(/^Sent [A-Z][a-z]{2} \d{1,2}, \d{4}$/)).toBeInTheDocument();
+		expect(screen.getByLabelText(`Sent ${messageDateFormatter.format(new Date(older))}`)).toBeInTheDocument();
 	});
 
 	it("survives StrictMode effect cleanup and keeps draining", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -24,6 +24,18 @@ const previousTabListeners = new Set<() => void>();
 const nextTabListeners = new Set<() => void>();
 const closeShellTerminalListeners = new Set<() => void>();
 const closeShellTerminalShortcutStates: boolean[] = [];
+const MESSAGE_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+};
+const MESSAGE_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+	hour: "2-digit",
+	minute: "2-digit",
+	hourCycle: "h23",
+};
+const messageDateFormatter = new Intl.DateTimeFormat(undefined, MESSAGE_DATE_FORMAT);
+const messageTimeFormatter = new Intl.DateTimeFormat(undefined, MESSAGE_TIME_FORMAT);
 type TerminalPaneTestProps = {
 	fontSize?: number;
 	focusRequested?: boolean;
@@ -277,7 +289,7 @@ describe("Chat message timestamps", () => {
 			</>,
 		);
 
-		expect(screen.getAllByLabelText(/^Sent \d{2}:\d{2}$/)).toHaveLength(2);
+		expect(screen.getAllByLabelText(`Sent ${messageTimeFormatter.format(new Date(today))}`)).toHaveLength(2);
 	});
 
 	it("labels yesterday and older messages with calendar dates", () => {
@@ -307,8 +319,10 @@ describe("Chat message timestamps", () => {
 			</>,
 		);
 
-		expect(screen.getByLabelText(/^Sent Yesterday · \d{2}:\d{2}$/)).toBeInTheDocument();
-		expect(screen.getByLabelText(/^Sent [A-Z][a-z]{2} \d{1,2}, \d{4}$/)).toBeInTheDocument();
+		expect(
+			screen.getByLabelText(`Sent Yesterday · ${messageTimeFormatter.format(new Date(messages[0].createdAt))}`),
+		).toBeInTheDocument();
+		expect(screen.getByLabelText(`Sent ${messageDateFormatter.format(new Date(messages[1].createdAt))}`)).toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/settings/AgentModelCombobox.test.tsx
+++ b/frontend/src/renderer/components/settings/AgentModelCombobox.test.tsx
@@ -3,6 +3,18 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentModelCombobox, buildModelSearchIndex, searchModelIndex } from "./AgentModelCombobox";
 
+const LARGE_CATALOG_MODEL_COUNT = 1_397;
+const LARGE_CATALOG_VISIBLE_MODELS = 50;
+const LARGE_CATALOG_STATIC_MENU_ITEMS = 2;
+const SINGLE_MATCH_COUNT = 1;
+const TYPE_TO_NARROW_TEXT = " — type to narrow";
+const hasTextContent =
+	(expected: string) =>
+	(_content: string, element: Element | null): boolean =>
+		element?.textContent === expected;
+const matchingCountText = (visible: number, total: number, suffix = "") =>
+	`Showing ${visible.toLocaleString()} of ${total.toLocaleString()} matching models${suffix}`;
+
 function renderCombobox(
 	models: Array<{ id: string; label: string; provider?: string; isDefault?: boolean }>,
 	overrides: Partial<React.ComponentProps<typeof AgentModelCombobox>> = {},
@@ -56,7 +68,7 @@ describe("AgentModelCombobox", () => {
 	});
 
 	it("renders only the first 50 models from a large cached catalog", async () => {
-		const models = Array.from({ length: 1_397 }, (_, index) => ({
+		const models = Array.from({ length: LARGE_CATALOG_MODEL_COUNT }, (_, index) => ({
 			id: `provider-${index % 4}/model-${index}`,
 			label: `Model ${index}`,
 			provider: `provider-${index % 4}`,
@@ -67,8 +79,14 @@ describe("AgentModelCombobox", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Worker model" }));
 
 		// Agent default, 50 catalog models, and the custom-model action.
-		expect(screen.getAllByRole("menuitem")).toHaveLength(52);
-		expect(screen.getByText("Showing 50 of 1,397 matching models — type to narrow")).toBeInTheDocument();
+		expect(screen.getAllByRole("menuitem")).toHaveLength(
+			LARGE_CATALOG_VISIBLE_MODELS + LARGE_CATALOG_STATIC_MENU_ITEMS,
+		);
+		expect(
+			screen.getByText(
+				hasTextContent(matchingCountText(LARGE_CATALOG_VISIBLE_MODELS, LARGE_CATALOG_MODEL_COUNT, TYPE_TO_NARROW_TEXT)),
+			),
+		).toBeInTheDocument();
 		expect(screen.queryByRole("menuitem", { name: /Model 1000/ })).not.toBeInTheDocument();
 	});
 
@@ -128,7 +146,9 @@ describe("AgentModelCombobox", () => {
 		await userEvent.type(screen.getByRole("searchbox", { name: "Search worker model" }), "provider-1/model-99");
 
 		expect(screen.getByText("provider-1", { selector: "div" })).toBeInTheDocument();
-		expect(screen.getByText("Showing 1 of 1 matching models")).toBeInTheDocument();
+		expect(
+			screen.getByText(hasTextContent(matchingCountText(SINGLE_MATCH_COUNT, SINGLE_MATCH_COUNT))),
+		).toBeInTheDocument();
 		await userEvent.click(screen.getByRole("menuitem", { name: /Model 99/ }));
 		expect(onChange).toHaveBeenCalledWith("provider-1/model-99");
 	});


### PR DESCRIPTION
## What

Fixes #4691.

The three locale-sensitive renderer specs now derive their expected timestamp and count text from the active `Intl` locale instead of assuming en-US date order, ASCII digits, and comma thousands separators.

## Why

The product intentionally formats timestamps and model counts with the viewer's locale. The tests were asserting English-only output, which made local Vitest runs fail on machines using locales such as Russian or Arabic even though product behavior was correct.

## How

- Use the same ambient `Intl.DateTimeFormat` options as the message timestamp UI when asserting sent-time and sent-date labels.
- Use locale-aware `toLocaleString()` expectations for model count text.
- Compare exact `textContent` for model count rows so non-breaking locale separators are preserved instead of normalized away by Testing Library text matching.

## Testing

## Test verification (RED to GREEN)

RED on unmodified `main` with Russian locale:

```text
Test Files  3 failed (3)
Tests  3 failed | 102 passed (105)
```

RED on unmodified `main` with Arabic locale:

```text
Test Files  3 failed (3)
Tests  6 failed | 99 passed (105)
```

## Full local suite

Final local CI on this branch:

```text
[run-ci] frontend_typecheck
[run-ci] frontend_vitest_english
Test Files  3 passed (3)
Tests  105 passed (105)
[run-ci] frontend_vitest_non_english
Test Files  3 passed (3)
Tests  105 passed (105)
[run-ci] frontend_vitest_non_latin_digits
Test Files  3 passed (3)
Tests  105 passed (105)
[run-ci] diff coverage skipped: test-only change, no production source lines changed
```

Commands covered by the local CI script:

```bash
npm --prefix frontend run typecheck
LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 npm --prefix frontend run test -- src/renderer/components/chat/ChatWorkspace.test.tsx src/renderer/components/settings/AgentModelCombobox.test.tsx src/renderer/components/chat/ChatTimelineItems.test.tsx
LC_ALL=ru_RU.UTF-8 LANG=ru_RU.UTF-8 npm --prefix frontend run test -- src/renderer/components/chat/ChatWorkspace.test.tsx src/renderer/components/settings/AgentModelCombobox.test.tsx src/renderer/components/chat/ChatTimelineItems.test.tsx
LC_ALL=ar_EG.UTF-8 LANG=ar_EG.UTF-8 npm --prefix frontend run test -- src/renderer/components/chat/ChatWorkspace.test.tsx src/renderer/components/settings/AgentModelCombobox.test.tsx src/renderer/components/chat/ChatTimelineItems.test.tsx
```

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
