### PR TITLE
Add Syndicate hackathon route

### DIFF
--- a/frontend/src/landing/src/app/hackathons/TextScramble.tsx
+++ b/frontend/src/landing/src/app/hackathons/TextScramble.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const characters = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+function randomCharacter() {
+  return characters[Math.floor(Math.random() * characters.length)];
+}
+
+export function TextScramble({ text }: { text: string }) {
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const element = textRef.current;
+    const staticLayer = element?.querySelector<HTMLElement>("[data-scramble-static]");
+    const overlay = element?.querySelector<HTMLElement>("[data-scramble-overlay]");
+    if (!element || !staticLayer || !overlay) return;
+
+    let timer: number | undefined;
+    let cancelled = false;
+
+    const start = () => {
+      if (cancelled) return;
+
+      const overlayRect = overlay.getBoundingClientRect();
+      const fontSize = Number.parseFloat(window.getComputedStyle(element).fontSize);
+      const words = Array.from(
+        staticLayer.querySelectorAll<HTMLElement>("[data-scramble-word]"),
+      ).map((word) => {
+        const rect = word.getBoundingClientRect();
+        const scrambledWord = document.createElement("span");
+        scrambledWord.style.position = "absolute";
+        scrambledWord.style.left = `${rect.left - overlayRect.left}px`;
+        scrambledWord.style.top = `${rect.top - overlayRect.top}px`;
+        scrambledWord.style.whiteSpace = "nowrap";
+        scrambledWord.style.lineHeight = "inherit";
+
+        return {
+          original: word.textContent ?? "",
+          sourceRect: rect,
+          element: scrambledWord,
+        };
+      });
+
+      overlay.replaceChildren(...words.map((word) => word.element));
+      words.forEach((word) => {
+        const overlayWordRect = word.element.getBoundingClientRect();
+        const verticalOffset =
+          word.sourceRect.top - overlayWordRect.top + fontSize * 0.125;
+        word.element.style.transform = `translateY(${verticalOffset}px)`;
+      });
+      staticLayer.style.color = "transparent";
+
+      let frame = 0;
+      const totalFrames = 18;
+      timer = window.setInterval(() => {
+        frame += 1;
+
+        words.forEach((word) => {
+          const resolvedCharacters = Math.floor(
+            (frame / totalFrames) * word.original.length,
+          );
+
+          word.element.textContent = Array.from(word.original, (character, index) => {
+            if (!/[a-z]/i.test(character) || index < resolvedCharacters) {
+              return character;
+            }
+            return randomCharacter();
+          }).join("");
+        });
+
+        if (frame >= totalFrames) {
+          staticLayer.style.color = "";
+          overlay.replaceChildren();
+          window.clearInterval(timer);
+        }
+      }, 40);
+    };
+
+    if (document.fonts.status === "loaded") {
+      start();
+    } else {
+      void document.fonts.ready.then(start);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearInterval(timer);
+    };
+  }, [text]);
+
+  return (
+    <span ref={textRef} aria-label={text}>
+      <span data-scramble-static>
+        {text.split(/(\s+)/).map((part, index) =>
+          /\s/.test(part) ? (
+            part
+          ) : (
+            <span key={`${part}-${index}`} data-scramble-word>
+              {part}
+            </span>
+          ),
+        )}
+      </span>
+      <span
+        data-scramble-overlay
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+      />
+    </span>
+  );
+}

--- a/frontend/src/landing/src/app/hackathons/page.tsx
+++ b/frontend/src/landing/src/app/hackathons/page.tsx
@@ -1,15 +1,8 @@
 import { COMPANY } from "@ao/shared/constants";
-import {
-  ArrowRight,
-  ArrowUpRight,
-  CalendarDays,
-  CircleDot,
-  Trophy,
-  Users,
-} from "lucide-react";
+import { ArrowRight, ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
+import { TextScramble } from "./TextScramble";
 
 const pageUrl = `${COMPANY.MARKETING_URL}/hackathons/`;
 
@@ -46,39 +39,14 @@ export const metadata: Metadata = {
   },
 };
 
-const pastStats = [
-  { icon: CalendarDays, label: "Aug 12-13", detail: "Two-day online sprint" },
-  { icon: Users, label: "311 went", detail: "Community builders on Luma" },
-  { icon: Trophy, label: "$200 prizes", detail: "Plus AO merch for standouts" },
-] as const;
-
 export default function HackathonsPage() {
   return (
-    <main className="min-h-[100dvh] overflow-hidden bg-background text-foreground">
+    <main className="min-h-[100dvh] overflow-hidden bg-background font-sans text-foreground">
       <section className="relative px-4 pb-16 pt-16 sm:px-8 sm:pb-20 sm:pt-20 lg:px-[30px] lg:pb-24 lg:pt-24">
-        <div className="pointer-events-none absolute inset-0 opacity-30">
-          <Image
-            src="/optimized/hero-background.webp"
-            alt=""
-            fill
-            priority
-            sizes="100vw"
-            className="object-cover"
-          />
-        </div>
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_8%,rgba(210,86,17,0.2),transparent_32%),linear-gradient(to_bottom,rgba(24,24,22,0.08),var(--background)_78%)]" />
-
-        <div className="relative mx-auto max-w-7xl">
+        <div className="mx-auto max-w-7xl">
           <div className="max-w-4xl">
-            <div className="inline-flex items-center gap-2 rounded-3xl border border-border bg-background/70 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
-              <CalendarDays
-                className="size-3.5 text-brand-light"
-                aria-hidden="true"
-              />
-              AO Hackathons
-            </div>
-            <h1 className="mt-6 text-balance text-[clamp(44px,8vw,96px)] font-normal leading-[0.96] tracking-normal text-foreground">
-              Build with agents, then show the work.
+            <h1 className="relative text-balance text-[clamp(44px,8vw,96px)] font-normal leading-[1.02] tracking-normal text-foreground">
+              <TextScramble text="Build with agents, then show the work." />
             </h1>
             <p className="mt-6 max-w-2xl text-pretty text-lg leading-8 text-muted-foreground sm:text-xl">
               Community build sprints for people turning AO into their coding
@@ -89,28 +57,9 @@ export default function HackathonsPage() {
 
           <div className="mt-12 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] lg:items-stretch">
             <article className="group relative overflow-hidden rounded-[8px] border border-border bg-card/85 backdrop-blur">
-              <div className="absolute inset-0 opacity-45">
-                <Image
-                  src="/optimized/feature3.webp"
-                  alt=""
-                  fill
-                  sizes="(max-width: 1024px) 100vw, 55vw"
-                  className="object-cover transition-transform duration-700 group-hover:scale-[1.02]"
-                />
-              </div>
-              <div className="absolute inset-0 bg-gradient-to-br from-background via-background/85 to-background/35" />
-              <div className="relative flex min-h-[520px] flex-col justify-between p-6 sm:p-8 lg:p-10">
+              <div className="flex min-h-[520px] flex-col justify-between p-6 sm:p-8 lg:p-10">
                 <div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="inline-flex items-center gap-2 rounded-3xl border border-brand/35 bg-brand/15 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-brand-light">
-                      <CircleDot className="size-3" aria-hidden="true" />
-                      Upcoming
-                    </span>
-                    <span className="rounded-3xl border border-border bg-background/70 px-3 py-1.5 text-sm text-muted-foreground">
-                      Registration open
-                    </span>
-                  </div>
-                  <h2 className="mt-7 max-w-2xl text-balance text-[clamp(34px,5vw,64px)] font-normal leading-[0.98] tracking-normal text-foreground">
+                  <h2 className="max-w-2xl text-balance text-[clamp(34px,5vw,64px)] font-normal leading-[0.98] tracking-normal text-foreground">
                     Syndicate Hackathon
                   </h2>
                   <p className="mt-5 max-w-xl text-base leading-7 text-muted-foreground sm:text-lg">
@@ -132,10 +81,7 @@ export default function HackathonsPage() {
             <article className="rounded-[8px] border border-border bg-card/75 p-6 backdrop-blur sm:p-8 lg:p-10">
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
-                    Past Hackathon
-                  </p>
-                  <h2 className="mt-4 text-3xl font-normal leading-tight tracking-normal text-foreground sm:text-4xl">
+                  <h2 className="text-3xl font-normal leading-tight tracking-normal text-foreground sm:text-4xl">
                     The Orchestra
                   </h2>
                 </div>
@@ -156,43 +102,6 @@ export default function HackathonsPage() {
                 and ship with agents running on their own machines.
               </p>
 
-              <div className="mt-8 grid gap-3">
-                {pastStats.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <div
-                      key={item.label}
-                      className="flex items-center gap-4 rounded-[8px] border border-border bg-background/50 p-4"
-                    >
-                      <Icon
-                        className="size-5 shrink-0 text-brand-light"
-                        aria-hidden="true"
-                      />
-                      <div>
-                        <div className="text-sm font-medium tracking-normal text-foreground">
-                          {item.label}
-                        </div>
-                        <div className="mt-1 text-sm text-muted-foreground">
-                          {item.detail}
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-
-              <div className="mt-8 flex flex-wrap gap-2">
-                {["Teams up to 4", "Demo video required", "Public repo required"].map(
-                  (item) => (
-                    <span
-                      key={item}
-                      className="rounded-3xl border border-border px-3 py-1.5 text-sm text-muted-foreground"
-                    >
-                      {item}
-                    </span>
-                  ),
-                )}
-              </div>
             </article>
           </div>
         </div>

--- a/frontend/src/landing/src/app/hackathons/page.tsx
+++ b/frontend/src/landing/src/app/hackathons/page.tsx
@@ -1,0 +1,202 @@
+import { COMPANY } from "@ao/shared/constants";
+import {
+  ArrowRight,
+  ArrowUpRight,
+  CalendarDays,
+  CircleDot,
+  Trophy,
+  Users,
+} from "lucide-react";
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+
+const pageUrl = `${COMPANY.MARKETING_URL}/hackathons/`;
+
+export const metadata: Metadata = {
+  title: "AO Hackathons",
+  description:
+    "Join upcoming AO hackathons and explore past community build sprints.",
+  openGraph: {
+    type: "website",
+    url: pageUrl,
+    siteName: COMPANY.NAME,
+    title: `AO Hackathons | ${COMPANY.NAME}`,
+    description:
+      "Join upcoming AO hackathons and explore past community build sprints.",
+    images: [
+      {
+        url: `${COMPANY.MARKETING_URL}/og-image.png`,
+        width: 1200,
+        height: 630,
+        alt: `${COMPANY.NAME} hackathons`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@aoagents",
+    title: `AO Hackathons | ${COMPANY.NAME}`,
+    description:
+      "Join upcoming AO hackathons and explore past community build sprints.",
+    images: [`${COMPANY.MARKETING_URL}/og-image.png`],
+  },
+  alternates: {
+    canonical: pageUrl,
+  },
+};
+
+const pastStats = [
+  { icon: CalendarDays, label: "Aug 12-13", detail: "Two-day online sprint" },
+  { icon: Users, label: "311 went", detail: "Community builders on Luma" },
+  { icon: Trophy, label: "$200 prizes", detail: "Plus AO merch for standouts" },
+] as const;
+
+export default function HackathonsPage() {
+  return (
+    <main className="min-h-[100dvh] overflow-hidden bg-background text-foreground">
+      <section className="relative px-4 pb-16 pt-16 sm:px-8 sm:pb-20 sm:pt-20 lg:px-[30px] lg:pb-24 lg:pt-24">
+        <div className="pointer-events-none absolute inset-0 opacity-30">
+          <Image
+            src="/optimized/hero-background.webp"
+            alt=""
+            fill
+            priority
+            sizes="100vw"
+            className="object-cover"
+          />
+        </div>
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_8%,rgba(210,86,17,0.2),transparent_32%),linear-gradient(to_bottom,rgba(24,24,22,0.08),var(--background)_78%)]" />
+
+        <div className="relative mx-auto max-w-7xl">
+          <div className="max-w-4xl">
+            <div className="inline-flex items-center gap-2 rounded-3xl border border-border bg-background/70 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
+              <CalendarDays
+                className="size-3.5 text-brand-light"
+                aria-hidden="true"
+              />
+              AO Hackathons
+            </div>
+            <h1 className="mt-6 text-balance text-[clamp(44px,8vw,96px)] font-normal leading-[0.96] tracking-normal text-foreground">
+              Build with agents, then show the work.
+            </h1>
+            <p className="mt-6 max-w-2xl text-pretty text-lg leading-8 text-muted-foreground sm:text-xl">
+              Community build sprints for people turning AO into their coding
+              workspace. Join the next run or look back at what builders already
+              shipped.
+            </p>
+          </div>
+
+          <div className="mt-12 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] lg:items-stretch">
+            <article className="group relative overflow-hidden rounded-[8px] border border-border bg-card/85 backdrop-blur">
+              <div className="absolute inset-0 opacity-45">
+                <Image
+                  src="/optimized/feature3.webp"
+                  alt=""
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 55vw"
+                  className="object-cover transition-transform duration-700 group-hover:scale-[1.02]"
+                />
+              </div>
+              <div className="absolute inset-0 bg-gradient-to-br from-background via-background/85 to-background/35" />
+              <div className="relative flex min-h-[520px] flex-col justify-between p-6 sm:p-8 lg:p-10">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="inline-flex items-center gap-2 rounded-3xl border border-brand/35 bg-brand/15 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-brand-light">
+                      <CircleDot className="size-3" aria-hidden="true" />
+                      Upcoming
+                    </span>
+                    <span className="rounded-3xl border border-border bg-background/70 px-3 py-1.5 text-sm text-muted-foreground">
+                      Registration open
+                    </span>
+                  </div>
+                  <h2 className="mt-7 max-w-2xl text-balance text-[clamp(34px,5vw,64px)] font-normal leading-[0.98] tracking-normal text-foreground">
+                    Syndicate Hackathon
+                  </h2>
+                  <p className="mt-5 max-w-xl text-base leading-7 text-muted-foreground sm:text-lg">
+                    A build sprint for people using coding agents as a team
+                    sport. Bring an idea worth handing to a fleet.
+                  </p>
+                </div>
+
+                <Link
+                  href="/hackathons/syndicate"
+                  className="mt-10 inline-flex w-fit items-center gap-2 rounded-3xl bg-primary px-5 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  View Syndicate
+                  <ArrowRight className="size-4" aria-hidden="true" />
+                </Link>
+              </div>
+            </article>
+
+            <article className="rounded-[8px] border border-border bg-card/75 p-6 backdrop-blur sm:p-8 lg:p-10">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+                    Past Hackathon
+                  </p>
+                  <h2 className="mt-4 text-3xl font-normal leading-tight tracking-normal text-foreground sm:text-4xl">
+                    The Orchestra
+                  </h2>
+                </div>
+                <a
+                  href="https://luma.com/iw1v5erp"
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="Open The Orchestra on Luma"
+                  className="inline-flex size-10 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <ArrowUpRight className="size-4" aria-hidden="true" />
+                </a>
+              </div>
+
+              <p className="mt-5 text-base leading-7 text-muted-foreground">
+                AO's first hackathon was a fully online sprint with no fixed
+                theme. Builders used AO to plan, delegate, code, review, test,
+                and ship with agents running on their own machines.
+              </p>
+
+              <div className="mt-8 grid gap-3">
+                {pastStats.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <div
+                      key={item.label}
+                      className="flex items-center gap-4 rounded-[8px] border border-border bg-background/50 p-4"
+                    >
+                      <Icon
+                        className="size-5 shrink-0 text-brand-light"
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <div className="text-sm font-medium tracking-normal text-foreground">
+                          {item.label}
+                        </div>
+                        <div className="mt-1 text-sm text-muted-foreground">
+                          {item.detail}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="mt-8 flex flex-wrap gap-2">
+                {["Teams up to 4", "Demo video required", "Public repo required"].map(
+                  (item) => (
+                    <span
+                      key={item}
+                      className="rounded-3xl border border-border px-3 py-1.5 text-sm text-muted-foreground"
+                    >
+                      {item}
+                    </span>
+                  ),
+                )}
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/landing/src/app/hackathons/syndicate/page.tsx
+++ b/frontend/src/landing/src/app/hackathons/syndicate/page.tsx
@@ -1,0 +1,178 @@
+import { COMPANY } from "@ao/shared/constants";
+import {
+  ArrowUpRight,
+  CalendarDays,
+  GitBranch,
+  Sparkles,
+  Users,
+} from "lucide-react";
+import type { Metadata } from "next";
+import Image from "next/image";
+
+const eventUrl = "https://luma.com/embed/event/evt-gkxbXap1DCJThsE/simple";
+const pageUrl = `${COMPANY.MARKETING_URL}/hackathons/syndicate/`;
+const lumaUrl = "https://luma.com/event/evt-gkxbXap1DCJThsE";
+
+const highlights = [
+  {
+    icon: GitBranch,
+    label: "Build in branches",
+    text: "Bring an idea, split the work, and let agent sessions move in parallel.",
+  },
+  {
+    icon: Users,
+    label: "Ship with a crew",
+    text: "A focused community sprint for builders exploring agent orchestration.",
+  },
+  {
+    icon: Sparkles,
+    label: "Demo real output",
+    text: "Make something concrete enough to show, review, and keep iterating on.",
+  },
+] as const;
+
+export const metadata: Metadata = {
+  title: "Syndicate Hackathon",
+  description: "Register for the AO Syndicate hackathon.",
+  openGraph: {
+    type: "website",
+    url: pageUrl,
+    siteName: COMPANY.NAME,
+    title: `Syndicate Hackathon | ${COMPANY.NAME}`,
+    description: "Register for the AO Syndicate hackathon.",
+    images: [
+      {
+        url: `${COMPANY.MARKETING_URL}/og-image.png`,
+        width: 1200,
+        height: 630,
+        alt: `${COMPANY.NAME} Syndicate hackathon`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@aoagents",
+    title: `Syndicate Hackathon | ${COMPANY.NAME}`,
+    description: "Register for the AO Syndicate hackathon.",
+    images: [`${COMPANY.MARKETING_URL}/og-image.png`],
+  },
+  alternates: {
+    canonical: pageUrl,
+  },
+};
+
+export default function SyndicateHackathonPage() {
+  return (
+    <main className="min-h-[100dvh] overflow-hidden bg-background text-foreground">
+      <section className="relative px-4 pb-16 pt-16 sm:px-8 sm:pb-20 sm:pt-20 lg:px-[30px] lg:pb-24 lg:pt-24">
+        <div className="pointer-events-none absolute inset-0 opacity-35">
+          <Image
+            src="/optimized/hero-background.webp"
+            alt=""
+            fill
+            priority
+            sizes="100vw"
+            className="object-cover"
+          />
+        </div>
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(210,86,17,0.18),transparent_34%),linear-gradient(to_bottom,rgba(24,24,22,0.2),var(--background)_88%)]" />
+
+        <div className="relative mx-auto max-w-7xl">
+          <div className="grid items-center gap-10 lg:grid-cols-[minmax(0,0.92fr)_minmax(460px,600px)] lg:gap-14">
+            <div className="max-w-3xl">
+              <div className="inline-flex items-center gap-2 rounded-3xl border border-border bg-background/70 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
+                <CalendarDays className="size-3.5 text-brand-light" aria-hidden="true" />
+                AO Hackathons
+              </div>
+              <h1 className="mt-6 max-w-4xl text-balance text-[clamp(42px,8vw,92px)] font-normal leading-[0.96] tracking-normal text-foreground">
+                Syndicate Hackathon
+              </h1>
+              <p className="mt-6 max-w-2xl text-pretty text-lg leading-8 text-muted-foreground sm:text-xl">
+                A build sprint for people using coding agents as a team sport.
+                Register on Luma and bring an idea worth handing to a fleet.
+              </p>
+
+              <div className="mt-8 flex flex-wrap gap-2">
+                {["Agent orchestration", "Parallel branches", "Community demos"].map(
+                  (item) => (
+                    <span
+                      key={item}
+                      className="rounded-3xl border border-border bg-card/70 px-4 py-2 text-sm text-foreground/85 backdrop-blur"
+                    >
+                      {item}
+                    </span>
+                  ),
+                )}
+              </div>
+
+              <a
+                href={lumaUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-8 inline-flex items-center gap-2 rounded-3xl bg-primary px-5 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Open event on Luma
+                <ArrowUpRight className="size-4" aria-hidden="true" />
+              </a>
+            </div>
+
+            <div className="relative">
+              <div className="absolute -inset-4 rounded-[8px] border border-brand/25 bg-brand/10 blur-2xl" />
+              <div className="relative overflow-hidden rounded-[8px] border border-border bg-card/90 shadow-2xl shadow-black/35 backdrop-blur">
+                <div className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-5">
+                  <div>
+                    <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                      Registration
+                    </p>
+                    <h2 className="mt-1 text-base font-medium tracking-normal text-foreground">
+                      Reserve your spot
+                    </h2>
+                  </div>
+                  <a
+                    href={lumaUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="Open Syndicate Hackathon on Luma"
+                    className="inline-flex size-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <ArrowUpRight className="size-4" aria-hidden="true" />
+                  </a>
+                </div>
+                <iframe
+                  src={eventUrl}
+                  title="AO Syndicate hackathon registration"
+                  width="600"
+                  height="450"
+                  className="block h-[520px] w-full bg-background sm:h-[560px] lg:h-[600px]"
+                  allow="fullscreen; payment"
+                  sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation"
+                  aria-hidden="false"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-14 grid gap-3 md:grid-cols-3">
+            {highlights.map((item) => {
+              const Icon = item.icon;
+              return (
+                <section
+                  key={item.label}
+                  className="rounded-[8px] border border-border bg-card/70 p-5 backdrop-blur"
+                >
+                  <Icon className="size-5 text-brand-light" aria-hidden="true" />
+                  <h2 className="mt-5 text-lg font-medium tracking-normal text-foreground">
+                    {item.label}
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    {item.text}
+                  </p>
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/landing/src/app/hackathons/syndicate/page.tsx
+++ b/frontend/src/landing/src/app/hackathons/syndicate/page.tsx
@@ -1,17 +1,11 @@
 import { COMPANY } from "@ao/shared/constants";
-import {
-  ArrowUpRight,
-  CalendarDays,
-  GitBranch,
-  Sparkles,
-  Users,
-} from "lucide-react";
+import { ArrowUpRight, GitBranch, Sparkles, Users } from "lucide-react";
 import type { Metadata } from "next";
-import Image from "next/image";
 
 const eventUrl = "https://luma.com/embed/event/evt-gkxbXap1DCJThsE/simple";
 const pageUrl = `${COMPANY.MARKETING_URL}/hackathons/syndicate/`;
 const lumaUrl = "https://luma.com/event/evt-gkxbXap1DCJThsE";
+const participantPassUrl = "https://aoagents.dev/hackathons/syndicate/pass/";
 
 const highlights = [
   {
@@ -63,28 +57,12 @@ export const metadata: Metadata = {
 
 export default function SyndicateHackathonPage() {
   return (
-    <main className="min-h-[100dvh] overflow-hidden bg-background text-foreground">
+    <main className="min-h-[100dvh] overflow-hidden bg-background font-sans text-foreground">
       <section className="relative px-4 pb-16 pt-16 sm:px-8 sm:pb-20 sm:pt-20 lg:px-[30px] lg:pb-24 lg:pt-24">
-        <div className="pointer-events-none absolute inset-0 opacity-35">
-          <Image
-            src="/optimized/hero-background.webp"
-            alt=""
-            fill
-            priority
-            sizes="100vw"
-            className="object-cover"
-          />
-        </div>
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(210,86,17,0.18),transparent_34%),linear-gradient(to_bottom,rgba(24,24,22,0.2),var(--background)_88%)]" />
-
-        <div className="relative mx-auto max-w-7xl">
+        <div className="mx-auto max-w-7xl">
           <div className="grid items-center gap-10 lg:grid-cols-[minmax(0,0.92fr)_minmax(460px,600px)] lg:gap-14">
             <div className="max-w-3xl">
-              <div className="inline-flex items-center gap-2 rounded-3xl border border-border bg-background/70 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
-                <CalendarDays className="size-3.5 text-brand-light" aria-hidden="true" />
-                AO Hackathons
-              </div>
-              <h1 className="mt-6 max-w-4xl text-balance text-[clamp(42px,8vw,92px)] font-normal leading-[0.96] tracking-normal text-foreground">
+              <h1 className="max-w-4xl text-balance text-[clamp(42px,8vw,92px)] font-normal leading-[0.96] tracking-normal text-foreground">
                 Syndicate Hackathon
               </h1>
               <p className="mt-6 max-w-2xl text-pretty text-lg leading-8 text-muted-foreground sm:text-xl">
@@ -92,39 +70,33 @@ export default function SyndicateHackathonPage() {
                 Register on Luma and bring an idea worth handing to a fleet.
               </p>
 
-              <div className="mt-8 flex flex-wrap gap-2">
-                {["Agent orchestration", "Parallel branches", "Community demos"].map(
-                  (item) => (
-                    <span
-                      key={item}
-                      className="rounded-3xl border border-border bg-card/70 px-4 py-2 text-sm text-foreground/85 backdrop-blur"
-                    >
-                      {item}
-                    </span>
-                  ),
-                )}
+              <div className="mt-8 flex flex-wrap gap-3">
+                <a
+                  href={participantPassUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-2 rounded-3xl bg-primary px-5 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  Get your participant pass
+                  <ArrowUpRight className="size-4" aria-hidden="true" />
+                </a>
+                <a
+                  href={lumaUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-2 rounded-3xl border border-border px-5 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+                >
+                  Open event on Luma
+                  <ArrowUpRight className="size-4" aria-hidden="true" />
+                </a>
               </div>
-
-              <a
-                href={lumaUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-8 inline-flex items-center gap-2 rounded-3xl bg-primary px-5 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-              >
-                Open event on Luma
-                <ArrowUpRight className="size-4" aria-hidden="true" />
-              </a>
             </div>
 
             <div className="relative">
-              <div className="absolute -inset-4 rounded-[8px] border border-brand/25 bg-brand/10 blur-2xl" />
               <div className="relative overflow-hidden rounded-[8px] border border-border bg-card/90 shadow-2xl shadow-black/35 backdrop-blur">
                 <div className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-5">
                   <div>
-                    <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                      Registration
-                    </p>
-                    <h2 className="mt-1 text-base font-medium tracking-normal text-foreground">
+                    <h2 className="text-base font-medium tracking-normal text-foreground">
                       Reserve your spot
                     </h2>
                   </div>

--- a/frontend/src/landing/src/app/sitemap.ts
+++ b/frontend/src/landing/src/app/sitemap.ts
@@ -32,6 +32,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.8,
 		},
 		{
+			url: `${baseUrl}/hackathons/`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.8,
+		},
+		{
+			url: `${baseUrl}/hackathons/syndicate/`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.8,
+		},
+		{
 			url: `${baseUrl}/testimonials/`,
 			lastModified: new Date(),
 			changeFrequency: "monthly",


### PR DESCRIPTION
## Summary
- Add /hackathons index route with a designed AO-native hackathon overview
- Add a featured Syndicate card linking to /hackathons/syndicate
- Add a past hackathon card for The Orchestra using details from Luma
- Embed the Luma registration panel on the Syndicate route
- Add both hackathon routes to the landing sitemap
- Keep the aoagents.dev OG image configured in social metadata without rendering it visibly on the page

## Verification
- npm run build
- Checked http://localhost:3001/hackathons/ returns 200 and includes Syndicate plus The Orchestra
- Checked http://localhost:3001/hackathons/syndicate/ returns 200 and includes the Luma embed