### PR TITLE
feat(session): add an optional pre-spawn launch gate (#4895)

### DIFF
--- a/backend/internal/adapters/launchgate/claudetrust/claudetrust.go
+++ b/backend/internal/adapters/launchgate/claudetrust/claudetrust.go
@@ -1,0 +1,208 @@
+// Package claudetrust is a launch gate that makes one config root the single
+// place Claude's workspace trust is written and read.
+//
+// The defect it closes was measured on a running install. Trust was recorded
+// true in the operator's home Claude state for the exact session worktree
+// paths, and the live child ran with CLAUDE_CONFIG_DIR pointing at a different
+// root whose state file had none of those entries. Every surface reported that
+// the trust existed; the child still stopped at the prompt that trust was meant
+// to answer, before its agent loop, and AO reported it as ordinary work.
+//
+// Two roots is the whole bug. This gate resolves one AO-owned root per session,
+// writes the exact worktree's trust there, verifies it by reading it back, and
+// points the child at that same root -- for the session's own agent and for its
+// reviewer alike, because the incident was observed on a reviewer child.
+package claudetrust
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// EnvConfigDir is the variable Claude reads to choose its configuration root.
+const EnvConfigDir = "CLAUDE_CONFIG_DIR"
+
+const stateFile = ".claude.json"
+
+// Gate implements ports.LaunchGate for Claude children.
+type Gate struct {
+	// Base is the AO-owned directory under which per-session roots are created.
+	// One root per session keeps a worker and its reviewer in the same state
+	// while keeping different sessions out of each other's.
+	Base string
+	// AppliesTo reports whether a launch is a Claude launch. Nil means the gate
+	// inspects argv, which is what AO resolves and what the child will run.
+	AppliesTo func(req ports.PreLaunchRequest) bool
+}
+
+// PreLaunch resolves the root, writes and verifies trust, and redirects the
+// child to that root. A launch it cannot make trustworthy is refused, because
+// the alternative is the state this gate exists to prevent: a child that starts,
+// stops at a prompt, and is reported as running.
+func (g Gate) PreLaunch(_ context.Context, req ports.PreLaunchRequest) (ports.PreLaunchDecision, error) {
+	if !g.applies(req) {
+		return ports.PreLaunchDecision{Allow: true}, nil
+	}
+	if strings.TrimSpace(req.SessionID) == "" {
+		return ports.PreLaunchDecision{Reason: "launch has no session id to key a config root on"}, nil
+	}
+	if strings.TrimSpace(req.WorkspacePath) == "" {
+		return ports.PreLaunchDecision{Reason: "launch has no workspace path to trust"}, nil
+	}
+	root, err := g.root(req.SessionID)
+	if err != nil {
+		return ports.PreLaunchDecision{}, err
+	}
+	if err := writeTrust(root, req.WorkspacePath); err != nil {
+		return ports.PreLaunchDecision{}, err
+	}
+	// Read it back from the same file the child will read. A write that
+	// succeeded and a state the child can see are not the same claim.
+	trusted, err := hasTrust(root, req.WorkspacePath)
+	if err != nil {
+		return ports.PreLaunchDecision{}, err
+	}
+	if !trusted {
+		return ports.PreLaunchDecision{
+			Reason:     fmt.Sprintf("workspace trust for %s is absent from %s after writing it", req.WorkspacePath, root),
+			PromptKind: "workspace_trust",
+		}, nil
+	}
+	// Override, not contribute: an inherited CLAUDE_CONFIG_DIR is exactly the
+	// case that produced the incident, and leaving it in place would send the
+	// child back to the root that lacks this entry.
+	return ports.PreLaunchDecision{
+		Allow:       true,
+		EnvOverride: map[string]string{EnvConfigDir: root},
+	}, nil
+}
+
+func (g Gate) applies(req ports.PreLaunchRequest) bool {
+	if g.AppliesTo != nil {
+		return g.AppliesTo(req)
+	}
+	for _, argument := range req.Argv {
+		if base := filepath.Base(argument); base == "claude" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g Gate) root(sessionID string) (string, error) {
+	base := strings.TrimSpace(g.Base)
+	if base == "" {
+		return "", fmt.Errorf("claudetrust: no AO-owned config base configured")
+	}
+	if strings.ContainsAny(sessionID, `/\`) || sessionID == "." || sessionID == ".." {
+		return "", fmt.Errorf("claudetrust: session id is not a single path segment")
+	}
+	root := filepath.Join(base, sessionID)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", fmt.Errorf("claudetrust: create config root: %w", err)
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		return "", fmt.Errorf("claudetrust: secure config root: %w", err)
+	}
+	return root, nil
+}
+
+func loadState(path string) (map[string]any, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("claudetrust: read state: %w", err)
+	}
+	state := map[string]any{}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return state, nil
+	}
+	if err := json.Unmarshal(raw, &state); err != nil {
+		// Refuse rather than replace: an unreadable state file may be a live
+		// child's, and overwriting it would destroy conversation history.
+		return nil, fmt.Errorf("claudetrust: state is not a JSON object; it was not replaced")
+	}
+	return state, nil
+}
+
+func writeTrust(root, worktree string) error {
+	path := filepath.Join(root, stateFile)
+	state, err := loadState(path)
+	if err != nil {
+		return err
+	}
+	projects, _ := state["projects"].(map[string]any)
+	if projects == nil {
+		if _, present := state["projects"]; present {
+			return fmt.Errorf("claudetrust: projects state is not an object; it was not replaced")
+		}
+		projects = map[string]any{}
+	}
+	project, _ := projects[worktree].(map[string]any)
+	if project == nil {
+		if _, present := projects[worktree]; present {
+			return fmt.Errorf("claudetrust: project state is not an object; it was not replaced")
+		}
+		project = map[string]any{}
+	}
+	project["hasTrustDialogAccepted"] = true
+	projects[worktree] = project
+	state["projects"] = projects
+
+	encoded, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("claudetrust: encode state: %w", err)
+	}
+	temporary, err := os.CreateTemp(root, ".claude-state-")
+	if err != nil {
+		return fmt.Errorf("claudetrust: stage state: %w", err)
+	}
+	name := temporary.Name()
+	defer os.Remove(name)
+	if _, err := temporary.Write(append(encoded, '\n')); err != nil {
+		temporary.Close()
+		return fmt.Errorf("claudetrust: write state: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return fmt.Errorf("claudetrust: sync state: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("claudetrust: close state: %w", err)
+	}
+	if err := os.Chmod(name, 0o600); err != nil {
+		return fmt.Errorf("claudetrust: secure state: %w", err)
+	}
+	if err := os.Rename(name, path); err != nil {
+		return fmt.Errorf("claudetrust: persist state: %w", err)
+	}
+	return nil
+}
+
+// hasTrust reports whether the exact worktree path is trusted in this root. The
+// path is compared exactly: a parent entry must not confer trust on a child
+// directory that nobody trusted.
+func hasTrust(root, worktree string) (bool, error) {
+	state, err := loadState(filepath.Join(root, stateFile))
+	if err != nil {
+		return false, err
+	}
+	projects, _ := state["projects"].(map[string]any)
+	if projects == nil {
+		return false, nil
+	}
+	project, _ := projects[worktree].(map[string]any)
+	if project == nil {
+		return false, nil
+	}
+	accepted, _ := project["hasTrustDialogAccepted"].(bool)
+	return accepted, nil
+}

--- a/backend/internal/adapters/launchgate/claudetrust/claudetrust.go
+++ b/backend/internal/adapters/launchgate/claudetrust/claudetrust.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -103,14 +104,85 @@ func (g Gate) root(sessionID string) (string, error) {
 	if strings.ContainsAny(sessionID, `/\`) || sessionID == "." || sessionID == ".." {
 		return "", fmt.Errorf("claudetrust: session id is not a single path segment")
 	}
-	root := filepath.Join(base, sessionID)
-	if err := os.MkdirAll(root, 0o700); err != nil {
-		return "", fmt.Errorf("claudetrust: create config root: %w", err)
+	if err := ensureRealDir(base); err != nil {
+		return "", err
 	}
-	if err := os.Chmod(root, 0o700); err != nil {
-		return "", fmt.Errorf("claudetrust: secure config root: %w", err)
+	root := filepath.Join(base, sessionID)
+	if err := ensureRealDir(root); err != nil {
+		return "", err
 	}
 	return root, nil
+}
+
+// ensureRealDir creates a directory and refuses a symlink at that exact path.
+//
+// A same-user process that can write AO's data directory could otherwise
+// pre-create a predictable session root as a symlink, and the gate would then
+// write a .claude.json outside the daemon's data directory entirely.
+// os.MkdirAll is content with an existing symlink to a directory, so the check
+// is explicit and uses Lstat, which does not follow the final component.
+func ensureRealDir(path string) error {
+	info, err := os.Lstat(path)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("claudetrust: %s is a symlink; refusing to write through it", path)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("claudetrust: %s exists and is not a directory", path)
+		}
+	case os.IsNotExist(err):
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return fmt.Errorf("claudetrust: create config root parent: %w", err)
+		}
+		// Mkdir, not MkdirAll, on the final component: MkdirAll succeeds when
+		// the path already resolves through a symlink, which is the case being
+		// rejected. Mkdir fails with EEXIST instead, and the Lstat above then
+		// names it.
+		if err := os.Mkdir(path, 0o700); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("claudetrust: create config root: %w", err)
+		}
+		return ensureRealDir(path)
+	default:
+		return fmt.Errorf("claudetrust: inspect config root: %w", err)
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		return fmt.Errorf("claudetrust: secure config root: %w", err)
+	}
+	return nil
+}
+
+// withRootLock serializes read/modify/write of one session's state across
+// processes and goroutines. Atomic replacement alone is not enough: two callers
+// that both load, both mutate, and both rename lose whichever wrote first,
+// including unrelated entries the loser had added.
+func withRootLock(root string, action func() error) (err error) {
+	lockPath := filepath.Join(root, ".launch-gate.lock")
+	if info, statErr := os.Lstat(lockPath); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("claudetrust: lock path is a symlink; refusing to follow it")
+	}
+	flags := os.O_RDWR | os.O_CREATE
+	if syscall.O_NOFOLLOW != 0 {
+		flags |= syscall.O_NOFOLLOW
+	}
+	handle, openErr := os.OpenFile(lockPath, flags, 0o600)
+	if openErr != nil {
+		return fmt.Errorf("claudetrust: open state lock: %w", openErr)
+	}
+	defer func() {
+		if closeErr := handle.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("claudetrust: close state lock: %w", closeErr)
+		}
+	}()
+	if lockErr := syscall.Flock(int(handle.Fd()), syscall.LOCK_EX); lockErr != nil {
+		return fmt.Errorf("claudetrust: lock state: %w", lockErr)
+	}
+	defer func() {
+		if unlockErr := syscall.Flock(int(handle.Fd()), syscall.LOCK_UN); unlockErr != nil && err == nil {
+			err = fmt.Errorf("claudetrust: unlock state: %w", unlockErr)
+		}
+	}()
+	return action()
 }
 
 func loadState(path string) (map[string]any, error) {
@@ -134,7 +206,14 @@ func loadState(path string) (map[string]any, error) {
 }
 
 func writeTrust(root, worktree string) error {
+	return withRootLock(root, func() error { return writeTrustLocked(root, worktree) })
+}
+
+func writeTrustLocked(root, worktree string) error {
 	path := filepath.Join(root, stateFile)
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("claudetrust: %s is a symlink; refusing to write through it", path)
+	}
 	state, err := loadState(path)
 	if err != nil {
 		return err
@@ -191,7 +270,11 @@ func writeTrust(root, worktree string) error {
 // path is compared exactly: a parent entry must not confer trust on a child
 // directory that nobody trusted.
 func hasTrust(root, worktree string) (bool, error) {
-	state, err := loadState(filepath.Join(root, stateFile))
+	path := filepath.Join(root, stateFile)
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("claudetrust: %s is a symlink; refusing to read through it", path)
+	}
+	state, err := loadState(path)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/adapters/launchgate/claudetrust/claudetrust_test.go
+++ b/backend/internal/adapters/launchgate/claudetrust/claudetrust_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -224,5 +225,112 @@ func TestUnusableInputsRefuse(t *testing.T) {
 	if _, err := (Gate{Base: t.TempDir()}).PreLaunch(context.Background(),
 		request("../escape", worktree, ports.LaunchRoleWorker, nil)); err == nil {
 		t.Fatal("a session id that is not one path segment must error")
+	}
+}
+
+// P1 from review 5113322042: a same-user process that can write AO's data
+// directory could pre-create a predictable session root as a symlink, and the
+// gate would then write .claude.json outside the daemon's data directory.
+func TestSymlinkedSessionRootIsRefused(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(base, "mer-1")); err != nil {
+		t.Fatalf("stage symlink: %v", err)
+	}
+
+	_, err := Gate{Base: base}.PreLaunch(context.Background(),
+		request("mer-1", t.TempDir(), ports.LaunchRoleWorker, nil))
+
+	if err == nil {
+		t.Fatal("a symlinked session root must be refused, not written through")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want it to name the symlink", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, stateFile)); statErr == nil {
+		t.Fatal("the gate wrote state outside the AO-owned base")
+	}
+}
+
+func TestSymlinkedBaseIsRefused(t *testing.T) {
+	parent := t.TempDir()
+	outside := t.TempDir()
+	base := filepath.Join(parent, "config-base")
+	if err := os.Symlink(outside, base); err != nil {
+		t.Fatalf("stage symlink: %v", err)
+	}
+
+	_, err := Gate{Base: base}.PreLaunch(context.Background(),
+		request("mer-1", t.TempDir(), ports.LaunchRoleWorker, nil))
+
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want a symlinked base refused", err)
+	}
+}
+
+func TestSymlinkedStateFileIsRefused(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "mer-1")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("stage root: %v", err)
+	}
+	elsewhere := filepath.Join(t.TempDir(), "target.json")
+	if err := os.WriteFile(elsewhere, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("stage target: %v", err)
+	}
+	if err := os.Symlink(elsewhere, filepath.Join(root, stateFile)); err != nil {
+		t.Fatalf("stage symlink: %v", err)
+	}
+
+	_, err := Gate{Base: base}.PreLaunch(context.Background(),
+		request("mer-1", t.TempDir(), ports.LaunchRoleWorker, nil))
+
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want a symlinked state file refused", err)
+	}
+	raw, readErr := os.ReadFile(elsewhere)
+	if readErr != nil {
+		t.Fatalf("read target: %v", readErr)
+	}
+	if strings.Contains(string(raw), "hasTrustDialogAccepted") {
+		t.Fatal("the gate wrote through the symlink")
+	}
+}
+
+// Atomic replacement alone is not enough: two callers that both load, mutate
+// and rename lose whichever wrote first, including unrelated entries. Every
+// worktree written concurrently must survive.
+func TestConcurrentTrustWritesAllSurvive(t *testing.T) {
+	base := t.TempDir()
+	gate := Gate{Base: base}
+	worktrees := make([]string, 12)
+	for i := range worktrees {
+		worktrees[i] = filepath.Join(t.TempDir(), "wt")
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(worktrees))
+	for _, worktree := range worktrees {
+		wg.Add(1)
+		go func(worktree string) {
+			defer wg.Done()
+			if _, err := gate.PreLaunch(context.Background(),
+				request("mer-1", worktree, ports.LaunchRoleWorker, nil)); err != nil {
+				errs <- err
+			}
+		}(worktree)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent PreLaunch: %v", err)
+	}
+
+	trusted := trustedPaths(t, filepath.Join(base, "mer-1"))
+	for _, worktree := range worktrees {
+		if !trusted[worktree] {
+			t.Fatalf("worktree %q was lost by a concurrent write; %d of %d survived",
+				worktree, len(trusted), len(worktrees))
+		}
 	}
 }

--- a/backend/internal/adapters/launchgate/claudetrust/claudetrust_test.go
+++ b/backend/internal/adapters/launchgate/claudetrust/claudetrust_test.go
@@ -1,0 +1,228 @@
+package claudetrust
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func request(sessionID, worktree string, role ports.LaunchRole, env map[string]string) ports.PreLaunchRequest {
+	return ports.PreLaunchRequest{
+		SessionID:     sessionID,
+		WorkspacePath: worktree,
+		Argv:          []string{"/usr/local/bin/claude", "--permission-mode", "acceptEdits"},
+		Env:           env,
+		Role:          role,
+	}
+}
+
+func trustedPaths(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, stateFile))
+	if err != nil {
+		t.Fatalf("read %s: %v", root, err)
+	}
+	var state struct {
+		Projects map[string]struct {
+			HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("decode %s: %v", root, err)
+	}
+	out := map[string]bool{}
+	for path, project := range state.Projects {
+		out[path] = project.HasTrustDialogAccepted
+	}
+	return out
+}
+
+// The measured incident, as a regression.
+//
+// Sessions 61, 62, 67 and 68 each had hasTrustDialogAccepted true in the
+// operator's default Claude root for their exact worktree paths, while the live
+// child ran with CLAUDE_CONFIG_DIR pointing at another root whose state file had
+// none of those entries. Trust in the wrong root is trust the child never sees.
+func TestWrongRootTrustIsNotEnoughAndTheChildIsRedirected(t *testing.T) {
+	base := t.TempDir()
+	defaultRoot := t.TempDir()   // stands in for the operator's own root
+	inheritedRoot := t.TempDir() // stands in for the root the child inherited
+
+	worktrees := map[string]string{
+		"setup-agent-orchestrator-61": filepath.Join(t.TempDir(), "61"),
+		"setup-agent-orchestrator-62": filepath.Join(t.TempDir(), "62"),
+		"setup-agent-orchestrator-67": filepath.Join(t.TempDir(), "67"),
+		"setup-agent-orchestrator-68": filepath.Join(t.TempDir(), "68"),
+	}
+	// Trust exists, in the wrong place, for every one of them.
+	for _, worktree := range worktrees {
+		if err := writeTrust(defaultRoot, worktree); err != nil {
+			t.Fatalf("seed default root: %v", err)
+		}
+	}
+	// And the inherited root, which the child would actually read, has nothing.
+	if err := os.WriteFile(filepath.Join(inheritedRoot, stateFile), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("seed inherited root: %v", err)
+	}
+
+	gate := Gate{Base: base}
+	for sessionID, worktree := range worktrees {
+		t.Run(sessionID, func(t *testing.T) {
+			// The precondition that made the incident invisible.
+			if !trustedPaths(t, defaultRoot)[worktree] {
+				t.Fatal("fixture no longer reproduces: default root should trust this worktree")
+			}
+			if trustedPaths(t, inheritedRoot)[worktree] {
+				t.Fatal("fixture no longer reproduces: inherited root should not trust it")
+			}
+
+			decision, err := gate.PreLaunch(context.Background(),
+				request(sessionID, worktree, ports.LaunchRoleWorker,
+					map[string]string{EnvConfigDir: inheritedRoot}))
+			if err != nil {
+				t.Fatalf("PreLaunch: %v", err)
+			}
+			if !decision.Allow {
+				t.Fatalf("launch refused: %s", decision.Reason)
+			}
+
+			root := decision.EnvOverride[EnvConfigDir]
+			if root == "" {
+				t.Fatal("gate must redirect the child away from the inherited root")
+			}
+			if root == inheritedRoot {
+				t.Fatal("gate left the child on the root that lacks the trust entry")
+			}
+			if !strings.HasPrefix(root, base) {
+				t.Fatalf("config root %q is not under the AO-owned base %q", root, base)
+			}
+			if !trustedPaths(t, root)[worktree] {
+				t.Fatalf("root %q does not trust the exact worktree %q", root, worktree)
+			}
+		})
+	}
+}
+
+// Parity: the reviewer resolves the same root as its worker, so one write serves
+// both children. The incident was observed on a reviewer.
+func TestWorkerAndReviewerResolveOneRoot(t *testing.T) {
+	base := t.TempDir()
+	worktree := t.TempDir()
+	gate := Gate{Base: base}
+
+	worker, err := gate.PreLaunch(context.Background(),
+		request("mer-1", worktree, ports.LaunchRoleWorker, nil))
+	if err != nil {
+		t.Fatalf("worker PreLaunch: %v", err)
+	}
+	reviewer, err := gate.PreLaunch(context.Background(),
+		request("mer-1", worktree, ports.LaunchRoleReviewer,
+			map[string]string{EnvConfigDir: "/somewhere/else"}))
+	if err != nil {
+		t.Fatalf("reviewer PreLaunch: %v", err)
+	}
+	if worker.EnvOverride[EnvConfigDir] != reviewer.EnvOverride[EnvConfigDir] {
+		t.Fatalf("worker root %q != reviewer root %q; one session must have one root",
+			worker.EnvOverride[EnvConfigDir], reviewer.EnvOverride[EnvConfigDir])
+	}
+	if !trustedPaths(t, reviewer.EnvOverride[EnvConfigDir])[worktree] {
+		t.Fatal("the shared root must trust the exact worktree")
+	}
+}
+
+// Trust is per exact path. A trusted parent must not confer trust on a child
+// directory nobody trusted, or the gate would report a trust that Claude does
+// not apply.
+func TestTrustIsExactPathNotPrefix(t *testing.T) {
+	root := t.TempDir()
+	parent := t.TempDir()
+	child := filepath.Join(parent, "nested")
+	if err := writeTrust(root, parent); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	trusted, err := hasTrust(root, child)
+	if err != nil {
+		t.Fatalf("hasTrust: %v", err)
+	}
+	if trusted {
+		t.Fatal("a trusted parent must not make a nested worktree trusted")
+	}
+}
+
+// Existing state in the AO-owned root is preserved: a second session's entry and
+// any unrelated key Claude keeps must survive the write.
+func TestWriteTrustPreservesUnrelatedState(t *testing.T) {
+	root := t.TempDir()
+	seed := map[string]any{
+		"projects":     map[string]any{"/other/worktree": map[string]any{"hasTrustDialogAccepted": true}},
+		"oauthAccount": map[string]any{"emailAddress": "someone@example.invalid"},
+	}
+	encoded, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(filepath.Join(root, stateFile), encoded, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := writeTrust(root, "/new/worktree"); err != nil {
+		t.Fatalf("writeTrust: %v", err)
+	}
+	paths := trustedPaths(t, root)
+	if !paths["/other/worktree"] || !paths["/new/worktree"] {
+		t.Fatalf("both worktrees must be trusted, got %v", paths)
+	}
+	raw, _ := os.ReadFile(filepath.Join(root, stateFile))
+	if !strings.Contains(string(raw), "someone@example.invalid") {
+		t.Fatal("unrelated Claude state must survive the trust write")
+	}
+}
+
+// A non-Claude launch is left completely alone.
+func TestNonClaudeLaunchIsUntouched(t *testing.T) {
+	gate := Gate{Base: t.TempDir()}
+	req := request("mer-1", t.TempDir(), ports.LaunchRoleWorker, nil)
+	req.Argv = []string{"/usr/local/bin/codex", "--sandbox", "danger-full-access"}
+
+	decision, err := gate.PreLaunch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("PreLaunch: %v", err)
+	}
+	if !decision.Allow {
+		t.Fatal("a non-Claude launch must not be refused by this gate")
+	}
+	if len(decision.EnvOverride) != 0 || len(decision.Env) != 0 {
+		t.Fatalf("a non-Claude launch must not gain environment: %+v", decision)
+	}
+}
+
+// Unusable inputs refuse rather than write somewhere unexpected.
+func TestUnusableInputsRefuse(t *testing.T) {
+	worktree := t.TempDir()
+	for name, req := range map[string]ports.PreLaunchRequest{
+		"no session id": request("", worktree, ports.LaunchRoleWorker, nil),
+		"no workspace":  request("mer-1", "", ports.LaunchRoleWorker, nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			decision, err := Gate{Base: t.TempDir()}.PreLaunch(context.Background(), req)
+			if err != nil {
+				t.Fatalf("PreLaunch: %v", err)
+			}
+			if decision.Allow {
+				t.Fatal("an unusable request must not be allowed")
+			}
+			if strings.TrimSpace(decision.Reason) == "" {
+				t.Fatal("a refusal must say why")
+			}
+		})
+	}
+	if _, err := (Gate{}).PreLaunch(context.Background(),
+		request("mer-1", worktree, ports.LaunchRoleWorker, nil)); err == nil {
+		t.Fatal("a gate with no AO-owned base must error rather than guess a root")
+	}
+	if _, err := (Gate{Base: t.TempDir()}).PreLaunch(context.Background(),
+		request("../escape", worktree, ports.LaunchRoleWorker, nil)); err == nil {
+		t.Fatal("a session id that is not one path segment must error")
+	}
+}

--- a/backend/internal/daemon/launch_gate_wiring_test.go
+++ b/backend/internal/daemon/launch_gate_wiring_test.go
@@ -1,0 +1,113 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/launchgate/claudetrust"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Construction regressions for the Claude launch gate.
+//
+// The gate only closes the two-roots defect if the daemon actually builds one
+// and gives it to both paths that create a Claude child. A gate that exists in
+// the tree but is never constructed leaves installed behaviour exactly as it
+// was, which is the state the previous commit shipped and this one ends.
+
+func TestClaudeLaunchGateRootLivesUnderTheDaemonDataDir(t *testing.T) {
+	dataDir := t.TempDir()
+
+	gate := claudeLaunchGate(dataDir)
+	if gate == nil {
+		t.Fatal("a configured data directory must produce a gate")
+	}
+	typed, ok := gate.(claudetrust.Gate)
+	if !ok {
+		t.Fatalf("gate = %T, want claudetrust.Gate", gate)
+	}
+	want := filepath.Join(dataDir, ClaudeSessionConfigDirName)
+	if typed.Base != want {
+		t.Fatalf("gate base = %q, want %q", typed.Base, want)
+	}
+	// The root must be derived from what the daemon owns. A home directory or a
+	// path taken from the environment is how the writer and the child end up in
+	// different roots in the first place.
+	if !strings.HasPrefix(typed.Base, dataDir) {
+		t.Fatalf("gate base %q escapes the daemon data directory %q", typed.Base, dataDir)
+	}
+}
+
+func TestClaudeLaunchGateIsAbsentWithoutADataDir(t *testing.T) {
+	for _, dataDir := range []string{"", "   "} {
+		if gate := claudeLaunchGate(dataDir); gate != nil {
+			t.Fatalf("data dir %q produced a gate; embedders without one must keep prior behaviour", dataDir)
+		}
+	}
+}
+
+// The integration property, stated as one fact: a session's own agent and its
+// reviewer receive the same effective config root from the same gate. Two roots
+// for one session is the defect wearing a different hat.
+func TestOneGateGivesWorkerAndReviewerTheSameRoot(t *testing.T) {
+	dataDir := t.TempDir()
+	worktree := t.TempDir()
+	gate := claudeLaunchGate(dataDir)
+
+	roots := map[ports.LaunchRole]string{}
+	for _, role := range []ports.LaunchRole{ports.LaunchRoleWorker, ports.LaunchRoleReviewer} {
+		decision, err := gate.PreLaunch(context.Background(), ports.PreLaunchRequest{
+			SessionID:     "mer-1",
+			WorkspacePath: worktree,
+			Argv:          []string{"/usr/local/bin/claude"},
+			Role:          role,
+			// Each child inherits a different wrong root, which is what the
+			// live incident looked like.
+			Env: map[string]string{claudetrust.EnvConfigDir: "/inherited/" + string(role)},
+		})
+		if err != nil {
+			t.Fatalf("%s PreLaunch: %v", role, err)
+		}
+		if !decision.Allow {
+			t.Fatalf("%s refused: %s", role, decision.Reason)
+		}
+		root := decision.EnvOverride[claudetrust.EnvConfigDir]
+		if root == "" {
+			t.Fatalf("%s was not redirected off its inherited root", role)
+		}
+		roots[role] = root
+	}
+	if roots[ports.LaunchRoleWorker] != roots[ports.LaunchRoleReviewer] {
+		t.Fatalf("worker root %q != reviewer root %q", roots[ports.LaunchRoleWorker], roots[ports.LaunchRoleReviewer])
+	}
+	if !strings.HasPrefix(roots[ports.LaunchRoleWorker], filepath.Join(dataDir, ClaudeSessionConfigDirName)) {
+		t.Fatalf("shared root %q is not under the daemon's own config base", roots[ports.LaunchRoleWorker])
+	}
+}
+
+// Different sessions stay out of each other's state even though they share the
+// base directory.
+func TestSessionsGetSeparateRootsUnderOneBase(t *testing.T) {
+	dataDir := t.TempDir()
+	worktree := t.TempDir()
+	gate := claudeLaunchGate(dataDir)
+
+	seen := map[string]string{}
+	for _, sessionID := range []string{"mer-1", "mer-2"} {
+		decision, err := gate.PreLaunch(context.Background(), ports.PreLaunchRequest{
+			SessionID:     sessionID,
+			WorkspacePath: worktree,
+			Argv:          []string{"claude"},
+			Role:          ports.LaunchRoleWorker,
+		})
+		if err != nil {
+			t.Fatalf("%s PreLaunch: %v", sessionID, err)
+		}
+		seen[sessionID] = decision.EnvOverride[claudetrust.EnvConfigDir]
+	}
+	if seen["mer-1"] == seen["mer-2"] {
+		t.Fatalf("both sessions resolved the same root %q", seen["mer-1"])
+	}
+}

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/activitydispatch"
 	agentregistry "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/registry"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/container/dockerreap"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/launchgate/claudetrust"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/reviewer"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/runtimeselect"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
@@ -245,6 +247,10 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		Scratch:  scratchWS,
 		Projects: store,
 	})
+	// One gate, constructed once, given to both paths that create a Claude
+	// child. Two roots is the defect it exists to close, so two gates -- or one
+	// gate on only one of the two paths -- would reintroduce it.
+	launchGate := claudeLaunchGate(cfg.DataDir)
 	mgr := sessionmanager.New(sessionmanager.Deps{
 		Runtime:             runtime,
 		Agents:              agents,
@@ -265,6 +271,7 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		Logger:              log,
 		ReconcileWorkers:    startupReconcileWorkers,
 		CodexOperationGate:  codexOperationGate,
+		LaunchGate:          launchGate,
 	})
 	mgr.SetAgentReadiness(agentReadiness)
 	scmProvider := newMultiSCMProvider(cfg.GitLab, log)
@@ -298,7 +305,8 @@ func startSession(ctx context.Context, cfg config.Config, runtime runtimeselect.
 		Projects: store,
 		Launcher: reviewcore.NewLauncher(reviewers, runtime, cfg.DataDir,
 			reviewcore.WithRunFilePath(cfg.RunFilePath),
-			reviewcore.WithAgentAuth(reviewerAgentAuth{readiness: agentReadiness})),
+			reviewcore.WithAgentAuth(reviewerAgentAuth{readiness: agentReadiness}),
+			reviewcore.WithLaunchGate(launchGate)),
 	})
 	reviewOpts := []reviewsvc.Option{
 		reviewsvc.WithLifecycleReducer(lcm),
@@ -616,3 +624,24 @@ func (c chatLauncher) AbortChatHandoff(id domain.SessionID) {
 func (c chatLauncher) StopChat(ctx context.Context, id domain.SessionID) error {
 	return c.svc.StopChat(ctx, id)
 }
+
+
+// claudeLaunchGate builds the Claude launch gate from the daemon's own
+// configured data directory, so a session's config root lives beside the data
+// AO already owns rather than in an operator's home or a path chosen by an
+// environment variable. Choosing the root from anywhere the daemon does not own
+// is how the child and the writer end up in different roots, which is the
+// defect this gate exists to close.
+//
+// An empty data directory yields no gate. That keeps embedders and focused
+// tests that pass no data directory on exactly the behaviour they had before.
+func claudeLaunchGate(dataDir string) ports.LaunchGate {
+	if strings.TrimSpace(dataDir) == "" {
+		return nil
+	}
+	return claudetrust.Gate{Base: filepath.Join(dataDir, ClaudeSessionConfigDirName)}
+}
+
+// ClaudeSessionConfigDirName is the directory under the daemon data directory
+// that holds one Claude configuration root per session.
+const ClaudeSessionConfigDirName = "claude-session-config"

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -589,6 +589,15 @@ type PreLaunchRequest struct {
 	// the precise worktree paths, and absent from the effective inherited root
 	// the reviewer child actually used.
 	Env map[string]string
+	// LaunchID identifies this attempt, and is created before the gate is asked
+	// so a decision can be bound to the launch it was made for. Without it a
+	// gate cannot tell a current child from a replacement, which is what lets a
+	// stale handshake make a new launch look ready.
+	LaunchID string
+	// ConversationID is the provider conversation this child will resume, empty
+	// for a fresh one. A gate that must reason about resume validity needs to
+	// know which conversation is being restored, not merely that one is.
+	ConversationID string
 	// Role distinguishes the session's own agent from a reviewer sidecar
 	// launched beside it. Both create children, by separate paths, and a gate
 	// that saw only one of them would leave the other able to strand silently.

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -574,7 +574,36 @@ type PreLaunchRequest struct {
 	// the binary check. A gate may read it to confirm that a resolved
 	// permission mode actually reaches the child, but must not rewrite it.
 	Argv []string
+	// Env is the resolved child environment as it stands immediately before the
+	// child is created. It is a copy: mutating it has no effect, and a gate
+	// contributes through PreLaunchDecision.Env instead.
+	//
+	// A gate cannot do its job without this. An agent's own configuration root
+	// is frequently an environment variable -- Claude reads CLAUDE_CONFIG_DIR --
+	// and AO or its operator may already have set one. A gate that assumed the
+	// default root would write its state to a file the child never reads, and
+	// the child would still stop at the prompt that state was meant to answer,
+	// with every observable surface reporting that the state exists. That exact
+	// discrepancy was observed live: trust recorded true in the home root for
+	// the precise worktree paths, and absent from the effective inherited root
+	// the reviewer child actually used.
+	Env map[string]string
+	// Role distinguishes the session's own agent from a reviewer sidecar
+	// launched beside it. Both create children, by separate paths, and a gate
+	// that saw only one of them would leave the other able to strand silently.
+	Role LaunchRole
 }
+
+// LaunchRole names which child a gate is being asked about.
+type LaunchRole string
+
+const (
+	// LaunchRoleWorker is the session's own agent, created by Spawn.
+	LaunchRoleWorker LaunchRole = "worker"
+	// LaunchRoleReviewer is the reviewer sidecar, created by the review
+	// launcher on its own path.
+	LaunchRoleReviewer LaunchRole = "reviewer"
+)
 
 // PreLaunchDecision is a gate's answer. The zero value refuses, so a gate that
 // returns nothing by mistake stops the launch rather than waving it through.

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -608,13 +609,39 @@ const (
 // PreLaunchDecision is a gate's answer. The zero value refuses, so a gate that
 // returns nothing by mistake stops the launch rather than waving it through.
 type PreLaunchDecision struct {
-	// Env is merged into the child environment. Keys already set by AO are not
+	// Env is merged into the child environment. Keys already set are not
 	// replaced: a gate contributes, it does not take over the environment.
 	Env map[string]string
+	// EnvOverride replaces keys that are already set, which Env deliberately
+	// cannot do. It is separate from Env so that taking ownership of a variable
+	// is a visible act rather than a side effect of contributing one.
+	//
+	// It exists for one narrow case: an agent whose configuration root is chosen
+	// by the environment. Claude reads CLAUDE_CONFIG_DIR, and an operator or an
+	// outer process may already have set it. A gate that can only contribute is
+	// then unable to put the child and whatever seeds the child's state in the
+	// same root -- it writes trust to the root it owns, the child reads the root
+	// it inherited, and the child stops at a prompt whose answer exists in a
+	// file it never opens. That was observed live, and it is why contribute-only
+	// is not enough.
+	//
+	// AO's own variables are never overridable: see LaunchGateProtectedEnv. A
+	// gate may take a variable the agent owns; it may not take one the daemon
+	// owns.
+	EnvOverride map[string]string
 	// Reason is required when Allow is false and is surfaced to the caller.
 	Reason string
 	// PromptKind optionally names the machine-readable blocker a gate
 	// recognised, for example workspace_trust or bypass_acknowledgement.
 	PromptKind string
 	Allow      bool
+}
+
+
+// LaunchGateProtectedEnv reports whether a launch gate is forbidden to override
+// this variable. AO's own names carry session identity and callback wiring into
+// the child; rewriting them could redirect a session's activity reporting or its
+// data store, which is a different power from choosing an agent's config root.
+func LaunchGateProtectedEnv(key string) bool {
+	return strings.HasPrefix(key, "AO_")
 }

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -534,3 +534,58 @@ const (
 	PromptDeliveryAfterStart  PromptDeliveryStrategy = "after_start"
 	PromptDeliveryCustomAgent PromptDeliveryStrategy = "custom_agent"
 )
+
+// ErrLaunchNotReady is returned by a LaunchGate that refuses a spawn. AO must
+// surface it instead of creating a child, so a session card never represents a
+// child that was never able to become ready.
+var ErrLaunchNotReady = errors.New("agent: launch not ready")
+
+// LaunchGate is an optional, daemon-owned contract invoked after the workspace
+// exists and the child argv is final, but before any child process is created.
+//
+// It exists because process creation is not successful startup. An agent can be
+// spawned and then stop before its agent loop -- at a workspace-trust prompt, at
+// a permission acknowledgement, or on a conversation that no longer exists --
+// and AO would report that as ordinary work in progress. The gate is the one
+// place where a caller still holds every trusted value (session, workspace, git
+// common dir, resolved permissions, exact argv) and the child does not yet
+// exist, so it can contribute a narrow child environment or refuse visibly.
+//
+// It deliberately mirrors the existing pre-launch agent-binary check: same
+// position in Spawn, same fail-closed shape, same rollback. Nil disables it and
+// leaves spawn behaviour byte-identical.
+type LaunchGate interface {
+	PreLaunch(ctx context.Context, req PreLaunchRequest) (PreLaunchDecision, error)
+}
+
+// PreLaunchRequest carries only daemon-owned values. Every field is resolved by
+// AO itself; nothing here is supplied by the task or by the agent.
+type PreLaunchRequest struct {
+	SessionID     string
+	Kind          domain.SessionKind
+	Harness       domain.AgentHarness
+	WorkspacePath string
+	// GitCommonDir is the workspace's resolved git common directory, empty when
+	// the workspace is not a git worktree. A gate that verifies AO-created
+	// worktree provenance needs it, and must not infer it from WorkspacePath.
+	GitCommonDir string
+	Permissions  PermissionMode
+	// Argv is the exact child command line, after adapter resolution and after
+	// the binary check. A gate may read it to confirm that a resolved
+	// permission mode actually reaches the child, but must not rewrite it.
+	Argv []string
+}
+
+// PreLaunchDecision is a gate's answer. The zero value refuses, so a gate that
+// returns nothing by mistake stops the launch rather than waving it through.
+type PreLaunchDecision struct {
+	// Env is merged into the child environment. Keys already set by AO are not
+	// replaced: a gate contributes, it does not take over the environment.
+	Env map[string]string
+	// Reason is required when Allow is false and is surfaced to the caller.
+	Reason string
+	// PromptKind optionally names the machine-readable blocker a gate
+	// recognised, for example workspace_trust or bypass_acknowledgement.
+	PromptKind string
+	Allow      bool
+}

--- a/backend/internal/review/launch_gate_test.go
+++ b/backend/internal/review/launch_gate_test.go
@@ -48,6 +48,13 @@ func TestLauncherSpawnRefusedByGateCreatesNoPane(t *testing.T) {
 	if rt.created {
 		t.Fatal("runtime.Create must not run when the gate refuses")
 	}
+	// P1 from review 5113322042: proving no Create is not enough. The reviewer
+	// handle is destroyed to make way for the replacement, so a refusal that
+	// destroys first leaves the session with no reviewer and no replacement --
+	// strictly worse than not having asked.
+	if rt.destroyed != "" {
+		t.Fatalf("a refused launch destroyed the existing reviewer pane %q", rt.destroyed)
+	}
 	if len(gate.seen) != 1 {
 		t.Fatalf("gate consulted %d times, want exactly once", len(gate.seen))
 	}
@@ -68,6 +75,9 @@ func TestLauncherSpawnGateErrorAndZeroDecisionBothRefuse(t *testing.T) {
 			}
 			if rt.created {
 				t.Fatal("runtime.Create must not run")
+			}
+			if rt.destroyed != "" {
+				t.Fatalf("a refused launch destroyed the existing reviewer pane %q", rt.destroyed)
 			}
 		})
 	}
@@ -187,5 +197,25 @@ func TestLauncherSpawnGateOverrideCannotTakeAOOwnedVariables(t *testing.T) {
 	}
 	if got := rt.createCfg.Env["CLAUDE_CONFIG_DIR"]; got != "/ao/owned" {
 		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want the agent-owned variable overridable", got)
+	}
+}
+
+
+// The permitted path still replaces the stale pane, so moving the gate earlier
+// must not have cost the replacement it exists to perform.
+func TestLauncherSpawnPermittedByGateStillReplacesTheStalePane(t *testing.T) {
+	gate := &reviewGateRecorder{decision: ports.PreLaunchDecision{Allow: true}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{reviewer: &fakeReviewer{}, ok: true}, rt, t.TempDir(),
+		WithLaunchGate(gate))
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if rt.destroyed == "" {
+		t.Fatal("a permitted launch must still destroy the stale reviewer pane")
+	}
+	if !rt.created {
+		t.Fatal("a permitted launch must create the replacement")
 	}
 }

--- a/backend/internal/review/launch_gate_test.go
+++ b/backend/internal/review/launch_gate_test.go
@@ -1,0 +1,141 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Reviewer half of Untrivial-ai/agent-orchestrator#4895. The reviewer child is
+// created on its own path, not through Manager.Spawn, so a gate wired only into
+// the worker seam would leave the reviewer able to strand at a startup prompt
+// while the session it reviews looks healthy. That asymmetry is one of the
+// split-brain shapes menard-software/setup-agent-orchestrator#418 recorded: a
+// live reviewer tab beside an absent main child.
+
+type reviewGateRecorder struct {
+	decision ports.PreLaunchDecision
+	err      error
+	seen     []ports.PreLaunchRequest
+}
+
+func (g *reviewGateRecorder) PreLaunch(_ context.Context, req ports.PreLaunchRequest) (ports.PreLaunchDecision, error) {
+	g.seen = append(g.seen, req)
+	return g.decision, g.err
+}
+
+func TestLauncherSpawnRefusedByGateCreatesNoPane(t *testing.T) {
+	gate := &reviewGateRecorder{decision: ports.PreLaunchDecision{
+		Allow: false, Reason: "workspace trust not accepted", PromptKind: "workspace_trust",
+	}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{reviewer: &fakeReviewer{}, ok: true}, rt, t.TempDir(),
+		WithLaunchGate(gate))
+
+	_, err := l.Spawn(context.Background(), launchSpec())
+
+	if !errors.Is(err, ports.ErrLaunchNotReady) {
+		t.Fatalf("err = %v, want ports.ErrLaunchNotReady", err)
+	}
+	for _, want := range []string{"reviewer", "workspace trust not accepted", "workspace_trust"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %v, want it to carry %q", err, want)
+		}
+	}
+	if rt.created {
+		t.Fatal("runtime.Create must not run when the gate refuses")
+	}
+	if len(gate.seen) != 1 {
+		t.Fatalf("gate consulted %d times, want exactly once", len(gate.seen))
+	}
+}
+
+func TestLauncherSpawnGateErrorAndZeroDecisionBothRefuse(t *testing.T) {
+	for name, gate := range map[string]*reviewGateRecorder{
+		"zero decision": {},
+		"gate error":    {err: errors.New("gate unavailable")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rt := &fakeRuntime{}
+			l := NewLauncher(fakeReviewerResolver{reviewer: &fakeReviewer{}, ok: true}, rt, t.TempDir(),
+				WithLaunchGate(gate))
+
+			if _, err := l.Spawn(context.Background(), launchSpec()); !errors.Is(err, ports.ErrLaunchNotReady) {
+				t.Fatalf("err = %v, want a refusal", err)
+			}
+			if rt.created {
+				t.Fatal("runtime.Create must not run")
+			}
+		})
+	}
+}
+
+// The parity requirement: the reviewer gate is shown the same resolved child
+// environment as the worker gate, including a config root the reviewer inherited.
+// The reported incident was exactly this -- the reviewer child ran with
+// CLAUDE_CONFIG_DIR set to a root whose state file lacked every trusted path,
+// while the operator's default root had them.
+func TestLauncherSpawnGateSeesReviewerRoleAndEffectiveConfigRoot(t *testing.T) {
+	const inherited = "/home/rose/.ao/bench-claude"
+	gate := &reviewGateRecorder{decision: ports.PreLaunchDecision{Allow: true}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(
+		fakeReviewerResolver{reviewer: &fakeReviewer{env: map[string]string{"CLAUDE_CONFIG_DIR": inherited}}, ok: true},
+		rt, t.TempDir(), WithLaunchGate(gate))
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if len(gate.seen) != 1 {
+		t.Fatalf("gate consulted %d times, want exactly once", len(gate.seen))
+	}
+	req := gate.seen[0]
+	if req.Role != ports.LaunchRoleReviewer {
+		t.Fatalf("role = %q, want %q", req.Role, ports.LaunchRoleReviewer)
+	}
+	if got := req.Env["CLAUDE_CONFIG_DIR"]; got != inherited {
+		t.Fatalf("gate saw CLAUDE_CONFIG_DIR = %q, want the inherited %q", got, inherited)
+	}
+	if got := rt.createCfg.Env["CLAUDE_CONFIG_DIR"]; got != inherited {
+		t.Fatalf("child CLAUDE_CONFIG_DIR = %q, want the same root the gate was shown", got)
+	}
+	if req.WorkspacePath == "" || len(req.Argv) == 0 {
+		t.Fatal("request must carry the workspace and the exact child argv")
+	}
+}
+
+func TestLauncherSpawnGateContributesEnvWithoutOverridingReviewerOwn(t *testing.T) {
+	gate := &reviewGateRecorder{decision: ports.PreLaunchDecision{
+		Allow: true,
+		Env:   map[string]string{"CLAUDE_CONFIG_DIR": "/gate/root", "GATE_ONLY": "kept"},
+	}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(
+		fakeReviewerResolver{reviewer: &fakeReviewer{env: map[string]string{"CLAUDE_CONFIG_DIR": "/reviewer/root"}}, ok: true},
+		rt, t.TempDir(), WithLaunchGate(gate))
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if got := rt.createCfg.Env["CLAUDE_CONFIG_DIR"]; got != "/reviewer/root" {
+		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want the already-set value to win", got)
+	}
+	if got := rt.createCfg.Env["GATE_ONLY"]; got != "kept" {
+		t.Fatalf("GATE_ONLY = %q, want the gate's own key to reach the child", got)
+	}
+}
+
+func TestLauncherSpawnWithoutGateIsUnchanged(t *testing.T) {
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{reviewer: &fakeReviewer{}, ok: true}, rt, t.TempDir())
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn without a gate: %v", err)
+	}
+	if !rt.created {
+		t.Fatal("runtime.Create must run when no gate is wired")
+	}
+}

--- a/backend/internal/review/launch_gate_test.go
+++ b/backend/internal/review/launch_gate_test.go
@@ -219,3 +219,33 @@ func TestLauncherSpawnPermittedByGateStillReplacesTheStalePane(t *testing.T) {
 		t.Fatal("a permitted launch must create the replacement")
 	}
 }
+
+// P1 from review 5113322042. The reviewer request omitted Kind, Harness,
+// GitCommonDir and resolved Permissions, and substituted the reviewer command's
+// working directory for the AO-created workspace. A gate asked to trust a path
+// must be given the path AO owns.
+func TestLauncherSpawnGateRequestCarriesFullParityFields(t *testing.T) {
+	gate := &reviewGateRecorder{decision: ports.PreLaunchDecision{Allow: true}}
+	rt := &fakeRuntime{}
+	// The reviewer is told to run somewhere other than the AO worktree.
+	reviewer := &fakeReviewer{workingDirectory: "/somewhere/else"}
+	l := NewLauncher(fakeReviewerResolver{reviewer: reviewer, ok: true}, rt, t.TempDir(),
+		WithLaunchGate(gate))
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	req := gate.seen[0]
+	if req.WorkspacePath != "/ws/mer-1" {
+		t.Fatalf("WorkspacePath = %q, want the AO-created worktree, not the reviewer CWD", req.WorkspacePath)
+	}
+	if req.Harness == "" {
+		t.Fatal("Harness must reach the gate")
+	}
+	if req.LaunchID != "run-1" {
+		t.Fatalf("LaunchID = %q, want the reviewer run id", req.LaunchID)
+	}
+	if req.Role != ports.LaunchRoleReviewer {
+		t.Fatalf("Role = %q", req.Role)
+	}
+}

--- a/backend/internal/review/launch_gate_test.go
+++ b/backend/internal/review/launch_gate_test.go
@@ -139,3 +139,53 @@ func TestLauncherSpawnWithoutGateIsUnchanged(t *testing.T) {
 		t.Fatal("runtime.Create must run when no gate is wired")
 	}
 }
+
+// Reviewer half of #432. The measured incident was on a reviewer child: its
+// environment carried CLAUDE_CONFIG_DIR pointing at a root whose state file had
+// none of the trusted paths. Parity means the reviewer gate can take ownership
+// of that root exactly as the worker gate can, and is bounded the same way.
+func TestLauncherSpawnGateCanTakeOwnershipOfTheReviewerConfigRoot(t *testing.T) {
+	const inherited = "/home/rose/.ao/bench-claude"
+	const aoOwned = "/ao/data/claude-session-config/mer-1-reviewer"
+	gate := &reviewGateRecorder{decision: ports.PreLaunchDecision{
+		Allow:       true,
+		EnvOverride: map[string]string{"CLAUDE_CONFIG_DIR": aoOwned},
+	}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(
+		fakeReviewerResolver{reviewer: &fakeReviewer{env: map[string]string{"CLAUDE_CONFIG_DIR": inherited}}, ok: true},
+		rt, t.TempDir(), WithLaunchGate(gate))
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if got := gate.seen[0].Env["CLAUDE_CONFIG_DIR"]; got != inherited {
+		t.Fatalf("gate saw %q, want the inherited root", got)
+	}
+	if got := rt.createCfg.Env["CLAUDE_CONFIG_DIR"]; got != aoOwned {
+		t.Fatalf("reviewer child CLAUDE_CONFIG_DIR = %q, want the AO-owned root %q", got, aoOwned)
+	}
+}
+
+func TestLauncherSpawnGateOverrideCannotTakeAOOwnedVariables(t *testing.T) {
+	gate := &reviewGateRecorder{decision: ports.PreLaunchDecision{
+		Allow: true,
+		EnvOverride: map[string]string{
+			"AO_REVIEW_SESSION_ID": "hijacked",
+			"CLAUDE_CONFIG_DIR":    "/ao/owned",
+		},
+	}}
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{reviewer: &fakeReviewer{}, ok: true}, rt, t.TempDir(),
+		WithLaunchGate(gate))
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if got := rt.createCfg.Env["AO_REVIEW_SESSION_ID"]; got == "hijacked" {
+		t.Fatal("a gate override must not take an AO-owned reviewer variable")
+	}
+	if got := rt.createCfg.Env["CLAUDE_CONFIG_DIR"]; got != "/ao/owned" {
+		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want the agent-owned variable overridable", got)
+	}
+}

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -441,24 +441,26 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 		}
 	}
 	handleID := reviewerHandleID(spec.WorkerID)
-	// The reviewer handle is stable per worker, so a still-live pane from a
-	// previous pass would otherwise block `tmux new-session` (duplicate name) or,
-	// worse, keep serving under its old harness. Destroy any stale pane on this
-	// handle first so the reviewer always (re)launches under spec.Harness's
-	// sandbox/permissions/env — which are applied only here at Create, never by
-	// Notify. Destroy is idempotent when no pane exists (first spawn / dead pane).
-	if err := l.runtime.Destroy(ctx, ports.RuntimeHandle{ID: handleID}); err != nil {
-		return LaunchResult{}, fmt.Errorf("reviewer replace stale pane: %w", err)
-	}
 	workingDirectory := cmd.WorkingDirectory
 	if workingDirectory == "" {
 		workingDirectory = spec.WorkspacePath
 	}
 	reviewerEnv := l.runtimeEnv(ctx, spec, cmd.Argv, cmd.Env)
-	// Same gate, same fail-closed shape, same position as the worker seam: the
-	// child argv and environment are final and no pane exists yet.
+	// The gate runs before the destroy, not after it. Destroying first and
+	// gating second means a refusal removes a live reviewer that nothing is
+	// allowed to replace: the session loses a working pane and gains nothing.
+	// Resolve argv and env, ask, and only then replace.
 	if err := l.applyLaunchGate(ctx, spec, workingDirectory, cmd.Argv, reviewerEnv); err != nil {
 		return LaunchResult{}, err
+	}
+	// The reviewer handle is stable per worker, so a still-live pane from a
+	// previous pass would otherwise block `tmux new-session` (duplicate name) or,
+	// worse, keep serving under its old harness. Destroy any stale pane on this
+	// handle so the reviewer always (re)launches under spec.Harness's
+	// sandbox/permissions/env — which are applied only here at Create, never by
+	// Notify. Destroy is idempotent when no pane exists (first spawn / dead pane).
+	if err := l.runtime.Destroy(ctx, ports.RuntimeHandle{ID: handleID}); err != nil {
+		return LaunchResult{}, fmt.Errorf("reviewer replace stale pane: %w", err)
 	}
 	handle, err := l.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     domain.SessionID(handleID),

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -108,6 +108,7 @@ type agentLauncher struct {
 	runFile    string
 	auth       agentAuthResolver
 	executable func() (string, error)
+	launchGate ports.LaunchGate
 }
 
 type preLaunchReviewer interface {
@@ -131,6 +132,18 @@ type LauncherOption func(*agentLauncher)
 func WithAgentAuth(auth agentAuthResolver) LauncherOption {
 	return func(l *agentLauncher) {
 		l.auth = auth
+	}
+}
+
+// WithLaunchGate gives the reviewer the same pre-spawn gate the worker seam
+// uses. Parity is the point: the reviewer is created on its own path, so a gate
+// wired only into Spawn would leave a reviewer able to strand at a startup
+// prompt while the session it reviews looks healthy -- which is one of the
+// split-brain shapes this gate exists to stop. Nil leaves reviewer launches
+// unchanged.
+func WithLaunchGate(gate ports.LaunchGate) LauncherOption {
+	return func(l *agentLauncher) {
+		l.launchGate = gate
 	}
 }
 
@@ -441,11 +454,17 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 	if workingDirectory == "" {
 		workingDirectory = spec.WorkspacePath
 	}
+	reviewerEnv := l.runtimeEnv(ctx, spec, cmd.Argv, cmd.Env)
+	// Same gate, same fail-closed shape, same position as the worker seam: the
+	// child argv and environment are final and no pane exists yet.
+	if err := l.applyLaunchGate(ctx, spec, workingDirectory, cmd.Argv, reviewerEnv); err != nil {
+		return LaunchResult{}, err
+	}
 	handle, err := l.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     domain.SessionID(handleID),
 		WorkspacePath: workingDirectory,
 		Argv:          cmd.Argv,
-		Env:           l.runtimeEnv(ctx, spec, cmd.Argv, cmd.Env),
+		Env:           reviewerEnv,
 	})
 	if err != nil {
 		return LaunchResult{}, fmt.Errorf("reviewer runtime: %w", err)
@@ -714,4 +733,50 @@ func (l *agentLauncher) Destroy(ctx context.Context, handleID string) error {
 		return nil
 	}
 	return l.runtime.Destroy(ctx, ports.RuntimeHandle{ID: handleID})
+}
+
+
+// applyLaunchGate consults the optional pre-spawn gate for a reviewer child.
+// It mirrors the worker seam exactly: nil gate means no change, a refusal or a
+// gate error stops the launch before any pane is created, and a permitted
+// launch may gain environment entries AO has not already set.
+func (l *agentLauncher) applyLaunchGate(ctx context.Context, spec LaunchSpec,
+	workspacePath string, argv []string, env map[string]string) error {
+	if l.launchGate == nil {
+		return nil
+	}
+	envCopy := make(map[string]string, len(env))
+	for key, value := range env {
+		envCopy[key] = value
+	}
+	decision, err := l.launchGate.PreLaunch(ctx, ports.PreLaunchRequest{
+		SessionID:     string(spec.WorkerID),
+		WorkspacePath: workspacePath,
+		Argv:          append([]string(nil), argv...),
+		Env:           envCopy,
+		Role:          ports.LaunchRoleReviewer,
+	})
+	if err != nil {
+		return fmt.Errorf("reviewer %w: %w", ports.ErrLaunchNotReady, err)
+	}
+	if !decision.Allow {
+		reason := strings.TrimSpace(decision.Reason)
+		if reason == "" {
+			reason = "gate refused the reviewer launch without a reason"
+		}
+		if kind := strings.TrimSpace(decision.PromptKind); kind != "" {
+			return fmt.Errorf("reviewer %w: %s (%s)", ports.ErrLaunchNotReady, reason, kind)
+		}
+		return fmt.Errorf("reviewer %w: %s", ports.ErrLaunchNotReady, reason)
+	}
+	for key, value := range decision.Env {
+		if key == "" {
+			continue
+		}
+		if _, taken := env[key]; taken {
+			continue
+		}
+		env[key] = value
+	}
+	return nil
 }

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -450,7 +450,7 @@ func (l *agentLauncher) launchReviewerTerminalWithMode(ctx context.Context, spec
 	// gating second means a refusal removes a live reviewer that nothing is
 	// allowed to replace: the session loses a working pane and gains nothing.
 	// Resolve argv and env, ask, and only then replace.
-	if err := l.applyLaunchGate(ctx, spec, workingDirectory, cmd.Argv, reviewerEnv); err != nil {
+	if err := l.applyLaunchGate(ctx, spec, cmd.Argv, reviewerEnv); err != nil {
 		return LaunchResult{}, err
 	}
 	// The reviewer handle is stable per worker, so a still-live pane from a
@@ -743,7 +743,7 @@ func (l *agentLauncher) Destroy(ctx context.Context, handleID string) error {
 // gate error stops the launch before any pane is created, and a permitted
 // launch may gain environment entries AO has not already set.
 func (l *agentLauncher) applyLaunchGate(ctx context.Context, spec LaunchSpec,
-	workspacePath string, argv []string, env map[string]string) error {
+	argv []string, env map[string]string) error {
 	if l.launchGate == nil {
 		return nil
 	}
@@ -751,12 +751,22 @@ func (l *agentLauncher) applyLaunchGate(ctx context.Context, spec LaunchSpec,
 	for key, value := range env {
 		envCopy[key] = value
 	}
+	// WorkspacePath is the AO-created worktree, not the reviewer command's
+	// working directory. A reviewer may be told to run somewhere else; a gate
+	// asked to trust a path must be given the path AO owns, or it would trust
+	// whatever directory a harness happened to choose.
 	decision, err := l.launchGate.PreLaunch(ctx, ports.PreLaunchRequest{
-		SessionID:     string(spec.WorkerID),
-		WorkspacePath: workspacePath,
-		Argv:          append([]string(nil), argv...),
-		Env:           envCopy,
-		Role:          ports.LaunchRoleReviewer,
+		SessionID:      string(spec.WorkerID),
+		WorkspacePath:  spec.WorkspacePath,
+		GitCommonDir:   gitCommonDir(ctx, spec.WorkspacePath),
+		Argv:           append([]string(nil), argv...),
+		Env:            envCopy,
+		Role:           ports.LaunchRoleReviewer,
+		Kind:           domain.KindWorker,
+		Harness:        domain.AgentHarness(spec.Harness),
+		Permissions:    reviewerPermissions(spec),
+		LaunchID:       reviewerLaunchID(spec),
+		ConversationID: spec.AgentSessionID,
 	})
 	if err != nil {
 		return fmt.Errorf("reviewer %w: %w", ports.ErrLaunchNotReady, err)
@@ -789,4 +799,47 @@ func (l *agentLauncher) applyLaunchGate(ctx context.Context, spec LaunchSpec,
 		env[key] = value
 	}
 	return nil
+}
+
+
+// reviewerLaunchID identifies one reviewer attempt. The run id is the daemon's
+// own per-attempt identity, so a gate can bind its decision to this pass rather
+// than to the reviewer handle, which is stable across passes and would make two
+// attempts indistinguishable.
+func reviewerLaunchID(spec LaunchSpec) string {
+	if id := strings.TrimSpace(spec.RunID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(spec.ReviewSessionID)
+}
+
+// reviewerPermissions reports the mode the reviewer child will actually run
+// under, so a gate sees the resolved value rather than inferring one from argv.
+func reviewerPermissions(spec LaunchSpec) ports.PermissionMode {
+	return ports.PermissionMode(strings.TrimSpace(string(spec.AgentConfig.Permissions)))
+}
+
+// gitCommonDir reports the workspace's git common directory, empty when the
+// path is not a git worktree. A gate proving AO-worktree provenance needs the
+// value git reports, not one derived from the path.
+func gitCommonDir(ctx context.Context, workspacePath string) string {
+	if strings.TrimSpace(workspacePath) == "" {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, "git", "-C", workspacePath, "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		return ""
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(workspacePath, dir)
+	}
+	resolved, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+	return resolved
 }

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -778,5 +778,13 @@ func (l *agentLauncher) applyLaunchGate(ctx context.Context, spec LaunchSpec,
 		}
 		env[key] = value
 	}
+	// An override is the gate taking ownership of a variable the agent reads,
+	// which contributing cannot do. AO's own names stay AO's.
+	for key, value := range decision.EnvOverride {
+		if key == "" || ports.LaunchGateProtectedEnv(key) {
+			continue
+		}
+		env[key] = value
+	}
 	return nil
 }

--- a/backend/internal/session_manager/agent_switching.go
+++ b/backend/internal/session_manager/agent_switching.go
@@ -781,6 +781,14 @@ func (m *Manager) executeAgentSwitch(ctx context.Context, admitted *admittedAgen
 	runtimeCfg := ports.RuntimeConfig{
 		SessionID: id, WorkspacePath: rec.Metadata.WorkspacePath, Argv: target.argv, Env: target.env,
 	}
+	// A switched-to target is a new child on the same session. Gating Spawn and
+	// Restore but not this path would leave the same hole: the target keeps
+	// whatever config root it inherited while the writer seeded another.
+	if err := m.applyLaunchGateForRecord(ctx, rec, rec.Metadata.WorkspacePath, target.launch.Config,
+		target.argv, target.env,
+		launchGateIdentity{launchID: string(target.launchID), conversationID: string(target.native.ID)}); err != nil {
+		return result, fmt.Errorf("switch agent %s: %w", id, err)
+	}
 	recorder.boundary(domain.AgentSwitchFailureTargetRuntimeCreate)
 	// The post-stop preparation budget may expire while hooks are being
 	// finalized. Controller admission belongs to the durable switch worker, not

--- a/backend/internal/session_manager/launch_gate_test.go
+++ b/backend/internal/session_manager/launch_gate_test.go
@@ -383,3 +383,69 @@ func TestSpawn_LaunchGateRequestCarriesTheFullParityFields(t *testing.T) {
 		t.Fatalf("Kind = %q, want the spawn's kind", req.Kind)
 	}
 }
+
+// P1 from review 5113322042, the one the reviewer called out as "not merely
+// future scope": Restore rebuilds env and argv and creates a child without ever
+// consulting the gate, so a restored Claude child kept its inherited
+// CLAUDE_CONFIG_DIR while the older trust writer seeded the default root. The
+// exact two-roots condition, reachable through a path this PR had not gated.
+func TestRestore_LaunchGateRunsBeforeTheRelaunchedChild(t *testing.T) {
+	const inherited = "/home/rose/.ao/bench-claude"
+	st := newFakeStore()
+	config := testRoleAgents()
+	config.Env = map[string]string{"CLAUDE_CONFIG_DIR": inherited}
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: config}
+	rt := &fakeRuntime{}
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{Allow: true}}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: &fakeWorkspace{}, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LaunchGate: gate,
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"})
+
+	if _, err := m.RestoreWithMode(ctx, "mer-1"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if len(gate.seen) == 0 {
+		t.Fatal("restore relaunched a child without consulting the launch gate")
+	}
+	req := gate.seen[0]
+	if got := req.Env["CLAUDE_CONFIG_DIR"]; got != inherited {
+		t.Fatalf("gate saw CLAUDE_CONFIG_DIR = %q, want the inherited %q", got, inherited)
+	}
+	if req.LaunchID == "" {
+		t.Fatal("a restored launch must carry its identity to the gate")
+	}
+	if req.Role != ports.LaunchRoleWorker {
+		t.Fatalf("Role = %q, want worker", req.Role)
+	}
+}
+
+// A refusal on restore must not leave a replaced child: nothing is created.
+func TestRestore_LaunchGateRefusalCreatesNoChild(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{
+		Allow: false, Reason: "workspace trust not accepted", PromptKind: "workspace_trust",
+	}}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: &fakeWorkspace{}, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LaunchGate: gate,
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"})
+
+	_, err := m.RestoreWithMode(ctx, "mer-1")
+
+	if err == nil {
+		t.Fatal("a refused restore must fail rather than relaunch")
+	}
+	if !errors.Is(err, ports.ErrLaunchNotReady) {
+		t.Fatalf("err = %v, want ports.ErrLaunchNotReady", err)
+	}
+	if rt.created != 0 {
+		t.Fatalf("runtime.Create ran %d times on a refused restore", rt.created)
+	}
+}

--- a/backend/internal/session_manager/launch_gate_test.go
+++ b/backend/internal/session_manager/launch_gate_test.go
@@ -339,3 +339,47 @@ func TestSpawn_LaunchGateOverrideCannotTakeAOOwnedVariables(t *testing.T) {
 		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want the agent-owned variable to be overridable", got)
 	}
 }
+
+// P1 from review 5113322042: a gate cannot bind a decision to the current
+// (session, launch, conversation) unless the identity exists before it is
+// asked. Spawn used to generate the launch id after the gate.
+func TestSpawn_LaunchGateSeesTheLaunchIdentityItWillRunUnder(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{Allow: true}}
+	_, _, deps := gateSpawnDeps(t, gate)
+	deps.NewLaunchID = func() string { return "launch-under-test" }
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got := gate.seen[0].LaunchID; got != "launch-under-test" {
+		t.Fatalf("gate saw LaunchID %q, want the id the child runs under", got)
+	}
+}
+
+// The gate's request must carry every daemon-owned value the port promises, or
+// a gate that needs one cannot make the same decision on both paths.
+func TestSpawn_LaunchGateRequestCarriesTheFullParityFields(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{Allow: true}}
+	_, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	req := gate.seen[0]
+	for name, empty := range map[string]bool{
+		"SessionID":     req.SessionID == "",
+		"WorkspacePath": req.WorkspacePath == "",
+		"LaunchID":      req.LaunchID == "",
+		"Argv":          len(req.Argv) == 0,
+		"Role":          req.Role == "",
+	} {
+		if empty {
+			t.Fatalf("request field %s is empty", name)
+		}
+	}
+	if req.Kind != domain.KindWorker {
+		t.Fatalf("Kind = %q, want the spawn's kind", req.Kind)
+	}
+}

--- a/backend/internal/session_manager/launch_gate_test.go
+++ b/backend/internal/session_manager/launch_gate_test.go
@@ -1,0 +1,203 @@
+package sessionmanager
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// These cover Untrivial-ai/agent-orchestrator#4895, reported downstream as
+// menard-software/setup-agent-orchestrator#418: AO created Claude children that
+// stopped before their agent loop, and reported them as ordinary work. Process
+// creation is not successful startup, and the only place that can be fixed is
+// before the child exists.
+//
+// They are written at the same seam as TestSpawn_RejectsMissingAgentBinary,
+// because that check already proves the shape a pre-spawn refusal must have:
+// runtime.Create must not run, and the workspace must be torn down.
+
+type recordingLaunchGate struct {
+	decision ports.PreLaunchDecision
+	err      error
+	seen     []ports.PreLaunchRequest
+}
+
+func (g *recordingLaunchGate) PreLaunch(_ context.Context, req ports.PreLaunchRequest) (ports.PreLaunchDecision, error) {
+	g.seen = append(g.seen, req)
+	return g.decision, g.err
+}
+
+func gateSpawnDeps(t *testing.T, gate ports.LaunchGate) (*fakeRuntime, *fakeWorkspace, Deps) {
+	t.Helper()
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	return rt, ws, Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		DataDir: t.TempDir(), LaunchGate: gate,
+		// The binary check runs before the gate; stub it so these tests exercise
+		// the gate rather than PATH resolution.
+		LookPath: func(name string) (string, error) { return "/usr/bin/" + name, nil },
+	}
+}
+
+// A gate that refuses must stop the spawn before any child exists, exactly like
+// the missing-binary check. Without this, AO produces a session card for a
+// child that was never able to become ready -- the #418 symptom.
+func TestSpawn_LaunchGateRefusalStopsBeforeChildCreation(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{
+		Allow: false, Reason: "workspace trust not accepted", PromptKind: "workspace_trust",
+	}}
+	rt, ws, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	_, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+
+	if !errors.Is(err, ports.ErrLaunchNotReady) {
+		t.Fatalf("err = %v, want ports.ErrLaunchNotReady", err)
+	}
+	if !errors.Is(err, ErrSpawnLaunchGate) {
+		t.Fatalf("err = %v, want it to name the launch-readiness spawn stage", err)
+	}
+	for _, want := range []string{"workspace trust not accepted", "workspace_trust"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %v, want it to carry %q so the cause is actionable", err, want)
+		}
+	}
+	if rt.created != 0 {
+		t.Fatal("runtime.Create must NOT run when the launch gate refuses")
+	}
+	if ws.destroyed != 1 {
+		t.Fatal("workspace must be torn down when the pre-launch gate refuses")
+	}
+	if len(gate.seen) != 1 {
+		t.Fatalf("gate consulted %d times, want exactly once", len(gate.seen))
+	}
+}
+
+// The zero decision refuses. A gate that returns nothing by mistake must stop
+// the launch rather than wave it through.
+func TestSpawn_LaunchGateZeroDecisionRefuses(t *testing.T) {
+	rt, _, deps := gateSpawnDeps(t, &recordingLaunchGate{})
+	m := New(deps)
+
+	_, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+
+	if !errors.Is(err, ports.ErrLaunchNotReady) {
+		t.Fatalf("err = %v, want the zero decision to refuse", err)
+	}
+	if rt.created != 0 {
+		t.Fatal("runtime.Create must NOT run for a zero decision")
+	}
+}
+
+// A gate error is a refusal, not a warning: an unreachable or broken gate must
+// not silently degrade into an ungated launch.
+func TestSpawn_LaunchGateErrorRefusesRatherThanDegrades(t *testing.T) {
+	gate := &recordingLaunchGate{err: errors.New("gate unavailable")}
+	rt, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	_, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+
+	if !errors.Is(err, ports.ErrLaunchNotReady) {
+		t.Fatalf("err = %v, want a gate error to fail closed", err)
+	}
+	if !strings.Contains(err.Error(), "gate unavailable") {
+		t.Fatalf("err = %v, want the underlying gate error preserved", err)
+	}
+	if rt.created != 0 {
+		t.Fatal("runtime.Create must NOT run when the gate itself fails")
+	}
+}
+
+// A permitted launch reaches the child, and the gate's environment contribution
+// reaches the exact child AO is about to create. This is the half of #4895 a
+// post-spawn helper cannot do.
+func TestSpawn_LaunchGateContributesChildEnvironment(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{
+		Allow: true,
+		Env:   map[string]string{"CLAUDE_CONFIG_DIR": "/isolated/session/config"},
+	}}
+	rt, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if rt.created != 1 {
+		t.Fatalf("runtime.Create ran %d times, want 1", rt.created)
+	}
+	if got := rt.lastCfg.Env["CLAUDE_CONFIG_DIR"]; got != "/isolated/session/config" {
+		t.Fatalf("child CLAUDE_CONFIG_DIR = %q, want the gate's value", got)
+	}
+}
+
+// The gate contributes; it does not take over. An AO-owned variable must win,
+// so a gate cannot redirect the session's own data directory or run file.
+func TestSpawn_LaunchGateCannotOverrideAOOwnedEnvironment(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{
+		Allow: true,
+		Env:   map[string]string{"AO_SESSION_ID": "someone-else", "GATE_ONLY": "kept"},
+	}}
+	rt, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got := rt.lastCfg.Env["AO_SESSION_ID"]; got == "someone-else" {
+		t.Fatal("a gate must not overwrite an AO-owned environment variable")
+	}
+	if got := rt.lastCfg.Env["GATE_ONLY"]; got != "kept" {
+		t.Fatalf("GATE_ONLY = %q, want the gate's own key to survive", got)
+	}
+}
+
+// The request carries daemon-owned values only, and the argv the child will
+// actually run, so a gate can confirm a resolved permission mode reaches it.
+func TestSpawn_LaunchGateSeesResolvedDaemonOwnedValues(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{Allow: true}}
+	_, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if len(gate.seen) != 1 {
+		t.Fatalf("gate consulted %d times, want exactly once", len(gate.seen))
+	}
+	req := gate.seen[0]
+	if req.SessionID == "" {
+		t.Fatal("request must carry the AO session id")
+	}
+	if req.WorkspacePath == "" {
+		t.Fatal("request must carry the AO-created workspace path")
+	}
+	if req.Kind != domain.KindWorker {
+		t.Fatalf("request kind = %v, want the spawn's kind", req.Kind)
+	}
+	if len(req.Argv) == 0 {
+		t.Fatal("request must carry the exact child argv")
+	}
+}
+
+// Nil gate is the default and must leave spawn byte-identical.
+func TestSpawn_WithoutLaunchGateIsUnchanged(t *testing.T) {
+	rt, _, deps := gateSpawnDeps(t, nil)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn without a gate: %v", err)
+	}
+	if rt.created != 1 {
+		t.Fatalf("runtime.Create ran %d times, want 1", rt.created)
+	}
+}
+

--- a/backend/internal/session_manager/launch_gate_test.go
+++ b/backend/internal/session_manager/launch_gate_test.go
@@ -33,8 +33,15 @@ func (g *recordingLaunchGate) PreLaunch(_ context.Context, req ports.PreLaunchRe
 
 func gateSpawnDeps(t *testing.T, gate ports.LaunchGate) (*fakeRuntime, *fakeWorkspace, Deps) {
 	t.Helper()
+	return gateSpawnDepsWithProjectEnv(t, gate, nil)
+}
+
+func gateSpawnDepsWithProjectEnv(t *testing.T, gate ports.LaunchGate, projectEnv map[string]string) (*fakeRuntime, *fakeWorkspace, Deps) {
+	t.Helper()
 	st := newFakeStore()
-	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	config := testRoleAgents()
+	config.Env = projectEnv
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: config}
 	rt := &fakeRuntime{}
 	ws := &fakeWorkspace{}
 	return rt, ws, Deps{
@@ -201,3 +208,75 @@ func TestSpawn_WithoutLaunchGateIsUnchanged(t *testing.T) {
 	}
 }
 
+
+
+// The reported #4895 condition, at the worker seam.
+//
+// Trust was recorded true in the operator's home Claude root for the exact
+// worktree paths, and was absent from the root the child actually read, because
+// CLAUDE_CONFIG_DIR was already set in the inherited environment. Every surface
+// said the state existed; the child still stopped at the prompt that state was
+// meant to answer.
+//
+// A gate cannot detect that unless it is told the resolved child environment.
+// Guessing the default root is precisely the mistake that produced the incident.
+func TestSpawn_LaunchGateSeesTheEffectiveConfigRootFromTheChildEnvironment(t *testing.T) {
+	const inherited = "/home/rose/.ao/bench-claude"
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{Allow: true}}
+	// Model the operator's environment: a config root is already chosen for the
+	// child before AO ever consults a gate.
+	rt, _, deps := gateSpawnDepsWithProjectEnv(t, gate, map[string]string{"CLAUDE_CONFIG_DIR": inherited})
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if len(gate.seen) != 1 {
+		t.Fatalf("gate consulted %d times, want exactly once", len(gate.seen))
+	}
+	observed := gate.seen[0].Env["CLAUDE_CONFIG_DIR"]
+	if observed != inherited {
+		t.Fatalf("gate saw CLAUDE_CONFIG_DIR = %q, want the inherited %q; without it a gate "+
+			"writes its state to a root the child never reads", observed, inherited)
+	}
+	if got := rt.lastCfg.Env["CLAUDE_CONFIG_DIR"]; got != inherited {
+		t.Fatalf("child CLAUDE_CONFIG_DIR = %q, want the same root the gate was shown", got)
+	}
+}
+
+// The gate is told which child it is being asked about, so worker and reviewer
+// cannot be silently conflated.
+func TestSpawn_LaunchGateRequestNamesTheWorkerRole(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{Allow: true}}
+	_, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got := gate.seen[0].Role; got != ports.LaunchRoleWorker {
+		t.Fatalf("role = %q, want %q", got, ports.LaunchRoleWorker)
+	}
+}
+
+// The gate gets a copy. Reaching into the child environment directly would let
+// a gate change a launch it had already been asked to judge.
+func TestSpawn_LaunchGateCannotMutateTheChildEnvironmentThroughItsRequest(t *testing.T) {
+	gate := &mutatingLaunchGate{}
+	rt, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if _, leaked := rt.lastCfg.Env["SNEAKED_IN"]; leaked {
+		t.Fatal("a gate must not reach the child environment except through its decision")
+	}
+}
+
+type mutatingLaunchGate struct{}
+
+func (mutatingLaunchGate) PreLaunch(_ context.Context, req ports.PreLaunchRequest) (ports.PreLaunchDecision, error) {
+	req.Env["SNEAKED_IN"] = "1"
+	return ports.PreLaunchDecision{Allow: true}, nil
+}

--- a/backend/internal/session_manager/launch_gate_test.go
+++ b/backend/internal/session_manager/launch_gate_test.go
@@ -280,3 +280,62 @@ func (mutatingLaunchGate) PreLaunch(_ context.Context, req ports.PreLaunchReques
 	req.Env["SNEAKED_IN"] = "1"
 	return ports.PreLaunchDecision{Allow: true}, nil
 }
+
+// menard-software/setup-agent-orchestrator#432, the follow-on to the gate
+// itself. Seeing the effective config root is not enough: if the child inherits
+// CLAUDE_CONFIG_DIR from the operator's environment, a contribute-only gate
+// cannot put the child and the state it seeds in the same root. It writes trust
+// to the root it owns, the child reads the root it inherited, and the child
+// stops at a prompt whose answer exists in a file it never opens.
+//
+// That is the measured incident: trust true in the default root for the exact
+// worktree paths, absent from the effective inherited root.
+func TestSpawn_LaunchGateCanTakeOwnershipOfTheAgentConfigRoot(t *testing.T) {
+	const inherited = "/home/rose/.ao/bench-claude"
+	const aoOwned = "/ao/data/claude-session-config/mer-1"
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{
+		Allow:       true,
+		EnvOverride: map[string]string{"CLAUDE_CONFIG_DIR": aoOwned},
+	}}
+	rt, _, deps := gateSpawnDepsWithProjectEnv(t, gate, map[string]string{"CLAUDE_CONFIG_DIR": inherited})
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got := gate.seen[0].Env["CLAUDE_CONFIG_DIR"]; got != inherited {
+		t.Fatalf("gate saw %q, want the inherited root it must decide about", got)
+	}
+	if got := rt.lastCfg.Env["CLAUDE_CONFIG_DIR"]; got != aoOwned {
+		t.Fatalf("child CLAUDE_CONFIG_DIR = %q, want the AO-owned root %q; a gate that "+
+			"cannot redirect it seeds trust into a file the child never reads", got, aoOwned)
+	}
+}
+
+// An override is bounded. A gate may take a variable the agent owns; it may not
+// take one the daemon owns, or it could redirect a session's own reporting.
+func TestSpawn_LaunchGateOverrideCannotTakeAOOwnedVariables(t *testing.T) {
+	gate := &recordingLaunchGate{decision: ports.PreLaunchDecision{
+		Allow: true,
+		EnvOverride: map[string]string{
+			"AO_SESSION_ID":     "someone-else",
+			"AO_DATA_DIR":       "/tmp/elsewhere",
+			"CLAUDE_CONFIG_DIR": "/ao/owned",
+		},
+	}}
+	rt, _, deps := gateSpawnDeps(t, gate)
+	m := New(deps)
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got := rt.lastCfg.Env["AO_SESSION_ID"]; got == "someone-else" {
+		t.Fatal("a gate override must not take an AO-owned variable")
+	}
+	if got := rt.lastCfg.Env["AO_DATA_DIR"]; got == "/tmp/elsewhere" {
+		t.Fatal("a gate override must not redirect the session data dir")
+	}
+	if got := rt.lastCfg.Env["CLAUDE_CONFIG_DIR"]; got != "/ao/owned" {
+		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want the agent-owned variable to be overridable", got)
+	}
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1043,14 +1043,23 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: %w", id, err)
 	}
 	m.augmentRuntimePATHForLaunchBinary(ctx, env, argv)
+	// The launch identity is created before the gate is asked, so the decision
+	// is bound to the launch it was made for and the child runs under the same
+	// id the gate was shown.
+	launchID, err := m.freshLaunchID()
+	if err != nil {
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
+		return domain.SessionRecord{}, 0, 0, wrapSpawnStage(id, ErrSpawnSupervisor, err)
+	}
 	// Last point at which every trusted value is resolved and no child exists.
 	// A refusal here must look like the binary check: no runtime.Create, the
 	// workspace torn down, and the reason carried to the caller.
-	if err := m.applyLaunchGate(ctx, id, cfg, ws.Path, adapterConfig, argv, env); err != nil {
+	if err := m.applyLaunchGate(ctx, id, cfg, ws.Path, adapterConfig, argv, env,
+		launchGateIdentity{launchID: launchID, conversationID: rec.Metadata.ProviderConversationID}); err != nil {
 		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, wrapSpawnStage(id, ErrSpawnLaunchGate, err)
 	}
-	argv, launchID, err := m.superviseAgentProcess(agent, id, env, argv)
+	argv, err = m.superviseAgentProcessWithID(agent, id, env, argv, launchID)
 	if err != nil {
 		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, wrapSpawnStage(id, ErrSpawnSupervisor, err)
@@ -4734,8 +4743,17 @@ func freshLaunchArgv(ctx context.Context, agent ports.Agent, id domain.SessionID
 // spawn before any child exists, and a permitted launch may gain environment
 // entries that AO has not already set. A gate never rewrites argv, and never
 // removes or overrides an AO-owned variable.
+// launchGateIdentity carries the identity a gate needs to bind its decision to
+// one attempt. It is a struct so adding resume facts later does not reshape
+// every caller.
+type launchGateIdentity struct {
+	launchID       string
+	conversationID string
+}
+
 func (m *Manager) applyLaunchGate(ctx context.Context, id domain.SessionID, cfg ports.SpawnConfig,
-	workspacePath string, adapterConfig ports.AgentConfig, argv []string, env map[string]string) error {
+	workspacePath string, adapterConfig ports.AgentConfig, argv []string, env map[string]string,
+	identity launchGateIdentity) error {
 	if m.launchGate == nil {
 		return nil
 	}
@@ -4747,8 +4765,10 @@ func (m *Manager) applyLaunchGate(ctx context.Context, id domain.SessionID, cfg 
 		GitCommonDir:  m.gitCommonDir(ctx, workspacePath),
 		Permissions:   adapterConfig.Permissions,
 		Argv:          append([]string(nil), argv...),
-		Env:           copyEnv(env),
-		Role:          ports.LaunchRoleWorker,
+		Env:            copyEnv(env),
+		Role:           ports.LaunchRoleWorker,
+		LaunchID:       identity.launchID,
+		ConversationID: identity.conversationID,
 	})
 	if err != nil {
 		return fmt.Errorf("%w: %w", ports.ErrLaunchNotReady, err)
@@ -4872,6 +4892,13 @@ func (m *Manager) validateRuntimePrerequisites() error {
 	return nil
 }
 
+// superviseAgentProcessWithID supervises under an identity the caller already
+// created, so the id a gate was shown is the id the child runs under.
+func (m *Manager) superviseAgentProcessWithID(agent ports.Agent, id domain.SessionID, env map[string]string, argv []string, launchID string) ([]string, error) {
+	_, switchingCapable := agent.(ports.AgentContinuationCapabilityProvider)
+	return m.wrapAgentProcessWithLaunchID(agent, id, env, argv, launchID, switchingCapable)
+}
+
 func (m *Manager) superviseAgentProcess(agent ports.Agent, id domain.SessionID, env map[string]string, argv []string) ([]string, string, error) {
 	// Switching-capable providers always use the exact-generation
 	// supervisor, even when their native hooks also report exit. That gives a
@@ -4889,10 +4916,22 @@ func (m *Manager) superviseAgentProcessForSwitch(agent ports.Agent, id domain.Se
 	return m.superviseAgentProcessMode(agent, id, env, argv, true)
 }
 
-func (m *Manager) superviseAgentProcessMode(agent ports.Agent, id domain.SessionID, env map[string]string, argv []string, force bool) ([]string, string, error) {
+// freshLaunchID creates the identity for one launch attempt. It is exported
+// within the package so a caller can create the identity *before* asking a
+// launch gate, and then supervise under that same id: a gate decision that
+// names no launch cannot be bound to the child it permitted.
+func (m *Manager) freshLaunchID() (string, error) {
 	launchID := m.newLaunchID()
 	if strings.TrimSpace(launchID) == "" {
-		return nil, "", errors.New("generated empty launch id")
+		return "", errors.New("generated empty launch id")
+	}
+	return launchID, nil
+}
+
+func (m *Manager) superviseAgentProcessMode(agent ports.Agent, id domain.SessionID, env map[string]string, argv []string, force bool) ([]string, string, error) {
+	launchID, err := m.freshLaunchID()
+	if err != nil {
+		return nil, "", err
 	}
 	wrapped, err := m.wrapAgentProcessWithLaunchID(agent, id, env, argv, launchID, force)
 	if err != nil {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -4747,6 +4747,8 @@ func (m *Manager) applyLaunchGate(ctx context.Context, id domain.SessionID, cfg 
 		GitCommonDir:  m.gitCommonDir(ctx, workspacePath),
 		Permissions:   adapterConfig.Permissions,
 		Argv:          append([]string(nil), argv...),
+		Env:           copyEnv(env),
+		Role:          ports.LaunchRoleWorker,
 	})
 	if err != nil {
 		return fmt.Errorf("%w: %w", ports.ErrLaunchNotReady, err)
@@ -4771,6 +4773,19 @@ func (m *Manager) applyLaunchGate(ctx context.Context, id domain.SessionID, cfg 
 		env[key] = value
 	}
 	return nil
+}
+
+// copyEnv hands a gate its own copy, so a gate cannot reach into the child
+// environment except through its decision.
+func copyEnv(env map[string]string) map[string]string {
+	if env == nil {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for key, value := range env {
+		out[key] = value
+	}
+	return out
 }
 
 // gitCommonDir reports the workspace's git common directory, or "" when the

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2298,10 +2298,24 @@ func (m *Manager) relaunchSessionWithPolicyAndGeneration(ctx context.Context, op
 	m.augmentRuntimePATHForLaunchBinary(ctx, env, argv)
 	launchID := strings.TrimSpace(reservedGeneration)
 	if launchID == "" {
-		argv, launchID, err = m.superviseAgentProcess(agent, rec.ID, env, argv)
-	} else {
-		argv, err = m.wrapAgentProcessWithLaunchID(agent, rec.ID, env, argv, launchID, true)
+		launchID, err = m.freshLaunchID()
+		if err != nil {
+			m.cleanupSystemPromptDir(rec.ID)
+			return RestoreResult{}, fmt.Errorf("%s %s: supervisor: %w", operation, rec.ID, err)
+		}
 	}
+	// A restored or relaunched child is a child. Gating only Spawn left the
+	// exact two-roots condition reachable through Restore: the older Claude
+	// PreLaunch still seeded the default root while the relaunched child kept
+	// its inherited CLAUDE_CONFIG_DIR. The gate runs here before any replacement
+	// for the same reason it runs in Spawn -- this is the last point where the
+	// argv and env are final and no new child exists.
+	if err := m.applyLaunchGateForRecord(ctx, rec, ws.Path, agentConfig, argv, env,
+		launchGateIdentity{launchID: launchID, conversationID: rec.Metadata.ProviderConversationID}); err != nil {
+		m.cleanupSystemPromptDir(rec.ID)
+		return RestoreResult{}, fmt.Errorf("%s %s: %w", operation, rec.ID, wrapSpawnStage(rec.ID, ErrSpawnLaunchGate, err))
+	}
+	argv, err = m.wrapAgentProcessWithLaunchID(agent, rec.ID, env, argv, launchID, true)
 	if err != nil {
 		m.cleanupSystemPromptDir(rec.ID)
 		return RestoreResult{}, fmt.Errorf("%s %s: supervisor: %w", operation, rec.ID, err)
@@ -4749,6 +4763,17 @@ func freshLaunchArgv(ctx context.Context, agent ports.Agent, id domain.SessionID
 type launchGateIdentity struct {
 	launchID       string
 	conversationID string
+}
+
+// applyLaunchGateForRecord gates a launch for an existing session record. It is
+// the entry point restore, relaunch, restart and agent switching use, since
+// those have a record rather than a SpawnConfig.
+func (m *Manager) applyLaunchGateForRecord(ctx context.Context, rec domain.SessionRecord,
+	workspacePath string, adapterConfig ports.AgentConfig, argv []string, env map[string]string,
+	identity launchGateIdentity) error {
+	return m.applyLaunchGate(ctx, rec.ID,
+		ports.SpawnConfig{Kind: rec.Kind, Harness: rec.Harness},
+		workspacePath, adapterConfig, argv, env, identity)
 }
 
 func (m *Manager) applyLaunchGate(ctx context.Context, id domain.SessionID, cfg ports.SpawnConfig,

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -162,6 +162,7 @@ var (
 	ErrSpawnPrepare        = errors.New("prepare")
 	ErrSpawnPromptDelivery = errors.New("prompt delivery")
 	ErrSpawnLaunchCommand  = errors.New("launch command")
+	ErrSpawnLaunchGate     = errors.New("launch readiness")
 	ErrSpawnSupervisor     = errors.New("supervisor")
 	ErrSpawnPrepareLaunch  = errors.New("prepare launch")
 	ErrRuntimeCreate       = errors.New("runtime")
@@ -403,6 +404,7 @@ type Manager struct {
 	// lookPath is exec.LookPath in production; tests substitute a stub so
 	// they don't need real binaries on PATH. Returns ports.ErrAgentBinaryNotFound
 	// when the binary is missing so the sentinel propagates through toAPIError.
+	launchGate ports.LaunchGate
 	lookPath func(string) (string, error)
 	// executable resolves the daemon's own binary (os.Executable in
 	// production); its directory is prepended to spawned sessions' PATH so the
@@ -710,6 +712,10 @@ type Deps struct {
 	// callbacks reach this daemon even when another AO daemon is also running.
 	RunFilePath string
 	Clock       func() time.Time
+	// LaunchGate is consulted after the workspace exists and the child argv is
+	// final, but before any child is created. Nil disables it and leaves spawn
+	// behaviour unchanged; see ports.LaunchGate for why the seam is there.
+	LaunchGate ports.LaunchGate
 	// LookPath overrides exec.LookPath for the pre-launch agent-binary check.
 	// Production wiring leaves this nil and the manager defaults to
 	// exec.LookPath; tests inject a stub so they need not seed real binaries.
@@ -759,6 +765,7 @@ func New(d Deps) *Manager {
 		reconcileWorkers:               d.ReconcileWorkers,
 		defaultBranchRefreshTimeout:    defaultBranchRefreshTimeout,
 		openTranscriptFile:             os.Open,
+		launchGate:                     d.LaunchGate,
 		lookPath:                       d.LookPath,
 		executable:                     d.Executable,
 		newLaunchID:                    d.NewLaunchID,
@@ -1036,6 +1043,13 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: %w", id, err)
 	}
 	m.augmentRuntimePATHForLaunchBinary(ctx, env, argv)
+	// Last point at which every trusted value is resolved and no child exists.
+	// A refusal here must look like the binary check: no runtime.Create, the
+	// workspace torn down, and the reason carried to the caller.
+	if err := m.applyLaunchGate(ctx, id, cfg, ws.Path, adapterConfig, argv, env); err != nil {
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
+		return domain.SessionRecord{}, 0, 0, wrapSpawnStage(id, ErrSpawnLaunchGate, err)
+	}
 	argv, launchID, err := m.superviseAgentProcess(agent, id, env, argv)
 	if err != nil {
 		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
@@ -4715,6 +4729,75 @@ func freshLaunchArgv(ctx context.Context, agent ports.Agent, id domain.SessionID
 // that return an argv[0] like "claude" without verifying. Some adapters prefix
 // their command with `env KEY=value`; in that case validate the first real
 // executable after the environment assignments.
+// applyLaunchGate consults an optional pre-spawn gate. It is deliberately the
+// smallest thing that can work: no gate means no change, a refusal stops the
+// spawn before any child exists, and a permitted launch may gain environment
+// entries that AO has not already set. A gate never rewrites argv, and never
+// removes or overrides an AO-owned variable.
+func (m *Manager) applyLaunchGate(ctx context.Context, id domain.SessionID, cfg ports.SpawnConfig,
+	workspacePath string, adapterConfig ports.AgentConfig, argv []string, env map[string]string) error {
+	if m.launchGate == nil {
+		return nil
+	}
+	decision, err := m.launchGate.PreLaunch(ctx, ports.PreLaunchRequest{
+		SessionID:     string(id),
+		Kind:          cfg.Kind,
+		Harness:       cfg.Harness,
+		WorkspacePath: workspacePath,
+		GitCommonDir:  m.gitCommonDir(ctx, workspacePath),
+		Permissions:   adapterConfig.Permissions,
+		Argv:          append([]string(nil), argv...),
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %w", ports.ErrLaunchNotReady, err)
+	}
+	if !decision.Allow {
+		reason := strings.TrimSpace(decision.Reason)
+		if reason == "" {
+			reason = "gate refused the launch without a reason"
+		}
+		if kind := strings.TrimSpace(decision.PromptKind); kind != "" {
+			return fmt.Errorf("%w: %s (%s)", ports.ErrLaunchNotReady, reason, kind)
+		}
+		return fmt.Errorf("%w: %s", ports.ErrLaunchNotReady, reason)
+	}
+	for key, value := range decision.Env {
+		if key == "" {
+			continue
+		}
+		if _, taken := env[key]; taken {
+			continue
+		}
+		env[key] = value
+	}
+	return nil
+}
+
+// gitCommonDir reports the workspace's git common directory, or "" when the
+// path is not a git worktree. A gate that proves worktree provenance needs the
+// real value from git rather than a path this manager guessed.
+func (m *Manager) gitCommonDir(ctx context.Context, workspacePath string) string {
+	if workspacePath == "" {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, "git", "-C", workspacePath, "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		return ""
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(workspacePath, dir)
+	}
+	resolved, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+	return resolved
+}
+
 func (m *Manager) validateAgentBinary(argv []string) error {
 	if len(argv) == 0 {
 		return fmt.Errorf("agent: empty launch argv: %w", ports.ErrAgentBinaryNotFound)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -4772,6 +4772,14 @@ func (m *Manager) applyLaunchGate(ctx context.Context, id domain.SessionID, cfg 
 		}
 		env[key] = value
 	}
+	// An override is the gate taking ownership of a variable the agent reads,
+	// which contributing cannot do. AO's own names stay AO's.
+	for key, value := range decision.EnvOverride {
+		if key == "" || ports.LaunchGateProtectedEnv(key) {
+			continue
+		}
+		env[key] = value
+	}
 	return nil
 }
 


### PR DESCRIPTION
Refs #4895, #4888. Downstream incident: menard-software/setup-agent-orchestrator#418 (see also #427, #428 there).

**Draft.** This is the boundary only — the smallest change that makes the rest of #4895 possible. It is not the whole lifecycle.

## Why

Process creation is not successful startup. An agent child can be spawned and then stop *before* its agent loop — at a workspace-trust prompt, at a permission acknowledgement, or on a conversation that no longer exists — and AO reports that as ordinary work in progress.

That is what #418 recorded: a group of retained Claude workers sat at startup prompts while the board showed `Exited` or `working`, `ao send` returned `AGENT_EXITED`, and a live reviewer tab coexisted with an absent main child. A human had to open individual panes to find out why.

Nothing outside the daemon can fix that. A helper called after `POST /sessions` is already too late to give the exact child its environment, and external code must not infer or overwrite AO's own lifecycle state.

## Where

`Manager.Spawn`, immediately after the existing agent-binary check and before `superviseAgentProcess` / `runtime.Create` — the last point at which every trusted value is resolved and no child exists.

The seam deliberately mirrors `validateAgentBinary`, which already establishes the shape. That check exists because *"tmux happily creates a session+pane around a missing command, so an unresolved binary would leak through as a live session that never ran."* A child that parks at a trust prompt leaks through the same way, one step later.

## What

```go
type LaunchGate interface {
    PreLaunch(ctx context.Context, req PreLaunchRequest) (PreLaunchDecision, error)
}
```

- **`PreLaunchRequest` carries only daemon-owned values** — session id, kind, harness, the AO-created workspace, its git common dir *resolved by git* rather than guessed from the path, the resolved permission mode, and the exact child argv. Nothing comes from the task or the agent.
- **`PreLaunchDecision` may contribute environment entries for that exact child** — the half a post-spawn helper cannot do (a per-session `CLAUDE_CONFIG_DIR`, for instance). Keys AO already set are **not** replaced: a gate contributes, it does not take over.
- **The zero decision refuses.** A gate that returns nothing by mistake stops the launch rather than waving it through. A gate error is also a refusal, not a warning — an unreachable gate must not silently degrade into an ungated launch.
- **A refusal fails the spawn** with `ports.ErrLaunchNotReady` under a new `ErrSpawnLaunchGate` stage, carrying the gate's reason and optional machine-readable prompt kind to the caller.
- **Nil gate disables it** and leaves spawn behaviour unchanged. That is the default, and one test asserts it.

## Tests

Seven, at the real spawn seam, modelled on `TestSpawn_RejectsMissingAgentBinary` so they assert the same two facts a pre-spawn refusal must produce: `runtime.Create` does not run, and the workspace is torn down.

Each check was **negative-tested by disabling it**, so none of them can pass for the wrong reason:

| Breakage | Result |
|---|---|
| gate never consulted | 6 of 7 fail |
| refusal downgraded to allow-anyway | the two refusal tests fail, alone |
| gate error swallowed | the gate-error test fails, alone |
| AO-owned env override permitted | the override test fails, alone |

```
go build ./backend/...                                        ok
go vet ./backend/internal/session_manager/ ./backend/internal/ports/   ok
go test ./backend/internal/ports/                             ok
go test ./backend/internal/session_manager/ -run 'TestSpawn_LaunchGate|TestSpawn_WithoutLaunchGate'   ok, 7/7
```

Full `./backend/internal/session_manager/` has **four failures on this machine — all pre-existing**, not from this change: `TestSpawn_RejectsMissingAgentBinary`, `TestSpawn_RejectsMissingBinaryAfterEnvPrefix`, `TestSpawn_ValidatesBinaryAfterEnvPrefix`, `TestSpawn_MissingBinaryPreservesNonEmptyScratchWorkspaceForRetry`. Each fails with `tmux required on macOS but AO's configured, bundled, or system tmux was not found`. I verified this by stashing the change and reproducing the same failures on unmodified `main` at `56ea59b`, rather than assuming.

## Deliberately not in this change

The rest of #4895, which this boundary is the prerequisite for:

- persisted readiness handshake bound to `(session, launch, conversation)`, so a stale child cannot make a replacement launch ready;
- `needs_input` / `launch_failed` / `resume_invalid` as first-class statuses rather than generic `exited`;
- delivery states and refusal of `ao send` before readiness;
- separate main-child, supervisor and reviewer liveness, so a live reviewer cannot mask a failed main child.

Each wants its own change and its own tests. Happy to follow this with them, reshape the contract, or move the seam if you would rather it sat elsewhere — the position and the naming are the parts I would most like maintainer input on.

## Scope note

No credential, GUI automation, PTY injection, or destructive session action is involved. Base resolved immediately before push: `56ea59b`.