### PR TITLE
fix(claude): gate injected input until startup hook

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -78,6 +78,13 @@ var _ ports.EmptyComposerDetector = (*Plugin)(nil)
 var _ ports.AgentInterfaceHandoff = (*Plugin)(nil)
 var _ ports.AgentInterfaceHandoffHistoryProbe = (*Plugin)(nil)
 var _ ports.TerminalSurfaceInspector = (*Plugin)(nil)
+var _ ports.StartupInputReadinessSignaler = (*Plugin)(nil)
+
+// FirstSignalProvesInputReady declares that Claude's first AO hook can only
+// arrive after its native startup sequence has reached the agent loop. Before
+// then, pane input may land on Claude's trust or responsibility dialog rather
+// than on the agent composer, so AO must not inject a message.
+func (p *Plugin) FirstSignalProvesInputReady() bool { return true }
 
 // ComposerIsEmpty recognizes Claude Code's blank composer or its dim
 // placeholder. Claude renders normal, non-dim status chrome below a bordered

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -8446,6 +8446,28 @@ func TestSend_TUIStartupPendingRejectsDelivery(t *testing.T) {
 	}
 }
 
+// Claude Code can display its own pre-session trust or responsibility dialog
+// before its hook can acknowledge the launch. A normal pane paste at that
+// point can answer the dialog rather than reach the agent composer.
+func TestSend_ClaudeTUIStartupPendingRejectsDelivery(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["s1"] = domain.SessionRecord{
+		ID: "s1", Harness: domain.HarnessClaudeCode, Mode: domain.SessionModeTUI,
+		Activity: domain.Activity{State: domain.ActivityIdle},
+		Metadata: domain.SessionMetadata{RuntimeHandleID: "h1"},
+	}
+	msg := &fakeMessenger{}
+	m := newSendTestManager(t, &claudecode.Plugin{}, msg, st)
+
+	err := m.Send(context.Background(), "s1", "follow-up after spawn", nil)
+	if !errors.Is(err, ErrStartupPending) {
+		t.Fatalf("Send error = %v, want ErrStartupPending", err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("Send calls = %d, want 0 before Claude emits its first hook", len(msg.msgs))
+	}
+}
+
 func TestSend_HooklessTUIStartupAllowsDelivery(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["s1"] = domain.SessionRecord{

--- a/backend/internal/session_manager/message_delivery.go
+++ b/backend/internal/session_manager/message_delivery.go
@@ -92,6 +92,13 @@ func (m *Manager) WaitForMessageDeliveryReady(ctx context.Context, id domain.Ses
 						ready = emptyComposerDetector.ComposerIsEmpty(output)
 					}
 				}
+				// A rendered idle composer can briefly survive a provider-owned
+				// startup dialog or resume sequence. Adapters that declare the
+				// first hook as their input-ready proof must satisfy it even when
+				// they also have a terminal activity detector.
+				if requireFirstSignal && rec.FirstSignalAt.IsZero() {
+					ready = false
+				}
 			} else {
 				// MarkSpawned records idle before the TUI is necessarily ready.
 				// Capability-declaring adapters require their first startup-ready

--- a/backend/internal/session_manager/message_delivery_test.go
+++ b/backend/internal/session_manager/message_delivery_test.go
@@ -38,6 +38,13 @@ func (terminalReadyAgent) DetectTerminalActivity(output string) (domain.Activity
 	return "", false
 }
 
+// A harness can both interpret its terminal and require its first hook as the
+// proof that native startup dialogs have cleared. Terminal idleness alone is
+// not sufficient evidence that pane input reaches the agent composer.
+type startupReadyTerminalAgent struct{ terminalReadyAgent }
+
+func (startupReadyTerminalAgent) FirstSignalProvesInputReady() bool { return true }
+
 type emptyComposerReadyAgent struct{ fakeAgent }
 
 func (emptyComposerReadyAgent) DetectTerminalActivity(string) (domain.ActivityState, bool) {
@@ -71,6 +78,33 @@ func TestWaitForMessageDeliveryReadyWaitsForTerminalIdleMarker(t *testing.T) {
 	}
 	if runtime.outputCalls < 2 {
 		t.Fatalf("terminal output calls = %d, want readiness polling", runtime.outputCalls)
+	}
+}
+
+func TestWaitForMessageDeliveryReadyRequiresFirstHookEvenWhenTerminalIsIdle(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["orch"] = domain.SessionRecord{
+		ID:        "orch",
+		ProjectID: "ao",
+		Kind:      domain.KindOrchestrator,
+		Harness:   domain.HarnessClaudeCode,
+		Mode:      domain.SessionModeTUI,
+		Activity:  domain.Activity{State: domain.ActivityIdle},
+		Metadata:  domain.SessionMetadata{RuntimeHandleID: "orch"},
+	}
+	m := New(Deps{
+		Runtime: &fakeRuntime{outputs: []string{"ready"}},
+		Agents:  singleAgent{agent: startupReadyTerminalAgent{}},
+		Store:   st,
+	})
+	// Longer than the ordinary 750 ms idle settle: a terminal-idle-only waiter
+	// would return success here. The first hook is intentionally absent.
+	ctx, cancel := context.WithTimeout(context.Background(), 1100*time.Millisecond)
+	defer cancel()
+
+	err := m.WaitForMessageDeliveryReady(ctx, "orch")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitForMessageDeliveryReady error = %v, want deadline before first hook", err)
 	}
 }
 


### PR DESCRIPTION
## Scope

A minimal upstream contribution for the false-ready half of setup-agent-orchestrator #388 / #418. Claude Code opts into the existing `StartupInputReadinessSignaler` contract, and `WaitForMessageDeliveryReady` now requires the first lifecycle hook even if terminal parsing reports an idle composer.

That prevents `ao send` from treating a startup pane as ready and injecting input into a provider-owned onboarding/disclaimer flow. It returns the existing bounded not-ready result rather than claiming a confirmed agent exit.

## Deliberate exclusions

- No workspace trust/config-root changes; draft #4897 owns that launch-gate seam.
- No prompt-state migration, UI/API rendering, or new terminal-text persistence. Those remain tracked by #388 / #418.
- No auto-accept, Enter injection, runtime, UI, credential, VM, host, or workflow action.

## Tests

`go test ./backend/internal/session_manager -run "^(TestSend_ClaudeTUIStartupPendingRejectsDelivery|TestWaitForMessageDeliveryReadyRequiresFirstHookEvenWhenTerminalIsIdle|TestSend_TUIStartupPendingRejectsDelivery|TestWaitForMessageDeliveryReadyWaitsForFirstHookSignal)$" -count=1`

Passes locally.

References https://github.com/menard-software/setup-agent-orchestrator/issues/388 and https://github.com/menard-software/setup-agent-orchestrator/issues/418. Draft #4899 remains frozen for separate minimality review; this PR is intentionally its non-overlapping first-hook subset.