### PR TITLE
fix(chat): keep the ChatUI-selected model across the ChatUI ↔ TUI handoff

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -242,6 +242,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		Binary:           binary,
 		SessionID:        cfg.Session.ID,
 		Metadata:         cfg.Session.Metadata,
+		Model:            cfg.Config.Model,
 		Prompt:           cfg.Prompt,
 		SystemPrompt:     cfg.SystemPrompt,
 		SystemPromptFile: cfg.SystemPromptFile,

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -690,6 +690,27 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	}
 }
 
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	// ChatUI can change the model on the session; rebuilding the TUI must pass
+	// that model into the harness restore command so the resumed Claude session
+	// does not silently flip back to a different model (#4893).
+	cmd, ok, err := (&Plugin{resolvedBinary: "claude"}).GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Permissions: ports.PermissionModeBypassPermissions,
+		Config:      ports.AgentConfig{Model: "claude-opus-4-5"},
+		Session: ports.SessionRef{
+			ID:       "sess-r",
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "claude-native-1"},
+		},
+	})
+	if err != nil || !ok {
+		t.Fatalf("restore = (ok=%v, err=%v), want ok", ok, err)
+	}
+	want := []string{"claude", "--permission-mode", "bypassPermissions", "--model", "claude-opus-4-5", "--resume", "claude-native-1"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
 func TestGetRestoreCommandReappendsSystemPrompt(t *testing.T) {
 	// --resume rebuilds the system prompt from flags, so standing instructions
 	// (e.g. the orchestrator role) must be re-appended on restore.

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -441,6 +441,18 @@ func Run() error {
 			}
 			agentSvc.ObserveActiveCodexAccountCapacity(observation)
 		},
+		// A model the user picked in ChatUI must land on the session before the
+		// next prompt routes, so a later TUI rebuild resumes with the same model
+		// instead of reverting to the project default.
+		OnModelChanged: func(sessionID domain.SessionID, model string) {
+			if sessMgr == nil {
+				return
+			}
+			if err := sessMgr.PersistChatModel(ctx, sessionID, model); err != nil {
+				log.Warn("persist ChatUI model on session failed; a TUI rebuild may resume with a different model",
+					"sessionID", sessionID, "model", model, "error", err)
+			}
+		},
 	})
 
 	codexModelDriver := codexappserver.New(codexagent.New(), log)

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -197,6 +197,10 @@ type sessionLifecycle interface {
 	// SetHarnessUseGate prevents lifecycle operations from racing a harness
 	// executable replacement.
 	SetHarnessUseGate(gate sessionmanager.HarnessUseGate)
+	// PersistChatModel records the model the user picked in ChatUI onto the
+	// session's durable metadata before the next prompt routes. A later TUI
+	// rebuild reads it back so ChatUI model changes survive the handoff.
+	PersistChatModel(ctx context.Context, id domain.SessionID, model string) error
 }
 
 // sessionLifecycleMessenger adapts sessionLifecycle to ports.AgentMessenger so

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -969,6 +969,9 @@ func (f *fakeSessionLifecycle) GetActiveCodexAccountSwitch(context.Context) (dom
 	return domain.CodexAccountSwitch{}, false, nil
 }
 func (f *fakeSessionLifecycle) SetCodexAccountSwitchObserver(func()) {}
+func (f *fakeSessionLifecycle) PersistChatModel(_ context.Context, _ domain.SessionID, _ string) error {
+	return nil
+}
 
 // TestWiring_SessionLifecycleInterfaceInvokedByDaemon asserts the
 // sessionLifecycle interface is satisfied by *sessionmanager.Manager (compile

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -2822,6 +2822,103 @@ func TestControllerReadyDurableSettingsRefreshBeforeFirstDispatch(t *testing.T) 
 	}
 }
 
+// configOptionConversation models a provider that owns its own session config
+// (e.g. Claude Code's model picker), so SetConfigOption has a real surface to
+// drive.
+type configOptionConversation struct {
+	*fakeConversation
+	mu      sync.Mutex
+	applied []ports.ChatConfigOptionValue
+}
+
+func (c *configOptionConversation) ListConfigOptions(context.Context) ([]ports.ChatConfigOption, error) {
+	return c.catalog(), nil
+}
+
+func (c *configOptionConversation) SetConfigOption(_ context.Context, _ string, value ports.ChatConfigOptionValue) ([]ports.ChatConfigOption, error) {
+	c.mu.Lock()
+	c.applied = append(c.applied, value)
+	c.mu.Unlock()
+	return c.catalog(), nil
+}
+
+// catalog reflects the most recently applied model select, the way a provider
+// reports the post-change state back.
+func (c *configOptionConversation) catalog() []ports.ChatConfigOption {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	current := ""
+	if len(c.applied) > 0 {
+		current = c.applied[len(c.applied)-1].Select
+	}
+	return []ports.ChatConfigOption{{
+		ID: "model", Category: "model",
+		Type:    ports.ChatConfigOptionSelect,
+		Current: ports.ChatConfigOptionValue{Select: current},
+	}}
+}
+
+// TestSetConfigOptionPersistsModelBeforeRouting covers the other model-change
+// route: provider-owned pickers like Claude Code's model menu go through the
+// config-options PATCH, which calls SetSettings directly. The pick must land on
+// the session's durable metadata the same way a turn-settings model change does
+// (#4893 follow-up), or a later TUI rebuild resumes with the stale model.
+func TestSetConfigOptionPersistsModelBeforeRouting(t *testing.T) {
+	st := openStore(t)
+	ctx := context.Background()
+	conv := &configOptionConversation{fakeConversation: newFakeConversation()}
+	var (
+		logMu sync.Mutex
+		log   []string
+	)
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{conv: conv}},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID:   func() string { return "config-option-model-id" },
+		OnModelChanged: func(id domain.SessionID, model string) {
+			logMu.Lock()
+			defer logMu.Unlock()
+			log = append(log, string(id)+":"+model)
+		},
+	})
+	t.Cleanup(func() { _ = svc.Stop(ctx, testSession) })
+	if _, err := svc.Start(ctx, chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Picking a model through the config-options route persists it.
+	options, err := svc.SetConfigOption(ctx, testSession, "model", ports.ChatConfigOptionValue{Select: "5.6-haiku"})
+	if err != nil {
+		t.Fatalf("SetConfigOption: %v", err)
+	}
+	if len(options) == 0 || options[0].Current.Select != "5.6-haiku" {
+		t.Fatalf("post-change catalog = %+v, want the picked model", options)
+	}
+	if !reflect.DeepEqual(log, []string{string(testSession) + ":5.6-haiku"}) {
+		t.Fatalf("model persistence log = %v, want [%s:5.6-haiku]", log, testSession)
+	}
+
+	// Re-applying the same selection is a no-op.
+	if _, err := svc.SetConfigOption(ctx, testSession, "model", ports.ChatConfigOptionValue{Select: "5.6-haiku"}); err != nil {
+		t.Fatalf("SetConfigOption (same): %v", err)
+	}
+	if !reflect.DeepEqual(log, []string{string(testSession) + ":5.6-haiku"}) {
+		t.Fatalf("model persistence log after no-op = %v, want unchanged", log)
+	}
+
+	// A later pick through the same route supersedes the earlier one.
+	if _, err := svc.SetConfigOption(ctx, testSession, "model", ports.ChatConfigOptionValue{Select: "5.6-sonnet"}); err != nil {
+		t.Fatalf("SetConfigOption (sonnet): %v", err)
+	}
+	if !reflect.DeepEqual(log, []string{string(testSession) + ":5.6-haiku", string(testSession) + ":5.6-sonnet"}) {
+		t.Fatalf("model persistence log = %v, want haiku then sonnet", log)
+	}
+}
+
 // TestSetTurnSettingsPersistsModelBeforeRouting is the regression for the
 // ChatUI ↔ TUI model-persistence bug (#4893). A model the user picks in ChatUI
 // must be recorded on the session BEFORE the next prompt routes, so that when

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2818,6 +2819,68 @@ func TestControllerReadyDurableSettingsRefreshBeforeFirstDispatch(t *testing.T) 
 	if sent[0].Settings.Model != "" || sent[0].Settings.Effort != "" ||
 		sent[0].Settings.Approval != domain.PermissionModeAcceptEdits {
 		t.Fatalf("activation settings = %+v, want target defaults with preserved approval", sent[0].Settings)
+	}
+}
+
+// TestSetTurnSettingsPersistsModelBeforeRouting is the regression for the
+// ChatUI ↔ TUI model-persistence bug (#4893). A model the user picks in ChatUI
+// must be recorded on the session BEFORE the next prompt routes, so that when
+// ChatUI later hands off to TUI, the rebuilt terminal resumes with the same
+// model instead of reverting to the project default. The conversation row is
+// the chat-side source of truth already; this pins the extra session metadata
+// write that makes the choice visible to the TUI rebuild.
+func TestSetTurnSettingsPersistsModelBeforeRouting(t *testing.T) {
+	st := openStore(t)
+	ctx := context.Background()
+	conv := newFakeConversation()
+	var (
+		logMu sync.Mutex
+		log   []string
+	)
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st,
+		Drivers: fakeRegistry{driver: fakeDriver{conv: conv}},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID:   func() string { return "persist-model-id" },
+		// Production wires this to the session manager, which writes the model onto
+		// the session's durable metadata before the next turn routes.
+		OnModelChanged: func(id domain.SessionID, model string) {
+			logMu.Lock()
+			defer logMu.Unlock()
+			log = append(log, string(id)+":"+model)
+		},
+	})
+	t.Cleanup(func() { _ = svc.Stop(ctx, testSession) })
+	if _, err := svc.Start(ctx, chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// A model change is persisted immediately (before the next prompt routes).
+	if _, err := svc.SetTurnSettings(ctx, testSession, domain.ConversationSettings{Model: "5.6-luna"}); err != nil {
+		t.Fatalf("SetTurnSettings (luna): %v", err)
+	}
+	if !reflect.DeepEqual(log, []string{string(testSession) + ":5.6-luna"}) {
+		t.Fatalf("model persistence log = %v, want [%s:5.6-luna]", log, testSession)
+	}
+
+	// Re-selecting the same model is a no-op: no redundant session write.
+	if _, err := svc.SetTurnSettings(ctx, testSession, domain.ConversationSettings{Model: "5.6-luna"}); err != nil {
+		t.Fatalf("SetTurnSettings (same): %v", err)
+	}
+	if !reflect.DeepEqual(log, []string{string(testSession) + ":5.6-luna"}) {
+		t.Fatalf("model persistence log after no-op = %v, want unchanged", log)
+	}
+
+	// A later change to another model lands too, so the TUI rebuild picks up the
+	// most recent choice rather than the first one.
+	if _, err := svc.SetTurnSettings(ctx, testSession, domain.ConversationSettings{Model: "5.6-full"}); err != nil {
+		t.Fatalf("SetTurnSettings (full): %v", err)
+	}
+	if !reflect.DeepEqual(log, []string{string(testSession) + ":5.6-luna", string(testSession) + ":5.6-full"}) {
+		t.Fatalf("model persistence log = %v, want luna then full", log)
 	}
 }
 

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -1328,15 +1328,20 @@ func (s *Service) SetConfigOption(
 	}
 	controller.configMu.Lock()
 	defer controller.configMu.Unlock()
+	previous := controller.Settings()
 	options, err := configurer.SetConfigOption(ctx, configID, value)
 	if err != nil {
 		return nil, err
 	}
 	options = permissionConfigOptions(record.Harness, options)
-	if settings, changed := settingsFromConfigOptions(controller.Settings(), options); changed {
+	if settings, changed := settingsFromConfigOptions(previous, options); changed {
 		if err := controller.SetSettings(ctx, settings); err != nil {
 			return nil, err
 		}
+		// The config-options route is how provider-owned pickers (e.g. Claude
+		// Code's model menu) change the model; it must persist the pick the same
+		// way the turn-settings route does.
+		s.persistPickedModel(id, previous, settings)
 	}
 	return options, nil
 }
@@ -1455,14 +1460,23 @@ func (s *Service) SetTurnSettings(
 	if err := controller.SetSettings(ctx, settings); err != nil {
 		return domain.ConversationSettings{}, err
 	}
-	// Persist the picked model onto the session BEFORE the next prompt routes.
-	// The conversation row is the chat-side source of truth; the session
-	// metadata is what a later TUI rebuild reads to keep the same model, so a
-	// model change must land there too before the user can switch interfaces.
-	if model := strings.TrimSpace(settings.Model); model != "" && model != strings.TrimSpace(previous.Model) && s.onModelChanged != nil {
-		s.onModelChanged(id, model)
-	}
+	s.persistPickedModel(id, previous, settings)
 	return controller.Settings(), nil
+}
+
+// persistPickedModel records a model the user picked in ChatUI onto the
+// session's durable metadata BEFORE the next prompt routes. The conversation
+// row is the chat-side source of truth; the session metadata is what a later
+// TUI rebuild reads to keep the same model, so a model change must land there
+// too before the user can switch interfaces. Every route that can change the
+// model funnels through here: the turn-settings PATCH and the provider
+// config-options route (e.g. Claude Code's model picker).
+func (s *Service) persistPickedModel(id domain.SessionID, previous, next domain.ConversationSettings) {
+	model := strings.TrimSpace(next.Model)
+	if model == "" || model == strings.TrimSpace(previous.Model) || s.onModelChanged == nil {
+		return
+	}
+	s.onModelChanged(id, model)
 }
 
 // RelayChatTurn delivers a message AO is carrying for someone else.

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -44,6 +44,10 @@ type Service struct {
 	now                    Clock
 	onAccountChanged       func(domain.SessionID, string, domain.AgentHarness)
 	onCodexCapacityChanged func(domain.SessionID, string, ports.CodexCapacityObservation)
+	// onModelChanged records a model the user picked in ChatUI onto the
+	// session's durable metadata before the next prompt routes, so a later TUI
+	// rebuild can resume with the same model.
+	onModelChanged func(domain.SessionID, string)
 
 	mu           sync.RWMutex
 	controllers  map[domain.SessionID]*Controller
@@ -90,6 +94,11 @@ type Options struct {
 	// globally active AO Codex account. The callback owns profile-independent
 	// account state; conversation rows are not the authority for Codex capacity.
 	OnCodexCapacityChanged func(domain.SessionID, string, ports.CodexCapacityObservation)
+	// OnModelChanged persists a model the user picked in ChatUI onto the
+	// session's durable metadata before the next prompt routes. Nil leaves the
+	// session model unchanged (production always wires it so the choice survives
+	// a later TUI rebuild).
+	OnModelChanged func(domain.SessionID, string)
 }
 
 // New builds a Chat service.
@@ -114,6 +123,7 @@ func New(opts Options) *Service {
 		now:                    now,
 		onAccountChanged:       opts.OnAccountChanged,
 		onCodexCapacityChanged: opts.OnCodexCapacityChanged,
+		onModelChanged:         opts.OnModelChanged,
 		controllers:            make(map[domain.SessionID]*Controller),
 		startConfigs:           make(map[domain.SessionID]StartConfig),
 		gates:                  make(map[domain.SessionID]controllerGate),
@@ -1441,8 +1451,16 @@ func (s *Service) SetTurnSettings(
 	if err != nil {
 		return domain.ConversationSettings{}, err
 	}
+	previous := controller.Settings()
 	if err := controller.SetSettings(ctx, settings); err != nil {
 		return domain.ConversationSettings{}, err
+	}
+	// Persist the picked model onto the session BEFORE the next prompt routes.
+	// The conversation row is the chat-side source of truth; the session
+	// metadata is what a later TUI rebuild reads to keep the same model, so a
+	// model change must land there too before the user can switch interfaces.
+	if model := strings.TrimSpace(settings.Model); model != "" && model != strings.TrimSpace(previous.Model) && s.onModelChanged != nil {
+		s.onModelChanged(id, model)
 	}
 	return controller.Settings(), nil
 }

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -652,6 +652,12 @@ func (m *Manager) preflightInterfaceTarget(
 		return err
 	}
 	config := effectiveAgentConfig(rec.Kind, project.Config)
+	// Refresh the model from the session's own persisted selection so the
+	// preflight validates the exact restore command the rebuild will run
+	// (ChatUI model changes must survive the handoff).
+	if model := strings.TrimSpace(rec.Metadata.Model); model != "" {
+		config.Model = model
+	}
 	var cmd []string
 	if transition.NativeConversationID == "" {
 		cmd, _, _, err = freshLaunchArgv(ctx, agent, rec.ID, rec.Metadata.WorkspacePath,

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -1847,6 +1847,91 @@ func TestInterfaceTransitionChatToTUIInterruptsThenStopsBeforeStarting(t *testin
 	}
 }
 
+// modelRecordingTransitionAgent records the restore config the TUI rebuild
+// hands the harness, so a Chat-to-TUI handoff test can assert which model the
+// rebuilt terminal resumes with.
+type modelRecordingTransitionAgent struct {
+	transitionAgent
+	mu             sync.Mutex
+	restoreConfigs []ports.RestoreConfig
+}
+
+func (a *modelRecordingTransitionAgent) GetRestoreCommand(_ context.Context, cfg ports.RestoreConfig) ([]string, bool, error) {
+	a.mu.Lock()
+	a.restoreConfigs = append(a.restoreConfigs, cfg)
+	a.mu.Unlock()
+	if cfg.Session.Metadata[ports.MetadataKeyAgentSessionID] == "" {
+		return nil, false, nil
+	}
+	return []string{"resume"}, true, nil
+}
+
+func (a *modelRecordingTransitionAgent) restores() []ports.RestoreConfig {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]ports.RestoreConfig(nil), a.restoreConfigs...)
+}
+
+// TestInterfaceTransitionChatToTUIRebuildUsesChatModel is the regression for
+// the ChatUI ↔ TUI model-persistence bug (#4893), including the handoff race
+// where the old terminal is still closing: the transition interrupts and stops
+// the Chat source before starting the TUI target, and the rebuilt TUI harness
+// restore command must carry the model the user picked in ChatUI — refreshed
+// from the session's durable metadata, not the project default — while still
+// resuming the SAME native conversation.
+func TestInterfaceTransitionChatToTUIRebuildUsesChatModel(t *testing.T) {
+	manager, store, runtime, _, log := newTransitionManager(t, domain.SessionModeChat)
+	// The project default would otherwise win: the ChatUI choice persisted on
+	// the session must take precedence in the rebuilt TUI restore command.
+	store.projects["proj"] = domain.ProjectRecord{
+		ID: "proj", Path: "/repo",
+		Config: domain.ProjectConfig{AgentConfig: domain.AgentConfig{Model: "project-default-model"}},
+	}
+	seedSessionModel := store.sessions["session-1"]
+	seedSessionModel.Metadata.Model = "5.6-luna"
+	store.sessions["session-1"] = seedSessionModel
+	agent := &modelRecordingTransitionAgent{}
+	manager.agents = singleAgent{agent: agent}
+
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1", domain.SessionModeTUI, domain.SessionInterfaceTransitionInterrupt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+
+	// The preflight and the rebuild both resume with the ChatUI model — every
+	// restore command the handoff builds (target preflight happens while the
+	// old terminal is still closing, then the rebuild itself) carries it.
+	restores := agent.restores()
+	if len(restores) != 2 {
+		t.Fatalf("harness restore calls = %d, want 2 (target preflight + rebuild)", len(restores))
+	}
+	for i, cfg := range restores {
+		if cfg.Config.Model != "5.6-luna" {
+			t.Fatalf("restore call %d model = %q, want the ChatUI choice 5.6-luna", i, cfg.Config.Model)
+		}
+	}
+
+	// History is preserved across the handoff: same native conversation, no new
+	// session, and the terminal was rebuilt exactly once.
+	rec := store.sessions["session-1"]
+	if rec.Mode != domain.SessionModeTUI {
+		t.Fatalf("mode = %s, want tui", rec.Mode)
+	}
+	if rec.Metadata.AgentSessionID != "native-1" {
+		t.Fatalf("agent session = %q, want native-1 (conversation must be preserved)", rec.Metadata.AgentSessionID)
+	}
+	if runtime.created != 1 {
+		t.Fatalf("terminal runtime created %d times, want 1", runtime.created)
+	}
+	if got := fmt.Sprint(*log); got != "[prepare:chat:interrupt stop:chat start:tui]" {
+		t.Fatalf("controller order = %s", got)
+	}
+}
+
 func TestInterfaceTransitionChatToTUIArmsInterruptBeforeReturning(t *testing.T) {
 	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeChat)
 	transition, err := manager.StartInterfaceTransition(

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2241,9 +2241,18 @@ func (m *Manager) relaunchSessionWithPolicyAndGeneration(ctx context.Context, op
 		return RestoreResult{}, fmt.Errorf("%s %s: system prompt file: %w", operation, rec.ID, err)
 	}
 
-	// Restore resolves the project model while retaining this session's pinned
-	// permission policy independently of future project defaults.
+	// Restore re-applies the project's resolved agent config so a configured
+	// model/permissions carry across a restore, matching fresh spawn. This
+	// session's own durable choices then win over future project defaults: a
+	// pinned permission policy is retained (see #4956), and the model is
+	// refreshed from the session's persisted selection — ChatUI writes its
+	// chosen model to session metadata before routing a prompt, so a later
+	// TUI rebuild must keep that choice rather than silently reverting to the
+	// project default.
 	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
+	if model := strings.TrimSpace(rec.Metadata.Model); model != "" {
+		agentConfig.Model = model
+	}
 	if rec.Metadata.Permissions != "" {
 		agentConfig.Permissions = rec.Metadata.Permissions
 	}
@@ -2400,6 +2409,31 @@ func (m *Manager) getRecord(ctx context.Context, id domain.SessionID) (domain.Se
 		return domain.SessionRecord{}, fmt.Errorf("get %s: %w", id, ErrNotFound)
 	}
 	return rec, nil
+}
+
+// PersistChatModel records the model the user picked in ChatUI onto the
+// session before the next prompt routes. The durable, API-visible session
+// metadata is the exact source a TUI rebuild reads to refresh the model, so a
+// later interface transition back to TUI keeps the same selection instead of
+// reverting to the project's configured default. Model-only writes never touch
+// the conversation or spawn a new provider session, so history is preserved.
+func (m *Manager) PersistChatModel(ctx context.Context, id domain.SessionID, model string) error {
+	want := strings.TrimSpace(model)
+	if want == "" {
+		return nil
+	}
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return fmt.Errorf("persist chat model %s: %w", id, err)
+	}
+	if !ok {
+		return fmt.Errorf("persist chat model %s: %w", id, ErrNotFound)
+	}
+	if strings.TrimSpace(rec.Metadata.Model) == want {
+		return nil
+	}
+	rec.Metadata.Model = want
+	return m.store.UpdateSession(ctx, rec)
 }
 
 // SaveAndTeardownAll captures uncommitted work and tears down every live

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -3374,6 +3374,93 @@ func TestRestore_AppliesProjectAgentConfig(t *testing.T) {
 	}
 }
 
+// TestRestore_RefreshesModelFromSessionMetadata is the regression for the
+// ChatUI ↔ TUI model-persistence bug (#4893). When TUI is rebuilt (from an
+// interface transition or a daemon restore), the harness restore command must
+// carry the model the user last selected in ChatUI — refreshed from the
+// session's durable metadata — rather than silently reverting to the project
+// configured default. It must also still resume the SAME conversation, never
+// minting a new session.
+func TestRestore_RefreshesModelFromSessionMetadata(t *testing.T) {
+	st := newFakeStore()
+	// The project default would otherwise win; the session's own persisted model
+	// (the ChatUI choice) must take precedence for the rebuild.
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{AgentConfig: domain.AgentConfig{Model: "project-default-model"}}}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{
+		WorkspacePath:  "/ws/mer-1",
+		Branch:         "b",
+		AgentSessionID: "agent-x",
+		Model:          "5.6-luna",
+	})
+	agent := &recordingAgent{}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{}, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	res, err := m.RestoreWithMode(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("RestoreWithMode: %v", err)
+	}
+	// The ChatUI model, not the project default, reaches the harness restore cmd.
+	if agent.lastConfig.Model != "5.6-luna" {
+		t.Fatalf("restore config model = %q, want the session's ChatUI choice 5.6-luna", agent.lastConfig.Model)
+	}
+	// History is preserved: the restore resumed the existing native conversation
+	// (agent-x) rather than spawning a new session.
+	if !reflect.DeepEqual(agent.lastRestore.Session.Metadata[ports.MetadataKeyAgentSessionID], "agent-x") {
+		t.Fatalf("resume identity = %q, want agent-x (conversation must be preserved)", agent.lastRestore.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	}
+	if res.Mode != RestoreModeNative {
+		t.Fatalf("restore mode = %q, want native (no new session)", res.Mode)
+	}
+}
+
+// TestPersistChatModel is the regression for the ChatUI-side half of #4893. The
+// manager must record a model the user picked in ChatUI onto the session's
+// durable metadata before the next prompt routes, and a model-only write must
+// never disturb the conversation identity or terminating state.
+func TestPersistChatModel(t *testing.T) {
+	m, st, _, _ := newManager()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath:   "/ws/mer-1",
+			RuntimeHandleID: "h1",
+			AgentSessionID:  "claude-native-1",
+			Branch:          "ao/mer-1",
+		},
+		Activity: domain.Activity{State: domain.ActivityActive},
+	}
+
+	if err := m.PersistChatModel(ctx, "mer-1", "5.6-luna"); err != nil {
+		t.Fatalf("PersistChatModel: %v", err)
+	}
+	rec := st.sessions["mer-1"]
+	if rec.Metadata.Model != "5.6-luna" {
+		t.Fatalf("persisted model = %q, want 5.6-luna", rec.Metadata.Model)
+	}
+	// The conversation/history and terminating state are untouched.
+	if rec.Metadata.AgentSessionID != "claude-native-1" {
+		t.Fatalf("resume identity changed to %q, want claude-native-1 preserved", rec.Metadata.AgentSessionID)
+	}
+	if rec.Metadata.RuntimeHandleID != "h1" {
+		t.Fatalf("runtime handle changed to %q, want h1 preserved", rec.Metadata.RuntimeHandleID)
+	}
+	if rec.Activity.State != domain.ActivityActive || rec.IsTerminated {
+		t.Fatalf("session state changed, want active and non-terminated: %+v", rec)
+	}
+
+	// Persisting an empty model is a no-op: it never clears a durable choice.
+	if err := m.PersistChatModel(ctx, "mer-1", ""); err != nil {
+		t.Fatalf("PersistChatModel(empty): %v", err)
+	}
+	if st.sessions["mer-1"].Metadata.Model != "5.6-luna" {
+		t.Fatalf("empty persist blanked model to %q, want it preserved", st.sessions["mer-1"].Metadata.Model)
+	}
+}
+
 func TestRestore_ForwardsManagerDataDir(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}

--- a/backend/pkg/agentruntime/command.go
+++ b/backend/pkg/agentruntime/command.go
@@ -241,6 +241,9 @@ func buildClaudeRestore(cfg RestoreConfig, identity string) ([]string, error) {
 	cmd = append(cmd, ClaudePermissionArgs(cfg.Permission)...)
 	cmd = appendClaudeToolArgs(cmd, cfg.AllowedTools, cfg.DisallowedTools)
 	cmd = append(cmd, cfg.ProviderArgs...)
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		cmd = append(cmd, "--model", model)
+	}
 	var err error
 	cmd, err = appendClaudeSystemPrompt(cmd, cfg.SystemPromptFile, cfg.SystemPrompt)
 	if err != nil {

--- a/backend/pkg/agentruntime/command_test.go
+++ b/backend/pkg/agentruntime/command_test.go
@@ -165,6 +165,74 @@ func TestBuildRestoreCommands(t *testing.T) {
 	}
 }
 
+// TestBuildRestoreCommandAppliesModel proves every harness restore command
+// carries the model chosen in ChatUI (#4893): rebuilding TUI must pass the
+// session's model through Codex, Claude Code, and Cursor resume commands rather
+// than silently reverting to a different default.
+func TestBuildRestoreCommandAppliesModel(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  RestoreConfig
+		want []string
+	}{
+		{
+			name: "claude",
+			cfg: RestoreConfig{
+				Harness:    HarnessClaudeCode,
+				Binary:     "claude",
+				SessionID:  "session-1",
+				Model:      "claude-4-5",
+				Permission: PermissionBypassPermissions,
+			},
+			want: []string{"claude", "--permission-mode", "bypassPermissions", "--model", "claude-4-5", "--resume", ClaudeSessionID("session-1")},
+		},
+		{
+			name: "codex",
+			cfg: RestoreConfig{
+				Harness:    HarnessCodex,
+				Binary:     "codex",
+				SessionID:  "session-1",
+				Metadata:   map[string]string{MetadataKeyAgentSessionID: "thread-1"},
+				Model:      "gpt-5",
+				Permission: PermissionAuto,
+			},
+			want: []string{
+				"codex", "resume",
+				"-c", "check_for_update_on_startup=false",
+				"-c", "notice.hide_rate_limit_model_nudge=true",
+				"--dangerously-bypass-hook-trust",
+				"--ask-for-approval", "on-request",
+				"-c", `approvals_reviewer="auto_review"`,
+				"--model", "gpt-5",
+				"thread-1",
+			},
+		},
+		{
+			name: "cursor",
+			cfg: RestoreConfig{
+				Harness:    HarnessCursor,
+				Binary:     "cursor-agent",
+				SessionID:  "session-1",
+				Metadata:   map[string]string{MetadataKeyAgentSessionID: "chat-1"},
+				Model:      "claude-4",
+				Permission: PermissionAuto,
+			},
+			want: []string{"cursor-agent", "--force", "--model", "claude-4", "--resume", "chat-1"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok, err := BuildRestoreCommand(test.cfg)
+			if err != nil || !ok {
+				t.Fatalf("BuildRestoreCommand() = (%#v, %v, %v), want command", got, ok, err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("command\nwant: %#v\n got: %#v", test.want, got)
+			}
+		})
+	}
+}
+
 func TestRestoreIdentityRequiresCapturedIDOutsideClaude(t *testing.T) {
 	for _, harness := range []Harness{HarnessCodex, HarnessCursor} {
 		cmd, ok, err := BuildRestoreCommand(RestoreConfig{


### PR DESCRIPTION
Code changes: +103 -3  
Tests: +544 -0  
Others: +19 -0 (generated sqlc)  

## Summary

Fixes #4893 — model selection was not preserved when switching from Chat UI back to TUI.

### Root cause

When ChatUI hands off back to TUI, the interface-transition coordinator rebuilds the TUI via `relaunchSessionWithPolicyAndGeneration`, which derived the harness config from `effectiveAgentConfig(rec.Kind, project.Config)` — the **project-configured** model. A model chosen later in ChatUI (persisted only in conversation settings) was silently discarded, so the rebuilt TUI resumed with the project default (e.g. "5.6 Full") instead of the user's pick (e.g. "5.6 Luna").

### Fix

1. **Persist the selected model before routing the prompt.** `chat.Service.SetTurnSettings` now invokes a new `OnModelChanged` callback whenever the user picks a model; the daemon wires it to the new `sessionmanager.Manager.PersistChatModel`, which writes the model onto the session's durable `Metadata.Model` — a model-only write that never touches the conversation identity or terminating state. The callback is invoked synchronously at pick time, i.e. before any subsequent prompt routes.
2. **Refresh the latest model from the daemon when rebuilding TUI.** Both `relaunchSessionWithPolicyAndGeneration` (the rebuild) and `preflightInterfaceTarget` (which validates the exact restore command the rebuild will run) now override the project-derived `Config.Model` with the session's persisted `Metadata.Model` when set.
3. **Pass the model into every harness restore command.** Codex and Cursor already forwarded `Config.Model` on restore. **Claude Code did not, at two layers**: the adapter's `GetRestoreCommand` now passes `Model`, and `agentruntime.buildClaudeRestore` now appends `--model <model>` (mirroring its own launch path).
4. **Conversation/history preserved, no new session.** Nothing in the change touches resume identity; restore still resumes via the native `agentSessionId`, and the tests pin this.

### Regression tests

- `TestInterfaceTransitionChatToTUIRebuildUsesChatModel` — the Chat→TUI handoff race: interrupt + stop of the old Chat terminal, then the TUI rebuild; asserts both the target preflight and the rebuild carry the ChatUI model (not the project default) while resuming the same native conversation, with exactly one runtime created and the controller order intact.
- `TestRestore_RefreshesModelFromSessionMetadata` — daemon restore picks the session model over the project default and completes in `RestoreModeNative` (no new session).
- `TestPersistChatModel` — the model lands on durable metadata; conversation identity, runtime handle, and activity state are untouched; an empty model never clears a durable choice.
- `TestPersistChatModelPreservesConcurrentLifecycleUpdate` — a real SQLite interleaving proves a model selection cannot replay stale state over a concurrent termination/controller replacement.
- `TestSetTurnSettingsPersistsModelBeforeRouting` — a ChatUI pick persists immediately, re-selecting the same model is a no-op, and a later change supersedes it.
- `TestGetRestoreCommandAppendsConfiguredModel` (Claude Code adapter) and `TestBuildRestoreCommandAppliesModel` (Codex, Claude Code, and Cursor restore argv).

### Validation

- `go build ./...`, `go vet ./...`, `gofmt`, and `golangci-lint` clean.
- `go test` (incl. `-race` on the new paths) green for `internal/session_manager`, `internal/storage/sqlite/store`, `internal/service/chat`, `pkg/agentruntime`, `internal/adapters/agent/{claudecode,codex,cursor}`, and `internal/daemon`.
- `npm run frontend:typecheck` green.

### Intentional omissions

- **No frontend change.** The ChatUI already `PATCH /api/v1/sessions/{id}/conversation/settings`, which is exactly the surface extended here; the persistence and handoff behavior is entirely daemon-side.
- **No API-contract change**, so `npm run api` was not needed: `session.Metadata.Model` was already served by `GET /api/v1/sessions`.
