### PR TITLE
fix(settings): align the Updates status icons with their text

### DIFF
--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -544,8 +544,10 @@ function UpdateActions({
 				/>
 				{channelSwitchMessage && <p className="text-xs leading-4 text-settings-muted">{channelSwitchMessage}</p>}
 				{checkedAt ? (
-					<p className="flex min-w-0 items-center gap-1.5 text-xs leading-4 tabular-nums text-settings-muted" data-testid="update-checked-at">
-						<Clock3 className="size-3 shrink-0" aria-hidden="true" />
+					<p className="flex min-w-0 items-start gap-2 text-xs leading-4 tabular-nums text-settings-muted" data-testid="update-checked-at">
+						<span className="flex h-4 shrink-0 items-center">
+							<Clock3 className="size-icon-sm shrink-0" aria-hidden="true" />
+						</span>
 						{t("settings.updates.lastChecked", { time: checkedAt })}
 					</p>
 				) : null}
@@ -668,7 +670,7 @@ function UpdateStatusLine({
 
 	return (
 		<div className={cn("flex min-w-0 items-start gap-2", className)}>
-			{icon !== null && <span className="mt-px shrink-0">{icon}</span>}
+			{icon !== null && <span className="flex h-5 shrink-0 items-center">{icon}</span>}
 			<div className="min-w-0">
 				<p className="text-pretty text-sm font-medium leading-5">{label}</p>
 				{detail !== null && (


### PR DESCRIPTION
Reported from the Updates page: the icons and their text do not line up.

There are **two** defects in that block, both visible at 1x.

## 1. The status icon sits ~2.5px high

```tsx
<div className="flex min-w-0 items-start gap-2">
  {icon !== null && <span className="mt-px shrink-0">{icon}</span>}
```

`--size-icon-sm` is **13px**; the first line is `text-sm leading-5`, a **20px** line box. Centring the icon on that line needs `(20 − 13) / 2 = 3.5px`. The wrapper carried `mt-px` — **1px**.

`items-start` is correct and stays: `detail` renders a second line and the icon belongs to the **first** one, so `items-center` would drift it down as soon as a build version is shown. The wrapper now takes that line's own height and centres inside it, which removes the hardcoded nudge — a number that would have gone wrong again on any change to the icon token or the text size.

## 2. The two stacked lines start in different columns

| Row | Icon | Gap | Text indent |
|---|---|---|---|
| `You're on the latest version.` | 13px (`size-icon-sm`) | `gap-2` (8px) | **21px** |
| `Last checked …` | 12px (`size-3`) | `gap-1.5` (6px) | **18px** |

Two lines directly on top of each other, staggered by 3px. The second row now matches the first and pins its icon to the first line the same way, so a wrapped timestamp cannot re-centre the clock across both lines.

This makes the clock 12px → 13px. That is the direction that reaches column alignment while using the design token instead of a raw `size-3`; shrinking the status icon to 12px would align them too but moves a tokenised size to a literal.

## Verification

Rendered both states against the real token values and lucide geometry at 4x, before and after — the fix was checked by eye, not by reading class names. Before: the check glyph sits above the text's optical centre and the clock row hangs 3px left of the column. After: both icons are centred and both rows share one text column.

No test added: the change is entirely utility classes, and asserting class strings would pin the implementation rather than the result while breaking on any restyle. The existing `UpdatesSection` tests (`data-testid="update-checked-at"` and siblings) still pass unchanged.

| Check | Result |
|---|---|
| `npm run typecheck` | pass |
| `npx vitest run` (full suite) | **278 files, 3804 passed, 7 skipped, 0 failed** |

Independent of #4981 (updater install-rejection recovery); branched from `main`, touches only this component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
