### PR TITLE
chore(mobile): bump app version to 1.3.0

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -2,7 +2,7 @@
 	"expo": {
 		"name": "AO",
 		"slug": "ao-mobile",
-		"version": "1.2.1",
+		"version": "1.3.0",
 		"runtimeVersion": {
 			"policy": "fingerprint"
 		},


### PR DESCRIPTION
## What

Bump the Expo mobile app marketing version from `1.2.1` to `1.3.0`.

## Why

The iOS and Android 1.3.0 release builds have been produced from this commit. Landing the version stamp keeps `main` reproducible for those artifacts and their fingerprint runtime versions.

## How

Update only `expo.version` in `packages/mobile/app.json`. EAS continues to manage platform build numbers remotely through `appVersionSource: remote` and `autoIncrement: true`.

## Testing

- `cd packages/mobile && npm test` — 77 files / 701 tests passed
- `cd packages/mobile && npm run typecheck`
- `cd packages/mobile && npx expo config --type public --json` — resolves version `1.3.0`
- `git diff --check`

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] No test change needed for a marketing-version-only update
- [x] Relevant mobile checks pass