### PR TITLE
fix(project): allocate unique derived project IDs

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -183,6 +183,8 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		return Project{}, apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load project")
 	}
 
+	// Display names retain the caller's requested/derived base even when an
+	// omitted project ID needs a storage-only suffix below.
 	name := string(id)
 	if in.Name != nil {
 		name = strings.TrimSpace(*in.Name)
@@ -202,10 +204,16 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 	if existing, ok, err := m.store.GetProject(ctx, string(id)); err != nil {
 		return Project{}, apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load project")
 	} else if ok && existing.ArchivedAt.IsZero() && existing.Path != path {
-		return Project{}, apierr.Conflict("ID_ALREADY_REGISTERED", "A project with this id is already registered for a different path", map[string]any{
-			"existingProjectId":  existing.ID,
-			"suggestedProjectId": string(m.suggestID(ctx, id)),
-		})
+		if in.ProjectID != nil {
+			return Project{}, apierr.Conflict("ID_ALREADY_REGISTERED", "A project with this id is already registered for a different path", map[string]any{
+				"existingProjectId":  existing.ID,
+				"suggestedProjectId": string(m.suggestID(ctx, id)),
+			})
+		}
+		// A caller that omitted projectId asked the service to derive one from
+		// the basename. Resolve that derived collision here; explicit IDs retain
+		// their conflict semantics so user intent is never silently rewritten.
+		id = m.suggestID(ctx, id)
 	}
 
 	var projectConfig domain.ProjectConfig

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -1054,6 +1054,43 @@ func TestManager_AddValidationAndConflicts(t *testing.T) {
 	wantCode(t, err, "ID_ALREADY_REGISTERED")
 }
 
+func TestManager_AddAllocatesUniqueIDForCollidingDerivedIDs(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	configureCommitter(t)
+
+	root := t.TempDir()
+	repoA := filepath.Join(root, "one", "app")
+	repoB := filepath.Join(root, "two", "app")
+	for _, repo := range []string{repoA, repoB} {
+		if err := os.MkdirAll(repo, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if out, err := exec.Command("git", "init", "-b", "main", repo).CombinedOutput(); err != nil {
+			t.Fatalf("git init: %v (%s)", err, out)
+		}
+		commitEmpty(t, repo)
+	}
+
+	first, err := m.Add(ctx, project.AddInput{Path: repoA})
+	if err != nil {
+		t.Fatalf("add first project: %v", err)
+	}
+	second, err := m.Add(ctx, project.AddInput{Path: repoB})
+	if err != nil {
+		t.Fatalf("add second project with colliding derived id: %v", err)
+	}
+	if first.ID != "app" {
+		t.Fatalf("first project id = %q, want app", first.ID)
+	}
+	if second.ID != "app1" {
+		t.Fatalf("second project id = %q, want app1", second.ID)
+	}
+	if second.Name != "app" {
+		t.Fatalf("second project display name = %q, want app", second.Name)
+	}
+}
+
 // gitRepoWithOrigin creates a real git repo with an `origin` remote pointing
 // at `originURL`. Used to assert project.Add captures the origin at add time.
 func gitRepoWithOrigin(t *testing.T, originURL string) string {


### PR DESCRIPTION
Fixes #4765

## Problem

When callers omitted `project_id`, project registration derived the ID from the repository basename. Two repositories with the same basename therefore collided even though ID allocation already had a deterministic suffixing helper.

## Fix

- allocate a unique suffixed ID only when an automatically derived ID collides
- preserve the existing `ID_ALREADY_REGISTERED` behavior for explicitly supplied IDs
- preserve the repository basename as the display name rather than exposing the suffixed storage ID

## Tests

- `cd backend && go test ./internal/service/project -run '^TestManager_Add(AllocatesUniqueIDForCollidingDerivedIDs|ValidationAndConflicts)$' -count=1`
- `git diff --check`

The full package test was also attempted on Windows but did not complete; the focused regression and conflict coverage passed deterministically.
