### PR TITLE
fix(api): always serialize config option choices

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -8169,6 +8169,7 @@ components:
       - id
       - name
       - type
+      - choices
       type: object
     ConversationConfigOptionsResponse:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build_test.go
+++ b/backend/internal/httpd/apispec/specgen/build_test.go
@@ -69,6 +69,26 @@ func TestBuild_MatchesEmbedded(t *testing.T) {
 	}
 }
 
+func TestBuild_ConfigOptionChoicesAreRequired(t *testing.T) {
+	got, err := specgen.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	var doc struct {
+		Components struct {
+			Schemas map[string]openAPISchemaNode `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(got, &doc); err != nil {
+		t.Fatalf("parse generated OpenAPI: %v", err)
+	}
+
+	required := doc.Components.Schemas["ConversationConfigOptionResponse"].Required
+	if !slices.Contains(required, "choices") {
+		t.Fatalf("ConversationConfigOptionResponse required = %v, missing choices", required)
+	}
+}
+
 func TestBuild_InstallJobTargetRemainsAnEnum(t *testing.T) {
 	got, err := specgen.Build()
 	if err != nil {

--- a/backend/internal/httpd/controllers/conversations_config_options_test.go
+++ b/backend/internal/httpd/controllers/conversations_config_options_test.go
@@ -70,6 +70,33 @@ func TestConfigOptionsRoutePreservesProviderCatalog(t *testing.T) {
 	}
 }
 
+func TestConfigOptionsRouteSerializesEmptyChoices(t *testing.T) {
+	svc := &fakeConversationService{configOptions: []ports.ChatConfigOption{{
+		ID: "model", Name: "Model", Category: "model", Type: ports.ChatConfigOptionSelect,
+	}}}
+	r := chi.NewRouter()
+	(&controllers.ConversationsController{Svc: svc}).Register(r)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/sessions/p1-1/conversation/config-options", nil,
+	))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.Bytes())
+	}
+
+	var got struct {
+		Options []struct {
+			Choices json.RawMessage `json:"choices"`
+		} `json:"options"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Options) != 1 || string(got.Options[0].Choices) != "[]" {
+		t.Fatalf("choices = %s, want [] (body = %s)", got.Options[0].Choices, rec.Body.Bytes())
+	}
+}
+
 func TestSetConfigOptionAcceptsSelectAndBooleanValues(t *testing.T) {
 	svc := &fakeConversationService{configOptions: []ports.ChatConfigOption{}}
 	status, body := configOptionsRequest(t, http.MethodPatch, `{"value":"opus"}`, svc)

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1833,7 +1833,7 @@ type ConversationConfigOptionResponse struct {
 	Type           string                             `json:"type" enum:"select,boolean"`
 	CurrentValue   string                             `json:"currentValue,omitempty"`
 	CurrentBoolean *bool                              `json:"currentBoolean,omitempty"`
-	Choices        []ConversationConfigChoiceResponse `json:"choices,omitempty"`
+	Choices        []ConversationConfigChoiceResponse `json:"choices"`
 }
 
 // ConversationConfigChoiceResponse is one value in a provider select.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2859,7 +2859,7 @@ export interface components {
         };
         ConversationConfigOptionResponse: {
             category?: string;
-            choices?: components["schemas"]["ConversationConfigChoiceResponse"][];
+            choices: components["schemas"]["ConversationConfigChoiceResponse"][];
             currentBoolean?: null | boolean;
             currentValue?: string;
             description?: string;


### PR DESCRIPTION
## What

Always serialize conversation config option choices, including an empty array when the provider has not advertised values yet. Regenerate the OpenAPI contract and typed frontend API client so choices is required.

## Why

Fixes #4869.

The DTO used omitempty while clients treated choices as required. Empty catalogs therefore omitted the field and created an ambiguous wire shape. This is the server-side contract fix behind #4868; defensive renderer compatibility remains in PR #4915.

## How

- Remove omitempty from ConversationConfigOptionResponse.Choices.
- Add a raw-wire regression test asserting an empty catalog serializes as choices: [].
- Add a spec-generation test asserting choices is required.
- Regenerate backend/internal/httpd/apispec/openapi.yaml and frontend/src/api/schema.ts with npm run api.

## Testing

- PASS: go test ./internal/httpd/controllers -run ConfigOption -count=1
- PASS: go test ./internal/httpd/apispec/... -count=1
- PASS: go build ./...
- PASS: npm --prefix frontend run typecheck
- Full go test ./... was run and fails in unrelated Windows/PATH/permission-dependent tests. Examples include missing POSIX sh and agent binaries, symlink privileges, Unix permission assertions, Windows path expectations, and the pre-existing TestProjectsAPI_Clone failure seen on the untouched baseline.

## Checklist

- [x] Branched from main
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for the wire behavior and generated contract
- [x] Relevant backend and frontend checks pass