### PR TITLE
fix(renderer): bounded exponential backoff for SSE reconnects

### DIFF
--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { computeSseRetryDelayMs } from "./sse-backoff";
 
 const {
 	onStatusMock,
@@ -111,6 +112,38 @@ describe("createEventTransport", () => {
 		expect(first.closed).toBe(true);
 		expect(EventSourceStub.instances).toHaveLength(2);
 		expect(EventSourceStub.instances[1].url).toBe("http://127.0.0.1:3099/api/v1/events");
+	});
+
+	it("does not make a new daemon port serve the dead port's backoff delay", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		createEventTransport(fakeQueryClient()).connect();
+		const onStatusHandler = onStatusMock.mock.calls[0][0] as () => void;
+
+		// Fail the old port repeatedly so the delay grows well past the initial step.
+		for (let failure = 1; failure <= 4; failure += 1) {
+			const source = EventSourceStub.instances.at(-1)!;
+			source.readyState = 2;
+			source.onerror?.();
+			vi.advanceTimersByTime(computeSseRetryDelayMs(failure, () => 0.5));
+		}
+		const beforeMove = EventSourceStub.instances.length;
+
+		// The daemon comes back on a different port: a fresh target.
+		getApiBaseUrlMock.mockReturnValue("http://127.0.0.1:3099");
+		onStatusHandler();
+		expect(EventSourceStub.instances).toHaveLength(beforeMove + 1);
+
+		const moved = EventSourceStub.instances.at(-1)!;
+		moved.readyState = 2;
+		moved.onerror?.();
+		const firstRetryMs = computeSseRetryDelayMs(1, () => 0.5);
+		const beforeRetry = EventSourceStub.instances.length;
+		vi.advanceTimersByTime(firstRetryMs - 1);
+		expect(EventSourceStub.instances).toHaveLength(beforeRetry);
+		vi.advanceTimersByTime(1);
+		expect(EventSourceStub.instances).toHaveLength(beforeRetry + 1);
+		vi.useRealTimers();
 	});
 
 	it("closes the source and skips reconnecting when the base URL is untrusted", () => {

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -132,18 +132,18 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				}, INVALIDATE_DEBOUNCE_MS);
 			};
 
-			// Consecutive rebuilds since the stream last opened. Paces the retry
-			// so a daemon that keeps refusing the stream is not hammered on a
-			// flat cadence (#4323).
-			let failures = 0;
+			// Consecutive scheduled rebuilds since the stream last opened. Paces
+			// the retry so a daemon that keeps refusing the stream is not
+			// hammered on a flat cadence (#4323).
+			let retries = 0;
 
 			const scheduleRetry = () => {
 				if (retryTimer) return;
-				failures += 1;
+				retries += 1;
 				retryTimer = setTimeout(() => {
 					retryTimer = undefined;
 					connectSource();
-				}, computeSseRetryDelayMs(failures));
+				}, computeSseRetryDelayMs(retries));
 			};
 
 			const connectSource = () => {
@@ -160,13 +160,17 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				// Keep a still-usable source on the same base URL; replace one the
 				// browser abandoned (CLOSED) or one bound to a stale port.
 				if (source && sourceBaseUrl === baseUrl && source.readyState !== EVENTSOURCE_CLOSED) return;
+				// A daemon that came back on a different port is a fresh target, not
+				// a continuation of the dead one: do not make it serve the delay the
+				// old port earned.
+				if (sourceBaseUrl && sourceBaseUrl !== baseUrl) retries = 0;
 				source?.close();
 				source = undefined;
 				sourceBaseUrl = baseUrl;
 				try {
 					source = new EventSource(`${baseUrl.replace(/\/+$/, "")}/api/v1/events`);
 					source.onopen = () => {
-						failures = 0;
+						retries = 0;
 						setEventsConnectionState("connected");
 						// Events emitted during the gap were lost; refetch once on (re)open.
 						refreshWorkspaces();

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { aoBridge } from "./bridge";
 import { getApiBaseUrl, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "./api-client";
 import { setEventsConnectionState } from "./events-connection";
+import { computeSseRetryDelayMs } from "./sse-backoff";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { sessionScmSummaryQueryKey } from "../hooks/useSessionScmSummary";
 import { conversationQueryKey, conversationQueryRoot } from "../hooks/useConversation";
@@ -13,9 +14,6 @@ export type EventTransport = {
 };
 
 const INVALIDATE_DEBOUNCE_MS = 150;
-// How long to wait before rebuilding an EventSource the browser gave up on
-// (readyState CLOSED — e.g. the daemon answered with a non-SSE response).
-const SSE_RETRY_MS = 5_000;
 // EventSource.CLOSED, referenced numerically so test stubs without the static
 // constants still work.
 const EVENTSOURCE_CLOSED = 2;
@@ -134,12 +132,18 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				}, INVALIDATE_DEBOUNCE_MS);
 			};
 
+			// Consecutive rebuilds since the stream last opened. Paces the retry
+			// so a daemon that keeps refusing the stream is not hammered on a
+			// flat cadence (#4323).
+			let failures = 0;
+
 			const scheduleRetry = () => {
 				if (retryTimer) return;
+				failures += 1;
 				retryTimer = setTimeout(() => {
 					retryTimer = undefined;
 					connectSource();
-				}, SSE_RETRY_MS);
+				}, computeSseRetryDelayMs(failures));
 			};
 
 			const connectSource = () => {
@@ -162,6 +166,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				try {
 					source = new EventSource(`${baseUrl.replace(/\/+$/, "")}/api/v1/events`);
 					source.onopen = () => {
+						failures = 0;
 						setEventsConnectionState("connected");
 						// Events emitted during the gap were lost; refetch once on (re)open.
 						refreshWorkspaces();

--- a/frontend/src/renderer/lib/notifications.test.ts
+++ b/frontend/src/renderer/lib/notifications.test.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { computeSseRetryDelayMs } from "./sse-backoff";
 import type { NotificationDTO, NotificationsCache } from "./notifications";
 
 const {
@@ -469,6 +470,35 @@ describe("createNotificationsTransport", () => {
 			expect(showNotificationMock).toHaveBeenCalledTimes(1);
 		},
 	);
+
+	it("does not make a new daemon port serve the dead port's backoff delay", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		createNotificationsTransport(queryClient()).connect();
+		const onBaseUrlChange = subscribeApiBaseUrlMock.mock.calls[0][0] as () => void;
+
+		// Grow the delay on the old port.
+		for (let failure = 1; failure <= 4; failure += 1) {
+			const source = EventSourceStub.instances.at(-1)!;
+			source.readyState = 2;
+			source.onerror?.();
+			vi.advanceTimersByTime(computeSseRetryDelayMs(failure, () => 0.5));
+		}
+
+		getApiBaseUrlMock.mockReturnValue("http://127.0.0.1:4555");
+		onBaseUrlChange();
+
+		// The fresh port starts over at the initial delay.
+		const moved = EventSourceStub.instances.at(-1)!;
+		moved.readyState = 2;
+		moved.onerror?.();
+		const beforeRetry = EventSourceStub.instances.length;
+		vi.advanceTimersByTime(computeSseRetryDelayMs(1, () => 0.5) - 1);
+		expect(EventSourceStub.instances).toHaveLength(beforeRetry);
+		vi.advanceTimersByTime(1);
+		expect(EventSourceStub.instances).toHaveLength(beforeRetry + 1);
+		vi.useRealTimers();
+	});
 
 	it("reconnects when the API base URL changes", () => {
 		createNotificationsTransport(queryClient()).connect();

--- a/frontend/src/renderer/lib/notifications.ts
+++ b/frontend/src/renderer/lib/notifications.ts
@@ -2,6 +2,7 @@ import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
 import { aoBridge } from "./bridge";
 import { apiClient, apiErrorMessage, getApiBaseUrl, subscribeApiBaseUrl } from "./api-client";
+import { computeSseRetryDelayMs } from "./sse-backoff";
 
 export type NotificationDTO = components["schemas"]["NotificationResponse"];
 export type NotificationsPage = components["schemas"]["ListNotificationsResponse"];
@@ -12,7 +13,6 @@ export const unreadNotificationsQueryKey = ["notifications", "history", "unread"
 export const recentNotificationsQueryKey = ["notifications", "history", "all"] as const;
 export const NOTIFICATION_PAGE_SIZE = 100;
 
-const SSE_RETRY_MS = 5_000;
 const EVENTSOURCE_CLOSED = 2;
 
 /**
@@ -296,12 +296,17 @@ export function createNotificationsTransport(
 				void queryClient.invalidateQueries({ queryKey: recentNotificationsQueryKey });
 			};
 
+			// Consecutive rebuilds since the stream last opened; paces the retry
+			// instead of knocking on a flat cadence forever (#4323).
+			let failures = 0;
+
 			const scheduleRetry = () => {
 				if (retryTimer) return;
+				failures += 1;
 				retryTimer = setTimeout(() => {
 					retryTimer = undefined;
 					connectSource();
-				}, SSE_RETRY_MS);
+				}, computeSseRetryDelayMs(failures));
 			};
 
 			const connectSource = () => {
@@ -313,7 +318,10 @@ export function createNotificationsTransport(
 				sourceBaseUrl = baseUrl;
 				try {
 					source = new EventSource(`${baseUrl.replace(/\/+$/, "")}/api/v1/notifications/stream`);
-					source.onopen = invalidateNotifications;
+					source.onopen = () => {
+						failures = 0;
+						invalidateNotifications();
+					};
 					source.onerror = () => {
 						if (source?.readyState === EVENTSOURCE_CLOSED) scheduleRetry();
 					};

--- a/frontend/src/renderer/lib/notifications.ts
+++ b/frontend/src/renderer/lib/notifications.ts
@@ -296,30 +296,33 @@ export function createNotificationsTransport(
 				void queryClient.invalidateQueries({ queryKey: recentNotificationsQueryKey });
 			};
 
-			// Consecutive rebuilds since the stream last opened; paces the retry
-			// instead of knocking on a flat cadence forever (#4323).
-			let failures = 0;
+			// Consecutive scheduled rebuilds since the stream last opened; paces
+			// the retry instead of knocking on a flat cadence forever (#4323).
+			let retries = 0;
 
 			const scheduleRetry = () => {
 				if (retryTimer) return;
-				failures += 1;
+				retries += 1;
 				retryTimer = setTimeout(() => {
 					retryTimer = undefined;
 					connectSource();
-				}, computeSseRetryDelayMs(failures));
+				}, computeSseRetryDelayMs(retries));
 			};
 
 			const connectSource = () => {
 				if (typeof EventSource === "undefined") return;
 				const baseUrl = getApiBaseUrl();
 				if (source && sourceBaseUrl === baseUrl && source.readyState !== EVENTSOURCE_CLOSED) return;
+				// A new daemon port is a fresh target; it should not inherit the
+				// delay the dead port earned.
+				if (sourceBaseUrl && sourceBaseUrl !== baseUrl) retries = 0;
 				source?.close();
 				source = undefined;
 				sourceBaseUrl = baseUrl;
 				try {
 					source = new EventSource(`${baseUrl.replace(/\/+$/, "")}/api/v1/notifications/stream`);
 					source.onopen = () => {
-						failures = 0;
+						retries = 0;
 						invalidateNotifications();
 					};
 					source.onerror = () => {

--- a/frontend/src/renderer/lib/sse-backoff.test.ts
+++ b/frontend/src/renderer/lib/sse-backoff.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { SSE_BACKOFF_INIT_MS, SSE_BACKOFF_MAX_MS, computeSseRetryDelayMs } from "./sse-backoff";
+
+/** Jitter at its top of range, so the delay equals the un-jittered step. */
+const noJitter = () => 0.999_999;
+/** Jitter at its floor: half the step. */
+const fullJitter = () => 0;
+
+describe("computeSseRetryDelayMs", () => {
+	it("starts at the initial delay on the first failure", () => {
+		expect(computeSseRetryDelayMs(1, noJitter)).toBe(SSE_BACKOFF_INIT_MS);
+		expect(computeSseRetryDelayMs(1, fullJitter)).toBe(SSE_BACKOFF_INIT_MS / 2);
+	});
+
+	it("doubles the step per consecutive failure until the ceiling", () => {
+		expect(computeSseRetryDelayMs(2, noJitter)).toBe(10_000);
+		expect(computeSseRetryDelayMs(3, noJitter)).toBe(20_000);
+		expect(computeSseRetryDelayMs(4, noJitter)).toBe(40_000);
+		expect(computeSseRetryDelayMs(5, noJitter)).toBe(SSE_BACKOFF_MAX_MS);
+	});
+
+	it("never exceeds the ceiling, however long the stream stays broken", () => {
+		for (const failures of [5, 12, 40, 5_000, Number.MAX_SAFE_INTEGER]) {
+			expect(computeSseRetryDelayMs(failures, noJitter)).toBeLessThanOrEqual(SSE_BACKOFF_MAX_MS);
+		}
+	});
+
+	it("keeps every delay finite and positive across the whole range", () => {
+		for (let failures = 1; failures <= 64; failures += 1) {
+			const delay = computeSseRetryDelayMs(failures);
+			expect(Number.isFinite(delay)).toBe(true);
+			expect(delay).toBeGreaterThanOrEqual(SSE_BACKOFF_INIT_MS / 2);
+			expect(delay).toBeLessThanOrEqual(SSE_BACKOFF_MAX_MS);
+		}
+	});
+
+	it("holds the jitter inside [0.5, 1) of the step so retries spread out", () => {
+		const step = SSE_BACKOFF_MAX_MS;
+		const delays = new Set<number>();
+		for (let i = 0; i < 500; i += 1) {
+			const delay = computeSseRetryDelayMs(9);
+			expect(delay).toBeGreaterThanOrEqual(step * 0.5);
+			expect(delay).toBeLessThanOrEqual(step);
+			delays.add(delay);
+		}
+		// Real randomness, not a constant: concurrent streams must desynchronise.
+		expect(delays.size).toBeGreaterThan(1);
+	});
+
+	it("treats a non-positive or non-finite failure count as the first failure", () => {
+		for (const failures of [0, -1, -1_000, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(computeSseRetryDelayMs(failures, noJitter)).toBe(SSE_BACKOFF_INIT_MS);
+		}
+	});
+
+	it("ignores a jitter source that strays outside [0, 1)", () => {
+		expect(computeSseRetryDelayMs(1, () => 5)).toBe(SSE_BACKOFF_INIT_MS);
+		expect(computeSseRetryDelayMs(1, () => -5)).toBe(SSE_BACKOFF_INIT_MS / 2);
+	});
+});

--- a/frontend/src/renderer/lib/sse-backoff.ts
+++ b/frontend/src/renderer/lib/sse-backoff.ts
@@ -1,0 +1,43 @@
+// Shared reconnect pacing for the renderer's SSE consumers (#4323).
+//
+// EventSource rebuilds are scheduled by hand once the browser gives up
+// (readyState CLOSED). A flat delay meant every stream in the app knocked on
+// the same cadence forever: when the daemon returns a transient 5xx while
+// setting a stream up — e.g. under the DB-lock contention in #3963 — all of
+// them re-fail together, and the retry traffic is itself what keeps the daemon
+// from recovering. Growing the delay gives it room, and the jitter spreads
+// streams that failed in lockstep so they stop arriving as one burst.
+//
+// Mirrors the bounded backoff the main process already uses for its daemon
+// links (see main/supervisor-link.ts), with a ceiling suited to a stream a
+// user is waiting on rather than a socket held for the process lifetime.
+
+/** Delay after the first failure, before growth or jitter. */
+export const SSE_BACKOFF_INIT_MS = 5_000;
+/** Ceiling for the grown delay. Jitter still applies below it. */
+export const SSE_BACKOFF_MAX_MS = 60_000;
+
+// 2^31 * 5s is already far past the ceiling; clamping keeps the exponent
+// finite so a long-dead stream cannot reach Infinity or NaN.
+const MAX_EXPONENT = 31;
+
+/**
+ * Delay before the next reconnect attempt, given how many consecutive
+ * failures the stream has seen since it last opened successfully.
+ *
+ * Doubles from {@link SSE_BACKOFF_INIT_MS} to {@link SSE_BACKOFF_MAX_MS}, then
+ * scales by jitter in `[0.5, 1)` so concurrent streams desynchronise. A
+ * `failures` below 1, or not a finite number, is treated as the first failure.
+ *
+ * @param random Injectable for tests; defaults to `Math.random`.
+ */
+export function computeSseRetryDelayMs(failures: number, random: () => number = Math.random): number {
+	const attempt = Number.isFinite(failures)
+		? Math.min(Math.max(Math.floor(failures), 1), MAX_EXPONENT)
+		: 1;
+	const step = Math.min(SSE_BACKOFF_INIT_MS * 2 ** (attempt - 1), SSE_BACKOFF_MAX_MS);
+	// Clamp the source too: a stub returning outside [0, 1) must not push the
+	// delay past the ceiling or collapse it to zero.
+	const jitter = 0.5 + Math.min(Math.max(random(), 0), 0.999_999) * 0.5;
+	return Math.round(step * jitter);
+}

--- a/frontend/src/renderer/lib/workspace-file-events.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { computeSseRetryDelayMs } from "./sse-backoff";
 
 const { getApiBaseUrlMock, hasTrustedApiBaseUrlMock, subscribeApiBaseUrlMock, unsubscribeBaseUrlMock } = vi.hoisted(
 	() => ({
@@ -125,10 +126,71 @@ describe("subscribeWorkspaceFileChanges", () => {
 		baseUrlListener?.();
 		expect(EventSourceStub.instances).toHaveLength(0);
 
-		vi.advanceTimersByTime(4_999);
+		// Backoff, not a flat 5s: the first retry is the initial step scaled by
+		// the mocked jitter (see sse-backoff.ts).
+		const firstRetryMs = computeSseRetryDelayMs(1, () => 0.5);
+		vi.advanceTimersByTime(firstRetryMs - 1);
 		expect(EventSourceStub.instances).toHaveLength(0);
 		vi.advanceTimersByTime(1);
 		expect(EventSourceStub.instances).toHaveLength(1);
+		unsubscribe();
+	});
+
+	it("waits longer after each consecutive failure instead of a flat interval", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const unsubscribe = subscribeWorkspaceFileChanges("sess-growth", fakeQueryClient());
+
+		// Fail the stream repeatedly and record the gap the retry actually waited.
+		const waits: number[] = [];
+		for (let failure = 1; failure <= 4; failure += 1) {
+			const source = EventSourceStub.instances.at(-1)!;
+			source.readyState = 2;
+			source.onerror?.();
+
+			const before = EventSourceStub.instances.length;
+			const scheduled = computeSseRetryDelayMs(failure, () => 0.5);
+			// One tick short of the scheduled delay, nothing has reconnected yet.
+			vi.advanceTimersByTime(scheduled - 1);
+			expect(EventSourceStub.instances).toHaveLength(before);
+			vi.advanceTimersByTime(1);
+			expect(EventSourceStub.instances).toHaveLength(before + 1);
+			waits.push(scheduled);
+		}
+
+		// This is the regression: on the old flat interval every wait was 5s.
+		expect(waits).toEqual([...waits].sort((a, b) => a - b));
+		expect(new Set(waits).size).toBe(waits.length);
+		expect(waits.at(-1)!).toBeGreaterThan(waits[0]);
+		unsubscribe();
+	});
+
+	it("drops back to the initial delay once the stream opens again", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const unsubscribe = subscribeWorkspaceFileChanges("sess-reset", fakeQueryClient());
+
+		// Three failures, so the delay has grown well past the initial step.
+		for (let failure = 1; failure <= 3; failure += 1) {
+			const source = EventSourceStub.instances.at(-1)!;
+			source.readyState = 2;
+			source.onerror?.();
+			vi.advanceTimersByTime(computeSseRetryDelayMs(failure, () => 0.5));
+		}
+
+		// A successful open must clear the accumulated failures.
+		const recovered = EventSourceStub.instances.at(-1)!;
+		recovered.readyState = 1;
+		recovered.onopen?.();
+
+		recovered.readyState = 2;
+		recovered.onerror?.();
+		const before = EventSourceStub.instances.length;
+		const firstRetryMs = computeSseRetryDelayMs(1, () => 0.5);
+		vi.advanceTimersByTime(firstRetryMs - 1);
+		expect(EventSourceStub.instances).toHaveLength(before);
+		vi.advanceTimersByTime(1);
+		expect(EventSourceStub.instances).toHaveLength(before + 1);
 		unsubscribe();
 	});
 
@@ -141,7 +203,9 @@ describe("subscribeWorkspaceFileChanges", () => {
 			const source = EventSourceStub.instances.at(-1)!;
 			source.readyState = 2;
 			source.onerror?.();
-			if (failure < 2) vi.advanceTimersByTime(5_000);
+			// Each retry waits longer than the last, so advance by the delay this
+			// failure count actually schedules rather than a fixed 5s.
+			if (failure < 2) vi.advanceTimersByTime(computeSseRetryDelayMs(failure + 1, () => 0.5));
 		}
 
 		expect(getWorkspaceFileConnectionState("sess-degraded")).toBe("degraded");

--- a/frontend/src/renderer/lib/workspace-file-events.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.test.ts
@@ -165,6 +165,33 @@ describe("subscribeWorkspaceFileChanges", () => {
 		unsubscribe();
 	});
 
+	it("does not let the browser's own retries inflate the scheduled delay", () => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const unsubscribe = subscribeWorkspaceFileChanges("sess-native", fakeQueryClient());
+
+		// readyState CONNECTING means the browser is retrying by itself; those
+		// errors drive the degraded label but are not rebuilds we scheduled, so
+		// they must not advance the backoff exponent.
+		const source = EventSourceStub.instances.at(-1)!;
+		for (let i = 0; i < 10; i += 1) {
+			source.readyState = 0;
+			source.onerror?.();
+		}
+		expect(EventSourceStub.instances).toHaveLength(1);
+
+		// The first failure we actually schedule a retry for must still wait the
+		// initial delay, not the 60s ceiling.
+		source.readyState = 2;
+		source.onerror?.();
+		const firstRetryMs = computeSseRetryDelayMs(1, () => 0.5);
+		vi.advanceTimersByTime(firstRetryMs - 1);
+		expect(EventSourceStub.instances).toHaveLength(1);
+		vi.advanceTimersByTime(1);
+		expect(EventSourceStub.instances).toHaveLength(2);
+		unsubscribe();
+	});
+
 	it("drops back to the initial delay once the stream opens again", () => {
 		vi.useFakeTimers();
 		vi.spyOn(Math, "random").mockReturnValue(0.5);

--- a/frontend/src/renderer/lib/workspace-file-events.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.ts
@@ -14,6 +14,12 @@ type WorkspaceStream = {
 	phase: ConnectionPhase;
 	generation: number;
 	failures: number;
+	/**
+	 * Scheduled rebuilds since the last successful open. Distinct from
+	 * `failures`, which also counts the browser's own non-terminal retries and
+	 * so would inflate the backoff exponent past what we actually retried.
+	 */
+	retries: number;
 	source?: EventSource;
 	sourceBaseUrl?: string;
 	debounce?: ReturnType<typeof setTimeout>;
@@ -86,10 +92,8 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 	const scheduleRetry = (generation: number) => {
 		if (stream.disposed || stream.retry) return;
 		stream.phase = "waiting";
-		// stream.failures counts consecutive failures since the last successful
-		// open (reset in onopen), so the delay grows only while the stream is
-		// actually broken.
-		const delay = computeSseRetryDelayMs(stream.failures);
+		stream.retries += 1;
+		const delay = computeSseRetryDelayMs(stream.retries);
 		stream.retry = setTimeout(() => {
 			stream.retry = undefined;
 			if (stream.disposed || generation !== stream.generation) return;
@@ -119,6 +123,7 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 	stream.phase = "idle";
 	stream.generation = 0;
 	stream.failures = 0;
+	stream.retries = 0;
 	setWorkspaceFileConnectionState(sessionId, "connecting");
 	stream.ensureConnected = () => {
 		if (stream.disposed) return;
@@ -135,6 +140,7 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 		if (stream.sourceBaseUrl && stream.sourceBaseUrl !== baseUrl) {
 			resetConnection();
 			stream.failures = 0;
+			stream.retries = 0;
 			setWorkspaceFileConnectionState(sessionId, "connecting");
 		}
 		if (stream.phase !== "idle") return;
@@ -151,6 +157,7 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 				if (stream.disposed || generation !== stream.generation || stream.source !== source) return;
 				stream.phase = "open";
 				stream.failures = 0;
+				stream.retries = 0;
 				setWorkspaceFileConnectionState(sessionId, "connected");
 				invalidate();
 			};

--- a/frontend/src/renderer/lib/workspace-file-events.ts
+++ b/frontend/src/renderer/lib/workspace-file-events.ts
@@ -1,9 +1,8 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { getApiBaseUrl, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "./api-client";
+import { computeSseRetryDelayMs } from "./sse-backoff";
 
 const INVALIDATE_DEBOUNCE_MS = 150;
-const SSE_RETRY_MS = 5_000;
-const SSE_RETRY_JITTER_MS = 1_000;
 const EVENTSOURCE_CLOSED = 2;
 
 export type WorkspaceFileConnectionState = "connecting" | "connected" | "degraded";
@@ -87,7 +86,10 @@ function createWorkspaceStream(sessionId: string, queryClient: QueryClient): Wor
 	const scheduleRetry = (generation: number) => {
 		if (stream.disposed || stream.retry) return;
 		stream.phase = "waiting";
-		const delay = SSE_RETRY_MS + (Math.random() * 2 - 1) * SSE_RETRY_JITTER_MS;
+		// stream.failures counts consecutive failures since the last successful
+		// open (reset in onopen), so the delay grows only while the stream is
+		// actually broken.
+		const delay = computeSseRetryDelayMs(stream.failures);
 		stream.retry = setTimeout(() => {
 			stream.retry = undefined;
 			if (stream.disposed || generation !== stream.generation) return;


### PR DESCRIPTION
## Problem

The renderer schedules its own `EventSource` rebuild once the browser gives up (`readyState` CLOSED), and every consumer used a flat delay: 5s in `event-transport.ts` and `notifications.ts`, 5s +/- 1s in `workspace-file-events.ts`. Nothing grew the delay and nothing capped the attempts, so a stream the daemon keeps refusing knocked every ~5s indefinitely.

That is the amplification in #4323. When the daemon returns a transient 5xx during stream setup, every open session's stream fails at once and they all retry in lockstep. The retry traffic is itself what keeps the daemon from recovering, so a brief hiccup sustains itself.

## Change

New `sse-backoff.ts` with `computeSseRetryDelayMs(retries)`: doubles from 5s to a 60s ceiling, scaled by jitter in `[0.5, 1)` so streams that failed together desynchronise, with the exponent clamped so a long-dead stream cannot reach `Infinity`. All three consumers track consecutive scheduled rebuilds and reset on a successful open, so a one-off failure still reconnects fast. This mirrors the bounded backoff `main/supervisor-link.ts` already uses for the daemon links.

Two details worth calling out, both from review of the first commit here:

- The exponent is driven by a `retries` counter, not the existing `failures` counter. `workspace-file-events` also increments `failures` on non-terminal `onerror` (readyState CONNECTING, where the browser retries on its own) to drive the "degraded" label. Those are not rebuilds we scheduled, and counting them made the first real failure wait the 60s ceiling instead of ~5s, which is slower to recover than the flat delay being replaced.
- All three consumers reset the counter when the API base URL changes. A daemon that comes back on a different port is a fresh target and should not serve the delay the dead port earned. `workspace-file-events` already did this; the other two did not.

## Verification

`sse-backoff.test.ts` covers growth, the ceiling, the jitter band, reset, and non-finite input. Stream-level tests assert that each wait is longer than the last, that a successful open drops back to the initial delay, that the browser's own non-terminal retries do not inflate the delay, and that a new daemon port starts over.

Every new test was mutation-tested rather than just observed passing. Reinstating the flat delay fails 4 tests; breaking the reset-on-open fails 1; reinstating the conflated counter fails the non-terminal test; dropping either port reset fails the corresponding test.

Full renderer suite: 3389 passed. The 5 failures in `src/landing` reproduce identically on `origin/main` and are unrelated to this change. `tsc --noEmit` is clean for every file touched here.

Two existing tests hardcoded the flat 5s and now derive the expected delay from the helper.

## Scope

Renderer only. The optional daemon-side `Retry-After` from #4323 is not included.

Supersedes #4340, whose branch predates the #4388 rewrite of `workspace-file-events.ts` and no longer applies.

Refs #4323, #3963