### PR TITLE
fix(session): resolve orchestrator workspace to the project checkout for desktop handoff

### DIFF
--- a/backend/internal/service/session/workspace_location.go
+++ b/backend/internal/service/session/workspace_location.go
@@ -23,13 +23,38 @@ func (s *Service) WorkspaceLocation(ctx context.Context, id domain.SessionID) (s
 		return "", apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
 	}
 
-	workspacePath := strings.TrimSpace(record.Metadata.WorkspacePath)
-	if workspacePath == "" || !filepath.IsAbs(workspacePath) {
+	// Orchestrators run directly in the project checkout and are never assigned
+	// a per-session worktree, so Metadata.WorkspacePath is empty by design.
+	// Their workspace location is the project's own path — without this branch
+	// the desktop editor-handoff probe 404s and the topbar permanently flags
+	// every orchestrator session as "Session workspace is not available".
+	// Workers and legacy records with no kind keep the strict Metadata-only
+	// contract below: a worker whose worktree vanished must surface as
+	// unavailable, not silently redirect the editor to the project checkout.
+	if record.Kind == domain.KindOrchestrator {
+		project, ok, err := s.store.GetProject(ctx, string(record.ProjectID))
+		if err != nil {
+			return "", fmt.Errorf("get project %s workspace: %w", record.ProjectID, err)
+		}
+		if !ok {
+			return "", apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace is not available")
+		}
+		return workspaceDir(project.Path)
+	}
+
+	return workspaceDir(record.Metadata.WorkspacePath)
+}
+
+// workspaceDir validates path as an existing absolute directory and returns it
+// cleaned; anything else is reported as "not available" rather than guessed at.
+func workspaceDir(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) {
 		return "", apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace is not available")
 	}
-	info, err := os.Stat(workspacePath)
+	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {
 		return "", apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace is not available")
 	}
-	return filepath.Clean(workspacePath), nil
+	return filepath.Clean(path), nil
 }

--- a/backend/internal/service/session/workspace_location_test.go
+++ b/backend/internal/service/session/workspace_location_test.go
@@ -35,6 +35,38 @@ func TestWorkspaceLocationDoesNotFallBackToProjectCheckout(t *testing.T) {
 	assertAPIErrorCode(t, err, "SESSION_WORKSPACE_NOT_FOUND")
 }
 
+// TestWorkspaceLocationResolvesOrchestratorToProjectCheckout: orchestrators
+// run directly in the project checkout and are never assigned a per-session
+// worktree, so Metadata.WorkspacePath is empty by design. Their workspace
+// location is the project's own path — without it the desktop editor-handoff
+// probe 404s and the topbar permanently flags every orchestrator session as
+// "Session workspace is not available".
+func TestWorkspaceLocationResolvesOrchestratorToProjectCheckout(t *testing.T) {
+	store := newFakeStore()
+	projectDir := t.TempDir()
+	store.sessions["ao-1"] = domain.SessionRecord{ID: "ao-1", ProjectID: "ao", Kind: domain.KindOrchestrator}
+	store.projects["ao"] = domain.ProjectRecord{ID: "ao", Path: projectDir}
+
+	got, err := (&Service{store: store}).WorkspaceLocation(context.Background(), "ao-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != projectDir {
+		t.Fatalf("WorkspaceLocation() = %q, want %q", got, projectDir)
+	}
+}
+
+// TestWorkspaceLocationRejectsOrchestratorWithMissingProjectDirectory: an
+// orchestrator whose project checkout is gone has nothing to hand off either.
+func TestWorkspaceLocationRejectsOrchestratorWithMissingProjectDirectory(t *testing.T) {
+	store := newFakeStore()
+	store.sessions["ao-1"] = domain.SessionRecord{ID: "ao-1", ProjectID: "ao", Kind: domain.KindOrchestrator}
+	store.projects["ao"] = domain.ProjectRecord{ID: "ao", Path: t.TempDir() + "/gone"}
+
+	_, err := (&Service{store: store}).WorkspaceLocation(context.Background(), "ao-1")
+	assertAPIErrorCode(t, err, "SESSION_WORKSPACE_NOT_FOUND")
+}
+
 func TestWorkspaceLocationRejectsMissingDirectory(t *testing.T) {
 	store := newFakeStore()
 	store.sessions["ao-1"] = domain.SessionRecord{


### PR DESCRIPTION
Closes #4991

## Summary

`WorkspaceLocation` — the loopback endpoint Electron main probes for the topbar editor-handoff — returned `SESSION_WORKSPACE_NOT_FOUND` for every orchestrator session: orchestrators run directly in the project checkout and are never assigned a per-session worktree, so `Metadata.WorkspacePath` is empty by design. The desktop topbar rendered that 404 as a permanent "Session workspace is not available" alert on every orchestrator tab.

The fix resolves orchestrator sessions to their project checkout:

- `record.Kind == orchestrator` → load the project record and return its `Path`, through the same absolute-path + directory-exists validation workers use (unknown project / missing directory still yields `SESSION_WORKSPACE_NOT_FOUND`);
- workers and legacy records with no kind keep the strict `Metadata.WorkspacePath`-only contract — the existing no-fallback guarantee (`TestWorkspaceLocationDoesNotFallBackToProjectCheckout`) is untouched, and its test still pins that a worker whose worktree vanished surfaces as unavailable rather than silently redirecting the editor to the project checkout.

The worker path is behaviorally identical; the shared validation moved into a small `workspaceDir` helper.

## Testing

- New: `TestWorkspaceLocationResolvesOrchestratorToProjectCheckout` (project checkout resolves), `TestWorkspaceLocationRejectsOrchestratorWithMissingProjectDirectory` (missing checkout still 404s), plus the existing four workspace-location tests unchanged and green.
- `go test ./internal/service/session/ ./internal/httpd/controllers/`, `go build ./...`, `go vet` on the touched packages, `gofmt -l .` across the backend module — all clean.
