### PR TITLE
feat(review): add opt-in Qwen native review mode

### DIFF
--- a/backend/internal/adapters/reviewer/qwen/qwen.go
+++ b/backend/internal/adapters/reviewer/qwen/qwen.go
@@ -4,6 +4,7 @@ package qwen
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 
 	workerqwen "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/nativeqwen"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/reviewgateway"
 )
@@ -27,13 +29,14 @@ type binaryResolver func(context.Context) (string, error)
 
 // Reviewer builds only Qwen's visible, long-lived interactive TUI command.
 type Reviewer struct {
-	resolveBinary binaryResolver
+	resolveBinary     binaryResolver
+	resolveExecutable func() (string, error)
 }
 
 // New creates the Qwen reviewer. Production launch invocations supply the
 // AO-owned data directory used for its neutral working and configuration roots.
 func New() *Reviewer {
-	return &Reviewer{resolveBinary: workerqwen.ResolveQwenBinary}
+	return &Reviewer{resolveBinary: workerqwen.ResolveQwenBinary, resolveExecutable: os.Executable}
 }
 
 // Harness returns Qwen's reviewer identity.
@@ -43,6 +46,7 @@ var _ ports.Reviewer = (*Reviewer)(nil)
 var _ ports.ReviewerCanceller = (*Reviewer)(nil)
 var _ ports.ReviewerReusePolicy = (*Reviewer)(nil)
 var _ ports.ReviewerPromptReadinessProvider = (*Reviewer)(nil)
+var _ ports.ReviewerIdleRestorePolicy = (*Reviewer)(nil)
 
 // ReviewCommand launches only Qwen's permanent interactive TUI. The task
 // reference is injected after runtime creation so neither prompts nor prompt
@@ -57,6 +61,9 @@ func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation
 	}
 	if !filepath.IsAbs(binary) {
 		return ports.ReviewCommandSpec{}, errors.New("qwen reviewer: resolved binary must be absolute")
+	}
+	if inv.Config.Mode == "native-review" {
+		return r.nativeReviewCommand(inv, binary, false)
 	}
 	// Launcher preflight runs before request-scoped prompt and gateway state
 	// exists. It only needs the resolved interactive executable; production
@@ -85,9 +92,118 @@ func (r *Reviewer) ReviewCommand(ctx context.Context, inv ports.ReviewInvocation
 	}, nil
 }
 
+func (r *Reviewer) nativeReviewCommand(inv ports.ReviewInvocation, binary string, restoring bool) (ports.ReviewCommandSpec, error) {
+	if strings.TrimSpace(inv.WorkspacePath) == "" || strings.TrimSpace(inv.RunID) == "" {
+		return ports.ReviewCommandSpec{}, errors.New("qwen native reviewer: workspace and run id are required")
+	}
+	if err := inv.Config.Validate(); err != nil {
+		return ports.ReviewCommandSpec{}, fmt.Errorf("qwen native reviewer config: %w", err)
+	}
+	opts := nativeqwen.Options{}
+	if inv.Config.NativeReview != nil {
+		opts = nativeqwen.Options{
+			Effort:         inv.Config.NativeReview.Effort,
+			Comment:        inv.Config.NativeReview.Comment,
+			Resume:         inv.Config.NativeReview.Resume,
+			Quiet:          inv.Config.NativeReview.Quiet,
+			TimeoutMinutes: inv.Config.NativeReview.TimeoutMinutes,
+		}
+	}
+	queue := inv.ReviewQueue
+	if len(queue) == 0 {
+		queue = []ports.ReviewTask{{RunID: inv.RunID, PRURL: inv.PRURL, TargetSHA: inv.TargetSHA}}
+	}
+	tasks := make([]nativeqwen.Task, 0, len(queue))
+	for _, item := range queue {
+		taskOpts := opts
+		taskOpts.Resume = taskOpts.Resume && resumableTarget(inv.PreviousRuns, item.PRURL, item.TargetSHA, restoring)
+		tasks = append(tasks, nativeqwen.Task{RunID: item.RunID, Target: item.PRURL, TargetSHA: item.TargetSHA, Options: taskOpts})
+	}
+	manifest := nativeqwen.Manifest{
+		Version:         1,
+		QwenBinary:      binary,
+		WorkerSessionID: string(inv.WorkerSessionID),
+		WorkspacePath:   inv.WorkspacePath,
+		Tasks:           tasks,
+	}
+	if err := manifest.Validate(); err != nil {
+		return ports.ReviewCommandSpec{}, fmt.Errorf("qwen native reviewer manifest: %w", err)
+	}
+	executable, err := r.resolveExecutable()
+	if err != nil {
+		return ports.ReviewCommandSpec{}, fmt.Errorf("qwen native reviewer: resolve AO executable: %w", err)
+	}
+	if !filepath.IsAbs(executable) {
+		return ports.ReviewCommandSpec{}, errors.New("qwen native reviewer: AO executable must be absolute")
+	}
+	env, err := r.prepareEnvironment(inv)
+	if err != nil {
+		return ports.ReviewCommandSpec{}, err
+	}
+	settingsEnv, err := seedHostQwenSettings(env.ConfigRoot)
+	if err != nil {
+		return ports.ReviewCommandSpec{}, err
+	}
+	envVars := env.TUIEnvironment()
+	for key, value := range settingsEnv {
+		envVars[key] = value
+	}
+	envVars["AO_DATA_DIR"] = env.DataDir
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return ports.ReviewCommandSpec{}, fmt.Errorf("qwen native reviewer: encode manifest: %w", err)
+	}
+	hash := sha256.Sum256([]byte(inv.RunID))
+	manifestDir := filepath.Join(inv.DataDir, "reviewer-runtime", inv.ReviewerID, "native-review")
+	if err := os.MkdirAll(manifestDir, 0o700); err != nil {
+		return ports.ReviewCommandSpec{}, fmt.Errorf("qwen native reviewer: create manifest directory: %w", err)
+	}
+	manifestPath := filepath.Join(manifestDir, fmt.Sprintf("%x.json", hash[:12]))
+	if err := os.WriteFile(manifestPath, manifestBytes, 0o600); err != nil {
+		return ports.ReviewCommandSpec{}, fmt.Errorf("qwen native reviewer: write manifest: %w", err)
+	}
+	return ports.ReviewCommandSpec{
+		Argv:             []string{executable, "review", "qwen-native-run", "--manifest", manifestPath},
+		Env:              envVars,
+		WorkingDirectory: inv.WorkspacePath,
+	}, nil
+}
+
+func resumableTarget(runs []domain.ReviewRun, prURL, targetSHA string, includeRunning bool) bool {
+	for _, run := range runs {
+		if run.PRURL == prURL && run.TargetSHA == targetSHA &&
+			(run.Status == domain.ReviewRunFailed || run.Status == domain.ReviewRunCancelled || includeRunning && run.Status == domain.ReviewRunRunning) {
+			return true
+		}
+	}
+	return false
+}
+
 // ReviewRestoreCommand restores a recorded Qwen reviewer pane by relaunching
 // with a fresh gateway manifest and the current task context.
 func (r *Reviewer) ReviewRestoreCommand(ctx context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, bool, error) {
+	if inv.Config.Mode == "native-review" {
+		queue := make([]ports.ReviewTask, 0)
+		for _, run := range inv.PreviousRuns {
+			if run.Status == domain.ReviewRunRunning {
+				queue = append(queue, ports.ReviewTask{RunID: run.ID, PRURL: run.PRURL, TargetSHA: run.TargetSHA})
+			}
+		}
+		if len(queue) == 0 {
+			return ports.ReviewCommandSpec{}, false, nil
+		}
+		binary, err := r.resolveBinary(ctx)
+		if err != nil {
+			return ports.ReviewCommandSpec{}, false, err
+		}
+		if !filepath.IsAbs(binary) {
+			return ports.ReviewCommandSpec{}, false, errors.New("qwen reviewer: resolved binary must be absolute")
+		}
+		inv.RunID, inv.PRURL, inv.TargetSHA = queue[0].RunID, queue[0].PRURL, queue[0].TargetSHA
+		inv.ReviewQueue = queue
+		cmd, err := r.nativeReviewCommand(inv, binary, true)
+		return cmd, err == nil, err
+	}
 	cmd, err := r.ReviewCommand(ctx, inv)
 	return cmd, true, err
 }
@@ -100,6 +216,20 @@ func (*Reviewer) ReviewMessage(_ context.Context, inv ports.ReviewInvocation) (s
 // ReviewProcessReusable returns false because Qwen's request-scoped reviewer
 // context is fixed at launch.
 func (*Reviewer) ReviewProcessReusable() bool { return false }
+
+// SkipIdleReviewRestore keeps native-review one-shot: daemon recovery must not
+// invent a provider run when there is no immutable review task to execute.
+func (*Reviewer) SkipIdleReviewRestore(inv ports.ReviewInvocation) bool {
+	if inv.Config.Mode != "native-review" {
+		return false
+	}
+	for _, run := range inv.PreviousRuns {
+		if run.Status == domain.ReviewRunRunning {
+			return false
+		}
+	}
+	return true
+}
 
 // ReviewPromptReadinessHints waits for Qwen's input footer before injecting the
 // task reference, avoiding a blind startup race while keeping timeout best-effort.

--- a/backend/internal/adapters/reviewer/qwen/qwen_test.go
+++ b/backend/internal/adapters/reviewer/qwen/qwen_test.go
@@ -2,13 +2,16 @@ package qwen
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/nativeqwen"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -34,14 +37,15 @@ func invocation(t *testing.T) ports.ReviewInvocation {
 
 func TestReviewCommandIsExactPermanentTUIWithPostReadinessReference(t *testing.T) {
 	reviewer := New()
-	reviewer.resolveBinary = func(context.Context) (string, error) { return "/opt/qwen/bin/qwen", nil }
+	qwenBinary := filepath.Join(t.TempDir(), "qwen")
+	reviewer.resolveBinary = func(context.Context) (string, error) { return qwenBinary, nil }
 	inv := invocation(t)
 
 	spec, err := reviewer.ReviewCommand(context.Background(), inv)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"/opt/qwen/bin/qwen", "--bare", "--approval-mode", "plan"}
+	want := []string{qwenBinary, "--bare", "--approval-mode", "plan"}
 	if !reflect.DeepEqual(spec.Argv, want) {
 		t.Fatalf("argv = %#v, want %#v", spec.Argv, want)
 	}
@@ -81,6 +85,7 @@ func TestReviewCommandIsExactPermanentTUIWithPostReadinessReference(t *testing.T
 func TestReviewCommandSeedsPrivateProfileFromHostSettings(t *testing.T) {
 	hostHome := t.TempDir()
 	t.Setenv("HOME", hostHome)
+	t.Setenv("USERPROFILE", hostHome)
 	settings := filepath.Join(hostHome, ".qwen", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(settings), 0o700); err != nil {
 		t.Fatal(err)
@@ -89,7 +94,7 @@ func TestReviewCommandSeedsPrivateProfileFromHostSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	reviewer := New()
-	reviewer.resolveBinary = func(context.Context) (string, error) { return "/opt/qwen/bin/qwen", nil }
+	reviewer.resolveBinary = func(context.Context) (string, error) { return filepath.Join(t.TempDir(), "qwen"), nil }
 
 	spec, err := reviewer.ReviewCommand(context.Background(), invocation(t))
 	if err != nil {
@@ -108,7 +113,8 @@ func TestReviewCommandSeedsPrivateProfileFromHostSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	// Windows does not preserve Unix permission bits for ordinary files.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("copied settings mode = %o, want 600", info.Mode().Perm())
 	}
 }
@@ -116,6 +122,7 @@ func TestReviewCommandSeedsPrivateProfileFromHostSettings(t *testing.T) {
 func TestReviewCommandExportsEnvValuesFromHostSettings(t *testing.T) {
 	hostHome := t.TempDir()
 	t.Setenv("HOME", hostHome)
+	t.Setenv("USERPROFILE", hostHome)
 	settings := filepath.Join(hostHome, ".qwen", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(settings), 0o700); err != nil {
 		t.Fatal(err)
@@ -131,7 +138,7 @@ func TestReviewCommandExportsEnvValuesFromHostSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	reviewer := New()
-	reviewer.resolveBinary = func(context.Context) (string, error) { return "/opt/qwen/bin/qwen", nil }
+	reviewer.resolveBinary = func(context.Context) (string, error) { return filepath.Join(t.TempDir(), "qwen"), nil }
 
 	spec, err := reviewer.ReviewCommand(context.Background(), invocation(t))
 	if err != nil {
@@ -163,7 +170,7 @@ func TestReviewCommandRequiresAODataDir(t *testing.T) {
 	inv := invocation(t)
 	inv.DataDir = ""
 	reviewer := New()
-	reviewer.resolveBinary = func(context.Context) (string, error) { return "/opt/qwen/bin/qwen", nil }
+	reviewer.resolveBinary = func(context.Context) (string, error) { return filepath.Join(t.TempDir(), "qwen"), nil }
 	if _, err := reviewer.ReviewCommand(context.Background(), inv); err == nil || !strings.Contains(err.Error(), "AO data directory is required") {
 		t.Fatalf("ReviewCommand error = %v", err)
 	}
@@ -171,13 +178,112 @@ func TestReviewCommandRequiresAODataDir(t *testing.T) {
 
 func TestReviewCommandPreflightShapeNeedsNoRequestData(t *testing.T) {
 	reviewer := New()
-	reviewer.resolveBinary = func(context.Context) (string, error) { return "/opt/qwen/bin/qwen", nil }
+	qwenBinary := filepath.Join(t.TempDir(), "qwen")
+	reviewer.resolveBinary = func(context.Context) (string, error) { return qwenBinary, nil }
 	spec, err := reviewer.ReviewCommand(context.Background(), ports.ReviewInvocation{WorkspacePath: "/ws"})
 	if err != nil {
 		t.Fatalf("ReviewCommand: %v", err)
 	}
-	if !reflect.DeepEqual(spec.Argv, []string{"/opt/qwen/bin/qwen"}) {
+	if !reflect.DeepEqual(spec.Argv, []string{qwenBinary}) {
 		t.Fatalf("argv = %#v", spec.Argv)
+	}
+}
+
+func TestNativeReviewCommandUsesRepositoryAndAOOwnedManifest(t *testing.T) {
+	inv := invocation(t)
+	inv.Config = domain.AgentConfig{Mode: "native-review", NativeReview: &domain.NativeReviewConfig{
+		Effort: "high", Comment: true, Resume: true, Quiet: true, TimeoutMinutes: 7,
+	}}
+	qwenBinary := filepath.Join(t.TempDir(), "qwen")
+	aoBinary := filepath.Join(t.TempDir(), "ao")
+	reviewer := New()
+	reviewer.resolveBinary = func(context.Context) (string, error) { return qwenBinary, nil }
+	reviewer.resolveExecutable = func() (string, error) { return aoBinary, nil }
+
+	spec, err := reviewer.ReviewCommand(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.WorkingDirectory != inv.WorkspacePath {
+		t.Fatalf("working directory = %q, want repository checkout %q", spec.WorkingDirectory, inv.WorkspacePath)
+	}
+	if len(spec.Argv) != 5 || spec.Argv[0] != aoBinary || spec.Argv[1] != "review" || spec.Argv[2] != "qwen-native-run" || spec.Argv[3] != "--manifest" {
+		t.Fatalf("argv = %#v", spec.Argv)
+	}
+	data, err := os.ReadFile(spec.Argv[4])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest nativeqwen.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.QwenBinary != qwenBinary || manifest.WorkspacePath != inv.WorkspacePath || len(manifest.Tasks) != 1 {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+	if manifest.Tasks[0].Options.Resume {
+		t.Fatal("first review must not use --resume without an interrupted same-head predecessor")
+	}
+	if !manifest.Tasks[0].Options.Comment || manifest.Tasks[0].Options.Effort != "high" {
+		t.Fatalf("native options = %+v", manifest.Tasks[0].Options)
+	}
+	if !reviewer.SkipIdleReviewRestore(inv) {
+		t.Fatal("native one-shot reviewer should skip idle terminal restore")
+	}
+}
+
+func TestNativeReviewResumeIsFencedToSameTargetAndHead(t *testing.T) {
+	inv := invocation(t)
+	inv.Config = domain.AgentConfig{Mode: "native-review", NativeReview: &domain.NativeReviewConfig{Resume: true}}
+	inv.PreviousRuns = []domain.ReviewRun{
+		{PRURL: inv.PRURL, TargetSHA: "older", Status: domain.ReviewRunFailed},
+		{PRURL: inv.PRURL, TargetSHA: inv.TargetSHA, Status: domain.ReviewRunCancelled},
+	}
+	reviewer := New()
+	reviewer.resolveBinary = func(context.Context) (string, error) { return filepath.Join(t.TempDir(), "qwen"), nil }
+	reviewer.resolveExecutable = func() (string, error) { return filepath.Join(t.TempDir(), "ao"), nil }
+	spec, err := reviewer.ReviewCommand(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(spec.Argv[4])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest nativeqwen.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if !manifest.Tasks[0].Options.Resume {
+		t.Fatal("same-target interrupted review should use --resume")
+	}
+}
+
+func TestNativeReviewRestoreResumesOnlyRecordedRunningHead(t *testing.T) {
+	inv := invocation(t)
+	inv.RunID, inv.PRURL, inv.TargetSHA = "", "", ""
+	inv.Config = domain.AgentConfig{Mode: "native-review", NativeReview: &domain.NativeReviewConfig{Resume: true}}
+	inv.PreviousRuns = []domain.ReviewRun{
+		{ID: "run-old", PRURL: "pr-old", TargetSHA: "old", Status: domain.ReviewRunComplete},
+		{ID: "run-running", PRURL: "pr-current", TargetSHA: "sha-current", Status: domain.ReviewRunRunning},
+	}
+	reviewer := New()
+	reviewer.resolveBinary = func(context.Context) (string, error) { return filepath.Join(t.TempDir(), "qwen"), nil }
+	reviewer.resolveExecutable = func() (string, error) { return filepath.Join(t.TempDir(), "ao"), nil }
+	spec, ok, err := reviewer.ReviewRestoreCommand(context.Background(), inv)
+	if err != nil || !ok {
+		t.Fatalf("ReviewRestoreCommand ok=%v err=%v", ok, err)
+	}
+	data, err := os.ReadFile(spec.Argv[4])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest nativeqwen.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Tasks) != 1 || manifest.Tasks[0].RunID != "run-running" || !manifest.Tasks[0].Options.Resume {
+		t.Fatalf("restore manifest = %+v", manifest)
 	}
 }
 

--- a/backend/internal/autoreview/coordinator.go
+++ b/backend/internal/autoreview/coordinator.go
@@ -133,6 +133,8 @@ func (c *Coordinator) EvaluateSession(ctx context.Context, id domain.SessionID) 
 			reason = "review_running"
 		case reviewcore.ReviewStateUpToDate:
 			reason = "already_approved"
+		case reviewcore.ReviewStateCommented:
+			reason = "commented_same_sha"
 		case reviewcore.ReviewStateChangesRequested:
 			reason = "changes_requested_same_sha"
 		case reviewcore.ReviewStateIneligible:
@@ -195,6 +197,9 @@ func existingHeadReason(runs []domain.ReviewRun, prURL, targetSHA string) string
 		}
 		if run.Verdict == domain.VerdictApproved {
 			return "already_approved"
+		}
+		if run.Verdict == domain.VerdictComment {
+			return "commented_same_sha"
 		}
 		if run.Verdict == domain.VerdictChangesRequested {
 			return "changes_requested_same_sha"

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -1,18 +1,23 @@
 package cli
 
 import (
+	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/nativeqwen"
 )
 
 // reviewRun mirrors the daemon's domain.ReviewRun for the CLI client.
@@ -63,14 +68,28 @@ type reviewRunResponse struct {
 // submitReviewItem mirrors controllers.SubmitReviewItem.
 type submitReviewItem struct {
 	RunID          string `json:"runId"`
+	Status         string `json:"status,omitempty"`
 	Verdict        string `json:"verdict"`
 	Body           string `json:"body,omitempty"`
 	GithubReviewID string `json:"githubReviewId,omitempty"`
 }
 
+type qwenNativeRecord struct {
+	SchemaVersion   int             `json:"schemaVersion"`
+	NativeTarget    string          `json:"nativeTarget"`
+	TargetSHA       string          `json:"targetSha"`
+	RequestedEffort string          `json:"requestedEffort,omitempty"`
+	EffectiveEffort string          `json:"effectiveEffort,omitempty"`
+	Completion      string          `json:"completion"`
+	Reason          string          `json:"reason,omitempty"`
+	ProviderResult  json.RawMessage `json:"providerResult,omitempty"`
+	RawStdout       string          `json:"rawStdout,omitempty"`
+}
+
 // submitReviewRequest mirrors controllers.SubmitReviewInput.
 type submitReviewRequest struct {
 	RunID          string             `json:"runId,omitempty"`
+	Status         string             `json:"status,omitempty"`
 	Verdict        string             `json:"verdict,omitempty"`
 	Body           string             `json:"body,omitempty"`
 	GithubReviewID string             `json:"githubReviewId,omitempty"`
@@ -103,7 +122,204 @@ func newReviewCommand(ctx *commandContext) *cobra.Command {
 	cmd.AddCommand(newReviewSubmitCommand(ctx))
 	cmd.AddCommand(newReviewCancelCommand(ctx))
 	cmd.AddCommand(newReviewTriggerCommand(ctx))
+	cmd.AddCommand(newQwenNativeRunCommand(ctx))
 	return cmd
+}
+
+func newQwenNativeRunCommand(ctx *commandContext) *cobra.Command {
+	var manifestPath string
+	cmd := &cobra.Command{
+		Use:    "qwen-native-run",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.runQwenNative(cmd, manifestPath)
+		},
+	}
+	cmd.Flags().StringVar(&manifestPath, "manifest", "", "AO-owned native review manifest")
+	return cmd
+}
+
+func (c *commandContext) runQwenNative(cmd *cobra.Command, manifestPath string) error {
+	manifestPath = strings.TrimSpace(manifestPath)
+	if manifestPath == "" {
+		return usageError{errors.New("usage: --manifest is required")}
+	}
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read native Qwen manifest: %w", err)
+	}
+	defer func() { _ = os.Remove(manifestPath) }()
+	var manifest nativeqwen.Manifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return fmt.Errorf("decode native Qwen manifest: %w", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return err
+	}
+	runCtx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+	stopEscapeWatch := watchNativeReviewEscape(runCtx, cmd.InOrStdin(), cancel)
+	defer stopEscapeWatch()
+	failed := 0
+	for _, task := range manifest.Tasks {
+		resultPath := qwenNativeSubmissionPath(manifestPath, task.RunID)
+		item, cached, err := readQwenNativeSubmission(resultPath, task)
+		if err != nil {
+			return err
+		}
+		if !cached {
+			stdout, exitCode, runErr := c.deps.NativeQwenRun(runCtx, manifest.QwenBinary, manifest.WorkspacePath, task, cmd.ErrOrStderr())
+			if runCtx.Err() != nil {
+				return runCtx.Err()
+			}
+			outcome := nativeqwen.Outcome{Status: "failed", Reason: "Qwen review process failed to start"}
+			if runErr == nil {
+				outcome = nativeqwen.Parse(stdout, exitCode)
+			} else {
+				outcome.Reason = runErr.Error()
+			}
+			record := qwenNativeRecord{
+				SchemaVersion:   1,
+				NativeTarget:    task.Target,
+				TargetSHA:       task.TargetSHA,
+				RequestedEffort: task.Options.Effort,
+				EffectiveEffort: effectiveNativeEffort(task.Options),
+				Completion:      outcome.Status,
+				Reason:          outcome.Reason,
+			}
+			if json.Valid(outcome.Raw) {
+				record.ProviderResult = outcome.Raw
+			} else if len(outcome.Raw) > 0 {
+				record.RawStdout = string(outcome.Raw)
+			}
+			body, err := json.MarshalIndent(record, "", "  ")
+			if err != nil {
+				return fmt.Errorf("encode native Qwen result: %w", err)
+			}
+			item = submitReviewRequest{RunID: task.RunID, Status: outcome.Status, Verdict: outcome.Verdict, Body: string(body)}
+			// Persist before contacting AO. If the daemon request fails after Qwen
+			// already posted optional PR comments, restore replays this exact
+			// idempotent submission instead of running the provider a second time.
+			if err := writeQwenNativeSubmission(resultPath, item); err != nil {
+				return fmt.Errorf("persist native Qwen result for run %s: %w", task.RunID, err)
+			}
+		}
+		path := "sessions/" + url.PathEscape(manifest.WorkerSessionID) + "/reviews/submit"
+		var response reviewRunResponse
+		if err := c.postJSON(runCtx, path, item, &response); err != nil {
+			return fmt.Errorf("record native Qwen result for run %s: %w", task.RunID, err)
+		}
+		if err := os.Remove(resultPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove recorded native Qwen result for run %s: %w", task.RunID, err)
+		}
+		if item.Status == "failed" {
+			failed++
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "native Qwen review failed for %s\n", task.Target)
+		} else {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "recorded %s native Qwen review for %s\n", item.Verdict, task.Target)
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d native Qwen review(s) did not produce a verdict", failed)
+	}
+	return nil
+}
+
+func qwenNativeSubmissionPath(manifestPath, runID string) string {
+	hash := sha256.Sum256([]byte(runID))
+	return filepath.Join(filepath.Dir(manifestPath), fmt.Sprintf("native-result-%x.json", hash[:12]))
+}
+
+func readQwenNativeSubmission(path string, task nativeqwen.Task) (submitReviewRequest, bool, error) {
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return submitReviewRequest{}, false, nil
+	}
+	if err != nil {
+		return submitReviewRequest{}, false, fmt.Errorf("read recorded native Qwen result: %w", err)
+	}
+	var item submitReviewRequest
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return submitReviewRequest{}, false, fmt.Errorf("decode recorded native Qwen result: %w", err)
+	}
+	var record qwenNativeRecord
+	if err := json.Unmarshal([]byte(item.Body), &record); err != nil || item.RunID != task.RunID || record.NativeTarget != task.Target || record.TargetSHA != task.TargetSHA {
+		return submitReviewRequest{}, false, errors.New("recorded native Qwen result does not match the current run target")
+	}
+	return item, true, nil
+}
+
+func writeQwenNativeSubmission(path string, item submitReviewRequest) error {
+	raw, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".native-result-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func watchNativeReviewEscape(ctx context.Context, input io.Reader, cancel context.CancelFunc) func() {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 1)
+		for {
+			if _, err := input.Read(buf); err != nil {
+				return
+			}
+			if buf[0] == '\x1b' {
+				cancel()
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
+	}()
+	return func() {
+		// Production uses the wrapper process's stdin file. Closing it releases a
+		// blocked Read when the provider finishes normally, so the input watcher
+		// cannot outlive the one-shot command.
+		if closer, ok := input.(io.Closer); ok {
+			_ = closer.Close()
+			<-done
+			return
+		}
+		select {
+		case <-done:
+		default:
+		}
+	}
+}
+
+func effectiveNativeEffort(options nativeqwen.Options) string {
+	if options.Comment {
+		return "high"
+	}
+	return options.Effort
 }
 
 func newReviewListCommand(ctx *commandContext) *cobra.Command {
@@ -150,7 +366,7 @@ func newReviewSubmitCommand(ctx *commandContext) *cobra.Command {
 	})
 	cmd.Flags().StringVar(&opts.session, "session", "", "Worker session id (or pass it as the positional argument)")
 	cmd.Flags().StringVar(&opts.runID, "run", "", "Review run id (required)")
-	cmd.Flags().StringVar(&opts.verdict, "verdict", "", "Review verdict: approved or changes_requested (required)")
+	cmd.Flags().StringVar(&opts.verdict, "verdict", "", "Review verdict: approved, comment, or changes_requested (required)")
 	cmd.Flags().StringVar(&opts.body, "body", "", "Review body: a path to a Markdown file, or - to read from stdin (so nothing is written into the worktree)")
 	cmd.Flags().StringVar(&opts.reviewID, "review-id", "", "Id of the GitHub PR review just posted (the .id from the gh api POST that created the review)")
 	cmd.Flags().StringVar(&opts.reviews, "reviews", "", "JSON review results array or object: a path, or - to read from stdin")
@@ -174,7 +390,7 @@ func (c *commandContext) submitReview(cmd *cobra.Command, args []string, opts re
 	}
 	verdict := strings.TrimSpace(opts.verdict)
 	if verdict == "" {
-		return usageError{errors.New("usage: --verdict is required (approved or changes_requested)")}
+		return usageError{errors.New("usage: --verdict is required (approved, comment, or changes_requested)")}
 	}
 	var body string
 	if path := strings.TrimSpace(opts.body); path != "" {

--- a/backend/internal/cli/review_test.go
+++ b/backend/internal/cli/review_test.go
@@ -1,14 +1,19 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/nativeqwen"
 )
 
 // reviewCapture records the method/path/body of the request the CLI made.
@@ -427,5 +432,156 @@ func TestReviewActionCommandNames(t *testing.T) {
 				t.Fatalf("request = %s %s", capture.method, capture.path)
 			}
 		})
+	}
+}
+
+func writeNativeManifest(t *testing.T, manifest nativeqwen.Manifest) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "native-review.json")
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestQwenNativeRunSeparatesProgressAndSubmitsStructuredResult(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"verdict":"comment"}}`)
+	writeRunFileFor(t, cfg, srv)
+	manifestPath := writeNativeManifest(t, nativeqwen.Manifest{
+		Version: 1, QwenBinary: "/qwen", WorkerSessionID: "worker-1", WorkspacePath: t.TempDir(),
+		Tasks: []nativeqwen.Task{{RunID: "run-1", Target: "https://github.com/o/r/pull/1", TargetSHA: "abc", Options: nativeqwen.Options{Effort: "medium"}}},
+	})
+	deps := aliveDeps()
+	deps.In = strings.NewReader("")
+	deps.NativeQwenRun = func(_ context.Context, binary, dir string, task nativeqwen.Task, stderr io.Writer) ([]byte, int, error) {
+		if binary != "/qwen" || dir == "" || task.TargetSHA != "abc" {
+			t.Fatalf("run args: binary=%q dir=%q task=%+v", binary, dir, task)
+		}
+		_, _ = io.WriteString(stderr, "provider progress\n")
+		return []byte(`{"completed":true,"verdictLine":"COMMENT","durationMs":12}`), 0, nil
+	}
+	out, errOut, err := executeCLI(t, deps, "review", "qwen-native-run", "--manifest", manifestPath)
+	if err != nil {
+		t.Fatalf("qwen-native-run: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "recorded comment") || !strings.Contains(errOut, "provider progress") {
+		t.Fatalf("stdout=%q stderr=%q", out, errOut)
+	}
+	var req submitReviewRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.RunID != "run-1" || req.Status != "complete" || req.Verdict != "comment" {
+		t.Fatalf("submission = %+v", req)
+	}
+	if strings.Contains(req.Body, "provider progress") || !strings.Contains(req.Body, `"targetSha": "abc"`) || !strings.Contains(req.Body, `"providerResult"`) {
+		t.Fatalf("stored body = %q", req.Body)
+	}
+	if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
+		t.Fatalf("manifest was not removed: %v", err)
+	}
+}
+
+func TestQwenNativeRunReplaysRecordedResultWithoutRepeatingProviderSideEffects(t *testing.T) {
+	cfg := setConfigEnv(t)
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, `{"message":"retry"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"review":{"verdict":"comment"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+	manifest := nativeqwen.Manifest{
+		Version: 1, QwenBinary: "/qwen", WorkerSessionID: "worker-1", WorkspacePath: t.TempDir(),
+		Tasks: []nativeqwen.Task{{RunID: "run-1", Target: "https://github.com/o/r/pull/1", TargetSHA: "abc"}},
+	}
+	manifestPath := writeNativeManifest(t, manifest)
+	rawManifest, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerRuns := 0
+	deps := aliveDeps()
+	deps.In = strings.NewReader("")
+	deps.NativeQwenRun = func(context.Context, string, string, nativeqwen.Task, io.Writer) ([]byte, int, error) {
+		providerRuns++
+		return []byte(`{"completed":true,"event":"COMMENT","verdictLine":"Verdict: Comment","cappedBy":[],"remediation":[]}`), 0, nil
+	}
+	if _, _, err := executeCLI(t, deps, "review", "qwen-native-run", "--manifest", manifestPath); err == nil {
+		t.Fatal("first submission unexpectedly succeeded")
+	}
+	if providerRuns != 1 {
+		t.Fatalf("provider runs after failed submit = %d, want 1", providerRuns)
+	}
+	if err := os.WriteFile(manifestPath, rawManifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps.In = strings.NewReader("")
+	if _, _, err := executeCLI(t, deps, "review", "qwen-native-run", "--manifest", manifestPath); err != nil {
+		t.Fatalf("replay recorded result: %v", err)
+	}
+	if providerRuns != 1 {
+		t.Fatalf("provider was repeated after its result was durable: %d runs", providerRuns)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("AO submission attempts = %d, want 2", requests.Load())
+	}
+	if _, err := os.Stat(qwenNativeSubmissionPath(manifestPath, "run-1")); !os.IsNotExist(err) {
+		t.Fatalf("recorded result was not removed after successful submission: %v", err)
+	}
+}
+
+func TestQwenNativeRunRecordsExitOneAsFailedWithoutVerdict(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"status":"failed"}}`)
+	writeRunFileFor(t, cfg, srv)
+	manifestPath := writeNativeManifest(t, nativeqwen.Manifest{
+		Version: 1, QwenBinary: "/qwen", WorkerSessionID: "worker-1", WorkspacePath: t.TempDir(),
+		Tasks: []nativeqwen.Task{{RunID: "run-1", Target: "pr-1", TargetSHA: "abc"}},
+	})
+	deps := aliveDeps()
+	deps.In = strings.NewReader("")
+	deps.NativeQwenRun = func(context.Context, string, string, nativeqwen.Task, io.Writer) ([]byte, int, error) {
+		return []byte(`{"completed":false,"timedOut":true}`), 1, nil
+	}
+	_, _, err := executeCLI(t, deps, "review", "qwen-native-run", "--manifest", manifestPath)
+	if err == nil {
+		t.Fatal("exit-one result unexpectedly succeeded")
+	}
+	var req submitReviewRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.Status != "failed" || req.Verdict != "" || !strings.Contains(req.Body, "did not produce a verdict") {
+		t.Fatalf("submission = %+v", req)
+	}
+}
+
+func TestQwenNativeRunEscapeCancelsWithoutSubmittingFailure(t *testing.T) {
+	setConfigEnv(t)
+	manifestPath := writeNativeManifest(t, nativeqwen.Manifest{
+		Version: 1, QwenBinary: "/qwen", WorkerSessionID: "worker-1", WorkspacePath: t.TempDir(),
+		Tasks: []nativeqwen.Task{{RunID: "run-1", Target: "pr-1", TargetSHA: "abc"}},
+	})
+	deps := aliveDeps()
+	deps.In = strings.NewReader("\x1b")
+	deps.NativeQwenRun = func(ctx context.Context, _ string, _ string, _ nativeqwen.Task, _ io.Writer) ([]byte, int, error) {
+		<-ctx.Done()
+		return nil, -1, ctx.Err()
+	}
+	_, _, err := executeCLI(t, deps, "review", "qwen-native-run", "--manifest", manifestPath)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context cancellation", err)
 	}
 }

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemon"
+	"github.com/aoagents/agent-orchestrator/backend/internal/nativeqwen"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
 	"github.com/aoagents/agent-orchestrator/backend/internal/telemetrymeta"
@@ -73,6 +74,7 @@ type Deps struct {
 	CommandOutputInDir    func(ctx context.Context, dir, name string, args ...string) ([]byte, error)
 	RunInteractiveCommand func(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error
 	ReadSecret            func(io.Reader) ([]byte, error)
+	NativeQwenRun         func(ctx context.Context, binary, dir string, task nativeqwen.Task, stderr io.Writer) ([]byte, int, error)
 	// DoctorGitHubRESTBase lets tests point the doctor GitHub token probe at
 	// httptest without mutating package-global state.
 	DoctorGitHubRESTBase string
@@ -98,6 +100,7 @@ func DefaultDeps() Deps {
 		CommandOutputInDir:    commandOutputInDir,
 		RunInteractiveCommand: runInteractiveCommand,
 		ReadSecret:            readSecret,
+		NativeQwenRun:         nativeqwen.Run,
 		DoctorGitHubRESTBase:  defaultDoctorGitHubRESTBase,
 		DoctorGitLabRESTBase:  defaultDoctorGitLabRESTBase,
 		Now:                   time.Now,
@@ -152,6 +155,9 @@ func (d Deps) withDefaults() Deps {
 	}
 	if d.ReadSecret == nil {
 		d.ReadSecret = def.ReadSecret
+	}
+	if d.NativeQwenRun == nil {
+		d.NativeQwenRun = def.NativeQwenRun
 	}
 	if d.DoctorGitHubRESTBase == "" {
 		d.DoctorGitHubRESTBase = def.DoctorGitHubRESTBase

--- a/backend/internal/domain/agentconfig.go
+++ b/backend/internal/domain/agentconfig.go
@@ -31,12 +31,42 @@ type AgentConfig struct {
 	// Permissions sets the agent's starting permission mode. Empty is treated
 	// like the adapter's default mode.
 	Permissions PermissionMode `json:"permissions,omitempty"`
+	// NativeReview configures an adapter-owned, non-interactive review command.
+	// It is currently consumed only when Qwen's mode is "native-review"; keeping
+	// these flags typed prevents arbitrary provider argv from crossing the API.
+	NativeReview *NativeReviewConfig `json:"nativeReview,omitempty"`
+}
+
+// NativeReviewConfig is the typed option set shared with Qwen Code's native
+// review command. Zero values deliberately defer to Qwen's own defaults.
+type NativeReviewConfig struct {
+	Effort         string `json:"effort,omitempty" enum:"low,medium,high"`
+	Comment        bool   `json:"comment,omitempty"`
+	Resume         bool   `json:"resume,omitempty"`
+	Quiet          bool   `json:"quiet,omitempty"`
+	TimeoutMinutes int    `json:"timeoutMinutes,omitempty"`
 }
 
 // IsZero reports whether the config carries no settings, so storage can persist
 // SQL NULL and resolution can skip an empty config.
 func (c AgentConfig) IsZero() bool {
 	return c == AgentConfig{}
+}
+
+// Equal compares configuration values rather than pointer identity. Native
+// review options arrive through JSON as fresh pointers on every read.
+func (c AgentConfig) Equal(other AgentConfig) bool {
+	if c.Model != other.Model || c.Mode != other.Mode || c.Permissions != other.Permissions {
+		return false
+	}
+	left, right := NativeReviewConfig{}, NativeReviewConfig{}
+	if c.NativeReview != nil {
+		left = *c.NativeReview
+	}
+	if other.NativeReview != nil {
+		right = *other.NativeReview
+	}
+	return left == right
 }
 
 // Valid reports whether the mode is one AO knows. Empty counts as valid: it means
@@ -56,12 +86,40 @@ func (m PermissionMode) Valid() bool {
 // refused when it is set (CLI/API) rather than silently dropped at spawn.
 func (c AgentConfig) Validate() error {
 	switch c.Mode {
-	case "", "low", "medium", "high", "ultra":
+	case "", "low", "medium", "high", "ultra", "native-review":
 	default:
-		return fmt.Errorf("invalid mode %q: want one of low, medium, high, ultra", c.Mode)
+		return fmt.Errorf("invalid mode %q: want one of low, medium, high, ultra, native-review", c.Mode)
+	}
+	if c.NativeReview != nil {
+		if c.Mode != "native-review" {
+			return fmt.Errorf("nativeReview requires mode %q", "native-review")
+		}
+		switch c.NativeReview.Effort {
+		case "", "low", "medium", "high":
+		default:
+			return fmt.Errorf("invalid nativeReview.effort %q: want one of low, medium, high", c.NativeReview.Effort)
+		}
+		if c.NativeReview.Comment && (c.NativeReview.Effort == "low" || c.NativeReview.Effort == "medium") {
+			return fmt.Errorf("nativeReview.comment requires effort high or omitted")
+		}
+		if c.NativeReview.TimeoutMinutes < 0 {
+			return fmt.Errorf("nativeReview.timeoutMinutes must be positive when set")
+		}
 	}
 	if c.Permissions.Valid() {
 		return nil
 	}
 	return fmt.Errorf("invalid permissions %q: want one of default, accept-edits, auto, bypass-permissions", c.Permissions)
+}
+
+// ValidateReviewer applies the provider boundary that the generic config
+// vocabulary cannot express: native-review is a Qwen-only reviewer mode.
+func (c AgentConfig) ValidateReviewer(harness ReviewerHarness) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	if (c.Mode == "native-review" || c.NativeReview != nil) && harness != ReviewerQwen {
+		return fmt.Errorf("native-review mode requires reviewer harness %q", ReviewerQwen)
+	}
+	return nil
 }

--- a/backend/internal/domain/agentconfig_native_review_test.go
+++ b/backend/internal/domain/agentconfig_native_review_test.go
@@ -1,0 +1,72 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNativeReviewConfigValidation(t *testing.T) {
+	valid := []AgentConfig{
+		{Mode: "native-review"},
+		{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "medium", TimeoutMinutes: 120}},
+		{Mode: "native-review", NativeReview: &NativeReviewConfig{Comment: true}},
+		{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "high", Comment: true}},
+	}
+	for _, config := range valid {
+		if err := config.Validate(); err != nil {
+			t.Fatalf("Validate(%+v): %v", config, err)
+		}
+	}
+	invalid := []AgentConfig{
+		{NativeReview: &NativeReviewConfig{}},
+		{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "ultra"}},
+		{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "medium", Comment: true}},
+		{Mode: "native-review", NativeReview: &NativeReviewConfig{TimeoutMinutes: -1}},
+	}
+	for _, config := range invalid {
+		if err := config.Validate(); err == nil {
+			t.Fatalf("Validate(%+v) unexpectedly succeeded", config)
+		}
+	}
+}
+
+func TestNativeReviewConfigValidationDoesNotAcceptUnrestrictedMode(t *testing.T) {
+	err := (AgentConfig{Mode: "qwen review run --yolo"}).Validate()
+	if err == nil || !strings.Contains(err.Error(), "invalid mode") {
+		t.Fatalf("Validate error = %v", err)
+	}
+}
+
+func TestAgentConfigEqualComparesNativeOptionsByValue(t *testing.T) {
+	left := AgentConfig{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "high", Quiet: true}}
+	right := AgentConfig{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "high", Quiet: true}}
+	if !left.Equal(right) {
+		t.Fatal("equal native-review values compared unequal")
+	}
+	if (AgentConfig{Mode: "native-review"}).Equal(AgentConfig{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "high"}}) {
+		t.Fatal("different native-review values compared equal")
+	}
+}
+
+func TestNativeReviewConfigIsQwenReviewerOnly(t *testing.T) {
+	config := AgentConfig{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "high"}}
+	if err := config.ValidateReviewer(ReviewerQwen); err != nil {
+		t.Fatalf("Qwen native review rejected: %v", err)
+	}
+	if err := config.ValidateReviewer(ReviewerClaudeCode); err == nil {
+		t.Fatal("non-Qwen native review unexpectedly accepted")
+	}
+}
+
+func TestProjectConfigRestrictsNativeReviewToQwenReviewer(t *testing.T) {
+	native := AgentConfig{Mode: "native-review", NativeReview: &NativeReviewConfig{Effort: "medium"}}
+	if err := (ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerQwen, AgentConfig: native}}}).Validate(); err != nil {
+		t.Fatalf("Qwen reviewer project config rejected: %v", err)
+	}
+	if err := (ProjectConfig{Reviewers: []ReviewerConfig{{Harness: ReviewerClaudeCode, AgentConfig: native}}}).Validate(); err == nil {
+		t.Fatal("non-Qwen reviewer project config unexpectedly accepted")
+	}
+	if err := (ProjectConfig{AgentConfig: native}).Validate(); err == nil {
+		t.Fatal("worker native-review config unexpectedly accepted")
+	}
+}

--- a/backend/internal/domain/projectconfig.go
+++ b/backend/internal/domain/projectconfig.go
@@ -173,6 +173,9 @@ func (c ProjectConfig) Validate() error {
 	if err := c.AgentConfig.Validate(); err != nil {
 		return err
 	}
+	if c.AgentConfig.Mode == "native-review" || c.AgentConfig.NativeReview != nil {
+		return fmt.Errorf("agentConfig: native-review is only valid for reviewers")
+	}
 	if err := validateNameComponent("sessionPrefix", c.SessionPrefix); err != nil {
 		return err
 	}
@@ -182,6 +185,9 @@ func (c ProjectConfig) Validate() error {
 		}
 		if err := ro.AgentConfig.Validate(); err != nil {
 			return fmt.Errorf("%s.%w", role, err)
+		}
+		if ro.AgentConfig.Mode == "native-review" || ro.AgentConfig.NativeReview != nil {
+			return fmt.Errorf("%s.agentConfig: native-review is only valid for reviewers", role)
 		}
 	}
 	for _, s := range c.Symlinks {
@@ -196,7 +202,7 @@ func (c ProjectConfig) Validate() error {
 		if !rv.Harness.IsKnown() {
 			return fmt.Errorf("reviewers[%d].harness: unknown harness %q", i, rv.Harness)
 		}
-		if err := rv.AgentConfig.Validate(); err != nil {
+		if err := rv.AgentConfig.ValidateReviewer(rv.Harness); err != nil {
 			return fmt.Errorf("reviewers[%d].%w", i, err)
 		}
 	}

--- a/backend/internal/domain/review.go
+++ b/backend/internal/domain/review.go
@@ -94,6 +94,7 @@ type ReviewVerdict = contract.AOReviewVerdict
 const (
 	VerdictNone             = contract.AOReviewVerdictNone
 	VerdictApproved         = contract.AOReviewVerdictApproved
+	VerdictComment          = contract.AOReviewVerdictComment
 	VerdictChangesRequested = contract.AOReviewVerdictChangesRequested
 )
 

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6558,6 +6558,8 @@ components:
           type: string
         model:
           type: string
+        nativeReview:
+          $ref: '#/components/schemas/DomainNativeReviewConfig'
         permissions:
           type: string
       type: object
@@ -8668,6 +8670,23 @@ components:
       - state
       - lastActivityAt
       type: object
+    DomainNativeReviewConfig:
+      properties:
+        comment:
+          type: boolean
+        effort:
+          enum:
+          - low
+          - medium
+          - high
+          type: string
+        quiet:
+          type: boolean
+        resume:
+          type: boolean
+        timeoutMinutes:
+          type: integer
+      type: object
     DomainReviewerConfig:
       properties:
         agentConfig:
@@ -9474,6 +9493,7 @@ components:
           - needs_review
           - running
           - up_to_date
+          - commented
           - changes_requested
           - ineligible
           type: string
@@ -10981,8 +11001,19 @@ components:
         runId:
           description: Review run id being completed.
           type: string
+        status:
+          description: Terminal result status; defaults to complete. Native one-shot
+            reviewers may report failed.
+          enum:
+          - complete
+          - failed
+          type: string
         verdict:
-          description: 'Review verdict: approved or changes_requested.'
+          description: 'Review verdict: approved, comment, or changes_requested.'
+          enum:
+          - approved
+          - comment
+          - changes_requested
           type: string
       type: object
     SubmitReviewItem:
@@ -10996,12 +11027,23 @@ components:
         runId:
           description: Review run id being completed.
           type: string
+        status:
+          description: Terminal result status; defaults to complete. Native one-shot
+            reviewers may report failed.
+          enum:
+          - complete
+          - failed
+          type: string
         verdict:
-          description: 'Review verdict: approved or changes_requested.'
+          description: 'Review verdict: approved, comment, or changes_requested. Required
+            when status is complete.'
+          enum:
+          - approved
+          - comment
+          - changes_requested
           type: string
       required:
       - runId
-      - verdict
       type: object
     SwitchAgentRequest:
       properties:

--- a/backend/internal/httpd/controllers/reviews.go
+++ b/backend/internal/httpd/controllers/reviews.go
@@ -74,7 +74,8 @@ type KillReviewResponse struct {
 // SubmitReviewItem is one review result in a batched submit request.
 type SubmitReviewItem struct {
 	RunID          string `json:"runId" description:"Review run id being completed."`
-	Verdict        string `json:"verdict" description:"Review verdict: approved or changes_requested."`
+	Status         string `json:"status,omitempty" description:"Terminal result status; defaults to complete. Native one-shot reviewers may report failed." enum:"complete,failed"`
+	Verdict        string `json:"verdict,omitempty" description:"Review verdict: approved, comment, or changes_requested. Required when status is complete." enum:"approved,comment,changes_requested"`
 	Body           string `json:"body,omitempty" description:"Review body recorded by AO. Required for changes_requested."`
 	GithubReviewID string `json:"githubReviewId,omitempty" description:"Id of the GitHub PR review the reviewer posted, if any."`
 }
@@ -82,7 +83,8 @@ type SubmitReviewItem struct {
 // SubmitReviewInput is the body of POST /api/v1/sessions/{sessionId}/reviews/submit.
 type SubmitReviewInput struct {
 	RunID          string             `json:"runId,omitempty" description:"Review run id being completed."`
-	Verdict        string             `json:"verdict,omitempty" description:"Review verdict: approved or changes_requested."`
+	Status         string             `json:"status,omitempty" description:"Terminal result status; defaults to complete. Native one-shot reviewers may report failed." enum:"complete,failed"`
+	Verdict        string             `json:"verdict,omitempty" description:"Review verdict: approved, comment, or changes_requested." enum:"approved,comment,changes_requested"`
 	Body           string             `json:"body,omitempty" description:"Review body recorded by AO. Required for changes_requested."`
 	GithubReviewID string             `json:"githubReviewId,omitempty" description:"Id of the GitHub PR review the reviewer posted, if any."`
 	Reviews        []SubmitReviewItem `json:"reviews,omitempty" description:"Batched review results recorded by one reviewer CLI command."`
@@ -360,6 +362,7 @@ func (c *ReviewsController) submit(w http.ResponseWriter, r *http.Request) {
 		for _, item := range in.Reviews {
 			reviews = append(reviews, reviewsvc.SubmittedReview{
 				RunID:          item.RunID,
+				Status:         domain.ReviewRunStatus(item.Status),
 				Verdict:        domain.ReviewVerdict(item.Verdict),
 				Body:           item.Body,
 				GithubReviewID: item.GithubReviewID,
@@ -368,6 +371,7 @@ func (c *ReviewsController) submit(w http.ResponseWriter, r *http.Request) {
 	} else {
 		reviews = append(reviews, reviewsvc.SubmittedReview{
 			RunID:          in.RunID,
+			Status:         domain.ReviewRunStatus(in.Status),
 			Verdict:        domain.ReviewVerdict(in.Verdict),
 			Body:           in.Body,
 			GithubReviewID: in.GithubReviewID,

--- a/backend/internal/nativeqwen/native.go
+++ b/backend/internal/nativeqwen/native.go
@@ -1,0 +1,279 @@
+// Package nativeqwen implements the bounded process and result contract for
+// Qwen Code's non-interactive `review run` command.
+package nativeqwen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Options are the typed Qwen-owned review flags AO permits.
+type Options struct {
+	Effort         string `json:"effort,omitempty"`
+	Comment        bool   `json:"comment,omitempty"`
+	Resume         bool   `json:"resume,omitempty"`
+	Quiet          bool   `json:"quiet,omitempty"`
+	TimeoutMinutes int    `json:"timeoutMinutes,omitempty"`
+}
+
+// Task binds one provider invocation to the immutable AO review run and PR head.
+type Task struct {
+	RunID     string  `json:"runId"`
+	Target    string  `json:"target"`
+	TargetSHA string  `json:"targetSha"`
+	Options   Options `json:"options,omitempty"`
+}
+
+// Manifest is written by the reviewer adapter and consumed by AO's hidden
+// one-shot command. The target is adapter-derived, never an extra argv string.
+type Manifest struct {
+	Version         int    `json:"version"`
+	QwenBinary      string `json:"qwenBinary"`
+	WorkerSessionID string `json:"workerSessionId"`
+	WorkspacePath   string `json:"workspacePath"`
+	Tasks           []Task `json:"tasks"`
+}
+
+func (m Manifest) Validate() error {
+	if m.Version != 1 {
+		return fmt.Errorf("unsupported native Qwen manifest version %d", m.Version)
+	}
+	if strings.TrimSpace(m.QwenBinary) == "" || strings.TrimSpace(m.WorkerSessionID) == "" || strings.TrimSpace(m.WorkspacePath) == "" {
+		return errors.New("native Qwen manifest is missing binary, worker session, or workspace")
+	}
+	if len(m.Tasks) == 0 {
+		return errors.New("native Qwen manifest has no review tasks")
+	}
+	for i, task := range m.Tasks {
+		if strings.TrimSpace(task.RunID) == "" || strings.TrimSpace(task.Target) == "" || strings.TrimSpace(task.TargetSHA) == "" {
+			return fmt.Errorf("native Qwen task %d is missing run, target, or target SHA", i)
+		}
+		if err := task.Options.Validate(); err != nil {
+			return fmt.Errorf("native Qwen task %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (o Options) Validate() error {
+	switch o.Effort {
+	case "", "low", "medium", "high":
+	default:
+		return fmt.Errorf("invalid effort %q", o.Effort)
+	}
+	if o.Comment && (o.Effort == "low" || o.Effort == "medium") {
+		return errors.New("comment requires high or provider-default effort")
+	}
+	if o.TimeoutMinutes < 0 {
+		return errors.New("timeout minutes must be positive when set")
+	}
+	const maxTimeoutMinutes = int64((time.Duration(1<<63 - 1)) / time.Minute)
+	if int64(o.TimeoutMinutes) > maxTimeoutMinutes {
+		return errors.New("timeout minutes exceed the supported duration")
+	}
+	return nil
+}
+
+// Args returns the exact native provider argv after the executable.
+func Args(task Task) ([]string, error) {
+	if err := task.Options.Validate(); err != nil {
+		return nil, err
+	}
+	args := []string{"review", "run", task.Target}
+	if task.Options.Effort != "" {
+		args = append(args, "--effort", task.Options.Effort)
+	}
+	args = append(args, "--json", "--fail-on", "request-changes")
+	if task.Options.Comment {
+		args = append(args, "--comment")
+	}
+	if task.Options.Resume {
+		args = append(args, "--resume")
+	}
+	if task.Options.Quiet {
+		args = append(args, "--quiet")
+	}
+	if task.Options.TimeoutMinutes > 0 {
+		args = append(args, "--timeout-minutes", fmt.Sprint(task.Options.TimeoutMinutes))
+	}
+	return args, nil
+}
+
+// ProviderResult contains the stable fields AO consumes. Raw JSON is retained
+// separately so newer Qwen findings remain available without widening this type.
+type ProviderResult struct {
+	Completed            bool     `json:"completed"`
+	Event                string   `json:"event,omitempty"`
+	VerdictLine          string   `json:"verdictLine,omitempty"`
+	BaseEvent            string   `json:"baseEvent,omitempty"`
+	CappedBy             []string `json:"cappedBy,omitempty"`
+	Downgraded           bool     `json:"downgraded,omitempty"`
+	DowngradedFrom       string   `json:"downgradedFrom,omitempty"`
+	Remediation          []string `json:"remediation,omitempty"`
+	ComposedPath         string   `json:"composedPath,omitempty"`
+	ExpectedComposedName string   `json:"expectedComposedName,omitempty"`
+	ReportPath           string   `json:"reportPath,omitempty"`
+	ChildExitCode        *int     `json:"childExitCode,omitempty"`
+	ChildSignal          *string  `json:"childSignal,omitempty"`
+	TimedOut             bool     `json:"timedOut,omitempty"`
+	DurationMS           int64    `json:"durationMs,omitempty"`
+}
+
+// Outcome is AO's normalized terminal observation of one provider process.
+type Outcome struct {
+	Status  string
+	Verdict string
+	Result  ProviderResult
+	Raw     json.RawMessage
+	Reason  string
+}
+
+// Parse maps Qwen's documented exit/JSON pair. It fails closed whenever the
+// process and payload disagree; exit 3 is a completed blocking review, not an
+// infrastructure failure.
+func Parse(stdout []byte, exitCode int) Outcome {
+	raw := bytes.TrimSpace(stdout)
+	var result ProviderResult
+	if len(raw) == 0 || json.Unmarshal(raw, &result) != nil {
+		return Outcome{Status: "failed", Raw: append(json.RawMessage(nil), raw...), Reason: "missing or malformed Qwen JSON result"}
+	}
+	base := Outcome{Result: result, Raw: append(json.RawMessage(nil), raw...)}
+	if exitCode == 1 {
+		base.Status = "failed"
+		base.Reason = "Qwen review did not produce a verdict"
+		return base
+	}
+	if exitCode != 0 && exitCode != 3 {
+		base.Status = "failed"
+		base.Reason = fmt.Sprintf("unexpected Qwen exit code %d", exitCode)
+		return base
+	}
+	if !result.Completed {
+		base.Status = "failed"
+		base.Reason = "Qwen reported an incomplete review"
+		return base
+	}
+	verdict, consistent := normalizedResultVerdict(result)
+	if !consistent {
+		base.Status, base.Reason = "failed", "Qwen event and verdict line disagree"
+		return base
+	}
+	// A completed result with no event is a valid non-approval observation for
+	// low-effort and up-to-date/empty-diff stops. Preserve it as AO's neutral
+	// comment verdict; treating it as an approval would weaken the gate, while
+	// treating it as infrastructure failure would make Qwen's valid exit-0
+	// contract unusable.
+	if verdict == "" {
+		verdict = "comment"
+	}
+	switch verdict {
+	case "approved":
+		if exitCode != 0 {
+			base.Status, base.Reason = "failed", "Qwen approval used a blocking exit code"
+			return base
+		}
+		base.Status, base.Verdict = "complete", "approved"
+	case "comment":
+		if exitCode != 0 {
+			base.Status, base.Reason = "failed", "Qwen comment used a blocking exit code"
+			return base
+		}
+		base.Status, base.Verdict = "complete", "comment"
+	case "changes_requested":
+		if exitCode != 3 {
+			base.Status, base.Reason = "failed", "Qwen request-changes verdict did not use exit code 3"
+			return base
+		}
+		base.Status, base.Verdict = "complete", "changes_requested"
+	default:
+		base.Status, base.Reason = "failed", "Qwen completed without a recognized verdict"
+	}
+	return base
+}
+
+func normalizedResultVerdict(result ProviderResult) (string, bool) {
+	event := normalizeVerdict(result.Event)
+	line := normalizeVerdict(result.VerdictLine)
+	if strings.TrimSpace(result.Event) != "" && event == "" {
+		return "", false
+	}
+	if event != "" && line != "" && event != line {
+		return "", false
+	}
+	if event != "" {
+		return event, true
+	}
+	return line, true
+}
+
+func normalizeVerdict(value string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	normalized = strings.TrimPrefix(normalized, "VERDICT:")
+	normalized = strings.TrimSpace(normalized)
+	switch normalized {
+	case "APPROVE", "APPROVED":
+		return "approved"
+	case "COMMENT", "COMMENTED":
+		return "comment"
+	case "REQUEST_CHANGES", "CHANGES_REQUESTED", "REQUEST CHANGES":
+		return "changes_requested"
+	}
+	// Verdict lines may include explanatory suffixes or finding counts. The
+	// provider's first disposition token remains stable; never inspect the last
+	// word, which is commonly part of that explanation.
+	if strings.HasPrefix(normalized, "APPROVE ") || strings.HasPrefix(normalized, "APPROVED ") {
+		return "approved"
+	}
+	if strings.HasPrefix(normalized, "COMMENT ") || strings.HasPrefix(normalized, "COMMENTED ") {
+		return "comment"
+	}
+	if strings.HasPrefix(normalized, "REQUEST_CHANGES ") || strings.HasPrefix(normalized, "CHANGES_REQUESTED ") || strings.HasPrefix(normalized, "REQUEST CHANGES ") {
+		return "changes_requested"
+	}
+	return ""
+}
+
+// Run performs one provider observation with separate stdout and stderr. The
+// process is placed in its own group so context cancellation kills descendants.
+func Run(ctx context.Context, binary, dir string, task Task, stderr io.Writer) ([]byte, int, error) {
+	args, err := Args(task)
+	if err != nil {
+		return nil, -1, err
+	}
+	runCtx, cancel := withTaskTimeout(ctx, task.Options.TimeoutMinutes)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, binary, args...) //nolint:gosec // binary and target are adapter-derived, typed manifest values.
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+	configureProcess(cmd)
+	cmd.Cancel = func() error { return killProcessTree(cmd) }
+	cmd.WaitDelay = 5 * time.Second
+	err = cmd.Run()
+	if err == nil {
+		return stdout.Bytes(), 0, nil
+	}
+	if runCtx.Err() != nil {
+		return stdout.Bytes(), -1, runCtx.Err()
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return stdout.Bytes(), exitErr.ExitCode(), nil
+	}
+	return stdout.Bytes(), -1, err
+}
+
+func withTaskTimeout(ctx context.Context, minutes int) (context.Context, context.CancelFunc) {
+	if minutes <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, time.Duration(minutes)*time.Minute)
+}

--- a/backend/internal/nativeqwen/native.go
+++ b/backend/internal/nativeqwen/native.go
@@ -41,6 +41,7 @@ type Manifest struct {
 	Tasks           []Task `json:"tasks"`
 }
 
+// Validate rejects incomplete manifests before AO starts a provider process.
 func (m Manifest) Validate() error {
 	if m.Version != 1 {
 		return fmt.Errorf("unsupported native Qwen manifest version %d", m.Version)
@@ -62,6 +63,7 @@ func (m Manifest) Validate() error {
 	return nil
 }
 
+// Validate rejects unsupported or internally inconsistent Qwen review options.
 func (o Options) Validate() error {
 	switch o.Effort {
 	case "", "low", "medium", "high":

--- a/backend/internal/nativeqwen/native_test.go
+++ b/backend/internal/nativeqwen/native_test.go
@@ -1,0 +1,83 @@
+package nativeqwen
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestArgsBuildsOnlyTypedNativeReviewFlags(t *testing.T) {
+	task := Task{Target: "https://github.com/o/r/pull/42", Options: Options{
+		Effort: "high", Comment: true, Resume: true, Quiet: true, TimeoutMinutes: 9,
+	}}
+	got, err := Args(task)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"review", "run", "https://github.com/o/r/pull/42",
+		"--effort", "high", "--json", "--fail-on", "request-changes",
+		"--comment", "--resume", "--quiet", "--timeout-minutes", "9",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Args() = %#v, want %#v", got, want)
+	}
+}
+
+func TestOptionsRejectsCommentWithLowerEffort(t *testing.T) {
+	for _, effort := range []string{"low", "medium"} {
+		if err := (Options{Effort: effort, Comment: true}).Validate(); err == nil {
+			t.Fatalf("effort %q with comment unexpectedly valid", effort)
+		}
+	}
+}
+
+func TestParseMapsDocumentedExitContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		exitCode int
+		status   string
+		verdict  string
+	}{
+		{"approve", `{"completed":true,"event":"APPROVE","verdictLine":"Verdict: Approve","cappedBy":[],"remediation":[],"childExitCode":0}`, 0, "complete", "approved"},
+		{"comment with suffix", `{"completed":true,"event":"COMMENT","verdictLine":"Verdict: Comment — Request changes was downgraded","cappedBy":["self-authored PR"],"remediation":["review manually"]}`, 0, "complete", "comment"},
+		{"request changes", `{"completed":true,"event":"REQUEST_CHANGES","verdictLine":"Verdict: Request changes (2 Critical)","cappedBy":[]}`, 3, "complete", "changes_requested"},
+		{"completed without event", `{"completed":true,"event":null,"verdictLine":null,"cappedBy":[],"remediation":[]}`, 0, "complete", "comment"},
+		{"provider failure", `{"completed":false,"timedOut":true}`, 1, "failed", ""},
+		{"malformed", `{nope`, 0, "failed", ""},
+		{"exit mismatch", `{"completed":true,"event":"REQUEST_CHANGES","verdictLine":"Verdict: Request changes"}`, 0, "failed", ""},
+		{"event mismatch", `{"completed":true,"event":"APPROVE","verdictLine":"Verdict: Comment"}`, 0, "failed", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse([]byte(tt.json), tt.exitCode)
+			if got.Status != tt.status || got.Verdict != tt.verdict {
+				t.Fatalf("Parse() = status %q verdict %q reason %q", got.Status, got.Verdict, got.Reason)
+			}
+		})
+	}
+}
+
+func TestRunHonorsCancelledContextBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := Run(ctx, "does-not-run", t.TempDir(), Task{Target: "target"}, nil)
+	if err == nil {
+		t.Fatal("Run() error = nil, want cancellation/start failure")
+	}
+}
+
+func TestTaskTimeoutBoundsProviderContext(t *testing.T) {
+	ctx, cancel := withTaskTimeout(context.Background(), 2)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("configured native review timeout did not set a process deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= time.Minute || remaining > 2*time.Minute {
+		t.Fatalf("process deadline is %s away, want at most two minutes", remaining)
+	}
+}

--- a/backend/internal/nativeqwen/process_unix.go
+++ b/backend/internal/nativeqwen/process_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package nativeqwen
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killProcessTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/nativeqwen/process_unix_test.go
+++ b/backend/internal/nativeqwen/process_unix_test.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package nativeqwen
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureProcessCreatesCancellableProcessGroup(t *testing.T) {
+	cmd := exec.Command("true")
+	configureProcess(cmd)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Fatalf("process attributes = %#v, want Setpgid", cmd.SysProcAttr)
+	}
+}

--- a/backend/internal/nativeqwen/process_windows.go
+++ b/backend/internal/nativeqwen/process_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package nativeqwen
+
+import (
+	"os/exec"
+	"strconv"
+
+	"golang.org/x/sys/windows"
+)
+
+func configureProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &windows.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP,
+		HideWindow:    true,
+	}
+}
+
+func killProcessTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	kill := exec.Command("taskkill", "/PID", strconv.Itoa(cmd.Process.Pid), "/T", "/F") //nolint:gosec // PID comes from the child we just started.
+	kill.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW, HideWindow: true}
+	if err := kill.Run(); err != nil {
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/backend/internal/nativeqwen/process_windows_test.go
+++ b/backend/internal/nativeqwen/process_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package nativeqwen
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureProcessCreatesCancellableProcessGroup(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit 0")
+	configureProcess(cmd)
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Fatalf("creation flags = %#v, want CREATE_NEW_PROCESS_GROUP", cmd.SysProcAttr)
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Fatal("native review child window should be hidden")
+	}
+}

--- a/backend/internal/ports/reviewer.go
+++ b/backend/internal/ports/reviewer.go
@@ -61,6 +61,13 @@ type ReviewerRestorer interface {
 	ReviewRestoreCommand(ctx context.Context, inv ReviewInvocation) (cmd ReviewCommandSpec, ok bool, err error)
 }
 
+// ReviewerIdleRestorePolicy lets one-shot reviewers opt out of recreating an
+// idle terminal after daemon restart. A native process exists only while a
+// concrete review run is active, so relaunching it without a run is incorrect.
+type ReviewerIdleRestorePolicy interface {
+	SkipIdleReviewRestore(inv ReviewInvocation) bool
+}
+
 // ReviewerReusePolicy is implemented by interactive reviewer adapters that
 // need a fresh TUI for each task because request-scoped context is fixed at
 // process launch. Returning false forces a fresh launch for every pass.
@@ -99,6 +106,9 @@ type ReviewInvocation struct {
 	ReviewQueue []ReviewTask
 	// ReviewIndex is this invocation's zero-based position in ReviewQueue.
 	ReviewIndex int
+	// PreviousRuns lets a one-shot adapter decide whether a provider-native
+	// resume belongs to the exact same review target and head.
+	PreviousRuns []domain.ReviewRun
 	// Config carries the reviewer's resolved agent configuration override.
 	Config domain.AgentConfig
 	// WorkspacePath is the worker's checkout the reviewer reads.

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -249,6 +249,7 @@ func (l *agentLauncher) invocation(spec LaunchSpec) ports.ReviewInvocation {
 		TargetSHA:       spec.TargetSHA,
 		ReviewQueue:     spec.ReviewQueue,
 		ReviewIndex:     spec.ReviewIndex,
+		PreviousRuns:    spec.PreviousRuns,
 		Config:          spec.AgentConfig,
 		WorkspacePath:   spec.WorkspacePath,
 		DataDir:         l.dataDir,
@@ -324,6 +325,7 @@ func (l *agentLauncher) prepareIdleInvocation(spec LaunchSpec) (ports.ReviewInvo
 		ReviewerID:       reviewerHandleID(spec.WorkerID),
 		WorkerSessionID:  spec.WorkerID,
 		AgentSessionID:   spec.AgentSessionID,
+		PreviousRuns:     spec.PreviousRuns,
 		Config:           spec.AgentConfig,
 		WorkspacePath:    spec.WorkspacePath,
 		DataDir:          l.dataDir,
@@ -399,6 +401,11 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 	reviewer, ok := l.reviewers.Reviewer(spec.Harness)
 	if !ok {
 		return LaunchResult{}, fmt.Errorf("no reviewer adapter for harness %q", spec.Harness)
+	}
+	if restoring {
+		if policy, ok := reviewer.(ports.ReviewerIdleRestorePolicy); ok && policy.SkipIdleReviewRestore(inv) {
+			return LaunchResult{}, nil
+		}
 	}
 	if pl, ok := reviewer.(preLaunchReviewer); ok {
 		if err := pl.PreLaunch(ctx, inv); err != nil {

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -249,6 +249,16 @@ type fakeRestoringReviewer struct {
 	restoreOK   bool
 }
 
+type fakeIdleRestorePolicyReviewer struct {
+	fakeReviewer
+	gotPolicy ports.ReviewInvocation
+}
+
+func (f *fakeIdleRestorePolicyReviewer) SkipIdleReviewRestore(inv ports.ReviewInvocation) bool {
+	f.gotPolicy = inv
+	return true
+}
+
 func (f *fakeRestoringReviewer) ReviewRestoreCommand(_ context.Context, inv ports.ReviewInvocation) (ports.ReviewCommandSpec, bool, error) {
 	f.restored = true
 	f.gotRestore = inv
@@ -531,6 +541,25 @@ func TestLauncherRestoreTerminalStartsIdlePane(t *testing.T) {
 	}
 	if reviewer.gotInv.DataDir != dataDir {
 		t.Fatalf("restore invocation data dir = %q, want %q", reviewer.gotInv.DataDir, dataDir)
+	}
+}
+
+func TestLauncherRestoreTerminalLetsOneShotReviewerSkipIdlePane(t *testing.T) {
+	reviewer := &fakeIdleRestorePolicyReviewer{}
+	rt := &fakeRuntime{}
+	l := newTestLauncher(t, reviewer, rt)
+	spec := launchSpec()
+	spec.PreviousRuns = []domain.ReviewRun{{ID: "run-1", Status: domain.ReviewRunComplete}}
+
+	launch, err := l.RestoreTerminal(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("RestoreTerminal: %v", err)
+	}
+	if launch.HandleID != "" || rt.created {
+		t.Fatalf("idle one-shot restore created a runtime: launch=%+v created=%v", launch, rt.created)
+	}
+	if len(reviewer.gotPolicy.PreviousRuns) != 1 || reviewer.gotPolicy.PreviousRuns[0].ID != "run-1" {
+		t.Fatalf("restore policy invocation = %+v", reviewer.gotPolicy)
 	}
 }
 

--- a/backend/internal/review/override_test.go
+++ b/backend/internal/review/override_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+func TestMergeReviewerAgentConfigIncludesNativeReviewOptions(t *testing.T) {
+	base := domain.AgentConfig{Mode: "native-review", NativeReview: &domain.NativeReviewConfig{Effort: "medium"}}
+	override := domain.AgentConfig{NativeReview: &domain.NativeReviewConfig{Effort: "high", Quiet: true}}
+	got := mergeReviewerAgentConfig(base, override)
+	if got.NativeReview == nil || got.NativeReview.Effort != "high" || !got.NativeReview.Quiet {
+		t.Fatalf("merged native review config = %+v", got.NativeReview)
+	}
+	if got.NativeReview == override.NativeReview {
+		t.Fatal("merge retained the caller's mutable native-review pointer")
+	}
+}
+
 func TestTriggerRejectsAnUnknownHarnessOverride(t *testing.T) {
 	eng := New(Deps{})
 

--- a/backend/internal/review/planner.go
+++ b/backend/internal/review/planner.go
@@ -17,6 +17,8 @@ const (
 	ReviewStateRunning = contract.AOReviewRunning
 	// ReviewStateUpToDate means AO approved the PR's current head.
 	ReviewStateUpToDate = contract.AOReviewUpToDate
+	// ReviewStateCommented means a completed review made no approval decision.
+	ReviewStateCommented = contract.AOReviewCommented
 	// ReviewStateChangesRequested means AO requested changes on the PR's current head.
 	ReviewStateChangesRequested = contract.AOReviewChangesRequested
 	// ReviewStateIneligible means the PR is closed, merged, or missing required facts.
@@ -29,7 +31,7 @@ type PRReviewState struct {
 	PRNumber    int               `json:"prNumber"`
 	Title       string            `json:"title"`
 	TargetSHA   string            `json:"targetSha"`
-	Status      StateStatus       `json:"status" enum:"needs_review,running,up_to_date,changes_requested,ineligible"`
+	Status      StateStatus       `json:"status" enum:"needs_review,running,up_to_date,commented,changes_requested,ineligible"`
 	LatestRun   *domain.ReviewRun `json:"latestRun,omitempty"`
 	PreviousRun *domain.ReviewRun `json:"previousRun,omitempty"`
 }
@@ -66,6 +68,8 @@ func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
 				review.Status = ReviewStateRunning
 			case run.Verdict == domain.VerdictApproved:
 				review.Status = ReviewStateUpToDate
+			case run.Verdict == domain.VerdictComment:
+				review.Status = ReviewStateCommented
 			case run.Verdict == domain.VerdictChangesRequested:
 				review.Status = ReviewStateChangesRequested
 			case run.Status == domain.ReviewRunFailed || run.Status == domain.ReviewRunCancelled:
@@ -98,7 +102,7 @@ func latestCompletedRunForOtherSHA(runs []domain.ReviewRun, prURL, targetSHA str
 		if run.Status != domain.ReviewRunComplete && run.Status != domain.ReviewRunDelivered {
 			continue
 		}
-		if run.Verdict != domain.VerdictApproved && run.Verdict != domain.VerdictChangesRequested {
+		if run.Verdict != domain.VerdictApproved && run.Verdict != domain.VerdictComment && run.Verdict != domain.VerdictChangesRequested {
 			continue
 		}
 		if !found || run.CreatedAt.After(latest.CreatedAt) {

--- a/backend/internal/review/planner_test.go
+++ b/backend/internal/review/planner_test.go
@@ -22,6 +22,9 @@ func TestPlanStatuses(t *testing.T) {
 		{name: "approved current sha up to date", pr: planPR("pr1", 1, "sha1"), runs: []domain.ReviewRun{
 			{ID: "run-1", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved, CreatedAt: now},
 		}, want: ReviewStateUpToDate},
+		{name: "comment current sha is completed without approval", pr: planPR("pr1", 1, "sha1"), runs: []domain.ReviewRun{
+			{ID: "run-1", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunComplete, Verdict: domain.VerdictComment, CreatedAt: now},
+		}, want: ReviewStateCommented},
 		{name: "changes requested current sha", pr: planPR("pr1", 1, "sha1"), runs: []domain.ReviewRun{
 			{ID: "run-1", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunComplete, Verdict: domain.VerdictChangesRequested, CreatedAt: now},
 		}, want: ReviewStateChangesRequested},

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -264,7 +264,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		harness = override
 		if override == resolvedHarness {
 			config = mergeReviewerAgentConfig(resolvedConfig, overrideConfig)
-			hasConfigOverride = config != resolvedConfig
+			hasConfigOverride = !config.Equal(resolvedConfig)
 		} else if !overrideConfig.IsZero() {
 			config = mergeReviewerAgentConfig(domain.AgentConfig{}, overrideConfig)
 		} else {
@@ -272,7 +272,10 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		}
 	} else if !overrideConfig.IsZero() {
 		config = mergeReviewerAgentConfig(config, overrideConfig)
-		hasConfigOverride = config != resolvedConfig
+		hasConfigOverride = !config.Equal(resolvedConfig)
+	}
+	if err := config.ValidateReviewer(harness); err != nil {
+		return TriggerResult{}, fmt.Errorf("%w: reviewer config: %w", ErrInvalid, err)
 	}
 	reviewRows, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
@@ -421,7 +424,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 		if err := e.launcher.Preflight(ctx, harness, worker.Metadata.WorkspacePath); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("reviewer preflight: %w", err))
 		}
-		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, config, launchRun, queue, 0, launchAgentSessionID))
+		launch, err := e.launcher.Spawn(ctx, reviewLaunchSpec(worker, harness, config, reviewRunsForHarness(runs, harness), launchRun, queue, 0, launchAgentSessionID))
 		if err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("launch reviewer: %w", err))
 		}
@@ -430,7 +433,7 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 			persistedAgentSessionID = launch.AgentSessionID
 		}
 	} else {
-		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, config, launchRun, queue, 0, reviewRow.AgentSessionID)); err != nil {
+		if err := e.launcher.Notify(ctx, handleID, reviewLaunchSpec(worker, harness, config, reviewRunsForHarness(runs, harness), launchRun, queue, 0, reviewRow.AgentSessionID)); err != nil {
 			return TriggerResult{}, failRuns(0, fmt.Errorf("notify reviewer: %w", err))
 		}
 	}
@@ -511,7 +514,7 @@ func (e *Engine) SwitchReviewer(
 	if harness != "" && !harness.IsKnown() {
 		return SessionReviews{}, fmt.Errorf("%w: unknown reviewer harness %q", ErrInvalid, harness)
 	}
-	if err := config.Validate(); err != nil {
+	if err := config.ValidateReviewer(harness); err != nil {
 		return SessionReviews{}, fmt.Errorf("%w: reviewer config: %w", ErrInvalid, err)
 	}
 	unlock := e.lockWorker(workerID)
@@ -546,7 +549,7 @@ func (e *Engine) SwitchReviewer(
 	if err := e.destroyOtherReviewerHandles(ctx, workerID, selected, reviewRows); err != nil {
 		return SessionReviews{}, err
 	}
-	if previousSelected == selected && previousConfig != selectedConfig {
+	if previousSelected == selected && !previousConfig.Equal(selectedConfig) {
 		if err := e.resetReviewerRuntimeLocked(ctx, workerID, selected); err != nil {
 			return SessionReviews{}, err
 		}
@@ -884,7 +887,7 @@ func autoReviewHeadBlocked(runs []domain.ReviewRun, prURL, targetSHA string, har
 		if run.PRURL != prURL || run.TargetSHA != targetSHA || (run.Harness != harness && run.Harness != "") {
 			continue
 		}
-		if run.Status == domain.ReviewRunRunning || run.Status == domain.ReviewRunCancelled || run.Verdict == domain.VerdictApproved || run.Verdict == domain.VerdictChangesRequested {
+		if run.Status == domain.ReviewRunRunning || run.Status == domain.ReviewRunCancelled || run.Verdict == domain.VerdictApproved || run.Verdict == domain.VerdictComment || run.Verdict == domain.VerdictChangesRequested {
 			return true
 		}
 		if run.Status == domain.ReviewRunFailed && run.TriggerSource == domain.ReviewTriggerAuto {
@@ -941,6 +944,7 @@ func reviewLaunchSpec(
 	worker domain.SessionRecord,
 	harness domain.ReviewerHarness,
 	config domain.AgentConfig,
+	previousRuns []domain.ReviewRun,
 	run domain.ReviewRun,
 	queue []ports.ReviewTask,
 	index int,
@@ -956,7 +960,7 @@ func reviewLaunchSpec(
 		AgentConfig:     config,
 		WorkspacePath:   worker.Metadata.WorkspacePath,
 		AgentSessionID:  agentSessionID,
-		PreviousRuns:    nil,
+		PreviousRuns:    previousRuns,
 		PRURL:           run.PRURL,
 		TargetSHA:       run.TargetSHA,
 		ReviewQueue:     queue,
@@ -1278,6 +1282,10 @@ func mergeReviewerAgentConfig(base, override domain.AgentConfig) domain.AgentCon
 	}
 	if override.Permissions != "" {
 		base.Permissions = override.Permissions
+	}
+	if override.NativeReview != nil {
+		value := *override.NativeReview
+		base.NativeReview = &value
 	}
 	return base
 }

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -427,6 +427,29 @@ func TestTriggerSpawnsNewReviewerAndRecordsRunAfterLaunch(t *testing.T) {
 	}
 }
 
+func TestTriggerPassesSameHarnessHistoryToReviewer(t *testing.T) {
+	previous := domain.ReviewRun{
+		ID: "qwen-failed", ReviewID: "rev-qwen", SessionID: "mer-1", Harness: domain.ReviewerQwen,
+		PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunFailed,
+	}
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-qwen", SessionID: "mer-1", Harness: domain.ReviewerQwen},
+		runs:   []domain.ReviewRun{previous},
+	}
+	worker := liveWorker()
+	worker.ReviewerHarness = domain.ReviewerQwen
+	worker.ReviewerConfig = domain.AgentConfig{Mode: "native-review", NativeReview: &domain.NativeReviewConfig{Resume: true}}
+	launcher := &fakeLauncher{handle: "review-mer-1"}
+	eng := newEngineForTest(store, fakeSessions{rec: worker, ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if len(launcher.gotSpec.PreviousRuns) != 1 || launcher.gotSpec.PreviousRuns[0].ID != previous.ID {
+		t.Fatalf("previous runs = %+v, want the prior Qwen run", launcher.gotSpec.PreviousRuns)
+	}
+}
+
 func TestRestoreReviewerNoopsWithoutReviewHistory(t *testing.T) {
 	store := &fakeStore{}
 	launcher := &fakeLauncher{handle: "review-mer-1"}

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -605,6 +605,7 @@ func (s *Service) ApplyReviewActivitySignal(ctx context.Context, reviewSessionID
 // SubmittedReview is one review result supplied by the reviewer CLI.
 type SubmittedReview struct {
 	RunID          string
+	Status         domain.ReviewRunStatus
 	Verdict        domain.ReviewVerdict
 	Body           string
 	GithubReviewID string
@@ -669,17 +670,33 @@ func (s *Service) SubmitMany(ctx context.Context, workerID domain.SessionID, rev
 
 func (s *Service) submitOne(ctx context.Context, workerID domain.SessionID, review SubmittedReview) (domain.ReviewRun, error) {
 	runID := review.RunID
+	status := review.Status
+	if status == "" {
+		status = domain.ReviewRunComplete
+	}
 	verdict := review.Verdict
 	body := review.Body
 	githubReviewID := review.GithubReviewID
 	if runID == "" {
 		return domain.ReviewRun{}, fmt.Errorf("%w: review run id is required", ErrInvalid)
 	}
-	if !verdict.Valid() {
-		return domain.ReviewRun{}, fmt.Errorf("%w: verdict must be %q or %q", ErrInvalid, domain.VerdictApproved, domain.VerdictChangesRequested)
-	}
-	if verdict == domain.VerdictChangesRequested && body == "" {
-		return domain.ReviewRun{}, fmt.Errorf("%w: a changes_requested review requires a body", ErrInvalid)
+	switch status {
+	case domain.ReviewRunComplete:
+		if !verdict.Valid() {
+			return domain.ReviewRun{}, fmt.Errorf("%w: verdict must be %q, %q, or %q", ErrInvalid, domain.VerdictApproved, domain.VerdictComment, domain.VerdictChangesRequested)
+		}
+		if verdict == domain.VerdictChangesRequested && body == "" {
+			return domain.ReviewRun{}, fmt.Errorf("%w: a changes_requested review requires a body", ErrInvalid)
+		}
+	case domain.ReviewRunFailed:
+		if verdict != domain.VerdictNone {
+			return domain.ReviewRun{}, fmt.Errorf("%w: a failed review cannot carry a verdict", ErrInvalid)
+		}
+		if strings.TrimSpace(body) == "" {
+			return domain.ReviewRun{}, fmt.Errorf("%w: a failed review requires diagnostic detail", ErrInvalid)
+		}
+	default:
+		return domain.ReviewRun{}, fmt.Errorf("%w: review status must be %q or %q", ErrInvalid, domain.ReviewRunComplete, domain.ReviewRunFailed)
 	}
 	run, ok, err := s.store.GetReviewRun(ctx, runID)
 	if err != nil {
@@ -701,14 +718,14 @@ func (s *Service) submitOne(ctx context.Context, workerID domain.SessionID, revi
 		if !found {
 			return domain.ReviewRun{}, fmt.Errorf("%w: worker session %q", ErrNotFound, workerID)
 		}
-		updated, err := s.store.UpdateReviewRunResult(ctx, run.ID, domain.ReviewRunComplete, verdict, body, githubReviewID, session.AutoInjectReview)
+		updated, err := s.store.UpdateReviewRunResult(ctx, run.ID, status, verdict, body, githubReviewID, session.AutoInjectReview)
 		if err != nil {
 			return domain.ReviewRun{}, err
 		}
 		if !updated {
 			return domain.ReviewRun{}, fmt.Errorf("%w: review run %q is not running", ErrInvalid, runID)
 		}
-		run.Status = domain.ReviewRunComplete
+		run.Status = status
 		run.Verdict = verdict
 		run.Body = body
 		run.GithubReviewID = githubReviewID
@@ -716,7 +733,11 @@ func (s *Service) submitOne(ctx context.Context, workerID domain.SessionID, revi
 		// Only on the real running -> complete transition. Re-submitting an
 		// already-complete run returns early below, so telemetry stays idempotent
 		// the same way the store does.
-		s.emit(ctx, "ao.review.submitted", workerID, map[string]any{
+		event := "ao.review.submitted"
+		if status == domain.ReviewRunFailed {
+			event = "ao.review.failed"
+		}
+		s.emit(ctx, event, workerID, map[string]any{
 			"harness":            string(run.Harness),
 			"verdict":            string(verdict),
 			"duration_ms":        s.clock().Sub(run.CreatedAt).Milliseconds(),
@@ -734,6 +755,9 @@ func (s *Service) submitOne(ctx context.Context, workerID domain.SessionID, revi
 			"auto_inject": session.AutoInjectReview,
 		})
 	case domain.ReviewRunComplete:
+		if status != domain.ReviewRunComplete {
+			return domain.ReviewRun{}, fmt.Errorf("%w: review run %q already recorded status %q", ErrInvalid, runID, run.Status)
+		}
 		if run.Verdict != verdict {
 			return domain.ReviewRun{}, fmt.Errorf("%w: review run %q already recorded verdict %q", ErrInvalid, runID, run.Verdict)
 		}
@@ -744,6 +768,11 @@ func (s *Service) submitOne(ctx context.Context, workerID domain.SessionID, revi
 			return domain.ReviewRun{}, fmt.Errorf("%w: review run %q already recorded GitHub review id %q", ErrInvalid, runID, run.GithubReviewID)
 		}
 	case domain.ReviewRunDelivered:
+		return run, nil
+	case domain.ReviewRunFailed:
+		if status != domain.ReviewRunFailed || run.Body != body {
+			return domain.ReviewRun{}, fmt.Errorf("%w: review run %q already recorded a different failed result", ErrInvalid, runID)
+		}
 		return run, nil
 	default:
 		return domain.ReviewRun{}, fmt.Errorf("%w: review run %q is not running", ErrInvalid, runID)

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -300,6 +300,42 @@ func TestSubmitPersistsThenAppliesThenStampsDelivered(t *testing.T) {
 	}
 }
 
+func TestSubmitPersistsCommentWithoutTreatingItAsApprovalOrFailure(t *testing.T) {
+	st := &fakeStore{
+		ok:  true,
+		run: domain.ReviewRun{ID: "run-1", SessionID: "mer-1", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunRunning},
+	}
+	svc := New(nil, st)
+	run, err := svc.Submit(context.Background(), "mer-1", "run-1", domain.VerdictComment, `{"verdictLine":"COMMENT"}`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewRunComplete || run.Verdict != domain.VerdictComment {
+		t.Fatalf("run = %+v", run)
+	}
+}
+
+func TestSubmitManyRecordsNativeInfrastructureFailureWithoutDelivery(t *testing.T) {
+	st := &fakeStore{
+		ok:  true,
+		run: domain.ReviewRun{ID: "run-1", SessionID: "mer-1", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunRunning},
+	}
+	reducer := &fakeReducer{outcome: lifecycle.ReviewDeliverySent}
+	svc := New(nil, st, WithLifecycleReducer(reducer))
+	runs, err := svc.SubmitMany(context.Background(), "mer-1", []SubmittedReview{{
+		RunID: "run-1", Status: domain.ReviewRunFailed, Body: `{"reason":"timed out"}`,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 || runs[0].Status != domain.ReviewRunFailed || runs[0].Verdict != domain.VerdictNone {
+		t.Fatalf("runs = %+v", runs)
+	}
+	if reducer.batchCalls != 0 || st.markCalls != 0 {
+		t.Fatalf("failed result was delivered: reducer=%d mark=%d", reducer.batchCalls, st.markCalls)
+	}
+}
+
 func TestApplyReviewActivitySignalPersistsNativeReviewerSessionID(t *testing.T) {
 	st := &fakeStore{
 		reviewOK: true,

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -823,7 +823,7 @@ func (s *Service) SetReviewerHarness(ctx context.Context, id domain.SessionID, h
 	if harness != "" && !harness.IsKnown() {
 		return domain.Session{}, apierr.Invalid("UNKNOWN_REVIEWER_HARNESS", "Unknown reviewer harness", nil)
 	}
-	if err := config.Validate(); err != nil {
+	if err := config.ValidateReviewer(harness); err != nil {
 		return domain.Session{}, apierr.Invalid("INVALID_REVIEWER_CONFIG", "Invalid reviewer config", map[string]any{"detail": err.Error()})
 	}
 	updated, err := s.store.SetSessionReviewerConfig(ctx, id, harness, config, time.Now().UTC())

--- a/backend/internal/telemetrymeta/cli.go
+++ b/backend/internal/telemetrymeta/cli.go
@@ -32,6 +32,7 @@ var routineInternalCLICommands = []string{
 	"ao hooks",
 	"ao pty-host",
 	"ao codex-login",
+	"ao review qwen-native-run",
 }
 
 // CLIActorType infers the actor for legacy loopback CLI telemetry requests that

--- a/backend/internal/telemetrymeta/cli_test.go
+++ b/backend/internal/telemetrymeta/cli_test.go
@@ -19,6 +19,7 @@ func TestIsRoutineInternalCLICommandNormalizesLegacyShapes(t *testing.T) {
 		"ao session handoff submit --switch switch-1",
 		"ao project ls",
 		"ao pty-host session-1",
+		"ao review qwen-native-run",
 	} {
 		if !IsRoutineInternalCLICommand(commandPath) {
 			t.Errorf("IsRoutineInternalCLICommand(%q) = false, want true", commandPath)

--- a/backend/pkg/contract/scm.go
+++ b/backend/pkg/contract/scm.go
@@ -47,12 +47,13 @@ type AOReviewVerdict string
 const (
 	AOReviewVerdictNone             AOReviewVerdict = ""
 	AOReviewVerdictApproved         AOReviewVerdict = "approved"
+	AOReviewVerdictComment          AOReviewVerdict = "comment"
 	AOReviewVerdictChangesRequested AOReviewVerdict = "changes_requested"
 )
 
 // Valid reports whether v is a verdict a reviewer may submit.
 func (v AOReviewVerdict) Valid() bool {
-	return v == AOReviewVerdictApproved || v == AOReviewVerdictChangesRequested
+	return v == AOReviewVerdictApproved || v == AOReviewVerdictComment || v == AOReviewVerdictChangesRequested
 }
 
 // AOReviewState is the current AO review state for one pull request head.
@@ -63,6 +64,7 @@ const (
 	AOReviewNeedsReview      AOReviewState = "needs_review"
 	AOReviewRunning          AOReviewState = "running"
 	AOReviewUpToDate         AOReviewState = "up_to_date"
+	AOReviewCommented        AOReviewState = "commented"
 	AOReviewChangesRequested AOReviewState = "changes_requested"
 	AOReviewIneligible       AOReviewState = "ineligible"
 )

--- a/backend/pkg/contract/scm_test.go
+++ b/backend/pkg/contract/scm_test.go
@@ -130,11 +130,11 @@ func TestSharedSCMVocabulariesAndCloudReadRoutesMatch(t *testing.T) {
 		}},
 		{"AOReviewVerdict", "AO_REVIEW_VERDICTS", []string{
 			string(contract.AOReviewVerdictNone), string(contract.AOReviewVerdictApproved),
-			string(contract.AOReviewVerdictChangesRequested),
+			string(contract.AOReviewVerdictComment), string(contract.AOReviewVerdictChangesRequested),
 		}},
 		{"AOReviewState", "AO_REVIEW_STATES", []string{
 			string(contract.AOReviewNeedsReview), string(contract.AOReviewRunning),
-			string(contract.AOReviewUpToDate), string(contract.AOReviewChangesRequested),
+			string(contract.AOReviewUpToDate), string(contract.AOReviewCommented), string(contract.AOReviewChangesRequested),
 			string(contract.AOReviewIneligible),
 		}},
 	}

--- a/contracts/cloud/openapi.yaml
+++ b/contracts/cloud/openapi.yaml
@@ -3077,10 +3077,10 @@ components:
       enum: [running, complete, delivered, failed, cancelled]
     AOReviewVerdict:
       type: string
-      enum: ["", approved, changes_requested]
+      enum: ["", approved, comment, changes_requested]
     AOReviewState:
       type: string
-      enum: [needs_review, running, up_to_date, changes_requested, ineligible]
+      enum: [needs_review, running, up_to_date, commented, changes_requested, ineligible]
     AOReviewRun:
       type: object
       additionalProperties: false

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2276,6 +2276,7 @@ export interface components {
         AgentConfig: {
             mode?: string;
             model?: string;
+            nativeReview?: components["schemas"]["DomainNativeReviewConfig"];
             permissions?: string;
         };
         AgentInfo: {
@@ -3028,6 +3029,14 @@ export interface components {
             lastActivityAt: string;
             state: string;
         };
+        DomainNativeReviewConfig: {
+            comment?: boolean;
+            /** @enum {string} */
+            effort?: "low" | "medium" | "high";
+            quiet?: boolean;
+            resume?: boolean;
+            timeoutMinutes?: number;
+        };
         DomainReviewerConfig: {
             agentConfig?: components["schemas"]["AgentConfig"];
             harness: string;
@@ -3338,7 +3347,7 @@ export interface components {
             prUrl: string;
             previousRun?: components["schemas"]["ReviewRun"];
             /** @enum {string} */
-            status: "needs_review" | "running" | "up_to_date" | "changes_requested" | "ineligible";
+            status: "needs_review" | "running" | "up_to_date" | "commented" | "changes_requested" | "ineligible";
             targetSha: string;
             title: string;
         };
@@ -3919,8 +3928,16 @@ export interface components {
             reviews?: components["schemas"]["SubmitReviewItem"][];
             /** @description Review run id being completed. */
             runId?: string;
-            /** @description Review verdict: approved or changes_requested. */
-            verdict?: string;
+            /**
+             * @description Terminal result status; defaults to complete. Native one-shot reviewers may report failed.
+             * @enum {string}
+             */
+            status?: "complete" | "failed";
+            /**
+             * @description Review verdict: approved, comment, or changes_requested.
+             * @enum {string}
+             */
+            verdict?: "approved" | "comment" | "changes_requested";
         };
         SubmitReviewItem: {
             /** @description Review body recorded by AO. Required for changes_requested. */
@@ -3929,8 +3946,16 @@ export interface components {
             githubReviewId?: string;
             /** @description Review run id being completed. */
             runId: string;
-            /** @description Review verdict: approved or changes_requested. */
-            verdict: string;
+            /**
+             * @description Terminal result status; defaults to complete. Native one-shot reviewers may report failed.
+             * @enum {string}
+             */
+            status?: "complete" | "failed";
+            /**
+             * @description Review verdict: approved, comment, or changes_requested. Required when status is complete.
+             * @enum {string}
+             */
+            verdict?: "approved" | "comment" | "changes_requested";
         };
         SwitchAgentRequest: {
             /** @description Optional retry key. Reusing it with a different request is rejected. */

--- a/frontend/src/renderer/components/ReviewerSelect.test.ts
+++ b/frontend/src/renderer/components/ReviewerSelect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { AgentModelCatalog } from "../hooks/useAgentModelsQuery";
+import { reviewerModelOptions } from "./ReviewerSelect";
+
+const qwenCatalog = {
+	agentId: "qwen",
+	allowCustom: true,
+	customModelEntry: "direct",
+	fetchedAt: "2026-09-03T00:00:00Z",
+	models: [{ id: "qwen3-coder", label: "Qwen 3 Coder" }],
+	selectionMode: "text",
+	source: "provider",
+	stale: false,
+} satisfies AgentModelCatalog;
+
+describe("reviewerModelOptions", () => {
+	it("adds the opt-in native review mode alongside Qwen models", () => {
+		expect(reviewerModelOptions("qwen", qwenCatalog, "Native review")).toEqual([
+			{ kind: "model", label: "Qwen 3 Coder", value: "qwen3-coder" },
+			{ kind: "mode", label: "Native review", value: "native-review" },
+		]);
+	});
+
+	it("does not expose Qwen native review for other reviewer adapters", () => {
+		expect(reviewerModelOptions("claude-code", undefined, "Native review")).toEqual([]);
+	});
+});

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -117,7 +117,11 @@ export function ReviewerSelect({
 			void queryClient.prefetchQuery(agentModelsQueryOptions(harness, menuProjectID));
 		}
 	}, [defaultHarness, menuOpen, menuProjectID, queryClient, selectableOptions]);
-	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
+	const nativeReviewLabel = t("settings.models.qwenNativeReview");
+	const selectedModelLabel =
+		effectiveHarness === "qwen" && mode === "native-review"
+			? nativeReviewLabel
+			: modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
 	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
 		.filter(Boolean)
 		.join(" · ");
@@ -202,6 +206,7 @@ function ReviewerHarnessOption({
 	});
 	const catalog = catalogQuery.data;
 	const isCurrent = currentHarness === persistHarness;
+	const choices = reviewerModelOptions(resolvedHarness, catalog, t("settings.models.qwenNativeReview"));
 
 	if (!resolvedHarness) {
 		return (
@@ -214,7 +219,7 @@ function ReviewerHarnessOption({
 		);
 	}
 
-	const hasChoices = hasModelChoices(catalog);
+	const hasChoices = choices.length > 0;
 	const supportsCustomModel = supportsReviewerCustomModel(catalog);
 	const catalogKnown = catalogQuery.data !== undefined || catalogQuery.isFetched;
 
@@ -297,7 +302,7 @@ function ReviewerHarnessOption({
 						</OptionMenuSubContent>
 					</OptionMenuSub>
 				) : null}
-				{modelOptions(catalog).map((option) => {
+				{choices.map((option) => {
 					const selected =
 						isCurrent &&
 						((option.kind === "mode" && currentMode === option.value) ||
@@ -375,10 +380,6 @@ function supportsReviewerCustomModel(catalog?: AgentModelCatalog): boolean {
 	return catalog?.selectionMode === "text" && catalog.allowCustom === true;
 }
 
-function hasModelChoices(catalog?: AgentModelCatalog): boolean {
-	return modelOptions(catalog).length > 0;
-}
-
 function modelOptions(catalog?: AgentModelCatalog): Array<{ kind: "model" | "mode"; label: string; value: string }> {
 	if (!catalog) return [];
 	if (catalog.selectionMode !== "catalog" && catalog.selectionMode !== "mode" && catalog.selectionMode !== "text") return [];
@@ -387,6 +388,18 @@ function modelOptions(catalog?: AgentModelCatalog): Array<{ kind: "model" | "mod
 		label: item.label,
 		value: item.id,
 	}));
+}
+
+export function reviewerModelOptions(
+	harness: string | undefined,
+	catalog: AgentModelCatalog | undefined,
+	nativeReviewLabel: string,
+): Array<{ kind: "model" | "mode"; label: string; value: string }> {
+	const options = modelOptions(catalog);
+	if (harness === "qwen" && !options.some((option) => option.kind === "mode" && option.value === "native-review")) {
+		options.push({ kind: "mode", label: nativeReviewLabel, value: "native-review" });
+	}
+	return options;
 }
 
 function modelOrModeLabel(catalog: AgentModelCatalog | undefined, model: string, mode: string, emptyLabel: string): string {

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -839,6 +839,7 @@
 	"settings.language.de": "Deutsch",
 	"settings.language.ptBR": "Português (Brasil)",
 	"settings.models.agentDefault": "Agent-Standard",
+	"settings.models.qwenNativeReview": "Native Überprüfung",
 	"settings.models.autoRouteLabel": "Auto (routet automatisch)",
 	"settings.models.browse": "Durchsuchen",
 	"settings.models.custom": "Modell-ID eingeben…",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -934,6 +934,7 @@
 	"settings.language.saveFailed": "Could not save the language preference.",
 	"settings.language.zhCN": "Simplified Chinese",
 	"settings.models.agentDefault": "Agent default",
+	"settings.models.qwenNativeReview": "Native review",
 	"settings.models.autoRouteLabel": "Auto (routes automatically)",
 	"settings.models.browse": "Browse",
 	"settings.models.custom": "Enter model ID…",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -854,6 +854,7 @@
 	"settings.language.de": "Deutsch",
 	"settings.language.ptBR": "Português (Brasil)",
 	"settings.models.agentDefault": "Predeterminado del agente",
+	"settings.models.qwenNativeReview": "Revisión nativa",
 	"settings.models.autoRouteLabel": "Auto (enruta automáticamente)",
 	"settings.models.browse": "Explorar",
 	"settings.models.custom": "Introducir ID del modelo…",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -854,6 +854,7 @@
 	"settings.language.de": "Deutsch",
 	"settings.language.ptBR": "Português (Brasil)",
 	"settings.models.agentDefault": "Valeur par défaut de l’agent",
+	"settings.models.qwenNativeReview": "Révision native",
 	"settings.models.autoRouteLabel": "Auto (achemine automatiquement)",
 	"settings.models.browse": "Parcourir",
 	"settings.models.custom": "Saisir l’identifiant du modèle…",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -839,6 +839,7 @@
 	"settings.language.de": "Deutsch",
 	"settings.language.ptBR": "Português (Brasil)",
 	"settings.models.agentDefault": "エージェントのデフォルト",
+	"settings.models.qwenNativeReview": "ネイティブレビュー",
 	"settings.models.autoRouteLabel": "自動（自動的にルーティング）",
 	"settings.models.browse": "参照",
 	"settings.models.custom": "モデル ID を入力…",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -839,6 +839,7 @@
 	"settings.language.de": "Deutsch",
 	"settings.language.ptBR": "Português (Brasil)",
 	"settings.models.agentDefault": "에이전트 기본값",
+	"settings.models.qwenNativeReview": "네이티브 리뷰",
 	"settings.models.autoRouteLabel": "자동 (자동으로 라우팅)",
 	"settings.models.browse": "찾아보기",
 	"settings.models.custom": "모델 ID 입력…",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -854,6 +854,7 @@
 	"settings.language.de": "Deutsch",
 	"settings.language.ptBR": "Português (Brasil)",
 	"settings.models.agentDefault": "Padrão do agente",
+	"settings.models.qwenNativeReview": "Revisão nativa",
 	"settings.models.autoRouteLabel": "Automático (roteia automaticamente)",
 	"settings.models.browse": "Procurar",
 	"settings.models.custom": "Inserir ID do modelo…",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -821,6 +821,7 @@
 	"settings.language.saveFailed": "无法保存语言偏好设置。",
 	"settings.language.zhCN": "简体中文",
 	"settings.models.agentDefault": "代理默认值",
+	"settings.models.qwenNativeReview": "原生审查",
 	"settings.models.autoRouteLabel": "自动（自动路由）",
 	"settings.models.browse": "浏览",
 	"settings.models.custom": "输入模型 ID…",

--- a/packages/cloud-client/src/schema.ts
+++ b/packages/cloud-client/src/schema.ts
@@ -1611,9 +1611,9 @@ export interface components {
         /** @enum {string} */
         AOReviewRunStatus: "running" | "complete" | "delivered" | "failed" | "cancelled";
         /** @enum {string} */
-        AOReviewVerdict: "" | "approved" | "changes_requested";
+        AOReviewVerdict: "" | "approved" | "comment" | "changes_requested";
         /** @enum {string} */
-        AOReviewState: "needs_review" | "running" | "up_to_date" | "changes_requested" | "ineligible";
+        AOReviewState: "needs_review" | "running" | "up_to_date" | "commented" | "changes_requested" | "ineligible";
         AOReviewRun: {
             id: string;
             reviewId: string;

--- a/packages/product-ui/src/scm-models.test.ts
+++ b/packages/product-ui/src/scm-models.test.ts
@@ -29,11 +29,12 @@ describe("raw SCM models", () => {
 		expect(REVIEW_DECISIONS).toEqual(["none", "approved", "changes_requested", "review_required"]);
 		expect(MERGEABILITY_STATES).toEqual(["unknown", "mergeable", "conflicting", "blocked", "unstable"]);
 		expect(AO_REVIEW_RUN_STATUSES).toEqual(["running", "complete", "delivered", "failed", "cancelled"]);
-		expect(AO_REVIEW_VERDICTS).toEqual(["", "approved", "changes_requested"]);
+		expect(AO_REVIEW_VERDICTS).toEqual(["", "approved", "comment", "changes_requested"]);
 		expect(AO_REVIEW_STATES).toEqual([
 			"needs_review",
 			"running",
 			"up_to_date",
+			"commented",
 			"changes_requested",
 			"ineligible",
 		]);

--- a/packages/product-ui/src/scm-models.ts
+++ b/packages/product-ui/src/scm-models.ts
@@ -25,13 +25,14 @@ export const AO_REVIEW_RUN_STATUSES = ["running", "complete", "delivered", "fail
 export type AOReviewRunStatus = (typeof AO_REVIEW_RUN_STATUSES)[number];
 
 // The empty value is AO's existing stored "no verdict yet" vocabulary.
-export const AO_REVIEW_VERDICTS = ["", "approved", "changes_requested"] as const;
+export const AO_REVIEW_VERDICTS = ["", "approved", "comment", "changes_requested"] as const;
 export type AOReviewVerdict = (typeof AO_REVIEW_VERDICTS)[number];
 
 export const AO_REVIEW_STATES = [
 	"needs_review",
 	"running",
 	"up_to_date",
+	"commented",
 	"changes_requested",
 	"ineligible",
 ] as const;


### PR DESCRIPTION
Fixes #4794

## Problem

AO's Qwen reviewer always launched the long-lived interactive TUI, so users could not opt into Qwen Code's structured `qwen review run` pipeline without leaving AO's review lifecycle. AO also needed to run the provider from the owning repository checkout, preserve its stdout JSON separately from stderr progress, bind results to the exact PR head, and distinguish a completed blocking review from a provider failure.

## Root cause

The Qwen adapter exposed only the generic interactive reviewer command. AO had no typed native-review configuration, one-shot lifecycle, provider JSON/exit-code normalization, neutral COMMENT state, or failed-review submission path. A raw command wrapper would have bypassed AO's run IDs, stale-head checks, cancellation, restore behavior, and idempotent persistence.

## Fix

- Add an opt-in Qwen-only `native-review` mode while leaving the existing interactive path unchanged.
- Build only the documented typed argv: `qwen review run <AO-derived target> --json --fail-on request-changes` plus validated effort/comment/resume/quiet/timeout options.
- Run from the worker's repository checkout with AO's existing Qwen binary, authentication, settings, and private environment setup.
- Parse the documented JSON and exit contract fail-closed: exit 0 is completed JSON, exit 3 is completed REQUEST_CHANGES, and exit 1/malformed/inconsistent results become failed AO runs.
- Preserve the raw provider JSON in a versioned AO result envelope, including the exact target/SHA and requested/effective effort (effective high is recorded when `--comment` forces it; omitted provider-default effort remains intentionally unspecified).
- Add a neutral COMMENT verdict/state so valid non-approval Qwen outcomes are neither approvals nor infrastructure failures, and suppress same-head auto-review loops for that terminal observation.
- Persist the exact AO submission before the loopback API call. A daemon restore replays that idempotent result rather than rerunning Qwen and duplicating optional provider comments.
- Fence `--resume` to an explicit user opt-in plus the same Qwen harness, PR target, and head SHA. Idle daemon restore does not invent a one-shot provider run; a recorded running run is resumed.
- Apply the configured timeout to both Qwen's CLI flag and AO's process context. Cancellation/timeout kills the complete process group on Unix and Windows.
- Expose the Qwen-only native mode in the reviewer selector and keep its existing host-trusted warning.

## Safety

- Existing interactive Qwen behavior is unchanged unless `mode: native-review` is selected.
- The target comes from AO's current PR record; arbitrary provider argv is not accepted.
- Existing current-head delivery/planning checks keep stale results from reaching the worker or satisfying the current head.
- Missing, malformed, incomplete, or exit-inconsistent provider output never passes.
- Failed native runs are stored idempotently and are not delivered as review feedback.
- COMMENT is terminal but never treated as approval.
- Provider comments remain opt-in and default off.
- No database migration or separate review controller/state store is introduced.

## Tests

Passed on the rebased current `main`:

- `npm run api:spec`
- `npm run api:ts` (repository-pinned openapi-typescript 7.4.4; clean regeneration)
- `go test ./internal/nativeqwen ./internal/adapters/reviewer/qwen ./internal/domain ./internal/service/review ./internal/autoreview ./internal/telemetrymeta ./pkg/contract -count=1 -timeout=10m`
- focused `go test ./internal/review` coverage for config merging, same-harness resume history, one-shot idle restore, reviewer switching, and invalid config
- focused `go test ./internal/httpd/controllers` review/submit coverage
- focused `go test ./internal/service/session` reviewer/config coverage
- focused `go test ./internal/cli` native-run, durable replay, cancellation, and telemetry coverage
- `go vet ./internal/nativeqwen ./internal/adapters/reviewer/qwen ./internal/service/review ./internal/domain ./internal/review ./internal/cli ./internal/telemetrymeta`
- frontend TypeScript typecheck
- frontend Qwen selector and locale coverage tests (3 tests)
- product-ui typecheck, SCM model tests, and production build
- cloud-client generation, typecheck, tests (21 tests), and production build

A pre-existing Windows-only reviewer PATH test also fails identically on a clean `origin/main` worktree; the new one-shot launcher test passes independently.

## Manual validation / remaining uncertainty

- No live Qwen provider review was run on this host because Qwen Code is not installed. The official current Qwen documentation/source contract was verified and represented with upstream-shaped deterministic fixtures.
- Go race mode is unavailable on this Windows host because the installed toolchain has no C compiler/CGO support; Linux CI is the authoritative race-capable environment.
- Live verification should confirm Qwen's same-repository worktree/build behavior and optional GitHub comment presentation with real authentication.

## Intentional omissions

- No change to interactive Qwen reviews or other reviewer adapters.
- No new merge-policy semantics for whether COMMENT satisfies a project-specific gate.
- No prose/Markdown verdict scraping, provider algorithm reimplementation, sidecar controller, or `--fix` support.