### PR TITLE
fix(desktop): bound stalled update downloads

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -88,9 +88,16 @@ async function importAutoUpdater(
   const BrowserWindow = {
     getAllWindows: vi.fn(() => [fakeWindow]),
   };
+  class CancellationToken {
+    cancelled = false;
+
+    cancel(): void {
+      this.cancelled = true;
+    }
+  }
   const statusMessages = () => sent.filter((m) => m.channel === "updates:status");
   const telemetryMessages = () => sent.filter((m) => m.channel === "updates:telemetry");
-  vi.doMock("electron-updater", () => ({ autoUpdater }));
+  vi.doMock("electron-updater", () => ({ autoUpdater, CancellationToken }));
   vi.doMock("electron", () => ({
     app: {
       isPackaged: options.isPackaged ?? true,
@@ -576,7 +583,10 @@ describe("startAutoUpdates", () => {
       updaterEvents.get("checking-for-update")?.();
       updaterEvents.get("update-available")?.({ version: "2.1.0" });
       updaterEvents.get("download-progress")?.({ percent: 42 });
-      return Promise.resolve({ downloadPromise: lateDownload.promise });
+      return Promise.resolve({
+        downloadPromise: lateDownload.promise,
+        cancellationToken: { cancel: vi.fn() },
+      });
     });
     const startPromise = module.startAutoUpdates(stateDir);
     await flushMicrotasks();
@@ -795,7 +805,10 @@ describe("startAutoUpdates", () => {
 
     autoUpdater.checkForUpdates.mockImplementationOnce(() => {
       updaterEvents.get("checking-for-update")?.();
-      return Promise.resolve({ downloadPromise: automaticDownload.promise });
+      return Promise.resolve({
+        downloadPromise: automaticDownload.promise,
+        cancellationToken: { cancel: vi.fn() },
+      });
     });
     const startPromise = module.startAutoUpdates(stateDir);
     await Promise.resolve();
@@ -841,6 +854,7 @@ describe("startAutoUpdates", () => {
     const err = new Error("download failed");
     autoUpdater.checkForUpdates.mockResolvedValueOnce({
       downloadPromise: lateDownload.promise,
+      cancellationToken: { cancel: vi.fn() },
     });
 
     const startPromise = module.startAutoUpdates(stateDir);
@@ -897,6 +911,129 @@ describe("startAutoUpdates", () => {
       state: "error",
       message: "manual download failed",
     });
+  });
+
+  it("cancels and reports a manual download after bounded progress inactivity", async () => {
+    vi.useFakeTimers();
+    const download = deferred<string[]>();
+    const { module, autoUpdater, updaterEvents, telemetryMessages } =
+      await importAutoUpdater();
+    autoUpdater.downloadUpdate.mockReturnValueOnce(download.promise);
+
+    const downloadPromise = module.downloadUpdateNow("manual-download");
+    await flushMicrotasks();
+    updaterEvents.get("download-progress")?.({
+      percent: 2.25,
+      transferred: 3_798_105,
+      total: 168_658_927,
+    });
+
+    await vi.advanceTimersByTimeAsync(module.DOWNLOAD_STALL_TIMEOUT_MS);
+    await downloadPromise;
+
+    const cancellationToken = autoUpdater.downloadUpdate.mock.calls[0]?.[0];
+    expect(cancellationToken?.cancelled).toBe(true);
+    expect(module.getUpdateStatus()).toEqual({
+      state: "error",
+      message: "Update download stalled. Check your connection and try again.",
+      requestId: "manual-download",
+    });
+    updaterEvents.get("download-progress")?.({ percent: 90, transferred: 90, total: 100 });
+    updaterEvents.get("update-downloaded")?.({ version: "2.0.0" });
+    expect(module.getUpdateStatus()).toEqual({
+      state: "error",
+      message: "Update download stalled. Check your connection and try again.",
+      requestId: "manual-download",
+    });
+    expect(telemetryMessages().map((message) => message.payload)).toContainEqual({
+      event: "ao.renderer.update_failed",
+      phase: "download",
+      trigger: "manual",
+      error_category: "network",
+      transferred_bytes: 3_798_105,
+      total_bytes: 168_658_927,
+      stalled_ms: module.DOWNLOAD_STALL_TIMEOUT_MS,
+    });
+  });
+
+  it("resets the watchdog on real progress and lets the download complete", async () => {
+    vi.useFakeTimers();
+    const download = deferred<string[]>();
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+    autoUpdater.downloadUpdate.mockReturnValueOnce(download.promise);
+
+    const downloadPromise = module.downloadUpdateNow("manual-download");
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(module.DOWNLOAD_STALL_TIMEOUT_MS - 1);
+    updaterEvents.get("download-progress")?.({ percent: 40, transferred: 40, total: 100 });
+    await vi.advanceTimersByTimeAsync(module.DOWNLOAD_STALL_TIMEOUT_MS - 1);
+
+    expect(module.getUpdateStatus()).toEqual({
+      state: "downloading",
+      version: undefined,
+      percent: 40,
+      requestId: "manual-download",
+    });
+    download.resolve([]);
+    updaterEvents.get("update-downloaded")?.({ version: "2.0.0" });
+    await downloadPromise;
+    expect(module.getUpdateStatus()).toEqual(
+      expect.objectContaining({ state: "downloaded", version: "2.0.0" }),
+    );
+  });
+
+  it("cancels a stalled automatic download and leaves a retryable terminal status", async () => {
+    vi.useFakeTimers();
+    const download = deferred<string[]>();
+    const cancellationToken = { cancel: vi.fn() };
+    const { module, autoUpdater, updaterEvents, telemetryMessages } = await importAutoUpdater();
+    autoUpdater.checkForUpdates.mockImplementationOnce(() => {
+      updaterEvents.get("update-available")?.({ version: "2.0.0" });
+      updaterEvents.get("download-progress")?.({ percent: 8, transferred: 8, total: 100 });
+      return Promise.resolve({ downloadPromise: download.promise, cancellationToken });
+    });
+
+    const startPromise = module.startAutoUpdates(stateDir);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(module.DOWNLOAD_STALL_TIMEOUT_MS);
+    await startPromise;
+
+    expect(cancellationToken.cancel).toHaveBeenCalledOnce();
+    expect(module.getUpdateStatus()).toEqual({
+      state: "error",
+      version: "2.0.0",
+      message: "Update download stalled. Check your connection and try again.",
+      checkedAt: expect.any(Number),
+    });
+    expect(telemetryMessages().map((message) => message.payload)).toContainEqual({
+      event: "ao.renderer.update_failed",
+      phase: "download",
+      trigger: "automatic",
+      error_category: "network",
+      to_version: "2.0.0",
+      transferred_bytes: 8,
+      total_bytes: 100,
+      stalled_ms: module.DOWNLOAD_STALL_TIMEOUT_MS,
+    });
+  });
+
+  it("starts a queued retry only after the stalled download releases ownership", async () => {
+    vi.useFakeTimers();
+    const first = deferred<string[]>();
+    const { module, autoUpdater } = await importAutoUpdater();
+    autoUpdater.downloadUpdate
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce([]);
+
+    const firstAttempt = module.downloadUpdateNow("first");
+    await flushMicrotasks();
+    const retry = module.downloadUpdateNow("retry");
+    await flushMicrotasks();
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(module.DOWNLOAD_STALL_TIMEOUT_MS);
+    await Promise.all([firstAttempt, retry]);
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(2);
   });
 
   it("keeps manual updater error events visible to the renderer", async () => {

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,4 +1,4 @@
-import { autoUpdater } from "electron-updater";
+import { autoUpdater, CancellationToken, type ProgressInfo } from "electron-updater";
 import { app, BrowserWindow, dialog } from "electron";
 import { accessSync, constants as fsConstants, existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -95,6 +95,11 @@ let escalationTimer: ReturnType<typeof setInterval> | undefined;
 let escalationStateDir: string | undefined;
 const STABLE_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 const NIGHTLY_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+// Long enough to tolerate a temporarily slow release CDN, but bounded so a
+// connection that has stopped delivering bytes cannot own the updater queue
+// forever. Every real progress event restarts this window.
+export const DOWNLOAD_STALL_TIMEOUT_MS = 2 * 60 * 1000;
+const DOWNLOAD_STALL_MESSAGE = "Update download stalled. Check your connection and try again.";
 let automaticUpdateTimer: ReturnType<typeof setInterval> | undefined;
 let automaticUpdateTimerIntervalMs: number | undefined;
 type UpdaterOperation =
@@ -138,6 +143,41 @@ let pendingUpdateVersion: string | undefined;
 // check the selected channel at launch regardless of whether automatic
 // downloading is enabled.
 let lastCheckedAtMs: number | undefined;
+type DownloadCancellation = Pick<CancellationToken, "cancel">;
+type DownloadProgressSnapshot = {
+  observedAtMs: number;
+  percent?: number;
+  transferredBytes?: number;
+  totalBytes?: number;
+};
+type ActiveDownloadObservation = {
+  cancellationToken: DownloadCancellation;
+  lastProgressAtMs: number;
+  percent?: number;
+  transferredBytes?: number;
+  totalBytes?: number;
+  timer?: ReturnType<typeof setTimeout>;
+  reject: (error: DownloadStalledError) => void;
+};
+let activeDownloadObservation: ActiveDownloadObservation | undefined;
+let pendingDownloadProgress: DownloadProgressSnapshot | undefined;
+// A cancelled provider can emit progress/downloaded after the timeout callback
+// has won the race. Ignore those stale events until a new serialized download
+// explicitly takes ownership.
+let ignoreDownloadEventsUntilNextDownload = false;
+
+class DownloadStalledError extends Error {
+  readonly version = pendingUpdateVersion;
+
+  constructor(
+    readonly transferredBytes: number | undefined,
+    readonly totalBytes: number | undefined,
+    readonly stalledMs: number,
+  ) {
+    super(DOWNLOAD_STALL_MESSAGE);
+    this.name = "DownloadStalledError";
+  }
+}
 
 // emitUpdateOutcome pushes an update outcome to renderers on a channel separate
 // from "updates:status", so suppressing a status for UI reasons (as the
@@ -158,6 +198,114 @@ function emitUpdateFailure(err: unknown): void {
   emitUpdateOutcome(
     updateFailureOutcome(message, activeUpdaterPhase, activeUpdateTrigger(), pendingUpdateVersion),
   );
+}
+
+function stalledDownloadStatus(error: DownloadStalledError): UpdateStatus {
+  return {
+    state: "error",
+    ...(error.version ? { version: error.version } : {}),
+    message: DOWNLOAD_STALL_MESSAGE,
+  };
+}
+
+function armDownloadWatchdog(
+  observation: ActiveDownloadObservation,
+  observedAtMs = Date.now(),
+): void {
+  if (observation.timer !== undefined) clearTimeout(observation.timer);
+  observation.lastProgressAtMs = observedAtMs;
+  observation.timer = setTimeout(() => {
+    if (activeDownloadObservation !== observation) return;
+    const stalledMs = Math.max(0, Date.now() - observation.lastProgressAtMs);
+    const error = new DownloadStalledError(
+      observation.transferredBytes,
+      observation.totalBytes,
+      stalledMs,
+    );
+    ignoreDownloadEventsUntilNextDownload = true;
+    emitUpdateOutcome({
+      event: "ao.renderer.update_failed",
+      phase: "download",
+      trigger: activeUpdateTrigger(),
+      error_category: "network",
+      ...(error.version ? { to_version: error.version } : {}),
+      ...(error.transferredBytes === undefined ? {} : { transferred_bytes: error.transferredBytes }),
+      ...(error.totalBytes === undefined ? {} : { total_bytes: error.totalBytes }),
+      stalled_ms: error.stalledMs,
+    });
+    // electron-updater owns the socket and cache file. Cancelling its token is
+    // the only safe way to release both; starting a second provider download
+    // while this one is still alive would corrupt request ownership.
+    try {
+      observation.cancellationToken.cancel();
+    } finally {
+      observation.reject(error);
+    }
+  }, Math.max(0, DOWNLOAD_STALL_TIMEOUT_MS - (Date.now() - observedAtMs)));
+  observation.timer.unref?.();
+}
+
+async function observeDownload<T>(
+  start: () => Promise<T>,
+  cancellationToken: DownloadCancellation,
+): Promise<T> {
+  let rejectStalled!: (error: DownloadStalledError) => void;
+  const stalled = new Promise<T>((_resolve, reject) => {
+    rejectStalled = reject;
+  });
+  const observation: ActiveDownloadObservation = {
+    cancellationToken,
+    lastProgressAtMs: pendingDownloadProgress?.observedAtMs ?? Date.now(),
+    percent: pendingDownloadProgress?.percent,
+    transferredBytes: pendingDownloadProgress?.transferredBytes,
+    totalBytes: pendingDownloadProgress?.totalBytes,
+    reject: rejectStalled,
+  };
+  ignoreDownloadEventsUntilNextDownload = false;
+  activeDownloadObservation = observation;
+  armDownloadWatchdog(observation, observation.lastProgressAtMs);
+  try {
+    return await Promise.race([Promise.resolve().then(start), stalled]);
+  } finally {
+    if (activeDownloadObservation === observation) {
+      if (observation.timer !== undefined) clearTimeout(observation.timer);
+      activeDownloadObservation = undefined;
+      pendingDownloadProgress = undefined;
+    }
+  }
+}
+
+function recordDownloadProgress(progress: ProgressInfo | undefined): boolean {
+  if (ignoreDownloadEventsUntilNextDownload) return false;
+  pendingDownloadProgress = {
+    observedAtMs: Date.now(),
+    percent: progress?.percent,
+    transferredBytes: progress?.transferred,
+    totalBytes: progress?.total,
+  };
+  const observation = activeDownloadObservation;
+  if (observation !== undefined) {
+    const transferred = progress?.transferred;
+    const percent = progress?.percent;
+    const advanced =
+      (transferred !== undefined &&
+        (observation.transferredBytes === undefined || transferred > observation.transferredBytes)) ||
+      (percent !== undefined &&
+        (observation.percent === undefined || percent > observation.percent));
+    if (transferred !== undefined) {
+      observation.transferredBytes = Math.max(observation.transferredBytes ?? 0, transferred);
+    }
+    if (progress?.total !== undefined) observation.totalBytes = progress.total;
+    if (percent !== undefined) observation.percent = Math.max(observation.percent ?? 0, percent);
+    // Repeated events that report the same byte/percentage position do not
+    // prove the socket is moving and therefore cannot postpone the deadline.
+    if (advanced) armDownloadWatchdog(observation);
+  }
+  return true;
+}
+
+function isDownloadCancellation(error: unknown): boolean {
+  return error instanceof Error && error.name === "CancellationError";
 }
 
 // broadcast pushes the latest update status to every renderer window so the
@@ -464,7 +612,12 @@ async function runSerializedUpdaterOperation(
     activeUpdaterOperation = operation;
     activeUpdaterRequestId = requestId;
     activeUpdaterPhase = operation === "manual-download" ? "download" : "check";
-    pendingUpdateVersion = undefined;
+    // A manual download consumes the update found by the preceding check, so
+    // retain its version for progress, stall status, and telemetry.
+    if (operation !== "manual-download") pendingUpdateVersion = undefined;
+    if (operation === "manual-download" || operation === "automatic-check") {
+      pendingDownloadProgress = undefined;
+    }
     if (operation === "automatic-check") {
       automaticCheckNetFailureCounted = false;
       automaticCheckFailureCounted = false;
@@ -657,6 +810,7 @@ function wireUpdaterEvents(): void {
       broadcastUpdaterStatus(stagedDownloadedStatus());
   });
   autoUpdater.on("download-progress", (p) => {
+    if (!recordDownloadProgress(p)) return;
     // Any progress proves the network stack is healthy and the check
     // succeeded, so a later error is a download failure even when the
     // operation began life as a check.
@@ -671,6 +825,7 @@ function wireUpdaterEvents(): void {
     });
   });
   autoUpdater.on("update-downloaded", (info) => {
+    if (ignoreDownloadEventsUntilNextDownload) return;
     emitUpdateOutcome({
       event: "ao.renderer.update_downloaded",
       phase: "download",
@@ -697,6 +852,7 @@ function wireUpdaterEvents(): void {
     escalationTimer.unref?.();
   });
   autoUpdater.on("error", (err) => {
+    if (ignoreDownloadEventsUntilNextDownload && isDownloadCancellation(err)) return;
     // Never crash on update failure (offline, unsigned macOS, etc.).
     // A one-off automatic failure restores the previous status so the UI does
     // not flash an error the user never asked for. That suppression is a UI
@@ -797,9 +953,28 @@ async function runAutomaticUpdateCheck(
       try {
         const result = await autoUpdater.checkForUpdates();
         if (settings.enabled && result?.downloadPromise) {
-          await result.downloadPromise;
+          if (!result.cancellationToken) {
+            throw new Error("Updater download did not provide a cancellation token");
+          }
+          try {
+            await observeDownload(
+              () => result.downloadPromise as Promise<Array<string>>,
+              result.cancellationToken,
+            );
+          } catch (err) {
+            if (err instanceof DownloadStalledError) {
+              // A stall is user-actionable even on the automatic path. Do not
+              // restore the pre-check status and recreate the indefinite
+              // progress UI that the watchdog just terminated.
+              automaticCheckPreviousStatus = undefined;
+              broadcast(stalledDownloadStatus(err));
+              throw err;
+            }
+            throw err;
+          }
         }
       } catch (err) {
+        if (err instanceof DownloadStalledError) throw err;
         // electron-updater normally also emits "error" (handled in
         // wireUpdaterEvents); a reject-only failure must still restore the
         // pre-check status so the renderer is neither stuck on "checking" nor
@@ -1050,12 +1225,21 @@ export async function downloadUpdateNow(requestId?: string): Promise<void> {
     await runSerializedUpdaterOperation(
       "manual-download",
       async () => {
-        await autoUpdater.downloadUpdate();
+        const cancellationToken = new CancellationToken();
+        await observeDownload(
+          () => autoUpdater.downloadUpdate(cancellationToken),
+          cancellationToken,
+        );
       },
       requestId,
     );
   } catch (err) {
-    if (isManifest404Error(err)) {
+    if (err instanceof DownloadStalledError) {
+      broadcast({
+        ...stalledDownloadStatus(err),
+        requestId,
+      });
+    } else if (isManifest404Error(err)) {
       console.error("update download failed:", err);
       broadcast({
         state: "error",

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -86,6 +86,9 @@ describe("telemetry sanitizers", () => {
 			error_category: "network",
 			phase: "download",
 			trigger: "automatic",
+			transferred_bytes: 3_798_105,
+			total_bytes: 168_658_927,
+			stalled_ms: 120_000,
 			// Must be dropped: raw updater text can carry feed URLs and local paths.
 			message: "EACCES /Users/someone/Library/Caches/ao-updater",
 			stack: "at Object.<anonymous>",
@@ -95,11 +98,20 @@ describe("telemetry sanitizers", () => {
 			error_category: "network",
 			phase: "download",
 			trigger: "automatic",
+			transferred_bytes: 3_798_105,
+			total_bytes: 168_658_927,
+			stalled_ms: 120_000,
 		});
 
 		// An unrecognized phase is not passed through as-is.
 		const bogus = await sanitizeRendererProperties("ao.renderer.update_failed", { phase: "sideload" });
 		expect(bogus.phase).toBeUndefined();
+		const invalidMetrics = await sanitizeRendererProperties("ao.renderer.update_failed", {
+			transferred_bytes: -1,
+			total_bytes: Number.NaN,
+			stalled_ms: "120000",
+		});
+		expect(invalidMetrics).toEqual({});
 	});
 
 	it("reports a support submission with only the destination and outcome", async () => {

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -565,6 +565,10 @@ export async function sanitizeRendererProperties(
 			if (typeof properties?.error_category === "string") safe.error_category = properties.error_category;
 			if (properties?.phase === "check" || properties?.phase === "download") safe.phase = properties.phase;
 			if (properties?.trigger === "automatic" || properties?.trigger === "manual") safe.trigger = properties.trigger;
+			for (const key of ["transferred_bytes", "total_bytes", "stalled_ms"] as const) {
+				const value = properties?.[key];
+				if (typeof value === "number" && Number.isFinite(value) && value >= 0) safe[key] = value;
+			}
 			break;
 		case "ao.renderer.mobile_connect_opened":
 			// Whether the bridge was already on when the modal opened separates

--- a/frontend/src/renderer/lib/update-telemetry.ts
+++ b/frontend/src/renderer/lib/update-telemetry.ts
@@ -22,6 +22,9 @@ export function startUpdateTelemetry(): () => void {
 			trigger: outcome.trigger,
 			error_category: outcome.error_category,
 			to_version: outcome.to_version,
+			transferred_bytes: outcome.transferred_bytes,
+			total_bytes: outcome.total_bytes,
+			stalled_ms: outcome.stalled_ms,
 		});
 	});
 	return () => off?.();

--- a/frontend/src/shared/update-telemetry.ts
+++ b/frontend/src/shared/update-telemetry.ts
@@ -41,6 +41,10 @@ export type UpdateOutcome = {
 	trigger: UpdateTrigger;
 	error_category?: UpdateFailureCategory;
 	to_version?: string;
+	/** Byte counts and inactivity duration are emitted only for a bounded download stall. */
+	transferred_bytes?: number;
+	total_bytes?: number;
+	stalled_ms?: number;
 };
 
 /**


### PR DESCRIPTION
Fixes #4461

## Problem

A macOS update download could stop receiving bytes while electron-updater kept its request open. AO retained the last `downloading` percentage indefinitely, kept the updater operation queue occupied, and offered no retryable terminal state.

## Root cause

AO forwarded `download-progress`, `update-downloaded`, and `error` events, but never bounded the time between real byte/percentage advances. Automatic downloads expose a provider-owned cancellation token, and manual downloads can receive one, but neither path used it.

## Fix

- add a two-minute inactivity watchdog shared by automatic and manual downloads
- reset the deadline only when transferred bytes or percentage actually advances
- capture progress emitted before `checkForUpdates()` returns its download promise
- cancel the exact electron-updater token when the deadline expires
- publish a terminal error with existing Check Again recovery in Settings
- preserve serialized request ownership so a queued retry starts only after cancellation releases the first operation
- suppress late progress/downloaded events from the cancelled attempt until a new download owns the stream
- report safe stall telemetry with target version, transferred bytes, total bytes, and inactivity duration

## Safety

- does not start a concurrent replacement download
- does not mutate or delete the updater cache directly
- keeps automatic/manual request ownership intact
- timer is cleared on every success, rejection, or cancellation path and is unref'd
- ordinary updater errors and staged-update behavior remain unchanged
- raw updater errors, URLs, and paths remain excluded from telemetry

## Tests

Passed locally:

- `npm test -- src/main/auto-updater.test.ts -t '^(?!.*(?:shows an actionable dialog instead of installing|shows the dialog when the app bundle|shows the dialog when the enclosing directory|disables install-on-quit)).*$'` (64 passed, 4 host-incompatible macOS-only cases skipped)
- `npm test -- src/shared/update-telemetry.test.ts src/renderer/lib/telemetry.test.ts` (55 passed)
- focused watchdog/telemetry regression run (5 passed)
- `git diff --check`

The four excluded install-location cases fail unchanged on an untouched pre-branch worktree on Windows because they exercise macOS bundle/translocation behavior.

`npm run typecheck` reached only existing workspace dependency-resolution failures in the shared junction (`@electron-forge/plugin-auto-unpack-natives` and product-ui React packages); it reported no changed-file diagnostic. Clean CI is the authoritative complete typecheck.

## Manual validation

No live stalled macOS provider transfer was induced. Coverage is deterministic fake-timer/provider-event verification of the real electron-updater token and event ordering.
