### PR TITLE
fix(cloud): stop archived projects reserving their repository URL

### DIFF
--- a/cloud/internal/httpapi/transport.go
+++ b/cloud/internal/httpapi/transport.go
@@ -72,6 +72,11 @@ func (s *Server) writeStoreError(w http.ResponseWriter, r *http.Request, err err
 		writeError(w, r, http.StatusConflict, "STALE_TURN", "The turn is owned by another worker attempt.")
 	case errors.Is(err, postgres.ErrInvalid):
 		writeError(w, r, http.StatusUnprocessableEntity, "validation_error", "The request violates a resource constraint.")
+	case errors.Is(err, postgres.ErrProjectRepositoryExists):
+		writeError(
+			w, r, http.StatusConflict, "PROJECT_REPOSITORY_EXISTS",
+			"This organization already has a project for that repository.",
+		)
 	case errors.Is(err, postgres.ErrIdempotencyMismatch):
 		writeError(w, r, http.StatusConflict, "IDEMPOTENCY_CONFLICT", "The idempotency key was already used for another request.")
 	case errors.Is(err, postgres.ErrSandboxQuotaExceeded):

--- a/cloud/internal/postgres/github_store.go
+++ b/cloud/internal/postgres/github_store.go
@@ -1020,7 +1020,7 @@ func (s *Store) CreateGitHubProject(
 			return ErrForbidden
 		}
 		if err != nil {
-			return normalizeConstraintError(err)
+			return normalizeProjectConstraintError(err)
 		}
 		if _, err := tx.Exec(
 			ctx,

--- a/cloud/internal/postgres/migrations/00032_project_repository_url_active_uniqueness.sql
+++ b/cloud/internal/postgres/migrations/00032_project_repository_url_active_uniqueness.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+
+-- Deleting a project archives its row (00013) so session history, events and the
+-- audit trail survive it. The founding schema's UNIQUE (org_id, repository_url)
+-- predates archiving and still counts archived rows, so a deleted project kept
+-- its repository URL reserved forever: creating a new project for that
+-- repository failed with a conflict that no visible project explained, and the
+-- URL could never be used again in that organization.
+--
+-- Scope the rule to live projects, the way ao_org_invitations_pending_email_key
+-- already scopes uniqueness to pending invitations. One active project per
+-- repository per organization still holds; archived rows no longer reserve it.
+ALTER TABLE ao_projects
+    DROP CONSTRAINT IF EXISTS ao_projects_org_id_repository_url_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ao_projects_org_active_repository_url_key
+    ON ao_projects(org_id, repository_url)
+    WHERE archived_at IS NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS ao_projects_org_active_repository_url_key;
+
+-- Restoring the original constraint requires that no organization holds both an
+-- archived and a live project for the same repository, which this migration
+-- deliberately allows. Resolve any such pair before rolling back.
+ALTER TABLE ao_projects
+    ADD CONSTRAINT ao_projects_org_id_repository_url_key UNIQUE (org_id, repository_url);

--- a/cloud/internal/postgres/project_session_store.go
+++ b/cloud/internal/postgres/project_session_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
 	"github.com/aoagents/agent-orchestrator/cloud/internal/sandbox"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 func (s *Store) CreateProject(
@@ -71,7 +72,7 @@ func (s *Store) CreateProject(
 			config,
 		), &project)
 		if err != nil {
-			return normalizeConstraintError(err)
+			return normalizeProjectConstraintError(err)
 		}
 		if _, err := tx.Exec(
 			ctx,
@@ -483,7 +484,7 @@ func (s *Store) CreateGitHubScratchProject(
 			return ErrForbidden
 		}
 		if err != nil {
-			return normalizeConstraintError(err)
+			return normalizeProjectConstraintError(err)
 		}
 		input.Session.ProjectID = project.ID
 		input.Session.Kind = "orchestrator"
@@ -874,6 +875,24 @@ func getSession(
 
 type scanner interface {
 	Scan(dest ...any) error
+}
+
+// activeProjectRepositoryIndex is the partial unique index that keeps one live
+// project per repository per organization (migration 00032). Archived projects
+// are outside it, so a deleted project no longer reserves its repository URL.
+const activeProjectRepositoryIndex = "ao_projects_org_active_repository_url_key"
+
+// normalizeProjectConstraintError names the one project conflict a caller can
+// act on, so the API can say which repository is taken instead of reporting an
+// unexplained conflict. Every other violation keeps the generic mapping.
+func normalizeProjectConstraintError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) &&
+		pgErr.Code == "23505" &&
+		pgErr.ConstraintName == activeProjectRepositoryIndex {
+		return ErrProjectRepositoryExists
+	}
+	return normalizeConstraintError(err)
 }
 
 func scanProject(row scanner, project *domain.Project) error {

--- a/cloud/internal/postgres/project_session_store_test.go
+++ b/cloud/internal/postgres/project_session_store_test.go
@@ -1,0 +1,65 @@
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestNormalizeProjectConstraintError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "live repository index reports the project conflict",
+			err:  &pgconn.PgError{Code: "23505", ConstraintName: activeProjectRepositoryIndex},
+			want: ErrProjectRepositoryExists,
+		},
+		{
+			name: "wrapped violation is still recognized",
+			err:  fmt.Errorf("insert project: %w", &pgconn.PgError{Code: "23505", ConstraintName: activeProjectRepositoryIndex}),
+			want: ErrProjectRepositoryExists,
+		},
+		{
+			// Only the repository index carries an actionable message; every
+			// other unique violation stays a generic conflict.
+			name: "another unique violation stays generic",
+			err:  &pgconn.PgError{Code: "23505", ConstraintName: "ao_commands_org_id_idempotency_key_key"},
+			want: ErrConflict,
+		},
+		{
+			name: "check violation keeps its own mapping",
+			err:  &pgconn.PgError{Code: "23514", ConstraintName: "ao_projects_display_name_check"},
+			want: ErrInvalid,
+		},
+		{
+			name: "foreign key violation keeps its own mapping",
+			err:  &pgconn.PgError{Code: "23503", ConstraintName: "ao_projects_org_id_fkey"},
+			want: ErrNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeProjectConstraintError(tc.err); !errors.Is(got, tc.want) {
+				t.Fatalf("normalizeProjectConstraintError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeProjectConstraintErrorPassesThroughUnknownErrors(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("connection reset")
+	if got := normalizeProjectConstraintError(sentinel); !errors.Is(got, sentinel) {
+		t.Fatalf("normalizeProjectConstraintError() = %v, want %v", got, sentinel)
+	}
+}

--- a/cloud/internal/postgres/store.go
+++ b/cloud/internal/postgres/store.go
@@ -20,6 +20,9 @@ var (
 	ErrWorkerUnavailable    = errors.New("worker unavailable")
 	ErrTransportExpired     = errors.New("worker request expired")
 	ErrWorkspaceReadOnly    = errors.New("workspace is read-only")
+	// ErrProjectRepositoryExists is the one project conflict a caller can act
+	// on: the organization already has a live project for that repository.
+	ErrProjectRepositoryExists = errors.New("organization already has a project for this repository")
 )
 
 type Store struct {


### PR DESCRIPTION
## What

Deleting a cloud project no longer reserves its repository URL. A repository whose project was deleted can be used for a new project again, while one active project per repository per organization still holds.

## Why

Fixes #4971.

Two migrations disagreed about what deletion means.

`00001_founding_schema.sql:150` created the table when deletion still removed the row, so its rule covered every row:

```sql
UNIQUE (org_id, repository_url)
```

`00013_project_archival.sql` then made deletion an archive, so session history, events and the audit trail survive it. It scoped the listing index to live rows but left the uniqueness rule counting archived ones:

```sql
ADD COLUMN archived_at TIMESTAMPTZ;
CREATE INDEX ao_projects_org_active_created_idx ... WHERE archived_at IS NULL;
```

`ArchiveProject` keeps the row, so a deleted project held its repository URL for good. Creating a project for that repository failed with a conflict that no visible project explained, and the URL was unusable in that organization from then on. All three creation paths share the constraint: plain create, GitHub project, and GitHub scratch.

## How

Scope the rule to live projects with a partial unique index, the way `ao_org_invitations_pending_email_key` already scopes uniqueness to pending invitations:

```sql
ALTER TABLE ao_projects DROP CONSTRAINT IF EXISTS ao_projects_org_id_repository_url_key;

CREATE UNIQUE INDEX IF NOT EXISTS ao_projects_org_active_repository_url_key
    ON ao_projects(org_id, repository_url)
    WHERE archived_at IS NULL;
```

The conflict a caller can still hit now names itself. Creating a second live project for a repository returns `PROJECT_REPOSITORY_EXISTS` with a message that says which rule was hit, following the shape `SANDBOX_QUOTA_EXCEEDED` already uses, rather than the generic conflict envelope that gave the user nothing to act on.

Notes for reviewers:

- Only that one violation is special-cased. `normalizeProjectConstraintError` matches the index by name and defers to `normalizeConstraintError` for everything else, so other unique, check and foreign-key violations keep their existing mapping.
- `UpdateProject` is deliberately left on the generic path: it accepts only `displayName` and `defaultBranch`, so it cannot reach this constraint.
- Nothing depended on the dropped constraint. No foreign key references it (all three reference `ao_projects(org_id, id)`, which is untouched), no `ON CONFLICT` targets it, `repository_url` is never used as a lookup key, no caller branches on `ErrConflict`, and no client branches on the error `code`. The spec needs no change either: `ErrorEnvelope.code` is a free-form string and the other specific codes are not enumerated there.
- The index cannot fail to build on an existing database, because the constraint it replaces was strictly broader.
- The fix is retroactive and needs no data cleanup: every repository URL that an archived project is holding today becomes available again the moment the migration runs, with no backfill and no manual intervention.
- The down migration restores the original constraint, which requires that no organization holds both an archived and a live project for the same repository. That is a state this migration deliberately allows, so the comment says to resolve such pairs before rolling back.

## Testing

```
cd cloud
go build ./... && go vet ./... && gofmt -l .     clean
go test -race ./...                              pass
```

`normalizeProjectConstraintError` is covered by a table test: the live repository index reports the project conflict, wrapped errors are still recognized, and other unique, check and foreign-key violations plus unknown errors keep their existing mapping. There is no PostgreSQL harness in this module to hang a store-level test on, so the schema behavior was verified against a running control plane instead.

Verified end to end on Linux against `npm run cloud:local` (docker sandbox provider).

Before the migration:

```
create project for octocat/Spoon-Knife   201
delete it                                202
create again, same URL                   409 conflict
                                         "The resource conflicts with an existing record."
```

After the migration, the same URL, still held by archived rows:

```
create again, same URL                   201

display_name | repository_url                         | state
before-test  | https://github.com/octocat/Spoon-Knife | archived
after-fix    | https://github.com/octocat/Spoon-Knife | archived
reuse-test   | https://github.com/octocat/Spoon-Knife | LIVE
```

The rule still holds, and now explains itself:

```
create a second live project, same URL   409 PROJECT_REPOSITORY_EXISTS
                                         "This organization already has a project for that repository."
```

The last two were driven through the desktop app's New cloud project dialog, not only the API.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)

