### PR TITLE
fix: align file tab sizing with terminal tabs and drop close-all menu

### DIFF
--- a/frontend/src/renderer/components/SessionFileTabs.test.tsx
+++ b/frontend/src/renderer/components/SessionFileTabs.test.tsx
@@ -17,7 +17,6 @@ describe("SessionFileTabs", () => {
 						onAddFeedback={onAddFeedback}
 						onActivateFile={onActivateFile}
 						onCloseFile={onCloseFile}
-						onCloseAll={vi.fn()}
 					/>
 				</div>
 			</TooltipProvider>,
@@ -29,32 +28,18 @@ describe("SessionFileTabs", () => {
 		const feedbackButton = screen.getByRole("button", { name: "Add feedback for file src/App.tsx" });
 		expect(closeButton.parentElement).toHaveClass("left-2");
 		expect(feedbackButton.parentElement).toHaveClass("right-1");
-		expect(tab.closest("[data-terminal-tab-frame]")).not.toHaveClass("pl-3", "pr-1.5");
+		expect(tab.closest("[data-terminal-tab-frame]")).toHaveClass("max-w-shell-tab-max");
+		expect(tab.closest("[data-terminal-tab-frame]")).not.toHaveClass(
+			"session-tab-icon-floor",
+			"session-tab-icon-floor--closable",
+			"pl-3",
+			"pr-1.5",
+		);
 		await userEvent.click(languageIcon!);
 		expect(onActivateFile).toHaveBeenCalledWith("src/App.tsx");
 		await userEvent.click(feedbackButton);
 		expect(onAddFeedback).toHaveBeenCalledWith("src/App.tsx");
 		await userEvent.click(closeButton);
 		expect(onCloseFile).toHaveBeenCalledWith("src/App.tsx");
-	});
-
-	it("offers close all for open files", async () => {
-		const onCloseAll = vi.fn();
-		render(
-			<TooltipProvider>
-				<div role="tablist">
-					<SessionFileTabs
-						state={{ openPaths: ["README.md"], activePath: null }}
-						onAddFeedback={vi.fn()}
-						onActivateFile={vi.fn()}
-						onCloseFile={vi.fn()}
-						onCloseAll={onCloseAll}
-					/>
-				</div>
-			</TooltipProvider>,
-		);
-		await userEvent.click(screen.getByRole("button", { name: "File tab actions" }));
-		await userEvent.click(await screen.findByRole("menuitem", { name: "Close all files" }));
-		expect(onCloseAll).toHaveBeenCalledOnce();
 	});
 });

--- a/frontend/src/renderer/components/SessionFileTabs.tsx
+++ b/frontend/src/renderer/components/SessionFileTabs.tsx
@@ -1,9 +1,7 @@
-import { MoreHorizontal, Plus, X } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { SessionFileTabState } from "../lib/session-file-tabs";
 import { TerminalTabFrame } from "./TerminalTabFrame";
-import { Button } from "./ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { WorkspaceEntryIcon } from "./WorkspaceEntryIcon";
 
@@ -16,13 +14,11 @@ export function SessionFileTabs({
 	onAddFeedback,
 	onActivateFile,
 	onCloseFile,
-	onCloseAll,
 }: {
 	state: SessionFileTabState;
 	onAddFeedback: (path: string) => void;
 	onActivateFile: (path: string) => void;
 	onCloseFile: (path: string) => void;
-	onCloseAll: () => void;
 }) {
 	if (state.openPaths.length === 0) return null;
 	return (
@@ -37,7 +33,6 @@ export function SessionFileTabs({
 					path={path}
 				/>
 			))}
-			<SessionFileTabActions onCloseAll={onCloseAll} />
 		</>
 	);
 }
@@ -101,13 +96,14 @@ export function SessionFileTab({
 			buttonProps={{
 				"aria-label": name,
 				"aria-selected": active,
+				className: "pr-9",
 				onClick: onActivate,
 				role: "tab",
 				tabIndex: active ? 0 : -1,
 				title: path,
 				type: "button",
 			}}
-			className="session-tab-icon-floor session-tab-icon-floor--closable max-w-shell-tab-max"
+			className="max-w-shell-tab-max"
 			contentClassName="font-medium"
 			trailingAction={feedbackAction}
 		>
@@ -118,26 +114,5 @@ export function SessionFileTab({
 			/>
 			<span className="truncate">{name}</span>
 		</TerminalTabFrame>
-	);
-}
-
-export function SessionFileTabActions({ onCloseAll }: { onCloseAll: () => void }) {
-	const { t } = useTranslation();
-	return (
-		<DropdownMenu>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<DropdownMenuTrigger asChild>
-						<Button aria-label={t("files.tabActions")} className="mx-1 self-center" size="icon-sm" type="button" variant="ghost">
-							<MoreHorizontal className="size-icon-sm" aria-hidden="true" />
-						</Button>
-					</DropdownMenuTrigger>
-				</TooltipTrigger>
-				<TooltipContent side="bottom">{t("files.tabActions")}</TooltipContent>
-			</Tooltip>
-			<DropdownMenuContent align="end">
-				<DropdownMenuItem onSelect={onCloseAll}>{t("files.closeAllTabs")}</DropdownMenuItem>
-			</DropdownMenuContent>
-		</DropdownMenu>
 	);
 }

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -25,7 +25,7 @@ import {
 import { NotificationCenter } from "./NotificationCenter";
 import { ResizeHandle } from "./ResizeHandle";
 import { SessionFileExplorer } from "./SessionFileExplorer";
-import { SessionFileTab, SessionFileTabActions } from "./SessionFileTabs";
+import { SessionFileTab } from "./SessionFileTabs";
 import { SessionFileWorkspace } from "./SessionFileWorkspace";
 import { SessionActionsMenu } from "./SessionActionsMenu";
 import { SessionInspector } from "./SessionInspector";
@@ -65,7 +65,6 @@ import { matchWorkspaceFilePath } from "../lib/workspace-file-path";
 import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
 import {
 	activateSessionFile,
-	closeAllSessionFiles,
 	closeSessionFile,
 	EMPTY_SESSION_FILE_TABS,
 	openSessionFile,
@@ -744,20 +743,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		}
 		removeAuxiliaryTab(`file:${path}`);
 	}, [activateAuxiliaryTab, adjacentAuxiliaryTab, fileTabs.activePath, removeAuxiliaryTab, sessionId]);
-	const closeAllCenterFiles = useCallback(() => {
-		setFileTabsBySession((current) => ({ ...current, [sessionId]: closeAllSessionFiles() }));
-		setAuxiliaryTabOrderBySession((current) => {
-			const currentOrder = current[sessionId];
-			if (!currentOrder?.some((key) => key.startsWith("file:"))) return current;
-			const nextOrder = currentOrder.filter((key) => !key.startsWith("file:"));
-			if (nextOrder.length === 0) {
-				const { [sessionId]: _removed, ...rest } = current;
-				return rest;
-			}
-			return { ...current, [sessionId]: nextOrder };
-		});
-	}, [sessionId]);
-
 	// The shell layout owns opening (it is mounted on every route, so the button
 	// and ⌘T / Ctrl+T work everywhere); this view only follows the result. When a new
 	// shell becomes active while a session is on screen, switch the pane to it —
@@ -1029,9 +1014,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			})),
 		[activateCenterFile, closeCenterFile, fileAnnotation, fileTabs.activePath, fileTabs.openPaths],
 	);
-	const centerFileTabActions = fileTabs.openPaths.length > 0 ? (
-		<SessionFileTabActions onCloseAll={closeAllCenterFiles} />
-	) : undefined;
 	const activeWorkspaceTabKey = fileTabs.activePath ? `file:${fileTabs.activePath}` : undefined;
 	const previewUrl = session?.previewUrl?.trim() || undefined;
 	const previewRevision = session?.previewRevision;
@@ -1546,7 +1528,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									tabStripAction={newShellTerminalAction}
 									handoffDialogOpen={handoffDialogOpen}
 									workspaceTabs={centerFileTabs}
-									workspaceTabActions={centerFileTabActions}
 									workspaceActiveTabKey={activeWorkspaceTabKey}
 									auxiliaryTabOrder={resolvedAuxiliaryTabOrder}
 									onAuxiliaryTabOrderChange={setAuxiliaryTabOrder}
@@ -1582,7 +1563,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									tabStripAction={newShellTerminalAction}
 									handoffDialogOpen={handoffDialogOpen}
 									workspaceTabs={centerFileTabs}
-									workspaceTabActions={centerFileTabActions}
 									workspaceActiveTabKey={activeWorkspaceTabKey}
 									auxiliaryTabOrder={resolvedAuxiliaryTabOrder}
 									onAuxiliaryTabOrderChange={setAuxiliaryTabOrder}


### PR DESCRIPTION
## Summary
- Match session file tab sizing to connected terminal tabs so switching tabs no longer expands or shrinks the strip
- Remove the file-tab overflow menu (`...` → "Close all files")
- Keep per-tab close (X on hover) and active-tab feedback (+) unchanged

## Details
File tabs previously used `session-tab-icon-floor--closable`, which pinned width between min/max values and made tabs feel animated on switch. They now use the same `max-w-shell-tab-max` treatment as connected shell tabs, with a fixed `pr-9` so the active feedback button does not change tab width.

## Test plan
- [x] `npm run typecheck` (frontend)
- [x] `SessionFileTabs.test.tsx`
- [x] `SessionView.test.tsx`
- [x] `CenterPane.test.tsx`
- [ ] Open multiple files in a session and switch between tabs — no width jump
- [ ] Close individual file tabs via hover X
- [ ] Confirm `...` close-all control is gone from the tab strip