### PR TITLE
fix(chat): render inline Markdown in tool activity titles

### DIFF
--- a/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { aoBridge } from "../../lib/bridge";
 import { renderMermaidDiagram } from "../../lib/mermaid-diagram";
-import { ChatLinkProvider, ChatMarkdown } from "./ChatMarkdown";
+import { ActivityTitle, ChatLinkProvider, ChatMarkdown } from "./ChatMarkdown";
 
 // Mermaid needs real SVG layout APIs jsdom lacks; pin the routing boundary and
 // let MermaidBlock.test.tsx own the block's states.
@@ -334,5 +334,22 @@ describe("ChatMarkdown code highlighting", () => {
 
 		await user.click(wrap);
 		expect(wrapper).toHaveAttribute("data-wrap", "false");
+	});
+});
+
+
+describe("ActivityTitle", () => {
+	it("keeps code delimiters inside multi-backtick code spans", () => {
+		const { container } = render(<ActivityTitle text={"Edit ``file`name.ts``"} />);
+		expect(container.querySelector("code")).toHaveTextContent("file`name.ts");
+	});
+
+	it("keeps disclosure titles inline and non-interactive", () => {
+		const { container } = render(
+			<button><ActivityTitle text={'# **Edit** [file](https://example.com) `path.ts` ![image](https://example.com/image.png) <input autofocus />'} /></button>,
+		);
+		expect(screen.getByRole("button")).toHaveTextContent("Edit file path.ts");
+		expect(container.querySelector("strong")).toHaveTextContent("Edit");
+		expect(container.querySelector("a, img, input, p, h1, pre")).toBeNull();
 	});
 });

--- a/frontend/src/renderer/components/chat/ChatMarkdown.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.tsx
@@ -53,6 +53,21 @@ import { MermaidBlock } from "./MermaidBlock";
 import { CopyButton } from "./CopyButton";
 import "./code-theme.css";
 
+// Activity titles live inside disclosure buttons: keep inline formatting, but
+// unwrap block elements and links so provider text cannot nest interactive UI.
+const TITLE_ELEMENTS = ["code", "em", "strong", "del"];
+const TITLE_COMPONENTS: Components = {
+	code: ({ children }) => <code className="font-mono text-[0.95em]">{children}</code>,
+};
+
+export const ActivityTitle = memo(function ActivityTitle({ text }: { text: string }) {
+	return (
+		<Markdown allowedElements={TITLE_ELEMENTS} unwrapDisallowed components={TITLE_COMPONENTS}>
+			{text}
+		</Markdown>
+	);
+});
+
 /** GitHub-flavoured markdown: tables, strikethrough, task lists, autolinks. */
 const PLUGINS = [remarkGfm];
 

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.test.tsx
@@ -292,6 +292,20 @@ describe("AssistantMessage streaming", () => {
 });
 
 describe("ActivityRow", () => {
+	it("renders inline code in provider activity titles without literal backticks", () => {
+		const path = "/Users/sachin/.ao/worktrees/murdock/docs/system-design.html";
+		const { container } = render(
+			<ActivityRow activity={{
+				kind: "activity", id: "edit-title", sequence: 1, revision: 0,
+				createdAt: "2026-08-23T00:00:00Z", activityKind: "file_change",
+				status: "completed", summary: `Edit \`${path}\``,
+			}} />,
+		);
+		expect(screen.getByRole("button")).toHaveTextContent(`Edit ${path}`);
+		expect(container.querySelector("code")).toHaveTextContent(path);
+		expect(screen.getByRole("button").textContent).not.toContain("`");
+	});
+
 	it("does not present a recovered historical activity as failed", () => {
 		render(
 			<ActivityRow

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -51,7 +51,7 @@ const activityIcon: Record<ActivityKind, typeof SquareTerminal> = {
 import { cn } from "../../lib/utils";
 import { caretNotation, stripAnsi } from "../../lib/ansi";
 import { getApiBaseUrl } from "../../lib/api-client";
-import { ChatMarkdown } from "./ChatMarkdown";
+import { ActivityTitle, ChatMarkdown } from "./ChatMarkdown";
 import { HighlightedCode } from "./HighlightedCode";
 import { CopyButton } from "./CopyButton";
 import { HumanMessageEditor } from "./HumanMessageEditor";
@@ -878,7 +878,7 @@ function GenericActivityRow({ activity }: { activity: ConversationActivity }) {
 						)}
 						title={compactSummary ? undefined : label}
 					>
-						{label}
+						<ActivityTitle text={label} />
 					</strong>
 				)}
 				{path && !singleEdit ? (
@@ -1616,7 +1616,7 @@ function AutoReviewRow({ activity }: { activity: ConversationActivity }) {
 					className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-muted-foreground"
 					title={activity.summary}
 				>
-					{shortenPaths(activity.summary)}
+					<ActivityTitle text={shortenPaths(activity.summary)} />
 				</span>
 				{detail?.riskLevel ? (
 					<span


### PR DESCRIPTION
Fixes #4962.

Chat tool titles such as `Edit \`/Users/.../docs/system-design.html\`` displayed Markdown delimiters as literal text. Render restricted inline Markdown in generic activity titles and automatic-review summaries so paths appear as code. Block elements and links are unwrapped, and images/raw HTML cannot introduce interactive content inside disclosure buttons. Stored summaries and structured file labels are unchanged.

Validation:
- Remote CI passed: 275 Vitest files, 3,759 tests passed (6 skipped); all 55 renderer smoke tests passed. Frontend and E2E typechecks, Cloud client/product UI checks, and gitleaks scan passed.
- 54 focused ChatTimelineItems/ChatMarkdown tests passed on Node 24; reverting the title fix reproduces the exact backtick failure (1 failed, 20 passed).
- Browser fixture confirmed the actual ActivityRow renders the path in a code element without backticks.
- Cloud client generation/drift, typechecks, tests and package dry-run passed. Product UI typecheck, tests and package dry-run passed. Go CLI build passed.
- Full frontend Vitest and frontend typecheck were attempted but stopped under severe local resource contention (typecheck was still running after seven minutes); neither is claimed passed. Renderer smoke attempt timed out (5 failures, 50 not run). Docker is unavailable, so the pinned Linux container was not available locally. These local gaps are covered by the successful remote Frontend workflow on commit 26e9c2ed5.
- `ao preview` could not attach because this Codex task has no AO_SESSION_ID; browser-fixture verification is not a native desktop acceptance test.

The accompanying permission question needs no policy change: Chat already exposes provider-specific approval modes in the composer, including bypass where supported. This PR only fixes title formatting.

