### PR TITLE
feat(lifecycle): add durable orchestration event outbox

### DIFF
--- a/backend/internal/adapters/agent/pi/pi.go
+++ b/backend/internal/adapters/agent/pi/pi.go
@@ -57,6 +57,11 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.SubmitActivitySignaler = (*Plugin)(nil)
+
+// EmitsSubmitActivity reports that AO's managed before_agent_start extension
+// carries the exact accepted prompt to the daemon.
+func (p *Plugin) EmitsSubmitActivity() bool { return true }
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -399,7 +399,7 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 	}
 	conversation := hookConversationSnapshot{}
 	switch domain.AgentHarness(agent) {
-	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessContinue:
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessContinue, domain.HarnessPi:
 		conversation = hookConversationFacts(payload)
 	}
 	path := "sessions/" + url.PathEscape(sessionID) + "/activity"

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -456,6 +456,26 @@ func TestHooks_ContinueStopReportsClaudeCompatibleConversationFacts(t *testing.T
 	}
 }
 
+func TestHooks_PiPromptSubmitCarriesExactAutomationBatch(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+	prompt := "[AO AUTOMATION batch_id=batch-7] machine wake\nworker_turn_settled worker=w"
+	payload := `{"session_id":"pi-native","prompt":` + mustJSONString(t, prompt) + `}`
+	_, _, err := executeCLI(t, Deps{In: strings.NewReader(payload), ProcessAlive: func(int) bool { return true }}, "hooks", "pi", "user-prompt-submit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.LatestUserPrompt != prompt || req.Event != "user-prompt-submit" || req.State != "active" {
+		t.Fatalf("Pi prompt acknowledgement payload = %#v", req)
+	}
+}
+
 func TestHooks_NonSwitchingHarnessDoesNotReportConversationFacts(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -511,6 +511,14 @@ func Run() error {
 		default:
 		}
 	})
+	if err := orchestrationevents.Recover(ctx, store, orchestrationDispatcher); err != nil {
+		stop()
+		lcStack.Stop()
+		if cdcErr := cdcPipe.Stop(); cdcErr != nil {
+			log.Error("cdc pipeline shutdown", "err", cdcErr)
+		}
+		return fmt.Errorf("recover orchestration events: %w", err)
+	}
 	go orchestrationevents.Run(ctx, store, orchestrationDispatcher, orchestrationWake, log)
 
 	// servers isn't clobbered. See preview_wiring.go (issue #4500).

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -503,6 +503,7 @@ func Run() error {
 	orchestrationDispatcher := &orchestrationevents.Dispatcher{
 		Store:     store,
 		Transport: orchestrationTransport{sender: wiredSessMgr},
+		Notifier:  notificationWriter,
 	}
 	orchestrationWake := make(chan domain.ProjectID, 64)
 	lcStack.LCM.SetOrchestrationWake(func(project domain.ProjectID) {

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	agentswitchobs "github.com/aoagents/agent-orchestrator/backend/internal/observe/agentswitch"
 	"github.com/aoagents/agent-orchestrator/backend/internal/observe/sentryobs"
 	usagepipeline "github.com/aoagents/agent-orchestrator/backend/internal/observe/usage"
+	"github.com/aoagents/agent-orchestrator/backend/internal/orchestrationevents"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/presence"
 	"github.com/aoagents/agent-orchestrator/backend/internal/preview"
@@ -499,6 +500,18 @@ func Run() error {
 		return fmt.Errorf("wire session service: %w", err)
 	}
 	sessMgr = wiredSessMgr
+	orchestrationDispatcher := &orchestrationevents.Dispatcher{
+		Store:     store,
+		Transport: orchestrationTransport{sender: wiredSessMgr},
+	}
+	orchestrationWake := make(chan domain.ProjectID, 64)
+	lcStack.LCM.SetOrchestrationWake(func(project domain.ProjectID) {
+		select {
+		case orchestrationWake <- project:
+		default:
+		}
+	})
+	go orchestrationevents.Run(ctx, store, orchestrationDispatcher, orchestrationWake, log)
 
 	// servers isn't clobbered. See preview_wiring.go (issue #4500).
 	wireManagedPreviewExit(managedPreview, sessionSvc, log)
@@ -739,35 +752,36 @@ func Run() error {
 	bs.HostID = hostIdentity.HostID
 
 	srv, err := httpd.NewWithDeps(cfg, log, termMgr, httpd.APIDeps{
-		Projects:           projectSvc,
-		HostID:             hostIdentity.HostID,
-		Endpoints:          bs,
-		Agents:             agentSvc,
-		CodexAccounts:      agentSvc,
-		SystemChecks:       systemChecks,
-		Installer:          systemInstall,
-		Sessions:           sessionSvc,
-		DesktopWorkspaces:  sessionSvc,
-		PRs:                prActions,
-		Reviews:            reviewSvc,
-		Notifications:      notifier,
-		NotificationStream: notificationHub,
-		Push:               pushRegistry,
-		Presence:           presenceTracker,
-		DeviceRoster:       deviceRoster,
-		DeviceLive:         presenceTracker,
-		Import:             importsvc.New(importsvc.Deps{Store: store}),
-		ShellTerminals:     shellTermSvc,
-		AgentAuth:          agentAuthSvc,
-		Conversations:      chatSvc,
-		Settings:           settingsSvc,
-		CDC:                store,
-		Events:             cdcPipe.Broadcaster,
-		Activity:           lcStack.LCM,
-		UsageHooks:         usageCollector,
-		UsageSummary:       usagesvc.NewSummaryReader(store),
-		Telemetry:          telemetrySink,
-		Mobile:             mc,
+		Projects:            projectSvc,
+		HostID:              hostIdentity.HostID,
+		Endpoints:           bs,
+		Agents:              agentSvc,
+		CodexAccounts:       agentSvc,
+		SystemChecks:        systemChecks,
+		Installer:           systemInstall,
+		Sessions:            sessionSvc,
+		DesktopWorkspaces:   sessionSvc,
+		PRs:                 prActions,
+		Reviews:             reviewSvc,
+		Notifications:       notifier,
+		NotificationStream:  notificationHub,
+		OrchestrationEvents: store,
+		Push:                pushRegistry,
+		Presence:            presenceTracker,
+		DeviceRoster:        deviceRoster,
+		DeviceLive:          presenceTracker,
+		Import:              importsvc.New(importsvc.Deps{Store: store}),
+		ShellTerminals:      shellTermSvc,
+		AgentAuth:           agentAuthSvc,
+		Conversations:       chatSvc,
+		Settings:            settingsSvc,
+		CDC:                 store,
+		Events:              cdcPipe.Broadcaster,
+		Activity:            lcStack.LCM,
+		UsageHooks:          usageCollector,
+		UsageSummary:        usagesvc.NewSummaryReader(store),
+		Telemetry:           telemetrySink,
+		Mobile:              mc,
 		DevImport: devimportsvc.New(devimportsvc.Deps{
 			Store:         store,
 			TargetDataDir: cfg.DataDir,

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -173,6 +173,7 @@ type sessionLifecycle interface {
 	WaitAgentSwitchWorkers(ctx context.Context) error
 	Kill(ctx context.Context, id domain.SessionID) (bool, error)
 	Send(ctx context.Context, id domain.SessionID, message string, attachment *ports.SpawnAttachment) error
+	SendAutomation(ctx context.Context, id domain.SessionID, message, clientMessageID string) error
 	// SetShellTerminalCloser late-binds Kill/Cleanup to close a session's
 	// scoped shell terminals before its worktree is torn down. shellterm.Service
 	// is built after Session Manager during boot (see startShellTerminals), so

--- a/backend/internal/daemon/orchestration_events.go
+++ b/backend/internal/daemon/orchestration_events.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/orchestrationevents"
+)
+
+type automationSender interface {
+	SendAutomation(context.Context, domain.SessionID, string, string) error
+}
+
+type orchestrationTransport struct{ sender automationSender }
+
+func (t orchestrationTransport) Submit(ctx context.Context, target domain.SessionRecord, batch orchestrationevents.Batch) (orchestrationevents.Submission, error) {
+	err := t.sender.SendAutomation(ctx, target.ID, batch.Payload, batch.ID)
+	if err != nil {
+		return orchestrationevents.Submission{}, err
+	}
+	// Chat's durable client-message-id admission is the acknowledgement. TUI is
+	// submitted only; its exact prompt-submit hook closes the leased batch.
+	return orchestrationevents.Submission{Submitted: true, Acknowledged: domain.NormalizeSessionMode(target.Mode) == domain.SessionModeChat}, nil
+}

--- a/backend/internal/daemon/orchestration_events_test.go
+++ b/backend/internal/daemon/orchestration_events_test.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/orchestrationevents"
+)
+
+type automationSenderFake struct {
+	id           domain.SessionID
+	message, key string
+	err          error
+}
+
+func (f *automationSenderFake) SendAutomation(_ context.Context, id domain.SessionID, message, key string) error {
+	f.id = id
+	f.message = message
+	f.key = key
+	return f.err
+}
+
+func TestOrchestrationTransportChatAcknowledgesStableClientMessageID(t *testing.T) {
+	s := &automationSenderFake{}
+	result, err := (orchestrationTransport{sender: s}).Submit(context.Background(), domain.SessionRecord{ID: "o", Mode: domain.SessionModeChat}, orchestrationevents.Batch{ID: "batch", Payload: "safe"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Submitted || !result.Acknowledged || s.key != "batch" {
+		t.Fatalf("result=%+v key=%q", result, s.key)
+	}
+}
+func TestOrchestrationTransportTUIWaitsForHookAcknowledgement(t *testing.T) {
+	s := &automationSenderFake{}
+	result, err := (orchestrationTransport{sender: s}).Submit(context.Background(), domain.SessionRecord{ID: "o", Mode: domain.SessionModeTUI}, orchestrationevents.Batch{ID: "batch", Payload: "safe"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Submitted || result.Acknowledged {
+		t.Fatalf("result=%+v", result)
+	}
+}
+func TestOrchestrationTransportFailureClaimsNoSubmission(t *testing.T) {
+	s := &automationSenderFake{err: errors.New("no")}
+	result, err := (orchestrationTransport{sender: s}).Submit(context.Background(), domain.SessionRecord{ID: "o", Mode: domain.SessionModeChat}, orchestrationevents.Batch{ID: "batch", Payload: "safe"})
+	if err == nil || result.Submitted || result.Acknowledged {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+}

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -923,6 +923,10 @@ func (f *fakeSessionLifecycle) Send(context.Context, domain.SessionID, string, *
 	return nil
 }
 
+func (f *fakeSessionLifecycle) SendAutomation(context.Context, domain.SessionID, string, string) error {
+	return nil
+}
+
 func (f *fakeSessionLifecycle) Kill(_ context.Context, _ domain.SessionID) (bool, error) {
 	return false, nil
 }

--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -16,13 +16,14 @@ const (
 	// NotificationPRMerged means a tracked PR was merged.
 	NotificationPRMerged NotificationType = "pr_merged"
 	// NotificationPRClosedUnmerged means a tracked PR closed without merging.
-	NotificationPRClosedUnmerged NotificationType = "pr_closed_unmerged"
+	NotificationPRClosedUnmerged       NotificationType = "pr_closed_unmerged"
+	NotificationOrchestrationAttention NotificationType = "orchestration_attention"
 )
 
 // Valid reports whether t is one of the v1 notification kinds.
 func (t NotificationType) Valid() bool {
 	switch t {
-	case NotificationNeedsInput, NotificationReadyToMerge, NotificationPRMerged, NotificationPRClosedUnmerged:
+	case NotificationNeedsInput, NotificationReadyToMerge, NotificationPRMerged, NotificationPRClosedUnmerged, NotificationOrchestrationAttention:
 		return true
 	default:
 		return false
@@ -34,7 +35,7 @@ func (t NotificationType) Valid() bool {
 // Terminal facts — a PR that merged or closed — describe something that already
 // happened, so they are surfaced once as unseen and never held as unresolved.
 func (t NotificationType) NeedsResolution() bool {
-	return t == NotificationNeedsInput || t == NotificationReadyToMerge
+	return t == NotificationNeedsInput || t == NotificationReadyToMerge || t == NotificationOrchestrationAttention
 }
 
 // NotificationStatus is the seen state for a stored notification. The stored

--- a/backend/internal/domain/orchestration_event.go
+++ b/backend/internal/domain/orchestration_event.go
@@ -1,0 +1,38 @@
+package domain
+
+import "time"
+
+// OrchestrationEventKind names an AO-owned fact. Settled deliberately does not
+// imply that a worker's task completed.
+type OrchestrationEventKind string
+
+const (
+	OrchestrationWorkerTurnSettled OrchestrationEventKind = "worker_turn_settled"
+	OrchestrationWorkerBlocked     OrchestrationEventKind = "worker_blocked"
+	OrchestrationWorkerReadyMerge  OrchestrationEventKind = "worker_ready_to_merge"
+	OrchestrationWorkerTerminated  OrchestrationEventKind = "worker_terminated"
+	OrchestrationPRMerged          OrchestrationEventKind = "pr_merged"
+)
+
+type OrchestrationDeliveryState string
+
+const (
+	OrchestrationPending      OrchestrationDeliveryState = "pending"
+	OrchestrationLeased       OrchestrationDeliveryState = "leased"
+	OrchestrationSubmitted    OrchestrationDeliveryState = "submitted"
+	OrchestrationAcknowledged OrchestrationDeliveryState = "acknowledged"
+	OrchestrationDeadLetter   OrchestrationDeliveryState = "dead_letter"
+)
+
+// OrchestrationEvent is the durable normalized event and delivery state. It
+// intentionally contains identifiers and enums only, never provider prose.
+type OrchestrationEvent struct {
+	ID, SourceRevision, LeaseToken, LastError   string
+	ProjectID                                   ProjectID
+	WorkerID, DestinationSessionID              SessionID
+	Kind                                        OrchestrationEventKind
+	State                                       OrchestrationDeliveryState
+	AttemptCount                                int
+	EnqueuedAt, NextAttemptAt                   time.Time
+	LeaseExpiresAt, SubmittedAt, AcknowledgedAt time.Time
+}

--- a/backend/internal/domain/orchestration_event.go
+++ b/backend/internal/domain/orchestration_event.go
@@ -35,4 +35,5 @@ type OrchestrationEvent struct {
 	AttemptCount                                int
 	EnqueuedAt, NextAttemptAt                   time.Time
 	LeaseExpiresAt, SubmittedAt, AcknowledgedAt time.Time
+	AttentionRequiredAt                         time.Time
 }

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -22,21 +22,22 @@ import (
 
 // APIDeps bundles every service the API layer's controllers depend on.
 type APIDeps struct {
-	Agents             controllers.AgentCatalog
-	CodexAccounts      controllers.CodexAccountService
-	Projects           projectsvc.Manager
-	Sessions           controllers.SessionService
-	DesktopWorkspaces  controllers.DesktopWorkspaceService
-	Activity           controllers.ActivityRecorder
-	UsageHooks         controllers.UsageHookRecorder
-	UsageSummary       controllers.UsageSummaryService
-	PRs                prsvc.ActionManager
-	Reviews            reviewsvc.Manager
-	Notifications      controllers.NotificationService
-	NotificationStream controllers.NotificationStream
-	Push               controllers.PushRegistry
-	Import             controllers.ImportService
-	ShellTerminals     controllers.ShellTerminalService
+	Agents              controllers.AgentCatalog
+	CodexAccounts       controllers.CodexAccountService
+	Projects            projectsvc.Manager
+	Sessions            controllers.SessionService
+	DesktopWorkspaces   controllers.DesktopWorkspaceService
+	Activity            controllers.ActivityRecorder
+	UsageHooks          controllers.UsageHookRecorder
+	UsageSummary        controllers.UsageSummaryService
+	PRs                 prsvc.ActionManager
+	Reviews             reviewsvc.Manager
+	Notifications       controllers.NotificationService
+	NotificationStream  controllers.NotificationStream
+	OrchestrationEvents controllers.OrchestrationEventReader
+	Push                controllers.PushRegistry
+	Import              controllers.ImportService
+	ShellTerminals      controllers.ShellTerminalService
 	// Conversations is nil until a Chat driver is wired; the controller then
 	// answers 501 rather than panicking, matching the other optional surfaces.
 	Conversations controllers.ConversationService
@@ -101,30 +102,31 @@ func normalizeAPIDeps(deps APIDeps, log *slog.Logger) APIDeps {
 // API owns one controller per resource and is the single Register call the
 // router invokes to mount the /api/v1 surface.
 type API struct {
-	cfg           config.Config
-	deps          APIDeps
-	agents        *controllers.AgentsController
-	codexAccounts *controllers.CodexAccountsController
-	projects      *controllers.ProjectsController
-	sessions      *controllers.SessionsController
-	desktop       *controllers.DesktopWorkspaceController
-	usage         *controllers.UsageController
-	prs           *controllers.PRsController
-	reviews       *controllers.ReviewsController
-	notifications *controllers.NotificationsController
-	push          *controllers.PushController
-	imports       *controllers.ImportController
-	shellTerms    *controllers.ShellTerminalsController
-	conversations *controllers.ConversationsController
-	settings      *controllers.SettingsController
-	dev           *controllers.DevController
-	browser       *controllers.BrowserController
-	system        *controllers.SystemController
-	identity      *controllers.IdentityController
-	endpoints     *controllers.EndpointsController
-	systemInstall *controllers.SystemInstallController
-	agentAuth     *controllers.AgentAuthController
-	events        *EventsController
+	cfg                 config.Config
+	deps                APIDeps
+	agents              *controllers.AgentsController
+	codexAccounts       *controllers.CodexAccountsController
+	projects            *controllers.ProjectsController
+	sessions            *controllers.SessionsController
+	desktop             *controllers.DesktopWorkspaceController
+	usage               *controllers.UsageController
+	prs                 *controllers.PRsController
+	reviews             *controllers.ReviewsController
+	notifications       *controllers.NotificationsController
+	orchestrationEvents *controllers.OrchestrationEventsController
+	push                *controllers.PushController
+	imports             *controllers.ImportController
+	shellTerms          *controllers.ShellTerminalsController
+	conversations       *controllers.ConversationsController
+	settings            *controllers.SettingsController
+	dev                 *controllers.DevController
+	browser             *controllers.BrowserController
+	system              *controllers.SystemController
+	identity            *controllers.IdentityController
+	endpoints           *controllers.EndpointsController
+	systemInstall       *controllers.SystemInstallController
+	agentAuth           *controllers.AgentAuthController
+	events              *EventsController
 }
 
 // NewAPI constructs the API surface from its dependencies. cfg carries the
@@ -149,24 +151,25 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 			PreviewServer: deps.PreviewServer,
 			Capabilities:  deps.SessionCapabilities,
 		},
-		desktop:       &controllers.DesktopWorkspaceController{Svc: deps.DesktopWorkspaces},
-		usage:         &controllers.UsageController{Svc: deps.UsageSummary},
-		prs:           &controllers.PRsController{Svc: deps.PRs},
-		reviews:       &controllers.ReviewsController{Svc: deps.Reviews},
-		notifications: &controllers.NotificationsController{Svc: deps.Notifications, Stream: deps.NotificationStream},
-		push:          &controllers.PushController{Registry: deps.Push},
-		imports:       &controllers.ImportController{Svc: deps.Import},
-		shellTerms:    &controllers.ShellTerminalsController{Svc: deps.ShellTerminals},
-		conversations: &controllers.ConversationsController{Svc: deps.Conversations},
-		settings:      &controllers.SettingsController{Svc: deps.Settings},
-		dev:           &controllers.DevController{Import: deps.DevImport},
-		browser:       &controllers.BrowserController{Svc: deps.Browser},
-		system:        &controllers.SystemController{Checks: deps.SystemChecks},
-		identity:      &controllers.IdentityController{HostID: deps.HostID},
-		endpoints:     &controllers.EndpointsController{Source: deps.Endpoints},
-		systemInstall: &controllers.SystemInstallController{Installer: deps.Installer},
-		agentAuth:     &controllers.AgentAuthController{Svc: deps.AgentAuth},
-		events:        &EventsController{Source: deps.CDC, Live: deps.Events},
+		desktop:             &controllers.DesktopWorkspaceController{Svc: deps.DesktopWorkspaces},
+		usage:               &controllers.UsageController{Svc: deps.UsageSummary},
+		prs:                 &controllers.PRsController{Svc: deps.PRs},
+		reviews:             &controllers.ReviewsController{Svc: deps.Reviews},
+		notifications:       &controllers.NotificationsController{Svc: deps.Notifications, Stream: deps.NotificationStream},
+		orchestrationEvents: &controllers.OrchestrationEventsController{Store: deps.OrchestrationEvents},
+		push:                &controllers.PushController{Registry: deps.Push},
+		imports:             &controllers.ImportController{Svc: deps.Import},
+		shellTerms:          &controllers.ShellTerminalsController{Svc: deps.ShellTerminals},
+		conversations:       &controllers.ConversationsController{Svc: deps.Conversations},
+		settings:            &controllers.SettingsController{Svc: deps.Settings},
+		dev:                 &controllers.DevController{Import: deps.DevImport},
+		browser:             &controllers.BrowserController{Svc: deps.Browser},
+		system:              &controllers.SystemController{Checks: deps.SystemChecks},
+		identity:            &controllers.IdentityController{HostID: deps.HostID},
+		endpoints:           &controllers.EndpointsController{Source: deps.Endpoints},
+		systemInstall:       &controllers.SystemInstallController{Installer: deps.Installer},
+		agentAuth:           &controllers.AgentAuthController{Svc: deps.AgentAuth},
+		events:              &EventsController{Source: deps.CDC, Live: deps.Events},
 	}
 }
 
@@ -193,6 +196,7 @@ func (a *API) Register(root chi.Router) {
 			a.prs.Register(r)
 			a.reviews.Register(r)
 			a.notifications.Register(r)
+			a.orchestrationEvents.Register(r)
 			a.push.Register(r)
 			a.imports.Register(r)
 			a.shellTerms.Register(r)

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -9789,6 +9789,7 @@ components:
           - ready_to_merge
           - pr_merged
           - pr_closed_unmerged
+          - orchestration_attention
           type: string
       required:
       - id

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2241,6 +2241,51 @@ paths:
       summary: Explicitly retry a dead-letter orchestration event
       tags:
       - notifications
+  /api/v1/projects/{id}/permissions:
+    patch:
+      operationId: setProjectPermissions
+      parameters:
+      - description: Project identifier (registry key).
+        in: path
+        name: id
+        required: true
+        schema:
+          description: Project identifier (registry key).
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetProjectPermissionsInput'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+      summary: Remember project permissions for future sessions
+      tags:
+      - projects
   /api/v1/projects/clone:
     post:
       operationId: cloneProject
@@ -6477,6 +6522,62 @@ paths:
       summary: Rename a standalone shell terminal tab
       tags:
       - shellTerminals
+  /api/v1/system/github-auth:
+    get:
+      operationId: getGitHubAuthRequirement
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemRequirement'
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Check advisory GitHub CLI authentication without blocking startup
+      tags:
+      - system
+  /api/v1/system/github-auth/terminal:
+    post:
+      operationId: openGitHubAuthTerminal
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShellTerminalEnvelope'
+          description: Created
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Open a trusted terminal running the GitHub CLI login flow
+      tags:
+      - system
   /api/v1/system/install/{target}:
     get:
       operationId: getSystemInstallStatus
@@ -8222,6 +8323,13 @@ components:
         groupName:
           type: string
         name:
+          type: string
+        permissionMode:
+          enum:
+          - default
+          - accept-edits
+          - auto
+          - bypass-permissions
           type: string
         value:
           type: string
@@ -11043,6 +11151,20 @@ components:
       required:
       - config
       type: object
+    SetProjectPermissionsInput:
+      properties:
+        permissions:
+          enum:
+          - default
+          - accept-edits
+          - auto
+          - bypass-permissions
+          type: string
+        sourceHarness:
+          type: string
+      required:
+      - permissions
+      type: object
     SetReviewActivityRequest:
       properties:
         agentSessionId:
@@ -11553,6 +11675,7 @@ components:
           - tmux
           - harness
           - gh
+          - github-auth
           type: string
         label:
           description: Human-readable requirement name.

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2152,9 +2152,9 @@ paths:
       summary: Replace a project's per-project config
       tags:
       - projects
-  /api/v1/projects/{id}/permissions:
-    patch:
-      operationId: setProjectPermissions
+  /api/v1/projects/{id}/orchestration-events:
+    get:
+      operationId: listOrchestrationEvents
       parameters:
       - description: Project identifier (registry key).
         in: path
@@ -2163,18 +2163,18 @@ paths:
         schema:
           description: Project identifier (registry key).
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetProjectPermissionsInput'
-        required: true
+      - in: query
+        name: limit
+        schema:
+          maximum: 100
+          minimum: 1
+          type: integer
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectResponse'
+                $ref: '#/components/schemas/ListOrchestrationEventsResponse'
           description: OK
         "400":
           content:
@@ -2182,21 +2182,65 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Bad Request
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Not Found
         "500":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Internal Server Error
-      summary: Remember project permissions for future sessions
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: List daemon orchestration delivery state
       tags:
-      - projects
+      - notifications
+  /api/v1/projects/{id}/orchestration-events/{eventId}/retry:
+    post:
+      operationId: retryOrchestrationEvent
+      parameters:
+      - description: Project identifier (registry key).
+        in: path
+        name: id
+        required: true
+        schema:
+          description: Project identifier (registry key).
+          type: string
+      - in: path
+        name: eventId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetryOrchestrationEventResponse'
+          description: OK
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Explicitly retry a dead-letter orchestration event
+      tags:
+      - notifications
   /api/v1/projects/clone:
     post:
       operationId: cloneProject
@@ -6433,62 +6477,6 @@ paths:
       summary: Rename a standalone shell terminal tab
       tags:
       - shellTerminals
-  /api/v1/system/github-auth:
-    get:
-      operationId: getGitHubAuthRequirement
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SystemRequirement'
-          description: OK
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Internal Server Error
-        "501":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Not Implemented
-      summary: Check advisory GitHub CLI authentication without blocking startup
-      tags:
-      - system
-  /api/v1/system/github-auth/terminal:
-    post:
-      operationId: openGitHubAuthTerminal
-      responses:
-        "201":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ShellTerminalEnvelope'
-          description: Created
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Bad Request
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Internal Server Error
-        "501":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIError'
-          description: Not Implemented
-      summary: Open a trusted terminal running the GitHub CLI login flow
-      tags:
-      - system
   /api/v1/system/install/{target}:
     get:
       operationId: getSystemInstallStatus
@@ -8235,13 +8223,6 @@ components:
           type: string
         name:
           type: string
-        permissionMode:
-          enum:
-          - default
-          - accept-edits
-          - auto
-          - bypass-permissions
-          type: string
         value:
           type: string
       required:
@@ -9449,6 +9430,15 @@ components:
       - unreadCount
       - unresolvedCount
       type: object
+    ListOrchestrationEventsResponse:
+      properties:
+        events:
+          items:
+            $ref: '#/components/schemas/OrchestrationEventResponse'
+          type: array
+      required:
+      - events
+      type: object
     ListProjectsResponse:
       properties:
         projects:
@@ -9851,6 +9841,63 @@ components:
           description: 'Windows shell selector: auto, git-bash, pwsh, powershell,
             cmd, or a custom executable path. Ignored on macOS and Linux.'
           type: string
+      type: object
+    OrchestrationEventResponse:
+      properties:
+        acknowledgedAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        attemptCount:
+          type: integer
+        attentionRequiredAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        destinationSessionId:
+          type: string
+        enqueuedAt:
+          format: date-time
+          type: string
+        id:
+          type: string
+        kind:
+          type: string
+        lastError:
+          type: string
+        leaseExpiresAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        nextAttemptAt:
+          format: date-time
+          type: string
+        projectId:
+          type: string
+        sourceRevision:
+          type: string
+        state:
+          type: string
+        submittedAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        workerId:
+          type: string
+      required:
+      - id
+      - projectId
+      - workerId
+      - kind
+      - sourceRevision
+      - state
+      - attemptCount
+      - enqueuedAt
+      - nextAttemptAt
       type: object
     OrchestratorResponse:
       properties:
@@ -10307,6 +10354,13 @@ components:
       - sessionId
       - resumeMode
       - session
+      type: object
+    RetryOrchestrationEventResponse:
+      properties:
+        retried:
+          type: boolean
+      required:
+      - retried
       type: object
     RetryTurnResponse:
       properties:
@@ -10988,20 +11042,6 @@ components:
       required:
       - config
       type: object
-    SetProjectPermissionsInput:
-      properties:
-        permissions:
-          enum:
-          - default
-          - accept-edits
-          - auto
-          - bypass-permissions
-          type: string
-        sourceHarness:
-          type: string
-      required:
-      - permissions
-      type: object
     SetReviewActivityRequest:
       properties:
         agentSessionId:
@@ -11512,7 +11552,6 @@ components:
           - tmux
           - harness
           - gh
-          - github-auth
           type: string
         label:
           description: Human-readable requirement name.

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -349,6 +349,11 @@ var schemaNames = map[string]string{ //nolint:gosec // Public OpenAPI type names
 	"PortsAgentModelCatalog":                      "AgentModelsResponse",
 	"PortsAgentModelInfo":                         "AgentModelInfo",
 	"ControllersListNotificationsQuery":           "ListNotificationsQuery",
+	"ControllersOrchestrationEventResponse":       "OrchestrationEventResponse",
+	"ControllersListOrchestrationEventsResponse":  "ListOrchestrationEventsResponse",
+	"ControllersListOrchestrationEventsQuery":     "ListOrchestrationEventsQuery",
+	"ControllersRetryOrchestrationEventResponse":  "RetryOrchestrationEventResponse",
+	"ControllersOrchestrationEventIDParam":        "OrchestrationEventIDParam",
 	"ControllersNotificationStreamQuery":          "NotificationStreamQuery",
 	"ControllersNotificationIDParam":              "NotificationIDParam",
 	"ControllersNotificationTarget":               "NotificationTarget",
@@ -1465,6 +1470,22 @@ func devOperations() []operation {
 
 func notificationOperations() []operation {
 	return []operation{
+		{
+			method: http.MethodGet, path: "/api/v1/projects/{id}/orchestration-events", id: "listOrchestrationEvents", tag: "notifications",
+			summary:    "List daemon orchestration delivery state",
+			pathParams: []any{controllers.ProjectIDParam{}, controllers.ListOrchestrationEventsQuery{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.ListOrchestrationEventsResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodPost, path: "/api/v1/projects/{id}/orchestration-events/{eventId}/retry", id: "retryOrchestrationEvent", tag: "notifications", summary: "Explicitly retry a dead-letter orchestration event",
+			pathParams: []any{controllers.ProjectIDParam{}, controllers.OrchestrationEventIDParam{}},
+			resps:      []respUnit{{http.StatusOK, controllers.RetryOrchestrationEventResponse{}}, {http.StatusConflict, envelope.APIError{}}, {http.StatusInternalServerError, envelope.APIError{}}, {http.StatusNotImplemented, envelope.APIError{}}},
+		},
 		{
 			method: http.MethodGet, path: "/api/v1/notifications", id: "listNotifications", tag: "notifications",
 			summary:    "List notification history",

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1488,7 +1488,7 @@ type NotificationResponse struct {
 	SessionID string    `json:"sessionId"`
 	ProjectID string    `json:"projectId"`
 	PRURL     string    `json:"prUrl"`
-	Type      string    `json:"type" enum:"needs_input,ready_to_merge,pr_merged,pr_closed_unmerged"`
+	Type      string    `json:"type" enum:"needs_input,ready_to_merge,pr_merged,pr_closed_unmerged,orchestration_attention"`
 	Title     string    `json:"title"`
 	Body      string    `json:"body"`
 	Status    string    `json:"status" enum:"unread,read" description:"Seen state. unread means the user has not opened the notification panel since it arrived."`

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1428,6 +1428,36 @@ type AgentInstallJobsResponse struct {
 	Jobs []systeminstall.Job `json:"jobs"`
 }
 
+type OrchestrationEventResponse struct {
+	ID                   string                            `json:"id"`
+	ProjectID            domain.ProjectID                  `json:"projectId"`
+	WorkerID             domain.SessionID                  `json:"workerId"`
+	Kind                 domain.OrchestrationEventKind     `json:"kind"`
+	SourceRevision       string                            `json:"sourceRevision"`
+	State                domain.OrchestrationDeliveryState `json:"state"`
+	AttemptCount         int                               `json:"attemptCount"`
+	EnqueuedAt           time.Time                         `json:"enqueuedAt"`
+	NextAttemptAt        time.Time                         `json:"nextAttemptAt"`
+	LeaseExpiresAt       *time.Time                        `json:"leaseExpiresAt,omitempty"`
+	DestinationSessionID domain.SessionID                  `json:"destinationSessionId,omitempty"`
+	SubmittedAt          *time.Time                        `json:"submittedAt,omitempty"`
+	AcknowledgedAt       *time.Time                        `json:"acknowledgedAt,omitempty"`
+	AttentionRequiredAt  *time.Time                        `json:"attentionRequiredAt,omitempty"`
+	LastError            string                            `json:"lastError,omitempty"`
+}
+type ListOrchestrationEventsResponse struct {
+	Events []OrchestrationEventResponse `json:"events"`
+}
+type ListOrchestrationEventsQuery struct {
+	Limit int `query:"limit,omitempty" minimum:"1" maximum:"100"`
+}
+type RetryOrchestrationEventResponse struct {
+	Retried bool `json:"retried"`
+}
+type OrchestrationEventIDParam struct {
+	EventID string `path:"eventId"`
+}
+
 // ListNotificationsQuery is the query string accepted by GET /api/v1/notifications.
 type ListNotificationsQuery struct {
 	Status string `query:"status,omitempty" enum:"unread,all,unresolved" description:"Notification filter. Defaults to unread (unseen); unresolved returns notifications whose underlying issue is still open; all includes read history."`

--- a/backend/internal/httpd/controllers/orchestration_events.go
+++ b/backend/internal/httpd/controllers/orchestration_events.go
@@ -14,7 +14,7 @@ import (
 
 type OrchestrationEventReader interface {
 	ListOrchestrationEvents(context.Context, domain.ProjectID, int) ([]domain.OrchestrationEvent, error)
-	RetryDeadLetterOrchestrationEvent(context.Context, string, time.Time) (bool, error)
+	RetryDeadLetterOrchestrationEvent(context.Context, domain.ProjectID, string, time.Time) (bool, error)
 }
 type OrchestrationEventsController struct{ Store OrchestrationEventReader }
 
@@ -27,7 +27,7 @@ func (c *OrchestrationEventsController) retry(w http.ResponseWriter, r *http.Req
 		apispec.NotImplemented(w, r, http.MethodPost, "/api/v1/projects/{id}/orchestration-events/{eventId}/retry")
 		return
 	}
-	changed, err := c.Store.RetryDeadLetterOrchestrationEvent(r.Context(), chi.URLParam(r, "eventId"), time.Now().UTC())
+	changed, err := c.Store.RetryDeadLetterOrchestrationEvent(r.Context(), domain.ProjectID(chi.URLParam(r, "id")), chi.URLParam(r, "eventId"), time.Now().UTC())
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return

--- a/backend/internal/httpd/controllers/orchestration_events.go
+++ b/backend/internal/httpd/controllers/orchestration_events.go
@@ -1,0 +1,76 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/go-chi/chi/v5"
+)
+
+type OrchestrationEventReader interface {
+	ListOrchestrationEvents(context.Context, domain.ProjectID, int) ([]domain.OrchestrationEvent, error)
+	RetryDeadLetterOrchestrationEvent(context.Context, string, time.Time) (bool, error)
+}
+type OrchestrationEventsController struct{ Store OrchestrationEventReader }
+
+func (c *OrchestrationEventsController) Register(r chi.Router) {
+	r.Get("/projects/{id}/orchestration-events", c.list)
+	r.Post("/projects/{id}/orchestration-events/{eventId}/retry", c.retry)
+}
+func (c *OrchestrationEventsController) retry(w http.ResponseWriter, r *http.Request) {
+	if c.Store == nil {
+		apispec.NotImplemented(w, r, http.MethodPost, "/api/v1/projects/{id}/orchestration-events/{eventId}/retry")
+		return
+	}
+	changed, err := c.Store.RetryDeadLetterOrchestrationEvent(r.Context(), chi.URLParam(r, "eventId"), time.Now().UTC())
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	if !changed {
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict", "ORCHESTRATION_EVENT_NOT_DEAD_LETTER", "event is not available for explicit retry", nil)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, RetryOrchestrationEventResponse{Retried: true})
+}
+func (c *OrchestrationEventsController) list(w http.ResponseWriter, r *http.Request) {
+	if c.Store == nil {
+		apispec.NotImplemented(w, r, http.MethodGet, "/api/v1/projects/{id}/orchestration-events")
+		return
+	}
+	limit := 100
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 {
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_LIMIT", "limit must be a positive integer", nil)
+			return
+		}
+		if parsed < limit {
+			limit = parsed
+		}
+	}
+	events, err := c.Store.ListOrchestrationEvents(r.Context(), domain.ProjectID(chi.URLParam(r, "id")), limit)
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	out := make([]OrchestrationEventResponse, len(events))
+	for i, e := range events {
+		out[i] = orchestrationEventResponse(e)
+	}
+	envelope.WriteJSON(w, http.StatusOK, ListOrchestrationEventsResponse{Events: out})
+}
+func orchestrationEventResponse(e domain.OrchestrationEvent) OrchestrationEventResponse {
+	return OrchestrationEventResponse{ID: e.ID, ProjectID: e.ProjectID, WorkerID: e.WorkerID, Kind: e.Kind, SourceRevision: e.SourceRevision, State: e.State, AttemptCount: e.AttemptCount, EnqueuedAt: e.EnqueuedAt, NextAttemptAt: e.NextAttemptAt, LeaseExpiresAt: timePointer(e.LeaseExpiresAt), DestinationSessionID: e.DestinationSessionID, SubmittedAt: timePointer(e.SubmittedAt), AcknowledgedAt: timePointer(e.AcknowledgedAt), AttentionRequiredAt: timePointer(e.AttentionRequiredAt), LastError: e.LastError}
+}
+func timePointer(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	return &value
+}

--- a/backend/internal/httpd/controllers/orchestration_events_test.go
+++ b/backend/internal/httpd/controllers/orchestration_events_test.go
@@ -1,0 +1,63 @@
+package controllers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
+	"github.com/go-chi/chi/v5"
+)
+
+type orchestrationReaderFake struct {
+	project domain.ProjectID
+	limit   int
+}
+
+func (f *orchestrationReaderFake) RetryDeadLetterOrchestrationEvent(context.Context, string, time.Time) (bool, error) {
+	return true, nil
+}
+
+func (f *orchestrationReaderFake) ListOrchestrationEvents(_ context.Context, p domain.ProjectID, limit int) ([]domain.OrchestrationEvent, error) {
+	f.project = p
+	f.limit = limit
+	now := time.Now().UTC()
+	return []domain.OrchestrationEvent{{ID: "e", ProjectID: p, WorkerID: "w", Kind: domain.OrchestrationWorkerTurnSettled, SourceRevision: "r", State: domain.OrchestrationSubmitted, AttemptCount: 1, EnqueuedAt: now, NextAttemptAt: now, DestinationSessionID: "o", SubmittedAt: now}}, nil
+}
+
+func TestListOrchestrationEventsExposesDeliveryObservability(t *testing.T) {
+	f := &orchestrationReaderFake{}
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) { (&controllers.OrchestrationEventsController{Store: f}).Register(r) })
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p/orchestration-events?limit=7", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Events []controllers.OrchestrationEventResponse `json:"events"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if f.project != "p" || f.limit != 7 || len(body.Events) != 1 || body.Events[0].DestinationSessionID != "o" || body.Events[0].SubmittedAt == nil {
+		t.Fatalf("project=%q limit=%d body=%+v", f.project, f.limit, body)
+	}
+}
+
+func TestListOrchestrationEventsRejectsInvalidLimit(t *testing.T) {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		(&controllers.OrchestrationEventsController{Store: &orchestrationReaderFake{}}).Register(r)
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/projects/p/orchestration-events?limit=zero", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/httpd/controllers/orchestration_events_test.go
+++ b/backend/internal/httpd/controllers/orchestration_events_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 type orchestrationReaderFake struct {
-	project domain.ProjectID
-	limit   int
+	project      domain.ProjectID
+	limit        int
+	retryProject domain.ProjectID
 }
 
-func (f *orchestrationReaderFake) RetryDeadLetterOrchestrationEvent(context.Context, string, time.Time) (bool, error) {
+func (f *orchestrationReaderFake) RetryDeadLetterOrchestrationEvent(_ context.Context, project domain.ProjectID, _ string, _ time.Time) (bool, error) {
+	f.retryProject = project
 	return true, nil
 }
 
@@ -27,6 +29,17 @@ func (f *orchestrationReaderFake) ListOrchestrationEvents(_ context.Context, p d
 	f.limit = limit
 	now := time.Now().UTC()
 	return []domain.OrchestrationEvent{{ID: "e", ProjectID: p, WorkerID: "w", Kind: domain.OrchestrationWorkerTurnSettled, SourceRevision: "r", State: domain.OrchestrationSubmitted, AttemptCount: 1, EnqueuedAt: now, NextAttemptAt: now, DestinationSessionID: "o", SubmittedAt: now}}, nil
+}
+
+func TestRetryOrchestrationEventIsProjectScoped(t *testing.T) {
+	f := &orchestrationReaderFake{}
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) { (&controllers.OrchestrationEventsController{Store: f}).Register(r) })
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/v1/projects/p/orchestration-events/e/retry", nil))
+	if w.Code != http.StatusOK || f.retryProject != "p" {
+		t.Fatalf("status=%d project=%q body=%s", w.Code, f.retryProject, w.Body.String())
+	}
 }
 
 func TestListOrchestrationEventsExposesDeliveryObservability(t *testing.T) {

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -503,6 +503,13 @@ func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.Session
 		return err
 	}
 	if terminated {
+		if rec, ok, readErr := m.store.GetSession(ctx, id); readErr != nil {
+			return readErr
+		} else if ok {
+			if eventErr := m.recordWorkerTerminalEvent(ctx, rec); eventErr != nil {
+				return eventErr
+			}
+		}
 		// Route reaper-observed death through the same container-reap hook as
 		// every other terminal path (#2652): a crash/SIGKILL detected by the
 		// runtime reaper must not leave the session's Docker containers behind
@@ -1505,7 +1512,14 @@ func (m *Manager) recordWorkerTerminalEvent(ctx context.Context, rec domain.Sess
 	if !ok {
 		return nil
 	}
-	_, err := store.RecordOrchestrationSourceState(ctx, rec.ProjectID, rec.ID, domain.OrchestrationWorkerTerminated, "session", true, m.clock())
+	source := strings.TrimSpace(rec.Metadata.RuntimeLaunchID)
+	if source == "" {
+		source = strings.TrimSpace(rec.Metadata.ControllerGeneration)
+	}
+	if source == "" {
+		source = rec.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	_, err := store.RecordOrchestrationSourceState(ctx, rec.ProjectID, rec.ID, domain.OrchestrationWorkerTerminated, source, true, m.clock())
 	return err
 }
 

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -66,6 +66,10 @@ type activityOrchestrationStore interface {
 	CommitActivityAndOrchestrationEvent(context.Context, domain.SessionRecord, domain.OrchestrationEvent) (bool, error)
 }
 
+type orchestrationBatchAcknowledgementStore interface {
+	AcknowledgeOrchestrationBatchAccepted(context.Context, domain.SessionID, string, time.Time) (int64, error)
+}
+
 // chatSpawnStore commits the lifecycle facts and the provider boundary in one
 // transaction. A fresh provider must never become the durable session owner
 // while the conversation head still names the provider it replaced.
@@ -250,6 +254,16 @@ type Manager struct {
 	// adapter via WithUrgentNudgeGate; the default answers false, so an unknown
 	// harness never takes an urgent write while waiting_input.
 	urgentNudgeWaitingInputSafe func(domain.AgentHarness) bool
+	orchestrationWake           func(domain.ProjectID)
+}
+
+// SetOrchestrationWake connects durable event commits to the daemon dispatcher.
+// Startup recovery remains authoritative, so events committed before wiring
+// are found by the dispatcher's initial database scan.
+func (m *Manager) SetOrchestrationWake(wake func(domain.ProjectID)) {
+	m.mu.Lock()
+	m.orchestrationWake = wake
+	m.mu.Unlock()
 }
 
 // New builds a Lifecycle Manager over the session store it writes and the messenger it uses for agent nudges.
@@ -670,12 +684,14 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	}
 	next.UpdatedAt = now
 	var applied bool
+	var orchestrationProject domain.ProjectID
 	if event, emit := normalizedActivityEvent(rec, next); emit {
 		if atomicStore, ok := m.store.(activityOrchestrationStore); ok {
 			applied, err = atomicStore.CommitActivityAndOrchestrationEvent(ctx, next, event)
 		} else {
 			applied, err = m.store.UpdateSessionFromActivitySignal(ctx, next)
 		}
+		orchestrationProject = event.ProjectID
 	} else {
 		applied, err = m.store.UpdateSessionFromActivitySignal(ctx, next)
 	}
@@ -686,6 +702,16 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	if !applied {
 		m.mu.Unlock()
 		return nil
+	}
+	if s.Event == "user-prompt-submit" {
+		if token, ok := orchestrationBatchID(s.LatestUserPrompt); ok {
+			if acknowledger, supported := m.store.(orchestrationBatchAcknowledgementStore); supported {
+				if _, ackErr := acknowledger.AcknowledgeOrchestrationBatchAccepted(ctx, id, token, now); ackErr != nil {
+					m.mu.Unlock()
+					return fmt.Errorf("acknowledge orchestration batch: %w", ackErr)
+				}
+			}
+		}
 	}
 	// Transition into the needs-input family (waiting_input or blocked) pings
 	// the user; an in-family escalation (waiting_input -> blocked) does not
@@ -703,7 +729,11 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// that pinged them has nothing left to resolve.
 	resolutions := needsInputResolutions(rec, next, now)
 	waitingEvents := m.waitingInputEvents(next, prevState, prevAt, now)
+	orchestrationWake := m.orchestrationWake
 	m.mu.Unlock()
+	if orchestrationProject != "" && orchestrationWake != nil {
+		orchestrationWake(orchestrationProject)
+	}
 	if err := m.acknowledgeAgentSwitchTarget(ctx, id, s, now); err != nil {
 		return err
 	}
@@ -713,6 +743,25 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	m.emitNotification(ctx, intent)
 	m.resolveNotifications(ctx, resolutions...)
 	return nil
+}
+
+func orchestrationBatchID(prompt string) (string, bool) {
+	const prefix = "[AO AUTOMATION batch_id="
+	if !strings.HasPrefix(prompt, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(prompt, prefix)
+	end := strings.IndexByte(rest, ']')
+	if end < 1 || end > 128 {
+		return "", false
+	}
+	token := rest[:end]
+	for _, r := range token {
+		if !(r == '-' || r == '_' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z') {
+			return "", false
+		}
+	}
+	return token, true
 }
 
 func normalizedActivityEvent(previous, next domain.SessionRecord) (domain.OrchestrationEvent, bool) {

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -62,6 +62,10 @@ type controllerEpochStore interface {
 	) (bool, error)
 }
 
+type activityOrchestrationStore interface {
+	CommitActivityAndOrchestrationEvent(context.Context, domain.SessionRecord, domain.OrchestrationEvent) (bool, error)
+}
+
 // chatSpawnStore commits the lifecycle facts and the provider boundary in one
 // transaction. A fresh provider must never become the durable session owner
 // while the conversation head still names the provider it replaced.
@@ -665,7 +669,16 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		delete(m.flights, id)
 	}
 	next.UpdatedAt = now
-	applied, err := m.store.UpdateSessionFromActivitySignal(ctx, next)
+	var applied bool
+	if event, emit := normalizedActivityEvent(rec, next); emit {
+		if atomicStore, ok := m.store.(activityOrchestrationStore); ok {
+			applied, err = atomicStore.CommitActivityAndOrchestrationEvent(ctx, next, event)
+		} else {
+			applied, err = m.store.UpdateSessionFromActivitySignal(ctx, next)
+		}
+	} else {
+		applied, err = m.store.UpdateSessionFromActivitySignal(ctx, next)
+	}
 	if err != nil {
 		m.mu.Unlock()
 		return err
@@ -700,6 +713,27 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	m.emitNotification(ctx, intent)
 	m.resolveNotifications(ctx, resolutions...)
 	return nil
+}
+
+func normalizedActivityEvent(previous, next domain.SessionRecord) (domain.OrchestrationEvent, bool) {
+	if next.Kind != domain.KindWorker || next.IsTerminated || previous.Activity.State == next.Activity.State {
+		return domain.OrchestrationEvent{}, false
+	}
+	var kind domain.OrchestrationEventKind
+	switch next.Activity.State {
+	case domain.ActivityIdle:
+		kind = domain.OrchestrationWorkerTurnSettled
+	case domain.ActivityBlocked, domain.ActivityWaitingInput:
+		kind = domain.OrchestrationWorkerBlocked
+	default:
+		return domain.OrchestrationEvent{}, false
+	}
+	revision := next.Activity.LastActivityAt.UTC().Format(time.RFC3339Nano)
+	return domain.OrchestrationEvent{
+		ID: fmt.Sprintf("oe:%s:%s:%s", next.ID, kind, revision), ProjectID: next.ProjectID,
+		WorkerID: next.ID, Kind: kind, SourceRevision: revision,
+		EnqueuedAt: next.UpdatedAt.UTC(), NextAttemptAt: next.UpdatedAt.UTC(),
+	}, true
 }
 
 // stagePendingAgentSwitchNativeMetadata persists provider-assigned startup

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -761,7 +761,7 @@ func orchestrationBatchID(prompt string) (string, bool) {
 	}
 	token := rest[:end]
 	for _, r := range token {
-		if !(r == '-' || r == '_' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z') {
+		if r != '-' && r != '_' && (r < '0' || r > '9') && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
 			return "", false
 		}
 	}

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -70,6 +70,10 @@ type orchestrationBatchAcknowledgementStore interface {
 	AcknowledgeOrchestrationBatchAccepted(context.Context, domain.SessionID, string, time.Time) (int64, error)
 }
 
+type orchestrationSourceStateStore interface {
+	RecordOrchestrationSourceState(context.Context, domain.ProjectID, domain.SessionID, domain.OrchestrationEventKind, string, bool, time.Time) (bool, error)
+}
+
 // chatSpawnStore commits the lifecycle facts and the provider boundary in one
 // transaction. A fresh provider must never become the durable session owner
 // while the conversation head still names the provider it replaced.
@@ -1433,6 +1437,9 @@ func (m *Manager) MarkTerminated(ctx context.Context, id domain.SessionID) error
 			return err
 		}
 		if rec.IsTerminated {
+			if err := m.recordWorkerTerminalEvent(ctx, rec); err != nil {
+				return err
+			}
 			m.reapSessionContainers(ctx, id)
 			return nil
 		}
@@ -1474,6 +1481,9 @@ func (m *Manager) MarkTerminated(ctx context.Context, id domain.SessionID) error
 		}
 		switch outcome {
 		case terminationApplied, terminationAlreadyApplied:
+			if err := m.recordWorkerTerminalEvent(ctx, rec); err != nil {
+				return err
+			}
 			m.reapSessionContainers(ctx, id)
 			return nil
 		case terminationLaunchChanged:
@@ -1485,6 +1495,18 @@ func (m *Manager) MarkTerminated(ctx context.Context, id domain.SessionID) error
 			continue
 		}
 	}
+}
+
+func (m *Manager) recordWorkerTerminalEvent(ctx context.Context, rec domain.SessionRecord) error {
+	if rec.Kind != domain.KindWorker {
+		return nil
+	}
+	store, ok := m.store.(orchestrationSourceStateStore)
+	if !ok {
+		return nil
+	}
+	_, err := store.RecordOrchestrationSourceState(ctx, rec.ProjectID, rec.ID, domain.OrchestrationWorkerTerminated, "session", true, m.clock())
+	return err
 }
 
 // reapSessionContainers is the container leg of #2652 (the container-owning

--- a/backend/internal/lifecycle/orchestration_event_test.go
+++ b/backend/internal/lifecycle/orchestration_event_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 func TestNormalizedActivityEventNeverCallsIdleCompletion(t *testing.T) {
@@ -19,6 +20,28 @@ func TestNormalizedActivityEventNeverCallsIdleCompletion(t *testing.T) {
 	}
 	if string(event.Kind) == "task_completed" {
 		t.Fatal("idle was relabeled task_completed")
+	}
+}
+
+func TestPRReadyOrchestrationUsesCanonicalReadiness(t *testing.T) {
+	ready := ports.PRObservation{Fetched: true, URL: "pr", CI: domain.CIPassing, Review: domain.ReviewApproved, Mergeability: domain.MergeMergeable}
+	if !prObservationIsReadyToMerge(ready) {
+		t.Fatal("canonical ready observation rejected")
+	}
+	for _, mutate := range []func(*ports.PRObservation){
+		func(o *ports.PRObservation) { o.Mergeability = domain.MergeUnstable },
+		func(o *ports.PRObservation) { o.Mergeability = domain.MergeUnknown },
+		func(o *ports.PRObservation) {
+			o.Comments = []ports.PRCommentObservation{{ID: "human", Resolved: false}}
+		},
+		func(o *ports.PRObservation) { o.Closed = true },
+		func(o *ports.PRObservation) { o.Merged = true },
+	} {
+		candidate := ready
+		mutate(&candidate)
+		if prObservationIsReadyToMerge(candidate) {
+			t.Fatalf("non-ready observation accepted: %+v", candidate)
+		}
 	}
 }
 

--- a/backend/internal/lifecycle/orchestration_event_test.go
+++ b/backend/internal/lifecycle/orchestration_event_test.go
@@ -1,0 +1,47 @@
+package lifecycle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestNormalizedActivityEventNeverCallsIdleCompletion(t *testing.T) {
+	now := time.Now().UTC()
+	previous := domain.SessionRecord{ID: "w", ProjectID: "p", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive}}
+	next := previous
+	next.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}
+	next.UpdatedAt = now
+	event, ok := normalizedActivityEvent(previous, next)
+	if !ok || event.Kind != domain.OrchestrationWorkerTurnSettled {
+		t.Fatalf("event=(%+v,%v), want worker_turn_settled", event, ok)
+	}
+	if string(event.Kind) == "task_completed" {
+		t.Fatal("idle was relabeled task_completed")
+	}
+}
+
+func TestNormalizedActivityEventDedupesRepeatsAndRearmsTransitions(t *testing.T) {
+	now := time.Now().UTC()
+	idle := domain.SessionRecord{ID: "w", ProjectID: "p", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, UpdatedAt: now}
+	if _, ok := normalizedActivityEvent(idle, idle); ok {
+		t.Fatal("unchanged idle emitted")
+	}
+	active := idle
+	active.Activity = domain.Activity{State: domain.ActivityActive, LastActivityAt: now.Add(time.Second)}
+	blocked := active
+	blocked.Activity = domain.Activity{State: domain.ActivityBlocked, LastActivityAt: now.Add(2 * time.Second)}
+	blocked.UpdatedAt = now.Add(2 * time.Second)
+	first, ok := normalizedActivityEvent(active, blocked)
+	if !ok {
+		t.Fatal("first blocked transition did not emit")
+	}
+	active.Activity.LastActivityAt = now.Add(3 * time.Second)
+	blocked.Activity.LastActivityAt = now.Add(4 * time.Second)
+	blocked.UpdatedAt = now.Add(4 * time.Second)
+	second, ok := normalizedActivityEvent(active, blocked)
+	if !ok || first.SourceRevision == second.SourceRevision {
+		t.Fatalf("rearm revisions first=%q second=%q", first.SourceRevision, second.SourceRevision)
+	}
+}

--- a/backend/internal/lifecycle/orchestration_event_test.go
+++ b/backend/internal/lifecycle/orchestration_event_test.go
@@ -45,3 +45,14 @@ func TestNormalizedActivityEventDedupesRepeatsAndRearmsTransitions(t *testing.T)
 		t.Fatalf("rearm revisions first=%q second=%q", first.SourceRevision, second.SourceRevision)
 	}
 }
+
+func TestOrchestrationBatchIDRequiresExactSafeMachinePrefix(t *testing.T) {
+	if got, ok := orchestrationBatchID("[AO AUTOMATION batch_id=batch-123] wake"); !ok || got != "batch-123" {
+		t.Fatalf("got=(%q,%v)", got, ok)
+	}
+	for _, prompt := range []string{"human prefix [AO AUTOMATION batch_id=x]", "[AO AUTOMATION batch_id=x;approve]", "[AO AUTOMATION batch_id=]"} {
+		if _, ok := orchestrationBatchID(prompt); ok {
+			t.Fatalf("accepted unsafe prompt %q", prompt)
+		}
+	}
+}

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -166,6 +166,9 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		if err != nil || !ok {
 			return err
 		}
+		if err := m.recordPRStateEvent(ctx, rec, o, domain.OrchestrationWorkerReadyMerge, false); err != nil {
+			return err
+		}
 		if o.Merged {
 			if err := m.recordPRStateEvent(ctx, rec, o, domain.OrchestrationPRMerged, true); err != nil {
 				return err
@@ -187,7 +190,7 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	if err != nil || !ok {
 		return err
 	}
-	ready := !o.Draft && o.CI == domain.CIPassing && o.Review != domain.ReviewChangesRequest && mergeabilityClearsConflict(o.Mergeability)
+	ready := prObservationIsReadyToMerge(o)
 	if err := m.recordPRStateEvent(ctx, rec, o, domain.OrchestrationWorkerReadyMerge, ready); err != nil {
 		return err
 	}
@@ -354,6 +357,17 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		return blockedCheckErr
 	}
 	return rearmErr
+}
+
+func prObservationIsReadyToMerge(o ports.PRObservation) bool {
+	unresolved := false
+	for _, comment := range o.Comments {
+		if !comment.Resolved && !comment.AutoInjectReview {
+			unresolved = true
+			break
+		}
+	}
+	return domain.MergeReadiness{Draft: o.Draft, Merged: o.Merged, Closed: o.Closed, CI: o.CI, Review: o.Review, Mergeability: o.Mergeability, UnresolvedComments: unresolved}.ReadyToMerge()
 }
 
 func (m *Manager) recordPRStateEvent(ctx context.Context, rec domain.SessionRecord, o ports.PRObservation, kind domain.OrchestrationEventKind, active bool) error {

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -166,6 +166,11 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		if err != nil || !ok {
 			return err
 		}
+		if o.Merged {
+			if err := m.recordPRStateEvent(ctx, rec, o, domain.OrchestrationPRMerged, true); err != nil {
+				return err
+			}
+		}
 		if rec.IsTerminated || !rec.TerminateOnPRMerge {
 			return nil
 		}
@@ -180,6 +185,10 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	}
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil || !ok {
+		return err
+	}
+	ready := !o.Draft && o.CI == domain.CIPassing && o.Review != domain.ReviewChangesRequest && mergeabilityClearsConflict(o.Mergeability)
+	if err := m.recordPRStateEvent(ctx, rec, o, domain.OrchestrationWorkerReadyMerge, ready); err != nil {
 		return err
 	}
 	// Re-arm the merge-conflict dedup on a definitively-cleared observation
@@ -345,6 +354,18 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		return blockedCheckErr
 	}
 	return rearmErr
+}
+
+func (m *Manager) recordPRStateEvent(ctx context.Context, rec domain.SessionRecord, o ports.PRObservation, kind domain.OrchestrationEventKind, active bool) error {
+	if rec.Kind != domain.KindWorker {
+		return nil
+	}
+	store, ok := m.store.(orchestrationSourceStateStore)
+	if !ok {
+		return nil
+	}
+	_, err := store.RecordOrchestrationSourceState(ctx, rec.ProjectID, rec.ID, kind, o.URL, active, m.clock())
+	return err
 }
 
 func (m *Manager) terminateCompletedSession(ctx context.Context, id domain.SessionID) error {

--- a/backend/internal/notify/enrich.go
+++ b/backend/internal/notify/enrich.go
@@ -19,7 +19,7 @@ func enrich(intent Intent) (domain.NotificationRecord, error) {
 	if !intent.Type.Valid() {
 		return domain.NotificationRecord{}, domain.ErrInvalidNotificationType
 	}
-	if intent.Type != domain.NotificationNeedsInput && rec.PRURL == "" {
+	if intent.Type != domain.NotificationNeedsInput && intent.Type != domain.NotificationOrchestrationAttention && rec.PRURL == "" {
 		return domain.NotificationRecord{}, domain.ErrInvalidNotificationRecord
 	}
 	rec.Title = titleForIntent(intent)
@@ -46,6 +46,8 @@ func titleForIntent(intent Intent) string {
 		return fmt.Sprintf("%s merged", prLabel(intent))
 	case domain.NotificationPRClosedUnmerged:
 		return fmt.Sprintf("%s closed", prLabel(intent))
+	case domain.NotificationOrchestrationAttention:
+		return "Orchestration delivery needs attention"
 	default:
 		return "Notification"
 	}
@@ -74,6 +76,8 @@ func bodyForIntent(intent Intent) string {
 			return fmt.Sprintf("%s was closed without merging. Reopen it if this wasn't intended.", title)
 		}
 		return "Closed without merging. Reopen it if this wasn't intended."
+	case domain.NotificationOrchestrationAttention:
+		return "AO could not safely deliver a pending orchestration event. Inspect the project orchestration event API and retry explicitly after correcting the destination."
 	default:
 		return ""
 	}

--- a/backend/internal/orchestrationevents/dispatcher.go
+++ b/backend/internal/orchestrationevents/dispatcher.go
@@ -1,0 +1,158 @@
+// Package orchestrationevents turns durable, normalized AO facts into bounded
+// orchestrator reconciliation turns. It does not consume UI event streams.
+package orchestrationevents
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+const (
+	MaxBatchEvents  = 50
+	MaxPayloadBytes = 32 * 1024
+	AttemptTimeout  = 5 * time.Second
+	LeaseDuration   = 30 * time.Second
+)
+
+type Store interface {
+	ListSessions(context.Context, domain.ProjectID) ([]domain.SessionRecord, error)
+	ListDueOrchestrationEvents(context.Context, domain.ProjectID, time.Time, int) ([]domain.OrchestrationEvent, error)
+	LeaseOrchestrationEvents(context.Context, []string, string, domain.SessionID, time.Time) error
+	MarkOrchestrationEventsSubmitted(context.Context, []string, string, time.Time) error
+	AcknowledgeOrchestrationEvents(context.Context, []string, string, time.Time) error
+	RetryOrchestrationEvents(context.Context, []domain.OrchestrationEvent, string, string, time.Time) error
+}
+
+// Transport must return Acknowledged only after the target controller accepts
+// the exact BatchID. Chat implementations use BatchID as ClientMessageID. TUI
+// implementations acknowledge from the matching prompt-submit lifecycle hook.
+type Transport interface {
+	Submit(context.Context, domain.SessionRecord, Batch) (Submission, error)
+}
+
+type Batch struct {
+	ID, Payload string
+	EventIDs    []string
+}
+type Submission struct{ Submitted, Acknowledged bool }
+
+type Dispatcher struct {
+	Store     Store
+	Transport Transport
+	Now       func() time.Time
+	NewID     func() string
+}
+
+func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.ProjectID) error {
+	now := time.Now().UTC()
+	if d.Now != nil {
+		now = d.Now()
+	}
+	target, ok, err := d.destination(ctx, project)
+	if err != nil || !ok {
+		return err
+	}
+	events, err := d.Store.ListDueOrchestrationEvents(ctx, project, now, MaxBatchEvents)
+	if err != nil || len(events) == 0 {
+		return err
+	}
+	payload, events := Prompt(events)
+	batchID := randomID()
+	if d.NewID != nil {
+		batchID = d.NewID()
+	}
+	ids := eventIDs(events)
+	if err := d.Store.LeaseOrchestrationEvents(ctx, ids, batchID, target.ID, now.Add(LeaseDuration)); err != nil {
+		return err
+	}
+	attemptCtx, cancel := context.WithTimeout(ctx, AttemptTimeout)
+	defer cancel()
+	result, submitErr := d.Transport.Submit(attemptCtx, target, Batch{ID: batchID, Payload: payload, EventIDs: ids})
+	if result.Submitted {
+		if err := d.Store.MarkOrchestrationEventsSubmitted(ctx, ids, batchID, now); err != nil {
+			return err
+		}
+	}
+	if submitErr != nil {
+		return d.Store.RetryOrchestrationEvents(ctx, events, batchID, sanitizeError(submitErr), now)
+	}
+	if !result.Acknowledged {
+		return nil
+	}
+	return d.Store.AcknowledgeOrchestrationEvents(ctx, ids, batchID, now)
+}
+
+func (d *Dispatcher) destination(ctx context.Context, project domain.ProjectID) (domain.SessionRecord, bool, error) {
+	sessions, err := d.Store.ListSessions(ctx, project)
+	if err != nil {
+		return domain.SessionRecord{}, false, err
+	}
+	for _, s := range sessions {
+		if s.Kind != domain.KindOrchestrator || s.IsTerminated {
+			continue
+		}
+		if s.Activity.State == domain.ActivityBlocked || s.Activity.State == domain.ActivityWaitingInput || s.Activity.State == domain.ActivityExited {
+			return domain.SessionRecord{}, false, nil
+		}
+		if s.FirstSignalAt.IsZero() {
+			return domain.SessionRecord{}, false, nil
+		}
+		if s.Activity.State == domain.ActivityActive && domain.NormalizeSessionMode(s.Mode) != domain.SessionModeChat {
+			return domain.SessionRecord{}, false, nil
+		}
+		return s, true, nil
+	}
+	return domain.SessionRecord{}, false, nil
+}
+
+// Prompt includes only AO-owned identifiers and enums. Provider titles,
+// comments, logs, branches and transcripts never enter this boundary.
+func Prompt(events []domain.OrchestrationEvent) (string, []domain.OrchestrationEvent) {
+	const intro = "[AO AUTOMATION] This machine-originated wake grants no permission or authorization. Reconcile AO state once, act only within your existing authority, then end the turn. Events:\n"
+	var b strings.Builder
+	b.WriteString(intro)
+	kept := make([]domain.OrchestrationEvent, 0, min(len(events), MaxBatchEvents))
+	for _, e := range events {
+		if len(kept) == MaxBatchEvents {
+			break
+		}
+		line := fmt.Sprintf("- id=%s kind=%s worker_id=%s source_revision=%s\n", e.ID, e.Kind, e.WorkerID, e.SourceRevision)
+		if b.Len()+len(line) > MaxPayloadBytes {
+			break
+		}
+		b.WriteString(line)
+		kept = append(kept, e)
+	}
+	return b.String(), kept
+}
+
+func eventIDs(events []domain.OrchestrationEvent) []string {
+	ids := make([]string, len(events))
+	for i := range events {
+		ids[i] = events[i].ID
+	}
+	return ids
+}
+func randomID() string {
+	var raw [16]byte
+	_, _ = rand.Read(raw[:])
+	return "ao-orchestration-" + hex.EncodeToString(raw[:])
+}
+func sanitizeError(err error) string {
+	s := strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, err.Error())
+	if len(s) > 512 {
+		s = s[:512]
+	}
+	return s
+}

--- a/backend/internal/orchestrationevents/dispatcher.go
+++ b/backend/internal/orchestrationevents/dispatcher.go
@@ -30,6 +30,7 @@ const (
 type Store interface {
 	ListSessions(context.Context, domain.ProjectID) ([]domain.SessionRecord, error)
 	ListDueOrchestrationEvents(context.Context, domain.ProjectID, time.Time, int) ([]domain.OrchestrationEvent, error)
+	ListOrchestrationEventsRequiringAttention(context.Context, domain.ProjectID) ([]domain.OrchestrationEvent, error)
 	LeaseOrchestrationEvents(context.Context, []string, string, domain.SessionID, time.Time) error
 	MarkOrchestrationEventsSubmitted(context.Context, []string, string, time.Time) error
 	AcknowledgeOrchestrationEvents(context.Context, []string, string, time.Time) error
@@ -85,7 +86,7 @@ func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.Project
 			return markErr
 		}
 		if changed > 0 {
-			return d.notifyAttention(ctx, events[0], now)
+			return d.notifyAttentionForEvents(ctx, events, now)
 		}
 		return nil
 	}
@@ -111,7 +112,7 @@ func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.Project
 			return err
 		}
 		if events[0].AttemptCount+1 >= 8 || now.Sub(events[0].EnqueuedAt) >= 15*time.Minute {
-			return d.notifyAttention(ctx, events[0], now)
+			return d.notifyAttentionForEvents(ctx, events, now)
 		}
 		return nil
 	}
@@ -120,6 +121,32 @@ func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.Project
 		return nil
 	}
 	return d.Store.AcknowledgeOrchestrationEvents(ctx, ids, batchID, now)
+}
+
+// ReconcileAttention recreates the human-visible side of every durable
+// attention marker. Notification insertion is deduplicated, so this closes a
+// daemon crash or publisher failure between the outbox state transition and
+// notification delivery without creating an alert storm.
+func (d *Dispatcher) ReconcileAttention(ctx context.Context, project domain.ProjectID, now time.Time) error {
+	events, err := d.Store.ListOrchestrationEventsRequiringAttention(ctx, project)
+	if err != nil {
+		return err
+	}
+	return d.notifyAttentionForEvents(ctx, events, now)
+}
+
+func (d *Dispatcher) notifyAttentionForEvents(ctx context.Context, events []domain.OrchestrationEvent, now time.Time) error {
+	seen := map[domain.SessionID]bool{}
+	for _, event := range events {
+		if seen[event.WorkerID] {
+			continue
+		}
+		seen[event.WorkerID] = true
+		if err := d.notifyAttention(ctx, event, now); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (d *Dispatcher) notifyAttention(ctx context.Context, event domain.OrchestrationEvent, now time.Time) error {

--- a/backend/internal/orchestrationevents/dispatcher.go
+++ b/backend/internal/orchestrationevents/dispatcher.go
@@ -14,12 +14,17 @@ import (
 )
 
 const (
-	MaxBatchEvents  = 50
+	// MaxBatchEvents bounds the event count in one reconciliation turn.
+	MaxBatchEvents = 50
+	// MaxPayloadBytes bounds the encoded prompt in one reconciliation turn.
 	MaxPayloadBytes = 32 * 1024
-	AttemptTimeout  = 5 * time.Second
-	LeaseDuration   = 30 * time.Second
+	// AttemptTimeout bounds one transport submission.
+	AttemptTimeout = 5 * time.Second
+	// LeaseDuration bounds ambiguous submission recovery.
+	LeaseDuration = 30 * time.Second
 )
 
+// Store is the durable outbox surface required by Dispatcher.
 type Store interface {
 	ListSessions(context.Context, domain.ProjectID) ([]domain.SessionRecord, error)
 	ListDueOrchestrationEvents(context.Context, domain.ProjectID, time.Time, int) ([]domain.OrchestrationEvent, error)
@@ -37,12 +42,16 @@ type Transport interface {
 	Submit(context.Context, domain.SessionRecord, Batch) (Submission, error)
 }
 
+// Batch is one bounded, stable-id reconciliation request.
 type Batch struct {
 	ID, Payload string
 	EventIDs    []string
 }
+
+// Submission distinguishes a transport write from exact turn admission.
 type Submission struct{ Submitted, Acknowledged bool }
 
+// Dispatcher leases and submits due events for one project.
 type Dispatcher struct {
 	Store     Store
 	Transport Transport
@@ -50,6 +59,7 @@ type Dispatcher struct {
 	NewID     func() string
 }
 
+// DispatchProject performs at most one bounded delivery attempt.
 func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.ProjectID) error {
 	now := time.Now().UTC()
 	if d.Now != nil {

--- a/backend/internal/orchestrationevents/dispatcher.go
+++ b/backend/internal/orchestrationevents/dispatcher.go
@@ -27,6 +27,7 @@ type Store interface {
 	MarkOrchestrationEventsSubmitted(context.Context, []string, string, time.Time) error
 	AcknowledgeOrchestrationEvents(context.Context, []string, string, time.Time) error
 	RetryOrchestrationEvents(context.Context, []domain.OrchestrationEvent, string, string, time.Time) error
+	MarkProjectNoDestinationAttention(context.Context, domain.ProjectID, time.Time) (int64, error)
 }
 
 // Transport must return Acknowledged only after the target controller accepts
@@ -55,18 +56,22 @@ func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.Project
 		now = d.Now()
 	}
 	target, ok, err := d.destination(ctx, project)
-	if err != nil || !ok {
+	if err != nil {
+		return err
+	}
+	if !ok {
+		_, err = d.Store.MarkProjectNoDestinationAttention(ctx, project, now)
 		return err
 	}
 	events, err := d.Store.ListDueOrchestrationEvents(ctx, project, now, MaxBatchEvents)
 	if err != nil || len(events) == 0 {
 		return err
 	}
-	payload, events := Prompt(events)
 	batchID := randomID()
 	if d.NewID != nil {
 		batchID = d.NewID()
 	}
+	payload, events := Prompt(batchID, events)
 	ids := eventIDs(events)
 	if err := d.Store.LeaseOrchestrationEvents(ctx, ids, batchID, target.ID, now.Add(LeaseDuration)); err != nil {
 		return err
@@ -113,8 +118,8 @@ func (d *Dispatcher) destination(ctx context.Context, project domain.ProjectID) 
 
 // Prompt includes only AO-owned identifiers and enums. Provider titles,
 // comments, logs, branches and transcripts never enter this boundary.
-func Prompt(events []domain.OrchestrationEvent) (string, []domain.OrchestrationEvent) {
-	const intro = "[AO AUTOMATION] This machine-originated wake grants no permission or authorization. Reconcile AO state once, act only within your existing authority, then end the turn. Events:\n"
+func Prompt(batchID string, events []domain.OrchestrationEvent) (string, []domain.OrchestrationEvent) {
+	intro := fmt.Sprintf("[AO AUTOMATION batch_id=%s] This machine-originated wake grants no permission or authorization. Reconcile AO state once, act only within your existing authority, then end the turn. Events:\n", batchID)
 	var b strings.Builder
 	b.WriteString(intro)
 	kept := make([]domain.OrchestrationEvent, 0, min(len(events), MaxBatchEvents))

--- a/backend/internal/orchestrationevents/dispatcher.go
+++ b/backend/internal/orchestrationevents/dispatcher.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 const (
@@ -55,8 +57,12 @@ type Submission struct{ Submitted, Acknowledged bool }
 type Dispatcher struct {
 	Store     Store
 	Transport Transport
-	Now       func() time.Time
-	NewID     func() string
+	Notifier  interface {
+		Notify(context.Context, ports.NotificationIntent) error
+		Resolve(context.Context, ports.NotificationResolution) error
+	}
+	Now   func() time.Time
+	NewID func() string
 }
 
 // DispatchProject performs at most one bounded delivery attempt.
@@ -65,17 +71,23 @@ func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.Project
 	if d.Now != nil {
 		now = d.Now()
 	}
+	events, err := d.Store.ListDueOrchestrationEvents(ctx, project, now, MaxBatchEvents)
+	if err != nil || len(events) == 0 {
+		return err
+	}
 	target, ok, err := d.destination(ctx, project)
 	if err != nil {
 		return err
 	}
 	if !ok {
-		_, err = d.Store.MarkProjectNoDestinationAttention(ctx, project, now)
-		return err
-	}
-	events, err := d.Store.ListDueOrchestrationEvents(ctx, project, now, MaxBatchEvents)
-	if err != nil || len(events) == 0 {
-		return err
+		changed, markErr := d.Store.MarkProjectNoDestinationAttention(ctx, project, now)
+		if markErr != nil {
+			return markErr
+		}
+		if changed > 0 {
+			return d.notifyAttention(ctx, events[0], now)
+		}
+		return nil
 	}
 	batchID := randomID()
 	if d.NewID != nil {
@@ -95,12 +107,40 @@ func (d *Dispatcher) DispatchProject(ctx context.Context, project domain.Project
 		}
 	}
 	if submitErr != nil {
-		return d.Store.RetryOrchestrationEvents(ctx, events, batchID, sanitizeError(submitErr), now)
+		if err := d.Store.RetryOrchestrationEvents(ctx, events, batchID, sanitizeError(submitErr), now); err != nil {
+			return err
+		}
+		if events[0].AttemptCount+1 >= 8 || now.Sub(events[0].EnqueuedAt) >= 15*time.Minute {
+			return d.notifyAttention(ctx, events[0], now)
+		}
+		return nil
 	}
+	d.resolveAttention(ctx, events, now)
 	if !result.Acknowledged {
 		return nil
 	}
 	return d.Store.AcknowledgeOrchestrationEvents(ctx, ids, batchID, now)
+}
+
+func (d *Dispatcher) notifyAttention(ctx context.Context, event domain.OrchestrationEvent, now time.Time) error {
+	if d.Notifier == nil {
+		return nil
+	}
+	return d.Notifier.Notify(ctx, ports.NotificationIntent{Type: domain.NotificationOrchestrationAttention, SessionID: event.WorkerID, ProjectID: event.ProjectID, CreatedAt: now})
+}
+
+func (d *Dispatcher) resolveAttention(ctx context.Context, events []domain.OrchestrationEvent, now time.Time) {
+	if d.Notifier == nil {
+		return
+	}
+	seen := map[domain.SessionID]bool{}
+	for _, event := range events {
+		if seen[event.WorkerID] {
+			continue
+		}
+		seen[event.WorkerID] = true
+		_ = d.Notifier.Resolve(ctx, ports.NotificationResolution{Type: domain.NotificationOrchestrationAttention, SessionID: event.WorkerID, ResolvedAt: now})
+	}
 }
 
 func (d *Dispatcher) destination(ctx context.Context, project domain.ProjectID) (domain.SessionRecord, bool, error) {
@@ -160,14 +200,14 @@ func randomID() string {
 	return "ao-orchestration-" + hex.EncodeToString(raw[:])
 }
 func sanitizeError(err error) string {
-	s := strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return -1
-		}
-		return r
-	}, err.Error())
-	if len(s) > 512 {
-		s = s[:512]
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.DeadlineExceeded):
+		return "transport_timeout"
+	case errors.Is(err, context.Canceled):
+		return "transport_cancelled"
+	default:
+		return "transport_error"
 	}
-	return s
 }

--- a/backend/internal/orchestrationevents/dispatcher_test.go
+++ b/backend/internal/orchestrationevents/dispatcher_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 type fakeStore struct {
@@ -16,6 +17,7 @@ type fakeStore struct {
 	leased, submitted, acked, retried []string
 	destination                       domain.SessionID
 	leaseErr, submitErr, ackErr       error
+	attentionChanged                  int64
 }
 
 func (f *fakeStore) ListSessions(context.Context, domain.ProjectID) ([]domain.SessionRecord, error) {
@@ -93,7 +95,40 @@ func (f *fakeStore) RetryOrchestrationEvents(_ context.Context, e []domain.Orche
 	return nil
 }
 func (f *fakeStore) MarkProjectNoDestinationAttention(context.Context, domain.ProjectID, time.Time) (int64, error) {
-	return 0, nil
+	return f.attentionChanged, nil
+}
+
+type fakeNotifier struct{ created, resolved []domain.SessionID }
+
+func (f *fakeNotifier) Notify(_ context.Context, intent ports.NotificationIntent) error {
+	f.created = append(f.created, intent.SessionID)
+	return nil
+}
+func (f *fakeNotifier) Resolve(_ context.Context, resolution ports.NotificationResolution) error {
+	f.resolved = append(f.resolved, resolution.SessionID)
+	return nil
+}
+
+func TestAttentionNotificationIsCreatedOnceAndResolvedByDelivery(t *testing.T) {
+	now := time.Now()
+	event := domain.OrchestrationEvent{ID: "e", ProjectID: "p", WorkerID: "w", Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "r", EnqueuedAt: now.Add(-16 * time.Minute)}
+	notifier := &fakeNotifier{}
+	missing := &fakeStore{events: []domain.OrchestrationEvent{event}, attentionChanged: 1}
+	if err := (&Dispatcher{Store: missing, Transport: &fakeTransport{}, Notifier: notifier, Now: func() time.Time { return now }}).DispatchProject(context.Background(), "p"); err != nil {
+		t.Fatal(err)
+	}
+	missing.attentionChanged = 0
+	_ = (&Dispatcher{Store: missing, Transport: &fakeTransport{}, Notifier: notifier, Now: func() time.Time { return now }}).DispatchProject(context.Background(), "p")
+	if len(notifier.created) != 1 {
+		t.Fatalf("created=%v", notifier.created)
+	}
+	deliverable := &fakeStore{events: []domain.OrchestrationEvent{event}, sessions: []domain.SessionRecord{{ID: "o", Kind: domain.KindOrchestrator, Mode: domain.SessionModeChat, Activity: domain.Activity{State: domain.ActivityIdle}, FirstSignalAt: now}}}
+	if err := (&Dispatcher{Store: deliverable, Transport: &fakeTransport{result: Submission{Submitted: true, Acknowledged: true}}, Notifier: notifier}).DispatchProject(context.Background(), "p"); err != nil {
+		t.Fatal(err)
+	}
+	if len(notifier.resolved) != 1 || notifier.resolved[0] != "w" {
+		t.Fatalf("resolved=%v", notifier.resolved)
+	}
 }
 
 type fakeTransport struct {
@@ -178,6 +213,17 @@ func TestTransportFailureRetriesAndSanitizesError(t *testing.T) {
 	}
 	if len(s.retried) != 1 {
 		t.Fatalf("retried=%v", s.retried)
+	}
+}
+
+func TestTransportErrorsPersistOnlyTypedCredentialSafeClass(t *testing.T) {
+	for _, raw := range []string{"Bearer ghp_abcdefghijklmnopqrstuvwxyz", "https://user:pass@example.test/?token=secret", "api_key=sk-live-secret\n\x1b[31m"} {
+		if got := sanitizeError(errors.New(raw)); got != "transport_error" {
+			t.Fatalf("sanitizeError(%q)=%q", raw, got)
+		}
+	}
+	if got := sanitizeError(context.DeadlineExceeded); got != "transport_timeout" {
+		t.Fatalf("deadline class=%q", got)
 	}
 }
 

--- a/backend/internal/orchestrationevents/dispatcher_test.go
+++ b/backend/internal/orchestrationevents/dispatcher_test.go
@@ -1,0 +1,144 @@
+package orchestrationevents
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type fakeStore struct {
+	sessions                          []domain.SessionRecord
+	events                            []domain.OrchestrationEvent
+	leased, submitted, acked, retried []string
+	destination                       domain.SessionID
+}
+
+func (f *fakeStore) ListSessions(context.Context, domain.ProjectID) ([]domain.SessionRecord, error) {
+	return f.sessions, nil
+}
+func (f *fakeStore) ListDueOrchestrationEvents(context.Context, domain.ProjectID, time.Time, int) ([]domain.OrchestrationEvent, error) {
+	return f.events, nil
+}
+func (f *fakeStore) LeaseOrchestrationEvents(_ context.Context, ids []string, _ string, d domain.SessionID, _ time.Time) error {
+	f.leased = ids
+	f.destination = d
+	return nil
+}
+func (f *fakeStore) MarkOrchestrationEventsSubmitted(_ context.Context, ids []string, _ string, _ time.Time) error {
+	f.submitted = ids
+	return nil
+}
+func (f *fakeStore) AcknowledgeOrchestrationEvents(_ context.Context, ids []string, _ string, _ time.Time) error {
+	f.acked = ids
+	return nil
+}
+func (f *fakeStore) RetryOrchestrationEvents(_ context.Context, e []domain.OrchestrationEvent, _, _ string, _ time.Time) error {
+	f.retried = eventIDs(e)
+	return nil
+}
+
+type fakeTransport struct {
+	calls  int
+	target domain.SessionID
+	batch  Batch
+	result Submission
+	err    error
+}
+
+func (f *fakeTransport) Submit(_ context.Context, s domain.SessionRecord, b Batch) (Submission, error) {
+	f.calls++
+	f.target = s.ID
+	f.batch = b
+	return f.result, f.err
+}
+
+func TestDispatchResolvesCurrentDestinationAndAcknowledgesAcceptedBatch(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{sessions: []domain.SessionRecord{
+		{ID: "old", ProjectID: "p", Kind: domain.KindOrchestrator, IsTerminated: true},
+		{ID: "current", ProjectID: "p", Kind: domain.KindOrchestrator, Mode: domain.SessionModeChat, Activity: domain.Activity{State: domain.ActivityIdle}, FirstSignalAt: now},
+	}, events: []domain.OrchestrationEvent{{ID: "e1", ProjectID: "p", WorkerID: "w", Kind: domain.OrchestrationWorkerTurnSettled, SourceRevision: "r1", EnqueuedAt: now}}}
+	transport := &fakeTransport{result: Submission{Submitted: true, Acknowledged: true}}
+	d := Dispatcher{Store: store, Transport: transport, Now: func() time.Time { return now }, NewID: func() string { return "batch-1" }}
+	if err := d.DispatchProject(context.Background(), "p"); err != nil {
+		t.Fatal(err)
+	}
+	if transport.target != "current" || store.destination != "current" {
+		t.Fatalf("destination transport=%q lease=%q", transport.target, store.destination)
+	}
+	if len(store.acked) != 1 || store.acked[0] != "e1" {
+		t.Fatalf("acked=%v", store.acked)
+	}
+	if !strings.Contains(transport.batch.Payload, "worker_turn_settled") || strings.Contains(transport.batch.Payload, "completed") {
+		t.Fatalf("payload=%q", transport.batch.Payload)
+	}
+}
+
+func TestUnsafeOrMissingDestinationPerformsNoWrite(t *testing.T) {
+	states := []domain.ActivityState{domain.ActivityBlocked, domain.ActivityWaitingInput, domain.ActivityExited}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			now := time.Now()
+			store := &fakeStore{sessions: []domain.SessionRecord{{ID: "o", ProjectID: "p", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: state}, FirstSignalAt: now}}, events: []domain.OrchestrationEvent{{ID: "e"}}}
+			transport := &fakeTransport{}
+			if err := (&Dispatcher{Store: store, Transport: transport}).DispatchProject(context.Background(), "p"); err != nil {
+				t.Fatal(err)
+			}
+			if transport.calls != 0 || len(store.leased) != 0 {
+				t.Fatalf("unsafe state wrote: calls=%d leased=%v", transport.calls, store.leased)
+			}
+		})
+	}
+}
+
+func TestBusyTUIDefersWhileBusyChatQueues(t *testing.T) {
+	now := time.Now()
+	event := domain.OrchestrationEvent{ID: "e", ProjectID: "p", WorkerID: "w", Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "r", EnqueuedAt: now}
+	for _, tc := range []struct {
+		name string
+		mode domain.SessionMode
+		want int
+	}{{"tui", domain.SessionModeTUI, 0}, {"chat", domain.SessionModeChat, 1}} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &fakeStore{sessions: []domain.SessionRecord{{ID: "o", ProjectID: "p", Kind: domain.KindOrchestrator, Mode: tc.mode, Activity: domain.Activity{State: domain.ActivityActive}, FirstSignalAt: now}}, events: []domain.OrchestrationEvent{event}}
+			tr := &fakeTransport{result: Submission{Submitted: true, Acknowledged: true}}
+			_ = (&Dispatcher{Store: s, Transport: tr}).DispatchProject(context.Background(), "p")
+			if tr.calls != tc.want {
+				t.Fatalf("calls=%d want %d", tr.calls, tc.want)
+			}
+		})
+	}
+}
+
+func TestTransportFailureRetriesAndSanitizesError(t *testing.T) {
+	now := time.Now()
+	s := &fakeStore{sessions: []domain.SessionRecord{{ID: "o", ProjectID: "p", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle}, FirstSignalAt: now}}, events: []domain.OrchestrationEvent{{ID: "e", ProjectID: "p", WorkerID: "w", Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "r", EnqueuedAt: now}}}
+	tr := &fakeTransport{result: Submission{Submitted: true}, err: errors.New("bad\x1b[31m\nsecret")}
+	if err := (&Dispatcher{Store: s, Transport: tr}).DispatchProject(context.Background(), "p"); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.retried) != 1 {
+		t.Fatalf("retried=%v", s.retried)
+	}
+}
+
+func TestPromptIsBoundedAndExcludesUntrustedProviderText(t *testing.T) {
+	events := make([]domain.OrchestrationEvent, 80)
+	for i := range events {
+		events[i] = domain.OrchestrationEvent{ID: strings.Repeat("x", 900), WorkerID: "w", Kind: domain.OrchestrationWorkerReadyMerge, SourceRevision: "r"}
+	}
+	payload, kept := Prompt(events)
+	if len(kept) > MaxBatchEvents || len(payload) > MaxPayloadBytes {
+		t.Fatalf("events=%d bytes=%d", len(kept), len(payload))
+	}
+	if strings.Contains(payload, "ignore previous instructions") {
+		t.Fatal("untrusted prose entered payload")
+	}
+	if !strings.Contains(payload, "grants no permission or authorization") {
+		t.Fatal("authorization warning absent")
+	}
+}

--- a/backend/internal/orchestrationevents/dispatcher_test.go
+++ b/backend/internal/orchestrationevents/dispatcher_test.go
@@ -14,6 +14,7 @@ import (
 type fakeStore struct {
 	sessions                          []domain.SessionRecord
 	events                            []domain.OrchestrationEvent
+	attentionEvents                   []domain.OrchestrationEvent
 	leased, submitted, acked, retried []string
 	destination                       domain.SessionID
 	leaseErr, submitErr, ackErr       error
@@ -25,6 +26,9 @@ func (f *fakeStore) ListSessions(context.Context, domain.ProjectID) ([]domain.Se
 }
 func (f *fakeStore) ListDueOrchestrationEvents(context.Context, domain.ProjectID, time.Time, int) ([]domain.OrchestrationEvent, error) {
 	return f.events, nil
+}
+func (f *fakeStore) ListOrchestrationEventsRequiringAttention(context.Context, domain.ProjectID) ([]domain.OrchestrationEvent, error) {
+	return f.attentionEvents, nil
 }
 func (f *fakeStore) LeaseOrchestrationEvents(_ context.Context, ids []string, _ string, d domain.SessionID, _ time.Time) error {
 	if f.leaseErr != nil {
@@ -98,11 +102,41 @@ func (f *fakeStore) MarkProjectNoDestinationAttention(context.Context, domain.Pr
 	return f.attentionChanged, nil
 }
 
-type fakeNotifier struct{ created, resolved []domain.SessionID }
+type fakeNotifier struct {
+	created, resolved []domain.SessionID
+	err               error
+}
 
 func (f *fakeNotifier) Notify(_ context.Context, intent ports.NotificationIntent) error {
+	if f.err != nil {
+		return f.err
+	}
 	f.created = append(f.created, intent.SessionID)
 	return nil
+}
+
+func TestReconcileAttentionRestoresEveryWorkerAlertAfterNotificationFailure(t *testing.T) {
+	now := time.Now()
+	events := []domain.OrchestrationEvent{
+		{ID: "e1", ProjectID: "p", WorkerID: "w1", AttentionRequiredAt: now},
+		{ID: "e2", ProjectID: "p", WorkerID: "w2", AttentionRequiredAt: now},
+		{ID: "e3", ProjectID: "p", WorkerID: "w1", AttentionRequiredAt: now},
+	}
+	store := &fakeStore{attentionEvents: events}
+	failed := &fakeNotifier{err: errors.New("publisher unavailable")}
+	if err := (&Dispatcher{Store: store, Notifier: failed}).ReconcileAttention(context.Background(), "p", now); err == nil {
+		t.Fatal("ReconcileAttention error=nil, want publisher failure")
+	}
+	restarted := &fakeNotifier{}
+	if err := (&Dispatcher{Store: store, Notifier: restarted}).ReconcileAttention(context.Background(), "p", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if len(restarted.created) != 2 {
+		t.Fatalf("created=%v", restarted.created)
+	}
+	if got := strings.Join([]string{string(restarted.created[0]), string(restarted.created[1])}, ","); got != "w1,w2" {
+		t.Fatalf("created=%v", restarted.created)
+	}
 }
 func (f *fakeNotifier) Resolve(_ context.Context, resolution ports.NotificationResolution) error {
 	f.resolved = append(f.resolved, resolution.SessionID)

--- a/backend/internal/orchestrationevents/dispatcher_test.go
+++ b/backend/internal/orchestrationevents/dispatcher_test.go
@@ -40,6 +40,9 @@ func (f *fakeStore) RetryOrchestrationEvents(_ context.Context, e []domain.Orche
 	f.retried = eventIDs(e)
 	return nil
 }
+func (f *fakeStore) MarkProjectNoDestinationAttention(context.Context, domain.ProjectID, time.Time) (int64, error) {
+	return 0, nil
+}
 
 type fakeTransport struct {
 	calls  int
@@ -131,7 +134,7 @@ func TestPromptIsBoundedAndExcludesUntrustedProviderText(t *testing.T) {
 	for i := range events {
 		events[i] = domain.OrchestrationEvent{ID: strings.Repeat("x", 900), WorkerID: "w", Kind: domain.OrchestrationWorkerReadyMerge, SourceRevision: "r"}
 	}
-	payload, kept := Prompt(events)
+	payload, kept := Prompt("batch", events)
 	if len(kept) > MaxBatchEvents || len(payload) > MaxPayloadBytes {
 		t.Fatalf("events=%d bytes=%d", len(kept), len(payload))
 	}

--- a/backend/internal/orchestrationevents/dispatcher_test.go
+++ b/backend/internal/orchestrationevents/dispatcher_test.go
@@ -15,6 +15,7 @@ type fakeStore struct {
 	events                            []domain.OrchestrationEvent
 	leased, submitted, acked, retried []string
 	destination                       domain.SessionID
+	leaseErr, submitErr, ackErr       error
 }
 
 func (f *fakeStore) ListSessions(context.Context, domain.ProjectID) ([]domain.SessionRecord, error) {
@@ -24,17 +25,68 @@ func (f *fakeStore) ListDueOrchestrationEvents(context.Context, domain.ProjectID
 	return f.events, nil
 }
 func (f *fakeStore) LeaseOrchestrationEvents(_ context.Context, ids []string, _ string, d domain.SessionID, _ time.Time) error {
+	if f.leaseErr != nil {
+		return f.leaseErr
+	}
 	f.leased = ids
 	f.destination = d
 	return nil
 }
 func (f *fakeStore) MarkOrchestrationEventsSubmitted(_ context.Context, ids []string, _ string, _ time.Time) error {
+	if f.submitErr != nil {
+		return f.submitErr
+	}
 	f.submitted = ids
 	return nil
 }
 func (f *fakeStore) AcknowledgeOrchestrationEvents(_ context.Context, ids []string, _ string, _ time.Time) error {
+	if f.ackErr != nil {
+		return f.ackErr
+	}
 	f.acked = ids
 	return nil
+}
+
+func TestFaultBoundariesDoNotClaimUncommittedDelivery(t *testing.T) {
+	now := time.Now()
+	session := domain.SessionRecord{ID: "o", ProjectID: "p", Kind: domain.KindOrchestrator, Mode: domain.SessionModeChat, Activity: domain.Activity{State: domain.ActivityIdle}, FirstSignalAt: now}
+	event := domain.OrchestrationEvent{ID: "e", ProjectID: "p", WorkerID: "w", Kind: domain.OrchestrationWorkerTerminated, SourceRevision: "r", EnqueuedAt: now}
+	wantErr := errors.New("injected boundary failure")
+	for _, tc := range []struct {
+		name       string
+		configure  func(*fakeStore)
+		wantWrites int
+		wantAck    bool
+	}{
+		{"after_outbox_before_lease", func(s *fakeStore) { s.leaseErr = wantErr }, 0, false},
+		{"after_lease_before_submitted", func(s *fakeStore) { s.submitErr = wantErr }, 1, false},
+		{"after_submission_before_ack", func(s *fakeStore) { s.ackErr = wantErr }, 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeStore{sessions: []domain.SessionRecord{session}, events: []domain.OrchestrationEvent{event}}
+			tc.configure(store)
+			transport := &fakeTransport{result: Submission{Submitted: true, Acknowledged: true}}
+			err := (&Dispatcher{Store: store, Transport: transport, Now: func() time.Time { return now }, NewID: func() string { return "batch" }}).DispatchProject(context.Background(), "p")
+			if !errors.Is(err, wantErr) || transport.calls != tc.wantWrites || (len(store.acked) > 0) != tc.wantAck {
+				t.Fatalf("err=%v writes=%d acked=%v", err, transport.calls, store.acked)
+			}
+		})
+	}
+}
+
+func TestSubmittedTUIBatchRemainsUnacknowledgedForRestartRecovery(t *testing.T) {
+	now := time.Now()
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "o", ProjectID: "p", Kind: domain.KindOrchestrator, Mode: domain.SessionModeTUI, Activity: domain.Activity{State: domain.ActivityIdle}, FirstSignalAt: now}},
+		events:   []domain.OrchestrationEvent{{ID: "e", ProjectID: "p", WorkerID: "w", Kind: domain.OrchestrationWorkerTurnSettled, SourceRevision: "r", EnqueuedAt: now}},
+	}
+	transport := &fakeTransport{result: Submission{Submitted: true, Acknowledged: false}}
+	if err := (&Dispatcher{Store: store, Transport: transport}).DispatchProject(context.Background(), "p"); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.submitted) != 1 || len(store.acked) != 0 {
+		t.Fatalf("submitted=%v acked=%v", store.submitted, store.acked)
+	}
 }
 func (f *fakeStore) RetryOrchestrationEvents(_ context.Context, e []domain.OrchestrationEvent, _, _ string, _ time.Time) error {
 	f.retried = eventIDs(e)

--- a/backend/internal/orchestrationevents/runner.go
+++ b/backend/internal/orchestrationevents/runner.go
@@ -33,6 +33,9 @@ func Recover(ctx context.Context, store RecoveryStore, dispatcher *Dispatcher) e
 		return err
 	}
 	for _, p := range projects {
+		if err := dispatcher.ReconcileAttention(ctx, domain.ProjectID(p.ID), time.Now().UTC()); err != nil {
+			return err
+		}
 		if err := dispatcher.DispatchProject(ctx, domain.ProjectID(p.ID)); err != nil {
 			return err
 		}

--- a/backend/internal/orchestrationevents/runner.go
+++ b/backend/internal/orchestrationevents/runner.go
@@ -11,6 +11,7 @@ import (
 // RecoveryStore supplies startup and retention maintenance.
 type RecoveryStore interface {
 	ListProjects(context.Context) ([]domain.ProjectRecord, error)
+	ReconcileTerminatedOrchestrationEvents(context.Context, time.Time) (int, error)
 	ReclaimOrchestrationEventLeases(context.Context, time.Time) (int64, error)
 	MarkOrchestrationRetentionOverflow(context.Context, time.Time) (int64, error)
 }
@@ -18,6 +19,9 @@ type RecoveryStore interface {
 // Recover synchronously reclaims interrupted work and attempts every due
 // project. Daemon startup calls this before exposing a healthy HTTP server.
 func Recover(ctx context.Context, store RecoveryStore, dispatcher *Dispatcher) error {
+	if _, err := store.ReconcileTerminatedOrchestrationEvents(ctx, time.Now().UTC()); err != nil {
+		return err
+	}
 	if _, err := store.ReclaimOrchestrationEventLeases(ctx, time.Now().UTC()); err != nil {
 		return err
 	}

--- a/backend/internal/orchestrationevents/runner.go
+++ b/backend/internal/orchestrationevents/runner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+// RecoveryStore supplies startup and retention maintenance.
 type RecoveryStore interface {
 	ListProjects(context.Context) ([]domain.ProjectRecord, error)
 	ReclaimOrchestrationEventLeases(context.Context, time.Time) (int64, error)

--- a/backend/internal/orchestrationevents/runner.go
+++ b/backend/internal/orchestrationevents/runner.go
@@ -15,31 +15,38 @@ type RecoveryStore interface {
 	MarkOrchestrationRetentionOverflow(context.Context, time.Time) (int64, error)
 }
 
-// Run owns restart recovery and cancellable daemon timers. It does not depend
-// on SSE, Electron, a shell process, or an agent-side polling loop.
+// Recover synchronously reclaims interrupted work and attempts every due
+// project. Daemon startup calls this before exposing a healthy HTTP server.
+func Recover(ctx context.Context, store RecoveryStore, dispatcher *Dispatcher) error {
+	if _, err := store.ReclaimOrchestrationEventLeases(ctx, time.Now().UTC()); err != nil {
+		return err
+	}
+	if _, err := store.MarkOrchestrationRetentionOverflow(ctx, time.Now().UTC()); err != nil {
+		return err
+	}
+	projects, err := store.ListProjects(ctx)
+	if err != nil {
+		return err
+	}
+	for _, p := range projects {
+		if err := dispatcher.DispatchProject(ctx, domain.ProjectID(p.ID)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Run owns cancellable daemon recovery timers. It does not depend on SSE,
+// Electron, a shell process, or an agent-side polling loop.
 func Run(ctx context.Context, store RecoveryStore, dispatcher *Dispatcher, wake <-chan domain.ProjectID, log *slog.Logger) {
 	if log == nil {
 		log = slog.Default()
 	}
-	if _, err := store.ReclaimOrchestrationEventLeases(ctx, time.Now().UTC()); err != nil {
-		log.Error("orchestration dispatcher lease recovery failed", "error", err)
-	}
 	dispatchAll := func() {
-		if _, err := store.MarkOrchestrationRetentionOverflow(ctx, time.Now().UTC()); err != nil {
-			log.Warn("orchestration retention maintenance failed", "error", err)
-		}
-		projects, err := store.ListProjects(ctx)
-		if err != nil {
-			log.Error("orchestration dispatcher project scan failed", "error", err)
-			return
-		}
-		for _, p := range projects {
-			if err := dispatcher.DispatchProject(ctx, domain.ProjectID(p.ID)); err != nil {
-				log.Warn("orchestration dispatch failed", "projectID", p.ID, "error", err)
-			}
+		if err := Recover(ctx, store, dispatcher); err != nil {
+			log.Warn("orchestration dispatcher recovery scan failed", "error", err)
 		}
 	}
-	dispatchAll()
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
 	for {

--- a/backend/internal/orchestrationevents/runner.go
+++ b/backend/internal/orchestrationevents/runner.go
@@ -1,0 +1,57 @@
+package orchestrationevents
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type RecoveryStore interface {
+	ListProjects(context.Context) ([]domain.ProjectRecord, error)
+	ReclaimOrchestrationEventLeases(context.Context, time.Time) (int64, error)
+	MarkOrchestrationRetentionOverflow(context.Context, time.Time) (int64, error)
+}
+
+// Run owns restart recovery and cancellable daemon timers. It does not depend
+// on SSE, Electron, a shell process, or an agent-side polling loop.
+func Run(ctx context.Context, store RecoveryStore, dispatcher *Dispatcher, wake <-chan domain.ProjectID, log *slog.Logger) {
+	if log == nil {
+		log = slog.Default()
+	}
+	if _, err := store.ReclaimOrchestrationEventLeases(ctx, time.Now().UTC()); err != nil {
+		log.Error("orchestration dispatcher lease recovery failed", "error", err)
+	}
+	dispatchAll := func() {
+		if _, err := store.MarkOrchestrationRetentionOverflow(ctx, time.Now().UTC()); err != nil {
+			log.Warn("orchestration retention maintenance failed", "error", err)
+		}
+		projects, err := store.ListProjects(ctx)
+		if err != nil {
+			log.Error("orchestration dispatcher project scan failed", "error", err)
+			return
+		}
+		for _, p := range projects {
+			if err := dispatcher.DispatchProject(ctx, domain.ProjectID(p.ID)); err != nil {
+				log.Warn("orchestration dispatch failed", "projectID", p.ID, "error", err)
+			}
+		}
+	}
+	dispatchAll()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case project := <-wake:
+			if err := dispatcher.DispatchProject(ctx, project); err != nil {
+				log.Warn("orchestration dispatch failed", "projectID", project, "error", err)
+			}
+		case <-timer.C:
+			dispatchAll()
+			timer.Reset(time.Second)
+		}
+	}
+}

--- a/backend/internal/orchestrationevents/runner_test.go
+++ b/backend/internal/orchestrationevents/runner_test.go
@@ -15,6 +15,10 @@ type recoveryStoreFake struct {
 	err                   error
 }
 
+func (f *recoveryStoreFake) ReconcileTerminatedOrchestrationEvents(context.Context, time.Time) (int, error) {
+	return 0, nil
+}
+
 func (f *recoveryStoreFake) ListProjects(context.Context) ([]domain.ProjectRecord, error) {
 	if f.err != nil {
 		return nil, f.err

--- a/backend/internal/orchestrationevents/runner_test.go
+++ b/backend/internal/orchestrationevents/runner_test.go
@@ -1,0 +1,55 @@
+package orchestrationevents
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+type recoveryStoreFake struct {
+	projects              []domain.ProjectRecord
+	reclaimed, maintained bool
+	err                   error
+}
+
+func (f *recoveryStoreFake) ListProjects(context.Context) ([]domain.ProjectRecord, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.projects, nil
+}
+func (f *recoveryStoreFake) ReclaimOrchestrationEventLeases(context.Context, time.Time) (int64, error) {
+	f.reclaimed = true
+	return 1, nil
+}
+func (f *recoveryStoreFake) MarkOrchestrationRetentionOverflow(context.Context, time.Time) (int64, error) {
+	f.maintained = true
+	return 0, nil
+}
+
+func TestRecoverReclaimsBeforeSynchronousProjectDispatch(t *testing.T) {
+	now := time.Now()
+	store := &recoveryStoreFake{projects: []domain.ProjectRecord{{ID: "p"}}}
+	dispatchStore := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "o", ProjectID: "p", Kind: domain.KindOrchestrator, Mode: domain.SessionModeChat, Activity: domain.Activity{State: domain.ActivityIdle}, FirstSignalAt: now}},
+		events:   []domain.OrchestrationEvent{{ID: "e", ProjectID: "p", WorkerID: "w", Kind: domain.OrchestrationWorkerTerminated, SourceRevision: "r", EnqueuedAt: now}},
+	}
+	dispatcher := &Dispatcher{Store: dispatchStore, Transport: &fakeTransport{result: Submission{Submitted: true, Acknowledged: true}}}
+	if err := Recover(context.Background(), store, dispatcher); err != nil {
+		t.Fatal(err)
+	}
+	if !store.reclaimed || !store.maintained || len(dispatchStore.acked) != 1 {
+		t.Fatalf("reclaimed=%v maintained=%v acked=%v", store.reclaimed, store.maintained, dispatchStore.acked)
+	}
+}
+
+func TestRecoverFailsClosedBeforeHealthOnStoreError(t *testing.T) {
+	want := errors.New("scan unavailable")
+	err := Recover(context.Background(), &recoveryStoreFake{err: want}, &Dispatcher{})
+	if !errors.Is(err, want) {
+		t.Fatalf("err=%v want %v", err, want)
+	}
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -3316,6 +3316,16 @@ func (m *Manager) Send(ctx context.Context, id domain.SessionID, message string,
 	return m.send(ctx, id, message, "")
 }
 
+// SendAutomation submits an AO-owned message with a stable idempotency key.
+// Chat controllers persist that key; TUI delivery is acknowledged separately
+// by the exact prompt-submit lifecycle hook.
+func (m *Manager) SendAutomation(ctx context.Context, id domain.SessionID, message, clientMessageID string) error {
+	if strings.TrimSpace(clientMessageID) == "" {
+		return errors.New("automation send requires a client message id")
+	}
+	return m.send(ctx, id, message, clientMessageID)
+}
+
 // send carries an optional idempotency key used by durable transition-message
 // retries. Ordinary callers leave it empty; the outbox preserves the key across
 // restart, rollback, and even a second overlapping handoff.

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -147,6 +147,9 @@ var (
 	// agent hook callback, so the native startup sequence (including pre-session
 	// approval dialogs) may still be consuming pane input.
 	ErrStartupPending = errors.New("session: agent startup not ready for input")
+	// ErrAutomationUnsupported means a TUI harness cannot echo the exact
+	// accepted prompt through its managed submit hook, so AO cannot safely ack.
+	ErrAutomationUnsupported = errors.New("session: automation acknowledgement unsupported")
 
 	// Spawn-stage sentinels. Each is the existing log word after "spawn" /
 	// "spawn <id>:" so wrapping them does not change daemon-log wording, while
@@ -3353,8 +3356,51 @@ func (m *Manager) SendAutomation(ctx context.Context, id domain.SessionID, messa
 		case rec.FirstSignalAt.IsZero():
 			return ErrStartupPending
 		}
+		return m.send(ctx, id, message, clientMessageID)
 	}
-	return m.send(ctx, id, message, clientMessageID)
+	message, err = m.prepareOutboundMessage(ctx, id, message)
+	if err != nil {
+		return err
+	}
+	outcome, err := m.messenger.Automation(ctx, id, message, m.harnessAutomationAcknowledges)
+	if err != nil {
+		return err
+	}
+	switch outcome {
+	case sessionguard.Sent:
+		return nil
+	case sessionguard.SuppressedNotFound:
+		return ErrNotFound
+	case sessionguard.SuppressedTerminated:
+		return ErrTerminated
+	case sessionguard.SuppressedExited:
+		return ErrAgentExited
+	case sessionguard.SuppressedAwaitingUser:
+		return ErrAwaitingDecision
+	case sessionguard.SuppressedStartupPending:
+		return ErrStartupPending
+	case sessionguard.SuppressedInputGated, sessionguard.SuppressedBusy:
+		return ErrSwitchInProgress
+	default:
+		return ErrAutomationUnsupported
+	}
+}
+
+func (m *Manager) harnessAutomationAcknowledges(harness domain.AgentHarness) bool {
+	// These managed hooks carry the exact accepted prompt text through
+	// LatestUserPrompt. Other submit signals prove activity only and cannot
+	// acknowledge an automation batch safely.
+	switch harness {
+	case domain.HarnessClaudeCode, domain.HarnessCodex, domain.HarnessContinue, domain.HarnessPi:
+		agent, ok := m.agents.Agent(harness)
+		if !ok {
+			return false
+		}
+		signal, ok := agent.(ports.SubmitActivitySignaler)
+		return ok && signal.EmitsSubmitActivity()
+	default:
+		return false
+	}
 }
 
 // send carries an optional idempotency key used by durable transition-message

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -3323,6 +3323,37 @@ func (m *Manager) SendAutomation(ctx context.Context, id domain.SessionID, messa
 	if strings.TrimSpace(clientMessageID) == "" {
 		return errors.New("automation send requires a client message id")
 	}
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrNotFound
+	}
+	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
+		release, admitted := m.AcquireSessionInput(id)
+		if !admitted {
+			return ErrSwitchInProgress
+		}
+		defer release()
+		rec, ok, err = m.store.GetSession(ctx, id)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return ErrNotFound
+		}
+		switch {
+		case rec.IsTerminated:
+			return ErrTerminated
+		case rec.Activity.State == domain.ActivityExited:
+			return ErrAgentExited
+		case rec.Activity.State.NeedsInput():
+			return ErrAwaitingDecision
+		case rec.FirstSignalAt.IsZero():
+			return ErrStartupPending
+		}
+	}
 	return m.send(ctx, id, message, clientMessageID)
 }
 
@@ -3424,7 +3455,13 @@ func copilotOrchestratorMessage(projectID domain.ProjectID, message string) stri
 	if project == "" {
 		project = "<project>"
 	}
-	return fmt.Sprintf(`AO ORCHESTRATOR DIRECTIVE
+	marker := ""
+	if strings.HasPrefix(message, "[AO AUTOMATION batch_id=") {
+		if end := strings.IndexByte(message, '\n'); end >= 0 {
+			marker, message = message[:end+1], message[end+1:]
+		}
+	}
+	return marker + fmt.Sprintf(`AO ORCHESTRATOR DIRECTIVE
 
 You are acting as the AO orchestrator for project %s. Do not implement code changes, edit files, run implementation tests, or complete the user's task yourself.
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -8646,6 +8646,16 @@ type flipOnNudgeMessenger struct {
 	flipped   bool
 }
 
+func TestCopilotOrchestratorMessagePreservesAutomationMarkerAtStart(t *testing.T) {
+	message := copilotOrchestratorMessage("p", "[AO AUTOMATION batch_id=batch-1] machine wake\nworker_terminated worker=w")
+	if !strings.HasPrefix(message, "[AO AUTOMATION batch_id=batch-1]") {
+		t.Fatalf("automation acknowledgement marker moved: %q", message)
+	}
+	if !strings.Contains(message, "AO ORCHESTRATOR DIRECTIVE") {
+		t.Fatalf("orchestrator safety directive missing: %q", message)
+	}
+}
+
 func (m *flipOnNudgeMessenger) Send(_ context.Context, _ domain.SessionID, msg string) error {
 	m.msgs = append(m.msgs, msg)
 	if msg == "" && !m.flipped {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -8591,6 +8591,33 @@ func TestHarnessNudgeSafe(t *testing.T) {
 	}
 }
 
+func TestSendAutomationTUIRechecksStateAndAcknowledgementCapability(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		harness  domain.AgentHarness
+		state    domain.ActivityState
+		wantErr  error
+		wantSend bool
+	}{
+		{"Pi idle", domain.HarnessPi, domain.ActivityIdle, nil, true},
+		{"Pi active", domain.HarnessPi, domain.ActivityActive, ErrSwitchInProgress, false},
+		{"Pi waiting", domain.HarnessPi, domain.ActivityWaitingInput, ErrAwaitingDecision, false},
+		{"Pi blocked", domain.HarnessPi, domain.ActivityBlocked, ErrAwaitingDecision, false},
+		{"unsupported TUI", domain.HarnessCursor, domain.ActivityIdle, ErrAutomationUnsupported, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeStore()
+			st.sessions["s1"] = pastStartupGate(domain.SessionRecord{ID: "s1", Mode: domain.SessionModeTUI, Harness: tc.harness, Activity: domain.Activity{State: tc.state}})
+			messenger := &fakeMessenger{}
+			m := newSendTestManager(t, submitOnlyAgent{}, messenger, st)
+			err := m.SendAutomation(context.Background(), "s1", "[AO AUTOMATION batch_id=b] wake", "b")
+			if !errors.Is(err, tc.wantErr) || (len(messenger.msgs) == 1) != tc.wantSend {
+				t.Fatalf("err=%v sends=%v", err, messenger.msgs)
+			}
+		})
+	}
+}
+
 func TestSwitchTargetsOnlyRetryEnterWhenActivitySignalsMakeItSafe(t *testing.T) {
 	agents := switchTestAgents{
 		domain.HarnessClaudeCode: claudecode.New(),

--- a/backend/internal/sessionguard/guard.go
+++ b/backend/internal/sessionguard/guard.go
@@ -205,6 +205,31 @@ func (g *Guard) DeliverWithPostWrite(ctx context.Context, id domain.SessionID, m
 	return g.sendThen(ctx, id, msg, g.refuseDeliver, after)
 }
 
+// Automation writes a machine-originated turn only at an idle, hook-capable
+// TUI prompt. It re-reads the session under the input lease immediately before
+// the pane write, so a dispatcher-time idle observation cannot race a later
+// active or decision state.
+func (g *Guard) Automation(ctx context.Context, id domain.SessionID, msg string, acknowledges func(domain.AgentHarness) bool) (Outcome, error) {
+	return g.send(ctx, id, msg, func(rec domain.SessionRecord) (Outcome, bool) {
+		if g.tuiAwaitingStartupInput(rec) {
+			return SuppressedStartupPending, true
+		}
+		if acknowledges == nil || !acknowledges(rec.Harness) {
+			return SuppressedUnknown, true
+		}
+		switch rec.Activity.State {
+		case domain.ActivityIdle:
+			return SuppressedUnknown, false
+		case domain.ActivityActive:
+			return SuppressedBusy, true
+		case domain.ActivityBlocked, domain.ActivityWaitingInput:
+			return SuppressedAwaitingUser, true
+		default:
+			return SuppressedUnknown, true
+		}
+	})
+}
+
 // DeliverUnderMutation applies the same just-in-time session safety checks as
 // Deliver but intentionally bypasses input admission. It is only for an AO
 // mutation that already owns the session's exclusive operation fence and must

--- a/backend/internal/sessionguard/guard_test.go
+++ b/backend/internal/sessionguard/guard_test.go
@@ -115,6 +115,36 @@ func TestGuard_OutcomeByState(t *testing.T) {
 	}
 }
 
+func TestGuard_AutomationFailsClosedAtJITBoundary(t *testing.T) {
+	ack := func(h domain.AgentHarness) bool { return h == domain.HarnessPi }
+	for _, tc := range []struct {
+		name string
+		rec  domain.SessionRecord
+		want Outcome
+	}{
+		{"idle Pi", record(domain.ActivityIdle, false), Sent},
+		{"active Pi", record(domain.ActivityActive, false), SuppressedBusy},
+		{"waiting Pi", record(domain.ActivityWaitingInput, false), SuppressedAwaitingUser},
+		{"blocked Pi", record(domain.ActivityBlocked, false), SuppressedAwaitingUser},
+		{"exited Pi", record(domain.ActivityExited, false), SuppressedExited},
+		{"terminated Pi", record(domain.ActivityIdle, true), SuppressedTerminated},
+		{"unsupported harness", record(domain.ActivityIdle, false), SuppressedUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.rec.Harness = domain.HarnessPi
+			if tc.name == "unsupported harness" {
+				tc.rec.Harness = domain.HarnessCursor
+			}
+			messenger := &fakeMessenger{}
+			guard := New(&fakeStore{rec: tc.rec, ok: true}, messenger, nil)
+			got, err := guard.Automation(context.Background(), tc.rec.ID, "wake", ack)
+			if err != nil || got != tc.want || (len(messenger.sent) == 1) != (tc.want == Sent) {
+				t.Fatalf("outcome=%v sends=%v err=%v", got, messenger.sent, err)
+			}
+		})
+	}
+}
+
 // TestGuard_NudgeUrgentReachesNeedsInputButNotBlocked pins NudgeUrgent's
 // outcome table directly: it is the only nudge method that may write into a
 // session idle at a needs-input prompt, and it must still refuse blocked (where

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -133,6 +133,7 @@ var shippedMigrations = map[int64]string{
 	126: "0126_canonical_repository_identity.sql",
 	127: "0127_session_permissions.sql",
 	128: "0128_orchestration_event_outbox.sql",
+	129: "0129_orchestration_attention_notifications.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -132,6 +132,7 @@ var shippedMigrations = map[int64]string{
 	125: "0125_agent_switch_failure_observability.sql",
 	126: "0126_canonical_repository_identity.sql",
 	127: "0127_session_permissions.sql",
+	128: "0128_orchestration_event_outbox.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0128_orchestration_event_outbox.sql
+++ b/backend/internal/storage/sqlite/migrations/0128_orchestration_event_outbox.sql
@@ -14,6 +14,7 @@ CREATE TABLE orchestration_events (
     destination_session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
     submitted_at TIMESTAMP,
     acknowledged_at TIMESTAMP,
+    attention_required_at TIMESTAMP,
     last_error TEXT NOT NULL DEFAULT '' CHECK (length(last_error) <= 512),
     UNIQUE(project_id, worker_id, kind, source_revision)
 );

--- a/backend/internal/storage/sqlite/migrations/0128_orchestration_event_outbox.sql
+++ b/backend/internal/storage/sqlite/migrations/0128_orchestration_event_outbox.sql
@@ -20,8 +20,19 @@ CREATE TABLE orchestration_events (
 );
 CREATE INDEX idx_orchestration_events_due ON orchestration_events(state, next_attempt_at, enqueued_at);
 CREATE INDEX idx_orchestration_events_project ON orchestration_events(project_id, state, enqueued_at);
+CREATE TABLE orchestration_source_states (
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    worker_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    active INTEGER NOT NULL CHECK(active IN (0,1)),
+    generation INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NOT NULL,
+    PRIMARY KEY(project_id,worker_id,kind,source_id)
+);
 
 -- +goose Down
 DROP INDEX IF EXISTS idx_orchestration_events_project;
 DROP INDEX IF EXISTS idx_orchestration_events_due;
+DROP TABLE IF EXISTS orchestration_source_states;
 DROP TABLE IF EXISTS orchestration_events;

--- a/backend/internal/storage/sqlite/migrations/0128_orchestration_event_outbox.sql
+++ b/backend/internal/storage/sqlite/migrations/0128_orchestration_event_outbox.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+CREATE TABLE orchestration_events (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    worker_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK (kind IN ('worker_turn_settled','worker_blocked','worker_ready_to_merge','worker_terminated','pr_merged')),
+    source_revision TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending' CHECK (state IN ('pending','leased','submitted','acknowledged','dead_letter')),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count BETWEEN 0 AND 8),
+    enqueued_at TIMESTAMP NOT NULL,
+    next_attempt_at TIMESTAMP NOT NULL,
+    lease_token TEXT,
+    lease_expires_at TIMESTAMP,
+    destination_session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+    submitted_at TIMESTAMP,
+    acknowledged_at TIMESTAMP,
+    last_error TEXT NOT NULL DEFAULT '' CHECK (length(last_error) <= 512),
+    UNIQUE(project_id, worker_id, kind, source_revision)
+);
+CREATE INDEX idx_orchestration_events_due ON orchestration_events(state, next_attempt_at, enqueued_at);
+CREATE INDEX idx_orchestration_events_project ON orchestration_events(project_id, state, enqueued_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_orchestration_events_project;
+DROP INDEX IF EXISTS idx_orchestration_events_due;
+DROP TABLE IF EXISTS orchestration_events;

--- a/backend/internal/storage/sqlite/migrations/0129_orchestration_attention_notifications.sql
+++ b/backend/internal/storage/sqlite/migrations/0129_orchestration_attention_notifications.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_notifications_open_dedupe;
+DROP INDEX IF EXISTS idx_notifications_unresolved;
+DROP INDEX IF EXISTS idx_notifications_status_history;
+DROP INDEX IF EXISTS idx_notifications_history;
+ALTER TABLE notifications RENAME TO notifications_before_orchestration_attention;
+CREATE TABLE notifications (
+ id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+ project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE, pr_url TEXT NOT NULL DEFAULT '',
+ type TEXT NOT NULL CHECK(type IN ('needs_input','ready_to_merge','pr_merged','pr_closed_unmerged','orchestration_attention')),
+ title TEXT NOT NULL, body TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'unread' CHECK(status IN ('read','unread')),
+ created_at TIMESTAMP NOT NULL, resolved_at TIMESTAMP
+);
+INSERT INTO notifications SELECT * FROM notifications_before_orchestration_attention;
+DROP TABLE notifications_before_orchestration_attention;
+CREATE INDEX idx_notifications_status_history ON notifications(status,created_at DESC,id DESC);
+CREATE INDEX idx_notifications_history ON notifications(created_at DESC,id DESC);
+CREATE UNIQUE INDEX idx_notifications_open_dedupe ON notifications(session_id,type,pr_url) WHERE status='unread' OR resolved_at IS NULL;
+CREATE INDEX idx_notifications_unresolved ON notifications(resolved_at,created_at DESC,id DESC);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM notifications WHERE type='orchestration_attention';
+DROP INDEX IF EXISTS idx_notifications_open_dedupe;
+DROP INDEX IF EXISTS idx_notifications_unresolved;
+DROP INDEX IF EXISTS idx_notifications_status_history;
+DROP INDEX IF EXISTS idx_notifications_history;
+ALTER TABLE notifications RENAME TO notifications_with_orchestration_attention;
+CREATE TABLE notifications (
+ id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+ project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE, pr_url TEXT NOT NULL DEFAULT '',
+ type TEXT NOT NULL CHECK(type IN ('needs_input','ready_to_merge','pr_merged','pr_closed_unmerged')),
+ title TEXT NOT NULL, body TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'unread' CHECK(status IN ('read','unread')),
+ created_at TIMESTAMP NOT NULL, resolved_at TIMESTAMP
+);
+INSERT INTO notifications SELECT * FROM notifications_with_orchestration_attention;
+DROP TABLE notifications_with_orchestration_attention;
+CREATE INDEX idx_notifications_status_history ON notifications(status,created_at DESC,id DESC);
+CREATE INDEX idx_notifications_history ON notifications(created_at DESC,id DESC);
+CREATE UNIQUE INDEX idx_notifications_open_dedupe ON notifications(session_id,type,pr_url) WHERE status='unread' OR resolved_at IS NULL;
+CREATE INDEX idx_notifications_unresolved ON notifications(resolved_at,created_at DESC,id DESC);
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/store/notification_store_test.go
+++ b/backend/internal/storage/sqlite/store/notification_store_test.go
@@ -9,6 +9,29 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+func TestNotificationStoreOrchestrationAttentionDedupesAndResolves(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	rec := domain.NotificationRecord{ID: "n1", SessionID: w.ID, ProjectID: "p", Type: domain.NotificationOrchestrationAttention, Title: "Orchestration delivery needs attention", Status: domain.NotificationUnread, CreatedAt: now}
+	if _, created, err := s.CreateNotification(ctx, rec); err != nil || !created {
+		t.Fatalf("create=%v err=%v", created, err)
+	}
+	rec.ID = "n2"
+	if _, created, err := s.CreateNotification(ctx, rec); err != nil || created {
+		t.Fatalf("duplicate create=%v err=%v", created, err)
+	}
+	resolved, err := s.ResolveSessionNotifications(ctx, w.ID, domain.NotificationOrchestrationAttention, now.Add(time.Second))
+	if err != nil || len(resolved) != 1 {
+		t.Fatalf("resolved=%v err=%v", resolved, err)
+	}
+}
+
 func TestNotificationStore_InsertListAndDedupe(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/backend/internal/storage/sqlite/store/orchestration_event_store.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store.go
@@ -132,10 +132,10 @@ func (s *Store) ListOrchestrationEvents(ctx context.Context, project domain.Proj
 	return scanOrchestrationEvents(rows)
 }
 
-func (s *Store) RetryDeadLetterOrchestrationEvent(ctx context.Context, id string, now time.Time) (bool, error) {
+func (s *Store) RetryDeadLetterOrchestrationEvent(ctx context.Context, project domain.ProjectID, id string, now time.Time) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='pending',attempt_count=0,next_attempt_at=?,lease_token=NULL,lease_expires_at=NULL,destination_session_id=NULL,submitted_at=NULL,acknowledged_at=NULL,attention_required_at=NULL,last_error='' WHERE id=? AND state='dead_letter'`, now, id)
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='pending',attempt_count=0,next_attempt_at=?,lease_token=NULL,lease_expires_at=NULL,destination_session_id=NULL,submitted_at=NULL,acknowledged_at=NULL,attention_required_at=NULL,last_error='' WHERE id=? AND project_id=? AND state='dead_letter'`, now, id, project)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/storage/sqlite/store/orchestration_event_store.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 
 const orchestrationColumns = `id, project_id, worker_id, kind, source_revision, state,
  attempt_count, enqueued_at, next_attempt_at, lease_token, lease_expires_at,
- destination_session_id, submitted_at, acknowledged_at, last_error`
+ destination_session_id, submitted_at, acknowledged_at, attention_required_at, last_error`
 
 func (s *Store) EnqueueOrchestrationEvent(ctx context.Context, e domain.OrchestrationEvent) (bool, error) {
 	s.writeMu.Lock()
@@ -32,9 +33,32 @@ func (s *Store) EnqueueOrchestrationEvent(ctx context.Context, e domain.Orchestr
 func (s *Store) ReclaimOrchestrationEventLeases(ctx context.Context, now time.Time) (int64, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='pending',
- lease_token=NULL,lease_expires_at=NULL,destination_session_id=NULL,next_attempt_at=?
- WHERE state IN ('leased','submitted') AND lease_expires_at<=?`, now, now)
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET
+	 state=CASE WHEN attempt_count+1>=2 OR enqueued_at<=? THEN 'dead_letter' ELSE 'pending' END,
+	 attempt_count=attempt_count+1,lease_token=NULL,lease_expires_at=NULL,
+	 attention_required_at=CASE WHEN attempt_count+1>=2 OR enqueued_at<=? THEN COALESCE(attention_required_at,?) ELSE attention_required_at END,
+	 destination_session_id=NULL,next_attempt_at=?
+	 WHERE state IN ('leased','submitted') AND lease_expires_at<=?`, now.Add(-15*time.Minute), now.Add(-15*time.Minute), now, now, now)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+func (s *Store) MarkProjectNoDestinationAttention(ctx context.Context, project domain.ProjectID, now time.Time) (int64, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET attention_required_at=? WHERE project_id=? AND state='pending' AND attention_required_at IS NULL AND enqueued_at<=?`, now, project, now.Add(-15*time.Minute))
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+func (s *Store) MarkOrchestrationRetentionOverflow(ctx context.Context, now time.Time) (int64, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='dead_letter',attention_required_at=COALESCE(attention_required_at,?),last_error='retention limit exceeded' WHERE state='pending' AND (enqueued_at<=? OR id IN (SELECT id FROM orchestration_events AS overflow WHERE overflow.project_id=orchestration_events.project_id AND overflow.state='pending' ORDER BY overflow.enqueued_at DESC,overflow.id DESC LIMIT -1 OFFSET 10000))`, now, now.Add(-30*24*time.Hour))
 	if err != nil {
 		return 0, err
 	}
@@ -49,6 +73,26 @@ func (s *Store) ListDueOrchestrationEvents(ctx context.Context, project domain.P
 	}
 	defer rows.Close()
 	return scanOrchestrationEvents(rows)
+}
+
+func (s *Store) ListOrchestrationEvents(ctx context.Context, project domain.ProjectID, limit int) ([]domain.OrchestrationEvent, error) {
+	rows, err := s.readDB.QueryContext(ctx, `SELECT `+orchestrationColumns+` FROM orchestration_events WHERE project_id=? ORDER BY enqueued_at DESC,id DESC LIMIT ?`, project, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanOrchestrationEvents(rows)
+}
+
+func (s *Store) RetryDeadLetterOrchestrationEvent(ctx context.Context, id string, now time.Time) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='pending',attempt_count=0,next_attempt_at=?,lease_token=NULL,lease_expires_at=NULL,destination_session_id=NULL,submitted_at=NULL,acknowledged_at=NULL,attention_required_at=NULL,last_error='' WHERE id=? AND state='dead_letter'`, now, id)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	return rows == 1, err
 }
 
 func (s *Store) LeaseOrchestrationEvents(ctx context.Context, ids []string, token string, destination domain.SessionID, expires time.Time) error {
@@ -69,6 +113,19 @@ func (s *Store) AcknowledgeOrchestrationEvents(ctx context.Context, ids []string
 	})
 }
 
+// AcknowledgeOrchestrationBatchAccepted closes a TUI batch only when the
+// lifecycle hook reports admission of the exact AO batch id at its destination.
+func (s *Store) AcknowledgeOrchestrationBatchAccepted(ctx context.Context, destination domain.SessionID, token string, at time.Time) (int64, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='acknowledged',acknowledged_at=?,lease_token=NULL,lease_expires_at=NULL,last_error=''
+ WHERE destination_session_id=? AND lease_token=? AND state IN ('leased','submitted')`, at, destination, token)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (s *Store) RetryOrchestrationEvents(ctx context.Context, events []domain.OrchestrationEvent, token, message string, now time.Time) error {
 	if len(message) > 512 {
 		message = message[:512]
@@ -87,11 +144,25 @@ func (s *Store) RetryOrchestrationEvents(ctx context.Context, events []domain.Or
 			state = domain.OrchestrationDeadLetter
 		}
 		backoff := time.Second << min(attempt-1, 5)
-		if backoff > time.Minute {
-			backoff = time.Minute
+		if backoff > 48*time.Second {
+			backoff = 48 * time.Second
 		}
-		return db.ExecContext(ctx, `UPDATE orchestration_events SET state=?,attempt_count=attempt_count+1,next_attempt_at=?,lease_token=NULL,lease_expires_at=NULL,last_error=? WHERE id=? AND state IN ('leased','submitted') AND lease_token=? AND attempt_count<8`, state, now.Add(backoff), message, id, token)
+		backoff += orchestrationJitter(id, backoff/4)
+		var attention any
+		if state == domain.OrchestrationDeadLetter {
+			attention = now
+		}
+		return db.ExecContext(ctx, `UPDATE orchestration_events SET state=?,attempt_count=attempt_count+1,next_attempt_at=?,lease_token=NULL,lease_expires_at=NULL,last_error=?,attention_required_at=COALESCE(attention_required_at,?) WHERE id=? AND state IN ('leased','submitted') AND lease_token=? AND attempt_count<8`, state, now.Add(backoff), message, attention, id, token)
 	})
+}
+
+func orchestrationJitter(id string, ceiling time.Duration) time.Duration {
+	if ceiling <= 0 {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(id))
+	return time.Duration(h.Sum64() % uint64(ceiling))
 }
 
 func (s *Store) updateOrchestrationBatch(ctx context.Context, what string, ids []string, update func(gen.DBTX, string) (sql.Result, error)) error {
@@ -121,8 +192,8 @@ func scanOrchestrationEvent(row rowScanner) (domain.OrchestrationEvent, error) {
 	var e domain.OrchestrationEvent
 	var project, worker, kind, state string
 	var lease, destination, lastError sql.NullString
-	var leaseExpiry, submitted, ack sql.NullTime
-	err := row.Scan(&e.ID, &project, &worker, &kind, &e.SourceRevision, &state, &e.AttemptCount, &e.EnqueuedAt, &e.NextAttemptAt, &lease, &leaseExpiry, &destination, &submitted, &ack, &lastError)
+	var leaseExpiry, submitted, ack, attention sql.NullTime
+	err := row.Scan(&e.ID, &project, &worker, &kind, &e.SourceRevision, &state, &e.AttemptCount, &e.EnqueuedAt, &e.NextAttemptAt, &lease, &leaseExpiry, &destination, &submitted, &ack, &attention, &lastError)
 	e.ProjectID = domain.ProjectID(project)
 	e.WorkerID = domain.SessionID(worker)
 	e.Kind = domain.OrchestrationEventKind(kind)
@@ -132,6 +203,7 @@ func scanOrchestrationEvent(row rowScanner) (domain.OrchestrationEvent, error) {
 	e.DestinationSessionID = domain.SessionID(destination.String)
 	e.SubmittedAt = submitted.Time
 	e.AcknowledgedAt = ack.Time
+	e.AttentionRequiredAt = attention.Time
 	e.LastError = strings.TrimSpace(lastError.String)
 	return e, err
 }

--- a/backend/internal/storage/sqlite/store/orchestration_event_store.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store.go
@@ -19,6 +19,36 @@ const orchestrationColumns = `id, project_id, worker_id, kind, source_revision, 
  attempt_count, enqueued_at, next_attempt_at, lease_token, lease_expires_at,
  destination_session_id, submitted_at, acknowledged_at, attention_required_at, last_error`
 
+// ReconcileTerminatedOrchestrationEvents deterministically closes the crash
+// window between any terminal session mutation and its normalized event.
+func (s *Store) ReconcileTerminatedOrchestrationEvents(ctx context.Context, now time.Time) (int, error) {
+	sessions, err := s.ListAllSessions(ctx)
+	if err != nil {
+		return 0, err
+	}
+	created := 0
+	for _, rec := range sessions {
+		if rec.Kind != domain.KindWorker || !rec.IsTerminated {
+			continue
+		}
+		source := strings.TrimSpace(rec.Metadata.RuntimeLaunchID)
+		if source == "" {
+			source = strings.TrimSpace(rec.Metadata.ControllerGeneration)
+		}
+		if source == "" {
+			source = rec.UpdatedAt.UTC().Format(time.RFC3339Nano)
+		}
+		inserted, err := s.RecordOrchestrationSourceState(ctx, rec.ProjectID, rec.ID, domain.OrchestrationWorkerTerminated, source, true, now)
+		if err != nil {
+			return created, err
+		}
+		if inserted {
+			created++
+		}
+	}
+	return created, nil
+}
+
 func (s *Store) EnqueueOrchestrationEvent(ctx context.Context, e domain.OrchestrationEvent) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -69,7 +99,8 @@ func (s *Store) RecordOrchestrationSourceState(ctx context.Context, project doma
 		if !created {
 			return nil
 		}
-		revision := strconv.Itoa(generation)
+		sourceHash := sha256.Sum256([]byte(sourceID))
+		revision := hex.EncodeToString(sourceHash[:8]) + ":" + strconv.Itoa(generation)
 		sum := sha256.Sum256([]byte(string(project) + "\x00" + string(worker) + "\x00" + string(kind) + "\x00" + sourceID + "\x00" + revision))
 		id := "oe:" + hex.EncodeToString(sum[:16])
 		_, err = db.ExecContext(ctx, `INSERT INTO orchestration_events(id,project_id,worker_id,kind,source_revision,enqueued_at,next_attempt_at)VALUES(?,?,?,?,?,?,?) ON CONFLICT(project_id,worker_id,kind,source_revision) DO NOTHING`, id, project, worker, kind, revision, now, now)
@@ -151,13 +182,13 @@ func (s *Store) LeaseOrchestrationEvents(ctx context.Context, ids []string, toke
 
 func (s *Store) MarkOrchestrationEventsSubmitted(ctx context.Context, ids []string, token string, at time.Time) error {
 	return s.updateOrchestrationBatch(ctx, "submit orchestration events", ids, func(db gen.DBTX, id string) (sql.Result, error) {
-		return db.ExecContext(ctx, `UPDATE orchestration_events SET state='submitted',submitted_at=? WHERE id=? AND state='leased' AND lease_token=?`, at, id, token)
+		return db.ExecContext(ctx, `UPDATE orchestration_events SET state=CASE WHEN state='leased' THEN 'submitted' ELSE state END,submitted_at=COALESCE(submitted_at,?) WHERE id=? AND state IN ('leased','acknowledged') AND lease_token=?`, at, id, token)
 	})
 }
 
 func (s *Store) AcknowledgeOrchestrationEvents(ctx context.Context, ids []string, token string, at time.Time) error {
 	return s.updateOrchestrationBatch(ctx, "acknowledge orchestration events", ids, func(db gen.DBTX, id string) (sql.Result, error) {
-		return db.ExecContext(ctx, `UPDATE orchestration_events SET state='acknowledged',acknowledged_at=?,lease_token=NULL,lease_expires_at=NULL,last_error='' WHERE id=? AND state IN ('leased','submitted') AND lease_token=?`, at, id, token)
+		return db.ExecContext(ctx, `UPDATE orchestration_events SET state='acknowledged',acknowledged_at=?,lease_expires_at=NULL,last_error='' WHERE id=? AND state IN ('leased','submitted') AND lease_token=?`, at, id, token)
 	})
 }
 
@@ -166,7 +197,7 @@ func (s *Store) AcknowledgeOrchestrationEvents(ctx context.Context, ids []string
 func (s *Store) AcknowledgeOrchestrationBatchAccepted(ctx context.Context, destination domain.SessionID, token string, at time.Time) (int64, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='acknowledged',acknowledged_at=?,lease_token=NULL,lease_expires_at=NULL,last_error=''
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='acknowledged',acknowledged_at=?,lease_expires_at=NULL,last_error=''
  WHERE destination_session_id=? AND lease_token=? AND state IN ('leased','submitted')`, at, destination, token)
 	if err != nil {
 		return 0, err

--- a/backend/internal/storage/sqlite/store/orchestration_event_store.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store.go
@@ -2,9 +2,12 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"hash/fnv"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +31,51 @@ func (s *Store) EnqueueOrchestrationEvent(ctx context.Context, e domain.Orchestr
 	}
 	rows, err := result.RowsAffected()
 	return rows == 1, err
+}
+
+func (s *Store) RecordOrchestrationSourceState(ctx context.Context, project domain.ProjectID, worker domain.SessionID, kind domain.OrchestrationEventKind, sourceID string, active bool, now time.Time) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	created := false
+	err := s.inTxDB(ctx, "record orchestration source state", func(_ *gen.Queries, db gen.DBTX) error {
+		var previous int
+		var generation int
+		err := db.QueryRowContext(ctx, `SELECT active,generation FROM orchestration_source_states WHERE project_id=? AND worker_id=? AND kind=? AND source_id=?`, project, worker, kind, sourceID).Scan(&previous, &generation)
+		if err != nil && err != sql.ErrNoRows {
+			return err
+		}
+		if err == sql.ErrNoRows {
+			if active {
+				generation = 1
+				created = true
+			}
+			_, err = db.ExecContext(ctx, `INSERT INTO orchestration_source_states(project_id,worker_id,kind,source_id,active,generation,updated_at)VALUES(?,?,?,?,?,?,?)`, project, worker, kind, sourceID, active, generation, now)
+			if err != nil {
+				return err
+			}
+		} else {
+			if (previous != 0) == active {
+				return nil
+			}
+			if active {
+				generation++
+				created = true
+			}
+			_, err = db.ExecContext(ctx, `UPDATE orchestration_source_states SET active=?,generation=?,updated_at=? WHERE project_id=? AND worker_id=? AND kind=? AND source_id=?`, active, generation, now, project, worker, kind, sourceID)
+			if err != nil {
+				return err
+			}
+		}
+		if !created {
+			return nil
+		}
+		revision := strconv.Itoa(generation)
+		sum := sha256.Sum256([]byte(string(project) + "\x00" + string(worker) + "\x00" + string(kind) + "\x00" + sourceID + "\x00" + revision))
+		id := "oe:" + hex.EncodeToString(sum[:16])
+		_, err = db.ExecContext(ctx, `INSERT INTO orchestration_events(id,project_id,worker_id,kind,source_revision,enqueued_at,next_attempt_at)VALUES(?,?,?,?,?,?,?) ON CONFLICT(project_id,worker_id,kind,source_revision) DO NOTHING`, id, project, worker, kind, revision, now, now)
+		return err
+	})
+	return created, err
 }
 
 func (s *Store) ReclaimOrchestrationEventLeases(ctx context.Context, now time.Time) (int64, error) {

--- a/backend/internal/storage/sqlite/store/orchestration_event_store.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store.go
@@ -163,6 +163,18 @@ func (s *Store) ListOrchestrationEvents(ctx context.Context, project domain.Proj
 	return scanOrchestrationEvents(rows)
 }
 
+// ListOrchestrationEventsRequiringAttention returns the durable source for
+// reconstructing human-visible alerts after daemon or publisher failure.
+func (s *Store) ListOrchestrationEventsRequiringAttention(ctx context.Context, project domain.ProjectID) ([]domain.OrchestrationEvent, error) {
+	rows, err := s.readDB.QueryContext(ctx, `SELECT `+orchestrationColumns+` FROM orchestration_events
+ WHERE project_id=? AND attention_required_at IS NOT NULL AND state IN ('pending','dead_letter') ORDER BY enqueued_at,id`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanOrchestrationEvents(rows)
+}
+
 func (s *Store) RetryDeadLetterOrchestrationEvent(ctx context.Context, project domain.ProjectID, id string, now time.Time) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()

--- a/backend/internal/storage/sqlite/store/orchestration_event_store.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/gen"
+)
+
+const orchestrationColumns = `id, project_id, worker_id, kind, source_revision, state,
+ attempt_count, enqueued_at, next_attempt_at, lease_token, lease_expires_at,
+ destination_session_id, submitted_at, acknowledged_at, last_error`
+
+func (s *Store) EnqueueOrchestrationEvent(ctx context.Context, e domain.OrchestrationEvent) (bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	result, err := s.writeDB.ExecContext(ctx, `INSERT INTO orchestration_events
+ (id,project_id,worker_id,kind,source_revision,enqueued_at,next_attempt_at)
+ VALUES (?,?,?,?,?,?,?) ON CONFLICT(project_id,worker_id,kind,source_revision) DO NOTHING`,
+		e.ID, e.ProjectID, e.WorkerID, e.Kind, e.SourceRevision, e.EnqueuedAt, e.NextAttemptAt)
+	if err != nil {
+		return false, fmt.Errorf("enqueue orchestration event: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	return rows == 1, err
+}
+
+func (s *Store) ReclaimOrchestrationEventLeases(ctx context.Context, now time.Time) (int64, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	result, err := s.writeDB.ExecContext(ctx, `UPDATE orchestration_events SET state='pending',
+ lease_token=NULL,lease_expires_at=NULL,destination_session_id=NULL,next_attempt_at=?
+ WHERE state IN ('leased','submitted') AND lease_expires_at<=?`, now, now)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+func (s *Store) ListDueOrchestrationEvents(ctx context.Context, project domain.ProjectID, now time.Time, limit int) ([]domain.OrchestrationEvent, error) {
+	rows, err := s.readDB.QueryContext(ctx, `SELECT `+orchestrationColumns+` FROM orchestration_events
+ WHERE project_id=? AND state='pending' AND next_attempt_at<=? ORDER BY enqueued_at,id LIMIT ?`, project, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanOrchestrationEvents(rows)
+}
+
+func (s *Store) LeaseOrchestrationEvents(ctx context.Context, ids []string, token string, destination domain.SessionID, expires time.Time) error {
+	return s.updateOrchestrationBatch(ctx, "lease orchestration events", ids, func(db gen.DBTX, id string) (sql.Result, error) {
+		return db.ExecContext(ctx, `UPDATE orchestration_events SET state='leased',lease_token=?,lease_expires_at=?,destination_session_id=? WHERE id=? AND state='pending'`, token, expires, destination, id)
+	})
+}
+
+func (s *Store) MarkOrchestrationEventsSubmitted(ctx context.Context, ids []string, token string, at time.Time) error {
+	return s.updateOrchestrationBatch(ctx, "submit orchestration events", ids, func(db gen.DBTX, id string) (sql.Result, error) {
+		return db.ExecContext(ctx, `UPDATE orchestration_events SET state='submitted',submitted_at=? WHERE id=? AND state='leased' AND lease_token=?`, at, id, token)
+	})
+}
+
+func (s *Store) AcknowledgeOrchestrationEvents(ctx context.Context, ids []string, token string, at time.Time) error {
+	return s.updateOrchestrationBatch(ctx, "acknowledge orchestration events", ids, func(db gen.DBTX, id string) (sql.Result, error) {
+		return db.ExecContext(ctx, `UPDATE orchestration_events SET state='acknowledged',acknowledged_at=?,lease_token=NULL,lease_expires_at=NULL,last_error='' WHERE id=? AND state IN ('leased','submitted') AND lease_token=?`, at, id, token)
+	})
+}
+
+func (s *Store) RetryOrchestrationEvents(ctx context.Context, events []domain.OrchestrationEvent, token, message string, now time.Time) error {
+	if len(message) > 512 {
+		message = message[:512]
+	}
+	byID := map[string]domain.OrchestrationEvent{}
+	ids := make([]string, len(events))
+	for i, e := range events {
+		ids[i] = e.ID
+		byID[e.ID] = e
+	}
+	return s.updateOrchestrationBatch(ctx, "retry orchestration events", ids, func(db gen.DBTX, id string) (sql.Result, error) {
+		e := byID[id]
+		attempt := e.AttemptCount + 1
+		state := domain.OrchestrationPending
+		if attempt >= 8 || now.Sub(e.EnqueuedAt) >= 15*time.Minute {
+			state = domain.OrchestrationDeadLetter
+		}
+		backoff := time.Second << min(attempt-1, 5)
+		if backoff > time.Minute {
+			backoff = time.Minute
+		}
+		return db.ExecContext(ctx, `UPDATE orchestration_events SET state=?,attempt_count=attempt_count+1,next_attempt_at=?,lease_token=NULL,lease_expires_at=NULL,last_error=? WHERE id=? AND state IN ('leased','submitted') AND lease_token=? AND attempt_count<8`, state, now.Add(backoff), message, id, token)
+	})
+}
+
+func (s *Store) updateOrchestrationBatch(ctx context.Context, what string, ids []string, update func(gen.DBTX, string) (sql.Result, error)) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.inTxDB(ctx, what, func(_ *gen.Queries, db gen.DBTX) error {
+		for _, id := range ids {
+			result, err := update(db, id)
+			if err != nil {
+				return err
+			}
+			rows, err := result.RowsAffected()
+			if err != nil {
+				return err
+			}
+			if rows != 1 {
+				return fmt.Errorf("event %s failed state fence", id)
+			}
+		}
+		return nil
+	})
+}
+
+type rowScanner interface{ Scan(...any) error }
+
+func scanOrchestrationEvent(row rowScanner) (domain.OrchestrationEvent, error) {
+	var e domain.OrchestrationEvent
+	var project, worker, kind, state string
+	var lease, destination, lastError sql.NullString
+	var leaseExpiry, submitted, ack sql.NullTime
+	err := row.Scan(&e.ID, &project, &worker, &kind, &e.SourceRevision, &state, &e.AttemptCount, &e.EnqueuedAt, &e.NextAttemptAt, &lease, &leaseExpiry, &destination, &submitted, &ack, &lastError)
+	e.ProjectID = domain.ProjectID(project)
+	e.WorkerID = domain.SessionID(worker)
+	e.Kind = domain.OrchestrationEventKind(kind)
+	e.State = domain.OrchestrationDeliveryState(state)
+	e.LeaseToken = lease.String
+	e.LeaseExpiresAt = leaseExpiry.Time
+	e.DestinationSessionID = domain.SessionID(destination.String)
+	e.SubmittedAt = submitted.Time
+	e.AcknowledgedAt = ack.Time
+	e.LastError = strings.TrimSpace(lastError.String)
+	return e, err
+}
+func scanOrchestrationEvents(rows *sql.Rows) ([]domain.OrchestrationEvent, error) {
+	var out []domain.OrchestrationEvent
+	for rows.Next() {
+		e, err := scanOrchestrationEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
@@ -228,3 +228,45 @@ func TestOrchestrationRetryDeadLettersAndRequiresMatchingProjectForRearm(t *test
 		t.Fatalf("rearmed events=%+v err=%v", events, err)
 	}
 }
+
+func TestOrchestrationMissingDestinationAttentionAndRetentionAreDurableAndDeduplicated(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, e := range []domain.OrchestrationEvent{
+		{ID: "attention", ProjectID: "p", WorkerID: w.ID, Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "a", EnqueuedAt: now.Add(-16 * time.Minute), NextAttemptAt: now},
+		{ID: "expired", ProjectID: "p", WorkerID: w.ID, Kind: domain.OrchestrationWorkerTurnSettled, SourceRevision: "b", EnqueuedAt: now.Add(-31 * 24 * time.Hour), NextAttemptAt: now},
+	} {
+		if ok, err := s.EnqueueOrchestrationEvent(ctx, e); err != nil || !ok {
+			t.Fatalf("enqueue %s=%v err=%v", e.ID, ok, err)
+		}
+	}
+	if n, err := s.MarkProjectNoDestinationAttention(ctx, "p", now); err != nil || n != 2 {
+		t.Fatalf("first attention=%d err=%v", n, err)
+	}
+	if n, err := s.MarkProjectNoDestinationAttention(ctx, "p", now.Add(time.Minute)); err != nil || n != 0 {
+		t.Fatalf("deduplicated attention=%d err=%v", n, err)
+	}
+	if n, err := s.MarkOrchestrationRetentionOverflow(ctx, now); err != nil || n != 1 {
+		t.Fatalf("retention=%d err=%v", n, err)
+	}
+	events, err := s.ListOrchestrationEvents(ctx, "p", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]domain.OrchestrationEvent{}
+	for _, event := range events {
+		byID[event.ID] = event
+	}
+	if byID["expired"].State != domain.OrchestrationDeadLetter || byID["expired"].LastError != "retention limit exceeded" {
+		t.Fatalf("expired=%+v", byID["expired"])
+	}
+	if byID["attention"].State != domain.OrchestrationPending || byID["attention"].AttemptCount != 0 || byID["attention"].AttentionRequiredAt.IsZero() {
+		t.Fatalf("attention=%+v", byID["attention"])
+	}
+}

--- a/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
@@ -91,3 +91,39 @@ func TestOrchestrationEventStoreRestartReclaimsExpiredLease(t *testing.T) {
 		t.Fatalf("due=%v err=%v", due, err)
 	}
 }
+
+func TestOrchestrationEventStoreTUIAcknowledgesOnlyExactDestinationAndBatch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := sampleRecord("p")
+	o.Kind = domain.KindOrchestrator
+	o, err = s.CreateSession(ctx, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	e := domain.OrchestrationEvent{ID: "e", ProjectID: "p", WorkerID: w.ID, Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "r", EnqueuedAt: now, NextAttemptAt: now}
+	if ok, err := s.EnqueueOrchestrationEvent(ctx, e); err != nil || !ok {
+		t.Fatal(err)
+	}
+	if err := s.LeaseOrchestrationEvents(ctx, []string{"e"}, "batch", o.ID, now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkOrchestrationEventsSubmitted(ctx, []string{"e"}, "batch", now); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := s.AcknowledgeOrchestrationBatchAccepted(ctx, o.ID, "wrong", now); err != nil || n != 0 {
+		t.Fatalf("wrong token n=%d err=%v", n, err)
+	}
+	if n, err := s.AcknowledgeOrchestrationBatchAccepted(ctx, "other", "batch", now); err != nil || n != 0 {
+		t.Fatalf("wrong destination n=%d err=%v", n, err)
+	}
+	if n, err := s.AcknowledgeOrchestrationBatchAccepted(ctx, o.ID, "batch", now); err != nil || n != 1 {
+		t.Fatalf("exact acknowledgement n=%d err=%v", n, err)
+	}
+}

--- a/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
@@ -127,3 +127,34 @@ func TestOrchestrationEventStoreTUIAcknowledgesOnlyExactDestinationAndBatch(t *t
 		t.Fatalf("exact acknowledgement n=%d err=%v", n, err)
 	}
 }
+
+func TestOrchestrationSourceStateDedupesAndRearmsSCMTransition(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	created, err := s.RecordOrchestrationSourceState(ctx, "p", w.ID, domain.OrchestrationWorkerReadyMerge, "https://example.invalid/pr/1", true, now)
+	if err != nil || !created {
+		t.Fatalf("first created=%v err=%v", created, err)
+	}
+	for i := 0; i < 100; i++ {
+		created, err = s.RecordOrchestrationSourceState(ctx, "p", w.ID, domain.OrchestrationWorkerReadyMerge, "https://example.invalid/pr/1", true, now.Add(time.Duration(i)*time.Second))
+		if err != nil || created {
+			t.Fatalf("repeat %d created=%v err=%v", i, created, err)
+		}
+	}
+	if created, err = s.RecordOrchestrationSourceState(ctx, "p", w.ID, domain.OrchestrationWorkerReadyMerge, "https://example.invalid/pr/1", false, now.Add(time.Minute)); err != nil || created {
+		t.Fatalf("clear created=%v err=%v", created, err)
+	}
+	if created, err = s.RecordOrchestrationSourceState(ctx, "p", w.ID, domain.OrchestrationWorkerReadyMerge, "https://example.invalid/pr/1", true, now.Add(2*time.Minute)); err != nil || !created {
+		t.Fatalf("rearm created=%v err=%v", created, err)
+	}
+	events, err := s.ListOrchestrationEvents(ctx, "p", 10)
+	if err != nil || len(events) != 2 || events[0].SourceRevision == events[1].SourceRevision {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+}

--- a/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
@@ -158,3 +158,73 @@ func TestOrchestrationSourceStateDedupesAndRearmsSCMTransition(t *testing.T) {
 		t.Fatalf("events=%+v err=%v", events, err)
 	}
 }
+
+func TestActivityAndOutboxCommitRollsBackOnInjectedInsertFailure(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, ok, err := s.GetSession(ctx, w.ID)
+	if err != nil || !ok {
+		t.Fatal(err)
+	}
+	next := before
+	now := time.Now().UTC().Truncate(time.Second)
+	next.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}
+	next.UpdatedAt = now
+	event := domain.OrchestrationEvent{ID: "e", ProjectID: "p", WorkerID: w.ID, Kind: "invalid_kind", SourceRevision: "r", EnqueuedAt: now, NextAttemptAt: now}
+	if _, err := s.CommitActivityAndOrchestrationEvent(ctx, next, event); err == nil {
+		t.Fatal("invalid event insert succeeded")
+	}
+	after, ok, err := s.GetSession(ctx, w.ID)
+	if err != nil || !ok {
+		t.Fatal(err)
+	}
+	if after.Activity.State != before.Activity.State || !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Fatalf("source fact escaped rollback: before=%+v after=%+v", before.Activity, after.Activity)
+	}
+}
+
+func TestOrchestrationRetryDeadLettersAndRequiresMatchingProjectForRearm(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := sampleRecord("p")
+	o.Kind = domain.KindOrchestrator
+	o, err = s.CreateSession(ctx, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	e := domain.OrchestrationEvent{ID: "e", ProjectID: "p", WorkerID: w.ID, Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "r", EnqueuedAt: now.Add(-16 * time.Minute), NextAttemptAt: now}
+	if ok, err := s.EnqueueOrchestrationEvent(ctx, e); err != nil || !ok {
+		t.Fatalf("enqueue=%v err=%v", ok, err)
+	}
+	if err := s.LeaseOrchestrationEvents(ctx, []string{"e"}, "batch", o.ID, now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RetryOrchestrationEvents(ctx, []domain.OrchestrationEvent{e}, "batch", "transient secret\nerror", now); err != nil {
+		t.Fatal(err)
+	}
+	events, err := s.ListOrchestrationEvents(ctx, "p", 10)
+	if err != nil || len(events) != 1 || events[0].State != domain.OrchestrationDeadLetter || events[0].AttentionRequiredAt.IsZero() {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+	if changed, err := s.RetryDeadLetterOrchestrationEvent(ctx, "other", "e", now); err != nil || changed {
+		t.Fatalf("cross-project changed=%v err=%v", changed, err)
+	}
+	if changed, err := s.RetryDeadLetterOrchestrationEvent(ctx, "p", "e", now); err != nil || !changed {
+		t.Fatalf("matching project changed=%v err=%v", changed, err)
+	}
+	events, err = s.ListOrchestrationEvents(ctx, "p", 10)
+	if err != nil || events[0].State != domain.OrchestrationPending || events[0].AttemptCount != 0 || !events[0].AttentionRequiredAt.IsZero() {
+		t.Fatalf("rearmed events=%+v err=%v", events, err)
+	}
+}

--- a/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
@@ -1,0 +1,93 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestOrchestrationEventStoreDedupeRearmLeaseAndAcknowledge(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	worker, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	orchestrator := sampleRecord("p")
+	orchestrator.Kind = domain.KindOrchestrator
+	orchestrator, err = s.CreateSession(ctx, orchestrator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	event := domain.OrchestrationEvent{ID: "e1", ProjectID: "p", WorkerID: worker.ID, Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "revision-1", EnqueuedAt: now, NextAttemptAt: now}
+	inserted, err := s.EnqueueOrchestrationEvent(ctx, event)
+	if err != nil || !inserted {
+		t.Fatalf("inserted=%v err=%v", inserted, err)
+	}
+	event.ID = "duplicate"
+	inserted, err = s.EnqueueOrchestrationEvent(ctx, event)
+	if err != nil || inserted {
+		t.Fatalf("duplicate inserted=%v err=%v", inserted, err)
+	}
+	event.ID = "e2"
+	event.SourceRevision = "revision-2"
+	inserted, err = s.EnqueueOrchestrationEvent(ctx, event)
+	if err != nil || !inserted {
+		t.Fatalf("rearm inserted=%v err=%v", inserted, err)
+	}
+	due, err := s.ListDueOrchestrationEvents(ctx, "p", now, 50)
+	if err != nil || len(due) != 2 {
+		t.Fatalf("due=%v err=%v", due, err)
+	}
+	ids := []string{due[0].ID, due[1].ID}
+	if err := s.LeaseOrchestrationEvents(ctx, ids, "batch", orchestrator.ID, now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkOrchestrationEventsSubmitted(ctx, ids, "batch", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AcknowledgeOrchestrationEvents(ctx, ids, "wrong", now); err == nil {
+		t.Fatal("wrong lease token acknowledged")
+	}
+	if err := s.AcknowledgeOrchestrationEvents(ctx, ids, "batch", now); err != nil {
+		t.Fatal(err)
+	}
+	if due, err = s.ListDueOrchestrationEvents(ctx, "p", now.Add(time.Hour), 50); err != nil || len(due) != 0 {
+		t.Fatalf("acknowledged due=%v err=%v", due, err)
+	}
+}
+
+func TestOrchestrationEventStoreRestartReclaimsExpiredLease(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, err := s.CreateSession(ctx, sampleRecord("p"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := sampleRecord("p")
+	o.Kind = domain.KindOrchestrator
+	o, err = s.CreateSession(ctx, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	e := domain.OrchestrationEvent{ID: "e", ProjectID: "p", WorkerID: w.ID, Kind: domain.OrchestrationWorkerTurnSettled, SourceRevision: "r", EnqueuedAt: now, NextAttemptAt: now}
+	if ok, err := s.EnqueueOrchestrationEvent(ctx, e); err != nil || !ok {
+		t.Fatal(err)
+	}
+	if err := s.LeaseOrchestrationEvents(ctx, []string{"e"}, "batch", o.ID, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if count, err := s.ReclaimOrchestrationEventLeases(ctx, now.Add(2*time.Second)); err != nil || count != 1 {
+		t.Fatalf("reclaimed=%d err=%v", count, err)
+	}
+	due, err := s.ListDueOrchestrationEvents(ctx, "p", now.Add(2*time.Second), 50)
+	if err != nil || len(due) != 1 {
+		t.Fatalf("due=%v err=%v", due, err)
+	}
+}

--- a/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
@@ -6,7 +6,19 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/orchestrationevents"
 )
+
+type synchronousAckTransport struct {
+	store interface {
+		AcknowledgeOrchestrationBatchAccepted(context.Context, domain.SessionID, string, time.Time) (int64, error)
+	}
+}
+
+func (t synchronousAckTransport) Submit(ctx context.Context, target domain.SessionRecord, batch orchestrationevents.Batch) (orchestrationevents.Submission, error) {
+	_, err := t.store.AcknowledgeOrchestrationBatchAccepted(ctx, target.ID, batch.ID, time.Now().UTC())
+	return orchestrationevents.Submission{Submitted: true}, err
+}
 
 func TestOrchestrationEventStoreDedupeRearmLeaseAndAcknowledge(t *testing.T) {
 	s := newTestStore(t)
@@ -125,6 +137,9 @@ func TestOrchestrationEventStoreTUIAcknowledgesOnlyExactDestinationAndBatch(t *t
 	}
 	if n, err := s.AcknowledgeOrchestrationBatchAccepted(ctx, o.ID, "batch", now); err != nil || n != 1 {
 		t.Fatalf("exact acknowledgement n=%d err=%v", n, err)
+	}
+	if err := s.MarkOrchestrationEventsSubmitted(ctx, []string{"e"}, "batch", now); err != nil {
+		t.Fatalf("early acknowledgement must make submitted marking idempotent: %v", err)
 	}
 }
 
@@ -268,5 +283,71 @@ func TestOrchestrationMissingDestinationAttentionAndRetentionAreDurableAndDedupl
 	}
 	if byID["attention"].State != domain.OrchestrationPending || byID["attention"].AttemptCount != 0 || byID["attention"].AttentionRequiredAt.IsZero() {
 		t.Fatalf("attention=%+v", byID["attention"])
+	}
+}
+
+func TestTerminatedEventReconciliationClosesCrashWindowAndRearmsPerLaunch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w := sampleRecord("p")
+	w.Metadata.RuntimeLaunchID = "launch-1"
+	w, err := s.CreateSession(ctx, w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.IsTerminated = true
+	w.Activity.State = domain.ActivityExited
+	w.UpdatedAt = time.Now().UTC()
+	if err := s.UpdateSession(ctx, w); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := s.ReconcileTerminatedOrchestrationEvents(ctx, w.UpdatedAt); err != nil || n != 1 {
+		t.Fatalf("first reconciliation=%d err=%v", n, err)
+	}
+	if n, err := s.ReconcileTerminatedOrchestrationEvents(ctx, w.UpdatedAt.Add(time.Second)); err != nil || n != 0 {
+		t.Fatalf("repeat reconciliation=%d err=%v", n, err)
+	}
+	w.IsTerminated = false
+	w.Metadata.RuntimeLaunchID = "launch-2"
+	w.UpdatedAt = w.UpdatedAt.Add(2 * time.Second)
+	if err := s.UpdateSession(ctx, w); err != nil {
+		t.Fatal(err)
+	}
+	w.IsTerminated = true
+	w.UpdatedAt = w.UpdatedAt.Add(time.Second)
+	if err := s.UpdateSession(ctx, w); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := s.ReconcileTerminatedOrchestrationEvents(ctx, w.UpdatedAt); err != nil || n != 1 {
+		t.Fatalf("second launch reconciliation=%d err=%v", n, err)
+	}
+	events, err := s.ListOrchestrationEvents(ctx, "p", 10)
+	if err != nil || len(events) != 2 {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+}
+
+func TestDispatcherAcceptsSynchronousTUIHookAcknowledgement(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "p")
+	w, _ := s.CreateSession(ctx, sampleRecord("p"))
+	o := sampleRecord("p")
+	o.Kind, o.Mode, o.FirstSignalAt = domain.KindOrchestrator, domain.SessionModeTUI, time.Now().UTC()
+	o.Activity.State = domain.ActivityIdle
+	o, _ = s.CreateSession(ctx, o)
+	now := time.Now().UTC()
+	e := domain.OrchestrationEvent{ID: "e-sync", ProjectID: "p", WorkerID: w.ID, Kind: domain.OrchestrationWorkerBlocked, SourceRevision: "r", EnqueuedAt: now, NextAttemptAt: now}
+	if ok, err := s.EnqueueOrchestrationEvent(ctx, e); err != nil || !ok {
+		t.Fatalf("enqueue=%v err=%v", ok, err)
+	}
+	dispatcher := orchestrationevents.Dispatcher{Store: s, Transport: synchronousAckTransport{store: s}, Now: func() time.Time { return now }, NewID: func() string { return "batch-sync" }}
+	if err := dispatcher.DispatchProject(ctx, "p"); err != nil {
+		t.Fatal(err)
+	}
+	events, err := s.ListOrchestrationEvents(ctx, "p", 10)
+	if err != nil || len(events) != 1 || events[0].State != domain.OrchestrationAcknowledged {
+		t.Fatalf("events=%+v err=%v", events, err)
 	}
 }

--- a/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
+++ b/backend/internal/storage/sqlite/store/orchestration_event_store_test.go
@@ -284,6 +284,10 @@ func TestOrchestrationMissingDestinationAttentionAndRetentionAreDurableAndDedupl
 	if byID["attention"].State != domain.OrchestrationPending || byID["attention"].AttemptCount != 0 || byID["attention"].AttentionRequiredAt.IsZero() {
 		t.Fatalf("attention=%+v", byID["attention"])
 	}
+	recoverable, err := s.ListOrchestrationEventsRequiringAttention(ctx, "p")
+	if err != nil || len(recoverable) != 2 {
+		t.Fatalf("recoverable attention=%+v err=%v", recoverable, err)
+	}
 }
 
 func TestTerminatedEventReconciliationClosesCrashWindowAndRearmsPerLaunch(t *testing.T) {

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -78,7 +78,37 @@ func (s *Store) UpdateSessionFromActivitySignal(ctx context.Context, rec domain.
 	activity := normalActivity(rec.Activity, rec.UpdatedAt)
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	rows, err := s.qw.UpdateSessionFromActivitySignal(ctx, gen.UpdateSessionFromActivitySignalParams{
+	rows, err := s.qw.UpdateSessionFromActivitySignal(ctx, activityUpdateParams(rec, activity))
+	if err != nil {
+		return false, fmt.Errorf("update session %s from activity signal: %w", rec.ID, err)
+	}
+	return rows > 0, nil
+}
+
+// CommitActivityAndOrchestrationEvent is the production atomic boundary for a
+// normalized lifecycle transition and its pending delivery row.
+func (s *Store) CommitActivityAndOrchestrationEvent(ctx context.Context, rec domain.SessionRecord, event domain.OrchestrationEvent) (bool, error) {
+	activity := normalActivity(rec.Activity, rec.UpdatedAt)
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	var applied bool
+	err := s.inTxDB(ctx, "commit activity and orchestration event", func(q *gen.Queries, db gen.DBTX) error {
+		rows, err := q.UpdateSessionFromActivitySignal(ctx, activityUpdateParams(rec, activity))
+		if err != nil || rows == 0 {
+			return err
+		}
+		applied = true
+		_, err = db.ExecContext(ctx, `INSERT INTO orchestration_events
+			(id,project_id,worker_id,kind,source_revision,enqueued_at,next_attempt_at)
+			VALUES (?,?,?,?,?,?,?) ON CONFLICT(project_id,worker_id,kind,source_revision) DO NOTHING`,
+			event.ID, event.ProjectID, event.WorkerID, event.Kind, event.SourceRevision, event.EnqueuedAt, event.NextAttemptAt)
+		return err
+	})
+	return applied, err
+}
+
+func activityUpdateParams(rec domain.SessionRecord, activity domain.Activity) gen.UpdateSessionFromActivitySignalParams {
+	return gen.UpdateSessionFromActivitySignalParams{
 		ActivityState:                activity.State,
 		ActivityLastAt:               activity.LastActivityAt,
 		FirstSignalAt:                timeToNullTime(rec.FirstSignalAt),
@@ -94,11 +124,7 @@ func (s *Store) UpdateSessionFromActivitySignal(ctx context.Context, rec domain.
 		ExpectedSessionMode:          domain.NormalizeSessionMode(rec.Mode),
 		ExpectedRuntimeLaunchID:      rec.Metadata.RuntimeLaunchID,
 		ExpectedControllerGeneration: rec.Metadata.ControllerGeneration,
-	})
-	if err != nil {
-		return false, fmt.Errorf("update session %s from activity signal: %w", rec.ID, err)
 	}
-	return rows > 0, nil
 }
 
 // RecordSessionLatestUserPrompt persists the latest real user direction without

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | Doc                                                    | What it covers                                                                                                        |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | [architecture.md](architecture.md)                     | Current backend model, package layout, status derivation, persistence/CDC, and load-bearing rules.                    |
+| [orchestration-events.md](orchestration-events.md)     | Durable normalized lifecycle events, acknowledged orchestrator delivery, retry policy, and rollback.                |
 | [scm-observer.md](scm-observer.md)                     | SCM subsystem: polling pipeline, durable-state invariants, PR identity model, and the rename/transfer design.         |
 | [backend-code-structure.md](backend-code-structure.md) | Package ownership rules for the Go backend: domain, services, ports, adapters, storage, HTTP, CLI, and daemon wiring. |
 | [cli/README.md](cli/README.md)                         | CLI commands and daemon control surface.                                                                              |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1043,9 +1043,15 @@ delivery.
 Transport attempts time out after five seconds and use persisted exponential
 backoff capped at one minute. Eight attempts or fifteen minutes moves a delivery
 to `dead_letter`; recovery is an explicit retry, not an endless timer. Missing
-destinations do not consume the transport budget. The dispatcher uses daemon
+destinations do not consume the transport budget. After fifteen minutes the
+event's `attentionRequiredAt` API field surfaces one durable operator alert;
+dead-letter transitions set the same field. The dispatcher uses daemon
 wakeups and cancellable due-time timers, never shell polling, cron, or a desktop
 client stream.
+
+Pending delivery retention is capped at 30 days and 10,000 rows per project.
+Overflow is retained as visible dead-letter state with `attentionRequiredAt`;
+it is never silently deleted.
 
 Upgrade from 0.12.10 adds the outbox without changing projects, sessions, or
 notifications. Startup reclaims expired leases before serving dispatch work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1019,6 +1019,40 @@ down Electron disables and discards the capture.
 
 ---
 
+## Orchestration event delivery
+
+AO records normalized lifecycle facts for daemon-owned delivery to the current
+project orchestrator. `worker_turn_settled` means only that the harness has no
+automatic continuation queued. It is never interpreted as task completion.
+Terminal and SCM outcomes use distinct event kinds and stable source revisions.
+
+The SQLite outbox deduplicates `(project, worker, kind, source_revision)` and
+tracks `pending -> leased -> submitted -> acknowledged`. Expired leases are
+reclaimed at daemon startup. Dispatch resolves the current orchestrator on every
+attempt and refuses blocked, waiting-input, exited, terminated, startup-pending,
+and input-gated destinations. Busy Chat controllers durably queue a single
+follow-up; busy TUI controllers defer until settled.
+
+Each machine-authored prompt carries at most 50 AO event identifiers or 32 KiB.
+It includes no provider title, comment, log, branch, transcript, environment, or
+credential and explicitly grants no authorization. Chat uses the batch id as a
+stable client-message id. A TUI submission remains unacknowledged until the
+matching lifecycle admission is observed, so a pane write alone never claims
+delivery.
+
+Transport attempts time out after five seconds and use persisted exponential
+backoff capped at one minute. Eight attempts or fifteen minutes moves a delivery
+to `dead_letter`; recovery is an explicit retry, not an endless timer. Missing
+destinations do not consume the transport budget. The dispatcher uses daemon
+wakeups and cancellable due-time timers, never shell polling, cron, or a desktop
+client stream.
+
+Upgrade from 0.12.10 adds the outbox without changing projects, sessions, or
+notifications. Startup reclaims expired leases before serving dispatch work.
+For rollback, stop the newer daemon before installing an older build; older
+builds ignore the additive table and pending rows resume when the newer build is
+restored. Do not manually drop or edit the outbox database.
+
 ## Load-Bearing Rules
 
 These rules are **load-bearing** — changing them breaks fundamental architectural assumptions:

--- a/docs/orchestration-events.md
+++ b/docs/orchestration-events.md
@@ -32,6 +32,14 @@ One turn carries at most 50 events or 32 KiB. Chat provider admission is an
 acknowledgement. A TUI pane write is only `submitted`; the exact matching
 prompt-submit lifecycle hook changes it to `acknowledged`.
 
+TUI automation is supported only for harnesses whose managed lifecycle hook can
+report the exact submitted prompt (`claude-code`, `codex`, `continue`, and
+`pi`). Other TUI harnesses fail closed before any pane write. Their delivery
+uses the bounded retry/dead-letter budget and raises an attention notification.
+This is an intentionally unsupported production path, not a
+claimed delivery mode. Chat controllers use their durable idempotent message
+transport and do not depend on a prompt-submit hook.
+
 Transport calls have a five-second deadline. Failures use persisted exponential
 backoff with bounded jitter and a 60-second maximum. Eight attempts or fifteen
 minutes results in `dead_letter`. An ambiguous TUI submission is retried
@@ -39,7 +47,9 @@ physically at most once. Missing destinations consume no transport attempts and
 set `attentionRequiredAt` after fifteen minutes. Either condition also creates
 one deduplicated `orchestration_attention` notification in Notification Center
 and the live notification stream. A later successful submission resolves it;
-the API timestamp is diagnostic state, not the human alert itself.
+the API timestamp is diagnostic state, not the human alert itself. Startup
+reconstructs any missing notification from that durable timestamp, including
+lease-expiry and retention dead letters, before dispatch recovery.
 
 Pending rows are capped at 30 days and 10,000 per project. Overflow is retained
 as visible dead-letter state rather than deleted. Inspect state with:
@@ -65,9 +75,12 @@ determine whether a destination can safely accept a turn.
 
 ## Upgrade and rollback
 
-Migration 0127 adds orchestration tables without changing projects, sessions,
-notifications, or conversations. Startup reclaims expired leases and scans due
-work independently of UI clients. Existing installations do not infer historic
+Migration 0128 adds orchestration tables without changing existing project,
+session, notification, or conversation rows. Migration 0129 extends the
+notification type constraint for the attention surface while preserving those
+rows and indexes. Startup reconstructs terminal events and attention alerts,
+reclaims expired leases, and scans due work independently of UI clients before
+the HTTP server reports healthy. Existing installations do not infer historic
 idle rows as completed tasks.
 
 For rollback, stop the newer daemon before installing an older build. Older

--- a/docs/orchestration-events.md
+++ b/docs/orchestration-events.md
@@ -36,7 +36,10 @@ Transport calls have a five-second deadline. Failures use persisted exponential
 backoff with bounded jitter and a 60-second maximum. Eight attempts or fifteen
 minutes results in `dead_letter`. An ambiguous TUI submission is retried
 physically at most once. Missing destinations consume no transport attempts and
-set `attentionRequiredAt` after fifteen minutes.
+set `attentionRequiredAt` after fifteen minutes. Either condition also creates
+one deduplicated `orchestration_attention` notification in Notification Center
+and the live notification stream. A later successful submission resolves it;
+the API timestamp is diagnostic state, not the human alert itself.
 
 Pending rows are capped at 30 days and 10,000 per project. Overflow is retained
 as visible dead-letter state rather than deleted. Inspect state with:

--- a/docs/orchestration-events.md
+++ b/docs/orchestration-events.md
@@ -1,0 +1,74 @@
+# Orchestration events
+
+AO starts project-orchestrator turns from normalized worker and SCM facts. The
+daemon owns the outbox, timers, destination lookup, safety checks, and
+acknowledgement. Electron, SSE clients, shell loops, cron, and agent-side
+extensions are not schedulers.
+
+## Semantics
+
+- `worker_turn_settled` means the harness has no queued automatic continuation.
+  It never means task completion.
+- `worker_blocked`, `worker_ready_to_merge`, `worker_terminated`, and
+  `pr_merged` are separate normalized facts.
+- Repeated observations deduplicate by project, worker, kind, and durable source
+  revision. SCM sources use a persisted generation so an exit and recurrence
+  re-arms delivery.
+
+The machine prompt contains only AO event IDs, enums, worker IDs, and source
+revisions. It excludes PR titles, comments, logs, branches, issue bodies,
+transcripts, environment values, and credentials. It identifies itself as
+automation, grants no permission, requests one fresh AO reconciliation, and
+then tells the orchestrator to end the turn.
+
+## Delivery policy
+
+AO resolves the current non-terminated orchestrator at every attempt. Blocked,
+waiting-input, exited, startup-pending, and input-gated sessions receive no
+write. A busy Chat orchestrator receives a durable queued follow-up using the
+batch ID as its client-message ID. A busy TUI orchestrator waits until idle.
+
+One turn carries at most 50 events or 32 KiB. Chat provider admission is an
+acknowledgement. A TUI pane write is only `submitted`; the exact matching
+prompt-submit lifecycle hook changes it to `acknowledged`.
+
+Transport calls have a five-second deadline. Failures use persisted exponential
+backoff with bounded jitter and a 60-second maximum. Eight attempts or fifteen
+minutes results in `dead_letter`. An ambiguous TUI submission is retried
+physically at most once. Missing destinations consume no transport attempts and
+set `attentionRequiredAt` after fifteen minutes.
+
+Pending rows are capped at 30 days and 10,000 per project. Overflow is retained
+as visible dead-letter state rather than deleted. Inspect state with:
+
+```text
+GET /api/v1/projects/{id}/orchestration-events?limit=100
+```
+
+Explicitly re-arm a dead letter with:
+
+```text
+POST /api/v1/projects/{id}/orchestration-events/{eventId}/retry
+```
+
+There is no endless automatic retry after dead-lettering.
+
+## Configuration
+
+The dispatcher is daemon-owned and enabled with lifecycle processing. There is
+no repository hook, polling script, or desktop-client setting. Existing session
+mode, lifecycle hooks, provider configuration, and the sessionguard input lease
+determine whether a destination can safely accept a turn.
+
+## Upgrade and rollback
+
+Migration 0127 adds orchestration tables without changing projects, sessions,
+notifications, or conversations. Startup reclaims expired leases and scans due
+work independently of UI clients. Existing installations do not infer historic
+idle rows as completed tasks.
+
+For rollback, stop the newer daemon before installing an older build. Older
+builds ignore the additive tables. They do not dispatch pending events or damage
+them; reinstalling the newer build resumes recovery. Do not manually edit or
+drop the outbox. Back up the normal AO data directory before manual database
+maintenance.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -912,7 +912,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/projects/{id}/permissions": {
+    "/api/v1/projects/{id}/orchestration-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List daemon orchestration delivery state */
+        get: operations["listOrchestrationEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{id}/orchestration-events/{eventId}/retry": {
         parameters: {
             query?: never;
             header?: never;
@@ -921,12 +938,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        post?: never;
+        /** Explicitly retry a dead-letter orchestration event */
+        post: operations["retryOrchestrationEvent"];
         delete?: never;
         options?: never;
         head?: never;
-        /** Remember project permissions for future sessions */
-        patch: operations["setProjectPermissions"];
+        patch?: never;
         trace?: never;
     };
     "/api/v1/projects/clone": {
@@ -2249,40 +2266,6 @@ export interface paths {
         patch: operations["renameShellTerminal"];
         trace?: never;
     };
-    "/api/v1/system/github-auth": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Check advisory GitHub CLI authentication without blocking startup */
-        get: operations["getGitHubAuthRequirement"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/system/github-auth/terminal": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Open a trusted terminal running the GitHub CLI login flow */
-        post: operations["openGitHubAuthTerminal"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/system/install/{target}": {
         parameters: {
             query?: never;
@@ -2906,8 +2889,6 @@ export interface components {
             group?: string;
             groupName?: string;
             name: string;
-            /** @enum {string} */
-            permissionMode?: "default" | "accept-edits" | "auto" | "bypass-permissions";
             value: string;
         };
         ConversationConfigOptionResponse: {
@@ -3349,6 +3330,9 @@ export interface components {
             unreadCount: number;
             unresolvedCount: number;
         };
+        ListOrchestrationEventsResponse: {
+            events: components["schemas"]["OrchestrationEventResponse"][];
+        };
         ListProjectsResponse: {
             projects: components["schemas"]["ProjectSummary"][];
         };
@@ -3506,6 +3490,29 @@ export interface components {
             sessionId?: string;
             /** @description Windows shell selector: auto, git-bash, pwsh, powershell, cmd, or a custom executable path. Ignored on macOS and Linux. */
             shell?: string;
+        };
+        OrchestrationEventResponse: {
+            /** Format: date-time */
+            acknowledgedAt?: null | string;
+            attemptCount: number;
+            /** Format: date-time */
+            attentionRequiredAt?: null | string;
+            destinationSessionId?: string;
+            /** Format: date-time */
+            enqueuedAt: string;
+            id: string;
+            kind: string;
+            lastError?: string;
+            /** Format: date-time */
+            leaseExpiresAt?: null | string;
+            /** Format: date-time */
+            nextAttemptAt: string;
+            projectId: string;
+            sourceRevision: string;
+            state: string;
+            /** Format: date-time */
+            submittedAt?: null | string;
+            workerId: string;
         };
         OrchestratorResponse: {
             id: string;
@@ -3685,6 +3692,9 @@ export interface components {
             resumeMode: "native" | "saved_prompt" | "fresh";
             session: components["schemas"]["ControllersSessionView"];
             sessionId: string;
+        };
+        RetryOrchestrationEventResponse: {
+            retried: boolean;
         };
         RetryTurnResponse: {
             providerTurnId?: string;
@@ -3945,11 +3955,6 @@ export interface components {
         SetProjectConfigInput: {
             config: components["schemas"]["ProjectConfig"];
         };
-        SetProjectPermissionsInput: {
-            /** @enum {string} */
-            permissions: "default" | "accept-edits" | "auto" | "bypass-permissions";
-            sourceHarness?: string;
-        };
         SetReviewActivityRequest: {
             /** @description Native reviewer session identifier used to resume its transcript. */
             agentSessionId?: string;
@@ -4155,7 +4160,7 @@ export interface components {
              * @description Stable requirement identifier.
              * @enum {string}
              */
-            id: "git" | "tmux" | "harness" | "gh" | "github-auth";
+            id: "git" | "tmux" | "harness" | "gh";
             /** @description Human-readable requirement name. */
             label: string;
             /** @description Whether this requirement blocks the overall Ready state. */
@@ -7172,9 +7177,11 @@ export interface operations {
             };
         };
     };
-    setProjectPermissions: {
+    listOrchestrationEvents: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+            };
             header?: never;
             path: {
                 /** @description Project identifier (registry key). */
@@ -7182,11 +7189,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SetProjectPermissionsInput"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description OK */
             200: {
@@ -7194,7 +7197,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ProjectResponse"];
+                    "application/json": components["schemas"]["ListOrchestrationEventsResponse"];
                 };
             };
             /** @description Bad Request */
@@ -7206,8 +7209,50 @@ export interface operations {
                     "application/json": components["schemas"]["APIError"];
                 };
             };
-            /** @description Not Found */
-            404: {
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    retryOrchestrationEvent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project identifier (registry key). */
+                id: string;
+                eventId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RetryOrchestrationEventResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7217,6 +7262,15 @@ export interface operations {
             };
             /** @description Internal Server Error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -12452,91 +12506,6 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Not Implemented */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-        };
-    };
-    getGitHubAuthRequirement: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SystemRequirement"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-            /** @description Not Implemented */
-            501: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["APIError"];
-                };
-            };
-        };
-    };
-    openGitHubAuthTerminal: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShellTerminalEnvelope"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -946,6 +946,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects/{id}/permissions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Remember project permissions for future sessions */
+        patch: operations["setProjectPermissions"];
+        trace?: never;
+    };
     "/api/v1/projects/clone": {
         parameters: {
             query?: never;
@@ -2266,6 +2283,40 @@ export interface paths {
         patch: operations["renameShellTerminal"];
         trace?: never;
     };
+    "/api/v1/system/github-auth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Check advisory GitHub CLI authentication without blocking startup */
+        get: operations["getGitHubAuthRequirement"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/system/github-auth/terminal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Open a trusted terminal running the GitHub CLI login flow */
+        post: operations["openGitHubAuthTerminal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/system/install/{target}": {
         parameters: {
             query?: never;
@@ -2889,6 +2940,8 @@ export interface components {
             group?: string;
             groupName?: string;
             name: string;
+            /** @enum {string} */
+            permissionMode?: "default" | "accept-edits" | "auto" | "bypass-permissions";
             value: string;
         };
         ConversationConfigOptionResponse: {
@@ -3955,6 +4008,11 @@ export interface components {
         SetProjectConfigInput: {
             config: components["schemas"]["ProjectConfig"];
         };
+        SetProjectPermissionsInput: {
+            /** @enum {string} */
+            permissions: "default" | "accept-edits" | "auto" | "bypass-permissions";
+            sourceHarness?: string;
+        };
         SetReviewActivityRequest: {
             /** @description Native reviewer session identifier used to resume its transcript. */
             agentSessionId?: string;
@@ -4160,7 +4218,7 @@ export interface components {
              * @description Stable requirement identifier.
              * @enum {string}
              */
-            id: "git" | "tmux" | "harness" | "gh";
+            id: "git" | "tmux" | "harness" | "gh" | "github-auth";
             /** @description Human-readable requirement name. */
             label: string;
             /** @description Whether this requirement blocks the overall Ready state. */
@@ -7271,6 +7329,60 @@ export interface operations {
             };
             /** @description Not Implemented */
             501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    setProjectPermissions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project identifier (registry key). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetProjectPermissionsInput"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -12506,6 +12618,91 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    getGitHubAuthRequirement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemRequirement"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    openGitHubAuthTerminal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShellTerminalEnvelope"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3471,7 +3471,7 @@ export interface components {
             target: components["schemas"]["NotificationTarget"];
             title: string;
             /** @enum {string} */
-            type: "needs_input" | "ready_to_merge" | "pr_merged" | "pr_closed_unmerged";
+            type: "needs_input" | "ready_to_merge" | "pr_merged" | "pr_closed_unmerged" | "orchestration_attention";
         };
         NotificationTarget: {
             /** @enum {string} */

--- a/frontend/src/main/notification-signals.test.ts
+++ b/frontend/src/main/notification-signals.test.ts
@@ -8,7 +8,7 @@ import {
 	type NotificationType,
 } from "./notification-signals";
 
-const ALL_TYPES: NotificationType[] = ["needs_input", "ready_to_merge", "pr_merged", "pr_closed_unmerged"];
+const ALL_TYPES: NotificationType[] = ["needs_input", "ready_to_merge", "pr_merged", "pr_closed_unmerged", "orchestration_attention"];
 
 describe("shouldToast", () => {
 	it("fires a toast for every backend notification type", () => {
@@ -28,6 +28,7 @@ describe("shouldSignalAttention", () => {
 	it("flashes the taskbar for the actionable types", () => {
 		expect(shouldSignalAttention("needs_input")).toBe(true);
 		expect(shouldSignalAttention("ready_to_merge")).toBe(true);
+		expect(shouldSignalAttention("orchestration_attention")).toBe(true);
 	});
 
 	it("does not flash the taskbar for informational PR outcomes", () => {

--- a/frontend/src/main/notification-signals.ts
+++ b/frontend/src/main/notification-signals.ts
@@ -9,7 +9,7 @@
  */
 
 /** The notification types defined by `backend/internal/domain/notification.go`. */
-export type NotificationType = "needs_input" | "ready_to_merge" | "pr_merged" | "pr_closed_unmerged";
+export type NotificationType = "needs_input" | "ready_to_merge" | "pr_merged" | "pr_closed_unmerged" | "orchestration_attention";
 
 /**
  * Whether to fire the Windows/Linux taskbar flash. Restricted to the
@@ -19,7 +19,7 @@ export type NotificationType = "needs_input" | "ready_to_merge" | "pr_merged" | 
  * The macOS dock bounce is deliberately NOT gated by this allowlist — every
  * notification bounces there, with urgency carried by {@link dockBounceType}.
  */
-const ATTENTION_TYPES: ReadonlySet<string> = new Set<NotificationType>(["needs_input", "ready_to_merge"]);
+const ATTENTION_TYPES: ReadonlySet<string> = new Set<NotificationType>(["needs_input", "ready_to_merge", "orchestration_attention"]);
 
 /** Whether this notification type should flash the Windows/Linux taskbar. */
 export function shouldSignalAttention(type: string | undefined): boolean {

--- a/frontend/src/renderer/lib/notifications.ts
+++ b/frontend/src/renderer/lib/notifications.ts
@@ -16,12 +16,12 @@ export const NOTIFICATION_PAGE_SIZE = 100;
 const EVENTSOURCE_CLOSED = 2;
 
 /**
- * Only these two kinds describe something still waiting on the user.
+ * These kinds describe something still waiting on the user or operator.
  * `pr_merged` / `pr_closed_unmerged` report something that already happened.
  * Mirrors NotificationType.NeedsResolution on the backend — used here only to
  * keep `unresolvedCount` accurate on the unread/all caches.
  */
-const UNRESOLVABLE_TYPES = new Set(["needs_input", "ready_to_merge"]);
+const UNRESOLVABLE_TYPES = new Set(["needs_input", "ready_to_merge", "orchestration_attention"]);
 
 type NotificationsQueryKey = typeof unreadNotificationsQueryKey | typeof recentNotificationsQueryKey;
 


### PR DESCRIPTION
Closes #4951. Related generation prerequisite: #4953.

## Summary

- Persist normalized AO-owned worker/SCM orchestration facts with stable revisions and transactional lifecycle enqueue.
- Dispatch daemon-owned, bounded reconciliation turns to the current safe orchestrator with explicit Chat/TUI acknowledgement.
- Recover terminal facts, expired leases, and missing human-visible attention alerts at startup; deduplicate/re-arm transitions and bound retries/dead letters/retention.
- Expose project-scoped delivery observability and explicit dead-letter retry APIs.
- Document behavior, configuration, supported modes, upgrade, and rollback.

Idle/agent-settled emits `worker_turn_settled`, never task completion. Payloads contain only AO-owned IDs/enums/revisions and explicitly grant no authorization. No Electron, SSE, shell-polling, cron, launchd, Pi-only extension, installed-app/database, or dew-app change is involved.

## AC-1..AC-22 evidence at `b83d27a94`

| AC | Evidence |
|---|---|
| 1 honest types | `TestNormalizedActivityEventNeverCallsIdleCompletion`; distinct settled, blocked, terminated, ready, and merged kinds. |
| 2 stable identity | `TestOrchestrationEventStoreDedupeRearmLeaseAndAcknowledge`, `TestOrchestrationSourceStateDedupesAndRearmsSCMTransition`; source ID hash plus persisted generation forms the revision. |
| 3 re-arm | `TestNormalizedActivityEventDedupesRepeatsAndRearmsTransitions`, `TestPRReadyOrchestrationUsesCanonicalReadiness`, `TestTerminatedEventReconciliationClosesCrashWindowAndRearmsPerLaunch`; terminal PR observations clear readiness before merged/closed handling. |
| 4 atomic/fault boundaries | `TestActivityAndOutboxCommitRollsBackOnInjectedInsertFailure`, `TestFaultBoundariesDoNotClaimUncommittedDelivery`, `TestDispatcherAcceptsSynchronousTUIHookAcknowledgement`; terminal mutation crash window is deterministically reconstructed. |
| 5 restart | `TestOrchestrationEventStoreRestartReclaimsExpiredLease`, `TestRecoverReclaimsBeforeSynchronousProjectDispatch`, terminal reconstruction and attention-recovery tests. Startup recovery runs before HTTP health. |
| 6 client independence | Dispatcher is wired only in the daemon and consumes store/timer/wake-channel inputs; no Electron dependency. |
| 7 reconnect independence | Dispatcher does not consume general or notification SSE. Durable Notification Center rows provide reconnect catch-up. |
| 8 real turn/timing | One-second cancellable daemon scan, immediate lifecycle wake channel, real Session Manager transport; Chat admission and Pi prompt-submit admission are explicit acknowledgements. Live provider wall-clock exercise is environment-limited and is not represented as a hermetic CI test. |
| 9 busy/burst | `TestBusyTUIDefersWhileBusyChatQueues`, `TestPromptIsBoundedAndExcludesUntrustedProviderText`; Chat queues by stable message ID, TUI waits for idle, and due work remains pending. |
| 10 safe deferral | `TestGuard_AutomationFailsClosedAtJITBoundary`, `TestSendAutomationTUIRechecksStateAndAcknowledgementCapability`, `TestUnsafeOrMissingDestinationPerformsNoWrite`; JIT lease/re-read covers blocked, waiting, active TUI, exited, terminated, startup, and input gate. |
| 11 replacement | `TestDispatchResolvesCurrentDestinationAndAcknowledgesAcceptedBatch`; store state fence records the current destination only. |
| 12 ambiguity | `TestSubmittedTUIBatchRemainsUnacknowledgedForRestartRecovery`, `TestDispatcherAcceptsSynchronousTUIHookAcknowledgement`, `TestHooks_PiPromptSubmitCarriesExactAutomationBatch`, exact token/destination fence tests; ambiguous TUI gets at most one physical retry, Chat reuses the client message ID. |
| 13 bounds | `TestPromptIsBoundedAndExcludesUntrustedProviderText`; 50 events/32 KiB, remainder stays pending. |
| 14 retry/dead letter | `TestTransportFailureRetriesAndSanitizesError`, `TestOrchestrationRetryDeadLettersAndRequiresMatchingProjectForRearm`; 5-second attempt, persisted capped exponential jitter, 8 attempts/15 minutes, durable attention. |
| 15 no destination | `TestAttentionNotificationIsCreatedOnceAndResolvedByDelivery`, `TestOrchestrationMissingDestinationAttentionAndRetentionAreDurableAndDeduplicated`; no attempt consumption, 15-minute alert, 30-day/10,000-row visible dead-letter retention. |
| 16 recovery | Project-scoped retry controller tests plus explicit store re-arm test; success resolves per-worker attention. |
| 17 injection boundary | `TestPromptIsBoundedAndExcludesUntrustedProviderText`, `TestOrchestrationBatchIDRequiresExactSafeMachinePrefix`; provider text, control sequences, logs, comments, and titles never enter payload. |
| 18 authorization | Machine-origin warning in the bounded payload plus automation-specific JIT guard; no permission-prompt approval or unsafe Enter path. |
| 19 observability | Project API/controller tests expose every required delivery field; `TestTransportErrorsPersistOnlyTypedCredentialSafeClass`; `orchestration_attention` is stored, streamed, rendered, deduplicated, resolved, and reconstructed after notification/publisher failure. |
| 20 no polling | Daemon channel plus cancellable Go timer only; repository inspection contains no shell watcher/cron/launchd loop. |
| 21 upgrade/rollback | Migrations 0128/0129 and migration tests preserve existing rows/indexes; synchronous startup recovery precedes HTTP health; official docs describe backup, downgrade, and reinstall recovery. |
| 22 modes/fail closed | Pi TUI hook-to-lifecycle exact acknowledgement, Chat stable-id acknowledgement, JIT mode safety, ambiguity/restart tests. Unsupported TUI harnesses fail before pane write and enter bounded alerting. |

## Supported and unsupported production paths

Chat controllers use durable idempotent provider admission. TUI automation is supported only for `claude-code`, `codex`, `continue`, and `pi`, whose managed hooks can report the exact submitted prompt. Every other TUI harness is intentionally unsupported: it fails closed before a pane write, retains the event, and reaches the bounded human-visible alert rather than claiming delivery. This policy is documented in `docs/orchestration-events.md`.

No live authenticated provider is available to the repository test harness, so AC-8's provider wall-clock observation is environment-limited; the production path below it (daemon scheduler -> Session Manager -> Chat idempotent admission or TUI exact hook acknowledgement) is covered at its real package boundaries. This limitation is not presented as green live-provider evidence.

## Verification

- PASS: `go test ./internal/orchestrationevents ./internal/lifecycle ./internal/storage/sqlite ./internal/storage/sqlite/store ./internal/httpd/... ./internal/daemon`
- PASS: focused Pi hook, Session Manager automation, and sessionguard JIT tests.
- PASS: `go test -race ./internal/orchestrationevents ./internal/lifecycle ./internal/storage/sqlite/store ./internal/daemon`
- PASS: `go build ./...`
- PASS on the prior API/frontend change: `npm run api`, frontend typecheck, and 34 focused notification tests.
- PASS on the prior change: targeted golangci-lint v2.12.2, 0 issues.

The full repository suite is **not claimed green**. Exact baseline/environment reproductions remain:

- `go test ./internal/session_manager`: tmux prerequisite wins before agent-binary assertions in `TestSpawn_RejectsMissingAgentBinary`, `TestSpawn_MissingBinaryPreservesNonEmptyScratchWorkspaceForRetry`, `TestSpawn_ValidatesBinaryAfterEnvPrefix`, and `TestSpawn_RejectsMissingBinaryAfterEnvPrefix` when the configured/bundled/system tmux is absent.
- `go test ./internal/cli`: tests contact the active local daemon and return HTTP 404/current-daemon behavior (`TestBrowserRequiresSessionAndValidWait` and spawn project-resolution cases).
- The earlier broad run also reproduces pre-existing Crush user-auth discovery and systemcheck real-tmux-vs-stub failures. These are baseline/environment exclusions, not weakened assertions or #4951 changes.

## sqlc prerequisite and security

This diff does not hand-edit generated sqlc artifacts. The pre-existing malformed `backend/sqlc.yaml`/generation drift is isolated in #4953 (related #4621); handwritten transactions follow the store's existing locked `inTxDB` convention and generated schema contracts are not bypassed.

Wake payloads exclude provider-controlled text and secrets. Persisted transport failures are typed (`transport_timeout`, `transport_cancelled`, `transport_error`) rather than raw errors. API/log tests cover credential-bearing URLs, bearer/API-key-shaped values, control characters, and transcripts. The daemon remains loopback-only; this PR adds no new network trust boundary.
