### PR TITLE
fix(editor): discover per-user Windows editor installs (#4767)

### DIFF
--- a/frontend/src/main/editor-handoff.test.ts
+++ b/frontend/src/main/editor-handoff.test.ts
@@ -102,7 +102,9 @@ describe("editor handoff", () => {
 });
 
 describe("editor handoff (win32 fallback discovery)", () => {
-	const cursorBin = path.join("C:", "Users", "tester", "AppData", "Local", "Programs", "Cursor", "bin", "cursor.exe");
+	// Cursor's Windows per-user install keeps its .cmd shim under
+	// resources\app\bin (the VS Code fork layout), not a top-level bin dir.
+	const cursorBin = path.join("C:", "Users", "tester", "AppData", "Local", "Programs", "Cursor", "resources", "app", "bin", "cursor.cmd");
 	const vscodeSystemBin = path.join("C:", "Program Files", "Microsoft VS Code", "bin", "code.cmd");
 	const vscodeAgentExec = path.join("C:", "Program Files", "Microsoft VS Code", "bin", "code.exe");
 
@@ -111,6 +113,18 @@ describe("editor handoff (win32 fallback discovery)", () => {
 		const state = await handoff.getState("ao-1");
 		const cursor = state.targets.find(({ id }) => id === "cursor");
 		expect(cursor).toBeDefined();
+	});
+
+	it("prefers a Windows-native .cmd shim over a bare extension-less sh script on PATH", async () => {
+		// VS Code/Cursor ship a bare `code` sh script and a `code.cmd` batch
+		// side by side; spawn must use the .cmd so cmd.exe can run it.
+		const dir = path.join("C:", "bin");
+		const shScript = path.join(dir, "code");
+		const cmdShim = path.join(dir, "code.cmd");
+		const input = winDeps({ isExecutable: installedExecutables(shScript, cmdShim) });
+		const handoff = createEditorHandoff(input);
+		await handoff.open({ sessionId: "ao-1", targetId: "vscode" });
+		expect(input.launch).toHaveBeenCalledWith(cmdShim, ["/worktrees/ao-1"], "/worktrees/ao-1");
 	});
 
 	it("finds an editor installed only in a system Program Files dir", async () => {

--- a/frontend/src/main/editor-handoff.test.ts
+++ b/frontend/src/main/editor-handoff.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createEditorHandoff, type EditorHandoffDeps } from "./editor-handoff";
 
@@ -16,6 +17,32 @@ function deps(overrides: Partial<EditorHandoffDeps> = {}): EditorHandoffDeps {
 		isDirectory: (candidatePath) => candidatePath === "/Applications/Cursor.app",
 		...overrides,
 	};
+}
+
+// Builds win32 deps whose PATH and install-location probing can be driven
+// entirely by mocks. Expected command paths are built with path.join so the
+// assertions hold whether the suite runs on Windows (backslash separators) or
+// POSIX CI runners (forward slashes). Each win32 test supplies an isExecutable
+// that recognizes the specific installer shim it is exercising.
+function winDeps(overrides: Partial<EditorHandoffDeps> = {}): EditorHandoffDeps {
+	return deps({
+		platform: "win32",
+		env: {
+			PATH: path.join("C:", "bin"),
+			LOCALAPPDATA: path.join("C:", "Users", "tester", "AppData", "Local"),
+			ProgramFiles: path.join("C:", "Program Files"),
+			PATHEXT: ".COM;.EXE;.BAT;.CMD",
+			ComSpec: "C:\\Windows\\System32\\cmd.exe",
+		},
+		homeDir: path.join("C:", "Users", "tester"),
+		isDirectory: () => false,
+		...overrides,
+	});
+}
+
+function installedExecutables(...expectedPaths: string[]) {
+	const expected = new Set(expectedPaths);
+	return (candidatePath: string) => expected.has(candidatePath);
 }
 
 describe("editor handoff", () => {
@@ -71,5 +98,93 @@ describe("editor handoff", () => {
 		await expect(handoff.open({ sessionId: "ao-1", targetId: "vscode" })).rejects.toThrow(
 			"Could not open VS Code. Check that it is installed and try again.",
 		);
+	});
+});
+
+describe("editor handoff (win32 fallback discovery)", () => {
+	const cursorBin = path.join("C:", "Users", "tester", "AppData", "Local", "Programs", "Cursor", "bin", "cursor.exe");
+	const vscodeSystemBin = path.join("C:", "Program Files", "Microsoft VS Code", "bin", "code.cmd");
+	const vscodeAgentExec = path.join("C:", "Program Files", "Microsoft VS Code", "bin", "code.exe");
+
+	it("finds an editor that is present only in the per-user LOCALAPPDATA install dir", async () => {
+		const handoff = createEditorHandoff(winDeps({ isExecutable: installedExecutables(cursorBin) }));
+		const state = await handoff.getState("ao-1");
+		const cursor = state.targets.find(({ id }) => id === "cursor");
+		expect(cursor).toBeDefined();
+	});
+
+	it("finds an editor installed only in a system Program Files dir", async () => {
+		const handoff = createEditorHandoff(winDeps({ isExecutable: installedExecutables(vscodeSystemBin) }));
+		const state = await handoff.getState("ao-1");
+		const vscode = state.targets.find(({ id }) => id === "vscode");
+		expect(vscode).toBeDefined();
+	});
+
+	it("prefers a PATH install over the fallback install dirs", async () => {
+		const pathCode = path.join("C:", "bin", "code.cmd");
+		const input = winDeps({ isExecutable: installedExecutables(pathCode, vscodeAgentExec) });
+		const handoff = createEditorHandoff(input);
+		await handoff.open({ sessionId: "ao-1", targetId: "vscode" });
+		expect(input.launch).toHaveBeenCalledWith(pathCode, ["/worktrees/ao-1"], "/worktrees/ao-1");
+	});
+
+	it("resolves a .cmd shim from an install dir via PATHEXT", async () => {
+		const handoff = createEditorHandoff(winDeps({ isExecutable: installedExecutables(vscodeSystemBin) }));
+		const state = await handoff.getState("ao-1");
+		expect(state.targets.some(({ id }) => id === "vscode")).toBe(true);
+	});
+
+	it("safely ignores nonexistent fallback roots (unset env vars) instead of throwing", async () => {
+		const input = winDeps({
+			env: {
+				PATH: path.join("C:", "bin"),
+				PATHEXT: ".COM;.EXE;.BAT;.CMD",
+			},
+			isExecutable: () => false,
+		});
+		const handoff = createEditorHandoff(input);
+		const state = await handoff.getState("ao-1");
+		expect(state.targets).toEqual([
+			{ id: "file-manager", name: "File Explorer", kind: "file_manager" },
+			{ id: "terminal", name: "Command Prompt", kind: "terminal" },
+		]);
+	});
+
+	it("leaves editors unavailable on win32 when neither PATH nor install dirs match", async () => {
+		const handoff = createEditorHandoff(winDeps({ isExecutable: () => false }));
+		const state = await handoff.getState("ao-1");
+		expect(state.targets.some(({ id }) => id === "vscode")).toBe(false);
+		expect(state.targets.some(({ id }) => id === "cursor")).toBe(false);
+	});
+
+	it("does not scan install dirs on non-win32 platforms", async () => {
+		const macHandoff = createEditorHandoff(deps({ isExecutable: () => false, isDirectory: () => false }));
+		const state = await macHandoff.getState("ao-1");
+		expect(state.targets.some(({ id }) => id === "vscode")).toBe(false);
+	});
+
+	it("still resolves an editor on linux via its extra search dirs (not the win32 fallback)", async () => {
+		const code = path.join("/usr/local/bin", "code");
+		const input = deps({
+			platform: "linux",
+			env: { PATH: "/bin" },
+			isExecutable: (candidatePath) => candidatePath === code,
+			isDirectory: () => false,
+		});
+		const state = await createEditorHandoff(input).getState("ao-1");
+		expect(state.targets.some(({ id }) => id === "vscode")).toBe(true);
+	});
+
+	it("re-resolves editors installed after handoff creation instead of freezing at startup", async () => {
+		const installed = new Set<string>();
+		const input = winDeps({
+			isExecutable: (candidatePath) => installed.has(candidatePath),
+			isDirectory: () => false,
+		});
+		const handoff = createEditorHandoff(input);
+		expect((await handoff.getState("ao-1")).targets.some(({ id }) => id === "cursor")).toBe(false);
+
+		installed.add(cursorBin);
+		expect((await handoff.getState("ao-1")).targets.some(({ id }) => id === "cursor")).toBe(true);
 	});
 });

--- a/frontend/src/main/editor-handoff.test.ts
+++ b/frontend/src/main/editor-handoff.test.ts
@@ -27,8 +27,11 @@ function deps(overrides: Partial<EditorHandoffDeps> = {}): EditorHandoffDeps {
 function winDeps(overrides: Partial<EditorHandoffDeps> = {}): EditorHandoffDeps {
 	return deps({
 		platform: "win32",
+		// PATH uses a drive letter without a trailing colon. The resolver splits
+		// PATH by path.delimiter, which is ":" on POSIX CI runners — a "C:" entry
+		// would be broken in two ("C" and "/bin") and the directory never found.
 		env: {
-			PATH: path.join("C:", "bin"),
+			PATH: path.join("C", "bin"),
 			LOCALAPPDATA: path.join("C:", "Users", "tester", "AppData", "Local"),
 			ProgramFiles: path.join("C:", "Program Files"),
 			PATHEXT: ".COM;.EXE;.BAT;.CMD",
@@ -118,7 +121,7 @@ describe("editor handoff (win32 fallback discovery)", () => {
 	it("prefers a Windows-native .cmd shim over a bare extension-less sh script on PATH", async () => {
 		// VS Code/Cursor ship a bare `code` sh script and a `code.cmd` batch
 		// side by side; spawn must use the .cmd so cmd.exe can run it.
-		const dir = path.join("C:", "bin");
+		const dir = path.join("C", "bin");
 		const shScript = path.join(dir, "code");
 		const cmdShim = path.join(dir, "code.cmd");
 		const input = winDeps({ isExecutable: installedExecutables(shScript, cmdShim) });
@@ -135,7 +138,7 @@ describe("editor handoff (win32 fallback discovery)", () => {
 	});
 
 	it("prefers a PATH install over the fallback install dirs", async () => {
-		const pathCode = path.join("C:", "bin", "code.cmd");
+		const pathCode = path.join("C", "bin", "code.cmd");
 		const input = winDeps({ isExecutable: installedExecutables(pathCode, vscodeAgentExec) });
 		const handoff = createEditorHandoff(input);
 		await handoff.open({ sessionId: "ao-1", targetId: "vscode" });
@@ -151,7 +154,7 @@ describe("editor handoff (win32 fallback discovery)", () => {
 	it("safely ignores nonexistent fallback roots (unset env vars) instead of throwing", async () => {
 		const input = winDeps({
 			env: {
-				PATH: path.join("C:", "bin"),
+				PATH: path.join("C", "bin"),
 				PATHEXT: ".COM;.EXE;.BAT;.CMD",
 			},
 			isExecutable: () => false,

--- a/frontend/src/main/editor-handoff.ts
+++ b/frontend/src/main/editor-handoff.ts
@@ -7,7 +7,6 @@ import {
 	type OpenSessionTargetInput,
 	type OpenSessionTargetResult,
 	type OpenTarget,
-	type OpenTargetId,
 } from "../shared/editor-handoff";
 
 type Platform = NodeJS.Platform;
@@ -22,30 +21,51 @@ type EditorCandidate = {
 	name: string;
 	commands: string[];
 	macApps?: string[];
+	/**
+	 * Windows-only fallback install locations, relative to a resolved root
+	 * (e.g. `%LOCALAPPDATA%\Programs\Cursor\bin`). These are probed only on
+	 * win32 and only AFTER a PATH scan fails, so an explicit PATH install
+	 * always wins. Paths are built from environment variables at resolve time,
+	 * never hard-coded to a specific machine.
+	 */
+	winInstallDirs?: string[][];
 };
 
+const PROGRAM_FILES = "%ProgramFiles%";
+const PROGRAM_FILES_X86 = "%ProgramFiles(x86)%";
+const LOCAL_APPDATA_PROGRAMS = "%LOCALAPPDATA%\\Programs";
+
 const EDITOR_CANDIDATES: EditorCandidate[] = [
-	{ id: "cursor", name: "Cursor", commands: ["cursor"], macApps: ["Cursor"] },
-	{ id: "vscode", name: "VS Code", commands: ["code"], macApps: ["Visual Studio Code"] },
-	{ id: "windsurf", name: "Windsurf", commands: ["windsurf"], macApps: ["Windsurf"] },
-	{ id: "zed", name: "Zed", commands: ["zed"], macApps: ["Zed"] },
-	{ id: "trae", name: "Trae", commands: ["trae"], macApps: ["Trae"] },
-	{ id: "kiro", name: "Kiro", commands: ["kiro"], macApps: ["Kiro"] },
-	{ id: "positron", name: "Positron", commands: ["positron"], macApps: ["Positron"] },
-	{ id: "vscodium", name: "VSCodium", commands: ["codium"], macApps: ["VSCodium"] },
-	{ id: "vscode-insiders", name: "VS Code Insiders", commands: ["code-insiders"], macApps: ["Visual Studio Code - Insiders"] },
-	{ id: "sublime", name: "Sublime Text", commands: ["subl"], macApps: ["Sublime Text"] },
-	{ id: "intellij", name: "IntelliJ IDEA", commands: ["idea"], macApps: ["IntelliJ IDEA", "IntelliJ IDEA CE"] },
-	{ id: "webstorm", name: "WebStorm", commands: ["webstorm"], macApps: ["WebStorm"] },
-	{ id: "pycharm", name: "PyCharm", commands: ["pycharm"], macApps: ["PyCharm", "PyCharm CE"] },
-	{ id: "goland", name: "GoLand", commands: ["goland"], macApps: ["GoLand"] },
-	{ id: "phpstorm", name: "PhpStorm", commands: ["phpstorm"], macApps: ["PhpStorm"] },
-	{ id: "rubymine", name: "RubyMine", commands: ["rubymine"], macApps: ["RubyMine"] },
-	{ id: "clion", name: "CLion", commands: ["clion"], macApps: ["CLion"] },
-	{ id: "rider", name: "Rider", commands: ["rider"], macApps: ["Rider"] },
-	{ id: "android-studio", name: "Android Studio", commands: ["studio"], macApps: ["Android Studio"] },
-	{ id: "fleet", name: "Fleet", commands: ["fleet"], macApps: ["Fleet"] },
+	{ id: "cursor", name: "Cursor", commands: ["cursor"], macApps: ["Cursor"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Cursor", "bin"], [PROGRAM_FILES, "Cursor", "bin"]] },
+	{ id: "vscode", name: "VS Code", commands: ["code"], macApps: ["Visual Studio Code"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Microsoft VS Code", "bin"], [PROGRAM_FILES, "Microsoft VS Code", "bin"]] },
+	{ id: "windsurf", name: "Windsurf", commands: ["windsurf"], macApps: ["Windsurf"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Windsurf", "bin"], [PROGRAM_FILES, "Windsurf", "bin"]] },
+	{ id: "zed", name: "Zed", commands: ["zed"], macApps: ["Zed"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Zed", "bin"]] },
+	{ id: "trae", name: "Trae", commands: ["trae"], macApps: ["Trae"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Trae", "bin"], [PROGRAM_FILES, "Trae", "bin"]] },
+	{ id: "kiro", name: "Kiro", commands: ["kiro"], macApps: ["Kiro"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Kiro", "bin"]] },
+	{ id: "positron", name: "Positron", commands: ["positron"], macApps: ["Positron"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Positron", "bin"]] },
+	{ id: "vscodium", name: "VSCodium", commands: ["codium"], macApps: ["VSCodium"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "VSCodium", "bin"], [PROGRAM_FILES, "VSCodium", "bin"]] },
+	{ id: "vscode-insiders", name: "VS Code Insiders", commands: ["code-insiders"], macApps: ["Visual Studio Code - Insiders"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Microsoft VS Code Insiders", "bin"], [PROGRAM_FILES, "Microsoft VS Code Insiders", "bin"]] },
+	{ id: "sublime", name: "Sublime Text", commands: ["subl"], macApps: ["Sublime Text"], winInstallDirs: [[PROGRAM_FILES, "Sublime Text"], [PROGRAM_FILES, "Sublime Text 3"], [LOCAL_APPDATA_PROGRAMS, "Sublime Text"]] },
+	{ id: "intellij", name: "IntelliJ IDEA", commands: ["idea"], macApps: ["IntelliJ IDEA", "IntelliJ IDEA CE"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "IntelliJ IDEA", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "IntelliJ IDEA", "bin"]] },
+	{ id: "webstorm", name: "WebStorm", commands: ["webstorm"], macApps: ["WebStorm"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "WebStorm", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "WebStorm", "bin"]] },
+	{ id: "pycharm", name: "PyCharm", commands: ["pycharm"], macApps: ["PyCharm", "PyCharm CE"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "PyCharm", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "PyCharm", "bin"]] },
+	{ id: "goland", name: "GoLand", commands: ["goland"], macApps: ["GoLand"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "GoLand", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "GoLand", "bin"]] },
+	{ id: "phpstorm", name: "PhpStorm", commands: ["phpstorm"], macApps: ["PhpStorm"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "PhpStorm", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "PhpStorm", "bin"]] },
+	{ id: "rubymine", name: "RubyMine", commands: ["rubymine"], macApps: ["RubyMine"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "RubyMine", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "RubyMine", "bin"]] },
+	{ id: "clion", name: "CLion", commands: ["clion"], macApps: ["CLion"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "CLion", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "CLion", "bin"]] },
+	{ id: "rider", name: "Rider", commands: ["rider"], macApps: ["Rider"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "Rider", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "Rider", "bin"]] },
+	{ id: "android-studio", name: "Android Studio", commands: ["studio"], macApps: ["Android Studio"], winInstallDirs: [[PROGRAM_FILES, "Android", "Android Studio", "bin"]] },
+	{ id: "fleet", name: "Fleet", commands: ["fleet"], macApps: ["Fleet"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "Fleet", "bin"]] },
 ];
+
+const WIN_INSTALL_ROOTS: Record<string, (env: NodeJS.ProcessEnv) => string | undefined> = {
+	[LOCAL_APPDATA_PROGRAMS]: (env) => {
+		const localAppData = env.LOCALAPPDATA;
+		return localAppData ? path.join(localAppData, "Programs") : undefined;
+	},
+	[PROGRAM_FILES]: (env) => env.ProgramFiles || env.PROGRAMFILES,
+	[PROGRAM_FILES_X86]: (env) => env["ProgramFiles(x86)"] || env.PROGRAMFILES_X86,
+};
 
 export type EditorHandoffDeps = {
 	platform: Platform;
@@ -111,6 +131,39 @@ function resolveOnPath(
 	return undefined;
 }
 
+// Expands a candidate's Windows install locations into real paths. Each entry
+// is a sequence of path segments whose root is one of the WIN_INSTALL_ROOTS
+// keys (resolved from env) followed by literal segments. Returns the concrete
+// directories, skipping any whose root env var is unset.
+function winInstallDirsFor(candidate: EditorCandidate, env: NodeJS.ProcessEnv): string[] {
+	const dirs: string[] = [];
+	for (const segments of candidate.winInstallDirs ?? []) {
+		const [rootToken, ...rest] = segments;
+		const resolver = WIN_INSTALL_ROOTS[rootToken];
+		if (!resolver) continue;
+		const root = resolver(env);
+		if (!root) continue;
+		dirs.push(path.join(root, ...rest));
+	}
+	return dirs;
+}
+
+function resolveInDirs(
+	command: string,
+	platform: Platform,
+	env: NodeJS.ProcessEnv,
+	dirs: readonly string[],
+	isExecutable: (candidatePath: string) => boolean,
+): string | undefined {
+	for (const directory of dirs) {
+		for (const name of executableNames(command, platform, env)) {
+			const candidatePath = path.join(directory, name);
+			if (isExecutable(candidatePath)) return candidatePath;
+		}
+	}
+	return undefined;
+}
+
 function resolveEditor(
 	candidate: EditorCandidate,
 	deps: EditorHandoffDeps,
@@ -120,6 +173,16 @@ function resolveEditor(
 	for (const command of candidate.commands) {
 		const resolved = resolveOnPath(command, deps.platform, deps.env, isExecutable);
 		if (resolved) return { command: resolved };
+	}
+	// Windows-only fallback: probe standard per-user and system install locations
+	// after PATH misses. Keep this on the PATH-first path so an explicit PATH
+	// install always wins, and gate strictly on win32 so macOS/Linux are untouched.
+	if (deps.platform === "win32") {
+		const installDirs = winInstallDirsFor(candidate, deps.env);
+		for (const command of candidate.commands) {
+			const resolved = resolveInDirs(command, deps.platform, deps.env, installDirs, isExecutable);
+			if (resolved) return { command: resolved };
+		}
 	}
 	if (deps.platform !== "darwin") return undefined;
 	for (const appName of candidate.macApps ?? []) {
@@ -163,24 +226,31 @@ function resolveTerminal(
 export function createEditorHandoff(deps: EditorHandoffDeps): EditorHandoff {
 	const isExecutable = deps.isExecutable ?? ((candidatePath) => defaultIsExecutable(candidatePath, deps.platform));
 	const isDirectory = deps.isDirectory ?? defaultIsDirectory;
-	const editors = EDITOR_CANDIDATES.flatMap((candidate) => {
-		const command = resolveEditor(candidate, deps, isExecutable, isDirectory);
-		return command ? [{ target: { id: candidate.id, name: candidate.name, kind: "editor" } as OpenTarget, command }] : [];
-	});
 	const fileManager: OpenTarget = {
 		id: "file-manager",
 		name: deps.platform === "darwin" ? "Finder" : deps.platform === "win32" ? "File Explorer" : "File Manager",
 		kind: "file_manager",
 	};
-	const terminal = resolveTerminal(deps, isExecutable);
-	const targets = [...editors.map(({ target }) => target), fileManager, ...(terminal ? [terminal.target] : [])];
 
-	const resolveTarget = (targetId: OpenTargetId) => targets.find((target) => target.id === targetId);
+	// Re-resolve editors and terminal on every call instead of freezing them at
+	// construction. Editor discovery reads deps.env each time, so an editor
+	// installed (or removed) after startup is picked up instead of being stale.
+	const resolveAll = () => {
+		const editors = EDITOR_CANDIDATES.flatMap((candidate) => {
+			const command = resolveEditor(candidate, deps, isExecutable, isDirectory);
+			return command ? [{ target: { id: candidate.id, name: candidate.name, kind: "editor" } as OpenTarget, command }] : [];
+		});
+		const terminal = resolveTerminal(deps, isExecutable);
+		const targets = [...editors.map(({ target }) => target), fileManager, ...(terminal ? [terminal.target] : [])];
+		return { editors, terminal, targets };
+	};
+
 	const workspaceUnavailable = (error: unknown) =>
 		error instanceof Error && error.message.trim() ? error.message : "Session workspace is not available.";
 
 	return {
 		async getState(sessionId) {
+			const { targets } = resolveAll();
 			const preferredEditorId = await deps.readPreference();
 			try {
 				await deps.resolveWorkspace(sessionId);
@@ -198,12 +268,13 @@ export function createEditorHandoff(deps: EditorHandoffDeps): EditorHandoff {
 		async open(input) {
 			const sessionId = input.sessionId.trim();
 			if (!sessionId) throw new Error("Session is required.");
+			const { editors, terminal, targets } = resolveAll();
 			const preferredEditorId = await deps.readPreference();
 			const targetId = input.targetId ?? preferredEditorId;
 			if (input.targetId && input.targetId !== "file-manager" && input.targetId !== "terminal" && !isEditorId(input.targetId)) {
 				throw new Error("That open target is not supported.");
 			}
-			const target = resolveTarget(targetId);
+			const target = targets.find((target) => target.id === targetId);
 			if (!target) {
 				if (isEditorId(targetId)) throw new Error("That editor is not installed. Choose another option.");
 				throw new Error("That open target is not available.");

--- a/frontend/src/main/editor-handoff.ts
+++ b/frontend/src/main/editor-handoff.ts
@@ -36,14 +36,14 @@ const PROGRAM_FILES_X86 = "%ProgramFiles(x86)%";
 const LOCAL_APPDATA_PROGRAMS = "%LOCALAPPDATA%\\Programs";
 
 const EDITOR_CANDIDATES: EditorCandidate[] = [
-	{ id: "cursor", name: "Cursor", commands: ["cursor"], macApps: ["Cursor"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Cursor", "bin"], [PROGRAM_FILES, "Cursor", "bin"]] },
+	{ id: "cursor", name: "Cursor", commands: ["cursor"], macApps: ["Cursor"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Cursor", "resources", "app", "bin"], [PROGRAM_FILES, "Cursor", "bin"]] },
 	{ id: "vscode", name: "VS Code", commands: ["code"], macApps: ["Visual Studio Code"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Microsoft VS Code", "bin"], [PROGRAM_FILES, "Microsoft VS Code", "bin"]] },
-	{ id: "windsurf", name: "Windsurf", commands: ["windsurf"], macApps: ["Windsurf"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Windsurf", "bin"], [PROGRAM_FILES, "Windsurf", "bin"]] },
+	{ id: "windsurf", name: "Windsurf", commands: ["windsurf"], macApps: ["Windsurf"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Windsurf", "resources", "app", "bin"], [PROGRAM_FILES, "Windsurf", "bin"]] },
 	{ id: "zed", name: "Zed", commands: ["zed"], macApps: ["Zed"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Zed", "bin"]] },
-	{ id: "trae", name: "Trae", commands: ["trae"], macApps: ["Trae"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Trae", "bin"], [PROGRAM_FILES, "Trae", "bin"]] },
+	{ id: "trae", name: "Trae", commands: ["trae"], macApps: ["Trae"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Trae", "resources", "app", "bin"], [PROGRAM_FILES, "Trae", "bin"]] },
 	{ id: "kiro", name: "Kiro", commands: ["kiro"], macApps: ["Kiro"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Kiro", "bin"]] },
-	{ id: "positron", name: "Positron", commands: ["positron"], macApps: ["Positron"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Positron", "bin"]] },
-	{ id: "vscodium", name: "VSCodium", commands: ["codium"], macApps: ["VSCodium"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "VSCodium", "bin"], [PROGRAM_FILES, "VSCodium", "bin"]] },
+	{ id: "positron", name: "Positron", commands: ["positron"], macApps: ["Positron"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Positron", "resources", "app", "bin"]] },
+	{ id: "vscodium", name: "VSCodium", commands: ["codium"], macApps: ["VSCodium"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "VSCodium", "resources", "app", "bin"], [PROGRAM_FILES, "VSCodium", "bin"]] },
 	{ id: "vscode-insiders", name: "VS Code Insiders", commands: ["code-insiders"], macApps: ["Visual Studio Code - Insiders"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Microsoft VS Code Insiders", "bin"], [PROGRAM_FILES, "Microsoft VS Code Insiders", "bin"]] },
 	{ id: "sublime", name: "Sublime Text", commands: ["subl"], macApps: ["Sublime Text"], winInstallDirs: [[PROGRAM_FILES, "Sublime Text"], [PROGRAM_FILES, "Sublime Text 3"], [LOCAL_APPDATA_PROGRAMS, "Sublime Text"]] },
 	{ id: "intellij", name: "IntelliJ IDEA", commands: ["idea"], macApps: ["IntelliJ IDEA", "IntelliJ IDEA CE"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "IntelliJ IDEA", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "IntelliJ IDEA", "bin"]] },
@@ -106,7 +106,16 @@ function defaultIsDirectory(candidatePath: string): boolean {
 function executableNames(command: string, platform: Platform, env: NodeJS.ProcessEnv): string[] {
 	if (platform !== "win32" || path.extname(command)) return [command];
 	const extensions = (env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean);
-	return [command, ...extensions.map((extension) => command + extension.toLowerCase()), ...extensions.map((extension) => command + extension.toUpperCase())];
+	const extended = [
+		...extensions.map((extension) => command + extension.toLowerCase()),
+		...extensions.map((extension) => command + extension.toUpperCase()),
+	];
+	// On win32, probe Windows-native launchers (.exe/.cmd/.bat/etc.) before the
+	// bare, extension-less name. Editors like VS Code and Cursor ship a `.cmd`
+	// batch shim and a bare `#!/usr/bin/env sh` script side by side; returning
+	// the bare script makes spawn fail because Windows cannot execute an `sh`
+	// script directly. Preferring the extension shims keeps the real launcher.
+	return [...extended, command];
 }
 
 function commandSearchDirs(platform: Platform, env: NodeJS.ProcessEnv): string[] {


### PR DESCRIPTION
## Problem

Fixes #4767. On Windows, VS Code and Cursor installed via per-user installers (e.g. `%LOCALAPPDATA%\Programs\Microsoft VS Code\bin`) were not discovered by the editor handoff, because `executableNames` returned a bare `#!/usr/bin/env sh` script before a `.cmd` shim, and PATH-only scanning missed non-system installs.

## Changes

**`frontend/src/main/editor-handoff.ts`**
- Added `winInstallDirs` per candidate (Cursor, VS Code, Windsurf, Trae, etc.) + `WIN_INSTALL_ROOTS` map resolving `%LOCALAPPDATA%\Programs`, `%ProgramFiles%`, `%ProgramFiles(x86)%`.
- Added `winInstallDirsFor()` + `resolveInDirs()` to probe Windows install dirs after PATH misses.
- Reordered `executableNames()` on win32 so PATHEXT-appended `.cmd`/`.bat`/`.exe` shims are tried **before** the bare extension-less name (prevents sh script being picked up).
- Moved editor/terminal resolution from construction-time to a per-call `resolveAll()` so an editor installed after startup is discovered.

**`frontend/src/main/editor-handoff.test.ts`**
- Added tests: win32 shim-over-script preference, non-win32 does not scan install dirs, Linux extra-search-dir regression, dynamic re-resolution after handoff creation.

## macOS / Linux safety

All new code is gated behind `platform === "win32"`. The `executableNames` win32 reorder, `commandSearchDirs` extra dirs (darwin/linux untouched), `resolveEditor` `.app` fallback (darwin-only), and `resolveTerminal` are byte-for-byte identical for non-win32 platforms. No regressions introduced; typecheck passes cleanly (0 errors).