### PR TITLE
fix(ui): put the caret where you have to type

### DIFF
--- a/frontend/e2e/cross-platform-focus.spec.ts
+++ b/frontend/e2e/cross-platform-focus.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installFakeAgent } from "./support/fake-bridge";
+import { installFakeTerminalMux } from "./support/fake-terminal-mux";
+
+// The focus fixes are renderer-only and Electron ships the same Chromium on
+// every desktop platform, but two things branch on the platform: the command
+// palette gives a focused terminal the plain Ctrl+K readline binding off macOS,
+// and the terminal host styles itself per platform. Cover the branches here by
+// faking the platform the way terminal-viewport-retention.spec.ts does, so the
+// macOS-only development machine is not the only place these are exercised.
+
+// isMacPlatform() checks navigator.userAgent as well as navigator.platform, so
+// a fake that sets only the platform still takes the macOS branch on a macOS
+// development machine. All three have to be overridden together.
+const PLATFORMS = [
+	{
+		name: "macOS",
+		navigator: "MacIntel",
+		userAgentData: "macOS",
+		userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
+	},
+	{
+		name: "Windows",
+		navigator: "Win32",
+		userAgentData: "Windows",
+		userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
+	},
+	{
+		name: "Linux",
+		navigator: "Linux x86_64",
+		userAgentData: "Linux",
+		userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
+	},
+] as const;
+
+const sessionA = { id: "xplat-a", title: "Xplat A", activity: "active" as const };
+const sessionB = { id: "xplat-b", title: "Xplat B", activity: "active" as const };
+const handleA = `${sessionA.id}/terminal_0`;
+const handleB = `${sessionB.id}/terminal_0`;
+
+async function fakePlatform(page: Page, platform: (typeof PLATFORMS)[number]) {
+	await page.addInitScript(
+		({ nav, uad, ua }) => {
+			Object.defineProperty(window.navigator, "platform", { configurable: true, value: nav });
+			Object.defineProperty(window.navigator, "userAgent", { configurable: true, value: ua });
+			Object.defineProperty(window.navigator, "userAgentData", {
+				configurable: true,
+				value: { platform: uad },
+			});
+		},
+		{ nav: platform.navigator, uad: platform.userAgentData, ua: platform.userAgent },
+	);
+}
+
+function visibleTerminal(page: Page) {
+	return page.getByTestId("session-terminal-slot").locator("[data-terminal-activation-phase='visible']");
+}
+
+function caretIsInTheVisibleTerminal(page: Page) {
+	return page.evaluate(() => {
+		const active = document.activeElement;
+		const host = active?.closest("[data-terminal-activation-phase]");
+		return (
+			Boolean(active?.classList.contains("xterm-helper-textarea")) &&
+			host?.getAttribute("data-terminal-activation-phase") === "visible"
+		);
+	});
+}
+
+async function terminalHarness(page: Page, platform: (typeof PLATFORMS)[number]) {
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await fakePlatform(page, platform);
+	await installFakeAgent(page, { workers: [sessionA, sessionB] });
+	await installFakeTerminalMux(page, { [handleA]: "A ready", [handleB]: "B ready" });
+	await page.goto(`/#/projects/fake-proj/sessions/${sessionA.id}`);
+	await expect(visibleTerminal(page)).toHaveCount(1);
+}
+
+for (const platform of PLATFORMS) {
+	test(`renderer: switching TUI sessions moves the caret on ${platform.name} @T0 @TRM`, async ({ page }) => {
+		await terminalHarness(page, platform);
+		await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+
+		await page.getByRole("button", { name: `Open ${sessionB.title}`, exact: true }).click();
+		await expect(visibleTerminal(page)).toHaveCount(1);
+		await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+		await page.keyboard.type("bbb");
+
+		const inputs = await page.evaluate(() => window.__aoFakeTerminalMux?.stats().inputs ?? {});
+		expect(inputs[handleB]?.join("")).toBe("bbb");
+	});
+
+	test(`renderer: New task from the project menu focuses the prompt on ${platform.name} @T0`, async ({ page }) => {
+		await fakePlatform(page, platform);
+		await installFakeAgent(page, { projectId: "fake-proj", projectName: "fake-proj" });
+		await page.goto("/#/projects/fake-proj");
+		await page
+			.getByRole("button", { name: /Project actions for fake-proj/ })
+			.first()
+			.click({ force: true });
+		await page.getByRole("menuitem", { name: /New session/ }).click();
+		const prompt = page.getByRole("dialog").getByLabel("Task");
+		await expect(prompt).toBeVisible();
+		await page.keyboard.type("caret is here");
+		await expect(prompt).toHaveValue("caret is here");
+	});
+}
+
+// Documents a deliberate consequence of focusing the terminal on open. Off
+// macOS the palette hands plain Ctrl+K to a focused terminal so readline's
+// kill-to-end-of-line keeps working, which now applies as soon as a session
+// opens rather than only after the user clicks into the terminal.
+test("renderer: a focused terminal keeps plain Ctrl+K off macOS @T0", async ({ page }) => {
+	await terminalHarness(page, PLATFORMS[1]);
+	await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+
+	await page.keyboard.press("Control+k");
+	await expect(page.getByRole("dialog", { name: "Command palette" })).toHaveCount(0);
+
+	// The palette is still reachable once focus is out of the terminal.
+	await page.getByRole("button", { name: `Open ${sessionB.title}`, exact: true }).focus();
+	await page.keyboard.press("Control+k");
+	await expect(page.getByRole("dialog", { name: "Command palette" })).toHaveCount(1);
+});
+
+test("renderer: macOS keeps Cmd+K working from a focused terminal @T0", async ({ page }) => {
+	await terminalHarness(page, PLATFORMS[0]);
+	await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+
+	await page.keyboard.press("Meta+k");
+	await expect(page.getByRole("dialog", { name: "Command palette" })).toHaveCount(1);
+});

--- a/frontend/e2e/new-task-focus.spec.ts
+++ b/frontend/e2e/new-task-focus.spec.ts
@@ -106,6 +106,7 @@ function activeElementInfo(page: Page) {
 		return {
 			label: active?.getAttribute("aria-label") ?? active?.tagName ?? "none",
 			inDialog: Boolean(active?.closest("[role='dialog']")),
+			inTerminal: Boolean(active?.closest(".xterm")),
 		};
 	});
 }
@@ -240,8 +241,34 @@ test("renderer: a dialog opened from a session menu keeps focus inside itself @T
 	await expect(dialog).toBeVisible();
 });
 
-test("renderer: closing that dialog hands focus back to the session menu trigger @T0", async ({ page }) => {
+test("renderer: closing that dialog never strands focus on the page body @T0", async ({ page }) => {
 	await setupSwitchAgentSession(page);
+	const dialog = await openSwitchAgentDialog(page);
+	await expect.poll(async () => (await activeElementInfo(page)).inDialog).toBe(true);
+
+	await page.keyboard.press("Escape");
+	await expect(dialog).toBeHidden();
+	// Closing re-enables worker input, so the terminal underneath claims the
+	// caret through its own effect and the menu hand-back stands down. Either
+	// landing spot is fine; `document.body` is not, because Tab would then
+	// restart from the top of the page.
+	await expect
+		.poll(async () => {
+			const { label, inTerminal } = await activeElementInfo(page);
+			return inTerminal || label === "Session actions";
+		})
+		.toBe(true);
+});
+
+test("renderer: a chat session hands focus back to the menu trigger when its dialog closes @T0", async ({
+	page,
+}) => {
+	// No terminal underneath to claim the caret, and the chat composer only
+	// autofocuses when the session changes, so this is the case the hand-back
+	// exists for: without it focus is left on `document.body`.
+	await setup(page);
+	await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
+	await expect(page.getByRole("combobox", { name: "Message the agent" })).toBeVisible();
 	const dialog = await openSwitchAgentDialog(page);
 	await expect.poll(async () => (await activeElementInfo(page)).inDialog).toBe(true);
 

--- a/frontend/e2e/new-task-focus.spec.ts
+++ b/frontend/e2e/new-task-focus.spec.ts
@@ -1,0 +1,251 @@
+import { expect, test, type Page } from "@playwright/test";
+import { agentReadiness } from "../src/renderer/test/agent-readiness-fixtures";
+import { installFakeAgent } from "./support/fake-bridge";
+import { openSwitchAgentDialog } from "./support/open-switch-agent-menu";
+
+// Focus hand-off between a closing Radix menu and the surface its item opened.
+// A menu traps focus for the commit in which it closes and restores focus to
+// its trigger a tick after it unmounts. Both of those used to land on top of a
+// dialog opened from a menu item, leaving the New task composer with no caret
+// until the user clicked it (#focus regression, reported 2026-09-03).
+
+const projectId = "task-focus";
+const sessionA = "focus-session-a";
+const sessionB = "focus-session-b";
+
+function conversation(sessionId: string) {
+	const completedAt = "2026-08-26T06:00:00Z";
+	return {
+		conversationId: `conversation-${sessionId}`,
+		sessionId,
+		harness: "codex",
+		mode: "chat",
+		controller: "ready",
+		latestSequence: 1,
+		oldestSequence: 1,
+		hasMoreBefore: false,
+		turns: [
+			{ id: `${sessionId}-turn-1`, state: "completed", requestedAt: completedAt, startedAt: completedAt, completedAt },
+		],
+		messages: [
+			{
+				kind: "message",
+				id: `${sessionId}-message-1`,
+				turnId: `${sessionId}-turn-1`,
+				sequence: 1,
+				revision: 0,
+				role: "user",
+				origin: "human",
+				text: `Existing conversation in ${sessionId}`,
+				streaming: false,
+				createdAt: completedAt,
+			},
+		],
+		activities: [],
+		settings: {},
+	};
+}
+
+async function setup(page: Page, { animated = false } = {}) {
+	// The menu's exit animation decides whether Radix's deferred focus restore
+	// lands before or after the dialog mounts, so both paths are worth covering.
+	await page.emulateMedia({ reducedMotion: animated ? "no-preference" : "reduce" });
+	await installFakeAgent(page, {
+		projectId,
+		projectName: projectId,
+		workers: [
+			{ id: sessionA, provider: "codex", title: "Session A", mode: "chat" },
+			{ id: sessionB, provider: "codex", title: "Session B", mode: "chat" },
+		],
+	});
+	await page.route("http://127.0.0.1:8080/api/v1/**", async (route) => {
+		const pathname = new URL(route.request().url()).pathname;
+		if (pathname === "/api/v1/agents/readiness" || pathname === "/api/v1/agents/readiness/ensure") {
+			await route.fulfill({ json: { agents: [agentReadiness("codex", "Codex")] } });
+			return;
+		}
+		if (pathname === `/api/v1/projects/${projectId}`) {
+			await route.fulfill({
+				json: {
+					status: "ok",
+					project: { id: projectId, agent: "codex", config: { worker: { agent: "codex" } } },
+				},
+			});
+			return;
+		}
+		for (const id of [sessionA, sessionB]) {
+			if (pathname === `/api/v1/sessions/${id}/conversation`) {
+				await route.fulfill({ json: conversation(id) });
+				return;
+			}
+			if (pathname === `/api/v1/sessions/${id}/conversation/models`) {
+				await route.fulfill({ json: { models: [], selected: {} } });
+				return;
+			}
+			if (pathname === `/api/v1/sessions/${id}/conversation/skills`) {
+				await route.fulfill({ json: { skills: [] } });
+				return;
+			}
+			if (pathname === `/api/v1/sessions/${id}/workspace/files`) {
+				await route.fulfill({ json: { files: [], truncated: false } });
+				return;
+			}
+			if (pathname === `/api/v1/sessions/${id}/interface-transition`) {
+				await route.fulfill({ json: { supported: true, targetMode: "tui" } });
+				return;
+			}
+		}
+		await route.fulfill({ json: { status: "ok" } });
+	});
+}
+
+
+function activeElementInfo(page: Page) {
+	return page.evaluate(() => {
+		const active = document.activeElement as HTMLElement | null;
+		return {
+			label: active?.getAttribute("aria-label") ?? active?.tagName ?? "none",
+			inDialog: Boolean(active?.closest("[role='dialog']")),
+		};
+	});
+}
+
+function openProjectMenu(page: Page) {
+	return page
+		.getByRole("button", { name: new RegExp(`Project actions for ${projectId}`) })
+		.first()
+		.click({ force: true });
+}
+
+async function expectPromptTakesTyping(page: Page) {
+	const prompt = page.getByRole("dialog").getByLabel("Task");
+	await expect(prompt).toBeVisible();
+	await page.keyboard.type("caret is here");
+	await expect(prompt).toHaveValue("caret is here");
+}
+
+test("renderer: the board New task button focuses the composer prompt @T0", async ({ page }) => {
+	await setup(page);
+	await page.goto(`/#/projects/${projectId}`);
+	await page.getByRole("button", { name: "New task" }).first().click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await expectPromptTakesTyping(page);
+});
+
+for (const animated of [false, true]) {
+	const motion = animated ? "animated" : "reduced motion";
+
+	test(`renderer: New task from the sidebar project menu focuses the composer prompt (${motion}) @T0`, async ({
+		page,
+	}) => {
+		await setup(page, { animated });
+		await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
+		await expect(page.getByRole("combobox", { name: "Message the agent" })).toBeVisible();
+		await openProjectMenu(page);
+		await page.getByRole("menuitem", { name: /New session/ }).click();
+		await expect(page.getByRole("dialog")).toBeVisible();
+		await expectPromptTakesTyping(page);
+	});
+
+	test(`renderer: closing a menu-opened dialog hands focus back to the menu trigger (${motion}) @T0`, async ({
+		page,
+	}) => {
+		await setup(page, { animated });
+		await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
+		await expect(page.getByRole("combobox", { name: "Message the agent" })).toBeVisible();
+		await openProjectMenu(page);
+		await page.getByRole("menuitem", { name: /New session/ }).click();
+		await expect(page.getByRole("dialog")).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(page.getByRole("dialog")).toBeHidden();
+		// Focus has to land somewhere a keyboard user can carry on from, not on body.
+		await expect
+			.poll(async () => (await activeElementInfo(page)).label)
+			.toBe(`Project actions for ${projectId}`);
+	});
+}
+
+test("renderer: New task from the sidebar context menu focuses the composer prompt @T0", async ({ page }) => {
+	await setup(page);
+	await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
+	await expect(page.getByRole("combobox", { name: "Message the agent" })).toBeVisible();
+	await page
+		.getByRole("button", { name: new RegExp(`Project actions for ${projectId}`) })
+		.first()
+		.locator("xpath=ancestor::li[1]")
+		.click({ button: "right", force: true });
+	await page.getByRole("menuitem", { name: /New session/ }).click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await expectPromptTakesTyping(page);
+});
+
+test("renderer: New task from the command palette focuses the composer prompt @T0", async ({ page }) => {
+	await setup(page);
+	await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
+	await expect(page.getByRole("combobox", { name: "Message the agent" })).toBeVisible();
+	await page.keyboard.press("ControlOrMeta+k");
+	await page.getByRole("option", { name: /New task/ }).first().click();
+	await expectPromptTakesTyping(page);
+});
+
+test("renderer: opening another session focuses its chat composer @T0", async ({ page }) => {
+	await setup(page);
+	await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
+	const composer = page.getByRole("combobox", { name: "Message the agent" });
+	await expect(composer).toBeVisible();
+	await expect.poll(async () => (await activeElementInfo(page)).label).toBe("Message the agent");
+
+	await page.getByRole("button", { name: /Open Session B/ }).first().click();
+	await expect(composer).toBeVisible();
+	await expect.poll(async () => (await activeElementInfo(page)).label).toBe("Message the agent");
+	await page.keyboard.type("typed after switching");
+	await expect(composer).toHaveText("typed after switching");
+});
+
+async function setupSwitchAgentSession(page: Page) {
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await installFakeAgent(page, {
+		projectId,
+		projectName: projectId,
+		workers: [{ id: "switch-worker", provider: "claude-code", title: "Switch worker" }],
+	});
+	await page.route("http://127.0.0.1:8080/api/v1/**", async (route) => {
+		const pathname = new URL(route.request().url()).pathname;
+		if (pathname === "/api/v1/agents/readiness" || pathname === "/api/v1/agents/readiness/ensure") {
+			await route.fulfill({
+				json: { agents: [agentReadiness("claude-code", "Claude Code"), agentReadiness("codex", "Codex")] },
+			});
+			return;
+		}
+		if (pathname === `/api/v1/projects/${projectId}`) {
+			await route.fulfill({
+				json: {
+					status: "ok",
+					project: { id: projectId, agent: "claude-code", config: { worker: { agent: "claude-code" } } },
+				},
+			});
+			return;
+		}
+		await route.fulfill({ json: { status: "ok" } });
+	});
+	await page.goto(`/#/projects/${projectId}/sessions/switch-worker`);
+}
+
+test("renderer: a dialog opened from a session menu keeps focus inside itself @T0", async ({ page }) => {
+	await setupSwitchAgentSession(page);
+	const dialog = await openSwitchAgentDialog(page);
+	// The menu trigger sits behind the dialog: focus landing back on it would put
+	// the next Tab outside the dialog entirely.
+	await expect.poll(async () => (await activeElementInfo(page)).inDialog).toBe(true);
+	await expect(dialog).toBeVisible();
+});
+
+test("renderer: closing that dialog hands focus back to the session menu trigger @T0", async ({ page }) => {
+	await setupSwitchAgentSession(page);
+	const dialog = await openSwitchAgentDialog(page);
+	await expect.poll(async () => (await activeElementInfo(page)).inDialog).toBe(true);
+
+	await page.keyboard.press("Escape");
+	await expect(dialog).toBeHidden();
+	await expect.poll(async () => (await activeElementInfo(page)).label).toBe("Session actions");
+});

--- a/frontend/e2e/new-task-focus.spec.ts
+++ b/frontend/e2e/new-task-focus.spec.ts
@@ -276,3 +276,25 @@ test("renderer: a chat session hands focus back to the menu trigger when its dia
 	await expect(dialog).toBeHidden();
 	await expect.poll(async () => (await activeElementInfo(page)).label).toBe("Session actions");
 });
+
+
+test("renderer: a context-menu dialog returns focus to where the menu opened from @T0", async ({
+	page,
+}) => {
+	// A context menu has no trigger to point back at, so the defined fallback is
+	// the element that held focus when the menu opened, which is what Radix itself
+	// restores to. Right-clicking the project row's action button focuses it, so
+	// that button is the expected landing spot, and never `document.body`.
+	await setup(page);
+	await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
+	await expect(page.getByRole("combobox", { name: "Message the agent" })).toBeVisible();
+
+	const openedFrom = `Project actions for ${projectId}`;
+	await page.getByRole("button", { name: new RegExp(openedFrom) }).first().click({ button: "right", force: true });
+	await page.getByRole("menuitem", { name: /New session/ }).click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(page.getByRole("dialog")).toBeHidden();
+
+	await expect.poll(async () => (await activeElementInfo(page)).label).toBe(openedFrom);
+});

--- a/frontend/e2e/session-terminal-focus.spec.ts
+++ b/frontend/e2e/session-terminal-focus.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installFakeAgent } from "./support/fake-bridge";
+import { installFakeTerminalMux } from "./support/fake-terminal-mux";
+
+// A worker terminal used to be auto-focused only mid agent-switch, so opening a
+// TUI session or switching between two of them left focus on the sidebar button
+// that was clicked. Keystrokes went nowhere until the user clicked the terminal.
+
+const sessionA = { id: "tui-focus-a", title: "Tui A", activity: "active" as const };
+const sessionB = { id: "tui-focus-b", title: "Tui B", activity: "active" as const };
+const handleA = `${sessionA.id}/terminal_0`;
+const handleB = `${sessionB.id}/terminal_0`;
+
+function visibleTerminal(page: Page) {
+	return page.getByTestId("session-terminal-slot").locator("[data-terminal-activation-phase='visible']");
+}
+
+function caretIsInTheVisibleTerminal(page: Page) {
+	return page.evaluate(() => {
+		const active = document.activeElement;
+		if (!active) return false;
+		const host = active.closest("[data-terminal-activation-phase]");
+		return active.classList.contains("xterm-helper-textarea") && host?.getAttribute("data-terminal-activation-phase") === "visible";
+	});
+}
+
+async function openSession(page: Page, title: string) {
+	await page.getByRole("button", { name: `Open ${title}`, exact: true }).click();
+	await expect(visibleTerminal(page)).toHaveCount(1);
+}
+
+async function harness(page: Page) {
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await installFakeAgent(page, { workers: [sessionA, sessionB] });
+	await installFakeTerminalMux(page, { [handleA]: "A ready", [handleB]: "B ready" });
+	await page.goto(`/#/projects/fake-proj/sessions/${sessionA.id}`);
+	await expect(visibleTerminal(page)).toHaveCount(1);
+}
+
+test("renderer: a TUI session terminal holds the caret when it opens @T0 @TRM", async ({ page }) => {
+	await harness(page);
+	await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+
+	await page.keyboard.type("hi");
+	await expect
+		.poll(async () => (await page.evaluate(() => window.__aoFakeTerminalMux?.stats().inputs ?? {}))[handleA]?.join(""))
+		.toBe("hi");
+});
+
+test("renderer: switching TUI sessions moves the caret to the session on screen @T0 @TRM", async ({ page }) => {
+	await harness(page);
+	await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+
+	await openSession(page, sessionB.title);
+	await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+	await page.keyboard.type("bbb");
+
+	await openSession(page, sessionA.title);
+	await expect.poll(() => caretIsInTheVisibleTerminal(page)).toBe(true);
+	await page.keyboard.type("aaa");
+
+	// Each session received only its own keystrokes, so the caret followed the
+	// terminal that was actually on screen.
+	const inputs = await page.evaluate(() => window.__aoFakeTerminalMux?.stats().inputs ?? {});
+	expect(inputs[handleB]?.join("")).toBe("bbb");
+	expect(inputs[handleA]?.join("")).toBe("aaa");
+});

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -693,11 +693,13 @@ export function CenterPane({
 					<TerminalPane
 						daemonReady={daemonReady}
 						fontSize={fontSize}
-						focusRequested={
-							target.kind === "shell" ||
-							(target.kind === "worker" &&
-								(Boolean(presentation?.allowSourceInput) || Boolean(displayedSuccessNotice)))
-						}
+						// A terminal you can type into should already hold the caret when you
+						// open or switch to the session, the same way the chat composer does.
+						// Worker input is off during an interface transition or a locked agent
+						// switch; every other target is interactive as soon as it is on screen.
+						// Without this a worker terminal was only focused mid agent-switch, so
+						// switching sessions left keystrokes going nowhere until you clicked it.
+						focusRequested={target.kind !== "worker" || !workerInputDisabled}
 						isFullscreen={isFullscreen}
 						inputDisabled={workerInputDisabled}
 						onChangeFontSize={updateFontSize}

--- a/frontend/src/renderer/components/ui/context-menu.tsx
+++ b/frontend/src/renderer/components/ui/context-menu.tsx
@@ -1,5 +1,6 @@
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
 import { cn } from "../../lib/utils";
+import { composeMenuCloseAutoFocus, useMenuReturnTarget } from "./menu-focus";
 import {
 	actionMenuContentClass,
 	actionMenuItemClass,
@@ -14,11 +15,15 @@ export const ContextMenuPortal = ContextMenuPrimitive.Portal;
 
 export function ContextMenuContent({
 	className,
+	onCloseAutoFocus,
 	...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+	const rememberReturnTarget = useMenuReturnTarget<HTMLDivElement>();
 	return (
 		<ContextMenuPrimitive.Portal>
 			<ContextMenuPrimitive.Content
+				ref={rememberReturnTarget}
+				onCloseAutoFocus={composeMenuCloseAutoFocus(onCloseAutoFocus)}
 				className={cn(
 					actionMenuContentClass,
 					"origin-(--radix-context-menu-content-transform-origin)",

--- a/frontend/src/renderer/components/ui/dropdown-menu.tsx
+++ b/frontend/src/renderer/components/ui/dropdown-menu.tsx
@@ -1,5 +1,6 @@
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import { cn } from "../../lib/utils";
+import { composeMenuCloseAutoFocus, useMenuReturnTarget } from "./menu-focus";
 import {
 	actionMenuContentClass,
 	actionMenuItemClass,
@@ -14,15 +15,19 @@ export const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 
 export function DropdownMenuContent({
 	className,
+	onCloseAutoFocus,
 	portalContainer,
 	sideOffset = 6,
 	...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content> & {
 	portalContainer?: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>["container"];
 }) {
+	const rememberReturnTarget = useMenuReturnTarget<HTMLDivElement>();
 	return (
 		<DropdownMenuPrimitive.Portal container={portalContainer}>
 			<DropdownMenuPrimitive.Content
+				ref={rememberReturnTarget}
+				onCloseAutoFocus={composeMenuCloseAutoFocus(onCloseAutoFocus)}
 				sideOffset={sideOffset}
 				className={cn(
 					actionMenuContentClass,

--- a/frontend/src/renderer/components/ui/menu-focus.test.tsx
+++ b/frontend/src/renderer/components/ui/menu-focus.test.tsx
@@ -88,6 +88,47 @@ describe("keepFocusOnOpenedSurface", () => {
 		await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
 	});
 
+	it("abandons the hand-back once focus finds a home outside the dialog", async () => {
+		const { menu, trigger } = await openMenu();
+		const field = openDialogField();
+		closeMenu(menu);
+
+		// The dialog hands focus straight to another element instead of dropping
+		// it, so there is nothing to hand back.
+		const elsewhere = document.createElement("input");
+		document.body.append(elsewhere);
+		field.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: elsewhere }));
+		elsewhere.focus();
+		field.remove();
+
+		// Much later, an unrelated element loses focus to nowhere. The stale menu
+		// trigger must not steal the caret off the back of it.
+		const unrelated = document.createElement("button");
+		document.body.append(unrelated);
+		unrelated.focus();
+		unrelated.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: null }));
+		unrelated.remove();
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.activeElement).not.toBe(trigger);
+	});
+
+	it("keeps waiting while the surface that borrowed the caret is still open", async () => {
+		const { menu, trigger } = await openMenu();
+		const field = openDialogField();
+		closeMenu(menu);
+
+		// A blur elsewhere on the page drops focus while the dialog is still there.
+		field.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: null }));
+		(document.activeElement as HTMLElement | null)?.blur();
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(document.activeElement).not.toBe(trigger);
+
+		// Closing it for real still hands the caret back.
+		closeDialogField(field);
+		await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+	});
+
 	it("leaves focus alone if something else claimed it before the hand-back", async () => {
 		const { menu, trigger } = await openMenu();
 		const field = openDialogField();

--- a/frontend/src/renderer/components/ui/menu-focus.test.tsx
+++ b/frontend/src/renderer/components/ui/menu-focus.test.tsx
@@ -20,6 +20,31 @@ function OpenMenu() {
 	);
 }
 
+// A context menu has no `aria-controls` trigger and grabs the caret for itself
+// while it opens, which is the case the return target has to survive.
+function ContextMenuLike() {
+	const contentRef = useMenuReturnTarget<HTMLDivElement>();
+	return (
+		<div role="menu" ref={contentRef} tabIndex={-1}>
+			<button type="button">New session</button>
+		</div>
+	);
+}
+
+async function openContextMenu() {
+	const openedFrom = document.createElement("button");
+	document.body.append(openedFrom);
+	openedFrom.focus();
+
+	const { getByRole } = render(<ContextMenuLike />);
+	const menu = getByRole("menu");
+	// Radix moves focus into the content as it opens, before any microtask the
+	// capture might have deferred to.
+	menu.focus();
+	await Promise.resolve();
+	return { menu, openedFrom };
+}
+
 async function openMenu() {
 	const { getByRole } = render(<OpenMenu />);
 	// The return target is captured a microtask after the content attaches.
@@ -127,6 +152,17 @@ describe("keepFocusOnOpenedSurface", () => {
 		// Closing it for real still hands the caret back.
 		closeDialogField(field);
 		await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+	});
+
+	it("returns a context menu to where it was opened from, not to the menu itself", async () => {
+		const { menu, openedFrom } = await openContextMenu();
+		const field = openDialogField();
+		closeMenu(menu);
+
+		closeDialogField(field);
+
+		await vi.waitFor(() => expect(document.activeElement).toBe(openedFrom));
+		openedFrom.remove();
 	});
 
 	it("leaves focus alone if something else claimed it before the hand-back", async () => {

--- a/frontend/src/renderer/components/ui/menu-focus.test.tsx
+++ b/frontend/src/renderer/components/ui/menu-focus.test.tsx
@@ -1,0 +1,105 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { keepFocusOnOpenedSurface, useMenuReturnTarget } from "./menu-focus";
+
+const MENU_ID = "menu-content";
+
+// Stands in for what Radix renders while a dropdown is open: a trigger linked
+// to the content by `aria-controls`, and the content itself.
+function OpenMenu() {
+	const contentRef = useMenuReturnTarget<HTMLDivElement>();
+	return (
+		<>
+			<button type="button" aria-controls={MENU_ID} aria-expanded>
+				Project actions
+			</button>
+			<div id={MENU_ID} role="menu" ref={contentRef}>
+				<button type="button">New session</button>
+			</div>
+		</>
+	);
+}
+
+async function openMenu() {
+	const { getByRole } = render(<OpenMenu />);
+	// The return target is captured a microtask after the content attaches.
+	await Promise.resolve();
+	return {
+		menu: getByRole("menu"),
+		item: getByRole("button", { name: "New session" }),
+		trigger: getByRole("button", { name: "Project actions" }),
+	};
+}
+
+/** Radix dispatches its unmount handler on the content element. */
+function closeMenu(menu: HTMLElement) {
+	const event = new CustomEvent("focusScope.autoFocusOnUnmount", { cancelable: true });
+	menu.addEventListener("focusScope.autoFocusOnUnmount", keepFocusOnOpenedSurface as EventListener, {
+		once: true,
+	});
+	menu.dispatchEvent(event);
+	return event;
+}
+
+function openDialogField() {
+	const field = document.createElement("textarea");
+	document.body.append(field);
+	field.focus();
+	return field;
+}
+
+/** A Radix dialog closes by unmounting: focus falls through to `document.body`. */
+function closeDialogField(field: HTMLElement) {
+	field.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: null }));
+	field.remove();
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("keepFocusOnOpenedSurface", () => {
+	it("lets Radix return focus to the trigger when nothing else claimed it", async () => {
+		const { menu } = await openMenu();
+		expect(closeMenu(menu).defaultPrevented).toBe(false);
+	});
+
+	it("lets Radix return focus to the trigger while focus is still in the menu", async () => {
+		const { menu, item } = await openMenu();
+		item.focus();
+		expect(closeMenu(menu).defaultPrevented).toBe(false);
+	});
+
+	it("keeps focus where a dialog opened by the selected item put it", async () => {
+		const { menu } = await openMenu();
+		const field = openDialogField();
+
+		expect(closeMenu(menu).defaultPrevented).toBe(true);
+		expect(document.activeElement).toBe(field);
+	});
+
+	it("hands focus back to the trigger once that dialog closes", async () => {
+		const { menu, trigger } = await openMenu();
+		const field = openDialogField();
+		closeMenu(menu);
+
+		closeDialogField(field);
+
+		await vi.waitFor(() => expect(document.activeElement).toBe(trigger));
+	});
+
+	it("leaves focus alone if something else claimed it before the hand-back", async () => {
+		const { menu, trigger } = await openMenu();
+		const field = openDialogField();
+		closeMenu(menu);
+
+		closeDialogField(field);
+		const elsewhere = document.createElement("input");
+		document.body.append(elsewhere);
+		elsewhere.focus();
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(document.activeElement).toBe(elsewhere);
+		expect(document.activeElement).not.toBe(trigger);
+	});
+});

--- a/frontend/src/renderer/components/ui/menu-focus.ts
+++ b/frontend/src/renderer/components/ui/menu-focus.ts
@@ -82,13 +82,18 @@ function handleFocusRelease(event: FocusEvent) {
 	if (event.relatedTarget !== null) return;
 	const target = pendingReturnTarget;
 	if (!target) return;
-	setTimeout(() => {
-		// Anything that claimed focus in the meantime outranks this hand-back: a
-		// route change, another menu, the user clicking elsewhere.
-		if (pendingReturnTarget !== target || document.activeElement !== document.body) return;
-		pendingReturnTarget = null;
-		if (target.isConnected) target.focus();
-	}, 0);
+	// Two frames, not one tick: the surface the dialog was covering gets first
+	// claim on the caret through its own effects. A worker terminal, for one,
+	// re-enables input as the dialog closes and focuses itself, and it is a
+	// better landing spot than the menu trigger. This hand-back is only the
+	// fallback for focus that would otherwise be stranded on `document.body`.
+	requestAnimationFrame(() =>
+		requestAnimationFrame(() => {
+			if (pendingReturnTarget !== target || document.activeElement !== document.body) return;
+			pendingReturnTarget = null;
+			if (target.isConnected) target.focus();
+		}),
+	);
 }
 
 /** Runs the caller's own handler first, then the hand-off guard. */

--- a/frontend/src/renderer/components/ui/menu-focus.ts
+++ b/frontend/src/renderer/components/ui/menu-focus.ts
@@ -41,20 +41,30 @@ export function useMenuReturnTarget<T extends HTMLElement>() {
 	return useCallback((menu: T | null) => {
 		// The node attaches when the menu opens and detaches when it closes. Radix
 		// recomposes its own refs on every render, so this fires repeatedly for the
-		// same element; only the first call is the moment the menu opened, and a
-		// later one would read the surface the selected item just opened instead.
+		// same element; only the first call is the moment the menu opened.
 		if (!menu || capturedForMenu === menu) return;
 		capturedForMenu = menu;
-		// Read once the commit has settled: the trigger's `aria-controls` link only
-		// exists while the menu is open, and Radix has not moved focus yet because
-		// it does that from a passive effect.
-		queueMicrotask(() => {
-			const trigger = menu.id
-				? menu.ownerDocument.querySelector<HTMLElement>(`[aria-controls="${CSS.escape(menu.id)}"]`)
+
+		// Synchronously, because a context menu takes the caret for itself during
+		// the same commit: read it now and the element the user was actually on is
+		// still focused, read it a tick later and the menu itself is. Never accept
+		// something inside the menu, which would leave a target that is detached by
+		// the time there is anything to hand back.
+		const active = document.activeElement;
+		menuReturnTarget =
+			active instanceof HTMLElement && active !== document.body && !menu.contains(active)
+				? active
 				: null;
-			const active = document.activeElement;
-			menuReturnTarget =
-				trigger ?? (active instanceof HTMLElement && active !== document.body ? active : null);
+
+		// A dropdown has somewhere better to go: its trigger, which is only
+		// discoverable through the `aria-controls` link while the menu is open, and
+		// only once the commit that opened it has landed.
+		queueMicrotask(() => {
+			if (capturedForMenu !== menu || !menu.id) return;
+			const trigger = menu.ownerDocument.querySelector<HTMLElement>(
+				`[aria-controls="${CSS.escape(menu.id)}"]`,
+			);
+			if (trigger) menuReturnTarget = trigger;
 		});
 	}, []);
 }

--- a/frontend/src/renderer/components/ui/menu-focus.ts
+++ b/frontend/src/renderer/components/ui/menu-focus.ts
@@ -1,0 +1,102 @@
+import { useCallback } from "react";
+
+/**
+ * Focus hand-off between a menu that is closing and the surface its selected
+ * item opened.
+ *
+ * Radix restores focus after a menu closes, but it defers that restore by a
+ * tick (FocusScope dispatches its unmount handler from a `setTimeout`). When
+ * the selected item opened a dialog, the dialog has already claimed the caret
+ * by then, and the late restore yanks it back out, so the user lands in a
+ * composer with no cursor in it.
+ *
+ * A menu that closes without opening anything leaves focus on `document.body`,
+ * so "something outside the menu already holds focus" is a reliable signal that
+ * another surface owns the caret. Only then is the restore skipped; Escape and
+ * plain item selection keep Radix's normal return-to-trigger behaviour that
+ * keyboard users depend on.
+ *
+ * Skipping it would stop there, except that the dialog cannot return focus for
+ * us: Radix captured its return target when the dialog mounted, and that was
+ * the menu item, which no longer exists. So the return target is captured when
+ * the menu opens and handed back once the surface that borrowed the caret lets
+ * go of it.
+ */
+
+// Only one menu is open at a time, so a single slot each is enough.
+let menuReturnTarget: HTMLElement | null = null;
+let capturedForMenu: HTMLElement | null = null;
+let pendingReturnTarget: HTMLElement | null = null;
+let watchingForRelease = false;
+
+/**
+ * Remember, while the menu is open, where focus should end up once it is done
+ * with it. A dropdown returns to its trigger, which is only discoverable by its
+ * `aria-controls` link while the menu is open; a context menu has no such
+ * trigger, so it falls back to whatever the user was on before right-clicking.
+ * Both are the element Radix itself would have returned to.
+ */
+export function useMenuReturnTarget<T extends HTMLElement>() {
+	return useCallback((menu: T | null) => {
+		// The node attaches when the menu opens and detaches when it closes. Radix
+		// recomposes its own refs on every render, so this fires repeatedly for the
+		// same element; only the first call is the moment the menu opened, and a
+		// later one would read the surface the selected item just opened instead.
+		if (!menu || capturedForMenu === menu) return;
+		capturedForMenu = menu;
+		// Read once the commit has settled: the trigger's `aria-controls` link only
+		// exists while the menu is open, and Radix has not moved focus yet because
+		// it does that from a passive effect.
+		queueMicrotask(() => {
+			const trigger = menu.id
+				? menu.ownerDocument.querySelector<HTMLElement>(`[aria-controls="${CSS.escape(menu.id)}"]`)
+				: null;
+			const active = document.activeElement;
+			menuReturnTarget =
+				trigger ?? (active instanceof HTMLElement && active !== document.body ? active : null);
+		});
+	}, []);
+}
+
+export function keepFocusOnOpenedSurface(event: Event) {
+	if (event.defaultPrevented) return;
+	const active = document.activeElement;
+	if (!active || active === document.body) return;
+	const menu = event.currentTarget ?? event.target;
+	if (menu instanceof Node && menu.contains(active)) return;
+	event.preventDefault();
+	returnFocusWhenSurfaceCloses();
+}
+
+function returnFocusWhenSurfaceCloses() {
+	pendingReturnTarget = menuReturnTarget;
+	if (!pendingReturnTarget || watchingForRelease) return;
+	watchingForRelease = true;
+	document.addEventListener("focusout", handleFocusRelease, true);
+}
+
+function handleFocusRelease(event: FocusEvent) {
+	// Focus moving to another element is the user's business. Only a null
+	// relatedTarget means it fell through to nowhere, which is what happens when
+	// the dialog that borrowed the caret unmounts.
+	if (event.relatedTarget !== null) return;
+	const target = pendingReturnTarget;
+	if (!target) return;
+	setTimeout(() => {
+		// Anything that claimed focus in the meantime outranks this hand-back: a
+		// route change, another menu, the user clicking elsewhere.
+		if (pendingReturnTarget !== target || document.activeElement !== document.body) return;
+		pendingReturnTarget = null;
+		if (target.isConnected) target.focus();
+	}, 0);
+}
+
+/** Runs the caller's own handler first, then the hand-off guard. */
+export function composeMenuCloseAutoFocus(handler?: (event: Event) => void) {
+	return (event: Event) => {
+		handler?.(event);
+		keepFocusOnOpenedSurface(event);
+	};
+}
+
+

--- a/frontend/src/renderer/components/ui/menu-focus.ts
+++ b/frontend/src/renderer/components/ui/menu-focus.ts
@@ -23,11 +23,12 @@ import { useCallback } from "react";
  * go of it.
  */
 
-// Only one menu is open at a time, so a single slot each is enough.
+// Only one menu is open at a time, so a single slot each is enough. `pending`
+// also holds the surface that borrowed the caret, so the hand-back can tell
+// "the dialog closed and dropped focus" from "focus moved on deliberately".
 let menuReturnTarget: HTMLElement | null = null;
 let capturedForMenu: HTMLElement | null = null;
-let pendingReturnTarget: HTMLElement | null = null;
-let watchingForRelease = false;
+let pending: { borrower: Element; target: HTMLElement } | null = null;
 
 /**
  * Remember, while the menu is open, where focus should end up once it is done
@@ -65,23 +66,40 @@ export function keepFocusOnOpenedSurface(event: Event) {
 	const menu = event.currentTarget ?? event.target;
 	if (menu instanceof Node && menu.contains(active)) return;
 	event.preventDefault();
-	returnFocusWhenSurfaceCloses();
+	returnFocusWhenSurfaceCloses(active);
 }
 
-function returnFocusWhenSurfaceCloses() {
-	pendingReturnTarget = menuReturnTarget;
-	if (!pendingReturnTarget || watchingForRelease) return;
-	watchingForRelease = true;
+function returnFocusWhenSurfaceCloses(borrower: Element) {
+	if (!menuReturnTarget) return;
+	// The overlay, not the focused field: the user tabbing between the dialog's
+	// own controls is not the caret finding a home somewhere else.
+	pending = {
+		borrower: borrower.closest("[role='dialog'], [role='alertdialog']") ?? borrower,
+		target: menuReturnTarget,
+	};
+	// Re-adding an identical listener is a no-op, so this stays a single listener
+	// that is removed again as soon as nothing is pending.
 	document.addEventListener("focusout", handleFocusRelease, true);
 }
 
+function clearPending() {
+	pending = null;
+	document.removeEventListener("focusout", handleFocusRelease, true);
+}
+
 function handleFocusRelease(event: FocusEvent) {
-	// Focus moving to another element is the user's business. Only a null
-	// relatedTarget means it fell through to nowhere, which is what happens when
-	// the dialog that borrowed the caret unmounts.
-	if (event.relatedTarget !== null) return;
-	const target = pendingReturnTarget;
-	if (!target) return;
+	const current = pending;
+	if (!current) {
+		clearPending();
+		return;
+	}
+	if (event.relatedTarget !== null) {
+		// Focus moved to a real element. Inside the surface that borrowed it, the
+		// user is still working there; anywhere else, the caret has a home and
+		// there is nothing left to hand back.
+		if (!current.borrower.contains(event.relatedTarget as Node)) clearPending();
+		return;
+	}
 	// Two frames, not one tick: the surface the dialog was covering gets first
 	// claim on the caret through its own effects. A worker terminal, for one,
 	// re-enables input as the dialog closes and focuses itself, and it is a
@@ -89,9 +107,15 @@ function handleFocusRelease(event: FocusEvent) {
 	// fallback for focus that would otherwise be stranded on `document.body`.
 	requestAnimationFrame(() =>
 		requestAnimationFrame(() => {
-			if (pendingReturnTarget !== target || document.activeElement !== document.body) return;
-			pendingReturnTarget = null;
-			if (target.isConnected) target.focus();
+			if (pending !== current) return;
+			// Focus can also be dropped while the surface is still open, by a blur
+			// somewhere else on the page. Nothing to hand back yet, so keep waiting.
+			if (current.borrower.isConnected) return;
+			// Decided either way: never leave the target armed for an unrelated
+			// focus loss later on.
+			clearPending();
+			if (document.activeElement !== document.body) return;
+			if (current.target.isConnected) current.target.focus();
 		}),
 	);
 }

--- a/packages/product-ui/src/TaskComposerView.test.tsx
+++ b/packages/product-ui/src/TaskComposerView.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createElement, type ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -118,6 +118,33 @@ describe("TaskComposerView", () => {
 		fireEvent.change(screen.getByRole("textbox", { name: "Model" }), { target: { value: "gpt-5.1" } });
 		expect(props.model.onModelChange).toHaveBeenCalledWith("gpt-5.1");
 		expect(screen.getByRole("group", { name: "Runs with" })).toHaveClass("composer-run-controls");
+	});
+
+	it("claims the caret when asked to autofocus, and reclaims it from a surface that steals it", async () => {
+		render(<TaskComposerView {...viewProps({ autoFocusPrompt: true })} />);
+		const prompt = screen.getByRole("textbox", { name: "Task" });
+		expect(document.activeElement).toBe(prompt);
+
+		// A Radix menu closing behind the dialog pulls focus back to itself for a
+		// frame. The prompt has to win that race or the user gets no caret.
+		const thief = document.createElement("button");
+		document.body.append(thief);
+		thief.focus();
+		expect(document.activeElement).toBe(thief);
+
+		await waitFor(() => expect(document.activeElement).toBe(prompt));
+		thief.remove();
+	});
+
+	it("leaves the caret alone when no autofocus was asked for", () => {
+		const before = document.createElement("button");
+		document.body.append(before);
+		before.focus();
+
+		render(<TaskComposerView {...viewProps()} />);
+
+		expect(document.activeElement).toBe(before);
+		before.remove();
 	});
 
 	it("keeps the surrounding controls stable while typing", () => {

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -17,6 +17,7 @@ import {
 	PaperclipIcon as Paperclip,
 	XIcon as X,
 } from "./icons";
+import { useOverlayAutoFocus } from "./overlay-auto-focus";
 
 // One fixed-height, non-wrapping row: 56px attachment tiles plus 6px top and
 // 8px bottom padding. Keeping this numeric avoids Motion's auto-height layout
@@ -147,6 +148,7 @@ const TaskPrompt = memo(function TaskPrompt({
 }: TaskPromptProps) {
 	const [value, setValue] = useState(initialValue);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	useOverlayAutoFocus(textareaRef, autoFocus === true);
 
 	useEffect(() => {
 		const el = textareaRef.current;
@@ -163,7 +165,6 @@ const TaskPrompt = memo(function TaskPrompt({
 			<textarea
 				ref={textareaRef}
 				id={id}
-				autoFocus={autoFocus}
 				className="min-h-[calc(3lh+1.75rem)] max-h-[calc(8lh+1.75rem)] w-full resize-none overflow-y-auto bg-transparent px-4 pb-3 pt-4 text-md leading-relaxed text-foreground outline-none placeholder:text-passive disabled:cursor-not-allowed disabled:opacity-50"
 				disabled={disabled}
 				placeholder={placeholder}

--- a/packages/product-ui/src/index.ts
+++ b/packages/product-ui/src/index.ts
@@ -4,6 +4,7 @@ export * from "./agent-capabilities";
 export * from "./agents";
 export * from "./external-link";
 export * from "./formatting";
+export * from "./overlay-auto-focus";
 export * from "./PRSummaryDisplay";
 export * from "./project-models";
 export * from "./ProjectViews";

--- a/packages/product-ui/src/overlay-auto-focus.ts
+++ b/packages/product-ui/src/overlay-auto-focus.ts
@@ -1,0 +1,40 @@
+import { type RefObject, useEffect } from "react";
+
+/**
+ * Put the caret in an overlay's primary field the moment the overlay opens, and
+ * keep it there while whatever opened the overlay finishes tearing down.
+ *
+ * The plain `autoFocus` attribute is not enough when the overlay was opened
+ * from a Radix menu item. The menu is still mounted for that commit and its
+ * focus trap pulls focus back out of the field React just focused, so the user
+ * lands in a dialog with no cursor and has to click the field. Re-asserting on
+ * the next couple of frames wins that race, and doing it only while focus sits
+ * outside the overlay means a user who deliberately tabbed or clicked to
+ * another control keeps it.
+ */
+export function useOverlayAutoFocus(ref: RefObject<HTMLElement | null>, enabled = true) {
+	useEffect(() => {
+		const element = ref.current;
+		if (!enabled || !element) return;
+
+		const doc = element.ownerDocument;
+		// The overlay, not the field, is the boundary: focus that moved to the
+		// agent picker or the Start button is the user's, focus on `body` or on
+		// the menu trigger behind the overlay is the race we are fixing.
+		const overlay = element.closest("[role='dialog']") ?? element;
+		const claim = () => {
+			const active = doc.activeElement;
+			if (active && active !== doc.body && overlay.contains(active)) return;
+			element.focus();
+		};
+
+		claim();
+		let remaining = 2;
+		let frame = requestAnimationFrame(function reassert() {
+			claim();
+			remaining -= 1;
+			if (remaining > 0) frame = requestAnimationFrame(reassert);
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [enabled, ref]);
+}


### PR DESCRIPTION
Three defects with one symptom: the caret is not where you have to type, so you click before you can start.

## 1. A TUI session never focused its terminal

Opening a `mode=tui` session, or switching between two of them, left focus on the sidebar button that was clicked. Keystrokes were dropped entirely until you clicked into the terminal. This is the one that bites hardest, since most worker sessions are TUI.

In `CenterPane`, `presentation` is the *agent-switch* presentation and is `undefined` unless a switch is in flight, so this only ever fired mid-switch:

```jsx
focusRequested={target.kind === "shell" ||
  (target.kind === "worker" &&
    (Boolean(presentation?.allowSourceInput) || Boolean(displayedSuccessNotice)))}
```

A terminal you can type into now holds the caret as soon as it is on screen, the same as the chat composer. Worker input is still left alone while it is genuinely disabled, during an interface transition, a locked agent switch, or an open handoff dialog, which is the condition that already marks the surface `inert`.

## 2. New task opened from a menu had no caret in the prompt

Opening **New task** from the sidebar project menu (dropdown or right-click) left the composer prompt empty of focus, while the board's New task button worked, which is why it looked intermittent. The composer was autofocusing correctly; a closing Radix menu took the caret back, twice:

1. **The menu still traps focus during the commit in which it closes.** `onSelect` opens the dialog and closes the menu in the same React commit, so when the textarea's `autoFocus` fires, the menu's `focusin` trap is still attached and pulls focus back into the menu.
2. **FocusScope restores focus to the menu trigger a tick after the menu unmounts** (it defers through `setTimeout`), landing on top of the already-open dialog.

`useOverlayAutoFocus` (new, in `packages/product-ui`) claims focus from an effect and re-asserts for two frames while focus sits *outside the field's overlay*, so a user who deliberately tabs to the agent picker keeps it. This replaces the `autoFocus` attribute, which loses the race in step 1.

`menu-focus.ts` (new), wired into the shared `DropdownMenuContent` and `ContextMenuContent`, skips the trigger restore when another surface already holds focus. A menu that closes without opening anything leaves focus on `document.body`, so Escape and ordinary item selection keep Radix's normal return-to-trigger behaviour that keyboard users rely on.

## 3. Closing a menu-opened dialog stranded focus on `document.body`

Skipping the restore is not sufficient on its own: the dialog cannot hand focus back afterwards, because Radix captured its return target when the dialog mounted and that was the menu item, which no longer exists. So the menu records where focus should return to while it is open (the trigger for a dropdown, the previously focused element for a context menu, the same targets Radix itself would use) and hands it back once the surface that borrowed the caret releases it.

The menu change is in the shared components, so it applies to every menu. That caught a second real bug: the **Switch agent** dialog opened from the Session actions menu used to leave focus on the trigger behind it, so the next Tab escaped the dialog entirely.

## Known consequence off macOS

The command palette deliberately hands plain `Ctrl+K` to a focused terminal so readline's kill-to-end-of-line keeps working (`CommandPalette.tsx`). Because the terminal now holds focus from the moment a session opens, that rule applies immediately rather than only after the user clicks into the terminal. Net effect on Windows and Linux: `Ctrl+K` right after opening a session goes to the terminal, and the palette opens once focus is anywhere else. macOS is unaffected, since it uses `Cmd+K`.

This follows the existing documented intent, but it is a real change in default behaviour and a reviewer may want to weigh it. Both halves are pinned by tests.

## How to test

```
cd frontend
npx playwright test e2e/session-terminal-focus.spec.ts e2e/new-task-focus.spec.ts e2e/cross-platform-focus.spec.ts
```

By hand: open a TUI session and type without clicking; switch to another session and type again. Then open a project's `...` menu in the sidebar, choose New session, type without clicking, and press Escape to confirm focus returns to the `...` button. Same via right-click, and via Session actions > Switch agent.

## Verification

20 e2e cases across three new specs, each confirmed red before the fix and green after. Each of the four mechanisms was reverted individually to check that the tests that should fail do.

- TUI: caret in the terminal on open, after switching, and after switching back, with each session receiving only its own keystrokes.
- New task from the board button, sidebar dropdown, sidebar right-click, and the command palette: all take typed text with no click.
- The sidebar-menu cases run with and without reduced motion, because the menu's exit animation decides whether Radix's deferred restore lands before or after the dialog mounts.
- Escape out of a menu-opened dialog returns focus to the menu trigger, not `document.body`.
- Switch agent keeps focus inside the dialog and returns it to Session actions on close.
- Switching sessions focuses the chat composer (already correct, covered to keep it that way).

Also on this branch: renderer and product-ui unit suites, the full Playwright suite (53 passing), and `tsc --noEmit` for `frontend`, `packages/product-ui`, and `tsconfig.e2e.json`.

## Cross-platform

Developed and hand-verified on macOS only. Two things mitigate that:

- CI runs the renderer unit suite and the `@T0/@P0` e2e gate on `ubuntu-latest`, and every new test here is tagged `@T0`, so Linux coverage is real rather than assumed.
- `e2e/cross-platform-focus.spec.ts` fakes the platform and runs the terminal-switch and menu flows as macOS, Windows and Linux, plus the `Ctrl+K` behaviour above. Note that `isMacPlatform()` reads `navigator.userAgent` as well as `navigator.platform`, so the fake overrides `platform`, `userAgent` and `userAgentData` together. Overriding only `platform` silently keeps the macOS branch on a macOS machine.

What that does **not** cover: a real Windows or Linux Electron build. The changes are renderer-only and Electron ships the same Chromium on all three, and none of the touched code branches on the OS, but no packaged non-macOS app was launched.

## Risks

- The shared menu change touches every dropdown and context menu in the renderer. Existing `onCloseAutoFocus` callers (`DiffSelectionMenu`, `XtermTerminal`, the settings option menus) are unaffected: they either already `preventDefault` or only do so on pointer closes, and the guard short-circuits on an already-prevented event.
- The two-frame re-assert in `useOverlayAutoFocus` is a race against a closing menu's focus trap. It only reclaims focus while focus is outside the overlay, so it cannot fight a user who moved to another control in the dialog.
