### PR TITLE
fix: streamline reviewer picker defaults

### DIFF
--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -780,9 +780,6 @@ describe("ProjectSettingsForm", () => {
 		const codexOption = (await screen.findAllByRole("menuitem")).find((option) => option.textContent?.includes("Codex"));
 		expect(codexOption).toBeTruthy();
 		await userEvent.click(codexOption!);
-		expect(screen.queryByRole("menuitem", { name: /GPT-5 Mini/i })).not.toBeInTheDocument();
-		await userEvent.click(reviewer);
-		await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
 		await userEvent.click(await screen.findByRole("menuitem", { name: /GPT-5 Mini/i }));
 		expect(reviewer).toHaveTextContent("Codex · GPT-5 Mini");
 

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -780,6 +780,9 @@ describe("ProjectSettingsForm", () => {
 		const codexOption = (await screen.findAllByRole("menuitem")).find((option) => option.textContent?.includes("Codex"));
 		expect(codexOption).toBeTruthy();
 		await userEvent.click(codexOption!);
+		expect(screen.queryByRole("menuitem", { name: /GPT-5 Mini/i })).not.toBeInTheDocument();
+		await userEvent.click(reviewer);
+		await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
 		await userEvent.click(await screen.findByRole("menuitem", { name: /GPT-5 Mini/i }));
 		expect(reviewer).toHaveTextContent("Codex · GPT-5 Mini");
 
@@ -1127,9 +1130,7 @@ describe("ProjectSettingsForm", () => {
 		await userEvent.click(await screen.findByRole("button", { name: "Default reviewer agent" }));
 		const reviewerLabels = (await screen.findAllByRole("menuitem"))
 			.map((option) => option.textContent)
-			.filter(
-				(label) => label !== "Project default" && label !== "Custom model…" && label !== "Enter model ID…",
-			);
+			.filter((label) => label !== "Project default" && label !== "Enter model ID…");
 
 		expect(reviewerLabels).toEqual([
 			"Claude Code",

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -207,8 +207,11 @@ function ReviewerHarnessOption({
 		enabled: false,
 	});
 	const catalog = catalogQuery.data;
-	const isCurrent = currentHarness === persistHarness;
-	const isCurrentDefaultSelection = isCurrent && currentModel === "" && currentMode === "";
+	const effectiveCurrentHarness =
+		currentHarness || (persistHarness === "" ? (resolvedHarness ?? "") : "");
+	const effectivePersistHarness = persistHarness || resolvedHarness || "";
+	const isCurrentHarness = effectiveCurrentHarness !== "" && effectiveCurrentHarness === effectivePersistHarness;
+	const isCurrentDefaultSelection = isCurrentHarness && currentModel === "" && currentMode === "";
 	const selectDefault = () => onSelect(persistHarness, {});
 
 	if (!resolvedHarness) {
@@ -237,7 +240,7 @@ function ReviewerHarnessOption({
 					<AgentSelectMenuItem
 						agentId={resolvedHarness}
 						label={agent.label}
-						selected={isCurrent}
+						selected={isCurrentHarness}
 						status={agent.status}
 						statusTone={agent.statusTone}
 						disabled={agent.disabled}
@@ -253,7 +256,7 @@ function ReviewerHarnessOption({
 				disabled={agent.disabled}
 				aria-label={agent.status ? `${agent.label}${agent.status}` : agent.label}
 				onClick={(event) => {
-					if (!isCurrentDefaultSelection) {
+					if (!isCurrentHarness) {
 						event.preventDefault();
 						closeMenu();
 						selectDefault();
@@ -263,7 +266,7 @@ function ReviewerHarnessOption({
 				<AgentSelectMenuItem
 					agentId={resolvedHarness}
 					label={agent.label}
-					selected={isCurrent}
+					selected={isCurrentHarness}
 					status={agent.status}
 					statusTone={agent.statusTone}
 					disabled={agent.disabled}
@@ -284,7 +287,7 @@ function ReviewerHarnessOption({
 				) : null}
 				{modelOptions(catalog).map((option) => {
 					const selected =
-						isCurrent &&
+						isCurrentHarness &&
 						((option.kind === "mode" && currentMode === option.value) ||
 							(option.kind === "model" && currentModel === option.value));
 					return (

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -146,12 +146,14 @@ export function ReviewerSelect({
 						currentModel={model}
 						currentMode={mode}
 						onSelect={(nextHarness, nextConfig) => {
+							setMenuOpen(false);
 							onChange(nextHarness);
 							onConfigChange?.(nextHarness, nextConfig);
 						}}
 						projectId={menuProjectID}
 						resolvedHarness={defaultHarness}
 						persistHarness=""
+						closeMenu={() => setMenuOpen(false)}
 					/>
 				) : null}
 				{selectableOptions.map((agent) => (
@@ -162,12 +164,14 @@ export function ReviewerSelect({
 						currentModel={model}
 						currentMode={mode}
 						onSelect={(nextHarness, nextConfig) => {
+							setMenuOpen(false);
 							onChange(nextHarness);
 							onConfigChange?.(nextHarness, nextConfig);
 						}}
 						projectId={menuProjectID}
 						resolvedHarness={agent.id}
 						persistHarness={agent.id}
+						closeMenu={() => setMenuOpen(false)}
 					/>
 				))}
 			</OptionMenuContent>
@@ -184,6 +188,7 @@ function ReviewerHarnessOption({
 	projectId,
 	resolvedHarness,
 	persistHarness,
+	closeMenu,
 }: {
 	agent: Pick<RankedAgentOption, "id" | "label" | "status" | "statusTone" | "disabled">;
 	currentHarness: string;
@@ -193,6 +198,7 @@ function ReviewerHarnessOption({
 	projectId: string;
 	resolvedHarness?: string;
 	persistHarness: string;
+	closeMenu: () => void;
 }) {
 	const { t } = useTranslation();
 	const [open, setOpen] = useState(false);
@@ -202,6 +208,8 @@ function ReviewerHarnessOption({
 	});
 	const catalog = catalogQuery.data;
 	const isCurrent = currentHarness === persistHarness;
+	const isCurrentDefaultSelection = isCurrent && currentModel === "" && currentMode === "";
+	const selectDefault = () => onSelect(persistHarness, {});
 
 	if (!resolvedHarness) {
 		return (
@@ -215,15 +223,14 @@ function ReviewerHarnessOption({
 	}
 
 	const hasChoices = hasModelChoices(catalog);
-	const supportsCustomModel = supportsReviewerCustomModel(catalog);
 	const catalogKnown = catalogQuery.data !== undefined || catalogQuery.isFetched;
 
 	if (catalogKnown && !hasChoices) {
 		return (
 			<>
 				<OptionMenuItem
-					onSelect={() => onSelect(persistHarness, {})}
-					active={isCurrent && currentModel === "" && currentMode === ""}
+					onSelect={selectDefault}
+					active={isCurrentDefaultSelection}
 					className="reviews-agent-menu-item"
 					disabled={agent.disabled}
 				>
@@ -236,29 +243,23 @@ function ReviewerHarnessOption({
 						disabled={agent.disabled}
 					/>
 				</OptionMenuItem>
-				{supportsCustomModel ? (
-					<OptionMenuSub>
-						<OptionMenuSubTrigger
-							className="pl-8 text-sm text-settings-muted"
-							aria-label={t("settings.models.customAgentModelAria", { label: agent.label })}
-							label={t("settings.models.custom")}
-						/>
-						<OptionMenuSubContent className="w-[15rem]">
-							<ReviewerCustomModelOption
-								label={agent.label}
-								currentModel={isCurrent ? currentModel : ""}
-								onSelect={(nextModel) => onSelect(persistHarness, { model: nextModel })}
-							/>
-						</OptionMenuSubContent>
-					</OptionMenuSub>
-				) : null}
 			</>
 		);
 	}
 
 	return (
 		<OptionMenuSub open={open} onOpenChange={setOpen}>
-			<OptionMenuSubTrigger disabled={agent.disabled} aria-label={agent.status ? `${agent.label}${agent.status}` : agent.label}>
+			<OptionMenuSubTrigger
+				disabled={agent.disabled}
+				aria-label={agent.status ? `${agent.label}${agent.status}` : agent.label}
+				onClick={(event) => {
+					if (!isCurrentDefaultSelection) {
+						event.preventDefault();
+						closeMenu();
+						selectDefault();
+					}
+				}}
+			>
 				<AgentSelectMenuItem
 					agentId={resolvedHarness}
 					label={agent.label}
@@ -270,32 +271,16 @@ function ReviewerHarnessOption({
 			</OptionMenuSubTrigger>
 			<OptionMenuSubContent className="w-[15rem]">
 				<OptionMenuItem
-					onSelect={() => onSelect(persistHarness, {})}
-					active={isCurrent && currentModel === "" && currentMode === ""}
+					onSelect={selectDefault}
+					active={isCurrentDefaultSelection}
 				>
 					<span className="flex min-w-0 items-center justify-between gap-3">
 						<span>{t("settings.models.agentDefault")}</span>
-						{isCurrent && currentModel === "" && currentMode === "" ? <Check aria-hidden="true" className="size-4" /> : null}
+						{isCurrentDefaultSelection ? <Check aria-hidden="true" className="size-4" /> : null}
 					</span>
 				</OptionMenuItem>
 				{!catalogKnown ? (
 					<OptionMenuItem disabled>{t("common.loading", { defaultValue: "Loading…" })}</OptionMenuItem>
-				) : null}
-				{catalogKnown && supportsCustomModel ? (
-					<OptionMenuSub>
-						<OptionMenuSubTrigger
-							className="text-sm text-settings-muted"
-							aria-label={t("settings.models.customAgentModelAria", { label: agent.label })}
-							label={t("settings.models.custom")}
-						/>
-						<OptionMenuSubContent className="w-[15rem]">
-							<ReviewerCustomModelOption
-								label={agent.label}
-								currentModel={isCurrent ? currentModel : ""}
-								onSelect={(nextModel) => onSelect(persistHarness, { model: nextModel })}
-							/>
-						</OptionMenuSubContent>
-					</OptionMenuSub>
 				) : null}
 				{modelOptions(catalog).map((option) => {
 					const selected =
@@ -318,61 +303,6 @@ function ReviewerHarnessOption({
 			</OptionMenuSubContent>
 		</OptionMenuSub>
 	);
-}
-
-function ReviewerCustomModelOption({
-	label,
-	currentModel,
-	onSelect,
-}: {
-	label: string;
-	currentModel: string;
-	onSelect: (model: string) => void;
-}) {
-	const { t } = useTranslation();
-	const [customModel, setCustomModel] = useState("");
-	const customModelActionLabel = useMemo(() => {
-		const nextModel = customModel.trim();
-		return nextModel !== ""
-			? t("settings.models.useCustom", { model: nextModel })
-			: t("settings.models.custom");
-	}, [customModel, t]);
-
-	return (
-		<>
-			<div className="p-1" onKeyDown={(event) => event.stopPropagation()}>
-				<input
-					type="text"
-					aria-label={t("settings.models.customAgentModelAria", { label })}
-					value={customModel}
-					onChange={(event) => setCustomModel(event.target.value)}
-					placeholder={currentModel || t("settings.models.custom")}
-					className="settings-inline-input w-full"
-					onKeyDown={(event) => {
-						if (event.key !== "Enter") return;
-						const nextModel = customModel.trim();
-						if (nextModel === "") return;
-						event.preventDefault();
-						onSelect(nextModel);
-					}}
-				/>
-			</div>
-			<OptionMenuItem
-				onSelect={() => {
-					const nextModel = customModel.trim();
-					if (nextModel === "") return;
-					onSelect(nextModel);
-				}}
-				disabled={customModel.trim() === ""}
-			>
-				<span className="min-w-0 truncate">{customModelActionLabel}</span>
-			</OptionMenuItem>
-		</>
-	);
-}
-
-function supportsReviewerCustomModel(catalog?: AgentModelCatalog): boolean {
-	return catalog?.selectionMode === "text" && catalog.allowCustom === true;
 }
 
 function hasModelChoices(catalog?: AgentModelCatalog): boolean {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2993,6 +2993,63 @@ describe("SessionInspector summary reviews", () => {
     );
   });
 
+  it("preserves hidden reviewer config when the explicit override matches the default harness", async () => {
+    getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
+      if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "codex") {
+        return {
+          data: {
+            agentId: "codex",
+            selectionMode: "catalog",
+            models: [
+              { id: "gpt-5", label: "GPT-5", isDefault: true },
+              { id: "gpt-5-mini", label: "GPT-5 Mini" },
+            ],
+            allowCustom: false,
+            source: "official-catalog",
+            fetchedAt: "2026-08-30T00:00:00Z",
+            stale: false,
+          },
+          error: undefined,
+        };
+      }
+      return commonGetsResponder([], "reviewer-pane", [reviewState(3, "needs_review", "sha-1")])(path);
+    });
+    postMock.mockResolvedValue({
+      data: { reviewerHandleId: "", reviews: [] },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    renderWithQuery(
+      <SessionInspector
+        session={session([pr(3, "open")], {
+          provider: "codex",
+          reviewerHarness: "codex",
+          reviewerConfig: { permissions: "bypass-permissions" },
+        })}
+      />,
+    );
+    await openReviewsSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "GPT-5 Mini" })).toBeInTheDocument(),
+    );
+    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(0);
+
+    await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5 Mini" }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { harness: undefined, agentConfig: { model: "gpt-5-mini", permissions: "bypass-permissions" } },
+        },
+      ),
+    );
+  });
+
   it("does not expose arbitrary custom reviewer models from another reviewer row", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models") {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2981,7 +2981,7 @@ describe("SessionInspector summary reviews", () => {
         "/api/v1/sessions/{sessionId}/reviews/switch",
         {
           params: { path: { sessionId: "sess-1" } },
-          body: { agentConfig: { permissions: "bypass-permissions" } },
+          body: { harness: undefined, agentConfig: undefined },
         },
       ),
     );
@@ -2998,7 +2998,7 @@ describe("SessionInspector summary reviews", () => {
         "/api/v1/sessions/{sessionId}/reviews/switch",
         {
           params: { path: { sessionId: "sess-1" } },
-          body: { agentConfig: { model: "gpt-5-mini", permissions: "bypass-permissions" } },
+          body: { harness: undefined, agentConfig: { model: "gpt-5-mini", permissions: "bypass-permissions" } },
         },
       ),
     );
@@ -3049,7 +3049,7 @@ describe("SessionInspector summary reviews", () => {
     expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(1);
   });
 
-  it("shows suggested reviewer models but not arbitrary custom reviewer entry", async () => {
+  it("shows suggested reviewer models after reopening the selected reviewer picker", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models") {
         const agent = options?.params?.path?.agent ?? "";
@@ -3094,6 +3094,17 @@ describe("SessionInspector summary reviews", () => {
     renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
     await openReviewsSection();
 
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^opencode$/i }));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { harness: "opencode" },
+        },
+      ),
+    );
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
     await userEvent.click(await screen.findByRole("menuitem", { name: /^opencode$/i }));
     expect(await screen.findByRole("menuitem", { name: "Suggested A" })).toBeInTheDocument();
@@ -3144,7 +3155,7 @@ describe("SessionInspector summary reviews", () => {
     expect(screen.queryByRole("textbox", { name: /custom opencode/i })).not.toBeInTheDocument();
   });
 
-  it("selects the default reviewer model when clicking a reviewer with model choices", async () => {
+  it("keeps the current default reviewer open for model selection", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "codex") {
         return {
@@ -3178,33 +3189,20 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
 
     await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/api/v1/sessions/{sessionId}/reviews/switch",
-        {
-          params: { path: { sessionId: "sess-1" } },
-          body: { agentConfig: undefined },
-        },
-      ),
-    );
-    expect(screen.queryByRole("menuitem", { name: "GPT-5 Mini" })).not.toBeInTheDocument();
-    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(1);
-
-    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
-    await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
-    await waitFor(() =>
       expect(screen.getByRole("menuitem", { name: "GPT-5 Mini" })).toBeInTheDocument(),
     );
+    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(0);
     await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5 Mini" }));
     await waitFor(() =>
       expect(postMock).toHaveBeenLastCalledWith(
         "/api/v1/sessions/{sessionId}/reviews/switch",
         {
           params: { path: { sessionId: "sess-1" } },
-          body: { agentConfig: { model: "gpt-5-mini" } },
+          body: { harness: undefined, agentConfig: { model: "gpt-5-mini" } },
         },
       ),
     );
-    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(2);
+    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(1);
   });
 
   it("clears hidden session reviewer config when returning an explicit default-matching reviewer to project default", async () => {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2977,20 +2977,9 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
     await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
     await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/api/v1/sessions/{sessionId}/reviews/switch",
-        {
-          params: { path: { sessionId: "sess-1" } },
-          body: { harness: undefined, agentConfig: undefined },
-        },
-      ),
-    );
-    expect(screen.queryByRole("menuitem", { name: "GPT-5 Mini" })).not.toBeInTheDocument();
-    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
-    await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
-    await waitFor(() =>
       expect(screen.getByRole("menuitem", { name: "GPT-5 Mini" })).toBeInTheDocument(),
     );
+    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(0);
     await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5 Mini" }));
 
     await waitFor(() =>

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -2977,6 +2977,18 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
     await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
     await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { agentConfig: { permissions: "bypass-permissions" } },
+        },
+      ),
+    );
+    expect(screen.queryByRole("menuitem", { name: "GPT-5 Mini" })).not.toBeInTheDocument();
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
+    await waitFor(() =>
       expect(screen.getByRole("menuitem", { name: "GPT-5 Mini" })).toBeInTheDocument(),
     );
     await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5 Mini" }));
@@ -2992,7 +3004,7 @@ describe("SessionInspector summary reviews", () => {
     );
   });
 
-  it("allows setting a custom reviewer model from another text-reviewer row before selecting it", async () => {
+  it("does not expose arbitrary custom reviewer models from another reviewer row", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models") {
         const agent = options?.params?.path?.agent ?? "";
@@ -3021,25 +3033,23 @@ describe("SessionInspector summary reviews", () => {
     await openReviewsSection();
 
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
-    await userEvent.click(await screen.findByRole("menuitem", { name: /^custom opencode model$/i }));
-
-    const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
-    await userEvent.type(customInput, "private/custom-model");
-    await userEvent.click(screen.getByRole("menuitem", { name: /use “private\/custom-model” as a custom model/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /^opencode$/i }));
 
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith(
         "/api/v1/sessions/{sessionId}/reviews/switch",
         {
           params: { path: { sessionId: "sess-1" } },
-          body: { harness: "opencode", agentConfig: { model: "private/custom-model" } },
+          body: { harness: "opencode" },
         },
       ),
     );
+    expect(screen.queryByRole("menuitem", { name: /^custom opencode model$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /custom opencode/i })).not.toBeInTheDocument();
     expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(1);
   });
 
-  it("allows custom reviewer models for text-selection catalogs with suggested models", async () => {
+  it("shows suggested reviewer models but not arbitrary custom reviewer entry", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models") {
         const agent = options?.params?.path?.agent ?? "";
@@ -3087,23 +3097,11 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
     await userEvent.click(await screen.findByRole("menuitem", { name: /^opencode$/i }));
     expect(await screen.findByRole("menuitem", { name: "Suggested A" })).toBeInTheDocument();
-    await userEvent.click(await screen.findByRole("menuitem", { name: /^custom opencode model$/i }));
-    const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
-    await userEvent.type(customInput, "private/custom-model");
-    await userEvent.click(screen.getByRole("menuitem", { name: /use “private\/custom-model” as a custom model/i }));
-
-    await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
-        "/api/v1/sessions/{sessionId}/reviews/switch",
-        {
-          params: { path: { sessionId: "sess-1" } },
-          body: { harness: "opencode", agentConfig: { model: "private/custom-model" } },
-        },
-      ),
-    );
+    expect(screen.queryByRole("menuitem", { name: /^custom opencode model$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /custom opencode/i })).not.toBeInTheDocument();
   });
 
-  it("allows a custom reviewer model for text-selection harnesses", async () => {
+  it("allows selecting a text-selection reviewer harness without exposing custom reviewer entry", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models") {
         const agent = options?.params?.path?.agent ?? "";
@@ -3142,25 +3140,11 @@ describe("SessionInspector summary reviews", () => {
         },
       ),
     );
-
-    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
-    await userEvent.click(await screen.findByRole("menuitem", { name: /^custom opencode model$/i }));
-    const customInput = await screen.findByRole("textbox", { name: /custom opencode/i });
-    await userEvent.type(customInput, "private/custom-model");
-    await userEvent.click(screen.getByRole("menuitem", { name: /use “private\/custom-model” as a custom model/i }));
-
-    await waitFor(() =>
-      expect(postMock).toHaveBeenLastCalledWith(
-        "/api/v1/sessions/{sessionId}/reviews/switch",
-        {
-          params: { path: { sessionId: "sess-1" } },
-          body: { harness: "opencode", agentConfig: { model: "private/custom-model" } },
-        },
-      ),
-    );
+    expect(screen.queryByRole("menuitem", { name: /^custom opencode model$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /custom opencode/i })).not.toBeInTheDocument();
   });
 
-  it("does not save an empty reviewer config just by opening a harness submenu", async () => {
+  it("selects the default reviewer model when clicking a reviewer with model choices", async () => {
     getMock.mockImplementation(async (path: string, options?: { params?: { path?: { agent?: string } } }) => {
       if (path === "/api/v1/agents/{agent}/models" && options?.params?.path?.agent === "codex") {
         return {
@@ -3194,13 +3178,25 @@ describe("SessionInspector summary reviews", () => {
     await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
 
     await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith(
+        "/api/v1/sessions/{sessionId}/reviews/switch",
+        {
+          params: { path: { sessionId: "sess-1" } },
+          body: { agentConfig: undefined },
+        },
+      ),
+    );
+    expect(screen.queryByRole("menuitem", { name: "GPT-5 Mini" })).not.toBeInTheDocument();
+    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(1);
+
+    await userEvent.click(await screen.findByRole("button", { name: /Select reviewer agent/ }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: /codex/i }));
+    await waitFor(() =>
       expect(screen.getByRole("menuitem", { name: "GPT-5 Mini" })).toBeInTheDocument(),
     );
-    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(0);
-
     await userEvent.click(screen.getByRole("menuitem", { name: "GPT-5 Mini" }));
     await waitFor(() =>
-      expect(postMock).toHaveBeenCalledWith(
+      expect(postMock).toHaveBeenLastCalledWith(
         "/api/v1/sessions/{sessionId}/reviews/switch",
         {
           params: { path: { sessionId: "sess-1" } },
@@ -3208,7 +3204,7 @@ describe("SessionInspector summary reviews", () => {
         },
       ),
     );
-    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(1);
+    expect(postCallsFor("/api/v1/sessions/{sessionId}/reviews/switch")).toHaveLength(2);
   });
 
   it("clears hidden session reviewer config when returning an explicit default-matching reviewer to project default", async () => {

--- a/frontend/src/renderer/components/ui/option-menu.tsx
+++ b/frontend/src/renderer/components/ui/option-menu.tsx
@@ -125,6 +125,7 @@ export function OptionMenuSubTrigger({
 	label,
 	value,
 	children,
+	onClick,
 	...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
 	label?: string;
@@ -136,7 +137,10 @@ export function OptionMenuSubTrigger({
 			// Stop the click reaching the composer's click-to-focus handler without
 			// calling preventDefault, which Radix's composeEventHandlers reads as a
 			// signal to skip its own open/close handling.
-			onClick={(e) => e.stopPropagation()}
+			onClick={(e) => {
+				e.stopPropagation();
+				onClick?.(e);
+			}}
 			{...props}
 		>
 			{children ?? (


### PR DESCRIPTION
## Summary
- remove arbitrary custom model entry from reviewer selection
- select the reviewer's default model/config on the first agent click
- close the reviewer dropdown immediately after that default selection

## Testing
- attempted: `npm test -- --run frontend/src/renderer/components/ProjectSettingsForm.test.tsx frontend/src/renderer/components/SessionInspector.test.tsx`
- attempted: `npm test -- --run frontend/src/renderer/components/settings/AgentModelCombobox.test.tsx`
- both failed in this worktree because frontend dependencies are not installed, so Vitest could not resolve `vitest/config`, `@vitejs/plugin-react`, and related packages

## Before
<img width="1000" height="621" alt="Screenshot 2026-09-05 at 12 41 49 AM" src="https://github.com/user-attachments/assets/ecabcfdd-cfb6-4307-be7f-f7ff323d3c95" />

## After
<img width="1330" height="858" alt="Screenshot 2026-09-05 at 12 47 24 AM" src="https://github.com/user-attachments/assets/2cd8119a-ba16-4a73-a5d3-73fab1d69dcd" />

## Risks / Follow-ups
- selecting a non-default reviewer model now requires reopening the picker after the initial agent selection, which is covered by the updated tests

