### PR TITLE
test(codexappserver): tolerate a provider older than the generated protocol

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/conformance_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conformance_test.go
@@ -177,6 +177,13 @@ func TestGeneratedProtocolMatchesTheInstalledProvider(t *testing.T) {
 		t.Skipf("provider declined to emit its schema (%v): %s", err, out)
 	}
 
+	// An older provider is always missing methods that later builds added, so the
+	// comparison below has to know which case it is looking at before it can call a
+	// gap drift.
+	installedOut, installedErr := exec.Command(bin, "--version").CombinedOutput()
+	olderProvider := installedErr == nil &&
+		providerOlderThanGenerated(string(installedOut), codexproto.ProviderVersion)
+
 	live := methodsFromSchema(t, dir)
 	generated := map[string]bool{}
 	for _, m := range codexproto.Methods {
@@ -204,11 +211,36 @@ func TestGeneratedProtocolMatchesTheInstalledProvider(t *testing.T) {
 			len(missing), truncate(missing))
 	}
 	// A method AO's generated file has and the provider does not is the dangerous
-	// direction: any call to it fails at runtime.
-	if len(extra) > 0 {
+	// direction: any call to it fails at runtime. That only means drift when the
+	// provider is at least the build this file was generated from. On an older
+	// provider the same gap just means the developer has not updated codex, which is
+	// not a defect in the checkout and must not fail the suite.
+	switch {
+	case len(extra) > 0 && olderProvider:
+		t.Logf("installed provider (%s) predates the generated %q, so it does not declare "+
+			"%d method(s) this file has; update codex or regenerate to compare them: %v",
+			strings.TrimSpace(string(installedOut)), codexproto.ProviderVersion,
+			len(extra), truncate(extra))
+	case len(extra) > 0:
 		t.Errorf("generated protocol declares %d method(s) the installed provider does not: %v",
 			len(extra), truncate(extra))
 	}
+}
+
+// providerOlderThanGenerated reports whether the installed provider predates the
+// build the generated file describes. Unparseable output on either side reports
+// false, which keeps the strict comparison: a version that cannot be read is not
+// evidence that the gap is benign.
+func providerOlderThanGenerated(installedVersionOutput, generatedProviderVersion string) bool {
+	installed, ok := parseCodexVersion(installedVersionOutput)
+	if !ok {
+		return false
+	}
+	generated, ok := parseCodexVersion(generatedProviderVersion)
+	if !ok {
+		return false
+	}
+	return installed.less(generated)
 }
 
 func methodsFromSchema(t *testing.T, dir string) map[string]bool {
@@ -315,5 +347,52 @@ func TestRealtimeStaysUnreachableUntilTheProviderPublishesAnEntryPoint(t *testin
 			"Voice is buildable — see this test's comment for what that entails. "+
 			"Regenerate the protocol and decide whether to take it on; if not, "+
 			"record the decision here so this stops reporting it.", startable)
+	}
+}
+
+func TestProviderOlderThanGenerated(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		installed string
+		generated string
+		want      bool
+	}{
+		{
+			name:      "older patch is older",
+			installed: "codex-cli 0.142.5",
+			generated: "codex-cli 0.146.0",
+			want:      true,
+		},
+		{
+			name:      "same build is not older",
+			installed: "codex-cli 0.146.0",
+			generated: "codex-cli 0.146.0",
+			want:      false,
+		},
+		{
+			name:      "newer build is not older",
+			installed: "codex-cli 0.147.1",
+			generated: "codex-cli 0.146.0",
+			want:      false,
+		},
+		{
+			name:      "unreadable installed output keeps the strict comparison",
+			installed: "codex-cli unknown",
+			generated: "codex-cli 0.146.0",
+			want:      false,
+		},
+		{
+			name:      "unreadable generated version keeps the strict comparison",
+			installed: "codex-cli 0.142.5",
+			generated: "unknown",
+			want:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := providerOlderThanGenerated(tc.installed, tc.generated); got != tc.want {
+				t.Errorf("providerOlderThanGenerated(%q, %q) = %v; want %v",
+					tc.installed, tc.generated, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Makes `TestGeneratedProtocolMatchesTheInstalledProvider` version aware. When the installed Codex is older than the build `protocol.gen.go` was generated from, the missing methods are reported with `t.Logf` instead of failing the test. When the installed build is not older, the existing `t.Errorf` is unchanged.

Fixes #4773.

## Why

`go test ./...` fails on a clean checkout for anyone whose Codex predates the pinned `ProviderVersion`, and nothing in the checkout is wrong.

The test compares the generated method table against the schema the installed `codex` emits, then splits the result two ways. A provider that declares methods the generated file lacks is only logged, because AO does not have to use everything. A generated file that declares methods the provider lacks is failed, because calling one of those breaks at runtime.

That second rule is right when the generated file has drifted. The problem is that an older provider produces exactly the same condition without anything having drifted: every method a later Codex added is a method the older build does not declare. The test could not tell the two apart, so it reported a version gap as a defect.

The test is already deliberate about not failing on an environment it cannot use. It skips when `codex` is absent and when the provider refuses to emit a schema. Failing only in the "your Codex is older" case was the gap.

This is not a rare state. `protocol.gen.go` pins `codex-cli 0.146.0` and has been regenerated once, in #3472, while Codex keeps releasing. My machine has `codex-cli 0.142.5` and reports five methods. `go test ./...` is what `docs/development.md` and `docs/STATUS.md` present as the local gate, and `npm run lint` runs it too, so this is the first command a new contributor runs.

## How

Test-only change. No production code is touched.

The comparison already exists in this package, so nothing new was introduced: `parseCodexVersion` and `codexVersion.less` in `driver.go` do the work. The new `providerOlderThanGenerated` helper only joins them and decides the one question the test needs answered.

Unparseable output on either side returns false and keeps the strict comparison. A version that cannot be read is not evidence that the gap is benign, so the safe direction is to keep failing rather than to quietly pass.

The version is read with `exec.Command(bin, "--version")` to match how this file already invokes the provider, rather than `installedCodexVersion`, which carries the driver's process environment that a schema comparison does not need.

The two `len(extra) > 0` arms are a `switch` rather than a nested `if` so the strict path stays visible at the same level as the tolerant one.

## Testing

```
go test ./internal/adapters/chatdriver/codexappserver/ -run TestGeneratedProtocolMatchesTheInstalledProvider -v
```

Before this change, on `codex-cli 0.142.5`:

```
--- FAIL: TestGeneratedProtocolMatchesTheInstalledProvider (0.84s)
    conformance_test.go:209: generated protocol declares 5 method(s) the installed provider does not: [...]
FAIL
```

After:

```
=== RUN   TestGeneratedProtocolMatchesTheInstalledProvider
    conformance_test.go:220: installed provider (codex-cli 0.142.5) predates the generated "codex-cli 0.146.0", so it does not declare 5 method(s) this file has; update codex or regenerate to compare them: [...]
--- PASS: TestGeneratedProtocolMatchesTheInstalledProvider (0.91s)
```

`TestProviderOlderThanGenerated` covers the decision directly: older, equal, newer, and unreadable version output on either side.

I could not verify the strict path against a real Codex at or above `0.146.0`, since the only build available to me is older. The equal and newer cases are covered by the table test, and that path is unchanged from the current behavior.

Also run: `gofmt -l` clean, `go vet` clean, full `go test ./...`.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
