### PR TITLE
fix(orchestrator): give replacement a lifecycle timeout

### DIFF
--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -158,6 +158,11 @@ var remotePayloadAllowlist = map[string]map[string]struct{}{
 		"kind":                   {},
 		"since_first_project_ms": {},
 	},
+	"ao.orchestrator.spawn_requested": {
+		"clean":  {},
+		"mode":   {},
+		"source": {},
+	},
 	"ao.review.triggered": {
 		"created_runs": {},
 		"harness":      {},

--- a/backend/internal/adapters/telemetry/posthog_test.go
+++ b/backend/internal/adapters/telemetry/posthog_test.go
@@ -297,6 +297,21 @@ func TestReviewPayloadAllowlistCoversTheReviewFunnel(t *testing.T) {
 	}
 }
 
+func TestOrchestratorSpawnPayloadKeepsAttributionFields(t *testing.T) {
+	got := sanitizeRemotePayload("ao.orchestrator.spawn_requested", map[string]any{
+		"clean":      true,
+		"mode":       "tui",
+		"source":     "restart",
+		"project_id": "must-not-export",
+	})
+	if got["clean"] != true || got["mode"] != "tui" || got["source"] != "restart" {
+		t.Fatalf("orchestrator attribution fields were dropped: %#v", got)
+	}
+	if _, ok := got["project_id"]; ok {
+		t.Fatalf("identifying project id survived sanitization: %#v", got)
+	}
+}
+
 // Review payloads carry counts, enums, and booleans. The review body is
 // reviewer prose about someone's code; the PR URL and SHA identify the
 // repository. None of them may survive into an exported property.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -29,6 +29,11 @@ const (
 	// DefaultRequestTimeout bounds a single REST request. Long-lived terminal mux
 	// connections are mounted outside this timeout.
 	DefaultRequestTimeout = 60 * time.Second
+	// DefaultOrchestratorSpawnTimeout bounds project-orchestrator creation and
+	// replacement. A clean replacement performs both teardown and a full spawn,
+	// so the ordinary REST budget can expire after the old coordinator is gone
+	// but before its successor exists.
+	DefaultOrchestratorSpawnTimeout = 3 * time.Minute
 	// DefaultShutdownTimeout is the hard cap on graceful shutdown. After this
 	// the process exits even if connections are still draining.
 	DefaultShutdownTimeout = 10 * time.Second

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -3,6 +3,7 @@ package httpd
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -130,6 +131,7 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 			Svc:           deps.Sessions,
 			Activity:      deps.Activity,
 			Usage:         deps.UsageHooks,
+			Telemetry:     deps.Telemetry,
 			Attachments:   attachmentstore.New(cfg.DataDir),
 			PreviewServer: deps.PreviewServer,
 			Capabilities:  deps.SessionCapabilities,
@@ -164,7 +166,7 @@ func (a *API) Register(root chi.Router) {
 		r.Get("/openapi.yaml", apispec.ServeYAML)
 
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.Timeout(timeout))
+			r.Use(restTimeout(timeout))
 			r.Use(presenceMiddleware(a.deps.Presence))
 			a.agents.Register(r)
 			a.projects.Register(r)
@@ -190,6 +192,28 @@ func (a *API) Register(root chi.Router) {
 		a.sessions.RegisterStreams(r)
 		a.events.Register(r)
 	})
+}
+
+// restTimeout keeps ordinary REST requests under the configured budget while
+// allowing an orchestrator spawn enough time to retire the current coordinator
+// and create its successor. The operation remains bounded; it simply must not
+// inherit a deadline shorter than its normal two-phase lifecycle.
+func restTimeout(ordinary time.Duration) func(http.Handler) http.Handler {
+	orchestrator := ordinary
+	if orchestrator < config.DefaultOrchestratorSpawnTimeout {
+		orchestrator = config.DefaultOrchestratorSpawnTimeout
+	}
+	return func(next http.Handler) http.Handler {
+		ordinaryHandler := middleware.Timeout(ordinary)(next)
+		orchestratorHandler := middleware.Timeout(orchestrator)(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/api/v1/orchestrators" {
+				orchestratorHandler.ServeHTTP(w, r)
+				return
+			}
+			ordinaryHandler.ServeHTTP(w, r)
+		})
+	}
 }
 
 // notFoundJSON returns the locked envelope for unmatched routes. Chi's default

--- a/backend/internal/httpd/api_timeout_test.go
+++ b/backend/internal/httpd/api_timeout_test.go
@@ -11,18 +11,126 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
 )
 
 type timeoutProbeSessionService struct {
 	controllers.SessionService
-	genericBudget chan time.Duration
-	switchBudget  chan time.Duration
+	genericBudget      chan time.Duration
+	switchBudget       chan time.Duration
+	orchestratorBudget chan time.Duration
+	orchestratorDelay  time.Duration
+}
+
+func (s *timeoutProbeSessionService) SpawnOrchestrator(
+	ctx context.Context,
+	projectID domain.ProjectID,
+	_ bool,
+	_ domain.SessionMode,
+) (domain.Session, error) {
+	s.orchestratorBudget <- remainingRequestBudget(ctx)
+	select {
+	case <-time.After(s.orchestratorDelay):
+		now := time.Now().UTC()
+		return domain.Session{SessionRecord: domain.SessionRecord{
+			ID:        domain.SessionID(string(projectID) + "-orchestrator"),
+			ProjectID: projectID,
+			Kind:      domain.KindOrchestrator,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}}, nil
+	case <-ctx.Done():
+		return domain.Session{}, ctx.Err()
+	}
 }
 
 func (s *timeoutProbeSessionService) List(ctx context.Context, _ sessionsvc.ListFilter) ([]domain.Session, error) {
 	s.genericBudget <- remainingRequestBudget(ctx)
 	return nil, nil
+}
+
+func TestSpawnOrchestratorRouteOutlivesOrdinaryTimeout(t *testing.T) {
+	const configuredTimeout = 25 * time.Millisecond
+	svc := &timeoutProbeSessionService{
+		genericBudget:      make(chan time.Duration, 1),
+		switchBudget:       make(chan time.Duration, 1),
+		orchestratorBudget: make(chan time.Duration, 1),
+		orchestratorDelay:  2 * configuredTimeout,
+	}
+	router := NewRouterWithControl(
+		config.Config{RequestTimeout: configuredTimeout},
+		discardLogger(),
+		nil,
+		APIDeps{Sessions: svc},
+		ControlDeps{},
+	)
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/orchestrators",
+		bytes.NewBufferString(`{"projectId":"ao","clean":true}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("POST orchestrators status = %d, want 201; body=%s", response.Code, response.Body.String())
+	}
+
+	budget := <-svc.orchestratorBudget
+	if budget <= configuredTimeout {
+		t.Fatalf("orchestrator request budget = %s, want more than ordinary timeout %s", budget, configuredTimeout)
+	}
+	if budget > config.DefaultOrchestratorSpawnTimeout {
+		t.Fatalf("orchestrator request budget = %s, want no more than %s", budget, config.DefaultOrchestratorSpawnTimeout)
+	}
+}
+
+func TestSpawnOrchestratorRecordsRendererSource(t *testing.T) {
+	svc := &timeoutProbeSessionService{
+		orchestratorBudget: make(chan time.Duration, 1),
+	}
+	sink := &captureSink{}
+	router := NewRouterWithControl(
+		config.Config{},
+		discardLogger(),
+		nil,
+		APIDeps{Sessions: svc, Telemetry: sink},
+		ControlDeps{},
+	)
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/orchestrators",
+		bytes.NewBufferString(`{"projectId":"ao","clean":true,"source":"restart"}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("POST orchestrators status = %d, want 201; body=%s", response.Code, response.Body.String())
+	}
+
+	var got *ports.TelemetryEvent
+	for i := range sink.events {
+		if sink.events[i].Name == "ao.orchestrator.spawn_requested" {
+			got = &sink.events[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("telemetry events = %#v, want ao.orchestrator.spawn_requested", sink.events)
+	}
+	if got.ProjectID == nil || *got.ProjectID != "ao" {
+		t.Fatalf("project id = %#v, want ao", got.ProjectID)
+	}
+	if got.RequestID == "" {
+		t.Fatal("request id is empty")
+	}
+	if got.Payload["source"] != "restart" || got.Payload["clean"] != true {
+		t.Fatalf("payload = %#v, want source=restart clean=true", got.Payload)
+	}
 }
 
 func (s *timeoutProbeSessionService) SwitchAgent(

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -9019,6 +9019,17 @@ components:
           type: string
         projectId:
           type: string
+        source:
+          enum:
+          - board
+          - restore_dialog
+          - topbar
+          - sidebar
+          - project_add
+          - settings
+          - restart
+          - command_palette
+          type: string
       required:
       - projectId
       type: object

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1013,6 +1013,9 @@ type ReviewSessionIDParam struct {
 type SpawnOrchestratorRequest struct {
 	ProjectID domain.ProjectID `json:"projectId"`
 	Clean     bool             `json:"clean,omitempty"`
+	// Source identifies the renderer surface that initiated the request. It is
+	// diagnostic only and may be omitted by older or non-renderer clients.
+	Source string `json:"source,omitempty" enum:"board,restore_dialog,topbar,sidebar,project_add,settings,restart,command_palette"`
 	// Mode applies only when this request creates a project orchestrator. An
 	// idempotent ensure returns the existing orchestrator unchanged, and a clean
 	// replacement inherits the existing orchestrator's currently committed mode.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -22,6 +22,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/attachmentstore"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -150,6 +151,7 @@ type SessionsController struct {
 	Svc           SessionService
 	Activity      ActivityRecorder
 	Usage         UsageHookRecorder
+	Telemetry     ports.EventSink
 	Attachments   *attachmentstore.Store
 	PreviewServer ManagedPreviewServer
 	Capabilities  SessionCapabilityValidator
@@ -1547,6 +1549,12 @@ func (c *SessionsController) spawnOrchestrator(w http.ResponseWriter, r *http.Re
 			return
 		}
 	}
+	source, validSource := orchestratorSpawnSource(in.Source)
+	if !validSource {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "validation", "ORCHESTRATOR_SOURCE_INVALID", "source is not a recognized orchestrator spawn source", nil)
+		return
+	}
+	c.emitOrchestratorSpawnRequested(r, in, source)
 	sess, err := c.Svc.SpawnOrchestrator(r.Context(), in.ProjectID, in.Clean, in.Mode)
 	if err != nil {
 		envelope.WriteError(w, r, err)
@@ -1554,6 +1562,49 @@ func (c *SessionsController) spawnOrchestrator(w http.ResponseWriter, r *http.Re
 	}
 	envelope.WriteJSON(w, http.StatusCreated, SpawnOrchestratorResponse{
 		Orchestrator: OrchestratorResponse{ID: sess.ID, ProjectID: sess.ProjectID},
+	})
+}
+
+var orchestratorSpawnSources = map[string]struct{}{
+	"board":           {},
+	"restore_dialog":  {},
+	"topbar":          {},
+	"sidebar":         {},
+	"project_add":     {},
+	"settings":        {},
+	"restart":         {},
+	"command_palette": {},
+}
+
+func orchestratorSpawnSource(raw string) (string, bool) {
+	source := strings.TrimSpace(raw)
+	if source == "" {
+		return "unknown", true
+	}
+	_, ok := orchestratorSpawnSources[source]
+	return source, ok
+}
+
+func (c *SessionsController) emitOrchestratorSpawnRequested(r *http.Request, in SpawnOrchestratorRequest, source string) {
+	if c.Telemetry == nil {
+		return
+	}
+	projectID := in.ProjectID
+	payload := map[string]any{
+		"clean":  in.Clean,
+		"source": source,
+	}
+	if in.Mode != "" {
+		payload["mode"] = string(in.Mode)
+	}
+	c.Telemetry.Emit(context.Background(), ports.TelemetryEvent{
+		Name:       "ao.orchestrator.spawn_requested",
+		Source:     "sessions_controller",
+		OccurredAt: time.Now().UTC(),
+		Level:      ports.TelemetryLevelInfo,
+		ProjectID:  &projectID,
+		RequestID:  middleware.GetReqID(r.Context()),
+		Payload:    payload,
 	})
 }
 

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -1307,6 +1307,15 @@ func TestSessionsAPI_OrchestratorRejectsUnknownExplicitMode(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusBadRequest, "SESSION_MODE_INVALID")
 }
 
+func TestSessionsAPI_OrchestratorRejectsUnknownSource(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/orchestrators",
+		`{"projectId":"ao","source":"mystery"}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "ORCHESTRATOR_SOURCE_INVALID")
+}
+
 func TestSessionsAPI_PreviewDiscoversAndServesStaticIndex(t *testing.T) {
 	svc := newFakeSessionService()
 	workspace := t.TempDir()

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3141,6 +3141,8 @@ export interface components {
             /** @enum {string} */
             mode?: "chat" | "tui";
             projectId: string;
+            /** @enum {string} */
+            source?: "board" | "restore_dialog" | "topbar" | "sidebar" | "project_add" | "settings" | "restart" | "command_palette";
         };
         SpawnOrchestratorResponse: {
             orchestrator: components["schemas"]["OrchestratorResponse"];

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -1457,7 +1457,7 @@ describe("ProjectSettingsForm", () => {
 		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
 		expect(postMock).toHaveBeenCalledWith("/api/v1/orchestrators", {
-			body: { projectId: "proj-1", clean: true },
+			body: { projectId: "proj-1", clean: true, source: "settings" },
 		});
 		await expectReplacementNavigation();
 	});

--- a/frontend/src/renderer/lib/spawn-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/spawn-orchestrator.test.ts
@@ -43,7 +43,7 @@ describe("spawnOrchestrator", () => {
 		const id = await spawnOrchestrator("proj", "restore_dialog", true);
 		expect(id).toBe("proj-9");
 		expect(apiClient.POST).toHaveBeenCalledWith("/api/v1/orchestrators", {
-			body: { projectId: "proj", clean: true },
+			body: { projectId: "proj", clean: true, source: "restore_dialog" },
 		});
 	});
 
@@ -55,7 +55,7 @@ describe("spawnOrchestrator", () => {
 		});
 		await spawnOrchestrator("proj", "board");
 		expect(apiClient.POST).toHaveBeenCalledWith("/api/v1/orchestrators", {
-			body: { projectId: "proj", clean: false },
+			body: { projectId: "proj", clean: false, source: "board" },
 		});
 	});
 
@@ -67,7 +67,7 @@ describe("spawnOrchestrator", () => {
 		});
 		await spawnOrchestrator("proj", "board", false, "tui");
 		expect(apiClient.POST).toHaveBeenCalledWith("/api/v1/orchestrators", {
-			body: { projectId: "proj", clean: false, mode: "tui" },
+			body: { projectId: "proj", clean: false, source: "board", mode: "tui" },
 		});
 	});
 

--- a/frontend/src/renderer/lib/spawn-orchestrator.ts
+++ b/frontend/src/renderer/lib/spawn-orchestrator.ts
@@ -50,7 +50,7 @@ export async function spawnOrchestrator(
 	void captureRendererEvent("ao.renderer.orchestrator_spawn_requested", { project_id: projectId, source });
 	try {
 		const { data, error, response } = await apiClient.POST("/api/v1/orchestrators", {
-			body: { projectId, clean, ...(mode ? { mode } : {}) },
+			body: { projectId, clean, source, ...(mode ? { mode } : {}) },
 		});
 
 		if (error || !data?.orchestrator?.id) {


### PR DESCRIPTION
## Summary

- give `POST /api/v1/orchestrators` a dedicated three-minute lifecycle bound while ordinary REST requests retain their configured timeout
- carry the closed renderer source enum into the daemon request and persist a correlated request event locally
- preserve safe source, clean, and mode fields in remote diagnostics and regenerate the API contract

## Why

In [#4700](https://github.com/Untrivial-ai/agent-orchestrator/issues/4700), a clean replacement began retiring a live Codex coordinator. The ordinary 60-second request deadline returned HTTP 500 after 62 seconds, retirement finished afterward, and that request created no successor orchestrator.

This fixes the exact observed timeout path and makes future initiating UI surfaces attributable. It does not make replacement atomic for every possible teardown or spawn failure; #4700 remains the tracker for that broader recovery path.

## Tests

- `npm run api`
- focused frontend tests: 43 passed
- `npm run frontend:typecheck`
- product UI checks: 118 tests, typecheck, build passed
- `go test ./internal/httpd/... ./internal/adapters/telemetry -count=1`
- `go vet ./internal/httpd/... ./internal/adapters/telemetry`
- isolated `go test ./...`
- `go build ./...`
- golangci-lint v2.12.2: 0 issues

## Risk

The operation remains synchronous and has a hard three-minute ceiling. Generic recovery after an arbitrary post-retirement failure is intentionally not attempted here because relaunching the predecessor under changed project settings can create a mismatched or duplicate coordinator.

Refs #4700
