### PR TITLE
fix: avoid xterm viewport callback after StrictMode disposal

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -313,6 +313,24 @@ describe("XtermTerminal", () => {
 		}
 	});
 
+	it("settles a pending write when terminal cleanup wins the race", () => {
+		let terminal: AttachableTerminal | undefined;
+		const view = render(
+			<XtermTerminal
+				theme="dark"
+				onReady={(ready) => {
+					terminal = ready;
+				}}
+			/>,
+		);
+		const done = vi.fn();
+
+		view.unmount();
+		terminal!.write(new Uint8Array([0x61]), done);
+
+		expect(done).toHaveBeenCalledOnce();
+	});
+
 	it("preserves the agent TUI palette without contrast remapping", () => {
 		render(<XtermTerminal theme="dark" />);
 

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AttachableTerminal } from "../hooks/useTerminalSession";
@@ -7,6 +8,9 @@ import { XtermTerminal } from "./XtermTerminal";
 
 const state = vi.hoisted(() => ({
 	fit: vi.fn(),
+	disposeCalls: 0,
+	openTimerRanAfterDispose: 0,
+	trackOpenTimerLifecycle: false,
 	linkHandler: null as null | ((event: MouseEvent, uri: string) => void),
 	searchAddon: null as null | {
 		clearDecorations: ReturnType<typeof vi.fn>;
@@ -103,10 +107,19 @@ vi.mock("@xterm/xterm", () => ({
 		loadAddon() {}
 		open(host: HTMLElement) {
 			host.appendChild(document.createElement("textarea"));
+			if (state.trackOpenTimerLifecycle) {
+				window.setTimeout(() => {
+					if (this.disposed) state.openTimerRanAfterDispose += 1;
+				}, 0);
+			}
 		}
 		write() {}
 		writeln() {}
-		dispose() {}
+		disposed = false;
+		dispose() {
+			this.disposed = true;
+			state.disposeCalls += 1;
+		}
 		onData(listener: (data: string) => void) {
 			this.dataListeners.add(listener);
 			return { dispose: () => this.dataListeners.delete(listener) };
@@ -208,6 +221,9 @@ function setNavigatorPlatform(platform: string) {
 describe("XtermTerminal", () => {
 	beforeEach(() => {
 		state.fit.mockReset();
+		state.disposeCalls = 0;
+		state.openTimerRanAfterDispose = 0;
+		state.trackOpenTimerLifecycle = false;
 		state.lastTerminal = null;
 		state.linkHandler = null;
 		state.searchAddon = null;
@@ -274,6 +290,26 @@ describe("XtermTerminal", () => {
 		} finally {
 			vi.useRealTimers();
 			vi.unstubAllGlobals();
+		}
+	});
+
+	it("lets xterm's deferred open work settle before StrictMode disposal", () => {
+		vi.useFakeTimers();
+		state.trackOpenTimerLifecycle = true;
+		try {
+			render(
+				<StrictMode>
+					<XtermTerminal theme="dark" />
+				</StrictMode>,
+			);
+
+			expect(state.disposeCalls).toBe(0);
+			act(() => vi.advanceTimersByTime(0));
+
+			expect(state.disposeCalls).toBe(1);
+			expect(state.openTimerRanAfterDispose).toBe(0);
+		} finally {
+			vi.useRealTimers();
 		}
 	});
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1171,7 +1171,10 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
 			write: (data, done) => {
-				if (disposed) return;
+				if (disposed) {
+					done?.();
+					return;
+				}
 				let hasEsc = false;
 				for (let i = 0; i < data.length; i++) {
 					if (data[i] === 0x1b) {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1108,6 +1108,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		shell.addEventListener("drop", dropInput);
 
 		const showLatestOutput = () => {
+			if (disposed) return;
 			term.scrollToBottom();
 			// Hidden output can leave the offscreen DOM scrollbar stale even
 			// after xterm's logical viewport moves. Synchronize it before either
@@ -1120,6 +1121,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 
 		let cancelActivationPreparation: (() => void) | null = null;
 		const prepareForActivation = (): Promise<void> => {
+			if (disposed) return Promise.resolve();
 			cancelActivationPreparation?.();
 			return new Promise((resolve) => {
 				let firstFrame: number | null = null;
@@ -1169,6 +1171,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
 			write: (data, done) => {
+				if (disposed) return;
 				let hasEsc = false;
 				for (let i = 0; i < data.length; i++) {
 					if (data[i] === 0x1b) {
@@ -1191,7 +1194,9 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					done?.();
 				});
 			},
-			writeln: (line) => term.writeln(line, scheduleScrollbarUpdate),
+			writeln: (line) => {
+				if (!disposed) term.writeln(line, scheduleScrollbarUpdate);
+			},
 			showLatestOutput,
 			prepareForActivation,
 			notifyCursorColorScheme: () => {
@@ -1256,12 +1261,19 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;
 			userInputListeners.clear();
-			try {
-				term.dispose();
-			} catch {
-				// Some renderer addons can throw during dispose in certain GPU
-				// environments; the terminal is being torn down regardless.
-			}
+			// xterm schedules an uncancellable zero-delay Viewport sync from open().
+			// React StrictMode tears this effect down in the same task, and disposing
+			// first leaves that callback reading RenderService.dimensions after its
+			// renderer has gone away. Invalidate the AO handle above immediately, but
+			// let xterm's already-queued open work run before releasing the renderer.
+			window.setTimeout(() => {
+				try {
+					term.dispose();
+				} catch {
+					// Some renderer addons can throw during dispose in certain GPU
+					// environments; the terminal is being torn down regardless.
+				}
+			}, 0);
 		};
 	}, []);
 


### PR DESCRIPTION
## Summary

- eliminate a development-only xterm lifecycle pageerror during React StrictMode cleanup
- invalidate the AO terminal handle immediately, then defer physical xterm disposal one task so xterm 5's queued viewport-open callback can finish
- cover the exact disposal ordering with a deterministic regression test

## Diagnosis and scope

The live cloud terminal path is healthy: deeper inspection found 752 xterm buffer lines and a visibly rendered Claude prompt including AO_CODER_WORKER_OK. The cached dimensions exception is therefore not evidence of a blank-pane or replay failure.

The exception itself is reproducible and narrowly understood. xterm 5 schedules an uncancellable zero-delay Viewport.syncScrollArea callback from Terminal.open. React StrictMode cleans up its first development mount in the same task. Immediate disposal releases the renderer before that callback runs, so it reads RenderService.dimensions after disposal and raises a pageerror.

This PR only removes that lifecycle pageerror. It does not change cloud ticketing, replay coalescing, attachment ordering, or local/cloud mux behavior, and it should not be treated as a product-blocker fix.

## Exact verification run

- npm test -- XtermTerminal.test.tsx TerminalPane.test.tsx useTerminalSession.test.tsx --run (167 passed)
- npm run frontend:typecheck (passed)
- lifecycle regression failed before the production change: the fake xterm open timer observed prior disposal; after the change, queued open work runs first and disposal still occurs exactly once
- PR CI passed: frontend test, renderer-smoke, and gitleaks

## Native visual-verification follow-up

A second real Electron instance was intentionally not launched because agent-orchestrator-211 owns the shared AO dev Chromium profile and ports 5173/3002 for active user hands-on testing. This PR did not stop or modify that instance, its preview, its ports, or its profile, and did not launch against the production/shared AO_DATA_DIR.

Follow-up requested: after agent-orchestrator-211's user test is explicitly finished and the shared dev resources are released, rerun this branch in the real Electron app and confirm terminal mount/navigation produces no xterm dimensions pageerror.

No staging or production deployment was performed.