### PR TITLE
fix(opencode): validate chat model overrides before launch

### DIFF
--- a/backend/internal/adapters/chatdriver/opencodeacp/driver.go
+++ b/backend/internal/adapters/chatdriver/opencodeacp/driver.go
@@ -4,7 +4,9 @@ package opencodeacp
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
@@ -18,9 +20,10 @@ import (
 // standing instructions and an explicit bypass-permissions choice.
 func New(plugin nativeacp.Plugin, log *slog.Logger) ports.ChatDriver {
 	return nativeacp.New(plugin, nativeacp.Config{
-		Harness:        domain.HarnessOpenCode,
-		Configure:      configure,
-		SessionOptions: sessionOptions,
+		Harness:              domain.HarnessOpenCode,
+		Configure:            configure,
+		SessionOptions:       sessionOptions,
+		ValidateTurnSettings: validateTurnSettings,
 	}, log)
 }
 
@@ -41,4 +44,18 @@ func sessionOptions(settings ports.ChatTurnSettings) []acpdriver.SessionOption {
 		return nil
 	}
 	return []acpdriver.SessionOption{{ID: "model", Value: settings.Model}}
+}
+
+// OpenCode parses model overrides as provider/model. A provider display name is
+// not an alias for its configured default model; keep that default only when
+// the override is empty. Leave model availability to the user's OpenCode.
+func validateTurnSettings(_ ports.PermissionMode, settings ports.ChatTurnSettings) error {
+	if settings.Model == "" {
+		return nil
+	}
+	provider, model, found := strings.Cut(settings.Model, "/")
+	if !found || strings.TrimSpace(provider) == "" || strings.TrimSpace(model) == "" {
+		return fmt.Errorf("%w: OpenCode model %q must use provider/model format (for example, anthropic/claude-sonnet); select a full model ID from `opencode models`, or clear the model override to use Agent default", ports.ErrChatConfigOptionInvalid, settings.Model)
+	}
+	return nil
 }

--- a/backend/internal/adapters/chatdriver/opencodeacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/opencodeacp/driver_test.go
@@ -3,6 +3,8 @@ package opencodeacp
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	acpdriver "github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/acp"
@@ -67,5 +69,64 @@ func TestSessionOptionsUseProviderAdvertisedModelOption(t *testing.T) {
 	got := sessionOptions(ports.ChatTurnSettings{Model: "anthropic/claude-sonnet"})
 	if len(got) != 1 || got[0].ID != "model" || got[0].Value != "anthropic/claude-sonnet" {
 		t.Fatalf("model settings = %#v", got)
+	}
+}
+
+func TestRejectsProviderNameBeforeLaunchingOpenCode(t *testing.T) {
+	for _, resume := range []bool{false, true} {
+		name := "start"
+		if resume {
+			name = "resume"
+		}
+		t.Run(name, func(t *testing.T) {
+			plugin := &unresolvedPlugin{}
+			driver := New(plugin, nil)
+			cfg := ports.ChatStartConfig{WorkspacePath: t.TempDir(), Model: "TensorMux"}
+			var err error
+			if resume {
+				_, err = driver.Resume(context.Background(), ports.ChatResumeConfig{WorkspacePath: cfg.WorkspacePath, Model: cfg.Model, ProviderConversationID: "existing"})
+			} else {
+				_, err = driver.Start(context.Background(), cfg)
+			}
+			if !errors.Is(err, ports.ErrChatConfigOptionInvalid) || !strings.Contains(err.Error(), "provider/model") {
+				t.Fatalf("error = %v, want model format validation with recovery guidance", err)
+			}
+			if plugin.resolved {
+				t.Fatal("invalid model reached OpenCode binary resolution")
+			}
+		})
+	}
+}
+
+type unresolvedPlugin struct{ resolved bool }
+
+func (p *unresolvedPlugin) ResolveBinary(context.Context) (string, error) {
+	p.resolved = true
+	return "", errors.New("unexpected binary resolution")
+}
+func (*unresolvedPlugin) AuthStatus(context.Context) (ports.AgentAuthStatus, error) {
+	return ports.AgentAuthStatusUnknown, nil
+}
+
+func TestValidateTurnSettingsModelFormat(t *testing.T) {
+	for _, model := range []string{"", "tensormux/glm-4-7-flash", "openrouter/vendor/model", "custom-provider/private-model:latest"} {
+		t.Run("valid/"+model, func(t *testing.T) {
+			settings := ports.ChatTurnSettings{Model: model}
+			if err := validateTurnSettings(ports.PermissionModeDefault, settings); err != nil {
+				t.Fatal(err)
+			}
+			options := sessionOptions(settings)
+			if model != "" && (len(options) != 1 || options[0].Value != model) {
+				t.Fatalf("model ID changed: %#v", options)
+			}
+		})
+	}
+	for _, model := range []string{"TensorMux", "glm-4-7-flash", " ", "/model", "provider/", " /model", "provider/ "} {
+		t.Run("invalid/"+model, func(t *testing.T) {
+			err := validateTurnSettings(ports.PermissionModeDefault, ports.ChatTurnSettings{Model: model})
+			if !errors.Is(err, ports.ErrChatConfigOptionInvalid) {
+				t.Fatalf("error = %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What
Reject malformed OpenCode Chat model overrides before provider launch, resume, or a turn-setting change, with guidance to choose a full `provider/model` ID or clear the override to use Agent default.

## Why
Fixes #4964. The reported orchestrator launch sent `TensorMux` as the model and surfaced a nested ACP `model not found` error. OpenCode requires a provider-qualified model ID; the screenshot's configured ID is `tensormux/glm-4-7-flash`. The screenshots do not establish how the incorrect AO override was entered.

## How
Use the existing ACP `ValidateTurnSettings` hook in the OpenCode binding. Validate only a missing/empty provider or model segment; preserve custom IDs, nested model paths, and empty overrides. Model availability remains OpenCode's responsibility. There is no automatic model substitution, saved-config migration, or credential change. TensorMux authentication/provider configuration is deliberately outside this fix.

## Testing
- Regression test failed before the fix: both Start and Resume attempted binary resolution for `TensorMux`. With the fix, both return `ErrChatConfigOptionInvalid` before launch.
- Focused OpenCode/ACP tests pass; table cases cover provider-only values, empty segments, Agent default, and custom IDs with additional slashes.
- `go build ./...`, `go vet ./...`, formatting, and API regeneration/drift checks pass.
- Full `npm run lint`/`go test ./...` completed with failures outside the changed adapter: fake-agent timing, Pi hook timing, installed Codex protocol mismatch, CLI switch-agent timing, and session-manager permission-window timing. The complete non-race rerun finished: fake/Pi/session-manager timing failures cleared; the installed Codex protocol mismatch and CLI doctor-test goroutine failures remained in unchanged packages.
- Full `go test -race -timeout=15m ./...` was run but could not complete: the remaining SQLite test process was stopped after a prolonged run (over 45 minutes wall time). It reported unrelated Codex conformance, ConPTY scrollback timing, installer cancellation timing, and browser screenshot failures. The changed OpenCode and shared ACP packages pass a fresh `go test -race -count=1` run.
- The complete native CLI E2E suite was run twice. Both runs failed `TestE2E_DaemonClosedOutputPipeShutdownRemovesRunFile` waiting 10 seconds for the run-file.
- Full golangci-lint v2.12.2 passes with zero issues using an isolated cache and `--timeout=15m`. The initial run hit its timeout and reported stale cached paths from a deleted worktree.
- All nine GitHub checks pass: full backend build/vet/race suite, lint, API drift, Windows workspace tests, native CLI E2E on macOS/Linux/Windows, Docker fresh-install, and secret scanning. Remote checks cover the local OS/Docker gaps listed below.
- Local environment: macOS arm64, Go 1.26.5 required by the repository's go.work; Node 26.4.0 (CI uses Node 24 for API generation).
- Linux/Windows native checks and the Docker fresh-install/gitleaks jobs cannot run on this local macOS host without Docker and must be verified in CI. The reporter's Windows installation and TensorMux credentials were not used.

## Checklist
- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md and PR hygiene; no screenshots, credentials, or planning artifacts committed
- [x] Regression tests added
- [x] Relevant CI checks pass
