### PR TITLE
fix(cloud): await Coder bootstrap result

### DIFF
--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -316,7 +316,7 @@ func (c *Client) BootstrapWorker(ctx context.Context, id sandbox.ID, bootstrap s
 	query.Set("height", "40")
 	query.Set("command", command)
 	// Bootstrap is a short-lived, non-interactive command. The buffered backend
-	// lets the command finish after AO disconnects once the upload is accepted.
+	// preserves the final result after the upload while AO keeps the PTY open.
 	query.Set("backend_type", "buffered")
 	ptyURL.RawQuery = query.Encode()
 	var lastErr error
@@ -352,12 +352,16 @@ func (c *Client) bootstrapThroughPTY(ctx context.Context, ptyURL *url.URL, encod
 		}
 		return fmt.Errorf("coder: open workspace PTY: %w", err)
 	}
-	defer conn.CloseNow()
-	netConn := websocket.NetConn(context.Background(), conn, websocket.MessageBinary)
-	defer netConn.Close()
+	streamCtx, stopStream := context.WithCancel(ctx)
+	netConn := websocket.NetConn(streamCtx, conn, websocket.MessageBinary)
+	output, outputDone := streamPTYOutput(streamCtx, netConn)
+	defer func() {
+		stopStream()
+		_ = conn.CloseNow()
+		<-outputDone
+	}()
 
 	encoder := json.NewEncoder(netConn)
-	output := streamPTYOutput(netConn)
 	// Coder's reconnecting PTY writes each decoded Data field to the OS PTY but
 	// does not retry a short write. Frame the archive as canonical terminal lines
 	// with sequence and length metadata. The receiver acknowledges only a
@@ -376,8 +380,18 @@ func (c *Client) bootstrapThroughPTY(ctx context.Context, ptyURL *url.URL, encod
 		}
 		sequence++
 	}
-	return sendBootstrapFrame(ctx, encoder, output,
-		fmt.Sprintf("done:%d:0:\n", sequence), bootstrapUploadDone)
+	if err := sendBootstrapFrame(ctx, encoder, output,
+		fmt.Sprintf("done:%d:0:\n", sequence), bootstrapUploadDone); err != nil {
+		return err
+	}
+	result, err := readBootstrapResult(ctx, output)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(result, bootstrapOK) {
+		return nil
+	}
+	return fmt.Errorf("coder: worker bootstrap failed: %s", sanitizePTYOutput(result))
 }
 
 func sendBootstrapFrame(
@@ -547,9 +561,11 @@ type ptyOutput struct {
 	err  error
 }
 
-func streamPTYOutput(reader io.Reader) <-chan ptyOutput {
+func streamPTYOutput(ctx context.Context, reader io.Reader) (<-chan ptyOutput, <-chan struct{}) {
 	result := make(chan ptyOutput)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		defer close(result)
 		buffered := bufio.NewReader(reader)
 		total := 0
@@ -557,15 +573,22 @@ func streamPTYOutput(reader io.Reader) <-chan ptyOutput {
 			line, err := buffered.ReadString('\n')
 			total += len(line)
 			if line != "" || err != nil {
-				result <- ptyOutput{data: line, err: err}
+				select {
+				case result <- ptyOutput{data: line, err: err}:
+				case <-ctx.Done():
+					return
+				}
 			}
 			if err != nil {
 				return
 			}
 		}
-		result <- ptyOutput{err: errors.New("coder: PTY output exceeded limit")}
+		select {
+		case result <- ptyOutput{err: errors.New("coder: PTY output exceeded limit")}:
+		case <-ctx.Done():
+		}
 	}()
-	return result
+	return result, done
 }
 
 func readBootstrapResult(ctx context.Context, output <-chan ptyOutput) (string, error) {

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -246,20 +247,140 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 	client := newTestClient(t, server.URL, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err := client.BootstrapWorker(ctx, testWorkspaceID, sandbox.WorkerBootstrap{
-		Binary: []byte("worker-binary"), Destination: "/usr/local/bin/ao-worker",
-		HelperBinary: []byte("helper-binary"), HelperDestination: "/usr/local/bin/ao",
-		User: "ao-worker", Environment: map[string]string{"AO_WORKER_TOKEN": secret},
-	})
-	if err != nil {
-		t.Fatalf("bootstrap: %v", err)
+	bootstrapResult := make(chan error, 1)
+	go func() {
+		bootstrapResult <- client.BootstrapWorker(ctx, testWorkspaceID, sandbox.WorkerBootstrap{
+			Binary: []byte("worker-binary"), Destination: "/usr/local/bin/ao-worker",
+			HelperBinary: []byte("helper-binary"), HelperDestination: "/usr/local/bin/ao",
+			User: "ao-worker", Environment: map[string]string{"AO_WORKER_TOKEN": secret},
+		})
+	}()
+	var files map[string]string
+	select {
+	case files = <-archiveResult:
+	case <-ctx.Done():
+		t.Fatalf("receive bootstrap archive: %v", ctx.Err())
 	}
-	files := <-archiveResult
 	if files["ao-worker"] != "worker-binary" || files["ao"] != "helper-binary" {
 		t.Fatalf("unexpected binaries in archive: %+v", files)
 	}
 	if !strings.Contains(files["worker.env"], secret) {
 		t.Fatalf("worker environment missing from archive")
+	}
+	if err := <-bootstrapResult; err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+}
+
+func TestBootstrapWorkerPropagatesPostUploadFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v2/workspaces/" + testWorkspaceID:
+			writeWorkspace(t, writer, "running", "connected", true)
+		case "/api/v2/workspaceagents/" + testAgentID + "/pty":
+			serveBootstrapPTY(t, writer, request, func(_ *websocket.Conn, output io.Writer) {
+				_, _ = io.WriteString(output, bootstrapFailed+":23\r\n")
+			})
+		default:
+			http.Error(writer, "unexpected route", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	client := newTestClient(t, server.URL, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.BootstrapWorker(ctx, testWorkspaceID, sandbox.WorkerBootstrap{
+		Binary: []byte("worker-binary"), Destination: "/usr/local/bin/ao-worker",
+		User: "ao-worker",
+	})
+	if err == nil || !strings.Contains(err.Error(), bootstrapFailed+":23") {
+		t.Fatalf("bootstrap error = %v, want post-upload failure", err)
+	}
+}
+
+func TestBootstrapThroughPTYRejectsPrematureClose(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		serveBootstrapPTY(t, writer, request, func(connection *websocket.Conn, _ io.Writer) {
+			_ = connection.Close(websocket.StatusNormalClosure, "")
+		})
+	}))
+	defer server.Close()
+	client := newTestClient(t, server.URL, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.bootstrapThroughPTY(ctx, mustParseURL(t, server.URL+"/pty"), "payload")
+	if err == nil || !strings.Contains(err.Error(), "read workspace PTY") {
+		t.Fatalf("bootstrap error = %v, want premature-close error", err)
+	}
+}
+
+func TestBootstrapThroughPTYCancellationStopsOutput(t *testing.T) {
+	t.Parallel()
+
+	uploaded := make(chan struct{})
+	releaseServer := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseServer) }) }
+	defer release()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		serveBootstrapPTY(t, writer, request, func(_ *websocket.Conn, _ io.Writer) {
+			close(uploaded)
+			<-releaseServer
+		})
+	}))
+	defer server.Close()
+	client := newTestClient(t, server.URL, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- client.bootstrapThroughPTY(ctx, mustParseURL(t, server.URL+"/pty"), "payload")
+	}()
+	select {
+	case <-uploaded:
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap upload did not complete")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("bootstrap error = %v, want context canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("bootstrap did not return after cancellation")
+	}
+	release()
+}
+
+func TestStreamPTYOutputCancellationDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	_, done := streamPTYOutput(ctx, reader)
+	written := make(chan struct{})
+	go func() {
+		_, _ = io.WriteString(writer, "unconsumed output\n")
+		close(written)
+	}()
+	select {
+	case <-written:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PTY reader did not consume output")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PTY output goroutine blocked after cancellation")
 	}
 }
 
@@ -315,6 +436,69 @@ func writeWorkspace(t *testing.T, writer http.ResponseWriter, status, agentStatu
 	}); err != nil {
 		t.Errorf("write workspace: %v", err)
 	}
+}
+
+func serveBootstrapPTY(
+	t *testing.T,
+	writer http.ResponseWriter,
+	request *http.Request,
+	afterUpload func(*websocket.Conn, io.Writer),
+) {
+	t.Helper()
+	connection, err := websocket.Accept(writer, request, nil)
+	if err != nil {
+		t.Errorf("accept websocket: %v", err)
+		return
+	}
+	defer connection.CloseNow()
+	netConnection := websocket.NetConn(context.Background(), connection, websocket.MessageBinary)
+	defer netConnection.Close()
+	decoder := json.NewDecoder(netConnection)
+	expectedSequence := 0
+	for {
+		var input struct {
+			Data string `json:"data"`
+		}
+		if err := decoder.Decode(&input); err != nil {
+			t.Errorf("decode PTY input: %v", err)
+			return
+		}
+		parts := strings.SplitN(strings.TrimSuffix(input.Data, "\n"), ":", 4)
+		if len(parts) != 4 {
+			continue
+		}
+		sequence, sequenceErr := strconv.Atoi(parts[1])
+		declared, declaredErr := strconv.Atoi(parts[2])
+		if sequenceErr != nil || declaredErr != nil {
+			continue
+		}
+		if parts[0] == "data" && sequence == expectedSequence && len(parts[3]) == declared {
+			expectedSequence++
+			if _, err := io.WriteString(netConnection,
+				fmt.Sprintf("%s:%d\r\n", bootstrapUploadACK, expectedSequence)); err != nil {
+				t.Errorf("write upload acknowledgement: %v", err)
+				return
+			}
+			continue
+		}
+		if parts[0] == "done" && sequence == expectedSequence && declared == 0 {
+			if _, err := io.WriteString(netConnection, bootstrapUploadDone+"\r\n"); err != nil {
+				t.Errorf("write upload completion: %v", err)
+				return
+			}
+			afterUpload(connection, netConnection)
+			return
+		}
+	}
+}
+
+func mustParseURL(t *testing.T, value string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(value)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	return parsed
 }
 
 func readArchive(t *testing.T, compressed []byte) map[string]string {

--- a/cloud/internal/sandbox/coder/live_test.go
+++ b/cloud/internal/sandbox/coder/live_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +58,17 @@ func TestLiveLifecycle(t *testing.T) {
 	if environment.Target == "" {
 		t.Fatal("running workspace carried no healthy agent target")
 	}
+	bootstrapFailure := client.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
+		Binary: []byte("#!/bin/sh\nexit 0\n"), Destination: "/proc/ao-worker", User: "ao-worker",
+		Environment: map[string]string{"AO_CODER_LIVE_TEST": "expected-install-failure"},
+	})
+	if bootstrapFailure == nil {
+		t.Fatal("bootstrap to unwritable destination succeeded")
+	}
+	if !strings.Contains(bootstrapFailure.Error(), bootstrapFailed) {
+		t.Fatalf("bootstrap to unwritable destination did not report post-upload failure: %v", bootstrapFailure)
+	}
+	t.Log("observed expected post-upload bootstrap failure")
 	if err := client.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
 		Binary:      []byte("#!/bin/sh\nmkdir -p /workspace/.ao/worker\necho live > /workspace/.ao/worker/coder-live-test\nsleep 300\n"),
 		Destination: "/usr/local/bin/ao-worker", User: "ao-worker",


### PR DESCRIPTION
## Summary

- keep the buffered Coder PTY open after `__AO_UPLOAD_DONE__` and return success only after explicit `__AO_BOOTSTRAP_OK__`
- propagate final `__AO_BOOTSTRAP_FAILED__` and PTY process/transport termination as bootstrap errors
- cancel, close, and join the PTY output producer on success, failure, cancellation, and disconnect so it cannot block after return
- preserve the existing framed archive upload and credential-handling behavior
- extend the credential-gated live lifecycle to prove a deterministic post-upload install failure is surfaced before the valid bootstrap path

Closes #4734.

This is a merge blocker for #4624 and is intentionally stacked on `ao/agent-orchestrator-211/coder-sandbox-provider`.

## Verification

- `cd cloud && go test ./internal/sandbox/coder -run 'TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL|TestBootstrapWorkerPropagatesPostUploadFailure|TestBootstrapThroughPTYRejectsPrematureClose|TestBootstrapThroughPTYCancellationStopsOutput|TestStreamPTYOutputCancellationDoesNotBlock' -count=20`
- `cd cloud && go test -race ./internal/sandbox/coder`
- `cd cloud && go test ./...`
- `cd cloud && go test -race ./...`
- `cd cloud && go vet ./...`
- credentialed staging Coder: `cd cloud && go test ./internal/sandbox/coder -run '^TestLiveLifecycle$' -count=1 -v` — passed in 118.46s, including expected `/proc/ao-worker` post-upload failure, valid bootstrap, stop/start, and delete
- post-test authenticated verification: disposable workspace absent from the owner's active workspace list and direct lookup returned HTTP 410
- `git diff --check`

## Scope and risk

- no persistence paths or lifecycle/reconciler semantics changed
- no shared workspace or staging ECS service changed
- no deployment performed
- credential values are omitted from this PR
