### PR TITLE
fix: validate workspace before spawn model

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -766,12 +766,10 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	}
 
 	// Resolve the effective agent config (project base + role override + spawn
-	// override) and validate the model before any durable state is created. A
-	// model the harness cannot honor should not leave a seed row behind.
+	// override) before durable state is created. Model validation is intentionally
+	// deferred until after workspace materialization so project/workspace setup
+	// errors are reported before model-selection errors.
 	agentConfig := applySpawnAgentConfig(effectiveAgentConfig(cfg.Kind, project.Config), cfg.AgentConfig)
-	if err := validateSpawnModel(cfg.Harness, agentConfig.Model); err != nil {
-		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w: %s", ErrUnsupportedModel, err.Error())
-	}
 	// Adapters whose model picker is an agent-owned mode list (e.g. Amp) keep
 	// their selectable values in AgentConfig.Mode. Normalize a copy for the
 	// adapter so `ao spawn --agent amp --model high` launches Amp with `--mode
@@ -847,6 +845,11 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		// in session lists (e.g. when gitworktree refuses the branch).
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, 0, 0, wrapSpawnStage(id, ErrWorkspaceCreate, err)
+	}
+
+	if err := validateSpawnModel(cfg.Harness, agentConfig.Model); err != nil {
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, false)
+		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: %w: %s", id, ErrUnsupportedModel, err.Error())
 	}
 
 	// Per-project workspace provisioning: symlink shared files, then run any

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1346,9 +1346,29 @@ func TestSpawnModelValidation(t *testing.T) {
 		t.Fatalf("amp launch model = %q, want empty after routing to mode", agent.lastConfig.Model)
 	}
 
-	// Amp rejects a model outside its mode list.
+	// Workspace validation happens before model validation so onboarding reports
+	// project/workspace setup problems (for example unresolved default branches)
+	// before model-selection problems.
+	ws.createErr = ports.ErrWorkspaceDefaultBranchUnresolved
 	before := len(st.sessions)
 	_, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, AgentConfig: ports.AgentConfig{Model: "invalid-mode"}})
+	if err == nil {
+		t.Fatal("expected workspace creation to fail")
+	}
+	if !errors.Is(err, ports.ErrWorkspaceDefaultBranchUnresolved) {
+		t.Fatalf("err = %v, want ErrWorkspaceDefaultBranchUnresolved", err)
+	}
+	if errors.Is(err, ErrUnsupportedModel) {
+		t.Fatalf("err = %v, should not report ErrUnsupportedModel before workspace validation", err)
+	}
+	if len(st.sessions) != before {
+		t.Fatalf("workspace failure left a session row behind: %d sessions, want %d", len(st.sessions), before)
+	}
+	ws.createErr = nil
+
+	// Amp rejects a model outside its mode list.
+	before = len(st.sessions)
+	_, _, _, err = m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, AgentConfig: ports.AgentConfig{Model: "invalid-mode"}})
 	if err == nil {
 		t.Fatal("expected amp to reject invalid-mode")
 	}

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -146,13 +146,14 @@ describe("TaskComposer", () => {
 		expect(h.agentValues).toHaveLength(1);
 	});
 
-	it("keeps agent and model in equal stable toolbar tracks", () => {
+	it("keeps agent and model in equal stable toolbar tracks", async () => {
 		render(
 			<Wrap>
 				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
 			</Wrap>,
 		);
 
+		await screen.findByLabelText("Model");
 		const runControls = screen.getByRole("group", { name: "Runs with" });
 		expect(runControls).toHaveClass("composer-run-controls");
 		expect(runControls.closest(".composer-toolbar")).not.toBeNull();
@@ -160,6 +161,40 @@ describe("TaskComposer", () => {
 		expect(screen.getByTestId("agent-field").closest(".composer-toolbar-slot")).not.toBeNull();
 		expect(screen.getByLabelText("Model").closest(".composer-toolbar-slot")).not.toBeNull();
 		expect(runControls.querySelector(".composer-toolbar-divider")).not.toBeNull();
+	});
+
+	it("hides model selection until the local project validates successfully", async () => {
+		h.get.mockImplementation(async (path: string) => {
+			if (path.includes("/models")) {
+				return {
+					data: {
+						agent: "codex",
+						selectionMode: "text",
+						models: [{ id: "gpt-5", label: "GPT-5", isDefault: true }],
+						allowCustom: true,
+					},
+				};
+			}
+			return { error: { message: "Default branch is unresolved" } };
+		});
+
+		render(
+			<Wrap>
+				<TaskComposer projectId="proj-1" onCreated={vi.fn()} />
+			</Wrap>,
+		);
+
+		await waitFor(() => expect(h.get).toHaveBeenCalledWith("/api/v1/projects/{id}", expect.anything()));
+		fireEvent.click(screen.getByTestId("agent-field"));
+
+		const runControls = screen.getByRole("group", { name: "Runs with" });
+		expect(runControls.querySelectorAll(".composer-toolbar-slot")).toHaveLength(1);
+		expect(runControls.querySelector(".composer-toolbar-divider")).toBeNull();
+		expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+		expect(h.get).not.toHaveBeenCalledWith(
+			"/api/v1/agents/{agent}/models",
+			expect.anything(),
+		);
 	});
 
 	it("keeps the file attach control in the bottom action row", () => {

--- a/frontend/src/renderer/components/TaskComposer.tsx
+++ b/frontend/src/renderer/components/TaskComposer.tsx
@@ -220,9 +220,12 @@ export function TaskComposer({
 	const projectModelForSelectedAgent = selectedAgent === defaultWorkerAgent ? defaultWorkerModel : "";
 	const projectModeForSelectedAgent = selectedAgent === defaultWorkerAgent ? defaultWorkerMode : "";
 	const agentCatalog = agentsQuery.data;
+	const projectReadyForModelSelection = isCloudProject || (Boolean(projectId) && projectQuery.isSuccess);
 
 	// Shares the picker's query key, so this is the same fetch, not a second one.
-	const modelCatalogQuery = useQuery(agentModelsQueryOptions(selectedAgent, modelsProjectId));
+	const modelCatalogQuery = useQuery(
+		agentModelsQueryOptions(selectedAgent, modelsProjectId, projectReadyForModelSelection),
+	);
 	const revalidationQuery = useQuery({
 		queryKey: [
 			"agent-model-revalidation",
@@ -231,7 +234,10 @@ export function TaskComposer({
 			modelCatalogQuery.data?.validatedAt ?? "",
 		],
 		queryFn: () => revalidateAgentModels(selectedAgent, modelsProjectId),
-		enabled: selectedAgent !== "" && modelCatalogQuery.data?.refreshRecommended === true,
+		enabled:
+			projectReadyForModelSelection &&
+			selectedAgent !== "" &&
+			modelCatalogQuery.data?.refreshRecommended === true,
 		staleTime: Number.POSITIVE_INFINITY,
 		retry: false,
 	});
@@ -429,6 +435,7 @@ export function TaskComposer({
 			}}
 			renderAgentControl={(control) => <DesktopAgentControl {...control} />}
 			renderModelControl={(control) => <TaskModelPicker {...control} />}
+			showModelControl={projectReadyForModelSelection}
 		/>
 	);
 }

--- a/frontend/src/renderer/hooks/useAgentModelsQuery.ts
+++ b/frontend/src/renderer/hooks/useAgentModelsQuery.ts
@@ -30,11 +30,11 @@ async function requestAgentModels(
 	return result.data as AgentModelCatalog;
 }
 
-export function agentModelsQueryOptions(agentId: string, projectId: string) {
+export function agentModelsQueryOptions(agentId: string, projectId: string, enabled = true) {
 	return queryOptions({
 		queryKey: agentModelsQueryKey(agentId, projectId),
 		queryFn: () => requestAgentModels(agentId, projectId, "cached"),
-		enabled: agentId !== "",
+		enabled: enabled && agentId !== "",
 		staleTime: MODEL_CATALOG_VALIDATION_INTERVAL_MS,
 	});
 }

--- a/packages/product-ui/src/TaskComposerView.test.tsx
+++ b/packages/product-ui/src/TaskComposerView.test.tsx
@@ -113,6 +113,16 @@ describe("TaskComposerView", () => {
 		expect(screen.getByRole("group", { name: "Runs with" })).toHaveClass("composer-run-controls");
 	});
 
+	it("can hide the model control while project validation is unresolved", () => {
+		render(<TaskComposerView {...viewProps({ showModelControl: false })} />);
+
+		const runControls = screen.getByRole("group", { name: "Runs with" });
+		expect(screen.getByRole("button", { name: "Agent" })).toBeInTheDocument();
+		expect(screen.queryByRole("textbox", { name: "Model" })).not.toBeInTheDocument();
+		expect(runControls.querySelectorAll(".composer-toolbar-slot")).toHaveLength(1);
+		expect(runControls.querySelector(".composer-toolbar-divider")).toBeNull();
+	});
+
 	it("keeps the surrounding controls stable while typing", () => {
 		const renderAgentControl = vi.fn((control) => <button type="button">{control.value}</button>);
 		render(<TaskComposerView {...viewProps({ renderAgentControl })} />);

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -113,6 +113,7 @@ export type TaskComposerViewProps = {
 	onPromptChange: (value: string) => void;
 	renderAgentControl: (control: TaskComposerAgentControl) => ReactNode;
 	renderModelControl: (control: TaskComposerModelControl) => ReactNode;
+	showModelControl?: boolean;
 	submission: TaskComposerSubmission;
 };
 
@@ -188,6 +189,7 @@ export function TaskComposerView({
 	onPromptChange,
 	renderAgentControl,
 	renderModelControl,
+	showModelControl = true,
 	submission,
 }: TaskComposerViewProps) {
 	const promptId = useId();
@@ -370,10 +372,14 @@ export function TaskComposerView({
 					<div className="composer-toolbar-slot">
 						{renderAgentControl({ ...agent, id: agentId })}
 					</div>
-					<span className="composer-toolbar-divider" aria-hidden="true" />
-					<div className="composer-toolbar-slot">
-						{renderModelControl({ ...model, id: modelId })}
-					</div>
+					{showModelControl ? (
+						<>
+							<span className="composer-toolbar-divider" aria-hidden="true" />
+							<div className="composer-toolbar-slot">
+								{renderModelControl({ ...model, id: modelId })}
+							</div>
+						</>
+					) : null}
 				</div>
 
 				<button


### PR DESCRIPTION
## Summary
- defer unsupported model validation until after session workspace materialization so project/workspace errors win during spawn
- hide the new-task model picker until the local project lookup validates successfully
- prevent model catalog and revalidation requests while project validation is unresolved or failed
- add regression coverage for backend error precedence and renderer/product-ui model-control hiding

## Tests
- cd backend && go test ./internal/session_manager -run TestSpawnModelValidation -count=1
- cd backend && go test ./internal/service/session -run DEFAULT_BRANCH_UNRESOLVED -count=1
- npm --prefix frontend test -- src/renderer/components/TaskComposer.test.tsx
- npm --prefix packages/product-ui test -- TaskComposerView.test.tsx
- npm --prefix frontend run typecheck
- npm --prefix packages/product-ui run typecheck

## Notes
- Full `go test ./internal/session_manager` was attempted but this local environment fails existing binary-prerequisite tests because no usable tmux is available.