### PR TITLE
fix(mobile): re-render the board on a change, not on the poll tick

### DIFF
--- a/packages/mobile/app/(tabs)/index.tsx
+++ b/packages/mobile/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import { SessionCard } from "../../lib/SessionCard";
 import { useApp, useVisibleSessions } from "../../lib/store";
 import type { Theme } from "../../lib/theme";
 import { useTheme, useThemedStyles } from "../../lib/ThemeProvider";
+import { MINUTE_MS, useNow } from "../../lib/useNow";
 import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
 import { Button, EmptyState, HeaderIconButton, ScreenHeader, SectionHeader } from "../../lib/ui";
 
@@ -35,6 +36,9 @@ export default function FleetScreen() {
 	const [archiveOpen, setArchiveOpen] = useState(false);
 
 	const listRef = useTabScrollToTop<SectionList<DashboardSession, ListSection>>();
+
+	// Relative timestamps go stale on their own; the board owns the clock.
+	const now = useNow(MINUTE_MS);
 
 	const { sections, archived } = useMemo(() => groupSessions(t, sessions), [t, sessions]);
 
@@ -166,7 +170,7 @@ export default function FleetScreen() {
 							<SectionHeader label={section.label} color={section.color} count={section.data.length} />
 						)
 					}
-					renderItem={({ item }) => <SessionCard session={item} showProject={activeProjectId === "all"} />}
+					renderItem={({ item }) => <SessionCard session={item} showProject={activeProjectId === "all"} now={now} />}
 					ListEmptyComponent={
 						error ? (
 							<EmptyState

--- a/packages/mobile/app/notifications.tsx
+++ b/packages/mobile/app/notifications.tsx
@@ -12,6 +12,7 @@ import type { Theme } from "../lib/theme";
 import { haptics } from "../lib/haptics";
 import { notificationTarget, notificationVisual, relativeTime } from "../lib/notificationView";
 import { useApp } from "../lib/store";
+import { MINUTE_MS, useNow } from "../lib/useNow";
 import { Dot, EmptyState } from "../lib/ui";
 import { useTheme, useThemedStyles } from "../lib/ThemeProvider";
 
@@ -25,6 +26,9 @@ export default function NotificationsScreen() {
 	const styles = useThemedStyles(makeStyles);
 	const router = useRouter();
 	const { config } = useApp();
+	// This screen fetches once and pages; nothing else redraws a row, so the
+	// relative stamps need their own clock.
+	const now = useNow(MINUTE_MS);
 	const [items, setItems] = useState<NotificationRecord[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [refreshing, setRefreshing] = useState(false);
@@ -151,14 +155,14 @@ export default function NotificationsScreen() {
 							}
 						/>
 					}
-					renderItem={({ item }) => <NotificationRow item={item} onPress={() => open(item)} />}
+					renderItem={({ item }) => <NotificationRow item={item} now={now} onPress={() => open(item)} />}
 				/>
 			)}
 		</View>
 	);
 }
 
-function NotificationRow({ item, onPress }: { item: NotificationRecord; onPress: () => void }) {
+function NotificationRow({ item, now, onPress }: { item: NotificationRecord; now: number; onPress: () => void }) {
 	const t = useTheme();
 	const styles = useThemedStyles(makeStyles);
 	const v = notificationVisual(t, item.type);
@@ -174,7 +178,7 @@ function NotificationRow({ item, onPress }: { item: NotificationRecord; onPress:
 						{item.title || v.label}
 					</Text>
 					{unread ? <Dot color={t.blue} size={7} /> : null}
-					<Text style={styles.time}>{relativeTime(item.createdAt)}</Text>
+					<Text style={styles.time}>{relativeTime(item.createdAt, now)}</Text>
 				</View>
 				{item.body ? (
 					<Text style={styles.body} numberOfLines={2}>

--- a/packages/mobile/lib/SessionCard.tsx
+++ b/packages/mobile/lib/SessionCard.tsx
@@ -22,9 +22,12 @@ import { cardShell, cardShellPressed, Dot } from "./ui";
 export function SessionCard({
 	session,
 	showProject = false,
+	now,
 }: {
 	session: DashboardSession;
 	showProject?: boolean;
+	/** The board's clock, so the list owns one interval instead of one per card. */
+	now: number;
 }) {
 	const t = useTheme();
 	const styles = useThemedStyles(makeStyles);
@@ -34,7 +37,7 @@ export function SessionCard({
 	const title = sessionTitle(session);
 	const branch = showBranch(session.branch, title) ? session.branch : null;
 	const prs = prLine(session);
-	const when = relativeTime(session.lastActivityAt);
+	const when = relativeTime(session.lastActivityAt, now);
 	// Only a real tracker reference earns a chip; a hand-typed task name does
 	// not, matching desktop.
 	const issue = trackerIssueId(session.issueId);

--- a/packages/mobile/lib/keepUnchanged.test.ts
+++ b/packages/mobile/lib/keepUnchanged.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+// Type-only, so this test pulls in no React Native module at runtime.
+import type { DashboardSession } from "./api";
+import { keepUnchanged, sameJson } from "./keepUnchanged";
+
+// A session shaped like the poll actually returns one: nested PR, optional
+// fields present and absent, so the walk is exercised on the real payload.
+const session = (over: Partial<DashboardSession> = {}): DashboardSession => ({
+	id: "ao-1",
+	projectId: "ao",
+	status: "running",
+	mode: "chat",
+	branch: "ao/ao-1/root",
+	issueId: null,
+	issueTitle: null,
+	userPrompt: "check the readme",
+	displayName: "flow-check",
+	summary: null,
+	isTerminated: false,
+	createdAt: "2026-09-03T09:00:00Z",
+	lastActivityAt: "2026-09-03T09:04:12Z",
+	pr: { number: 7, url: "https://github.com/o/r/pull/7", ciStatus: "passing", mergeability: { mergeable: true, blockers: [] } },
+	...over,
+});
+
+describe("sameJson", () => {
+	it("treats a re-mapped but identical fleet as unchanged", () => {
+		expect(sameJson([session(), session({ id: "ao-2" })], [session(), session({ id: "ao-2" })])).toBe(true);
+	});
+
+	it.each([
+		["a status", { status: "waiting_input" }],
+		["an activity timestamp", { lastActivityAt: "2026-09-03T09:05:00Z" }],
+		["a nulled field", { branch: null }],
+		["termination", { isTerminated: true }],
+	])("sees %s change", (_name, over) => {
+		expect(sameJson(session(), session(over))).toBe(false);
+	});
+
+	it("sees a change nested inside the PR", () => {
+		const before = session();
+		const after = session({ pr: { ...before.pr!, ciStatus: "failing" } });
+		expect(sameJson(before, after)).toBe(false);
+	});
+
+	it("sees a change nested two levels down, inside mergeability", () => {
+		const before = session();
+		const after = session({ pr: { ...before.pr!, mergeability: { mergeable: false, blockers: ["conflicts"] } } });
+		expect(sameJson(before, after)).toBe(false);
+	});
+
+	it("sees a session appear and disappear", () => {
+		expect(sameJson([session()], [session(), session({ id: "ao-2" })])).toBe(false);
+		expect(sameJson([session(), session({ id: "ao-2" })], [session()])).toBe(false);
+	});
+
+	// The daemon orders the board; a reorder is a real change to render.
+	it("sees a reorder", () => {
+		expect(sameJson([session(), session({ id: "ao-2" })], [session({ id: "ao-2" }), session()])).toBe(false);
+	});
+
+	// A hand-written field list would go blind to a field added later. This is
+	// the property that makes the deep compare the safe choice.
+	it("sees a field the comparison was never told about", () => {
+		expect(sameJson(session(), { ...session(), somethingAddedLater: true })).toBe(false);
+	});
+
+	it("does not confuse an empty array with an empty object", () => {
+		expect(sameJson([], {})).toBe(false);
+	});
+
+	it("distinguishes null, undefined and absent", () => {
+		expect(sameJson({ pr: null }, { pr: undefined })).toBe(false);
+		expect(sameJson({ pr: undefined }, {})).toBe(false);
+	});
+
+});
+
+describe("keepUnchanged", () => {
+	// The point of the whole module: an unchanged poll tick must hand React back
+	// the array it already holds, or it re-renders every card on the board.
+	it("returns the previous array when the tick brought nothing new", () => {
+		const prev = [session()];
+		expect(keepUnchanged(prev, [session()])).toBe(prev);
+	});
+
+	it("returns the new array when something moved", () => {
+		const prev = [session()];
+		const next = [session({ status: "done" })];
+		expect(keepUnchanged(prev, next)).toBe(next);
+	});
+
+	it("holds for the stats object too", () => {
+		const prev = { totalSessions: 3, workingSessions: 1 };
+		expect(keepUnchanged(prev, { totalSessions: 3, workingSessions: 1 })).toBe(prev);
+		expect(keepUnchanged(prev, { totalSessions: 3, workingSessions: 2 })).not.toBe(prev);
+	});
+
+	it("starts from empty without pretending an arriving fleet is unchanged", () => {
+		const empty: DashboardSession[] = [];
+		expect(keepUnchanged(empty, [])).toBe(empty);
+		expect(keepUnchanged(empty, [session()])).not.toBe(empty);
+	});
+});

--- a/packages/mobile/lib/keepUnchanged.ts
+++ b/packages/mobile/lib/keepUnchanged.ts
@@ -1,0 +1,42 @@
+/**
+ * Deep equality for the daemon's JSON read model.
+ *
+ * Deep rather than a field list like `sameServerConfig`: a `DashboardSession`
+ * carries two dozen fields plus a nested PR, and a hand-written comparison goes
+ * blind to the next field someone adds — dropping a real update. Everything
+ * compared here came from `JSON.parse` and a pure mapping, so there are no
+ * functions, Dates or cycles to handle.
+ */
+export function sameJson(a: unknown, b: unknown): boolean {
+	if (Object.is(a, b)) return true;
+	if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
+	if (Array.isArray(a) !== Array.isArray(b)) return false;
+	if (Array.isArray(a) && Array.isArray(b)) {
+		if (a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i += 1) {
+			if (!sameJson(a[i], b[i])) return false;
+		}
+		return true;
+	}
+	const left = a as Record<string, unknown>;
+	const right = b as Record<string, unknown>;
+	const keys = Object.keys(left);
+	if (keys.length !== Object.keys(right).length) return false;
+	for (const key of keys) {
+		// A present `undefined` and an absent key count as different; both sides
+		// come from the same mapper, so equal input cannot differ that way.
+		if (!Object.prototype.hasOwnProperty.call(right, key)) return false;
+		if (!sameJson(left[key], right[key])) return false;
+	}
+	return true;
+}
+
+/**
+ * The previous value when the new one carries the same data, so state that is
+ * re-fetched on a timer only changes identity when something moved:
+ *
+ *     setSessions((prev) => keepUnchanged(prev, next));
+ */
+export function keepUnchanged<T>(prev: T, next: T): T {
+	return sameJson(prev, next) ? prev : next;
+}

--- a/packages/mobile/lib/store.tsx
+++ b/packages/mobile/lib/store.tsx
@@ -30,6 +30,7 @@ import { activeHost, loadHosts } from "./hosts";
 import { shouldReRace } from "./reRace";
 import { shouldRaceForUpgrade, UPGRADE_RACE_CHECK_MS } from "./upgradeRace";
 import { sameServerConfig } from "./sameConfig";
+import { keepUnchanged } from "./keepUnchanged";
 import { shouldShowLoading } from "./configLoading";
 import { shouldKeepPolling } from "./connectionError";
 import { primeInstallId } from "./installId";
@@ -221,7 +222,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
 			// Read alongside the config so a failure can be explained: a stored
 			// tunnel that no longer answers is a rotated hostname, not a machine
 			// that is merely out of range.
-			setActiveEndpoints((await activeHost())?.endpoints ?? []);
+			const endpoints = (await activeHost())?.endpoints ?? [];
+			setActiveEndpoints((current) => keepUnchanged(current, endpoints));
 		} finally {
 			setConfigResolved(true);
 		}
@@ -291,11 +293,13 @@ export function AppProvider({ children }: { children: ReactNode }) {
 			// getSessions returns projects, so don't fetch /projects again alongside
 			// it — that duplicate doubled the auth attempts spent per failing tick.
 			const sess = await getSessions(c, "all");
-			setProjects(sess.projects);
-			setSessions(sess.sessions);
-			setOrchestrators(sess.orchestrators);
+			// Most ticks bring back the fleet exactly as it was; keep the previous
+			// value so React bails out of the render — see keepUnchanged.
+			setProjects((prev) => keepUnchanged(prev, sess.projects));
+			setSessions((prev) => keepUnchanged(prev, sess.sessions));
+			setOrchestrators((prev) => keepUnchanged(prev, sess.orchestrators));
 			setOrchestratorId(sess.orchestratorId);
-			setStats(sess.stats);
+			setStats((prev) => keepUnchanged(prev, sess.stats));
 			setError(null);
 			setErrorStatus(null);
 			setConnection("open");
@@ -515,6 +519,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
 		}),
 		[
 			config,
+			activeEndpoints,
 			projects,
 			sessions,
 			orchestrators,

--- a/packages/mobile/lib/useNow.ts
+++ b/packages/mobile/lib/useNow.ts
@@ -1,24 +1,47 @@
 import { useEffect, useState } from "react";
 import { AppState } from "react-native";
 
+import { shouldPoll } from "./appStatePoll";
+
 /**
  * A clock for text that goes stale on its own — relative timestamps.
  *
  * One interval per screen rather than one per row: pass `now` down and let each
  * row compute its own label. `interval` should be the coarsest step the label
  * can take; a label can trail its true value by up to one tick.
+ *
+ * The clock stops while the app is backgrounded, on the same predicate as the
+ * board poll. React Native does not suspend JS timers for us: iOS hands pending
+ * timers to an NSTimer on the way out (RCTTiming's sleep timer) and Android's
+ * JS thread never stops, so a clock left running would redraw every row of a
+ * screen nobody is looking at, once a tick, for as long as the app lives.
  */
 export function useNow(interval: number): number {
 	const [now, setNow] = useState(() => Date.now());
 
 	useEffect(() => {
-		const id = setInterval(() => setNow(Date.now()), interval);
-		// Timers do not fire while backgrounded, so re-read on the way back in.
+		const tick = () => setNow(Date.now());
+		// Undefined while the clock is stopped for the background. Kept in the
+		// effect rather than in state so that leaving costs no render at all.
+		let id: ReturnType<typeof setInterval> | undefined;
+		const stop = () => {
+			if (id !== undefined) clearInterval(id);
+			id = undefined;
+		};
+		if (shouldPoll(AppState.currentState)) id = setInterval(tick, interval);
 		const sub = AppState.addEventListener("change", (state) => {
-			if (state === "active") setNow(Date.now());
+			if (!shouldPoll(state)) {
+				stop();
+			} else if (id === undefined) {
+				// Back from the background: the labels may be several ticks stale,
+				// so read the clock now rather than at the first tick. `inactive`
+				// never lands here — the timer kept running through it.
+				tick();
+				id = setInterval(tick, interval);
+			}
 		});
 		return () => {
-			clearInterval(id);
+			stop();
 			sub.remove();
 		};
 	}, [interval]);

--- a/packages/mobile/lib/useNow.ts
+++ b/packages/mobile/lib/useNow.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { AppState } from "react-native";
+
+/**
+ * A clock for text that goes stale on its own — relative timestamps.
+ *
+ * One interval per screen rather than one per row: pass `now` down and let each
+ * row compute its own label. `interval` should be the coarsest step the label
+ * can take; a label can trail its true value by up to one tick.
+ */
+export function useNow(interval: number): number {
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		const id = setInterval(() => setNow(Date.now()), interval);
+		// Timers do not fire while backgrounded, so re-read on the way back in.
+		const sub = AppState.addEventListener("change", (state) => {
+			if (state === "active") setNow(Date.now());
+		});
+		return () => {
+			clearInterval(id);
+			sub.remove();
+		};
+	}, [interval]);
+
+	return now;
+}
+
+/** The step `relativeTime` moves in below an hour. */
+export const MINUTE_MS = 60_000;

--- a/packages/mobile/lib/usePRSummaries.ts
+++ b/packages/mobile/lib/usePRSummaries.ts
@@ -41,8 +41,8 @@ export function usePRSummaries(sessionIds: string[]): PRSummaryLookup {
 	const [generation, setGeneration] = useState(0);
 	const fetchedGeneration = useRef(-1);
 
-	// The array identity changes on every 8s poll, so the effect keys on the
-	// contents. Without this it would re-run continuously.
+	// Keyed on the ids, not the array: a tick that changes any session field
+	// yields a new array even when the id set is unchanged.
 	const key = sessionIds.join(",");
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary

- Keep the previous value when the mapped payload matches, the idiom `reloadConfig` already uses for the config object at `store.tsx:218`. New `keepUnchanged.ts` compares structurally — deep rather than a field list, because `DashboardSession` carries two dozen fields plus a nested PR, and a hand-written comparison goes blind to the next field someone adds, which fails the wrong way by dropping a real update.
- `activeEndpoints` was in the context value but missing from its `useMemo` deps. The churn was hiding it: the value object was rebuilt every tick anyway, so a re-raced endpoint list reached consumers by accident. Fixed here rather than left as a landmine, and guarded the same way, since `activeHost()` re-parses storage into a fresh array on every resolve.
- Relative timestamps were riding on that churn. The board and the notifications list now own a one-minute clock (`useNow.ts`) — the coarsest step `relativeTime` takes — instead of redrawing on someone else's schedule.

Deliberately not memoizing `SessionCard` here: the array reuse is the fix, and per-row memo is only worth adding once it has been measured.

Fixes #4853

## Test plan

- `npm run typecheck` and `npm test` (78 files / 717 tests) in `packages/mobile`
- `npx expo export --platform ios` — CI does not bundle, so this is the only local guard against a Metro-level break
- iPhone 17 Pro simulator, Debug build against a packaged daemon, render counters inside `FleetScreen` and `SessionCard`, board left idle for 90s with two cards visible:

  | | FleetScreen | SessionCard |
  |---|---|---|
  | guard bypassed (`main`'s behaviour) | 12 | 24 |
  | with the guard | 1 | 2 |

  The one remaining render is the minute clock, not the poll.
- Guard is not inert: `/sessions`, `/orchestrators` and `/projects` polled twice at 9s apart and again at 45s apart on a 12-session fleet came back structurally identical every time, so a quiet tick really is a no-op.