### PR TITLE
fix(chat): show submitted prompts while new sessions start

### DIFF
--- a/frontend/e2e/new-session-startup.spec.ts
+++ b/frontend/e2e/new-session-startup.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+import { agentReadiness } from "../src/renderer/test/agent-readiness-fixtures";
+import { installFakeAgent } from "./support/fake-bridge";
+
+// Real renderer with a held daemon response: isolates perceived startup latency
+// from provider inference. Never spawns a paid model or claims model speedups.
+for (const outcome of ["success", "failure", "background failure"] as const) {
+	test(`new task opens chat during startup and handles ${outcome} @T0`, async ({ page }, testInfo) => {
+		test.setTimeout(60_000);
+		await page.setViewportSize({ width: 1440, height: 1000 });
+		await installFakeAgent(page, { projectId: "startup", projectName: "Startup", workers: [] });
+		let delegateCount = 0;
+		let release!: () => void;
+		const startup = new Promise<void>((resolve) => { release = resolve; });
+		await page.route("http://127.0.0.1:8080/api/v1/**", async (route) => {
+			const path = new URL(route.request().url()).pathname;
+			if (path === "/api/v1/settings") {
+				await route.fulfill({ json: { defaultSessionMode: "chat", chatHarnesses: ["claude-code"] } });
+			} else if (path.startsWith("/api/v1/agents/readiness")) {
+				await route.fulfill({ json: { agents: [agentReadiness("claude-code", "Claude Code")] } });
+			} else if (path === "/api/v1/projects/startup") {
+				await route.fulfill({ json: { status: "ok", project: { id: "startup", config: { worker: { agent: "claude-code", agentConfig: { model: "opus" } } } } } });
+			} else if (path.endsWith("/models")) {
+				await route.fulfill({ json: { agent: "claude-code", selectionMode: "text", models: [], allowCustom: true, selected: {} } });
+			} else if (path === "/api/v1/orchestrators/delegate") {
+				delegateCount++;
+				expect(route.request().postDataJSON()).toMatchObject({ projectId: "startup", brief: "hi", agent: "claude-code" });
+				// Unchanged project-default Opus is inherited by the daemon.
+				expect(route.request().postDataJSON().model).toBeUndefined();
+				expect(route.request().postDataJSON().mode).toBeUndefined();
+				await startup;
+				if (outcome !== "success") {
+					await route.fulfill({ status: 422, json: { error: "invalid", code: "STARTUP_FAILED", message: "Could not initialize the agent" } });
+					return;
+				}
+				await page.evaluate(() => window.__aoFakeAgent!.createWorker({ id: "startup-worker", title: "hi", mode: "chat", provider: "claude-code" }));
+				await route.fulfill({ json: { workerId: "startup-worker" } });
+			} else if (path.endsWith("/conversation")) {
+				await route.fulfill({ json: { conversationId: "startup-conversation", sessionId: "startup-worker", harness: "claude-code", mode: "chat", controller: "ready", latestSequence: 1, oldestSequence: 1, hasMoreBefore: false,
+					turns: [{ id: "first-turn", state: "running", requestedAt: "2026-09-06T00:00:00Z" }],
+					messages: [{ kind: "message", id: "first-message", turnId: "first-turn", sequence: 1, revision: 0, role: "user", origin: "human", text: "hi", streaming: false, createdAt: "2026-09-06T00:00:00Z" }],
+					activities: [], settings: {} } });
+			} else {
+				await route.fulfill({ json: { status: "ok", files: [], skills: [] } });
+			}
+		});
+		await page.goto("/#/projects/startup");
+		await page.getByRole("button", { name: "New task", exact: true }).first().click();
+		await page.getByRole("textbox", { name: "Task", exact: true }).fill("hi");
+		await expect(page.getByRole("button", { name: "Model", exact: true })).toContainText(/opus/i);
+		const submittedAt = Date.now();
+		await page.getByRole("button", { name: "Start task", exact: true }).click();
+		await expect(page.getByText("Starting session…", { exact: true })).toBeVisible();
+		await expect(page.getByRole("dialog")).toHaveCount(0);
+		await expect(page.getByTestId("task-startup-underlying-route")).toHaveAttribute("inert", "");
+		await expect(page.locator("body")).not.toHaveCSS("pointer-events", "none");
+		await expect(page.getByText("hi", { exact: true })).toBeVisible();
+		const startupVisibleMs = Date.now() - submittedAt;
+		await expect.poll(() => delegateCount).toBe(1);
+		await expect(page).not.toHaveURL(/sessions\/startup-worker/);
+		await testInfo.attach("starting-session", { body: await page.screenshot(), contentType: "image/png" });
+		if (outcome === "background failure") {
+			await page.evaluate(() => { window.location.hash = "#/projects/startup/sessions/startup-orchestrator"; });
+			await expect(page.getByTestId("task-startup-chat")).toBeHidden();
+		}
+		if (outcome === "success") {
+			await page.evaluate(() => {
+				const fake = window.__aoFakeAgent!;
+				const snapshot = fake.snapshot;
+				const gate = new Promise<void>((resolve) => {
+					(window as unknown as { releaseStartupSnapshot: () => void }).releaseStartupSnapshot = resolve;
+				});
+				// fetchWorkspaces is async; hold its result without changing real rendering.
+				fake.snapshot = (() => gate.then(() => snapshot())) as unknown as typeof fake.snapshot;
+			});
+		}
+		const response = page.waitForResponse((response) => response.url().endsWith("/orchestrators/delegate"));
+		release();
+		await response;
+		if (outcome === "success") {
+			await expect(page.getByText("Starting session…", { exact: true })).toBeVisible();
+			await expect(page).not.toHaveURL(/sessions\/startup-worker/);
+			await page.evaluate(() => (window as unknown as { releaseStartupSnapshot: () => void }).releaseStartupSnapshot());
+		}
+		if (outcome === "background failure") {
+			await expect(page.getByRole("button", { name: "Return to draft", exact: true })).toBeVisible();
+			await expect(page).toHaveURL(/sessions\/startup-orchestrator/);
+			await page.getByRole("button", { name: "Return to draft", exact: true }).click();
+		}
+		if (outcome !== "success") {
+			await expect(page.getByRole("alert")).toContainText("Could not initialize the agent");
+			await expect(page.getByRole("textbox", { name: "Task", exact: true })).toHaveValue("hi");
+			await expect(page.getByRole("button", { name: "Start task", exact: true })).toBeEnabled();
+			await testInfo.attach("startup-failure", { body: await page.screenshot(), contentType: "image/png" });
+		} else {
+			await expect(page).toHaveURL(/sessions\/startup-worker/);
+			await expect(page.getByRole("region", { name: "Chat", exact: true })).toBeVisible();
+			await expect(page.getByRole("region", { name: "Chat", exact: true }).locator(".cursor-chat-human-message")).toHaveCount(1);
+			await expect(page.getByTestId("task-startup-chat")).toHaveCount(0);
+		}
+		expect(delegateCount).toBe(1);
+		await testInfo.attach("startup-timing", { body: JSON.stringify({ startupVisibleMs, delegateCount, note: "Held synthetic daemon response, not a provider benchmark" }), contentType: "application/json" });
+	});
+}

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -93,6 +93,7 @@ const ctx = vi.hoisted(() => {
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
+	useLocation: () => ({ href: "/" }),
 	useParams: () => ctx.params,
 }));
 

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams, useLocation } from "@tanstack/react-router";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type AnimationEvent, type MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
@@ -48,6 +48,9 @@ export function CommandPalette() {
 	const { i18n, t } = useTranslation();
 	const enabled = useCommandPaletteEnabled();
 	const navigate = useNavigate();
+	const location = useLocation();
+	const [composerContainer, setComposerContainer] = useState<HTMLDivElement | null>(null);
+	const [startup, setStartup] = useState(false);
 	const queryClient = useQueryClient();
 	const restoreSessionById = useRestoreSession();
 	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
@@ -437,13 +440,16 @@ export function CommandPalette() {
 	);
 
 	const handleTaskCreated = useCallback(
-		async (projectId: string, sessionId: string) => {
+		async (projectId: string, sessionId: string, focusSession = true) => {
+			const origin = window.location.href;
+			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey }, { throwOnError: true });
+			if (focusSession && window.location.href === origin) {
+				await navigate({
+					to: "/projects/$projectId/sessions/$sessionId",
+					params: { projectId, sessionId },
+				});
+			}
 			closePalette();
-			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId },
-			});
 		},
 		[navigate, queryClient, closePalette],
 	);
@@ -496,11 +502,30 @@ export function CommandPalette() {
 
 	return (
 		<>
+			{/* Keep request ownership outside Radix's replaceable modal content. */}
+			{isOpen && view.mode === "new-task" ? (
+				<TaskComposer
+					container={composerContainer}
+					projectId={view.projectId}
+					navigationKey={location.href}
+					onStartupChange={setStartup}
+					onDiscard={closePalette}
+					autoFocusTitle
+					onDirtyChange={onComposerDirtyChange}
+					onSubmittingChange={onComposerSubmittingChange}
+					onCreated={(sessionId, focusSession) => handleTaskCreated(view.projectId, sessionId, focusSession)}
+				/>
+			) : null}
 			<CommandDialog
 				open={isOpen}
+				modal={!startup}
+				className={startup ? "hidden" : undefined}
 				onOpenChange={(open) => (open ? setOpen(true) : requestDismiss("close"))}
 				contentProps={{
+					role: startup ? "presentation" : "dialog",
 					onAnimationEnd: handlePaletteAnimationEnd,
+					onOpenAutoFocus: (event) => { if (startup) event.preventDefault(); },
+					onInteractOutside: (event) => { if (startup) event.preventDefault(); },
 					onEscapeKeyDown: (event) => {
 						event.preventDefault();
 						if (event.isComposing) return;
@@ -550,13 +575,7 @@ export function CommandPalette() {
 								</div>
 							</div>
 						)}
-						<TaskComposer
-							projectId={view.projectId}
-							autoFocusTitle
-							onDirtyChange={onComposerDirtyChange}
-							onSubmittingChange={onComposerSubmittingChange}
-							onCreated={(sessionId) => void handleTaskCreated(view.projectId, sessionId)}
-						/>
+						<div ref={setComposerContainer} />
 					</div>
 				) : (
 					<>

--- a/frontend/src/renderer/components/GlobalNewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/GlobalNewTaskDialog.test.tsx
@@ -10,6 +10,7 @@ const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
+	useLocation: () => ({ href: "/" }),
 }));
 
 // Probe stand-in: surfaces the props the real dialog would receive, preserves a
@@ -23,7 +24,7 @@ vi.mock("./NewTaskDialog", () => ({
 	}: {
 		open: boolean;
 		projectId?: string;
-		onCreated: (id: string) => void;
+		onCreated: (id: string, focusSession?: boolean) => void;
 		onOpenChange: (open: boolean) => void;
 	}) => {
 		const [draft, setDraft] = useState("");
@@ -36,6 +37,7 @@ vi.mock("./NewTaskDialog", () => ({
 				<button type="button" onClick={() => onCreated("sess-9")}>
 					create
 				</button>
+				<button type="button" onClick={() => onCreated("sess-background", false)}>finish in background</button>
 				<button type="button" onClick={() => onOpenChange(false)}>
 					close
 				</button>
@@ -51,6 +53,7 @@ function renderDialog() {
 			<GlobalNewTaskDialog />
 		</QueryClientProvider>,
 	);
+	return queryClient;
 }
 
 beforeEach(() => {
@@ -60,6 +63,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	window.history.replaceState({}, "", "/");
 });
 
 describe("GlobalNewTaskDialog", () => {
@@ -127,5 +131,32 @@ describe("GlobalNewTaskDialog", () => {
 			useUiStore.getState().requestNewTask("proj-8");
 		});
 		expect(await screen.findByTestId("new-task-dialog")).toHaveAttribute("data-project", "proj-8");
+	});
+});
+
+
+it("does not navigate when a completed startup no longer owns focus", async () => {
+	const user = userEvent.setup();
+	renderDialog();
+	act(() => useUiStore.getState().requestNewTask("proj-7"));
+	await user.click(await screen.findByRole("button", { name: "finish in background" }));
+	expect(navigateMock).not.toHaveBeenCalled();
+});
+
+
+it.each([false, true])("awaits workspace refresh and respects intervening navigation (%s)", async (navigateAway) => {
+	const user = userEvent.setup();
+	const queryClient = renderDialog();
+	let finishRefresh!: () => void;
+	vi.spyOn(queryClient, "invalidateQueries").mockReturnValue(new Promise<void>((resolve) => { finishRefresh = resolve; }));
+	act(() => useUiStore.getState().requestNewTask("proj-7"));
+	await user.click(await screen.findByRole("button", { name: "create" }));
+	expect(navigateMock).not.toHaveBeenCalled();
+	if (navigateAway) window.history.pushState({}, "", "/elsewhere");
+	await act(async () => finishRefresh());
+	if (navigateAway) expect(navigateMock).not.toHaveBeenCalled();
+	else expect(navigateMock).toHaveBeenCalledWith({
+		to: "/projects/$projectId/sessions/$sessionId",
+		params: { projectId: "proj-7", sessionId: "sess-9" },
 	});
 });

--- a/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
+++ b/frontend/src/renderer/components/GlobalNewTaskDialog.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useLocation } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useUiStore } from "../stores/ui-store";
@@ -13,6 +13,7 @@ import { NewTaskDialog } from "./NewTaskDialog";
 // request for the same project re-open the dialog.
 export function GlobalNewTaskDialog() {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const queryClient = useQueryClient();
 	const newTaskRequest = useUiStore((state) => state.newTaskRequest);
 	const [open, setOpen] = useState(false);
@@ -30,10 +31,12 @@ export function GlobalNewTaskDialog() {
 		setOpen(true);
 	}, [newTaskRequest, open]);
 
-	const handleCreated = async (sessionId: string) => {
+	const handleCreated = async (sessionId: string, focusSession = true) => {
 		if (!projectId) return;
-		await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-		void navigate({
+		const origin = window.location.href;
+		await queryClient.invalidateQueries({ queryKey: workspaceQueryKey }, { throwOnError: true });
+		if (!focusSession || window.location.href !== origin) return;
+		await navigate({
 			to: "/projects/$projectId/sessions/$sessionId",
 			params: { projectId, sessionId },
 		});
@@ -43,7 +46,8 @@ export function GlobalNewTaskDialog() {
 		<NewTaskDialog
 			open={open}
 			projectId={projectId}
-			onCreated={(sessionId) => void handleCreated(sessionId)}
+			navigationKey={location.href}
+			onCreated={handleCreated}
 			onOpenChange={setOpen}
 		/>
 	);

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -1,9 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { agentReadiness } from "../test/agent-readiness-fixtures";
 import { NewTaskDialog } from "./NewTaskDialog";
+import { TooltipProvider } from "./ui/tooltip";
 
 const { getMock, postMock, ensureAgentReadinessMock } = vi.hoisted(() => ({
 	getMock: vi.fn(),
@@ -40,7 +41,7 @@ function renderDialog() {
 	const onOpenChange = vi.fn();
 	render(
 		<QueryClientProvider client={new QueryClient()}>
-			<NewTaskDialog open projectId="proj-1" onCreated={onCreated} onOpenChange={onOpenChange} />
+			<TooltipProvider><NewTaskDialog open projectId="proj-1" onCreated={onCreated} onOpenChange={onOpenChange} /></TooltipProvider>
 		</QueryClientProvider>,
 	);
 	return { onCreated, onOpenChange };
@@ -341,4 +342,36 @@ describe("NewTaskDialog", () => {
 
 		expect(await screen.findByText(`${message} (${code})`)).toBeInTheDocument();
 	});
+});
+
+
+it("keeps the request alive when the modal becomes a central chat surface", async () => {
+	const originalGet = getMock.getMockImplementation()!;
+	getMock.mockImplementation((path: string, ...args: unknown[]) => path === "/api/v1/settings"
+		? Promise.resolve({ data: { defaultSessionMode: "chat", chatHarnesses: ["claude-code"] } })
+		: originalGet(path, ...args));
+	const host = document.createElement("div");
+	host.id = "task-startup-host";
+	document.body.append(host);
+	try {
+		let resolve!: (value: { data: { workerId: string } }) => void;
+		postMock.mockImplementation((path: string) => path === "/api/v1/orchestrators/delegate"
+			? new Promise((done) => { resolve = done; })
+			: Promise.resolve({ data: agentInventory }));
+		const { onCreated, onOpenChange } = renderDialog();
+		await waitForAgentCatalog();
+		fireEvent.change(screen.getByLabelText("Task"), { target: { value: "hello from the dialog" } });
+		fireEvent.click(screen.getByRole("button", { name: "Start task" }));
+		await waitFor(() => expect(delegateCalls()).toHaveLength(1));
+		expect(screen.getByRole("region", { name: "Chat" })).toHaveTextContent("hello from the dialog");
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(document.body.style.pointerEvents).not.toBe("none");
+		fireEvent.keyDown(document.body, { key: "Escape" });
+		expect(onOpenChange).not.toHaveBeenCalled();
+		await act(async () => resolve({ data: { workerId: "started-worker" } }));
+		expect(onCreated).toHaveBeenCalledExactlyOnceWith("started-worker");
+		expect(delegateCalls()).toHaveLength(1);
+	} finally {
+		host.remove();
+	}
 });

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -1,35 +1,62 @@
 import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TaskComposer } from "./TaskComposer";
 
 type NewTaskDialogProps = {
 	open: boolean;
 	projectId?: string;
-	onCreated: (sessionId: string) => void;
+	onCreated: (sessionId: string, focusSession?: boolean) => void | Promise<void>;
+	navigationKey?: string;
 	onOpenChange: (open: boolean) => void;
 };
 
-export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewTaskDialogProps) {
+export function NewTaskDialog({ open, projectId, onCreated, onOpenChange, navigationKey }: NewTaskDialogProps) {
 	const { t } = useTranslation();
+	const [container, setContainer] = useState<HTMLDivElement | null>(null);
+	const [startup, setStartup] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
 	return (
-		<Dialog.Root open={open} onOpenChange={onOpenChange}>
-			<Dialog.Portal>
-				<Dialog.Overlay className="dialog-overlay data-[state=open]:animate-overlay-in data-[state=closed]:animate-overlay-out" />
-				<Dialog.Content className="fixed left-1/2 top-1/2 z-overlay w-dialog-xl -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none">
-					{/* One title line names the dialog, styled like every other settings-style
-					    modal; everything else stays the composer's surface, no bordered header. */}
-					<Dialog.Title className="settings-dialog-title px-4 pt-3">{t("newTask.title")}</Dialog.Title>
-					<Dialog.Description className="sr-only">{t("newTask.description")}</Dialog.Description>
-					<TaskComposer
-						projectId={projectId}
-						autoFocusTitle
-						onCreated={(sessionId) => {
-							onCreated(sessionId);
-							onOpenChange(false);
-						}}
-					/>
-				</Dialog.Content>
-			</Dialog.Portal>
-		</Dialog.Root>
+		<>
+			<Dialog.Root
+				open={open}
+				modal={!startup}
+				onOpenChange={(next) => { if (!submitting && !startup) onOpenChange(next); }}
+			>
+				<Dialog.Portal>
+					<Dialog.Overlay className="dialog-overlay data-[state=open]:animate-overlay-in data-[state=closed]:animate-overlay-out" />
+					<Dialog.Content
+						role={startup ? "presentation" : "dialog"}
+						style={startup ? { display: "none" } : undefined}
+						onOpenAutoFocus={(event) => { if (startup) event.preventDefault(); }}
+						onInteractOutside={(event) => { if (startup || submitting) event.preventDefault(); }}
+						onEscapeKeyDown={(event) => { if (startup || submitting) event.preventDefault(); }}
+						className="fixed left-1/2 top-1/2 z-overlay w-dialog-xl -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-lg border border-border bg-popover p-0 text-popover-foreground shadow-xl data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out motion-reduce:animate-none"
+					>
+						<Dialog.Title className="settings-dialog-title px-4 pt-3">{t("newTask.title")}</Dialog.Title>
+						<Dialog.Description className="sr-only">{t("newTask.description")}</Dialog.Description>
+						<div ref={setContainer} />
+					</Dialog.Content>
+				</Dialog.Portal>
+			</Dialog.Root>
+			{/* Radix swaps its content implementation when modality changes. Keep
+			    the request owner outside that subtree so startup cannot remount it. */}
+			{open ? (
+				<TaskComposer
+					container={container}
+					projectId={projectId}
+					navigationKey={navigationKey}
+					onStartupChange={setStartup}
+					onDiscard={() => onOpenChange(false)}
+					onSubmittingChange={setSubmitting}
+					autoFocusTitle
+					onCreated={async (sessionId, focusSession) => {
+						if (focusSession === false) await onCreated(sessionId, false);
+						else await onCreated(sessionId);
+						onOpenChange(false);
+					}}
+				/>
+			) : null}
+		</>
 	);
 }

--- a/frontend/src/renderer/components/TaskComposer.test.tsx
+++ b/frontend/src/renderer/components/TaskComposer.test.tsx
@@ -62,6 +62,8 @@ vi.mock("../lib/api-client", () => ({
 vi.mock("../lib/telemetry", () => ({ captureRendererEvent: h.capture }));
 
 import { TaskComposer } from "./TaskComposer";
+import { TooltipProvider } from "./ui/tooltip";
+import { OPEN_BROWSER_OVERLAY_SELECTOR } from "../lib/dom-selectors";
 import { agentReadiness } from "../test/agent-readiness-fixtures";
 import { agentReadinessQueryKey } from "../hooks/useAgentReadinessQuery";
 
@@ -69,7 +71,7 @@ function Wrap({ children, queryClient = new QueryClient({ defaultOptions: { quer
 	children: ReactNode;
 	queryClient?: QueryClient;
 }) {
-	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+	return <QueryClientProvider client={queryClient}><TooltipProvider>{children}</TooltipProvider></QueryClientProvider>;
 }
 
 const task = () => screen.getByRole("textbox", { name: "Task" });
@@ -841,5 +843,162 @@ describe("TaskComposer", () => {
 				}),
 			),
 		);
+	});
+});
+
+
+describe("immediate chat startup", () => {
+	let host: HTMLDivElement;
+	beforeEach(() => {
+		const originalGet = h.get.getMockImplementation()!;
+		h.get.mockImplementation((path: string, ...args: unknown[]) => path === "/api/v1/settings"
+			? Promise.resolve({ data: { defaultSessionMode: "chat", chatHarnesses: ["codex", "claude-code"] } })
+			: originalGet(path, ...args));
+		host = document.createElement("div");
+		host.id = "task-startup-host";
+		document.body.append(host);
+	});
+	afterEach(() => {
+		host.remove();
+		window.history.replaceState({}, "", "/");
+	});
+
+	it("shows the submitted prompt before delegate resolves and submits only once", async () => {
+		let resolve!: (value: { data: { workerId: string } }) => void;
+		h.post.mockReturnValue(new Promise((done) => { resolve = done; }));
+		const onCreated = vi.fn();
+		render(<Wrap><TaskComposer projectId="proj-1" onCreated={onCreated} /></Wrap>);
+		fireEvent.change(task(), { target: { value: "Build the requested feature" } });
+		const form = task().closest("form")!;
+		act(() => { fireEvent.submit(form); fireEvent.submit(form); });
+		expect(screen.getByRole("region", { name: "Chat" })).toHaveTextContent("Build the requested feature");
+		expect(document.querySelector(OPEN_BROWSER_OVERLAY_SELECTOR)).toBe(screen.getByRole("region", { name: "Chat" }));
+		expect(screen.getByRole("status")).toHaveTextContent("Starting session…");
+		expect(screen.queryByRole("textbox", { name: "Task" })).not.toBeInTheDocument();
+		expect(screen.getByLabelText("Message the agent")).toHaveAttribute("contenteditable", "false");
+		expect(screen.getByText("Waiting for the session to start…")).toBeInTheDocument();
+		await waitFor(() => expect(h.post).toHaveBeenCalledTimes(1));
+		expect(onCreated).not.toHaveBeenCalled();
+		await act(async () => resolve({ data: { workerId: "worker-1" } }));
+		expect(onCreated).toHaveBeenCalledExactlyOnceWith("worker-1");
+		expect(h.post).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps startup visible after delegate succeeds until workspace refresh and navigation finish", async () => {
+		let finishOpening!: () => void;
+		const onCreated = vi.fn(() => new Promise<void>((resolve) => { finishOpening = resolve; }));
+		h.post.mockResolvedValue({ data: { workerId: "created-worker" } });
+		render(<Wrap><TaskComposer projectId="proj-1" onCreated={onCreated} /></Wrap>);
+		fireEvent.change(task(), { target: { value: "Wait for the destination" } });
+		fireEvent.submit(task().closest("form")!);
+		await waitFor(() => expect(onCreated).toHaveBeenCalledExactlyOnceWith("created-worker"));
+		expect(screen.getByRole("region", { name: "Chat" })).toHaveTextContent("Wait for the destination");
+		expect(screen.getByRole("status")).toHaveTextContent("Starting session…");
+		expect(screen.queryByRole("button", { name: "Start task" })).not.toBeInTheDocument();
+		await act(async () => finishOpening());
+		expect(screen.queryByRole("region", { name: "Chat" })).not.toBeInTheDocument();
+		expect(h.post).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries opening an existing session after refresh failure without another delegate", async () => {
+		const onCreated = vi.fn().mockRejectedValueOnce(new Error("Workspace refresh failed")).mockResolvedValue(undefined);
+		h.post.mockResolvedValue({ data: { workerId: "created-worker" } });
+		render(<Wrap><TaskComposer projectId="proj-1" onCreated={onCreated} /></Wrap>);
+		fireEvent.change(task(), { target: { value: "Create only once" } });
+		fireEvent.submit(task().closest("form")!);
+		expect(await screen.findByRole("alert")).toHaveTextContent("The session was created, but could not be opened.");
+		expect(screen.getByRole("alert")).toHaveTextContent("Workspace refresh failed");
+		expect(screen.queryByRole("button", { name: "Start task" })).not.toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Open session" }));
+		await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(2));
+		expect(onCreated).toHaveBeenNthCalledWith(2, "created-worker");
+		expect(h.post).toHaveBeenCalledTimes(1);
+	});
+
+	it("retains the draft and attachments after failure and waits for an explicit retry", async () => {
+		let reject!: (reason: Error) => void;
+		h.post.mockReturnValueOnce(new Promise((_resolve, fail) => { reject = fail; }));
+		render(<Wrap><TaskComposer projectId="proj-1" onCreated={vi.fn()} /></Wrap>);
+		fireEvent.change(task(), { target: { value: "Keep this draft" } });
+		fireEvent.paste(task(), { clipboardData: { files: [new File(["hello"], "notes.txt", { type: "text/plain" })], getData: () => "" } });
+		fireEvent.submit(task().closest("form")!);
+		await waitFor(() => expect(h.post).toHaveBeenCalledTimes(1));
+		await act(async () => reject(new Error("Connection lost; check sessions before retrying")));
+		expect(task()).toHaveValue("Keep this draft");
+		expect(screen.getByRole("alert")).toHaveTextContent("Connection lost");
+		expect(screen.getAllByText("notes.txt").length).toBeGreaterThan(0);
+		expect(h.post).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not request focus when navigation changes during startup", async () => {
+		let resolve!: (value: { data: { workerId: string } }) => void;
+		h.post.mockReturnValue(new Promise((done) => { resolve = done; }));
+		const onCreated = vi.fn();
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const view = render(<Wrap queryClient={queryClient}><TaskComposer projectId="proj-1" navigationKey="/" onCreated={onCreated} /></Wrap>);
+		fireEvent.change(task(), { target: { value: "hi" } });
+		fireEvent.submit(task().closest("form")!);
+		await waitFor(() => expect(h.post).toHaveBeenCalledTimes(1));
+		window.history.pushState({}, "", "/other");
+		view.rerender(<Wrap queryClient={queryClient}><TaskComposer projectId="proj-1" navigationKey="/other" onCreated={onCreated} /></Wrap>);
+		expect(screen.queryByRole("region", { name: "Chat" })).not.toBeInTheDocument();
+		expect(document.querySelector(OPEN_BROWSER_OVERLAY_SELECTOR)).toBeNull();
+		await act(async () => resolve({ data: { workerId: "worker-2" } }));
+		expect(onCreated).toHaveBeenCalledExactlyOnceWith("worker-2", false);
+	});
+
+	it.each(["recover", "discard"] as const)("makes an off-route failure discoverable and allows %s", async (action) => {
+		let reject!: (reason: Error) => void;
+		h.post.mockReturnValue(new Promise((_resolve, fail) => { reject = fail; }));
+		const onCreated = vi.fn();
+		const onDiscard = vi.fn();
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const content = (navigationKey: string) => (
+			<Wrap queryClient={queryClient}>
+				<button type="button">Unrelated route action</button>
+				<TaskComposer projectId="proj-1" navigationKey={navigationKey} onCreated={onCreated} onDiscard={onDiscard} />
+			</Wrap>
+		);
+		const view = render(content("/"));
+		fireEvent.change(task(), { target: { value: "Retain this draft" } });
+		fireEvent.paste(task(), { clipboardData: { files: [new File(["hello"], "notes.txt", { type: "text/plain" })], getData: () => "" } });
+		fireEvent.submit(task().closest("form")!);
+		await waitFor(() => expect(h.post).toHaveBeenCalledTimes(1));
+		window.history.pushState({}, "", "/other");
+		view.rerender(content("/other"));
+		const unrelatedAction = screen.getByRole("button", { name: "Unrelated route action" });
+		unrelatedAction.focus();
+		await act(async () => reject(new Error("Could not initialize the agent")));
+		expect(screen.queryByRole("region", { name: "Chat" })).not.toBeInTheDocument();
+		expect(screen.getByRole("alert")).toHaveTextContent("Could not initialize the agent");
+		expect(unrelatedAction).toHaveFocus();
+		expect(window.location.pathname).toBe("/other");
+		if (action === "recover") {
+			fireEvent.click(screen.getByRole("button", { name: "Return to draft" }));
+			expect(screen.getByRole("region", { name: "Chat" })).toBeVisible();
+			expect(task()).toHaveValue("Retain this draft");
+			expect(screen.getByRole("button", { name: "Remove notes.txt" })).toBeInTheDocument();
+			expect(onDiscard).not.toHaveBeenCalled();
+		} else {
+			fireEvent.click(screen.getByRole("button", { name: "Discard draft" }));
+			expect(onDiscard).toHaveBeenCalledExactlyOnceWith();
+			expect(screen.queryByRole("button", { name: "Return to draft" })).not.toBeInTheDocument();
+		}
+		expect(h.post).toHaveBeenCalledTimes(1);
+		expect(onCreated).not.toHaveBeenCalled();
+	});
+
+	it("does not call a stale completion callback after its owner unmounts", async () => {
+		let resolve!: (value: { data: { workerId: string } }) => void;
+		h.post.mockReturnValue(new Promise((done) => { resolve = done; }));
+		const onCreated = vi.fn();
+		const view = render(<Wrap><TaskComposer projectId="proj-1" onCreated={onCreated} /></Wrap>);
+		fireEvent.change(task(), { target: { value: "hi" } });
+		fireEvent.submit(task().closest("form")!);
+		await waitFor(() => expect(h.post).toHaveBeenCalledTimes(1));
+		view.unmount();
+		await act(async () => resolve({ data: { workerId: "worker-3" } }));
+		expect(onCreated).not.toHaveBeenCalled();
+		expect(h.post).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/renderer/components/TaskComposer.tsx
+++ b/frontend/src/renderer/components/TaskComposer.tsx
@@ -5,7 +5,9 @@ import {
 	type TaskComposerModelCatalog,
 	type TaskComposerModelControl,
 } from "@aoagents/product-ui";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { TaskStartupSurface } from "./TaskStartupSurface";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
@@ -74,7 +76,11 @@ function hasErrorDetail(details: components["schemas"]["APIError"]["details"] | 
 
 export type TaskComposerProps = {
 	projectId?: string;
-	onCreated: (sessionId: string) => void;
+	onCreated: (sessionId: string, focusSession?: boolean) => void | Promise<void>;
+	onStartupChange?: (starting: boolean) => void;
+	onDiscard?: () => void;
+	navigationKey?: string;
+	container?: HTMLElement | null;
 	onDirtyChange?: (dirty: boolean) => void;
 	onSubmittingChange?: (submitting: boolean) => void;
 	autoFocusTitle?: boolean;
@@ -83,6 +89,10 @@ export type TaskComposerProps = {
 export function TaskComposer({
 	projectId,
 	onCreated,
+	onStartupChange,
+	onDiscard,
+	navigationKey,
+	container,
 	onDirtyChange,
 	onSubmittingChange,
 	autoFocusTitle,
@@ -102,7 +112,23 @@ export function TaskComposer({
 	const [agentTouched, setAgentTouched] = useState(false);
 	const [modelTouched, setModelTouched] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const submittingRef = useRef(false);
+	const mountedRef = useRef(true);
+	const promptRef = useRef("");
+	const [startup, setStartup] = useState<{ brief: string; createdAt: string; navigationKey?: string }>();
+	const startupHost = document.getElementById("task-startup-host");
+	const startupVisible = Boolean(startup && startup.navigationKey === navigationKey);
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => { mountedRef.current = false; };
+	}, []);
+	useEffect(() => {
+		onStartupChange?.(Boolean(startup));
+	}, [startup, onStartupChange]);
+	useEffect(() => () => onStartupChange?.(false), [onStartupChange]);
 	const [error, setError] = useState<string | undefined>();
+	const [createdSessionId, setCreatedSessionId] = useState<string>();
+	const [completionError, setCompletionError] = useState<string>();
 	const [fallbackAction, setFallbackAction] = useState<FallbackAction>();
 	const {
 		attachments,
@@ -309,6 +335,7 @@ export function TaskComposer({
 
 	const isDirty = isPromptDirty || modelTouched || attachments.length > 0;
 	const handlePromptChange = useCallback((value: string) => {
+		promptRef.current = value;
 		const nextDirty = value.trim() !== "";
 		setIsPromptDirty((wasDirty) => (wasDirty === nextDirty ? wasDirty : nextDirty));
 	}, []);
@@ -323,12 +350,45 @@ export function TaskComposer({
 	useEffect(() => () => onSubmittingChange?.(false), [onSubmittingChange]);
 	useEffect(() => () => clearAttachments(), [clearAttachments]);
 
+	// Once delegate succeeds, cache/navigation failures must never re-enter the
+	// creation path: retry only opening the already-created session.
+	const finishCreatedSession = async (sessionId: string, focusSession: boolean) => {
+		try {
+			if (focusSession) await onCreated(sessionId);
+			else await onCreated(sessionId, false);
+			if (mountedRef.current) {
+				setStartup(undefined);
+				setCreatedSessionId(undefined);
+				setCompletionError(undefined);
+			}
+		} catch (err) {
+			if (mountedRef.current) {
+				setCreatedSessionId(sessionId);
+				setCompletionError(err instanceof Error ? err.message : t("newTask.unableToStart"));
+			}
+		}
+	};
+
+	const retryOpenSession = async () => {
+		if (!createdSessionId || submittingRef.current) return;
+		submittingRef.current = true;
+		setIsSubmitting(true);
+		try {
+			await finishCreatedSession(createdSessionId, true);
+		} finally {
+			submittingRef.current = false;
+			if (mountedRef.current) setIsSubmitting(false);
+		}
+	};
+
 	const submitTask = async (
 		brief: string,
 		interfaceMode?: "tui",
 		approvalMode?: "bypass-permissions",
 	) => {
-		if (!projectId || isSubmitting) return;
+		if (!projectId || submittingRef.current || createdSessionId) return;
+		submittingRef.current = true;
+		const submittedLocation = window.location.href;
 
 		const cleanModel = model.trim();
 		const cleanMode = mode.trim();
@@ -338,6 +398,11 @@ export function TaskComposer({
 				: undefined;
 
 		setIsSubmitting(true);
+		// The owner stays mounted while its presentation moves into the shell.
+		// No temporary session is persisted and the brief is sent only by delegate.
+		if (startupHost && !isCloudProject && interfaceMode !== "tui" && settings?.defaultSessionMode !== "tui") {
+			setStartup({ brief, createdAt: new Date().toISOString(), navigationKey });
+		}
 		setError(undefined);
 		setFallbackAction(undefined);
 		try {
@@ -353,8 +418,11 @@ export function TaskComposer({
 				approvalMode,
 				attachments: attachmentPayloads.length > 0 ? attachmentPayloads : undefined,
 			});
-			onCreated(sessionId);
+			if (mountedRef.current) {
+				await finishCreatedSession(sessionId, window.location.href === submittedLocation);
+			}
 		} catch (err) {
+			if (!mountedRef.current) return;
 			const canBypassApprovals =
 				err instanceof TaskCreateError &&
 				err.code === "SESSION_MODE_UNSUPPORTED" &&
@@ -371,12 +439,30 @@ export function TaskComposer({
 			);
 			setError(err instanceof Error ? err.message : t("newTask.unableToStart"));
 		} finally {
-			setIsSubmitting(false);
+			submittingRef.current = false;
+			if (mountedRef.current) setIsSubmitting(false);
 		}
 	};
 
-	return (
+	const completionRecovery = createdSessionId ? (
+		<div className="p-4 text-sm">
+			{completionError ? (
+				<>
+					<div role="alert" className="mb-3 text-destructive">
+						<p>{t("newTask.createdButNotOpened", { defaultValue: "The session was created, but could not be opened." })}</p>
+						<p>{completionError}</p>
+					</div>
+					<button type="button" onClick={() => void retryOpenSession()} disabled={isSubmitting} className="font-medium underline underline-offset-4">
+						{t("newTask.openSession", { defaultValue: "Open session" })}
+					</button>
+				</>
+			) : null}
+		</div>
+	) : null;
+
+	const composer = (
 		<TaskComposerView
+			initialPrompt={promptRef.current}
 			autoFocusPrompt={autoFocusTitle}
 			canSubmit={Boolean(projectId)}
 			onPromptChange={handlePromptChange}
@@ -451,6 +537,33 @@ export function TaskComposer({
 			renderModelControl={(control) => <TaskModelPicker {...control} onRefresh={refreshSelectedModels} />}
 		/>
 	);
+	if (startup && startupHost) {
+		return createPortal(
+			<TaskStartupSurface
+				brief={startup.brief}
+				createdAt={startup.createdAt}
+				visible={startupVisible}
+				pending={isSubmitting}
+				attachments={attachments}
+				error={completionError ?? error}
+				sessionCreated={Boolean(createdSessionId)}
+				onReturn={() => setStartup({ ...startup, navigationKey })}
+				onDiscard={onDiscard ? () => {
+					if (submittingRef.current) return;
+					setStartup(undefined);
+					onDiscard();
+				} : undefined}
+				onBack={() => {
+					if (!submittingRef.current) setStartup(undefined);
+				}}
+			>
+				{!isSubmitting && startupVisible ? (completionRecovery ?? composer) : null}
+			</TaskStartupSurface>,
+			startupHost,
+		);
+	}
+	const content = completionRecovery ?? composer;
+	return container === undefined ? content : container ? createPortal(content, container) : null;
 }
 
 function DesktopAgentControl(control: TaskComposerAgentControl) {

--- a/frontend/src/renderer/components/TaskStartupContext.test.tsx
+++ b/frontend/src/renderer/components/TaskStartupContext.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TaskStartupProvider, TaskStartupRoute, useTaskStartupVisibility } from "./TaskStartupContext";
+
+function Owner({ visible }: { visible: boolean }) {
+	useTaskStartupVisibility(visible);
+	return null;
+}
+
+function Shell({ first, second }: { first?: boolean; second?: boolean }) {
+	return (
+		<TaskStartupProvider>
+			<button type="button">Sidebar navigation</button>
+			<TaskStartupRoute><button type="button">Underlying session control</button></TaskStartupRoute>
+			{first !== undefined ? <Owner visible={first} /> : null}
+			{second !== undefined ? <Owner visible={second} /> : null}
+		</TaskStartupProvider>
+	);
+}
+
+describe("startup route coverage", () => {
+	it("covers only the underlying route until all visible startup owners release it", () => {
+		const view = render(<Shell first second />);
+		const route = screen.getByTestId("task-startup-underlying-route");
+		expect(route).toHaveAttribute("inert");
+		expect(route).toHaveAttribute("aria-hidden", "true");
+		expect(route).toHaveClass("invisible");
+		expect(screen.getByRole("button", { name: "Sidebar navigation" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Underlying session control" })).not.toBeInTheDocument();
+		view.rerender(<Shell first={false} second />);
+		expect(route).toHaveAttribute("inert");
+		view.rerender(<Shell first={false} />);
+		expect(route).not.toHaveAttribute("inert");
+		expect(route).not.toHaveAttribute("aria-hidden");
+		expect(route).not.toHaveClass("invisible");
+		expect(screen.getByRole("button", { name: "Underlying session control" })).toBeInTheDocument();
+	});
+});

--- a/frontend/src/renderer/components/TaskStartupContext.tsx
+++ b/frontend/src/renderer/components/TaskStartupContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useState, type ReactNode } from "react";
+
+const TaskStartupContext = createContext<{ covered: boolean; register: () => () => void } | null>(null);
+
+// Both new-task entry points can own a startup. Reference counting keeps the
+// underlying route covered until the last visible startup releases ownership.
+export function TaskStartupProvider({ children }: { children: ReactNode }) {
+	const [owners, setOwners] = useState(0);
+	const register = useCallback(() => {
+		setOwners((count) => count + 1);
+		return () => setOwners((count) => count - 1);
+	}, []);
+	const value = useMemo(() => ({ covered: owners > 0, register }), [owners, register]);
+	return <TaskStartupContext.Provider value={value}>{children}</TaskStartupContext.Provider>;
+}
+
+export function useTaskStartupVisibility(visible: boolean) {
+	const register = useContext(TaskStartupContext)?.register;
+	useLayoutEffect(() => {
+		if (visible) return register?.();
+		return undefined;
+	}, [visible, register]);
+}
+
+export function TaskStartupRoute({ children }: { children: ReactNode }) {
+	const covered = useContext(TaskStartupContext)?.covered ?? false;
+	return (
+		<div
+			inert={covered ? true : undefined}
+			aria-hidden={covered ? true : undefined}
+			className={`min-h-0 flex-1 overflow-x-hidden${covered ? " invisible" : ""}`}
+			data-testid="task-startup-underlying-route"
+		>
+			{children}
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/TaskStartupSurface.tsx
+++ b/frontend/src/renderer/components/TaskStartupSurface.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { FileAttachment } from "../hooks/useFileAttachments";
+import { useTaskStartupVisibility } from "./TaskStartupContext";
+import { ChatComposer } from "./chat/ChatComposer";
+import { HumanMessage } from "./chat/ChatTimelineItems";
+
+// A renderer-only presentation of the one in-flight delegate request. This is
+// deliberately not a ConversationSnapshot: the daemon owns durable sessions.
+export function TaskStartupSurface({ brief, createdAt, attachments, pending, visible, error, sessionCreated, onReturn, onDiscard, onBack, children }: {
+	brief: string;
+	createdAt: string;
+	attachments: FileAttachment[];
+	pending: boolean;
+	visible: boolean;
+	error?: string;
+	sessionCreated?: boolean;
+	onReturn: () => void;
+	onDiscard?: () => void;
+	onBack: () => void;
+	children: ReactNode;
+}) {
+	const { t } = useTranslation();
+	useTaskStartupVisibility(visible);
+	const surfaceRef = useRef<HTMLElement>(null);
+	useEffect(() => {
+		if (!visible) return;
+		const frame = requestAnimationFrame(() => surfaceRef.current?.focus());
+		return () => cancelAnimationFrame(frame);
+	}, [visible]);
+	return (
+		<>
+			{!visible && !pending && error ? (
+				<aside data-browser-native-overlay="true" data-state="open" className="absolute right-4 bottom-4 z-20 w-[min(360px,calc(100%_-_32px))] rounded-lg border border-border bg-popover p-4 text-sm text-popover-foreground shadow-lg">
+					<div role="alert">
+						<p className="font-medium">{sessionCreated ? t("newTask.createdButNotOpened", { defaultValue: "The session was created, but could not be opened." }) : t("newTask.startupFailed", { defaultValue: "Session could not start" })}</p>
+						<p className="mt-1 break-words text-xs text-muted-foreground">{error}</p>
+					</div>
+					<div className="mt-3 flex flex-wrap gap-3">
+						<button type="button" onClick={onReturn} className="text-xs font-medium underline underline-offset-4">
+							{sessionCreated ? t("newTask.returnToSession", { defaultValue: "Return to session" }) : t("newTask.returnToDraft", { defaultValue: "Return to draft" })}
+						</button>
+						{onDiscard ? (
+							<button type="button" onClick={onDiscard} className="text-xs text-muted-foreground underline underline-offset-4">
+								{sessionCreated ? t("newTask.dismiss", { defaultValue: "Dismiss" }) : t("newTask.discardDraft", { defaultValue: "Discard draft" })}
+							</button>
+						) : null}
+					</div>
+				</aside>
+			) : null}
+			<section
+				ref={surfaceRef}
+				role="region"
+				aria-label={t("chat.title", { defaultValue: "Chat" })}
+				tabIndex={-1}
+				hidden={!visible}
+				className="cursor-chat-surface absolute inset-0 z-10 flex min-h-0 flex-col bg-background text-foreground outline-none"
+				style={!visible ? { display: "none" } : undefined}
+				data-browser-native-overlay={visible ? "true" : undefined}
+				data-state={visible ? "open" : undefined}
+				data-testid="task-startup-chat"
+			>
+				<div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
+					{!pending ? (
+						<button type="button" onClick={onBack} aria-label={t("command.back")} className="rounded-md p-1 hover:bg-surface">
+							<ArrowLeft className="size-4" aria-hidden="true" />
+						</button>
+					) : null}
+					<span className="text-sm font-medium">{t("newTask.title")}</span>
+				</div>
+				<div className="cursor-chat-timeline min-h-0 flex-1 overflow-y-auto px-4 py-5">
+					<div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4.5">
+					{brief.trim() ? <HumanMessage
+						apiBaseUrl=""
+						sessionId=""
+						message={{
+							kind: "message",
+							id: "starting-prompt",
+							sequence: 0,
+							revision: 0,
+							role: "user",
+							origin: "human",
+							text: brief,
+							streaming: false,
+							createdAt,
+						}}
+					/> : null}
+					{attachments.length > 0 ? (
+						<ul aria-label={t("newTask.addFile")} className="mb-4 flex flex-wrap justify-end gap-2 text-xs text-muted-foreground">
+							{attachments.map((attachment) => (
+								<li key={attachment.id} className="rounded-md border border-border px-2 py-1">{attachment.name}</li>
+							))}
+						</ul>
+					) : null}
+					{pending ? (
+						<div role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
+							<Loader2 className="size-4 animate-spin" aria-hidden="true" />
+							{t("newTask.startingSession", { defaultValue: "Starting session…" })}
+						</div>
+					) : null}
+					</div>
+				</div>
+				{visible ? (
+					<div className="cursor-chat-composer-dock shrink-0 px-4 pb-3">
+						<div className="mx-auto flex w-full max-w-3xl flex-col gap-2">
+							{pending ? (
+								<ChatComposer
+									disabled
+									autoFocus={false}
+									disabledPlaceholder={t("newTask.waitingForSession", { defaultValue: "Waiting for the session to start…" })}
+									onSend={() => undefined}
+								/>
+							) : children}
+						</div>
+					</div>
+				) : null}
+			</section>
+		</>
+	);
+}

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -81,6 +81,7 @@ export const ChatComposer = memo(function ChatComposer({
 	busy,
 	willQueue,
 	disabled,
+	disabledPlaceholder,
 	settings,
 	approval,
 	skills = [],
@@ -117,6 +118,8 @@ export const ChatComposer = memo(function ChatComposer({
 	/** The agent is mid-turn, so this message is held until the turn ends. */
 	willQueue?: boolean;
 	disabled?: boolean;
+	/** Explain a temporary disabled state, such as session startup. */
+	disabledPlaceholder?: string;
 	/** The provider's skills. Empty leaves `/` an ordinary character. */
 	skills?: ChatSkill[];
 	/** Worktree-relative paths offered for `@`. Empty leaves `@` ordinary. */
@@ -815,7 +818,7 @@ export const ChatComposer = memo(function ChatComposer({
 					label="Message the agent"
 					placeholder={
 						disabled
-							? "The controller is not connected"
+							? (disabledPlaceholder ?? "The controller is not connected")
 							: willQueue
 								? "Agent is working — this sends when it finishes"
 								: "Message the agent…"

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -15,6 +15,7 @@ import { SettingsDialog } from "../components/SettingsDialog";
 import { KeyboardShortcutsDialog } from "../components/KeyboardShortcutsDialog";
 import { KeyboardShortcutsSettingsDialog } from "../components/settings/KeyboardShortcutsSettingsDialog";
 import { ShellTopbar } from "../components/ShellTopbar";
+import { TaskStartupProvider, TaskStartupRoute } from "../components/TaskStartupContext";
 import { SessionTopbarProvider } from "../components/SessionTopbarPortal";
 import { OrchestratorReplacementDialog } from "../components/OrchestratorReplacementDialog";
 import { RestartToUpdateDialog } from "../components/RestartToUpdateDialog";
@@ -831,6 +832,7 @@ function ShellLayout() {
 		<ShellProvider
 			value={shellContextValue}
 		>
+			<TaskStartupProvider>
 			<SessionTopbarProvider>
 				<NotificationRuntime />
 				<TrayRuntime />
@@ -928,15 +930,16 @@ function ShellLayout() {
 						workspaceError={workspaceQuery.isError ? errorMessage(workspaceQuery.error) : undefined}
 						workspaces={workspaces}
 					/>
-					<main className={cn("flex min-w-0 flex-1 flex-col overflow-x-hidden", !sidebarHasLayout && "sidebar-hidden")}>
-						<div className="min-h-0 flex-1 overflow-x-hidden">
+					<main className={cn("relative flex min-w-0 flex-1 flex-col overflow-x-hidden", !sidebarHasLayout && "sidebar-hidden")}>
+						<div id="task-startup-host" />
+						<TaskStartupRoute>
 							{/* Board/session routes render inside the same inset box the welcome board and settings paint for themselves, so every screen sits within the app's outer boundary. */}
 							<ShellCenter
 								hideShellTopbar={hideShellTopbar}
 								isSessionRoute={Boolean(routeParams.sessionId)}
 								selfFramedCenterPanel={selfFramedCenterPanel}
 							/>
-						</div>
+						</TaskStartupRoute>
 					</main>
 					</div>
 					<DaemonFailureBanner status={daemonStatus} />
@@ -983,6 +986,7 @@ function ShellLayout() {
 				</div>
 				</TerminalCacheProvider>
 			</SessionTopbarProvider>
+			</TaskStartupProvider>
 		</ShellProvider>
 	);
 }


### PR DESCRIPTION
## What & why

Starting a local chat task kept the New task dialog visible until the daemon finished creating the session. A slow workspace/harness startup therefore looked like an unresponsive composer. On Send, AO now immediately shows the submitted prompt in its chat surface with **Starting session…**, then opens the durable session after creation and workspace refresh complete.

## Behavior

- Uses the existing delegate request exactly once; preserves the chosen harness, model, approvals and attachments. No daemon, API, storage or provider changes.
- Keeps the sidebar usable while startup runs. Navigating elsewhere is respected; completion does not pull the user back.
- Startup failures retain the editable draft and attachments. Off-route failures offer Return to draft or Discard draft. A cache/navigation failure after creation offers Open session for the existing session, never another delegate request.
- Applies to both local new-task entry points. Cloud and terminal-mode creation retain their existing presentation.

## Verification

Remote checks are **all green** on `5573a7cfa0a070aa9c32f4ba517cb8bb2a947c12`: [Frontend test and renderer smoke](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34006207807), [gitleaks](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34006207802).

- Full frontend Vitest suite: **3,802 passed, 6 skipped** across 277 files (`npx vitest run --maxWorkers=2`).
- Frontend and E2E TypeScript checks passed under Node 24.
- Cloud client generation/drift check, typecheck, 21 tests, build and pack dry-run passed; product UI typecheck, 120 tests, build and pack dry-run passed.
- Production renderer build and pinned agent-browser runtime preparation passed.
- Gitleaks v7.4 scanned the one PR commit with the workflow config: no leaks.
- Full renderer smoke suite: **58/58 passed**, including the three new startup scenarios (single Chromium worker).

Earlier full-suite attempts hit a socket-test teardown timeout and a Radix/jsdom teardown exception; the final complete unit run above is clean. The changed startup scenarios pass with deferred daemon and workspace responses.

Local environment gap: workflow commands run on macOS with Node 24.20.0. Docker is unavailable (`~/.docker/run/docker.sock` does not exist), so the Ubuntu/Playwright-container environment cannot be reproduced here. The all-workflow runner also stops before dispatch because `VITE_WORKOS_CLIENT_ID` is absent for the release build workflow; no publishing/deployment was attempted. Remote PR checks are the authority for Linux. This change has renderer coverage, not a fresh packaged-Electron/real-Opus end-to-end run.

## Benchmark method and limits

The reported symptom was an 8–10 second delay after sending “hi” with Opus. The creation flow awaits the daemon before navigation, so that wait can include workspace setup and harness startup as well as provider work; it cannot be attributed entirely to Opus from the UI observation.

Before/after measurements use the real development renderer in Chromium, with identical fake bridge/API fixtures configured with Claude Code + project-default Opus and holding the delegate response for 10 seconds. Three sequential runs per checkout measure click-to-observed-visible latency, response release, real-chat visibility and delegate count. This isolates the UI behavior; these are not real Opus inference measurements or packaged Electron startup benchmarks. Playwright observation overhead and shared-host load are included.

No claim is made that the backend or model now starts faster. The improvement is that the user sees their submitted prompt and honest startup status immediately instead of waiting in the dialog.


| Observation | Before (`589bb4e0a`) | After (3 runs) |
| --- | --- | --- |
| Startup chat visible before delegate release | Never | 181 / 333 / 283 ms; median **283 ms** |
| Delegate released after click | 10,002 / 10,133 / 10,003 ms | 10,167 / 10,004 / 10,002 ms |
| Durable chat visible after click | 11,007 / 11,602 / 11,456 ms | 11,666 / 10,387 / 10,391 ms |
| Delegate requests | 1 in every run | 1 in every run |

Environment: Apple M5, 10 logical CPUs, 24 GiB RAM, Node 24.20.0, Chromium 148.0.7778.96, 1440×1000 viewport. Shared-host load and Playwright observation overhead affect these small samples; durable-chat timing differences are not evidence of a provider speedup. Baseline and changed screenshots show the state while the response is held.

To reproduce the behavioral gate:

```sh
cd frontend
npm run test:e2e:renderer -- e2e/new-session-startup.spec.ts --workers=1
```

The checked-in test holds the delegate promise until assertions establish that the prompt/startup UI is visible, then holds workspace refresh independently to verify the final handoff. It also covers retained draft errors and off-route recovery. For timing samples, the same controlled response was released 10 seconds after the click, with three repetitions per checkout.


## Screenshots

**Before:** the new-task dialog remains visible throughout the held daemon response.

![Before: still in the new-task dialog](https://github.com/user-attachments/assets/dcba4b3c-ffe8-49f7-a95b-401b13224de3)

**After:** AO shows the submitted prompt and honest startup status while the same request is still pending.

![After: chat visible during startup](https://github.com/user-attachments/assets/23d3fd63-3de9-4714-a116-d865f0927e20)

**Recoverable failure:** the error is visible and the original prompt remains editable, with project-default Opus preserved.

![After: startup failure retains the draft](https://github.com/user-attachments/assets/6dabe4ed-2ff5-4075-b1b5-037ad92d45af)
