### PR TITLE
fix: restore section anchors and repeatable hash navigation

### DIFF
--- a/frontend/src/landing/src/app/components/FeaturesSection/FeaturesSection.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/FeaturesSection.tsx
@@ -26,7 +26,10 @@ const FEATURE_BACKGROUNDS = [
 
 export function FeaturesSection() {
 	return (
-		<section className="relative px-4 py-16 sm:px-8 sm:py-20 lg:px-[30px] lg:py-24">
+		<section
+			id="features"
+			className="relative px-4 py-16 sm:px-8 sm:py-20 lg:px-[30px] lg:py-24"
+		>
 			<div className="max-w-7xl mx-auto">
 				{/* Feature Rows */}
 				<div className="space-y-20 sm:space-y-24 lg:space-y-32">

--- a/frontend/src/landing/src/app/components/Footer/Footer.tsx
+++ b/frontend/src/landing/src/app/components/Footer/Footer.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { COMPANY } from "@ao/shared/constants";
-import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { usePathname } from "next/navigation";
+import { HashLink } from "../HashLink/HashLink";
 import { track } from "@/lib/analytics";
 import { TileWordmark } from "./TileWordmark";
 
@@ -137,12 +137,12 @@ function FooterColumn({
                 <ArrowUpRight className="hidden h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 sm:block" />
               </a>
             ) : (
-              <Link
+              <HashLink
                 href={link.href}
                 className="flex min-h-8 items-center justify-between gap-1 py-1.5 text-[13px] text-muted-foreground transition-colors hover:text-foreground sm:gap-3 sm:text-sm"
               >
                 {link.label}
-              </Link>
+              </HashLink>
             )}
           </li>
           );

--- a/frontend/src/landing/src/app/components/HashLink/HashLink.tsx
+++ b/frontend/src/landing/src/app/components/HashLink/HashLink.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import type { ComponentPropsWithoutRef, MouseEvent } from "react";
 
 type LinkProps = ComponentPropsWithoutRef<typeof Link>;
@@ -20,8 +19,6 @@ type LinkProps = ComponentPropsWithoutRef<typeof Link>;
  * degrades to a real navigation with JS off.
  */
 export function HashLink({ href, onClick, ...props }: LinkProps) {
-	const pathname = usePathname();
-
 	const raw = typeof href === "string" ? href : null;
 	const hashIndex = raw?.indexOf("#") ?? -1;
 	const targetId = hashIndex >= 0 ? raw?.slice(hashIndex + 1) : undefined;
@@ -41,7 +38,7 @@ export function HashLink({ href, onClick, ...props }: LinkProps) {
 		) {
 			return;
 		}
-		if (!targetId || targetPath !== pathname) return;
+		if (!targetId || targetPath !== window.location.pathname) return;
 
 		const target = document.getElementById(targetId);
 		if (!target) return;

--- a/frontend/src/landing/src/app/components/HashLink/HashLink.tsx
+++ b/frontend/src/landing/src/app/components/HashLink/HashLink.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ComponentPropsWithoutRef, MouseEvent } from "react";
+
+type LinkProps = ComponentPropsWithoutRef<typeof Link>;
+
+/**
+ * `<Link>` for in-page anchors that never leaves the fragment in the URL.
+ *
+ * A plain `<Link href="/#see-it">` sets `#see-it` and scrolls, but the hash then
+ * sits in the address bar forever — scroll away, click the same link again, and
+ * the browser considers the target current and does nothing. Here a same-page
+ * click is handled directly: scroll the element into view and let the URL stay
+ * clean, so the link works identically on every click.
+ *
+ * Cross-page navigation (`/docs` -> `/#see-it`) falls through to normal `Link`
+ * behaviour, and so does anything without a resolvable target — the anchor still
+ * degrades to a real navigation with JS off.
+ */
+export function HashLink({ href, onClick, ...props }: LinkProps) {
+	const pathname = usePathname();
+
+	const raw = typeof href === "string" ? href : null;
+	const hashIndex = raw?.indexOf("#") ?? -1;
+	const targetId = hashIndex >= 0 ? raw?.slice(hashIndex + 1) : undefined;
+	const targetPath = hashIndex >= 0 ? raw?.slice(0, hashIndex) || "/" : undefined;
+
+	const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+		onClick?.(event);
+
+		if (event.defaultPrevented) return;
+		// Let the browser own modified clicks (new tab, download, middle click).
+		if (
+			event.button !== 0 ||
+			event.metaKey ||
+			event.ctrlKey ||
+			event.shiftKey ||
+			event.altKey
+		) {
+			return;
+		}
+		if (!targetId || targetPath !== pathname) return;
+
+		const target = document.getElementById(targetId);
+		if (!target) return;
+
+		event.preventDefault();
+		// Deferred a frame so an `onClick` that unlocks the page first — the mobile
+		// nav restores `body { overflow }` on close — has committed; scrolling a
+		// still-locked body silently does nothing.
+		requestAnimationFrame(() => {
+			// No behaviour override: `scroll-behavior` / `scroll-padding-top` on
+			// <html> supply the smoothness and the header offset, and honour the
+			// reduced-motion preference.
+			target.scrollIntoView();
+		});
+	};
+
+	return <Link href={href} onClick={handleClick} {...props} />;
+}

--- a/frontend/src/landing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
+++ b/frontend/src/landing/src/app/components/Header/components/DesktopNav/DesktopNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@ao/ui/utils";
-import Link from "next/link";
+import { HashLink } from "../../../HashLink/HashLink";
 import {
   type NavLink,
   PRODUCT_LINKS,
@@ -38,8 +38,8 @@ function NavLinkItem({ link }: { link: NavLink }) {
     );
   }
   return (
-    <Link href={link.href} className={linkClass}>
+    <HashLink href={link.href} className={linkClass}>
       {link.label}
-    </Link>
+    </HashLink>
   );
 }

--- a/frontend/src/landing/src/app/components/Header/components/MobileNav/MobileNav.tsx
+++ b/frontend/src/landing/src/app/components/Header/components/MobileNav/MobileNav.tsx
@@ -2,8 +2,8 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { Menu, X } from "lucide-react";
-import Link from "next/link";
 import { useEffect, useState } from "react";
+import { HashLink } from "../../../HashLink/HashLink";
 import {
 	type NavLink,
 	PRODUCT_LINKS,
@@ -139,14 +139,14 @@ function MobileSection({
 						{link.label}
 					</a>
 				) : (
-					<Link
+					<HashLink
 						key={link.href}
 						href={link.href}
 						onClick={onNavigate}
 						className="flex min-h-11 items-center rounded-md px-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
 					>
 						{link.label}
-					</Link>
+					</HashLink>
 				),
 			)}
 		</div>

--- a/frontend/src/landing/src/app/components/TrustedBySection/TrustedBySection.tsx
+++ b/frontend/src/landing/src/app/components/TrustedBySection/TrustedBySection.tsx
@@ -66,7 +66,10 @@ function AgentGroup({ duplicate = false }: { duplicate?: boolean }) {
 
 export function TrustedBySection() {
   return (
-    <section className="py-16 sm:py-24 bg-background overflow-hidden">
+    <section
+      id="agents"
+      className="py-16 sm:py-24 bg-background overflow-hidden"
+    >
       <div className="max-w-7xl mx-auto text-center">
         <h2 className="mx-auto mb-12 max-w-3xl select-none px-4 text-3xl font-semibold text-foreground sm:px-8 sm:text-4xl lg:max-w-none lg:px-[30px] lg:text-5xl">
           Use the agents you already trust.


### PR DESCRIPTION
Fixes #4771 

## Summary
- Add `id="features"` to `FeaturesSection` and `id="agents"` to `TrustedBySection` so footer links land on real sections.
- Add `HashLink` for same-page `/#` navigation: scrolls via `scrollIntoView()` without writing the hash, so Demo/Features/Agents work on repeat clicks.
- Wire `HashLink` into footer, desktop nav, and mobile nav.

## Not included
- Themed scrollbar / `--header-height` changes from the issue are not in this PR yet.

## Test plan
- [ ] Footer **Features** scrolls to the features section
- [ ] Footer **Agents** scrolls to the trusted-by/agents marquee
- [ ] Nav **Demo** scrolls to the video on first click
- [ ] Scroll back to top, click **Demo** again — still scrolls; URL stays `/` (no stuck `#see-it`)
- [ ] Mobile nav: open menu, tap Demo, menu closes and scroll works