### PR TITLE
fix(tmux): target bare session in respawn-pane and pane-pid probe

### DIFF
--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -17,11 +17,13 @@ func newSessionArgs(id, cwd, shellPath, launchCmd string) []string {
 }
 
 // respawnPaneArgs replaces the process in the session's only pane while keeping
-// the tmux session and terminal handle intact.
+// the tmux session and terminal handle intact. The bare session target resolves
+// to the active window/pane regardless of the user's base-index /
+// pane-base-index (a hardcoded :0.0 misses when either is 1, see #4656).
 func respawnPaneArgs(id, cwd, shellPath, launchCmd string) []string {
 	return []string{
 		"respawn-pane", "-k",
-		"-t", id + ":0.0",
+		"-t", id,
 		"-c", cwd,
 		shellPath, "-c", launchCmd,
 	}
@@ -56,9 +58,11 @@ func setWindowSizeLargestArgs(id string) []string {
 }
 
 // panePIDArgs returns the pid of tmux's direct pane process. AO walks its
-// descendants to find the exact supervisor for the current launch.
+// descendants to find the exact supervisor for the current launch. The bare
+// session target keeps this independent of base-index / pane-base-index
+// (see respawnPaneArgs, #4656).
 func panePIDArgs(id string) []string {
-	return []string{"display-message", "-p", "-t", id + ":0.0", "#{pane_pid}"}
+	return []string{"display-message", "-p", "-t", id, "#{pane_pid}"}
 }
 
 // paneCurrentPathArgs prints tmux's cwd for the session's active pane. Create

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -236,7 +236,7 @@ func TestCommandBuilders(t *testing.T) {
 		t.Fatalf("newSessionArgs = %#v, want %#v", got, want)
 	}
 	if got, want := respawnPaneArgs("sess-1", "/tmp/ws", "/bin/sh", "echo hi"),
-		[]string{"respawn-pane", "-k", "-t", "sess-1:0.0", "-c", "/tmp/ws", "/bin/sh", "-c", "echo hi"}; !reflect.DeepEqual(got, want) {
+		[]string{"respawn-pane", "-k", "-t", "sess-1", "-c", "/tmp/ws", "/bin/sh", "-c", "echo hi"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("respawnPaneArgs = %#v, want %#v", got, want)
 	}
 	// set-option uses pane-targeting (no = prefix).
@@ -259,7 +259,7 @@ func TestCommandBuilders(t *testing.T) {
 	if got, want := hasSessionArgs("sess-1"), []string{"has-session", "-t", "=sess-1"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("hasSessionArgs = %#v, want %#v", got, want)
 	}
-	if got, want := panePIDArgs("sess-1"), []string{"display-message", "-p", "-t", "sess-1:0.0", "#{pane_pid}"}; !reflect.DeepEqual(got, want) {
+	if got, want := panePIDArgs("sess-1"), []string{"display-message", "-p", "-t", "sess-1", "#{pane_pid}"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("panePIDArgs = %#v, want %#v", got, want)
 	}
 	// list-panes reaps whole-session (-s) with exact-match target and prints pane pids.
@@ -733,7 +733,7 @@ func TestRestartRespawnsExistingPaneAndPreservesHandle(t *testing.T) {
 	if len(fr.calls) != 2 {
 		t.Fatalf("calls = %d, want respawn + liveness probe", len(fr.calls))
 	}
-	if args := fr.calls[0].args; len(args) < 6 || args[0] != "respawn-pane" || args[1] != "-k" || args[3] != "sess-1:0.0" || args[5] != "/tmp/ws" {
+	if args := fr.calls[0].args; len(args) < 6 || args[0] != "respawn-pane" || args[1] != "-k" || args[3] != "sess-1" || args[5] != "/tmp/ws" {
 		t.Fatalf("respawn args = %#v", args)
 	}
 	if args := fr.calls[1].args; !reflect.DeepEqual(args, hasSessionArgs("sess-1")) {


### PR DESCRIPTION
Fixes #4656.

## What
`respawn-pane` and the pane-pid probe hardcoded the target `<session>:0.0`, assuming tmux's `base-index` / `pane-base-index` are both `0`. With either set to `1` (a very common customization) the target misses and `Runtime.Restart` — the path session restore uses — always fails with `can't find pane: 0` / `can't find window: 0`.

## How
Target the bare session name instead (`respawn-pane -k -t <session>`, `display-message -p -t <session>`), which resolves to the active window/pane regardless of either option. AO sessions have a single pane, so this is exact. It also matches the file's existing convention: `set-option`, `send-keys`, `capture-pane`, and `paneCurrentPathArgs` already use the bare id. The alternative (resolving a stable `#{pane_id}` first) was left out as unnecessary complexity for single-pane sessions.

`panePIDArgs` was latent rather than broken (`display-message` falls back silently) but carried the same unchecked assumption, so it gets the same fix.

## Tests
- Updated `TestCommandBuilders` (both arg builders) and `TestRestartRespawnsExistingPaneAndPreservesHandle` (restart call-site assertion).
- Targeted tests pass; `go vet` clean; build passes.
- Full `tmux` package run has 4 failures (`TestNewUsesSystemTmuxForLegacyDefaultSocket`, `TestExecRunnerRunsFromStableDir`, `TestExecRunnerFallsBackWhenTempDirMissing`, `TestIsUnsupportedMatcher`) that fail identically on unmodified `main` — pre-existing Windows-environment issues (TempDir/socket preconditions), unrelated to this change.
- The issue's Linux integration tests (`TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell`, `TestAttachmentStreamsRealTmuxPane`) need real tmux and can't run on this Windows box; CI should cover them.
