### PR TITLE
fix(cloud): preserve Coder workspace state across resume

### DIFF
--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -65,6 +65,10 @@ AO_CLOUD_CODER_OWNER=ao-integration
 AO_CLOUD_CODER_TEMPLATE_ID=
 AO_CLOUD_CODER_AGENT_NAME=
 AO_CLOUD_CODER_PARAMETERS_JSON={}
+# Exact persistent-volume mount in the approved template. It must be an
+# absolute non-root mount point and survive Coder stop/start. AO stores the
+# repository, worker data, and Claude/Codex homes beneath it.
+AO_CLOUD_CODER_DURABLE_ROOT=
 AO_CLOUD_CODER_WORKER_TOKEN_TTL=
 
 # Control-plane idle pause: pauses a session's sandbox once the user has sent

--- a/cloud/cmd/ao-cloud/main.go
+++ b/cloud/cmd/ao-cloud/main.go
@@ -80,6 +80,7 @@ func provisioningDefaults(cfg config.Config) sandbox.ProvisioningDefaults {
 			TemplateID:     cfg.CoderTemplateID,
 			AgentName:      cfg.CoderAgentName,
 			Parameters:     cfg.CoderParameters,
+			DurableRoot:    cfg.CoderDurableRoot,
 			WorkerTokenTTL: cfg.CoderWorkerTokenTTL,
 		},
 	}

--- a/cloud/docs/coder-sandbox-provider.md
+++ b/cloud/docs/coder-sandbox-provider.md
@@ -43,13 +43,38 @@ Coder nor the workspace needs inbound connectivity from the AO desktop app.
 ## Template contract
 
 The approved template must create a Linux workspace with at least one
-`coder_agent`. The normal workspace user must have passwordless `sudo` for the
-pilot bootstrap. AO uses it to:
+`coder_agent` and one persistent volume mount dedicated to workspace state.
+Configure that exact mount point with `AO_CLOUD_CODER_DURABLE_ROOT`; it is not
+assumed to be `/home/coder`. The root must be an absolute, normalized, non-root
+path, must exist as a non-symlink mount point, and must survive Coder `stop` then
+`start`. The template must include the `mountpoint` utility so bootstrap can
+verify the contract before writing state.
+
+AO derives every stateful path beneath that root:
+
+| State | Path relative to the durable root |
+| --- | --- |
+| Repository and uncommitted files | `repository` |
+| AO worker token, Git helper, sockets, and logs | `.ao/worker` |
+| Worker `HOME` | `.ao/home` |
+| Claude Code configuration and conversations | `.ao/home/.claude` |
+| Codex configuration and conversations | `.ao/home/.codex` |
+| AO/Coder restore identity | `.ao/durable-session-id` |
+
+The durable root is stamped into each session's provider plan, so changing the
+deployment setting does not move existing sessions. A first bootstrap writes a
+session identity marker; a bootstrap after stop/start must find the same marker
+or it fails instead of silently launching a fresh agent against an empty
+filesystem.
+
+The normal workspace user must have passwordless `sudo` for the pilot
+bootstrap. AO uses it to:
 
 - create the unprivileged `ao-worker` OS user;
 - install the release-pinned `ao-worker` and AO helper binaries under
   `/usr/local/bin`;
-- create and assign `/workspace` to the worker user; and
+- create and assign only the derived repository and `.ao` directories to the
+  worker user; and
 - launch the worker, which then dials the AO service plane and sends its own
   heartbeats.
 
@@ -80,6 +105,7 @@ AO_CLOUD_CODER_OWNER=ao-integration
 AO_CLOUD_CODER_TEMPLATE_ID=<approved-template-uuid>
 AO_CLOUD_CODER_AGENT_NAME=<optional-agent-name>
 AO_CLOUD_CODER_PARAMETERS_JSON={"instance_type":"t3.medium","region":"us-west-2"}
+AO_CLOUD_CODER_DURABLE_ROOT=<template-persistent-volume-mount>
 AO_CLOUD_CODER_WORKER_TOKEN_TTL=15m
 ```
 
@@ -107,9 +133,30 @@ Secrets Manager JSON document (`ao-cloud/staging/coder` or
   "template_id": "<approved-template-uuid>",
   "agent_name": "",
   "parameters_json": "{}",
+  "durable_root": "/template-specific/persistent-mount",
   "worker_token_ttl": "15m"
 }
 ```
+
+Before enabling idle pause for a Coder template, run the opt-in lifecycle test
+against that exact template and root. It creates a disposable workspace, writes
+the durable session marker plus representative repository, Claude, and Codex
+state, stops and starts the workspace, requires the original marker during
+restore bootstrap, and deletes the workspace:
+
+```bash
+cd cloud
+CODER_LIVE_URL=https://coder.customer.example \
+CODER_LIVE_TOKEN=... \
+CODER_LIVE_OWNER=ao-integration \
+CODER_LIVE_TEMPLATE_ID=... \
+CODER_LIVE_DURABLE_ROOT=/template-specific/persistent-mount \
+go test ./internal/sandbox/coder -run TestLiveLifecycle -count=1 -v
+```
+
+Set `CODER_LIVE_AGENT_NAME` and `CODER_LIVE_PARAMETERS_JSON` when the approved
+template requires them. Do not treat a successful workspace start alone as a
+persistence check; the restore bootstrap is the gate.
 
 Grant the environment's ECS execution role `secretsmanager:GetSecretValue` on
 that secret, then deploy staging with `AO_CLOUD_SANDBOX_PROVIDER=coder`. The

--- a/cloud/docs/coder-sandbox-provider.md
+++ b/cloud/docs/coder-sandbox-provider.md
@@ -61,11 +61,19 @@ AO derives every stateful path beneath that root:
 | Codex configuration and conversations | `.ao/home/.codex` |
 | AO/Coder restore identity | `.ao/durable-session-id` |
 
-The durable root is stamped into each session's provider plan, so changing the
-deployment setting does not move existing sessions. A first bootstrap writes a
-session identity marker; a bootstrap after stop/start must find the same marker
-or it fails instead of silently launching a fresh agent against an empty
-filesystem.
+The owner, template ID, template parameters, selected agent, and durable root
+are stamped into each session's provider plan. Reconciliation binds the current
+deployment-scoped Coder connection credential to that stored profile, so a
+later configuration change does not move or recreate existing sessions with
+new defaults. Coder workspace responses must match the planned owner,
+deterministic workspace name, and template ID before AO adopts the workspace,
+accepts a provider ID, or uploads worker credentials. Configure
+`AO_CLOUD_CODER_OWNER` as the canonical owner name returned by Coder, not an
+alias such as `me`.
+
+A first bootstrap writes a session identity marker; a bootstrap after
+stop/start must find the same marker or it fails instead of silently launching
+a fresh agent against an empty filesystem.
 
 The normal workspace user must have passwordless `sudo` for the pilot
 bootstrap. AO uses it to:

--- a/cloud/docs/coder-sandbox-provider.md
+++ b/cloud/docs/coder-sandbox-provider.md
@@ -75,6 +75,11 @@ A first bootstrap writes a session identity marker; a bootstrap after
 stop/start must find the same marker or it fails instead of silently launching
 a fresh agent against an empty filesystem.
 
+Because the worker runs as a separate OS user, bootstrap preserves the durable
+root's existing mode bits while adding traversal-only (`o+x`) access to that
+mount point. It does not make the root listable or readable. Only the derived
+`repository` and `.ao` subdirectories are assigned to `ao-worker`.
+
 The normal workspace user must have passwordless `sudo` for the pilot
 bootstrap. AO uses it to:
 

--- a/cloud/docs/deployment.md
+++ b/cloud/docs/deployment.md
@@ -110,11 +110,14 @@ directly from its environment-scoped secret. Provider auto-pause is
 intentionally absent from this deployment configuration.
 
 `coder` is a JSON secret with `url`, `token`, `owner`, `template_id`,
-`agent_name`, `parameters_json`, and `worker_token_ttl`. `parameters_json` must
-be a JSON object whose values are strings; use `{}` when the approved template
-has no parameters. The deployment validates only the selected provider and
-removes the other provider's environment variables and secret references from
-the new task definition. The ECS execution role needs
+`agent_name`, `parameters_json`, `durable_root`, and `worker_token_ttl`.
+`durable_root` is the approved template's exact persistent-volume mount point,
+not a deployment-wide assumption about the Coder user's home. It must be an
+absolute normalized non-root path. `parameters_json` must be a JSON object whose
+values are strings; use `{}` when the approved template has no parameters. The
+deployment validates only the selected provider and removes the other
+provider's environment variables and secret references from the new task
+definition. The ECS execution role needs
 `secretsmanager:GetSecretValue` for the selected environment-scoped provider
 secret.
 

--- a/cloud/internal/config/config.go
+++ b/cloud/internal/config/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	CoderTemplateID     string
 	CoderAgentName      string
 	CoderParameters     map[string]string
+	CoderDurableRoot    string
 	CoderWorkerTokenTTL time.Duration
 
 	GitHub GitHubConfig
@@ -221,6 +222,9 @@ func Load() (Config, error) {
 		CoderTemplateID: strings.TrimSpace(os.Getenv("AO_CLOUD_CODER_TEMPLATE_ID")),
 		CoderAgentName:  strings.TrimSpace(os.Getenv("AO_CLOUD_CODER_AGENT_NAME")),
 		CoderParameters: coderParametersEnv,
+		CoderDurableRoot: strings.TrimSpace(
+			os.Getenv("AO_CLOUD_CODER_DURABLE_ROOT"),
+		),
 		CoderWorkerTokenTTL: durationEnv(
 			"AO_CLOUD_CODER_WORKER_TOKEN_TTL", sandbox.DefaultWorkerTokenTTL,
 		),
@@ -360,6 +364,7 @@ func Load() (Config, error) {
 			TemplateID:     cfg.CoderTemplateID,
 			AgentName:      cfg.CoderAgentName,
 			Parameters:     cfg.CoderParameters,
+			DurableRoot:    cfg.CoderDurableRoot,
 			WorkerTokenTTL: cfg.CoderWorkerTokenTTL,
 		}).Validate(); err != nil {
 			return Config{}, err

--- a/cloud/internal/reconcile/reconciler.go
+++ b/cloud/internal/reconcile/reconciler.go
@@ -991,9 +991,6 @@ type providerProfile struct {
 		Ingress          string `json:"ingress"`
 		AutoPauseSeconds int    `json:"autoPauseSeconds"`
 	} `json:"nodeOps"`
-	Coder struct {
-		DurableRoot string `json:"durableRoot"`
-	} `json:"coder"`
 }
 
 type workerWorkspaceLayout struct {
@@ -1015,7 +1012,11 @@ func workspaceLayout(record domain.Sandbox, profile providerProfile) (workerWork
 			codexHome:    "/workspace/.ao/home/.codex",
 		}, nil
 	}
-	coderLayout, err := sandbox.NewCoderWorkspaceLayout(profile.Coder.DurableRoot)
+	coderProfile, err := sandbox.DecodeCoderSessionProfile(record.ResourceProfile)
+	if err != nil {
+		return workerWorkspaceLayout{}, fmt.Errorf("coder workspace layout: %w", err)
+	}
+	coderLayout, err := sandbox.NewCoderWorkspaceLayout(coderProfile.DurableRoot)
 	if err != nil {
 		return workerWorkspaceLayout{}, fmt.Errorf("coder workspace layout: %w", err)
 	}
@@ -1032,10 +1033,7 @@ func workspaceLayout(record domain.Sandbox, profile providerProfile) (workerWork
 func (r *Reconciler) workerSpec(ctx context.Context, record domain.Sandbox) (sandbox.Spec, error) {
 	var profile providerProfile
 	if len(record.ResourceProfile) > 0 {
-		if err := json.Unmarshal(record.ResourceProfile, &profile); err != nil &&
-			record.Provider == sandbox.ProviderCoder {
-			return sandbox.Spec{}, fmt.Errorf("decode sandbox resource profile: %w", err)
-		}
+		_ = json.Unmarshal(record.ResourceProfile, &profile)
 	}
 	layout, err := workspaceLayout(record, profile)
 	if err != nil {

--- a/cloud/internal/reconcile/reconciler.go
+++ b/cloud/internal/reconcile/reconciler.go
@@ -713,14 +713,9 @@ func (r *Reconciler) superviseRunning(
 				"provider", record.Provider,
 				"provider_id", environment.ID,
 			)
-			if err := bootstrapper.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
-				Binary:            r.options.WorkerBinary,
-				Destination:       r.options.WorkerDestination,
-				HelperBinary:      r.options.WorkerHelperBinary,
-				HelperDestination: r.options.WorkerHelperDestination,
-				User:              r.options.WorkerUser,
-				Environment:       spec.Environment,
-			}); err != nil {
+			if err := bootstrapper.BootstrapWorker(
+				ctx, environment.ID, r.workerBootstrap(record, spec, false),
+			); err != nil {
 				return r.fail(ctx, record, err)
 			}
 			return r.observe(ctx, record, string(environment.ID),
@@ -742,14 +737,9 @@ func (r *Reconciler) superviseRunning(
 				"provider_id", environment.ID,
 				"reason", repairReason(record, startupExpired, heartbeatExpired),
 			)
-			if err := bootstrapper.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
-				Binary:            r.options.WorkerBinary,
-				Destination:       r.options.WorkerDestination,
-				HelperBinary:      r.options.WorkerHelperBinary,
-				HelperDestination: r.options.WorkerHelperDestination,
-				User:              r.options.WorkerUser,
-				Environment:       spec.Environment,
-			}); err != nil {
+			if err := bootstrapper.BootstrapWorker(
+				ctx, environment.ID, r.workerBootstrap(record, spec, false),
+			); err != nil {
 				return r.fail(ctx, record, err)
 			}
 			return r.observe(ctx, record, string(environment.ID),
@@ -792,14 +782,9 @@ func (r *Reconciler) refreshRestoredWorker(
 		"provider", record.Provider,
 		"provider_id", environment.ID,
 	)
-	if err := bootstrapper.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
-		Binary:            r.options.WorkerBinary,
-		Destination:       r.options.WorkerDestination,
-		HelperBinary:      r.options.WorkerHelperBinary,
-		HelperDestination: r.options.WorkerHelperDestination,
-		User:              r.options.WorkerUser,
-		Environment:       spec.Environment,
-	}); err != nil {
+	if err := bootstrapper.BootstrapWorker(
+		ctx, environment.ID, r.workerBootstrap(record, spec, true),
+	); err != nil {
 		return r.fail(ctx, record, err)
 	}
 	return r.observe(ctx, record, string(environment.ID),
@@ -953,14 +938,9 @@ func (r *Reconciler) provision(
 				"provider", record.Provider,
 				"provider_id", environment.ID,
 			)
-			if err := bootstrapper.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
-				Binary:            r.options.WorkerBinary,
-				Destination:       r.options.WorkerDestination,
-				HelperBinary:      r.options.WorkerHelperBinary,
-				HelperDestination: r.options.WorkerHelperDestination,
-				User:              r.options.WorkerUser,
-				Environment:       spec.Environment,
-			}); err != nil {
+			if err := bootstrapper.BootstrapWorker(
+				ctx, environment.ID, r.workerBootstrap(record, spec, false),
+			); err != nil {
 				return r.fail(ctx, record, err)
 			}
 			return r.observe(ctx, record, string(environment.ID),
@@ -992,33 +972,75 @@ func (r *Reconciler) recreate(
 		return r.fail(ctx, record, err)
 	}
 	if bootstrapper, ok := recreator.(sandbox.Bootstrapper); ok && len(r.options.WorkerBinary) > 0 {
-		if err := bootstrapper.BootstrapWorker(ctx, recreated.ID, sandbox.WorkerBootstrap{
-			Binary:            r.options.WorkerBinary,
-			Destination:       r.options.WorkerDestination,
-			HelperBinary:      r.options.WorkerHelperBinary,
-			HelperDestination: r.options.WorkerHelperDestination,
-			User:              r.options.WorkerUser,
-			Environment:       spec.Environment,
-		}); err != nil {
+		if err := bootstrapper.BootstrapWorker(
+			ctx, recreated.ID, r.workerBootstrap(record, spec, false),
+		); err != nil {
 			return r.fail(ctx, record, err)
 		}
 	}
 	return r.observe(ctx, record, string(recreated.ID), domain.SandboxObservedBootstrapping, "", 2*time.Second)
 }
 
-// nodeOpsProfile is the subset of the stored resource profile the provider
-// needs. Reading the shape from the durable row rather than from configuration
-// means a config change never disturbs an in-flight session.
-type nodeOpsProfile struct {
+// providerProfile is the subset of the stored resource profile the reconciler
+// needs. Reading it from the durable row means a configuration change never
+// moves an in-flight session onto a different template or filesystem root.
+type providerProfile struct {
 	NodeOps struct {
 		DefaultShape     string `json:"defaultShape"`
 		DefaultRootFS    string `json:"defaultRootFs"`
 		Ingress          string `json:"ingress"`
 		AutoPauseSeconds int    `json:"autoPauseSeconds"`
 	} `json:"nodeOps"`
+	Coder struct {
+		DurableRoot string `json:"durableRoot"`
+	} `json:"coder"`
+}
+
+type workerWorkspaceLayout struct {
+	root         string
+	repository   string
+	workerData   string
+	home         string
+	claudeConfig string
+	codexHome    string
+}
+
+func workspaceLayout(record domain.Sandbox, profile providerProfile) (workerWorkspaceLayout, error) {
+	if record.Provider != sandbox.ProviderCoder {
+		return workerWorkspaceLayout{
+			repository:   "/workspace/repository",
+			workerData:   "/workspace/.ao/worker",
+			home:         "/workspace/.ao/home",
+			claudeConfig: "/workspace/.ao/home/.claude",
+			codexHome:    "/workspace/.ao/home/.codex",
+		}, nil
+	}
+	coderLayout, err := sandbox.NewCoderWorkspaceLayout(profile.Coder.DurableRoot)
+	if err != nil {
+		return workerWorkspaceLayout{}, fmt.Errorf("coder workspace layout: %w", err)
+	}
+	return workerWorkspaceLayout{
+		root:         coderLayout.DurableRoot,
+		repository:   coderLayout.Repository,
+		workerData:   coderLayout.WorkerData,
+		home:         coderLayout.Home,
+		claudeConfig: coderLayout.ClaudeConfig,
+		codexHome:    coderLayout.CodexHome,
+	}, nil
 }
 
 func (r *Reconciler) workerSpec(ctx context.Context, record domain.Sandbox) (sandbox.Spec, error) {
+	var profile providerProfile
+	if len(record.ResourceProfile) > 0 {
+		if err := json.Unmarshal(record.ResourceProfile, &profile); err != nil &&
+			record.Provider == sandbox.ProviderCoder {
+			return sandbox.Spec{}, fmt.Errorf("decode sandbox resource profile: %w", err)
+		}
+	}
+	layout, err := workspaceLayout(record, profile)
+	if err != nil {
+		return sandbox.Spec{}, err
+	}
 	ticket, err := r.store.IssueAccessTicket(
 		ctx,
 		record.OrgID,
@@ -1041,19 +1063,15 @@ func (r *Reconciler) workerSpec(ctx context.Context, record domain.Sandbox) (san
 		return sandbox.Spec{}, err
 	}
 
-	var profile nodeOpsProfile
-	if len(record.ResourceProfile) > 0 {
-		_ = json.Unmarshal(record.ResourceProfile, &profile)
-	}
 	workerEnvironment := map[string]string{
 		"AO_CLOUD_PUBLIC_URL":       r.options.PublicURL,
 		"AO_CLOUD_SESSION_ID":       record.SessionID,
 		"AO_WORKER_BOOTSTRAP_TOKEN": ticket,
-		"AO_WORKSPACE_DIR":          "/workspace/repository",
-		"AO_DATA_DIR":               "/workspace/.ao/worker",
-		"HOME":                      "/workspace/.ao/home",
-		"CLAUDE_CONFIG_DIR":         "/workspace/.ao/home/.claude",
-		"CODEX_HOME":                "/workspace/.ao/home/.codex",
+		"AO_WORKSPACE_DIR":          layout.repository,
+		"AO_DATA_DIR":               layout.workerData,
+		"HOME":                      layout.home,
+		"CLAUDE_CONFIG_DIR":         layout.claudeConfig,
+		"CODEX_HOME":                layout.codexHome,
 		"DISABLE_AUTOUPDATER":       "1",
 	}
 	if record.Provider == sandbox.ProviderDocker || r.options.AllowAnonymousCheckout {
@@ -1069,6 +1087,7 @@ func (r *Reconciler) workerSpec(ctx context.Context, record domain.Sandbox) (san
 		Ingress:          profile.NodeOps.Ingress,
 		AutoPauseSeconds: profile.NodeOps.AutoPauseSeconds,
 		Environment:      workerEnvironment,
+		DurableRoot:      layout.root,
 		Labels: map[string]string{
 			"ao.session_id": record.SessionID,
 			"ao.org_id":     record.OrgID,
@@ -1076,6 +1095,26 @@ func (r *Reconciler) workerSpec(ctx context.Context, record domain.Sandbox) (san
 		},
 		AutoDeleteMinutes: 7 * 24 * 60,
 	}, nil
+}
+
+func (r *Reconciler) workerBootstrap(
+	record domain.Sandbox,
+	spec sandbox.Spec,
+	restoring bool,
+) sandbox.WorkerBootstrap {
+	requireIdentity := record.Provider == sandbox.ProviderCoder &&
+		(restoring || record.WorkerLastSeenAt != nil)
+	return sandbox.WorkerBootstrap{
+		Binary:                 r.options.WorkerBinary,
+		Destination:            r.options.WorkerDestination,
+		HelperBinary:           r.options.WorkerHelperBinary,
+		HelperDestination:      r.options.WorkerHelperDestination,
+		User:                   r.options.WorkerUser,
+		Environment:            spec.Environment,
+		DurableRoot:            spec.DurableRoot,
+		DurableIdentity:        record.SessionID,
+		RequireDurableIdentity: requireIdentity,
+	}
 }
 
 func (r *Reconciler) fail(ctx context.Context, record domain.Sandbox, cause error) error {

--- a/cloud/internal/reconcile/reconciler_test.go
+++ b/cloud/internal/reconcile/reconciler_test.go
@@ -27,7 +27,7 @@ func TestWorkerSpecUsesPersistedCoderWorkspaceLayout(t *testing.T) {
 	t.Parallel()
 	store := &workerSpecStore{}
 	reconciler := New(store, nil, Options{PublicURL: "https://cloud.example.com"})
-	profile := json.RawMessage(`{"coder":{"durableRoot":"/customer/persistent"}}`)
+	profile := json.RawMessage(`{"coder":{"owner":"planned-owner","templateId":"2a2e262c-b31c-4202-946d-a19ad45d1fd2","parameters":{"region":"us-west-2"},"durableRoot":"/customer/persistent"}}`)
 	spec, err := reconciler.workerSpec(context.Background(), domain.Sandbox{
 		SessionID: "session-1", OrgID: "org-1", Provider: sandbox.ProviderCoder,
 		ResourceProfile: profile,
@@ -75,7 +75,7 @@ func TestWorkerSpecRejectsCoderWithoutDurableContractBeforeIssuingTicket(t *test
 	_, err := reconciler.workerSpec(context.Background(), domain.Sandbox{
 		SessionID: "session-1", OrgID: "org-1", Provider: sandbox.ProviderCoder,
 	})
-	if err == nil || !strings.Contains(err.Error(), "AO_CLOUD_CODER_DURABLE_ROOT") {
+	if err == nil || !strings.Contains(err.Error(), "session resource profile") {
 		t.Fatalf("workerSpec error = %v", err)
 	}
 	if store.issued != 0 {

--- a/cloud/internal/reconcile/reconciler_test.go
+++ b/cloud/internal/reconcile/reconciler_test.go
@@ -1,0 +1,103 @@
+package reconcile
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
+	"github.com/aoagents/agent-orchestrator/cloud/internal/sandbox"
+)
+
+type workerSpecStore struct {
+	Store
+	issued int
+}
+
+func (s *workerSpecStore) IssueAccessTicket(
+	context.Context, string, string, string, []string, time.Duration,
+) (string, error) {
+	s.issued++
+	return "bootstrap-ticket", nil
+}
+
+func TestWorkerSpecUsesPersistedCoderWorkspaceLayout(t *testing.T) {
+	t.Parallel()
+	store := &workerSpecStore{}
+	reconciler := New(store, nil, Options{PublicURL: "https://cloud.example.com"})
+	profile := json.RawMessage(`{"coder":{"durableRoot":"/customer/persistent"}}`)
+	spec, err := reconciler.workerSpec(context.Background(), domain.Sandbox{
+		SessionID: "session-1", OrgID: "org-1", Provider: sandbox.ProviderCoder,
+		ResourceProfile: profile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"AO_WORKSPACE_DIR":  "/customer/persistent/repository",
+		"AO_DATA_DIR":       "/customer/persistent/.ao/worker",
+		"HOME":              "/customer/persistent/.ao/home",
+		"CLAUDE_CONFIG_DIR": "/customer/persistent/.ao/home/.claude",
+		"CODEX_HOME":        "/customer/persistent/.ao/home/.codex",
+	}
+	for key, expected := range want {
+		if spec.Environment[key] != expected {
+			t.Errorf("%s = %q, want %q", key, spec.Environment[key], expected)
+		}
+	}
+	if spec.DurableRoot != "/customer/persistent" {
+		t.Errorf("DurableRoot = %q", spec.DurableRoot)
+	}
+}
+
+func TestWorkerSpecPreservesOtherProviderWorkspaceLayout(t *testing.T) {
+	t.Parallel()
+	store := &workerSpecStore{}
+	reconciler := New(store, nil, Options{PublicURL: "https://cloud.example.com"})
+	spec, err := reconciler.workerSpec(context.Background(), domain.Sandbox{
+		SessionID: "session-1", OrgID: "org-1", Provider: sandbox.ProviderNodeOps,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Environment["AO_WORKSPACE_DIR"] != "/workspace/repository" ||
+		spec.Environment["AO_DATA_DIR"] != "/workspace/.ao/worker" || spec.DurableRoot != "" {
+		t.Fatalf("unexpected non-Coder layout: %+v", spec)
+	}
+}
+
+func TestWorkerSpecRejectsCoderWithoutDurableContractBeforeIssuingTicket(t *testing.T) {
+	t.Parallel()
+	store := &workerSpecStore{}
+	reconciler := New(store, nil, Options{PublicURL: "https://cloud.example.com"})
+	_, err := reconciler.workerSpec(context.Background(), domain.Sandbox{
+		SessionID: "session-1", OrgID: "org-1", Provider: sandbox.ProviderCoder,
+	})
+	if err == nil || !strings.Contains(err.Error(), "AO_CLOUD_CODER_DURABLE_ROOT") {
+		t.Fatalf("workerSpec error = %v", err)
+	}
+	if store.issued != 0 {
+		t.Fatalf("issued %d bootstrap tickets for an invalid layout", store.issued)
+	}
+}
+
+func TestCoderRestoreBootstrapRequiresDurableIdentity(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	reconciler := New(&workerSpecStore{}, nil, Options{})
+	record := domain.Sandbox{
+		SessionID: "session-1", Provider: sandbox.ProviderCoder, WorkerLastSeenAt: &now,
+	}
+	bootstrap := reconciler.workerBootstrap(record, sandbox.Spec{DurableRoot: "/mnt/ao"}, false)
+	if !bootstrap.RequireDurableIdentity || bootstrap.DurableIdentity != "session-1" {
+		t.Fatalf("unexpected restore bootstrap: %+v", bootstrap)
+	}
+	first := reconciler.workerBootstrap(domain.Sandbox{
+		SessionID: "session-2", Provider: sandbox.ProviderCoder,
+	}, sandbox.Spec{DurableRoot: "/mnt/ao"}, false)
+	if first.RequireDurableIdentity {
+		t.Fatal("first Coder bootstrap unexpectedly required an existing identity")
+	}
+}

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -670,13 +670,13 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 	script := "set -eu\n" +
 		"stage=$(mktemp -d)\nencoded=\"$stage/payload.b64\"\n" +
 		"trap 'code=$?; stty echo icanon 2>/dev/null || true; echo " + bootstrapFailed + ":$code' EXIT\n" +
-		"target=" + strconv.Itoa(encodedLength) + "\nexpected=0\nreceived=0\n: >\"$encoded\"\nstty -echo icanon\necho " + bootstrapReady + "\n" +
+		"target=" + strconv.Itoa(encodedLength) + "\nexpected=0\nreceived=0\n: >\"$encoded\"\nstty -echo icanon 2>/dev/null || true\necho " + bootstrapReady + "\n" +
 		"while IFS=: read -r kind sequence declared chunk; do\n" +
 		"  case \"$sequence\" in ''|*[!0-9]*) continue ;; esac\n" +
 		"  case \"$declared\" in ''|*[!0-9]*) continue ;; esac\n" +
 		"  if [ \"$kind\" = data ] && [ \"$sequence\" -eq \"$expected\" ] && [ \"${#chunk}\" -eq \"$declared\" ] && [ $((received + declared)) -le \"$target\" ]; then\n" +
 		"    printf %s \"$chunk\" >>\"$encoded\"\n    received=$((received + declared))\n    expected=$((expected + 1))\n    echo " + bootstrapUploadACK + ":$expected\n" +
-		"  elif [ \"$kind\" = done ] && [ \"$received\" -eq \"$target\" ]; then\n    echo " + bootstrapUploadDone + "\n    break\n  fi\ndone\nstty echo icanon\n" +
+		"  elif [ \"$kind\" = done ] && [ \"$received\" -eq \"$target\" ]; then\n    echo " + bootstrapUploadDone + "\n    break\n  fi\ndone\nstty echo icanon 2>/dev/null || true\n" +
 		"base64 -d \"$encoded\" | gzip -d | tar -xf - -C \"$stage\"\n" +
 		"sudo -n id -u " + shellQuote(workerUser) + " >/dev/null 2>&1 || sudo -n useradd -m " + shellQuote(workerUser) + "\n" +
 		"durable_root=" + shellQuote(layout.DurableRoot) + "\n" +

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -694,8 +694,8 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"  if sudo -n test -s " + shellQuote(workerPID) + "; then worker_pid=$(sudo -n cat " + shellQuote(workerPID) + "); fi\n" +
 		"  case \"$worker_pid\" in ''|*[!0-9]*) ;; *) if kill -0 \"$worker_pid\" 2>/dev/null; then break; fi ;; esac\n" +
 		"  worker_pid=\nattempt=$((attempt + 1))\nsleep 1\ndone\n" +
-		"case \"$worker_pid\" in ''|*[!0-9]*) echo 'AO worker did not start' >&2; exit 1 ;; esac\n" +
-		"sleep 1\nkill -0 \"$worker_pid\" 2>/dev/null || { echo 'AO worker exited during startup' >&2; exit 1; }\n" +
+		"case \"$worker_pid\" in ''|*[!0-9]*) echo 'AO worker did not start' >&2; sudo -n test ! -f " + shellQuote(workerLog) + " || sudo -n tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1 ;; esac\n" +
+		"sleep 1\nkill -0 \"$worker_pid\" 2>/dev/null || { echo 'AO worker exited during startup' >&2; sudo -n test ! -f " + shellQuote(workerLog) + " || sudo -n tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1; }\n" +
 		"rm -rf \"$stage\"\ntrap - EXIT\necho " + bootstrapOK + "\n"
 	return "sh -lc " + shellQuote(script)
 }

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -701,7 +701,7 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"sudo -n pkill -u " + shellQuote(workerUser) + " -f " + shellQuote(workerDestination) + " 2>/dev/null || true\n" +
 		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 /dev/null " + shellQuote(workerLog) + "\n" +
 		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 /dev/null " + shellQuote(workerPID) + "\n" +
-		"sudo -n -u " + shellQuote(workerUser) + " sh -c " + shellQuote("nohup "+shellQuote(workerLauncher)+" "+shellQuote(workerEnvironment)+" "+shellQuote(workerDestination)+" "+shellQuote(workerPID)+" >"+shellQuote(workerLog)+" 2>&1 </dev/null &") + "\n" +
+		"sudo -n -b -u " + shellQuote(workerUser) + " sh -c " + shellQuote("exec nohup "+shellQuote(workerLauncher)+" "+shellQuote(workerEnvironment)+" "+shellQuote(workerDestination)+" "+shellQuote(workerPID)+" >"+shellQuote(workerLog)+" 2>&1 </dev/null") + "\n" +
 		"attempt=0\nworker_pid=\nwhile [ \"$attempt\" -lt 5 ]; do\n" +
 		"  if sudo -n test -s " + shellQuote(workerPID) + "; then worker_pid=$(sudo -n cat " + shellQuote(workerPID) + "); fi\n" +
 		"  case \"$worker_pid\" in ''|*[!0-9]*) ;; *) if kill -0 \"$worker_pid\" 2>/dev/null; then break; fi ;; esac\n" +

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -599,7 +599,7 @@ func bootstrapArchive(bootstrap sandbox.WorkerBootstrap) ([]byte, error) {
 	}{
 		{name: "ao-worker", mode: 0o700, data: bootstrap.Binary},
 		{name: "worker.env", mode: 0o600, data: []byte(environmentFile(bootstrap.Environment))},
-		{name: "launch.sh", mode: 0o700, data: []byte("#!/bin/sh\nset -eu\nset -a\n. \"$1\"\nset +a\nrm -f \"$1\"\nexec \"$2\"\n")},
+		{name: "launch.sh", mode: 0o700, data: []byte("#!/bin/sh\nset -eu\nprintf '%s\\n' \"$$\" >\"$3\"\nset -a\n. \"$1\"\nset +a\nrm -f \"$1\"\nexec \"$2\"\n")},
 	}
 	if len(bootstrap.HelperBinary) > 0 {
 		files = append(files, struct {
@@ -653,6 +653,10 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 	if len(bootstrap.HelperBinary) > 0 {
 		helperInstall = "sudo -n install -m 0755 \"$stage/ao\" " + shellQuote(bootstrap.HelperDestination) + "\n"
 	}
+	workerEnvironment := path.Join(layout.WorkerData, "worker.env")
+	workerLauncher := path.Join(layout.WorkerData, "launch.sh")
+	workerLog := path.Join(layout.WorkerData, "worker.log")
+	workerPID := path.Join(layout.WorkerData, "worker.pid")
 	script := "set -eu\n" +
 		"stage=$(mktemp -d)\nencoded=\"$stage/payload.b64\"\n" +
 		"trap 'code=$?; stty echo icanon 2>/dev/null || true; echo " + bootstrapFailed + ":$code' EXIT\n" +
@@ -681,10 +685,17 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"  printf '%s\\n' " + shellQuote(strings.TrimSpace(bootstrap.DurableIdentity)) + " | sudo -n tee \"$identity_file\" >/dev/null\nfi\n" +
 		"sudo -n chown -R " + shellQuote(workerUser+":"+workerUser) + " " + shellQuote(layout.Repository) + " " + shellQuote(path.Dir(layout.WorkerData)) + "\n" +
 		"sudo -n install -m 0755 \"$stage/ao-worker\" " + shellQuote(workerDestination) + "\n" + helperInstall +
-		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 \"$stage/worker.env\" " + shellQuote(path.Join(layout.WorkerData, "worker.env")) + "\n" +
-		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0700 \"$stage/launch.sh\" " + shellQuote(path.Join(layout.WorkerData, "launch.sh")) + "\n" +
+		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 \"$stage/worker.env\" " + shellQuote(workerEnvironment) + "\n" +
+		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0700 \"$stage/launch.sh\" " + shellQuote(workerLauncher) + "\n" +
 		"sudo -n pkill -u " + shellQuote(workerUser) + " -f " + shellQuote(workerDestination) + " 2>/dev/null || true\n" +
-		"sudo -n -u " + shellQuote(workerUser) + " sh -c " + shellQuote("nohup "+shellQuote(path.Join(layout.WorkerData, "launch.sh"))+" "+shellQuote(path.Join(layout.WorkerData, "worker.env"))+" "+shellQuote(workerDestination)+" >"+shellQuote(path.Join(layout.WorkerData, "worker.log"))+" 2>&1 </dev/null &") + "\n" +
+		"sudo -n rm -f " + shellQuote(workerPID) + "\n" +
+		"sudo -n -u " + shellQuote(workerUser) + " sh -c " + shellQuote("nohup "+shellQuote(workerLauncher)+" "+shellQuote(workerEnvironment)+" "+shellQuote(workerDestination)+" "+shellQuote(workerPID)+" >"+shellQuote(workerLog)+" 2>&1 </dev/null &") + "\n" +
+		"attempt=0\nworker_pid=\nwhile [ \"$attempt\" -lt 5 ]; do\n" +
+		"  if sudo -n test -s " + shellQuote(workerPID) + "; then worker_pid=$(sudo -n cat " + shellQuote(workerPID) + "); fi\n" +
+		"  case \"$worker_pid\" in ''|*[!0-9]*) ;; *) if kill -0 \"$worker_pid\" 2>/dev/null; then break; fi ;; esac\n" +
+		"  worker_pid=\nattempt=$((attempt + 1))\nsleep 1\ndone\n" +
+		"case \"$worker_pid\" in ''|*[!0-9]*) echo 'AO worker did not start' >&2; exit 1 ;; esac\n" +
+		"sleep 1\nkill -0 \"$worker_pid\" 2>/dev/null || { echo 'AO worker exited during startup' >&2; exit 1; }\n" +
 		"rm -rf \"$stage\"\ntrap - EXIT\necho " + bootstrapOK + "\n"
 	return "sh -lc " + shellQuote(script)
 }

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -376,8 +376,18 @@ func (c *Client) bootstrapThroughPTY(ctx context.Context, ptyURL *url.URL, encod
 		}
 		sequence++
 	}
-	return sendBootstrapFrame(ctx, encoder, output,
-		fmt.Sprintf("done:%d:0:\n", sequence), bootstrapUploadDone)
+	if err := sendBootstrapFrame(ctx, encoder, output,
+		fmt.Sprintf("done:%d:0:\n", sequence), bootstrapUploadDone); err != nil {
+		return err
+	}
+	result, err := readBootstrapResult(ctx, output)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(result, bootstrapOK) {
+		return fmt.Errorf("coder: worker bootstrap failed: %s", sanitizePTYOutput(result))
+	}
+	return nil
 }
 
 func sendBootstrapFrame(
@@ -441,6 +451,15 @@ func validateBootstrap(bootstrap sandbox.WorkerBootstrap) error {
 	}
 	if !userPattern.MatchString(strings.TrimSpace(bootstrap.User)) {
 		return fmt.Errorf("coder: worker user %q is invalid", bootstrap.User)
+	}
+	if _, err := sandbox.NewCoderWorkspaceLayout(bootstrap.DurableRoot); err != nil {
+		return fmt.Errorf("coder: durable workspace root: %w", err)
+	}
+	identity := strings.TrimSpace(bootstrap.DurableIdentity)
+	if identity == "" || len(identity) > 200 || strings.IndexFunc(identity, func(character rune) bool {
+		return character < ' ' || character == 0x7f
+	}) >= 0 {
+		return errors.New("coder: durable workspace identity is invalid")
 	}
 	for key := range bootstrap.Environment {
 		if !regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(key) {
@@ -511,6 +530,11 @@ func environmentFile(environment map[string]string) string {
 func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) string {
 	workerUser := strings.TrimSpace(bootstrap.User)
 	workerDestination := strings.TrimSpace(bootstrap.Destination)
+	layout, _ := sandbox.NewCoderWorkspaceLayout(bootstrap.DurableRoot)
+	requireIdentity := "0"
+	if bootstrap.RequireDurableIdentity {
+		requireIdentity = "1"
+	}
 	helperInstall := ""
 	if len(bootstrap.HelperBinary) > 0 {
 		helperInstall = "sudo -n install -m 0755 \"$stage/ao\" " + shellQuote(bootstrap.HelperDestination) + "\n"
@@ -527,13 +551,26 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"  elif [ \"$kind\" = done ] && [ \"$received\" -eq \"$target\" ]; then\n    echo " + bootstrapUploadDone + "\n    break\n  fi\ndone\nstty echo icanon\n" +
 		"base64 -d \"$encoded\" | gzip -d | tar -xf - -C \"$stage\"\n" +
 		"sudo -n id -u " + shellQuote(workerUser) + " >/dev/null 2>&1 || sudo -n useradd -m " + shellQuote(workerUser) + "\n" +
-		"sudo -n mkdir -p /workspace/repository /workspace/.ao/worker /workspace/.ao/harness /workspace/.ao/repository-credentials\n" +
-		"sudo -n chown -R " + shellQuote(workerUser+":"+workerUser) + " /workspace\n" +
+		"durable_root=" + shellQuote(layout.DurableRoot) + "\n" +
+		"if [ ! -d \"$durable_root\" ] || [ -L \"$durable_root\" ] || ! mountpoint -q \"$durable_root\"; then\n" +
+		"  echo 'configured Coder durable root is not a mounted directory' >&2\n  exit 1\nfi\n" +
+		"sudo -n mkdir -p " + shellQuote(layout.Repository) + " " + shellQuote(layout.WorkerData) + " " +
+		shellQuote(layout.Home) + " " + shellQuote(layout.ClaudeConfig) + " " + shellQuote(layout.CodexHome) + "\n" +
+		"identity_file=" + shellQuote(layout.DurableIdentity) + "\n" +
+		"if sudo -n test -f \"$identity_file\"; then\n" +
+		"  existing_identity=$(sudo -n cat \"$identity_file\")\n" +
+		"  if [ \"$existing_identity\" != " + shellQuote(strings.TrimSpace(bootstrap.DurableIdentity)) + " ]; then\n" +
+		"    echo 'Coder durable root belongs to a different AO session' >&2\n    exit 1\n  fi\n" +
+		"elif [ " + requireIdentity + " -eq 1 ]; then\n" +
+		"  echo 'Coder durable state did not survive workspace stop/start' >&2\n  exit 1\n" +
+		"else\n" +
+		"  printf '%s\\n' " + shellQuote(strings.TrimSpace(bootstrap.DurableIdentity)) + " | sudo -n tee \"$identity_file\" >/dev/null\nfi\n" +
+		"sudo -n chown -R " + shellQuote(workerUser+":"+workerUser) + " " + shellQuote(layout.Repository) + " " + shellQuote(path.Dir(layout.WorkerData)) + "\n" +
 		"sudo -n install -m 0755 \"$stage/ao-worker\" " + shellQuote(workerDestination) + "\n" + helperInstall +
-		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 \"$stage/worker.env\" /workspace/.ao/worker/worker.env\n" +
-		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0700 \"$stage/launch.sh\" /workspace/.ao/worker/launch.sh\n" +
+		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 \"$stage/worker.env\" " + shellQuote(path.Join(layout.WorkerData, "worker.env")) + "\n" +
+		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0700 \"$stage/launch.sh\" " + shellQuote(path.Join(layout.WorkerData, "launch.sh")) + "\n" +
 		"sudo -n pkill -u " + shellQuote(workerUser) + " -f " + shellQuote(workerDestination) + " 2>/dev/null || true\n" +
-		"sudo -n -u " + shellQuote(workerUser) + " sh -c " + shellQuote("nohup /workspace/.ao/worker/launch.sh /workspace/.ao/worker/worker.env "+shellQuote(workerDestination)+" >/workspace/.ao/worker/worker.log 2>&1 </dev/null &") + "\n" +
+		"sudo -n -u " + shellQuote(workerUser) + " sh -c " + shellQuote("nohup "+shellQuote(path.Join(layout.WorkerData, "launch.sh"))+" "+shellQuote(path.Join(layout.WorkerData, "worker.env"))+" "+shellQuote(workerDestination)+" >"+shellQuote(path.Join(layout.WorkerData, "worker.log"))+" 2>&1 </dev/null &") + "\n" +
 		"rm -rf \"$stage\"\ntrap - EXIT\necho " + bootstrapOK + "\n"
 	return "sh -lc " + shellQuote(script)
 }

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -58,13 +58,14 @@ type Config struct {
 
 // Client manages AO-owned workspaces through one dedicated Coder user.
 type Client struct {
-	baseURL    string
-	token      string
-	owner      string
-	templateID string
-	agentName  string
-	parameters map[string]string
-	http       *http.Client
+	baseURL               string
+	token                 string
+	owner                 string
+	templateID            string
+	agentName             string
+	parameters            map[string]string
+	expectedWorkspaceName string
+	http                  *http.Client
 }
 
 var (
@@ -86,7 +87,8 @@ func New(config Config) (*Client, error) {
 	if strings.TrimSpace(config.Owner) == "" {
 		return nil, errors.New("coder: workspace owner is required")
 	}
-	if _, err := uuid.Parse(strings.TrimSpace(config.TemplateID)); err != nil {
+	templateID, err := uuid.Parse(strings.TrimSpace(config.TemplateID))
+	if err != nil {
 		return nil, errors.New("coder: template ID must be a UUID")
 	}
 	httpClient := config.HTTPClient
@@ -105,11 +107,39 @@ func New(config Config) (*Client, error) {
 		baseURL:    strings.TrimRight(endpoint.String(), "/"),
 		token:      strings.TrimSpace(config.Token),
 		owner:      strings.TrimSpace(config.Owner),
-		templateID: strings.TrimSpace(config.TemplateID),
+		templateID: templateID.String(),
 		agentName:  strings.TrimSpace(config.AgentName),
 		parameters: parameters,
 		http:       httpClient,
 	}, nil
+}
+
+// ForSandbox binds the deployment-scoped connection credential to the
+// non-secret Coder contract stored on one session. The returned client is safe
+// to use only for that session's deterministic workspace identity.
+func (c *Client) ForSandbox(record domain.Sandbox) (sandbox.Provider, error) {
+	if strings.TrimSpace(record.SessionID) == "" {
+		return nil, errors.New("coder: durable session ID is required")
+	}
+	profile, err := sandbox.DecodeCoderSessionProfile(record.ResourceProfile)
+	if err != nil {
+		return nil, fmt.Errorf("coder: resolve durable session profile: %w", err)
+	}
+	templateID, err := uuid.Parse(profile.TemplateID)
+	if err != nil {
+		return nil, errors.New("coder: durable session template ID must be a UUID")
+	}
+	parameters := make(map[string]string, len(profile.Parameters))
+	for name, value := range profile.Parameters {
+		parameters[name] = value
+	}
+	sessionClient := *c
+	sessionClient.owner = profile.Owner
+	sessionClient.templateID = templateID.String()
+	sessionClient.agentName = profile.AgentName
+	sessionClient.parameters = parameters
+	sessionClient.expectedWorkspaceName = WorkspaceName(record.SessionID)
+	return &sessionClient, nil
 }
 
 type workspace struct {
@@ -169,6 +199,12 @@ func (c *Client) Create(ctx context.Context, spec sandbox.Spec) (sandbox.Environ
 	if name == "" {
 		return sandbox.Environment{}, errors.New("coder: workspace name is required")
 	}
+	if c.expectedWorkspaceName != "" && name != c.expectedWorkspaceName {
+		return sandbox.Environment{}, fmt.Errorf(
+			"coder: session workspace name mismatch: got %q, want %q",
+			name, c.expectedWorkspaceName,
+		)
+	}
 	parameterNames := make([]string, 0, len(c.parameters))
 	for parameterName := range c.parameters {
 		parameterNames = append(parameterNames, parameterName)
@@ -186,6 +222,9 @@ func (c *Client) Create(ctx context.Context, spec sandbox.Spec) (sandbox.Environ
 	if err := c.do(ctx, http.MethodPost, "/api/v2/users/"+url.PathEscape(c.owner)+"/workspaces", body, &view); err != nil {
 		return sandbox.Environment{}, err
 	}
+	if err := c.validateWorkspaceIdentity(view, name); err != nil {
+		return sandbox.Environment{}, err
+	}
 	return c.toEnvironment(view), nil
 }
 
@@ -195,15 +234,27 @@ func (c *Client) Get(ctx context.Context, id sandbox.ID) (sandbox.Environment, e
 	if err := c.do(ctx, http.MethodGet, "/api/v2/workspaces/"+url.PathEscape(string(id)), nil, &view); err != nil {
 		return sandbox.Environment{}, err
 	}
+	if c.expectedWorkspaceName != "" {
+		if err := c.validateWorkspaceIdentity(view, c.expectedWorkspaceName); err != nil {
+			return sandbox.Environment{}, err
+		}
+	}
 	return c.toEnvironment(view), nil
 }
 
 // FindBySession recovers a workspace after a control-plane crash between
 // provider creation and persistence of the returned Coder workspace ID.
 func (c *Client) FindBySession(ctx context.Context, sessionID string) (sandbox.Environment, bool, error) {
+	expectedName := WorkspaceName(sessionID)
+	if c.expectedWorkspaceName != "" && expectedName != c.expectedWorkspaceName {
+		return sandbox.Environment{}, false, fmt.Errorf(
+			"coder: session workspace name mismatch: got %q, want %q",
+			expectedName, c.expectedWorkspaceName,
+		)
+	}
 	var view workspace
 	requestPath := "/api/v2/users/" + url.PathEscape(c.owner) + "/workspace/" +
-		url.PathEscape(WorkspaceName(sessionID))
+		url.PathEscape(expectedName)
 	err := c.do(ctx, http.MethodGet, requestPath, nil, &view)
 	if errors.Is(err, sandbox.ErrNotFound) {
 		return sandbox.Environment{}, false, nil
@@ -211,10 +262,32 @@ func (c *Client) FindBySession(ctx context.Context, sessionID string) (sandbox.E
 	if err != nil {
 		return sandbox.Environment{}, false, err
 	}
+	if err := c.validateWorkspaceIdentity(view, expectedName); err != nil {
+		return sandbox.Environment{}, false, err
+	}
 	if normalizeState(view.LatestBuild.Status) == sandbox.StateDeleted {
 		return sandbox.Environment{}, false, nil
 	}
 	return c.toEnvironment(view), true, nil
+}
+
+func (c *Client) validateWorkspaceIdentity(view workspace, expectedName string) error {
+	if view.Name != expectedName {
+		return fmt.Errorf(
+			"coder: workspace name mismatch: got %q, want %q", view.Name, expectedName,
+		)
+	}
+	if view.OwnerName != c.owner {
+		return fmt.Errorf(
+			"coder: workspace owner mismatch: got %q, want %q", view.OwnerName, c.owner,
+		)
+	}
+	if view.TemplateID != c.templateID {
+		return fmt.Errorf(
+			"coder: workspace template mismatch: got %q, want %q", view.TemplateID, c.templateID,
+		)
+	}
+	return nil
 }
 
 func (c *Client) Start(ctx context.Context, id sandbox.ID) error {
@@ -295,6 +368,13 @@ func (c *Client) BootstrapWorker(ctx context.Context, id sandbox.ID, bootstrap s
 	}
 	var view workspace
 	if err := c.do(ctx, http.MethodGet, "/api/v2/workspaces/"+url.PathEscape(string(id)), nil, &view); err != nil {
+		return err
+	}
+	expectedName := c.expectedWorkspaceName
+	if expectedName == "" {
+		expectedName = WorkspaceName(bootstrap.DurableIdentity)
+	}
+	if err := c.validateWorkspaceIdentity(view, expectedName); err != nil {
 		return err
 	}
 	agent, ok := c.selectAgent(view)

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -704,10 +704,10 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"sudo -n -b -u " + shellQuote(workerUser) + " sh -c " + shellQuote("exec nohup "+shellQuote(workerLauncher)+" "+shellQuote(workerEnvironment)+" "+shellQuote(workerDestination)+" "+shellQuote(workerPID)+" >"+shellQuote(workerLog)+" 2>&1 </dev/null") + "\n" +
 		"attempt=0\nworker_pid=\nwhile [ \"$attempt\" -lt 5 ]; do\n" +
 		"  if sudo -n test -s " + shellQuote(workerPID) + "; then worker_pid=$(sudo -n cat " + shellQuote(workerPID) + "); fi\n" +
-		"  case \"$worker_pid\" in ''|*[!0-9]*) ;; *) if kill -0 \"$worker_pid\" 2>/dev/null; then break; fi ;; esac\n" +
+		"  case \"$worker_pid\" in ''|*[!0-9]*) ;; *) if sudo -n -u " + shellQuote(workerUser) + " kill -0 \"$worker_pid\" 2>/dev/null; then break; fi ;; esac\n" +
 		"  worker_pid=\nattempt=$((attempt + 1))\nsleep 1\ndone\n" +
-		"case \"$worker_pid\" in ''|*[!0-9]*) echo 'AO worker did not start' >&2; sudo -n test ! -f " + shellQuote(workerLog) + " || sudo -n tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1 ;; esac\n" +
-		"sleep 1\nkill -0 \"$worker_pid\" 2>/dev/null || { echo 'AO worker exited during startup' >&2; sudo -n test ! -f " + shellQuote(workerLog) + " || sudo -n tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1; }\n" +
+		"case \"$worker_pid\" in ''|*[!0-9]*) echo 'AO worker did not start' >&2; sudo -n -u " + shellQuote(workerUser) + " test ! -f " + shellQuote(workerLog) + " || sudo -n -u " + shellQuote(workerUser) + " tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1 ;; esac\n" +
+		"sleep 1\nsudo -n -u " + shellQuote(workerUser) + " kill -0 \"$worker_pid\" 2>/dev/null || { echo 'AO worker exited during startup' >&2; sudo -n -u " + shellQuote(workerUser) + " test ! -f " + shellQuote(workerLog) + " || sudo -n -u " + shellQuote(workerUser) + " tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1; }\n" +
 		"rm -rf \"$stage\"\ntrap - EXIT\necho " + bootstrapOK + "\n"
 	return "sh -lc " + shellQuote(script)
 }

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -682,6 +682,7 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"durable_root=" + shellQuote(layout.DurableRoot) + "\n" +
 		"if [ ! -d \"$durable_root\" ] || [ -L \"$durable_root\" ] || ! mountpoint -q \"$durable_root\"; then\n" +
 		"  echo 'configured Coder durable root is not a mounted directory' >&2\n  exit 1\nfi\n" +
+		"sudo -n chmod o+x \"$durable_root\"\n" +
 		"sudo -n mkdir -p " + shellQuote(layout.Repository) + " " + shellQuote(layout.WorkerData) + " " +
 		shellQuote(layout.Home) + " " + shellQuote(layout.ClaudeConfig) + " " + shellQuote(layout.CodexHome) + "\n" +
 		"identity_file=" + shellQuote(layout.DurableIdentity) + "\n" +

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -706,8 +706,8 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"  if sudo -n test -s " + shellQuote(workerPID) + "; then worker_pid=$(sudo -n cat " + shellQuote(workerPID) + "); fi\n" +
 		"  case \"$worker_pid\" in ''|*[!0-9]*) ;; *) if sudo -n -u " + shellQuote(workerUser) + " kill -0 \"$worker_pid\" 2>/dev/null; then break; fi ;; esac\n" +
 		"  worker_pid=\nattempt=$((attempt + 1))\nsleep 1\ndone\n" +
-		"case \"$worker_pid\" in ''|*[!0-9]*) echo 'AO worker did not start' >&2; sudo -n -u " + shellQuote(workerUser) + " test ! -f " + shellQuote(workerLog) + " || sudo -n -u " + shellQuote(workerUser) + " tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1 ;; esac\n" +
-		"sleep 1\nsudo -n -u " + shellQuote(workerUser) + " kill -0 \"$worker_pid\" 2>/dev/null || { echo 'AO worker exited during startup' >&2; sudo -n -u " + shellQuote(workerUser) + " test ! -f " + shellQuote(workerLog) + " || sudo -n -u " + shellQuote(workerUser) + " tail -c 2048 " + shellQuote(workerLog) + " >&2; exit 1; }\n" +
+		"case \"$worker_pid\" in ''|*[!0-9]*) echo 'AO worker did not start' >&2; exit 1 ;; esac\n" +
+		"sleep 1\nsudo -n -u " + shellQuote(workerUser) + " kill -0 \"$worker_pid\" 2>/dev/null || { echo 'AO worker exited during startup' >&2; exit 1; }\n" +
 		"rm -rf \"$stage\"\ntrap - EXIT\necho " + bootstrapOK + "\n"
 	return "sh -lc " + shellQuote(script)
 }

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -400,8 +400,9 @@ func (c *Client) BootstrapWorker(ctx context.Context, id sandbox.ID, bootstrap s
 	// preserves the final result after the upload while AO keeps the PTY open.
 	query.Set("backend_type", "buffered")
 	ptyURL.RawQuery = query.Encode()
+	const bootstrapAttempts = 5
 	var lastErr error
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := 0; attempt < bootstrapAttempts; attempt++ {
 		if err := c.bootstrapThroughPTY(ctx, ptyURL, encoded); err == nil {
 			return nil
 		} else {
@@ -409,6 +410,15 @@ func (c *Client) BootstrapWorker(ctx context.Context, id sandbox.ID, bootstrap s
 		}
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+		if attempt+1 < bootstrapAttempts {
+			timer := time.NewTimer(time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
 		}
 	}
 	return fmt.Errorf("coder: bootstrap worker after PTY retries: %w", lastErr)

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -688,7 +688,8 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 \"$stage/worker.env\" " + shellQuote(workerEnvironment) + "\n" +
 		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0700 \"$stage/launch.sh\" " + shellQuote(workerLauncher) + "\n" +
 		"sudo -n pkill -u " + shellQuote(workerUser) + " -f " + shellQuote(workerDestination) + " 2>/dev/null || true\n" +
-		"sudo -n rm -f " + shellQuote(workerPID) + "\n" +
+		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 /dev/null " + shellQuote(workerLog) + "\n" +
+		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 /dev/null " + shellQuote(workerPID) + "\n" +
 		"sudo -n -u " + shellQuote(workerUser) + " sh -c " + shellQuote("nohup "+shellQuote(workerLauncher)+" "+shellQuote(workerEnvironment)+" "+shellQuote(workerDestination)+" "+shellQuote(workerPID)+" >"+shellQuote(workerLog)+" 2>&1 </dev/null &") + "\n" +
 		"attempt=0\nworker_pid=\nwhile [ \"$attempt\" -lt 5 ]; do\n" +
 		"  if sudo -n test -s " + shellQuote(workerPID) + "; then worker_pid=$(sudo -n cat " + shellQuote(workerPID) + "); fi\n" +

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -37,6 +37,7 @@ const (
 	maxErrorBody        = 64 << 10
 	maxPTYOutput        = 1 << 20
 	workspaceNamePrefix = "ao-"
+	bootstrapReady      = "__AO_BOOTSTRAP_READY__"
 	bootstrapOK         = "__AO_BOOTSTRAP_OK__"
 	bootstrapFailed     = "__AO_BOOTSTRAP_FAILED__"
 	bootstrapUploadACK  = "__AO_UPLOAD_ACK__"
@@ -441,6 +442,9 @@ func (c *Client) bootstrapThroughPTY(ctx context.Context, ptyURL *url.URL, encod
 		<-outputDone
 	}()
 
+	if err := waitForBootstrapReady(ctx, output); err != nil {
+		return err
+	}
 	encoder := json.NewEncoder(netConn)
 	// Coder's reconnecting PTY writes each decoded Data field to the OS PTY but
 	// does not retry a short write. Frame the archive as canonical terminal lines
@@ -472,6 +476,32 @@ func (c *Client) bootstrapThroughPTY(ctx context.Context, ptyURL *url.URL, encod
 		return nil
 	}
 	return fmt.Errorf("coder: worker bootstrap failed: %s", sanitizePTYOutput(result))
+}
+
+func waitForBootstrapReady(ctx context.Context, output <-chan ptyOutput) error {
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return errors.New("coder: workspace PTY did not become ready for worker upload")
+		case response, ok := <-output:
+			if !ok {
+				return errors.New("coder: workspace PTY closed before worker upload was ready")
+			}
+			if strings.Contains(response.data, bootstrapReady) {
+				return nil
+			}
+			if strings.Contains(response.data, bootstrapFailed) {
+				return fmt.Errorf("coder: worker bootstrap failed before upload: %s", sanitizePTYOutput(response.data))
+			}
+			if response.err != nil {
+				return fmt.Errorf("coder: read workspace PTY before worker upload: %w", response.err)
+			}
+		}
+	}
 }
 
 func sendBootstrapFrame(
@@ -626,7 +656,7 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 	script := "set -eu\n" +
 		"stage=$(mktemp -d)\nencoded=\"$stage/payload.b64\"\n" +
 		"trap 'code=$?; stty echo icanon 2>/dev/null || true; echo " + bootstrapFailed + ":$code' EXIT\n" +
-		"target=" + strconv.Itoa(encodedLength) + "\nexpected=0\nreceived=0\n: >\"$encoded\"\nstty -echo icanon\n" +
+		"target=" + strconv.Itoa(encodedLength) + "\nexpected=0\nreceived=0\n: >\"$encoded\"\nstty -echo icanon\necho " + bootstrapReady + "\n" +
 		"while IFS=: read -r kind sequence declared chunk; do\n" +
 		"  case \"$sequence\" in ''|*[!0-9]*) continue ;; esac\n" +
 		"  case \"$declared\" in ''|*[!0-9]*) continue ;; esac\n" +

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
 	"github.com/aoagents/agent-orchestrator/cloud/internal/sandbox"
 	"github.com/coder/websocket"
 )
@@ -292,6 +293,123 @@ func TestNewRejectsUnsafeConfiguration(t *testing.T) {
 	}
 }
 
+func TestForSandboxUsesDurableSessionProfile(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, "https://coder.example.com", map[string]string{"source": "deployment"})
+	provider, err := client.ForSandbox(domain.Sandbox{
+		SessionID:       "session-1",
+		ResourceProfile: json.RawMessage(`{"coder":{"owner":"planned-owner","templateId":"2a2e262c-b31c-4202-946d-a19ad45d1fd2","agentName":"planned-agent","parameters":{"source":"session"},"durableRoot":"/persistent/coder"}}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	scoped := provider.(*Client)
+	if scoped == client {
+		t.Fatal("ForSandbox returned the deployment singleton")
+	}
+	if scoped.owner != "planned-owner" || scoped.templateID != testTemplateID ||
+		scoped.agentName != "planned-agent" || scoped.parameters["source"] != "session" ||
+		scoped.expectedWorkspaceName != WorkspaceName("session-1") {
+		t.Fatalf("unexpected scoped client: %+v", scoped)
+	}
+	if client.owner != "ao-integration" || client.parameters["source"] != "deployment" {
+		t.Fatal("ForSandbox mutated the deployment client")
+	}
+}
+
+func TestScopedCreateUsesDurableOwnerTemplateAndParameters(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v2/users/planned-owner/workspaces" {
+			http.Error(writer, "unexpected route", http.StatusNotFound)
+			return
+		}
+		var body createWorkspaceRequest
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Errorf("decode create request: %v", err)
+		}
+		if body.TemplateID != testTemplateID || body.Name != WorkspaceName("session-1") ||
+			len(body.RichParameterValues) != 1 || body.RichParameterValues[0] != (buildParameter{Name: "source", Value: "session"}) {
+			t.Errorf("create request did not use durable profile: %+v", body)
+		}
+		view := healthyWorkspace()
+		view.OwnerName = "planned-owner"
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(view)
+	}))
+	defer server.Close()
+	client := scopedTestClient(t, server.URL)
+	if _, err := client.Create(context.Background(), sandbox.Spec{SessionID: "session-1"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFindBySessionRejectsWorkspaceIdentityMismatch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*workspace)
+		want   string
+	}{
+		{name: "name", mutate: func(view *workspace) { view.Name = "ao-other" }, want: "workspace name mismatch"},
+		{name: "owner", mutate: func(view *workspace) { view.OwnerName = "other-owner" }, want: "workspace owner mismatch"},
+		{name: "template", mutate: func(view *workspace) { view.TemplateID = "a4ecb7eb-58dc-438f-8fb8-3787236dd43d" }, want: "workspace template mismatch"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				view := healthyWorkspace()
+				view.OwnerName = "planned-owner"
+				test.mutate(&view)
+				writer.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(writer).Encode(view); err != nil {
+					t.Errorf("write workspace: %v", err)
+				}
+			}))
+			defer server.Close()
+			client := scopedTestClient(t, server.URL)
+			_, found, err := client.FindBySession(context.Background(), "session-1")
+			if err == nil || !strings.Contains(err.Error(), test.want) || found {
+				t.Fatalf("FindBySession = found %t, error %v", found, err)
+			}
+		})
+	}
+}
+
+func TestBootstrapRejectsWorkspaceMismatchBeforePTYUpload(t *testing.T) {
+	t.Parallel()
+	ptyCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v2/workspaces/"+testWorkspaceID:
+			view := healthyWorkspace()
+			view.OwnerName = "planned-owner"
+			view.TemplateID = "a4ecb7eb-58dc-438f-8fb8-3787236dd43d"
+			writer.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(writer).Encode(view)
+		case strings.Contains(request.URL.Path, "/pty"):
+			ptyCalls++
+			http.Error(writer, "must not upload", http.StatusInternalServerError)
+		default:
+			http.Error(writer, "unexpected route", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	client := scopedTestClient(t, server.URL)
+	err := client.BootstrapWorker(context.Background(), testWorkspaceID, sandbox.WorkerBootstrap{
+		Binary: []byte("worker"), Destination: "/usr/local/bin/ao-worker", User: "ao-worker",
+		DurableRoot: "/mnt/ao", DurableIdentity: "session-1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "workspace template mismatch") {
+		t.Fatalf("BootstrapWorker error = %v", err)
+	}
+	if ptyCalls != 0 {
+		t.Fatalf("opened %d PTYs for a mismatched workspace", ptyCalls)
+	}
+}
+
 func TestValidateBootstrapRejectsUnsafeDurableContract(t *testing.T) {
 	t.Parallel()
 	base := sandbox.WorkerBootstrap{
@@ -383,18 +501,40 @@ func newTestClient(t *testing.T, baseURL string, parameters map[string]string) *
 	return client
 }
 
+func scopedTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	base := newTestClient(t, baseURL, map[string]string{"source": "deployment"})
+	provider, err := base.ForSandbox(domain.Sandbox{
+		SessionID:       "session-1",
+		ResourceProfile: json.RawMessage(`{"coder":{"owner":"planned-owner","templateId":"2a2e262c-b31c-4202-946d-a19ad45d1fd2","agentName":"dev","parameters":{"source":"session"},"durableRoot":"/persistent/coder"}}`),
+	})
+	if err != nil {
+		t.Fatalf("scope client: %v", err)
+	}
+	return provider.(*Client)
+}
+
 func writeWorkspace(t *testing.T, writer http.ResponseWriter, status, agentStatus string, healthy bool) {
 	t.Helper()
 	writer.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(writer).Encode(workspace{
-		ID: testWorkspaceID, Name: "ao-test", OwnerName: "ao-integration", TemplateID: testTemplateID,
-		Health: workspaceHealth{Healthy: healthy},
-		LatestBuild: workspaceBuild{Status: status, Resources: []workspaceResource{{Agents: []workspaceAgent{{
-			ID: testAgentID, Name: "dev", Status: agentStatus, LifecycleState: "ready",
-			Health: workspaceHealth{Healthy: healthy},
-		}}}}},
-	}); err != nil {
+	view := healthyWorkspace()
+	view.LatestBuild.Status = status
+	view.LatestBuild.Resources[0].Agents[0].Status = agentStatus
+	view.LatestBuild.Resources[0].Agents[0].Health.Healthy = healthy
+	view.Health.Healthy = healthy
+	if err := json.NewEncoder(writer).Encode(view); err != nil {
 		t.Errorf("write workspace: %v", err)
+	}
+}
+
+func healthyWorkspace() workspace {
+	return workspace{
+		ID: testWorkspaceID, Name: WorkspaceName("session-1"), OwnerName: "ao-integration", TemplateID: testTemplateID,
+		Health: workspaceHealth{Healthy: true},
+		LatestBuild: workspaceBuild{Status: "running", Resources: []workspaceResource{{Agents: []workspaceAgent{{
+			ID: testAgentID, Name: "dev", Status: "connected", LifecycleState: "ready",
+			Health: workspaceHealth{Healthy: true},
+		}}}}},
 	}
 }
 

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -324,6 +324,57 @@ func TestBootstrapWorkerPropagatesPostUploadFailure(t *testing.T) {
 	}
 }
 
+func TestBootstrapWorkerRetriesPTYBeforeReady(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		attempts int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/workspaces/" + testWorkspaceID:
+			writeWorkspace(t, writer, "running", "connected", true)
+		case "/api/v2/workspaceagents/" + testAgentID + "/pty":
+			mu.Lock()
+			attempts++
+			attempt := attempts
+			mu.Unlock()
+			if attempt < 3 {
+				connection, err := websocket.Accept(writer, request, nil)
+				if err != nil {
+					t.Errorf("accept websocket: %v", err)
+					return
+				}
+				_ = connection.Close(websocket.StatusNormalClosure, "")
+				return
+			}
+			serveBootstrapPTY(t, writer, request, func(_ *websocket.Conn, output io.Writer) {
+				_, _ = io.WriteString(output, bootstrapOK+"\r\n")
+			})
+		default:
+			http.Error(writer, "unexpected route", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	client := newTestClient(t, server.URL, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.BootstrapWorker(ctx, testWorkspaceID, sandbox.WorkerBootstrap{
+		Binary: []byte("worker-binary"), Destination: "/usr/local/bin/ao-worker",
+		User: "ao-worker", DurableRoot: "/mnt/ao", DurableIdentity: "session-1",
+	})
+	if err != nil {
+		t.Fatalf("bootstrap after transient PTY closes: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts != 3 {
+		t.Fatalf("PTY attempts = %d, want 3", attempts)
+	}
+}
+
 func TestBootstrapThroughPTYRejectsPrematureClose(t *testing.T) {
 	t.Parallel()
 

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -191,6 +191,8 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 				"/mnt/ao/.ao/home/.codex",
 				"mountpoint -q",
 				"/mnt/ao/.ao/durable-session-id",
+				"/mnt/ao/.ao/worker/worker.pid",
+				"kill -0",
 			} {
 				if !strings.Contains(command, expected) {
 					t.Errorf("bootstrap command missing durable path contract %q", expected)
@@ -284,6 +286,9 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 	}
 	if !strings.Contains(files["worker.env"], secret) {
 		t.Fatalf("worker environment missing from archive")
+	}
+	if !strings.Contains(files["launch.sh"], `>"$3"`) {
+		t.Fatalf("worker launcher does not publish its process ID: %q", files["launch.sh"])
 	}
 	if err := <-bootstrapResult; err != nil {
 		t.Fatalf("bootstrap: %v", err)

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -194,6 +194,7 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 				"/mnt/ao/.ao/worker/worker.pid",
 				"kill -0",
 				"chmod o+x",
+				"sudo -n -b -u",
 			} {
 				if !strings.Contains(command, expected) {
 					t.Errorf("bootstrap command missing durable path contract %q", expected)

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -294,6 +295,28 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 	}
 	if err := <-bootstrapResult; err != nil {
 		t.Fatalf("bootstrap: %v", err)
+	}
+}
+
+func TestBootstrapCommandRunsThroughUploadWithPipedInput(t *testing.T) {
+	t.Parallel()
+
+	command := bootstrapCommand(sandbox.WorkerBootstrap{
+		Destination: "/usr/local/bin/ao-worker", User: "ao-worker",
+		DurableRoot: "/mnt/ao", DurableIdentity: "session-1",
+	}, 0)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	process := exec.CommandContext(ctx, "sh", "-c", command)
+	process.Stdin = strings.NewReader("done:0:0:\n")
+	output, err := process.CombinedOutput()
+	if err == nil {
+		t.Fatal("empty bootstrap payload unexpectedly succeeded")
+	}
+	for _, marker := range []string{bootstrapReady, bootstrapUploadDone, bootstrapFailed} {
+		if !strings.Contains(string(output), marker) {
+			t.Fatalf("bootstrap output %q missing %s", output, marker)
+		}
 	}
 }
 

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -182,6 +183,18 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 				t.Errorf("PTY backend_type = %q, want buffered", got)
 			}
 			command := request.URL.Query().Get("command")
+			for _, expected := range []string{
+				"/mnt/ao/repository",
+				"/mnt/ao/.ao/worker",
+				"/mnt/ao/.ao/home/.claude",
+				"/mnt/ao/.ao/home/.codex",
+				"mountpoint -q",
+				"/mnt/ao/.ao/durable-session-id",
+			} {
+				if !strings.Contains(command, expected) {
+					t.Errorf("bootstrap command missing durable path contract %q", expected)
+				}
+			}
 			match := regexp.MustCompile(`target=([0-9]+)`).FindStringSubmatch(command)
 			if len(match) != 2 {
 				t.Errorf("bootstrap command did not include payload length")
@@ -250,6 +263,7 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 		Binary: []byte("worker-binary"), Destination: "/usr/local/bin/ao-worker",
 		HelperBinary: []byte("helper-binary"), HelperDestination: "/usr/local/bin/ao",
 		User: "ao-worker", Environment: map[string]string{"AO_WORKER_TOKEN": secret},
+		DurableRoot: "/mnt/ao", DurableIdentity: "session-1",
 	})
 	if err != nil {
 		t.Fatalf("bootstrap: %v", err)
@@ -275,6 +289,73 @@ func TestNewRejectsUnsafeConfiguration(t *testing.T) {
 		if _, err := New(config); err == nil {
 			t.Fatalf("New(%+v) succeeded", config)
 		}
+	}
+}
+
+func TestValidateBootstrapRejectsUnsafeDurableContract(t *testing.T) {
+	t.Parallel()
+	base := sandbox.WorkerBootstrap{
+		Binary: []byte("worker"), Destination: "/usr/local/bin/ao-worker",
+		User: "ao-worker", DurableRoot: "/mnt/ao", DurableIdentity: "session-1",
+	}
+	tests := []struct {
+		name   string
+		mutate func(*sandbox.WorkerBootstrap)
+	}{
+		{name: "missing root", mutate: func(value *sandbox.WorkerBootstrap) { value.DurableRoot = "" }},
+		{name: "root filesystem", mutate: func(value *sandbox.WorkerBootstrap) { value.DurableRoot = "/" }},
+		{name: "unclean root", mutate: func(value *sandbox.WorkerBootstrap) { value.DurableRoot = "/mnt/../ao" }},
+		{name: "missing identity", mutate: func(value *sandbox.WorkerBootstrap) { value.DurableIdentity = "" }},
+		{name: "identity control", mutate: func(value *sandbox.WorkerBootstrap) { value.DurableIdentity = "bad\nidentity" }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			value := base
+			test.mutate(&value)
+			if err := validateBootstrap(value); err == nil {
+				t.Fatal("validateBootstrap succeeded")
+			}
+		})
+	}
+}
+
+func TestBootstrapThroughPTYReportsFailureAfterUpload(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(writer, request, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer connection.CloseNow()
+		netConnection := websocket.NetConn(context.Background(), connection, websocket.MessageBinary)
+		defer netConnection.Close()
+		var frame struct {
+			Data string `json:"data"`
+		}
+		if err := json.NewDecoder(netConnection).Decode(&frame); err != nil {
+			t.Errorf("decode done frame: %v", err)
+			return
+		}
+		if !strings.HasPrefix(frame.Data, "done:0:") {
+			t.Errorf("unexpected frame: %q", frame.Data)
+		}
+		_, _ = io.WriteString(netConnection, bootstrapUploadDone+"\r\n")
+		_, _ = io.WriteString(netConnection, bootstrapFailed+":1\r\n")
+	}))
+	defer server.Close()
+	client := newTestClient(t, server.URL, nil)
+	ptyURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = client.bootstrapThroughPTY(ctx, ptyURL, "")
+	if err == nil || !strings.Contains(err.Error(), "worker bootstrap failed") {
+		t.Fatalf("bootstrapThroughPTY error = %v", err)
 	}
 }
 

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -210,6 +210,10 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 			defer connection.CloseNow()
 			netConnection := websocket.NetConn(context.Background(), connection, websocket.MessageBinary)
 			defer netConnection.Close()
+			if _, err := io.WriteString(netConnection, bootstrapReady+"\r\n"); err != nil {
+				t.Errorf("write bootstrap ready: %v", err)
+				return
+			}
 			decoder := json.NewDecoder(netConnection)
 			var encoded strings.Builder
 			expectedSequence := 0
@@ -331,6 +335,30 @@ func TestBootstrapThroughPTYRejectsPrematureClose(t *testing.T) {
 	err := client.bootstrapThroughPTY(ctx, mustParseURL(t, server.URL+"/pty"), "payload")
 	if err == nil || !strings.Contains(err.Error(), "read workspace PTY") {
 		t.Fatalf("bootstrap error = %v, want premature-close error", err)
+	}
+}
+
+func TestWaitForBootstrapReadyIgnoresEarlierOutput(t *testing.T) {
+	t.Parallel()
+
+	output := make(chan ptyOutput, 2)
+	output <- ptyOutput{data: "shell startup noise\r\n"}
+	output <- ptyOutput{data: bootstrapReady + "\r\n"}
+	close(output)
+
+	if err := waitForBootstrapReady(context.Background(), output); err != nil {
+		t.Fatalf("waitForBootstrapReady error = %v", err)
+	}
+}
+
+func TestWaitForBootstrapReadyRejectsPrematureClose(t *testing.T) {
+	t.Parallel()
+
+	output := make(chan ptyOutput)
+	close(output)
+	if err := waitForBootstrapReady(context.Background(), output); err == nil ||
+		!strings.Contains(err.Error(), "closed before worker upload was ready") {
+		t.Fatalf("waitForBootstrapReady error = %v, want premature-close error", err)
 	}
 }
 
@@ -570,6 +598,10 @@ func TestBootstrapThroughPTYReportsFailureAfterUpload(t *testing.T) {
 		defer connection.CloseNow()
 		netConnection := websocket.NetConn(context.Background(), connection, websocket.MessageBinary)
 		defer netConnection.Close()
+		if _, err := io.WriteString(netConnection, bootstrapReady+"\r\n"); err != nil {
+			t.Errorf("write bootstrap ready: %v", err)
+			return
+		}
 		var frame struct {
 			Data string `json:"data"`
 		}
@@ -673,6 +705,10 @@ func serveBootstrapPTY(
 	defer connection.CloseNow()
 	netConnection := websocket.NetConn(context.Background(), connection, websocket.MessageBinary)
 	defer netConnection.Close()
+	if _, err := io.WriteString(netConnection, bootstrapReady+"\r\n"); err != nil {
+		t.Errorf("write bootstrap ready: %v", err)
+		return
+	}
 	decoder := json.NewDecoder(netConnection)
 	expectedSequence := 0
 	for {

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -193,6 +193,7 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 				"/mnt/ao/.ao/durable-session-id",
 				"/mnt/ao/.ao/worker/worker.pid",
 				"kill -0",
+				"chmod o+x",
 			} {
 				if !strings.Contains(command, expected) {
 					t.Errorf("bootstrap command missing durable path contract %q", expected)

--- a/cloud/internal/sandbox/coder/live_test.go
+++ b/cloud/internal/sandbox/coder/live_test.go
@@ -166,6 +166,7 @@ func assertLiveDurableState(
 	query.Set("height", "40")
 	query.Set("backend_type", "buffered")
 	query.Set("command", "sh -lc "+shellQuote(script))
+	query.Set("reconnect", uuid.NewString())
 	ptyURL.RawQuery = query.Encode()
 	connection, response, err := websocket.Dial(ctx, ptyURL.String(), &websocket.DialOptions{
 		HTTPClient: client.http,

--- a/cloud/internal/sandbox/coder/live_test.go
+++ b/cloud/internal/sandbox/coder/live_test.go
@@ -4,21 +4,30 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/url"
 	"os"
+	"path"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/cloud/internal/sandbox"
+	"github.com/coder/websocket"
 	"github.com/google/uuid"
 )
 
-// TestLiveLifecycle exercises the real Coder API when explicitly configured.
-// It is skipped in ordinary and CI test runs and always requests workspace
-// deletion before returning.
+// TestLiveLifecycle exercises the real Coder API and template persistence when
+// explicitly configured. It is skipped in ordinary and CI test runs and always
+// requests workspace deletion before returning.
 func TestLiveLifecycle(t *testing.T) {
 	baseURL := os.Getenv("CODER_LIVE_URL")
 	if baseURL == "" {
 		t.Skip("CODER_LIVE_URL is not set")
+	}
+	durableRoot := os.Getenv("CODER_LIVE_DURABLE_ROOT")
+	if durableRoot == "" {
+		t.Fatal("CODER_LIVE_DURABLE_ROOT is required for the stop/start persistence test")
 	}
 	parameters := map[string]string{}
 	if raw := os.Getenv("CODER_LIVE_PARAMETERS_JSON"); raw != "" {
@@ -58,12 +67,19 @@ func TestLiveLifecycle(t *testing.T) {
 		t.Fatal("running workspace carried no healthy agent target")
 	}
 	if err := client.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
-		Binary:      []byte("#!/bin/sh\nmkdir -p /workspace/.ao/worker\necho live > /workspace/.ao/worker/coder-live-test\nsleep 300\n"),
+		Binary:      []byte("#!/bin/sh\nset -eu\necho live > \"$AO_WORKSPACE_DIR/uncommitted.txt\"\nmkdir -p \"$CLAUDE_CONFIG_DIR/projects/live\" \"$CODEX_HOME/sessions\"\necho '{}' > \"$CLAUDE_CONFIG_DIR/projects/live/conversation.jsonl\"\necho state > \"$CODEX_HOME/sessions/thread.jsonl\"\nsleep 300\n"),
 		Destination: "/usr/local/bin/ao-worker", User: "ao-worker",
-		Environment: map[string]string{"AO_CODER_LIVE_TEST": "true"},
+		Environment: map[string]string{
+			"AO_CODER_LIVE_TEST": "true",
+			"AO_WORKSPACE_DIR":   durableRoot + "/repository",
+			"CLAUDE_CONFIG_DIR":  durableRoot + "/.ao/home/.claude",
+			"CODEX_HOME":         durableRoot + "/.ao/home/.codex",
+		},
+		DurableRoot: durableRoot, DurableIdentity: sessionID,
 	}); err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
+	assertLiveDurableState(t, ctx, client, environment.Target, durableRoot)
 	if err := client.Stop(ctx, environment.ID); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
@@ -71,12 +87,87 @@ func TestLiveLifecycle(t *testing.T) {
 	if err := client.Start(ctx, environment.ID); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	waitForState(t, ctx, client, environment.ID, sandbox.StateRunning)
+	environment = waitForState(t, ctx, client, environment.ID, sandbox.StateRunning)
+	assertLiveDurableState(t, ctx, client, environment.Target, durableRoot)
+	// A restore bootstrap requires the marker written before Stop. If the
+	// template recreated its filesystem, bootstrap fails before starting a new
+	// worker and the live test catches the persistence contract violation.
+	if err := client.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
+		Binary:      []byte("#!/bin/sh\nsleep 300\n"),
+		Destination: "/usr/local/bin/ao-worker", User: "ao-worker",
+		Environment: map[string]string{"AO_CODER_LIVE_TEST": "restored"},
+		DurableRoot: durableRoot, DurableIdentity: sessionID,
+		RequireDurableIdentity: true,
+	}); err != nil {
+		t.Fatalf("restore bootstrap did not find durable session identity: %v", err)
+	}
 	if err := client.Delete(ctx, environment.ID); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	waitForDeleted(t, ctx, client, environment.ID)
 	deleted = true
+}
+
+func assertLiveDurableState(
+	t *testing.T,
+	ctx context.Context,
+	client *Client,
+	agentID string,
+	durableRoot string,
+) {
+	t.Helper()
+	checks := []struct {
+		path    string
+		content string
+	}{
+		{path.Join(durableRoot, "repository", "uncommitted.txt"), "live"},
+		{path.Join(durableRoot, ".ao", "home", ".claude", "projects", "live", "conversation.jsonl"), "{}"},
+		{path.Join(durableRoot, ".ao", "home", ".codex", "sessions", "thread.jsonl"), "state"},
+	}
+	var condition strings.Builder
+	for index, check := range checks {
+		if index > 0 {
+			condition.WriteString(" && ")
+		}
+		condition.WriteString("[ -f ")
+		condition.WriteString(shellQuote(check.path))
+		condition.WriteString(" ] && [ \"$(cat ")
+		condition.WriteString(shellQuote(check.path))
+		condition.WriteString(")\" = ")
+		condition.WriteString(shellQuote(check.content))
+		condition.WriteString(" ]")
+	}
+	script := "set -u\nattempt=0\nwhile [ $attempt -lt 30 ]; do\n" +
+		"  if " + condition.String() + "; then echo " + bootstrapOK + "; exit 0; fi\n" +
+		"  attempt=$((attempt + 1))\n  sleep 1\ndone\nexit 1\n"
+	ptyURL, err := url.Parse(client.baseURL + "/api/v2/workspaceagents/" + url.PathEscape(agentID) + "/pty")
+	if err != nil {
+		t.Fatalf("build persistence probe URL: %v", err)
+	}
+	query := ptyURL.Query()
+	query.Set("width", "120")
+	query.Set("height", "40")
+	query.Set("backend_type", "buffered")
+	query.Set("command", "sh -lc "+shellQuote(script))
+	ptyURL.RawQuery = query.Encode()
+	connection, response, err := websocket.Dial(ctx, ptyURL.String(), &websocket.DialOptions{
+		HTTPClient: client.http,
+		HTTPHeader: http.Header{"Coder-Session-Token": []string{client.token}},
+	})
+	if err != nil {
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		t.Fatalf("open persistence probe PTY: %v", err)
+	}
+	defer connection.CloseNow()
+	netConnection := websocket.NetConn(context.Background(), connection, websocket.MessageBinary)
+	defer netConnection.Close()
+	output, err := readBootstrapResult(ctx, streamPTYOutput(netConnection))
+	if err != nil || !strings.Contains(output, bootstrapOK) {
+		t.Fatalf("durable repository/harness state did not survive stop/start: %s: %v", sanitizePTYOutput(output), err)
+	}
+	t.Logf("verified %d durable files after Coder stop/start", len(checks))
 }
 
 func waitForState(t *testing.T, ctx context.Context, client *Client, id sandbox.ID, state string) sandbox.Environment {

--- a/cloud/internal/sandbox/coder/live_test.go
+++ b/cloud/internal/sandbox/coder/live_test.go
@@ -94,7 +94,7 @@ func TestLiveLifecycle(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
-	assertLiveDurableState(t, ctx, client, environment.Target, durableRoot)
+	assertLiveDurableState(t, ctx, client, environment.Target, durableRoot, sessionID)
 	if err := client.Stop(ctx, environment.ID); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestLiveLifecycle(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 	environment = waitForState(t, ctx, client, environment.ID, sandbox.StateRunning)
-	assertLiveDurableState(t, ctx, client, environment.Target, durableRoot)
+	assertLiveDurableState(t, ctx, client, environment.Target, durableRoot, sessionID)
 	// A restore bootstrap requires the marker written before Stop. If the
 	// template recreated its filesystem, bootstrap fails before starting a new
 	// worker and the live test catches the persistence contract violation.
@@ -131,17 +131,20 @@ func assertLiveDurableState(
 	client *Client,
 	agentID string,
 	durableRoot string,
+	sessionID string,
 ) {
 	t.Helper()
 	checks := []struct {
 		path    string
 		content string
 	}{
+		{path.Join(durableRoot, ".ao", "durable-session-id"), sessionID},
 		{path.Join(durableRoot, "repository", "uncommitted.txt"), "live"},
 		{path.Join(durableRoot, ".ao", "home", ".claude", "projects", "live", "conversation.jsonl"), "{}"},
 		{path.Join(durableRoot, ".ao", "home", ".codex", "sessions", "thread.jsonl"), "state"},
 	}
 	var condition strings.Builder
+	var diagnostics strings.Builder
 	for index, check := range checks {
 		if index > 0 {
 			condition.WriteString(" && ")
@@ -153,10 +156,24 @@ func assertLiveDurableState(
 		condition.WriteString(")\" = ")
 		condition.WriteString(shellQuote(check.content))
 		condition.WriteString(" ]")
+		diagnostics.WriteString("if [ ! -f ")
+		diagnostics.WriteString(shellQuote(check.path))
+		diagnostics.WriteString(" ]; then echo ")
+		diagnostics.WriteString(shellQuote("missing:" + check.path))
+		diagnostics.WriteString("; elif [ \"$(cat ")
+		diagnostics.WriteString(shellQuote(check.path))
+		diagnostics.WriteString(")\" != ")
+		diagnostics.WriteString(shellQuote(check.content))
+		diagnostics.WriteString(" ]; then echo ")
+		diagnostics.WriteString(shellQuote("mismatch:" + check.path))
+		diagnostics.WriteString("; fi\n")
 	}
 	script := "set -u\nattempt=0\nwhile [ $attempt -lt 30 ]; do\n" +
 		"  if " + condition.String() + "; then echo " + bootstrapOK + "; exit 0; fi\n" +
-		"  attempt=$((attempt + 1))\n  sleep 1\ndone\nexit 1\n"
+		"  attempt=$((attempt + 1))\n  sleep 1\ndone\n" + diagnostics.String() +
+		"if [ -f " + shellQuote(path.Join(durableRoot, ".ao", "worker", "worker.log")) +
+		" ]; then echo worker-log:; tail -c 2048 " + shellQuote(path.Join(durableRoot, ".ao", "worker", "worker.log")) +
+		"; fi\necho " + bootstrapFailed + ":1\nexit 1\n"
 	ptyURL, err := url.Parse(client.baseURL + "/api/v2/workspaceagents/" + url.PathEscape(agentID) + "/pty")
 	if err != nil {
 		t.Fatalf("build persistence probe URL: %v", err)

--- a/cloud/internal/sandbox/coder/live_test.go
+++ b/cloud/internal/sandbox/coder/live_test.go
@@ -58,7 +58,10 @@ func TestLiveLifecycle(t *testing.T) {
 			defer cleanupCancel()
 			if cleanupErr := client.Delete(cleanupContext, environment.ID); cleanupErr != nil {
 				t.Errorf("cleanup workspace %s: %v", environment.ID, cleanupErr)
+				return
 			}
+			waitForDeleted(t, cleanupContext, client, environment.ID)
+			t.Logf("cleanup confirmed workspace %s is absent", environment.ID)
 		}
 	}()
 
@@ -113,10 +116,12 @@ func TestLiveLifecycle(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("restore bootstrap did not find durable session identity: %v", err)
 	}
+	t.Logf("accepted durable session identity %s after Coder stop/start", sessionID)
 	if err := client.Delete(ctx, environment.ID); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	waitForDeleted(t, ctx, client, environment.ID)
+	t.Logf("cleanup confirmed workspace %s is absent", environment.ID)
 	deleted = true
 }
 

--- a/cloud/internal/sandbox/provider.go
+++ b/cloud/internal/sandbox/provider.go
@@ -20,15 +20,18 @@ type ID string
 
 // Spec describes a sandbox to create.
 type Spec struct {
-	Name              string
-	SessionID         string
-	OrgID             string
-	ResourceProfile   domain.ResourceProfile
-	Shape             string
-	RootFS            string
-	Ingress           string
-	Environment       map[string]string
-	Labels            map[string]string
+	Name            string
+	SessionID       string
+	OrgID           string
+	ResourceProfile domain.ResourceProfile
+	Shape           string
+	RootFS          string
+	Ingress         string
+	Environment     map[string]string
+	Labels          map[string]string
+	// DurableRoot is provider-specific persisted workspace storage. It remains
+	// empty for providers whose established contract already owns persistence.
+	DurableRoot       string
 	AutoDeleteMinutes int
 	// AutoPauseSeconds is disabled when zero.
 	AutoPauseSeconds int
@@ -52,6 +55,13 @@ type WorkerBootstrap struct {
 	HelperDestination string
 	User              string
 	Environment       map[string]string
+	// DurableRoot and DurableIdentity are used by providers whose compute is
+	// replaced on stop/start while a template-backed filesystem is retained.
+	// RequireDurableIdentity makes a restore fail closed if the original volume
+	// marker is missing or belongs to another session.
+	DurableRoot            string
+	DurableIdentity        string
+	RequireDurableIdentity bool
 }
 
 // Bootstrapper installs and starts an AO worker in an existing sandbox.

--- a/cloud/internal/sandbox/provisioning.go
+++ b/cloud/internal/sandbox/provisioning.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -59,7 +60,51 @@ type CoderConfig struct {
 	TemplateID     string
 	AgentName      string
 	Parameters     map[string]string
+	DurableRoot    string
 	WorkerTokenTTL time.Duration
+}
+
+// CoderWorkspaceLayout is the provider-specific filesystem contract between AO
+// and a Coder template. DurableRoot must be the template's persistent volume
+// mount point; every path AO must retain across stop/start is derived beneath it.
+type CoderWorkspaceLayout struct {
+	DurableRoot     string
+	Repository      string
+	WorkerData      string
+	Home            string
+	ClaudeConfig    string
+	CodexHome       string
+	DurableIdentity string
+}
+
+// NewCoderWorkspaceLayout validates and expands the configured Coder volume
+// mount. Bootstrap separately verifies that DurableRoot is an actual mount point
+// inside the workspace before AO writes anything beneath it.
+func NewCoderWorkspaceLayout(durableRoot string) (CoderWorkspaceLayout, error) {
+	durableRoot = strings.TrimSpace(durableRoot)
+	if durableRoot == "" {
+		return CoderWorkspaceLayout{}, errors.New("AO_CLOUD_CODER_DURABLE_ROOT is required")
+	}
+	if len(durableRoot) > 1024 || !strings.HasPrefix(durableRoot, "/") ||
+		path.Clean(durableRoot) != durableRoot || durableRoot == "/" ||
+		strings.IndexFunc(durableRoot, func(character rune) bool {
+			return character < ' ' || character == 0x7f
+		}) >= 0 {
+		return CoderWorkspaceLayout{}, errors.New(
+			"AO_CLOUD_CODER_DURABLE_ROOT must be a safe absolute non-root path",
+		)
+	}
+	aoRoot := path.Join(durableRoot, ".ao")
+	home := path.Join(aoRoot, "home")
+	return CoderWorkspaceLayout{
+		DurableRoot:     durableRoot,
+		Repository:      path.Join(durableRoot, "repository"),
+		WorkerData:      path.Join(aoRoot, "worker"),
+		Home:            home,
+		ClaudeConfig:    path.Join(home, ".claude"),
+		CodexHome:       path.Join(home, ".codex"),
+		DurableIdentity: path.Join(aoRoot, "durable-session-id"),
+	}, nil
 }
 
 func (c CoderConfig) Validate() error {
@@ -74,6 +119,9 @@ func (c CoderConfig) Validate() error {
 	}
 	if strings.TrimSpace(c.TemplateID) == "" {
 		return errors.New("AO_CLOUD_CODER_TEMPLATE_ID is required")
+	}
+	if _, err := NewCoderWorkspaceLayout(c.DurableRoot); err != nil {
+		return err
 	}
 	if c.WorkerTokenTTL <= 0 {
 		return errors.New("AO_CLOUD_CODER_WORKER_TOKEN_TTL must be positive")
@@ -205,12 +253,14 @@ func (d ProvisioningDefaults) SessionPlan(harness string) (Plan, error) {
 			"templateId":            strings.TrimSpace(d.Coder.TemplateID),
 			"agentName":             strings.TrimSpace(d.Coder.AgentName),
 			"parameters":            d.Coder.Parameters,
+			"durableRoot":           strings.TrimSpace(d.Coder.DurableRoot),
 			"workerTokenTtlSeconds": int64(d.Coder.WorkerTokenTTL / time.Second),
 		}
 		bootstrapContext["coder"] = map[string]any{
-			"owner":      strings.TrimSpace(d.Coder.Owner),
-			"templateId": strings.TrimSpace(d.Coder.TemplateID),
-			"agentName":  strings.TrimSpace(d.Coder.AgentName),
+			"owner":       strings.TrimSpace(d.Coder.Owner),
+			"templateId":  strings.TrimSpace(d.Coder.TemplateID),
+			"agentName":   strings.TrimSpace(d.Coder.AgentName),
+			"durableRoot": strings.TrimSpace(d.Coder.DurableRoot),
 		}
 	}
 	resourceJSON, err := json.Marshal(resourceProfile)

--- a/cloud/internal/sandbox/provisioning.go
+++ b/cloud/internal/sandbox/provisioning.go
@@ -64,6 +64,17 @@ type CoderConfig struct {
 	WorkerTokenTTL time.Duration
 }
 
+// CoderSessionProfile is the non-secret provider contract stamped onto one
+// session. Reconciliation reads these values from the durable sandbox row; a
+// later deployment configuration change must not move or recreate that session.
+type CoderSessionProfile struct {
+	Owner       string            `json:"owner"`
+	TemplateID  string            `json:"templateId"`
+	AgentName   string            `json:"agentName"`
+	Parameters  map[string]string `json:"parameters"`
+	DurableRoot string            `json:"durableRoot"`
+}
+
 // CoderWorkspaceLayout is the provider-specific filesystem contract between AO
 // and a Coder template. DurableRoot must be the template's persistent volume
 // mount point; every path AO must retain across stop/start is derived beneath it.
@@ -107,6 +118,60 @@ func NewCoderWorkspaceLayout(durableRoot string) (CoderWorkspaceLayout, error) {
 	}, nil
 }
 
+// DecodeCoderSessionProfile reads and validates the Coder contract stored in a
+// sandbox resource profile. Connection credentials deliberately remain outside
+// this profile and come from the configured provider connection.
+func DecodeCoderSessionProfile(raw json.RawMessage) (CoderSessionProfile, error) {
+	var resource struct {
+		Coder *CoderSessionProfile `json:"coder"`
+	}
+	if len(raw) == 0 {
+		return CoderSessionProfile{}, errors.New("Coder session resource profile is required")
+	}
+	if err := json.Unmarshal(raw, &resource); err != nil {
+		return CoderSessionProfile{}, fmt.Errorf("decode Coder session resource profile: %w", err)
+	}
+	if resource.Coder == nil {
+		return CoderSessionProfile{}, errors.New("Coder session resource profile is required")
+	}
+	profile := *resource.Coder
+	profile.Owner = strings.TrimSpace(profile.Owner)
+	profile.TemplateID = strings.TrimSpace(profile.TemplateID)
+	profile.AgentName = strings.TrimSpace(profile.AgentName)
+	if profile.Owner == "" {
+		return CoderSessionProfile{}, errors.New("Coder session owner is required")
+	}
+	if profile.TemplateID == "" {
+		return CoderSessionProfile{}, errors.New("Coder session template ID is required")
+	}
+	parameters, err := normalizedCoderParameters(profile.Parameters)
+	if err != nil {
+		return CoderSessionProfile{}, err
+	}
+	profile.Parameters = parameters
+	layout, err := NewCoderWorkspaceLayout(profile.DurableRoot)
+	if err != nil {
+		return CoderSessionProfile{}, err
+	}
+	profile.DurableRoot = layout.DurableRoot
+	return profile, nil
+}
+
+func normalizedCoderParameters(parameters map[string]string) (map[string]string, error) {
+	normalized := make(map[string]string, len(parameters))
+	for name, value := range parameters {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, errors.New("Coder template parameter name must not be empty")
+		}
+		if _, exists := normalized[name]; exists {
+			return nil, fmt.Errorf("Coder template parameter %q is duplicated", name)
+		}
+		normalized[name] = value
+	}
+	return normalized, nil
+}
+
 func (c CoderConfig) Validate() error {
 	endpoint, err := url.Parse(strings.TrimSpace(c.BaseURL))
 	if err != nil || endpoint.Host == "" || endpoint.User != nil ||
@@ -121,6 +186,9 @@ func (c CoderConfig) Validate() error {
 		return errors.New("AO_CLOUD_CODER_TEMPLATE_ID is required")
 	}
 	if _, err := NewCoderWorkspaceLayout(c.DurableRoot); err != nil {
+		return err
+	}
+	if _, err := normalizedCoderParameters(c.Parameters); err != nil {
 		return err
 	}
 	if c.WorkerTokenTTL <= 0 {
@@ -247,12 +315,16 @@ func (d ProvisioningDefaults) SessionPlan(harness string) (Plan, error) {
 		if err := d.Coder.Validate(); err != nil {
 			return Plan{}, err
 		}
+		parameters, err := normalizedCoderParameters(d.Coder.Parameters)
+		if err != nil {
+			return Plan{}, err
+		}
 		resourceProfile["coder"] = map[string]any{
 			"baseUrl":               strings.TrimRight(strings.TrimSpace(d.Coder.BaseURL), "/"),
 			"owner":                 strings.TrimSpace(d.Coder.Owner),
 			"templateId":            strings.TrimSpace(d.Coder.TemplateID),
 			"agentName":             strings.TrimSpace(d.Coder.AgentName),
-			"parameters":            d.Coder.Parameters,
+			"parameters":            parameters,
 			"durableRoot":           strings.TrimSpace(d.Coder.DurableRoot),
 			"workerTokenTtlSeconds": int64(d.Coder.WorkerTokenTTL / time.Second),
 		}

--- a/cloud/internal/sandbox/provisioning_test.go
+++ b/cloud/internal/sandbox/provisioning_test.go
@@ -54,10 +54,12 @@ func TestCoderConfigRejectsUnsafeDurableRoot(t *testing.T) {
 
 func TestCoderSessionPlanPersistsDurableRoot(t *testing.T) {
 	t.Parallel()
+	const templateID = "2a2e262c-b31c-4202-946d-a19ad45d1fd2"
 	plan, err := (ProvisioningDefaults{
 		Provider: ProviderCoder,
 		Coder: CoderConfig{
-			BaseURL: "https://coder.example.com", Owner: "owner", TemplateID: "template",
+			BaseURL: "https://coder.example.com", Owner: "owner", TemplateID: templateID,
+			AgentName: "dev", Parameters: map[string]string{" region ": "us-west-2"},
 			DurableRoot: "/persistent/ao", WorkerTokenTTL: time.Minute,
 		},
 	}).SessionPlan("codex")
@@ -78,6 +80,32 @@ func TestCoderSessionPlanPersistsDurableRoot(t *testing.T) {
 		}
 		if decoded.Coder.DurableRoot != "/persistent/ao" {
 			t.Errorf("%s durable root = %q", name, decoded.Coder.DurableRoot)
+		}
+	}
+	profile, err := DecodeCoderSessionProfile(plan.ResourceProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.Owner != "owner" || profile.TemplateID != templateID ||
+		profile.AgentName != "dev" || profile.Parameters["region"] != "us-west-2" ||
+		profile.DurableRoot != "/persistent/ao" {
+		t.Fatalf("unexpected durable profile: %+v", profile)
+	}
+}
+
+func TestDecodeCoderSessionProfileRejectsIncompleteContract(t *testing.T) {
+	t.Parallel()
+	profiles := []json.RawMessage{
+		nil,
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"coder":{"templateId":"template","durableRoot":"/mnt/ao"}}`),
+		json.RawMessage(`{"coder":{"owner":"owner","durableRoot":"/mnt/ao"}}`),
+		json.RawMessage(`{"coder":{"owner":"owner","templateId":"template"}}`),
+		json.RawMessage(`{"coder":{"owner":"owner","templateId":"template","durableRoot":"/mnt/ao","parameters":{"x":"one"," x ":"two"}}}`),
+	}
+	for index, raw := range profiles {
+		if _, err := DecodeCoderSessionProfile(raw); err == nil {
+			t.Errorf("profile %d unexpectedly decoded: %s", index, raw)
 		}
 	}
 }

--- a/cloud/internal/sandbox/provisioning_test.go
+++ b/cloud/internal/sandbox/provisioning_test.go
@@ -1,0 +1,83 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNewCoderWorkspaceLayout(t *testing.T) {
+	t.Parallel()
+	layout, err := NewCoderWorkspaceLayout("/home/coder")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"repository":       "/home/coder/repository",
+		"worker data":      "/home/coder/.ao/worker",
+		"home":             "/home/coder/.ao/home",
+		"Claude config":    "/home/coder/.ao/home/.claude",
+		"Codex home":       "/home/coder/.ao/home/.codex",
+		"durable identity": "/home/coder/.ao/durable-session-id",
+	}
+	got := map[string]string{
+		"repository":       layout.Repository,
+		"worker data":      layout.WorkerData,
+		"home":             layout.Home,
+		"Claude config":    layout.ClaudeConfig,
+		"Codex home":       layout.CodexHome,
+		"durable identity": layout.DurableIdentity,
+	}
+	for name, expected := range want {
+		if got[name] != expected {
+			t.Errorf("%s = %q, want %q", name, got[name], expected)
+		}
+	}
+}
+
+func TestCoderConfigRejectsUnsafeDurableRoot(t *testing.T) {
+	t.Parallel()
+	for _, root := range []string{"", "/", "relative", "/home/coder/../workspace", "/home/coder\nother"} {
+		root := root
+		t.Run(root, func(t *testing.T) {
+			t.Parallel()
+			config := CoderConfig{
+				BaseURL: "https://coder.example.com", Owner: "owner", TemplateID: "template",
+				DurableRoot: root, WorkerTokenTTL: time.Minute,
+			}
+			if err := config.Validate(); err == nil {
+				t.Fatal("Validate succeeded")
+			}
+		})
+	}
+}
+
+func TestCoderSessionPlanPersistsDurableRoot(t *testing.T) {
+	t.Parallel()
+	plan, err := (ProvisioningDefaults{
+		Provider: ProviderCoder,
+		Coder: CoderConfig{
+			BaseURL: "https://coder.example.com", Owner: "owner", TemplateID: "template",
+			DurableRoot: "/persistent/ao", WorkerTokenTTL: time.Minute,
+		},
+	}).SessionPlan("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, raw := range map[string]json.RawMessage{
+		"resource profile":  plan.ResourceProfile,
+		"bootstrap context": plan.BootstrapContext,
+	} {
+		var decoded struct {
+			Coder struct {
+				DurableRoot string `json:"durableRoot"`
+			} `json:"coder"`
+		}
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		if decoded.Coder.DurableRoot != "/persistent/ao" {
+			t.Errorf("%s durable root = %q", name, decoded.Coder.DurableRoot)
+		}
+	}
+}

--- a/cloud/internal/sandboxresolve/resolver.go
+++ b/cloud/internal/sandboxresolve/resolver.go
@@ -17,6 +17,10 @@ type Resolver struct {
 	coder   sandbox.Provider
 }
 
+type sessionScopedProvider interface {
+	ForSandbox(domain.Sandbox) (sandbox.Provider, error)
+}
+
 // New creates a resolver backed by the providers enabled for this deployment.
 func New(nodeOps, docker, coder sandbox.Provider) *Resolver {
 	return &Resolver{nodeOps: nodeOps, docker: docker, coder: coder}
@@ -55,7 +59,11 @@ func (r *Resolver) Resolve(_ context.Context, record domain.Sandbox) (sandbox.Pr
 		if r.coder == nil {
 			return nil, fmt.Errorf("coder sandbox provider is not configured")
 		}
-		return r.coder, nil
+		scoped, ok := r.coder.(sessionScopedProvider)
+		if !ok {
+			return nil, fmt.Errorf("coder sandbox provider does not support durable session profiles")
+		}
+		return scoped.ForSandbox(record)
 	case sandbox.ProviderDaytona, sandbox.ProviderECS:
 		return nil, fmt.Errorf("sandbox provider %q is not configured", record.Provider)
 	default:

--- a/cloud/internal/sandboxresolve/resolver_test.go
+++ b/cloud/internal/sandboxresolve/resolver_test.go
@@ -1,0 +1,47 @@
+package sandboxresolve
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
+	"github.com/aoagents/agent-orchestrator/cloud/internal/sandbox"
+)
+
+type scopedCoderProvider struct {
+	sandbox.Provider
+	record domain.Sandbox
+}
+
+func (p *scopedCoderProvider) ForSandbox(record domain.Sandbox) (sandbox.Provider, error) {
+	p.record = record
+	return p, nil
+}
+
+func TestResolveScopesCoderProviderToDurableSessionProfile(t *testing.T) {
+	t.Parallel()
+	provider := &scopedCoderProvider{}
+	resolver := New(nil, nil, provider)
+	record := domain.Sandbox{
+		SessionID: "session-1", Provider: sandbox.ProviderCoder,
+		ResourceProfile: json.RawMessage(`{"coder":{"owner":"planned-owner"}}`),
+	}
+	resolved, err := resolver.Resolve(context.Background(), record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != provider || provider.record.SessionID != record.SessionID ||
+		string(provider.record.ResourceProfile) != string(record.ResourceProfile) {
+		t.Fatalf("resolver did not pass the durable session row: %+v", provider.record)
+	}
+}
+
+func TestResolveRejectsUnscopedCoderProvider(t *testing.T) {
+	t.Parallel()
+	resolver := New(nil, nil, struct{ sandbox.Provider }{})
+	_, err := resolver.Resolve(context.Background(), domain.Sandbox{Provider: sandbox.ProviderCoder})
+	if err == nil {
+		t.Fatal("Resolve accepted a Coder provider without durable session scoping")
+	}
+}

--- a/cloud/internal/workerexec/command.go
+++ b/cloud/internal/workerexec/command.go
@@ -455,11 +455,10 @@ func (b HarnessBuilder) configureCodexCredential(
 	command *Command,
 	credential worker.CredentialResponse,
 ) error {
-	parent := strings.TrimSpace(b.DataDir)
-	if parent == "" {
-		return errors.New("worker data directory is required for Codex configuration")
+	home, err := b.codexHome()
+	if err != nil {
+		return err
 	}
-	home := filepath.Join(parent, "codex")
 	if err := os.MkdirAll(home, 0o700); err != nil {
 		return fmt.Errorf("create Codex home: %w", err)
 	}
@@ -472,6 +471,17 @@ func (b HarnessBuilder) configureCodexCredential(
 	}
 	command.Env["CODEX_HOME"] = home
 	return nil
+}
+
+func (b HarnessBuilder) codexHome() (string, error) {
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return home, nil
+	}
+	parent := strings.TrimSpace(b.DataDir)
+	if parent == "" {
+		return "", errors.New("worker data directory is required for Codex configuration")
+	}
+	return filepath.Join(parent, "codex"), nil
 }
 
 func loginCodex(binary, home, credentialType, secret string) error {

--- a/cloud/internal/workerexec/command_test.go
+++ b/cloud/internal/workerexec/command_test.go
@@ -1,0 +1,75 @@
+package workerexec
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/cloud/internal/worker"
+)
+
+func TestBuildInteractiveRestoresClaudeConversationFromDurableConfig(t *testing.T) {
+	configDir := filepath.Join(t.TempDir(), "claude")
+	identity := "99a68dd6-2ad8-4fd8-9ea7-d833ceb2914e"
+	conversation := filepath.Join(configDir, "projects", "repository", identity+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(conversation), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(conversation, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+	command, err := (HarnessBuilder{}).BuildInteractive(worker.LaunchContext{
+		SessionID: "session-1", Harness: "claude-code", AgentSessionID: identity,
+		Mode: "standard",
+	}, worker.CredentialResponse{
+		Provider: "claude-code", CredentialType: "api_key", Secret: "secret",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAdjacent(command.Args, "--resume", identity) {
+		t.Fatalf("restore args missing from %#v", command.Args)
+	}
+	if slices.Contains(command.Args, "--session-id") {
+		t.Fatalf("fresh-launch identity present in restore command %#v", command.Args)
+	}
+	if command.Env["CLAUDE_CONFIG_DIR"] != configDir {
+		t.Errorf("CLAUDE_CONFIG_DIR = %q", command.Env["CLAUDE_CONFIG_DIR"])
+	}
+}
+
+func TestBuildInteractiveUsesConfiguredDurableCodexHomeOnRestore(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), "codex")
+	t.Setenv("CODEX_HOME", codexHome)
+	loginHome := ""
+	builder := HarnessBuilder{CodexLogin: func(_, home, _, _ string) error {
+		loginHome = home
+		return nil
+	}}
+	command, err := builder.BuildInteractive(worker.LaunchContext{
+		SessionID: "session-1", Harness: "codex", AgentSessionID: "thread-1",
+		Mode: "standard",
+	}, worker.CredentialResponse{
+		Provider: "codex", CredentialType: "api_key", Secret: "secret",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loginHome != codexHome || command.Env["CODEX_HOME"] != codexHome {
+		t.Fatalf("Codex durable home: login=%q env=%q", loginHome, command.Env["CODEX_HOME"])
+	}
+	if !slices.Contains(command.Args, "thread-1") || len(command.Args) == 0 || command.Args[0] != "resume" {
+		t.Fatalf("unexpected Codex restore args: %#v", command.Args)
+	}
+}
+
+func containsAdjacent(values []string, first, second string) bool {
+	for index := 0; index+1 < len(values); index++ {
+		if values[index] == first && values[index+1] == second {
+			return true
+		}
+	}
+	return false
+}

--- a/cloud/scripts/deploy-staging.sh
+++ b/cloud/scripts/deploy-staging.sh
@@ -239,6 +239,7 @@ register_task_definition() {
 				--set-secret "AO_CLOUD_CODER_TEMPLATE_ID=${sandbox_secret_arn}:template_id::"
 				--set-secret "AO_CLOUD_CODER_AGENT_NAME=${sandbox_secret_arn}:agent_name::"
 				--set-secret "AO_CLOUD_CODER_PARAMETERS_JSON=${sandbox_secret_arn}:parameters_json::"
+				--set-secret "AO_CLOUD_CODER_DURABLE_ROOT=${sandbox_secret_arn}:durable_root::"
 				--set-secret "AO_CLOUD_CODER_WORKER_TOKEN_TTL=${sandbox_secret_arn}:worker_token_ttl::"
 			)
 		else

--- a/cloud/scripts/lib/deployment.py
+++ b/cloud/scripts/lib/deployment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import copy
 import json
+import posixpath
 import re
 from typing import Any
 from urllib.parse import urlparse
@@ -43,6 +44,7 @@ CODER_SECRET_ENV = {
     "AO_CLOUD_CODER_TEMPLATE_ID": "template_id",
     "AO_CLOUD_CODER_AGENT_NAME": "agent_name",
     "AO_CLOUD_CODER_PARAMETERS_JSON": "parameters_json",
+    "AO_CLOUD_CODER_DURABLE_ROOT": "durable_root",
     "AO_CLOUD_CODER_WORKER_TOKEN_TTL": "worker_token_ttl",
 }
 WORKER_SECRET_ENV = {
@@ -135,9 +137,18 @@ def _validate_coder_settings(coder: dict[str, Any]) -> None:
         or base_url.fragment
     ):
         raise ValueError("Coder url must be an absolute HTTPS origin")
-    for key in ("token", "owner", "template_id"):
+    for key in ("token", "owner", "template_id", "durable_root"):
         if not coder[key].strip():
             raise ValueError(f"Coder {key} must not be empty")
+    durable_root = coder["durable_root"]
+    if (
+        len(durable_root) > 1024
+        or not durable_root.startswith("/")
+        or durable_root == "/"
+        or posixpath.normpath(durable_root) != durable_root
+        or any(ord(character) < 32 or ord(character) == 127 for character in durable_root)
+    ):
+        raise ValueError("Coder durable_root must be a safe absolute non-root path")
     try:
         parameters = json.loads(coder["parameters_json"])
     except json.JSONDecodeError as error:

--- a/cloud/scripts/promote-production.sh
+++ b/cloud/scripts/promote-production.sh
@@ -276,6 +276,7 @@ register_api_task() {
 			--set-secret "AO_CLOUD_CODER_TEMPLATE_ID=${sandbox_secret_arn}:template_id::"
 			--set-secret "AO_CLOUD_CODER_AGENT_NAME=${sandbox_secret_arn}:agent_name::"
 			--set-secret "AO_CLOUD_CODER_PARAMETERS_JSON=${sandbox_secret_arn}:parameters_json::"
+			--set-secret "AO_CLOUD_CODER_DURABLE_ROOT=${sandbox_secret_arn}:durable_root::"
 			--set-secret "AO_CLOUD_CODER_WORKER_TOKEN_TTL=${sandbox_secret_arn}:worker_token_ttl::"
 		)
 	else

--- a/cloud/scripts/tests/test_deployment.py
+++ b/cloud/scripts/tests/test_deployment.py
@@ -69,6 +69,7 @@ def coder_settings():
             "template_id": "template-uuid",
             "agent_name": "main",
             "parameters_json": '{"instance_type":"t3.medium"}',
+            "durable_root": "/home/coder",
             "worker_token_ttl": "15m",
         },
         hosted_settings()[1],
@@ -332,6 +333,12 @@ class HostedSettingsTests(unittest.TestCase):
         coder, worker = coder_settings()
         coder["url"] = "http://coder.example.com"
         with self.assertRaisesRegex(ValueError, "HTTPS origin"):
+            validate_hosted_settings(coder, worker, provider="coder")
+
+    def test_rejects_unsafe_coder_durable_root(self):
+        coder, worker = coder_settings()
+        coder["durable_root"] = "/home/coder/../ephemeral"
+        with self.assertRaisesRegex(ValueError, "safe absolute non-root path"):
             validate_hosted_settings(coder, worker, provider="coder")
 
 


### PR DESCRIPTION
## Stack

- Stacked on #4624 (`ao/agent-orchestrator-211/coder-sandbox-provider`).
- This is a baseline blocker that must merge into #4624's source branch before #4624 can land.
- Keep this PR in draft; do not merge it directly to `main` or mark it ready while the parent integration is still under review.

Fixes #4731.

## Summary

- add a required, validated `AO_CLOUD_CODER_DURABLE_ROOT` template contract and persist the Coder owner, template, parameters, selected agent, and root in each session plan
- resolve every Coder reconcile/recovery operation from that durable session profile while retaining only the deployment-scoped connection credential
- reject workspace owner, deterministic name, or template mismatches during create, `FindBySession`, persisted-ID lookup, and bootstrap before worker credentials can be uploaded
- derive the repository, AO worker data, repository credential helper, `HOME`, Claude config, and Codex home from the provider-specific durable root while preserving the existing `/workspace` layout for other providers
- require a real non-symlink mount, write a session identity marker on first bootstrap, and fail closed after stop/start if the marker is missing or belongs to another session
- wait for PTY shell readiness, retry transient pre-ready closes, await the post-upload bootstrap result, and verify the detached worker remains alive so setup/launch failures reach the reconciler instead of being reported as success
- make Codex honor the configured durable `CODEX_HOME`
- extend focused tests and the opt-in live Coder lifecycle test to verify repository, Claude, Codex, restore-marker, session-profile authority, and mismatch behavior

## Template and configuration requirements

- Set `AO_CLOUD_CODER_DURABLE_ROOT` to the approved template's exact persistent-volume mount point; AO does not assume `/home/coder`.
- The path must be absolute, normalized, non-root, no longer than 1024 bytes, and free of control characters.
- The path must exist in each workspace as a non-symlink mount point and the template must provide `mountpoint`.
- Configure `AO_CLOUD_CODER_OWNER` as the canonical owner name returned by Coder, not an alias such as `me`.
- The mount must survive Coder `stop` then `start`; run the documented `TestLiveLifecycle` gate against the exact template/root before enabling idle pause.
- Hosted `coder` Secrets Manager JSON now requires `durable_root`; deployment validation fails closed when it is absent or unsafe.

## Verification

- `cd cloud && go build ./...`
- `cd cloud && go vet ./...`
- `cd cloud && go test -race ./...`
- `python3 cloud/scripts/tests/test_deployment.py` (18 tests)
- `bash -n cloud/scripts/deploy-staging.sh cloud/scripts/promote-production.sh`
- `git diff --check`

- credentialed `TestLiveLifecycle` against the approved `/home/coder` template at `21f4d9ca6` (129 seconds): expected post-upload install failure surfaced, real worker launch verified, repository/Claude/Codex/session-marker state survived stop/start, restore identity was accepted, and workspace deletion was confirmed

No ECS or shared AO staging service deployment was performed.

## Risk / rollout

Coder session rows created before this contract do not contain the complete durable profile and fail closed rather than falling back to singleton deployment defaults or ephemeral `/workspace`. Before any rollout, supply the new secret field, update and verify the approved template, run the live stop/start gate, and create fresh sessions or explicitly migrate preview-only rows in a separate reviewed change.