### PR TITLE
fix(workspace): resolve inferred default branch without remote round trips

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -126,8 +126,14 @@ func (w *Workspace) ResolveDefaultBranch(ctx context.Context, repoPath, configur
 	}
 	branch := strings.TrimSpace(configuredBranch)
 	if branch == "" {
+		// Local-only by contract (ports.WorkspaceDefaultBranchRefresher): the
+		// spawn path calls this once per workspace repo before the budgeted
+		// FetchDefaultBranch pass, so a live remote probe here would multiply
+		// spawn latency by the number of child repos. Repos with no
+		// cached HEAD fall back to the budgeted live lookup in
+		// CreateWorkspaceProject.
 		resolver := gitdefault.New(w.binary, gitdefault.Runner(w.run))
-		resolution, err := resolver.Resolve(ctx, ctx, repo)
+		resolution, err := resolver.ResolveLocal(ctx, repo)
 		if err != nil {
 			return ports.WorkspaceDefaultBranch{}, fmt.Errorf("gitworktree: resolve repository default for %q: %w", repo, err)
 		}

--- a/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -729,6 +730,39 @@ func TestFetchDefaultBranchRefreshesRemoteTrackingRef(t *testing.T) {
 	}
 	if got := gitOutput(t, git, repo, "rev-parse", "refs/remotes/origin/main"); got != freshMain {
 		t.Fatalf("origin/main = %s, want refreshed %s", got, freshMain)
+	}
+}
+
+func TestResolveDefaultBranchInferredDoesNotContactRemote(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginCloneOnBranch(t, git, tmp, "dev")
+	ws, err := New(Options{Binary: git, ManagedRoot: filepath.Join(tmp, "managed"), RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	// The spawn path resolves every workspace repo with this call before the
+	// budgeted fetch pass, so it must answer from cached refs/remotes/origin/HEAD
+	// without any remote round trip.
+	realRun := ws.run
+	ws.run = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		for _, arg := range args {
+			if arg == "ls-remote" || arg == "fetch" {
+				t.Fatalf("ResolveDefaultBranch ran a remote git command: git %s", strings.Join(args, " "))
+			}
+		}
+		return realRun(ctx, binary, args...)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	target, err := ws.ResolveDefaultBranch(ctx, repo, "")
+	if err != nil {
+		t.Fatalf("resolve inferred default with offline origin: %v", err)
+	}
+	want := ports.WorkspaceDefaultBranch{Remote: "origin", Branch: "dev", BaseRef: "refs/remotes/origin/dev"}
+	if target != want {
+		t.Fatalf("target = %#v, want %#v", target, want)
 	}
 }
 

--- a/backend/internal/gitdefault/resolver.go
+++ b/backend/internal/gitdefault/resolver.go
@@ -165,6 +165,29 @@ func (r *Resolver) Resolve(ctx, remoteCtx context.Context, repo string) (Resolut
 	)
 }
 
+// ResolveLocal answers from repository metadata only: the selected remote's
+// cached symbolic HEAD, or the branch AO recorded when it initialized the
+// repository. It never contacts a remote, so its cost does not grow with
+// network latency; callers that need a live answer use Resolve.
+func (r *Resolver) ResolveLocal(ctx context.Context, repo string) (Resolution, error) {
+	remote, remotes, err := r.selectRemote(ctx, repo)
+	if err != nil {
+		return Resolution{}, err
+	}
+	if len(remotes) == 0 {
+		return r.resolveAOInitialized(ctx, repo)
+	}
+	if cached, ok := r.cachedRemoteHead(ctx, repo, remote); ok {
+		return cached, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return Resolution{}, err
+	}
+	return Resolution{}, unresolvedf(
+		"repository %q has no cached HEAD for remote %q (run `git remote set-head %s --auto`)", repo, remote, remote,
+	)
+}
+
 func (r *Resolver) selectRemote(ctx context.Context, repo string) (string, []string, error) {
 	out, err := r.run(ctx, r.binary, "-C", repo, "remote")
 	if err != nil {

--- a/backend/internal/gitdefault/resolver_test.go
+++ b/backend/internal/gitdefault/resolver_test.go
@@ -57,6 +57,54 @@ func TestResolveFallsBackToCachedHeadWhenRemoteIsOffline(t *testing.T) {
 	}
 }
 
+func TestResolveLocalUsesCachedHeadWithoutContactingRemote(t *testing.T) {
+	_, repo := remoteRepo(t, "trunk")
+	// The bare origin is reachable on disk, so guard against network use by
+	// rejecting any git subcommand that talks to a remote.
+	guarded := func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		for _, arg := range args {
+			if arg == "ls-remote" || arg == "fetch" {
+				t.Fatalf("ResolveLocal ran a remote git command: git %s", strings.Join(args, " "))
+			}
+		}
+		return runCommand(ctx, binary, args...)
+	}
+
+	resolution, err := New("", guarded).ResolveLocal(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("ResolveLocal: %v", err)
+	}
+	if resolution.Branch != "trunk" || resolution.Remote != "origin" || resolution.Source != SourceCachedRemoteHead {
+		t.Fatalf("resolution = %#v, want cached origin/trunk", resolution)
+	}
+}
+
+func TestResolveLocalIsUnresolvedWithoutCachedHead(t *testing.T) {
+	_, repo := remoteRepo(t, "trunk")
+	runGit(t, repo, "symbolic-ref", "--delete", "refs/remotes/origin/HEAD")
+
+	_, err := New("", nil).ResolveLocal(context.Background(), repo)
+	if !errors.Is(err, ErrUnresolved) {
+		t.Fatalf("ResolveLocal error = %v, want ErrUnresolved", err)
+	}
+	if !strings.Contains(err.Error(), "no cached HEAD") {
+		t.Fatalf("ResolveLocal error = %v, want missing cached HEAD detail", err)
+	}
+}
+
+func TestResolveLocalUsesBranchAORecordedAtInitialization(t *testing.T) {
+	repo := localRepo(t, "main")
+	runGit(t, repo, "config", "--local", ManagedDefaultConfigKey, "main")
+
+	resolution, err := New("", nil).ResolveLocal(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("ResolveLocal: %v", err)
+	}
+	if resolution.Branch != "main" || resolution.Source != SourceAOInitialized {
+		t.Fatalf("resolution = %#v, want AO-initialized main", resolution)
+	}
+}
+
 func TestResolveNeverFallsBackToCurrentOrConventionalBranch(t *testing.T) {
 	repo := localRepo(t, "main")
 	runGit(t, repo, "switch", "-c", "feature/temporary")


### PR DESCRIPTION
## What

Make `gitworktree.ResolveDefaultBranch` local-only when no default branch is configured, via a new `gitdefault.Resolver.ResolveLocal` that answers from the cached remote HEAD (or the AO-initialized default) and never runs `git ls-remote` / `git fetch`.

## Why

Spawning any session in a workspace project times out (`SPAWN_TIMEOUT`, `error_kind=conflict`) once the workspace has more than a handful of child repos, and the UI then shows `SESSION_INCOMPLETE_HANDLE` for a session row that never received handles.

`refreshDefaultBranchesBestEffort` in `session_manager` calls `ResolveDefaultBranch` for every child repo *before* the shared 5 s `defaultBranchRefreshTimeout` fetch pass. Its comment, and the `ports.WorkspaceDefaultBranchRefresher` contract, say this step is local-only. It is not: with an empty configured branch the adapter called `resolver.Resolve(ctx, ctx, repo)`, which runs a live `ls-remote --symref` plus a `fetch` per repo under the unbounded request context. A slow remote for one repo (I observed a single fetch running for 40+ s) multiplies across the workspace, and the request dies at `AO_REQUEST_TIMEOUT` before a worktree is ever created.

Repro on 0.12.9: `ao project add --as-workspace` on a folder with ~75 child repos, then `ao spawn --kind orchestrator`. Every spawn fails with `SPAWN_TIMEOUT` after ~140-150 s; the daemon's only child process during that time is `git fetch` in one child repo after another.

## How

- `gitdefault.Resolver.ResolveLocal(ctx, repo)`: same remote selection and AO-initialized fallback as `Resolve`, but only the cached `refs/remotes/<remote>/HEAD` path for repos with remotes. Returns `ErrUnresolved` with a `git remote set-head` hint when there is no cached HEAD.
- `gitworktree.ResolveDefaultBranch` uses `ResolveLocal` for the inferred-branch case. Repos without a cached HEAD now hit the existing "resolution failed; continuing with adapter fallback" branch in the manager, and `CreateWorkspaceProject` still performs its live lookup for them under the aggregate `defaultBranchResolutionBudget`.
- Freshness: the budgeted `FetchDefaultBranch` pass still refreshes the resolved branch tip. What is no longer refreshed at spawn is a *change of the remote's default branch* for repos that already have a cached HEAD. That matches the documented contract for this port; if a live check is wanted it belongs under the shared budget, not per repo.

Not changed: request timeout defaults, and the per-repo `git worktree add` cost in `CreateWorkspaceProject` (very large workspaces can still exceed the request timeout there, but that is bounded work with no network dependency).

## Testing

```
cd backend
go vet ./internal/gitdefault/ ./internal/adapters/workspace/gitworktree/
go test ./internal/gitdefault/ ./internal/adapters/workspace/... ./internal/session_manager/
```

New tests:
- `TestResolveLocalUsesCachedHeadWithoutContactingRemote`, `TestResolveLocalIsUnresolvedWithoutCachedHead`, `TestResolveLocalUsesBranchAORecordedAtInitialization` (gitdefault).
- `TestResolveDefaultBranchInferredDoesNotContactRemote` (gitworktree integration) wraps the git runner and fails on any `ls-remote`/`fetch`. Verified it fails against the unpatched adapter (`ran a remote git command: git -C ... ls-remote --symref -- origin HEAD`) and passes with this change.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for the changed behavior
- [ ] Relevant CI checks pass (`go`)
