### PR TITLE
fix(desktop): keep Linux app available from tray

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -69,7 +69,7 @@ import {
 	type KeybindingOverrides,
 } from "./shared/shortcuts";
 import { createTrayController, type TrayController } from "./main/tray";
-import { createTrayLifecycle, isTrayEnabled } from "./main/tray-lifecycle";
+import { createTrayLifecycle, isTrayEnabled, shouldQuitWhenAllWindowsClosed } from "./main/tray-lifecycle";
 import {
 	TRAY_RENDERER_READY_CHANNEL,
 	TRAY_SET_ATTENTION_STATE_CHANNEL,
@@ -2385,6 +2385,9 @@ app.whenReady().then(async () => {
 			focusWindow: focusMainWindow,
 			openSession: trayLifecycle.openSession,
 			locale: initialUiSettings.locale,
+			onUnavailable: (error) => {
+				console.warn("system tray unavailable; closing the last window will quit:", error);
+			},
 		});
 	}
 	await createWindow();
@@ -2453,7 +2456,7 @@ process.on("exit", () => {
 });
 
 app.on("window-all-closed", () => {
-	if (process.platform !== "darwin") {
+	if (shouldQuitWhenAllWindowsClosed(process.platform, trayController !== null)) {
 		app.quit();
 	}
 });

--- a/frontend/src/main/tray-lifecycle.test.ts
+++ b/frontend/src/main/tray-lifecycle.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { createTrayLifecycle, isTrayEnabled, type TrayLifecycleDeps } from "./tray-lifecycle";
+import {
+	createTrayLifecycle,
+	isTrayEnabled,
+	shouldQuitWhenAllWindowsClosed,
+	type TrayLifecycleDeps,
+} from "./tray-lifecycle";
 import type { TrayController } from "./tray";
 import { TRAY_OPEN_SESSION_CHANNEL } from "../shared/tray";
 
@@ -47,9 +52,28 @@ describe("isTrayEnabled", () => {
 		expect(isTrayEnabled("darwin", true, "0.10.3")).toBe(false);
 	});
 
-	it("is disabled on every non-darwin platform even for dev/nightly builds", () => {
+	it("is disabled on Windows", () => {
 		expect(isTrayEnabled("win32", false, "0.10.3")).toBe(false);
-		expect(isTrayEnabled("linux", true, "0.10.3-nightly.20260804")).toBe(false);
+	});
+
+	it("is enabled on Linux for both development and packaged builds", () => {
+		expect(isTrayEnabled("linux", false, "0.10.3")).toBe(true);
+		expect(isTrayEnabled("linux", true, "0.10.3")).toBe(true);
+	});
+});
+
+describe("shouldQuitWhenAllWindowsClosed", () => {
+	it("keeps macOS alive without requiring a tray", () => {
+		expect(shouldQuitWhenAllWindowsClosed("darwin", false)).toBe(false);
+	});
+
+	it("keeps Linux alive only when its tray was created", () => {
+		expect(shouldQuitWhenAllWindowsClosed("linux", true)).toBe(false);
+		expect(shouldQuitWhenAllWindowsClosed("linux", false)).toBe(true);
+	});
+
+	it("continues to quit Windows when its last window closes", () => {
+		expect(shouldQuitWhenAllWindowsClosed("win32", true)).toBe(true);
 	});
 });
 

--- a/frontend/src/main/tray-lifecycle.ts
+++ b/frontend/src/main/tray-lifecycle.ts
@@ -3,7 +3,13 @@ import type { TrayController } from "./tray";
 import { TRAY_OPEN_SESSION_CHANNEL, type TrayAttentionState, type TrayOpenSessionTarget } from "../shared/tray";
 
 export function isTrayEnabled(platform: NodeJS.Platform, isPackaged: boolean, appVersion: string): boolean {
-	return platform === "darwin" && (!isPackaged || appVersion.includes("-nightly."));
+	return platform === "linux" || (platform === "darwin" && (!isPackaged || appVersion.includes("-nightly.")));
+}
+
+export function shouldQuitWhenAllWindowsClosed(platform: NodeJS.Platform, trayAvailable: boolean): boolean {
+	if (platform === "darwin") return false;
+	if (platform === "linux") return !trayAvailable;
+	return true;
 }
 
 export type TrayLifecycleDeps = {

--- a/frontend/src/main/tray.test.ts
+++ b/frontend/src/main/tray.test.ts
@@ -11,14 +11,16 @@ type MenuItem = {
 	submenu?: MenuItem[];
 };
 
-const { FakeTray, trayInstances } = vi.hoisted(() => {
+const { FakeTray, trayInstances, trayConstructor } = vi.hoisted(() => {
 	const trayInstances: FakeTray[] = [];
+	const trayConstructor: { error: Error | null } = { error: null };
 	class FakeTray {
 		title = "";
 		tooltip = "";
 		template: MenuItem[] = [];
 		destroyed = false;
 		constructor(public icon: unknown) {
+			if (trayConstructor.error) throw trayConstructor.error;
 			trayInstances.push(this);
 		}
 		setTitle(title: string) {
@@ -34,7 +36,7 @@ const { FakeTray, trayInstances } = vi.hoisted(() => {
 			this.destroyed = true;
 		}
 	}
-	return { FakeTray, trayInstances };
+	return { FakeTray, trayInstances, trayConstructor };
 });
 
 const setTemplateImage = vi.hoisted(() => vi.fn());
@@ -71,6 +73,7 @@ const sessionItems = (tray: { template: MenuItem[] }) =>
 
 afterEach(() => {
 	trayInstances.length = 0;
+	trayConstructor.error = null;
 	vi.clearAllMocks();
 });
 
@@ -80,6 +83,17 @@ describe("createTrayController", () => {
 		expect(tray.title).toBe("");
 		expect(tray.template.some((i) => i.label === "No sessions need attention" && i.enabled === false)).toBe(true);
 		expect(tray.template.some((i) => i.role === "quit")).toBe(true);
+	});
+
+	it("reports an unavailable native tray without crashing startup", () => {
+		const unavailable = new Error("no status notifier");
+		const onUnavailable = vi.fn();
+		trayConstructor.error = unavailable;
+
+		expect(
+			createTrayController({ focusWindow: vi.fn(), openSession: vi.fn(), locale: "en", onUnavailable }),
+		).toBeNull();
+		expect(onUnavailable).toHaveBeenCalledWith(unavailable);
 	});
 
 	it("uses grammatically correct singular for exactly one attention session", () => {

--- a/frontend/src/main/tray.ts
+++ b/frontend/src/main/tray.ts
@@ -33,6 +33,7 @@ export type TrayControllerOptions = {
 	focusWindow: () => void;
 	openSession: (target: TrayOpenSessionTarget) => void;
 	locale: AppLocale;
+	onUnavailable?: (error: unknown) => void;
 };
 
 export function createTrayController(options: TrayControllerOptions): TrayController | null {
@@ -42,7 +43,13 @@ export function createTrayController(options: TrayControllerOptions): TrayContro
 	if (icon.isEmpty()) return null;
 	icon.setTemplateImage(true);
 
-	const tray = new Tray(icon);
+	let tray: Tray;
+	try {
+		tray = new Tray(icon);
+	} catch (error) {
+		options.onUnavailable?.(error);
+		return null;
+	}
 	let sessions: TraySessionEntry[] = [];
 	let catalog = catalogFor(options.locale);
 


### PR DESCRIPTION
Fixes #4811

## Problem

Linux never initialized AO's tray controller, and the generic non-macOS last-window policy immediately quit the app. That made closing the window terminate the desktop supervisor and provided no tray affordance for reopening it.

## Root cause

`isTrayEnabled` hard-excluded every non-macOS platform, while `window-all-closed` treated Linux like Windows regardless of whether a tray existed.

## Fix

- enable the existing tray controller on Linux in development and packaged builds
- make last-window quit behavior depend on whether Linux actually created a tray controller
- catch native `Tray` construction failures, report them, and retain the prior quit behavior instead of leaving an inaccessible background process
- preserve the existing macOS release gate and Windows close behavior

Electron documents StatusNotifierItem with GtkStatusIcon fallback on Linux: https://www.electronjs.org/docs/latest/api/tray/#platform-considerations

## Safety

- Linux stays resident only after successful native tray construction
- a missing icon, empty native image, or constructor failure leaves the controller null and therefore quits on last-window close
- macOS and Windows policies remain unchanged
- tray session routing and attention-state behavior are untouched

## Tests

- regression state confirmed first: 4 failures before implementation
- `npm test -- src/main/tray-lifecycle.test.ts src/main/tray.test.ts` (31 passed)
- full local `npm run typecheck` produced no diagnostics but did not complete on this resource-constrained Windows host; CI is the authoritative full typecheck

## Manual validation

No live Linux desktop-environment validation was performed here. CI covers the deterministic policy and adapter tests; a maintainer should still smoke-test packaged builds under the supported Linux desktop environments.