### PR TITLE
feat: close pinned browser tabs on hover

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1376,6 +1376,28 @@ describe("BrowserPanel", () => {
 			expect(screen.getByTestId("browser-tabs-flyout")).toHaveAttribute("data-state", "closed");
 		});
 
+		it("closes a tab directly from the pinned rail on hover", async () => {
+			pinRail();
+			hookState.tabs = [
+				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
+				{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: true },
+			];
+			hookState.activeTabId = "t2";
+			render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			const rail = screen.getByTestId("browser-tabs-rail");
+			const pinnedTabs = within(rail.querySelector("nav") as HTMLElement);
+			const closeButton = pinnedTabs.getByRole("button", { name: "Close tab First app" });
+			fireEvent.pointerEnter(pinnedTabs.getByRole("button", { name: "First app — localhost:3000" }));
+
+			expect(closeButton).toHaveClass("group-hover/tab-icon:opacity-100");
+			await userEvent.click(closeButton);
+
+			expect(hookState.closeTab).toHaveBeenCalledWith("t1");
+			expect(hookState.selectTab).not.toHaveBeenCalled();
+			expect(screen.getByTestId("browser-tabs-flyout")).toHaveAttribute("data-state", "closed");
+		});
+
 		it("still opens the flyout on hover while the rail is collapsed", () => {
 			hookState.tabs = [
 				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1409,16 +1409,30 @@ describe("BrowserPanel", () => {
 			expect(hookState.closeTab).not.toHaveBeenCalled();
 
 			expect(firstTab).toHaveAttribute("aria-roledescription", "sortable");
-			fireEvent.pointerDown(firstTab, { button: 0, clientX: 16, clientY: 48, isPrimary: true, pointerId: 1 });
-			fireEvent.pointerMove(secondTab, { clientX: 16, clientY: 80, pointerId: 1 });
+			vi.useFakeTimers();
+			try {
+				fireEvent.pointerDown(firstTab, {
+					button: 0,
+					clientX: 16,
+					clientY: 48,
+					isPrimary: true,
+					pointerId: 1,
+				});
+				fireEvent.pointerMove(secondTab, { clientX: 16, clientY: 80, pointerId: 1 });
 
-			expect(firstTab).toHaveAttribute("aria-pressed", "true");
-			fireEvent.pointerUp(secondTab, { clientX: 16, clientY: 80, pointerId: 1 });
+				expect(firstTab).toHaveAttribute("aria-pressed", "true");
+				fireEvent.pointerUp(secondTab, { clientX: 16, clientY: 80, pointerId: 1 });
+				// dnd-kit removes its capture-phase click suppressor 50 ms after
+				// a completed drag. Flush that teardown before the next test.
+				act(() => vi.advanceTimersByTime(50));
+			} finally {
+				vi.useRealTimers();
+			}
 			expect(secondTab).toBeInTheDocument();
 			expect(closeButton).not.toHaveClass("absolute");
 		});
 
-		it("closes only from the distinct pinned-rail close action", async () => {
+		it("closes only from the distinct pinned-rail close action", () => {
 			pinRail();
 			hookState.tabs = [
 				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
@@ -1431,7 +1445,9 @@ describe("BrowserPanel", () => {
 			const pinnedTabs = within(rail.querySelector("nav") as HTMLElement);
 			const closeButton = pinnedTabs.getByRole("button", { name: "Close tab First app" });
 			fireEvent.pointerEnter(pinnedTabs.getByRole("button", { name: "First app — localhost:3000" }));
-			await userEvent.click(closeButton);
+			expect(closeButton).toHaveAttribute("data-state", "open");
+			expect(closeButton).toBeEnabled();
+			fireEvent.click(closeButton);
 
 			expect(hookState.closeTab).toHaveBeenCalledWith("t1");
 			expect(hookState.selectTab).not.toHaveBeenCalled();

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1432,7 +1432,7 @@ describe("BrowserPanel", () => {
 			expect(closeButton).not.toHaveClass("absolute");
 		});
 
-		it("closes only from the distinct pinned-rail close action", () => {
+		it("closes only from the distinct pinned-rail close action", async () => {
 			pinRail();
 			hookState.tabs = [
 				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
@@ -1447,7 +1447,7 @@ describe("BrowserPanel", () => {
 			fireEvent.pointerEnter(pinnedTabs.getByRole("button", { name: "First app — localhost:3000" }));
 			expect(closeButton).toHaveAttribute("data-state", "open");
 			expect(closeButton).toBeEnabled();
-			fireEvent.click(closeButton);
+			await userEvent.click(closeButton);
 
 			expect(hookState.closeTab).toHaveBeenCalledWith("t1");
 			expect(hookState.selectTab).not.toHaveBeenCalled();

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -99,7 +99,7 @@ const session: WorkspaceSession = {
 	prs: [],
 };
 
-it("reorders horizontal browser tabs around the drop target", () => {
+it("reorders browser tabs around the drop target", () => {
 	expect(reorderBrowserTabs(["t1", "t2", "t3"], "t1", "t3")).toEqual(["t2", "t3", "t1"]);
 	expect(reorderBrowserTabs(["t1", "t2", "t3"], "t2", "missing")).toBeNull();
 });
@@ -1386,7 +1386,39 @@ describe("BrowserPanel", () => {
 			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 		});
 
-		it("closes a tab directly from the pinned rail on hover", async () => {
+		it("keeps selection and drag activation on the favicon while the close action is visible", async () => {
+			pinRail();
+			hookState.tabs = [
+				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
+				{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: true },
+			];
+			hookState.activeTabId = "t2";
+			render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			const rail = screen.getByTestId("browser-tabs-rail");
+			const pinnedTabs = within(rail.querySelector("nav") as HTMLElement);
+			const firstTab = pinnedTabs.getByRole("button", { name: "First app — localhost:3000" });
+			const secondTab = pinnedTabs.getByRole("button", { name: "Second app — localhost:4173" });
+			const closeButton = pinnedTabs.getByRole("button", { name: "Close tab First app" });
+			fireEvent.pointerEnter(firstTab);
+
+			expect(closeButton).toHaveClass("group-hover/tab-icon:opacity-100");
+			await userEvent.click(firstTab);
+
+			expect(hookState.selectTab).toHaveBeenCalledWith("t1");
+			expect(hookState.closeTab).not.toHaveBeenCalled();
+
+			expect(firstTab).toHaveAttribute("aria-roledescription", "sortable");
+			fireEvent.pointerDown(firstTab, { button: 0, clientX: 16, clientY: 48, isPrimary: true, pointerId: 1 });
+			fireEvent.pointerMove(secondTab, { clientX: 16, clientY: 80, pointerId: 1 });
+
+			expect(firstTab).toHaveAttribute("aria-pressed", "true");
+			fireEvent.pointerUp(secondTab, { clientX: 16, clientY: 80, pointerId: 1 });
+			expect(secondTab).toBeInTheDocument();
+			expect(closeButton).not.toHaveClass("absolute");
+		});
+
+		it("closes only from the distinct pinned-rail close action", async () => {
 			pinRail();
 			hookState.tabs = [
 				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
@@ -1399,13 +1431,27 @@ describe("BrowserPanel", () => {
 			const pinnedTabs = within(rail.querySelector("nav") as HTMLElement);
 			const closeButton = pinnedTabs.getByRole("button", { name: "Close tab First app" });
 			fireEvent.pointerEnter(pinnedTabs.getByRole("button", { name: "First app — localhost:3000" }));
-
-			expect(closeButton).toHaveClass("group-hover/tab-icon:opacity-100");
 			await userEvent.click(closeButton);
 
 			expect(hookState.closeTab).toHaveBeenCalledWith("t1");
 			expect(hookState.selectTab).not.toHaveBeenCalled();
 			expect(screen.getByTestId("browser-tabs-flyout")).toHaveAttribute("data-state", "closed");
+		});
+
+		it("keeps the pinned close action disabled for the only tab", async () => {
+			pinRail();
+			hookState.tabs = [{ id: "t1", url: "http://localhost:3000/", title: "First app", active: true }];
+			hookState.activeTabId = "t1";
+			render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+			const rail = screen.getByTestId("browser-tabs-rail");
+			const closeButton = within(rail.querySelector("nav") as HTMLElement).getByRole("button", {
+				name: "Close tab First app",
+			});
+			expect(closeButton).toBeDisabled();
+			await userEvent.click(closeButton);
+
+			expect(hookState.closeTab).not.toHaveBeenCalled();
 		});
 
 		it("still opens the flyout on hover while the rail is collapsed", () => {
@@ -1429,7 +1475,7 @@ describe("BrowserPanel", () => {
 			expect(screen.getByTestId("browser-tabs-flyout")).toHaveAttribute("data-state", "open");
 		});
 
-		it("names the site in a tooltip when a pinned favicon takes focus", async () => {
+		it("suppresses the site tooltip when pinned-tab focus reveals the close action", () => {
 			pinRail();
 			hookState.tabs = [
 				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
@@ -1440,15 +1486,13 @@ describe("BrowserPanel", () => {
 
 			fireEvent.focus(screen.getByRole("button", { name: "First app — localhost:3000" }));
 
-			const tooltip = await screen.findByRole("tooltip");
-			expect(tooltip).toHaveTextContent("First app");
-			expect(tooltip).toHaveTextContent("localhost:3000");
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 		});
 
-		it("marks the tooltip as a browser overlay so it paints above the live page", async () => {
+		it("marks the focused close action as a browser overlay so it paints above the live page", () => {
 			// The live page is a native view above the transparent shell; the shell
 			// is only raised for elements matching OPEN_BROWSER_OVERLAY_SELECTOR, so
-			// an unmarked tooltip would render behind the page and be invisible.
+			// an unmarked close action extending left of the rail would be unreachable.
 			pinRail();
 			hookState.tabs = [
 				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
@@ -1459,8 +1503,12 @@ describe("BrowserPanel", () => {
 
 			fireEvent.focus(screen.getByRole("button", { name: "First app — localhost:3000" }));
 
-			const tooltip = await screen.findByRole("tooltip");
-			expect(tooltip.closest('[data-browser-native-overlay="true"]')).not.toBeNull();
+			const rail = screen.getByTestId("browser-tabs-rail");
+			const closeButton = within(rail.querySelector("nav") as HTMLElement).getByRole("button", {
+				name: "Close tab First app",
+			});
+			expect(closeButton).toHaveAttribute("data-browser-native-overlay", "true");
+			expect(closeButton).toHaveAttribute("data-state", "open");
 			expect(document.querySelector(OPEN_BROWSER_OVERLAY_SELECTOR)).not.toBeNull();
 		});
 	});

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1352,9 +1352,10 @@ describe("BrowserPanel", () => {
 			window.localStorage.removeItem("ao.browserTabs.railPinned");
 		});
 
-		it("does not open the flyout when hovering the pinned rail", () => {
+		it("shows the close affordance without opening a competing hover overlay", () => {
 			// Pinned already shows every tab as a favicon row, so the flyout would
-			// just cover the live page with a duplicate of what's on screen.
+			// just cover the live page with a duplicate of what's on screen. The
+			// site tooltip is likewise suppressed while the close action is visible.
 			pinRail();
 			hookState.tabs = [
 				{ id: "t1", url: "http://localhost:3000/", title: "First app", active: false },
@@ -1366,6 +1367,7 @@ describe("BrowserPanel", () => {
 			vi.useFakeTimers();
 			try {
 				fireEvent.pointerEnter(screen.getByTestId("browser-tabs-rail"));
+				fireEvent.pointerEnter(screen.getByRole("button", { name: "First app — localhost:3000" }));
 				act(() => {
 					vi.advanceTimersByTime(300);
 				});
@@ -1374,6 +1376,7 @@ describe("BrowserPanel", () => {
 			}
 
 			expect(screen.getByTestId("browser-tabs-flyout")).toHaveAttribute("data-state", "closed");
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 		});
 
 		it("closes a tab directly from the pinned rail on hover", async () => {

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -533,7 +533,7 @@ function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, ta
 			<button
 				aria-label={closeLabel}
 				className={cn(
-					"pointer-events-none absolute left-1/2 top-1/2 grid size-7 -translate-x-1/2 -translate-y-1/2 scale-90 place-items-center rounded-md",
+					"pointer-events-none absolute left-[calc(50%_-_0.5px)] top-1/2 grid size-7 -translate-x-1/2 -translate-y-1/2 scale-90 place-items-center rounded-md",
 					"bg-interactive-hover text-muted-foreground opacity-0",
 					"transition-[opacity,transform,background-color,color] duration-150 ease-out",
 					"hover:bg-interactive-active hover:text-foreground active:scale-95",

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -533,7 +533,7 @@ function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, ta
 			<button
 				aria-label={closeLabel}
 				className={cn(
-					"pointer-events-none absolute inset-0.5 grid size-7 scale-90 place-items-center rounded-md",
+					"pointer-events-none absolute left-1/2 top-1/2 grid size-7 -translate-x-1/2 -translate-y-1/2 scale-90 place-items-center rounded-md",
 					"bg-interactive-hover text-muted-foreground opacity-0",
 					"transition-[opacity,transform,background-color,color] duration-150 ease-out",
 					"hover:bg-interactive-active hover:text-foreground active:scale-95",

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -536,7 +536,7 @@ function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, ta
 					"pointer-events-none absolute inset-0.5 grid size-7 scale-90 place-items-center rounded-md",
 					"bg-interactive-hover text-muted-foreground opacity-0",
 					"transition-[opacity,transform,background-color,color] duration-150 ease-out",
-					"hover:bg-destructive/15 hover:text-destructive active:scale-95",
+					"hover:bg-interactive-active hover:text-foreground active:scale-95",
 					"group-hover/tab-icon:pointer-events-auto group-hover/tab-icon:scale-100 group-hover/tab-icon:opacity-100",
 					"group-focus-within/tab-icon:pointer-events-auto group-focus-within/tab-icon:scale-100 group-focus-within/tab-icon:opacity-100",
 					"focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent/60",

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -20,7 +20,6 @@ import {
 } from "@dnd-kit/core";
 import {
 	SortableContext,
-	arrayMove,
 	sortableKeyboardCoordinates,
 	useSortable,
 	verticalListSortingStrategy,
@@ -30,8 +29,8 @@ import { Globe2, History, Pin, PinOff, Plus, X } from "lucide-react";
 import type { BrowserTabState } from "../../main/browser-view-host";
 import type { ClosedBrowserTab } from "../hooks/useBrowserView";
 import { browserTabLabel } from "../lib/browser-tab-label";
+import { reorderBrowserTabs } from "../lib/browser-tab-order";
 import { useResizable } from "../hooks/useResizable";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import { cn } from "../lib/utils";
 
 const RAIL_DEFAULT_WIDTH = 220;
@@ -220,12 +219,13 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent) => {
 			const { active, over } = event;
-			if (!over || active.id === over.id) return;
-			const ids = tabs.map((tab) => tab.id);
-			const oldIndex = ids.indexOf(String(active.id));
-			const newIndex = ids.indexOf(String(over.id));
-			if (oldIndex === -1 || newIndex === -1) return;
-			onReorderTabs(arrayMove(ids, oldIndex, newIndex));
+			if (!over) return;
+			const orderedIds = reorderBrowserTabs(
+				tabs.map((tab) => tab.id),
+				String(active.id),
+				String(over.id),
+			);
+			if (orderedIds) onReorderTabs(orderedIds);
 		},
 		[onReorderTabs, tabs],
 	);
@@ -245,8 +245,8 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 			// Only the collapsed (0px) rail opens the flyout on hover. Pinned already
 			// renders every tab as a favicon row, so opening the flyout there covered
 			// the live page with a duplicate of the list the user is already looking
-			// at; each favicon carries a tooltip naming its site instead. The toolbar
-			// trigger is likewise hidden while pinned (BrowserPanel.tsx's
+			// at; each favicon exposes its own adjacent close action instead. The
+			// toolbar trigger is likewise hidden while pinned (BrowserPanel.tsx's
 			// showTabsTrigger), so this is the last path into the flyout.
 			onBlur={
 				collapsed
@@ -292,13 +292,16 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 					<PinOff aria-hidden="true" className="size-icon-base" />
 				</button>
 			) : null}
-			<nav aria-label={t("browser.tabsAria", { count: tabs.length })} className="min-h-0 flex-1 overflow-y-auto">
+			<nav
+				aria-label={t("browser.tabsAria", { count: tabs.length })}
+				className={cn(
+					"min-h-0 flex-1 overflow-y-auto",
+					pinned && !expanded && "w-15 -translate-x-7",
+				)}
+			>
 				{collapsed ? null : (
 					<DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd} sensors={sensors}>
 						<SortableContext items={tabIds} strategy={verticalListSortingStrategy}>
-							{/* No app-wide TooltipProvider exists (each site mounts its own),
-							    so the pinned rail's favicon tooltips need one here. */}
-							<TooltipProvider delayDuration={250}>
 							<div className="flex flex-col">
 								{tabs.map((tab) =>
 									expanded ? (
@@ -324,7 +327,6 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 									),
 								)}
 							</div>
-							</TooltipProvider>
 						</SortableContext>
 					</DndContext>
 				)}
@@ -481,59 +483,41 @@ function ClosedTabsSection({
 function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, tab }: TabRowProps) {
 	const { t } = useTranslation();
 	const [hovered, setHovered] = useState(false);
-	const [tooltipOpen, setTooltipOpen] = useState(false);
+	const [focused, setFocused] = useState(false);
 	const label = browserTabLabel(tab.title, tab.url);
 	const closeLabel = t("browser.closeTab", { title: label.title });
+	const closeVisible = hovered || focused;
 	return (
 		<div
-			className={cn(
-				"group/tab-icon relative flex h-8 w-full items-center overflow-hidden",
-				active && "bg-interactive-active",
-			)}
-			onPointerEnter={() => {
-				setHovered(true);
-				setTooltipOpen(false);
+			className="group/tab-icon flex h-8 w-full items-center"
+			onBlurCapture={(event) => {
+				if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+				setFocused(false);
 			}}
+			onFocusCapture={() => setFocused(true)}
+			onPointerEnter={() => setHovered(true)}
 			onPointerLeave={() => setHovered(false)}
 			ref={chrome?.setNodeRef}
 			style={chrome?.style}
 		>
-			<Tooltip
-				onOpenChange={(open) => setTooltipOpen(hovered ? false : open)}
-				open={tooltipOpen}
+			<button
+				aria-current={active ? "true" : undefined}
+				aria-label={`${label.title} — ${label.subtitle}`}
+				className={cn(
+					"order-2 flex h-full w-8 shrink-0 items-center justify-center p-1.5 transition-colors",
+					"hover:bg-interactive-hover",
+					active && "bg-interactive-active",
+				)}
+				onClick={onSelect}
+				type="button"
+				{...chrome?.dragProps}
 			>
-				<TooltipTrigger asChild>
-					<button
-						aria-current={active ? "true" : undefined}
-						aria-label={`${label.title} — ${label.subtitle}`}
-						className="flex h-full w-full items-center justify-center p-1.5"
-						onClick={onSelect}
-						type="button"
-						{...chrome?.dragProps}
-					>
-						<TabFavicon
-							className={cn(
-								"size-icon-base transition-[opacity,transform] duration-150 ease-out",
-								"group-hover/tab-icon:scale-75 group-hover/tab-icon:opacity-0",
-								"group-focus-within/tab-icon:scale-75 group-focus-within/tab-icon:opacity-0",
-							)}
-							tab={tab}
-						/>
-					</button>
-				</TooltipTrigger>
-				{/* The rail hugs the right edge, so the tooltip opens leftward over the
-				    page. `data-browser-native-overlay` raises the transparent shell above
-				    the live native page for as long as it shows — without it the tooltip
-				    paints behind the page and is invisible (see dom-selectors.ts). */}
-				<TooltipContent data-browser-native-overlay="true" side="left">
-					<span className="block max-w-56 truncate font-medium">{label.title}</span>
-					<span className="block max-w-56 truncate text-muted-foreground">{label.subtitle}</span>
-				</TooltipContent>
-			</Tooltip>
+				<TabFavicon className="size-icon-base" tab={tab} />
+			</button>
 			<button
 				aria-label={closeLabel}
 				className={cn(
-					"pointer-events-none absolute left-[calc(50%_-_0.5px)] top-1/2 grid size-7 -translate-x-1/2 -translate-y-1/2 scale-90 place-items-center rounded-md",
+					"pointer-events-none order-1 grid size-7 shrink-0 scale-90 place-items-center rounded-md",
 					"bg-interactive-hover text-muted-foreground opacity-0",
 					"transition-[opacity,transform,background-color,color] duration-150 ease-out",
 					"hover:bg-interactive-active hover:text-foreground active:scale-95",
@@ -542,6 +526,8 @@ function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, ta
 					"focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent/60",
 					"disabled:pointer-events-none",
 				)}
+				data-browser-native-overlay="true"
+				data-state={closeVisible ? "open" : "closed"}
 				disabled={onlyTab}
 				onClick={(event) => {
 					event.stopPropagation();

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -478,37 +478,65 @@ function ClosedTabsSection({
 	);
 }
 
-function IconTabRow({ active, chrome, onSelect, tab }: TabRowProps) {
+function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, tab }: TabRowProps) {
+	const { t } = useTranslation();
 	const label = browserTabLabel(tab.title, tab.url);
+	const closeLabel = t("browser.closeTab", { title: label.title });
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					aria-current={active ? "true" : undefined}
-					aria-label={`${label.title} — ${label.subtitle}`}
-					className={cn(
-						"flex h-8 w-full items-center justify-center overflow-hidden p-1.5 transition-colors",
-						"hover:bg-interactive-hover",
-						active && "bg-interactive-active",
-					)}
-					onClick={onSelect}
-					ref={chrome?.setNodeRef}
-					style={chrome?.style}
-					type="button"
-					{...chrome?.dragProps}
-				>
-					<TabFavicon className="size-icon-base" tab={tab} />
-				</button>
-			</TooltipTrigger>
-			{/* The rail hugs the right edge, so the tooltip opens leftward over the
-			    page. `data-browser-native-overlay` raises the transparent shell above
-			    the live native page for as long as it shows — without it the tooltip
-			    paints behind the page and is invisible (see dom-selectors.ts). */}
-			<TooltipContent data-browser-native-overlay="true" side="left">
-				<span className="block max-w-56 truncate font-medium">{label.title}</span>
-				<span className="block max-w-56 truncate text-muted-foreground">{label.subtitle}</span>
-			</TooltipContent>
-		</Tooltip>
+		<div
+			className={cn(
+				"group/tab-icon relative flex h-8 w-full items-center overflow-hidden transition-colors",
+				"hover:bg-interactive-hover",
+				active && "bg-interactive-active",
+			)}
+			ref={chrome?.setNodeRef}
+			style={chrome?.style}
+		>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						aria-current={active ? "true" : undefined}
+						aria-label={`${label.title} — ${label.subtitle}`}
+						className="flex h-full w-full items-center justify-center p-1.5"
+						onClick={onSelect}
+						type="button"
+						{...chrome?.dragProps}
+					>
+						<TabFavicon
+							className="size-icon-base transition-opacity group-hover/tab-icon:opacity-0 group-focus-within/tab-icon:opacity-0"
+							tab={tab}
+						/>
+					</button>
+				</TooltipTrigger>
+				{/* The rail hugs the right edge, so the tooltip opens leftward over the
+				    page. `data-browser-native-overlay` raises the transparent shell above
+				    the live native page for as long as it shows — without it the tooltip
+				    paints behind the page and is invisible (see dom-selectors.ts). */}
+				<TooltipContent data-browser-native-overlay="true" side="left">
+					<span className="block max-w-56 truncate font-medium">{label.title}</span>
+					<span className="block max-w-56 truncate text-muted-foreground">{label.subtitle}</span>
+				</TooltipContent>
+			</Tooltip>
+			<button
+				aria-label={closeLabel}
+				className={cn(
+					"pointer-events-none absolute inset-1.5 grid size-icon-base place-items-center rounded-sm text-passive opacity-0",
+					"transition-[opacity,color] hover:text-foreground",
+					"group-hover/tab-icon:pointer-events-auto group-hover/tab-icon:opacity-100",
+					"group-focus-within/tab-icon:pointer-events-auto group-focus-within/tab-icon:opacity-100",
+					"disabled:pointer-events-none",
+				)}
+				disabled={onlyTab}
+				onClick={(event) => {
+					event.stopPropagation();
+					onClose();
+				}}
+				title={onlyTab ? closeTitle : closeLabel}
+				type="button"
+			>
+				<X aria-hidden="true" className="size-icon-sm" />
+			</button>
+		</div>
 	);
 }
 

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -480,19 +480,28 @@ function ClosedTabsSection({
 
 function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, tab }: TabRowProps) {
 	const { t } = useTranslation();
+	const [hovered, setHovered] = useState(false);
+	const [tooltipOpen, setTooltipOpen] = useState(false);
 	const label = browserTabLabel(tab.title, tab.url);
 	const closeLabel = t("browser.closeTab", { title: label.title });
 	return (
 		<div
 			className={cn(
-				"group/tab-icon relative flex h-8 w-full items-center overflow-hidden transition-colors",
-				"hover:bg-interactive-hover",
+				"group/tab-icon relative flex h-8 w-full items-center overflow-hidden",
 				active && "bg-interactive-active",
 			)}
+			onPointerEnter={() => {
+				setHovered(true);
+				setTooltipOpen(false);
+			}}
+			onPointerLeave={() => setHovered(false)}
 			ref={chrome?.setNodeRef}
 			style={chrome?.style}
 		>
-			<Tooltip>
+			<Tooltip
+				onOpenChange={(open) => setTooltipOpen(hovered ? false : open)}
+				open={tooltipOpen}
+			>
 				<TooltipTrigger asChild>
 					<button
 						aria-current={active ? "true" : undefined}
@@ -503,7 +512,11 @@ function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, ta
 						{...chrome?.dragProps}
 					>
 						<TabFavicon
-							className="size-icon-base transition-opacity group-hover/tab-icon:opacity-0 group-focus-within/tab-icon:opacity-0"
+							className={cn(
+								"size-icon-base transition-[opacity,transform] duration-150 ease-out",
+								"group-hover/tab-icon:scale-75 group-hover/tab-icon:opacity-0",
+								"group-focus-within/tab-icon:scale-75 group-focus-within/tab-icon:opacity-0",
+							)}
 							tab={tab}
 						/>
 					</button>
@@ -520,10 +533,13 @@ function IconTabRow({ active, chrome, closeTitle, onClose, onSelect, onlyTab, ta
 			<button
 				aria-label={closeLabel}
 				className={cn(
-					"pointer-events-none absolute inset-1.5 grid size-icon-base place-items-center rounded-sm text-passive opacity-0",
-					"transition-[opacity,color] hover:text-foreground",
-					"group-hover/tab-icon:pointer-events-auto group-hover/tab-icon:opacity-100",
-					"group-focus-within/tab-icon:pointer-events-auto group-focus-within/tab-icon:opacity-100",
+					"pointer-events-none absolute inset-0.5 grid size-7 scale-90 place-items-center rounded-md",
+					"bg-interactive-hover text-muted-foreground opacity-0",
+					"transition-[opacity,transform,background-color,color] duration-150 ease-out",
+					"hover:bg-destructive/15 hover:text-destructive active:scale-95",
+					"group-hover/tab-icon:pointer-events-auto group-hover/tab-icon:scale-100 group-hover/tab-icon:opacity-100",
+					"group-focus-within/tab-icon:pointer-events-auto group-focus-within/tab-icon:scale-100 group-focus-within/tab-icon:opacity-100",
+					"focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent/60",
 					"disabled:pointer-events-none",
 				)}
 				disabled={onlyTab}

--- a/frontend/src/renderer/lib/dom-selectors.ts
+++ b/frontend/src/renderer/lib/dom-selectors.ts
@@ -7,9 +7,9 @@ export const OPEN_DIALOG_OR_MENU_SELECTOR =
 // every Radix menu causes the preview to flash on ordinary toolbar clicks.
 // Radix tooltips never use `data-state="open"` — they report `delayed-open` or
 // `instant-open` depending on whether the hover delay elapsed or focus opened
-// them instantly. The pinned tabs rail marks its tooltip as a browser overlay so
-// it paints above the live page, so those two states have to be matched here as
-// well or the shell is never raised and the tooltip renders behind the page.
+// them instantly. Browser-panel tooltips can also be explicitly marked as native
+// overlays, so those two states have to be matched here as well or the shell is
+// never raised and the tooltip renders behind the page.
 export const OPEN_BROWSER_OVERLAY_SELECTOR =
 	'[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [data-browser-native-overlay="true"][data-state="open"], [data-browser-native-overlay="true"][data-state="delayed-open"], [data-browser-native-overlay="true"][data-state="instant-open"]';
 


### PR DESCRIPTION
Adds a direct close control to each pinned browser-tab favicon on hover or keyboard focus, without opening the full tabs flyout. The favicon transitions into a neutral close affordance, and the competing site tooltip is suppressed while that action is visible. Preserves tab selection, drag ordering, accessibility labels, and the existing single-tab close guard. The control is visually centered against the rail border. Verification: BrowserPanel.test.tsx (65 passed), frontend typecheck, and visual review in the native Electron app with real AO data.