### PR TITLE
perf(cloud): launch preinstalled Coder worker

### DIFF
--- a/cloud/coder/README.md
+++ b/cloud/coder/README.md
@@ -1,0 +1,35 @@
+# AO Coder workspace template
+
+This is the reference Docker-backed Coder template for AO Cloud. Its image
+contains release-matched `ao-worker` and `ao` binaries plus the template's
+approved coding harness. The control plane verifies both binary hashes before
+launching them; if a customer has not updated their template yet, or the image
+belongs to an older AO release, bootstrap falls back to the compatible PTY
+upload instead of running mismatched code.
+
+Build the image from the exact control-plane image being deployed:
+
+```bash
+docker build \
+  --build-arg AO_CONTROL_PLANE_IMAGE="$AO_CLOUD_CP_IMAGE" \
+  --tag ao-coder-workspace:local \
+  --file coder/Sandbox.Dockerfile \
+  .
+```
+
+Run that command from `cloud/`. For a Coder deployment whose provisioner uses a
+different Docker host, push the image to an approved registry and change the
+`workspace_image` default in `main.tf` to its immutable reference. The Coder
+host must be able to authenticate to and pull from that registry.
+
+Then publish the directory with the Coder CLI:
+
+```bash
+CODER_URL=https://coder.example.com \
+CODER_SESSION_TOKEN=... \
+coder templates push --yes ao-linux-docker --directory coder
+```
+
+Configure AO with `/home/coder` as the durable root for this reference
+template. A customer's equivalent template can use another mounted path as
+long as its AO connection records that exact path.

--- a/cloud/coder/Sandbox.Dockerfile
+++ b/cloud/coder/Sandbox.Dockerfile
@@ -19,8 +19,9 @@ COPY --from=node-runtime /usr/local/ /usr/local/
 RUN npm install --global "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" && \
     claude --version && \
     mkdir -p /etc/skel/.local/bin && \
-    ln -s "$(readlink -f "$(command -v claude)")" \
-      /etc/skel/.local/bin/claude
+    ln -sfn "$(readlink -f "$(command -v claude)")" \
+      /etc/skel/.local/bin/claude && \
+    test -x /etc/skel/.local/bin/claude
 
 COPY --from=ao-release /ao-worker /usr/local/bin/ao-worker
 COPY --from=ao-release /ao /usr/local/bin/ao

--- a/cloud/coder/Sandbox.Dockerfile
+++ b/cloud/coder/Sandbox.Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# The binaries come from the exact control-plane image that will manage these
+# workspaces. Coder's bootstrap verifies their SHA-256 hashes before using the
+# fast path, so a stale template safely falls back to the PTY upload.
+ARG AO_CONTROL_PLANE_IMAGE=ao-cloud-control-plane:local
+FROM ${AO_CONTROL_PLANE_IMAGE} AS ao-release
+
+FROM node:22-bookworm-slim AS node-runtime
+
+FROM codercom/enterprise-base:ubuntu
+ARG CLAUDE_CODE_VERSION=2.1.228
+USER root
+
+# Keep the normal Coder image/user/sudo contract, while baking the harness that
+# this approved template exposes. Copying the official Node runtime avoids a
+# package-manager install on every workspace start.
+COPY --from=node-runtime /usr/local/ /usr/local/
+RUN npm install --global "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" && \
+    claude --version && \
+    mkdir -p /etc/skel/.local/bin && \
+    ln -s "$(readlink -f "$(command -v claude)")" \
+      /etc/skel/.local/bin/claude
+
+COPY --from=ao-release /ao-worker /usr/local/bin/ao-worker
+COPY --from=ao-release /ao /usr/local/bin/ao
+RUN chmod 0755 /usr/local/bin/ao-worker /usr/local/bin/ao && \
+    sha256sum /usr/local/bin/ao-worker /usr/local/bin/ao \
+      > /usr/local/share/ao-worker.sha256
+
+USER coder

--- a/cloud/coder/main.tf
+++ b/cloud/coder/main.tf
@@ -1,0 +1,118 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}
+
+variable "docker_socket" {
+  default     = ""
+  description = "Optional Docker socket URI"
+  type        = string
+}
+
+variable "workspace_image" {
+  default     = "ao-coder-workspace:local"
+  description = "Approved image containing the release-matched AO worker and coding harness"
+  type        = string
+}
+
+provider "docker" {
+  host = var.docker_socket != "" ? var.docker_socket : null
+}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+resource "coder_agent" "main" {
+  arch = data.coder_provisioner.me.arch
+  os   = "linux"
+
+  startup_script = <<-EOT
+    set -e
+    if [ ! -f ~/.init_done ]; then
+      cp -rT /etc/skel ~
+      touch ~/.init_done
+    fi
+    claude --version
+  EOT
+
+  env = {
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_AUTHOR_EMAIL    = data.coder_workspace_owner.me.email
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_COMMITTER_EMAIL = data.coder_workspace_owner.me.email
+  }
+}
+
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+
+  lifecycle {
+    ignore_changes = all
+  }
+
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
+}
+
+resource "docker_container" "workspace" {
+  count = data.coder_workspace.me.start_count
+  image = var.workspace_image
+
+  name     = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  hostname = data.coder_workspace.me.name
+  entrypoint = [
+    "sh",
+    "-c",
+    replace(coder_agent.main.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal"),
+  ]
+  env = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+}

--- a/cloud/docs/coder-sandbox-provider.md
+++ b/cloud/docs/coder-sandbox-provider.md
@@ -2,8 +2,10 @@
 
 AO Cloud can use a customer-operated Coder deployment as its sandbox compute
 provider. AO creates one Coder workspace per AO session, installs `ao-worker`
-through the workspace's existing `coder_agent`, and keeps the rest of the
-session lifecycle behind the same provider-neutral reconciler used by NodeOps.
+in the approved template image, launches it through the workspace's existing
+`coder_agent`, and keeps the rest of the session lifecycle behind the same
+provider-neutral reconciler used by NodeOps. Older templates remain compatible:
+AO verifies the baked binaries and falls back to the PTY upload on a hash miss.
 
 The first implementation is deployment-scoped: every AO organization on that
 control plane uses the same Coder connection and approved template. It does not
@@ -28,7 +30,7 @@ AO calls these Coder API surfaces:
 | Inspect | `GET /api/v2/workspaces/{id}` |
 | Recover by AO session | `GET /api/v2/users/{owner}/workspace/{name}` |
 | Start, stop, delete | `POST /api/v2/workspaces/{id}/builds` |
-| Install or repair worker | `GET /api/v2/workspaceagents/{agent}/pty` (WebSocket) |
+| Launch or repair worker | `GET /api/v2/workspaceagents/{agent}/pty` (WebSocket) |
 
 For a quick Community Edition pilot, an API token with `coder:all` is bounded by
 the permissions of this ordinary user and is the simplest setup. On Coder
@@ -75,6 +77,14 @@ A first bootstrap writes a session identity marker; a bootstrap after
 stop/start must find the same marker or it fails instead of silently launching
 a fresh agent against an empty filesystem.
 
+For normal startup latency, bake `/usr/local/bin/ao-worker` and
+`/usr/local/bin/ao` from the exact control-plane image into the approved
+workspace image. The reference Dockerfile and Terraform template live under
+`cloud/coder/`. At launch AO compares SHA-256 hashes for both executables with
+the binaries embedded in its own release. A match transfers only the small,
+one-time launch environment; a missing or stale binary uses the full PTY upload
+so template and control-plane rollouts do not have to be perfectly atomic.
+
 Because the worker runs as a separate OS user, bootstrap preserves the durable
 root's existing mode bits while adding traversal-only (`o+x`) access to that
 mount point. It does not make the root listable or readable. Only the derived
@@ -84,8 +94,8 @@ The normal workspace user must have passwordless `sudo` for the pilot
 bootstrap. AO uses it to:
 
 - create the unprivileged `ao-worker` OS user;
-- install the release-pinned `ao-worker` and AO helper binaries under
-  `/usr/local/bin`;
+- install the release-pinned binaries only when the template hash does not
+  match the active control-plane release;
 - create and assign only the derived repository and `.ao` directories to the
   worker user; and
 - launch the worker, which then dials the AO service plane and sends its own
@@ -97,9 +107,10 @@ Code or Codex). Those tools are baked into AO's NodeOps image today; the Coder
 provider deliberately does not mutate a customer's template by installing
 third-party harnesses at session startup.
 
-No worker credential is placed in the PTY URL or command. AO streams a private
-archive over terminal input, writes the launch environment with mode `0600`,
-and deletes that environment file when the worker starts.
+No worker credential is placed in the PTY URL or command. Even on the baked
+fast path, AO streams the private launch environment over terminal input,
+writes it with mode `0600`, and deletes that environment file when the worker
+starts.
 
 For a production rollout, prefer baking the OS user and directories into the
 template or a narrowly scoped install helper over unrestricted passwordless

--- a/cloud/internal/sandbox/coder/client.go
+++ b/cloud/internal/sandbox/coder/client.go
@@ -42,10 +42,14 @@ const (
 	bootstrapFailed     = "__AO_BOOTSTRAP_FAILED__"
 	bootstrapUploadACK  = "__AO_UPLOAD_ACK__"
 	bootstrapUploadDone = "__AO_UPLOAD_DONE__"
+	preinstalledMiss    = "__AO_PREINSTALLED_MISS__"
 	bootstrapResultWait = 2 * time.Minute
 )
 
-var userPattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
+var (
+	userPattern                       = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
+	errPreinstalledWorkerDoesNotMatch = errors.New("coder: preinstalled AO worker does not match")
+)
 
 // Config describes one Coder deployment and the template AO is allowed to use.
 type Config struct {
@@ -389,31 +393,61 @@ func (c *Client) BootstrapWorker(ctx context.Context, id sandbox.ID, bootstrap s
 	if !ok || agent.ID == "" || agent.Status != "connected" || !agent.Health.Healthy {
 		return errors.New("coder: workspace agent is not connected and healthy")
 	}
-	payload, err := bootstrapArchive(bootstrap)
+	// Fast path: an approved template can bake the exact worker and helper from
+	// the control-plane image. Verify both hashes inside the workspace, then send
+	// only the small launch environment through the PTY. A stale or unmodified
+	// customer template explicitly falls through to the full binary upload.
+	launchPayload, err := bootstrapLaunchArchive(bootstrap)
 	if err != nil {
 		return err
 	}
-	encoded := base64.StdEncoding.EncodeToString(payload)
-	command := bootstrapCommand(bootstrap, len(encoded))
 	ptyURL, err := url.Parse(c.baseURL + "/api/v2/workspaceagents/" + url.PathEscape(agent.ID) + "/pty")
 	if err != nil {
 		return fmt.Errorf("coder: build PTY URL: %w", err)
 	}
-	query := ptyURL.Query()
+	if err := c.bootstrapWorkerThroughPTY(ctx, ptyURL, bootstrap, launchPayload, true); err == nil {
+		return nil
+	} else if !errors.Is(err, errPreinstalledWorkerDoesNotMatch) {
+		return fmt.Errorf("coder: launch preinstalled worker: %w", err)
+	}
+
+	payload, err := bootstrapArchive(bootstrap)
+	if err != nil {
+		return err
+	}
+	if err := c.bootstrapWorkerThroughPTY(ctx, ptyURL, bootstrap, payload, false); err != nil {
+		return fmt.Errorf("coder: bootstrap worker after PTY retries: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) bootstrapWorkerThroughPTY(
+	ctx context.Context,
+	ptyURL *url.URL,
+	bootstrap sandbox.WorkerBootstrap,
+	payload []byte,
+	preinstalled bool,
+) error {
+	encoded := base64.StdEncoding.EncodeToString(payload)
+	attemptURL := *ptyURL
+	query := attemptURL.Query()
 	query.Set("width", "120")
 	query.Set("height", "40")
-	query.Set("command", command)
+	query.Set("command", bootstrapCommandForArchive(bootstrap, len(encoded), preinstalled))
 	// Bootstrap is a short-lived, non-interactive command. The buffered backend
 	// preserves the final result after the upload while AO keeps the PTY open.
 	query.Set("backend_type", "buffered")
-	ptyURL.RawQuery = query.Encode()
+	attemptURL.RawQuery = query.Encode()
 	const bootstrapAttempts = 5
 	var lastErr error
 	for attempt := 0; attempt < bootstrapAttempts; attempt++ {
-		if err := c.bootstrapThroughPTY(ctx, ptyURL, encoded); err == nil {
+		if err := c.bootstrapThroughPTY(ctx, &attemptURL, encoded); err == nil {
 			return nil
 		} else {
 			lastErr = err
+		}
+		if errors.Is(lastErr, errPreinstalledWorkerDoesNotMatch) {
+			return lastErr
 		}
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -428,7 +462,7 @@ func (c *Client) BootstrapWorker(ctx context.Context, id sandbox.ID, bootstrap s
 			}
 		}
 	}
-	return fmt.Errorf("coder: bootstrap worker after PTY retries: %w", lastErr)
+	return lastErr
 }
 
 func (c *Client) bootstrapThroughPTY(ctx context.Context, ptyURL *url.URL, encoded string) error {
@@ -517,6 +551,9 @@ func waitForBootstrapReady(ctx context.Context, output <-chan ptyOutput) error {
 			}
 			if strings.Contains(response.data, bootstrapReady) {
 				return nil
+			}
+			if strings.Contains(response.data, preinstalledMiss) {
+				return errPreinstalledWorkerDoesNotMatch
 			}
 			if strings.Contains(response.data, bootstrapFailed) {
 				return fmt.Errorf("coder: worker bootstrap failed before upload: %s", sanitizePTYOutput(response.data))
@@ -624,6 +661,14 @@ func safeAbsolutePath(value string) bool {
 }
 
 func bootstrapArchive(bootstrap sandbox.WorkerBootstrap) ([]byte, error) {
+	return buildBootstrapArchive(bootstrap, true)
+}
+
+func bootstrapLaunchArchive(bootstrap sandbox.WorkerBootstrap) ([]byte, error) {
+	return buildBootstrapArchive(bootstrap, false)
+}
+
+func buildBootstrapArchive(bootstrap sandbox.WorkerBootstrap, includeBinaries bool) ([]byte, error) {
 	var compressed bytes.Buffer
 	gzipWriter := gzip.NewWriter(&compressed)
 	tarWriter := tar.NewWriter(gzipWriter)
@@ -632,11 +677,17 @@ func bootstrapArchive(bootstrap sandbox.WorkerBootstrap) ([]byte, error) {
 		mode int64
 		data []byte
 	}{
-		{name: "ao-worker", mode: 0o700, data: bootstrap.Binary},
 		{name: "worker.env", mode: 0o600, data: []byte(environmentFile(bootstrap.Environment))},
 		{name: "launch.sh", mode: 0o700, data: []byte("#!/bin/sh\nset -eu\nprintf '%s\\n' \"$$\" >\"$3\"\nset -a\n. \"$1\"\nset +a\nrm -f \"$1\"\nexec \"$2\"\n")},
 	}
-	if len(bootstrap.HelperBinary) > 0 {
+	if includeBinaries {
+		files = append(files, struct {
+			name string
+			mode int64
+			data []byte
+		}{name: "ao-worker", mode: 0o700, data: bootstrap.Binary})
+	}
+	if includeBinaries && len(bootstrap.HelperBinary) > 0 {
 		files = append(files, struct {
 			name string
 			mode int64
@@ -677,6 +728,14 @@ func environmentFile(environment map[string]string) string {
 }
 
 func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) string {
+	return bootstrapCommandForArchive(bootstrap, encodedLength, false)
+}
+
+func bootstrapCommandForArchive(
+	bootstrap sandbox.WorkerBootstrap,
+	encodedLength int,
+	preinstalled bool,
+) string {
 	workerUser := strings.TrimSpace(bootstrap.User)
 	workerDestination := strings.TrimSpace(bootstrap.Destination)
 	layout, _ := sandbox.NewCoderWorkspaceLayout(bootstrap.DurableRoot)
@@ -684,15 +743,34 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 	if bootstrap.RequireDurableIdentity {
 		requireIdentity = "1"
 	}
-	helperInstall := ""
+	binaryPreparation := "sudo -n install -m 0755 \"$stage/ao-worker\" " + shellQuote(workerDestination) + "\n"
 	if len(bootstrap.HelperBinary) > 0 {
-		helperInstall = "sudo -n install -m 0755 \"$stage/ao\" " + shellQuote(bootstrap.HelperDestination) + "\n"
+		binaryPreparation += "sudo -n install -m 0755 \"$stage/ao\" " + shellQuote(bootstrap.HelperDestination) + "\n"
+	}
+	preinstalledCheck := ""
+	if preinstalled {
+		binaryPreparation = ""
+		workerHash := sha256.Sum256(bootstrap.Binary)
+		guards := []string{
+			"[ -x " + shellQuote(workerDestination) + " ]",
+			"[ \"$(sha256sum " + shellQuote(workerDestination) + " | cut -d' ' -f1)\" = " +
+				shellQuote(hex.EncodeToString(workerHash[:])) + " ]",
+		}
+		if len(bootstrap.HelperBinary) > 0 {
+			helperHash := sha256.Sum256(bootstrap.HelperBinary)
+			guards = append(guards,
+				"[ -x "+shellQuote(bootstrap.HelperDestination)+" ]",
+				"[ \"$(sha256sum "+shellQuote(bootstrap.HelperDestination)+" | cut -d' ' -f1)\" = "+
+					shellQuote(hex.EncodeToString(helperHash[:]))+" ]",
+			)
+		}
+		preinstalledCheck = "if ! { " + strings.Join(guards, " && ") + "; }; then echo " + preinstalledMiss + "; exit 0; fi\n"
 	}
 	workerEnvironment := path.Join(layout.WorkerData, "worker.env")
 	workerLauncher := path.Join(layout.WorkerData, "launch.sh")
 	workerLog := path.Join(layout.WorkerData, "worker.log")
 	workerPID := path.Join(layout.WorkerData, "worker.pid")
-	script := "set -eu\n" +
+	script := "set -eu\n" + preinstalledCheck +
 		"stage=$(mktemp -d)\nencoded=\"$stage/payload.b64\"\n" +
 		"trap 'code=$?; stty echo icanon 2>/dev/null || true; echo " + bootstrapFailed + ":$code' EXIT\n" +
 		"target=" + strconv.Itoa(encodedLength) + "\nexpected=0\nreceived=0\n: >\"$encoded\"\nstty -echo icanon 2>/dev/null || true\necho " + bootstrapReady + "\n" +
@@ -720,7 +798,7 @@ func bootstrapCommand(bootstrap sandbox.WorkerBootstrap, encodedLength int) stri
 		"else\n" +
 		"  printf '%s\\n' " + shellQuote(strings.TrimSpace(bootstrap.DurableIdentity)) + " | sudo -n tee \"$identity_file\" >/dev/null\nfi\n" +
 		"sudo -n chown -R " + shellQuote(workerUser+":"+workerUser) + " " + shellQuote(layout.Repository) + " " + shellQuote(path.Dir(layout.WorkerData)) + "\n" +
-		"sudo -n install -m 0755 \"$stage/ao-worker\" " + shellQuote(workerDestination) + "\n" + helperInstall +
+		binaryPreparation +
 		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0600 \"$stage/worker.env\" " + shellQuote(workerEnvironment) + "\n" +
 		"sudo -n install -o " + shellQuote(workerUser) + " -g " + shellQuote(workerUser) + " -m 0700 \"$stage/launch.sh\" " + shellQuote(workerLauncher) + "\n" +
 		"sudo -n pkill -u " + shellQuote(workerUser) + " -f " + shellQuote(workerDestination) + " 2>/dev/null || true\n" +

--- a/cloud/internal/sandbox/coder/client_test.go
+++ b/cloud/internal/sandbox/coder/client_test.go
@@ -4,7 +4,9 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -170,6 +172,7 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 
 	const secret = "TOP_SECRET_WORKER_TOKEN"
 	archiveResult := make(chan map[string]string, 1)
+	preinstalledChecks := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		switch {
 		case request.URL.Path == "/api/v2/workspaces/"+testWorkspaceID:
@@ -185,6 +188,19 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 				t.Errorf("PTY backend_type = %q, want buffered", got)
 			}
 			command := request.URL.Query().Get("command")
+			if strings.Contains(command, preinstalledMiss) {
+				connection, err := websocket.Accept(writer, request, nil)
+				if err != nil {
+					t.Errorf("accept preinstalled probe websocket: %v", err)
+					return
+				}
+				defer connection.CloseNow()
+				output := websocket.NetConn(context.Background(), connection, websocket.MessageBinary)
+				defer output.Close()
+				preinstalledChecks <- struct{}{}
+				_, _ = io.WriteString(output, preinstalledMiss+"\r\n")
+				return
+			}
 			for _, expected := range []string{
 				"/mnt/ao/repository",
 				"/mnt/ao/.ao/worker",
@@ -287,6 +303,11 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 	if files["ao-worker"] != "worker-binary" || files["ao"] != "helper-binary" {
 		t.Fatalf("unexpected binaries in archive: %+v", files)
 	}
+	select {
+	case <-preinstalledChecks:
+	default:
+		t.Fatal("bootstrap did not probe the preinstalled worker before uploading binaries")
+	}
 	if !strings.Contains(files["worker.env"], secret) {
 		t.Fatalf("worker environment missing from archive")
 	}
@@ -295,6 +316,48 @@ func TestBootstrapWorkerStreamsArchiveWithoutSecretsInURL(t *testing.T) {
 	}
 	if err := <-bootstrapResult; err != nil {
 		t.Fatalf("bootstrap: %v", err)
+	}
+}
+
+func TestPreinstalledBootstrapUsesExactHashesAndLaunchOnlyArchive(t *testing.T) {
+	t.Parallel()
+	bootstrap := sandbox.WorkerBootstrap{
+		Binary: []byte("worker-binary"), Destination: "/usr/local/bin/ao-worker",
+		HelperBinary: []byte("helper-binary"), HelperDestination: "/usr/local/bin/ao",
+		User: "ao-worker", Environment: map[string]string{"AO_WORKER_TOKEN": "secret"},
+		DurableRoot: "/mnt/ao", DurableIdentity: "session-1",
+	}
+	archive, err := bootstrapLaunchArchive(bootstrap)
+	if err != nil {
+		t.Fatalf("build launch archive: %v", err)
+	}
+	files := readArchive(t, archive)
+	if _, ok := files["ao-worker"]; ok {
+		t.Fatal("launch-only archive unexpectedly contains ao-worker")
+	}
+	if _, ok := files["ao"]; ok {
+		t.Fatal("launch-only archive unexpectedly contains ao helper")
+	}
+	if !strings.Contains(files["worker.env"], "secret") || files["launch.sh"] == "" {
+		t.Fatalf("launch-only archive is missing launch configuration: %+v", files)
+	}
+
+	command := bootstrapCommandForArchive(bootstrap, len(base64.StdEncoding.EncodeToString(archive)), true)
+	workerHash := sha256.Sum256(bootstrap.Binary)
+	helperHash := sha256.Sum256(bootstrap.HelperBinary)
+	for _, expected := range []string{
+		preinstalledMiss,
+		hex.EncodeToString(workerHash[:]),
+		hex.EncodeToString(helperHash[:]),
+		"/usr/local/bin/ao-worker",
+		"/usr/local/bin/ao",
+	} {
+		if !strings.Contains(command, expected) {
+			t.Errorf("preinstalled bootstrap command missing %q", expected)
+		}
+	}
+	if strings.Contains(command, `install -m 0755 "$stage/ao-worker"`) {
+		t.Fatal("preinstalled bootstrap command unexpectedly reinstalls the worker binary")
 	}
 }
 


### PR DESCRIPTION
Depends on #4624.

## Summary
- add a reference Coder workspace image/template that bakes release-matched `ao-worker`, `ao`, Node, and Claude Code
- link the baked harness into `/etc/skel` idempotently (`ln -sfn`) so a rebuild over a base that already carries that path cannot fail with `ln: Already exists`, and assert the link resolves in the same layer
- verify the installed worker/helper hashes before launch and transfer only the small launch environment on a match
- retain the existing PTY binary upload as a safe fallback for stale or unmodified customer templates
- document the image/template rollout and durable-root contract

## Verification
- `go test ./internal/sandbox/... ./internal/reconcile/...`
- `go test -race ./internal/sandbox/coder`
- `go vet ./internal/sandbox/coder ./internal/reconcile`
- `terraform validate` for `cloud/coder/main.tf`
- live Coder CE lifecycle: fresh create, healthy agent, fallback bootstrap, stop/start durable-state verification, delete (117.52s total)
- isolated preview fast path: worker bootstrap began at 10:55:47.937Z and worker callback completed at 10:55:50.460Z (~2.5s, versus ~111s before baking)
- workspace image build (`linux/amd64`, `codercom/enterprise-base:ubuntu@sha256:b937171039ee…`, `claude-code@2.1.228`, control-plane `a1e70b1c5-coder-review`): builds clean and the baked link resolves to `/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe` reporting `2.1.228 (Claude Code)`
- `ln: Already exists` reproduced deterministically only by rebuilding on a base that already ships `/etc/skel/.local/bin/claude`: the previous `ln -s` fails that build, `ln -sfn` succeeds and repoints the link at this image's harness. The originally reported build blocker traced to a contaminated local `codercom/enterprise-base:ubuntu` tag on the preview host (no `RepoDigests`, same image id as a prior `ao-coder-workspace:local`), not to this PR on a clean base — so `ln -sfn` is idempotency hardening, not a required blocker fix

## Deployment scope
Validated only on the isolated `ao-cloud-coder-preview-api` lane and dedicated Coder POC host. Shared NodeOps dev, staging, and production were not changed.

