### PR TITLE
fix(tasks): allow longer initial task prompts

### DIFF
--- a/backend/internal/adapters/runtime/conpty/spawn_windows.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_windows.go
@@ -65,6 +65,9 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 
 	// Build: <exe> pty-host <sessionID> <cwd> <shellCmd> <shellArgs...>
 	args := append([]string{"pty-host", sessionID, cwd}, argv...)
+	if err := validateWindowsCommandLine(append([]string{exe}, args...)); err != nil {
+		return "", 0, fmt.Errorf("conpty spawn: %w", err)
+	}
 
 	// Merge and normalize the environment for an interactive true-color PTY.
 	merged := interactiveTerminalEnv(os.Environ(), env, envAssignments)

--- a/backend/internal/adapters/runtime/conpty/windows_command_line.go
+++ b/backend/internal/adapters/runtime/conpty/windows_command_line.go
@@ -1,0 +1,90 @@
+package conpty
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf16"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const maxWindowsCommandLineUTF16 = 32767
+
+func validateWindowsCommandLine(args []string) error {
+	length := windowsCommandLineUTF16Len(args)
+	if length <= maxWindowsCommandLineUTF16 {
+		return nil
+	}
+	return fmt.Errorf("%w: escaped command line is %d UTF-16 code units; maximum is %d",
+		ports.ErrRuntimeCommandLineTooLong, length, maxWindowsCommandLineUTF16)
+}
+
+func windowsCommandLineUTF16Len(args []string) int {
+	return len(utf16.Encode([]rune(windowsCommandLine(args)))) + 1
+}
+
+func windowsCommandLine(args []string) string {
+	var commandLine strings.Builder
+	for i, arg := range args {
+		if i > 0 {
+			commandLine.WriteByte(' ')
+		}
+		appendWindowsEscapedArg(&commandLine, arg)
+	}
+	return commandLine.String()
+}
+
+func appendWindowsEscapedArg(dst *strings.Builder, arg string) {
+	if arg == "" {
+		dst.WriteString(`""`)
+		return
+	}
+
+	needsBackslash := false
+	hasSpace := false
+	for i := 0; i < len(arg); i++ {
+		switch arg[i] {
+		case '"', '\\':
+			needsBackslash = true
+		case ' ', '\t':
+			hasSpace = true
+		}
+	}
+
+	if !needsBackslash && !hasSpace {
+		dst.WriteString(arg)
+		return
+	}
+	if !needsBackslash {
+		dst.WriteByte('"')
+		dst.WriteString(arg)
+		dst.WriteByte('"')
+		return
+	}
+
+	if hasSpace {
+		dst.WriteByte('"')
+	}
+	slashes := 0
+	for i := 0; i < len(arg); i++ {
+		char := arg[i]
+		switch char {
+		case '\\':
+			slashes++
+		case '"':
+			for ; slashes > 0; slashes-- {
+				dst.WriteByte('\\')
+			}
+			dst.WriteByte('\\')
+		default:
+			slashes = 0
+		}
+		dst.WriteByte(char)
+	}
+	if hasSpace {
+		for ; slashes > 0; slashes-- {
+			dst.WriteByte('\\')
+		}
+		dst.WriteByte('"')
+	}
+}

--- a/backend/internal/adapters/runtime/conpty/windows_command_line_test.go
+++ b/backend/internal/adapters/runtime/conpty/windows_command_line_test.go
@@ -1,0 +1,42 @@
+package conpty
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestWindowsCommandLineUTF16LenEscapesQuotesAndBackslashes(t *testing.T) {
+	args := []string{`C:\Program Files\AO\ao.exe`, "-i", `say "hello"`, `trailing slash \`}
+	const escaped = `"C:\Program Files\AO\ao.exe" -i "say \"hello\"" "trailing slash \\"`
+
+	if got := windowsCommandLine(args); got != escaped {
+		t.Fatalf("windowsCommandLine() = %q, want %q", got, escaped)
+	}
+	want := len(escaped) + 1
+	if got := windowsCommandLineUTF16Len(args); got != want {
+		t.Fatalf("windowsCommandLineUTF16Len() = %d, want %d for %q", got, want, escaped)
+	}
+
+	if got, want := windowsCommandLineUTF16Len([]string{"qwen", "🙂"}), 8; got != want {
+		t.Fatalf("windowsCommandLineUTF16Len() with surrogate pair = %d, want %d", got, want)
+	}
+}
+
+func TestValidateWindowsCommandLineQuoteBoundary(t *testing.T) {
+	atLimit := []string{"qwen", "-i", strings.Repeat(`"`, 16379)}
+	if got := windowsCommandLineUTF16Len(atLimit); got != maxWindowsCommandLineUTF16 {
+		t.Fatalf("at-limit command length = %d, want %d", got, maxWindowsCommandLineUTF16)
+	}
+	if err := validateWindowsCommandLine(atLimit); err != nil {
+		t.Fatalf("validateWindowsCommandLine(at limit) error = %v", err)
+	}
+
+	overLimit := []string{"qwen", "-i", strings.Repeat(`"`, 16380)}
+	err := validateWindowsCommandLine(overLimit)
+	if !errors.Is(err, ports.ErrRuntimeCommandLineTooLong) {
+		t.Fatalf("validateWindowsCommandLine(over limit) error = %v, want ErrRuntimeCommandLineTooLong", err)
+	}
+}

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -8830,7 +8830,7 @@ components:
             $ref: '#/components/schemas/AttachmentInput'
           type: array
         brief:
-          maxLength: 4096
+          maxLength: 16384
           type: string
         mode:
           enum:
@@ -11286,7 +11286,7 @@ components:
         projectId:
           type: string
         prompt:
-          maxLength: 4096
+          maxLength: 16384
           type: string
         trackerProvider:
           enum:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -265,7 +265,7 @@ type SpawnSessionRequest struct {
 	// switch through the durable interface-transition endpoint. An unsupported
 	// explicit request fails rather than quietly producing the other kind of session.
 	Mode   domain.SessionMode `json:"mode,omitempty" enum:"chat,tui"`
-	Prompt string             `json:"prompt,omitempty" maxLength:"4096"`
+	Prompt string             `json:"prompt,omitempty" maxLength:"16384"`
 	// Model is an optional agent model override scoped to this single spawn. Empty
 	// keeps the resolved project/role default. The daemon validates that the
 	// selected harness can honor the model before launching.
@@ -748,7 +748,7 @@ type SendSessionMessageResponse struct {
 // An omitted agent tells the orchestrator to use the project's worker default.
 type DelegateTaskRequest struct {
 	ProjectID domain.ProjectID    `json:"projectId"`
-	Brief     string              `json:"brief" maxLength:"4096"`
+	Brief     string              `json:"brief" maxLength:"16384"`
 	Agent     domain.AgentHarness `json:"agent,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,muse,kiro,kilocode,vibe,pi,kimchi,omp,prime-agent,autohand,fake"`
 	Model     string              `json:"model,omitempty" maxLength:"256"`
 	// ApprovalMode is an optional per-session override. The UI uses the explicit

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -36,9 +36,6 @@ import (
 )
 
 const (
-	// Initial task prompts are passed to some TUI agents in their launch argv.
-	// Keep this below Windows' command-line ceiling while allowing substantial
-	// task briefs such as pasted setup guides and reference documents.
 	maxPromptLen      = 16 << 10
 	maxMessageLen     = 4096
 	maxModelLen       = 256

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -36,7 +36,10 @@ import (
 )
 
 const (
-	maxPromptLen      = 4096
+	// Initial task prompts are passed to some TUI agents in their launch argv.
+	// Keep this below Windows' command-line ceiling while allowing substantial
+	// task briefs such as pasted setup guides and reference documents.
+	maxPromptLen      = 16 << 10
 	maxMessageLen     = 4096
 	maxModelLen       = 256
 	maxDisplayNameLen = 20
@@ -256,7 +259,7 @@ func (c *SessionsController) spawn(w http.ResponseWriter, r *http.Request) {
 	}
 	in.Mode = mode
 	if len(in.Prompt) > maxPromptLen {
-		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "PROMPT_TOO_LONG", "prompt is too long", nil)
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "PROMPT_TOO_LONG", "Prompt must be 16 KiB or fewer", nil)
 		return
 	}
 	// displayName is optional at the API (the desktop new-task dialog omits it
@@ -1390,7 +1393,7 @@ func (c *SessionsController) delegateTask(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if len(in.Brief) > maxPromptLen {
-		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "TASK_TOO_LONG", "Task is too long", nil)
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "TASK_TOO_LONG", "Task must be 16 KiB or fewer", nil)
 		return
 	}
 	if utf8.RuneCountInString(strings.TrimSpace(in.Model)) > maxModelLen {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -2600,6 +2600,55 @@ func TestSessionsAPI_DelegateTask(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_DelegateTaskAcceptsLongBrief(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+	// The original controller rejected the first byte past 4 KiB even though
+	// valid task briefs commonly include longer pasted reference documents.
+	brief := strings.Repeat("a", 4097)
+	payload, err := json.Marshal(map[string]string{
+		"projectId": "ao",
+		"brief":     brief,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	body, status, _ := doRequest(t, srv, http.MethodPost, "/api/v1/orchestrators/delegate", string(payload))
+	if status != http.StatusAccepted {
+		t.Fatalf("delegate long brief = %d, want 202; body=%s", status, body)
+	}
+	if svc.delegationInput.Brief != brief {
+		t.Fatalf("delegation brief length = %d, want %d", len(svc.delegationInput.Brief), len(brief))
+	}
+}
+
+func TestSessionsAPI_DelegateTaskRejectsBriefPastLaunchSafeLimit(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+	brief := strings.Repeat("a", (16<<10)+1)
+	payload, err := json.Marshal(map[string]string{
+		"projectId": "ao",
+		"brief":     brief,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	body, status, _ := doRequest(t, srv, http.MethodPost, "/api/v1/orchestrators/delegate", string(payload))
+	assertErrorCode(t, body, status, http.StatusBadRequest, "TASK_TOO_LONG")
+	var got struct {
+		Message string `json:"message"`
+	}
+	mustJSON(t, body, &got)
+	if got.Message != "Task must be 16 KiB or fewer" {
+		t.Fatalf("error message = %q, want actionable size limit", got.Message)
+	}
+	if svc.delegationInput.ProjectID != "" {
+		t.Fatalf("delegate service called with oversized brief: %#v", svc.delegationInput)
+	}
+}
+
 func TestSessionsAPI_DelegatesOMPChat(t *testing.T) {
 	svc := newFakeSessionService()
 	srv := newSessionTestServer(t, svc)

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -2603,8 +2603,6 @@ func TestSessionsAPI_DelegateTask(t *testing.T) {
 func TestSessionsAPI_DelegateTaskAcceptsLongBrief(t *testing.T) {
 	svc := newFakeSessionService()
 	srv := newSessionTestServer(t, svc)
-	// The original controller rejected the first byte past 4 KiB even though
-	// valid task briefs commonly include longer pasted reference documents.
 	brief := strings.Repeat("a", 4097)
 	payload, err := json.Marshal(map[string]string{
 		"projectId": "ao",

--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -25,7 +25,7 @@ const (
 	DefaultFailureBackoff = 5 * time.Minute
 	// maxIntakePromptLen mirrors the session HTTP prompt limit. Intake uses the
 	// session service directly, so it must enforce the same boundary itself.
-	maxIntakePromptLen = 4096
+	maxIntakePromptLen = 16 << 10
 
 	intakePromptTruncationNotice = "\n\n[Issue content truncated to fit the session prompt limit. Open the linked issue for the full details.]\n"
 	intakePromptFooter           = "\nImplement the requested change in this repository, run the relevant checks, and open or update a pull request when ready."

--- a/backend/internal/observe/trackerintake/observer_test.go
+++ b/backend/internal/observe/trackerintake/observer_test.go
@@ -297,7 +297,7 @@ func TestBuildIssuePromptCapsLargeIssueBody(t *testing.T) {
 		ID:    domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#99"},
 		Title: "Large issue",
 		URL:   "https://github.com/acme/demo/issues/99",
-		Body:  strings.Repeat("body ", 2000),
+		Body:  strings.Repeat("body ", 4000),
 	})
 	if len(prompt) > maxIntakePromptLen {
 		t.Fatalf("prompt length = %d, want <= %d", len(prompt), maxIntakePromptLen)
@@ -310,6 +310,38 @@ func TestBuildIssuePromptCapsLargeIssueBody(t *testing.T) {
 	}
 	if !strings.HasSuffix(prompt, intakePromptFooter) {
 		t.Fatalf("prompt missing footer:\n%s", prompt)
+	}
+}
+
+func TestCapIntakePromptBoundaries(t *testing.T) {
+	tests := []struct {
+		name          string
+		promptLen     int
+		wantTruncated bool
+	}{
+		{name: "above old limit", promptLen: 4097},
+		{name: "at current limit", promptLen: 16 << 10},
+		{name: "above current limit", promptLen: (16 << 10) + 1, wantTruncated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prompt := strings.Repeat("x", tt.promptLen-len(intakePromptFooter)) + intakePromptFooter
+			got := capIntakePrompt(prompt)
+
+			if len(got) > maxIntakePromptLen {
+				t.Fatalf("capIntakePrompt() length = %d, want <= %d", len(got), maxIntakePromptLen)
+			}
+			if gotTruncated := strings.Contains(got, intakePromptTruncationNotice); gotTruncated != tt.wantTruncated {
+				t.Fatalf("capIntakePrompt() truncated = %t, want %t", gotTruncated, tt.wantTruncated)
+			}
+			if !tt.wantTruncated && got != prompt {
+				t.Fatal("capIntakePrompt() changed a prompt within the limit")
+			}
+			if !strings.HasSuffix(got, intakePromptFooter) {
+				t.Fatal("capIntakePrompt() removed the intake footer")
+			}
+		})
 	}
 }
 

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -450,6 +450,9 @@ var (
 	// ErrRuntimePrerequisite reports a missing host prerequisite for the selected
 	// runtime before a session can be created.
 	ErrRuntimePrerequisite = errors.New("runtime: prerequisite missing")
+	// ErrRuntimeCommandLineTooLong reports that the fully escaped command line
+	// exceeds the host operating system's process-creation limit.
+	ErrRuntimeCommandLineTooLong = errors.New("runtime: command line too long")
 	// ErrRuntimeWorkspaceCwdMismatch reports that a runtime session's working
 	// directory never settled on the wanted workspace path after Create's
 	// retried verification (see the tmux adapter's verifyPaneWorkingDirectory).

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -1139,6 +1139,9 @@ func mapSessionError(err error) error {
 		return apierr.Invalid("AGENT_BINARY_NOT_FOUND", err.Error(), nil)
 	case errors.Is(err, ports.ErrRuntimePrerequisite):
 		return apierr.Invalid("RUNTIME_PREREQUISITE_MISSING", err.Error(), nil)
+	case errors.Is(err, ports.ErrRuntimeCommandLineTooLong):
+		return apierr.Invalid("WINDOWS_COMMAND_LINE_TOO_LONG",
+			"The agent launch command exceeds the Windows size limit. Shorten the task or project instructions.", nil)
 	case errors.Is(err, ports.ErrChatUnsupported):
 		var capabilityErr *ports.ChatCapabilityError
 		if errors.As(err, &capabilityErr) {

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -3051,6 +3051,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"invalid branch", fmt.Errorf("spawn mer-1: workspace: %w: \"bad!!\" (exit 1)", ports.ErrWorkspaceBranchInvalid), apierr.KindInvalid, "INVALID_BRANCH"},
 		{"agent binary not found", fmt.Errorf("spawn mer-1: %w", ports.ErrAgentBinaryNotFound), apierr.KindInvalid, "AGENT_BINARY_NOT_FOUND"},
 		{"runtime prerequisite missing", fmt.Errorf("spawn: %w: tmux required on macOS/Linux but not in PATH", ports.ErrRuntimePrerequisite), apierr.KindInvalid, "RUNTIME_PREREQUISITE_MISSING"},
+		{"Windows command line too long", fmt.Errorf("spawn: %w: escaped command line is 32769 UTF-16 code units", ports.ErrRuntimeCommandLineTooLong), apierr.KindInvalid, "WINDOWS_COMMAND_LINE_TOO_LONG"},
 		{"runtime workspace cwd mismatch", fmt.Errorf("spawn mer-1: runtime: %w: session mer-1 started in \"/deleted/shipit\", want \"/tmp/ws\"", ports.ErrRuntimeWorkspaceCwdMismatch), apierr.KindConflict, "WORKSPACE_CWD_MISMATCH"},
 		{"workspace locked", fmt.Errorf("restore mer-1: %w: \"/tmp/ws\" (branch \"ao/mer-1\") is registered but its directory is missing", ports.ErrWorkspaceLocked), apierr.KindConflict, "WORKSPACE_LOCKED"},
 		{"unknown harness", fmt.Errorf("spawn: %w: %q", sessionmanager.ErrUnknownHarness, "bogus"), apierr.KindInvalid, "UNKNOWN_HARNESS"},


### PR DESCRIPTION
Fixes https://github.com/Untrivial-ai/agent-orchestrator/issues/5004

## Summary

- raise the shared initial spawn/delegation prompt ceiling from 4 KiB to 16 KiB so ordinary pasted setup guides and reference documents can create tasks
- align automatic tracker intake with the same 16 KiB boundary
- preflight the fully escaped Windows launch command against the 32,767 UTF-16-unit OS limit before process creation, including wrapper arguments and the terminating NUL
- return actionable errors for both the request limit and the platform-specific launch limit
- regenerate the OpenAPI contract and add regression coverage for HTTP, tracker-intake, and Windows quote/backslash boundaries

## Root cause

The New Task delegation handler reused the original Go session controller's `maxPromptLen = 4096` validation. That value was not tied to an agent context window, and it rejected the request before the session service or selected agent was called. LAN request-memory protection is handled independently by the existing bounded-body reader.

The 16 KiB request limit remains a predictable application boundary. Because Windows argument escaping can expand prompt content, the ConPTY runtime now separately validates the actual escaped command instead of assuming every 16 KiB prompt is launch-safe.

## Local verification

- verified the real Electron app with a 16,127-byte task brief; the modal stays fixed and the task field scrolls internally
- verified the running daemon passes 16,127 bytes through length validation and rejects 16,385 bytes with `TASK_TOO_LONG`
- [screenshots attached in the PR conversation](https://github.com/Untrivial-ai/agent-orchestrator/pull/5005#issuecomment-5566308136)

## Testing

- focused ConPTY, tracker-intake, session-service, and HTTP controller tests
- race-enabled ConPTY, tracker-intake, and session-service tests
- Windows/amd64 cross-compilation of the ConPTY package
- full backend `go test ./...`; three timing-sensitive packages failed under parallel load and passed immediately when rerun serially
- golangci-lint v2.12.2: `0 issues`
- `npm run frontend:typecheck`
- `npm run api`

