### PR TITLE
fix(mobile): require confirmation for plaintext LAN pairing

### DIFF
--- a/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.telemetry.test.tsx
@@ -51,6 +51,11 @@ function toggleEvents() {
 	return captureRendererEvent.mock.calls.filter((c) => c[0] === "ao.renderer.mobile_bridge_toggled");
 }
 
+async function confirmBridgeStart() {
+	await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+	await userEvent.click(await screen.findByRole("button", { name: "I trust this network — generate" }));
+}
+
 describe("Connect Mobile telemetry", () => {
 	beforeEach(() => {
 		captureRendererEvent.mockClear();
@@ -76,8 +81,11 @@ describe("Connect Mobile telemetry", () => {
 		await waitFor(() => expect(openEvents()).toHaveLength(1));
 		expect(openEvents()[0][1]).toEqual({ bridge_enabled: false });
 
-		mobileStatus.enabled = true;
-		await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+		post.mockImplementationOnce(async () => {
+			mobileStatus.enabled = true;
+			return { data: {}, error: undefined };
+		});
+		await confirmBridgeStart();
 
 		await waitFor(() => expect(toggleEvents()).toHaveLength(1));
 		await waitFor(() => expect(screen.getByRole("button", { name: "Generate" })).toBeDisabled());
@@ -96,7 +104,7 @@ describe("Connect Mobile telemetry", () => {
 		renderMobileSettings();
 		await waitFor(() => expect(openEvents()).toHaveLength(1));
 
-		await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+		await confirmBridgeStart();
 
 		await waitFor(() => expect(toggleEvents()).toHaveLength(1));
 		expect(toggleEvents()[0][1]).toEqual({ enabled: true, outcome: "succeeded" });
@@ -114,7 +122,7 @@ describe("Connect Mobile telemetry", () => {
 		renderMobileSettings();
 		await waitFor(() => expect(openEvents()).toHaveLength(1));
 
-		await userEvent.click(screen.getByRole("button", { name: "Generate" }));
+		await confirmBridgeStart();
 
 		await waitFor(() => expect(toggleEvents()).toHaveLength(1));
 		expect(toggleEvents()[0][1]).toEqual({ enabled: true, outcome: "failed" });

--- a/frontend/src/renderer/components/ConnectMobileModal.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.test.tsx
@@ -97,7 +97,8 @@ beforeEach(() => {
 	mobileStatus.tunnel = undefined;
 	mobileStatus.endpoints = [{ kind: "lan", host: "192.168.1.42", port: 3011, secure: false }];
 	mobileStatus.tailscaleHost = "100.72.46.7";
-	mobileStatus.warning = "";
+	mobileStatus.warning = "Traffic on this connection is not encrypted. Only use it on a network you trust.";
+	vi.mocked(apiClient.POST).mockClear();
 	mobileStatus.securePairing = {
 		enabled: false,
 		available: false,
@@ -106,6 +107,18 @@ beforeEach(() => {
 		port: 0,
 		reason: "",
 	};
+});
+
+test("requires explicit trusted-network confirmation before exposing the LAN bridge", async () => {
+	mobileStatus.enabled = false;
+	renderMobileSettings();
+
+	await userEvent.click(await screen.findByRole("button", { name: "Generate" }));
+	expect(screen.getByRole("dialog")).toHaveTextContent("Use an unencrypted local connection?");
+	expect(apiClient.POST).not.toHaveBeenCalledWith("/api/v1/mobile/enable");
+
+	await userEvent.click(screen.getByRole("button", { name: "I trust this network — generate" }));
+	await waitFor(() => expect(apiClient.POST).toHaveBeenCalledWith("/api/v1/mobile/enable"));
 });
 
 test("QR payload carries host, port, and password for one-scan connect", () => {

--- a/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
@@ -14,6 +14,17 @@ import { PairingQr } from "./PairingQr";
 import { scramblePairingCodes } from "./qrScramble";
 import { InstallCloudflared } from "./InstallCloudflared";
 import { Button } from "../ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	settingsDialogContentClass,
+	settingsDialogFooterClass,
+	settingsDialogHeaderClass,
+} from "../ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "../../lib/utils";
 
@@ -221,6 +232,7 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 	const queryClient = useQueryClient();
 	const [copied, setCopied] = useState(false);
 	const [optimisticEnabled, setOptimisticEnabled] = useState<boolean | null>(null);
+	const [trustConfirmationOpen, setTrustConfirmationOpen] = useState(false);
 	const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const lastQrValueRef = useRef<string | null>(null);
 	// Pinned to "lan" while the connection picker below is commented out.
@@ -392,6 +404,12 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 
 	const startBridge = () => {
 		if (busy || enabled) return;
+		setTrustConfirmationOpen(true);
+	};
+
+	const confirmStartBridge = () => {
+		if (busy || enabled) return;
+		setTrustConfirmationOpen(false);
 		clearActionErrors();
 		setOptimisticEnabled(true);
 		enable.mutate(undefined, {
@@ -447,6 +465,14 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 	return (
 		<div className="flex flex-col gap-4">
 			<p className="text-xs leading-4 text-settings-muted">{t("mobile.description")}</p>
+			{status.warning ? (
+				<p
+					className="rounded-md border border-warning/35 bg-warning/10 px-3 py-2 text-xs leading-5 text-warning"
+					role="alert"
+				>
+					{status.warning}
+				</p>
+			) : null}
 
 			<div className="flex flex-col gap-6 sm:flex-row sm:items-start">
 				{/* Left: the walkthrough. */}
@@ -661,6 +687,23 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 					)}
 					</div>
 			</div>
+
+			<Dialog open={trustConfirmationOpen} onOpenChange={setTrustConfirmationOpen}>
+				<DialogContent className={settingsDialogContentClass} showCloseButton={false}>
+					<DialogHeader className={settingsDialogHeaderClass}>
+						<DialogTitle className="settings-dialog-title">{t("mobile.unencryptedConfirmTitle")}</DialogTitle>
+						<DialogDescription>{status.warning}</DialogDescription>
+					</DialogHeader>
+					<DialogFooter className={settingsDialogFooterClass}>
+						<Button type="button" variant="footer" onClick={() => setTrustConfirmationOpen(false)}>
+							{t("confirm.cancel")}
+						</Button>
+						<Button type="button" variant="footer-primary" onClick={confirmStartBridge}>
+							{t("mobile.trustNetworkAndGenerate")}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -443,6 +443,8 @@
 	"mobile.devices.title": "Verbundene Geräte",
 	"mobile.devices.unnamed": "Unbenanntes Gerät",
 	"mobile.generate": "Generieren",
+	"mobile.trustNetworkAndGenerate": "Ich vertraue diesem Netzwerk — generieren",
+	"mobile.unencryptedConfirmTitle": "Unverschlüsselte lokale Verbindung verwenden?",
 	"mobile.preparingQr": "Sichere Verbindung wird vorbereitet – das dauert meist 30-60 Sekunden",
 	"mobile.getApp": "App holen",
 	"mobile.getApp.step1": "Agent Orchestrator auf dem Telefon installieren",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -443,6 +443,8 @@
 	"mobile.devices.title": "Connected devices",
 	"mobile.devices.unnamed": "Unnamed device",
 	"mobile.generate": "Generate",
+	"mobile.trustNetworkAndGenerate": "I trust this network — generate",
+	"mobile.unencryptedConfirmTitle": "Use an unencrypted local connection?",
 	"mobile.preparingQr": "Preparing your secure link — this usually takes 30-60 seconds",
 	"mobile.getApp": "Get the app",
 	"mobile.getApp.step1": "Install Agent Orchestrator on your phone",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -445,6 +445,8 @@
 	"mobile.devices.title": "Dispositivos conectados",
 	"mobile.devices.unnamed": "Dispositivo sin nombre",
 	"mobile.generate": "Generar",
+	"mobile.trustNetworkAndGenerate": "Confío en esta red — generar",
+	"mobile.unencryptedConfirmTitle": "¿Usar una conexión local sin cifrar?",
 	"mobile.preparingQr": "Preparando tu enlace seguro: suele tardar entre 30 y 60 segundos",
 	"mobile.getApp": "Obtener la aplicación",
 	"mobile.getApp.step1": "Instala Agent Orchestrator en tu teléfono",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -445,6 +445,8 @@
 	"mobile.devices.title": "Appareils connectés",
 	"mobile.devices.unnamed": "Appareil sans nom",
 	"mobile.generate": "Générer",
+	"mobile.trustNetworkAndGenerate": "Je fais confiance à ce réseau — générer",
+	"mobile.unencryptedConfirmTitle": "Utiliser une connexion locale non chiffrée ?",
 	"mobile.preparingQr": "Préparation de votre lien sécurisé — cela prend généralement 30 à 60 secondes",
 	"mobile.getApp": "Obtenir l'application",
 	"mobile.getApp.step1": "Installez Agent Orchestrator sur votre téléphone",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -443,6 +443,8 @@
 	"mobile.devices.title": "接続済みデバイス",
 	"mobile.devices.unnamed": "名前未設定のデバイス",
 	"mobile.generate": "生成",
+	"mobile.trustNetworkAndGenerate": "このネットワークを信頼して生成",
+	"mobile.unencryptedConfirmTitle": "暗号化されていないローカル接続を使用しますか？",
 	"mobile.preparingQr": "セキュアリンクを準備しています — 通常30〜60秒かかります",
 	"mobile.getApp": "アプリを入手",
 	"mobile.getApp.step1": "スマートフォンに Agent Orchestrator をインストール",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -443,6 +443,8 @@
 	"mobile.devices.title": "연결된 기기",
 	"mobile.devices.unnamed": "이름 없는 기기",
 	"mobile.generate": "생성",
+	"mobile.trustNetworkAndGenerate": "이 네트워크를 신뢰하고 생성",
+	"mobile.unencryptedConfirmTitle": "암호화되지 않은 로컬 연결을 사용하시겠습니까?",
 	"mobile.preparingQr": "보안 링크를 준비하는 중입니다 — 보통 30~60초 정도 걸립니다",
 	"mobile.getApp": "앱 받기",
 	"mobile.getApp.step1": "휴대폰에 Agent Orchestrator 설치",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -445,6 +445,8 @@
 	"mobile.devices.title": "Dispositivos conectados",
 	"mobile.devices.unnamed": "Dispositivo sem nome",
 	"mobile.generate": "Gerar",
+	"mobile.trustNetworkAndGenerate": "Confio nesta rede — gerar",
+	"mobile.unencryptedConfirmTitle": "Usar uma conexão local sem criptografia?",
 	"mobile.preparingQr": "Preparando seu link seguro — normalmente leva de 30 a 60 segundos",
 	"mobile.getApp": "Obter o app",
 	"mobile.getApp.step1": "Instale o Agent Orchestrator no seu celular",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -443,6 +443,8 @@
 	"mobile.devices.title": "已连接的设备",
 	"mobile.devices.unnamed": "未命名设备",
 	"mobile.generate": "生成",
+	"mobile.trustNetworkAndGenerate": "我信任此网络 — 生成",
+	"mobile.unencryptedConfirmTitle": "使用未加密的本地连接？",
 	"mobile.preparingQr": "正在准备安全链接 — 通常需要 30-60 秒",
 	"mobile.getApp": "获取应用",
 	"mobile.getApp.step1": "在手机上安装 Agent Orchestrator",

--- a/packages/mobile/app/(tabs)/settings.tsx
+++ b/packages/mobile/app/(tabs)/settings.tsx
@@ -169,7 +169,11 @@ function ConnectionSection({
 	return (
 		<SettingsGroup
 			title="Connection"
-			footer="Your PC's Tailscale name / 100.x address, or its LAN IP on the same Wi-Fi."
+			footer={
+				paired && !cfg.secure
+					? "Not encrypted. Use this connection only on a private network you trust."
+					: "Your PC's Tailscale name / 100.x address, or its LAN IP on the same Wi-Fi."
+			}
 		>
 			<SettingsRow
 				icon="link"

--- a/packages/mobile/app/pair.tsx
+++ b/packages/mobile/app/pair.tsx
@@ -2,7 +2,7 @@ import { Feather } from "@expo/vector-icons";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useRef, useState } from "react";
-import { Linking, Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import { Alert, Linking, Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { pingServer } from "../lib/api";
 import { pickNormalLens } from "../lib/cameraLens";
@@ -17,7 +17,11 @@ import type { Theme } from "../lib/theme";
 import { haptics } from "../lib/haptics";
 import { clearOnboardingSkipped } from "../lib/onboardingStore";
 import { pairFromCode } from "../lib/pairFlow";
-import { isLegacyPairingCode, parsePairingCode } from "../lib/pairingCode";
+import {
+	isLegacyPairingCode,
+	pairingNeedsUnencryptedConfirmation,
+	parsePairingCode,
+} from "../lib/pairingCode";
 import { saveHost, setActiveHost } from "../lib/hosts";
 import { probeEndpoint } from "../lib/connectRuntime";
 import { raceEndpoints } from "../lib/race";
@@ -81,7 +85,8 @@ export default function PairScreen() {
 		if (scanned.current || busy || !focused.current) return;
 		// Cheap reject first: the camera sees every barcode in frame, and only a
 		// code we can actually parse should stop the scanner.
-		if (!parsePairingCode(data)) {
+		const offer = parsePairingCode(data);
+		if (!offer) {
 			if (rejected.current !== data) {
 				rejected.current = data;
 				// A v1 code is a recognisable thing, not noise: say what to do
@@ -93,6 +98,23 @@ export default function PairScreen() {
 		}
 		rejected.current = null;
 		scanned.current = true;
+		if (pairingNeedsUnencryptedConfirmation(offer)) {
+			Alert.alert(
+				"Unencrypted local connection",
+				"This pairing can send your AO password over the local network without encryption. Continue only on a private network you trust.",
+				[
+					{
+						text: "Cancel",
+						style: "cancel",
+						onPress: () => {
+							scanned.current = false;
+						},
+					},
+					{ text: "I trust this network", onPress: () => void pair(data) },
+				],
+			);
+			return;
+		}
 		await pair(data);
 	}
 

--- a/packages/mobile/lib/ManualConnectSheet.tsx
+++ b/packages/mobile/lib/ManualConnectSheet.tsx
@@ -1,6 +1,6 @@
 import { Feather } from "@expo/vector-icons";
 import { useEffect, useState } from "react";
-import { Linking, Platform, ScrollView, StyleSheet, Switch, Text, TextInput, View } from "react-native";
+import { Alert, Linking, Platform, ScrollView, StyleSheet, Switch, Text, TextInput, View } from "react-native";
 import { ApiError, pingServer } from "./api";
 import { DEFAULT_CONFIG, loadConfig, saveConfig, type ServerConfig } from "./config";
 import { saveHost, setActiveHost } from "./hosts";
@@ -86,6 +86,21 @@ export function ManualConnectSheet({ onConnected }: { onConnected: () => void })
 		}
 	}
 
+	function requestConnect() {
+		if (cfg.secure) {
+			void connect();
+			return;
+		}
+		Alert.alert(
+			"Unencrypted local connection",
+			"Your AO password will be sent over the local network without encryption. Continue only on a private network you trust.",
+			[
+				{ text: "Cancel", style: "cancel" },
+				{ text: "I trust this network", onPress: () => void connect() },
+			],
+		);
+	}
+
 	const form = (
 		<>
 			<Field
@@ -115,6 +130,14 @@ export function ManualConnectSheet({ onConnected }: { onConnected: () => void })
 					trackColor={{ true: t.blue, false: t.borderStrong }}
 				/>
 			</View>
+			{!cfg.secure ? (
+				<View style={styles.warningBox}>
+					<Feather name="alert-triangle" size={15} color={t.amber} />
+					<Text style={styles.warningText}>
+						Not encrypted. Use this connection only on a private network you trust.
+					</Text>
+				</View>
+			) : null}
 
 			{failure ? (
 				<View style={styles.errorBox}>
@@ -142,7 +165,7 @@ export function ManualConnectSheet({ onConnected }: { onConnected: () => void })
 				icon="link"
 				loading={busy}
 				disabled={!cfg.host.trim()}
-				onPress={connect}
+				onPress={requestConnect}
 				style={{ marginTop: 16 }}
 			/>
 		</>
@@ -225,4 +248,14 @@ const makeStyles = (t: Theme) =>
 			marginTop: 16,
 		},
 		errorText: { color: t.red, fontSize: 13, lineHeight: 19 },
+		warningBox: {
+			flexDirection: "row",
+			gap: 9,
+			alignItems: "flex-start",
+			backgroundColor: t.tintAmber,
+			borderRadius: 10,
+			padding: 12,
+			marginTop: 16,
+		},
+		warningText: { color: t.amber, fontSize: 13, lineHeight: 19, flex: 1 },
 	});

--- a/packages/mobile/lib/pairingCode.test.ts
+++ b/packages/mobile/lib/pairingCode.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { encodePairingCode, isLegacyPairingCode, parsePairingCode, pairingUrl } from "./pairingCode";
+import {
+	encodePairingCode,
+	isLegacyPairingCode,
+	pairingNeedsUnencryptedConfirmation,
+	parsePairingCode,
+	pairingUrl,
+} from "./pairingCode";
 
 const offer = {
 	v: 2 as const,
@@ -71,6 +77,21 @@ describe("parsePairingCode", () => {
 	it("decodes a payload whose base64 padding was stripped", () => {
 		const padded = encodePairingCode(offer);
 		expect(parsePairingCode(padded.replace(/=+$/, ""))?.hostId).toBe("h_b3e07f31");
+	});
+});
+
+describe("pairingNeedsUnencryptedConfirmation", () => {
+	it("requires confirmation when endpoint racing could select plaintext LAN", () => {
+		expect(pairingNeedsUnencryptedConfirmation(offer)).toBe(true);
+	});
+
+	it("does not interrupt an all-TLS pairing offer", () => {
+		expect(
+			pairingNeedsUnencryptedConfirmation({
+				...offer,
+				endpoints: [{ kind: "tunnel", host: "abc.trycloudflare.com", port: 443, secure: true }],
+			}),
+		).toBe(false);
 	});
 });
 

--- a/packages/mobile/lib/pairingCode.ts
+++ b/packages/mobile/lib/pairingCode.ts
@@ -142,3 +142,13 @@ export function parsePairingCode(input: string): PairingOffer | null {
 		token: typeof o.token === "string" ? o.token : "",
 	};
 }
+
+/**
+ * Whether accepting this offer can expose the bearer token in plaintext.
+ *
+ * A mixed offer still needs confirmation: endpoint racing may legitimately
+ * choose its faster LAN address even when a TLS tunnel is also advertised.
+ */
+export function pairingNeedsUnencryptedConfirmation(offer: PairingOffer): boolean {
+	return offer.endpoints.some((endpoint) => !endpoint.secure);
+}


### PR DESCRIPTION
Fixes #4504

## Problem

The LAN mobile bridge is intentionally plaintext HTTP, but enabling it from desktop settings was a one-click action and the mobile client could accept a plaintext pairing code without a blocking trust decision. The bearer password can therefore cross a shared local network in cleartext.

## Fix

- require an explicit trusted-private-network confirmation before the desktop enables the LAN bridge
- show the daemon-provided unencrypted transport warning prominently in desktop settings
- require confirmation before the mobile app accepts any offer that could race onto a plaintext endpoint, including mixed TLS/LAN offers
- require the same confirmation for manual plaintext connections
- keep a persistent unencrypted warning in mobile connection settings

This is the issue's documented interim mitigation. It does not claim to add TLS or make plaintext transport secure.

## Safety

- TLS-only pairing continues without an unnecessary prompt
- mixed offers remain guarded because endpoint racing may select LAN
- cancelling QR confirmation re-enables scanning
- no bridge endpoint, bearer-token, tunnel, or transport semantics changed
- the existing server-authenticated pairing flow remains intact

## Tests

- renderer mobile-settings regressions and i18n coverage: 30 passed, 6 skipped
- mobile pairing-code regressions: 19 passed
- renderer TypeScript typecheck: passed
- mobile TypeScript typecheck: one pre-existing unrelated error in `lib/session/TerminalSessionScreen.tsx:1173`; reproduced identically on clean `origin/main` with the same dependency tree
- `git diff --check`: passed (line-ending notices only)

## Intentional omissions

LAN TLS with certificate pinning remains a larger follow-up. This PR implements only the explicitly permitted blocking-warning mitigation and does not alter the repository's existing raw-LAN/tunnel architecture.

No live packet-capture or real-device pairing validation was performed; coverage is deterministic code-path and UI testing.