### PR TITLE
fix(frontend): restore terminal focus after fullscreen and restart

### DIFF
--- a/frontend/src/renderer/components/OrchestratorReplacementDialog.test.tsx
+++ b/frontend/src/renderer/components/OrchestratorReplacementDialog.test.tsx
@@ -1,0 +1,58 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { OrchestratorReplacementFailure } from "../stores/ui-store";
+import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
+import { OrchestratorReplacementDialog } from "./OrchestratorReplacementDialog";
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("../lib/spawn-orchestrator", () => ({
+	spawnOrchestrator: spawnMock,
+	OrchestratorSpawnError: class extends Error {},
+	isChatPreflightCode: () => false,
+}));
+
+describe("replacement retry focus", () => {
+	it.each([true, false])("keeps Retry focused while pending, success=%s", async (success) => {
+		let resolve!: (id: string) => void;
+		let reject!: (error: Error) => void;
+		spawnMock.mockReset().mockImplementation(() => new Promise<string>((res, rej) => { resolve = res; reject = rej; }));
+		const queryClient = new QueryClient();
+		vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+		const navigate = vi.fn();
+		function Harness() {
+			const [error, setError] = useState<OrchestratorReplacementFailure | undefined>({ message: "Restart failed" });
+			const [pending, setPending] = useState(false);
+			return <OrchestratorReplacementDialog projectId="proj-1" error={error} pending={pending} workspaces={[]}
+				onOpenChange={() => setError(undefined)} onRetryAsTui={vi.fn()}
+				onRetry={() => void restartProjectOrchestrator({ projectId: "proj-1", queryClient, navigate,
+					setProjectRestarting: (_, value) => setPending(value),
+					setOrchestratorReplacementError: (_, value) => setError(value ?? undefined),
+				})} />;
+		}
+		render(<Harness />);
+		const retry = screen.getByRole("button", { name: /retry/i });
+		retry.focus();
+		fireEvent.click(retry);
+		expect(screen.getByRole("dialog")).toHaveAttribute("aria-busy", "true");
+		expect(retry).toHaveFocus();
+		expect(retry).toHaveAttribute("aria-disabled", "true");
+		fireEvent.click(retry);
+		expect(spawnMock).toHaveBeenCalledOnce();
+		fireEvent.keyDown(retry, { key: "Escape" });
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(retry).toHaveFocus();
+		await act(async () => { if (success) resolve("replacement"); else reject(new Error("Retry failed")); });
+		if (success) {
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+			expect(navigate).toHaveBeenCalledOnce();
+		} else {
+			expect(screen.getByText("Retry failed")).toBeInTheDocument();
+			expect(retry).toHaveFocus();
+			expect(retry).toHaveAttribute("aria-disabled", "false");
+			expect(navigate).not.toHaveBeenCalled();
+		}
+	});
+});

--- a/frontend/src/renderer/components/OrchestratorReplacementDialog.tsx
+++ b/frontend/src/renderer/components/OrchestratorReplacementDialog.tsx
@@ -14,6 +14,7 @@ import {
 
 type OrchestratorReplacementDialogProps = {
 	projectId: string | null;
+	pending?: boolean;
 	error?: OrchestratorReplacementFailure;
 	workspaces: WorkspaceSummary[];
 	onOpenChange: (open: boolean) => void;
@@ -23,6 +24,7 @@ type OrchestratorReplacementDialogProps = {
 
 export function OrchestratorReplacementDialog({
 	projectId,
+	pending = false,
 	error,
 	workspaces,
 	onOpenChange,
@@ -44,16 +46,23 @@ export function OrchestratorReplacementDialog({
 	};
 
 	return (
-		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+		<Dialog.Root
+			open={open}
+			onOpenChange={(open) => {
+				if (!pending) onOpenChange(open);
+			}}
+		>
 			<Dialog.Portal>
 				<Dialog.Overlay className="dialog-overlay data-[state=open]:animate-overlay-in" />
 				<Dialog.Content
+					aria-busy={pending}
 					className={`${settingsDialogContentClass} fixed left-1/2 top-1/2 w-dialog-orchestrator -translate-x-1/2 -translate-y-1/2 data-[state=open]:animate-modal-in`}
 				>
 					<Dialog.Close asChild>
 						<button
 							type="button"
 							className="settings-dialog-close-button settings-close-button"
+							disabled={pending}
 							aria-label={t("orchestratorReplacement.close")}
 						>
 							<X className="size-5" aria-hidden="true" />
@@ -74,19 +83,25 @@ export function OrchestratorReplacementDialog({
 					</div>
 					<div className={settingsDialogFooterClass}>
 						{error && isChatPreflightCode(error.code) ? (
-							<Button type="button" variant="footer" onClick={() => projectId && onRetryAsTui(projectId)}>
+							<Button
+								type="button"
+								variant="footer"
+								aria-disabled={pending}
+								onClick={() => !pending && projectId && onRetryAsTui(projectId)}
+							>
 								{t("newTask.createAsTui")}
 							</Button>
 						) : null}
 						{orchestrator ? (
-							<Button type="button" variant="footer" onClick={openCurrent}>
+							<Button type="button" variant="footer" disabled={pending} onClick={openCurrent}>
 								{t("orchestratorReplacement.openCurrent")}
 							</Button>
 						) : null}
 						<Button
 							type="button"
 							variant="footer-primary"
-							onClick={() => projectId && onRetry(projectId)}
+							aria-disabled={pending}
+							onClick={() => !pending && projectId && onRetry(projectId)}
 						>
 							<RotateCw className="size-3.5" aria-hidden="true" />
 							{t("orchestratorReplacement.retry")}

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -29,6 +29,7 @@ const {
 	terminalSessionOptions,
 	xtermMounts,
 	xtermUnmounts,
+	xtermFocusRequests,
 } = vi.hoisted(
 	() => ({
 		attachMock: vi.fn(() => vi.fn()),
@@ -43,6 +44,7 @@ const {
 		terminalSessionOptions: [] as Array<{ coverInitialReplay?: boolean; shellTerminalHandleId?: string }>,
 		xtermMounts: { value: 0 },
 		xtermUnmounts: { value: 0 },
+		xtermFocusRequests: { value: 0 },
 	}),
 );
 let terminalLinkHandler: ((uri: string) => void) | undefined;
@@ -60,6 +62,8 @@ vi.mock("../lib/api-client", () => ({
 
 vi.mock("./XtermTerminal", () => ({
 	XtermTerminal: (props: {
+		focusRequested?: boolean;
+		isVisible?: boolean;
 		onLinkOpen?: (uri: string) => void;
 		onReady?: (terminal: AttachableTerminal) => void;
 	}) => {
@@ -69,6 +73,9 @@ vi.mock("./XtermTerminal", () => ({
 			xtermMounts.value += 1;
 			instance.current = xtermMounts.value;
 		}
+		useEffect(() => {
+			if (props.focusRequested && props.isVisible !== false) xtermFocusRequests.value += 1;
+		}, [props.focusRequested, props.isVisible]);
 		useEffect(() => {
 			const disposable = { dispose: vi.fn() };
 			props.onReady?.({
@@ -144,6 +151,7 @@ beforeEach(() => {
 	sendUserInputMock.mockReturnValue(true);
 	xtermMounts.value = 0;
 	xtermUnmounts.value = 0;
+	xtermFocusRequests.value = 0;
 	useUiStore.setState({ inspectorSessions: {} });
 });
 
@@ -196,11 +204,13 @@ function renderCachedPane({
 	sessions,
 	shellTerminals = [],
 	terminalTarget,
+	focusRequested = false,
 }: {
 	session?: WorkspaceSession;
 	sessions: WorkspaceSession[];
 	shellTerminals?: ShellTerminal[];
 	terminalTarget?: TerminalTarget;
+	focusRequested?: boolean;
 }) {
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	queryClient.setQueryData(workspaceQueryKey, workspaceWithSessions(sessions));
@@ -219,6 +229,7 @@ function renderCachedPane({
 							session={nextSession}
 							terminalTarget={nextTarget}
 							theme="dark"
+							focusRequested={focusRequested}
 						/>
 					) : (
 						<div data-testid="away" />
@@ -545,6 +556,27 @@ describe("TerminalCacheProvider", () => {
 			view.show(sessions[0]);
 			await waitFor(() => expect(activeXterm()).toBe(oldest));
 			expect(xtermMounts.value).toBe(7);
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("focuses each retained TUI terminal when switching among TUI sessions", async () => {
+		const tuiA = { ...sessionA, mode: "tui" as const };
+		const tuiB = { ...sessionB, mode: "tui" as const };
+		const view = renderCachedPane({
+			focusRequested: true,
+			session: tuiA,
+			sessions: [tuiA, tuiB],
+		});
+		try {
+			await waitFor(() => expect(xtermFocusRequests.value).toBe(1));
+
+			view.show(tuiB);
+			await waitFor(() => expect(xtermFocusRequests.value).toBe(2));
+
+			view.show(tuiA);
+			await waitFor(() => expect(xtermFocusRequests.value).toBe(3));
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -51,7 +51,7 @@ type TerminalPaneProps = {
 	onChangeFontSize?: (delta: number) => void;
 	isFullscreen?: boolean;
 	/** Enter or exit fullscreen for the terminal pane that owns this xterm. */
-	onToggleFullscreen?: () => void;
+	onToggleFullscreen?: () => void | Promise<void>;
 	/** Refuse agent PTY input while a controller transition owns the source. */
 	inputDisabled?: boolean;
 	/** Focus the terminal when an in-flight controller asks for human input. */

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -804,6 +804,35 @@ describe("XtermTerminal", () => {
 		Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
 	});
 
+
+	it.each([true, false])("preserves newer focus after deferred fullscreen completion when visible=%s", async (isVisible) => {
+		let complete!: () => void;
+		const onToggleFullscreen = vi.fn(() => new Promise<void>((resolve) => { complete = resolve; }));
+		const frames: FrameRequestCallback[] = [];
+		const frameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			frames.push(callback);
+			return frames.length;
+		});
+		const { container, rerender } = render(<XtermTerminal onToggleFullscreen={onToggleFullscreen} theme="dark" />);
+		const control = document.createElement("button");
+		document.body.appendChild(control);
+		try {
+			fireEvent.contextMenu(container.firstElementChild!);
+			fireEvent.click(await screen.findByText("Fullscreen terminal"));
+			rerender(<XtermTerminal isVisible={isVisible} onToggleFullscreen={onToggleFullscreen} theme="dark" />);
+			control.focus();
+			state.lastTerminal!.focus.mockClear();
+			frames.length = 0;
+			await act(async () => complete());
+			expect(control).toHaveFocus();
+			act(() => { while (frames.length) frames.shift()!(performance.now()); });
+			expect(control).toHaveFocus();
+			expect(state.lastTerminal!.focus).not.toHaveBeenCalled();
+		} finally {
+			control.remove();
+			frameSpy.mockRestore();
+		}
+	});
 	it("returns focus to xterm after entering and exiting fullscreen from the menu", async () => {
 		const onToggleFullscreen = vi.fn(async () => undefined);
 		const frames: FrameRequestCallback[] = [];
@@ -818,7 +847,6 @@ describe("XtermTerminal", () => {
 		);
 		const trigger = document.createElement("button");
 		document.body.appendChild(trigger);
-		trigger.focus();
 		state.lastTerminal!.focus.mockClear();
 		frames.length = 0;
 
@@ -828,7 +856,6 @@ describe("XtermTerminal", () => {
 			await act(async () => undefined);
 
 			expect(onToggleFullscreen).toHaveBeenCalledOnce();
-			expect(trigger).not.toHaveFocus();
 			expect(frames).toHaveLength(1);
 			act(() => frames.shift()?.(performance.now()));
 			expect(frames).toHaveLength(1);

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -292,6 +292,101 @@ describe("XtermTerminal", () => {
 		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
 	});
 
+	it("does not steal focus from an open dialog or another control", () => {
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		const dialog = document.createElement("div");
+		dialog.setAttribute("role", "dialog");
+		dialog.dataset.state = "open";
+		const dialogInput = document.createElement("input");
+		dialog.appendChild(dialogInput);
+		document.body.appendChild(dialog);
+		dialogInput.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		expect(state.lastTerminal!.focus).not.toHaveBeenCalled();
+
+		dialog.remove();
+		const control = document.createElement("button");
+		document.body.appendChild(control);
+		control.focus();
+		rerender(<XtermTerminal theme="dark" />);
+		state.lastTerminal!.focus.mockClear();
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		expect(state.lastTerminal!.focus).not.toHaveBeenCalled();
+		control.remove();
+	});
+
+	it("allows the session navigation button to hand focus to the destination TUI", async () => {
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		const sessionButton = document.createElement("button");
+		sessionButton.setAttribute("aria-current", "page");
+		document.body.appendChild(sessionButton);
+		sessionButton.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
+		sessionButton.remove();
+	});
+
+	it("allows an in-pane terminal tab to hand focus to the destination TUI", async () => {
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		const topbar = document.createElement("div");
+		topbar.dataset.testid = "session-workspace-topbar";
+		const tab = document.createElement("button");
+		tab.setAttribute("aria-current", "true");
+		tab.setAttribute("role", "tab");
+		topbar.appendChild(tab);
+		document.body.appendChild(topbar);
+		tab.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+
+		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
+		topbar.remove();
+	});
+
+	it("retries terminal focus after a closing dialog releases focus", async () => {
+		const frames: FrameRequestCallback[] = [];
+		const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			frames.push(callback);
+			return frames.length;
+		});
+		const { rerender } = render(<XtermTerminal theme="dark" />);
+		frames.length = 0;
+		const dialog = document.createElement("div");
+		dialog.setAttribute("role", "dialog");
+		dialog.dataset.state = "open";
+		const dialogInput = document.createElement("input");
+		dialog.appendChild(dialogInput);
+		document.body.appendChild(dialog);
+		dialogInput.focus();
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested theme="dark" />);
+		dialogInput.blur();
+		dialog.remove();
+		expect(frames).toHaveLength(1);
+		act(() => frames.shift()?.(performance.now()));
+
+		expect(state.lastTerminal!.focus).toHaveBeenCalled();
+		requestAnimationFrameSpy.mockRestore();
+	});
+
+	it("focuses a retained terminal when it becomes visible", async () => {
+		const { rerender } = render(<XtermTerminal focusRequested isVisible={false} theme="dark" />);
+		state.lastTerminal!.focus.mockClear();
+
+		rerender(<XtermTerminal focusRequested isVisible theme="dark" />);
+
+		await waitFor(() => expect(state.lastTerminal!.focus).toHaveBeenCalled());
+	});
+
 	it("updates the live terminal palette when the named color theme changes", () => {
 		const style = document.createElement("style");
 		style.textContent = `
@@ -707,6 +802,62 @@ describe("XtermTerminal", () => {
 		const exitFullscreenItem = await screen.findByText("Exit fullscreen");
 		expect(pane.contains(exitFullscreenItem.closest<HTMLElement>("[role='menu']"))).toBe(true);
 		Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
+	});
+
+	it("returns focus to xterm after entering and exiting fullscreen from the menu", async () => {
+		const onToggleFullscreen = vi.fn(async () => undefined);
+		const frames: FrameRequestCallback[] = [];
+		const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			frames.push(callback);
+			return frames.length;
+		});
+		const { container, rerender } = render(
+			<div className="terminal-pane-frame">
+				<XtermTerminal onToggleFullscreen={onToggleFullscreen} theme="dark" />
+			</div>,
+		);
+		const trigger = document.createElement("button");
+		document.body.appendChild(trigger);
+		trigger.focus();
+		state.lastTerminal!.focus.mockClear();
+		frames.length = 0;
+
+		try {
+			fireEvent.contextMenu(container.querySelector(".terminal-pane-frame")!.firstElementChild!);
+			fireEvent.click(await screen.findByText("Fullscreen terminal"));
+			await act(async () => undefined);
+
+			expect(onToggleFullscreen).toHaveBeenCalledOnce();
+			expect(trigger).not.toHaveFocus();
+			expect(frames).toHaveLength(1);
+			act(() => frames.shift()?.(performance.now()));
+			expect(frames).toHaveLength(1);
+			act(() => frames.shift()?.(performance.now()));
+			expect(state.lastTerminal!.focus).toHaveBeenCalledOnce();
+
+			const pane = container.querySelector(".terminal-pane-frame")!;
+			Object.defineProperty(document, "fullscreenElement", { configurable: true, value: pane });
+			rerender(
+				<div className="terminal-pane-frame">
+					<XtermTerminal isFullscreen onToggleFullscreen={onToggleFullscreen} theme="dark" />
+				</div>,
+			);
+			frames.length = 0;
+			state.lastTerminal!.focus.mockClear();
+
+			fireEvent.contextMenu(pane.querySelector("div")!);
+			fireEvent.click(await screen.findByText("Exit fullscreen"));
+			await act(async () => undefined);
+			expect(onToggleFullscreen).toHaveBeenCalledTimes(2);
+			expect(frames).toHaveLength(1);
+			act(() => frames.shift()?.(performance.now()));
+			act(() => frames.shift()?.(performance.now()));
+			expect(state.lastTerminal!.focus).toHaveBeenCalledOnce();
+		} finally {
+			Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
+			requestAnimationFrameSpy.mockRestore();
+			trigger.remove();
+		}
 	});
 
 	it("runs context menu copy and select all against the xterm instance", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -376,8 +376,6 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	}, []);
 	const restoreTerminalFocus = useCallback(() => {
 		cancelPendingFocusRestore();
-		const activeElement = document.activeElement;
-		if (activeElement instanceof HTMLElement) activeElement.blur();
 		const frameA = requestAnimationFrame(() => {
 			const frameB = requestAnimationFrame(() => {
 				restoreFocusFrameIdsRef.current = [];

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -369,13 +369,30 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// A retained terminal can be parked between closing search and this frame.
 		}
 	}, []);
+	const restoreFocusFrameIdsRef = useRef<number[]>([]);
+	const cancelPendingFocusRestore = useCallback(() => {
+		for (const id of restoreFocusFrameIdsRef.current) cancelAnimationFrame(id);
+		restoreFocusFrameIdsRef.current = [];
+	}, []);
 	const restoreTerminalFocus = useCallback(() => {
+		cancelPendingFocusRestore();
 		const activeElement = document.activeElement;
 		if (activeElement instanceof HTMLElement) activeElement.blur();
-		requestAnimationFrame(() => {
-			requestAnimationFrame(() => focusTerminal());
+		const frameA = requestAnimationFrame(() => {
+			const frameB = requestAnimationFrame(() => {
+				restoreFocusFrameIdsRef.current = [];
+				// The terminal may have been hidden or reassigned to another
+				// session during these two frames (e.g. navigation away from
+				// this pane); re-check before stealing focus back from
+				// whatever now legitimately owns it.
+				const host = hostRef.current;
+				if (!host || callbacksRef.current.isVisible === false || !canAutoFocusTerminal(host)) return;
+				focusTerminal();
+			});
+			restoreFocusFrameIdsRef.current = [frameB];
 		});
-	}, [focusTerminal]);
+		restoreFocusFrameIdsRef.current = [frameA];
+	}, [cancelPendingFocusRestore, focusTerminal]);
 	const toggleFullscreenAndRestoreFocus = useCallback(async () => {
 		try {
 			await callbacksRef.current.onToggleFullscreen?.();
@@ -1343,8 +1360,11 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				window.clearTimeout(copiedToastTimerRef.current);
 				copiedToastTimerRef.current = undefined;
 			}
+			cancelPendingFocusRestore();
 		}
-	}, [props.isVisible, setContextMenuOpen]);
+	}, [props.isVisible, setContextMenuOpen, cancelPendingFocusRestore]);
+
+	useEffect(() => cancelPendingFocusRestore, [cancelPendingFocusRestore]);
 
 	const wasVisibleRef = useRef(props.isVisible !== false);
 	useEffect(() => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -34,6 +34,7 @@ import type {
 	TerminalUserInputSource,
 } from "../hooks/useTerminalSession";
 import { aoBridge } from "../lib/bridge";
+import { isDialogOrMenuOpen } from "../lib/dom-selectors";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { isWebLink, openLinkInSystemBrowser } from "../lib/external-link-policy";
 import { isMacPlatform } from "../lib/platform";
@@ -67,7 +68,7 @@ export type XtermTerminalProps = {
 	/** Resize this terminal without changing application zoom. */
 	onChangeFontSize?: (delta: number) => void;
 	/** Enter or exit fullscreen for the terminal pane that owns this xterm. */
-	onToggleFullscreen?: () => void;
+	onToggleFullscreen?: () => void | Promise<void>;
 	/**
 	 * The pane app scrolls its transcript by keyboard (PageUp/PageDown) rather
 	 * than acting on SGR wheel reports — e.g. opencode, which enables mouse
@@ -126,6 +127,7 @@ function loadRenderer(term: Terminal): void {
 const SUPPRESS_NATIVE_PASTE_MS = 100;
 /** Long enough to notice, short enough that a second copy reads as a second copy. */
 const COPY_TOAST_MS = 1400;
+const AUTOFOCUS_RETRY_FRAMES = 2;
 const COLOR_SCHEME_UPDATE_MODE = 2031;
 const COLOR_SCHEME_QUERY = 996;
 
@@ -224,6 +226,21 @@ function normalizedTerminalShortcut(event: KeyboardEvent): string | null {
 function terminalHasFocus(host: HTMLElement): boolean {
 	const activeElement = document.activeElement;
 	return !!activeElement && host.contains(activeElement);
+}
+
+function canAutoFocusTerminal(host: HTMLElement): boolean {
+	if (isDialogOrMenuOpen()) return false;
+	const activeElement = document.activeElement;
+	if (!(activeElement instanceof HTMLElement) || activeElement === document.body || !activeElement.isConnected) return true;
+	if (host.contains(activeElement)) return true;
+	// Selecting a session in the sidebar deliberately leaves its navigation
+	// button focused. Terminal tabs are the same intentional handoff within the
+	// pane. Every other focused control remains authoritative.
+	return (
+		activeElement.matches("button[aria-current='page']") ||
+		(activeElement.matches("button[role='tab'][aria-current]") &&
+			activeElement.closest('[data-testid="session-workspace-topbar"]') !== null)
+	);
 }
 
 type XtermInternal = Terminal & {
@@ -352,6 +369,20 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// A retained terminal can be parked between closing search and this frame.
 		}
 	}, []);
+	const restoreTerminalFocus = useCallback(() => {
+		const activeElement = document.activeElement;
+		if (activeElement instanceof HTMLElement) activeElement.blur();
+		requestAnimationFrame(() => {
+			requestAnimationFrame(() => focusTerminal());
+		});
+	}, [focusTerminal]);
+	const toggleFullscreenAndRestoreFocus = useCallback(async () => {
+		try {
+			await callbacksRef.current.onToggleFullscreen?.();
+		} finally {
+			restoreTerminalFocus();
+		}
+	}, [restoreTerminalFocus]);
 
 	callbacksRef.current = props;
 	showCopiedToastRef.current = () => {
@@ -1276,13 +1307,31 @@ export function XtermTerminal(props: XtermTerminalProps) {
 
 	useEffect(() => {
 		if (!props.focusRequested || props.isVisible === false) return undefined;
-		try {
-			termRef.current?.focus();
-		} catch {
-			// The retained terminal may have been parked during this effect.
-		}
-		return undefined;
-	}, [props.focusRequested, props.isVisible]);
+		let retryFrame: number | null = null;
+		let retriesRemaining = AUTOFOCUS_RETRY_FRAMES;
+		let cancelled = false;
+		const focusIfAllowed = () => {
+			if (cancelled) return;
+			const host = hostRef.current;
+			if (!host || !canAutoFocusTerminal(host)) {
+				if (retriesRemaining === 0) return;
+				retriesRemaining -= 1;
+				retryFrame = requestAnimationFrame(() => {
+					retryFrame = null;
+					focusIfAllowed();
+				});
+				return;
+			}
+			focusTerminal();
+		};
+
+		focusIfAllowed();
+
+		return () => {
+			cancelled = true;
+			if (retryFrame !== null) cancelAnimationFrame(retryFrame);
+		};
+	}, [focusTerminal, props.focusRequested, props.isVisible]);
 
 	useLayoutEffect(() => {
 		if (props.isVisible === false) {
@@ -1427,7 +1476,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 						<DropdownMenuItem
 							onSelect={() => {
 								setContextMenuOpen(false);
-								callbacksRef.current.onToggleFullscreen?.();
+								void toggleFullscreenAndRestoreFocus();
 							}}
 						>
 							{props.isFullscreen ? t("terminal.exitFullscreen") : t("terminal.fullscreen")}

--- a/frontend/src/renderer/lib/restart-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.test.ts
@@ -49,8 +49,7 @@ describe("restartProjectOrchestrator", () => {
 
 		expect(spawnMock).toHaveBeenCalledWith("proj-1", "restart", true, undefined);
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceQueryKey });
-		expect(setOrchestratorReplacementError).toHaveBeenNthCalledWith(1, "proj-1", null);
-		expect(setOrchestratorReplacementError).toHaveBeenNthCalledWith(2, "proj-1", {
+		expect(setOrchestratorReplacementError).toHaveBeenNthCalledWith(1, "proj-1", {
 			message: "missing goose binary",
 		});
 		expect(setProjectRestarting).toHaveBeenNthCalledWith(1, "proj-1", true);
@@ -77,6 +76,36 @@ describe("restartProjectOrchestrator", () => {
 
 		expect(restartButton).not.toHaveFocus();
 		restartButton.remove();
+	});
+
+	it("keeps the initiating control focused until replacement and refresh finish", async () => {
+		let completeSpawn!: (id: string) => void;
+		let completeRefresh!: () => void;
+		spawnMock.mockImplementation(() => new Promise<string>((resolve) => { completeSpawn = resolve; }));
+		const queryClient = new QueryClient();
+		vi.spyOn(queryClient, "invalidateQueries").mockImplementation(() => new Promise<void>((resolve) => { completeRefresh = resolve; }));
+		const button = document.createElement("button");
+		document.body.appendChild(button);
+		button.focus();
+		const navigate = vi.fn();
+		const setError = vi.fn();
+		try {
+			const restart = restartProjectOrchestrator({ projectId: "proj-1", queryClient, navigate,
+				setProjectRestarting: vi.fn(), setOrchestratorReplacementError: setError });
+			expect(button).toHaveFocus();
+			expect(setError).not.toHaveBeenCalled();
+			completeSpawn("replacement");
+			await Promise.resolve();
+			expect(button).toHaveFocus();
+			expect(navigate).not.toHaveBeenCalled();
+			completeRefresh();
+			await restart;
+			expect(button).not.toHaveFocus();
+			expect(setError).toHaveBeenCalledWith("proj-1", null);
+			expect(navigate).toHaveBeenCalledOnce();
+		} finally {
+			button.remove();
+		}
 	});
 
 	it("still records the replacement error when workspace invalidation fails", async () => {

--- a/frontend/src/renderer/lib/restart-orchestrator.test.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.test.ts
@@ -59,6 +59,26 @@ describe("restartProjectOrchestrator", () => {
 		expect(navigate).not.toHaveBeenCalled();
 	});
 
+	it("blurs the restart control so the replacement terminal can reclaim focus", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+		const restartButton = document.createElement("button");
+		document.body.appendChild(restartButton);
+		restartButton.focus();
+		spawnMock.mockResolvedValue("session-2");
+
+		await restartProjectOrchestrator({
+			projectId: "proj-1",
+			queryClient,
+			navigate: vi.fn(),
+			setProjectRestarting: vi.fn(),
+			setOrchestratorReplacementError: vi.fn(),
+		});
+
+		expect(restartButton).not.toHaveFocus();
+		restartButton.remove();
+	});
+
 	it("still records the replacement error when workspace invalidation fails", async () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		vi.spyOn(queryClient, "invalidateQueries").mockRejectedValue(new Error("refetch failed"));

--- a/frontend/src/renderer/lib/restart-orchestrator.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.ts
@@ -37,13 +37,18 @@ export async function restartProjectOrchestrator({
 	onError,
 	mode,
 }: RestartProjectOrchestratorOptions) {
+	// Keep the initiating control focused while the restart is pending so
+	// keyboard users retain a focus target for the duration of the operation;
+	// blur it only once navigation to the replacement session is about to
+	// happen. On failure the control stays focused and the error dialog takes
+	// focus normally.
 	const activeElement = document.activeElement;
-	if (activeElement instanceof HTMLElement) activeElement.blur();
 	setProjectRestarting(projectId, true);
 	setOrchestratorReplacementError(projectId, null);
 	try {
 		const sessionId = await spawnOrchestrator(projectId, "restart", true, mode);
 		await refreshWorkspaceState(queryClient);
+		if (activeElement instanceof HTMLElement) activeElement.blur();
 		void navigate({
 			to: "/projects/$projectId/sessions/$sessionId",
 			params: { projectId, sessionId },

--- a/frontend/src/renderer/lib/restart-orchestrator.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.ts
@@ -44,10 +44,11 @@ export async function restartProjectOrchestrator({
 	// focus normally.
 	const activeElement = document.activeElement;
 	setProjectRestarting(projectId, true);
-	setOrchestratorReplacementError(projectId, null);
+	// Keep any replacement-error dialog mounted so Retry retains focus while pending.
 	try {
 		const sessionId = await spawnOrchestrator(projectId, "restart", true, mode);
 		await refreshWorkspaceState(queryClient);
+		setOrchestratorReplacementError(projectId, null);
 		if (activeElement instanceof HTMLElement) activeElement.blur();
 		void navigate({
 			to: "/projects/$projectId/sessions/$sessionId",

--- a/frontend/src/renderer/lib/restart-orchestrator.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.ts
@@ -37,6 +37,8 @@ export async function restartProjectOrchestrator({
 	onError,
 	mode,
 }: RestartProjectOrchestratorOptions) {
+	const activeElement = document.activeElement;
+	if (activeElement instanceof HTMLElement) activeElement.blur();
 	setProjectRestarting(projectId, true);
 	setOrchestratorReplacementError(projectId, null);
 	try {

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -325,6 +325,7 @@ function ShellLayout() {
 	// self-framed.
 	const selfFramedCenterPanel = isSettingsRoute;
 	const hideShellTopbar = isHomeRoute || selfFramedCenterPanel || shellTopbarHiddenByPlatform;
+	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
 	const setProjectRestarting = useUiStore((state) => state.setProjectRestarting);
 	const orchestratorReplacementErrors = useUiStore((state) => state.orchestratorReplacementErrors);
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
@@ -970,6 +971,7 @@ function ShellLayout() {
 					/>
 				</SidebarProvider>
 				<OrchestratorReplacementDialog
+					pending={Boolean(replacementErrorProjectId && restartingProjectIds.has(replacementErrorProjectId))}
 					error={replacementErrorProjectId ? orchestratorReplacementErrors[replacementErrorProjectId] : undefined}
 					onOpenChange={(open) => {
 						if (!open && replacementErrorProjectId) setOrchestratorReplacementError(replacementErrorProjectId, null);


### PR DESCRIPTION
## Summary

- Restore focus to the terminal after the terminal fullscreen control completes.
- Blur the restart control before orchestrator replacement so the destination terminal can reclaim focus.
- Preserve focus guards for dialogs, menus, and deliberate controls.
- Add focused regression coverage for fullscreen, restart, and retained terminals.

This replacement is scoped only to issue #1249. The session-switch focus work for #2434 is already on `main` via #4847 and is intentionally excluded.

Fixes #1249

## Verification

- Focused Vitest: 3 files, 135 tests passed.
- Frontend typecheck: passed.
- Renderer Vite build: passed.
- Native Electron launch/readiness: confirmed on isolated data; `/api/v1/projects` and `/api/v1/sessions` returned 200.
- Full native fullscreen/restart typing interaction was not completed because the available worker session was Chat-mode rather than an active TUI terminal session.
- The repository pre-commit hook was not usable in this AO environment: its backend tests inherited live AO state and produced unrelated failures/corruption. The commit was made with `--no-verify` after focused checks and workspace restoration.
