### PR TITLE
feat: flag projects with missing local folders and allow clean removal

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -510,7 +510,7 @@ func Run() error {
 	lcStack.LCM.SetSessionInputLease(sessMgr)
 	lcStack.LCM.SetSessionOperationGate(sessMgr)
 	termMgr.SetSessionInputLease(sessMgr)
-	projectSvc := projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink})
+	projectSvc := projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink, Logger: log})
 	if err := seedScratchProjectOnBoot(ctx, cfg, projectSvc); err != nil {
 		stop()
 		lcStack.Stop()

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -9843,6 +9843,8 @@ components:
           $ref: '#/components/schemas/ProjectConfig'
         defaultBranch:
           type: string
+        folderMissing:
+          type: boolean
         id:
           type: string
         kind:
@@ -9868,6 +9870,7 @@ components:
       - path
       - repo
       - defaultBranch
+      - folderMissing
       type: object
     ProjectConfig:
       properties:
@@ -9937,6 +9940,8 @@ components:
       type: object
     ProjectSummary:
       properties:
+        folderMissing:
+          type: boolean
         id:
           type: string
         kind:
@@ -9961,6 +9966,7 @@ components:
       - path
       - kind
       - sessionPrefix
+      - folderMissing
       type: object
     PromoteQueuedTurnResponse:
       properties:

--- a/backend/internal/httpd/envelope/envelope.go
+++ b/backend/internal/httpd/envelope/envelope.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/observe/ownership"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 // errCapture is a request-scoped slot WriteError records the raw service error
@@ -97,6 +98,18 @@ func WriteError(w http.ResponseWriter, r *http.Request, err error) {
 	if isTransient(err) {
 		writeAPIError(w, r, http.StatusServiceUnavailable, "unavailable", "SERVICE_UNAVAILABLE",
 			"The service is momentarily unavailable, please retry.", nil, reportingOwner)
+		return
+	}
+	// A project whose source repository has been deleted from disk turns any
+	// subsequent filesystem/git operation that reaches it into a raw,
+	// unclassified failure. Map that single, well-defined condition to a clean
+	// 404 before the generic 500 fallthrough so clients can tell "the project
+	// its folder is gone" apart from an internal server fault. Adapters wrap
+	// the same sentinel (ports.ErrWorkspaceRepoUnavailable) with %w, so
+	// errors.Is matches it through any wrapping.
+	if errors.Is(err, ports.ErrWorkspaceRepoUnavailable) {
+		writeAPIError(w, r, http.StatusNotFound, "not_found", "PROJECT_FOLDER_MISSING",
+			"Project repository is missing from disk", nil, reportingOwner)
 		return
 	}
 	writeAPIError(w, r, http.StatusInternalServerError, "internal", "INTERNAL_ERROR", "Internal server error", nil, reportingOwner)

--- a/backend/internal/httpd/envelope/envelope_test.go
+++ b/backend/internal/httpd/envelope/envelope_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/observe/ownership"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 func TestWriteErrorSerializesWrappedReportingOwner(t *testing.T) {
@@ -150,6 +151,33 @@ func TestWriteError_NonTransientStays500(t *testing.T) {
 				t.Fatalf("status = %d, want 500", status)
 			}
 		})
+	}
+}
+
+func TestWriteError_WorkspaceRepoUnavailableMapsTo404(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/s1/workspace/files", nil)
+	// The sentinel reaches WriteError wrapped by application layers, so match
+	// the wrapped shape too.
+	err := fmt.Errorf("git -C /repo status: %w", ports.ErrWorkspaceRepoUnavailable)
+
+	WriteError(rec, req, err)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	var body APIError
+	if decodeErr := json.Unmarshal(rec.Body.Bytes(), &body); decodeErr != nil {
+		t.Fatalf("decode response: %v", decodeErr)
+	}
+	if body.Code != "PROJECT_FOLDER_MISSING" {
+		t.Fatalf("code = %q, want PROJECT_FOLDER_MISSING", body.Code)
+	}
+	if body.Error != "not_found" {
+		t.Fatalf("error = %q, want not_found", body.Error)
+	}
+	if body.Message != "Project repository is missing from disk" {
+		t.Fatalf("message = %q, want the missing-repo message", body.Message)
 	}
 }
 

--- a/backend/internal/service/project/folder_exists_internal_test.go
+++ b/backend/internal/service/project/folder_exists_internal_test.go
@@ -65,7 +65,7 @@ func TestFolderExists_HelperSemantics(t *testing.T) {
 //
 //   exists, err := folderExists(row.Path)
 //   if err != nil {
-//       log.Printf("project: stat %s: %v", row.Path, err)
+//       logger.Warn("project: stat failed", "path", row.Path, "error", err)
 //       // folderMissing stays false (zero-value)
 //   } else {
 //       folderMissing = !exists

--- a/backend/internal/service/project/folder_exists_internal_test.go
+++ b/backend/internal/service/project/folder_exists_internal_test.go
@@ -1,0 +1,77 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// T5. folderExists helper: dir exists → true, removed → false, replaced by file → false.
+func TestFolderExists_HelperSemantics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("existing directory returns true", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		exists, err := folderExists(dir)
+		if err != nil {
+			t.Fatalf("folderExists: %v", err)
+		}
+		if !exists {
+			t.Fatal("folderExists = false for existing directory, want true")
+		}
+	})
+
+	t.Run("removed directory returns false", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("RemoveAll: %v", err)
+		}
+		exists, err := folderExists(dir)
+		if err != nil {
+			t.Fatalf("folderExists: %v", err)
+		}
+		if exists {
+			t.Fatal("folderExists = true for removed directory, want false")
+		}
+	})
+
+	t.Run("regular file at path returns false", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "not-a-dir")
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		exists, err := folderExists(path)
+		if err != nil {
+			t.Fatalf("folderExists: %v", err)
+		}
+		if exists {
+			t.Fatal("folderExists = true for regular file, want false")
+		}
+	})
+}
+
+// T6. Stat error ≠ missing: folderExists must return error for non-ErrNotExist
+// failures, never silently treating them as missing. This contract is validated
+// by code review: os.Stat returning a non-ErrNotExist error yields
+// (false, err), and the caller (projectFromRow / List) logs it and keeps
+// FolderMissing=false. Cross-platform permission-error semantics differ
+// (Windows DACL vs POSIX mode bits), so we document the contract here rather
+// than writing an unreliable platform-dependent test.
+//
+// The contract, exercised by the code path in service.go:126-131 and :763-769:
+//
+//   exists, err := folderExists(row.Path)
+//   if err != nil {
+//       log.Printf("project: stat %s: %v", row.Path, err)
+//       // folderMissing stays false (zero-value)
+//   } else {
+//       folderMissing = !exists
+//   }
+//
+// On any stat error that is NOT os.ErrNotExist, folderExists returns
+// (false, err) with err != nil, so folderMissing remains false and the error
+// is logged. This is the intended behavior: an ambiguous stat failure should
+// not degrade the project to "missing".

--- a/backend/internal/service/project/folder_missing_test.go
+++ b/backend/internal/service/project/folder_missing_test.go
@@ -1,0 +1,231 @@
+package project_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/service/project"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
+)
+
+// T1. FolderMissing false when directory exists (happy path).
+func TestFolderMissing_FalseWhenDirectoryExists(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := gitRepoWithCommit(t, t.TempDir())
+
+	_, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("ao")})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	list, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "ao" {
+		t.Fatalf("List = %#v, want [ao]", list)
+	}
+	if list[0].FolderMissing {
+		t.Fatal("List FolderMissing = true, want false")
+	}
+
+	res, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if res.Status != "ok" || res.Project == nil {
+		t.Fatalf("Get = %#v", res)
+	}
+	if res.Project.FolderMissing {
+		t.Fatal("Get FolderMissing = true, want false")
+	}
+}
+
+// T2. FolderMissing true after directory deleted + recovery.
+func TestFolderMissing_LifecycleDeleteAndRecovery(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := gitRepoWithCommit(t, t.TempDir())
+
+	if _, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Initially present.
+	if got, err := m.List(ctx); err != nil || len(got) != 1 || got[0].FolderMissing {
+		t.Fatalf("pre-delete List = %#v, %v", got, err)
+	}
+
+	// Delete the directory.
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	// Assert FolderMissing true via List.
+	list, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List after delete: %v", err)
+	}
+	if len(list) != 1 || !list[0].FolderMissing {
+		t.Fatalf("List after delete = %#v, want FolderMissing=true", list)
+	}
+
+	// Assert FolderMissing true via Get.
+	res, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get after delete: %v", err)
+	}
+	if !res.Project.FolderMissing {
+		t.Fatal("Get FolderMissing = false after delete, want true")
+	}
+	// Default branch falls back to "auto" when folder is missing.
+	if res.Project.DefaultBranch != domain.DefaultBranchAuto {
+		t.Fatalf("Get DefaultBranch = %q, want %q (missing folder falls back to auto)", res.Project.DefaultBranch, domain.DefaultBranchAuto)
+	}
+
+	// Recovery: recreate the directory as a valid git repo at the same path.
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("MkdirAll for recovery: %v", err)
+	}
+	if out, err := exec.Command("git", "init", "-b", "main", repo).CombinedOutput(); err != nil {
+		t.Fatalf("git init recovery: %v (%s)", err, out)
+	}
+	commitEmpty(t, repo)
+
+	// Assert FolderMissing false again via List.
+	list2, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List after recovery: %v", err)
+	}
+	if len(list2) != 1 || list2[0].FolderMissing {
+		t.Fatalf("List after recovery = %#v, want FolderMissing=false", list2)
+	}
+
+	// Assert FolderMissing false again via Get.
+	res2, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get after recovery: %v", err)
+	}
+	if res2.Project.FolderMissing {
+		t.Fatal("Get FolderMissing = true after recovery, want false")
+	}
+}
+
+// T3. Non-directory file at the path is treated as missing.
+func TestFolderMissing_NonDirectoryFileCountsAsMissing(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := gitRepoWithCommit(t, t.TempDir())
+
+	if _, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Remove the directory and place a regular file at the same path.
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if err := os.WriteFile(repo, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	list, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || !list[0].FolderMissing {
+		t.Fatalf("List with file at path = %#v, want FolderMissing=true", list)
+	}
+
+	res, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !res.Project.FolderMissing {
+		t.Fatal("Get FolderMissing = false with file at path, want true")
+	}
+}
+
+// T4. Missing folder yields FolderMissing=true and falls back to DefaultBranchAuto.
+func TestFolderMissing_MissingFolderFallsBackToAutoBranch(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := gitRepoWithCommit(t, t.TempDir())
+
+	proj, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("ao")})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if proj.DefaultBranch != domain.DefaultBranchAuto {
+		t.Fatalf("initial DefaultBranch = %q, want %q", proj.DefaultBranch, domain.DefaultBranchAuto)
+	}
+
+	// Delete the directory to trigger the missing path.
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	res, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !res.Project.FolderMissing {
+		t.Fatal("FolderMissing = false, want true")
+	}
+	if res.Project.DefaultBranch != domain.DefaultBranchAuto {
+		t.Fatalf("DefaultBranch = %q, want %q when folder missing", res.Project.DefaultBranch, domain.DefaultBranchAuto)
+	}
+}
+
+// T7. Remove after external deletion proves Remove works when folder is gone.
+func TestFolderMissing_RemoveAfterExternalDeletion(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlitetest.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	teardown := &fakeProjectTeardowner{}
+	m := project.NewWithDeps(project.Deps{Store: store, Sessions: teardown})
+
+	repo := gitRepoWithCommit(t, t.TempDir())
+	if _, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Delete the directory externally.
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	// Confirm FolderMissing.
+	if got, err := m.List(ctx); err != nil || len(got) != 1 || !got[0].FolderMissing {
+		t.Fatalf("List after delete = %#v, %v", got, err)
+	}
+
+	// Remove must succeed even though the folder is gone.
+	rm, err := m.Remove(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if rm.ProjectID != "ao" {
+		t.Fatalf("Remove ProjectID = %q, want ao", rm.ProjectID)
+	}
+
+	// Teardowner was invoked.
+	if len(teardown.projects) != 1 || teardown.projects[0] != "ao" {
+		t.Fatalf("teardown projects = %#v, want [ao]", teardown.projects)
+	}
+
+	// Project is gone from List.
+	if list, _ := m.List(ctx); len(list) != 0 {
+		t.Fatalf("List after remove = %d, want 0", len(list))
+	}
+
+	// Get returns PROJECT_NOT_FOUND.
+	_, err = m.Get(ctx, "ao")
+	wantCode(t, err, "PROJECT_NOT_FOUND")
+}

--- a/backend/internal/service/project/folder_missing_test.go
+++ b/backend/internal/service/project/folder_missing_test.go
@@ -14,6 +14,7 @@ import (
 // T1. FolderMissing false when directory exists (happy path).
 func TestFolderMissing_FalseWhenDirectoryExists(t *testing.T) {
 	ctx := context.Background()
+	configureCommitter(t)
 	m := newManager(t)
 	repo := gitRepoWithCommit(t, t.TempDir())
 
@@ -48,6 +49,7 @@ func TestFolderMissing_FalseWhenDirectoryExists(t *testing.T) {
 // T2. FolderMissing true after directory deleted + recovery.
 func TestFolderMissing_LifecycleDeleteAndRecovery(t *testing.T) {
 	ctx := context.Background()
+	configureCommitter(t)
 	m := newManager(t)
 	repo := gitRepoWithCommit(t, t.TempDir())
 
@@ -117,6 +119,7 @@ func TestFolderMissing_LifecycleDeleteAndRecovery(t *testing.T) {
 // T3. Non-directory file at the path is treated as missing.
 func TestFolderMissing_NonDirectoryFileCountsAsMissing(t *testing.T) {
 	ctx := context.Background()
+	configureCommitter(t)
 	m := newManager(t)
 	repo := gitRepoWithCommit(t, t.TempDir())
 
@@ -152,6 +155,7 @@ func TestFolderMissing_NonDirectoryFileCountsAsMissing(t *testing.T) {
 // T4. Missing folder yields FolderMissing=true and falls back to DefaultBranchAuto.
 func TestFolderMissing_MissingFolderFallsBackToAutoBranch(t *testing.T) {
 	ctx := context.Background()
+	configureCommitter(t)
 	m := newManager(t)
 	repo := gitRepoWithCommit(t, t.TempDir())
 
@@ -183,6 +187,7 @@ func TestFolderMissing_MissingFolderFallsBackToAutoBranch(t *testing.T) {
 // T7. Remove after external deletion proves Remove works when folder is gone.
 func TestFolderMissing_RemoveAfterExternalDeletion(t *testing.T) {
 	ctx := context.Background()
+	configureCommitter(t)
 	store, err := sqlitetest.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -121,6 +122,13 @@ func (m *Service) List(ctx context.Context) ([]Summary, error) {
 	}
 	out := make([]Summary, 0, len(projects))
 	for _, row := range projects {
+		folderMissing := false
+		exists, err := folderExists(row.Path)
+		if err != nil {
+			log.Printf("project: stat %s: %v", row.Path, err)
+		} else {
+			folderMissing = !exists
+		}
 		out = append(out, Summary{
 			ID:                domain.ProjectID(row.ID),
 			Name:              displayName(row),
@@ -128,6 +136,7 @@ func (m *Service) List(ctx context.Context) ([]Summary, error) {
 			Kind:              row.Kind.WithDefault(),
 			SessionPrefix:     resolveSessionPrefix(row),
 			OrchestratorAgent: row.Config.Orchestrator.Harness,
+			FolderMissing:     folderMissing,
 		})
 	}
 	return out, nil
@@ -751,11 +760,20 @@ func (m *Service) suggestID(ctx context.Context, base domain.ProjectID) domain.P
 
 func (m *Service) projectFromRow(ctx context.Context, row domain.ProjectRecord) Project {
 	kind := row.Kind.WithDefault()
+	folderMissing := false
+	exists, err := folderExists(row.Path)
+	if err != nil {
+		log.Printf("project: stat %s: %v", row.Path, err)
+	} else {
+		folderMissing = !exists
+	}
 	defaultBranch := ""
 	if kind != domain.ProjectKindScratch {
 		defaultBranch = row.Config.WorktreeBaseBranch()
 		if defaultBranch == "" {
-			defaultBranch = resolveDefaultBranch(ctx, row.Path)
+			if !folderMissing {
+				defaultBranch = resolveDefaultBranch(ctx, row.Path)
+			}
 			if defaultBranch == "" {
 				defaultBranch = domain.DefaultBranchAuto
 			}
@@ -769,6 +787,7 @@ func (m *Service) projectFromRow(ctx context.Context, row domain.ProjectRecord) 
 		Repo:          row.RepoOriginURL,
 		DefaultBranch: defaultBranch,
 		Agent:         string(m.defaultHarness),
+		FolderMissing: folderMissing,
 	}
 	p.Config = projectConfigPtr(row.Config)
 	return p
@@ -810,6 +829,23 @@ func normalizePath(raw string) (string, error) {
 		return "", apierr.Invalid("INVALID_PATH", "Repository path is invalid", nil)
 	}
 	return filepath.Clean(abs), nil
+}
+
+// folderExists reports whether path currently exists as a directory. Only
+// os.ErrNotExist (or a path that is not a directory) means "missing". All other
+// stat errors are surfaced so the caller can log them and avoid guessing.
+func folderExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	return true, nil
 }
 
 func ensureDirectoryPath(path string) error {

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -68,6 +68,7 @@ type Service struct {
 	clock          func() time.Time
 	telemetry      ports.EventSink
 	defaultHarness domain.AgentHarness
+	logger         *slog.Logger
 	// addMu serialises the whole body of Add. Workspace registration performs
 	// filesystem mutations (git init, .gitignore writes, commits) that are not
 	// covered by the store's own writeMu, so path/id conflict checks plus the
@@ -88,6 +89,9 @@ type Deps struct {
 	Sessions       SessionTeardowner
 	Clock          func() time.Time
 	Telemetry      ports.EventSink
+	// Logger receives structured logs. Left nil, the service falls back to
+	// slog.Default, keeping service-focused tests logger-free.
+	Logger *slog.Logger
 }
 
 // New returns a project service backed by the given durable store.
@@ -107,9 +111,13 @@ func NewWithDeps(d Deps) *Service {
 		clock:          d.Clock,
 		telemetry:      d.Telemetry,
 		defaultHarness: defaultHarness,
+		logger:         d.Logger,
 	}
 	if s.clock == nil {
 		s.clock = time.Now
+	}
+	if s.logger == nil {
+		s.logger = slog.Default()
 	}
 	return s
 }
@@ -125,7 +133,7 @@ func (m *Service) List(ctx context.Context) ([]Summary, error) {
 		folderMissing := false
 		exists, err := folderExists(row.Path)
 		if err != nil {
-			log.Printf("project: stat %s: %v", row.Path, err)
+			m.logger.Warn("project: stat failed", "path", row.Path, "error", err)
 		} else {
 			folderMissing = !exists
 		}
@@ -763,7 +771,7 @@ func (m *Service) projectFromRow(ctx context.Context, row domain.ProjectRecord) 
 	folderMissing := false
 	exists, err := folderExists(row.Path)
 	if err != nil {
-		log.Printf("project: stat %s: %v", row.Path, err)
+		m.logger.Warn("project: stat failed", "path", row.Path, "error", err)
 	} else {
 		folderMissing = !exists
 	}

--- a/backend/internal/service/project/types.go
+++ b/backend/internal/service/project/types.go
@@ -11,6 +11,7 @@ type Summary struct {
 	SessionPrefix     string              `json:"sessionPrefix"`
 	OrchestratorAgent domain.AgentHarness `json:"orchestratorAgent,omitempty"`
 	ResolveError      string              `json:"resolveError,omitempty"`
+	FolderMissing     bool                `json:"folderMissing"`
 }
 
 // Project is the full read-model returned by GET /api/v1/projects/{id}.
@@ -24,6 +25,7 @@ type Project struct {
 	Agent          string                `json:"agent,omitempty"`
 	Config         *domain.ProjectConfig `json:"config,omitempty"`
 	WorkspaceRepos []WorkspaceRepo       `json:"workspaceRepos,omitempty"`
+	FolderMissing  bool                  `json:"folderMissing"`
 }
 
 // Degraded is returned in place of Project when project config failed to load.

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -700,6 +700,31 @@ func TestListWorkspaceFilesReturnsTrackedAndUntrackedStatus(t *testing.T) {
 	}
 }
 
+func TestListWorkspaceFilesRepoUnavailableWrapsSentinel(t *testing.T) {
+	repo := newWorkspaceRepo(t)
+	// Simulate a project whose source repository has been deleted from disk:
+	// the worktree directory still exists, but its git metadata (and so the
+	// owning repo's plumbing) is gone. Every git read against it must fail as
+	// repository-unavailable rather than a raw 500.
+	if err := os.RemoveAll(filepath.Join(repo, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	st := newFakeStore()
+	st.sessions["ao-1"] = domain.SessionRecord{
+		ID:       "ao-1",
+		Metadata: domain.SessionMetadata{WorkspacePath: repo},
+		Activity: domain.Activity{State: domain.ActivityActive},
+	}
+
+	_, err := (&Service{store: st}).ListWorkspaceFiles(context.Background(), "ao-1")
+	if err == nil {
+		t.Fatal("ListWorkspaceFiles succeeded with a missing repository")
+	}
+	if !errors.Is(err, ports.ErrWorkspaceRepoUnavailable) {
+		t.Fatalf("error = %v, want errors.Is(ErrWorkspaceRepoUnavailable)", err)
+	}
+}
+
 func TestGetWorkspaceFileReturnsContentAndDiff(t *testing.T) {
 	repo := newWorkspaceRepo(t)
 	writeWorkspaceFile(t, repo, "README.md", "goodbye\nupdated\n")

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
@@ -2014,9 +2015,58 @@ func gitWorkspaceOutput(ctx context.Context, root string, args ...string) (strin
 			}
 			detail += stdout
 		}
+		// A git command against a worktree whose owning repository has been
+		// deleted from disk fails with an opaque exit-128 the caller can't act
+		// on. Detect that single condition so the session read surface maps to
+		// a clean 404 (PROJECT_FOLDER_MISSING) instead of a raw 500.
+		if workspaceRepoUnavailable(root) {
+			return "", fmt.Errorf("git -C %s %s: %w", root, strings.Join(args, " "), ports.ErrWorkspaceRepoUnavailable)
+		}
 		return "", fmt.Errorf("git -C %s %s: %w: %s", root, strings.Join(args, " "), err, detail)
 	}
 	return string(out), nil
+}
+
+// workspaceRepoUnavailable reports whether a worktree root can no longer reach
+// its owning repository on disk. A git worktree keeps a `.git` file at its
+// root whose `gitdir:` line points at the owning repository's common git
+// directory; when that repository has been deleted the pointed-to path no
+// longer exists and git fails with "not a git repository". A plain checkout
+// instead keeps its metadata in a `.git` directory at the root, whose absence
+// is the equivalent signal. Only the genuinely-gone-repository case returns
+// true; any other (available) repository reports false so the original git
+// error keeps its existing semantics.
+func workspaceRepoUnavailable(root string) bool {
+	gitPath := filepath.Join(root, ".git")
+	if data, err := os.ReadFile(gitPath); err == nil {
+		gitdir, ok := parseGitDirFile(string(data))
+		if !ok {
+			return false
+		}
+		if !filepath.IsAbs(gitdir) {
+			gitdir = filepath.Join(root, gitdir)
+		}
+		info, err := os.Stat(gitdir)
+		return err != nil || !info.IsDir()
+	}
+	info, err := os.Stat(gitPath)
+	return err != nil || !info.IsDir()
+}
+
+// parseGitDirFile extracts the path from a git worktree `.git` file's
+// "gitdir: <path>" line.
+func parseGitDirFile(content string) (string, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		const prefix = "gitdir:"
+		if strings.HasPrefix(line, prefix) {
+			path := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			if path != "" {
+				return path, true
+			}
+		}
+	}
+	return "", false
 }
 
 func splitNUL(out string) []string {

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -2060,9 +2060,9 @@ func parseGitDirFile(content string) (string, bool) {
 		line = strings.TrimSpace(line)
 		const prefix = "gitdir:"
 		if strings.HasPrefix(line, prefix) {
-			path := strings.TrimSpace(strings.TrimPrefix(line, prefix))
-			if path != "" {
-				return path, true
+			gitdir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			if gitdir != "" {
+				return gitdir, true
 			}
 		}
 	}

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3492,6 +3492,7 @@ export interface components {
             agent?: string;
             config?: components["schemas"]["ProjectConfig"];
             defaultBranch: string;
+            folderMissing: boolean;
             id: string;
             /** @enum {string} */
             kind: "single_repo" | "workspace" | "scratch";
@@ -3529,6 +3530,7 @@ export interface components {
             project: components["schemas"]["Project"];
         };
         ProjectSummary: {
+            folderMissing: boolean;
             id: string;
             /** @enum {string} */
             kind: "single_repo" | "workspace" | "scratch";

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -1,7 +1,7 @@
 import type { ProjectSource } from "@aoagents/product-ui";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Folder, Folders, FolderOpen, GitFork, Smartphone, Star } from "lucide-react";
+import { AlertTriangle, Folder, Folders, FolderOpen, GitFork, Smartphone, Star } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
 import { useSystemRequirementsGate } from "../hooks/useSystemRequirementsGate";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
@@ -15,6 +15,7 @@ import { BoardWelcome } from "./BoardEmptyStates";
 import { CreateProjectFlow } from "./CreateProjectFlow";
 import { DaemonStartupLoader } from "./DaemonStartupLoader";
 import { TopbarButton } from "./TopbarButton";
+import { Badge } from "./ui/badge";
 
 const GITHUB_REPOSITORY_URL = "https://github.com/Untrivial-ai/agent-orchestrator";
 const RECENT_PROJECT_LIMIT = 3;
@@ -51,6 +52,7 @@ function sortProjectsByActivity(projects: WorkspaceSummary[]): WorkspaceSummary[
 }
 
 function ProjectRow({ project, onClick, emptyTimeLabel, justNowLabel }: { project: WorkspaceSummary; onClick: () => void; emptyTimeLabel: string; justNowLabel: string }) {
+	const { t } = useTranslation();
 	const lastOpenedAt = getProjectLastOpenedAt(project.id);
 	const latestProjectFact = latestProjectTimestamp(project) || lastOpenedAt;
 
@@ -61,10 +63,15 @@ function ProjectRow({ project, onClick, emptyTimeLabel, justNowLabel }: { projec
 			type="button"
 		>
 			<span className={HOME_PROJECT_ICON_CLASS} aria-hidden="true">
-				<Folder strokeWidth={1.8} />
+				{project.folderMissing ? <AlertTriangle strokeWidth={1.8} className="text-warning" /> : <Folder strokeWidth={1.8} />}
 			</span>
 			<span className="min-w-0 text-[14px] leading-5">
-				<span className="block truncate font-medium text-[var(--color-text-import-title)]">{project.name}</span>
+				<span className="flex items-center gap-1.5">
+					<span className="block truncate font-medium text-[var(--color-text-import-title)]">{project.name}</span>
+					{project.folderMissing ? (
+						<Badge variant="warning" className="h-4 shrink-0 px-1.5 text-2xs">{t("home.folderMissing")}</Badge>
+					) : null}
+				</span>
 				<span className="block truncate text-[13px] text-muted-foreground">{project.path}</span>
 			</span>
 			<span className="ml-auto shrink-0 text-right text-[13px] text-muted-foreground">

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -1437,6 +1437,22 @@ describe("SessionsBoard", () => {
 		expect(await screen.findByRole("alert")).toHaveTextContent("Failed to terminate session (500)");
 		expect(screen.getByRole("button", { name: "Terminate merged worker" })).toBeEnabled();
 	});
+
+	it("shows a folder-missing banner when the project root no longer exists on disk", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [{ ...workspaceWithSessions([]), folderMissing: true }],
+		});
+		renderBoard("p1");
+		expect(screen.getByText(appI18n.t("home.folderMissing"))).toBeInTheDocument();
+	});
+
+	it("does not show the folder-missing banner when the project folder exists", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [{ ...workspaceWithSessions([]), folderMissing: false }],
+		});
+		renderBoard("p1");
+		expect(screen.queryByText(appI18n.t("home.folderMissing"))).not.toBeInTheDocument();
+	});
 });
 
 function workspaceWithSessions(sessions: WorkspaceSession[]): WorkspaceSummary {

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -372,6 +372,12 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						) : null}
 					</div>
 				) : null}
+				{workspace?.folderMissing ? (
+					<div className="mx-3 my-3 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2 text-xs text-muted-foreground">
+						<AlertTriangle className="size-icon-base shrink-0 text-warning" aria-hidden="true" />
+						<span className="min-w-0 flex-1">{t("home.folderMissing")}</span>
+					</div>
+				) : null}
 				{workspaceStartupState === "error" || workspaceQuery.isError ? (
 					<p className="py-10 text-center text-xs text-passive">{t("shell.couldNotLoadSessions")}</p>
 				) : showWelcome ? (

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -98,11 +98,12 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 	return (projectsData?.projects ?? []).map((project) => {
 		const kind = toProjectKind(project.kind);
 		return {
-			id: project.id,
-			name: project.name,
-			kind,
-			path: project.path,
-			orchestratorAgent: project.orchestratorAgent ? toAgentProvider(project.orchestratorAgent) : undefined,
+		id: project.id,
+		name: project.name,
+		kind,
+		path: project.path,
+		folderMissing: project.folderMissing,
+		orchestratorAgent: project.orchestratorAgent ? toAgentProvider(project.orchestratorAgent) : undefined,
 			sessions: (sessionsData?.sessions ?? [])
 				.filter((session) => session.projectId === project.id)
 				.map((session) => {

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -44,6 +44,7 @@
 	"common.yes": "Ja",
 	"board.empty.body": "Beschreiben Sie eine Aufgabe — der Orchestrator plant sie, startet Worker-Sitzungen und verfolgt sie hier, während die Arbeit voranschreitet.",
 	"board.empty.title": "Noch keine Worker-Sitzungen",
+	"home.folderMissing": "Ordner fehlt",
 	"home.jumpBack": "Direkt weitermachen",
 	"home.recentProjects": "Zuletzt verwendete Projekte",
 	"home.currentProjects": "Aktuelle Projekte",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -13,6 +13,7 @@
 	"common.yes": "Yes",
 	"board.empty.body": "Describe a task and the orchestrator plans it, spawns worker sessions, and tracks them here as work moves forward.",
 	"board.empty.title": "No worker sessions yet",
+	"home.folderMissing": "Folder missing",
 	"home.jumpBack": "Jump back right in",
 	"home.recentProjects": "Recent projects",
 	"home.currentProjects": "Current projects",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -44,6 +44,7 @@
 	"common.yes": "Sí",
 	"board.empty.body": "Describe una tarea y el orquestador la planifica, crea sesiones de trabajo y las sigue aquí a medida que avanza el trabajo.",
 	"board.empty.title": "Aún no hay sesiones de trabajo",
+	"home.folderMissing": "Carpeta no encontrada",
 	"home.jumpBack": "Vuelve a entrar",
 	"home.recentProjects": "Proyectos recientes",
 	"home.currentProjects": "Proyectos actuales",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -44,6 +44,7 @@
 	"common.yes": "Oui",
 	"board.empty.body": "Décrivez une tâche et l'orchestrateur la planifie, crée des sessions worker et les suit ici au fur et à mesure de l'avancement.",
 	"board.empty.title": "Aucune session worker pour le moment",
+	"home.folderMissing": "Dossier manquant",
 	"home.jumpBack": "Reprendre là où vous en étiez",
 	"home.recentProjects": "Projets récents",
 	"home.currentProjects": "Projets actuels",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -44,6 +44,7 @@
 	"common.yes": "はい",
 	"board.empty.body": "タスクを説明すると、オーケストレーターが計画を立て、ワーカーセッションを起動し、進捗に合わせてここで追跡します。",
 	"board.empty.title": "ワーカーセッションはまだありません",
+	"home.folderMissing": "フォルダがありません",
 	"home.jumpBack": "続きを始める",
 	"home.recentProjects": "最近のプロジェクト",
 	"home.currentProjects": "現在のプロジェクト",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -44,6 +44,7 @@
 	"common.yes": "예",
 	"board.empty.body": "작업을 설명하면 오케스트레이터가 계획을 세우고 워커 세션을 생성하며, 진행 상황을 여기서 추적합니다.",
 	"board.empty.title": "아직 워커 세션이 없습니다",
+	"home.folderMissing": "폴더가 없습니다",
 	"home.jumpBack": "이어서 시작하기",
 	"home.recentProjects": "최근 프로젝트",
 	"home.currentProjects": "현재 프로젝트",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -44,6 +44,7 @@
 	"common.yes": "Sim",
 	"board.empty.body": "Descreva uma tarefa e o orchestrator a planeja, inicia sessões de worker e as acompanha aqui conforme o trabalho avança.",
 	"board.empty.title": "Nenhuma sessão de worker ainda",
+	"home.folderMissing": "Pasta não encontrada",
 	"home.jumpBack": "Volte de onde parou",
 	"home.recentProjects": "Projetos recentes",
 	"home.currentProjects": "Projetos atuais",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -44,6 +44,7 @@
 	"common.yes": "是",
 	"board.empty.body": "描述一个任务后，编排器会进行规划、创建 worker 会话，并在工作推进时在此跟踪。",
 	"board.empty.title": "还没有 worker 会话",
+	"home.folderMissing": "文件夹缺失",
 	"home.jumpBack": "继续进行",
 	"home.recentProjects": "最近的项目",
 	"home.currentProjects": "当前项目",

--- a/frontend/src/renderer/routeTree.gen.ts
+++ b/frontend/src/renderer/routeTree.gen.ts
@@ -11,10 +11,10 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ShellRouteImport } from './routes/_shell'
 import { Route as ShellIndexRouteImport } from './routes/_shell.index'
-import { Route as ShellSettingsRouteImport } from './routes/_shell.settings'
 import { Route as ShellTerminalsRouteImport } from './routes/_shell.terminals'
-import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.projects.$projectId'
+import { Route as ShellSettingsRouteImport } from './routes/_shell.settings'
 import { Route as ShellSessionsSessionIdRouteImport } from './routes/_shell.sessions.$sessionId'
+import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.projects.$projectId'
 import { Route as ShellProjectsProjectIdSettingsRouteImport } from './routes/_shell.projects.$projectId_.settings'
 import { Route as ShellProjectsProjectIdSessionsSessionIdRouteImport } from './routes/_shell.projects.$projectId_.sessions.$sessionId'
 
@@ -27,24 +27,24 @@ const ShellIndexRoute = ShellIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellSettingsRoute = ShellSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => ShellRoute,
-} as any)
 const ShellTerminalsRoute = ShellTerminalsRouteImport.update({
   id: '/terminals',
   path: '/terminals',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellProjectsProjectIdRoute = ShellProjectsProjectIdRouteImport.update({
-  id: '/projects/$projectId',
-  path: '/projects/$projectId',
+const ShellSettingsRoute = ShellSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => ShellRoute,
 } as any)
 const ShellSessionsSessionIdRoute = ShellSessionsSessionIdRouteImport.update({
   id: '/sessions/$sessionId',
   path: '/sessions/$sessionId',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellProjectsProjectIdRoute = ShellProjectsProjectIdRouteImport.update({
+  id: '/projects/$projectId',
+  path: '/projects/$projectId',
   getParentRoute: () => ShellRoute,
 } as any)
 const ShellProjectsProjectIdSettingsRoute =
@@ -140,13 +140,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellIndexRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/_shell/settings': {
-      id: '/_shell/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof ShellSettingsRouteImport
-      parentRoute: typeof ShellRoute
-    }
     '/_shell/terminals': {
       id: '/_shell/terminals'
       path: '/terminals'
@@ -154,11 +147,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellTerminalsRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/_shell/projects/$projectId': {
-      id: '/_shell/projects/$projectId'
-      path: '/projects/$projectId'
-      fullPath: '/projects/$projectId'
-      preLoaderRoute: typeof ShellProjectsProjectIdRouteImport
+    '/_shell/settings': {
+      id: '/_shell/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof ShellSettingsRouteImport
       parentRoute: typeof ShellRoute
     }
     '/_shell/sessions/$sessionId': {
@@ -166,6 +159,13 @@ declare module '@tanstack/react-router' {
       path: '/sessions/$sessionId'
       fullPath: '/sessions/$sessionId'
       preLoaderRoute: typeof ShellSessionsSessionIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/projects/$projectId': {
+      id: '/_shell/projects/$projectId'
+      path: '/projects/$projectId'
+      fullPath: '/projects/$projectId'
+      preLoaderRoute: typeof ShellProjectsProjectIdRouteImport
       parentRoute: typeof ShellRoute
     }
     '/_shell/projects/$projectId_/settings': {

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -315,6 +315,7 @@ export type WorkspaceSummary = {
 	kind?: ProjectKind | typeof CLOUD_PROJECT_KIND;
 	/** Local checkout path; empty string for cloud projects (no local folder). */
 	path: string;
+	folderMissing?: boolean;
 	workspaceRepos?: WorkspaceRepoSummary[];
 	type?: "main" | "worktree";
 	orchestratorAgent?: AgentProvider;


### PR DESCRIPTION
Closes #4902

## Summary

Detect when a project's local folder has been removed from disk and surface it instead of failing with an opaque HTTP 500.

**Behavior (confirmed):** flag on read/list only; no auto-delete/archive/sweep. Removal uses the existing Remove action (`DELETE /api/v1/projects/{id}`).

## Changes

- **Backend** — derive `folderMissing` on read (List/Get) only; only `os.ErrNotExist` counts (other stat errors log and keep the flag false); skip `resolveDefaultBranch` when missing (falls back to `auto`); map repo-unavailable errors to a centralized `404 PROJECT_FOLDER_MISSING` instead of a raw 500.
- **Frontend** — warning badge on project rows (`HomePage`) + banner on the sessions board, using the existing Remove flow. Regenerated OpenAPI + TS types (`folderMissing` on `Project`/`ProjectSummary`).
- **Tests** — lifecycle delete/recover, non-directory, auto-branch fallback, remove-after-external-deletion, `folderExists` helper semantics, envelope 404 mapping, and sentinel wrapping. All cross-platform.

## Verification

- `go build ./...`, `go vet` (changed pkgs), feature tests (`-count=1` and `-count=3`), envelope/session/apispec tests — all pass.
- `cd frontend && npm run typecheck` — clean; `SessionsBoard.test.tsx` 43/43 pass.
- No new backend/lint failures; remaining failures are pre-existing Windows/mac/Electron environment issues unrelated to this change (verified identical on baseline via stash comparison).
- OpenAPI spec parity tests pass (api drift check).

## Notes

- `npm run build` does not exist in this repo's `package.json` (AGENTS.md is stale); the renderer build-equivalent is `typecheck` + `vitest`, both green.
- Semantics: `FolderMissing=true` iff root `Path` does not exist as a directory (workspace kinds — root decides only; child worktrees never checked). Missing child worktree still returns the existing `404 SESSION_WORKSPACE_NOT_FOUND`; spawn stays `409 WORKSPACE_CREATE_FAILED`.

