### PR TITLE
fix: keep sidebar visible on first browser open

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -631,6 +631,8 @@ describe("SessionView", () => {
 		workspaceQueryState.isLoading = false;
 		useUiStore.setState({
 			activeShellTerminalHandleId: null,
+			browserSidebarAutoResizeAttempted: false,
+			browserSidebarAutoResizeRequested: false,
 			inspectorSessions: {},
 			isSidebarOpen: true,
 			visibleTerminalKindBySession: {},
@@ -1953,11 +1955,14 @@ describe("SessionView", () => {
 
 		fireEvent.click(screen.getByRole("tab", { name: "Browser" }));
 		expect(useUiStore.getState().isSidebarOpen).toBe(true);
+		expect(useUiStore.getState().browserSidebarAutoResizeRequested).toBe(true);
+		act(() => useUiStore.getState().consumeBrowserSidebarAutoResize());
 
 		fireEvent.click(screen.getByRole("tab", { name: "Summary" }));
 		expect(useUiStore.getState().isSidebarOpen).toBe(true);
 
 		fireEvent.click(screen.getByRole("tab", { name: "Browser" }));
+		expect(useUiStore.getState().browserSidebarAutoResizeRequested).toBe(false);
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
 		expect(useUiStore.getState().isSidebarOpen).toBe(true);
 

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -348,7 +348,12 @@ beforeEach(() => {
 	cloudSessionState.status = "unauthenticated";
 	cloudSessionState.signIn.mockReset();
 	cloudSessionState.signOut.mockReset().mockResolvedValue(undefined);
-	useUiStore.setState({ isCommandPaletteOpen: false, settingsModal: null });
+	useUiStore.setState({
+		browserSidebarAutoResizeAttempted: false,
+		browserSidebarAutoResizeRequested: false,
+		isCommandPaletteOpen: false,
+		settingsModal: null,
+	});
 	getMock.mockReset();
 	postMock.mockReset();
 	getMock.mockResolvedValue({
@@ -1746,6 +1751,82 @@ describe("Sidebar", () => {
 		// Sidebar stays expanded; dragging no longer collapses it.
 		expect(document.querySelector('[data-slot="sidebar"][data-state="expanded"]')).toBeInTheDocument();
 		expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${SIDEBAR_MIN_WIDTH}px`);
+	});
+
+	it("springs the first Browser open to 200 without persisting the automatic width", async () => {
+		const storedWidth = SIDEBAR_MIN_WIDTH + 80;
+		window.localStorage.setItem("ao-sidebar-w", String(storedWidth));
+		const seen: number[] = [];
+		const setProperty = CSSStyleDeclaration.prototype.setProperty;
+		const spy = vi.spyOn(CSSStyleDeclaration.prototype, "setProperty").mockImplementation(function (
+			this: CSSStyleDeclaration,
+			name: string,
+			value: string | null,
+			priority?: string,
+		) {
+			if (name === "--ao-sidebar-w" && typeof value === "string") seen.push(Number.parseFloat(value));
+			return setProperty.call(this, name, value, priority);
+		});
+
+		try {
+			renderSidebar();
+			expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${storedWidth}px`);
+
+			act(() => useUiStore.getState().setInspectorView("session-1", "browser"));
+
+			await waitFor(() =>
+				expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${SIDEBAR_MIN_WIDTH}px`),
+			);
+			expect(seen.some((width) => width > SIDEBAR_MIN_WIDTH && width < storedWidth)).toBe(true);
+			expect(useUiStore.getState()).toMatchObject({
+				browserSidebarAutoResizeAttempted: true,
+				browserSidebarAutoResizeRequested: false,
+			});
+			expect(window.localStorage.getItem("ao-sidebar-w")).toBe(String(storedWidth));
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("applies the first Browser width immediately for reduced motion", () => {
+		const storedWidth = SIDEBAR_MIN_WIDTH + 80;
+		window.localStorage.setItem("ao-sidebar-w", String(storedWidth));
+		const matchMedia = vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+			matches: query === "(prefers-reduced-motion: reduce)",
+			media: query,
+			onchange: null,
+			addEventListener: () => undefined,
+			removeEventListener: () => undefined,
+			addListener: () => undefined,
+			removeListener: () => undefined,
+			dispatchEvent: () => false,
+		}));
+
+		try {
+			renderSidebar();
+			act(() => useUiStore.getState().setInspectorView("session-1", "browser"));
+
+			expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${SIDEBAR_MIN_WIDTH}px`);
+			expect(useUiStore.getState().browserSidebarAutoResizeAttempted).toBe(true);
+			expect(window.localStorage.getItem("ao-sidebar-w")).toBe(String(storedWidth));
+		} finally {
+			matchMedia.mockRestore();
+		}
+	});
+
+	it("keeps a manually closed sidebar closed when the first Browser opens", () => {
+		const storedWidth = SIDEBAR_MIN_WIDTH + 80;
+		window.localStorage.setItem("ao-sidebar-w", String(storedWidth));
+		renderSidebar({ initialOpen: false });
+
+		act(() => useUiStore.getState().setInspectorView("session-1", "browser"));
+
+		expect(document.documentElement.style.getPropertyValue("--ao-sidebar-w")).toBe(`${storedWidth}px`);
+		expect(useUiStore.getState()).toMatchObject({
+			browserSidebarAutoResizeAttempted: true,
+			browserSidebarAutoResizeRequested: false,
+		});
+		expect(document.querySelector('[data-slot="sidebar"][data-state="collapsed"]')).toBeInTheDocument();
 	});
 
 	it("flushes any queued rAF frame on pointer-up and persists the clamped width", async () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -419,6 +419,8 @@ export function Sidebar({
 	const selection = useSelection();
 	const { state, setOpen, toggleSidebar } = useSidebar();
 	const isCollapsed = state === "collapsed";
+	const browserSidebarAutoResizeRequested = useUiStore((s) => s.browserSidebarAutoResizeRequested);
+	const consumeBrowserSidebarAutoResize = useUiStore((s) => s.consumeBrowserSidebarAutoResize);
 	const [expandedChromeVisible, setExpandedChromeVisible] = useState(!isCollapsed);
 	// One IPC subscription for both footer variants of the restart-to-update prompt.
 	const updateStatus = useUpdateStatus();
@@ -486,6 +488,7 @@ export function Sidebar({
 		onPointerDown: onResizePointerDown,
 		onCollapsedPointerDown: onCollapsedResizePointerDown,
 		onDoubleClick: onResizeDoubleClick,
+		animateWidth: animateSidebarWidth,
 	} = useResizable({
 		cssVar: "--ao-sidebar-w",
 		storageKey: "ao-sidebar-w",
@@ -495,6 +498,14 @@ export function Sidebar({
 		edge: "right",
 		onExpand: () => setOpen(true),
 	});
+	useLayoutEffect(() => {
+		if (!browserSidebarAutoResizeRequested) return;
+		// A manually closed sidebar stays closed. Consume the one-shot request even
+		// in that case so a later manual reopen is never treated as Browser's first
+		// open. Visible sidebars shrink to the minimum on the shared shell spring.
+		if (!isCollapsed) animateSidebarWidth(SIDEBAR_MIN_WIDTH);
+		consumeBrowserSidebarAutoResize();
+	}, [animateSidebarWidth, browserSidebarAutoResizeRequested, consumeBrowserSidebarAutoResize, isCollapsed]);
 
 	const [projectOrder, setProjectOrder] = useState<string[]>([]);
 	const [sessionOrderByProject, setSessionOrderByProject] = useState<Record<string, string[]>>({});

--- a/frontend/src/renderer/hooks/useResizable.ts
+++ b/frontend/src/renderer/hooks/useResizable.ts
@@ -1,4 +1,10 @@
+import { animate } from "motion/react";
 import { useCallback, useLayoutEffect, useRef } from "react";
+import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
+
+function prefersReducedMotion(): boolean {
+	return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
 
 type ResizableConstraint = number | (() => number);
 
@@ -44,8 +50,13 @@ export function useResizable({
 	const widthRef = useRef(defaultWidth);
 	const frameRef = useRef<number | null>(null);
 	const pendingWidthRef = useRef<number | null>(null);
+	const animationRef = useRef<{ stop: () => void } | null>(null);
 	const minValue = useCallback(() => (typeof min === "function" ? min() : min), [min]);
 	const maxValue = useCallback(() => (typeof max === "function" ? max() : max), [max]);
+	const stopAnimation = useCallback(() => {
+		animationRef.current?.stop();
+		animationRef.current = null;
+	}, []);
 
 	const apply = useCallback(
 		(next: number) => {
@@ -80,6 +91,28 @@ export function useResizable({
 		if (pending !== null) apply(pending);
 	}, [apply]);
 
+	const animateWidth = useCallback(
+		(next: number) => {
+			const target = Math.min(maxValue(), Math.max(minValue(), next));
+			const from = widthRef.current;
+			stopAnimation();
+			if (from === target || prefersReducedMotion()) {
+				apply(target);
+				return;
+			}
+			const controls = animate(from, target, {
+				...SHELL_PANEL_SPRING,
+				onUpdate: (value) => apply(value),
+				onComplete: () => {
+					apply(target);
+					if (animationRef.current === controls) animationRef.current = null;
+				},
+			});
+			animationRef.current = controls;
+		},
+		[apply, maxValue, minValue, stopAnimation],
+	);
+
 	// Restore persisted width before first paint so the sidebar does not appear
 	// at the default width on reload and then jump/animate to the stored width.
 	useLayoutEffect(() => {
@@ -87,14 +120,16 @@ export function useResizable({
 		const restored = Number.isFinite(saved) && saved > 0 ? saved : defaultWidth;
 		apply(restoreMin === undefined ? restored : Math.max(restoreMin, restored));
 		return () => {
+			stopAnimation();
 			if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
 			document.documentElement.style.removeProperty(cssVar);
 		};
-	}, [apply, cssVar, defaultWidth, restoreMin, storageKey]);
+	}, [apply, cssVar, defaultWidth, restoreMin, stopAnimation, storageKey]);
 
 	const onPointerDown = useCallback(
 		(event: React.PointerEvent<HTMLElement>) => {
 			event.preventDefault();
+			stopAnimation();
 			const startX = event.clientX;
 			const startWidth = Math.min(maxValue(), Math.max(minValue(), widthRef.current));
 			const sign = edge === "right" ? 1 : -1;
@@ -115,11 +150,12 @@ export function useResizable({
 			window.addEventListener("pointermove", onMove);
 			window.addEventListener("pointerup", onUp);
 		},
-		[applyOnFrame, edge, flushPending, maxValue, minValue, storageKey],
+		[applyOnFrame, edge, flushPending, maxValue, minValue, stopAnimation, storageKey],
 	);
 
 	const onCollapsedPointerDown = useCallback(
 		(event: React.PointerEvent<HTMLElement>) => {
+			stopAnimation();
 			const startX = event.clientX;
 			const sign = edge === "right" ? 1 : -1;
 			let expanded = false;
@@ -144,14 +180,15 @@ export function useResizable({
 			window.addEventListener("pointermove", onMove);
 			window.addEventListener("pointerup", onUp);
 		},
-		[applyOnFrame, edge, expandDragThreshold, flushPending, minValue, onExpand, storageKey],
+		[applyOnFrame, edge, expandDragThreshold, flushPending, minValue, onExpand, stopAnimation, storageKey],
 	);
 
 	/** Double-click the handle to reset to the default width. */
 	const onDoubleClick = useCallback(() => {
+		stopAnimation();
 		apply(defaultWidth);
 		window.localStorage.setItem(storageKey, String(defaultWidth));
-	}, [apply, defaultWidth, storageKey]);
+	}, [apply, defaultWidth, stopAnimation, storageKey]);
 
-	return { onPointerDown, onCollapsedPointerDown, onDoubleClick };
+	return { onPointerDown, onCollapsedPointerDown, onDoubleClick, animateWidth };
 }

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -4,7 +4,29 @@ import { sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "./ui-store"
 describe("sidebar visibility", () => {
 	beforeEach(() => {
 		window.localStorage.clear();
-		useUiStore.setState({ isSidebarOpen: true });
+		useUiStore.setState({
+			browserSidebarAutoResizeAttempted: false,
+			browserSidebarAutoResizeRequested: false,
+			inspectorSessions: {},
+			isSidebarOpen: true,
+		});
+	});
+
+	it("requests the automatic sidebar resize only for the first Browser open in the app session", () => {
+		useUiStore.getState().setInspectorView("session-1", "browser");
+		expect(useUiStore.getState()).toMatchObject({
+			browserSidebarAutoResizeAttempted: false,
+			browserSidebarAutoResizeRequested: true,
+		});
+
+		useUiStore.getState().consumeBrowserSidebarAutoResize();
+		useUiStore.getState().setInspectorView("session-1", "summary");
+		useUiStore.getState().setInspectorView("session-2", "browser");
+
+		expect(useUiStore.getState()).toMatchObject({
+			browserSidebarAutoResizeAttempted: true,
+			browserSidebarAutoResizeRequested: false,
+		});
 	});
 
 	it("changes only through the explicit toggle and persists the preference", () => {

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -67,6 +67,10 @@ export type UiState = {
 	workbenchTab: WorkbenchTab;
 	/** The user's durable sidebar preference. */
 	isSidebarOpen: boolean;
+	/** A transient first-Browser-open request consumed by the mounted Sidebar. */
+	browserSidebarAutoResizeRequested: boolean;
+	/** The first-Browser-open request has already been consumed in this app session. */
+	browserSidebarAutoResizeAttempted: boolean;
 	inspectorSessions: Record<string, InspectorSessionState>;
 	isCommandPaletteOpen: boolean;
 	settingsModal: SettingsModal | null;
@@ -121,6 +125,7 @@ export type UiState = {
 	/** Refresh resolvedTheme from OS without writing light/dark to storage. */
 	syncSystemTheme: () => void;
 	toggleSidebar: () => void;
+	consumeBrowserSidebarAutoResize: () => void;
 	setInspectorOpen: (sessionId: string, isOpen: boolean) => void;
 	toggleInspector: (sessionId: string) => void;
 	setInspectorView: (sessionId: string, view: InspectorView) => void;
@@ -190,6 +195,8 @@ const initialThemeStyle = readStoredThemeStyle();
 export const useUiStore = create<UiState>((set, get) => ({
 	workbenchTab: "changes",
 	isSidebarOpen: initialSidebarOpen(),
+	browserSidebarAutoResizeRequested: false,
+	browserSidebarAutoResizeAttempted: false,
 	inspectorSessions: {},
 	isCommandPaletteOpen: false,
 	settingsModal: null,
@@ -248,6 +255,8 @@ export const useUiStore = create<UiState>((set, get) => ({
 			getLocalStorage()?.setItem(sidebarStorageKey, String(isSidebarOpen));
 			return { isSidebarOpen };
 		}),
+	consumeBrowserSidebarAutoResize: () =>
+		set({ browserSidebarAutoResizeRequested: false, browserSidebarAutoResizeAttempted: true }),
 	setInspectorOpen: (sessionId, isOpen) =>
 		set((state) => {
 			const current = inspectorState(state.inspectorSessions, sessionId);
@@ -272,7 +281,12 @@ export const useUiStore = create<UiState>((set, get) => ({
 		set((state) => {
 			const current = inspectorState(state.inspectorSessions, sessionId);
 			const browserUnseen = view === "browser" ? false : current.browserUnseen;
+			const requestSidebarResize =
+				view === "browser" &&
+				!state.browserSidebarAutoResizeRequested &&
+				!state.browserSidebarAutoResizeAttempted;
 			return {
+				...(requestSidebarResize ? { browserSidebarAutoResizeRequested: true } : {}),
 				inspectorSessions: {
 					...state.inspectorSessions,
 					[sessionId]: { ...current, view, browserUnseen },


### PR DESCRIPTION
## What

Keep the left sidebar visible when the docked Browser opens for the first time in an app session by animating it to AO's existing 200px minimum width.

## Why

The Browser should gain workspace without removing session navigation. The automatic adjustment must happen only once per app session, while explicit sidebar close and resize actions remain authoritative.

Closes #4545

## How

- Raise one transient sidebar-resize request when any session switches to Browser for the first time in the renderer session.
- Let `Sidebar` consume that request and animate the current width to 200px with the shared `SHELL_PANEL_SPRING`; reduced-motion users receive the final width immediately.
- Do not persist the automatic width or modify the durable sidebar-open preference.
- Keep manual close and drag-resize authoritative, including cancelling an in-flight automatic animation when a manual resize starts.
- Preserve the simplified manual sidebar/layout contract from #4823; this change does not restore the removed automatic compact/release system.

## Testing

- Focused Vitest: 4 files, 270/270 tests passed.
- `npm run typecheck`: passed.
- `npx vite build --config vite.renderer.config.ts`: passed; 3443 modules transformed.
- `git diff --check origin/main...HEAD`: passed.

GitHub created new Frontend and gitleaks runs for the rebased fork head, but both are awaiting maintainer approval and have not executed jobs. Their current `action_required` conclusions are approval-gate state, not test results.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.) - awaiting maintainer approval for fork workflows
