### PR TITLE
fix(cli): echo display name in ao spawn confirmation output

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -52,8 +52,9 @@ type spawnRequest struct {
 
 type spawnResult struct {
 	Session struct {
-		ID     string `json:"id"`
-		Status string `json:"status"`
+		ID          string `json:"id"`
+		Status      string `json:"status"`
+		DisplayName string `json:"displayName"`
 	} `json:"session"`
 	PromptBytes       int `json:"promptBytes,omitempty"`
 	SystemPromptBytes int `json:"systemPromptBytes,omitempty"`
@@ -169,7 +170,11 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			if res.PromptBytes > 0 || res.SystemPromptBytes > 0 {
 				promptSize = fmt.Sprintf(" [prompt %d B, system %d B]", res.PromptBytes, res.SystemPromptBytes)
 			}
-			_, err = fmt.Fprintf(out, "spawned session %s (%s)%s%s\n", res.Session.ID, res.Session.Status, claimLabel, promptSize)
+			displayName := res.Session.DisplayName
+			if displayName == "" {
+				displayName = name
+			}
+			_, err = fmt.Fprintf(out, "spawned session %s %q (%s)%s%s\n", res.Session.ID, displayName, res.Session.Status, claimLabel, promptSize)
 			return err
 		},
 	}

--- a/backend/internal/cli/spawn_test.go
+++ b/backend/internal/cli/spawn_test.go
@@ -274,6 +274,56 @@ func TestSpawnCommand_RejectsOverlongName(t *testing.T) {
 	}
 }
 
+func TestSpawnConfirmationIncludesDisplayName(t *testing.T) {
+	// Issue #2592: the confirmation line echoed only the session id, forcing a
+	// follow-up lookup to map the id back to the --name just passed.
+	tests := []struct {
+		name        string
+		sessionJSON string
+		want        string
+	}{
+		{
+			name:        "daemon echoes displayName",
+			sessionJSON: `{"id":"demo-11","status":"idle","displayName":"worker"}`,
+			want:        `spawned session demo-11 "worker" (idle)`,
+		},
+		{
+			name:        "daemon omits displayName falls back to --name",
+			sessionJSON: `{"id":"demo-11","status":"idle"}`,
+			want:        `spawned session demo-11 "worker" (idle)`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setConfigEnv(t)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/demo":
+					_, _ = io.WriteString(w, `{"status":"ok","project":{"id":"demo","name":"Demo","path":"/repo/demo","config":{"worker":{"agent":"codex"}}}}`)
+				case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/readiness/ensure":
+					_, _ = io.WriteString(w, authorizedAgentsJSON("codex"))
+				case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
+					_, _ = io.WriteString(w, `{"session":`+tt.sessionJSON+`,"promptBytes":0,"systemPromptBytes":0}`)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			writeRunFileFor(t, cfg, srv)
+
+			out, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }},
+				"spawn", "--project", "demo", "--agent", "codex", "--name", "worker")
+			if err != nil {
+				t.Fatalf("spawn failed: %v stderr=%s", err, errOut)
+			}
+			if !strings.Contains(out, tt.want) {
+				t.Fatalf("confirmation missing display name:\nwant %q\n got %q", tt.want, out)
+			}
+		})
+	}
+}
+
 func TestSpawnResolvesProjectFromEnvAndDefaultAgent(t *testing.T) {
 	cfg := setConfigEnv(t)
 	var requests []string


### PR DESCRIPTION
Fixes #2592.

## What
`ao spawn --name quiet-fox-42` printed only the session id (`spawned session agent-orchestrator-15 (idle)`), forcing a follow-up `ao session get/ls` to recover the name mapping. The confirmation now echoes the display name:

`spawned session agent-orchestrator-15 "quiet-fox-42" (idle)`

## How
- The daemon already returns `displayName` in `SpawnSessionResponse`; the CLI hand-mirrored `spawnResult` DTO dropped it, so the field is added there (deliberate manual boundary, no controller changes).
- Prefer the daemon-echoed value, fall back to the local `--name` (same precedent as `renameSession` in `session.go`). `--name` is required, so the name is always present.
- `%q` quoting matches `session %s renamed to %q`; the `spawned session <id>` prefix is unchanged so existing output assertions keep passing.

## Tests
- New `TestSpawnConfirmationIncludesDisplayName` (daemon-echoes + daemon-omits/fallback cases).
- Full `go test ./internal/cli/` passes, `go vet` clean, gofmt applied.

## Intentionally omitted
- No skill-doc changes here: the docs-only reporting instruction is PR #2593's scope, still open. This PR covers only the CLI output half the triage kept open as P3.
