### PR TITLE
fix(desktop): keep the interface-switch pill out of the session tab

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -368,8 +368,8 @@ vi.mock("./CenterPane", () => ({
 			<div data-testid={`auxiliary-tab-order-tui-${session?.id ?? "none"}`}>
 				{auxiliaryTabOrder?.join("|") ?? ""}
 			</div>
-			{topbarActions}
-			{sessionTabAction}
+			<div data-testid="tui-topbar-actions">{topbarActions}</div>
+			<div data-testid="tui-session-tab-action">{sessionTabAction}</div>
 			<div role="tablist">
 				{workspaceTabs?.map((tab) => <div key={tab.key}>{tab.content}</div>)}
 				{workspaceTabActions}
@@ -1324,6 +1324,35 @@ describe("SessionView", () => {
 		interfaceTransitionState.settling = false;
 		view.rerender(<SessionView sessionId="sess-1" />);
 		expect(chatSurface()).toHaveAttribute("data-new-work-disabled", "false");
+	});
+
+	it("keeps the interface-switch status out of the session tab while a switch runs", () => {
+		// A tab action is absolutely positioned over the tab and the label only
+		// reserves a fixed icon-width gutter for it, so the status pill has to stay
+		// in the header action region or it paints over the tab label (#4848).
+		interfaceTransitionState.status = {
+			supported: true,
+			targetMode: "chat",
+			transition: {
+				id: "switch-tui-to-chat",
+				sessionId: "sess-1",
+				sourceMode: "tui",
+				targetMode: "chat",
+				policy: "drain",
+				phase: "draining",
+				createdAt: "2026-08-06T00:00:00Z",
+				updatedAt: "2026-08-06T00:00:01Z",
+			},
+		};
+		const session = workerSession("sess-1");
+		session.mode = "tui";
+
+		render(<SessionView sessionId="sess-1" />);
+
+		const status = screen.getByRole("status");
+		expect(status).toHaveTextContent("Chat UI");
+		expect(screen.getByTestId("tui-topbar-actions")).toContainElement(status);
+		expect(screen.getByTestId("tui-session-tab-action")).not.toContainElement(status);
 	});
 
 	it("discards one session's switch consent dialog when navigating to another session", async () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1141,16 +1141,23 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		/>
 	) : null;
 	const sessionTabActions = (
-		<SessionActionsMenu inlineStatus={interfaceSwitchInlineStatus}>
+		<SessionActionsMenu>
 			{interfaceSwitchMenuItem}
 			{handoffMenuItem}
 		</SessionActionsMenu>
 	);
+	// The transition pill belongs to the session, not to one tab. A tab action is
+	// absolutely positioned over the tab and the label only reserves a fixed
+	// icon-width gutter for it, so the pill's phase copy ("Stopping controller…
+	// Chat UI") plus Cancel paints straight over the tab label. The action region
+	// is a real flex row, so the pill takes space there and the tab strip
+	// (shrink + min-w-0) yields and truncates instead of being overdrawn.
 	const sessionHeaderActions = (
 		<div
 			className="session-topbar-session-chrome flex shrink-0 items-center"
 			data-compact-session-chrome="false"
 		>
+			{interfaceSwitchInlineStatus}
 			<ShellTopbar embedded />
 		</div>
 	);


### PR DESCRIPTION
## What

Renders the interface-transition status pill in the session topbar's action region instead of passing it into `SessionPaneTab` as a tab action.

## Why

Fixes #4848.

After a TUI → Chat switch, the topbar painted the tab label, the action labels and the switch pill's `Cancel` on top of each other, leaving the strip unreadable.

The cause is not the shared portal host. Tab actions are absolutely positioned over the tab (`TerminalTabFrame`), and the label button reserves only a fixed icon-width gutter (`pr-9`) for them — sized for the overflow-menu trigger that normally sits there.

During a switch, that same slot instead holds the pill: a spinner, the phase copy (`Stopping controller… Chat UI`), and a `Cancel` button, all `whitespace-nowrap`. That is far wider than the reserved gutter, and being absolutely positioned it contributes nothing to layout, so it painted straight over the tab label. The overlap landed in a different place on each attempt because every phase string has a different width.

## How

The pill is session-level status, not a per-tab control, so it moves to `sessionHeaderActions`. That region is a real flex row, so the pill takes space and the tab strip (`shrink` + `min-w-0`) yields and truncates instead of being overdrawn. Both surfaces already route this through `session-action-region` (terminal via `topbarActions`, chat via `headerActions`), so one change covers both.

Side benefit: this moves a `role="status"` / `aria-live="polite"` element out from inside `role="tablist"`, so the tab strip is no longer announced with a live region nested inside it — one of the accessibility complaints in the issue.

Notes for reviewers:

- The issue's stated root cause (two headers portalling into the same host concurrently) did not reproduce. Instrumenting `SessionTopbarHost` with a `MutationObserver` showed the host's child count never exceeded 1, and the tab and action regions were always exactly adjacent (`[241→1009]` / `[1009→1303]`, `scrollWidth - clientWidth = 0`). The overlap was between `"Orchestrator"` and the pill's own text, inside the tab.
- `SessionActionsMenu`'s `inlineStatus` prop now has no caller. Left in place to keep this diff surgical; happy to remove it here or in a follow-up if preferred.
- In compact chrome the pill does not collapse the way `ShellTopbar`'s labels do. `.session-topbar-surface` is `overflow: hidden`, so a very narrow window clips rather than overlaps.

## Testing

Verified locally on Linux against a real drain switch (`Finish work, then switch`) with an agent turn in flight.

Instrumented the host to log geometry and flag any two overlapping text nodes:

Before — the pill sits in the tab and collides with the label:

```
headers=1 leaves=5 action=[1009→1303 w=295] *** OVERLAP(1): "Orchestrator"@268 X "Chat UI"@234
headers=1 leaves=5 action=[1009→1303 w=295] *** OVERLAP(1): "Orchestrator"@268 X "Terminal UI"@283
```

After — the action region grows to hold the pill, no overlaps:

```
headers=1 leaves=4 action=[1009→1303 w=295] actionOverflow=0 ok   (idle)
headers=1 leaves=5 action=[762→1303  w=541] actionOverflow=0 ok   (switching)
headers=1 leaves=5 action=[742→1303  w=562] actionOverflow=0 ok
headers=1 leaves=4 action=[1009→1303 w=295] actionOverflow=0 ok   (settled)
```

Also ruled out GPU compositing as a cause — the overlap reproduced identically with software rendering (`LIBGL_ALWAYS_SOFTWARE=1`).

Checks run:

- `npm run frontend:typecheck` — clean
- `npx vitest run` over `SessionView`, `SessionInterfaceSwitch`, `CenterPane`, `ChatWorkspace`, `SessionChatSurface` — 268 passed
- Added a regression test in `SessionView.test.tsx` asserting the status pill renders in the header action region and not in the session tab's action slot. Confirmed it fails against the pre-fix commit and passes after.
- Remaining full-suite failures (`src/landing/*`, `src/main/browser-profile-import`) reproduce identically on an unmodified checkout and are unrelated to this change.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
