### PR TITLE
fix: support explicit upstream PR claims from fork-backed projects

### DIFF
--- a/backend/internal/cli/claim_config_preservation_test.go
+++ b/backend/internal/cli/claim_config_preservation_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestCanonicalConfigPreservesExistingSettings(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"status":"ok","project":{"id":"demo","config":{"containerReap":{"disabled":true},"reviewers":[{"harness":"codex","agentConfig":{"model":"gpt-5","mode":"high"}}],"env":{"KEEP":"value"}}}}`)
+	writeRunFileFor(t, cfg, srv)
+	deps := Deps{ProcessAlive: func(int) bool { return true }}
+	out, _, err := executeCLI(t, deps, "project", "get", "demo", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got projectGetResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Project.Config == nil {
+		t.Fatal("project get lost config")
+	}
+	got.Project.Config.CanonicalRepoURL = "https://gitlab.com/group/repo"
+	edited, err := json.Marshal(got.Project.Config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := executeCLI(t, deps, "project", "set-config", "demo", "--config-json", string(edited)); err != nil {
+		t.Fatal(err)
+	}
+	var body setConfigRequest
+	if err := json.Unmarshal(capture.body, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Config.ContainerReap == nil || !body.Config.ContainerReap.Disabled {
+		t.Fatalf("container opt-out lost: %s", capture.body)
+	}
+	if len(body.Config.Reviewers) != 1 || body.Config.Reviewers[0].AgentConfig == nil || body.Config.Reviewers[0].AgentConfig.Model != "gpt-5" || body.Config.Reviewers[0].AgentConfig.Mode != "high" {
+		t.Fatalf("reviewer config lost: %s", capture.body)
+	}
+	if body.Config.Env["KEEP"] != "value" || body.Config.CanonicalRepoURL != got.Project.Config.CanonicalRepoURL {
+		t.Fatalf("config lost: %s", capture.body)
+	}
+}

--- a/backend/internal/cli/claim_upstream_test.go
+++ b/backend/internal/cli/claim_upstream_test.go
@@ -13,6 +13,7 @@ import (
 func TestClaimCommandsCanonicalRepository(t *testing.T) {
 	for _, provider := range []struct{ name, origin, canonical, pr string }{
 		{"github", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/acme/repo/pull/7"},
+		{"gitlab custom port", "https://gitlab.example.com:8443/alice/repo", "https://gitlab.example.com:8443/group/sub/repo", "https://gitlab.example.com:8443/group/sub/repo/-/merge_requests/7"},
 		{"gitlab", "https://gitlab.com/alice/team/repo", "https://gitlab.com/group/subgroup/repo", "https://gitlab.com/group/subgroup/repo/-/merge_requests/7"},
 	} {
 		for _, spawn := range []bool{false, true} {

--- a/backend/internal/cli/claim_upstream_test.go
+++ b/backend/internal/cli/claim_upstream_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClaimCommandsCanonicalRepository(t *testing.T) {
+	for _, provider := range []struct{ name, origin, canonical, pr string }{
+		{"github", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/acme/repo/pull/7"},
+		{"gitlab", "https://gitlab.com/alice/team/repo", "https://gitlab.com/group/subgroup/repo", "https://gitlab.com/group/subgroup/repo/-/merge_requests/7"},
+	} {
+		for _, spawn := range []bool{false, true} {
+			for _, ref := range []string{"7", provider.pr} {
+				t.Run(fmt.Sprintf("%s/spawn=%t/%s", provider.name, spawn, ref), func(t *testing.T) {
+					cfg := setConfigEnv(t)
+					var captured claimPRRequest
+					srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						switch {
+						case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/demo":
+							_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "project": projectDetails{ID: "demo", Path: "/repo/demo", Repo: provider.origin, Config: &projectConfig{CanonicalRepoURL: provider.canonical}}})
+						case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions/demo-1":
+							_, _ = io.WriteString(w, `{"session":`+sessionJSON("demo-1", "demo", "worker", "working", false)+`}`)
+						case r.URL.Path == "/api/v1/agents/readiness/ensure":
+							_, _ = io.WriteString(w, authorizedAgentsJSON("codex"))
+						case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
+							_, _ = io.WriteString(w, `{"session":{"id":"demo-1","status":"idle"}}`)
+						case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/demo-1/pr/claim":
+							_ = json.NewDecoder(r.Body).Decode(&captured)
+							_, _ = io.WriteString(w, `{"ok":true,"sessionId":"demo-1","prs":[{"url":"`+provider.pr+`","number":7}],"takenOverFrom":[]}`)
+						default:
+							http.NotFound(w, r)
+						}
+					}))
+					t.Cleanup(srv.Close)
+					writeRunFileFor(t, cfg, srv)
+					args := []string{"session", "claim-pr", "demo-1", ref}
+					if spawn {
+						args = []string{"spawn", "--project", "demo", "--agent", "codex", "--name", "worker", "--claim-pr", ref}
+					}
+					_, _, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, args...)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if captured.PR != provider.pr {
+						t.Fatalf("claim target = %q, want %q", captured.PR, provider.pr)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestProjectSetConfigCanonicalRepo(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"project":{"id":"demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+	_, _, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "project", "set-config", "demo", "--canonical-repo-url", "https://github.com/acme/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(capture.body), `"canonicalRepoURL":"https://github.com/acme/repo"`) {
+		t.Fatalf("body=%s", capture.body)
+	}
+}

--- a/backend/internal/cli/pr_ref.go
+++ b/backend/internal/cli/pr_ref.go
@@ -16,6 +16,9 @@ func (c *commandContext) resolvePRRef(ctx context.Context, ref string, project p
 	}
 	if isNumericPRRef(ref) {
 		repo := strings.TrimSpace(project.Repo)
+		if project.Config != nil && project.Config.CanonicalRepoURL != "" {
+			repo = project.Config.CanonicalRepoURL
+		}
 		if repo == "" {
 			// The daemon must not shell out to external CLIs from its loopback API;
 			// when the durable project record lacks repo_origin_url, the thin CLI
@@ -61,14 +64,14 @@ func cliParsePRURL(raw string) (host, owner, name string, number int, err error)
 	if err != nil {
 		return "", "", "", 0, err
 	}
-	if !strings.EqualFold(u.Scheme, "https") {
+	if !strings.EqualFold(u.Scheme, "https") || u.Hostname() == "" || u.User != nil || u.Port() != "" || u.RawPath != "" {
 		return "", "", "", 0, errors.New("not https")
 	}
 	host = u.Hostname()
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 
 	// GitHub: /owner/repo/pull/N → 4 parts, parts[2] == "pull"
-	if len(parts) == 4 && parts[2] == "pull" {
+	if isCLIGitHubHost(host) && len(parts) == 4 && parts[2] == "pull" {
 		n, parseErr := strconv.Atoi(parts[3])
 		if parseErr != nil || n <= 0 {
 			return "", "", "", 0, errors.New("bad number")
@@ -78,7 +81,7 @@ func cliParsePRURL(raw string) (host, owner, name string, number int, err error)
 
 	// GitLab: /owner/repo/-/merge_requests/N
 	// Supports nested groups: /group/subgroup/repo/-/merge_requests/N
-	if len(parts) >= 5 && parts[len(parts)-2] == "merge_requests" && parts[len(parts)-3] == "-" {
+	if !isCLIGitHubHost(host) && len(parts) >= 5 && parts[len(parts)-2] == "merge_requests" && parts[len(parts)-3] == "-" {
 		n, parseErr := strconv.Atoi(parts[len(parts)-1])
 		if parseErr != nil || n <= 0 {
 			return "", "", "", 0, errors.New("bad number")

--- a/backend/internal/cli/pr_ref.go
+++ b/backend/internal/cli/pr_ref.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -64,10 +65,10 @@ func cliParsePRURL(raw string) (host, owner, name string, number int, err error)
 	if err != nil {
 		return "", "", "", 0, err
 	}
-	if !strings.EqualFold(u.Scheme, "https") || u.Hostname() == "" || u.User != nil || u.Port() != "" || u.RawPath != "" {
+	if !strings.EqualFold(u.Scheme, "https") || u.Hostname() == "" || u.User != nil || u.RawPath != "" {
 		return "", "", "", 0, errors.New("not https")
 	}
-	host = u.Hostname()
+	host = u.Host
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 
 	// GitHub: /owner/repo/pull/N → 4 parts, parts[2] == "pull"
@@ -128,7 +129,7 @@ func cliRepoFromURL(raw string) (host, owner, name string, err error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	host = u.Hostname()
+	host = u.Host
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) < 2 {
 		return "", "", "", errors.New("bad repo")
@@ -144,6 +145,9 @@ func cliRepoFromURL(raw string) (host, owner, name string, err error) {
 }
 
 func isCLIGitHubHost(host string) bool {
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		host = hostname
+	}
 	host = strings.ToLower(host)
 	return host == "github.com" || host == "www.github.com" || host == "api.github.com" ||
 		strings.HasSuffix(host, ".github.com") || strings.HasSuffix(host, ".ghe.io")

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -103,6 +103,7 @@ type reviewerConfig struct {
 // client. The CLI sets common fields via flags and the whole object via
 // --config-json.
 type projectConfig struct {
+	CanonicalRepoURL  string              `json:"canonicalRepoURL,omitempty"`
 	DefaultBranch     string              `json:"defaultBranch,omitempty"`
 	SessionPrefix     string              `json:"sessionPrefix,omitempty"`
 	Env               map[string]string   `json:"env,omitempty"`
@@ -126,6 +127,7 @@ type setConfigRequest struct {
 }
 
 type projectSetConfigOptions struct {
+	canonicalRepoURL  string
 	defaultBranch     string
 	sessionPrefix     string
 	model             string
@@ -319,6 +321,7 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	}
 	f := cmd.Flags()
 	f.StringVar(&opts.defaultBranch, "default-branch", "", "Base branch for new worktrees; auto infers each repository's Git default")
+	f.StringVar(&opts.canonicalRepoURL, "canonical-repo-url", "", "Explicit upstream HTTPS repository URL for PR claims (same provider and host as origin)")
 	f.StringVar(&opts.sessionPrefix, "session-prefix", "", "Displayed session-id prefix")
 	f.StringVar(&opts.model, "model", "", "Agent model override (e.g. claude-opus-4-5)")
 	f.StringVar(&opts.permission, "permission", "", "Permission mode: default, accept-edits, auto, bypass-permissions")
@@ -361,6 +364,7 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 		return projectConfig{}, err
 	}
 	cfg := projectConfig{
+		CanonicalRepoURL:  opts.canonicalRepoURL,
 		DefaultBranch:     opts.defaultBranch,
 		SessionPrefix:     opts.sessionPrefix,
 		Env:               env,

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -96,28 +96,34 @@ type trackerIntakeConfig struct {
 
 // reviewerConfig mirrors domain.ReviewerConfig.
 type reviewerConfig struct {
-	Harness string `json:"harness"`
+	Harness     string       `json:"harness"`
+	AgentConfig *agentConfig `json:"agentConfig,omitempty"`
+}
+
+type containerReapConfig struct {
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // projectConfig mirrors the daemon's typed domain.ProjectConfig for the CLI
 // client. The CLI sets common fields via flags and the whole object via
 // --config-json.
 type projectConfig struct {
-	CanonicalRepoURL  string              `json:"canonicalRepoURL,omitempty"`
-	DefaultBranch     string              `json:"defaultBranch,omitempty"`
-	SessionPrefix     string              `json:"sessionPrefix,omitempty"`
-	Env               map[string]string   `json:"env,omitempty"`
-	Symlinks          []string            `json:"symlinks,omitempty"`
-	PostCreate        []string            `json:"postCreate,omitempty"`
-	AgentRules        string              `json:"agentRules,omitempty"`
-	AgentRulesFile    string              `json:"agentRulesFile,omitempty"`
-	OrchestratorRules string              `json:"orchestratorRules,omitempty"`
-	AgentConfig       agentConfig         `json:"agentConfig,omitempty"`
-	Worker            roleOverride        `json:"worker,omitempty"`
-	Orchestrator      roleOverride        `json:"orchestrator,omitempty"`
-	TrackerIntake     trackerIntakeConfig `json:"trackerIntake,omitempty"`
-	AutoReview        bool                `json:"autoReview,omitempty"`
-	Reviewers         []reviewerConfig    `json:"reviewers,omitempty"`
+	ContainerReap     *containerReapConfig `json:"containerReap,omitempty"`
+	CanonicalRepoURL  string               `json:"canonicalRepoURL,omitempty"`
+	DefaultBranch     string               `json:"defaultBranch,omitempty"`
+	SessionPrefix     string               `json:"sessionPrefix,omitempty"`
+	Env               map[string]string    `json:"env,omitempty"`
+	Symlinks          []string             `json:"symlinks,omitempty"`
+	PostCreate        []string             `json:"postCreate,omitempty"`
+	AgentRules        string               `json:"agentRules,omitempty"`
+	AgentRulesFile    string               `json:"agentRulesFile,omitempty"`
+	OrchestratorRules string               `json:"orchestratorRules,omitempty"`
+	AgentConfig       agentConfig          `json:"agentConfig,omitempty"`
+	Worker            roleOverride         `json:"worker,omitempty"`
+	Orchestrator      roleOverride         `json:"orchestrator,omitempty"`
+	TrackerIntake     trackerIntakeConfig  `json:"trackerIntake,omitempty"`
+	AutoReview        bool                 `json:"autoReview,omitempty"`
+	Reviewers         []reviewerConfig     `json:"reviewers,omitempty"`
 }
 
 // setConfigRequest mirrors the daemon's SetConfigInput body for
@@ -321,7 +327,7 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	}
 	f := cmd.Flags()
 	f.StringVar(&opts.defaultBranch, "default-branch", "", "Base branch for new worktrees; auto infers each repository's Git default")
-	f.StringVar(&opts.canonicalRepoURL, "canonical-repo-url", "", "Explicit upstream HTTPS repository URL for PR claims (same provider and host as origin)")
+	f.StringVar(&opts.canonicalRepoURL, "canonical-repo-url", "", "Explicit upstream HTTPS repository URL for PR claims (same provider, host, and port as origin)")
 	f.StringVar(&opts.sessionPrefix, "session-prefix", "", "Displayed session-id prefix")
 	f.StringVar(&opts.model, "model", "", "Agent model override (e.g. claude-opus-4-5)")
 	f.StringVar(&opts.permission, "permission", "", "Permission mode: default, accept-edits, auto, bypass-permissions")

--- a/backend/internal/domain/projectconfig.go
+++ b/backend/internal/domain/projectconfig.go
@@ -18,6 +18,9 @@ import (
 // yet exist (tracker/SCM per-project config) are intentionally absent and land in
 // focused follow-up PRs alongside the code that reads them.
 type ProjectConfig struct {
+	// CanonicalRepoURL explicitly trusts one upstream repository for PR claims.
+	// Numeric PR references use this repository when set; checkout/push stays on origin.
+	CanonicalRepoURL string `json:"canonicalRepoURL,omitempty"`
 	// DefaultBranch is the base branch new session worktrees are created from.
 	// Empty and DefaultBranchAuto both mean infer each repository's Git default.
 	DefaultBranch string `json:"defaultBranch,omitempty"`
@@ -170,6 +173,11 @@ func (c ProjectConfig) IsZero() bool {
 // Validate rejects values outside the typed vocabulary so a bad config is
 // refused when it is set (CLI/API) rather than surfacing at spawn.
 func (c ProjectConfig) Validate() error {
+	if c.CanonicalRepoURL != "" {
+		if err := c.ValidateCanonicalRepository(c.CanonicalRepoURL); err != nil {
+			return err
+		}
+	}
 	if err := c.AgentConfig.Validate(); err != nil {
 		return err
 	}

--- a/backend/internal/domain/repository_identity.go
+++ b/backend/internal/domain/repository_identity.go
@@ -1,0 +1,87 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// RepositoryIdentity identifies a provider repository, including its entire namespace.
+// Git transport remotes never implicitly authorize additional repositories.
+type RepositoryIdentity struct {
+	Provider  string
+	Host      string
+	Namespace string
+	Name      string
+}
+
+// RepositoryProvider follows the SCM dispatcher: recognized GitHub hosts use
+// GitHub; other hosts use GitLab, including self-managed installations.
+func RepositoryProvider(host string) string {
+	host = strings.ToLower(host)
+	if host == "github.com" || host == "www.github.com" || host == "api.github.com" || strings.HasSuffix(host, ".github.com") || strings.HasSuffix(host, ".ghe.io") {
+		return "github"
+	}
+	return "gitlab"
+}
+
+// ParseRepositoryIdentity accepts repository URLs and Git SSH remotes, never PR URLs.
+func ParseRepositoryIdentity(raw string) (RepositoryIdentity, error) {
+	invalid := errors.New("expected a repository URL with host and full namespace/repository")
+	if raw == "" || strings.TrimSpace(raw) != raw {
+		return RepositoryIdentity{}, invalid
+	}
+	if strings.HasPrefix(raw, "git@") {
+		host, path, ok := strings.Cut(strings.TrimPrefix(raw, "git@"), ":")
+		if !ok {
+			return RepositoryIdentity{}, invalid
+		}
+		raw = "ssh://git@" + host + "/" + path
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return RepositoryIdentity{}, invalid
+	}
+	if (u.Scheme != "https" && u.Scheme != "http" && u.Scheme != "ssh") || u.Hostname() == "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || strings.ContainsAny(u.Path, `\`) {
+		return RepositoryIdentity{}, invalid
+	}
+	if u.Scheme != "ssh" && (u.User != nil || u.Port() != "") {
+		return RepositoryIdentity{}, invalid
+	}
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), "/"), "/")
+	if len(parts) < 2 {
+		return RepositoryIdentity{}, invalid
+	}
+	parts[len(parts)-1] = strings.TrimSuffix(parts[len(parts)-1], ".git")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." || part == "-" || strings.ContainsAny(part, " \t\r\n?#%") {
+			return RepositoryIdentity{}, invalid
+		}
+	}
+	provider := RepositoryProvider(u.Hostname())
+	if provider == "github" && len(parts) != 2 {
+		return RepositoryIdentity{}, invalid
+	}
+	return RepositoryIdentity{Provider: provider, Host: strings.ToLower(u.Hostname()), Namespace: strings.Join(parts[:len(parts)-1], "/"), Name: parts[len(parts)-1]}, nil
+}
+
+// ValidateCanonicalRepository keeps an explicitly selected upstream on the
+// checkout's provider and host. Empty canonical identity preserves origin-only claims.
+func (c ProjectConfig) ValidateCanonicalRepository(origin string) error {
+	if c.CanonicalRepoURL == "" {
+		return nil
+	}
+	upstream, err := ParseRepositoryIdentity(c.CanonicalRepoURL)
+	if err != nil || !strings.HasPrefix(c.CanonicalRepoURL, "https://") {
+		return fmt.Errorf("canonicalRepoURL: use an HTTPS repository URL without credentials, query, fragment, or port")
+	}
+	checkout, err := ParseRepositoryIdentity(origin)
+	if err != nil {
+		return fmt.Errorf("canonicalRepoURL: project must have a valid checkout origin repository")
+	}
+	if upstream.Provider != checkout.Provider || upstream.Host != checkout.Host {
+		return fmt.Errorf("canonicalRepoURL: upstream must use the checkout origin's provider and host (%s)", checkout.Host)
+	}
+	return nil
+}

--- a/backend/internal/domain/repository_identity.go
+++ b/backend/internal/domain/repository_identity.go
@@ -46,7 +46,7 @@ func ParseRepositoryIdentity(raw string) (RepositoryIdentity, error) {
 	if (u.Scheme != "https" && u.Scheme != "http" && u.Scheme != "ssh") || u.Hostname() == "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || strings.ContainsAny(u.Path, `\`) {
 		return RepositoryIdentity{}, invalid
 	}
-	if u.Scheme != "ssh" && (u.User != nil || u.Port() != "") {
+	if u.Scheme != "ssh" && u.Port() != "" {
 		return RepositoryIdentity{}, invalid
 	}
 	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), "/"), "/")
@@ -73,7 +73,8 @@ func (c ProjectConfig) ValidateCanonicalRepository(origin string) error {
 		return nil
 	}
 	upstream, err := ParseRepositoryIdentity(c.CanonicalRepoURL)
-	if err != nil || !strings.HasPrefix(c.CanonicalRepoURL, "https://") {
+	canonicalURL, urlErr := url.Parse(c.CanonicalRepoURL)
+	if err != nil || urlErr != nil || canonicalURL.Scheme != "https" || canonicalURL.User != nil {
 		return fmt.Errorf("canonicalRepoURL: use an HTTPS repository URL without credentials, query, fragment, or port")
 	}
 	checkout, err := ParseRepositoryIdentity(origin)

--- a/backend/internal/domain/repository_identity.go
+++ b/backend/internal/domain/repository_identity.go
@@ -3,14 +3,17 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
 // RepositoryIdentity identifies a provider repository, including its entire namespace.
 // Git transport remotes never implicitly authorize additional repositories.
 type RepositoryIdentity struct {
-	Provider  string
+	Provider string
+	// Host includes an explicit port, matching the SCM provider authority.
 	Host      string
 	Namespace string
 	Name      string
@@ -19,6 +22,9 @@ type RepositoryIdentity struct {
 // RepositoryProvider follows the SCM dispatcher: recognized GitHub hosts use
 // GitHub; other hosts use GitLab, including self-managed installations.
 func RepositoryProvider(host string) string {
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		host = hostname
+	}
 	host = strings.ToLower(host)
 	if host == "github.com" || host == "www.github.com" || host == "api.github.com" || strings.HasSuffix(host, ".github.com") || strings.HasSuffix(host, ".ghe.io") {
 		return "github"
@@ -46,8 +52,14 @@ func ParseRepositoryIdentity(raw string) (RepositoryIdentity, error) {
 	if (u.Scheme != "https" && u.Scheme != "http" && u.Scheme != "ssh") || u.Hostname() == "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.RawPath != "" || strings.ContainsAny(u.Path, `\`) {
 		return RepositoryIdentity{}, invalid
 	}
-	if u.Scheme != "ssh" && u.Port() != "" {
+	if strings.HasSuffix(u.Host, ":") {
 		return RepositoryIdentity{}, invalid
+	}
+	if u.Port() != "" {
+		port, err := strconv.Atoi(u.Port())
+		if err != nil || port < 1 || port > 65535 {
+			return RepositoryIdentity{}, invalid
+		}
 	}
 	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), "/"), "/")
 	if len(parts) < 2 {
@@ -63,7 +75,7 @@ func ParseRepositoryIdentity(raw string) (RepositoryIdentity, error) {
 	if provider == "github" && len(parts) != 2 {
 		return RepositoryIdentity{}, invalid
 	}
-	return RepositoryIdentity{Provider: provider, Host: strings.ToLower(u.Hostname()), Namespace: strings.Join(parts[:len(parts)-1], "/"), Name: parts[len(parts)-1]}, nil
+	return RepositoryIdentity{Provider: provider, Host: strings.ToLower(u.Host), Namespace: strings.Join(parts[:len(parts)-1], "/"), Name: parts[len(parts)-1]}, nil
 }
 
 // ValidateCanonicalRepository keeps an explicitly selected upstream on the
@@ -75,7 +87,7 @@ func (c ProjectConfig) ValidateCanonicalRepository(origin string) error {
 	upstream, err := ParseRepositoryIdentity(c.CanonicalRepoURL)
 	canonicalURL, urlErr := url.Parse(c.CanonicalRepoURL)
 	if err != nil || urlErr != nil || canonicalURL.Scheme != "https" || canonicalURL.User != nil {
-		return fmt.Errorf("canonicalRepoURL: use an HTTPS repository URL without credentials, query, fragment, or port")
+		return fmt.Errorf("canonicalRepoURL: use an HTTPS repository URL without credentials, query, or fragment")
 	}
 	checkout, err := ParseRepositoryIdentity(origin)
 	if err != nil {

--- a/backend/internal/domain/repository_identity_test.go
+++ b/backend/internal/domain/repository_identity_test.go
@@ -21,6 +21,7 @@ func TestCanonicalRepositoryValidation(t *testing.T) {
 		{"credentials", "https://github.com/alice/repo", "https://user:secret@github.com/acme/repo", false},
 		{"traversal", "https://gitlab.com/alice/repo", "https://gitlab.com/acme/../repo", false},
 		{"encoded namespace", "https://gitlab.com/alice/repo", "https://gitlab.com/acme%2fsub/repo", false},
+		{"custom authority", "https://gitlab.example.com:8443/alice/repo", "https://gitlab.example.com:8443/group/sub/repo", true},
 		{"port", "https://github.com/alice/repo", "https://github.com:8443/acme/repo", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/domain/repository_identity_test.go
+++ b/backend/internal/domain/repository_identity_test.go
@@ -8,6 +8,7 @@ func TestCanonicalRepositoryValidation(t *testing.T) {
 		valid                   bool
 	}{
 		{"legacy", "", "", true},
+		{"authenticated checkout origin", "https://git-user:token@github.com/alice/repo.git", "https://github.com/acme/repo", true},
 		{"github fork", "git@github.com:alice/repo.git", "https://github.com/acme/repo", true},
 		{"gitlab nested", "ssh://git@gitlab.example.com/alice/team/repo.git", "https://gitlab.example.com/group/subgroup/repo", true},
 		{"cross host", "https://gitlab.com/alice/repo", "https://gitlab.example.com/group/repo", false},

--- a/backend/internal/domain/repository_identity_test.go
+++ b/backend/internal/domain/repository_identity_test.go
@@ -1,0 +1,32 @@
+package domain
+
+import "testing"
+
+func TestCanonicalRepositoryValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name, origin, canonical string
+		valid                   bool
+	}{
+		{"legacy", "", "", true},
+		{"github fork", "git@github.com:alice/repo.git", "https://github.com/acme/repo", true},
+		{"gitlab nested", "ssh://git@gitlab.example.com/alice/team/repo.git", "https://gitlab.example.com/group/subgroup/repo", true},
+		{"cross host", "https://gitlab.com/alice/repo", "https://gitlab.example.com/group/repo", false},
+		{"cross provider", "https://github.com/alice/repo", "https://gitlab.com/group/repo", false},
+		{"no origin", "", "https://github.com/acme/repo", false},
+		{"remote name", "https://github.com/alice/repo", "upstream", false},
+		{"PR URL", "https://github.com/alice/repo", "https://github.com/acme/repo/pull/7", false},
+		{"MR URL", "https://gitlab.com/alice/repo", "https://gitlab.com/acme/repo/-/merge_requests/7", false},
+		{"query", "https://github.com/alice/repo", "https://github.com/acme/repo?x=y", false},
+		{"credentials", "https://github.com/alice/repo", "https://user:secret@github.com/acme/repo", false},
+		{"traversal", "https://gitlab.com/alice/repo", "https://gitlab.com/acme/../repo", false},
+		{"encoded namespace", "https://gitlab.com/alice/repo", "https://gitlab.com/acme%2fsub/repo", false},
+		{"port", "https://github.com/alice/repo", "https://github.com:8443/acme/repo", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ProjectConfig{CanonicalRepoURL: tc.canonical}
+			if err := cfg.ValidateCanonicalRepository(tc.origin); (err == nil) != tc.valid {
+				t.Fatalf("validation = %v, valid=%v", err, tc.valid)
+			}
+		})
+	}
+}

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -9882,6 +9882,8 @@ components:
           type: string
         autoReview:
           type: boolean
+        canonicalRepoURL:
+          type: string
         containerReap:
           $ref: '#/components/schemas/ContainerReapConfig'
         defaultBranch:

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -1661,7 +1661,7 @@ func writeSessionPRError(w http.ResponseWriter, r *http.Request, err error) {
 	case errors.Is(err, sessionsvc.ErrSessionNoWorkspace):
 		envelope.WriteAPIError(w, r, http.StatusUnprocessableEntity, "unprocessable", "SESSION_NO_WORKSPACE", "Session has no workspace", nil)
 	case errors.Is(err, sessionsvc.ErrProjectMismatch):
-		envelope.WriteAPIError(w, r, http.StatusUnprocessableEntity, "unprocessable", "PR_PROJECT_MISMATCH", "PR does not belong to the session project", nil)
+		envelope.WriteAPIError(w, r, http.StatusUnprocessableEntity, "unprocessable", "PR_PROJECT_MISMATCH", "PR repository must match the project origin or its explicit canonicalRepoURL. For a fork, configure the upstream HTTPS repository URL with ao project set-config <project-id> --canonical-repo-url <url> (replaces config; preserve existing fields with --config-json). Git remotes alone do not grant trust.", nil)
 	case errors.Is(err, sessionsvc.ErrSCMUnavailable):
 		envelope.WriteAPIError(w, r, http.StatusServiceUnavailable, "unavailable", "SCM_UNAVAILABLE", "SCM unavailable", nil)
 	default:

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -2941,6 +2941,13 @@ func TestSessionsAPI_ClaimPRErrors(t *testing.T) {
 			srv := newSessionTestServer(t, svc)
 			body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/pr/claim", tc.body)
 			assertErrorCode(t, body, status, tc.code, tc.want)
+			if tc.want == "PR_PROJECT_MISMATCH" {
+				for _, hint := range []string{"canonicalRepoURL", "--canonical-repo-url", "--config-json", "Git remotes"} {
+					if !strings.Contains(string(body), hint) {
+						t.Fatalf("mismatch missing %q guidance: %s", hint, body)
+					}
+				}
+			}
 		})
 	}
 }

--- a/backend/internal/legacyimport/project_test.go
+++ b/backend/internal/legacyimport/project_test.go
@@ -67,6 +67,9 @@ func TestBuildProjectConfig_RemapAndPreserveMain(t *testing.T) {
 		Tracker:       nonNilNode(),
 	}
 	cfg := buildProjectConfig(pc, &notes)
+	if cfg.CanonicalRepoURL != "" {
+		t.Fatal("legacy import must not infer canonical trust")
+	}
 	if cfg.DefaultBranch != "main" {
 		t.Fatalf("defaultBranch = %q, want explicit main preserved", cfg.DefaultBranch)
 	}

--- a/backend/internal/service/devimport/service_test.go
+++ b/backend/internal/service/devimport/service_test.go
@@ -58,7 +58,17 @@ func TestRunProjectsImportsIntoTarget(t *testing.T) {
 	sourceDir := filepath.Join(t.TempDir(), "source")
 	targetDir := filepath.Join(t.TempDir(), "target")
 	registeredAt := time.Unix(200, 0).UTC()
-	writeProject(t, sourceDir, "alpha", "/repos/alpha", registeredAt)
+	source := writeProject(t, sourceDir, "alpha", "/repos/alpha", registeredAt)
+	original, ok, err := source.GetProject(ctx, "alpha")
+	if err != nil || !ok {
+		t.Fatalf("source project: %v", err)
+	}
+	original.RepoOriginURL = "https://gitlab.com/alice/repo"
+	original.Config.CanonicalRepoURL = "https://gitlab.com/group/subgroup/repo"
+	if err := source.UpsertProject(ctx, original); err != nil {
+		t.Fatal(err)
+	}
+
 	target := openStore(t, targetDir)
 	svc := New(Deps{Store: target, TargetDataDir: targetDir, OpenSource: openReadOnlySource})
 
@@ -80,6 +90,10 @@ func TestRunProjectsImportsIntoTarget(t *testing.T) {
 	if !ok || !got.RegisteredAt.Equal(registeredAt) {
 		t.Fatalf("target project = %#v, want registered_at %s", got, registeredAt)
 	}
+	if got.Config.CanonicalRepoURL != original.Config.CanonicalRepoURL {
+		t.Fatalf("canonical identity lost during native import: %+v", got.Config)
+	}
+
 }
 
 func TestRunProjectsRejectsSameSourceAndTarget(t *testing.T) {
@@ -125,7 +139,7 @@ func openReadOnlySource(ctx context.Context, dataDir string) (SourceStore, error
 	return sqlite.OpenReadOnly(ctx, dataDir)
 }
 
-func writeProject(t *testing.T, dataDir string, id string, path string, registeredAt time.Time) {
+func writeProject(t *testing.T, dataDir string, id string, path string, registeredAt time.Time) *sqlite.Store {
 	t.Helper()
 	store := openStore(t, dataDir)
 	project := domain.ProjectRecord{
@@ -140,4 +154,5 @@ func writeProject(t *testing.T, dataDir string, id string, path string, register
 	if err := store.UpsertWorkspaceProject(context.Background(), project, nil); err != nil {
 		t.Fatal(err)
 	}
+	return store
 }

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -255,6 +255,9 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		}
 		row.Kind = domain.ProjectKindWorkspace
 		row.RepoOriginURL = resolveGitOriginURL(path)
+		if err := row.Config.ValidateCanonicalRepository(row.RepoOriginURL); err != nil {
+			return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
+		}
 		if err := m.store.UpsertWorkspaceProject(ctx, row, repos); err != nil {
 			return Project{}, apierr.Internal("PROJECT_ADD_FAILED", "Failed to register workspace project")
 		}
@@ -273,6 +276,9 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		})
 	}
 	row.RepoOriginURL = resolveGitOriginURL(path)
+	if err := row.Config.ValidateCanonicalRepository(row.RepoOriginURL); err != nil {
+		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
+	}
 	if err := m.store.UpsertProject(ctx, row); err != nil {
 		return Project{}, apierr.Internal("PROJECT_ADD_FAILED", "Failed to register project")
 	}
@@ -600,6 +606,9 @@ func (m *Service) UpdateSettings(ctx context.Context, id domain.ProjectID, in Up
 			return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
 		}
 	}
+	if err := in.Config.ValidateCanonicalRepository(row.RepoOriginURL); err != nil {
+		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
+	}
 	updated, err := m.store.UpdateProjectSettings(ctx, string(id), displayName, in.Config)
 	if err != nil {
 		return Project{}, apierr.Internal("PROJECT_SETTINGS_UPDATE_FAILED", "Failed to update project settings")
@@ -684,6 +693,9 @@ func (m *Service) SetConfig(ctx context.Context, id domain.ProjectID, in SetConf
 			return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
 		}
 	}
+	if err := in.Config.ValidateCanonicalRepository(row.RepoOriginURL); err != nil {
+		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
+	}
 	row.Config = in.Config
 	if err := m.store.UpsertProject(ctx, row); err != nil {
 		return Project{}, apierr.Internal("PROJECT_CONFIG_UPDATE_FAILED", "Failed to update project config")
@@ -692,6 +704,9 @@ func (m *Service) SetConfig(ctx context.Context, id domain.ProjectID, in SetConf
 }
 
 func validateScratchProjectConfig(cfg domain.ProjectConfig) error {
+	if cfg.CanonicalRepoURL != "" {
+		return errors.New("scratch projects do not support canonicalRepoURL")
+	}
 	if strings.TrimSpace(cfg.DefaultBranch) != "" {
 		return errors.New("scratch projects do not support defaultBranch")
 	}

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -1776,3 +1776,54 @@ func TestManager_AddWorkspaceRejectsBareParent(t *testing.T) {
 	_, err := m.Add(ctx, project.AddInput{Path: bareParent, ProjectID: ptr("bare"), AsWorkspace: true})
 	wantCode(t, err, "WORKSPACE_PARENT_BARE")
 }
+
+func TestManager_CanonicalRepositoryConfigPersistence(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := gitRepo(t)
+	if out, err := exec.Command("git", "-C", repo, "remote", "add", "origin", "https://gitlab.com/alice/repo").CombinedOutput(); err != nil {
+		t.Fatalf("origin: %v %s", err, out)
+	}
+	// An unrelated remote must never enter durable claim trust automatically.
+	if out, err := exec.Command("git", "-C", repo, "remote", "add", "upstream", "https://gitlab.com/unrelated/repo").CombinedOutput(); err != nil {
+		t.Fatalf("upstream: %v %s", err, out)
+	}
+	added, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("fork")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if added.Config != nil && added.Config.CanonicalRepoURL != "" {
+		t.Fatal("remote inferred as trusted upstream")
+	}
+	cfg := domain.ProjectConfig{CanonicalRepoURL: "https://gitlab.com/group/subgroup/repo", DefaultBranch: "main"}
+	if _, err := m.SetConfig(ctx, "fork", project.SetConfigInput{Config: cfg}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.Get(ctx, "fork")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Project.Config == nil || got.Project.Config.CanonicalRepoURL != cfg.CanonicalRepoURL {
+		t.Fatalf("stored config = %+v", got.Project.Config)
+	}
+	for _, target := range []string{"https://github.com/group/repo", "https://gitlab.example.com/group/subgroup/repo"} {
+		bad := domain.ProjectConfig{CanonicalRepoURL: target}
+		if _, err := m.SetConfig(ctx, "fork", project.SetConfigInput{Config: bad}); err == nil {
+			t.Fatalf("SetConfig accepted %s", target)
+		}
+		if _, err := m.UpdateSettings(ctx, "fork", project.UpdateSettingsInput{DisplayName: "Fork", Config: bad}); err == nil {
+			t.Fatalf("UpdateSettings accepted %s", target)
+		}
+	}
+	got, err = m.Get(ctx, "fork")
+	if err != nil || got.Project.Config == nil || got.Project.Config.CanonicalRepoURL != cfg.CanonicalRepoURL {
+		t.Fatalf("invalid write changed config: %+v %v", got.Project.Config, err)
+	}
+	if _, err := m.SetConfig(ctx, "fork", project.SetConfigInput{}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = m.Get(ctx, "fork")
+	if err != nil || (got.Project.Config != nil && got.Project.Config.CanonicalRepoURL != "") {
+		t.Fatalf("clear: %+v %v", got.Project.Config, err)
+	}
+}

--- a/backend/internal/service/session/claim_port_test.go
+++ b/backend/internal/service/session/claim_port_test.go
@@ -2,8 +2,9 @@ package session
 
 import (
 	"context"
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 func TestClaimPRSSHPortPreserved(t *testing.T) {

--- a/backend/internal/service/session/claim_port_test.go
+++ b/backend/internal/service/session/claim_port_test.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"context"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"testing"
+)
+
+func TestClaimPRSSHPortPreserved(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["demo-1"] = domain.SessionRecord{ID: "demo-1", ProjectID: "demo", Kind: domain.KindWorker, Metadata: domain.SessionMetadata{WorkspacePath: "/ws"}}
+	st.projects["demo"] = domain.ProjectRecord{ID: "demo", RepoOriginURL: "ssh://git@gitlab.example.com:8443/alice/repo.git"}
+	scm := &claimTargetSCM{}
+	svc := NewWithDeps(Deps{Store: st, SCM: scm, PRClaimer: &fakePRClaimer{}})
+	_, err := svc.ClaimPR(context.Background(), "demo-1", "7", ClaimPROptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scm.refs[0].Repo.Host != "gitlab.example.com:8443" {
+		t.Fatalf("claim changed SCM authority to %q; expected explicit origin port 8443", scm.refs[0].Repo.Host)
+	}
+}
+func TestClaimPRHTTPSPortOriginStillClaimable(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["demo-1"] = domain.SessionRecord{ID: "demo-1", ProjectID: "demo", Kind: domain.KindWorker, Metadata: domain.SessionMetadata{WorkspacePath: "/ws"}}
+	st.projects["demo"] = domain.ProjectRecord{ID: "demo", RepoOriginURL: "https://gitlab.example.com:8443/alice/repo.git"}
+	svc := NewWithDeps(Deps{Store: st, SCM: &claimTargetSCM{}, PRClaimer: &fakePRClaimer{}})
+	_, err := svc.ClaimPR(context.Background(), "demo-1", "7", ClaimPROptions{})
+	if err != nil {
+		t.Fatalf("previously supported HTTPS origin is no longer claimable: %v", err)
+	}
+}

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -415,10 +415,10 @@ func parsePRURL(raw string) (host, owner, name string, number int, err error) {
 	if err != nil {
 		return "", "", "", 0, err
 	}
-	if !strings.EqualFold(u.Scheme, "https") || u.Hostname() == "" || u.User != nil || u.Port() != "" || u.RawPath != "" {
+	if !strings.EqualFold(u.Scheme, "https") || u.Hostname() == "" || u.User != nil || u.RawPath != "" {
 		return "", "", "", 0, ErrInvalidPRRef
 	}
-	host = u.Hostname()
+	host = u.Host
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 
 	// GitHub: /owner/repo/pull/N → 4 parts, parts[2] == "pull"

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -86,17 +86,23 @@ func (s *Service) ClaimPR(ctx context.Context, id domain.SessionID, ref string, 
 	if project.Kind.WithDefault() == domain.ProjectKindScratch {
 		return ClaimPRResult{}, ErrSessionNotClaimable
 	}
-	prURL, number, err := normalizePRRef(ref, project.RepoOriginURL)
+	if err := project.Config.ValidateCanonicalRepository(project.RepoOriginURL); err != nil {
+		return ClaimPRResult{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
+	}
+	claimOrigin := firstNonEmpty(project.Config.CanonicalRepoURL, project.RepoOriginURL)
+	prURL, number, err := normalizePRRef(ref, claimOrigin)
 	if err != nil {
 		return ClaimPRResult{}, err
 	}
 	if err := requireSameRepo(prURL, project.RepoOriginURL); err != nil {
-		return ClaimPRResult{}, err
+		if project.Config.CanonicalRepoURL == "" || requireSameRepo(prURL, project.Config.CanonicalRepoURL) != nil {
+			return ClaimPRResult{}, err
+		}
 	}
 	if s.scm == nil || s.prClaimer == nil {
 		return ClaimPRResult{}, ErrSCMUnavailable
 	}
-	repo, err := scmRepoForClaim(s.scm, project.RepoOriginURL, prURL)
+	repo, err := scmRepoForClaim(prURL)
 	if err != nil {
 		return ClaimPRResult{}, err
 	}
@@ -192,10 +198,7 @@ func (s *Service) enrichClaimReviews(ctx context.Context, ref ports.SCMPRRef, ob
 	return ports.ReviewWriteReplace, nil
 }
 
-func scmRepoForClaim(provider scmProvider, projectOrigin, prURL string) (ports.SCMRepo, error) {
-	if repo, ok := provider.ParseRepository(projectOrigin); ok {
-		return repo, nil
-	}
+func scmRepoForClaim(prURL string) (ports.SCMRepo, error) {
 	host, owner, name, _, err := parsePRURL(prURL)
 	if err != nil {
 		return ports.SCMRepo{}, ErrInvalidPRRef
@@ -207,12 +210,7 @@ func scmRepoForClaim(provider scmProvider, projectOrigin, prURL string) (ports.S
 // multi-provider dispatcher. GitHub hosts return "github"; everything else is
 // treated as GitLab to match the multi-provider's registration order.
 func providerKey(host string) string {
-	host = strings.ToLower(host)
-	if host == "github.com" || host == "www.github.com" || host == "api.github.com" ||
-		strings.HasSuffix(host, ".github.com") || strings.HasSuffix(host, ".ghe.io") {
-		return "github"
-	}
-	return "gitlab"
+	return domain.RepositoryProvider(host)
 }
 
 func claimRowsFromSCM(sessionID domain.SessionID, obs ports.SCMObservation, now time.Time, sessionRecord domain.SessionRecord) (domain.PullRequest, []domain.PullRequestCheck, []domain.PullRequestReview, []domain.PullRequestReviewThread, []domain.PullRequestComment) {
@@ -389,7 +387,7 @@ func prURLFromParts(host, owner, repo string, number int) string {
 
 func requireSameRepo(prURL, repoOrigin string) error {
 	if strings.TrimSpace(repoOrigin) == "" {
-		return nil
+		return ErrProjectMismatch
 	}
 	prHost, prOwner, prRepo, _, err := parsePRURL(prURL)
 	if err != nil {
@@ -417,16 +415,19 @@ func parsePRURL(raw string) (host, owner, name string, number int, err error) {
 	if err != nil {
 		return "", "", "", 0, err
 	}
-	if !strings.EqualFold(u.Scheme, "https") {
+	if !strings.EqualFold(u.Scheme, "https") || u.Hostname() == "" || u.User != nil || u.Port() != "" || u.RawPath != "" {
 		return "", "", "", 0, ErrInvalidPRRef
 	}
 	host = u.Hostname()
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 
 	// GitHub: /owner/repo/pull/N → 4 parts, parts[2] == "pull"
-	if len(parts) == 4 && parts[2] == "pull" {
+	if providerKey(host) == "github" && len(parts) == 4 && parts[2] == "pull" {
 		n, parseErr := strconv.Atoi(parts[3])
 		if parseErr != nil || n <= 0 {
+			return "", "", "", 0, ErrInvalidPRRef
+		}
+		if _, err := domain.ParseRepositoryIdentity("https://" + host + "/" + strings.Join(parts[:2], "/")); err != nil {
 			return "", "", "", 0, ErrInvalidPRRef
 		}
 		return host, parts[0], strings.TrimSuffix(parts[1], ".git"), n, nil
@@ -434,7 +435,7 @@ func parsePRURL(raw string) (host, owner, name string, number int, err error) {
 
 	// GitLab: /owner/repo/-/merge_requests/N → parts[2] == "-", parts[3] == "merge_requests"
 	// Supports nested groups: /group/subgroup/repo/-/merge_requests/N
-	if len(parts) >= 5 && parts[len(parts)-2] == "merge_requests" && parts[len(parts)-3] == "-" {
+	if providerKey(host) == "gitlab" && len(parts) >= 5 && parts[len(parts)-2] == "merge_requests" && parts[len(parts)-3] == "-" {
 		n, parseErr := strconv.Atoi(parts[len(parts)-1])
 		if parseErr != nil || n <= 0 {
 			return "", "", "", 0, ErrInvalidPRRef
@@ -442,6 +443,9 @@ func parsePRURL(raw string) (host, owner, name string, number int, err error) {
 		// owner = everything before "-"; name = the last segment before "-"
 		repoParts := parts[:len(parts)-3]
 		if len(repoParts) < 2 {
+			return "", "", "", 0, ErrInvalidPRRef
+		}
+		if _, err := domain.ParseRepositoryIdentity("https://" + host + "/" + strings.Join(repoParts, "/")); err != nil {
 			return "", "", "", 0, ErrInvalidPRRef
 		}
 		owner = strings.Join(repoParts[:len(repoParts)-1], "/")
@@ -453,48 +457,11 @@ func parsePRURL(raw string) (host, owner, name string, number int, err error) {
 }
 
 func repoFromURL(raw string) (host, owner, name string, err error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", "", "", ErrInvalidPRRef
-	}
-	if strings.HasPrefix(raw, "git@") {
-		rest := strings.TrimPrefix(raw, "git@")
-		colonIdx := strings.Index(rest, ":")
-		if colonIdx < 0 {
-			return "", "", "", ErrInvalidPRRef
-		}
-		host = rest[:colonIdx]
-		path := strings.TrimSuffix(rest[colonIdx+1:], ".git")
-		parts := strings.Split(path, "/")
-		if len(parts) < 2 {
-			return "", "", "", ErrInvalidPRRef
-		}
-		for _, seg := range parts {
-			if seg == "" {
-				return "", "", "", ErrInvalidPRRef
-			}
-		}
-		name = parts[len(parts)-1]
-		owner = strings.Join(parts[:len(parts)-1], "/")
-		return host, owner, name, nil
-	}
-	u, err := url.Parse(raw)
+	identity, err := domain.ParseRepositoryIdentity(raw)
 	if err != nil {
-		return "", "", "", err
-	}
-	host = u.Hostname()
-	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-	if len(parts) < 2 {
 		return "", "", "", ErrInvalidPRRef
 	}
-	for _, seg := range parts {
-		if seg == "" {
-			return "", "", "", ErrInvalidPRRef
-		}
-	}
-	name = strings.TrimSuffix(parts[len(parts)-1], ".git")
-	owner = strings.Join(parts[:len(parts)-1], "/")
-	return host, owner, name, nil
+	return identity.Host, identity.Namespace, identity.Name, nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/backend/internal/service/session/claim_upstream_test.go
+++ b/backend/internal/service/session/claim_upstream_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -26,6 +27,8 @@ func TestClaimPRExplicitCanonicalRepository(t *testing.T) {
 		wantErr                                         error
 	}{
 		{"authenticated checkout origin", "https://git-user:token@github.com/alice/repo.git", "https://github.com/acme/repo", "7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
+		{"gitlab custom port", "https://gitlab.example.com:8443/alice/repo", "https://gitlab.example.com:8443/group/sub/repo", "7", "group/sub/repo", "https://gitlab.example.com:8443/group/sub/repo/-/merge_requests/7", nil},
+		{"SSH custom port", "ssh://git@gitlab.example.com:8443/alice/repo.git", "", "7", "alice/repo", "https://gitlab.example.com:8443/alice/repo/-/merge_requests/7", nil},
 		{"github upstream URL", "git@github.com:alice/repo.git", "https://github.com/acme/repo", "https://github.com/acme/repo/pull/7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
 		{"github upstream number", "https://github.com/alice/repo", "https://github.com/acme/repo", "7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
 		{"origin remains trusted", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/alice/repo/pull/7", "alice/repo", "https://github.com/alice/repo/pull/7", nil},
@@ -38,7 +41,7 @@ func TestClaimPRExplicitCanonicalRepository(t *testing.T) {
 		{"full namespace", "https://gitlab.com/alice/repo", "https://gitlab.com/group/sub/repo", "https://gitlab.com/other/sub/repo/-/merge_requests/7", "", "", ErrProjectMismatch},
 		{"nested prefix", "https://gitlab.com/alice/repo", "https://gitlab.com/group/sub/repo", "https://gitlab.com/sub/repo/-/merge_requests/7", "", "", ErrProjectMismatch},
 		{"wrong provider route", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/acme/repo/-/merge_requests/7", "", "", ErrInvalidPRRef},
-		{"port cannot collapse", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com:8443/acme/repo/pull/7", "", "", ErrInvalidPRRef},
+		{"port authority cannot collapse", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com:8443/acme/repo/pull/7", "", "", ErrProjectMismatch},
 		{"no identity", "", "", "https://github.com/acme/repo/pull/7", "", "", ErrProjectMismatch},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -61,8 +64,32 @@ func TestClaimPRExplicitCanonicalRepository(t *testing.T) {
 			if len(scm.refs) != 1 || scm.refs[0].Repo.Repo != tc.wantRepo || scm.refs[0].URL != tc.wantURL {
 				t.Fatalf("SCM target = %+v", scm.refs)
 			}
+			if !strings.HasPrefix(tc.wantURL, "https://"+scm.refs[0].Repo.Host+"/"+scm.refs[0].Repo.Repo+"/") {
+				t.Fatalf("SCM authority lost: %+v", scm.refs[0])
+			}
 			if !claimer.called || claimer.gotPR.Repo != tc.wantRepo || claimer.gotPR.URL != tc.wantURL {
 				t.Fatalf("persisted claim = %+v", claimer.gotPR)
+			}
+		})
+	}
+}
+
+func TestClaimPRRejectsInvalidPersistedCanonicalIdentity(t *testing.T) {
+	for _, canonical := range []string{"upstream", "https://gitlab.com/acme/repo", "https://evil.ghe.io/acme/repo"} {
+		t.Run(canonical, func(t *testing.T) {
+			st := newFakeStore()
+			st.sessions["demo-1"] = domain.SessionRecord{ID: "demo-1", ProjectID: "demo", Kind: domain.KindWorker, Metadata: domain.SessionMetadata{WorkspacePath: "/ws"}}
+			// Native imports copy durable config without running the project service's
+			// validation. Claims must validate it again before any provider access.
+			st.projects["demo"] = domain.ProjectRecord{ID: "demo", RepoOriginURL: "https://github.com/alice/repo", Config: domain.ProjectConfig{CanonicalRepoURL: canonical}}
+			scm := &claimTargetSCM{}
+			claimer := &fakePRClaimer{}
+			svc := NewWithDeps(Deps{Store: st, SCM: scm, PRClaimer: claimer})
+			if _, err := svc.ClaimPR(context.Background(), "demo-1", "7", ClaimPROptions{}); err == nil {
+				t.Fatal("invalid persisted identity authorized claim")
+			}
+			if len(scm.refs) != 0 || claimer.called {
+				t.Fatal("invalid config reached SCM or storage")
 			}
 		})
 	}

--- a/backend/internal/service/session/claim_upstream_test.go
+++ b/backend/internal/service/session/claim_upstream_test.go
@@ -25,6 +25,7 @@ func TestClaimPRExplicitCanonicalRepository(t *testing.T) {
 		name, origin, canonical, ref, wantRepo, wantURL string
 		wantErr                                         error
 	}{
+		{"authenticated checkout origin", "https://git-user:token@github.com/alice/repo.git", "https://github.com/acme/repo", "7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
 		{"github upstream URL", "git@github.com:alice/repo.git", "https://github.com/acme/repo", "https://github.com/acme/repo/pull/7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
 		{"github upstream number", "https://github.com/alice/repo", "https://github.com/acme/repo", "7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
 		{"origin remains trusted", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/alice/repo/pull/7", "alice/repo", "https://github.com/alice/repo/pull/7", nil},

--- a/backend/internal/service/session/claim_upstream_test.go
+++ b/backend/internal/service/session/claim_upstream_test.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type claimTargetSCM struct {
+	fakeSCM
+	refs []ports.SCMPRRef
+}
+
+func (f *claimTargetSCM) FetchPullRequests(_ context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
+	f.refs = refs
+	ref := refs[0]
+	return []ports.SCMObservation{{Fetched: true, Provider: ref.Repo.Provider, Host: ref.Repo.Host, Repo: ref.Repo.Repo, PR: ports.SCMPRObservation{URL: ref.URL, Number: ref.Number}}}, nil
+}
+
+func TestClaimPRExplicitCanonicalRepository(t *testing.T) {
+	for _, tc := range []struct {
+		name, origin, canonical, ref, wantRepo, wantURL string
+		wantErr                                         error
+	}{
+		{"github upstream URL", "git@github.com:alice/repo.git", "https://github.com/acme/repo", "https://github.com/acme/repo/pull/7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
+		{"github upstream number", "https://github.com/alice/repo", "https://github.com/acme/repo", "7", "acme/repo", "https://github.com/acme/repo/pull/7", nil},
+		{"origin remains trusted", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/alice/repo/pull/7", "alice/repo", "https://github.com/alice/repo/pull/7", nil},
+		{"gitlab nested upstream URL", "git@gitlab.com:alice/team/repo.git", "https://gitlab.com/group/subgroup/repo.git", "https://gitlab.com/group/subgroup/repo/-/merge_requests/7", "group/subgroup/repo", "https://gitlab.com/group/subgroup/repo/-/merge_requests/7", nil},
+		{"gitlab nested upstream number", "https://gitlab.example.com/alice/repo", "https://gitlab.example.com/group/subgroup/repo", "#7", "group/subgroup/repo", "https://gitlab.example.com/group/subgroup/repo/-/merge_requests/7", nil},
+		{"unconfigured upstream", "https://github.com/alice/repo", "", "https://github.com/acme/repo/pull/7", "", "", ErrProjectMismatch},
+		{"unrelated remote", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/other/repo/pull/7", "", "", ErrProjectMismatch},
+		{"cross host", "https://gitlab.com/alice/repo", "https://gitlab.com/group/sub/repo", "https://gitlab.example.com/group/sub/repo/-/merge_requests/7", "", "", ErrProjectMismatch},
+		{"cross provider", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://gitlab.com/acme/repo/-/merge_requests/7", "", "", ErrProjectMismatch},
+		{"full namespace", "https://gitlab.com/alice/repo", "https://gitlab.com/group/sub/repo", "https://gitlab.com/other/sub/repo/-/merge_requests/7", "", "", ErrProjectMismatch},
+		{"nested prefix", "https://gitlab.com/alice/repo", "https://gitlab.com/group/sub/repo", "https://gitlab.com/sub/repo/-/merge_requests/7", "", "", ErrProjectMismatch},
+		{"wrong provider route", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com/acme/repo/-/merge_requests/7", "", "", ErrInvalidPRRef},
+		{"port cannot collapse", "https://github.com/alice/repo", "https://github.com/acme/repo", "https://github.com:8443/acme/repo/pull/7", "", "", ErrInvalidPRRef},
+		{"no identity", "", "", "https://github.com/acme/repo/pull/7", "", "", ErrProjectMismatch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeStore()
+			st.sessions["demo-1"] = domain.SessionRecord{ID: "demo-1", ProjectID: "demo", Kind: domain.KindWorker, Metadata: domain.SessionMetadata{WorkspacePath: "/ws"}}
+			st.projects["demo"] = domain.ProjectRecord{ID: "demo", RepoOriginURL: tc.origin, Config: domain.ProjectConfig{CanonicalRepoURL: tc.canonical}}
+			scm := &claimTargetSCM{}
+			claimer := &fakePRClaimer{}
+			svc := NewWithDeps(Deps{Store: st, SCM: scm, PRClaimer: claimer})
+			_, err := svc.ClaimPR(context.Background(), "demo-1", tc.ref, ClaimPROptions{})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantErr != nil {
+				if len(scm.refs) != 0 || claimer.called {
+					t.Fatal("rejected claim reached SCM or storage")
+				}
+				return
+			}
+			if len(scm.refs) != 1 || scm.refs[0].Repo.Repo != tc.wantRepo || scm.refs[0].URL != tc.wantURL {
+				t.Fatalf("SCM target = %+v", scm.refs)
+			}
+			if !claimer.called || claimer.gotPR.Repo != tc.wantRepo || claimer.gotPR.URL != tc.wantURL {
+				t.Fatalf("persisted claim = %+v", claimer.gotPR)
+			}
+		})
+	}
+}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -3721,22 +3721,6 @@ func TestClaimRowsFromSCMSnapshotsSessionReviewPolicy(t *testing.T) {
 	}
 }
 
-// noopSCMProvider implements scmProvider but always fails ParseRepository
-// to exercise the scmRepoForClaim fallback path.
-type noopSCMProvider struct{}
-
-func (noopSCMProvider) ParseRepository(string) (ports.SCMRepo, bool) { return ports.SCMRepo{}, false }
-func (noopSCMProvider) FetchPullRequests(_ context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error) {
-	out := make([]ports.SCMObservation, len(refs))
-	for i := range out {
-		out[i].Error = ports.ErrSCMNotFound
-	}
-	return out, nil
-}
-func (noopSCMProvider) FetchReviewThreads(context.Context, ports.SCMPRRef) (ports.SCMReviewObservation, error) {
-	return ports.SCMReviewObservation{}, nil
-}
-
 func (f fakeSCM) ParseRepository(remote string) (ports.SCMRepo, bool) {
 	host, owner, repo, err := repoFromURL(remote)
 	if err != nil {
@@ -4054,7 +4038,7 @@ func TestRequireSameRepoGitLab(t *testing.T) {
 	}{
 		{"matching gitlab", "https://gitlab.com/castai/ctxd/-/merge_requests/9", "https://gitlab.com/castai/ctxd", nil},
 		{"matching github", "https://github.com/owner/repo/pull/42", "https://github.com/owner/repo", nil},
-		{"empty origin allows any", "https://gitlab.com/castai/ctxd/-/merge_requests/9", "", nil},
+		{"empty origin rejects", "https://gitlab.com/castai/ctxd/-/merge_requests/9", "", ErrProjectMismatch},
 		{"mismatch", "https://gitlab.com/castai/ctxd/-/merge_requests/9", "https://github.com/other/repo", ErrProjectMismatch},
 		{"gitlab mismatch repo", "https://gitlab.com/castai/ctxd/-/merge_requests/9", "https://gitlab.com/other/repo", ErrProjectMismatch},
 		// Cross-provider mismatch: same owner/repo name on GitHub and GitLab
@@ -4085,10 +4069,8 @@ func TestRequireSameRepoGitLab(t *testing.T) {
 }
 
 func TestScmRepoForClaimGitLab(t *testing.T) {
-	// When the provider cannot parse the origin, the fallback should detect
-	// GitLab from the PR URL and set Provider="gitlab".
-	var noopProvider noopSCMProvider
-	repo, err := scmRepoForClaim(noopProvider, "", "https://gitlab.com/castai/ctxd/-/merge_requests/9")
+	// The SCM target comes from the claimed URL, including its provider.
+	repo, err := scmRepoForClaim("https://gitlab.com/castai/ctxd/-/merge_requests/9")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -130,6 +130,7 @@ var shippedMigrations = map[int64]string{
 	123: "0123_agent_install_jobs.sql",
 	124: "0124_codex_account_management.sql",
 	125: "0125_agent_switch_failure_observability.sql",
+	126: "0126_canonical_repository_identity.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_canonical_repository_test.go
+++ b/backend/internal/storage/sqlite/migrate_canonical_repository_test.go
@@ -1,0 +1,51 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigrateCanonicalRepositoryPreservesExplicitTrust(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	upTo(t, db, 125)
+	for _, seed := range []struct {
+		id     string
+		config any
+	}{
+		{"legacy", `{"defaultBranch":"main","worker":{"agent":"codex"}}`},
+		{"explicit", `{"canonicalRepoURL":"https://gitlab.com/group/subgroup/repo"}`},
+		{"empty", nil},
+	} {
+		if _, err := db.Exec(`INSERT INTO projects(id,path,repo_origin_url,registered_at,config) VALUES(?,?,?,CURRENT_TIMESTAMP,?)`, seed.id, "/repo/"+seed.id, "https://gitlab.com/alice/repo", seed.config); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	var canonical, branch, agent string
+	if err := db.QueryRow(`SELECT json_extract(config,'$.canonicalRepoURL'),json_extract(config,'$.defaultBranch'),json_extract(config,'$.worker.agent') FROM projects WHERE id='legacy'`).Scan(&canonical, &branch, &agent); err != nil {
+		t.Fatal(err)
+	}
+	if canonical != "" || branch != "main" || agent != "codex" {
+		t.Fatalf("legacy config changed: %q %q %q", canonical, branch, agent)
+	}
+	if err := db.QueryRow(`SELECT json_extract(config,'$.canonicalRepoURL') FROM projects WHERE id='explicit'`).Scan(&canonical); err != nil {
+		t.Fatal(err)
+	}
+	if canonical != "https://gitlab.com/group/subgroup/repo" {
+		t.Fatalf("explicit trust changed: %q", canonical)
+	}
+	var config sql.NullString
+	if err := db.QueryRow(`SELECT config FROM projects WHERE id='empty'`).Scan(&config); err != nil {
+		t.Fatal(err)
+	}
+	if config.Valid {
+		t.Fatal("NULL config changed")
+	}
+}

--- a/backend/internal/storage/sqlite/migrations/0126_canonical_repository_identity.sql
+++ b/backend/internal/storage/sqlite/migrations/0126_canonical_repository_identity.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Existing projects explicitly retain origin-only claim trust. Do not discover
+-- remotes or infer an upstream during upgrade. NULL configs still mean defaults.
+UPDATE projects
+SET config = json_set(config, '$.canonicalRepoURL', '')
+WHERE config IS NOT NULL AND json_valid(config)
+  AND json_type(config, '$.canonicalRepoURL') IS NULL;
+
+-- +goose Down
+-- Preserve explicit trust configuration on downgrade, like other project settings.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -246,8 +246,10 @@ ao project set-config my-project \
 `ao project get my-project --json`, preserve its `project.config` fields, add
 `canonicalRepoURL`, and submit the complete object with `--config-json`. The same
 object is accepted by `PUT /api/v1/projects/{id}/config` as `{"config": {...}}`.
-Use an HTTPS repository URL, without a PR/MR suffix, credentials, query, fragment,
-or port. Self-managed GitLab URLs and nested namespaces are supported.
+Use an HTTPS repository URL, without a PR/MR suffix, credentials, query, or fragment.
+Self-managed GitLab URLs and nested namespaces are supported. Explicit ports
+are preserved and must match too; `gitlab.example.com:8443` is a different
+authority from `gitlab.example.com`.
 
 Both `ao session claim-pr 42` and `ao spawn --claim-pr 42` resolve numbers against
 canonical when configured, otherwise origin. A full PR/MR URL may name either

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -226,3 +226,39 @@ actions.
 
 Do not port old in-process TypeScript CLI behavior that mixed command handling
 with storage and runtime implementation details.
+
+### Claiming upstream PRs from a fork
+
+The registered origin remains the checkout and push repository. An optional
+`canonicalRepoURL` in project config explicitly authorizes one upstream repository
+for PR claims. Git remotes, including a remote named `upstream`, never grant claim
+permission automatically. Both identities must have the same provider and host;
+claims match the entire namespace and repository, including GitLab subgroups.
+
+For a project with no other config:
+
+```bash
+ao project set-config my-project \
+  --canonical-repo-url https://github.com/my-org/my-repo
+```
+
+`set-config` replaces the whole config. For an existing configured project, read
+`ao project get my-project --json`, preserve its `project.config` fields, add
+`canonicalRepoURL`, and submit the complete object with `--config-json`. The same
+object is accepted by `PUT /api/v1/projects/{id}/config` as `{"config": {...}}`.
+Use an HTTPS repository URL, without a PR/MR suffix, credentials, query, fragment,
+or port. Self-managed GitLab URLs and nested namespaces are supported.
+
+Both `ao session claim-pr 42` and `ao spawn --claim-pr 42` resolve numbers against
+canonical when configured, otherwise origin. A full PR/MR URL may name either
+identity. Unrelated repositories and different hosts/providers remain rejected.
+Removing `canonicalRepoURL` restores origin-only claims. This does not unlink PRs
+already claimed or move existing worktrees. Repository identity is read at claim
+time, so existing sessions need no restart or duplicate project.
+
+Migration 0126 adds an empty canonical identity to existing non-NULL config JSON
+where absent, preserving all other settings and any explicit canonical value.
+NULL configs retain their defaults. No Git discovery runs during migration, and
+no earlier migration is modified. Downgrading preserves config data; older
+versions do not support canonical claims and may drop this field when saving
+project settings.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3506,6 +3506,7 @@ export interface components {
             agentRules?: string;
             agentRulesFile?: string;
             autoReview?: boolean;
+            canonicalRepoURL?: string;
             containerReap?: components["schemas"]["ContainerReapConfig"];
             defaultBranch?: string;
             env?: {

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -413,6 +413,7 @@ describe("ProjectSettingsForm", () => {
 			repo: "git@github.com:acme/project-one.git",
 			defaultBranch: "main",
 			config: {
+				canonicalRepoURL: "https://github.com/upstream/project-one",
 				defaultBranch: "develop",
 				sessionPrefix: "po",
 				env: { FOO: "bar" },
@@ -463,6 +464,7 @@ describe("ProjectSettingsForm", () => {
 				displayName: "Project One",
 				config: expect.objectContaining({
 					// Hidden workflow config is preserved
+					canonicalRepoURL: "https://github.com/upstream/project-one",
 					defaultBranch: "develop",
 					sessionPrefix: "po",
 					env: { FOO: "bar" },


### PR DESCRIPTION
Fork-backed projects currently reject PRs in their upstream repository. Add an explicit `canonicalRepoURL` project setting so claims can target the origin or one deliberately configured upstream, while checkout/push configuration stays on origin.

- Keep provider, host (including explicit ports), and full namespace checks strict. Never derive claim trust from arbitrary Git remotes. Reject malformed/provider-inconsistent PR URLs before SCM access.
- Resolve numeric references against canonical when set in both `ao session claim-pr` and `ao spawn --claim-pr`, and fetch SCM facts from the actual claimed repository.
- Validate config through daemon project services, persist it in project config JSON, and add migration 0126 preserving existing settings and origin-only defaults. Regenerate the API schema and document config replacement and downgrade behavior.
- Add GitHub and GitLab fork/upstream tests, including self-managed GitLab and nested namespaces, rejected targets, CLI parity, API guidance, config persistence, and migration compatibility.

Validation on the final implementation:

- Full backend suite: `go test -p 2 ./...` with inherited AO runtime variables unset.
- Focused race tests for canonical identity, port handling, and project configuration.
- Full golangci-lint v2.12.2 with an isolated cache: zero issues.
- `npm run api`, HTTP/spec tests, and `npm run frontend:typecheck`.
- All 40 `ProjectSettingsForm` tests, including canonical identity preservation.
- GitHub/GitLab claim and spawn regressions, authenticated origins, custom-port authorities, CLI config read/edit/write preservation, native/legacy import behavior, and migration compatibility.

The initial independent review found custom-port authority loss and CLI config field loss. Both are fixed with reproductions committed, replies posted, and threads resolved. All 11 CI checks pass at `03e35f532b9688652c1bcab52ab121fad8d801e0`. Independent re-review of this exact head is still required; do not merge based on an earlier head's approval.

Scope: canonical identity authorizes PR claims only. It does not change checkout/push remotes, infer fork relationships, retarget tracker intake, or unlink already claimed PRs when config changes.

Closes #4927
