### PR TITLE
fix(updates): resolve feature feeds from completed releases

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -406,6 +406,87 @@ describe("startAutoUpdates", () => {
     }
   });
 
+  it("feature checks resolve the newest completed PR release without the Atom feed", async () => {
+    const platformManifest =
+      process.platform === "darwin"
+        ? "pr4473-mac.yml"
+        : process.platform === "linux"
+          ? "pr4473-linux.yml"
+          : "pr4473.yml";
+    const resourcesPath = mkdtempSync(
+      nodePath.join(os.tmpdir(), "ao-feature-feed-"),
+    );
+    writeFileSync(
+      nodePath.join(resourcesPath, "app-update.yml"),
+      "provider: github\nowner: Untrivial-ai\nrepo: agent-orchestrator\n",
+    );
+    const originalResourcesPath = Object.getOwnPropertyDescriptor(
+      process,
+      "resourcesPath",
+    );
+    Object.defineProperty(process, "resourcesPath", {
+      configurable: true,
+      value: resourcesPath,
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            tag_name: "v1.0.0-pr4473.202608271543",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: "Agent.Orchestrator.dmg" }],
+          },
+          {
+            tag_name: "v1.0.0-pr4473.202608271542",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: platformManifest }],
+          },
+          {
+            tag_name: "v1.0.0-pr9999.202608271544",
+            draft: false,
+            prerelease: true,
+            assets: [{ name: platformManifest }],
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const { module, autoUpdater } = await importAutoUpdater({
+        enabled: true,
+        channel: "nightly",
+        nightlyAck: true,
+        feature: { pr: 4473 },
+      });
+
+      await module.startAutoUpdates(stateDir);
+
+      expect(autoUpdater.setFeedURL).toHaveBeenNthCalledWith(1, {
+        provider: "generic",
+        url: "https://github.com/Untrivial-ai/agent-orchestrator/releases/download/v1.0.0-pr4473.202608271542",
+        channel: "pr4473",
+        useMultipleRangeRequest: false,
+      });
+      expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(autoUpdater.setFeedURL).toHaveBeenNthCalledWith(2, {
+        provider: "github",
+        owner: "Untrivial-ai",
+        repo: "agent-orchestrator",
+      });
+    } finally {
+      if (originalResourcesPath) {
+        Object.defineProperty(process, "resourcesPath", originalResourcesPath);
+      } else {
+        Reflect.deleteProperty(process, "resourcesPath");
+      }
+      rmSync(resourcesPath, { recursive: true, force: true });
+    }
+  });
+
   it("checks stable on launch and hourly when automatic downloads are disabled", async () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -255,9 +255,10 @@ interface GitHubReleaseSummary {
  * This is used only for user-requested checks; failures fall back to the normal
  * provider so API rate limits or an outage never break update checks.
  */
-async function fetchLatestCompletedNightlyTag(
+async function fetchLatestCompletedPrereleaseTag(
   owner: string,
   repo: string,
+  channel: string,
 ): Promise<string | undefined> {
   try {
     const response = await fetch(
@@ -274,7 +275,7 @@ async function fetchLatestCompletedNightlyTag(
     );
     if (!response.ok) return undefined;
     const releases = (await response.json()) as GitHubReleaseSummary[];
-    const manifestName = `nightly${platformSuffix()}.yml`;
+    const manifestName = `${channel}${platformSuffix()}.yml`;
     return releases
       .filter((release) => {
         const parsed = semver.valid(release.tag_name);
@@ -282,7 +283,7 @@ async function fetchLatestCompletedNightlyTag(
           !release.draft &&
           release.prerelease &&
           parsed !== null &&
-          semver.prerelease(parsed)?.[0] === "nightly" &&
+          semver.prerelease(parsed)?.[0] === channel &&
           release.assets?.some((asset) => asset.name === manifestName) === true
         );
       })
@@ -293,10 +294,11 @@ async function fetchLatestCompletedNightlyTag(
   }
 }
 
-function usesDirectNightlyFeed(
+function directPrereleaseChannel(
   settings: Pick<UpdateSettings, "channel" | "feature">,
-): boolean {
-  return settings.channel === "nightly" && settings.feature === null;
+): string | undefined {
+  if (settings.feature) return `pr${settings.feature.pr}`;
+  return settings.channel === "nightly" ? "nightly" : undefined;
 }
 
 /**
@@ -310,21 +312,23 @@ function usesDirectNightlyFeed(
  * checks; electron-updater retains the direct provider with the discovered
  * update, so a subsequent Download action still uses the correct asset URLs.
  */
-async function configureDirectNightlyFeed(
+async function configureDirectPrereleaseFeed(
   settings: UpdateSettings,
 ): Promise<(() => void) | undefined> {
-  if (!usesDirectNightlyFeed(settings)) return undefined;
+  const channel = directPrereleaseChannel(settings);
+  if (!channel) return undefined;
   const coordinates = await readAppUpdateYml();
   if (!coordinates) return undefined;
-  const tag = await fetchLatestCompletedNightlyTag(
+  const tag = await fetchLatestCompletedPrereleaseTag(
     coordinates.owner,
     coordinates.repo,
+    channel,
   );
   if (!tag) return undefined;
   const runningVersion = app.getVersion();
   if (
     semver.valid(runningVersion) !== null &&
-    semver.prerelease(runningVersion)?.[0] === "nightly" &&
+    semver.prerelease(runningVersion)?.[0] === channel &&
     semver.lt(tag, runningVersion)
   ) {
     return undefined;
@@ -333,7 +337,7 @@ async function configureDirectNightlyFeed(
   autoUpdater.setFeedURL({
     provider: "generic",
     url: `https://github.com/${coordinates.owner}/${coordinates.repo}/releases/download/${tag}`,
-    channel: "nightly",
+    channel,
     useMultipleRangeRequest: false,
   });
   return () => {
@@ -789,10 +793,10 @@ async function runAutomaticUpdateCheck(
       // leaves it in `available` for the sidebar action.
       autoUpdater.autoDownload = settings.enabled;
       applyInstallOnQuitPolicy();
-      // Only nightly resolves a direct feed. Skipping the await entirely on the
-      // other channels keeps this check's event ordering exactly as it was.
-      const restoreFeed = usesDirectNightlyFeed(settings)
-        ? await configureDirectNightlyFeed(settings)
+      // Only prerelease channels resolve a direct feed. Skipping the await on
+      // stable keeps that check's event ordering exactly as it was.
+      const restoreFeed = directPrereleaseChannel(settings)
+        ? await configureDirectPrereleaseFeed(settings)
         : undefined;
       try {
         const result = await autoUpdater.checkForUpdates();
@@ -947,7 +951,7 @@ export async function checkForUpdatesNow(
         autoUpdater.autoDownload = false;
         applyInstallOnQuitPolicy();
         broadcastUpdaterStatus({ state: "checking" });
-        const restoreFeed = await configureDirectNightlyFeed(settings);
+        const restoreFeed = await configureDirectPrereleaseFeed(settings);
         try {
           await autoUpdater.checkForUpdates();
         } finally {


### PR DESCRIPTION
## Summary

- resolve pinned feature channels through the GitHub Releases API, matching the existing direct Nightly path
- select the newest non-draft prerelease that matches the pinned `pr<N>` channel and contains that platform's manifest
- restore the normal GitHub provider after each operation while retaining the resolved update for download

This prevents an installed feature build from checking a deleted predecessor when GitHub's Atom feed lags behind a same-PR replacement. It also skips incomplete replacement releases until their platform manifest exists.

Addresses the feature-channel instance of #4487.

## Tests

- `npm test -- --run src/main/auto-updater.test.ts` (65 passed)
- `npm run typecheck`
- `git diff --check`

## Risk

GitHub API failure still falls back to the existing Atom-backed provider, preserving current behavior during API outages or rate limiting.
