### PR TITLE
fix(cleanup): stop counting already-gone workspaces as reclaimed

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -97,6 +97,7 @@ var _ ports.Workspace = (*Workspace)(nil)
 var _ ports.WorkspaceDefaultBranchRefresher = (*Workspace)(nil)
 var _ ports.WorkspaceProject = (*Workspace)(nil)
 var _ ports.WorkspaceObserver = (*Workspace)(nil)
+var _ ports.WorkspaceReclaimer = (*Workspace)(nil)
 
 // New builds a gitworktree Workspace, validating that ManagedRoot and
 // RepoResolver are set and resolving the root to an absolute, symlink-free path.
@@ -411,59 +412,83 @@ func (w *Workspace) DestroyWorkspaceProject(ctx context.Context, info ports.Work
 // Destroy removes the session's worktree and prunes it from the repo, refusing
 // (rather than force-deleting) if git still has the path registered afterwards.
 func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error {
+	_, err := w.destroy(ctx, info)
+	return err
+}
+
+// DestroyReclaim is Destroy plus the reclaim outcome. A worktree directory that
+// was already gone before this call leaves nothing for `git worktree remove` to
+// operate on: the prune below still clears the stale registration and the final
+// os.RemoveAll is a no-op on a missing path, so the whole teardown reports
+// success without any disk having been released. Callers that count reclaimed
+// workspaces need that told apart from a real removal.
+func (w *Workspace) DestroyReclaim(ctx context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
+	return w.destroy(ctx, info)
+}
+
+func (w *Workspace) destroy(ctx context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
 	if info.Path == "" {
-		return fmt.Errorf("%w: empty path", ErrUnsafePath)
+		return ports.WorkspaceReclaimAlreadyAbsent, fmt.Errorf("%w: empty path", ErrUnsafePath)
 	}
 	repo, err := w.repoPathForInfo(info)
 	if err != nil {
-		return err
+		return ports.WorkspaceReclaimAlreadyAbsent, err
 	}
 	path, err := w.validateManagedPath(info.Path)
 	if err != nil {
-		return err
+		return ports.WorkspaceReclaimAlreadyAbsent, err
+	}
+	// Sampled before any teardown step runs, so it reflects the state this call
+	// found rather than the state it left behind. Only a definite absence counts
+	// as already-absent; a stat that fails for any other reason (permissions, a
+	// racing writer) stays on the removed path so an unknown is never reported
+	// as "nothing to do".
+	reclaim := ports.WorkspaceReclaimRemoved
+	if _, statErr := os.Lstat(path); errors.Is(statErr, os.ErrNotExist) {
+		reclaim = ports.WorkspaceReclaimAlreadyAbsent
 	}
 	if err := w.requireReachableRepo(repo); err != nil {
-		return err
+		return reclaim, err
 	}
 	// Move the directory aside rather than waiting out `git worktree remove`'s
 	// walk of an ignored-file mountain; falls through to the git-driven path
 	// below whenever the move is not clearly safe.
 	if handled, err := w.discardWorktree(ctx, repo, path); handled {
-		return err
+		return reclaim, err
 	}
 	_, removeErr := w.run(ctx, w.binary, worktreeRemoveArgs(repo, path)...)
 	if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
-		return fmt.Errorf("gitworktree: worktree prune: %w", err)
+		return reclaim, fmt.Errorf("gitworktree: worktree prune: %w", err)
 	}
 	records, err := w.listRecords(ctx, repo)
 	if err != nil {
-		return err
+		return reclaim, err
 	}
 	if _, ok := findWorktree(records, path); ok {
 		if removeErr != nil {
 			if isLockedWorktreeRemoveError(removeErr) {
-				return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w)", path, removeErr)
+				return reclaim, fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w)", path, removeErr)
 			}
 			// Distinguish the dirty-worktree refusal (uncommitted agent work)
 			// from other registration leftovers (e.g. a locked worktree) so the
 			// Session Manager can preserve the workspace without erroring.
 			dirty, statusErr := w.isDirty(ctx, path)
 			if statusErr == nil && dirty {
-				return fmt.Errorf("gitworktree: refusing to remove %q: %w (worktree remove: %w)", path, ports.ErrWorkspaceDirty, removeErr)
+				return reclaim, fmt.Errorf("gitworktree: refusing to remove %q: %w (worktree remove: %w)", path, ports.ErrWorkspaceDirty, removeErr)
 			}
 			if statusErr != nil {
 				// A failed probe must stay visible: without it the caller can't
 				// tell "not dirty" from "couldn't check".
-				return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w; dirty probe: %w)", path, removeErr, statusErr)
+				return reclaim, fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w; dirty probe: %w)", path, removeErr, statusErr)
 			}
-			return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w)", path, removeErr)
+			return reclaim, fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w)", path, removeErr)
 		}
-		return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune", path)
+		return reclaim, fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune", path)
 	}
 	if err := removeAllWithRetry(ctx, path); err != nil {
-		return fmt.Errorf("gitworktree: remove unregistered path %q: %w", path, err)
+		return reclaim, fmt.Errorf("gitworktree: remove unregistered path %q: %w", path, err)
 	}
-	return nil
+	return reclaim, nil
 }
 
 // ForceDestroy removes the session's worktree unconditionally (--force), prunes

--- a/backend/internal/adapters/workspace/gitworktree/workspace_reclaim_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_reclaim_test.go
@@ -1,0 +1,94 @@
+package gitworktree
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// TestDestroyReclaimReportsAlreadyAbsentWorktree covers the accounting half of
+// teardown. A worktree directory that is already gone leaves `git worktree
+// remove` nothing to act on; the prune still clears the stale registration and
+// the final os.RemoveAll is a documented no-op on a missing path, so Destroy
+// returns nil having reclaimed nothing. Callers that count reclaimed
+// workspaces from that nil report space they never freed, so DestroyReclaim
+// has to name the two cases apart.
+func TestDestroyReclaimReportsAlreadyAbsentWorktree(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	root := filepath.Join(tmp, "managed")
+	ws, err := New(Options{Binary: git, ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	cfg := ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess-absent", Branch: "feature/absent"}
+
+	info, err := ws.Create(ctx, cfg)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// The directory disappears behind AO's back while git still has it
+	// registered: an external `rm -rf`, a wiped scratch disk, a restored backup.
+	if err := os.RemoveAll(info.Path); err != nil {
+		t.Fatalf("remove worktree dir: %v", err)
+	}
+
+	reclaim, err := ws.DestroyReclaim(ctx, info)
+	if err != nil {
+		t.Fatalf("destroy reclaim: %v", err)
+	}
+	if reclaim != ports.WorkspaceReclaimAlreadyAbsent {
+		t.Fatalf("reclaim = %q, want %q", reclaim, ports.WorkspaceReclaimAlreadyAbsent)
+	}
+
+	// The stale registration is still reconciled, so the post-state matches a
+	// real removal; only the accounting differs.
+	records, err := ws.listRecords(ctx, repo)
+	if err != nil {
+		t.Fatalf("list records: %v", err)
+	}
+	if _, ok := findWorktree(records, info.Path); ok {
+		t.Fatalf("worktree %q still registered after DestroyReclaim", info.Path)
+	}
+}
+
+// TestDestroyReclaimReportsRemovedWorktree pins the other side: a workspace
+// that was really there must not be reported as already absent, or the fix
+// would trade one wrong count for another.
+func TestDestroyReclaimReportsRemovedWorktree(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	root := filepath.Join(tmp, "managed")
+	ws, err := New(Options{Binary: git, ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	cfg := ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess-present", Branch: "feature/present"}
+
+	info, err := ws.Create(ctx, cfg)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, statErr := os.Stat(info.Path); statErr != nil {
+		t.Fatalf("precondition: worktree missing before destroy: %v", statErr)
+	}
+
+	reclaim, err := ws.DestroyReclaim(ctx, info)
+	if err != nil {
+		t.Fatalf("destroy reclaim: %v", err)
+	}
+	if reclaim != ports.WorkspaceReclaimRemoved {
+		t.Fatalf("reclaim = %q, want %q", reclaim, ports.WorkspaceReclaimRemoved)
+	}
+	if _, statErr := os.Stat(info.Path); !os.IsNotExist(statErr) {
+		t.Fatalf("path after destroy stat err = %v, want not exist", statErr)
+	}
+}

--- a/backend/internal/adapters/workspace/router/router.go
+++ b/backend/internal/adapters/workspace/router/router.go
@@ -40,6 +40,7 @@ var _ ports.Workspace = (*Workspace)(nil)
 var _ ports.WorkspaceDefaultBranchRefresher = (*Workspace)(nil)
 var _ ports.WorkspaceProject = (*Workspace)(nil)
 var _ ports.WorkspaceObserver = (*Workspace)(nil)
+var _ ports.WorkspaceReclaimer = (*Workspace)(nil)
 
 // New returns a router over git and scratch workspace implementations.
 func New(deps Deps) *Workspace {
@@ -88,6 +89,21 @@ func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error
 		return err
 	}
 	return adapter.Destroy(ctx, info)
+}
+
+// DestroyReclaim delegates teardown to the project-appropriate adapter and
+// reports whether that adapter actually released anything. An adapter that does
+// not report reclaim outcomes falls back to Destroy, whose nil error keeps the
+// pre-existing meaning of a completed removal.
+func (w *Workspace) DestroyReclaim(ctx context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
+	adapter, err := w.adapterForProject(ctx, info.ProjectID)
+	if err != nil {
+		return ports.WorkspaceReclaimAlreadyAbsent, err
+	}
+	if reclaimer, ok := adapter.(ports.WorkspaceReclaimer); ok {
+		return reclaimer.DestroyReclaim(ctx, info)
+	}
+	return ports.WorkspaceReclaimRemoved, adapter.Destroy(ctx, info)
 }
 
 // ForceDestroy delegates forced session workspace cleanup to the

--- a/backend/internal/adapters/workspace/scratch/workspace.go
+++ b/backend/internal/adapters/workspace/scratch/workspace.go
@@ -24,6 +24,7 @@ type Workspace struct {
 
 var _ ports.Workspace = (*Workspace)(nil)
 var _ ports.WorkspaceObserver = (*Workspace)(nil)
+var _ ports.WorkspaceReclaimer = (*Workspace)(nil)
 
 // New validates ManagedRoot and returns a scratch workspace adapter.
 func New(opts Options) (*Workspace, error) {
@@ -71,22 +72,42 @@ func (w *Workspace) Restore(_ context.Context, cfg ports.WorkspaceConfig) (ports
 
 // Destroy removes only an empty scratch directory. Non-empty directories are
 // treated as dirty user work and preserved.
-func (w *Workspace) Destroy(_ context.Context, info ports.WorkspaceInfo) error {
+func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error {
+	_, err := w.destroy(ctx, info)
+	return err
+}
+
+// DestroyReclaim is Destroy plus the reclaim outcome. os.Remove is tolerated on
+// a missing path, so a scratch directory that was already gone tears down
+// without error while releasing nothing; callers counting reclaimed workspaces
+// need that separated from a real removal.
+func (w *Workspace) DestroyReclaim(ctx context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
+	return w.destroy(ctx, info)
+}
+
+func (w *Workspace) destroy(_ context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
 	path, err := w.validateManagedPath(info.Path)
 	if err != nil {
-		return err
+		return ports.WorkspaceReclaimAlreadyAbsent, err
+	}
+	// Only a definite absence counts as already-absent; any other stat failure
+	// stays on the removed path so an unknown is never reported as "nothing to
+	// do".
+	reclaim := ports.WorkspaceReclaimRemoved
+	if _, statErr := os.Lstat(path); errors.Is(statErr, os.ErrNotExist) {
+		reclaim = ports.WorkspaceReclaimAlreadyAbsent
 	}
 	nonEmpty, err := pathExistsNonEmpty(path)
 	if err != nil {
-		return err
+		return reclaim, err
 	}
 	if nonEmpty {
-		return fmt.Errorf("scratch workspace: preserve non-empty %q: %w", path, ports.ErrWorkspaceDirty)
+		return reclaim, fmt.Errorf("scratch workspace: preserve non-empty %q: %w", path, ports.ErrWorkspaceDirty)
 	}
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("scratch workspace: remove empty %q: %w", path, err)
+		return reclaim, fmt.Errorf("scratch workspace: remove empty %q: %w", path, err)
 	}
-	return nil
+	return reclaim, nil
 }
 
 // ForceDestroy intentionally follows Destroy semantics for scratch. Normal AO

--- a/backend/internal/adapters/workspace/scratch/workspace_test.go
+++ b/backend/internal/adapters/workspace/scratch/workspace_test.go
@@ -107,3 +107,40 @@ func TestWorkspaceRejectsUnsafeSessionIDs(t *testing.T) {
 		t.Fatal("Create unsafe session id succeeded, want error")
 	}
 }
+
+// TestWorkspaceDestroyReclaimReportsAlreadyAbsentDirectory covers the scratch
+// half of the cleanup accounting. os.Remove is deliberately tolerated on a
+// missing path, so a scratch directory that was already gone tears down without
+// error while releasing nothing. Counting that as reclaimed reports space that
+// was never freed.
+func TestWorkspaceDestroyReclaimReportsAlreadyAbsentDirectory(t *testing.T) {
+	ws, err := scratch.New(scratch.Options{ManagedRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	info, err := ws.Create(context.Background(), ports.WorkspaceConfig{
+		ProjectID: "scratch",
+		SessionID: "scratch-gone",
+		Kind:      domain.KindWorker,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	reclaim, err := ws.DestroyReclaim(context.Background(), info)
+	if err != nil {
+		t.Fatalf("DestroyReclaim present: %v", err)
+	}
+	if reclaim != ports.WorkspaceReclaimRemoved {
+		t.Fatalf("reclaim = %q, want %q", reclaim, ports.WorkspaceReclaimRemoved)
+	}
+
+	// Second pass: the directory is gone, so there is nothing left to release.
+	reclaim, err = ws.DestroyReclaim(context.Background(), info)
+	if err != nil {
+		t.Fatalf("DestroyReclaim absent: %v", err)
+	}
+	if reclaim != ports.WorkspaceReclaimAlreadyAbsent {
+		t.Fatalf("reclaim = %q, want %q", reclaim, ports.WorkspaceReclaimAlreadyAbsent)
+	}
+}

--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -102,8 +102,9 @@ type cleanupSkippedSession struct {
 }
 
 type cleanupSessionsResponse struct {
-	Cleaned []string                `json:"cleaned"`
-	Skipped []cleanupSkippedSession `json:"skipped"`
+	Cleaned     []string                `json:"cleaned"`
+	AlreadyGone []string                `json:"alreadyGone"`
+	Skipped     []cleanupSkippedSession `json:"skipped"`
 }
 
 type claimPRRequest struct {
@@ -682,6 +683,15 @@ func (c *commandContext) cleanupSessions(ctx context.Context, cmd *cobra.Command
 			return err
 		}
 	}
+	for _, id := range res.AlreadyGone {
+		label := id
+		if mapped := labelByID[id]; mapped != "" {
+			label = mapped
+		}
+		if _, err := fmt.Fprintf(out, "  Already gone: %s (workspace was missing; nothing reclaimed)\n", label); err != nil {
+			return err
+		}
+	}
 	for _, skip := range res.Skipped {
 		label := skip.SessionID
 		if mapped := labelByID[skip.SessionID]; mapped != "" {
@@ -692,6 +702,9 @@ func (c *commandContext) cleanupSessions(ctx context.Context, cmd *cobra.Command
 		}
 	}
 	summary := fmt.Sprintf("\nCleanup complete. %d session%s cleaned", len(cleaned), pluralS(len(cleaned)))
+	if len(res.AlreadyGone) > 0 {
+		summary += fmt.Sprintf(", %d already gone", len(res.AlreadyGone))
+	}
 	if len(res.Skipped) > 0 {
 		summary += fmt.Sprintf(", %d skipped", len(res.Skipped))
 	}

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -407,6 +407,49 @@ func TestSessionCleanup_YesSkipsPrompt(t *testing.T) {
 	}
 }
 
+// TestSessionCleanup_ReportsAlreadyGoneWorkspacesSeparately: a workspace whose
+// directory was already missing tears down without error but reclaims nothing.
+// Folding it into the cleaned count is what lets a batch run report hundreds of
+// sessions cleaned while disk usage does not move, so the summary has to keep
+// the two apart.
+func TestSessionCleanup_ReportsAlreadyGoneWorkspacesSeparately(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sessions":
+			_, _ = io.WriteString(w, `{"sessions":[`+
+				sessionJSON("demo-old", "demo", "worker", "terminated", true)+`,`+
+				sessionJSON("demo-orch", "demo", "orchestrator", "terminated", true)+`]}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions/cleanup":
+			_, _ = io.WriteString(w, `{"ok":true,"cleaned":["demo-old"],"alreadyGone":["demo-orch"],"skipped":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "session", "cleanup", "--project", "demo", "--yes")
+	if err != nil {
+		t.Fatalf("session cleanup failed: %v\nstderr=%s", err, errOut)
+	}
+	for _, want := range []string{
+		"Cleaned: demo-old",
+		"Already gone: demo-orch (workspace was missing; nothing reclaimed)",
+		"Cleanup complete. 1 session cleaned, 1 already gone.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cleanup output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Cleaned: demo-orch") {
+		t.Fatalf("a workspace that was already gone must not be reported as cleaned:\n%s", out)
+	}
+}
+
 // TestSessionCleanup_DryRunListsWithoutPromptingOrDeleting: --dry-run must
 // preview the candidate sessions and stop there — no confirmation prompt and,
 // critically, no POST to the cleanup endpoint, so nothing is removed.

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -7164,6 +7164,10 @@ components:
       type: object
     CleanupSessionsResponse:
       properties:
+        alreadyGone:
+          items:
+            type: string
+          type: array
         cleaned:
           items:
             type: string
@@ -7177,6 +7181,7 @@ components:
       required:
       - ok
       - cleaned
+      - alreadyGone
       - skipped
       type: object
     CleanupSkippedSession:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -719,9 +719,13 @@ type CleanupSkippedSession struct {
 
 // CleanupSessionsResponse is the body of POST /api/v1/sessions/cleanup.
 type CleanupSessionsResponse struct {
-	OK      bool                    `json:"ok"`
-	Cleaned []domain.SessionID      `json:"cleaned"`
-	Skipped []CleanupSkippedSession `json:"skipped"`
+	OK bool `json:"ok"`
+	// Cleaned lists sessions whose workspace was present and has been released.
+	Cleaned []domain.SessionID `json:"cleaned"`
+	// AlreadyGone lists sessions whose workspace directory was already missing,
+	// so teardown completed without reclaiming anything.
+	AlreadyGone []domain.SessionID      `json:"alreadyGone"`
+	Skipped     []CleanupSkippedSession `json:"skipped"`
 }
 
 // SendSessionMessageRequest is the body of POST /api/v1/sessions/{sessionId}/send.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -1333,7 +1333,9 @@ func (c *SessionsController) cleanup(w http.ResponseWriter, r *http.Request) {
 	for _, skip := range out.Skipped {
 		skipped = append(skipped, CleanupSkippedSession{SessionID: skip.SessionID, Reason: skip.Reason})
 	}
-	envelope.WriteJSON(w, http.StatusOK, CleanupSessionsResponse{OK: true, Cleaned: out.Cleaned, Skipped: skipped})
+	envelope.WriteJSON(w, http.StatusOK, CleanupSessionsResponse{
+		OK: true, Cleaned: out.Cleaned, AlreadyGone: out.AlreadyGone, Skipped: skipped,
+	})
 }
 
 func (c *SessionsController) send(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -279,6 +279,32 @@ type Attacher interface {
 
 // The Agent port and its supporting types live in agent.go.
 
+// WorkspaceReclaim distinguishes a teardown that actually released disk from
+// one that found nothing to release. Destroy returning a nil error proves only
+// that the workspace is absent afterwards, not that this call is what removed
+// it: a directory that was already gone leaves nothing for the adapter to fail
+// on. Callers that report teardown counts need the two kept apart.
+type WorkspaceReclaim string
+
+// Workspace reclaim outcomes.
+const (
+	// WorkspaceReclaimRemoved means the workspace was present and this call
+	// released it.
+	WorkspaceReclaimRemoved WorkspaceReclaim = "removed"
+	// WorkspaceReclaimAlreadyAbsent means there was nothing on disk to release.
+	// Any stale registration is still reconciled, so the post-state matches
+	// WorkspaceReclaimRemoved; only the accounting differs.
+	WorkspaceReclaimAlreadyAbsent WorkspaceReclaim = "already_absent"
+)
+
+// WorkspaceReclaimer is the optional half of Workspace that reports which of
+// the two reclaim outcomes a teardown reached. Implementing it is optional:
+// callers fall back to Destroy and treat a nil error as
+// WorkspaceReclaimRemoved, which is the pre-existing behaviour.
+type WorkspaceReclaimer interface {
+	DestroyReclaim(ctx context.Context, info WorkspaceInfo) (WorkspaceReclaim, error)
+}
+
 // Workspace is the isolated checkout an agent works in (a git worktree or clone).
 type Workspace interface {
 	Create(ctx context.Context, cfg WorkspaceConfig) (WorkspaceInfo, error)

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -103,8 +103,9 @@ type RollbackOutcome struct {
 
 // CleanupOutcome reports what session cleanup reclaimed and what it preserved.
 type CleanupOutcome struct {
-	Cleaned []domain.SessionID `json:"cleaned"`
-	Skipped []CleanupSkipped   `json:"skipped"`
+	Cleaned     []domain.SessionID `json:"cleaned"`
+	AlreadyGone []domain.SessionID `json:"alreadyGone"`
+	Skipped     []CleanupSkipped   `json:"skipped"`
 }
 
 // CleanupSkipped is one terminal session whose workspace was preserved by
@@ -856,9 +857,16 @@ func (s *Service) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 	if err != nil {
 		return CleanupOutcome{}, err
 	}
-	out := CleanupOutcome{Cleaned: res.Cleaned, Skipped: make([]CleanupSkipped, 0, len(res.Skipped))}
+	out := CleanupOutcome{
+		Cleaned:     res.Cleaned,
+		AlreadyGone: res.AlreadyGone,
+		Skipped:     make([]CleanupSkipped, 0, len(res.Skipped)),
+	}
 	if out.Cleaned == nil {
 		out.Cleaned = []domain.SessionID{}
+	}
+	if out.AlreadyGone == nil {
+		out.AlreadyGone = []domain.SessionID{}
 	}
 	for _, skip := range res.Skipped {
 		out.Skipped = append(out.Skipped, CleanupSkipped{SessionID: skip.SessionID, Reason: skip.Reason})

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1715,7 +1715,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	}
 	freed := false
 	if workspaceProject {
-		cleaned, err := m.destroyWorkspaceProjectRows(ctx, workspaceProjectRows)
+		_, cleaned, err := m.destroyWorkspaceProjectRows(ctx, workspaceProjectRows)
 		if err != nil {
 			if workspacePreserved(err) {
 				if err := m.lcm.MarkTerminated(ctx, id); err != nil {
@@ -3179,7 +3179,22 @@ func (m *Manager) saveAndTeardownWorkspaceProject(ctx context.Context, rec domai
 	return nil
 }
 
-func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) (bool, error) {
+// destroyWorkspaceProjectRows tears down every repo of a multi-repo workspace,
+// children before root. It reports two different things, because they answer
+// two different questions and only coincide when every repo still had a
+// directory on disk:
+//
+//   - reclaim aggregates the per-repo outcomes. A session released disk if any
+//     one of its repos did, so a single removed repo makes the whole session
+//     WorkspaceReclaimRemoved; only when no repo had anything left to release
+//     is it WorkspaceReclaimAlreadyAbsent. Callers that count reclaimed
+//     workspaces need this.
+//   - cleaned reports whether at least one repo tore down without an error,
+//     which is what the kill path uses to decide that the session's registration
+//     is reconciled. A repo whose directory was already gone still tears down,
+//     so cleaned stays true there while reclaim does not.
+func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) (ports.WorkspaceReclaim, bool, error) {
+	reclaim := ports.WorkspaceReclaimAlreadyAbsent
 	cleaned := false
 	var firstErr error
 	for i := len(rows) - 1; i >= 0; i-- {
@@ -3187,9 +3202,10 @@ func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.
 			continue
 		}
 		info := workspaceInfoFromRepoInfo(rows[i])
-		if err := m.workspace.Destroy(ctx, info); err != nil {
+		rowReclaim, err := m.destroyWorkspace(ctx, info)
+		if err != nil {
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
-				return cleaned, err
+				return reclaim, cleaned, err
 			}
 			if stateErr := m.upsertWorkspaceProjectRowState(ctx, rows[i], "retry_remove"); stateErr != nil && firstErr == nil {
 				firstErr = stateErr
@@ -3199,12 +3215,15 @@ func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.
 			}
 			continue
 		}
+		if rowReclaim == ports.WorkspaceReclaimRemoved {
+			reclaim = ports.WorkspaceReclaimRemoved
+		}
 		if err := m.upsertWorkspaceProjectRowState(ctx, rows[i], "unavailable"); err != nil && firstErr == nil {
 			firstErr = err
 		}
 		cleaned = true
 	}
-	return cleaned, firstErr
+	return reclaim, cleaned, firstErr
 }
 
 func (m *Manager) upsertWorkspaceProjectRowState(ctx context.Context, row ports.WorkspaceRepoInfo, state string) error {
@@ -3697,17 +3716,19 @@ func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws p
 		m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
 		return ports.WorkspaceReclaimRemoved, "workspace teardown failed"
 	} else if ok {
-		// A workspace project spans several repos with their own per-row state
-		// machine; it is reported as a real reclaim so that multi-repo teardown
-		// keeps its existing accounting.
-		if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
+		// A workspace project spans several repos, so its reclaim outcome is the
+		// aggregate of theirs rather than one directory's: reporting a fixed
+		// "removed" here would put a multi-repo session back on the same false
+		// count this whole change exists to remove.
+		projectReclaim, _, err := m.destroyWorkspaceProjectRows(ctx, rows)
+		if err != nil {
 			if !workspacePreserved(err) {
 				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
 			}
 			return ports.WorkspaceReclaimRemoved, cleanupSkipReason(err)
 		}
 		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-		return ports.WorkspaceReclaimRemoved, ""
+		return projectReclaim, ""
 	}
 	reclaim, err := m.destroyWorkspace(ctx, ws)
 	if err != nil {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -3606,8 +3606,15 @@ type CleanupSkip struct {
 
 // CleanupResult reports what Cleanup reclaimed and what it preserved.
 type CleanupResult struct {
+	// Cleaned lists sessions whose workspace was present and has been released
+	// by this run. It is the only bucket that corresponds to reclaimed disk.
 	Cleaned []domain.SessionID
-	Skipped []CleanupSkip
+	// AlreadyGone lists sessions whose workspace directory was missing before
+	// this run started. Their teardown completes (any stale registration is
+	// reconciled) but reclaims nothing, so counting them as Cleaned reports
+	// space that was never freed.
+	AlreadyGone []domain.SessionID
+	Skipped     []CleanupSkip
 }
 
 // Cleanup reclaims the workspaces of terminal sessions in a project. A workspace
@@ -3618,7 +3625,11 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 	if err != nil {
 		return CleanupResult{}, fmt.Errorf("cleanup %s: %w", project, err)
 	}
-	result := CleanupResult{Cleaned: make([]domain.SessionID, 0, len(recs)), Skipped: []CleanupSkip{}}
+	result := CleanupResult{
+		Cleaned:     make([]domain.SessionID, 0, len(recs)),
+		AlreadyGone: []domain.SessionID{},
+		Skipped:     []CleanupSkip{},
+	}
 	for _, rec := range recs {
 		if !rec.IsTerminated {
 			continue
@@ -3632,61 +3643,83 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 		if h := runtimeHandle(rec.Metadata); h.ID != "" {
 			_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
 		}
-		if reason := m.cleanupOne(ctx, rec, ws); reason != "" {
+		reclaim, reason := m.cleanupOne(ctx, rec, ws)
+		if reason != "" {
 			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: reason})
 			continue
 		}
 		m.cleanupSystemPromptDir(rec.ID)
+		if reclaim == ports.WorkspaceReclaimAlreadyAbsent {
+			result.AlreadyGone = append(result.AlreadyGone, rec.ID)
+			continue
+		}
 		result.Cleaned = append(result.Cleaned, rec.ID)
 	}
 	return result, nil
+}
+
+// destroyWorkspace tears down one workspace and reports whether the call
+// actually released anything. Workspace adapters are not required to report
+// that, so a plain Destroy keeps its existing meaning: a nil error is a
+// completed removal.
+func (m *Manager) destroyWorkspace(ctx context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
+	if reclaimer, ok := m.workspace.(ports.WorkspaceReclaimer); ok {
+		return reclaimer.DestroyReclaim(ctx, info)
+	}
+	return ports.WorkspaceReclaimRemoved, m.workspace.Destroy(ctx, info)
 }
 
 // cleanupOne reclaims one terminated session's workspace, gating shut any
 // shell terminal scoped to it first (same ordering as Kill). Split out of
 // Cleanup's loop so the release function's defer is scoped to one session's
 // call, not deferred across every iteration until Cleanup itself returns.
-// Returns "" when the workspace was reclaimed; a non-empty reason means it was
-// left alone this run (Cleanup records it in Skipped and can retry on a later
-// call) — most commonly because a scoped shell terminal could not be
-// confirmed closed, so reclaiming would pull the ground out from under it.
-func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo) (skipReason string) {
+// Returns an empty reason when the workspace was reclaimed; a non-empty reason
+// means it was left alone this run (Cleanup records it in Skipped and can retry
+// on a later call) — most commonly because a scoped shell terminal could not be
+// confirmed closed, so reclaiming would pull the ground out from under it. The
+// reclaim outcome says whether anything was actually released and is only
+// meaningful when the reason is empty.
+func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo) (reclaim ports.WorkspaceReclaim, skipReason string) {
 	release, closeErr := m.beginShellTerminalTeardown(ctx, rec.ID)
 	if closeErr != nil {
 		m.logger.Warn("cleanup: shell terminal still open", "sessionID", rec.ID, "error", closeErr)
-		return "shell terminal still open"
+		return ports.WorkspaceReclaimRemoved, "shell terminal still open"
 	}
 	if release != nil {
 		defer release()
 	}
 	if err := m.importAttachments(ctx, rec); err != nil {
 		m.logger.Warn("cleanup: attachment preservation failed", "sessionID", rec.ID, "error", err)
-		return "attachment preservation failed"
+		return ports.WorkspaceReclaimRemoved, "attachment preservation failed"
 	}
 
 	if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
 		m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
-		return "workspace teardown failed"
+		return ports.WorkspaceReclaimRemoved, "workspace teardown failed"
 	} else if ok {
+		// A workspace project spans several repos with their own per-row state
+		// machine; it is reported as a real reclaim so that multi-repo teardown
+		// keeps its existing accounting.
 		if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
 			if !workspacePreserved(err) {
 				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
 			}
-			return cleanupSkipReason(err)
+			return ports.WorkspaceReclaimRemoved, cleanupSkipReason(err)
 		}
 		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-		return ""
+		return ports.WorkspaceReclaimRemoved, ""
 	}
-	if err := m.workspace.Destroy(ctx, ws); err != nil {
+	reclaim, err := m.destroyWorkspace(ctx, ws)
+	if err != nil {
 		if !workspacePreserved(err) {
 			// The public reason stays a fixed string (the raw error carries
 			// internal filesystem paths); the full cause lands here.
 			m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
 		}
-		return cleanupSkipReason(err)
+		return reclaim, cleanupSkipReason(err)
 	}
 	m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-	return ""
+	return reclaim, ""
 }
 
 // cleanupSkipReason renders a workspace teardown refusal as a short

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -3114,6 +3114,37 @@ func TestKill_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
 	}
 }
 
+// TestKill_WorkspaceProjectAlreadyAbsentStaysFreed guards the boundary between
+// the two answers destroyWorkspaceProjectRows returns. Kill's freed flag is not
+// a disk-reclaim count: freed=false means the workspace was preserved, and the
+// CLI prints "workspace preserved" from it. A worktree that was already gone
+// was torn down, not preserved, so collapsing freed onto the reclaim outcome
+// would make kill report a preserved workspace that does not exist.
+func TestKill_WorkspaceProjectAlreadyAbsentStaysFreed(t *testing.T) {
+	m, st, _, ws := newManager()
+	ws.destroyReclaim = ports.WorkspaceReclaimAlreadyAbsent
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	freed, err := m.Kill(ctx, "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !freed {
+		t.Fatal("freed = false, want true: the worktrees were torn down, not preserved")
+	}
+}
+
 func TestKill_WorkspaceProjectFailsClosedOnUnregisteredChildRows(t *testing.T) {
 	m, st, _, ws := newManager()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -817,6 +817,10 @@ type fakeWorkspace struct {
 	destroyed  int
 	// destroyReclaim, when set, is the reclaim outcome DestroyReclaim reports.
 	destroyReclaim ports.WorkspaceReclaim
+	// destroyReclaimByPath overrides destroyReclaim for one workspace path, so a
+	// multi-repo test can have one repo still on disk while another is already
+	// gone — the state a partly cleaned workspace project is actually in.
+	destroyReclaimByPath map[string]ports.WorkspaceReclaim
 	// destroyCtxErr records ctx.Err() as seen by Destroy, so a test can prove
 	// teardown does not inherit a caller's cancellation.
 	destroyCtxErr error
@@ -986,10 +990,14 @@ func (w *fakeWorkspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) e
 // keeps them on the "a completed teardown released something" default.
 func (w *fakeWorkspace) DestroyReclaim(ctx context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
 	err := w.Destroy(ctx, info)
-	if w.destroyReclaim == "" {
+	reclaim := w.destroyReclaim
+	if override, ok := w.destroyReclaimByPath[info.Path]; ok {
+		reclaim = override
+	}
+	if reclaim == "" {
 		return ports.WorkspaceReclaimRemoved, err
 	}
-	return w.destroyReclaim, err
+	return reclaim, err
 }
 func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.WorkspaceProjectInfo) error {
 	w.projectDestroyed++
@@ -3611,6 +3619,81 @@ func TestCleanup_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
 	want := []string{"Destroy:api", "Destroy:__root__"}
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("destroy order = %v, want %v", got, want)
+	}
+}
+
+// TestCleanup_WorkspaceProjectRepeatRunReportsAlreadyGone is the multi-repo
+// half of the false-count fix. A workspace project's teardown succeeds on every
+// later run — the worktrees are gone, so there is nothing left to fail on — and
+// counting those runs as reclaimed is exactly the report that made a batch
+// cleanup look like it freed disk it never touched. The second run here must
+// land in AlreadyGone.
+func TestCleanup_WorkspaceProjectRepeatRunReportsAlreadyGone(t *testing.T) {
+	m, st, _, ws := newManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"})
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	first, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Cleaned) != 1 || first.Cleaned[0] != "mer-1" {
+		t.Fatalf("first run cleaned = %v, want [mer-1]: both worktrees were present", first.Cleaned)
+	}
+	if len(first.AlreadyGone) != 0 {
+		t.Fatalf("first run alreadyGone = %v, want none", first.AlreadyGone)
+	}
+
+	// The first run removed both directories, so every repo is now absent —
+	// which is what the adapter reports on the second run.
+	ws.destroyReclaim = ports.WorkspaceReclaimAlreadyAbsent
+
+	second, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.Cleaned) != 0 {
+		t.Fatalf("second run cleaned = %v, want none: both worktrees were already gone", second.Cleaned)
+	}
+	if len(second.AlreadyGone) != 1 || second.AlreadyGone[0] != "mer-1" {
+		t.Fatalf("second run alreadyGone = %v, want [mer-1]", second.AlreadyGone)
+	}
+	if len(second.Skipped) != 0 {
+		t.Fatalf("second run skipped = %v, want none: teardown did not fail", second.Skipped)
+	}
+}
+
+// TestCleanup_WorkspaceProjectPartialReclaimCountsAsCleaned pins the aggregate
+// on the other side. Repos of one workspace project can disagree — a child
+// removed by hand, the root still there — and a session that released any disk
+// at all was reclaimed, so only a project where nothing was left may report
+// already gone.
+func TestCleanup_WorkspaceProjectPartialReclaimCountsAsCleaned(t *testing.T) {
+	m, st, _, ws := newManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"})
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+	ws.destroyReclaim = ports.WorkspaceReclaimAlreadyAbsent
+	ws.destroyReclaimByPath = map[string]ports.WorkspaceReclaim{"/ws/mer-1": ports.WorkspaceReclaimRemoved}
+
+	res, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Cleaned) != 1 || res.Cleaned[0] != "mer-1" {
+		t.Fatalf("cleaned = %v, want [mer-1]: the root worktree was reclaimed", res.Cleaned)
+	}
+	if len(res.AlreadyGone) != 0 {
+		t.Fatalf("alreadyGone = %v, want none", res.AlreadyGone)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -815,6 +815,8 @@ type fakeWorkspace struct {
 	createErr  error
 	destroyErr error
 	destroyed  int
+	// destroyReclaim, when set, is the reclaim outcome DestroyReclaim reports.
+	destroyReclaim ports.WorkspaceReclaim
 	// destroyCtxErr records ctx.Err() as seen by Destroy, so a test can prove
 	// teardown does not inherit a caller's cancellation.
 	destroyCtxErr error
@@ -977,6 +979,17 @@ func (w *fakeWorkspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) e
 	}
 	w.destroyed++
 	return w.destroyErr
+}
+
+// DestroyReclaim makes the fake report reclaim outcomes like the real git
+// worktree adapter. destroyReclaim is empty in every pre-existing test, which
+// keeps them on the "a completed teardown released something" default.
+func (w *fakeWorkspace) DestroyReclaim(ctx context.Context, info ports.WorkspaceInfo) (ports.WorkspaceReclaim, error) {
+	err := w.Destroy(ctx, info)
+	if w.destroyReclaim == "" {
+		return ports.WorkspaceReclaimRemoved, err
+	}
+	return w.destroyReclaim, err
 }
 func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.WorkspaceProjectInfo) error {
 	w.projectDestroyed++
@@ -3371,6 +3384,37 @@ func TestCleanup_ReclaimsTerminalWorkspaces(t *testing.T) {
 	}
 	if ws.destroyed != 1 {
 		t.Fatal("live workspace must not be destroyed")
+	}
+}
+
+// TestCleanup_SeparatesAlreadyGoneWorkspacesFromReclaimedOnes keeps the
+// reported count evidence rather than bookkeeping. A workspace whose directory
+// was already missing tears down without error, so counting it as Cleaned
+// claims disk that was never reclaimed and makes a batch run look like it did
+// work it did not do.
+func TestCleanup_SeparatesAlreadyGoneWorkspacesFromReclaimedOnes(t *testing.T) {
+	m, st, _, ws := newManager()
+	ws.destroyReclaim = ports.WorkspaceReclaimAlreadyAbsent
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+
+	res, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.Cleaned) != 0 {
+		t.Fatalf("cleaned = %v, want none: nothing was reclaimed", res.Cleaned)
+	}
+	if len(res.AlreadyGone) != 1 || res.AlreadyGone[0] != "mer-1" {
+		t.Fatalf("alreadyGone = %v, want [mer-1]", res.AlreadyGone)
+	}
+	if len(res.Skipped) != 0 {
+		t.Fatalf("skipped = %v, want none: teardown did not fail", res.Skipped)
+	}
+	// Teardown still runs, so any stale registration is reconciled exactly as
+	// before; only the accounting changed.
+	if ws.destroyed != 1 {
+		t.Fatalf("destroyed = %d, want 1", ws.destroyed)
 	}
 }
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2522,6 +2522,7 @@ export interface components {
             takenOverFrom: string[];
         };
         CleanupSessionsResponse: {
+            alreadyGone: string[];
             cleaned: string[];
             ok: boolean;
             skipped: components["schemas"]["CleanupSkippedSession"][];


### PR DESCRIPTION
## What

`ao session cleanup` now reports three outcomes instead of two: **cleaned**, **already gone**, and **skipped**. A workspace whose directory was already missing is no longer counted as reclaimed.

## Why

Refs #3219.

The count was derived from a single signal: did `Destroy` return an error. That is not the same question as "was a workspace released".

When a worktree directory is already gone on disk:

1. `git worktree remove` fails, but that error is only ever re-read inside the `findWorktree(records, path)` branch
2. `git worktree prune` succeeds and clears the stale registration
3. `findWorktree` then returns false, so the failure from step 1 is never looked at
4. `os.RemoveAll` returns nil, since it is documented to succeed on a missing path
5. `Destroy` returns nil, and the session is counted as cleaned

Nothing was released, but the run reports otherwise. In a batch that is how a cleanup reports hundreds of sessions cleaned while disk usage does not move, and why running it again never lowers the number.

The scratch adapter had the same shape: `os.Remove` is deliberately tolerated on a missing path, so an absent scratch directory also tore down "successfully" without releasing anything.

## How

`Destroy` keeps its signature and its behaviour. It is in the `ports.Workspace` interface, implemented by three adapters plus test fakes, and changing that contract for a reporting fix would touch every implementation for no functional gain.

Instead this adds an optional capability interface, matching the pattern already used for `AgentInterfaceHandoff`, `TerminalSurfaceInspector` and friends:

```go
type WorkspaceReclaimer interface {
    DestroyReclaim(ctx context.Context, info WorkspaceInfo) (WorkspaceReclaim, error)
}
```

- `gitworktree` and `scratch` implement it; the existing `Destroy` bodies were extracted into a shared `destroy` so there is one code path, not two.
- `router` forwards it, and falls back to `Destroy` for any adapter that does not implement it.
- `Manager.Cleanup` type-asserts for the capability and falls back the same way, so an adapter that does not report reclaim outcomes keeps the previous meaning of a nil error.
- The outcome flows out through `CleanupResult`, `CleanupOutcome`, `CleanupSessionsResponse` and the CLI summary.

Two details worth a reviewer's eye:

- **The path is sampled before any teardown step runs**, not after. Sampling afterwards would always report "absent", because teardown has by then removed it.
- **Only a definite `ErrNotExist` counts as already-absent.** A stat that fails for any other reason (permissions, a racing writer) stays on the removed path, so an unknown is never reported as "there was nothing to do".

API note: `alreadyGone` is added to the cleanup response, so `openapi.yaml` and `frontend/src/api/schema.ts` are regenerated and committed alongside. The field is always serialised as `[]` rather than `null`. No frontend, mobile or packages client calls this endpoint today.

## Testing

`go build ./...`, `go test -race` on the touched packages, `golangci-lint run` (v2.12.2, as CI runs it) reporting 0 issues, `gofmt -l` clean, `npm run frontend:typecheck`, and `npm run api` leaving no spec drift.

The backend suite has 20 pre-existing failures on this machine (`codexappserver` protocol conformance and the Codex account catalog tests). I confirmed they are unrelated by stashing this change and running the same packages on a clean `main`, which reproduces them identically.

New tests: `DestroyReclaim` reporting `already_absent` for a missing worktree and `removed` for a present one (real git repo), the same pair for scratch, `Cleanup` routing an already-absent workspace into its own bucket, and the CLI summary keeping the two apart.

End to end, I built the daemon and CLI from `main` and from this branch and ran each against its own isolated copy of a real data directory, with the project repo cloned locally so nothing touched the original:

```
BEFORE (main)          Cleanup complete. 14 sessions cleaned, 6 skipped.
AFTER (this branch)    Cleanup complete. 6 sessions cleaned, 8 already gone, 6 skipped.

Disk reclaimed in both runs: 11M -> 6.9M
```

Identical teardown work, honest count. Running cleanup a second time on the same data shows the difference more sharply, since by then there is nothing left to reclaim at all:

```
BEFORE, second run     Cleanup complete. 14 sessions cleaned, 6 skipped.
AFTER,  second run     Cleanup complete. 1 session cleaned, 13 already gone, 6 skipped.
```

One detail from that run that shows the accounting working: several terminated sessions shared one orchestrator worktree. The first of them is reported as cleaned because the directory was there, and the rest as already gone. The old code called all of them cleaned.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
