### PR TITLE
fix(cursor): continue execution after plan approval

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -89,6 +89,7 @@ type conversation struct {
 	sessionID         string
 	capabilities      ports.ChatCapabilities
 	prepared          *preparedTurn
+	continuation      []acpsdk.ContentBlock
 	activeTurn        string
 	settlingTurn      string
 	turnCancel        context.CancelFunc
@@ -407,6 +408,7 @@ func (c *conversation) StartDeferredTurn(providerTurnID string) error {
 	}
 	turn := *c.prepared
 	c.prepared = nil
+	c.continuation = nil
 	c.activeTurn = turn.id
 	c.settlingTurn = ""
 	turnCtx, cancel := context.WithCancel(context.Background())
@@ -435,11 +437,22 @@ func (c *conversation) runTurn(ctx context.Context, sessionID string, turn prepa
 	if messageID == "" {
 		messageID = uuid.NewString()
 	}
-	resp, err := c.conn.Prompt(ctx, acpsdk.PromptRequest{
-		SessionId: acpsdk.SessionId(sessionID),
-		MessageId: &messageID,
-		Prompt:    turn.prompt,
-	})
+	prompt := turn.prompt
+	var resp acpsdk.PromptResponse
+	var err error
+	for {
+		resp, err = c.conn.Prompt(ctx, acpsdk.PromptRequest{
+			SessionId: acpsdk.SessionId(sessionID),
+			MessageId: &messageID,
+			Prompt:    prompt,
+		})
+		continuation := c.takeTurnContinuation(turn.id)
+		if err != nil || resp.StopReason != acpsdk.StopReasonEndTurn || len(continuation) == 0 {
+			break
+		}
+		messageID = uuid.NewString()
+		prompt = continuation
+	}
 
 	c.mu.Lock()
 	c.settlingTurn = turn.id
@@ -499,6 +512,44 @@ func (c *conversation) runTurn(ctx context.Context, sessionID string, turn prepa
 		}
 	}
 	c.mu.Unlock()
+}
+
+// RequestTurnContinuation schedules one provider prompt after the current ACP
+// prompt returns. It remains part of the active AO turn, so provider-specific
+// approval flows can perform an explicit user-approved transition without
+// creating an unattributed or detached durable turn.
+func (c *conversation) RequestTurnContinuation(ctx context.Context, text string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(text) == "" {
+		return errors.New("ACP turn continuation is empty")
+	}
+	prompt, err := c.promptContent(ports.ChatUserMessage{Text: text})
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || c.activeTurn == "" || c.settlingTurn != "" {
+		return ports.ErrChatNoActiveTurn
+	}
+	if len(c.continuation) > 0 {
+		return errors.New("ACP turn continuation is already scheduled")
+	}
+	c.continuation = prompt
+	return nil
+}
+
+func (c *conversation) takeTurnContinuation(turnID string) []acpsdk.ContentBlock {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeTurn != turnID {
+		return nil
+	}
+	prompt := c.continuation
+	c.continuation = nil
+	return prompt
 }
 
 func turnState(reason acpsdk.StopReason) domain.TurnState {

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -32,7 +32,9 @@ type fakeAgent struct {
 	loadCalls           int
 	resumeCalls         int
 	promptParams        acpsdk.PromptRequest
+	promptHistory       []acpsdk.PromptRequest
 	promptNoPermission  bool
+	promptExtension     string
 	elicitation         *acpsdk.UnstableCreateElicitationRequest
 	elicitationResponse acpsdk.UnstableCreateElicitationResponse
 	promptErr           error
@@ -309,7 +311,10 @@ func (a *fakeAgent) SetSessionMode(_ context.Context, params acpsdk.SetSessionMo
 func (a *fakeAgent) Prompt(ctx context.Context, params acpsdk.PromptRequest) (acpsdk.PromptResponse, error) {
 	a.mu.Lock()
 	a.promptParams = params
+	a.promptHistory = append(a.promptHistory, params)
+	promptNumber := len(a.promptHistory)
 	promptNoPermission := a.promptNoPermission
+	promptExtension := a.promptExtension
 	elicitation := a.elicitation
 	promptErr := a.promptErr
 	promptBlock := a.promptBlock
@@ -317,6 +322,11 @@ func (a *fakeAgent) Prompt(ctx context.Context, params acpsdk.PromptRequest) (ac
 	a.mu.Unlock()
 	if promptErr != nil {
 		return acpsdk.PromptResponse{}, promptErr
+	}
+	if promptNumber == 1 && promptExtension != "" {
+		if _, err := a.conn.CallExtension(ctx, promptExtension, map[string]any{}); err != nil {
+			return acpsdk.PromptResponse{}, err
+		}
 	}
 	if promptBlock {
 		if promptStarted != nil {
@@ -365,6 +375,72 @@ func (a *fakeAgent) Prompt(ctx context.Context, params acpsdk.PromptRequest) (ac
 		})
 	}
 	return acpsdk.PromptResponse{StopReason: acpsdk.StopReasonEndTurn}, nil
+}
+
+func TestACPDriverContinuesTheActiveTurnAfterAnExtensionRequest(t *testing.T) {
+	agent := &fakeAgent{promptNoPermission: true, promptExtension: "_test/continue"}
+	driver := New(Config{
+		Harness: domain.HarnessCursor,
+		Probe:   func(context.Context) error { return nil },
+		Launch: func(context.Context, LaunchConfig) (Launch, error) {
+			return Launch{Command: "fake"}, nil
+		},
+		ClientExtension: func(
+			ctx context.Context,
+			bridge ClientExtensionBridge,
+			method string,
+			_ json.RawMessage,
+		) (any, bool, error) {
+			if method != "test/continue" {
+				return nil, false, nil
+			}
+			if err := bridge.RequestTurnContinuation(ctx, "Implement the approved plan now."); err != nil {
+				return nil, true, err
+			}
+			return map[string]any{"outcome": "accepted"}, true, nil
+		},
+		ClientExtensionAliases: map[string]string{"test/continue": "_test/continue"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeSpawn(agent)
+
+	conversation, err := driver.Start(context.Background(), ports.ChatStartConfig{
+		WorkspacePath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conversation.Close()
+	_ = nextEvent(t, conversation.Events()) // controller.ready
+	ref, err := conversation.SendTurn(context.Background(), ports.ChatUserMessage{Text: "Make a plan."})
+	if err != nil {
+		t.Fatalf("SendTurn: %v", err)
+	}
+	if err := conversation.(ports.ChatDeferredTurnStarter).StartDeferredTurn(ref.ProviderTurnID); err != nil {
+		t.Fatalf("StartDeferredTurn: %v", err)
+	}
+	started, completed := 0, 0
+	for completed == 0 {
+		event := nextEvent(t, conversation.Events())
+		switch event.Kind {
+		case ports.ChatEventTurnStarted:
+			started++
+		case ports.ChatEventTurnCompleted:
+			completed++
+			if event.TurnState != domain.TurnStateCompleted {
+				t.Fatalf("turn state = %q", event.TurnState)
+			}
+		}
+	}
+	agent.mu.Lock()
+	history := append([]acpsdk.PromptRequest(nil), agent.promptHistory...)
+	agent.mu.Unlock()
+	if started != 1 || completed != 1 || len(history) != 2 {
+		t.Fatalf("turn events/prompts = started %d, completed %d, prompts %d", started, completed, len(history))
+	}
+	if len(history[1].Prompt) != 1 || history[1].Prompt[0].Text == nil ||
+		history[1].Prompt[0].Text.Text != "Implement the approved plan now." {
+		t.Fatalf("continuation prompt = %#v", history[1].Prompt)
+	}
 }
 
 func TestACPDriverDefersPromptUntilDurableTurnBinding(t *testing.T) {

--- a/backend/internal/adapters/chatdriver/acp/extensions.go
+++ b/backend/internal/adapters/chatdriver/acp/extensions.go
@@ -19,11 +19,15 @@ type ClientApprovalRequest struct {
 	Decisions    []ports.ChatDecisionOption
 }
 
-// ClientExtensionBridge exposes only the durable user-interaction operations a
-// provider extension may need while its JSON-RPC request is blocked.
+// ClientExtensionBridge exposes only the conversation operations a provider
+// extension may need while its JSON-RPC request is blocked. Approval and input
+// remain durable AO interactions; configuration and continuation let an
+// accepted provider workflow resume inside that same durable turn.
 type ClientExtensionBridge interface {
 	RequestInput(context.Context, ports.ChatInputRequest) (ports.ChatInputResponse, error)
 	RequestApproval(context.Context, ClientApprovalRequest) (string, error)
+	RequestTurnContinuation(context.Context, string) error
+	SetConfigOption(context.Context, string, ports.ChatConfigOptionValue) ([]ports.ChatConfigOption, error)
 	UpdatePlan(*domain.ConversationPlan)
 }
 

--- a/backend/internal/adapters/chatdriver/cursoracp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/cursoracp/driver_test.go
@@ -18,11 +18,16 @@ import (
 )
 
 type fakeExtensionBridge struct {
-	input         ports.ChatInputRequest
-	inputResponse ports.ChatInputResponse
-	approval      acpdriver.ClientApprovalRequest
-	selected      string
-	plan          *domain.ConversationPlan
+	input           ports.ChatInputRequest
+	inputResponse   ports.ChatInputResponse
+	approval        acpdriver.ClientApprovalRequest
+	selected        string
+	plan            *domain.ConversationPlan
+	configID        string
+	configValue     ports.ChatConfigOptionValue
+	configErr       error
+	continuation    string
+	continuationErr error
 }
 
 func (f *fakeExtensionBridge) RequestInput(
@@ -42,6 +47,21 @@ func (f *fakeExtensionBridge) RequestApproval(
 }
 
 func (f *fakeExtensionBridge) UpdatePlan(plan *domain.ConversationPlan) { f.plan = plan }
+
+func (f *fakeExtensionBridge) SetConfigOption(
+	_ context.Context,
+	id string,
+	value ports.ChatConfigOptionValue,
+) ([]ports.ChatConfigOption, error) {
+	f.configID = id
+	f.configValue = value
+	return nil, f.configErr
+}
+
+func (f *fakeExtensionBridge) RequestTurnContinuation(_ context.Context, text string) error {
+	f.continuation = text
+	return f.continuationErr
+}
 
 func TestConfigureWritesManagedStandingRuleForStartAndResume(t *testing.T) {
 	dataDir := t.TempDir()
@@ -268,9 +288,84 @@ func TestHandleCreatePlanPublishesPlanAndUsesDurableApprovalFlow(t *testing.T) {
 	if bridge.approval.Summary != "Approve Cursor plan: Repair ACP" || len(bridge.approval.Decisions) != 2 {
 		t.Fatalf("approval request = %#v", bridge.approval)
 	}
+	if bridge.configID != "mode" || bridge.configValue.Select != "agent" {
+		t.Fatalf("accepted plan config = %q %#v, want mode=agent", bridge.configID, bridge.configValue)
+	}
+	if bridge.continuation != "Implement the approved plan now." {
+		t.Fatalf("accepted plan continuation = %q", bridge.continuation)
+	}
 	encoded, _ := json.Marshal(result)
 	if string(encoded) != `{"outcome":{"outcome":"accepted"}}` {
 		t.Fatalf("plan response = %s", encoded)
+	}
+}
+
+func TestHandleCreatePlanDoesNotSwitchModeWhenRejected(t *testing.T) {
+	bridge := &fakeExtensionBridge{selected: "reject"}
+	result, handled, err := handleExtension(
+		context.Background(), bridge, "cursor/create_plan", json.RawMessage(`{"name":"Stop"}`),
+	)
+	if err != nil {
+		t.Fatalf("handleExtension: %v", err)
+	}
+	if !handled {
+		t.Fatal("cursor/create_plan was not handled")
+	}
+	if bridge.configID != "" {
+		t.Fatalf("rejected plan changed config %q", bridge.configID)
+	}
+	if bridge.continuation != "" {
+		t.Fatalf("rejected plan scheduled continuation %q", bridge.continuation)
+	}
+	encoded, _ := json.Marshal(result)
+	if string(encoded) != `{"outcome":{"outcome":"rejected"}}` {
+		t.Fatalf("plan response = %s", encoded)
+	}
+}
+
+func TestHandleCreatePlanDoesNotSwitchModeWhenCancelled(t *testing.T) {
+	bridge := &fakeExtensionBridge{}
+	result, handled, err := handleExtension(
+		context.Background(), bridge, "cursor/create_plan", json.RawMessage(`{"name":"Stop"}`),
+	)
+	if err != nil {
+		t.Fatalf("handleExtension: %v", err)
+	}
+	if !handled {
+		t.Fatal("cursor/create_plan was not handled")
+	}
+	if bridge.configID != "" || bridge.continuation != "" {
+		t.Fatalf("cancelled plan changed config %q or scheduled continuation %q", bridge.configID, bridge.continuation)
+	}
+	encoded, _ := json.Marshal(result)
+	if string(encoded) != `{"outcome":{"outcome":"cancelled"}}` {
+		t.Fatalf("plan response = %s", encoded)
+	}
+}
+
+func TestHandleCreatePlanSurfacesAgentModeSwitchFailure(t *testing.T) {
+	bridge := &fakeExtensionBridge{selected: "accept", configErr: errors.New("mode unavailable")}
+	_, handled, err := handleExtension(
+		context.Background(), bridge, "cursor/create_plan", json.RawMessage(`{"name":"Build"}`),
+	)
+	if !handled {
+		t.Fatal("cursor/create_plan was not handled")
+	}
+	if err == nil || !strings.Contains(err.Error(), "switch Cursor to agent mode after plan approval") {
+		t.Fatalf("handleExtension error = %v", err)
+	}
+}
+
+func TestHandleCreatePlanSurfacesContinuationFailure(t *testing.T) {
+	bridge := &fakeExtensionBridge{selected: "accept", continuationErr: errors.New("turn settled")}
+	_, handled, err := handleExtension(
+		context.Background(), bridge, "cursor/create_plan", json.RawMessage(`{"name":"Build"}`),
+	)
+	if !handled {
+		t.Fatal("cursor/create_plan was not handled")
+	}
+	if err == nil || !strings.Contains(err.Error(), "continue Cursor turn after plan approval") {
+		t.Fatalf("handleExtension error = %v", err)
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/cursoracp/extensions.go
+++ b/backend/internal/adapters/chatdriver/cursoracp/extensions.go
@@ -185,6 +185,12 @@ func handleCreatePlan(
 	}
 	switch selected {
 	case "accept":
+		if _, err := bridge.SetConfigOption(ctx, "mode", ports.ChatConfigOptionValue{Select: "agent"}); err != nil {
+			return nil, fmt.Errorf("switch Cursor to agent mode after plan approval: %w", err)
+		}
+		if err := bridge.RequestTurnContinuation(ctx, "Implement the approved plan now."); err != nil {
+			return nil, fmt.Errorf("continue Cursor turn after plan approval: %w", err)
+		}
 		return map[string]any{"outcome": map[string]any{"outcome": "accepted"}}, nil
 	case "reject":
 		return map[string]any{"outcome": map[string]any{"outcome": "rejected"}}, nil

--- a/backend/internal/adapters/chatdriver/cursoracp/live_test.go
+++ b/backend/internal/adapters/chatdriver/cursoracp/live_test.go
@@ -145,6 +145,96 @@ func TestLiveCursorACPPermissionModes(t *testing.T) {
 	}
 }
 
+// Accepting Cursor's custom create-plan request must resume the same provider
+// turn. Auto-review removes ordinary tool permissions from this scenario so a
+// second approval or timeout identifies plan continuation rather than policy.
+func TestLiveCursorACPPlanAcceptanceContinues(t *testing.T) {
+	if os.Getenv("AO_LIVE_CURSOR_ACP") != "1" {
+		t.Skip("set AO_LIVE_CURSOR_ACP=1 to run against the local Cursor account")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	workspace := t.TempDir()
+	conv, err := New(cursor.New(), nil).Start(ctx, ports.ChatStartConfig{
+		SessionID: "live-cursor-plan-continuation", DataDir: liveDataDir(t),
+		WorkspacePath: workspace, Env: liveEnvMap(), Permissions: ports.PermissionModeAuto,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conv.Close()
+	setCursorPlanMode(ctx, t, conv)
+	ref := sendLiveTurnWithSettings(ctx, t, conv,
+		"Create a plan first. After I approve it, use the file editing tool to create plan-proof.txt containing continued, then say done.",
+		ports.ChatTurnSettings{Approval: ports.PermissionModeAuto})
+	waitForApprovedCursorPlan(ctx, t, conv, ref.ProviderTurnID)
+	content, err := os.ReadFile(filepath.Join(workspace, "plan-proof.txt"))
+	if err != nil || strings.TrimSpace(string(content)) != "continued" {
+		t.Fatalf("plan continuation proof = %q, %v", content, err)
+	}
+}
+
+func setCursorPlanMode(ctx context.Context, t *testing.T, conv ports.ChatConversation) {
+	t.Helper()
+	controller := conv.(ports.ChatConfigOptionController)
+	options, err := controller.ListConfigOptions(ctx)
+	if err != nil {
+		t.Fatalf("ListConfigOptions: %v", err)
+	}
+	for _, option := range options {
+		if option.ID != "mode" {
+			continue
+		}
+		for _, choice := range option.Choices {
+			if choice.Value == "plan" {
+				if _, err := controller.SetConfigOption(ctx, "mode", ports.ChatConfigOptionValue{Select: choice.Value}); err != nil {
+					t.Fatalf("SetConfigOption(mode=plan): %v", err)
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("Cursor did not advertise mode=plan: %#v", options)
+}
+
+func waitForApprovedCursorPlan(
+	ctx context.Context,
+	t *testing.T,
+	conv ports.ChatConversation,
+	turnID string,
+) {
+	t.Helper()
+	approved := false
+	for {
+		select {
+		case event, ok := <-conv.Events():
+			if !ok {
+				t.Fatal("controller closed before plan continuation completed")
+			}
+			if event.ProviderTurnID != "" && event.ProviderTurnID != turnID {
+				continue
+			}
+			switch event.Kind {
+			case ports.ChatEventApprovalRequested:
+				if approved || event.ActivityKind != domain.ActivityKindPlan {
+					t.Fatalf("unexpected approval after accepting Cursor plan: %#v", event)
+				}
+				if err := conv.ResolveRequest(ctx, event.RequestID, ports.ChatDecision{ID: "accept"}); err != nil {
+					t.Fatalf("ResolveRequest(plan): %v", err)
+				}
+				approved = true
+			case ports.ChatEventTurnCompleted:
+				if !approved || event.TurnState != domain.TurnStateCompleted {
+					t.Fatalf("plan turn completed without continuation: approved=%v state=%q", approved, event.TurnState)
+				}
+				return
+			}
+		case <-ctx.Done():
+			t.Fatalf("Cursor did not continue after plan approval: %v", ctx.Err())
+		}
+	}
+}
+
 func assertCursorAdvertisements(ctx context.Context, t *testing.T, conv ports.ChatConversation) {
 	t.Helper()
 	options, err := conv.(ports.ChatConfigOptionController).ListConfigOptions(ctx)

--- a/docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md
+++ b/docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md
@@ -206,7 +206,7 @@ go test -race ./internal/adapters/chatdriver/acp ./internal/adapters/chatdriver/
 
 Observed: focused ACP/Cursor tests passed, and the authenticated live test passed in 41.45 seconds with `plan-proof.txt` created during the same AO turn. The race command remains part of final verification.
 
-- [ ] **Step 5: Commit the minimal fix**
+- [x] **Step 5: Commit the minimal fix**
 
 ```bash
 git add backend/internal/adapters/chatdriver/acp backend/internal/adapters/chatdriver/cursoracp backend/internal/service/chat
@@ -218,7 +218,7 @@ git commit -m "fix: continue cursor work after plan approval"
 **Files:**
 - Modify: `docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md` to mark completed checkboxes and record the observed root cause.
 
-- [ ] **Step 1: Run repository checks**
+- [x] **Step 1: Run repository checks**
 
 ```bash
 npm run lint
@@ -227,7 +227,15 @@ npm run frontend:typecheck
 
 Expected: PASS, except the already-observed environment-dependent Codex protocol conformance mismatch must be reported separately if it recurs.
 
-- [ ] **Step 2: Confirm the branch contains no unrelated changes**
+Observed:
+
+- `npm run frontend:typecheck`: PASS after installing the fresh worktree's frontend and shared product-UI dependencies.
+- pinned `golangci-lint` v2.12.2: PASS with `0 issues`.
+- `npm run lint`: all changed Cursor/ACP packages passed, but the aggregate Go test step reported the pre-existing installed-Codex/schema mismatch plus two environment/load failures. The timing-sensitive CLI test passed immediately on retry; the project telemetry test passed with the machine's global GPG signing config disabled.
+- a CI-like `go test ./...` run with the incompatible local Codex binary hidden passed every package except `session_manager`, where the same reduced PATH also hid `tmux`; that package passed separately with `tmux` restored.
+- final authenticated Cursor live regression: PASS in 28.11 seconds.
+
+- [x] **Step 2: Confirm the branch contains no unrelated changes**
 
 ```bash
 git status --short
@@ -237,6 +245,6 @@ git diff --check origin/main...HEAD
 
 Expected: only the Cursor plan regression, its minimal proven fix, and this plan document; no whitespace errors.
 
-- [ ] **Step 3: Leave the work local**
+- [x] **Step 3: Leave the work local**
 
 Do not push and do not create a pull request. Report the branch name, worktree path, reproduction evidence, root cause, changed files, commits, and exact verification results.

--- a/docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md
+++ b/docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md
@@ -134,7 +134,7 @@ Expected before the fix: FAIL after the plan is accepted, with either a second a
 
 Observed with Cursor Agent `2026.08.25-3e8eec8`: AO received and accepted the plan, Cursor completed the original turn successfully, but `plan-proof.txt` was absent. No second approval occurred. Cursor remained in Plan mode, so accepting `cursor/create_plan` did not perform Cursor's separate Build transition into Agent mode.
 
-- [ ] **Step 5: Commit the isolated reproducer**
+- [x] **Step 5: Commit the isolated reproducer**
 
 ```bash
 git add backend/internal/adapters/chatdriver/cursoracp/live_test.go \
@@ -142,10 +142,12 @@ git add backend/internal/adapters/chatdriver/cursoracp/live_test.go \
 git commit -m "test: reproduce cursor plan continuation stall"
 ```
 
-### Task 2: Switch Cursor to Agent mode when its plan is accepted
+### Task 2: Continue the same AO turn in Cursor Agent mode
 
 **Files:**
 - Modify: `backend/internal/adapters/chatdriver/acp/extensions.go`
+- Modify: `backend/internal/adapters/chatdriver/acp/conversation.go`
+- Modify: `backend/internal/adapters/chatdriver/acp/driver_test.go`
 - Modify: `backend/internal/adapters/chatdriver/cursoracp/extensions.go`
 - Modify: `backend/internal/adapters/chatdriver/cursoracp/driver_test.go`
 
@@ -160,25 +162,28 @@ Use this decision table; do not modify more than the row selected by the trace.
 | Cursor emits an ordinary tool permission | no transport defect | preserve the permission request; improve only test/diagnostic wording because plan consent is not tool consent |
 | Cursor emits nothing until timeout | Cursor provider behavior | do not auto-grant or synthesize a detached turn; retain the regression and document the provider incompatibility with the captured Cursor version |
 
-Selected observation: Cursor emitted a successful turn completion immediately after the accepted plan but performed no implementation. The correction belongs in the Cursor extension adapter: AO must apply the advertised `mode=agent` session option as the Build transition before returning the accepted plan result.
+Selected observation: Cursor emitted a successful turn completion immediately after the accepted plan but performed no implementation. Applying the advertised `mode=agent` session option changed future turns but did not resume the already-running Plan prompt. The correction therefore has two bounded pieces: the Cursor extension adapter performs the explicit Build transition and requests continuation, while the generic ACP loop executes that one queued prompt before completing the same durable AO turn.
 
-- [ ] **Step 2: Write a deterministic failing test at the selected boundary**
+- [x] **Step 2: Write a deterministic failing test at the selected boundary**
 
-Extend `fakeExtensionBridge` with the existing `ChatConfigOptionController.SetConfigOption` signature. Update `TestHandleCreatePlanPublishesPlanAndUsesDurableApprovalFlow` to require `mode=agent`, add a rejected-plan case that requires no mode change, and add a mode-switch failure case that requires the error to surface.
+Extend `fakeExtensionBridge` with config and continuation methods. Update `TestHandleCreatePlanPublishesPlanAndUsesDurableApprovalFlow` to require `mode=agent` plus the continuation instruction, cover rejected/cancelled plans, and require mode/continuation failures to surface. Add a generic ACP transport test that requires two sequential provider prompts but only one AO turn-start/turn-complete pair.
 
 Run the single new test with `-count=1`; expected result is FAIL before implementation.
 
-- [ ] **Step 3: Implement the minimal correction**
+- [x] **Step 3: Implement the minimal correction**
 
-Add `SetConfigOption` to `ClientExtensionBridge`. After `handleCreatePlan` receives `accept`, call:
+Add `SetConfigOption` and `RequestTurnContinuation` to `ClientExtensionBridge`. After `handleCreatePlan` receives `accept`, call:
 
 ```go
 if _, err := bridge.SetConfigOption(ctx, "mode", ports.ChatConfigOptionValue{Select: "agent"}); err != nil {
 	return nil, fmt.Errorf("switch Cursor to agent mode after plan approval: %w", err)
 }
+if err := bridge.RequestTurnContinuation(ctx, "Implement the approved plan now."); err != nil {
+	return nil, fmt.Errorf("continue Cursor turn after plan approval: %w", err)
+}
 ```
 
-Then return the existing accepted response. Rejected and cancelled outcomes must return without changing mode. The implementation must keep these invariants:
+The generic ACP `runTurn` loop consumes a queued continuation only after the current prompt ends successfully, assigns it a fresh provider message ID, and emits no intermediate AO turn completion. Then the Cursor handler returns the existing accepted response. Rejected and cancelled outcomes must return without changing mode or scheduling work. The implementation must keep these invariants:
 
 ```text
 plan approval accepts only cursor/create_plan
@@ -187,7 +192,7 @@ rejected and cancelled plans never continue
 the existing provider turn remains the durable owner of all continuation events
 ```
 
-- [ ] **Step 4: Verify the deterministic and live regressions**
+- [x] **Step 4: Verify the deterministic and live regressions**
 
 Run:
 
@@ -199,7 +204,7 @@ AO_LIVE_CURSOR_ACP=1 go test ./internal/adapters/chatdriver/cursoracp \
 go test -race ./internal/adapters/chatdriver/acp ./internal/adapters/chatdriver/cursoracp
 ```
 
-Expected: all commands PASS. If the provider itself emits nothing, the live test remains an evidence-backed skipped/known-incompatibility test rather than adding speculative automatic steering.
+Observed: focused ACP/Cursor tests passed, and the authenticated live test passed in 41.45 seconds with `plan-proof.txt` created during the same AO turn. The race command remains part of final verification.
 
 - [ ] **Step 5: Commit the minimal fix**
 

--- a/docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md
+++ b/docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md
@@ -1,0 +1,237 @@
+# Cursor Plan Continuation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reproduce and fix Cursor ACP sessions that remain idle after AO accepts a generated plan, without weakening AO's permission boundaries.
+
+**Architecture:** Exercise the real Cursor ACP adapter in provider Plan mode while launching Cursor with AO's existing auto-review permission mode. The test accepts only the custom `cursor/create_plan` approval and then requires the same provider turn to create a proof file, which separates plan continuation from ordinary tool approval behavior. Use the resulting ACP event sequence to make the smallest Cursor-specific adapter correction, leaving the generic ACP transport and durable approval controller unchanged unless the trace proves they are responsible.
+
+**Tech Stack:** Go, Cursor Agent ACP, `coder/acp-go-sdk`, AO chat-driver ports, Go tests.
+
+---
+
+### Task 1: Add the account-backed plan continuation regression
+
+**Files:**
+- Modify: `backend/internal/adapters/chatdriver/cursoracp/live_test.go`
+
+- [x] **Step 1: Add a live test that selects Cursor Plan mode**
+
+Add `TestLiveCursorACPPlanAcceptanceContinues` beside the permission-mode matrix. Start the conversation with `PermissionModeAuto`, find the advertised `mode` option, require a `plan` choice, and select it through `ChatConfigOptionController.SetConfigOption`.
+
+```go
+func TestLiveCursorACPPlanAcceptanceContinues(t *testing.T) {
+	if os.Getenv("AO_LIVE_CURSOR_ACP") != "1" {
+		t.Skip("set AO_LIVE_CURSOR_ACP=1 to run against the local Cursor account")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	workspace := t.TempDir()
+	conv, err := New(cursor.New(), nil).Start(ctx, ports.ChatStartConfig{
+		SessionID: "live-cursor-plan-continuation", DataDir: liveDataDir(t),
+		WorkspacePath: workspace, Env: liveEnvMap(), Permissions: ports.PermissionModeAuto,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer conv.Close()
+	setCursorPlanMode(ctx, t, conv)
+	ref := sendLiveTurnWithSettings(ctx, t, conv,
+		"Create a plan first. After I approve it, use the file editing tool to create plan-proof.txt containing continued, then say done.",
+		ports.ChatTurnSettings{Approval: ports.PermissionModeAuto})
+	waitForApprovedCursorPlan(ctx, t, conv, ref.ProviderTurnID)
+	content, err := os.ReadFile(filepath.Join(workspace, "plan-proof.txt"))
+	if err != nil || strings.TrimSpace(string(content)) != "continued" {
+		t.Fatalf("plan continuation proof = %q, %v", content, err)
+	}
+}
+```
+
+- [x] **Step 2: Add focused helpers that reject a second approval**
+
+Add `setCursorPlanMode` and `waitForApprovedCursorPlan`. The waiter must resolve only an `ActivityKindPlan` approval, fail on any later approval, and require the original turn to complete successfully.
+
+```go
+func setCursorPlanMode(ctx context.Context, t *testing.T, conv ports.ChatConversation) {
+	t.Helper()
+	controller := conv.(ports.ChatConfigOptionController)
+	options, err := controller.ListConfigOptions(ctx)
+	if err != nil {
+		t.Fatalf("ListConfigOptions: %v", err)
+	}
+	for _, option := range options {
+		if option.ID != "mode" {
+			continue
+		}
+		for _, choice := range option.Choices {
+			if choice.Value == "plan" {
+				if _, err := controller.SetConfigOption(ctx, "mode", ports.ChatConfigOptionValue{Select: choice.Value}); err != nil {
+					t.Fatalf("SetConfigOption(mode=plan): %v", err)
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("Cursor did not advertise mode=plan: %#v", options)
+}
+
+func waitForApprovedCursorPlan(ctx context.Context, t *testing.T, conv ports.ChatConversation, turnID string) {
+	t.Helper()
+	approved := false
+	for {
+		select {
+		case event, ok := <-conv.Events():
+			if !ok {
+				t.Fatal("controller closed before plan continuation completed")
+			}
+			if event.ProviderTurnID != "" && event.ProviderTurnID != turnID {
+				continue
+			}
+			switch event.Kind {
+			case ports.ChatEventApprovalRequested:
+				if approved || event.ActivityKind != domain.ActivityKindPlan {
+					t.Fatalf("unexpected approval after accepting Cursor plan: %#v", event)
+				}
+				if err := conv.ResolveRequest(ctx, event.RequestID, ports.ChatDecision{ID: "accept"}); err != nil {
+					t.Fatalf("ResolveRequest(plan): %v", err)
+				}
+				approved = true
+			case ports.ChatEventTurnCompleted:
+				if !approved || event.TurnState != domain.TurnStateCompleted {
+					t.Fatalf("plan turn completed without continuation: approved=%v state=%q", approved, event.TurnState)
+				}
+				return
+			}
+		case <-ctx.Done():
+			t.Fatalf("Cursor did not continue after plan approval: %v", ctx.Err())
+		}
+	}
+}
+```
+
+- [x] **Step 3: Verify ordinary tests remain hermetic**
+
+Run:
+
+```bash
+cd backend
+go test ./internal/adapters/chatdriver/cursoracp -count=1
+```
+
+Expected: PASS with the new test skipped unless `AO_LIVE_CURSOR_ACP=1` is set.
+
+- [x] **Step 4: Run the live regression against the authenticated issue-era Cursor CLI**
+
+Run:
+
+```bash
+cd backend
+AO_LIVE_CURSOR_ACP=1 go test ./internal/adapters/chatdriver/cursoracp \
+  -run TestLiveCursorACPPlanAcceptanceContinues -count=1 -v -timeout 6m
+```
+
+Expected before the fix: FAIL after the plan is accepted, with either a second approval, an incomplete turn, or a timeout. Preserve the exact observed event sequence in the implementation notes.
+
+Observed with Cursor Agent `2026.08.25-3e8eec8`: AO received and accepted the plan, Cursor completed the original turn successfully, but `plan-proof.txt` was absent. No second approval occurred. Cursor remained in Plan mode, so accepting `cursor/create_plan` did not perform Cursor's separate Build transition into Agent mode.
+
+- [ ] **Step 5: Commit the isolated reproducer**
+
+```bash
+git add backend/internal/adapters/chatdriver/cursoracp/live_test.go \
+  docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md
+git commit -m "test: reproduce cursor plan continuation stall"
+```
+
+### Task 2: Switch Cursor to Agent mode when its plan is accepted
+
+**Files:**
+- Modify: `backend/internal/adapters/chatdriver/acp/extensions.go`
+- Modify: `backend/internal/adapters/chatdriver/cursoracp/extensions.go`
+- Modify: `backend/internal/adapters/chatdriver/cursoracp/driver_test.go`
+
+- [x] **Step 1: Classify the live failure from observable evidence**
+
+Use this decision table; do not modify more than the row selected by the trace.
+
+| Observation after `accepted` | Boundary | Required correction |
+| --- | --- | --- |
+| Cursor emits tool/message events but AO still reports pending | generic ACP conversation state | clear only the resolved extension request and retain the active provider turn |
+| Cursor immediately emits another plan approval | Cursor extension adapter | de-duplicate the same provider plan tool call while preserving new plan revisions |
+| Cursor emits an ordinary tool permission | no transport defect | preserve the permission request; improve only test/diagnostic wording because plan consent is not tool consent |
+| Cursor emits nothing until timeout | Cursor provider behavior | do not auto-grant or synthesize a detached turn; retain the regression and document the provider incompatibility with the captured Cursor version |
+
+Selected observation: Cursor emitted a successful turn completion immediately after the accepted plan but performed no implementation. The correction belongs in the Cursor extension adapter: AO must apply the advertised `mode=agent` session option as the Build transition before returning the accepted plan result.
+
+- [ ] **Step 2: Write a deterministic failing test at the selected boundary**
+
+Extend `fakeExtensionBridge` with the existing `ChatConfigOptionController.SetConfigOption` signature. Update `TestHandleCreatePlanPublishesPlanAndUsesDurableApprovalFlow` to require `mode=agent`, add a rejected-plan case that requires no mode change, and add a mode-switch failure case that requires the error to surface.
+
+Run the single new test with `-count=1`; expected result is FAIL before implementation.
+
+- [ ] **Step 3: Implement the minimal correction**
+
+Add `SetConfigOption` to `ClientExtensionBridge`. After `handleCreatePlan` receives `accept`, call:
+
+```go
+if _, err := bridge.SetConfigOption(ctx, "mode", ports.ChatConfigOptionValue{Select: "agent"}); err != nil {
+	return nil, fmt.Errorf("switch Cursor to agent mode after plan approval: %w", err)
+}
+```
+
+Then return the existing accepted response. Rejected and cancelled outcomes must return without changing mode. The implementation must keep these invariants:
+
+```text
+plan approval accepts only cursor/create_plan
+tool permissions still require their configured AO policy
+rejected and cancelled plans never continue
+the existing provider turn remains the durable owner of all continuation events
+```
+
+- [ ] **Step 4: Verify the deterministic and live regressions**
+
+Run:
+
+```bash
+cd backend
+go test ./internal/adapters/chatdriver/acp ./internal/adapters/chatdriver/cursoracp -count=1
+AO_LIVE_CURSOR_ACP=1 go test ./internal/adapters/chatdriver/cursoracp \
+  -run TestLiveCursorACPPlanAcceptanceContinues -count=1 -v -timeout 6m
+go test -race ./internal/adapters/chatdriver/acp ./internal/adapters/chatdriver/cursoracp
+```
+
+Expected: all commands PASS. If the provider itself emits nothing, the live test remains an evidence-backed skipped/known-incompatibility test rather than adding speculative automatic steering.
+
+- [ ] **Step 5: Commit the minimal fix**
+
+```bash
+git add backend/internal/adapters/chatdriver/acp backend/internal/adapters/chatdriver/cursoracp backend/internal/service/chat
+git commit -m "fix: continue cursor work after plan approval"
+```
+
+### Task 3: Repository verification and local handoff
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-31-cursor-plan-continuation.md` to mark completed checkboxes and record the observed root cause.
+
+- [ ] **Step 1: Run repository checks**
+
+```bash
+npm run lint
+npm run frontend:typecheck
+```
+
+Expected: PASS, except the already-observed environment-dependent Codex protocol conformance mismatch must be reported separately if it recurs.
+
+- [ ] **Step 2: Confirm the branch contains no unrelated changes**
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: only the Cursor plan regression, its minimal proven fix, and this plan document; no whitespace errors.
+
+- [ ] **Step 3: Leave the work local**
+
+Do not push and do not create a pull request. Report the branch name, worktree path, reproduction evidence, root cause, changed files, commits, and exact verification results.


### PR DESCRIPTION
## What & why

Cursor stopped after a user approved a plan because AO returned the approval but left Cursor in plan mode without starting an implementation prompt. This keeps the approved workflow inside the same durable AO turn, switches Cursor to agent mode, and explicitly continues execution.

Closes #4648.

## Changes

- Add an ACP turn-continuation bridge that can issue a follow-up provider prompt while preserving one AO turn lifecycle.
- On accepted Cursor plans, switch the provider mode to `agent` and request implementation; rejected and cancelled plans remain unchanged.
- Cover continuation lifecycle, accepted/rejected/cancelled decisions, and failure propagation with unit tests.
- Add an opt-in authenticated Cursor regression test and record the reproduction/verification plan.

## How to test

1. Run the focused race tests:
   ```bash
   cd backend
   go test -count=1 -race ./internal/adapters/chatdriver/acp ./internal/adapters/chatdriver/cursoracp
   ```
2. With a locally authenticated Cursor account, run:
   ```bash
   AO_LIVE_CURSOR_ACP=1 go test -count=1 -run '^TestLiveCursorACPPlanAcceptanceContinues$' -v ./internal/adapters/chatdriver/cursoracp
   ```
3. Start an AO Cursor chat task, select Plan mode, request a file change, and approve the generated plan.
4. Confirm Cursor switches to Agent mode and performs the change without requiring another message.

## Risks & notes

- The continuation primitive is implemented at the shared ACP layer, but this PR invokes it only from Cursor's accepted-plan extension path.
- No API, storage, migration, or frontend contract changes.
- Local `npm run lint` reached one unrelated environment-dependent failure: the installed Codex provider lacks five methods declared by the generated protocol. The standalone golangci-lint run reports `0 issues`, all focused race tests pass, and the authenticated Cursor regression passes.
