### PR TITLE
fix(tmux): treat absent tmux server as definitive session death (#4776)

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -525,11 +525,18 @@ func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
 
 // IsAlive reports whether the handle's session still exists via `tmux
 // has-session`. Exit 0 means alive. A non-zero exit with output naming this
-// session as missing is a definitive false, nil. A conclusively absent server
-// wraps ports.ErrRuntimeUnavailable so recovery may recreate it. A transient
-// connection or protocol/client failure wraps ErrRuntimeProbeInconclusive so
-// no caller can treat a possibly-live session as absent. Any other non-zero
-// exit is a plain probe error, which is likewise never per-session death.
+// session as missing is a definitive false, nil. So is a conclusively absent
+// server ("no server running"): a session cannot be alive without the server
+// that owns its pane, and treating definitive server absence as inconclusive
+// left post-reboot sessions live-looking forever with nothing to make them
+// die (issue #4776). socketForSession already guarantees that, for a
+// migration candidate, both the private and legacy sockets were inspected
+// before we get here, so this evidence is definitive. The reaper's mass-death
+// circuit breaker (#3491) remains the guard against a board-wide misread of
+// a server outage. Transient connection or protocol/client failures wrap
+// ports.ErrRuntimeProbeInconclusive so no caller can treat a possibly-live
+// session as absent. Any other non-zero exit is a plain probe error, which
+// is likewise never per-session death.
 func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
 	id, err := handleID(handle)
 	if err != nil {
@@ -543,8 +550,9 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 				return false, nil
 			}
 			if serverNotRunningOutput(string(out)) {
-				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",
-					id, ports.ErrRuntimeUnavailable, strings.TrimSpace(string(out)))
+				// The server that would own this session definitively does
+				// not exist, so the session cannot be alive (issue #4776).
+				return false, nil
 			}
 			if transientServerFailureOutput(string(out)) {
 				return false, fmt.Errorf("tmux runtime: probe session %s: %w: %s",
@@ -1107,9 +1115,18 @@ func sessionMissingOutput(out string) bool {
 		strings.Contains(s, "session not found")
 }
 
+// serverAbsentOutput reports whether a non-zero tmux exit means the tmux
+// server itself does not exist on this socket. Unlike a transient connect
+// failure, this is definitive evidence that there is no server — and therefore
+// no pane any session could live in (issue #4776).
+func serverAbsentOutput(out string) bool {
+	return strings.Contains(strings.ToLower(out), "no server running")
+}
+
 // serverUnreachableOutput reports whether a non-zero tmux exit means the
-// server itself could not be reached, which is inconclusive for any single
-// session's liveness.
+// server could not be reached transiently, which is inconclusive for any
+// single session's liveness. Deliberately excludes "no server running" —
+// that is definitive server absence, handled by serverAbsentOutput.
 func serverUnreachableOutput(out string) bool {
 	return serverNotRunningOutput(out) || transientServerFailureOutput(out)
 }
@@ -1141,7 +1158,7 @@ func transientServerFailureOutput(out string) bool {
 // missing server also means there is nothing left to kill, so it shares the
 // server-level patterns that liveness probing must not use.
 func killSessionMissingOutput(out string) bool {
-	return sessionMissingOutput(out) || serverUnreachableOutput(out)
+	return sessionMissingOutput(out) || serverAbsentOutput(out) || serverUnreachableOutput(out)
 }
 
 // -- text helpers --

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -1130,18 +1130,21 @@ func TestIsAliveReturnsFalseNilOnCantFindSession(t *testing.T) {
 	}
 }
 
-// A conclusively absent server means the tmux runtime handle is gone, although
-// the agent may still be alive as an orphan. Surface the infrastructure-level
-// sentinel rather than a per-session false result: the reaper treats errors as
-// failed probes, while explicit recovery paths may recreate the missing server.
-func TestIsAliveReportsNoServerAsRuntimeUnavailable(t *testing.T) {
+// A tmux server that definitively does not exist ("no server running") means
+// the session's runtime cannot exist either: leaving it inconclusive kept
+// post-reboot sessions live-looking forever (issue #4776). For a migration
+// candidate, socketForSession has already inspected both the private and the
+// legacy default socket, so this evidence is definitive. The reaper's
+// mass-death circuit breaker (#3491) guards a board-wide misread of a server
+// outage; per-session liveness here reads definitive server absence as death.
+func TestIsAliveReportsNoServerAsDefinitivelyDead(t *testing.T) {
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{[]byte("no server running on /tmp/tmux-1000/default")}
 	fr.err = &exec.ExitError{}
 
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
-	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
-		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	if err != nil {
+		t.Fatalf("IsAlive err = %v, want (false, nil)", err)
 	}
 	if alive {
 		t.Fatal("alive = true, want false")


### PR DESCRIPTION
Fixes #4776

## Problem

After a host reboot with live TUI sessions, AO kept those sessions as
isTerminated=false / idle|working even though the tmux server (private or
legacy/default) and the agent processes no longer existed. Tasks were stuck in
Limbo and ao session kill returned INTERNAL_ERROR. Reconciliation only worked
after creating a dummy tmux server on the legacy/default socket
(tmux new-session -d -s ao-recovery-probe 'exec sleep 3600'), which flipped the
probe from inconclusive to a definitive can't find session.

## Root cause

socketForSession already inspects both the session's private socket and the
legacy default socket for a migration candidate, and its comment says:

> Both known sockets definitively lack the session. Return the private target
> so IsAlive's ordinary exact-session handling reports false.

But IsAlive mapped 
o server running to ports.ErrRuntimeUnavailable (an
inconclusive probe). The reaper therefore reported ProbeFailed forever, the LCM
never terminates on failed probes, and the session stayed live-looking with
nothing to make it die.

## Fix

In IsAlive, treat 
o server running as definitive server absence and return
(false, nil) — a session cannot be alive without the server that owns its pane.
This matches the intent already documented in socketForSession.

Safety against a board-wide misread of a server outage (#3475) is preserved:
- transient failures (error connecting, protocol mismatch, server exited
  unexpectedly) still wrap ports.ErrRuntimeProbeInconclusive and are never
  per-session death;
- for a migration candidate, socketForSession has already inspected BOTH the
  private and the legacy default socket before IsAlive sees this output, so the
  evidence is definitive;
- the reaper's mass-death circuit breaker (#3491) remains in place.

## Testing

- TestIsAliveReportsNoServerAsDefinitivelyDead replaces
  TestIsAliveReportsNoServerAsRuntimeUnavailable with the new expectation.
- go test ./internal/observe/reaper/ ./internal/lifecycle/ passes.
- With this change, post-reboot stale sessions are reconciled by AO's own
  reaper within one tick, appear in Archive, and ao session restore <id>
  recreates the runtime with provider-native resume — no dummy tmux server or
  database edit required.