### PR TITLE
fix(mobile): Android keyboard inset and orchestrator restart visibility

### DIFF
--- a/packages/mobile/app/(tabs)/orchestrator.tsx
+++ b/packages/mobile/app/(tabs)/orchestrator.tsx
@@ -12,7 +12,7 @@ import { useApp } from "../../lib/store";
 import { attentionMetaFor, type AttentionLevel, type Theme } from "../../lib/theme";
 import { useTheme, useThemedStyles } from "../../lib/ThemeProvider";
 import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
-import { Button, cardShell, Dot, EmptyState, IconButton, ScreenHeader } from "../../lib/ui";
+import { Button, cardShell, Dot, EmptyState, ScreenHeader } from "../../lib/ui";
 
 const ZONE_ORDER: AttentionLevel[] = ["merge", "respond", "review", "pending", "working", "done"];
 
@@ -223,21 +223,26 @@ function OrchestratorCard({
 				<Text style={styles.workers}>
 					{workers.length} worker{workers.length === 1 ? "" : "s"}
 				</Text>
+				{/* A running orchestrator offers Open and nothing else. Restart used to
+				    sit here too, which put the button on every healthy card and took it
+				    away from the stopped ones that actually needed it — see launchIntent.
+				    The card itself is deliberately not pressable: the zone pills open the
+				    board, so a whole-card target would send two taps a few pixels apart to
+				    different screens. The action carries its own label instead, which is
+				    also what makes it big enough to hit. */}
 				{running ? (
-					<View style={styles.actions}>
-						<IconButton icon="rotate-ccw" label="Restart orchestrator" loading={busy} onPress={onLaunch} />
-						<IconButton icon={link?.mode === "chat" ? "message-square" : "terminal"} label="Open orchestrator" onPress={() => link && openSession(link.id)} />
-					</View>
+					<Button
+						title="Open"
+						icon={link?.mode === "chat" ? "message-square" : "terminal"}
+						variant="ghost"
+						onPress={() => link && openSession(link.id)}
+					/>
 				) : (
-					<Pressable
-						accessibilityRole="button"
-						accessibilityLabel={intent.label}
-						disabled={busy}
-						onPress={() => { haptics.tap(); onLaunch(); }}
-						style={({ pressed }) => [styles.start, pressed && { opacity: 0.85 }, busy && { opacity: 0.5 }]}
-					>
-						<Text style={styles.startText}>{busy ? "Starting…" : intent.label}</Text>
-					</Pressable>
+					<Button
+						title={busy ? "Starting…" : intent.label}
+						loading={busy}
+						onPress={onLaunch}
+					/>
 				)}
 			</View>
 		</View>
@@ -269,14 +274,4 @@ const makeStyles = (t: Theme) =>
 		// card's own padding, centred rather than baseline-aligned.
 		footer: { flexDirection: "row", alignItems: "center", gap: 10, marginTop: 12 },
 		workers: { flex: 1, color: t.textTertiary, fontSize: 12 },
-		actions: { flexDirection: "row", gap: 6 },
-		start: {
-			backgroundColor: t.blue,
-			borderRadius: 9,
-			paddingHorizontal: 14,
-			height: 32,
-			alignItems: "center",
-			justifyContent: "center",
-		},
-		startText: { color: t.onAccent, fontSize: 13, fontWeight: "700" },
 	});

--- a/packages/mobile/app/spawn.tsx
+++ b/packages/mobile/app/spawn.tsx
@@ -14,6 +14,7 @@ import {
 	TextInput,
 	View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AgentLogo } from "../lib/AgentLogo";
 import { agentErrorCopy } from "../lib/agentError";
 import { defaultAgent, rankAgents } from "../lib/agentPicker";
@@ -51,6 +52,9 @@ export default function SpawnModal() {
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [keyboardHeight, setKeyboardHeight] = useState(0);
+	// Android's keyboard event reports its height with the nav bar subtracted; the
+	// root view draws under that nav bar, so screenKeyboardAvoidance adds it back.
+	const insets = useSafeAreaInsets();
 
 	const [catalog, setCatalog] = useState<AgentCatalog | null>(null);
 	const [catalogError, setCatalogError] = useState<string | null>(null);
@@ -59,7 +63,7 @@ export default function SpawnModal() {
 
 	useEffect(() => {
 		if (Platform.OS !== "android") return;
-		const avoidance = screenKeyboardAvoidance("android", 0);
+		const avoidance = screenKeyboardAvoidance("android", 0, 0);
 		const animate = (duration?: number) => LayoutAnimation.configureNext({
 			duration: duration || 250,
 			update: { type: LayoutAnimation.Types.keyboard },
@@ -229,7 +233,7 @@ export default function SpawnModal() {
 			style={[
 				styles.screen,
 				Platform.OS === "android" && keyboardHeight > 0
-					? screenKeyboardAvoidance("android", keyboardHeight).rootStyle
+					? screenKeyboardAvoidance("android", keyboardHeight, insets.bottom).rootStyle
 					: undefined,
 			]}
 			behavior={Platform.OS === "ios" ? "padding" : undefined}

--- a/packages/mobile/lib/chat/ChatSessionScreen.tsx
+++ b/packages/mobile/lib/chat/ChatSessionScreen.tsx
@@ -17,6 +17,7 @@ import {
 	TextInput,
 	View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { restoreSession, resumeSessionAgent, type DashboardSession, type OrchestratorLink } from "../api";
 import { haptics } from "../haptics";
 import { headerActionStyle } from "../headerAction";
@@ -76,6 +77,9 @@ export function ChatSessionScreen({ session }: { session: MobileChatSession }) {
 	const [openingShell, setOpeningShell] = useState(false);
 	const [resuming, setResuming] = useState(false);
 	const [keyboardHeight, setKeyboardHeight] = useState(0);
+	// Android's keyboard event reports its height with the nav bar subtracted; the
+	// root view draws under that nav bar, so screenKeyboardAvoidance adds it back.
+	const insets = useSafeAreaInsets();
 	const terminated = "projectName" in session ? Boolean(session.isTerminal) : Boolean(session.isTerminated);
 	const interfaceTransitionActive = mobileInterfaceTransitionIsActive(interfaceSwitch.transition);
 	const interfaceTransitionNotice =
@@ -109,7 +113,7 @@ export function ChatSessionScreen({ session }: { session: MobileChatSession }) {
 
 	useEffect(() => {
 		if (Platform.OS !== "android") return;
-		const avoidance = screenKeyboardAvoidance("android", 0);
+		const avoidance = screenKeyboardAvoidance("android", 0, 0);
 		const animate = (duration?: number) => LayoutAnimation.configureNext({
 			duration: duration || 250,
 			update: { type: LayoutAnimation.Types.keyboard },
@@ -262,7 +266,7 @@ export function ChatSessionScreen({ session }: { session: MobileChatSession }) {
 			style={[
 				styles.screen,
 				Platform.OS === "android" && keyboardHeight > 0
-					? { paddingBottom: screenKeyboardAvoidance("android", keyboardHeight).paddingBottom }
+					? { paddingBottom: screenKeyboardAvoidance("android", keyboardHeight, insets.bottom).paddingBottom }
 					: undefined,
 			]}
 			behavior={Platform.OS === "ios" ? "padding" : undefined}

--- a/packages/mobile/lib/orchestratorView.test.ts
+++ b/packages/mobile/lib/orchestratorView.test.ts
@@ -61,8 +61,18 @@ describe("launchIntent", () => {
 	it("uses the cheap ensure when there is nothing live to retire", () => {
 		for (const state of ["missing", "stopped"] as const) {
 			expect(launchIntent(state).clean, state).toBe(false);
-			expect(launchIntent(state).label, state).toMatch(/start/i);
 		}
+	});
+
+	// The card only ever offers a launch when the orchestrator is not running
+	// (running shows Open alone), so these two labels are the only ones a user
+	// can actually tap — and they must not both read "Start". An orchestrator
+	// that exited needs restarting; one that never existed needs starting.
+	// Asserted exactly, not with /start/i: "Restart" contains "start", so a
+	// loose match passes whichever label is wrong.
+	it("says Start only when there is no orchestrator, and Restart when one exited", () => {
+		expect(launchIntent("missing").label).toBe("Start orchestrator");
+		expect(launchIntent("stopped").label).toBe("Restart orchestrator");
 	});
 });
 

--- a/packages/mobile/lib/orchestratorView.ts
+++ b/packages/mobile/lib/orchestratorView.ts
@@ -50,10 +50,22 @@ export type LaunchIntent = { clean: boolean; label: string; confirm: boolean };
  * for the project is sent a retire notice ("AO is replacing this project
  * orchestrator. Stop coordinating new work now") and replaced. That is worth a
  * confirmation, which it never had.
+ *
+ * The card does not currently expose the running case: a healthy orchestrator
+ * offers Open and nothing else, because a restart button is only meaningful
+ * once there is something to restart. The branch stays because it is the
+ * correct answer to "what would launching do right now", and because the
+ * destructive path must keep its confirmation if the card ever offers it again
+ * (a long-press, say) — not because the screen calls it today.
  */
 export function launchIntent(state: OrchestratorState): LaunchIntent {
 	if (state === "running") return { clean: true, label: "Restart orchestrator", confirm: true };
-	// Nothing live to retire, so the cheap ensure is also the correct call.
+	// Nothing live to retire, so the cheap ensure is also the correct call. The
+	// two remaining states are not the same action to a reader, though: an
+	// orchestrator that exited is being *restarted*, one that never existed is
+	// being *started*. Saying "Start" over a session that has clearly already
+	// run reads as though the app lost track of it.
+	if (state === "stopped") return { clean: false, label: "Restart orchestrator", confirm: false };
 	return { clean: false, label: "Start orchestrator", confirm: false };
 }
 

--- a/packages/mobile/lib/session/TerminalSessionScreen.tsx
+++ b/packages/mobile/lib/session/TerminalSessionScreen.tsx
@@ -13,7 +13,7 @@ import { resetHeaderRightForSwap } from "../headerRightSwap";
 import { MinimalBackButton } from "../MinimalBackButton";
 import { MuxClient, type MuxStatus } from "../mux";
 import { Composer } from "./Composer";
-import { dockInset } from "./keyboardInset";
+import { dockInset, rootKeyboardPad } from "./keyboardInset";
 import { KeyRow } from "./KeyRow";
 import {
 	REROUTED_NOTICE,
@@ -668,10 +668,12 @@ export default function TerminalScreen() {
 	// Neither platform shrinks the layout for the keyboard: iOS never has, and on
 	// Android edge-to-edge (edgeToEdgeEnabled) defeats windowSoftInputMode=adjustResize
 	// so the window no longer resizes - the keyboard just draws over our content.
-	// So reserve kbHeight on BOTH platforms and let the screen pad itself above the
-	// keyboard, else the input dock (and its send button) hide behind it. This is
-	// the ONLY place the keyboard height is applied — the dock adds nothing on top
-	// of it (see dockInset), because doing both is what made the bar kick.
+	// So reserve the keyboard on BOTH platforms and let the screen pad itself above
+	// it, else the input dock (and its send button) hide behind it. What the event
+	// reports is not the same quantity on the two platforms — rootKeyboardPad owns
+	// that difference. This is the ONLY place the keyboard height is applied — the
+	// dock adds nothing on top of it (see dockInset), because doing both is what
+	// made the bar kick.
 	useEffect(() => {
 		const isIOS = Platform.OS === "ios";
 		const showEvt = isIOS ? "keyboardWillShow" : "keyboardDidShow";
@@ -1200,12 +1202,15 @@ export default function TerminalScreen() {
 		);
 	}
 
-	// One inset for the whole dock. The root already reserves kbHeight, so the
+	// One inset for the whole dock. The root already reserves the keyboard, so the
 	// dock owes nothing more while the keyboard is up — see dockInset.
 	const bottomPad = dockInset(kbHeight, insets.bottom);
+	// Android's reported kbHeight excludes the nav bar our root view draws under,
+	// so rootKeyboardPad adds it back; on iOS it passes the height through.
+	const rootPad = rootKeyboardPad(Platform.OS === "android" ? "android" : "ios", kbHeight, insets.bottom);
 
 	return (
-		<View style={[styles.screen, kbHeight > 0 && { paddingBottom: kbHeight }]}>
+		<View style={[styles.screen, rootPad > 0 && { paddingBottom: rootPad }]}>
 			<View style={styles.statusBar}>
 				<View style={[styles.statusDot, { backgroundColor: statusColorFor(t)[status] }]} />
 				<Text style={styles.statusText}>{statusLabel[status]}</Text>

--- a/packages/mobile/lib/session/keyboardInset.test.ts
+++ b/packages/mobile/lib/session/keyboardInset.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dockInset, MIN_DOCK_INSET, screenKeyboardAvoidance } from "./keyboardInset";
+import { dockInset, MIN_DOCK_INSET, rootKeyboardPad, screenKeyboardAvoidance } from "./keyboardInset";
 import { CONTROL_KEYS } from "./keys";
 
 describe("dockInset", () => {
@@ -20,14 +20,58 @@ describe("dockInset", () => {
 	});
 });
 
+describe("rootKeyboardPad", () => {
+	// The regression this exists for: React Native's Android keyboard event
+	// reports `imeInsets.bottom - systemBars.bottom` (ReactRootView.java), i.e.
+	// the keyboard height with the navigation bar already subtracted. Our root
+	// view runs edge-to-edge underneath that nav bar, so padding by the reported
+	// height alone left the dock short by exactly the nav-bar inset - half an
+	// input row under gesture nav, a whole one under 3-button nav.
+	it("adds the navigation-bar inset back on Android", () => {
+		expect(rootKeyboardPad("android", 336, 24)).toBe(360);
+		expect(rootKeyboardPad("android", 336, 48)).toBe(384);
+	});
+
+	it("reserves only the reported height on iOS, which already spans the home indicator", () => {
+		expect(rootKeyboardPad("ios", 336, 34)).toBe(336);
+	});
+
+	it("reserves nothing on either platform while the keyboard is down", () => {
+		expect(rootKeyboardPad("android", 0, 48)).toBe(0);
+		expect(rootKeyboardPad("ios", 0, 34)).toBe(0);
+	});
+
+	it("handles a device with the navigation bar hidden", () => {
+		expect(rootKeyboardPad("android", 336, 0)).toBe(336);
+	});
+});
+
 describe("screenKeyboardAvoidance", () => {
-	it("reserves the reported keyboard height using Android's final keyboard events", () => {
-		expect(screenKeyboardAvoidance("android", 336)).toEqual({
+	it("reserves the reported keyboard height plus the nav bar using Android's final keyboard events", () => {
+		expect(screenKeyboardAvoidance("android", 336, 48)).toEqual({
 			showEvent: "keyboardDidShow",
 			hideEvent: "keyboardDidHide",
-			paddingBottom: 336,
-			rootStyle: { paddingBottom: 336 },
+			paddingBottom: 384,
+			rootStyle: { paddingBottom: 384 },
 		});
+	});
+
+	it("collapses to nothing when the keyboard is down", () => {
+		expect(screenKeyboardAvoidance("android", 0, 48).rootStyle).toEqual({ paddingBottom: 0 });
+	});
+});
+
+// The dock sits inside the root view, so the root's padding is the only place
+// the keyboard is accounted for. Together they must clear the keyboard exactly.
+describe("root padding and dock inset together", () => {
+	it("clear the full Android keyboard occupancy without double-counting", () => {
+		const kb = 336; // as reported by RN: ime inset minus nav bar
+		const nav = 48;
+		expect(rootKeyboardPad("android", kb, nav) + dockInset(kb, nav)).toBe(kb + nav);
+	});
+
+	it("fall back to the safe-area inset with the keyboard down", () => {
+		expect(rootKeyboardPad("android", 0, 48) + dockInset(0, 48)).toBe(48);
 	});
 });
 

--- a/packages/mobile/lib/session/keyboardInset.ts
+++ b/packages/mobile/lib/session/keyboardInset.ts
@@ -2,9 +2,9 @@
 // is testable — getting it wrong is what made the dock jump twice whenever the
 // keyboard appeared.
 //
-// The screen already reserves `kbHeight` as padding on its root view, which
-// lifts everything above the keyboard. The dock must therefore add *nothing*
-// more while the keyboard is up: the old code flipped its own padding from
+// The screen already reserves the keyboard (see `rootKeyboardPad`) as padding
+// on its root view, which lifts everything above the keyboard. The dock must
+// therefore add *nothing* more while the keyboard is up: the old code flipped its own padding from
 // `insets.bottom` (34pt on a notched phone) to `8` at the same moment the root
 // gained the keyboard height, so the two moves fought each other and the bar
 // visibly kicked.
@@ -15,18 +15,50 @@
 /** Minimum breathing room under the dock on a device with no home indicator. */
 export const MIN_DOCK_INSET = 8;
 
-export function screenKeyboardAvoidance(platform: "android" | "ios", height: number) {
+/**
+ * Bottom padding the root view owes to clear the keyboard.
+ *
+ * `height` is whatever the platform's keyboard event reported, and the two
+ * platforms report different things:
+ *
+ * - iOS measures from the bottom of the screen, so the value already spans the
+ *   home indicator. Reserve it as-is.
+ * - Android reports `imeInsets.bottom - systemBars.bottom` (see
+ *   `checkForKeyboardEvents` in ReactRootView.java) — the keyboard height with
+ *   the navigation bar already subtracted. But our root view runs edge-to-edge
+ *   underneath that nav bar, so the keyboard actually covers the full
+ *   `imeInsets.bottom`. Padding by the reported height alone left the dock
+ *   short by exactly the nav-bar inset, which is why the input row was cut in
+ *   half under gesture nav (~24dp) and hidden outright under 3-button nav
+ *   (48dp). Add the inset back.
+ */
+export function rootKeyboardPad(
+	platform: "android" | "ios",
+	height: number,
+	insetsBottom: number,
+): number {
+	if (height <= 0) return 0;
+	return platform === "android" ? height + insetsBottom : height;
+}
+
+export function screenKeyboardAvoidance(
+	platform: "android" | "ios",
+	height: number,
+	insetsBottom: number,
+) {
+	const paddingBottom = rootKeyboardPad(platform, height, insetsBottom);
 	return {
 		showEvent: platform === "ios" ? "keyboardWillShow" as const : "keyboardDidShow" as const,
 		hideEvent: platform === "ios" ? "keyboardWillHide" as const : "keyboardDidHide" as const,
-		paddingBottom: height,
-		rootStyle: { paddingBottom: height },
+		paddingBottom,
+		rootStyle: { paddingBottom },
 	};
 }
 
 export function dockInset(kbHeight: number, insetsBottom: number): number {
-	// Keyboard up: the root view's padding already clears it. Anything here is
-	// dead space between the dock and the keyboard.
+	// Keyboard up: the root view's padding (rootKeyboardPad) already clears the
+	// keyboard *and* the nav bar beneath it. Anything here is dead space between
+	// the dock and the keyboard.
 	if (kbHeight > 0) return 0;
 	return insetsBottom > 0 ? insetsBottom : MIN_DOCK_INSET;
 }


### PR DESCRIPTION
Two Android-only mobile fixes. Both are pure JS/TS — no native module, config plugin, or `app.json` change.

## 1. Keyboard covered the input dock on every Android device

React Native's Android keyboard event does not report the keyboard's height above the screen bottom. From `ReactRootView.checkForKeyboardEvents`:

```java
Insets barInsets = rootInsets.getInsets(WindowInsetsCompat.Type.systemBars());
Insets imeInsets = rootInsets.getInsets(WindowInsetsCompat.Type.ime());
int height = imeInsets.bottom - barInsets.bottom;   // nav bar subtracted
```

So `e.endCoordinates.height` is the keyboard height **with the navigation bar already subtracted**. The terminal, chat and spawn screens padded their root view by exactly that value, but the root view draws edge-to-edge underneath the nav bar, so the keyboard actually covers the full `imeInsets.bottom`.

Every Android device was short by exactly the nav-bar inset:

| Nav mode | Inset | Symptom |
|---|---|---|
| Gesture | ~24dp | input row cut in half |
| 3-button | 48dp | input row hidden behind the keyboard |

iOS was unaffected — its event measures from the screen bottom and already spans the home indicator.

New `rootKeyboardPad(platform, height, insetsBottom)` owns that platform difference; `screenKeyboardAvoidance` now takes the inset as a **required** argument so a call site cannot silently reintroduce the bug. `useSafeAreaInsets().bottom` is the correct addend: `react-native-safe-area-context` builds its bottom inset from `statusBars | displayCutout | navigationBars | captionBar` on API 30+ and clamps the IME out on the older path, so it is exactly the `barInsets.bottom` RN subtracted.

Verified on a Pixel 7 emulator (API 35) in both nav modes, and on the terminal and chat docks.

## 2. Orchestrator card offered Restart only when nothing needed restarting

The card rendered Restart when `state === "running"` and hid it otherwise — the inverse. A healthy orchestrator carried a destructive retire-and-replace button, while one that had exited offered "Start orchestrator", which reads as though the app had lost track of a session that has clearly already run.

| State | Footer now |
|---|---|
| running | `Open` only |
| stopped (exited) | `Restart orchestrator` |
| missing (never started) | `Start orchestrator` |

`launchIntent` keeps its running branch: it is still the correct answer to what a launch would do, and the destructive path must keep its confirmation if the card ever offers it again.

Both footer actions are now the shared `Button` rather than a 32x32 `IconButton` and a bespoke 32pt pill, so the tap target is a full-height labelled control. The card itself stays deliberately inert — the zone pills open the board, so a whole-card target would send two taps a few pixels apart to different screens.

## Verification

- `npx tsc --noEmit` — exit 0
- `npx vitest run` — 709 passed (up from 708; new tests written red-first)
- Both changes exercised on a live Pixel 7 / API 35 emulator against a real daemon

The new `launchIntent` test asserts the two labels **exactly** rather than with `/start/i` — "Restart" contains "start", so a loose match passes whichever label is wrong.

## Shipping

JS-only, and this branch's Android fingerprint `bcfb745ef3a294b08d2324b090febfc0a900bc0f` matches production build `ed8bcf7e` (1.3.0, versionCode 8), so this is deliverable over EAS Update on the `production` channel.

## Not verified

The stopped/missing orchestrator footer is covered by unit tests only — every project on the test daemon had a running orchestrator, and staging the state would have meant stopping a live one.
