### PR TITLE
fix(installer): fail closed on incomplete macOS signing

### DIFF
--- a/frontend/assets/entitlements.mac.inherit.plist
+++ b/frontend/assets/entitlements.mac.inherit.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/frontend/assets/entitlements.mac.plist
+++ b/frontend/assets/entitlements.mac.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.print</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+</dict>
+</plist>

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -48,6 +48,11 @@ Windows installers follow the same boundary (#4502): the NSIS maker
 when signing credentials are present in the environment, so the public build
 stays unsigned while the conductor signs with its own credentials downstream.
 
+The Forge configuration preserves that unsigned `make` boundary, but rejects
+partial macOS signing/notarization credentials. A direct Forge `publish` on
+macOS additionally requires both credential sets, so the legacy publication
+path cannot emit an unsigned ZIP when it is invoked accidentally.
+
 ## Channels
 
 - **Stable** releases are deliberate production cuts. After all verification

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -9,6 +9,11 @@ import MakerAppImage from "./makers/maker-appimage";
 import { existsSync, readdirSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import {
+	assertMacReleaseCredentials,
+	isForgePublishCommand,
+	macPackagerSecurity,
+} from "./mac-release-security";
 
 // Default GitHub release target (production). Releases land on Untrivial-ai
 // (the org the repo was transferred to in July 2026; AgentWrapper and aoagents
@@ -83,6 +88,17 @@ function parseReleaseRepo(value: string | undefined): { owner: string; name: str
 	return { owner, name };
 }
 
+// The public artifact workflow deliberately runs unsigned; the private release
+// conductor seals those artifacts later. Direct Forge publication, however,
+// must never emit an unsigned macOS update. Validate at config load for an
+// immediate publish failure and again in prePackage for an explicit target.
+assertMacReleaseCredentials(
+	process.env,
+	process.platform,
+	isForgePublishCommand(process.argv),
+);
+const macSecurity = macPackagerSecurity(process.env);
+
 const config: ForgeConfig = {
 	packagerConfig: {
 		asar: true,
@@ -108,20 +124,8 @@ const config: ForgeConfig = {
 		//  - Local: AO_NOTARY_PROFILE, a notarytool keychain profile created with
 		//    `notarytool store-credentials`. See ao-macos-signed-release runbook.
 		// Both are valid NotaryToolCredentials, so no cast is needed.
-		osxSign: process.env.APPLE_SIGNING_IDENTITY
-			? { identity: process.env.APPLE_SIGNING_IDENTITY }
-			: process.env.CSC_LINK
-				? {}
-				: undefined,
-		osxNotarize: process.env.AO_NOTARY_PROFILE
-			? { keychainProfile: process.env.AO_NOTARY_PROFILE }
-			: process.env.APPLE_API_KEY
-				? {
-						appleApiKey: process.env.APPLE_API_KEY,
-						appleApiKeyId: process.env.APPLE_API_KEY_ID!,
-						appleApiIssuer: process.env.APPLE_API_ISSUER!,
-					}
-				: undefined,
+		osxSign: macSecurity.osxSign,
+		osxNotarize: macSecurity.osxNotarize,
 	},
 	hooks: {
 		// electron-forge does not generate app-update.yml (electron-builder does);
@@ -133,6 +137,11 @@ const config: ForgeConfig = {
 		// and macOS reports the app as "damaged". owner/repo are baked from
 		// AO_RELEASE_REPO at build time.
 		prePackage: async (_forgeConfig, platform, arch) => {
+			assertMacReleaseCredentials(
+				process.env,
+				platform as NodeJS.Platform,
+				isForgePublishCommand(process.argv),
+			);
 			await prepareNativeDependencies(platform as NodeJS.Platform, arch);
 			const { owner, name } = parseReleaseRepo(process.env.AO_RELEASE_REPO);
 			const yml = [

--- a/frontend/mac-release-security.test.ts
+++ b/frontend/mac-release-security.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+	assertMacReleaseCredentials,
+	isForgePublishCommand,
+	macPackagerSecurity,
+} from "./mac-release-security";
+
+describe("macOS release credentials", () => {
+	it("allows the intentionally unsigned public make path", () => {
+		expect(() =>
+			assertMacReleaseCredentials({}, "darwin", false),
+		).not.toThrow();
+	});
+
+	it("fails closed when a direct macOS publish has no credentials", () => {
+		expect(() => assertMacReleaseCredentials({}, "darwin", true)).toThrow(
+			/macOS publish requires both signing and notarization credentials/,
+		);
+	});
+
+	it("rejects incomplete App Store Connect credentials", () => {
+		expect(() =>
+			assertMacReleaseCredentials(
+				{ APPLE_API_KEY: "/tmp/AuthKey.p8" },
+				"darwin",
+				false,
+			),
+		).toThrow(
+			/APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER must be set together/,
+		);
+	});
+
+	it("rejects signing without notarization for any macOS artifact", () => {
+		expect(() =>
+			assertMacReleaseCredentials(
+				{ APPLE_SIGNING_IDENTITY: "Developer ID Application" },
+				"darwin",
+				false,
+			),
+		).toThrow(
+			/macOS packaging requires signing and notarization credentials together/,
+		);
+	});
+
+	it("rejects notarization without signing for any macOS artifact", () => {
+		expect(() =>
+			assertMacReleaseCredentials(
+				{ AO_NOTARY_PROFILE: "ao-notary" },
+				"darwin",
+				false,
+			),
+		).toThrow(
+			/macOS packaging requires signing and notarization credentials together/,
+		);
+	});
+
+	it("accepts a complete identity and App Store Connect credential set", () => {
+		const env = {
+			APPLE_SIGNING_IDENTITY: "Developer ID Application",
+			APPLE_API_KEY: "/tmp/AuthKey.p8",
+			APPLE_API_KEY_ID: "KEY123",
+			APPLE_API_ISSUER: "issuer-id",
+		};
+		expect(() =>
+			assertMacReleaseCredentials(env, "darwin", true),
+		).not.toThrow();
+		expect(macPackagerSecurity(env).osxSign).toMatchObject({
+			identity: "Developer ID Application",
+			hardenedRuntime: true,
+			entitlements: "assets/entitlements.mac.plist",
+			entitlementsInherit: "assets/entitlements.mac.inherit.plist",
+		});
+	});
+
+	it("accepts a signing certificate link with a keychain notary profile", () => {
+		const env = {
+			CSC_LINK: "file:///certificate.p12",
+			AO_NOTARY_PROFILE: "ao-notary",
+		};
+		expect(() =>
+			assertMacReleaseCredentials(env, "darwin", true),
+		).not.toThrow();
+		expect(macPackagerSecurity(env).osxSign).toMatchObject({
+			hardenedRuntime: true,
+		});
+	});
+
+	it("does not apply the macOS guard to other platforms", () => {
+		expect(() =>
+			assertMacReleaseCredentials(
+				{ APPLE_API_KEY: "/tmp/AuthKey.p8" },
+				"linux",
+				true,
+			),
+		).not.toThrow();
+	});
+
+	it("recognizes publish without confusing make for a publication", () => {
+		expect(isForgePublishCommand(["node", "electron-forge", "publish"])).toBe(
+			true,
+		);
+		expect(isForgePublishCommand(["node", "electron-forge", "make"])).toBe(
+			false,
+		);
+	});
+});

--- a/frontend/mac-release-security.ts
+++ b/frontend/mac-release-security.ts
@@ -1,0 +1,100 @@
+type ReleaseEnvironment = Record<string, string | undefined>;
+
+interface MacPackagerSecurity {
+	osxSign?: {
+		identity?: string;
+		hardenedRuntime: true;
+		entitlements: string;
+		entitlementsInherit: string;
+	};
+	osxNotarize?:
+		| { keychainProfile: string }
+		| { appleApiKey: string; appleApiKeyId: string; appleApiIssuer: string };
+}
+
+const APP_STORE_CONNECT_KEYS = [
+	"APPLE_API_KEY",
+	"APPLE_API_KEY_ID",
+	"APPLE_API_ISSUER",
+] as const;
+
+function configured(value: string | undefined): boolean {
+	return Boolean(value?.trim());
+}
+
+function credentialState(env: ReleaseEnvironment) {
+	const apiValues = APP_STORE_CONNECT_KEYS.map((key) => configured(env[key]));
+	const anyApiCredential = apiValues.some(Boolean);
+	const completeApiCredentials = apiValues.every(Boolean);
+	const hasSigning =
+		configured(env.APPLE_SIGNING_IDENTITY) || configured(env.CSC_LINK);
+	const hasNotarization =
+		configured(env.AO_NOTARY_PROFILE) || completeApiCredentials;
+	return {
+		anyApiCredential,
+		completeApiCredentials,
+		hasSigning,
+		hasNotarization,
+	};
+}
+
+export function isForgePublishCommand(argv: readonly string[]): boolean {
+	return argv.some((argument) => argument === "publish");
+}
+
+export function assertMacReleaseCredentials(
+	env: ReleaseEnvironment,
+	platform: NodeJS.Platform,
+	isPublish: boolean,
+): void {
+	if (platform !== "darwin") return;
+	const {
+		anyApiCredential,
+		completeApiCredentials,
+		hasSigning,
+		hasNotarization,
+	} = credentialState(env);
+
+	if (anyApiCredential && !completeApiCredentials) {
+		throw new Error(
+			"APPLE_API_KEY, APPLE_API_KEY_ID, and APPLE_API_ISSUER must be set together",
+		);
+	}
+	if (hasSigning !== hasNotarization) {
+		throw new Error(
+			"macOS packaging requires signing and notarization credentials together",
+		);
+	}
+	if (isPublish && !hasSigning) {
+		throw new Error(
+			"macOS publish requires both signing and notarization credentials",
+		);
+	}
+}
+
+export function macPackagerSecurity(
+	env: ReleaseEnvironment,
+): MacPackagerSecurity {
+	const { completeApiCredentials, hasSigning } = credentialState(env);
+	return {
+		osxSign: hasSigning
+			? {
+					...(configured(env.APPLE_SIGNING_IDENTITY)
+						? { identity: env.APPLE_SIGNING_IDENTITY }
+						: {}),
+					hardenedRuntime: true,
+					entitlements: "assets/entitlements.mac.plist",
+					entitlementsInherit: "assets/entitlements.mac.inherit.plist",
+				}
+			: undefined,
+		osxNotarize: configured(env.AO_NOTARY_PROFILE)
+			? { keychainProfile: env.AO_NOTARY_PROFILE as string }
+			: completeApiCredentials
+				? {
+						appleApiKey: env.APPLE_API_KEY as string,
+						appleApiKeyId: env.APPLE_API_KEY_ID as string,
+						appleApiIssuer: env.APPLE_API_ISSUER as string,
+					}
+				: undefined,
+	};
+}


### PR DESCRIPTION
Fixes #4501

## Problem

The Forge configuration silently omitted macOS signing and notarization when credentials were absent. The DMG sealing path rejected partial credentials, but the auto-update ZIP passed through the shared packaging path without an equivalent guard. A direct Forge publication could therefore emit an unsigned update, and the signing policy depended on `@electron/osx-sign` defaults.

The public repository's artifact workflow is intentionally unsigned: the private `Untrivial-ai/ao-releases` conductor signs, notarizes, verifies, and publishes those artifacts downstream. This patch preserves that boundary.

## Fix

- validates macOS credential completeness before packaging
- requires both signing and notarization for direct Forge `publish`
- continues to allow credential-free `make` for the public unsigned-artifact workflow
- pins Hardened Runtime and explicit parent/child entitlements
- constructs notarization options only from a complete API-key trio or a keychain profile

The guard runs in the common pre-package path, so it covers both ZIP and DMG makers rather than relying on a ZIP-specific wrapper.

## Safety

- no credentials are logged
- incomplete App Store Connect triples fail before provider tooling runs
- signing-only and notarization-only configurations fail
- non-macOS builds are unchanged
- the canonical private release conductor remains the only publisher
- Electron's current non-MAS entitlement defaults are pinned rather than broadened

## Tests

- `npm test -- --run mac-release-security.test.ts forge.config.test.ts` — 14 passed
- `npx tsc mac-release-security.ts --noEmit --strict --types node --moduleResolution node --skipLibCheck --target ES2022 --module commonjs` — passed
- full `npm run typecheck` — no diagnostics in changed files; this shared Windows workspace lacks React/motion dependencies for `packages/product-ui`
- `npm test -- --run mac-release-security.test.ts forge.config.test.ts makers/maker-dmg.test.ts` — the 31 relevant tests passed; one pre-existing Windows path-separator assertion in `maker-dmg.test.ts` failed

## Manual validation

A real signed/notarized macOS artifact was not produced on this Windows host. Clean macOS release CI and the private conductor remain authoritative for codesign, notarization, stapling, and Gatekeeper validation.
