### PR TITLE
fix(cloud): coalesce pending terminal input

### DIFF
--- a/cloud/internal/postgres/worker_transport_store.go
+++ b/cloud/internal/postgres/worker_transport_store.go
@@ -83,17 +83,19 @@ func createWorkerRequest(
 	if kind == "workspace.write" && effectiveMode(mode, modeCap) == "read-only" {
 		return domain.WorkerRequest{}, ErrWorkspaceReadOnly
 	}
+	terminalRequest := strings.HasPrefix(kind, "terminal.")
 	var outstanding int
 	if err := tx.QueryRow(ctx,
 		`SELECT count(*) FROM ao_worker_requests
 		WHERE org_id = $1 AND session_id = $2
-		  AND status IN ('pending', 'claimed') AND expires_at > now()`,
-		orgID, sessionID,
+		  AND status IN ('pending', 'claimed')
+		  AND expires_at > CASE WHEN $3 THEN statement_timestamp() ELSE now() END`,
+		orgID, sessionID, terminalRequest,
 	).Scan(&outstanding); err != nil {
 		return domain.WorkerRequest{}, err
 	}
 	limit := maxOutstandingWorkspaceRequests
-	if strings.HasPrefix(kind, "terminal.") {
+	if terminalRequest {
 		limit = maxOutstandingWorkerRequests
 	}
 	if outstanding >= limit {
@@ -105,11 +107,17 @@ func createWorkerRequest(
 	}
 	err := scanWorkerRequest(tx.QueryRow(ctx,
 		`INSERT INTO ao_worker_requests (
-			org_id, session_id, worker_epoch, kind, payload, expires_at
-		) VALUES ($1, $2, $3, $4, $5, now() + $6::interval)
+			org_id, session_id, worker_epoch, kind, payload, expires_at,
+			created_at, updated_at
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			(CASE WHEN $7 THEN statement_timestamp() ELSE now() END) + $6::interval,
+			CASE WHEN $7 THEN statement_timestamp() ELSE now() END,
+			CASE WHEN $7 THEN statement_timestamp() ELSE now() END
+		)
 		RETURNING id, org_id, session_id, worker_epoch, kind, payload, status,
 			response, error_code, error_message, attempt_count, expires_at`,
-		orgID, sessionID, epoch, kind, payload, intervalString(ttl),
+		orgID, sessionID, epoch, kind, payload, intervalString(ttl), terminalRequest,
 	), &request)
 	return request, normalizeConstraintError(err)
 }
@@ -682,46 +690,56 @@ func (s *Store) QueueTerminalInput(
 	inputID string,
 	data []byte,
 ) error {
+	return s.withOrg(ctx, terminal.OrgID, func(tx pgx.Tx) error {
+		return queueTerminalInput(ctx, tx, terminal, inputID, data)
+	})
+}
+
+func queueTerminalInput(
+	ctx context.Context,
+	tx pgx.Tx,
+	terminal domain.TerminalSession,
+	inputID string,
+	data []byte,
+) error {
 	payload, _ := json.Marshal(map[string]any{
 		"terminalId": terminal.ID,
 		"inputId":    inputID,
 		"data":       data,
 	})
-	return s.withOrg(ctx, terminal.OrgID, func(tx pgx.Tx) error {
-		// Serialize terminal enqueue operations per session. Besides preserving the
-		// existing created_at order across simultaneous terminal connections, this
-		// keeps a resize from being inserted between selecting a coalescing target
-		// and appending input to it.
-		if _, err := tx.Exec(ctx,
-			`SELECT id FROM ao_sessions
-			WHERE org_id = $1 AND id = $2
-			FOR UPDATE`,
-			terminal.OrgID, terminal.SessionID,
-		); err != nil {
-			return err
-		}
-		if err := terminalRequestReady(ctx, tx, terminal); err != nil {
-			return err
-		}
-		if inputID != "" {
-			exists, err := terminalRequestExists(
-				ctx, tx, terminal, "terminal.input", inputID,
-			)
-			if err != nil || exists {
-				return err
-			}
-		} else {
-			coalesced, err := coalescePendingTerminalInput(ctx, tx, terminal, data)
-			if err != nil || coalesced {
-				return err
-			}
-		}
-		_, err := createWorkerRequest(
-			ctx, tx, terminal.OrgID, terminal.SessionID,
-			"terminal.input", payload, terminalRequestTTL, "",
-		)
+	// Serialize terminal enqueue operations per session. Besides preserving the
+	// existing created_at order across simultaneous terminal connections, this
+	// keeps a resize from being inserted between selecting a coalescing target
+	// and appending input to it.
+	if _, err := tx.Exec(ctx,
+		`SELECT id FROM ao_sessions
+		WHERE org_id = $1 AND id = $2
+		FOR UPDATE`,
+		terminal.OrgID, terminal.SessionID,
+	); err != nil {
 		return err
-	})
+	}
+	if err := terminalRequestReady(ctx, tx, terminal); err != nil {
+		return err
+	}
+	if inputID != "" {
+		exists, err := terminalRequestExists(
+			ctx, tx, terminal, "terminal.input", inputID,
+		)
+		if err != nil || exists {
+			return err
+		}
+	} else {
+		coalesced, err := coalescePendingTerminalInput(ctx, tx, terminal, data)
+		if err != nil || coalesced {
+			return err
+		}
+	}
+	_, err := createWorkerRequest(
+		ctx, tx, terminal.OrgID, terminal.SessionID,
+		"terminal.input", payload, terminalRequestTTL, "",
+	)
+	return err
 }
 
 func (s *Store) QueueTerminalResize(
@@ -745,23 +763,34 @@ func (s *Store) queueTerminalRequest(
 	payload []byte,
 ) error {
 	return s.withOrg(ctx, terminal.OrgID, func(tx pgx.Tx) error {
-		if err := terminalRequestReady(ctx, tx, terminal); err != nil {
+		return queueTerminalRequest(ctx, tx, terminal, kind, idempotencyKey, payload)
+	})
+}
+
+func queueTerminalRequest(
+	ctx context.Context,
+	tx pgx.Tx,
+	terminal domain.TerminalSession,
+	kind string,
+	idempotencyKey string,
+	payload []byte,
+) error {
+	if err := terminalRequestReady(ctx, tx, terminal); err != nil {
+		return err
+	}
+	if idempotencyKey != "" {
+		exists, err := terminalRequestExists(ctx, tx, terminal, kind, idempotencyKey)
+		if err != nil {
 			return err
 		}
-		if idempotencyKey != "" {
-			exists, err := terminalRequestExists(ctx, tx, terminal, kind, idempotencyKey)
-			if err != nil {
-				return err
-			}
-			if exists {
-				return nil
-			}
+		if exists {
+			return nil
 		}
-		_, err := createWorkerRequest(
-			ctx, tx, terminal.OrgID, terminal.SessionID, kind, payload, terminalRequestTTL, "",
-		)
-		return err
-	})
+	}
+	_, err := createWorkerRequest(
+		ctx, tx, terminal.OrgID, terminal.SessionID, kind, payload, terminalRequestTTL, "",
+	)
+	return err
 }
 
 func terminalRequestReady(
@@ -780,7 +809,8 @@ func terminalRequestReady(
 			 AND worker.disconnected_at IS NULL
 			WHERE terminal.org_id = $1 AND terminal.session_id = $2
 			  AND terminal.id = $3 AND terminal.worker_epoch = $4
-			  AND terminal.state = 'open' AND terminal.expires_at > now()
+			  AND terminal.state = 'open'
+			  AND terminal.expires_at > statement_timestamp()
 		)`,
 		terminal.OrgID, terminal.SessionID, terminal.ID, terminal.WorkerEpoch,
 	).Scan(&current); err != nil {
@@ -826,7 +856,8 @@ func coalescePendingTerminalInput(
 		FROM ao_worker_requests
 		WHERE org_id = $1 AND session_id = $2 AND worker_epoch = $3
 		  AND kind IN ('terminal.input', 'terminal.resize')
-		  AND status IN ('pending', 'claimed') AND expires_at > now()
+		  AND status IN ('pending', 'claimed')
+		  AND expires_at > statement_timestamp()
 		  AND payload->>'terminalId' = $4
 		ORDER BY created_at DESC, id DESC
 		LIMIT 1
@@ -851,7 +882,9 @@ func coalescePendingTerminalInput(
 	}
 	tag, err := tx.Exec(ctx,
 		`UPDATE ao_worker_requests
-		SET payload = $1, expires_at = now() + $2::interval, updated_at = now()
+		SET payload = $1,
+			expires_at = statement_timestamp() + $2::interval,
+			updated_at = statement_timestamp()
 		WHERE org_id = $3 AND session_id = $4 AND id = $5
 		  AND worker_epoch = $6 AND kind = 'terminal.input'
 		  AND status = 'pending'`,

--- a/cloud/internal/postgres/worker_transport_store.go
+++ b/cloud/internal/postgres/worker_transport_store.go
@@ -19,6 +19,8 @@ const (
 	maxOutstandingWorkerRequests    = 10
 	maxOutstandingWorkspaceRequests = 6
 	maxTerminalOutputBytes          = 4 << 20
+	maxTerminalInputBytes           = 16 << 10
+	terminalRequestTTL              = 15 * time.Second
 	// interactiveSessionLease prevents the idle scanner from pausing a sandbox
 	// while a user is connecting to either terminal surface.
 	interactiveSessionLease = 2 * time.Minute
@@ -685,7 +687,41 @@ func (s *Store) QueueTerminalInput(
 		"inputId":    inputID,
 		"data":       data,
 	})
-	return s.queueTerminalRequest(ctx, terminal, "terminal.input", inputID, payload)
+	return s.withOrg(ctx, terminal.OrgID, func(tx pgx.Tx) error {
+		// Serialize terminal enqueue operations per session. Besides preserving the
+		// existing created_at order across simultaneous terminal connections, this
+		// keeps a resize from being inserted between selecting a coalescing target
+		// and appending input to it.
+		if _, err := tx.Exec(ctx,
+			`SELECT id FROM ao_sessions
+			WHERE org_id = $1 AND id = $2
+			FOR UPDATE`,
+			terminal.OrgID, terminal.SessionID,
+		); err != nil {
+			return err
+		}
+		if err := terminalRequestReady(ctx, tx, terminal); err != nil {
+			return err
+		}
+		if inputID != "" {
+			exists, err := terminalRequestExists(
+				ctx, tx, terminal, "terminal.input", inputID,
+			)
+			if err != nil || exists {
+				return err
+			}
+		} else {
+			coalesced, err := coalescePendingTerminalInput(ctx, tx, terminal, data)
+			if err != nil || coalesced {
+				return err
+			}
+		}
+		_, err := createWorkerRequest(
+			ctx, tx, terminal.OrgID, terminal.SessionID,
+			"terminal.input", payload, terminalRequestTTL, "",
+		)
+		return err
+	})
 }
 
 func (s *Store) QueueTerminalResize(
@@ -709,37 +745,12 @@ func (s *Store) queueTerminalRequest(
 	payload []byte,
 ) error {
 	return s.withOrg(ctx, terminal.OrgID, func(tx pgx.Tx) error {
-		var current bool
-		if err := tx.QueryRow(ctx,
-			`SELECT EXISTS (
-				SELECT 1 FROM ao_terminal_sessions terminal
-				JOIN ao_worker_connections worker
-				  ON worker.org_id = terminal.org_id
-				 AND worker.session_id = terminal.session_id
-				 AND worker.epoch = terminal.worker_epoch
-				 AND worker.disconnected_at IS NULL
-				WHERE terminal.org_id = $1 AND terminal.session_id = $2
-				  AND terminal.id = $3 AND terminal.worker_epoch = $4
-				  AND terminal.state = 'open' AND terminal.expires_at > now()
-			)`,
-			terminal.OrgID, terminal.SessionID, terminal.ID, terminal.WorkerEpoch,
-		).Scan(&current); err != nil {
+		if err := terminalRequestReady(ctx, tx, terminal); err != nil {
 			return err
 		}
-		if !current {
-			return ErrWorkerUnavailable
-		}
 		if idempotencyKey != "" {
-			var exists bool
-			if err := tx.QueryRow(ctx,
-				`SELECT EXISTS (
-					SELECT 1 FROM ao_worker_requests
-					WHERE org_id = $1 AND session_id = $2 AND kind = $3
-					  AND payload->>'terminalId' = $4
-					  AND payload->>'inputId' = $5
-				)`,
-				terminal.OrgID, terminal.SessionID, kind, terminal.ID, idempotencyKey,
-			).Scan(&exists); err != nil {
+			exists, err := terminalRequestExists(ctx, tx, terminal, kind, idempotencyKey)
+			if err != nil {
 				return err
 			}
 			if exists {
@@ -747,10 +758,129 @@ func (s *Store) queueTerminalRequest(
 			}
 		}
 		_, err := createWorkerRequest(
-			ctx, tx, terminal.OrgID, terminal.SessionID, kind, payload, 15*time.Second, "",
+			ctx, tx, terminal.OrgID, terminal.SessionID, kind, payload, terminalRequestTTL, "",
 		)
 		return err
 	})
+}
+
+func terminalRequestReady(
+	ctx context.Context,
+	tx pgx.Tx,
+	terminal domain.TerminalSession,
+) error {
+	var current bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM ao_terminal_sessions terminal
+			JOIN ao_worker_connections worker
+			  ON worker.org_id = terminal.org_id
+			 AND worker.session_id = terminal.session_id
+			 AND worker.epoch = terminal.worker_epoch
+			 AND worker.disconnected_at IS NULL
+			WHERE terminal.org_id = $1 AND terminal.session_id = $2
+			  AND terminal.id = $3 AND terminal.worker_epoch = $4
+			  AND terminal.state = 'open' AND terminal.expires_at > now()
+		)`,
+		terminal.OrgID, terminal.SessionID, terminal.ID, terminal.WorkerEpoch,
+	).Scan(&current); err != nil {
+		return err
+	}
+	if !current {
+		return ErrWorkerUnavailable
+	}
+	return nil
+}
+
+func terminalRequestExists(
+	ctx context.Context,
+	tx pgx.Tx,
+	terminal domain.TerminalSession,
+	kind string,
+	idempotencyKey string,
+) (bool, error) {
+	var exists bool
+	err := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM ao_worker_requests
+			WHERE org_id = $1 AND session_id = $2 AND kind = $3
+			  AND payload->>'terminalId' = $4
+			  AND payload->>'inputId' = $5
+		)`,
+		terminal.OrgID, terminal.SessionID, kind, terminal.ID, idempotencyKey,
+	).Scan(&exists)
+	return exists, err
+}
+
+func coalescePendingTerminalInput(
+	ctx context.Context,
+	tx pgx.Tx,
+	terminal domain.TerminalSession,
+	data []byte,
+) (bool, error) {
+	var requestID string
+	var kind, status string
+	var payload []byte
+	err := tx.QueryRow(ctx,
+		`SELECT id, kind, status, payload
+		FROM ao_worker_requests
+		WHERE org_id = $1 AND session_id = $2 AND worker_epoch = $3
+		  AND kind IN ('terminal.input', 'terminal.resize')
+		  AND status IN ('pending', 'claimed') AND expires_at > now()
+		  AND payload->>'terminalId' = $4
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1
+		FOR UPDATE`,
+		terminal.OrgID, terminal.SessionID, terminal.WorkerEpoch, terminal.ID,
+	).Scan(&requestID, &kind, &status, &payload)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	// Only an unclaimed input at the tail of the terminal stream is safe to
+	// extend. A claimed input may already have reached the PTY, while a resize is
+	// an ordering boundary for full-screen TUIs.
+	if kind != "terminal.input" || status != "pending" {
+		return false, nil
+	}
+	coalesced, ok := appendTerminalInputPayload(payload, terminal.ID, data)
+	if !ok {
+		return false, nil
+	}
+	tag, err := tx.Exec(ctx,
+		`UPDATE ao_worker_requests
+		SET payload = $1, expires_at = now() + $2::interval, updated_at = now()
+		WHERE org_id = $3 AND session_id = $4 AND id = $5
+		  AND worker_epoch = $6 AND kind = 'terminal.input'
+		  AND status = 'pending'`,
+		coalesced, intervalString(terminalRequestTTL), terminal.OrgID,
+		terminal.SessionID, requestID, terminal.WorkerEpoch,
+	)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+func appendTerminalInputPayload(payload []byte, terminalID string, data []byte) ([]byte, bool) {
+	var input struct {
+		TerminalID string `json:"terminalId"`
+		InputID    string `json:"inputId,omitempty"`
+		Data       []byte `json:"data"`
+	}
+	if json.Unmarshal(payload, &input) != nil ||
+		input.TerminalID != terminalID ||
+		input.InputID != "" ||
+		len(input.Data) == 0 ||
+		len(data) == 0 ||
+		len(input.Data)+len(data) > maxTerminalInputBytes {
+		return nil, false
+	}
+	input.Data = append(input.Data, data...)
+	coalesced, err := json.Marshal(input)
+	return coalesced, err == nil
 }
 
 func (s *Store) CloseTerminal(ctx context.Context, terminal domain.TerminalSession) error {

--- a/cloud/internal/postgres/worker_transport_store_test.go
+++ b/cloud/internal/postgres/worker_transport_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
 	"github.com/aoagents/agent-orchestrator/cloud/internal/worker"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 func TestAppendTerminalInputPayloadPreservesOrderedBytes(t *testing.T) {
@@ -152,6 +153,77 @@ func TestQueueTerminalInputCoalescesOnlyThePendingTail(t *testing.T) {
 	); err != nil || ok || request.ID != "" {
 		t.Fatalf("extra request = %+v, ok = %v, err = %v", request, ok, err)
 	}
+}
+
+func TestTerminalRequestOrderUsesPostLockTimestamp(t *testing.T) {
+	store, terminal, workerID := newTerminalQueueFixture(t)
+	ctx := context.Background()
+
+	// Transaction A starts first, but B acquires the session lock and enqueues a
+	// resize first. Transaction timestamps would put A ahead of B even though the
+	// lock defines the opposite mutation order.
+	txA := beginTerminalQueueTransaction(t, store, terminal.OrgID)
+	var startedA time.Time
+	if err := txA.QueryRow(ctx, `SELECT transaction_timestamp()`).Scan(&startedA); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1500 * time.Millisecond)
+	txB := beginTerminalQueueTransaction(t, store, terminal.OrgID)
+	var startedB time.Time
+	if err := txB.QueryRow(ctx, `SELECT transaction_timestamp()`).Scan(&startedB); err != nil {
+		t.Fatal(err)
+	}
+	if !startedB.After(startedA) {
+		t.Fatalf("transaction B started at %s, want after A at %s", startedB, startedA)
+	}
+
+	resizePayload, err := json.Marshal(map[string]any{
+		"terminalId": terminal.ID,
+		"columns":    120,
+		"rows":       40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := queueTerminalRequest(
+		ctx, txB, terminal, "terminal.resize", "", resizePayload,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := txB.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := queueTerminalInput(ctx, txA, terminal, "input-a", []byte("a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := txA.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	resize := claimTerminalRequest(t, store, terminal, workerID, "terminal.resize")
+	completeTerminalRequest(t, store, terminal, workerID, resize)
+	input := claimTerminalRequest(t, store, terminal, workerID, "terminal.input")
+	if data := terminalRequestData(t, input); !bytes.Equal(data, []byte("a")) {
+		t.Fatalf("input = %v, want %v", data, []byte("a"))
+	}
+	if remaining := time.Until(input.ExpiresAt); remaining < terminalRequestTTL-time.Second {
+		t.Fatalf("input TTL remaining = %s, want at least %s", remaining, terminalRequestTTL-time.Second)
+	}
+}
+
+func beginTerminalQueueTransaction(t *testing.T, store *Store, orgID string) pgx.Tx {
+	t.Helper()
+	tx, err := store.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback(context.Background()) })
+	if _, err := tx.Exec(
+		context.Background(), `SELECT set_config('ao.org_id', $1, true)`, orgID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return tx
 }
 
 func newTerminalQueueFixture(

--- a/cloud/internal/postgres/worker_transport_store_test.go
+++ b/cloud/internal/postgres/worker_transport_store_test.go
@@ -1,0 +1,293 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
+	"github.com/aoagents/agent-orchestrator/cloud/internal/worker"
+	"github.com/google/uuid"
+)
+
+func TestAppendTerminalInputPayloadPreservesOrderedBytes(t *testing.T) {
+	original := []byte{'a', 0x03, 0x1b, '[', 'A', 0x00}
+	incoming := []byte("界\r")
+	payload, err := json.Marshal(map[string]any{
+		"terminalId": "terminal-1",
+		"data":       original,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	coalesced, ok := appendTerminalInputPayload(payload, "terminal-1", incoming)
+	if !ok {
+		t.Fatal("appendTerminalInputPayload() did not coalesce compatible input")
+	}
+	var command struct {
+		TerminalID string `json:"terminalId"`
+		Data       []byte `json:"data"`
+	}
+	if err := json.Unmarshal(coalesced, &command); err != nil {
+		t.Fatal(err)
+	}
+	if command.TerminalID != "terminal-1" {
+		t.Fatalf("terminal id = %q, want terminal-1", command.TerminalID)
+	}
+	want := append(append([]byte(nil), original...), incoming...)
+	if !bytes.Equal(command.Data, want) {
+		t.Fatalf("coalesced data = %v, want %v", command.Data, want)
+	}
+}
+
+func TestAppendTerminalInputPayloadKeepsDeliveryBoundaries(t *testing.T) {
+	tests := []struct {
+		name       string
+		terminalID string
+		inputID    string
+		data       []byte
+		incoming   []byte
+	}{
+		{
+			name:       "different terminal",
+			terminalID: "terminal-2",
+			data:       []byte("a"),
+			incoming:   []byte("b"),
+		},
+		{
+			name:       "idempotent input",
+			terminalID: "terminal-1",
+			inputID:    "input-1",
+			data:       []byte("a"),
+			incoming:   []byte("b"),
+		},
+		{
+			name:       "empty existing input",
+			terminalID: "terminal-1",
+			data:       nil,
+			incoming:   []byte("b"),
+		},
+		{
+			name:       "empty incoming input",
+			terminalID: "terminal-1",
+			data:       []byte("a"),
+			incoming:   nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload, err := json.Marshal(map[string]any{
+				"terminalId": "terminal-1",
+				"inputId":    test.inputID,
+				"data":       test.data,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := appendTerminalInputPayload(payload, test.terminalID, test.incoming); ok {
+				t.Fatal("appendTerminalInputPayload() crossed a delivery boundary")
+			}
+		})
+	}
+}
+
+func TestAppendTerminalInputPayloadHonorsWorkerFrameLimit(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"terminalId": "terminal-1",
+		"data":       []byte(strings.Repeat("a", maxTerminalInputBytes-1)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := appendTerminalInputPayload(payload, "terminal-1", []byte("b")); !ok {
+		t.Fatal("appendTerminalInputPayload() rejected the exact worker frame limit")
+	}
+	if _, ok := appendTerminalInputPayload(payload, "terminal-1", []byte("bc")); ok {
+		t.Fatal("appendTerminalInputPayload() exceeded the worker frame limit")
+	}
+}
+
+func TestQueueTerminalInputCoalescesOnlyThePendingTail(t *testing.T) {
+	store, terminal, workerID := newTerminalQueueFixture(t)
+	ctx := context.Background()
+
+	first := bytes.Repeat([]byte("a"), 100)
+	copy(first[1:5], []byte{0x03, 0x1b, '[', 'A'})
+	for _, value := range first {
+		if err := store.QueueTerminalInput(ctx, terminal, "", []byte{value}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	request := claimTerminalRequest(t, store, terminal, workerID, "terminal.input")
+	if data := terminalRequestData(t, request); !bytes.Equal(data, first) {
+		t.Fatalf("first input = %v, want %v", data, first)
+	}
+	completeTerminalRequest(t, store, terminal, workerID, request)
+
+	if err := store.QueueTerminalResize(ctx, terminal, 120, 40); err != nil {
+		t.Fatal(err)
+	}
+	for _, data := range [][]byte{[]byte("界"), []byte("\r")} {
+		if err := store.QueueTerminalInput(ctx, terminal, "", data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	resize := claimTerminalRequest(t, store, terminal, workerID, "terminal.resize")
+	completeTerminalRequest(t, store, terminal, workerID, resize)
+	request = claimTerminalRequest(t, store, terminal, workerID, "terminal.input")
+	if data := terminalRequestData(t, request); !bytes.Equal(data, []byte("界\r")) {
+		t.Fatalf("input after resize = %v, want %v", data, []byte("界\r"))
+	}
+	completeTerminalRequest(t, store, terminal, workerID, request)
+
+	if request, ok, err := store.ClaimWorkerRequest(
+		ctx, terminal.OrgID, terminal.SessionID, workerID, terminal.WorkerEpoch, time.Minute,
+	); err != nil || ok || request.ID != "" {
+		t.Fatalf("extra request = %+v, ok = %v, err = %v", request, ok, err)
+	}
+}
+
+func newTerminalQueueFixture(
+	t *testing.T,
+) (*Store, domain.TerminalSession, string) {
+	t.Helper()
+	databaseURL := os.Getenv("AO_CLOUD_TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("AO_CLOUD_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, databaseURL); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store, err := Open(ctx, databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(store.Close)
+
+	unique := strings.ToLower(uuid.NewString()[:8])
+	tokenHash := make([]byte, 32)
+	if _, err := rand.Read(tokenHash); err != nil {
+		t.Fatal(err)
+	}
+	principal, orgID, err := store.RegisterLocal(ctx, domain.LocalRegistration{
+		Email:        "terminal-queue-" + unique + "@example.com",
+		DisplayName:  "Terminal queue test",
+		PasswordHash: "test-password-hash",
+		OrgSlug:      "terminal-queue-" + unique,
+		OrgName:      "Terminal queue test",
+	}, tokenHash, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, err := store.CreateProject(
+		ctx, principal, orgID, unique+"-project", domain.CreateProject{
+			DisplayName:   "Terminal queue test",
+			RepositoryURL: "https://github.com/example/repo.git",
+			DefaultBranch: "main",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := store.CreateSession(
+		ctx, principal, orgID, unique+"-session", 100, domain.CreateSession{
+			ProjectID:   project.ID,
+			Kind:        "worker",
+			Harness:     "codex",
+			DisplayName: "Terminal queue test",
+			Provider:    "nodeops",
+			ResourceProfile: json.RawMessage(
+				`{"provider":"nodeops","nodeOps":{"defaultShape":"s-4vcpu-8gb","defaultRootFs":"devbox:1"}}`,
+			),
+			BootstrapContext: json.RawMessage(`{"provider":"nodeops"}`),
+			Release:          "test-release",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := store.IssueAccessTicket(
+		ctx, orgID, session.ID, "worker_bootstrap", []string{"worker:transport"}, time.Minute,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := store.RedeemWorkerBootstrapTicket(ctx, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerID := worker.NextWorkerID(session.ID, ticket.WorkerEpoch)
+	capabilities := []string{"worker.transport"}
+	if err := store.RegisterWorkerBootstrap(
+		ctx, orgID, session.ID, workerID, "test", ticket.WorkerEpoch, capabilities,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkWorkerSeen(
+		ctx, orgID, session.ID, workerID, "test", ticket.WorkerEpoch, capabilities,
+	); err != nil {
+		t.Fatal(err)
+	}
+	terminal, err := store.EnsureWorkerAgentTerminal(
+		ctx, orgID, session.ID, workerID, ticket.WorkerEpoch, time.Minute,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, terminal, workerID
+}
+
+func claimTerminalRequest(
+	t *testing.T,
+	store *Store,
+	terminal domain.TerminalSession,
+	workerID string,
+	kind string,
+) domain.WorkerRequest {
+	t.Helper()
+	request, ok, err := store.ClaimWorkerRequest(
+		context.Background(), terminal.OrgID, terminal.SessionID,
+		workerID, terminal.WorkerEpoch, time.Minute,
+	)
+	if err != nil || !ok || request.Kind != kind {
+		t.Fatalf("request = %+v, ok = %v, err = %v; want %s", request, ok, err, kind)
+	}
+	return request
+}
+
+func completeTerminalRequest(
+	t *testing.T,
+	store *Store,
+	terminal domain.TerminalSession,
+	workerID string,
+	request domain.WorkerRequest,
+) {
+	t.Helper()
+	if err := store.CompleteWorkerRequest(
+		context.Background(), terminal.OrgID, terminal.SessionID, workerID,
+		request.ID, terminal.WorkerEpoch, request.Attempt, json.RawMessage(`{"ok":true}`),
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func terminalRequestData(t *testing.T, request domain.WorkerRequest) []byte {
+	t.Helper()
+	var command worker.TerminalCommand
+	raw, err := json.Marshal(request.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &command); err != nil {
+		t.Fatal(err)
+	}
+	return command.Data
+}


### PR DESCRIPTION
## What

Coalesce consecutive, unclaimed terminal input into the pending durable worker request at the PostgreSQL queue boundary.

## Why

Cloud terminal input currently amplifies every xterm `onData` event into one `ao_worker_requests` row followed by a serial worker `ClaimTransport` and `CompleteTransport` pair. For N input events, the saturated path therefore requires N durable work items and 2N worker/control-plane HTTP operations. At 75-100 ms per worker HTTP operation, a 20-character burst has a 3-4 second serial drain-time floor, before database and PTY work.

The focused database-backed test sends 100 one-byte events before claim. Before this change that represents 100 worker requests / 200 worker HTTP operations (and exceeds the outstanding-request cap unless the worker drains concurrently); after this change it is 1 request / 2 worker HTTP operations: a 99% reduction for the backlogged burst.

## How

- Serialize terminal enqueue mutations per session and append bytes only to the newest `pending` `terminal.input` request.
- Do not add a frontend timer: the first input is still enqueued immediately, and coalescing activates only when transport has fallen behind.
- Treat resize as an ordering boundary and never mutate a `claimed` request.
- Keep idempotency-keyed input in separate requests so reconnect/deduplication semantics remain intact.
- Preserve raw byte concatenation, including control bytes and partial/complete UTF-8 sequences, and cap coalesced payloads at the existing 16 KiB worker limit.
- Refresh the 15-second request TTL when appending so new bytes never inherit a nearly expired deadline.

Trade-off: each WebSocket input still performs one small PostgreSQL transaction (an update instead of another insert while backlogged). This intentionally targets the measured serial worker HTTP amplification without changing the public protocol, worker API, provider adapter, frontend timing, or delivery fencing.

## Testing

- `cd cloud && go build ./...`
- `cd cloud && go test ./... -count=1`
- `cd cloud && go test -race ./... -count=1`
- `cd cloud && go vet ./...`
- PostgreSQL 17 integration: `AO_CLOUD_TEST_DATABASE_URL=... go test ./internal/postgres -run TestQueueTerminalInputCoalescesOnlyThePendingTail -count=1`
  - Verifies 100 one-byte inputs claim as one ordered request.
  - Verifies resize splits batches.
  - Verifies no extra worker request remains.
- Unit coverage verifies Ctrl-C, escape sequences, NUL, UTF-8, carriage return, idempotency boundaries, terminal boundaries, empty input, and the 16 KiB cap.

No staging or production deployment was performed.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)