### PR TITLE
fix(mobile): poll native-session readiness so Switch to Chat enables itself

### DIFF
--- a/packages/mobile/lib/chat/ChatSessionScreen.tsx
+++ b/packages/mobile/lib/chat/ChatSessionScreen.tsx
@@ -442,12 +442,16 @@ function LiveTurnBar({ snapshot, startedAt, stopping, onInterrupt }: { snapshot:
 	return <View style={styles.live}><ActivityIndicator size="small" color={blocked ? t.amber : t.orange} /><Text style={styles.liveText}>{blocked ? "Waiting for your input" : "Agent is working"}{elapsed ? ` · ${elapsed}` : ""}{queued ? ` · ${queued} queued` : ""}</Text><Pressable accessibilityRole="button" accessibilityLabel={stopLabel} accessibilityState={{ busy: stopping }} disabled={stopping} onPress={() => { haptics.tap(); void onInterrupt(); }} style={styles.stopTurn}><Feather name="square" size={11} color={t.textPrimary} /><Text style={styles.stopTurnText}>{stopping ? "Stopping…" : stopLabel}</Text></Pressable></View>;
 }
 
+// A slot renders from its label and is pressable only when it has a handler.
+// Callers withhold the handler to mean "busy" — "Retrying…", "Resuming…" — and
+// without `disabled` the row still highlighted and still fired a tap haptic, so
+// a label that does nothing felt like a button that had been ignored.
 function InlineBanner({ tone, icon, text, action, secondary, onPress, onSecondary }: { tone: "warning" | "danger" | "muted"; icon: keyof typeof Feather.glyphMap; text: string; action?: string; secondary?: string; onPress?(): void; onSecondary?(): void }) {
 	const t = useTheme();
 	const styles = useThemedStyles(makeStyles);
 	const color = tone === "danger" ? t.red : tone === "warning" ? t.amber : t.textTertiary;
 	const fill = tone === "danger" ? t.tintRed : tone === "warning" ? t.tintAmber : t.bgSubtle;
-	return <View style={[styles.banner, { backgroundColor: fill }]}><Feather name={icon} size={13} color={color} /><Text style={styles.bannerText}>{text}</Text>{secondary ? <Pressable hitSlop={7} onPress={() => { haptics.tap(); onSecondary?.(); }}><Text style={styles.bannerSecondary}>{secondary}</Text></Pressable> : null}{action ? <Pressable hitSlop={7} onPress={() => { haptics.tap(); onPress?.(); }}><Text style={[styles.bannerAction, { color }]}>{action}</Text></Pressable> : null}</View>;
+	return <View style={[styles.banner, { backgroundColor: fill }]}><Feather name={icon} size={13} color={color} /><Text style={styles.bannerText}>{text}</Text>{secondary ? <Pressable hitSlop={7} disabled={!onSecondary} onPress={() => { haptics.tap(); onSecondary?.(); }}><Text style={styles.bannerSecondary}>{secondary}</Text></Pressable> : null}{action ? <Pressable hitSlop={7} disabled={!onPress} onPress={() => { haptics.tap(); onPress?.(); }}><Text style={[styles.bannerAction, { color }]}>{action}</Text></Pressable> : null}</View>;
 }
 
 function ConversationMenu({ visible, onClose, snapshot, openingShell, compacting, mcpReloading, compactSupported, mcpReloadSupported, interfaceSupported, interfaceReason, interfaceSwitching, onMap, onOpenShell, onPreview, onPullRequests, onSettings, onSwitchInterface, onCompact, onReload, onRename }: { visible: boolean; onClose(): void; snapshot: NonNullable<ReturnType<typeof useMobileConversation>["snapshot"]>; openingShell: boolean; compacting: boolean; mcpReloading: boolean; compactSupported: boolean; mcpReloadSupported: boolean; interfaceSupported: boolean; interfaceReason?: string; interfaceSwitching: boolean; onMap(): void; onOpenShell(): void; onPreview(): void; onPullRequests(): void; onSettings(): void; onSwitchInterface(): void; onCompact(): void; onReload(): void; onRename(title: string): void }) {

--- a/packages/mobile/lib/chat/ChatSessionScreen.tsx
+++ b/packages/mobile/lib/chat/ChatSessionScreen.tsx
@@ -242,6 +242,39 @@ export function ChatSessionScreen({ session }: { session: MobileChatSession }) {
 		);
 	}, [interfaceSwitch, startInterfaceSwitch, turnActive, turnWaiting]);
 
+	// The poll keeps retrying on its own at up to 8s; this is for the user who can
+	// see the network is back and does not want to wait for the tick. Nothing else
+	// on this screen re-asks the hook, so without it a transition whose poll had
+	// failed could only be checked by leaving and coming back. The ref is the
+	// guard (state updates are async); the state drives the label.
+	const [recheckingTransition, setRecheckingTransition] = useState(false);
+	const recheckingTransitionRef = useRef(false);
+	const retryInterfaceCheck = useCallback(async () => {
+		if (recheckingTransitionRef.current) return;
+		recheckingTransitionRef.current = true;
+		setRecheckingTransition(true);
+		try {
+			await interfaceSwitch.refresh();
+		} finally {
+			recheckingTransitionRef.current = false;
+			setRecheckingTransition(false);
+		}
+	}, [interfaceSwitch]);
+	const interfaceTransitionPhaseText = `Switching to Terminal UI · ${interfacePhaseLabel(interfaceSwitch.transition?.phase)}`;
+	const interfaceTransitionBanner = {
+		text: interfaceSwitch.fetchFailed
+			? `${interfaceTransitionPhaseText}. Could not check on it${interfaceSwitch.error ? `: ${interfaceSwitch.error}` : ""}`
+			: interfaceTransitionPhaseText,
+		// Cancel stays put while a check is failing: the phase the hook holds is
+		// still cancellable and the cancel is its own request, so a user who wants
+		// out should not have to prove the link first. Retry rides alongside it,
+		// which is also how the terminal card lays the two out.
+		action: mobileInterfaceTransitionIsCancellable(interfaceSwitch.transition) ? (interfaceSwitch.cancelling ? "Cancelling…" : "Cancel") : undefined,
+		onPress: interfaceSwitch.cancelling ? undefined : () => void interfaceSwitch.cancel().catch(() => {}),
+		secondary: interfaceSwitch.fetchFailed ? (recheckingTransition ? "Retrying…" : "Retry") : undefined,
+		onSecondary: recheckingTransition ? undefined : () => void retryInterfaceCheck(),
+	};
+
 	if (conversation.loading && !conversation.snapshot) return <Centered icon="message-square" title="Loading conversation…" spinning />;
 	if (conversation.unavailable) return <Unavailable message={conversation.unavailable.message} onShell={() => void openShell()} openingShell={openingShell} />;
 	if (!conversation.snapshot) return <Centered icon="alert-triangle" title="Could not load conversation" message={conversation.error || "The daemon did not return a conversation."} action="Retry" onAction={() => void conversation.refresh()} />;
@@ -277,9 +310,11 @@ export function ChatSessionScreen({ session }: { session: MobileChatSession }) {
 				<InlineBanner
 					tone="warning"
 					icon="repeat"
-					text={`Switching to Terminal UI · ${interfacePhaseLabel(interfaceSwitch.transition?.phase)}`}
-					action={mobileInterfaceTransitionIsCancellable(interfaceSwitch.transition) ? (interfaceSwitch.cancelling ? "Cancelling…" : "Cancel") : undefined}
-					onPress={interfaceSwitch.cancelling ? undefined : () => void interfaceSwitch.cancel().catch(() => {})}
+					text={interfaceTransitionBanner.text}
+					action={interfaceTransitionBanner.action}
+					secondary={interfaceTransitionBanner.secondary}
+					onPress={interfaceTransitionBanner.onPress}
+					onSecondary={interfaceTransitionBanner.onSecondary}
 				/>
 			) : interfaceTransitionNotice ? (
 				<InlineBanner

--- a/packages/mobile/lib/session/TerminalSessionScreen.tsx
+++ b/packages/mobile/lib/session/TerminalSessionScreen.tsx
@@ -1081,8 +1081,14 @@ export default function TerminalScreen() {
 		// The guard at the top saw the pre-tap render. The fresh answer can carry
 		// a transition someone else started while the recheck was in flight (the
 		// desktop button, say); starting another gets a 409 and a "Switch failed"
-		// banner for a switch that is in fact proceeding. The card takes over.
-		if (mobileInterfaceTransitionIsActive(status.transition)) return;
+		// banner for a switch that is in fact proceeding. The card takes over and
+		// explains it — but after a visible spinner, returning in silence reads
+		// as a tap that was dropped, so confirm the outcome the user asked for
+		// actually happened rather than leaving the card to arrive unannounced.
+		if (mobileInterfaceTransitionIsActive(status.transition)) {
+			haptics.success();
+			return;
+		}
 		if (!interfaceBusy) {
 			void startInterfaceSwitch("drain");
 			return;

--- a/packages/mobile/lib/session/TerminalSessionScreen.tsx
+++ b/packages/mobile/lib/session/TerminalSessionScreen.tsx
@@ -643,6 +643,10 @@ export default function TerminalScreen() {
 			mountedRef.current = false;
 		};
 	}, []);
+	// The status the hook holds right now, readable after an await. The tap's
+	// closure is from the render it started in, which is the pre-tap status.
+	const interfaceStatusRef = useRef(interfaceSwitch.status);
+	interfaceStatusRef.current = interfaceSwitch.status;
 	const interfaceTransitionActive = mobileInterfaceTransitionIsActive(interfaceSwitch.transition);
 	const interfaceTransitionNotice =
 		!interfaceTransitionActive &&
@@ -1056,6 +1060,12 @@ export default function TerminalScreen() {
 				const result = await interfaceSwitch.refresh();
 				if (!mountedRef.current) return;
 				if (!result) recheck = { outcome: "not-attempted" };
+				// A superseded answer is not a verdict, same rule as the hook's own
+				// loop: the readiness tick can overtake a slow tap request, and acting
+				// on the tap's payload would alert "Could not reach AO" (or "Not ready
+				// yet" off an older body) while the button had just enabled itself.
+				// The newer request owns the answer; use whatever the hook adopted.
+				else if (result.stale) status = interfaceStatusRef.current;
 				else if (result.ok) status = result.status;
 				else recheck = { outcome: "failed", error: result.error, status: result.status };
 			} finally {
@@ -1068,6 +1078,11 @@ export default function TerminalScreen() {
 			Alert.alert(title, message);
 			return;
 		}
+		// The guard at the top saw the pre-tap render. The fresh answer can carry
+		// a transition someone else started while the recheck was in flight (the
+		// desktop button, say); starting another gets a 409 and a "Switch failed"
+		// banner for a switch that is in fact proceeding. The card takes over.
+		if (mobileInterfaceTransitionIsActive(status.transition)) return;
 		if (!interfaceBusy) {
 			void startInterfaceSwitch("drain");
 			return;
@@ -1084,6 +1099,24 @@ export default function TerminalScreen() {
 			],
 		);
 	}, [interfaceBusy, interfaceSwitch, interfaceTransitionActive, known?.activity, startInterfaceSwitch]);
+
+	// The poll keeps retrying on its own at up to 8s; this is for the user who can
+	// see the network is back and does not want to wait for the tick. The header
+	// button is disabled for the whole transition, so this is the only tap that
+	// re-asks while one is live. Same guard as the header recheck: it is the same
+	// request, and two of them against a slow link is what the guard prevents.
+	const retryInterfaceCheck = useCallback(async () => {
+		if (recheckingRef.current) return;
+		haptics.tap();
+		recheckingRef.current = true;
+		setRechecking(true);
+		try {
+			await interfaceSwitch.refresh();
+		} finally {
+			recheckingRef.current = false;
+			if (mountedRef.current) setRechecking(false);
+		}
+	}, [interfaceSwitch]);
 
 	const requestInterfaceFailureRecovery = useCallback(() => {
 		if (!interfaceFailureRecovery) return;
@@ -1384,6 +1417,15 @@ export default function TerminalScreen() {
 								</Pressable>
 							) : null}
 							{interfaceSwitch.error ? <Text style={styles.interfaceError}>{interfaceSwitch.error}</Text> : null}
+							{interfaceSwitch.fetchFailed ? (
+								<Pressable
+									disabled={rechecking}
+									onPress={() => void retryInterfaceCheck()}
+									style={styles.interfaceCancel}
+								>
+									<Text style={styles.interfaceCancelText}>{rechecking ? "Retrying…" : "Retry"}</Text>
+								</Pressable>
+							) : null}
 						</View>
 					</View>
 				) : null}

--- a/packages/mobile/lib/session/TerminalSessionScreen.tsx
+++ b/packages/mobile/lib/session/TerminalSessionScreen.tsx
@@ -1113,8 +1113,11 @@ export default function TerminalScreen() {
 						style={({ pressed }) => [styles.headerBrowserBtn, pressed && { opacity: 0.6 }]}
 					>
 						{/* A spinner rather than a dimmed glyph: the recheck only runs while
-						    the icon is already faint, so fading it further reads as broken. */}
-						{rechecking ? (
+						    the icon is already faint, so fading it further reads as broken.
+						    `starting` shows it too — that POST is disabled-but-silent for up
+						    to REQUEST_TIMEOUT_MS otherwise, the same dead-button shape the
+						    recheck spinner exists to remove. */}
+						{rechecking || interfaceSwitch.starting ? (
 							<ActivityIndicator size="small" color={t.blue} />
 						) : (
 							<Feather

--- a/packages/mobile/lib/session/TerminalSessionScreen.tsx
+++ b/packages/mobile/lib/session/TerminalSessionScreen.tsx
@@ -28,6 +28,7 @@ import { useVoiceInput } from "../voice/useVoiceInput";
 import { useTheme, useThemedStyles, useThemeState } from "../ThemeProvider";
 import { closeShellTerminal } from "../chat/api";
 import {
+	interfaceSwitchUnavailableMessage,
 	mobileInterfaceTransitionIsActive,
 	mobileInterfaceTransitionIsCancellable,
 	useInterfaceTransition,
@@ -1019,15 +1020,16 @@ export default function TerminalScreen() {
 		[interfaceSwitch],
 	);
 
-	const requestInterfaceSwitch = useCallback(() => {
+	const requestInterfaceSwitch = useCallback(async () => {
 		haptics.tap();
-		if (!interfaceSwitch.status?.supported) {
-			Alert.alert(
-				"Chat unavailable",
-				interfaceSwitch.status?.reason ||
-					interfaceSwitch.error ||
-					"This agent has not declared a compatible native conversation handoff.",
-			);
+		let status = interfaceSwitch.status;
+		if (!status?.supported) {
+			// A tap can land between two polls, or before the first answer: ask
+			// once more before telling the user it is unavailable.
+			status = (await interfaceSwitch.refresh()) ?? status;
+		}
+		if (!status?.supported) {
+			Alert.alert("Chat unavailable", interfaceSwitchUnavailableMessage(status, interfaceSwitch.error));
 			return;
 		}
 		if (!interfaceBusy) {
@@ -1068,7 +1070,7 @@ export default function TerminalScreen() {
 						hitSlop={10}
 						accessibilityLabel="Open Chat interface"
 						accessibilityState={{ busy: interfaceTransitionActive || interfaceSwitch.starting }}
-						onPress={requestInterfaceSwitch}
+						onPress={() => void requestInterfaceSwitch()}
 						style={({ pressed }) => [styles.headerBrowserBtn, pressed && { opacity: 0.6 }]}
 					>
 						<Feather

--- a/packages/mobile/lib/session/TerminalSessionScreen.tsx
+++ b/packages/mobile/lib/session/TerminalSessionScreen.tsx
@@ -2,7 +2,7 @@ import { Feather } from "@expo/vector-icons";
 import { XtermJsWebView, type XtermWebViewHandle } from "@fressh/react-native-xtermjs-webview";
 import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Alert, Keyboard, LayoutAnimation, Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, Alert, Keyboard, LayoutAnimation, Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 import { ApiError, getPreview, isTerminalStatus, killSession, sendMessage } from "../api";
@@ -28,7 +28,8 @@ import { useVoiceInput } from "../voice/useVoiceInput";
 import { useTheme, useThemedStyles, useThemeState } from "../ThemeProvider";
 import { closeShellTerminal } from "../chat/api";
 import {
-	interfaceSwitchUnavailableMessage,
+	interfaceSwitchAlert,
+	type InterfaceSwitchRecheck,
 	mobileInterfaceTransitionIsActive,
 	mobileInterfaceTransitionIsCancellable,
 	useInterfaceTransition,
@@ -626,6 +627,22 @@ export default function TerminalScreen() {
 	// session-id handle, which keeps the fallback backward-compatible.
 	const terminalHandleId = shellOnly ? id : known?.terminalHandleId || id;
 	const interfaceSwitch = useInterfaceTransition(cfg, shellOnly ? "" : sessionId, refresh);
+	// Owned by the screen rather than the hook: the background poll calls the same
+	// `refresh()`, so a hook-wide busy flag would let a poll tick disable the
+	// user's own button and swallow the very tap the recheck exists to serve.
+	// The ref is the guard (state updates are async); the state drives the spinner.
+	const [rechecking, setRechecking] = useState(false);
+	const recheckingRef = useRef(false);
+	// A recheck can be in flight for up to REQUEST_TIMEOUT_MS, long enough for the
+	// user to leave. Alerting from a screen they already navigated away from would
+	// interrupt whatever they went to instead.
+	const mountedRef = useRef(true);
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
 	const interfaceTransitionActive = mobileInterfaceTransitionIsActive(interfaceSwitch.transition);
 	const interfaceTransitionNotice =
 		!interfaceTransitionActive &&
@@ -1021,15 +1038,34 @@ export default function TerminalScreen() {
 	);
 
 	const requestInterfaceSwitch = useCallback(async () => {
+		// A second tap would start a second recheck against a link already slow
+		// enough for the first one to be visible. `starting` and an active
+		// transition are guarded too, so the button blocks exactly what it
+		// announces as busy — otherwise a tap during the start POST fires a
+		// duplicate the daemon answers with 409.
+		if (recheckingRef.current || interfaceSwitch.starting || interfaceTransitionActive) return;
 		haptics.tap();
 		let status = interfaceSwitch.status;
+		let recheck: InterfaceSwitchRecheck = { outcome: "answered" };
 		if (!status?.supported) {
 			// A tap can land between two polls, or before the first answer: ask
 			// once more before telling the user it is unavailable.
-			status = (await interfaceSwitch.refresh()) ?? status;
+			recheckingRef.current = true;
+			setRechecking(true);
+			try {
+				const result = await interfaceSwitch.refresh();
+				if (!mountedRef.current) return;
+				if (!result) recheck = { outcome: "not-attempted" };
+				else if (result.ok) status = result.status;
+				else recheck = { outcome: "failed", error: result.error, status: result.status };
+			} finally {
+				recheckingRef.current = false;
+				if (mountedRef.current) setRechecking(false);
+			}
 		}
 		if (!status?.supported) {
-			Alert.alert("Chat unavailable", interfaceSwitchUnavailableMessage(status, interfaceSwitch.error));
+			const { title, message } = interfaceSwitchAlert(status, interfaceSwitch.error, recheck);
+			Alert.alert(title, message);
 			return;
 		}
 		if (!interfaceBusy) {
@@ -1047,7 +1083,7 @@ export default function TerminalScreen() {
 				{ text: "Stop and switch", style: "destructive", onPress: () => void startInterfaceSwitch("interrupt") },
 			],
 		);
-	}, [interfaceBusy, interfaceSwitch, known?.activity, startInterfaceSwitch]);
+	}, [interfaceBusy, interfaceSwitch, interfaceTransitionActive, known?.activity, startInterfaceSwitch]);
 
 	const requestInterfaceFailureRecovery = useCallback(() => {
 		if (!interfaceFailureRecovery) return;
@@ -1069,15 +1105,24 @@ export default function TerminalScreen() {
 					<Pressable
 						hitSlop={10}
 						accessibilityLabel="Open Chat interface"
-						accessibilityState={{ busy: interfaceTransitionActive || interfaceSwitch.starting }}
+						accessibilityState={{
+							busy: interfaceTransitionActive || interfaceSwitch.starting || rechecking,
+						}}
+						disabled={rechecking || interfaceSwitch.starting || interfaceTransitionActive}
 						onPress={() => void requestInterfaceSwitch()}
 						style={({ pressed }) => [styles.headerBrowserBtn, pressed && { opacity: 0.6 }]}
 					>
-						<Feather
-							name={interfaceTransitionActive ? "repeat" : "message-square"}
-							size={18}
-							color={interfaceSwitch.status?.supported ? t.blue : t.textFaint}
-						/>
+						{/* A spinner rather than a dimmed glyph: the recheck only runs while
+						    the icon is already faint, so fading it further reads as broken. */}
+						{rechecking ? (
+							<ActivityIndicator size="small" color={t.blue} />
+						) : (
+							<Feather
+								name={interfaceTransitionActive ? "repeat" : "message-square"}
+								size={18}
+								color={interfaceSwitch.status?.supported ? t.blue : t.textFaint}
+							/>
+						)}
 					</Pressable>
 					<Pressable
 						hitSlop={12}
@@ -1095,7 +1140,7 @@ export default function TerminalScreen() {
 				</View>
 			),
 		});
-	}, [headerRightReady, navigation, browserOpen, hasPreview, toggleBrowser, styles, t, shellOnly, interfaceTransitionActive, interfaceSwitch.starting, interfaceSwitch.status?.supported, requestInterfaceSwitch]);
+	}, [headerRightReady, navigation, browserOpen, hasPreview, toggleBrowser, styles, t, shellOnly, interfaceTransitionActive, interfaceSwitch.starting, rechecking, interfaceSwitch.status?.supported, requestInterfaceSwitch]);
 
 	const confirmKill = useCallback(() => {
 		const doKill = async () => {

--- a/packages/mobile/lib/session/interfaceTransition.test.ts
+++ b/packages/mobile/lib/session/interfaceTransition.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
 	interfaceSwitchAlert,
 	interfaceSwitchUnavailableMessage,
-	interfaceTransitionFailureAttempts,
 	interfaceTransitionNextPoll,
 	interfaceTransitionPollInterval,
+	interfaceTransitionSessionGone,
 	nativeSessionReadinessAttempts,
 } from "./interfaceTransition";
 
@@ -102,31 +102,52 @@ describe("readiness recheck is bounded", () => {
 	});
 });
 
-describe("failed rechecks get their own bounded budget", () => {
+describe("failed rechecks back off on their own count", () => {
 	const waiting = { reasonCode: "NATIVE_SESSION_UNVERIFIED" };
+	const draining = { transition: { phase: "draining" } };
 
-	it("backs off instead of hammering, and gives up", () => {
+	it("backs off instead of hammering, then holds at the ceiling rather than giving up", () => {
 		expect(interfaceTransitionNextPoll({ consecutiveFailures: 1 })).toBe(1_000);
 		expect(interfaceTransitionNextPoll({ consecutiveFailures: 2 })).toBe(2_000);
 		expect(interfaceTransitionNextPoll({ consecutiveFailures: 3 })).toBe(4_000);
 		expect(interfaceTransitionNextPoll({ consecutiveFailures: 4 })).toBe(8_000);
-		expect(
-			interfaceTransitionNextPoll({ consecutiveFailures: interfaceTransitionFailureAttempts }),
-		).toBeUndefined();
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: 5 })).toBe(8_000);
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: 500 })).toBe(8_000);
 	});
 
-	it("bounds a 404 arriving mid-transition, which the status poll alone cannot", () => {
-		// A failed request never advances `status`, so rescheduling on the last
-		// known phase would re-arm the 300ms transition poll forever.
-		const draining = { transition: { phase: "draining" } };
+	it("keeps a timer alive through a 90s outage mid-transition, so the handoff resumes when the link does", () => {
+		// A budget of five used to spend itself in about 75s of timeouts and leave
+		// no timer to notice the network coming back: the banner froze for good.
+		let elapsed = 0;
+		let failures = 0;
+		while (elapsed < 90_000) {
+			failures += 1;
+			const delay = interfaceTransitionNextPoll({ status: draining, consecutiveFailures: failures });
+			expect(delay).toBe(failures < 4 ? [1_000, 2_000, 4_000][failures - 1] : 8_000);
+			elapsed += (delay ?? 0) + 12_000; // each attempt also waits out REQUEST_TIMEOUT_MS
+		}
+		// The first answer after the outage resets the count; back to the fast cadence.
 		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 0 })).toBe(300);
-		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 1 })).toBe(1_000);
-		expect(
-			interfaceTransitionNextPoll({
-				status: draining,
-				consecutiveFailures: interfaceTransitionFailureAttempts,
-			}),
-		).toBeUndefined();
+	});
+
+	it.each([500, 502, 503])("treats a %s as the link's problem, not the session's", (failureStatus) => {
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 1, failureStatus })).toBe(1_000);
+		expect(interfaceTransitionSessionGone(failureStatus)).toBe(false);
+	});
+
+	it.each([404, 410])("stops at once on a %s, the daemon's word that the session is gone", (failureStatus) => {
+		// A failed request never advances `status`, so rescheduling on the last
+		// known phase would otherwise re-arm the 300ms transition poll forever
+		// against a session that was deleted mid-transition.
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 0 })).toBe(300);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 1, failureStatus })).toBeUndefined();
+		expect(interfaceTransitionNextPoll({ status: waiting, consecutiveFailures: 1, failureStatus })).toBeUndefined();
+		expect(interfaceTransitionSessionGone(failureStatus)).toBe(true);
+	});
+
+	it("does not mistake a request that never landed for a gone session", () => {
+		expect(interfaceTransitionSessionGone(undefined)).toBe(false);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 1, failureStatus: undefined })).toBe(1_000);
 	});
 
 	it("retries a cold start that never landed, so one dropped fetch is recoverable", () => {

--- a/packages/mobile/lib/session/interfaceTransition.test.ts
+++ b/packages/mobile/lib/session/interfaceTransition.test.ts
@@ -6,6 +6,7 @@ import {
 	interfaceTransitionPollInterval,
 	interfaceTransitionSessionGone,
 	nativeSessionReadinessAttempts,
+	speculativeFailureAttempts,
 } from "./interfaceTransition";
 
 const daemonReason =
@@ -106,13 +107,58 @@ describe("failed rechecks back off on their own count", () => {
 	const waiting = { reasonCode: "NATIVE_SESSION_UNVERIFIED" };
 	const draining = { transition: { phase: "draining" } };
 
-	it("backs off instead of hammering, then holds at the ceiling rather than giving up", () => {
-		expect(interfaceTransitionNextPoll({ consecutiveFailures: 1 })).toBe(1_000);
-		expect(interfaceTransitionNextPoll({ consecutiveFailures: 2 })).toBe(2_000);
-		expect(interfaceTransitionNextPoll({ consecutiveFailures: 3 })).toBe(4_000);
-		expect(interfaceTransitionNextPoll({ consecutiveFailures: 4 })).toBe(8_000);
-		expect(interfaceTransitionNextPoll({ consecutiveFailures: 5 })).toBe(8_000);
-		expect(interfaceTransitionNextPoll({ consecutiveFailures: 500 })).toBe(8_000);
+	it("backs off instead of hammering, then holds at the ceiling for a live handoff", () => {
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 1 })).toBe(1_000);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 2 })).toBe(2_000);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 3 })).toBe(4_000);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 4 })).toBe(8_000);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 5 })).toBe(8_000);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 500 })).toBe(8_000);
+	});
+
+	// The review's row: an hour on NATIVE_SESSION_UNVERIFIED with every request
+	// timing out was 183 requests, `attempts` still 0, still scheduled. Answers
+	// are the only thing that can spend the readiness window, and failures had
+	// stopped terminating anything, so nothing was left to end the wait.
+	it("gives up on a readiness wait the link will not let it finish", () => {
+		let failures = 0;
+		let elapsed = 0;
+		let requests = 0;
+		let delay: number | undefined;
+		do {
+			failures += 1;
+			requests += 1;
+			delay = interfaceTransitionNextPoll({ status: waiting, readinessAttempts: 0, consecutiveFailures: failures });
+			elapsed += (delay ?? 0) + 12_000; // each attempt also waits out REQUEST_TIMEOUT_MS
+		} while (delay !== undefined && requests < 500);
+		expect(requests).toBe(speculativeFailureAttempts);
+		expect(elapsed).toBeLessThan(90_000);
+	});
+
+	// Same shape for a mount fetch that never landed: it is worth retrying, but
+	// there is no operation in flight to keep it alive indefinitely.
+	it("gives up on a cold start the link will not let it finish", () => {
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: speculativeFailureAttempts - 1 })).toBe(8_000);
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: speculativeFailureAttempts })).toBeUndefined();
+	});
+
+	// A live handoff is the one wait that outlives its failures: the user is
+	// watching a banner and the operation is real, so it holds at the ceiling for
+	// as long as the screen is open. An hour of timeouts must not end it.
+	it("never gives up on a live handoff, however long the link is down", () => {
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 300 })).toBe(8_000);
+	});
+
+	// The review asked for this to be decided rather than inherited: a 5xx on a
+	// speculative wait now stops, because a daemon failing this one handler is a
+	// fact about the session too. Under a live handoff it still retries.
+	it.each([500, 502, 503])("stops a speculative wait on a persistent %s, but not a live handoff", (failureStatus) => {
+		expect(
+			interfaceTransitionNextPoll({ status: waiting, consecutiveFailures: speculativeFailureAttempts, failureStatus }),
+		).toBeUndefined();
+		expect(
+			interfaceTransitionNextPoll({ status: draining, consecutiveFailures: speculativeFailureAttempts, failureStatus }),
+		).toBe(8_000);
 	});
 
 	it("keeps a timer alive through a 90s outage mid-transition, so the handoff resumes when the link does", () => {
@@ -156,6 +202,9 @@ describe("failed rechecks back off on their own count", () => {
 		expect(interfaceTransitionNextPoll({ status: undefined, consecutiveFailures: 0 })).toBeUndefined();
 	});
 
+	// Answers, and only answers, spend the readiness window — a timeout says
+	// nothing about whether the native session became ready. What ends a wait
+	// the link will not let us finish is the failure count, tested above.
 	it("does not spend the readiness budget on failures", () => {
 		expect(
 			interfaceTransitionNextPoll({

--- a/packages/mobile/lib/session/interfaceTransition.test.ts
+++ b/packages/mobile/lib/session/interfaceTransition.test.ts
@@ -1,13 +1,70 @@
 import { describe, expect, it } from "vitest";
-import { interfaceTransitionPollInterval } from "./interfaceTransition";
+import {
+	interfaceSwitchUnavailableMessage,
+	interfaceTransitionPollInterval,
+} from "./interfaceTransition";
+
+const daemonReason =
+	"session: native conversation id is not confirmed for the current terminal launch for claude-code";
 
 describe("mobile interface transition polling", () => {
 	it("polls quickly while a transition is active", () => {
-		expect(interfaceTransitionPollInterval({ phase: "draining" })).toBe(300);
+		expect(interfaceTransitionPollInterval({ transition: { phase: "draining" } })).toBe(300);
 	});
 
 	it("does not poll while idle or after a transition settles", () => {
 		expect(interfaceTransitionPollInterval()).toBeUndefined();
-		expect(interfaceTransitionPollInterval({ phase: "completed" })).toBeUndefined();
+		expect(interfaceTransitionPollInterval({})).toBeUndefined();
+		expect(interfaceTransitionPollInterval({ transition: { phase: "completed" } })).toBeUndefined();
+	});
+
+	it.each(["NATIVE_SESSION_MISSING", "NATIVE_SESSION_UNVERIFIED"])(
+		"rechecks %s once a second, since it clears without the user doing anything",
+		(reasonCode) => {
+			expect(interfaceTransitionPollInterval({ reasonCode })).toBe(1_000);
+		},
+	);
+
+	it.each(["CHAT_UNSUPPORTED", "INTERFACE_HANDOFF_UNSUPPORTED", "SESSION_TERMINATED"])(
+		"never polls %s, which no amount of waiting resolves",
+		(reasonCode) => {
+			expect(interfaceTransitionPollInterval({ reasonCode })).toBeUndefined();
+		},
+	);
+
+	it("keeps the fast cadence when a transition starts during a readiness wait", () => {
+		expect(
+			interfaceTransitionPollInterval({
+				reasonCode: "NATIVE_SESSION_UNVERIFIED",
+				transition: { phase: "requested" },
+			}),
+		).toBe(300);
+	});
+});
+
+describe("chat unavailable copy", () => {
+	it("replaces the daemon's Go error while the native session is still settling", () => {
+		const message = interfaceSwitchUnavailableMessage({
+			reasonCode: "NATIVE_SESSION_UNVERIFIED",
+			reason: daemonReason,
+		});
+		expect(message).not.toContain(daemonReason);
+		expect(message).toContain("Try again in a moment");
+	});
+
+	it("passes the daemon's reason through for a verdict the user has to act on", () => {
+		expect(
+			interfaceSwitchUnavailableMessage({
+				reasonCode: "CHAT_UNSUPPORTED",
+				reason: "cursor does not support Chat UI.",
+			}),
+		).toBe("cursor does not support Chat UI.");
+	});
+
+	it("falls back to the request error, then to generic copy", () => {
+		expect(interfaceSwitchUnavailableMessage(undefined, "Network request failed")).toBe(
+			"Network request failed",
+		);
+		expect(interfaceSwitchUnavailableMessage()).toMatch(/compatible native conversation handoff/);
 	});
 });

--- a/packages/mobile/lib/session/interfaceTransition.test.ts
+++ b/packages/mobile/lib/session/interfaceTransition.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+	interfaceSwitchAlert,
 	interfaceSwitchUnavailableMessage,
+	interfaceTransitionFailureAttempts,
+	interfaceTransitionNextPoll,
 	interfaceTransitionPollInterval,
+	nativeSessionReadinessAttempts,
 } from "./interfaceTransition";
 
 const daemonReason =
@@ -66,5 +70,143 @@ describe("chat unavailable copy", () => {
 			"Network request failed",
 		);
 		expect(interfaceSwitchUnavailableMessage()).toMatch(/compatible native conversation handoff/);
+	});
+});
+
+describe("readiness recheck is bounded", () => {
+	const waiting = { reasonCode: "NATIVE_SESSION_UNVERIFIED" };
+
+	it("keeps rechecking through the window", () => {
+		expect(interfaceTransitionPollInterval(waiting, 0)).toBe(1_000);
+		expect(interfaceTransitionPollInterval(waiting, nativeSessionReadinessAttempts - 1)).toBe(1_000);
+	});
+
+	it("stops once the window is spent, so #4122 cannot poll forever", () => {
+		expect(interfaceTransitionPollInterval(waiting, nativeSessionReadinessAttempts)).toBeUndefined();
+		expect(
+			interfaceTransitionPollInterval(waiting, nativeSessionReadinessAttempts + 50),
+		).toBeUndefined();
+	});
+
+	it("does not bound a live transition, which settles on its own", () => {
+		expect(
+			interfaceTransitionPollInterval(
+				{ transition: { phase: "draining" } },
+				nativeSessionReadinessAttempts + 50,
+			),
+		).toBe(300);
+	});
+
+	it("defaults to the start of the window so an unspent caller still polls", () => {
+		expect(interfaceTransitionPollInterval(waiting)).toBe(1_000);
+	});
+});
+
+describe("failed rechecks get their own bounded budget", () => {
+	const waiting = { reasonCode: "NATIVE_SESSION_UNVERIFIED" };
+
+	it("backs off instead of hammering, and gives up", () => {
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: 1 })).toBe(1_000);
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: 2 })).toBe(2_000);
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: 3 })).toBe(4_000);
+		expect(interfaceTransitionNextPoll({ consecutiveFailures: 4 })).toBe(8_000);
+		expect(
+			interfaceTransitionNextPoll({ consecutiveFailures: interfaceTransitionFailureAttempts }),
+		).toBeUndefined();
+	});
+
+	it("bounds a 404 arriving mid-transition, which the status poll alone cannot", () => {
+		// A failed request never advances `status`, so rescheduling on the last
+		// known phase would re-arm the 300ms transition poll forever.
+		const draining = { transition: { phase: "draining" } };
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 0 })).toBe(300);
+		expect(interfaceTransitionNextPoll({ status: draining, consecutiveFailures: 1 })).toBe(1_000);
+		expect(
+			interfaceTransitionNextPoll({
+				status: draining,
+				consecutiveFailures: interfaceTransitionFailureAttempts,
+			}),
+		).toBeUndefined();
+	});
+
+	it("retries a cold start that never landed, so one dropped fetch is recoverable", () => {
+		// No status at all: without the failure branch nothing would ever schedule.
+		expect(interfaceTransitionNextPoll({ status: undefined, consecutiveFailures: 1 })).toBe(1_000);
+		expect(interfaceTransitionNextPoll({ status: undefined, consecutiveFailures: 0 })).toBeUndefined();
+	});
+
+	it("does not spend the readiness budget on failures", () => {
+		expect(
+			interfaceTransitionNextPoll({
+				status: waiting,
+				readinessAttempts: nativeSessionReadinessAttempts - 1,
+				consecutiveFailures: 0,
+			}),
+		).toBe(1_000);
+	});
+});
+
+describe("chat unavailable alert", () => {
+	it("says it could not reach AO when nothing answered", () => {
+		const alert = interfaceSwitchAlert(undefined, undefined, {
+			outcome: "failed",
+			error: "Network request failed",
+		});
+		expect(alert.title).toBe("Could not reach AO");
+		expect(alert.message).toContain("Network request failed");
+		expect(alert.message).not.toMatch(/compatible native conversation handoff/);
+	});
+
+	it("sends a rejected phone to re-pair rather than to check its Wi-Fi", () => {
+		const alert = interfaceSwitchAlert(undefined, undefined, {
+			outcome: "failed",
+			error: "401 Unauthorized",
+			status: 401,
+		});
+		expect(alert.title).toBe("AO rejected this phone");
+		expect(alert.message).toContain("scan the code again");
+		expect(alert.message).not.toMatch(/could not reach/i);
+	});
+
+	it("does not blame the network for a session the daemon says is gone", () => {
+		const alert = interfaceSwitchAlert(undefined, undefined, {
+			outcome: "failed",
+			error: "404 Not Found - Unknown session",
+			status: 404,
+		});
+		expect(alert.title).toBe("AO could not answer");
+		expect(alert.message).toContain("was reached");
+	});
+
+	it("names the lockout and its real cause rather than reporting a dead link", () => {
+		const alert = interfaceSwitchAlert(undefined, undefined, {
+			outcome: "failed",
+			error: "429",
+			status: 429,
+		});
+		expect(alert.title).toBe("AO is not accepting requests");
+		expect(alert.message).toContain("Connect Mobile");
+		expect(alert.message).not.toMatch(/could not reach/i);
+	});
+
+	it("does not call a cold start an incapable agent", () => {
+		const alert = interfaceSwitchAlert(undefined, undefined, { outcome: "not-attempted" });
+		expect(alert.title).toBe("Not connected yet");
+		expect(alert.message).not.toMatch(/compatible native conversation handoff/);
+	});
+
+	it("reports the agent's verdict when the daemon did answer", () => {
+		const alert = interfaceSwitchAlert({
+			reasonCode: "CHAT_UNSUPPORTED",
+			reason: "cursor does not support Chat UI.",
+		});
+		expect(alert.title).toBe("Chat unavailable");
+		expect(alert.message).toBe("cursor does not support Chat UI.");
+	});
+
+	it("titles a still-settling session as waiting, not as unavailable", () => {
+		const alert = interfaceSwitchAlert({ reasonCode: "NATIVE_SESSION_UNVERIFIED" });
+		expect(alert.title).toBe("Not ready yet");
+		expect(alert.message).toContain("Try again in a moment");
 	});
 });

--- a/packages/mobile/lib/session/interfaceTransition.ts
+++ b/packages/mobile/lib/session/interfaceTransition.ts
@@ -105,9 +105,11 @@ const failureBackoff = [1_000, 2_000, 4_000, 8_000];
  * A spent count survives backgrounding, like the readiness window and for the
  * same reason: `appActive` re-runs the effect, so anything the effect owned
  * would make app-switching the way to refill a budget. Returning to the app is
- * news about the user, not about the link — unlike the 401 stop, which
- * foregrounding does give one fresh request, because a password is re-paired
- * outside the app.
+ * news about the user, not about the link.
+ *
+ * This never competes with the 401 stop, which foregrounding does give one
+ * fresh request: a rejection is a request that landed, so `refresh` clears the
+ * count rather than spending it, and `pollable` owns that stop on its own.
  */
 export const speculativeFailureAttempts = 5;
 
@@ -119,7 +121,9 @@ export const speculativeFailureAttempts = 5;
  *
  * Retrying on failure with no status at all is deliberate: a first fetch that
  * never landed would otherwise leave the screen with no poll to start, and the
- * switch would stay greyed out for the life of the screen.
+ * switch would stay greyed out for the life of the screen. That retry is
+ * bounded like the readiness wait — see speculativeFailureAttempts — because
+ * there is no operation in flight to keep it alive indefinitely.
  */
 export function interfaceTransitionNextPoll(args: {
 	status?: InterfaceTransitionStatus;

--- a/packages/mobile/lib/session/interfaceTransition.ts
+++ b/packages/mobile/lib/session/interfaceTransition.ts
@@ -33,6 +33,11 @@ const nativeSessionReadinessPoll = 1_000;
 // The budget is per readiness state, not per screen: the daemon reports MISSING
 // before UNVERIFIED, and that progression is real news, so it earns a fresh
 // window. Worst case is therefore two windows, not one.
+//
+// Only ANSWERS are counted here — a timeout says nothing about whether the
+// native session became ready, so it must not spend the window. That leaves
+// this budget unable to end a wait against a daemon that never answers, which
+// is what `speculativeFailureAttempts` below is for.
 export const nativeSessionReadinessAttempts = 10;
 
 export function mobileInterfaceTransitionIsActive(transition?: InterfaceTransition): boolean {
@@ -67,11 +72,7 @@ export function interfaceTransitionPollInterval(
 // known status re-arms on it: a session deleted mid-transition would 404 at
 // 300ms indefinitely. But only a 404 or 410 is the daemon's word that the
 // session is gone. A timeout, a refused connection or a 5xx is a fact about the
-// link, not the session, and a link comes back, so those are retried at a
-// backoff that holds at its ceiling instead of being counted against a budget.
-// A blanket cap on failures was tried first and stranded a live handoff behind
-// any outage longer than the budget: once the last timer had fired, connectivity
-// returning changed nothing, and the banner froze until the screen was remounted.
+// link, not the session, and a link comes back.
 //
 // 401/403/429 never reach the scheduler: the hook stops polling on those (see
 // `shouldKeepPolling`), because retrying a rejected password arms the lockout.
@@ -80,6 +81,35 @@ export function interfaceTransitionSessionGone(status: number | undefined): bool
 }
 
 const failureBackoff = [1_000, 2_000, 4_000, 8_000];
+
+/**
+ * How many consecutive failures a poll with nothing in flight will absorb
+ * before it gives up.
+ *
+ * The two waits this scheduler serves are not the same shape, so they do not
+ * share a retry policy. A live handoff is a real operation with a banner on
+ * screen: it retries until the link returns, because a blanket cap stranded one
+ * behind any outage longer than the budget — once the last timer had fired,
+ * connectivity returning changed nothing and the banner froze until the screen
+ * was remounted (#4852 review). A readiness wait is speculative: #4122 says it
+ * may never clear even on a healthy link, which is why it was given a budget at
+ * all, and against a daemon that never answers it cannot make progress by
+ * waiting longer. The same goes for a mount fetch that never landed.
+ *
+ * Five is five requests with 1+2+4+8s between them, the fifth failure being
+ * the one that stops it: about 15s against a refused connection, and about 75s
+ * when every request burns REQUEST_TIMEOUT_MS instead of answering. Past it the
+ * escape is the header recheck, tappable precisely because no transition is
+ * live, and any request that lands clears the count and restarts this loop.
+ *
+ * A spent count survives backgrounding, like the readiness window and for the
+ * same reason: `appActive` re-runs the effect, so anything the effect owned
+ * would make app-switching the way to refill a budget. Returning to the app is
+ * news about the user, not about the link — unlike the 401 stop, which
+ * foregrounding does give one fresh request, because a password is re-paired
+ * outside the app.
+ */
+export const speculativeFailureAttempts = 5;
 
 /**
  * The one scheduler for the status poll. Failures back off on their own count,
@@ -100,6 +130,10 @@ export function interfaceTransitionNextPoll(args: {
 	const failures = args.consecutiveFailures ?? 0;
 	if (failures > 0) {
 		if (interfaceTransitionSessionGone(args.failureStatus)) return undefined;
+		// A live handoff is retried for as long as the screen is open; anything
+		// else is speculative and stops. See speculativeFailureAttempts.
+		const live = mobileInterfaceTransitionIsActive(args.status?.transition);
+		if (!live && failures >= speculativeFailureAttempts) return undefined;
 		return failureBackoff[Math.min(failures - 1, failureBackoff.length - 1)];
 	}
 	return interfaceTransitionPollInterval(args.status, args.readinessAttempts ?? 0);

--- a/packages/mobile/lib/session/interfaceTransition.ts
+++ b/packages/mobile/lib/session/interfaceTransition.ts
@@ -63,19 +63,29 @@ export function interfaceTransitionPollInterval(
 	return undefined;
 }
 
-// Consecutive failed rechecks before the loop gives up. A failed request never
-// advances `status`, so a poll rescheduled from the last known status re-arms on
-// it forever: a session deleted mid-transition would 404 at 300ms indefinitely,
-// which is worse than the unbounded readiness poll this all started with. After
-// the loop stops the tap path re-asks.
-export const interfaceTransitionFailureAttempts = 5;
+// A failed request never advances `status`, so a poll rescheduled from the last
+// known status re-arms on it: a session deleted mid-transition would 404 at
+// 300ms indefinitely. But only a 404 or 410 is the daemon's word that the
+// session is gone. A timeout, a refused connection or a 5xx is a fact about the
+// link, not the session, and a link comes back, so those are retried at a
+// backoff that holds at its ceiling instead of being counted against a budget.
+// A blanket cap on failures was tried first and stranded a live handoff behind
+// any outage longer than the budget: once the last timer had fired, connectivity
+// returning changed nothing, and the banner froze until the screen was remounted.
+//
+// 401/403/429 never reach the scheduler: the hook stops polling on those (see
+// `shouldKeepPolling`), because retrying a rejected password arms the lockout.
+export function interfaceTransitionSessionGone(status: number | undefined): boolean {
+	return status === 404 || status === 410;
+}
 
 const failureBackoff = [1_000, 2_000, 4_000, 8_000];
 
 /**
- * The one scheduler for the status poll. Failures back off and are capped on
- * their own budget, because a run of failures teaches us nothing about `status`
- * and must not be paid for out of the readiness window.
+ * The one scheduler for the status poll. Failures back off on their own count,
+ * because a run of failures teaches us nothing about `status` and must not be
+ * paid for out of the readiness window. `failureStatus` is the HTTP status of
+ * the latest failure, `undefined` when nothing answered.
  *
  * Retrying on failure with no status at all is deliberate: a first fetch that
  * never landed would otherwise leave the screen with no poll to start, and the
@@ -85,10 +95,11 @@ export function interfaceTransitionNextPoll(args: {
 	status?: InterfaceTransitionStatus;
 	readinessAttempts?: number;
 	consecutiveFailures?: number;
+	failureStatus?: number;
 }): number | undefined {
 	const failures = args.consecutiveFailures ?? 0;
 	if (failures > 0) {
-		if (failures >= interfaceTransitionFailureAttempts) return undefined;
+		if (interfaceTransitionSessionGone(args.failureStatus)) return undefined;
 		return failureBackoff[Math.min(failures - 1, failureBackoff.length - 1)];
 	}
 	return interfaceTransitionPollInterval(args.status, args.readinessAttempts ?? 0);

--- a/packages/mobile/lib/session/interfaceTransition.ts
+++ b/packages/mobile/lib/session/interfaceTransition.ts
@@ -1,4 +1,10 @@
+import type { SessionInterfaceTransitionStatus } from "../chat/api";
+
 type InterfaceTransition = { phase: string };
+
+type InterfaceTransitionStatus = Pick<SessionInterfaceTransitionStatus, "reasonCode" | "reason"> & {
+	transition?: InterfaceTransition;
+};
 
 const activePhases = new Set([
 	"requested",
@@ -10,6 +16,13 @@ const activePhases = new Set([
 	"activating",
 ]);
 
+// Transient: the daemon reports these until the terminal's session-start hook
+// proves which native conversation it is running, so rechecking is what lets the
+// switch enable itself. Slow, because they are not guaranteed to clear — a
+// `--resume` relaunch stays UNVERIFIED (#4122).
+const nativeSessionReadinessCodes = new Set(["NATIVE_SESSION_MISSING", "NATIVE_SESSION_UNVERIFIED"]);
+const nativeSessionReadinessPoll = 1_000;
+
 export function mobileInterfaceTransitionIsActive(transition?: InterfaceTransition): boolean {
 	return Boolean(transition && activePhases.has(transition.phase));
 }
@@ -20,6 +33,27 @@ export function mobileInterfaceTransitionIsCancellable(transition?: InterfaceTra
 	);
 }
 
-export function interfaceTransitionPollInterval(transition?: InterfaceTransition): number | undefined {
-	return mobileInterfaceTransitionIsActive(transition) ? 300 : undefined;
+function nativeSessionReadinessPending(status?: InterfaceTransitionStatus): boolean {
+	return Boolean(status?.reasonCode && nativeSessionReadinessCodes.has(status.reasonCode));
+}
+
+export function interfaceTransitionPollInterval(status?: InterfaceTransitionStatus): number | undefined {
+	if (mobileInterfaceTransitionIsActive(status?.transition)) return 300;
+	if (nativeSessionReadinessPending(status)) return nativeSessionReadinessPoll;
+	return undefined;
+}
+
+// The daemon's reason is a Go error: fair for a verdict, useless for a wait.
+export function interfaceSwitchUnavailableMessage(
+	status?: InterfaceTransitionStatus,
+	fallbackError?: string,
+): string {
+	if (nativeSessionReadinessPending(status)) {
+		return "The terminal has not confirmed its agent conversation yet. Try again in a moment, or send the terminal a message first.";
+	}
+	return (
+		status?.reason ||
+		fallbackError ||
+		"This agent has not declared a compatible native conversation handoff."
+	);
 }

--- a/packages/mobile/lib/session/interfaceTransition.ts
+++ b/packages/mobile/lib/session/interfaceTransition.ts
@@ -1,3 +1,4 @@
+import { classifyConnectionFailure } from "../connectionError";
 import type { SessionInterfaceTransitionStatus } from "../chat/api";
 
 type InterfaceTransition = { phase: string };
@@ -18,10 +19,21 @@ const activePhases = new Set([
 
 // Transient: the daemon reports these until the terminal's session-start hook
 // proves which native conversation it is running, so rechecking is what lets the
-// switch enable itself. Slow, because they are not guaranteed to clear — a
-// `--resume` relaunch stays UNVERIFIED (#4122).
+// switch enable itself.
 const nativeSessionReadinessCodes = new Set(["NATIVE_SESSION_MISSING", "NATIVE_SESSION_UNVERIFIED"]);
 const nativeSessionReadinessPoll = 1_000;
+
+// The recheck is bounded because these codes are not guaranteed to clear at all:
+// a `--resume` relaunch stays UNVERIFIED indefinitely (#4122), so "poll until it
+// resolves" has no terminating condition and would mean one request per second
+// for as long as the screen stays open. A session that is going to settle does so
+// in about a second, so this window is generous; past it the tap path re-asks,
+// which is the escape hatch for the rare late clear.
+//
+// The budget is per readiness state, not per screen: the daemon reports MISSING
+// before UNVERIFIED, and that progression is real news, so it earns a fresh
+// window. Worst case is therefore two windows, not one.
+export const nativeSessionReadinessAttempts = 10;
 
 export function mobileInterfaceTransitionIsActive(transition?: InterfaceTransition): boolean {
 	return Boolean(transition && activePhases.has(transition.phase));
@@ -37,10 +49,49 @@ function nativeSessionReadinessPending(status?: InterfaceTransitionStatus): bool
 	return Boolean(status?.reasonCode && nativeSessionReadinessCodes.has(status.reasonCode));
 }
 
-export function interfaceTransitionPollInterval(status?: InterfaceTransitionStatus): number | undefined {
+// `readinessAttempts` counts rechecks already spent on the CURRENT readiness wait.
+// A live transition is a finite operation with terminal phases, so its 300ms poll
+// stays unbounded; only the open-ended readiness wait is capped.
+export function interfaceTransitionPollInterval(
+	status?: InterfaceTransitionStatus,
+	readinessAttempts = 0,
+): number | undefined {
 	if (mobileInterfaceTransitionIsActive(status?.transition)) return 300;
-	if (nativeSessionReadinessPending(status)) return nativeSessionReadinessPoll;
+	if (nativeSessionReadinessPending(status) && readinessAttempts < nativeSessionReadinessAttempts) {
+		return nativeSessionReadinessPoll;
+	}
 	return undefined;
+}
+
+// Consecutive failed rechecks before the loop gives up. A failed request never
+// advances `status`, so a poll rescheduled from the last known status re-arms on
+// it forever: a session deleted mid-transition would 404 at 300ms indefinitely,
+// which is worse than the unbounded readiness poll this all started with. After
+// the loop stops the tap path re-asks.
+export const interfaceTransitionFailureAttempts = 5;
+
+const failureBackoff = [1_000, 2_000, 4_000, 8_000];
+
+/**
+ * The one scheduler for the status poll. Failures back off and are capped on
+ * their own budget, because a run of failures teaches us nothing about `status`
+ * and must not be paid for out of the readiness window.
+ *
+ * Retrying on failure with no status at all is deliberate: a first fetch that
+ * never landed would otherwise leave the screen with no poll to start, and the
+ * switch would stay greyed out for the life of the screen.
+ */
+export function interfaceTransitionNextPoll(args: {
+	status?: InterfaceTransitionStatus;
+	readinessAttempts?: number;
+	consecutiveFailures?: number;
+}): number | undefined {
+	const failures = args.consecutiveFailures ?? 0;
+	if (failures > 0) {
+		if (failures >= interfaceTransitionFailureAttempts) return undefined;
+		return failureBackoff[Math.min(failures - 1, failureBackoff.length - 1)];
+	}
+	return interfaceTransitionPollInterval(args.status, args.readinessAttempts ?? 0);
 }
 
 // The daemon's reason is a Go error: fair for a verdict, useless for a wait.
@@ -56,4 +107,68 @@ export function interfaceSwitchUnavailableMessage(
 		fallbackError ||
 		"This agent has not declared a compatible native conversation handoff."
 	);
+}
+
+/**
+ * How the recheck behind a tap turned out. `not-attempted` is its own case
+ * because there is no config yet — treating that as an answer would report a
+ * cold start as an agent that cannot do Chat.
+ */
+export type InterfaceSwitchRecheck =
+	| { outcome: "answered" }
+	| { outcome: "failed"; error: string; status?: number }
+	| { outcome: "not-attempted" };
+
+/**
+ * A recheck that never got an answer is not a verdict about the agent. Without
+ * this split a connectivity failure surfaces as "This agent has not declared a
+ * compatible native conversation handoff." — telling the user their agent is
+ * incapable when in fact we never got to ask.
+ *
+ * The failure branch then splits again on the same rule the rest of the app
+ * follows (see connectionError.ts): being reached and rejected is not the same
+ * as never being reached. A rotated password sends the user to re-pair, not to
+ * go and check their Wi-Fi.
+ */
+export function interfaceSwitchAlert(
+	status?: InterfaceTransitionStatus,
+	fallbackError?: string,
+	recheck: InterfaceSwitchRecheck = { outcome: "answered" },
+): { title: string; message: string } {
+	if (recheck.outcome === "not-attempted") {
+		return {
+			title: "Not connected yet",
+			message: "AO has not finished loading this phone's connection settings. Try again in a moment.",
+		};
+	}
+	if (recheck.outcome === "failed") {
+		switch (classifyConnectionFailure(recheck.status)) {
+			case "auth":
+				return {
+					title: "AO rejected this phone",
+					message:
+						"The connection password has changed, so this phone can no longer talk to AO. Open Settings \u2192 Connect Mobile on your computer and scan the code again.",
+				};
+			case "rate-limited":
+				return {
+					title: "AO is not accepting requests",
+					message:
+						"AO has paused this phone for a minute. That usually means the connection password changed \u2014 re-scan the code in Settings \u2192 Connect Mobile on your computer.",
+				};
+			case "server-error":
+				return {
+					title: "AO could not answer",
+					message: `AO was reached but could not say whether this session can switch to Chat. ${recheck.error}`,
+				};
+			default:
+				return {
+					title: "Could not reach AO",
+					message: `This phone could not reach AO to check whether this session can switch to Chat. ${recheck.error}`,
+				};
+		}
+	}
+	return {
+		title: nativeSessionReadinessPending(status) ? "Not ready yet" : "Chat unavailable",
+		message: interfaceSwitchUnavailableMessage(status, fallbackError),
+	};
 }

--- a/packages/mobile/lib/session/useInterfaceTransition.ts
+++ b/packages/mobile/lib/session/useInterfaceTransition.ts
@@ -51,6 +51,7 @@ export function useInterfaceTransition(
 	// Lets a failed fetch reach the poll effect. Without it a first fetch that never
 	// landed leaves `status` undefined, the effect schedules nothing, and no later
 	// request is ever made — the switch stays greyed out for the life of the screen.
+	// Also what the screens key their Retry action on.
 	const [fetchFailed, setFetchFailed] = useState(false);
 	const settledRef = useRef("");
 	const onSettledRef = useRef(onSettled);
@@ -59,6 +60,21 @@ export function useInterfaceTransition(
 	// newer one already has. Only the newest is allowed to write state; otherwise a
 	// stale answer could revert a `supported: true` status back to unsupported.
 	const requestSeq = useRef(0);
+	// Consecutive failed requests and the HTTP status of the latest one. Held by
+	// the hook rather than the poll effect for the same reason `readinessRef` is
+	// (below): the effect re-runs on `appActive`, so a count it owned would
+	// restart the backoff from 1s every time the app was switched, and while
+	// failures had a budget it silently refilled that too. It is written only
+	// where a request ends, so a tap recheck and the poll loop share one count,
+	// and a stale answer never touches it. Any request that lands clears it: a
+	// start POST that the daemon accepted is proof the link is back, and leaving
+	// the count on it would open the new transition on the backoff cadence with
+	// a Retry showing for a switch that is in fact proceeding.
+	const failureRef = useRef<{ count: number; status?: number }>({ count: 0 });
+	const noteRequestLanded = useCallback(() => {
+		failureRef.current = { count: 0 };
+		setFetchFailed(false);
+	}, []);
 
 	// Resolves with the fetched status so a tap can act on a fresh answer.
 	const refresh = useCallback(async (): Promise<InterfaceTransitionRecheck | undefined> => {
@@ -74,7 +90,7 @@ export function useInterfaceTransition(
 			setStatus(next);
 			setError(undefined);
 			setPollable(true);
-			setFetchFailed(false);
+			noteRequestLanded();
 			const transition = next.transition;
 			if (transition && !mobileInterfaceTransitionIsActive(transition) && settledRef.current !== transition.id) {
 				settledRef.current = transition.id;
@@ -89,6 +105,7 @@ export function useInterfaceTransition(
 				setError(message);
 				setPollable(shouldKeepPolling(httpStatus));
 				setFetchFailed(true);
+				failureRef.current = { count: failureRef.current.count + 1, status: httpStatus };
 			}
 			// The status code rides along so the caller can tell a rejection from an
 			// unreachable daemon; `shouldKeepPolling` consumes it and drops it.
@@ -96,9 +113,12 @@ export function useInterfaceTransition(
 		} finally {
 			if (current()) setLoading(false);
 		}
-	}, [cfg, sessionId]);
+	}, [cfg, noteRequestLanded, sessionId]);
 
 	useEffect(() => {
+		// A new session or config starts with a clean count: the previous
+		// session's 404 must not stop the poll for the one that replaced it.
+		failureRef.current = { count: 0 };
 		void refresh();
 	}, [refresh]);
 
@@ -107,7 +127,15 @@ export function useInterfaceTransition(
 	// desktop's live dot on. The board poll already applies this rule.
 	const [appActive, setAppActive] = useState(() => shouldPoll(RNAppState.currentState));
 	useEffect(() => {
-		const sub = RNAppState.addEventListener("change", (s) => setAppActive(shouldPoll(s)));
+		const sub = RNAppState.addEventListener("change", (s) => {
+			const active = shouldPoll(s);
+			setAppActive(active);
+			// The board poll's stop flag lives in its effect, so it gets one fresh
+			// request per foreground and recovers once the lockout clears. `pollable`
+			// is state and would survive; give it the same second chance. A single
+			// request per app switch cannot arm anything.
+			if (active) setPollable(true);
+		});
 		return () => sub.remove();
 	}, []);
 
@@ -130,16 +158,14 @@ export function useInterfaceTransition(
 		if (readinessRef.current.key !== key) readinessRef.current = { key, attempts: 0 };
 
 		let cancelled = false;
-		// Seeded from the last fetch so a failure that happened outside this loop —
-		// the mount fetch, most importantly — still gets retried.
-		let failures = fetchFailed ? 1 : 0;
 		let timer: ReturnType<typeof setTimeout> | undefined;
 
 		const schedule = (current: SessionInterfaceTransitionStatus | undefined) => {
 			const delay = interfaceTransitionNextPoll({
 				status: current,
 				readinessAttempts: readinessRef.current.attempts,
-				consecutiveFailures: failures,
+				consecutiveFailures: failureRef.current.count,
+				failureStatus: failureRef.current.status,
 			});
 			if (cancelled || delay === undefined) return;
 			timer = setTimeout(run, delay);
@@ -159,7 +185,6 @@ export function useInterfaceTransition(
 				return;
 			}
 			if (result?.ok) {
-				failures = 0;
 				// Answers are what the readiness window is for. Counting requests would
 				// let a run of timeouts spend the whole budget without ever learning
 				// whether the native session became ready.
@@ -167,7 +192,10 @@ export function useInterfaceTransition(
 				schedule(result.status);
 				return;
 			}
-			failures += 1;
+			// `refresh` has already counted this failure. A failure never produces a
+			// new status, so the loop re-arms on the one the hook still holds; the
+			// scheduler decides from the count and the status code whether that is
+			// a backoff or, for a session the daemon says is gone, a stop.
 			schedule(statusRef.current);
 		};
 
@@ -185,6 +213,7 @@ export function useInterfaceTransition(
 			setError(undefined);
 			try {
 				const transition = await startSessionInterfaceTransition(cfg, sessionId, targetMode, policy);
+				noteRequestLanded();
 				setStatus((current) => ({
 					supported: current?.supported ?? true,
 					targetMode,
@@ -198,7 +227,7 @@ export function useInterfaceTransition(
 				setStarting(false);
 			}
 		},
-		[cfg, sessionId],
+		[cfg, noteRequestLanded, sessionId],
 	);
 
 	const cancel = useCallback(async () => {
@@ -228,6 +257,7 @@ export function useInterfaceTransition(
 					sessionId,
 					transitionId,
 				);
+				noteRequestLanded();
 				setStatus((current) =>
 					current?.transition?.id === transition.id ? { ...current, transition } : current,
 				);
@@ -239,7 +269,7 @@ export function useInterfaceTransition(
 				setAcknowledgingNotice(false);
 			}
 		},
-		[cfg, sessionId],
+		[cfg, noteRequestLanded, sessionId],
 	);
 
 	return {
@@ -251,6 +281,11 @@ export function useInterfaceTransition(
 		acknowledgingNotice,
 		error,
 		acknowledgeNoticeError,
+		// True from a failed request until the next one lands. The transition
+		// banners show a Retry while it is set: the poll keeps trying on its own at
+		// up to 8s, but a user who can see the network is back should not have to
+		// wait for the tick.
+		fetchFailed,
 		start,
 		cancel,
 		acknowledgeNotice,

--- a/packages/mobile/lib/session/useInterfaceTransition.ts
+++ b/packages/mobile/lib/session/useInterfaceTransition.ts
@@ -102,10 +102,20 @@ export function useInterfaceTransition(
 			const httpStatus = cause instanceof ApiError ? cause.status : undefined;
 			const stale = !current();
 			if (!stale) {
+				const keepPolling = shouldKeepPolling(httpStatus);
 				setError(message);
-				setPollable(shouldKeepPolling(httpStatus));
+				setPollable(keepPolling);
 				setFetchFailed(true);
-				failureRef.current = { count: failureRef.current.count + 1, status: httpStatus };
+				// A rejection is a request that LANDED: the daemon answered, so the
+				// link is not what is wrong and the failure backoff has nothing to
+				// measure. `pollable` owns the stop for those, and clearing the count
+				// keeps the two from interacting — counting them would let five app
+				// switches under a rotated password spend the speculative budget, and
+				// the sixth foreground would then get no fresh request at all, which
+				// is the one thing that notices the password was fixed.
+				failureRef.current = keepPolling
+					? { count: failureRef.current.count + 1, status: httpStatus }
+					: { count: 0 };
 			}
 			// The status code rides along so the caller can tell a rejection from an
 			// unreachable daemon; `shouldKeepPolling` consumes it and drops it.

--- a/packages/mobile/lib/session/useInterfaceTransition.ts
+++ b/packages/mobile/lib/session/useInterfaceTransition.ts
@@ -204,7 +204,21 @@ export function useInterfaceTransition(
 			cancelled = true;
 			if (timer) clearTimeout(timer);
 		};
-	}, [appActive, cfg, fetchFailed, pollable, refresh, sessionId, status?.transition?.phase, status?.reasonCode]);
+	}, [
+		appActive,
+		cfg,
+		// Deliberately a dependency and deliberately unread in the body: a mount
+		// fetch that never lands leaves `status` undefined, and this is the only
+		// thing that re-runs the effect so the loop gets scheduled at all. A
+		// dependency cleanup that drops it as unused would silently take
+		// cold-start recovery with it.
+		fetchFailed,
+		pollable,
+		refresh,
+		sessionId,
+		status?.transition?.phase,
+		status?.reasonCode,
+	]);
 
 	const start = useCallback(
 		async (targetMode: "chat" | "tui", policy: "drain" | "interrupt") => {

--- a/packages/mobile/lib/session/useInterfaceTransition.ts
+++ b/packages/mobile/lib/session/useInterfaceTransition.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { AppState as RNAppState } from "react-native";
 import type { ServerConfig } from "../config";
 import { ApiError } from "../api";
+import { shouldPoll } from "../appStatePoll";
 import { shouldKeepPolling } from "../connectionError";
 import {
 	acknowledgeSessionInterfaceTransitionNotice,
@@ -10,15 +12,24 @@ import {
 	type SessionInterfaceTransitionStatus,
 } from "../chat/api";
 import {
-	interfaceTransitionPollInterval,
+	interfaceTransitionNextPoll,
 	mobileInterfaceTransitionIsActive,
 } from "./interfaceTransition";
 
 export {
-	interfaceSwitchUnavailableMessage,
+	interfaceSwitchAlert,
 	mobileInterfaceTransitionIsActive,
 	mobileInterfaceTransitionIsCancellable,
 } from "./interfaceTransition";
+export type { InterfaceSwitchRecheck } from "./interfaceTransition";
+
+/**
+ * Discriminated so a caller can tell "asked, and the answer is no" from "could
+ * not ask". `undefined` means the recheck was never attempted (no config yet).
+ */
+export type InterfaceTransitionRecheck =
+	| { ok: true; status: SessionInterfaceTransitionStatus; stale?: boolean }
+	| { ok: false; error: string; status?: number; stale?: boolean };
 
 export function useInterfaceTransition(
 	cfg: ServerConfig | null,
@@ -37,30 +48,53 @@ export function useInterfaceTransition(
 	// rotated password would arm that lockout in five seconds and hold it there
 	// for as long as the screen stays open. Same rule as the board poll.
 	const [pollable, setPollable] = useState(true);
+	// Lets a failed fetch reach the poll effect. Without it a first fetch that never
+	// landed leaves `status` undefined, the effect schedules nothing, and no later
+	// request is ever made — the switch stays greyed out for the life of the screen.
+	const [fetchFailed, setFetchFailed] = useState(false);
 	const settledRef = useRef("");
 	const onSettledRef = useRef(onSettled);
 	onSettledRef.current = onSettled;
+	// Requests can take up to REQUEST_TIMEOUT_MS, so a slow one can resolve after a
+	// newer one already has. Only the newest is allowed to write state; otherwise a
+	// stale answer could revert a `supported: true` status back to unsupported.
+	const requestSeq = useRef(0);
 
 	// Resolves with the fetched status so a tap can act on a fresh answer.
-	const refresh = useCallback(async (): Promise<SessionInterfaceTransitionStatus | undefined> => {
+	const refresh = useCallback(async (): Promise<InterfaceTransitionRecheck | undefined> => {
 		if (!cfg || !sessionId) return undefined;
+		const seq = ++requestSeq.current;
+		const current = () => seq === requestSeq.current;
 		try {
 			const next = await getSessionInterfaceTransition(cfg, sessionId);
+			// A superseded answer is not allowed to write state, stamp `settledRef`,
+			// or fire `onSettled` — that callback is a full board refetch, and running
+			// it off a response the hook just refused to trust settles the wrong turn.
+			if (!current()) return { ok: true, status: next, stale: true };
 			setStatus(next);
 			setError(undefined);
 			setPollable(true);
+			setFetchFailed(false);
 			const transition = next.transition;
 			if (transition && !mobileInterfaceTransitionIsActive(transition) && settledRef.current !== transition.id) {
 				settledRef.current = transition.id;
 				await onSettledRef.current?.();
 			}
-			return next;
+			return { ok: true, status: next };
 		} catch (cause) {
-			setError(cause instanceof Error ? cause.message : String(cause));
-			setPollable(shouldKeepPolling(cause instanceof ApiError ? cause.status : undefined));
-			return undefined;
+			const message = cause instanceof Error ? cause.message : String(cause);
+			const httpStatus = cause instanceof ApiError ? cause.status : undefined;
+			const stale = !current();
+			if (!stale) {
+				setError(message);
+				setPollable(shouldKeepPolling(httpStatus));
+				setFetchFailed(true);
+			}
+			// The status code rides along so the caller can tell a rejection from an
+			// unreachable daemon; `shouldKeepPolling` consumes it and drops it.
+			return { ok: false, error: message, status: httpStatus, stale };
 		} finally {
-			setLoading(false);
+			if (current()) setLoading(false);
 		}
 	}, [cfg, sessionId]);
 
@@ -68,12 +102,81 @@ export function useInterfaceTransition(
 		void refresh();
 	}, [refresh]);
 
+	// The poll is also the daemon's liveness signal (see shouldPoll), so a
+	// backgrounded phone must stop ticking the roster rather than hold the
+	// desktop's live dot on. The board poll already applies this rule.
+	const [appActive, setAppActive] = useState(() => shouldPoll(RNAppState.currentState));
 	useEffect(() => {
-		const interval = interfaceTransitionPollInterval(status);
-		if (!cfg || !sessionId || interval === undefined || !pollable) return;
-		const timer = setInterval(() => void refresh(), interval);
-		return () => clearInterval(timer);
-	}, [cfg, pollable, refresh, sessionId, status?.transition?.phase, status?.reasonCode]);
+		const sub = RNAppState.addEventListener("change", (s) => setAppActive(shouldPoll(s)));
+		return () => sub.remove();
+	}, []);
+
+	// Latest status without depending on its identity: every poll returns a fresh
+	// object, and depending on it would re-run this effect on every tick.
+	const statusRef = useRef<SessionInterfaceTransitionStatus | undefined>(undefined);
+	statusRef.current = status;
+
+	// The readiness budget is keyed on the situation rather than owned by the
+	// effect, so backgrounding and returning does not hand the same wait a fresh
+	// ten attempts — `appActive` is in the dep list and would otherwise make app
+	// switching the way to restart a spent window.
+	const readinessRef = useRef({ key: "", attempts: 0 });
+
+	useEffect(() => {
+		if (!cfg || !sessionId || !pollable || !appActive) return;
+		// `sessionId` is in the key so a screen reused for another session does not
+		// inherit the previous one's spent budget.
+		const key = `${sessionId}|${status?.transition?.phase ?? ""}|${status?.reasonCode ?? ""}`;
+		if (readinessRef.current.key !== key) readinessRef.current = { key, attempts: 0 };
+
+		let cancelled = false;
+		// Seeded from the last fetch so a failure that happened outside this loop —
+		// the mount fetch, most importantly — still gets retried.
+		let failures = fetchFailed ? 1 : 0;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+
+		const schedule = (current: SessionInterfaceTransitionStatus | undefined) => {
+			const delay = interfaceTransitionNextPoll({
+				status: current,
+				readinessAttempts: readinessRef.current.attempts,
+				consecutiveFailures: failures,
+			});
+			if (cancelled || delay === undefined) return;
+			timer = setTimeout(run, delay);
+		};
+
+		// Self-scheduling rather than setInterval: the next tick is only queued once
+		// this one has come back, so an unreachable daemon holding requests open for
+		// REQUEST_TIMEOUT_MS cannot stack a dozen of them.
+		const run = async () => {
+			const result = await refresh();
+			if (cancelled) return;
+			if (result?.stale) {
+				// A superseded answer teaches us nothing and must not move either
+				// counter: the newer request owns the status. Keep the loop alive on
+				// whatever the hook actually adopted.
+				schedule(statusRef.current);
+				return;
+			}
+			if (result?.ok) {
+				failures = 0;
+				// Answers are what the readiness window is for. Counting requests would
+				// let a run of timeouts spend the whole budget without ever learning
+				// whether the native session became ready.
+				readinessRef.current.attempts += 1;
+				schedule(result.status);
+				return;
+			}
+			failures += 1;
+			schedule(statusRef.current);
+		};
+
+		schedule(statusRef.current);
+		return () => {
+			cancelled = true;
+			if (timer) clearTimeout(timer);
+		};
+	}, [appActive, cfg, fetchFailed, pollable, refresh, sessionId, status?.transition?.phase, status?.reasonCode]);
 
 	const start = useCallback(
 		async (targetMode: "chat" | "tui", policy: "drain" | "interrupt") => {

--- a/packages/mobile/lib/session/useInterfaceTransition.ts
+++ b/packages/mobile/lib/session/useInterfaceTransition.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ServerConfig } from "../config";
+import { ApiError } from "../api";
+import { shouldKeepPolling } from "../connectionError";
 import {
 	acknowledgeSessionInterfaceTransitionNotice,
 	cancelSessionInterfaceTransition,
@@ -30,6 +32,11 @@ export function useInterfaceTransition(
 	const [acknowledgingNotice, setAcknowledgingNotice] = useState(false);
 	const [acknowledgeNoticeError, setAcknowledgeNoticeError] = useState<string>();
 	const [error, setError] = useState<string>();
+	// A rejected recheck is not a failed one. The readiness poll runs at 1s, and
+	// the bridge locks a device out for a minute after five failed auths, so a
+	// rotated password would arm that lockout in five seconds and hold it there
+	// for as long as the screen stays open. Same rule as the board poll.
+	const [pollable, setPollable] = useState(true);
 	const settledRef = useRef("");
 	const onSettledRef = useRef(onSettled);
 	onSettledRef.current = onSettled;
@@ -41,6 +48,7 @@ export function useInterfaceTransition(
 			const next = await getSessionInterfaceTransition(cfg, sessionId);
 			setStatus(next);
 			setError(undefined);
+			setPollable(true);
 			const transition = next.transition;
 			if (transition && !mobileInterfaceTransitionIsActive(transition) && settledRef.current !== transition.id) {
 				settledRef.current = transition.id;
@@ -49,6 +57,7 @@ export function useInterfaceTransition(
 			return next;
 		} catch (cause) {
 			setError(cause instanceof Error ? cause.message : String(cause));
+			setPollable(shouldKeepPolling(cause instanceof ApiError ? cause.status : undefined));
 			return undefined;
 		} finally {
 			setLoading(false);
@@ -61,10 +70,10 @@ export function useInterfaceTransition(
 
 	useEffect(() => {
 		const interval = interfaceTransitionPollInterval(status);
-		if (!cfg || !sessionId || interval === undefined) return;
+		if (!cfg || !sessionId || interval === undefined || !pollable) return;
 		const timer = setInterval(() => void refresh(), interval);
 		return () => clearInterval(timer);
-	}, [cfg, refresh, sessionId, status?.transition?.phase, status?.reasonCode]);
+	}, [cfg, pollable, refresh, sessionId, status?.transition?.phase, status?.reasonCode]);
 
 	const start = useCallback(
 		async (targetMode: "chat" | "tui", policy: "drain" | "interrupt") => {

--- a/packages/mobile/lib/session/useInterfaceTransition.ts
+++ b/packages/mobile/lib/session/useInterfaceTransition.ts
@@ -13,6 +13,7 @@ import {
 } from "./interfaceTransition";
 
 export {
+	interfaceSwitchUnavailableMessage,
 	mobileInterfaceTransitionIsActive,
 	mobileInterfaceTransitionIsCancellable,
 } from "./interfaceTransition";
@@ -33,8 +34,9 @@ export function useInterfaceTransition(
 	const onSettledRef = useRef(onSettled);
 	onSettledRef.current = onSettled;
 
-	const refresh = useCallback(async () => {
-		if (!cfg || !sessionId) return;
+	// Resolves with the fetched status so a tap can act on a fresh answer.
+	const refresh = useCallback(async (): Promise<SessionInterfaceTransitionStatus | undefined> => {
+		if (!cfg || !sessionId) return undefined;
 		try {
 			const next = await getSessionInterfaceTransition(cfg, sessionId);
 			setStatus(next);
@@ -44,8 +46,10 @@ export function useInterfaceTransition(
 				settledRef.current = transition.id;
 				await onSettledRef.current?.();
 			}
+			return next;
 		} catch (cause) {
 			setError(cause instanceof Error ? cause.message : String(cause));
+			return undefined;
 		} finally {
 			setLoading(false);
 		}
@@ -56,11 +60,11 @@ export function useInterfaceTransition(
 	}, [refresh]);
 
 	useEffect(() => {
-		const interval = interfaceTransitionPollInterval(status?.transition);
+		const interval = interfaceTransitionPollInterval(status);
 		if (!cfg || !sessionId || interval === undefined) return;
 		const timer = setInterval(() => void refresh(), interval);
 		return () => clearInterval(timer);
-	}, [cfg, refresh, sessionId, status?.transition?.phase]);
+	}, [cfg, refresh, sessionId, status?.transition?.phase, status?.reasonCode]);
 
 	const start = useCallback(
 		async (targetMode: "chat" | "tui", policy: "drain" | "interrupt") => {


### PR DESCRIPTION
## Summary

- A freshly spawned Claude Code TUI session reports `NATIVE_SESSION_UNVERIFIED` until its session-start hook lands, ~1.3s after spawn. Mobile fetched the interface-transition status once on mount and only polled while a transition was already active, so the chat icon stayed unavailable until you left the screen and came back.
- Recheck the two transient readiness codes once a second — same codes and cadence as desktop's `nativeSessionReadinessPoll` (`frontend/src/renderer/hooks/useSessionInterfaceTransition.ts`), added in #3735 and extended to `NATIVE_SESSION_UNVERIFIED` in #3953. Mobile never got it. #3753 is the same bug reported on desktop.
- Refresh once on tap, so a tap landing between two polls does not alert.
- Stop the recheck on a rejected status and keep it on a transient one, reusing `shouldKeepPolling` (`lib/connectionError.ts`) — the rule the board poll already applies. A 1s poll into a rotated password would otherwise arm the bridge's five-failures-per-minute lockout in five seconds and hold it for as long as the screen stayed open. A successful recheck, or the tap-refresh above, resumes it.
- Give the readiness states plain language instead of the daemon's Go error. Every other reason is still passed through.

The Chat screen shares the hook and picks up the poll, but only the Terminal screen re-asks on tap and shows the new copy. `NATIVE_SESSION_UNVERIFIED` — the code a freshly spawned TUI session hits — is TUI-only: `interface_transition.go:526` gates it on `mode == SessionModeTUI`. `NATIVE_SESSION_MISSING` (`:519`) is not mode-gated, so a Chat session that has not started its provider conversation can sit in the same wait; its menu hint keeps the existing reason text.

Known limitation: on a never-prompted session the status now flips to `supported: true` while the POST still 409s `NATIVE_SESSION_MISSING`. That is #4842, filed separately; the new copy names the workaround.

Fixes #4841

## Test plan

- `npm run typecheck` and `npm test` (77 files / 710 tests) in `packages/mobile`
- `npx expo export --platform ios` — CI does not bundle, so this is the only local guard against a Metro-level break
- iPhone 17 Pro simulator against a packaged daemon, `fetch` wrapped to count calls: `origin/main` made 1 status call and stopped; patched made 2 (unverified, then supported) and stopped. The chat icon enables itself ~1.3s after spawn without leaving the screen.
- The stop-on-rejection rule reuses `shouldKeepPolling`, covered by `lib/connectionError.test.ts`. This package has no hook-test harness, so that path is not separately exercised in the hook itself.

