### PR TITLE
fix(runtime): recover when legacy tmux socket is gone

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -518,6 +518,12 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	r.reapSessions(ctx, sessionIDs, r.reapGrace)
 
 	if err != nil {
+		// Socket discovery can classify the control endpoint as unavailable before
+		// kill-session runs. Explicit teardown already accepts that as idempotent.
+		if errors.Is(err, ports.ErrRuntimeUnavailable) {
+			r.forgetSessionSocket(id)
+			return nil
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && killSessionMissingOutput(string(out)) {
 			r.forgetSessionSocket(id)
@@ -747,7 +753,17 @@ func (r *Runtime) Interrupt(ctx context.Context, handle ports.RuntimeHandle) err
 	if err != nil {
 		return err
 	}
-	if _, err := r.runForSession(ctx, id, sendInterruptArgs(id)...); err != nil {
+	out, err := r.runForSession(ctx, id, sendInterruptArgs(id)...)
+	if err != nil {
+		var exitErr *exec.ExitError
+		// A missing session/control endpoint leaves nothing reachable to interrupt.
+		// Other connection failures may hide a target that never received Ctrl-C.
+		if errors.Is(err, ports.ErrRuntimeUnavailable) ||
+			errors.As(err, &exitErr) && (sessionMissingOutput(string(out)) ||
+				serverNotRunningOutput(string(out)) || migrationSocketAbsentOutput(string(out))) {
+			r.forgetSessionSocket(id)
+			return nil
+		}
 		return fmt.Errorf("tmux runtime: interrupt session %s: %w", id, err)
 	}
 	return nil
@@ -953,6 +969,18 @@ func (r *Runtime) socketForSession(ctx context.Context, id string) (string, erro
 	}
 	if ctx.Err() != nil {
 		return "", ctx.Err()
+	}
+	// The private lookup already missed before reaching the legacy probe. A
+	// missing legacy socket proves control-endpoint absence, not process death:
+	// keep liveness fail-closed while allowing explicit teardown to recover.
+	if migrationSocketAbsentOutput(string(legacyOut)) {
+		return "", fmt.Errorf(
+			"%w: system tmux %q could not reach legacy default-socket session %s: %w",
+			ports.ErrRuntimeUnavailable,
+			r.legacyBinary,
+			id,
+			legacyErr,
+		)
 	}
 	if sessionMissingOutput(string(legacyOut)) || serverNotRunningOutput(string(legacyOut)) {
 		// Both known sockets definitively lack the session. Return the private

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -75,6 +75,30 @@ func newTestRuntime(chunkSize int) (*Runtime, *fakeRunner) {
 	return r, fr
 }
 
+func newMissingSocketTestRuntime(discoveries int) *Runtime {
+	r := New(Options{
+		Binary:       "bundled-tmux-test",
+		LegacyBinary: "system-tmux-test",
+		SocketName:   "ao",
+		Timeout:      time.Second,
+	})
+	privateMissing := fakeRunnerResult{
+		out: []byte("error connecting to /private/tmp/tmux-501/ao (No such file or directory)"),
+		err: &exec.ExitError{},
+	}
+	legacyMissing := fakeRunnerResult{
+		out: []byte("error connecting to /private/tmp/tmux-501/default (No such file or directory)"),
+		err: &exec.ExitError{},
+	}
+	results := make([]fakeRunnerResult, 0, discoveries*2)
+	for range discoveries {
+		results = append(results, privateMissing, legacyMissing)
+	}
+	r.runner = &fakeRunnerSequence{results: results}
+	r.reapSessions = (&recordingReaper{}).reap
+	return r
+}
+
 // countCalls returns how many of fr's recorded calls invoked the given tmux
 // subcommand (args[0]), e.g. "display-message" for pane cwd verification
 // probes.
@@ -950,7 +974,27 @@ func TestIsAliveReportsTransientLegacyConnectionAsProbeInconclusive(t *testing.T
 	}
 }
 
+func TestIsAliveReportsMissingPrivateAndLegacySocketsAsRuntimeUnavailable(t *testing.T) {
+	r := newMissingSocketTestRuntime(1)
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if !errors.Is(err, ports.ErrRuntimeUnavailable) {
+		t.Fatalf("IsAlive err = %v, want ports.ErrRuntimeUnavailable", err)
+	}
+	if alive {
+		t.Fatal("alive = true, want false with unavailable runtime")
+	}
+}
+
 // -- Destroy tests --
+
+func TestDestroyTreatsMissingPrivateAndLegacySocketsAsAlreadyGone(t *testing.T) {
+	r := newMissingSocketTestRuntime(2)
+
+	if err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
+		t.Fatalf("Destroy with missing sockets: %v", err)
+	}
+}
 
 func TestDestroyIsIdempotentWhenSessionMissing(t *testing.T) {
 	r, fr := newTestRuntime(0)
@@ -1531,6 +1575,27 @@ func TestInterruptSendsCtrlC(t *testing.T) {
 	}
 	if got, want := fr.calls[0].args, sendInterruptArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("interrupt args = %#v, want %#v", got, want)
+	}
+}
+
+func TestInterruptTreatsMissingPrivateAndLegacySocketsAsAlreadyStopped(t *testing.T) {
+	r := newMissingSocketTestRuntime(1)
+
+	if err := r.Interrupt(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
+		t.Fatalf("Interrupt with missing sockets: %v", err)
+	}
+}
+
+func TestInterruptTreatsCachedLegacySocketDisappearanceAsAlreadyStopped(t *testing.T) {
+	r := newMissingSocketTestRuntime(0)
+	r.rememberSessionSocket("sess-1", "")
+	r.runner = &fakeRunnerSequence{results: []fakeRunnerResult{{
+		out: []byte("error connecting to /private/tmp/tmux-501/default (No such file or directory)"),
+		err: &exec.ExitError{},
+	}}}
+
+	if err := r.Interrupt(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
+		t.Fatalf("Interrupt after legacy socket disappeared: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- classify a missing legacy default tmux socket as unavailable runtime infrastructure after the private-socket lookup misses
- let explicit tmux teardown and interrupt treat that unavailable controller as idempotently stopped
- retain fail-closed liveness semantics, so reaper/attach paths do not infer process death from a missing tmux socket

## Root cause
After a daemon restart, legacy socket ownership is rediscovered. The private lookup could fall back to the default socket, but a missing default socket was returned as `ErrRuntimeProbeInconclusive` before `Destroy` reached its existing idempotent server-unavailable handling. `Kill` therefore stopped before lifecycle termination; `Interrupt` also failed on the same resolver path.

A missing tmux control socket does not prove an agent process is dead, so `IsAlive` still returns an unavailable-runtime error rather than per-session death. The recovery is deliberately limited to explicit stop/teardown operations.

## Tests
- `npm run lint` (with AO_* environment scrubbed and isolated golangci cache)
- `cd backend && go test -race ./internal/adapters/runtime/tmux -count=1`

## Risk / follow-up
An unavailable tmux control endpoint can leave an orphan process; this PR preserves existing fail-closed automated liveness behavior and only makes explicit user-requested stop paths idempotent.