### PR TITLE
fix(updates): honor saved channels and recover stalled checks

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2668,22 +2668,37 @@ describe("channel downgrade safety", () => {
     });
   }
 
-  it("rejects older stable on routine manual and automatic checks", async () => {
-    const h = await importAutoUpdater(stable, { version: running });
+  it.each([false, true])("honors saved Stable on startup and later checks (automatic download %s)", async (enabled) => {
+    const h = await importAutoUpdater({ ...stable, enabled }, { version: running });
     serveVersion(h, "0.12.10");
-    await h.module.checkForUpdatesNow(stateDir);
-    expect(h.module.getUpdateStatus().state).toBe("not-available");
     await h.module.startAutoUpdates(stateDir);
-    expect(h.module.getUpdateStatus().state).toBe("not-available");
-    expect(h.autoUpdater.allowDowngrade).toBe(false);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+    expect(h.autoUpdater.autoDownload).toBe(enabled);
+    await h.module.checkForUpdatesNow(stateDir);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+    expect(h.autoUpdater.allowDowngrade).toBe(true);
   });
 
-  it("permits an explicit channel change but resets downgrade permission on the next routine check", async () => {
+  it("retains a saved channel switch after its first check fails", async () => {
     const h = await importAutoUpdater(nightly, { version: running });
-    serveVersion(h, "0.12.10");
+    h.writeUpdateSettings.mockImplementation(async (_dir, settings) => {
+      h.readUpdateSettings.mockResolvedValue(settings);
+    });
+    h.autoUpdater.checkForUpdates.mockRejectedValueOnce(new Error("network unavailable"));
     await h.module.checkForUpdatesNow(stateDir, { settings: stable });
-    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+    expect(h.module.getUpdateStatus().state).toBe("error");
+    serveVersion(h, "0.12.10");
     await h.module.checkForUpdatesNow(stateDir);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+  });
+
+  it("stops allowing downgrades after relaunching into the selected Stable channel", async () => {
+    const h = await importAutoUpdater(stable, { version: "0.12.10" });
+    serveVersion(h, "0.12.9", "0.12.10");
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.module.getUpdateStatus().state).toBe("not-available");
     expect(h.autoUpdater.allowDowngrade).toBe(false);
   });
 

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import semver from "semver";
+import { CancellationToken } from "builder-util-runtime";
 import nodePath from "node:path";
 
 type UpdateSettings = {
@@ -36,6 +37,7 @@ type AutoUpdaterMock = {
   allowDowngrade: boolean;
   autoDownload: boolean;
   autoInstallOnAppQuit: boolean;
+  httpExecutor: { request: ReturnType<typeof vi.fn<(options: object, token?: CancellationToken) => Promise<string | null>>> };
 };
 
 function createAutoUpdaterMock(): AutoUpdaterMock {
@@ -50,6 +52,7 @@ function createAutoUpdaterMock(): AutoUpdaterMock {
     allowDowngrade: false,
     autoDownload: false,
     autoInstallOnAppQuit: false,
+    httpExecutor: { request: vi.fn(async () => null) },
   };
 }
 
@@ -1973,6 +1976,66 @@ describe("startAutoUpdates", () => {
 
     updaterEvents.get("update-downloaded")?.({ version: "2.2.0" });
     expect(setIntervalSpy.mock.calls.length).toBeGreaterThan(afterFirst);
+  });
+
+  it.each([false, true])("settles an automatic check without a terminal event (available %s)", async (available) => {
+    const h = await importAutoUpdater({ enabled: false, channel: "nightly", nightlyAck: true, feature: null });
+    h.autoUpdater.checkForUpdates.mockImplementation(async () => {
+      h.updaterEvents.get("checking-for-update")?.();
+      return { isUpdateAvailable: available, updateInfo: { version: "2.0.0-nightly.1" } };
+    });
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.module.getUpdateStatus().state).toBe(available ? "available" : "not-available");
+  });
+
+  it.each(["manual", "automatic", "return-home"] as const)("aborts a hung %s check before letting a queued retry run", async (kind) => {
+    vi.useFakeTimers();
+    const h = await importAutoUpdater();
+    let requestAborted = false;
+    let finishAborting!: () => void;
+    const originalRequest = h.autoUpdater.httpExecutor.request;
+    originalRequest.mockImplementation(async (_options, token) => {
+      try {
+        return await token!.createPromise<string>(() => {});
+      } finally {
+        requestAborted = true;
+        await new Promise<void>((resolve) => { finishAborting = resolve; });
+      }
+    });
+    h.autoUpdater.checkForUpdates.mockImplementationOnce(async () => {
+      h.updaterEvents.get("checking-for-update")?.();
+      await h.autoUpdater.httpExecutor.request({});
+    }).mockResolvedValue({ isUpdateAvailable: false, updateInfo: { version: "1.0.0" } });
+    const first = kind === "manual" ? h.module.checkForUpdatesNow(stateDir, { requestId: "hung" })
+      : kind === "automatic" ? h.module.startAutoUpdates(stateDir) : h.module.returnToHome(stateDir, "hung");
+    await vi.advanceTimersByTimeAsync(0);
+    const retry = h.module.checkForUpdatesNow(stateDir, { requestId: "retry" });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(requestAborted).toBe(true);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "error", message: expect.stringContaining("timed out") });
+    expect(h.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+    finishAborting();
+    await first;
+    await retry;
+    expect(h.autoUpdater.httpExecutor.request).toBe(originalRequest);
+    expect(h.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "not-available", requestId: "retry" });
+  });
+
+  it("clears the check deadline before an automatic download continues", async () => {
+    vi.useFakeTimers();
+    const h = await importAutoUpdater();
+    const originalRequest = h.autoUpdater.httpExecutor.request;
+    let finishDownload!: () => void;
+    h.autoUpdater.checkForUpdates.mockResolvedValue({
+      isUpdateAvailable: true, updateInfo: { version: "2.0.0" },
+      downloadPromise: new Promise<void>((resolve) => { finishDownload = resolve; }),
+    });
+    const checking = h.module.startAutoUpdates(stateDir);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(h.autoUpdater.httpExecutor.request).toBe(originalRequest);
+    finishDownload();
+    await checking;
   });
 
   // Regression: electron-updater returns the in-flight promise when a check is

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
+import semver from "semver";
 import nodePath from "node:path";
 
 type UpdateSettings = {
@@ -21,6 +22,7 @@ type ImportOptions = {
     settings: UpdateSettings,
   ) => Promise<{ settings: UpdateSettings; cleared: boolean }>;
   isPackaged?: boolean;
+  version?: string;
 };
 
 type AutoUpdaterMock = {
@@ -109,7 +111,7 @@ async function importAutoUpdater(
   vi.doMock("electron", () => ({
     app: {
       isPackaged: options.isPackaged ?? true,
-      getVersion: () => "1.0.0",
+      getVersion: () => options.version ?? "1.0.0",
     },
     BrowserWindow,
     dialog,
@@ -2649,5 +2651,131 @@ describe("install-on-quit policy", () => {
       restore();
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("channel downgrade safety", () => {
+  const nightly = { enabled: false, channel: "nightly", nightlyAck: true, feature: null } as const;
+  const stable = { enabled: false, channel: "latest", nightlyAck: false, feature: null } as const;
+  const running = "0.12.11-nightly.202609051608";
+
+  function serveVersion(harness: Awaited<ReturnType<typeof importAutoUpdater>>, version: string, installed = running) {
+    harness.autoUpdater.checkForUpdates.mockImplementation(async () => {
+      const available = semver.gt(version, installed) ||
+        (harness.autoUpdater.allowDowngrade && semver.lt(version, installed));
+      harness.updaterEvents.get(available ? "update-available" : "update-not-available")?.({ version });
+      return { isUpdateAvailable: available, updateInfo: { version } };
+    });
+  }
+
+  it("rejects older stable on routine manual and automatic checks", async () => {
+    const h = await importAutoUpdater(stable, { version: running });
+    serveVersion(h, "0.12.10");
+    await h.module.checkForUpdatesNow(stateDir);
+    expect(h.module.getUpdateStatus().state).toBe("not-available");
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.module.getUpdateStatus().state).toBe("not-available");
+    expect(h.autoUpdater.allowDowngrade).toBe(false);
+  });
+
+  it("permits an explicit channel change but resets downgrade permission on the next routine check", async () => {
+    const h = await importAutoUpdater(nightly, { version: running });
+    serveVersion(h, "0.12.10");
+    await h.module.checkForUpdatesNow(stateDir, { settings: stable });
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+    await h.module.checkForUpdatesNow(stateDir);
+    expect(h.autoUpdater.allowDowngrade).toBe(false);
+  });
+
+  it.each([
+    { settings: stable, installed: "0.12.11", offered: "0.12.10" },
+    { settings: { ...stable, feature: { pr: 4900 } }, installed: "0.12.11-pr4900.2", offered: "0.12.11-pr4900.1" },
+  ])("rejects routine older releases on $installed", async ({ settings, installed, offered }) => {
+    const h = await importAutoUpdater(settings, { version: installed });
+    serveVersion(h, offered, installed);
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.module.getUpdateStatus().state).toBe("not-available");
+    await h.module.checkForUpdatesNow(stateDir);
+    expect(h.module.getUpdateStatus().state).toBe("not-available");
+  });
+
+  it("does not redownload a staged candidate after rejecting an older manifest", async () => {
+    const h = await importAutoUpdater({ ...nightly, enabled: true }, { version: running });
+    await h.module.checkForUpdatesNow(stateDir);
+    h.updaterEvents.get("update-downloaded")?.({ version: "0.12.11-nightly.202609061608" });
+    serveVersion(h, "0.12.11-nightly.202609041608");
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.autoUpdater.autoDownload).toBe(false);
+    expect(h.autoUpdater.downloadUpdate).not.toHaveBeenCalled();
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "downloaded", version: "0.12.11-nightly.202609061608" });
+  });
+
+  it.each([
+    { settings: stable, installed: "0.12.10", offered: "0.12.11" },
+    { settings: nightly, installed: running, offered: "0.12.11-nightly.202609061608" },
+  ])("offers newer releases on $installed without downgrade permission", async ({ settings, installed, offered }) => {
+    const h = await importAutoUpdater(settings, { version: installed });
+    serveVersion(h, offered, installed);
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: offered });
+    await h.module.checkForUpdatesNow(stateDir);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: offered });
+    expect(h.autoUpdater.allowDowngrade).toBe(false);
+  });
+
+  it("allows an explicit channel switch when the preference was saved before checking", async () => {
+    const h = await importAutoUpdater(stable, { version: running });
+    serveVersion(h, "0.12.10");
+    await h.module.setUpdateSettings(stateDir, stable);
+    await h.module.checkForUpdatesNow(stateDir, { settings: stable });
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+  });
+
+  it("returns an installed feature build home after its pin is retired", async () => {
+    const installed = "0.12.11-pr4900.2";
+    const h = await importAutoUpdater(stable, { version: installed });
+    serveVersion(h, "0.12.10", installed);
+    await h.module.startAutoUpdates(stateDir);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+  });
+
+  it("permits an explicit return home from nightly", async () => {
+    const h = await importAutoUpdater(stable, { version: running });
+    serveVersion(h, "0.12.10");
+    await h.module.returnToHome(stateDir);
+    expect(h.module.getUpdateStatus()).toMatchObject({ state: "available", version: "0.12.10" });
+  });
+
+  it("does not permit a same-channel settings check to downgrade nightly", async () => {
+    const h = await importAutoUpdater(nightly, { version: running });
+    serveVersion(h, "0.12.11-nightly.202609041608");
+    await h.module.checkForUpdatesNow(stateDir, { settings: nightly });
+    expect(h.module.getUpdateStatus().state).toBe("not-available");
+  });
+
+  it("keeps first-run nightly on nightly when automatic downloads are declined", async () => {
+    const h = await importAutoUpdater(stable, { version: running });
+    h.dialog.showMessageBox.mockResolvedValue({ response: 1 });
+    await h.module.ensureUpdatePrefs(stateDir);
+    expect(h.writeUpdateSettings).toHaveBeenCalledWith(stateDir, nightly);
+  });
+
+  it("preselects nightly for the first-run channel choice on a nightly install", async () => {
+    const h = await importAutoUpdater(stable, { version: running });
+    h.dialog.showMessageBox
+      .mockResolvedValueOnce({ response: 0 })
+      .mockResolvedValueOnce({ response: 1 })
+      .mockResolvedValueOnce({ response: 0 });
+    await h.module.ensureUpdatePrefs(stateDir);
+    expect(h.dialog.showMessageBox.mock.calls[1]?.[0]).toMatchObject({ defaultId: 1, cancelId: 1 });
+    expect(h.writeUpdateSettings).toHaveBeenCalledWith(stateDir, { ...nightly, enabled: true });
+  });
+
+  it("preserves existing explicit stable preferences on a nightly install", async () => {
+    const h = await importAutoUpdater(stable, { version: running });
+    writeFileSync(nodePath.join(stateDir, "update-settings.json"), JSON.stringify(stable));
+    await h.module.ensureUpdatePrefs(stateDir);
+    expect(h.dialog.showMessageBox).not.toHaveBeenCalled();
+    expect(h.writeUpdateSettings).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -58,17 +58,18 @@ async function reconcileAndPersist(
 // checkForUpdates.
 //
 // When settings.feature is set, the feed tracks the pr<N> prerelease channel
-// (e.g. "pr2270") with allowPrerelease and allowDowngrade enabled so the user
-// can switch back to stable after testing. Otherwise falls back to the home
+// (e.g. "pr2270") with allowPrerelease enabled. Downgrades require a channel
+// transition; routine checks only move forward. Otherwise falls back to the home
 // channel logic (latest vs nightly).
 export function configureFeed(
   settings: Pick<UpdateSettings, "channel" | "feature">,
+  allowDowngrade = false,
 ): void {
   if (settings.feature !== null && settings.feature !== undefined) {
     // Feature build: pin to the pr<N> semver prerelease identifier channel.
     autoUpdater.channel = `pr${settings.feature.pr}`;
     autoUpdater.allowPrerelease = true;
-    autoUpdater.allowDowngrade = true; // allows switching back to stable/nightly
+    autoUpdater.allowDowngrade = allowDowngrade;
     return;
   }
 
@@ -79,7 +80,7 @@ export function configureFeed(
   // release and looks for nightly-mac.yml there, which 404s. Enable prerelease
   // scanning on the nightly channel only; stable must never pull prereleases.
   autoUpdater.allowPrerelease = channel === "nightly";
-  autoUpdater.allowDowngrade = true; // permits a nightly -> stable channel switch
+  autoUpdater.allowDowngrade = allowDowngrade;
 }
 
 let lastStatus: UpdateStatus = { state: "idle" };
@@ -562,6 +563,21 @@ function effectiveChannel(
   settings: Pick<UpdateSettings, "channel" | "feature">,
 ): string {
   return settings.feature ? `pr${settings.feature.pr}` : settings.channel;
+}
+
+/** Identify the running build independently of a channel choice already saved by Settings. */
+function installedUpdateChannel(): string {
+  const prerelease = semver.prerelease(app.getVersion())?.[0];
+  return typeof prerelease === "string" ? prerelease : "latest";
+}
+
+function isChannelTransition(settings: Pick<UpdateSettings, "channel" | "feature">): boolean {
+  return effectiveChannel(settings) !== installedUpdateChannel();
+}
+
+/** A retired feature pin must still be able to return to its home release. */
+function returningFromFeatureBuild(settings: UpdateSettings): boolean {
+  return settings.feature === null && /^pr\d+$/.test(installedUpdateChannel());
 }
 
 /**
@@ -1100,7 +1116,7 @@ async function runAutomaticUpdateCheck(
 
       escalationStateDir = stateDir;
       wireUpdaterEvents();
-      configureFeed(settings);
+      configureFeed(settings, returningFromFeatureBuild(settings));
       // Discovery is always on for the selected release channel. This preference
       // controls only whether electron-updater downloads the discovered build or
       // leaves it in `available` for the sidebar action.
@@ -1134,7 +1150,10 @@ async function runAutomaticUpdateCheck(
             // so a stall can actually be cancelled rather than just reported.
             activeDownloadCancellation = result.cancellationToken;
             await result.downloadPromise;
-          } else if (supersedesStagedBuild(result?.updateInfo?.version)) {
+          } else if (
+            result?.isUpdateAvailable === true &&
+            supersedesStagedBuild(result.updateInfo?.version)
+          ) {
             // autoDownload was suspended for the staged build, but this is a
             // different version, so it still has to be fetched automatically.
             activeUpdaterPhase = "download";
@@ -1290,7 +1309,11 @@ export async function checkForUpdatesNow(
           options.settings ?? (await readUpdateSettings(stateDir)),
         );
         reconcileAutomaticUpdateSchedule(stateDir, settings);
-        configureFeed(settings);
+        configureFeed(
+          settings,
+          (options.settings !== undefined && isChannelTransition(settings)) ||
+            returningFromFeatureBuild(settings),
+        );
         // Same reason as the automatic path: a channel switch leaves the old
         // channel's build armed, and only staging the new one over it helps.
         const staleStaged = stagedBuildIsStale(settings);
@@ -1363,7 +1386,7 @@ export async function returnToHome(
         );
         const settings = await reconcileAndPersist(stateDir, cleared);
         reconcileAutomaticUpdateSchedule(stateDir, settings);
-        configureFeed(settings);
+        configureFeed(settings, isChannelTransition(settings));
         // Leaving a pinned PR build is the same class of switch: its build is
         // armed and has to be superseded, not merely forgotten.
         const staleStaged = stagedBuildIsStale(settings);
@@ -1533,6 +1556,7 @@ export function quitAndInstallUpdate(): void {
 export async function ensureUpdatePrefs(stateDir: string): Promise<void> {
   if (existsSync(path.join(stateDir, UPDATE_SETTINGS_FILE_NAME))) return;
 
+  const installedNightly = installedUpdateChannel() === "nightly";
   const optIn = await dialog.showMessageBox({
     type: "question",
     buttons: ["Enable auto-updates", "Not now"],
@@ -1544,8 +1568,8 @@ export async function ensureUpdatePrefs(stateDir: string): Promise<void> {
   if (optIn.response !== 0) {
     await writeUpdateSettings(stateDir, {
       enabled: false,
-      channel: "latest",
-      nightlyAck: false,
+      channel: installedNightly ? "nightly" : "latest",
+      nightlyAck: installedNightly,
       feature: null,
     });
     return;
@@ -1554,8 +1578,8 @@ export async function ensureUpdatePrefs(stateDir: string): Promise<void> {
   const chan = await dialog.showMessageBox({
     type: "question",
     buttons: ["Stable", "Nightly"],
-    defaultId: 0,
-    cancelId: 0,
+    defaultId: installedNightly ? 1 : 0,
+    cancelId: installedNightly ? 1 : 0,
     message: "Which update channel?",
     detail: "Stable is released and tested. Nightly is the newest daily build.",
   });

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -5,6 +5,7 @@ import { accessSync, constants as fsConstants, existsSync, readFileSync } from "
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import semver from "semver";
+import type { RequestOptions } from "node:http";
 import {
   readUpdateSettings,
   updateUpdateSettings,
@@ -652,6 +653,49 @@ function supersedesStagedBuild(version: string | undefined): boolean {
 
 type UpdateCheckOutcome = Awaited<ReturnType<typeof autoUpdater.checkForUpdates>>;
 
+const UPDATE_CHECK_TIMEOUT_MS = 60_000;
+const UPDATE_CHECK_TIMEOUT_MESSAGE = "Update check timed out. Check your connection and try again.";
+
+// electron-updater owns this executor but omits it from its public declarations.
+// Limit the adapter to metadata requests; downloads retain their own cancellation.
+type UpdateMetadataExecutor = {
+  request(options: RequestOptions, token?: CancellationToken, data?: Record<string, unknown> | null): Promise<string | null>;
+};
+
+async function checkForUpdatesWithDeadline(): Promise<UpdateCheckOutcome> {
+  const executor = (autoUpdater as typeof autoUpdater & { httpExecutor: UpdateMetadataExecutor }).httpExecutor;
+  const request = executor.request;
+  const tokens = new Set<CancellationToken>();
+  let timedOut = false;
+  executor.request = async (options, parent, data) => {
+    const token = new CancellationToken(parent);
+    tokens.add(token);
+    if (timedOut) token.cancel();
+    try {
+      return await request.call(executor, options, token, data);
+    } finally {
+      tokens.delete(token);
+      token.dispose();
+    }
+  };
+  const timer = setTimeout(() => {
+    timedOut = true;
+    broadcast(withActiveRequest({ state: "error", message: UPDATE_CHECK_TIMEOUT_MESSAGE }));
+    // Cancellation aborts the request AND rejects its promise. Do not race the
+    // check: electron-updater must clear its cached promise before AO retries.
+    for (const token of tokens) token.cancel();
+  }, UPDATE_CHECK_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    return await autoUpdater.checkForUpdates();
+  } catch (err) {
+    throw timedOut ? new Error(UPDATE_CHECK_TIMEOUT_MESSAGE) : err;
+  } finally {
+    clearTimeout(timer);
+    executor.request = request;
+  }
+}
+
 /**
  * Land a terminal status when a check resolved without emitting one.
  *
@@ -660,7 +704,7 @@ type UpdateCheckOutcome = Awaited<ReturnType<typeof autoUpdater.checkForUpdates>
  * already consumed under a different operation. Nothing else ever moves the
  * status off "checking", and the Settings row keys its spinner and its disabled
  * Check button off that state, so the page wedges with no visible explanation.
- * Called only on renderer-requested checks, which are the ones a user is waiting on.
+ * Applied to both background and renderer-requested checks.
  */
 function settleCheckStatus(result: UpdateCheckOutcome): void {
   if (lastStatus.state !== "checking") return;
@@ -1140,7 +1184,8 @@ async function runAutomaticUpdateCheck(
         ? await configureDirectPrereleaseFeed(settings)
         : undefined;
       try {
-        const result = await autoUpdater.checkForUpdates();
+        const result = await checkForUpdatesWithDeadline();
+        settleCheckStatus(result);
         if (settings.enabled) {
           if (result?.downloadPromise) {
             // The provider owns this download's token; hand it to the watchdog
@@ -1316,7 +1361,7 @@ export async function checkForUpdatesNow(
         broadcastUpdaterStatus({ state: "checking" });
         const restoreFeed = await configureDirectPrereleaseFeed(settings);
         try {
-          settleCheckStatus(await autoUpdater.checkForUpdates());
+          settleCheckStatus(await checkForUpdatesWithDeadline());
         } finally {
           restoreFeed?.();
         }
@@ -1387,7 +1432,7 @@ export async function returnToHome(
         autoUpdater.autoDownload = staleStaged;
         applyInstallOnQuitPolicy();
         broadcastUpdaterStatus({ state: "checking" });
-        settleCheckStatus(await autoUpdater.checkForUpdates());
+        settleCheckStatus(await checkForUpdatesWithDeadline());
       },
       requestId,
     );

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -59,12 +59,14 @@ async function reconcileAndPersist(
 //
 // When settings.feature is set, the feed tracks the pr<N> prerelease channel
 // (e.g. "pr2270") with allowPrerelease enabled. Downgrades require a channel
-// transition; routine checks only move forward. Otherwise falls back to the home
+// transition, including one saved on an earlier launch. Otherwise falls back to the home
 // channel logic (latest vs nightly).
 export function configureFeed(
   settings: Pick<UpdateSettings, "channel" | "feature">,
-  allowDowngrade = false,
 ): void {
+  // A saved channel choice remains intent until the running build reaches it.
+  // Assign after channel: electron-updater's channel setter enables downgrades.
+  const allowDowngrade = isChannelTransition(settings);
   if (settings.feature !== null && settings.feature !== undefined) {
     // Feature build: pin to the pr<N> semver prerelease identifier channel.
     autoUpdater.channel = `pr${settings.feature.pr}`;
@@ -573,11 +575,6 @@ function installedUpdateChannel(): string {
 
 function isChannelTransition(settings: Pick<UpdateSettings, "channel" | "feature">): boolean {
   return effectiveChannel(settings) !== installedUpdateChannel();
-}
-
-/** A retired feature pin must still be able to return to its home release. */
-function returningFromFeatureBuild(settings: UpdateSettings): boolean {
-  return settings.feature === null && /^pr\d+$/.test(installedUpdateChannel());
 }
 
 /**
@@ -1116,7 +1113,7 @@ async function runAutomaticUpdateCheck(
 
       escalationStateDir = stateDir;
       wireUpdaterEvents();
-      configureFeed(settings, returningFromFeatureBuild(settings));
+      configureFeed(settings);
       // Discovery is always on for the selected release channel. This preference
       // controls only whether electron-updater downloads the discovered build or
       // leaves it in `available` for the sidebar action.
@@ -1309,11 +1306,7 @@ export async function checkForUpdatesNow(
           options.settings ?? (await readUpdateSettings(stateDir)),
         );
         reconcileAutomaticUpdateSchedule(stateDir, settings);
-        configureFeed(
-          settings,
-          (options.settings !== undefined && isChannelTransition(settings)) ||
-            returningFromFeatureBuild(settings),
-        );
+        configureFeed(settings);
         // Same reason as the automatic path: a channel switch leaves the old
         // channel's build armed, and only staging the new one over it helps.
         const staleStaged = stagedBuildIsStale(settings);
@@ -1386,7 +1379,7 @@ export async function returnToHome(
         );
         const settings = await reconcileAndPersist(stateDir, cleared);
         reconcileAutomaticUpdateSchedule(stateDir, settings);
-        configureFeed(settings, isChannelTransition(settings));
+        configureFeed(settings);
         // Leaving a pinned PR build is the same class of switch: its build is
         // armed and has to be superseded, not merely forgotten.
         const staleStaged = stagedBuildIsStale(settings);


### PR DESCRIPTION
## What and why

Update checks can leave Settings showing “Checking for updates” indefinitely: automatic checks did not settle a returned result when a completion event was absent, and a hung metadata request kept electron-updater's cached check promise and AO's operation queue occupied.

Both automatic and manual checks now settle returned results. A 60-second deadline cancels metadata requests through their cancellation tokens, displays an actionable timeout, and waits for the original check to unwind before allowing a queued retry. The adapter wraps only the updater executor's metadata `request` method during a serialized check and restores it afterward; download cancellation remains separate. This uses electron-updater's internal executor field, verified against the installed library in a real Electron probe. Closing the network session alone did not release the check promise in that probe, so the implementation cancels the requests instead.

The saved channel remains a persistent preference. A user running `0.12.11-nightly.202609051608` who selected Stable is offered stable `0.12.10`, including after restarting or retrying a failed check. That cross-channel downgrade is intended; the original downgrade screenshot alone does not establish a bug. Older releases within the installed channel are rejected. Fresh nightly installs retain Nightly when automatic downloads are declined, existing explicit choices are preserved, and rejected manifests do not redownload the cached staged candidate.

## Validation

- Five new regressions failed before this fix: automatic result settlement and stalled manual, automatic, and return-home checks.
- Updater/settings suite: 117 tests passed, including cancellation/queue ordering and keeping the check deadline away from downloads.
- Real Electron probe of the changed production code against a local stalled manifest: timeout surfaced, followed by a successful retry that discovered version 99.0.0. The probe shortened only the deadline to two seconds; production uses 60 seconds.
- Frontend and E2E typechecks passed. Cloud client generation/typechecks/21 tests/package dry run and product UI typecheck/120 tests/package dry run passed.
- Full local frontend run: all 3,754 assertions passed, but an unexpected HTTP GET hit browser-runtime-link.test.ts's JSON socket and produced an unhandled error. A complete rerun again encountered HTTP socket interference (273 files passed; that file had one failed test and unhandled parse errors). This is **not a clean local full-suite pass**. An earlier interrupted run also had a roughly 14-minute timing jump and UI timeouts; subsequent runs used a temporary sleep inhibitor. The full suite requires verification on the isolated CI runner.
- Local renderer smoke: 53 passed, 2 failed on initial chat/terminal rendering timeouts. A full rerun encountered 6 UI timeouts and was interrupted (4 passed, 1 interrupted, 44 not run). This is **not a clean local renderer-smoke pass**. All three checks passed on final head `5a4ee39d6cbbe8043927f157d55de6abd5efc79c`: frontend tests (5m19s), isolated Linux renderer smoke (2m14s), and gitleaks (20s).

Local checks use Node 24.20.0. Docker is unavailable locally, so the pinned Linux renderer-smoke container and gitleaks also require remote verification. No publishing workflow is used for validation.

## Limits and rollout

This does not cancel an already staged native installer or implement the separate recovery work in #4905. Release manifests, publication schedules, and signing configuration are unchanged. Installed clients need a conductor-built release containing the fix.
