### PR TITLE
fix(cli): make screenshot JSON honor paths

### DIFF
--- a/backend/internal/cli/browser.go
+++ b/backend/internal/cli/browser.go
@@ -36,6 +36,13 @@ type browserCommandResponseDTO struct {
 	Result    map[string]any `json:"result"`
 }
 
+type browserScreenshotFileResult struct {
+	Path   string `json:"path"`
+	Size   int64  `json:"size"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+
 const browserCapabilityHeader = "X-AO-Browser-Capability"
 const maxBrowserWaitMillis = 55_000
 const (
@@ -424,25 +431,36 @@ func newBrowserCommand(ctx *commandContext) *cobra.Command {
 	waitCmd.Flags().IntVar(&timeoutMS, "timeout", 10_000, "condition timeout in milliseconds")
 	cmd.AddCommand(waitCmd)
 
-	cmd.AddCommand(&cobra.Command{
+	var screenshotBase64 bool
+	screenshot := &cobra.Command{
 		Use:   "screenshot [path]",
 		Short: "Capture the current page to a PNG file",
-		Args:  atMostOneArg,
+		Long: "Capture the current page to a PNG file. JSON output writes the file and returns compact metadata.\n" +
+			"To return inline base64 image data instead, omit the path and use --base64 with --json.",
+		Args: atMostOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if screenshotBase64 && !jsonOutput {
+				return usageError{errors.New("--base64 requires --json")}
+			}
+			if screenshotBase64 && len(args) != 0 {
+				return usageError{errors.New("--base64 cannot be combined with a screenshot path")}
+			}
 			resp, err := ctx.browserAction(cmd.Context(), "screenshot", nil)
 			if err != nil {
 				return err
 			}
-			if jsonOutput {
+			if screenshotBase64 {
 				return writeJSON(cmd.OutOrStdout(), resp)
 			}
 			path := "ao-browser-" + ctx.deps.Now().Format("20060102-150405.000") + ".png"
 			if len(args) == 1 {
 				path = args[0]
 			}
-			return writeBrowserScreenshot(cmd, resp.Result, path)
+			return writeBrowserScreenshot(cmd, resp.Result, path, jsonOutput)
 		},
-	})
+	}
+	screenshot.Flags().BoolVar(&screenshotBase64, "base64", false, "include inline base64 image data in JSON output (cannot be used with a path)")
+	cmd.AddCommand(screenshot)
 
 	var networkDuration int
 	networkCmd := &cobra.Command{
@@ -810,7 +828,7 @@ func writeBrowserNetworkResult(cmd *cobra.Command, action string, result map[str
 	return err
 }
 
-func writeBrowserScreenshot(cmd *cobra.Command, result map[string]any, target string) error {
+func writeBrowserScreenshot(cmd *cobra.Command, result map[string]any, target string, jsonOutput bool) error {
 	encoded, _ := result["data"].(string)
 	if encoded == "" {
 		return errors.New("browser returned an empty screenshot")
@@ -830,18 +848,41 @@ func writeBrowserScreenshot(cmd *cobra.Command, result map[string]any, target st
 		}
 		return err
 	}
-	defer func() { _ = file.Close() }()
-	if _, err := file.Write(data); err != nil {
-		return err
+	written, writeErr := file.Write(data)
+	closeErr := file.Close()
+	if writeErr != nil {
+		return writeErr
 	}
-	width := numberString(result["width"])
-	height := numberString(result["height"])
+	if closeErr != nil {
+		return closeErr
+	}
+	width := numberInt(result["width"])
+	height := numberInt(result["height"])
+	if jsonOutput {
+		return writeJSON(cmd.OutOrStdout(), browserScreenshotFileResult{
+			Path:   abs,
+			Size:   int64(written),
+			Width:  width,
+			Height: height,
+		})
+	}
 	size := ""
-	if width != "" && height != "" {
-		size = " (" + width + "x" + height + ")"
+	if width > 0 && height > 0 {
+		size = fmt.Sprintf(" (%dx%d)", width, height)
 	}
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Saved %s%s\n", abs, size)
 	return err
+}
+
+func numberInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return 0
+	}
 }
 
 func numberString(v any) string {

--- a/backend/internal/cli/browser_test.go
+++ b/backend/internal/cli/browser_test.go
@@ -426,6 +426,105 @@ func TestBrowserScreenshotWritesWithoutOverwrite(t *testing.T) {
 	}
 }
 
+func TestBrowserScreenshotWritesRelativePath(t *testing.T) {
+	setBrowserIdentity(t)
+	cfg := setConfigEnv(t)
+	capture := &browserRequestCapture{}
+	srv := browserCLIServer(t, capture)
+	writeRunFileFor(t, cfg, srv)
+	deps := Deps{ProcessAlive: func(int) bool { return true }}
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	out, errOut, err := executeCLI(t, deps, "browser", "screenshot", "relative.png")
+	if err != nil {
+		t.Fatalf("relative screenshot err=%v stderr=%s", err, errOut)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "relative.png"))
+	if err != nil || string(data) != "png" {
+		t.Fatalf("relative screenshot data=%q err=%v", data, err)
+	}
+	if !strings.Contains(out, filepath.Join(dir, "relative.png")) {
+		t.Fatalf("relative screenshot output = %q", out)
+	}
+}
+
+func TestBrowserScreenshotJSONWritesCompactMetadata(t *testing.T) {
+	setBrowserIdentity(t)
+	cfg := setConfigEnv(t)
+	capture := &browserRequestCapture{}
+	srv := browserCLIServer(t, capture)
+	writeRunFileFor(t, cfg, srv)
+	deps := Deps{ProcessAlive: func(int) bool { return true }}
+	target := filepath.Join(t.TempDir(), "shot.png")
+
+	out, errOut, err := executeCLI(t, deps, "browser", "screenshot", target, "--json")
+	if err != nil {
+		t.Fatalf("JSON screenshot err=%v stderr=%s", err, errOut)
+	}
+	var metadata browserScreenshotFileResult
+	if err := json.Unmarshal([]byte(out), &metadata); err != nil {
+		t.Fatalf("decode JSON screenshot output: %v; output=%q", err, out)
+	}
+	if metadata.Path != target || metadata.Size != 3 || metadata.Width != 10 || metadata.Height != 20 {
+		t.Fatalf("JSON screenshot metadata = %#v", metadata)
+	}
+	if strings.Contains(out, "cG5n") || len(out) > 256 {
+		t.Fatalf("JSON screenshot output was not compact: %q", out)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "png" {
+		t.Fatalf("JSON screenshot data=%q err=%v", data, err)
+	}
+	if _, _, err := executeCLI(t, deps, "browser", "screenshot", target, "--json"); err == nil || !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Fatalf("JSON overwrite error = %v", err)
+	}
+}
+
+func TestBrowserScreenshotBase64RequiresExplicitJSONMode(t *testing.T) {
+	setBrowserIdentity(t)
+	cfg := setConfigEnv(t)
+	capture := &browserRequestCapture{}
+	srv := browserCLIServer(t, capture)
+	writeRunFileFor(t, cfg, srv)
+	deps := Deps{ProcessAlive: func(int) bool { return true }}
+	t.Chdir(t.TempDir())
+
+	out, errOut, err := executeCLI(t, deps, "browser", "screenshot", "--base64", "--json")
+	if err != nil {
+		t.Fatalf("base64 screenshot err=%v stderr=%s", err, errOut)
+	}
+	var response browserCommandResponseDTO
+	if err := json.Unmarshal([]byte(out), &response); err != nil {
+		t.Fatalf("decode base64 screenshot output: %v; output=%q", err, out)
+	}
+	if response.Result["data"] != "cG5n" {
+		t.Fatalf("base64 screenshot result = %#v", response.Result)
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("base64 screenshot wrote files: entries=%v err=%v", entries, err)
+	}
+	if _, _, err := executeCLI(t, deps, "browser", "screenshot", "--base64"); ExitCode(err) != 2 {
+		t.Fatalf("base64 without JSON error = %v code=%d", err, ExitCode(err))
+	}
+	if _, _, err := executeCLI(t, deps, "browser", "screenshot", "shot.png", "--base64", "--json"); ExitCode(err) != 2 {
+		t.Fatalf("base64 with path error = %v code=%d", err, ExitCode(err))
+	}
+}
+
+func TestBrowserScreenshotHelpExplainsJSONAndBase64Modes(t *testing.T) {
+	out, errOut, err := executeCLI(t, Deps{}, "browser", "screenshot", "--help")
+	if err != nil {
+		t.Fatalf("screenshot help err=%v stderr=%s", err, errOut)
+	}
+	for _, want := range []string{"compact metadata", "--base64", "cannot be used with a path"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("screenshot help missing %q: %s", want, out)
+		}
+	}
+}
+
 func TestBrowserRequiresSessionAndValidWait(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "")
 	if _, _, err := executeCLI(t, Deps{}, "browser", "status"); ExitCode(err) != 2 {

--- a/backend/internal/skillassets/using-ao/commands/browser.md
+++ b/backend/internal/skillassets/using-ao/commands/browser.md
@@ -92,6 +92,7 @@ ao browser uncheck <ref> [--json]
 ao browser get <property> [ref] [--json]
 ao browser wait (--text <text> | --text-gone <text> | --selector <css> | --selector-gone <css> | --url <substring> | --load | --dom-stable <milliseconds> | --ms <milliseconds>) [--timeout <milliseconds>] [--json]
 ao browser screenshot [path] [--json]
+ao browser screenshot --base64 --json
 ao browser network start [--duration <seconds>] [--json]
 ao browser network status [--json]
 ao browser network list [--json]
@@ -151,7 +152,11 @@ response bodies, credentials, cookies, or query values. `network status` and
 `network list` never enable capture. Use `network stop` as soon as the relevant
 failure is reproduced, and `network clear` to discard retained entries.
 
-Without `--json`, `screenshot` writes a PNG and refuses to overwrite an existing file. With `--json`, it returns the structured response including base64 image data.
+`screenshot` writes a PNG and refuses to overwrite an existing file. With
+`--json`, it still writes the requested (or generated default) path and returns
+only compact metadata: the resolved path, byte size, width, and height. To
+return inline image data instead, omit the path and explicitly combine
+`--base64` with `--json`.
 
 `ao preview` remains available for the passive URL/static-file workflow. Use `ao browser` when the agent needs to inspect or verify the page.
 


### PR DESCRIPTION
## What

- write screenshots to the requested or generated path in both text and JSON modes
- return compact `path`, `size`, `width`, and `height` metadata after JSON file writes
- require explicit `--base64 --json` for inline image data and reject ambiguous path/flag combinations before contacting the daemon
- document both screenshot modes and add coverage for absolute and relative paths, file bytes, compact JSON, overwrite refusal, validation, and help text

## Why

`ao browser screenshot <path> --json` accepted the path but skipped file creation and emitted the full base64 image response. This could flood and truncate agent output while silently ignoring the requested destination.

Fixes #4707.

## Testing

- `go test ./internal/cli`
- `go test ./internal/skillassets`
- `go vet ./internal/cli`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs ./internal/cli/...` (`0 issues`)

A repository-wide `npm run lint` attempt reached and passed the modified CLI and skill-asset packages, but its test stage was blocked locally by an unrelated missing-tmux prerequisite in `internal/session_manager`; one unrelated Pi timing test also failed under the parallel run and passed immediately when rerun in isolation.