### PR TITLE
fix(frontend): prevent switch-agent dialog auto-dismiss race with dropdown menu

### DIFF
--- a/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
+++ b/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
@@ -114,6 +114,64 @@ beforeEach(() => {
 	postMock.mockReset();
 });
 
+// JSDOM reports animationName "none" everywhere, so Radix Presence unmounts a
+// closing menu immediately instead of retaining it for the 100ms
+// `animate-popover-out` exit — which is exactly the real-renderer window this
+// suite exists to cover. Make the exit visible to Presence only, scoped to
+// menu content and derived from its own `data-state` just like the CSS pair
+// `data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out`.
+// Presence needs the two names to DIFFER: it compares the name it saw while
+// mounted against the one at close time to decide an animation is running.
+// Scoped to this file on purpose: a global stub would flip every menu in every
+// suite into retained-until-animationend mode.
+function fakeMenuExitAnimation(): () => void {
+	const original = window.getComputedStyle;
+	const real = original.bind(window);
+	Object.defineProperty(window, "getComputedStyle", {
+		configurable: true,
+		writable: true,
+		value: (element: Element, pseudo?: string | null) => {
+			const styles = real(element, pseudo);
+			if (element.getAttribute("role") !== "menu") return styles;
+			return new Proxy(styles, {
+				get(target, property) {
+					if (property === "animationName") {
+						return element.getAttribute("data-state") === "closed"
+							? "animate-popover-out"
+							: "animate-popover-in";
+					}
+					const value = Reflect.get(target, property, target);
+					return typeof value === "function" ? (value as () => unknown).bind(target) : value;
+				},
+			}) as CSSStyleDeclaration;
+		},
+	});
+	return () => {
+		Object.defineProperty(window, "getComputedStyle", {
+			configurable: true,
+			writable: true,
+			value: original,
+		});
+	};
+}
+
+// jsdom has no AnimationEvent constructor. Presence only reads
+// `event.animationName` off the event and requires `event.target === node`,
+// so a plain Event with the property defined is enough.
+function dispatchAnimationEnd(element: Element, animationName: string) {
+	const event = new Event("animationend");
+	Object.defineProperty(event, "animationName", { value: animationName });
+	element.dispatchEvent(event);
+}
+
+// The spawning menu's teardown has fully completed: content unmounted (after
+// its exit animation in a real renderer), and Radix's deferred FocusScope
+// restore — dispatched one macrotask after the unmount — has run.
+async function waitForMenuTeardown() {
+	await waitFor(() => expect(screen.queryByRole("menu")).not.toBeInTheDocument());
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("SessionActionsMenu > Switch agent", () => {
 	it("keeps the switch-agent dialog open after choosing it from the actions menu", async () => {
 		renderHarness();
@@ -130,6 +188,48 @@ describe("SessionActionsMenu > Switch agent", () => {
 		expect(dialog).toBeInTheDocument();
 	});
 
+	// The reviewer's exact real-renderer timeline: Radix Presence retains the
+	// closing menu for the whole `animate-popover-out` exit (100ms), and only
+	// when that animation ends does the content unmount and its FocusScope run
+	// the deferred focus restore. The dismissal suppression must survive that
+	// whole sequence — a guard expiring early lets the late restore re-dismiss
+	// the dialog, and jsdom's default "no animations" behavior hides the bug.
+	//
+	// While the retained menu is still mounted, its `hideOthers` a11y lock
+	// (undone only on unmount) marks everything outside it aria-hidden — the
+	// dialog included. That is real-renderer behavior too, so the pre-teardown
+	// queries use hidden:true to see through it; after the teardown they are
+	// back in the accessible tree.
+	it("keeps the dialog open through the menu's retained exit animation and focus restore", async () => {
+		const restoreStyles = fakeMenuExitAnimation();
+		try {
+			renderHarness();
+
+			await userEvent.click(await screen.findByRole("button", { name: "Session actions" }));
+			await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
+			const dialog = await screen.findByRole("dialog", { name: "Switch agent", hidden: true });
+
+			// Presence is holding the content for the animate-popover-out exit...
+			const menu = screen.getByRole("menu");
+			expect(menu.getAttribute("data-state")).toBe("closed");
+			// ...and focus has already moved into the dialog, not back to the trigger.
+			expect(dialog.contains(document.activeElement)).toBe(true);
+			expect(document.activeElement).not.toBe(screen.getByRole("button", { name: "Session actions", hidden: true }));
+
+			// Only now does the menu unmount and run the deferred FocusScope
+			// restore that used to re-dismiss the dialog.
+			dispatchAnimationEnd(menu, "animate-popover-out");
+			await waitForMenuTeardown();
+
+			// Post-animation state: the dialog survived the genuine teardown.
+			expect(screen.getByRole("dialog", { name: "Switch agent" })).toBe(dialog);
+			expect(dialog.contains(document.activeElement)).toBe(true);
+			expect(document.activeElement).not.toBe(screen.getByRole("button", { name: "Session actions" }));
+		} finally {
+			restoreStyles();
+		}
+	});
+
 	it("still closes the dialog on a genuine outside click", async () => {
 		renderHarness();
 
@@ -137,9 +237,9 @@ describe("SessionActionsMenu > Switch agent", () => {
 		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
 		await screen.findByRole("dialog", { name: "Switch agent" });
 
-		// Let any open-time transition settle, then click somewhere genuinely
+		// Let the opening menu's teardown settle, then click somewhere genuinely
 		// outside the dialog — this must still dismiss it.
-		await new Promise((resolve) => requestAnimationFrame(resolve));
+		await waitForMenuTeardown();
 		await userEvent.click(document.body);
 
 		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
@@ -156,8 +256,11 @@ describe("SessionActionsMenu > Switch agent", () => {
 		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
 		await screen.findByRole("dialog", { name: "Switch agent" });
 
-		// Let the opening-race window close before the later interaction.
-		await new Promise((resolve) => setTimeout(resolve, 150));
+		// Let the opening menu's teardown close the exemption before the later
+		// interaction — and prove the dialog survived that settle, so a
+		// prematurely-disarmed guard cannot hide behind the dismissal below.
+		await waitForMenuTeardown();
+		expect(screen.getByRole("dialog", { name: "Switch agent" })).toBeInTheDocument();
 
 		await userEvent.click(screen.getByRole("button", { name: "Session actions" }));
 
@@ -174,7 +277,8 @@ describe("SessionActionsMenu > Switch agent", () => {
 		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
 		await screen.findByRole("dialog", { name: "Switch agent" });
 
-		await new Promise((resolve) => setTimeout(resolve, 150));
+		await waitForMenuTeardown();
+		expect(screen.getByRole("dialog", { name: "Switch agent" })).toBeInTheDocument();
 
 		// Radix returns focus to the trigger when the menu closes, so blur first
 		// to make the refocus an actual focus change (a fresh focusin outside
@@ -188,7 +292,8 @@ describe("SessionActionsMenu > Switch agent", () => {
 
 	// Suppressing the opening-race dismissal must not leave keyboard focus
 	// stranded on the external session-actions trigger: once the opening
-	// focus race has settled, focus has to live inside the opened dialog.
+	// menu's teardown has fully settled, focus has to live inside the opened
+	// dialog.
 	it("moves focus into the opened dialog", async () => {
 		renderHarness();
 
@@ -196,11 +301,9 @@ describe("SessionActionsMenu > Switch agent", () => {
 		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
 		const dialog = await screen.findByRole("dialog", { name: "Switch agent" });
 
-		// Let the opening focus race (dialog FocusScope vs. the closing
-		// menu's focus return) settle across the same couple of frames the
-		// opening-race exemption covers.
-		await new Promise((resolve) => requestAnimationFrame(resolve));
-		await new Promise((resolve) => requestAnimationFrame(resolve));
+		// Let the opening focus race (dialog FocusScope vs. the closing menu's
+		// deferred focus restore) settle through the menu's full teardown.
+		await waitForMenuTeardown();
 
 		await waitFor(() => expect(dialog).toContainElement(document.activeElement as HTMLElement | null));
 		expect(document.activeElement).not.toBe(screen.getByRole("button", { name: "Session actions" }));

--- a/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
+++ b/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
@@ -144,4 +144,45 @@ describe("SessionActionsMenu > Switch agent", () => {
 
 		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
 	});
+
+	// The opening-race exemption is scoped to the opening interaction only.
+	// Once the dismissed menu's teardown has settled, the session actions
+	// trigger is a genuine outside element again: clicking it (to reopen the
+	// menu) must dismiss the dialog instead of being swallowed.
+	it("dismisses the dialog when the actions-menu trigger is clicked again later", async () => {
+		renderHarness();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Session actions" }));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
+		await screen.findByRole("dialog", { name: "Switch agent" });
+
+		// Let the opening-race window close before the later interaction.
+		await new Promise((resolve) => setTimeout(resolve, 150));
+
+		await userEvent.click(screen.getByRole("button", { name: "Session actions" }));
+
+		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+	});
+
+	// Keyboard focus: once the opening interaction has settled, moving focus
+	// to an element outside the non-modal dialog is a genuine outside focus
+	// interaction and must dismiss the dialog rather than be suppressed.
+	it("dismisses the dialog when focus moves outside it later", async () => {
+		renderHarness();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Session actions" }));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
+		await screen.findByRole("dialog", { name: "Switch agent" });
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+
+		// Radix returns focus to the trigger when the menu closes, so blur first
+		// to make the refocus an actual focus change (a fresh focusin outside
+		// the dialog's layer).
+		const trigger = screen.getByRole("button", { name: "Session actions" });
+		trigger.blur();
+		trigger.focus();
+
+		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+	});
 });

--- a/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
+++ b/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
@@ -185,4 +185,24 @@ describe("SessionActionsMenu > Switch agent", () => {
 
 		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
 	});
+
+	// Suppressing the opening-race dismissal must not leave keyboard focus
+	// stranded on the external session-actions trigger: once the opening
+	// focus race has settled, focus has to live inside the opened dialog.
+	it("moves focus into the opened dialog", async () => {
+		renderHarness();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Session actions" }));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
+		const dialog = await screen.findByRole("dialog", { name: "Switch agent" });
+
+		// Let the opening focus race (dialog FocusScope vs. the closing
+		// menu's focus return) settle across the same couple of frames the
+		// opening-race exemption covers.
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+
+		await waitFor(() => expect(dialog).toContainElement(document.activeElement as HTMLElement | null));
+		expect(document.activeElement).not.toBe(screen.getByRole("button", { name: "Session actions" }));
+	});
 });

--- a/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
+++ b/frontend/src/renderer/components/SessionActionsMenu.switch-agent.test.tsx
@@ -1,0 +1,147 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceSession } from "../types/workspace";
+import { SessionActionsMenu } from "./SessionActionsMenu";
+import { SwitchAgentDialog } from "./SwitchAgentDialog";
+import { TerminalSwitchAgentButton } from "./TerminalSwitchAgentButton";
+import { TooltipProvider } from "./ui/tooltip";
+
+// Regression test for: clicking "Switch agent" in the session actions dropdown
+// opened SwitchAgentDialog and then immediately closed it again in the same
+// tick. Root cause: DropdownMenuItem's onSelect closes the parent
+// DropdownMenu (Radix default, no preventDefault), and SwitchAgentDialog is
+// non-modal (Dialog modal={false}), so its Radix DismissableLayer treats the
+// residual pointer/focus activity from the closing dropdown as an
+// outside-interaction and dismisses the dialog right after it opens.
+//
+// Unlike TerminalSwitchAgentButton.test.tsx and SwitchAgentDialog.test.tsx,
+// this test drives the *real* DropdownMenuItem click path (variant="menu-item"
+// inside a real SessionActionsMenu/DropdownMenu) instead of mocking the
+// button out or opening the dialog directly with open=true.
+
+const { getMock, postMock } = vi.hoisted(() => ({
+	getMock: vi.fn(),
+	postMock: vi.fn(),
+}));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: {
+		GET: getMock,
+		POST: postMock,
+	},
+	apiErrorMessage: (error: unknown, fallback = "Request failed") => {
+		if (error instanceof Error) return error.message;
+		if (typeof error === "object" && error !== null && "message" in error) {
+			return String((error as { message: unknown }).message);
+		}
+		return fallback;
+	},
+}));
+
+const worker: WorkspaceSession = {
+	activity: { state: "active", lastActivityAt: "2026-06-10T00:00:00Z" },
+	branch: "ao/sess-1",
+	id: "sess-1",
+	kind: "worker",
+	provider: "claude-code",
+	prs: [],
+	status: "working",
+	title: "do the thing",
+	updatedAt: "2026-06-10T00:00:00Z",
+	workspaceId: "proj-1",
+	workspaceName: "my-app",
+};
+
+function SessionActionsMenuHarness() {
+	const [container, setContainer] = useState<HTMLDivElement | null>(null);
+	const [open, setOpen] = useState(false);
+	return (
+		<div className="relative" data-testid="terminal-container" ref={setContainer}>
+			<SessionActionsMenu>
+				<TerminalSwitchAgentButton
+					container={container}
+					onOpenChange={setOpen}
+					open={open}
+					session={worker}
+					switchError={null}
+					variant="menu-item"
+				/>
+			</SessionActionsMenu>
+			{container ? (
+				<SwitchAgentDialog container={container} onOpenChange={setOpen} open={open} session={worker} />
+			) : null}
+		</div>
+	);
+}
+
+function renderHarness() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<TooltipProvider>
+				<SessionActionsMenuHarness />
+			</TooltipProvider>
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	getMock.mockReset();
+	getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
+		if (path === "/api/v1/agents/{agent}/models") {
+			const agentId = options?.params?.path?.agent ?? "codex";
+			return {
+				data: {
+					agentId,
+					allowCustom: false,
+					fetchedAt: "2026-06-10T00:00:00Z",
+					models: [{ id: agentId === "codex" ? "gpt-5.4" : "claude-opus-4-6", label: "Default" }],
+					selectionMode: "catalog",
+					source: "test",
+					stale: false,
+				},
+				error: undefined,
+				response: { status: 200 },
+			};
+		}
+		return { data: { switches: [] }, error: undefined, response: { status: 200 } };
+	});
+	postMock.mockReset();
+});
+
+describe("SessionActionsMenu > Switch agent", () => {
+	it("keeps the switch-agent dialog open after choosing it from the actions menu", async () => {
+		renderHarness();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Session actions" }));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
+
+		// The bug: the dialog opens and is immediately dismissed by Radix's
+		// DismissableLayer reacting to the same click that closed the dropdown.
+		// Assert it is still there after the dropdown's close animation/focus
+		// return has had a chance to run.
+		const dialog = await screen.findByRole("dialog", { name: "Switch agent" });
+		await waitFor(() => expect(screen.getByRole("dialog", { name: "Switch agent" })).toBeInTheDocument());
+		expect(dialog).toBeInTheDocument();
+	});
+
+	it("still closes the dialog on a genuine outside click", async () => {
+		renderHarness();
+
+		await userEvent.click(await screen.findByRole("button", { name: "Session actions" }));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Switch agent" }));
+		await screen.findByRole("dialog", { name: "Switch agent" });
+
+		// Let any open-time transition settle, then click somewhere genuinely
+		// outside the dialog — this must still dismiss it.
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+		await userEvent.click(document.body);
+
+		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+	});
+});

--- a/frontend/src/renderer/components/SwitchAgentDialog.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { LoaderCircle, Repeat2, TriangleAlert, X } from "lucide-react";
-import { type FormEvent, useEffect, useRef, useState } from "react";
+import { type FormEvent, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	agentSwitchesQueryKey,
@@ -33,6 +33,7 @@ import {
 	DialogTitle,
 } from "./ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import { onMenuTeardownComplete } from "./ui/menu-focus";
 
 export const SWITCH_AGENT_OPTIONS = [
 	{ value: "claude-code", label: "Claude Code" },
@@ -57,32 +58,63 @@ function isFromDismissedMenuTrigger(target: EventTarget | null): boolean {
 	return Boolean(target.closest('[role="menuitem"], [role="menu"], [data-session-actions-trigger]'));
 }
 
-// The exemption only covers the opening interaction (the closing dropdown's
-// teardown in the ticks right after mount). After it settles, the menu and
-// trigger are ordinary outside elements again: suppressing outside events
-// from them for the dialog's whole lifetime would swallow later actions-menu
-// interactions and leave keyboard focus stranded outside the non-modal
-// dialog. Two animation frames are enough for the dropdown's same-tick
-// dismissal to have run; anything after that is a genuine outside event.
+// Longest teardown this can still be covering: Radix keeps a closing menu
+// mounted for the 100ms `animate-popover-out` exit, and its FocusScope defers
+// the focus restore one more tick after that. Safety net only — for opens with
+// no menu behind them (the toolbar icon button, an auto-open from a switch
+// error), where no teardown event will ever arrive.
+const OPENING_RACE_FALLBACK_MS = 300;
+
+// The exemption covers the opening interaction only, and only when the dialog
+// was genuinely opened from a menu: it is armed while the caret still sits on
+// the clicked menu item, and stays armed until that menu reports its teardown
+// as complete — content unmounted after the exit animation, deferred focus
+// restore dispatched. Radix keeps a closing menu mounted through its whole
+// exit animation, and only when that ends does its FocusScope restore focus to
+// the trigger, so any time-based window either expires too early (the real
+// renderer) or suppresses too long. After the teardown settles, the menu and
+// trigger are ordinary outside elements again: suppressing outside events from
+// them for the dialog's whole lifetime would swallow later actions-menu
+// interactions and leave keyboard focus stranded outside the non-modal dialog.
 function useSuppressOpeningRace(open: boolean) {
 	const suppressRef = useRef(false);
-	useEffect(() => {
-		if (!open) {
+	const armedMenuRef = useRef<Element | null>(null);
+	// Layout effect on purpose: the dialog's own FocusScope claims the caret
+	// from a passive effect, so by the time an ordinary effect ran, the clicked
+	// menu item would no longer be focused and the open could no longer be
+	// traced back to a menu.
+	useLayoutEffect(() => {
+		const disarm = () => {
 			suppressRef.current = false;
+			armedMenuRef.current = null;
+		};
+		if (!open) {
+			disarm();
 			return;
 		}
+		const active = document.activeElement;
+		if (!(active instanceof Element)) return;
+		const armed = active.closest('[role="menu"]');
+		if (!armed || !active.closest('[role="menuitem"], [role="menu"]')) return;
+		armedMenuRef.current = armed;
 		suppressRef.current = true;
-		let frames = 0;
-		let rafId = 0;
-		const tick = () => {
-			if (++frames >= 2) {
-				suppressRef.current = false;
-				return;
-			}
-			rafId = requestAnimationFrame(tick);
+		const unsubscribe = onMenuTeardownComplete(({ menu }) => {
+			const current = armedMenuRef.current;
+			if (current === null) return;
+			// Either the menu that opened this dialog finished its teardown, or it
+			// was replaced by another menu the user opened over the dialog and the
+			// armed one is already gone. Both mean the opening interaction is over.
+			if (menu !== current && current.isConnected) return;
+			// Microtask, not synchronous: an unprevented restore focuses the
+			// trigger inside this same macrotask, right after the dispatch, and
+			// that focusin is exactly what the guard exists to swallow.
+			queueMicrotask(disarm);
+		});
+		const fallback = window.setTimeout(disarm, OPENING_RACE_FALLBACK_MS);
+		return () => {
+			unsubscribe();
+			window.clearTimeout(fallback);
 		};
-		rafId = requestAnimationFrame(tick);
-		return () => cancelAnimationFrame(rafId);
 	}, [open]);
 	return suppressRef;
 }

--- a/frontend/src/renderer/components/SwitchAgentDialog.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.tsx
@@ -45,6 +45,18 @@ export function canSwitchAgentHarness(value: string): value is SwitchAgentHarnes
 	return SWITCH_AGENT_OPTIONS.some((option) => option.value === value);
 }
 
+// SwitchAgentDialog is opened from a DropdownMenuItem ("Switch agent" in the
+// session actions menu). Radix closes that dropdown on the same click that
+// opens this dialog; since the dialog is non-modal (see below), its
+// DismissableLayer would otherwise treat the dropdown's residual pointer/
+// focus activity as an outside interaction and dismiss the dialog right
+// after it opens. Ignore only outside events that originate from the
+// just-dismissed menu/trigger so a genuine outside click still closes it.
+function isFromDismissedMenuTrigger(target: EventTarget | null): boolean {
+	if (!(target instanceof Element)) return false;
+	return Boolean(target.closest('[role="menuitem"], [role="menu"], [data-session-actions-trigger]'));
+}
+
 function SwitchTargetPicker({
 	currentHarness,
 	disabled,
@@ -228,6 +240,12 @@ export function SwitchAgentDialog({ agentSwitch, container, open, session, onOpe
 						data-testid="switch-agent-terminal-backdrop"
 					/>
 				}
+				onFocusOutside={(event) => {
+					if (isFromDismissedMenuTrigger(event.target)) event.preventDefault();
+				}}
+				onPointerDownOutside={(event) => {
+					if (isFromDismissedMenuTrigger(event.target)) event.preventDefault();
+				}}
 				showCloseButton={false}
 				className="absolute left-1/2 top-1/2 z-overlay w-[min(var(--size-dialog-md),calc(100%-var(--space-8)))] max-w-none -translate-x-1/2 -translate-y-1/2 gap-0 overflow-hidden rounded-xl border border-border-strong bg-surface/95 p-0 text-foreground shadow-xl shadow-black/20 data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none"
 			>

--- a/frontend/src/renderer/components/SwitchAgentDialog.tsx
+++ b/frontend/src/renderer/components/SwitchAgentDialog.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { LoaderCircle, Repeat2, TriangleAlert, X } from "lucide-react";
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	agentSwitchesQueryKey,
@@ -55,6 +55,36 @@ export function canSwitchAgentHarness(value: string): value is SwitchAgentHarnes
 function isFromDismissedMenuTrigger(target: EventTarget | null): boolean {
 	if (!(target instanceof Element)) return false;
 	return Boolean(target.closest('[role="menuitem"], [role="menu"], [data-session-actions-trigger]'));
+}
+
+// The exemption only covers the opening interaction (the closing dropdown's
+// teardown in the ticks right after mount). After it settles, the menu and
+// trigger are ordinary outside elements again: suppressing outside events
+// from them for the dialog's whole lifetime would swallow later actions-menu
+// interactions and leave keyboard focus stranded outside the non-modal
+// dialog. Two animation frames are enough for the dropdown's same-tick
+// dismissal to have run; anything after that is a genuine outside event.
+function useSuppressOpeningRace(open: boolean) {
+	const suppressRef = useRef(false);
+	useEffect(() => {
+		if (!open) {
+			suppressRef.current = false;
+			return;
+		}
+		suppressRef.current = true;
+		let frames = 0;
+		let rafId = 0;
+		const tick = () => {
+			if (++frames >= 2) {
+				suppressRef.current = false;
+				return;
+			}
+			rafId = requestAnimationFrame(tick);
+		};
+		rafId = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(rafId);
+	}, [open]);
+	return suppressRef;
 }
 
 function SwitchTargetPicker({
@@ -173,6 +203,7 @@ export function SwitchAgentDialog({ agentSwitch, container, open, session, onOpe
 	);
 	const [refreshingRecovery, setRefreshingRecovery] = useState(false);
 	const operationPending = admissionPending || recoverAgentSwitch.isPending;
+	const suppressOpeningRace = useSuppressOpeningRace(open);
 	useEffect(() => {
 		setTargetHarness(session.provider === "claude-code" ? "codex" : "claude-code");
 		setModel("");
@@ -241,10 +272,10 @@ export function SwitchAgentDialog({ agentSwitch, container, open, session, onOpe
 					/>
 				}
 				onFocusOutside={(event) => {
-					if (isFromDismissedMenuTrigger(event.target)) event.preventDefault();
+					if (suppressOpeningRace.current && isFromDismissedMenuTrigger(event.target)) event.preventDefault();
 				}}
 				onPointerDownOutside={(event) => {
-					if (isFromDismissedMenuTrigger(event.target)) event.preventDefault();
+					if (suppressOpeningRace.current && isFromDismissedMenuTrigger(event.target)) event.preventDefault();
 				}}
 				showCloseButton={false}
 				className="absolute left-1/2 top-1/2 z-overlay w-[min(var(--size-dialog-md),calc(100%-var(--space-8)))] max-w-none -translate-x-1/2 -translate-y-1/2 gap-0 overflow-hidden rounded-xl border border-border-strong bg-surface/95 p-0 text-foreground shadow-xl shadow-black/20 data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none"

--- a/frontend/src/renderer/components/ui/menu-focus.test.tsx
+++ b/frontend/src/renderer/components/ui/menu-focus.test.tsx
@@ -1,6 +1,11 @@
 import { render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { keepFocusOnOpenedSurface, useMenuReturnTarget } from "./menu-focus";
+import {
+	composeMenuCloseAutoFocus,
+	type MenuTeardownDetail,
+	onMenuTeardownComplete,
+	useMenuReturnTarget,
+} from "./menu-focus";
 
 const MENU_ID = "menu-content";
 
@@ -59,7 +64,9 @@ async function openMenu() {
 /** Radix dispatches its unmount handler on the content element. */
 function closeMenu(menu: HTMLElement) {
 	const event = new CustomEvent("focusScope.autoFocusOnUnmount", { cancelable: true });
-	menu.addEventListener("focusScope.autoFocusOnUnmount", keepFocusOnOpenedSurface as EventListener, {
+	// The full composition, the way ui/dropdown-menu.tsx wires it — the hand-off
+	// guard plus the teardown report.
+	menu.addEventListener("focusScope.autoFocusOnUnmount", composeMenuCloseAutoFocus() as EventListener, {
 		once: true,
 	});
 	menu.dispatchEvent(event);
@@ -178,5 +185,53 @@ describe("keepFocusOnOpenedSurface", () => {
 		await new Promise((resolve) => setTimeout(resolve, 10));
 		expect(document.activeElement).toBe(elsewhere);
 		expect(document.activeElement).not.toBe(trigger);
+	});
+});
+
+// The teardown report is how a surface opened from a menu item (e.g. the
+// switch-agent dialog) learns that the opening interaction is over: the menu
+// content is gone and the deferred focus restore has been decided.
+describe("menu teardown signal", () => {
+	it("reports the menu and its trigger once the restore has been decided", async () => {
+		const { menu, trigger } = await openMenu();
+		const field = openDialogField();
+		const seen: MenuTeardownDetail[] = [];
+		const unsubscribe = onMenuTeardownComplete((detail) => seen.push(detail));
+
+		const event = closeMenu(menu); // keepFocusOnOpenedSurface preventDefaults the restore
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(seen).toHaveLength(1);
+		expect(seen[0].menu).toBe(menu);
+		expect(seen[0].trigger).toBe(trigger);
+		unsubscribe();
+		field.remove();
+	});
+
+	it("stops reporting once the listener unsubscribes", async () => {
+		const { menu } = await openMenu();
+		const field = openDialogField();
+		const seen: MenuTeardownDetail[] = [];
+		const unsubscribe = onMenuTeardownComplete((detail) => seen.push(detail));
+
+		closeMenu(menu);
+		unsubscribe();
+		closeMenu(menu);
+
+		expect(seen).toHaveLength(1);
+		field.remove();
+	});
+
+	it("reports even when nothing borrowed the caret", async () => {
+		const { menu } = await openMenu();
+		const seen: MenuTeardownDetail[] = [];
+		const unsubscribe = onMenuTeardownComplete((detail) => seen.push(detail));
+
+		// Radix restores focus to the trigger itself in this case.
+		expect(closeMenu(menu).defaultPrevented).toBe(false);
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0].menu).toBe(menu);
+		unsubscribe();
 	});
 });

--- a/frontend/src/renderer/components/ui/menu-focus.ts
+++ b/frontend/src/renderer/components/ui/menu-focus.ts
@@ -31,6 +31,36 @@ let capturedForMenu: HTMLElement | null = null;
 let pending: { borrower: Element; target: HTMLElement } | null = null;
 
 /**
+ * Published once a menu's teardown has genuinely finished: Presence let go of
+ * the content and the FocusScope restore Radix defers by a tick has been
+ * dispatched and either allowed or prevented. That is the last moment a closing
+ * menu can still move the caret or emit outside-interactions, so anything that
+ * opened a surface from it can stop covering for it here.
+ */
+export type MenuTeardownDetail = {
+	/** The menu content node — detached from the document by the time this fires. */
+	menu: HTMLElement;
+	/** Where Radix would have restored focus, or null when there was nowhere to go. */
+	trigger: HTMLElement | null;
+};
+
+type MenuTeardownListener = (detail: MenuTeardownDetail) => void;
+const teardownListeners = new Set<MenuTeardownListener>();
+
+export function onMenuTeardownComplete(listener: MenuTeardownListener): () => void {
+	teardownListeners.add(listener);
+	return () => {
+		teardownListeners.delete(listener);
+	};
+}
+
+function publishMenuTeardownComplete(menu: HTMLElement) {
+	const detail: MenuTeardownDetail = { menu, trigger: menuReturnTarget };
+	// Copy before iterating so a listener can unsubscribe re-entrantly.
+	for (const listener of [...teardownListeners]) listener(detail);
+}
+
+/**
  * Remember, while the menu is open, where focus should end up once it is done
  * with it. A dropdown returns to its trigger, which is only discoverable by its
  * `aria-controls` link while the menu is open; a context menu has no such
@@ -130,11 +160,13 @@ function handleFocusRelease(event: FocusEvent) {
 	);
 }
 
-/** Runs the caller's own handler first, then the hand-off guard. */
+/** Runs the caller's own handler first, then the hand-off guard, then reports the teardown. */
 export function composeMenuCloseAutoFocus(handler?: (event: Event) => void) {
 	return (event: Event) => {
 		handler?.(event);
 		keepFocusOnOpenedSurface(event);
+		const menu = event.currentTarget ?? event.target;
+		if (menu instanceof HTMLElement) publishMenuTeardownComplete(menu);
 	};
 }
 


### PR DESCRIPTION
Closes #4710.

## Bug

Clicking **"Switch agent"** in the session actions dropdown opened `SwitchAgentDialog` and then immediately closed it again in the same tick — the dialog flashed and disappeared instead of staying open.

## Root cause

Two independent Radix dismissal mechanisms fire on the same click:

1. `TerminalSwitchAgentButton.tsx`'s `DropdownMenuItem onSelect={() => handleOpenChange(true)}` doesn't call `event.preventDefault()`, so Radix's default post-`onSelect` behavior closes the parent `DropdownMenu` (`SessionActionsMenu.tsx`) in the same tick the dialog's `open` prop flips to `true`.
2. `SwitchAgentDialog.tsx` renders `<Dialog modal={false} ...>` — intentionally non-modal so it doesn't fight `xterm`'s focus/keyboard handling underneath it. Because it's non-modal, Radix's `Dialog.Content` relies on `DismissableLayer`'s document-level `pointerdown`/`focusout` listeners for outside-click dismissal. The dropdown item unmounts and returns focus in the very same event cycle the dialog mounts, so `DismissableLayer` treats the residual pointer/focus activity as "outside" and immediately dismisses the just-opened dialog.

`263ba3b82` (#4572) already moved `SwitchAgentDialog`'s render site from inside the button into `SessionView` to stop the closing dropdown from *unmounting* the dialog before it opened — that fixed the unmount race but left this `DismissableLayer` outside-click race untouched.

## Fix

Add an `onPointerDownOutside`/`onFocusOutside` guard on `SwitchAgentDialog`'s `DialogContent` that ignores only outside events whose target is inside the just-dismissed menu/trigger (`[role="menuitem"]`, `[role="menu"]`, `[data-session-actions-trigger]`), so a genuine outside click still closes the dialog normally. This mirrors the existing `onEscapeKeyDown`/`onPointerDownOutside` guard pattern already used in `InstallDependencyDialog.tsx`.

## Tests

- **New regression test**: `SessionActionsMenu.switch-agent.test.tsx` drives the real `DropdownMenuItem` click path (`variant="menu-item"` inside a real `SessionActionsMenu`), unlike the existing `SessionView.test.tsx` (mocks the button out) or `SwitchAgentDialog.test.tsx` (opens with `open=true` directly) — neither exercised this race. It fails against `main` with the exact reported symptom before the fix (verified via `git stash`), and passes after.
- A companion assertion in the same test proves a genuine outside click (`document.body`) still dismisses the dialog, so the guard doesn't over-suppress legitimate dismissal.
- Full relevant suite green: `SwitchAgentDialog.test.tsx` + `TerminalSwitchAgentButton.test.tsx` + `SessionView.test.tsx` + the new file — 119/119 passing.
- Full `frontend` vitest suite: 3189 passed / 1 skipped / 4 failed, all 4 pre-existing and unrelated (confirmed via `git stash` — they fail identically with and without this change; they're a known machine-locale `toLocaleString` issue in `AgentModelCombobox`/`ChatTimelineItems`/`ChatWorkspace`).
- `npm run typecheck` — clean.

## Manual verification

- Verified in the real Electron desktop app (dev build on this branch, pointed at real session data) — clicking "Switch agent" from the session actions menu now opens the dialog and it stays open and interactive; a genuine click outside still closes it.
- Verified again against a full self-build of the packaged desktop app + Go daemon (not just the dev harness): this branch merged onto a freshly upstream-synced fork main, `.app` repackaged and daemon restarted, then re-tested live against real session data. Confirmed by the reporting user directly in the rebuilt production app: "все работает, я подтверждаю" ("everything works, confirmed") — the dialog opens and stays open, no more flash-close.

