### PR TITLE
fix(session): don't report terminated session as merged while a PR is open

### DIFF
--- a/backend/pkg/contract/status.go
+++ b/backend/pkg/contract/status.go
@@ -106,7 +106,7 @@ func DeriveStatus(
 	noSignalGrace time.Duration,
 ) SessionStatus {
 	if session.IsTerminated {
-		if anyMerged(prs) {
+		if len(openPRs(prs)) == 0 && anyMerged(prs) {
 			return StatusMerged
 		}
 		return StatusTerminated

--- a/backend/pkg/contract/status_test.go
+++ b/backend/pkg/contract/status_test.go
@@ -26,6 +26,9 @@ func TestDeriveStatusPrecedence(t *testing.T) {
 	}{
 		{"terminated", contract.SessionFacts{IsTerminated: true}, nil, contract.StatusTerminated},
 		{"terminated merged", contract.SessionFacts{IsTerminated: true}, []contract.PRFacts{{Merged: true}}, contract.StatusMerged},
+		{"terminated closed only", contract.SessionFacts{IsTerminated: true}, []contract.PRFacts{{Closed: true}}, contract.StatusTerminated},
+		{"terminated merged with open pr", contract.SessionFacts{IsTerminated: true}, []contract.PRFacts{{Merged: true}, {Merged: false}}, contract.StatusTerminated},
+		{"terminated all merged", contract.SessionFacts{IsTerminated: true}, []contract.PRFacts{{Merged: true}, {Merged: true}}, contract.StatusMerged},
 		{"active before PR", session(contract.ActivityActive), []contract.PRFacts{{CI: contract.CIFailing}}, contract.StatusWorking},
 		{"exited before PR", session(contract.ActivityExited), []contract.PRFacts{{Mergeability: contract.MergeMergeable}}, contract.StatusExited},
 		{"waiting before PR", session(contract.ActivityWaitingInput), []contract.PRFacts{{CI: contract.CIFailing}}, contract.StatusNeedsInput},


### PR DESCRIPTION
Fixes #2390.

## Summary
\deriveStatus\ reported a terminated session as \merged\ whenever *any* of its PRs was merged, even if the session still owned an open PR — contradicting the documented invariant that merged PRs only matter once no open PR remains.

## Change
Gate the terminated branch's merged short-circuit on there being no open PR, mirroring the non-terminated branch (backend/pkg/contract/status.go):

\\\go
if len(openPRs(prs)) == 0 && anyMerged(prs) {
\\\

Behavior is preserved for a terminated session whose only PRs are merged; only the \merged + open\ combination now stays \	erminated\.

## Tests
- Added table cases: terminated (merged + open) → \	erminated\; terminated (all merged) → \merged\; terminated (closed only) → \	erminated\.
- \go test ./pkg/contract/\, \go test -run TestDerive ./internal/service/session/\, \go vet\ pass.