### PR TITLE
feat: validate repositories before cloning

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -69,14 +69,15 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 			// resolves — an incomplete object would throw the moment the app touched
 			// a missing method.
 			const ao = {
-					app: {
-						getVersion: async () => version,
-						chooseDirectory: async () => null,
-						openExternal: async () => undefined,
-						scanImportFolder: async ({ path }: { path: string }) => ({ path, repos: [] }),
-						checkAncestorRepo: async () => undefined,
-						getRepositoryBranch: async () => undefined,
-						getPathForFile: () => "",
+				app: {
+					getVersion: async () => version,
+					chooseDirectory: async () => null,
+					checkGitRepository: async () => true,
+					openExternal: async () => undefined,
+					scanImportFolder: async ({ path }: { path: string }) => ({ path, repos: [] }),
+					checkAncestorRepo: async () => undefined,
+					getRepositoryBranch: async () => undefined,
+					getPathForFile: () => "",
 					onOpenFolderPath: () => () => undefined,
 					onNewSessionShortcut: unsubscribe,
 					onKeyboardShortcutsHelp: unsubscribe,
@@ -594,14 +595,15 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				...(error ? { error } : {}),
 			});
 			const ao = {
-					app: {
-						getVersion: async () => version,
-						chooseDirectory: async () => null,
-						openExternal: async () => undefined,
-						scanImportFolder: async ({ path }: { path: string }) => ({ path, repos: [] }),
-						checkAncestorRepo: async () => undefined,
-						getRepositoryBranch: async () => undefined,
-						getPathForFile: () => "",
+				app: {
+					getVersion: async () => version,
+					chooseDirectory: async () => null,
+					checkGitRepository: async () => true,
+					openExternal: async () => undefined,
+					scanImportFolder: async ({ path }: { path: string }) => ({ path, repos: [] }),
+					checkAncestorRepo: async () => undefined,
+					getRepositoryBranch: async () => undefined,
+					getPathForFile: () => "",
 					onOpenFolderPath: () => () => undefined,
 					onNewSessionShortcut: unsubscribe,
 					onKeyboardShortcutsHelp: unsubscribe,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -51,13 +51,14 @@ import {
 	writeUiSettings,
 	type UiSettings,
 } from "./main/ui-settings";
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { chmod, copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { type DaemonLaunchSpec, bundledDaemonIdentityError, resolveDaemonLaunch } from "./shared/daemon-launch";
 import { createListenPortScanner, defaultRunFilePath, parseRunFile } from "./shared/daemon-discovery";
 import type { DaemonStatus } from "./shared/daemon-status";
@@ -145,6 +146,8 @@ import { AGENT_SWITCH_VISIBILITY_IPC_CHANNEL } from "./shared/agent-switch-obser
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
+
+const execFileAsync = promisify(execFile);
 
 // Windows GUI launches (e.g. from a Start-menu/desktop shortcut) have no attached
 // console, so process.stdout and process.stderr are dead pipes. The daemon-output
@@ -2023,6 +2026,18 @@ async function chooseDirectory(title: string): Promise<string | null> {
 
 ipcMain.handle("app:chooseDirectory", async (_event, title?: string) => {
 	return chooseDirectory(typeof title === "string" && title.trim() ? title : "Choose a git repository");
+});
+ipcMain.handle("app:checkGitRepository", async (_event, remoteUrl: string) => {
+	await ensureShellEnv();
+	try {
+		await execFileAsync("git", ["ls-remote", "--quiet", remoteUrl, "HEAD"], {
+			env: daemonEnv(),
+			timeout: 8000,
+		});
+		return true;
+	} catch {
+		return false;
+	}
 });
 ipcMain.handle("app:scanImportFolder", async (_event, input: { path: string; mode: "project" | "workspace" }) => {
 	await ensureShellEnv();

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -159,6 +159,7 @@ const api = {
 	app: {
 		getVersion: () => ipcRenderer.invoke("app:getVersion") as Promise<string>,
 		chooseDirectory: (title?: string) => ipcRenderer.invoke("app:chooseDirectory", title) as Promise<string | null>,
+		checkGitRepository: (remoteUrl: string) => ipcRenderer.invoke("app:checkGitRepository", remoteUrl) as Promise<boolean>,
 		openExternal: (url: string) => ipcRenderer.invoke("app:openExternal", url) as Promise<void>,
 		scanImportFolder: (input: { path: string; mode: ImportFolderMode }) =>
 			ipcRenderer.invoke("app:scanImportFolder", input) as Promise<ImportFolderScan>,

--- a/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
@@ -21,6 +21,9 @@ describe("clone repository input", () => {
 		"https://example.com/acme/repo.git?access_token=secret",
 		"ssh://git:secret@example.com/acme/repo.git",
 		"https://github.com/acme/two words.git",
+		"https://github.com/acme/web-app/pull/123",
+		"https://github.com/acme/web-app/issues/12",
+		"https://gitlab.com/acme/web-app/-/merge_requests/12",
 		"file:///tmp/bad%ZZ.git",
 	])("rejects unsafe or incomplete URL %s", (remoteUrl) => {
 		expect(repositoryNameFromGitUrl(remoteUrl)).toBeNull();

--- a/frontend/src/renderer/components/CloneRepositoryDialog.tsx
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.tsx
@@ -1,6 +1,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { ChevronLeft, Folder, Link2, X } from "lucide-react";
-import { type FormEvent, useEffect, useState } from "react";
+import { ChevronLeft, Folder, Link2, LoaderCircle, X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { aoBridge } from "../lib/bridge";
 import { Button } from "./ui/button";
@@ -43,6 +44,8 @@ export default function CloneRepositoryDialog({
 }) {
 	const { t } = useTranslation();
 	const [submitted, setSubmitted] = useState(false);
+	const [repositoryCheck, setRepositoryCheck] = useState<"idle" | "checking" | "valid" | "invalid">("idle");
+	const repositoryCheckRequest = useRef(0);
 	const [choosingDestination, setChoosingDestination] = useState(false);
 	const [destinationPickerError, setDestinationPickerError] = useState<string | null>(null);
 	const repositoryName = repositoryNameFromGitUrl(value.remoteUrl);
@@ -57,9 +60,39 @@ export default function CloneRepositoryDialog({
 			(targetPath && existingProjectPaths.some((path) => sameProjectPath(path, targetPath)))),
 	);
 	const urlError = hasRemoteUrl && !repositoryName ? t("createProject.cloneInvalidUrl") : null;
+	const repositoryAccessError = repositoryName && repositoryCheck === "invalid"
+		? t("createProject.cloneRepositoryUnavailable", {
+				defaultValue: "This isn't a repository or you don't have access",
+			})
+		: null;
 	const duplicateError = repositoryName && projectExists ? t("createProject.cloneProjectExists") : null;
+	const inlineRepositoryError = urlError ?? repositoryAccessError ?? duplicateError;
 	const destinationError = submitted && !value.destinationParent ? t("createProject.cloneDestinationRequired") : null;
-	const canContinue = Boolean(repositoryName && value.destinationParent && !projectExists && !disabled && !choosingDestination);
+	const canContinue = Boolean(
+		repositoryName &&
+		repositoryCheck === "valid" &&
+		value.destinationParent &&
+		!projectExists &&
+		!disabled &&
+		!choosingDestination,
+	);
+
+	useEffect(() => {
+		const requestId = ++repositoryCheckRequest.current;
+		if (!repositoryName) {
+			setRepositoryCheck("idle");
+			return;
+		}
+		setRepositoryCheck("checking");
+		const timer = window.setTimeout(() => {
+			void aoBridge.app.checkGitRepository(value.remoteUrl.trim()).then((exists) => {
+				if (requestId === repositoryCheckRequest.current) setRepositoryCheck(exists ? "valid" : "invalid");
+			}).catch(() => {
+				if (requestId === repositoryCheckRequest.current) setRepositoryCheck("invalid");
+			});
+		}, 300);
+		return () => window.clearTimeout(timer);
+	}, [repositoryName, value.remoteUrl]);
 
 	const chooseDestination = async () => {
 		setDestinationPickerError(null);
@@ -135,40 +168,49 @@ export default function CloneRepositoryDialog({
 							) : null}
 
 							<div className="space-y-2">
-								<Label htmlFor="cloneRepositoryUrl" className="text-[13px] font-semibold text-[var(--color-text-import-title)]">
-									{t("createProject.cloneRepositoryUrl")}
-								</Label>
+								<div className="relative">
+									<Label htmlFor="cloneRepositoryUrl" className="text-[13px] font-semibold text-[var(--color-text-import-title)]">
+										{t("createProject.cloneRepositoryUrl")}
+									</Label>
+									<AnimatePresence initial={false}>
+										{inlineRepositoryError ? (
+											<motion.p
+												key={urlError ? "repository-url-error" : repositoryAccessError ? "repository-access-error" : "duplicate-project-error"}
+												initial={{ opacity: 0, filter: "blur(2px)" }}
+												animate={{ opacity: 1, filter: "blur(0px)" }}
+												exit={{ opacity: 0, filter: "blur(2px)" }}
+												transition={{ duration: 0.15, ease: "easeOut" }}
+												className="absolute right-0 top-0 max-w-[65%] truncate overflow-hidden whitespace-nowrap text-right text-[12px] leading-5 text-destructive"
+												role="alert"
+											>
+												{inlineRepositoryError}
+											</motion.p>
+										) : null}
+									</AnimatePresence>
+								</div>
 								<div className="relative">
 									<Input
 										id="cloneRepositoryUrl"
 										autoFocus
 										autoCapitalize="none"
 										autoComplete="off"
-										aria-describedby={urlError ? "cloneRepositoryUrlError" : "cloneRepositoryUrlHelp"}
-										aria-invalid={urlError ? true : undefined}
-										className="bg-[var(--color-bg-import-card)] pl-10 font-mono text-[13px]"
+										aria-describedby="cloneRepositoryUrlHelp"
+										aria-invalid={urlError || repositoryAccessError || duplicateError ? true : undefined}
+										className="bg-[var(--color-bg-import-card)] pl-10 pr-10 font-mono text-[13px]"
 										disabled={disabled}
 										placeholder={t("createProject.cloneRepositoryUrlPlaceholder")}
 										spellCheck={false}
 										value={value.remoteUrl}
 										onChange={(event) => onChange({ ...value, remoteUrl: event.target.value })}
 									/>
+									{repositoryCheck === "checking" ? (
+										<LoaderCircle className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 animate-spin text-muted-foreground" aria-label={t("createProject.cloneCheckingRepository", { defaultValue: "Checking repository" })} />
+									) : null}
 									<RepositoryOwnerIcon owner={repositoryAvatar?.owner ?? null} avatarUrl={repositoryAvatar?.url ?? null} />
 								</div>
-								{urlError ? (
-									<p id="cloneRepositoryUrlError" className="text-pretty text-[12px] leading-5 text-destructive" role="alert">
-										{urlError}
-									</p>
-								) : (
-									<span id="cloneRepositoryUrlHelp" className="sr-only">
-										{t("createProject.cloneRepositoryUrlHelp")}
-									</span>
-								)}
-								{duplicateError ? (
-									<p className="text-pretty text-[12px] leading-5 text-destructive" role="alert">
-										{duplicateError}
-									</p>
-								) : null}
+								<span id="cloneRepositoryUrlHelp" className="sr-only">
+									{t("createProject.cloneRepositoryUrlHelp")}
+								</span>
 							</div>
 
 							<div className="space-y-2">

--- a/frontend/src/renderer/components/CloneRepositoryDialog.tsx
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.tsx
@@ -26,6 +26,8 @@ export default function CloneRepositoryDialog({
 	onClose,
 	onContinue,
 	open,
+	existingProjectPaths = [],
+	existingProjectNames = [],
 	value,
 }: {
 	disabled: boolean;
@@ -35,6 +37,8 @@ export default function CloneRepositoryDialog({
 	onClose: () => void;
 	onContinue: (selection: CloneRepositorySelection) => void;
 	open: boolean;
+	existingProjectPaths?: readonly string[];
+	existingProjectNames?: readonly string[];
 	value: CloneRepositoryDetails;
 }) {
 	const { t } = useTranslation();
@@ -43,8 +47,19 @@ export default function CloneRepositoryDialog({
 	const [destinationPickerError, setDestinationPickerError] = useState<string | null>(null);
 	const repositoryName = repositoryNameFromGitUrl(value.remoteUrl);
 	const repositoryAvatar = repositoryAvatarFromGitUrl(value.remoteUrl);
-	const urlError = submitted && !repositoryName ? t("createProject.cloneInvalidUrl") : null;
+	const hasRemoteUrl = value.remoteUrl.trim().length > 0;
+	const targetPath = repositoryName && value.destinationParent
+		? joinCloneDestination(value.destinationParent, repositoryName)
+		: "";
+	const projectExists = Boolean(
+		repositoryName &&
+		(existingProjectNames.some((name) => sameProjectName(name, repositoryName)) ||
+			(targetPath && existingProjectPaths.some((path) => sameProjectPath(path, targetPath)))),
+	);
+	const urlError = hasRemoteUrl && !repositoryName ? t("createProject.cloneInvalidUrl") : null;
+	const duplicateError = repositoryName && projectExists ? t("createProject.cloneProjectExists") : null;
 	const destinationError = submitted && !value.destinationParent ? t("createProject.cloneDestinationRequired") : null;
+	const canContinue = Boolean(repositoryName && value.destinationParent && !projectExists && !disabled && !choosingDestination);
 
 	const chooseDestination = async () => {
 		setDestinationPickerError(null);
@@ -69,11 +84,11 @@ export default function CloneRepositoryDialog({
 	const submit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		setSubmitted(true);
-		if (!repositoryName || !value.destinationParent || disabled) return;
+		if (!canContinue) return;
 		onContinue({
 			...value,
 			remoteUrl: value.remoteUrl.trim(),
-			targetPath: joinCloneDestination(value.destinationParent, repositoryName),
+			targetPath,
 		});
 	};
 
@@ -149,6 +164,11 @@ export default function CloneRepositoryDialog({
 										{t("createProject.cloneRepositoryUrlHelp")}
 									</span>
 								)}
+								{duplicateError ? (
+									<p className="text-pretty text-[12px] leading-5 text-destructive" role="alert">
+										{duplicateError}
+									</p>
+								) : null}
 							</div>
 
 							<div className="space-y-2">
@@ -184,7 +204,7 @@ export default function CloneRepositoryDialog({
 
 						<div className="flex shrink-0 justify-end gap-2 px-4 pb-4 pt-3">
 							<div className="flex items-center justify-end gap-3">
-								<Button type="submit" variant="primary" disabled={disabled || choosingDestination}>
+								<Button type="submit" variant="primary" disabled={!canContinue}>
 									{t("createProject.cloneContinue")}
 								</Button>
 							</div>
@@ -246,8 +266,10 @@ export function repositoryNameFromGitUrl(raw: string): string | null {
 	const value = raw.trim();
 	if (!value || /\s/.test(value) || value.startsWith("-")) return null;
 	let remotePath = "";
+	let host = "";
 	const scpMatch = value.match(/^[^/@:\s]+@[^/:\s]+:(.+)$/);
 	if (scpMatch?.[1]) {
+		host = value.match(/^[^/@:\s]+@([^/:\s]+):/)?.[1]?.toLowerCase() ?? "";
 		remotePath = scpMatch[1];
 	} else {
 		try {
@@ -260,6 +282,7 @@ export function repositoryNameFromGitUrl(raw: string): string | null {
 			) {
 				return null;
 			}
+			host = parsed.hostname.toLowerCase();
 			// URL.pathname preserves percent escapes, while Go's net/url exposes a
 			// decoded URL.Path to the daemon. Decode once so this preview names the
 			// exact directory the daemon will create, including escaped separators.
@@ -268,7 +291,20 @@ export function repositoryNameFromGitUrl(raw: string): string | null {
 			return null;
 		}
 	}
-	const lastSegment = remotePath.replace(/[\\/]+$/, "").split(/[\\/]/).pop() ?? "";
+	const segments = remotePath.replace(/[\\/]+$/, "").split(/[\\/]/).filter(Boolean);
+	if (segments.length < 2) return null;
+	const providerSubpage = segments[2];
+	if (
+		(host === "github.com" &&
+			["actions", "blob", "commit", "commits", "compare", "issues", "pull", "releases", "settings", "tree", "wiki"].includes(
+				providerSubpage ?? "",
+			)) ||
+		(host === "bitbucket.org" && providerSubpage === "pull-requests") ||
+		(host === "gitlab.com" && segments.includes("merge_requests"))
+	) {
+		return null;
+	}
+	const lastSegment = segments[segments.length - 1] ?? "";
 	const name = lastSegment.replace(/\.git$/, "");
 	if (!name || name === "." || name === ".." || /[\\/<>:"|?*]/.test(name)) return null;
 	return name;
@@ -322,6 +358,17 @@ function repositoryRemoteParts(raw: string): RepositoryRemoteParts | null {
 
 	const segments = remotePath.replace(/[\\/]+$/, "").split(/[\\/]/).filter(Boolean);
 	if (segments.length < 2) return null;
+	const providerSubpage = segments[2];
+	if (
+		(host === "github.com" &&
+			["actions", "blob", "commit", "commits", "compare", "issues", "pull", "releases", "settings", "tree", "wiki"].includes(
+				providerSubpage ?? "",
+			)) ||
+		(host === "bitbucket.org" && providerSubpage === "pull-requests") ||
+		(host === "gitlab.com" && segments.includes("merge_requests"))
+	) {
+		return null;
+	}
 	const repository = segments[segments.length - 1]?.replace(/\.git$/, "");
 	const owner = segments[0];
 	if (!repository || !owner || repository === "." || repository === ".." || /[\\/<>:"|?*]/.test(repository)) return null;
@@ -331,4 +378,15 @@ function repositoryRemoteParts(raw: string): RepositoryRemoteParts | null {
 export function joinCloneDestination(parent: string, repositoryName: string): string {
 	const separator = parent.includes("\\") && !parent.includes("/") ? "\\" : "/";
 	return `${parent.replace(/[\\/]+$/, "")}${separator}${repositoryName}`;
+}
+
+function sameProjectPath(left: string, right: string): boolean {
+	const normalize = (path: string) => path.replace(/[\\/]+$/, "").replaceAll("\\", "/");
+	const normalizedLeft = normalize(left);
+	const normalizedRight = normalize(right);
+	return normalizedLeft.toLowerCase() === normalizedRight.toLowerCase();
+}
+
+function sameProjectName(left: string, right: string): boolean {
+	return left.trim().toLowerCase() === right.trim().toLowerCase();
 }

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -640,6 +640,8 @@ export function CommandPalette() {
 				onCloneProject={cloneProject}
 				onCreateProject={createProject}
 				onInitializeProject={initializeProjectRepository}
+				existingProjectPaths={workspaces.map((workspace) => workspace.path)}
+				existingProjectNames={workspaces.map((workspace) => workspace.name)}
 			>
 				{({ choosePath }) => <BindChoosePath choosePath={choosePath} choosePathRef={choosePathRef} />}
 			</CreateProjectFlow>

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -65,8 +65,12 @@ export function CreateProjectFlow({
 	onInitializeProject,
 	openSignal,
 	sourceSignal,
+	existingProjectPaths = [],
+	existingProjectNames = [],
 }: {
 	children?: (state: { choosePath: () => void; disabled: boolean; error: string | null; label: string }) => ReactNode;
+	existingProjectPaths?: readonly string[];
+	existingProjectNames?: readonly string[];
 	// A folder was dropped on the app window (ShellLayout owns the global
 	// listener). Mirrors openSignal but carries a path: skips straight to the
 	// mode picker with the native OS dialog step skipped.
@@ -525,6 +529,8 @@ export function CreateProjectFlow({
 								}, 80);
 							}}
 							open={cloneDialogOpen}
+							existingProjectPaths={existingProjectPaths}
+							existingProjectNames={existingProjectNames}
 							value={cloneDetails}
 						/>
 					) : null}

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -1,4 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
+import type { TFunction } from "i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import {
@@ -30,6 +31,7 @@ import { cn } from "../lib/utils";
 import type { ProjectKind } from "../types/workspace";
 import { CreateProjectAgentSheet, type CreateProjectAgentSelection } from "./CreateProjectAgentSheet";
 import CloneRepositoryDialog, { type CloneRepositoryDetails, type CloneRepositorySelection } from "./CloneRepositoryDialog";
+import CreateProjectProgressDialog from "./CreateProjectProgressDialog";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -37,7 +39,7 @@ import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
 
 export type CreateProjectInput = { path: string; asWorkspace?: boolean; defaultBranch?: string } & CreateProjectAgentSelection;
 export type CloneProjectInput = Pick<CloneRepositorySelection, "remoteUrl" | "destinationParent"> &
-	CreateProjectAgentSelection;
+	CreateProjectAgentSelection & { signal?: AbortSignal };
 
 const LAST_CLONE_DESTINATION_KEY = "ao.clone.lastDestinationParent";
 const LAST_IMPORT_REMOTE_URL_KEY = "ao.import.lastRemoteUrl";
@@ -50,6 +52,24 @@ type ProjectSource = "clone" | "local" | "workspace";
 
 /** Where the new project should live: on this machine or in AO Cloud. */
 type ProjectOffering = "local" | "cloud";
+type CloneProgressStage = "starting" | "connecting" | "cloning" | "settingUp" | "finishing" | "complete";
+
+function cloneProgressMessage(t: TFunction, stage: CloneProgressStage): string {
+	switch (stage) {
+		case "starting":
+			return t("createProject.cloneProgressStarting", { defaultValue: "Preparing the project" });
+		case "connecting":
+			return t("createProject.cloneProgressConnecting", { defaultValue: "Connecting to the repository" });
+		case "cloning":
+			return t("createProject.cloneProgressCloning", { defaultValue: "Cloning the repository" });
+		case "settingUp":
+			return t("createProject.cloneProgressSettingUp", { defaultValue: "Setting up the project" });
+		case "finishing":
+			return t("createProject.cloneProgressFinishing", { defaultValue: "Finishing project setup" });
+		default:
+			return t("createProject.cloneProgressComplete", { defaultValue: "Project created" });
+	}
+}
 
 // Shared create-project flow. Local projects/workspaces use the native folder
 // picker; remote projects progressively reveal a lazily loaded clone form.
@@ -117,6 +137,11 @@ export function CreateProjectFlow({
 	const [isCreating, setIsCreating] = useState(false);
 	const [isInitializing, setIsInitializing] = useState(false);
 	const [isPreparingGit, setIsPreparingGit] = useState(false);
+	const [cloneProgressOpen, setCloneProgressOpen] = useState(false);
+	const [cloneProgress, setCloneProgress] = useState(0);
+	const [cloneProgressStage, setCloneProgressStage] = useState<CloneProgressStage>("starting");
+	const cloneAbortController = useRef<AbortController | null>(null);
+	const cloneCancelled = useRef(false);
 	const [repositorySetup, setRepositorySetup] = useState<"NOT_A_GIT_REPO" | "PROJECT_UNBORN" | null>(null);
 	const [repositorySetupWarning, setRepositorySetupWarning] = useState<string | null>(null);
 	// A path that arrived via droppedPath, staged until the user confirms
@@ -136,6 +161,33 @@ export function CreateProjectFlow({
 	const hasModePicker = mode === "choose";
 	const projectImportOpen = projectImportStep !== null && projectValidation !== null;
 	const isBusy = isChoosingPath || isCreating || isInitializing || isPreparingGit;
+
+	useEffect(() => {
+		if (!cloneProgressOpen) return;
+		const startedAt = Date.now();
+		const updateProgress = () => {
+			const elapsed = Date.now() - startedAt;
+			if (elapsed < 800) {
+				setCloneProgressStage("starting");
+				setCloneProgress(Math.min(12, 4 + elapsed / 100));
+			} else if (elapsed < 1800) {
+				setCloneProgressStage("connecting");
+				setCloneProgress(12 + ((elapsed - 800) / 1000) * 18);
+			} else if (elapsed < 5000) {
+				setCloneProgressStage("cloning");
+				setCloneProgress(30 + ((elapsed - 1800) / 3200) * 38);
+			} else if (elapsed < 7600) {
+				setCloneProgressStage("settingUp");
+				setCloneProgress(68 + ((elapsed - 5000) / 2600) * 17);
+			} else {
+				setCloneProgressStage("finishing");
+				setCloneProgress(Math.min(90, 85 + (elapsed - 7600) / 1000));
+			}
+		};
+		updateProgress();
+		const timer = window.setInterval(updateProgress, 250);
+		return () => window.clearInterval(timer);
+	}, [cloneProgressOpen]);
 
 	const transitionToChild = (open: () => void) => {
 		setChildTransitioning(true);
@@ -301,11 +353,21 @@ export function CreateProjectFlow({
 		setIsCreating(true);
 		try {
 			if (cloneSelection) {
+				const abortController = new AbortController();
+				cloneAbortController.current = abortController;
+				cloneCancelled.current = false;
+				setCloneProgress(0);
+				setCloneProgressStage("starting");
+				setCloneProgressOpen(true);
 				await onCloneProject({
 					remoteUrl: cloneSelection.remoteUrl,
 					destinationParent: cloneSelection.destinationParent,
+					signal: abortController.signal,
 					...selection,
 				});
+				setCloneProgress(100);
+				setCloneProgressStage("complete");
+				await new Promise((resolve) => window.setTimeout(resolve, 180));
 				setSelectedPath(null);
 				setCloneSelection(null);
 				return;
@@ -329,6 +391,7 @@ export function CreateProjectFlow({
 			});
 			setSelectedPath(null);
 		} catch (err) {
+			if (cloneCancelled.current) return;
 			const code = err instanceof Error && "code" in err ? (err.code as string | undefined) : undefined;
 			const message = err instanceof Error ? err.message : t("createProject.couldNotAdd");
 			if (!cloneSelection && selectedKind === "single_repo" && isRepositorySetupRecoveryCode(code)) {
@@ -353,6 +416,8 @@ export function CreateProjectFlow({
 				setFolderPickerOpen(true);
 			}
 		} finally {
+			cloneAbortController.current = null;
+			setCloneProgressOpen(false);
 			setIsCreating(false);
 			setIsInitializing(false);
 		}
@@ -428,6 +493,17 @@ export function CreateProjectFlow({
 		}
 	};
 
+	const cancelClone = () => {
+		cloneCancelled.current = true;
+		cloneAbortController.current?.abort();
+		cloneAbortController.current = null;
+		setCloneProgressOpen(false);
+		setSelectedPath(null);
+		setCloneSelection(null);
+		setError(null);
+		setIsCreating(false);
+	};
+
 	const label = isInitializing
 		? hasModePicker
 			? t("createProject.initializing")
@@ -450,7 +526,7 @@ export function CreateProjectFlow({
 					error,
 					label,
 				})}
-			<CreateProjectFlowBackdrop open={modePickerOpen || cloneDialogOpen || folderPickerOpen || selectedPath !== null || childTransitioning} />
+			<CreateProjectFlowBackdrop open={modePickerOpen || cloneDialogOpen || folderPickerOpen || selectedPath !== null || cloneProgressOpen || childTransitioning} />
 			{hasModePicker && embedded && !modePickerOpen && !cloneDialogOpen && selectedPath === null && (
 				<div className="flex w-full flex-col items-center gap-3">
 					{cloudEnabled && (
@@ -618,10 +694,16 @@ export function CreateProjectFlow({
 						: undefined
 				}
 				onSubmit={createProject}
-				open={selectedPath !== null}
+				open={selectedPath !== null && !cloneProgressOpen}
 				path={selectedPath}
 				repositorySetupNeeded={repositorySetup !== null}
 				repositorySetupWarning={repositorySetupWarning}
+			/>
+			<CreateProjectProgressDialog
+				message={cloneProgressMessage(t, cloneProgressStage)}
+				onCancel={cancelClone}
+				open={cloneProgressOpen}
+				progress={cloneProgress}
 			/>
 			{error && !hasModePicker && (
 				<span className="sr-only" role="status">

--- a/frontend/src/renderer/components/CreateProjectProgressDialog.tsx
+++ b/frontend/src/renderer/components/CreateProjectProgressDialog.tsx
@@ -1,0 +1,61 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useTranslation } from "react-i18next";
+import { Button } from "./ui/button";
+
+export default function CreateProjectProgressDialog({
+	message,
+	onCancel,
+	open,
+	progress,
+}: {
+	message: string;
+	onCancel: () => void;
+	open: boolean;
+	progress: number;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<Dialog.Root open={open} onOpenChange={(next) => !next && onCancel()}>
+			<Dialog.Portal>
+				<Dialog.Content className="fixed left-1/2 top-1/2 z-overlay w-[min(440px,calc(100vw-24px))] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none">
+					<div className="px-5 pb-5 pt-5">
+						<Dialog.Title className="text-[18px] font-semibold text-[var(--color-text-import-title)]">
+							{t("createProject.cloneProgressTitle", { defaultValue: "Creating the project" })}
+						</Dialog.Title>
+						<Dialog.Description className="sr-only">
+							{t("createProject.cloneProgressDescription", {
+								defaultValue: "Cloning the repository and creating the project",
+							})}
+						</Dialog.Description>
+
+						<div className="mt-6 space-y-3">
+							<div
+								aria-label={`${Math.round(progress)}%`}
+								aria-valuemax={100}
+								aria-valuemin={0}
+								aria-valuenow={Math.round(progress)}
+								className="h-2 w-full overflow-hidden rounded-full bg-muted"
+								role="progressbar"
+							>
+								<div
+									className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
+									style={{ width: `${Math.max(0, Math.min(100, progress))}%` }}
+								/>
+							</div>
+							<p className="min-h-5 text-[13px] text-muted-foreground" role="status">
+								{message}
+							</p>
+						</div>
+
+						<div className="mt-6 flex justify-end">
+							<Button type="button" variant="outline" onClick={onCancel}>
+								{t("createProject.cancel")}
+							</Button>
+						</div>
+					</div>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -223,6 +223,7 @@ type CloneProjectHandler = (input: {
 	workerAgent: string;
 	orchestratorAgent: string;
 	trackerIntake?: unknown;
+	signal?: AbortSignal;
 }) => Promise<void>;
 type InitializeProjectHandler = (path: string) => Promise<void>;
 type RemoveProjectHandler = (projectId: string) => Promise<void>;
@@ -884,18 +885,20 @@ describe("Sidebar", () => {
 		);
 		await user.click(screen.getByRole("button", { name: "Choose" }));
 		expect(window.ao!.app.chooseDirectory).toHaveBeenCalledWith("Choose where to clone the repository");
+		await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
 		await user.click(screen.getByRole("button", { name: "Continue" }));
 
 		expect(await screen.findByRole("dialog", { name: "Set up project" })).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: "Clone" }));
 		await waitFor(() =>
-			expect(onCloneProject).toHaveBeenCalledWith({
+			expect(onCloneProject).toHaveBeenCalledWith(expect.objectContaining({
 				remoteUrl: "git@github.com:acme/web-app.git",
 				destinationParent: "/repo",
 				workerAgent: "claude-code",
 				orchestratorAgent: "claude-code",
 				trackerIntake: undefined,
-			}),
+				signal: expect.any(AbortSignal),
+			})),
 		);
 	});
 
@@ -916,6 +919,7 @@ describe("Sidebar", () => {
 			"git@github.com:acme/web-app.git",
 		);
 		await user.click(screen.getByRole("button", { name: "Choose" }));
+		await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
 		await user.click(await screen.findByRole("button", { name: "Continue" }));
 
 		await user.click(await screen.findByRole("button", { name: "Back to clone details" }));

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -744,6 +744,8 @@ export function Sidebar({
 								onCloneProject={onCloneProject}
 								onCreateProject={onCreateProject}
 								onInitializeProject={onInitializeProject}
+								existingProjectPaths={workspaces.map((workspace) => workspace.path)}
+								existingProjectNames={workspaces.map((workspace) => workspace.name)}
 							/>
 						}
 					/>
@@ -2424,11 +2426,17 @@ function SidebarSearchButton({ onOpen }: { onOpen: () => void }) {
 }
 
 function CreateProjectButton({
+	existingProjectPaths,
+	existingProjectNames,
 	hideTrigger = false,
 	onCloneProject,
 	onCreateProject,
 	onInitializeProject,
-}: Pick<SidebarProps, "onCloneProject" | "onCreateProject" | "onInitializeProject"> & { hideTrigger?: boolean }) {
+}: Pick<SidebarProps, "onCloneProject" | "onCreateProject" | "onInitializeProject"> & {
+	existingProjectPaths: readonly string[];
+	existingProjectNames: readonly string[];
+	hideTrigger?: boolean;
+}) {
 	const { t } = useTranslation();
 	// Single CreateProjectFlow owner for the sidebar: the header "+" stays mounted
 	// (CSS-hidden when collapsed or on the empty start page) so it can own
@@ -2444,6 +2452,8 @@ function CreateProjectButton({
 			onCreateProject={onCreateProject}
 			onInitializeProject={onInitializeProject}
 			openSignal={createProjectNonce}
+			existingProjectPaths={existingProjectPaths}
+			existingProjectNames={existingProjectNames}
 		>
 			{({ disabled, choosePath, label }) => (
 				<Tooltip>

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -183,6 +183,7 @@
 	"createProject.cloneDestinationPlaceholder": "Übergeordneten Ordner auswählen",
 	"createProject.cloneDestinationRequired": "Wähle einen Zielordner aus.",
 	"createProject.cloneFailedTitle": "Repository konnte nicht geklont werden",
+	"createProject.cloneProjectExists": "An diesem Speicherort gibt es bereits ein Projekt",
 	"createProject.cloneFromGit": "Von Git klonen",
 	"createProject.cloneFromGitDesc": "Starte mit einem Remote-Repository über eine HTTPS- oder SSH-URL.",
 	"createProject.cloneInvalidUrl": "Gib eine gültige HTTPS-, SSH-, Git- oder Datei-URL ein.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -183,6 +183,7 @@
 	"createProject.cloneDestinationPlaceholder": "Choose a parent folder",
 	"createProject.cloneDestinationRequired": "Choose a destination folder.",
 	"createProject.cloneFailedTitle": "Could not clone repository",
+	"createProject.cloneProjectExists": "A project already exists at this location",
 	"createProject.cloneFromGit": "Clone from Git",
 	"createProject.cloneFromGitDesc": "Start from a remote repository using an HTTPS or SSH URL",
 	"createProject.cloneInvalidUrl": "Enter a valid HTTPS, SSH, Git, or file URL.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -184,6 +184,7 @@
 	"createProject.cloneDestinationPlaceholder": "Elegir una carpeta principal",
 	"createProject.cloneDestinationRequired": "Elige una carpeta de destino.",
 	"createProject.cloneFailedTitle": "No se pudo clonar el repositorio",
+	"createProject.cloneProjectExists": "Ya existe un proyecto en esta ubicación",
 	"createProject.cloneFromGit": "Clonar desde Git",
 	"createProject.cloneFromGitDesc": "Empieza desde un repositorio remoto mediante una URL HTTPS o SSH.",
 	"createProject.cloneInvalidUrl": "Introduce una URL HTTPS, SSH, Git o de archivo válida.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -184,6 +184,7 @@
 	"createProject.cloneDestinationPlaceholder": "Choisir un dossier parent",
 	"createProject.cloneDestinationRequired": "Choisissez un dossier de destination.",
 	"createProject.cloneFailedTitle": "Impossible de cloner le dépôt",
+	"createProject.cloneProjectExists": "Un projet existe déjà à cet emplacement",
 	"createProject.cloneFromGit": "Cloner depuis Git",
 	"createProject.cloneFromGitDesc": "Commencez avec un dépôt distant à l'aide d'une URL HTTPS ou SSH.",
 	"createProject.cloneInvalidUrl": "Saisissez une URL HTTPS, SSH, Git ou de fichier valide.",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -183,6 +183,7 @@
 	"createProject.cloneDestinationPlaceholder": "親フォルダーを選択",
 	"createProject.cloneDestinationRequired": "保存先フォルダーを選択してください。",
 	"createProject.cloneFailedTitle": "リポジトリをクローンできませんでした",
+	"createProject.cloneProjectExists": "この場所にはすでにプロジェクトがあります",
 	"createProject.cloneFromGit": "Git からクローン",
 	"createProject.cloneFromGitDesc": "HTTPS または SSH URL を使ってリモートリポジトリから開始します。",
 	"createProject.cloneInvalidUrl": "有効な HTTPS、SSH、Git、またはファイル URL を入力してください。",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -183,6 +183,7 @@
 	"createProject.cloneDestinationPlaceholder": "상위 폴더 선택",
 	"createProject.cloneDestinationRequired": "대상 폴더를 선택하세요.",
 	"createProject.cloneFailedTitle": "저장소를 복제할 수 없습니다",
+	"createProject.cloneProjectExists": "이 위치에 이미 프로젝트가 있습니다",
 	"createProject.cloneFromGit": "Git에서 복제",
 	"createProject.cloneFromGitDesc": "HTTPS 또는 SSH URL을 사용하여 원격 저장소에서 시작합니다.",
 	"createProject.cloneInvalidUrl": "유효한 HTTPS, SSH, Git 또는 파일 URL을 입력하세요.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -184,6 +184,7 @@
 	"createProject.cloneDestinationPlaceholder": "Escolher uma pasta principal",
 	"createProject.cloneDestinationRequired": "Escolha uma pasta de destino.",
 	"createProject.cloneFailedTitle": "Não foi possível clonar o repositório",
+	"createProject.cloneProjectExists": "Já existe um projeto neste local",
 	"createProject.cloneFromGit": "Clonar do Git",
 	"createProject.cloneFromGitDesc": "Comece com um repositório remoto usando uma URL HTTPS ou SSH.",
 	"createProject.cloneInvalidUrl": "Insira uma URL HTTPS, SSH, Git ou de arquivo válida.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -183,6 +183,7 @@
 	"createProject.cloneDestinationPlaceholder": "选择父文件夹",
 	"createProject.cloneDestinationRequired": "请选择目标文件夹。",
 	"createProject.cloneFailedTitle": "无法克隆仓库",
+	"createProject.cloneProjectExists": "此位置已存在项目",
 	"createProject.cloneFromGit": "从 Git 克隆",
 	"createProject.cloneFromGitDesc": "使用 HTTPS 或 SSH URL 从远程仓库开始。",
 	"createProject.cloneInvalidUrl": "请输入有效的 HTTPS、SSH、Git 或文件 URL。",

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -9,6 +9,7 @@ export const aoBridge: AoBridge =
 		app: {
 			getVersion: async () => "0.0.0-preview",
 			chooseDirectory: async () => null,
+			checkGitRepository: async () => true,
 			openExternal: async (url: string) => {
 				window.open(url, "_blank", "noopener,noreferrer");
 			},

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -464,6 +464,7 @@ function ShellLayout() {
 			workerAgent: string;
 			orchestratorAgent: string;
 			trackerIntake?: components["schemas"]["TrackerIntakeConfig"];
+			signal?: AbortSignal;
 		}) => {
 			void addRendererExceptionStep("Project clone requested", {
 				source: "project-clone",
@@ -476,6 +477,7 @@ function ShellLayout() {
 				throw new Error(status.message || "AO daemon is not ready.");
 			}
 			const { data, error } = await apiClient.POST("/api/v1/projects/clone", {
+				signal: input.signal,
 				body: {
 					remoteUrl: input.remoteUrl,
 					destinationParent: input.destinationParent,

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -100,6 +100,7 @@ if (typeof window !== "undefined") {
 		app: {
 			getVersion: async () => "0.0.0-test",
 			chooseDirectory: async () => null,
+			checkGitRepository: async () => true,
 			openExternal: async () => undefined,
 			scanImportFolder: async ({ path }: { path: string }) => ({ path, repos: [] }),
 			checkAncestorRepo: async () => undefined,


### PR DESCRIPTION
## Summary
- validate Git remotes before enabling Clone
- show debounced checking state and inline repository errors
- keep clone progress in a dedicated cancellable modal with staged UI progress

## Design choices
- Validation runs through the desktop Git process (`git ls-remote`) so configured SSH keys and Git credentials work across providers without a backend/API contract change.
- Progress is intentionally staged UI feedback: it advances to 90% while the request is running and reaches 100% only after the clone request resolves because the daemon does not expose transfer progress.
- Cancel aborts the frontend request and immediately dismisses the progress modal.

## Verification
- `npm run typecheck`
- 29 focused frontend tests
- `git diff --check`

Unrelated `frontend/src/renderer/routeTree.gen.ts` changes were left uncommitted.