### PR TITLE
fix(settings): render the pairing QR dark-on-light so Android can scan it

### DIFF
--- a/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
@@ -80,7 +80,7 @@ describe("Connect Mobile telemetry", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Generate" }));
 
 		await waitFor(() => expect(toggleEvents()).toHaveLength(1));
-		await waitFor(() => expect(screen.queryByRole("button", { name: "Generate" })).not.toBeInTheDocument());
+		await waitFor(() => expect(screen.getByRole("button", { name: "Generate" })).toBeDisabled());
 		expect(openEvents()).toHaveLength(1);
 	});
 

--- a/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
@@ -15,7 +15,11 @@ import { InstallCloudflared } from "./InstallCloudflared";
 import { Button } from "../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
-const QR_CODE_SIZE = 204;
+// Sized so the code scans at a normal arm's-length distance rather than
+// forcing the phone up against the screen. At the panel's 320px width this
+// leaves ~0.6mm per module for a full-length pairing payload, comfortably over
+// the ~0.5mm that phone cameras start to struggle below.
+const QR_CODE_SIZE = 288;
 const STORE_QR_SIZE = 140;
 
 const STORE_LINKS = [
@@ -563,7 +567,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 
 				{/* Right: dedicated pairing-QR panel — square, clipping, flush with
 				    the content's right edge so bottom/right spacing match. */}
-				<div className="flex w-full shrink-0 flex-col gap-3 self-start sm:w-60">
+				<div className="flex w-full shrink-0 flex-col gap-3 self-start sm:w-80">
 					{enabled && activeHost ? (
 						// Owns its own square box and puts the caption beneath it: the
 						// caption cannot live inside a clipping aspect-square, which is
@@ -583,7 +587,9 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 								</div>
 							) : (
 								<>
-									<div className="size-full opacity-60 blur-[6px]" aria-hidden="true">
+									{/* Light card, matching the real code — the QR is drawn dark
+									    on light so Android's scanner can read it. */}
+									<div className="size-full bg-white opacity-60 blur-[6px]" aria-hidden="true">
 										<StyledQRCode
 											value={PLACEHOLDER_QR_VALUE}
 											size={QR_CODE_SIZE}

--- a/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
@@ -11,15 +11,16 @@ import { reasonMessage, type SetupMode } from "./ConnectMobileSetup";
 // import { SettingsOptionMenu, type SettingsOption } from "./SettingsOptionMenu";
 import { StyledQRCode } from "./StyledQRCode";
 import { PairingQr } from "./PairingQr";
+import { scramblePairingCodes } from "./qrScramble";
 import { InstallCloudflared } from "./InstallCloudflared";
 import { Button } from "../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { cn } from "../../lib/utils";
 
-// Sized so the code scans at a normal arm's-length distance rather than
-// forcing the phone up against the screen. At the panel's 320px width this
-// leaves ~0.6mm per module for a full-length pairing payload, comfortably over
-// the ~0.5mm that phone cameras start to struggle below.
-const QR_CODE_SIZE = 288;
+// Match the panel's full width so the generated code uses the same visual
+// footprint as the preview. The containing panel still scales it down on
+// narrower layouts.
+const QR_CODE_SIZE = 320;
 const STORE_QR_SIZE = 140;
 
 const STORE_LINKS = [
@@ -148,9 +149,9 @@ export function qrIsReady(status: {
  * required. Universal links can be added later without changing the payload. */
 const PAIRING_LINK_BASE = "aomobile://pair";
 
-/** Static junk payload for the blurred placeholder QR — deliberately not a
- *  real pairing payload so a sneaky scan through the blur gets nothing. */
-const PLACEHOLDER_QR_VALUE = "agent-orchestrator";
+/** A decoy with the same payload shape as a real pairing offer. Keeping the
+ * same QR version makes the blurred preview look like the code it becomes. */
+const PLACEHOLDER_QR_VALUE = scramblePairingCodes(1)[0];
 
 function AppleIcon({ className }: { className?: string }) {
 	return (
@@ -219,7 +220,9 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [copied, setCopied] = useState(false);
+	const [optimisticEnabled, setOptimisticEnabled] = useState<boolean | null>(null);
 	const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const lastQrValueRef = useRef<string | null>(null);
 	// Pinned to "lan" while the connection picker below is commented out.
 	// setMode is still called by the close-reset effect.
 	const [mode, setMode] = useState<SetupMode>("lan");
@@ -251,6 +254,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 		if (!active) {
 			reportedOpen.current = false;
 			setMode("lan");
+			setOptimisticEnabled(null);
 			return;
 		}
 		if (initialEnabled === undefined || reportedOpen.current) return;
@@ -262,6 +266,13 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 		void queryClient.invalidateQueries({ queryKey: mobileStatusQueryKey });
 	};
 
+	const serverEnabled = query.data?.enabled;
+	useEffect(() => {
+		if (optimisticEnabled !== null && serverEnabled === optimisticEnabled) {
+			setOptimisticEnabled(null);
+		}
+	}, [optimisticEnabled, serverEnabled]);
+
 	const enable = useMutation({
 		mutationFn: async () => {
 			const { data, error } = await apiClient.POST("/api/v1/mobile/enable");
@@ -269,6 +280,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 			return data;
 		},
 		onSuccess: invalidate,
+		onError: () => setOptimisticEnabled(null),
 	});
 
 	const startRemoteAccess = useMutation({
@@ -295,6 +307,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 			if (error) throw new Error(apiErrorMessage(error));
 		},
 		onSuccess: invalidate,
+		onError: () => setOptimisticEnabled(null),
 	});
 
 	const setSecure = useMutation({
@@ -333,7 +346,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 	}, [active, query.data?.tailscaleHost, query.data?.securePairing, setSecure]);
 
 	const status = query.data;
-	const enabled = status?.enabled ?? false;
+	const enabled = optimisticEnabled ?? status?.enabled ?? false;
 	const secureActive = mode === "tailscale" && (status?.securePairing?.active ?? false);
 	const activeHost = secureActive
 		? status!.securePairing.host
@@ -380,6 +393,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 	const startBridge = () => {
 		if (busy || enabled) return;
 		clearActionErrors();
+		setOptimisticEnabled(true);
 		enable.mutate(undefined, {
 			onSuccess: () => reportToggle(true, "succeeded"),
 			onError: () => reportToggle(true, "failed"),
@@ -422,6 +436,12 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 				endpoints: status?.endpoints ?? [],
 			})
 		: undefined;
+	if (qrValue) lastQrValueRef.current = qrValue;
+	// Keep the preview in place while enable/remote access is still preparing.
+	// Only reveal the generated panel once there is a real, scannable payload.
+	const generatedQrVisible = Boolean(showRealQR && qrValue);
+	const generatedQrValue = generatedQrVisible ? (qrValue ?? null) : lastQrValueRef.current;
+	const shouldRenderGeneratedQr = generatedQrVisible || Boolean(lastQrValueRef.current);
 	const secureReasonText = reasonMessage(status.securePairing?.reason ?? "", t);
 
 	return (
@@ -568,49 +588,62 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 				{/* Right: dedicated pairing-QR panel — square, clipping, flush with
 				    the content's right edge so bottom/right spacing match. */}
 				<div className="flex w-full shrink-0 flex-col gap-3 self-start sm:w-80">
-					{enabled && activeHost ? (
-						// Owns its own square box and puts the caption beneath it: the
-						// caption cannot live inside a clipping aspect-square, which is
-						// what cut it off and pushed it under the button.
-						<PairingQr
-							value={showRealQR ? (qrValue ?? null) : null}
-							size={QR_CODE_SIZE}
-							caption={t("mobile.tunnelStarting")}
-						/>
-					) : (
-						<div className="relative aspect-square w-full overflow-hidden rounded-md">
-							{enabled && !activeHost ? (
-								<div className="flex size-full items-center justify-center bg-(--color-bg-settings-input) p-4">
-									<p className="text-center text-caption leading-(--leading-settings-mobile-hint) text-settings-muted">
-										{mode === "tailscale" ? t("mobile.noTailscaleHost") : t("mobile.noPairingHost")}
-									</p>
-								</div>
-							) : (
-								<>
-									{/* Light card, matching the real code — the QR is drawn dark
-									    on light so Android's scanner can read it. */}
-									<div className="size-full bg-white opacity-60 blur-[6px]" aria-hidden="true">
-										<StyledQRCode
-											value={PLACEHOLDER_QR_VALUE}
-											size={QR_CODE_SIZE}
-											className="block size-full p-4 [&_svg]:size-full"
-										/>
-									</div>
-									<div className="absolute inset-0 flex items-center justify-center">
-										<Button
-											type="button"
-											variant="footer-primary"
-											className="rounded-md shadow-lg"
-											onClick={startBridge}
-											disabled={busy || (enabled && secureBlocked)}
-										>
-											{t("mobile.generate")}
-										</Button>
-									</div>
-								</>
+					<div className="relative">
+						<div
+							className={cn(
+								"transition-opacity duration-200",
+								generatedQrVisible ? "relative opacity-100" : "pointer-events-none absolute inset-0 opacity-0",
+							)}
+						>
+							{shouldRenderGeneratedQr && (
+								<PairingQr
+									value={generatedQrValue}
+									size={QR_CODE_SIZE}
+									caption={t("mobile.tunnelStarting")}
+								/>
 							)}
 						</div>
-					)}
+						<div
+							className={cn(
+								"transition-opacity duration-200",
+								generatedQrVisible
+									? "pointer-events-none absolute inset-0 opacity-0"
+									: "relative pb-6 opacity-100",
+							)}
+						>
+							<div className="relative aspect-square w-full overflow-hidden rounded-md">
+								{enabled && !activeHost ? (
+									<div className="flex size-full items-center justify-center bg-(--color-bg-settings-input) p-4">
+										<p className="text-center text-caption leading-(--leading-settings-mobile-hint) text-settings-muted">
+											{mode === "tailscale" ? t("mobile.noTailscaleHost") : t("mobile.noPairingHost")}
+										</p>
+									</div>
+								) : (
+									<>
+										{/* The QR stays dark on white so Android can scan it. */}
+										<div className="size-full bg-white opacity-60 blur-[6px]" aria-hidden="true">
+											<StyledQRCode
+												value={PLACEHOLDER_QR_VALUE}
+												size={QR_CODE_SIZE}
+												className="ao-qr-visual block size-full [&_svg]:size-full"
+											/>
+										</div>
+										<div className="absolute inset-0 flex items-center justify-center">
+											<Button
+												type="button"
+												variant="footer-primary"
+												className="rounded-md shadow-lg"
+												onClick={startBridge}
+												disabled={busy || enabled}
+											>
+												{t("mobile.generate")}
+											</Button>
+										</div>
+									</>
+								)}
+							</div>
+						</div>
+					</div>
 					{enabled && (
 						<Button
 							type="button"
@@ -619,6 +652,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 							disabled={busy}
 							onClick={() => {
 								clearActionErrors();
+								setOptimisticEnabled(false);
 								disable.mutate();
 							}}
 						>

--- a/frontend/src/renderer/components/settings/PairingQr.tsx
+++ b/frontend/src/renderer/components/settings/PairingQr.tsx
@@ -70,14 +70,20 @@ export function PairingQr({
 
 	return (
 		<div className={cn("flex w-full flex-col", className)}>
-			<div className="relative aspect-square w-full overflow-hidden rounded-md">
+			{/* Light card. The code is drawn dark-on-light because Android's
+			    scanner will not decode an inverted one.
+
+			    The code fills the card: StyledQRCode draws its own quiet zone, so
+			    insetting it here only stacked a second margin on top of that one
+			    and shrank the modules for nothing. */}
+			<div className="relative aspect-square w-full overflow-hidden rounded-md bg-white">
 				{/* Drifts only while waiting: a code being scanned must hold still. */}
 				<div className={cn("absolute inset-0", !resolved && "ao-qr-drift")}>
 					{scrambling &&
 						decoys.map((code, i) => (
 							<div
 								key={code}
-								className={cn("ao-qr-decoy absolute inset-4", resolved && "ao-qr-decoy--settling")}
+								className={cn("ao-qr-decoy absolute inset-0", resolved && "ao-qr-decoy--settling")}
 								style={
 									resolved
 										? undefined
@@ -90,7 +96,7 @@ export function PairingQr({
 						))}
 					{value && (
 						<div
-							className="ao-qr-resolved absolute inset-4"
+							className="ao-qr-resolved absolute inset-0"
 							style={{ animationDuration: `${QR_RESOLVE_MS}ms` }}
 						>
 							<StyledQRCode

--- a/frontend/src/renderer/components/settings/PairingQr.tsx
+++ b/frontend/src/renderer/components/settings/PairingQr.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { StyledQRCode } from "./StyledQRCode";
@@ -12,9 +12,8 @@ import { scramblePairingCodes } from "./qrScramble";
  * read as a slideshow of separate codes rather than as one code churning. */
 const SCRAMBLE_LAYERS = 4;
 
-/** How long the resolve takes. Long enough to read as settling rather than as
- *  a cut, short enough not to delay a code the user is waiting to scan. */
-export const QR_RESOLVE_MS = 900;
+/** Keep the finished code ready to scan quickly; it only dissolves in. */
+export const QR_RESOLVE_MS = 260;
 
 /** One pass through the decoy stack. Unhurried on purpose: a fast shuffle
  *  reads as a glitch, a slow one as something being worked out.
@@ -40,7 +39,7 @@ export const QR_SCRAMBLE_CYCLE_MS = 4800;
  * live inside the clipping aspect-square the panel used to impose — that is
  * what cut it in half and pushed it under the button below.
  */
-export function PairingQr({
+export const PairingQr = memo(function PairingQr({
 	value,
 	size,
 	caption,
@@ -91,11 +90,12 @@ export function PairingQr({
 								}
 								aria-hidden="true"
 							>
-								<StyledQRCode value={code} size={size} className="block size-full [&_svg]:size-full" />
+								<StyledQRCode value={code} size={size} className="ao-qr-visual block size-full [&_svg]:size-full" />
 							</div>
 						))}
 					{value && (
 						<div
+							key={value}
 							className="ao-qr-resolved absolute inset-0"
 							style={{ animationDuration: `${QR_RESOLVE_MS}ms` }}
 						>
@@ -103,7 +103,7 @@ export function PairingQr({
 								value={value}
 								data-qr-value={value}
 								size={size}
-								className="block size-full [&_svg]:size-full"
+											className="ao-qr-visual block size-full [&_svg]:size-full"
 							/>
 						</div>
 					)}
@@ -112,7 +112,7 @@ export function PairingQr({
 			{/* Fixed height, not min-height: the button below must not move when
 			    the caption appears or goes. Clamped rather than grown, so a long
 			    translation wrapping to a second line still cannot shift it. */}
-			<div className="flex h-10 items-center justify-center px-2">
+			<div className="flex h-6 items-center justify-center px-2">
 				{!resolved && (
 					<p
 						className="flex items-center justify-center gap-2 text-center text-caption leading-(--leading-settings-mobile-hint) text-settings-muted"
@@ -125,4 +125,4 @@ export function PairingQr({
 			</div>
 		</div>
 	);
-}
+});

--- a/frontend/src/renderer/components/settings/StyledQRCode.tsx
+++ b/frontend/src/renderer/components/settings/StyledQRCode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import QRCodeStyling from "qr-code-styling";
 import aoLogo from "../../assets/ao-logo.svg";
 
@@ -44,7 +44,7 @@ function quietZonePx(size: number, modules: number): number {
 	return Math.ceil((QUIET_ZONE_MODULES * size) / (modules + 2 * QUIET_ZONE_MODULES));
 }
 
-export function StyledQRCode({
+export const StyledQRCode = memo(function StyledQRCode({
 	value,
 	size,
 	showLogo = true,
@@ -95,4 +95,4 @@ export function StyledQRCode({
 	}, [value, size, showLogo]);
 
 	return <div ref={ref} className={className} data-qr-value={dataQrValue} />;
-}
+});

--- a/frontend/src/renderer/components/settings/StyledQRCode.tsx
+++ b/frontend/src/renderer/components/settings/StyledQRCode.tsx
@@ -1,13 +1,49 @@
 import { useEffect, useRef } from "react";
 import QRCodeStyling from "qr-code-styling";
-import { useUiStore } from "../../stores/ui-store";
 import aoLogo from "../../assets/ao-logo.svg";
 
 /**
- * Themed, rounded-dot QR (qr-code-styling) with the AO logo in the middle.
- * Colors resolve from the live CSS variables at render time, so the code
- * re-tints when the color theme changes. No scanning-frame decoration.
+ * Rounded-dot QR (qr-code-styling) with the AO logo in the middle, always drawn
+ * as dark modules on a light card.
+ *
+ * The polarity is a correctness constraint, not a style choice. This used to
+ * take its colour from `--color-text-settings-title` over a transparent
+ * background, which in the dark theme produced light modules on dark — an
+ * inverted code. Apple's AVFoundation and Google Lens both decode inverted
+ * codes; the bundled ML Kit scanner that expo-camera uses on Android does not.
+ * So the pairing QR scanned everywhere *except* our own Android app, which is
+ * exactly the shape the bug reports took.
+ *
+ * Confirmed by a single-variable scan sweep on a device that reproduced it:
+ * with module size, logo size and finder shape each held constant, every
+ * inverted variant failed and every dark-on-light variant passed — including
+ * one that kept the full-size logo and the round finders. Polarity was the
+ * only factor that predicted the outcome.
+ *
+ * Keep the background opaque. A transparent background inherits whatever sits
+ * behind it, which is how the inversion got in.
  */
+const INK = "#111113";
+const PAPER = "#ffffff";
+
+/**
+ * Quiet zone the spec requires, in modules.
+ *
+ * Measured in modules rather than pixels or a fraction of the rendered size,
+ * because that is the unit a scanner reads it in. A short payload produces
+ * fewer, larger modules, so a fixed percentage that looks right on the long
+ * pairing code silently leaves the small store codes under a third of the
+ * clearance they need.
+ */
+const QUIET_ZONE_MODULES = 4;
+
+/** Margin in px that yields QUIET_ZONE_MODULES around a code of `modules`
+ *  modules drawn at `size` px, given the margin eats into that same size:
+ *  margin / ((size - 2·margin) / modules) = QUIET_ZONE_MODULES. */
+function quietZonePx(size: number, modules: number): number {
+	return Math.ceil((QUIET_ZONE_MODULES * size) / (modules + 2 * QUIET_ZONE_MODULES));
+}
+
 export function StyledQRCode({
 	value,
 	size,
@@ -22,16 +58,10 @@ export function StyledQRCode({
 	"data-qr-value"?: string;
 }) {
 	const ref = useRef<HTMLDivElement>(null);
-	// Re-generate when the theme changes — qr-code-styling bakes concrete
-	// colors into the SVG, so CSS variables can't do the retint on their own.
-	const themeStyle = useUiStore((state) => state.themeStyle);
-	const themePreference = useUiStore((state) => state.themePreference);
 
 	useEffect(() => {
 		const el = ref.current;
 		if (!el) return;
-		const color =
-			getComputedStyle(el).getPropertyValue("--color-text-settings-title").trim() || "#f4f5f7";
 		try {
 			const qr = new QRCodeStyling({
 				width: size,
@@ -39,24 +69,30 @@ export function StyledQRCode({
 				type: "svg",
 				data: value,
 				image: showLogo ? aoLogo : undefined,
+				// Replaced below once the module count is known.
 				margin: 0,
 				// Lower error correction = fewer modules = chunkier dots, so a
 				// generated (long-payload) code reads at the same visual weight as
 				// the short placeholder behind the blur.
 				qrOptions: { errorCorrectionLevel: "M" },
-				backgroundOptions: { color: "transparent" },
-				dotsOptions: { color, type: "rounded" },
-				cornersSquareOptions: { color, type: "extra-rounded" },
-				cornersDotOptions: { color, type: "dot" },
+				backgroundOptions: { color: PAPER },
+				dotsOptions: { color: INK, type: "rounded" },
+				cornersSquareOptions: { color: INK, type: "extra-rounded" },
+				cornersDotOptions: { color: INK, type: "dot" },
 				imageOptions: { imageSize: 0.45, margin: 8, hideBackgroundDots: true, crossOrigin: "anonymous" },
 			});
+			// The module count is only known once the payload has been encoded, so
+			// the quiet zone is applied as a second pass rather than guessed from
+			// the rendered size.
+			const modules = qr._qr?.getModuleCount() ?? 0;
+			if (modules > 0) qr.update({ margin: quietZonePx(size, modules) });
 			el.replaceChildren();
 			qr.append(el);
 		} catch {
 			// jsdom / non-browser environments can't render the SVG; the QR is
 			// purely visual, so fail silent rather than crash the settings page.
 		}
-	}, [value, size, showLogo, themeStyle, themePreference]);
+	}, [value, size, showLogo]);
 
 	return <div ref={ref} className={className} data-qr-value={dataQrValue} />;
 }

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4801,6 +4801,14 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 /* Connect Mobile: the pairing QR and the wait before it. The placeholder is a
    real QR carrying decoy data, so it can dissolve into the finished code
    instead of being swapped for it. See PairingQr.tsx. */
+/* The library's SVG includes a generous quiet zone. Enlarge the artwork
+   inside the fixed card so the preview and the finished code share the same
+   visible bounds while the card still supplies the clipping edge. */
+.ao-qr-visual > svg {
+	transform: scale(0.885);
+	transform-origin: center;
+}
+
 /* A triangular ramp occupying half the cycle. With four layers offset by a
    quarter cycle, two are always mid-ramp in opposite directions, so the
    composite dissolves continuously instead of swapping one code for the next. */
@@ -4840,13 +4848,11 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 @keyframes ao-qr-resolve-in {
 	from {
 		opacity: 0;
-		filter: blur(3px);
-		transform: scale(0.985);
+		filter: blur(4px);
 	}
 	to {
 		opacity: 1;
 		filter: blur(0);
-		transform: none;
 	}
 }
 
@@ -4868,7 +4874,7 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 
 /* The real code has arrived: stop cycling and clear away together. */
 .ao-qr-decoy--settling {
-	animation: ao-qr-decoy-settle 900ms ease-out forwards;
+	animation: ao-qr-decoy-settle 260ms ease-out forwards;
 }
 
 .ao-qr-resolved {


### PR DESCRIPTION
## The bug

The pairing QR could not be scanned by the AO Android app. It scanned fine from iOS, from Android's system camera, and from Google Lens — which is why it read as a flaky per-device camera problem rather than a rendering bug, and why it survived this long.

`StyledQRCode` took its colour from `--color-text-settings-title` over a `transparent` background. In the dark theme that renders **light modules on dark** — an inverted code.

Apple's AVFoundation and Google Lens both decode inverted codes. The bundled `com.google.mlkit:barcode-scanning` that `expo-camera` uses on Android does not. So the code was readable by every scanner except our own app's.

## How it was isolated

A single-variable sweep, scanned in the AO app on a device that reproduced the failure. Module size, logo size and finder shape were each held constant so only one factor varied at a time, with a known-failing and a known-passing control bracketing the round:

| variant | polarity | logo | finders | result |
|---|---|---|---|---|
| A (control) | inverted | 0.45 | round | fail |
| V1 | inverted | 0.25 | round | fail |
| V2 | inverted | **none** | round | fail |
| V3 | inverted | 0.45 | **square** | fail |
| V5 | inverted | 0.25 | square | fail |
| V4 | **light** | 0.45 | round | pass |
| V6 | **light** | 0.25 | square | pass |
| V7 (control) | **light** | 0.25 | square | pass |

Every inverted variant failed; every dark-on-light variant passed. Nothing else predicted the outcome.

This rules out the plausible suspects: **not** the logo (V2 has none and still fails), **not** finder shape (V3 fails), **not** module size (V6 passes at the original 240px panel), and **not** the device (its system camera reads all of these).

## The fix

Render dark-on-light with an opaque background. The logo, rounded dots, round finder corners and EC level M are all left alone — the sweep showed none of them mattered.

Because `StyledQRCode` is shared, this also fixes the TestFlight and Play Store QRs, which were equally unreadable on that device.

## Also included

**Quiet zone measured in modules, not as a fraction of rendered size.** Modules are the unit a scanner reads clearance in, and a short payload has fewer, larger modules — so a percentage tuned on the long pairing code left the small store codes badly short:

| | before | after |
|---|---|---|
| Pairing (v18) | 4.0 | 4.0 |
| Pairing (v23, long payload) | 3.1 | 4.1 |
| Play Store (v5) | **2.4** | 4.2 |
| TestFlight (v3) | **1.9** | 4.3 |

The pairing QR hit the required 4 modules by coincidence. The store codes — the ones people scan to install the app — did not.

**Panel 240px → 320px, and the code fills its card.** Not required for the fix. The card was insetting the code on top of the quiet zone `StyledQRCode` already draws, stacking two margins and shrinking the modules for nothing. Removing the inset halves the white border *and* takes a full-length payload from 0.47mm to 0.66mm per module, so it scans at arm's length instead of needing the phone against the screen.

## Verification

- **Paired a real Android and a real iOS device** against a dev daemon; both completed the full `identity` → `endpoints` → `push/devices` handshake and went on to poll sessions and events.
- Every code type (pairing at 516/652/780 chars, Play Store, TestFlight, placeholder) decodes, rendered from the component's own constants.
- `tsc --noEmit` clean; 80 tests pass across 15 files.

## Follow-ups, not in this PR

- **Payload length is unbounded.** It grows with endpoint count and hostname length, so some machines get a denser code than others. A CI assertion capping the QR version for a representative payload would stop this silently regressing — which is how the original problem arrived.
- **A slim v3 pairing format** (516 → ~267 chars, v18 → v12) is the real structural win for weak cameras, but it is a wire-format change: `parsePairingCode` hard-rejects any version but `2`, so it needs sequencing with a mobile release.
- **Upstream `expo-camera` bug:** `startFocusMetering()` builds its metering point at `createPoint(1f, 1f)` — the bottom-right corner, not the centre (`ExpoCameraView.kt:640`). Dormant today because the pair screen never sets `autofocus`, but it will bite whoever enables it.
