### PR TITLE
fix(desktop): clear opaque browser-popout-frame under native composition

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1904,10 +1904,14 @@ ipcMain.on("shell:focus", () => browserViewHost?.forgetLastFocusedPanel());
 ipcMain.on("browser:overlay", (event, open: unknown) => {
 	if (event.sender !== getShellWebContents() || typeof open !== "boolean") return;
 	windowComposition?.setOverlayOpen(open);
-	// Raising the shell can leave the live page's own compositor surface stale
-	// (the same class of bug window-composition.ts already works around for
-	// the shell itself) — nudge it the same way once the shell is on top.
-	if (open) browserViewHost?.refreshLastFocusedPanelSurface();
+	// Refresh the live page's surface only on macOS: refreshLastFocusedPanelSurface
+	// is a macOS-specific compositor workaround (its own docstring says so). On
+	// Windows, hiding/restoring the native view under the raised shell causes a
+	// brief black flash, and window-composition.ts gates its equivalent nudge to
+	// darwin for the same reason.
+	if (open && process.platform === "darwin") {
+		browserViewHost?.refreshLastFocusedPanelSurface();
+	}
 });
 
 ipcMain.on(SET_CLOSE_SHELL_TERMINAL_SHORTCUT_ENABLED_CHANNEL, (_event, enabled: unknown) => {

--- a/frontend/src/renderer/native-composition-cascade.test.ts
+++ b/frontend/src/renderer/native-composition-cascade.test.ts
@@ -95,4 +95,14 @@ describe("native-composition transparency cascade", () => {
 	it("clears the popped-out overlay surface", () => {
 		expect(clearsBackgroundFor((selector) => selector.endsWith(".browser-popout-overlay"))).toBe(true);
 	});
+
+	it("clears the popped-out frame that directly wraps the maximized browser panel", () => {
+		// SessionView.tsx portals the maximized browser into a `.browser-popout-frame`
+		// wrapper that paints an opaque `background: var(--bg)` plate. The popped-out
+		// shell clears above target #root ancestors via `:has(.browser-popout-overlay)`
+		// and never match this element, so it must be cleared explicitly — otherwise
+		// raising the transparent shell for a tooltip/menu paints the frame's opaque
+		// background over the native page and blanks it to black (Windows, maximized).
+		expect(clearsBackgroundFor((selector) => selector.includes(".browser-popout-frame"))).toBe(true);
+	});
 });

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4765,6 +4765,16 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
 	background: transparent;
 }
 
+/* The popped-out frame is the direct wrapper of the maximized browser panel
+ * (SessionView.tsx's portal) and paints its own opaque `background: var(--bg)`
+ * plate. It is NOT covered by the `:has(.browser-popout-overlay)` shell clears
+ * above — those target ancestors under #root — and leaving it opaque blanked
+ * the live page to black on Windows whenever an overlay (tooltip, menu) raised
+ * the transparent shell over the native view in a maximized window. */
+html[data-native-browser-composition="true"] .browser-popout-frame {
+	background: transparent;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.browser-popout-frame,
 	.browser-popout-backdrop {


### PR DESCRIPTION
## What

Fixes the Windows maximized-window blackout of the embedded browser (issue #4979) when a renderer-owned overlay (toolbar tooltip, Browser Controls dropdown) appears above the native page.

When any `[data-browser-native-overlay]` opens, the transparent shell `WebContentsView` is raised above the native browser view (`setOverlayOpen(true)`). Every shell layer stacked over the page must be transparent for the duration, or it blanks the page. The native-composition cascade clears the `.browser-popout-overlay`, `.browser-popout-backdrop`, shell roots, and the browser panel viewport — but the popped-out maximized browser is portaled (SessionView) into a `.browser-popout-frame` wrapper that paints its own **opaque** `background: var(--bg)` plate. That rule was missed, so raising the shell for a tooltip/menu painted the opaque frame across the whole maximized page → solid black on Windows until the overlay closed.

## Change

- `styles.css`: clear `background` on `html[data-native-browser-composition="true"] .browser-popout-frame` alongside the existing overlay/backdrop clears.
- `native-composition-cascade.test.ts`: pin the contract so any future opaque ancestor of the popped-out browser panel is caught at source level, like the other settle/cascade tests.

## Root cause

The overlay/menu/tooltip backgrounds are intentionally opaque and correct. The black-out source was the always-present opaque `.browser-popout-frame` ancestor behind them, which the `:has(.browser-popout-overlay)` shell clears can never match (the portal pops out of `#root`).

## Verification

- Manual: reproduced in the real Electron desktop app on Windows — maximized window, embedded Browser panel; toolbar tooltip and Browser Controls/device dropdown open with the live page remaining visible underneath. Tabs, device presets, profiles, DevTools, and resize all still work.
- `frontend` `npm run typecheck`: pass.
- `vitest run src/renderer/native-composition-cascade.test.ts`: 6/6 pass.
- BrowserPanel + useBrowserView suites: pass.

Note: the full renderer suite has 2 pre-existing unrelated failures (`ChatTimelineItems`/`ChatWorkspace` "yesterday and older messages" date-label tests), present on `main` independent of this change (date-boundary/locale issue in chat tests).