### PR TITLE
fix(browser): redact URL secrets from agent output

### DIFF
--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -54,6 +54,9 @@ describe("browser URL sanitization", () => {
 		expect(sanitizeBrowserTitle(`Portal ${signed}`)).toBe(
 			"Portal https://example.test/access?token=%5Bredacted%5D",
 		);
+		expect(sanitizeBrowserTitle("about:blank")).toBe("about:blank");
+		expect(sanitizeBrowserTitle("mailto:operator@example.test?token=opaque")).toBe("mailto:[redacted]");
+		expect(sanitizeBrowserTitle("Status: all systems operational")).toBe("Status: all systems operational");
 		expect(sanitizeBrowserTitle("Government access portal")).toBe("Government access portal");
 	});
 });
@@ -1676,6 +1679,20 @@ describe("agent browser runtime", () => {
 				42,
 				"http://localhost:3000/app.js?token=source-secret#private",
 			);
+			const onCompleted = views[0].webContents.session.webRequest.onCompleted.mock.calls[0]?.[1] as
+				| ((details: {
+						resourceType: string;
+						method: string;
+						url: string;
+						statusCode: number;
+				  }) => void)
+				| undefined;
+			onCompleted?.({
+				resourceType: "xhr",
+				method: "POST",
+				url: "https://alice:completed-password@example.test/api/data?token=completed-secret#private",
+				statusCode: 403,
+			});
 			const onErrorOccurred = views[0].webContents.session.webRequest.onErrorOccurred.mock.calls[0]?.[1] as
 				| ((details: {
 						resourceType: string;
@@ -1687,7 +1704,7 @@ describe("agent browser runtime", () => {
 			onErrorOccurred?.({
 				resourceType: "xhr",
 				method: "GET",
-				url: "http://localhost:3000/api/data?token=request-secret#private",
+				url: "http://bob:error-password@localhost:3000/api/data?token=request-secret#private",
 				error: "net::ERR_CONNECTION_REFUSED",
 			});
 
@@ -1697,18 +1714,25 @@ describe("agent browser runtime", () => {
 				messages: Array<{ level: string; message: string }>;
 			};
 
-			expect(result.messages).toHaveLength(2);
+			expect(result.messages).toHaveLength(3);
 			expect(result.messages[0]).toMatchObject({ level: "error" });
 			expect(result.messages[0]?.message).toContain(
 				"render failed at https://example.test/page?token=%5Bredacted%5D (http://localhost:3000/app.js?token=%5Bredacted%5D:42)",
 			);
 			expect(result.messages[1]).toMatchObject({ level: "error" });
 			expect(result.messages[1]?.message).toContain(
+				"POST https://example.test/api/data?token=%5Bredacted%5D → 403",
+			);
+			expect(result.messages[2]).toMatchObject({ level: "error" });
+			expect(result.messages[2]?.message).toContain(
 				"GET http://localhost:3000/api/data?token=%5Bredacted%5D failed: net::ERR_CONNECTION_REFUSED",
 			);
 			expect(JSON.stringify(result)).not.toContain("console-secret");
 			expect(JSON.stringify(result)).not.toContain("source-secret");
+			expect(JSON.stringify(result)).not.toContain("completed-secret");
+			expect(JSON.stringify(result)).not.toContain("completed-password");
 			expect(JSON.stringify(result)).not.toContain("request-secret");
+			expect(JSON.stringify(result)).not.toContain("error-password");
 		} finally {
 			fetchSpy.mockReset();
 			vi.useRealTimers();

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -54,10 +54,27 @@ describe("browser URL sanitization", () => {
 		expect(sanitizeBrowserTitle(`Portal ${signed}`)).toBe(
 			"Portal https://example.test/access?token=%5Bredacted%5D",
 		);
+		expect(sanitizeBrowserTitle("custom://alice:password@example.test/path?token=opaque#private")).toBe(
+			"custom:[redacted]",
+		);
 		expect(sanitizeBrowserTitle("about:blank")).toBe("about:blank");
 		expect(sanitizeBrowserTitle("mailto:operator@example.test?token=opaque")).toBe("mailto:[redacted]");
+		expect(sanitizeBrowserTitle("data:text/plain,opaque")).toBe("data:[redacted]");
+		expect(sanitizeBrowserTitle("javascript:alert('opaque')")).toBe("javascript:[redacted]");
+		expect(sanitizeBrowserTitle("blob:https://example.test/opaque")).toBe("blob:[redacted]");
 		expect(sanitizeBrowserTitle("Status: all systems operational")).toBe("Status: all systems operational");
 		expect(sanitizeBrowserTitle("Government access portal")).toBe("Government access portal");
+	});
+
+	it.each([
+		["compact status label", "Status:degraded", "Status:degraded"],
+		[
+			"compact URL label",
+			"Docs:https://alice:password@example.test/path?token=opaque#private",
+			"Docs:https://example.test/path?token=%5Bredacted%5D",
+		],
+	])("preserves %s while sanitizing embedded URLs", (_name, input, expected) => {
+		expect(sanitizeBrowserTitle(input)).toBe(expected);
 	});
 });
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -8,6 +8,8 @@ import {
 	createBrowserViewHost,
 	isAllowedBrowserURL,
 	normalizeBrowserURL,
+	sanitizeBrowserTitle,
+	sanitizeBrowserURL,
 	scaleBoundsForZoom,
 } from "./browser-view-host";
 import {
@@ -21,6 +23,39 @@ import { parseAgentBrowserJSON } from "./agent-browser-runtime";
 vi.mock("electron", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("electron")>();
 	return { ...actual, net: { fetch: vi.fn() } };
+});
+
+describe("browser URL sanitization", () => {
+	it.each([
+		["ordinary URL", "https://example.test/docs/page", "https://example.test/docs/page"],
+		[
+			"query values and fragment",
+			"https://example.test/access?token=opaque-high-entropy-value&state=another-secret#private",
+			"https://example.test/access?token=%5Bredacted%5D&state=%5Bredacted%5D",
+		],
+		[
+			"embedded credentials",
+			"https://alice:password@example.test/private?next=secret",
+			"https://example.test/private?next=%5Bredacted%5D",
+		],
+		["blank page", "about:blank", "about:blank"],
+		[
+			"malformed URL",
+			"https://alice:password@example test/private?token=secret#private",
+			"https://example test/private",
+		],
+	])("sanitizes %s", (_name, input, expected) => {
+		expect(sanitizeBrowserURL(input)).toBe(expected);
+	});
+
+	it("sanitizes URL-shaped and URL-containing titles", () => {
+		const signed = "https://example.test/access?token=opaque#private";
+		expect(sanitizeBrowserTitle(signed)).toBe("https://example.test/access?token=%5Bredacted%5D");
+		expect(sanitizeBrowserTitle(`Portal ${signed}`)).toBe(
+			"Portal https://example.test/access?token=%5Bredacted%5D",
+		);
+		expect(sanitizeBrowserTitle("Government access portal")).toBe("Government access portal");
+	});
 });
 
 type InvokeHandler = (event: unknown, ...args: unknown[]) => unknown;
@@ -1369,6 +1404,30 @@ describe("agent browser runtime", () => {
 		expect(webContents.loadURL.mock.calls.some(([url]) => url !== "about:blank")).toBe(false);
 	});
 
+	it("redacts signed tab metadata only at the agent response boundary", async () => {
+		const { host, invoke } = setupTabHost();
+		const signed =
+			"https://alice:password@example.test/access?token=opaque-high-entropy-value&state=another-secret#private";
+		const safe = "https://example.test/access?token=%5Bredacted%5D&state=%5Bredacted%5D";
+
+		const opened = (await host.execute("sess-1", "open", { url: signed })) as BrowserNavState;
+		const ensured = (await invoke("browser:ensure", "sess-1")) as BrowserNavState;
+		const agentTabs = (await host.execute("sess-1", "tabs")) as BrowserTabsState;
+		const current = await host.execute("sess-1", "get", { property: "url" });
+		const unhighlighted = await host.execute("sess-1", "unhighlight");
+		const rendererTabs = (await invoke("browser:getTabs", ensured.viewId)) as BrowserTabsState;
+
+		expect(opened).toMatchObject({ url: safe, title: `Title ${safe}` });
+		expect(agentTabs.tabs[0]).toMatchObject({ url: safe, title: `Title ${safe}` });
+		expect(current).toMatchObject({ value: safe });
+		expect(unhighlighted).toMatchObject({ url: safe });
+		const agentOutput = JSON.stringify({ opened, agentTabs, current, unhighlighted });
+		expect(agentOutput).not.toContain("opaque-high-entropy-value");
+		expect(agentOutput).not.toContain("another-secret");
+		expect(agentOutput).not.toContain("password");
+		expect(rendererTabs.tabs[0]).toMatchObject({ url: signed, title: `Title ${signed}` });
+	});
+
 	it("destroys a headless session target through the daemon lifecycle command", async () => {
 		const { host, webContents } = setupHost();
 		await host.execute("sess-1", "tabs");
@@ -1611,7 +1670,12 @@ describe("agent browser runtime", () => {
 			const { host, views } = setupTabHost();
 			await host.execute("sess-1", "open", { url: "http://localhost:3000" });
 
-			views[0].webContents.emitConsoleMessage(3, "render failed", 42, "http://localhost:3000/app.js");
+			views[0].webContents.emitConsoleMessage(
+				3,
+				"render failed at https://example.test/page?token=console-secret#private",
+				42,
+				"http://localhost:3000/app.js?token=source-secret#private",
+			);
 			const onErrorOccurred = views[0].webContents.session.webRequest.onErrorOccurred.mock.calls[0]?.[1] as
 				| ((details: {
 						resourceType: string;
@@ -1623,7 +1687,7 @@ describe("agent browser runtime", () => {
 			onErrorOccurred?.({
 				resourceType: "xhr",
 				method: "GET",
-				url: "http://localhost:3000/api/data",
+				url: "http://localhost:3000/api/data?token=request-secret#private",
 				error: "net::ERR_CONNECTION_REFUSED",
 			});
 
@@ -1636,12 +1700,15 @@ describe("agent browser runtime", () => {
 			expect(result.messages).toHaveLength(2);
 			expect(result.messages[0]).toMatchObject({ level: "error" });
 			expect(result.messages[0]?.message).toContain(
-				"render failed (http://localhost:3000/app.js:42)",
+				"render failed at https://example.test/page?token=%5Bredacted%5D (http://localhost:3000/app.js?token=%5Bredacted%5D:42)",
 			);
 			expect(result.messages[1]).toMatchObject({ level: "error" });
 			expect(result.messages[1]?.message).toContain(
-				"GET http://localhost:3000/api/data failed: net::ERR_CONNECTION_REFUSED",
+				"GET http://localhost:3000/api/data?token=%5Bredacted%5D failed: net::ERR_CONNECTION_REFUSED",
 			);
+			expect(JSON.stringify(result)).not.toContain("console-secret");
+			expect(JSON.stringify(result)).not.toContain("source-secret");
+			expect(JSON.stringify(result)).not.toContain("request-secret");
 		} finally {
 			fetchSpy.mockReset();
 			vi.useRealTimers();

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -2618,7 +2618,9 @@ export function sanitizeBrowserURL(raw: string): string {
 
 export function sanitizeBrowserTitle(raw: string): string {
 	const title = raw.trim();
-	if (/^[a-z][a-z\d+.-]*:\S/i.test(title)) return sanitizeBrowserURL(title);
+	if (/^(?:[a-z][a-z\d+.-]*:\/\/|(?:about|mailto|data|javascript|blob):)/i.test(title)) {
+		return sanitizeBrowserURL(title);
+	}
 	return sanitizeURLsInText(raw);
 }
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -640,10 +640,12 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		// agent-browser's own debugger attachment for this tab.
 		view.webContents.on("console-message", (_event, level, message, line, sourceId) => {
 			if (level < 3) return;
-			const location = sourceId ? `${sourceId}${typeof line === "number" ? `:${line}` : ""}` : "";
+			const location = sourceId
+				? `${sanitizeBrowserURL(sourceId)}${typeof line === "number" ? `:${line}` : ""}`
+				: "";
 			recordBrowserSignal(session, {
 				kind: "console-error",
-				message: location ? `${message} (${location})` : message,
+				message: location ? `${sanitizeURLsInText(message)} (${location})` : sanitizeURLsInText(message),
 			});
 		});
 		hardenWebContents(
@@ -792,7 +794,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			if (details.resourceType !== "xhr") return;
 			recordBrowserSignal(session, {
 				kind: "network-failure",
-				message: `${details.method} ${details.url} failed: ${details.error}`,
+				message: `${details.method} ${sanitizeBrowserURL(details.url)} failed: ${details.error}`,
 			});
 		});
 	};
@@ -1667,7 +1669,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 				case "open": {
 					const url = stringArg(args, "url", "URL_REQUIRED", "url is required");
 					await runNative(action, { url: normalizeAgentBrowserURL(url) });
-					return pushNavState(options, activeEntry(session));
+					return agentNavState(pushNavState(options, activeEntry(session)));
 				}
 				case "snapshot": {
 					const result = await runNative(action, { interactive: Boolean(args.interactive) });
@@ -1774,24 +1776,24 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 						targetRef: stringArg(args, "targetRef", "REFERENCE_REQUIRED", "target ref is required"),
 					});
 				case "unhighlight":
-					return unhighlightEntry(entry);
+					return agentURLResult(await unhighlightEntry(entry));
 				case "tabs":
-					return listTabs(session);
+					return agentTabsResult(session);
 				case "tab-new": {
 					const url =
 						typeof args.url === "string" && args.url.trim() ? normalizeAgentBrowserURL(args.url) : undefined;
 					await runNative(action, { url });
-					return tabResult(activeEntry(session), true);
+					return agentTabResult(activeEntry(session), true);
 				}
 				case "tab-select": {
 					await runNative(action, { tabId: stringArg(args, "tabId", "TAB_ID_REQUIRED", "tabId is required") });
-					return tabResult(activeEntry(session), true);
+					return agentTabResult(activeEntry(session), true);
 				}
 				case "tab-close": {
 					const tabId =
 						typeof args.tabId === "string" && args.tabId.trim() ? args.tabId.trim() : session.activeTabId;
 					await runNative(action, { tabId });
-					return { closedTabId: tabId, ...listTabs(session) };
+					return { closedTabId: tabId, ...agentTabsResult(session) };
 				}
 				case "scroll":
 					return runNative(action, {
@@ -1809,7 +1811,18 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 						property,
 						ref: typeof args.ref === "string" && args.ref.trim() ? args.ref : undefined,
 					});
-					return { ...result, value: result.value ?? result[property] };
+					const value = result.value ?? result[property];
+					const safeValue =
+						property === "url"
+							? sanitizeBrowserURL(String(value ?? ""))
+							: property === "title"
+								? sanitizeBrowserTitle(String(value ?? ""))
+								: value;
+					return {
+						...result,
+						...(property === "url" || property === "title" ? { [property]: safeValue } : {}),
+						value: safeValue,
+					};
 				}
 				case "wait":
 					return runNative(action, args);
@@ -2040,6 +2053,44 @@ function tabResult(entry: BrowserEntry, active: boolean): BrowserTabState & { un
 		active,
 		...(entry.favicon ? { favicon: entry.favicon } : {}),
 		untrustedExternalContent: true,
+	};
+}
+
+// Renderer IPC deliberately keeps the real URL for the address bar and tab
+// navigation. Agent/daemon responses use this separate projection because they
+// are retained in tool output and transcripts.
+function agentTabResult(entry: BrowserEntry, active: boolean): BrowserTabState & { untrustedExternalContent: true } {
+	const tab = tabResult(entry, active);
+	return {
+		...tab,
+		url: sanitizeBrowserURL(tab.url),
+		title: sanitizeBrowserTitle(tab.title),
+	};
+}
+
+function agentTabsResult(session: BrowserSessionEntry): BrowserTabsState & { untrustedExternalContent: true } {
+	return {
+		viewId: session.viewId,
+		activeTabId: session.activeTabId,
+		tabs: [...session.tabs.values()].map((entry) => agentTabResult(entry, entry.tabId === session.activeTabId)),
+		untrustedExternalContent: true,
+	};
+}
+
+function agentNavState(state: BrowserNavState): BrowserNavState {
+	return {
+		...state,
+		url: sanitizeBrowserURL(state.url),
+		title: sanitizeBrowserTitle(state.title),
+		...(state.error ? { error: sanitizeURLsInText(state.error) } : {}),
+	};
+}
+
+function agentURLResult(result: unknown): unknown {
+	if (!result || typeof result !== "object" || !("url" in result)) return result;
+	return {
+		...result,
+		url: sanitizeBrowserURL(String(result.url ?? "")),
 	};
 }
 
@@ -2436,14 +2487,14 @@ function handleNetworkDebuggerEvent(entry: BrowserEntry, method: string, params:
 		if (previous && Object.keys(redirect).length > 0) {
 			applyNetworkResponse(previous, redirect);
 			finishNetworkRequest(previous, timestamp);
-			previous.redirectedTo = sanitizeNetworkURL(url);
+			previous.redirectedTo = sanitizeBrowserURL(url);
 		}
 		const wallTime = finiteNumber(params.wallTime);
 		const item: InternalBrowserNetworkRequest = {
 			id: `n${capture.nextSequence++}`,
 			protocolRequestId: requestID,
 			method: typeof request.method === "string" ? request.method : "GET",
-			url: sanitizeNetworkURL(url),
+			url: sanitizeBrowserURL(url),
 			resourceType: typeof params.type === "string" ? params.type.toLowerCase() : undefined,
 			startedAt: wallTime ? new Date(wallTime * 1_000).toISOString() : new Date().toISOString(),
 			startedMonotonic: timestamp,
@@ -2535,13 +2586,17 @@ function selectedNetworkHeaders(value: unknown, kind: "request" | "response"): R
 		const name = rawName.toLowerCase();
 		if (!allowed.has(name)) continue;
 		let headerValue = typeof rawValue === "string" ? rawValue : String(rawValue);
-		if (name === "referer" || name === "location") headerValue = sanitizeNetworkURL(headerValue);
+		if (name === "referer" || name === "location") headerValue = sanitizeBrowserURL(headerValue);
 		selected[name] = headerValue.slice(0, 1_000);
 	}
 	return Object.keys(selected).length > 0 ? selected : undefined;
 }
 
-function sanitizeNetworkURL(raw: string): string {
+// Safe-to-retain URL form: keep the location useful while removing values that
+// commonly carry credentials or one-time handoff material.
+export function sanitizeBrowserURL(raw: string): string {
+	if (!raw) return "";
+	if (raw === "about:blank") return raw;
 	try {
 		const url = new URL(raw);
 		if (!["http:", "https:", "file:"].includes(url.protocol)) {
@@ -2556,8 +2611,19 @@ function sanitizeNetworkURL(raw: string): string {
 		return url.href;
 	} catch {
 		const withoutFragment = raw.split("#", 1)[0] ?? "";
-		return (withoutFragment.split("?", 1)[0] ?? "").slice(0, 2_000);
+		const withoutQuery = withoutFragment.split("?", 1)[0] ?? "";
+		return withoutQuery.replace(/^([a-z][a-z\d+.-]*:\/\/)[^/@\s]+@/i, "$1").slice(0, 2_000);
 	}
+}
+
+export function sanitizeBrowserTitle(raw: string): string {
+	const title = raw.trim();
+	if (/^[a-z][a-z\d+.-]*:/i.test(title)) return sanitizeBrowserURL(title);
+	return sanitizeURLsInText(raw);
+}
+
+function sanitizeURLsInText(raw: string): string {
+	return raw.replace(/\b(?:https?|file):\/\/[^\s<>"']+/gi, (match) => sanitizeBrowserURL(match));
 }
 
 function objectValue(value: unknown): Record<string, unknown> {
@@ -2662,7 +2728,7 @@ function normalizeNativeMessages(
 		if (typeof item === "string") {
 			return {
 				level: action === "errors" ? "error" : "log",
-				message: markUntrusted(externalText(item)),
+				message: markUntrusted(externalText(sanitizeURLsInText(item))),
 				timestamp: new Date().toISOString(),
 			};
 		}
@@ -2683,7 +2749,7 @@ function normalizeNativeMessages(
 					: JSON.stringify(record);
 		return {
 			level,
-			message: markUntrusted(externalText(message)),
+			message: markUntrusted(externalText(sanitizeURLsInText(message))),
 			timestamp: typeof record.timestamp === "string" ? record.timestamp : new Date().toISOString(),
 		};
 	});

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -787,7 +787,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			if (details.resourceType !== "xhr" || details.statusCode < 400) return;
 			recordBrowserSignal(session, {
 				kind: "network-failure",
-				message: `${details.method} ${details.url} → ${details.statusCode}`,
+				message: `${details.method} ${sanitizeBrowserURL(details.url)} → ${details.statusCode}`,
 			});
 		});
 		electronSession.webRequest.onErrorOccurred(filter, (details) => {
@@ -2618,7 +2618,7 @@ export function sanitizeBrowserURL(raw: string): string {
 
 export function sanitizeBrowserTitle(raw: string): string {
 	const title = raw.trim();
-	if (/^[a-z][a-z\d+.-]*:/i.test(title)) return sanitizeBrowserURL(title);
+	if (/^[a-z][a-z\d+.-]*:\S/i.test(title)) return sanitizeBrowserURL(title);
 	return sanitizeURLsInText(raw);
 }
 


### PR DESCRIPTION
## Summary

- sanitize browser tab URLs and URL-shaped titles before Electron returns them to the daemon
- cover adjacent agent-facing URL metadata from open, tab actions, get URL/title, and unhighlight while preserving raw renderer state for navigation
- redact structured and embedded URLs in captured console and network errors

## Security behavior

The safe retained form preserves scheme, host, port, and path. It removes embedded credentials and fragments, and replaces every query value with [redacted]. No unsafe full-URL opt-in is added because current agent workflows do not require one.

## Tests

- npm test -- --run src/main/browser-view-host.test.ts (106 passed)
- npm run typecheck
- go test ./internal/cli
- native Electron launch in isolated mode; renderer http://localhost:5173 and daemon 127.0.0.1:3002 responded successfully

## Broader checks

- full frontend suite: 3,220 passed, 2 skipped, 35 unrelated Windows/environment failures (macOS path assumptions, blocked temp sockets, missing landing-only dependencies, locale formatting, and one timeout)
- go test ./internal/httpd/...: HTTP/spec packages passed; controllers had one unrelated existing clone-URL fixture failure on Windows

Closes #4706