### PR TITLE
fix: stop ⌘T on project board from opening /terminals

### DIFF
--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -332,6 +332,7 @@ function ShellLayout() {
 	// The root route is the intentionally minimal home surface, regardless of
 	// whether projects have already been registered.
 	const isHomeRoute = Boolean(matchRoute({ to: "/" }));
+	const isTerminalsRoute = Boolean(matchRoute({ to: "/terminals" }));
 	const isSettingsRoute =
 		Boolean(matchRoute({ to: "/settings", fuzzy: true })) ||
 		Boolean(matchRoute({ to: "/projects/$projectId/settings", fuzzy: true }));
@@ -732,32 +733,45 @@ function ShellLayout() {
 	// New standalone terminal (⌘T / Ctrl+T), also detected in the main process so it
 	// fires from inside a terminal pane. It raises the same store signal as the
 	// tab-strip + button so the two cannot drift apart.
-	useEffect(() => aoBridge.app.onNewShellTerminalShortcut(() => requestNewShellTerminal()), [requestNewShellTerminal]);
+	useEffect(
+		() =>
+			aoBridge.app.onNewShellTerminalShortcut(() => {
+				// The project board is not a terminal surface — ⌘T here used to yank
+				// users into the standalone /terminals route (#4772). Sessions and the
+				// dedicated terminals view keep the shortcut; explicit UI can still
+				// open shells from the board.
+				if (routeParams.sessionId || isTerminalsRoute) {
+					requestNewShellTerminal();
+				}
+			}),
+		[isTerminalsRoute, requestNewShellTerminal, routeParams.sessionId],
+	);
 
 	// The shell layout is the single consumer of that signal, because it is the
 	// only component mounted on EVERY route. Owning it here is what lets the
-	// button and the keyboard shortcut work from the board, a project page, or a session alike
-	// — when the session view owned it, both silently did nothing outside a
-	// session, since nothing was listening.
+	// topbar + button and the keyboard shortcut work from a session or the
+	// standalone terminals view alike — when the session view owned it, both
+	// silently did nothing outside a session, since nothing was listening.
 	//
 	// Where the new shell becomes visible depends on where the user is: inside a
-	// session it joins that pane's tab strip, anywhere else it gets the
-	// standalone /terminals view. Either way the store records it as active, and
-	// whichever view is on screen selects it.
+	// session it joins that pane's tab strip; on /terminals it joins that strip;
+	// explicit board UI can still route here without the keyboard shortcut.
 	useEffect(() => {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
-		openShellTerminal.mutate(
+		const shell = openShellTerminal.open(
 			{ projectId: scopedProjectId, sessionId: routeParams.sessionId },
 			{
-				onSuccess: (shell) => {
-					setActiveShellTerminal(shell.handleId);
-					if (!routeParams.sessionId) {
-						void navigate({ to: "/terminals" });
-					}
+				onSuccess: (openedShell) => {
+					setActiveShellTerminal(openedShell.handleId);
 				},
 			},
 		);
+		if (!shell) return;
+		setActiveShellTerminal(shell.handleId);
+		if (!routeParams.sessionId) {
+			void navigate({ to: "/terminals" });
+		}
 	}, [
 		newShellTerminalNonce,
 		openShellTerminal,

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -18,6 +18,7 @@ const shellMocks = vi.hoisted(() => {
 		openFolderPathListener: undefined as ((path: string) => void) | undefined,
 		routeParams: {} as { projectId?: string; sessionId?: string },
 		routeSearch: {} as Record<string, unknown>,
+		matchRouteTarget: null as string | null,
 		workspaces: [] as WorkspaceSummary[],
 		workspaceQuery: {
 			data: [] as WorkspaceSummary[],
@@ -46,7 +47,15 @@ const shellMocks = vi.hoisted(() => {
 			state.newShellTerminalListener = listener;
 			return vi.fn();
 		}),
-		openShellTerminal: vi.fn(),
+		openShellTerminal: vi.fn((input: { projectId?: string; sessionId?: string }) => ({
+			handleId: "pending-shell:test",
+			projectId: input.projectId,
+			sessionId: input.sessionId,
+			workingDir: "",
+			title: "Terminal 1",
+			createdAt: new Date().toISOString(),
+			optimistic: true as const,
+		})),
 		onOpenSettingsShortcut: vi.fn((listener: () => void) => {
 			state.openSettingsListener = listener;
 			return vi.fn();
@@ -97,7 +106,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@tanstack/react-router")>()),
 	createFileRoute: () => (options: unknown) => ({ options }),
 	Outlet: () => null,
-	useMatchRoute: () => () => false,
+	useMatchRoute: () => (options: { to: string }) => shellMocks.state.matchRouteTarget === options.to,
 	useNavigate: () => shellMocks.navigate,
 	useParams: () => shellMocks.state.routeParams,
 	useSearch: () => shellMocks.state.routeSearch,
@@ -151,7 +160,10 @@ vi.mock("../hooks/useCloudCp", () => ({
 // shortcut subscriptions, so the mutation is stubbed rather than driven.
 vi.mock("../hooks/useShellTerminals", () => ({
 	useShellTerminals: () => ({ data: [], isSuccess: true }),
-	useOpenShellTerminal: () => ({ mutate: shellMocks.openShellTerminal }),
+	useOpenShellTerminal: () => ({
+		open: shellMocks.openShellTerminal,
+		mutate: shellMocks.openShellTerminal,
+	}),
 }));
 
 vi.mock("../hooks/useAgentsQuery", () => ({
@@ -303,6 +315,7 @@ beforeEach(() => {
 	shellMocks.state.openFolderPathListener = undefined;
 	shellMocks.state.routeParams = {};
 	shellMocks.state.routeSearch = {};
+	shellMocks.state.matchRouteTarget = null;
 	shellMocks.state.workspaces = workspaces;
 	shellMocks.state.workspaceQuery = {
 		data: workspaces,
@@ -534,7 +547,8 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 	// Regression: the shell LAYOUT must own this, not the session view. When the
 	// session view owned it, the shortcut did nothing outside a session route —
 	// nothing was mounted to hear it.
-	it("opens a terminal even with no session on screen", async () => {
+	it("opens a terminal from the dedicated terminals route", async () => {
+		shellMocks.state.matchRouteTarget = "/terminals";
 		await renderShell();
 
 		pressNewShellTerminal();
@@ -543,16 +557,15 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledTimes(1);
 	});
 
-	it("scopes the terminal to the project in scope", async () => {
+	// Regression (#4772): ⌘T on the project board must not yank users into /terminals.
+	it("ignores the shortcut on the project board", async () => {
 		shellMocks.state.routeParams = { projectId: "proj-1" };
 		await renderShell();
 
 		pressNewShellTerminal();
 
-		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
-			expect.objectContaining({ projectId: "proj-1" }),
-			expect.anything(),
-		);
+		expect(useUiStore.getState().newShellTerminalNonce).toBe(0);
+		expect(shellMocks.openShellTerminal).not.toHaveBeenCalled();
 	});
 
 	// Regression: a terminal opened from a session view must carry the session
@@ -585,6 +598,7 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 	});
 
 	it("re-fires on a repeat press so a second terminal can be opened", async () => {
+		shellMocks.state.routeParams = { sessionId: "sess-1" };
 		await renderShell();
 
 		pressNewShellTerminal();


### PR DESCRIPTION
## Summary
- Fixes [#4772](https://github.com/Untrivial-ai/agent-orchestrator/issues/4772): ⌘T/Ctrl+T on the project board no longer navigates to the standalone `/terminals` view.
- The shortcut still works in sessions (new tab in the session terminal strip) and on `/terminals` (new standalone shell).
- Opening a shell from the keyboard shortcut now uses the same optimistic `open()` path as the session **New terminal** button, so tab selection and navigation happen immediately instead of after the daemon API returns.

## Test plan
- [ ] On a project board, press ⌘T / Ctrl+T — nothing should happen (no navigation to `/terminals`).
- [ ] On a project board, click **New terminal** (if exposed) — should still open `/terminals` as before.
- [ ] In a session, press ⌘T / Ctrl+T — new terminal tab appears immediately in the session strip.
- [ ] On `/terminals`, press ⌘T / Ctrl+T — new tab appears immediately without a ~2s wait.
- [ ] `npx vitest run src/renderer/test/shell-new-session-shortcut.test.tsx`