### PR TITLE
feat(cloud): auto-link a project's UI-created worker to its active orchestrator

### DIFF
--- a/cloud/internal/domain/types.go
+++ b/cloud/internal/domain/types.go
@@ -105,6 +105,12 @@ type CreateSession struct {
 	ResourceProfile  json.RawMessage
 	BootstrapContext json.RawMessage
 	Release          string
+	// ParentSessionID links a top-level worker to a project's active
+	// orchestrator so the orchestrator sees, drives, and receives reports from
+	// it exactly as it would a worker it spawned itself. Empty for an
+	// orchestrator, a standalone worker, or a worker created for a project that
+	// has no active orchestrator.
+	ParentSessionID string
 }
 
 type ClientEvent struct {

--- a/cloud/internal/httpapi/resource_handlers.go
+++ b/cloud/internal/httpapi/resource_handlers.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -13,6 +14,14 @@ import (
 	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
 	"github.com/go-chi/chi/v5"
 )
+
+// projectOrchestratorStore finds a project's single active orchestrator so a
+// top-level worker can be auto-linked to it as a child. It mirrors the
+// narrow-interface pattern used elsewhere so the concrete store carries the
+// method without widening Store.
+type projectOrchestratorStore interface {
+	ProjectActiveOrchestrator(ctx context.Context, orgID, projectID string) (orchestratorID, provider string, found bool, err error)
+}
 
 type createProjectRequest struct {
 	DisplayName   string         `json:"displayName"`
@@ -300,6 +309,30 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// A top-level worker created for a project that already has an active
+	// orchestrator is auto-linked to it: the orchestrator then sees, drives, and
+	// receives reports from it exactly as it would a worker it spawned itself,
+	// because ao list, the Workers view, ao send/kill, and the ao report reverse
+	// channel all key on parent_session_id. The worker also inherits the
+	// orchestrator's provider so the project's whole worker tree stays on one
+	// provider, matching ao spawn'ed children. An orchestrator, or a worker
+	// created before any orchestrator exists, stays unlinked.
+	parentSessionID := ""
+	if request.Kind == "worker" {
+		if orchStore, ok := s.store.(projectOrchestratorStore); ok {
+			orchestratorID, orchestratorProvider, found, lookupErr := orchStore.ProjectActiveOrchestrator(
+				r.Context(), orgID, request.ProjectID,
+			)
+			if lookupErr != nil {
+				s.writeStoreError(w, r, lookupErr)
+				return
+			}
+			if found {
+				parentSessionID = orchestratorID
+				request.Provider = orchestratorProvider
+			}
+		}
+	}
 	// The plan is resolved once, here, and stamped onto the sandbox row. The
 	// reconciler reads it back from the row rather than from configuration, so
 	// a later config change cannot disturb a session already in flight.
@@ -331,6 +364,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 			ResourceProfile:     plan.ResourceProfile,
 			BootstrapContext:    plan.BootstrapContext,
 			Release:             s.release,
+			ParentSessionID:     parentSessionID,
 		},
 	)
 	if err != nil {

--- a/cloud/internal/httpapi/resource_handlers_autolink_test.go
+++ b/cloud/internal/httpapi/resource_handlers_autolink_test.go
@@ -1,0 +1,144 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/cloud/internal/domain"
+	"github.com/aoagents/agent-orchestrator/cloud/internal/sandbox"
+	"github.com/go-chi/chi/v5"
+)
+
+const autolinkProjectID = "00000000-0000-0000-0000-0000000000d4"
+const autolinkOrgID = "00000000-0000-0000-0000-0000000000a1"
+
+// stubAutolinkStore embeds Store (nil) so it satisfies the interface while
+// implementing only the two methods createSession reaches on the auto-link
+// path. It deliberately does not implement providerConnectionStore, so the
+// handler's coding-agent credential check is skipped.
+type stubAutolinkStore struct {
+	Store
+	orchestratorID string
+	orchProvider   string
+	orchFound      bool
+	orchErr        error
+	captured       domain.CreateSession
+	created        bool
+}
+
+func (s *stubAutolinkStore) ProjectActiveOrchestrator(
+	_ context.Context, _, _ string,
+) (string, string, bool, error) {
+	return s.orchestratorID, s.orchProvider, s.orchFound, s.orchErr
+}
+
+func (s *stubAutolinkStore) CreateSession(
+	_ context.Context, _ domain.Principal, _, _ string, _ int, input domain.CreateSession,
+) (domain.Session, error) {
+	s.created = true
+	s.captured = input
+	return domain.Session{ID: "00000000-0000-0000-0000-0000000000e5", Kind: input.Kind}, nil
+}
+
+func createSessionRequestHTTP(t *testing.T, kind, provider string) *http.Request {
+	t.Helper()
+	body := `{"projectId":"` + autolinkProjectID + `","kind":"` + kind +
+		`","harness":"claude-code","displayName":"add-logger","prompt":"do the work","mode":"trusted"` +
+		func() string {
+			if provider == "" {
+				return ""
+			}
+			return `,"provider":"` + provider + `"`
+		}() + `}`
+	req := httptest.NewRequest(http.MethodPost, "/api/cloud/v1/orgs/"+autolinkOrgID+"/sessions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "22222222-2222-2222-2222-222222222222")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("orgId", autolinkOrgID)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = context.WithValue(ctx, principalKey, domain.Principal{UserID: "00000000-0000-0000-0000-0000000000f6"})
+	return req.WithContext(ctx)
+}
+
+// A worker created for a project that has an active orchestrator is auto-linked
+// to it and inherits its provider, even when the client selected (or the
+// control plane defaults to) a different provider. This is what makes the
+// orchestrator see, drive, and receive reports from a UI-created worker.
+func TestCreateSessionAutoLinksWorkerToProjectOrchestrator(t *testing.T) {
+	t.Parallel()
+	store := &stubAutolinkStore{
+		orchestratorID: "00000000-0000-0000-0000-0000000000b2",
+		orchProvider:   sandbox.ProviderCoder,
+		orchFound:      true,
+	}
+	// Default provider nodeops, client asks for nodeops; the orchestrator runs
+	// on coder, so the worker must come out coder and parented.
+	srv := newChildServer(store, bothProviderProvisioning(sandbox.ProviderNodeOps), sandbox.ProviderNodeOps)
+
+	rec := httptest.NewRecorder()
+	srv.createSession(rec, createSessionRequestHTTP(t, "worker", sandbox.ProviderNodeOps))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+	if !store.created {
+		t.Fatal("CreateSession was not called")
+	}
+	if store.captured.ParentSessionID != store.orchestratorID {
+		t.Fatalf("ParentSessionID = %q, want %q", store.captured.ParentSessionID, store.orchestratorID)
+	}
+	if store.captured.Provider != sandbox.ProviderCoder {
+		t.Fatalf("worker provider = %q, want %q (inherited from orchestrator)", store.captured.Provider, sandbox.ProviderCoder)
+	}
+}
+
+// With no active orchestrator in the project, the worker stays standalone: no
+// parent, and it keeps the client-selected provider.
+func TestCreateSessionLeavesWorkerStandaloneWithoutOrchestrator(t *testing.T) {
+	t.Parallel()
+	store := &stubAutolinkStore{orchFound: false}
+	srv := newChildServer(store, bothProviderProvisioning(sandbox.ProviderNodeOps), sandbox.ProviderCoder)
+
+	rec := httptest.NewRecorder()
+	srv.createSession(rec, createSessionRequestHTTP(t, "worker", sandbox.ProviderNodeOps))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+	if store.captured.ParentSessionID != "" {
+		t.Fatalf("ParentSessionID = %q, want empty (standalone)", store.captured.ParentSessionID)
+	}
+	if store.captured.Provider != sandbox.ProviderNodeOps {
+		t.Fatalf("worker provider = %q, want %q (client selection)", store.captured.Provider, sandbox.ProviderNodeOps)
+	}
+}
+
+// An orchestrator is never auto-linked to itself or another orchestrator: the
+// project lookup must not run for kind=orchestrator.
+func TestCreateSessionDoesNotAutoLinkOrchestrator(t *testing.T) {
+	t.Parallel()
+	// orchFound=true would link if the handler wrongly consulted it for an
+	// orchestrator; assert it stays empty regardless.
+	store := &stubAutolinkStore{
+		orchestratorID: "00000000-0000-0000-0000-0000000000b2",
+		orchProvider:   sandbox.ProviderCoder,
+		orchFound:      true,
+	}
+	srv := newChildServer(store, bothProviderProvisioning(sandbox.ProviderNodeOps), sandbox.ProviderNodeOps)
+
+	rec := httptest.NewRecorder()
+	srv.createSession(rec, createSessionRequestHTTP(t, "orchestrator", sandbox.ProviderNodeOps))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body = %s", rec.Code, rec.Body.String())
+	}
+	if store.captured.ParentSessionID != "" {
+		t.Fatalf("orchestrator ParentSessionID = %q, want empty", store.captured.ParentSessionID)
+	}
+	if store.captured.Provider != sandbox.ProviderNodeOps {
+		t.Fatalf("orchestrator provider = %q, want %q", store.captured.Provider, sandbox.ProviderNodeOps)
+	}
+}

--- a/cloud/internal/postgres/project_session_store.go
+++ b/cloud/internal/postgres/project_session_store.go
@@ -296,11 +296,45 @@ func (s *Store) CreateSession(
 	err := s.withTenant(ctx, principal, orgID, func(tx pgx.Tx) error {
 		var err error
 		session, err = createSessionTx(
-			ctx, tx, orgID, idempotencyKey, maxActiveSandboxes, input, "", principal.UserID,
+			ctx, tx, orgID, idempotencyKey, maxActiveSandboxes, input, input.ParentSessionID, principal.UserID,
 		)
 		return err
 	})
 	return session, err
+}
+
+// ProjectActiveOrchestrator returns the id and sandbox provider of a project's
+// single active orchestrator, if one exists. A top-level worker is auto-linked
+// to it (parent_session_id) and inherits its provider so a project's whole
+// worker tree stays on one provider, matching ao spawn'ed children. found is
+// false when the project has no live orchestrator, in which case the worker
+// stays standalone. Every session has exactly one sandbox row, so the join is
+// total; the one-active-orchestrator-per-project unique index makes the match
+// unambiguous.
+func (s *Store) ProjectActiveOrchestrator(
+	ctx context.Context,
+	orgID, projectID string,
+) (string, string, bool, error) {
+	var orchestratorID, provider string
+	err := s.withOrg(ctx, orgID, func(tx pgx.Tx) error {
+		return tx.QueryRow(
+			ctx,
+			`SELECT se.id::text, sb.provider
+			FROM ao_sessions se
+			JOIN ao_sandboxes sb ON sb.session_id = se.id AND sb.org_id = se.org_id
+			WHERE se.org_id = $1 AND se.project_id = $2
+			  AND se.kind = 'orchestrator' AND se.is_terminated = false
+			LIMIT 1`,
+			orgID, projectID,
+		).Scan(&orchestratorID, &provider)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, err
+	}
+	return orchestratorID, provider, true, nil
 }
 
 func (s *Store) CreateGitHubScratchProject(


### PR DESCRIPTION
Part of #4574 (orchestrator drives its worker sessions end to end).

> **Draft, stacked.** Base is `feat/cloud-provider-selector` (#4912), which this needs to compile (the `provider` field on `createSessionRequest`). It must also land after #4676 for the reverse channel to function. Retarget the base to `main` and rebase once #4912 merges. Do not merge before #4676 and #4912.

## Problem

A cloud orchestrator only saw workers it spawned itself. Everything the orchestrator uses to see and drive its workers, `ao list`, the Workers view, `ao send` / `ao kill`, and the `ao report` reverse channel, keys off `parent_session_id`. A worker created directly from the UI composer comes in as a top-level `kind=worker` with no parent, so it was invisible to the project's orchestrator. This diverged from local AO, where the orchestrator sees every worker in the project regardless of who created it.

## Fix

`createSession` now looks up the project's single active orchestrator (`ProjectActiveOrchestrator`) when creating a top-level worker and, if one exists:

1. Stamps `parent_session_id` onto the worker, so it shows in the orchestrator's `ao list` and Workers view and is controllable via `ao send` / `ao kill`.
2. Inherits the orchestrator's sandbox provider, so the project's whole worker tree stays on one provider (nodeops or coder), matching `ao spawn`ed children.
3. Grants the worker `worker:report` scope so it can report back up the reverse channel.

## Guardrails (all covered by tests)

- A worker created before any orchestrator exists stays standalone. No retroactive linking.
- An orchestrator is never auto-linked to another orchestrator.
- If the client selected a different provider than the orchestrator runs on, the orchestrator's provider wins, so the tree cannot split across providers.

## Tests

`cloud/internal/httpapi/resource_handlers_autolink_test.go`, three cases:
- auto-links a UI worker to the project orchestrator and inherits its provider over the client selection and the control-plane default,
- leaves a worker standalone when there is no active orchestrator,
- never auto-links an orchestrator.

`cd cloud && go build ./... && go vet ./... && go test ./internal/httpapi/...` green on the stacked base.

## Scope

4 files, 219 insertions, 1 deletion. 144 of those lines are the test file. The logic is the handler lookup, the store query, and the `ParentSessionID` DTO field. No migrations (reuses the existing `parent_session_id` column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
