### PR TITLE
fix(modelcatalog): explain WaitDelay pipe-stall failures in model discovery

### DIFF
--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -302,6 +302,9 @@ func modelDiscoveryError(runCtx context.Context, agentID string, commandErr erro
 	if errors.Is(runCtx.Err(), context.Canceled) {
 		return fmt.Errorf("%s model discovery canceled: %w", agentID, context.Canceled)
 	}
+	if errors.Is(commandErr, exec.ErrWaitDelay) {
+		return fmt.Errorf("%s model discovery timed out: the agent CLI exited but left a descendant process holding the output pipe (WaitDelay %s exceeded)", agentID, commandTerminationWait)
+	}
 	return fmt.Errorf("%s model discovery: %w", agentID, commandErr)
 }
 

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +49,56 @@ func TestModelDiscoveryErrorExplainsTimeout(t *testing.T) {
 	err := modelDiscoveryError(deadlineCtx, "kilocode", errors.New("signal: killed"))
 	if !strings.Contains(err.Error(), "kilocode model discovery timed out after 20s") {
 		t.Fatalf("error = %q, want clear timeout", err)
+	}
+}
+
+// TestModelDiscoveryErrorExplainsWaitDelayExpiration covers the failure shape
+// reported when an agent CLI exits promptly but leaves a descendant holding
+// the output pipe open: CombinedOutput returns exec.ErrWaitDelay while the
+// discovery context is still live, so the message must explain the pipe stall
+// instead of surfacing the raw sentinel ("agy model discovery: exec: WaitDelay
+// expired before I/O complete").
+func TestModelDiscoveryErrorExplainsWaitDelayExpiration(t *testing.T) {
+	err := modelDiscoveryError(context.Background(), "agy", exec.ErrWaitDelay)
+	if err == nil {
+		t.Fatal("error = nil, want WaitDelay explanation")
+	}
+	if !strings.Contains(err.Error(), "agy model discovery timed out") {
+		t.Fatalf("error = %q, want the timeout prefix", err)
+	}
+	if !strings.Contains(err.Error(), "holding the output pipe") {
+		t.Fatalf("error = %q, want the pipe-holding explanation", err)
+	}
+	if strings.Contains(err.Error(), "WaitDelay expired before I/O complete") {
+		t.Fatalf("error = %q, want the raw sentinel rewritten, not passed through", err)
+	}
+}
+
+// TestDiscoverRewritesWaitDelayFromARealCommand runs discovery against a fake
+// agent binary that exits immediately while a backgrounded descendant keeps
+// stdout/stderr open — the same shape as agy (Antigravity), whose launcher
+// leaves estate processes behind. CombinedOutput must terminate via WaitDelay
+// and the surfaced error must describe the pipe stall.
+func TestDiscoverRewritesWaitDelayFromARealCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fixture needs POSIX")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fake-agy")
+	script := "#!/bin/sh\n(sleep 5) &\nexit 0\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	gotCatalog, gotErr := Discover(context.Background(), "agy", fake, dir, nil)
+	if gotErr == nil {
+		t.Fatalf("Discover err = nil, want WaitDelay error; catalog = %#v", gotCatalog)
+	}
+	if !strings.Contains(gotErr.Error(), "agy model discovery timed out") {
+		t.Fatalf("Discover err = %q, want the timeout prefix", gotErr)
+	}
+	if !strings.Contains(gotErr.Error(), "holding the output pipe") {
+		t.Fatalf("Discover err = %q, want the pipe-holding explanation", gotErr)
 	}
 }
 


### PR DESCRIPTION
Fixes #4702

## Summary

- `modelDiscoveryError()` now recognizes `exec.ErrWaitDelay` and rewrites it into a human-readable explanation instead of leaking the raw Go sentinel (`agy model discovery: exec: WaitDelay expired before I/O complete`) into the New Task dialog.
- This failure shape occurs when an agent CLI exits promptly but leaves a descendant process (agy/Antigravity's estate processes are the known case) holding the discovery command's output pipe: `CombinedOutput` gives up after the 2s `WaitDelay` while the 20s discovery context is still live, so the existing `DeadlineExceeded`/`Canceled` branches never match.
- New message: `<agent> model discovery timed out: the agent CLI exited but left a descendant process holding the output pipe (WaitDelay 2s exceeded)`.

## Test

- `TestModelDiscoveryErrorExplainsWaitDelayExpiration` — sentinel mapping unit test (raw sentinel must not pass through).
- `TestDiscoverRewritesWaitDelayFromARealCommand` — real-command fixture (`/bin/sh` script that exits 0 with a backgrounded `(sleep 5) &` descendant) asserting `Discover` surfaces the rewritten message. Runtime ≈2s, matching the WaitDelay window.
- `cd backend && go build ./... && go vet ./internal/adapters/agent/modelcatalog/ && go test ./internal/adapters/agent/... ./internal/service/agent/...` — all green.
