### PR TITLE
fix: detect Windows agent binaries after install

### DIFF
--- a/backend/internal/adapters/agent/binaryutil/binaryutil.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil.go
@@ -171,6 +171,8 @@ func WindowsPackageManagerBinCandidates(names ...string) []string {
 	home, _ := os.UserHomeDir()
 	appData := os.Getenv("APPDATA")
 	localAppData := os.Getenv("LOCALAPPDATA")
+	programFiles := os.Getenv("ProgramFiles")
+	programFilesX86 := os.Getenv("ProgramFiles(x86)")
 	programData := os.Getenv("ProgramData")
 	if programData == "" {
 		programData = os.Getenv("PROGRAMDATA")
@@ -203,6 +205,9 @@ func WindowsPackageManagerBinCandidates(names ...string) []string {
 		}
 		if localAppData != "" {
 			out = append(out,
+				filepath.Join(localAppData, "npm", name+".cmd"),
+				filepath.Join(localAppData, "npm", name+".exe"),
+				filepath.Join(localAppData, "Microsoft", "WinGet", "Links", name+".exe"),
 				filepath.Join(localAppData, "pnpm", name+".cmd"),
 				filepath.Join(localAppData, "pnpm", name+".exe"),
 				filepath.Join(localAppData, "Yarn", "bin", name+".cmd"),
@@ -212,6 +217,12 @@ func WindowsPackageManagerBinCandidates(names ...string) []string {
 				filepath.Join(localAppData, "mise", "shims", name+".exe"),
 				filepath.Join(localAppData, "mise", "shims", name+".cmd"),
 			)
+		}
+		if programFiles != "" {
+			out = append(out, filepath.Join(programFiles, "WinGet", "Links", name+".exe"))
+		}
+		if programFilesX86 != "" {
+			out = append(out, filepath.Join(programFilesX86, "WinGet", "Links", name+".exe"))
 		}
 		if voltaHome != "" {
 			out = append(out,

--- a/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
@@ -129,6 +129,8 @@ func TestWindowsPackageManagerBinCandidates(t *testing.T) {
 	appData := filepath.Join(home, "AppData", "Roaming")
 	localAppData := filepath.Join(home, "AppData", "Local")
 	programData := filepath.Join(string(filepath.Separator), "ProgramData")
+	programFiles := filepath.Join(string(filepath.Separator), "Program Files")
+	programFilesX86 := filepath.Join(string(filepath.Separator), "Program Files (x86)")
 	voltaHome := filepath.Join(home, "Volta")
 	nvmSymlink := filepath.Join(home, "AppData", "Roaming", "nvm-current")
 	t.Setenv("HOME", home)
@@ -137,6 +139,8 @@ func TestWindowsPackageManagerBinCandidates(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", localAppData)
 	t.Setenv("ProgramData", programData)
 	t.Setenv("PROGRAMDATA", programData)
+	t.Setenv("ProgramFiles", programFiles)
+	t.Setenv("ProgramFiles(x86)", programFilesX86)
 	t.Setenv("VOLTA_HOME", voltaHome)
 	t.Setenv("NVM_SYMLINK", nvmSymlink)
 
@@ -152,6 +156,9 @@ func TestWindowsPackageManagerBinCandidates(t *testing.T) {
 		filepath.Join(programData, "chocolatey", "bin", "widget.exe"),
 		filepath.Join(programData, "chocolatey", "bin", "widget.bat"),
 		filepath.Join(programData, "chocolatey", "bin", "widget.cmd"),
+		filepath.Join(localAppData, "npm", "widget.cmd"),
+		filepath.Join(localAppData, "npm", "widget.exe"),
+		filepath.Join(localAppData, "Microsoft", "WinGet", "Links", "widget.exe"),
 		filepath.Join(localAppData, "pnpm", "widget.cmd"),
 		filepath.Join(localAppData, "pnpm", "widget.exe"),
 		filepath.Join(localAppData, "Yarn", "bin", "widget.cmd"),
@@ -160,6 +167,8 @@ func TestWindowsPackageManagerBinCandidates(t *testing.T) {
 		filepath.Join(localAppData, "Volta", "bin", "widget.exe"),
 		filepath.Join(localAppData, "mise", "shims", "widget.exe"),
 		filepath.Join(localAppData, "mise", "shims", "widget.cmd"),
+		filepath.Join(programFiles, "WinGet", "Links", "widget.exe"),
+		filepath.Join(programFilesX86, "WinGet", "Links", "widget.exe"),
 		filepath.Join(voltaHome, "bin", "widget.cmd"),
 		filepath.Join(voltaHome, "bin", "widget.exe"),
 		filepath.Join(nvmSymlink, "widget.cmd"),

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -15,6 +16,31 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+func TestResolveClaudeBinaryFindsLocalAppDataNPMInstallOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows install location")
+	}
+	localAppData := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("APPDATA", "")
+	t.Setenv("LOCALAPPDATA", localAppData)
+	t.Setenv("USERPROFILE", t.TempDir())
+	want := filepath.Join(localAppData, "npm", "claude.exe")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveClaudeBinary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("ResolveClaudeBinary() = %q, want %q", got, want)
+	}
+}
 
 func TestNativeConversationIDUsesTheSameClaudeUUIDAcrossInterfaces(t *testing.T) {
 	p := &Plugin{}

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestResolveClaudeBinaryFindsLocalAppDataNPMInstallOnWindows(t *testing.T) {
+func TestResolveClaudeBinaryFindsLocalAppDataNPMShimOnWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows install location")
 	}
@@ -26,11 +26,11 @@ func TestResolveClaudeBinaryFindsLocalAppDataNPMInstallOnWindows(t *testing.T) {
 	t.Setenv("APPDATA", "")
 	t.Setenv("LOCALAPPDATA", localAppData)
 	t.Setenv("USERPROFILE", t.TempDir())
-	want := filepath.Join(localAppData, "npm", "claude.exe")
+	want := filepath.Join(localAppData, "npm", "claude.cmd")
 	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(want, nil, 0o600); err != nil {
+	if err := os.WriteFile(want, []byte("@echo off\r\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	got, err := ResolveClaudeBinary(context.Background())

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestResolveCodexBinaryFindsLocalAppDataNPMInstallOnWindows(t *testing.T) {
+func TestResolveCodexBinaryFindsLocalAppDataNPMShimOnWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows install location")
 	}
@@ -23,11 +23,11 @@ func TestResolveCodexBinaryFindsLocalAppDataNPMInstallOnWindows(t *testing.T) {
 	t.Setenv("APPDATA", "")
 	t.Setenv("LOCALAPPDATA", localAppData)
 	t.Setenv("USERPROFILE", t.TempDir())
-	want := filepath.Join(localAppData, "npm", "codex.exe")
+	want := filepath.Join(localAppData, "npm", "codex.cmd")
 	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(want, nil, 0o600); err != nil {
+	if err := os.WriteFile(want, []byte("@echo off\r\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	got, err := ResolveCodexBinary(context.Background())

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -14,6 +14,31 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
+func TestResolveCodexBinaryFindsLocalAppDataNPMInstallOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows install location")
+	}
+	localAppData := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("APPDATA", "")
+	t.Setenv("LOCALAPPDATA", localAppData)
+	t.Setenv("USERPROFILE", t.TempDir())
+	want := filepath.Join(localAppData, "npm", "codex.exe")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveCodexBinary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("ResolveCodexBinary() = %q, want %q", got, want)
+	}
+}
+
 func TestNativeConversationIDRequiresCapturedCodexThreadForTUI(t *testing.T) {
 	p := &Plugin{}
 	if id, ok, err := p.NativeConversationID(context.Background(), ports.SessionRef{

--- a/backend/internal/adapters/agent/cursor/cursor_test.go
+++ b/backend/internal/adapters/agent/cursor/cursor_test.go
@@ -7,11 +7,37 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+func TestResolveCursorBinaryFindsWinGetLinkOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows install location")
+	}
+	localAppData := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("APPDATA", "")
+	t.Setenv("LOCALAPPDATA", localAppData)
+	t.Setenv("USERPROFILE", t.TempDir())
+	want := filepath.Join(localAppData, "Microsoft", "WinGet", "Links", "cursor-agent.exe")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveCursorBinary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("ResolveCursorBinary() = %q, want %q", got, want)
+	}
+}
 
 func TestGetLaunchCommandBuildsArgv(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "cursor-agent"}

--- a/backend/internal/adapters/systemexec/process_unix.go
+++ b/backend/internal/adapters/systemexec/process_unix.go
@@ -3,10 +3,17 @@
 package systemexec
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"syscall"
 )
+
+func commandContext(ctx context.Context, name string, args ...string) (*exec.Cmd, error) {
+	return exec.CommandContext(ctx, name, args...), nil //nolint:gosec // Callers supply server-owned argv.
+}
+
+func refreshExecutablePath() {}
 
 func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/backend/internal/adapters/systemexec/process_windows.go
+++ b/backend/internal/adapters/systemexec/process_windows.go
@@ -3,18 +3,106 @@
 package systemexec
 
 import (
+	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 )
 
-func configureProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP,
-		HideWindow:    true,
+func commandContext(ctx context.Context, name string, args ...string) (*exec.Cmd, error) {
+	resolved, err := exec.LookPath(name)
+	if err != nil {
+		return nil, err
 	}
+	extension := filepath.Ext(resolved)
+	if !strings.EqualFold(extension, ".cmd") && !strings.EqualFold(extension, ".bat") {
+		return exec.CommandContext(ctx, resolved, args...), nil //nolint:gosec // Callers supply server-owned argv.
+	}
+
+	shell := strings.TrimSpace(os.Getenv("ComSpec"))
+	if shell == "" {
+		shell = "cmd.exe"
+	}
+	cmd := exec.CommandContext(ctx, shell) //nolint:gosec // ComSpec is Windows' configured batch interpreter.
+	cmd.Args = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: `/d /s /c "` + windowsBatchCommandLine(resolved, args) + `"`}
+	return cmd, nil
+}
+
+func windowsBatchCommandLine(executable string, args []string) string {
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, quoteWindowsBatchArg(executable))
+	for _, arg := range args {
+		parts = append(parts, quoteWindowsBatchArg(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func quoteWindowsBatchArg(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func refreshExecutablePath() {
+	paths := []string{os.Getenv("Path")}
+	paths = append(paths,
+		registryPath(registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control\Session Manager\Environment`),
+		registryPath(registry.CURRENT_USER, `Environment`),
+	)
+	if merged := mergeWindowsPath(paths...); merged != "" {
+		_ = os.Setenv("Path", merged)
+	}
+}
+
+func registryPath(root registry.Key, keyPath string) string {
+	key, err := registry.OpenKey(root, keyPath, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = key.Close() }()
+	value, valueType, err := key.GetStringValue("Path")
+	if err != nil {
+		return ""
+	}
+	if valueType == registry.EXPAND_SZ {
+		if expanded, expandErr := registry.ExpandString(value); expandErr == nil {
+			value = expanded
+		}
+	}
+	return value
+}
+
+func mergeWindowsPath(values ...string) string {
+	seen := make(map[string]struct{})
+	merged := make([]string, 0)
+	for _, value := range values {
+		for _, entry := range strings.Split(value, ";") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			key := strings.ToLower(strings.TrimRight(entry, `\/`))
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, entry)
+		}
+	}
+	return strings.Join(merged, ";")
+}
+
+func configureProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP
+	cmd.SysProcAttr.HideWindow = true
 }
 
 func killProcessTree(cmd *exec.Cmd) error {

--- a/backend/internal/adapters/systemexec/process_windows_test.go
+++ b/backend/internal/adapters/systemexec/process_windows_test.go
@@ -13,24 +13,34 @@ import (
 func TestCommandContextWrapsBatchShimWithComSpec(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "agent tool.cmd")
-	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o600); err != nil {
+	if err := os.WriteFile(shim, []byte("@echo off\r\necho %~1\r\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("ComSpec", `C:\Windows\System32\cmd.exe`)
+	comSpec := os.Getenv("ComSpec")
+	if comSpec == "" {
+		t.Fatal("ComSpec is not set")
+	}
 
-	cmd, err := commandContext(context.Background(), shim, "--version")
+	cmd, err := commandContext(context.Background(), shim, "argument with spaces")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cmd.Path != `C:\Windows\System32\cmd.exe` {
+	if !strings.EqualFold(cmd.Path, comSpec) {
 		t.Fatalf("Path = %q, want ComSpec", cmd.Path)
 	}
-	if cmd.SysProcAttr == nil || !strings.Contains(cmd.SysProcAttr.CmdLine, `"agent tool.cmd" "--version"`) {
+	if cmd.SysProcAttr == nil || !strings.Contains(cmd.SysProcAttr.CmdLine, `"agent tool.cmd" "argument with spaces"`) {
 		t.Fatalf("CmdLine = %q, want quoted shim and argument", cmd.SysProcAttr.CmdLine)
 	}
 	configureProcessGroup(cmd)
 	if cmd.SysProcAttr.CmdLine == "" {
 		t.Fatal("configureProcessGroup discarded the batch command line")
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run batch shim: %v\n%s", err, output)
+	}
+	if got := strings.TrimSpace(string(output)); got != "argument with spaces" {
+		t.Fatalf("output = %q, want batch argument preserved", got)
 	}
 }
 

--- a/backend/internal/adapters/systemexec/process_windows_test.go
+++ b/backend/internal/adapters/systemexec/process_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package systemexec
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandContextWrapsBatchShimWithComSpec(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "agent tool.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ComSpec", `C:\Windows\System32\cmd.exe`)
+
+	cmd, err := commandContext(context.Background(), shim, "--version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Path != `C:\Windows\System32\cmd.exe` {
+		t.Fatalf("Path = %q, want ComSpec", cmd.Path)
+	}
+	if cmd.SysProcAttr == nil || !strings.Contains(cmd.SysProcAttr.CmdLine, `"agent tool.cmd" "--version"`) {
+		t.Fatalf("CmdLine = %q, want quoted shim and argument", cmd.SysProcAttr.CmdLine)
+	}
+	configureProcessGroup(cmd)
+	if cmd.SysProcAttr.CmdLine == "" {
+		t.Fatal("configureProcessGroup discarded the batch command line")
+	}
+}
+
+func TestMergeWindowsPathAddsRegistryEntriesWithoutDuplicates(t *testing.T) {
+	got := mergeWindowsPath(
+		`C:\Windows\System32;C:\Users\tester\AppData\Roaming\npm`,
+		`C:\Program Files\Git\cmd;C:\WINDOWS\SYSTEM32`,
+		`C:\Users\tester\AppData\Local\Microsoft\WinGet\Links`,
+	)
+	want := strings.Join([]string{
+		`C:\Windows\System32`,
+		`C:\Users\tester\AppData\Roaming\npm`,
+		`C:\Program Files\Git\cmd`,
+		`C:\Users\tester\AppData\Local\Microsoft\WinGet\Links`,
+	}, ";")
+	if got != want {
+		t.Fatalf("mergeWindowsPath() = %q, want %q", got, want)
+	}
+}

--- a/backend/internal/adapters/systemexec/systemexec.go
+++ b/backend/internal/adapters/systemexec/systemexec.go
@@ -53,7 +53,10 @@ func (Adapter) LookPath(file string) (string, error) {
 // stdin. The small Env list augments the daemon environment rather than
 // replacing PATH and the user's package-manager configuration.
 func (Adapter) RunInstall(ctx context.Context, command ports.InstallCommand, stdout, stderr io.Writer) error {
-	cmd := exec.CommandContext(ctx, command.Argv[0], command.Argv[1:]...) //nolint:gosec // G204: argv is selected from systeminstall's fixed recipes.
+	cmd, err := commandContext(ctx, command.Argv[0], command.Argv[1:]...)
+	if err != nil {
+		return err
+	}
 	configureProcessGroup(cmd)
 	cmd.Cancel = func() error { return killProcessTree(cmd) }
 	cmd.WaitDelay = 5 * time.Second
@@ -61,7 +64,14 @@ func (Adapter) RunInstall(ctx context.Context, command ports.InstallCommand, std
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Env = append(os.Environ(), command.Env...)
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	// Windows installers persist PATH changes outside the already-running
+	// daemon's process environment. Refresh it before adapter-backed
+	// verification tries to resolve the newly installed executable.
+	refreshExecutablePath()
+	return nil
 }
 
 // Probe takes one cancellation-aware snapshot of the package-manager facts
@@ -110,7 +120,10 @@ func (Adapter) Probe(ctx context.Context) (ports.InstallCapabilities, error) {
 func capabilityOutput(parent context.Context, name string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(parent, 3*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // fixed read-only argv from Probe.
+	cmd, err := commandContext(ctx, name, args...)
+	if err != nil {
+		return "", err
+	}
 	configureProcessGroup(cmd)
 	cmd.Cancel = func() error { return killProcessTree(cmd) }
 	cmd.WaitDelay = 5 * time.Second
@@ -165,7 +178,10 @@ func pathWritable(ctx context.Context, path string) (bool, error) {
 
 // Run executes argv with ctx and connects its output to the supplied writers.
 func (Adapter) Run(ctx context.Context, argv []string, stdout, stderr io.Writer) error {
-	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec // G204: argv is built from fixed system service commands.
+	cmd, err := commandContext(ctx, argv[0], argv[1:]...)
+	if err != nil {
+		return err
+	}
 	configureProcessGroup(cmd)
 	cmd.Cancel = func() error { return killProcessTree(cmd) }
 	cmd.WaitDelay = 5 * time.Second


### PR DESCRIPTION
## Problem

Agent installation can succeed on Windows while AO still reports the agent binary as missing. This affects users whose installer adds the executable to a persisted Windows `Path` or installs an npm/WinGet shim outside the daemon's startup environment.

The failure is most visible when installing Claude Code, Codex, or Cursor from the desktop app: installation completes, but the immediate post-install version check cannot resolve or launch the newly installed binary.

## Root cause

There are three Windows-specific gaps in the agent installation path:

1. The AO daemon keeps the `Path` inherited when it started. Windows installers update the user or machine environment in the registry, but they do not update an already-running process.
2. npm-installed CLIs are commonly exposed as `.cmd` or `.bat` shims. Passing those files directly to Go's `exec.CommandContext` does not execute them correctly on Windows.
3. The agent fallback search omitted common per-user npm and WinGet link directories used by affected installations.

This PR is scoped to agent installation and agent-binary resolution. It does not change the Git or GitHub CLI checks in `systemcheck`.

## Changes

- Refresh the daemon's process `Path` after a successful install by merging:
  - the existing process `Path`
  - the machine environment from `HKLM`
  - the current-user environment from `HKCU`
- Preserve existing path entries and deduplicate them case-insensitively.
- Execute `.cmd` and `.bat` shims through Windows `ComSpec` for installer capability checks, installation commands, and post-install version checks.
- Add fallback candidates for:
  - `%LOCALAPPDATA%\npm`
  - `%LOCALAPPDATA%\Microsoft\WinGet\Links`
  - `%ProgramFiles%\WinGet\Links`
  - `%ProgramFiles(x86)%\WinGet\Links`
- Add Windows-specific resolution coverage for Claude Code, Codex, and Cursor.

## Expected behavior

After AO installs an agent on Windows, the same running daemon can immediately locate and verify it without requiring the user to restart AO or manually edit `Path`.

## Validation

- Focused Go tests passed for `systemexec`, `binaryutil`, Claude Code, Codex, Cursor, and `systeminstall`.
- `go vet` passed for the affected packages.
- Windows cross-build passed for `systemexec`.
- Windows test binaries compiled for `systemexec`, `binaryutil`, Claude Code, Codex, and Cursor.
- `git diff --check` passed.

## Test-suite note

A full local `go test ./...` is currently blocked by unrelated upstream module-graph drift: the workspace graph requests missing `modernc.org/libc` packages, while the standalone backend module reports that `go.mod` needs tidying. The focused affected packages pass with `GOWORK=off` and `-mod=readonly`.

No API or generated artifacts are changed.
