### PR TITLE
fix(updater): recover from macOS staging missing-file failures

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -326,6 +326,26 @@ describe("startAutoUpdates", () => {
     }
   });
 
+  it.each(["download", "check", "return-home"])("does not discard a queued retry when the previous %s rejects", async (operation) => {
+    const restore = stubProcess("darwin", "/usr/bin/node");
+    try {
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+      await module.checkForUpdatesNow(stateDir);
+      const failure = new Error("ditto: /cache/app.ShipIt/update.abc/AO.app/Contents/Resources/._app.asar__: No such file or directory");
+      autoUpdater.downloadUpdate.mockImplementation(async () => {
+        updaterEvents.get("update-downloaded")?.({ version: "2.2.0" });
+      });
+      if (operation === "download") autoUpdater.downloadUpdate.mockRejectedValueOnce(failure);
+      else autoUpdater.checkForUpdates.mockRejectedValueOnce(failure);
+      const failed = operation === "download" ? module.downloadUpdateNow("failed")
+        : operation === "check" ? module.checkForUpdatesNow(stateDir, { requestId: "failed" })
+        : module.returnToHome(stateDir, "failed");
+      await Promise.all([failed, module.downloadUpdateNow("retry")]);
+      expect(module.getUpdateStatus().staged?.version).toBe("2.2.0");
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+    } finally { restore(); }
+  });
+
   it("does not invalidate a staged update for an unrelated missing file", async () => {
     const { module, updaterEvents } = await importAutoUpdater();
     await module.startAutoUpdates(stateDir);

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -214,6 +214,127 @@ describe("startAutoUpdates", () => {
     vi.resetModules();
   });
 
+  it("recovers a macOS ShipIt missing-file failure instead of retaining a ready update", async () => {
+    const restore = stubProcess("darwin", "/usr/local/bin/node");
+    try {
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+      await module.startAutoUpdates(stateDir);
+      updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+      await flushMicrotasks();
+      updaterEvents.get("error")?.(new Error(
+        "ditto: Could not lstat /Users/test/Library/Caches/dev.agent-orchestrator.desktop.ShipIt/update.abc/Agent Orchestrator.app/Contents/Resources/acp-runtime/node_modules/.bin/node-which: No such file or directory",
+      ));
+      expect(module.getUpdateStatus()).toMatchObject({ state: "error", message: expect.stringContaining("prepare the update") });
+      expect(module.getUpdateStatus().staged).toBeUndefined();
+      module.quitAndInstallUpdate();
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+      // A check and an explicit download can retry the SAME release, without
+      // touching ShipIt's files or deleting a cache concurrently with a download.
+      autoUpdater.checkForUpdates.mockResolvedValue({ isUpdateAvailable: true, updateInfo: { version: "2.1.0" } });
+      await module.checkForUpdatesNow(stateDir);
+      expect(module.getUpdateStatus().state).toBe("available");
+      autoUpdater.downloadUpdate.mockImplementation(async () => {
+        updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+      });
+      await module.downloadUpdateNow();
+      expect(module.getUpdateStatus().staged?.version).toBe("2.1.0");
+      module.quitAndInstallUpdate();
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps native preparation failures visible during an automatic check and retries next time", async () => {
+    const restore = stubProcess("darwin", "/usr/local/bin/node");
+    try {
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+      await module.checkForUpdatesNow(stateDir);
+      updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+      const error = new Error("ditto: /cache/app.ShipIt/update.abc/AO.app/Contents/Resources/._app.asar__: No such file or directory");
+      autoUpdater.checkForUpdates.mockImplementationOnce(async () => {
+        updaterEvents.get("checking-for-update")?.();
+        updaterEvents.get("error")?.(error);
+        throw error;
+      });
+      await module.startAutoUpdates(stateDir);
+      expect(module.getUpdateStatus()).toMatchObject({ state: "error", message: expect.stringContaining("prepare the update") });
+      expect(module.getUpdateStatus().staged).toBeUndefined();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const second = await importAutoUpdaterKeepingStagedFile();
+      await second.module.startAutoUpdates(stateDir);
+      expect(second.module.getUpdateStatus().staged).toBeUndefined();
+      expect(second.autoUpdater.autoDownload).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("handles a reject-only native failure before AO has recorded a staged build", async () => {
+    const restore = stubProcess("darwin", "/usr/local/bin/node");
+    try {
+      const { module, autoUpdater } = await importAutoUpdater();
+      await module.checkForUpdatesNow(stateDir);
+      autoUpdater.downloadUpdate.mockRejectedValue(new Error(
+        "ditto: /cache/app.ShipIt/update.abc/AO.app/Contents/Resources/._app.asar__: No such file or directory",
+      ));
+      await module.downloadUpdateNow("failed-download");
+      expect(module.getUpdateStatus()).toMatchObject({ state: "error", requestId: "failed-download", message: expect.stringContaining("prepare the update") });
+      module.quitAndInstallUpdate();
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not let an in-flight escalation check restore a failed installation", async () => {
+    const restore = stubProcess("darwin", "/usr/local/bin/node");
+    try {
+      const { module, updaterEvents, readUpdateSettings } = await importAutoUpdater();
+      await module.checkForUpdatesNow(stateDir);
+      const pendingSettings = deferred<UpdateSettings>();
+      readUpdateSettings.mockReturnValueOnce(pendingSettings.promise);
+      updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+      updaterEvents.get("error")?.(new Error(
+        "ditto: /cache/app.ShipIt/update.abc/AO.app/Contents/Resources/._app.asar__: No such file or directory",
+      ));
+      pendingSettings.resolve({ enabled: true, channel: "latest", nightlyAck: false, feature: null });
+      await flushMicrotasks();
+      expect(module.getUpdateStatus().state).toBe("error");
+      expect(module.getUpdateStatus().staged).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("preserves replacement provenance when staging immediately follows a failure", async () => {
+    const restore = stubProcess("darwin", "/usr/local/bin/node");
+    try {
+      const { module, updaterEvents } = await importAutoUpdater();
+      await module.checkForUpdatesNow(stateDir);
+      updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+      updaterEvents.get("error")?.(new Error(
+        "ditto: /cache/app.ShipIt/update.abc/AO.app/Contents/Resources/._app.asar__: No such file or directory",
+      ));
+      updaterEvents.get("update-downloaded")?.({ version: "2.2.0" });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const second = await importAutoUpdaterKeepingStagedFile();
+      await second.module.startAutoUpdates(stateDir);
+      expect(second.module.getUpdateStatus().staged?.version).toBe("2.2.0");
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not invalidate a staged update for an unrelated missing file", async () => {
+    const { module, updaterEvents } = await importAutoUpdater();
+    await module.startAutoUpdates(stateDir);
+    updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+    await flushMicrotasks();
+    updaterEvents.get("error")?.(new Error("ENOENT: no such file or directory, open /tmp/download.zip"));
+    expect(module.getUpdateStatus().staged?.version).toBe("2.1.0");
+  });
+
   it("runs the automatic updater check immediately on launch", async () => {
     const { module, autoUpdater } = await importAutoUpdater();
 

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -844,6 +844,13 @@ async function runSerializedUpdaterOperation(
     }
     try {
       await runOperation();
+    } catch (err) {
+      // Recover before releasing the queue. An outer caller catch can run after
+      // the next download starts and would discard that replacement's stamp.
+      if ((operation === "automatic-check" || operation === "manual-check" ||
+        operation === "manual-download" || operation === "return-home") &&
+        handleMacStagingFailure(err, requestId)) return;
+      throw err;
     } finally {
       activeUpdaterOperation = undefined;
       activeUpdaterRequestId = undefined;
@@ -1414,7 +1421,6 @@ export async function checkForUpdatesNow(
       options.requestId,
     );
   } catch (err) {
-    if (handleMacStagingFailure(err, options.requestId)) return;
     if (isManifest404Error(err)) {
       console.info("manual update check failed:", err);
       broadcastCompletedCheck({
@@ -1483,7 +1489,6 @@ export async function returnToHome(
       requestId,
     );
   } catch (err) {
-    if (handleMacStagingFailure(err, requestId)) return;
     broadcast({
       state: "error",
       message: (err as Error)?.message ?? "Return failed",
@@ -1522,7 +1527,6 @@ export async function downloadUpdateNow(requestId?: string): Promise<void> {
       requestId,
     );
   } catch (err) {
-    if (handleMacStagingFailure(err, requestId)) return;
     if (isManifest404Error(err)) {
       console.error("update download failed:", err);
       broadcast({

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -509,7 +509,11 @@ function stagedUpdateFile(stateDir: string): string {
   return path.join(stateDir, STAGED_UPDATE_FILE_NAME);
 }
 
-/** Fire-and-forget: losing this file costs provenance, never correctness. */
+// Keep removal behind older writes so a failed staging attempt cannot reappear
+// on relaunch, or delete the provenance of its replacement.
+let stagedPersistenceQueue: Promise<unknown> = Promise.resolve();
+
+/** Persist in event order without blocking updater events. */
 function persistStagedBuild(stateDir: string | undefined): void {
   if (stateDir === undefined || stagedVersion === undefined || stagedAtMs === undefined) return;
   const payload = `${JSON.stringify({
@@ -519,14 +523,17 @@ function persistStagedBuild(stateDir: string | undefined): void {
   })}\n`;
   // mkdir first: this can be the earliest write into the state dir on a fresh
   // install, and writeUpdateSettings is not guaranteed to have run yet.
-  void mkdir(stateDir, { recursive: true, mode: 0o750 })
+  stagedPersistenceQueue = stagedPersistenceQueue
+    .then(() => mkdir(stateDir, { recursive: true, mode: 0o750 }))
     .then(() => writeFile(stagedUpdateFile(stateDir), payload, { mode: 0o600 }))
     .catch(() => undefined);
 }
 
 function forgetPersistedStagedBuild(stateDir: string | undefined): void {
   if (stateDir === undefined) return;
-  void unlink(stagedUpdateFile(stateDir)).catch(() => undefined);
+  stagedPersistenceQueue = stagedPersistenceQueue
+    .then(() => unlink(stagedUpdateFile(stateDir)))
+    .catch(() => undefined);
 }
 
 /**
@@ -641,6 +648,36 @@ function discardStagedBuild(): void {
   stopEscalationTimer();
 }
 
+const MAC_STAGING_FAILURE_MESSAGE =
+  "macOS couldn't prepare the update because files were missing from its temporary installation copy. Check for updates and download it again to retry. If it happens again, install the latest app manually from GitHub Releases.";
+
+function handleMacStagingFailure(err: unknown, requestId = activeUpdaterRequestId): boolean {
+  if (process.platform !== "darwin") return false;
+  const message = err instanceof Error ? err.message : String(err);
+  // Match the installer failure, not an unrelated ENOENT or download error.
+  if (
+    !/ditto:/i.test(message) ||
+    !/\.ShipIt\/update[^/]*\/.*\.app\//i.test(message) ||
+    !/No such file or directory/i.test(message)
+  ) return false;
+  console.error("macOS update staging failed:", err);
+  // AO's download event precedes native extraction. A failure can also arrive
+  // before that stamp exists; neither case proves an installer is ready.
+  discardStagedBuild();
+  downloadStalled = false;
+  applyInstallOnQuitPolicy();
+  automaticCheckPreviousStatus = undefined;
+  broadcast({
+    state: "error",
+    message: MAC_STAGING_FAILURE_MESSAGE,
+    ...(requestId === undefined ? {} : { requestId }),
+  });
+  // Leave the verified ZIP alone. The failed copy is owned by ShipIt; repeating
+  // the download handoff lets the native updater prepare it again. Deleting a
+  // live cache here could race a newer download or an installer still reading it.
+  return true;
+}
+
 /** A build is downloaded and waiting to install, and we know which one. */
 function hasStagedBuild(): boolean {
   return stagedAtMs !== undefined && stagedVersion !== undefined;
@@ -744,6 +781,8 @@ async function runEscalationCheck(): Promise<void> {
   if (escalationStateDir === undefined) return;
   // A newer build is being pulled; let its progress own the status stream.
   if (lastStatus.state === "downloading") return;
+  const evaluatedVersion = stagedVersion;
+  const evaluatedAt = stagedAtMs;
   try {
     const settings = await readUpdateSettings(escalationStateDir);
     let important = false;
@@ -759,6 +798,7 @@ async function runEscalationCheck(): Promise<void> {
           : Promise.resolve(false),
       ]);
     }
+    if (stagedVersion !== evaluatedVersion || stagedAtMs !== evaluatedAt) return;
     stagedEscalated = evaluateEscalation({
       channel: settings.channel,
       stagedAt: stagedAtMs,
@@ -1058,6 +1098,10 @@ function wireUpdaterEvents(): void {
   });
   autoUpdater.on("error", (err) => {
     clearDownloadStallWatchdog();
+    if (handleMacStagingFailure(err)) {
+      emitUpdateFailure(err);
+      return;
+    }
     if (downloadStalled) {
       // Our own cancellation surfacing as an error. The stall status is already
       // published and is more useful than "cancelled"; replacing it would lose
@@ -1211,6 +1255,7 @@ async function runAutomaticUpdateCheck(
         // pre-check status so the renderer is neither stuck on "checking" nor
         // denied the stale-check nudge once the streak crosses the threshold
         // (#3526). Record before restoring so the restore broadcast is stamped.
+        if (handleMacStagingFailure(err)) return;
         recordAutomaticCheckFailure(err);
         restoreAutomaticCheckPreviousStatus();
         publishFailingChecks();
@@ -1369,6 +1414,7 @@ export async function checkForUpdatesNow(
       options.requestId,
     );
   } catch (err) {
+    if (handleMacStagingFailure(err, options.requestId)) return;
     if (isManifest404Error(err)) {
       console.info("manual update check failed:", err);
       broadcastCompletedCheck({
@@ -1437,6 +1483,7 @@ export async function returnToHome(
       requestId,
     );
   } catch (err) {
+    if (handleMacStagingFailure(err, requestId)) return;
     broadcast({
       state: "error",
       message: (err as Error)?.message ?? "Return failed",
@@ -1475,6 +1522,7 @@ export async function downloadUpdateNow(requestId?: string): Promise<void> {
       requestId,
     );
   } catch (err) {
+    if (handleMacStagingFailure(err, requestId)) return;
     if (isManifest404Error(err)) {
       console.error("update download failed:", err);
       broadcast({
@@ -1569,7 +1617,7 @@ function applyInstallOnQuitPolicy(): void {
 // quitAndInstallUpdate installs a downloaded update and relaunches. isSilent
 // false keeps the installer UI on Windows; isForceRunAfter relaunches the app.
 export function quitAndInstallUpdate(): void {
-	if (!app.isPackaged) return;
+	if (!app.isPackaged || awaitingStagedReplacement) return;
   const blocker = getMacInstallBlocker();
   if (blocker !== undefined) {
     console.warn("update install blocked:", blocker);


### PR DESCRIPTION
## What

Recover from macOS `ditto ... .ShipIt/update... .app/...: No such file or directory` errors by dropping AO's failed ready-to-install state and allowing the selected release to be offered again.

## Why

Related to #4175. After native preparation fails, AO can retain its staged stamp, keep offering Restart & install, and suppress another automatic download of that same version. This handles the reported missing-file error; it does not establish what originally removed the temporary files on the affected Mac.

## How

- Recognize the macOS ShipIt/ditto missing-file error, surface plain-language retry/manual-install guidance even during background checks, and retain the raw error in logs.
- Remove the failed staged stamp and reject stale install actions. Order persisted stamp writes/removal so a failed record cannot overwrite or remove its replacement. Ignore escalation results for a discarded/replaced build.
- Finish failure recovery inside the serialized operation before releasing a queued retry. An older rejected check/download/return must not discard the replacement staged by that retry.
- Preserve manual request IDs for reject-only failures, including failures before AO records a staged build.
- Leave the downloaded ZIP and native ShipIt files alone. Retrying the download hands the ZIP back to the native updater; there is no asynchronous cache deletion racing another download.

This is narrower than #4981's signature-rejection work and overlaps its error-handler area. Channel selection/downgrade policy is unchanged. Clearing AO's stamp/quit flag does **not** cancel an already-armed native macOS installer, and this does not move AO's downloaded event to native staging completion.

## Testing

- Reproduced the reported error with a failing regression test before the fix; all 117 updater tests now pass; new queued check/download/return regressions failed before the queue-ordering correction and pass afterwards.
- Full frontend Vitest suite: **280 files, 3,875 passed, 6 skipped** (`AO_AGENT_BROWSER_TEST_BINARY=... node node_modules/vitest/vitest.mjs run --maxWorkers=2`, Node 24).
- Renderer smoke: **55 passed** (`CI=true AO_E2E_PORT=5291 npm run test:e2e:renderer -- --workers=1`).
- Frontend `npm run typecheck` and `npm run typecheck:e2e`: pass.
- Cloud client generation/drift check, typecheck, 21 tests, and pack dry-run: pass. Product UI typecheck, 120 tests, and pack dry-run: pass.
- Initial concurrent local runs had one settings test failure and three renderer smoke failures. The settings/updater files passed together (149 tests), then both full suites passed on rerun without code changes.
- Local host is macOS; the pinned Linux smoke container and gitleaks action were verified in GitHub CI (Docker daemon unavailable locally). Native signed-app failure/retry has not been reproduced end to end; unit tests verify AO's recovery state, not elimination of the underlying ShipIt file-loss trigger.

GitHub CI on `5af86c7ad`: frontend `test`, `renderer-smoke`, and gitleaks `scan` all passed. [Frontend run](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34038758833).

The revised head is also included in #5002, where its overlap with native restart preparation has been resolved and tested.
