### PR TITLE
fix(chat): refresh ACP history during TUI-to-Chat transition

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/driver.go
+++ b/backend/internal/adapters/chatdriver/acp/driver.go
@@ -256,21 +256,20 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 	}
 	var configOptions []acpsdk.SessionConfigOption
 	var modes *acpsdk.SessionModeState
+	var historyConversation *refreshableConversation
 	if init.AgentCapabilities.LoadSession {
-		conv.beginHistoryReplay(cfg.ProviderConversationID)
-		resp, err := conv.conn.LoadSession(resumeCtx, acpsdk.LoadSessionRequest{
+		historyConversation = newRefreshableConversation(conv, acpsdk.LoadSessionRequest{
 			Meta:                  meta,
 			SessionId:             acpsdk.SessionId(cfg.ProviderConversationID),
 			Cwd:                   cfg.WorkspacePath,
 			AdditionalDirectories: additional,
 			McpServers:            mcpServers,
 		})
+		resp, err := historyConversation.loadHistory(resumeCtx)
 		if err != nil {
-			conv.abortHistoryReplay()
 			_ = conv.Close()
 			return nil, fmt.Errorf("%w: %w", ports.ErrChatResumeFailed, normalizeACPError("ACP session/load", err))
 		}
-		conv.finishHistoryReplay()
 		configOptions = resp.ConfigOptions
 		modes = resp.Modes
 	} else {
@@ -299,6 +298,9 @@ func (d *Driver) Resume(ctx context.Context, cfg ports.ChatResumeConfig) (ports.
 			_ = conv.Close()
 			return nil, fmt.Errorf("%w: configure ACP session: %w", ports.ErrChatResumeFailed, err)
 		}
+	}
+	if historyConversation != nil {
+		return historyConversation, nil
 	}
 	return conv, nil
 }

--- a/backend/internal/adapters/chatdriver/acp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/acp/driver_test.go
@@ -29,6 +29,9 @@ type fakeAgent struct {
 	loadParams          acpsdk.LoadSessionRequest
 	resumeParams        acpsdk.ResumeSessionRequest
 	loadUpdates         []acpsdk.SessionUpdate
+	loadUpdateBatches   [][]acpsdk.SessionUpdate
+	blockLoadCall       int
+	loadStarted         chan struct{}
 	loadCalls           int
 	resumeCalls         int
 	promptParams        acpsdk.PromptRequest
@@ -259,8 +262,21 @@ func (a *fakeAgent) LoadSession(ctx context.Context, params acpsdk.LoadSessionRe
 	a.mu.Lock()
 	a.loadParams = params
 	a.loadCalls++
+	loadCall := a.loadCalls
 	updates := append([]acpsdk.SessionUpdate(nil), a.loadUpdates...)
+	if batch := a.loadCalls - 1; batch < len(a.loadUpdateBatches) {
+		updates = append([]acpsdk.SessionUpdate(nil), a.loadUpdateBatches[batch]...)
+	}
+	block := a.blockLoadCall == loadCall
+	started := a.loadStarted
 	a.mu.Unlock()
+	if block {
+		if started != nil {
+			close(started)
+		}
+		<-ctx.Done()
+		return acpsdk.LoadSessionResponse{}, ctx.Err()
+	}
 	for _, update := range updates {
 		if err := a.conn.SessionUpdate(ctx, acpsdk.SessionNotification{SessionId: params.SessionId, Update: update}); err != nil {
 			return acpsdk.LoadSessionResponse{}, err
@@ -746,9 +762,12 @@ func TestACPDriverReappliesLaunchContextWhenResuming(t *testing.T) {
 	if _, err := conv.(ports.ChatHistoryReader).ReadHistory(context.Background()); !errors.Is(err, ports.ErrChatHistoryUnavailable) {
 		t.Fatalf("ReadHistory error = %v, want ErrChatHistoryUnavailable after session/resume", err)
 	}
+	if _, ok := conv.(ports.ChatHistoryRefresher); ok {
+		t.Fatal("resume-only ACP conversation advertised refreshable history")
+	}
 }
 
-func TestACPDriverClosesReplayTurnsAsRecoveredWithoutBlockingResume(t *testing.T) {
+func TestACPDriverRefreshesHistoryWithAnotherSessionLoad(t *testing.T) {
 	userOneID := "11111111-1111-4111-8111-111111111111"
 	answerOneID := "22222222-2222-4222-8222-222222222222"
 	userTwoID := "33333333-3333-4333-8333-333333333333"
@@ -780,8 +799,10 @@ func TestACPDriverClosesReplayTurnsAsRecoveredWithoutBlockingResume(t *testing.T
 		capabilities: &acpsdk.AgentCapabilities{
 			LoadSession: true,
 		},
-		loadUpdates: []acpsdk.SessionUpdate{
-			userOne, replaySeed, answerOneA, answerOneB, userTwo, answerTwo, pendingTool,
+		loadUpdateBatches: [][]acpsdk.SessionUpdate{
+			{userOne, replaySeed, answerOneA, answerOneB},
+			{userOne, replaySeed, answerOneA, answerOneB, userTwo, answerTwo, pendingTool},
+			{userOne, replaySeed, answerOneA, answerOneB, userTwo, answerTwo, pendingTool},
 		},
 	}
 	driver := New(Config{
@@ -805,8 +826,9 @@ func TestACPDriverClosesReplayTurnsAsRecoveredWithoutBlockingResume(t *testing.T
 		t.Fatalf("Resume: %v", err)
 	}
 	defer conv.Close()
-	if _, ok := conv.(ports.ChatHistoryRefresher); ok {
-		t.Fatal("ACP session/load replay is a frozen snapshot, not refreshable history")
+	refresher, ok := conv.(ports.ChatHistoryRefresher)
+	if !ok {
+		t.Fatal("load-capable ACP conversation does not advertise refreshable history")
 	}
 
 	agent.mu.Lock()
@@ -822,9 +844,56 @@ func TestACPDriverClosesReplayTurnsAsRecoveredWithoutBlockingResume(t *testing.T
 		t.Fatalf("session/load metadata = %#v, want recomputed system prompt", loadMeta)
 	}
 
-	history, err := conv.(ports.ChatHistoryReader).ReadHistory(context.Background())
+	initial, err := conv.(ports.ChatHistoryReader).ReadHistory(context.Background())
 	if err != nil {
 		t.Fatalf("ReadHistory: %v", err)
+	}
+	initialTurns := 0
+	for _, event := range initial {
+		if event.Kind == ports.ChatEventTurnCompleted {
+			initialTurns++
+		}
+	}
+	if initialTurns != 1 {
+		t.Fatalf("initial completed turns = %d, want only the first replayed turn", initialTurns)
+	}
+	history, err := refresher.RefreshHistory(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshHistory: %v", err)
+	}
+	agent.mu.Lock()
+	loadCalls = agent.loadCalls
+	agent.mu.Unlock()
+	if loadCalls != 2 {
+		t.Fatalf("session/load calls = %d, want a fresh provider observation", loadCalls)
+	}
+	if len(history) <= len(initial) {
+		t.Fatalf("refreshed history has %d events, want more than initial snapshot's %d", len(history), len(initial))
+	}
+	for i := range initial {
+		if initial[i].ProviderEventID != history[i].ProviderEventID {
+			t.Fatalf("event %d identity changed across replay: %q != %q",
+				i, initial[i].ProviderEventID, history[i].ProviderEventID)
+		}
+	}
+	identical, err := refresher.RefreshHistory(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshHistory identical replay: %v", err)
+	}
+	agent.mu.Lock()
+	loadCalls = agent.loadCalls
+	agent.mu.Unlock()
+	if loadCalls != 3 {
+		t.Fatalf("session/load calls = %d after identical refresh, want another provider observation", loadCalls)
+	}
+	if len(identical) != len(history) {
+		t.Fatalf("identical replay has %d events, want %d", len(identical), len(history))
+	}
+	for i := range history {
+		if history[i].ProviderEventID != identical[i].ProviderEventID {
+			t.Fatalf("identical replay event %d changed identity: %q != %q",
+				i, history[i].ProviderEventID, identical[i].ProviderEventID)
+		}
 	}
 	var states []domain.TurnState
 	var recoveredActivity bool
@@ -866,6 +935,47 @@ func TestACPDriverClosesReplayTurnsAsRecoveredWithoutBlockingResume(t *testing.T
 	case event := <-conv.Events():
 		t.Fatalf("history leaked onto the live event stream: %#v", event)
 	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+func TestACPDriverHistoryRefreshHonorsCancellation(t *testing.T) {
+	userID := "11111111-1111-4111-8111-111111111111"
+	user := acpsdk.UpdateUserMessageText("Inspect the repository")
+	user.UserMessageChunk.MessageId = &userID
+	refreshStarted := make(chan struct{})
+	agent := &fakeAgent{
+		capabilities:  &acpsdk.AgentCapabilities{LoadSession: true},
+		loadUpdates:   []acpsdk.SessionUpdate{user},
+		blockLoadCall: 2,
+		loadStarted:   refreshStarted,
+	}
+	driver := New(Config{
+		Harness:      domain.HarnessClaudeCode,
+		Capabilities: ports.ChatCapabilities{ports.ChatCapabilityStreaming: true},
+		Probe:        func(context.Context) error { return nil },
+		Launch:       func(context.Context, LaunchConfig) (Launch, error) { return Launch{Command: "fake"}, nil },
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	driver.spawn = fakeSpawn(agent)
+
+	conv, err := driver.Resume(context.Background(), ports.ChatResumeConfig{
+		ProviderConversationID: "provider-session-1",
+		WorkspacePath:          t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	defer conv.Close()
+	refresher := conv.(ports.ChatHistoryRefresher)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, refreshErr := refresher.RefreshHistory(ctx)
+		done <- refreshErr
+	}()
+	<-refreshStarted
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("RefreshHistory error = %v, want context cancellation", err)
 	}
 }
 

--- a/backend/internal/adapters/chatdriver/acp/history.go
+++ b/backend/internal/adapters/chatdriver/acp/history.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	acpsdk "github.com/coder/acp-go-sdk"
 
@@ -14,6 +15,59 @@ import (
 )
 
 const aoInternalReplayMetaKey = "ao.internalReplay"
+
+// refreshableConversation is returned only when the agent advertised
+// session/load. Calling session/load again on the already resumed ACP connection
+// asks the provider to replay its durable transcript again; it does not start a
+// new provider conversation or merely reread historyEvents.
+type refreshableConversation struct {
+	*conversation
+	loadMu      sync.Mutex
+	loadRequest acpsdk.LoadSessionRequest
+}
+
+var _ ports.ChatHistoryRefresher = (*refreshableConversation)(nil)
+
+func newRefreshableConversation(
+	conversation *conversation,
+	request acpsdk.LoadSessionRequest,
+) *refreshableConversation {
+	return &refreshableConversation{conversation: conversation, loadRequest: request}
+}
+
+func (c *refreshableConversation) loadHistory(ctx context.Context) (acpsdk.LoadSessionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return acpsdk.LoadSessionResponse{}, err
+	}
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return acpsdk.LoadSessionResponse{}, err
+	}
+
+	c.beginHistoryReplay(string(c.loadRequest.SessionId))
+	response, err := c.conn.LoadSession(ctx, c.loadRequest)
+	if err != nil {
+		c.abortHistoryReplay()
+		return acpsdk.LoadSessionResponse{}, err
+	}
+	c.finishHistoryReplay()
+	return response, nil
+}
+
+// RefreshHistory implements ports.ChatHistoryRefresher with a new ACP
+// session/load request. Replaying identical provider data is safe because the
+// capture regenerates the same stable ProviderEventID values, and the Chat
+// projector deduplicates those identities when importing a settled snapshot.
+func (c *refreshableConversation) RefreshHistory(ctx context.Context) ([]ports.ChatEvent, error) {
+	if _, err := c.loadHistory(ctx); err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, fmt.Errorf("refresh ACP session history: %w: %w", contextErr, err)
+		}
+		return nil, normalizeACPError("refresh ACP session history", err)
+	}
+	return c.ReadHistory(ctx)
+}
 
 // historyCapture receives the session/update replay produced by ACP session/load.
 // ACP deliberately replays a flat stream rather than provider turns, so user


### PR DESCRIPTION
Fixes #4681

## Problem

ACP-backed sessions could fail immediately when switching from TUI to Chat if the first native-history replay had not yet reached the transition checkpoint. ACP exposed only a history reader, so the controller treated the snapshot as non-refreshable and returned `TARGET_HISTORY_UNSETTLED`.

## Root cause

During TUI-to-Chat transition, the session manager stops the source TUI, commits the target controller epoch, and asks Chat to resume the same provider conversation with native history required. ACP's `Resume` opens the target connection and performs one `session/load`; the adapter captured that replay into an immutable slice. If Claude Code's durable transcript had not yet exposed AO's latest completed-turn checkpoint, `controller.readNativeHistory` correctly rejected the stale prefix. Because ACP did not implement `ChatHistoryRefresher`, the capability-based retry path from #4123 failed immediately instead of making another provider observation.

ACP `session/load` is repeatable for the same session ID: it resolves the existing session and replays that session's durable history again. The live adapter retains the connection and full load request needed to repeat that observation safely. The checkpoint remains proven only by the existing completed-turn/high-water matching in the Chat controller.

This differs from:

- #4120, which corrected which AO turn states may anchor the replay high-water mark;
- #4123, which introduced capability-based refresh and intentionally fast-failed ACP while its snapshot was considered immutable;
- #4424, which concerns unscoped checkpoint provenance/recovery and is unchanged here.

## Fix

Return a small `refreshableConversation` wrapper only for ACP agents that advertise `session/load`. It stores the exact initial load request and serializes repeated loads on the already-resumed ACP connection. `RefreshHistory` issues a new `session/load`, captures the new provider replay, and then exposes that snapshot to the existing controller checkpoint logic.

This is not polling the cached `historyEvents` slice: every refresh crosses the ACP protocol and causes another provider transcript observation. Resume-only ACP agents remain non-refreshable.

## Safety

- preserves history-completeness and checkpoint checks unchanged
- keeps the source TUI session intact through the existing rollback path on failure
- reloads the existing provider session; it does not create a replacement conversation
- regenerates stable provider event IDs, so identical replay prefixes remain idempotent and the existing projector deduplication remains effective
- uses the existing bounded controller retry/timeout and propagates context cancellation
- creates no target Chat controller until native history is accepted
- adds no harness-name conditional to service code and changes no Codex behavior

## Tests

Passed:

- regression-first proof: `go test ./internal/adapters/chatdriver/acp -run TestACPDriverRefreshesHistoryWithAnotherSessionLoad -count=1` failed before implementation because ACP did not advertise refreshable history
- `go test ./internal/adapters/chatdriver/acp/... -count=1`
- `go test ./internal/adapters/chatdriver/acp/... ./internal/service/chat/... ./internal/session_manager/... -count=1` (ACP and Chat packages passed; session-manager Windows baseline failures noted below)
- `go test ./internal/session_manager -run InterfaceTransition -count=1`
- `go test -race ./internal/adapters/chatdriver/acp/... ./internal/service/chat/... -count=1`
- `go test -race ./internal/session_manager -run InterfaceTransition -count=1`
- `go vet ./...`
- pinned golangci-lint against the diff: `... golangci-lint@v2.12.2 run --path-mode=abs --new-from-rev=origin/main --timeout=10m` — 0 issues

The final test-only assertion proving a third identical replay performs another wire `session/load` passed in the normal ACP suite. A post-assertion race rerun could not start after Windows cleaned the temporary checksum-verified Go/MinGW toolchain; the race suite above passed with the same production implementation.

Repository-wide Windows limitations:

- `npm run lint` and its `go test ./...` step encounter existing POSIX-path, shell/tmux, symlink-privilege, `/tmp`, and environment-sensitive test failures on Windows.
- The representative session-manager failures were reproduced in a clean `origin/main` worktree at `9aadfc8ae` with the same results.
- Running pinned golangci-lint globally on Windows reported 1,033 baseline findings (1,022 repository-wide goimports reports plus existing Windows errcheck/gosec findings) and timed out; diff-only lint reports 0 issues.

No live Claude Code/ACP provider validation was performed; coverage is deterministic fake-provider replay plus code-path verification.

## Intentional omissions

- No change to #4424's unscoped-checkpoint behavior.
- No controller timeout, replay-completeness, error-mapping, migration, frontend, or Codex app-server change.
- No retry by rereading an immutable cached snapshot and no arbitrary sleep.