### PR TITLE
fix(updater): recover from a staged build the installer rejects

### DIFF
--- a/frontend/scripts/e2e-mac-update.mjs
+++ b/frontend/scripts/e2e-mac-update.mjs
@@ -164,8 +164,12 @@ export function assertSentinelCapable(appPath) {
 	if (!readFileSync(asar).includes(SENTINEL_ENV)) {
 		throw new UsageError(
 			`baseline at ${appPath} has no ${SENTINEL_ENV} listener, so it can never signal that an update staged. ` +
-				`That listener landed with the macOS release hardening work (#3288 workstream 0); pick a baseline ` +
-				`released after it. Running anyway would just wait out the download timeout and report a false failure.`,
+				`Running anyway would just wait out the download timeout and report a false failure. Two different ` +
+				`causes look identical here, so check both: the baseline may predate the listener (#3288 workstream 0), ` +
+				`or the listener may have been removed from src/main/auto-updater.ts, in which case EVERY baseline ` +
+				`built after that point fails this check and picking a newer one makes it worse. That second case is ` +
+				`real: #3012 deleted it on 2026-07-31 and run 30758412650 failed here on a 2026-08-01 baseline while ` +
+				`a 2026-07-30 baseline passed. Confirm the listener still exists in the app before changing baselines.`,
 		);
 	}
 }

--- a/frontend/scripts/e2e-mac-update.test.mjs
+++ b/frontend/scripts/e2e-mac-update.test.mjs
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { assertSentinelCapable, launchEnv, parseArgs, removeRunFile, seedUpdateSettings } from "./e2e-mac-update.mjs";
@@ -168,5 +168,33 @@ describe("e2e-mac-update assertSentinelCapable", () => {
 
 	it("fails when the path is not a packaged bundle at all", () => {
 		expect(() => assertSentinelCapable(bundle("Unpackaged", null))).toThrow(/packaged build/);
+	});
+});
+
+// assertSentinelCapable is a substring scan of a BUILT app.asar, so it can only
+// fail after a release is cut — and it fails by refusing to run, which reads as
+// "old baseline" rather than "the app stopped emitting the signal". That is
+// exactly how the listener stayed missing from #3012 until #4254: five weeks in
+// which no build could satisfy the harness and the macOS update-hop job could
+// never run against any baseline.
+//
+// This asserts the coupling at its source instead, so deleting the listener
+// fails a unit test in the same commit rather than silently disabling a job.
+describe("update-hop coverage is wired to the app", () => {
+	it("keeps the sentinel listener the harness scans for in auto-updater.ts", () => {
+		// Resolved from the runner's cwd rather than import.meta.url: the test
+		// transform rewrites import.meta.url to a non-file scheme. Both
+		// candidates are listed so this works whether vitest is invoked from
+		// frontend/ (the npm script) or from the repo root.
+		const sourcePath = ["src/main/auto-updater.ts", "frontend/src/main/auto-updater.ts"]
+			.map((rel) => join(process.cwd(), rel))
+			.find((candidate) => existsSync(candidate));
+		expect(sourcePath, "could not locate auto-updater.ts from " + process.cwd()).toBeDefined();
+		const source = readFileSync(sourcePath, "utf8");
+		expect(source).toContain('E2E_UPDATE_SENTINEL_ENV = "AO_E2E_UPDATE_SENTINEL"');
+		// The native updater is the only signal that means "staged, will swap on
+		// quit"; electron-updater's own update-downloaded fires before Squirrel
+		// has fetched anything, so hanging the sentinel there stages nothing.
+		expect(source).toMatch(/nativeAutoUpdater\.on\("update-downloaded"/);
 	});
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,6 +18,7 @@ import {
 	type OpenDialogOptions,
 } from "electron";
 import {
+	setRendererSink,
 	startAutoUpdates,
 	ensureUpdatePrefs,
 	checkForUpdatesNow,
@@ -2369,6 +2370,12 @@ function initAutoUpdates(): void {
 	const runFile = runFilePath();
 	if (!runFile) return;
 	const stateDir = path.dirname(runFile);
+	// Route update pushes at the shell WebContents, the same target daemon status
+	// uses. The shell is a BaseWindow + WebContentsView (#3750), which
+	// BrowserWindow.getAllWindows() does not return, so the updater cannot find
+	// the renderer on its own. Resolved lazily so a recreated window still gets
+	// pushes.
+	setRendererSink(() => getShellWebContents());
 	void ensureUpdatePrefs(stateDir).then(() => startAutoUpdates(stateDir));
 }
 

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2939,6 +2939,33 @@ describe("staged install rejection", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  // The 2026-09-05 v0.12.10 report carries the OTHER Security-framework
+  // wording for the same "the staged copy is not installable" outcome. Both
+  // reach us through the same SQRLCodeSignature.m prefix, and both have to
+  // clear the cache: reproduced locally, "code object is not signed at all" is
+  // what codesign reports when the staged bundle's main executable is missing
+  // or zero-length, which no retry of the same bytes can fix.
+  it("also handles the 'not signed at all' wording", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(
+      new Error(
+        "Code signature at URL file:///Users/graycup/Library/Caches/" +
+          "dev.agent-orchestrator.desktop.ShipIt/update.lmaIGgc/Agent%20Orchestrator.app/ " +
+          "did not pass validation: code object is not signed at all",
+      ),
+    );
+
+    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
+    expect(module.getUpdateStatus().staged).toBeUndefined();
+    consoleErrorSpy.mockRestore();
+  });
+
   it("leaves an ordinary download failure alone", async () => {
     // Same "error" event, nothing staged to reject: the existing suppress-and-
     // restore behaviour has to survive untouched.

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2942,9 +2942,13 @@ describe("staged install rejection", () => {
   // The 2026-09-05 v0.12.10 report carries the OTHER Security-framework
   // wording for the same "the staged copy is not installable" outcome. Both
   // reach us through the same SQRLCodeSignature.m prefix, and both have to
-  // clear the cache: reproduced locally, "code object is not signed at all" is
-  // what codesign reports when the staged bundle's main executable is missing
-  // or zero-length, which no retry of the same bytes can fix.
+  // clear the cache. Reproduced locally against the published nightly, driving
+  // SecStaticCodeCheckValidityWithErrors with the flags Electron's patched
+  // Squirrel.Mac actually uses (nested | strict | all-architectures): this
+  // string is errSecCSUnsigned, which a staged bundle reports when its root
+  // executable OR a nested helper-app/framework binary is missing or unsigned.
+  // Seal damage and sealed-resource damage give different codes. No retry of
+  // the same staged bytes can fix any of them.
   it("also handles the 'not signed at all' wording", async () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2993,6 +2993,49 @@ describe("staged install rejection", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  // Squirrel's checkForUpdatesCommand is a RACCommand that does not allow
+  // concurrent execution, so a second native handoff while one is staging is
+  // REFUSED with RACCommandErrorDomain/1 rather than queued — and Electron puts
+  // that code and domain on the JS Error. It is not an update failure, and its
+  // native wording ("The command is disabled and cannot be executed") is
+  // meaningless to a user.
+  const nativeBusyError = Object.assign(
+    new Error("The command is disabled and cannot be executed"),
+    { code: 1, domain: "RACCommandErrorDomain" },
+  );
+
+  it("does not report a refused native handoff as an update failure", async () => {
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+    const { module, updaterEvents, statusMessages } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    const beforeRefusal = statusMessages().at(-1)?.payload;
+
+    updaterEvents.get("error")?.(nativeBusyError);
+
+    expect(statusMessages().at(-1)?.payload).toEqual(beforeRefusal);
+    expect(module.getUpdateStatus().state).not.toBe("error");
+    consoleInfoSpy.mockRestore();
+  });
+
+  it("settles a manual check whose native handoff was refused", async () => {
+    // The manual path broadcasts "checking" before it starts, so swallowing the
+    // rejection outright would wedge the Settings spinner.
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater } = await importAutoUpdater();
+    autoUpdater.checkForUpdates.mockRejectedValue(nativeBusyError);
+
+    await module.checkForUpdatesNow(stateDir, { requestId: "manual-1" });
+
+    expect(module.getUpdateStatus().state).toBe("not-available");
+    consoleInfoSpy.mockRestore();
+  });
+
   it("restores the budget when the user checks again", async () => {
     // The exhausted message tells the user to check for updates again, so that
     // has to actually do something.

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2887,7 +2887,13 @@ describe("staged install rejection", () => {
       "code failed to satisfy specified code requirement(s)",
   );
 
-  it("clears the cached download and disarms the staged build", async () => {
+  it("keeps the verified download on a first failure and re-stages instead", async () => {
+    // Squirrel verifies the copy it extracted, in-process, before ShipIt exists.
+    // A rejection therefore indicts the EXTRACTION, not the zip — which
+    // electron-updater already checked against the feed sha512. Observed on a
+    // real failure: the cached zip was byte-identical to the feed and the next
+    // attempt extracted it cleanly. Purging here would force a 176 MB
+    // re-download to fix a bad untar.
     const consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
@@ -2896,24 +2902,100 @@ describe("staged install rejection", () => {
 
     await module.checkForUpdatesNow(stateDir);
     updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
-    expect(module.getUpdateStatus().state).toBe("downloaded");
+    updaterEvents.get("error")?.(rejection);
+
+    expect(autoUpdater.downloadedUpdateHelper.clear).not.toHaveBeenCalled();
+    // Still disarmed: that copy cannot install, and leaving it staged would
+    // promise a restart that fails. This also re-enables auto-download, which
+    // is what drives the re-extraction.
+    expect(module.getUpdateStatus().staged).toBeUndefined();
+    expect(statusMessages().at(-1)?.payload).toMatchObject({
+      state: "error",
+      message: expect.stringContaining("prepare it again"),
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("discards the download once the same build fails a second time", async () => {
+    // A re-extraction failing too is the first real evidence the bytes are
+    // suspect, so now the zip goes.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents, statusMessages } =
+      await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(rejection);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(rejection);
+
+    // Deferred, not fired and forgotten: the clear is queued on the operation
+    // chain, so it has not run at the instant the rejection is handled.
+    expect(autoUpdater.downloadedUpdateHelper.clear).not.toHaveBeenCalled();
+    expect(statusMessages().at(-1)?.payload).toMatchObject({
+      state: "error",
+      message: expect.stringContaining("failed verification again"),
+    });
+
+    // ...and the next operation cannot begin until it has. Awaiting one drains
+    // the queue behind the cleanup, which is the property that stops a download
+    // starting into a pending directory that is still being emptied.
+    await module.checkForUpdatesNow(stateDir);
+    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("keeps the actionable message when one rejection is delivered twice", async () => {
+    // MacUpdater re-emits every native Squirrel error onto electron-updater's
+    // own "error" event, and the operation promise can reject with that same
+    // error. Handling the first delivery disarms the staged build, so without a
+    // dedupe the second misses the branch, falls through to generic handling,
+    // and replaces the actionable message with the raw signature dump.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const consoleDebugSpy = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents, statusMessages } =
+      await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(rejection);
+    const afterFirstDelivery = statusMessages().at(-1)?.payload;
 
     updaterEvents.get("error")?.(rejection);
 
-    // Without the clear, the next check hands Squirrel the same bytes again.
-    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
-    // And without the disarm, the sidebar keeps offering a restart-to-install
-    // that cannot succeed.
-    expect(module.getUpdateStatus().staged).toBeUndefined();
-    expect(module.getUpdateStatus().state).toBe("error");
+    expect(statusMessages().at(-1)?.payload).toEqual(afterFirstDelivery);
     expect(statusMessages().at(-1)?.payload).toMatchObject({
       state: "error",
-      message: expect.stringContaining("download it again on the next check"),
+      message: expect.stringContaining("prepare it again"),
     });
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "staged update rejected at install time; discarding cached download:",
-      rejection,
-    );
+    // The repeat must not be miscounted as a genuine second failure, which
+    // would discard a download that has only actually failed once.
+    expect(autoUpdater.downloadedUpdateHelper.clear).not.toHaveBeenCalled();
+    consoleDebugSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not carry a previous build's failure over to a new one", async () => {
+    // The count answers "has THIS build failed before". A newer build that
+    // fails once must still get its cheap retry.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(rejection);
+    updaterEvents.get("update-downloaded")?.({ version: "2.2.0" });
+    updaterEvents.get("error")?.(rejection);
+
+    expect(autoUpdater.downloadedUpdateHelper.clear).not.toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
   });
 
@@ -2937,7 +3019,7 @@ describe("staged install rejection", () => {
     await module.startAutoUpdates(stateDir);
 
     expect(module.getUpdateStatus().state).toBe("error");
-    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
+    expect(module.getUpdateStatus().staged).toBeUndefined();
     consoleErrorSpy.mockRestore();
   });
 
@@ -2955,7 +3037,7 @@ describe("staged install rejection", () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+    const { module, updaterEvents } = await importAutoUpdater();
 
     await module.checkForUpdatesNow(stateDir);
     updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
@@ -2967,8 +3049,8 @@ describe("staged install rejection", () => {
       ),
     );
 
-    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
     expect(module.getUpdateStatus().staged).toBeUndefined();
+    expect(module.getUpdateStatus().state).toBe("error");
     consoleErrorSpy.mockRestore();
   });
 
@@ -2979,7 +3061,7 @@ describe("staged install rejection", () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+    const { module, updaterEvents } = await importAutoUpdater();
 
     await module.checkForUpdatesNow(stateDir);
     updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
@@ -2990,8 +3072,8 @@ describe("staged install rejection", () => {
       ),
     );
 
-    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
     expect(module.getUpdateStatus().staged).toBeUndefined();
+    expect(module.getUpdateStatus().state).toBe("error");
     consoleErrorSpy.mockRestore();
   });
 

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2970,6 +2970,52 @@ describe("staged install rejection", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  // The other failure Squirrel raises for the same outcome
+  // (SQRLCodeSignature.m:116, CouldNotCreateStaticCode): the staged bundle is
+  // damaged badly enough that a code object cannot even be constructed.
+  it("also handles 'failed to get static code for bundle'", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(
+      new Error(
+        "Failed to get static code for bundle file:///Users/x/Library/Caches/" +
+          "dev.agent-orchestrator.desktop.ShipIt/update.M9ZvE0X/Agent%20Orchestrator.app/",
+      ),
+    );
+
+    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
+    expect(module.getUpdateStatus().staged).toBeUndefined();
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Merely mentioning the staging path must NOT trip this. The staging path
+  // literally contains "ShipIt", so a pattern loose enough to match the path
+  // would fire on unrelated failures that a re-download cannot fix.
+  it("ignores an unrelated error that only mentions the ShipIt path", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(
+      new Error(
+        "EACCES: permission denied, open '/Users/x/Library/Caches/" +
+          "dev.agent-orchestrator.desktop.ShipIt/ShipItState.plist'",
+      ),
+    );
+
+    expect(autoUpdater.downloadedUpdateHelper.clear).not.toHaveBeenCalled();
+    expect(module.getUpdateStatus().staged).toBeDefined();
+    consoleErrorSpy.mockRestore();
+  });
+
   it("leaves an ordinary download failure alone", async () => {
     // Same "error" event, nothing staged to reject: the existing suppress-and-
     // restore behaviour has to survive untouched.

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2936,7 +2936,7 @@ describe("staged install rejection", () => {
     expect(autoUpdater.downloadedUpdateHelper.clear).not.toHaveBeenCalled();
     expect(statusMessages().at(-1)?.payload).toMatchObject({
       state: "error",
-      message: expect.stringContaining("failed verification again"),
+      message: expect.stringContaining("stopped retrying on its own"),
     });
 
     // ...and the next operation cannot begin until it has. Awaiting one drains
@@ -2944,6 +2944,70 @@ describe("staged install rejection", () => {
     // starting into a pending directory that is still being emptied.
     await module.checkForUpdatesNow(stateDir);
     expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Disarming a rejected build re-enables auto-download, which is what buys the
+  // cheap re-preparation. Unbounded, that is also a loop: fetch 176 MB, fail
+  // verification, discard, fetch again, on every check for as long as the app
+  // runs. These three cover the bound and both of its resets.
+  const failTwice = (
+    updaterEvents: Map<string, (...args: unknown[]) => unknown>,
+  ) => {
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(rejection);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(rejection);
+  };
+
+  it("stops automatically re-downloading a build that failed twice", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    failTwice(updaterEvents);
+
+    await module.startAutoUpdates(stateDir);
+
+    expect(autoUpdater.autoDownload).toBe(false);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("gives a different build its own recovery attempts", async () => {
+    // The budget answers "has THIS target exhausted its retries". Something
+    // newer must not inherit the previous build's exhaustion.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    failTwice(updaterEvents);
+    updaterEvents.get("update-available")?.({ version: "2.2.0" });
+
+    await module.startAutoUpdates(stateDir);
+
+    expect(autoUpdater.autoDownload).toBe(true);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("restores the budget when the user checks again", async () => {
+    // The exhausted message tells the user to check for updates again, so that
+    // has to actually do something.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    failTwice(updaterEvents);
+    await module.checkForUpdatesNow(stateDir);
+
+    await module.startAutoUpdates(stateDir);
+
+    expect(autoUpdater.autoDownload).toBe(true);
     consoleErrorSpy.mockRestore();
   });
 

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -101,16 +101,16 @@ async function importAutoUpdater(
   // status never suppresses its telemetry, and only a per-channel view can tell
   // those two apart.
   const sent: { channel: string; payload: unknown }[] = [];
-  const fakeWindow = {
-    isDestroyed: () => false,
-    webContents: {
-      send: (channel: string, payload: unknown) => {
-        sent.push({ channel, payload });
-      },
-    },
-  };
+  // The renderer is reached through the injected shell sink, never by walking
+  // BrowserWindow.getAllWindows(): the AO shell is a BaseWindow hosting a
+  // WebContentsView (#3750), so that registry is empty in the real app and
+  // enumerating it silently dropped every push. Keeping the mock registry empty
+  // here means every test in this file exercises the real delivery path.
+  const rendererSend = vi.fn((channel: string, payload: unknown) => {
+    sent.push({ channel, payload });
+  });
   const BrowserWindow = {
-    getAllWindows: vi.fn(() => [fakeWindow]),
+    getAllWindows: vi.fn(() => [] as unknown[]),
   };
   const statusMessages = () => sent.filter((m) => m.channel === "updates:status");
   const telemetryMessages = () => sent.filter((m) => m.channel === "updates:telemetry");
@@ -159,8 +159,10 @@ async function importAutoUpdater(
         Promise.resolve({ settings: current, cleared: false })),
   }));
   const module = await import("./auto-updater");
+  module.setRendererSink(() => ({ send: rendererSend }));
   return {
     sent,
+    rendererSend,
     statusMessages,
     telemetryMessages,
     module,
@@ -643,7 +645,7 @@ describe("startAutoUpdates", () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    const { module, autoUpdater, dialog, BrowserWindow } =
+    const { module, autoUpdater, dialog, statusMessages } =
       await importAutoUpdater();
     autoUpdater.checkForUpdates
       .mockResolvedValueOnce(undefined)
@@ -660,7 +662,7 @@ describe("startAutoUpdates", () => {
       expect.any(Error),
     );
     expect(dialog.showMessageBox).not.toHaveBeenCalled();
-    expect(BrowserWindow.getAllWindows).not.toHaveBeenCalled();
+    expect(statusMessages()).toHaveLength(0);
 
     await vi.advanceTimersByTimeAsync(delay);
     expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3);
@@ -1089,13 +1091,13 @@ describe("startAutoUpdates", () => {
   });
 
   it("keeps manual updater error events visible to the renderer", async () => {
-    const { module, BrowserWindow, updaterEvents } = await importAutoUpdater();
+    const { module, rendererSend, updaterEvents } = await importAutoUpdater();
     const err = new Error("manual feed failed");
 
     await module.checkForUpdatesNow(stateDir);
     updaterEvents.get("error")?.(err);
 
-    expect(BrowserWindow.getAllWindows).toHaveBeenCalled();
+    expect(rendererSend).toHaveBeenCalledWith("updates:status", expect.anything());
     expect(module.getUpdateStatus()).toEqual({
       state: "error",
       message: "manual feed failed",
@@ -3068,5 +3070,54 @@ describe("e2e staging sentinel", () => {
     const { module, nativeAutoUpdater } = await importAutoUpdater();
     await module.checkForUpdatesNow(stateDir);
     expect(nativeAutoUpdater.on).not.toHaveBeenCalled();
+  });
+});
+
+// The AO shell is a BaseWindow hosting the UI in a WebContentsView (#3750), and
+// BrowserWindow.getAllWindows() only ever returns BrowserWindow instances. The
+// updater walked that registry to push status, so from 2026-08-09 it matched
+// nothing and every push was dropped. `invoke` still answered its own sender, so
+// updates:getStatus kept working and it read as a caching bug: "Last checked"
+// was correct when Settings was reopened and never moved while it was open.
+describe("renderer delivery does not depend on the window registry", () => {
+  it("pushes status and telemetry through the shell sink, never through BrowserWindow", async () => {
+    const { module, autoUpdater, updaterEvents, rendererSend, BrowserWindow, statusMessages, telemetryMessages } =
+      await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    updaterEvents.get("error")?.(new Error("net::ERR_CONNECTION_RESET"));
+
+    // The registry is empty here exactly as it is in the packaged app, so any
+    // code that reaches for it delivers nothing.
+    expect(BrowserWindow.getAllWindows).not.toHaveBeenCalled();
+    expect(statusMessages().length).toBeGreaterThan(0);
+    expect(telemetryMessages().length).toBeGreaterThan(0);
+    expect(rendererSend).toHaveBeenCalledWith("updates:status", expect.anything());
+    expect(rendererSend).toHaveBeenCalledWith("updates:telemetry", expect.anything());
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalled();
+  });
+
+  it("resolves the sink per send, so a recreated shell still receives pushes", async () => {
+    // Caching the first WebContents would silently stop delivery after the
+    // window is recreated - the same class of failure, one step later.
+    const { module, updaterEvents } = await importAutoUpdater();
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+    let current = first;
+    module.setRendererSink(() => ({ send: (_c: string, p: unknown) => current.push(p) }));
+
+    await module.checkForUpdatesNow(stateDir);
+    expect(first.length).toBeGreaterThan(0);
+
+    current = second;
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    expect(second.length).toBeGreaterThan(0);
+  });
+
+  it("does not throw when no sink is installed yet", async () => {
+    const { module } = await importAutoUpdater();
+    module.setRendererSink(() => null);
+    await expect(module.checkForUpdatesNow(stateDir)).resolves.toBeUndefined();
   });
 });

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import semver from "semver";
 import { CancellationToken } from "builder-util-runtime";
@@ -38,6 +38,9 @@ type AutoUpdaterMock = {
   autoDownload: boolean;
   autoInstallOnAppQuit: boolean;
   httpExecutor: { request: ReturnType<typeof vi.fn<(options: object, token?: CancellationToken) => Promise<string | null>>> };
+  // electron-updater keeps its cached pending download behind this protected
+  // member; the install-rejection path clears it through the same name.
+  downloadedUpdateHelper: { clear: ReturnType<typeof vi.fn> };
 };
 
 function createAutoUpdaterMock(): AutoUpdaterMock {
@@ -53,6 +56,7 @@ function createAutoUpdaterMock(): AutoUpdaterMock {
     autoDownload: false,
     autoInstallOnAppQuit: false,
     httpExecutor: { request: vi.fn(async () => null) },
+    downloadedUpdateHelper: { clear: vi.fn(() => Promise.resolve()) },
   };
 }
 
@@ -111,6 +115,13 @@ async function importAutoUpdater(
   const statusMessages = () => sent.filter((m) => m.channel === "updates:status");
   const telemetryMessages = () => sent.filter((m) => m.channel === "updates:telemetry");
   vi.doMock("electron-updater", () => ({ autoUpdater }));
+  const nativeUpdaterEvents = new Map<string, UpdaterEventHandler>();
+  const nativeAutoUpdater = {
+    on: vi.fn((event: string, handler: UpdaterEventHandler) => {
+      nativeUpdaterEvents.set(event, handler);
+      return nativeAutoUpdater;
+    }),
+  };
   vi.doMock("electron", () => ({
     app: {
       isPackaged: options.isPackaged ?? true,
@@ -118,6 +129,7 @@ async function importAutoUpdater(
     },
     BrowserWindow,
     dialog,
+    autoUpdater: nativeAutoUpdater,
   }));
   const readUpdateSettings =
     typeof settings === "function"
@@ -156,6 +168,8 @@ async function importAutoUpdater(
     dialog,
     BrowserWindow,
     updaterEvents,
+    nativeAutoUpdater,
+    nativeUpdaterEvents,
     readUpdateSettings,
     writeUpdateSettings,
     updateUpdateSettings,
@@ -2855,5 +2869,127 @@ describe("channel downgrade safety", () => {
     await h.module.ensureUpdatePrefs(stateDir);
     expect(h.dialog.showMessageBox).not.toHaveBeenCalled();
     expect(h.writeUpdateSettings).not.toHaveBeenCalled();
+  });
+});
+
+// #4254: macOS auto-update failed at ShipIt's code-signature validation and
+// then failed identically on every retry. MacUpdater re-emits native Squirrel
+// failures onto electron-updater's "error" event, and
+// DownloadedUpdateHelper.validateDownloadedPath re-serves an
+// already-downloaded file on existence alone for the lifetime of the process,
+// so the retry never re-downloads and never re-verifies.
+describe("staged install rejection", () => {
+  const rejection = new Error(
+    "Code signature at URL file:///Users/x/Library/Caches/dev.agent-orchestrator.desktop.ShipIt/" +
+      "update.M9ZvE0X/Agent%20Orchestrator.app/ did not pass validation: " +
+      "code failed to satisfy specified code requirement(s)",
+  );
+
+  it("clears the cached download and disarms the staged build", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents, statusMessages } =
+      await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    expect(module.getUpdateStatus().state).toBe("downloaded");
+
+    updaterEvents.get("error")?.(rejection);
+
+    // Without the clear, the next check hands Squirrel the same bytes again.
+    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
+    // And without the disarm, the sidebar keeps offering a restart-to-install
+    // that cannot succeed.
+    expect(module.getUpdateStatus().staged).toBeUndefined();
+    expect(module.getUpdateStatus().state).toBe("error");
+    expect(statusMessages().at(-1)?.payload).toMatchObject({
+      state: "error",
+      message: expect.stringContaining("download it again on the next check"),
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "staged update rejected at install time; discarding cached download:",
+      rejection,
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("surfaces the failure even on an automatic check", async () => {
+    // The automatic path suppresses one-off failures so the UI does not flash
+    // an error nobody asked for. That suppression must not swallow this class:
+    // an install the user cannot retry out of is exactly what has to be shown.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+
+    autoUpdater.checkForUpdates.mockImplementationOnce(() => {
+      updaterEvents.get("checking-for-update")?.();
+      updaterEvents.get("error")?.(rejection);
+      return Promise.resolve();
+    });
+    await module.startAutoUpdates(stateDir);
+
+    expect(module.getUpdateStatus().state).toBe("error");
+    expect(autoUpdater.downloadedUpdateHelper.clear).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("leaves an ordinary download failure alone", async () => {
+    // Same "error" event, nothing staged to reject: the existing suppress-and-
+    // restore behaviour has to survive untouched.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    updaterEvents.get("error")?.(new Error("net::ERR_CONNECTION_RESET"));
+
+    expect(autoUpdater.downloadedUpdateHelper.clear).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+// #3288 workstream 0: scripts/e2e-mac-update.mjs waits on this listener to know
+// an update actually STAGED. It was deleted by an unrelated refactor in #3012
+// and the macOS update-hop e2e job silently stopped being runnable, which is
+// how #4254 reached users with no update-hop coverage at all.
+describe("e2e staging sentinel", () => {
+  const originalSentinel = process.env.AO_E2E_UPDATE_SENTINEL;
+  afterEach(() => {
+    if (originalSentinel === undefined) delete process.env.AO_E2E_UPDATE_SENTINEL;
+    else process.env.AO_E2E_UPDATE_SENTINEL = originalSentinel;
+  });
+
+  it("writes the sentinel from the NATIVE updater's update-downloaded", async () => {
+    const sentinel = nodePath.join(stateDir, "sentinel.json");
+    process.env.AO_E2E_UPDATE_SENTINEL = sentinel;
+    const { module, nativeUpdaterEvents, updaterEvents } =
+      await importAutoUpdater();
+
+    await module.checkForUpdatesNow(stateDir);
+    // electron-updater's own update-downloaded fires BEFORE Squirrel is told to
+    // fetch, so keying the harness off it would stage nothing. It must not
+    // write the sentinel.
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    expect(existsSync(sentinel)).toBe(false);
+
+    nativeUpdaterEvents.get("update-downloaded")?.({}, "notes", "2.1.0");
+    expect(JSON.parse(readFileSync(sentinel, "utf8"))).toEqual({
+      stagedAt: expect.any(Number),
+      releaseName: "2.1.0",
+    });
+  });
+
+  it("registers nothing when the env var is unset", async () => {
+    delete process.env.AO_E2E_UPDATE_SENTINEL;
+    const { module, nativeAutoUpdater } = await importAutoUpdater();
+    await module.checkForUpdatesNow(stateDir);
+    expect(nativeAutoUpdater.on).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -942,19 +942,35 @@ function isManifest404Error(err: unknown): boolean {
 // A staged build that the native installer refused to install, as opposed to
 // anything that goes wrong while checking for or downloading one.
 //
-// On macOS these originate in Squirrel.Mac's ShipIt and reach us verbatim:
-// MacUpdater re-emits every native failure onto electron-updater's own "error"
-// event (`this.nativeUpdater.on("error", it => this.emit("error", it))`), so
-// the report in #4254 —
+// Matching on message text is regrettable but forced: electron-updater collapses
+// check failures, download failures and native install failures onto ONE untyped
+// "error" event carrying a plain Error, and MacUpdater re-emits the native
+// failure verbatim (`this.nativeUpdater.on("error", it => this.emit("error", it))`)
+// with no code, domain or phase attached. Listening to the native updater
+// directly would be structural, but it does not help: MacUpdater registers its
+// own native listener in its constructor at import time and `emit` is
+// synchronous, so the handler below has already run to completion before any
+// listener we add later is called. Same reason isManifest404Error and
+// isNetErrorMessage read the text.
 //
-//   Code signature at URL file:///.../update.M9ZvE0X/Agent Orchestrator.app/
-//   did not pass validation: code failed to satisfy specified code requirement(s)
+// So the strings are pinned to the two literals Squirrel actually emits, read
+// off the exact commit Electron bundles (SQRLCodeSignature.m @0e5d146):
 //
-// arrives at the handler below rather than at download time. Matching the
-// phrases instead of the whole string covers the sibling wordings ShipIt uses
-// for the same "the staged copy is not installable" outcome (#3034, #4175).
+//   :134  "Code signature at URL %@ did not pass validation"   -> DidNotPass
+//   :116  "Failed to get static code for bundle %@"            -> CouldNotCreateStaticCode
+//
+// Both are SQRLCodeSignatureErrorDomain and both mean "the staged copy is not
+// installable", so both take the same remedy. Everything after the colon in the
+// first one is the Security-framework detail (`code object is not signed at
+// all`, `code failed to satisfy specified code requirement(s)`, …) and varies
+// with the damage, so it is deliberately not matched.
+//
+// Guardrails, because this is still a text match: it is gated on
+// hasStagedBuild(), so nothing that fails while merely checking or downloading
+// can reach it; a false positive costs one re-download; a false negative is the
+// status quo this fixes.
 const STAGED_INSTALL_REJECTION_PATTERN =
-  /did not pass validation|failed to satisfy specified code requirement|shipit/i;
+  /did not pass validation|failed to get static code for bundle/i;
 
 function isStagedInstallRejection(err: unknown): boolean {
   return STAGED_INSTALL_REJECTION_PATTERN.test(errorMessage(err));

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,6 +1,6 @@
 import { autoUpdater } from "electron-updater";
 import { CancellationToken } from "builder-util-runtime";
-import { app, BrowserWindow, dialog, autoUpdater as nativeAutoUpdater } from "electron";
+import { app, dialog, autoUpdater as nativeAutoUpdater } from "electron";
 import { accessSync, constants as fsConstants, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -203,13 +203,40 @@ function armDownloadStallWatchdog(): void {
 // downloading is enabled.
 let lastCheckedAtMs: number | undefined;
 
+/**
+ * Where renderer pushes go.
+ *
+ * NOT BrowserWindow.getAllWindows(). Since #3750 the AO shell is a BaseWindow
+ * hosting the UI in a WebContentsView, and BrowserWindow.getAllWindows() only
+ * ever returns BrowserWindow instances — so enumerating windows here matched
+ * nothing and every "updates:status" and "updates:telemetry" push was dropped
+ * on the floor from 2026-08-09 onward. `invoke` handlers reply to their own
+ * sender regardless of window type, so updates:getStatus kept working and the
+ * breakage looked like a stale-cache bug: Settings showed a correct timestamp
+ * on reopen and never moved while open.
+ *
+ * main.ts owns the shell handle and already pushes daemon status this way
+ * (`getShellWebContents()?.send("daemon:status", …)`), so it injects the same
+ * resolver here rather than this module reaching back into it.
+ */
+type RendererSink = { send: (channel: string, payload: unknown) => void };
+let resolveRendererSink: () => RendererSink | null | undefined = () => undefined;
+
+export function setRendererSink(resolve: () => RendererSink | null | undefined): void {
+  resolveRendererSink = resolve;
+}
+
+// Resolved per send, never cached: the shell WebContents is replaced when the
+// window is recreated, and holding the first one would silently stop delivering.
+function sendToRenderer(channel: string, payload: unknown): void {
+  resolveRendererSink()?.send(channel, payload);
+}
+
 // emitUpdateOutcome pushes an update outcome to renderers on a channel separate
 // from "updates:status", so suppressing a status for UI reasons (as the
 // automatic path does) never suppresses the telemetry for it.
 function emitUpdateOutcome(outcome: UpdateOutcome): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (!win.isDestroyed()) win.webContents.send("updates:telemetry", outcome);
-  }
+  sendToRenderer("updates:telemetry", outcome);
 }
 
 function activeUpdateTrigger(): UpdateTrigger {
@@ -266,9 +293,7 @@ function broadcast(
     }
   }
   lastStatus = stamped;
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (!win.isDestroyed()) win.webContents.send("updates:status", stamped);
-  }
+  sendToRenderer("updates:status", stamped);
 }
 
 function withActiveRequest(status: UpdateStatus): UpdateStatus {

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -119,7 +119,10 @@ type UpdaterOperation =
   | "manual-check"
   | "manual-download"
   | "settings-write"
-  | "return-home";
+  | "return-home"
+  // Recovery cleanup. Queued rather than run inline so a download cannot start
+  // into a pending cache directory that is still being emptied.
+  | "cache-clear";
 let activeUpdaterOperation: UpdaterOperation | undefined;
 let activeUpdaterRequestId: string | undefined;
 let automaticCheckPreviousStatus:
@@ -1002,6 +1005,41 @@ function isStagedInstallRejection(err: unknown): boolean {
 }
 
 /**
+ * Consecutive verification failures for one staged version.
+ *
+ * Keyed by version because the question is "has THIS build failed before", not
+ * "how many failures have we seen". A different build resets the count.
+ */
+let installRejections: { version: string | undefined; count: number } | undefined;
+
+/**
+ * The rejection already handled and reported, so the SAME native failure
+ * arriving a second time cannot be re-processed.
+ *
+ * MacUpdater re-emits every native Squirrel error onto electron-updater's own
+ * "error" event synchronously, and the operation promise can reject with that
+ * same error, so one verification failure can be delivered more than once.
+ * Handling it disarms the staged build, which makes hasStagedBuild() false — so
+ * without this record the second delivery misses the branch below, falls through
+ * to generic handling, and replaces the actionable message with the raw Squirrel
+ * signature dump (or, on the automatic path, restores the pre-check status and
+ * shows nothing at all).
+ *
+ * Cleared when a build stages again, so a genuinely new rejection is handled in
+ * full rather than swallowed.
+ */
+let handledInstallRejection: { version: string | undefined } | undefined;
+
+/** Count this rejection and report how many times this build has now failed. */
+function recordInstallRejection(version: string | undefined): number {
+  installRejections =
+    installRejections !== undefined && installRejections.version === version
+      ? { version, count: installRejections.count + 1 }
+      : { version, count: 1 };
+  return installRejections.count;
+}
+
+/**
  * Drop electron-updater's cached pending download.
  *
  * Verified against the published electron-updater@6.8.9 tarball:
@@ -1171,7 +1209,9 @@ function wireUpdaterEvents(): void {
       stagedEscalated = false;
     }
     stagedRequestId = activeUpdaterRequestId;
-    // A build is staged again, so install-on-quit has something correct to run.
+    // A build is staged again, so install-on-quit has something correct to run,
+    // and a later rejection is a NEW one rather than a repeat delivery.
+    handledInstallRejection = undefined;
     awaitingStagedReplacement = false;
     applyInstallOnQuitPolicy();
     persistStagedBuild(escalationStateDir);
@@ -1228,17 +1268,70 @@ function wireUpdaterEvents(): void {
     // Deliberately narrow: the richer in-app remediation for this class (the
     // direct-download offer after repeated failures) belongs to #3528, and the
     // pre-v0.11.0-baseline hop that provokes it belongs to #3288's matrix.
+    if (isStagedInstallRejection(err)) {
+      // A repeat delivery of a rejection already handled: keep the actionable
+      // message that is on screen rather than letting this fall through and
+      // overwrite it. Deliberately not a general "last error" deduplicator —
+      // it matches only this class, and only while no build is staged.
+      if (!hasStagedBuild() && handledInstallRejection !== undefined) {
+        console.debug("ignoring a duplicate delivery of an install rejection:", err);
+        return;
+      }
+    }
+    // NOTE for the readiness work (Prepare phase): this branch is gated on
+    // hasStagedBuild(), which reads stagedAtMs. Moving stagedAtMs to the native
+    // update-downloaded event makes this guard FALSE at exactly the moment a
+    // verification failure arrives, silently reclassifying install rejections as
+    // generic check errors. Re-anchor it to the active native preparation in the
+    // same change that moves the assignment.
     if (hasStagedBuild() && isStagedInstallRejection(err)) {
-      console.error("staged update rejected at install time; discarding cached download:", err);
+      // Squirrel verifies the bundle it just extracted, in this process, before
+      // any ShipIt request exists. So a rejection indicts the EXTRACTED COPY.
+      //
+      // It does not by itself prove the cached archive is bad: electron-updater
+      // checked that archive against the feed's sha512 when it downloaded it,
+      // which establishes agreement with the feed AT THAT TIME — not a correctly
+      // signed release, and not the absence of later damage to the cache. So one
+      // re-preparation is worth attempting before the download is discarded.
+      //
+      // Disarm either way: the copy Squirrel holds cannot install, and leaving
+      // it staged makes the UI promise a restart that fails. Dropping the staged
+      // record re-enables auto-download, so the next check re-stages and
+      // re-prepares from the archive already in the cache.
+      //
+      // Bounding automatic retries (a stop, and a defined reset) belongs with
+      // the attempt-lifecycle work, not here: this only makes the existing
+      // unbounded retry cheaper, it does not introduce it.
+      const failures = recordInstallRejection(stagedVersion);
+      handledInstallRejection = { version: stagedVersion };
       discardStagedBuild();
-      void clearPendingUpdateCache();
+      // Only once a re-preparation has ALSO failed is the archive worth
+      // suspecting. Purging earlier costs a full re-download to fix a copy that
+      // may well prepare cleanly on the next attempt.
+      //
+      // Queued on the operation chain rather than fired and forgotten:
+      // discardStagedBuild() re-enables auto-download, so the next check can
+      // start a download into the very directory this is emptying.
+      if (failures > 1) {
+        void runSerializedUpdaterOperation(
+          "cache-clear",
+          clearPendingUpdateCache,
+        ).catch(() => undefined);
+      }
+      console.error(
+        `staged update rejected at install time (attempt ${failures}${failures > 1 ? ", discarding cached download" : ""}):`,
+        err,
+      );
       broadcast(
         withActiveRequest({
           state: "error",
           message:
-            "Couldn't install the update — the downloaded copy was rejected. " +
-            "AO will download it again on the next check. If it keeps failing, " +
-            "download the latest build manually and install it over this one.",
+            failures > 1
+              ? "Couldn't install the update — the copy failed verification again. " +
+                "AO has discarded the download and will fetch it again. If it keeps " +
+                "failing, download the latest build manually and install it over this one."
+              : "Couldn't install the update — the downloaded copy failed verification. " +
+                "AO will prepare it again on the next check.",
         }),
       );
       return;

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1000,6 +1000,49 @@ function isManifest404Error(err: unknown): boolean {
 const STAGED_INSTALL_REJECTION_PATTERN =
   /did not pass validation|failed to get static code for bundle/i;
 
+/**
+ * A redundant native staging request that Squirrel refused — not a failure.
+ *
+ * SQRLUpdater.checkForUpdatesCommand is a RACCommand built with
+ * `initWithEnabled:` and never sets `allowsConcurrentExecution`, which defaults
+ * to NO. RACCommand computes `moreExecutionsAllowed` as
+ * `allowsConcurrentExecution ? YES : !executing`, so calling `-execute:` while a
+ * staging run is in flight does not queue: it returns `[RACSignal error:]` with
+ * domain RACCommandErrorDomain and code RACCommandErrorNotEnabled (1), carrying
+ * the message "The command is disabled and cannot be executed".
+ *
+ * MacUpdater asks the native updater to fetch on every completed download, so a
+ * download finishing while the previous build is still being staged produces
+ * exactly this. It arrives twice — re-emitted onto electron-updater's own error
+ * event, and as a rejection of the download promise (MacUpdater registers
+ * `nativeUpdater.once("error", reject)` before kicking the native check off).
+ * Untreated, that raw string reached the user as an update failure.
+ *
+ * Matched STRUCTURALLY, unlike the install-rejection pattern below: Electron's
+ * three-argument AutoUpdater::OnError sets `code` and `domain` on the JS Error
+ * (electron_api_auto_updater.cc), so there is no need to match on text here.
+ * Verified against Electron 33.4.11, which pins Squirrel.Mac 0e5d146 and
+ * ReactiveObjC 74ab5ba.
+ *
+ * The redundant handoff itself is a symptom of nothing owning an attempt through
+ * native staging; this only stops it being reported as a failure.
+ */
+function isNativeStagingBusyError(err: unknown): boolean {
+  const e = err as { code?: unknown; domain?: unknown };
+  return e?.domain === "RACCommandErrorDomain" && e?.code === 1;
+}
+
+/**
+ * Leave the UI on a truthful terminal status after something that was not a
+ * failure. A manual path broadcasts "checking" before it starts, so simply
+ * swallowing the error would wedge the Settings spinner.
+ */
+function settleWithoutFailure(): void {
+  broadcastCompletedCheck(
+    hasStagedBuild() ? stagedDownloadedStatus() : { state: "not-available" },
+  );
+}
+
 function isStagedInstallRejection(err: unknown): boolean {
   return STAGED_INSTALL_REJECTION_PATTERN.test(errorMessage(err));
 }
@@ -1289,6 +1332,13 @@ function wireUpdaterEvents(): void {
       // the retry wording.
       downloadStalled = false;
       console.info("update download cancelled after stalling:", err);
+      return;
+    }
+    if (isNativeStagingBusyError(err)) {
+      // Squirrel is already staging a build; this request was refused, nothing
+      // failed. Reporting it would replace a true status with a native string
+      // the user cannot act on.
+      console.info("native staging already in progress; request refused:", err);
       return;
     }
     // Never crash on update failure (offline, unsigned macOS, etc.).
@@ -1685,6 +1735,11 @@ export async function checkForUpdatesNow(
       options.requestId,
     );
   } catch (err) {
+    if (isNativeStagingBusyError(err)) {
+      console.info("manual check refused: native staging already in progress:", err);
+      settleWithoutFailure();
+      return;
+    }
     if (isManifest404Error(err)) {
       console.info("manual update check failed:", err);
       broadcastCompletedCheck({
@@ -1753,6 +1808,11 @@ export async function returnToHome(
       requestId,
     );
   } catch (err) {
+    if (isNativeStagingBusyError(err)) {
+      console.info("return home refused: native staging already in progress:", err);
+      settleWithoutFailure();
+      return;
+    }
     broadcast({
       state: "error",
       message: (err as Error)?.message ?? "Return failed",
@@ -1792,6 +1852,11 @@ export async function downloadUpdateNow(requestId?: string): Promise<void> {
       requestId,
     );
   } catch (err) {
+    if (isNativeStagingBusyError(err)) {
+      console.info("download refused: native staging already in progress:", err);
+      settleWithoutFailure();
+      return;
+    }
     if (isManifest404Error(err)) {
       console.error("update download failed:", err);
       broadcast({

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,7 +1,7 @@
 import { autoUpdater } from "electron-updater";
 import { CancellationToken } from "builder-util-runtime";
-import { app, BrowserWindow, dialog } from "electron";
-import { accessSync, constants as fsConstants, existsSync, readFileSync } from "node:fs";
+import { app, BrowserWindow, dialog, autoUpdater as nativeAutoUpdater } from "electron";
+import { accessSync, constants as fsConstants, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import semver from "semver";
@@ -939,12 +939,110 @@ function isManifest404Error(err: unknown): boolean {
   return msg.includes("HttpError: 404") && /\.yml\b/i.test(msg);
 }
 
+// A staged build that the native installer refused to install, as opposed to
+// anything that goes wrong while checking for or downloading one.
+//
+// On macOS these originate in Squirrel.Mac's ShipIt and reach us verbatim:
+// MacUpdater re-emits every native failure onto electron-updater's own "error"
+// event (`this.nativeUpdater.on("error", it => this.emit("error", it))`), so
+// the report in #4254 —
+//
+//   Code signature at URL file:///.../update.M9ZvE0X/Agent Orchestrator.app/
+//   did not pass validation: code failed to satisfy specified code requirement(s)
+//
+// arrives at the handler below rather than at download time. Matching the
+// phrases instead of the whole string covers the sibling wordings ShipIt uses
+// for the same "the staged copy is not installable" outcome (#3034, #4175).
+const STAGED_INSTALL_REJECTION_PATTERN =
+  /did not pass validation|failed to satisfy specified code requirement|shipit/i;
+
+function isStagedInstallRejection(err: unknown): boolean {
+  return STAGED_INSTALL_REJECTION_PATTERN.test(errorMessage(err));
+}
+
+/**
+ * Drop electron-updater's cached pending download.
+ *
+ * Verified against the published electron-updater@6.8.9 tarball:
+ * DownloadedUpdateHelper.validateDownloadedPath short-circuits on existence
+ * alone once a build has been downloaded by the running instance ("check here
+ * only existence, not checksum"), and nothing in electron-updater clears that
+ * cache when the native install fails. So without this, every later check hands
+ * ShipIt the exact same staged bytes and fails identically until the app is
+ * restarted.
+ *
+ * downloadedUpdateHelper is `protected` on AppUpdater, so it is reached through
+ * a narrowed cast rather than `any`: the cast names the one member being
+ * borrowed, and the optional calls make this a no-op instead of a crash if a
+ * later electron-updater renames or removes it.
+ */
+async function clearPendingUpdateCache(): Promise<void> {
+  const helper = (
+    autoUpdater as unknown as {
+      downloadedUpdateHelper?: { clear?: () => Promise<void> } | null;
+    }
+  ).downloadedUpdateHelper;
+  try {
+    await helper?.clear?.();
+  } catch (err) {
+    console.error("could not clear the cached update download:", err);
+  }
+}
+
+// AO_E2E_UPDATE_SENTINEL is the absolute path the end-to-end mac update test
+// (scripts/e2e-mac-update.mjs) asks the app to write once an update is actually
+// STAGED on disk and ready for the ShipIt swap. Unset in every real build, so
+// this is a complete no-op for users.
+//
+// Do not delete this while tidying: scripts/e2e-mac-update.mjs refuses to run
+// against a bundle whose app.asar does not contain this exact string, so
+// dropping it silently disables the whole macOS update-hop e2e job rather than
+// failing it. That is what happened between #3012 and #4254, and
+// e2e-mac-update.test.mjs now asserts the coupling to keep it from recurring.
+export const E2E_UPDATE_SENTINEL_ENV = "AO_E2E_UPDATE_SENTINEL";
+
+// installE2EUpdateSentinel hangs the sentinel off the NATIVE macOS updater
+// (require("electron").autoUpdater, i.e. Squirrel.Mac), NOT electron-updater's
+// own "update-downloaded".
+//
+// That distinction is load-bearing and was verified against the published
+// electron-updater@6.8.9 tarball. In MacUpdater.updateDownloaded(),
+// dispatchUpdateDownloaded(event) fires FIRST and only then does
+// `if (this.autoInstallOnAppQuit) { this.nativeUpdater.checkForUpdates() }`
+// kick Squirrel into fetching from the local proxy server. So electron-updater
+// announces "downloaded" BEFORE Squirrel has fetched or staged anything: a
+// harness that quits on that signal stages nothing, installs nothing, and
+// reports a false failure or flaps. The native event is the one MacUpdater
+// itself listens to in order to set squirrelDownloadedUpdate = true, and it is
+// the only signal that means "staged, will swap on quit". See #3288.
+//
+// macOS only in practice: NsisUpdater and AppImageUpdater never drive the
+// native updater, so this listener simply never fires off darwin.
+function installE2EUpdateSentinel(): void {
+  const sentinelPath = process.env[E2E_UPDATE_SENTINEL_ENV];
+  if (!sentinelPath) return;
+  nativeAutoUpdater.on("update-downloaded", (_event, _notes, releaseName) => {
+    try {
+      // Written synchronously: the harness quits the app right after seeing
+      // this file, so an async write could lose the race with termination.
+      writeFileSync(
+        sentinelPath,
+        `${JSON.stringify({ stagedAt: Date.now(), releaseName: releaseName ?? null })}\n`,
+      );
+      console.info(`[e2e] native updater staged ${releaseName ?? "an update"}; wrote ${sentinelPath}`);
+    } catch (err) {
+      console.error("[e2e] failed to write update sentinel:", err);
+    }
+  });
+}
+
 // wireUpdaterEvents registers electron-updater listeners once and forwards each
 // to the renderer as an UpdateStatus. Idempotent: safe to call on every entry
 // point (launch auto-check and manual check).
 function wireUpdaterEvents(): void {
   if (eventsWired) return;
   eventsWired = true;
+  installE2EUpdateSentinel();
   // With a build staged, "checking" briefly hides the sidebar restart row; that
   // is acceptable and self-healing: the available / not-available handlers below
   // restore the enriched downloaded status right after.
@@ -1072,6 +1170,38 @@ function wireUpdaterEvents(): void {
     // decision and must not suppress the telemetry: automatic checks are the
     // main way an install goes silently stale.
     emitUpdateFailure(err);
+    // The native installer rejected the build already sitting in the cache
+    // (#4254). This is the one failure class that cannot be left to the
+    // automatic path's suppress-and-retry, because retrying it is exactly what
+    // does not work: electron-updater re-serves the same cached bytes to
+    // Squirrel on every subsequent check for the lifetime of this process, so
+    // the install fails identically forever while the UI keeps offering a
+    // restart that cannot succeed.
+    //
+    // Dropping the cached download turns the next check back into a real
+    // download-and-verify instead of a replay, and disarming the staged state
+    // stops the sidebar promising an install that is no longer possible. The
+    // cost is one re-download when a rejection was transient, which is the
+    // right trade against an install that is otherwise stuck until relaunch.
+    //
+    // Deliberately narrow: the richer in-app remediation for this class (the
+    // direct-download offer after repeated failures) belongs to #3528, and the
+    // pre-v0.11.0-baseline hop that provokes it belongs to #3288's matrix.
+    if (hasStagedBuild() && isStagedInstallRejection(err)) {
+      console.error("staged update rejected at install time; discarding cached download:", err);
+      discardStagedBuild();
+      void clearPendingUpdateCache();
+      broadcast(
+        withActiveRequest({
+          state: "error",
+          message:
+            "Couldn't install the update — the downloaded copy was rejected. " +
+            "AO will download it again on the next check. If it keeps failing, " +
+            "download the latest build manually and install it over this one.",
+        }),
+      );
+      return;
+    }
     if (activeUpdaterOperation === "automatic-check") {
       console.error("auto-update check failed:", err);
       recordAutomaticCheckFailure(err);

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1030,6 +1030,44 @@ let installRejections: { version: string | undefined; count: number } | undefine
  */
 let handledInstallRejection: { version: string | undefined } | undefined;
 
+/**
+ * How many times one build may fail verification before AO stops re-preparing
+ * it on every check.
+ *
+ * Two: the first failure buys a re-preparation from the archive already in the
+ * cache, the second discards that archive. A third automatic attempt would just
+ * re-download the same bytes on every check forever, which is the loop this
+ * bound exists to stop.
+ */
+const MAX_AUTOMATIC_INSTALL_ATTEMPTS = 2;
+
+/**
+ * True once a build has used up its automatic recovery attempts.
+ *
+ * Checked before an automatic check arms auto-download, which is the only place
+ * the loop can be broken: the download is started by checkForUpdates() itself,
+ * before the offered version is known, so this cannot discriminate by version at
+ * that point. It is deliberately cleared as soon as the feed offers something
+ * else, or the user asks explicitly — see forgetInstallRejections.
+ */
+function automaticRecoveryExhausted(): boolean {
+  return (
+    installRejections !== undefined &&
+    installRejections.count >= MAX_AUTOMATIC_INSTALL_ATTEMPTS
+  );
+}
+
+/**
+ * Reset the budget.
+ *
+ * Called when the feed offers a different build (a new target gets its own
+ * attempts) and on an explicit manual check or download (the user asking again
+ * is the "explicit retry" route the exhausted message points at).
+ */
+function forgetInstallRejections(): void {
+  installRejections = undefined;
+}
+
 /** Count this rejection and report how many times this build has now failed. */
 function recordInstallRejection(version: string | undefined): number {
   installRejections =
@@ -1152,6 +1190,14 @@ function wireUpdaterEvents(): void {
       broadcastCompletedCheck(stagedDownloadedStatus());
       return;
     }
+    // A different build is a different target, so it starts with a full budget
+    // even if the previous one exhausted its own.
+    if (
+      installRejections !== undefined &&
+      info?.version !== installRejections.version
+    ) {
+      forgetInstallRejections();
+    }
     pendingUpdateVersion = info?.version;
     offeredReleaseNotes = normalizeReleaseNotes(info?.releaseNotes) ?? directFeedReleaseNotes;
     broadcastCompletedCheck({ state: "available", version: info?.version });
@@ -1255,9 +1301,9 @@ function wireUpdaterEvents(): void {
     // (#4254). This is the one failure class that cannot be left to the
     // automatic path's suppress-and-retry, because retrying it is exactly what
     // does not work: electron-updater re-serves the same cached bytes to
-    // Squirrel on every subsequent check for the lifetime of this process, so
-    // the install fails identically forever while the UI keeps offering a
-    // restart that cannot succeed.
+    // Squirrel on every subsequent check for the lifetime of this process,
+    // rather than a fresh download — while the UI keeps offering a restart that
+    // nothing has re-verified.
     //
     // Dropping the cached download turns the next check back into a real
     // download-and-verify instead of a replay, and disarming the staged state
@@ -1299,10 +1345,8 @@ function wireUpdaterEvents(): void {
       // record re-enables auto-download, so the next check re-stages and
       // re-prepares from the archive already in the cache.
       //
-      // Bounding automatic retries (a stop, and a defined reset) belongs with
-      // the attempt-lifecycle work, not here: this only makes the existing
-      // unbounded retry cheaper, it does not introduce it.
       const failures = recordInstallRejection(stagedVersion);
+      const exhausted = failures >= MAX_AUTOMATIC_INSTALL_ATTEMPTS;
       handledInstallRejection = { version: stagedVersion };
       discardStagedBuild();
       // Only once a re-preparation has ALSO failed is the archive worth
@@ -1312,24 +1356,25 @@ function wireUpdaterEvents(): void {
       // Queued on the operation chain rather than fired and forgotten:
       // discardStagedBuild() re-enables auto-download, so the next check can
       // start a download into the very directory this is emptying.
-      if (failures > 1) {
+      if (exhausted) {
         void runSerializedUpdaterOperation(
           "cache-clear",
           clearPendingUpdateCache,
         ).catch(() => undefined);
       }
       console.error(
-        `staged update rejected at install time (attempt ${failures}${failures > 1 ? ", discarding cached download" : ""}):`,
+        `staged update rejected at install time (attempt ${failures}${exhausted ? ", discarding cached download and stopping automatic retries" : ""}):`,
         err,
       );
       broadcast(
         withActiveRequest({
           state: "error",
           message:
-            failures > 1
-              ? "Couldn't install the update — the copy failed verification again. " +
-                "AO has discarded the download and will fetch it again. If it keeps " +
-                "failing, download the latest build manually and install it over this one."
+            exhausted
+              ? "Couldn't install the update — the copy failed verification twice. " +
+                "AO has discarded the download and stopped retrying on its own. Check " +
+                "for updates again to start a fresh one, or download the latest build " +
+                "manually and install it over this one."
               : "Couldn't install the update — the downloaded copy failed verification. " +
                 "AO will prepare it again on the next check.",
         }),
@@ -1439,8 +1484,13 @@ async function runAutomaticUpdateCheck(
       // downloading is off, or quitting installs the build they moved away from.
       const staleStaged = stagedBuildIsStale(settings);
       if (staleStaged) discardStagedBuild();
+      // automaticRecoveryExhausted() breaks the re-download loop: without it a
+      // build that keeps failing verification is fetched and re-prepared on
+      // every check, forever. A stale staged build still overrides, because
+      // leaving THAT one armed installs a channel the user has left.
       autoUpdater.autoDownload =
-        staleStaged || (settings.enabled && !hasStagedBuild());
+        staleStaged ||
+        (settings.enabled && !hasStagedBuild() && !automaticRecoveryExhausted());
       applyInstallOnQuitPolicy();
       // Only prerelease channels resolve a direct feed. Skipping the await on
       // stable keeps that check's event ordering exactly as it was.
@@ -1590,6 +1640,8 @@ export async function checkForUpdatesNow(
 ): Promise<void> {
   escalationStateDir = stateDir;
   wireUpdaterEvents();
+  // Asking again IS the explicit retry the exhausted message points at.
+  forgetInstallRejections();
 	if (!app.isPackaged) {
     emitUpdateOutcome({
       event: "ao.renderer.update_unsupported",
@@ -1712,6 +1764,7 @@ export async function returnToHome(
 // downloadUpdateNow starts downloading the update found by checkForUpdatesNow.
 export async function downloadUpdateNow(requestId?: string): Promise<void> {
   wireUpdaterEvents();
+  forgetInstallRejections();
 	if (!app.isPackaged) {
     emitUpdateOutcome({
       event: "ao.renderer.update_unsupported",


### PR DESCRIPTION
Makes a rejected install **recoverable** instead of a dead end, and restores the update-hop coverage that should have caught it.

> **Scope note.** This does **not** fix #4254. What corrupts the occasional extraction is still undiagnosed — an earlier transport-truncation theory of mine was disproved (Node's `server.close()` is graceful, and the operation lock is wider than I claimed). This PR is a resilience and honesty layer: stop promising a restart that cannot work, and say something actionable when it fails.

## What is actually wrong

Not signing, not packaging. Both published ZIPs for the hop in the latest report (v0.12.10 → v0.12.11-nightly.202609052046) were independently hash-matched, `codesign --deep --strict` verified, stapled and Gatekeeper-accepted, and the same hop installed cleanly on my machine today (`ShipIt_stderr.log`: `2026-09-05 14:44:52 Installation completed successfully`, five successful installs over five days, zero errors). Nothing here touches signing, packaging, or the nightly no-DMG policy.

Two separate defects turn a *single* install rejection into a permanent one, and hide it from CI.

### 1. The retry cannot possibly work

`MacUpdater` re-emits every native Squirrel failure onto electron-updater's own `error` event:

```js
this.nativeUpdater.on("error", it => { ...; this.emit("error", it) })   // MacUpdater.js:18
```

so ShipIt's `did not pass validation: code failed to satisfy specified code requirement(s)` arrives in our error handler — where it was treated as a generic check failure, and on the automatic path suppressed entirely.

Then, from the published `electron-updater@6.8.9` tarball:

```js
async validateDownloadedPath(updateFile, updateInfo, fileInfo, logger) {
    if (this.versionInfo != null && this.file === updateFile && this.fileInfo != null) {
        // update has already been downloaded from this running instance
        // check here only existence, not checksum
        if (isEqual(...) && (await pathExists(updateFile))) return updateFile
```

Once the running instance has downloaded a build, the cached copy is re-served on **existence alone** — never re-hashed — and nothing in electron-updater clears that cache when the *native install* fails. So every subsequent check hands Squirrel the identical staged bytes rather than a fresh download. Whether that then fails again depends on where the fault actually is: a maintainer's machine recovered on its own within ~60s on 2026-09-06, so "fails forever" is **not** supportable — but the UI keeps offering a restart-to-install with nothing having re-verified it, and the archive is never re-hashed while the process lives.

**Fix:** when a build is staged and the error is an install rejection, disarm the staged build, drop the cached pending download so the next check becomes a real download-and-verify instead of a replay, and broadcast an actionable message rather than a raw Squirrel dump. This branch runs *before* the automatic-check suppression, because suppress-and-retry is precisely what does not work for this class.

### 2. There was no update-hop coverage, and its absence was invisible

`scripts/e2e-mac-update.mjs` learns that an update actually **staged** by waiting on an `AO_E2E_UPDATE_SENTINEL` listener in `auto-updater.ts` (added by #3294). An unrelated reformat in #3012 (`9caafbee8`, 2026-07-31) deleted it:

```
$ git log --oneline -S"E2E_UPDATE_SENTINEL_ENV" -- frontend/src/main/auto-updater.ts
9caafbee8 fix(updater): suppress auto-update error dialogs ... (#3012)   <- removed
0bdfbe6b6 feat(macos): release hardening ...                (#3294)     <- added
```

The guard (`assertSentinelCapable`) only inspects a **built** `app.asar`, and it fails by *refusing to run* with a message about picking a newer baseline. So the failure reads as "you chose an old baseline", not "the app no longer emits the signal" — and the macOS update-hop job has been unrunnable against **any** baseline for five weeks. I verified the string is absent from the real published v0.12.10 bundle.

**Fix:** restore the listener (verbatim from #3294, still hung off the *native* updater — electron-updater's own `update-downloaded` fires before Squirrel has fetched anything, so keying on it stages nothing), and assert the coupling from a unit test so a future tidy-up fails in the same commit instead of silently disabling a job. Verified the guard bites: renaming the constant fails the new test.

## Scope, and what I deliberately did not do

- **The direct-download remediation after repeated failures stays with #3528.** This PR only stops the loop and replaces the raw Squirrel string with something actionable.
- **The pre-v0.11.0 baseline hop stays with #3288** — and it needs design work first, not just a matrix entry: v0.10.0 predates the sentinel, so it can never signal staging and `assertSentinelCapable` will reject it by construction. Testing that baseline needs a different staging signal (polling the ShipIt cache dir).
- **No free-space / ENOSPC handling.** Ruled out by the entry-order evidence below, and the maintainer confirms disk space was not a problem on the affected Mac. A disk-space preflight (#3528) would not have prevented this.

## Reproduction and evidence

Disk space is **ruled out**, not merely unconfirmed — see the elimination below. No free-space handling is added here.

Fully isolated: separate `HOME`, `TMPDIR`, `AO_DATA_DIR`, `AO_RUN_FILE`, Electron `userData`, updater cache and ShipIt cache, launched with `env -i`. Production AO data, the installed app and the real updater cache were never touched. Adequate free disk throughout (>9 GB).

### The published artifact is sound (independently re-verified)

Downloaded `Agent.Orchestrator-darwin-arm64-0.12.11-nightly.202609052046.zip` fresh: size `176688854` = feed exactly; SHA-512 `RQ/iTIQvANcRTh2f…qA==` = feed exactly; `ditto -x -k` rc=0; `codesign --verify --deep --strict` rc=0; **passes `-R` against the running app's designated requirement** (the one ShipIt actually checks); `stapler validate` OK; `spctl` accepted as Notarized Developer ID.

### What the error string actually means

Electron v33.4.11 patches Squirrel.Mac (`patches/squirrel.mac/fix_use_kseccschecknestedcode_kseccsstrictvalidate_in_the_sec.patch`), so the effective verify call is:

```objc
SecStaticCodeCheckValidityWithErrors(staticCode,
    kSecCSCheckNestedCode | kSecCSStrictValidate | kSecCSCheckAllArchitectures,
    (__bridge SecRequirementRef)self.requirement, &validityError);   // = 0x19
```

against the *running* app's designated requirement. The patch exists precisely "to ensure Squirrel.Mac validates the nested bundles (nested Frameworks)". `codesign(1)` applies its own defaults and cannot model this, so I called the API directly and mutated the verified bundle one way at a time:

| Mutation of the staged bundle | `0x1` | `0x9` | **`0x19` (effective)** |
|---|---|---|---|
| control / all xattrs stripped | PASS | PASS | **PASS** |
| root executable removed or zero-length | -67062 | -67062 | **-67062** |
| nested helper `.app` executable removed | -67062 | -67062 | **-67062** |
| `Electron Framework` / `Squirrel.framework` binary removed | -67062 | -67062 | **-67062** |
| `_CodeSignature/` removed | -67023 | -67023 | **-67023** |
| `Resources/daemon/ao`, `tmux`, `agent-browser` zeroed | -67054 | -67054 | **-67054** |

`-67062` = `errSecCSUnsigned` = *"code object is not signed at all"*. Identical across all three flag sets.

So the report means: **the staged bundle's root code object, or a nested helper `.app`/framework binary, is missing or unsigned.** Seal damage (-67023) and sealed-resource damage (-67054) are excluded. The error cannot distinguish root from nested.

This also confirms the two reports in the issue are different failures: the original v0.10.0 one (`code failed to satisfy specified code requirement(s)`) is a requirement failure, so the AppleDouble/symlink theory does not explain this one.

### Reproduced: the repeated-request loop strips a staged bundle

Ran a real **v0.12.10** baseline against the live Nightly feed, fully isolated. It resolved and downloaded `0.12.11-nightly.202609052046` (arm64). Sampling the ShipIt staging directory once a second:

```
17:24:54  update.okxiJh2  exe=69632   helper=ABSENT   fw=0  plist=ABSENT   <- extracting
17:24:57  update.okxiJh2  exe=69632   helper=122000   fw=8  plist=ok       <- complete, valid
17:39:57  update.okxiJh2  exe=ABSENT  helper=122000   fw=8  plist=ok       <- *** executable gone ***
17:39:58  update.4hDq9mS  exe=69632   helper=ABSENT   fw=0  plist=ABSENT   <- next request stages afresh
17:40:00  update.4hDq9mS  exe=69632   helper=122000   fw=8  plist=ok
```

At **17:39:57** — 15 minutes on the dot after the first staging, one second before the next request — the completed staging directory had its **main executable removed while `Info.plist`, the helpers and all 8 frameworks remained**. That is byte-for-byte the `root executable removed` row above, i.e. **exactly the state that yields `errSecCSUnsigned`**. 9 install requests were recorded in ~20 minutes.

So the pre-#4849 repeated-request loop demonstrably produces the precise corrupt staging state this bug reports. What I did *not* observe is a verification landing inside that window — this run's install completed successfully and the app ended on `0.12.11-nightly.202609052046`. The corrupt state and the race window are reproduced; the collision itself remains timing-dependent, which fits the intermittency and the self-healing in #4175.

### Why truncation — and therefore ENOSPC — cannot be the cause

Entry order in the published ZIP (7,152 files):

| Entry | Position |
|---|---|
| `Contents/_CodeSignature/CodeResources` | **#5** |
| `Contents/MacOS/agent-orchestrator` | **#7** |
| `Contents/Info.plist` | **#7,151 (last)** |

The executable comes out essentially first and `Info.plist` last, so any short read loses `Info.plist` and keeps the executable — the opposite of the observed failure. Confirmed empirically: `ditto -x -k` on a 116 MB prefix of the 176 MB ZIP produced a full 69,632-byte `MacOS/agent-orchestrator`, no `Info.plist`, and `bundle format unrecognized`. Independently, `ditto` exits non-zero on a short ZIP and Squirrel captures that as `SQRLZipArchiverExitCodeErrorKey`, so a truncated download surfaces as a **ZIP error, never a signature error**.

### The trigger: v0.12.10 predates #4849

```
v0.12.10           published 2026-08-31T05:19:26Z
190df05fc (#4849)  merged    2026-09-05 02:16
merge-base --is-ancestor 190df05fc v0.12.10  -> NO   (v0.12.10 lacks the fix)
merge-base --is-ancestor 190df05fc 7e8a66229 -> YES  (the offered nightly has it)
```

#4849's live measurements on a pre-fix install: a Squirrel install request **every 15 minutes** — **526 total against 10 actual installs since Jul 4** — with `update.zip` rewritten in full and ShipIt logging the next install request 3 seconds later.

So an affected v0.12.10 machine re-extracts ~175 MB into a fresh `update.XXXX/` under one shared ShipIt cache root and verifies it, every 15 minutes, indefinitely, while the user sits on a staged build. Overlapping extract → verify → cleanup cycles over one staging root can leave a tree whose nested code objects are gone while its structure survives — exactly the signature above. Consistent with my isolated repro of **142 ShipIt relaunches in ~5 minutes** and with this machine's 5/5 successes on a build that *has* #4849.

**Why that does not make this PR redundant:** #4849 fixes the trigger but is undeliverable to the population that needs it, because receiving it requires the update that is failing. A stranded v0.12.10 user cannot reach the fix by updating, so a recovery path is the only way out.

### Other prioritized hypotheses, checked

- **Architecture / feed selection — sound.** `MacUpdater.filterFilesForArch` selects on the `arm64` substring in the filename; the feed lists both slices with correct sizes/hashes; an arm64 host selects the arm64 ZIP (my isolated run logged exactly that). Rosetta hosts deliberately also take arm64.
- **Designated requirement drift — none.** The running app's DR is the standard Developer ID form (`X9LNSP8MC2`), and the freshly downloaded nightly validates against it.
- **Quarantine / translocation — not implicated.** The installed app carries no `com.apple.quarantine` and is not translocated; ShipIt clears quarantine itself (`clearQuarantineForDirectory:`), and stripping every xattr still passes verification.
- **Unsigned feature build behind a "Nightly" dropdown — ruled out.** Feature builds are properly Developer ID signed (`Authority=Developer ID Application: Prateek Karnal (X9LNSP8MC2)`, `flags=0x10000(runtime)`), verified by pulling the first 8 MB of a `pr<N>` release. Checking it did surface a separate display bug — `UpdatesSection.tsx:159` ignores a non-null `feature` pin for display unless `developerMode`, while `configureFeed` gives the pin absolute priority, so Settings can read "Nightly" while the updater is pinned to `pr<N>`. Not this bug's cause; flagged on the issue for its own ticket.
- **Cached/staged artifact identity — this is the real exposure.** `validateDownloadedPath` reuses the cached ZIP on existence alone within a process, and `updateDownloaded` serves it to Squirrel with `Content-Length` taken from the **feed** (`zipFileInfo.info.size`), never from the file on disk. Nothing re-hashes between "verified download" and "handed to Squirrel". That is why a mutated staged copy is replayed indefinitely, and it is what this PR fixes.

### Not reproduced

I could not make the hop fail on a healthy machine: it succeeded here (5/5 ShipIt installs over 5 days, including this exact hop today). The mutation is environmental — a concurrent staging cleanup or an external agent touching `~/Library/Caches` are both consistent with the signature — so this PR fixes AO's *response* to it, which is cause-agnostic, rather than guessing at the trigger.

Worth flagging separately: my isolated run reproduced **142 ShipIt relaunches in ~5 minutes**, each failing `ShipItState.plist … no such file`, and **each relaunch truncates `ShipIt_stderr.log`**. That is why reports in this family only ever carry the last error and never the first one's cause. Combined with the note at `auto-updater.ts:1240` that a cache hit "hands Squirrel a fresh install request", concurrent installers sharing one staging directory is a plausible in-house trigger for the post-extraction removal — but I have not reproduced that, so it is flagged, not claimed.

## Tests

- `staged install rejection`: clears the cached download and disarms the staged build; surfaces the failure even on an automatic check (where it would otherwise be suppressed); leaves an ordinary download failure completely alone.
- `e2e staging sentinel`: writes from the **native** updater's `update-downloaded` and *not* from electron-updater's; registers nothing when the env var is unset.
- `update-hop coverage is wired to the app`: fails if the listener is deleted again.


---

## Added: update status pushes never reached the renderer at all

Found while chasing a separate report ("Last checked" not moving until Settings is closed and reopened). It turned out to be undelivered IPC, and it **blocks this PR's own fix**, so it is fixed here rather than separately.

`broadcast()` pushed status by walking `BrowserWindow.getAllWindows()`. Since **#3750** (`22c121720`, 2026-08-09) the shell is a `BaseWindow` hosting the UI in a `WebContentsView`:

```ts
mainWindow = new BaseWindow(windowOptions);
const composition = createWindowComposition({ mainWindow, WebContentsView, preload: preloadPath() });
```

`BrowserWindow.getAllWindows()` only returns `BrowserWindow` instances, so that loop matched nothing and **every `updates:status` and `updates:telemetry` push has been dropped since 2026-08-09**, shipped in v0.12.11.

It stayed invisible because `invoke` replies to its own sender regardless of window type, so `updates:getStatus` kept working — the UI was correct on every open and frozen while open, which reads as a renderer caching bug. Confirmed from a user's devtools: after clicking Check, `updates.check` resolved and **no push arrived at all**.

`main.ts` already had the right pattern for its one other push — `getShellWebContents()?.send("daemon:status", …)` — so the updater now sends to the same target via an injected resolver (`main.ts` owns the shell handle), resolved per send so a recreated window keeps receiving.

**Three distinct user-visible symptoms, one cause.** Every `updates:status` push goes through `broadcast()`, so all of them were dead, not just the timestamp:

| Symptom | Push that never arrived |
|---|---|
| "Last checked" frozen until Settings is reopened | `broadcastCompletedCheck` |
| Download bar stuck at a stale percentage | `download-progress` → `broadcastUpdaterStatus` |
| Install rejection surfaced nothing | the status this PR adds |

The download-bar case was reported on `0.12.12-nightly.202609061620` while this PR was still open, i.e. against a build without the fix — independent confirmation from a second symptom.

**Why it belongs in this PR:** the install-rejection status added above is broadcast through exactly this path. Without this fix the actionable message never reaches the user, and the recovery is silent.

**Regression lock:** the mock window registry in `auto-updater.test.ts` is now empty, matching the packaged app, so all 119 cases exercise the real delivery path instead of a fake window that hid the bug. Restoring the old walk fails 8 of them. Three added cases pin it directly: pushes must not touch `BrowserWindow`, the sink is resolved per send, and a missing sink must not throw.

Note this invalidates an earlier claim in my own analysis that the main process was "provably correct" — that test mocked `getAllWindows()` to return a fake window, which is precisely what concealed this.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | pass |
| `npm run typecheck:e2e` | pass |
| `npx vitest run` (full suite) | **280 files, 3872 passed, 7 skipped, 0 failed** |
| GitHub Actions on this PR | `test`, `renderer-smoke`, `scan` all pass |

Node 22.22.3 locally vs CI's Node 24 — the one gap I cannot close here. `mac-update-e2e.yml` itself is `workflow_dispatch`-only and needs a published baseline plus a live feed, so it cannot run locally; it should be dispatched once a build carrying the restored listener is published, which is the first time it will have been runnable since 2026-07-31.

Refs #3288, #3528, #3034, #4175

🤖 Generated with [Claude Code](https://claude.com/claude-code)







