### PR TITLE
fix(frontend): recover terminal rendering after WebGL context loss

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -7,6 +7,8 @@ import { XtermTerminal } from "./XtermTerminal";
 
 const state = vi.hoisted(() => ({
 	fit: vi.fn(),
+	webgl: { listener: null as null | (() => void), disposeThrows: false, disposeCalls: 0 },
+	loadedAddons: [] as string[],
 	linkHandler: null as null | ((event: MouseEvent, uri: string) => void),
 	searchAddon: null as null | {
 		clearDecorations: ReturnType<typeof vi.fn>;
@@ -100,7 +102,9 @@ vi.mock("@xterm/xterm", () => ({
 			state.lastTerminal = this;
 		}
 
-		loadAddon() {}
+		loadAddon(addon: unknown) {
+			state.loadedAddons.push((addon as object).constructor.name);
+		}
 		open(host: HTMLElement) {
 			host.appendChild(document.createElement("textarea"));
 		}
@@ -189,8 +193,13 @@ vi.mock("@xterm/addon-canvas", () => ({
 
 vi.mock("@xterm/addon-webgl", () => ({
 	WebglAddon: class FakeWebglAddon {
-		onContextLoss() {}
-		dispose() {}
+		onContextLoss(listener: () => void) {
+			state.webgl.listener = listener;
+		}
+		dispose() {
+			state.webgl.disposeCalls += 1;
+			if (state.webgl.disposeThrows) throw new Error("simulated WebGL addon dispose failure");
+		}
 	},
 }));
 
@@ -208,6 +217,8 @@ function setNavigatorPlatform(platform: string) {
 describe("XtermTerminal", () => {
 	beforeEach(() => {
 		state.fit.mockReset();
+		state.webgl = { listener: null, disposeThrows: false, disposeCalls: 0 };
+		state.loadedAddons = [];
 		state.lastTerminal = null;
 		state.linkHandler = null;
 		state.searchAddon = null;
@@ -282,6 +293,35 @@ describe("XtermTerminal", () => {
 
 		expect(state.lastTerminal!.options.drawBoldTextInBrightColors).toBe(true);
 		expect(state.lastTerminal!.options.minimumContrastRatio).toBe(1);
+	});
+
+	it("falls back to the canvas renderer even when the WebGL addon throws while disposing after context loss", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		try {
+			state.webgl.disposeThrows = true;
+			render(<XtermTerminal theme="dark" />);
+			expect(state.loadedAddons).toContain("FakeWebglAddon");
+			expect(state.loadedAddons).not.toContain("FakeCanvasAddon");
+			expect(state.webgl.listener).not.toBeNull();
+
+			expect(() => state.webgl.listener!()).not.toThrow();
+
+			expect(state.webgl.disposeCalls).toBe(1);
+			expect(state.loadedAddons.filter((name) => name === "FakeCanvasAddon")).toHaveLength(1);
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("WebGL"), expect.any(Error));
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it("handles a repeated context-loss notification once", () => {
+		render(<XtermTerminal theme="dark" />);
+
+		state.webgl.listener!();
+		state.webgl.listener!();
+
+		expect(state.webgl.disposeCalls).toBe(1);
+		expect(state.loadedAddons.filter((name) => name === "FakeCanvasAddon")).toHaveLength(1);
 	});
 
 	it("focuses the terminal when human input is requested", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -110,8 +110,24 @@ function loadRenderer(term: Terminal): void {
 	};
 	try {
 		const webgl = new WebglAddon();
+		let contextLost = false;
 		webgl.onContextLoss(() => {
-			webgl.dispose();
+			// Chromium keeps at most 16 live WebGL contexts per renderer process and
+			// evicts the least-recently-drawn one when a 17th is created. Every
+			// retained terminal holds one context, so long-parked panes are evicted
+			// first. Disposing the WebGL addon here can throw (observed 2026-09-05:
+			// the error's stack passed through this handler twice, re-entering from
+			// the addon's dispose-time renderer restore), and an uncaught throw
+			// skipped the canvas fallback, leaving the pane blank while its PTY
+			// attachment kept working. Handle the loss once, tolerate the throw, and
+			// always install the canvas renderer.
+			if (contextLost) return;
+			contextLost = true;
+			try {
+				webgl.dispose();
+			} catch (error) {
+				console.warn("xterm: WebGL addon dispose failed after context loss; loading the canvas renderer", error);
+			}
 			loadCanvasFallback();
 		});
 		term.loadAddon(webgl);


### PR DESCRIPTION
## What

Keep an xterm terminal rendering after WebGL context loss, even if disposing the WebGL addon throws. Handle repeated loss notifications once.

## Why

Reported on desktop v0.12.10 / Electron 33.4.11 after visiting many sessions in one shell renderer. Chromium logged "Too many active WebGL contexts. Oldest context will be lost." Long-parked terminal panes became blank while their PTY attachments kept working.

The existing loss handler calls `webgl.dispose()` before `loadCanvasFallback()`. A dispose error escapes the handler and prevents the canvas renderer from loading.

## How

Set a per-addon loss flag before disposing. Warn if disposal throws, then call the existing canvas fallback. The flag also prevents repeated or reentrant notifications from disposing or loading the fallback twice. The production call site remains `loadRenderer(term)` in `XtermTerminal`.

Only `XtermTerminal.tsx` and its test file change. This does not change terminal retention, Chromium's context budget, session lifecycle, or the existing behavior if the canvas addon itself cannot load.

## Testing

Rebased onto upstream `main` at `d06b2162d0a84887d67105cae392184255032e21`. Local validation used macOS arm64, Node 24.13.0 and locked dependencies.

| Check | Result |
| --- | --- |
| `npx vitest run --config vite.renderer.config.ts src/renderer/components/XtermTerminal.test.tsx` | 83 passed |
| Mutation proof: restore the upstream handler while retaining the new tests | Exactly the two new tests fail: disposal throws, and repeated loss disposes twice |
| Restore the fix | 83 passed again |
| `npm run typecheck` and `npm run typecheck:e2e` in frontend | Both pass |
| Complete frontend `npx vitest run` with the pinned agent-browser test binary | 3,734 passed, 6 skipped, zero failures |
| `CI=true npm run test:e2e:renderer` with an isolated port and the live daemon proxy disabled | 55 passed |
| Cloud client generate, schema drift check, typecheck, tests, pack dry run | All pass; 21 tests |
| Product UI typecheck, tests, pack dry run | All pass; 120 tests |
| Pinned CI gitleaks v7.4 image and configuration | One PR commit scanned; no leaks |

The initial complete-suite attempt lacked the SQLite native binding and Electron test dependency. Preparing those dependencies resolved the failures without source changes. The browser smoke suite passed after installing its pinned Chromium.

The local smoke run uses macOS, not CI's Ubuntu Playwright container. Remote CI remains a separate check. The new context-loss tests simulate addon events and disposal errors; no packaged-app GPU-context eviction or live desktop installation was performed.

## Checklist

- [x] Based on current upstream `main`
- [x] One focused change
- [x] Follows repository conventions and PR hygiene
- [x] Regression tests added and proven to fail without the fix
- [ ] Remote CI checks pass (pending upstream execution)
