### PR TITLE
fix: tighten Help report form submit button layout

### DIFF
--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -537,12 +537,14 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.queryByRole("combobox", { name: "Report type" })).not.toBeInTheDocument();
 		expect(screen.queryByLabelText("Include safe diagnostics")).not.toBeInTheDocument();
 		expect(screen.queryByLabelText("Expected behavior")).not.toBeInTheDocument();
-		expect(screen.getByRole("radiogroup", { name: "Report destination" })).toBeInTheDocument();
-		expect(screen.getByRole("radio", { name: "GitHub" })).toHaveAttribute("aria-checked", "true");
+		expect(screen.getByRole("group", { name: "Report destination" })).toBeInTheDocument();
+		expect(screen.queryByRole("radiogroup", { name: "Report destination" })).not.toBeInTheDocument();
 		expect(screen.queryByLabelText("Report preview")).not.toBeInTheDocument();
 
 		expect(screen.getByRole("button", { name: /copy & create github issue/i })).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: /copy & open email/i })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /copy & open discord/i })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /copy & open email/i })).toBeInTheDocument();
+		expect(screen.getByLabelText("What happened?")).toHaveClass("resize-none");
 		await user.click(screen.getByRole("button", { name: /copy & create github issue/i }));
 
 		await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
@@ -574,9 +576,8 @@ describe("GlobalSettingsForm", () => {
 		await user.type(await screen.findByLabelText("Title"), "Need help with setup");
 		await user.type(screen.getByLabelText("What happened?"), "The setup flow stalls after the first prompt.");
 
-		await user.click(screen.getByRole("radio", { name: "Discord" }));
 		expect(screen.getByRole("button", { name: /copy & open discord/i })).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: /copy & open email/i })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /copy & open email/i })).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: /copy & open discord/i }));
 		await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
 		expect(writeText.mock.calls[0][0]).toContain("**AO feedback**");
@@ -584,12 +585,9 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.getByLabelText("Title")).toHaveValue("");
 		expect(screen.getByLabelText("What happened?")).toHaveValue("");
 
-		await user.click(screen.getByRole("radio", { name: "Email" }));
-		expect(screen.getByRole("button", { name: /copy & open email/i })).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: /copy & open discord/i })).not.toBeInTheDocument();
-		expect(screen.queryByText("Discord draft copied.")).not.toBeInTheDocument();
 		expect(screen.getByRole("button", { name: /copy & open email/i })).toBeDisabled();
 		await user.type(screen.getByLabelText("Title"), "Need help with setup");
+		expect(screen.queryByText("Discord draft copied.")).not.toBeInTheDocument();
 		await user.type(screen.getByLabelText("What happened?"), "The setup flow stalls after the first prompt.");
 		await user.click(screen.getByRole("button", { name: /copy & open email/i }));
 

--- a/frontend/src/renderer/components/settings/ReportProblemContent.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemContent.tsx
@@ -171,45 +171,45 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 				/>
 			</div>
 
-			<RadioGroup.Root
-				value={selectedOutput}
-				onValueChange={(value) => {
-					setSelectedOutput(value as ReportProblemOutput);
-					clearStatus();
-				}}
-				aria-label={t("report.destination")}
-				className="settings-segment self-start"
-			>
-				{destinations.map((option) => (
-					<RadioGroup.Item key={option.value} value={option.value} className="settings-segment-item">
-						<option.icon className="size-icon-sm" aria-hidden="true" />
-						{option.label}
-					</RadioGroup.Item>
-				))}
-			</RadioGroup.Root>
-
-			{copyError && (
-				<p role="alert" className="text-caption leading-4 text-error">
-					{copyError}
-				</p>
-			)}
-			{copiedLabel && !copyError && (
-				<p className="text-caption leading-4 text-success">{t("report.draftCopied", { label: copiedLabel })}</p>
-			)}
-
-			<div className="flex items-center justify-end gap-3">
-				<Button
-					type="button"
-					variant="footer-primary"
-					className="rounded-md"
-					disabled={!canSubmit}
-					onClick={() => {
-						if (!canSubmit) return;
-						void copyDraft();
-					}}
-				>
-					{destination.action}
-				</Button>
+			<div className="flex flex-col gap-2">
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<RadioGroup.Root
+						value={selectedOutput}
+						onValueChange={(value) => {
+							setSelectedOutput(value as ReportProblemOutput);
+							clearStatus();
+						}}
+						aria-label={t("report.destination")}
+						className="settings-segment self-start"
+					>
+						{destinations.map((option) => (
+							<RadioGroup.Item key={option.value} value={option.value} className="settings-segment-item">
+								<option.icon className="size-icon-sm" aria-hidden="true" />
+								{option.label}
+							</RadioGroup.Item>
+						))}
+					</RadioGroup.Root>
+					<Button
+						type="button"
+						variant="footer-primary"
+						className="shrink-0 rounded-md"
+						disabled={!canSubmit}
+						onClick={() => {
+							if (!canSubmit) return;
+							void copyDraft();
+						}}
+					>
+						{destination.action}
+					</Button>
+				</div>
+				{copyError ? (
+					<p role="alert" className="text-caption leading-4 text-error">
+						{copyError}
+					</p>
+				) : null}
+				{copiedLabel && !copyError ? (
+					<p className="text-caption leading-4 text-success">{t("report.draftCopied", { label: copiedLabel })}</p>
+				) : null}
 			</div>
 		</div>
 	);

--- a/frontend/src/renderer/components/settings/ReportProblemContent.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemContent.tsx
@@ -1,4 +1,3 @@
-import { RadioGroup } from "radix-ui";
 import { useTranslation } from "react-i18next";
 import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import {
@@ -11,6 +10,7 @@ import {
 import { aoBridge } from "../../lib/bridge";
 import { captureRendererEvent } from "../../lib/telemetry";
 import { Button } from "../ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 type DestinationIconProps = {
 	className?: string;
@@ -66,7 +66,6 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 	const titleId = useId();
 	const detailsId = useId();
 	const titleRef = useRef<HTMLInputElement>(null);
-	const [selectedOutput, setSelectedOutput] = useState<ReportProblemOutput>("github");
 	const [summary, setSummary] = useState("");
 	const [details, setDetails] = useState("");
 	const [copiedOutput, setCopiedOutput] = useState<ReportProblemOutput | null>(null);
@@ -79,7 +78,6 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 		if (!active) {
 			setSummary("");
 			setDetails("");
-			setSelectedOutput("github");
 			setCopiedOutput(null);
 			setCopyError(null);
 			return;
@@ -95,8 +93,6 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 	}, [active]);
 
 	const input = { summary, details };
-	const draft = formatReportProblemDraft(input, diagnostics, selectedOutput);
-	const destination = destinations.find((option) => option.value === selectedOutput) ?? destinations[0];
 	const canSubmit = summary.trim().length > 0 && details.trim().length > 0;
 
 	const clearStatus = () => {
@@ -104,10 +100,10 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 		setCopyError(null);
 	};
 
-	const copyDraft = async () => {
+	const copyDraft = async (output: ReportProblemOutput) => {
 		if (!canSubmit) return;
 		setCopyError(null);
-		const output = selectedOutput;
+		const draft = formatReportProblemDraft(input, diagnostics, output);
 		try {
 			await aoBridge.clipboard.writeText(draft);
 			const destinationUrl = reportProblemDestinationUrl(input, diagnostics, output);
@@ -117,7 +113,6 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 			setCopiedOutput(output);
 			setSummary("");
 			setDetails("");
-			setSelectedOutput("github");
 			void captureRendererEvent("ao.renderer.support_submitted", { destination: output, outcome: "succeeded" });
 		} catch (err) {
 			setCopyError(err instanceof Error ? err.message : t("report.copyFailed"));
@@ -132,7 +127,7 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 			onKeyDown={(event) => {
 				if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
 					event.preventDefault();
-					void copyDraft();
+					void copyDraft("github");
 				}
 			}}
 		>
@@ -145,7 +140,7 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 				<input
 					ref={titleRef}
 					id={titleId}
-					className="settings-field-control h-(--size-settings-action-height)"
+					className="settings-field-control h-(--size-settings-action-height) rounded-md!"
 					value={summary}
 					onChange={(event) => {
 						setSummary(event.target.value);
@@ -161,7 +156,7 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 				</label>
 				<textarea
 					id={detailsId}
-					className="settings-field-control min-h-(--size-textarea-min) resize-y py-2.5"
+					className="settings-field-control min-h-(--size-textarea-min) resize-none overflow-y-auto py-2.5 rounded-md!"
 					value={details}
 					onChange={(event) => {
 						setDetails(event.target.value);
@@ -171,37 +166,7 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 				/>
 			</div>
 
-			<div className="flex flex-col gap-2">
-				<div className="flex flex-wrap items-center justify-between gap-2">
-					<RadioGroup.Root
-						value={selectedOutput}
-						onValueChange={(value) => {
-							setSelectedOutput(value as ReportProblemOutput);
-							clearStatus();
-						}}
-						aria-label={t("report.destination")}
-						className="settings-segment self-start"
-					>
-						{destinations.map((option) => (
-							<RadioGroup.Item key={option.value} value={option.value} className="settings-segment-item">
-								<option.icon className="size-icon-sm" aria-hidden="true" />
-								{option.label}
-							</RadioGroup.Item>
-						))}
-					</RadioGroup.Root>
-					<Button
-						type="button"
-						variant="footer-primary"
-						className="shrink-0 rounded-md"
-						disabled={!canSubmit}
-						onClick={() => {
-							if (!canSubmit) return;
-							void copyDraft();
-						}}
-					>
-						{destination.action}
-					</Button>
-				</div>
+			<div role="group" aria-label={t("report.destination")} className="flex flex-wrap items-center justify-end gap-3">
 				{copyError ? (
 					<p role="alert" className="text-caption leading-4 text-error">
 						{copyError}
@@ -210,6 +175,28 @@ export function ReportProblemContent({ active }: { active: boolean }) {
 				{copiedLabel && !copyError ? (
 					<p className="text-caption leading-4 text-success">{t("report.draftCopied", { label: copiedLabel })}</p>
 				) : null}
+				<div className="flex items-center gap-1.5">
+					{destinations.map((option) => (
+						<Tooltip key={option.value}>
+							<TooltipTrigger asChild>
+								<Button
+									type="button"
+									variant="footer"
+									className="size-(--size-settings-action-height) shrink-0 rounded-md! p-0"
+									disabled={!canSubmit}
+									aria-label={option.action}
+									onClick={() => {
+										if (!canSubmit) return;
+										void copyDraft(option.value);
+									}}
+								>
+									<option.icon className="size-icon-sm" aria-hidden="true" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>{option.action}</TooltipContent>
+						</Tooltip>
+					))}
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Move the Help report copy/submit button onto the same row as the destination picker
- Keep success/error feedback directly below that row

## Test plan
- [x] `GlobalSettingsForm.test.tsx`
- [ ] Open Settings → Help and confirm the submit button sits beside the destination tabs
- [ ] Submit a report via GitHub, Discord, and Email — behavior unchanged

## image
<img width="954" height="633" alt="image" src="https://github.com/user-attachments/assets/35151f63-1a89-45e3-b1c3-2b8b0fa92f8b" />
<img width="1157" height="822" alt="image" src="https://github.com/user-attachments/assets/b5b2bfc5-691f-4300-86b0-da3fc8003d67" />
