### PR TITLE
feat(frontend): unify session tab ordering

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -927,7 +927,36 @@ describe("CenterPane toolbar session label", () => {
 		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-0", "Reviewer", "agent-orchestrator-1"]);
 	});
 
-	it("drops a session's remembered terminal order after navigating away", () => {
+	it("appends new terminals after open files and reorders terminals with files", () => {
+		Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+			configurable: true,
+			value: vi.fn(),
+		});
+		const shells = makeShells(2);
+		const fileTab = {
+			key: "file:.gitignore",
+			content: <button role="tab">.gitignore</button>,
+			onSelect: vi.fn(),
+		};
+		const view = renderCenterPane({ session: worker, shellTerminals: [shells[0]], workspaceTabs: [fileTab] });
+		const tabLabels = () =>
+			Array.from(screen.getByRole("tablist", { name: "Open terminals" }).querySelectorAll('[role="tab"]')).map(
+				(tab) => tab.textContent,
+			);
+
+		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-0", ".gitignore"]);
+		view.rerender(
+			<TooltipProvider>
+				<CenterPane daemonReady session={worker} shellTerminals={shells} theme="dark" workspaceTabs={[fileTab]} />
+			</TooltipProvider>,
+		);
+		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-0", ".gitignore", "agent-orchestrator-1"]);
+
+		act(() => reorderMocks.onReorder?.(["file:.gitignore", "h-1", "h-0"]));
+		expect(tabLabels()).toEqual(["do the thing", ".gitignore", "agent-orchestrator-1", "agent-orchestrator-0"]);
+	});
+
+	it("restores a session's remembered tab order after navigating away", () => {
 		const shells = makeShells(2);
 		const view = renderCenterPane({ session: worker, shellTerminals: shells });
 		const tabLabels = () =>
@@ -949,7 +978,7 @@ describe("CenterPane toolbar session label", () => {
 			</TooltipProvider>,
 		);
 
-		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-0", "agent-orchestrator-1"]);
+		expect(tabLabels()).toEqual(["do the thing", "agent-orchestrator-1", "agent-orchestrator-0"]);
 	});
 
 	it("scrolls the tab strip horizontally with the mouse wheel", () => {

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -74,6 +74,9 @@ type CenterPaneProps = {
 	workspaceTabs?: CenterPaneWorkspaceTab[];
 	workspaceTabActions?: ReactNode;
 	workspaceActiveTabKey?: string;
+	/** Session-owned order shared with the Chat surface. */
+	auxiliaryTabOrder?: string[];
+	onAuxiliaryTabOrderChange?: (keys: string[]) => void;
 	/** Stop forwarding the agent pane's keystrokes while its controller drains. */
 	agentInputDisabled?: boolean;
 };
@@ -149,6 +152,8 @@ export function CenterPane({
 	workspaceTabs,
 	workspaceTabActions,
 	workspaceActiveTabKey,
+	auxiliaryTabOrder,
+	onAuxiliaryTabOrderChange,
 	agentInputDisabled = false,
 }: CenterPaneProps) {
 	const { t } = useTranslation();
@@ -179,7 +184,7 @@ export function CenterPane({
 	);
 	const availableAuxiliaryKeys = useMemo(() => auxiliaryTabs.map((tab) => tab.key), [auxiliaryTabs]);
 	const orderedAuxiliaryTabs = useMemo(() => {
-		const preferred = sessionId ? (tabOrderBySession[sessionId] ?? []) : [];
+		const preferred = auxiliaryTabOrder ?? (sessionId ? (tabOrderBySession[sessionId] ?? []) : []);
 		const byKey = new Map(auxiliaryTabs.map((tab) => [tab.key, tab]));
 		const ordered = preferred.flatMap((key) => {
 			const tab = byKey.get(key);
@@ -188,7 +193,7 @@ export function CenterPane({
 			return [tab];
 		});
 		return [...ordered, ...byKey.values()];
-	}, [auxiliaryTabs, sessionId, tabOrderBySession]);
+	}, [auxiliaryTabOrder, auxiliaryTabs, sessionId, tabOrderBySession]);
 	const tabOverflowWatch = `${sessionId ?? ""}|${availableAuxiliaryKeys.join("|")}`;
 	const {
 		scrollRef: tabsOverflowRef,
@@ -314,9 +319,10 @@ export function CenterPane({
 			for (const key of availableAuxiliaryKeys) {
 				if (!next.includes(key)) next.push(key);
 			}
-			setTabOrderBySession((current) => ({ ...current, [sessionId]: next }));
+			if (onAuxiliaryTabOrderChange) onAuxiliaryTabOrderChange(next);
+			else setTabOrderBySession((current) => ({ ...current, [sessionId]: next }));
 		},
-		[availableAuxiliaryKeys, sessionId],
+		[availableAuxiliaryKeys, onAuxiliaryTabOrderChange, sessionId],
 	);
 	const selectAdjacentTab = useCallback(
 		(direction: -1 | 1) => {
@@ -350,6 +356,17 @@ export function CenterPane({
 
 	useEffect(() => {
 		if (!sessionId) return;
+		if (auxiliaryTabOrder) {
+			const available = new Set(availableAuxiliaryKeys);
+			const keys = auxiliaryTabOrder.filter((key) => available.has(key));
+			for (const key of availableAuxiliaryKeys) {
+				if (!keys.includes(key)) keys.push(key);
+			}
+			if (!keys.every((key, index) => key === auxiliaryTabOrder[index]) || keys.length !== auxiliaryTabOrder.length) {
+				onAuxiliaryTabOrderChange?.(keys);
+			}
+			return;
+		}
 		setTabOrderBySession((current) => {
 			const currentOrder = current[sessionId] ?? [];
 			const available = new Set(availableAuxiliaryKeys);
@@ -364,7 +381,7 @@ export function CenterPane({
 			}
 			return { ...current, [sessionId]: keys };
 		});
-	}, [availableAuxiliaryKeys, sessionId]);
+	}, [auxiliaryTabOrder, availableAuxiliaryKeys, onAuxiliaryTabOrderChange, sessionId]);
 
 	useEffect(() => {
 		if (!switchMutation.isPending || currentAgentSwitch) return;

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -71,17 +71,23 @@ type CenterPaneProps = {
 	/** Pinned beside the tab strip, before the workspace topbar actions. */
 	tabStripAction?: ReactNode;
 	handoffDialogOpen?: boolean;
-	workspaceTabs?: ReactNode;
-	workspaceFileActive?: boolean;
+	workspaceTabs?: CenterPaneWorkspaceTab[];
+	workspaceTabActions?: ReactNode;
+	workspaceActiveTabKey?: string;
 	/** Stop forwarding the agent pane's keystrokes while its controller drains. */
 	agentInputDisabled?: boolean;
 };
 
-type AuxiliaryTerminal =
-	| { key: string; kind: "reviewer"; terminal: NonNullable<CenterPaneProps["reviewerTerminal"]> }
-	| { key: string; kind: "shell"; terminal: ShellTerminal };
+export type CenterPaneWorkspaceTab = {
+	key: string;
+	content: ReactNode;
+	onSelect: () => void;
+};
 
-type TerminalOrder = { sessionId: string; keys: string[] };
+type AuxiliaryTab =
+	| { key: string; kind: "reviewer"; terminal: NonNullable<CenterPaneProps["reviewerTerminal"]> }
+	| { key: string; kind: "shell"; terminal: ShellTerminal }
+	| { key: string; kind: "workspace"; tab: CenterPaneWorkspaceTab };
 
 const terminalFontSizeStorageKey = "ao.terminal.fontSize";
 const WHEEL_ZOOM_THRESHOLD = 80;
@@ -89,7 +95,7 @@ const WHEEL_ZOOM_RESET_MS = 250;
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
 
-function DraggableTerminalTab({ children, value }: { children: ReactNode; value: string }) {
+function DraggableWorkspaceTab({ children, value }: { children: ReactNode; value: string }) {
 	const dragControls = useDragControls();
 	const startDrag = (event: PointerEvent<HTMLDivElement>) => {
 		if ((event.target as HTMLElement).closest("[data-terminal-tab-action],input,a")) return;
@@ -141,7 +147,8 @@ export function CenterPane({
 	tabStripAction,
 	handoffDialogOpen = false,
 	workspaceTabs,
-	workspaceFileActive = false,
+	workspaceTabActions,
+	workspaceActiveTabKey,
 	agentInputDisabled = false,
 }: CenterPaneProps) {
 	const { t } = useTranslation();
@@ -151,10 +158,10 @@ export function CenterPane({
 	const [fontSize, setFontSize] = useState(initialTerminalFontSize);
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const [terminalBounds, setTerminalBounds] = useState({ leftInset: 0, rightInset: 0, width: 0 });
-	const [terminalOrder, setTerminalOrder] = useState<TerminalOrder | null>(null);
+	const [tabOrderBySession, setTabOrderBySession] = useState<Record<string, string[]>>({});
 	const isSidebarOpen = useUiStore(sidebarOccupiesLayout);
 	const sessionId = session?.id;
-	const auxiliaryTerminals = useMemo<AuxiliaryTerminal[]>(
+	const auxiliaryTabs = useMemo<AuxiliaryTab[]>(
 		() => [
 			...(reviewerTerminal
 				? [
@@ -166,21 +173,22 @@ export function CenterPane({
 					]
 				: []),
 			...shellTerminals.map((terminal) => ({ key: terminal.handleId, kind: "shell" as const, terminal })),
+			...(workspaceTabs ?? []).map((tab) => ({ key: tab.key, kind: "workspace" as const, tab })),
 		],
-		[reviewerTerminal, shellTerminals],
+		[reviewerTerminal, shellTerminals, workspaceTabs],
 	);
-	const availableAuxiliaryKeys = useMemo(() => auxiliaryTerminals.map((terminal) => terminal.key), [auxiliaryTerminals]);
-	const orderedAuxiliaryTerminals = useMemo(() => {
-		const preferred = terminalOrder && terminalOrder.sessionId === sessionId ? terminalOrder.keys : [];
-		const byKey = new Map(auxiliaryTerminals.map((terminal) => [terminal.key, terminal]));
+	const availableAuxiliaryKeys = useMemo(() => auxiliaryTabs.map((tab) => tab.key), [auxiliaryTabs]);
+	const orderedAuxiliaryTabs = useMemo(() => {
+		const preferred = sessionId ? (tabOrderBySession[sessionId] ?? []) : [];
+		const byKey = new Map(auxiliaryTabs.map((tab) => [tab.key, tab]));
 		const ordered = preferred.flatMap((key) => {
-			const terminal = byKey.get(key);
-			if (!terminal) return [];
+			const tab = byKey.get(key);
+			if (!tab) return [];
 			byKey.delete(key);
-			return [terminal];
+			return [tab];
 		});
 		return [...ordered, ...byKey.values()];
-	}, [auxiliaryTerminals, sessionId, terminalOrder]);
+	}, [auxiliaryTabs, sessionId, tabOrderBySession]);
 	const tabOverflowWatch = `${sessionId ?? ""}|${availableAuxiliaryKeys.join("|")}`;
 	const {
 		scrollRef: tabsOverflowRef,
@@ -188,7 +196,7 @@ export function CenterPane({
 		showLeftFade,
 		showRightFade,
 	} = useTabScrollEdges([tabOverflowWatch]);
-	const previousShellCountRef = useRef(shellTerminals.length);
+	const previousTabCountRef = useRef(availableAuxiliaryKeys.length);
 	const agentSwitchesQuery = useAgentSwitches(session?.id ?? "");
 	const agentSwitches = agentSwitchesQuery.data ?? [];
 	const switchMutation = useSwitchAgentState(session?.id ?? "");
@@ -298,7 +306,7 @@ export function CenterPane({
 			: target.kind === "reviewer"
 				? `${t("terminal.reviewer")} · ${target.harness}`
 				: (session?.title ?? sessionTabLabel);
-	const reorderAuxiliaryTerminals = useCallback(
+	const reorderAuxiliaryTabs = useCallback(
 		(nextKeys: string[]) => {
 			if (!sessionId) return;
 			const available = new Set(availableAuxiliaryKeys);
@@ -306,46 +314,55 @@ export function CenterPane({
 			for (const key of availableAuxiliaryKeys) {
 				if (!next.includes(key)) next.push(key);
 			}
-			setTerminalOrder({ keys: next, sessionId });
+			setTabOrderBySession((current) => ({ ...current, [sessionId]: next }));
 		},
 		[availableAuxiliaryKeys, sessionId],
 	);
 	const selectAdjacentTab = useCallback(
 		(direction: -1 | 1) => {
 			const activeKey =
-				target.kind === "shell"
+				workspaceActiveTabKey ?? (target.kind === "shell"
 					? target.handleId
 					: target.kind === "reviewer"
 						? `reviewer:${target.handleId}`
-						: "worker";
-			const tabKeys = ["worker", ...orderedAuxiliaryTerminals.map((terminal) => terminal.key)];
+						: "worker");
+			const tabKeys = ["worker", ...orderedAuxiliaryTabs.map((tab) => tab.key)];
 			const activeIndex = Math.max(0, tabKeys.indexOf(activeKey));
 			const nextIndex = (activeIndex + direction + tabKeys.length) % tabKeys.length;
 			if (nextIndex === 0) {
 				onSelectSessionTerminal?.();
 				return;
 			}
-			const nextTerminal = orderedAuxiliaryTerminals[nextIndex - 1];
-			if (nextTerminal?.kind === "reviewer") onSelectReviewerTerminal?.(nextTerminal.terminal);
-			if (nextTerminal?.kind === "shell") onSelectShellTerminal?.(nextTerminal.terminal.handleId);
+			const nextTab = orderedAuxiliaryTabs[nextIndex - 1];
+			if (nextTab?.kind === "reviewer") onSelectReviewerTerminal?.(nextTab.terminal);
+			if (nextTab?.kind === "shell") onSelectShellTerminal?.(nextTab.terminal.handleId);
+			if (nextTab?.kind === "workspace") nextTab.tab.onSelect();
 		},
 		[
 			onSelectReviewerTerminal,
 			onSelectSessionTerminal,
 			onSelectShellTerminal,
-			orderedAuxiliaryTerminals,
+			orderedAuxiliaryTabs,
 			target,
+			workspaceActiveTabKey,
 		],
 	);
 
 	useEffect(() => {
-		setTerminalOrder((current) => {
-			if (!current) return current;
-			if (!sessionId || current.sessionId !== sessionId) return null;
+		if (!sessionId) return;
+		setTabOrderBySession((current) => {
+			const currentOrder = current[sessionId] ?? [];
 			const available = new Set(availableAuxiliaryKeys);
-			const keys = current.keys.filter((key) => available.has(key));
-			if (keys.length === current.keys.length) return current;
-			return keys.length > 0 ? { ...current, keys } : null;
+			const keys = currentOrder.filter((key) => available.has(key));
+			for (const key of availableAuxiliaryKeys) {
+				if (!keys.includes(key)) keys.push(key);
+			}
+			if (keys.length === currentOrder.length && keys.every((key, index) => key === currentOrder[index])) return current;
+			if (keys.length === 0) {
+				const { [sessionId]: _removed, ...rest } = current;
+				return rest;
+			}
+			return { ...current, [sessionId]: keys };
 		});
 	}, [availableAuxiliaryKeys, sessionId]);
 
@@ -438,17 +455,17 @@ export function CenterPane({
 	}, [isFullscreen, tabOverflowWatch]);
 
 	useEffect(() => {
-		if (shellTerminals.length > previousShellCountRef.current) scrollTabsToEnd();
-		previousShellCountRef.current = shellTerminals.length;
-	}, [scrollTabsToEnd, shellTerminals.length]);
+		if (availableAuxiliaryKeys.length > previousTabCountRef.current) scrollTabsToEnd();
+		previousTabCountRef.current = availableAuxiliaryKeys.length;
+	}, [availableAuxiliaryKeys.length, scrollTabsToEnd]);
 
 	useEffect(() => {
 		const activeKey =
-			target.kind === "shell"
+			workspaceActiveTabKey ?? (target.kind === "shell"
 				? target.handleId
 				: target.kind === "reviewer"
 					? `reviewer:${target.handleId}`
-					: undefined;
+					: undefined);
 		if (!activeKey) return;
 		const scrollRegion = tabsOverflowRef.current;
 		if (!scrollRegion) return;
@@ -463,7 +480,7 @@ export function CenterPane({
 		if (tabRect.right > scrollRect.right) nextScrollLeft += tabRect.right - scrollRect.right;
 		if (nextScrollLeft === scrollRegion.scrollLeft) return;
 		scrollRegion.scrollTo({ behavior: "smooth", left: Math.max(0, nextScrollLeft) });
-	}, [orderedAuxiliaryTerminals, target]);
+	}, [orderedAuxiliaryTabs, target, workspaceActiveTabKey]);
 
 	useEffect(() => {
 		const pane = paneRef.current;
@@ -566,7 +583,7 @@ export function CenterPane({
 									{/* The owning session scrolls with its auxiliary terminals, but remains fixed in order. */}
 									{session ? (
 										<SessionPaneTab
-											isActive={target.kind === "worker" && !workspaceFileActive}
+											isActive={target.kind === "worker" && !workspaceActiveTabKey}
 											label={sessionTabLabel}
 											onSelect={onSelectSessionTerminal}
 											session={session}
@@ -579,44 +596,46 @@ export function CenterPane({
 										as="div"
 										axis="x"
 										className="flex items-stretch self-stretch"
-										onReorder={reorderAuxiliaryTerminals}
-										values={orderedAuxiliaryTerminals.map((terminal) => terminal.key)}
+										onReorder={reorderAuxiliaryTabs}
+										values={orderedAuxiliaryTabs.map((tab) => tab.key)}
 									>
-										{orderedAuxiliaryTerminals.map((terminal) => (
-											<DraggableTerminalTab key={terminal.key} value={terminal.key}>
-												{terminal.kind === "reviewer" ? (
+										{orderedAuxiliaryTabs.map((tab) => (
+											<DraggableWorkspaceTab key={tab.key} value={tab.key}>
+												{tab.kind === "reviewer" ? (
 													<SessionPaneTab
 														appearance="connected"
 														icon={
 															<AgentAvatar
-																provider={terminal.terminal.harness}
+																provider={tab.terminal.harness}
 																className="size-terminal-agent-icon"
 																decorative
 															/>
 														}
 														isActive={target.kind === "reviewer"}
 														label={t("terminal.reviewer")}
-														onSelect={() => onSelectReviewerTerminal?.(terminal.terminal)}
-														title={terminal.terminal.harness}
+														onSelect={() => onSelectReviewerTerminal?.(tab.terminal)}
+														title={tab.terminal.harness}
 													/>
-												) : (
+												) : tab.kind === "shell" ? (
 													<ShellTerminalTab
 														appearance="connected"
-														isActive={target.kind === "shell" && target.handleId === terminal.terminal.handleId}
-														onClose={() => onCloseShellTerminal?.(terminal.terminal.handleId)}
+														isActive={target.kind === "shell" && target.handleId === tab.terminal.handleId}
+														onClose={() => onCloseShellTerminal?.(tab.terminal.handleId)}
 														onRename={
 															onRenameShellTerminal
-																? (title) => onRenameShellTerminal(terminal.terminal.handleId, title)
+																? (title) => onRenameShellTerminal(tab.terminal.handleId, title)
 																: undefined
 														}
-																	onSelect={() => onSelectShellTerminal?.(terminal.terminal.handleId)}
-																	shell={terminal.terminal}
+														onSelect={() => onSelectShellTerminal?.(tab.terminal.handleId)}
+														shell={tab.terminal}
 													/>
+												) : (
+													tab.tab.content
 												)}
-											</DraggableTerminalTab>
+											</DraggableWorkspaceTab>
 										))}
 									</Reorder.Group>
-									{workspaceTabs}
+									{workspaceTabActions}
 								</div>
 							</div>
 								{showLeftFade ? <div aria-hidden="true" className="session-tab-scroll-fade session-tab-scroll-fade--left" /> : null}

--- a/frontend/src/renderer/components/FileContentPane.test.tsx
+++ b/frontend/src/renderer/components/FileContentPane.test.tsx
@@ -87,6 +87,38 @@ describe("FileContentPane", () => {
 		expect(await screen.findByText("hello")).toBeInTheDocument();
 	});
 
+	it("falls back to current content when a changed extensionless file has no renderable diff", async () => {
+		getMock.mockResolvedValue({
+			data: {
+				sessionId: "sess-1",
+				path: "build",
+				status: "modified",
+				additions: 0,
+				deletions: 0,
+				size: 24,
+				binary: false,
+				deleted: false,
+				content: "#!/usr/bin/env bash\necho ok\n",
+				contentTruncated: false,
+				diff: "",
+				diffTruncated: false,
+			},
+		});
+
+		renderWithQuery(<FileContentPane annotation={noopAnnotation()} path="build" sessionId="sess-1" split={false} wrap />);
+
+		expect(await screen.findByText(/echo ok/)).toBeInTheDocument();
+	});
+
+	it("shows a retryable error instead of a blank pane when a successful response has no body", async () => {
+		getMock.mockResolvedValue({ data: undefined });
+
+		renderWithQuery(<FileContentPane annotation={noopAnnotation()} path="README.md" sessionId="sess-1" split={false} wrap />);
+
+		expect(await screen.findByText("Unable to load workspace file")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+	});
+
 	it("shows a retry action on load failure and refetches on click", async () => {
 		getMock.mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce({
 			data: {

--- a/frontend/src/renderer/components/FileContentPane.tsx
+++ b/frontend/src/renderer/components/FileContentPane.tsx
@@ -33,6 +33,7 @@ export function FileContentPane({
 		...sessionWorkspaceFileQueryOptions(sessionId, path ?? "", t("files.error.loadWorkspaceFile")),
 		enabled: Boolean(path) && !selectionOrMenuActive,
 	});
+	const refetch = query.refetch;
 
 	if (!path) {
 		return <PanelMessage>{t("files.explorer.selectFile")}</PanelMessage>;
@@ -42,12 +43,18 @@ export function FileContentPane({
 	}
 	if (query.error) {
 		return (
-			<PanelMessage action={<RetryButton onClick={() => void query.refetch()} />}>
+			<PanelMessage action={<RetryButton onClick={() => void refetch()} />}>
 				{query.error.message || t("files.error.loadFile")}
 			</PanelMessage>
 		);
 	}
-	if (!query.data) return null;
+	if (!query.data) {
+		return (
+			<PanelMessage action={<RetryButton onClick={() => void refetch()} />}>
+				{t("files.error.loadFile")}
+			</PanelMessage>
+		);
+	}
 
 	const detail = query.data;
 	if (detail.status !== "unmodified") {
@@ -56,6 +63,11 @@ export function FileContentPane({
 				annotation={annotation}
 				detail={detail}
 				detailLoadedAt={query.dataUpdatedAt}
+				emptyFallback={
+					!detail.binary && !detail.contentTruncated && !detail.deleted && detail.content ? (
+						<ReadOnlyFileView detail={detail} sessionId={sessionId} />
+					) : undefined
+				}
 				filePath={path}
 				onActiveSelectionChange={setSelectionOrMenuActive}
 				sessionId={sessionId}

--- a/frontend/src/renderer/components/SessionFileTabs.test.tsx
+++ b/frontend/src/renderer/components/SessionFileTabs.test.tsx
@@ -22,11 +22,16 @@ describe("SessionFileTabs", () => {
 		const tab = screen.getByRole("tab", { name: "App.tsx" });
 		const languageIcon = tab.querySelector('[aria-hidden="true"]');
 		expect(languageIcon).toBeInTheDocument();
+		const closeButton = screen.getByRole("button", { name: "Close App.tsx" });
+		const feedbackButton = screen.getByRole("button", { name: "Add feedback for file src/App.tsx" });
+		expect(closeButton.parentElement).toHaveClass("left-2");
+		expect(feedbackButton.parentElement).toHaveClass("right-1");
+		expect(tab.closest("[data-terminal-tab-frame]")).not.toHaveClass("pl-3", "pr-1.5");
 		await userEvent.click(languageIcon!);
 		expect(onActivateFile).toHaveBeenCalledWith("src/App.tsx");
-		await userEvent.click(screen.getByRole("button", { name: "Add feedback for file src/App.tsx" }));
+		await userEvent.click(feedbackButton);
 		expect(onAddFeedback).toHaveBeenCalledWith("src/App.tsx");
-		await userEvent.click(screen.getByRole("button", { name: "Close App.tsx" }));
+		await userEvent.click(closeButton);
 		expect(onCloseFile).toHaveBeenCalledWith("src/App.tsx");
 	});
 

--- a/frontend/src/renderer/components/SessionFileTabs.tsx
+++ b/frontend/src/renderer/components/SessionFileTabs.tsx
@@ -1,7 +1,7 @@
 import { MoreHorizontal, Plus, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { cn } from "../lib/utils";
 import type { SessionFileTabState } from "../lib/session-file-tabs";
+import { TerminalTabFrame } from "./TerminalTabFrame";
 import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 import { WorkspaceEntryIcon } from "./WorkspaceEntryIcon";
@@ -23,70 +23,105 @@ export function SessionFileTabs({
 	onCloseFile: (path: string) => void;
 	onCloseAll: () => void;
 }) {
-	const { t } = useTranslation();
 	if (state.openPaths.length === 0) return null;
 	return (
 		<>
-			{state.openPaths.map((path) => {
-				const name = basename(path);
-				const active = state.activePath === path;
-				return (
-					<span
-						className={cn(
-							"group relative inline-flex min-w-shell-tab-min max-w-shell-tab-max self-stretch items-center gap-1.5 border-r border-border py-0 pl-3 pr-1.5",
-							active
-								? "bg-overlay text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground/80"
-								: "text-muted-foreground hover:bg-raised hover:text-foreground",
-						)}
-						key={path}
-					>
-						<button
-							aria-label={name}
-							aria-selected={active}
-							className="inline-flex min-w-0 flex-1 items-center gap-1.5 truncate text-left text-control font-medium leading-none"
-							onClick={() => onActivateFile(path)}
-							role="tab"
-							tabIndex={active ? 0 : -1}
-							title={path}
-							type="button"
-						>
-							<WorkspaceEntryIcon className="size-icon-base shrink-0" kind="file" name={name} />
-							<span className="truncate">{name}</span>
-						</button>
-						{active ? (
-							<button
-								aria-label={t("files.addFileFeedback", { file: path })}
-								className="grid size-5 shrink-0 place-items-center rounded-sm text-passive hover:bg-interactive-hover hover:text-foreground"
-								onClick={() => onAddFeedback(path)}
-								type="button"
-							>
-								<Plus className="size-3" aria-hidden="true" />
-							</button>
-						) : null}
-						<button
-							aria-label={t("files.closeTab", { name })}
-							className="grid size-5 shrink-0 place-items-center rounded-sm text-passive opacity-70 hover:bg-interactive-hover hover:text-foreground hover:opacity-100"
-							onClick={(event) => {
-								event.stopPropagation();
-								onCloseFile(path);
-							}}
-							type="button"
-						>
-							<X className="size-3" aria-hidden="true" />
-						</button>
-					</span>
-				);
-			})}
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<Button aria-label={t("files.tabActions")} className="mx-1 self-center" size="icon-sm" type="button" variant="ghost">
-						<MoreHorizontal className="size-icon-sm" aria-hidden="true" />
-					</Button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="end">
-					<DropdownMenuItem onSelect={onCloseAll}>{t("files.closeAllTabs")}</DropdownMenuItem>
-				</DropdownMenuContent>
-			</DropdownMenu>
+			{state.openPaths.map((path) => (
+				<SessionFileTab
+					active={state.activePath === path}
+					key={path}
+					onActivate={() => onActivateFile(path)}
+					onAddFeedback={() => onAddFeedback(path)}
+					onClose={() => onCloseFile(path)}
+					path={path}
+				/>
+			))}
+			<SessionFileTabActions onCloseAll={onCloseAll} />
 		</>
+	);
+}
+
+export function SessionFileTab({
+	active,
+	onActivate,
+	onAddFeedback,
+	onClose,
+	path,
+}: {
+	active: boolean;
+	onActivate: () => void;
+	onAddFeedback: () => void;
+	onClose: () => void;
+	path: string;
+}) {
+	const { t } = useTranslation();
+	const name = basename(path);
+	const closeAction = (
+		<button
+			aria-label={t("files.closeTab", { name })}
+			className="grid size-icon-sm place-items-center rounded-sm text-passive opacity-0 pointer-events-none hover:bg-interactive-hover hover:text-foreground group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+			onClick={(event) => {
+				event.stopPropagation();
+				onClose();
+			}}
+			type="button"
+		>
+			<X className="size-icon-sm" aria-hidden="true" />
+		</button>
+	);
+	const feedbackAction = active ? (
+		<button
+			aria-label={t("files.addFileFeedback", { file: path })}
+			className="grid size-5 shrink-0 place-items-center rounded-sm text-passive hover:bg-interactive-hover hover:text-foreground"
+			onClick={(event) => {
+				event.stopPropagation();
+				onAddFeedback();
+			}}
+			type="button"
+		>
+			<Plus className="size-3" aria-hidden="true" />
+		</button>
+	) : undefined;
+	return (
+		<TerminalTabFrame
+			action={closeAction}
+			actionPosition="leading"
+			active={active}
+			buttonProps={{
+				"aria-label": name,
+				"aria-selected": active,
+				onClick: onActivate,
+				role: "tab",
+				tabIndex: active ? 0 : -1,
+				title: path,
+				type: "button",
+			}}
+			className="session-tab-icon-floor session-tab-icon-floor--closable max-w-shell-tab-max"
+			contentClassName="font-medium"
+			trailingAction={feedbackAction}
+		>
+			<WorkspaceEntryIcon
+				className="size-icon-base shrink-0 group-hover:opacity-0 group-focus-within:opacity-0"
+				kind="file"
+				name={name}
+			/>
+			<span className="truncate">{name}</span>
+		</TerminalTabFrame>
+	);
+}
+
+export function SessionFileTabActions({ onCloseAll }: { onCloseAll: () => void }) {
+	const { t } = useTranslation();
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button aria-label={t("files.tabActions")} className="mx-1 self-center" size="icon-sm" type="button" variant="ghost">
+					<MoreHorizontal className="size-icon-sm" aria-hidden="true" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem onSelect={onCloseAll}>{t("files.closeAllTabs")}</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -206,6 +206,7 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		shellTarget,
 		onSelectShellTerminal,
 		workspaceTabs,
+		workspaceTabActions,
 		newWorkDisabled,
 		onConversationWorkChange,
 	}: {
@@ -221,7 +222,8 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		shellTerminals?: Array<{ handleId: string; title: string }>;
 		shellTarget?: { kind: "shell"; handleId: string };
 		onSelectShellTerminal?: (handleId: string) => void;
-		workspaceTabs?: ReactNode;
+		workspaceTabs?: Array<{ key: string; content: ReactNode; onSelect: () => void }>;
+		workspaceTabActions?: ReactNode;
 		newWorkDisabled?: boolean;
 		onConversationWorkChange?: (state: typeof chatSurfaceWorkState) => void;
 	}) => (
@@ -233,7 +235,8 @@ vi.mock("./chat/SessionChatSurface", () => ({
 			{headerActions}
 			{sessionTabAction}
 			<div role="tablist">
-				{workspaceTabs}
+				{workspaceTabs?.map((tab) => <div key={tab.key}>{tab.content}</div>)}
+				{workspaceTabActions}
 				{tabStripAction}
 			</div>
 			{onOpenFile ? (
@@ -292,6 +295,7 @@ vi.mock("./CenterPane", () => ({
 		sessionTabAction,
 		tabStripAction,
 		workspaceTabs,
+		workspaceTabActions,
 		reviewerTerminal,
 		terminalTarget,
 	}: {
@@ -304,7 +308,8 @@ vi.mock("./CenterPane", () => ({
 		topbarActions?: ReactNode;
 		sessionTabAction?: ReactNode;
 		tabStripAction?: ReactNode;
-		workspaceTabs?: ReactNode;
+		workspaceTabs?: Array<{ key: string; content: ReactNode; onSelect: () => void }>;
+		workspaceTabActions?: ReactNode;
 		reviewerTerminal?: { handleId: string; harness: string };
 		terminalTarget?: { kind: string; handleId?: string };
 	}) => (
@@ -313,7 +318,8 @@ vi.mock("./CenterPane", () => ({
 			{topbarActions}
 			{sessionTabAction}
 			<div role="tablist">
-				{workspaceTabs}
+				{workspaceTabs?.map((tab) => <div key={tab.key}>{tab.content}</div>)}
+				{workspaceTabActions}
 				{tabStripAction}
 			</div>
 			<div data-testid="terminal-target">
@@ -713,6 +719,29 @@ describe("SessionView", () => {
 		expect(newTerminalButton).toHaveAttribute("title", "New terminal (Ctrl+T)");
 		fireEvent.click(newTerminalButton);
 		expect(openShellTerminalMock).toHaveBeenCalledWith({ projectId: "proj-1", sessionId: "sess-2" }, expect.anything());
+	});
+
+	it("activates a new terminal opened while a file tab is selected", async () => {
+		const shell = {
+			handleId: "sh-after-file",
+			projectId: "proj-1",
+			sessionId: "sess-1",
+			title: "Terminal 1",
+			workingDir: "/p",
+			createdAt: "2026-08-31T00:00:00Z",
+		};
+		openShellTerminalMock.mockImplementation((_input, options) => {
+			shellTerminalsState.data = [shell];
+			options.onSuccess(shell);
+		});
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		expect(await screen.findByTestId("session-file-workspace")).toHaveTextContent("src/panel.tsx");
+
+		fireEvent.click(screen.getByRole("button", { name: "New terminal" }));
+		expect(screen.queryByTestId("session-file-workspace")).not.toBeInTheDocument();
+		expect(screen.getByTestId("terminal-target")).toHaveTextContent("sh-after-file");
 	});
 
 	it("does not offer a new terminal for orchestrator sessions", () => {

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -102,6 +102,7 @@ vi.mock("../lib/api-client", () => ({
 	apiClient: {
 		GET: reviewGetMock,
 	},
+	apiErrorCode: (error: { code?: string }) => error.code,
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
 }));
 
@@ -193,6 +194,7 @@ vi.mock("./TerminalSwitchAgentButton", () => ({
 }));
 vi.mock("./chat/SessionChatSurface", () => ({
 	SessionChatSurface: ({
+		session,
 		onOpenShell,
 		onOpenFile,
 		headerActions,
@@ -205,11 +207,15 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		shellTerminals = [],
 		shellTarget,
 		onSelectShellTerminal,
+		onCloseShellTerminal,
 		workspaceTabs,
 		workspaceTabActions,
 		newWorkDisabled,
 		onConversationWorkChange,
+		auxiliaryTabOrder,
+		onAuxiliaryTabOrderChange,
 	}: {
+		session: WorkspaceSession;
 		onOpenShell?: () => void;
 		onOpenFile?: (path: string) => void;
 		headerActions?: ReactNode;
@@ -222,16 +228,42 @@ vi.mock("./chat/SessionChatSurface", () => ({
 		shellTerminals?: Array<{ handleId: string; title: string }>;
 		shellTarget?: { kind: "shell"; handleId: string };
 		onSelectShellTerminal?: (handleId: string) => void;
+		onCloseShellTerminal?: (handleId: string) => void;
 		workspaceTabs?: Array<{ key: string; content: ReactNode; onSelect: () => void }>;
 		workspaceTabActions?: ReactNode;
 		newWorkDisabled?: boolean;
 		onConversationWorkChange?: (state: typeof chatSurfaceWorkState) => void;
+		auxiliaryTabOrder?: string[];
+		onAuxiliaryTabOrderChange?: (keys: string[]) => void;
 	}) => (
 		<div
 			data-new-work-disabled={newWorkDisabled ? "true" : "false"}
 			data-testid="chat-surface"
 		>
 			chat surface
+			<div data-testid={`auxiliary-tab-order-${session.id}`}>
+				{auxiliaryTabOrder?.join("|") ?? ""}
+			</div>
+			<button
+				type="button"
+				onClick={() => onAuxiliaryTabOrderChange?.(["sh-a", "file:src/panel.tsx"])}
+			>
+				reorder auxiliary tabs
+			</button>
+			<button
+				type="button"
+				onClick={() =>
+					onAuxiliaryTabOrderChange?.(["sh-a", "reviewer:review-sess-1", "file:src/panel.tsx"])
+				}
+			>
+				reorder reviewer tab
+			</button>
+			<button
+				type="button"
+				onClick={() => onAuxiliaryTabOrderChange?.(["file:src/panel.tsx", "sh-a"])}
+			>
+				reorder visible tabs
+			</button>
 			{headerActions}
 			{sessionTabAction}
 			<div role="tablist">
@@ -259,13 +291,14 @@ vi.mock("./chat/SessionChatSurface", () => ({
 			) : null}
 			<div data-testid="shell-tabs">
 				{shellTerminals.map((shell) => (
-					<button
-						key={shell.handleId}
-						onClick={() => onSelectShellTerminal?.(shell.handleId)}
-						type="button"
-					>
-						{shell.title}
-					</button>
+					<div key={shell.handleId}>
+						<button onClick={() => onSelectShellTerminal?.(shell.handleId)} type="button">
+							{shell.title}
+						</button>
+						<button onClick={() => onCloseShellTerminal?.(shell.handleId)} type="button">
+							close {shell.title}
+						</button>
+					</div>
 				))}
 			</div>
 			{shellTarget ? <div data-testid="terminal-target">shell</div> : null}
@@ -298,6 +331,7 @@ vi.mock("./CenterPane", () => ({
 		workspaceTabActions,
 		reviewerTerminal,
 		terminalTarget,
+		auxiliaryTabOrder,
 	}: {
 		session?: WorkspaceSession;
 		shellTerminals?: Array<{ handleId: string; title: string }>;
@@ -312,9 +346,13 @@ vi.mock("./CenterPane", () => ({
 		workspaceTabActions?: ReactNode;
 		reviewerTerminal?: { handleId: string; harness: string };
 		terminalTarget?: { kind: string; handleId?: string };
+		auxiliaryTabOrder?: string[];
 	}) => (
 		<div>
 			terminal center
+			<div data-testid={`auxiliary-tab-order-tui-${session?.id ?? "none"}`}>
+				{auxiliaryTabOrder?.join("|") ?? ""}
+			</div>
 			{topbarActions}
 			{sessionTabAction}
 			<div role="tablist">
@@ -802,6 +840,147 @@ describe("SessionView", () => {
 		expect(screen.queryByTestId("terminal-target")).not.toBeInTheDocument();
 	});
 
+	it("preserves mixed tab order across session navigation and interface changes", async () => {
+		workerSession("sess-1").mode = "chat";
+		workerSession("sess-2").mode = "chat";
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				projectId: "proj-1",
+				sessionId: "sess-1",
+				title: "session one shell",
+				workingDir: "/p",
+				createdAt: "2026-08-31T00:00:00Z",
+			},
+		];
+		const view = render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByTestId("session-file-workspace");
+		fireEvent.click(screen.getByRole("button", { name: "reorder auxiliary tabs" }));
+		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
+			"sh-a|file:src/panel.tsx",
+		);
+
+		view.rerender(<SessionView sessionId="sess-2" />);
+		view.rerender(<SessionView sessionId="sess-1" />);
+
+		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
+			"sh-a|file:src/panel.tsx",
+		);
+
+		workerSession("sess-1").mode = "tui";
+		view.rerender(<SessionView sessionId="sess-1" />);
+		expect(screen.getByTestId("auxiliary-tab-order-tui-sess-1")).toHaveTextContent(
+			"sh-a|file:src/panel.tsx",
+		);
+	});
+
+	it("selects the adjacent shell when closing a reordered file tab", async () => {
+		workerSession("sess-1").mode = "chat";
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				projectId: "proj-1",
+				sessionId: "sess-1",
+				title: "session one shell",
+				workingDir: "/p",
+				createdAt: "2026-08-31T00:00:00Z",
+			},
+		];
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByTestId("session-file-workspace");
+		fireEvent.click(screen.getByRole("button", { name: "reorder auxiliary tabs" }));
+		fireEvent.click(screen.getByRole("button", { name: "Close panel.tsx" }));
+
+		expect(screen.queryByTestId("session-file-workspace")).not.toBeInTheDocument();
+		expect(screen.getByTestId("terminal-target")).toHaveTextContent("shell");
+	});
+
+	it("preserves a reordered reviewer position while the session is inactive", async () => {
+		const worker = workerSession("sess-1");
+		worker.mode = "chat";
+		worker.prs = [
+			{
+				url: "https://github.com/acme/repo/pull/7",
+				number: 7,
+				state: "open",
+				ci: "passing",
+				review: "none",
+				mergeability: "mergeable",
+				reviewComments: false,
+				updatedAt: "2026-06-15T00:00:00Z",
+			},
+		];
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				projectId: "proj-1",
+				sessionId: "sess-1",
+				title: "session one shell",
+				workingDir: "/p",
+				createdAt: "2026-08-31T00:00:00Z",
+			},
+		];
+		reviewGetMock.mockResolvedValueOnce({
+			data: { reviewerHandleId: "review-sess-1", reviewerHarness: "codex", reviews: [] },
+			error: undefined,
+		});
+		const view = render(<SessionView sessionId="sess-1" />);
+
+		await screen.findByRole("button", { name: "Reviewer" });
+		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByTestId("session-file-workspace");
+		fireEvent.click(screen.getByRole("button", { name: "reorder reviewer tab" }));
+		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
+			"sh-a|reviewer:review-sess-1|file:src/panel.tsx",
+		);
+
+		worker.status = "terminated";
+		worker.isTerminated = true;
+		view.rerender(<SessionView sessionId="sess-1" />);
+		fireEvent.click(screen.getByRole("button", { name: "reorder visible tabs" }));
+		worker.status = "working";
+		worker.isTerminated = false;
+		view.rerender(<SessionView sessionId="sess-1" />);
+
+		await screen.findByRole("button", { name: "Reviewer" });
+		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
+			"file:src/panel.tsx|reviewer:review-sess-1|sh-a",
+		);
+	});
+
+	it("keeps a shell's reordered position when closing it fails", async () => {
+		workerSession("sess-1").mode = "chat";
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				projectId: "proj-1",
+				sessionId: "sess-1",
+				title: "session one shell",
+				workingDir: "/p",
+				createdAt: "2026-08-31T00:00:00Z",
+			},
+		];
+		closeShellTerminalMock.mockImplementation((_handleId, options) => {
+			options?.onError?.({ code: "SHELL_TERMINAL_CLOSE_FAILED" });
+		});
+		const view = render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByTestId("session-file-workspace");
+		fireEvent.click(screen.getByRole("button", { name: "reorder auxiliary tabs" }));
+		fireEvent.click(screen.getByRole("button", { name: "session one shell" }));
+		fireEvent.click(screen.getByRole("button", { name: "close session one shell" }));
+		view.rerender(<SessionView sessionId="sess-1" />);
+
+		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
+			"sh-a|file:src/panel.tsx",
+		);
+	});
+
 	it.each([
 		["Terminal UI worker", "sess-1", "tui", "chat", "Switch to chat UI"],
 		["Terminal UI orchestrator", "sess-orch", "tui", "chat", "Switch to chat UI"],
@@ -1236,14 +1415,14 @@ describe("SessionView", () => {
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("sh-b");
 
 		fireEvent.click(screen.getByRole("button", { name: "close second shell" }));
-		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-b");
+		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-b", expect.any(Object));
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("sh-a");
 		expect(useUiStore.getState().activeShellTerminalHandleId).toBe("sh-a");
 
 		shellTerminalsState.data = shellTerminalsState.data.filter((shell) => shell.handleId !== "sh-b");
 		view.rerender(<SessionView sessionId="sess-1" />);
 		fireEvent.click(screen.getByRole("button", { name: "close first shell" }));
-		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-a");
+		expect(closeShellTerminalMock).toHaveBeenCalledWith("sh-a", expect.any(Object));
 		expect(screen.getByTestId("terminal-target")).toHaveTextContent("worker");
 		expect(useUiStore.getState().activeShellTerminalHandleId).toBeNull();
 	});

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -58,7 +58,7 @@ import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { useSessionHandoffMenu } from "../hooks/useSessionHandoffMenu";
 import { clearSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
 import { sessionWorkspaceFilesQueryOptions } from "../hooks/useSessionWorkspaceFiles";
 import { matchWorkspaceFilePath } from "../lib/workspace-file-path";
 import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
@@ -98,6 +98,7 @@ const BROWSER_CHAT_MIN_PX = 440;
 const BROWSER_CHAT_COMFORT_PX = 720;
 const WORKSPACE_ABSOLUTE_MIN_PX = 300;
 const INSPECTOR_SEPARATOR_RESERVE_PX = 8;
+const EMPTY_AUXILIARY_TAB_ORDER: string[] = [];
 // The inspector tab labels respond to the tablist's remaining width. The
 // 239px tablist breakpoint plus the 76px pinned-action reserve and 10px leading
 // inset gives a 325px inspector breakpoint for the animation lock.
@@ -407,6 +408,38 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
 	const [fileTabsBySession, setFileTabsBySession] = useState<Record<string, SessionFileTabState>>({});
 	const fileTabs = fileTabsBySession[sessionId] ?? EMPTY_SESSION_FILE_TABS;
+	const [auxiliaryTabOrderBySession, setAuxiliaryTabOrderBySession] = useState<Record<string, string[]>>({});
+	const auxiliaryTabOrder = auxiliaryTabOrderBySession[sessionId] ?? EMPTY_AUXILIARY_TAB_ORDER;
+	const setAuxiliaryTabOrder = useCallback(
+		(nextOrder: string[]) => {
+			setAuxiliaryTabOrderBySession((current) => {
+				const currentOrder = current[sessionId] ?? [];
+				const visibleKeys = new Set(nextOrder);
+				let nextIndex = 0;
+				const mergedOrder = currentOrder.map((key) =>
+					visibleKeys.has(key) ? nextOrder[nextIndex++]! : key,
+				);
+				while (nextIndex < nextOrder.length) mergedOrder.push(nextOrder[nextIndex++]!);
+				return { ...current, [sessionId]: mergedOrder };
+			});
+		},
+		[sessionId],
+	);
+	const removeAuxiliaryTab = useCallback(
+		(key: string) => {
+			setAuxiliaryTabOrderBySession((current) => {
+				const currentOrder = current[sessionId];
+				if (!currentOrder?.includes(key)) return current;
+				const nextOrder = currentOrder.filter((candidate) => candidate !== key);
+				if (nextOrder.length === 0) {
+					const { [sessionId]: _removed, ...rest } = current;
+					return rest;
+				}
+				return { ...current, [sessionId]: nextOrder };
+			});
+		},
+		[sessionId],
+	);
 	const browserPopOutPhase = browserPopOutState.sessionId === sessionId ? browserPopOutState.phase : "docked";
 	const browserPoppedOut = browserPopOutPhase !== "docked";
 	const [handoffDialogOpen, setHandoffDialogOpen] = useState(false);
@@ -502,6 +535,19 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		() => allShellTerminals.filter((shell) => shell.sessionId === sessionId),
 		[allShellTerminals, sessionId],
 	);
+	const resolvedAuxiliaryTabOrder = useMemo(() => {
+		const available = [
+			...(reviewerTerminal ? [`reviewer:${reviewerTerminal.handleId}`] : []),
+			...shellTerminals.map((shell) => shell.handleId),
+			...fileTabs.openPaths.map((path) => `file:${path}`),
+		];
+		const availableKeys = new Set(available);
+		const resolved = auxiliaryTabOrder.filter((key) => availableKeys.has(key));
+		for (const key of available) {
+			if (!resolved.includes(key)) resolved.push(key);
+		}
+		return resolved;
+	}, [auxiliaryTabOrder, fileTabs.openPaths, reviewerTerminal, shellTerminals]);
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
 	const renameShellTerminal = useRenameShellTerminal();
@@ -539,6 +585,66 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		);
 	}, [openShellTerminal, sessionId, session?.workspaceId, setActiveShellTerminal]);
 
+	const activateAuxiliaryTab = useCallback(
+		(key?: string) => {
+			if (key?.startsWith("file:")) {
+				const path = key.slice("file:".length);
+				setActiveShellTerminal(null);
+				setTerminalTarget({ kind: "worker" });
+				setFileTabsBySession((current) => ({
+					...current,
+					[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, path),
+				}));
+				return;
+			}
+			if (reviewerTerminal && key === `reviewer:${reviewerTerminal.handleId}`) {
+				setActiveShellTerminal(null);
+				setTerminalTarget({
+					kind: "reviewer",
+					handleId: reviewerTerminal.handleId,
+					harness: reviewerTerminal.harness,
+					sessionId,
+				});
+				setFileTabsBySession((current) => ({
+					...current,
+					[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
+				}));
+				return;
+			}
+			const shell = shellTerminals.find((candidate) => candidate.handleId === key);
+			if (shell) {
+				setActiveShellTerminal(shell.handleId);
+				setTerminalTarget({
+					generation: shell.createdAt,
+					kind: "shell",
+					handleId: shell.handleId,
+					sessionId,
+					title: shell.title,
+				});
+				setFileTabsBySession((current) => ({
+					...current,
+					[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
+				}));
+				return;
+			}
+			setActiveShellTerminal(null);
+			setTerminalTarget({ kind: "worker" });
+			setFileTabsBySession((current) => ({
+				...current,
+				[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
+			}));
+		},
+		[reviewerTerminal, sessionId, shellTerminals, setActiveShellTerminal],
+	);
+	const adjacentAuxiliaryTab = useCallback(
+		(closingKey: string) => {
+			const closingIndex = resolvedAuxiliaryTabOrder.indexOf(closingKey);
+			if (closingIndex < 0) return undefined;
+			return resolvedAuxiliaryTabOrder[closingIndex - 1] ?? resolvedAuxiliaryTabOrder[closingIndex + 1];
+		},
+		[resolvedAuxiliaryTabOrder],
+	);
+
 	const selectShellTerminal = useCallback(
 		(handleId: string) => {
 			const shell = shellTerminals.find((s) => s.handleId === handleId);
@@ -562,35 +668,25 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const closeShellTerminalByHandle = useCallback(
 		(handleId: string) => {
 			if (terminalTarget.kind === "shell" && terminalTarget.handleId === handleId) {
-				const closingIndex = shellTerminals.findIndex((shell) => shell.handleId === handleId);
-				// Match browser-tab ergonomics: closing the selected auxiliary terminal
-				// reveals its nearest predecessor, then the next tab when the first one
-				// closes. The permanent agent terminal is only the final fallback.
-				const nextShell = shellTerminals[closingIndex - 1] ?? shellTerminals[closingIndex + 1];
-				if (nextShell) {
-					setActiveShellTerminal(nextShell.handleId);
-					setTerminalTarget({
-						generation: nextShell.createdAt,
-						kind: "shell",
-						handleId: nextShell.handleId,
-						sessionId,
-						title: nextShell.title,
-					});
-				} else {
-					setActiveShellTerminal(null);
-					setTerminalTarget({ kind: "worker" });
-				}
+				// Match the visible mixed strip, not the shell-only creation order.
+				activateAuxiliaryTab(adjacentAuxiliaryTab(handleId));
 			} else if (activeShellTerminalHandleId === handleId) {
 				setActiveShellTerminal(null);
 			}
-			closeShellTerminal.mutate(handleId);
+			closeShellTerminal.mutate(handleId, {
+				onSuccess: () => removeAuxiliaryTab(handleId),
+				onError: (error) => {
+					if (apiErrorCode(error) === "SHELL_TERMINAL_NOT_FOUND") removeAuxiliaryTab(handleId);
+				},
+			});
 		},
 		[
 			activeShellTerminalHandleId,
+			activateAuxiliaryTab,
+			adjacentAuxiliaryTab,
 			closeShellTerminal,
+			removeAuxiliaryTab,
 			setActiveShellTerminal,
-			sessionId,
-			shellTerminals,
 			terminalTarget,
 		],
 	);
@@ -630,9 +726,23 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			...current,
 			[sessionId]: closeSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, path),
 		}));
-	}, [sessionId]);
+		if (fileTabs.activePath === path) {
+			activateAuxiliaryTab(adjacentAuxiliaryTab(`file:${path}`));
+		}
+		removeAuxiliaryTab(`file:${path}`);
+	}, [activateAuxiliaryTab, adjacentAuxiliaryTab, fileTabs.activePath, removeAuxiliaryTab, sessionId]);
 	const closeAllCenterFiles = useCallback(() => {
 		setFileTabsBySession((current) => ({ ...current, [sessionId]: closeAllSessionFiles() }));
+		setAuxiliaryTabOrderBySession((current) => {
+			const currentOrder = current[sessionId];
+			if (!currentOrder?.some((key) => key.startsWith("file:"))) return current;
+			const nextOrder = currentOrder.filter((key) => !key.startsWith("file:"));
+			if (nextOrder.length === 0) {
+				const { [sessionId]: _removed, ...rest } = current;
+				return rest;
+			}
+			return { ...current, [sessionId]: nextOrder };
+		});
 	}, [sessionId]);
 
 	// The shell layout owns opening (it is mounted on every route, so the button
@@ -1420,6 +1530,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									workspaceTabs={centerFileTabs}
 									workspaceTabActions={centerFileTabActions}
 									workspaceActiveTabKey={activeWorkspaceTabKey}
+									auxiliaryTabOrder={resolvedAuxiliaryTabOrder}
+									onAuxiliaryTabOrderChange={setAuxiliaryTabOrder}
 									controllerTransitioning={chatControllerTransitioning}
 									newWorkDisabled={chatNewWorkDisabled}
 									onConversationWorkChange={handleConversationWorkChange}
@@ -1454,6 +1566,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									workspaceTabs={centerFileTabs}
 									workspaceTabActions={centerFileTabActions}
 									workspaceActiveTabKey={activeWorkspaceTabKey}
+									auxiliaryTabOrder={resolvedAuxiliaryTabOrder}
+									onAuxiliaryTabOrderChange={setAuxiliaryTabOrder}
 								/>
 							)}
 							</div>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -25,7 +25,7 @@ import {
 import { NotificationCenter } from "./NotificationCenter";
 import { ResizeHandle } from "./ResizeHandle";
 import { SessionFileExplorer } from "./SessionFileExplorer";
-import { SessionFileTabs } from "./SessionFileTabs";
+import { SessionFileTab, SessionFileTabActions } from "./SessionFileTabs";
 import { SessionFileWorkspace } from "./SessionFileWorkspace";
 import { SessionActionsMenu } from "./SessionActionsMenu";
 import { SessionInspector } from "./SessionInspector";
@@ -523,6 +523,10 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			{
 				onSuccess: (shell) => {
 					setActiveShellTerminal(shell.handleId);
+					setFileTabsBySession((current) => ({
+						...current,
+						[sessionId]: activateSessionFile(current[sessionId] ?? EMPTY_SESSION_FILE_TABS, null),
+					}));
 					setTerminalTarget({
 						generation: shell.createdAt,
 						kind: "shell",
@@ -880,15 +884,27 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			</TopbarButton>
 		) : null;
 	const fileAnnotation = useFileAnnotation(sessionId);
-	const centerFileTabs = (
-		<SessionFileTabs
-			state={fileTabs}
-			onAddFeedback={(path) => fileAnnotation.begin({ path, side: "file" })}
-			onActivateFile={activateCenterFile}
-			onCloseFile={closeCenterFile}
-			onCloseAll={closeAllCenterFiles}
-		/>
+	const centerFileTabs = useMemo(
+		() =>
+			fileTabs.openPaths.map((path) => ({
+				key: `file:${path}`,
+				content: (
+					<SessionFileTab
+						active={fileTabs.activePath === path}
+						onActivate={() => activateCenterFile(path)}
+						onAddFeedback={() => fileAnnotation.begin({ path, side: "file" })}
+						onClose={() => closeCenterFile(path)}
+						path={path}
+					/>
+				),
+				onSelect: () => activateCenterFile(path),
+			})),
+		[activateCenterFile, closeCenterFile, fileAnnotation, fileTabs.activePath, fileTabs.openPaths],
 	);
+	const centerFileTabActions = fileTabs.openPaths.length > 0 ? (
+		<SessionFileTabActions onCloseAll={closeAllCenterFiles} />
+	) : undefined;
+	const activeWorkspaceTabKey = fileTabs.activePath ? `file:${fileTabs.activePath}` : undefined;
 	const previewUrl = session?.previewUrl?.trim() || undefined;
 	const previewRevision = session?.previewRevision;
 	const browserSlotVisible = Boolean(
@@ -1402,7 +1418,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									tabStripAction={newShellTerminalAction}
 									handoffDialogOpen={handoffDialogOpen}
 									workspaceTabs={centerFileTabs}
-									workspaceFileActive={Boolean(fileTabs.activePath)}
+									workspaceTabActions={centerFileTabActions}
+									workspaceActiveTabKey={activeWorkspaceTabKey}
 									controllerTransitioning={chatControllerTransitioning}
 									newWorkDisabled={chatNewWorkDisabled}
 									onConversationWorkChange={handleConversationWorkChange}
@@ -1435,7 +1452,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									tabStripAction={newShellTerminalAction}
 									handoffDialogOpen={handoffDialogOpen}
 									workspaceTabs={centerFileTabs}
-									workspaceFileActive={Boolean(fileTabs.activePath)}
+									workspaceTabActions={centerFileTabActions}
+									workspaceActiveTabKey={activeWorkspaceTabKey}
 								/>
 							)}
 							</div>

--- a/frontend/src/renderer/components/TerminalTabFrame.tsx
+++ b/frontend/src/renderer/components/TerminalTabFrame.tsx
@@ -5,6 +5,7 @@ type TerminalTabFrameProps = {
 	active: boolean;
 	action?: ReactNode;
 	actionPosition?: "leading" | "trailing";
+	trailingAction?: ReactNode;
 	buttonRef?: Ref<HTMLButtonElement>;
 	children: ReactNode;
 	className?: string;
@@ -21,6 +22,7 @@ export function TerminalTabFrame({
 	active,
 	action,
 	actionPosition = "trailing",
+	trailingAction,
 	buttonRef,
 	children,
 	className,
@@ -50,7 +52,7 @@ export function TerminalTabFrame({
 						ref={buttonRef}
 						className={cn(
 							"inline-flex h-full min-w-0 flex-1 cursor-pointer items-center px-2 text-left text-control leading-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
-							actionPosition === "trailing" && action && "pr-9",
+							((actionPosition === "trailing" && action) || trailingAction) && "pr-9",
 							buttonClassName,
 						)}
 						{...restButtonProps}
@@ -69,6 +71,14 @@ export function TerminalTabFrame({
 						data-terminal-tab-action
 					>
 						{action}
+					</div>
+				) : null}
+				{trailingAction ? (
+					<div
+						className="absolute inset-y-0 right-1 z-10 flex items-center"
+						data-terminal-tab-action
+					>
+						{trailingAction}
 					</div>
 				) : null}
 			</span>

--- a/frontend/src/renderer/components/WorkspaceDiffView.tsx
+++ b/frontend/src/renderer/components/WorkspaceDiffView.tsx
@@ -64,6 +64,7 @@ export function ReviewDiffBody({
 	annotation,
 	detail,
 	detailLoadedAt,
+	emptyFallback,
 	filePath,
 	onActiveSelectionChange,
 	sessionId,
@@ -73,6 +74,7 @@ export function ReviewDiffBody({
 	annotation: FileAnnotationModel;
 	detail: WorkspaceFileDetail;
 	detailLoadedAt: number;
+	emptyFallback?: ReactNode;
 	filePath: string;
 	onActiveSelectionChange: (active: boolean) => void;
 	sessionId: string;
@@ -101,7 +103,7 @@ export function ReviewDiffBody({
 		return <PanelMessage compact>{t("files.loadingDiff")}</PanelMessage>;
 	}
 	if (rows.length === 0) {
-		return <PanelMessage compact>{emptyDiffMessage(detail.compareMode, t)}</PanelMessage>;
+		return emptyFallback ?? <PanelMessage compact>{emptyDiffMessage(detail.compareMode, t)}</PanelMessage>;
 	}
 	return (
 		<DiffView

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -29,6 +29,7 @@ import {
 	type WheelEvent as ReactWheelEvent,
 } from "react";
 import { ArrowDown, Loader2, TriangleAlert, Undo2 } from "lucide-react";
+import { Reorder, useDragControls } from "motion/react";
 import { useTranslation } from "react-i18next";
 import { cn } from "../../lib/utils";
 import { sameContent, useStableList } from "../../lib/stable-list";
@@ -135,6 +136,32 @@ function initialTerminalFontSize(): number {
 
 type ReviewerTerminalTarget = Extract<TerminalTarget, { kind: "reviewer" }>;
 type ShellTerminalTarget = Extract<TerminalTarget, { kind: "shell" }>;
+type WorkspaceTab = { key: string; content: ReactNode; onSelect: () => void };
+type ChatAuxiliaryTab =
+	| { key: string; kind: "reviewer"; terminal: { handleId: string; harness: string } }
+	| { key: string; kind: "shell"; terminal: ShellTerminal }
+	| { key: string; kind: "workspace"; tab: WorkspaceTab };
+
+function DraggableChatTab({ children, value }: { children: ReactNode; value: string }) {
+	const dragControls = useDragControls();
+	return (
+		<Reorder.Item
+			as="div"
+			className="flex shrink-0 self-stretch touch-pan-y"
+			data-terminal-tab-key={value}
+			drag="x"
+			dragControls={dragControls}
+			dragListener={false}
+			onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => {
+				if ((event.target as HTMLElement).closest("[data-terminal-tab-action],input,a")) return;
+				dragControls.start(event);
+			}}
+			value={value}
+		>
+			{children}
+		</Reorder.Item>
+	);
+}
 
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
@@ -165,8 +192,9 @@ export interface ChatWorkspaceProps {
 	/** Pinned beside the tab strip, before the workspace topbar actions. */
 	tabStripAction?: ReactNode;
 	/** File tabs coordinated by SessionView, appended to the native chat tab strip. */
-	workspaceTabs?: ReactNode;
-	workspaceFileActive?: boolean;
+	workspaceTabs?: WorkspaceTab[];
+	workspaceTabActions?: ReactNode;
+	workspaceActiveTabKey?: string;
 	/** Suppress a transient stopped snapshot while a mode handoff installs Chat. */
 	controllerTransitioning?: boolean;
 	/** Freeze agent-owned Chat controls while a durable session mutation owns input. */
@@ -305,7 +333,8 @@ export function ChatWorkspace({
 	sessionTabAction,
 	tabStripAction,
 	workspaceTabs,
-	workspaceFileActive = false,
+	workspaceTabActions,
+	workspaceActiveTabKey,
 	controllerTransitioning,
 	agentInputDisabled = false,
 	newWorkDisabled = false,
@@ -428,6 +457,56 @@ export function ChatWorkspace({
 	// session temporarily becomes terminated and later returns.
 	const reviewerActive = Boolean(reviewerTarget && session);
 	const shellActive = Boolean(shellTarget && session);
+	const auxiliaryTabs = useMemo<ChatAuxiliaryTab[]>(
+		() => [
+			...(reviewerTerminal
+				? [{ key: `reviewer:${reviewerTerminal.handleId}`, kind: "reviewer" as const, terminal: reviewerTerminal }]
+				: []),
+			...(shellTerminals ?? []).map((terminal) => ({ key: terminal.handleId, kind: "shell" as const, terminal })),
+			...(workspaceTabs ?? []).map((tab) => ({ key: tab.key, kind: "workspace" as const, tab })),
+		],
+		[reviewerTerminal, shellTerminals, workspaceTabs],
+	);
+	const availableTabKeys = useMemo(() => auxiliaryTabs.map((tab) => tab.key), [auxiliaryTabs]);
+	const [tabOrderBySession, setTabOrderBySession] = useState<Record<string, string[]>>({});
+	const orderedAuxiliaryTabs = useMemo(() => {
+		const preferred = tabOrderBySession[snapshot.sessionId] ?? [];
+		const byKey = new Map(auxiliaryTabs.map((tab) => [tab.key, tab]));
+		const ordered = preferred.flatMap((key) => {
+			const tab = byKey.get(key);
+			if (!tab) return [];
+			byKey.delete(key);
+			return [tab];
+		});
+		return [...ordered, ...byKey.values()];
+	}, [auxiliaryTabs, snapshot.sessionId, tabOrderBySession]);
+	const reorderAuxiliaryTabs = useCallback(
+		(nextKeys: string[]) => {
+			const available = new Set(availableTabKeys);
+			const next = nextKeys.filter((key, index) => available.has(key) && nextKeys.indexOf(key) === index);
+			for (const key of availableTabKeys) {
+				if (!next.includes(key)) next.push(key);
+			}
+			setTabOrderBySession((current) => ({ ...current, [snapshot.sessionId]: next }));
+		},
+		[availableTabKeys, snapshot.sessionId],
+	);
+	useEffect(() => {
+		setTabOrderBySession((current) => {
+			const currentOrder = current[snapshot.sessionId] ?? [];
+			const available = new Set(availableTabKeys);
+			const next = currentOrder.filter((key) => available.has(key));
+			for (const key of availableTabKeys) {
+				if (!next.includes(key)) next.push(key);
+			}
+			if (next.length === currentOrder.length && next.every((key, index) => key === currentOrder[index])) return current;
+			if (next.length === 0) {
+				const { [snapshot.sessionId]: _removed, ...rest } = current;
+				return rest;
+			}
+			return { ...current, [snapshot.sessionId]: next };
+		});
+	}, [availableTabKeys, snapshot.sessionId]);
 	const queuedMessages = useMemo(() => {
 		const messagesByTurn = new Map(
 			snapshot.items
@@ -577,20 +656,14 @@ export function ChatWorkspace({
 	// tabs there is nothing to cycle to and the shortcut is a no-op.
 	const selectAdjacentTab = useCallback(
 		(direction: -1 | 1) => {
-			const tabs = [
-				{ kind: "chat" as const },
-				...(reviewerTerminal ? [{ kind: "reviewer" as const }] : []),
-				...(shellTerminals ?? []).map((shell) => ({
-					kind: "shell" as const,
-					handleId: shell.handleId,
-				})),
-			];
+			const tabs = [{ key: "chat", kind: "chat" as const }, ...orderedAuxiliaryTabs];
 			if (tabs.length <= 1) return;
-			const activeIndex = shellActive
-				? tabs.findIndex((tab) => tab.kind === "shell" && tab.handleId === shellTarget?.handleId)
+			const activeKey = workspaceActiveTabKey ?? (shellActive
+				? shellTarget?.handleId
 				: reviewerActive
-					? tabs.findIndex((tab) => tab.kind === "reviewer")
-					: 0;
+					? `reviewer:${reviewerTerminal?.handleId}`
+					: "chat");
+			const activeIndex = tabs.findIndex((tab) => tab.key === activeKey);
 			const currentIndex = activeIndex >= 0 ? activeIndex : 0;
 			const next = tabs[(currentIndex + direction + tabs.length) % tabs.length];
 			if (!next) return;
@@ -599,10 +672,14 @@ export function ChatWorkspace({
 				return;
 			}
 			if (next.kind === "reviewer") {
-				if (reviewerTerminal) onOpenReviewerTerminal?.(reviewerTerminal);
+				onOpenReviewerTerminal?.(next.terminal);
 				return;
 			}
-			onSelectShellTerminal?.(next.handleId);
+			if (next.kind === "shell") {
+				onSelectShellTerminal?.(next.terminal.handleId);
+				return;
+			}
+			next.tab.onSelect();
 		},
 		[
 			onOpenReviewerTerminal,
@@ -610,9 +687,10 @@ export function ChatWorkspace({
 			onSelectShellTerminal,
 			reviewerActive,
 			reviewerTerminal,
+			orderedAuxiliaryTabs,
 			shellActive,
 			shellTarget,
-			shellTerminals,
+			workspaceActiveTabKey,
 		],
 	);
 	const handleChatTabsKeyDown = useCallback(
@@ -761,11 +839,9 @@ export function ChatWorkspace({
 				snapshot={snapshot}
 				sessionTitle={sessionTitle}
 				sessionRole={sessionRole}
-				reviewerTerminal={reviewerTerminal}
 				onOpenReviewerTerminal={onOpenReviewerTerminal}
 				reviewerActive={reviewerActive}
 				onSelectChat={onSelectChat}
-				shellTerminals={shellTerminals}
 				shellActiveHandleId={shellActive ? shellTarget?.handleId : undefined}
 				onSelectShellTerminal={onSelectShellTerminal}
 				onCloseShellTerminal={onCloseShellTerminal}
@@ -775,8 +851,10 @@ export function ChatWorkspace({
 				session={session}
 				sessionTabAction={sessionTabAction}
 				tabStripAction={tabStripAction}
-				workspaceTabs={workspaceTabs}
-				workspaceFileActive={workspaceFileActive}
+				workspaceTabActions={workspaceTabActions}
+				workspaceActiveTabKey={workspaceActiveTabKey}
+				orderedAuxiliaryTabs={orderedAuxiliaryTabs}
+				onReorderAuxiliaryTabs={reorderAuxiliaryTabs}
 				inline={isFullscreen}
 				topbarBounds={topbarBounds}
 			/>
@@ -1135,11 +1213,9 @@ function ChatHeader({
 	snapshot,
 	sessionTitle,
 	sessionRole,
-	reviewerTerminal,
 	onOpenReviewerTerminal,
 	reviewerActive,
 	onSelectChat,
-	shellTerminals,
 	shellActiveHandleId,
 	onSelectShellTerminal,
 	onCloseShellTerminal,
@@ -1148,8 +1224,10 @@ function ChatHeader({
 	headerActions,
 	sessionTabAction,
 	tabStripAction,
-	workspaceTabs,
-	workspaceFileActive = false,
+	workspaceTabActions,
+	workspaceActiveTabKey,
+	orderedAuxiliaryTabs,
+	onReorderAuxiliaryTabs,
 	inline,
 	topbarBounds,
 	session,
@@ -1157,14 +1235,11 @@ function ChatHeader({
 	snapshot: ConversationSnapshot;
 	sessionTitle?: string;
 	sessionRole: SessionKind;
-	reviewerTerminal?: { handleId: string; harness: string };
 	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
 	/** The reviewer tab is selected; the chat tab is the clickable alternative. */
 	reviewerActive?: boolean;
 	/** Return the tab strip to the chat tab. */
 	onSelectChat?: () => void;
-	/** This session's standalone shells, as tabs after the reviewer. */
-	shellTerminals?: ShellTerminal[];
 	/** The selected shell tab, if any. */
 	shellActiveHandleId?: string;
 	onSelectShellTerminal?: (handleId: string) => void;
@@ -1174,8 +1249,10 @@ function ChatHeader({
 	headerActions?: ReactNode;
 	sessionTabAction?: ReactNode;
 	tabStripAction?: ReactNode;
-	workspaceTabs?: ReactNode;
-	workspaceFileActive?: boolean;
+	workspaceTabActions?: ReactNode;
+	workspaceActiveTabKey?: string;
+	orderedAuxiliaryTabs: ChatAuxiliaryTab[];
+	onReorderAuxiliaryTabs: (keys: string[]) => void;
 	session?: WorkspaceSession;
 	/** Fullscreen content cannot see the normal topbar portal outside its subtree. */
 	inline?: boolean;
@@ -1189,21 +1266,20 @@ function ChatHeader({
 	const label = sessionIsOrchestrator
 		? t("shell.orchestrator")
 		: (sessionTitle || session?.title || snapshot.title || snapshot.sessionId);
-	const tabScrollWatch = `${session?.id ?? ""}|${reviewerTerminal?.handleId ?? ""}|${(shellTerminals ?? []).map((shell) => shell.handleId).join("|")}`;
+	const tabScrollWatch = `${session?.id ?? ""}|${orderedAuxiliaryTabs.map((tab) => tab.key).join("|")}`;
 	const {
 		scrollRef: tabsOverflowRef,
 		scrollToEnd: scrollTabsToEnd,
 		showLeftFade,
 		showRightFade,
 	} = useTabScrollEdges([tabScrollWatch]);
-	const previousShellCountRef = useRef(shellTerminals?.length ?? 0);
+	const previousTabCountRef = useRef(orderedAuxiliaryTabs.length);
 	useEffect(() => {
-		const shellCount = shellTerminals?.length ?? 0;
-		if (shellCount > previousShellCountRef.current) scrollTabsToEnd();
-		previousShellCountRef.current = shellCount;
-	}, [scrollTabsToEnd, shellTerminals?.length]);
+		if (orderedAuxiliaryTabs.length > previousTabCountRef.current) scrollTabsToEnd();
+		previousTabCountRef.current = orderedAuxiliaryTabs.length;
+	}, [orderedAuxiliaryTabs.length, scrollTabsToEnd]);
 	// The chat tab is "selected" only when neither terminal pane is the body.
-	const timelineActive = !workspaceFileActive && !reviewerActive && !shellActiveHandleId;
+	const timelineActive = !workspaceActiveTabKey && !reviewerActive && !shellActiveHandleId;
 	// Match CenterPane: when the sidebar is off-canvas, the fixed TitlebarNav
 	// cluster sits over the session tab strip. Terminal already reserves that
 	// space; chat must too or the back/forward buttons land on the tab label.
@@ -1253,7 +1329,7 @@ function ChatHeader({
 								)}
 								onClick={timelineActive ? undefined : onSelectChat}
 								role="tab"
-								tabIndex={timelineActive || (!reviewerTerminal && !shellTerminals?.length) ? 0 : -1}
+								tabIndex={timelineActive || orderedAuxiliaryTabs.length === 0 ? 0 : -1}
 								title={label}
 								type="button"
 							>
@@ -1264,47 +1340,51 @@ function ChatHeader({
 						<div className="relative min-w-0 flex-1 self-stretch overflow-hidden">
 							<div ref={tabsOverflowRef} className="scrollbar-none flex h-full min-w-flex-min min-w-0 items-stretch overflow-x-auto">
 								<div className="flex w-max items-stretch">
-								{reviewerTerminal ? (
-									<button
-										aria-current={reviewerActive ? true : undefined}
-										aria-label="Reviewer"
-										aria-selected={Boolean(reviewerActive)}
-										className={cn(
-											"group relative inline-flex min-w-shell-tab-min max-w-shell-tab-max self-stretch cursor-pointer items-center gap-1.5 border-r border-border px-3 text-control font-medium leading-none transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
-											reviewerActive
-												? "bg-overlay text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground/80"
-												: "text-muted-foreground hover:bg-raised hover:text-foreground",
-										)}
-										onClick={() => onOpenReviewerTerminal?.(reviewerTerminal)}
-										role="tab"
-										tabIndex={reviewerActive ? 0 : -1}
-										title={reviewerTerminal.harness}
-										type="button"
-									>
-										<AgentAvatar
-											className="size-icon-base"
-											decorative
-											provider={reviewerTerminal.harness}
-										/>
-										<span className="truncate">Reviewer</span>
-									</button>
-								) : null}
-								{(shellTerminals ?? []).map((shell) => (
-									<ShellTerminalTab
-										key={shell.handleId}
-										appearance="connected"
-										isActive={shell.handleId === shellActiveHandleId}
-										onClose={() => onCloseShellTerminal?.(shell.handleId)}
-										onRename={
-											onRenameShellTerminal
-												? (title) => onRenameShellTerminal(shell.handleId, title)
-												: undefined
-										}
-										onSelect={() => onSelectShellTerminal?.(shell.handleId)}
-										shell={shell}
-									/>
-								))}
-								{workspaceTabs}
+								<Reorder.Group
+									as="div"
+									axis="x"
+									className="flex items-stretch self-stretch"
+									onReorder={onReorderAuxiliaryTabs}
+									values={orderedAuxiliaryTabs.map((tab) => tab.key)}
+								>
+									{orderedAuxiliaryTabs.map((tab) => (
+										<DraggableChatTab key={tab.key} value={tab.key}>
+											{tab.kind === "reviewer" ? (
+												<button
+													aria-current={reviewerActive ? true : undefined}
+													aria-label="Reviewer"
+													aria-selected={Boolean(reviewerActive)}
+													className={cn(
+														"group relative inline-flex min-w-shell-tab-min max-w-shell-tab-max self-stretch cursor-pointer items-center gap-1.5 border-r border-border px-3 text-control font-medium leading-none transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
+														reviewerActive
+															? "bg-overlay text-foreground after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground/80"
+															: "text-muted-foreground hover:bg-raised hover:text-foreground",
+													)}
+													onClick={() => onOpenReviewerTerminal?.(tab.terminal)}
+													role="tab"
+													tabIndex={reviewerActive ? 0 : -1}
+													title={tab.terminal.harness}
+													type="button"
+												>
+													<AgentAvatar className="size-icon-base" decorative provider={tab.terminal.harness} />
+													<span className="truncate">Reviewer</span>
+												</button>
+											) : tab.kind === "shell" ? (
+												<ShellTerminalTab
+													appearance="connected"
+													isActive={tab.terminal.handleId === shellActiveHandleId}
+													onClose={() => onCloseShellTerminal?.(tab.terminal.handleId)}
+													onRename={onRenameShellTerminal ? (title) => onRenameShellTerminal(tab.terminal.handleId, title) : undefined}
+													onSelect={() => onSelectShellTerminal?.(tab.terminal.handleId)}
+													shell={tab.terminal}
+												/>
+											) : (
+												tab.tab.content
+											)}
+										</DraggableChatTab>
+									))}
+								</Reorder.Group>
+								{workspaceTabActions}
 								</div>
 							</div>
 							{showLeftFade ? <div aria-hidden="true" className="session-tab-scroll-fade session-tab-scroll-fade--left" /> : null}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -195,6 +195,9 @@ export interface ChatWorkspaceProps {
 	workspaceTabs?: WorkspaceTab[];
 	workspaceTabActions?: ReactNode;
 	workspaceActiveTabKey?: string;
+	/** Session-owned order shared with the terminal UI surface. */
+	auxiliaryTabOrder?: string[];
+	onAuxiliaryTabOrderChange?: (keys: string[]) => void;
 	/** Suppress a transient stopped snapshot while a mode handoff installs Chat. */
 	controllerTransitioning?: boolean;
 	/** Freeze agent-owned Chat controls while a durable session mutation owns input. */
@@ -335,6 +338,8 @@ export function ChatWorkspace({
 	workspaceTabs,
 	workspaceTabActions,
 	workspaceActiveTabKey,
+	auxiliaryTabOrder,
+	onAuxiliaryTabOrderChange,
 	controllerTransitioning,
 	agentInputDisabled = false,
 	newWorkDisabled = false,
@@ -470,7 +475,7 @@ export function ChatWorkspace({
 	const availableTabKeys = useMemo(() => auxiliaryTabs.map((tab) => tab.key), [auxiliaryTabs]);
 	const [tabOrderBySession, setTabOrderBySession] = useState<Record<string, string[]>>({});
 	const orderedAuxiliaryTabs = useMemo(() => {
-		const preferred = tabOrderBySession[snapshot.sessionId] ?? [];
+		const preferred = auxiliaryTabOrder ?? tabOrderBySession[snapshot.sessionId] ?? [];
 		const byKey = new Map(auxiliaryTabs.map((tab) => [tab.key, tab]));
 		const ordered = preferred.flatMap((key) => {
 			const tab = byKey.get(key);
@@ -479,7 +484,7 @@ export function ChatWorkspace({
 			return [tab];
 		});
 		return [...ordered, ...byKey.values()];
-	}, [auxiliaryTabs, snapshot.sessionId, tabOrderBySession]);
+	}, [auxiliaryTabOrder, auxiliaryTabs, snapshot.sessionId, tabOrderBySession]);
 	const reorderAuxiliaryTabs = useCallback(
 		(nextKeys: string[]) => {
 			const available = new Set(availableTabKeys);
@@ -487,11 +492,23 @@ export function ChatWorkspace({
 			for (const key of availableTabKeys) {
 				if (!next.includes(key)) next.push(key);
 			}
-			setTabOrderBySession((current) => ({ ...current, [snapshot.sessionId]: next }));
+			if (onAuxiliaryTabOrderChange) onAuxiliaryTabOrderChange(next);
+			else setTabOrderBySession((current) => ({ ...current, [snapshot.sessionId]: next }));
 		},
-		[availableTabKeys, snapshot.sessionId],
+		[availableTabKeys, onAuxiliaryTabOrderChange, snapshot.sessionId],
 	);
 	useEffect(() => {
+		if (auxiliaryTabOrder) {
+			const available = new Set(availableTabKeys);
+			const next = auxiliaryTabOrder.filter((key) => available.has(key));
+			for (const key of availableTabKeys) {
+				if (!next.includes(key)) next.push(key);
+			}
+			if (!next.every((key, index) => key === auxiliaryTabOrder[index]) || next.length !== auxiliaryTabOrder.length) {
+				onAuxiliaryTabOrderChange?.(next);
+			}
+			return;
+		}
 		setTabOrderBySession((current) => {
 			const currentOrder = current[snapshot.sessionId] ?? [];
 			const available = new Set(availableTabKeys);
@@ -506,7 +523,7 @@ export function ChatWorkspace({
 			}
 			return { ...current, [snapshot.sessionId]: next };
 		});
-	}, [availableTabKeys, snapshot.sessionId]);
+	}, [auxiliaryTabOrder, availableTabKeys, onAuxiliaryTabOrderChange, snapshot.sessionId]);
 	const queuedMessages = useMemo(() => {
 		const messagesByTurn = new Map(
 			snapshot.items

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -72,6 +72,8 @@ export function SessionChatSurface({
 	workspaceTabs,
 	workspaceTabActions,
 	workspaceActiveTabKey,
+	auxiliaryTabOrder,
+	onAuxiliaryTabOrderChange,
 	controllerTransitioning,
 	newWorkDisabled,
 	onConversationWorkChange,
@@ -104,6 +106,9 @@ export function SessionChatSurface({
 	workspaceTabs?: Array<{ key: string; content: ReactNode; onSelect: () => void }>;
 	workspaceTabActions?: ReactNode;
 	workspaceActiveTabKey?: string;
+	/** Session-owned order shared with the terminal UI surface. */
+	auxiliaryTabOrder?: string[];
+	onAuxiliaryTabOrderChange?: (keys: string[]) => void;
 	/** The target controller is being installed by an interface handoff. */
 	controllerTransitioning?: boolean;
 	/** An interface handoff fences new agent work while current-turn decisions remain available. */
@@ -317,6 +322,8 @@ export function SessionChatSurface({
 				workspaceTabs={workspaceTabs}
 				workspaceTabActions={workspaceTabActions}
 				workspaceActiveTabKey={workspaceActiveTabKey}
+				auxiliaryTabOrder={auxiliaryTabOrder}
+				onAuxiliaryTabOrderChange={onAuxiliaryTabOrderChange}
 				controllerTransitioning={controllerTransitioning}
 				hasOlder={hasOlder}
 				loadingOlder={isLoadingOlder}

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -70,7 +70,8 @@ export function SessionChatSurface({
 	tabStripAction,
 	handoffDialogOpen = false,
 	workspaceTabs,
-	workspaceFileActive,
+	workspaceTabActions,
+	workspaceActiveTabKey,
 	controllerTransitioning,
 	newWorkDisabled,
 	onConversationWorkChange,
@@ -100,8 +101,9 @@ export function SessionChatSurface({
 	sessionTabAction?: ReactNode;
 	tabStripAction?: ReactNode;
 	handoffDialogOpen?: boolean;
-	workspaceTabs?: ReactNode;
-	workspaceFileActive?: boolean;
+	workspaceTabs?: Array<{ key: string; content: ReactNode; onSelect: () => void }>;
+	workspaceTabActions?: ReactNode;
+	workspaceActiveTabKey?: string;
 	/** The target controller is being installed by an interface handoff. */
 	controllerTransitioning?: boolean;
 	/** An interface handoff fences new agent work while current-turn decisions remain available. */
@@ -313,7 +315,8 @@ export function SessionChatSurface({
 				sessionTabAction={sessionTabAction}
 				tabStripAction={tabStripAction}
 				workspaceTabs={workspaceTabs}
-				workspaceFileActive={workspaceFileActive}
+				workspaceTabActions={workspaceTabActions}
+				workspaceActiveTabKey={workspaceActiveTabKey}
 				controllerTransitioning={controllerTransitioning}
 				hasOlder={hasOlder}
 				loadingOlder={isLoadingOlder}


### PR DESCRIPTION
## Summary

- unify reviewer, terminal, and file tabs in a single reorderable session strip
- preserve mixed tab order per session and append newly opened terminals after existing file tabs
- align file-tab close and feedback controls with terminal tab chrome
- render extensionless text content when no parsed diff is available and show a retryable error instead of a blank file pane

## Testing

- 
pm run frontend:typecheck
- 152 focused renderer tests covering CenterPane, SessionView, SessionFileTabs, and FileContentPane
- production Vite renderer build
- real Electron app launched from this worktree against existing AO data; tab behavior visually confirmed