### PR TITLE
fix(lifecycle): ignore stale TUI metadata for Chat activity

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -543,13 +543,21 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		m.mu.Unlock()
 		return nil
 	}
-	if rec.Metadata.RuntimeLaunchID != "" && s.LaunchID != rec.Metadata.RuntimeLaunchID {
+	mode := domain.NormalizeSessionMode(rec.Mode)
+	currentChatController := mode == domain.SessionModeChat &&
+		s.ControllerGeneration != "" &&
+		s.ControllerGeneration == rec.Metadata.ControllerGeneration
+	// Controller ownership is mode-specific. A Chat controller has no terminal
+	// launch id, so stale TUI metadata must not veto its current generation.
+	// Provider hooks inherited from a shell never receive that internal
+	// credential and therefore cannot mutate structured Chat lifecycle facts.
+	if mode != domain.SessionModeChat && rec.Metadata.RuntimeLaunchID != "" &&
+		s.LaunchID != rec.Metadata.RuntimeLaunchID {
 		m.mu.Unlock()
 		return nil
 	}
-	if s.ControllerGeneration != "" &&
-		(domain.NormalizeSessionMode(rec.Mode) != domain.SessionModeChat ||
-			s.ControllerGeneration != rec.Metadata.ControllerGeneration) {
+	if (mode == domain.SessionModeChat && !currentChatController) ||
+		(mode != domain.SessionModeChat && s.ControllerGeneration != "") {
 		m.mu.Unlock()
 		return nil
 	}
@@ -1126,6 +1134,14 @@ func (m *Manager) markSpawned(
 		// a stale "signals worked once" fact.
 		rec.FirstSignalAt = time.Time{}
 		rec.Metadata = mergeMetadata(rec.Metadata, metadata)
+		if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat &&
+			strings.TrimSpace(metadata.ControllerGeneration) != "" {
+			// A committed Chat controller is the sole session owner. Clear any
+			// terminal identity retained by an older handoff/recovery build so it
+			// cannot confuse runtime observation or a later daemon restart.
+			rec.Metadata.RuntimeHandleID = ""
+			rec.Metadata.RuntimeLaunchID = ""
+		}
 		rec.UpdatedAt = now
 		if boundary == nil {
 			if err := m.store.UpdateSession(ctx, rec); err != nil {

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -3649,7 +3649,13 @@ func TestRuntimeObservation_WorkloadDeathAloneDoesNotReap(t *testing.T) {
 func TestMarkSpawnedPersistsChatControllerFacts(t *testing.T) {
 	ctx := context.Background()
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Mode: domain.SessionModeChat}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Mode: domain.SessionModeChat,
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID: "stale-tui-runtime",
+			RuntimeLaunchID: "stale-tui-generation",
+		},
+	}
 	m := New(st, nil)
 
 	if err := m.MarkSpawned(ctx, "mer-1", domain.SessionMetadata{
@@ -3670,6 +3676,9 @@ func TestMarkSpawnedPersistsChatControllerFacts(t *testing.T) {
 	}
 	if got.Metadata.ControllerGeneration != "gen-1" {
 		t.Fatalf("controller generation = %q", got.Metadata.ControllerGeneration)
+	}
+	if got.Metadata.RuntimeHandleID != "" || got.Metadata.RuntimeLaunchID != "" {
+		t.Fatalf("Chat spawn retained terminal ownership metadata: %+v", got.Metadata)
 	}
 
 	// A relaunch rotates the generation: the new value must replace the old, or
@@ -3834,6 +3843,44 @@ func TestActivitySignalRejectsStaleChatControllerGenerationAcrossHandoff(t *test
 	}
 	if got := st.sessions["mer-1"].Activity.State; got != domain.ActivityIdle {
 		t.Fatalf("old Chat controller changed TUI activity to %q", got)
+	}
+}
+
+func TestActivitySignalFencesChatByControllerGenerationDespiteStaleRuntimeMetadata(t *testing.T) {
+	ctx := context.Background()
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Mode: domain.SessionModeChat,
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID:      "stale-tui-runtime",
+			RuntimeLaunchID:      "stale-tui-generation",
+			ControllerGeneration: "chat-generation",
+		},
+		Activity: domain.Activity{State: domain.ActivityIdle},
+	}
+	m := New(st, nil)
+
+	for _, signal := range []ports.ActivitySignal{
+		{Valid: true, State: domain.ActivityActive, LaunchID: "stale-tui-generation"},
+		{Valid: true, State: domain.ActivityActive, ControllerGeneration: "foreign-generation"},
+	} {
+		if err := m.ApplyActivitySignal(ctx, "mer-1", signal); err != nil {
+			t.Fatalf("reject non-owner signal: %v", err)
+		}
+		if got := st.sessions["mer-1"].Activity.State; got != domain.ActivityIdle {
+			t.Fatalf("non-owner signal changed activity to %q", got)
+		}
+	}
+
+	for _, state := range []domain.ActivityState{domain.ActivityActive, domain.ActivityIdle} {
+		if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+			Valid: true, State: state, ControllerGeneration: "chat-generation",
+		}); err != nil {
+			t.Fatalf("apply current Chat signal %q: %v", state, err)
+		}
+		if got := st.sessions["mer-1"].Activity.State; got != state {
+			t.Fatalf("current Chat signal left activity at %q, want %q", got, state)
+		}
 	}
 }
 

--- a/backend/internal/ports/runtime_observations.go
+++ b/backend/internal/ports/runtime_observations.go
@@ -59,9 +59,9 @@ type ActivitySignal struct {
 	// LaunchID is set by AO's process supervisor. Lifecycle rejects a signal
 	// from an older process generation of the same session.
 	LaunchID string
-	// ControllerGeneration is the equivalent fence for a runtime-less Chat
-	// controller. It is intentionally internal (provider events never call the
-	// public hook endpoint): lifecycle rejects it after a mode handoff or Chat
-	// controller replacement.
+	// ControllerGeneration is the required ownership fence for a runtime-less
+	// Chat controller. It is intentionally internal (provider events never call
+	// the public hook endpoint): lifecycle rejects a Chat signal without the
+	// current generation, as well as one received after a handoff or replacement.
 	ControllerGeneration string
 }


### PR DESCRIPTION
Fixes #4696

## Problem

A structured Chat session could retain terminal runtime metadata from an older TUI ownership epoch. Chat activity signals correctly carried the current `controller_generation`, but lifecycle applied the generic `runtime_launch_id` fence first. Because Chat signals intentionally have no terminal launch id, the reducer silently discarded `chat.turn.started` and `chat.turn.completed`, leaving durable activity stuck at `idle`.

## Root cause

The SQLite activity write fence was already mode-aware: TUI writes compare `runtime_launch_id`, while Chat writes compare `controller_generation`. The in-memory lifecycle reducer was not. It applied the terminal fence to every mode before checking the optional Chat generation.

Current Chat startup already clears `runtime_launch_id` through metadata merging, and interface-transition epoch commits clear both runtime fields. However, `runtime_handle_id` was merged only when non-empty, so a legacy/recovered Chat row could retain a stale terminal handle across another successful Chat startup.

## Fix

- Make lifecycle ownership checks mode-specific:
  - TUI signals remain fenced by the current runtime launch id.
  - Chat signals must carry the exact current controller generation and ignore irrelevant stale terminal metadata.
  - controller-generation signals remain invalid for TUI mode.
- Clear stale runtime handle and launch metadata whenever a current Chat controller is successfully committed.
- Document `ControllerGeneration` as the required Chat activity ownership fence.

## Safety

- Preserves existing TUI launch-generation fencing.
- Preserves stale/foreign Chat-controller rejection and additionally rejects generationless inherited provider hooks.
- Does not infer activity, bypass the durable owner CAS, change interface-transition sequencing, or add a second activity source.
- Cleanup occurs only when a Chat controller with a non-empty generation is successfully committed; a failed controller commit leaves the previous durable owner untouched.
- CDC behavior is unchanged: the existing SQLite session update and trigger remain the only durable/event path.

## Tests

Passed locally with Go 1.26.5:

- `go test ./internal/lifecycle -run 'Test(MarkSpawnedPersistsChatControllerFacts|ActivitySignalFencesChatByControllerGenerationDespiteStaleRuntimeMetadata)$' -count=1`
- `go test ./internal/lifecycle -count=1`

The regression proves that a Chat row containing stale runtime handle/launch metadata:

- accepts `active` and `idle` from its current controller generation;
- rejects a generationless stale TUI hook even when its launch id matches the stale value;
- rejects a foreign Chat generation; and
- scrubs stale terminal ownership metadata on successful Chat startup.

Broader `internal/service/chat` and `internal/session_manager` validation was attempted with build/module/tmp caches moved to a secondary disk because the host system drive was full. Dependency preparation did not complete within a bounded 15-minute local wait under concurrent builds, so those results are not claimed; CI remains the authoritative broad run. A focused `go vet ./internal/lifecycle` attempt likewise did not complete within the bounded local wait.

## Related scope

PR #4204 / issue #4125 address the separate sticky-`exited` resurrection and controller shutdown ordering problem. This PR deliberately does not copy those controller/interrupt changes. It aligns the ownership terminology with #4204 while fixing #4696's distinct ordering defect: terminal launch fencing must not precede and veto current Chat generation ownership.