### PR TITLE
fix(browser): keep docked tabs compact when resized

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -516,7 +516,7 @@ describe("BrowserPanel", () => {
 			{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: true },
 		];
 		hookState.activeTabId = "t2";
-		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut session={session} />);
 
 		const tabList = screen.getByRole("tablist", { name: "Browser tabs" });
 		const firstTab = within(tabList).getByRole("tab", { name: "First app" });
@@ -534,7 +534,7 @@ describe("BrowserPanel", () => {
 			{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: false },
 		];
 		hookState.activeTabId = "t1";
-		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut session={session} />);
 
 		const tabList = screen.getByRole("tablist", { name: "Browser tabs" });
 		const firstTab = within(tabList).getByRole("tab", { name: "First app" });
@@ -552,7 +552,7 @@ describe("BrowserPanel", () => {
 			{ id: "t2", url: "http://localhost:4173/", title: "Second app", active: false },
 		];
 		hookState.activeTabId = "t1";
-		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut session={session} />);
 
 		const tabList = screen.getByRole("tablist", { name: "Browser tabs" });
 		await userEvent.click(within(tabList).getByRole("button", { name: "Close tab Second app" }));
@@ -561,11 +561,18 @@ describe("BrowserPanel", () => {
 	});
 
 	it("opens a new browser tab from the horizontal tab strip", async () => {
-		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut session={session} />);
 
 		await userEvent.click(within(screen.getByTestId("browser-tab-bar")).getByRole("button", { name: "Open new tab" }));
 
 		expect(hookState.openTab).toHaveBeenCalledOnce();
+	});
+
+	it("keeps the horizontal tab strip out of docked mode", () => {
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		expect(screen.queryByTestId("browser-tab-bar")).not.toBeInTheDocument();
+		expect(screen.getByTestId("browser-tabs-rail")).toBeInTheDocument();
 	});
 
 	it("does not render a tab-specific agent marker", async () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -567,44 +567,46 @@ export function BrowserPanelView({
 			ref={panelRef}
 			role="tabpanel"
 		>
-			<div className="browser-panel__tab-bar" data-testid="browser-tab-bar">
-				<DndContext
-					collisionDetection={closestCenter}
-					onDragCancel={() => setTopTabDragActive(false)}
-					onDragEnd={handleTopTabDragEnd}
-					onDragStart={() => setTopTabDragActive(true)}
-					sensors={tabSensors}
-				>
-					<SortableContext items={tabs.map((tab) => tab.id)} strategy={horizontalListSortingStrategy}>
-						<div
-							aria-label={t("browser.tabs")}
-							className="browser-panel__tab-strip"
-							onKeyDown={topTabDragActive ? undefined : handleTabListKeyDown}
-							role="tablist"
-						>
-							{tabs.map((tab) => (
-								<SortableBrowserTopTab
-									key={tab.id}
-									onClose={handleCloseTab}
-									onSelect={handleSelectTab}
-									onlyTab={tabs.length === 1}
-									selected={tab.id === activeTabId}
-									tab={tab}
-								/>
-							))}
-						</div>
-					</SortableContext>
-				</DndContext>
-				<button
-					aria-label={t("browser.openNewTab")}
-					className="browser-panel__tab-new"
-					onClick={() => void handleOpenTab()}
-					title={t("browser.openNewTab")}
-					type="button"
-				>
-					<Plus aria-hidden="true" className="size-icon-base" />
-				</button>
-			</div>
+			{poppedOut ? (
+				<div className="browser-panel__tab-bar" data-testid="browser-tab-bar">
+					<DndContext
+						collisionDetection={closestCenter}
+						onDragCancel={() => setTopTabDragActive(false)}
+						onDragEnd={handleTopTabDragEnd}
+						onDragStart={() => setTopTabDragActive(true)}
+						sensors={tabSensors}
+					>
+						<SortableContext items={tabs.map((tab) => tab.id)} strategy={horizontalListSortingStrategy}>
+							<div
+								aria-label={t("browser.tabs")}
+								className="browser-panel__tab-strip"
+								onKeyDown={topTabDragActive ? undefined : handleTabListKeyDown}
+								role="tablist"
+							>
+								{tabs.map((tab) => (
+									<SortableBrowserTopTab
+										key={tab.id}
+										onClose={handleCloseTab}
+										onSelect={handleSelectTab}
+										onlyTab={tabs.length === 1}
+										selected={tab.id === activeTabId}
+										tab={tab}
+									/>
+								))}
+							</div>
+						</SortableContext>
+					</DndContext>
+					<button
+						aria-label={t("browser.openNewTab")}
+						className="browser-panel__tab-new"
+						onClick={() => void handleOpenTab()}
+						title={t("browser.openNewTab")}
+						type="button"
+					>
+						<Plus aria-hidden="true" className="size-icon-base" />
+					</button>
+				</div>
+			) : null}
 			<form
 				className={cn(
 					"browser-panel__toolbar flex shrink-0 min-w-0 items-center gap-1 border-b border-border bg-surface",

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4427,13 +4427,13 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 }
 
 @container browser-panel (min-width: 640px) {
-	.browser-panel__tab-bar {
+	.browser-panel--popped-out .browser-panel__tab-bar {
 		display: flex;
 	}
 
-	.browser-panel__toolbar-new-tab,
-	.browser-panel__toolbar-tabs-trigger,
-	.browser-tabs-rail {
+	.browser-panel--popped-out .browser-panel__toolbar-new-tab,
+	.browser-panel--popped-out .browser-panel__toolbar-tabs-trigger,
+	.browser-panel--popped-out .browser-tabs-rail {
 		display: none;
 	}
 }


### PR DESCRIPTION
## Summary

- keep the horizontal browser tab strip exclusive to the popped-out layout
- preserve the compact tabs rail when a docked browser panel grows past the wide-layout breakpoint
- add regression coverage for docked versus popped-out tab chrome

## Testing

- npm test -- --run src/renderer/components/BrowserPanel.test.tsx (65 passed)
- npm run typecheck
- native Electron verification on Windows with existing AO session data: resized the docked browser and confirmed it kept compact tab chrome

## Local CI notes

- Full frontend suite on Windows: 3206 passed, 37 failed across unrelated macOS/Unix-only, locale-sensitive, missing landing dependency, and existing flaky tests; BrowserPanel.test.tsx passed.
- npm run lint was attempted, but repo-wide backend tests hit existing Windows, local-auth, POSIX-shell, permission-mode, and path-assumption failures before golangci-lint ran.