### PR TITLE
feat(onboarding): infer role-specific agent defaults

### DIFF
--- a/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.test.tsx
@@ -3,8 +3,14 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { agentReadinessQueryKey } from "../hooks/useAgentReadinessQuery";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { agentReadiness } from "../test/agent-readiness-fixtures";
-import { CreateProjectAgentSheet, defaultAuthorizedAgent, RequiredAgentField } from "./CreateProjectAgentSheet";
+import {
+	CreateProjectAgentSheet,
+	defaultAuthorizedAgent,
+	defaultAuthorizedAgentForRole,
+	RequiredAgentField,
+} from "./CreateProjectAgentSheet";
 import { TooltipProvider } from "./ui/tooltip";
 
 function renderSheet(onSubmit = vi.fn().mockResolvedValue(undefined), queryClient?: QueryClient) {
@@ -13,6 +19,9 @@ function renderSheet(onSubmit = vi.fn().mockResolvedValue(undefined), queryClien
 		queryClient.setQueryData(agentReadinessQueryKey, {
 			agents: [agentReadiness("claude-code"), agentReadiness("codex")],
 		});
+	}
+	if (queryClient.getQueryData(workspaceQueryKey) === undefined) {
+		queryClient.setQueryData(workspaceQueryKey, []);
 	}
 	render(
 		<QueryClientProvider client={queryClient}>
@@ -65,6 +74,56 @@ describe("CreateProjectAgentSheet", () => {
 		).toBe("devin");
 	});
 
+	it("chooses worker and orchestrator defaults from their own session history", () => {
+		const agents = [
+			agentReadiness("claude-code", "Claude Code"),
+			agentReadiness("codex", "Codex"),
+		];
+		const sessions = [
+			{ kind: "worker" as const, provider: "codex", createdAt: "2026-08-01T10:00:00Z" },
+			{ kind: "worker" as const, provider: "codex", createdAt: "2026-08-02T10:00:00Z" },
+			{ kind: "worker" as const, provider: "claude-code", createdAt: "2026-08-03T10:00:00Z" },
+			{ kind: "orchestrator" as const, provider: "claude-code", createdAt: "2026-08-04T10:00:00Z" },
+		];
+
+		expect(defaultAuthorizedAgentForRole(agents, sessions, "worker")).toBe("codex");
+		expect(defaultAuthorizedAgentForRole(agents, sessions, "orchestrator")).toBe("claude-code");
+	});
+
+	it("breaks equal role usage counts by the most recent matching session", () => {
+		const agents = [
+			agentReadiness("claude-code", "Claude Code"),
+			agentReadiness("codex", "Codex"),
+		];
+		const sessions = [
+			{ kind: "worker" as const, provider: "claude-code", createdAt: "2026-08-01T10:00:00Z" },
+			{ kind: "worker" as const, provider: "codex", createdAt: "2026-08-02T10:00:00Z" },
+		];
+
+		expect(defaultAuthorizedAgentForRole(agents, sessions, "worker")).toBe("codex");
+	});
+
+	it("ignores unavailable historical winners and falls back to Claude Code with no eligible history", () => {
+		const agents = [
+			agentReadiness("claude-code", "Claude Code"),
+			agentReadiness("codex", "Codex"),
+		];
+		const unavailableWinner = Array.from({ length: 4 }, (_, index) => ({
+			kind: "worker" as const,
+			provider: "goose",
+			createdAt: `2026-08-0${index + 1}T10:00:00Z`,
+		}));
+
+		expect(defaultAuthorizedAgentForRole(agents, unavailableWinner, "worker")).toBe("claude-code");
+		expect(
+			defaultAuthorizedAgentForRole(
+				[agentReadiness("codex", "Codex")],
+				[],
+				"worker",
+			),
+		).toBe("codex");
+	});
+
 	it("uses the compact trigger size for agent fields", () => {
 		render(
 			<RequiredAgentField
@@ -103,6 +162,55 @@ describe("CreateProjectAgentSheet", () => {
 			orchestratorAgent: "claude-code",
 			trackerIntake: undefined,
 		});
+	});
+
+	it("submits independent defaults from cached worker and orchestrator history", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		queryClient.setQueryData(workspaceQueryKey, [
+			{
+				sessions: [
+					{ kind: "worker", provider: "codex", createdAt: "2026-08-01T10:00:00Z" },
+					{ kind: "worker", provider: "codex", createdAt: "2026-08-02T10:00:00Z" },
+					{ kind: "orchestrator", provider: "claude-code", createdAt: "2026-08-03T10:00:00Z" },
+				],
+			},
+		]);
+		const onSubmit = renderSheet(vi.fn().mockResolvedValue(undefined), queryClient);
+
+		await userEvent.click(screen.getByRole("button", { name: "Create and start" }));
+
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith({
+			workerAgent: "codex",
+			orchestratorAgent: "claude-code",
+			trackerIntake: undefined,
+		});
+	});
+
+	it("does not replace a manually selected role when history refreshes", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		queryClient.setQueryData(workspaceQueryKey, [
+			{
+				sessions: [
+					{ kind: "worker", provider: "claude-code", createdAt: "2026-08-01T10:00:00Z" },
+				],
+			},
+		]);
+		const onSubmit = renderSheet(vi.fn().mockResolvedValue(undefined), queryClient);
+		await chooseOption(screen.getByLabelText("Worker agent"), "codex");
+
+		queryClient.setQueryData(workspaceQueryKey, [
+			{
+				sessions: [
+					{ kind: "worker", provider: "claude-code", createdAt: "2026-08-02T10:00:00Z" },
+					{ kind: "worker", provider: "claude-code", createdAt: "2026-08-03T10:00:00Z" },
+				],
+			},
+		]);
+		await userEvent.click(screen.getByRole("button", { name: "Create and start" }));
+
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ workerAgent: "codex" }));
 	});
 
 	it("does not show a manual agent catalog refresh action", () => {

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -3,12 +3,14 @@ import {
 	ProjectSetupFormView,
 	ProjectSetupHeaderView,
 } from "@aoagents/product-ui";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import * as Dialog from "@radix-ui/react-dialog";
 import { ChevronLeft, TriangleAlert, X, type LucideIcon } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { components } from "../../api/schema";
 import { useAgentReadinessQuery, useEnsureAgentReadiness } from "../hooks/useAgentReadinessQuery";
+import { workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import {
 	agentLabelCompare,
@@ -125,6 +127,10 @@ export function CreateProjectAgentSheet({
 		displayedOnBack.current = onBack;
 	}
 	const agentsQuery = useAgentReadinessQuery(contentOpen);
+	const workspacesQuery = useQuery({
+		...workspaceQueryOptions,
+		enabled: open,
+	});
 	useEnsureAgentReadiness({ enabled: contentOpen });
 	const agents = agentsQuery.data;
 	const agentOptions = useMemo(() => agents?.agents ?? [], [agents]);
@@ -181,10 +187,14 @@ export function CreateProjectAgentSheet({
 
 	useEffect(() => {
 		if (!open) return;
-		const defaultAgent = defaultAuthorizedAgent(authorizedAgents);
-		if (!workerAgentTouched) setWorkerAgent(defaultAgent);
-		if (!orchestratorAgentTouched) setOrchestratorAgent(defaultAgent);
-	}, [authorizedAgents, open, orchestratorAgentTouched, workerAgentTouched]);
+		const sessionHistory = (workspacesQuery.data ?? []).flatMap((workspace) => workspace.sessions);
+		if (!workerAgentTouched) {
+			setWorkerAgent(defaultAuthorizedAgentForRole(authorizedAgents, sessionHistory, "worker"));
+		}
+		if (!orchestratorAgentTouched) {
+			setOrchestratorAgent(defaultAuthorizedAgentForRole(authorizedAgents, sessionHistory, "orchestrator"));
+		}
+	}, [authorizedAgents, open, orchestratorAgentTouched, workerAgentTouched, workspacesQuery.data]);
 
 	return (
 		<Dialog.Root
@@ -563,4 +573,45 @@ export function defaultAuthorizedAgent(authorizedAgents: AgentInfo[]): string {
 					(DEFAULT_AGENT_PRIORITY_RANK.get(b.id) ?? Number.MAX_SAFE_INTEGER) ||
 				agentLabelCompare(a, b),
 		)[0]?.id ?? "";
+}
+
+type RoleUsageSession = {
+	createdAt: string;
+	kind?: "worker" | "orchestrator";
+	provider: string;
+};
+
+// Role defaults are derived only from sessions whose harness is currently
+// eligible. Historical use of an unavailable harness must not suppress the
+// normal catalog-priority fallback.
+export function defaultAuthorizedAgentForRole(
+	authorizedAgents: AgentInfo[],
+	sessions: RoleUsageSession[],
+	role: "worker" | "orchestrator",
+): string {
+	const stats = new Map<string, { count: number; latest: number }>();
+	const eligible = new Set(authorizedAgents.map((agent) => agent.id));
+
+	for (const session of sessions) {
+		if (session.kind !== role || !eligible.has(session.provider)) continue;
+		const current = stats.get(session.provider) ?? { count: 0, latest: Number.NEGATIVE_INFINITY };
+		const createdAt = Date.parse(session.createdAt);
+		stats.set(session.provider, {
+			count: current.count + 1,
+			latest: Number.isNaN(createdAt) ? current.latest : Math.max(current.latest, createdAt),
+		});
+	}
+
+	return [...authorizedAgents]
+		.sort((a, b) => {
+			const aStats = stats.get(a.id) ?? { count: 0, latest: Number.NEGATIVE_INFINITY };
+			const bStats = stats.get(b.id) ?? { count: 0, latest: Number.NEGATIVE_INFINITY };
+			return (
+				bStats.count - aStats.count ||
+				bStats.latest - aStats.latest ||
+				(DEFAULT_AGENT_PRIORITY_RANK.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+					(DEFAULT_AGENT_PRIORITY_RANK.get(b.id) ?? Number.MAX_SAFE_INTEGER) ||
+				agentLabelCompare(a, b)
+			);
+		})[0]?.id ?? "";
 }

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -576,7 +576,7 @@ export function defaultAuthorizedAgent(authorizedAgents: AgentInfo[]): string {
 }
 
 type RoleUsageSession = {
-	createdAt: string;
+	createdAt?: string;
 	kind?: "worker" | "orchestrator";
 	provider: string;
 };
@@ -595,7 +595,7 @@ export function defaultAuthorizedAgentForRole(
 	for (const session of sessions) {
 		if (session.kind !== role || !eligible.has(session.provider)) continue;
 		const current = stats.get(session.provider) ?? { count: 0, latest: Number.NEGATIVE_INFINITY };
-		const createdAt = Date.parse(session.createdAt);
+		const createdAt = Date.parse(session.createdAt ?? "");
 		stats.set(session.provider, {
 			count: current.count + 1,
 			latest: Number.isNaN(createdAt) ? current.latest : Math.max(current.latest, createdAt),


### PR DESCRIPTION
Fixes #4493

## Problem

New-project onboarding chose one generic authorized-agent default and assigned it to both Worker and Orchestrator, ignoring the user's role-specific AO session history.

## Root cause

The sheet only consulted the current agent-readiness catalog. It had no role-filtered usage signal, so both untouched fields received the same catalog-priority result.

## Fix

- load existing workspace session summaries while the sheet is open
- rank currently eligible agents independently for worker and orchestrator by usage count, then newest matching session
- retain the existing Claude Code / authorized-catalog fallback when no eligible history exists
- preserve touched-field protection so later query refreshes cannot replace a manual selection

## Safety

- changes only the initial suggestion in new-project onboarding
- does not mutate saved project configuration or session history
- unavailable historical harnesses are never selected
- preserves a valid fallback when Claude Code is unavailable

## Tests

- `npm test -- src/renderer/components/CreateProjectAgentSheet.test.tsx src/renderer/components/CreateProjectFlow.test.tsx` (25 passed)
- regression test was first observed failing before the implementation because the role-aware selector did not exist
- full local `npm run typecheck` produced no diagnostics but did not complete on this resource-constrained Windows host; CI is the authoritative full typecheck