### PR TITLE
fix(review): prevent Claude reviewer permission stalls

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -134,6 +134,7 @@ func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
 		{"default omits flag (defers to settings.json)", ports.PermissionModeDefault, nil, "--permission-mode"},
 		{"accept-edits", ports.PermissionModeAcceptEdits, []string{"--permission-mode", "acceptEdits"}, ""},
 		{"auto", ports.PermissionModeAuto, []string{"--permission-mode", "auto"}, ""},
+		{"deny-unapproved internal mode", ports.PermissionModeDenyUnapproved, []string{"--permission-mode", "dontAsk"}, ""},
 		{"bypass-permissions", ports.PermissionModeBypassPermissions, []string{"--permission-mode", "bypassPermissions"}, ""},
 		{"empty omits permission flags", "", nil, "--permission-mode"},
 	}

--- a/backend/internal/adapters/reviewer/claudecode/claudecode.go
+++ b/backend/internal/adapters/reviewer/claudecode/claudecode.go
@@ -37,19 +37,19 @@ var _ ports.ReviewerRestorer = (*Reviewer)(nil)
 
 // reviewerAllowedTools is the read-only tool allowlist the reviewer launches
 // with. The reviewer runs headless (no human to approve prompts) but must stay
-// read-only, so instead of bypassPermissions — which skips the permission
-// system entirely and ignores allow/deny rules — it launches in the default
-// mode where these rules are honored: allow rules auto-approve without
-// prompting, so the reviewer can read the checkout and run the few commands it
-// needs (git diff/log/show to inspect the PR, printf to pipe review JSON into
-// the downstream commands without writing a worktree file, gh to post the
-// review, and `ao review submit` to record the verdict) without stalling.
+// read-only. It launches in Claude's dontAsk-equivalent policy: allow rules are
+// honored, while an action that Claude cannot statically approve is rejected
+// instead of parking the unattended reviewer at a permission prompt. Reporting
+// uses an analyzer-safe base64 pipeline so review JSON is neither placed raw in
+// a shell operand nor written to the worktree.
 var reviewerAllowedTools = []string{
 	"Read",
 	"Grep",
 	"Glob",
 	"Bash(printf:*)",
-	"Bash(gh:*)",
+	"Bash(base64 --decode:*)",
+	"Bash(base64 -D:*)",
+	"Bash(gh api --method POST repos/:*)",
 	"Bash(git diff:*)",
 	"Bash(git log:*)",
 	"Bash(git show:*)",
@@ -66,6 +66,19 @@ var reviewerDisallowedTools = []string{
 	"NotebookEdit",
 	"Bash(git push:*)",
 	"Bash(git commit:*)",
+	"Bash(gh pr merge:*)",
+	"Bash(gh api --method DELETE:*)",
+	"Bash(gh api --method PUT:*)",
+	"Bash(gh api --method PATCH:*)",
+	"Bash(gh gist:*)",
+}
+
+const analyzerSafeReportingRule = `
+
+Claude reviewer reporting rule: when the review task shows a command that pipes raw JSON from printf, base64-encode the UTF-8 JSON yourself and run the same pipeline as printf '%s' '<base64>' | base64 --decode | <report command> (use base64 -D instead of --decode on systems that require it). Never place raw review JSON in a Bash operand or write it to a file.`
+
+func reviewMessage(prompt string) string {
+	return prompt + analyzerSafeReportingRule
 }
 
 // ReviewCommand builds a claude-code invocation that reviews the worker's
@@ -81,13 +94,12 @@ func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation
 		// from an id that the process was not launched with.
 		SessionID:        agentSessionID,
 		WorkspacePath:    inv.WorkspacePath,
-		Prompt:           inv.Prompt,
+		Prompt:           reviewMessage(inv.Prompt),
 		SystemPrompt:     inv.SystemPrompt,
 		SystemPromptFile: inv.SystemPromptFile,
-		// Launch off bypassPermissions so the allow/deny lists are enforced.
-		// Set an explicit non-bypass mode instead of deferring to the user's
-		// Claude defaultMode, which may itself be bypassPermissions.
-		Permissions:     ports.PermissionModeAuto,
+		// A headless reviewer cannot answer a prompt. Deny anything outside the
+		// allowlist so upstream analyzer changes fail closed rather than stall.
+		Permissions:     ports.PermissionModeDenyUnapproved,
 		AllowedTools:    reviewerAllowedTools,
 		DisallowedTools: reviewerDisallowedTools,
 	})
@@ -124,14 +136,14 @@ func (r *Reviewer) PreLaunch(ctx context.Context, inv ports.ReviewInvocation) er
 // ReviewMessage is the text injected into an already-running reviewer pane to
 // review a new commit — AO's central review prompt.
 func (r *Reviewer) ReviewMessage(_ context.Context, inv ports.ReviewInvocation) (string, error) {
-	return inv.Prompt, nil
+	return reviewMessage(inv.Prompt), nil
 }
 
 // ReviewRestoreCommand resumes the reviewer Claude Code conversation captured
 // from hooks, reapplying the same read-only tool policy as a fresh review launch.
 func (r *Reviewer) ReviewRestoreCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, bool, error) {
 	cmd, ok, err := agentrestore.Command(ctx, r.agent, inv, agentrestore.Options{
-		Permissions:     ports.PermissionModeAuto,
+		Permissions:     ports.PermissionModeDenyUnapproved,
 		AllowedTools:    reviewerAllowedTools,
 		DisallowedTools: reviewerDisallowedTools,
 	})

--- a/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/reviewer/claudecode/claudecode_test.go
@@ -52,7 +52,7 @@ func (a *captureAgent) SessionInfo(context.Context, ports.SessionRef) (ports.Ses
 	return ports.SessionInfo{}, false, nil
 }
 
-func TestReviewCommandLaunchesReadOnlyOffBypass(t *testing.T) {
+func TestReviewCommandLaunchesReadOnlyWithoutInteractivePrompts(t *testing.T) {
 	agent := &captureAgent{}
 	r := &Reviewer{agent: agent}
 
@@ -69,8 +69,8 @@ func TestReviewCommandLaunchesReadOnlyOffBypass(t *testing.T) {
 	// The allowlist is what enforces read-only, so it must launch in an
 	// explicit non-bypass mode: bypassPermissions ignores allow/deny rules
 	// entirely, and an empty mode would defer to a user's defaultMode.
-	if agent.got.Permissions != ports.PermissionModeAuto {
-		t.Fatalf("reviewer must launch in auto permission mode; got %q", agent.got.Permissions)
+	if agent.got.Permissions != ports.PermissionModeDenyUnapproved {
+		t.Fatalf("reviewer must deny unapproved tools without prompting; got %q", agent.got.Permissions)
 	}
 	if agent.got.SessionID == "" {
 		t.Fatal("reviewer must pin the persisted Claude session id")
@@ -78,10 +78,16 @@ func TestReviewCommandLaunchesReadOnlyOffBypass(t *testing.T) {
 	if spec.AgentSessionID != agent.got.SessionID {
 		t.Fatalf("persisted agent session id = %q, launched session id = %q", spec.AgentSessionID, agent.got.SessionID)
 	}
-	if !contains(agent.got.AllowedTools, "Read") || !contains(agent.got.AllowedTools, "Bash(ao review submit:*)") {
+	if !contains(agent.got.AllowedTools, "Read") || !contains(agent.got.AllowedTools, "Bash(ao review submit:*)") || !contains(agent.got.AllowedTools, "Bash(base64 --decode:*)") {
 		t.Fatalf("allowlist missing read-only review tools: %#v", agent.got.AllowedTools)
 	}
-	for _, denied := range []string{"Edit", "Write", "Bash(git push:*)", "Bash(git commit:*)"} {
+	if contains(agent.got.AllowedTools, "Bash(gh:*)") {
+		t.Fatalf("allowlist grants blanket gh access: %#v", agent.got.AllowedTools)
+	}
+	if !contains(agent.got.AllowedTools, "Bash(gh api --method POST repos/:*)") {
+		t.Fatalf("allowlist missing exact GitHub review-post path: %#v", agent.got.AllowedTools)
+	}
+	for _, denied := range []string{"Edit", "Write", "Bash(git push:*)", "Bash(git commit:*)", "Bash(gh pr merge:*)"} {
 		if !contains(agent.got.DisallowedTools, denied) {
 			t.Fatalf("disallow list missing %q: %#v", denied, agent.got.DisallowedTools)
 		}
@@ -124,8 +130,8 @@ func TestAllowlistCoversPromptRequiredPipedCommands(t *testing.T) {
 	}
 
 	for _, cmd := range []string{
-		"printf '%s' '{ \"event\": \"COMMENT\", \"body\": \"x\" }' | gh api --method POST repos/o/r/pulls/1/reviews --input - --jq '.id'",
-		"printf '%s' '{ \"reviews\": [] }' | ao review submit --session sess-1 --reviews -",
+		"printf '%s' 'eyJldmVudCI6IkNPTU1FTlQifQ==' | base64 --decode | gh api --method POST repos/o/r/pulls/1/reviews --input - --jq '.id'",
+		"printf '%s' 'eyJyZXZpZXdzIjpbXX0=' | base64 --decode | ao review submit --session sess-1 --reviews -",
 	} {
 		if !compoundCommandCovered(agent.got.AllowedTools, cmd) {
 			t.Fatalf("allowlist does not cover prompt-required command %q with tools %#v", cmd, agent.got.AllowedTools)
@@ -135,6 +141,31 @@ func TestAllowlistCoversPromptRequiredPipedCommands(t *testing.T) {
 	disallowed := "printf x | rm -rf /"
 	if compoundCommandCovered(agent.got.AllowedTools, disallowed) {
 		t.Fatalf("allowlist unexpectedly covers disallowed command %q with tools %#v", disallowed, agent.got.AllowedTools)
+	}
+}
+
+func TestReviewMessagesRequireAnalyzerSafeBase64Reporting(t *testing.T) {
+	agent := &captureAgent{}
+	r := &Reviewer{agent: agent}
+
+	if _, err := r.ReviewCommand(context.Background(), ports.ReviewInvocation{
+		ReviewerID: "review-w1",
+		Prompt:     "Read `/ao/task.md`.",
+	}); err != nil {
+		t.Fatalf("ReviewCommand: %v", err)
+	}
+	for _, want := range []string{"base64-encode", "base64 --decode", "Never place raw review JSON"} {
+		if !strings.Contains(agent.got.Prompt, want) {
+			t.Fatalf("launch prompt missing %q: %q", want, agent.got.Prompt)
+		}
+	}
+
+	message, err := r.ReviewMessage(context.Background(), ports.ReviewInvocation{Prompt: "Read `/ao/next.md`."})
+	if err != nil {
+		t.Fatalf("ReviewMessage: %v", err)
+	}
+	if !strings.Contains(message, "base64 --decode") {
+		t.Fatalf("follow-up prompt lacks analyzer-safe reporting rule: %q", message)
 	}
 }
 
@@ -148,7 +179,7 @@ func TestReviewCommandUsesHiddenSystemPromptFile(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("ReviewCommand: %v", err)
 	}
-	if agent.got.Prompt != "Start the AO review task." || agent.got.SystemPrompt != "" || agent.got.SystemPromptFile != "/ao/prompts/reviewer/system.md" {
+	if !strings.HasPrefix(agent.got.Prompt, "Start the AO review task.") || !strings.Contains(agent.got.Prompt, "base64 --decode") || agent.got.SystemPrompt != "" || agent.got.SystemPromptFile != "/ao/prompts/reviewer/system.md" {
 		t.Fatalf("launch config = %+v", agent.got)
 	}
 }
@@ -175,8 +206,8 @@ func TestReviewRestoreCommandUsesNativeSessionIDAndReadOnlyPolicy(t *testing.T) 
 	if agent.gotRestore.Session.Metadata[ports.MetadataKeyAgentSessionID] != "claude-native-1" {
 		t.Fatalf("restore metadata = %#v", agent.gotRestore.Session.Metadata)
 	}
-	if agent.gotRestore.Permissions != ports.PermissionModeAuto {
-		t.Fatalf("restore permissions = %q, want auto", agent.gotRestore.Permissions)
+	if agent.gotRestore.Permissions != ports.PermissionModeDenyUnapproved {
+		t.Fatalf("restore permissions = %q, want deny-unapproved", agent.gotRestore.Permissions)
 	}
 	if !contains(agent.gotRestore.AllowedTools, "Read") || !contains(agent.gotRestore.DisallowedTools, "Write") {
 		t.Fatalf("restore tool policy allowed=%#v disallowed=%#v", agent.gotRestore.AllowedTools, agent.gotRestore.DisallowedTools)

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -507,6 +507,11 @@ const (
 	PermissionModeAcceptEdits       = domain.PermissionModeAcceptEdits
 	PermissionModeAuto              = domain.PermissionModeAuto
 	PermissionModeBypassPermissions = domain.PermissionModeBypassPermissions
+	// PermissionModeDenyUnapproved is an internal launch-only policy for
+	// unattended restricted agents. It is deliberately not accepted by
+	// AgentConfig: adapters may map it to a provider-native mode that executes
+	// allowlisted actions and denies everything else instead of prompting.
+	PermissionModeDenyUnapproved PermissionMode = "deny-unapproved"
 )
 
 // NormalizePermissionMode collapses an empty or unrecognized mode to

--- a/backend/pkg/agentruntime/command.go
+++ b/backend/pkg/agentruntime/command.go
@@ -31,6 +31,10 @@ const (
 	PermissionAcceptEdits       PermissionPolicy = "accept-edits"
 	PermissionAuto              PermissionPolicy = "auto"
 	PermissionBypassPermissions PermissionPolicy = "bypass-permissions"
+	// PermissionDenyUnapproved is an internal policy used by unattended,
+	// allowlisted processes. It is not a user-selectable project permission
+	// mode; provider mappings may opt into a native fail-closed equivalent.
+	PermissionDenyUnapproved PermissionPolicy = "deny-unapproved"
 )
 
 // SessionMode is the durable Cloud execution mode.
@@ -172,6 +176,9 @@ func PermissionPolicyForMode(mode SessionMode) PermissionPolicy {
 
 // ClaudePermissionArgs maps AO policy onto Claude Code flags.
 func ClaudePermissionArgs(policy PermissionPolicy) []string {
+	if policy == PermissionDenyUnapproved {
+		return []string{"--permission-mode", "dontAsk"}
+	}
 	switch NormalizePermissionPolicy(policy) {
 	case PermissionAcceptEdits:
 		return []string{"--permission-mode", "acceptEdits"}

--- a/backend/pkg/agentruntime/command_test.go
+++ b/backend/pkg/agentruntime/command_test.go
@@ -192,6 +192,14 @@ func TestPermissionPolicyForMode(t *testing.T) {
 	}
 }
 
+func TestClaudePermissionArgsMapsDenyUnapprovedToDontAsk(t *testing.T) {
+	got := ClaudePermissionArgs(PermissionDenyUnapproved)
+	want := []string{"--permission-mode", "dontAsk"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClaudePermissionArgs() = %#v, want %#v", got, want)
+	}
+}
+
 func TestClaudeNativeSessionIDValidation(t *testing.T) {
 	id := uuid.NewString()
 	cmd, err := BuildLaunchCommand(LaunchConfig{


### PR DESCRIPTION
Fixes #4810

## Problem

Claude Code 2.1.257+ can route commands that its Bash analyzer cannot prove safe to an interactive permission prompt before AO's allow rules settle the request. The Claude reviewer is unattended, so a prompt can park the review forever and prevent its GitHub review or AO verdict bookkeeping from completing.

## Root cause

AO launched the restricted Claude reviewer in `auto` mode and relied on broad command allow rules, including blanket `Bash(gh:*)`. The review protocol also embedded arbitrary review JSON directly in `printf` operands. Newer Claude analyzers can reject that content shape before an allow rule prevents the prompt. The reviewer correctly prohibited file writes, leaving no safe payload-file fallback.

## Fix

- add an internal, launch-only `deny-unapproved` policy and map it to Claude's native `dontAsk` mode
- use that policy for fresh and restored Claude reviewer sessions, so unknown/unparseable actions are denied instead of opening an unattended prompt
- tell Claude reviewers to base64-encode reporting JSON and decode it in the existing pipe, keeping payloads off disk and out of analyzer-sensitive shell operands
- allow only the two base64 decode forms needed by Linux/macOS
- replace blanket `gh` access with the required `gh api --method POST repos/...` review-post path
- explicitly deny `gh pr merge`, destructive API methods, and gist access as defense in depth
- preserve both the GitHub review and `ao review submit` bookkeeping channels

## Safety

- reviewer file-edit tools remain denied
- no temporary-file or worktree write permission is added
- commands outside the allowlist fail closed without interaction
- reviewer restore reapplies the same policy
- the project/user permission vocabulary is unchanged; the new policy is internal-only
- other reviewer harnesses and ordinary Claude worker sessions are unchanged

## Tests

Passed:

- `go test ./pkg/agentruntime ./internal/adapters/agent/claudecode ./internal/adapters/reviewer/claudecode`
- `go vet ./pkg/agentruntime ./internal/adapters/agent/claudecode ./internal/adapters/reviewer/claudecode`

A broader reviewer-adapter run reached the unchanged host-dependent suites, where unrelated Windows tests require locally installed reviewer binaries or Unix permission semantics. Every changed package passed in that run. CI is the authoritative broad check.

## Validation boundary

This is deterministic command/policy coverage plus verification against current official Claude Code permission and hook documentation. Claude Code is not installed on this host, so no live-provider review cycle is claimed.