### PR TITLE
feat(files): preview diffs before opening center tabs

### DIFF
--- a/frontend/src/renderer/components/SessionFileExplorer.test.tsx
+++ b/frontend/src/renderer/components/SessionFileExplorer.test.tsx
@@ -46,11 +46,14 @@ vi.mock("./FileContentPane", () => ({
 
 function renderWithQuery(children: ReactNode) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	return render(
-		<QueryClientProvider client={client}>
-			<TooltipProvider>{children}</TooltipProvider>
-		</QueryClientProvider>,
-	);
+	return {
+		client,
+		...render(
+			<QueryClientProvider client={client}>
+				<TooltipProvider>{children}</TooltipProvider>
+			</QueryClientProvider>,
+		),
+	};
 }
 
 describe("SessionFileExplorer", () => {
@@ -84,14 +87,36 @@ describe("SessionFileExplorer", () => {
 		expect(screen.getByTestId("tree-changed-only")).toBeInTheDocument();
 	});
 
-	it("opens docked files in the coordinated center workspace and keeps the tree visible", async () => {
+	it("previews docked files before explicitly opening them in the center workspace", async () => {
 		const onOpenFile = vi.fn();
 		renderWithQuery(<SessionFileExplorer onOpenFile={onOpenFile} sessionId="sess-explorer-center" />);
 
 		await userEvent.click(screen.getByRole("button", { name: "select src/App.tsx" }));
+		expect(screen.getByTestId("content-pane")).toHaveTextContent("src/App.tsx");
+		expect(onOpenFile).not.toHaveBeenCalled();
+
+		await userEvent.click(screen.getByRole("button", { name: "Open in center: src/App.tsx" }));
 		expect(onOpenFile).toHaveBeenCalledWith("src/App.tsx");
-		expect(screen.getByTestId("tree-changed-only")).toBeVisible();
+	});
+
+	it("reveals an externally requested file in the docked preview", () => {
+		const { client, rerender } = renderWithQuery(
+			<SessionFileExplorer sessionId="sess-explorer-reveal" revealRequest={null} />,
+		);
+
 		expect(screen.queryByTestId("content-pane")).not.toBeInTheDocument();
+		rerender(
+			<QueryClientProvider client={client}>
+				<TooltipProvider>
+					<SessionFileExplorer
+						revealRequest={{ path: "docs/notes.txt", key: 1 }}
+						sessionId="sess-explorer-reveal"
+					/>
+				</TooltipProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getByTestId("content-pane")).toHaveTextContent("docs/notes.txt");
 	});
 
 	it("keeps the tree and content side by side when maximized", async () => {

--- a/frontend/src/renderer/components/SessionFileExplorer.tsx
+++ b/frontend/src/renderer/components/SessionFileExplorer.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { ChevronLeft, Columns2, Maximize2, Minimize2, Rows3, Search } from "lucide-react";
+import {
+	ChevronLeft,
+	Columns2,
+	Maximize2,
+	Minimize2,
+	PanelTopOpen,
+	Rows3,
+	Search,
+} from "lucide-react";
 import { cn } from "../lib/utils";
 import { sessionWorkspaceFilesQueryOptions } from "../hooks/useSessionWorkspaceFiles";
 import { buildChangedOnlyTree, type TreeNode } from "../hooks/useSessionWorkspaceTree";
@@ -18,17 +26,17 @@ import { FileContentPane } from "./FileContentPane";
 type SessionFileExplorerProps = {
 	sessionId: string;
 	isMaximized?: boolean;
-	activePath?: string | null;
 	onOpenFile?: (path: string) => void;
 	onToggleMaximized?: (next: boolean) => void;
+	revealRequest?: { path: string; key: number } | null;
 };
 
 export function SessionFileExplorer({
 	sessionId,
 	isMaximized = false,
-	activePath,
 	onOpenFile,
 	onToggleMaximized,
+	revealRequest,
 }: SessionFileExplorerProps) {
 	const { t } = useTranslation();
 	const [filter, setFilter] = useState("");
@@ -53,6 +61,10 @@ export function SessionFileExplorer({
 		setSelectedPath(null);
 		setFilter("");
 	}, [sessionId]);
+
+	useEffect(() => {
+		if (revealRequest) setSelectedPath(revealRequest.path);
+	}, [revealRequest]);
 
 	// Routes vertical wheel scroll landing on the diff's own horizontal
 	// scrollbar back up to the shared scroll root, so scrolling down over a
@@ -81,13 +93,9 @@ export function SessionFileExplorer({
 	}, []);
 
 	const handleSelectPath = (node: TreeNode) => {
-		if (!isMaximized && onOpenFile) {
-			onOpenFile(node.path);
-			return;
-		}
 		setSelectedPath(node.path);
 	};
-	const treeSelectedPath = !isMaximized && onOpenFile ? (activePath ?? null) : selectedPath;
+	const treeSelectedPath = selectedPath;
 
 	return (
 		<section
@@ -178,15 +186,6 @@ export function SessionFileExplorer({
 						</ContentScrollArea>
 					</ResizablePanel>
 				</ResizablePanelGroup>
-			) : onOpenFile ? (
-				<FileTree
-					changedOnly={changedOnly}
-					changedOnlyData={changedOnlyData}
-					filterText={filter}
-					onSelectPath={handleSelectPath}
-					selectedPath={treeSelectedPath}
-					sessionId={sessionId}
-				/>
 			) : (
 				// Docked in the 316px inspector rail there isn't room for the tree
 				// and the content side by side (see git history for the version that
@@ -217,7 +216,27 @@ export function SessionFileExplorer({
 								>
 									<ChevronLeft className="size-icon-sm" aria-hidden="true" />
 								</Button>
-								<span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">{selectedPath}</span>
+								<span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+									{selectedPath}
+								</span>
+								{onOpenFile ? (
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button
+												aria-label={t("files.openInCenter", { path: selectedPath })}
+												onClick={() => onOpenFile(selectedPath)}
+												size="icon-sm"
+												type="button"
+												variant="ghost"
+											>
+												<PanelTopOpen className="size-icon-sm" aria-hidden="true" />
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent side="bottom">
+											{t("files.openInCenter", { path: selectedPath })}
+										</TooltipContent>
+									</Tooltip>
+								) : null}
 							</div>
 							<ContentScrollArea>
 								<FileContentPane annotation={annotation} path={selectedPath} sessionId={sessionId} split={split} wrap={true} />

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -429,19 +429,30 @@ vi.mock("./SessionFileExplorer", () => ({
 		isMaximized,
 		onOpenFile,
 		onToggleMaximized,
+		revealRequest,
 	}: {
 		isMaximized?: boolean;
 		onOpenFile?: (path: string) => void;
 		onToggleMaximized?: (next: boolean) => void;
+		revealRequest?: { path: string; key: number } | null;
 	}) => (
 		<div>
 			<button type="button" onClick={() => onToggleMaximized?.(!isMaximized)}>
 				{isMaximized ? "files center" : "files rail"}
 			</button>
 			{!isMaximized && onOpenFile ? (
-				<button type="button" onClick={() => onOpenFile("src/App.tsx")}>
-					open src/App.tsx
-				</button>
+				<>
+					<span>{revealRequest ? `rail preview ${revealRequest.path}` : "file tree"}</span>
+					<button type="button">select src/App.tsx</button>
+					<button type="button" onClick={() => onOpenFile("src/App.tsx")}>
+						pop out src/App.tsx
+					</button>
+					{revealRequest ? (
+						<button type="button" onClick={() => onOpenFile(revealRequest.path)}>
+							pop out {revealRequest.path}
+						</button>
+					) : null}
+				</>
 			) : null}
 		</div>
 	),
@@ -838,6 +849,8 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByText("rail preview src/panel.tsx");
+		fireEvent.click(screen.getByRole("button", { name: "pop out src/panel.tsx" }));
 		expect(await screen.findByTestId("session-file-workspace")).toHaveTextContent("src/panel.tsx");
 
 		fireEvent.click(screen.getByRole("button", { name: "New terminal" }));
@@ -920,6 +933,8 @@ describe("SessionView", () => {
 		const view = render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByText("rail preview src/panel.tsx");
+		fireEvent.click(screen.getByRole("button", { name: "pop out src/panel.tsx" }));
 		await screen.findByTestId("session-file-workspace");
 		fireEvent.click(screen.getByRole("button", { name: "reorder auxiliary tabs" }));
 		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
@@ -955,6 +970,8 @@ describe("SessionView", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByText("rail preview src/panel.tsx");
+		fireEvent.click(screen.getByRole("button", { name: "pop out src/panel.tsx" }));
 		await screen.findByTestId("session-file-workspace");
 		fireEvent.click(screen.getByRole("button", { name: "reorder auxiliary tabs" }));
 		fireEvent.click(screen.getByRole("button", { name: "Close panel.tsx" }));
@@ -996,6 +1013,8 @@ describe("SessionView", () => {
 
 		await screen.findByRole("button", { name: "Reviewer" });
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByText("rail preview src/panel.tsx");
+		fireEvent.click(screen.getByRole("button", { name: "pop out src/panel.tsx" }));
 		await screen.findByTestId("session-file-workspace");
 		fireEvent.click(screen.getByRole("button", { name: "reorder reviewer tab" }));
 		expect(screen.getByTestId("auxiliary-tab-order-sess-1")).toHaveTextContent(
@@ -1034,6 +1053,8 @@ describe("SessionView", () => {
 		const view = render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
+		await screen.findByText("rail preview src/panel.tsx");
+		fireEvent.click(screen.getByRole("button", { name: "pop out src/panel.tsx" }));
 		await screen.findByTestId("session-file-workspace");
 		fireEvent.click(screen.getByRole("button", { name: "reorder auxiliary tabs" }));
 		fireEvent.click(screen.getByRole("button", { name: "session one shell" }));
@@ -2062,12 +2083,18 @@ describe("SessionView", () => {
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 	});
 
-	it("opens docked files as center tabs while preserving the agent surface", () => {
+	it("previews docked files and only opens a center tab on explicit pop-out", () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
-		fireEvent.click(screen.getByRole("button", { name: "open src/App.tsx" }));
+		fireEvent.click(screen.getByRole("button", { name: "select src/App.tsx" }));
+
+		expect(screen.queryByRole("tab", { name: "App.tsx" })).not.toBeInTheDocument();
+		expect(screen.queryByTestId("session-file-workspace")).not.toBeInTheDocument();
+		expect(screen.getByText("terminal center")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "pop out src/App.tsx" }));
 
 		expect(screen.getByRole("tab", { name: "App.tsx" })).toHaveAttribute("aria-selected", "true");
 		expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("src/App.tsx");
@@ -2078,18 +2105,24 @@ describe("SessionView", () => {
 		expect(screen.getByRole("tab", { name: "App.tsx" })).toHaveAttribute("aria-selected", "false");
 	});
 
-	it("opens a review file target in a center tab and keeps the Files inspector visible", async () => {
+	it("previews a review file target in the Files inspector without replacing the center", async () => {
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", true));
 		render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "view review file" }));
 
 		await waitFor(() => {
-			expect(screen.getByRole("tab", { name: "panel.tsx" })).toHaveAttribute("aria-selected", "true");
-			expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("src/panel.tsx");
+			expect(screen.getByText("rail preview src/panel.tsx")).toBeInTheDocument();
 		});
+		expect(screen.queryByRole("tab", { name: "panel.tsx" })).not.toBeInTheDocument();
+		expect(screen.queryByTestId("session-file-workspace")).not.toBeInTheDocument();
+		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(useUiStore.getState().inspectorSessions["sess-1"]?.view).toBe("files");
 		expect(screen.queryByRole("button", { name: "files center" })).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "pop out src/panel.tsx" }));
+		expect(screen.getByRole("tab", { name: "panel.tsx" })).toHaveAttribute("aria-selected", "true");
+		expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("src/panel.tsx");
 	});
 
 	it("resolves a basename against workspace files before opening on a cold cache", async () => {
@@ -2125,8 +2158,9 @@ describe("SessionView", () => {
 		fireEvent.click(screen.getByRole("button", { name: "view review basename" }));
 
 		await waitFor(() => {
-			expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("docs/notes.txt");
+			expect(screen.getByText("rail preview docs/notes.txt")).toBeInTheDocument();
 		});
+		expect(screen.queryByTestId("session-file-workspace")).not.toBeInTheDocument();
 	});
 
 	it("resolves a chat basename against workspace files before opening on a cold cache", async () => {
@@ -2163,8 +2197,9 @@ describe("SessionView", () => {
 		fireEvent.click(screen.getByRole("button", { name: "open chat basename" }));
 
 		await waitFor(() => {
-			expect(screen.getByTestId("session-file-workspace")).toHaveTextContent("docs/notes.txt");
+			expect(screen.getByText("rail preview docs/notes.txt")).toBeInTheDocument();
 		});
+		expect(screen.queryByTestId("session-file-workspace")).not.toBeInTheDocument();
 	});
 
 	it("maximizes files over the whole app window and returns to the rail", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -410,6 +410,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		phase: "docked",
 	});
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
+	const [filePreviewRequestsBySession, setFilePreviewRequestsBySession] = useState<
+		Record<string, { path: string; key: number }>
+	>({});
 	const [fileTabsBySession, setFileTabsBySession] = useState<Record<string, SessionFileTabState>>({});
 	const fileTabs = fileTabsBySession[sessionId] ?? EMPTY_SESSION_FILE_TABS;
 	const [auxiliaryTabOrderBySession, setAuxiliaryTabOrderBySession] = useState<Record<string, string[]>>({});
@@ -1207,12 +1210,16 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		);
 	}, [queryClient, sessionId, t]);
 
-	const openResolvedWorkspaceFile = useCallback(
+	const revealResolvedWorkspaceFile = useCallback(
 		async (rawPath: string) => {
 			const data = await fetchWorkspaceFiles();
-			openCenterFile(matchWorkspaceFilePath(rawPath, data.files ?? []));
+			const path = matchWorkspaceFilePath(rawPath, data.files ?? []);
+			setFilePreviewRequestsBySession((current) => ({
+				...current,
+				[sessionId]: { path, key: (current[sessionId]?.key ?? 0) + 1 },
+			}));
 		},
-		[fetchWorkspaceFiles, openCenterFile],
+		[fetchWorkspaceFiles, sessionId],
 	);
 
 	const handleOpenFiles = useCallback(() => {
@@ -1223,17 +1230,17 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const handleOpenReviewFile = useCallback(
 		(target: { line?: number; path: string }) => {
 			prepareFilesInspector();
-			void openResolvedWorkspaceFile(target.path);
+			void revealResolvedWorkspaceFile(target.path);
 		},
-		[openResolvedWorkspaceFile, prepareFilesInspector],
+		[prepareFilesInspector, revealResolvedWorkspaceFile],
 	);
 
 	const handleOpenFile = useCallback(
 		(path: string) => {
 			prepareFilesInspector();
-			void openResolvedWorkspaceFile(path);
+			void revealResolvedWorkspaceFile(path);
 		},
-		[openResolvedWorkspaceFile, prepareFilesInspector],
+		[prepareFilesInspector, revealResolvedWorkspaceFile],
 	);
 
 	const handleToggleFilesPopOut = useCallback(
@@ -1665,9 +1672,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 							filesView={
 								session ? (
 									<SessionFileExplorer
-										activePath={fileTabs.activePath}
 										onOpenFile={openCenterFile}
 										onToggleMaximized={handleToggleFilesPopOut}
+										revealRequest={filePreviewRequestsBySession[sessionId] ?? null}
 										sessionId={session.id}
 									/>
 								) : null

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1405,6 +1405,7 @@
 	"files.feedbackError": "Feedback konnte nicht gesendet werden",
 	"files.minimize": "Dateien minimieren",
 	"files.maximize": "Dateien maximieren",
+	"files.openInCenter": "Im Hauptbereich öffnen: {{path}}",
 	"files.loading": "Dateien werden geladen...",
 	"files.error.load": "Dateien konnten nicht geladen werden.",
 	"files.collapseFile": "{{file}} einklappen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1565,6 +1565,7 @@
 	"files.feedbackError": "Unable to send feedback",
 	"files.minimize": "Minimize files",
 	"files.maximize": "Maximize files",
+	"files.openInCenter": "Open in center: {{path}}",
 	"files.loading": "Loading files...",
 	"files.error.load": "Unable to load files.",
 	"files.collapseFile": "Collapse {{file}}",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1424,6 +1424,7 @@
 	"files.feedbackError": "No se pudieron enviar los comentarios",
 	"files.minimize": "Minimizar archivos",
 	"files.maximize": "Maximizar archivos",
+	"files.openInCenter": "Abrir en el panel central: {{path}}",
 	"files.loading": "Cargando archivos...",
 	"files.error.load": "No se pudieron cargar los archivos.",
 	"files.collapseFile": "Contraer {{file}}",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1424,6 +1424,7 @@
 	"files.feedbackError": "Impossible d'envoyer le commentaire",
 	"files.minimize": "Réduire les fichiers",
 	"files.maximize": "Agrandir les fichiers",
+	"files.openInCenter": "Ouvrir dans le panneau central : {{path}}",
 	"files.loading": "Chargement des fichiers...",
 	"files.error.load": "Impossible de charger les fichiers.",
 	"files.collapseFile": "Réduire {{file}}",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1405,6 +1405,7 @@
 	"files.feedbackError": "フィードバックを送信できません",
 	"files.minimize": "ファイルを最小化",
 	"files.maximize": "ファイルを最大化",
+	"files.openInCenter": "中央パネルで開く: {{path}}",
 	"files.loading": "ファイルを読み込み中...",
 	"files.error.load": "ファイルを読み込めません。",
 	"files.collapseFile": "{{file}} を折りたたむ",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1405,6 +1405,7 @@
 	"files.feedbackError": "피드백을 보낼 수 없습니다",
 	"files.minimize": "파일 최소화",
 	"files.maximize": "파일 최대화",
+	"files.openInCenter": "가운데 패널에서 열기: {{path}}",
 	"files.loading": "파일 불러오는 중...",
 	"files.error.load": "파일을 불러올 수 없습니다.",
 	"files.collapseFile": "{{file}} 접기",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1424,6 +1424,7 @@
 	"files.feedbackError": "Não foi possível enviar o feedback",
 	"files.minimize": "Minimizar arquivos",
 	"files.maximize": "Maximizar arquivos",
+	"files.openInCenter": "Abrir no painel central: {{path}}",
 	"files.loading": "Carregando arquivos...",
 	"files.error.load": "Não foi possível carregar os arquivos.",
 	"files.collapseFile": "Recolher {{file}}",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1417,6 +1417,7 @@
 	"files.feedbackError": "无法发送反馈",
 	"files.minimize": "最小化文件面板",
 	"files.maximize": "最大化文件面板",
+	"files.openInCenter": "在中央面板中打开：{{path}}",
 	"files.loading": "正在加载文件...",
 	"files.error.load": "无法加载文件。",
 	"files.collapseFile": "折叠 {{file}}",


### PR DESCRIPTION
## What

- Preview selected and linked files in the right-side Files inspector.
- Keep the center terminal/agent surface unchanged until the user explicitly pops a file out.
- Add a localized, accessible open-in-center action that reuses the existing center file-tab workflow.

## Why

File and diff clicks currently open a center tab immediately, which makes the Files inspector and center workspace feel like competing experiences. This restores a unified preview-first flow while preserving the full center editor when requested.

## How

- The docked file explorer now uses its existing tree-to-content master/detail flow.
- Chat and review file links resolve workspace paths and reveal them in the inspector.
- Repeated reveal requests are keyed per session so the same file can be reopened predictably.
- The existing maximized Files view and center-tab implementation remain unchanged.

## Testing

- Manual review in the real AO Electron app using existing session history.
- npm test -- --run src/renderer/components/SessionFileExplorer.test.tsx src/renderer/components/SessionView.test.tsx — 107/107 passed.
- npm run typecheck — passed.
- npx vite build --config vite.renderer.config.ts — passed.
- Full frontend suite attempted: 3,493 passed; remaining failures are existing Windows/platform, missing landing dependency/alias, native Node ABI, and locale-sensitive failures outside this change.
- Repository lint/backend suite attempted; existing POSIX-only and optional-agent environment failures prevent it from completing on Windows.

## Checklist

- [x] Branched from main
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant frontend checks pass