### PR TITLE
perf: reduce renderer interaction overhead

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -88,6 +88,7 @@
 				"jsdom": "^29.1.1",
 				"openapi-typescript": "^7.13.0",
 				"playwright": "^1.60.0",
+				"react-scan": "^0.5.7",
 				"tailwindcss": "^4.3.0",
 				"typescript": "^5.6.0",
 				"vite": "^8.0.16",
@@ -228,6 +229,13 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
 			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@astrojs/compiler": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+			"integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2908,6 +2916,121 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+			"integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/config-helpers": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+			"integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
 		"node_modules/@exodus/bytes": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -3003,6 +3126,84 @@
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
+				"@humanwhocodes/retry": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@iarna/toml": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/@inquirer/checkbox": {
 			"version": "3.0.1",
@@ -4494,6 +4695,353 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@oxc-parser/binding-android-arm-eabi": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
+			"integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-android-arm64": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
+			"integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-darwin-arm64": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
+			"integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-darwin-x64": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
+			"integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-freebsd-x64": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
+			"integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
+			"integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
+			"integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
+			"integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
+			"integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
+			"integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
+			"integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
+			"integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
+			"integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
+			"integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-linux-x64-musl": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
+			"integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-openharmony-arm64": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
+			"integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
+			"integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
+			"integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
+			"integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.133.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -4502,6 +5050,682 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-android-arm-eabi": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+			"integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-android-arm64": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+			"integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-arm64": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+			"integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-x64": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+			"integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-freebsd-x64": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+			"integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+			"integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+			"integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+			"integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+			"integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+			"integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+			"integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+			"integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+			"integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+			"integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-musl": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+			"integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-openharmony-arm64": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+			"integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+			"integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.2",
+				"@emnapi/runtime": "1.11.2",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+			"integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+			"integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxlint/binding-android-arm-eabi": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
+			"integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-android-arm64": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
+			"integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-darwin-arm64": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
+			"integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-darwin-x64": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
+			"integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-freebsd-x64": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
+			"integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
+			"integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
+			"integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm64-gnu": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
+			"integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm64-musl": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
+			"integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
+			"integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
+			"integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-riscv64-musl": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
+			"integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-s390x-gnu": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
+			"integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-x64-gnu": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
+			"integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-x64-musl": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
+			"integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-openharmony-arm64": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
+			"integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-arm64-msvc": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
+			"integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-ia32-msvc": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
+			"integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-x64-msvc": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
+			"integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@peculiar/asn1-schema": {
@@ -4586,6 +5810,23 @@
 			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.390.0.tgz",
 			"integrity": "sha512-zMjK6nrUWhAlL8ECrM4WldvgawqdoAE5B0ys7eA0lCoWuyzfFoSyh6zYtEuBSDRyN7fQLSfNCK+mQH4ngOl7Zw==",
 			"license": "MIT"
+		},
+		"node_modules/@preact/signals": {
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.11.1.tgz",
+			"integrity": "sha512-uYoD+USkacTNU02kfCBkJEV7xabKTmA78W5pnT2GymsuGEC9n/ZO+UT4S96l0dIL6KLDk77VJyUFuOMBvftVHg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@preact/signals-core": "^1.14.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact": ">= 10.25.0 || >=11.0.0-0"
+			}
 		},
 		"node_modules/@preact/signals-core": {
 			"version": "1.14.4",
@@ -6118,6 +7359,263 @@
 			"integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
 			"license": "MIT"
 		},
+		"node_modules/@react-grab/cli": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@react-grab/cli/-/cli-0.2.0.tgz",
+			"integrity": "sha512-LVfA+j5cFT0Szd958WRD8W/B8ucCtz4ViiveDKWLqAwBkZFW9VRW1ZvwOUhp/M3SmVPtjDaRkW12GvAuTArP+Q==",
+			"dev": true,
+			"dependencies": {
+				"agent-install": "^0.0.6",
+				"commander": "^14.0.3",
+				"ignore": "^7.0.5",
+				"ora": "^9.4.0",
+				"package-manager-detector": "^1.6.0",
+				"picocolors": "^1.1.1",
+				"prompts": "^2.4.2",
+				"tinyexec": "^1.1.2"
+			},
+			"bin": {
+				"react-grab": "bin/cli.js"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/agent-install": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/agent-install/-/agent-install-0.0.6.tgz",
+			"integrity": "sha512-7NRMZ/ZDz2vHevQTgJsocBFpakB1/Wx5ip19YSJuj4VOXpraWztTerViNtdSyARKZT9e2yVwUUB5JXXCE7mNrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@iarna/toml": "^2.2.5",
+				"commander": "^14.0.0",
+				"jsonc-parser": "^3.3.1",
+				"picocolors": "^1.1.1",
+				"prompts": "^2.4.2",
+				"yaml": "^2.8.3"
+			},
+			"bin": {
+				"agent-install": "bin/agent-install.mjs"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/cli-spinners": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+			"integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/ignore": {
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.7.tgz",
+			"integrity": "sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/is-interactive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/log-symbols": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+			"integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0",
+				"yoctocolors": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/onetime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/ora": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+			"integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.6.2",
+				"cli-cursor": "^5.0.0",
+				"cli-spinners": "^3.2.0",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^2.1.0",
+				"log-symbols": "^7.0.1",
+				"stdin-discarder": "^0.3.2",
+				"string-width": "^8.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@react-grab/cli/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@react-symbols/icons": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/@react-symbols/icons/-/icons-1.4.1.tgz",
@@ -6481,6 +7979,36 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+			"integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@sentry/browser": {
 			"version": "10.70.0",
 			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.70.0.tgz",
@@ -6681,6 +8209,16 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@shaderfrog/glsl-parser": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@shaderfrog/glsl-parser/-/glsl-parser-7.0.1.tgz",
+			"integrity": "sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/@sindresorhus/is": {
@@ -7460,6 +8998,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -7627,6 +9172,20 @@
 			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.68.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+			"integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
@@ -8065,6 +9624,17 @@
 				"acorn": "^8.14.0"
 			}
 		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -8073,6 +9643,34 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/agent-install": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/agent-install/-/agent-install-0.0.5.tgz",
+			"integrity": "sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@iarna/toml": "^2.2.5",
+				"commander": "^14.0.0",
+				"jsonc-parser": "^3.3.1",
+				"picocolors": "^1.1.1",
+				"prompts": "^2.4.2",
+				"yaml": "^2.8.3"
+			},
+			"bin": {
+				"agent-install": "bin/agent-install.mjs"
+			}
+		},
+		"node_modules/agent-install/node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/agentkeepalive": {
@@ -8476,6 +10074,17 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/atomically": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+			"integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"stubborn-fs": "^2.0.0",
+				"when-exit": "^2.1.4"
+			}
+		},
 		"node_modules/author-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
@@ -8575,6 +10184,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
+			}
+		},
+		"node_modules/bippy": {
+			"version": "0.5.43",
+			"resolved": "https://registry.npmjs.org/bippy/-/bippy-0.5.43.tgz",
+			"integrity": "sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=17.0.1"
 			}
 		},
 		"node_modules/bl": {
@@ -9541,6 +11160,68 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/conf": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
+			"integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"atomically": "^2.0.3",
+				"debounce-fn": "^6.0.0",
+				"dot-prop": "^10.0.0",
+				"env-paths": "^3.0.0",
+				"json-schema-typed": "^8.0.1",
+				"semver": "^7.7.2",
+				"uint8array-extras": "^1.5.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/conf/node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/conf/node_modules/env-paths": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/confbox": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9682,6 +11363,22 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
+		"node_modules/debounce-fn": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+			"integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -9747,6 +11444,14 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
@@ -9833,6 +11538,31 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/deslop-js": {
+			"version": "0.9.12",
+			"resolved": "https://registry.npmjs.org/deslop-js/-/deslop-js-0.9.12.tgz",
+			"integrity": "sha512-Ku6Zngzmu4EISb58WUkRKZytfgWjJ18Cic7lb4wl+/BF0tHWRvpBOLlA0FP35r82mV45Y72AK3RPC1Nw0GLbIw==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"@oxc-project/types": "^0.143.0",
+				"fast-glob": "^3.3.3",
+				"minimatch": "^10.2.5",
+				"oxc-parser": "^0.143.0",
+				"oxc-resolver": "^11.24.2",
+				"typescript": ">=5.0.4 <6"
+			}
+		},
+		"node_modules/deslop-js/node_modules/@oxc-project/types": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -10014,6 +11744,38 @@
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/dot-prop": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.2.0.tgz",
+			"integrity": "sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/dot-prop/node_modules/type-fest": {
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+			"integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/dotenv": {
@@ -10787,12 +12549,91 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+			"integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"workspaces": [
+				"packages/*"
+			],
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.7.0",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.2",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"minimatch": "^10.2.5",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-plugin-react-hooks": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+			"integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"hermes-parser": "^0.25.1",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-validation-error": "^3.5.0 || ^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -10807,6 +12648,109 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/eslint/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/eslint/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esquery": {
@@ -10881,6 +12825,17 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/eta": {
@@ -11120,6 +13075,22 @@
 				"node": ">=8.6.0"
 			}
 		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -11180,6 +13151,20 @@
 			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
 			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
 			"license": "MIT"
+		},
+		"node_modules/file-entry-cache": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"flat-cache": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
 		},
 		"node_modules/filelist": {
 			"version": "1.0.6",
@@ -11278,6 +13263,29 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/flat-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+			"integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/flora-colossus": {
 			"version": "2.0.0",
@@ -11527,6 +13535,19 @@
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-folder-size": {
@@ -12066,6 +14087,23 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hermes-estree": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+			"integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hermes-parser": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+			"integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hermes-estree": "0.25.1"
+			}
+		},
 		"node_modules/highlight.js": {
 			"version": "11.11.1",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -12255,6 +14293,17 @@
 				}
 			],
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
 		},
 		"node_modules/import-in-the-middle": {
 			"version": "3.3.3",
@@ -12760,6 +14809,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -12780,6 +14844,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
 			"version": "4.0.0",
@@ -12811,11 +14882,36 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"node_modules/kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/lazy-val": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
 			"integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
 			"license": "MIT"
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
 		},
 		"node_modules/lexical": {
 			"version": "0.49.0",
@@ -13540,6 +15636,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+			"integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/make-fetch-happen": {
@@ -14654,6 +16762,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -14975,6 +17096,14 @@
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.4",
@@ -15338,6 +17467,25 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/optionator": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/ora": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -15397,6 +17545,453 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/oxc-parser": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
+			"integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "^0.143.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-parser/binding-android-arm-eabi": "0.143.0",
+				"@oxc-parser/binding-android-arm64": "0.143.0",
+				"@oxc-parser/binding-darwin-arm64": "0.143.0",
+				"@oxc-parser/binding-darwin-x64": "0.143.0",
+				"@oxc-parser/binding-freebsd-x64": "0.143.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.143.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.143.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.143.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.143.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.143.0"
+			}
+		},
+		"node_modules/oxc-parser/node_modules/@oxc-project/types": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/oxc-resolver": {
+			"version": "11.24.2",
+			"resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+			"integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+				"@oxc-resolver/binding-android-arm64": "11.24.2",
+				"@oxc-resolver/binding-darwin-arm64": "11.24.2",
+				"@oxc-resolver/binding-darwin-x64": "11.24.2",
+				"@oxc-resolver/binding-freebsd-x64": "11.24.2",
+				"@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+				"@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+				"@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+				"@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+				"@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+				"@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+				"@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+				"@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+				"@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+				"@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+				"@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+				"@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+				"@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+				"@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
+			}
+		},
+		"node_modules/oxlint": {
+			"version": "1.77.0",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
+			"integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"oxlint": "bin/oxlint"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxlint/binding-android-arm-eabi": "1.77.0",
+				"@oxlint/binding-android-arm64": "1.77.0",
+				"@oxlint/binding-darwin-arm64": "1.77.0",
+				"@oxlint/binding-darwin-x64": "1.77.0",
+				"@oxlint/binding-freebsd-x64": "1.77.0",
+				"@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
+				"@oxlint/binding-linux-arm-musleabihf": "1.77.0",
+				"@oxlint/binding-linux-arm64-gnu": "1.77.0",
+				"@oxlint/binding-linux-arm64-musl": "1.77.0",
+				"@oxlint/binding-linux-ppc64-gnu": "1.77.0",
+				"@oxlint/binding-linux-riscv64-gnu": "1.77.0",
+				"@oxlint/binding-linux-riscv64-musl": "1.77.0",
+				"@oxlint/binding-linux-s390x-gnu": "1.77.0",
+				"@oxlint/binding-linux-x64-gnu": "1.77.0",
+				"@oxlint/binding-linux-x64-musl": "1.77.0",
+				"@oxlint/binding-openharmony-arm64": "1.77.0",
+				"@oxlint/binding-win32-arm64-msvc": "1.77.0",
+				"@oxlint/binding-win32-ia32-msvc": "1.77.0",
+				"@oxlint/binding-win32-x64-msvc": "1.77.0"
+			},
+			"peerDependencies": {
+				"oxlint-tsgolint": ">=7.0.2001",
+				"vite-plus": "*"
+			},
+			"peerDependenciesMeta": {
+				"oxlint-tsgolint": {
+					"optional": true
+				},
+				"vite-plus": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor": {
+			"version": "0.9.12",
+			"resolved": "https://registry.npmjs.org/oxlint-plugin-react-doctor/-/oxlint-plugin-react-doctor-0.9.12.tgz",
+			"integrity": "sha512-BplcCUU/tGByFGgY1YIax6evUmjk0K8zOGGrdPs3A3dqamrzjUvVuJdYpM1Ftyt/B5fFx6+VwRrWi3YZbIz4VQ==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"@shaderfrog/glsl-parser": "^7.0.1",
+				"@typescript-eslint/types": "^8.59.3",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"lightningcss": "^1.33.0",
+				"oxc-parser": "^0.143.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.13.0"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.33.0",
+				"lightningcss-darwin-arm64": "1.33.0",
+				"lightningcss-darwin-x64": "1.33.0",
+				"lightningcss-freebsd-x64": "1.33.0",
+				"lightningcss-linux-arm-gnueabihf": "1.33.0",
+				"lightningcss-linux-arm64-gnu": "1.33.0",
+				"lightningcss-linux-arm64-musl": "1.33.0",
+				"lightningcss-linux-x64-gnu": "1.33.0",
+				"lightningcss-linux-x64-musl": "1.33.0",
+				"lightningcss-win32-arm64-msvc": "1.33.0",
+				"lightningcss-win32-x64-msvc": "1.33.0"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-android-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-darwin-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-darwin-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-freebsd-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -15496,6 +18091,13 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/package-manager-detector": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+			"integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/parse-author": {
 			"version": "2.0.0",
@@ -15857,6 +18459,17 @@
 				"url": "https://opencollective.com/preact"
 			}
 		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/prettier": {
 			"version": "3.8.4",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
@@ -15949,6 +18562,20 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/prompts": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/proper-lockfile": {
@@ -16223,6 +18850,40 @@
 				"dnd-core": "14.0.1"
 			}
 		},
+		"node_modules/react-doctor": {
+			"version": "0.9.12",
+			"resolved": "https://registry.npmjs.org/react-doctor/-/react-doctor-0.9.12.tgz",
+			"integrity": "sha512-H7RNg13RYKwpQvi3+O3IkSj8pAD1pGTxSetxu7aOwXX3wmF+BydCLDiWxkPT9Pq7bIMHjuJ0taSZLsxEjlNjcA==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE",
+			"dependencies": {
+				"@astrojs/compiler": "^4.0.0",
+				"@sentry/node": "^10.54.0",
+				"agent-install": "0.0.5",
+				"conf": "^15.1.0",
+				"confbox": "^0.2.4",
+				"deslop-js": "0.9.12",
+				"eslint-plugin-react-hooks": "^7.1.1",
+				"jiti": "^2.7.0",
+				"magicast": "^0.5.3",
+				"oxc-resolver": "^11.24.2",
+				"oxlint": ">=1.77.0 <1.78.0",
+				"oxlint-plugin-react-doctor": "0.9.12",
+				"prompts": "^2.4.2",
+				"typescript": ">=5.0.4 <6",
+				"vscode-languageserver": "^9.0.1",
+				"vscode-languageserver-textdocument": "^1.0.12",
+				"vscode-uri": "^3.1.0",
+				"yaml": "^2.9.0",
+				"yoga-layout": "~3.2.1"
+			},
+			"bin": {
+				"react-doctor": "bin/react-doctor.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.13.0"
+			}
+		},
 		"node_modules/react-dom": {
 			"version": "19.2.7",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
@@ -16233,6 +18894,38 @@
 			},
 			"peerDependencies": {
 				"react": "^19.2.7"
+			}
+		},
+		"node_modules/react-grab": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/react-grab/-/react-grab-0.2.0.tgz",
+			"integrity": "sha512-ohhsfXD4qN0j6cMQd56aaVJBPDF3kUdviF/Od1Eak/rEIXQ3svQ4gjkwTfuTZwTBnxHRL16p9JqdlVQO5nUHqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-grab/cli": "0.2.0",
+				"bippy": "^0.6.1"
+			},
+			"bin": {
+				"react-grab": "bin/cli.js"
+			},
+			"peerDependencies": {
+				"react": ">=17.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-grab/node_modules/bippy": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/bippy/-/bippy-0.6.1.tgz",
+			"integrity": "sha512-ky4m94Y/KfsddjGkKTsV4uFjZqkJjpOjQ2t5gKPdX6XH1MNxMNX5FrVefsxV4lpjemEmEdwe0e0YbzAMNs3oUQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=17.0.1"
 			}
 		},
 		"node_modules/react-i18next": {
@@ -16352,6 +19045,52 @@
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
 				"react-dom": "^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/react-scan": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/react-scan/-/react-scan-0.5.7.tgz",
+			"integrity": "sha512-KRlq734yN6q/f2CZmZi9CWHuiqSzoLhPFLtcJOL6XM4lR54myyFcY81pG9QOwj+eBC1hIHm5n+Ntbtqiilu8Rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@preact/signals": "^2.9.0",
+				"@rollup/pluginutils": "^5.3.0",
+				"bippy": "^0.5.39",
+				"commander": "^14.0.0",
+				"picocolors": "^1.1.1",
+				"preact": "^10.29.1",
+				"prompts": "^2.4.2",
+				"react-doctor": "latest",
+				"react-grab": "latest"
+			},
+			"bin": {
+				"react-scan": "bin/cli.js"
+			},
+			"optionalDependencies": {
+				"unplugin": "^3.0.0"
+			},
+			"peerDependencies": {
+				"esbuild": ">=0.18.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"esbuild": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-scan/node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/react-style-singleton": {
@@ -17080,6 +19819,13 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/slice-ansi": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -17311,6 +20057,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/stdin-discarder": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+			"integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -17419,6 +20178,23 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/stubborn-fs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+			"integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"stubborn-utils": "^1.0.1"
+			}
+		},
+		"node_modules/stubborn-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+			"integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/style-to-js": {
 			"version": "1.1.21",
 			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -17488,6 +20264,19 @@
 			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
 			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
 			"license": "MIT"
+		},
+		"node_modules/tagged-tag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/tailwind-merge": {
 			"version": "3.6.0",
@@ -17913,6 +20702,20 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
 		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/type-fest": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -17939,6 +20742,19 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/undici": {
@@ -18184,6 +21000,17 @@
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/uri-js-replace": {
@@ -18509,6 +21336,61 @@
 				}
 			}
 		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+			"integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+			"integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/w3c-xmlserializer": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -18684,6 +21566,13 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
+		"node_modules/when-exit": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+			"integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/which": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -18721,8 +21610,8 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -18817,6 +21706,22 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/yaml-ast-parser": {
 			"version": "0.0.43",
 			"resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
@@ -18895,6 +21800,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/yoctocolors": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+			"integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/yoctocolors-cjs": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
@@ -18908,6 +21826,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/yoga-layout": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+			"integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/zod": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -18916,6 +21841,19 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-validation-error": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+			"integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
 			}
 		},
 		"node_modules/zustand": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -88,7 +88,6 @@
 				"jsdom": "^29.1.1",
 				"openapi-typescript": "^7.13.0",
 				"playwright": "^1.60.0",
-				"react-scan": "^0.5.7",
 				"tailwindcss": "^4.3.0",
 				"typescript": "^5.6.0",
 				"vite": "^8.0.16",
@@ -229,13 +228,6 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
 			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@astrojs/compiler": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
-			"integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2916,121 +2908,6 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
-			"integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^3.4.3"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-			}
-		},
-		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@eslint-community/regexpp": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@eslint/config-array": {
-			"version": "0.23.5",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@eslint/object-schema": "^3.0.5",
-				"debug": "^4.3.1",
-				"minimatch": "^10.2.4"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			}
-		},
-		"node_modules/@eslint/config-helpers": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
-			"integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@eslint/core": "^1.2.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			}
-		},
-		"node_modules/@eslint/core": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.15"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			}
-		},
-		"node_modules/@eslint/object-schema": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			}
-		},
-		"node_modules/@eslint/plugin-kit": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@eslint/core": "^1.2.1",
-				"levn": "^0.4.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			}
-		},
 		"node_modules/@exodus/bytes": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -3126,84 +3003,6 @@
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@humanfs/core": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
-			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@humanfs/types": "^0.15.0"
-			},
-			"engines": {
-				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/@humanfs/node": {
-			"version": "0.16.8",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
-			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@humanfs/core": "^0.19.2",
-				"@humanfs/types": "^0.15.0",
-				"@humanwhocodes/retry": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/@humanfs/types": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
-			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": ">=18.18.0"
-			}
-		},
-		"node_modules/@humanwhocodes/module-importer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": ">=12.22"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@humanwhocodes/retry": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": ">=18.18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@iarna/toml": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/@inquirer/checkbox": {
 			"version": "3.0.1",
@@ -4695,353 +4494,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@oxc-parser/binding-android-arm-eabi": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
-			"integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-android-arm64": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
-			"integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-darwin-arm64": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
-			"integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-darwin-x64": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
-			"integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-freebsd-x64": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
-			"integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
-			"integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
-			"integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
-			"integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
-			"integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
-			"integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
-			"integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
-			"integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
-			"integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
-			"integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-linux-x64-musl": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
-			"integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-openharmony-arm64": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
-			"integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
-			"integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
-			"integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
-			"integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.133.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -5050,682 +4502,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
-			}
-		},
-		"node_modules/@oxc-resolver/binding-android-arm-eabi": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
-			"integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-android-arm64": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
-			"integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-darwin-arm64": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
-			"integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-darwin-x64": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
-			"integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-freebsd-x64": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
-			"integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
-			"integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
-			"integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
-			"integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
-			"integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
-			"integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
-			"integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
-			"integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
-			"integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
-			"integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-linux-x64-musl": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
-			"integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-openharmony-arm64": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
-			"integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-wasm32-wasi": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
-			"integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "1.11.2",
-				"@emnapi/runtime": "1.11.2",
-				"@napi-rs/wasm-runtime": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
-			"integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
-			"integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@oxlint/binding-android-arm-eabi": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
-			"integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-android-arm64": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
-			"integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-darwin-arm64": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
-			"integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-darwin-x64": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
-			"integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-freebsd-x64": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
-			"integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
-			"integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
-			"integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-arm64-gnu": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
-			"integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-arm64-musl": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
-			"integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
-			"integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
-			"integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-riscv64-musl": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
-			"integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-s390x-gnu": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
-			"integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-x64-gnu": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
-			"integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-linux-x64-musl": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
-			"integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-openharmony-arm64": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
-			"integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-win32-arm64-msvc": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
-			"integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-win32-ia32-msvc": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
-			"integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@oxlint/binding-win32-x64-msvc": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
-			"integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@peculiar/asn1-schema": {
@@ -5810,23 +4586,6 @@
 			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.390.0.tgz",
 			"integrity": "sha512-zMjK6nrUWhAlL8ECrM4WldvgawqdoAE5B0ys7eA0lCoWuyzfFoSyh6zYtEuBSDRyN7fQLSfNCK+mQH4ngOl7Zw==",
 			"license": "MIT"
-		},
-		"node_modules/@preact/signals": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.11.1.tgz",
-			"integrity": "sha512-uYoD+USkacTNU02kfCBkJEV7xabKTmA78W5pnT2GymsuGEC9n/ZO+UT4S96l0dIL6KLDk77VJyUFuOMBvftVHg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@preact/signals-core": "^1.14.4"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
-			},
-			"peerDependencies": {
-				"preact": ">= 10.25.0 || >=11.0.0-0"
-			}
 		},
 		"node_modules/@preact/signals-core": {
 			"version": "1.14.4",
@@ -7359,263 +6118,6 @@
 			"integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
 			"license": "MIT"
 		},
-		"node_modules/@react-grab/cli": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@react-grab/cli/-/cli-0.2.0.tgz",
-			"integrity": "sha512-LVfA+j5cFT0Szd958WRD8W/B8ucCtz4ViiveDKWLqAwBkZFW9VRW1ZvwOUhp/M3SmVPtjDaRkW12GvAuTArP+Q==",
-			"dev": true,
-			"dependencies": {
-				"agent-install": "^0.0.6",
-				"commander": "^14.0.3",
-				"ignore": "^7.0.5",
-				"ora": "^9.4.0",
-				"package-manager-detector": "^1.6.0",
-				"picocolors": "^1.1.1",
-				"prompts": "^2.4.2",
-				"tinyexec": "^1.1.2"
-			},
-			"bin": {
-				"react-grab": "bin/cli.js"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/agent-install": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/agent-install/-/agent-install-0.0.6.tgz",
-			"integrity": "sha512-7NRMZ/ZDz2vHevQTgJsocBFpakB1/Wx5ip19YSJuj4VOXpraWztTerViNtdSyARKZT9e2yVwUUB5JXXCE7mNrA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@iarna/toml": "^2.2.5",
-				"commander": "^14.0.0",
-				"jsonc-parser": "^3.3.1",
-				"picocolors": "^1.1.1",
-				"prompts": "^2.4.2",
-				"yaml": "^2.8.3"
-			},
-			"bin": {
-				"agent-install": "bin/agent-install.mjs"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/ansi-regex": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/cli-cursor": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"restore-cursor": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/cli-spinners": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
-			"integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/commander": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/ignore": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.7.tgz",
-			"integrity": "sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/is-interactive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/is-unicode-supported": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/log-symbols": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
-			"integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-unicode-supported": "^2.0.0",
-				"yoctocolors": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/onetime": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-function": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/ora": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
-			"integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^5.6.2",
-				"cli-cursor": "^5.0.0",
-				"cli-spinners": "^3.2.0",
-				"is-interactive": "^2.0.0",
-				"is-unicode-supported": "^2.1.0",
-				"log-symbols": "^7.0.1",
-				"stdin-discarder": "^0.3.2",
-				"string-width": "^8.1.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/restore-cursor": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"onetime": "^7.0.0",
-				"signal-exit": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/string-width": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
-			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"get-east-asian-width": "^1.5.0",
-				"strip-ansi": "^7.1.2"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@react-grab/cli/node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.2.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
 		"node_modules/@react-symbols/icons": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/@react-symbols/icons/-/icons-1.4.1.tgz",
@@ -7979,36 +6481,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@rollup/pluginutils": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-			"integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^2.0.2",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@sentry/browser": {
 			"version": "10.70.0",
 			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.70.0.tgz",
@@ -8209,16 +6681,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@shaderfrog/glsl-parser": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@shaderfrog/glsl-parser/-/glsl-parser-7.0.1.tgz",
-			"integrity": "sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/@sindresorhus/is": {
@@ -8998,13 +7460,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/esrecurse": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -9172,20 +7627,6 @@
 			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
-			}
-		},
-		"node_modules/@typescript-eslint/types": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
-			"integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@ungap/structured-clone": {
@@ -9624,17 +8065,6 @@
 				"acorn": "^8.14.0"
 			}
 		},
-		"node_modules/acorn-jsx": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"peerDependencies": {
-				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -9643,34 +8073,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/agent-install": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/agent-install/-/agent-install-0.0.5.tgz",
-			"integrity": "sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@iarna/toml": "^2.2.5",
-				"commander": "^14.0.0",
-				"jsonc-parser": "^3.3.1",
-				"picocolors": "^1.1.1",
-				"prompts": "^2.4.2",
-				"yaml": "^2.8.3"
-			},
-			"bin": {
-				"agent-install": "bin/agent-install.mjs"
-			}
-		},
-		"node_modules/agent-install/node_modules/commander": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/agentkeepalive": {
@@ -10074,17 +8476,6 @@
 				"node": ">= 4.0.0"
 			}
 		},
-		"node_modules/atomically": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
-			"integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"stubborn-fs": "^2.0.0",
-				"when-exit": "^2.1.4"
-			}
-		},
 		"node_modules/author-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
@@ -10184,16 +8575,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
-			}
-		},
-		"node_modules/bippy": {
-			"version": "0.5.43",
-			"resolved": "https://registry.npmjs.org/bippy/-/bippy-0.5.43.tgz",
-			"integrity": "sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"react": ">=17.0.1"
 			}
 		},
 		"node_modules/bl": {
@@ -11160,68 +9541,6 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
-		"node_modules/conf": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
-			"integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^8.17.1",
-				"ajv-formats": "^3.0.1",
-				"atomically": "^2.0.3",
-				"debounce-fn": "^6.0.0",
-				"dot-prop": "^10.0.0",
-				"env-paths": "^3.0.0",
-				"json-schema-typed": "^8.0.1",
-				"semver": "^7.7.2",
-				"uint8array-extras": "^1.5.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/conf/node_modules/ajv-formats": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/conf/node_modules/env-paths": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/confbox": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -11363,22 +9682,6 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/debounce-fn": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
-			"integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-function": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -11444,14 +9747,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/deep-is": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
@@ -11538,31 +9833,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/deslop-js": {
-			"version": "0.9.12",
-			"resolved": "https://registry.npmjs.org/deslop-js/-/deslop-js-0.9.12.tgz",
-			"integrity": "sha512-Ku6Zngzmu4EISb58WUkRKZytfgWjJ18Cic7lb4wl+/BF0tHWRvpBOLlA0FP35r82mV45Y72AK3RPC1Nw0GLbIw==",
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE",
-			"dependencies": {
-				"@oxc-project/types": "^0.143.0",
-				"fast-glob": "^3.3.3",
-				"minimatch": "^10.2.5",
-				"oxc-parser": "^0.143.0",
-				"oxc-resolver": "^11.24.2",
-				"typescript": ">=5.0.4 <6"
-			}
-		},
-		"node_modules/deslop-js/node_modules/@oxc-project/types": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -11744,38 +10014,6 @@
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
-			}
-		},
-		"node_modules/dot-prop": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.2.0.tgz",
-			"integrity": "sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/dot-prop/node_modules/type-fest": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-			"integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"dependencies": {
-				"tagged-tag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/dotenv": {
@@ -12549,91 +10787,12 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint": {
-			"version": "10.9.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
-			"integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"workspaces": [
-				"packages/*"
-			],
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.8.0",
-				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.5",
-				"@eslint/config-helpers": "^0.7.0",
-				"@eslint/core": "^1.2.1",
-				"@eslint/plugin-kit": "^0.7.2",
-				"@humanfs/node": "^0.16.6",
-				"@humanwhocodes/module-importer": "^1.0.1",
-				"@humanwhocodes/retry": "^0.4.2",
-				"@types/estree": "^1.0.6",
-				"ajv": "^6.14.0",
-				"cross-spawn": "^7.0.6",
-				"debug": "^4.3.2",
-				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^9.1.2",
-				"eslint-visitor-keys": "^5.0.1",
-				"espree": "^11.2.0",
-				"esquery": "^1.7.0",
-				"esutils": "^2.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^8.0.0",
-				"find-up": "^5.0.0",
-				"glob-parent": "^6.0.2",
-				"ignore": "^5.2.0",
-				"imurmurhash": "^0.1.4",
-				"is-glob": "^4.0.0",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.5",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3"
-			},
-			"bin": {
-				"eslint": "bin/eslint.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://eslint.org/donate"
-			},
-			"peerDependencies": {
-				"jiti": "*"
-			},
-			"peerDependenciesMeta": {
-				"jiti": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-react-hooks": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
-			"integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.24.4",
-				"@babel/parser": "^7.24.4",
-				"hermes-parser": "^0.25.1",
-				"zod": "^3.25.0 || ^4.0.0",
-				"zod-validation-error": "^3.5.0 || ^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -12648,109 +10807,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/ajv": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"@types/esrecurse": "^4.3.1",
-				"@types/estree": "^1.0.8",
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/eslint/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"is-glob": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/eslint/node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/espree": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"acorn": "^8.16.0",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^5.0.1"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esquery": {
@@ -12825,17 +10881,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
-			}
-		},
-		"node_modules/esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/eta": {
@@ -13075,22 +11120,6 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/fast-levenshtein": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/fast-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -13151,20 +11180,6 @@
 			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
 			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
 			"license": "MIT"
-		},
-		"node_modules/file-entry-cache": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"flat-cache": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
 		},
 		"node_modules/filelist": {
 			"version": "1.0.6",
@@ -13263,29 +11278,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/flat-cache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"flatted": "^3.2.9",
-				"keyv": "^4.5.4"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/flatted": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
-			"integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true
 		},
 		"node_modules/flora-colossus": {
 			"version": "2.0.0",
@@ -13535,19 +11527,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
-		"node_modules/get-east-asian-width": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-folder-size": {
@@ -14087,23 +12066,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/hermes-estree": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-			"integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/hermes-parser": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-			"integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hermes-estree": "0.25.1"
-			}
-		},
 		"node_modules/highlight.js": {
 			"version": "11.11.1",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -14293,17 +12255,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 4"
-			}
 		},
 		"node_modules/import-in-the-middle": {
 			"version": "3.3.3",
@@ -14809,21 +12760,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/json-schema-typed": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/json-stable-stringify-without-jsonify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -14844,13 +12780,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
 			"version": "4.0.0",
@@ -14882,36 +12811,11 @@
 				"json-buffer": "3.0.1"
 			}
 		},
-		"node_modules/kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/lazy-val": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
 			"integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
 			"license": "MIT"
-		},
-		"node_modules/levn": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"prelude-ls": "^1.2.1",
-				"type-check": "~0.4.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
 		},
 		"node_modules/lexical": {
 			"version": "0.49.0",
@@ -15636,18 +13540,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
-			}
-		},
-		"node_modules/magicast": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
-			"integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.29.7",
-				"@babel/types": "^7.29.7",
-				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/make-fetch-happen": {
@@ -16762,19 +14654,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/mimic-function": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -17096,14 +14975,6 @@
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
-		},
-		"node_modules/natural-compare": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.4",
@@ -17467,25 +15338,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/optionator": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"deep-is": "^0.1.3",
-				"fast-levenshtein": "^2.0.6",
-				"levn": "^0.4.1",
-				"prelude-ls": "^1.2.1",
-				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.5"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/ora": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -17545,453 +15397,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/oxc-parser": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
-			"integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@oxc-project/types": "^0.143.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
-			},
-			"optionalDependencies": {
-				"@oxc-parser/binding-android-arm-eabi": "0.143.0",
-				"@oxc-parser/binding-android-arm64": "0.143.0",
-				"@oxc-parser/binding-darwin-arm64": "0.143.0",
-				"@oxc-parser/binding-darwin-x64": "0.143.0",
-				"@oxc-parser/binding-freebsd-x64": "0.143.0",
-				"@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
-				"@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
-				"@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
-				"@oxc-parser/binding-linux-arm64-musl": "0.143.0",
-				"@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
-				"@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
-				"@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
-				"@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
-				"@oxc-parser/binding-linux-x64-gnu": "0.143.0",
-				"@oxc-parser/binding-linux-x64-musl": "0.143.0",
-				"@oxc-parser/binding-openharmony-arm64": "0.143.0",
-				"@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
-				"@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
-				"@oxc-parser/binding-win32-x64-msvc": "0.143.0"
-			}
-		},
-		"node_modules/oxc-parser/node_modules/@oxc-project/types": {
-			"version": "0.143.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
-			}
-		},
-		"node_modules/oxc-resolver": {
-			"version": "11.24.2",
-			"resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
-			"integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
-			},
-			"optionalDependencies": {
-				"@oxc-resolver/binding-android-arm-eabi": "11.24.2",
-				"@oxc-resolver/binding-android-arm64": "11.24.2",
-				"@oxc-resolver/binding-darwin-arm64": "11.24.2",
-				"@oxc-resolver/binding-darwin-x64": "11.24.2",
-				"@oxc-resolver/binding-freebsd-x64": "11.24.2",
-				"@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
-				"@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
-				"@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
-				"@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
-				"@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
-				"@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
-				"@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
-				"@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
-				"@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
-				"@oxc-resolver/binding-linux-x64-musl": "11.24.2",
-				"@oxc-resolver/binding-openharmony-arm64": "11.24.2",
-				"@oxc-resolver/binding-wasm32-wasi": "11.24.2",
-				"@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
-				"@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
-			}
-		},
-		"node_modules/oxlint": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
-			"integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"oxlint": "bin/oxlint"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
-			},
-			"optionalDependencies": {
-				"@oxlint/binding-android-arm-eabi": "1.77.0",
-				"@oxlint/binding-android-arm64": "1.77.0",
-				"@oxlint/binding-darwin-arm64": "1.77.0",
-				"@oxlint/binding-darwin-x64": "1.77.0",
-				"@oxlint/binding-freebsd-x64": "1.77.0",
-				"@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
-				"@oxlint/binding-linux-arm-musleabihf": "1.77.0",
-				"@oxlint/binding-linux-arm64-gnu": "1.77.0",
-				"@oxlint/binding-linux-arm64-musl": "1.77.0",
-				"@oxlint/binding-linux-ppc64-gnu": "1.77.0",
-				"@oxlint/binding-linux-riscv64-gnu": "1.77.0",
-				"@oxlint/binding-linux-riscv64-musl": "1.77.0",
-				"@oxlint/binding-linux-s390x-gnu": "1.77.0",
-				"@oxlint/binding-linux-x64-gnu": "1.77.0",
-				"@oxlint/binding-linux-x64-musl": "1.77.0",
-				"@oxlint/binding-openharmony-arm64": "1.77.0",
-				"@oxlint/binding-win32-arm64-msvc": "1.77.0",
-				"@oxlint/binding-win32-ia32-msvc": "1.77.0",
-				"@oxlint/binding-win32-x64-msvc": "1.77.0"
-			},
-			"peerDependencies": {
-				"oxlint-tsgolint": ">=7.0.2001",
-				"vite-plus": "*"
-			},
-			"peerDependenciesMeta": {
-				"oxlint-tsgolint": {
-					"optional": true
-				},
-				"vite-plus": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor": {
-			"version": "0.9.12",
-			"resolved": "https://registry.npmjs.org/oxlint-plugin-react-doctor/-/oxlint-plugin-react-doctor-0.9.12.tgz",
-			"integrity": "sha512-BplcCUU/tGByFGgY1YIax6evUmjk0K8zOGGrdPs3A3dqamrzjUvVuJdYpM1Ftyt/B5fFx6+VwRrWi3YZbIz4VQ==",
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE",
-			"dependencies": {
-				"@shaderfrog/glsl-parser": "^7.0.1",
-				"@typescript-eslint/types": "^8.59.3",
-				"eslint-scope": "^9.1.2",
-				"eslint-visitor-keys": "^5.0.1",
-				"lightningcss": "^1.33.0",
-				"oxc-parser": "^0.143.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.13.0"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/eslint-scope": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@types/esrecurse": "^4.3.1",
-				"@types/estree": "^1.0.8",
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-			"dev": true,
-			"license": "MPL-2.0",
-			"dependencies": {
-				"detect-libc": "^2.0.3"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"lightningcss-android-arm64": "1.33.0",
-				"lightningcss-darwin-arm64": "1.33.0",
-				"lightningcss-darwin-x64": "1.33.0",
-				"lightningcss-freebsd-x64": "1.33.0",
-				"lightningcss-linux-arm-gnueabihf": "1.33.0",
-				"lightningcss-linux-arm64-gnu": "1.33.0",
-				"lightningcss-linux-arm64-musl": "1.33.0",
-				"lightningcss-linux-x64-gnu": "1.33.0",
-				"lightningcss-linux-x64-musl": "1.33.0",
-				"lightningcss-win32-arm64-msvc": "1.33.0",
-				"lightningcss-win32-x64-msvc": "1.33.0"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-android-arm64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-darwin-arm64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-darwin-x64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-freebsd-x64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-arm-gnueabihf": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-arm64-gnu": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-arm64-musl": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-x64-gnu": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"glibc"
-			],
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-linux-x64-musl": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"libc": [
-				"musl"
-			],
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-win32-arm64-msvc": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/oxlint-plugin-react-doctor/node_modules/lightningcss-win32-x64-msvc": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -18091,13 +15496,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/package-manager-detector": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
-			"integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/parse-author": {
 			"version": "2.0.0",
@@ -18459,17 +15857,6 @@
 				"url": "https://opencollective.com/preact"
 			}
 		},
-		"node_modules/prelude-ls": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/prettier": {
 			"version": "3.8.4",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
@@ -18562,20 +15949,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/prompts": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/proper-lockfile": {
@@ -18850,40 +16223,6 @@
 				"dnd-core": "14.0.1"
 			}
 		},
-		"node_modules/react-doctor": {
-			"version": "0.9.12",
-			"resolved": "https://registry.npmjs.org/react-doctor/-/react-doctor-0.9.12.tgz",
-			"integrity": "sha512-H7RNg13RYKwpQvi3+O3IkSj8pAD1pGTxSetxu7aOwXX3wmF+BydCLDiWxkPT9Pq7bIMHjuJ0taSZLsxEjlNjcA==",
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE",
-			"dependencies": {
-				"@astrojs/compiler": "^4.0.0",
-				"@sentry/node": "^10.54.0",
-				"agent-install": "0.0.5",
-				"conf": "^15.1.0",
-				"confbox": "^0.2.4",
-				"deslop-js": "0.9.12",
-				"eslint-plugin-react-hooks": "^7.1.1",
-				"jiti": "^2.7.0",
-				"magicast": "^0.5.3",
-				"oxc-resolver": "^11.24.2",
-				"oxlint": ">=1.77.0 <1.78.0",
-				"oxlint-plugin-react-doctor": "0.9.12",
-				"prompts": "^2.4.2",
-				"typescript": ">=5.0.4 <6",
-				"vscode-languageserver": "^9.0.1",
-				"vscode-languageserver-textdocument": "^1.0.12",
-				"vscode-uri": "^3.1.0",
-				"yaml": "^2.9.0",
-				"yoga-layout": "~3.2.1"
-			},
-			"bin": {
-				"react-doctor": "bin/react-doctor.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.13.0"
-			}
-		},
 		"node_modules/react-dom": {
 			"version": "19.2.7",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
@@ -18894,38 +16233,6 @@
 			},
 			"peerDependencies": {
 				"react": "^19.2.7"
-			}
-		},
-		"node_modules/react-grab": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/react-grab/-/react-grab-0.2.0.tgz",
-			"integrity": "sha512-ohhsfXD4qN0j6cMQd56aaVJBPDF3kUdviF/Od1Eak/rEIXQ3svQ4gjkwTfuTZwTBnxHRL16p9JqdlVQO5nUHqA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@react-grab/cli": "0.2.0",
-				"bippy": "^0.6.1"
-			},
-			"bin": {
-				"react-grab": "bin/cli.js"
-			},
-			"peerDependencies": {
-				"react": ">=17.0.0"
-			},
-			"peerDependenciesMeta": {
-				"react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/react-grab/node_modules/bippy": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/bippy/-/bippy-0.6.1.tgz",
-			"integrity": "sha512-ky4m94Y/KfsddjGkKTsV4uFjZqkJjpOjQ2t5gKPdX6XH1MNxMNX5FrVefsxV4lpjemEmEdwe0e0YbzAMNs3oUQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"react": ">=17.0.1"
 			}
 		},
 		"node_modules/react-i18next": {
@@ -19045,52 +16352,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
 				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/react-scan": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/react-scan/-/react-scan-0.5.7.tgz",
-			"integrity": "sha512-KRlq734yN6q/f2CZmZi9CWHuiqSzoLhPFLtcJOL6XM4lR54myyFcY81pG9QOwj+eBC1hIHm5n+Ntbtqiilu8Rg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.29.0",
-				"@babel/types": "^7.29.0",
-				"@preact/signals": "^2.9.0",
-				"@rollup/pluginutils": "^5.3.0",
-				"bippy": "^0.5.39",
-				"commander": "^14.0.0",
-				"picocolors": "^1.1.1",
-				"preact": "^10.29.1",
-				"prompts": "^2.4.2",
-				"react-doctor": "latest",
-				"react-grab": "latest"
-			},
-			"bin": {
-				"react-scan": "bin/cli.js"
-			},
-			"optionalDependencies": {
-				"unplugin": "^3.0.0"
-			},
-			"peerDependencies": {
-				"esbuild": ">=0.18.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"esbuild": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/react-scan/node_modules/commander": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/react-style-singleton": {
@@ -19819,13 +17080,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/slice-ansi": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -20057,19 +17311,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/stdin-discarder": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
-			"integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -20178,23 +17419,6 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/stubborn-fs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
-			"integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"stubborn-utils": "^1.0.1"
-			}
-		},
-		"node_modules/stubborn-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
-			"integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/style-to-js": {
 			"version": "1.1.21",
 			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -20264,19 +17488,6 @@
 			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
 			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
 			"license": "MIT"
-		},
-		"node_modules/tagged-tag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/tailwind-merge": {
 			"version": "3.6.0",
@@ -20702,20 +17913,6 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD"
 		},
-		"node_modules/type-check": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"prelude-ls": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/type-fest": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -20742,19 +17939,6 @@
 			},
 			"engines": {
 				"node": ">=14.17"
-			}
-		},
-		"node_modules/uint8array-extras": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/undici": {
@@ -21000,17 +18184,6 @@
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
-			}
-		},
-		"node_modules/uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/uri-js-replace": {
@@ -21336,61 +18509,6 @@
 				}
 			}
 		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vscode-languageserver": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageserver-protocol": "3.17.5"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"vscode-jsonrpc": "8.2.0",
-				"vscode-languageserver-types": "3.17.5"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
-			"integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vscode-uri": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
-			"integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/w3c-xmlserializer": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -21566,13 +18684,6 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/when-exit": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
-			"integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/which": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -21610,8 +18721,8 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -21706,22 +18817,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/yaml-ast-parser": {
 			"version": "0.0.43",
 			"resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
@@ -21800,19 +18895,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/yoctocolors": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
-			"integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/yoctocolors-cjs": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
@@ -21826,13 +18908,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/yoga-layout": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
-			"integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/zod": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -21841,19 +18916,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-validation-error": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
-			"integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.0 || ^4.0.0"
 			}
 		},
 		"node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
 		"jsdom": "^29.1.1",
 		"openapi-typescript": "^7.13.0",
 		"playwright": "^1.60.0",
+		"react-scan": "^0.5.7",
 		"tailwindcss": "^4.3.0",
 		"typescript": "^5.6.0",
 		"vite": "^8.0.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,6 @@
 		"jsdom": "^29.1.1",
 		"openapi-typescript": "^7.13.0",
 		"playwright": "^1.60.0",
-		"react-scan": "^0.5.7",
 		"tailwindcss": "^4.3.0",
 		"typescript": "^5.6.0",
 		"vite": "^8.0.16",

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -1,4 +1,5 @@
 import {
+	memo,
 	useCallback,
 	useEffect,
 	useRef,
@@ -520,6 +521,12 @@ export function BrowserPanelView({
 		},
 		[selectTab],
 	);
+	const handleCloseTab = useCallback(
+		(tabId: string) => {
+			void closeTab(tabId);
+		},
+		[closeTab],
+	);
 
 	const annotationStatusLabel =
 		status === "picking"
@@ -578,8 +585,8 @@ export function BrowserPanelView({
 							{tabs.map((tab) => (
 								<SortableBrowserTopTab
 									key={tab.id}
-									onClose={() => void closeTab(tab.id)}
-									onSelect={() => void handleSelectTab(tab.id)}
+									onClose={handleCloseTab}
+									onSelect={handleSelectTab}
 									onlyTab={tabs.length === 1}
 									selected={tab.id === activeTabId}
 									tab={tab}
@@ -933,7 +940,7 @@ export function BrowserPanelView({
 	);
 }
 
-function SortableBrowserTopTab({
+const SortableBrowserTopTab = memo(function SortableBrowserTopTab({
 	tab,
 	selected,
 	onlyTab,
@@ -943,8 +950,8 @@ function SortableBrowserTopTab({
 	tab: BrowserViewModel["tabs"][number];
 	selected: boolean;
 	onlyTab: boolean;
-	onSelect: () => void;
-	onClose: () => void;
+	onSelect: (tabId: string) => void;
+	onClose: (tabId: string) => void;
 }) {
 	const { t } = useTranslation();
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id });
@@ -965,7 +972,7 @@ function SortableBrowserTopTab({
 				{...listeners}
 				aria-selected={selected}
 				className="browser-panel__tab-select"
-				onClick={onSelect}
+				onClick={() => void onSelect(tab.id)}
 				role="tab"
 				tabIndex={selected ? 0 : -1}
 				title={label.title}
@@ -982,7 +989,7 @@ function SortableBrowserTopTab({
 				aria-label={closeLabel}
 				className="browser-panel__tab-close"
 				disabled={onlyTab}
-				onClick={onClose}
+				onClick={() => onClose(tab.id)}
 				title={onlyTab ? t("browser.onlyTab") : closeLabel}
 				type="button"
 			>
@@ -990,7 +997,7 @@ function SortableBrowserTopTab({
 			</button>
 		</div>
 	);
-}
+});
 
 function compactBrowserAddress(url: string): string {
 	if (!url) return "";

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -15,6 +15,7 @@ const captureEventMock = vi.hoisted(() => vi.fn());
 const openExternalMock = vi.hoisted(() => vi.fn());
 const writeTextMock = vi.hoisted(() => vi.fn());
 const restoreMock = vi.hoisted(() => vi.fn());
+const workspaceSubscriptionMock = vi.hoisted(() => vi.fn());
 
 const ctx = vi.hoisted(() => {
 	const workspaces: WorkspaceSummary[] = [
@@ -102,7 +103,10 @@ vi.mock("../hooks/useCommandPaletteEnabled", () => ({
 }));
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => ({ data: ctx.workspaces }),
+	useWorkspaceQuery: (options: { subscribed?: boolean }) => {
+		workspaceSubscriptionMock(options);
+		return { data: ctx.workspaces };
+	},
 	workspaceQueryKey: ["workspaces"],
 }));
 
@@ -233,6 +237,7 @@ beforeEach(() => {
 	openExternalMock.mockReset();
 	writeTextMock.mockReset();
 	restoreMock.mockReset();
+	workspaceSubscriptionMock.mockReset();
 	restoreMock.mockResolvedValue({ status: "success" });
 	act(() => {
 		useUiStore.setState({
@@ -250,6 +255,14 @@ afterEach(() => {
 });
 
 describe("CommandPalette gating", () => {
+	it("subscribes to workspace updates only while open", () => {
+		renderPalette();
+		expect(workspaceSubscriptionMock).toHaveBeenLastCalledWith({ subscribed: false });
+
+		act(() => useUiStore.getState().setCommandPaletteOpen(true));
+		expect(workspaceSubscriptionMock).toHaveBeenLastCalledWith({ subscribed: true });
+	});
+
 	it("renders nothing and binds no shortcut on a disabled (stable) build", () => {
 		ctx.enabled = false;
 		renderPalette();

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -92,6 +92,7 @@ export function CommandPalette() {
 	// Review states are fetched only while the palette is open; the shared query
 	// key means sessions already viewed in the inspector reuse the cached data.
 	const reviewQuerySummary = useQueries({
+		subscribed: isOpen,
 		queries: sessionsWithOpenPRs.map((session) =>
 			sessionReviewsQueryOptions(session, isOpen, PALETTE_REVIEW_STALE_TIME_MS),
 		),

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -52,13 +52,16 @@ export function CommandPalette() {
 	const queryClient = useQueryClient();
 	const restoreSessionById = useRestoreSession();
 	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
-	const workspaces = useWorkspaceQuery().data ?? [];
 	const { cloneProject, createProject, initializeProjectRepository } = useShell();
 	const resolvedTheme = useUiStore((s) => s.resolvedTheme);
 	const setThemePreference = useUiStore((s) => s.setThemePreference);
 	const isOpen = useUiStore((s) => s.isCommandPaletteOpen);
 	const setOpen = useUiStore((s) => s.setCommandPaletteOpen);
 	const restartingProjectIds = useUiStore((s) => s.restartingProjectIds);
+	// The palette stays mounted to preserve its close animation and global
+	// shortcut. While closed, commands are invisible, so retain the cached
+	// snapshot without subscribing this hidden surface to streamed updates.
+	const workspaces = useWorkspaceQuery({ subscribed: isOpen }).data ?? [];
 
 	const [view, setView] = useState<PaletteView>({ mode: "root" });
 	const [query, setQuery] = useState("");

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -246,6 +246,14 @@ describe("NotificationRuntime", () => {
 });
 
 describe("NotificationCenter", () => {
+	it("subscribes to workspace metadata only while the panel is open", async () => {
+		renderNotificationCenter();
+
+		expect(workspaceQueryMock).not.toHaveBeenCalled();
+		await clickOpen();
+		expect(workspaceQueryMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("uses the compact topbar bell and unread badge sizing", () => {
 		renderNotificationCenter();
 		const trigger = screen.getByRole("button", { name: /unread notifications/ });

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMarkAllNotificationsReadMutation, useNotificationsQuery } from "../hooks/useNotificationsQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import type { WorkspaceSummary } from "../types/workspace";
 import { aoBridge } from "../lib/bridge";
 import { openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { formatTimeCompact } from "../lib/format-time";
@@ -71,13 +72,17 @@ function useNotificationTargetNavigation() {
 	return { openPrimary, openSession };
 }
 
-function useSessionTerminationLookup(): {
+function useSessionTerminationLookup(
+	workspaces: WorkspaceSummary[] | undefined,
+	isError: boolean,
+	isSuccess: boolean,
+	refetch: () => void,
+): {
 	retryWorkspace: () => void;
 	sessionsReady: boolean;
 	terminatedIds: Set<string>;
 	workspaceError: boolean;
 } {
-	const { data: workspaces, isError, isSuccess, refetch } = useWorkspaceQuery();
 	const terminatedIds = useMemo(() => {
 		const ids = new Set<string>();
 		for (const workspace of workspaces ?? []) {
@@ -92,9 +97,7 @@ function useSessionTerminationLookup(): {
 	// Only successful workspace data is trustworthy. Pending and error both leave
 	// sessions non-navigable — a failed query must not treat terminated rows as live.
 	return {
-		retryWorkspace: () => {
-			void refetch();
-		},
+		retryWorkspace: refetch,
 		sessionsReady: isSuccess,
 		terminatedIds,
 		workspaceError: isError,
@@ -164,8 +167,21 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 	const allQuery = useNotificationsQuery("all", open);
 	const markAllRead = useMarkAllNotificationsReadMutation();
 	const restoreSession = useRestoreSession();
-	const { retryWorkspace, sessionsReady, terminatedIds, workspaceError } = useSessionTerminationLookup();
-	const { data: workspaces } = useWorkspaceQuery();
+	// This panel needs one workspace snapshot for both termination gating and
+	// human-readable notification metadata. Keep a single query observer here:
+	// two observers of the same full workspace tree caused duplicate derivation
+	// and render notifications for every streamed workspace update.
+	const workspaceQuery = useWorkspaceQuery();
+	const { data: workspaces } = workspaceQuery;
+	const retryWorkspace = useCallback(() => {
+		void workspaceQuery.refetch();
+	}, [workspaceQuery.refetch]);
+	const { sessionsReady, terminatedIds, workspaceError } = useSessionTerminationLookup(
+		workspaces,
+		workspaceQuery.isError,
+		workspaceQuery.isSuccess,
+		retryWorkspace,
+	);
 	// Resolve the human project + session names for each notification so the row
 	// can show where it came from (the DTO only carries opaque ids).
 	const sessionMeta = useMemo(() => {

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -15,7 +15,7 @@ import {
 	MessageSquareDot,
 	RotateCcw,
 } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useMarkAllNotificationsReadMutation, useNotificationsQuery } from "../hooks/useNotificationsQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
@@ -104,6 +104,44 @@ function useSessionTerminationLookup(
 	};
 }
 
+/**
+ * Radix only mounts PopoverContent while the bell is open. Keeping the broad
+ * workspace observer here means streamed workspace activity cannot wake the
+ * always-mounted bell while its panel is closed.
+ */
+function NotificationWorkspaceState({
+	children,
+}: {
+	children: (state: {
+		retryWorkspace: () => void;
+		sessionMeta: Map<string, { projectName: string; sessionName: string }>;
+		sessionsReady: boolean;
+		terminatedIds: Set<string>;
+		workspaceError: boolean;
+	}) => ReactNode;
+}) {
+	const workspaceQuery = useWorkspaceQuery();
+	const retryWorkspace = useCallback(() => {
+		void workspaceQuery.refetch();
+	}, [workspaceQuery.refetch]);
+	const { sessionsReady, terminatedIds, workspaceError } = useSessionTerminationLookup(
+		workspaceQuery.data,
+		workspaceQuery.isError,
+		workspaceQuery.isSuccess,
+		retryWorkspace,
+	);
+	const sessionMeta = useMemo(() => {
+		const map = new Map<string, { projectName: string; sessionName: string }>();
+		for (const workspace of workspaceQuery.data ?? []) {
+			for (const session of workspace.sessions) {
+				map.set(session.id, { projectName: workspace.name, sessionName: session.title });
+			}
+		}
+		return map;
+	}, [workspaceQuery.data]);
+	return <>{children({ retryWorkspace, sessionMeta, sessionsReady, terminatedIds, workspaceError })}</>;
+}
+
 export function NotificationRuntime() {
 	const queryClient = useQueryClient();
 	const { openPrimary } = useNotificationTargetNavigation();
@@ -167,32 +205,6 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 	const allQuery = useNotificationsQuery("all", open);
 	const markAllRead = useMarkAllNotificationsReadMutation();
 	const restoreSession = useRestoreSession();
-	// This panel needs one workspace snapshot for both termination gating and
-	// human-readable notification metadata. Keep a single query observer here:
-	// two observers of the same full workspace tree caused duplicate derivation
-	// and render notifications for every streamed workspace update.
-	const workspaceQuery = useWorkspaceQuery();
-	const { data: workspaces } = workspaceQuery;
-	const retryWorkspace = useCallback(() => {
-		void workspaceQuery.refetch();
-	}, [workspaceQuery.refetch]);
-	const { sessionsReady, terminatedIds, workspaceError } = useSessionTerminationLookup(
-		workspaces,
-		workspaceQuery.isError,
-		workspaceQuery.isSuccess,
-		retryWorkspace,
-	);
-	// Resolve the human project + session names for each notification so the row
-	// can show where it came from (the DTO only carries opaque ids).
-	const sessionMeta = useMemo(() => {
-		const map = new Map<string, { projectName: string; sessionName: string }>();
-		for (const workspace of workspaces ?? []) {
-			for (const session of workspace.sessions) {
-				map.set(session.id, { projectName: workspace.name, sessionName: session.title });
-			}
-		}
-		return map;
-	}, [workspaces]);
 	const notifications = useMemo(() => getCachedNotifications(allQuery.data), [allQuery.data]);
 	const unreadCount = getCachedUnreadCount(unreadQuery.data);
 	const { openSession } = useNotificationTargetNavigation();
@@ -326,7 +338,9 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 				<div className="border-b border-border bg-[var(--color-overlay-subtle)] px-4 py-3.5">
 					<p className="text-subtitle font-semibold tracking-tight text-foreground">{t("notify.title")}</p>
 				</div>
-
+				<NotificationWorkspaceState>
+					{({ retryWorkspace, sessionMeta, sessionsReady, terminatedIds, workspaceError }) => (
+						<>
 				{markReadError ? (
 					<div
 						aria-live="polite"
@@ -425,6 +439,9 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 						) : null}
 					</div>
 				)}
+						</>
+					)}
+				</NotificationWorkspaceState>
 			</PopoverContent>
 		</Popover>
 	);

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -15,7 +15,7 @@ import {
 	MessageSquareDot,
 	RotateCcw,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMarkAllNotificationsReadMutation, useNotificationsQuery } from "../hooks/useNotificationsQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
@@ -251,25 +251,25 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 			});
 	}, [ackRetryNonce, markAllMutate, open, t, unreadQuery.isLoading, visibleUnreadKey]);
 
-	const setPanelOpen = (nextOpen: boolean) => {
+	const setPanelOpen = useCallback((nextOpen: boolean) => {
 		setOpen(nextOpen);
 		if (!nextOpen) {
 			keepLatestNotificationsPage(queryClient, unreadNotificationsQueryKey);
 			keepLatestNotificationsPage(queryClient, recentNotificationsQueryKey);
 		}
-	};
+	}, [queryClient]);
 
 	const retryMarkRead = () => {
 		setMarkReadError(null);
 		setAckRetryNonce((nonce) => nonce + 1);
 	};
 
-	const openSessionAndDismiss = (notification: NotificationDTO) => {
+	const openSessionAndDismiss = useCallback((notification: NotificationDTO) => {
 		openSession(notification);
 		setPanelOpen(false);
-	};
+	}, [openSession, setPanelOpen]);
 
-	const restoreAndOpen = async (notification: NotificationDTO) => {
+	const restoreAndOpen = useCallback(async (notification: NotificationDTO) => {
 		const sessionId = notification.target.sessionId || notification.sessionId;
 		if (!sessionId || restoringSessionId) return;
 		setRestoringSessionId(sessionId);
@@ -285,7 +285,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 		} finally {
 			setRestoringSessionId(undefined);
 		}
-	};
+	}, [openSession, restoreSession, restoringSessionId, setPanelOpen, t]);
 
 	const loadEarlierOnScroll = (event: React.UIEvent<HTMLDivElement>) => {
 		const list = event.currentTarget;
@@ -375,6 +375,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 					>
 						{notifications.map((notification) => {
 							const sessionId = notification.target.sessionId || notification.sessionId;
+							const meta = sessionId ? sessionMeta.get(sessionId) : undefined;
 							const terminated = Boolean(sessionId) && terminatedIds.has(sessionId);
 							// Restoring only makes sense when an agent is actually paused waiting
 							// on input. PR outcomes (ready_to_merge, pr_merged, pr_closed_unmerged)
@@ -386,12 +387,13 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 								<NotificationItem
 									highlighted={highlightedIds.has(notification.id) || notification.status === "unread"}
 									key={notification.id}
-									meta={sessionId ? sessionMeta.get(sessionId) : undefined}
 									notification={notification}
 									onOpenSession={openSessionAndDismiss}
-									onRestore={() => void restoreAndOpen(notification)}
+									onRestore={restoreAndOpen}
 									restoring={restoringSessionId === sessionId}
 									restoreDisabled={restoringSessionId !== undefined}
+									projectName={meta?.projectName}
+									sessionName={meta?.sessionName}
 									sessionsReady={sessionsReady}
 									terminated={terminated}
 									offerRestore={offerRestore}
@@ -449,26 +451,28 @@ function NotificationEmpty({ icon: Icon, message }: { icon: typeof Bell; message
  * viewable there instead of being gated behind restore. PR titles stay a real
  * link so a PR row can open the PR without a separate icon button.
  */
-function NotificationItem({
+const NotificationItem = memo(function NotificationItem({
 	highlighted,
-	meta,
 	notification,
 	offerRestore,
 	onOpenSession,
 	onRestore,
+	projectName,
 	restoring,
 	restoreDisabled,
+	sessionName,
 	sessionsReady,
 	terminated,
 }: {
 	highlighted: boolean;
-	meta?: { projectName: string; sessionName: string };
 	notification: NotificationDTO;
 	offerRestore: boolean;
 	onOpenSession: (notification: NotificationDTO) => void;
-	onRestore: () => void;
+	onRestore: (notification: NotificationDTO) => void;
+	projectName?: string;
 	restoring: boolean;
 	restoreDisabled: boolean;
+	sessionName?: string;
 	sessionsReady: boolean;
 	terminated: boolean;
 }) {
@@ -476,9 +480,9 @@ function NotificationItem({
 	const Icon = notificationIcon(notification.type);
 	const sessionId = notification.target.sessionId || notification.sessionId;
 	const canOpenSession = Boolean(sessionId) && sessionsReady && (!terminated || !offerRestore);
-	const copy = notificationCopy(notification, meta?.sessionName);
+	const copy = notificationCopy(notification, sessionName);
 	const titleLink = notificationPRTitleLink(notification, copy.title);
-	const showSessionMeta = Boolean(meta?.sessionName) && !notificationMentions(copy, meta?.sessionName ?? "");
+	const showSessionMeta = Boolean(sessionName) && !notificationMentions(copy, sessionName ?? "");
 	const openRow = () => {
 		if (canOpenSession) onOpenSession(notification);
 	};
@@ -553,13 +557,13 @@ function NotificationItem({
 							{copy.body}
 						</p>
 					) : null}
-					{meta && (meta.projectName || showSessionMeta) ? (
+					{projectName || showSessionMeta ? (
 						<p className="mt-1 flex min-w-0 items-center gap-1.5 text-caption leading-none text-passive">
-							{meta.projectName ? (
-								<span className="truncate font-medium text-muted-foreground">{meta.projectName}</span>
+							{projectName ? (
+								<span className="truncate font-medium text-muted-foreground">{projectName}</span>
 							) : null}
-							{meta.projectName && showSessionMeta ? <span aria-hidden="true">·</span> : null}
-							{showSessionMeta ? <span className="truncate">{meta.sessionName}</span> : null}
+							{projectName && showSessionMeta ? <span aria-hidden="true">·</span> : null}
+							{showSessionMeta ? <span className="truncate">{sessionName}</span> : null}
 						</p>
 					) : null}
 				</div>
@@ -577,7 +581,7 @@ function NotificationItem({
 									disabled={restoreDisabled}
 									onClick={(event) => {
 										event.stopPropagation();
-										onRestore();
+								onRestore(notification);
 									}}
 									type="button"
 								>
@@ -593,7 +597,7 @@ function NotificationItem({
 			</div>
 		</div>
 	);
-}
+});
 
 type NotificationCopy = Pick<NotificationDTO, "body" | "title">;
 

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -341,7 +341,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 				<NotificationWorkspaceState>
 					{({ retryWorkspace, sessionMeta, sessionsReady, terminatedIds, workspaceError }) => (
 						<>
-				{markReadError ? (
+							{markReadError ? (
 					<div
 						aria-live="polite"
 						className="flex items-center justify-between gap-2 border-b border-border bg-error/5 px-4 py-2 text-caption text-error"
@@ -598,7 +598,7 @@ const NotificationItem = memo(function NotificationItem({
 									disabled={restoreDisabled}
 									onClick={(event) => {
 										event.stopPropagation();
-								onRestore(notification);
+										onRestore(notification);
 									}}
 									type="button"
 								>

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
@@ -11,7 +11,7 @@ const { spawnMock, workspaceQueryMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => workspaceQueryMock(),
+	useWorkspaceScope: () => workspaceQueryMock(),
 }));
 
 vi.mock("../lib/spawn-orchestrator", () => ({
@@ -41,7 +41,7 @@ const workspace: WorkspaceSummary = {
 beforeEach(() => {
 	vi.clearAllMocks();
 	useUiStore.setState({ settingsModal: null });
-	workspaceQueryMock.mockReturnValue({ data: [workspace], isLoading: false });
+	workspaceQueryMock.mockReturnValue({ data: { project: workspace }, isLoading: false });
 });
 
 describe("RestoreUnavailableDialog", () => {
@@ -49,7 +49,7 @@ describe("RestoreUnavailableDialog", () => {
 		const onOpenChange = vi.fn();
 		const onRecreated = vi.fn();
 		workspaceQueryMock.mockReturnValue({
-			data: [{ ...workspace, orchestratorAgent: undefined }],
+		data: { project: { ...workspace, orchestratorAgent: undefined } },
 			isLoading: false,
 		});
 		render(

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
@@ -2,7 +2,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Loader2, X } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { useWorkspaceScope } from "../hooks/useWorkspaceQuery";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { useUiStore } from "../stores/ui-store";
 import { hasConfiguredOrchestratorAgent, isOrchestratorSession } from "../types/workspace";
@@ -24,11 +24,11 @@ type RestoreUnavailableDialogProps = {
 
 export function RestoreUnavailableDialog({ open, session, onOpenChange, onRecreated }: RestoreUnavailableDialogProps) {
 	const { t } = useTranslation();
-	const workspaceQuery = useWorkspaceQuery();
+	const workspaceQuery = useWorkspaceScope(session.workspaceId);
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | undefined>();
 	const orchestrator = isOrchestratorSession(session);
-	const workspace = workspaceQuery.data?.find((candidate) => candidate.id === session.workspaceId);
+	const workspace = workspaceQuery.data?.project;
 	const hasOrchestratorAgent = hasConfiguredOrchestratorAgent(workspace);
 	const checkingProject = workspaceQuery.isLoading && workspaceQuery.data === undefined;
 

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useId, useState, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useId, useState, type ReactNode } from "react";
 import type { TFunction } from "i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -177,11 +177,12 @@ export function SessionInspector({
 		session ? Boolean(state.inspectorSessions[session.id]?.browserUnseen) : false,
 	);
 	const filesChangedCount = useSessionWorkspaceFilesChangedCount(session?.id);
-	const setView = (next: InspectorView) => {
+	const setView = useCallback((next: InspectorView) => {
 		setInternalView(next);
 		onViewChange?.(next);
 		if (next === "files") onOpenFiles?.();
-	};
+	}, [onOpenFiles, onViewChange]);
+	const openReviews = useCallback(() => setView("reviews"), [setView]);
 	// A persisted/controlled Reviews selection can outlive the last reviewable PR.
 	// Keep the shell on a real, visible tab instead of rendering an empty, unlabelled body.
 	const reviewsAvailable = reviewsTabVisible(session);
@@ -239,7 +240,7 @@ export function SessionInspector({
 					session ? <ReviewsView onOpenReviewFile={onOpenReviewFile} onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : undefined
 				}
 				summaryView={
-					session ? <SummaryView canOpenReviews={reviewsAvailable} onOpenReviews={() => setView("reviews")} session={session} /> : undefined
+					session ? <SummaryView canOpenReviews={reviewsAvailable} onOpenReviews={openReviews} session={session} /> : undefined
 				}
 				tabs={tabs}
 			/>
@@ -262,7 +263,7 @@ function normalizeReviewerId(value: string | undefined): string {
 	return value?.trim().replace(/^@+/, "").toLowerCase() ?? "";
 }
 
-function SummaryView({
+const SummaryView = memo(function SummaryView({
 	canOpenReviews,
 	onOpenReviews,
 	session,
@@ -327,9 +328,9 @@ function SummaryView({
 			}
 		/>
 	);
-}
+});
 
-function ReviewsView({
+const ReviewsView = memo(function ReviewsView({
 	session,
 	onOpenReviewFile,
 	onOpenReviewerTerminal,
@@ -343,7 +344,7 @@ function ReviewsView({
 			<ReviewsSection onOpenReviewFile={onOpenReviewFile} onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
 		</div>
 	);
-}
+});
 
 function InspectorPolicyRow({
 	id,

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -545,7 +545,7 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 // real hooks would need a QueryClientProvider this suite deliberately omits.
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
-	useOpenShellTerminal: () => ({ mutate: openShellTerminalMock }),
+	useOpenShellTerminal: () => ({ open: openShellTerminalMock, isPending: false }),
 	useCloseShellTerminal: () => ({ mutate: closeShellTerminalMock }),
 	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
 }));
@@ -619,6 +619,15 @@ describe("SessionView", () => {
 		shellTerminalsState.data = [];
 		navigateMock.mockReset();
 		openShellTerminalMock.mockReset();
+		openShellTerminalMock.mockImplementation((input: { projectId?: string; sessionId?: string }) => ({
+			handleId: "pending-shell:test",
+			projectId: input.projectId,
+			sessionId: input.sessionId,
+			workingDir: "",
+			title: "Terminal 1",
+			createdAt: "2026-08-31T00:00:00Z",
+			optimistic: true,
+		}));
 		closeShellTerminalMock.mockReset();
 		interfaceTransitionMock.start.mockReset();
 		interfaceTransitionMock.resetStartError.mockReset();
@@ -763,6 +772,7 @@ describe("SessionView", () => {
 		expect(newTerminalButton).toHaveAttribute("title", "New terminal (Ctrl+T)");
 		fireEvent.click(newTerminalButton);
 		expect(openShellTerminalMock).toHaveBeenCalledWith({ projectId: "proj-1", sessionId: "sess-2" }, expect.anything());
+		expect(useUiStore.getState().activeShellTerminalHandleId).toBe("pending-shell:test");
 	});
 
 	it("activates a new terminal opened while a file tab is selected", async () => {
@@ -829,6 +839,7 @@ describe("SessionView", () => {
 		openShellTerminalMock.mockImplementation((_input, options) => {
 			shellTerminalsState.data = [shell];
 			options.onSuccess(shell);
+			return shell;
 		});
 
 		render(<SessionView sessionId="sess-1" />);

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -534,6 +534,12 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 		data: workspaceQueryState.data,
 		isLoading: workspaceQueryState.isLoading,
 	}),
+	useWorkspaceSession: (sessionId: string) => ({
+		data: workspaceQueryState.data
+			?.flatMap((workspace) => workspace.sessions)
+			.find((session) => session.id === sessionId),
+		isLoading: workspaceQueryState.isLoading,
+	}),
 }));
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -563,25 +563,37 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// session's worktree (the project id is only the fallback when the session's
 	// workspace can no longer be resolved).
 	const addShellTerminal = useCallback(() => {
-		openShellTerminal.mutate(
+		const shell = openShellTerminal.open(
 			{ projectId: session?.workspaceId, sessionId },
 			{
-				onSuccess: (shell) => {
-					setActiveShellTerminal(shell.handleId);
+				onSuccess: (openedShell) => {
+					setActiveShellTerminal(openedShell.handleId);
 					setFileTabsBySession((current) => ({
 						...current,
 						[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
 					}));
 					setTerminalTarget({
-						generation: shell.createdAt,
+						generation: openedShell.createdAt,
 						kind: "shell",
-						handleId: shell.handleId,
+						handleId: openedShell.handleId,
 						sessionId,
-						title: shell.title,
+						title: openedShell.title,
 					});
 				},
 			},
 		);
+		setFileTabsBySession((current) => ({
+			...current,
+			[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
+		}));
+		setActiveShellTerminal(shell.handleId);
+		setTerminalTarget({
+			generation: shell.createdAt,
+			kind: "shell",
+			handleId: shell.handleId,
+			sessionId,
+			title: shell.title,
+		});
 	}, [openShellTerminal, sessionId, session?.workspaceId, setActiveShellTerminal]);
 
 	const activateAuxiliaryTab = useCallback(
@@ -983,7 +995,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		session && !isOrchestrator ? (
 			<TopbarButton
 				aria-label={t("shortcut.new-shell-terminal")}
-				disabled={openShellTerminal.isPending}
 				onClick={addShellTerminal}
 				title={newTerminalError ?? t("terminal.newWithShortcut", { shortcut: newTerminalShortcutLabel })}
 				type="button"

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -54,7 +54,7 @@ import {
 	interfaceTransitionIsActive,
 	useSessionInterfaceTransition,
 } from "../hooks/useSessionInterfaceTransition";
-import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { useWorkspaceSession } from "../hooks/useWorkspaceQuery";
 import { useSessionHandoffMenu } from "../hooks/useSessionHandoffMenu";
 import { clearSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
@@ -378,8 +378,7 @@ function SessionInspectorRail({
 export function SessionView({ sessionId }: SessionViewProps) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
-	const workspaceQuery = useWorkspaceQuery();
-	const workspaces = workspaceQuery.data ?? [];
+	const workspaceQuery = useWorkspaceSession(sessionId);
 	const theme = useResolvedTheme();
 	const prefersReducedMotion = useReducedMotion();
 	const isInspectorOpen = useUiStore((state) => state.inspectorSessions[sessionId]?.isOpen ?? true);
@@ -506,7 +505,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 
 	useEffect(() => stopTerminalLiveResize, [stopTerminalLiveResize]);
 
-	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
+	const session = workspaceQuery.data;
 	const interfaceSwitch = useSessionInterfaceTransition(session?.id);
 	const reviewerQuery = useQuery({
 		queryKey: ["session-reviews", sessionId],

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -582,6 +582,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				},
 			},
 		);
+		if (!shell) return;
 		setFileTabsBySession((current) => ({
 			...current,
 			[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -38,6 +38,13 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	workspaceQueryKey: ["workspaces"],
 	useWorkspaceQuery: workspaceQueryMock,
+	useWorkspaceScope: (projectId?: string) => {
+		const query = workspaceQueryMock();
+		return {
+			...query,
+			data: { project: query.data?.find((workspace: WorkspaceSummary) => workspace.id === projectId) },
+		};
+	},
 }));
 
 vi.mock("../hooks/useSessionUsageSummaries", () => ({

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, type MouseEvent } from "react";
+import { memo, useCallback, useEffect, useRef, useState, type MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
@@ -180,11 +180,11 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const activeProjectIdRef = useRef(projectId);
 	activeProjectIdRef.current = projectId;
 
-	const openSession = (session: WorkspaceSession) =>
+	const openSession = useCallback((session: WorkspaceSession) =>
 		void navigate({
 			to: "/projects/$projectId/sessions/$sessionId",
 			params: { projectId: session.workspaceId, sessionId: session.id },
-		});
+		}), [navigate]);
 
 	const openOrchestrator = async (mode?: "tui") => {
 		if (!projectId || isProjectRestarting) return;
@@ -393,8 +393,8 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						labels={boardLabels}
 						renderSessionCard={(session) => (
 							<BoardSessionCardAdapter
-								onOpen={() => openSession(session)}
-								onTerminate={() => terminateSession.mutate(session)}
+								onOpenSession={openSession}
+								onTerminateSession={terminateSession.mutate}
 								session={session}
 								usage={usageBySession.get(session.id)}
 							/>

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from "react";
+import { memo, useEffect, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -72,26 +72,26 @@ export function sessionsBoardLabels(t: TFunction): BoardColumnLabels {
 	};
 }
 
-export function BoardSessionCardAdapter({
-	onOpen,
-	onTerminate,
+export const BoardSessionCardAdapter = memo(function BoardSessionCardAdapter({
+	onOpenSession,
+	onTerminateSession,
 	session,
 	usage,
 }: {
-	onOpen: () => void;
-	onTerminate: () => void;
+	onOpenSession: (session: WorkspaceSession) => void;
+	onTerminateSession: (session: WorkspaceSession) => void;
 	session: WorkspaceSession;
 	usage?: SessionUsageSummary;
 }) {
 	return (
 		<DesktopSessionCard
-			onOpen={onOpen}
-			onTerminate={onTerminate}
+			onOpen={() => onOpenSession(session)}
+			onTerminate={() => onTerminateSession(session)}
 			session={session}
 			usage={usage}
 		/>
 	);
-}
+});
 
 export function ArchivedSessionCardAdapter({
 	isRestoreDisabled,
@@ -128,7 +128,7 @@ export function ArchivedSessionCardAdapter({
 	);
 }
 
-function DesktopSessionCard({
+const DesktopSessionCard = memo(function DesktopSessionCard({
 	action,
 	branchAction,
 	footer,
@@ -239,7 +239,7 @@ function DesktopSessionCard({
 			usage={usagePresentation}
 		/>
 	);
-}
+});
 
 function pullRequestLabels(t: TFunction): BoardPullRequestLabels {
 	return {

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -45,6 +45,7 @@ export function ShellTerminalTab({
 	const [draft, setDraft] = useState(shell.title);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const lastClickAtRef = useRef(0);
+	const canEdit = Boolean(onRename) && !shell.optimistic;
 	// Rename gesture per platform: Windows uses right-click (its convention for
 	// tab/file renames); macOS and Linux use double-click.
 	const renameViaRightClick = isWindowsPlatform();
@@ -57,7 +58,7 @@ export function ShellTerminalTab({
 	}, [isEditing]);
 
 	const beginEdit = () => {
-		if (!onRename || isEditing) return;
+		if (!canEdit || isEditing) return;
 		setDraft(title);
 		setIsEditing(true);
 	};
@@ -120,10 +121,10 @@ export function ShellTerminalTab({
 		"size-icon-sm shrink-0 translate-y-px";
 	const isConnected = appearance === "connected";
 	if (isConnected) {
-		const closeAction = isEditing ? undefined : (
+		const closeAction = isEditing || shell.optimistic ? undefined : (
 			<button
 				{...closeControl}
-				className="grid size-icon-sm place-items-center rounded-sm text-passive opacity-0 pointer-events-none transition-[background,color] duration-fast ease-out hover:bg-interactive-hover hover:text-foreground group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
+				className="relative grid size-icon-sm place-items-center text-passive opacity-0 pointer-events-none before:absolute before:-inset-1.5 before:content-[''] transition-colors duration-fast ease-out hover:text-foreground group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
 			>
 				<X aria-hidden="true" className="size-icon-sm translate-y-px" />
 			</button>
@@ -262,13 +263,13 @@ export function ShellTerminalTab({
 					</span>
 				</button>
 			)}
-			{isConnected && isEditing ? null : (
+			{isConnected && (isEditing || shell.optimistic) ? null : (
 				<button
 					{...closeControl}
 					className={
 						isConnected
-							? "absolute top-[calc(50%_-_1px)] left-2 z-10 grid size-icon-sm -translate-y-1/2 place-items-center rounded-sm text-passive opacity-0 pointer-events-none transition-[background,color] duration-fast ease-out hover:bg-interactive-hover hover:text-foreground group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
-							: "inline-flex h-control-sm w-control-sm shrink-0 items-center justify-center overflow-hidden rounded-sm text-passive opacity-0 transition-[background,color] duration-fast ease-out hover:bg-interactive-hover hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
+							? "absolute top-[calc(50%_-_1px)] left-2 z-20 grid size-icon-sm -translate-y-1/2 place-items-center text-passive opacity-0 pointer-events-none before:absolute before:-inset-1.5 before:content-[''] transition-colors duration-fast ease-out hover:text-foreground group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
+							: "inline-flex h-control-sm w-control-sm shrink-0 items-center justify-center overflow-hidden text-passive opacity-0 transition-colors duration-fast ease-out hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
 					}
 				>
 					<X

--- a/frontend/src/renderer/components/ShellTopbar.linux.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.linux.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 });
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => useWorkspaceQueryMock(),
+	useWorkspaceScope: () => ({ ...useWorkspaceQueryMock(), data: {} }),
 	workspaceQueryKey: ["workspaces"],
 }));
 

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -32,7 +32,21 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 });
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => useWorkspaceQueryMock(),
+	useWorkspaceScope: () => {
+		const query = useWorkspaceQueryMock();
+		const project = query.data?.find((workspace: WorkspaceSummary) => workspace.id === paramsMock.projectId);
+		const session = query.data
+			?.flatMap((workspace: WorkspaceSummary) => workspace.sessions)
+			.find((candidate: WorkspaceSession) => candidate.id === paramsMock.sessionId);
+		return {
+			...query,
+			data: {
+				project,
+				session,
+				orchestrator: project?.sessions.find((candidate: WorkspaceSession) => candidate.kind === "orchestrator"),
+			},
+		};
+	},
 	workspaceQueryKey: ["workspaces"],
 }));
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -87,7 +87,6 @@ export function ShellTopbar({
 	const isInspectorOpen = useUiStore((state) =>
 		currentSessionId ? (state.inspectorSessions[currentSessionId]?.isOpen ?? true) : false,
 	);
-	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const isSidebarOpen = useUiStore(sidebarOccupiesLayout);
 	const isFullScreen = useWindowFullScreen();
@@ -124,13 +123,15 @@ export function ShellTopbar({
 	// removed, or data still loading) shows an empty crumb — never the raw
 	// route slug. "Board" is the root-board crumb only.
 	const projectId = session?.workspaceId ?? params.projectId;
+	const isProjectRestarting = useUiStore((state) =>
+		projectId ? state.restartingProjectIds.has(projectId) : false,
+	);
 	const isProjectBoardRoute = !isSessionRoute && Boolean(projectId);
 	const isRootBoardRoute = !isSessionRoute && !isProjectBoardRoute;
 	const project = workspaceScope?.project;
 	const projectLabel = project?.name ?? session?.workspaceName ?? (projectId ? "" : t("shell.board"));
 	const orchestrator = workspaceScope?.orchestrator;
 	const orchestratorActivityLabel = orchestrator ? getAgentActivityView(orchestrator.activity, t).label : undefined;
-	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
 	const orchestratorActionLabel = orchestrator ? t("shell.openOrchestrator") : t("shell.spawnOrchestrator");
 	const orchestratorTooltip = isProjectRestarting
 		? t("shell.restarting")

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -7,13 +7,12 @@ import { animate, LayoutGroup, motion, useMotionValue, useReducedMotion } from "
 import { NotificationCenter } from "./NotificationCenter";
 import {
 	CLOUD_PROJECT_KIND,
-	findProjectOrchestrator,
 	hasConfiguredOrchestratorAgent,
 	isOrchestratorSession,
 	sessionIsActive,
 	type WorkspaceSession,
 } from "../types/workspace";
-import { cloudSessionsQueryKey, useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { cloudSessionsQueryKey, useWorkspaceScope, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import {
 	clearTerminateSessionState,
 	useProjectTerminateSessionStates,
@@ -115,11 +114,8 @@ export function ShellTopbar({
 	const [isSpawning, setIsSpawning] = useState(false);
 	// Board-scope spawn failures surface where the board actions render.
 	const [boardSpawnError, setBoardSpawnError] = useState<string | null>(null);
-	const all = useWorkspaceQuery().data ?? [];
-
-	const session = params.sessionId
-		? all.flatMap((workspace) => workspace.sessions).find((s) => s.id === params.sessionId)
-		: undefined;
+	const workspaceScope = useWorkspaceScope(params.projectId, params.sessionId).data;
+	const session = workspaceScope?.session;
 	const isSessionRoute = Boolean(params.sessionId);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
 	// Project in scope: the session's workspace wins over the route param so the
@@ -130,9 +126,9 @@ export function ShellTopbar({
 	const projectId = session?.workspaceId ?? params.projectId;
 	const isProjectBoardRoute = !isSessionRoute && Boolean(projectId);
 	const isRootBoardRoute = !isSessionRoute && !isProjectBoardRoute;
-	const project = projectId ? all.find((workspace) => workspace.id === projectId) : undefined;
+	const project = workspaceScope?.project;
 	const projectLabel = project?.name ?? session?.workspaceName ?? (projectId ? "" : t("shell.board"));
-	const orchestrator = projectId ? findProjectOrchestrator(all, projectId) : undefined;
+	const orchestrator = workspaceScope?.orchestrator;
 	const orchestratorActivityLabel = orchestrator ? getAgentActivityView(orchestrator.activity, t).label : undefined;
 	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
 	const orchestratorActionLabel = orchestrator ? t("shell.openOrchestrator") : t("shell.spawnOrchestrator");

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -94,7 +94,7 @@ vi.mock("@dnd-kit/core", async (importOriginal) => {
 			if (id && onDragEnd) dragEnds.set(id, onDragEnd);
 			if (id && onDragOver) dragOvers.set(id, onDragOver);
 			if (id && onDragStart) dragStarts.set(id, onDragStart);
-			return children;
+			return <div data-dnd-context={id}>{children}</div>;
 		},
 		DragOverlay: ({ children }: { children: React.ReactNode }) => children,
 	};
@@ -2066,6 +2066,22 @@ describe("Sidebar", () => {
 		expect(Array.from(document.querySelectorAll("[data-project-label]"), (node) => node.textContent)).toEqual(["Bravo", "Alpha"]);
 	});
 
+	it("pauses nested session drag contexts during a project drag", async () => {
+		renderSidebar({
+			workspaces: [
+				{ ...workspace, id: "alpha", name: "Alpha", sessions: [{ ...session, id: "alpha-session", workspaceId: "alpha" }] },
+				{ ...workspace, id: "bravo", name: "Bravo", sessions: [{ ...session, id: "bravo-session", workspaceId: "bravo" }] },
+			],
+		});
+
+		expect(document.querySelectorAll('[data-dnd-context^="sidebar-sessions-"]')).toHaveLength(2);
+
+		act(() => dragStarts.get("sidebar-projects")?.({ active: { id: "alpha" } }));
+
+		await waitFor(() => expect(document.querySelectorAll('[data-dnd-context^="sidebar-sessions-"]')).toHaveLength(0));
+		expect(screen.getAllByRole("button", { name: "Open fix login" })).toHaveLength(2);
+	});
+
 	it("commits a session drop within its project", () => {
 		renderSidebar({
 			workspaces: [{
@@ -2115,7 +2131,9 @@ describe("Sidebar", () => {
 		act(() => dragEnds.get("sidebar-sessions-proj-1")?.({ active: { id: "second" }, over: { id: "first" } }));
 		act(() => dragStarts.get("sidebar-projects")?.({ active: { id: "proj-1" } }));
 
-		expect(document.querySelector("[data-project-drag-overlay]")).toHaveTextContent(/Project One.*Second.*First/);
+		const overlay = document.querySelector("[data-project-drag-overlay]");
+		expect(overlay).toHaveTextContent(/Project One.*Second.*First/);
+		expect(overlay?.querySelector("[data-project-drag-preview-session]")).toHaveClass("pl-0.5");
 	});
 
 	it("keeps hidden sessions out of compact project drag previews", () => {
@@ -2153,7 +2171,9 @@ describe("Sidebar", () => {
 				over: { id: "alpha", rect: { height: 32, top: 0 } },
 			}));
 
-			const indicator = document.querySelector("[data-project-drop-indicator]");
+			const target = document.querySelector('[data-project-id="alpha"]');
+			expect(target).toHaveAttribute("data-drop-indicator", "before");
+			const indicator = target?.querySelector('[data-project-drop-indicator="before"]');
 			expect(indicator).toHaveClass("bg-foreground");
 			expect(indicator).not.toHaveClass("bg-white");
 		} finally {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -356,6 +356,7 @@ function useSelection() {
 	});
 	const goHome = useCallback(() => void navigate({ to: "/" }), [navigate]);
 	const goGlobalSettings = useCallback(() => openGlobalSettings(), [openGlobalSettings]);
+	const goConnectMobile = useCallback(() => openGlobalSettings("mobile"), [openGlobalSettings]);
 	const goSettings = useCallback((projectId: string) => openProjectSettings(projectId), [openProjectSettings]);
 	const goProject = useCallback(
 		(projectId: string) => void navigate({ to: "/projects/$projectId", params: { projectId } }),
@@ -377,11 +378,11 @@ function useSelection() {
 		// Settings is a modal — open it in place so the current page (session
 		// terminal, board, etc.) stays underneath.
 		goGlobalSettings,
-		goConnectMobile: () => openGlobalSettings("mobile"),
+		goConnectMobile,
 		goSettings,
 		goProject,
 		goSession,
-	}), [goGlobalSettings, goHome, goProject, goSession, goSettings, params.projectId, params.sessionId, pathname]);
+	}), [goConnectMobile, goGlobalSettings, goHome, goProject, goSession, goSettings, params.projectId, params.sessionId, pathname]);
 }
 
 // Colour tracks the session's board section, preserving SCM state while the

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1024,7 +1024,6 @@ const ProjectItemContent = memo(function ProjectItemContent({
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	const [isSpawning, setIsSpawning] = useState(false);
 	const [projectPressed, setProjectPressed] = useState(false);
-	const [rowHovered, setRowHovered] = useState(false);
 	// Skip enter animation on first mount — sessions arrive async and we don't
 	// want them to slide in on every sidebar load. Only animate on subsequent
 	// expand/collapse toggles.
@@ -1206,8 +1205,6 @@ const ProjectItemContent = memo(function ProjectItemContent({
 					data-sidebar="menu-item"
 					data-slot="sidebar-menu-item"
 					layout={draggingProjectId ? false : "position"}
-					onMouseEnter={() => setRowHovered(true)}
-					onMouseLeave={() => setRowHovered(false)}
 					ref={setDroppableNodeRef}
 					transition={prefersReducedMotion ? { duration: 0 } : { type: "spring", stiffness: 520, damping: 42, mass: 0.55 }}
 				>
@@ -1270,20 +1267,23 @@ const ProjectItemContent = memo(function ProjectItemContent({
 										className="relative inline-flex size-icon-md shrink-0 translate-y-px items-center justify-center text-muted-foreground group-data-[collapsible=icon]:hidden"
 										data-project-folder-visual=""
 									>
-										{rowHovered && !draggingProjectId ? (
-											<motion.span
-												animate={{ rotate: expanded ? 90 : 0 }}
-												initial={false}
-												transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.14, ease: [0.25, 0.46, 0.45, 0.94] }}
-												className="inline-flex size-icon-md items-center justify-center"
-											>
-												<ChevronRight strokeWidth={1.75} />
-											</motion.span>
-										) : expanded ? (
-											<FolderOpen strokeWidth={1.75} />
-										) : (
-											<Folder strokeWidth={1.75} />
-										)}
+										<span
+											className={cn(
+												"inline-flex size-icon-md items-center justify-center transition-opacity duration-150 group-hover/menu-item:opacity-0",
+												draggingProjectId && "group-hover/menu-item:opacity-100",
+											)}
+										>
+											{expanded ? <FolderOpen strokeWidth={1.75} /> : <Folder strokeWidth={1.75} />}
+										</span>
+										<span
+											className={cn(
+												"absolute inline-flex size-icon-md items-center justify-center opacity-0 transition-[opacity,transform] duration-150 group-hover/menu-item:opacity-100",
+												expanded && "rotate-90",
+												draggingProjectId && "group-hover/menu-item:opacity-0",
+											)}
+										>
+											<ChevronRight strokeWidth={1.75} />
+										</span>
 									</span>
 									{/* Collapsed icon rail: folder icon */}
 									<span

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -53,6 +53,7 @@ import {
 	useState,
 	type CSSProperties,
 	type MouseEvent,
+	type PointerEvent as ReactPointerEvent,
 	type ReactNode,
 } from "react";
 import { flushSync } from "react-dom";
@@ -509,18 +510,15 @@ export function Sidebar({
 	const projectIds = useMemo(() => orderedWorkspaces.map((workspace) => workspace.id), [orderedWorkspaces]);
 	const reorderSensors = useReorderSensors();
 	const projectDragClickGuard = usePostDragClickGuard();
-	const [projectDragState, setProjectDragState] = useState<{
-		activeId: string | null;
-		overId: string | null;
-		placement: ProjectDropPlacement | null;
-	}>({ activeId: null, overId: null, placement: null });
+	const [draggingProjectId, setDraggingProjectId] = useState<string | null>(null);
 	const projectDragBoundsRef = useRef<DragBounds | null>(null);
 	const projectDropTargetRef = useRef<{ overId: string; placement: ProjectDropPlacement } | null>(null);
-	useGrabbingCursor(projectDragState.activeId !== null);
+	const projectDropNodesRef = useRef(new Map<string, HTMLElement>());
+	useGrabbingCursor(draggingProjectId !== null);
 
 	const activeDragWorkspace = useMemo(
-		() => orderedWorkspaces.find((workspace) => workspace.id === projectDragState.activeId) ?? null,
-		[orderedWorkspaces, projectDragState.activeId],
+		() => orderedWorkspaces.find((workspace) => workspace.id === draggingProjectId) ?? null,
+		[draggingProjectId, orderedWorkspaces],
 	);
 	const activeDragSessions = useMemo(
 		() => activeDragWorkspace
@@ -550,6 +548,16 @@ export function Sidebar({
 	const commitProjectOrder = useCallback((next: string[] | null) => {
 		if (next) setProjectOrder(next);
 	}, []);
+	const setProjectDropIndicator = useCallback((next: { overId: string; placement: ProjectDropPlacement } | null) => {
+		const previous = projectDropTargetRef.current;
+		if (previous && (previous.overId !== next?.overId || previous.placement !== next?.placement)) {
+			projectDropNodesRef.current.get(previous.overId)?.removeAttribute("data-drop-indicator");
+		}
+		if (next && (previous?.overId !== next.overId || previous.placement !== next.placement)) {
+			projectDropNodesRef.current.get(next.overId)?.setAttribute("data-drop-indicator", next.placement);
+		}
+		projectDropTargetRef.current = next;
+	}, []);
 
 	const onProjectDragEnd = useCallback(
 		({ active, over }: DragEndEvent) => {
@@ -559,21 +567,22 @@ export function Sidebar({
 				const targetId = String(over.id);
 				const placement = projectDropTargetRef.current?.overId === targetId
 					? projectDropTargetRef.current.placement
-					: projectDragState.placement ??
-					(projectIds.indexOf(projectId) < projectIds.indexOf(targetId) ? "after" : "before");
+					: projectIds.indexOf(projectId) < projectIds.indexOf(targetId) ? "after" : "before";
 				commitProjectOrder(reorderAtProjectBoundary(projectIds, projectId, targetId, placement));
 			}
 			projectDragBoundsRef.current = null;
-			projectDropTargetRef.current = null;
-			setProjectDragState({ activeId: null, overId: null, placement: null });
+			setProjectDropIndicator(null);
+			projectDropNodesRef.current.clear();
+			setDraggingProjectId(null);
 		},
-		[commitProjectOrder, projectDragClickGuard, projectDragState.placement, projectIds],
+		[commitProjectOrder, projectDragClickGuard, projectIds, setProjectDropIndicator],
 	);
 	const onProjectDragStart = useCallback(({ active }: DragStartEvent) => {
 		const projectId = String(active.id);
 		projectDragBoundsRef.current = null;
 		projectDropTargetRef.current = null;
 		const blocks = Array.from(document.querySelectorAll<HTMLElement>("[data-project-drop-target]"));
+		projectDropNodesRef.current = new Map(blocks.map((block) => [block.dataset.projectId ?? "", block]));
 		const activeRow = blocks.find((block) => block.dataset.projectId === projectId)
 			?.querySelector<HTMLElement>("[data-project-drag-row]");
 		if (activeRow && blocks.length > 0) {
@@ -583,18 +592,13 @@ export function Sidebar({
 				maxY: blocks[blocks.length - 1].getBoundingClientRect().bottom - activeTop,
 			};
 		}
-		setProjectDragState({ activeId: projectId, overId: projectId, placement: null });
+		setDraggingProjectId(projectId);
 	}, []);
 	const updateProjectDropTarget = useCallback(({ active, activatorEvent, delta, over }: DragMoveEvent | DragOverEvent) => {
 		const activeId = String(active.id);
 		const overId = over ? String(over.id) : null;
 		if (!over || activeId === overId) {
-			projectDropTargetRef.current = null;
-			setProjectDragState((previous) =>
-				previous.overId === overId && previous.placement === null
-					? previous
-					: { ...previous, overId, placement: null },
-			);
+			setProjectDropIndicator(null);
 			return;
 		}
 		const pointerY = activatorEvent && "clientY" in activatorEvent && typeof activatorEvent.clientY === "number"
@@ -606,20 +610,15 @@ export function Sidebar({
 		const placement: ProjectDropPlacement = boundaryReference === null
 			? projectIds.indexOf(activeId) < projectIds.indexOf(overId!) ? "after" : "before"
 			: boundaryReference <= over.rect.top + over.rect.height / 2 ? "before" : "after";
-		projectDropTargetRef.current = { overId: overId!, placement };
 		const changesOrder = reorderAtProjectBoundary(projectIds, activeId, overId!, placement) !== null;
-		const visiblePlacement = changesOrder ? placement : null;
-		setProjectDragState((previous) =>
-			previous.overId === overId && previous.placement === visiblePlacement
-				? previous
-				: { ...previous, overId, placement: visiblePlacement },
-		);
-	}, [projectIds]);
+		setProjectDropIndicator(changesOrder ? { overId: overId!, placement } : null);
+	}, [projectIds, setProjectDropIndicator]);
 	const onProjectDragCancel = useCallback(() => {
 		projectDragBoundsRef.current = null;
-		projectDropTargetRef.current = null;
-		setProjectDragState({ activeId: null, overId: null, placement: null });
-	}, []);
+		setProjectDropIndicator(null);
+		projectDropNodesRef.current.clear();
+		setDraggingProjectId(null);
+	}, [setProjectDropIndicator]);
 
 	const pinnedSessions = useMemo(
 		() => workspaces
@@ -816,8 +815,7 @@ export function Sidebar({
 											expanded={expandedIds.has(workspace.id) || (initialActiveSessionProjectId === workspace.id && !dismissedInitialActiveProjectIds.has(workspace.id))}
 											suppressInitialExpandAnimation={expandedIds.has(workspace.id)}
 											selection={selection}
-											draggingProjectId={projectDragState.activeId}
-											dropIndicator={projectDragState.overId === workspace.id ? projectDragState.placement ?? undefined : undefined}
+											draggingProjectId={draggingProjectId}
 											consumeDragClick={projectDragClickGuard.consumeClick}
 											onSessionOrderChange={recordSessionOrder}
 											onToggle={toggleProjectDisclosure}
@@ -958,7 +956,6 @@ type ProjectItemProps = {
 	expanded: boolean;
 	selection: Selection;
 	draggingProjectId?: string | null;
-	dropIndicator?: "before" | "after";
 	consumeDragClick: (id: string) => boolean;
 	onSessionOrderChange: (projectId: string, order: string[]) => void;
 	onToggle: (projectId: string) => void;
@@ -976,12 +973,39 @@ type ProjectItemDndProps = Pick<ProjectDraggable, "listeners" | "setActivatorNod
 // project/session subtree. The content only rerenders when its visible props
 // change (drag start/end or a different drop boundary), not for every transform.
 const ProjectItem = memo(function ProjectItem(props: ProjectItemProps) {
-	const { listeners, setActivatorNodeRef, setNodeRef: setDraggableNodeRef } = useDraggable({
+	const draggable = useDraggable({
 		id: props.workspace.id,
 	});
-	const { setNodeRef: setDroppableNodeRef } = useDroppable({
+	const droppable = useDroppable({
 		id: props.workspace.id,
 	});
+	// dnd-kit refreshes the objects returned by these hooks as the pointer moves.
+	// Keep that high-frequency churn in this thin wrapper: the project content
+	// contains the expanded session tree and must not receive new props merely
+	// because the cursor crossed another project.
+	const draggableRef = useRef(draggable);
+	const droppableRef = useRef(droppable);
+	draggableRef.current = draggable;
+	droppableRef.current = droppable;
+	const listeners = useMemo<ProjectDraggable["listeners"]>(
+		() => ({
+			onPointerDown: (event: ReactPointerEvent<HTMLElement>) =>
+				draggableRef.current.listeners?.onPointerDown?.(event),
+		}),
+		[],
+	);
+	const setActivatorNodeRef = useCallback(
+		(node: HTMLElement | null) => draggableRef.current.setActivatorNodeRef(node),
+		[],
+	);
+	const setDraggableNodeRef = useCallback(
+		(node: HTMLElement | null) => draggableRef.current.setNodeRef(node),
+		[],
+	);
+	const setDroppableNodeRef = useCallback(
+		(node: HTMLElement | null) => droppableRef.current.setNodeRef(node),
+		[],
+	);
 	return (
 		<ProjectItemContent
 			{...props}
@@ -998,7 +1022,6 @@ const ProjectItemContent = memo(function ProjectItemContent({
 	expanded,
 	selection,
 	draggingProjectId,
-	dropIndicator,
 	consumeDragClick,
 	onSessionOrderChange,
 	onToggle,
@@ -1051,6 +1074,11 @@ const ProjectItemContent = memo(function ProjectItemContent({
 	);
 	const sessionIds = useMemo(() => sessions.map((session) => session.id), [sessions]);
 	const sessionLayoutDependency = useMemo(() => sessionIds.join("\u0000"), [sessionIds]);
+	// Project and session reordering use nested DnD contexts. While a project is
+	// being dragged, leave the session lists as plain rows: otherwise every
+	// expanded project's DnD context measures its sortable descendants on drop.
+	// With a dense sidebar that turns one project drop into a full-tree layout.
+	const projectDragInProgress = draggingProjectId !== null && draggingProjectId !== undefined;
 	const sessionSensors = useReorderSensors();
 	const sessionDragClickGuard = usePostDragClickGuard();
 	const [sessionDragging, setSessionDragging] = useState(false);
@@ -1203,22 +1231,23 @@ const ProjectItemContent = memo(function ProjectItemContent({
 					data-dragging={projectIsDragging ? "true" : undefined}
 					data-project-drop-target=""
 					data-project-id={workspace.id}
+					data-drop-indicator={undefined}
 					data-sidebar="menu-item"
 					data-slot="sidebar-menu-item"
 					layout={draggingProjectId ? false : "position"}
 					ref={setDroppableNodeRef}
 					transition={prefersReducedMotion ? { duration: 0 } : { type: "spring", stiffness: 520, damping: 42, mass: 0.55 }}
 				>
-					{dropIndicator ? (
-						<div
-							aria-hidden="true"
-							className={cn(
-								"pointer-events-none absolute inset-x-0 z-[70] h-px bg-foreground",
-								dropIndicator === "before" ? "top-0" : "bottom-0",
-							)}
-							data-project-drop-indicator={dropIndicator}
-						/>
-					) : null}
+					<div
+						aria-hidden="true"
+						className="pointer-events-none absolute inset-x-0 top-0 z-[70] h-px bg-foreground opacity-0 group-data-[drop-indicator=before]/menu-item:opacity-100"
+						data-project-drop-indicator="before"
+					/>
+					<div
+						aria-hidden="true"
+						className="pointer-events-none absolute inset-x-0 bottom-0 z-[70] h-px bg-foreground opacity-0 group-data-[drop-indicator=after]/menu-item:opacity-100"
+						data-project-drop-indicator="after"
+					/>
 					{/* The whole visual row scales when its navigation surface is pressed.
 		    Action-button presses stop before reaching this boundary. */}
 					<div
@@ -1437,35 +1466,52 @@ const ProjectItemContent = memo(function ProjectItemContent({
 						exit={{ y: -12, opacity: 0 }}
 						transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.14, ease: [0.25, 0.46, 0.45, 0.94] }}
 					>
-											<DndContext
-										collisionDetection={closestCenter}
-										modifiers={[restrictToListBounds]}
-										id={sessionDndId(workspace.id)}
-										onDragStart={() => setSessionDragging(true)}
-									onDragCancel={onSessionDragCancel}
-										onDragEnd={onSessionDragEnd}
-										sensors={sessionSensors}
-									>
-										<SortableContext items={sessionIds} strategy={verticalListSortingStrategy}>
-											<SidebarMenuSub
-												className="mx-0 ml-3.5 translate-x-0 gap-px border-l-0 px-0 py-1"
-												data-testid={`session-list-${workspace.id}`}
-											>
-												{sessions.map((session) => (
-													<SortableSessionRow
-														key={session.id}
-														session={session}
-														active={selection.activeSessionId === session.id}
-														consumeDragClick={sessionDragClickGuard.consumeClick}
-														layoutDependency={sessionLayoutDependency}
-														listIsDragging={sessionDragging}
-														dropTransitionDisabled={dropTransitionDisabledId === session.id}
-														onOpen={openSession}
-													/>
-												))}
-											</SidebarMenuSub>
-										</SortableContext>
-									</DndContext>
+											{projectDragInProgress ? (
+												<SidebarMenuSub
+													className="mx-0 ml-3.5 translate-x-0 gap-px border-l-0 px-0 py-1"
+													data-testid={`session-list-${workspace.id}`}
+												>
+													{sessions.map((session) => (
+														<SessionRow
+															key={session.id}
+															session={session}
+															active={selection.activeSessionId === session.id}
+															disableLayout
+															onOpen={() => openSession(session.id)}
+														/>
+													))}
+												</SidebarMenuSub>
+											) : (
+												<DndContext
+													collisionDetection={closestCenter}
+													modifiers={[restrictToListBounds]}
+													id={sessionDndId(workspace.id)}
+													onDragStart={() => setSessionDragging(true)}
+													onDragCancel={onSessionDragCancel}
+													onDragEnd={onSessionDragEnd}
+													sensors={sessionSensors}
+												>
+													<SortableContext items={sessionIds} strategy={verticalListSortingStrategy}>
+														<SidebarMenuSub
+															className="mx-0 ml-3.5 translate-x-0 gap-px border-l-0 px-0 py-1"
+															data-testid={`session-list-${workspace.id}`}
+														>
+															{sessions.map((session) => (
+																<SortableSessionRow
+																	key={session.id}
+																	session={session}
+																	active={selection.activeSessionId === session.id}
+																	consumeDragClick={sessionDragClickGuard.consumeClick}
+																	layoutDependency={sessionLayoutDependency}
+																	listIsDragging={sessionDragging}
+																	dropTransitionDisabled={dropTransitionDisabledId === session.id}
+																	onOpen={openSession}
+																/>
+															))}
+														</SidebarMenuSub>
+													</SortableContext>
+												</DndContext>
+											)}
 								</motion.div>
 							</motion.div>
 						)}
@@ -1537,9 +1583,9 @@ const ProjectDragPreview = memo(function ProjectDragPreview({ workspace, expande
 						const switchLabel = switchPresentation ? t(switchPresentation.compactLabelKey, switchPresentation.values) : undefined;
 						const active = selection.activeSessionId === session.id;
 						return (
-							<div className="pl-4.5" key={session.id}>
+							<div className="pl-0.5" data-project-drag-preview-session="" key={session.id}>
 								<div className={cn("flex h-8 w-full items-center rounded-lg", active && "bg-interactive-active text-foreground")}>
-									<div className="flex h-8 min-w-0 flex-1 items-center gap-1.5 px-2.5 text-sm">
+									<div className="flex h-8 min-w-0 flex-1 items-center gap-1.5 py-0 pl-1.5 pr-2.5 text-sm">
 										<SessionStatusDot session={session} />
 										<span className="flex min-w-0 flex-1 items-center gap-1.5">
 											<span className={cn("min-w-0 flex-1 truncate", active ? "text-foreground" : "text-muted-foreground")}>
@@ -1630,6 +1676,7 @@ function SessionRow({
 	indented = true,
 	layoutDependency,
 	listIsDragging = false,
+	disableLayout = false,
 	onOpen,
 	reorder,
 }: {
@@ -1638,6 +1685,8 @@ function SessionRow({
 	indented?: boolean;
 	layoutDependency?: string;
 	listIsDragging?: boolean;
+	/** Project drags pause nested session projection work. */
+	disableLayout?: boolean;
 	onOpen: () => void;
 	/** Present only for rows inside a reorderable project list. */
 	reorder?: SessionReorder;
@@ -1733,8 +1782,8 @@ function SessionRow({
 			style={reorder ? sortableRowStyle(reorder) : undefined}
 		>
 			<motion.div
-				layout={listIsDragging ? false : "position"}
-				layoutDependency={layoutDependency}
+				layout={disableLayout || listIsDragging ? false : "position"}
+				layoutDependency={disableLayout ? undefined : layoutDependency}
 				transition={prefersReducedMotion ? { duration: 0 } : { type: "spring", stiffness: 520, damping: 42, mass: 0.55 }}
 			>
 				<div

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -449,7 +449,7 @@ export function Sidebar({
 	const [dismissedInitialActiveProjectIds, setDismissedInitialActiveProjectIds] = useState<ReadonlySet<string>>(
 		() => new Set(),
 	);
-	const toggleProjectDisclosure = (id: string) => {
+	const toggleProjectDisclosure = useCallback((id: string) => {
 		const routeFallbackActive =
 			initialActiveSessionProjectId === id && !dismissedInitialActiveProjectIds.has(id);
 		const currentlyExpanded = expandedIds.has(id) || routeFallbackActive;
@@ -467,7 +467,7 @@ export function Sidebar({
 			currentlyExpanded ? next.add(id) : next.delete(id);
 			return next;
 		});
-	};
+	}, [dismissedInitialActiveProjectIds, expandedIds, initialActiveSessionProjectId]);
 	// Section disclosure: Pinned header collapses its body. Projects stays open.
 	const [pinnedOpen, setPinnedOpen] = useState(true);
 	// Fetch the running app version to derive the build channel. Channel is
@@ -819,7 +819,7 @@ export function Sidebar({
 											dropIndicator={projectDragState.overId === workspace.id ? projectDragState.placement ?? undefined : undefined}
 											consumeDragClick={projectDragClickGuard.consumeClick}
 											onSessionOrderChange={recordSessionOrder}
-											onToggle={() => toggleProjectDisclosure(workspace.id)}
+											onToggle={toggleProjectDisclosure}
 											onRemoveProject={onRemoveProject}
 										/>
 									))}
@@ -960,7 +960,7 @@ type ProjectItemProps = {
 	dropIndicator?: "before" | "after";
 	consumeDragClick: (id: string) => boolean;
 	onSessionOrderChange: (projectId: string, order: string[]) => void;
-	onToggle: () => void;
+	onToggle: (projectId: string) => void;
 	onRemoveProject: (projectId: string) => Promise<void>;
 	suppressInitialExpandAnimation: boolean;
 };
@@ -1097,7 +1097,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 	const orchestrator = newestActiveOrchestrator(workspace.sessions);
 	const toggleDisclosure = () => {
 		hasInteractedWithDisclosure.current = true;
-		onToggle();
+		onToggle(workspace.id);
 	};
 
 	// Mirrors ShellTopbar's launcher: attach to the running orchestrator, or

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -37,7 +37,7 @@ const {
 		terminalState: { value: "idle" },
 		replaySettled: { value: true },
 		hasAttached: { value: false },
-		terminalSessionOptions: [] as Array<{ coverInitialReplay?: boolean }>,
+		terminalSessionOptions: [] as Array<{ coverInitialReplay?: boolean; shellTerminalHandleId?: string }>,
 		xtermMounts: { value: 0 },
 		xtermUnmounts: { value: 0 },
 	}),
@@ -90,7 +90,7 @@ vi.mock("./XtermTerminal", () => ({
 vi.mock("../hooks/useTerminalSession", () => ({
 	useTerminalSession: (
 		_session: WorkspaceSession | undefined,
-		options: { coverInitialReplay?: boolean },
+		options: { coverInitialReplay?: boolean; shellTerminalHandleId?: string },
 	) => {
 		terminalSessionOptions.push(options);
 		return {
@@ -272,6 +272,36 @@ describe("TerminalPane empty states", () => {
 			view.restore();
 		}
 	});
+
+	it("selects a temporary shell without attaching xterm to its temporary handle", () => {
+		const shell = {
+			handleId: "pending-shell:test",
+			sessionId: worker.id,
+			workingDir: "",
+			title: "Terminal 1",
+			createdAt: "2026-08-31T00:00:00Z",
+			optimistic: true,
+		} satisfies ShellTerminal;
+		const view = renderCachedPane({
+			session: worker,
+			sessions: [worker],
+			shellTerminals: [shell],
+			terminalTarget: {
+				generation: shell.createdAt,
+				kind: "shell",
+				handleId: shell.handleId,
+				sessionId: worker.id,
+				title: shell.title,
+			},
+		});
+		try {
+			expect(screen.getByTestId("optimistic-terminal")).toBeInTheDocument();
+			expect(screen.queryByTestId("xterm")).not.toBeInTheDocument();
+			expect(terminalSessionOptions.at(-1)?.shellTerminalHandleId).toBeUndefined();
+		} finally {
+			view.restore();
+		}
+	});
 });
 
 // Initial-replay cover (issue #3160): xterm stays mounted and ingesting behind
@@ -428,6 +458,23 @@ describe("TerminalCacheProvider", () => {
 			view.show(sessions[0]);
 			await waitFor(() => expect(activeXterm()).toBe(oldest));
 			expect(xtermMounts.value).toBe(7);
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("reveals a cached terminal immediately while its activation preparation is still pending", async () => {
+		prepareForActivationMock.mockImplementation(() => new Promise<void>(() => undefined));
+		const view = renderCachedPane({ session: sessionA, sessions: [sessionA, sessionB] });
+		try {
+			const terminalA = await waitFor(() => activeXterm());
+			view.show(sessionB);
+			await waitFor(() => expect(activeXterm()).not.toBe(terminalA));
+
+			view.show(sessionA);
+			const host = document.querySelector<HTMLElement>(`[data-terminal-cache-key^="session:${sessionA.id}:worker|"]`);
+			expect(host).toHaveAttribute("data-terminal-activation-phase", "visible");
+			expect(host?.style.visibility).not.toBe("hidden");
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -285,7 +285,9 @@ describe("TerminalPane empty states", () => {
 		const view = renderCachedPane({
 			session: worker,
 			sessions: [worker],
-			shellTerminals: [shell],
+			// The authoritative shell can replace the optimistic cache row before
+			// the selected target changes. A pending handle itself is the contract.
+			shellTerminals: [],
 			terminalTarget: {
 				generation: shell.createdAt,
 				kind: "shell",

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -600,6 +600,7 @@ export function TerminalPane({
 	inputDisabled,
 	focusRequested,
 }: TerminalPaneProps) {
+	const { t } = useTranslation();
 	const terminalTarget =
 		requestedTerminalTarget &&
 		terminalTargetBelongsToSession(requestedTerminalTarget, session?.id)
@@ -668,7 +669,13 @@ export function TerminalPane({
 	// rather than surfacing a separate loading state or attaching xterm to a
 	// handle that cannot exist yet.
 	if (isOptimisticShell) {
-		return <div aria-label="Terminal" className="terminal-surface h-full" data-testid="optimistic-terminal" />;
+		return (
+			<div
+				aria-label={t("terminal.shellAria")}
+				className="terminal-surface h-full"
+				data-testid="optimistic-terminal"
+			/>
+		);
 	}
 
 	const props = {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -70,7 +70,7 @@ type TerminalCacheDescriptor = {
 
 type CachedTerminalEntry = TerminalCacheDescriptor & {
 	activationId: number;
-	activationPhase: "parked" | "preparing" | "ready" | "revealed" | "visible";
+	activationPhase: "parked" | "visible";
 	container: HTMLDivElement;
 	discardOnDeactivate?: boolean;
 	props: TerminalPaneProps;
@@ -169,7 +169,6 @@ function setTerminalPhase(
 	entry.activationPhase = phase;
 	entry.container.dataset.terminalActivationPhase = phase;
 	const interactive = phase === "visible";
-	const rendered = phase === "revealed" || interactive;
 	entry.container.inert = !interactive;
 	if (interactive) {
 		entry.container.removeAttribute("aria-hidden");
@@ -178,7 +177,7 @@ function setTerminalPhase(
 		entry.container.setAttribute("aria-hidden", "true");
 		entry.container.style.pointerEvents = "none";
 	}
-	if (rendered) {
+	if (interactive) {
 		entry.container.style.visibility = "";
 	} else {
 		entry.container.style.visibility = "hidden";
@@ -197,39 +196,23 @@ function parkTerminal(entry: CachedTerminalEntry, parking: HTMLDivElement): void
 
 function showTerminal(entry: CachedTerminalEntry, slot: HTMLDivElement): void {
 	entry.activationId += 1;
-	// A retained renderer already has the latest hidden output. Prepare it at the
-	// bottom while hidden so returning to a worker never exposes the historical
-	// viewport the user happened to leave behind.
-	setTerminalPhase(entry, entry.terminal ? "preparing" : "visible");
-	if (entry.activationPhase === "visible") entry.container.style.visibility = "";
+	// Do not hide a retained terminal while it crosses xterm's two paint-frame
+	// preparation cycle: that made every return to a tab flash blank.
+	setTerminalPhase(entry, "visible");
 	entry.container.style.width = "100%";
 	entry.container.style.height = "100%";
 	slot.appendChild(entry.container);
-}
-
-function revealTerminal(entry: CachedTerminalEntry): void {
-	setTerminalPhase(entry, "revealed");
-}
-
-function activateTerminal(entry: CachedTerminalEntry): void {
-	setTerminalPhase(entry, "visible");
 }
 
 function CachedTerminalPortal({
 	active,
 	entry,
 	onFatal,
-	onPrepared,
-	onReveal,
-	onActivated,
 	onTerminalReady,
 }: {
 	active: boolean;
 	entry: CachedTerminalEntry;
 	onFatal: (cacheKey: string, message: string) => void;
-	onPrepared: (cacheKey: string, activationId: number) => void;
-	onReveal: (cacheKey: string, activationId: number) => void;
-	onActivated: (cacheKey: string, activationId: number) => void;
 	onTerminalReady: (cacheKey: string, terminal: AttachableTerminal) => void;
 }) {
 	const handleFatal = useCallback(
@@ -244,41 +227,17 @@ function CachedTerminalPortal({
 	);
 	useLayoutEffect(() => {
 		const terminal = entry.terminal;
-		if (!active || entry.activationPhase !== "preparing" || !terminal) return;
-		const activationId = entry.activationId;
-		let current = true;
-		void terminal.prepareForActivation().then(() => {
-			if (current) onPrepared(entry.cacheKey, activationId);
-		});
-		return () => {
-			current = false;
-		};
+		if (!active || entry.activationPhase !== "visible" || !terminal) return;
+		// Fit and scroll after the host is visible. This retains the cache's
+		// settled viewport behavior without putting a blank frame in front of it.
+		void terminal.prepareForActivation();
 	}, [
 		active,
 		entry,
 		entry.activationId,
 		entry.activationPhase,
 		entry.terminal,
-		onPrepared,
 	]);
-	useLayoutEffect(() => {
-		if (!active || entry.activationPhase !== "ready") return;
-		onReveal(entry.cacheKey, entry.activationId);
-	}, [active, entry, entry.activationId, entry.activationPhase, onReveal]);
-	useLayoutEffect(() => {
-		if (!active || entry.activationPhase !== "revealed") return;
-		const activationId = entry.activationId;
-		let paintFrame: number | null = null;
-		const revealFrame = requestAnimationFrame(() => {
-			paintFrame = requestAnimationFrame(() => {
-				onActivated(entry.cacheKey, activationId);
-			});
-		});
-		return () => {
-			cancelAnimationFrame(revealFrame);
-			if (paintFrame !== null) cancelAnimationFrame(paintFrame);
-		};
-	}, [active, entry, entry.activationId, entry.activationPhase, onActivated]);
 	return createPortal(
 		<AttachedTerminal
 			{...entry.props}
@@ -490,57 +449,6 @@ export function TerminalCacheProvider({
 		[rerender],
 	);
 
-	const markPrepared = useCallback(
-		(cacheKey: string, activationId: number) => {
-			const entry = entriesRef.current.get(cacheKey);
-			if (
-				!entry ||
-				entry.activationId !== activationId ||
-				entry.activationPhase !== "preparing" ||
-				activeRef.current?.key !== cacheKey
-			) {
-				return;
-			}
-			setTerminalPhase(entry, "ready");
-			rerender();
-		},
-		[rerender],
-	);
-
-	const markReveal = useCallback(
-		(cacheKey: string, activationId: number) => {
-			const entry = entriesRef.current.get(cacheKey);
-			if (
-				!entry ||
-				entry.activationId !== activationId ||
-				entry.activationPhase !== "ready" ||
-				activeRef.current?.key !== cacheKey
-			) {
-				return;
-			}
-			revealTerminal(entry);
-			rerender();
-		},
-		[rerender],
-	);
-
-	const markActivated = useCallback(
-		(cacheKey: string, activationId: number) => {
-			const entry = entriesRef.current.get(cacheKey);
-			if (
-				!entry ||
-				entry.activationId !== activationId ||
-				entry.activationPhase !== "revealed" ||
-				activeRef.current?.key !== cacheKey
-			) {
-				return;
-			}
-			activateTerminal(entry);
-			rerender();
-		},
-		[rerender],
-	);
-
 	// Daemon readiness and theme are shell-wide. Parked entries must observe
 	// them too so reconnect and rendering behavior never depends on the route
 	// that happened to be active when they were parked.
@@ -648,10 +556,7 @@ export function TerminalCacheProvider({
 					active={activeRef.current?.key === entry.cacheKey}
 					entry={entry}
 					key={entry.cacheKey}
-					onActivated={markActivated}
 					onFatal={markFatal}
-					onPrepared={markPrepared}
-					onReveal={markReveal}
 					onTerminalReady={markTerminalReady}
 				/>
 			))}
@@ -700,6 +605,11 @@ export function TerminalPane({
 		terminalTargetBelongsToSession(requestedTerminalTarget, session?.id)
 			? requestedTerminalTarget
 			: ({ kind: "worker" } satisfies TerminalTarget);
+	const shellTerminals = useShellTerminals().data ?? [];
+	const isOptimisticShell = Boolean(
+		terminalTarget.kind === "shell" &&
+			shellTerminals.some((shell) => shell.handleId === terminalTarget.handleId && shell.optimistic),
+	);
 	const cache = useContext(TerminalCacheContext);
 	const terminalKey =
 		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"
@@ -755,6 +665,13 @@ export function TerminalPane({
 				))}
 			</pre>
 		);
+	}
+	// The tab is intentionally selected before the daemon allocates its handle.
+	// Keep that short bridge visually indistinguishable from an empty terminal,
+	// rather than surfacing a separate loading state or attaching xterm to a
+	// handle that cannot exist yet.
+	if (isOptimisticShell) {
+		return <div aria-label="Terminal" className="terminal-surface h-full" data-testid="optimistic-terminal" />;
 	}
 
 	const props = {
@@ -956,7 +873,9 @@ function AttachedTerminal({
 }) {
 	const { t } = useTranslation();
 	const attachSession =
-		session && terminalTarget?.kind === "reviewer"
+		terminalTarget?.kind === "shell"
+			? undefined
+			: session && terminalTarget?.kind === "reviewer"
 			? { ...session, terminalHandleId: terminalTarget.handleId }
 			: session;
 	// One terminal instance per logical-terminal + handle generation. The shell

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -605,11 +605,8 @@ export function TerminalPane({
 		terminalTargetBelongsToSession(requestedTerminalTarget, session?.id)
 			? requestedTerminalTarget
 			: ({ kind: "worker" } satisfies TerminalTarget);
-	const shellTerminals = useShellTerminals().data ?? [];
-	const isOptimisticShell = Boolean(
-		terminalTarget.kind === "shell" &&
-			shellTerminals.some((shell) => shell.handleId === terminalTarget.handleId && shell.optimistic),
-	);
+	const isOptimisticShell =
+		terminalTarget.kind === "shell" && terminalTarget.handleId.startsWith("pending-shell:");
 	const cache = useContext(TerminalCacheContext);
 	const terminalKey =
 		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"

--- a/frontend/src/renderer/components/TerminalTabFrame.tsx
+++ b/frontend/src/renderer/components/TerminalTabFrame.tsx
@@ -65,7 +65,7 @@ export function TerminalTabFrame({
 				{action ? (
 					<div
 						className={cn(
-							"absolute inset-y-0 z-10 flex items-center",
+							"absolute inset-y-0 z-20 flex items-center",
 							actionPosition === "leading" ? "left-2" : "right-1",
 						)}
 						data-terminal-tab-action

--- a/frontend/src/renderer/components/TrayRuntime.test.tsx
+++ b/frontend/src/renderer/components/TrayRuntime.test.tsx
@@ -1,6 +1,6 @@
 import { act, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
+import { attentionZone, workerSessions, type WorkspaceSession, type WorkspaceSummary } from "../types/workspace";
 
 const h = vi.hoisted(() => ({
 	setAttentionState: vi.fn(),
@@ -10,7 +10,15 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
-	useWorkspaceQuery: () => ({ data: h.workspaces }),
+	useWorkspaceTraySessions: () => ({
+		data: h.workspaces.flatMap((workspace) =>
+			workerSessions(workspace.sessions).flatMap((session) => {
+				const zone = attentionZone(session);
+				if ((zone === "merge" && session.status === "merged") || (zone !== "action" && zone !== "merge")) return [];
+				return [{ projectId: workspace.id, projectName: workspace.name, sessionId: session.id, title: session.title, zone }];
+			}),
+		),
+	}),
 	workspaceQueryKey: ["workspaces"],
 }));
 

--- a/frontend/src/renderer/components/TrayRuntime.tsx
+++ b/frontend/src/renderer/components/TrayRuntime.tsx
@@ -1,32 +1,11 @@
-import { useEffect, useMemo, useRef } from "react";
-import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { useEffect, useRef } from "react";
+import { useWorkspaceTraySessions } from "../hooks/useWorkspaceQuery";
 import { aoBridge } from "../lib/bridge";
 import { useNavigateToSession } from "../lib/navigate-to-session";
-import { attentionZone, workerSessions } from "../types/workspace";
-import type { TraySessionEntry } from "../../shared/tray";
 
 export function TrayRuntime() {
-	const workspaces = useWorkspaceQuery().data ?? [];
+	const sessions = useWorkspaceTraySessions().data ?? [];
 	const navigateToSession = useNavigateToSession();
-
-	const sessions = useMemo<TraySessionEntry[]>(() => {
-		const entries: TraySessionEntry[] = [];
-		for (const workspace of workspaces) {
-			for (const session of workerSessions(workspace.sessions)) {
-				const zone = attentionZone(session);
-				if (zone === "merge" && session.status === "merged") continue;
-				if (zone !== "action" && zone !== "merge") continue;
-				entries.push({
-					projectId: workspace.id,
-					projectName: workspace.name,
-					sessionId: session.id,
-					title: session.title,
-					zone,
-				});
-			}
-		}
-		return entries;
-	}, [workspaces]);
 
 	const lastPushed = useRef<string | null>(null);
 	const serialized = JSON.stringify(sessions);

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -506,14 +506,14 @@ describe("slash commands", () => {
 		expect(selected).toBe(0);
 	});
 
-	it("scrolls the first result back into view when filtering resets selection", async () => {
+	it("does not force-scroll when filtering keeps the visible first result selected", async () => {
 		const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
 		const { field } = renderComposer({ skills: SKILLS });
 		await typeInComposer(field, "/");
 		scrollIntoView.mockClear();
 		await typeInComposer(field, "r");
 
-		expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+		expect(scrollIntoView).not.toHaveBeenCalled();
 		scrollIntoView.mockRestore();
 	});
 

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -36,6 +36,7 @@ import {
 	useRef,
 	useState,
 	isValidElement,
+	memo,
 	type ClipboardEvent,
 	type DragEvent,
 	type FormEvent,
@@ -74,7 +75,7 @@ function withAttachmentReferences(text: string, paths: string[]): string {
 	return `${lead}Attached files (read these files in the workspace):\n${paths.map((path) => `- ${path}`).join("\n")}`;
 }
 
-export function ChatComposer({
+export const ChatComposer = memo(function ChatComposer({
 	onSend,
 	busy,
 	willQueue,
@@ -872,4 +873,4 @@ export function ChatComposer({
 				</div>
 			</form>,
 	);
-}
+});

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -76,7 +76,7 @@ import {
 import { HumanMessageEditor } from "./HumanMessageEditor";
 import { ChatLinkProvider } from "./ChatMarkdown";
 import { ChatComposer } from "./ChatComposer";
-import { QueuedMessageDock } from "./QueuedMessageDock";
+import { QueuedMessageDock, type QueuedMessage } from "./QueuedMessageDock";
 import { ActivityRun } from "./ActivityRun";
 import { TurnPlan } from "./TurnPlan";
 import { TurnSettingsBar } from "./TurnSettingsBar";
@@ -178,6 +178,45 @@ type MessageEditDraft = {
 	content: ConversationContentSummary[];
 	reconstructedContext: boolean;
 };
+
+/**
+ * A stream refresh replaces the complete snapshot object. Queue prompts do not
+ * change while a running turn emits output, so retain the previous list when its
+ * contents are equal and avoid redrawing the dock and composer subtree.
+ */
+function useQueuedMessages(snapshot: ConversationSnapshot): QueuedMessage[] {
+	const previous = useRef<QueuedMessage[]>([]);
+	return useMemo(() => {
+		const messagesByTurn = new Map(
+			snapshot.items
+				.filter(
+					(item): item is ConversationMessage =>
+						item.kind === "message" &&
+						item.role === "user" &&
+						item.origin === "human" &&
+						Boolean(item.turnId),
+				)
+				.map((message) => [message.turnId as string, message]),
+		);
+		const next = snapshot.turns.flatMap((queuedTurn) => {
+			if (queuedTurn.state !== "queued") return [];
+			const message = messagesByTurn.get(queuedTurn.id);
+			return message ? [{ turnId: queuedTurn.id, message }] : [];
+		});
+		const current = previous.current;
+		if (
+			current.length === next.length &&
+			current.every(
+				(entry, index) =>
+					entry.turnId === next[index]?.turnId && sameContent(entry.message, next[index]?.message),
+			)
+		) {
+			return current;
+		}
+		previous.current = next;
+		return next;
+	}, [snapshot.items, snapshot.turns]);
+}
 
 export interface ChatWorkspaceProps {
 	snapshot: ConversationSnapshot;
@@ -524,24 +563,9 @@ export function ChatWorkspace({
 			return { ...current, [snapshot.sessionId]: next };
 		});
 	}, [auxiliaryTabOrder, availableTabKeys, onAuxiliaryTabOrderChange, snapshot.sessionId]);
-	const queuedMessages = useMemo(() => {
-		const messagesByTurn = new Map(
-			snapshot.items
-				.filter(
-					(item): item is ConversationMessage =>
-						item.kind === "message" &&
-						item.role === "user" &&
-						item.origin === "human" &&
-						Boolean(item.turnId),
-				)
-				.map((message) => [message.turnId as string, message]),
-		);
-		return snapshot.turns.flatMap((queuedTurn) => {
-			if (queuedTurn.state !== "queued") return [];
-			const message = messagesByTurn.get(queuedTurn.id);
-			return message ? [{ turnId: queuedTurn.id, message }] : [];
-		});
-	}, [snapshot.items, snapshot.turns]);
+	const queuedMessages = useQueuedMessages(snapshot);
+	const stablePromoteQueuedTurn = useStableCallback(onPromoteQueuedTurn);
+	const stableCancelQueuedTurn = useStableCallback(onCancelQueuedTurn);
 	const [queueEdit, setQueueEdit] = useState<{ turnId: string; text: string } | undefined>();
 	useEffect(() => {
 		if (!queueEdit) return;
@@ -552,10 +576,10 @@ export function ChatWorkspace({
 	const handleCancelQueuedTurn = useCallback(
 		async (turnId: string) => {
 			if (!onCancelQueuedTurn) return;
-			await onCancelQueuedTurn(turnId);
+			await stableCancelQueuedTurn(turnId);
 			setQueueEdit((current) => (current?.turnId === turnId ? undefined : current));
 		},
-		[onCancelQueuedTurn],
+		[stableCancelQueuedTurn],
 	);
 	const handleComposerSend = useCallback(
 		async (text: string, attachments?: Parameters<NonNullable<typeof onSend>>[1]) => {
@@ -574,6 +598,22 @@ export function ChatWorkspace({
 		},
 		[onEditQueuedTurn, onSend, queueEdit],
 	);
+	const composerSend = useStableCallback(handleComposerSend);
+	const stableInterrupt = useStableCallback(onInterrupt);
+	const stableSteer = useStableCallback(onSteer);
+	const beginQueuedEdit = useCallback(
+		(turnId: string, text: string) => {
+			if (newWorkDisabled) return;
+			setQueueEdit({ turnId, text });
+		},
+		[newWorkDisabled],
+	);
+	const cancelQueuedEdit = useCallback(() => setQueueEdit(undefined), []);
+	const promoteQueuedTurn = useCallback(
+		async (turnId: string) => stablePromoteQueuedTurn(turnId),
+		[stablePromoteQueuedTurn],
+	);
+	const steer = useCallback(async (text: string) => stableSteer(text), [stableSteer]);
 	// The turn a confirmation is open for. Undo is not reversible and it changes what
 	// the agent knows, so it is never one click.
 	const [confirming, setConfirming] = useState<string | undefined>(undefined);
@@ -774,6 +814,86 @@ export function ChatWorkspace({
 				return !latest || item.sequence > latest.sequence ? item : latest;
 			}, undefined),
 		[snapshot.items, turn],
+	);
+	const stableSettings = useStableValue(snapshot.settings);
+	const stableModelReroute = useStableValue(snapshot.modelReroute);
+	const stablePendingApproval = useStableValue(pendingApproval);
+	const composerSettings = useMemo(
+		() =>
+			onChooseSettings || onChooseConfigOption ? (
+				<TurnSettingsBar
+					models={models ?? []}
+					settings={stableSettings}
+					reroute={stableModelReroute}
+					onChange={newWorkDisabled ? undefined : onChooseSettings}
+					configOptions={configOptions ?? []}
+					onChangeConfigOption={newWorkDisabled ? undefined : onChooseConfigOption}
+					configPending={configOptionPending}
+					error={configOptionError}
+					disabled={
+						snapshot.controller.state === "stopped" || configOptionPending || newWorkDisabled
+					}
+				/>
+			) : null,
+		[
+			configOptionError,
+			configOptionPending,
+			configOptions,
+			models,
+			newWorkDisabled,
+			onChooseConfigOption,
+			onChooseSettings,
+			snapshot.controller.state,
+			stableModelReroute,
+			stableSettings,
+		],
+	);
+	const composerApproval = useMemo(
+		() =>
+			stablePendingApproval ? (
+				<ApprovalCard
+					activity={stablePendingApproval}
+					onDecide={onDecide}
+					busy={busy}
+					embedded
+				/>
+			) : undefined,
+		[busy, onDecide, stablePendingApproval],
+	);
+	const canSteerQueuedMessage =
+		Boolean(onSteer) && can(snapshot, "steer") && turn?.state === "running";
+	const composerQueuedDock = useMemo(
+		() =>
+			queuedMessages.length > 0 ? (
+				<QueuedMessageDock
+					messages={queuedMessages}
+					editingTurnId={queueEdit?.turnId}
+					canSteer={canSteerQueuedMessage}
+					onPromoteQueuedTurn={newWorkDisabled ? undefined : promoteQueuedTurn}
+					onBeginQueuedEdit={
+						newWorkDisabled || !onEditQueuedTurn ? undefined : beginQueuedEdit
+					}
+					onCancelQueuedTurn={newWorkDisabled ? undefined : handleCancelQueuedTurn}
+					promotePendingTurnId={promoteQueuedTurnPendingTurnId}
+					cancelPendingTurnId={cancelQueuedTurnPendingTurnId}
+				/>
+			) : null,
+		[
+			beginQueuedEdit,
+			canSteerQueuedMessage,
+			cancelQueuedTurnPendingTurnId,
+			handleCancelQueuedTurn,
+			newWorkDisabled,
+			onEditQueuedTurn,
+			promoteQueuedTurn,
+			promoteQueuedTurnPendingTurnId,
+			queueEdit?.turnId,
+			queuedMessages,
+		],
+	);
+	const composerDraftSeed = useMemo(
+		() => (queueEdit ? { id: queueEdit.turnId, text: queueEdit.text } : undefined),
+		[queueEdit],
 	);
 	// Empty chats center the prompt; once a turn or item exists the composer docks
 	// at the bottom and stays there for the rest of the session.
@@ -990,71 +1110,19 @@ export function ChatWorkspace({
 							>
 								{discarded > 0 ? <RolledBackNotice count={discarded} /> : null}
 								<ChatComposer
-									queuedDock={
-										queuedMessages.length > 0 ? (
-											<QueuedMessageDock
-												messages={queuedMessages}
-												editingTurnId={queueEdit?.turnId}
-												canSteer={
-													Boolean(onSteer) &&
-													can(snapshot, "steer") &&
-													turn?.state === "running"
-												}
-												onPromoteQueuedTurn={newWorkDisabled ? undefined : onPromoteQueuedTurn}
-												onBeginQueuedEdit={
-													newWorkDisabled || !onEditQueuedTurn
-														? undefined
-														: (turnId, text) => setQueueEdit({ turnId, text })
-												}
-												onCancelQueuedTurn={
-													newWorkDisabled ? undefined : handleCancelQueuedTurn
-												}
-												promotePendingTurnId={promoteQueuedTurnPendingTurnId}
-												cancelPendingTurnId={cancelQueuedTurnPendingTurnId}
-											/>
-										) : null
-									}
-									approval={
-										pendingApproval ? (
-											<ApprovalCard
-												activity={pendingApproval}
-												onDecide={onDecide}
-												busy={busy}
-												embedded
-											/>
-										) : undefined
-									}
-									onSend={(text, attachments) => handleComposerSend(text, attachments)}
-									draftSeed={
-										queueEdit ? { id: queueEdit.turnId, text: queueEdit.text } : undefined
-									}
+									queuedDock={composerQueuedDock}
+									approval={composerApproval}
+									onSend={composerSend}
+									draftSeed={composerDraftSeed}
 									editingQueuedTurnId={queueEdit?.turnId}
 									savingQueuedEditPending={Boolean(
 										queueEdit?.turnId &&
 											editQueuedTurnPendingTurnId === queueEdit.turnId,
 									)}
-									onCancelQueuedEdit={() => setQueueEdit(undefined)}
-									onInterrupt={turn && !newWorkDisabled ? onInterrupt : undefined}
+									onCancelQueuedEdit={cancelQueuedEdit}
+									onInterrupt={turn && !newWorkDisabled ? stableInterrupt : undefined}
 									commandError={commandError}
-									settings={
-										onChooseSettings || onChooseConfigOption ? (
-											<TurnSettingsBar
-												models={models ?? []}
-												settings={snapshot.settings}
-												reroute={snapshot.modelReroute}
-												onChange={newWorkDisabled ? undefined : onChooseSettings}
-												configOptions={configOptions ?? []}
-												onChangeConfigOption={newWorkDisabled ? undefined : onChooseConfigOption}
-												configPending={configOptionPending}
-												error={configOptionError}
-												disabled={
-													snapshot.controller.state === "stopped" ||
-													configOptionPending ||
-													newWorkDisabled
-												}
-											/>
-										) : null
-									}
+									settings={composerSettings}
 									busy={busy}
 									willQueue={Boolean(turn)}
 									disabled={snapshot.controller.state === "stopped" || newWorkDisabled}
@@ -1067,7 +1135,7 @@ export function ChatWorkspace({
 									autoFocusKey={snapshot.sessionId}
 									// Steering is only meaningful into a turn that is running. A queued turn
 									// has not reached the provider, so there is nothing to steer.
-									onSteer={newWorkDisabled ? undefined : onSteer}
+									onSteer={newWorkDisabled ? undefined : steer}
 									canSteer={Boolean(onSteer) && turn?.state === "running"}
 									sendPending={sendPending}
 									steerPending={steerPending}
@@ -2679,6 +2747,13 @@ function useStableCallback<Args extends unknown[], Result>(
 	// Only ever called from an event handler, which runs after the commit that
 	// updated the ref — there is no render-phase caller to read a stale closure.
 	return useCallback((...args: Args) => latest.current?.(...args), []);
+}
+
+/** Retain an unchanged JSON-shaped value across snapshot refreshes. */
+function useStableValue<T>(value: T): T {
+	const previous = useRef(value);
+	if (!sameContent(previous.current, value)) previous.current = value;
+	return previous.current;
 }
 
 type TimelineGroup = {

--- a/frontend/src/renderer/components/chat/ComposerSuggestMenu.tsx
+++ b/frontend/src/renderer/components/chat/ComposerSuggestMenu.tsx
@@ -12,7 +12,7 @@
  * rather than a focus move).
  */
 
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowDownUp, CornerDownLeft } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { composerFileIcon } from "./composerFileIcon";
@@ -38,6 +38,7 @@ export function ComposerSuggestMenu({
 	const list = useRef<HTMLUListElement>(null);
 	const lastScrollTop = useRef(0);
 	const scrollDirection = useRef<"up" | "down" | null>(null);
+	const previousHighlighted = useRef(highlighted);
 	const [scrollIndicators, setScrollIndicators] = useState({
 		top: false,
 		bottom: true,
@@ -66,12 +67,19 @@ export function ComposerSuggestMenu({
 
 	// Keep the highlighted row visible when it moves by keyboard past the edge of
 	// the scroll area.
-	useLayoutEffect(() => {
+	useEffect(() => {
+		const previous = previousHighlighted.current;
+		previousHighlighted.current = highlighted;
+		// Index zero is visible whenever the menu opens or its results re-rank.
+		// Calling scrollIntoView for it forced a synchronous layout on every typed
+		// character, which made `/` and `@` suggestions hitch the composer. It
+		// still needs a scroll when filtering reset a keyboard selection to zero.
+		if (highlighted === 0 && previous === 0 && (list.current?.scrollTop ?? 0) <= 1) return;
 		const row = list.current?.querySelector<HTMLElement>(`[data-index="${highlighted}"]`);
 		row?.scrollIntoView({ block: "nearest" });
-	}, [highlighted, items]);
+	}, [highlighted]);
 
-	useLayoutEffect(() => {
+	useEffect(() => {
 		const node = list.current;
 		scrollDirection.current = null;
 		lastScrollTop.current = node?.scrollTop ?? 0;
@@ -80,7 +88,7 @@ export function ComposerSuggestMenu({
 		const observer = new ResizeObserver(updateScrollIndicators);
 		observer.observe(node);
 		return () => observer.disconnect();
-	}, [items, updateScrollIndicators]);
+	}, [kind, updateScrollIndicators]);
 
 	if (items.length === 0) return null;
 

--- a/frontend/src/renderer/components/chat/ComposerSuggestMenu.tsx
+++ b/frontend/src/renderer/components/chat/ComposerSuggestMenu.tsx
@@ -77,7 +77,7 @@ export function ComposerSuggestMenu({
 		if (highlighted === 0 && previous === 0 && (list.current?.scrollTop ?? 0) <= 1) return;
 		const row = list.current?.querySelector<HTMLElement>(`[data-index="${highlighted}"]`);
 		row?.scrollIntoView({ block: "nearest" });
-	}, [highlighted]);
+	}, [highlighted, items]);
 
 	useEffect(() => {
 		const node = list.current;
@@ -88,7 +88,7 @@ export function ComposerSuggestMenu({
 		const observer = new ResizeObserver(updateScrollIndicators);
 		observer.observe(node);
 		return () => observer.disconnect();
-	}, [kind, updateScrollIndicators]);
+	}, [items, updateScrollIndicators]);
 
 	if (items.length === 0) return null;
 

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { memo, useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import { ChevronDown, Circle, CornerDownLeft, Pencil, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { ConversationMessage } from "../../types/conversation";
@@ -7,7 +7,7 @@ export type QueuedMessage = { turnId: string; message: ConversationMessage };
 
 const QUEUE_DOCK_VISIBLE_ROWS = 5;
 
-function QueuedMessageRow({
+const QueuedMessageRow = memo(function QueuedMessageRow({
 	turnId,
 	message,
 	hiddenFromView,
@@ -118,9 +118,9 @@ function QueuedMessageRow({
 			) : null}
 		</div>
 	);
-}
+});
 
-export function QueuedMessageDock({
+export const QueuedMessageDock = memo(function QueuedMessageDock({
 	messages,
 	editingTurnId,
 	canSteer,
@@ -319,4 +319,4 @@ export function QueuedMessageDock({
 			) : null}
 		</div>
 	);
-}
+});

--- a/frontend/src/renderer/components/ui/context-menu.tsx
+++ b/frontend/src/renderer/components/ui/context-menu.tsx
@@ -1,5 +1,11 @@
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
 import { cn } from "../../lib/utils";
+import {
+	actionMenuContentClass,
+	actionMenuItemClass,
+	actionMenuLabelClass,
+	actionMenuSeparatorClass,
+} from "./menu-styles";
 
 export const ContextMenu = ContextMenuPrimitive.Root;
 export const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
@@ -14,8 +20,9 @@ export function ContextMenuContent({
 		<ContextMenuPrimitive.Portal>
 			<ContextMenuPrimitive.Content
 				className={cn(
-					"z-overlay min-w-[10rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md",
-					"data-[state=open]:animate-overlay-in",
+					actionMenuContentClass,
+					"origin-(--radix-context-menu-content-transform-origin)",
+					"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					className,
 				)}
 				{...props}
@@ -32,9 +39,7 @@ export function ContextMenuItem({
 	return (
 		<ContextMenuPrimitive.Item
 			className={cn(
-				"relative flex cursor-default select-none items-center gap-2.5 rounded-md px-2 py-1.5 text-control outline-none transition-colors",
-				"text-muted-foreground focus:bg-surface focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-				"[&_svg]:size-icon-lg [&_svg]:shrink-0 [&_svg]:text-passive",
+				actionMenuItemClass,
 				inset && "pl-8",
 				className,
 			)}
@@ -51,7 +56,7 @@ export function ContextMenuLabel({
 	return (
 		<ContextMenuPrimitive.Label
 			className={cn(
-				"px-2 py-1.5 text-micro tracking-wide text-passive",
+				actionMenuLabelClass,
 				inset && "pl-8",
 				className,
 			)}
@@ -64,5 +69,5 @@ export function ContextMenuSeparator({
 	className,
 	...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
-	return <ContextMenuPrimitive.Separator className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />;
+	return <ContextMenuPrimitive.Separator className={cn(actionMenuSeparatorClass, className)} {...props} />;
 }

--- a/frontend/src/renderer/components/ui/dropdown-menu.tsx
+++ b/frontend/src/renderer/components/ui/dropdown-menu.tsx
@@ -1,5 +1,11 @@
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import { cn } from "../../lib/utils";
+import {
+	actionMenuContentClass,
+	actionMenuItemClass,
+	actionMenuLabelClass,
+	actionMenuSeparatorClass,
+} from "./menu-styles";
 
 export const DropdownMenu = DropdownMenuPrimitive.Root;
 export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
@@ -19,8 +25,7 @@ export function DropdownMenuContent({
 			<DropdownMenuPrimitive.Content
 				sideOffset={sideOffset}
 				className={cn(
-					"z-overlay min-w-[10rem] overflow-hidden rounded-lg border border-border bg-card p-1 text-popover-foreground",
-					"flex flex-col gap-px",
+					actionMenuContentClass,
 					"origin-(--radix-dropdown-menu-content-transform-origin)",
 					"data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out",
 					className,
@@ -39,9 +44,7 @@ export function DropdownMenuItem({
 	return (
 		<DropdownMenuPrimitive.Item
 			className={cn(
-				"relative flex cursor-default select-none items-center gap-2.5 rounded-md px-2 py-1.5 text-control outline-none transition-colors",
-				"text-muted-foreground focus:bg-interactive-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-				"[&_svg]:size-icon-lg [&_svg]:shrink-0 [&_svg]:text-muted-foreground focus:[&_svg]:text-foreground",
+				actionMenuItemClass,
 				inset && "pl-8",
 				className,
 			)}
@@ -58,7 +61,7 @@ export function DropdownMenuLabel({
 	return (
 		<DropdownMenuPrimitive.Label
 			className={cn(
-				"px-2 py-1.5 text-micro tracking-wide text-passive",
+				actionMenuLabelClass,
 				inset && "pl-8",
 				className,
 			)}
@@ -71,7 +74,7 @@ export function DropdownMenuSeparator({
 	className,
 	...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
-	return <DropdownMenuPrimitive.Separator className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />;
+	return <DropdownMenuPrimitive.Separator className={cn(actionMenuSeparatorClass, className)} {...props} />;
 }
 
 export function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {

--- a/frontend/src/renderer/components/ui/menu-styles.ts
+++ b/frontend/src/renderer/components/ui/menu-styles.ts
@@ -1,0 +1,11 @@
+// Shared visual recipe for Radix action menus. Keep context and dropdown menus
+// on this one surface so a menu opened with a right-click cannot drift from the
+// equivalent trigger menu.
+export const actionMenuContentClass =
+	"z-overlay min-w-[10rem] overflow-hidden rounded-lg border border-border bg-card p-1 text-popover-foreground flex flex-col gap-px";
+
+export const actionMenuItemClass =
+	"relative flex cursor-default select-none items-center gap-2.5 rounded-md px-2 py-1.5 text-control outline-none transition-col text-muted-foreground focus:bg-interactive-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:size-icon-lg [&_svg]:shrink-0 [&_svg]:text-muted-foreground focus:[&_svg]:text-foreground";
+
+export const actionMenuLabelClass = "px-2 py-1.5 text-micro tracking-wide text-passive";
+export const actionMenuSeparatorClass = "-mx-1 my-1 h-px bg-border";

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -19,6 +19,12 @@ export type ShellTerminal = {
 	workingDir: string;
 	title: string;
 	createdAt: string;
+	/**
+	 * Exists only in the renderer while the daemon is creating the PTY. It lets
+	 * the tab strip respond to the click immediately without ever attempting to
+	 * attach xterm to a handle that does not exist yet.
+	 */
+	optimistic?: true;
 };
 
 export const shellTerminalsQueryKey = ["shell-terminals"] as const;
@@ -76,6 +82,43 @@ export function useShellTerminals() {
 }
 
 export type OpenShellTerminalInput = { projectId?: string; sessionId?: string; shell?: string };
+type OpenShellTerminalMutationInput = OpenShellTerminalInput & { optimisticShell?: ShellTerminal };
+type OpenShellTerminalCallbacks = { onSuccess?: (shell: ShellTerminal) => void };
+
+function nextShellTerminalTitle(terminals: ShellTerminal[]): string {
+	let maxNumber = 0;
+	for (const terminal of terminals) {
+		if (terminal.title === "Terminal") {
+			maxNumber = Math.max(maxNumber, 1);
+			continue;
+		}
+		const match = /^Terminal (\d+)$/.exec(terminal.title);
+		if (match) maxNumber = Math.max(maxNumber, Number(match[1]));
+	}
+	return `Terminal ${maxNumber + 1}`;
+}
+
+function createOptimisticShellTerminal(
+	{ projectId, sessionId }: OpenShellTerminalInput,
+	terminals: ShellTerminal[],
+): ShellTerminal {
+	const id = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	return {
+		handleId: `pending-shell:${id}`,
+		projectId,
+		sessionId,
+		workingDir: "",
+		title: nextShellTerminalTitle(terminals),
+		createdAt: new Date().toISOString(),
+		optimistic: true,
+	};
+}
+
+function addOptimisticShell(queryClient: ReturnType<typeof useQueryClient>, shell: ShellTerminal) {
+	queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+		current?.some((candidate) => candidate.handleId === shell.handleId) ? current : [...(current ?? []), shell],
+	);
+}
 
 /**
  * Opens a shell in the given project's root (or the daemon data dir when
@@ -84,8 +127,8 @@ export type OpenShellTerminalInput = { projectId?: string; sessionId?: string; s
  */
 export function useOpenShellTerminal() {
 	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: async ({ projectId, sessionId, shell }: OpenShellTerminalInput = {}): Promise<ShellTerminal> => {
+	const mutation = useMutation({
+		mutationFn: async ({ projectId, sessionId, shell, optimisticShell }: OpenShellTerminalMutationInput = {}): Promise<ShellTerminal> => {
 			if (usePreviewData) {
 				previewShellSeq += 1;
 				const shell: ShellTerminal = {
@@ -93,7 +136,7 @@ export function useOpenShellTerminal() {
 					projectId,
 					sessionId,
 					workingDir: `/Users/demo/Projects/${projectId ?? "ao"}`,
-					title: `Terminal ${previewShellSeq}`,
+					title: optimisticShell?.title ?? `Terminal ${previewShellSeq}`,
 					createdAt: new Date().toISOString(),
 				};
 				previewShellTerminals = [...previewShellTerminals, shell];
@@ -111,26 +154,53 @@ export function useOpenShellTerminal() {
 			if (!data) throw new Error("Daemon returned no shell terminal");
 			return toShellTerminal(data.shellTerminal);
 		},
-		onSuccess: (shell) => {
-			// The POST already returned the authoritative terminal. Publish it to the
-			// shared list immediately so its tab can render and receive focus without
-			// waiting for a second daemon round trip. The background refetch still
-			// reconciles concurrent changes from another window.
+		onMutate: (input) => {
+			const optimisticShell =
+				input.optimisticShell ??
+				createOptimisticShellTerminal(input, queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? []);
+			addOptimisticShell(queryClient, optimisticShell);
+			return { optimisticHandleId: optimisticShell.handleId };
+		},
+		onSuccess: (shell, _input, context) => {
+			// Replace, rather than append to, the tab that was visible while the POST
+			// ran. This preserves selection and prevents a duplicate tab flash.
 			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) => {
 				if (current?.some((candidate) => candidate.handleId === shell.handleId)) return current;
-				return [...(current ?? []), shell];
+				const optimisticHandleId = context?.optimisticHandleId;
+				const index = current?.findIndex((candidate) => candidate.handleId === optimisticHandleId) ?? -1;
+				if (index < 0) return [...(current ?? []), shell];
+				return current?.map((candidate, candidateIndex) => (candidateIndex === index ? shell : candidate)) ?? [shell];
 			});
 			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
 		},
-		// Without this, a failed open (worktree gone, no shell resolvable, daemon
-		// busy) leaves the "+" button looking like it silently did nothing.
-		onError: (error) => {
+		onError: (error, _input, context) => {
+			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
+				current?.filter((shell) => shell.handleId !== context?.optimisticHandleId),
+			);
 			console.error("Failed to open shell terminal:", error);
 			if (isWindowsPlatform() && apiErrorCode(error) === "SHELL_TERMINAL_SHELL_UNAVAILABLE") {
 				void useTerminalShellStore.getState().setPreference({ kind: "auto" });
 			}
 		},
+		onSettled: () => {
+			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		},
 	});
+
+	// Session topbars need the pending shell synchronously so they can select
+	// it in the same click event. Other callers can keep using mutation.mutate;
+	// onMutate supplies an optimistic entry for them too.
+	const open = (input: OpenShellTerminalInput = {}, callbacks?: OpenShellTerminalCallbacks) => {
+		const optimisticShell = createOptimisticShellTerminal(
+			input,
+			queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? [],
+		);
+		addOptimisticShell(queryClient, optimisticShell);
+		mutation.mutate({ ...input, optimisticShell }, callbacks);
+		return optimisticShell;
+	};
+
+	return { ...mutation, open };
 }
 
 /** Closes a shell and destroys its PTY. */

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -32,7 +32,7 @@ vi.mock("./useCloudOrg", () => ({
 	useCloudOrg: () => ({ org: cloudState.org, isLoading: false, error: undefined, ready: cloudState.ready }),
 }));
 
-import { useWorkspaceQuery } from "./useWorkspaceQuery";
+import { useWorkspaceQuery, useWorkspaceTraySessions } from "./useWorkspaceQuery";
 
 function wrapper({ children }: { children: ReactNode }) {
 	// The hook pins its own retry policy; retryDelay 0 keeps the error tests fast.
@@ -439,5 +439,30 @@ describe("useWorkspaceQuery", () => {
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
 		expect(listProjectsMock).not.toHaveBeenCalled();
+	});
+
+	it("selects only attention-worthy worker sessions for the always-mounted tray", async () => {
+		respondWith({
+			projects: { data: { projects: [{ id: "proj-1", name: "my-app", path: "/p" }] }, error: undefined },
+			sessions: {
+				data: {
+					sessions: [
+						{ id: "needs-input", projectId: "proj-1", displayName: "Needs input", harness: "codex", status: "needs_input", updatedAt: "2026-08-01T00:00:00Z" },
+						{ id: "mergeable", projectId: "proj-1", displayName: "Mergeable", harness: "codex", status: "mergeable", updatedAt: "2026-08-01T00:00:00Z" },
+						{ id: "working", projectId: "proj-1", displayName: "Working", harness: "codex", status: "working", updatedAt: "2026-08-01T00:00:00Z" },
+						{ id: "merged", projectId: "proj-1", displayName: "Merged", harness: "codex", status: "merged", updatedAt: "2026-08-01T00:00:00Z" },
+						{ id: "orchestrator", projectId: "proj-1", displayName: "Orchestrator", harness: "codex", kind: "orchestrator", status: "needs_input", updatedAt: "2026-08-01T00:00:00Z" },
+					],
+				},
+				error: undefined,
+			},
+		});
+
+		const { result } = renderHook(() => useWorkspaceTraySessions(), { wrapper });
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual([
+			{ projectId: "proj-1", projectName: "my-app", sessionId: "needs-input", title: "Needs input", zone: "action" },
+			{ projectId: "proj-1", projectName: "my-app", sessionId: "mergeable", title: "Mergeable", zone: "merge" },
+		]);
 	});
 });

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -18,6 +18,7 @@ import {
 	toProjectKind,
 	toSessionActivity,
 	toSessionStatus,
+	newestActiveOrchestrator,
 	type WorkspaceSession,
 	type WorkspaceSummary,
 } from "../types/workspace";
@@ -292,4 +293,46 @@ export function useWorkspaceSession(sessionId: string) {
 		return project ? toCloudWorkspaceSession(session, project, org.id) : undefined;
 	}, [cloud.data, cloudSessions.data, org?.id, ready, sessionId]);
 	return { ...local, data: local.data ?? cloudSession };
+}
+
+export type WorkspaceScope = {
+	project?: WorkspaceSummary;
+	session?: WorkspaceSession;
+	orchestrator?: WorkspaceSession;
+};
+
+function selectWorkspaceScope(
+	workspaces: WorkspaceSummary[],
+	projectId: string | undefined,
+	sessionId: string | undefined,
+): WorkspaceScope {
+	const session = sessionId
+		? workspaces.flatMap((workspace) => workspace.sessions).find((candidate) => candidate.id === sessionId)
+		: undefined;
+	const resolvedProjectId = session?.workspaceId ?? projectId;
+	const project = resolvedProjectId ? workspaces.find((workspace) => workspace.id === resolvedProjectId) : undefined;
+	return { project, session, orchestrator: project ? newestActiveOrchestrator(project.sessions) : undefined };
+}
+
+/**
+ * Subscribe shell chrome to just the routed project and session. This avoids
+ * redrawing the topbar for streamed activity from every other project.
+ */
+export function useWorkspaceScope(projectId?: string, sessionId?: string) {
+	const selectLocalScope = useMemo(
+		() => (workspaces: WorkspaceSummary[]) => selectWorkspaceScope(workspaces, projectId, sessionId),
+		[projectId, sessionId],
+	);
+	const local = useQuery({ ...workspaceQueryOptions, select: selectLocalScope });
+	const cloud = useCloudProjectsQuery();
+	const cloudSessions = useCloudSessionsQuery();
+	const { org, ready } = useCloudOrg();
+	const cloudScope = useMemo(() => {
+		if (!ready || !org?.id || !cloud.data) return undefined;
+		const workspaces = cloud.data.map((project) => toCloudWorkspace(project, cloudSessions.data ?? [], org.id));
+		return selectWorkspaceScope(workspaces, projectId, sessionId);
+	}, [cloud.data, cloudSessions.data, org?.id, projectId, ready, sessionId]);
+	// Match useWorkspaceQuery's local-first semantics: do not reveal cloud
+	// records before the local workspace query has resolved successfully.
+	return { ...local, data: local.data ?? (local.isSuccess ? cloudScope : undefined) };
 }

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -296,7 +296,7 @@ export function useWorkspaceSession(sessionId: string) {
 }
 
 export type WorkspaceScope = {
-	project?: WorkspaceSummary;
+	project?: Pick<WorkspaceSummary, "id" | "kind" | "name" | "orchestratorAgent">;
 	session?: WorkspaceSession;
 	orchestrator?: WorkspaceSession;
 };
@@ -310,8 +310,19 @@ function selectWorkspaceScope(
 		? workspaces.flatMap((workspace) => workspace.sessions).find((candidate) => candidate.id === sessionId)
 		: undefined;
 	const resolvedProjectId = session?.workspaceId ?? projectId;
-	const project = resolvedProjectId ? workspaces.find((workspace) => workspace.id === resolvedProjectId) : undefined;
-	return { project, session, orchestrator: project ? newestActiveOrchestrator(project.sessions) : undefined };
+	const workspace = resolvedProjectId ? workspaces.find((candidate) => candidate.id === resolvedProjectId) : undefined;
+	// Do not carry the project's complete sessions array into shell chrome. With
+	// React Query's structural sharing, this small metadata projection retains
+	// its identity when another session in the same project streams an update.
+	const project = workspace
+		? {
+				id: workspace.id,
+				kind: workspace.kind,
+				name: workspace.name,
+				orchestratorAgent: workspace.orchestratorAgent,
+			}
+		: undefined;
+	return { project, session, orchestrator: workspace ? newestActiveOrchestrator(workspace.sessions) : undefined };
 }
 
 /**

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { TraySessionEntry } from "../../shared/tray";
 import { useMemo } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
@@ -19,6 +20,8 @@ import {
 	toSessionActivity,
 	toSessionStatus,
 	newestActiveOrchestrator,
+	attentionZone,
+	workerSessions,
 	type WorkspaceSession,
 	type WorkspaceSummary,
 } from "../types/workspace";
@@ -352,4 +355,43 @@ export function useWorkspaceScope(projectId?: string, sessionId?: string) {
 	// Match useWorkspaceQuery's local-first semantics: do not reveal cloud
 	// records before the local workspace query has resolved successfully.
 	return { ...local, data: local.data ?? (local.isSuccess ? cloudScope : undefined) };
+}
+
+function selectTraySessions(workspaces: WorkspaceSummary[]): TraySessionEntry[] {
+	const entries: TraySessionEntry[] = [];
+	for (const workspace of workspaces) {
+		for (const session of workerSessions(workspace.sessions)) {
+			const zone = attentionZone(session);
+			if ((zone === "merge" && session.status === "merged") || (zone !== "action" && zone !== "merge")) continue;
+			entries.push({
+				projectId: workspace.id,
+				projectName: workspace.name,
+				sessionId: session.id,
+				title: session.title,
+				zone,
+			});
+		}
+	}
+	return entries;
+}
+
+/**
+ * The tray lives for the whole app lifetime, but only attention-worthy worker
+ * sessions affect its native payload. Select that compact projection at the
+ * query boundary so ordinary streamed activity does not wake the runtime.
+ */
+export function useWorkspaceTraySessions() {
+	const local = useQuery({ ...workspaceQueryOptions, select: selectTraySessions });
+	const cloud = useCloudProjectsQuery();
+	const cloudSessions = useCloudSessionsQuery();
+	const { org, ready } = useCloudOrg();
+	const cloudEntries = useMemo(() => {
+		if (!ready || !org?.id || !cloud.data) return [];
+		return selectTraySessions(cloud.data.map((project) => toCloudWorkspace(project, cloudSessions.data ?? [], org.id)));
+	}, [cloud.data, cloudSessions.data, org?.id, ready]);
+	const data = useMemo(() => {
+		if (local.data === undefined) return undefined;
+		return cloudEntries.length === 0 ? local.data : [...local.data, ...cloudEntries];
+	}, [cloudEntries, local.data]);
+	return { ...local, data };
 }

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -268,3 +268,28 @@ export function useWorkspaceQuery() {
 	}, [localData, cloudData, cloudSessionData, orgId, ready]);
 	return { ...local, data };
 }
+
+/**
+ * Subscribe a detail surface to one session instead of the complete workspace
+ * tree. TanStack Query applies structural sharing to the selected value, so an
+ * activity update elsewhere no longer redraws the open session workspace.
+ */
+export function useWorkspaceSession(sessionId: string) {
+	const selectLocalSession = useMemo(
+		() => (workspaces: WorkspaceSummary[]) =>
+			workspaces.flatMap((workspace) => workspace.sessions).find((session) => session.id === sessionId),
+		[sessionId],
+	);
+	const local = useQuery({ ...workspaceQueryOptions, select: selectLocalSession });
+	const cloud = useCloudProjectsQuery();
+	const cloudSessions = useCloudSessionsQuery();
+	const { org, ready } = useCloudOrg();
+	const cloudSession = useMemo(() => {
+		if (!ready || !org?.id || !cloud.data || !cloudSessions.data) return undefined;
+		const session = cloudSessions.data.find((candidate) => candidate.id === sessionId);
+		if (!session) return undefined;
+		const project = cloud.data.find((candidate) => candidate.id === session.projectId);
+		return project ? toCloudWorkspaceSession(session, project, org.id) : undefined;
+	}, [cloud.data, cloudSessions.data, org?.id, ready, sessionId]);
+	return { ...local, data: local.data ?? cloudSession };
+}

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -210,13 +210,18 @@ function toCloudWorkspace(
 	};
 }
 
-export function useCloudProjectsQuery() {
+type WorkspaceSubscriptionOptions = {
+	subscribed?: boolean;
+};
+
+export function useCloudProjectsQuery(options: WorkspaceSubscriptionOptions = {}) {
 	const { client, ready, baseUrl } = useCloudCp();
 	const { org } = useCloudOrg();
 	const orgId = org?.id;
 	return useQuery({
 		queryKey: [...cloudProjectsQueryKey, baseUrl, orgId ?? ""],
 		enabled: ready && orgId !== undefined,
+		subscribed: options.subscribed,
 		retry: 1,
 		queryFn: async (): Promise<CloudCpProject[]> => {
 			if (orgId === undefined) return [];
@@ -228,13 +233,14 @@ export function useCloudProjectsQuery() {
 	});
 }
 
-export function useCloudSessionsQuery() {
+export function useCloudSessionsQuery(options: WorkspaceSubscriptionOptions = {}) {
 	const { client, ready, baseUrl } = useCloudCp();
 	const { org } = useCloudOrg();
 	const orgId = org?.id;
 	return useQuery({
 		queryKey: [...cloudSessionsQueryKey, baseUrl, orgId ?? ""],
 		enabled: ready && orgId !== undefined,
+		subscribed: options.subscribed,
 		retry: 1,
 		// A provisioning sandbox changes state without a client action, so poll to
 		// reflect requested -> running -> ready the same way local sessions stream.
@@ -247,10 +253,10 @@ export function useCloudSessionsQuery() {
 	});
 }
 
-export function useWorkspaceQuery() {
-	const local = useQuery(workspaceQueryOptions);
-	const cloud = useCloudProjectsQuery();
-	const cloudSessions = useCloudSessionsQuery();
+export function useWorkspaceQuery(options: WorkspaceSubscriptionOptions = {}) {
+	const local = useQuery({ ...workspaceQueryOptions, subscribed: options.subscribed });
+	const cloud = useCloudProjectsQuery(options);
+	const cloudSessions = useCloudSessionsQuery(options);
 	const { org, ready } = useCloudOrg();
 	const orgId = org?.id;
 	const localData = local.data;

--- a/frontend/src/renderer/lib/stable-list.test.ts
+++ b/frontend/src/renderer/lib/stable-list.test.ts
@@ -37,6 +37,17 @@ describe("useStableList", () => {
 		expect(result.current[1]).toBe(stable[1]);
 	});
 
+	it("keeps the list reference when a refetch changes no entries", () => {
+		const { result, rerender } = renderHook(
+			({ list }) => useStableList(list, keyOf, sameContent),
+			{ initialProps: { list: [{ id: "a", n: 1 }, { id: "b", n: 2 }] } },
+		);
+		const stable = result.current;
+
+		rerender({ list: [{ id: "a", n: 1 }, { id: "b", n: 2 }] });
+		expect(result.current).toBe(stable);
+	});
+
 	it("adopts the new object for the one entry that changed", () => {
 		const { result, rerender } = renderHook(
 			({ list }) => useStableList(list, keyOf, sameContent),

--- a/frontend/src/renderer/lib/stable-list.ts
+++ b/frontend/src/renderer/lib/stable-list.ts
@@ -26,6 +26,7 @@ export function useStableList<T>(
 	equal: (a: T, b: T) => boolean,
 ): T[] {
 	const seen = useRef(new Map<string, T>());
+	const previousList = useRef<T[] | undefined>(undefined);
 	return useMemo(() => {
 		const next = new Map<string, T>();
 		const stable = list.map((entry) => {
@@ -37,7 +38,17 @@ export function useStableList<T>(
 		// Entries that dropped out of the list are dropped here too, so a long-lived
 		// surface does not accumulate the whole history of everything it has shown.
 		seen.current = next;
-		return stable;
+		// A fresh array invalidates downstream memo dependencies even when each row
+		// retained identity. Reuse the old array for a wholly unchanged list too.
+		const previous = previousList.current;
+		const result =
+			previous &&
+			previous.length === stable.length &&
+			previous.every((entry, index) => entry === stable[index])
+				? previous
+				: stable;
+		previousList.current = result;
+		return result;
 	}, [list, keyOf, equal]);
 }
 

--- a/frontend/src/renderer/main.tsx
+++ b/frontend/src/renderer/main.tsx
@@ -1,5 +1,4 @@
 import "./lib/apply-initial-theme";
-import { scan } from "react-scan";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -18,13 +17,6 @@ import { startUpdateTelemetry } from "./lib/update-telemetry";
 import { appI18n } from "./i18n";
 import { useLocaleStore } from "./stores/locale-store";
 import { useSoundNotificationsStore } from "./stores/sound-notifications-store";
-
-if (import.meta.env.DEV) {
-	scan({
-		enabled: true,
-		showToolbar: true,
-	});
-}
 
 const router = createAppRouter(queryClient);
 

--- a/frontend/src/renderer/main.tsx
+++ b/frontend/src/renderer/main.tsx
@@ -23,7 +23,6 @@ if (import.meta.env.DEV) {
 	scan({
 		enabled: true,
 		showToolbar: true,
-		trackUnnecessaryRenders: true,
 	});
 }
 

--- a/frontend/src/renderer/main.tsx
+++ b/frontend/src/renderer/main.tsx
@@ -1,4 +1,5 @@
 import "./lib/apply-initial-theme";
+import { scan } from "react-scan";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -17,6 +18,14 @@ import { startUpdateTelemetry } from "./lib/update-telemetry";
 import { appI18n } from "./i18n";
 import { useLocaleStore } from "./stores/locale-store";
 import { useSoundNotificationsStore } from "./stores/sound-notifications-store";
+
+if (import.meta.env.DEV) {
+	scan({
+		enabled: true,
+		showToolbar: true,
+		trackUnnecessaryRenders: true,
+	});
+}
 
 const router = createAppRouter(queryClient);
 

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
-import { type CSSProperties, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { FolderPlus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CommandPalette } from "../components/CommandPalette";
@@ -743,10 +743,26 @@ function ShellLayout() {
 			}),
 		[],
 	);
+	const shellContextValue = useMemo(
+		() => ({
+			daemonStatus,
+			workspaceStartupState,
+			cloneProject,
+			createProject,
+			initializeProjectRepository,
+		}),
+		[
+			cloneProject,
+			createProject,
+			daemonStatus,
+			initializeProjectRepository,
+			workspaceStartupState,
+		],
+	);
 
 	return (
 		<ShellProvider
-			value={{ daemonStatus, workspaceStartupState, cloneProject, createProject, initializeProjectRepository }}
+			value={shellContextValue}
 		>
 			<SessionTopbarProvider>
 				<NotificationRuntime />

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -150,6 +150,10 @@ function ShellLayout() {
 	const queryClient = useQueryClient();
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
+	// Global shortcut listeners need the latest workspace list, but recreating
+	// those subscriptions for every streamed activity update is avoidable.
+	const workspacesRef = useRef(workspaces);
+	workspacesRef.current = workspaces;
 	const daemonStatus = useDaemonStatus(queryClient);
 	const [workspaceStartupState, setWorkspaceStartupState] = useState<"loading" | "ready" | "error">("loading");
 	const workspaceStartupBaselineRef = useRef(0);
@@ -351,7 +355,7 @@ function ShellLayout() {
 	const navigateSession = useCallback(
 		(direction: -1 | 1) => {
 			if (!scopedProjectId) return;
-			const sessions = (workspaces.find((workspace) => workspace.id === scopedProjectId)?.sessions ?? []).filter(
+			const sessions = (workspacesRef.current.find((workspace) => workspace.id === scopedProjectId)?.sessions ?? []).filter(
 				sessionIsActive,
 			);
 			if (sessions.length === 0) return;
@@ -369,7 +373,7 @@ function ShellLayout() {
 				params: { projectId: scopedProjectId, sessionId: session.id },
 			});
 		},
-		[navigate, routeParams.sessionId, scopedProjectId, workspaces],
+		[navigate, routeParams.sessionId, scopedProjectId],
 	);
 
 	const updateWorkspaces = useCallback(
@@ -688,7 +692,7 @@ function ShellLayout() {
 				return;
 			}
 			if (matchesRendererShortcut("open-project", event)) {
-				const workspace = workspaces[Number(event.key) - 1];
+				const workspace = workspacesRef.current[Number(event.key) - 1];
 				if (workspace) {
 					event.preventDefault();
 					void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
@@ -697,7 +701,7 @@ function ShellLayout() {
 		};
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [navigate, toggleSidebar, workspaces]);
+	}, [navigate, toggleSidebar]);
 
 	// New session (⌘N / Ctrl+Shift+N) is detected in the main process and
 	// delivered here, so it fires even when focus is inside xterm or a native

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
-import { type CSSProperties, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, type CSSProperties, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { FolderPlus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { CommandPalette } from "../components/CommandPalette";
@@ -90,6 +90,52 @@ const isWindows = isWindowsPlatform();
 const isLinux = isLinuxPlatform();
 const framedAppTopbar = usesFramedAppTopbar();
 const shellTopbarHiddenByPlatform = hidesShellTopbar();
+
+/**
+ * The shell must observe the complete workspace list for the sidebar, but a
+ * streamed update there should not reconcile the active route surface. Keep
+ * the center frame behind a primitive-only memo boundary; SessionView and the
+ * board own their more granular workspace subscriptions.
+ */
+const ShellCenter = memo(function ShellCenter({
+	hideShellTopbar,
+	isSessionRoute,
+	selfFramedCenterPanel,
+}: {
+	hideShellTopbar: boolean;
+	isSessionRoute: boolean;
+	selfFramedCenterPanel: boolean;
+}) {
+	const panelClassName = isSessionRoute ? "center-panel-shell--session" : undefined;
+	if (hideShellTopbar) {
+		return selfFramedCenterPanel ? (
+			<Outlet />
+		) : (
+			<CenterPanelShell className={panelClassName}>
+				<div className="flex min-h-0 flex-1 flex-col">
+					<Outlet />
+				</div>
+			</CenterPanelShell>
+		);
+	}
+	if (framedAppTopbar) {
+		return (
+			<CenterPanelShell className={panelClassName}>
+				{isSessionRoute ? null : <ShellTopbar />}
+				<div className="flex min-h-0 flex-1 flex-col">
+					<Outlet />
+				</div>
+			</CenterPanelShell>
+		);
+	}
+	return (
+		<CenterPanelShell className={panelClassName}>
+			<div className="flex min-h-0 flex-1 flex-col">
+				<Outlet />
+			</div>
+		</CenterPanelShell>
+	);
+});
 
 // Persistent app shell: the Sidebar + shared state survive route changes; only
 // the <Outlet> content (board / session / settings / …) swaps. Lifted out of
@@ -864,33 +910,11 @@ function ShellLayout() {
 					<main className={cn("flex min-w-0 flex-1 flex-col overflow-x-hidden", !sidebarHasLayout && "sidebar-hidden")}>
 						<div className="min-h-0 flex-1 overflow-x-hidden">
 							{/* Board/session routes render inside the same inset box the welcome board and settings paint for themselves, so every screen sits within the app's outer boundary. */}
-							{hideShellTopbar ? (
-								selfFramedCenterPanel ? (
-									<Outlet />
-								) : (
-							// Platform hides shell topbar: full-height panel; session mounts actions in-panel.
-							<CenterPanelShell className={routeParams.sessionId ? "center-panel-shell--session" : undefined}>
-								<div className="flex min-h-0 flex-1 flex-col">
-									<Outlet />
-								</div>
-							</CenterPanelShell>
-						)
-					) : framedAppTopbar ? (
-						<CenterPanelShell className={routeParams.sessionId ? "center-panel-shell--session" : undefined}>
-							{routeParams.sessionId ? null : (
-								<ShellTopbar />
-							)}
-							<div className="flex min-h-0 flex-1 flex-col">
-								<Outlet />
-							</div>
-						</CenterPanelShell>
-					) : (
-						<CenterPanelShell className={routeParams.sessionId ? "center-panel-shell--session" : undefined}>
-							<div className="flex min-h-0 flex-1 flex-col">
-								<Outlet />
-							</div>
-						</CenterPanelShell>
-					)}
+							<ShellCenter
+								hideShellTopbar={hideShellTopbar}
+								isSessionRoute={Boolean(routeParams.sessionId)}
+								selfFramedCenterPanel={selfFramedCenterPanel}
+							/>
 						</div>
 					</main>
 					</div>

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4744,7 +4744,6 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 	padding-inline: var(--space-2_5);
 	padding-block: var(--space-2);
 }
-
 /* Connect Mobile: the pairing QR and the wait before it. The placeholder is a
    real QR carrying decoy data, so it can dissolve into the finished code
    instead of being swapped for it. See PairingQr.tsx. */

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4834,4 +4834,3 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 	.ao-qr-resolved {
 		animation: none;
 	}
-}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4833,3 +4833,4 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 	.ao-qr-resolved {
 		animation: none;
 	}
+}

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -131,6 +131,7 @@ vi.mock("../lib/bridge", () => ({
 
 vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceQuery: () => shellMocks.state.workspaceQuery,
+	useWorkspaceTraySessions: () => ({ data: [] }),
 	workspaceQueryKey: ["workspaces"],
 	workspaceQueryOptions: {},
 }));


### PR DESCRIPTION
## Summary
- isolate renderer subscriptions and sidebar drag updates to avoid broad React work
- remove forced composer suggestion layouts and hover-transition paint churn
- make shell terminal creation and tab switching feel immediate
- unify sidebar context-menu styling with dropdown menus

## Validation
- `npm run typecheck`
- focused renderer tests (149 passing)
- `npm test` is blocked by unrelated landing-site test setup failures (Android download tests and markdown-twin generation)