### PR TITLE
fix(cloud): keep terminal WebSockets alive

### DIFF
--- a/cloud/internal/httpapi/terminal_handlers.go
+++ b/cloud/internal/httpapi/terminal_handlers.go
@@ -30,6 +30,8 @@ const (
 	agentTerminalTTL           = 24 * time.Hour
 	terminalInteractionTTL     = 2 * time.Minute
 	terminalInteractionRefresh = 30 * time.Second
+	terminalPingInterval       = 20 * time.Second
+	terminalPingTimeout        = 5 * time.Second
 )
 
 var errTerminalProcessUnavailable = errors.New("terminal process unavailable")
@@ -146,10 +148,15 @@ func (s *Server) connectTerminal(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		writeResult <- s.writeTerminalOutput(ctx, connection, terminal, after, structured, &writeMu)
 	}()
+	pingResult := make(chan error, 1)
+	go func() {
+		pingResult <- keepTerminalAlive(ctx, connection)
+	}()
 
 	select {
 	case err = <-readResult:
 	case err = <-writeResult:
+	case err = <-pingResult:
 	case <-ctx.Done():
 		err = ctx.Err()
 	}
@@ -160,6 +167,28 @@ func (s *Server) connectTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 	status, reason := terminalStreamClose(err, terminal.Kind)
 	_ = connection.Close(status, reason)
+}
+
+// keepTerminalAlive sends protocol-level pings often enough to keep idle
+// terminal connections active through the public load balancer. Browsers
+// answer WebSocket pings automatically while readTerminalInput continuously
+// reads the corresponding pong control frames.
+func keepTerminalAlive(ctx context.Context, connection *websocket.Conn) error {
+	ticker := time.NewTicker(terminalPingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			pingCtx, cancel := context.WithTimeout(ctx, terminalPingTimeout)
+			err := connection.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func (s *Server) refreshTerminalInteraction(ctx context.Context, terminal domain.TerminalSession) {


### PR DESCRIPTION
## Summary
- send protocol-level WebSocket pings every 20 seconds for cloud terminal streams
- bound pong waits to five seconds and close unhealthy streams cleanly
- prevent the ALB 60-second idle timeout from repeatedly disconnecting inactive terminals

## Evidence
The isolated Coder dev control plane showed a successful terminal upgrade followed by an unexpected EOF at exactly 60,005 ms. The public ALB idle timeout is 60 seconds and the terminal stream previously emitted no traffic while idle.

## Tests
- `cd cloud && go test ./...`
- `cd cloud && go vet ./...`

## Risk
Low. The ping goroutine shares the connection through the WebSocket library's documented concurrent-safe methods and is cancelled with the existing terminal context.