### PR TITLE
fix(workspacewatch): verify git toplevel belongs to the workspace (#4860)

### DIFF
--- a/backend/internal/workspacewatch/watcher.go
+++ b/backend/internal/workspacewatch/watcher.go
@@ -131,7 +131,8 @@ func discoverGitWorkspace(ctx context.Context, root string) gitWorkspace {
 	// case on Windows, where the filesystem is case-insensitive), then fall
 	// back to filesystem identity for symlinked roots.
 	toplevel := filepath.Clean(filepath.FromSlash(strings.TrimSpace(string(topRaw))))
-	if toplevel != root && !(runtime.GOOS == "windows" && strings.EqualFold(toplevel, root)) {
+	samePath := toplevel == root || (runtime.GOOS == "windows" && strings.EqualFold(toplevel, root))
+	if !samePath {
 		topInfo, topErr := os.Stat(toplevel)
 		rootInfo, rootErr := os.Stat(root)
 		if topErr != nil || rootErr != nil || !os.SameFile(topInfo, rootInfo) {

--- a/backend/internal/workspacewatch/watcher.go
+++ b/backend/internal/workspacewatch/watcher.go
@@ -122,8 +122,21 @@ func discoverGitWorkspace(ctx context.Context, root string) gitWorkspace {
 	// subdirectories. Only use the git-derived watch set when the repository
 	// actually has this workspace as its toplevel.
 	topRaw, err := aoprocess.CommandContext(ctx, "git", "-C", root, "rev-parse", "--show-toplevel").Output()
-	if err != nil || !sameWorkspaceDir(filepath.Clean(filepath.FromSlash(strings.TrimSpace(string(topRaw)))), root) {
+	if err != nil {
 		return gitWorkspace{}
+	}
+	// Git prints forward slashes on Windows and canonicalizes the toplevel
+	// through symlinks, so the reported path may differ textually from root
+	// while naming the same directory. Compare the strings first (folding
+	// case on Windows, where the filesystem is case-insensitive), then fall
+	// back to filesystem identity for symlinked roots.
+	toplevel := filepath.Clean(filepath.FromSlash(strings.TrimSpace(string(topRaw))))
+	if toplevel != root && !(runtime.GOOS == "windows" && strings.EqualFold(toplevel, root)) {
+		topInfo, topErr := os.Stat(toplevel)
+		rootInfo, rootErr := os.Stat(root)
+		if topErr != nil || rootErr != nil || !os.SameFile(topInfo, rootInfo) {
+			return gitWorkspace{}
+		}
 	}
 	gitDirRaw, err := aoprocess.CommandContext(ctx, "git", "-C", root, "rev-parse", "--absolute-git-dir").Output()
 	if err != nil {
@@ -287,19 +300,6 @@ func gitIgnored(ctx context.Context, root, target string) bool {
 		return false
 	}
 	return aoprocess.CommandContext(ctx, "git", "-C", root, "check-ignore", "-q", "--", filepath.ToSlash(rel)).Run() == nil
-}
-
-// sameWorkspaceDir reports whether left and right point at the same
-// directory. Git prints forward slashes on Windows and the filesystem may be
-// case-insensitive there, so compare cleaned paths and fold case on Windows.
-func sameWorkspaceDir(left, right string) bool {
-	if left == right {
-		return true
-	}
-	if runtime.GOOS == "windows" {
-		return strings.EqualFold(left, right)
-	}
-	return false
 }
 
 func isWithin(root, target string) bool {

--- a/backend/internal/workspacewatch/watcher.go
+++ b/backend/internal/workspacewatch/watcher.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -113,6 +114,17 @@ type gitWorkspace struct {
 }
 
 func discoverGitWorkspace(ctx context.Context, root string) gitWorkspace {
+	// Git searches upward for a repository, so rev-parse can resolve a parent
+	// repo (or a stray .git above the workspace) instead of one that belongs
+	// to this workspace. Trusting that answer watches almost nothing: the git
+	// file list is empty for the workspace, so only the root directory is
+	// registered and the non-recursive fsnotify backends never see changes in
+	// subdirectories. Only use the git-derived watch set when the repository
+	// actually has this workspace as its toplevel.
+	topRaw, err := aoprocess.CommandContext(ctx, "git", "-C", root, "rev-parse", "--show-toplevel").Output()
+	if err != nil || !sameWorkspaceDir(filepath.Clean(filepath.FromSlash(strings.TrimSpace(string(topRaw)))), root) {
+		return gitWorkspace{}
+	}
 	gitDirRaw, err := aoprocess.CommandContext(ctx, "git", "-C", root, "rev-parse", "--absolute-git-dir").Output()
 	if err != nil {
 		return gitWorkspace{}
@@ -275,6 +287,19 @@ func gitIgnored(ctx context.Context, root, target string) bool {
 		return false
 	}
 	return aoprocess.CommandContext(ctx, "git", "-C", root, "check-ignore", "-q", "--", filepath.ToSlash(rel)).Run() == nil
+}
+
+// sameWorkspaceDir reports whether left and right point at the same
+// directory. Git prints forward slashes on Windows and the filesystem may be
+// case-insensitive there, so compare cleaned paths and fold case on Windows.
+func sameWorkspaceDir(left, right string) bool {
+	if left == right {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return false
 }
 
 func isWithin(root, target string) bool {

--- a/backend/internal/workspacewatch/watcher_test.go
+++ b/backend/internal/workspacewatch/watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -121,8 +122,6 @@ func TestWatchDoesNotTurnGitStatusIndexRefreshIntoAChange(t *testing.T) {
 func TestWatchStillReportsChangesWhenWorkspaceIsNestedInAnotherRepository(t *testing.T) {
 	parent := t.TempDir()
 	runGit(t, parent, "init")
-	runGit(t, parent, "config", "user.email", "ao@example.com")
-	runGit(t, parent, "config", "user.name", "AO Tests")
 
 	// The workspace sits inside the parent repository. Git's upward search
 	// resolves the parent repo, which tracks no files under the workspace; the
@@ -147,6 +146,74 @@ func TestWatchStillReportsChangesWhenWorkspaceIsNestedInAnotherRepository(t *tes
 		t.Fatalf("write existing-directory file: %v", err)
 	}
 	waitForChange(t, changes)
+}
+
+func TestWatchReportsChangesWhenWorkspaceRootIsASymlink(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	existing := filepath.Join(repo, "src")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatalf("mkdir existing directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(existing, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write existing-directory file: %v", err)
+	}
+
+	// Git canonicalizes --show-toplevel to the real path, so a symlinked
+	// workspace root must still be recognized as the repository toplevel;
+	// otherwise the watch falls back to WalkDir, which does not descend
+	// through a symlink root, and nested edits are never reported.
+	link := filepath.Join(t.TempDir(), "workspace")
+	// A junction needs no privileges on Windows and, like a symlink, is
+	// canonicalized away by git rev-parse --show-toplevel.
+	if runtime.GOOS == "windows" {
+		if out, err := exec.Command("cmd", "/c", "mklink", "/J", link, repo).CombinedOutput(); err != nil {
+			t.Fatalf("junction workspace: %v\n%s", err, out)
+		}
+	} else if err := os.Symlink(repo, link); err != nil {
+		t.Fatalf("symlink workspace: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changes, err := Watch(ctx, link)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(existing, "main.go"), []byte("package main // updated\n"), 0o644); err != nil {
+		t.Fatalf("update existing-directory file: %v", err)
+	}
+	waitForChange(t, changes)
+}
+
+func TestDiscoverGitWorkspaceRecognizesSymlinkedToplevel(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+
+	link := filepath.Join(t.TempDir(), "workspace")
+	// A junction needs no privileges on Windows and, like a symlink, is
+	// canonicalized away by git rev-parse --show-toplevel.
+	if runtime.GOOS == "windows" {
+		if out, err := exec.Command("cmd", "/c", "mklink", "/J", link, repo).CombinedOutput(); err != nil {
+			t.Fatalf("junction workspace: %v\n%s", err, out)
+		}
+	} else if err := os.Symlink(repo, link); err != nil {
+		t.Fatalf("symlink workspace: %v", err)
+	}
+
+	// Git reports the canonical real path as the toplevel, so the workspace
+	// must be matched by filesystem identity, not by path string.
+	git := discoverGitWorkspace(context.Background(), link)
+	if !git.available {
+		t.Fatal("symlinked repository toplevel was not recognized as a git workspace")
+	}
+	if len(git.files) == 0 {
+		t.Fatal("git file list is empty for the symlinked repository toplevel")
+	}
 }
 
 func waitForChange(t *testing.T, changes <-chan struct{}) {

--- a/backend/internal/workspacewatch/watcher_test.go
+++ b/backend/internal/workspacewatch/watcher_test.go
@@ -118,6 +118,37 @@ func TestWatchDoesNotTurnGitStatusIndexRefreshIntoAChange(t *testing.T) {
 	waitForChange(t, changes)
 }
 
+func TestWatchStillReportsChangesWhenWorkspaceIsNestedInAnotherRepository(t *testing.T) {
+	parent := t.TempDir()
+	runGit(t, parent, "init")
+	runGit(t, parent, "config", "user.email", "ao@example.com")
+	runGit(t, parent, "config", "user.name", "AO Tests")
+
+	// The workspace sits inside the parent repository. Git's upward search
+	// resolves the parent repo, which tracks no files under the workspace; the
+	// watch must fall back to walking the tree instead of trusting that answer.
+	root := filepath.Join(parent, "workspace", "session")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir nested workspace: %v", err)
+	}
+	existing := filepath.Join(root, "src")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatalf("mkdir existing directory: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changes, err := Watch(ctx, root)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(existing, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write existing-directory file: %v", err)
+	}
+	waitForChange(t, changes)
+}
+
 func waitForChange(t *testing.T, changes <-chan struct{}) {
 	t.Helper()
 	select {


### PR DESCRIPTION
Closes #4860.

## Summary
- `discoverGitWorkspace` trusted `git rev-parse`, which **searches upward** for a repository. A workspace nested under another repo (worktrees under a repo, projects inside a monorepo, or a machine with a stray `.git` in a parent/home directory) resolved the **parent** repo with an empty file list for the workspace.
- With `available=true` and no files, `addInitialDirectories` registered only the root directory (plus the parent repo's `.git` metadata dirs, outside the workspace), and the non-recursive fsnotify backends (inotify on Linux, ReadDirectoryChangesW on Windows) never reported subdirectory changes — the invalidation stream died silently.
- The fix: run `git rev-parse --show-toplevel` first and only use the git-derived watch set when the toplevel **is the workspace root**; otherwise fall back to the existing `WalkDir`-based watching. Added `sameWorkspaceDir` to compare paths (git prints forward slashes on Windows; the FS is case-insensitive there).
- Note: this is orthogonal to [#4510](https://github.com/Untrivial-ai/agent-orchestrator/pull/4510) (watch-cap/degradation work in the same file); no conflicts expected, and it composes with the limiter once both land.

## Test
- New regression: `TestWatchStillReportsChangesWhenWorkspaceIsNestedInAnotherRepository` — parent repo `git init`, workspace nested inside, write into a subdirectory, expect a change. Fails on all platforms without the fix (inotify is non-recursive too).
- `cd backend; go test -race -count=1 ./internal/workspacewatch/` — all green, including `TestWatchReportsExistingAndNewDirectoryChanges`, which failed 4/4 on a machine with a stray `~/.git` before the fix.
- `go build ./...`, `go vet`, `gofmt -l` — clean.

## Reproduction notes
On a machine where `C:\Users\<user>\.git` exists: `git -C <any tmp dir> rev-parse --show-toplevel` resolved `C:/Users/<user>`, so `discoverGitWorkspace` returned `available=true, files=0` with `metadataFiles` pointing at the home-dir `.git`. Root-only fsnotify watch delivered zero events for a write into `src/` (probed directly), matching the package test timeout.
