### PR TITLE
fix(chat): finalize plans on successful turns

### DIFF
--- a/backend/internal/service/chat/provider_state_test.go
+++ b/backend/internal/service/chat/provider_state_test.go
@@ -224,6 +224,66 @@ func TestPlanInProgressStaysRunning(t *testing.T) {
 	}
 }
 
+// A provider is allowed to omit a final plan notification. Successful turn
+// completion is AO's durable proof that the remaining plan work finished, so
+// both copies of the plan must settle with the turn instead of leaving a
+// completed answer beside a permanent "0 / N" plan.
+func TestSuccessfulCompletionFinalizesPlanWhenProviderOmitsTerminalPlan(t *testing.T) {
+	h := newHarness(t)
+
+	if _, err := h.svc.Send(context.Background(), testSession, ports.ChatUserMessage{
+		Text: "do four things", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	plan := domain.ConversationPlan{Steps: []domain.ConversationPlanStep{
+		{Text: "one", Status: domain.PlanStepInProgress},
+		{Text: "two", Status: domain.PlanStepPending},
+		{Text: "three", Status: domain.PlanStepPending},
+		{Text: "four", Status: domain.PlanStepPending},
+	}}
+	h.conv.emit(
+		ports.ChatEvent{Kind: ports.ChatEventPlanUpdated, ProviderTurnID: "provider-turn-1",
+			Plan: &plan, Summary: "Plan 0/4: one"},
+		ports.ChatEvent{Kind: ports.ChatEventMessageCompleted, ProviderTurnID: "provider-turn-1",
+			ProviderItemID: "message-1", Text: "Done."},
+		ports.ChatEvent{Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-1",
+			TurnState: domain.TurnStateCompleted},
+	)
+
+	snapshot := h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return len(s.Turns) == 1 && s.Turns[0].State == domain.TurnStateCompleted
+	})
+	turn := snapshot.Turns[0]
+	if turn.Plan == nil || len(turn.Plan.Steps) != 4 {
+		t.Fatalf("turn plan = %#v, want four steps", turn.Plan)
+	}
+	for i, step := range turn.Plan.Steps {
+		if step.Status != domain.PlanStepCompleted {
+			t.Errorf("turn plan step %d status = %q, want completed", i, step.Status)
+		}
+	}
+
+	activity := firstActivityOfKind(snapshot, domain.ActivityKindPlan)
+	if activity.Status != domain.ActivityStatusCompleted {
+		t.Errorf("plan activity status = %q, want completed", activity.Status)
+	}
+	if activity.Summary != "Plan 4/4 steps done" {
+		t.Errorf("plan activity summary = %q, want completed count", activity.Summary)
+	}
+	var detail struct {
+		Steps []domain.ConversationPlanStep `json:"steps"`
+	}
+	if err := json.Unmarshal(activity.Detail, &detail); err != nil {
+		t.Fatalf("decode plan activity detail: %v", err)
+	}
+	for i, step := range detail.Steps {
+		if step.Status != domain.PlanStepCompleted {
+			t.Errorf("plan activity step %d status = %q, want completed", i, step.Status)
+		}
+	}
+}
+
 /* ---- model reroute ----------------------------------------------------- */
 
 // A reroute becomes conversation state AND a timeline row. The state says what is

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -548,6 +548,40 @@ func (q *Queries) FailRolledBackConversationApprovals(ctx context.Context, arg F
 	return err
 }
 
+const finalizeConversationPlanActivity = `-- name: FinalizeConversationPlanActivity :exec
+UPDATE conversation_activities
+SET status = 'completed',
+    summary = ?1,
+    detail_json = ?2,
+    revision = revision + 1,
+    updated_at = ?3
+WHERE conversation_activities.conversation_id = ?4
+  AND turn_id = ?5
+  AND kind = 'plan'
+`
+
+type FinalizeConversationPlanActivityParams struct {
+	Summary        string
+	DetailJson     string
+	UpdatedAt      time.Time
+	ConversationID string
+	TurnID         sql.NullString
+}
+
+// Successful completion is the terminal fact for a plan even when the provider
+// omits its customary final plan notification. Keep the timeline copy identical
+// to the turn copy that SettleTurn finalizes from the same event.
+func (q *Queries) FinalizeConversationPlanActivity(ctx context.Context, arg FinalizeConversationPlanActivityParams) error {
+	_, err := q.db.ExecContext(ctx, finalizeConversationPlanActivity,
+		arg.Summary,
+		arg.DetailJson,
+		arg.UpdatedAt,
+		arg.ConversationID,
+		arg.TurnID,
+	)
+	return err
+}
+
 const hasPendingConversationInteractions = `-- name: HasPendingConversationInteractions :one
 SELECT EXISTS (
     SELECT 1

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -123,6 +123,7 @@ var shippedMigrations = map[int64]string{
 	116: "0116_usage_billing_provider_source.sql",
 	117: "0117_allow_kimi_usage.sql",
 	118: "0118_cancelled_conversation_turns.sql",
+	119: "0119_finalize_completed_conversation_plans.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -607,6 +607,118 @@ FROM usage_bindings WHERE harness = 'kimi';`, now, now); err != nil {
 	}
 }
 
+func TestCompletedPlanMigrationRepairsStructuredStateWithoutChangingProviderEvents(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 118)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(`
+INSERT INTO projects (id, path, registered_at, config)
+VALUES ('plan-migration', '/repo/plan', ?, '{}');
+INSERT INTO sessions (
+    id, project_id, num, harness, activity_last_at, created_at, updated_at, session_mode
+) VALUES ('plan-migration-1', 'plan-migration', 1, 'codex', ?, ?, ?, 'chat');
+INSERT INTO conversations (
+    id, scope, project_id, session_id, current_session_id, latest_sequence,
+    created_at, updated_at, active_branch_id
+) VALUES (
+    'conversation-1', 'session', 'plan-migration', 'plan-migration-1',
+    'plan-migration-1', 2, ?, ?, 'branch-1'
+);
+INSERT INTO conversation_branches (
+    id, conversation_id, session_id, provider_conversation_id, created_at
+) VALUES ('branch-1', 'conversation-1', 'plan-migration-1', 'thread-1', ?);
+INSERT INTO conversation_turns (
+    id, conversation_id, handled_by_session_id, provider_turn_id, state,
+    requested_at, completed_at, plan_json, branch_id
+) VALUES
+    ('turn-completed', 'conversation-1', 'plan-migration-1', 'provider-completed',
+     'completed', ?, ?,
+     '{"steps":[{"text":"one","status":"in_progress"},{"text":"two","status":"pending"}]}',
+     'branch-1'),
+    ('turn-failed', 'conversation-1', 'plan-migration-1', 'provider-failed',
+     'failed', ?, ?,
+     '{"steps":[{"text":"one","status":"in_progress"},{"text":"two","status":"pending"}]}',
+     'branch-1');
+INSERT INTO conversation_activities (
+    id, conversation_id, turn_id, sequence, revision, kind, status, summary,
+    detail_json, provider_item_id, created_at, updated_at, branch_id
+) VALUES
+    ('activity-completed', 'conversation-1', 'turn-completed', 1, 3, 'plan',
+     'completed', 'Plan 0/2: one',
+     '{"event":"plan","steps":[{"text":"one","status":"in_progress"},{"text":"two","status":"pending"}]}',
+     'ao-plan-provider-completed', ?, ?, 'branch-1'),
+    ('activity-failed', 'conversation-1', 'turn-failed', 2, 4, 'plan',
+     'failed', 'Plan 0/2: one',
+     '{"event":"plan","steps":[{"text":"one","status":"in_progress"},{"text":"two","status":"pending"}]}',
+     'ao-plan-provider-failed', ?, ?, 'branch-1');
+INSERT INTO conversation_provider_events (
+    conversation_id, session_id, provider_event_id, method, payload_json, received_at, branch_id
+) VALUES
+    ('conversation-1', 'plan-migration-1', 'event-plan', 'turn.plan', '{"raw":"plan"}', ?, 'branch-1'),
+    ('conversation-1', 'plan-migration-1', 'event-completed', 'turn.completed', '{"raw":"completed"}', ?, 'branch-1');`,
+		now, now, now, now, now, now, now, now, now, now, now, now, now, now, now, now); err != nil {
+		t.Fatalf("seed stale completed plan: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("apply completed-plan migration: %v", err)
+	}
+
+	var turnStatuses, activityStatuses, summary string
+	var revision int
+	if err := db.QueryRow(`
+SELECT json_extract(turn.plan_json, '$.steps[0].status') || ',' ||
+       json_extract(turn.plan_json, '$.steps[1].status'),
+       json_extract(activity.detail_json, '$.steps[0].status') || ',' ||
+       json_extract(activity.detail_json, '$.steps[1].status'),
+       activity.summary, activity.revision
+FROM conversation_turns turn
+JOIN conversation_activities activity ON activity.turn_id = turn.id
+WHERE turn.id = 'turn-completed'`).Scan(
+		&turnStatuses, &activityStatuses, &summary, &revision,
+	); err != nil {
+		t.Fatalf("read repaired completed plan: %v", err)
+	}
+	if turnStatuses != "completed,completed" || activityStatuses != "completed,completed" ||
+		summary != "Plan 2/2 steps done" || revision != 4 {
+		t.Fatalf("repaired plan = turn:%q activity:%q summary:%q revision:%d",
+			turnStatuses, activityStatuses, summary, revision)
+	}
+
+	var failedTurnStatus, failedActivityStatus string
+	var failedRevision int
+	if err := db.QueryRow(`
+SELECT json_extract(turn.plan_json, '$.steps[0].status'),
+       json_extract(activity.detail_json, '$.steps[0].status'), activity.revision
+FROM conversation_turns turn
+JOIN conversation_activities activity ON activity.turn_id = turn.id
+WHERE turn.id = 'turn-failed'`).Scan(
+		&failedTurnStatus, &failedActivityStatus, &failedRevision,
+	); err != nil {
+		t.Fatalf("read failed plan control: %v", err)
+	}
+	if failedTurnStatus != "in_progress" || failedActivityStatus != "in_progress" || failedRevision != 4 {
+		t.Fatalf("failed plan was changed = turn:%q activity:%q revision:%d",
+			failedTurnStatus, failedActivityStatus, failedRevision)
+	}
+
+	var rawEvents string
+	if err := db.QueryRow(`
+SELECT group_concat(method || ':' || payload_json, '|')
+FROM (SELECT method, payload_json FROM conversation_provider_events ORDER BY id)`).Scan(&rawEvents); err != nil {
+		t.Fatalf("read raw provider archive: %v", err)
+	}
+	if rawEvents != `turn.plan:{"raw":"plan"}|turn.completed:{"raw":"completed"}` {
+		t.Fatalf("provider archive changed: %q", rawEvents)
+	}
+}
+
 func openMigratedTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)

--- a/backend/internal/storage/sqlite/migrations/0119_finalize_completed_conversation_plans.sql
+++ b/backend/internal/storage/sqlite/migrations/0119_finalize_completed_conversation_plans.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Before 0119, a successful provider turn could omit its final turn.plan event.
+-- AO settled the turn and the plan activity status but left both structured plan
+-- payloads at their last intermediate step state. Repair only successful turns:
+-- failure, interruption, recovery, and cancellation do not prove unfinished
+-- plan steps actually completed.
+UPDATE conversation_activities
+SET status = 'completed',
+    summary = 'Plan ' || json_array_length(detail_json, '$.steps') || '/' ||
+              json_array_length(detail_json, '$.steps') || ' steps done',
+    detail_json = json_set(
+        detail_json,
+        '$.steps',
+        (SELECT json_group_array(json_set(value, '$.status', 'completed'))
+         FROM json_each(conversation_activities.detail_json, '$.steps'))
+    ),
+    revision = revision + 1,
+    updated_at = COALESCE(
+        (SELECT completed_at FROM conversation_turns WHERE id = conversation_activities.turn_id),
+        updated_at
+    )
+WHERE kind = 'plan'
+  AND json_valid(detail_json)
+  AND json_type(detail_json, '$.steps') = 'array'
+  AND EXISTS (
+      SELECT 1 FROM json_each(conversation_activities.detail_json, '$.steps')
+      WHERE json_extract(value, '$.status') <> 'completed'
+  )
+  AND turn_id IN (SELECT id FROM conversation_turns WHERE state = 'completed');
+
+UPDATE conversation_turns
+SET plan_json = json_set(
+        plan_json,
+        '$.steps',
+        (SELECT json_group_array(json_set(value, '$.status', 'completed'))
+         FROM json_each(conversation_turns.plan_json, '$.steps'))
+    )
+WHERE state = 'completed'
+  AND json_valid(plan_json)
+  AND json_type(plan_json, '$.steps') = 'array'
+  AND EXISTS (
+      SELECT 1 FROM json_each(conversation_turns.plan_json, '$.steps')
+      WHERE json_extract(value, '$.status') <> 'completed'
+  );
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- The provider never reported which intermediate steps were truly last after a
+-- successful turn, so the repaired terminal inference cannot be reversed.
+SELECT 1;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -502,6 +502,20 @@ WHERE conversation_activities.conversation_id = sqlc.arg(conversation_id)
   AND turn_id = sqlc.arg(turn_id)
   AND status = 'running';
 
+-- Successful completion is the terminal fact for a plan even when the provider
+-- omits its customary final plan notification. Keep the timeline copy identical
+-- to the turn copy that SettleTurn finalizes from the same event.
+-- name: FinalizeConversationPlanActivity :exec
+UPDATE conversation_activities
+SET status = 'completed',
+    summary = sqlc.arg(summary),
+    detail_json = sqlc.arg(detail_json),
+    revision = revision + 1,
+    updated_at = sqlc.arg(updated_at)
+WHERE conversation_activities.conversation_id = sqlc.arg(conversation_id)
+  AND turn_id = sqlc.arg(turn_id)
+  AND kind = 'plan';
+
 -- The same invariant applies when startup discovers work abandoned by a dead
 -- controller. This runs before SettleOrphanedConversationTurns while their turn
 -- states still identify the affected rows.

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -1034,6 +1034,70 @@ func (s *Store) SettleTurn(
 		}); err != nil {
 		return fmt.Errorf("settle running activities for turn %s: %w", turn.ID, err)
 	}
+	if state == domain.TurnStateCompleted {
+		if err := finalizeCompletedTurnPlan(ctx, q, turn, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// finalizeCompletedTurnPlan reconciles the two durable plan projections when a
+// provider completes a turn without sending a final plan notification. The raw
+// provider event remains unchanged; this only records AO's terminal inference.
+func finalizeCompletedTurnPlan(
+	ctx context.Context,
+	q *gen.Queries,
+	turn gen.ConversationTurn,
+	now time.Time,
+) error {
+	if turn.PlanJson == "" {
+		return nil
+	}
+	var plan domain.ConversationPlan
+	if err := json.Unmarshal([]byte(turn.PlanJson), &plan); err != nil {
+		return fmt.Errorf("decode plan for completed turn %s: %w", turn.ID, err)
+	}
+	changed := false
+	for i := range plan.Steps {
+		if plan.Steps[i].Status != domain.PlanStepCompleted {
+			plan.Steps[i].Status = domain.PlanStepCompleted
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	encodedPlan, err := json.Marshal(plan)
+	if err != nil {
+		return fmt.Errorf("encode finalized plan for turn %s: %w", turn.ID, err)
+	}
+	if _, err := q.UpdateConversationTurnPlan(ctx, gen.UpdateConversationTurnPlanParams{
+		PlanJson:       string(encodedPlan),
+		ConversationID: turn.ConversationID,
+		ProviderTurnID: turn.ProviderTurnID,
+	}); err != nil {
+		return fmt.Errorf("finalize turn plan %s: %w", turn.ID, err)
+	}
+
+	detail := map[string]any{"event": "plan", "steps": plan.Steps}
+	if plan.Explanation != "" {
+		detail["explanation"] = plan.Explanation
+	}
+	encodedDetail, err := json.Marshal(detail)
+	if err != nil {
+		return fmt.Errorf("encode finalized plan activity for turn %s: %w", turn.ID, err)
+	}
+	if err := q.FinalizeConversationPlanActivity(ctx, gen.FinalizeConversationPlanActivityParams{
+		Summary:        fmt.Sprintf("Plan %d/%d steps done", len(plan.Steps), len(plan.Steps)),
+		DetailJson:     string(encodedDetail),
+		UpdatedAt:      now,
+		ConversationID: turn.ConversationID,
+		TurnID:         sql.NullString{String: turn.ID, Valid: true},
+	}); err != nil {
+		return fmt.Errorf("finalize plan activity for turn %s: %w", turn.ID, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What

Finalize every remaining structured plan step when a conversation turn settles successfully, and add migration 0119 to repair completed turns that already persisted a stale non-terminal plan.

## Why

A provider can emit an initial `turn.plan` and then finish with `turn.completed` without sending a terminal plan update. AO previously stored the completed answer and turn state while leaving the plan at `0/N` or partially pending.

Fixes https://github.com/Untrivial-ai/agent-orchestrator/issues/4663

## How

- Treat successful turn completion as the terminal durable fact for the turn plan.
- Update the turn plan and matching plan activity in the same transaction.
- Preserve the raw provider-event archive.
- Do not infer completion for failed, interrupted, recovered, or cancelled turns.
- Backfill only stale plans attached to already-completed turns.

## Testing

- `go test ./internal/service/chat ./internal/storage/sqlite ./internal/storage/sqlite/store -count=1`
- `go test -p 1 ./...`
- `go test -race ./internal/service/chat ./internal/storage/sqlite ./internal/storage/sqlite/store -count=1`
- `golangci-lint run`
- `npm run frontend:typecheck`
- Real Electron E2E: reproduced the completed-answer plus `Plan 0/4` state, restarted through migration 0119 and observed `Plan 4/4`, then ran a fresh provider flow with one `turn.plan` plus one `turn.completed` and observed `4/4` in the UI, API, and SQLite.

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added for user-visible behavior and migration repair
- [x] Relevant local checks pass