### PR TITLE
Cloud session startup improvement and other bug fixes 

### DIFF
--- a/cloud/cmd/ao-cloud/main.go
+++ b/cloud/cmd/ao-cloud/main.go
@@ -125,6 +125,7 @@ func newSandboxReconciler(
 			DefaultRoot:  cfg.NodeOpsDefaultRootFS,
 			Region:       cfg.NodeOpsRegion,
 			SSHPubKeys:   sshPubKeys,
+			Logger:       logger,
 		})
 	case sandbox.ProviderDocker:
 		provider, err := dockerprovider.New(dockerprovider.Config{

--- a/cloud/cmd/ao-worker/main.go
+++ b/cloud/cmd/ao-worker/main.go
@@ -123,9 +123,8 @@ func run(logger *slog.Logger) error {
 		"repository_url", bootstrap.Launch.RepositoryURL,
 	)
 
-	// The workspace shell is deliberately available before checkout starts. A
-	// developer can inspect the sandbox immediately while repository preparation
-	// and coding-agent authentication continue in the background.
+	// Create the workspace directory before transport starts, but reserve it for
+	// checkout until the repository is prepared.
 	if err := os.MkdirAll(workspace, 0o755); err != nil {
 		return fmt.Errorf("create workspace directory: %w", err)
 	}
@@ -161,10 +160,10 @@ func run(logger *slog.Logger) error {
 		Control: client, Workspace: workspace, Logger: logger,
 		Started: started,
 	}
-	// The coding-agent process may connect before checkout completes, but no
-	// user prompt may reach it until the repository is usable. This keeps the
-	// perceived connection path independent from clone latency without letting
-	// a prompt run in an empty workspace.
+	// Do not claim agent input until checkout has prepared the workspace and the
+	// agent PTY exists. In particular, the harness must not start in workspace
+	// before PrepareCheckout has populated it: several harnesses write project
+	// local state during startup, which makes git clone reject the destination.
 	transportSupervisor.HoldAgentInputUntilWorkspaceReady()
 	results := make(chan error, 5)
 	go func() { results <- client.heartbeatLoop(runCtx, logger) }()
@@ -195,26 +194,29 @@ func run(logger *slog.Logger) error {
 	}); err != nil {
 		logger.Warn("publish worker.ready failed", "error", err)
 	}
+	startupFailure := make(chan error, 1)
 	go func() {
 		if err := prepareWorkspace(
 			runCtx, logger, client, bootstrap, workspace, dataDir, publicURL,
 		); err != nil {
 			if runCtx.Err() == nil {
-				logger.Error("background workspace startup failed", "error", err)
+				startupFailure <- fmt.Errorf("prepare workspace: %w", err)
 			}
 			return
 		}
 		transportSupervisor.MarkWorkspaceReady()
-	}()
-	go func() {
 		if err := startInteractiveAgent(
 			runCtx, logger, client, bootstrap, workspace, dataDir,
 			pullRequestSocketPath, reviewSocketPath, &transportSupervisor,
 		); err != nil && runCtx.Err() == nil {
-			logger.Error("background coding-agent startup failed", "error", err)
+			startupFailure <- fmt.Errorf("start interactive agent: %w", err)
 		}
 	}()
-	first := <-results
+	var first error
+	select {
+	case first = <-results:
+	case first = <-startupFailure:
+	}
 	cancel()
 	<-results
 	<-results

--- a/cloud/cmd/ao-worker/main.go
+++ b/cloud/cmd/ao-worker/main.go
@@ -68,18 +68,10 @@ func main() {
 }
 
 func run(logger *slog.Logger) error {
-	startupStartedAt := time.Now()
 	publicURL := strings.TrimRight(strings.TrimSpace(os.Getenv("AO_CLOUD_PUBLIC_URL")), "/")
 	sessionID := strings.TrimSpace(os.Getenv("AO_CLOUD_SESSION_ID"))
 	bootstrapToken := strings.TrimSpace(os.Getenv("AO_WORKER_BOOTSTRAP_TOKEN"))
 	workspace := strings.TrimSpace(os.Getenv("AO_WORKSPACE_DIR"))
-	logStartupStage := func(stage string) {
-		logger.Info("worker startup stage",
-			"session_id", sessionID,
-			"stage", stage,
-			"elapsed_ms", time.Since(startupStartedAt).Milliseconds(),
-		)
-	}
 	if publicURL == "" {
 		return errors.New("AO_CLOUD_PUBLIC_URL is required")
 	}
@@ -108,7 +100,6 @@ func run(logger *slog.Logger) error {
 		http:      &http.Client{Timeout: requestTimeout},
 		tokenFile: filepath.Join(dataDir, "worker-token"),
 	}
-	logStartupStage("worker_process_started")
 
 	bootstrap, err := client.bootstrap(ctx, bootstrapToken)
 	if err != nil {
@@ -131,7 +122,6 @@ func run(logger *slog.Logger) error {
 		"harness", bootstrap.Launch.Harness,
 		"repository_url", bootstrap.Launch.RepositoryURL,
 	)
-	logStartupStage("bootstrap_exchange_completed")
 
 	// The workspace shell is deliberately available before checkout starts. A
 	// developer can inspect the sandbox immediately while repository preparation
@@ -161,8 +151,6 @@ func run(logger *slog.Logger) error {
 		logger.Warn("first heartbeat failed", "error", err)
 	} else if err := client.setToken(renewed); err != nil {
 		return err
-	} else {
-		logStartupStage("first_heartbeat_completed")
 	}
 	pullRequestSocketPath := filepath.Join(dataDir, "ao-pull-request.sock")
 	reviewSocketPath := filepath.Join(dataDir, "ao-review.sock")
@@ -199,7 +187,6 @@ func run(logger *slog.Logger) error {
 		<-results
 		return fmt.Errorf("start workspace transport: %w", err)
 	}
-	logStartupStage("workspace_transport_ready")
 	if err := client.publishEvent(ctx, "worker.ready", map[string]any{
 		"workerId":     bootstrap.WorkerID,
 		"epoch":        bootstrap.Epoch,
@@ -208,10 +195,9 @@ func run(logger *slog.Logger) error {
 	}); err != nil {
 		logger.Warn("publish worker.ready failed", "error", err)
 	}
-	logStartupStage("worker_ready_published")
 	go func() {
 		if err := prepareWorkspace(
-			runCtx, logger, logStartupStage, client, bootstrap, workspace, dataDir, publicURL,
+			runCtx, logger, client, bootstrap, workspace, dataDir, publicURL,
 		); err != nil {
 			if runCtx.Err() == nil {
 				logger.Error("background workspace startup failed", "error", err)
@@ -219,11 +205,10 @@ func run(logger *slog.Logger) error {
 			return
 		}
 		transportSupervisor.MarkWorkspaceReady()
-		logStartupStage("workspace_ready_for_agent_requests")
 	}()
 	go func() {
 		if err := startInteractiveAgent(
-			runCtx, logger, logStartupStage, client, bootstrap, workspace, dataDir,
+			runCtx, logger, client, bootstrap, workspace, dataDir,
 			pullRequestSocketPath, reviewSocketPath, &transportSupervisor,
 		); err != nil && runCtx.Err() == nil {
 			logger.Error("background coding-agent startup failed", "error", err)
@@ -245,20 +230,16 @@ func run(logger *slog.Logger) error {
 func prepareWorkspace(
 	ctx context.Context,
 	logger *slog.Logger,
-	logStartupStage func(string),
 	client *client,
 	bootstrap worker.BootstrapResponse,
 	workspace, dataDir, publicURL string,
 ) error {
 	if worker.IsScratchRepositoryURL(bootstrap.Launch.RepositoryURL) {
-		logStartupStage("scratch_workspace_preparation_started")
 		if err := worker.PrepareScratchWorkspace(ctx, worker.ExecGitRunner{}, workspace); err != nil {
 			return fmt.Errorf("prepare scratch workspace: %w", err)
 		}
 		logger.Info("initialized scratch workspace")
-		logStartupStage("scratch_workspace_preparation_completed")
 	} else {
-		logStartupStage("repository_checkout_started")
 		checkoutGrant, err := client.checkoutGrant(ctx)
 		if err != nil {
 			if !anonymousCheckoutEnabled() {
@@ -277,14 +258,12 @@ func prepareWorkspace(
 		if err := worker.PrepareCheckout(ctx, worker.ExecGitRunner{}, workspace, checkoutGrant); err != nil {
 			return fmt.Errorf("prepare repository checkout: %w", err)
 		}
-		logStartupStage("repository_checkout_completed")
 		if err := worker.ConfigureWorkerGit(
 			ctx, worker.ExecGitRunner{}, workspace, dataDir, publicURL,
 			bootstrap.SessionID, bootstrap.Launch.Branch,
 		); err != nil {
 			return fmt.Errorf("configure repository tooling: %w", err)
 		}
-		logStartupStage("repository_tooling_configured")
 	}
 	return nil
 }
@@ -292,7 +271,6 @@ func prepareWorkspace(
 func startInteractiveAgent(
 	ctx context.Context,
 	logger *slog.Logger,
-	logStartupStage func(string),
 	client *client,
 	bootstrap worker.BootstrapResponse,
 	workspace, dataDir, pullRequestSocketPath, reviewSocketPath string,
@@ -302,20 +280,16 @@ func startInteractiveAgent(
 		logger.Warn("coding-agent harness unavailable", "error", err)
 		return nil
 	}
-	logStartupStage("agent_credential_fetch_started")
 	credential, err := client.Credential(ctx)
 	if err != nil {
 		return fmt.Errorf("load coding-agent credential: %w", err)
 	}
-	logStartupStage("agent_credential_fetch_completed")
-	logStartupStage("agent_harness_setup_started")
 	agentCommand, err := (workerexec.HarnessBuilder{DataDir: dataDir}).BuildInteractive(
 		bootstrap.Launch, credential, workspace,
 	)
 	if err != nil {
 		return fmt.Errorf("build interactive coding-agent command: %w", err)
 	}
-	logStartupStage("agent_harness_setup_completed")
 	agentCommand.Env["AO_CLOUD_WORKER_API_URL"] = client.baseURL
 	agentCommand.Env["AO_CLOUD_WORKER_TOKEN_FILE"] = client.tokenFile
 	agentCommand.Env["AO_SESSION_ID"] = bootstrap.SessionID
@@ -336,11 +310,9 @@ func startInteractiveAgent(
 		agentCommand.Cleanup()
 		return fmt.Errorf("initialize agent terminal: %w", err)
 	}
-	logStartupStage("agent_terminal_registered")
 	if err := transportSupervisor.StartAgent(ctx, agentCommand, agentTerminal.TerminalID); err != nil {
 		return fmt.Errorf("start interactive coding-agent terminal: %w", err)
 	}
-	logStartupStage("agent_terminal_started")
 	if err := client.publishEvent(ctx, "agent.ready", map[string]any{
 		"workerId":     bootstrap.WorkerID,
 		"epoch":        bootstrap.Epoch,

--- a/cloud/cmd/ao-worker/main.go
+++ b/cloud/cmd/ao-worker/main.go
@@ -68,10 +68,18 @@ func main() {
 }
 
 func run(logger *slog.Logger) error {
+	startupStartedAt := time.Now()
 	publicURL := strings.TrimRight(strings.TrimSpace(os.Getenv("AO_CLOUD_PUBLIC_URL")), "/")
 	sessionID := strings.TrimSpace(os.Getenv("AO_CLOUD_SESSION_ID"))
 	bootstrapToken := strings.TrimSpace(os.Getenv("AO_WORKER_BOOTSTRAP_TOKEN"))
 	workspace := strings.TrimSpace(os.Getenv("AO_WORKSPACE_DIR"))
+	logStartupStage := func(stage string) {
+		logger.Info("worker startup stage",
+			"session_id", sessionID,
+			"stage", stage,
+			"elapsed_ms", time.Since(startupStartedAt).Milliseconds(),
+		)
+	}
 	if publicURL == "" {
 		return errors.New("AO_CLOUD_PUBLIC_URL is required")
 	}
@@ -100,6 +108,7 @@ func run(logger *slog.Logger) error {
 		http:      &http.Client{Timeout: requestTimeout},
 		tokenFile: filepath.Join(dataDir, "worker-token"),
 	}
+	logStartupStage("worker_process_started")
 
 	bootstrap, err := client.bootstrap(ctx, bootstrapToken)
 	if err != nil {
@@ -122,52 +131,13 @@ func run(logger *slog.Logger) error {
 		"harness", bootstrap.Launch.Harness,
 		"repository_url", bootstrap.Launch.RepositoryURL,
 	)
+	logStartupStage("bootstrap_exchange_completed")
 
-	if worker.IsScratchRepositoryURL(bootstrap.Launch.RepositoryURL) {
-		if err := worker.PrepareScratchWorkspace(
-			ctx,
-			worker.ExecGitRunner{},
-			workspace,
-		); err != nil {
-			return fmt.Errorf("prepare scratch workspace: %w", err)
-		}
-		logger.Info("initialized scratch workspace")
-	} else {
-		checkoutGrant, err := client.checkoutGrant(ctx)
-		if err != nil {
-			if !anonymousCheckoutEnabled() {
-				if errors.Is(err, errCheckoutForbidden) {
-					// A permanent fault: the session has no repository grant, so
-					// no amount of restarting this worker will make progress.
-					// Surface the cause plainly; the reconciler's startup ceiling
-					// stops the sandbox once repairs stay fruitless.
-					logger.Error("checkout grant refused; session cannot start without a repository grant",
-						"session_id", bootstrap.SessionID,
-						"repository_url", bootstrap.Launch.RepositoryURL,
-						"hint", "connect the repository through the GitHub App, or set AO_CLOUD_ALLOW_ANONYMOUS_GITHUB_CHECKOUT for a public repository",
-					)
-				}
-				return fmt.Errorf("request checkout grant: %w", err)
-			}
-			checkoutGrant = worker.CheckoutGrantResponse{
-				CloneURL: bootstrap.Launch.RepositoryURL,
-			}
-			logger.Info("using anonymous public GitHub checkout")
-		}
-		if err := worker.PrepareCheckout(
-			ctx,
-			worker.ExecGitRunner{},
-			workspace,
-			checkoutGrant,
-		); err != nil {
-			return fmt.Errorf("prepare repository checkout: %w", err)
-		}
-		if err := worker.ConfigureWorkerGit(
-			ctx, worker.ExecGitRunner{}, workspace, dataDir, publicURL,
-			bootstrap.SessionID, bootstrap.Launch.Branch,
-		); err != nil {
-			return fmt.Errorf("configure repository tooling: %w", err)
-		}
+	// The workspace shell is deliberately available before checkout starts. A
+	// developer can inspect the sandbox immediately while repository preparation
+	// and coding-agent authentication continue in the background.
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		return fmt.Errorf("create workspace directory: %w", err)
 	}
 	for key, value := range map[string]string{
 		"AO_CLOUD_PUBLIC_URL": publicURL,
@@ -191,58 +161,23 @@ func run(logger *slog.Logger) error {
 		logger.Warn("first heartbeat failed", "error", err)
 	} else if err := client.setToken(renewed); err != nil {
 		return err
+	} else {
+		logStartupStage("first_heartbeat_completed")
 	}
-	var agentCommand workerexec.Command
-	agentTerminalID := ""
 	pullRequestSocketPath := filepath.Join(dataDir, "ao-pull-request.sock")
 	reviewSocketPath := filepath.Join(dataDir, "ao-review.sock")
-	if err := verifyHarnessAvailable(bootstrap.Launch.Harness); err != nil {
-		// Workspace files and shell terminals use the same worker transport as the
-		// coding agent. Keep that transport alive when a rootfs is missing the
-		// selected harness instead of making the whole sandbox unreachable.
-		logger.Warn("coding-agent harness unavailable; continuing with workspace transport", "error", err)
-	} else {
-		credential, err := client.Credential(ctx)
-		if err != nil {
-			return fmt.Errorf("load coding-agent credential: %w", err)
-		}
-		agentCommand, err = (workerexec.HarnessBuilder{
-			DataDir: dataDir,
-		}).BuildInteractive(bootstrap.Launch, credential, workspace)
-		if err != nil {
-			return fmt.Errorf("build interactive coding-agent command: %w", err)
-		}
-		agentCommand.Env["AO_CLOUD_WORKER_API_URL"] = client.baseURL
-		agentCommand.Env["AO_CLOUD_WORKER_TOKEN_FILE"] = client.tokenFile
-		agentCommand.Env["AO_SESSION_ID"] = bootstrap.SessionID
-		agentCommand.Env["AO_PROJECT_ID"] = bootstrap.Launch.ProjectID
-		agentCommand.Env["AO_SESSION_KIND"] = bootstrap.Launch.Kind
-		agentCommand.Env["AO_PULL_REQUEST_SOCKET"] = pullRequestSocketPath
-		agentCommand.Env["AO_PULL_REQUEST_HELP"] = "curl --unix-socket $AO_PULL_REQUEST_SOCKET " +
-			`-X POST http://localhost/pull-request -H 'Content-Type: application/json' ` +
-			`-d '{"branch":"<pushed branch name>","title":"<PR title>","body":"<PR body>"}' ` +
-			"to push the current branch and open a pull request against the repository's default branch."
-		agentCommand.Env["AO_REVIEW_SOCKET"] = reviewSocketPath
-		agentCommand.Env["AO_REVIEW_HELP"] = "curl --unix-socket $AO_REVIEW_SOCKET " +
-			`-X POST http://localhost/review -H 'Content-Type: application/json' ` +
-			`-d '{"reviewRunId":"<review run id from the prompt>","verdict":"approved|changes_requested","body":"<your findings>"}' ` +
-			"to submit an AO-triggered review verdict."
-		agentTerminal, err := client.ensureAgentTerminal(ctx)
-		if err != nil {
-			agentCommand.Cleanup()
-			return fmt.Errorf("initialize agent terminal: %w", err)
-		}
-		agentTerminalID = agentTerminal.TerminalID
-	}
-
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	started := make(chan error, 1)
 	transportSupervisor := workertransport.Supervisor{
 		Control: client, Workspace: workspace, Logger: logger,
-		AgentCommand: agentCommand, AgentTerminalID: agentTerminalID,
 		Started: started,
 	}
+	// The coding-agent process may connect before checkout completes, but no
+	// user prompt may reach it until the repository is usable. This keeps the
+	// perceived connection path independent from clone latency without letting
+	// a prompt run in an empty workspace.
+	transportSupervisor.HoldAgentInputUntilWorkspaceReady()
 	results := make(chan error, 5)
 	go func() { results <- client.heartbeatLoop(runCtx, logger) }()
 	go func() { results <- transportSupervisor.Run(runCtx) }()
@@ -262,8 +197,9 @@ func run(logger *slog.Logger) error {
 		<-results
 		<-results
 		<-results
-		return fmt.Errorf("start interactive coding-agent terminal: %w", err)
+		return fmt.Errorf("start workspace transport: %w", err)
 	}
+	logStartupStage("workspace_transport_ready")
 	if err := client.publishEvent(ctx, "worker.ready", map[string]any{
 		"workerId":     bootstrap.WorkerID,
 		"epoch":        bootstrap.Epoch,
@@ -272,6 +208,27 @@ func run(logger *slog.Logger) error {
 	}); err != nil {
 		logger.Warn("publish worker.ready failed", "error", err)
 	}
+	logStartupStage("worker_ready_published")
+	go func() {
+		if err := prepareWorkspace(
+			runCtx, logger, logStartupStage, client, bootstrap, workspace, dataDir, publicURL,
+		); err != nil {
+			if runCtx.Err() == nil {
+				logger.Error("background workspace startup failed", "error", err)
+			}
+			return
+		}
+		transportSupervisor.MarkWorkspaceReady()
+		logStartupStage("workspace_ready_for_agent_requests")
+	}()
+	go func() {
+		if err := startInteractiveAgent(
+			runCtx, logger, logStartupStage, client, bootstrap, workspace, dataDir,
+			pullRequestSocketPath, reviewSocketPath, &transportSupervisor,
+		); err != nil && runCtx.Err() == nil {
+			logger.Error("background coding-agent startup failed", "error", err)
+		}
+	}()
 	first := <-results
 	cancel()
 	<-results
@@ -283,6 +240,116 @@ func run(logger *slog.Logger) error {
 		return nil
 	}
 	return first
+}
+
+func prepareWorkspace(
+	ctx context.Context,
+	logger *slog.Logger,
+	logStartupStage func(string),
+	client *client,
+	bootstrap worker.BootstrapResponse,
+	workspace, dataDir, publicURL string,
+) error {
+	if worker.IsScratchRepositoryURL(bootstrap.Launch.RepositoryURL) {
+		logStartupStage("scratch_workspace_preparation_started")
+		if err := worker.PrepareScratchWorkspace(ctx, worker.ExecGitRunner{}, workspace); err != nil {
+			return fmt.Errorf("prepare scratch workspace: %w", err)
+		}
+		logger.Info("initialized scratch workspace")
+		logStartupStage("scratch_workspace_preparation_completed")
+	} else {
+		logStartupStage("repository_checkout_started")
+		checkoutGrant, err := client.checkoutGrant(ctx)
+		if err != nil {
+			if !anonymousCheckoutEnabled() {
+				if errors.Is(err, errCheckoutForbidden) {
+					logger.Error("checkout grant refused; session cannot start without a repository grant",
+						"session_id", bootstrap.SessionID,
+						"repository_url", bootstrap.Launch.RepositoryURL,
+						"hint", "connect the repository through the GitHub App, or set AO_CLOUD_ALLOW_ANONYMOUS_GITHUB_CHECKOUT for a public repository",
+					)
+				}
+				return fmt.Errorf("request checkout grant: %w", err)
+			}
+			checkoutGrant = worker.CheckoutGrantResponse{CloneURL: bootstrap.Launch.RepositoryURL}
+			logger.Info("using anonymous public GitHub checkout")
+		}
+		if err := worker.PrepareCheckout(ctx, worker.ExecGitRunner{}, workspace, checkoutGrant); err != nil {
+			return fmt.Errorf("prepare repository checkout: %w", err)
+		}
+		logStartupStage("repository_checkout_completed")
+		if err := worker.ConfigureWorkerGit(
+			ctx, worker.ExecGitRunner{}, workspace, dataDir, publicURL,
+			bootstrap.SessionID, bootstrap.Launch.Branch,
+		); err != nil {
+			return fmt.Errorf("configure repository tooling: %w", err)
+		}
+		logStartupStage("repository_tooling_configured")
+	}
+	return nil
+}
+
+func startInteractiveAgent(
+	ctx context.Context,
+	logger *slog.Logger,
+	logStartupStage func(string),
+	client *client,
+	bootstrap worker.BootstrapResponse,
+	workspace, dataDir, pullRequestSocketPath, reviewSocketPath string,
+	transportSupervisor *workertransport.Supervisor,
+) error {
+	if err := verifyHarnessAvailable(bootstrap.Launch.Harness); err != nil {
+		logger.Warn("coding-agent harness unavailable", "error", err)
+		return nil
+	}
+	logStartupStage("agent_credential_fetch_started")
+	credential, err := client.Credential(ctx)
+	if err != nil {
+		return fmt.Errorf("load coding-agent credential: %w", err)
+	}
+	logStartupStage("agent_credential_fetch_completed")
+	logStartupStage("agent_harness_setup_started")
+	agentCommand, err := (workerexec.HarnessBuilder{DataDir: dataDir}).BuildInteractive(
+		bootstrap.Launch, credential, workspace,
+	)
+	if err != nil {
+		return fmt.Errorf("build interactive coding-agent command: %w", err)
+	}
+	logStartupStage("agent_harness_setup_completed")
+	agentCommand.Env["AO_CLOUD_WORKER_API_URL"] = client.baseURL
+	agentCommand.Env["AO_CLOUD_WORKER_TOKEN_FILE"] = client.tokenFile
+	agentCommand.Env["AO_SESSION_ID"] = bootstrap.SessionID
+	agentCommand.Env["AO_PROJECT_ID"] = bootstrap.Launch.ProjectID
+	agentCommand.Env["AO_SESSION_KIND"] = bootstrap.Launch.Kind
+	agentCommand.Env["AO_PULL_REQUEST_SOCKET"] = pullRequestSocketPath
+	agentCommand.Env["AO_PULL_REQUEST_HELP"] = "curl --unix-socket $AO_PULL_REQUEST_SOCKET " +
+		`-X POST http://localhost/pull-request -H 'Content-Type: application/json' ` +
+		`-d '{"branch":"<pushed branch name>","title":"<PR title>","body":"<PR body>"}' ` +
+		"to push the current branch and open a pull request against the repository's default branch."
+	agentCommand.Env["AO_REVIEW_SOCKET"] = reviewSocketPath
+	agentCommand.Env["AO_REVIEW_HELP"] = "curl --unix-socket $AO_REVIEW_SOCKET " +
+		`-X POST http://localhost/review -H 'Content-Type: application/json' ` +
+		`-d '{"reviewRunId":"<review run id from the prompt>","verdict":"approved|changes_requested","body":"<your findings>"}' ` +
+		"to submit an AO-triggered review verdict."
+	agentTerminal, err := client.ensureAgentTerminal(ctx)
+	if err != nil {
+		agentCommand.Cleanup()
+		return fmt.Errorf("initialize agent terminal: %w", err)
+	}
+	logStartupStage("agent_terminal_registered")
+	if err := transportSupervisor.StartAgent(ctx, agentCommand, agentTerminal.TerminalID); err != nil {
+		return fmt.Errorf("start interactive coding-agent terminal: %w", err)
+	}
+	logStartupStage("agent_terminal_started")
+	if err := client.publishEvent(ctx, "agent.ready", map[string]any{
+		"workerId":     bootstrap.WorkerID,
+		"epoch":        bootstrap.Epoch,
+		"version":      workerVersion,
+		"capabilities": workerCapabilities,
+	}); err != nil {
+		logger.Warn("publish agent.ready failed", "error", err)
+	}
+	return nil
 }
 
 var errStaleWorker = errors.New("worker credential replaced")

--- a/cloud/internal/domain/provider.go
+++ b/cloud/internal/domain/provider.go
@@ -29,3 +29,12 @@ type UserProviderConnection struct {
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
+
+// WorkerGitHubPAT is the encrypted personal access token the current worker
+// may use only for its own session's GitHub repository.
+type WorkerGitHubPAT struct {
+	OwnerUserID     string
+	CloneURL        string
+	EncryptedSecret []byte
+	Nonce           []byte
+}

--- a/cloud/internal/httpapi/provider_handlers.go
+++ b/cloud/internal/httpapi/provider_handlers.go
@@ -14,6 +14,8 @@ import (
 
 const defaultAgentConnectionLabel = "default"
 
+const githubPATProvider = "github"
+
 type providerConnectionStore interface {
 	ListProviderConnections(
 		context.Context,
@@ -73,6 +75,10 @@ type credentialValidator interface {
 type putAgentConnectionRequest struct {
 	CredentialType string `json:"credentialType"`
 	Secret         string `json:"secret"`
+}
+
+type putGitHubPATRequest struct {
+	Secret string `json:"secret"`
 }
 
 type providerConnectionResponse struct {
@@ -219,6 +225,64 @@ func (s *Server) deleteAgentConnection(w http.ResponseWriter, r *http.Request) {
 		agent,
 		defaultAgentConnectionLabel,
 	); err != nil {
+		s.writeStoreError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// putGitHubPAT stores the caller's GitHub personal access token for private
+// repository checkout. It intentionally does not call GitHub: the token is
+// validated by git against the selected repository, and never echoed or logged.
+func (s *Server) putGitHubPAT(w http.ResponseWriter, r *http.Request) {
+	if s.secretCipher == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "provider_connections_unavailable", "GitHub credential storage is not configured.")
+		return
+	}
+	var request putGitHubPATRequest
+	if err := decodeJSON(w, r, &request); err != nil {
+		writeError(w, r, http.StatusBadRequest, "invalid_request", "The request body is invalid.")
+		return
+	}
+	secret := []byte(strings.TrimSpace(request.Secret))
+	defer clear(secret)
+	request.Secret = ""
+	if len(secret) < 8 || len(secret) > 64<<10 {
+		writeError(w, r, http.StatusUnprocessableEntity, "validation_error", "The GitHub personal access token is invalid.")
+		return
+	}
+	principal := principalFrom(r)
+	encrypted, nonce, err := s.secretCipher.Encrypt(secret, providerSecretAssociatedData("user:"+principal.UserID, githubPATProvider))
+	if err != nil {
+		s.logger.Error("encrypt GitHub personal access token", "error", err, "request_id", requestID(r))
+		writeError(w, r, http.StatusInternalServerError, "internal_error", "The GitHub token could not be stored.")
+		return
+	}
+	store, ok := s.store.(userProviderConnectionStore)
+	if !ok {
+		writeError(w, r, http.StatusNotImplemented, "not_implemented", "Provider connections are unavailable.")
+		return
+	}
+	config, err := json.Marshal(map[string]string{"credentialType": "personal_access_token"})
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "internal_error", "The GitHub token could not be stored.")
+		return
+	}
+	connection, err := store.UpsertUserProviderConnection(r.Context(), principal, githubPATProvider, defaultAgentConnectionLabel, encrypted, nonce, config)
+	if err != nil {
+		s.writeStoreError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"providerConnection": toUserProviderConnectionResponse(connection)})
+}
+
+func (s *Server) deleteGitHubPAT(w http.ResponseWriter, r *http.Request) {
+	store, ok := s.store.(userProviderConnectionStore)
+	if !ok {
+		writeError(w, r, http.StatusNotImplemented, "not_implemented", "Provider connections are unavailable.")
+		return
+	}
+	if err := store.DeleteUserProviderConnection(r.Context(), principalFrom(r), githubPATProvider, defaultAgentConnectionLabel); err != nil {
 		s.writeStoreError(w, r, err)
 		return
 	}

--- a/cloud/internal/httpapi/server.go
+++ b/cloud/internal/httpapi/server.go
@@ -277,6 +277,8 @@ func New(options Options) *Server {
 		router.With(server.authenticate).Get("/me/providers", server.listUserProviderConnections)
 		router.With(server.authenticate).Put("/me/providers/{agent}", server.putUserAgentConnection)
 		router.With(server.authenticate).Delete("/me/providers/{agent}", server.deleteUserAgentConnection)
+		router.With(server.authenticate).Put("/me/github-pat", server.putGitHubPAT)
+		router.With(server.authenticate).Delete("/me/github-pat", server.deleteGitHubPAT)
 		router.With(server.authenticate).Post("/share-links/redeem", server.redeemProjectShareLink)
 		router.With(server.authenticate).Get("/shared/projects", server.listSharedProjects)
 		if server.github != nil {

--- a/cloud/internal/httpapi/terminal_handlers.go
+++ b/cloud/internal/httpapi/terminal_handlers.go
@@ -113,6 +113,14 @@ func (s *Server) connectTerminal(w http.ResponseWriter, r *http.Request) {
 		s.closeTerminal(r, terminal)
 		return
 	}
+	if s.logger != nil {
+		s.logger.Info("browser terminal attached",
+			"session_id", terminal.SessionID,
+			"terminal_id", terminal.ID,
+			"kind", terminal.Kind,
+			"worker_epoch", terminal.WorkerEpoch,
+		)
+	}
 	connection.SetReadLimit(maxTerminalFrame)
 	defer func() {
 		if terminal.Kind != "agent" {
@@ -311,6 +319,14 @@ func (s *Server) writeTerminalOutput(
 			if state == "open" {
 				messageType = "ready"
 				ready = true
+				if s.logger != nil {
+					s.logger.Info("browser terminal ready",
+						"session_id", terminal.SessionID,
+						"terminal_id", terminal.ID,
+						"kind", terminal.Kind,
+						"worker_epoch", terminal.WorkerEpoch,
+					)
+				}
 			} else {
 				startingSent = true
 			}

--- a/cloud/internal/httpapi/worker_handlers.go
+++ b/cloud/internal/httpapi/worker_handlers.go
@@ -21,6 +21,7 @@ import (
 // control-plane or billing event onto its own session stream.
 var workerEventTypes = map[string]struct{}{
 	"agent.activity":       {},
+	"agent.ready":          {},
 	"worker.ready":         {},
 	"chat.assistant_delta": {},
 }
@@ -546,7 +547,7 @@ func (s *Server) workerEvent(w http.ResponseWriter, r *http.Request) {
 		s.appendSessionProjectionEvent(
 			r.Context(), claims.OrgID, claims.SessionID, input.Type, activity,
 		)
-	case "worker.ready":
+	case "worker.ready", "agent.ready":
 		var ready worker.ReadyEvent
 		if err := json.Unmarshal(input.Payload, &ready); err != nil ||
 			ready.WorkerID != claims.WorkerID ||

--- a/cloud/internal/httpapi/worker_handlers.go
+++ b/cloud/internal/httpapi/worker_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -16,6 +17,48 @@ import (
 	"github.com/aoagents/agent-orchestrator/cloud/internal/worker"
 	"github.com/go-chi/chi/v5"
 )
+
+type workerGitHubPATStore interface {
+	WorkerGitHubPAT(context.Context, string, string, string, int64) (domain.WorkerGitHubPAT, error)
+}
+
+// workerGitHubPATGrant resolves the configured PAT only for the authenticated
+// worker's own session. A missing PAT is deliberately indistinguishable from
+// no configured fallback so the GitHub App broker remains the normal path.
+func (s *Server) workerGitHubPATGrant(ctx context.Context, claims worker.Claims) (worker.CheckoutGrantResponse, bool) {
+	store, ok := s.store.(workerGitHubPATStore)
+	if !ok || s.secretCipher == nil {
+		return worker.CheckoutGrantResponse{}, false
+	}
+	credential, err := store.WorkerGitHubPAT(ctx, claims.OrgID, claims.SessionID, claims.WorkerID, claims.Epoch)
+	if err != nil {
+		if !errors.Is(err, postgres.ErrNotFound) && !errors.Is(err, postgres.ErrForbidden) {
+			s.logger.Warn("resolve worker GitHub personal access token", "error", err)
+		}
+		return worker.CheckoutGrantResponse{}, false
+	}
+	parsed, err := url.Parse(credential.CloneURL)
+	if err != nil || parsed.Scheme != "https" || !strings.EqualFold(parsed.Hostname(), "github.com") || parsed.User != nil {
+		s.logger.Warn("reject worker GitHub personal access token for non-GitHub repository", "session_id", claims.SessionID)
+		return worker.CheckoutGrantResponse{}, false
+	}
+	secret, err := s.secretCipher.Decrypt(credential.EncryptedSecret, credential.Nonce, providerSecretAssociatedData("user:"+credential.OwnerUserID, githubPATProvider))
+	if err != nil {
+		s.logger.Error("decrypt worker GitHub personal access token", "error", err)
+		return worker.CheckoutGrantResponse{}, false
+	}
+	if len(secret) == 0 {
+		return worker.CheckoutGrantResponse{}, false
+	}
+	defer clear(secret)
+	return worker.CheckoutGrantResponse{
+		CloneURL: credential.CloneURL,
+		Token:    string(secret),
+		// A PAT has no provider expiry. This is only a response freshness bound;
+		// the worker asks again whenever Git needs credentials.
+		ExpiresAt: time.Now().Add(time.Hour),
+	}, true
+}
 
 // Worker events are namespaced so a compromised sandbox cannot forge a
 // control-plane or billing event onto its own session stream.
@@ -230,6 +273,10 @@ func (s *Server) workerCheckoutGrant(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusForbidden, "SCOPE_REQUIRED", "The worker:git scope is required.")
 		return
 	}
+	if grant, ok := s.workerGitHubPATGrant(r.Context(), claims); ok {
+		writeJSON(w, http.StatusOK, worker.CheckoutGrantResponse{CloneURL: grant.CloneURL, Token: grant.Token, ExpiresAt: grant.ExpiresAt})
+		return
+	}
 	if s.checkoutBroker == nil {
 		writeError(w, r, http.StatusServiceUnavailable, "SCM_BROKER_UNAVAILABLE", "Repository checkout is not available.")
 		return
@@ -259,6 +306,10 @@ func (s *Server) workerPushGrant(w http.ResponseWriter, r *http.Request) {
 	claims := workerFrom(r)
 	if !worker.HasScope(claims, "worker:git") {
 		writeError(w, r, http.StatusForbidden, "SCOPE_REQUIRED", "The worker:git scope is required.")
+		return
+	}
+	if grant, ok := s.workerGitHubPATGrant(r.Context(), claims); ok {
+		writeJSON(w, http.StatusOK, worker.CheckoutGrantResponse{CloneURL: grant.CloneURL, Token: grant.Token, ExpiresAt: grant.ExpiresAt})
 		return
 	}
 	if s.checkoutBroker == nil {
@@ -293,6 +344,10 @@ func (s *Server) workerGitHubToken(w http.ResponseWriter, r *http.Request) {
 	claims := workerFrom(r)
 	if !worker.HasScope(claims, "worker:git") {
 		writeError(w, r, http.StatusForbidden, "SCOPE_REQUIRED", "The worker:git scope is required.")
+		return
+	}
+	if grant, ok := s.workerGitHubPATGrant(r.Context(), claims); ok {
+		writeJSON(w, http.StatusOK, worker.GitHubTokenResponse{Token: grant.Token, ExpiresAt: grant.ExpiresAt})
 		return
 	}
 	if s.checkoutBroker == nil {

--- a/cloud/internal/postgres/event_store.go
+++ b/cloud/internal/postgres/event_store.go
@@ -11,6 +11,7 @@ import (
 
 var clientEventTypes = []string{
 	"agent.activity",
+	"agent.ready",
 	"worker.connected",
 	"worker.ready",
 	"sandbox.provisioning",

--- a/cloud/internal/postgres/worker_checkout_store.go
+++ b/cloud/internal/postgres/worker_checkout_store.go
@@ -71,6 +71,64 @@ func (s *Store) WorkerGitHubCheckoutContext(
 	return authorization, nil
 }
 
+// WorkerGitHubPAT resolves the session creator's explicitly configured GitHub
+// personal access token. It deliberately derives the repository and token
+// owner from the session rather than accepting either from the worker.
+func (s *Store) WorkerGitHubPAT(
+	ctx context.Context,
+	orgID, sessionID, workerID string,
+	epoch int64,
+) (domain.WorkerGitHubPAT, error) {
+	var credential domain.WorkerGitHubPAT
+	err := s.withOrg(ctx, orgID, func(tx pgx.Tx) error {
+		if err := requireCurrentWorker(ctx, tx, orgID, sessionID, workerID, epoch); err != nil {
+			return err
+		}
+		var ownerUserID *string
+		if err := tx.QueryRow(ctx,
+			`SELECT project.repository_url, session.created_by_user_id::text
+			FROM ao_sessions session
+			JOIN ao_projects project
+			  ON project.org_id = session.org_id AND project.id = session.project_id
+			WHERE session.org_id = $1 AND session.id = $2
+			  AND session.is_terminated = false`,
+			orgID, sessionID,
+		).Scan(&credential.CloneURL, &ownerUserID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("resolve worker GitHub repository: %w", err)
+		}
+		if ownerUserID == nil {
+			return ErrNotFound
+		}
+		credential.OwnerUserID = *ownerUserID
+		if _, err := tx.Exec(ctx, `SELECT set_config('ao.user_id', $1, true)`, credential.OwnerUserID); err != nil {
+			return err
+		}
+		err := tx.QueryRow(ctx,
+			`SELECT encrypted_secret, secret_nonce
+			FROM ao_user_provider_connections
+			WHERE user_id = $1
+			  AND provider = 'github'
+			  AND label = 'default'
+			  AND validation_state = 'valid'`,
+			credential.OwnerUserID,
+		).Scan(&credential.EncryptedSecret, &credential.Nonce)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("resolve worker GitHub PAT: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return domain.WorkerGitHubPAT{}, err
+	}
+	return credential, nil
+}
+
 // WorkerRemoteGitHubCheckoutContext returns only the encrypted production
 // capability bound to the worker's own session. Repository and installation
 // identifiers are read from the project row and are never supplied by the

--- a/cloud/internal/postgres/worker_transport_store.go
+++ b/cloud/internal/postgres/worker_transport_store.go
@@ -379,10 +379,8 @@ func (s *Store) IssueTerminalTicket(
 			  ON worker.org_id = session.org_id
 			 AND worker.session_id = session.id
 			 AND worker.disconnected_at IS NULL
-			 AND worker.ready_at IS NOT NULL
 			WHERE session.org_id = $1 AND session.id = $2
-			  AND sandbox.desired_state = 'running'
-			  AND sandbox.observed_state = 'running'`,
+			  AND sandbox.desired_state = 'running'`,
 			orgID, sessionID,
 		).Scan(&epoch, &mode, &terminated, &deniedCommands)
 		if errors.Is(err, pgx.ErrNoRows) || terminated {

--- a/cloud/internal/reconcile/reconciler.go
+++ b/cloud/internal/reconcile/reconciler.go
@@ -938,7 +938,6 @@ func (r *Reconciler) provision(
 	// running) first. A provider slower than the budget falls back to the
 	// supervise-on-running path unchanged.
 	if bootstrapper, ok := provider.(sandbox.Bootstrapper); ok && len(r.options.WorkerBinary) > 0 {
-		runningWaitStartedAt := time.Now()
 		deadline := time.Now().Add(inlineRunningWait)
 		for environment.State != sandbox.StateRunning && time.Now().Before(deadline) && ctx.Err() == nil {
 			time.Sleep(inlineRunningPoll)
@@ -949,18 +948,11 @@ func (r *Reconciler) provision(
 			environment = refreshed
 		}
 		if environment.State == sandbox.StateRunning {
-			r.log.Info("sandbox provider reported running",
-				"session_id", record.SessionID,
-				"provider", record.Provider,
-				"provider_id", environment.ID,
-				"wait_ms", time.Since(runningWaitStartedAt).Milliseconds(),
-			)
 			r.log.Info("bootstrapping worker in freshly provisioned sandbox",
 				"session_id", record.SessionID,
 				"provider", record.Provider,
 				"provider_id", environment.ID,
 			)
-			bootstrapStartedAt := time.Now()
 			if err := bootstrapper.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
 				Binary:            r.options.WorkerBinary,
 				Destination:       r.options.WorkerDestination,
@@ -971,12 +963,6 @@ func (r *Reconciler) provision(
 			}); err != nil {
 				return r.fail(ctx, record, err)
 			}
-			r.log.Info("sandbox worker bootstrap launched",
-				"session_id", record.SessionID,
-				"provider", record.Provider,
-				"provider_id", environment.ID,
-				"duration_ms", time.Since(bootstrapStartedAt).Milliseconds(),
-			)
 			return r.observe(ctx, record, string(environment.ID),
 				domain.SandboxObservedBootstrapping, "", r.options.Interval)
 		}

--- a/cloud/internal/reconcile/reconciler.go
+++ b/cloud/internal/reconcile/reconciler.go
@@ -938,6 +938,7 @@ func (r *Reconciler) provision(
 	// running) first. A provider slower than the budget falls back to the
 	// supervise-on-running path unchanged.
 	if bootstrapper, ok := provider.(sandbox.Bootstrapper); ok && len(r.options.WorkerBinary) > 0 {
+		runningWaitStartedAt := time.Now()
 		deadline := time.Now().Add(inlineRunningWait)
 		for environment.State != sandbox.StateRunning && time.Now().Before(deadline) && ctx.Err() == nil {
 			time.Sleep(inlineRunningPoll)
@@ -948,11 +949,18 @@ func (r *Reconciler) provision(
 			environment = refreshed
 		}
 		if environment.State == sandbox.StateRunning {
+			r.log.Info("sandbox provider reported running",
+				"session_id", record.SessionID,
+				"provider", record.Provider,
+				"provider_id", environment.ID,
+				"wait_ms", time.Since(runningWaitStartedAt).Milliseconds(),
+			)
 			r.log.Info("bootstrapping worker in freshly provisioned sandbox",
 				"session_id", record.SessionID,
 				"provider", record.Provider,
 				"provider_id", environment.ID,
 			)
+			bootstrapStartedAt := time.Now()
 			if err := bootstrapper.BootstrapWorker(ctx, environment.ID, sandbox.WorkerBootstrap{
 				Binary:            r.options.WorkerBinary,
 				Destination:       r.options.WorkerDestination,
@@ -963,6 +971,12 @@ func (r *Reconciler) provision(
 			}); err != nil {
 				return r.fail(ctx, record, err)
 			}
+			r.log.Info("sandbox worker bootstrap launched",
+				"session_id", record.SessionID,
+				"provider", record.Provider,
+				"provider_id", environment.ID,
+				"duration_ms", time.Since(bootstrapStartedAt).Milliseconds(),
+			)
 			return r.observe(ctx, record, string(environment.ID),
 				domain.SandboxObservedBootstrapping, "", r.options.Interval)
 		}

--- a/cloud/internal/sandbox/createos/client.go
+++ b/cloud/internal/sandbox/createos/client.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sort"
@@ -77,6 +78,7 @@ type Client struct {
 	// sandbox has actually gone away. A field rather than a constant so tests
 	// can drive the poll loop without sleeping.
 	deletePoll time.Duration
+	log        *slog.Logger
 }
 
 var (
@@ -94,6 +96,7 @@ type Config struct {
 	Region       string
 	SSHPubKeys   []string
 	HTTPClient   *http.Client
+	Logger       *slog.Logger
 }
 
 // New creates a CreateOS sandbox provider.
@@ -101,6 +104,10 @@ func New(config Config) *Client {
 	httpClient := config.HTTPClient
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: defaultTimeout}
+	}
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.Default()
 	}
 	return &Client{
 		baseURL:      strings.TrimRight(strings.TrimSpace(config.BaseURL), "/"),
@@ -111,6 +118,7 @@ func New(config Config) *Client {
 		sshPubKeys:   append([]string(nil), config.SSHPubKeys...),
 		http:         httpClient,
 		deletePoll:   deletePollInterval,
+		log:          logger,
 	}
 }
 
@@ -459,9 +467,16 @@ func (c *Client) launchBakedWorker(
 	script.WriteString("echo AO_BAKED_OK")
 	result, err := c.execCapture(ctx, id, "bash", []string{"-c", script.String()})
 	if err != nil {
+		c.log.Warn("createos baked worker launch check failed; falling back to upload",
+			"provider_id", id, "error", err)
 		return false
 	}
-	return strings.Contains(result.Stdout, "AO_BAKED_OK")
+	if strings.Contains(result.Stdout, "AO_BAKED_OK") {
+		c.log.Info("createos baked worker launch hit", "provider_id", id)
+		return true
+	}
+	c.log.Info("createos baked worker launch miss; falling back to upload", "provider_id", id)
+	return false
 }
 
 // execCapture runs a command and returns its captured result, failing on a

--- a/cloud/internal/workertransport/supervisor.go
+++ b/cloud/internal/workertransport/supervisor.go
@@ -44,9 +44,8 @@ type Supervisor struct {
 	pendingAgentTerminalData [][]byte
 }
 
-// HoldAgentInputUntilWorkspaceReady permits the agent PTY to start while the
-// checkout runs, but preserves user input and durable turns until the checkout
-// has completed. Call this before Run.
+// HoldAgentInputUntilWorkspaceReady keeps repository-mutating transport and
+// agent input blocked until checkout has completed. Call this before Run.
 func (s *Supervisor) HoldAgentInputUntilWorkspaceReady() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -54,8 +53,8 @@ func (s *Supervisor) HoldAgentInputUntilWorkspaceReady() {
 	s.workspaceReady = false
 }
 
-// MarkWorkspaceReady releases prompts collected while the agent was booting
-// against an empty workspace.
+// MarkWorkspaceReady releases transport and prompts after checkout has
+// prepared the repository.
 func (s *Supervisor) MarkWorkspaceReady() {
 	s.mu.Lock()
 	s.workspaceReady = true
@@ -156,8 +155,7 @@ func (s *Supervisor) Run(ctx context.Context) error {
 }
 
 // StartAgent adds the coding-agent PTY after the workspace transport is already
-// serving. This lets a browser attach to a usable workspace shell while a
-// repository checkout and agent credential setup continue in the background.
+// serving.
 func (s *Supervisor) StartAgent(ctx context.Context, command workerexec.Command, terminalID string) error {
 	if terminalID == "" {
 		return errors.New("agent terminal id is required")
@@ -234,10 +232,14 @@ func (s *Supervisor) handle(
 			response, err = workspace.Read(input)
 		}
 	case "workspace.write":
-		var input worker.WorkspaceWriteRequest
-		err = decodePayload(request.Payload, &input)
-		if err == nil {
-			response, err = workspace.Write(input)
+		if !s.isWorkspaceReady() {
+			err = errors.New("workspace is still preparing")
+		} else {
+			var input worker.WorkspaceWriteRequest
+			err = decodePayload(request.Payload, &input)
+			if err == nil {
+				response, err = workspace.Write(input)
+			}
 		}
 	case "workspace.diff":
 		response, err = workspace.Diff(ctx)
@@ -250,7 +252,9 @@ func (s *Supervisor) handle(
 	case "terminal.open":
 		var input worker.TerminalCommand
 		err = decodePayload(request.Payload, &input)
-		if err == nil {
+		if err == nil && input.Kind == "workspace" && !s.isWorkspaceReady() {
+			err = errors.New("workspace is still preparing")
+		} else if err == nil {
 			err = s.openTerminal(ctx, input)
 			response = map[string]bool{"open": err == nil}
 		}
@@ -292,6 +296,12 @@ func (s *Supervisor) handle(
 	); failErr != nil {
 		s.Logger.Warn("fail worker transport request", "error", failErr, "kind", request.Kind)
 	}
+}
+
+func (s *Supervisor) isWorkspaceReady() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.holdAgentInput || s.workspaceReady
 }
 
 func (s *Supervisor) openTerminal(ctx context.Context, input worker.TerminalCommand) error {

--- a/cloud/internal/workertransport/supervisor.go
+++ b/cloud/internal/workertransport/supervisor.go
@@ -37,8 +37,41 @@ type Supervisor struct {
 	PollInterval    time.Duration
 	Logger          *slog.Logger
 
-	mu        sync.Mutex
-	terminals map[string]*terminalProcess
+	mu                       sync.Mutex
+	terminals                map[string]*terminalProcess
+	holdAgentInput           bool
+	workspaceReady           bool
+	pendingAgentTerminalData [][]byte
+}
+
+// HoldAgentInputUntilWorkspaceReady permits the agent PTY to start while the
+// checkout runs, but preserves user input and durable turns until the checkout
+// has completed. Call this before Run.
+func (s *Supervisor) HoldAgentInputUntilWorkspaceReady() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.holdAgentInput = true
+	s.workspaceReady = false
+}
+
+// MarkWorkspaceReady releases prompts collected while the agent was booting
+// against an empty workspace.
+func (s *Supervisor) MarkWorkspaceReady() {
+	s.mu.Lock()
+	s.workspaceReady = true
+	pending := s.pendingAgentTerminalData
+	s.pendingAgentTerminalData = nil
+	terminal := s.terminals[s.AgentTerminalID]
+	s.mu.Unlock()
+	if terminal == nil {
+		return
+	}
+	for _, data := range pending {
+		if _, err := terminal.pty.Write(data); err != nil {
+			s.Logger.Warn("flush queued agent terminal input", "error", err)
+			return
+		}
+	}
 }
 
 type terminalProcess struct {
@@ -122,7 +155,43 @@ func (s *Supervisor) Run(ctx context.Context) error {
 	}
 }
 
+// StartAgent adds the coding-agent PTY after the workspace transport is already
+// serving. This lets a browser attach to a usable workspace shell while a
+// repository checkout and agent credential setup continue in the background.
+func (s *Supervisor) StartAgent(ctx context.Context, command workerexec.Command, terminalID string) error {
+	if terminalID == "" {
+		return errors.New("agent terminal id is required")
+	}
+	s.mu.Lock()
+	if s.AgentTerminalID != "" {
+		s.mu.Unlock()
+		return errors.New("interactive agent terminal is already configured")
+	}
+	s.AgentCommand = command
+	s.mu.Unlock()
+	if err := s.openTerminal(ctx, worker.TerminalCommand{TerminalID: terminalID, Kind: "agent"}); err != nil {
+		s.mu.Lock()
+		s.AgentCommand = workerexec.Command{}
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Lock()
+	s.AgentTerminalID = terminalID
+	s.mu.Unlock()
+	return nil
+}
+
 func (s *Supervisor) forwardTurn(ctx context.Context) (bool, error) {
+	// Do not claim a queued user turn until the agent PTY is actually live. The
+	// workspace transport starts first, so claiming here would otherwise mark
+	// the initial task failed while the coding agent is still booting.
+	s.mu.Lock()
+	agentTerminalID := s.AgentTerminalID
+	workspaceReady := !s.holdAgentInput || s.workspaceReady
+	s.mu.Unlock()
+	if agentTerminalID == "" || !workspaceReady {
+		return false, nil
+	}
 	turn, err := s.Control.ClaimTurn(ctx)
 	if err != nil || turn == nil {
 		return false, err
@@ -130,13 +199,8 @@ func (s *Supervisor) forwardTurn(ctx context.Context) (bool, error) {
 	if turn.CancelRequested {
 		return true, s.Control.CompleteTurn(ctx, turn.ID, turn.Attempt, true)
 	}
-	if s.AgentTerminalID == "" {
-		return true, s.Control.FailTurn(
-			ctx, turn.ID, turn.Attempt, "interactive agent terminal is unavailable",
-		)
-	}
 	if err := s.writeTerminal(worker.TerminalCommand{
-		TerminalID: s.AgentTerminalID,
+		TerminalID: agentTerminalID,
 		Data:       []byte(turn.Prompt + "\r"),
 	}); err != nil {
 		if failErr := s.Control.FailTurn(
@@ -354,6 +418,11 @@ func (s *Supervisor) writeTerminal(input worker.TerminalCommand) error {
 		return errors.New("invalid terminal input request")
 	}
 	s.mu.Lock()
+	if s.holdAgentInput && !s.workspaceReady && input.TerminalID == s.AgentTerminalID {
+		s.pendingAgentTerminalData = append(s.pendingAgentTerminalData, append([]byte(nil), input.Data...))
+		s.mu.Unlock()
+		return nil
+	}
 	terminal := s.terminals[input.TerminalID]
 	s.mu.Unlock()
 	if terminal == nil {

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -40,7 +40,7 @@ const {
 		terminalState: { value: "idle" },
 		replaySettled: { value: true },
 		hasAttached: { value: false },
-		terminalSessionOptions: [] as Array<{ coverInitialReplay?: boolean; shellTerminalHandleId?: string }>,
+	terminalSessionOptions: [] as Array<{ coverInitialReplay?: boolean; waitForInitialOutput?: boolean; shellTerminalHandleId?: string }>,
 		xtermMounts: { value: 0 },
 		xtermUnmounts: { value: 0 },
 	}),
@@ -94,7 +94,7 @@ vi.mock("./XtermTerminal", () => ({
 vi.mock("../hooks/useTerminalSession", () => ({
 	useTerminalSession: (
 		_session: WorkspaceSession | undefined,
-		options: { coverInitialReplay?: boolean; shellTerminalHandleId?: string },
+		options: { coverInitialReplay?: boolean; waitForInitialOutput?: boolean; shellTerminalHandleId?: string },
 	) => {
 		terminalSessionOptions.push(options);
 		return {
@@ -409,6 +409,17 @@ describe("TerminalPane replay cover", () => {
 			// xterm keeps rendering underneath — covered, never unmounted, so the
 			// grid it measures stays correct.
 			expect(screen.getByTestId("xterm")).toBeInTheDocument();
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("keeps Cloud startup on Connecting until the agent terminal draws", () => {
+		replaySettled.value = false;
+		const view = renderPane({ ...worker, terminalHandleId: "term-1", cloud: { orgId: "org-1" } });
+		try {
+			expect(screen.getByTestId("terminal-replay-cover")).toHaveTextContent("Connecting…");
+			expect(terminalSessionOptions.at(-1)?.waitForInitialOutput).toBe(true);
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -37,6 +37,7 @@ import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useShellTerminals } from "../hooks/useShellTerminals";
 import { useCloudCp } from "../hooks/useCloudCp";
 import { createCloudTerminalMux } from "../lib/cloud-terminal-mux";
+import { subscribeSessionEventsBridged } from "../lib/cloud-cp/stream-bridge";
 import { XtermTerminal } from "./XtermTerminal";
 import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -314,12 +315,29 @@ export function TerminalCacheProvider({
 			const factory = () =>
 				createCloudTerminalMux({
 					wsBaseUrl: `${cloudCpRef.current.baseUrl.replace(/^http/i, "ws").replace(/\/+$/, "")}/api/cloud/v1`,
+					// Do not expose the temporary workspace shell. Keep the pane in its
+					// normal connecting state until the worker says the real coding-agent
+					// terminal is ready.
 					kind: "agent",
-					mintTicket: async () => {
+					waitForAgentReady: true,
+					mintTicket: async (kind) => {
 						const response = await cloudCpRef.current.client.createTerminalTicket(orgId, sessionId, {
-							kind: "agent",
+							kind,
 						});
 						return response.ticket;
+					},
+					subscribeAgentReady: (onReady) => {
+						const controller = new AbortController();
+						void subscribeSessionEventsBridged({
+							baseUrl: cloudCpRef.current.baseUrl,
+							orgId,
+							sessionId,
+							signal: controller.signal,
+							onEvent: (event) => {
+								if (event.type === "agent.ready") onReady();
+							},
+						});
+						return () => controller.abort();
 					},
 				});
 			cloudMuxFactoriesRef.current.set(sessionId, factory);

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -941,6 +941,9 @@ function AttachedTerminal({
 	const shellTerminalHandleId = terminalTarget?.kind === "shell" ? terminalTarget.handleId : undefined;
 	const { attach, state, error, replaySettled, hasAttached, syncVisibleSize } = useTerminalSession(attachSession, {
 		coverInitialReplay: terminalTarget?.kind !== "reviewer",
+		// Cloud workers can acknowledge a terminal before the coding agent emits
+		// its first screen. Keep the loading surface visible through that gap.
+		waitForInitialOutput: Boolean(attachSession?.cloud),
 		createMux,
 		daemonReady,
 		inputDisabled,
@@ -1117,7 +1120,7 @@ function AttachedTerminal({
 						</div>
 					</div>
 				)}
-				{showReplayCover && <ReplayCover />}
+				{showReplayCover && <ReplayCover message={attachSession?.cloud ? t("terminal.connecting") : undefined} />}
 				{banner && (
 					<div className="absolute inset-x-3 top-2 rounded-md border border-border bg-surface/95 px-3 py-1.5 font-mono text-caption text-muted-foreground">
 						{banner}
@@ -1138,16 +1141,18 @@ function AttachedTerminal({
 	);
 }
 
-function ReplayCover() {
+function ReplayCover({ message }: { message?: string }) {
 	return (
-		// Keep this cover silent: its only job is to hide the initial replay's
-		// intermediate paints. xterm remains live underneath, and pointer events
-		// pass through so selection and wheel input never wait on attachment.
+		// xterm remains live underneath. Cloud startup has no meaningful output
+		// until the agent TUI draws, so it gets one continuous Connecting surface;
+		// local replay stays deliberately silent to avoid covering settled output.
 		<div
-			aria-hidden="true"
-			className="bg-terminal-opaque pointer-events-none absolute inset-0"
+			aria-hidden={message ? undefined : "true"}
+			className="bg-terminal-opaque pointer-events-none absolute inset-0 grid place-items-center"
 			data-testid="terminal-replay-cover"
-		/>
+		>
+			{message ? <span className="font-mono text-sm text-terminal-dim">{message}</span> : null}
+		</div>
 	);
 }
 

--- a/frontend/src/renderer/components/settings/CloudCredentialsSection.tsx
+++ b/frontend/src/renderer/components/settings/CloudCredentialsSection.tsx
@@ -1,7 +1,11 @@
 import { KeyRound } from "lucide-react";
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 import { useCloudGate } from "../../hooks/useCloudGate";
+import { useCloudCp } from "../../hooks/useCloudCp";
 import { useCloudOrg } from "../../hooks/useCloudOrg";
 import { hasValidAgentConnection, useProviderConnections } from "../../hooks/useProviderConnections";
 import { useCloudSession } from "../../lib/cloud-session";
@@ -14,6 +18,7 @@ const AGENT_LABELS: Record<string, string> = {
 	"claude-code": "Claude Code",
 	codex: "Codex",
 	cursor: "Cursor",
+	github: "GitHub",
 };
 
 /**
@@ -34,8 +39,18 @@ function CloudCredentialsSectionInner({ titleHidden }: { titleHidden?: boolean }
 	const { t } = useTranslation();
 	const { status } = useCloudSession();
 	const { org } = useCloudOrg();
+	const { client } = useCloudCp();
+	const queryClient = useQueryClient();
 	const connections = useProviderConnections(org?.id);
+	const userConnections = useQuery({
+		queryKey: ["cloud-user-provider-connections"],
+		enabled: status === "authenticated",
+		queryFn: async () => (await client.listUserProviderConnections()).providerConnections,
+	});
 	const openCredentialDialog = useCredentialDialogStore((s) => s.openDialog);
+	const [githubPAT, setGitHubPAT] = useState("");
+	const [githubPATBusy, setGitHubPATBusy] = useState(false);
+	const [githubPATError, setGitHubPATError] = useState<string | null>(null);
 
 	// Managing credentials needs the signed-in org. The Cloud settings page is
 	// reachable while signed out, so say why it is empty instead of rendering a
@@ -49,10 +64,39 @@ function CloudCredentialsSectionInner({ titleHidden }: { titleHidden?: boolean }
 	}
 
 	const rows = connections.data ?? [];
+	const githubPATConnected = (userConnections.data ?? []).some(
+		(connection) => connection.provider === "github" && connection.label === "default" && connection.validationState === "valid",
+	);
+	const saveGitHubPAT = async () => {
+		if (githubPAT.trim() === "") return;
+		setGitHubPATBusy(true);
+		setGitHubPATError(null);
+		try {
+			await client.putGitHubPAT({ secret: githubPAT.trim() });
+			setGitHubPAT("");
+			await queryClient.invalidateQueries({ queryKey: ["cloud-user-provider-connections"] });
+		} catch (error) {
+			setGitHubPATError(error instanceof Error ? error.message : "Could not save the GitHub token.");
+		} finally {
+			setGitHubPATBusy(false);
+		}
+	};
+	const removeGitHubPAT = async () => {
+		setGitHubPATBusy(true);
+		setGitHubPATError(null);
+		try {
+			await client.deleteGitHubPAT();
+			await queryClient.invalidateQueries({ queryKey: ["cloud-user-provider-connections"] });
+		} catch (error) {
+			setGitHubPATError(error instanceof Error ? error.message : "Could not remove the GitHub token.");
+		} finally {
+			setGitHubPATBusy(false);
+		}
+	};
 	return (
 		<SettingsSection title={t("settings.cloudAgents")} sectionId="cloud-agents" titleHidden={titleHidden}>
 			<div className="flex w-full flex-col gap-1.5">
-				{rows.map((connection) => (
+				{rows.filter((connection) => connection.provider !== "github").map((connection) => (
 					<SettingsRow key={connection.id} icon={KeyRound} label={AGENT_LABELS[connection.provider] ?? connection.provider}>
 						<span className="text-sm leading-5 text-settings-muted">
 							{connection.validationState === "valid"
@@ -69,6 +113,22 @@ function CloudCredentialsSectionInner({ titleHidden }: { titleHidden?: boolean }
 					<Button type="button" variant="footer" onClick={() => openCredentialDialog()}>
 						{t("settings.cloudAgents.connect")}
 					</Button>
+				</div>
+				<div className="mt-3 border-t border-border px-3 pt-3">
+					<SettingsRow key="github-pat" icon={KeyRound} label="GitHub private repositories">
+						<span className="text-sm leading-5 text-settings-muted">{githubPATConnected ? "Connected" : "Not connected"}</span>
+					</SettingsRow>
+					<p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+						Optional. Paste a GitHub personal access token with access to private repositories. It is encrypted and used only by Cloud workers when cloning GitHub repositories.
+					</p>
+					<div className="mt-2 flex items-center gap-2">
+						<Input type="password" autoComplete="off" spellCheck={false} value={githubPAT} onChange={(event) => setGitHubPAT(event.target.value)} placeholder="github_pat_…" />
+						<Button type="button" variant="footer" disabled={githubPATBusy || githubPAT.trim() === ""} onClick={() => void saveGitHubPAT()}>
+							{githubPATBusy ? "Saving…" : "Save token"}
+						</Button>
+						{githubPATConnected ? <Button type="button" variant="footer" disabled={githubPATBusy} onClick={() => void removeGitHubPAT()}>Remove</Button> : null}
+					</div>
+					{githubPATError ? <p role="alert" className="mt-2 text-xs text-error">{githubPATError}</p> : null}
 				</div>
 			</div>
 		</SettingsSection>

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -156,6 +156,7 @@ function createFakeTerminal(): FakeTerminal {
 
 function setup({
 	coverInitialReplay = true,
+	waitForInitialOutput = false,
 	daemonReady = true,
 	attachedSession = session as WorkspaceSession | undefined,
 	isVisible = true,
@@ -181,6 +182,7 @@ function setup({
 		({ daemonReady: ready, isVisible: visible = true, inputDisabled: blocked = false }: { daemonReady: boolean; isVisible?: boolean; inputDisabled?: boolean }) =>
 			useTerminalSession(attachedSession, {
 				coverInitialReplay,
+				waitForInitialOutput,
 				daemonReady: ready,
 				createMux,
 				inputDisabled: blocked,
@@ -407,6 +409,16 @@ describe("useTerminalSession", () => {
 			expect(view.result.current.replaySettled).toBe(true);
 			act(() => muxes[0].emitData("handle-1", "review output"));
 			expect(terminal.lines).toEqual(["review output"]);
+			expect(view.result.current.replaySettled).toBe(true);
+		});
+
+		it("keeps a cloud-style startup covered until terminal output arrives", () => {
+			const { view, muxes } = setup({ waitForInitialOutput: true });
+			act(() => muxes[0].emitOpened("handle-1"));
+			act(() => void vi.advanceTimersByTime(1_000));
+			expect(view.result.current.replaySettled).toBe(false);
+			act(() => muxes[0].emitData("handle-1", "Codex is ready\\r\\n"));
+			act(() => void vi.advanceTimersByTime(60 + 180));
 			expect(view.result.current.replaySettled).toBe(true);
 		});
 

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -68,6 +68,8 @@ export type UseTerminalSessionOptions = {
 	inputDisabled?: boolean;
 	/** Coalesce and cover the initial replay. Disable for non-retained reviewer panes. */
 	coverInitialReplay?: boolean;
+	/** Keep the initial cover up until the terminal emits its first bytes. */
+	waitForInitialOutput?: boolean;
 	/**
 	 * False while a retained terminal is parked off screen. Output and transport
 	 * recovery continue, but hidden panes cannot send user input or PTY resizes.
@@ -591,13 +593,15 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				// Bound the gate from here: the daemon fires onOpen from setPTY and
 				// starts copyOut immediately after, so the replay is imminent and
 				// the cap now measures the burst rather than the connect handshake.
-				if (r.replayBuffering && !r.replayCapTimer) {
+				if (r.replayBuffering && !optionsRef.current.waitForInitialOutput && !r.replayCapTimer) {
 					r.replayCapTimer = setTimeout(() => flushReplay(true), REPLAY_CAP_MS);
 				}
-				// Same anchor, different job: uncover a pane that turns out to have
-				// nothing to replay (see REPLAY_FIRST_BYTE_MS). Deliberately not a
-				// flush — the gate stays armed so a late burst is still coalesced.
-				if (r.replayBuffering && !r.replayFirstByteTimer) {
+				// Same anchor, different job: local panes may uncover when there is
+				// nothing to replay (see REPLAY_FIRST_BYTE_MS). Cloud agent panes
+				// deliberately wait for their first real TUI bytes: showing xterm
+				// after the worker attaches but before Codex draws created a second
+				// blank screen between “Connecting…” and the agent UI.
+				if (r.replayBuffering && !optionsRef.current.waitForInitialOutput && !r.replayFirstByteTimer) {
 					r.replayFirstByteTimer = setTimeout(() => {
 						r.replayFirstByteTimer = null;
 						if (!isCurrentAttachment(generation, handle, mux)) return;

--- a/frontend/src/renderer/lib/cloud-cp/client.ts
+++ b/frontend/src/renderer/lib/cloud-cp/client.ts
@@ -30,6 +30,7 @@ import type {
 	CloudCpProviderConnectionResponse,
 	CloudCpProviderConnectionsResponse,
 	CloudCpPutAgentConnectionRequest,
+	CloudCpPutGitHubPATRequest,
 	CloudCpSendMessageRequest,
 	CloudCpSendMessageResponse,
 	CloudCpSessionDeletedResponse,
@@ -160,6 +161,7 @@ export interface CloudCpClient {
 		orgId: string,
 		options?: CloudCpRequestOptions,
 	): Promise<CloudCpProviderConnectionsResponse>;
+	listUserProviderConnections(options?: CloudCpRequestOptions): Promise<CloudCpProviderConnectionsResponse>;
 	putAgentConnection(
 		orgId: string,
 		agent: CloudCpAgentProvider,
@@ -167,6 +169,8 @@ export interface CloudCpClient {
 		options?: CloudCpRequestOptions,
 	): Promise<CloudCpProviderConnectionResponse>;
 	deleteAgentConnection(orgId: string, agent: CloudCpAgentProvider, options?: CloudCpRequestOptions): Promise<void>;
+	putGitHubPAT(body: CloudCpPutGitHubPATRequest, options?: CloudCpRequestOptions): Promise<CloudCpProviderConnectionResponse>;
+	deleteGitHubPAT(options?: CloudCpRequestOptions): Promise<void>;
 }
 
 type QueryParams = Record<string, string | number | undefined>;
@@ -391,6 +395,7 @@ export function createCloudCpClient(options: CloudCpClientOptions): CloudCpClien
 
 		listProviderConnections: (orgId, o) =>
 			requestJson("GET", `/orgs/${seg(orgId)}/provider-connections`, { signal: o?.signal }),
+		listUserProviderConnections: (o) => requestJson("GET", "/me/providers", { signal: o?.signal }),
 		putAgentConnection: (orgId, agent, body, o) =>
 			requestJson("PUT", `/orgs/${seg(orgId)}/provider-connections/agents/${seg(agent)}`, {
 				body,
@@ -400,5 +405,7 @@ export function createCloudCpClient(options: CloudCpClientOptions): CloudCpClien
 			requestVoid("DELETE", `/orgs/${seg(orgId)}/provider-connections/agents/${seg(agent)}`, {
 				signal: o?.signal,
 			}),
+		putGitHubPAT: (body, o) => requestJson("PUT", "/me/github-pat", { body, signal: o?.signal }),
+		deleteGitHubPAT: (o) => requestVoid("DELETE", "/me/github-pat", { signal: o?.signal }),
 	};
 }

--- a/frontend/src/renderer/lib/cloud-cp/types.ts
+++ b/frontend/src/renderer/lib/cloud-cp/types.ts
@@ -289,6 +289,12 @@ export interface CloudCpPutAgentConnectionRequest {
 	secret: string;
 }
 
+/** PUT /orgs/{orgId}/provider-connections/github-pat */
+export interface CloudCpPutGitHubPATRequest {
+	/** Raw GitHub personal access token; stored encrypted and never echoed. */
+	secret: string;
+}
+
 export interface CloudCpProviderConnection {
 	id: string;
 	provider: string;

--- a/frontend/src/renderer/lib/cloud-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/cloud-orchestrator.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { CloudCpProviderConnection } from "./cloud-cp";
+import { selectCloudOrchestratorHarness } from "./cloud-orchestrator";
+
+function connection(provider: string, validationState = "valid"): CloudCpProviderConnection {
+	return {
+		id: provider,
+		provider,
+		label: "default",
+		config: {},
+		validationState,
+		createdAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+	};
+}
+
+describe("selectCloudOrchestratorHarness", () => {
+	it("uses the connected harness when it is the only Cloud option", () => {
+		expect(selectCloudOrchestratorHarness([connection("claude-code")])).toBe("claude-code");
+	});
+
+	it("preserves Codex as the preference when several supported agents are connected", () => {
+		expect(selectCloudOrchestratorHarness([connection("cursor"), connection("codex")])).toBe("codex");
+	});
+
+	it("ignores invalid, non-default, and non-agent provider connections", () => {
+		const invalid = connection("codex", "invalid");
+		const nonDefault = { ...connection("claude-code"), label: "secondary" };
+		expect(selectCloudOrchestratorHarness([invalid, nonDefault, connection("github")])).toBeUndefined();
+	});
+});

--- a/frontend/src/renderer/lib/cloud-orchestrator.ts
+++ b/frontend/src/renderer/lib/cloud-orchestrator.ts
@@ -30,7 +30,7 @@ export async function spawnCloudOrchestrator(queryClient: QueryClient, projectId
 	const { session } = await client.createSession(orgId, {
 		projectId,
 		kind: "orchestrator",
-		harness: "claude-code",
+		harness: "codex",
 		displayName: "Orchestrator",
 		prompt: ORCHESTRATOR_KICKOFF_PROMPT,
 	});

--- a/frontend/src/renderer/lib/cloud-orchestrator.ts
+++ b/frontend/src/renderer/lib/cloud-orchestrator.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { createRendererCloudCpClient } from "../hooks/useCloudCp";
+import type { CloudCpAgentProvider, CloudCpProviderConnection } from "./cloud-cp";
 import { settingsQueryKey, type Settings } from "../hooks/useSettings";
 
 // A cloud project has no locally-configured orchestrator agent (that config
@@ -16,6 +17,23 @@ import { settingsQueryKey, type Settings } from "../hooks/useSettings";
 const ORCHESTRATOR_KICKOFF_PROMPT =
 	"You are the orchestrator for this project. Survey the repository, then wait for tasks and delegate work to worker sessions.";
 
+// A Cloud worker image currently ships these three harnesses. This ordering
+// preserves the former Codex default whenever it is available, while allowing
+// a user's connected Claude Code or Cursor credential to run the orchestrator
+// when Codex is not connected.
+const CLOUD_ORCHESTRATOR_HARNESS_PRIORITY: readonly CloudCpAgentProvider[] = ["codex", "claude-code", "cursor"];
+
+export function selectCloudOrchestratorHarness(
+	connections: readonly CloudCpProviderConnection[],
+): CloudCpAgentProvider | undefined {
+	const connected = new Set(
+		connections
+			.filter((connection) => connection.label === "default" && connection.validationState === "valid")
+			.map((connection) => connection.provider),
+	);
+	return CLOUD_ORCHESTRATOR_HARNESS_PRIORITY.find((harness) => connected.has(harness));
+}
+
 /** Spawns a cloud orchestrator session for the project and returns its id. */
 export async function spawnCloudOrchestrator(queryClient: QueryClient, projectId: string): Promise<string> {
 	const settings = queryClient.getQueryData<Settings>(settingsQueryKey);
@@ -27,10 +45,19 @@ export async function spawnCloudOrchestrator(queryClient: QueryClient, projectId
 	const me = await client.me();
 	const orgId = me.organizations[0]?.id;
 	if (orgId === undefined) throw new Error("No cloud organization is available.");
+	const [orgCredentials, personalCredentials] = await Promise.all([
+		client.listProviderConnections(orgId),
+		client.listUserProviderConnections(),
+	]);
+	const harness = selectCloudOrchestratorHarness([
+		...orgCredentials.providerConnections,
+		...personalCredentials.providerConnections,
+	]);
+	if (!harness) throw new Error("Connect a Cloud coding agent before spawning an orchestrator.");
 	const { session } = await client.createSession(orgId, {
 		projectId,
 		kind: "orchestrator",
-		harness: "codex",
+		harness,
 		displayName: "Orchestrator",
 		prompt: ORCHESTRATOR_KICKOFF_PROMPT,
 	});

--- a/frontend/src/renderer/lib/cloud-terminal-mux.ts
+++ b/frontend/src/renderer/lib/cloud-terminal-mux.ts
@@ -25,7 +25,11 @@ export interface CloudTerminalMuxOptions {
 	/** "agent" attaches the running coding agent; "workspace" opens a shell. */
 	kind: "agent" | "workspace";
 	/** Mints a fresh single-use terminal ticket (goes through the CP proxy). */
-	mintTicket: () => Promise<string>;
+	mintTicket: (kind: "agent" | "workspace") => Promise<string>;
+	/** Subscribes to the worker's explicit agent-ready lifecycle signal. */
+	subscribeAgentReady?: (onReady: () => void) => () => void;
+	/** Keep the pane in its connecting state until an agent-ready event arrives. */
+	waitForAgentReady?: boolean;
 	WebSocketImpl?: typeof WebSocket;
 }
 
@@ -45,6 +49,9 @@ export function createCloudTerminalMux(options: CloudTerminalMuxOptions): Termin
 
 	let socket: WebSocket | null = null;
 	let after = 0;
+	let activeKind: "agent" | "workspace" | null = options.waitForAgentReady ? null : options.kind;
+	let agentUpgradeRequested = false;
+	let agentRetryTimer: ReturnType<typeof setTimeout> | null = null;
 	let disposed = false;
 	let exited = false;
 	let connectionState: MuxConnectionState | undefined;
@@ -92,10 +99,43 @@ export function createCloudTerminalMux(options: CloudTerminalMuxOptions): Termin
 		}
 	};
 
-	const connect = async () => {
+	const openSocket = (kind: "agent" | "workspace", ticket: string) => {
+		if (disposed) return;
+		const query = new URLSearchParams({
+			ticket,
+			kind,
+			after: String(after),
+			protocol: "2",
+		});
+		const url = `${options.wsBaseUrl.replace(/\/+$/, "")}/terminal?${query.toString()}`;
+		const ws = new WS(url);
+		socket = ws;
+		ws.addEventListener("open", () => {
+			if (disposed || socket !== ws) return;
+			if (pendingResize) sendJSON({ type: "resize", columns: pendingResize.cols, rows: pendingResize.rows });
+			for (const input of pendingInput.splice(0)) sendJSON({ type: "input", data: input });
+			setConnectionState("open");
+		});
+		ws.addEventListener("message", (event) => {
+			if (socket === ws) handleMessage(event);
+		});
+		ws.addEventListener("close", (event: CloseEvent) => {
+			if (socket !== ws) return;
+			if (event.code === 1000 && !exited) {
+				exited = true;
+				exitListeners.forEach((listener) => listener());
+			}
+			setConnectionState("closed");
+		});
+		ws.addEventListener("error", () => {
+			if (socket === ws) setConnectionState("closed");
+		});
+	};
+
+	const connect = async (kind: "agent" | "workspace") => {
 		let ticket: string;
 		try {
-			ticket = await options.mintTicket();
+			ticket = await options.mintTicket(kind);
 		} catch {
 			if (disposed) return;
 			// A freshly created session's worker may not be connected yet while its
@@ -108,37 +148,39 @@ export function createCloudTerminalMux(options: CloudTerminalMuxOptions): Termin
 			return;
 		}
 		if (disposed) return;
-		const query = new URLSearchParams({
-			ticket,
-			kind: options.kind,
-			after: String(after),
-			protocol: "2",
-		});
-		const url = `${options.wsBaseUrl.replace(/\/+$/, "")}/terminal?${query.toString()}`;
-		const ws = new WS(url);
-		socket = ws;
-		ws.addEventListener("open", () => {
-			if (disposed) return;
-			if (pendingResize) sendJSON({ type: "resize", columns: pendingResize.cols, rows: pendingResize.rows });
-			for (const input of pendingInput.splice(0)) sendJSON({ type: "input", data: input });
-			setConnectionState("open");
-		});
-		ws.addEventListener("message", handleMessage);
-		ws.addEventListener("close", (event: CloseEvent) => {
-			// A normal closure (1000) is the CP telling us the terminal process
-			// exited or the terminal was closed — the pane is gone, so signal exit
-			// and let the hook stop reattaching. Any other close is a transport
-			// drop the hook should reconnect through (with a fresh ticket).
-			if (event.code === 1000 && !exited) {
-				exited = true;
-				exitListeners.forEach((listener) => listener());
-			}
-			setConnectionState("closed");
-		});
-		ws.addEventListener("error", () => setConnectionState("closed"));
+		if (kind === "workspace" && agentUpgradeRequested) return;
+		activeKind = kind;
+		openSocket(kind, ticket);
 	};
 
-	void connect();
+	const upgradeToAgent = () => {
+		if (disposed || activeKind === "agent" || agentUpgradeRequested) return;
+		agentUpgradeRequested = true;
+		void (async () => {
+			try {
+				const ticket = await options.mintTicket("agent");
+				if (disposed) return;
+				after = 0;
+				dataListeners.forEach((listener) => listener(new TextEncoder().encode("\u001bc")));
+				const previous = socket;
+				socket = null;
+				try {
+					previous?.close(1000, "switching to coding agent");
+				} catch {
+					// Already closed.
+				}
+				activeKind = "agent";
+				openSocket("agent", ticket);
+			} catch {
+				if (disposed) return;
+				agentUpgradeRequested = false;
+				agentRetryTimer = setTimeout(upgradeToAgent, 100);
+			}
+		})();
+	};
+
+	const unsubscribeAgentReady = options.subscribeAgentReady?.(upgradeToAgent);
+	if (!options.waitForAgentReady) void connect(options.kind);
 
 	return {
 		open: (_id, cols, rows) => {
@@ -184,6 +226,8 @@ export function createCloudTerminalMux(options: CloudTerminalMuxOptions): Termin
 		dispose: () => {
 			if (disposed) return;
 			disposed = true;
+			if (agentRetryTimer) clearTimeout(agentRetryTimer);
+			unsubscribeAgentReady?.();
 			dataListeners.clear();
 			exitListeners.clear();
 			openedListeners.clear();

--- a/frontend/src/renderer/routeTree.gen.ts
+++ b/frontend/src/renderer/routeTree.gen.ts
@@ -11,10 +11,10 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ShellRouteImport } from './routes/_shell'
 import { Route as ShellIndexRouteImport } from './routes/_shell.index'
-import { Route as ShellSettingsRouteImport } from './routes/_shell.settings'
 import { Route as ShellTerminalsRouteImport } from './routes/_shell.terminals'
-import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.projects.$projectId'
+import { Route as ShellSettingsRouteImport } from './routes/_shell.settings'
 import { Route as ShellSessionsSessionIdRouteImport } from './routes/_shell.sessions.$sessionId'
+import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.projects.$projectId'
 import { Route as ShellProjectsProjectIdSettingsRouteImport } from './routes/_shell.projects.$projectId_.settings'
 import { Route as ShellProjectsProjectIdSessionsSessionIdRouteImport } from './routes/_shell.projects.$projectId_.sessions.$sessionId'
 
@@ -27,24 +27,24 @@ const ShellIndexRoute = ShellIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellSettingsRoute = ShellSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => ShellRoute,
-} as any)
 const ShellTerminalsRoute = ShellTerminalsRouteImport.update({
   id: '/terminals',
   path: '/terminals',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellProjectsProjectIdRoute = ShellProjectsProjectIdRouteImport.update({
-  id: '/projects/$projectId',
-  path: '/projects/$projectId',
+const ShellSettingsRoute = ShellSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => ShellRoute,
 } as any)
 const ShellSessionsSessionIdRoute = ShellSessionsSessionIdRouteImport.update({
   id: '/sessions/$sessionId',
   path: '/sessions/$sessionId',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellProjectsProjectIdRoute = ShellProjectsProjectIdRouteImport.update({
+  id: '/projects/$projectId',
+  path: '/projects/$projectId',
   getParentRoute: () => ShellRoute,
 } as any)
 const ShellProjectsProjectIdSettingsRoute =
@@ -140,13 +140,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellIndexRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/_shell/settings': {
-      id: '/_shell/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof ShellSettingsRouteImport
-      parentRoute: typeof ShellRoute
-    }
     '/_shell/terminals': {
       id: '/_shell/terminals'
       path: '/terminals'
@@ -154,11 +147,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellTerminalsRouteImport
       parentRoute: typeof ShellRoute
     }
-    '/_shell/projects/$projectId': {
-      id: '/_shell/projects/$projectId'
-      path: '/projects/$projectId'
-      fullPath: '/projects/$projectId'
-      preLoaderRoute: typeof ShellProjectsProjectIdRouteImport
+    '/_shell/settings': {
+      id: '/_shell/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof ShellSettingsRouteImport
       parentRoute: typeof ShellRoute
     }
     '/_shell/sessions/$sessionId': {
@@ -166,6 +159,13 @@ declare module '@tanstack/react-router' {
       path: '/sessions/$sessionId'
       fullPath: '/sessions/$sessionId'
       preLoaderRoute: typeof ShellSessionsSessionIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/projects/$projectId': {
+      id: '/_shell/projects/$projectId'
+      path: '/projects/$projectId'
+      fullPath: '/projects/$projectId'
+      preLoaderRoute: typeof ShellProjectsProjectIdRouteImport
       parentRoute: typeof ShellRoute
     }
     '/_shell/projects/$projectId_/settings': {


### PR DESCRIPTION
# Cloud startup, private GitHub repos, and dynamic orchestrator agent

## What

Improve the Cloud session startup and private-repository experience:

- Start worker transport before repository checkout completes.
- Run checkout and coding-agent initialization in parallel.
- Keep the Cloud terminal on a continuous `Connecting…` state until the agent TUI emits its first output.
- Add encrypted, user-scoped GitHub PAT support for private GitHub repositories.
- Dynamically choose the Cloud orchestrator harness from connected Cloud credentials instead of always using Codex.
- Remove temporary startup timing instrumentation.

## Why

Cloud sessions had unnecessary perceived startup delay and visible blank terminal transitions:

- Repository checkout blocked worker and terminal availability.
- The terminal could attach before Codex had drawn, exposing an empty terminal between loading states.
- Private GitHub repositories could hang or fail without a checkout credential.
- Cloud orchestrators always requested Codex, even when the user had only connected Claude Code or Cursor.

This improves the Cloud parity and startup roadmap. 

Issue #4575 

## How

- Worker transport, heartbeat, checkout renewal, PR bridge, and review bridge start independently from repository preparation.
- Agent input remains queued until checkout completes, preventing work from running in an empty workspace.
- `worker.ready` signals transport availability; `agent.ready` signals coding-agent terminal startup.
- Cloud terminal replay remains covered until the first agent terminal bytes are rendered. Local terminal replay behavior is unchanged.
- GitHub PATs are encrypted in the existing user-scoped provider credential store:
  - no GitHub OAuth flow;
  - no validation request is made when saving;
  - the secret is never returned or logged;
  - only a worker for a session created by that user can retrieve it.
- The orchestrator reads valid organization and personal Cloud credentials, then chooses:
  1. Codex
  2. Claude Code
  3. Cursor

The worker image still intentionally supports only those three installed harnesses. This does not add arbitrary-harness support.

## Testing

Validated locally with:

```bash
cd cloud && go test ./cmd/ao-worker ./internal/reconcile
```

```bash
cd frontend
npx vitest run --config vite.renderer.config.ts \
  src/renderer/hooks/useTerminalSession.test.tsx \
  src/renderer/components/TerminalPane.test.tsx \
  src/renderer/lib/cloud-orchestrator.test.ts

npm run typecheck
```

Also verified:

```bash
git diff --check
```

Manual scenario validated with the local Docker Cloud control plane:

- Signed in to local Cloud.
- Saved a GitHub PAT in Cloud Settings.
- Created a Cloud project backed by a private repository.
- Confirmed private repository checkout succeeds.
- Confirmed the terminal stays on `Connecting…` until the agent TUI renders.

## Checklist

- [x] Continuing the existing `cloud/bug-fix` branch
- [x] Focused Cloud startup/private-repository improvement; no related issue supplied
- [x] Follows [[AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md)](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for terminal loading and orchestrator harness selection
- [x] Relevant Cloud Go and frontend checks pass