### PR TITLE
fix(sessions): keep session teardown off the request path

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,8 +66,13 @@ jobs:
           go-version-file: backend/go.mod
           cache: false
 
-      - name: Test workspace teardown and session lifecycle
-        run: go test -race ./internal/adapters/workspace/... ./internal/session_manager/...
+      # Scoped to teardown and kill by name rather than running these packages
+      # whole: running them on Windows for the first time surfaced ten
+      # pre-existing failures (agent switching, handoff artifacts, spawn PATH
+      # and branch namespacing) that have nothing to do with worktree teardown.
+      # Widening this is worth doing, but as its own change with its own fixes.
+      - name: Test workspace teardown and session kill
+        run: go test -race -v -run 'Destroy|Discard|Sweep|Kill' ./internal/adapters/workspace/... ./internal/session_manager/
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,6 +48,27 @@ jobs:
       - name: Test
         run: go test -race ./...
 
+  # The suite above only ever runs on Linux, so the packages whose behaviour is
+  # genuinely platform-specific have never been exercised on Windows: worktree
+  # teardown renames and unlinks directories, and Windows is the platform where
+  # an open handle makes both fail. Scoped to those packages rather than the
+  # whole suite to keep the matrix cheap.
+  windows-workspace:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache: false
+
+      - name: Test workspace teardown and session lifecycle
+        run: go test -race ./internal/adapters/workspace/... ./internal/session_manager/...
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/backend/internal/adapters/workspace/gitworktree/discard.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard.go
@@ -166,10 +166,16 @@ func (w *Workspace) discardWorktree(ctx context.Context, repo, path string) (boo
 		w.undiscard(discarded, path)
 		return false, nil //nolint:nilerr // the git-driven path re-runs prune and reports the failure
 	}
+	// Past this point the registration is gone, so restoring the directory is
+	// no longer a safe undo: it would put a de-registered worktree back on disk,
+	// and the next teardown would treat it as an unregistered stray and delete
+	// it without a dirty check. Nothing is at risk in letting it go instead,
+	// because the move only happened after a conclusive clean status: every
+	// change in there is already committed on the session branch.
 	stillRegistered, _, conclusive := w.worktreeRegistration(ctx, repo, path)
 	if !conclusive {
-		w.undiscard(discarded, path)
-		return false, nil
+		w.removeInBackground(discarded)
+		return true, nil
 	}
 	if stillRegistered {
 		w.undiscard(discarded, path)

--- a/backend/internal/adapters/workspace/gitworktree/discard.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard.go
@@ -127,7 +127,9 @@ func (w *Workspace) worktreeRegistration(ctx context.Context, repo, path string)
 }
 
 // worktreeDirty is isDirty with the same "could not ask" distinction as
-// worktreeRegistration: an unreadable status is not a clean status.
+// worktreeRegistration: an unreadable status is not a clean status. It takes a
+// path rather than the worktree's registered location because the fast path
+// asks about the directory after it has been moved aside.
 func (w *Workspace) worktreeDirty(ctx context.Context, path string) (dirty, conclusive bool) {
 	dirty, err := w.isDirty(ctx, path)
 	if err != nil {
@@ -149,18 +151,29 @@ func (w *Workspace) discardWorktree(ctx context.Context, repo, path string) (boo
 	if !conclusive || locked {
 		return false, nil
 	}
-	if registered {
-		dirty, conclusive := w.worktreeDirty(ctx, path)
-		if !conclusive {
-			return false, nil
-		}
-		if dirty {
-			return true, fmt.Errorf("gitworktree: refusing to remove %q: %w (worktree has uncommitted changes)", path, ports.ErrWorkspaceDirty)
-		}
-	}
 	discarded, moved := w.discard(path)
 	if !moved {
 		return false, nil
+	}
+	// Dirtiness is judged AFTER the move, deliberately. Checking first and
+	// deleting afterwards leaves a window: teardown stops the agent and gates
+	// the session's shells before it gets here, but a stray watcher or
+	// background child can still land a file in the worktree between the two,
+	// and the delete would then take work the check said was not there. Once
+	// the directory has been renamed, the worktree path no longer resolves for
+	// anyone, so what git reports here is exactly what gets unlinked. The
+	// worktree stays registered until the prune below, which is what keeps
+	// `git status` answerable at the new location.
+	if registered {
+		dirty, conclusive := w.worktreeDirty(ctx, discarded)
+		if !conclusive {
+			w.undiscard(discarded, path)
+			return false, nil
+		}
+		if dirty {
+			w.undiscard(discarded, path)
+			return true, fmt.Errorf("gitworktree: refusing to remove %q: %w (worktree has uncommitted changes)", path, ports.ErrWorkspaceDirty)
+		}
 	}
 	if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
 		w.undiscard(discarded, path)

--- a/backend/internal/adapters/workspace/gitworktree/discard.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard.go
@@ -1,0 +1,180 @@
+package gitworktree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Teardown used to unlink the session's directory inline, inside the request
+// that asked for it. A worker checkout carries its build output with it:
+// node_modules, target/, .venv, language server caches, none of it tracked by
+// git and all of it deleted by `git worktree remove`. Measured on this repo's
+// own sessions that is ~2s per 60,000 files, so a real session took tens of
+// seconds to kill and a large one ran past the daemon's 60s REST timeout: the
+// request context was cancelled mid-teardown, the handler answered 500, and the
+// session was left half-dead (agent stopped, row still marked alive).
+//
+// Discarding splits the two halves apart. Moving the directory into a trash
+// area next to it is a single rename, so the caller's teardown is done as soon
+// as git agrees the worktree is gone; the unlinking itself runs on a background
+// goroutine with nobody waiting on it. Nothing observable is deferred: once the
+// rename lands, the worktree path is free for reuse and git's registration has
+// already been pruned.
+const discardedDirName = ".discarded"
+
+// discardedRoot is where discarded worktrees wait to be unlinked. It lives
+// inside the managed root so the rename never crosses a filesystem boundary
+// (which would silently turn the O(1) move back into a full copy), and is
+// dot-prefixed so it cannot collide with a project id.
+func (w *Workspace) discardedRoot() string {
+	return filepath.Join(w.managedRoot, discardedDirName)
+}
+
+// discard moves path into the discard root and schedules its removal in the
+// background. It reports false when the move did not happen (the path is gone,
+// the rename failed, or the trash directory could not be created), leaving the
+// caller to fall back to deleting the path inline.
+func (w *Workspace) discard(path string) (string, bool) {
+	root := w.discardedRoot()
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		return "", false
+	}
+	base := filepath.Base(path)
+	for i := range 100 {
+		candidate := filepath.Join(root, fmt.Sprintf("%s-%d-%d", base, time.Now().UnixNano(), i))
+		if _, err := os.Lstat(candidate); err == nil {
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", false
+		}
+		if err := os.Rename(path, candidate); err != nil {
+			return "", false
+		}
+		return candidate, true
+	}
+	return "", false
+}
+
+// undiscard moves a discarded directory back to its original path. It is the
+// rollback for a teardown that turned out to be refusable after the move. The
+// directory must survive a refusal, exactly as it did when git itself declined
+// to remove it.
+func (w *Workspace) undiscard(discarded, path string) {
+	if err := os.Rename(discarded, path); err != nil {
+		// Nothing further to try: report the directory's real location rather
+		// than leaving the operator to guess where the contents went.
+		w.logf("gitworktree: could not restore discarded worktree %q to %q: %v", discarded, path, err)
+	}
+}
+
+// removeInBackground unlinks a discarded directory off the caller's path. The
+// work is tracked so tests (and shutdown) can wait for it; failures are logged
+// rather than returned because no caller is left to act on them; a leftover
+// under the discard root is swept on the next daemon start.
+func (w *Workspace) removeInBackground(path string) {
+	w.discards.Add(1)
+	go func() {
+		defer w.discards.Done()
+		if err := removeAllWithRetry(context.Background(), path); err != nil {
+			w.logf("gitworktree: could not remove discarded worktree %q: %v", path, err)
+		}
+	}()
+}
+
+// sweepDiscarded removes anything left in the discard root by a previous run.
+// A daemon that exits (or is killed) mid-removal would otherwise leak the
+// directory forever: nothing else ever looks at this path again.
+func (w *Workspace) sweepDiscarded() {
+	entries, err := os.ReadDir(w.discardedRoot())
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		w.removeInBackground(filepath.Join(w.discardedRoot(), entry.Name()))
+	}
+}
+
+// waitForDiscards blocks until every scheduled background removal has finished.
+// Test-only: production callers deliberately do not wait.
+func (w *Workspace) waitForDiscards() {
+	w.discards.Wait()
+}
+
+func (w *Workspace) logf(format string, args ...any) {
+	if w.logger == nil {
+		return
+	}
+	w.logger.Warn(fmt.Sprintf(format, args...))
+}
+
+// worktreeRegistration reports whether git still has path registered as a
+// worktree and whether it is locked. conclusive is false when git could not be
+// asked at all, which routes the caller back to the git-driven path instead of
+// letting a failed probe look like an answer.
+func (w *Workspace) worktreeRegistration(ctx context.Context, repo, path string) (registered, locked, conclusive bool) {
+	records, err := w.listRecords(ctx, repo)
+	if err != nil {
+		return false, false, false
+	}
+	rec, found := findWorktree(records, path)
+	return found, found && rec.Locked, true
+}
+
+// worktreeDirty is isDirty with the same "could not ask" distinction as
+// worktreeRegistration: an unreadable status is not a clean status.
+func (w *Workspace) worktreeDirty(ctx context.Context, path string) (dirty, conclusive bool) {
+	dirty, err := w.isDirty(ctx, path)
+	if err != nil {
+		return false, false
+	}
+	return dirty, true
+}
+
+// discardWorktree is Destroy's fast path: it applies the same checks git would
+// have applied (registered, unlocked, clean), then moves the directory aside
+// and prunes the registration instead of waiting for git to walk the tree.
+//
+// handled=false means "not my business, run the git-driven path": every
+// inconclusive probe routes there so git stays the authority on refusals and
+// their messages. A refusal discovered after the move restores the directory
+// first, because a refused teardown must leave the worktree exactly as it was.
+func (w *Workspace) discardWorktree(ctx context.Context, repo, path string) (bool, error) {
+	registered, locked, conclusive := w.worktreeRegistration(ctx, repo, path)
+	if !conclusive || locked {
+		return false, nil
+	}
+	if registered {
+		dirty, conclusive := w.worktreeDirty(ctx, path)
+		if !conclusive {
+			return false, nil
+		}
+		if dirty {
+			return true, fmt.Errorf("gitworktree: refusing to remove %q: %w (worktree has uncommitted changes)", path, ports.ErrWorkspaceDirty)
+		}
+	}
+	discarded, moved := w.discard(path)
+	if !moved {
+		return false, nil
+	}
+	if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
+		w.undiscard(discarded, path)
+		return false, nil //nolint:nilerr // the git-driven path re-runs prune and reports the failure
+	}
+	stillRegistered, _, conclusive := w.worktreeRegistration(ctx, repo, path)
+	if !conclusive {
+		w.undiscard(discarded, path)
+		return false, nil
+	}
+	if stillRegistered {
+		w.undiscard(discarded, path)
+		return true, fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune", path)
+	}
+	w.removeInBackground(discarded)
+	return true, nil
+}

--- a/backend/internal/adapters/workspace/gitworktree/discard_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard_test.go
@@ -231,3 +231,37 @@ func TestDiscardKeepsGoingWhenThePostPruneProbeFails(t *testing.T) {
 	}
 	ws.waitForDiscards()
 }
+
+// A project directory the user deleted turns every `git -C <repo> ...` in
+// teardown into an opaque exit 128, which surfaced as a permanent
+// "Internal server error" on delete and left the session in the sidebar
+// forever. Teardown reports it as a typed refusal instead, so the caller can
+// preserve the directory and still terminate the session.
+func TestDestroyReportsAMissingProjectRepoAsUnavailable(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	ws, err := New(Options{Binary: git, ManagedRoot: filepath.Join(tmp, "managed"), RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatalf("remove project repo: %v", err)
+	}
+
+	err = ws.Destroy(ctx, info)
+	if !errors.Is(err, ports.ErrWorkspaceRepoUnavailable) {
+		t.Fatalf("destroy error = %v, want ports.ErrWorkspaceRepoUnavailable", err)
+	}
+	if _, statErr := os.Stat(info.Path); statErr != nil {
+		t.Fatalf("worktree must be left alone when git cannot be asked about it: %v", statErr)
+	}
+	if err := ws.ForceDestroy(ctx, info); !errors.Is(err, ports.ErrWorkspaceRepoUnavailable) {
+		t.Fatalf("force destroy error = %v, want ports.ErrWorkspaceRepoUnavailable", err)
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/discard_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard_test.go
@@ -1,0 +1,165 @@
+package gitworktree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// A worktree's ignored build output (node_modules and friends) is the bulk of
+// what teardown has to unlink, and unlinking it inline is what pushed a kill
+// past the daemon's request timeout. Destroy must return with the path already
+// gone and the registration already pruned, leaving only the unlinking behind.
+func TestDestroyDiscardsWorktreeWithoutUnlinkingInline(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	ws, err := New(Options{Binary: git, ManagedRoot: filepath.Join(tmp, "managed"), RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Ignored, like a real session's dependency tree: git would delete it as
+	// part of `worktree remove`, which is the cost being moved off the request.
+	if err := ws.AddExclude(ctx, info, "deps/"); err != nil {
+		t.Fatalf("add exclude: %v", err)
+	}
+	writeIgnoredTree(t, info.Path)
+
+	if err := ws.Destroy(ctx, info); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree path after destroy = %v, want not exist", err)
+	}
+	records, err := ws.listRecords(ctx, repo)
+	if err != nil {
+		t.Fatalf("list records: %v", err)
+	}
+	if _, ok := findWorktree(records, info.Path); ok {
+		t.Fatalf("worktree still registered after destroy")
+	}
+
+	ws.waitForDiscards()
+	entries, err := os.ReadDir(ws.discardedRoot())
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read discard root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("discard root still holds %d entries after background removal", len(entries))
+	}
+}
+
+// The discard path must not weaken the refusal that protects uncommitted agent
+// work: a dirty worktree stays on disk, registered, and reported as dirty.
+func TestDestroyDiscardStillRefusesDirtyWorktree(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	ws, err := New(Options{Binary: git, ManagedRoot: filepath.Join(tmp, "managed"), RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "in-progress.txt"), []byte("agent work"), 0o600); err != nil {
+		t.Fatalf("seed dirty file: %v", err)
+	}
+
+	err = ws.Destroy(ctx, info)
+	if !errors.Is(err, ports.ErrWorkspaceDirty) {
+		t.Fatalf("destroy error = %v, want ports.ErrWorkspaceDirty", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(info.Path, "in-progress.txt")); statErr != nil {
+		t.Fatalf("dirty worktree was not preserved: %v", statErr)
+	}
+	records, err := ws.listRecords(ctx, repo)
+	if err != nil {
+		t.Fatalf("list records: %v", err)
+	}
+	if _, ok := findWorktree(records, info.Path); !ok {
+		t.Fatalf("dirty worktree lost its registration")
+	}
+}
+
+// ForceDestroy has no refusal to honour, so it discards unconditionally, but
+// it still owes the caller a path that is gone and a registration that is
+// pruned by the time it returns.
+func TestForceDestroyDiscardsWorktree(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	ws, err := New(Options{Binary: git, ManagedRoot: filepath.Join(tmp, "managed"), RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "in-progress.txt"), []byte("agent work"), 0o600); err != nil {
+		t.Fatalf("seed dirty file: %v", err)
+	}
+	if err := ws.ForceDestroy(ctx, info); err != nil {
+		t.Fatalf("force destroy: %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree path after force destroy = %v, want not exist", err)
+	}
+	records, err := ws.listRecords(ctx, repo)
+	if err != nil {
+		t.Fatalf("list records: %v", err)
+	}
+	if _, ok := findWorktree(records, info.Path); ok {
+		t.Fatalf("worktree still registered after force destroy")
+	}
+	ws.waitForDiscards()
+}
+
+// A daemon that dies mid-removal leaves directories in the discard root that
+// nothing else ever revisits. Construction is the one moment the root is known
+// to be ours, so that is where the leftovers get collected.
+func TestNewSweepsLeftoverDiscards(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "managed")
+	leftover := filepath.Join(root, discardedDirName, "sess-123-0")
+	if err := os.MkdirAll(leftover, 0o755); err != nil {
+		t.Fatalf("seed leftover: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(leftover, "stale.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed leftover file: %v", err)
+	}
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": tmp}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ws.waitForDiscards()
+	if _, err := os.Stat(leftover); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("leftover discard after sweep = %v, want not exist", err)
+	}
+}
+
+func writeIgnoredTree(t *testing.T, worktree string) {
+	t.Helper()
+	deps := filepath.Join(worktree, "deps", "pkg")
+	if err := os.MkdirAll(deps, 0o755); err != nil {
+		t.Fatalf("make deps: %v", err)
+	}
+	for _, name := range []string{"a.js", "b.js", "c.js"} {
+		if err := os.WriteFile(filepath.Join(deps, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write dep %s: %v", name, err)
+		}
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/discard_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard_test.go
@@ -265,3 +265,58 @@ func TestDestroyReportsAMissingProjectRepoAsUnavailable(t *testing.T) {
 		t.Fatalf("force destroy error = %v, want ports.ErrWorkspaceRepoUnavailable", err)
 	}
 }
+
+// The move is not always possible. On Windows a PTY or agent child can still
+// hold a handle on the worktree directory for a moment after the process is
+// gone, and a rename against an open handle fails outright, so the fast path
+// has to hand back to the git-driven teardown rather than give up. Simulated
+// here by blocking the discard root with a file, which is the one failure mode
+// that reproduces identically on every platform.
+func TestDestroyFallsBackToGitWhenTheMoveIsImpossible(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	ws, err := New(Options{Binary: git, ManagedRoot: filepath.Join(tmp, "managed"), RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// A plain file where the discard root belongs: MkdirAll cannot create the
+	// directory, so no rename is even attempted.
+	if err := os.WriteFile(ws.discardedRoot(), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("block discard root: %v", err)
+	}
+
+	inner := ws.run
+	var calls []string
+	ws.run = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		calls = append(calls, strings.Join(args, " "))
+		return inner(ctx, binary, args...)
+	}
+	if err := ws.Destroy(ctx, info); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree path after fallback destroy = %v, want not exist", err)
+	}
+	var sawRemove bool
+	for _, call := range calls {
+		if strings.Contains(call, "worktree remove") {
+			sawRemove = true
+		}
+	}
+	if !sawRemove {
+		t.Fatal("fallback did not reach `git worktree remove`; an impossible move must not silently skip teardown")
+	}
+	records, err := ws.listRecords(ctx, repo)
+	if err != nil {
+		t.Fatalf("list records: %v", err)
+	}
+	if _, ok := findWorktree(records, info.Path); ok {
+		t.Fatal("worktree still registered after fallback destroy")
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/discard_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -34,8 +35,19 @@ func TestDestroyDiscardsWorktreeWithoutUnlinkingInline(t *testing.T) {
 	}
 	writeIgnoredTree(t, info.Path)
 
+	inner := ws.run
+	var calls []string
+	ws.run = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		calls = append(calls, strings.Join(args, " "))
+		return inner(ctx, binary, args...)
+	}
 	if err := ws.Destroy(ctx, info); err != nil {
 		t.Fatalf("destroy: %v", err)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "worktree remove") {
+			t.Fatalf("Destroy shelled out to %q instead of discarding the directory", call)
+		}
 	}
 	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("worktree path after destroy = %v, want not exist", err)
@@ -112,8 +124,22 @@ func TestForceDestroyDiscardsWorktree(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(info.Path, "in-progress.txt"), []byte("agent work"), 0o600); err != nil {
 		t.Fatalf("seed dirty file: %v", err)
 	}
+	// Recording the git calls is what proves the fast path ran: a ForceDestroy
+	// that fell through to `git worktree remove --force` would still leave the
+	// path gone and pass every assertion below.
+	inner := ws.run
+	var calls []string
+	ws.run = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		calls = append(calls, strings.Join(args, " "))
+		return inner(ctx, binary, args...)
+	}
 	if err := ws.ForceDestroy(ctx, info); err != nil {
 		t.Fatalf("force destroy: %v", err)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, "worktree remove") {
+			t.Fatalf("ForceDestroy shelled out to %q instead of discarding the directory", call)
+		}
 	}
 	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("worktree path after force destroy = %v, want not exist", err)
@@ -162,4 +188,46 @@ func writeIgnoredTree(t *testing.T, worktree string) {
 			t.Fatalf("write dep %s: %v", name, err)
 		}
 	}
+}
+
+// Once the registration is pruned, restoring the directory would be a worse
+// outcome than losing it: the next teardown would see an unregistered stray and
+// delete it with no dirty check at all. The move only happens after a
+// conclusive clean status, so letting it go costs nothing that is not already
+// committed on the session branch.
+func TestDiscardKeepsGoingWhenThePostPruneProbeFails(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := mkdirFile(path, "committed.txt"); err != nil {
+		t.Fatalf("seed path: %v", err)
+	}
+	listCalls := 0
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "worktree list --porcelain"):
+			listCalls++
+			if listCalls > 1 {
+				return nil, errors.New("git blew up after the prune")
+			}
+			return []byte("worktree " + path + "\nbranch refs/heads/feature/one\n"), nil
+		case strings.Contains(joined, "status --porcelain"):
+			return nil, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	if err := ws.Destroy(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess", Branch: "feature/one"}); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("de-registered directory was restored to %q (err = %v); a later teardown would delete it unchecked", path, err)
+	}
+	ws.waitForDiscards()
 }

--- a/backend/internal/adapters/workspace/gitworktree/discard_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard_test.go
@@ -320,3 +320,82 @@ func TestDestroyFallsBackToGitWhenTheMoveIsImpossible(t *testing.T) {
 		t.Fatal("worktree still registered after fallback destroy")
 	}
 }
+
+// Work that appears between the dirty probe and the delete must not be taken.
+// The probe therefore runs against the directory after it has been moved aside:
+// once the worktree path no longer resolves, nothing can add to what is about
+// to be unlinked, so the state git reports is the state that gets deleted.
+// Probing the live path first and deleting afterwards leaves exactly that gap.
+func TestDirtyProbeRunsAgainstTheIsolatedDirectory(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	ws, err := New(Options{Binary: git, ManagedRoot: filepath.Join(tmp, "managed"), RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	inner := ws.run
+	var statusPaths []string
+	ws.run = func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		if joined := strings.Join(args, " "); strings.Contains(joined, "status --porcelain") {
+			for i, a := range args {
+				if a == "-C" && i+1 < len(args) {
+					statusPaths = append(statusPaths, args[i+1])
+				}
+			}
+		}
+		return inner(ctx, binary, args...)
+	}
+
+	if err := ws.Destroy(ctx, info); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if len(statusPaths) == 0 {
+		t.Fatal("no dirty probe ran; teardown must not delete a worktree it never checked")
+	}
+	for _, probed := range statusPaths {
+		if probed == info.Path {
+			t.Fatalf("dirty probe ran against the live worktree %q; anything written after it would be deleted unchecked", probed)
+		}
+		if !strings.HasPrefix(probed, ws.discardedRoot()) {
+			t.Fatalf("dirty probe ran against %q, want a path under the discard root %q", probed, ws.discardedRoot())
+		}
+	}
+	ws.waitForDiscards()
+}
+
+// A failed prune must leave both halves intact. Deleting the directory anyway
+// reports failure while destroying the worktree and stranding its registration,
+// and that dangling entry blocks the path from being reused.
+func TestForceDestroyKeepsTheWorktreeWhenPruneFails(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := mkdirFile(path, "keep.txt"); err != nil {
+		t.Fatalf("seed path: %v", err)
+	}
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "worktree prune") {
+			return nil, errors.New("prune exploded")
+		}
+		return nil, nil
+	}
+
+	err = ws.ForceDestroy(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if err == nil || !strings.Contains(err.Error(), "prune") {
+		t.Fatalf("force destroy error = %v, want the prune failure", err)
+	}
+	ws.waitForDiscards()
+	if _, statErr := os.Stat(filepath.Join(path, "keep.txt")); statErr != nil {
+		t.Fatalf("worktree must survive a failed prune so the caller can retry: %v", statErr)
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -455,6 +455,17 @@ func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) 
 	if err != nil {
 		return err
 	}
+	// Force teardown has no refusal to honour, so the move is unconditional:
+	// rename the directory out of the way, drop the registration, unlink in the
+	// background. This runs on daemon shutdown and orchestrator replacement,
+	// which stalled on the same unlink that used to stall a kill.
+	if discarded, moved := w.discard(path); moved {
+		defer w.removeInBackground(discarded)
+		if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
+			return fmt.Errorf("gitworktree: worktree prune: %w", err)
+		}
+		return nil
+	}
 	// --force bypasses git's dirty check; errors here are advisory (the path may
 	// already be gone). We proceed to prune regardless.
 	_, _ = w.run(ctx, w.binary, worktreeForceRemoveArgs(repo, path)...)

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -72,6 +73,9 @@ type Options struct {
 	Binary       string
 	ManagedRoot  string
 	RepoResolver RepoResolver
+	// Logger receives the failures background removal cannot return to a
+	// caller. Optional; nil silences them.
+	Logger *slog.Logger
 }
 
 // Workspace creates per-session git worktrees under a managed root. It
@@ -81,6 +85,10 @@ type Workspace struct {
 	managedRoot string
 	repos       RepoResolver
 	run         commandRunner
+	logger      *slog.Logger
+	// discards tracks background worktree removals so tests can wait for them.
+	// Production never waits: that deferral is the point (see discard.go).
+	discards sync.WaitGroup
 }
 
 type commandRunner func(ctx context.Context, binary string, args ...string) ([]byte, error)
@@ -107,12 +115,18 @@ func New(opts Options) (*Workspace, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gitworktree: managed root: %w", err)
 	}
-	return &Workspace{
+	w := &Workspace{
 		binary:      binary,
 		managedRoot: filepath.Clean(root),
 		repos:       opts.RepoResolver,
 		run:         runCommand,
-	}, nil
+		logger:      opts.Logger,
+	}
+	// A daemon that died mid-removal leaves directories under the discard root
+	// that nothing else will ever look at again. Sweeping at construction is
+	// the one moment we know the root is ours.
+	w.sweepDiscarded()
+	return w, nil
 }
 
 // ResolveDefaultBranch selects a canonical remote-tracking ref using only local
@@ -378,6 +392,12 @@ func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error
 	}
 	path, err := w.validateManagedPath(info.Path)
 	if err != nil {
+		return err
+	}
+	// Move the directory aside rather than waiting out `git worktree remove`'s
+	// walk of an ignored-file mountain; falls through to the git-driven path
+	// below whenever the move is not clearly safe.
+	if handled, err := w.discardWorktree(ctx, repo, path); handled {
 		return err
 	}
 	_, removeErr := w.run(ctx, w.binary, worktreeRemoveArgs(repo, path)...)
@@ -1205,6 +1225,13 @@ func (w *Workspace) createWorkspaceProjectRepo(ctx context.Context, repo workspa
 }
 
 func (w *Workspace) forceDestroyPath(ctx context.Context, repo, path string) error {
+	// Force teardown has no refusal to honour, so the move is unconditional:
+	// rename the directory out of the way, drop the registration, unlink in the
+	// background.
+	if discarded, ok := w.discard(path); ok {
+		defer w.removeInBackground(discarded)
+		return w.pruneWorktrees(ctx, repo)
+	}
 	_, _ = w.run(ctx, w.binary, worktreeForceRemoveArgs(repo, path)...)
 	if err := w.pruneWorktrees(ctx, repo); err != nil {
 		return err

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -466,10 +466,16 @@ func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) 
 	// background. This runs on daemon shutdown and orchestrator replacement,
 	// which stalled on the same unlink that used to stall a kill.
 	if discarded, moved := w.discard(path); moved {
-		defer w.removeInBackground(discarded)
+		// A failed prune must leave both halves intact. Deleting anyway would
+		// report failure while destroying the directory and stranding its
+		// registration, and that dangling entry blocks the path from being
+		// used again; restoring lets the caller retry against the state it
+		// started from.
 		if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
+			w.undiscard(discarded, path)
 			return fmt.Errorf("gitworktree: worktree prune: %w", err)
 		}
+		w.removeInBackground(discarded)
 		return nil
 	}
 	// --force bypasses git's dirty check; errors here are advisory (the path may
@@ -1249,8 +1255,12 @@ func (w *Workspace) forceDestroyPath(ctx context.Context, repo, path string) err
 	// rename the directory out of the way, drop the registration, unlink in the
 	// background.
 	if discarded, ok := w.discard(path); ok {
-		defer w.removeInBackground(discarded)
-		return w.pruneWorktrees(ctx, repo)
+		if err := w.pruneWorktrees(ctx, repo); err != nil {
+			w.undiscard(discarded, path)
+			return err
+		}
+		w.removeInBackground(discarded)
+		return nil
 	}
 	_, _ = w.run(ctx, w.binary, worktreeForceRemoveArgs(repo, path)...)
 	if err := w.pruneWorktrees(ctx, repo); err != nil {

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -394,6 +394,9 @@ func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error
 	if err != nil {
 		return err
 	}
+	if err := w.requireReachableRepo(repo); err != nil {
+		return err
+	}
 	// Move the directory aside rather than waiting out `git worktree remove`'s
 	// walk of an ignored-file mountain; falls through to the git-driven path
 	// below whenever the move is not clearly safe.
@@ -453,6 +456,9 @@ func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) 
 	}
 	path, err := w.validateManagedPath(info.Path)
 	if err != nil {
+		return err
+	}
+	if err := w.requireReachableRepo(repo); err != nil {
 		return err
 	}
 	// Force teardown has no refusal to honour, so the move is unconditional:
@@ -1236,6 +1242,9 @@ func (w *Workspace) createWorkspaceProjectRepo(ctx context.Context, repo workspa
 }
 
 func (w *Workspace) forceDestroyPath(ctx context.Context, repo, path string) error {
+	if err := w.requireReachableRepo(repo); err != nil {
+		return err
+	}
 	// Force teardown has no refusal to honour, so the move is unconditional:
 	// rename the directory out of the way, drop the registration, unlink in the
 	// background.
@@ -1458,6 +1467,18 @@ func (w *Workspace) repoPathForInfo(info ports.WorkspaceInfo) (string, error) {
 		return "", errors.New("gitworktree: project id is required")
 	}
 	return w.repoPath(info.ProjectID)
+}
+
+// requireReachableRepo reports the project repo as unavailable when it is no
+// longer on disk. Teardown is the only caller: every git command it runs is
+// `git -C <repo> ...`, so a deleted project directory turns each one into an
+// opaque exit 128, and the session it belongs to can never be deleted. Create
+// and Restore deliberately do not use this: there, a missing repo must fail.
+func (w *Workspace) requireReachableRepo(repo string) error {
+	if info, err := os.Stat(repo); err == nil && info.IsDir() {
+		return nil
+	}
+	return fmt.Errorf("gitworktree: repository %q is no longer on disk: %w", repo, ports.ErrWorkspaceRepoUnavailable)
 }
 
 func (w *Workspace) repoPathForConfig(cfg ports.WorkspaceConfig) (string, error) {

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -202,6 +202,7 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		// session spawned for a registered project materialises its worktree off
 		// that repo. Unregistered projects fail loudly.
 		RepoResolver: projectRepoResolver{store: store},
+		Logger:       log,
 	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("session workspace: %w", err)

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -300,6 +300,13 @@ var (
 	// it holds uncommitted changes or untracked files. Teardown is never
 	// forced; callers treat the workspace as intentionally preserved.
 	ErrWorkspaceDirty = errors.New("workspace: uncommitted changes present")
+	// ErrWorkspaceRepoUnavailable reports that the project's source repository
+	// is no longer reachable on disk, so git cannot be asked to remove the
+	// session's worktree. Teardown treats this like ErrWorkspaceDirty: the
+	// directory is left alone and the session still terminates, because a
+	// session the user deleted must leave the sidebar whether or not its
+	// worktree could be reclaimed.
+	ErrWorkspaceRepoUnavailable = errors.New("workspace: project repository is unavailable")
 	// ErrWorkspaceStale reports an AO-managed workspace path no longer points
 	// at a registered git worktree. Replacement paths may skip preservation for
 	// this state after path-safety checks, while real preserve failures remain

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1525,6 +1525,12 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 	return m.rollbackSpawn(ctx, id)
 }
 
+// killTeardownBudget bounds the detached teardown Kill runs below. Generous on
+// purpose: every step is expected to finish in well under a second, and the
+// only thing this ceiling protects against is a git or runtime call that never
+// returns at all.
+const killTeardownBudget = 5 * time.Minute
+
 // Kill tears down the runtime and workspace, then records terminal intent with
 // the LCM. A workspace teardown refused by the worktree-remove safety
 // (uncommitted work) is never forced: Kill succeeds with freed=false,
@@ -1536,6 +1542,18 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 // available destroy steps are skipped so it can be cleaned up from the
 // dashboard.
 func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
+	// Teardown deliberately stops riding the caller's context. Kill runs a
+	// sequence (stop the agent, tear the controller down, drop the worktree,
+	// mark the row terminated) where being cancelled partway leaves a session
+	// that is dead in every way except the one the UI reads: the row still says
+	// alive while its agent is gone. That is exactly what a caller-side timeout
+	// (the REST layer caps a request at cfg.RequestTimeout) or a closed browser
+	// tab used to produce. Values still flow through, so request-scoped logging
+	// keeps working; only the cancellation is dropped, under its own ceiling so
+	// a wedged git or runtime call cannot pin the goroutine forever.
+	ctx, cancelTeardown := context.WithTimeout(context.WithoutCancel(ctx), killTeardownBudget)
+	defer cancelTeardown()
+
 	if err := m.beginAgentOperation(ctx, id, agentOperationKill); err != nil {
 		if errors.Is(err, errAgentOperationInProgress) {
 			err = ErrSwitchInProgress

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1525,11 +1525,13 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 	return m.rollbackSpawn(ctx, id)
 }
 
-// killTeardownBudget bounds the detached teardown Kill runs below. Generous on
-// purpose: every step is expected to finish in well under a second, and the
-// only thing this ceiling protects against is a git or runtime call that never
-// returns at all.
-const killTeardownBudget = 5 * time.Minute
+// killTeardownBudget bounds the detached teardown Kill runs below. Sized just
+// past the REST layer's default 60s request cap: long enough that a teardown
+// which was going to finish still finishes coherently after the caller has
+// given up, short enough that a genuinely wedged git or runtime call does not
+// hold this session's agent-operation lock (and the connection chi only
+// cancels, never aborts) for minutes on end.
+const killTeardownBudget = 90 * time.Second
 
 // Kill tears down the runtime and workspace, then records terminal intent with
 // the LCM. A workspace teardown refused by the worktree-remove safety

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1525,6 +1525,17 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 	return m.rollbackSpawn(ctx, id)
 }
 
+// workspacePreserved reports a teardown refusal that must not fail the kill.
+// Both cases leave the directory on disk and neither is the user's problem to
+// resolve before the session can go away: uncommitted work is deliberately
+// never force-removed, and a project whose repository has been deleted can
+// never have its worktree reclaimed by git at all. Erroring instead strands
+// the session in the sidebar forever, which is the one outcome a delete must
+// not produce.
+func workspacePreserved(err error) bool {
+	return errors.Is(err, ports.ErrWorkspaceDirty) || errors.Is(err, ports.ErrWorkspaceRepoUnavailable)
+}
+
 // killTeardownBudget bounds the detached teardown Kill runs below. Sized just
 // past the REST layer's default 60s request cap: long enough that a teardown
 // which was going to finish still finishes coherently after the caller has
@@ -1644,7 +1655,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	if workspaceProject {
 		cleaned, err := m.destroyWorkspaceProjectRows(ctx, workspaceProjectRows)
 		if err != nil {
-			if errors.Is(err, ports.ErrWorkspaceDirty) {
+			if workspacePreserved(err) {
 				if err := m.lcm.MarkTerminated(ctx, id); err != nil {
 					return false, fmt.Errorf("kill %s: %w", id, err)
 				}
@@ -1659,7 +1670,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 		}
 	} else if ws.Path != "" {
 		if err := m.workspace.Destroy(ctx, ws); err != nil {
-			if errors.Is(err, ports.ErrWorkspaceDirty) {
+			if workspacePreserved(err) {
 				if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
 					m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
 				}
@@ -3451,7 +3462,7 @@ func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws p
 		return "workspace teardown failed"
 	} else if ok {
 		if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
-			if !errors.Is(err, ports.ErrWorkspaceDirty) {
+			if !workspacePreserved(err) {
 				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
 			}
 			return cleanupSkipReason(err)
@@ -3460,7 +3471,7 @@ func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws p
 		return ""
 	}
 	if err := m.workspace.Destroy(ctx, ws); err != nil {
-		if !errors.Is(err, ports.ErrWorkspaceDirty) {
+		if !workspacePreserved(err) {
 			// The public reason stays a fixed string (the raw error carries
 			// internal filesystem paths); the full cause lands here.
 			m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
@@ -3478,6 +3489,9 @@ func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws p
 func cleanupSkipReason(err error) string {
 	if errors.Is(err, ports.ErrWorkspaceDirty) {
 		return "workspace has uncommitted changes"
+	}
+	if errors.Is(err, ports.ErrWorkspaceRepoUnavailable) {
+		return "project repository is missing; remove worktree manually"
 	}
 	if errors.Is(err, ErrProjectNotResolvable) {
 		return "project is archived or unregistered — remove worktree manually"

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2953,6 +2953,27 @@ func TestKill_DirtyWorkspacePreservesAndTerminates(t *testing.T) {
 	}
 }
 
+// A project directory the user deleted leaves git unable to reclaim the
+// session's worktree, and failing the kill for that stranded the session in
+// the sidebar permanently: every retry answered 500 and the row never left.
+// The session must still terminate, with the worktree preserved on disk.
+func TestKill_MissingProjectRepoPreservesWorkspaceAndTerminates(t *testing.T) {
+	m, st, _, ws := newManager()
+	ws.destroyErr = fmt.Errorf("gitworktree: repository %q is no longer on disk: %w", "/gone", ports.ErrWorkspaceRepoUnavailable)
+	st.sessions["mer-1"] = mkLive("mer-1")
+
+	freed, err := m.Kill(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("kill err = %v, want the session to terminate anyway", err)
+	}
+	if freed {
+		t.Fatal("freed = true, want false: the worktree was left on disk")
+	}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session must be marked terminated so it leaves the sidebar")
+	}
+}
+
 func TestKill_DeletesStaleRestoreMarker(t *testing.T) {
 	m, st, _, _ := newManager()
 	st.sessions["mer-1"] = mkLive("mer-1")

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -787,11 +787,14 @@ type fakeWorkspace struct {
 	createErr  error
 	destroyErr error
 	destroyed  int
-	fetchErr   error
-	fetches    []fetchDefaultBranchCall
-	resolves   []resolveDefaultBranchCall
-	resolved   map[string]ports.WorkspaceDefaultBranch
-	fetchFunc  func(context.Context, string, ports.WorkspaceDefaultBranch) error
+	// destroyCtxErr records ctx.Err() as seen by Destroy, so a test can prove
+	// teardown does not inherit a caller's cancellation.
+	destroyCtxErr error
+	fetchErr      error
+	fetches       []fetchDefaultBranchCall
+	resolves      []resolveDefaultBranchCall
+	resolved      map[string]ports.WorkspaceDefaultBranch
+	fetchFunc     func(context.Context, string, ports.WorkspaceDefaultBranch) error
 	// createRepoPath, when set, is returned as the RepoPath of a single-repo
 	// Create so tests can assert it survives the spawn->teardown metadata round
 	// trip (production Create resolves this path; the zero default keeps every
@@ -934,8 +937,9 @@ func (w *fakeWorkspace) CreateWorkspaceProject(_ context.Context, cfg ports.Work
 	}
 	return out, nil
 }
-func (w *fakeWorkspace) Destroy(_ context.Context, info ports.WorkspaceInfo) error {
+func (w *fakeWorkspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error {
 	w.lastDestroyInfo = info
+	w.destroyCtxErr = ctx.Err()
 	if info.RepoPath != "" {
 		entry := "Destroy:" + fakeWorkspaceRepoName(info)
 		w.calls = append(w.calls, entry)
@@ -2634,6 +2638,33 @@ func TestKill_TearsDownRuntimeAndWorkspace(t *testing.T) {
 		t.Fatalf("reviewer terminate bodies = %v", reviewer.bodies)
 	}
 	requireNoPromptDir(t, dataDir, "mer-1")
+}
+
+// A caller that gives up must not take the teardown down with it. The REST
+// layer caps a request at cfg.RequestTimeout, and a session whose worktree
+// carries a large ignored tree used to run past that: the request context was
+// cancelled mid-Kill, so the agent was already stopped while the row still read
+// as alive, and the caller got a 500 for a session that was half gone.
+func TestKill_CompletesTeardownAfterCallerContextIsCancelled(t *testing.T) {
+	m, st, rt, ws := newManager()
+	st.sessions["mer-1"] = mkLive("mer-1")
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	freed, err := m.Kill(cancelled, "mer-1")
+	if err != nil || !freed {
+		t.Fatalf("freed=%v err=%v, want a completed teardown", freed, err)
+	}
+	if ws.destroyCtxErr != nil {
+		t.Fatalf("workspace teardown saw ctx.Err() = %v, want a live context", ws.destroyCtxErr)
+	}
+	if rt.destroyed != 1 || ws.destroyed != 1 {
+		t.Fatalf("runtime=%d workspace=%d, want both torn down", rt.destroyed, ws.destroyed)
+	}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session row must be marked terminated")
+	}
 }
 
 func TestKill_NativeTerminationFailurePreservesRuntimeAndWorkspace(t *testing.T) {

--- a/frontend/src/renderer/hooks/useTerminateSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminateSession.test.tsx
@@ -1,0 +1,121 @@
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
+
+const { postMock } = vi.hoisted(() => ({ postMock: vi.fn() }));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { POST: postMock },
+	apiErrorMessage: () => "request failed",
+}));
+
+import { useTerminateSession } from "./useTerminateSession";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+
+const session = {
+	activity: { state: "active", lastActivityAt: "2026-06-10T00:00:00Z" },
+	branch: "ao/sess-1",
+	id: "sess-1",
+	kanbanColumn: "building",
+	kind: "worker",
+	provider: "codex",
+	prs: [],
+	status: "working",
+	terminalHandleId: "sess-1-terminal",
+	title: "do the thing",
+	updatedAt: "2026-06-10T00:00:00Z",
+	workspaceId: "proj-1",
+	workspaceName: "my-app",
+} satisfies WorkspaceSession;
+
+const workspaces: WorkspaceSummary[] = [
+	{ id: "proj-1", kind: "single_repo", name: "my-app", path: "/repos/my-app", sessions: [session] },
+];
+
+function wrapper(queryClient: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+	};
+}
+
+function newQueryClient() {
+	const queryClient = new QueryClient({
+		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+	});
+	queryClient.setQueryData(workspaceQueryKey, workspaces);
+	return queryClient;
+}
+
+beforeEach(() => {
+	postMock.mockReset();
+});
+
+describe("useTerminateSession", () => {
+	// The delete control is disabled while the mutation is pending, and a
+	// mutation stays pending until its onSuccess settles. Waiting on the
+	// workspace refetch there kept the spinner up for an extra round trip after
+	// the daemon had already finished the kill.
+	it("settles without waiting for the workspace refetch", async () => {
+		postMock.mockResolvedValue({ data: { ok: true }, error: undefined, response: { status: 200 } });
+		const queryClient = newQueryClient();
+		let refetchResolved = false;
+		// An observer on the workspace query, as the real board always has: it is
+		// what makes the post-kill invalidation actually refetch.
+		const { result } = renderHook(
+			() => ({
+				terminate: useTerminateSession(),
+				workspaces: useQuery({
+					queryKey: workspaceQueryKey,
+					queryFn: async () => {
+						await new Promise((resolve) => setTimeout(resolve, 100));
+						refetchResolved = true;
+						return workspaces;
+					},
+					initialData: workspaces,
+					staleTime: Number.POSITIVE_INFINITY,
+				}),
+			}),
+			{ wrapper: wrapper(queryClient) },
+		);
+
+		result.current.terminate.mutate(session);
+
+		// isSuccess flips only once onSuccess has settled, so a refetch that is
+		// still in flight here is one the delete control never waited on.
+		await waitFor(() => expect(result.current.terminate.isSuccess).toBe(true));
+		expect(refetchResolved).toBe(false);
+		// The refresh is still requested, just not blocking.
+		await waitFor(() => expect(refetchResolved).toBe(true));
+	});
+
+	it("marks the killed session terminated in the cached board", async () => {
+		postMock.mockResolvedValue({ data: { ok: true }, error: undefined, response: { status: 200 } });
+		const queryClient = newQueryClient();
+		const { result } = renderHook(() => useTerminateSession(), { wrapper: wrapper(queryClient) });
+
+		result.current.mutate(session);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		const cached = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+		expect(cached?.[0]?.sessions[0]).toMatchObject({
+			id: "sess-1",
+			isTerminated: true,
+			kanbanColumn: "archive",
+			status: "terminated",
+		});
+	});
+
+	it("leaves the board untouched when the kill fails", async () => {
+		postMock.mockResolvedValue({ data: undefined, error: { message: "nope" }, response: { status: 500 } });
+		const queryClient = newQueryClient();
+		const { result } = renderHook(() => useTerminateSession(), { wrapper: wrapper(queryClient) });
+
+		result.current.mutate(session);
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		const cached = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryKey);
+		expect(cached?.[0]?.sessions[0]?.isTerminated).toBeUndefined();
+	});
+});

--- a/frontend/src/renderer/hooks/useTerminateSession.ts
+++ b/frontend/src/renderer/hooks/useTerminateSession.ts
@@ -1,5 +1,5 @@
 import { type QueryClient, useMutation, useMutationState, useQueryClient } from "@tanstack/react-query";
-import type { WorkspaceSession } from "../types/workspace";
+import { toKanbanColumn, type WorkspaceSession, type WorkspaceSummary } from "../types/workspace";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { captureRendererEvent } from "../lib/telemetry";
@@ -9,6 +9,21 @@ type TerminateSessionOptions = {
 };
 
 export const terminateSessionMutationKey = ["terminate-session"] as const;
+
+// A killed session keeps its row and flips to terminated, which is exactly what
+// the next workspace fetch would report. Applying it locally lets the board
+// settle on the click rather than on the refetch.
+function markTerminated(sessionId: string) {
+	return (session: WorkspaceSession): WorkspaceSession =>
+		session.id === sessionId
+			? {
+				...session,
+				isTerminated: true,
+				status: "terminated",
+				kanbanColumn: toKanbanColumn(undefined, "terminated"),
+			}
+			: session;
+}
 
 type TerminateSessionMutationState = {
 	error: unknown;
@@ -65,9 +80,20 @@ export function useTerminateSession(options: TerminateSessionOptions = {}) {
 				throw new Error(apiErrorMessage(error, fallback));
 			}
 		},
-		onSuccess: async (_data, session) => {
+		onSuccess: (_data, session) => {
 			void captureRendererEvent("ao.renderer.session_kill_succeeded", { project_id: session.workspaceId });
-			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			// Write the outcome into the cached board first, then refresh in the
+			// background. A mutation stays `pending` until its onSuccess settles,
+			// so awaiting the refetch here kept the row's spinner up for a whole
+			// extra round trip after the daemon had already finished the kill.
+			queryClient.setQueryData<WorkspaceSummary[]>(workspaceQueryKey, (workspaces) =>
+				workspaces?.map((workspace) =>
+					workspace.id === session.workspaceId
+						? { ...workspace, sessions: workspace.sessions.map(markTerminated(session.id)) }
+						: workspace,
+				),
+			);
+			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 			options.onSuccess?.(session);
 		},
 		onError: (_error, session) => {


### PR DESCRIPTION
## The bug

Deleting a session could answer `500 Internal server error` and leave the session half dead: the agent stopped, the worktree half gone, and the row still reading as alive in the sidebar.

Reproduced against a local daemon with a session worktree holding 60,000 ignored files (a `node_modules`-sized tree):

```
POST /api/v1/sessions/repo-4/kill
{"error":"internal","code":"INTERNAL_ERROR","message":"Internal server error"}   HTTP 500
daemon: kill repo-4: workspace: gitworktree: worktree prune: context deadline exceeded
```

Two causes, both about teardown running inside the HTTP request:

1. `git worktree remove` unlinks the session's whole directory, and a worker checkout is mostly ignored build output (`node_modules`, `target/`, `.venv`, caches). Measured at roughly 2s per 60,000 files, so a real session took tens of seconds and a large one ran past the daemon's 60s REST cap.
2. `Kill` used the request context. When the cap hit, the sequence was cancelled partway, so the session was already dead everywhere except the row the UI reads.

## The fix

**`gitworktree`** gains a discard path (`discard.go`). `Destroy` applies the checks git would have applied (registered, unlocked, clean), moves the directory into `<data>/worktrees/.discarded` with one rename, prunes the registration, and unlinks in the background. Every inconclusive probe falls back to the existing git-driven path, so git stays the authority on refusals and their messages. A refusal found after the move restores the directory, so a dirty worktree is preserved exactly as before. `ForceDestroy` and `forceDestroyPath` take the same path, which also removes the stall from daemon shutdown and orchestrator replacement. Leftovers from a daemon that died mid-unlink are swept at construction.

**`Kill`** runs its teardown on `context.WithoutCancel` under a 90s ceiling: past the 60s REST cap so a teardown that was going to finish still finishes coherently, short enough that a wedged call cannot hold the session's agent-operation lock for minutes.

**Renderer**: the kill mutation awaited a full workspace refetch inside `onSuccess`, and a mutation stays pending until `onSuccess` settles, so the delete control kept spinning for an extra round trip after the daemon was done. It now writes the terminated session into the cached board and refreshes in the background.

## What this does not change

Deleting still archives the session and removes the worktree directory. The session row, its branch and every commit are kept, and restore rebuilds the worktree from the branch. Uncommitted work still blocks removal: the worktree stays on disk and the session archives with `freed: false`. Gitignored files are still not preserved, which is what `git worktree remove` already did.

## Verification

Live, against a daemon on a fresh data dir with the default 60s timeout:

| case | result |
|---|---|
| clean worktree, 60,006 files / 234 MB | `200` in **0.635s** (was `500` at the cap), `freed: true`, path gone on return |
| disk reclaimed | `.discarded` empty within seconds, data dir back to 4.8 MB |
| session after delete | `terminated`, column `archive`, branch retained |
| commit made in the session | `6902ecf agent work` still on `ao/repo-1/root` |
| restore from archive | worktree rebuilt, `kept.txt` and the commit back |
| worktree with uncommitted work | delete refused, `wip.txt` intact, session still archived |

Checks: `go build`, `go vet`, `gofmt` clean; `golangci-lint` 0 issues; `-race` clean on the workspace adapters and the kill path (this change adds a goroutine); frontend `typecheck` clean; renderer session suites pass. Four `TestSpawn_*` failures in `session_manager` are environmental (no tmux on the test machine) and fail identically on the base commit.

New regression tests, each confirmed to fail without its fix: the discard fast path and its dirty refusal, the post-prune rollback hazard, `ForceDestroy` taking the fast path (asserted on the git calls, not just the end state, since the end state looks identical either way), the discard sweep, `Kill` completing after caller cancellation, and the renderer mutation settling without the refetch.


---

## Second cause, added after testing against real data

A session can also fail to delete **permanently**, which is what the reporter was actually hitting: one session had been sitting in the sidebar for two hours with `Internal server error (INTERNAL_ERROR)` pinned to its trash icon.

Teardown runs every git command as `git -C <project repo> ...`. When the project folder is deleted from disk (here `/Users/psudokit/zero_to_one`, still registered, 14 live sessions), each one exits 128 with `cannot change to ...: No such file or directory`, so `Kill` fails, the row never terminates, and retrying can never help. Reproduced on a live daemon by deleting a registered project's directory and then deleting one of its sessions:

```
kill repo-3: workspace: gitworktree: worktree prune:
  git -C /tmp/ao58f/repo worktree prune: exit status 128:
  fatal: cannot change to '/tmp/ao58f/repo': No such file or directory
```

Teardown now reports an unreachable repository as `ports.ErrWorkspaceRepoUnavailable` and treats it the way an uncommitted worktree is already treated: the directory is left alone, the session terminates, kill answers `freed=false`. Deleting a session has to let it leave the sidebar whether or not the worktree can be reclaimed. `ao session cleanup` reports it with an actionable reason instead of the generic teardown failure.

## Verified in the desktop app

Ran this branch's Electron build against an isolated data dir seeded with both failure shapes, including sessions in two real repos:

| session | condition | result |
|---|---|---|
| `alpha-3` | project folder deleted mid-flight | `200`, archived, worktree preserved |
| `8x-bookmark-2` | 238 MB / 60,350 files in a real repo | `200`, archived, worktree removed |
| `beta-4` / `armor-iq-3` | uncommitted file present | archived, file intact |

One number worth stating plainly: with a live agent still running, delete takes ~5.6s end to end. None of that is the worktree any more; it is the tmux reap grace waiting for the agent's child processes to exit after SIGTERM. That path is untouched here and is a candidate for the same treatment.
