### PR TITLE
refactor(agents): share the signed-in authentication predicate

### DIFF
--- a/backend/internal/domain/agent_readiness.go
+++ b/backend/internal/domain/agent_readiness.go
@@ -28,6 +28,16 @@ const (
 	AgentAuthenticationNotApplicable AgentAuthenticationState = "not_applicable"
 )
 
+// SignedIn reports whether this state means the user must not be asked to
+// authenticate: the harness was observed as authorized, or it needs no
+// authentication at all. These are the only two states that may present a
+// harness as usable, so callers should ask this rather than compare against
+// AgentAuthenticationAuthorized alone, which silently excludes API-key and
+// no-auth harnesses.
+func (s AgentAuthenticationState) SignedIn() bool {
+	return s == AgentAuthenticationAuthorized || s == AgentAuthenticationNotApplicable
+}
+
 // AgentEffectiveReadiness is derived from installation and authentication.
 type AgentEffectiveReadiness string
 

--- a/backend/internal/domain/agent_readiness_test.go
+++ b/backend/internal/domain/agent_readiness_test.go
@@ -27,6 +27,35 @@ func TestEffectiveAgentReadiness(t *testing.T) {
 	}
 }
 
+func TestAgentAuthenticationStateSignedIn(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state AgentAuthenticationState
+		want  bool
+	}{
+		{AgentAuthenticationAuthorized, true},
+		{AgentAuthenticationNotApplicable, true},
+		{AgentAuthenticationUnauthorized, false},
+		{AgentAuthenticationUnknown, false},
+		{AgentAuthenticationState("checking"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			t.Parallel()
+			if got := tt.state.SignedIn(); got != tt.want {
+				t.Fatalf("%q.SignedIn() = %t, want %t", tt.state, got, tt.want)
+			}
+		})
+	}
+	// Readiness derivation and the predicate must not drift apart.
+	for _, state := range []AgentAuthenticationState{AgentAuthenticationAuthorized, AgentAuthenticationNotApplicable, AgentAuthenticationUnauthorized, AgentAuthenticationUnknown} {
+		ready := EffectiveAgentReadiness(AgentInstallationInstalled, state) == AgentReadinessReady
+		if ready != state.SignedIn() {
+			t.Fatalf("%q: ready=%t but SignedIn=%t", state, ready, state.SignedIn())
+		}
+	}
+}
+
 func TestAgentReadinessPurposeValidation(t *testing.T) {
 	t.Parallel()
 	if !AgentReadinessPurposeDisplay.Valid() || !AgentReadinessPurposeLaunch.Valid() {

--- a/backend/internal/service/agent/codex_account_login.go
+++ b/backend/internal/service/agent/codex_account_login.go
@@ -150,7 +150,7 @@ func (m *codexAccountManager) verifyLogin(ctx context.Context, operationID strin
 	if observation.Authentication == domain.AgentAuthenticationUnauthorized {
 		return m.finishLogin(operationID, domain.CodexAccountLoginUnauthorized, domain.CodexAccountLoginReasonUnauthorized, "Codex is still signed out.", nil), nil
 	}
-	if observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable {
+	if !observation.Authentication.SignedIn() {
 		return m.finishLoginUnverified(operationID, "Codex could not verify this account."), nil
 	}
 	exclusive, exclusiveErr := m.acquireGlobalMutation(ctx)

--- a/backend/internal/service/agent/codex_account_mutation.go
+++ b/backend/internal/service/agent/codex_account_mutation.go
@@ -209,7 +209,7 @@ func (m *codexAccountManager) activateFromCredentialLocked(ctx context.Context, 
 	if currentErr != nil || !bytes.Equal(currentCredential, targetCredential) {
 		return domain.CodexActiveAccount{}, ports.ErrCodexGlobalAccountChanged
 	}
-	if err != nil || (observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable) || !m.observationAndCredentialIdentifyRecord(record, observation, currentCredential) {
+	if err != nil || !observation.Authentication.SignedIn() || !m.observationAndCredentialIdentifyRecord(record, observation, currentCredential) {
 		currentCredential, currentErr := readOpaqueCredential(globalPath)
 		if currentErr != nil || !bytes.Equal(currentCredential, targetCredential) {
 			return domain.CodexActiveAccount{}, ports.ErrCodexGlobalAccountChanged

--- a/backend/internal/service/agent/codex_account_reconcile.go
+++ b/backend/internal/service/agent/codex_account_reconcile.go
@@ -230,7 +230,7 @@ func (m *codexAccountManager) reconcileGlobalInner(ctx context.Context) error {
 		}
 		return nil
 	}
-	if observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable {
+	if !observation.Authentication.SignedIn() {
 		m.setGlobalAuthenticationFailure(failedAuthentication(m.now(), domain.AgentReadinessReasonAuthCheckInconclusive, "Authentication check was inconclusive."))
 		m.setUnmanagedGlobal("Device Codex account", observation.Method, observation.Email, "global_account_unverified", "AO could not verify the device's current Codex account.")
 		return nil
@@ -274,7 +274,7 @@ func (m *codexAccountManager) reconcileGlobalInner(ctx context.Context) error {
 		checked, checkErr := verifiedClient.Read(verifyCtx, true)
 		_ = verifiedClient.Close()
 		verifyCancel()
-		if checkErr != nil || (checked.Authentication != domain.AgentAuthenticationAuthorized && checked.Authentication != domain.AgentAuthenticationNotApplicable) {
+		if checkErr != nil || !checked.Authentication.SignedIn() {
 			m.setUnmanagedGlobal(accountLabel("device", observation.Method, observation.Email), observation.Method, observation.Email, "global_account_unverified", "AO could not verify the device's current Codex account for import.")
 			return nil
 		}
@@ -423,7 +423,7 @@ func (m *codexAccountManager) verifyOpaqueGlobalCredential(ctx context.Context, 
 	if readErr != nil {
 		return ports.CodexAccountObservation{}, readErr
 	}
-	if observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable {
+	if !observation.Authentication.SignedIn() {
 		return ports.CodexAccountObservation{}, errors.New("global Codex credential could not be verified in a file-backed store")
 	}
 	return observation, nil

--- a/backend/internal/service/agent/codex_account_service.go
+++ b/backend/internal/service/agent/codex_account_service.go
@@ -35,7 +35,7 @@ func (s *Service) structuredCodexAuthentication(ctx context.Context, agentID str
 		s.codexAccounts.mu.Lock()
 		global := s.codexAccounts.globalAuth
 		s.codexAccounts.mu.Unlock()
-		if global.State == domain.AgentAuthenticationAuthorized || global.State == domain.AgentAuthenticationNotApplicable || global.State == domain.AgentAuthenticationUnknown {
+		if global.State.SignedIn() || global.State == domain.AgentAuthenticationUnknown {
 			return global, true
 		}
 		return successfulAuthentication(s.codexAccounts.now(), domain.AgentAuthenticationUnauthorized, domain.AgentReadinessReasonUnauthorized, "Sign in to Codex or add an account in Settings."), true
@@ -430,7 +430,7 @@ func (s *Service) VerifyCodexAccountForSwitch(ctx context.Context, accountID str
 	_ = client.Close()
 	latestCredential, latest, latestErr := readCodexFileState(credentialPath, false)
 	stableOpaqueIdentity := distinguishableCodexIdentity(observation) || (latestErr == nil && sameCodexFileState(admitted, latest))
-	if err != nil || latestErr != nil || !stableOpaqueIdentity || (observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable) || !s.codexAccounts.observationAndCredentialIdentifyRecord(record, observation, latestCredential) || (!distinguishableCodexIdentity(observation) && !bytes.Equal(credential, latestCredential)) {
+	if err != nil || latestErr != nil || !stableOpaqueIdentity || !observation.Authentication.SignedIn() || !s.codexAccounts.observationAndCredentialIdentifyRecord(record, observation, latestCredential) || (!distinguishableCodexIdentity(observation) && !bytes.Equal(credential, latestCredential)) {
 		s.codexAccounts.requireReauthentication(record.Snapshot.ID)
 		return apierr.Conflict("CODEX_ACCOUNT_REAUTHENTICATION_REQUIRED", "Sign in again before switching to this Codex account", nil)
 	}
@@ -469,7 +469,7 @@ func (s *Service) VerifyCurrentCodexAccount(ctx context.Context, accountID strin
 	observation, readErr := client.Read(verifyCtx, false)
 	_ = client.Close()
 	latestCredential, latest, latestErr := readCodexFileState(globalPath, false)
-	if readErr != nil || (observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable) ||
+	if readErr != nil || !observation.Authentication.SignedIn() ||
 		latestErr != nil || !sameCodexFileState(admitted, latest) || !bytes.Equal(globalCredential, latestCredential) ||
 		!s.codexAccounts.observationAndCredentialIdentifyRecord(record, observation, latestCredential) {
 		return apierr.Conflict("CODEX_GLOBAL_ACCOUNT_CHANGED", "The device Codex account changed", nil)
@@ -595,7 +595,7 @@ func (s *Service) RestoreCodexAccountCredential(ctx context.Context, sourceAccou
 	_ = client.Close()
 	latestCredential, latest, latestErr := readCodexFileState(globalPath, false)
 	if readErr != nil ||
-		(observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable) ||
+		!observation.Authentication.SignedIn() ||
 		latestErr != nil || !sameCodexFileState(admitted, latest) || !bytes.Equal(admittedCredential, latestCredential) ||
 		!s.codexAccounts.observationAndCredentialIdentifyRecord(source, observation, latestCredential) {
 		return apierr.Unavailable("CODEX_ACCOUNT_SWITCH_ACTIVATION_UNCONFIRMED", "The previous Codex account could not be verified")

--- a/backend/internal/service/agent/codex_accounts.go
+++ b/backend/internal/service/agent/codex_accounts.go
@@ -522,7 +522,7 @@ func (m *codexAccountManager) finishAuthentication(id string, observation domain
 		// saved slot still belongs to the same account, and discarding its label
 		// would both hide who must sign in again and break global reconciliation's
 		// identity match.
-		identified := observation.State == domain.AgentAuthenticationAuthorized || observation.State == domain.AgentAuthenticationNotApplicable
+		identified := observation.State.SignedIn()
 		m.catalog.updateSnapshot(id, func(s *domain.CodexAccountSnapshot) {
 			s.Authentication = observation
 			if identified {

--- a/backend/internal/service/agent/readiness.go
+++ b/backend/internal/service/agent/readiness.go
@@ -216,7 +216,7 @@ func projectInventory(snapshots []domain.AgentReadinessSnapshot) Inventory {
 		if snapshot.Installation.State == domain.AgentInstallationInstalled {
 			inventory.Installed = append(inventory.Installed, info)
 		}
-		if snapshot.Authentication.State == domain.AgentAuthenticationAuthorized || snapshot.Authentication.State == domain.AgentAuthenticationNotApplicable {
+		if snapshot.Authentication.State.SignedIn() {
 			inventory.Authorized = append(inventory.Authorized, info)
 		}
 	}

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -9,6 +9,7 @@ import { ChevronLeft, TriangleAlert, X, type LucideIcon } from "lucide-react";
 import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { components } from "../../api/schema";
 import { useAgentReadinessQuery, useEnsureAgentReadiness } from "../hooks/useAgentReadinessQuery";
+import { agentAuthenticationSignedIn } from "../lib/agent-auth";
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import {
 	agentLabelCompare,
@@ -130,9 +131,7 @@ export function CreateProjectAgentSheet({
 	const agentOptions = useMemo(() => agents?.agents ?? [], [agents]);
 	const authorizedAgents = useMemo(
 		() =>
-			agentOptions.filter((agent) =>
-				["authorized", "not_applicable"].includes(agent.authentication.state),
-			),
+			agentOptions.filter((agent) => agentAuthenticationSignedIn(agent.authentication.state)),
 		[agentOptions],
 	);
 	const isLoadingAgents = agents === undefined && agentsQuery.isFetching;

--- a/frontend/src/renderer/hooks/codex-accounts-state.ts
+++ b/frontend/src/renderer/hooks/codex-accounts-state.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
+import { agentAuthenticationSignedIn } from "../lib/agent-auth";
 import type { CodexAccount, CodexAccountSwitch, CodexAccountsResponse } from "./useCodexAccountsQuery";
 
 export const codexAccountsQueryKey = ["codex-accounts"] as const;
@@ -41,7 +42,7 @@ export function writeCodexAccounts(
  * state here means the next Codex session can start.
  */
 export function codexAccountAuthorized(account: Pick<CodexAccount, "authentication">): boolean {
-	return account.authentication.state === "authorized" || account.authentication.state === "not_applicable";
+	return agentAuthenticationSignedIn(account.authentication.state);
 }
 
 export function codexAccountSignedOut(account: Pick<CodexAccount, "authentication" | "status">): boolean {

--- a/frontend/src/renderer/lib/agent-auth.ts
+++ b/frontend/src/renderer/lib/agent-auth.ts
@@ -1,0 +1,14 @@
+/** Normalized harness authentication states published by the daemon. */
+export type AgentAuthenticationState = "authorized" | "unauthorized" | "unknown" | "not_applicable";
+
+/**
+ * A harness counts as signed in when the daemon observed it as authorized, or
+ * decided it needs no authentication at all. Both mean the user must not be
+ * asked to sign in, so this is the only predicate the UI should use to present
+ * a harness as usable. Comparing against `authorized` alone silently excludes
+ * API-key and no-auth harnesses, and mirrors the daemon's
+ * `AgentAuthenticationState.SignedIn`.
+ */
+export function agentAuthenticationSignedIn(state: AgentAuthenticationState): boolean {
+	return state === "authorized" || state === "not_applicable";
+}

--- a/frontend/src/renderer/lib/agent-select-options.ts
+++ b/frontend/src/renderer/lib/agent-select-options.ts
@@ -1,6 +1,8 @@
+import { agentAuthenticationSignedIn, type AgentAuthenticationState } from "./agent-auth";
+
 export type AgentInfo = {
 	authentication: {
-		state: "authorized" | "unauthorized" | "unknown" | "not_applicable";
+		state: AgentAuthenticationState;
 		freshness: "fresh" | "stale" | "checking";
 	};
 	effectiveReadiness: "ready" | "not_ready" | "unknown";
@@ -93,8 +95,7 @@ export function buildRankedAgentOptions({
 		.map((agent) => {
 			const isInstallationUnknown = agent.installation.state === "unknown";
 			const isAuthUnknown = agent.authentication.state === "unknown";
-			const isAuthorized =
-				agent.authentication.state === "authorized" || agent.authentication.state === "not_applicable";
+			const isAuthorized = agentAuthenticationSignedIn(agent.authentication.state);
 			const isDefinitelyUnavailable =
 				agent.installation.state === "not_installed" || agent.authentication.state === "unauthorized";
 			const isSelectable = !isDefinitelyUnavailable;

--- a/frontend/src/renderer/test/agent-readiness-fixtures.ts
+++ b/frontend/src/renderer/test/agent-readiness-fixtures.ts
@@ -1,4 +1,5 @@
 import type { components } from "../../api/schema";
+import { agentAuthenticationSignedIn } from "../lib/agent-auth";
 
 export type AgentReadinessSnapshot = components["schemas"]["AgentReadinessSnapshot"];
 
@@ -35,7 +36,7 @@ export function agentReadiness(
 			reason: `${label} authentication test observation.`,
 		},
 		effectiveReadiness:
-			installation === "installed" && (authentication === "authorized" || authentication === "not_applicable")
+			installation === "installed" && agentAuthenticationSignedIn(authentication)
 				? "ready"
 				: installation === "not_installed" || authentication === "unauthorized"
 					? "not_ready"


### PR DESCRIPTION
Stacked on #4974 — targets that branch, so review/merge it after #4974. Cleanup only, no behavior change.

## Why

"Signed in" means `authorized` **or** `not_applicable`: a harness that needs no authentication must never be presented as needing a sign-in. That rule was open-coded at **11 backend sites** and **4 renderer sites** with no shared definition:

- `codex_account_service.go` ×4, `codex_account_reconcile.go` ×3, `codex_account_login.go`, `codex_account_mutation.go`, `codex_accounts.go`, `readiness.go`
- `CreateProjectAgentSheet.tsx`, `agent-select-options.ts`, `codex-accounts-state.ts`, `test/agent-readiness-fixtures.ts`

Any one of them could drift to comparing against `authorized` alone and silently exclude API-key and no-auth harnesses. This came out of review discussion on #4974: the display-vs-launch bug there was a shared function with a divergent flag, but it prompted a look at what else in the auth path is duplicated.

## What

- `domain.AgentAuthenticationState.SignedIn()` and the renderer's `agentAuthenticationSignedIn` mirror (new `frontend/src/renderer/lib/agent-auth.ts`), both documented with the reason the second state exists.
- Every open-coded copy now calls one of them. `codexAccountAuthorized` delegates rather than re-implementing.
- `agent-select-options.ts` now imports the state union instead of redeclaring it.

Each replaced expression is logically identical to the predicate — several were the negated form, which reads better as `!observation.Authentication.SignedIn()`.

## Deliberately not changed

- **Three exhaustive switches** keep their `case Authorized, NotApplicable` arms: `readiness.go` `readinessInfo`, `lifecycle_wiring.go` `AuthStatus`, and `EffectiveAgentReadiness` itself. There the two states are one arm of a total mapping over every state, not a predicate; rewriting them as if-chains would read worse and lose exhaustiveness.
- **`HarnessSettingsSection.tsx`** compares `ports.AgentAuthStatus`, a different three-value probe result that has no `not_applicable` state.
- **`agent-inventory-telemetry.ts:35`** filters on `state === "authorized"` only, while the daemon's `projectInventory` counts `authorized || not_applicable` as authorized. That looks like a real inconsistency, but changing it moves telemetry numbers, so it needs a product decision rather than a silent refactor. Flagging it here as a follow-up.

## Tests

- New `TestAgentAuthenticationStateSignedIn` pins all four states plus an unknown value, and asserts the invariant that `SignedIn` agrees with `EffectiveAgentReadiness` for every state — so the predicate and the readiness derivation cannot drift apart.
- `go test ./internal/domain/ ./internal/service/agent/ ./internal/service/session/ ./internal/daemon/ ./internal/httpd/controllers/` — pass.
- `golangci-lint run` — 0 issues.
- `npm run typecheck` — clean (remaining errors are only in `packages/product-ui`, whose deps are not installed in this worktree).
- Full `vitest run` — 7 failed files / 5 failed tests, **identical to the baseline on the parent branch**, all in `src/landing/**` from uninstalled landing deps in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)