### PR TITLE
fix(onboarding): automatically start GitHub login PTY

### DIFF
--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -264,7 +264,13 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 	defer cancel()
 	var stdout bytes.Buffer
 	if err := s.commands.Run(probeCtx, []string{path, "auth", "status", "--active", "--json", "hosts"}, &stdout, io.Discard); err != nil {
-		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
+		// `auth status --json` was added after many still-supported gh releases.
+		// Bare `auth status` preserves compatibility while still validating the
+		// credential instead of merely checking that token text exists.
+		if !s.hasGitHubAuth(probeCtx, path) {
+			return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
+		}
+		return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
 	}
 	var status struct {
 		Hosts map[string][]struct {
@@ -273,7 +279,10 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 		} `json:"hosts"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
-		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
+		if !s.hasGitHubAuth(probeCtx, path) {
+			return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
+		}
+		return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
 	}
 	authenticated := false
 	for _, accounts := range status.Hosts {
@@ -291,4 +300,8 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 	}
 	return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
+}
+
+func (s *Service) hasGitHubAuth(ctx context.Context, path string) bool {
+	return s.commands.Run(ctx, []string{path, "auth", "status"}, io.Discard, io.Discard) == nil
 }

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -6,7 +6,9 @@
 package systemcheck
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"runtime"
@@ -260,7 +262,32 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	if err := s.commands.Run(probeCtx, []string{path, "auth", "token"}, io.Discard, io.Discard); err != nil {
+	var stdout bytes.Buffer
+	if err := s.commands.Run(probeCtx, []string{path, "auth", "status", "--active", "--json", "hosts"}, &stdout, io.Discard); err != nil {
+		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
+	}
+	var status struct {
+		Hosts map[string][]struct {
+			Active bool   `json:"active"`
+			State  string `json:"state"`
+		} `json:"hosts"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
+	}
+	authenticated := false
+	for _, accounts := range status.Hosts {
+		for _, account := range accounts {
+			if account.Active && account.State == "success" {
+				authenticated = true
+				break
+			}
+		}
+		if authenticated {
+			break
+		}
+	}
+	if !authenticated {
 		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 	}
 	return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -126,12 +126,11 @@ func (s *Service) OpenGitHubAuthTerminal(ctx context.Context) (shellterm.ShellTe
 		return shellterm.ShellTerminal{}, apierr.Internal("GITHUB_AUTH_TERMINAL_UNAVAILABLE", "GitHub authentication terminal service is unavailable.")
 	}
 	return s.terminals.OpenCommandTerminal(ctx, shellterm.OpenCommandTerminalInput{
-		Argv: []string{
-			path, "auth", "login",
-			"--hostname", "github.com",
-			"--git-protocol", "https",
-			"--web",
-		},
+		// Keep the native interactive flow so users can choose GitHub.com or
+		// Enterprise, HTTPS or SSH, and any authentication mode supported by their
+		// installed gh version. The renderer forwards the terminal protocol replies
+		// these prompts require.
+		Argv:  []string{path, "auth", "login"},
 		Title: "Connect GitHub",
 	})
 }

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -72,8 +72,8 @@ func New(harnesses HarnessCatalog, executables ports.ExecutableFinder) *Service 
 }
 
 // NewWithCommandRunner returns a Service that can also verify GitHub CLI
-// authentication. The probe discards token output and records only whether
-// gh could resolve a credential.
+// authentication. The probe discards token output and records only whether an
+// active account passes gh's authentication check.
 func NewWithCommandRunner(harnesses HarnessCatalog, executables ports.ExecutableFinder, commands ports.CommandRunner) *Service {
 	return &Service{harnesses: harnesses, executables: executables, commands: commands}
 }

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -298,7 +298,8 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 	}
 	// This advisory checks whether credentials are configured. A failed online
 	// validation must not open a login PTY for a user with a local credential.
-	if !authenticated && !s.hasGitHubAuth(ctx, path) {
+	// An empty host map is a definitive sign-out, not a validation failure.
+	if !authenticated && (len(status.Hosts) == 0 || !s.hasGitHubAuth(ctx, path)) {
 		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 	}
 	return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -126,7 +126,12 @@ func (s *Service) OpenGitHubAuthTerminal(ctx context.Context) (shellterm.ShellTe
 		return shellterm.ShellTerminal{}, apierr.Internal("GITHUB_AUTH_TERMINAL_UNAVAILABLE", "GitHub authentication terminal service is unavailable.")
 	}
 	return s.terminals.OpenCommandTerminal(ctx, shellterm.OpenCommandTerminalInput{
-		Argv:  []string{path, "auth", "login"},
+		Argv: []string{
+			path, "auth", "login",
+			"--hostname", "github.com",
+			"--git-protocol", "https",
+			"--web",
+		},
 		Title: "Connect GitHub",
 	})
 }

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -72,8 +72,7 @@ func New(harnesses HarnessCatalog, executables ports.ExecutableFinder) *Service 
 }
 
 // NewWithCommandRunner returns a Service that can also verify GitHub CLI
-// authentication. The probe discards token output and records only whether an
-// active account passes gh's authentication check.
+// credential configuration. The probe never captures token output.
 func NewWithCommandRunner(harnesses HarnessCatalog, executables ports.ExecutableFinder, commands ports.CommandRunner) *Service {
 	return &Service{harnesses: harnesses, executables: executables, commands: commands}
 }
@@ -263,46 +262,32 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	var stdout bytes.Buffer
-	if err := s.commands.Run(probeCtx, []string{path, "auth", "status", "--active", "--json", "hosts"}, &stdout, io.Discard); err != nil {
-		// `auth status --json` was added after many still-supported gh releases.
-		// A local token check preserves compatibility and avoids treating
-		// network failures as proof that the user is signed out.
-		if !s.hasGitHubAuth(ctx, path) {
-			return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
-		}
-		return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
-	}
+	err = s.commands.Run(probeCtx, []string{path, "auth", "status", "--active", "--json", "hosts"}, &stdout, io.Discard)
 	var status struct {
 		Hosts map[string][]struct {
 			Active bool   `json:"active"`
 			State  string `json:"state"`
 		} `json:"hosts"`
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
-		if !s.hasGitHubAuth(ctx, path) {
+	if err == nil && json.Unmarshal(stdout.Bytes(), &status) == nil {
+		// An empty host map is a definitive sign-out, not a validation failure.
+		if len(status.Hosts) == 0 {
 			return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 		}
-		return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
-	}
-	authenticated := false
-	for _, accounts := range status.Hosts {
-		for _, account := range accounts {
-			if account.Active && account.State == "success" {
-				authenticated = true
-				break
+		for _, accounts := range status.Hosts {
+			for _, account := range accounts {
+				if account.Active && account.State == "success" {
+					return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
+				}
 			}
 		}
-		if authenticated {
-			break
-		}
 	}
-	// This advisory checks whether credentials are configured. A failed online
-	// validation must not open a login PTY for a user with a local credential.
-	// An empty host map is a definitive sign-out, not a validation failure.
-	if !authenticated && (len(status.Hosts) == 0 || !s.hasGitHubAuth(ctx, path)) {
-		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
+	// Unsupported/malformed JSON or failed validation falls back to the local
+	// credential check so an offline user is not prompted to sign in again.
+	if s.hasGitHubAuth(ctx, path) {
+		return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
 	}
-	return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
+	return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 }
 
 func (s *Service) hasGitHubAuth(ctx context.Context, path string) bool {

--- a/backend/internal/service/systemcheck/systemcheck.go
+++ b/backend/internal/service/systemcheck/systemcheck.go
@@ -265,9 +265,9 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 	var stdout bytes.Buffer
 	if err := s.commands.Run(probeCtx, []string{path, "auth", "status", "--active", "--json", "hosts"}, &stdout, io.Discard); err != nil {
 		// `auth status --json` was added after many still-supported gh releases.
-		// Bare `auth status` preserves compatibility while still validating the
-		// credential instead of merely checking that token text exists.
-		if !s.hasGitHubAuth(probeCtx, path) {
+		// A local token check preserves compatibility and avoids treating
+		// network failures as proof that the user is signed out.
+		if !s.hasGitHubAuth(ctx, path) {
 			return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 		}
 		return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
@@ -279,7 +279,7 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 		} `json:"hosts"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
-		if !s.hasGitHubAuth(probeCtx, path) {
+		if !s.hasGitHubAuth(ctx, path) {
 			return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 		}
 		return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
@@ -296,12 +296,17 @@ func (s *Service) checkGitHubAuth(ctx context.Context) Requirement {
 			break
 		}
 	}
-	if !authenticated {
+	// This advisory checks whether credentials are configured. A failed online
+	// validation must not open a login PTY for a user with a local credential.
+	if !authenticated && !s.hasGitHubAuth(ctx, path) {
 		return Requirement{ID: "github-auth", Label: "GitHub access", Detail: detail}
 	}
 	return Requirement{ID: "github-auth", Label: "GitHub access", Satisfied: true, Detail: "GitHub CLI is signed in."}
 }
 
 func (s *Service) hasGitHubAuth(ctx context.Context, path string) bool {
-	return s.commands.Run(ctx, []string{path, "auth", "status"}, io.Discard, io.Discard) == nil
+	// Give the local credential probe its own budget, even when status timed out.
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	return s.commands.Run(probeCtx, []string{path, "auth", "token"}, io.Discard, io.Discard) == nil
 }

--- a/backend/internal/service/systemcheck/systemcheck_test.go
+++ b/backend/internal/service/systemcheck/systemcheck_test.go
@@ -22,9 +22,11 @@ type fakeHarnessCatalog struct {
 }
 
 type fakeCommandRunner struct {
-	err    error
-	stdout string
-	argv   []string
+	err     error
+	errors  []error
+	stdout  string
+	argv    []string
+	argvLog [][]string
 }
 
 type fakeGitHubAuthTerminalOpener struct {
@@ -38,7 +40,11 @@ func (f *fakeGitHubAuthTerminalOpener) OpenCommandTerminal(_ context.Context, in
 
 func (f *fakeCommandRunner) Run(_ context.Context, argv []string, stdout, _ io.Writer) error {
 	f.argv = append([]string(nil), argv...)
+	f.argvLog = append(f.argvLog, append([]string(nil), argv...))
 	_, _ = io.WriteString(stdout, f.stdout)
+	if index := len(f.argvLog) - 1; index < len(f.errors) {
+		return f.errors[index]
+	}
 	return f.err
 }
 
@@ -358,8 +364,62 @@ func TestCheckGitHubAuth_IsAdvisory(t *testing.T) {
 	if auth.Satisfied || auth.Required {
 		t.Fatalf("github-auth = %+v, want unsatisfied advisory", auth)
 	}
-	if got, want := runner.argv, []string{"/usr/bin/gh", "auth", "status", "--active", "--json", "hosts"}; !slices.Equal(got, want) {
-		t.Fatalf("auth probe argv = %#v, want %#v", got, want)
+	wantCalls := [][]string{
+		{"/usr/bin/gh", "auth", "status", "--active", "--json", "hosts"},
+		{"/usr/bin/gh", "auth", "status"},
+	}
+	if len(runner.argvLog) != len(wantCalls) {
+		t.Fatalf("auth probe argv = %#v, want %#v", runner.argvLog, wantCalls)
+	}
+	for i := range wantCalls {
+		if !slices.Equal(runner.argvLog[i], wantCalls[i]) {
+			t.Fatalf("auth probe argv = %#v, want %#v", runner.argvLog, wantCalls)
+		}
+	}
+}
+
+func TestCheckGitHubAuth_FallsBackForOlderGitHubCLI(t *testing.T) {
+	runner := &fakeCommandRunner{errors: []error{errors.New("unknown flag: --json"), nil}}
+	svc := NewWithCommandRunner(&fakeHarnessCatalog{}, executableFinderFunc(lookPathFound(map[string]string{
+		"gh": "/usr/bin/gh",
+	})), runner)
+
+	auth, err := svc.CheckGitHubAuth(context.Background())
+	if err != nil {
+		t.Fatalf("CheckGitHubAuth() error = %v", err)
+	}
+	if !auth.Satisfied {
+		t.Fatalf("github-auth = %+v, want legacy status fallback to satisfy auth", auth)
+	}
+	wantCalls := [][]string{
+		{"/usr/bin/gh", "auth", "status", "--active", "--json", "hosts"},
+		{"/usr/bin/gh", "auth", "status"},
+	}
+	if len(runner.argvLog) != len(wantCalls) {
+		t.Fatalf("auth probe argv = %#v, want %#v", runner.argvLog, wantCalls)
+	}
+	for i := range wantCalls {
+		if !slices.Equal(runner.argvLog[i], wantCalls[i]) {
+			t.Fatalf("auth probe argv = %#v, want %#v", runner.argvLog, wantCalls)
+		}
+	}
+}
+
+func TestCheckGitHubAuth_DoesNotFallbackForReportedAuthFailure(t *testing.T) {
+	runner := &fakeCommandRunner{stdout: `{"hosts":{"github.com":[{"active":true,"state":"failure"}]}}`}
+	svc := NewWithCommandRunner(&fakeHarnessCatalog{}, executableFinderFunc(lookPathFound(map[string]string{
+		"gh": "/usr/bin/gh",
+	})), runner)
+
+	auth, err := svc.CheckGitHubAuth(context.Background())
+	if err != nil {
+		t.Fatalf("CheckGitHubAuth() error = %v", err)
+	}
+	if auth.Satisfied {
+		t.Fatalf("github-auth = %+v, want reported credential failure to remain unsatisfied", auth)
+	}
+	if len(runner.argvLog) != 1 {
+		t.Fatalf("auth probe argv = %#v, want only the JSON status probe", runner.argvLog)
 	}
 }
 

--- a/backend/internal/service/systemcheck/systemcheck_test.go
+++ b/backend/internal/service/systemcheck/systemcheck_test.go
@@ -530,3 +530,15 @@ func TestCheckGitHubAuth_FallbackHasFreshDeadline(t *testing.T) {
 		t.Fatalf("auth = %+v, err = %v, calls = %d", auth, err, calls)
 	}
 }
+
+func TestCheckGitHubAuth_EmptyHostsIsSignedOut(t *testing.T) {
+	runner := &fakeCommandRunner{stdout: `{"hosts":{}}`}
+	svc := NewWithCommandRunner(&fakeHarnessCatalog{}, executableFinderFunc(lookPathFound(map[string]string{"gh": "/usr/bin/gh"})), runner)
+	auth, err := svc.CheckGitHubAuth(context.Background())
+	if err != nil || auth.Satisfied {
+		t.Fatalf("auth = %+v, err = %v", auth, err)
+	}
+	if len(runner.argvLog) != 1 {
+		t.Fatalf("unexpected token fallback: %v", runner.argvLog)
+	}
+}

--- a/backend/internal/service/systemcheck/systemcheck_test.go
+++ b/backend/internal/service/systemcheck/systemcheck_test.go
@@ -385,7 +385,12 @@ func TestOpenGitHubAuthTerminalUsesTrustedCommand(t *testing.T) {
 	if terminal.HandleID != "shellterm-github" {
 		t.Fatalf("terminal handle = %q, want shellterm-github", terminal.HandleID)
 	}
-	if got, want := opener.input.Argv, []string{"/usr/local/bin/gh", "auth", "login"}; !slices.Equal(got, want) {
+	if got, want := opener.input.Argv, []string{
+		"/usr/local/bin/gh", "auth", "login",
+		"--hostname", "github.com",
+		"--git-protocol", "https",
+		"--web",
+	}; !slices.Equal(got, want) {
 		t.Fatalf("terminal argv = %#v, want %#v", got, want)
 	}
 	if opener.input.Title != "Connect GitHub" {

--- a/backend/internal/service/systemcheck/systemcheck_test.go
+++ b/backend/internal/service/systemcheck/systemcheck_test.go
@@ -3,6 +3,7 @@ package systemcheck
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"runtime"
 	"slices"
@@ -27,6 +28,7 @@ type fakeCommandRunner struct {
 	stdout  string
 	argv    []string
 	argvLog [][]string
+	run     func(context.Context) error
 }
 
 type fakeGitHubAuthTerminalOpener struct {
@@ -38,7 +40,10 @@ func (f *fakeGitHubAuthTerminalOpener) OpenCommandTerminal(_ context.Context, in
 	return shellterm.ShellTerminal{HandleID: "shellterm-github"}, nil
 }
 
-func (f *fakeCommandRunner) Run(_ context.Context, argv []string, stdout, _ io.Writer) error {
+func (f *fakeCommandRunner) Run(ctx context.Context, argv []string, stdout, _ io.Writer) error {
+	if f.run != nil {
+		return f.run(ctx)
+	}
 	f.argv = append([]string(nil), argv...)
 	f.argvLog = append(f.argvLog, append([]string(nil), argv...))
 	_, _ = io.WriteString(stdout, f.stdout)
@@ -366,7 +371,7 @@ func TestCheckGitHubAuth_IsAdvisory(t *testing.T) {
 	}
 	wantCalls := [][]string{
 		{"/usr/bin/gh", "auth", "status", "--active", "--json", "hosts"},
-		{"/usr/bin/gh", "auth", "status"},
+		{"/usr/bin/gh", "auth", "token"},
 	}
 	if len(runner.argvLog) != len(wantCalls) {
 		t.Fatalf("auth probe argv = %#v, want %#v", runner.argvLog, wantCalls)
@@ -389,11 +394,11 @@ func TestCheckGitHubAuth_FallsBackForOlderGitHubCLI(t *testing.T) {
 		t.Fatalf("CheckGitHubAuth() error = %v", err)
 	}
 	if !auth.Satisfied {
-		t.Fatalf("github-auth = %+v, want legacy status fallback to satisfy auth", auth)
+		t.Fatalf("github-auth = %+v, want local token fallback to satisfy auth", auth)
 	}
 	wantCalls := [][]string{
 		{"/usr/bin/gh", "auth", "status", "--active", "--json", "hosts"},
-		{"/usr/bin/gh", "auth", "status"},
+		{"/usr/bin/gh", "auth", "token"},
 	}
 	if len(runner.argvLog) != len(wantCalls) {
 		t.Fatalf("auth probe argv = %#v, want %#v", runner.argvLog, wantCalls)
@@ -405,21 +410,29 @@ func TestCheckGitHubAuth_FallsBackForOlderGitHubCLI(t *testing.T) {
 	}
 }
 
-func TestCheckGitHubAuth_DoesNotFallbackForReportedAuthFailure(t *testing.T) {
-	runner := &fakeCommandRunner{stdout: `{"hosts":{"github.com":[{"active":true,"state":"failure"}]}}`}
-	svc := NewWithCommandRunner(&fakeHarnessCatalog{}, executableFinderFunc(lookPathFound(map[string]string{
-		"gh": "/usr/bin/gh",
-	})), runner)
-
-	auth, err := svc.CheckGitHubAuth(context.Background())
-	if err != nil {
-		t.Fatalf("CheckGitHubAuth() error = %v", err)
-	}
-	if auth.Satisfied {
-		t.Fatalf("github-auth = %+v, want reported credential failure to remain unsatisfied", auth)
-	}
-	if len(runner.argvLog) != 1 {
-		t.Fatalf("auth probe argv = %#v, want only the JSON status probe", runner.argvLog)
+func TestCheckGitHubAuth_LocalTokenIsFloor(t *testing.T) {
+	for _, output := range []string{
+		`{"hosts":{"github.com":[{"active":true,"state":"error","error":"proxyconnect tcp: connection refused"}]}}`,
+		`{"hosts":{"github.com":[{"active":true,"state":"failure"}]}}`,
+		`invalid json`,
+	} {
+		for _, hasToken := range []bool{true, false} {
+			t.Run(output+fmt.Sprint(hasToken), func(t *testing.T) {
+				var tokenErr error
+				if !hasToken {
+					tokenErr = errors.New("no local token")
+				}
+				runner := &fakeCommandRunner{stdout: output, errors: []error{nil, tokenErr}}
+				svc := NewWithCommandRunner(&fakeHarnessCatalog{}, executableFinderFunc(lookPathFound(map[string]string{"gh": "/usr/bin/gh"})), runner)
+				auth, err := svc.CheckGitHubAuth(context.Background())
+				if err != nil || auth.Satisfied != hasToken {
+					t.Fatalf("auth = %+v, err = %v, want satisfied=%v", auth, err, hasToken)
+				}
+				if len(runner.argvLog) != 2 || !slices.Equal(runner.argvLog[1], []string{"/usr/bin/gh", "auth", "token"}) {
+					t.Fatalf("calls = %v", runner.argvLog)
+				}
+			})
+		}
 	}
 }
 
@@ -491,4 +504,29 @@ func requirementByID(t *testing.T, report Report, id string) Requirement {
 	}
 	t.Fatalf("no requirement with id %q in %+v", id, report.Requirements)
 	return Requirement{}
+}
+
+// The first subprocess consumes its entire budget; fallback must still be able
+// to read credentials, without extending a caller's own cancellation deadline.
+func TestCheckGitHubAuth_FallbackHasFreshDeadline(t *testing.T) {
+	calls := 0
+	runner := &fakeCommandRunner{run: func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("fallback started with expired context: %v", err)
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("fallback has no deadline")
+		}
+		return nil
+	}}
+	svc := NewWithCommandRunner(&fakeHarnessCatalog{}, executableFinderFunc(lookPathFound(map[string]string{"gh": "/usr/bin/gh"})), runner)
+	auth, err := svc.CheckGitHubAuth(context.Background())
+	if err != nil || !auth.Satisfied || calls != 2 {
+		t.Fatalf("auth = %+v, err = %v, calls = %d", auth, err, calls)
+	}
 }

--- a/backend/internal/service/systemcheck/systemcheck_test.go
+++ b/backend/internal/service/systemcheck/systemcheck_test.go
@@ -22,8 +22,9 @@ type fakeHarnessCatalog struct {
 }
 
 type fakeCommandRunner struct {
-	err  error
-	argv []string
+	err    error
+	stdout string
+	argv   []string
 }
 
 type fakeGitHubAuthTerminalOpener struct {
@@ -35,8 +36,9 @@ func (f *fakeGitHubAuthTerminalOpener) OpenCommandTerminal(_ context.Context, in
 	return shellterm.ShellTerminal{HandleID: "shellterm-github"}, nil
 }
 
-func (f *fakeCommandRunner) Run(_ context.Context, argv []string, _, _ io.Writer) error {
+func (f *fakeCommandRunner) Run(_ context.Context, argv []string, stdout, _ io.Writer) error {
 	f.argv = append([]string(nil), argv...)
+	_, _ = io.WriteString(stdout, f.stdout)
 	return f.err
 }
 
@@ -67,7 +69,7 @@ func TestCheck_AllSatisfied(t *testing.T) {
 		"git":  "/usr/bin/git",
 		"tmux": "/usr/bin/tmux",
 		"gh":   "/usr/bin/gh",
-	})), &fakeCommandRunner{})
+	})), &fakeCommandRunner{stdout: `{"hosts":{"github.com":[{"active":true,"state":"success"}]}}`})
 
 	report, err := svc.Check(context.Background())
 	if err != nil {
@@ -356,8 +358,23 @@ func TestCheckGitHubAuth_IsAdvisory(t *testing.T) {
 	if auth.Satisfied || auth.Required {
 		t.Fatalf("github-auth = %+v, want unsatisfied advisory", auth)
 	}
-	if got, want := runner.argv, []string{"/usr/bin/gh", "auth", "token"}; !slices.Equal(got, want) {
+	if got, want := runner.argv, []string{"/usr/bin/gh", "auth", "status", "--active", "--json", "hosts"}; !slices.Equal(got, want) {
 		t.Fatalf("auth probe argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestCheckGitHubAuth_AcceptsActiveEnterpriseHost(t *testing.T) {
+	runner := &fakeCommandRunner{stdout: `{"hosts":{"github.example.com":[{"active":true,"state":"success"}]}}`}
+	svc := NewWithCommandRunner(&fakeHarnessCatalog{}, executableFinderFunc(lookPathFound(map[string]string{
+		"gh": "/usr/bin/gh",
+	})), runner)
+
+	auth, err := svc.CheckGitHubAuth(context.Background())
+	if err != nil {
+		t.Fatalf("CheckGitHubAuth() error = %v", err)
+	}
+	if !auth.Satisfied {
+		t.Fatalf("github-auth = %+v, want satisfied for active Enterprise host", auth)
 	}
 }
 

--- a/backend/internal/service/systemcheck/systemcheck_test.go
+++ b/backend/internal/service/systemcheck/systemcheck_test.go
@@ -385,12 +385,7 @@ func TestOpenGitHubAuthTerminalUsesTrustedCommand(t *testing.T) {
 	if terminal.HandleID != "shellterm-github" {
 		t.Fatalf("terminal handle = %q, want shellterm-github", terminal.HandleID)
 	}
-	if got, want := opener.input.Argv, []string{
-		"/usr/local/bin/gh", "auth", "login",
-		"--hostname", "github.com",
-		"--git-protocol", "https",
-		"--web",
-	}; !slices.Equal(got, want) {
+	if got, want := opener.input.Argv, []string{"/usr/local/bin/gh", "auth", "login"}; !slices.Equal(got, want) {
 		t.Fatalf("terminal argv = %#v, want %#v", got, want)
 	}
 	if opener.input.Title != "Connect GitHub" {

--- a/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
@@ -8,6 +8,7 @@ const routeMocks = vi.hoisted(() => ({
 	requirements: [] as Array<{ id: string; label: string; satisfied: boolean; required: boolean; detail: string }>,
 	authRequirement: undefined as { id: string; label: string; satisfied: boolean; required: boolean; detail: string } | undefined,
 	startGitHubAuth: vi.fn(),
+	markAutoLoginOffered: vi.fn(),
 	closeTerminal: vi.fn(),
 }));
 
@@ -23,6 +24,7 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 vi.mock("../hooks/useSystemRequirementsGate", () => ({
 	useSystemRequirementsGate: () => ({ blocked: false, requirements: routeMocks.requirements, query: { refetch: vi.fn() } }),
 	useGitHubAuthRequirement: () => ({ data: routeMocks.authRequirement, isFetching: false, refetch: vi.fn() }),
+	useGitHubAuthAutoLoginOffered: () => ({ offered: false, markOffered: routeMocks.markAutoLoginOffered }),
 	useGitHubAuthTerminal: () => ({ data: null, clear: vi.fn() }),
 	useStartGitHubAuthTerminal: () => ({ mutate: routeMocks.startGitHubAuth, isPending: false, isError: false }),
 }));
@@ -58,6 +60,7 @@ beforeEach(() => {
 	routeMocks.requirements = [];
 	routeMocks.authRequirement = undefined;
 	routeMocks.startGitHubAuth.mockReset();
+	routeMocks.markAutoLoginOffered.mockReset();
 	routeMocks.closeTerminal.mockReset();
 });
 

--- a/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-home.test.tsx
@@ -100,6 +100,11 @@ describe("shell index route", () => {
 
 		expect(screen.getByText("Connect GitHub for pull requests")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Sign in with GitHub" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /Scratch/ }).compareDocumentPosition(
+				screen.getByText("Connect GitHub for pull requests"),
+			) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
 	});
 
 	it("opens a project from the recent-project list", async () => {

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -249,7 +249,7 @@ describe("global board first launch", () => {
 		expect(screen.queryByText("Board")).not.toBeInTheDocument();
 	});
 
-	it("automatically opens and focuses GitHub sign-in when gh is signed out", async () => {
+	it("automatically opens GitHub sign-in without requesting focus when gh is signed out", async () => {
 		respondWith([], [], false);
 		renderBoard(
 			<StrictMode>
@@ -264,7 +264,7 @@ describe("global board first launch", () => {
 		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "false");
 		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("attached"));
 		expect(screen.queryByRole("button", { name: "Check again" })).not.toBeInTheDocument();
-		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "true");
+		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "false");
 	});
 
 	it("does not open GitHub sign-in when the initial auth check succeeds", async () => {
@@ -311,6 +311,8 @@ describe("global board first launch", () => {
 			params: { path: { handleId: "shellterm-github" } },
 		}));
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("attached"));
+		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "true");
 	});
 
 	it("keeps sign-in available when GitHub CLI readiness is unknown", async () => {
@@ -322,6 +324,11 @@ describe("global board first launch", () => {
 		expect(screen.getByRole("button", { name: "Check again" })).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Get GitHub CLI" })).not.toBeInTheDocument();
 		expect(postMock).not.toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
+
+		await userEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
+		await screen.findByTestId("github-auth-terminal");
+		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("attached"));
+		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "true");
 	});
 
 	it("opens the native folder picker from the Project card", async () => {

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render as rtlRender, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
+import { StrictMode, type ReactNode } from "react";
 import { TooltipProvider } from "../../components/ui/tooltip";
 
 function render(ui: ReactNode) {
@@ -40,7 +40,9 @@ vi.mock("../../lib/api-client", () => ({
 }));
 
 vi.mock("../../components/TerminalPane", () => ({
-	TerminalPane: () => <div data-testid="terminal-pane" />,
+	TerminalPane: ({ focusRequested }: { focusRequested?: boolean }) => (
+		<div data-focus-requested={focusRequested ? "true" : "false"} data-testid="terminal-pane" />
+	),
 }));
 
 vi.mock("../../lib/bridge", () => ({
@@ -74,7 +76,7 @@ function respondWith(
 	projects: Project[],
 	sessions: Session[],
 	githubAuthenticated = true,
-	githubCliSatisfied: boolean | undefined = true,
+	githubCliSatisfied: boolean | null = true,
 ) {
 	getMock.mockImplementation(async (url: string) => {
 		if (url === "/api/v1/projects") return { data: { projects }, error: undefined };
@@ -87,7 +89,7 @@ function respondWith(
 						{ id: "git", label: "git", satisfied: true, required: true, detail: "/usr/bin/git" },
 						{ id: "tmux", label: "tmux", satisfied: true, required: true, detail: "/usr/bin/tmux" },
 						{ id: "harness", label: "agent harness", satisfied: true, required: true, detail: "Claude Code" },
-						...(githubCliSatisfied === undefined
+						...(githubCliSatisfied === null
 							? []
 							: [{ id: "gh", label: "gh", satisfied: githubCliSatisfied, required: false, detail: githubCliSatisfied ? "/usr/bin/gh" : "Not found" }]),
 					],
@@ -245,24 +247,37 @@ describe("global board first launch", () => {
 		expect(screen.queryByText("Board")).not.toBeInTheDocument();
 	});
 
-	it("shows GitHub sign-in guidance during onboarding when gh is signed out", async () => {
+	it("automatically opens and focuses GitHub sign-in when gh is signed out", async () => {
 		respondWith([], [], false);
-		renderBoard(<SessionsBoard />);
+		renderBoard(
+			<StrictMode>
+				<SessionsBoard />
+			</StrictMode>,
+		);
 
 		expect(await screen.findByText("Connect GitHub for pull requests")).toBeInTheDocument();
-		await userEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
-		await waitFor(() => expect(postMock).toHaveBeenCalledWith("/api/v1/system/github-auth/terminal"));
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock).toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 		expect(await screen.findByTestId("github-auth-terminal")).toBeInTheDocument();
-		expect(screen.getByTestId("terminal-pane")).toBeInTheDocument();
+		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "true");
+	});
+
+	it("does not open GitHub sign-in when the initial auth check succeeds", async () => {
+		respondWith([], []);
+		renderBoard(<SessionsBoard />);
+
+		expect(await screen.findByText("Add a project")).toBeInTheDocument();
+		expect(postMock).not.toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 	});
 
 	it("keeps sign-in available when GitHub CLI readiness is unknown", async () => {
-		respondWith([], [], false, undefined);
+		respondWith([], [], false, null);
 		renderBoard(<SessionsBoard />);
 
 		expect(await screen.findByText("Connect GitHub for pull requests")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Sign in with GitHub" })).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Get GitHub CLI" })).not.toBeInTheDocument();
+		expect(postMock).not.toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 	});
 
 	it("opens the native folder picker from the Project card", async () => {

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -275,6 +275,25 @@ describe("global board first launch", () => {
 		expect(postMock).not.toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 	});
 
+	it("respects a dismissed automatic login after the notice remounts", async () => {
+		respondWith([], [], false);
+		const view = renderBoard(<SessionsBoard />);
+		await screen.findByTestId("github-auth-terminal");
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+
+		await userEvent.click(screen.getByRole("button", { name: "Close" }));
+		await waitFor(() => expect(screen.queryByTestId("github-auth-terminal")).not.toBeInTheDocument());
+		view.unmount();
+		render(
+			<QueryClientProvider client={lastQueryClient!}>
+				<ShellProvider value={lastShell!}><SessionsBoard /></ShellProvider>
+			</QueryClientProvider>,
+		);
+
+		expect(await screen.findByText("Connect GitHub for pull requests")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("offers recovery instead of treating an exited login terminal as active", async () => {
 		respondWith([], [], false);
 		renderBoard(<SessionsBoard />);

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -41,7 +41,7 @@ vi.mock("../../lib/api-client", () => ({
 }));
 
 vi.mock("../../components/TerminalPane", () => ({
-	TerminalPane: (props: { focusRequested?: boolean; onTerminalStateChange?: (state: "attached") => void }) => {
+	TerminalPane: (props: { focusRequested?: boolean; onTerminalStateChange?: (state: "attached" | "exited") => void }) => {
 		terminalPanePropsMock(props);
 		return <div data-focus-requested={props.focusRequested ? "true" : "false"} data-testid="terminal-pane" />;
 	},
@@ -261,9 +261,9 @@ describe("global board first launch", () => {
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
 		expect(postMock).toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 		expect(await screen.findByTestId("github-auth-terminal")).toBeInTheDocument();
-		expect(screen.queryByRole("button", { name: "Check again" })).not.toBeInTheDocument();
 		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "false");
 		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("attached"));
+		expect(screen.queryByRole("button", { name: "Check again" })).not.toBeInTheDocument();
 		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "true");
 	});
 
@@ -273,6 +273,25 @@ describe("global board first launch", () => {
 
 		expect(await screen.findByText("Add a project")).toBeInTheDocument();
 		expect(postMock).not.toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
+	});
+
+	it("offers recovery instead of treating an exited login terminal as active", async () => {
+		respondWith([], [], false);
+		renderBoard(<SessionsBoard />);
+		await screen.findByTestId("github-auth-terminal");
+
+		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("attached"));
+		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("exited"));
+
+		expect(await screen.findByText("Sign-in stopped before GitHub was connected")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+		expect(screen.getByRole("button", { name: "Check again" })).toBeEnabled();
+
+		await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+		await waitFor(() => expect(deleteMock).toHaveBeenCalledWith("/api/v1/shell-terminals/{handleId}", {
+			params: { path: { handleId: "shellterm-github" } },
+		}));
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
 	});
 
 	it("keeps sign-in available when GitHub CLI readiness is unknown", async () => {

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -36,6 +36,7 @@ vi.mock("../../lib/spawn-orchestrator", () => ({
 
 vi.mock("../../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: postMock, DELETE: deleteMock },
+	apiErrorCode: () => undefined,
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
 	hasTrustedApiBaseUrl: () => true,
 }));
@@ -317,6 +318,23 @@ describe("global board first launch", () => {
 		);
 
 		expect(await screen.findByText("Connect GitHub for pull requests")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+	});
+
+	it.each(["Close", "Try again"])("retains the login handle when %s cannot close its PTY", async (action) => {
+		respondWith([], [], false);
+		renderBoard(<SessionsBoard />);
+		await screen.findByTestId("github-auth-terminal");
+		if (action === "Try again") {
+			act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("exited"));
+		}
+		deleteMock.mockResolvedValue({ error: new Error("Close failed") });
+		await userEvent.click(await screen.findByRole("button", { name: action }));
+		await waitFor(() => {
+			expect(deleteMock).toHaveBeenCalledTimes(1);
+			expect(lastQueryClient!.isMutating()).toBe(0);
+		});
+		expect(screen.getByTestId("github-auth-terminal")).toBeInTheDocument();
 		expect(postMock).toHaveBeenCalledTimes(1);
 	});
 

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render as rtlRender, screen, waitFor } from "@testing-library/react";
+import { act, render as rtlRender, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StrictMode, type ReactNode } from "react";
@@ -17,7 +17,7 @@ function render(ui: ReactNode) {
 // first-run states, mocking only the HTTP client, the router, and the native
 // folder picker: an empty daemon shows the import chooser (no column shells), a
 // fresh project shows the task invitation, and any session brings the columns back.
-const { getMock, postMock, deleteMock, navigateMock, chooseDirectoryMock, clipboardWriteMock, spawnOrchestratorMock } = vi.hoisted(() => ({
+const { getMock, postMock, deleteMock, navigateMock, chooseDirectoryMock, clipboardWriteMock, spawnOrchestratorMock, terminalPanePropsMock } = vi.hoisted(() => ({
 	getMock: vi.fn(),
 	postMock: vi.fn(),
 	deleteMock: vi.fn(),
@@ -25,6 +25,7 @@ const { getMock, postMock, deleteMock, navigateMock, chooseDirectoryMock, clipbo
 	chooseDirectoryMock: vi.fn(),
 	clipboardWriteMock: vi.fn(),
 	spawnOrchestratorMock: vi.fn(),
+	terminalPanePropsMock: vi.fn(),
 }));
 
 vi.mock("../../lib/spawn-orchestrator", () => ({
@@ -40,9 +41,10 @@ vi.mock("../../lib/api-client", () => ({
 }));
 
 vi.mock("../../components/TerminalPane", () => ({
-	TerminalPane: ({ focusRequested }: { focusRequested?: boolean }) => (
-		<div data-focus-requested={focusRequested ? "true" : "false"} data-testid="terminal-pane" />
-	),
+	TerminalPane: (props: { focusRequested?: boolean; onTerminalStateChange?: (state: "attached") => void }) => {
+		terminalPanePropsMock(props);
+		return <div data-focus-requested={props.focusRequested ? "true" : "false"} data-testid="terminal-pane" />;
+	},
 }));
 
 vi.mock("../../lib/bridge", () => ({
@@ -259,6 +261,8 @@ describe("global board first launch", () => {
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
 		expect(postMock).toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 		expect(await screen.findByTestId("github-auth-terminal")).toBeInTheDocument();
+		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "false");
+		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("attached"));
 		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "true");
 	});
 

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -267,6 +267,32 @@ describe("global board first launch", () => {
 		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "false");
 	});
 
+	it("adopts a daemon-owned login after renderer state is lost", async () => {
+		respondWith([], [], false);
+		const originalGet = getMock.getMockImplementation()!;
+		getMock.mockImplementation(async (url: string) => url === "/api/v1/shell-terminals"
+			? { data: { shellTerminals: [{ handleId: "surviving-login", title: "Connect GitHub", workingDir: "/tmp/auth", createdAt: "2026-07-04T10:00:00Z" }] } }
+			: originalGet(url));
+		const first = renderBoard(<SessionsBoard />);
+		await waitFor(() => expect(terminalPanePropsMock).toHaveBeenCalledWith(expect.objectContaining({ terminalTarget: expect.objectContaining({ handleId: "surviving-login" }) })));
+		first.unmount();
+		terminalPanePropsMock.mockClear();
+		renderBoard(<SessionsBoard />);
+		await waitFor(() => expect(terminalPanePropsMock).toHaveBeenCalledWith(expect.objectContaining({ terminalTarget: expect.objectContaining({ handleId: "surviving-login" }) })));
+		expect(postMock).not.toHaveBeenCalled();
+	});
+
+	it("does not spawn when daemon terminal reconciliation fails", async () => {
+		respondWith([], [], false);
+		const originalGet = getMock.getMockImplementation()!;
+		getMock.mockImplementation(async (url: string) => url === "/api/v1/shell-terminals"
+			? { error: new Error("Terminal list unavailable") }
+			: originalGet(url));
+		renderBoard(<SessionsBoard />);
+		expect(await screen.findByRole("alert", {}, { timeout: 5000 })).toHaveTextContent("Terminal list unavailable");
+		expect(postMock).not.toHaveBeenCalled();
+	});
+
 	it("does not open GitHub sign-in when the initial auth check succeeds", async () => {
 		respondWith([], []);
 		renderBoard(<SessionsBoard />);

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -261,6 +261,7 @@ describe("global board first launch", () => {
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
 		expect(postMock).toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 		expect(await screen.findByTestId("github-auth-terminal")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Check again" })).not.toBeInTheDocument();
 		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "false");
 		act(() => terminalPanePropsMock.mock.lastCall?.[0].onTerminalStateChange?.("attached"));
 		expect(screen.getByTestId("terminal-pane")).toHaveAttribute("data-focus-requested", "true");
@@ -280,6 +281,7 @@ describe("global board first launch", () => {
 
 		expect(await screen.findByText("Connect GitHub for pull requests")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Sign in with GitHub" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Check again" })).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Get GitHub CLI" })).not.toBeInTheDocument();
 		expect(postMock).not.toHaveBeenCalledWith("/api/v1/system/github-auth/terminal");
 	});

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -39,6 +39,7 @@ export function GitHubOnboardingNotice() {
 	const refetchAuthRef = useRef(authQuery.refetch);
 	const exitCheckedTerminalRef = useRef<string | null>(null);
 	const completedTerminalRef = useRef<string | null>(null);
+	const [loginFocusRequested, setLoginFocusRequested] = useState(false);
 	const [manualCheckPending, setManualCheckPending] = useState(false);
 	const gh = requirements.find((requirement) => requirement.id === "gh");
 	const auth = authQuery.data;
@@ -78,11 +79,13 @@ export function GitHubOnboardingNotice() {
 	if (!auth || auth.satisfied) return null;
 
 	const openLogin = () => {
+		setLoginFocusRequested(true);
 		autoLogin.markOffered();
 		startLogin.mutate();
 	};
 	const retryLogin = () => {
 		if (!terminal) return;
+		setLoginFocusRequested(true);
 		closeTerminal(terminal.handleId, {
 			onSettled: () => {
 				terminalQuery.clear();
@@ -100,6 +103,7 @@ export function GitHubOnboardingNotice() {
 		}
 	};
 	const closeLogin = () => {
+		setLoginFocusRequested(false);
 		if (!terminal) return;
 		closeTerminal(terminal.handleId, { onSettled: terminalQuery.clear });
 	};
@@ -160,7 +164,7 @@ export function GitHubOnboardingNotice() {
 									</TopbarButton>
 								</div>
 								<div className="h-[240px] min-h-0">
-									<TerminalPane daemonReady={shell ? shell.daemonStatus.state === "ready" : true} focusRequested={terminalState === "attached"} fontSize={12} onTerminalStateChange={handleTerminalState} terminalTarget={{ kind: "shell", handleId: terminal.handleId, generation: terminal.createdAt, title: terminal.title }} theme={theme} />
+									<TerminalPane daemonReady={shell ? shell.daemonStatus.state === "ready" : true} focusRequested={loginFocusRequested && terminalState === "attached"} fontSize={12} onTerminalStateChange={handleTerminalState} terminalTarget={{ kind: "shell", handleId: terminal.handleId, generation: terminal.createdAt, title: terminal.title }} theme={theme} />
 								</div>
 							</div>
 						) : null}

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -11,7 +11,6 @@ import { TerminalPane } from "./TerminalPane";
 import { TopbarButton } from "./TopbarButton";
 
 const GITHUB_CLI_INSTALL_URL = "https://cli.github.com/";
-const automaticallyChecked = new Set<string>();
 
 /** Onboarding advisory. GitHub is not required for local work, but surfacing
  * missing auth before task creation prevents a late PR-creation failure inside
@@ -21,18 +20,25 @@ export function GitHubOnboardingNotice() {
 	const gate = useSystemRequirementsGate();
 	const startLogin = useStartGitHubAuthTerminal();
 	const terminalQuery = useGitHubAuthTerminal();
-	const authQuery = useGitHubAuthRequirement(Boolean(terminalQuery.data));
+	const terminal = terminalQuery.data;
+	const [terminalStatus, setTerminalStatus] = useState<{ handleId: string | null; state: TerminalSessionState }>({
+		handleId: null,
+		state: "idle",
+	});
+	const terminalState = terminalStatus.handleId === terminal?.handleId ? terminalStatus.state : "idle";
+	const loginRunning = Boolean(terminal && (terminalState === "connecting" || terminalState === "attached" || terminalState === "reattaching"));
+	const loginEnded = Boolean(terminal && (terminalState === "exited" || terminalState === "error"));
+	const authQuery = useGitHubAuthRequirement(loginRunning);
 	const { mutate: closeTerminal } = useCloseShellTerminal();
 	const showGlobalToast = useUiStore((state) => state.showGlobalToast);
 	const theme = useResolvedTheme();
 	const shell = useShellMaybe();
 	const requirements = gate.requirements ?? [];
-	const terminal = terminalQuery.data;
 	const terminalRef = useRef(terminal);
 	const refetchAuthRef = useRef(authQuery.refetch);
 	const automaticLoginStartedRef = useRef(false);
+	const exitCheckedTerminalRef = useRef<string | null>(null);
 	const completedTerminalRef = useRef<string | null>(null);
-	const [terminalState, setTerminalState] = useState<TerminalSessionState>("idle");
 	const [manualCheckPending, setManualCheckPending] = useState(false);
 	const gh = requirements.find((requirement) => requirement.id === "gh");
 	const auth = authQuery.data;
@@ -40,11 +46,11 @@ export function GitHubOnboardingNotice() {
 	terminalRef.current = terminal;
 	refetchAuthRef.current = authQuery.refetch;
 	const handleTerminalState = useCallback((state: TerminalSessionState) => {
-		setTerminalState(state);
 		const active = terminalRef.current;
+		setTerminalStatus({ handleId: active?.handleId ?? null, state });
 		if (!active || (state !== "exited" && state !== "error")) return;
-		if (automaticallyChecked.has(active.handleId)) return;
-		automaticallyChecked.add(active.handleId);
+		if (exitCheckedTerminalRef.current === active.handleId) return;
+		exitCheckedTerminalRef.current = active.handleId;
 		void refetchAuthRef.current();
 	}, []);
 	useEffect(() => {
@@ -74,6 +80,15 @@ export function GitHubOnboardingNotice() {
 	const openLogin = () => {
 		startLogin.mutate();
 	};
+	const retryLogin = () => {
+		if (!terminal) return;
+		closeTerminal(terminal.handleId, {
+			onSettled: () => {
+				terminalQuery.clear();
+				startLogin.mutate();
+			},
+		});
+	};
 
 	const checkAgain = async () => {
 		setManualCheckPending(true);
@@ -102,8 +117,12 @@ export function GitHubOnboardingNotice() {
 						</p>
 						<div className="mt-2 flex flex-wrap items-center gap-2">
 							<TopbarButton
-								disabled={!cliMissing && (startLogin.isPending || Boolean(terminal))}
-								onClick={() => cliMissing ? void aoBridge.app.openExternal(GITHUB_CLI_INSTALL_URL) : openLogin()}
+								disabled={!cliMissing && (startLogin.isPending || Boolean(terminal && !loginEnded))}
+								onClick={() => cliMissing
+									? void aoBridge.app.openExternal(GITHUB_CLI_INSTALL_URL)
+									: loginEnded
+										? retryLogin()
+										: openLogin()}
 								variant="primary"
 							>
 								{cliMissing ? null : <TerminalSquare className="size-icon-sm" aria-hidden="true" />}
@@ -111,9 +130,11 @@ export function GitHubOnboardingNotice() {
 									? t("startup.openGithubCliDocs")
 									: startLogin.isPending
 										? t("startup.githubLoginStarting")
-										: t("startup.githubLogin")}
+										: loginEnded
+											? t("startup.githubLoginTryAgain")
+											: t("startup.githubLogin")}
 							</TopbarButton>
-							{terminal ? null : (
+							{loginRunning ? null : (
 								<TopbarButton
 									disabled={manualCheckPending}
 									onClick={() => void checkAgain()}
@@ -129,7 +150,9 @@ export function GitHubOnboardingNotice() {
 								<div className="flex min-h-9 items-center justify-between gap-3 border-b border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-modal)] px-3 py-1.5">
 									<div className="min-w-0">
 										<p className="truncate text-xs font-medium text-[var(--color-text-import-title)]">{terminal.title}</p>
-										<p className="truncate text-[11px] text-[var(--color-text-import-muted)]">{t("startup.githubLoginRunning")}</p>
+										<p className="truncate text-[11px] text-[var(--color-text-import-muted)]">
+											{t(loginEnded ? "startup.githubLoginStopped" : "startup.githubLoginRunning")}
+										</p>
 									</div>
 									<TopbarButton aria-label={t("common.close")} className="!size-7 shrink-0" onClick={closeLogin} variant="icon">
 										<X className="size-4" aria-hidden="true" />

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TerminalSessionState } from "../hooks/useTerminalSession";
 import { useCloseShellTerminal } from "../hooks/useShellTerminals";
-import { useGitHubAuthRequirement, useGitHubAuthTerminal, useStartGitHubAuthTerminal, useSystemRequirementsGate } from "../hooks/useSystemRequirementsGate";
+import { useGitHubAuthAutoLoginOffered, useGitHubAuthRequirement, useGitHubAuthTerminal, useStartGitHubAuthTerminal, useSystemRequirementsGate } from "../hooks/useSystemRequirementsGate";
 import { aoBridge } from "../lib/bridge";
 import { useShellMaybe } from "../lib/shell-context";
 import { useResolvedTheme, useUiStore } from "../stores/ui-store";
@@ -19,6 +19,7 @@ export function GitHubOnboardingNotice() {
 	const { t } = useTranslation();
 	const gate = useSystemRequirementsGate();
 	const startLogin = useStartGitHubAuthTerminal();
+	const autoLogin = useGitHubAuthAutoLoginOffered();
 	const terminalQuery = useGitHubAuthTerminal();
 	const terminal = terminalQuery.data;
 	const [terminalStatus, setTerminalStatus] = useState<{ handleId: string | null; state: TerminalSessionState }>({
@@ -36,7 +37,6 @@ export function GitHubOnboardingNotice() {
 	const requirements = gate.requirements ?? [];
 	const terminalRef = useRef(terminal);
 	const refetchAuthRef = useRef(authQuery.refetch);
-	const automaticLoginStartedRef = useRef(false);
 	const exitCheckedTerminalRef = useRef<string | null>(null);
 	const completedTerminalRef = useRef<string | null>(null);
 	const [manualCheckPending, setManualCheckPending] = useState(false);
@@ -67,17 +67,18 @@ export function GitHubOnboardingNotice() {
 			gh?.satisfied !== true ||
 			terminal ||
 			startLogin.isPending ||
-			automaticLoginStartedRef.current
+			autoLogin.offered
 		) {
 			return;
 		}
-		automaticLoginStartedRef.current = true;
+		autoLogin.markOffered();
 		startLogin.mutate();
-	}, [auth, gh?.satisfied, startLogin.isPending, startLogin.mutate, terminal]);
+	}, [auth, autoLogin.markOffered, autoLogin.offered, gh?.satisfied, startLogin.isPending, startLogin.mutate, terminal]);
 
 	if (!auth || auth.satisfied) return null;
 
 	const openLogin = () => {
+		autoLogin.markOffered();
 		startLogin.mutate();
 	};
 	const retryLogin = () => {

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -59,7 +59,7 @@ export function GitHubOnboardingNotice() {
 		if (completedTerminalRef.current === terminal.handleId) return;
 		completedTerminalRef.current = terminal.handleId;
 		showGlobalToast(t("startup.githubConnected"));
-		closeTerminal(terminal.handleId, { onSettled: terminalQuery.clear });
+		closeTerminal(terminal.handleId, { onSuccess: terminalQuery.clear });
 	}, [auth?.satisfied, closeTerminal, showGlobalToast, t, terminal, terminalQuery.clear]);
 	useEffect(() => {
 		if (
@@ -87,7 +87,7 @@ export function GitHubOnboardingNotice() {
 		if (!terminal) return;
 		setLoginFocusRequested(true);
 		closeTerminal(terminal.handleId, {
-			onSettled: () => {
+			onSuccess: () => {
 				terminalQuery.clear();
 				startLogin.mutate();
 			},
@@ -105,7 +105,7 @@ export function GitHubOnboardingNotice() {
 	const closeLogin = () => {
 		setLoginFocusRequested(false);
 		if (!terminal) return;
-		closeTerminal(terminal.handleId, { onSettled: terminalQuery.clear });
+		closeTerminal(terminal.handleId, { onSuccess: terminalQuery.clear });
 	};
 	const cliMissing = gh?.satisfied === false;
 	return (

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -28,6 +28,7 @@ export function GitHubOnboardingNotice() {
 	const terminal = terminalQuery.data;
 	const terminalRef = useRef(terminal);
 	const refetchAuthRef = useRef(authQuery.refetch);
+	const automaticLoginStartedRef = useRef(false);
 	const gh = requirements.find((requirement) => requirement.id === "gh");
 	const auth = authQuery.data;
 
@@ -44,6 +45,20 @@ export function GitHubOnboardingNotice() {
 		if (!auth?.satisfied || !terminal) return;
 		closeTerminal(terminal.handleId, { onSettled: terminalQuery.clear });
 	}, [auth?.satisfied, closeTerminal, terminal, terminalQuery.clear]);
+	useEffect(() => {
+		if (
+			!auth ||
+			auth.satisfied ||
+			gh?.satisfied !== true ||
+			terminal ||
+			startLogin.isPending ||
+			automaticLoginStartedRef.current
+		) {
+			return;
+		}
+		automaticLoginStartedRef.current = true;
+		startLogin.mutate();
+	}, [auth, gh?.satisfied, startLogin.isPending, startLogin.mutate, terminal]);
 
 	if (!auth || auth.satisfied) return null;
 
@@ -106,7 +121,7 @@ export function GitHubOnboardingNotice() {
 									</button>
 								</div>
 								<div className="h-[240px] min-h-0">
-									<TerminalPane daemonReady={shell ? shell.daemonStatus.state === "ready" : true} fontSize={12} onTerminalStateChange={handleTerminalState} terminalTarget={{ kind: "shell", handleId: terminal.handleId, generation: terminal.createdAt, title: terminal.title }} theme={theme} />
+									<TerminalPane daemonReady={shell ? shell.daemonStatus.state === "ready" : true} focusRequested fontSize={12} onTerminalStateChange={handleTerminalState} terminalTarget={{ kind: "shell", handleId: terminal.handleId, generation: terminal.createdAt, title: terminal.title }} theme={theme} />
 								</div>
 							</div>
 						) : null}

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -1,5 +1,5 @@
 import { GitPullRequest, TerminalSquare, X } from "lucide-react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TerminalSessionState } from "../hooks/useTerminalSession";
 import { useCloseShellTerminal } from "../hooks/useShellTerminals";
@@ -8,6 +8,7 @@ import { aoBridge } from "../lib/bridge";
 import { useShellMaybe } from "../lib/shell-context";
 import { useResolvedTheme } from "../stores/ui-store";
 import { TerminalPane } from "./TerminalPane";
+import { TopbarButton } from "./TopbarButton";
 
 const GITHUB_CLI_INSTALL_URL = "https://cli.github.com/";
 const automaticallyChecked = new Set<string>();
@@ -29,12 +30,14 @@ export function GitHubOnboardingNotice() {
 	const terminalRef = useRef(terminal);
 	const refetchAuthRef = useRef(authQuery.refetch);
 	const automaticLoginStartedRef = useRef(false);
+	const [terminalState, setTerminalState] = useState<TerminalSessionState>("idle");
 	const gh = requirements.find((requirement) => requirement.id === "gh");
 	const auth = authQuery.data;
 
 	terminalRef.current = terminal;
 	refetchAuthRef.current = authQuery.refetch;
 	const handleTerminalState = useCallback((state: TerminalSessionState) => {
+		setTerminalState(state);
 		const active = terminalRef.current;
 		if (!active || (state !== "exited" && state !== "error")) return;
 		if (automaticallyChecked.has(active.handleId)) return;
@@ -77,20 +80,21 @@ export function GitHubOnboardingNotice() {
 	const checking = authQuery.isFetching;
 	return (
 		<div className="flex w-full justify-center px-3">
-			<div className="w-full max-w-[620px] rounded-lg border border-warning/30 bg-warning/10 px-4 py-3" role="status">
+			<div className="w-full max-w-[620px] rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-4 py-4" role="status">
 				<div className="flex items-start gap-3">
-					<GitPullRequest className="mt-0.5 size-5 shrink-0 text-warning" aria-hidden="true" />
+					<span className="grid size-9 shrink-0 place-items-center rounded-lg bg-[var(--color-bg-import-chip)] text-[var(--color-text-import-muted)]">
+						<GitPullRequest className="size-4" aria-hidden="true" />
+					</span>
 					<div className="min-w-0 flex-1">
-						<p className="text-[14px] font-medium text-foreground">{t("startup.githubSetupTitle")}</p>
-						<p className="mt-0.5 text-[12px] leading-5 text-muted-foreground">
+						<p className="text-[14px] font-semibold text-[var(--color-text-import-title)]">{t("startup.githubSetupTitle")}</p>
+						<p className="mt-0.5 text-[12px] leading-5 text-[var(--color-text-import-muted)]">
 							{t(cliMissing ? "startup.githubSetupMissingCli" : "startup.githubSetupSignedOut")}
 						</p>
 						<div className="mt-2 flex flex-wrap items-center gap-2">
-							<button
-								type="button"
-								className="settings-footer-button settings-footer-button-primary"
+							<TopbarButton
 								disabled={!cliMissing && (startLogin.isPending || Boolean(terminal))}
 								onClick={() => cliMissing ? void aoBridge.app.openExternal(GITHUB_CLI_INSTALL_URL) : openLogin()}
+								variant="primary"
 							>
 								{cliMissing ? null : <TerminalSquare className="size-icon-sm" aria-hidden="true" />}
 								{cliMissing
@@ -98,30 +102,29 @@ export function GitHubOnboardingNotice() {
 									: startLogin.isPending
 										? t("startup.githubLoginStarting")
 										: t("startup.githubLogin")}
-							</button>
-							<button
-								type="button"
-								className="settings-footer-button"
+							</TopbarButton>
+							<TopbarButton
 								disabled={checking}
 								onClick={() => void checkAgain()}
+								variant="accent"
 							>
 								{checking ? t("startup.checkingAgain") : t("startup.checkAgain")}
-							</button>
+							</TopbarButton>
 						</div>
 						{startLogin.isError ? <p className="mt-2 text-xs text-destructive" role="alert">{startLogin.error.message}</p> : null}
 						{terminal ? (
-							<div className="mt-3 overflow-hidden rounded-md border border-border bg-terminal" data-testid="github-auth-terminal">
-								<div className="flex min-h-9 items-center justify-between gap-3 border-b border-border bg-surface/90 px-3 py-1.5">
+							<div className="mt-3 overflow-hidden rounded-lg border border-[var(--color-border-import-modal)] bg-terminal" data-testid="github-auth-terminal">
+								<div className="flex min-h-9 items-center justify-between gap-3 border-b border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-modal)] px-3 py-1.5">
 									<div className="min-w-0">
-										<p className="truncate text-xs font-medium text-foreground">{terminal.title}</p>
-										<p className="truncate text-[11px] text-muted-foreground">{t("startup.githubLoginRunning")}</p>
+										<p className="truncate text-xs font-medium text-[var(--color-text-import-title)]">{terminal.title}</p>
+										<p className="truncate text-[11px] text-[var(--color-text-import-muted)]">{t("startup.githubLoginRunning")}</p>
 									</div>
-									<button type="button" aria-label={t("common.close")} className="grid size-7 shrink-0 place-items-center rounded text-muted-foreground hover:bg-interactive-hover hover:text-foreground" onClick={closeLogin}>
+									<TopbarButton aria-label={t("common.close")} className="!size-7 shrink-0" onClick={closeLogin} variant="icon">
 										<X className="size-4" aria-hidden="true" />
-									</button>
+									</TopbarButton>
 								</div>
 								<div className="h-[240px] min-h-0">
-									<TerminalPane daemonReady={shell ? shell.daemonStatus.state === "ready" : true} focusRequested fontSize={12} onTerminalStateChange={handleTerminalState} terminalTarget={{ kind: "shell", handleId: terminal.handleId, generation: terminal.createdAt, title: terminal.title }} theme={theme} />
+									<TerminalPane daemonReady={shell ? shell.daemonStatus.state === "ready" : true} focusRequested={terminalState === "attached"} fontSize={12} onTerminalStateChange={handleTerminalState} terminalTarget={{ kind: "shell", handleId: terminal.handleId, generation: terminal.createdAt, title: terminal.title }} theme={theme} />
 								</div>
 							</div>
 						) : null}

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -6,7 +6,7 @@ import { useCloseShellTerminal } from "../hooks/useShellTerminals";
 import { useGitHubAuthRequirement, useGitHubAuthTerminal, useStartGitHubAuthTerminal, useSystemRequirementsGate } from "../hooks/useSystemRequirementsGate";
 import { aoBridge } from "../lib/bridge";
 import { useShellMaybe } from "../lib/shell-context";
-import { useResolvedTheme } from "../stores/ui-store";
+import { useResolvedTheme, useUiStore } from "../stores/ui-store";
 import { TerminalPane } from "./TerminalPane";
 import { TopbarButton } from "./TopbarButton";
 
@@ -19,10 +19,11 @@ const automaticallyChecked = new Set<string>();
 export function GitHubOnboardingNotice() {
 	const { t } = useTranslation();
 	const gate = useSystemRequirementsGate();
-	const authQuery = useGitHubAuthRequirement();
 	const startLogin = useStartGitHubAuthTerminal();
 	const terminalQuery = useGitHubAuthTerminal();
+	const authQuery = useGitHubAuthRequirement(Boolean(terminalQuery.data));
 	const { mutate: closeTerminal } = useCloseShellTerminal();
+	const showGlobalToast = useUiStore((state) => state.showGlobalToast);
 	const theme = useResolvedTheme();
 	const shell = useShellMaybe();
 	const requirements = gate.requirements ?? [];
@@ -30,6 +31,7 @@ export function GitHubOnboardingNotice() {
 	const terminalRef = useRef(terminal);
 	const refetchAuthRef = useRef(authQuery.refetch);
 	const automaticLoginStartedRef = useRef(false);
+	const completedTerminalRef = useRef<string | null>(null);
 	const [terminalState, setTerminalState] = useState<TerminalSessionState>("idle");
 	const gh = requirements.find((requirement) => requirement.id === "gh");
 	const auth = authQuery.data;
@@ -46,8 +48,11 @@ export function GitHubOnboardingNotice() {
 	}, []);
 	useEffect(() => {
 		if (!auth?.satisfied || !terminal) return;
+		if (completedTerminalRef.current === terminal.handleId) return;
+		completedTerminalRef.current = terminal.handleId;
+		showGlobalToast(t("startup.githubConnected"));
 		closeTerminal(terminal.handleId, { onSettled: terminalQuery.clear });
-	}, [auth?.satisfied, closeTerminal, terminal, terminalQuery.clear]);
+	}, [auth?.satisfied, closeTerminal, showGlobalToast, t, terminal, terminalQuery.clear]);
 	useEffect(() => {
 		if (
 			!auth ||

--- a/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
+++ b/frontend/src/renderer/components/GitHubOnboardingNotice.tsx
@@ -33,6 +33,7 @@ export function GitHubOnboardingNotice() {
 	const automaticLoginStartedRef = useRef(false);
 	const completedTerminalRef = useRef<string | null>(null);
 	const [terminalState, setTerminalState] = useState<TerminalSessionState>("idle");
+	const [manualCheckPending, setManualCheckPending] = useState(false);
 	const gh = requirements.find((requirement) => requirement.id === "gh");
 	const auth = authQuery.data;
 
@@ -75,14 +76,18 @@ export function GitHubOnboardingNotice() {
 	};
 
 	const checkAgain = async () => {
-		await authQuery.refetch();
+		setManualCheckPending(true);
+		try {
+			await authQuery.refetch();
+		} finally {
+			setManualCheckPending(false);
+		}
 	};
 	const closeLogin = () => {
 		if (!terminal) return;
 		closeTerminal(terminal.handleId, { onSettled: terminalQuery.clear });
 	};
 	const cliMissing = gh?.satisfied === false;
-	const checking = authQuery.isFetching;
 	return (
 		<div className="flex w-full justify-center px-3">
 			<div className="w-full max-w-[620px] rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-4 py-4" role="status">
@@ -108,13 +113,15 @@ export function GitHubOnboardingNotice() {
 										? t("startup.githubLoginStarting")
 										: t("startup.githubLogin")}
 							</TopbarButton>
-							<TopbarButton
-								disabled={checking}
-								onClick={() => void checkAgain()}
-								variant="accent"
-							>
-								{checking ? t("startup.checkingAgain") : t("startup.checkAgain")}
-							</TopbarButton>
+							{terminal ? null : (
+								<TopbarButton
+									disabled={manualCheckPending}
+									onClick={() => void checkAgain()}
+									variant="accent"
+								>
+									{manualCheckPending ? t("startup.checkingAgain") : t("startup.checkAgain")}
+								</TopbarButton>
+							)}
 						</div>
 						{startLogin.isError ? <p className="mt-2 text-xs text-destructive" role="alert">{startLogin.error.message}</p> : null}
 						{terminal ? (

--- a/frontend/src/renderer/components/HomePage.tsx
+++ b/frontend/src/renderer/components/HomePage.tsx
@@ -168,9 +168,7 @@ export function HomePage() {
 						</TopbarButton>
 					</div>
 
-					<GitHubOnboardingNotice />
-
-					<div className="-mt-3 grid grid-cols-2 gap-3 px-3">
+					<div className="grid grid-cols-2 gap-3 px-3">
 						<HomeActionCard
 							ariaLabel={t("createProject.cloneFromGit")}
 							icon={<GitFork className="size-4" aria-hidden="true" />}
@@ -209,6 +207,8 @@ export function HomePage() {
 							/>
 						))}
 					</div>
+
+					<GitHubOnboardingNotice />
 				</div>
 
 				<CreateProjectFlow

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -26,6 +26,7 @@ const state = vi.hoisted(() => ({
 		scrollToLine: ReturnType<typeof vi.fn>;
 		refresh: ReturnType<typeof vi.fn>;
 		clear: ReturnType<typeof vi.fn>;
+		dispose: ReturnType<typeof vi.fn>;
 		focus: ReturnType<typeof vi.fn>;
 		selectAll: ReturnType<typeof vi.fn>;
 		dataListeners: Set<(data: string) => void>;
@@ -104,9 +105,15 @@ vi.mock("@xterm/xterm", () => ({
 		open(host: HTMLElement) {
 			host.appendChild(document.createElement("textarea"));
 		}
-		write() {}
+		write(data: Uint8Array, done?: () => void) {
+			const output = new TextDecoder().decode(data);
+			if (output.includes("\x1b[6n")) {
+				this.dataListeners.forEach((listener) => listener("\x1b[7;21R"));
+			}
+			done?.();
+		}
 		writeln() {}
-		dispose() {}
+		dispose = vi.fn();
 		onData(listener: (data: string) => void) {
 			this.dataListeners.add(listener);
 			return { dispose: () => this.dataListeners.delete(listener) };
@@ -263,6 +270,7 @@ describe("XtermTerminal", () => {
 		try {
 			let terminal: AttachableTerminal | undefined;
 			render(<XtermTerminal theme="dark" onReady={(ready) => { terminal = ready; }} />);
+			state.lastTerminal!.buffer.active.baseY = 1;
 			const preparation = terminal!.prepareForActivation();
 			await act(async () => {
 				vi.advanceTimersByTime(250);
@@ -274,6 +282,44 @@ describe("XtermTerminal", () => {
 		} finally {
 			vi.useRealTimers();
 			vi.unstubAllGlobals();
+		}
+	});
+
+	it("does not scroll an empty terminal before renderer dimensions exist", async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+			window.setTimeout(() => callback(performance.now()), 0),
+		);
+		vi.stubGlobal("cancelAnimationFrame", (id: number) => window.clearTimeout(id));
+		try {
+			let terminal: AttachableTerminal | undefined;
+			render(<XtermTerminal theme="dark" onReady={(ready) => { terminal = ready; }} />);
+			const preparation = terminal!.prepareForActivation();
+			await act(async () => {
+				vi.advanceTimersByTime(250);
+				vi.runAllTimers();
+				await preparation;
+			});
+			expect(state.lastTerminal!.scrollToBottom).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it("defers disposal behind xterm's pending viewport callback", () => {
+		vi.useFakeTimers();
+		try {
+			const { unmount } = render(<XtermTerminal theme="dark" />);
+			const terminal = state.lastTerminal!;
+
+			unmount();
+			expect(terminal.dispose).not.toHaveBeenCalled();
+
+			act(() => vi.runOnlyPendingTimers());
+			expect(terminal.dispose).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
 		}
 	});
 
@@ -1205,13 +1251,26 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenCalledWith("\x1b]4;196;rgb:ffff/0000/8000\x07", "protocol");
 	});
 
-	it("forwards validated cursor-position replies for interactive shell prompts", () => {
+	it("forwards the cursor-position reply generated for a PTY request", () => {
+		const onInput = vi.fn();
+		let terminal: AttachableTerminal | undefined;
+		render(<XtermTerminal theme="dark" onReady={(ready) => {
+			terminal = ready;
+			return ready.onUserInput(onInput);
+		}} />);
+
+		terminal!.write(new TextEncoder().encode("prompt\x1b[6n"));
+
+		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
+	});
+
+	it("does not forward an unsolicited cursor-position-shaped input", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 
 		state.lastTerminal!.dataListeners.forEach((listener) => listener("\x1b[7;21R"));
 
-		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
+		expect(onInput).not.toHaveBeenCalled();
 	});
 
 	it("updates protocol handling when a retained terminal becomes a Cursor terminal", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1,6 +1,8 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AttachableTerminal } from "../hooks/useTerminalSession";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { TerminalMux } from "../lib/terminal-mux";
+import { useTerminalSession, type AttachableTerminal } from "../hooks/useTerminalSession";
 import { useUiStore } from "../stores/ui-store";
 import { safeTerminalFind } from "./TerminalSearch";
 import { XtermTerminal } from "./XtermTerminal";
@@ -1256,6 +1258,55 @@ describe("XtermTerminal", () => {
 		terminal!.write(new TextEncoder().encode("historical prompt\x1b[6n"), undefined, "replay");
 
 		expect(onInput).not.toHaveBeenCalledWith("\x1b[7;21R", "protocol");
+	});
+
+	it("answers Cursor color-scheme requests during replay", () => {
+		const onInput = vi.fn();
+		let terminal: AttachableTerminal | undefined;
+		render(<XtermTerminal theme="light" supportsCursorColorScheme onReady={(ready) => {
+			terminal = ready;
+			return ready.onUserInput(onInput);
+		}} />);
+		onInput.mockClear();
+		terminal!.write(new TextEncoder().encode("\x1b[?2031h"), undefined, "replay");
+		expect(onInput).toHaveBeenCalledWith(expect.stringContaining("\x1b[?997;2n"), "protocol");
+	});
+
+	it("keeps pending live cursor credits when replay is queued before parsing", () => {
+		const onInput = vi.fn();
+		let terminal: AttachableTerminal | undefined;
+		render(<XtermTerminal theme="dark" onReady={(ready) => {
+			terminal = ready;
+			return ready.onUserInput(onInput);
+		}} />);
+		vi.spyOn(state.lastTerminal!, "write").mockImplementation(() => {});
+		terminal!.write(new TextEncoder().encode("\x1b[6n"));
+		terminal!.write(new TextEncoder().encode("tail"), undefined, "replay");
+		state.lastTerminal!.dataListeners.forEach((listener) => listener("\x1b[7;21R"));
+		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
+	});
+
+	it("returns a CPR to a fresh shell PTY through coverInitialReplay", async () => {
+		let output: (data: Uint8Array) => void = () => {};
+		let opened: () => void = () => {};
+		const sendInput = vi.fn();
+		const mux: TerminalMux = {
+			open: vi.fn(), close: vi.fn(), resize: vi.fn(), dispose: vi.fn(), sendInput,
+			onData: (_id, listener) => { output = listener; return () => {}; },
+			onOpened: (_id, listener) => { opened = listener; return () => {}; },
+			onExit: () => () => {}, onError: () => () => {}, onConnectionChange: () => () => {},
+		};
+		function Shell() {
+			const session = useTerminalSession(undefined, { daemonReady: true, coverInitialReplay: true, shellTerminalHandleId: "fresh-login", createMux: () => mux });
+			return <XtermTerminal theme="dark" onReady={session.attach} />;
+		}
+		render(<QueryClientProvider client={new QueryClient()}><Shell /></QueryClientProvider>);
+		act(() => {
+			opened();
+			output(new TextEncoder().encode("prompt\x1b"));
+			output(new TextEncoder().encode("[6n"));
+		});
+		await waitFor(() => expect(sendInput).toHaveBeenCalledWith("fresh-login", "\x1b[7;21R"));
 	});
 
 	it("does not forward an unsolicited cursor-position-shaped input", () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -87,6 +87,7 @@ vi.mock("@xterm/xterm", () => ({
 		keyListeners = new Set<(event: { key: string }) => void>();
 		selectionListeners = new Set<() => void>();
 		scrollListeners = new Set<() => void>();
+		writeBuffer = "";
 		_core = {
 			element: { classList: { add: vi.fn(), remove: vi.fn() } },
 			viewport: { scrollBarWidth: 15 },
@@ -106,9 +107,10 @@ vi.mock("@xterm/xterm", () => ({
 			host.appendChild(document.createElement("textarea"));
 		}
 		write(data: Uint8Array, done?: () => void) {
-			const output = new TextDecoder().decode(data);
-			if (output.includes("\x1b[6n")) {
+			this.writeBuffer += new TextDecoder().decode(data);
+			if (this.writeBuffer.includes("\x1b[6n")) {
 				this.dataListeners.forEach((listener) => listener("\x1b[7;21R"));
+				this.writeBuffer = "";
 			}
 			done?.();
 		}
@@ -279,28 +281,6 @@ describe("XtermTerminal", () => {
 			});
 			expect(state.lastTerminal!.scrollToBottom).toHaveBeenCalled();
 			expect(state.lastTerminal!.refresh).not.toHaveBeenCalled();
-		} finally {
-			vi.useRealTimers();
-			vi.unstubAllGlobals();
-		}
-	});
-
-	it("does not scroll an empty terminal before renderer dimensions exist", async () => {
-		vi.useFakeTimers();
-		vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
-			window.setTimeout(() => callback(performance.now()), 0),
-		);
-		vi.stubGlobal("cancelAnimationFrame", (id: number) => window.clearTimeout(id));
-		try {
-			let terminal: AttachableTerminal | undefined;
-			render(<XtermTerminal theme="dark" onReady={(ready) => { terminal = ready; }} />);
-			const preparation = terminal!.prepareForActivation();
-			await act(async () => {
-				vi.advanceTimersByTime(250);
-				vi.runAllTimers();
-				await preparation;
-			});
-			expect(state.lastTerminal!.scrollToBottom).not.toHaveBeenCalled();
 		} finally {
 			vi.useRealTimers();
 			vi.unstubAllGlobals();
@@ -1259,7 +1239,8 @@ describe("XtermTerminal", () => {
 			return ready.onUserInput(onInput);
 		}} />);
 
-		terminal!.write(new TextEncoder().encode("prompt\x1b[6n"));
+		terminal!.write(new TextEncoder().encode("prompt\x1b"));
+		terminal!.write(new TextEncoder().encode("[6n"));
 
 		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
 	});

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1248,32 +1248,7 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
 	});
 
-	it("does not forward cursor replies generated while replaying history", () => {
-		const onInput = vi.fn();
-		let terminal: AttachableTerminal | undefined;
-		render(<XtermTerminal theme="dark" onReady={(ready) => {
-			terminal = ready;
-			return ready.onUserInput(onInput);
-		}} />);
-
-		terminal!.write(new TextEncoder().encode("historical prompt\x1b[6n"), undefined, "replay");
-
-		expect(onInput).not.toHaveBeenCalledWith("\x1b[7;21R", "protocol");
-	});
-
-	it("answers Cursor color-scheme requests during replay", () => {
-		const onInput = vi.fn();
-		let terminal: AttachableTerminal | undefined;
-		render(<XtermTerminal theme="light" supportsCursorColorScheme onReady={(ready) => {
-			terminal = ready;
-			return ready.onUserInput(onInput);
-		}} />);
-		onInput.mockClear();
-		terminal!.write(new TextEncoder().encode("\x1b[?2031h"), undefined, "replay");
-		expect(onInput).toHaveBeenCalledWith(expect.stringContaining("\x1b[?997;2n"), "protocol");
-	});
-
-	it("keeps pending live cursor credits when replay is queued before parsing", () => {
+	it("keeps pending cursor credits when more output is queued before parsing", () => {
 		const onInput = vi.fn();
 		let terminal: AttachableTerminal | undefined;
 		render(<XtermTerminal theme="dark" onReady={(ready) => {
@@ -1282,9 +1257,21 @@ describe("XtermTerminal", () => {
 		}} />);
 		vi.spyOn(state.lastTerminal!, "write").mockImplementation(() => {});
 		terminal!.write(new TextEncoder().encode("\x1b[6n"));
-		terminal!.write(new TextEncoder().encode("tail"), undefined, "replay");
+		terminal!.write(new TextEncoder().encode("tail"));
 		state.lastTerminal!.dataListeners.forEach((listener) => listener("\x1b[7;21R"));
 		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
+	});
+
+	it("answers Cursor color-scheme output queries", () => {
+		const onInput = vi.fn();
+		let terminal: AttachableTerminal | undefined;
+		render(<XtermTerminal theme="light" supportsCursorColorScheme onReady={(ready) => {
+			terminal = ready;
+			return ready.onUserInput(onInput);
+		}} />);
+		onInput.mockClear();
+		terminal!.write(new TextEncoder().encode("\x1b[?2031h"));
+		expect(onInput).toHaveBeenCalledWith(expect.stringContaining("\x1b[?997;2n"), "protocol");
 	});
 
 	it("returns a CPR to a fresh shell PTY through coverInitialReplay", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1205,6 +1205,15 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenCalledWith("\x1b]4;196;rgb:ffff/0000/8000\x07", "protocol");
 	});
 
+	it("forwards validated cursor-position replies for interactive shell prompts", () => {
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		state.lastTerminal!.dataListeners.forEach((listener) => listener("\x1b[7;21R"));
+
+		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
+	});
+
 	it("updates protocol handling when a retained terminal becomes a Cursor terminal", () => {
 		const onInput = vi.fn();
 		const { rerender } = render(

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1297,6 +1297,40 @@ describe("XtermTerminal", () => {
 		await waitFor(() => expect(sendInput).toHaveBeenCalledWith("fresh-login", "\x1b[7;21R"));
 	});
 
+	it("stops treating covered output as live after a fresh handle reconnects", async () => {
+		const outputs: Array<(data: Uint8Array) => void> = [];
+		const opened: Array<() => void> = [];
+		const connectionChanges: Array<(state: "open" | "closed") => void> = [];
+		const sendInputs = [vi.fn(), vi.fn()];
+		const createMux = vi.fn((): TerminalMux => {
+			const index = outputs.length;
+			return {
+				open: vi.fn(), close: vi.fn(), resize: vi.fn(), dispose: vi.fn(), sendInput: sendInputs[index],
+				onData: (_id, listener) => { outputs[index] = listener; return () => {}; },
+				onOpened: (_id, listener) => { opened[index] = listener; return () => {}; },
+				onExit: () => () => {}, onError: () => () => {},
+				onConnectionChange: (listener) => { connectionChanges[index] = listener; return () => {}; },
+			};
+		});
+		function Shell() {
+			const session = useTerminalSession(undefined, { daemonReady: true, coverInitialReplay: true, shellTerminalHandleId: "fresh-then-reconnected", createMux });
+			return <XtermTerminal theme="dark" onReady={session.attach} />;
+		}
+		render(<QueryClientProvider client={new QueryClient()}><Shell /></QueryClientProvider>);
+		act(() => {
+			opened[0]();
+			connectionChanges[0]("closed");
+		});
+		await waitFor(() => expect(createMux).toHaveBeenCalledTimes(2), { timeout: 2_000 });
+		const xtermWrite = vi.spyOn(state.lastTerminal!, "write");
+		act(() => {
+			opened[1]();
+			outputs[1](new TextEncoder().encode("history\x1b[6n"));
+		});
+		await waitFor(() => expect(xtermWrite).toHaveBeenCalled());
+		expect(sendInputs[1]).not.toHaveBeenCalled();
+	});
+
 	it("does not forward an unsolicited cursor-position-shaped input", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -17,6 +17,7 @@ const state = vi.hoisted(() => ({
 		resultListeners: Set<(results: { resultCount: number; resultIndex: number }) => void>;
 	},
 	lastTerminal: null as null | {
+		write(data: Uint8Array, done?: () => void): void;
 		keyHandler?: (event: KeyboardEvent) => boolean;
 		wheelHandler?: (event: WheelEvent) => boolean;
 		selection: string;

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1245,6 +1245,19 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenCalledWith("\x1b[7;21R", "protocol");
 	});
 
+	it("does not forward cursor replies generated while replaying history", () => {
+		const onInput = vi.fn();
+		let terminal: AttachableTerminal | undefined;
+		render(<XtermTerminal theme="dark" onReady={(ready) => {
+			terminal = ready;
+			return ready.onUserInput(onInput);
+		}} />);
+
+		terminal!.write(new TextEncoder().encode("historical prompt\x1b[6n"), undefined, "replay");
+
+		expect(onInput).not.toHaveBeenCalledWith("\x1b[7;21R", "protocol");
+	});
+
 	it("does not forward an unsolicited cursor-position-shaped input", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { TerminalMux } from "../lib/terminal-mux";
+import { markTerminalHandleFresh } from "../lib/fresh-terminal-handles";
 import { useTerminalSession, type AttachableTerminal } from "../hooks/useTerminalSession";
 import { useUiStore } from "../stores/ui-store";
 import { safeTerminalFind } from "./TerminalSearch";
@@ -1275,6 +1276,7 @@ describe("XtermTerminal", () => {
 	});
 
 	it("returns a CPR to a fresh shell PTY through coverInitialReplay", async () => {
+		markTerminalHandleFresh("fresh-login");
 		let output: (data: Uint8Array) => void = () => {};
 		let opened: () => void = () => {};
 		const sendInput = vi.fn();
@@ -1298,6 +1300,7 @@ describe("XtermTerminal", () => {
 	});
 
 	it("stops treating covered output as live after a fresh handle reconnects", async () => {
+		markTerminalHandleFresh("fresh-then-reconnected");
 		const outputs: Array<(data: Uint8Array) => void> = [];
 		const opened: Array<() => void> = [];
 		const connectionChanges: Array<(state: "open" | "closed") => void> = [];
@@ -1329,6 +1332,41 @@ describe("XtermTerminal", () => {
 		});
 		await waitFor(() => expect(xtermWrite).toHaveBeenCalled());
 		expect(sendInputs[1]).not.toHaveBeenCalled();
+	});
+
+	it.each(["remount", "existing"])("discards historical CPRs on %s pane mount", async (scenario) => {
+		const outputs: Array<(data: Uint8Array) => void> = [];
+		const opened: Array<() => void> = [];
+		const sendInputs = [vi.fn(), vi.fn()];
+		const createMux = vi.fn((): TerminalMux => {
+			const index = outputs.length;
+			return {
+				open: vi.fn(), close: vi.fn(), resize: vi.fn(), dispose: vi.fn(), sendInput: sendInputs[index],
+				onData: (_id, listener) => { outputs[index] = listener; return () => {}; },
+				onOpened: (_id, listener) => { opened[index] = listener; return () => {}; },
+				onExit: () => () => {}, onError: () => () => {},
+				onConnectionChange: () => () => {},
+			};
+		});
+		function Shell() {
+			const session = useTerminalSession(undefined, { daemonReady: true, coverInitialReplay: true, shellTerminalHandleId: "mounted-existing", createMux });
+			return <XtermTerminal theme="dark" onReady={session.attach} />;
+		}
+		if (scenario === "remount") {
+			markTerminalHandleFresh("mounted-existing");
+			const first = render(<QueryClientProvider client={new QueryClient()}><Shell /></QueryClientProvider>);
+			act(() => opened[0]());
+			first.unmount();
+		}
+		render(<QueryClientProvider client={new QueryClient()}><Shell /></QueryClientProvider>);
+		const index = outputs.length - 1;
+		const xtermWrite = vi.spyOn(state.lastTerminal!, "write");
+		act(() => {
+			opened[index]();
+			outputs[index](new TextEncoder().encode("history\x1b[6n"));
+		});
+		await waitFor(() => expect(xtermWrite).toHaveBeenCalled());
+		expect(sendInputs[index]).not.toHaveBeenCalled();
 	});
 
 	it("does not forward an unsolicited cursor-position-shaped input", () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -44,6 +44,7 @@ import {
 } from "../lib/cursor-color-scheme";
 import {
 	buildOscColorReports,
+	createCursorPositionReportForwarder,
 	createOscColorReportForwarder,
 	type OscTerminalColors,
 } from "../lib/osc-color-report";
@@ -987,15 +988,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		// those bytes through the mux writes dirty input into the real Codex PTY and
 		// corrupts the TUI. Keyboard is the only safe generic text path here; paste,
 		// composition, shortcuts, and wheel reports are emitted explicitly below.
-		// Forward validated OSC 4/10/11/12 color replies only. xterm answers them
-		// on onData; other bytes must not reach the PTY or agent TUIs break.
+		// Forward validated OSC 4/10/11/12 color replies and cursor-position
+		// reports only. Interactive prompts such as `gh auth login` use DSR to ask
+		// xterm for the cursor position and block until the corresponding CPR reaches
+		// the PTY. Other onData bytes must not reach the PTY or agent TUIs break.
 		// Retained terminals can change providers without remounting. Keep the
 		// listener mounted for every provider so standard color replies continue to
 		// reach the PTY after a provider change.
 		const oscColorForwarder = createOscColorReportForwarder((report) => {
 			emitUserInput(report, "protocol");
 		});
-		const oscColorInput = term.onData((data) => oscColorForwarder.push(data));
+		const cursorPositionForwarder = createCursorPositionReportForwarder((report) => {
+			emitUserInput(report, "protocol");
+		});
+		const protocolInput = term.onData((data) => {
+			oscColorForwarder.push(data);
+			cursorPositionForwarder.push(data);
+		});
 		const keyInput = term.onKey(({ key }) => emitUserInput(key, "keyboard"));
 
 		// Translate wheel motion into SGR wheel reports for the pane (see
@@ -1260,7 +1269,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			for (const timer of schemeRetryTimers) window.clearTimeout(timer);
 			schemeRetryTimers = [];
 			oscColorForwarder.dispose();
-			oscColorInput.dispose();
+			cursorPositionForwarder.dispose();
+			protocolInput.dispose();
 			keyInput.dispose();
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1121,7 +1121,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		shell.addEventListener("drop", dropInput);
 
 		const showLatestOutput = () => {
-			term.scrollToBottom();
+			// A newly opened xterm has no renderer dimensions until its first paint.
+			// scrollToBottom schedules Viewport.syncScrollArea, which dereferences those
+			// dimensions and crashes when activation runs before any output exists.
+			// There is nothing to scroll in that state; defer the API call until the
+			// buffer actually contains scrollback.
+			if (term.buffer.active.baseY > 0) term.scrollToBottom();
 			// Hidden output can leave the offscreen DOM scrollbar stale even
 			// after xterm's logical viewport moves. Synchronize it before either
 			// the first-load cover or retained-cache container is revealed.
@@ -1191,6 +1196,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				}
 				if (hasEsc) {
 					const chunk = new TextDecoder().decode(data);
+					cursorPositionForwarder.observeOutput(chunk);
 					const reply = callbacksRef.current.supportsCursorColorScheme
 						? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)
 						: null;
@@ -1275,12 +1281,20 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;
 			userInputListeners.clear();
-			try {
-				term.dispose();
-			} catch {
-				// Some renderer addons can throw during dispose in certain GPU
-				// environments; the terminal is being torn down regardless.
-			}
+			// xterm's Viewport constructor queues an untracked zero-delay
+			// syncScrollArea(). React StrictMode immediately runs this cleanup after
+			// the development probe mount; disposing synchronously clears the render
+			// service before that callback reads its dimensions. Queue disposal behind
+			// the already-pending viewport callback so the probe mount cannot surface an
+			// unhandled `dimensions` error.
+			window.setTimeout(() => {
+				try {
+					term.dispose();
+				} catch {
+					// Some renderer addons can throw during dispose in certain GPU
+					// environments; the terminal is being torn down regardless.
+				}
+			}, 0);
 		};
 	}, []);
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1181,7 +1181,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// Forward xterm's write callback: it fires once THIS chunk has been
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
-			write: (data, done) => {
+			write: (data, done, source = "live") => {
 				let hasEsc = false;
 				for (let i = 0; i < data.length; i++) {
 					if (data[i] === 0x1b) {
@@ -1189,11 +1189,16 @@ export function XtermTerminal(props: XtermTerminalProps) {
 						break;
 					}
 				}
+				if (source === "replay") {
+					// Existing panes replay historical DSRs through xterm. Clear any old
+					// correlation credits so their generated CPRs cannot reach the live PTY.
+					cursorPositionForwarder.dispose();
+				}
 				if (hasEsc || cursorPositionForwarder.hasPartialRequest()) {
 					// A DSR can be split immediately after ESC. Decode an ESC-free chunk
 					// only while a request prefix from the preceding chunk is incomplete.
 					const chunk = new TextDecoder().decode(data);
-					cursorPositionForwarder.observeOutput(chunk);
+					if (source === "live") cursorPositionForwarder.observeOutput(chunk);
 					if (hasEsc) {
 						const reply = callbacksRef.current.supportsCursorColorScheme
 							? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1190,16 +1190,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 						break;
 					}
 				}
-				if (source === "replay") {
-					// Replayed history is parsed by xterm again and can contain old DSRs.
-					// Clear correlation state so their generated CPRs are discarded rather
-					// than injected into the newly attached live PTY.
-					cursorPositionForwarder.dispose();
-				} else if (hasEsc || cursorPositionForwarder.hasPartialRequest()) {
+				if (hasEsc || cursorPositionForwarder.hasPartialRequest()) {
 					// A DSR can be split immediately after ESC. Decode an ESC-free chunk
 					// only while a request prefix from the preceding chunk is incomplete.
 					const chunk = new TextDecoder().decode(data);
-					cursorPositionForwarder.observeOutput(chunk);
+					// Historical writes must not erase credits for live writes still in xterm's queue.
+					if (source !== "replay") cursorPositionForwarder.observeOutput(chunk);
 					if (hasEsc) {
 						const reply = callbacksRef.current.supportsCursorColorScheme
 							? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1121,12 +1121,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		shell.addEventListener("drop", dropInput);
 
 		const showLatestOutput = () => {
-			// A newly opened xterm has no renderer dimensions until its first paint.
-			// scrollToBottom schedules Viewport.syncScrollArea, which dereferences those
-			// dimensions and crashes when activation runs before any output exists.
-			// There is nothing to scroll in that state; defer the API call until the
-			// buffer actually contains scrollback.
-			if (term.buffer.active.baseY > 0) term.scrollToBottom();
+			term.scrollToBottom();
 			// Hidden output can leave the offscreen DOM scrollbar stale even
 			// after xterm's logical viewport moves. Synchronize it before either
 			// the first-load cover or retained-cache container is revealed.
@@ -1187,16 +1182,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
 			write: (data, done) => {
-				let hasEsc = false;
-				for (let i = 0; i < data.length; i++) {
-					if (data[i] === 0x1b) {
-						hasEsc = true;
-						break;
-					}
-				}
-				if (hasEsc) {
-					const chunk = new TextDecoder().decode(data);
-					cursorPositionForwarder.observeOutput(chunk);
+				const chunk = new TextDecoder().decode(data);
+				// A PTY can split a DSR at any byte boundary, including immediately
+				// after ESC. Feed every chunk to the correlator so an ESC-free
+				// continuation still completes the pending request.
+				cursorPositionForwarder.observeOutput(chunk);
+				if (chunk.includes("\x1b")) {
 					const reply = callbacksRef.current.supportsCursorColorScheme
 						? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)
 						: null;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -32,7 +32,6 @@ import { terminalFontSizeDelta as shortcutFontSizeDelta } from "../../shared/sho
 import type {
 	AttachableTerminal,
 	TerminalUserInputSource,
-	TerminalWriteSource,
 } from "../hooks/useTerminalSession";
 import { aoBridge } from "../lib/bridge";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
@@ -1182,7 +1181,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// Forward xterm's write callback: it fires once THIS chunk has been
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
-			write: (data, done, source: TerminalWriteSource = "live") => {
+			write: (data, done) => {
 				let hasEsc = false;
 				for (let i = 0; i < data.length; i++) {
 					if (data[i] === 0x1b) {
@@ -1194,8 +1193,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					// A DSR can be split immediately after ESC. Decode an ESC-free chunk
 					// only while a request prefix from the preceding chunk is incomplete.
 					const chunk = new TextDecoder().decode(data);
-					// Historical writes must not erase credits for live writes still in xterm's queue.
-					if (source !== "replay") cursorPositionForwarder.observeOutput(chunk);
+					cursorPositionForwarder.observeOutput(chunk);
 					if (hasEsc) {
 						const reply = callbacksRef.current.supportsCursorColorScheme
 							? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -32,6 +32,7 @@ import { terminalFontSizeDelta as shortcutFontSizeDelta } from "../../shared/sho
 import type {
 	AttachableTerminal,
 	TerminalUserInputSource,
+	TerminalWriteSource,
 } from "../hooks/useTerminalSession";
 import { aoBridge } from "../lib/bridge";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
@@ -1181,19 +1182,32 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// Forward xterm's write callback: it fires once THIS chunk has been
 			// parsed into the buffer, which is what lets the attachment reveal the
 			// pane at the replay's settled scroll position (issue #3160).
-			write: (data, done) => {
-				const chunk = new TextDecoder().decode(data);
-				// A PTY can split a DSR at any byte boundary, including immediately
-				// after ESC. Feed every chunk to the correlator so an ESC-free
-				// continuation still completes the pending request.
-				cursorPositionForwarder.observeOutput(chunk);
-				if (chunk.includes("\x1b")) {
-					const reply = callbacksRef.current.supportsCursorColorScheme
-						? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)
-						: null;
-					if (reply) {
-						announcedCursorSchemeRef.current = null;
-						notifyCursorScheme(callbacksRef.current.theme, true, true);
+			write: (data, done, source: TerminalWriteSource = "live") => {
+				let hasEsc = false;
+				for (let i = 0; i < data.length; i++) {
+					if (data[i] === 0x1b) {
+						hasEsc = true;
+						break;
+					}
+				}
+				if (source === "replay") {
+					// Replayed history is parsed by xterm again and can contain old DSRs.
+					// Clear correlation state so their generated CPRs are discarded rather
+					// than injected into the newly attached live PTY.
+					cursorPositionForwarder.dispose();
+				} else if (hasEsc || cursorPositionForwarder.hasPartialRequest()) {
+					// A DSR can be split immediately after ESC. Decode an ESC-free chunk
+					// only while a request prefix from the preceding chunk is incomplete.
+					const chunk = new TextDecoder().decode(data);
+					cursorPositionForwarder.observeOutput(chunk);
+					if (hasEsc) {
+						const reply = callbacksRef.current.supportsCursorColorScheme
+							? cursorColorSchemeReplyForOutput(chunk, callbacksRef.current.theme)
+							: null;
+						if (reply) {
+							announcedCursorSchemeRef.current = null;
+							notifyCursorScheme(callbacksRef.current.theme, true, true);
+						}
 					}
 				}
 				term.write(data, () => {
@@ -1272,20 +1286,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;
 			userInputListeners.clear();
-			// xterm's Viewport constructor queues an untracked zero-delay
-			// syncScrollArea(). React StrictMode immediately runs this cleanup after
-			// the development probe mount; disposing synchronously clears the render
-			// service before that callback reads its dimensions. Queue disposal behind
-			// the already-pending viewport callback so the probe mount cannot surface an
-			// unhandled `dimensions` error.
-			window.setTimeout(() => {
+			const disposeTerminal = () => {
 				try {
 					term.dispose();
 				} catch {
 					// Some renderer addons can throw during dispose in certain GPU
 					// environments; the terminal is being torn down regardless.
 				}
-			}, 0);
+			};
+			if (import.meta.env.DEV) {
+				// xterm's Viewport constructor queues an untracked zero-delay
+				// syncScrollArea(). React StrictMode immediately runs this cleanup after
+				// its development probe mount; queue disposal behind that callback so it
+				// cannot read the already-cleared renderer dimensions.
+				window.setTimeout(disposeTerminal, 0);
+			} else {
+				disposeTerminal();
+			}
 		};
 	}, []);
 

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -4,6 +4,7 @@
 // must not invalidate session state when they come and go.
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { markTerminalHandleFresh } from "../lib/fresh-terminal-handles";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorCode, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { mockShellTerminals } from "../lib/mock-data";
@@ -152,6 +153,7 @@ export function useOpenShellTerminal() {
 			const { data, error } = await apiClient.POST("/api/v1/shell-terminals", { body });
 			if (error) throw error;
 			if (!data) throw new Error("Daemon returned no shell terminal");
+			markTerminalHandleFresh(data.shellTerminal.handleId);
 			return toShellTerminal(data.shellTerminal);
 		},
 		onMutate: (input) => {

--- a/frontend/src/renderer/hooks/useSystemRequirementsGate.test.tsx
+++ b/frontend/src/renderer/hooks/useSystemRequirementsGate.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -8,10 +8,11 @@ vi.mock("../lib/api-client", () => ({
 	apiErrorMessage: (error: unknown) => String(error),
 }));
 
-vi.mock("../lib/preview-mode", () => ({ usesPreviewWorkspaceData: () => false }));
+vi.mock("../lib/preview-mode", () => ({ usesPreviewWorkspaceData: false }));
 
 import type { ShellTerminal } from "./useShellTerminals";
-import { githubAuthTerminalQueryKey, useGitHubAuthTerminal } from "./useSystemRequirementsGate";
+import { apiClient } from "../lib/api-client";
+import { githubAuthTerminalQueryKey, useGitHubAuthRequirement, useGitHubAuthTerminal } from "./useSystemRequirementsGate";
 
 const loginTerminal: ShellTerminal = {
 	createdAt: "2026-09-06T00:00:00Z",
@@ -71,5 +72,29 @@ describe("useGitHubAuthTerminal", () => {
 
 		await waitFor(() => expect(result.current.data).toBeNull());
 		expect(queryClient.getQueryData(githubAuthTerminalQueryKey)).toBeNull();
+	});
+});
+
+describe("useGitHubAuthRequirement", () => {
+	it("polls only while a GitHub login terminal is active", async () => {
+		vi.useFakeTimers();
+		const getMock = vi.mocked(apiClient.GET);
+		getMock.mockResolvedValue({
+			data: { id: "github-auth", label: "GitHub access", satisfied: false, required: false, detail: "Sign in." },
+			error: undefined,
+		} as never);
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const { rerender } = renderHook(
+			({ active }) => useGitHubAuthRequirement(active),
+			{ initialProps: { active: true }, wrapper: wrapper(queryClient) },
+		);
+
+		await act(async () => vi.advanceTimersByTimeAsync(1_600));
+		expect(getMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+		rerender({ active: false });
+		const callsAfterStopping = getMock.mock.calls.length;
+		await act(async () => vi.advanceTimersByTimeAsync(1_600));
+		expect(getMock).toHaveBeenCalledTimes(callsAfterStopping);
 	});
 });

--- a/frontend/src/renderer/hooks/useSystemRequirementsGate.test.tsx
+++ b/frontend/src/renderer/hooks/useSystemRequirementsGate.test.tsx
@@ -12,7 +12,7 @@ vi.mock("../lib/preview-mode", () => ({ usesPreviewWorkspaceData: false }));
 
 import type { ShellTerminal } from "./useShellTerminals";
 import { apiClient } from "../lib/api-client";
-import { githubAuthTerminalQueryKey, useGitHubAuthRequirement, useGitHubAuthTerminal } from "./useSystemRequirementsGate";
+import { githubAuthAutoLoginOfferedQueryKey, githubAuthTerminalQueryKey, useGitHubAuthAutoLoginOffered, useGitHubAuthRequirement, useGitHubAuthTerminal } from "./useSystemRequirementsGate";
 
 const loginTerminal: ShellTerminal = {
 	createdAt: "2026-09-06T00:00:00Z",
@@ -75,6 +75,23 @@ describe("useGitHubAuthTerminal", () => {
 	});
 });
 
+describe("useGitHubAuthAutoLoginOffered", () => {
+	it("retains a dismissed offer while the notice is unmounted", async () => {
+		vi.useFakeTimers();
+		const queryClient = new QueryClient();
+		const first = renderHook(() => useGitHubAuthAutoLoginOffered(), { wrapper: wrapper(queryClient) });
+
+		act(() => first.result.current.markOffered());
+		expect(queryClient.getQueryData(githubAuthAutoLoginOfferedQueryKey)).toBe(true);
+		first.unmount();
+		vi.advanceTimersByTime(10 * 60 * 1000);
+
+		expect(queryClient.getQueryData(githubAuthAutoLoginOfferedQueryKey)).toBe(true);
+		const second = renderHook(() => useGitHubAuthAutoLoginOffered(), { wrapper: wrapper(queryClient) });
+		expect(second.result.current.offered).toBe(true);
+	});
+});
+
 describe("useGitHubAuthRequirement", () => {
 	it("polls only while a GitHub login terminal is active", async () => {
 		vi.useFakeTimers();
@@ -89,12 +106,12 @@ describe("useGitHubAuthRequirement", () => {
 			{ initialProps: { active: true }, wrapper: wrapper(queryClient) },
 		);
 
-		await act(async () => vi.advanceTimersByTimeAsync(1_600));
+		await act(async () => vi.advanceTimersByTimeAsync(5_100));
 		expect(getMock.mock.calls.length).toBeGreaterThanOrEqual(2);
 
 		rerender({ active: false });
 		const callsAfterStopping = getMock.mock.calls.length;
-		await act(async () => vi.advanceTimersByTimeAsync(1_600));
+		await act(async () => vi.advanceTimersByTimeAsync(5_100));
 		expect(getMock).toHaveBeenCalledTimes(callsAfterStopping);
 	});
 });

--- a/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
+++ b/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
@@ -9,6 +9,8 @@ export type SystemRequirement = components["schemas"]["SystemRequirement"];
 
 export const systemRequirementsQueryKey = ["system-requirements"] as const;
 export const githubAuthTerminalQueryKey = ["github-auth-terminal"] as const;
+export const githubAuthAutoLoginOfferedQueryKey = ["github-auth-auto-login-offered"] as const;
+const GITHUB_AUTH_POLL_INTERVAL_MS = 2_500;
 
 async function fetchSystemRequirements(): Promise<components["schemas"]["SystemRequirementsResponse"]> {
 	const { data, error } = await apiClient.GET("/api/v1/system/requirements");
@@ -47,7 +49,7 @@ export function useGitHubAuthRequirement(loginActive = false) {
 		// The browser/device flow can finish before its PTY exit reaches the
 		// renderer. Probe only while AO owns an active login terminal so the card
 		// closes promptly after authorization without permanent background polling.
-		refetchInterval: loginActive ? 750 : false,
+		refetchInterval: loginActive ? GITHUB_AUTH_POLL_INTERVAL_MS : false,
 	});
 }
 
@@ -91,6 +93,23 @@ export function useGitHubAuthTerminal() {
 		queryClient.setQueryData<ShellTerminal | null>(githubAuthTerminalQueryKey, null);
 	}, [queryClient]);
 	return { ...query, clear };
+}
+
+/** Remember an automatic login offer for the lifetime of this renderer so
+ * dismissing its PTY remains respected across home/board remounts. */
+export function useGitHubAuthAutoLoginOffered() {
+	const queryClient = useQueryClient();
+	const query = useQuery<boolean>({
+		queryKey: githubAuthAutoLoginOfferedQueryKey,
+		queryFn: async () => false,
+		enabled: false,
+		initialData: false,
+		gcTime: Number.POSITIVE_INFINITY,
+	});
+	const markOffered = useCallback(() => {
+		queryClient.setQueryData(githubAuthAutoLoginOfferedQueryKey, true);
+	}, [queryClient]);
+	return { offered: query.data, markOffered };
 }
 
 /** Single source of truth for whether the machine satisfies AO's startup

--- a/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
+++ b/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
@@ -41,8 +41,14 @@ export const githubAuthRequirementQueryOptions = {
 
 /** Advisory authentication probe. Kept separate from the startup gate because
  * credential-store access can be slow or interactive on some machines. */
-export function useGitHubAuthRequirement() {
-	return useQuery(githubAuthRequirementQueryOptions);
+export function useGitHubAuthRequirement(loginActive = false) {
+	return useQuery({
+		...githubAuthRequirementQueryOptions,
+		// The browser/device flow can finish before its PTY exit reaches the
+		// renderer. Probe only while AO owns an active login terminal so the card
+		// closes promptly after authorization without permanent background polling.
+		refetchInterval: loginActive ? 750 : false,
+	});
 }
 
 export function useStartGitHubAuthTerminal() {

--- a/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
+++ b/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { markTerminalHandleFresh } from "../lib/fresh-terminal-handles";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
@@ -64,6 +65,7 @@ export function useStartGitHubAuthTerminal() {
 			if (existing) return existing;
 			const { data, error } = await apiClient.POST("/api/v1/system/github-auth/terminal");
 			if (error || !data) throw new Error(apiErrorMessage(error, "Could not start GitHub sign-in."));
+			markTerminalHandleFresh(data.shellTerminal.handleId);
 			return data.shellTerminal;
 		},
 		onSuccess: (terminal) => {

--- a/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
+++ b/frontend/src/renderer/hooks/useSystemRequirementsGate.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
-import { shellTerminalsQueryKey, type ShellTerminal } from "./useShellTerminals";
+import { shellTerminalsQueryKey, shellTerminalsQueryOptions, type ShellTerminal } from "./useShellTerminals";
 
 export type SystemRequirement = components["schemas"]["SystemRequirement"];
 
@@ -57,6 +57,11 @@ export function useStartGitHubAuthTerminal() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: async (): Promise<ShellTerminal> => {
+			// Renderer state is lost on reload, while daemon-owned login PTYs survive.
+			// Reconcile before every start and fail without spawning if the list fails.
+			const terminals = await queryClient.fetchQuery({ ...shellTerminalsQueryOptions, staleTime: 0 });
+			const existing = terminals.find((terminal) => terminal.title === "Connect GitHub" && !terminal.sessionId && !terminal.projectId);
+			if (existing) return existing;
 			const { data, error } = await apiClient.POST("/api/v1/system/github-auth/terminal");
 			if (error || !data) throw new Error(apiErrorMessage(error, "Could not start GitHub sign-in."));
 			return data.shellTerminal;

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MuxConnectionState, TerminalMux } from "../lib/terminal-mux";
 import type { WorkspaceSession } from "../types/workspace";
-import { useTerminalSession, type AttachableTerminal, type TerminalWriteSource } from "./useTerminalSession";
+import { useTerminalSession, type AttachableTerminal } from "./useTerminalSession";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 const session: WorkspaceSession = {
@@ -91,7 +91,6 @@ type FakeTerminal = AttachableTerminal & {
 	autoCompleteWrites: boolean;
 	lines: string[];
 	pendingWriteCallbacks: Array<() => void>;
-	writeSources: TerminalWriteSource[];
 	latestOutputRequests: number;
 	typeKeys(data: string): void;
 	paste(data: string): void;
@@ -114,12 +113,10 @@ function createFakeTerminal(): FakeTerminal {
 		autoCompleteWrites: true,
 		lines: [],
 		pendingWriteCallbacks: [],
-		writeSources: [],
 		latestOutputRequests: 0,
 		// Mirrors xterm: the callback fires once the chunk has been parsed.
-		write: (bytes, done, source = "live") => {
+		write: (bytes, done) => {
 			terminal.lines.push(new TextDecoder().decode(bytes));
-			terminal.writeSources.push(source);
 			if (done) {
 				if (terminal.autoCompleteWrites) done();
 				else terminal.pendingWriteCallbacks.push(done);
@@ -468,7 +465,6 @@ describe("useTerminalSession", () => {
 			expect(terminal.lines).toEqual(["replay", "live-1"]);
 			act(() => muxes[0].emitData("handle-1", "live-2"));
 			expect(terminal.lines).toEqual(["replay", "live-1", "live-2"]);
-			expect(terminal.writeSources).toEqual(["live", "live", "live"]);
 		});
 
 		it("reveals a pane that replays nothing instead of holding the cover to the cap", () => {
@@ -702,7 +698,6 @@ describe("useTerminalSession", () => {
 			act(() => void vi.runOnlyPendingTimers());
 
 			expect(terminal.lines.join("")).toBe(`${replay}TAIL`);
-			expect(terminal.writeSources).toEqual(["live", "live", "live"]);
 		});
 
 		it("queues an unfinished replay before an exit marker and attachment teardown", () => {
@@ -721,7 +716,6 @@ describe("useTerminalSession", () => {
 			const output = terminal.lines.join("");
 			expect(output.startsWith(replay)).toBe(true);
 			expect(output).toContain("[process exited]");
-			expect(terminal.writeSources.slice(0, 3)).toEqual(["live", "live", "live"]);
 		});
 
 		it("lifts the cover when the attachment is torn down with no reconnect scheduled", () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -702,6 +702,7 @@ describe("useTerminalSession", () => {
 			act(() => void vi.runOnlyPendingTimers());
 
 			expect(terminal.lines.join("")).toBe(`${replay}TAIL`);
+			expect(terminal.writeSources).toEqual(["replay", "replay", "live"]);
 		});
 
 		it("queues an unfinished replay before an exit marker and attachment teardown", () => {
@@ -711,6 +712,8 @@ describe("useTerminalSession", () => {
 			act(() => muxes[0].emitData("handle-1", replay));
 			act(() => void vi.advanceTimersByTime(60));
 
+			act(() => muxes[0].emitData("handle-1", "\x1b[6n\x1b[?996n"));
+
 			// Exit lands while the next replay batch is waiting for its event-loop
 			// turn. The unwritten remainder must be submitted before the marker and
 			// before teardown invalidates this attachment's generation.
@@ -718,6 +721,7 @@ describe("useTerminalSession", () => {
 			const output = terminal.lines.join("");
 			expect(output.startsWith(replay)).toBe(true);
 			expect(output).toContain("[process exited]");
+			expect(terminal.writeSources.slice(0, 3)).toEqual(["replay", "replay", "live"]);
 		});
 
 		it("lifts the cover when the attachment is torn down with no reconnect scheduled", () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MuxConnectionState, TerminalMux } from "../lib/terminal-mux";
 import type { WorkspaceSession } from "../types/workspace";
-import { useTerminalSession, type AttachableTerminal } from "./useTerminalSession";
+import { useTerminalSession, type AttachableTerminal, type TerminalWriteSource } from "./useTerminalSession";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 const session: WorkspaceSession = {
@@ -91,6 +91,7 @@ type FakeTerminal = AttachableTerminal & {
 	autoCompleteWrites: boolean;
 	lines: string[];
 	pendingWriteCallbacks: Array<() => void>;
+	writeSources: TerminalWriteSource[];
 	latestOutputRequests: number;
 	typeKeys(data: string): void;
 	paste(data: string): void;
@@ -113,10 +114,12 @@ function createFakeTerminal(): FakeTerminal {
 		autoCompleteWrites: true,
 		lines: [],
 		pendingWriteCallbacks: [],
+		writeSources: [],
 		latestOutputRequests: 0,
 		// Mirrors xterm: the callback fires once the chunk has been parsed.
-		write: (bytes, done) => {
+		write: (bytes, done, source = "live") => {
 			terminal.lines.push(new TextDecoder().decode(bytes));
+			terminal.writeSources.push(source);
 			if (done) {
 				if (terminal.autoCompleteWrites) done();
 				else terminal.pendingWriteCallbacks.push(done);
@@ -465,6 +468,7 @@ describe("useTerminalSession", () => {
 			expect(terminal.lines).toEqual(["replay", "live-1"]);
 			act(() => muxes[0].emitData("handle-1", "live-2"));
 			expect(terminal.lines).toEqual(["replay", "live-1", "live-2"]);
+			expect(terminal.writeSources).toEqual(["replay", "live", "live"]);
 		});
 
 		it("reveals a pane that replays nothing instead of holding the cover to the cap", () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -468,7 +468,7 @@ describe("useTerminalSession", () => {
 			expect(terminal.lines).toEqual(["replay", "live-1"]);
 			act(() => muxes[0].emitData("handle-1", "live-2"));
 			expect(terminal.lines).toEqual(["replay", "live-1", "live-2"]);
-			expect(terminal.writeSources).toEqual(["replay", "live", "live"]);
+			expect(terminal.writeSources).toEqual(["live", "live", "live"]);
 		});
 
 		it("reveals a pane that replays nothing instead of holding the cover to the cap", () => {
@@ -702,7 +702,7 @@ describe("useTerminalSession", () => {
 			act(() => void vi.runOnlyPendingTimers());
 
 			expect(terminal.lines.join("")).toBe(`${replay}TAIL`);
-			expect(terminal.writeSources).toEqual(["replay", "replay", "live"]);
+			expect(terminal.writeSources).toEqual(["live", "live", "live"]);
 		});
 
 		it("queues an unfinished replay before an exit marker and attachment teardown", () => {
@@ -721,7 +721,7 @@ describe("useTerminalSession", () => {
 			const output = terminal.lines.join("");
 			expect(output.startsWith(replay)).toBe(true);
 			expect(output).toContain("[process exited]");
-			expect(terminal.writeSources.slice(0, 3)).toEqual(["replay", "replay", "live"]);
+			expect(terminal.writeSources.slice(0, 3)).toEqual(["live", "live", "live"]);
 		});
 
 		it("lifts the cover when the attachment is torn down with no reconnect scheduled", () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -26,6 +26,7 @@ import { workspaceQueryKey } from "./useWorkspaceQuery";
  * drive the hook with a tiny fake instead of a real xterm + DOM.
  */
 export type TerminalUserInputSource = "keyboard" | "paste" | "composition" | "shortcut" | "wheel" | "protocol";
+export type TerminalWriteSource = "live" | "replay";
 
 export type AttachableTerminal = {
 	cols: number;
@@ -35,7 +36,7 @@ export type AttachableTerminal = {
 	 * own write callback). The attachment uses it to reveal the pane at the
 	 * replay's final scroll position instead of guessing with a timer.
 	 */
-	write: (data: Uint8Array, done?: () => void) => void;
+	write: (data: Uint8Array, done?: () => void, source?: TerminalWriteSource) => void;
 	writeln: (line: string) => void;
 	/** Move xterm's logical viewport and DOM scrollbar to the latest output. */
 	showLatestOutput: () => void;
@@ -388,6 +389,9 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		let replayBatchTimer: ReturnType<typeof setTimeout> | null = null;
 		let replayBatchDone: (() => void) | null = null;
 		let replayWritesPreserved = false;
+		// The first attachment may be a brand-new PTY whose covered output is live.
+		// Reconnects replay history, so xterm-generated replies must be discarded.
+		const initialWriteSource: TerminalWriteSource = r.hasAttachedOnce ? "replay" : "live";
 
 		// Reveal only after xterm has parsed the coalesced replay and any late tail
 		// frames have gone quiet. The tail itself streams straight into xterm behind
@@ -427,8 +431,8 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				r.replayTailCapTimer = setTimeout(revealReplayTail, REPLAY_TAIL_CAP_MS);
 			}
 		};
-		// The mux does not distinguish historical bytes from fresh PTY output.
-		// This cover is visual buffering only; every batch must retain live protocol replies.
+		// The mux does not distinguish historical bytes from fresh PTY output, so
+		// the handle's creation state classifies the entire covered burst.
 		const writeReplayBatches = (bytes: Uint8Array, done: () => void) => {
 			replayBatchBytes = bytes;
 			replayBatchOffset = 0;
@@ -454,7 +458,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 						return;
 					}
 					replayBatchTimer = setTimeout(writeNext, 0);
-				});
+				}, initialWriteSource);
 			};
 			writeNext();
 		};
@@ -468,12 +472,12 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			if (replayBatchBytes && replayBatchOffset < replayBatchBytes.length) {
 				// The current batch is already in xterm's queue. Queue the remainder in
 				// one call before dispose so it cannot be overtaken or discarded.
-				terminal.write(replayBatchBytes.subarray(replayBatchOffset));
+				terminal.write(replayBatchBytes.subarray(replayBatchOffset), undefined, initialWriteSource);
 			}
 			replayBatchBytes = null;
 			replayBatchOffset = 0;
 			replayBatchDone = null;
-			for (const bytes of postReplayWriteQueue) terminal.write(bytes);
+			for (const bytes of postReplayWriteQueue) terminal.write(bytes, undefined, initialWriteSource);
 			postReplayWriteQueue.length = 0;
 			postReplayWriteActive = false;
 			pendingReplayWrites = 0;
@@ -506,7 +510,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				postReplayWriteActive = false;
 				pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
 				drainPostReplayWrites();
-			});
+			}, initialWriteSource);
 		};
 
 		// End the buffered part of the initial replay: concatenate what arrived so
@@ -552,7 +556,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				offset += chunk.length;
 			}
 			if (preserveBeforeTeardown) {
-				terminal.write(replay);
+				terminal.write(replay, undefined, initialWriteSource);
 				preservePendingReplayWrites();
 				return;
 			}

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -472,7 +472,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			replayBatchBytes = null;
 			replayBatchOffset = 0;
 			replayBatchDone = null;
-			for (const bytes of postReplayWriteQueue) terminal.write(bytes, undefined, "replay");
+			for (const bytes of postReplayWriteQueue) terminal.write(bytes, undefined, "live");
 			postReplayWriteQueue.length = 0;
 			postReplayWriteActive = false;
 			pendingReplayWrites = 0;
@@ -505,7 +505,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				postReplayWriteActive = false;
 				pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
 				drainPostReplayWrites();
-			}, "replay");
+			}, "live");
 		};
 
 		// End the buffered part of the initial replay: concatenate what arrived so

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -15,6 +15,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { getApiBaseUrl } from "../lib/api-client";
+import { consumeFreshTerminalHandle } from "../lib/fresh-terminal-handles";
 import { captureRendererEvent } from "../lib/telemetry";
 import { LOCAL_ECHO_ENABLED, withPredictiveLocalEcho } from "../lib/terminal-local-echo";
 import { createTerminalMux, muxUrlFromApiBase, type TerminalMux } from "../lib/terminal-mux";
@@ -389,9 +390,9 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		let replayBatchTimer: ReturnType<typeof setTimeout> | null = null;
 		let replayBatchDone: (() => void) | null = null;
 		let replayWritesPreserved = false;
-		// The first attachment may be a brand-new PTY whose covered output is live.
-		// Reconnects replay history, so xterm-generated replies must be discarded.
-		const initialWriteSource: TerminalWriteSource = r.hasAttachedOnce ? "replay" : "live";
+		// Only a newly created handle can have live initial output. Component
+		// mounts, including the first mount after app startup, can replay history.
+		const initialWriteSource: TerminalWriteSource = consumeFreshTerminalHandle(handle) ? "live" : "replay";
 
 		// Reveal only after xterm has parsed the coalesced replay and any late tail
 		// frames have gone quiet. The tail itself streams straight into xterm behind

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -428,6 +428,8 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				r.replayTailCapTimer = setTimeout(revealReplayTail, REPLAY_TAIL_CAP_MS);
 			}
 		};
+		// The mux does not distinguish historical bytes from fresh PTY output.
+		// This cover is visual buffering only; every batch must retain live protocol replies.
 		const writeReplayBatches = (bytes: Uint8Array, done: () => void) => {
 			replayBatchBytes = bytes;
 			replayBatchOffset = 0;
@@ -453,7 +455,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 						return;
 					}
 					replayBatchTimer = setTimeout(writeNext, 0);
-				}, "replay");
+				}, "live");
 			};
 			writeNext();
 		};
@@ -467,7 +469,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			if (replayBatchBytes && replayBatchOffset < replayBatchBytes.length) {
 				// The current batch is already in xterm's queue. Queue the remainder in
 				// one call before dispose so it cannot be overtaken or discarded.
-				terminal.write(replayBatchBytes.subarray(replayBatchOffset), undefined, "replay");
+				terminal.write(replayBatchBytes.subarray(replayBatchOffset), undefined, "live");
 			}
 			replayBatchBytes = null;
 			replayBatchOffset = 0;
@@ -551,7 +553,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				offset += chunk.length;
 			}
 			if (preserveBeforeTeardown) {
-				terminal.write(replay, undefined, "replay");
+				terminal.write(replay, undefined, "live");
 				preservePendingReplayWrites();
 				return;
 			}

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -26,6 +26,7 @@ import { workspaceQueryKey } from "./useWorkspaceQuery";
  * drive the hook with a tiny fake instead of a real xterm + DOM.
  */
 export type TerminalUserInputSource = "keyboard" | "paste" | "composition" | "shortcut" | "wheel" | "protocol";
+export type TerminalWriteSource = "live" | "replay";
 
 export type AttachableTerminal = {
 	cols: number;
@@ -35,7 +36,7 @@ export type AttachableTerminal = {
 	 * own write callback). The attachment uses it to reveal the pane at the
 	 * replay's final scroll position instead of guessing with a timer.
 	 */
-	write: (data: Uint8Array, done?: () => void) => void;
+	write: (data: Uint8Array, done?: () => void, source?: TerminalWriteSource) => void;
 	writeln: (line: string) => void;
 	/** Move xterm's logical viewport and DOM scrollbar to the latest output. */
 	showLatestOutput: () => void;
@@ -452,7 +453,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 						return;
 					}
 					replayBatchTimer = setTimeout(writeNext, 0);
-				});
+				}, "replay");
 			};
 			writeNext();
 		};
@@ -466,12 +467,12 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			if (replayBatchBytes && replayBatchOffset < replayBatchBytes.length) {
 				// The current batch is already in xterm's queue. Queue the remainder in
 				// one call before dispose so it cannot be overtaken or discarded.
-				terminal.write(replayBatchBytes.subarray(replayBatchOffset));
+				terminal.write(replayBatchBytes.subarray(replayBatchOffset), undefined, "replay");
 			}
 			replayBatchBytes = null;
 			replayBatchOffset = 0;
 			replayBatchDone = null;
-			for (const bytes of postReplayWriteQueue) terminal.write(bytes);
+			for (const bytes of postReplayWriteQueue) terminal.write(bytes, undefined, "replay");
 			postReplayWriteQueue.length = 0;
 			postReplayWriteActive = false;
 			pendingReplayWrites = 0;
@@ -504,7 +505,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				postReplayWriteActive = false;
 				pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
 				drainPostReplayWrites();
-			});
+			}, "replay");
 		};
 
 		// End the buffered part of the initial replay: concatenate what arrived so
@@ -550,7 +551,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				offset += chunk.length;
 			}
 			if (preserveBeforeTeardown) {
-				terminal.write(replay);
+				terminal.write(replay, undefined, "replay");
 				preservePendingReplayWrites();
 				return;
 			}

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -26,7 +26,6 @@ import { workspaceQueryKey } from "./useWorkspaceQuery";
  * drive the hook with a tiny fake instead of a real xterm + DOM.
  */
 export type TerminalUserInputSource = "keyboard" | "paste" | "composition" | "shortcut" | "wheel" | "protocol";
-export type TerminalWriteSource = "live" | "replay";
 
 export type AttachableTerminal = {
 	cols: number;
@@ -36,7 +35,7 @@ export type AttachableTerminal = {
 	 * own write callback). The attachment uses it to reveal the pane at the
 	 * replay's final scroll position instead of guessing with a timer.
 	 */
-	write: (data: Uint8Array, done?: () => void, source?: TerminalWriteSource) => void;
+	write: (data: Uint8Array, done?: () => void) => void;
 	writeln: (line: string) => void;
 	/** Move xterm's logical viewport and DOM scrollbar to the latest output. */
 	showLatestOutput: () => void;
@@ -455,7 +454,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 						return;
 					}
 					replayBatchTimer = setTimeout(writeNext, 0);
-				}, "live");
+				});
 			};
 			writeNext();
 		};
@@ -469,12 +468,12 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 			if (replayBatchBytes && replayBatchOffset < replayBatchBytes.length) {
 				// The current batch is already in xterm's queue. Queue the remainder in
 				// one call before dispose so it cannot be overtaken or discarded.
-				terminal.write(replayBatchBytes.subarray(replayBatchOffset), undefined, "live");
+				terminal.write(replayBatchBytes.subarray(replayBatchOffset));
 			}
 			replayBatchBytes = null;
 			replayBatchOffset = 0;
 			replayBatchDone = null;
-			for (const bytes of postReplayWriteQueue) terminal.write(bytes, undefined, "live");
+			for (const bytes of postReplayWriteQueue) terminal.write(bytes);
 			postReplayWriteQueue.length = 0;
 			postReplayWriteActive = false;
 			pendingReplayWrites = 0;
@@ -507,7 +506,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				postReplayWriteActive = false;
 				pendingReplayWrites = Math.max(0, pendingReplayWrites - 1);
 				drainPostReplayWrites();
-			}, "live");
+			});
 		};
 
 		// End the buffered part of the initial replay: concatenate what arrived so
@@ -553,7 +552,7 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 				offset += chunk.length;
 			}
 			if (preserveBeforeTeardown) {
-				terminal.write(replay, undefined, "live");
+				terminal.write(replay);
 				preservePendingReplayWrites();
 				return;
 			}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1234,6 +1234,8 @@
 	"startup.detailGhMissing": "gh wurde nicht im PATH gefunden. Damit können Agent-Sitzungen Pull Requests öffnen und Issues lesen, AO funktioniert aber auch ohne.",
 	"startup.githubLogin": "Bei GitHub anmelden",
 	"startup.githubLoginRunning": "Anmeldung in diesem Terminal abschließen",
+	"startup.githubLoginStopped": "Die Anmeldung wurde beendet, bevor GitHub verbunden war",
+	"startup.githubLoginTryAgain": "Erneut versuchen",
 	"startup.githubConnected": "GitHub verbunden",
 	"startup.githubLoginStarting": "Anmeldung wird gestartet…",
 	"startup.githubSetupMissingCli": "Installiere GitHub CLI und melde dich an, bevor Agenten Pull Requests öffnen sollen.",

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1234,6 +1234,7 @@
 	"startup.detailGhMissing": "gh wurde nicht im PATH gefunden. Damit können Agent-Sitzungen Pull Requests öffnen und Issues lesen, AO funktioniert aber auch ohne.",
 	"startup.githubLogin": "Bei GitHub anmelden",
 	"startup.githubLoginRunning": "Anmeldung in diesem Terminal abschließen",
+	"startup.githubConnected": "GitHub verbunden",
 	"startup.githubLoginStarting": "Anmeldung wird gestartet…",
 	"startup.githubSetupMissingCli": "Installiere GitHub CLI und melde dich an, bevor Agenten Pull Requests öffnen sollen.",
 	"startup.githubSetupSignedOut": "Melde dich einmal an, damit Agent-Sitzungen Pull Requests öffnen und Issues lesen können, ohne nach einem Token zu fragen.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1371,6 +1371,7 @@
 	"startup.detailGhMissing": "gh was not found on PATH. It lets agent sessions open pull requests and read issues, but AO runs fine without it.",
 	"startup.githubLogin": "Sign in with GitHub",
 	"startup.githubLoginRunning": "Complete sign-in in this terminal",
+	"startup.githubConnected": "GitHub connected",
 	"startup.githubLoginStarting": "Starting sign-in…",
 	"startup.githubSetupMissingCli": "Install GitHub CLI and sign in before asking agents to open pull requests.",
 	"startup.githubSetupSignedOut": "Sign in once so agent sessions can open pull requests and read issues without asking you for a token.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1371,6 +1371,8 @@
 	"startup.detailGhMissing": "gh was not found on PATH. It lets agent sessions open pull requests and read issues, but AO runs fine without it.",
 	"startup.githubLogin": "Sign in with GitHub",
 	"startup.githubLoginRunning": "Complete sign-in in this terminal",
+	"startup.githubLoginStopped": "Sign-in stopped before GitHub was connected",
+	"startup.githubLoginTryAgain": "Try again",
 	"startup.githubConnected": "GitHub connected",
 	"startup.githubLoginStarting": "Starting sign-in…",
 	"startup.githubSetupMissingCli": "Install GitHub CLI and sign in before asking agents to open pull requests.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1251,6 +1251,7 @@
 	"startup.detailGhMissing": "No se encontró gh en el PATH. Permite que las sesiones de agente abran pull requests y lean issues, pero AO funciona bien sin él.",
 	"startup.githubLogin": "Iniciar sesión con GitHub",
 	"startup.githubLoginRunning": "Completa el inicio de sesión en esta terminal",
+	"startup.githubConnected": "GitHub conectado",
 	"startup.githubLoginStarting": "Iniciando sesión…",
 	"startup.githubSetupMissingCli": "Instala GitHub CLI e inicia sesión antes de pedir a los agentes que abran pull requests.",
 	"startup.githubSetupSignedOut": "Inicia sesión una vez para que las sesiones de agente puedan abrir pull requests y leer issues sin pedirte un token.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1251,6 +1251,8 @@
 	"startup.detailGhMissing": "No se encontró gh en el PATH. Permite que las sesiones de agente abran pull requests y lean issues, pero AO funciona bien sin él.",
 	"startup.githubLogin": "Iniciar sesión con GitHub",
 	"startup.githubLoginRunning": "Completa el inicio de sesión en esta terminal",
+	"startup.githubLoginStopped": "El inicio de sesión se detuvo antes de conectar GitHub",
+	"startup.githubLoginTryAgain": "Intentar de nuevo",
 	"startup.githubConnected": "GitHub conectado",
 	"startup.githubLoginStarting": "Iniciando sesión…",
 	"startup.githubSetupMissingCli": "Instala GitHub CLI e inicia sesión antes de pedir a los agentes que abran pull requests.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1251,6 +1251,7 @@
 	"startup.detailGhMissing": "gh est introuvable dans le PATH. Il permet aux sessions d'agent d'ouvrir des pull requests et de lire les issues, mais AO fonctionne très bien sans.",
 	"startup.githubLogin": "Se connecter à GitHub",
 	"startup.githubLoginRunning": "Terminez la connexion dans ce terminal",
+	"startup.githubConnected": "GitHub connecté",
 	"startup.githubLoginStarting": "Démarrage de la connexion…",
 	"startup.githubSetupMissingCli": "Installez GitHub CLI et connectez-vous avant de demander aux agents d'ouvrir des pull requests.",
 	"startup.githubSetupSignedOut": "Connectez-vous une fois pour que les sessions d'agent puissent ouvrir des pull requests et lire les issues sans demander de jeton.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1251,6 +1251,8 @@
 	"startup.detailGhMissing": "gh est introuvable dans le PATH. Il permet aux sessions d'agent d'ouvrir des pull requests et de lire les issues, mais AO fonctionne très bien sans.",
 	"startup.githubLogin": "Se connecter à GitHub",
 	"startup.githubLoginRunning": "Terminez la connexion dans ce terminal",
+	"startup.githubLoginStopped": "La connexion s’est arrêtée avant que GitHub soit connecté",
+	"startup.githubLoginTryAgain": "Réessayer",
 	"startup.githubConnected": "GitHub connecté",
 	"startup.githubLoginStarting": "Démarrage de la connexion…",
 	"startup.githubSetupMissingCli": "Installez GitHub CLI et connectez-vous avant de demander aux agents d'ouvrir des pull requests.",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1234,6 +1234,8 @@
 	"startup.detailGhMissing": "gh が PATH に見つかりませんでした。エージェントセッションがプルリクエストを開いたり Issue を読んだりできるようになりますが、なくても AO は問題なく動作します。",
 	"startup.githubLogin": "GitHub にサインイン",
 	"startup.githubLoginRunning": "このターミナルでサインインを完了してください",
+	"startup.githubLoginStopped": "GitHub に接続する前にサインインが停止しました",
+	"startup.githubLoginTryAgain": "もう一度試す",
 	"startup.githubConnected": "GitHub に接続しました",
 	"startup.githubLoginStarting": "サインインを開始しています…",
 	"startup.githubSetupMissingCli": "エージェントにプルリクエストを開かせる前に GitHub CLI をインストールしてサインインしてください。",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1234,6 +1234,7 @@
 	"startup.detailGhMissing": "gh が PATH に見つかりませんでした。エージェントセッションがプルリクエストを開いたり Issue を読んだりできるようになりますが、なくても AO は問題なく動作します。",
 	"startup.githubLogin": "GitHub にサインイン",
 	"startup.githubLoginRunning": "このターミナルでサインインを完了してください",
+	"startup.githubConnected": "GitHub に接続しました",
 	"startup.githubLoginStarting": "サインインを開始しています…",
 	"startup.githubSetupMissingCli": "エージェントにプルリクエストを開かせる前に GitHub CLI をインストールしてサインインしてください。",
 	"startup.githubSetupSignedOut": "一度サインインすると、トークンを求められずにエージェントセッションがプルリクエストを開き、Issue を読めるようになります。",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1234,6 +1234,8 @@
 	"startup.detailGhMissing": "PATH에서 gh를 찾을 수 없습니다. gh가 있으면 에이전트 세션이 풀 리퀘스트를 열고 이슈를 읽을 수 있지만, 없어도 AO는 정상적으로 동작합니다.",
 	"startup.githubLogin": "GitHub에 로그인",
 	"startup.githubLoginRunning": "이 터미널에서 로그인을 완료하세요",
+	"startup.githubLoginStopped": "GitHub에 연결되기 전에 로그인이 중지되었습니다",
+	"startup.githubLoginTryAgain": "다시 시도",
 	"startup.githubConnected": "GitHub 연결됨",
 	"startup.githubLoginStarting": "로그인 시작 중…",
 	"startup.githubSetupMissingCli": "에이전트에게 풀 리퀘스트 생성을 요청하기 전에 GitHub CLI를 설치하고 로그인하세요.",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1234,6 +1234,7 @@
 	"startup.detailGhMissing": "PATH에서 gh를 찾을 수 없습니다. gh가 있으면 에이전트 세션이 풀 리퀘스트를 열고 이슈를 읽을 수 있지만, 없어도 AO는 정상적으로 동작합니다.",
 	"startup.githubLogin": "GitHub에 로그인",
 	"startup.githubLoginRunning": "이 터미널에서 로그인을 완료하세요",
+	"startup.githubConnected": "GitHub 연결됨",
 	"startup.githubLoginStarting": "로그인 시작 중…",
 	"startup.githubSetupMissingCli": "에이전트에게 풀 리퀘스트 생성을 요청하기 전에 GitHub CLI를 설치하고 로그인하세요.",
 	"startup.githubSetupSignedOut": "한 번 로그인하면 에이전트 세션이 토큰을 요청하지 않고 풀 리퀘스트를 열고 이슈를 읽을 수 있습니다.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1251,6 +1251,8 @@
 	"startup.detailGhMissing": "O gh não foi encontrado no PATH. Ele permite que as sessões do agente abram pull requests e leiam issues, mas o AO funciona bem sem ele.",
 	"startup.githubLogin": "Entrar com o GitHub",
 	"startup.githubLoginRunning": "Conclua o login neste terminal",
+	"startup.githubLoginStopped": "O login foi interrompido antes de conectar o GitHub",
+	"startup.githubLoginTryAgain": "Tentar novamente",
 	"startup.githubConnected": "GitHub conectado",
 	"startup.githubLoginStarting": "Iniciando login…",
 	"startup.githubSetupMissingCli": "Instale a GitHub CLI e entre na conta antes de pedir aos agentes para abrir pull requests.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1251,6 +1251,7 @@
 	"startup.detailGhMissing": "O gh não foi encontrado no PATH. Ele permite que as sessões do agente abram pull requests e leiam issues, mas o AO funciona bem sem ele.",
 	"startup.githubLogin": "Entrar com o GitHub",
 	"startup.githubLoginRunning": "Conclua o login neste terminal",
+	"startup.githubConnected": "GitHub conectado",
 	"startup.githubLoginStarting": "Iniciando login…",
 	"startup.githubSetupMissingCli": "Instale a GitHub CLI e entre na conta antes de pedir aos agentes para abrir pull requests.",
 	"startup.githubSetupSignedOut": "Entre uma vez para que as sessões do agente possam abrir pull requests e ler issues sem pedir um token.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1235,6 +1235,8 @@
 	"startup.detailGhMissing": "在 PATH 中未找到 gh。它可让代理会话打开拉取请求并读取议题，但没有它 AO 也能正常运行。",
 	"startup.githubLogin": "登录 GitHub",
 	"startup.githubLoginRunning": "在此终端中完成登录",
+	"startup.githubLoginStopped": "登录在连接 GitHub 前已停止",
+	"startup.githubLoginTryAgain": "重试",
 	"startup.githubConnected": "GitHub 已连接",
 	"startup.githubLoginStarting": "正在开始登录…",
 	"startup.githubSetupMissingCli": "在让代理创建拉取请求之前，请安装 GitHub CLI 并登录。",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1235,6 +1235,7 @@
 	"startup.detailGhMissing": "在 PATH 中未找到 gh。它可让代理会话打开拉取请求并读取议题，但没有它 AO 也能正常运行。",
 	"startup.githubLogin": "登录 GitHub",
 	"startup.githubLoginRunning": "在此终端中完成登录",
+	"startup.githubConnected": "GitHub 已连接",
 	"startup.githubLoginStarting": "正在开始登录…",
 	"startup.githubSetupMissingCli": "在让代理创建拉取请求之前，请安装 GitHub CLI 并登录。",
 	"startup.githubSetupSignedOut": "登录一次后，代理会话即可创建拉取请求和读取议题，而无需向你索取令牌。",

--- a/frontend/src/renderer/lib/fresh-terminal-handles.ts
+++ b/frontend/src/renderer/lib/fresh-terminal-handles.ts
@@ -1,0 +1,12 @@
+// Only PTYs created by this renderer may answer DSRs in their initial output.
+// Consuming the handle on the first connection keeps remounts and reconnects
+// conservative; handles discovered after an app restart are replay by default.
+const freshTerminalHandles = new Set<string>();
+
+export function markTerminalHandleFresh(handleId: string): void {
+	freshTerminalHandles.add(handleId);
+}
+
+export function consumeFreshTerminalHandle(handleId: string): boolean {
+	return freshTerminalHandles.delete(handleId);
+}

--- a/frontend/src/renderer/lib/osc-color-report.test.ts
+++ b/frontend/src/renderer/lib/osc-color-report.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildOscColorReports,
+	createCursorPositionReportForwarder,
 	createOscColorReportForwarder,
 	cursorOscProbeRepliesForOutput,
 	hexToOscRgb,
@@ -143,5 +144,36 @@ describe("createOscColorReportForwarder", () => {
 
 		expect(forwarded).toEqual([]);
 		forwarder.dispose();
+	});
+});
+
+describe("createCursorPositionReportForwarder", () => {
+	it("forwards standard and private cursor-position replies", () => {
+		const forwarded: string[] = [];
+		const forwarder = createCursorPositionReportForwarder((report) => forwarded.push(report));
+
+		forwarder.push("\x1b[12;34R\x1b[?5;9R");
+
+		expect(forwarded).toEqual(["\x1b[12;34R", "\x1b[?5;9R"]);
+	});
+
+	it("buffers a split cursor-position reply", () => {
+		const forwarded: string[] = [];
+		const forwarder = createCursorPositionReportForwarder((report) => forwarded.push(report));
+
+		forwarder.push("\x1b[12;");
+		expect(forwarded).toEqual([]);
+		forwarder.push("34R");
+
+		expect(forwarded).toEqual(["\x1b[12;34R"]);
+	});
+
+	it("rejects keyboard and malformed control data", () => {
+		const forwarded: string[] = [];
+		const forwarder = createCursorPositionReportForwarder((report) => forwarded.push(report));
+
+		forwarder.push("y\r\x1b[A\x1b[0;2R\x1b[2;3H");
+
+		expect(forwarded).toEqual([]);
 	});
 });

--- a/frontend/src/renderer/lib/osc-color-report.test.ts
+++ b/frontend/src/renderer/lib/osc-color-report.test.ts
@@ -152,6 +152,7 @@ describe("createCursorPositionReportForwarder", () => {
 		const forwarded: string[] = [];
 		const forwarder = createCursorPositionReportForwarder((report) => forwarded.push(report));
 
+		forwarder.observeOutput("\x1b[6n\x1b[?6n");
 		forwarder.push("\x1b[12;34R\x1b[?5;9R");
 
 		expect(forwarded).toEqual(["\x1b[12;34R", "\x1b[?5;9R"]);
@@ -161,6 +162,8 @@ describe("createCursorPositionReportForwarder", () => {
 		const forwarded: string[] = [];
 		const forwarder = createCursorPositionReportForwarder((report) => forwarded.push(report));
 
+		forwarder.observeOutput("\x1b[");
+		forwarder.observeOutput("6n");
 		forwarder.push("\x1b[12;");
 		expect(forwarded).toEqual([]);
 		forwarder.push("34R");
@@ -168,11 +171,11 @@ describe("createCursorPositionReportForwarder", () => {
 		expect(forwarded).toEqual(["\x1b[12;34R"]);
 	});
 
-	it("rejects keyboard and malformed control data", () => {
+	it("rejects unsolicited, keyboard, and malformed control data", () => {
 		const forwarded: string[] = [];
 		const forwarder = createCursorPositionReportForwarder((report) => forwarded.push(report));
 
-		forwarder.push("y\r\x1b[A\x1b[0;2R\x1b[2;3H");
+		forwarder.push("\x1b[12;34Ry\r\x1b[A\x1b[0;2R\x1b[2;3H");
 
 		expect(forwarded).toEqual([]);
 	});

--- a/frontend/src/renderer/lib/osc-color-report.ts
+++ b/frontend/src/renderer/lib/osc-color-report.ts
@@ -18,6 +18,9 @@ const MAX_OSC_BUFFER_LENGTH = 16 * 1024;
 const CURSOR_POSITION_REPORT = /^\u001b\[\??[1-9]\d{0,4};[1-9]\d{0,4}R/;
 const PARTIAL_CURSOR_POSITION_REPORT = /^\u001b(?:\[\??(?:\d{0,5}(?:;\d{0,5})?)?)?$/;
 const MAX_CURSOR_POSITION_REPORT_LENGTH = 16;
+const CURSOR_POSITION_REQUEST = /\u001b\[\??6n/g;
+const CURSOR_POSITION_REQUEST_PREFIXES = ["\x1b", "\x1b[", "\x1b[6", "\x1b[?", "\x1b[?6"];
+const MAX_PENDING_CURSOR_POSITION_REPORTS = 32;
 
 export function isOscColorReport(data: string): boolean {
 	return OSC_COLOR_REPORT.test(data);
@@ -132,12 +135,23 @@ export function createOscColorReportForwarder(emit: (report: string) => void): {
 
 /** Buffer split xterm onData chunks and forward only strict ANSI cursor-position replies. */
 export function createCursorPositionReportForwarder(emit: (report: string) => void): {
+	observeOutput: (data: string) => void;
 	push: (data: string) => void;
 	dispose: () => void;
 } {
 	let buffer = "";
+	let outputBuffer = "";
+	let pendingReports = 0;
 
 	return {
+		observeOutput(data: string) {
+			const output = outputBuffer + data;
+			const requests = output.match(CURSOR_POSITION_REQUEST)?.length ?? 0;
+			pendingReports = Math.min(MAX_PENDING_CURSOR_POSITION_REPORTS, pendingReports + requests);
+			outputBuffer = CURSOR_POSITION_REQUEST_PREFIXES
+				.filter((prefix) => output.endsWith(prefix))
+				.sort((left, right) => right.length - left.length)[0] ?? "";
+		},
 		push(data: string) {
 			buffer += data;
 			for (;;) {
@@ -150,7 +164,10 @@ export function createCursorPositionReportForwarder(emit: (report: string) => vo
 
 				const match = buffer.match(CURSOR_POSITION_REPORT);
 				if (match) {
-					emit(match[0]);
+					if (pendingReports > 0) {
+						pendingReports--;
+						emit(match[0]);
+					}
 					buffer = buffer.slice(match[0].length);
 					continue;
 				}
@@ -161,6 +178,8 @@ export function createCursorPositionReportForwarder(emit: (report: string) => vo
 		},
 		dispose() {
 			buffer = "";
+			outputBuffer = "";
+			pendingReports = 0;
 		},
 	};
 }

--- a/frontend/src/renderer/lib/osc-color-report.ts
+++ b/frontend/src/renderer/lib/osc-color-report.ts
@@ -135,6 +135,7 @@ export function createOscColorReportForwarder(emit: (report: string) => void): {
 
 /** Buffer split xterm onData chunks and forward only strict ANSI cursor-position replies. */
 export function createCursorPositionReportForwarder(emit: (report: string) => void): {
+	hasPartialRequest: () => boolean;
 	observeOutput: (data: string) => void;
 	push: (data: string) => void;
 	dispose: () => void;
@@ -144,6 +145,9 @@ export function createCursorPositionReportForwarder(emit: (report: string) => vo
 	let pendingReports = 0;
 
 	return {
+		hasPartialRequest() {
+			return outputBuffer.length > 0;
+		},
 		observeOutput(data: string) {
 			const output = outputBuffer + data;
 			const requests = output.match(CURSOR_POSITION_REQUEST)?.length ?? 0;

--- a/frontend/src/renderer/lib/osc-color-report.ts
+++ b/frontend/src/renderer/lib/osc-color-report.ts
@@ -15,6 +15,9 @@ const OSC_COLOR_REPORT = new RegExp(`^\\u001b]${OSC_COLOR_PAYLOAD}(?:\\u0007|\\u
 const COMPLETE_OSC_COLOR_REPORT = new RegExp(`^\\u001b]${OSC_COLOR_PAYLOAD}(?:\\u0007|\\u001b\\\\)`);
 const OSC_COLOR_PROBE = /\u001b\](?:10|11|12);\?/;
 const MAX_OSC_BUFFER_LENGTH = 16 * 1024;
+const CURSOR_POSITION_REPORT = /^\u001b\[\??[1-9]\d{0,4};[1-9]\d{0,4}R/;
+const PARTIAL_CURSOR_POSITION_REPORT = /^\u001b(?:\[\??(?:\d{0,5}(?:;\d{0,5})?)?)?$/;
+const MAX_CURSOR_POSITION_REPORT_LENGTH = 16;
 
 export function isOscColorReport(data: string): boolean {
 	return OSC_COLOR_REPORT.test(data);
@@ -119,6 +122,41 @@ export function createOscColorReportForwarder(emit: (report: string) => void): {
 					continue;
 				}
 				return;
+			}
+		},
+		dispose() {
+			buffer = "";
+		},
+	};
+}
+
+/** Buffer split xterm onData chunks and forward only strict ANSI cursor-position replies. */
+export function createCursorPositionReportForwarder(emit: (report: string) => void): {
+	push: (data: string) => void;
+	dispose: () => void;
+} {
+	let buffer = "";
+
+	return {
+		push(data: string) {
+			buffer += data;
+			for (;;) {
+				const reportStart = buffer.indexOf("\x1b[");
+				if (reportStart === -1) {
+					buffer = buffer.endsWith("\x1b") ? "\x1b" : "";
+					return;
+				}
+				if (reportStart > 0) buffer = buffer.slice(reportStart);
+
+				const match = buffer.match(CURSOR_POSITION_REPORT);
+				if (match) {
+					emit(match[0]);
+					buffer = buffer.slice(match[0].length);
+					continue;
+				}
+				if (buffer.length <= MAX_CURSOR_POSITION_REPORT_LENGTH && PARTIAL_CURSOR_POSITION_REPORT.test(buffer)) return;
+
+				buffer = buffer.slice(1);
 			}
 		},
 		dispose() {


### PR DESCRIPTION
Fixes #5008

When GitHub CLI is installed but signed out, AO opens the native `gh auth login` flow in an embedded terminal. Users retain the installed CLI's choices of host, protocol, and authentication method. AO polls while login is active, closes the terminal after successful authentication, and provides retry/check actions after an interrupted login.

The renderer checks the daemon's shell-terminal list before starting login and adopts an existing standalone “Connect GitHub” terminal. This recovers a login after window reloads without spawning another PTY. A failed list request prevents creation. Renderer query state retains the handle and dismissal state across navigation. Failed close requests retain the handle, and retry starts a replacement only after successful closure.

Cursor-position replies are correlated with PTY requests, including requests split across chunks. The initial visual buffering window can contain fresh PTY output, so its writes retain live protocol handling, including during teardown flushing. The mux has no history/live boundary: suppressing historical DSRs based on arrival timing would also suppress fresh login prompts. All production writes share one protocol path; the unused replay/live argument and test-only replay branch have been removed. Cursor theme requests continue to receive replies during buffered output.

Authentication uses `gh auth status --active --json hosts`, accepting an active successful account on GitHub.com or Enterprise. An empty host map is definitively signed out and does not fall back. Unsupported or malformed JSON and validation failures for configured hosts fall back to local `gh auth token`, discarding token output. This is a credential-configuration advisory, not a guarantee that a configured token remains valid; the fallback can accept expired or revoked local credentials. The fallback paths share one implementation. Each subprocess has a three-second budget, so fallback may take up to six seconds. Polling is limited to active login terminals.

The change also preserves deferred development-only xterm disposal for StrictMode and translated success/retry copy. GitHub remains optional for local workflows.

Validation:

- Backend systemcheck tests passed (`GOCACHE=/private/tmp/ao-go-cache GOWORK=off go test ./internal/service/systemcheck`).
- 186 targeted frontend tests passed across XtermTerminal, useTerminalSession, useSystemRequirementsGate, board-empty-states, and osc-color-report. The final XtermTerminal test adjustment was rerun separately (87 passed).
- Coverage includes a split DSR through the real attachment hook and XtermTerminal protocol handling with a simulated xterm parser, pending CPR credits, Cursor theme replies, renderer-restart adoption, failed terminal-list reconciliation, failed close/retry retention, and definitive empty-host sign-out.
- `git diff --check` passed.
- Frontend typechecking reports only the missing local `mermaid` dependency in unchanged `mermaid-diagram.ts` (lines 93 and 100); no changed-file errors remain. Native Electron validation was not repeated for these review fixes.
