### PR TITLE
fix(project): surface store error when scratch seed fails to list projects

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -606,7 +606,7 @@ func (m *Service) EnsureDefaultScratchProject(ctx context.Context, scratchPath s
 
 	projects, err := m.store.ListProjects(ctx)
 	if err != nil {
-		return Project{}, apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load projects")
+		return Project{}, apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load projects: "+err.Error())
 	}
 	if len(projects) != 0 {
 		return Project{}, nil

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -428,6 +428,38 @@ func TestManager_EnsureDefaultScratchProjectReseedsAfterArchivedScratchLeavesNoA
 		t.Fatalf("active projects = %#v, want reseeded scratch", list)
 	}
 }
+// failingListStore fails every ListProjects call with a fixed cause so the
+// seed path's error wrapping can be asserted.
+type failingListStore struct {
+	project.Store
+	err error
+}
+
+func (s *failingListStore) ListProjects(context.Context) ([]domain.ProjectRecord, error) {
+	return nil, s.err
+}
+
+func TestManager_EnsureDefaultScratchProjectSurfacesStoreFailure(t *testing.T) {
+	ctx := context.Background()
+	cause := errors.New("disk I/O error")
+	m := project.NewWithDeps(project.Deps{Store: &failingListStore{err: cause}})
+
+	_, err := m.EnsureDefaultScratchProject(ctx, filepath.Join(t.TempDir(), "scratch", "default"))
+	if err == nil {
+		t.Fatalf("EnsureDefaultScratchProject: want error, got nil")
+	}
+	var e *apierr.Error
+	if !errors.As(err, &e) {
+		t.Fatalf("error = %v, want *apierr.Error", err)
+	}
+	if e.Code != "PROJECT_LOAD_FAILED" {
+		t.Fatalf("code = %q, want PROJECT_LOAD_FAILED", e.Code)
+	}
+	if !strings.Contains(e.Message, "disk I/O error") {
+		t.Fatalf("message = %q, want wrapped cause", e.Message)
+	}
+}
+
 
 func TestManager_SetConfigRejectsScratchGitOnlyFields(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #4724

## Summary
The reporter's daemon-exit-1 on Windows v0.12.10 was traced to `seedScratchProjectOnBoot` → `EnsureDefaultScratchProject` → `ListProjects` store error — but `EnsureDefaultScratchProject` **discarded the underlying error**, returning `apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load projects")` with no cause. The desktop banner's Details block could only ever show the static message; the real driver error (AV/file lock, disk I/O, WAL state) was unobservable — to the user and to us.

This PR makes the seed path wrap the store cause into the `PROJECT_LOAD_FAILED` message (`"Failed to load projects: " + err.Error()`), matching the file's existing `err.Error()` embedding style elsewhere (e.g. `GIT_INIT_FAILED`). The daemon banner's final line will now carry `seed scratch project: Failed to load projects: list projects: <driver error>`.

**Surgical scope** — one line in `backend/internal/service/project/service.go`, plus a failure-path test.

## What this PR intentionally does NOT do
- **Does not change boot-fatal semantics.** Whether scratch-seed failure should hard-fail the daemon remains as-is; that's a maintainer decision (see issue #4724 RCA comment for the argument both ways — first-run UX vs. "half-alive daemon" risk).
- Does not fix the same dropped-cause pattern at `Service.List` (`PROJECTS_LIST_FAILED`) — different route (HTTP API), filed as follow-up in the issue. Avoiding drive-by.

## Test
- New: `TestManager_EnsureDefaultScratchProjectSurfacesStoreFailure` — failing fake store, asserts `*apierr.Error` + code `PROJECT_LOAD_FAILED` + wrapped cause in message.
- `cd backend && go build ./...` ✅
- `go test ./internal/service/project/...` ✅ (full package, includes existing scratch-seed happy/reseed paths)
- `go vet ./internal/service/project/...` ✅
