### PR TITLE
fix(session): mark truncated delegated task titles

### DIFF
--- a/backend/internal/service/session/delegation.go
+++ b/backend/internal/service/session/delegation.go
@@ -169,7 +169,11 @@ func delegatedTaskDisplayName(brief string) string {
 	if utf8.RuneCountInString(title) <= delegatedTaskTitleLimit {
 		return title
 	}
-	return strings.TrimSpace(string([]rune(title)[:delegatedTaskTitleLimit]))
+	truncated := string([]rune(title)[:delegatedTaskTitleLimit-1])
+	if lastSpace := strings.LastIndexByte(truncated, ' '); lastSpace > 0 {
+		truncated = truncated[:lastSpace]
+	}
+	return strings.TrimSpace(truncated) + "…"
 }
 
 func taskTitleDelegationMessage(workerID domain.SessionID, in DelegateTaskInput) string {

--- a/backend/internal/service/session/delegation_test.go
+++ b/backend/internal/service/session/delegation_test.go
@@ -46,7 +46,7 @@ func TestDelegateTaskSpawnsWorkerThenRequestsTitleFromNewestActiveOrchestrator(t
 			if out.WorkerID != "mer-9" || out.OrchestratorID != "" {
 				t.Fatalf("out = %#v, want worker mer-9 with asynchronous title handoff", out)
 			}
-			if !cmd.spawned || cmd.spawnedCfg.ProjectID != "ao" || cmd.spawnedCfg.Kind != domain.KindWorker || cmd.spawnedCfg.Harness != tt.wantAgent || cmd.spawnedCfg.Prompt != brief || cmd.spawnedCfg.DisplayName != "Fix the renderer wit" {
+			if !cmd.spawned || cmd.spawnedCfg.ProjectID != "ao" || cmd.spawnedCfg.Kind != domain.KindWorker || cmd.spawnedCfg.Harness != tt.wantAgent || cmd.spawnedCfg.Prompt != brief || cmd.spawnedCfg.DisplayName != "Fix the renderer…" {
 				t.Fatalf("spawn cfg = %#v", cmd.spawnedCfg)
 			}
 			if cmd.spawnedCfg.AgentConfig.Model != strings.TrimSpace(tt.model) {
@@ -87,8 +87,9 @@ func TestDelegatedTaskDisplayName(t *testing.T) {
 	}{
 		{name: "empty", brief: " \n\t ", want: "Untitled task"},
 		{name: "short", brief: "  tell me a joke  ", want: "tell me a joke"},
-		{name: "whitespace", brief: "Fix the renderer\nwithout changing the API", want: "Fix the renderer wit"},
-		{name: "unicode rune limit", brief: "一二三四五六七八九十一二三四五六七八九十一", want: "一二三四五六七八九十一二三四五六七八九十"},
+		{name: "whitespace", brief: "Fix the renderer\nwithout changing the API", want: "Fix the renderer…"},
+		{name: "reported phrase", brief: "build a function for palindrome number", want: "build a function…"},
+		{name: "unicode rune limit", brief: "一二三四五六七八九十一二三四五六七八九十一", want: "一二三四五六七八九十一二三四五六七八九…"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := delegatedTaskDisplayName(tt.brief); got != tt.want {


### PR DESCRIPTION
## What

Truncate provisional delegated-task display names at a word boundary and add an ellipsis while preserving the existing 20-rune limit.

## Why

A hard cut could turn a task brief into a phrase such as “build a function for”, producing the confusing notification title “build a function for needs your input”.

Fixes #4846.

## How

Reserve one rune for the ellipsis, prefer the final word boundary in the remaining prefix, and fall back to rune-safe truncation for unbroken text.

## Testing

- GOCACHE=/private/tmp/ao-go-cache go test ./internal/service/session ./internal/notify
- Added coverage for the reported phrase and rune-safe Unicode truncation.

## Checklist

- [x] Branched from main
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant backend tests pass locally