### PR TITLE
feat(ui): rename sessions from navigation surfaces

### DIFF
--- a/docs/superpowers/plans/2026-09-04-session-rename-surfaces.md
+++ b/docs/superpowers/plans/2026-09-04-session-rename-surfaces.md
@@ -1,0 +1,271 @@
+# Session Rename Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users rename a worker session inline from either its sidebar row or its owning terminal tab by double-clicking or choosing Rename from a context menu.
+
+**Architecture:** Keep the existing daemon `PATCH /api/v1/sessions/{sessionId}` contract unchanged. Extract the existing renderer rename state/persistence into one hook used by both surfaces, while each component retains layout-specific input styling and interaction guards.
+
+**Tech Stack:** React 19, TypeScript, TanStack Query, Radix context menus, Testing Library, Vitest, Electron Forge.
+
+---
+
+### Task 1: Shared session rename behavior
+
+**Files:**
+- Create: `frontend/src/renderer/hooks/useSessionRename.ts`
+- Modify: `frontend/src/renderer/components/Sidebar.tsx:1700-1905`
+- Test: `frontend/src/renderer/components/Sidebar.test.tsx:700-750`
+
+- [ ] **Step 1: Extend the sidebar regression tests for the complete interaction**
+
+Add tests that double-click the full session button (not only the text node), right-click the row and choose `Rename fix login`, then verify Enter saves a trimmed title, Escape cancels, and neither empty nor unchanged input calls `renameSessionMock`.
+
+```tsx
+it("starts inline rename from the full row double-click target", async () => {
+	renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+	fireEvent.doubleClick(screen.getByRole("button", { name: "Open fix login" }));
+	expect(screen.getByRole("textbox", { name: "Rename fix login" })).toHaveValue("fix login");
+});
+
+it("starts the same inline rename from the session context menu", async () => {
+	const user = userEvent.setup();
+	renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+	await user.pointer({ keys: "[MouseRight]", target: screen.getByRole("button", { name: "Open fix login" }) });
+	await user.click(screen.getByRole("menuitem", { name: "Rename fix login" }));
+	expect(screen.getByRole("textbox", { name: "Rename fix login" })).toHaveFocus();
+});
+```
+
+- [ ] **Step 2: Run the sidebar tests and observe the new failures**
+
+Run: `cd frontend && npm test -- --run src/renderer/components/Sidebar.test.tsx`
+
+Expected: the full-button double-click test opens the session instead of entering edit mode, and no session Rename menu item is found.
+
+- [ ] **Step 3: Extract the shared state and persistence hook**
+
+Create a focused hook that owns edit state, draft normalization, cancellation, API persistence, and workspace-query invalidation.
+
+```ts
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef, useState } from "react";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+import { renameSession } from "../lib/rename-session";
+import type { WorkspaceSession } from "../types/workspace";
+
+export const MAX_SESSION_DISPLAY_NAME_LEN = 20;
+
+export function useSessionRename(session: Pick<WorkspaceSession, "id" | "title">) {
+	const queryClient = useQueryClient();
+	const [isEditing, setIsEditing] = useState(false);
+	const [draft, setDraft] = useState(session.title);
+	const cancelledRef = useRef(false);
+
+	const begin = useCallback(() => {
+		cancelledRef.current = false;
+		setDraft(session.title);
+		setIsEditing(true);
+	}, [session.title]);
+
+	const cancel = useCallback(() => {
+		cancelledRef.current = true;
+		setDraft(session.title);
+		setIsEditing(false);
+	}, [session.title]);
+
+	const commit = useCallback(async () => {
+		if (cancelledRef.current) {
+			cancelledRef.current = false;
+			setIsEditing(false);
+			return;
+		}
+		setIsEditing(false);
+		const name = draft.trim();
+		if (!name || name === session.title) return;
+		try {
+			await renameSession(session.id, name);
+			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+		} catch (error) {
+			console.error("Failed to rename session:", error);
+		}
+	}, [draft, queryClient, session.id, session.title]);
+
+	return { begin, cancel, commit, draft, isEditing, setDraft };
+}
+```
+
+- [ ] **Step 4: Rewire the sidebar row and expose the two entry points**
+
+Replace the component-local rename state with `useSessionRename(session)`, move `onDoubleClick` to the full session button, and wrap the non-editing row in the existing Radix menu primitives.
+
+```tsx
+const rename = useSessionRename(session);
+
+<ContextMenu>
+	<ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+	<ContextMenuContent className="min-w-44">
+		<ContextMenuItem onSelect={rename.begin}>
+			{t("shell.renameSession", { title: session.title })}
+		</ContextMenuItem>
+	</ContextMenuContent>
+</ContextMenu>
+```
+
+The button handler must use `onDoubleClick={(event) => { event.preventDefault(); event.stopPropagation(); rename.begin(); }}` and the editor must call `rename.commit()` on blur/Enter and `rename.cancel()` on Escape. Keep `maxLength={MAX_SESSION_DISPLAY_NAME_LEN}` and stop context-menu/pointer events from triggering navigation or drag.
+
+- [ ] **Step 5: Run sidebar tests until the behavior passes**
+
+Run: `cd frontend && npm test -- --run src/renderer/components/Sidebar.test.tsx`
+
+Expected: all Sidebar tests pass, including both rename entry points and save/cancel/no-op cases.
+
+- [ ] **Step 6: Commit the sidebar/shared behavior**
+
+```bash
+git add frontend/src/renderer/hooks/useSessionRename.ts frontend/src/renderer/components/Sidebar.tsx frontend/src/renderer/components/Sidebar.test.tsx
+git commit -m "feat(ui): expose session rename in sidebar"
+```
+
+### Task 2: Owning terminal-tab rename behavior
+
+**Files:**
+- Modify: `frontend/src/renderer/components/CenterPane.tsx:600-660,907-965`
+- Modify: `frontend/src/renderer/components/CenterPane.test.tsx:1-180,1010-1140`
+
+- [ ] **Step 1: Add failing terminal-tab interaction tests**
+
+Mock `renameSession`, provide a fresh `QueryClient` through `QueryClientProvider` in `renderCenterPane`, and add tests for double-click, context-menu selection, F2, Enter, Escape, and no navigation while editing.
+
+```tsx
+it("renames the owning session from a double-click on its terminal tab", async () => {
+	const user = userEvent.setup();
+	renderCenterPane({ session: worker });
+	await user.dblClick(screen.getByRole("tab", { name: /^do the thing/ }));
+	const input = screen.getByRole("textbox", { name: "Rename do the thing" });
+	await user.clear(input);
+	await user.type(input, "  clearer task  {Enter}");
+	await waitFor(() => expect(renameSessionMock).toHaveBeenCalledWith("sess-1", "clearer task"));
+});
+
+it("opens terminal-tab rename from its context menu", async () => {
+	const user = userEvent.setup();
+	renderCenterPane({ session: worker });
+	await user.pointer({ keys: "[MouseRight]", target: screen.getByRole("tab", { name: /^do the thing/ }) });
+	await user.click(screen.getByRole("menuitem", { name: "Rename do the thing" }));
+	expect(screen.getByRole("textbox", { name: "Rename do the thing" })).toHaveFocus();
+});
+```
+
+- [ ] **Step 2: Run the CenterPane tests and verify the tests fail for missing rename UI**
+
+Run: `cd frontend && npm test -- --run src/renderer/components/CenterPane.test.tsx`
+
+Expected: no rename textbox or context-menu item exists for the owning session tab.
+
+- [ ] **Step 3: Add rename mode to `SessionPaneTab` without changing tab chrome**
+
+When `session` is present, call `useSessionRename(session)`. Pass a layout-matched input through `TerminalTabFrame.editingContent`, using the same agent avatar and existing tab dimensions.
+
+```tsx
+const editingContent = rename.isEditing ? (
+	<div className="flex h-full min-w-0 flex-1 items-center gap-2 px-2">
+		{tabIcon}
+		<input
+			aria-label={t("shell.renameSession", { title: session.title })}
+			autoFocus
+			className="min-w-0 flex-1 rounded-xs border border-accent bg-background px-1 text-control text-foreground outline-none ring-1 ring-accent"
+			maxLength={MAX_SESSION_DISPLAY_NAME_LEN}
+			onBlur={() => void rename.commit()}
+			onChange={(event) => rename.setDraft(event.target.value)}
+			onFocus={(event) => event.currentTarget.select()}
+			onKeyDown={handleRenameKeyDown}
+			value={rename.draft}
+		/>
+	</div>
+) : undefined;
+```
+
+The normal tab button starts editing on double-click and F2, while retaining its current click selection and roving-tab behavior. Events from the input must not select, reorder, or reach the terminal.
+
+- [ ] **Step 4: Add the existing context-menu treatment around the owning tab**
+
+Wrap `TerminalTabFrame` in `ContextMenu` only when `session` exists and add one `ContextMenuItem` using the existing translated `shell.renameSession` label. Selecting it calls the same `rename.begin()` function as double-click and F2.
+
+```tsx
+<ContextMenu>
+	<ContextMenuTrigger asChild>{tabFrame}</ContextMenuTrigger>
+	<ContextMenuContent className="min-w-44">
+		<ContextMenuItem onSelect={rename.begin}>
+			{t("shell.renameSession", { title: session.title })}
+		</ContextMenuItem>
+	</ContextMenuContent>
+</ContextMenu>
+```
+
+- [ ] **Step 5: Run the terminal-tab and sidebar regression suites**
+
+Run: `cd frontend && npm test -- --run src/renderer/components/CenterPane.test.tsx src/renderer/components/Sidebar.test.tsx`
+
+Expected: both component suites pass with no test warnings or unhandled promise rejections.
+
+- [ ] **Step 6: Commit the terminal-tab behavior**
+
+```bash
+git add frontend/src/renderer/components/CenterPane.tsx frontend/src/renderer/components/CenterPane.test.tsx
+git commit -m "feat(ui): rename sessions from terminal tabs"
+```
+
+### Task 3: Verify, publish the review branch, and launch locally
+
+**Files:**
+- Verify only; no generated API files should change.
+
+- [ ] **Step 1: Run formatter/diff checks**
+
+Run: `git diff --check origin/main...HEAD`
+
+Expected: exit 0 with no whitespace errors.
+
+- [ ] **Step 2: Run frontend typecheck**
+
+Run: `npm run frontend:typecheck`
+
+Expected: exit 0 with no TypeScript diagnostics.
+
+- [ ] **Step 3: Run the production frontend build**
+
+Run: `cd frontend && npm run build`
+
+Expected: exit 0 with renderer, preload, and Electron main bundles produced successfully.
+
+- [ ] **Step 4: Push the feature branch and open one PR against `main`**
+
+```bash
+git push -u fork codex/session-rename-surfaces
+gh pr create --repo AgentWrapper/agent-orchestrator \
+  --base main \
+  --head Pulkit7070:codex/session-rename-surfaces \
+  --title "feat(ui): rename sessions from navigation surfaces" \
+  --body "## Summary
+- let users rename sessions by double-clicking the sidebar row or owning terminal tab
+- add Rename to both context menus while preserving the existing inline visual treatment
+- share persistence through the existing daemon rename endpoint and workspace-query refresh
+
+## Verification
+- cd frontend && npm test -- --run src/renderer/components/CenterPane.test.tsx src/renderer/components/Sidebar.test.tsx
+- npm run frontend:typecheck
+- cd frontend && npm run build
+
+The daemon and generated API contract are unchanged."
+```
+
+The PR body must summarize both interaction surfaces, list the exact tests run, and state that the daemon/API contract is unchanged.
+
+- [ ] **Step 5: Launch the real Electron app from this checkout**
+
+Follow `.agents/skills/ao-desktop-dev/SKILL.md` to select the correct isolated/real-data launch mode, start the repository's Electron development app, and leave it running so the user can rename a real session from both surfaces.
+
+- [ ] **Step 6: Report the PR number and local app state**
+
+Provide the PR link/number, branch name, verification commands with outcomes, and the exact local data mode used for the running app.

--- a/docs/superpowers/specs/2026-09-04-session-rename-surfaces-design.md
+++ b/docs/superpowers/specs/2026-09-04-session-rename-surfaces-design.md
@@ -1,0 +1,51 @@
+# Session Rename Surfaces
+
+## Goal
+
+Make session renaming easy to discover and consistent in the two places where a session name is used for navigation: the project sidebar and the owning session tab above the terminal.
+
+## Interaction
+
+- Double-clicking the session name in either surface starts inline editing.
+- Right-clicking either surface opens its existing context menu with a **Rename** action that starts the same inline editor.
+- Rename mode preserves the dimensions and visual treatment of the surrounding row or tab. The focused text input uses the existing compact input, focus, color, and radius tokens.
+- Enter or blur saves a trimmed non-empty name through the existing session rename API.
+- Escape cancels without saving.
+- Empty or unchanged values leave the existing name in place.
+- While editing, navigation, dragging, and other pointer actions from the containing row or tab must not fire.
+
+## Architecture
+
+The daemon endpoint and typed `renameSession` client already exist, so this is a renderer-only change. The sidebar keeps its current inline rename state and persistence flow, but expands the double-click target and exposes Rename in its context menu. The session terminal tab receives the equivalent edit state and uses the same API/query invalidation boundary so both surfaces refresh from the canonical session read model.
+
+Shared behavior should be extracted only if the two real call sites otherwise duplicate meaningful state or save/cancel logic. Styling remains local to each surface because a sidebar row and terminal tab have different layout constraints.
+
+## Errors and synchronization
+
+Failed requests leave the prior server-provided title visible and log through the frontend's existing error path. A successful rename invalidates the workspace query; the daemon's existing change stream continues to synchronize other clients. No optimistic durable state or backend/API changes are needed.
+
+## Accessibility
+
+- The input has a session-specific accessible label.
+- The context-menu item is keyboard reachable.
+- F2 continues to start sidebar rename and should start rename for the focused owning terminal tab where the tab keyboard model permits it.
+- Focus moves into the editor on entry and returns naturally to the renamed navigation surface after save or cancel.
+
+## Tests
+
+Component tests cover both surfaces and both entry points:
+
+- double-click enters rename mode;
+- context-menu Rename enters the same mode;
+- Enter saves the trimmed name through the daemon client and refreshes workspace data;
+- Escape cancels;
+- editing does not navigate or trigger drag behavior;
+- empty and unchanged names do not call the daemon.
+
+Frontend typecheck and build remain the broader verification gates. The real Electron development app is launched against the local AO data only after automated checks pass so the interaction can be tried manually.
+
+## Out of scope
+
+- Renaming standalone shell terminals, reviewer terminals, projects, or agent runtime identifiers.
+- Changing the daemon rename endpoint, storage schema, session IDs, or title fallback rules.
+- Introducing a modal rename dialog or new visual language.

--- a/frontend/e2e/new-task-focus.spec.ts
+++ b/frontend/e2e/new-task-focus.spec.ts
@@ -166,14 +166,13 @@ for (const animated of [false, true]) {
 	});
 }
 
-test("renderer: New task from the sidebar context menu focuses the composer prompt @T0", async ({ page }) => {
+test("renderer: New task from the sidebar project context menu focuses the composer prompt @T0", async ({ page }) => {
 	await setup(page);
 	await page.goto(`/#/projects/${projectId}/sessions/${sessionA}`);
 	await expect(page.getByRole("combobox", { name: "Message the agent" })).toBeVisible();
 	await page
 		.getByRole("button", { name: new RegExp(`Project actions for ${projectId}`) })
 		.first()
-		.locator("xpath=ancestor::li[1]")
 		.click({ button: "right", force: true });
 	await page.getByRole("menuitem", { name: /New session/ }).click();
 	await expect(page.getByRole("dialog")).toBeVisible();

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -230,7 +230,10 @@ describe("CenterPane toolbar session label", () => {
 		renderCenterPane({ session: worker, onSelectSessionTerminal });
 
 		fireEvent.contextMenu(screen.getByRole("tab", { name: /^do the thing/ }));
-		await user.click(await screen.findByRole("menuitem", { name: "Rename do the thing" }));
+		const renameItem = await screen.findByRole("menuitem", { name: "Rename do the thing" });
+		expect(renameItem).toHaveTextContent(/^Rename$/);
+		expect(renameItem.querySelector("svg")).toBeInTheDocument();
+		await user.click(renameItem);
 
 		expect(screen.getByRole("textbox", { name: "Rename do the thing" })).toHaveFocus();
 		expect(onSelectSessionTerminal).not.toHaveBeenCalled();

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,6 +34,10 @@ const visibilityMocks = vi.hoisted(() => ({
 const reorderMocks = vi.hoisted(() => ({
 	onReorder: undefined as ((values: string[]) => void) | undefined,
 }));
+
+const renameSessionMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../lib/rename-session", () => ({ renameSession: renameSessionMock }));
 
 vi.mock("motion/react", () => ({
 	Reorder: {
@@ -159,10 +164,14 @@ const defaultSwitchAgentAction = (
 
 function renderCenterPane(props: Partial<ComponentProps<typeof CenterPane>> = {}) {
 	const { topbarActions = defaultSwitchAgentAction, ...rest } = props;
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(
 		<TooltipProvider>
 			<CenterPane daemonReady theme="dark" topbarActions={topbarActions} {...rest} />
 		</TooltipProvider>,
+		{
+			wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+		},
 	);
 }
 
@@ -180,6 +189,7 @@ beforeEach(() => {
 	visibilityMocks.presentation.mockReset();
 	visibilityMocks.route.mockReset();
 	reorderMocks.onReorder = undefined;
+	renameSessionMock.mockReset().mockResolvedValue(undefined);
 });
 
 describe("CenterPane toolbar session label", () => {
@@ -198,6 +208,62 @@ describe("CenterPane toolbar session label", () => {
 		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
 		expect(screen.getByTestId("terminal-interaction-surface")).not.toHaveAttribute("inert");
 		expect(screen.queryByTestId("agent-switch-terminal-overlay")).not.toBeInTheDocument();
+	});
+
+	it("renames the owning session from a double-click on its terminal tab", async () => {
+		const user = userEvent.setup();
+		const onSelectSessionTerminal = vi.fn();
+		renderCenterPane({ session: worker, onSelectSessionTerminal });
+
+		await user.dblClick(screen.getByRole("tab", { name: /^do the thing/ }));
+		const input = screen.getByRole("textbox", { name: "Rename do the thing" });
+		await user.clear(input);
+		await user.type(input, "  clearer task  {Enter}");
+
+		await waitFor(() => expect(renameSessionMock).toHaveBeenCalledWith("sess-1", "clearer task"));
+		expect(onSelectSessionTerminal).toHaveBeenCalledOnce();
+	});
+
+	it("starts owning-session rename from its context menu", async () => {
+		const user = userEvent.setup();
+		const onSelectSessionTerminal = vi.fn();
+		renderCenterPane({ session: worker, onSelectSessionTerminal });
+
+		fireEvent.contextMenu(screen.getByRole("tab", { name: /^do the thing/ }));
+		await user.click(await screen.findByRole("menuitem", { name: "Rename do the thing" }));
+
+		expect(screen.getByRole("textbox", { name: "Rename do the thing" })).toHaveFocus();
+		expect(onSelectSessionTerminal).not.toHaveBeenCalled();
+	});
+
+	it("cancels owning-session rename with Escape", async () => {
+		const user = userEvent.setup();
+		renderCenterPane({ session: worker });
+
+		const tab = screen.getByRole("tab", { name: /^do the thing/ });
+		tab.focus();
+		await user.keyboard("{F2}");
+		const input = screen.getByRole("textbox", { name: "Rename do the thing" });
+		await user.clear(input);
+		await user.type(input, "discard this{Escape}");
+
+		expect(renameSessionMock).not.toHaveBeenCalled();
+		expect(screen.getByRole("tab", { name: /^do the thing/ })).toBeInTheDocument();
+	});
+
+	it.each(["", "do the thing"])("does not persist the no-op terminal-tab rename %j", async (nextName) => {
+		const user = userEvent.setup();
+		renderCenterPane({ session: worker });
+
+		await user.dblClick(screen.getByRole("tab", { name: /^do the thing/ }));
+		const input = screen.getByRole("textbox", { name: "Rename do the thing" });
+		expect(input).toHaveAttribute("maxlength", "20");
+		await user.clear(input);
+		if (nextName) await user.type(input, nextName);
+		await user.keyboard("{Enter}");
+
+		expect(renameSessionMock).not.toHaveBeenCalled();
+		expect(screen.getByRole("tab", { name: /^do the thing/ })).toBeInTheDocument();
 	});
 
 	it("blocks only the terminal interaction surface while the switch selector is open", () => {

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -24,6 +24,7 @@ import {
 import { useObservedAgentSwitchLifecycle } from "../hooks/useObservedAgentSwitchLifecycle";
 import { useAgentSwitchPresentationVisibility, useAgentSwitchRouteVisibility } from "../hooks/useAgentSwitchVisibility";
 import { useTabScrollEdges } from "../hooks/useTabScrollEdges";
+import { MAX_SESSION_DISPLAY_NAME_LEN, useSessionRename } from "../hooks/useSessionRename";
 import { useSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useTruncatedText } from "../hooks/useTruncatedText";
 import type { ShellTerminal } from "../hooks/useShellTerminals";
@@ -52,6 +53,7 @@ import { ShellTerminalTab } from "./ShellTerminalTab";
 import { TerminalTabFrame } from "./TerminalTabFrame";
 import { TerminalPane } from "./TerminalPane";
 import { SessionTopbarPortal } from "./SessionTopbarPortal";
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "./ui/context-menu";
 
 type CenterPaneProps = {
 	session?: WorkspaceSession;
@@ -936,15 +938,57 @@ export function SessionPaneTab({
 	const providerLabel = session ? agentLabel(session.provider) : undefined;
 	const tabIcon = session ? <AgentAvatar className="size-terminal-agent-icon" decorative provider={session.provider} /> : icon;
 	const connected = appearance === "connected";
-	return (
+	const rename = useSessionRename(session);
+	const editingContent = session && rename.isEditing ? (
+		<div className="flex h-full min-w-0 flex-1 items-center gap-2 px-2">
+			{tabIcon}
+			<input
+				aria-label={t("shell.renameSession", { title: session.title })}
+				autoFocus
+				className="min-w-0 flex-1 rounded-xs border border-accent bg-background px-1 text-control text-foreground outline-none ring-1 ring-accent"
+				maxLength={MAX_SESSION_DISPLAY_NAME_LEN}
+				onBlur={() => void rename.commit()}
+				onChange={(event) => rename.setDraft(event.target.value)}
+				onFocus={(event) => event.currentTarget.select()}
+				onKeyDown={(event) => {
+					if (event.key === "Enter") {
+						event.preventDefault();
+						event.currentTarget.blur();
+					} else if (event.key === "Escape") {
+						event.preventDefault();
+						rename.cancel();
+					}
+				}}
+				value={rename.draft}
+			/>
+		</div>
+	) : undefined;
+	const tabFrame = (
 		<TerminalTabFrame
-			action={tabAction ? <span data-testid="session-tab-action">{tabAction}</span> : undefined}
+			action={!rename.isEditing && tabAction ? <span data-testid="session-tab-action">{tabAction}</span> : undefined}
 			active={isActive}
 			buttonProps={{
 				"aria-current": isActive,
+				"aria-keyshortcuts": session ? "F2" : undefined,
 				"aria-label": [label, providerLabel, activityLabel].filter(Boolean).join(" · "),
 				"aria-selected": isActive,
-				onClick: onSelect,
+				onClick: (event) => {
+					if (event.detail > 1) return;
+					onSelect?.();
+				},
+				onDoubleClick: session
+					? (event) => {
+							event.preventDefault();
+							rename.begin();
+						}
+					: undefined,
+				onKeyDown: session
+					? (event) => {
+							if (event.key !== "F2") return;
+							event.preventDefault();
+							rename.begin();
+						}
+					: undefined,
 				role: "tab",
 				tabIndex: isActive ? 0 : -1,
 				title: title ?? (isTruncated ? label : t("terminal.sessionAria")),
@@ -953,9 +997,23 @@ export function SessionPaneTab({
 			buttonRef={ref}
 			className="w-shell-tab-connected min-w-shell-tab-min"
 			data-terminal-role={connected ? undefined : "primary"}
+			editingContent={editingContent}
 		>
 			{tabIcon}
 			<span className="truncate">{label}</span>
 		</TerminalTabFrame>
+	);
+	if (!session || rename.isEditing) return tabFrame;
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<span className="contents">{tabFrame}</span>
+			</ContextMenuTrigger>
+			<ContextMenuContent className="min-w-44">
+				<ContextMenuItem onSelect={rename.begin}>
+					{t("shell.renameSession", { title: session.title })}
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -15,6 +15,7 @@ import {
 	type ReactNode,
 	type WheelEvent as ReactWheelEvent,
 } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import {
 	findActiveAgentSwitch,
@@ -24,6 +25,7 @@ import {
 import { useObservedAgentSwitchLifecycle } from "../hooks/useObservedAgentSwitchLifecycle";
 import { useAgentSwitchPresentationVisibility, useAgentSwitchRouteVisibility } from "../hooks/useAgentSwitchVisibility";
 import { useTabScrollEdges } from "../hooks/useTabScrollEdges";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { MAX_SESSION_DISPLAY_NAME_LEN, useSessionRename } from "../hooks/useSessionRename";
 import { useSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useTruncatedText } from "../hooks/useTruncatedText";
@@ -171,6 +173,11 @@ export function CenterPane({
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const [terminalBounds, setTerminalBounds] = useState({ leftInset: 0, rightInset: 0, width: 0 });
 	const [tabOrderBySession, setTabOrderBySession] = useState<Record<string, string[]>>({});
+	const queryClient = useQueryClient();
+	const refreshWorkspaces = useCallback(
+		() => queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
+		[queryClient],
+	);
 	const isSidebarOpen = useUiStore(sidebarOccupiesLayout);
 	const sessionId = session?.id;
 	const auxiliaryTabs = useMemo<AuxiliaryTab[]>(
@@ -618,6 +625,7 @@ export function CenterPane({
 											isActive={target.kind === "worker" && !workspaceActiveTabKey}
 											label={sessionTabLabel}
 											onSelect={onSelectSessionTerminal}
+											onRenamed={refreshWorkspaces}
 											session={session}
 											tabAction={sessionTabAction}
 										/>
@@ -911,6 +919,7 @@ type SessionPaneTabProps = {
 	isActive: boolean;
 	appearance?: "primary" | "connected";
 	onSelect?: () => void;
+	onRenamed?: () => void | Promise<void>;
 	session?: WorkspaceSession;
 	icon?: ReactNode;
 	title?: string;
@@ -927,6 +936,7 @@ export function SessionPaneTab({
 	isActive,
 	appearance = "primary",
 	onSelect,
+	onRenamed,
 	session,
 	icon,
 	title,
@@ -938,7 +948,7 @@ export function SessionPaneTab({
 	const providerLabel = session ? agentLabel(session.provider) : undefined;
 	const tabIcon = session ? <AgentAvatar className="size-terminal-agent-icon" decorative provider={session.provider} /> : icon;
 	const connected = appearance === "connected";
-	const rename = useSessionRename(session);
+	const rename = useSessionRename(session, onRenamed);
 	const editingContent = session && rename.isEditing ? (
 		<div className="flex h-full min-w-0 flex-1 items-center gap-2 px-2">
 			{tabIcon}

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -949,12 +949,16 @@ export function SessionPaneTab({
 	const providerLabel = session ? agentLabel(session.provider) : undefined;
 	const tabIcon = session ? <AgentAvatar className="size-terminal-agent-icon" decorative provider={session.provider} /> : icon;
 	const connected = appearance === "connected";
-	const rename = useSessionRename(session, onRenamed);
-	const editingContent = session && rename.isEditing ? (
+	// A session object supplies the tab presentation; refresh wiring explicitly
+	// opts the owning surface into rename so shared preview/cloud tabs cannot
+	// persist a title without updating their query cache.
+	const renameSession = onRenamed ? session : undefined;
+	const rename = useSessionRename(renameSession, onRenamed);
+	const editingContent = renameSession && rename.isEditing ? (
 		<div className="flex h-full min-w-0 flex-1 items-center gap-2 px-2">
 			{tabIcon}
 			<input
-				aria-label={t("shell.renameSession", { title: session.title })}
+				aria-label={t("shell.renameSession", { title: renameSession.title })}
 				autoFocus
 				className="min-w-0 flex-1 rounded-xs border border-accent bg-background px-1 text-control text-foreground outline-none ring-1 ring-accent"
 				maxLength={MAX_SESSION_DISPLAY_NAME_LEN}
@@ -980,20 +984,20 @@ export function SessionPaneTab({
 			active={isActive}
 			buttonProps={{
 				"aria-current": isActive,
-				"aria-keyshortcuts": session ? "F2" : undefined,
+				"aria-keyshortcuts": renameSession ? "F2" : undefined,
 				"aria-label": [label, providerLabel, activityLabel].filter(Boolean).join(" · "),
 				"aria-selected": isActive,
 				onClick: (event) => {
 					if (event.detail > 1) return;
 					onSelect?.();
 				},
-				onDoubleClick: session
+				onDoubleClick: renameSession
 					? (event) => {
 							event.preventDefault();
 							rename.begin();
 						}
 					: undefined,
-				onKeyDown: session
+				onKeyDown: renameSession
 					? (event) => {
 							if (event.key !== "F2") return;
 							event.preventDefault();
@@ -1014,14 +1018,14 @@ export function SessionPaneTab({
 			<span className="truncate">{label}</span>
 		</TerminalTabFrame>
 	);
-	if (!session || rename.isEditing) return tabFrame;
+	if (!renameSession || rename.isEditing) return tabFrame;
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
 				<span className="contents">{tabFrame}</span>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="min-w-44">
-				<ContextMenuItem aria-label={t("shell.renameSession", { title: session.title })} onSelect={rename.begin}>
+				<ContextMenuItem aria-label={t("shell.renameSession", { title: renameSession.title })} onSelect={rename.begin}>
 					<Pencil aria-hidden="true" />
 					{t("shell.rename")}
 				</ContextMenuItem>

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,6 +1,7 @@
 import {
 	ArrowRight,
 	CheckCircle2,
+	Pencil,
 	TriangleAlert,
 	X,
 } from "lucide-react";
@@ -1020,8 +1021,9 @@ export function SessionPaneTab({
 				<span className="contents">{tabFrame}</span>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="min-w-44">
-				<ContextMenuItem onSelect={rename.begin}>
-					{t("shell.renameSession", { title: session.title })}
+				<ContextMenuItem aria-label={t("shell.renameSession", { title: session.title })} onSelect={rename.begin}>
+					<Pencil aria-hidden="true" />
+					{t("shell.rename")}
 				</ContextMenuItem>
 			</ContextMenuContent>
 		</ContextMenu>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -60,7 +60,7 @@ import {
 	useSessionInterfaceTransition,
 } from "../hooks/useSessionInterfaceTransition";
 import { useAgentSwitchRouteVisibility } from "../hooks/useAgentSwitchVisibility";
-import { useWorkspaceSession } from "../hooks/useWorkspaceQuery";
+import { useWorkspaceSession, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useSessionHandoffMenu } from "../hooks/useSessionHandoffMenu";
 import { clearSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
@@ -383,6 +383,10 @@ function SessionInspectorRail({
 export function SessionView({ sessionId }: SessionViewProps) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
+	const refreshWorkspaces = useCallback(
+		() => queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
+		[queryClient],
+	);
 	const workspaceQuery = useWorkspaceSession(sessionId);
 	const theme = useResolvedTheme();
 	const prefersReducedMotion = useReducedMotion();
@@ -1564,6 +1568,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									session={session}
 									reviewerTerminal={reviewerTerminal}
 									onOpenReviewerTerminal={selectReviewerTerminal}
+									onSessionRenamed={refreshWorkspaces}
 									reviewerTarget={
 										routedTerminalTarget.kind === "reviewer" ? routedTerminalTarget : undefined
 									}

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1486,6 +1486,14 @@ describe("Sidebar", () => {
 
 		fireEvent.contextMenu(screen.getByRole("button", { name: "Open fix login" }));
 		const renameItem = await screen.findByRole("menuitem", { name: "Rename fix login" });
+		const menu = renameItem.closest('[role="menu"]');
+		if (!menu) throw new Error("Session context menu not found");
+		expect(within(menu as HTMLElement).getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+			"Rename",
+			"New session",
+			"Project settings",
+			"Remove project",
+		]);
 		expect(renameItem).toHaveTextContent(/^Rename$/);
 		expect(renameItem.querySelector("svg")).toBeInTheDocument();
 		await user.click(renameItem);

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1485,7 +1485,10 @@ describe("Sidebar", () => {
 		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
 
 		fireEvent.contextMenu(screen.getByRole("button", { name: "Open fix login" }));
-		await user.click(await screen.findByRole("menuitem", { name: "Rename fix login" }));
+		const renameItem = await screen.findByRole("menuitem", { name: "Rename fix login" });
+		expect(renameItem).toHaveTextContent(/^Rename$/);
+		expect(renameItem.querySelector("svg")).toBeInTheDocument();
+		await user.click(renameItem);
 
 		expect(screen.getByRole("textbox", { name: "Rename fix login" })).toHaveFocus();
 		expect(navigateMock).not.toHaveBeenCalled();

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1473,11 +1473,29 @@ describe("Sidebar", () => {
 		renderSidebar({ workspaces: [workspaceWithSession] });
 
 		await user.dblClick(screen.getByRole("button", { name: "Open fix login" }));
+		expect(navigateMock).not.toHaveBeenCalled();
 		const input = screen.getByLabelText("Rename fix login");
 		await user.clear(input);
 		await user.type(input, "  polish login  {Enter}");
 
 		await waitFor(() => expect(renameSessionMock).toHaveBeenCalledWith("proj-1-1", "polish login"));
+		expect(navigateMock).not.toHaveBeenCalled();
+	});
+
+	it("still opens a session after an unpaired single click", async () => {
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+
+		fireEvent.click(screen.getByRole("button", { name: "Open fix login" }), { detail: 1 });
+		expect(navigateMock).not.toHaveBeenCalled();
+
+		await waitFor(
+			() =>
+				expect(navigateMock).toHaveBeenCalledWith({
+					to: "/projects/$projectId/sessions/$sessionId",
+					params: { projectId: "proj-1", sessionId: "proj-1-1" },
+				}),
+			{ timeout: 1_000 },
+		);
 	});
 
 	it("starts the same inline rename from the session context menu", async () => {
@@ -1488,12 +1506,7 @@ describe("Sidebar", () => {
 		const renameItem = await screen.findByRole("menuitem", { name: "Rename fix login" });
 		const menu = renameItem.closest('[role="menu"]');
 		if (!menu) throw new Error("Session context menu not found");
-		expect(within(menu as HTMLElement).getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
-			"Rename",
-			"New session",
-			"Project settings",
-			"Remove project",
-		]);
+		expect(within(menu as HTMLElement).getAllByRole("menuitem").map((item) => item.textContent)).toEqual(["Rename"]);
 		expect(renameItem).toHaveTextContent(/^Rename$/);
 		expect(renameItem.querySelector("svg")).toBeInTheDocument();
 		await user.click(renameItem);

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1467,17 +1467,28 @@ describe("Sidebar", () => {
 		expect(dialog).toHaveTextContent("repository folder");
 	});
 
-	it("renames a session inline by double-clicking its name", async () => {
+	it("renames a session inline by double-clicking its full navigation target", async () => {
 		const user = userEvent.setup();
 		const workspaceWithSession = { ...workspace, sessions: [session] };
 		renderSidebar({ workspaces: [workspaceWithSession] });
 
-		await user.dblClick(screen.getByText("fix login"));
+		await user.dblClick(screen.getByRole("button", { name: "Open fix login" }));
 		const input = screen.getByLabelText("Rename fix login");
 		await user.clear(input);
-		await user.type(input, "polish login{Enter}");
+		await user.type(input, "  polish login  {Enter}");
 
 		await waitFor(() => expect(renameSessionMock).toHaveBeenCalledWith("proj-1-1", "polish login"));
+	});
+
+	it("starts the same inline rename from the session context menu", async () => {
+		const user = userEvent.setup();
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+
+		fireEvent.contextMenu(screen.getByRole("button", { name: "Open fix login" }));
+		await user.click(await screen.findByRole("menuitem", { name: "Rename fix login" }));
+
+		expect(screen.getByRole("textbox", { name: "Rename fix login" })).toHaveFocus();
+		expect(navigateMock).not.toHaveBeenCalled();
 	});
 
 	it("caps the inline rename input at 20 characters", async () => {
@@ -1541,6 +1552,20 @@ describe("Sidebar", () => {
 		const input = screen.getByLabelText("Rename fix login");
 		await user.clear(input);
 		await user.type(input, "discard me{Escape}");
+
+		expect(renameSessionMock).not.toHaveBeenCalled();
+		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();
+	});
+
+	it.each(["", "fix login"])("does not persist the no-op rename %j", async (nextName) => {
+		const user = userEvent.setup();
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
+
+		await user.dblClick(screen.getByRole("button", { name: "Open fix login" }));
+		const input = screen.getByLabelText("Rename fix login");
+		await user.clear(input);
+		if (nextName) await user.type(input, nextName);
+		await user.keyboard("{Enter}");
 
 		expect(renameSessionMock).not.toHaveBeenCalled();
 		expect(screen.getByLabelText("Open fix login")).toBeInTheDocument();

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -76,7 +76,6 @@ import { cloudSessionsQueryKey, workspaceQueryKey } from "../hooks/useWorkspaceQ
 import { usePinSession, useUnpinSession } from "../hooks/usePinSession";
 import { spawnCloudOrchestrator } from "../lib/cloud-orchestrator";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
-import { renameSession } from "../lib/rename-session";
 import { formatTimeCompact, formatTimeTerse } from "../lib/format-time";
 import { useTerminateSession } from "../hooks/useTerminateSession";
 import { useResizable } from "../hooks/useResizable";
@@ -86,6 +85,7 @@ import { useLocalSignInDialogStore } from "../stores/local-signin-dialog-store";
 import { useShellMaybe } from "../lib/shell-context";
 import { useSidebarUpdateDismissal } from "../hooks/useSidebarUpdateDismissal";
 import { useUpdateStatus } from "../hooks/useUpdateStatus";
+import { MAX_SESSION_DISPLAY_NAME_LEN, useSessionRename } from "../hooks/useSessionRename";
 import { effectiveShortcutBindings, shortcutBindingKeys } from "../../shared/shortcuts";
 import {
 	ContextMenu,
@@ -162,7 +162,6 @@ const PROJECT_DRAG_OVERLAY_STYLE: CSSProperties = { willChange: "transform" };
 
 // Mirrors the daemon's display-name cap (maxDisplayNameLen) and the spawn
 // `--name` flag, so inline edits never round-trip a value the API would reject.
-const MAX_DISPLAY_NAME_LEN = 20;
 
 // Reorder drags start from the row's primary click surface. The 4px activation
 // distance keeps a plain navigation/disclosure click from starting a drag;
@@ -1730,40 +1729,12 @@ function SessionRow({
 		: undefined;
 	const switchStatusId = useId();
 	const describedBy = switchLabel ? switchStatusId : undefined;
-	const [isEditing, setIsEditing] = useState(false);
-	const [draft, setDraft] = useState(session.title);
+	const rename = useSessionRename(session);
 	const [sessionPressed, setSessionPressed] = useState(false);
 	const lastTouchAtRef = useRef(0);
 	const suppressTouchOpenRef = useRef(false);
-	// Escape must not be swallowed by the blur-to-save path: the keydown handler
-	// blurs the input, so it flags a cancel here for onBlur to honour.
-	const cancelledRef = useRef(false);
 
-	const queryClient = useQueryClient();
-
-	const startEditing = useCallback(() => {
-		setDraft(session.title);
-		setIsEditing(true);
-	}, [session.title]);
-
-	const commit = async () => {
-		if (cancelledRef.current) {
-			cancelledRef.current = false;
-			setIsEditing(false);
-			return;
-		}
-		setIsEditing(false);
-		const name = draft.trim();
-		if (!name || name === session.title) return;
-		try {
-			await renameSession(session.id, name);
-			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-		} catch (err) {
-			console.error("Failed to rename session:", err);
-		}
-	};
-
-	if (isEditing) {
+	if (rename.isEditing) {
 		return (
 			<SidebarMenuSubItem className={cn(indented && "pl-0.5")}>
 				<div
@@ -1782,9 +1753,9 @@ function SessionRow({
 							session.lastUserMessageAt && "pr-[36px]",
 						)}
 						data-session-inline-editor=""
-						maxLength={MAX_DISPLAY_NAME_LEN}
-						onBlur={() => void commit()}
-						onChange={(e) => setDraft(e.target.value)}
+						maxLength={MAX_SESSION_DISPLAY_NAME_LEN}
+						onBlur={() => void rename.commit()}
+						onChange={(e) => rename.setDraft(e.target.value)}
 						onFocus={(e) => e.currentTarget.select()}
 						onKeyDown={(e) => {
 							if (e.key === "Enter") {
@@ -1792,11 +1763,10 @@ function SessionRow({
 								e.currentTarget.blur();
 							} else if (e.key === "Escape") {
 								e.preventDefault();
-								cancelledRef.current = true;
-								e.currentTarget.blur();
+								rename.cancel();
 							}
 						}}
-						value={draft}
+						value={rename.draft}
 					/>
 					<SessionMessageAge session={session} />
 				</div>
@@ -1805,12 +1775,14 @@ function SessionRow({
 	}
 
 	return (
-		<SidebarMenuSubItem
-			className={cn(indented && "pl-0.5", reorder?.isDragging && "z-chrome cursor-grabbing opacity-60")}
-			data-dragging={reorder?.isDragging ? "true" : undefined}
-			ref={reorder?.setNodeRef}
-			style={reorder ? sortableRowStyle(reorder) : undefined}
-		>
+		<ContextMenu>
+			<ContextMenuTrigger asChild>
+				<SidebarMenuSubItem
+					className={cn(indented && "pl-0.5", reorder?.isDragging && "z-chrome cursor-grabbing opacity-60")}
+					data-dragging={reorder?.isDragging ? "true" : undefined}
+					ref={reorder?.setNodeRef}
+					style={reorder ? sortableRowStyle(reorder) : undefined}
+				>
 			<motion.div
 				layout={disableLayout || listIsDragging ? false : "position"}
 				layoutDependency={disableLayout ? undefined : layoutDependency}
@@ -1848,12 +1820,7 @@ function SessionRow({
 							)}
 							{...(reorder?.listeners ?? {})}
 							onClick={(event) => {
-								if (
-									event.detail > 1 &&
-									(event.target as HTMLElement).closest("[data-session-name]")
-								) {
-									return;
-								}
+								if (event.detail > 1) return;
 								if (suppressTouchOpenRef.current) {
 									suppressTouchOpenRef.current = false;
 									return;
@@ -1863,7 +1830,12 @@ function SessionRow({
 							onKeyDown={(event) => {
 								if (event.key !== "F2") return;
 								event.preventDefault();
-								startEditing();
+								rename.begin();
+							}}
+							onDoubleClick={(event) => {
+								event.preventDefault();
+								event.stopPropagation();
+								rename.begin();
 							}}
 							ref={reorder?.setActivatorNodeRef}
 							type="button"
@@ -1876,17 +1848,12 @@ function SessionRow({
 										active ? "text-foreground" : "text-muted-foreground group-hover/session-row:text-foreground",
 									)}
 									data-session-name=""
-									onDoubleClick={(event) => {
-										event.preventDefault();
-										event.stopPropagation();
-										startEditing();
-									}}
 									onPointerUp={(event) => {
 										if (event.pointerType !== "touch") return;
 										const now = Date.now();
 										if (now - lastTouchAtRef.current <= 500) {
 											suppressTouchOpenRef.current = true;
-											startEditing();
+										rename.begin();
 										}
 										lastTouchAtRef.current = now;
 									}}
@@ -1909,7 +1876,14 @@ function SessionRow({
 					/>
 				</div>
 			</motion.div>
-		</SidebarMenuSubItem>
+				</SidebarMenuSubItem>
+			</ContextMenuTrigger>
+			<ContextMenuContent className="min-w-44">
+				<ContextMenuItem onSelect={rename.begin}>
+					{t("shell.renameSession", { title: session.title })}
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }
 

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1221,6 +1221,13 @@ const ProjectItemContent = memo(function ProjectItemContent({
 		setRemoveError(null);
 		setConfirmOpen(true);
 	};
+	const sessionProjectActions: SessionProjectActions = {
+		isProjectRestarting,
+		isRemoving,
+		onNewSession: () => requestNewTask(workspace.id),
+		onProjectSettings: () => selection.goSettings(workspace.id),
+		onRemoveProject: removeProject,
+	};
 
 	const handleConfirmRemove = async () => {
 		setConfirmOpen(false);
@@ -1508,6 +1515,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 															active={selection.activeSessionId === session.id}
 															disableLayout
 															onOpen={() => openSession(session.id)}
+															projectActions={sessionProjectActions}
 														/>
 													))}
 												</SidebarMenuSub>
@@ -1536,6 +1544,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 																	listIsDragging={sessionDragging}
 																	dropTransitionDisabled={dropTransitionDisabledId === session.id}
 																	onOpen={openSession}
+																	projectActions={sessionProjectActions}
 																/>
 															))}
 														</SidebarMenuSub>
@@ -1659,6 +1668,7 @@ const SortableSessionRow = memo(function SortableSessionRow({
 	listIsDragging,
 	dropTransitionDisabled,
 	onOpen,
+	projectActions,
 }: {
 	session: WorkspaceSession;
 	active: boolean;
@@ -1667,6 +1677,7 @@ const SortableSessionRow = memo(function SortableSessionRow({
 	listIsDragging: boolean;
 	dropTransitionDisabled: boolean;
 	onOpen: (sessionId: string) => void;
+	projectActions: SessionProjectActions;
 }) {
 	const { isDragging, listeners, setActivatorNodeRef, setNodeRef, transform, transition } = useSortable({
 		id: session.id,
@@ -1680,6 +1691,7 @@ const SortableSessionRow = memo(function SortableSessionRow({
 			}}
 			layoutDependency={layoutDependency}
 			listIsDragging={listIsDragging}
+			projectActions={projectActions}
 			reorder={{
 				isDragging,
 				listeners,
@@ -1697,6 +1709,14 @@ type SessionReorder = Pick<SortableRow, "isDragging" | "listeners" | "setActivat
 	dropTransitionDisabled: boolean;
 };
 
+type SessionProjectActions = {
+	isProjectRestarting: boolean;
+	isRemoving: boolean;
+	onNewSession: () => void;
+	onProjectSettings: () => void;
+	onRemoveProject: () => void;
+};
+
 // One worker-session row. Reads as a link by default; double-click/double-tap
 // on the name or F2 flips the label into an inline input (Enter/blur saves,
 // Escape cancels) that persists through the daemon rename endpoint.
@@ -1708,6 +1728,7 @@ function SessionRow({
 	listIsDragging = false,
 	disableLayout = false,
 	onOpen,
+	projectActions,
 	reorder,
 }: {
 	session: WorkspaceSession;
@@ -1718,6 +1739,7 @@ function SessionRow({
 	/** Project drags pause nested session projection work. */
 	disableLayout?: boolean;
 	onOpen: () => void;
+	projectActions?: SessionProjectActions;
 	/** Present only for rows inside a reorderable project list. */
 	reorder?: SessionReorder;
 }) {
@@ -1889,6 +1911,29 @@ function SessionRow({
 					<Pencil aria-hidden="true" />
 					{t("shell.rename")}
 				</ContextMenuItem>
+				{projectActions ? (
+					<>
+						<ContextMenuSeparator />
+						<ContextMenuItem disabled={projectActions.isProjectRestarting} onSelect={projectActions.onNewSession}>
+							<Plus aria-hidden="true" />
+							{t("shell.newSession")}
+						</ContextMenuItem>
+						<ContextMenuSeparator />
+						<ContextMenuItem onSelect={projectActions.onProjectSettings}>
+							<Settings aria-hidden="true" />
+							{t("shell.projectSettings")}
+						</ContextMenuItem>
+						<ContextMenuSeparator />
+						<ContextMenuItem
+							className="text-destructive focus:text-destructive [&_svg]:text-destructive"
+							disabled={projectActions.isRemoving}
+							onSelect={projectActions.onRemoveProject}
+						>
+							<Trash2 aria-hidden="true" />
+							{t("shell.removeProjectTitle")}
+						</ContextMenuItem>
+					</>
+				) : null}
 			</ContextMenuContent>
 		</ContextMenu>
 	);

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
 	LogOut,
 	MoreVertical,
 	PanelLeft,
+	Pencil,
 	Pin,
 	PinOff,
 	Plus,
@@ -1884,8 +1885,9 @@ function SessionRow({
 				</SidebarMenuSubItem>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="min-w-44">
-				<ContextMenuItem onSelect={rename.begin}>
-					{t("shell.renameSession", { title: session.title })}
+				<ContextMenuItem aria-label={t("shell.renameSession", { title: session.title })} onSelect={rename.begin}>
+					<Pencil aria-hidden="true" />
+					{t("shell.rename")}
 				</ContextMenuItem>
 			</ContextMenuContent>
 		</ContextMenu>

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1221,13 +1221,6 @@ const ProjectItemContent = memo(function ProjectItemContent({
 		setRemoveError(null);
 		setConfirmOpen(true);
 	};
-	const sessionProjectActions: SessionProjectActions = {
-		isProjectRestarting,
-		isRemoving,
-		onNewSession: () => requestNewTask(workspace.id),
-		onProjectSettings: () => selection.goSettings(workspace.id),
-		onRemoveProject: removeProject,
-	};
 
 	const handleConfirmRemove = async () => {
 		setConfirmOpen(false);
@@ -1515,7 +1508,6 @@ const ProjectItemContent = memo(function ProjectItemContent({
 															active={selection.activeSessionId === session.id}
 															disableLayout
 															onOpen={() => openSession(session.id)}
-															projectActions={sessionProjectActions}
 														/>
 													))}
 												</SidebarMenuSub>
@@ -1544,7 +1536,6 @@ const ProjectItemContent = memo(function ProjectItemContent({
 																	listIsDragging={sessionDragging}
 																	dropTransitionDisabled={dropTransitionDisabledId === session.id}
 																	onOpen={openSession}
-																	projectActions={sessionProjectActions}
 																/>
 															))}
 														</SidebarMenuSub>
@@ -1668,7 +1659,6 @@ const SortableSessionRow = memo(function SortableSessionRow({
 	listIsDragging,
 	dropTransitionDisabled,
 	onOpen,
-	projectActions,
 }: {
 	session: WorkspaceSession;
 	active: boolean;
@@ -1677,7 +1667,6 @@ const SortableSessionRow = memo(function SortableSessionRow({
 	listIsDragging: boolean;
 	dropTransitionDisabled: boolean;
 	onOpen: (sessionId: string) => void;
-	projectActions: SessionProjectActions;
 }) {
 	const { isDragging, listeners, setActivatorNodeRef, setNodeRef, transform, transition } = useSortable({
 		id: session.id,
@@ -1691,7 +1680,6 @@ const SortableSessionRow = memo(function SortableSessionRow({
 			}}
 			layoutDependency={layoutDependency}
 			listIsDragging={listIsDragging}
-			projectActions={projectActions}
 			reorder={{
 				isDragging,
 				listeners,
@@ -1709,14 +1697,6 @@ type SessionReorder = Pick<SortableRow, "isDragging" | "listeners" | "setActivat
 	dropTransitionDisabled: boolean;
 };
 
-type SessionProjectActions = {
-	isProjectRestarting: boolean;
-	isRemoving: boolean;
-	onNewSession: () => void;
-	onProjectSettings: () => void;
-	onRemoveProject: () => void;
-};
-
 // One worker-session row. Reads as a link by default; double-click/double-tap
 // on the name or F2 flips the label into an inline input (Enter/blur saves,
 // Escape cancels) that persists through the daemon rename endpoint.
@@ -1728,7 +1708,6 @@ function SessionRow({
 	listIsDragging = false,
 	disableLayout = false,
 	onOpen,
-	projectActions,
 	reorder,
 }: {
 	session: WorkspaceSession;
@@ -1739,7 +1718,6 @@ function SessionRow({
 	/** Project drags pause nested session projection work. */
 	disableLayout?: boolean;
 	onOpen: () => void;
-	projectActions?: SessionProjectActions;
 	/** Present only for rows inside a reorderable project list. */
 	reorder?: SessionReorder;
 }) {
@@ -1761,6 +1739,17 @@ function SessionRow({
 	const [sessionPressed, setSessionPressed] = useState(false);
 	const lastTouchAtRef = useRef(0);
 	const suppressTouchOpenRef = useRef(false);
+	const pendingOpenRef = useRef<number | null>(null);
+	const cancelPendingOpen = useCallback(() => {
+		if (pendingOpenRef.current === null) return;
+		window.clearTimeout(pendingOpenRef.current);
+		pendingOpenRef.current = null;
+	}, []);
+	useEffect(() => cancelPendingOpen, [cancelPendingOpen]);
+	const beginRename = useCallback(() => {
+		cancelPendingOpen();
+		rename.begin();
+	}, [cancelPendingOpen, rename.begin]);
 
 	if (rename.isEditing) {
 		return (
@@ -1848,22 +1837,36 @@ function SessionRow({
 							)}
 							{...(reorder?.listeners ?? {})}
 							onClick={(event) => {
-								if (event.detail > 1) return;
+								if (event.detail === 0) {
+									cancelPendingOpen();
+									onOpen();
+									return;
+								}
+								if (event.detail > 1) {
+									cancelPendingOpen();
+									return;
+								}
 								if (suppressTouchOpenRef.current) {
 									suppressTouchOpenRef.current = false;
 									return;
 								}
-								onOpen();
+								// Wait for the native double-click window before navigating. A
+								// second click cancels this so inline rename has no route side effect.
+								cancelPendingOpen();
+								pendingOpenRef.current = window.setTimeout(() => {
+									pendingOpenRef.current = null;
+									onOpen();
+								}, 500);
 							}}
 							onKeyDown={(event) => {
 								if (event.key !== "F2") return;
 								event.preventDefault();
-								rename.begin();
+								beginRename();
 							}}
 							onDoubleClick={(event) => {
 								event.preventDefault();
 								event.stopPropagation();
-								rename.begin();
+								beginRename();
 							}}
 							ref={reorder?.setActivatorNodeRef}
 							type="button"
@@ -1881,7 +1884,7 @@ function SessionRow({
 										const now = Date.now();
 										if (now - lastTouchAtRef.current <= 500) {
 											suppressTouchOpenRef.current = true;
-										rename.begin();
+										beginRename();
 										}
 										lastTouchAtRef.current = now;
 									}}
@@ -1907,33 +1910,10 @@ function SessionRow({
 				</SidebarMenuSubItem>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="min-w-44">
-				<ContextMenuItem aria-label={t("shell.renameSession", { title: session.title })} onSelect={rename.begin}>
+				<ContextMenuItem aria-label={t("shell.renameSession", { title: session.title })} onSelect={beginRename}>
 					<Pencil aria-hidden="true" />
 					{t("shell.rename")}
 				</ContextMenuItem>
-				{projectActions ? (
-					<>
-						<ContextMenuSeparator />
-						<ContextMenuItem disabled={projectActions.isProjectRestarting} onSelect={projectActions.onNewSession}>
-							<Plus aria-hidden="true" />
-							{t("shell.newSession")}
-						</ContextMenuItem>
-						<ContextMenuSeparator />
-						<ContextMenuItem onSelect={projectActions.onProjectSettings}>
-							<Settings aria-hidden="true" />
-							{t("shell.projectSettings")}
-						</ContextMenuItem>
-						<ContextMenuSeparator />
-						<ContextMenuItem
-							className="text-destructive focus:text-destructive [&_svg]:text-destructive"
-							disabled={projectActions.isRemoving}
-							onSelect={projectActions.onRemoveProject}
-						>
-							<Trash2 aria-hidden="true" />
-							{t("shell.removeProjectTitle")}
-						</ContextMenuItem>
-					</>
-				) : null}
 			</ContextMenuContent>
 		</ContextMenu>
 	);

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1729,7 +1729,12 @@ function SessionRow({
 		: undefined;
 	const switchStatusId = useId();
 	const describedBy = switchLabel ? switchStatusId : undefined;
-	const rename = useSessionRename(session);
+	const queryClient = useQueryClient();
+	const refreshWorkspaces = useCallback(
+		() => queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
+		[queryClient],
+	);
+	const rename = useSessionRename(session, refreshWorkspaces);
 	const [sessionPressed, setSessionPressed] = useState(false);
 	const lastTouchAtRef = useRef(0);
 	const suppressTouchOpenRef = useRef(false);

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -20,6 +20,10 @@ import { useUiStore } from "../../stores/ui-store";
 import type { WorkspaceSession } from "../../types/workspace";
 import { TooltipProvider } from "../ui/tooltip";
 
+const renameSessionMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../lib/rename-session", () => ({ renameSession: renameSessionMock }));
+
 function render(ui: ReactElement) {
 	const result = rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
 	return {
@@ -147,6 +151,7 @@ beforeEach(() => {
 	closeShellTerminalListeners.clear();
 	closeShellTerminalShortcutStates.length = 0;
 	terminalPaneState.props = undefined;
+	renameSessionMock.mockReset().mockResolvedValue(undefined);
 	window.localStorage.clear();
 	setApiBaseUrl("http://127.0.0.1:3001");
 	useUiStore.setState({ isSidebarOpen: true, inspectorSessions: {} });
@@ -394,6 +399,27 @@ describe("ChatWorkspace timeline", () => {
 			/>,
 		);
 		expect(screen.getByRole("tab", { name: "Orchestrator · Codex · Working" })).toBeInTheDocument();
+	});
+
+	it("refreshes the owning workspace after renaming the primary chat tab", async () => {
+		const user = userEvent.setup();
+		const onSessionRenamed = vi.fn().mockResolvedValue(undefined);
+		render(
+			<ChatWorkspace
+				snapshot={chatFixture}
+				session={chatSession}
+				sessionRole="worker"
+				onSessionRenamed={onSessionRenamed}
+			/>,
+		);
+
+		await user.dblClick(screen.getByRole("tab", { name: "Reviewer chat · Codex · Working" }));
+		const input = screen.getByRole("textbox", { name: "Rename Reviewer chat" });
+		await user.clear(input);
+		await user.type(input, "Focused review{Enter}");
+
+		await waitFor(() => expect(renameSessionMock).toHaveBeenCalledWith(chatSession.id, "Focused review"));
+		expect(onSessionRenamed).toHaveBeenCalledOnce();
 	});
 
 	it("clears the fixed titlebar nav when the sidebar is collapsed, like the terminal session", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -275,6 +275,8 @@ export interface ChatWorkspaceProps {
 	models?: ChatModel[];
 	/** The AO session this surface renders for. Used to attach the reviewer pane. */
 	session?: WorkspaceSession;
+	/** Refresh the owning workspace cache after the shared primary tab is renamed. */
+	onSessionRenamed?: () => void | Promise<void>;
 	/** The selected reviewer pane. Kept even while its tab is temporarily unavailable. */
 	reviewerTarget?: ReviewerTerminalTarget;
 	/** Switch the active tab back to the chat timeline. */
@@ -389,6 +391,7 @@ export function ChatWorkspace({
 	reviewerTerminal,
 	onOpenReviewerTerminal,
 	session,
+	onSessionRenamed,
 	reviewerTarget,
 	onSelectChat,
 	shellTerminals,
@@ -1000,6 +1003,7 @@ export function ChatWorkspace({
 				onTabsKeyDown={handleChatTabsKeyDown}
 				headerActions={headerActions}
 				session={session}
+				onSessionRenamed={onSessionRenamed}
 				sessionTabAction={sessionTabAction}
 				tabStripAction={tabStripAction}
 				workspaceTabActions={workspaceTabActions}
@@ -1330,6 +1334,7 @@ function ChatHeader({
 	inline,
 	topbarBounds,
 	session,
+	onSessionRenamed,
 }: {
 	snapshot: ConversationSnapshot;
 	sessionTitle?: string;
@@ -1353,6 +1358,7 @@ function ChatHeader({
 	orderedAuxiliaryTabs: ChatAuxiliaryTab[];
 	onReorderAuxiliaryTabs: (keys: string[]) => void;
 	session?: WorkspaceSession;
+	onSessionRenamed?: () => void | Promise<void>;
 	/** Fullscreen content cannot see the normal topbar portal outside its subtree. */
 	inline?: boolean;
 	topbarBounds: TopbarBounds;
@@ -1411,6 +1417,7 @@ function ChatHeader({
 								isActive={timelineActive}
 								label={label}
 								onSelect={timelineActive ? undefined : onSelectChat}
+								onRenamed={onSessionRenamed}
 								session={session}
 								tabAction={sessionTabAction}
 							/>

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -53,6 +53,7 @@ export function SessionChatSurface({
 	session,
 	reviewerTerminal,
 	onOpenReviewerTerminal,
+	onSessionRenamed,
 	reviewerTarget,
 	onSelectChat,
 	shellTerminals,
@@ -84,6 +85,7 @@ export function SessionChatSurface({
 	session: WorkspaceSession;
 	reviewerTerminal?: { handleId: string; harness: string };
 	onOpenReviewerTerminal?: (target: { handleId: string; harness: string }) => void;
+	onSessionRenamed?: () => void | Promise<void>;
 	reviewerTarget?: Extract<TerminalTarget, { kind: "reviewer" }>;
 	onSelectChat?: () => void;
 	/** This session's standalone shells, rendered as tabs in the chat header. */
@@ -325,6 +327,7 @@ export function SessionChatSurface({
 				sessionTitle={session.title}
 				sessionRole={session.kind}
 				session={session}
+				onSessionRenamed={onSessionRenamed}
 				reviewerTerminal={reviewerTerminal}
 				onOpenReviewerTerminal={onOpenReviewerTerminal}
 				reviewerTarget={reviewerTarget}

--- a/frontend/src/renderer/hooks/useSessionRename.ts
+++ b/frontend/src/renderer/hooks/useSessionRename.ts
@@ -1,0 +1,49 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef, useState } from "react";
+import { renameSession } from "../lib/rename-session";
+import type { WorkspaceSession } from "../types/workspace";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+
+export const MAX_SESSION_DISPLAY_NAME_LEN = 20;
+
+type RenameableSession = Pick<WorkspaceSession, "id" | "title">;
+
+export function useSessionRename(session?: RenameableSession) {
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(session?.title ?? "");
+  const cancelledRef = useRef(false);
+
+  const begin = useCallback(() => {
+    if (!session) return;
+    cancelledRef.current = false;
+    setDraft(session.title);
+    setIsEditing(true);
+  }, [session]);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+    setDraft(session?.title ?? "");
+    setIsEditing(false);
+  }, [session?.title]);
+
+  const commit = useCallback(async () => {
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      setIsEditing(false);
+      return;
+    }
+    setIsEditing(false);
+    if (!session) return;
+    const name = draft.trim();
+    if (!name || name === session.title) return;
+    try {
+      await renameSession(session.id, name);
+      await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+    } catch (error) {
+      console.error("Failed to rename session:", error);
+    }
+  }, [draft, queryClient, session]);
+
+  return { begin, cancel, commit, draft, isEditing, setDraft };
+}

--- a/frontend/src/renderer/hooks/useSessionRename.ts
+++ b/frontend/src/renderer/hooks/useSessionRename.ts
@@ -1,15 +1,12 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 import { renameSession } from "../lib/rename-session";
 import type { WorkspaceSession } from "../types/workspace";
-import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 export const MAX_SESSION_DISPLAY_NAME_LEN = 20;
 
 type RenameableSession = Pick<WorkspaceSession, "id" | "title">;
 
-export function useSessionRename(session?: RenameableSession) {
-  const queryClient = useQueryClient();
+export function useSessionRename(session?: RenameableSession, onRenamed?: () => void | Promise<void>) {
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(session?.title ?? "");
   const cancelledRef = useRef(false);
@@ -37,13 +34,13 @@ export function useSessionRename(session?: RenameableSession) {
     if (!session) return;
     const name = draft.trim();
     if (!name || name === session.title) return;
-    try {
-      await renameSession(session.id, name);
-      await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-    } catch (error) {
+		try {
+			await renameSession(session.id, name);
+			await onRenamed?.();
+		} catch (error) {
       console.error("Failed to rename session:", error);
     }
-  }, [draft, queryClient, session]);
+	}, [draft, onRenamed, session]);
 
   return { begin, cancel, commit, draft, isEditing, setDraft };
 }

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1091,6 +1091,7 @@
 	"shell.removeProjectLead": "Dadurch wird {{name}} aus AO entfernt",
 	"shell.removeProjectTitle": "Projekt entfernen",
 	"shell.removingNamed": "{{name}} wird entfernt…",
+	"shell.rename": "Umbenennen",
 	"shell.renameSession": "{{title}} umbenennen",
 	"shell.restartToUpdate": "Neu starten zum Aktualisieren",
 	"shell.restartInstallUpdate": "Neu starten, um Update zu installieren",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1214,6 +1214,7 @@
 	"shell.removeProjectLead": "This will remove {{name}} from AO",
 	"shell.removeProjectTitle": "Remove project",
 	"shell.removingNamed": "Removing {{name}}…",
+	"shell.rename": "Rename",
 	"shell.renameSession": "Rename {{title}}",
 	"shell.restartToUpdate": "Restart to update",
 	"shell.restartInstallUpdate": "Restart to install update",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1107,6 +1107,7 @@
 	"shell.removeProjectLead": "Esto eliminará {{name}} de AO",
 	"shell.removeProjectTitle": "Eliminar proyecto",
 	"shell.removingNamed": "Eliminando {{name}}…",
+	"shell.rename": "Renombrar",
 	"shell.renameSession": "Renombrar {{title}}",
 	"shell.restartToUpdate": "Reiniciar para actualizar",
 	"shell.restartInstallUpdate": "Reiniciar para instalar la actualización",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1107,6 +1107,7 @@
 	"shell.removeProjectLead": "Cela supprimera {{name}} d'AO",
 	"shell.removeProjectTitle": "Supprimer le projet",
 	"shell.removingNamed": "Suppression de {{name}}…",
+	"shell.rename": "Renommer",
 	"shell.renameSession": "Renommer {{title}}",
 	"shell.restartToUpdate": "Redémarrer pour mettre à jour",
 	"shell.restartInstallUpdate": "Redémarrer pour installer la mise à jour",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1091,6 +1091,7 @@
 	"shell.removeProjectLead": "{{name}} を AO から削除します",
 	"shell.removeProjectTitle": "プロジェクトを削除",
 	"shell.removingNamed": "{{name}} を削除中…",
+	"shell.rename": "名前を変更",
 	"shell.renameSession": "{{title}} の名前を変更",
 	"shell.restartToUpdate": "再起動して更新",
 	"shell.restartInstallUpdate": "再起動してアップデートをインストール",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1091,6 +1091,7 @@
 	"shell.removeProjectLead": "AO에서 {{name}}을(를) 제거합니다",
 	"shell.removeProjectTitle": "프로젝트 제거",
 	"shell.removingNamed": "{{name}} 제거 중…",
+	"shell.rename": "이름 바꾸기",
 	"shell.renameSession": "{{title}} 이름 바꾸기",
 	"shell.restartToUpdate": "다시 시작하여 업데이트",
 	"shell.restartInstallUpdate": "다시 시작하여 업데이트 설치",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1107,6 +1107,7 @@
 	"shell.removeProjectLead": "Isso removerá {{name}} do AO",
 	"shell.removeProjectTitle": "Remover projeto",
 	"shell.removingNamed": "Removendo {{name}}…",
+	"shell.rename": "Renomear",
 	"shell.renameSession": "Renomear {{title}}",
 	"shell.restartToUpdate": "Reiniciar para atualizar",
 	"shell.restartInstallUpdate": "Reiniciar para instalar a atualização",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1077,6 +1077,7 @@
 	"shell.removeProjectLead": "这将从 AO 中移除 {{name}}",
 	"shell.removeProjectTitle": "移除项目",
 	"shell.removingNamed": "正在移除 {{name}}…",
+	"shell.rename": "重命名",
 	"shell.renameSession": "重命名{{title}}",
 	"shell.restartToUpdate": "重启以更新",
 	"shell.restartInstallUpdate": "重启以安装更新",


### PR DESCRIPTION
## Summary
- let users rename sessions by double-clicking the sidebar row or owning terminal tab
- add Rename to both context menus while preserving the existing inline visual treatment
- share persistence through the existing daemon rename endpoint and workspace-query refresh

## Verification
- `npm test --prefix frontend` (268 files, 3,604 passed, 7 skipped)
- `npm run frontend:typecheck`
- `cd frontend && npx electron-forge package`

The daemon and generated API contract are unchanged.