### PR TITLE
fix: align session card delete button with title row

### DIFF
--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -177,7 +177,7 @@ const DesktopSessionCard = memo(function DesktopSessionCard({
 										: t("shell.terminateNamed", { title: session.title })
 								}
 								className={cn(
-									"absolute right-2 top-1.5 z-10 inline-flex size-control-md items-center justify-center rounded-sm text-passive transition-[color,background-color,opacity] hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+									"inline-flex size-control-md items-center justify-center rounded-sm text-passive transition-[color,background-color,opacity] hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
 									keepTerminateVisible || termination.isPending
 										? "opacity-100"
 										: "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
@@ -233,7 +233,7 @@ const DesktopSessionCard = memo(function DesktopSessionCard({
 				state: pr.state,
 				url: prBrowserUrl(pr),
 			}))}
-			renderAvatar={(provider) => <AgentAvatar className="mt-0.5" provider={provider} />}
+			renderAvatar={(provider) => <AgentAvatar provider={provider} />}
 			session={toBoardSessionPresentation(session, t)}
 			translate={translate}
 			renderUsage={(usage) => (

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -272,22 +272,21 @@ export function SessionCardView({
 					type="button"
 				/>
 			) : null}
-			{overlay}
-			{action ? <div className="absolute right-2 top-1.5 z-10">{action}</div> : null}
-			<div className="px-3.5 pb-2.5 pt-3">
-				<div className="flex min-w-0 items-start gap-2.5">
+			<div className="px-3.5 pb-2.5 pt-2.5">
+				<div className="flex min-w-0 items-center gap-2.5">
 					{renderAvatar(session.provider)}
-					<div className="min-w-0 flex-1">
-						<div
-							className={cn(
-								"line-clamp-2 overflow-hidden text-balance text-sm-md font-semibold leading-tight tracking-tight text-foreground",
-								(overlay || action) && "pr-6",
-							)}
-							title={session.title}
-						>
-							{session.title}
-						</div>
+					<div
+						className="min-w-0 flex-1 line-clamp-2 overflow-hidden text-balance text-sm-md font-semibold leading-tight tracking-tight text-foreground"
+						title={session.title}
+					>
+						{session.title}
 					</div>
+					{overlay || action ? (
+						<div className="relative z-10 -mr-1 shrink-0 self-center">
+							{overlay}
+							{action}
+						</div>
+					) : null}
 				</div>
 				{showBranch && (
 					<div className="mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-2xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Move the session card delete/restore action into the title row so it aligns vertically with the title and avatar
- Reduce top padding on the card header (`pt-3` → `pt-2.5`) to remove extra space above the title
- Drop absolute positioning from the terminate button and the avatar top offset that caused the misalignment

## Test plan
- [ ] Open the sessions board and confirm card headers have less top padding
- [ ] Hover a session card and confirm the delete button aligns with the title row
- [ ] Verify archive restore button alignment on archived cards
- [ ] Run `npm test -- SessionsBoardView.test.tsx` in `packages/product-ui`
- [ ] Run `npm test -- SessionsBoard.test.tsx` in `frontend`

<img width="368" height="181" alt="image" src="https://github.com/user-attachments/assets/57448e3f-efe4-4cba-b995-8aee55e4dbe8" />
<img width="791" height="219" alt="image" src="https://github.com/user-attachments/assets/c6e9c797-e12a-4f2a-afd9-63b2c0d1d340" />
