### PR TITLE
fix(frontend): keep compact sidebar toggle fixed

### DIFF
--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -37,7 +37,7 @@ import { isLinuxPlatform, isMacPlatform } from "../lib/platform";
 import { aoBridge } from "../lib/bridge";
 import { handleTerminalTabListKeyDown } from "../lib/terminal-tabs";
 import { cn } from "../lib/utils";
-import { sidebarOccupiesLayout, useUiStore, type Theme } from "../stores/ui-store";
+import { sidebarIsCompact, sidebarOccupiesLayout, useUiStore, type Theme } from "../stores/ui-store";
 import type { TerminalTarget } from "../types/terminal";
 import {
 	isOrchestratorSession,
@@ -165,6 +165,7 @@ export function CenterPane({
 	const [terminalBounds, setTerminalBounds] = useState({ leftInset: 0, rightInset: 0, width: 0 });
 	const [tabOrderBySession, setTabOrderBySession] = useState<Record<string, string[]>>({});
 	const isSidebarOpen = useUiStore(sidebarOccupiesLayout);
+	const isSidebarCompact = useUiStore(sidebarIsCompact);
 	const sessionId = session?.id;
 	const auxiliaryTabs = useMemo<AuxiliaryTab[]>(
 		() => [
@@ -576,7 +577,8 @@ export function CenterPane({
 			<div className="session-topbar-surface flex min-w-0 flex-1" data-testid="session-workspace-topbar">
 				<div
 					className={cn(
-						"flex min-w-0 shrink items-stretch",
+						"session-topbar-terminal-region flex min-w-0 shrink items-stretch",
+						!isFullscreen && isSidebarCompact && isMac && "session-topbar-traffic-light-clearance-mac",
 						!isFullscreen && !isSidebarOpen && isMac && "session-topbar-titlebar-clearance-mac",
 						!isFullscreen && !isSidebarOpen && isLinux && "session-topbar-titlebar-clearance-linux",
 					)}

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1631,8 +1631,7 @@ describe("Sidebar", () => {
 		const sidebar = document.querySelector('[data-slot="sidebar"][data-state="collapsed"]');
 		expect(sidebar).toHaveAttribute("data-collapsible", "icon");
 		const compactToggle = document.querySelector('[data-slot="sidebar-header"] button[aria-label="Expand sidebar"]');
-		expect(compactToggle).toBeInTheDocument();
-		expect(compactToggle?.querySelector("svg")).toBeInTheDocument();
+		expect(compactToggle).not.toBeInTheDocument();
 		expect(screen.queryByText("Connect Mobile")).not.toBeVisible();
 		expect(screen.queryByText("Settings")).not.toBeVisible();
 		expect(document.querySelector('[data-slot="sidebar-container"]')).toHaveAttribute(

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -31,7 +31,6 @@ import {
 	LogIn,
 	LogOut,
 	MoreVertical,
-	PanelLeft,
 	Pin,
 	PinOff,
 	Plus,
@@ -128,9 +127,9 @@ import { isLinuxPlatform, isMacPlatform, isWindowsPlatform } from "../lib/platfo
 import { useCloudSession } from "../lib/cloud-session";
 import { useCanGoForward } from "./TitlebarNav";
 
-// macOS paints framed chrome: the fixed TitlebarNav cluster carries the
-// sidebar toggle + history arrows above this surface. Windows hangs the sidebar
-// under its custom titlebar.
+// macOS paints framed chrome: TitlebarNav keeps the sidebar toggle fixed above
+// this surface. Compact mode keeps history accessible in the icon rail. Windows
+// hangs the sidebar under its custom titlebar.
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
 const isWindows = isWindowsPlatform();
@@ -422,7 +421,7 @@ export function Sidebar({
 }: SidebarProps) {
 	const { t } = useTranslation();
 	const selection = useSelection();
-	const { state, setOpen, toggleSidebar } = useSidebar();
+	const { state, setOpen } = useSidebar();
 	const isCollapsed = state === "collapsed";
 	const [expandedChromeVisible, setExpandedChromeVisible] = useState(!isCollapsed);
 	const router = useRouter();
@@ -686,21 +685,6 @@ export function Sidebar({
 						</span>
 					)}
 				</div>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<button
-							aria-label={isCollapsed ? t("shell.expandSidebar") : t("shell.collapseSidebar")}
-							className="hidden size-control-board place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground group-data-[collapsible=icon]:grid [&_svg]:size-icon-base"
-							onClick={toggleSidebar}
-							type="button"
-						>
-							<PanelLeft aria-hidden="true" />
-						</button>
-					</TooltipTrigger>
-					<TooltipContent side="right">
-						{isCollapsed ? t("shell.expandSidebar") : t("shell.collapseSidebar")}
-					</TooltipContent>
-				</Tooltip>
 				{showCompactRailHistory ? (
 					<div className="flex flex-col items-center gap-1 pb-2">
 						<Tooltip>

--- a/frontend/src/renderer/components/TitlebarNav.linux.test.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.linux.test.tsx
@@ -1,4 +1,4 @@
-import { render as rtlRender } from "@testing-library/react";
+import { render as rtlRender, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useUiStore } from "../stores/ui-store";
@@ -31,7 +31,11 @@ const { TitlebarNav } = await import("./TitlebarNav");
 
 describe("TitlebarNav on Linux", () => {
 	afterEach(() => {
-		useUiStore.setState({ isSidebarOpen: true });
+		useUiStore.setState({
+			isSidebarOpen: true,
+			isSidebarAutoCollapsed: false,
+			sidebarAutoCollapseOverride: false,
+		});
 	});
 
 	it("pins the collapse cluster to the Linux inset, not the macOS traffic-light offset", () => {
@@ -50,5 +54,15 @@ describe("TitlebarNav on Linux", () => {
 		const nav = container.querySelector('[data-slot="titlebar-nav"]');
 		expect(nav).toHaveClass("left-titlebar-cluster-left-linux-panel");
 		expect(nav).not.toHaveClass("left-titlebar-cluster-left-linux");
+	});
+
+	it("keeps the compact sidebar toggle at the expanded Linux inset", () => {
+		useUiStore.setState({ isSidebarAutoCollapsed: true });
+		const { container } = render(<TitlebarNav />);
+
+		const nav = container.querySelector('[data-slot="titlebar-nav"]');
+		expect(nav).toHaveClass("left-titlebar-cluster-left-linux", "top-0.75");
+		expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Go back" })).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/TitlebarNav.test.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.test.tsx
@@ -30,7 +30,11 @@ vi.mock("../lib/platform", () => ({
 
 describe("TitlebarNav", () => {
 	beforeEach(() => {
-		useUiStore.setState({ isSidebarOpen: true });
+		useUiStore.setState({
+			isSidebarOpen: true,
+			isSidebarAutoCollapsed: false,
+			sidebarAutoCollapseOverride: false,
+		});
 	});
 
 	it("uses the compact sidebar-aligned chrome row in native fullscreen", () => {
@@ -66,11 +70,15 @@ describe("TitlebarNav", () => {
 		expect(nav).toHaveClass("left-titlebar-cluster-left", "h-traffic-light-clearance", "-top-0.6");
 	});
 
-	it("hides the fixed navigation cluster while the sidebar is an icon rail", () => {
+	it("keeps the sidebar toggle fixed while history moves into the icon rail", () => {
 		useUiStore.setState({ isSidebarAutoCollapsed: true });
 
 		const { container } = render(<TitlebarNav />);
 
-		expect(container.querySelector('[data-slot="titlebar-nav"]')).toBeNull();
+		const nav = container.querySelector('[data-slot="titlebar-nav"]');
+		expect(nav).toHaveClass("left-titlebar-cluster-left", "h-traffic-light-clearance", "-top-0.6");
+		expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Go back" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Go forward" })).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -12,10 +12,12 @@ const noDragStyle = isMac
   ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties)
   : undefined;
 
-// Sidebar chrome cluster (sidebar toggle + history arrows). It stays fixed while
-// the sidebar expands or collapses. macOS pins it beside the traffic lights;
-// Linux has no traffic lights, so it sits at the sidebar's top-left. (Windows
-// keeps these controls in its own titlebar.)
+// Sidebar chrome cluster. The sidebar toggle stays fixed while the sidebar
+// expands, compacts, or moves off-canvas. History normally sits beside it, then
+// moves into the compact icon rail so the fixed toggle keeps its exact position.
+// macOS pins it beside the traffic lights; Linux has no traffic lights, so it
+// sits at the sidebar's top-left. (Windows keeps these controls in its own
+// titlebar.)
 // The installed router has no useCanGoForward, and deriving one as
 // `__TSR_index < history.length - 1` (the upstream hook's approach) is wrong
 // here: window.history.length also counts entries the router never created —
@@ -58,7 +60,6 @@ export function TitlebarNav({
   const canGoForward = useCanGoForward();
 
   if (!isMac && !isLinux) return null;
-  if (isSidebarCompact) return null;
 
   // macOS: pinned beside the traffic lights. Native dots sit at y: 12 with a
   // 12px hit target (centerline 18); the 40px clearance band is items-centered,
@@ -68,7 +69,7 @@ export function TitlebarNav({
   // the sidebar is off-canvas it shifts right to clear the framed centre
   // panel's left border instead of straddling it.
   const leftClass = !isMac
-    ? isSidebarOpen
+    ? sidebarHasLayout
       ? "left-titlebar-cluster-left-linux"
       : "left-titlebar-cluster-left-linux-panel"
     : isFullScreen
@@ -107,22 +108,26 @@ export function TitlebarNav({
       >
         <PanelLeft className="size-icon-lg" aria-hidden="true" />
       </TitlebarButton>
-      <TitlebarButton
-        disabled={historyLocked || !canGoBack}
-        label={t("titlebar.goBack")}
-        onClick={() => router.history.back()}
-        title={t("titlebar.goBack")}
-      >
-        <ArrowLeft className="size-icon-lg" aria-hidden="true" />
-      </TitlebarButton>
-      <TitlebarButton
-        disabled={historyLocked || !canGoForward}
-        label={t("titlebar.goForward")}
-        onClick={() => router.history.forward()}
-        title={t("titlebar.goForward")}
-      >
-        <ArrowRight className="size-icon-lg" aria-hidden="true" />
-      </TitlebarButton>
+      {isSidebarCompact ? null : (
+        <>
+          <TitlebarButton
+            disabled={historyLocked || !canGoBack}
+            label={t("titlebar.goBack")}
+            onClick={() => router.history.back()}
+            title={t("titlebar.goBack")}
+          >
+            <ArrowLeft className="size-icon-lg" aria-hidden="true" />
+          </TitlebarButton>
+          <TitlebarButton
+            disabled={historyLocked || !canGoForward}
+            label={t("titlebar.goForward")}
+            onClick={() => router.history.forward()}
+            title={t("titlebar.goForward")}
+          >
+            <ArrowRight className="size-icon-lg" aria-hidden="true" />
+          </TitlebarButton>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -149,7 +149,12 @@ beforeEach(() => {
 	terminalPaneState.props = undefined;
 	window.localStorage.clear();
 	setApiBaseUrl("http://127.0.0.1:3001");
-	useUiStore.setState({ isSidebarOpen: true, inspectorSessions: {} });
+	useUiStore.setState({
+		isSidebarOpen: true,
+		isSidebarAutoCollapsed: false,
+		sidebarAutoCollapseOverride: false,
+		inspectorSessions: {},
+	});
 });
 
 afterEach(async () => {
@@ -409,6 +414,15 @@ describe("ChatWorkspace timeline", () => {
 
 		expect(screen.getByTestId("session-terminal-region")).not.toHaveClass(
 			"session-topbar-titlebar-clearance-mac",
+		);
+	});
+
+	it("clears compact session tabs past the fixed sidebar toggle on macOS", () => {
+		useUiStore.setState({ isSidebarAutoCollapsed: true });
+		render(<ChatWorkspace snapshot={chatFixture} />);
+
+		expect(screen.getByTestId("session-terminal-region")).toHaveClass(
+			"session-topbar-traffic-light-clearance-mac",
 		);
 	});
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -46,7 +46,7 @@ import { isLinuxPlatform, isMacPlatform } from "../../lib/platform";
 import { handleTerminalTabListKeyDown } from "../../lib/terminal-tabs";
 import { agentLabel } from "../../lib/agent-options";
 import type { ShellTerminal } from "../../hooks/useShellTerminals";
-import { sidebarOccupiesLayout, useUiStore } from "../../stores/ui-store";
+import { sidebarIsCompact, sidebarOccupiesLayout, useUiStore } from "../../stores/ui-store";
 import type { TerminalTarget } from "../../types/terminal";
 import {
 	isOrchestratorSession,
@@ -1369,6 +1369,7 @@ function ChatHeader({
 	// cluster sits over the session tab strip. Terminal already reserves that
 	// space; chat must too or the back/forward buttons land on the tab label.
 	const isSidebarOpen = useUiStore(sidebarOccupiesLayout);
+	const isSidebarCompact = useUiStore(sidebarIsCompact);
 	const header = (
 		<header className="flex h-inspector-tabs w-full shrink-0 items-stretch bg-sidebar">
 			<div
@@ -1377,7 +1378,8 @@ function ChatHeader({
 			>
 				<div
 					className={cn(
-						"flex min-w-0 shrink items-stretch",
+						"session-topbar-terminal-region flex min-w-0 shrink items-stretch",
+						isSidebarCompact && isMac && "session-topbar-traffic-light-clearance-mac",
 						!isSidebarOpen && isMac && "session-topbar-titlebar-clearance-mac",
 						!isSidebarOpen && isLinux && "session-topbar-titlebar-clearance-linux",
 					)}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -937,9 +937,9 @@ function ShellLayout() {
 						/>
 					) : null}
 					{/* Fixed macOS titlebar cluster beside the traffic lights — rendered
-              once here so the toggle/history buttons never move when the
-              sidebar collapses or expands. History arrows stay visible but
-              locked on the empty start page. MUST come after the drag strip
+              once here so the sidebar toggle never moves when the sidebar
+              collapses, compacts, or expands. History moves into the compact rail
+              and otherwise stays locked on the empty start page. MUST come after the drag strip
               (ShellTopbar or the welcome substitute) in the DOM: Electron
               builds the window-drag region in document order (drag rects add,
               no-drag rects subtract), so the cluster's no-drag holes only

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -549,8 +549,9 @@
 }
 
 /* Browser pressure keeps a 48px navigation rail in layout. Native macOS
- * traffic lights extend to the 72px titlebar boundary, so reserve only the
- * missing slice instead of applying the full off-canvas navigation clearance. */
+ * traffic lights extend to the 72px titlebar boundary, and the fixed sidebar
+ * toggle follows them. Reserve that missing slice plus the toggle and its gap
+ * instead of applying the full off-canvas navigation clearance. */
 .session-topbar-terminal-region {
 	transition: padding-left 280ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
@@ -574,7 +575,9 @@
 }
 
 .session-topbar-traffic-light-clearance-mac {
-	padding-left: calc(var(--size-titlebar-cluster-left) - var(--size-sidebar-icon));
+	padding-left: calc(
+		var(--size-titlebar-cluster-left) - var(--size-sidebar-icon) + var(--size-control-md) + var(--space-1)
+	);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Fixes #4695

## Summary

- keep the macOS/Linux sidebar toggle in the fixed titlebar when Browser pressure compacts the sidebar
- remove the duplicate toggle that previously appeared below the AO logo while retaining compact-rail history controls
- reserve compact macOS session-header space for the fixed toggle so terminal and chat tabs do not overlap it
- add macOS and Linux regression coverage for the stable toggle position

## Tests

- `npm test -- src/renderer` — 157 files, 2,322 tests passed
- `npm run frontend:typecheck`
- `npx vite build --config vite.renderer.config.ts`
- `git diff --check`

## Desktop check

Launched the real Electron checkout in isolated mode with renderer `http://localhost:5173` and daemon `127.0.0.1:3002`; the app loaded and successfully fetched projects/sessions. This macOS host marks the Electron window non-shareable, so an automated native-window screenshot was unavailable. The isolated app and daemon were stopped after the check.

## Risk

Low. The behavior change is limited to Browser-driven compact sidebar mode. Compact history controls remain in the rail, and platform-specific tests cover both macOS and Linux toggle geometry.