### PR TITLE
feat(cloud): shared dev environment deploy path (dev-api.aoagents.dev)

### DIFF
--- a/cloud/scripts/deploy-dev.sh
+++ b/cloud/scripts/deploy-dev.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Deploys the current checkout to the shared DEV control plane
+# (https://dev-api.aoagents.dev). The dev environment is sacrificial: any
+# branch, any provider config, no ancestry checks. It shares nothing with
+# staging or production except the NodeOps account and the WorkOS app —
+# its database, task families, service, secrets, and alarm are all its own.
+#
+# Usage: AWS_PROFILE=ao-cloud ./cloud/scripts/deploy-dev.sh
+# (run from the cloud/ directory or repo root; requires Docker)
+set -euo pipefail
+
+export AO_CLOUD_ECS_CLUSTER="ao-cloud-dev"
+export AO_CLOUD_ECS_SERVICE="ao-cloud-dev-api"
+export AO_CLOUD_API_TASK_FAMILY="ao-cloud-dev-api"
+export AO_CLOUD_MIGRATION_TASK_FAMILY="ao-cloud-dev-migrate"
+export AO_CLOUD_ROLLBACK_ALARM="ao-cloud-dev-target-5xx"
+export AO_CLOUD_RUNTIME_DATABASE_USER="ao_dev_app"
+export AO_CLOUD_WORKER_SECRET_ID="ao-cloud/dev/worker"
+export AO_CLOUD_PROVIDER_SECRET_ID="ao-cloud/dev/provider-secret-key"
+export AO_CLOUD_PUBLIC_URL="https://dev-api.aoagents.dev"
+export AO_CLOUD_DEPLOY_ENVIRONMENT="dev"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir/.."
+exec ./scripts/deploy-staging.sh "$@"

--- a/cloud/scripts/deploy-dev.sh
+++ b/cloud/scripts/deploy-dev.sh
@@ -17,6 +17,7 @@ export AO_CLOUD_ROLLBACK_ALARM="ao-cloud-dev-target-5xx"
 export AO_CLOUD_RUNTIME_DATABASE_USER="ao_dev_app"
 export AO_CLOUD_WORKER_SECRET_ID="ao-cloud/dev/worker"
 export AO_CLOUD_PROVIDER_SECRET_ID="ao-cloud/dev/provider-secret-key"
+export AO_CLOUD_NODEOPS_SECRET_ID="ao-cloud/dev/nodeops"
 # Until dev-api.aoagents.dev DNS + certificate exist, workers reach the dev
 # control plane through the ALB listener on :8443 (routes by port, valid
 # staging-api certificate). Override once DNS lands.

--- a/cloud/scripts/deploy-dev.sh
+++ b/cloud/scripts/deploy-dev.sh
@@ -17,7 +17,10 @@ export AO_CLOUD_ROLLBACK_ALARM="ao-cloud-dev-target-5xx"
 export AO_CLOUD_RUNTIME_DATABASE_USER="ao_dev_app"
 export AO_CLOUD_WORKER_SECRET_ID="ao-cloud/dev/worker"
 export AO_CLOUD_PROVIDER_SECRET_ID="ao-cloud/dev/provider-secret-key"
-export AO_CLOUD_PUBLIC_URL="https://dev-api.aoagents.dev"
+# Until dev-api.aoagents.dev DNS + certificate exist, workers reach the dev
+# control plane through the ALB listener on :8443 (routes by port, valid
+# staging-api certificate). Override once DNS lands.
+export AO_CLOUD_PUBLIC_URL="${AO_CLOUD_PUBLIC_URL:-https://staging-api.aoagents.dev:8443}"
 export AO_CLOUD_DEPLOY_ENVIRONMENT="dev"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/cloud/scripts/deploy-staging.sh
+++ b/cloud/scripts/deploy-staging.sh
@@ -62,7 +62,7 @@ secret_arn() {
 		--output text
 }
 
-provider_secret_arn="$(secret_arn ao-cloud/staging/provider-secret-key)"
+provider_secret_arn="$(secret_arn "${AO_CLOUD_PROVIDER_SECRET_ID:-ao-cloud/staging/provider-secret-key}")"
 nodeops_secret_arn="$(secret_arn "$NODEOPS_SECRET_ID")"
 worker_secret_arn="$(secret_arn "$WORKER_SECRET_ID")"
 broker_secret_arn="$(secret_arn "${AO_CLOUD_REPOSITORY_BROKER_SECRET_ID:-ao-cloud/repository-broker}")"
@@ -202,7 +202,7 @@ register_task_definition() {
 	if [[ "$container_name" == "control-plane" ]]; then
 		render_args+=(
 			--worker-image "$worker_image"
-			--set-environment AO_CLOUD_PUBLIC_URL=https://staging-api.aoagents.dev
+			--set-environment "AO_CLOUD_PUBLIC_URL=${AO_CLOUD_PUBLIC_URL:-https://staging-api.aoagents.dev}"
 			--set-environment AO_CLOUD_REPOSITORY_BROKER_URL=https://api.aoagents.dev
 			--set-environment AO_CLOUD_ALLOW_ANONYMOUS_GITHUB_CHECKOUT=true
 			--set-environment "AO_CLOUD_NODEOPS_ROOTFS_BY_HARNESS=${rootfs_by_harness}"
@@ -252,7 +252,7 @@ migration_result="$(
 		--started-by "deploy-${RELEASE:0:28}" \
 		--tags \
 			key=Project,value=ao-cloud \
-			key=Environment,value=staging \
+			key=Environment,value="${AO_CLOUD_DEPLOY_ENVIRONMENT:-staging}" \
 			"key=Release,value=${RELEASE}"
 )"
 migration_arn="$(


### PR DESCRIPTION
## What

Adds `cloud/scripts/deploy-dev.sh` — a wrapper that deploys the current checkout to the new **shared dev control plane** at `https://dev-api.aoagents.dev` — and parameterizes three previously-hardcoded values in `deploy-staging.sh` (`AO_CLOUD_PUBLIC_URL`, `AO_CLOUD_PROVIDER_SECRET_ID`, environment tag) with staging defaults, so existing staging deploys are byte-for-byte unchanged.

## Why

Two incidents in two days (task-def `:64` and `:68–:71`) came from experiments being deployed to the shared staging environment, breaking every NodeOps session and the team's dogfooding builds. The dev environment is the sanctioned home for that work: any branch, any repo state, any sandbox provider (`AO_CLOUD_SANDBOX_PROVIDER=coder`, Fly, …) — with its own database, task families, ECS service, secrets (`ao-cloud/dev/*`), execution role, and rollback alarm. Blast radius is the dev environment itself.

## Infrastructure (already provisioned)

- ECS: cluster `ao-cloud-dev`, service `ao-cloud-dev-api` (1 task), task families `ao-cloud-dev-api`/`ao-cloud-dev-migrate`/`ao-cloud-dev-oneoff-sql`
- DB: `ao_cloud_dev` on the staging RDS instance, roles `ao_dev_migrate`/`ao_dev_app`, migrated to v36
- Secrets: `ao-cloud/dev/{database,database-url,migration-database-url,worker,provider-secret-key}` (fresh credentials; WorkOS/NodeOps/broker shared read-only)
- IAM: `ao-cloud-dev-execution-role` scoped to dev + shared secrets
- ALB: host rule `dev-api.aoagents.dev` → target group `ao-cloud-dev-cp` on the existing staging-public ALB; ACM cert requested (pending DNS validation)
- Alarm: `ao-cloud-dev-target-5xx`

## Dev flow

```bash
AWS_PROFILE=ao-cloud ./cloud/scripts/deploy-dev.sh          # any branch
AO_CLOUD_CONTROL_PLANE_URL=https://dev-api.aoagents.dev npm run dev   # point the app at it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)