### PR TITLE
fix: restore Recent projects subtitle on home page

### DIFF
--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -188,6 +188,7 @@ export function HomePage() {
 					</div>
 
 					<div className="-mt-3 space-y-1 px-3">
+						<h2 className="text-[17px] font-medium tracking-[-0.01em] text-foreground/80">{t("home.recentProjects")}</h2>
 						{recentProjects.map((project) => (
 							<ProjectRow
 								key={project.id}


### PR DESCRIPTION
## Summary
- Restore the **Recent projects** subtitle above the recent-project list on the home page
- Brings back the section label that was dropped in the home page redesign

## Test plan
- [ ] Open the home page with at least one recent project
- [ ] Confirm **Recent projects** appears above the list
- [ ] Confirm project rows still open correctly on click