### PR TITLE
fix(landing): restore themed scroll indicators

### DIFF
--- a/frontend/src/landing/src/app/components/Header/Header.tsx
+++ b/frontend/src/landing/src/app/components/Header/Header.tsx
@@ -50,7 +50,7 @@ export function Header({ ctaButtons }: HeaderProps) {
     >
       <div className="px-4 sm:px-8 lg:px-[30px]">
         <div className="max-w-7xl mx-auto">
-          <div className="flex items-center justify-between h-14">
+          <div className="flex items-center justify-between h-(--header-height)">
             <div className="flex items-center">
               <Link
                 href="/"

--- a/frontend/src/landing/src/app/components/Header/components/MobileNav/MobileNav.tsx
+++ b/frontend/src/landing/src/app/components/Header/components/MobileNav/MobileNav.tsx
@@ -69,7 +69,7 @@ export function MobileNav({ ctaButtons }: MobileNavProps) {
 					<>
 						<motion.div
 							key="mobile-nav-backdrop"
-							className="fixed inset-x-0 bottom-0 top-14 z-40 bg-background/70 backdrop-blur-sm"
+							className="fixed inset-x-0 bottom-0 top-(--header-height) z-40 bg-background/70 backdrop-blur-sm"
 							initial={{ opacity: 0 }}
 							animate={{ opacity: 1 }}
 							exit={{ opacity: 0 }}
@@ -80,13 +80,13 @@ export function MobileNav({ ctaButtons }: MobileNavProps) {
 						<motion.div
 							key="mobile-nav-panel"
 							id="mobile-nav"
-							className="absolute inset-x-0 top-14 z-50 overflow-hidden border-t border-border bg-background"
+							className="absolute inset-x-0 top-(--header-height) z-50 overflow-hidden border-t border-border bg-background"
 							initial={{ height: 0 }}
 							animate={{ height: "auto" }}
 							exit={{ height: 0 }}
 							transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
 						>
-							<div className="max-h-[calc(100dvh-3.5rem)] overflow-y-auto overscroll-contain px-4 pb-[env(safe-area-inset-bottom)] sm:px-8 lg:px-[30px]">
+							<div className="max-h-[calc(100dvh-var(--header-height))] overflow-y-auto overscroll-contain px-4 pb-[env(safe-area-inset-bottom)] sm:px-8 lg:px-[30px]">
 								<div className="max-w-7xl mx-auto py-4 flex flex-col gap-6">
 									<MobileSection
 										title="Product"

--- a/frontend/src/site-theme/tokens.css
+++ b/frontend/src/site-theme/tokens.css
@@ -35,6 +35,14 @@
   --brand: #d25611;
   --brand-light: #e8804a;
   --brand-dark: #9e400a;
+
+  /* Shared with the sticky header and anchor offset so they cannot drift. */
+  --header-height: 3.5rem;
+
+  --scrollbar-thumb: oklch(1 0 0 / 18%);
+  --scrollbar-thumb-hover: oklch(1 0 0 / 32%);
+
+  color-scheme: dark;
 }
 
 @theme {
@@ -78,16 +86,45 @@
 }
 
 @layer base {
-  html,
-  body {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
+	html {
+		scroll-padding-top: var(--header-height);
+		scroll-behavior: smooth;
+	}
 
-  html::-webkit-scrollbar,
-  body::-webkit-scrollbar {
-    display: none;
-  }
+	@media (prefers-reduced-motion: reduce) {
+		html {
+			scroll-behavior: auto;
+		}
+	}
+
+	/* Restore a visible scroll indicator while retaining the dark site theme.
+	   Utility-scoped `.scrollbar-hide` remains available for intentional inner
+	   canvases such as demos and carousels. */
+	* {
+		scrollbar-width: thin;
+		scrollbar-color: var(--scrollbar-thumb) transparent;
+	}
+
+	::-webkit-scrollbar {
+		width: 10px;
+		height: 10px;
+	}
+
+	::-webkit-scrollbar-track,
+	::-webkit-scrollbar-corner {
+		background: transparent;
+	}
+
+	::-webkit-scrollbar-thumb {
+		border: 2px solid transparent;
+		border-radius: 9999px;
+		background-color: var(--scrollbar-thumb);
+		background-clip: content-box;
+	}
+
+	::-webkit-scrollbar-thumb:hover {
+		background-color: var(--scrollbar-thumb-hover);
+	}
 
   body {
     font-family: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;


### PR DESCRIPTION
Follow-up to #4771 and #4777

## Problem

#4777 restored section anchors and repeatable hash navigation, but explicitly left the themed scrollbar and shared header-height work out. The global site theme still hid the page scrollbar, so the landing page offered no scroll-position indicator.

## Fix

- replace global hidden-scrollbar rules with themed cross-browser scrollbar styling
- add a shared `--header-height` token used by header/mobile geometry and anchor scroll padding
- honor reduced-motion preferences for smooth anchor scrolling
- keep `.scrollbar-hide` available for intentionally hidden inner demo scrollbars

## Tests

- `cd frontend/src/landing && npm run build`
- `git diff --check`
