### PR TITLE
fix(terminal): resolve reboot reattach loop and add native auto-resume (#4641)

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -525,11 +525,12 @@ func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
 
 // IsAlive reports whether the handle's session still exists via `tmux
 // has-session`. Exit 0 means alive. A non-zero exit with output naming this
-// session as missing is a definitive false, nil. A conclusively absent server
-// wraps ports.ErrRuntimeUnavailable so recovery may recreate it. A transient
-// connection or protocol/client failure wraps ErrRuntimeProbeInconclusive so
-// no caller can treat a possibly-live session as absent. Any other non-zero
-// exit is a plain probe error, which is likewise never per-session death.
+// session as missing OR a conclusively absent server is a definitive (false,
+// nil) — after a reboot the tmux server is gone and every session it hosted
+// is permanently dead. A transient connection or protocol/client failure wraps
+// ErrRuntimeProbeInconclusive so no caller can treat a possibly-live session
+// as absent. Any other non-zero exit is a plain probe error, which is likewise
+// never per-session death.
 func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
 	id, err := handleID(handle)
 	if err != nil {
@@ -539,12 +540,8 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			if sessionMissingOutput(string(out)) {
+			if sessionMissingOutput(string(out)) || serverNotRunningOutput(string(out)) {
 				return false, nil
-			}
-			if serverNotRunningOutput(string(out)) {
-				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",
-					id, ports.ErrRuntimeUnavailable, strings.TrimSpace(string(out)))
 			}
 			if transientServerFailureOutput(string(out)) {
 				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -2,7 +2,6 @@ package tmux
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -68,14 +67,13 @@ func TestRuntimeIntegration(t *testing.T) {
 	}
 
 	// Destroy and verify liveness goes false. When this was the server's last
-	// session the server itself exits with it, and the probe reports the
-	// server-level outage as ErrRuntimeUnavailable rather than a per-session
-	// false result (issue #3475); both outcomes mean the tmux handle is gone.
+	// session the server itself exits with it; both "session not found" and
+	// "no server running" are definitive (false, nil) now (#4641).
 	if err := r.Destroy(ctx, h); err != nil {
 		t.Fatalf("Destroy: %v", err)
 	}
 	alive, err = r.IsAlive(ctx, h)
-	if err != nil && !errors.Is(err, ports.ErrRuntimeUnavailable) {
+	if err != nil {
 		t.Fatalf("IsAlive after destroy: %v", err)
 	}
 	if alive {

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -1130,18 +1130,18 @@ func TestIsAliveReturnsFalseNilOnCantFindSession(t *testing.T) {
 	}
 }
 
-// A conclusively absent server means the tmux runtime handle is gone, although
-// the agent may still be alive as an orphan. Surface the infrastructure-level
-// sentinel rather than a per-session false result: the reaper treats errors as
-// failed probes, while explicit recovery paths may recreate the missing server.
-func TestIsAliveReportsNoServerAsRuntimeUnavailable(t *testing.T) {
+// After a reboot the tmux server is gone and every session it hosted is
+// permanently dead. Surface (false, nil) — the same definitive signal as a
+// missing session — so attachment.go calls markExited() immediately instead
+// of retrying with backoff forever. Fixes #4641.
+func TestIsAliveReportsNoServerAsPermanentDeath(t *testing.T) {
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{[]byte("no server running on /tmp/tmux-1000/default")}
 	fr.err = &exec.ExitError{}
 
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	if err != nil {
+		t.Fatalf("IsAlive err = %v, want nil (permanent death)", err)
 	}
 	if alive {
 		t.Fatal("alive = true, want false")

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2135,6 +2135,51 @@ paths:
       summary: Set the auto-inject review setting for a session
       tags:
       - sessions
+  /api/v1/sessions/{sessionId}/auto-resume-agent:
+    post:
+      operationId: autoResumeAgent
+      parameters:
+      - description: Session identifier, e.g. project-1.
+        in: path
+        name: sessionId
+        required: true
+        schema:
+          description: Session identifier, e.g. project-1.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResumeAgentResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Auto-resume an exited agent via native session recovery only
+      tags:
+      - sessions
   /api/v1/sessions/{sessionId}/auto-review:
     put:
       operationId: setSessionAutoReview

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -4847,6 +4847,51 @@ paths:
       summary: Send a message to a running session's agent
       tags:
       - sessions
+  /api/v1/sessions/{sessionId}/spawn-fresh-terminal:
+    post:
+      operationId: spawnFreshTerminal
+      parameters:
+      - description: Session identifier, e.g. project-1.
+        in: path
+        name: sessionId
+        required: true
+        schema:
+          description: Session identifier, e.g. project-1.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResumeAgentResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Spawn a fresh login shell PTY for an unrecoverable dead session
+      tags:
+      - sessions
   /api/v1/sessions/{sessionId}/switch-agent:
     post:
       operationId: switchSessionAgent

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -1854,6 +1854,18 @@ func sessionOperations() []operation {
 			},
 		},
 		{
+			method: http.MethodPost, path: "/api/v1/sessions/{sessionId}/spawn-fresh-terminal", id: "spawnFreshTerminal", tag: "sessions",
+			summary:    "Spawn a fresh login shell PTY for an unrecoverable dead session",
+			pathParams: []any{controllers.SessionIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.ResumeAgentResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
 			method: http.MethodPost, path: "/api/v1/sessions/{sessionId}/switch-agent", id: "switchSessionAgent", tag: "sessions",
 			summary:    "Switch a logical AO session to another agent harness",
 			pathParams: []any{controllers.SessionIDParam{}},

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -1842,6 +1842,18 @@ func sessionOperations() []operation {
 			},
 		},
 		{
+			method: http.MethodPost, path: "/api/v1/sessions/{sessionId}/auto-resume-agent", id: "autoResumeAgent", tag: "sessions",
+			summary:    "Auto-resume an exited agent via native session recovery only",
+			pathParams: []any{controllers.SessionIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.ResumeAgentResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
 			method: http.MethodPost, path: "/api/v1/sessions/{sessionId}/switch-agent", id: "switchSessionAgent", tag: "sessions",
 			summary:    "Switch a logical AO session to another agent harness",
 			pathParams: []any{controllers.SessionIDParam{}},

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -87,6 +87,7 @@ type SessionService interface {
 	Restore(ctx context.Context, id domain.SessionID) (sessionsvc.RestoreOutcome, error)
 	ResumeAgent(ctx context.Context, id domain.SessionID) (sessionsvc.ResumeAgentOutcome, error)
 	AutoResumeAgent(ctx context.Context, id domain.SessionID) (sessionsvc.ResumeAgentOutcome, error)
+	SpawnFreshTerminal(ctx context.Context, id domain.SessionID) (sessionsvc.ResumeAgentOutcome, error)
 	SwitchAgent(ctx context.Context, id domain.SessionID, in sessionsvc.SwitchAgentInput) (domain.AgentSwitch, error)
 	RecoverAgentSwitch(ctx context.Context, id domain.SessionID, switchID domain.AgentSwitchID) (domain.AgentSwitch, error)
 	ListAgentSwitches(ctx context.Context, id domain.SessionID) ([]domain.AgentSwitch, error)
@@ -185,6 +186,7 @@ func (c *SessionsController) Register(r chi.Router) {
 	r.Post("/sessions/{sessionId}/restore", c.restore)
 	r.Post("/sessions/{sessionId}/resume-agent", c.resumeAgent)
 	r.Post("/sessions/{sessionId}/auto-resume-agent", c.autoResumeAgent)
+	r.Post("/sessions/{sessionId}/spawn-fresh-terminal", c.spawnFreshTerminal)
 	r.Post("/sessions/{sessionId}/switch-agent", c.switchAgent)
 	r.Get("/sessions/{sessionId}/agent-switches", c.listAgentSwitches)
 	r.Post("/sessions/{sessionId}/agent-switches/{switchId}/recover", c.recoverAgentSwitch)
@@ -1179,6 +1181,24 @@ func (c *SessionsController) autoResumeAgent(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	out, err := c.Svc.AutoResumeAgent(r.Context(), sessionID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, ResumeAgentResponse{
+		OK:         true,
+		SessionID:  sessionID(r),
+		ResumeMode: out.Mode,
+		Session:    sessionView(out.Session),
+	})
+}
+
+func (c *SessionsController) spawnFreshTerminal(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/sessions/{sessionId}/spawn-fresh-terminal")
+		return
+	}
+	out, err := c.Svc.SpawnFreshTerminal(r.Context(), sessionID(r))
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -86,6 +86,7 @@ type SessionService interface {
 	Get(ctx context.Context, id domain.SessionID) (domain.Session, error)
 	Restore(ctx context.Context, id domain.SessionID) (sessionsvc.RestoreOutcome, error)
 	ResumeAgent(ctx context.Context, id domain.SessionID) (sessionsvc.ResumeAgentOutcome, error)
+	AutoResumeAgent(ctx context.Context, id domain.SessionID) (sessionsvc.ResumeAgentOutcome, error)
 	SwitchAgent(ctx context.Context, id domain.SessionID, in sessionsvc.SwitchAgentInput) (domain.AgentSwitch, error)
 	RecoverAgentSwitch(ctx context.Context, id domain.SessionID, switchID domain.AgentSwitchID) (domain.AgentSwitch, error)
 	ListAgentSwitches(ctx context.Context, id domain.SessionID) ([]domain.AgentSwitch, error)
@@ -183,6 +184,7 @@ func (c *SessionsController) Register(r chi.Router) {
 	r.Put("/sessions/{sessionId}/auto-review", c.setAutoReview)
 	r.Post("/sessions/{sessionId}/restore", c.restore)
 	r.Post("/sessions/{sessionId}/resume-agent", c.resumeAgent)
+	r.Post("/sessions/{sessionId}/auto-resume-agent", c.autoResumeAgent)
 	r.Post("/sessions/{sessionId}/switch-agent", c.switchAgent)
 	r.Get("/sessions/{sessionId}/agent-switches", c.listAgentSwitches)
 	r.Post("/sessions/{sessionId}/agent-switches/{switchId}/recover", c.recoverAgentSwitch)
@@ -1159,6 +1161,24 @@ func (c *SessionsController) resumeAgent(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	out, err := c.Svc.ResumeAgent(r.Context(), sessionID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, ResumeAgentResponse{
+		OK:         true,
+		SessionID:  sessionID(r),
+		ResumeMode: out.Mode,
+		Session:    sessionView(out.Session),
+	})
+}
+
+func (c *SessionsController) autoResumeAgent(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/sessions/{sessionId}/auto-resume-agent")
+		return
+	}
+	out, err := c.Svc.AutoResumeAgent(r.Context(), sessionID(r))
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -332,6 +332,14 @@ func (f *fakeSessionService) ResumeAgent(_ context.Context, id domain.SessionID)
 	return sessionsvc.ResumeAgentOutcome{Session: s, Mode: sessionsvc.RestoreModeViewNative}, nil
 }
 
+func (f *fakeSessionService) AutoResumeAgent(_ context.Context, id domain.SessionID) (sessionsvc.ResumeAgentOutcome, error) {
+	s := f.sessions[id]
+	s.Activity.State = domain.ActivityIdle
+	s.Status = domain.StatusIdle
+	f.sessions[id] = s
+	return sessionsvc.ResumeAgentOutcome{Session: s, Mode: sessionsvc.RestoreModeViewNative}, nil
+}
+
 func (f *fakeSessionService) SwitchAgent(_ context.Context, id domain.SessionID, cfg sessionsvc.SwitchAgentInput) (domain.AgentSwitch, error) {
 	if f.switchErr != nil {
 		return domain.AgentSwitch{}, f.switchErr
@@ -1065,6 +1073,19 @@ func TestSessionsAPI_ListSpawnGetAndActions(t *testing.T) {
 	mustJSON(t, body, &resumed)
 	if resumed.SessionID != "ao-2" || resumed.ResumeMode != "native" {
 		t.Fatalf("resume response = %#v", resumed)
+	}
+
+	body, status, _ = doRequest(t, srv, "POST", "/api/v1/sessions/ao-2/auto-resume-agent", "")
+	if status != http.StatusOK {
+		t.Fatalf("auto-resume agent = %d, want 200; body=%s", status, body)
+	}
+	var autoResumed struct {
+		SessionID  string `json:"sessionId"`
+		ResumeMode string `json:"resumeMode"`
+	}
+	mustJSON(t, body, &autoResumed)
+	if autoResumed.SessionID != "ao-2" || autoResumed.ResumeMode != "native" {
+		t.Fatalf("auto-resume response = %#v", autoResumed)
 	}
 
 	body, status, _ = doRequest(t, srv, "PATCH", "/api/v1/sessions/ao-2", `{"displayName":"Renamed"}`)

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -340,6 +340,14 @@ func (f *fakeSessionService) AutoResumeAgent(_ context.Context, id domain.Sessio
 	return sessionsvc.ResumeAgentOutcome{Session: s, Mode: sessionsvc.RestoreModeViewNative}, nil
 }
 
+func (f *fakeSessionService) SpawnFreshTerminal(_ context.Context, id domain.SessionID) (sessionsvc.ResumeAgentOutcome, error) {
+	s := f.sessions[id]
+	s.Activity.State = domain.ActivityIdle
+	s.Status = domain.StatusIdle
+	f.sessions[id] = s
+	return sessionsvc.ResumeAgentOutcome{Session: s, Mode: sessionsvc.RestoreModeViewFresh}, nil
+}
+
 func (f *fakeSessionService) SwitchAgent(_ context.Context, id domain.SessionID, cfg sessionsvc.SwitchAgentInput) (domain.AgentSwitch, error) {
 	if f.switchErr != nil {
 		return domain.AgentSwitch{}, f.switchErr
@@ -1086,6 +1094,19 @@ func TestSessionsAPI_ListSpawnGetAndActions(t *testing.T) {
 	mustJSON(t, body, &autoResumed)
 	if autoResumed.SessionID != "ao-2" || autoResumed.ResumeMode != "native" {
 		t.Fatalf("auto-resume response = %#v", autoResumed)
+	}
+
+	body, status, _ = doRequest(t, srv, "POST", "/api/v1/sessions/ao-2/spawn-fresh-terminal", "")
+	if status != http.StatusOK {
+		t.Fatalf("spawn-fresh-terminal = %d, want 200; body=%s", status, body)
+	}
+	var freshSpawned struct {
+		SessionID  string `json:"sessionId"`
+		ResumeMode string `json:"resumeMode"`
+	}
+	mustJSON(t, body, &freshSpawned)
+	if freshSpawned.SessionID != "ao-2" || freshSpawned.ResumeMode != "fresh" {
+		t.Fatalf("spawn fresh terminal response = %#v", freshSpawned)
 	}
 
 	body, status, _ = doRequest(t, srv, "PATCH", "/api/v1/sessions/ao-2", `{"displayName":"Renamed"}`)

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -66,6 +66,7 @@ type commander interface {
 	SubmitAgentHandoff(ctx context.Context, id domain.SessionID, switchID domain.AgentSwitchID, sourceGenerationID domain.AgentGenerationID, handoff json.RawMessage) (domain.AgentSwitch, error)
 	RestoreWithMode(ctx context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error)
 	ResumeAgentWithMode(ctx context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error)
+	AutoResumeAgentWithMode(ctx context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error)
 	Kill(ctx context.Context, id domain.SessionID) (bool, error)
 	RetireForReplacement(ctx context.Context, id domain.SessionID) error
 	WaitForMessageDeliveryReady(ctx context.Context, id domain.SessionID) error
@@ -540,6 +541,22 @@ func (s *Service) ResumeAgent(ctx context.Context, id domain.SessionID) (ResumeA
 	return ResumeAgentOutcome{Session: session, Mode: restoreModeView(res.Mode)}, nil
 }
 
+// AutoResumeAgent attempts a native-only resume of an exited agent. Returns an
+// error mapped from ErrNoNativeResume when the adapter cannot natively continue
+// the conversation, so the frontend falls back to the clean "session ended"
+// state without silently relaunching.
+func (s *Service) AutoResumeAgent(ctx context.Context, id domain.SessionID) (ResumeAgentOutcome, error) {
+	res, err := s.manager.AutoResumeAgentWithMode(ctx, id)
+	if err != nil {
+		return ResumeAgentOutcome{}, toAPIError(err)
+	}
+	session, err := s.toSession(ctx, res.Session)
+	if err != nil {
+		return ResumeAgentOutcome{}, err
+	}
+	return ResumeAgentOutcome{Session: session, Mode: restoreModeView(res.Mode)}, nil
+}
+
 // InterfaceTransitionStatus returns capability and progress without launching
 // a provider process or mutating the session.
 func (s *Service) InterfaceTransitionStatus(ctx context.Context, id domain.SessionID) (InterfaceTransitionStatus, error) {
@@ -979,6 +996,9 @@ func toAPIError(err error) error {
 	case errors.Is(err, sessionmanager.ErrNotResumable):
 		return apierr.Conflict("SESSION_NOT_RESUMABLE",
 			"This session has no saved agent session or prompt to resume from", nil)
+	case errors.Is(err, sessionmanager.ErrNoNativeResume):
+		return apierr.Conflict("SESSION_NO_NATIVE_RESUME",
+			"The agent adapter cannot natively resume this conversation", nil)
 	case errors.Is(err, sessionmanager.ErrProjectNotResolvable):
 		return apierr.Invalid("PROJECT_NOT_RESOLVABLE", "Project is not registered or has no repo. Register it with `ao project add`", nil)
 	case errors.Is(err, sessionmanager.ErrUnknownHarness):

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -67,6 +67,7 @@ type commander interface {
 	RestoreWithMode(ctx context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error)
 	ResumeAgentWithMode(ctx context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error)
 	AutoResumeAgentWithMode(ctx context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error)
+	SpawnFreshTerminal(ctx context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error)
 	Kill(ctx context.Context, id domain.SessionID) (bool, error)
 	RetireForReplacement(ctx context.Context, id domain.SessionID) error
 	WaitForMessageDeliveryReady(ctx context.Context, id domain.SessionID) error
@@ -547,6 +548,19 @@ func (s *Service) ResumeAgent(ctx context.Context, id domain.SessionID) (ResumeA
 // state without silently relaunching.
 func (s *Service) AutoResumeAgent(ctx context.Context, id domain.SessionID) (ResumeAgentOutcome, error) {
 	res, err := s.manager.AutoResumeAgentWithMode(ctx, id)
+	if err != nil {
+		return ResumeAgentOutcome{}, toAPIError(err)
+	}
+	session, err := s.toSession(ctx, res.Session)
+	if err != nil {
+		return ResumeAgentOutcome{}, err
+	}
+	return ResumeAgentOutcome{Session: session, Mode: restoreModeView(res.Mode)}, nil
+}
+
+// SpawnFreshTerminal launches a fresh login shell PTY for an unrecoverable dead session.
+func (s *Service) SpawnFreshTerminal(ctx context.Context, id domain.SessionID) (ResumeAgentOutcome, error) {
+	res, err := s.manager.SpawnFreshTerminal(ctx, id)
 	if err != nil {
 		return ResumeAgentOutcome{}, toAPIError(err)
 	}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2197,6 +2197,13 @@ func (f *fakeCommander) ResumeAgentWithMode(_ context.Context, id domain.Session
 	}
 	return f.restoreResult, nil
 }
+func (f *fakeCommander) AutoResumeAgentWithMode(_ context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error) {
+	f.resumed = append(f.resumed, id)
+	if f.restoreErr != nil {
+		return sessionmanager.RestoreResult{}, f.restoreErr
+	}
+	return f.restoreResult, nil
+}
 func (f *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, error) {
 	if f.killErr != nil {
 		return false, f.killErr

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2204,6 +2204,13 @@ func (f *fakeCommander) AutoResumeAgentWithMode(_ context.Context, id domain.Ses
 	}
 	return f.restoreResult, nil
 }
+func (f *fakeCommander) SpawnFreshTerminal(_ context.Context, id domain.SessionID) (sessionmanager.RestoreResult, error) {
+	f.resumed = append(f.resumed, id)
+	if f.restoreErr != nil {
+		return sessionmanager.RestoreResult{}, f.restoreErr
+	}
+	return f.restoreResult, nil
+}
 func (f *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, error) {
 	if f.killErr != nil {
 		return false, f.killErr

--- a/backend/internal/service/shellterm/loginshell.go
+++ b/backend/internal/service/shellterm/loginshell.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 )
 
-// resolveUserLoginShell returns the argv a standalone terminal launches.
+// ResolveUserLoginShell returns the argv a standalone terminal launches.
 //
 // Unlike an agent session — where the argv is a specific CLI the adapter
 // resolved and the runtime must be able to prove exists — a shell terminal
@@ -17,7 +17,7 @@ import (
 // The fallbacks are last-resort only: an empty argv would be rejected by the
 // runtime adapters, so a terminal that cannot name a shell must not open at
 // all rather than open something unusable.
-func resolveUserLoginShell() []string {
+func ResolveUserLoginShell() []string {
 	if runtime.GOOS == "windows" {
 		return resolveWindowsShell()
 	}

--- a/backend/internal/service/shellterm/service.go
+++ b/backend/internal/service/shellterm/service.go
@@ -227,7 +227,7 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 	if err != nil {
 		return ShellTerminal{}, fmt.Errorf("open shell terminal: list existing terminals: %w", err)
 	}
-	argv := resolveUserLoginShell()
+	argv := ResolveUserLoginShell()
 	if len(argv) == 0 {
 		return ShellTerminal{}, apierr.Internal("SHELL_TERMINAL_NO_SHELL",
 			"Could not determine a shell to launch. Set SHELL (macOS/Linux) or ComSpec (Windows).")

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -990,7 +990,7 @@ func (m *Manager) startTransitionTarget(ctx context.Context, id domain.SessionID
 	// daemon restore deliberately use the normal context-resume policy.
 	_, err = m.relaunchSessionWithPolicy(
 		ctx, "switch interface", rec, project, ws, nil,
-		fresh, requireNativeHistory && !fresh,
+		fresh, requireNativeHistory && !fresh, false,
 	)
 	return err
 }

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -60,6 +60,10 @@ var (
 	// with the system prompt only). Workers without a task and without a native
 	// session id have nothing meaningful to restore.
 	ErrNotResumable = errors.New("session: nothing to resume from")
+	// ErrNoNativeResume means the agent's adapter cannot natively resume its
+	// conversation (GetRestoreCommand returned ok=false). Auto-resume only
+	// fires for native transcript continuations, never fresh re-launches.
+	ErrNoNativeResume = errors.New("session: no native resume available")
 	// ErrSwitchInProgress means an agent switch is already running for this
 	// session. The API maps it to a 409 so a double-submit does not race two
 	// teardown/relaunch cycles over one worktree.
@@ -1939,11 +1943,68 @@ func (m *Manager) ResumeAgentWithMode(ctx context.Context, id domain.SessionID) 
 	return m.relaunchSession(ctx, "resume agent", rec, project, ws, &handle)
 }
 
-func (m *Manager) relaunchSession(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle) (RestoreResult, error) {
-	return m.relaunchSessionWithPolicy(ctx, operation, rec, project, ws, restartHandle, false, false)
+// AutoResumeAgentWithMode is the automatic counterpart of ResumeAgentWithMode.
+// It fires only when the agent's adapter can natively continue its conversation
+// (GetRestoreCommand returns ok=true). If native resume is unavailable it
+// returns ErrNoNativeResume so the caller falls back to the clean "session
+// ended" state without silently relaunching from a saved prompt.
+func (m *Manager) AutoResumeAgentWithMode(ctx context.Context, id domain.SessionID) (RestoreResult, error) {
+	if err := m.beginAgentResume(ctx, id); err != nil {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, err)
+	}
+	defer m.endAgentResume(id)
+	if active, err := m.hasActiveInterfaceTransition(ctx, id); err != nil {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: interface transition: %w", id, err)
+	} else if active {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, ErrInterfaceTransitionInProgress)
+	}
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, err)
+	}
+	if !ok {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, ErrNotFound)
+	}
+	if rec.IsTerminated {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, ErrTerminated)
+	}
+	mode := domain.NormalizeSessionMode(rec.Mode)
+	if mode == domain.SessionModeChat && m.chat != nil && m.chat.HasLiveChatController(id) {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, ErrAgentNotExited)
+	}
+	if rec.Activity.State != domain.ActivityExited {
+		if mode != domain.SessionModeChat || m.chat == nil {
+			return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, ErrAgentNotExited)
+		}
+	}
+	project, err := m.loadProject(ctx, rec.ProjectID)
+	if err != nil {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, err)
+	}
+	meta := rec.Metadata
+	if meta.WorkspacePath == "" ||
+		(meta.Branch == "" && project.Kind.WithDefault() != domain.ProjectKindScratch) ||
+		(mode != domain.SessionModeChat && meta.RuntimeHandleID == "") {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, ErrIncompleteHandle)
+	}
+	ws := ports.WorkspaceInfo{
+		Path:      meta.WorkspacePath,
+		Branch:    meta.Branch,
+		SessionID: rec.ID,
+		ProjectID: rec.ProjectID,
+	}
+	if mode == domain.SessionModeChat {
+		return RestoreResult{}, fmt.Errorf("auto-resume agent %s: %w", id, ErrNoNativeResume)
+	}
+	handle := ports.RuntimeHandle{ID: meta.RuntimeHandleID}
+	return m.relaunchSessionWithPolicy(ctx, "auto-resume agent", rec, project, ws, &handle, false, false, true)
 }
 
-func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle, forceFresh, requireNativeHistory bool) (RestoreResult, error) {
+func (m *Manager) relaunchSession(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle) (RestoreResult, error) {
+	return m.relaunchSessionWithPolicy(ctx, operation, rec, project, ws, restartHandle, false, false, false)
+}
+
+func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle, forceFresh, requireNativeHistory, nativeOnly bool) (RestoreResult, error) {
 	// Relaunch dispatches from the currently committed persisted mode, never from
 	// a caller hint. The interface-transition coordinator changes that fact only
 	// after stopping the old controller, then reuses this ordinary restore path.
@@ -1997,7 +2058,7 @@ func (m *Manager) relaunchSessionWithPolicy(ctx context.Context, operation strin
 			systemPrompt, systemPromptFile, agentConfig, rec.Kind, m.dataDir, true)
 	} else {
 		argv, delivery, mode, err = restoreArgv(ctx, agent, rec.ID, ws.Path, rec.Metadata,
-			systemPrompt, systemPromptFile, agentConfig, rec.Kind, rec.Harness, m.dataDir)
+			systemPrompt, systemPromptFile, agentConfig, rec.Kind, rec.Harness, m.dataDir, nativeOnly)
 	}
 	if err != nil {
 		m.cleanupSystemPromptDir(rec.ID)
@@ -4322,7 +4383,7 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 // signals via ok=false (e.g. no native session id captured yet). Returns
 // ErrNotResumable when transcript-preserving restore is required but unavailable,
 // or when a promptless, unresumable worker has nothing to restore from.
-func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, _ domain.AgentHarness, dataDir string) ([]string, ports.PromptDeliveryStrategy, RestoreMode, error) {
+func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, _ domain.AgentHarness, dataDir string, nativeOnly bool) ([]string, ports.PromptDeliveryStrategy, RestoreMode, error) {
 	ref := ports.SessionRef{
 		ID:            string(id),
 		WorkspacePath: workspacePath,
@@ -4334,6 +4395,9 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 	}
 	if ok {
 		return cmd, ports.PromptDeliveryInCommand, RestoreModeNative, nil
+	}
+	if nativeOnly {
+		return nil, "", "", ErrNoNativeResume
 	}
 	return freshLaunchArgv(ctx, agent, id, workspacePath, meta, systemPrompt,
 		systemPromptFile, agentConfig, kind, dataDir, false)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/sessionguard"
+	"github.com/aoagents/agent-orchestrator/backend/internal/service/shellterm"
 	"github.com/aoagents/agent-orchestrator/backend/internal/skillassets"
 	"github.com/aoagents/agent-orchestrator/backend/internal/tmuxbin"
 )
@@ -1998,6 +1999,107 @@ func (m *Manager) AutoResumeAgentWithMode(ctx context.Context, id domain.Session
 	}
 	handle := ports.RuntimeHandle{ID: meta.RuntimeHandleID}
 	return m.relaunchSessionWithPolicy(ctx, "auto-resume agent", rec, project, ws, &handle, false, false, true)
+}
+
+// SpawnFreshTerminal launches a fresh login shell PTY for a dead session in its
+// existing workspace when native agent recovery is not possible. It preserves the
+// session row and workspace so the user retains their task context.
+func (m *Manager) SpawnFreshTerminal(ctx context.Context, id domain.SessionID) (RestoreResult, error) {
+	if err := m.beginAgentResume(ctx, id); err != nil {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", id, err)
+	}
+	defer m.endAgentResume(id)
+	if active, err := m.hasActiveInterfaceTransition(ctx, id); err != nil {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: interface transition: %w", id, err)
+	} else if active {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", id, ErrInterfaceTransitionInProgress)
+	}
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", id, err)
+	}
+	if !ok {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", id, ErrNotFound)
+	}
+	if rec.IsTerminated {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", id, ErrTerminated)
+	}
+	mode := domain.NormalizeSessionMode(rec.Mode)
+	if mode == domain.SessionModeChat {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: chat sessions do not use terminal runtimes", id)
+	}
+	project, err := m.loadProject(ctx, rec.ProjectID)
+	if err != nil {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", id, err)
+	}
+	meta := rec.Metadata
+	if meta.WorkspacePath == "" ||
+		(meta.Branch == "" && project.Kind.WithDefault() != domain.ProjectKindScratch) {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", id, ErrIncompleteHandle)
+	}
+	ws := ports.WorkspaceInfo{
+		Path:      meta.WorkspacePath,
+		Branch:    meta.Branch,
+		SessionID: rec.ID,
+		ProjectID: rec.ProjectID,
+	}
+	return m.relaunchFreshShell(ctx, rec, project, ws)
+}
+
+func (m *Manager) relaunchFreshShell(ctx context.Context, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo) (RestoreResult, error) {
+	shellArgv := shellterm.ResolveUserLoginShell()
+	if len(shellArgv) == 0 {
+		return RestoreResult{}, errors.New("spawn fresh terminal: no usable user login shell found")
+	}
+	var env map[string]string
+	var err error
+	rec, env, err = m.prepareWorkerLaunchEnv(ctx, rec, project.Config.Env)
+	if err != nil {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: %w", rec.ID, err)
+	}
+	m.augmentRuntimePATHForLaunchBinary(ctx, env, shellArgv)
+	launchID := m.newLaunchID()
+	if err := m.lcm.PrepareLaunch(rec.ID, launchID); err != nil {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: prepare launch: %w", rec.ID, err)
+	}
+	defer m.lcm.CancelLaunch(rec.ID, launchID)
+
+	runtimeCfg := ports.RuntimeConfig{
+		SessionID:     rec.ID,
+		WorkspacePath: ws.Path,
+		Argv:          shellArgv,
+		Env:           env,
+	}
+	var handle ports.RuntimeHandle
+	if rec.Metadata.RuntimeHandleID != "" {
+		handle, err = m.restartRuntime(ctx, ports.RuntimeHandle{ID: rec.Metadata.RuntimeHandleID}, runtimeCfg)
+	} else {
+		handle, err = m.runtime.Create(ctx, runtimeCfg)
+	}
+	if err != nil {
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: runtime: %w", rec.ID, err)
+	}
+
+	metadata := domain.SessionMetadata{
+		Branch:                    ws.Branch,
+		WorkspacePath:             ws.Path,
+		WorkspaceRepoPath:         ws.RepoPath,
+		RuntimeHandleID:           handle.ID,
+		RuntimeLaunchID:           launchID,
+		AgentSessionID:            rec.Metadata.AgentSessionID,
+		Prompt:                    rec.Metadata.Prompt,
+		BrowserCapabilityVerifier: rec.Metadata.BrowserCapabilityVerifier,
+	}
+	if err := m.lcm.MarkSpawned(ctx, rec.ID, metadata); err != nil {
+		_ = m.runtime.Destroy(ctx, handle)
+		return RestoreResult{}, fmt.Errorf("spawn fresh terminal %s: completed: %w", rec.ID, err)
+	}
+
+	updated, err := m.getRecord(ctx, rec.ID)
+	if err != nil {
+		return RestoreResult{}, err
+	}
+	return RestoreResult{Session: updated, Mode: RestoreModeFresh}, nil
 }
 
 func (m *Manager) relaunchSession(ctx context.Context, operation string, rec domain.SessionRecord, project domain.ProjectRecord, ws ports.WorkspaceInfo, restartHandle *ports.RuntimeHandle) (RestoreResult, error) {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1942,6 +1942,61 @@ func TestAutoResumeAgent_RequiresLiveExitedSession(t *testing.T) {
 	}
 }
 
+func TestSpawnFreshTerminal_SucceedsForDeadUnresumableSession(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": false}}
+	runtime := &fakeRestartRuntime{fakeRuntime: baseRuntime}
+	// agent whose GetRestoreCommand returns ok=false
+	agent := unresumableAgent{argv: []string{"agent", "run"}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+
+	// Step 1: AutoResume fails with ErrNoNativeResume for this unresumable agent
+	_, err := m.AutoResumeAgentWithMode(ctx, "mer-1")
+	if !errors.Is(err, ErrNoNativeResume) {
+		t.Fatalf("AutoResumeAgentWithMode err = %v, want ErrNoNativeResume", err)
+	}
+
+	// Step 2: Fallback to SpawnFreshTerminal
+	result, err := m.SpawnFreshTerminal(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("SpawnFreshTerminal: %v", err)
+	}
+	if result.Mode != RestoreModeFresh {
+		t.Fatalf("restore mode = %q, want %q", result.Mode, RestoreModeFresh)
+	}
+
+	// Step 3: Verify the session remains in the session list, is NOT terminated, and is idle
+	got, ok := st.sessions["mer-1"]
+	if !ok {
+		t.Fatal("session mer-1 was removed from store, want it preserved")
+	}
+	if got.IsTerminated {
+		t.Fatalf("session IsTerminated = true, want false")
+	}
+	if got.Activity.State != domain.ActivityIdle {
+		t.Fatalf("session activity state = %v, want idle", got.Activity.State)
+	}
+	if got.Metadata.RuntimeHandleID == "" {
+		t.Fatal("session RuntimeHandleID is empty, want fresh handle")
+	}
+	if baseRuntime.created != 1 {
+		t.Fatalf("baseRuntime.created = %d, want 1", baseRuntime.created)
+	}
+}
+
+func TestSpawnFreshTerminal_RejectsTerminatedSession(t *testing.T) {
+	runtime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	agent := unresumableAgent{argv: []string{"agent", "run"}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+
+	rec := st.sessions["mer-1"]
+	rec.IsTerminated = true
+	st.sessions["mer-1"] = rec
+
+	if _, err := m.SpawnFreshTerminal(ctx, "mer-1"); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("terminated SpawnFreshTerminal error = %v, want ErrTerminated", err)
+	}
+}
+
 func TestSpawn_RejectsMissingRoleHarness(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -579,6 +579,23 @@ func (a launchArgvAgent) GetRestoreCommand(context.Context, ports.RestoreConfig)
 	return a.argv, true, nil
 }
 
+type unresumableAgent struct {
+	fakeAgent
+	argv []string
+}
+
+func (a unresumableAgent) GetLaunchCommand(context.Context, ports.LaunchConfig) ([]string, error) {
+	return a.argv, nil
+}
+
+func (unresumableAgent) GetRestoreCommand(context.Context, ports.RestoreConfig) ([]string, bool, error) {
+	return nil, false, nil
+}
+
+func (unresumableAgent) ExitDetectionMode() ports.AgentExitDetectionMode {
+	return ports.AgentExitDetectionSupervisor
+}
+
 type supervisedLaunchAgent struct{ launchArgvAgent }
 
 func (supervisedLaunchAgent) ExitDetectionMode() ports.AgentExitDetectionMode {
@@ -1861,6 +1878,67 @@ func TestResumeAgent_ReleasesInputGateAfterInterfaceTransitionRejection(t *testi
 				t.Fatal("interface-transition rejection left input admission closed")
 			}
 		})
+	}
+}
+
+func TestAutoResumeAgent_SucceedsForNativeRestore(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &fakeRestartRuntime{fakeRuntime: baseRuntime}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+
+	result, err := m.AutoResumeAgentWithMode(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("AutoResumeAgentWithMode: %v", err)
+	}
+	if result.Mode != RestoreModeNative {
+		t.Fatalf("resume mode = %q, want %q", result.Mode, RestoreModeNative)
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityIdle {
+		t.Fatalf("resumed session = %+v, want live idle", got)
+	}
+}
+
+func TestAutoResumeAgent_FailsWithErrNoNativeResumeWhenNotResumable(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &fakeRestartRuntime{fakeRuntime: baseRuntime}
+	// agent whose GetRestoreCommand returns ok=false
+	agent := unresumableAgent{argv: []string{"agent", "run"}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+
+	_, err := m.AutoResumeAgentWithMode(ctx, "mer-1")
+	if !errors.Is(err, ErrNoNativeResume) {
+		t.Fatalf("AutoResumeAgentWithMode err = %v, want ErrNoNativeResume", err)
+	}
+	// Verify session remained exited and was NOT relaunched
+	got := st.sessions["mer-1"]
+	if got.Activity.State != domain.ActivityExited {
+		t.Fatalf("session activity = %v, want exited", got.Activity.State)
+	}
+	if baseRuntime.created != 0 || runtime.restarted != 0 {
+		t.Fatalf("auto-resume must not launch or recreate runtime on ErrNoNativeResume: created=%d restarted=%d",
+			baseRuntime.created, runtime.restarted)
+	}
+}
+
+func TestAutoResumeAgent_RequiresLiveExitedSession(t *testing.T) {
+	runtime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+
+	rec := st.sessions["mer-1"]
+	rec.Activity.State = domain.ActivityIdle
+	st.sessions["mer-1"] = rec
+	if _, err := m.AutoResumeAgentWithMode(ctx, "mer-1"); !errors.Is(err, ErrAgentNotExited) {
+		t.Fatalf("idle auto-resume error = %v, want ErrAgentNotExited", err)
+	}
+
+	rec.Activity.State = domain.ActivityExited
+	rec.IsTerminated = true
+	st.sessions["mer-1"] = rec
+	if _, err := m.AutoResumeAgentWithMode(ctx, "mer-1"); !errors.Is(err, ErrTerminated) {
+		t.Fatalf("terminated auto-resume error = %v, want ErrTerminated", err)
 	}
 }
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1583,6 +1583,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sessions/{sessionId}/spawn-fresh-terminal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Spawn a fresh login shell PTY for an unrecoverable dead session */
+        post: operations["spawnFreshTerminal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sessions/{sessionId}/switch-agent": {
         parameters: {
             query?: never;
@@ -9503,6 +9520,65 @@ export interface operations {
             };
             /** @description Internal Server Error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    spawnFreshTerminal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Session identifier, e.g. project-1. */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResumeAgentResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -777,6 +777,23 @@ export interface paths {
         patch: operations["setSessionAutoInjectReview"];
         trace?: never;
     };
+    "/api/v1/sessions/{sessionId}/auto-resume-agent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Auto-resume an exited agent via native session recovery only */
+        post: operations["autoResumeAgent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sessions/{sessionId}/auto-review": {
         parameters: {
             query?: never;
@@ -6096,6 +6113,65 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    autoResumeAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Session identifier, e.g. project-1. */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResumeAgentResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -35,6 +35,7 @@ import { cn } from "../lib/utils";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useAutoResumeAgent } from "../hooks/useAutoResumeAgent";
+import { useSpawnFreshTerminal } from "../hooks/useSpawnFreshTerminal";
 import { useShellTerminals } from "../hooks/useShellTerminals";
 import { useCloudCp } from "../hooks/useCloudCp";
 import { createCloudTerminalMux } from "../lib/cloud-terminal-mux";
@@ -1049,12 +1050,14 @@ function AttachedTerminal({
 	}, [canRestoreSession, isRestoring, restoreSessionById, session?.id, t]);
 
 	const autoResumeAgent = useAutoResumeAgent();
+	const spawnFreshTerminal = useSpawnFreshTerminal();
 	const [autoResumed, setAutoResumed] = useState(false);
 	const [autoResumeBanner, setAutoResumeBanner] = useState<string | undefined>();
 
 	// Auto-resume: when a non-terminated session's terminal is confirmed
 	// permanently dead (state === "exited"), attempt native-only resume via the
-	// agent's adapter. Only fires for worker sessions with native recovery support.
+	// agent's adapter. If native recovery is not available, fallback to spawning
+	// a fresh login shell PTY in the same workspace so the session entry stays visible and usable.
 	useEffect(() => {
 		if (
 			state !== "exited" ||
@@ -1067,7 +1070,7 @@ function AttachedTerminal({
 			return;
 		}
 		let cancelled = false;
-		void autoResumeAgent(session.id).then((result) => {
+		void autoResumeAgent(session.id).then(async (result) => {
 			if (cancelled) return;
 			if (result.status === "resumed") {
 				setAutoResumed(true);
@@ -1075,12 +1078,23 @@ function AttachedTerminal({
 				setAutoResumeBanner(
 					`Session expired after restart — resumed via ${providerName}'s native session recovery`,
 				);
+				return;
+			}
+			if (result.status === "no_native_resume") {
+				const freshResult = await spawnFreshTerminal(session.id);
+				if (cancelled) return;
+				if (freshResult.status === "success") {
+					setAutoResumed(true);
+					setAutoResumeBanner(
+						"Previous process could not be recovered — opened a fresh terminal in this workspace",
+					);
+				}
 			}
 		});
 		return () => {
 			cancelled = true;
 		};
-	}, [state, session?.id, session?.isTerminated, session?.provider, terminalTarget?.kind, autoResumed, autoResumeAgent]);
+	}, [state, session?.id, session?.isTerminated, session?.provider, terminalTarget?.kind, autoResumed, autoResumeAgent, spawnFreshTerminal]);
 
 	useEffect(() => {
 		if (!terminal) return;

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -34,6 +34,7 @@ import {
 import { cn } from "../lib/utils";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
+import { useAutoResumeAgent } from "../hooks/useAutoResumeAgent";
 import { useShellTerminals } from "../hooks/useShellTerminals";
 import { useCloudCp } from "../hooks/useCloudCp";
 import { createCloudTerminalMux } from "../lib/cloud-terminal-mux";
@@ -1047,6 +1048,40 @@ function AttachedTerminal({
 		}
 	}, [canRestoreSession, isRestoring, restoreSessionById, session?.id, t]);
 
+	const autoResumeAgent = useAutoResumeAgent();
+	const [autoResumed, setAutoResumed] = useState(false);
+	const [autoResumeBanner, setAutoResumeBanner] = useState<string | undefined>();
+
+	// Auto-resume: when a non-terminated session's terminal is confirmed
+	// permanently dead (state === "exited"), attempt native-only resume via the
+	// agent's adapter. Only fires for worker sessions with native recovery support.
+	useEffect(() => {
+		if (
+			state !== "exited" ||
+			!session?.id ||
+			session.isTerminated ||
+			terminalTarget?.kind === "reviewer" ||
+			terminalTarget?.kind === "shell" ||
+			autoResumed
+		) {
+			return;
+		}
+		let cancelled = false;
+		void autoResumeAgent(session.id).then((result) => {
+			if (cancelled) return;
+			if (result.status === "resumed") {
+				setAutoResumed(true);
+				const providerName = session.provider ?? "agent";
+				setAutoResumeBanner(
+					`Session expired after restart — resumed via ${providerName}'s native session recovery`,
+				);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [state, session?.id, session?.isTerminated, session?.provider, terminalTarget?.kind, autoResumed, autoResumeAgent]);
+
 	useEffect(() => {
 		if (!terminal) return;
 		let current = true;
@@ -1089,7 +1124,7 @@ function AttachedTerminal({
 		Boolean(handleId) &&
 		(!replaySettled || replayPaintPending) &&
 		(state === "connecting" || state === "attached");
-	const showEndedState = state === "exited" || canRestoreSession;
+	const showEndedState = (state === "exited" || canRestoreSession) && !autoResumed;
 	const emptyStateTitle = session ? t("terminal.startingSession") : "Agent Orchestrator";
 	const emptyStateMessage = session
 		? session.kind === "orchestrator"
@@ -1143,6 +1178,11 @@ function AttachedTerminal({
 				{banner && (
 					<div className="absolute inset-x-3 top-2 rounded-md border border-border bg-surface/95 px-3 py-1.5 font-mono text-caption text-muted-foreground">
 						{banner}
+					</div>
+				)}
+				{autoResumeBanner && !banner && (
+					<div className="absolute inset-x-3 top-2 z-10 rounded-md border border-border bg-surface/95 px-3 py-1.5 font-mono text-caption text-muted-foreground">
+						{autoResumeBanner}
 					</div>
 				)}
 			</div>

--- a/frontend/src/renderer/hooks/useAutoResumeAgent.ts
+++ b/frontend/src/renderer/hooks/useAutoResumeAgent.ts
@@ -1,0 +1,50 @@
+import { useCallback, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+
+export type AutoResumeResult =
+	| { status: "resumed"; resumeMode: string }
+	| { status: "no_native_resume" }
+	| { status: "error"; message: string };
+
+/**
+ * Attempts a native-only auto-resume of a dead terminal session's agent.
+ * Returns "no_native_resume" when the adapter cannot natively continue the
+ * conversation, so the caller falls back to the clean "session ended" state.
+ * Tracks attempted session IDs to avoid duplicate calls.
+ */
+export function useAutoResumeAgent(): (sessionId: string) => Promise<AutoResumeResult> {
+	const queryClient = useQueryClient();
+	const attemptedRef = useRef<Set<string>>(new Set());
+
+	return useCallback(
+		async (sessionId: string) => {
+			if (attemptedRef.current.has(sessionId)) {
+				return { status: "no_native_resume" as const };
+			}
+			attemptedRef.current.add(sessionId);
+			try {
+				const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/auto-resume-agent", {
+					params: { path: { sessionId } },
+				});
+				if (error) {
+					const code = (error as { code?: string }).code;
+					if (code === "SESSION_NO_NATIVE_RESUME" || code === "SESSION_NOT_RESUMABLE") {
+						return { status: "no_native_resume" as const };
+					}
+					const message = apiErrorMessage(error, "Unable to auto-resume agent");
+					return { status: "error" as const, message };
+				}
+				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+				return { status: "resumed" as const, resumeMode: data?.resumeMode ?? "native" };
+			} catch (err) {
+				return {
+					status: "error" as const,
+					message: err instanceof Error ? err.message : "Unable to auto-resume agent",
+				};
+			}
+		},
+		[queryClient],
+	);
+}

--- a/frontend/src/renderer/hooks/useSpawnFreshTerminal.ts
+++ b/frontend/src/renderer/hooks/useSpawnFreshTerminal.ts
@@ -1,0 +1,43 @@
+import { useCallback, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+
+export type SpawnFreshTerminalResult =
+	| { status: "success" }
+	| { status: "error"; message: string };
+
+/**
+ * Spawns a fresh login shell PTY in the existing workspace for a dead session
+ * when native agent recovery is not possible.
+ */
+export function useSpawnFreshTerminal(): (sessionId: string) => Promise<SpawnFreshTerminalResult> {
+	const queryClient = useQueryClient();
+	const attemptedRef = useRef<Set<string>>(new Set());
+
+	return useCallback(
+		async (sessionId: string) => {
+			if (attemptedRef.current.has(sessionId)) {
+				return { status: "error" as const, message: "Fresh terminal spawn already attempted" };
+			}
+			attemptedRef.current.add(sessionId);
+			try {
+				const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/spawn-fresh-terminal", {
+					params: { path: { sessionId } },
+				});
+				if (error) {
+					const message = apiErrorMessage(error, "Unable to spawn fresh terminal");
+					return { status: "error" as const, message };
+				}
+				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+				return { status: "success" as const };
+			} catch (err) {
+				return {
+					status: "error" as const,
+					message: err instanceof Error ? err.message : "Unable to spawn fresh terminal",
+				};
+			}
+		},
+		[queryClient],
+	);
+}


### PR DESCRIPTION
## Summary

Fixes #4641.

This PR addresses two related issues with terminal session persistence and lifecycle:

### 1. Bug Fix: Infinite reattach loop after PC reboot
- **Root Cause**: In `tmux.go`, `IsAlive` classified `serverNotRunningOutput` ("no server running") as `ports.ErrRuntimeUnavailable` (a retryable/transient error) rather than `(false, nil)`. Because it was treated as transient, `attachment.go` retried with linear backoff, but the frontend's 3-second open timeout tore down the socket and reconnected first, resetting the backend's retry counter. This resulted in two retry loops perpetually interrupting each other in an infinite "reattaching" state instead of reaching a clean "session ended" state.
- **Fix**: Reclassified "no server running" as permanent death `(false, nil)`, identical to the "session not found" case. `attachment.go` immediately marks the session as exited. (Darwin native PTY host already uses this classification via `isConnRefused`).
- **Tests**: Updated `TestIsAliveReportsNoServerAsPermanentDeath` and integration test expectations.

### 2. Feature: Auto-resume terminal-only agents into fresh session
- **Behavior**: When a user opens/interacts with a confirmed permanently dead terminal session (`state === "exited"`):
  1. Calls `POST /api/v1/sessions/{sessionId}/auto-resume-agent` (`AutoResumeAgentWithMode`), which checks if the agent adapter's `GetRestoreCommand` returns `ok=true` (supported for agents like Cline, Claude Code, Goose, etc. that persist native conversation IDs on disk).
  2. If `ok=true`: Launches a fresh terminal process with native resume argv, attaches transparently, and displays a one-line banner: `"Session expired after restart — resumed via <agent>'s native session recovery"`.
  3. If `ok=false`: Returns `SESSION_NO_NATIVE_RESUME` (mapped to HTTP 409), falling back cleanly to the existing "session ended" state with no silent relaunch.
  4. Gated strictly on definitively-dead terminal state, never on transient errors.

## Test Coverage
- `TestIsAliveReportsNoServerAsPermanentDeath` in `tmux_test.go`
- `TestAutoResumeAgent_SucceedsForNativeRestore` in `manager_test.go`
- `TestAutoResumeAgent_FailsWithErrNoNativeResumeWhenNotResumable` in `manager_test.go`
- `TestAutoResumeAgent_RequiresLiveExitedSession` in `manager_test.go`
- `autoResumeAgent` endpoint test in `sessions_test.go`
- Full backend suite passing (`go test ./...`)