### PR TITLE
fix: harden contextual terminal shortcut handling

### DIFF
--- a/frontend/src/renderer/components/KeyboardShortcutsDialog.test.tsx
+++ b/frontend/src/renderer/components/KeyboardShortcutsDialog.test.tsx
@@ -27,6 +27,13 @@ describe("KeyboardShortcutsDialog", () => {
 		expect(screen.getByLabelText("Ctrl+PageDown")).toBeInTheDocument();
 	});
 
+	it("explains that the new-terminal shortcut is contextual", () => {
+		render(<KeyboardShortcutsDialog isMac={false} onOpenChange={vi.fn()} open />);
+
+		expect(screen.getByText("New terminal")).toBeInTheDocument();
+		expect(screen.getByText("Available in worker sessions and the Terminals view")).toBeInTheDocument();
+	});
+
 	it("uses macOS key labels when requested", () => {
 		render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} isMac />);
 

--- a/frontend/src/renderer/components/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/renderer/components/KeyboardShortcutsDialog.tsx
@@ -6,7 +6,7 @@ import {
 } from "../../shared/shortcuts";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
-import { shortcutCategoryLabelKeys, shortcutLabelKeys } from "../i18n/key-maps";
+import { shortcutCategoryLabelKeys, shortcutDescriptionKeys, shortcutLabelKeys } from "../i18n/key-maps";
 import type { AppShortcutId, ShortcutCategory } from "../../shared/shortcuts";
 import { useCommandPaletteEnabled } from "../hooks/useCommandPaletteEnabled";
 import { useKeybindingsStore } from "../stores/keybindings-store";
@@ -21,6 +21,10 @@ function shortcutCategoryLabel(category: ShortcutCategory, t: TFunction): string
 	return t(shortcutCategoryLabelKeys[category]);
 }
 
+function shortcutDescription(id: AppShortcutId, t: TFunction): string | undefined {
+	const key = shortcutDescriptionKeys[id];
+	return key ? t(key) : undefined;
+}
 
 type KeyboardShortcutsDialogProps = {
 	open: boolean;
@@ -69,9 +73,18 @@ export function KeyboardShortcutsDialog({
 									{shortcutCategoryLabel(category, t)}
 								</h2>
 								<div className="flex flex-col">
-									{shortcuts.map((shortcut) => (
-										<div className="flex min-h-11 items-center justify-between gap-5 py-1.5" key={shortcut.id}>
-											<p className="min-w-0 text-control font-medium text-foreground">{shortcutLabel(shortcut.id, t)}</p>
+									{shortcuts.map((shortcut) => {
+										const description = shortcutDescription(shortcut.id, t);
+										return (
+											<div className="flex min-h-11 items-center justify-between gap-5 py-1.5" key={shortcut.id}>
+											<div className="min-w-0">
+												<p className="text-control font-medium text-foreground">{shortcutLabel(shortcut.id, t)}</p>
+												{description ? (
+													<p className="mt-0.5 text-caption text-muted-foreground">
+														{description}
+													</p>
+												) : null}
+											</div>
 											<div className="flex shrink-0 flex-col items-end gap-1">
 												{effectiveShortcutBindings(shortcut.id, isMac, overrides).map((binding, bindingIndex) => {
 													const keys = shortcutBindingKeys(binding, isMac);
@@ -93,8 +106,9 @@ export function KeyboardShortcutsDialog({
 													);
 												})}
 											</div>
-										</div>
-									))}
+											</div>
+										);
+									})}
 								</div>
 							</section>
 						);

--- a/frontend/src/renderer/hooks/useShellTerminals.test.tsx
+++ b/frontend/src/renderer/hooks/useShellTerminals.test.tsx
@@ -77,6 +77,88 @@ beforeEach(() => {
 });
 
 describe("useOpenShellTerminal", () => {
+	it("publishes and selects a distinct optimistic shell before the daemon responds", async () => {
+		let finishOpen!: (result: { data: { shellTerminal: ShellTerminal } }) => void;
+		postMock.mockReturnValue(new Promise((resolve) => (finishOpen = resolve)));
+		const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		queryClient.setQueryData(shellTerminalsQueryKey, []);
+		const onSuccess = vi.fn();
+		const { result } = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
+
+		let optimisticShell!: ShellTerminal;
+		act(() => {
+			optimisticShell = result.current.open({ sessionId: "session-1" }, { onSuccess });
+		});
+
+		expect(optimisticShell).toMatchObject({
+			handleId: expect.stringMatching(/^pending-shell:/),
+			optimistic: true,
+			sessionId: "session-1",
+			title: "Terminal 1",
+		});
+		expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([optimisticShell]);
+
+		const openedShell = { ...shells[0], sessionId: "session-1", title: optimisticShell.title };
+		act(() => finishOpen({ data: { shellTerminal: openedShell } }));
+
+		await waitFor(() => expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([openedShell]));
+		expect(onSuccess).toHaveBeenCalledWith(openedShell, optimisticShell);
+	});
+
+	it("reconciles concurrent opens independently when responses finish out of order", async () => {
+		const finishOpen: Array<(result: { data: { shellTerminal: ShellTerminal } }) => void> = [];
+		postMock.mockImplementation(() => new Promise((resolve) => finishOpen.push(resolve)));
+		const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		queryClient.setQueryData(shellTerminalsQueryKey, []);
+		const firstSuccess = vi.fn();
+		const secondSuccess = vi.fn();
+		const { result } = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
+
+		let firstOptimistic!: ShellTerminal;
+		let secondOptimistic!: ShellTerminal;
+		act(() => {
+			firstOptimistic = result.current.open({}, { onSuccess: firstSuccess });
+			secondOptimistic = result.current.open({}, { onSuccess: secondSuccess });
+		});
+
+		expect(firstOptimistic.handleId).not.toBe(secondOptimistic.handleId);
+		expect([firstOptimistic.title, secondOptimistic.title]).toEqual(["Terminal 1", "Terminal 2"]);
+		expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([firstOptimistic, secondOptimistic]);
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+
+		const firstOpened = { ...shells[0], title: firstOptimistic.title };
+		const secondOpened = { ...shells[1], title: secondOptimistic.title };
+		act(() => finishOpen[1]?.({ data: { shellTerminal: secondOpened } }));
+		await waitFor(() =>
+			expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([firstOptimistic, secondOpened]),
+		);
+		act(() => finishOpen[0]?.({ data: { shellTerminal: firstOpened } }));
+
+		await waitFor(() => expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([firstOpened, secondOpened]));
+		expect(firstSuccess).toHaveBeenCalledWith(firstOpened, firstOptimistic);
+		expect(secondSuccess).toHaveBeenCalledWith(secondOpened, secondOptimistic);
+	});
+
+	it("removes only the failed optimistic shell and reports its matching context", async () => {
+		let finishOpen!: (result: { error: unknown }) => void;
+		postMock.mockReturnValue(new Promise((resolve) => (finishOpen = resolve)));
+		const queryClient = queryClientWithShells();
+		const onError = vi.fn();
+		const { result } = renderHook(() => useOpenShellTerminal(), { wrapper: wrapper(queryClient) });
+
+		let optimisticShell!: ShellTerminal;
+		act(() => {
+			optimisticShell = result.current.open({}, { onError });
+		});
+		expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual([...shells, optimisticShell]);
+
+		const error = { code: "SHELL_TERMINAL_OPEN_FAILED" };
+		act(() => finishOpen({ error }));
+
+		await waitFor(() => expect(queryClient.getQueryData(shellTerminalsQueryKey)).toEqual(shells));
+		expect(onError).toHaveBeenCalledWith(error, optimisticShell);
+	});
+
 	it("publishes the returned shell immediately without waiting for a list refetch", async () => {
 		const shell = shells[0];
 		postMock.mockResolvedValue({

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -82,8 +82,14 @@ export function useShellTerminals() {
 }
 
 export type OpenShellTerminalInput = { projectId?: string; sessionId?: string; shell?: string };
-type OpenShellTerminalMutationInput = OpenShellTerminalInput & { optimisticShell?: ShellTerminal };
-type OpenShellTerminalCallbacks = { onSuccess?: (shell: ShellTerminal) => void };
+type OpenShellTerminalCallbacks = {
+	onSuccess?: (shell: ShellTerminal, optimisticShell: ShellTerminal) => void;
+	onError?: (error: unknown, optimisticShell: ShellTerminal) => void;
+};
+type OpenShellTerminalMutationInput = OpenShellTerminalInput & {
+	optimisticShell?: ShellTerminal;
+	callbacks?: OpenShellTerminalCallbacks;
+};
 
 function nextShellTerminalTitle(terminals: ShellTerminal[]): string {
 	let maxNumber = 0;
@@ -159,24 +165,26 @@ export function useOpenShellTerminal() {
 				input.optimisticShell ??
 				createOptimisticShellTerminal(input, queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? []);
 			addOptimisticShell(queryClient, optimisticShell);
-			return { optimisticHandleId: optimisticShell.handleId };
+			return { optimisticShell };
 		},
-		onSuccess: (shell, _input, context) => {
+		onSuccess: (shell, input, context) => {
 			// Replace, rather than append to, the tab that was visible while the POST
 			// ran. This preserves selection and prevents a duplicate tab flash.
 			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) => {
 				if (current?.some((candidate) => candidate.handleId === shell.handleId)) return current;
-				const optimisticHandleId = context?.optimisticHandleId;
+				const optimisticHandleId = context?.optimisticShell.handleId;
 				const index = current?.findIndex((candidate) => candidate.handleId === optimisticHandleId) ?? -1;
 				if (index < 0) return [...(current ?? []), shell];
 				return current?.map((candidate, candidateIndex) => (candidateIndex === index ? shell : candidate)) ?? [shell];
 			});
+			if (context?.optimisticShell) input.callbacks?.onSuccess?.(shell, context.optimisticShell);
 			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
 		},
-		onError: (error, _input, context) => {
+		onError: (error, input, context) => {
 			queryClient.setQueryData<ShellTerminal[]>(shellTerminalsQueryKey, (current) =>
-				current?.filter((shell) => shell.handleId !== context?.optimisticHandleId),
+				current?.filter((shell) => shell.handleId !== context?.optimisticShell.handleId),
 			);
+			if (context?.optimisticShell) input.callbacks?.onError?.(error, context.optimisticShell);
 			console.error("Failed to open shell terminal:", error);
 			if (isWindowsPlatform() && apiErrorCode(error) === "SHELL_TERMINAL_SHELL_UNAVAILABLE") {
 				void useTerminalShellStore.getState().setPreference({ kind: "auto" });
@@ -196,7 +204,11 @@ export function useOpenShellTerminal() {
 			queryClient.getQueryData<ShellTerminal[]>(shellTerminalsQueryKey) ?? [],
 		);
 		addOptimisticShell(queryClient, optimisticShell);
-		mutation.mutate({ ...input, optimisticShell }, callbacks);
+		// Keep callbacks with their mutation input instead of mutate's per-call
+		// observer. TanStack replaces that observer on consecutive mutate calls;
+		// carrying them here guarantees every rapidly opened shell reconciles its
+		// own optimistic tab even when responses complete out of order.
+		mutation.mutate({ ...input, optimisticShell, callbacks });
 		return optimisticShell;
 	};
 

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -961,6 +961,7 @@
 	"shortcut.movedBody": "{{binding}} von {{from}} nach {{to}} verschoben",
 	"shortcut.new-session": "Neue Sitzung",
 	"shortcut.new-shell-terminal": "Neues Terminal",
+	"shortcut.new-shell-terminal-context": "In Arbeitssitzungen und in der Terminalansicht verfügbar",
 	"shortcut.next-session": "Nächste Sitzung",
 	"shortcut.next-tab": "Nächster Tab",
 	"shortcut.noMatching": "Keine passenden Befehle.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -979,6 +979,7 @@
 	"shortcut.movedBody": "{{binding}} moved from {{from}} to {{to}}",
 	"shortcut.new-session": "New session",
 	"shortcut.new-shell-terminal": "New terminal",
+	"shortcut.new-shell-terminal-context": "Available in worker sessions and the Terminals view",
 	"shortcut.next-session": "Next session",
 	"shortcut.next-tab": "Next tab",
 	"shortcut.noMatching": "No matching commands.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -971,6 +971,7 @@
 	"shortcut.movedBody": "{{binding}} movido de {{from}} a {{to}}",
 	"shortcut.new-session": "Nueva sesión",
 	"shortcut.new-shell-terminal": "Nuevo terminal",
+	"shortcut.new-shell-terminal-context": "Disponible en sesiones de trabajo y en la vista Terminales",
 	"shortcut.next-session": "Sesión siguiente",
 	"shortcut.next-tab": "Pestaña siguiente",
 	"shortcut.noMatching": "No hay comandos coincidentes.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -971,6 +971,7 @@
 	"shortcut.movedBody": "{{binding}} déplacé de {{from}} vers {{to}}",
 	"shortcut.new-session": "Nouvelle session",
 	"shortcut.new-shell-terminal": "Nouveau terminal",
+	"shortcut.new-shell-terminal-context": "Disponible dans les sessions de travail et la vue Terminaux",
 	"shortcut.next-session": "Session suivante",
 	"shortcut.next-tab": "Onglet suivant",
 	"shortcut.noMatching": "Aucune commande correspondante.",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -961,6 +961,7 @@
 	"shortcut.movedBody": "{{binding}} を {{from}} から {{to}} に移動しました",
 	"shortcut.new-session": "新しいセッション",
 	"shortcut.new-shell-terminal": "新しいターミナル",
+	"shortcut.new-shell-terminal-context": "ワーカーセッションとターミナル画面で使用できます",
 	"shortcut.next-session": "次のセッション",
 	"shortcut.next-tab": "次のタブ",
 	"shortcut.noMatching": "一致するコマンドがありません。",

--- a/frontend/src/renderer/i18n/key-maps.ts
+++ b/frontend/src/renderer/i18n/key-maps.ts
@@ -21,6 +21,11 @@ export const shortcutLabelKeys: Record<AppShortcutId, MessageKey> = {
 	"toggle-browser-devtools": "titlebar.devtools",
 };
 
+/** Optional scope guidance for shortcuts that are intentionally contextual. */
+export const shortcutDescriptionKeys: Partial<Record<AppShortcutId, MessageKey>> = {
+	"new-shell-terminal": "shortcut.new-shell-terminal-context",
+};
+
 export const shortcutCategoryLabelKeys: Record<ShortcutCategory, MessageKey> = {
 	General: "shortcut.category.general",
 	Navigation: "shortcut.category.navigation",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -961,6 +961,7 @@
 	"shortcut.movedBody": "{{binding}}을(를) {{from}}에서 {{to}}(으)로 이동했습니다",
 	"shortcut.new-session": "새 세션",
 	"shortcut.new-shell-terminal": "새 터미널",
+	"shortcut.new-shell-terminal-context": "작업자 세션 및 터미널 보기에서 사용할 수 있습니다",
 	"shortcut.next-session": "다음 세션",
 	"shortcut.next-tab": "다음 탭",
 	"shortcut.noMatching": "일치하는 명령이 없습니다.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -971,6 +971,7 @@
 	"shortcut.movedBody": "{{binding}} movido de {{from}} para {{to}}",
 	"shortcut.new-session": "Nova sessão",
 	"shortcut.new-shell-terminal": "Novo terminal",
+	"shortcut.new-shell-terminal-context": "Disponível em sessões de trabalho e na visualização Terminais",
 	"shortcut.next-session": "Próxima sessão",
 	"shortcut.next-tab": "Próxima aba",
 	"shortcut.noMatching": "Nenhum comando correspondente.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -962,6 +962,7 @@
 	"shortcut.movedBody": "{{binding}} 已从 {{from}} 移至 {{to}}",
 	"shortcut.new-session": "新建会话",
 	"shortcut.new-shell-terminal": "新建终端",
+	"shortcut.new-shell-terminal-context": "可在工作会话和终端视图中使用",
 	"shortcut.next-session": "下一个会话",
 	"shortcut.next-tab": "下一个标签页",
 	"shortcut.noMatching": "没有匹配的命令。",

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -22,7 +22,7 @@ import { WindowTitlebar } from "../components/WindowTitlebar";
 import { TerminalCacheProvider } from "../components/TerminalPane";
 import { agentModelsQueryOptions } from "../hooks/useAgentModelsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
-import { useOpenShellTerminal } from "../hooks/useShellTerminals";
+import { type OpenShellTerminalInput, useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
@@ -46,7 +46,7 @@ import {
 } from "../lib/platform";
 import { sidebarIsCompact, sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "../stores/ui-store";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
-import { sessionIsActive, toProjectKind, type WorkspaceSummary } from "../types/workspace";
+import { isOrchestratorSession, sessionIsActive, toProjectKind, type WorkspaceSummary } from "../types/workspace";
 import type { components } from "../../api/schema";
 import { useAgentInventoryTelemetry } from "../hooks/useAgentInventoryTelemetry";
 
@@ -83,6 +83,32 @@ export function createProjectConfig(input: CreateProjectConfigInput): components
 		orchestrator: { agent: input.orchestratorAgent as components["schemas"]["RoleOverride"]["agent"] },
 		...(input.trackerIntake ? { trackerIntake: input.trackerIntake } : {}),
 	};
+}
+
+type ShellTerminalRouteParams = { projectId?: string; sessionId?: string };
+
+/**
+ * Resolve the exact terminal scope at shortcut-dispatch time. The shortcut is
+ * intentionally contextual: standalone terminals and worker sessions expose
+ * it, while boards, settings, and orchestrator sessions do not. Unknown
+ * sessions remain eligible so the existing backend session gate stays the
+ * authority during workspace refreshes.
+ */
+function shellTerminalShortcutTarget(
+	routeParams: ShellTerminalRouteParams,
+	workspaces: WorkspaceSummary[],
+	isTerminalsRoute: boolean,
+): OpenShellTerminalInput | null {
+	if (routeParams.sessionId) {
+		const session = workspaces
+			.flatMap((workspace) => workspace.sessions)
+			.find((candidate) => candidate.id === routeParams.sessionId);
+		if (session ? isOrchestratorSession(session) : routeParams.sessionId.endsWith("-orchestrator")) return null;
+		const projectId = routeParams.projectId ?? session?.workspaceId;
+		return { ...(projectId ? { projectId } : {}), sessionId: routeParams.sessionId };
+	}
+	if (!isTerminalsRoute) return null;
+	return routeParams.projectId ? { projectId: routeParams.projectId } : {};
 }
 
 const isMac = isMacPlatform();
@@ -172,7 +198,6 @@ function ShellLayout() {
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const requestCreateProject = useUiStore((state) => state.requestCreateProject);
 	const requestCreateProjectFromPath = useUiStore((state) => state.requestCreateProjectFromPath);
-	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
 	const newShellTerminalNonce = useUiStore((state) => state.newShellTerminalNonce);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
 	const openShellTerminal = useOpenShellTerminal();
@@ -234,7 +259,7 @@ function ShellLayout() {
 	const handledShellNonceRef = useRef(newShellTerminalNonce);
 	const [isKeyboardShortcutsOpen, setIsKeyboardShortcutsOpen] = useState(false);
 	const [isKeyboardShortcutsSettingsOpen, setIsKeyboardShortcutsSettingsOpen] = useState(false);
-	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
+	const routeParams = useParams({ strict: false }) as ShellTerminalRouteParams;
 	useEffect(() => {
 		document.addEventListener("click", handleModifierLinkClick);
 		return () => document.removeEventListener("click", handleModifierLinkClick);
@@ -333,6 +358,37 @@ function ShellLayout() {
 	// whether projects have already been registered.
 	const isHomeRoute = Boolean(matchRoute({ to: "/" }));
 	const isTerminalsRoute = Boolean(matchRoute({ to: "/terminals" }));
+	const shellTerminalShortcutTargetValue = shellTerminalShortcutTarget(routeParams, workspaces, isTerminalsRoute);
+	const openShellTerminalForTarget = useCallback(
+		(target: OpenShellTerminalInput) => {
+			const shell = openShellTerminal.open(target, {
+				onSuccess: (openedShell, optimisticShell) => {
+					// Do not steal focus back if the user selected another tab while
+					// the daemon was opening this shell.
+					if (useUiStore.getState().activeShellTerminalHandleId === optimisticShell.handleId) {
+						setActiveShellTerminal(openedShell.handleId);
+					}
+				},
+				onError: (_error, optimisticShell) => {
+					// The mutation removes only its own optimistic cache entry. Clear
+					// the shared selection only when it still points at that failed tab.
+					if (useUiStore.getState().activeShellTerminalHandleId === optimisticShell.handleId) {
+						setActiveShellTerminal(null);
+					}
+				},
+			});
+			setActiveShellTerminal(shell.handleId);
+			if (!target.sessionId) void navigate({ to: "/terminals" });
+		},
+		[navigate, openShellTerminal, setActiveShellTerminal],
+	);
+	// The bridge subscription is intentionally stable across route transitions.
+	// Its callback reads these refs once per keypress, capturing one coherent
+	// target and avoiding a cleanup/re-subscribe window between app surfaces.
+	const shellTerminalShortcutTargetRef = useRef(shellTerminalShortcutTargetValue);
+	shellTerminalShortcutTargetRef.current = shellTerminalShortcutTargetValue;
+	const openShellTerminalForTargetRef = useRef(openShellTerminalForTarget);
+	openShellTerminalForTargetRef.current = openShellTerminalForTarget;
 	const isSettingsRoute =
 		Boolean(matchRoute({ to: "/settings", fuzzy: true })) ||
 		Boolean(matchRoute({ to: "/projects/$projectId/settings", fuzzy: true }));
@@ -730,55 +786,31 @@ function ShellLayout() {
 		[requestCreateProjectFromPath],
 	);
 
-	// New standalone terminal (⌘T / Ctrl+T), also detected in the main process so it
-	// fires from inside a terminal pane. It raises the same store signal as the
-	// tab-strip + button so the two cannot drift apart.
+	// New terminal (⌘T / Ctrl+T), detected in the main process so it fires from
+	// inside xterm and native Browser views. The stable listener resolves a
+	// capability target at dispatch time: worker sessions and /terminals accept
+	// it; boards, settings, and orchestrator sessions ignore it (#4772).
 	useEffect(
 		() =>
 			aoBridge.app.onNewShellTerminalShortcut(() => {
-				// The project board is not a terminal surface — ⌘T here used to yank
-				// users into the standalone /terminals route (#4772). Sessions and the
-				// dedicated terminals view keep the shortcut; explicit UI can still
-				// open shells from the board.
-				if (routeParams.sessionId || isTerminalsRoute) {
-					requestNewShellTerminal();
-				}
+				const target = shellTerminalShortcutTargetRef.current;
+				if (target) openShellTerminalForTargetRef.current(target);
 			}),
-		[isTerminalsRoute, requestNewShellTerminal, routeParams.sessionId],
+		[],
 	);
 
-	// The shell layout is the single consumer of that signal, because it is the
-	// only component mounted on EVERY route. Owning it here is what lets the
-	// topbar + button and the keyboard shortcut work from a session or the
-	// standalone terminals view alike — when the session view owned it, both
-	// silently did nothing outside a session, since nothing was listening.
-	//
-	// Where the new shell becomes visible depends on where the user is: inside a
-	// session it joins that pane's tab strip; on /terminals it joins that strip;
-	// explicit board UI can still route here without the keyboard shortcut.
+	// Explicit UI still raises the existing store signal. Keep that legacy path
+	// separate from shortcut capability gating so a future board button can
+	// intentionally open /terminals without making the keyboard shortcut global.
 	useEffect(() => {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
-		const shell = openShellTerminal.open(
-			{ projectId: scopedProjectId, sessionId: routeParams.sessionId },
-			{
-				onSuccess: (openedShell) => {
-					setActiveShellTerminal(openedShell.handleId);
-				},
-			},
-		);
-		if (!shell) return;
-		setActiveShellTerminal(shell.handleId);
-		if (!routeParams.sessionId) {
-			void navigate({ to: "/terminals" });
-		}
+		openShellTerminalForTarget({ projectId: scopedProjectId, sessionId: routeParams.sessionId });
 	}, [
 		newShellTerminalNonce,
-		openShellTerminal,
+		openShellTerminalForTarget,
 		scopedProjectId,
 		routeParams.sessionId,
-		navigate,
-		setActiveShellTerminal,
 	]);
 
 	useEffect(

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -19,6 +19,14 @@ const shellMocks = vi.hoisted(() => {
 		routeParams: {} as { projectId?: string; sessionId?: string },
 		routeSearch: {} as Record<string, unknown>,
 		matchRouteTarget: null as string | null,
+		pendingShellSequence: 0,
+		openShellCallbacks: new Map<
+			string,
+			{
+				onSuccess?: (shell: Record<string, unknown>, optimisticShell: Record<string, unknown>) => void;
+				onError?: (error: unknown, optimisticShell: Record<string, unknown>) => void;
+			}
+		>(),
 		workspaces: [] as WorkspaceSummary[],
 		workspaceQuery: {
 			data: [] as WorkspaceSummary[],
@@ -47,15 +55,28 @@ const shellMocks = vi.hoisted(() => {
 			state.newShellTerminalListener = listener;
 			return vi.fn();
 		}),
-		openShellTerminal: vi.fn((input: { projectId?: string; sessionId?: string }) => ({
-			handleId: "pending-shell:test",
-			projectId: input.projectId,
-			sessionId: input.sessionId,
-			workingDir: "",
-			title: "Terminal 1",
-			createdAt: new Date().toISOString(),
-			optimistic: true as const,
-		})),
+		openShellTerminal: vi.fn(
+			(
+				input: { projectId?: string; sessionId?: string },
+				callbacks?: {
+					onSuccess?: (shell: Record<string, unknown>, optimisticShell: Record<string, unknown>) => void;
+					onError?: (error: unknown, optimisticShell: Record<string, unknown>) => void;
+				},
+			) => {
+				state.pendingShellSequence += 1;
+				const shell = {
+					handleId: `pending-shell:${state.pendingShellSequence}`,
+					projectId: input.projectId,
+					sessionId: input.sessionId,
+					workingDir: "",
+					title: `Terminal ${state.pendingShellSequence}`,
+					createdAt: new Date().toISOString(),
+					optimistic: true as const,
+				};
+				state.openShellCallbacks.set(shell.handleId, callbacks ?? {});
+				return shell;
+			},
+		),
 		onOpenSettingsShortcut: vi.fn((listener: () => void) => {
 			state.openSettingsListener = listener;
 			return vi.fn();
@@ -266,6 +287,19 @@ const workspaces = [
 		path: "/two",
 		sessions: [{ id: "sess-cross", workspaceId: "proj-2", status: "working" }],
 	},
+	{
+		id: "proj-orchestrator",
+		name: "Orchestrator Project",
+		path: "/orchestrator",
+		sessions: [
+			{
+				id: "sess-orchestrator",
+				kind: "orchestrator",
+				workspaceId: "proj-orchestrator",
+				status: "working",
+			},
+		],
+	},
 ] as unknown as WorkspaceSummary[];
 
 async function renderShell() {
@@ -299,6 +333,8 @@ beforeEach(() => {
 	shellMocks.onKeyboardShortcutsHelp.mockClear();
 	shellMocks.onNewShellTerminalShortcut.mockClear();
 	shellMocks.openShellTerminal.mockClear();
+	shellMocks.state.openShellCallbacks.clear();
+	shellMocks.state.pendingShellSequence = 0;
 	shellMocks.state.newShellTerminalListener = undefined;
 	shellMocks.onOpenSettingsShortcut.mockClear();
 	shellMocks.onPreviousSessionShortcut.mockClear();
@@ -538,10 +574,14 @@ describe("shell sidebar toggle", () => {
 });
 
 describe("shell new-shell-terminal shortcut subscription", () => {
-	function pressNewShellTerminal() {
+	function newShellTerminalListener() {
 		const listener = shellMocks.state.newShellTerminalListener;
 		if (!listener) throw new Error("new-shell-terminal listener was not registered");
-		act(() => listener());
+		return listener;
+	}
+
+	function pressNewShellTerminal() {
+		act(() => newShellTerminalListener()());
 	}
 
 	// Regression: the shell LAYOUT must own this, not the session view. When the
@@ -553,8 +593,9 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 
 		pressNewShellTerminal();
 
-		expect(useUiStore.getState().newShellTerminalNonce).toBe(1);
+		expect(useUiStore.getState().newShellTerminalNonce).toBe(0);
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledTimes(1);
+		expect(shellMocks.navigate).toHaveBeenCalledWith({ to: "/terminals" });
 	});
 
 	// Regression (#4772): ⌘T on the project board must not yank users into /terminals.
@@ -566,6 +607,30 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 
 		expect(useUiStore.getState().newShellTerminalNonce).toBe(0);
 		expect(shellMocks.openShellTerminal).not.toHaveBeenCalled();
+		expect(shellMocks.navigate).not.toHaveBeenCalled();
+	});
+
+	it("preserves the explicit board action that intentionally opens the Terminals view", async () => {
+		shellMocks.state.routeParams = { projectId: "proj-1" };
+		await renderShell();
+
+		act(() => useUiStore.getState().requestNewShellTerminal());
+
+		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
+			expect.objectContaining({ projectId: "proj-1", sessionId: undefined }),
+			expect.anything(),
+		);
+		expect(shellMocks.navigate).toHaveBeenCalledWith({ to: "/terminals" });
+	});
+
+	it("ignores the shortcut for orchestrator sessions that do not expose a terminal action", async () => {
+		shellMocks.state.routeParams = { sessionId: "sess-orchestrator" };
+		await renderShell();
+
+		pressNewShellTerminal();
+
+		expect(shellMocks.openShellTerminal).not.toHaveBeenCalled();
+		expect(shellMocks.navigate).not.toHaveBeenCalled();
 	});
 
 	// Regression: a terminal opened from a session view must carry the session
@@ -597,15 +662,88 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 		);
 	});
 
-	it("re-fires on a repeat press so a second terminal can be opened", async () => {
+	it("does not collapse two shortcut events delivered in the same render batch", async () => {
 		shellMocks.state.routeParams = { sessionId: "sess-1" };
 		await renderShell();
 
+		act(() => {
+			const listener = newShellTerminalListener();
+			listener();
+			listener();
+		});
+
+		expect(useUiStore.getState().newShellTerminalNonce).toBe(0);
+		expect(shellMocks.openShellTerminal).toHaveBeenCalledTimes(2);
+		expect(shellMocks.openShellTerminal.mock.results.map((result) => result.value.handleId)).toEqual([
+			"pending-shell:1",
+			"pending-shell:2",
+		]);
+	});
+
+	it("keeps one subscription while route capability changes", async () => {
+		shellMocks.state.routeParams = { projectId: "proj-1" };
+		const view = await renderShell();
+
 		pressNewShellTerminal();
+		expect(shellMocks.openShellTerminal).not.toHaveBeenCalled();
+
+		shellMocks.state.routeParams = { sessionId: "sess-1" };
+		view.rerender(
+			<Suspense fallback={null}>
+				<ShellRoute />
+			</Suspense>,
+		);
+		pressNewShellTerminal();
+		expect(shellMocks.openShellTerminal).toHaveBeenCalledTimes(1);
+
+		shellMocks.state.routeParams = { sessionId: "sess-orchestrator" };
+		view.rerender(
+			<Suspense fallback={null}>
+				<ShellRoute />
+			</Suspense>,
+		);
+		pressNewShellTerminal();
+		expect(shellMocks.openShellTerminal).toHaveBeenCalledTimes(1);
+
+		shellMocks.state.routeParams = {};
+		shellMocks.state.matchRouteTarget = "/terminals";
+		view.rerender(
+			<Suspense fallback={null}>
+				<ShellRoute />
+			</Suspense>,
+		);
 		pressNewShellTerminal();
 
-		expect(useUiStore.getState().newShellTerminalNonce).toBe(2);
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledTimes(2);
+		expect(shellMocks.onNewShellTerminalShortcut).toHaveBeenCalledTimes(1);
+	});
+
+	it("reconciles selection only while its own optimistic tab remains active", async () => {
+		shellMocks.state.matchRouteTarget = "/terminals";
+		await renderShell();
+		pressNewShellTerminal();
+
+		const optimisticShell = shellMocks.openShellTerminal.mock.results[0]?.value;
+		expect(useUiStore.getState().activeShellTerminalHandleId).toBe(optimisticShell.handleId);
+		const callbacks = shellMocks.state.openShellCallbacks.get(optimisticShell.handleId);
+		const openedShell = { ...optimisticShell, handleId: "shell:authoritative", optimistic: false };
+		act(() => callbacks?.onSuccess?.(openedShell, optimisticShell));
+		expect(useUiStore.getState().activeShellTerminalHandleId).toBe(openedShell.handleId);
+
+		pressNewShellTerminal();
+		const laterOptimisticShell = shellMocks.openShellTerminal.mock.results[1]?.value;
+		useUiStore.getState().setActiveShellTerminal("shell:user-selected");
+		const laterCallbacks = shellMocks.state.openShellCallbacks.get(laterOptimisticShell.handleId);
+		act(() => laterCallbacks?.onError?.(new Error("open failed"), laterOptimisticShell));
+
+		expect(useUiStore.getState().activeShellTerminalHandleId).toBe("shell:user-selected");
+
+		pressNewShellTerminal();
+		const failedActiveShell = shellMocks.openShellTerminal.mock.results[2]?.value;
+		const failedActiveCallbacks = shellMocks.state.openShellCallbacks.get(failedActiveShell.handleId);
+		act(() => failedActiveCallbacks?.onError?.(new Error("open failed"), failedActiveShell));
+
+		expect(useUiStore.getState().activeShellTerminalHandleId).toBeNull();
 	});
 });
 


### PR DESCRIPTION
Improves #4779
Related to #4772

## Why this is stacked

The canonical issue fix is already open as #4779 on the organization-owned branch `fix/cmd-t-project-board`. This PR targets that branch so the hardening can be merged into #4779 without creating a competing fix against `main`.

## Additional risks covered

- route changes recreated the IPC subscription and left shortcut intent to be consumed later through a global nonce
- two shortcut events delivered in one React batch could collapse into one open
- orchestrator sessions hid the New terminal action but still accepted the keyboard shortcut
- concurrent optimistic opens used per-call mutation callbacks, whose observer can be replaced by a later mutate call
- completion or failure could steal or clear a terminal selection the user had changed while the request was pending
- shortcut help presented New terminal as globally available

## Changes

- resolve an explicit worker-session or standalone terminal target at keypress time
- keep one bridge subscription across board/session/terminals route transitions
- reject the shortcut on boards, settings, and orchestrator sessions
- preserve the existing explicit board/UI signal that intentionally opens `/terminals`
- carry optimistic callbacks with each mutation input so out-of-order opens reconcile independently
- update the active handle only while that mutation's optimistic tab remains selected
- document shortcut scope in all supported locale catalogs

## Legacy safety

- no backend, PTY, persistence, or session-gate changes
- shell creation still uses the existing `useOpenShellTerminal` → `/api/v1/shell-terminals` path
- explicit UI requests retain their existing standalone-terminal behavior
- each failed open removes only its own optimistic cache entry
- rapid presses create distinct optimistic handles and daemon requests

## Validation

Passed locally with Node 24:

- focused Vitest suite: 50 tests passed
- final shell shortcut section: new capability/route/optimistic cases passed; a separate pre-existing workspace-startup test timed out under the Windows/OneDrive runner
- frontend TypeScript typecheck
- E2E TypeScript typecheck
- `git diff --check`

The complete Vitest suite was also attempted locally but existing Windows-only updater, shell-script, packaging, socket, and long-running UI tests timed out. The upstream Linux Frontend workflow remains the authoritative broad gate.