### PR TITLE
fix(cline): keep bypass-permissions in TUI mode with --auto-approve

### DIFF
--- a/backend/internal/adapters/agent/cline/cline.go
+++ b/backend/internal/adapters/agent/cline/cline.go
@@ -213,7 +213,10 @@ func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
 		// Auto-approve every tool for unattended runs.
 		*cmd = append(*cmd, "--auto-approve", "true")
 	case ports.PermissionModeBypassPermissions:
-		// yolo mode: auto-approve tools with the restricted (safer) toolset.
-		*cmd = append(*cmd, "--yolo")
+		// Bypass maps onto --auto-approve, not --yolo: Cline's --yolo forces
+		// headless plain-text output (exit-when-complete), which contradicts
+		// this adapter's TUI assumptions (readiness hints, terminal activity
+		// detection, and after-start prompt injection). See #4944.
+		*cmd = append(*cmd, "--auto-approve", "true")
 	}
 }

--- a/backend/internal/adapters/agent/cline/cline_test.go
+++ b/backend/internal/adapters/agent/cline/cline_test.go
@@ -28,7 +28,7 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 
 	want := []string{
 		"cline",
-		"--yolo",
+		"--auto-approve", "true",
 		"-s", "be careful",
 	}
 	if !reflect.DeepEqual(cmd, want) {
@@ -55,7 +55,7 @@ func TestGetLaunchCommandOmitsJSONForPromptlessInteractiveLaunch(t *testing.T) {
 
 	want := []string{
 		"cline",
-		"--yolo",
+		"--auto-approve", "true",
 		"-s", "coordinate the project",
 	}
 	if !reflect.DeepEqual(cmd, want) {
@@ -91,7 +91,7 @@ func TestGetLaunchCommandMapsApprovalModes(t *testing.T) {
 		{
 			name:       "bypass-permissions",
 			permission: ports.PermissionModeBypassPermissions,
-			want:       []string{"--yolo"},
+			want:       []string{"--auto-approve", "true"},
 		},
 		{
 			name:        "empty",


### PR DESCRIPTION
Fixes #4944

## Summary
Cline's --yolo forces headless plain-text output, which contradicts the
adapter's TUI assumptions (readiness hints, terminal activity detection,
after-start prompt injection). Bypass-permissions sessions therefore never
became ready. This maps bypass onto --auto-approve true (same as uto
mode) and updates the three test spots that enshrined --yolo.

Changed: ackend/internal/adapters/agent/cline/cline.go
(ppendApprovalFlags) + cline_test.go. No other adapter touched:
every other harness's --yolo is its own flag and does not force
headless; the Cline reviewer twin sends no approval flags at all.

Caveat (also in #4944): --yolo implies exit-when-complete, which
--auto-approve true does not. Nothing in the adapter depends on
headless auto-exit (it expects a persistent TUI).

## Test
- cd backend && go build ./... — pass
- go test ./internal/adapters/agent/cline/... ./internal/adapters/agent/activitydispatch/... ./internal/adapters/reviewer/cline/... ./internal/cli/... — all ok
- go vet ./internal/adapters/agent/cline/ — clean
- Full go test ./...: 3 failing packages (session_manager x7,
  	muxbin symlink privilege, workspacewatch timing) reproduce
  identically on pristine main (verified via a clean worktree at
  d2c88dae7) — pre-existing Windows-environment failures, unrelated
  to this change.