### PR TITLE
fix(browser): Keep browser tabs intact and bounded while dragging

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render as rtlRender, renderHook, screen, waitFor, withi
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
+import { BrowserPanel, BrowserPanelView, BrowserTopTabDragOverlay, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { reorderBrowserTabs } from "../lib/browser-tab-order";
 import { useBrowserView, type BrowserNavState } from "../hooks/useBrowserView";
 import { OPEN_BROWSER_OVERLAY_SELECTOR } from "../lib/dom-selectors";
@@ -706,6 +706,21 @@ describe("BrowserPanel", () => {
 		expect(secondTab).toHaveAttribute("aria-selected", "true");
 		await userEvent.click(firstTab);
 		expect(hookState.selectTab).toHaveBeenCalledWith("t1");
+	});
+
+	it("renders the complete tab chrome in the drag overlay", () => {
+		render(
+			<BrowserTopTabDragOverlay
+				onlyTab={false}
+				tab={{ id: "t1", url: "http://localhost:3000/", title: "First app", active: true }}
+			/>,
+		);
+
+		const overlay = screen.getByTestId("browser-tab-drag-overlay");
+		expect(overlay).toHaveClass("browser-panel__tab--drag-overlay");
+		expect(overlay).toHaveTextContent("First app");
+		expect(overlay.querySelector(".browser-panel__tab-icon")).not.toBeNull();
+		expect(overlay.querySelector(".browser-panel__tab-close")).not.toBeNull();
 	});
 
 	it("moves browser tab focus and selection with arrow keys", async () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -12,12 +12,14 @@ import {
 import { useTranslation } from "react-i18next";
 import {
 	DndContext,
+	DragOverlay,
 	KeyboardSensor,
 	PointerSensor,
 	closestCenter,
 	useSensor,
 	useSensors,
 	type DragEndEvent,
+	type Modifier,
 } from "@dnd-kit/core";
 import {
 	SortableContext,
@@ -110,6 +112,22 @@ const DEVICE_PRESETS: { id: string; label: string; width: number; height: number
 const CUSTOM_DEVICE_PRESET_ID = "custom";
 const MIN_DEVICE_FRAME_WIDTH = 240;
 const MAX_DEVICE_FRAME_WIDTH = 2560;
+
+const restrictBrowserTopTabDragToHorizontalAxis: Modifier = ({
+	activeNodeRect,
+	transform,
+	windowRect,
+}) => {
+	if (!activeNodeRect || !windowRect) return { ...transform, y: 0 };
+	const minX = windowRect.left - activeNodeRect.left;
+	const maxX = windowRect.right - activeNodeRect.right;
+	return {
+		...transform,
+		x: Math.min(maxX, Math.max(minX, transform.x)),
+		y: 0,
+	};
+};
+const browserTopTabDragModifiers = [restrictBrowserTopTabDragToHorizontalAxis];
 
 function clampDeviceFrameWidth(width: number): number | undefined {
 	if (!Number.isFinite(width)) return undefined;
@@ -378,7 +396,8 @@ export function BrowserPanelView({
 	const urlInputRef = useRef<HTMLInputElement>(null);
 	const [pinned, setPinned] = useState(() => window.localStorage.getItem(RAIL_PINNED_STORAGE_KEY) === "1");
 	const showTabsTrigger = !poppedOut && !pinned;
-	const [topTabDragActive, setTopTabDragActive] = useState(false);
+	const [draggedTopTabId, setDraggedTopTabId] = useState<string | null>(null);
+	const draggedTopTab = tabs.find((tab) => tab.id === draggedTopTabId);
 
 	useEffect(() => {
 		if (controlsView !== "profiles" || !window.ao?.browserProfiles) return;
@@ -451,7 +470,7 @@ export function BrowserPanelView({
 	);
 	const handleTopTabDragEnd = useCallback(
 		(event: DragEndEvent) => {
-			setTopTabDragActive(false);
+			setDraggedTopTabId(null);
 			if (!event.over) return;
 			const orderedIds = reorderBrowserTabs(
 				tabs.map((tab) => tab.id),
@@ -679,16 +698,17 @@ export function BrowserPanelView({
 			<div className="browser-panel__tab-bar" data-testid="browser-tab-bar">
 				<DndContext
 					collisionDetection={closestCenter}
-					onDragCancel={() => setTopTabDragActive(false)}
+					modifiers={browserTopTabDragModifiers}
+					onDragCancel={() => setDraggedTopTabId(null)}
 					onDragEnd={handleTopTabDragEnd}
-					onDragStart={() => setTopTabDragActive(true)}
+					onDragStart={({ active }) => setDraggedTopTabId(String(active.id))}
 					sensors={tabSensors}
 				>
 					<SortableContext items={tabs.map((tab) => tab.id)} strategy={horizontalListSortingStrategy}>
 						<div
 							aria-label={t("browser.tabs")}
 							className="browser-panel__tab-strip"
-							onKeyDown={topTabDragActive ? undefined : handleTabListKeyDown}
+							onKeyDown={draggedTopTabId ? undefined : handleTabListKeyDown}
 							role="tablist"
 						>
 							{tabs.map((tab) => (
@@ -703,10 +723,22 @@ export function BrowserPanelView({
 							))}
 						</div>
 					</SortableContext>
+					<DragOverlay
+						adjustScale={false}
+						dropAnimation={null}
+						modifiers={browserTopTabDragModifiers}
+					>
+						{draggedTopTab ? (
+							<BrowserTopTabDragOverlay onlyTab={tabs.length === 1} tab={draggedTopTab} />
+						) : null}
+					</DragOverlay>
 				</DndContext>
 				<button
 					aria-label={t("browser.openNewTab")}
-					className="browser-panel__tab-new"
+					className={cn(
+						"browser-panel__tab-new",
+						draggedTopTabId && "browser-panel__tab-new--dragging",
+					)}
 					onClick={() => void handleOpenTab()}
 					title={t("browser.openNewTab")}
 					type="button"
@@ -1196,7 +1228,7 @@ const SortableBrowserTopTab = memo(function SortableBrowserTopTab({
 			className={cn(
 				"browser-panel__tab",
 				selected && "browser-panel__tab--active",
-				isDragging && "browser-panel__tab--dragging z-chrome opacity-80",
+				isDragging && "browser-panel__tab--drag-placeholder",
 			)}
 			ref={setNodeRef}
 			style={{ transform: CSS.Transform.toString(transform), transition }}
@@ -1229,6 +1261,37 @@ const SortableBrowserTopTab = memo(function SortableBrowserTopTab({
 			>
 				<X aria-hidden="true" className="size-icon-sm" />
 			</button>
+		</div>
+	);
+});
+
+export const BrowserTopTabDragOverlay = memo(function BrowserTopTabDragOverlay({
+	tab,
+	onlyTab,
+}: {
+	tab: BrowserViewModel["tabs"][number];
+	onlyTab: boolean;
+}) {
+	const label = browserTabLabel(tab.title, tab.url);
+	return (
+		<div
+			aria-hidden="true"
+			className="browser-panel__tab browser-panel__tab--drag-overlay"
+			data-testid="browser-tab-drag-overlay"
+		>
+			<div className="browser-panel__tab-select">
+				{tab.favicon ? (
+					<img alt="" className="browser-panel__tab-icon object-cover" src={tab.favicon} />
+				) : (
+					<Globe2 aria-hidden="true" className="browser-panel__tab-icon" />
+				)}
+				<span className="browser-panel__tab-title">{label.title}</span>
+			</div>
+			{onlyTab ? null : (
+				<span className="browser-panel__tab-close">
+					<X aria-hidden="true" className="size-icon-sm" />
+				</span>
+			)}
 		</div>
 	);
 });

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4341,6 +4341,26 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	background: transparent;
 }
 
+.browser-panel__tab--drag-placeholder {
+	opacity: 0;
+	pointer-events: none;
+}
+
+.browser-panel__tab--drag-overlay {
+	width: 100%;
+	min-width: 0;
+	max-width: none;
+	flex: none;
+	color: var(--fg);
+	border-color: color-mix(in srgb, var(--color-border) 72%, transparent);
+	background: var(--surface);
+	box-shadow:
+		inset 0 1px 0 color-mix(in srgb, white 7%, transparent),
+		0 6px 16px color-mix(in srgb, black 22%, transparent);
+	cursor: grabbing;
+	pointer-events: none;
+}
+
 .browser-panel__tab:not(:last-child)::after {
 	position: absolute;
 	top: 8px;
@@ -4357,8 +4377,8 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 .browser-panel__tab:has(+ .browser-panel__tab--active)::after,
 .browser-panel__tab:hover::after,
 .browser-panel__tab:has(+ .browser-panel__tab:hover)::after,
-.browser-panel__tab--dragging::after,
-.browser-panel__tab:has(+ .browser-panel__tab--dragging)::after {
+.browser-panel__tab--drag-placeholder::after,
+.browser-panel__tab:has(+ .browser-panel__tab--drag-placeholder)::after {
 	opacity: 0;
 }
 
@@ -4451,6 +4471,11 @@ body:has(#root .platform-linux) > .browser-popout-overlay {
 	border-radius: 7px;
 	color: var(--fg-muted);
 	background: transparent;
+}
+
+.browser-panel__tab-new--dragging {
+	visibility: hidden;
+	pointer-events: none;
 }
 
 .browser-panel__tab-new:not(:disabled):hover {


### PR DESCRIPTION
## What

Improve popped-out browser tab dragging so tabs retain their full appearance, remain within the browser window, and reorder naturally.

The new-tab button is temporarily hidden during a drag without changing the tab-strip layout.

## Why

Dragging the live flex-sized tab caused its content to collapse visually. The dragged tab could also move beyond the browser window, despite tab detachment not being supported.

## How

- Render the dragged tab in a `DragOverlay` at its measured width.
- Keep an invisible placeholder in the tab strip so neighboring tabs shift to preview the new order.
- Restrict movement to the horizontal axis and clamp it to the browser viewport.
- Hide the new-tab button during active dragging while preserving its layout space.
- Preserve the existing tab selection, closing, and reorder logic.

## Testing

- `npm test -- --run src/renderer/components/BrowserPanel.test.tsx`
  - 1 test file passed
  - 74 tests passed
- Manually verified tab dragging and reordering.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)