### PR TITLE
fix: simplify harness installer actions

### DIFF
--- a/frontend/src/renderer/components/settings/HarnessSettingsSection.test.tsx
+++ b/frontend/src/renderer/components/settings/HarnessSettingsSection.test.tsx
@@ -122,21 +122,39 @@ describe("HarnessSettingsSection", () => {
 		}));
 	});
 
-	it("allows an installed harness to be reinstalled with its recommended method", async () => {
+	it("automatically uses the installer available on the user's machine", async () => {
+		const npmOnlyPlans = {
+			agents: plans.agents.map((plan) => plan.agentId === "codex" ? {
+				...plan,
+				method: "npm",
+				methods: plan.methods.map((method) => ({
+					...method,
+					available: method.id === "npm",
+					recommended: method.id === "npm",
+				})),
+			} : plan),
+		};
+		vi.mocked(apiClient.GET).mockImplementation(async (path) => {
+			if (path === "/api/v1/agents/readiness") return { data: catalog } as never;
+			if (path === "/api/v1/agents/installers") return { data: npmOnlyPlans } as never;
+			if (path === "/api/v1/agents/install-jobs") return { data: { jobs: [] } } as never;
+			return { data: undefined } as never;
+		});
 		const user = userEvent.setup();
 		renderSection();
-		const row = (await screen.findByText("Claude Code")).closest('[data-agent="claude-code"]') as HTMLElement;
-		const reinstall = await within(row).findByRole("button", { name: "Reinstall" });
+		const row = (await screen.findByText("Codex")).closest('[data-agent="codex"]') as HTMLElement;
 
-		await user.click(reinstall);
+		await waitFor(() => expect(row).toHaveTextContent("Available via npm"));
+		expect(within(row).queryByRole("combobox", { name: "Installation method" })).not.toBeInTheDocument();
+		await user.click(within(row).getByRole("button", { name: "Install" }));
 
 		await waitFor(() => expect(apiClient.POST).toHaveBeenCalledWith("/api/v1/agents/{agent}/install", {
-			params: { path: { agent: "claude-code" } },
-			body: { method: "homebrew", operation: "reinstall" },
+			params: { path: { agent: "codex" } },
+			body: { method: "npm", operation: "install" },
 		}));
 	});
 
-	it("shows vendor instructions when an installed harness has no headless reinstall method", async () => {
+	it("shows no reinstall or instructions actions for installed harnesses", async () => {
 		vi.mocked(apiClient.GET).mockImplementation(async (path) => {
 			if (path === "/api/v1/agents/readiness") return { data: catalogWithInstalled("claude-code", "cursor") } as never;
 			if (path === "/api/v1/agents/installers") return { data: plans } as never;
@@ -144,10 +162,14 @@ describe("HarnessSettingsSection", () => {
 			return { data: undefined } as never;
 		});
 		renderSection();
-		const row = (await screen.findByText("Cursor")).closest('[data-agent="cursor"]') as HTMLElement;
+		const claudeRow = (await screen.findByText("Claude Code")).closest('[data-agent="claude-code"]') as HTMLElement;
+		const cursorRow = (await screen.findByText("Cursor")).closest('[data-agent="cursor"]') as HTMLElement;
 
-		expect(await within(row).findByRole("button", { name: "Instructions" })).toBeEnabled();
-		expect(within(row).queryByRole("button", { name: "Reinstall" })).not.toBeInTheDocument();
+		for (const row of [claudeRow, cursorRow]) {
+			expect(row).toHaveTextContent("Installed");
+			expect(within(row).queryByRole("button", { name: "Reinstall" })).not.toBeInTheDocument();
+			expect(within(row).queryByRole("button", { name: "Instructions" })).not.toBeInTheDocument();
+		}
 	});
 
 	it("starts an official vendor installer with one click and no instructions dialog", async () => {
@@ -172,10 +194,10 @@ describe("HarnessSettingsSection", () => {
 		expect(row).toHaveTextContent("Installing…");
 	});
 
-	it("keeps unsupported native Windows harnesses on vendor instructions", async () => {
+	it("does not show instructions for harnesses without an automatic installer", async () => {
 		renderSection();
 		const row = (await screen.findByText("Goose")).closest('[data-agent="goose"]') as HTMLElement;
-		expect(await within(row).findByRole("button", { name: "Instructions" })).toBeEnabled();
+		expect(within(row).queryByRole("button", { name: "Instructions" })).not.toBeInTheDocument();
 		expect(within(row).queryByRole("button", { name: "Install" })).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/settings/HarnessSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/HarnessSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Copy, Download, ExternalLink, LoaderCircle, RefreshCw, Search, TriangleAlert } from "lucide-react";
+import { Check, Copy, Download, LoaderCircle, RefreshCw, Search, TriangleAlert } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { components } from "../../../api/schema";
@@ -133,13 +133,13 @@ export function HarnessSettingsSection({ titleHidden = false }: { titleHidden?: 
 		setPendingAgentIds(new Set(pendingActions.current));
 	};
 
-	const startInstall = async (agentId: AgentId, method: string, operation: "install" | "reinstall") => {
+	const startInstall = async (agentId: AgentId, method: string) => {
 		if (!beginAction(agentId)) return;
 		setActionErrors((current) => ({ ...current, [agentId]: undefined }));
 		try {
 			const { data, error } = await apiClient.POST("/api/v1/agents/{agent}/install", {
 				params: { path: { agent: agentId } },
-				body: { method, operation },
+				body: { method, operation: "install" },
 			});
 			if (error || !data) {
 				setActionErrors((current) => ({ ...current, [agentId]: apiErrorMessage(error, t("settings.harness.startFailed")) }));
@@ -216,8 +216,7 @@ export function HarnessSettingsSection({ titleHidden = false }: { titleHidden?: 
 					const plan = plans.get(agentId);
 					const job = jobMap.get(agentId);
 					const isInstalled = installed.has(agentId);
-					const operation = isInstalled ? "reinstall" : "install";
-					const availableMethods = plan?.methods.filter((method) => operation === "reinstall" ? method.reinstallAvailable : method.available) ?? [];
+					const availableMethods = plan?.methods.filter((method) => method.available) ?? [];
 					const recommendedMethod = availableMethods.find((method) => method.recommended) ?? availableMethods[0];
 					const selectedMethodId = selectedMethods[agentId] ?? (availableMethods.some((method) => method.id === job?.method) ? job?.method : recommendedMethod?.id) ?? "";
 					const selectedMethod = availableMethods.find((method) => method.id === selectedMethodId);
@@ -232,9 +231,6 @@ export function HarnessSettingsSection({ titleHidden = false }: { titleHidden?: 
 							{availableMethods.map((method) => <option key={method.id} value={method.id}>{method.label}</option>)}
 						</select>
 					) : null;
-					const instructionsButton = (
-						<Button size="sm" variant="outline" onClick={() => void aoBridge.app.openExternal(plan?.documentationUrl ?? "https://aoagents.dev/docs/installation")}><ExternalLink aria-hidden="true" />{t("settings.harness.instructions")}</Button>
-					);
 					return (
 						<div className="settings-row-bar min-h-14 flex-wrap gap-3" data-agent={agentId} key={agentId}>
 							<AgentAvatar className="size-7 shrink-0" decorative provider={agentId} />
@@ -247,32 +243,24 @@ export function HarnessSettingsSection({ titleHidden = false }: { titleHidden?: 
 
 							{active ? (
 								<span className="inline-flex items-center gap-1.5 text-xs text-settings-muted" role="status"><LoaderCircle className="size-4 animate-spin" aria-hidden="true" />{job?.status === "installing" ? t("settings.harness.installing") : t("settings.harness.verifying")}</span>
+							) : isInstalled ? (
+								<span className="inline-flex items-center gap-1 text-xs font-medium text-success"><Check className="size-4" aria-hidden="true" />{t("settings.harness.installed")}</span>
 							) : failed ? (
 								<div className="flex items-center gap-1.5">
 									{methodSelect}
 									<Button size="sm" variant="outline" disabled={pending} onClick={() => void verifyInstall(agentId)}>{t("settings.harness.verifyAgain")}</Button>
-									{selectedMethodId ? <Button size="sm" onClick={() => void startInstall(agentId, selectedMethodId, operation)} disabled={pending}>{isInstalled ? t("settings.harness.reinstall") : t("settings.harness.retry")}</Button> : instructionsButton}
+									{selectedMethodId ? <Button size="sm" onClick={() => void startInstall(agentId, selectedMethodId)} disabled={pending}>{t("settings.harness.retry")}</Button> : null}
 								</div>
-							) : isInstalled && availableMethods.length > 0 ? (
-								<div className="flex items-center gap-1.5">
-									<span className="inline-flex items-center gap-1 text-xs font-medium text-success"><Check className="size-4" aria-hidden="true" />{t("settings.harness.installed")}</span>
-									{methodSelect}
-									<Button size="sm" variant="outline" onClick={() => selectedMethodId && void startInstall(agentId, selectedMethodId, "reinstall")} disabled={pending || !selectedMethodId}>{t("settings.harness.reinstall")}</Button>
-								</div>
-							) : isInstalled ? (
-								instructionsButton
 							) : !plan && installers.isPending ? (
 								<span className="inline-flex items-center gap-1.5 text-xs text-settings-muted" role="status"><LoaderCircle className="size-4 animate-spin" aria-hidden="true" /></span>
 							) : availableMethods.length > 0 ? (
 								<div className="flex items-center gap-1.5">
 									{methodSelect}
-									<Button size="sm" disabled={pending} onClick={() => selectedMethodId && void startInstall(agentId, selectedMethodId, "install")}><Download aria-hidden="true" />{t("settings.harness.install")}</Button>
+									<Button size="sm" disabled={pending} onClick={() => selectedMethodId && void startInstall(agentId, selectedMethodId)}><Download aria-hidden="true" />{t("settings.harness.install")}</Button>
 								</div>
 							) : plan?.command ? (
 								<Button size="sm" variant="outline" onClick={() => void copyText(agentId, plan.command!)}>{copiedAgent === agentId ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}{copiedAgent === agentId ? t("settings.harness.copied") : t("settings.harness.copyCommand")}</Button>
-							) : (
-								instructionsButton
-							)}
+							) : null}
 
 							{hasDiagnostics ? (
 								<div className="basis-full pl-10">


### PR DESCRIPTION
## Summary
- hide reinstall controls for installed harnesses
- remove instructions buttons from the Harnesses settings section
- automatically use the daemon-recommended installer available on the user's machine

## Tests
- frontend HarnessSettingsSection test suite (13 tests)
- frontend TypeScript typecheck