### PR TITLE
fix: preserve attachments when editing queued messages

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -8983,6 +8983,20 @@ components:
       type: object
     EditQueuedConversationMessageRequest:
       properties:
+        attachments:
+          items:
+            $ref: '#/components/schemas/ConversationImageContentRequest'
+          type: array
+        expectedRevision:
+          type:
+          - "null"
+          - integer
+        retainedContent:
+          items:
+            type: integer
+          type:
+          - "null"
+          - array
         text:
           type: string
       required:

--- a/backend/internal/httpd/controllers/conversation_queue.go
+++ b/backend/internal/httpd/controllers/conversation_queue.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -17,11 +16,6 @@ import (
 const cancelQueuedTurnPath = "/api/v1/sessions/{sessionId}/conversation/turns/{turnId}/cancel"
 const editQueuedTurnPath = "/api/v1/sessions/{sessionId}/conversation/turns/{turnId}/queue/edit"
 const reorderQueuedTurnsPath = "/api/v1/sessions/{sessionId}/conversation/queue/reorder"
-
-// EditQueuedConversationMessageRequest rewrites one undispatched queue item.
-type EditQueuedConversationMessageRequest struct {
-	Text string `json:"text"`
-}
 
 // ReorderQueuedConversationTurnsRequest rewrites the durable queue order.
 type ReorderQueuedConversationTurnsRequest struct {
@@ -54,16 +48,18 @@ func (c *ConversationsController) editQueuedTurn(w http.ResponseWriter, r *http.
 	if !decodeConversationBody(w, r, &req) {
 		return
 	}
-	if strings.TrimSpace(req.Text) == "" {
+	content, attachmentErr := conversationContent(SendConversationMessageRequest{Attachments: req.Attachments})
+	if attachmentErr != nil {
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "validation",
-			"CHAT_QUEUED_TEXT_REQUIRED", "queued message text is required", nil)
+			attachmentErr.code, attachmentErr.message, nil)
 		return
 	}
 	err := c.Svc.EditQueuedTurn(
 		r.Context(),
 		domain.SessionID(chi.URLParam(r, "sessionId")),
 		chi.URLParam(r, "turnId"),
-		req.Text,
+		chatsvc.QueuedMessageEdit{Text: req.Text, Content: content,
+			RetainedContent: req.RetainedContent, ExpectedRevision: req.ExpectedRevision},
 	)
 	if err != nil {
 		writeQueuedTurnMutationError(w, r, err)
@@ -100,6 +96,12 @@ func (c *ConversationsController) reorderQueuedTurns(w http.ResponseWriter, r *h
 
 func writeQueuedTurnMutationError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
+	case errors.Is(err, chatsvc.ErrQueuedContentInvalid):
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "validation",
+			"CHAT_QUEUED_CONTENT_INVALID", "queued message attachments are invalid", nil)
+	case errors.Is(err, chatsvc.ErrQueuedEditConflict):
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict",
+			"CHAT_QUEUED_EDIT_CONFLICT", "that queued message changed; reopen it before editing", nil)
 	case errors.Is(err, chatsvc.ErrQueuedTurnTextRequired):
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "validation",
 			"CHAT_QUEUED_TEXT_REQUIRED", "queued message text is required", nil)

--- a/backend/internal/httpd/controllers/conversation_queue_test.go
+++ b/backend/internal/httpd/controllers/conversation_queue_test.go
@@ -22,19 +22,22 @@ type editQueuedStub struct {
 	session domain.SessionID
 	turnID  string
 	text    string
+	edit    chatsvc.QueuedMessageEdit
 	err     error
 }
 
 func (s *editQueuedStub) EditQueuedTurn(
 	_ context.Context,
 	session domain.SessionID,
-	turnID, text string,
+	turnID string,
+	edit chatsvc.QueuedMessageEdit,
 ) error {
-	s.session, s.turnID, s.text = session, turnID, text
+	s.session, s.turnID, s.text = session, turnID, edit.Text
+	s.edit = edit
 	return s.err
 }
 
-func postEditQueuedTurn(t *testing.T, svc *editQueuedStub, turnID, text string) int {
+func postEditQueuedTurn(t *testing.T, svc *editQueuedStub, turnID string, request map[string]any) int {
 	t.Helper()
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
@@ -43,7 +46,7 @@ func postEditQueuedTurn(t *testing.T, svc *editQueuedStub, turnID, text string) 
 	}, httpd.ControlDeps{}))
 	t.Cleanup(srv.Close)
 
-	body, err := json.Marshal(map[string]string{"text": text})
+	body, err := json.Marshal(request)
 	if err != nil {
 		t.Fatalf("encode request: %v", err)
 	}
@@ -61,11 +64,57 @@ func postEditQueuedTurn(t *testing.T, svc *editQueuedStub, turnID, text string) 
 
 func TestEditQueuedTurnRoute(t *testing.T) {
 	svc := &editQueuedStub{fakeConversationService: &fakeConversationService{}}
-	if status := postEditQueuedTurn(t, svc, "turn-queued", "updated text"); status != http.StatusNoContent {
+	if status := postEditQueuedTurn(t, svc, "turn-queued", map[string]any{"text": "updated text"}); status != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", status, http.StatusNoContent)
 	}
 	if svc.session != "p1-1" || svc.turnID != "turn-queued" || svc.text != "updated text" {
 		t.Fatalf("svc saw session=%q turn=%q text=%q", svc.session, svc.turnID, svc.text)
+	}
+}
+
+func TestEditQueuedTurnRouteForwardsImageChanges(t *testing.T) {
+	svc := &editQueuedStub{fakeConversationService: &fakeConversationService{}}
+	status := postEditQueuedTurn(t, svc, "turn-queued", map[string]any{
+		"text": "", "retainedContent": []int{}, "expectedRevision": 3,
+		"attachments": []map[string]string{{"mimeType": "image/png", "data": "aGVsbG8="}},
+	})
+	if status != http.StatusNoContent {
+		t.Fatalf("status = %d", status)
+	}
+	if svc.edit.RetainedContent == nil || len(*svc.edit.RetainedContent) != 0 ||
+		svc.edit.ExpectedRevision == nil || *svc.edit.ExpectedRevision != 3 ||
+		len(svc.edit.Content) != 1 || svc.edit.Content[0].Data != "aGVsbG8=" {
+		t.Fatalf("edit = %+v", svc.edit)
+	}
+}
+
+func TestEditQueuedTurnRouteRefusals(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		err    error
+		status int
+	}{
+		{"empty", chatsvc.ErrQueuedTurnTextRequired, http.StatusBadRequest},
+		{"invalid content", chatsvc.ErrQueuedContentInvalid, http.StatusBadRequest},
+		{"stale revision", chatsvc.ErrQueuedEditConflict, http.StatusConflict},
+		{"already dispatched", store.ErrQueuedTurnNotAvailable, http.StatusConflict},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &editQueuedStub{fakeConversationService: &fakeConversationService{}, err: tc.err}
+			if status := postEditQueuedTurn(t, svc, "turn-queued", map[string]any{"text": "update"}); status != tc.status {
+				t.Fatalf("status = %d, want %d", status, tc.status)
+			}
+		})
+	}
+}
+
+func TestEditQueuedTurnRouteRejectsMalformedImageBeforeService(t *testing.T) {
+	svc := &editQueuedStub{fakeConversationService: &fakeConversationService{}}
+	status := postEditQueuedTurn(t, svc, "turn-queued", map[string]any{
+		"text": "update", "attachments": []map[string]string{{"mimeType": "image/png", "data": "not base64"}},
+	})
+	if status != http.StatusBadRequest || svc.turnID != "" {
+		t.Fatalf("status=%d, called turn=%q", status, svc.turnID)
 	}
 }
 

--- a/backend/internal/httpd/controllers/conversation_steer_test.go
+++ b/backend/internal/httpd/controllers/conversation_steer_test.go
@@ -58,7 +58,7 @@ func (f *fakeConversationService) CancelQueuedTurn(context.Context, domain.Sessi
 	return nil
 }
 
-func (f *fakeConversationService) EditQueuedTurn(context.Context, domain.SessionID, string, string) error {
+func (f *fakeConversationService) EditQueuedTurn(context.Context, domain.SessionID, string, chatsvc.QueuedMessageEdit) error {
 	return nil
 }
 
@@ -78,7 +78,7 @@ func (f *fakeChatService) CancelQueuedTurn(context.Context, domain.SessionID, st
 	return nil
 }
 
-func (f *fakeChatService) EditQueuedTurn(context.Context, domain.SessionID, string, string) error {
+func (f *fakeChatService) EditQueuedTurn(context.Context, domain.SessionID, string, chatsvc.QueuedMessageEdit) error {
 	return nil
 }
 

--- a/backend/internal/httpd/controllers/conversations.go
+++ b/backend/internal/httpd/controllers/conversations.go
@@ -37,7 +37,7 @@ type ConversationService interface {
 	Steer(ctx context.Context, session domain.SessionID, msg ports.ChatUserMessage) (chatsvc.SteerResult, error)
 	PromoteQueuedTurn(ctx context.Context, session domain.SessionID, turnID string) (chatsvc.PromoteQueuedTurnResult, error)
 	CancelQueuedTurn(ctx context.Context, session domain.SessionID, turnID string) error
-	EditQueuedTurn(ctx context.Context, session domain.SessionID, turnID, text string) error
+	EditQueuedTurn(ctx context.Context, session domain.SessionID, turnID string, edit chatsvc.QueuedMessageEdit) error
 	ReorderQueuedTurns(ctx context.Context, session domain.SessionID, turnIDs []string) error
 	Models(ctx context.Context, session domain.SessionID) ([]ports.ChatModel, domain.ConversationSettings, error)
 	ConfigOptions(ctx context.Context, session domain.SessionID) ([]ports.ChatConfigOption, error)

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1731,6 +1731,17 @@ type ConversationImageContentRequest struct {
 	Data     string `json:"data"`
 }
 
+// EditQueuedConversationMessageRequest changes an undispatched prompt. Omitted
+// retainedContent preserves the stored blocks; an empty list removes attachments.
+type EditQueuedConversationMessageRequest struct {
+	Text        string                            `json:"text"`
+	Attachments []ConversationImageContentRequest `json:"attachments,omitempty"`
+	// Indices in the message's public content summary, in their original order.
+	RetainedContent *[]int `json:"retainedContent,omitempty"`
+	// Reject a stale editor before interpreting attachment indices.
+	ExpectedRevision *int64 `json:"expectedRevision,omitempty"`
+}
+
 // ConversationResourceContentRequest is a resource link, or embedded text when
 // Text is present and the provider negotiated embedded context.
 type ConversationResourceContentRequest struct {

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -77,7 +77,8 @@ type Store interface {
 	CancelQueuedTurns(ctx context.Context, conversationID string, cutoff, now time.Time) error
 	CancelAllQueuedTurns(ctx context.Context, conversationID string, now time.Time) error
 	CancelQueuedTurnByID(ctx context.Context, conversationID, turnID string, now time.Time) error
-	UpdateQueuedTurnMessage(ctx context.Context, conversationID, turnID, text string, now time.Time) error
+	QueuedTurnMessage(ctx context.Context, conversationID, turnID string) (domain.ConversationMessage, error)
+	UpdateQueuedTurnMessage(ctx context.Context, conversationID, turnID, text, contentJSON string, revision int64, now time.Time) error
 	ReorderQueuedTurns(ctx context.Context, conversationID string, turnIDs []string) error
 
 	RetryPrompt(ctx context.Context, conversationID, turnID string) (domain.RetryPrompt, error)

--- a/backend/internal/service/chat/queue.go
+++ b/backend/internal/service/chat/queue.go
@@ -148,7 +148,11 @@ func (c *Controller) EditQueuedTurn(ctx context.Context, turnID string, edit Que
 			continue
 		}
 		images++
-		imageBytes += base64.StdEncoding.DecodedLen(len(block.Data))
+		data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(block.Data))
+		if err != nil {
+			return ErrQueuedContentInvalid
+		}
+		imageBytes += len(data)
 	}
 	if images > 8 || imageBytes > 25*1024*1024 {
 		return ErrQueuedContentInvalid

--- a/backend/internal/service/chat/queue.go
+++ b/backend/internal/service/chat/queue.go
@@ -2,15 +2,33 @@ package chat
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/store"
 )
 
 // ErrQueuedTurnTextRequired refuses an empty rewrite of a queued prompt.
 var ErrQueuedTurnTextRequired = errors.New("queued message text is required")
+
+// ErrQueuedContentInvalid refuses invalid retained indices or oversized content.
+var ErrQueuedContentInvalid = errors.New("queued message attachments are invalid")
+
+// ErrQueuedEditConflict refuses an edit based on an outdated message revision.
+var ErrQueuedEditConflict = errors.New("queued message changed during editing")
+
+// QueuedMessageEdit retains server-owned content by public summary index and
+// appends newly uploaded blocks. Nil RetainedContent preserves existing content.
+type QueuedMessageEdit struct {
+	Text             string
+	Content          []ports.ChatContent
+	RetainedContent  *[]int
+	ExpectedRevision *int64
+}
 
 // ErrInvalidQueuedTurnOrder refuses a queue reorder that does not match the
 // current undispatched queue exactly.
@@ -38,11 +56,9 @@ func (s *Service) CancelQueuedTurn(
 func (s *Service) EditQueuedTurn(
 	ctx context.Context,
 	id domain.SessionID,
-	turnID, text string,
+	turnID string,
+	edit QueuedMessageEdit,
 ) error {
-	if strings.TrimSpace(text) == "" {
-		return ErrQueuedTurnTextRequired
-	}
 	if _, err := s.requireChatSession(ctx, id); err != nil {
 		return err
 	}
@@ -50,7 +66,7 @@ func (s *Service) EditQueuedTurn(
 	if err != nil {
 		return err
 	}
-	return controller.EditQueuedTurn(ctx, turnID, text)
+	return controller.EditQueuedTurn(ctx, turnID, edit)
 }
 
 // ReorderQueuedTurns rewrites the durable queue order for undispatched turns.
@@ -80,13 +96,76 @@ func (c *Controller) CancelQueuedTurn(ctx context.Context, turnID string) error 
 }
 
 // EditQueuedTurn rewrites the durable human prompt for a queued turn.
-func (c *Controller) EditQueuedTurn(ctx context.Context, turnID, text string) error {
+func (c *Controller) EditQueuedTurn(ctx context.Context, turnID string, edit QueuedMessageEdit) error {
 	c.sendMu.Lock()
 	defer c.sendMu.Unlock()
 	if c.handoffActive() {
 		return ErrControllerHandoff
 	}
-	return c.store.UpdateQueuedTurnMessage(ctx, c.conversation.ID, turnID, text, c.now())
+	message, err := c.store.QueuedTurnMessage(ctx, c.conversation.ID, turnID)
+	if err != nil {
+		return err
+	}
+	if edit.ExpectedRevision != nil && *edit.ExpectedRevision != message.Revision {
+		return ErrQueuedEditConflict
+	}
+	var content []ports.ChatContent
+	if message.DeliveryContentJSON != "" {
+		if err := json.Unmarshal([]byte(message.DeliveryContentJSON), &content); err != nil {
+			return ErrQueuedContentInvalid
+		}
+	}
+	if edit.RetainedContent != nil {
+		if edit.ExpectedRevision == nil {
+			return ErrQueuedContentInvalid
+		}
+		// Match conversationContentSummary: text and internal replay context are
+		// not exposed as user attachments and must survive attachment removal.
+		retained := *edit.RetainedContent
+		selected := make([]ports.ChatContent, 0, len(content))
+		index, next := 0, 0
+		for _, block := range content {
+			if block.Type == "text" || ports.IsInternalReplayContent(block) {
+				selected = append(selected, block)
+				continue
+			}
+			if next < len(retained) && retained[next] == index {
+				selected = append(selected, block)
+				next++
+			}
+			index++
+		}
+		if next != len(retained) {
+			return ErrQueuedContentInvalid
+		}
+		content = selected
+	}
+	content = append(content, edit.Content...)
+	// Match the upload limits across repeated edits as well as a single request.
+	images, imageBytes := 0, 0
+	for _, block := range content {
+		if block.Type != "image" {
+			continue
+		}
+		images++
+		imageBytes += base64.StdEncoding.DecodedLen(len(block.Data))
+	}
+	if images > 8 || imageBytes > 25*1024*1024 {
+		return ErrQueuedContentInvalid
+	}
+	if strings.TrimSpace(edit.Text) == "" && len(content) == 0 {
+		return ErrQueuedTurnTextRequired
+	}
+	encoded := ""
+	if len(content) > 0 {
+		data, err := json.Marshal(content)
+		if err != nil {
+			return err
+		}
+		encoded = string(data)
+	}
+	return c.store.UpdateQueuedTurnMessage(ctx, c.conversation.ID, turnID,
+		edit.Text, encoded, message.Revision, c.now())
 }
 
 // ReorderQueuedTurns permutes undispatched queue rows without changing their text.

--- a/backend/internal/service/chat/queue_test.go
+++ b/backend/internal/service/chat/queue_test.go
@@ -2,6 +2,7 @@ package chat_test
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 
@@ -13,8 +14,15 @@ import (
 func TestQueuedEditAttachmentChanges(t *testing.T) {
 	zero := int64(0)
 	one := int64(1)
+	tenMiB := ports.ChatContent{Type: "image", MIMEType: "image/png", Data: base64.StdEncoding.EncodeToString(make([]byte, 10<<20))}
+	fiveMiB := ports.ChatContent{Type: "image", MIMEType: "image/png", Data: base64.StdEncoding.EncodeToString(make([]byte, 5<<20))}
+	overFiveMiB := ports.ChatContent{Type: "image", MIMEType: "image/png", Data: base64.StdEncoding.EncodeToString(make([]byte, (5<<20)+1))}
+	atLimit := []ports.ChatContent{tenMiB, tenMiB, fiveMiB}
+	atLimitData := []string{tenMiB.Data, tenMiB.Data, fiveMiB.Data}
 	for _, tc := range []struct {
 		name     string
+		unedited bool
+		initial  []ports.ChatContent
 		text     string
 		retained *[]int
 		revision *int64
@@ -22,6 +30,7 @@ func TestQueuedEditAttachmentChanges(t *testing.T) {
 		wantData []string
 		wantErr  error
 	}{
+		{name: "without edit", unedited: true, text: "original", wantData: []string{"aGVsbG8="}},
 		{name: "preserve omitted", text: "updated", wantData: []string{"aGVsbG8="}},
 		{name: "preserve explicit", text: "updated", retained: &[]int{0}, revision: &zero, wantData: []string{"aGVsbG8="}},
 		{name: "remove", text: "updated", retained: &[]int{}, revision: &zero},
@@ -34,18 +43,27 @@ func TestQueuedEditAttachmentChanges(t *testing.T) {
 		{name: "invalid index", text: "updated", retained: &[]int{1}, revision: &zero, wantErr: chatsvc.ErrQueuedContentInvalid},
 		{name: "duplicate index", text: "updated", retained: &[]int{0, 0}, revision: &zero, wantErr: chatsvc.ErrQueuedContentInvalid},
 		{name: "negative index", text: "updated", retained: &[]int{-1}, revision: &zero, wantErr: chatsvc.ErrQueuedContentInvalid},
+		{name: "preserve at size limit", text: "updated", initial: atLimit, wantData: atLimitData},
+		{name: "append at size limit", text: "updated", initial: atLimit[:2], add: atLimit[2:], wantData: atLimitData},
+		{name: "append over size limit", text: "updated", initial: atLimit[:2], add: []ports.ChatContent{overFiveMiB}, wantErr: chatsvc.ErrQueuedContentInvalid},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h, provider := steerHarness(t)
 			ctx := context.Background()
+			initial := tc.initial
+			if initial == nil {
+				initial = []ports.ChatContent{{Type: "image", MIMEType: "image/png", Data: "aGVsbG8="}}
+			}
 			turn, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{Text: "original", ClientMessageID: "queued-edit",
-				Origin: domain.MessageOriginHuman, Content: []ports.ChatContent{{Type: "image", MIMEType: "image/png", Data: "aGVsbG8="}}})
+				Origin: domain.MessageOriginHuman, Content: initial})
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = h.svc.EditQueuedTurn(ctx, testSession, turn.ID, chatsvc.QueuedMessageEdit{
-				Text: tc.text, Content: tc.add, RetainedContent: tc.retained, ExpectedRevision: tc.revision,
-			})
+			if !tc.unedited {
+				err = h.svc.EditQueuedTurn(ctx, testSession, turn.ID, chatsvc.QueuedMessageEdit{
+					Text: tc.text, Content: tc.add, RetainedContent: tc.retained, ExpectedRevision: tc.revision,
+				})
+			}
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("edit = %v, want %v", err, tc.wantErr)
 			}
@@ -58,7 +76,10 @@ func TestQueuedEditAttachmentChanges(t *testing.T) {
 			}
 			wantText, wantData := tc.text, tc.wantData
 			if tc.wantErr != nil {
-				wantText, wantData = "original", []string{"aGVsbG8="}
+				wantText, wantData = "original", nil
+				for _, block := range initial {
+					wantData = append(wantData, block.Data)
+				}
 			}
 			if calls[0].msg.Text != wantText || len(calls[0].msg.Content) != len(wantData) {
 				t.Fatalf("provider got text %q and %d attachments; want %q and %d", calls[0].msg.Text, len(calls[0].msg.Content), wantText, len(wantData))
@@ -67,42 +88,6 @@ func TestQueuedEditAttachmentChanges(t *testing.T) {
 				if calls[0].msg.Content[i].Data != data {
 					t.Fatalf("attachment %d changed", i)
 				}
-			}
-		})
-	}
-}
-
-func TestQueuedTextEditPreservesImageDelivery(t *testing.T) {
-	for _, edit := range []bool{false, true} {
-		name := "without_edit"
-		if edit {
-			name = "with_text_edit"
-		}
-		t.Run(name, func(t *testing.T) {
-			h, provider := steerHarness(t)
-			ctx := context.Background()
-			turn, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
-				Text:            "inspect this\n\nAttached files (read these files in the workspace):\n- .ao/attachments/image.png",
-				ClientMessageID: "queued-image-analysis", Origin: domain.MessageOriginHuman,
-				Content: []ports.ChatContent{{Type: "image", Data: "aGVsbG8=", MIMEType: "image/png"}},
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if edit {
-				if err := h.svc.EditQueuedTurn(ctx, testSession, turn.ID, chatsvc.QueuedMessageEdit{Text: "inspect carefully\n\nAttached files (read these files in the workspace):\n- .ao/attachments/image.png"}); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if _, err := h.svc.PromoteQueuedTurn(ctx, testSession, turn.ID); err != nil {
-				t.Fatal(err)
-			}
-			calls := provider.steers()
-			if len(calls) != 1 {
-				t.Fatalf("provider calls = %d, want 1", len(calls))
-			}
-			if len(calls[0].msg.Content) != 1 {
-				t.Fatalf("provider image blocks = %d, want 1; text = %q", len(calls[0].msg.Content), calls[0].msg.Text)
 			}
 		})
 	}

--- a/backend/internal/service/chat/queue_test.go
+++ b/backend/internal/service/chat/queue_test.go
@@ -1,0 +1,109 @@
+package chat_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
+)
+
+func TestQueuedEditAttachmentChanges(t *testing.T) {
+	zero := int64(0)
+	one := int64(1)
+	for _, tc := range []struct {
+		name     string
+		text     string
+		retained *[]int
+		revision *int64
+		add      []ports.ChatContent
+		wantData []string
+		wantErr  error
+	}{
+		{name: "preserve omitted", text: "updated", wantData: []string{"aGVsbG8="}},
+		{name: "preserve explicit", text: "updated", retained: &[]int{0}, revision: &zero, wantData: []string{"aGVsbG8="}},
+		{name: "remove", text: "updated", retained: &[]int{}, revision: &zero},
+		{name: "replace", text: "updated", retained: &[]int{}, revision: &zero, add: []ports.ChatContent{{Type: "image", MIMEType: "image/png", Data: "bmV3"}}, wantData: []string{"bmV3"}},
+		{name: "append", text: "updated", add: []ports.ChatContent{{Type: "image", MIMEType: "image/png", Data: "bmV3"}}, wantData: []string{"aGVsbG8=", "bmV3"}},
+		{name: "image only", wantData: []string{"aGVsbG8="}},
+		{name: "empty after removal", retained: &[]int{}, revision: &zero, wantErr: chatsvc.ErrQueuedTurnTextRequired},
+		{name: "stale", text: "updated", retained: &[]int{}, revision: &one, wantErr: chatsvc.ErrQueuedEditConflict},
+		{name: "missing revision", text: "updated", retained: &[]int{}, wantErr: chatsvc.ErrQueuedContentInvalid},
+		{name: "invalid index", text: "updated", retained: &[]int{1}, revision: &zero, wantErr: chatsvc.ErrQueuedContentInvalid},
+		{name: "duplicate index", text: "updated", retained: &[]int{0, 0}, revision: &zero, wantErr: chatsvc.ErrQueuedContentInvalid},
+		{name: "negative index", text: "updated", retained: &[]int{-1}, revision: &zero, wantErr: chatsvc.ErrQueuedContentInvalid},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, provider := steerHarness(t)
+			ctx := context.Background()
+			turn, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{Text: "original", ClientMessageID: "queued-edit",
+				Origin: domain.MessageOriginHuman, Content: []ports.ChatContent{{Type: "image", MIMEType: "image/png", Data: "aGVsbG8="}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = h.svc.EditQueuedTurn(ctx, testSession, turn.ID, chatsvc.QueuedMessageEdit{
+				Text: tc.text, Content: tc.add, RetainedContent: tc.retained, ExpectedRevision: tc.revision,
+			})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("edit = %v, want %v", err, tc.wantErr)
+			}
+			if _, err := h.svc.PromoteQueuedTurn(ctx, testSession, turn.ID); err != nil {
+				t.Fatal(err)
+			}
+			calls := provider.steers()
+			if len(calls) != 1 {
+				t.Fatalf("provider calls = %d", len(calls))
+			}
+			wantText, wantData := tc.text, tc.wantData
+			if tc.wantErr != nil {
+				wantText, wantData = "original", []string{"aGVsbG8="}
+			}
+			if calls[0].msg.Text != wantText || len(calls[0].msg.Content) != len(wantData) {
+				t.Fatalf("provider got text %q and %d attachments; want %q and %d", calls[0].msg.Text, len(calls[0].msg.Content), wantText, len(wantData))
+			}
+			for i, data := range wantData {
+				if calls[0].msg.Content[i].Data != data {
+					t.Fatalf("attachment %d changed", i)
+				}
+			}
+		})
+	}
+}
+
+func TestQueuedTextEditPreservesImageDelivery(t *testing.T) {
+	for _, edit := range []bool{false, true} {
+		name := "without_edit"
+		if edit {
+			name = "with_text_edit"
+		}
+		t.Run(name, func(t *testing.T) {
+			h, provider := steerHarness(t)
+			ctx := context.Background()
+			turn, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+				Text:            "inspect this\n\nAttached files (read these files in the workspace):\n- .ao/attachments/image.png",
+				ClientMessageID: "queued-image-analysis", Origin: domain.MessageOriginHuman,
+				Content: []ports.ChatContent{{Type: "image", Data: "aGVsbG8=", MIMEType: "image/png"}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if edit {
+				if err := h.svc.EditQueuedTurn(ctx, testSession, turn.ID, chatsvc.QueuedMessageEdit{Text: "inspect carefully\n\nAttached files (read these files in the workspace):\n- .ao/attachments/image.png"}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := h.svc.PromoteQueuedTurn(ctx, testSession, turn.ID); err != nil {
+				t.Fatal(err)
+			}
+			calls := provider.steers()
+			if len(calls) != 1 {
+				t.Fatalf("provider calls = %d, want 1", len(calls))
+			}
+			if len(calls[0].msg.Content) != 1 {
+				t.Fatalf("provider image blocks = %d, want 1; text = %q", len(calls[0].msg.Content), calls[0].msg.Text)
+			}
+		})
+	}
+}

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -2594,6 +2594,47 @@ func (q *Queries) SelectProjectConversation(ctx context.Context, projectID domai
 	return i, err
 }
 
+const selectQueuedConversationMessage = `-- name: SelectQueuedConversationMessage :one
+SELECT conversation_messages.id, conversation_messages.conversation_id, conversation_messages.turn_id, conversation_messages.sequence, conversation_messages.revision, conversation_messages.role, conversation_messages.origin, conversation_messages.text, conversation_messages.streaming, conversation_messages.provider_item_id, conversation_messages.client_message_id, conversation_messages.created_at, conversation_messages.updated_at, conversation_messages.delivery_content_json, conversation_messages.branch_id
+FROM conversation_messages
+JOIN conversation_turns ON conversation_turns.id = conversation_messages.turn_id
+WHERE conversation_messages.conversation_id = ?
+  AND conversation_messages.turn_id = ?
+  AND conversation_messages.role = 'user'
+  AND conversation_messages.origin = 'human'
+  AND conversation_turns.state = 'queued'
+  AND conversation_turns.promotion_started_at IS NULL
+`
+
+type SelectQueuedConversationMessageParams struct {
+	ConversationID string
+	TurnID         sql.NullString
+}
+
+// Read only an undispatched human prompt for editing.
+func (q *Queries) SelectQueuedConversationMessage(ctx context.Context, arg SelectQueuedConversationMessageParams) (ConversationMessage, error) {
+	row := q.db.QueryRowContext(ctx, selectQueuedConversationMessage, arg.ConversationID, arg.TurnID)
+	var i ConversationMessage
+	err := row.Scan(
+		&i.ID,
+		&i.ConversationID,
+		&i.TurnID,
+		&i.Sequence,
+		&i.Revision,
+		&i.Role,
+		&i.Origin,
+		&i.Text,
+		&i.Streaming,
+		&i.ProviderItemID,
+		&i.ClientMessageID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeliveryContentJson,
+		&i.BranchID,
+	)
+	return i, err
+}
+
 const selectQueuedConversationTurnOrder = `-- name: SelectQueuedConversationTurnOrder :many
 SELECT id, requested_at
 FROM conversation_turns
@@ -3237,11 +3278,12 @@ const updateQueuedConversationMessageText = `-- name: UpdateQueuedConversationMe
 UPDATE conversation_messages
 SET text = ?,
     revision = revision + 1,
-    delivery_content_json = '',
+    delivery_content_json = ?,
     updated_at = ?
 WHERE conversation_messages.conversation_id = ?
   AND conversation_messages.turn_id = ?
   AND conversation_messages.role = 'user'
+  AND conversation_messages.revision = ?
   AND EXISTS (
       SELECT 1
       FROM conversation_turns
@@ -3253,19 +3295,23 @@ WHERE conversation_messages.conversation_id = ?
 `
 
 type UpdateQueuedConversationMessageTextParams struct {
-	Text           string
-	UpdatedAt      time.Time
-	ConversationID string
-	TurnID         sql.NullString
+	Text                string
+	DeliveryContentJson string
+	UpdatedAt           time.Time
+	ConversationID      string
+	TurnID              sql.NullString
+	Revision            int64
 }
 
-// Rewrite the durable human prompt for a turn that has not yet dispatched.
+// Rewrite text and content together, only if the edited revision is current.
 func (q *Queries) UpdateQueuedConversationMessageText(ctx context.Context, arg UpdateQueuedConversationMessageTextParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, updateQueuedConversationMessageText,
 		arg.Text,
+		arg.DeliveryContentJson,
 		arg.UpdatedAt,
 		arg.ConversationID,
 		arg.TurnID,
+		arg.Revision,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -869,16 +869,29 @@ WHERE id = ?
   AND state = 'queued'
   AND promotion_started_at IS NULL;
 
--- Rewrite the durable human prompt for a turn that has not yet dispatched.
+-- Read only an undispatched human prompt for editing.
+-- name: SelectQueuedConversationMessage :one
+SELECT conversation_messages.*
+FROM conversation_messages
+JOIN conversation_turns ON conversation_turns.id = conversation_messages.turn_id
+WHERE conversation_messages.conversation_id = ?
+  AND conversation_messages.turn_id = ?
+  AND conversation_messages.role = 'user'
+  AND conversation_messages.origin = 'human'
+  AND conversation_turns.state = 'queued'
+  AND conversation_turns.promotion_started_at IS NULL;
+
+-- Rewrite text and content together, only if the edited revision is current.
 -- name: UpdateQueuedConversationMessageText :execrows
 UPDATE conversation_messages
 SET text = ?,
     revision = revision + 1,
-    delivery_content_json = '',
+    delivery_content_json = ?,
     updated_at = ?
 WHERE conversation_messages.conversation_id = ?
   AND conversation_messages.turn_id = ?
   AND conversation_messages.role = 'user'
+  AND conversation_messages.revision = ?
   AND EXISTS (
       SELECT 1
       FROM conversation_turns

--- a/backend/internal/storage/sqlite/store/conversation_history_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_history_store_test.go
@@ -640,7 +640,7 @@ func TestUpdateQueuedTurnMessage(t *testing.T) {
 		t.Fatalf("append queued turn: created=%v err=%v", created, err)
 	}
 
-	if err := s.UpdateQueuedTurnMessage(ctx, conversation, "queued-1", "edited draft", histClock.Add(time.Minute)); err != nil {
+	if err := s.UpdateQueuedTurnMessage(ctx, conversation, "queued-1", "edited draft", "", 0, histClock.Add(time.Minute)); err != nil {
 		t.Fatalf("update queued turn message: %v", err)
 	}
 
@@ -651,7 +651,7 @@ func TestUpdateQueuedTurnMessage(t *testing.T) {
 	if got := texts(page.Messages); len(got) != 1 || got[0] != "edited draft" {
 		t.Fatalf("messages after edit = %#v, want [edited draft]", got)
 	}
-	if err := s.UpdateQueuedTurnMessage(ctx, conversation, "missing", "nope", histClock.Add(2*time.Minute)); !errors.Is(err, store.ErrQueuedTurnNotAvailable) {
+	if err := s.UpdateQueuedTurnMessage(ctx, conversation, "missing", "nope", "", 0, histClock.Add(2*time.Minute)); !errors.Is(err, store.ErrQueuedTurnNotAvailable) {
 		t.Fatalf("missing turn error = %v, want ErrQueuedTurnNotAvailable", err)
 	}
 }

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -1835,21 +1835,38 @@ func (s *Store) ReorderQueuedTurns(
 	return nil
 }
 
-// UpdateQueuedTurnMessage rewrites the durable human prompt for a turn that has
-// not yet dispatched. Attachments are cleared because the edit path is text-only.
+// QueuedTurnMessage reads the durable text and content without exposing image
+// bytes to the renderer.
+func (s *Store) QueuedTurnMessage(ctx context.Context, conversationID, turnID string) (domain.ConversationMessage, error) {
+	row, err := s.qr.SelectQueuedConversationMessage(ctx, gen.SelectQueuedConversationMessageParams{
+		ConversationID: conversationID, TurnID: nullableString(turnID),
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.ConversationMessage{}, ErrQueuedTurnNotAvailable
+	}
+	if err != nil {
+		return domain.ConversationMessage{}, err
+	}
+	return messageToDomain(row), nil
+}
+
+// UpdateQueuedTurnMessage atomically replaces a still-queued prompt's text and content.
 func (s *Store) UpdateQueuedTurnMessage(
 	ctx context.Context,
-	conversationID, turnID, text string,
+	conversationID, turnID, text, contentJSON string,
+	revision int64,
 	now time.Time,
 ) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	rows, err := s.qw.UpdateQueuedConversationMessageText(ctx,
 		gen.UpdateQueuedConversationMessageTextParams{
-			Text:           text,
-			UpdatedAt:      now,
-			ConversationID: conversationID,
-			TurnID:         sql.NullString{String: turnID, Valid: true},
+			Text:                text,
+			DeliveryContentJson: contentJSON,
+			Revision:            revision,
+			UpdatedAt:           now,
+			ConversationID:      conversationID,
+			TurnID:              sql.NullString{String: turnID, Valid: true},
 		})
 	if err != nil {
 		return fmt.Errorf("update queued turn message %s: %w", turnID, err)
@@ -3090,18 +3107,19 @@ func turnToDomain(row gen.ConversationTurn) domain.ConversationTurn {
 
 func messageToDomain(row gen.ConversationMessage) domain.ConversationMessage {
 	msg := domain.ConversationMessage{
-		ID:              row.ID,
-		ConversationID:  row.ConversationID,
-		Sequence:        row.Sequence,
-		Revision:        row.Revision,
-		Role:            row.Role,
-		Origin:          row.Origin,
-		Text:            row.Text,
-		Streaming:       row.Streaming != 0,
-		ProviderItemID:  row.ProviderItemID,
-		ClientMessageID: row.ClientMessageID,
-		CreatedAt:       row.CreatedAt,
-		UpdatedAt:       row.UpdatedAt,
+		ID:                  row.ID,
+		ConversationID:      row.ConversationID,
+		Sequence:            row.Sequence,
+		Revision:            row.Revision,
+		Role:                row.Role,
+		Origin:              row.Origin,
+		Text:                row.Text,
+		Streaming:           row.Streaming != 0,
+		ProviderItemID:      row.ProviderItemID,
+		ClientMessageID:     row.ClientMessageID,
+		DeliveryContentJSON: row.DeliveryContentJson,
+		CreatedAt:           row.CreatedAt,
+		UpdatedAt:           row.UpdatedAt,
 	}
 	if row.TurnID.Valid {
 		msg.TurnID = row.TurnID.String

--- a/frontend/e2e/chat-queued-attachments.spec.ts
+++ b/frontend/e2e/chat-queued-attachments.spec.ts
@@ -141,6 +141,7 @@ test("queued image edits preserve attachments and the ordinary draft @T0", async
 	expect(message.content).toHaveLength(1);
 	await page.getByRole("button", { name: "Edit queued message" }).click();
 	await page.getByLabel("Remove attachment-queue.png").click();
+	await page.getByLabel("Remove Image 1", { exact: true }).click();
 	await page.getByRole("button", { name: "Send message", exact: true }).click();
 	await expect.poll(() => edits.length).toBe(3);
 	expect(edits[2]).toEqual({ text: "Inspect it carefully", retainedContent: [], expectedRevision: 2 });

--- a/frontend/e2e/chat-queued-attachments.spec.ts
+++ b/frontend/e2e/chat-queued-attachments.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "@playwright/test";
+import { installFakeAgent } from "./support/fake-bridge";
+
+const sessionId = "queued-attachments";
+const path = ".ao/attachments/attachment-queue.png";
+const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=";
+
+test("queued image edits preserve attachments and the ordinary draft @T0", async ({ page }) => {
+	await installFakeAgent(page, { workers: [{ id: sessionId, title: "Queued images", mode: "chat" }] });
+	const now = "2026-09-06T10:00:00Z";
+	let message = {
+		id: "message-queued",
+		turnId: "queued-1",
+		sequence: 2,
+		revision: 0,
+		role: "user",
+		origin: "human",
+		text: "Inspect the screenshot",
+		streaming: false,
+		createdAt: now,
+		content: [] as { type: string; mimeType: string }[],
+	};
+	const edits: {
+		text: string;
+		attachments?: { mimeType: string; data: string }[];
+		retainedContent: number[];
+		expectedRevision: number;
+	}[] = [];
+	await page.route(`**/api/v1/sessions/${sessionId}/**`, async (route) => {
+		const url = new URL(route.request().url());
+		if (url.pathname.endsWith("/conversation") && route.request().method() === "GET") {
+			await route.fulfill({
+				json: {
+					conversationId: "conversation-queued",
+					sessionId,
+					harness: "codex",
+					mode: "chat",
+					controller: "busy",
+					capabilities: ["images", "steer"],
+					latestSequence: 2,
+					oldestSequence: 1,
+					hasMoreBefore: false,
+					turns: [
+						{
+							id: "running-1",
+							state: "running",
+							providerTurnId: "provider-1",
+							requestedAt: now,
+							startedAt: now,
+						},
+						{ id: "queued-1", state: "queued", requestedAt: now },
+					],
+					messages: [message],
+					activities: [],
+					settings: {},
+				},
+			});
+			return;
+		}
+		if (url.pathname.endsWith("/attachments")) {
+			expect(route.request().postDataJSON().attachments[0].data).toBe(png);
+			await route.fulfill({ json: { paths: [path] } });
+			return;
+		}
+		if (url.pathname.endsWith("/queue/edit")) {
+			const edit = route.request().postDataJSON();
+			edits.push(edit);
+			expect(edit.expectedRevision).toBe(message.revision);
+			message = {
+				...message,
+				text: edit.text,
+				revision: message.revision + 1,
+				content: [
+					...message.content.filter((_, index) => edit.retainedContent.includes(index)),
+					...(edit.attachments ?? []).map((attachment: { mimeType: string }) => ({
+						type: "image",
+						mimeType: attachment.mimeType,
+					})),
+				],
+			};
+			await route.fulfill({ status: 204 });
+			return;
+		}
+		if (url.pathname.endsWith("/preview/files/" + path)) {
+			await route.fulfill({ contentType: "image/png", body: Buffer.from(png, "base64") });
+			return;
+		}
+		if (url.pathname.endsWith("/conversation/models")) {
+			await route.fulfill({ json: { models: [], selected: {} } });
+			return;
+		}
+		if (url.pathname.endsWith("/conversation/skills")) {
+			await route.fulfill({ json: { skills: [] } });
+			return;
+		}
+		if (url.pathname.endsWith("/workspace/files")) {
+			await route.fulfill({ json: { files: [], truncated: false } });
+			return;
+		}
+		if (url.pathname.endsWith("/interface-transition")) {
+			await route.fulfill({ json: { supported: true, targetMode: "tui" } });
+			return;
+		}
+		await route.fulfill({ status: 404, json: { error: { code: "NOT_FOUND", message: "not found" } } });
+	});
+	await page.goto(`/#/projects/fake-proj/sessions/${sessionId}`);
+	const field = page.getByRole("combobox", { name: "Message the agent" });
+	await expect(field).toBeVisible();
+	await field.fill("Keep my ordinary draft");
+	await page
+		.locator('input[type="file"]')
+		.setInputFiles({ name: "ordinary.png", mimeType: "image/png", buffer: Buffer.from(png, "base64") });
+	await expect(page.getByLabel("Remove ordinary.png")).toBeVisible();
+	await page.getByRole("button", { name: "Edit queued message" }).click();
+	await expect(field).toHaveText("Inspect the screenshot");
+	await expect(page.getByLabel("Remove ordinary.png")).toHaveCount(0);
+	await page
+		.locator('input[type="file"]')
+		.setInputFiles({ name: "screenshot.png", mimeType: "image/png", buffer: Buffer.from(png, "base64") });
+	await expect(page.getByLabel("Remove screenshot.png")).toBeVisible();
+	await page.getByRole("button", { name: "Send message", exact: true }).click();
+	await expect.poll(() => edits.length).toBe(1);
+	expect(edits[0]).toEqual({
+		text: `Inspect the screenshot\n\nAttached files (read these files in the workspace):\n- ${path}`,
+		attachments: [{ mimeType: "image/png", data: png }],
+		retainedContent: [],
+		expectedRevision: 0,
+	});
+	await expect(field).toHaveText("Keep my ordinary draft");
+	await expect(page.getByLabel("Remove ordinary.png")).toBeVisible();
+	await expect(page.getByText("Queued message edits cannot include attachments.")).toHaveCount(0);
+
+	await page.getByRole("button", { name: "Edit queued message" }).click();
+	await expect(page.getByLabel("Remove attachment-queue.png")).toBeVisible();
+	await expect(field).toHaveText("Inspect the screenshot");
+	await field.fill("Inspect it carefully");
+	await page.getByRole("button", { name: "Send message", exact: true }).click();
+	await expect.poll(() => edits.length).toBe(2);
+	expect(edits[1].retainedContent).toEqual([0]);
+	expect(edits[1].attachments).toBeUndefined();
+	expect(message.content).toHaveLength(1);
+	await page.getByRole("button", { name: "Edit queued message" }).click();
+	await page.getByLabel("Remove attachment-queue.png").click();
+	await page.getByRole("button", { name: "Send message", exact: true }).click();
+	await expect.poll(() => edits.length).toBe(3);
+	expect(edits[2]).toEqual({ text: "Inspect it carefully", retainedContent: [], expectedRevision: 2 });
+	expect(message.content).toHaveLength(0);
+	await expect(field).toHaveText("Keep my ordinary draft");
+	await page.getByRole("button", { name: "Edit queued message" }).click();
+	await field.fill("Discard this edit");
+	await page.getByRole("button", { name: "Cancel edit" }).click();
+	await expect(field).toHaveText("Keep my ordinary draft");
+	await expect(page.getByLabel("Remove ordinary.png")).toBeVisible();
+});

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3180,6 +3180,9 @@ export interface components {
             turnId?: string;
         };
         EditQueuedConversationMessageRequest: {
+            attachments?: components["schemas"]["ConversationImageContentRequest"][];
+            expectedRevision?: null | number;
+            retainedContent?: null | number[];
             text: string;
         };
         EndpointsResponse: {

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -317,7 +317,7 @@ describe("queued message edit", () => {
 		);
 		await waitFor(() => expect(screen.getByLabelText("Message the agent")).toHaveTextContent("hi"));
 		await userEvent.keyboard("{Enter}");
-		await waitFor(() => expect(onSend).toHaveBeenCalledWith("hi"));
+			await waitFor(() => expect(onSend).toHaveBeenCalledWith("hi", undefined, []));
 	});
 });
 

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -354,9 +354,11 @@ export const ChatComposer = memo(function ChatComposer({
 	}, []);
 
 	const previousEditingQueuedTurnIdRef = useRef(editingQueuedTurnId);
+	const previousEditSeedIdRef = useRef(draftSeedId);
 	useLayoutEffect(() => {
 		const previous = previousEditingQueuedTurnIdRef.current;
-		if (previous === editingQueuedTurnId) return;
+		if (previous === editingQueuedTurnId && previousEditSeedIdRef.current === draftSeedId) return;
+		previousEditSeedIdRef.current = draftSeedId;
 		previousEditingQueuedTurnIdRef.current = editingQueuedTurnId;
 		stagedDelivery.current = null;
 		editAttachments.clear();
@@ -371,7 +373,7 @@ export const ChatComposer = memo(function ChatComposer({
 			editor.current?.setText(text);
 			setSendError(null);
 		}
-	}, [draftSeed, editingQueuedTurnId, editAttachments.clear]);
+	}, [draftSeed, draftSeedId, editingQueuedTurnId, editAttachments.clear]);
 
 	useEffect(() => {
 		if (draftSeedText === undefined) return;

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -84,6 +84,7 @@ export type StoredComposerAttachment = {
 	path?: string;
 	dataUrl?: string;
 	contentIndex?: number;
+	contentType?: string;
 };
 
 export const ChatComposer = memo(function ChatComposer({
@@ -532,8 +533,10 @@ export const ChatComposer = memo(function ChatComposer({
 		// leave the image behind when its FileReader completes.
 		const attachmentPayloads = await fileAttachments.toSettledPayload();
 		const hasAttachments = attachmentPayloads.length > 0;
-		if (attachmentPayloads.length + visibleRetainedAttachments.length > MAX_ATTACHMENTS) {
-			setSendError(`You can attach up to ${MAX_ATTACHMENTS} files.`);
+		const imageCount = visibleRetainedAttachments.filter((attachment) => attachment.contentType === "image").length
+			+ (nativeImages ? attachmentPayloads.filter((attachment) => isSupportedImageAttachment(attachment.mimeType)).length : 0);
+		if (imageCount > MAX_ATTACHMENTS) {
+			setSendError(`You can attach up to ${MAX_ATTACHMENTS} images.`);
 			return;
 		}
 		const canSubmitNow =

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -60,6 +60,7 @@ import { moveHighlight, rankFiles, rankSkills, type Suggestion } from "./compose
 import {
 	isSupportedImageAttachment,
 	useFileAttachments,
+	MAX_ATTACHMENTS,
 	type FileAttachmentPayload,
 } from "../../hooks/useFileAttachments";
 import { File } from "lucide-react";
@@ -75,6 +76,15 @@ function withAttachmentReferences(text: string, paths: string[]): string {
 	const lead = text.trim() === "" ? "" : `${text}\n\n`;
 	return `${lead}Attached files (read these files in the workspace):\n${paths.map((path) => `- ${path}`).join("\n")}`;
 }
+
+/** A retained server-owned attachment; image bytes stay in durable storage. */
+export type StoredComposerAttachment = {
+	id: string;
+	name: string;
+	path?: string;
+	dataUrl?: string;
+	contentIndex?: number;
+};
 
 export const ChatComposer = memo(function ChatComposer({
 	onSend,
@@ -108,7 +118,7 @@ export const ChatComposer = memo(function ChatComposer({
 	autoFocusKey,
 	autoFocus = true,
 }: {
-	onSend: (text: string, attachments?: FileAttachmentPayload[]) => void | Promise<unknown>;
+	onSend: (text: string, attachments?: FileAttachmentPayload[], retainedContent?: number[]) => void | Promise<unknown>;
 	settings?: ReactNode;
 	/** A provider decision that temporarily replaces ordinary message entry. */
 	approval?: ReactNode;
@@ -146,7 +156,7 @@ export const ChatComposer = memo(function ChatComposer({
 	/** Why the last steer was refused. */
 	steerRefusal?: string;
 	/** A selected history message to load into the composer as a new draft. */
-	draftSeed?: { id: string; text: string };
+	draftSeed?: { id: string; text: string; attachments?: StoredComposerAttachment[] };
 	/** A queued turn being edited in the composer instead of the dock. */
 	editingQueuedTurnId?: string;
 	onCancelQueuedEdit?: () => void;
@@ -210,7 +220,12 @@ export const ChatComposer = memo(function ChatComposer({
 	const previousTrigger = useRef<ComposerTrigger | undefined>(undefined);
 	const triggerRef = useRef<ComposerTrigger | undefined>(undefined);
 
-	const fileAttachments = useFileAttachments();
+	const ordinaryAttachments = useFileAttachments();
+	const editAttachments = useFileAttachments();
+	const fileAttachments = editingQueuedTurnId ? editAttachments : ordinaryAttachments;
+	const [retainedAttachments, setRetainedAttachments] = useState<StoredComposerAttachment[]>(draftSeed?.attachments ?? []);
+	const visibleRetainedAttachments = editingQueuedTurnId ? retainedAttachments : [];
+	const ordinaryDraftRef = useRef("");
 	const canAttach = Boolean(onStageAttachments);
 
 	const slashCommands = useMemo<ChatSkill[]>(() => {
@@ -246,7 +261,7 @@ export const ChatComposer = memo(function ChatComposer({
 	// index from the previous list can point past the end of this one.
 	const activeIndex = Math.min(highlighted, suggestions.length - 1);
 
-	const staged = fileAttachments.attachments.length > 0;
+	const staged = fileAttachments.attachments.length > 0 || visibleRetainedAttachments.length > 0;
 	const controlsDisabled = Boolean(disabled || submitting);
 	const hasDraft = hasText || staged;
 	const savingQueuedEdit = Boolean(editingQueuedTurnId);
@@ -282,8 +297,9 @@ export const ChatComposer = memo(function ChatComposer({
 				queuedDock as ReactElement<{
 					canSteerNext?: boolean;
 					steerNextRequest?: number;
+					disabled?: boolean;
 				}>,
-				{ canSteerNext, steerNextRequest },
+				{ canSteerNext, steerNextRequest, disabled: submitting },
 			)
 		: queuedDock;
 
@@ -337,6 +353,26 @@ export const ChatComposer = memo(function ChatComposer({
 		editor.current?.clear();
 	}, []);
 
+	const previousEditingQueuedTurnIdRef = useRef(editingQueuedTurnId);
+	useLayoutEffect(() => {
+		const previous = previousEditingQueuedTurnIdRef.current;
+		if (previous === editingQueuedTurnId) return;
+		previousEditingQueuedTurnIdRef.current = editingQueuedTurnId;
+		stagedDelivery.current = null;
+		editAttachments.clear();
+		setRetainedAttachments(draftSeed?.attachments ?? []);
+		if (!previous && editingQueuedTurnId) {
+			ordinaryDraftRef.current = textRef.current;
+		} else if (previous && !editingQueuedTurnId) {
+			const text = ordinaryDraftRef.current;
+			textRef.current = text;
+			hasTextRef.current = text.trim().length > 0;
+			setHasText(hasTextRef.current);
+			editor.current?.setText(text);
+			setSendError(null);
+		}
+	}, [draftSeed, editingQueuedTurnId, editAttachments.clear]);
+
 	useEffect(() => {
 		if (draftSeedText === undefined) return;
 		textRef.current = draftSeedText;
@@ -349,15 +385,6 @@ export const ChatComposer = memo(function ChatComposer({
 		setHighlighted(0);
 		setSendError(null);
 	}, [draftSeedId, draftSeedText]);
-
-	const previousEditingQueuedTurnIdRef = useRef(editingQueuedTurnId);
-	useEffect(() => {
-		const previous = previousEditingQueuedTurnIdRef.current;
-		previousEditingQueuedTurnIdRef.current = editingQueuedTurnId;
-		if (previous && !editingQueuedTurnId) {
-			clearEditor();
-		}
-	}, [clearEditor, editingQueuedTurnId]);
 
 	const onEditorChange = useCallback((snapshot: ComposerEditorSnapshot) => {
 		textRef.current = snapshot.text;
@@ -472,7 +499,7 @@ export const ChatComposer = memo(function ChatComposer({
 
 		// `/compact` is a local AO command. It must refuse while a turn is running
 		// without being blocked by the ordinary busy send gate.
-		if (body === "/compact" && onCompact) {
+		if (body === "/compact" && onCompact && !editingQueuedTurnId) {
 			setSendError(null);
 			if (compactBlocked) {
 				setSendError("Stop the current turn before compacting.");
@@ -503,8 +530,12 @@ export const ChatComposer = memo(function ChatComposer({
 		// leave the image behind when its FileReader completes.
 		const attachmentPayloads = await fileAttachments.toSettledPayload();
 		const hasAttachments = attachmentPayloads.length > 0;
+		if (attachmentPayloads.length + visibleRetainedAttachments.length > MAX_ATTACHMENTS) {
+			setSendError(`You can attach up to ${MAX_ATTACHMENTS} files.`);
+			return;
+		}
 		const canSubmitNow =
-			(body.length > 0 || hasAttachments) &&
+			(body.length > 0 || hasAttachments || visibleRetainedAttachments.length > 0) &&
 			!disabled &&
 			!steerPending &&
 			!savingQueuedEditPending &&
@@ -525,7 +556,8 @@ export const ChatComposer = memo(function ChatComposer({
 		setSendError(null);
 
 		const shouldSteer = forceSteer ?? false;
-		let message = body;
+		const retainedPaths = visibleRetainedAttachments.flatMap((attachment) => attachment.path ? [attachment.path] : []);
+		let message = withAttachmentReferences(body, retainedPaths);
 		let nativePayloads: FileAttachmentPayload[] = [];
 		if (hasAttachments) {
 			if (!onStageAttachments) {
@@ -547,7 +579,7 @@ export const ChatComposer = memo(function ChatComposer({
 				setSendError("The files could not be attached. Nothing was sent.");
 				return;
 			}
-			message = withAttachmentReferences(body, paths);
+			message = withAttachmentReferences(body, [...retainedPaths, ...paths]);
 			nativePayloads = attachmentPayloads.filter((attachment) =>
 				isSupportedImageAttachment(attachment.mimeType),
 			);
@@ -574,6 +606,15 @@ export const ChatComposer = memo(function ChatComposer({
 		}
 
 		try {
+			if (editingQueuedTurnId) {
+				const retainedContent = visibleRetainedAttachments.flatMap((attachment) =>
+					attachment.contentIndex === undefined ? [] : [attachment.contentIndex],
+				).sort((a, b) => a - b);
+				await onSend(message, nativeImages && nativePayloads.length ? nativePayloads : undefined, retainedContent);
+				// Exiting edit mode restores the separate ordinary draft. Do not clear it
+				// from this submission's continuation after the parent changes modes.
+				return;
+			}
 			if (nativeImages && nativePayloads.length > 0) await onSend(message, nativePayloads);
 			else await onSend(message);
 		} catch (error) {
@@ -653,9 +694,8 @@ export const ChatComposer = memo(function ChatComposer({
 			}
 		}
 
-		if (event.key === "Escape" && editingQueuedTurnId && onCancelQueuedEdit) {
+		if (event.key === "Escape" && editingQueuedTurnId && onCancelQueuedEdit && !submitInFlight.current) {
 			event.preventDefault();
-			clearEditor();
 			onCancelQueuedEdit();
 		}
 	}
@@ -773,9 +813,22 @@ export const ChatComposer = memo(function ChatComposer({
 					/>
 				) : null}
 
+				{editingQueuedTurnId ? (
+					<div className="flex items-center justify-between text-xs text-muted-foreground">
+						<span>Editing queued message</span>
+						<button
+							type="button"
+							disabled={controlsDisabled}
+							onClick={onCancelQueuedEdit}
+							className="rounded px-1.5 py-0.5 hover:text-foreground focus-visible:outline focus-visible:outline-ring"
+						>
+							Cancel edit
+						</button>
+					</div>
+				) : null}
 				{staged ? (
 					<ul className="flex flex-wrap gap-1.5" aria-label="Attached files">
-						{fileAttachments.attachments.map((file) => (
+						{[...visibleRetainedAttachments, ...fileAttachments.attachments].map((file) => (
 							<li
 								key={file.id}
 								className="flex items-center gap-1.5 rounded border border-border bg-background py-0.5 pl-0.5 pr-1"
@@ -796,7 +849,10 @@ export const ChatComposer = memo(function ChatComposer({
 								<button
 									type="button"
 									onClick={() => {
-										if (!submitInFlight.current) fileAttachments.remove(file.id);
+									if (submitInFlight.current) return;
+									if (visibleRetainedAttachments.some((attachment) => attachment.id === file.id)) {
+										setRetainedAttachments((current) => current.filter((attachment) => attachment.id !== file.id));
+									} else fileAttachments.remove(file.id);
 									}}
 									disabled={controlsDisabled}
 									aria-label={`Remove ${file.name}`}

--- a/frontend/src/renderer/components/chat/ChatQueuedAttachments.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatQueuedAttachments.test.tsx
@@ -181,4 +181,28 @@ describe("queued message attachments", () => {
 		expect(field).toHaveTextContent("inspect this");
 		expect(screen.getByLabelText("Remove shot.png")).toBeInTheDocument();
 	});
+
+	it("reloads retained attachments when reopening a newer revision of the same queued turn", async () => {
+		const { edit, snapshot, rerenderSnapshot, field } = setup(`inspect this\n\n${suffix}`, [
+			{ type: "image", mimeType: "image/png" },
+		]);
+		await beginEdit();
+		expect(screen.getByLabelText("Remove attachment-shot.png")).toBeInTheDocument();
+		rerenderSnapshot({
+			...snapshot,
+			items: snapshot.items.map((item) =>
+				item.kind === "message" ? { ...item, text: "newer edit", revision: 1, content: [] } : item,
+			),
+		});
+		await beginEdit();
+		await waitFor(() => expect(field).toHaveTextContent("newer edit"));
+		expect(screen.queryByLabelText("Remove attachment-shot.png")).not.toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() =>
+			expect(edit).toHaveBeenCalledWith("q1", "newer edit", {
+				retainedContent: [],
+				expectedRevision: 1,
+			}),
+		);
+	});
 });

--- a/frontend/src/renderer/components/chat/ChatQueuedAttachments.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatQueuedAttachments.test.tsx
@@ -114,17 +114,52 @@ describe("queued message attachments", () => {
 		);
 	});
 
-	it("removes an existing image's reference and native content together", async () => {
+	it.each(["path", "native"])("removes only the selected %s attachment when independent image counts match", async (selected) => {
 		const { edit } = setup(`inspect this\n\n${suffix}`, [{ type: "image", mimeType: "image/png" }]);
 		await beginEdit();
-		await userEvent.click(screen.getByLabelText("Remove attachment-shot.png"));
+		await userEvent.click(screen.getByLabelText(selected === "path" ? "Remove attachment-shot.png" : "Remove Image 1"));
 		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
 		await waitFor(() =>
-			expect(edit).toHaveBeenCalledWith("q1", "inspect this", {
-				retainedContent: [],
+			expect(edit).toHaveBeenCalledWith("q1", selected === "path" ? "inspect this" : `inspect this\n\n${suffix}`, {
+				retainedContent: selected === "path" ? [0] : [],
 				expectedRevision: 0,
 			}),
 		);
+	});
+
+	it.each([8, 9])("preserves %i resources when saving a valid queued edit", async (count) => {
+		const resources = Array.from({ length: count }, (_, index) => ({
+			type: "resource_link", uri: `file:///context-${index}.txt`, name: `Context ${index}`,
+		}));
+		const { edit, field } = setup("inspect this", resources);
+		await beginEdit();
+		await typeInLexicalEditor(field, " carefully");
+		if (count === 8) await pasteImage(field);
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() => expect(edit).toHaveBeenCalledWith(
+			"q1", count === 8 ? `inspect this carefully\n\n${suffix}` : "inspect this carefully",
+			{
+				retainedContent: resources.map((_, index) => index), expectedRevision: 0,
+				...(count === 8 ? { attachments: [{ mimeType: "image/png", data: expect.any(String) }] } : {}),
+			},
+		));
+	});
+
+	it.each(["image/png", "text/plain"])("counts only native images when adding %s to eight retained images", async (mimeType) => {
+		const { edit, field, stage } = setup("inspect this", Array.from({ length: 8 }, () => ({ type: "image", mimeType: "image/png" })));
+		stage.mockResolvedValue([".ao/attachments/attachment-context.txt"]);
+		await beginEdit();
+		fireEvent.paste(field, { clipboardData: { files: [new File(["context"], "new-file", { type: mimeType })], items: [] } });
+		await screen.findByLabelText("Remove new-file");
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		if (mimeType === "image/png") {
+			await screen.findByText("You can attach up to 8 images.");
+			expect(edit).not.toHaveBeenCalled();
+		} else {
+			await waitFor(() => expect(edit).toHaveBeenCalledWith("q1", "inspect this\n\nAttached files (read these files in the workspace):\n- .ao/attachments/attachment-context.txt", {
+				retainedContent: [0, 1, 2, 3, 4, 5, 6, 7], expectedRevision: 0,
+			}));
+		}
 	});
 
 	it.each(["cancel", "save"])("isolates the ordinary draft and restores it after %s", async (action) => {

--- a/frontend/src/renderer/components/chat/ChatQueuedAttachments.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatQueuedAttachments.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ChatWorkspace } from "./ChatWorkspace";
+import { chatFixture } from "../../lib/chat-fixture";
+import { typeInLexicalEditor } from "../../test/lexical";
+import { TooltipProvider } from "../ui/tooltip";
+import type { ConversationContentSummary, ConversationSnapshot } from "../../types/conversation";
+
+const path = ".ao/attachments/attachment-shot.png";
+const suffix = `Attached files (read these files in the workspace):\n- ${path}`;
+
+function setup(text = "inspect this", content: ConversationContentSummary[] = []) {
+	const edit = vi.fn().mockResolvedValue(undefined);
+	const send = vi.fn().mockResolvedValue(undefined);
+	const stage = vi.fn().mockResolvedValue([path]);
+	const snapshot: ConversationSnapshot = {
+		...chatFixture,
+		turns: [{ id: "q1", state: "queued" as const, requestedAt: "2026-09-06T10:00:00Z" }],
+		items: [
+			{
+				kind: "message" as const,
+				id: "m1",
+				turnId: "q1",
+				sequence: 1,
+				revision: 0,
+				role: "user" as const,
+				origin: "human" as const,
+				text,
+				content,
+				streaming: false,
+				createdAt: "2026-09-06T10:00:00Z",
+			},
+		],
+	};
+	const view = render(
+		<TooltipProvider>
+			<ChatWorkspace
+				snapshot={snapshot}
+				onSend={send}
+				onEditQueuedTurn={edit}
+				onStageAttachments={stage}
+				nativeImages
+			/>
+		</TooltipProvider>,
+	);
+	return {
+		edit,
+		send,
+		stage,
+		snapshot,
+		field: screen.getByRole("combobox"),
+		rerenderSnapshot: (next: ConversationSnapshot) =>
+			view.rerender(
+				<TooltipProvider>
+					<ChatWorkspace
+						snapshot={next}
+						onSend={send}
+						onEditQueuedTurn={edit}
+						onStageAttachments={stage}
+						nativeImages
+					/>
+				</TooltipProvider>,
+			),
+	};
+}
+
+async function beginEdit() {
+	await userEvent.click(
+		within(screen.getByTestId("queued-message-q1")).getByRole("button", { name: "Edit queued message" }),
+	);
+}
+
+async function pasteImage(field: HTMLElement, name = "shot.png") {
+	fireEvent.paste(field, {
+		clipboardData: {
+			files: [new File([new Uint8Array([137, 80, 78, 71])], name, { type: "image/png" })],
+			items: [],
+		},
+	});
+	await screen.findByLabelText(`Remove ${name}`);
+}
+
+describe("queued message attachments", () => {
+	it("saves newly attached image bytes and their staged reference to the queued turn", async () => {
+		const { edit, send, stage, field } = setup();
+		await beginEdit();
+		await pasteImage(field);
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() =>
+			expect(edit).toHaveBeenCalledWith("q1", `inspect this\n\n${suffix}`, {
+				attachments: [{ mimeType: "image/png", data: expect.any(String) }],
+				retainedContent: [],
+				expectedRevision: 0,
+			}),
+		);
+		expect(stage).toHaveBeenCalledOnce();
+		expect(send).not.toHaveBeenCalled();
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("opens existing images as chips and retains their server-owned bytes when text changes", async () => {
+		const { edit, field } = setup(`inspect this\n\n${suffix}`, [{ type: "image", mimeType: "image/png" }]);
+		await beginEdit();
+		expect(screen.getByLabelText("Remove attachment-shot.png")).toBeInTheDocument();
+		expect(field).not.toHaveTextContent(".ao/attachments");
+		await typeInLexicalEditor(field, " carefully");
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() =>
+			expect(edit).toHaveBeenCalledWith("q1", `inspect this carefully\n\n${suffix}`, {
+				retainedContent: [0],
+				expectedRevision: 0,
+			}),
+		);
+	});
+
+	it("removes an existing image's reference and native content together", async () => {
+		const { edit } = setup(`inspect this\n\n${suffix}`, [{ type: "image", mimeType: "image/png" }]);
+		await beginEdit();
+		await userEvent.click(screen.getByLabelText("Remove attachment-shot.png"));
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() =>
+			expect(edit).toHaveBeenCalledWith("q1", "inspect this", {
+				retainedContent: [],
+				expectedRevision: 0,
+			}),
+		);
+	});
+
+	it.each(["cancel", "save"])("isolates the ordinary draft and restores it after %s", async (action) => {
+		const { field, edit } = setup();
+		await typeInLexicalEditor(field, "unrelated draft");
+		await pasteImage(field, "unrelated.png");
+		await beginEdit();
+		expect(field).toHaveTextContent("inspect this");
+		expect(screen.queryByLabelText("Remove unrelated.png")).not.toBeInTheDocument();
+		if (action === "save") {
+			await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+			await waitFor(() => expect(edit).toHaveBeenCalledOnce());
+		} else {
+			await userEvent.click(field);
+			await userEvent.keyboard("{Escape}");
+		}
+		await waitFor(() => expect(field).toHaveTextContent("unrelated draft"));
+		expect(screen.getByLabelText("Remove unrelated.png")).toBeInTheDocument();
+	});
+
+	it("keeps a failed edit for retry without staging the same image twice", async () => {
+		const { edit, send, stage, field } = setup();
+		edit.mockRejectedValueOnce(new Error("Could not save queued message edit"));
+		await beginEdit();
+		await pasteImage(field);
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await screen.findByText("Could not save queued message edit");
+		expect(field).toHaveTextContent("inspect this");
+		expect(screen.getByLabelText("Remove shot.png")).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() => expect(edit).toHaveBeenCalledTimes(2));
+		expect(edit.mock.calls[1]).toEqual(edit.mock.calls[0]);
+		expect(stage).toHaveBeenCalledOnce();
+		expect(send).not.toHaveBeenCalled();
+		await waitFor(() => expect(screen.queryByText("Editing queued message")).not.toBeInTheDocument());
+	});
+
+	it("keeps the edit target and draft when the turn dispatches before saving", async () => {
+		const { edit, send, snapshot, rerenderSnapshot, field } = setup();
+		edit.mockRejectedValueOnce(new Error("that message is no longer queued"));
+		await beginEdit();
+		await pasteImage(field);
+		rerenderSnapshot({ ...snapshot, turns: snapshot.turns.map((turn) => ({ ...turn, state: "running" })) });
+		await waitFor(() => expect(screen.queryByTestId("queued-message-q1")).not.toBeInTheDocument());
+		expect(screen.getByText("Editing queued message")).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await screen.findByText("that message is no longer queued");
+		expect(edit).toHaveBeenCalledWith(
+			"q1",
+			expect.any(String),
+			expect.objectContaining({ expectedRevision: 0 }),
+		);
+		expect(send).not.toHaveBeenCalled();
+		expect(field).toHaveTextContent("inspect this");
+		expect(screen.getByLabelText("Remove shot.png")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -7,6 +7,7 @@
  * re-sorting. Those belong to the daemon.
  */
 
+import { stagedAttachmentParts, attachmentName, attachmentURL, IMAGE_ATTACHMENT_PATH } from "./messageAttachments";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
 	AlertTriangle,
@@ -100,15 +101,6 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
 
 const ORIGIN_REPORT_COLLAPSE_AT = 600;
 const ORIGIN_REPORT_PREVIEW_LENGTH = 240;
-
-// These are AO-owned prompt suffixes, not general markdown. Chat and spawn used
-// slightly different wording, and older conversations used "Attached images";
-// accepting every shipped form lets the transcript improve without rewriting
-// its durable history.
-const ATTACHMENT_REFERENCE_BLOCK =
-	/(?:^|\n\n)(?:Attached files \(read these files in the workspace(?: for context)?\)|Attached images \(read these files in the workspace for visual context\)):\n((?:- [^\n]+(?:\n|$))+)$/;
-const STAGED_ATTACHMENT_PATH = /^\.ao\/attachments\/(?:attachment|image)-[A-Za-z0-9][A-Za-z0-9._-]*$/;
-const IMAGE_ATTACHMENT_PATH = /\.(?:png|jpe?g|gif|webp|bmp)$/i;
 
 /** Smooth baseline, with adaptive catch-up when provider chunks outrun playback. */
 const STREAM_BASE_CHARACTERS_PER_SECOND = 58;
@@ -274,24 +266,6 @@ function useSmoothStreamingText(message: ConversationMessage): string {
 	return visibleText;
 }
 
-function stagedAttachmentParts(text: string): { body: string; attachments: string[] } {
-	const match = ATTACHMENT_REFERENCE_BLOCK.exec(text);
-	if (!match?.[1]) return { body: text, attachments: [] };
-
-	const attachments = match[1]
-		.trimEnd()
-		.split("\n")
-		.map((line) => line.slice(2));
-	// Only reinterpret paths AO itself stages. A user can write an identically
-	// worded example about docs/screenshot.png; that prose must remain untouched.
-	if (attachments.length === 0 || attachments.some((path) => !STAGED_ATTACHMENT_PATH.test(path))) {
-		return { body: text, attachments: [] };
-	}
-	// The match begins at the generated separator, so slicing at its index
-	// removes only AO-owned text and preserves the authored body byte-for-byte.
-	return { body: text.slice(0, match.index), attachments };
-}
-
 /** A status message followed by a full-width rule, with no text inside the rule. */
 function TwoRowTimelineMarker({
 	message,
@@ -400,18 +374,6 @@ export function TurnOutcome({
 function formatTokens(tokens: number): string {
 	if (tokens < 1000) return `${tokens}`;
 	return `${(tokens / 1000).toFixed(1)}k`;
-}
-
-function attachmentName(path: string): string {
-	return path.slice(path.lastIndexOf("/") + 1);
-}
-
-function attachmentURL(apiBaseUrl: string, sessionId: string, path: string): string {
-	const route = `/api/v1/sessions/${encodeURIComponent(sessionId)}/preview/files/${path
-		.split("/")
-		.map(encodeURIComponent)
-		.join("/")}`;
-	return apiBaseUrl ? new URL(route, apiBaseUrl).toString() : route;
 }
 
 function StagedAttachmentItems({

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -76,7 +76,9 @@ import {
 } from "./ChatTimelineItems";
 import { HumanMessageEditor } from "./HumanMessageEditor";
 import { ChatLinkProvider } from "./ChatMarkdown";
-import { ChatComposer } from "./ChatComposer";
+import { ChatComposer, type StoredComposerAttachment } from "./ChatComposer";
+import { stagedAttachmentParts, attachmentName, attachmentURL, IMAGE_ATTACHMENT_PATH } from "./messageAttachments";
+import type { QueuedMessageEditOptions } from "../../types/conversation";
 import { QueuedMessageDock, type QueuedMessage } from "./QueuedMessageDock";
 import { ActivityRun } from "./ActivityRun";
 import { TurnPlan } from "./TurnPlan";
@@ -366,7 +368,7 @@ export interface ChatWorkspaceProps {
 	/** Why the last steer was refused, from the daemon's typed answer. */
 	steerRefusal?: string;
 	onPromoteQueuedTurn?: (turnId: string) => Promise<unknown>;
-	onEditQueuedTurn?: (turnId: string, text: string) => Promise<unknown>;
+	onEditQueuedTurn?: (turnId: string, text: string, options?: QueuedMessageEditOptions) => Promise<unknown>;
 	onCancelQueuedTurn?: (turnId: string) => Promise<unknown>;
 	onReorderQueuedTurns?: (turnIds: string[]) => Promise<unknown>;
 	promoteQueuedTurnPendingTurnId?: string;
@@ -583,13 +585,9 @@ export function ChatWorkspace({
 	const queuedMessages = useQueuedMessages(snapshot);
 	const stablePromoteQueuedTurn = useStableCallback(onPromoteQueuedTurn);
 	const stableCancelQueuedTurn = useStableCallback(onCancelQueuedTurn);
-	const [queueEdit, setQueueEdit] = useState<{ turnId: string; text: string } | undefined>();
-	useEffect(() => {
-		if (!queueEdit) return;
-		if (!queuedMessages.some((message) => message.turnId === queueEdit.turnId)) {
-			setQueueEdit(undefined);
-		}
-	}, [queueEdit, queuedMessages]);
+	const [queueEdit, setQueueEdit] = useState<{
+		turnId: string; text: string; revision: number; attachments: StoredComposerAttachment[];
+	} | undefined>();
 	const handleCancelQueuedTurn = useCallback(
 		async (turnId: string) => {
 			if (!onCancelQueuedTurn) return;
@@ -599,15 +597,15 @@ export function ChatWorkspace({
 		[stableCancelQueuedTurn],
 	);
 	const handleComposerSend = useCallback(
-		async (text: string, attachments?: Parameters<NonNullable<typeof onSend>>[1]) => {
+		async (text: string, attachments?: Parameters<NonNullable<typeof onSend>>[1], retainedContent?: number[]) => {
 			if (queueEdit) {
-				if (attachments && attachments.length > 0) {
-					throw new Error("Queued message edits cannot include attachments.");
-				}
 				if (!onEditQueuedTurn) {
 					throw new Error("Queued message edits are unavailable right now.");
 				}
-				await onEditQueuedTurn(queueEdit.turnId, text);
+				await onEditQueuedTurn(queueEdit.turnId, text, {
+					...(attachments?.length ? { attachments } : {}),
+					retainedContent, expectedRevision: queueEdit.revision,
+				});
 				setQueueEdit(undefined);
 				return;
 			}
@@ -615,15 +613,35 @@ export function ChatWorkspace({
 		},
 		[onEditQueuedTurn, onSend, queueEdit],
 	);
-	const composerSend = useStableCallback(handleComposerSend);
 	const stableInterrupt = useStableCallback(onInterrupt);
 	const stableSteer = useStableCallback(onSteer);
 	const beginQueuedEdit = useCallback(
 		(turnId: string, text: string) => {
 			if (newWorkDisabled) return;
-			setQueueEdit({ turnId, text });
+			const message = queuedMessages.find((queued) => queued.turnId === turnId)?.message;
+			if (!message) return;
+			const parts = stagedAttachmentParts(text);
+			const content = message.content ?? [];
+			const images = content.flatMap((item, index) => item.type === "image" ? [index] : []);
+			// Pair only an unambiguous set of native images with staged image paths.
+			// Path-only and imported native attachments can otherwise coexist.
+			const pairedImages = parts.attachments.filter((path) => IMAGE_ATTACHMENT_PATH.test(path)).length === images.length;
+			let imageIndex = 0;
+			const attachments: StoredComposerAttachment[] = parts.attachments.map((path) => ({
+				id: path, name: attachmentName(path), path,
+				...(IMAGE_ATTACHMENT_PATH.test(path) ? {
+					dataUrl: attachmentURL(getApiBaseUrl(), snapshot.sessionId, path),
+					contentIndex: pairedImages ? images[imageIndex++] : undefined,
+				} : {}),
+			}));
+			content.forEach((item, index) => {
+				if (attachments.some((attachment) => attachment.contentIndex === index)) return;
+				attachments.push({ id: `content-${index}`, contentIndex: index,
+					name: item.name || (item.type === "image" ? `Image ${index + 1}` : item.uri || "Attachment") });
+			});
+			setQueueEdit({ turnId, text: parts.body, revision: message.revision, attachments });
 		},
-		[newWorkDisabled],
+		[newWorkDisabled, queuedMessages, snapshot.sessionId],
 	);
 	const cancelQueuedEdit = useCallback(() => setQueueEdit(undefined), []);
 	const promoteQueuedTurn = useCallback(
@@ -926,7 +944,7 @@ export function ChatWorkspace({
 		],
 	);
 	const composerDraftSeed = useMemo(
-		() => (queueEdit ? { id: queueEdit.turnId, text: queueEdit.text } : undefined),
+		() => (queueEdit ? { id: queueEdit.turnId, text: queueEdit.text, attachments: queueEdit.attachments } : undefined),
 		[queueEdit],
 	);
 	// Empty chats center the prompt; once a turn or item exists the composer docks
@@ -1147,7 +1165,7 @@ export function ChatWorkspace({
 								<ChatComposer
 									queuedDock={composerQueuedDock}
 									approval={composerApproval}
-									onSend={composerSend}
+									onSend={handleComposerSend}
 									draftSeed={composerDraftSeed}
 									editingQueuedTurnId={queueEdit?.turnId}
 									savingQueuedEditPending={Boolean(

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -622,21 +622,16 @@ export function ChatWorkspace({
 			if (!message) return;
 			const parts = stagedAttachmentParts(text);
 			const content = message.content ?? [];
-			const images = content.flatMap((item, index) => item.type === "image" ? [index] : []);
-			// Pair only an unambiguous set of native images with staged image paths.
-			// Path-only and imported native attachments can otherwise coexist.
-			const pairedImages = parts.attachments.filter((path) => IMAGE_ATTACHMENT_PATH.test(path)).length === images.length;
-			let imageIndex = 0;
+			// Paths and native blocks have no shared persisted identity. Keep their
+			// removal independent, even when the image counts happen to match.
 			const attachments: StoredComposerAttachment[] = parts.attachments.map((path) => ({
 				id: path, name: attachmentName(path), path,
 				...(IMAGE_ATTACHMENT_PATH.test(path) ? {
 					dataUrl: attachmentURL(getApiBaseUrl(), snapshot.sessionId, path),
-					contentIndex: pairedImages ? images[imageIndex++] : undefined,
 				} : {}),
 			}));
 			content.forEach((item, index) => {
-				if (attachments.some((attachment) => attachment.contentIndex === index)) return;
-				attachments.push({ id: `content-${index}`, contentIndex: index,
+				attachments.push({ id: `content-${index}`, contentIndex: index, contentType: item.type,
 					name: item.name || (item.type === "image" ? `Image ${index + 1}` : item.uri || "Attachment") });
 			});
 			setQueueEdit({ turnId, text: parts.body, revision: message.revision, attachments });

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -944,7 +944,7 @@ export function ChatWorkspace({
 		],
 	);
 	const composerDraftSeed = useMemo(
-		() => (queueEdit ? { id: queueEdit.turnId, text: queueEdit.text, attachments: queueEdit.attachments } : undefined),
+		() => (queueEdit ? { id: `${queueEdit.turnId}:${queueEdit.revision}`, text: queueEdit.text, attachments: queueEdit.attachments } : undefined),
 		[queueEdit],
 	);
 	// Empty chats center the prompt; once a turn or item exists the composer docks

--- a/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
+++ b/frontend/src/renderer/components/chat/QueuedMessageDock.tsx
@@ -291,6 +291,7 @@ function SortableQueuedMessageRow({
 
 export const QueuedMessageDock = memo(function QueuedMessageDock({
 	messages,
+	disabled,
 	editingTurnId,
 	canSteer,
 	canSteerNext,
@@ -303,6 +304,7 @@ export const QueuedMessageDock = memo(function QueuedMessageDock({
 	cancelPendingTurnId,
 }: {
 	messages: QueuedMessage[];
+	disabled?: boolean;
 	editingTurnId?: string;
 	canSteer?: boolean;
 	canSteerNext?: boolean;
@@ -608,7 +610,7 @@ export const QueuedMessageDock = memo(function QueuedMessageDock({
 							>
 								{displayMessages.map(({ turnId, message }, index) => {
 									const busy =
-										promotePendingTurnId === turnId || cancelPendingTurnId === turnId;
+										disabled || promotePendingTurnId === turnId || cancelPendingTurnId === turnId;
 									const isNextQueuedTurn = turnId === nextQueuedTurnId;
 									return (
 										<SortableQueuedMessageRow

--- a/frontend/src/renderer/components/chat/messageAttachments.ts
+++ b/frontend/src/renderer/components/chat/messageAttachments.ts
@@ -1,0 +1,38 @@
+// These are AO-owned prompt suffixes, not general markdown. Chat and spawn used
+// slightly different wording, and older conversations used "Attached images";
+// accepting every shipped form lets the transcript improve without rewriting
+// its durable history.
+const ATTACHMENT_REFERENCE_BLOCK =
+	/(?:^|\n\n)(?:Attached files \(read these files in the workspace(?: for context)?\)|Attached images \(read these files in the workspace for visual context\)):\n((?:- [^\n]+(?:\n|$))+)$/;
+const STAGED_ATTACHMENT_PATH = /^\.ao\/attachments\/(?:attachment|image)-[A-Za-z0-9][A-Za-z0-9._-]*$/;
+export const IMAGE_ATTACHMENT_PATH = /\.(?:png|jpe?g|gif|webp|bmp)$/i;
+
+export function stagedAttachmentParts(text: string): { body: string; attachments: string[] } {
+	const match = ATTACHMENT_REFERENCE_BLOCK.exec(text);
+	if (!match?.[1]) return { body: text, attachments: [] };
+
+	const attachments = match[1]
+		.trimEnd()
+		.split("\n")
+		.map((line) => line.slice(2));
+	// Only reinterpret paths AO itself stages. A user can write an identically
+	// worded example about docs/screenshot.png; that prose must remain untouched.
+	if (attachments.length === 0 || attachments.some((path) => !STAGED_ATTACHMENT_PATH.test(path))) {
+		return { body: text, attachments: [] };
+	}
+	// The match begins at the generated separator, so slicing at its index
+	// removes only AO-owned text and preserves the authored body byte-for-byte.
+	return { body: text.slice(0, match.index), attachments };
+}
+
+export function attachmentName(path: string): string {
+	return path.slice(path.lastIndexOf("/") + 1);
+}
+
+export function attachmentURL(apiBaseUrl: string, sessionId: string, path: string): string {
+	const route = `/api/v1/sessions/${encodeURIComponent(sessionId)}/preview/files/${path
+		.split("/")
+		.map(encodeURIComponent)
+		.join("/")}`;
+	return apiBaseUrl ? new URL(route, apiBaseUrl).toString() : route;
+}

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -41,6 +41,7 @@ import type {
 	ChatSkill,
 	PlanStep,
 	PlanStepStatus,
+	QueuedMessageEditOptions,
 	SessionMode,
 	ThreadStatus,
 	TurnSettings,
@@ -576,14 +577,14 @@ export function useConversationCommands(sessionId: string | undefined) {
 	});
 
 	const editQueuedTurn = useMutation({
-		mutationFn: async ({ turnId, text }: { turnId: string; text: string }) => {
+		mutationFn: async ({ turnId, text, ...options }: { turnId: string; text: string } & QueuedMessageEditOptions) => {
 			const { error } = await apiClient.POST(
 				"/api/v1/sessions/{sessionId}/conversation/turns/{turnId}/queue/edit",
 				{
 					params: {
 						path: { sessionId: sessionId as string, turnId },
 					},
-					body: { text },
+					body: { text, ...options },
 				},
 			);
 			if (error) throw new Error(apiErrorMessage(error, "Could not save queued message edit"));
@@ -875,9 +876,9 @@ export function useConversationCommands(sessionId: string | undefined) {
 			}),
 		promoteQueuedTurn: (turnId: string) => promoteQueuedTurn.mutateAsync(turnId),
 		cancelQueuedTurn: (turnId: string) => cancelQueuedTurn.mutateAsync(turnId),
-		editQueuedTurn: (turnId: string, text: string) => {
+		editQueuedTurn: (turnId: string, text: string, options?: QueuedMessageEditOptions) => {
 			if (!sessionId) return Promise.reject(new Error("No conversation session is selected."));
-			return editQueuedTurn.mutateAsync({ turnId, text });
+			return editQueuedTurn.mutateAsync({ turnId, text, ...options });
 		},
 		reorderQueuedTurns: (turnIds: string[]) => {
 			if (!sessionId) return Promise.reject(new Error("No conversation session is selected."));

--- a/frontend/src/renderer/hooks/useFileAttachments.test.ts
+++ b/frontend/src/renderer/hooks/useFileAttachments.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
 	MAX_ATTACHMENTS,
@@ -73,5 +73,31 @@ describe("useFileAttachments", () => {
 			MAX_ATTACHMENTS_BYTES,
 		);
 		expect(result.current.error).toMatch(/total under/i);
+	});
+
+	it("discards a pending file read when its draft is cleared", async () => {
+		const readers: FileReader[] = [];
+		const read = vi.spyOn(FileReader.prototype, "readAsDataURL").mockImplementation(function (this: FileReader) {
+			readers.push(this);
+		});
+		try {
+			const { result } = renderHook(() => useFileAttachments());
+			let pending!: Promise<void>;
+			act(() => {
+				pending = result.current.addFiles([file("discarded.png", 8, "image/png")]);
+			});
+			expect(result.current.hasPendingReads()).toBe(true);
+			act(() => result.current.clear());
+			expect(result.current.hasPendingReads()).toBe(false);
+			await act(async () => {
+				Object.defineProperty(readers[0], "result", { value: "data:image/png;base64,AQ==" });
+				readers[0].dispatchEvent(new ProgressEvent("load"));
+				await pending;
+			});
+			expect(result.current.attachments).toEqual([]);
+			expect(await result.current.toSettledPayload()).toEqual([]);
+		} finally {
+			read.mockRestore();
+		}
 	});
 });

--- a/frontend/src/renderer/hooks/useFileAttachments.ts
+++ b/frontend/src/renderer/hooks/useFileAttachments.ts
@@ -73,8 +73,10 @@ export function useFileAttachments() {
 	const [error, setError] = useState<string | null>(null);
 	const attachmentsRef = useRef<FileAttachment[]>([]);
 	const pendingReadsRef = useRef<Set<Promise<unknown>>>(new Set());
+	const generationRef = useRef(0);
 
 	const addFiles = useCallback(async (files: Iterable<File>) => {
+		const generation = generationRef.current;
 		// Filter out directories - they have type "" and size 0 in most browsers
 		const validFiles = Array.from(files).filter((file) => {
 			// Exclude directories (they typically have no type and size 0)
@@ -116,6 +118,7 @@ export function useFileAttachments() {
 		pendingReadsRef.current.add(pendingReads);
 		const results = await pendingReads;
 		pendingReadsRef.current.delete(pendingReads);
+		if (generation !== generationRef.current) return;
 
 		const fresh: FileAttachment[] = [];
 		for (const { file, result } of results) {
@@ -169,6 +172,8 @@ export function useFileAttachments() {
 	}, []);
 
 	const clear = useCallback(() => {
+		generationRef.current++;
+		pendingReadsRef.current.clear();
 		attachmentsRef.current = [];
 		setAttachments([]);
 		setError(null);

--- a/frontend/src/renderer/types/conversation.ts
+++ b/frontend/src/renderer/types/conversation.ts
@@ -142,6 +142,12 @@ export interface ConversationContentSummary {
 	name?: string;
 }
 
+export interface QueuedMessageEditOptions {
+	attachments?: { mimeType: string; data: string }[];
+	retainedContent?: number[];
+	expectedRevision?: number;
+}
+
 export interface ConversationMessage {
 	kind: "message";
 	id: string;


### PR DESCRIPTION
## What

Queued messages support adding, retaining, removing, and replacing image attachments. Saving or canceling an edit restores the ordinary composer draft and its attachments.

## Why

The queued-edit UI rejected native images with “Queued message edits cannot include attachments.” The daemon's text-only update also cleared stored delivery content, so editing text could silently remove images before provider delivery. Entering an edit reused the ordinary draft's attachment state.

## How

- Extend the existing queued-edit API with new images, retained content indices, and the editor's message revision. Keep image bytes in daemon storage; reject stale indices and turns that have already dispatched. Text-only callers that omit retention preserve existing content.
- Update queued text and delivery content atomically, preserving queued-state guards. Populate the existing domain content field so snapshots expose attachment summaries.
- Reuse the transcript's staged-file parser to open removable attachment chips. Keep path references and native content as separate chips: they have no shared persisted identity, even when their counts match. Removing either representation preserves the other.
- Count only retained and newly added native images against the combined eight-image limit. Resource summaries and path references do not consume this image limit; existing staging limits still apply to newly attached files.
- Keep ordinary and edit drafts separate, retain failed saves, and invalidate unfinished file reads when an edit is discarded.
- Count actual decoded bytes against the combined 25 MiB image limit, accepting exactly 25 MiB and rejecting one byte over without changing stored content.
- Regenerate OpenAPI, TypeScript API types, and sqlc output. No schema migration or unrelated cleanup.

## Testing

Current head: `f0c50dc434cb76ea6694eb507ab77905e5518f19`.

- **Frontend:** full Vitest suite passed: **281 files, 3,872 tests, 6 skips**, using Node 24, the pinned agent-browser runtime, and `--maxWorkers=4`. Project and E2E typechecks passed. All 13 queued-attachment tests pass, including independent path/native removal, eight resources plus an image, nine-resource text edits, the nine-image rejection, and eight images plus a text file. The new regressions exposed the old behavior before the fixes.
- **Renderer smoke:** all **56 tests passed**, including add/retain/remove/cancel (`CI=true npm run test:e2e:renderer -- --workers=2`).
- **Real Electron:** this checkout ran against isolated daemon/data state. Removing an unrelated path preserved the native image; after dispatch Claude returned its printed code, `CEDAR-1E885B`, with zero tool activities. The stored image was independently inspected to confirm the code. Eight resources plus an image and a nine-resource text-only edit each saved with HTTP 204, revision 1, and all intended content persisted. The ordinary text/image draft was restored after all saves.
- **Native-run limitation:** the combined UI script passed all save/content assertions, then cleanup returned 409 because the extra turns had already dispatched. Later provider turns were blocked by the provider. A separate verification of daemon responses, persisted content, the successful first image delivery, and the restored draft passed. No successful provider delivery is claimed for the later resource turns.
- **Shared packages:** cloud-client generation/drift check, typecheck, tests and pack dry run; product-ui typecheck, tests and pack dry run passed again for this follow-up.
- **Unchanged backend and CLI:** at `e33b3ea`, full backend race suite, build, vet, gofmt, golangci-lint v2.12.2, API/sqlc drift, native macOS CLI E2E and the fresh-install Docker check passed. All 16 SQLite/provider table cases passed. This follow-up changes only four frontend files (+48/−14); those backend checks were not repeated locally.
- **Secret scan:** passed in CI for the current head. The local pinned-container rerun could not start because Docker stopped responding, including to a bounded read-only container query.
- **Remote CI:** all **11 checks passed** on `f0c50dc434cb76ea6694eb507ab77905e5518f19`, including both frontend jobs, the full Linux backend test job, lint, API drift, Windows workspace tests, native CLI on all three platforms, the container CLI check, and the secret scan. Linux/Windows-native validation comes from CI, not this macOS host.

Screenshot attachments from the earlier verified add/retain/replace/cancel flow remain in [the evidence comment](https://github.com/Untrivial-ai/agent-orchestrator/pull/5006#issuecomment-5567697539). New screenshots were captured locally; the browser upload tool rejected the attachment attempt. No evidence files are committed.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Remote CI checks pass on current head
