### PR TITLE
fix(mobile): send required PR merge payload

### DIFF
--- a/packages/mobile/lib/api.ts
+++ b/packages/mobile/lib/api.ts
@@ -32,6 +32,12 @@ export type DashboardPR = {
 	unresolvedThreads?: number;
 };
 
+export type MergePRInput = {
+	number: number;
+	url: string;
+	headSha: string;
+};
+
 export type DashboardSession = {
 	id: string;
 	projectId: string;
@@ -651,6 +657,7 @@ export type SessionPRSummary = {
 	author: string;
 	sourceBranch: string;
 	targetBranch: string;
+	headSha: string;
 	additions: number;
 	deletions: number;
 	changedFiles: number;
@@ -770,8 +777,11 @@ export async function launchOrchestrator(
 	};
 }
 
-export async function mergePR(cfg: ServerConfig, pr: DashboardPR): Promise<void> {
-	await req(cfg, `${API}/prs/${pr.number}/merge`, { method: "POST" });
+export async function mergePR(cfg: ServerConfig, pr: MergePRInput): Promise<void> {
+	await req(cfg, `${API}/prs/${pr.number}/merge`, {
+		method: "POST",
+		body: JSON.stringify({ prUrl: pr.url, expectedHeadSha: pr.headSha }),
+	});
 }
 
 // Quick reachability probe for the Settings "Test connection" button.

--- a/packages/mobile/lib/chatModeApi.test.ts
+++ b/packages/mobile/lib/chatModeApi.test.ts
@@ -5,7 +5,7 @@ vi.mock("expo-secure-store", () => ({ getItemAsync: vi.fn(), setItemAsync: vi.fn
 vi.mock("expo/fetch", () => ({ fetch: vi.fn() }));
 
 import { fetch as expoFetch } from "expo/fetch";
-import { ApiError, apiRequest, delegateTask, getAgentModels, getPreview, getSessions, getSettings, launchOrchestrator, mobileReachablePreviewURL, restoreSession, resumeSessionAgent, spawnSession } from "./api";
+import { ApiError, apiRequest, delegateTask, getAgentModels, getPreview, getSessions, getSettings, launchOrchestrator, mergePR, mobileReachablePreviewURL, restoreSession, resumeSessionAgent, spawnSession } from "./api";
 import * as chatApi from "./chat/api";
 import type { ServerConfig } from "./config";
 
@@ -88,6 +88,23 @@ describe("mobile Chat API boundaries", () => {
 		const [, init] = vi.mocked(fetch).mock.calls[0];
 		expect(JSON.parse(String(init?.body))).toMatchObject({ projectId: "p-1", clean: true, mode: "tui" });
 		expect(orchestrator.mode).toBe("tui");
+	});
+
+	it("sends the PR URL and observed head SHA when merging", async () => {
+		vi.mocked(fetch).mockResolvedValue(response({ ok: true, prNumber: 42, method: "squash" }));
+
+		await mergePR(cfg, {
+			number: 42,
+			url: "https://github.com/acme/widgets/pull/42",
+			headSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		});
+
+		const [url, init] = vi.mocked(fetch).mock.calls[0];
+		expect(url).toBe("http://ao.test:3011/api/v1/prs/42/merge");
+		expect(JSON.parse(String(init?.body))).toEqual({
+			prUrl: "https://github.com/acme/widgets/pull/42",
+			expectedHeadSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		});
 	});
 
 	it("resumes a stopped Chat controller without restoring the AO session", async () => {

--- a/packages/mobile/lib/store.tsx
+++ b/packages/mobile/lib/store.tsx
@@ -15,9 +15,9 @@ import {
 	mergePR as apiMergePR,
 	restoreSession,
 	sendMessage,
-	type DashboardPR,
 	type DashboardSession,
 	type DashboardStats,
+	type MergePRInput,
 	type OrchestratorLink,
 	type ProjectInfo,
 	type SessionMode,
@@ -81,7 +81,7 @@ type AppState = {
 	setActiveProject: (id: string) => void;
 	spawn: (opts: SpawnOptions) => Promise<DashboardSession>;
 	launchConductor: (projectId: string, clean?: boolean, mode?: SessionMode) => Promise<OrchestratorLink>;
-	merge: (pr: DashboardPR) => Promise<void>;
+	merge: (pr: MergePRInput) => Promise<void>;
 	kill: (id: string) => Promise<void>;
 	restore: (id: string) => Promise<void>;
 	send: (id: string, message: string) => Promise<void>;
@@ -452,7 +452,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
 	);
 
 	const merge = useCallback(
-		async (pr: DashboardPR) =>
+		async (pr: MergePRInput) =>
 			trackFeature("merge", async () => {
 				await apiMergePR(cfgRef.current!, pr);
 				await fetchAll();


### PR DESCRIPTION
## What

Send the PR URL and observed head SHA in the mobile merge request, matching the daemon MergePRRequest contract.

## Why

The mobile helper posted an empty body to the merge endpoint, so every invocation failed with INVALID_JSON.

Fixes #4845.

## How

Add a typed MergePRInput, retain headSha from the rich PR summary, and serialize prUrl plus expectedHeadSha in the POST body. The action remains unexposed in the UI; a future merge control still needs to respect the existing readiness reasons.

## Testing

- npm test: 77 files, 702 tests passed
- npm run typecheck
- Added an HTTP-boundary test that asserts the endpoint and exact request body.

## Checklist

- [x] Branched from main
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant mobile tests and typecheck pass locally