### PR TITLE
fix: preserve publishing scope for freeform tasks

### DIFF
--- a/backend/internal/session_manager/prompt.go
+++ b/backend/internal/session_manager/prompt.go
@@ -88,13 +88,24 @@ func buildSystemPromptText(cfg systemPromptConfig) string {
 	default:
 		return ""
 	}
-	sections = append(sections, systemPromptGuard())
+	sections = append(sections, publishingScopePrompt(), systemPromptGuard())
 	for _, section := range cfg.AdditionalSections {
 		if section := strings.TrimSpace(section); section != "" {
 			sections = append(sections, section)
 		}
 	}
 	return strings.Join(sections, "\n\n")
+}
+
+// publishingScopePrompt clarifies authority without replacing the established
+// issue-to-PR, opt-in intake, or PR maintenance workflows.
+func publishingScopePrompt() string {
+	return `## Publishing Scope
+
+- Keep the task-source workflows above for provider-backed issues, explicitly enabled issue intake, and user-requested PR/MR continuation. Do not request fresh approval for each push or PR/MR update within an already authorized workflow.
+- For freeform work, publish only when the user requests it or explicitly configured project rules require it. Available credentials, a configured remote, auto/bypass tool permissions, or an associated PR/MR alone do not authorize publishing.
+- Explicit user restrictions such as local-only, review-only, or do-not-publish take precedence over workflow defaults, including issue-task prompts and CI/review follow-up instructions. Complete the permitted local work and report the result without publishing.
+- Preserve the user's publishing scope and restrictions when spawning or redirecting workers. Do not add publishing to a freeform implementation task unless the user or explicitly configured project rules authorize it.`
 }
 
 // systemPromptGuard is appended to every agent system prompt. The role,
@@ -222,7 +233,7 @@ func workerSystemPrompt(project promptProject, hasOrchestrator bool) string {
 
 - Treat the explicit task description, provider issue context, or claimed PR/MR context as the source of truth for this session.
 - If the task is backed by a provider issue from GitHub, GitLab, or another tracker/SCM, implement the task, run verification, and create or update a PR/MR when the project has a configured remote/provider and the change is ready. Link the provider issue in the PR/MR body.
-- If the task is a freeform task, new-task button task, or orchestrator-requested feature without a provider issue, implement and verify the task; do not invent issue, PR, or MR requirements. Create or update a PR/MR only when the user asks, the project workflow clearly requires it, or an associated PR/MR already exists.
+- If the task is a freeform task, new-task button task, or orchestrator-requested feature without a provider issue, implement and verify the task; do not invent issue, PR, or MR requirements. Create or update a PR/MR only when the user asks for that action or explicitly configured project rules require it. An associated PR/MR alone does not authorize publishing; a user request to continue that PR/MR does authorize its normal follow-up workflow.
 - If the task is to claim or continue an existing PR/MR, attach it to this worker first with ` + "`ao session claim-pr <pr-ref>`" + `; AO resolves this session from ` + "`AO_SESSION_ID`" + `. Then inspect its description, diff, CI, and review comments, keep that PR/MR context, and continue only the work required by that PR/MR. Do not create a replacement PR/MR unless explicitly asked.
 - If no remote or SCM provider is available, work locally, verify the result, and report changed files, tests, and risks instead of inventing issue, PR, or MR requirements.`
 

--- a/backend/internal/session_manager/prompt_test.go
+++ b/backend/internal/session_manager/prompt_test.go
@@ -176,3 +176,35 @@ func TestProjectRelativeFileRejectsTraversal(t *testing.T) {
 		t.Fatal("expected traversal path to be rejected")
 	}
 }
+
+func TestBuildSystemPromptPreservesPublishingScope(t *testing.T) {
+	for _, role := range []sessionPromptRole{sessionPromptRoleWorker, sessionPromptRoleOrchestrator} {
+		for _, repo := range []string{"", "https://github.com/acme/repo"} {
+			t.Run(string(role)+"/"+repo, func(t *testing.T) {
+				got := buildSystemPromptText(systemPromptConfig{Role: role, Project: promptProject{Repo: repo}})
+				for _, want := range []string{
+					"Do not request fresh approval for each push or PR/MR update within an already authorized workflow",
+					"Available credentials, a configured remote, auto/bypass tool permissions, or an associated PR/MR alone do not authorize publishing",
+					"local-only, review-only, or do-not-publish take precedence over workflow defaults",
+					"Preserve the user's publishing scope and restrictions when spawning or redirecting workers",
+				} {
+					if !strings.Contains(got, want) {
+						t.Errorf("prompt missing scope rule %q", want)
+					}
+				}
+				if strings.Contains(got, "the project workflow clearly requires it, or an associated PR/MR already exists") {
+					t.Error("freeform task still treats PR association as publishing authority")
+				}
+			})
+		}
+	}
+}
+
+func TestBuildTaskPromptPreservesExplicitPublishingScope(t *testing.T) {
+	for _, prompt := range []string{"Fix the issue, push the branch, and open a PR.", "Fix the issue locally. Do not push or open a PR."} {
+		got := buildTaskPrompt(taskPromptConfig{Role: sessionPromptRoleWorker, Prompt: prompt, IssueID: "42"})
+		if got != prompt {
+			t.Fatalf("explicit user scope changed: %q", got)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

AO’s freeform worker instructions allowed publishing merely because an associated PR existed or an inferred project workflow required it. Require a user request or explicitly configured project rules instead, and preserve publishing restrictions when orchestrators delegate work.

Keep the existing provider-issue, opt-in issue-intake, and user-requested PR continuation workflows. Already authorized pushes and PR updates do not require repeated approval. Explicit local-only, review-only, and do-not-publish restrictions override workflow defaults.

This is a prompt-level scope clarification, not a command-level enforcement gate. It does not alter authentication, permission modes, runtime behavior, or UI. The original reported task transcript was unavailable, so this does not claim to establish that incident’s exact cause.

## Validation

GitHub Actions passed all nine checks on commit `185384cc96e8298ee71adef6d84e7b24ad054e21`: Go build/vet/race tests, lint, API drift, Windows workspace tests, native CLI E2E on Linux/macOS/Windows, container CLI E2E, and secret scanning.

- New regression tests fail against the original prompt and pass with this change.
- Full affected race suites passed: session_manager, trackerintake, claudecode, and claudeacp.
- Backend build and vet passed; pinned golangci-lint v2.12.2 reported zero issues for session_manager.
- Full local backend testing encountered failures outside the changed packages (provider conformance, notification relay, terminal/runtime, installer cleanup) and was stopped. The full lint run was also stopped; neither is claimed as passed.
- Local all-workflow validation could not proceed: VITE_WORKOS_CLIENT_ID is unavailable and Docker is not running. Linux and Windows workflow validation requires GitHub Actions.

No screenshots: this change has no UI surface. All PR validation workflows passed; no release or deployment was triggered.
