### PR TITLE
fix(codex): preserve explicit model selection

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -318,9 +318,14 @@ func (c *conversation) ListModels(ctx context.Context) ([]ports.ChatModel, error
 	}
 	// Thread settings include the user's config; model/list only has generic defaults.
 	for i := range models {
+		// An omitted turn model inherits thread/start (including config.toml),
+		// not model/list's generic catalog default. If the configured model is
+		// absent, leave no catalog default rather than advertise another model.
+		if c.threadModel != "" {
+			models[i].Default = models[i].ID == c.threadModel
+		}
 		if models[i].ID == c.threadModel && c.threadEffort != "" {
 			models[i].DefaultEffort = c.threadEffort
-			break
 		}
 	}
 	return models, nil

--- a/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver_test.go
@@ -1117,6 +1117,30 @@ func TestListModelsKeepsCatalogAndUsesThreadEffort(t *testing.T) {
 	}
 }
 
+func TestListModelsUsesConfiguredThreadDefault(t *testing.T) {
+	for _, configured := range []string{"nano", "custom-model"} {
+		t.Run(configured, func(t *testing.T) {
+			d, srv := newTestDriver(t)
+			srv.reply("thread/start", `{"thread":{"id":"thread-1"},"model":"`+configured+`","cwd":"/tmp/ws"}`)
+			srv.reply("model/list", `{"data":[{"id":"astra","isDefault":true},{"id":"nano","isDefault":false}]}`)
+			conv, err := d.Start(context.Background(), ports.ChatStartConfig{WorkspacePath: "/tmp/ws"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = conv.Close() }()
+			models, err := conv.(ports.ChatModelLister).ListModels(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, model := range models {
+				if model.Default != (model.ID == configured) {
+					t.Errorf("model %q default = %v, configured thread model = %q", model.ID, model.Default, configured)
+				}
+			}
+		})
+	}
+}
+
 func TestDiscoverModelsReadsCatalogWithoutOpeningThread(t *testing.T) {
 	d, srv := newTestDriver(t)
 	srv.reply("model/list", `{"data":[{"id":"gpt-visible","displayName":"GPT Visible","isDefault":true,"hidden":false},{"id":"gpt-hidden","displayName":"GPT Hidden","hidden":true}]}`)

--- a/backend/internal/session_manager/prompt.go
+++ b/backend/internal/session_manager/prompt.go
@@ -204,7 +204,7 @@ Your job is to coordinate work, not to perform implementation. Keep the project 
 - Before running `+"`ao spawn`"+`, count the `+"`--name`"+` label yourself. It must be 20 characters or fewer. If your first label is longer, shorten it before executing the command.
 - Add `+"`--agent <name>`"+` when a worker must use a specific agent.
 - Add `+"`--model <id>`"+` when the human or task explicitly requests a specific model.
-- If `+"`ao spawn --model ...`"+` fails because the model is unsupported, retry the same spawn without `+"`--model`"+` to use the agent default, then tell the human you fell back to the default model.
+- Never drop an explicitly requested `+"`--model`"+` or substitute another model automatically. If `+"`ao spawn --model ...`"+` fails because the model is unsupported, report the error and ask the human to choose an alternative; model access, credits, and cost may differ.
 - `+"`ao send --session <session-id> --message \"<message>\"`"+` - message a worker.
 - `+"`ao session claim-pr <worker-session-id> <pr-ref>`"+` - attach an existing PR to a worker session. Orchestrators must pass the target worker session explicitly; never rely on the orchestrator's own `+"`AO_SESSION_ID`"+`.
 - `+"`ao session kill <session-id>`"+` - terminate a session when appropriate.

--- a/backend/internal/session_manager/prompt_test.go
+++ b/backend/internal/session_manager/prompt_test.go
@@ -90,8 +90,8 @@ func TestBuildSystemPrompt_OrchestratorRequiresConfirmationAndAOOnlyDelegation(t
 		"ao session claim-pr <worker-session-id> <pr-ref>",
 		"must pass the target worker session explicitly",
 		"Add `--model <id>` when the human or task explicitly requests a specific model",
-		"retry the same spawn without `--model`",
-		"tell the human you fell back to the default model",
+		"Never drop an explicitly requested `--model` or substitute another model automatically",
+		"ask the human to choose an alternative",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("orchestrator prompt missing %q:\n%s", want, got)

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
@@ -338,3 +338,21 @@ describe("ACP session config options", () => {
 		).not.toBeInTheDocument();
 	});
 });
+
+describe("native model selection", () => {
+	it("keeps an explicit model visible when the catalog does not contain it", () => {
+		render(
+			<TurnSettingsBar
+				models={[
+					{ id: "astra", displayName: "Astra", default: true, efforts: ["high"], defaultEffort: "high" },
+				]}
+				settings={{ model: "nano" }}
+				onChange={vi.fn()}
+				harness="codex"
+			/>,
+		);
+		expect(
+			screen.getByRole("button", { name: "Model and reasoning effort for the next turn" }),
+		).toHaveTextContent(/^nano$/);
+	});
+});

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -115,10 +115,11 @@ export function TurnSettingsBar({
 	children?: ReactNode;
 }) {
 	const selected = models.find((model) => model.id === settings.model);
-	const fallback = models.find((model) => model.default);
-	// The label says what will actually be used: the provider's default is a real
-	// answer, not an absence, so it is named rather than shown as "none".
-	const chosenLabel = selected?.displayName ?? fallback?.displayName ?? "Provider default";
+	const fallback = settings.model ? undefined : models.find((model) => model.default);
+	// A catalog miss must not relabel an explicit choice or borrow another model's
+	// effort settings. Custom or newly available models may not be listed yet.
+	const chosenLabel =
+		selected?.displayName ?? settings.model ?? fallback?.displayName ?? "Provider default";
 	const rerouted = reroute
 		? models.find((model) => model.id === reroute.toModel)?.displayName ?? reroute.toModel
 		: undefined;


### PR DESCRIPTION
## What
Preserve explicit Codex model choices and stop showing the catalog default when it is not the selected model. For example, a Nano-configured thread or an unlisted Nano selection must not be displayed as Astra.

## Why
A user reported that Nano worked in PowerShell but appeared to switch to Astra and fail in AO. Investigation confirmed misleading model labels and an orchestrator instruction to retry rejected explicit models using the default. The original Windows launch failure remains unverified because the exact error and successful command were not supplied.

## How
- Use the effective Codex thread model when marking the conversation catalog default; clear the generic default when that model is absent.
- Preserve an explicit model ID in the picker when the catalog lacks it, without borrowing another model's reasoning-effort choices.
- Instruct the orchestrator to report a rejected model and request an alternative instead of dropping `--model` automatically. This is a prompt-policy change, not a new CLI enforcement mechanism.
- Add regression coverage for configured and unlisted models and the orchestrator policy.

## Testing
- Reproduced the backend default mismatch and frontend `Astra High` mislabel before the fix; focused backend tests and all 15 picker tests passed afterward.
- Current-base `go build ./...`, `go vet ./...`, and formatting check passed.
- API regeneration has no drift; Cloud client and product UI typechecks, tests, and package dry-runs passed.
- Remote CI passed: frontend typechecks and full Vitest suite, renderer smoke, lint, API drift, secret scan, CLI E2E on Linux/macOS/Windows, fresh-install container, and Windows workspace tests. Go build/test is still running.
- Local full backend run has reported an installed-Codex protocol mismatch (also reproduced on unchanged code) and a Pi adapter timing failure. Native CLI E2E returned a nonzero result.
- Docker daemon is unavailable, so pinned Linux containers and the fresh-install container check cannot run locally. Native Windows/Linux jobs require CI. Local Go auto-selects 1.26.5 as required by the repository workspace; frontend checks use Node 24.
- No original-account Windows reproduction or screenshots are claimed.

## Checklist
- [x] Branched from `main` and rebased onto current `origin/main`
- [x] One focused change
- [x] Only intended source and regression tests included; no review artifacts
- [x] Tests added for user-visible behavior
- [x] All CI checks pass (10 passed; Go build/test still running)
