### PR TITLE
fix(chat): handle config options without choices

### DIFF
--- a/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
@@ -87,6 +87,36 @@ describe("ACP session config options", () => {
 		expect(screen.queryByText("More")).not.toBeInTheDocument();
 	});
 
+	it("keeps config controls usable when a select option has no choices", async () => {
+		const user = userEvent.setup();
+		render(
+			<TurnSettingsBar
+				models={[]}
+				settings={{}}
+				configOptions={[
+					{ id: "model", name: "Model", category: "model", type: "select" },
+					{
+						id: "mode",
+						name: "Mode",
+						category: "mode",
+						type: "select",
+						currentValue: "default",
+						choices: [
+							{ value: "default", name: "Default" },
+							{ value: "plan", name: "Plan" },
+							{ value: "auto", name: "Auto" },
+							{ value: "yolo", name: "YOLO" },
+						],
+					},
+				]}
+				onChangeConfigOption={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Model mode for the next turn" }));
+		expect(screen.getByRole("switch", { name: "Plan Mode" })).toBeInTheDocument();
+	});
+
 	it("maps Agent Mode back to the provider's Manual value", async () => {
 		const onChange = vi.fn();
 		const user = userEvent.setup();

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -33,6 +33,7 @@ import { cn } from "../../lib/utils";
 import { Switch } from "../ui/switch";
 import type {
 	ApprovalMode,
+	ChatConfigChoice,
 	ChatConfigOption,
 	ChatConfigOptionValue,
 	ChatModel,
@@ -472,8 +473,8 @@ function PlanModeToggle({
 	onChange: (optionId: string, value: ChatConfigOptionValue) => void;
 }) {
 	const planning = isPlanMode(option);
-	const planChoice = option.choices.find((choice) => isPlanChoice(choice));
-	const agentChoice = option.choices.find((choice) => !isPlanChoice(choice));
+	const planChoice = option.choices?.find((choice) => isPlanChoice(choice));
+	const agentChoice = option.choices?.find((choice) => !isPlanChoice(choice));
 	const next = planning ? agentChoice : planChoice;
 	if (!next) return null;
 	return (
@@ -501,7 +502,7 @@ function ConfigToggle({
 					onChange(option.id, { enabled });
 					return;
 				}
-				const next = option.choices.find((choice) => choiceIsEnabled(choice) === enabled);
+				const next = option.choices?.find((choice) => choiceIsEnabled(choice) === enabled);
 				if (next) onChange(option.id, { value: next.value });
 			}}
 		/>
@@ -670,10 +671,11 @@ function ConfigOptionChoices({
 		);
 	}
 
+	const choices = option.choices ?? [];
 	return (
 		<>
-			{option.choices.map((choice, index) => {
-				const previousGroup = index > 0 ? option.choices[index - 1]?.group : undefined;
+			{choices.map((choice, index) => {
+				const previousGroup = index > 0 ? choices[index - 1]?.group : undefined;
 				return (
 					<Fragment key={choice.value}>
 						{choice.group && choice.group !== previousGroup ? (
@@ -772,10 +774,10 @@ function isInlineToggleOption(option: ChatConfigOption): boolean {
 
 function optionIsEnabled(option: ChatConfigOption): boolean {
 	if (option.type === "boolean") return Boolean(option.currentBoolean);
-	return choiceIsEnabled(option.choices.find((choice) => choice.value === option.currentValue));
+	return choiceIsEnabled(option.choices?.find((choice) => choice.value === option.currentValue));
 }
 
-function choiceIsEnabled(choice: ChatConfigOption["choices"][number] | undefined): boolean {
+function choiceIsEnabled(choice: ChatConfigChoice | undefined): boolean {
 	return Boolean(choice && /(?:^|[\s_-])(on|enabled|true)(?:[\s_-]|$)/i.test(`${choice.name} ${choice.value}`));
 }
 
@@ -798,6 +800,8 @@ function partitionConfigOptions(options: ChatConfigOption[]): {
 	let mode: ChatConfigOption | undefined;
 	for (const option of options) {
 		if (isAgentOption(option)) continue;
+		const choices = option.choices ?? [];
+		if (option.type === "select" && choices.length === 0) continue;
 		if (isModelOption(option)) {
 			if (option.category === "model" || option.id === "model") primaryModel.push(option);
 			else otherModel.push(option);
@@ -812,9 +816,9 @@ function partitionConfigOptions(options: ChatConfigOption[]): {
 			continue;
 		}
 		if (isModeOption(option) && !mode) {
-			const permissionChoices = option.choices.filter((choice) => !isExecutionModeChoice(choice));
+			const permissionChoices = choices.filter((choice) => !isExecutionModeChoice(choice));
 			const executionChoices = addAgentModeChoice(
-				option.choices.filter(isExecutionModeChoice),
+				choices.filter(isExecutionModeChoice),
 				permissionChoices,
 			);
 			if (executionChoices.length > 0) {
@@ -836,7 +840,7 @@ function partitionConfigOptions(options: ChatConfigOption[]): {
  * are not the same decision for a person composing a turn. Preserve the provider
  * values while presenting those choices under their respective controls.
  */
-function isExecutionModeChoice(choice: ChatConfigOption["choices"][number]): boolean {
+function isExecutionModeChoice(choice: ChatConfigChoice): boolean {
 	return /(?:^|[\s_-])(plan|agent)(?:[\s_-]|$)/i.test(`${choice.name} ${choice.value}`);
 }
 
@@ -847,9 +851,9 @@ function isExecutionModeChoice(choice: ChatConfigOption["choices"][number]): boo
  * value. Other harnesses that advertise Agent Mode explicitly stay untouched.
  */
 function addAgentModeChoice(
-	executionChoices: ChatConfigOption["choices"],
-	permissionChoices: ChatConfigOption["choices"],
-): ChatConfigOption["choices"] {
+	executionChoices: ChatConfigChoice[],
+	permissionChoices: ChatConfigChoice[],
+): ChatConfigChoice[] {
 	if (executionChoices.some((choice) => /(?:^|[\s_-])agent(?:[\s_-]|$)/i.test(`${choice.name} ${choice.value}`))) {
 		return executionChoices;
 	}
@@ -864,13 +868,13 @@ function isPlanMode(option: ChatConfigOption | undefined): boolean {
 	return Boolean(option?.currentValue && isPlanChoice({ value: option.currentValue, name: option.currentValue }));
 }
 
-function isPlanChoice(choice: Pick<ChatConfigOption["choices"][number], "name" | "value">): boolean {
+function isPlanChoice(choice: Pick<ChatConfigChoice, "name" | "value">): boolean {
 	return /(?:^|[\s_-])plan(?:[\s_-]|$)/i.test(`${choice.name} ${choice.value}`);
 }
 
 function withChoices(
 	option: ChatConfigOption,
-	choices: ChatConfigOption["choices"],
+	choices: ChatConfigChoice[],
 	name = option.name,
 ): ChatConfigOption {
 	const currentValue = choices.some((choice) => choice.value === option.currentValue)
@@ -881,7 +885,7 @@ function withChoices(
 
 function optionCurrentLabel(option: ChatConfigOption): string {
 	if (option.type === "boolean") return option.currentBoolean ? "On" : "Off";
-	return option.choices.find((choice) => choice.value === option.currentValue)?.name
+	return option.choices?.find((choice) => choice.value === option.currentValue)?.name
 		?? option.currentValue
 		?? option.name;
 }

--- a/frontend/src/renderer/types/conversation.ts
+++ b/frontend/src/renderer/types/conversation.ts
@@ -558,7 +558,7 @@ export interface ChatConfigOption {
 	type: "select" | "boolean";
 	currentValue?: string;
 	currentBoolean?: boolean;
-	choices: ChatConfigChoice[];
+	choices?: ChatConfigChoice[];
 }
 
 /** One value offered by a select config option. */


### PR DESCRIPTION
## What

Prevent the chat turn settings bar from crashing when an ACP select config option omits its choices array. Empty select options are hidden until the provider advertises values.

## Why

Fixes #4868.

ACP providers can advertise a select option before its catalog is ready. The renderer typed choices as required and dereferenced it during render, taking down the entire chat route. This stays defensive even when paired with an older daemon; the API contract mismatch is tracked separately in #4869.

## How

- Make ChatConfigOption.choices optional to match the observed wire payload.
- Skip select options with no available choices during control partitioning.
- Guard every downstream choice lookup and use ChatConfigChoice directly for helper types.
- Add a regression test using the reported model-without-choices payload and verify Plan Mode remains reachable.

## Testing

- PASS: npm --prefix frontend test -- src/renderer/components/chat/TurnSettingsBar.test.tsx (15/15)
- PASS: npm --prefix frontend run typecheck
- Full npm --prefix frontend test: 244 files passed / 24 failed; 3,497 tests passed / 59 failed / 8 skipped. Failures are unrelated platform and worktree-environment cases, including macOS path assertions, Windows symlink permissions, missing landing-only dependencies, locale-specific date assertions, and native asset loading.

## Checklist

- [x] Branched from main
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for the user-visible behavior
- [x] Relevant frontend checks pass