### PR TITLE
fix(updates): stop a stranded build installing on quit on Windows and Linux

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2568,6 +2568,74 @@ describe("install-on-quit policy", () => {
     }
   });
 
+  // Regression: dropping a stale staged build stopped AO advertising it, but
+  // the build itself stayed in the cache with install-on-quit armed. On Windows
+  // and Linux BaseUpdater.addQuitHandler re-reads autoInstallOnAppQuit at quit
+  // time, so quitting before the replacement landed installed the channel the
+  // user had just left.
+  it("disables install-on-quit while a stale staged build awaits replacement", async () => {
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater({
+      enabled: false,
+      channel: "nightly",
+      nightlyAck: true,
+      feature: null,
+    });
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0-nightly.1" });
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+
+    await module.checkForUpdatesNow(stateDir, {
+      settings: { enabled: false, channel: "latest", nightlyAck: false, feature: null },
+    });
+
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+  });
+
+  it("re-enables install-on-quit once the replacement is staged", async () => {
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater({
+      enabled: false,
+      channel: "nightly",
+      nightlyAck: true,
+      feature: null,
+    });
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0-nightly.1" });
+    await module.checkForUpdatesNow(stateDir, {
+      settings: { enabled: false, channel: "latest", nightlyAck: false, feature: null },
+    });
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+
+    updaterEvents.get("update-downloaded")?.({ version: "2.0.0" });
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+  });
+
+  it("keeps install-on-quit off for an uninstallable location even once replaced", async () => {
+    const restore = stubProcess("darwin", TRANSLOCATED_EXEC_PATH);
+    try {
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater({
+        enabled: false,
+        channel: "nightly",
+        nightlyAck: true,
+        feature: null,
+      });
+
+      await module.checkForUpdatesNow(stateDir);
+      updaterEvents.get("update-downloaded")?.({ version: "2.1.0-nightly.1" });
+      await module.checkForUpdatesNow(stateDir, {
+        settings: { enabled: false, channel: "latest", nightlyAck: false, feature: null },
+      });
+      updaterEvents.get("update-downloaded")?.({ version: "2.0.0" });
+
+      // The location blocker outranks the replacement: nothing installs from a
+      // translocated bundle whatever is staged.
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
   it("leaves install-on-quit on for an installable location", async () => {
     const { root, execPath } = makeBundle();
     const restore = stubProcess("darwin", execPath);

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -596,7 +596,26 @@ function stagedBuildIsStale(
  * stays armed until the replacement finishes downloading; that window is why
  * the replacement download is forced rather than left to the user's preference.
  */
+/**
+ * True from the moment a stale staged build is dropped until a replacement is
+ * staged over it.
+ *
+ * Windows and Linux re-read autoInstallOnAppQuit inside the quit handler
+ * (BaseUpdater.addQuitHandler), so clearing it there genuinely stops the
+ * install. macOS cannot: MacUpdater reads the flag once, at download time, to
+ * decide whether to hand the build to Squirrel, and the ShipIt waiting on
+ * process exit is not recallable.
+ *
+ * So on Windows and Linux this closes the gap completely, and on macOS it is a
+ * no-op that costs nothing. Superseding the build with a correct one stays the
+ * only lever that works on all three.
+ */
+let awaitingStagedReplacement = false;
+
 function discardStagedBuild(): void {
+  // Nothing valid is installable until the replacement lands: the only build in
+  // the cache belongs to a channel the user has left.
+  awaitingStagedReplacement = true;
   forgetPersistedStagedBuild(escalationStateDir);
   offeredReleaseNotes = undefined;
   directFeedReleaseNotes = undefined;
@@ -956,6 +975,9 @@ function wireUpdaterEvents(): void {
       stagedEscalated = false;
     }
     stagedRequestId = activeUpdaterRequestId;
+    // A build is staged again, so install-on-quit has something correct to run.
+    awaitingStagedReplacement = false;
+    applyInstallOnQuitPolicy();
     persistStagedBuild(escalationStateDir);
     automaticCheckPreviousStatus = undefined;
     // A completed automatic download advances the independent baseline; a
@@ -1469,7 +1491,12 @@ export function getMacInstallBlocker(): string | undefined {
 // the staged build wait for a location it can actually install from.
 function applyInstallOnQuitPolicy(): void {
   const blocker = getMacInstallBlocker();
-  autoUpdater.autoInstallOnAppQuit = blocker === undefined;
+  autoUpdater.autoInstallOnAppQuit = blocker === undefined && !awaitingStagedReplacement;
+  if (awaitingStagedReplacement) {
+    console.info(
+      "install-on-quit disabled until the replacement build is staged; the cached one belongs to a channel the user left",
+    );
+  }
   if (blocker !== undefined) {
     console.warn(
       "install-on-quit disabled; the update cannot be installed from here:",


### PR DESCRIPTION
Follow-up to #4849, which is merged.

## Why

#4849 handles a staged build whose channel the user has left by dropping it and staging a correct one over it. Superseding is the only lever **macOS** has: `MacUpdater` reads `autoInstallOnAppQuit` once, at download time, to decide whether to hand the build to Squirrel, and the ShipIt process then waiting on app exit is not recallable.

Windows and Linux are not stuck with that. `BaseUpdater.addQuitHandler` re-reads the flag inside the quit handler:

```js
// BaseUpdater.js
if (!this.autoInstallOnAppQuit) {
    this._logger.info("Update will not be installed on quit because autoInstallOnAppQuit is set to false.");
    return;
}
```

AO never cleared it. `applyInstallOnQuitPolicy` consulted only the macOS location blocker, and `getMacInstallBlocker` returns `undefined` off darwin, so the flag stayed `true`. Between the channel switch and the replacement download finishing, `downloadedUpdateHelper` still pointed at the old installer — so quitting in that window installed the channel the user had just left, on the two platforms where that was avoidable.

## The fix

Install-on-quit is off from the moment a stale build is discarded until a replacement is staged.

- **Windows / Linux** — closes the window completely.
- **macOS** — a no-op. Documented as such in the code, so the asymmetry does not read as an oversight later.

The location blocker still outranks it: nothing installs from a translocated or unwritable bundle whatever is staged. There is a test for that ordering.

If the replacement never lands (the new channel offers nothing, or the download fails), install-on-quit stays off. That is the correct direction: the only build in the cache belongs to a channel the user is no longer on.

## Tests

Three cases in `auto-updater.test.ts`; the two behavioural ones were confirmed to fail without the change. 3188 tests pass, typecheck clean.

## Not verified by execution

Same standing caveat as #4849: **the install step has never been run on any platform.** This is read from `electron-updater`'s source — `BaseUpdater.addQuitHandler` for the Windows/Linux behaviour, `MacUpdater.js` for why macOS cannot do the same. Nobody has exercised a real signed update end to end, on any OS.
