### PR TITLE
Feat/home page redesign

### DIFF
--- a/frontend/e2e/history-nav.spec.ts
+++ b/frontend/e2e/history-nav.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 // then the forward arrow must be enabled and actually traverse forward.
 test("titlebar back/forward arrows traverse history", async ({ page }) => {
 	await page.goto("/");
-	await expect(page.getByText("Projects")).toBeVisible();
+	await expect(page.getByText("Projects", { exact: true })).toBeVisible();
 
 	// Navigate: home → session view (in-app push).
 	await page.getByRole("button", { name: "Open refactor-mux" }).click();

--- a/frontend/e2e/smoke-projects.spec.ts
+++ b/frontend/e2e/smoke-projects.spec.ts
@@ -15,7 +15,7 @@ test("renderer: added project appears in the sidebar and board @T0 @PRJ", async 
 	// dev:web serves lib/mock-data.ts (ao-demo, docs-site). A registered project
 	// must show as a sidebar row AND drive the board it opens.
 	await page.goto("/#/");
-	await expect(page.getByText("Projects")).toBeVisible();
+	await expect(page.getByText("Projects", { exact: true })).toBeVisible();
 
 	// Sidebar row for the project.
 	const projectRow = page.locator('[data-sidebar="menu-button"]').filter({ hasText: "ao-demo" }).first();

--- a/frontend/e2e/smoke-t0.spec.ts
+++ b/frontend/e2e/smoke-t0.spec.ts
@@ -63,7 +63,7 @@ test("renderer: first-run home renders with the app launched @T0 @INS", async ({
 	await page.goto("/");
 	await expect(page.getByText("Jump back right in")).toBeVisible();
 	await expect(page.getByTestId("daemon-status")).toBeAttached();
-	await expect(page.getByText("Projects")).toBeVisible();
+	await expect(page.getByText("Projects", { exact: true })).toBeVisible();
 });
 
 // #2483 INS-003.

--- a/frontend/e2e/titlebar-brand.spec.ts
+++ b/frontend/e2e/titlebar-brand.spec.ts
@@ -45,13 +45,13 @@ async function expectBrandClearsCluster(page: Page) {
 
 test("home board route: brand clears the macOS titlebar cluster and stays readable", async ({ page }) => {
 	await page.goto("/");
-	await expect(page.getByText("Projects")).toBeVisible();
+	await expect(page.getByText("Projects", { exact: true })).toBeVisible();
 	await expectBrandClearsCluster(page);
 });
 
 test("project board route: brand clears the macOS titlebar cluster and stays readable", async ({ page }) => {
 	await page.goto("/");
-	await expect(page.getByText("Projects")).toBeVisible();
+	await expect(page.getByText("Projects", { exact: true })).toBeVisible();
 
 	// In-app nav to /projects/:id (a hard load boots the router at the board).
 	await page.locator('[data-sidebar="menu-button"]').filter({ hasText: "api-gateway" }).first().click();
@@ -63,7 +63,7 @@ test("project board route: brand clears the macOS titlebar cluster and stays rea
 
 test("brand stays put and readable when navigating board → session", async ({ page }) => {
 	await page.goto("/");
-	await expect(page.getByText("Projects")).toBeVisible();
+	await expect(page.getByText("Projects", { exact: true })).toBeVisible();
 
 	const boardBrandBox = await brand(page).boundingBox();
 	expect(boardBrandBox).not.toBeNull();

--- a/frontend/e2e/workbench.spec.ts
+++ b/frontend/e2e/workbench.spec.ts
@@ -9,7 +9,7 @@ test("renders the orchestrator-first workbench shell", async ({ page }) => {
 	await page.goto("/");
 	// The single pinned Orchestrator anchor + the Projects group + a name-only worker row.
 	await expect(page.getByRole("button", { name: "Orchestrator", exact: true })).toBeVisible();
-	await expect(page.getByText("Projects")).toBeVisible();
+	await expect(page.getByText("Projects", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "fix-webgl-fallback", exact: true })).toBeVisible();
 	// Orchestrator side rail = the quiet Workers list.
 	await expect(page.getByText("Workers", { exact: true })).toBeVisible();

--- a/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
@@ -85,4 +85,19 @@ describe("shell index route", () => {
 			params: { projectId: "proj-1" },
 		});
 	});
+
+	it("shows only the first three projects", () => {
+		routeMocks.workspaces = [
+			{ id: "proj-1", name: "Project One", kind: "single_repo", path: "/repo/project-one", sessions: [] },
+			{ id: "proj-2", name: "Project Two", kind: "single_repo", path: "/repo/project-two", sessions: [] },
+			{ id: "proj-3", name: "Project Three", kind: "single_repo", path: "/repo/project-three", sessions: [] },
+			{ id: "proj-4", name: "Project Four", kind: "single_repo", path: "/repo/project-four", sessions: [] },
+		];
+
+		render(<HomePage />);
+
+		expect(screen.getByRole("button", { name: /Project One/ })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /Project Three/ })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /Project Four/ })).not.toBeInTheDocument();
+	});
 });

--- a/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
@@ -16,6 +16,18 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceQuery: () => ({ data: routeMocks.workspaces, isSuccess: true }),
 }));
 
+vi.mock("../lib/shell-context", () => ({
+	useShell: () => ({
+		cloneProject: vi.fn(),
+		createProject: vi.fn(),
+		initializeProjectRepository: vi.fn(),
+	}),
+}));
+
+vi.mock("../components/CreateProjectFlow", () => ({
+	CreateProjectFlow: () => null,
+}));
+
 vi.mock("../components/BoardEmptyStates", () => ({
 	BoardWelcome: () => <div data-testid="board-welcome" />,
 }));

--- a/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
@@ -16,8 +16,14 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 	useWorkspaceQuery: () => ({ data: routeMocks.workspaces, isSuccess: true }),
 }));
 
+vi.mock("../hooks/useSystemRequirementsGate", () => ({
+	useSystemRequirementsGate: () => ({ blocked: false }),
+}));
+
 vi.mock("../lib/shell-context", () => ({
 	useShell: () => ({
+		daemonStatus: { state: "ready" },
+		workspaceStartupState: "ready",
 		cloneProject: vi.fn(),
 		createProject: vi.fn(),
 		initializeProjectRepository: vi.fn(),

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -58,6 +58,7 @@ export function CreateProjectFlow({
 	onCreateProject,
 	onInitializeProject,
 	openSignal,
+	sourceSignal,
 }: {
 	children?: (state: { choosePath: () => void; disabled: boolean; error: string | null; label: string }) => ReactNode;
 	// A folder was dropped on the app window (ShellLayout owns the global
@@ -76,6 +77,8 @@ export function CreateProjectFlow({
 	// "no project in scope" fallback). Lets the shortcut reuse the sidebar's own
 	// create-project flow instead of a separate delegating component.
 	openSignal?: number;
+	// Home-page action cards: each new nonce jumps straight to clone/local/workspace.
+	sourceSignal?: { source: ProjectSource; nonce: number } | null;
 }) {
 	const { t } = useTranslation();
 	const resolvedIdleLabel = idleLabel ?? t("createProject.newProject");
@@ -241,6 +244,14 @@ export function CreateProjectFlow({
 		if (isBusy || modePickerOpen || cloneDialogOpen || folderPickerOpen || selectedPath !== null) return;
 		startFlow(droppedPath.path);
 	}, [droppedPath]);
+
+	const lastSourceNonce = useRef(sourceSignal?.nonce);
+	useEffect(() => {
+		if (!sourceSignal || sourceSignal.nonce === lastSourceNonce.current) return;
+		lastSourceNonce.current = sourceSignal.nonce;
+		if (isBusy || modePickerOpen || cloneDialogOpen || folderPickerOpen || selectedPath !== null) return;
+		selectSource(sourceSignal.source);
+	}, [sourceSignal]);
 
 	const createProject = async (selection: CreateProjectAgentSelection) => {
 		if (!selectedPath) return;

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -61,7 +61,7 @@ function HomeActionCard({
 	return (
 		<button
 			aria-label={ariaLabel}
-			className="flex w-full items-center gap-3 rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-import-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50"
+			className="flex w-full items-center gap-3 rounded-welcome-panel bg-[var(--color-bg-import-card)] px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-import-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50"
 			disabled={disabled}
 			onClick={onClick}
 			type="button"
@@ -166,7 +166,7 @@ export function HomePage() {
 						/>
 						<div
 							aria-hidden="true"
-							className="rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-4 py-3 opacity-50"
+							className="rounded-welcome-panel bg-[var(--color-bg-import-card)] px-4 py-3 opacity-50"
 						/>
 					</div>
 

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -61,15 +61,15 @@ function HomeActionCard({
 	return (
 		<button
 			aria-label={ariaLabel}
-			className="flex min-h-[108px] flex-col justify-between gap-3 rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] p-4 text-left transition-colors hover:bg-[var(--color-bg-import-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50"
+			className="flex w-full items-center gap-3 rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-import-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50"
 			disabled={disabled}
 			onClick={onClick}
 			type="button"
 		>
-			<span className="grid size-9 place-items-center rounded-lg border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-chip)] text-[var(--color-text-import-muted)]">
+			<span className="grid size-8 shrink-0 place-items-center rounded-lg bg-[color-mix(in_srgb,var(--color-bg-import-chip)_60%,transparent)] text-[var(--color-text-import-muted)]">
 				{icon}
 			</span>
-			<span className="text-[14px] font-medium leading-5 text-[var(--color-text-import-title)]">{label}</span>
+			<span className="min-w-0 text-[14px] font-medium leading-5 text-[var(--color-text-import-title)]">{label}</span>
 		</button>
 	);
 }
@@ -166,7 +166,7 @@ export function HomePage() {
 						/>
 						<div
 							aria-hidden="true"
-							className="min-h-[108px] rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] p-4 opacity-50"
+							className="rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-4 py-3 opacity-50"
 						/>
 					</div>
 

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -3,12 +3,15 @@ import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { Folder, Folders, FolderOpen, GitFork, Star } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
-import { aoBridge } from "../lib/bridge";
-import { useShell } from "../lib/shell-context";
+import { useSystemRequirementsGate } from "../hooks/useSystemRequirementsGate";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { aoBridge } from "../lib/bridge";
+import { usesPreviewWorkspaceData } from "../lib/preview-mode";
+import { useShell } from "../lib/shell-context";
 import type { WorkspaceSummary } from "../types/workspace";
 import { BoardWelcome } from "./BoardEmptyStates";
 import { CreateProjectFlow } from "./CreateProjectFlow";
+import { DaemonStartupLoader } from "./DaemonStartupLoader";
 import { TopbarButton } from "./TopbarButton";
 
 const GITHUB_REPOSITORY_URL = "https://github.com/Untrivial-ai/agent-orchestrator";
@@ -104,10 +107,11 @@ function HomeProjectSection({
 export function HomePage() {
 	const navigate = useNavigate();
 	const { t } = useTranslation();
-	const { cloneProject, createProject, initializeProjectRepository } = useShell();
+	const { cloneProject, createProject, daemonStatus, initializeProjectRepository, workspaceStartupState } =
+		useShell();
+	const { blocked: requirementsBlocked } = useSystemRequirementsGate();
 	const workspaceQuery = useWorkspaceQuery();
 	const [sourceSignal, setSourceSignal] = useState<{ source: ProjectSource; nonce: number } | null>(null);
-
 	const projects = workspaceQuery.data ?? [];
 	const { recentProjects, currentProjects } = useMemo(() => {
 		const sortedByActivity = sortProjectsByActivity(projects);
@@ -119,6 +123,17 @@ export function HomePage() {
 		return { recentProjects: recent, currentProjects: current };
 	}, [projects]);
 
+	const isDaemonReady = usesPreviewWorkspaceData || daemonStatus.state === "ready";
+	const daemonHasFailed = Boolean(daemonStatus.code);
+	const showStartup =
+		!daemonHasFailed &&
+		(!isDaemonReady ||
+			workspaceStartupState === "loading" ||
+			(!workspaceQuery.isSuccess && !workspaceQuery.isError) ||
+			requirementsBlocked);
+
+	if (showStartup) return <DaemonStartupLoader />;
+
 	const requestSource = (source: ProjectSource) => {
 		setSourceSignal({ source, nonce: Date.now() });
 	};
@@ -127,7 +142,15 @@ export function HomePage() {
 		void navigate({ to: "/projects/$projectId", params: { projectId } });
 	};
 
-	if (workspaceQuery.isSuccess && projects.length === 0) return <BoardWelcome />;
+	if (workspaceStartupState === "error" || workspaceQuery.isError) {
+		return (
+			<div className="flex min-h-full items-center justify-center px-6 py-16">
+				<p className="text-center text-xs text-passive">{t("shell.couldNotLoadProjects")}</p>
+			</div>
+		);
+	}
+
+	if (projects.length === 0) return <BoardWelcome />;
 
 	return (
 		<div className="flex min-h-full items-center justify-center px-6 py-16">

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -1,13 +1,15 @@
 import type { ProjectSource } from "@aoagents/product-ui";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Folder, Folders, FolderOpen, GitFork, Star } from "lucide-react";
+import { Folder, Folders, FolderOpen, GitFork, Smartphone, Star } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
 import { useSystemRequirementsGate } from "../hooks/useSystemRequirementsGate";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { aoBridge } from "../lib/bridge";
+import { getProjectLastOpenedAt } from "../lib/project-history";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { useShell } from "../lib/shell-context";
+import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSummary } from "../types/workspace";
 import { BoardWelcome } from "./BoardEmptyStates";
 import { CreateProjectFlow } from "./CreateProjectFlow";
@@ -16,9 +18,30 @@ import { TopbarButton } from "./TopbarButton";
 
 const GITHUB_REPOSITORY_URL = "https://github.com/Untrivial-ai/agent-orchestrator";
 const RECENT_PROJECT_LIMIT = 3;
+const HOME_BUTTON_CLASS =
+	"flex w-full items-center gap-3 rounded-welcome-panel bg-[var(--color-bg-import-card)] px-4 py-3 text-left hover:bg-interactive-hover hover:text-foreground active:bg-interactive-hover active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60";
+const HOME_ICON_SLOT_CLASS =
+	"grid size-8 shrink-0 place-items-center text-[var(--color-text-import-muted)] [&_svg]:size-4";
+const HOME_PROJECT_ICON_CLASS =
+	"grid size-8 shrink-0 place-items-center rounded-lg text-foreground/65 [&_svg]:size-4";
 
 function latestProjectTimestamp(project: WorkspaceSummary): string {
-	return project.sessions.reduce((latest, session) => (session.updatedAt > latest ? session.updatedAt : latest), "");
+	return [
+		getProjectLastOpenedAt(project.id),
+		...project.sessions.flatMap((session) => [session.lastUserMessageAt, session.createdAt]),
+	]
+		.filter((timestamp): timestamp is string => Boolean(timestamp))
+		.sort()
+		.at(-1) ?? "";
+}
+
+function relativeProjectTime(timestamp: string | undefined, emptyLabel: string, justNowLabel: string): string {
+	if (!timestamp) return emptyLabel;
+	const elapsedMinutes = Math.floor((Date.now() - new Date(timestamp).getTime()) / 60_000);
+	if (!Number.isFinite(elapsedMinutes) || elapsedMinutes < 1) return justNowLabel;
+	const unit: Intl.RelativeTimeFormatUnit = elapsedMinutes < 60 ? "minute" : elapsedMinutes < 1_440 ? "hour" : "day";
+	const amount = unit === "minute" ? elapsedMinutes : unit === "hour" ? Math.floor(elapsedMinutes / 60) : Math.floor(elapsedMinutes / 1_440);
+	return new Intl.RelativeTimeFormat(undefined, { numeric: "always" }).format(-amount, unit);
 }
 
 function sortProjectsByActivity(projects: WorkspaceSummary[]): WorkspaceSummary[] {
@@ -27,22 +50,25 @@ function sortProjectsByActivity(projects: WorkspaceSummary[]): WorkspaceSummary[
 		.sort((left, right) => latestProjectTimestamp(right).localeCompare(latestProjectTimestamp(left)));
 }
 
-function ProjectRow({ project, onClick }: { project: WorkspaceSummary; onClick: () => void }) {
+function ProjectRow({ project, onClick, emptyTimeLabel, justNowLabel }: { project: WorkspaceSummary; onClick: () => void; emptyTimeLabel: string; justNowLabel: string }) {
+	const lastOpenedAt = getProjectLastOpenedAt(project.id);
+	const latestProjectFact = latestProjectTimestamp(project) || lastOpenedAt;
+
 	return (
 		<button
-			className="group flex w-full items-center gap-3 rounded-md p-3 text-left text-foreground/75 hover:bg-interactive-hover hover:text-foreground"
+			className="group flex w-full items-center gap-3 rounded-welcome-panel px-4 py-3 text-left text-foreground/75 hover:bg-interactive-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
 			onClick={onClick}
 			type="button"
 		>
-			<span className="grid size-6 shrink-0 place-items-center text-foreground/65 group-hover:text-foreground" aria-hidden="true">
-				<Folder className="size-5" strokeWidth={1.8} />
+			<span className={HOME_PROJECT_ICON_CLASS} aria-hidden="true">
+				<Folder strokeWidth={1.8} />
 			</span>
-			<span className="min-w-0 text-[16px] leading-tight tracking-[-0.01em]">
-				<span className="block truncate text-foreground">{project.name}</span>
-				<span className="mt-1 block truncate text-sm text-muted-foreground">{project.path}</span>
+			<span className="min-w-0 text-[14px] leading-5">
+				<span className="block truncate font-medium text-[var(--color-text-import-title)]">{project.name}</span>
+				<span className="block truncate text-[13px] text-muted-foreground">{project.path}</span>
 			</span>
-			<span className="ml-auto shrink-0 self-center text-sm text-muted-foreground">
-				{project.sessions.length} {project.sessions.length === 1 ? "session" : "sessions"}
+			<span className="ml-auto shrink-0 text-right text-[13px] text-muted-foreground">
+				{relativeProjectTime(latestProjectFact, emptyTimeLabel, justNowLabel)}
 			</span>
 		</button>
 	);
@@ -64,12 +90,12 @@ function HomeActionCard({
 	return (
 		<button
 			aria-label={ariaLabel}
-			className="flex w-full items-center gap-3 rounded-welcome-panel bg-[var(--color-bg-import-card)] px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-import-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50"
+			className={`${HOME_BUTTON_CLASS} disabled:pointer-events-none disabled:opacity-50`}
 			disabled={disabled}
 			onClick={onClick}
 			type="button"
 		>
-			<span className="grid size-8 shrink-0 place-items-center rounded-lg bg-[color-mix(in_srgb,var(--color-bg-import-chip)_60%,transparent)] text-[var(--color-text-import-muted)]">
+			<span className={HOME_ICON_SLOT_CLASS}>
 				{icon}
 			</span>
 			<span className="min-w-0 text-[14px] font-medium leading-5 text-[var(--color-text-import-title)]">{label}</span>
@@ -77,51 +103,17 @@ function HomeActionCard({
 	);
 }
 
-function HomeProjectSection({
-	label,
-	projects,
-	onOpenProject,
-}: {
-	label: string;
-	projects: WorkspaceSummary[];
-	onOpenProject: (projectId: string) => void;
-}) {
-	if (projects.length === 0) return null;
-
-	return (
-		<section className="space-y-1">
-			<h2 className="px-3 text-sm font-medium text-muted-foreground">{label}</h2>
-			<div className="space-y-1">
-				{projects.map((project) => (
-					<ProjectRow
-						key={project.id}
-						project={project}
-						onClick={() => onOpenProject(project.id)}
-					/>
-				))}
-			</div>
-		</section>
-	);
-}
-
 export function HomePage() {
 	const navigate = useNavigate();
 	const { t } = useTranslation();
+	const openGlobalSettings = useUiStore((state) => state.openGlobalSettings);
 	const { cloneProject, createProject, daemonStatus, initializeProjectRepository, workspaceStartupState } =
 		useShell();
 	const { blocked: requirementsBlocked } = useSystemRequirementsGate();
 	const workspaceQuery = useWorkspaceQuery();
 	const [sourceSignal, setSourceSignal] = useState<{ source: ProjectSource; nonce: number } | null>(null);
 	const projects = workspaceQuery.data ?? [];
-	const { recentProjects, currentProjects } = useMemo(() => {
-		const sortedByActivity = sortProjectsByActivity(projects);
-		const recent = sortedByActivity.slice(0, RECENT_PROJECT_LIMIT);
-		const recentIds = new Set(recent.map((project) => project.id));
-		const current = projects
-			.filter((project) => !recentIds.has(project.id))
-			.sort((left, right) => left.name.localeCompare(right.name));
-		return { recentProjects: recent, currentProjects: current };
-	}, [projects]);
+	const recentProjects = useMemo(() => sortProjectsByActivity(projects).slice(0, RECENT_PROJECT_LIMIT), [projects]);
 
 	const isDaemonReady = usesPreviewWorkspaceData || daemonStatus.state === "ready";
 	const daemonHasFailed = Boolean(daemonStatus.code);
@@ -159,7 +151,7 @@ export function HomePage() {
 					<div className="flex items-center justify-between gap-4 px-3">
 						<h1 className="text-[17px] font-medium tracking-[-0.01em] text-foreground/80">{t("home.jumpBack")}</h1>
 						<TopbarButton
-							className="shrink-0 font-mono text-[15px] tracking-[0.03em] transition-[transform,filter,background,color,border-color] duration-150 ease-out active:scale-[0.96] motion-reduce:transform-none"
+							className="!transition-none !border-0 shrink-0 font-mono text-[15px] tracking-[0.03em] hover:bg-interactive-hover hover:text-foreground active:bg-interactive-hover active:scale-[0.96]"
 							onClick={() => void aoBridge.app.openExternal(`${GITHUB_REPOSITORY_URL}/stargazers`)}
 							variant="accent"
 						>
@@ -168,7 +160,7 @@ export function HomePage() {
 						</TopbarButton>
 					</div>
 
-					<div className="grid grid-cols-2 gap-3 px-3">
+					<div className="-mt-3 grid grid-cols-2 gap-3 px-3">
 						<HomeActionCard
 							ariaLabel={t("createProject.cloneFromGit")}
 							icon={<GitFork className="size-4" aria-hidden="true" />}
@@ -187,14 +179,25 @@ export function HomePage() {
 							label={t("createProject.addWorkspace")}
 							onClick={() => requestSource("workspace")}
 						/>
-						<div
-							aria-hidden="true"
-							className="rounded-welcome-panel bg-[var(--color-bg-import-card)] px-4 py-3 opacity-50"
+						<HomeActionCard
+							ariaLabel={t("settings.connectMobile")}
+							icon={<Smartphone aria-hidden="true" />}
+							label={t("settings.connectMobile")}
+							onClick={() => openGlobalSettings("mobile")}
 						/>
 					</div>
 
-					<HomeProjectSection label={t("home.recentProjects")} projects={recentProjects} onOpenProject={openProject} />
-					<HomeProjectSection label={t("home.currentProjects")} projects={currentProjects} onOpenProject={openProject} />
+					<div className="-mt-3 space-y-1 px-3">
+						{recentProjects.map((project) => (
+							<ProjectRow
+								key={project.id}
+								project={project}
+								onClick={() => openProject(project.id)}
+								emptyTimeLabel={t("home.never")}
+								justNowLabel={t("time.justNow")}
+							/>
+						))}
+					</div>
 				</div>
 
 				<CreateProjectFlow

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -1,16 +1,27 @@
+import type { ProjectSource } from "@aoagents/product-ui";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Folder, Star } from "lucide-react";
+import { Folder, Folders, FolderOpen, GitFork, Star } from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
 import { aoBridge } from "../lib/bridge";
+import { useShell } from "../lib/shell-context";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import type { WorkspaceSummary } from "../types/workspace";
 import { BoardWelcome } from "./BoardEmptyStates";
+import { CreateProjectFlow } from "./CreateProjectFlow";
 import { TopbarButton } from "./TopbarButton";
 
 const GITHUB_REPOSITORY_URL = "https://github.com/Untrivial-ai/agent-orchestrator";
+const RECENT_PROJECT_LIMIT = 3;
 
 function latestProjectTimestamp(project: WorkspaceSummary): string {
 	return project.sessions.reduce((latest, session) => (session.updatedAt > latest ? session.updatedAt : latest), "");
+}
+
+function sortProjectsByActivity(projects: WorkspaceSummary[]): WorkspaceSummary[] {
+	return projects
+		.slice()
+		.sort((left, right) => latestProjectTimestamp(right).localeCompare(latestProjectTimestamp(left)));
 }
 
 function ProjectRow({ project, onClick }: { project: WorkspaceSummary; onClick: () => void }) {
@@ -34,21 +45,94 @@ function ProjectRow({ project, onClick }: { project: WorkspaceSummary; onClick: 
 	);
 }
 
+function HomeActionCard({
+	ariaLabel,
+	disabled,
+	icon,
+	label,
+	onClick,
+}: {
+	ariaLabel: string;
+	disabled?: boolean;
+	icon: ReactNode;
+	label: string;
+	onClick?: () => void;
+}) {
+	return (
+		<button
+			aria-label={ariaLabel}
+			className="flex min-h-[108px] flex-col justify-between gap-3 rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] p-4 text-left transition-colors hover:bg-[var(--color-bg-import-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50"
+			disabled={disabled}
+			onClick={onClick}
+			type="button"
+		>
+			<span className="grid size-9 place-items-center rounded-lg border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-chip)] text-[var(--color-text-import-muted)]">
+				{icon}
+			</span>
+			<span className="text-[14px] font-medium leading-5 text-[var(--color-text-import-title)]">{label}</span>
+		</button>
+	);
+}
+
+function HomeProjectSection({
+	label,
+	projects,
+	onOpenProject,
+}: {
+	label: string;
+	projects: WorkspaceSummary[];
+	onOpenProject: (projectId: string) => void;
+}) {
+	if (projects.length === 0) return null;
+
+	return (
+		<section className="space-y-1">
+			<h2 className="px-3 text-sm font-medium text-muted-foreground">{label}</h2>
+			<div className="space-y-1">
+				{projects.map((project) => (
+					<ProjectRow
+						key={project.id}
+						project={project}
+						onClick={() => onOpenProject(project.id)}
+					/>
+				))}
+			</div>
+		</section>
+	);
+}
+
 export function HomePage() {
 	const navigate = useNavigate();
 	const { t } = useTranslation();
+	const { cloneProject, createProject, initializeProjectRepository } = useShell();
 	const workspaceQuery = useWorkspaceQuery();
-	const projects = (workspaceQuery.data ?? [])
-		.slice()
-		.sort((left, right) => latestProjectTimestamp(right).localeCompare(latestProjectTimestamp(left)))
-		.slice(0, 3);
+	const [sourceSignal, setSourceSignal] = useState<{ source: ProjectSource; nonce: number } | null>(null);
+
+	const projects = workspaceQuery.data ?? [];
+	const { recentProjects, currentProjects } = useMemo(() => {
+		const sortedByActivity = sortProjectsByActivity(projects);
+		const recent = sortedByActivity.slice(0, RECENT_PROJECT_LIMIT);
+		const recentIds = new Set(recent.map((project) => project.id));
+		const current = projects
+			.filter((project) => !recentIds.has(project.id))
+			.sort((left, right) => left.name.localeCompare(right.name));
+		return { recentProjects: recent, currentProjects: current };
+	}, [projects]);
+
+	const requestSource = (source: ProjectSource) => {
+		setSourceSignal({ source, nonce: Date.now() });
+	};
+
+	const openProject = (projectId: string) => {
+		void navigate({ to: "/projects/$projectId", params: { projectId } });
+	};
 
 	if (workspaceQuery.isSuccess && projects.length === 0) return <BoardWelcome />;
 
 	return (
 		<div className="flex min-h-full items-center justify-center px-6 py-16">
-			<div className="w-full max-w-[530px] -translate-y-3">
-				<div className="space-y-3">
+			<div className="w-full max-w-[640px] -translate-y-3">
+				<div className="space-y-6">
 					<div className="flex items-center justify-between gap-4 px-3">
 						<h1 className="text-[17px] font-medium tracking-[-0.01em] text-foreground/80">{t("home.jumpBack")}</h1>
 						<TopbarButton
@@ -60,16 +144,43 @@ export function HomePage() {
 							{t("home.starUs")}
 						</TopbarButton>
 					</div>
-					<div className="space-y-1">
-						{projects.map((project) => (
-							<ProjectRow
-								key={project.id}
-								project={project}
-								onClick={() => void navigate({ to: "/projects/$projectId", params: { projectId: project.id } })}
-							/>
-						))}
+
+					<div className="grid grid-cols-2 gap-3 px-3">
+						<HomeActionCard
+							ariaLabel={t("createProject.cloneFromGit")}
+							icon={<GitFork className="size-4" aria-hidden="true" />}
+							label={t("createProject.cloneFromGit")}
+							onClick={() => requestSource("clone")}
+						/>
+						<HomeActionCard
+							ariaLabel={t("createProject.openLocal")}
+							icon={<FolderOpen className="size-4" aria-hidden="true" />}
+							label={t("createProject.openLocal")}
+							onClick={() => requestSource("local")}
+						/>
+						<HomeActionCard
+							ariaLabel={t("createProject.addWorkspace")}
+							icon={<Folders className="size-4" aria-hidden="true" />}
+							label={t("createProject.addWorkspace")}
+							onClick={() => requestSource("workspace")}
+						/>
+						<div
+							aria-hidden="true"
+							className="min-h-[108px] rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] p-4 opacity-50"
+						/>
 					</div>
+
+					<HomeProjectSection label={t("home.recentProjects")} projects={recentProjects} onOpenProject={openProject} />
+					<HomeProjectSection label={t("home.currentProjects")} projects={currentProjects} onOpenProject={openProject} />
 				</div>
+
+				<CreateProjectFlow
+					mode="choose"
+					onCloneProject={cloneProject}
+					onCreateProject={createProject}
+					onInitializeProject={initializeProjectRepository}
+					sourceSignal={sourceSignal}
+				/>
 			</div>
 		</div>
 	);

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -170,6 +170,7 @@ export const workspaceQueryOptions = {
 	queryKey: workspaceQueryKey,
 	queryFn: fetchWorkspaces,
 	retry: 1,
+	staleTime: 10_000,
 	refetchInterval: 15_000,
 };
 

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -44,6 +44,8 @@
 	"board.empty.body": "Beschreiben Sie eine Aufgabe — der Orchestrator plant sie, startet Worker-Sitzungen und verfolgt sie hier, während die Arbeit voranschreitet.",
 	"board.empty.title": "Noch keine Worker-Sitzungen",
 	"home.jumpBack": "Direkt weitermachen",
+	"home.recentProjects": "Zuletzt verwendete Projekte",
+	"home.currentProjects": "Aktuelle Projekte",
 	"home.starUs": "Mit Stern markieren",
 	"browser.agentAction": "Agent {{verb}}",
 	"browser.agentUsing": "Agent nutzt den Browser",

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -5,6 +5,7 @@
 	"activity.idle": "Inaktiv",
 	"activity.unknown": "Unbekannt",
 	"activity.waiting_input": "Eingabe erforderlich",
+	"home.never": "Nie",
 	"cloudCredential.agentLabel": "Coding-Agent",
 	"cloudCredential.cancel": "Abbrechen",
 	"cloudCredential.connect": "Verbinden",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -16,6 +16,7 @@
 	"home.jumpBack": "Jump back right in",
 	"home.recentProjects": "Recent projects",
 	"home.currentProjects": "Current projects",
+	"home.never": "Never",
 	"home.starUs": "Star Us",
 	"browser.agentAction": "Agent {{verb}}",
 	"browser.agentUsing": "Agent using browser",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -14,6 +14,8 @@
 	"board.empty.body": "Describe a task and the orchestrator plans it, spawns worker sessions, and tracks them here as work moves forward.",
 	"board.empty.title": "No worker sessions yet",
 	"home.jumpBack": "Jump back right in",
+	"home.recentProjects": "Recent projects",
+	"home.currentProjects": "Current projects",
 	"home.starUs": "Star Us",
 	"browser.agentAction": "Agent {{verb}}",
 	"browser.agentUsing": "Agent using browser",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -5,6 +5,7 @@
 	"activity.idle": "Inactivo",
 	"activity.unknown": "Desconocido",
 	"activity.waiting_input": "Se necesita entrada",
+	"home.never": "Nunca",
 	"cloudCredential.agentLabel": "Agente de código",
 	"cloudCredential.cancel": "Cancelar",
 	"cloudCredential.connect": "Conectar",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -44,6 +44,8 @@
 	"board.empty.body": "Describe una tarea y el orquestador la planifica, crea sesiones de trabajo y las sigue aquí a medida que avanza el trabajo.",
 	"board.empty.title": "Aún no hay sesiones de trabajo",
 	"home.jumpBack": "Vuelve a entrar",
+	"home.recentProjects": "Proyectos recientes",
+	"home.currentProjects": "Proyectos actuales",
 	"home.starUs": "Danos una estrella",
 	"browser.agentAction": "Agente {{verb}}",
 	"browser.agentUsing": "Agente usando el navegador",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -5,6 +5,7 @@
 	"activity.idle": "Inactif",
 	"activity.unknown": "Inconnu",
 	"activity.waiting_input": "Saisie requise",
+	"home.never": "Jamais",
 	"cloudCredential.agentLabel": "Agent de code",
 	"cloudCredential.cancel": "Annuler",
 	"cloudCredential.connect": "Connecter",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -44,6 +44,8 @@
 	"board.empty.body": "Décrivez une tâche et l'orchestrateur la planifie, crée des sessions worker et les suit ici au fur et à mesure de l'avancement.",
 	"board.empty.title": "Aucune session worker pour le moment",
 	"home.jumpBack": "Reprendre là où vous en étiez",
+	"home.recentProjects": "Projets récents",
+	"home.currentProjects": "Projets actuels",
 	"home.starUs": "Ajouter une étoile",
 	"browser.agentAction": "Agent {{verb}}",
 	"browser.agentUsing": "Agent utilisant le navigateur",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -44,6 +44,8 @@
 	"board.empty.body": "タスクを説明すると、オーケストレーターが計画を立て、ワーカーセッションを起動し、進捗に合わせてここで追跡します。",
 	"board.empty.title": "ワーカーセッションはまだありません",
 	"home.jumpBack": "続きを始める",
+	"home.recentProjects": "最近のプロジェクト",
+	"home.currentProjects": "現在のプロジェクト",
 	"home.starUs": "スターを付ける",
 	"browser.agentAction": "エージェントが{{verb}}",
 	"browser.agentUsing": "エージェントがブラウザを使用中",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -5,6 +5,7 @@
 	"activity.idle": "アイドル",
 	"activity.unknown": "不明",
 	"activity.waiting_input": "入力が必要",
+	"home.never": "なし",
 	"cloudCredential.agentLabel": "コーディングエージェント",
 	"cloudCredential.cancel": "キャンセル",
 	"cloudCredential.connect": "接続",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -44,6 +44,8 @@
 	"board.empty.body": "작업을 설명하면 오케스트레이터가 계획을 세우고 워커 세션을 생성하며, 진행 상황을 여기서 추적합니다.",
 	"board.empty.title": "아직 워커 세션이 없습니다",
 	"home.jumpBack": "이어서 시작하기",
+	"home.recentProjects": "최근 프로젝트",
+	"home.currentProjects": "현재 프로젝트",
 	"home.starUs": "별표하기",
 	"browser.agentAction": "에이전트가 {{verb}}",
 	"browser.agentUsing": "에이전트가 브라우저 사용 중",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -5,6 +5,7 @@
 	"activity.idle": "유휴",
 	"activity.unknown": "알 수 없음",
 	"activity.waiting_input": "입력 필요",
+	"home.never": "없음",
 	"cloudCredential.agentLabel": "코딩 에이전트",
 	"cloudCredential.cancel": "취소",
 	"cloudCredential.connect": "연결",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -44,6 +44,8 @@
 	"board.empty.body": "Descreva uma tarefa e o orchestrator a planeja, inicia sessões de worker e as acompanha aqui conforme o trabalho avança.",
 	"board.empty.title": "Nenhuma sessão de worker ainda",
 	"home.jumpBack": "Volte de onde parou",
+	"home.recentProjects": "Projetos recentes",
+	"home.currentProjects": "Projetos atuais",
 	"home.starUs": "Dar uma estrela",
 	"browser.agentAction": "Agente {{verb}}",
 	"browser.agentUsing": "Agente usando o navegador",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -5,6 +5,7 @@
 	"activity.idle": "Inativo",
 	"activity.unknown": "Desconhecido",
 	"activity.waiting_input": "Entrada necessária",
+	"home.never": "Nunca",
 	"cloudCredential.agentLabel": "Agente de código",
 	"cloudCredential.cancel": "Cancelar",
 	"cloudCredential.connect": "Conectar",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -44,6 +44,8 @@
 	"board.empty.body": "描述一个任务后，编排器会进行规划、创建 worker 会话，并在工作推进时在此跟踪。",
 	"board.empty.title": "还没有 worker 会话",
 	"home.jumpBack": "继续进行",
+	"home.recentProjects": "最近的项目",
+	"home.currentProjects": "当前项目",
 	"home.starUs": "点个星标",
 	"browser.agentAction": "代理正在{{verb}}",
 	"browser.agentUsing": "代理正在使用浏览器",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -5,6 +5,7 @@
 	"activity.idle": "空闲",
 	"activity.unknown": "未知",
 	"activity.waiting_input": "需要输入",
+	"home.never": "从未",
 	"cloudCredential.agentLabel": "编码代理",
 	"cloudCredential.cancel": "取消",
 	"cloudCredential.connect": "连接",

--- a/frontend/src/renderer/lib/project-history.ts
+++ b/frontend/src/renderer/lib/project-history.ts
@@ -1,0 +1,29 @@
+const PROJECT_HISTORY_KEY = "ao.project-history";
+
+type ProjectHistory = Record<string, string>;
+
+function readHistory(): ProjectHistory {
+	if (typeof window === "undefined") return {};
+	try {
+		const value: unknown = JSON.parse(window.localStorage.getItem(PROJECT_HISTORY_KEY) ?? "{}");
+		if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+		return Object.fromEntries(
+			Object.entries(value).filter((entry): entry is [string, string] => typeof entry[0] === "string" && typeof entry[1] === "string"),
+		);
+	} catch {
+		return {};
+	}
+}
+
+export function getProjectLastOpenedAt(projectId: string): string | undefined {
+	return readHistory()[projectId];
+}
+
+export function recordProjectOpened(projectId: string): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(PROJECT_HISTORY_KEY, JSON.stringify({ ...readHistory(), [projectId]: new Date().toISOString() }));
+	} catch {
+		// Local history is best effort and must never block navigation.
+	}
+}

--- a/frontend/src/renderer/routes/_shell.index.tsx
+++ b/frontend/src/renderer/routes/_shell.index.tsx
@@ -1,8 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { HomePage } from "../components/HomePage";
 import { MigrationPopup } from "../components/MigrationPopup";
+import { workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
+import { hasTrustedApiBaseUrl } from "../lib/api-client";
+import { refreshDaemonStatus } from "../lib/daemon-status";
+import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 
 export const Route = createFileRoute("/_shell/")({
+	loader: async ({ context }) => {
+		await refreshDaemonStatus().catch(() => undefined);
+		if (!usesPreviewWorkspaceData && !hasTrustedApiBaseUrl()) return;
+		return context.queryClient.ensureQueryData(workspaceQueryOptions);
+	},
 	component: ShellIndex,
 });
 

--- a/frontend/src/renderer/routes/_shell.index.tsx
+++ b/frontend/src/renderer/routes/_shell.index.tsx
@@ -1,17 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { HomePage } from "../components/HomePage";
 import { MigrationPopup } from "../components/MigrationPopup";
-import { workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
-import { hasTrustedApiBaseUrl } from "../lib/api-client";
-import { refreshDaemonStatus } from "../lib/daemon-status";
-import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 
 export const Route = createFileRoute("/_shell/")({
-	loader: async ({ context }) => {
-		await refreshDaemonStatus().catch(() => undefined);
-		if (!usesPreviewWorkspaceData && !hasTrustedApiBaseUrl()) return;
-		return context.queryClient.ensureQueryData(workspaceQueryOptions);
-	},
 	component: ShellIndex,
 });
 

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
 import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
+import { DaemonStartupLoader } from "../components/DaemonStartupLoader";
 import { NotificationRuntime } from "../components/NotificationCenter";
 import { TrayRuntime } from "../components/TrayRuntime";
 import { GlobalNewTaskDialog } from "../components/GlobalNewTaskDialog";
@@ -35,6 +36,7 @@ import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-repla
 import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
 import { aoBridge } from "../lib/bridge";
 import { handleModifierLinkClick } from "../lib/external-link-policy";
+import { recordProjectOpened } from "../lib/project-history";
 import { cn } from "../lib/utils";
 import { adaptiveSidebarShouldCompact } from "../lib/adaptive-sidebar";
 import {
@@ -57,7 +59,7 @@ export const Route = createFileRoute("/_shell")({
 	loader: async ({ context }) => {
 		await refreshDaemonStatus().catch(() => undefined);
 		if (!usesPreviewWorkspaceData && !hasTrustedApiBaseUrl()) return;
-		return context.queryClient.ensureQueryData(workspaceQueryOptions);
+		return context.queryClient.fetchQuery({ ...workspaceQueryOptions, staleTime: 0 });
 	},
 	component: ShellLayout,
 });
@@ -332,6 +334,9 @@ function ShellLayout() {
 	// The root route is the intentionally minimal home surface, regardless of
 	// whether projects have already been registered.
 	const isHomeRoute = Boolean(matchRoute({ to: "/" }));
+	useEffect(() => {
+		if (routeParams.projectId) recordProjectOpened(routeParams.projectId);
+	}, [routeParams.projectId]);
 	const isTerminalsRoute = Boolean(matchRoute({ to: "/terminals" }));
 	const isSettingsRoute =
 		Boolean(matchRoute({ to: "/settings", fuzzy: true })) ||
@@ -352,7 +357,7 @@ function ShellLayout() {
 	const isStartupLoading =
 		!usesPreviewWorkspaceData &&
 		!daemonStatus.code &&
-		(daemonStatus.state !== "ready" || workspaceStartupState === "loading");
+		(daemonStatus.state !== "ready" || workspaceStartupState === "loading" || (!workspaceQuery.isSuccess && !workspaceQuery.isError));
 	const navigateSession = useCallback(
 		(direction: -1 | 1) => {
 			if (!scopedProjectId) return;
@@ -823,6 +828,12 @@ function ShellLayout() {
 			workspaceStartupState,
 		],
 	);
+
+	// Keep the shell chrome and its first route behind the same readiness gate.
+	// Rendering the sidebar with an empty query while the home outlet shows its
+	// loader creates a visible two-stage launch and can make the home page flash
+	// before the project list arrives.
+	if (isStartupLoading) return <DaemonStartupLoader />;
 
 	return (
 		<ShellProvider

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -175,6 +175,9 @@ vi.mock("../hooks/useAgentReadinessQuery", () => ({
 }));
 
 vi.mock("../components/NotificationCenter", () => ({ NotificationRuntime: () => null }));
+vi.mock("../components/DaemonStartupLoader", () => ({
+	DaemonStartupLoader: () => <div data-testid="daemon-startup-loader" />,
+}));
 vi.mock("../components/CommandPalette", () => ({ CommandPalette: () => null }));
 vi.mock("../components/OrchestratorReplacementDialog", () => ({ OrchestratorReplacementDialog: () => null }));
 vi.mock("../components/ShellTopbar", () => ({ ShellTopbar: () => null }));
@@ -369,8 +372,8 @@ describe("shell workspace startup", () => {
 		);
 
 		const view = await renderShell();
-		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
-		expect(screen.getByTestId("sidebar-provider")).toHaveAttribute("data-open", "false");
+		expect(screen.getByTestId("daemon-startup-loader")).toBeInTheDocument();
+		expect(screen.queryByTestId("sidebar-provider")).not.toBeInTheDocument();
 		expect(shellMocks.queryClient.fetchQuery).toHaveBeenCalledWith(expect.objectContaining({ staleTime: 0 }));
 
 		await act(async () => resolveFetch?.(workspaces));
@@ -397,7 +400,7 @@ describe("shell workspace startup", () => {
 		await waitFor(() =>
 			expect(shellMocks.queryClient.fetchQuery).toHaveBeenCalledWith(expect.objectContaining({ staleTime: 0 })),
 		);
-		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+		expect(screen.getByTestId("daemon-startup-loader")).toBeInTheDocument();
 	});
 
 	it("forces a workspace fetch when a daemon returns ready on the same port", async () => {
@@ -405,7 +408,7 @@ describe("shell workspace startup", () => {
 		shellMocks.queryClient.fetchQuery.mockResolvedValue(workspaces);
 
 		const view = await renderShell();
-		expect(shellMocks.state.shellValue?.workspaceStartupState).toBe("loading");
+		expect(screen.getByTestId("daemon-startup-loader")).toBeInTheDocument();
 		expect(shellMocks.queryClient.fetchQuery).not.toHaveBeenCalled();
 
 		shellMocks.state.daemonStatus = { state: "ready", port: 4777 };


### PR DESCRIPTION
#### Summary

- Redesigns the home surface with a **Jump back right in** header, **Star Us** button, and a **2×2 action grid** (Clone from Git, Open local repository, Add workspace, plus an empty cloud placeholder).
- Splits project lists into **Recent projects** (top 3 by activity) and **Current projects** (remaining, alphabetical).
- Wires action cards into the existing `CreateProjectFlow` via a new `sourceSignal` prop — no duplicated create/clone logic.
- Gates home rendering on workspace readiness (`DaemonStartupLoader` + route prefetch) to avoid empty-state layout shifts on first paint.

## Details

- Uses existing import-card theme tokens; action cards are compact, borderless, horizontal icon + label.
- Icon chips use a subtler 60% fill with no border.
- First-run empty state (`BoardWelcome`) is unchanged when there are no projects.
- Home route loader prefetches workspace data via `ensureQueryData`.

## Test plan

- [ ] Open app with existing projects — home shows loader briefly, then full layout without list pop-in
- [ ] Navigate away and back to home — no loader flash, data renders immediately
- [ ] Empty data dir — `BoardWelcome` still shows (not the redesigned home)
- [ ] Click each action card — clone / local / workspace flows open as before
- [ ] Click a project row — navigates to project board
- [ ] `npm run typecheck` and home unit tests pass What

Brief description of the change.

## Why

Problem this solves / issue it closes (e.g. `Fixes #123`).

## How

Key implementation decisions, trade-offs, or areas reviewers should focus on.
Call out intentional omissions (especially vs older TypeScript behavior) when relevant.

## Testing

How you validated this locally (commands, scenarios, screenshots if UI).

## Checklist

- [ ] Branched from `main` (or continuing an existing PR branch)
- [ ] One focused change; links the related issue when applicable
- [ ] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [ ] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
