### PR TITLE
feat: make file previews selectable and closeable

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -774,6 +774,26 @@ describe("CenterPane toolbar session label", () => {
 		expect(onCloseShellTerminal).not.toHaveBeenCalled();
 	});
 
+	it("closes the selected workspace file from the application shortcut", () => {
+		const onClose = vi.fn();
+		renderCenterPane({
+			session: worker,
+			workspaceActiveTabKey: "file:README.md",
+			workspaceTabs: [
+				{
+					key: "file:README.md",
+					content: <button role="tab">README.md</button>,
+					onSelect: vi.fn(),
+					onClose,
+				},
+			],
+		});
+
+		expect(shortcutMocks.closeableStates.at(-1)).toBe(true);
+		act(() => shortcutMocks.closeListener?.());
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
 	it("cycles from the session terminal to its next shell tab", () => {
 		const [shell] = makeShells(1);
 		const onSelectShellTerminal = vi.fn();

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -94,6 +94,7 @@ export type CenterPaneWorkspaceTab = {
 	key: string;
 	content: ReactNode;
 	onSelect: () => void;
+	onClose?: () => void;
 };
 
 type AuxiliaryTab =
@@ -302,6 +303,9 @@ export function CenterPane({
 	);
 	const displayedSuccessNotice = presentation ? undefined : transientSuccessNotice;
 	const target = terminalTarget ?? { kind: "worker" };
+	const activeWorkspaceTab = workspaceActiveTabKey
+		? workspaceTabs?.find((tab) => tab.key === workspaceActiveTabKey)
+		: undefined;
 	const switchLocksWorkerInput = Boolean(
 		presentation?.lockAgentTerminal && !presentation.allowSourceInput,
 	);
@@ -460,9 +464,10 @@ export function CenterPane({
 	useEffect(
 		() =>
 			aoBridge.app.onCloseShellTerminalShortcut(() => {
-				if (target.kind === "shell") onCloseShellTerminal?.(target.handleId);
+				if (activeWorkspaceTab?.onClose) activeWorkspaceTab.onClose();
+				else if (target.kind === "shell") onCloseShellTerminal?.(target.handleId);
 			}),
-		[target, onCloseShellTerminal],
+		[activeWorkspaceTab, target, onCloseShellTerminal],
 	);
 
 	useEffect(() => {
@@ -476,10 +481,10 @@ export function CenterPane({
 
 	useEffect(() => {
 		aoBridge.app.setCloseShellTerminalShortcutEnabled(
-			target.kind === "shell" && Boolean(onCloseShellTerminal),
+			Boolean(activeWorkspaceTab?.onClose) || (target.kind === "shell" && Boolean(onCloseShellTerminal)),
 		);
 		return () => aoBridge.app.setCloseShellTerminalShortcutEnabled(false);
-	}, [target.kind, onCloseShellTerminal]);
+	}, [activeWorkspaceTab, target.kind, onCloseShellTerminal]);
 
 	useEffect(() => {
 		const element = tabsOverflowRef.current;

--- a/frontend/src/renderer/components/ReadOnlyFileView.test.tsx
+++ b/frontend/src/renderer/components/ReadOnlyFileView.test.tsx
@@ -30,8 +30,9 @@ function baseDetail(overrides: Partial<WorkspaceFileDetail> = {}): WorkspaceFile
 
 describe("ReadOnlyFileView", () => {
 	it("renders plain content through the shared syntax renderer", () => {
-		render(<ReadOnlyFileView detail={baseDetail()} sessionId="sess-1" />);
+		const { container } = render(<ReadOnlyFileView detail={baseDetail()} sessionId="sess-1" />);
 		expect(screen.getByText("hello world")).toBeInTheDocument();
+		expect(container.querySelector(".chat-code")).toHaveClass("select-text");
 	});
 
 	it("selects the JSON grammar from the opened file path", () => {

--- a/frontend/src/renderer/components/ReadOnlyFileView.tsx
+++ b/frontend/src/renderer/components/ReadOnlyFileView.tsx
@@ -47,7 +47,7 @@ function HighlightedContent({ content, path }: { content: string; path: string }
 	const extension = path.split("/").pop()?.split(".").pop();
 	const language = canonicalLanguage(extension);
 	return (
-		<div className="chat-code min-h-0 flex-1 overflow-auto p-3">
+		<div className="chat-code min-h-0 flex-1 select-text overflow-auto p-3">
 			<pre className="whitespace-pre font-mono text-xs leading-5 text-foreground">
 				<code>
 					<HighlightedCode code={content} language={language} />

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1009,6 +1009,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					/>
 				),
 				onSelect: () => activateCenterFile(path),
+				onClose: () => closeCenterFile(path),
 			})),
 		[activateCenterFile, closeCenterFile, fileAnnotation, fileTabs.activePath, fileTabs.openPaths],
 	);

--- a/frontend/src/renderer/components/WorkspaceDiffView.test.tsx
+++ b/frontend/src/renderer/components/WorkspaceDiffView.test.tsx
@@ -93,7 +93,7 @@ describe("ReviewDiffBody", () => {
 	});
 
 	it("renders a real diff without git-header noise and with markers in the gutter", async () => {
-		render(
+		const { container } = render(
 			<ReviewDiffBody
 				annotation={noopAnnotation()}
 				detail={baseDetail()}
@@ -110,6 +110,7 @@ describe("ReviewDiffBody", () => {
 		expect(screen.getByText(diffLine("const value = 0;"))).toBeInTheDocument();
 		expect(screen.getByText("@@ -1,1 +1,1 @@")).toBeInTheDocument();
 		expect(screen.queryByText("diff --git a/src/App.tsx b/src/App.tsx")).not.toBeInTheDocument();
+		expect(container.querySelector(".diff-code")).toHaveClass("select-text");
 	});
 
 	it("highlights only the changed tokens within a replaced line", async () => {

--- a/frontend/src/renderer/components/WorkspaceDiffView.tsx
+++ b/frontend/src/renderer/components/WorkspaceDiffView.tsx
@@ -344,7 +344,7 @@ function DiffView({
 				</div>
 			) : null}
 			<div
-				className="diff-code session-files-diff-scrollbar overflow-x-auto overflow-y-visible bg-terminal font-mono text-xs leading-row text-terminal-foreground"
+				className="diff-code session-files-diff-scrollbar select-text overflow-x-auto overflow-y-visible bg-terminal font-mono text-xs leading-row text-terminal-foreground"
 				onContextMenu={onContextMenu}
 				ref={containerRef}
 			>

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -2401,4 +2401,26 @@ describe("ChatWorkspace shell tabs", () => {
 		);
 		expect(closeShellTerminalShortcutStates.at(-1)).toBe(false);
 	});
+
+	it("enables the close shortcut and closes the active workspace file tab", () => {
+		const onClose = vi.fn();
+		render(
+			<ChatWorkspace
+				snapshot={idleSnapshot()}
+				workspaceActiveTabKey="file:README.md"
+				workspaceTabs={[
+					{
+						key: "file:README.md",
+						content: <button role="tab">README.md</button>,
+						onSelect: vi.fn(),
+						onClose,
+					},
+				]}
+			/>,
+		);
+
+		expect(closeShellTerminalShortcutStates.at(-1)).toBe(true);
+		act(() => [...closeShellTerminalListeners][0]?.());
+		expect(onClose).toHaveBeenCalledOnce();
+	});
 });

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -137,7 +137,7 @@ function initialTerminalFontSize(): number {
 
 type ReviewerTerminalTarget = Extract<TerminalTarget, { kind: "reviewer" }>;
 type ShellTerminalTarget = Extract<TerminalTarget, { kind: "shell" }>;
-type WorkspaceTab = { key: string; content: ReactNode; onSelect: () => void };
+type WorkspaceTab = { key: string; content: ReactNode; onSelect: () => void; onClose?: () => void };
 type ChatAuxiliaryTab =
 	| { key: string; kind: "reviewer"; terminal: { handleId: string; harness: string } }
 	| { key: string; kind: "shell"; terminal: ShellTerminal }
@@ -541,6 +541,9 @@ export function ChatWorkspace({
 		});
 		return [...ordered, ...byKey.values()];
 	}, [auxiliaryTabOrder, auxiliaryTabs, snapshot.sessionId, tabOrderBySession]);
+	const activeWorkspaceTab = workspaceActiveTabKey
+		? workspaceTabs?.find((tab) => tab.key === workspaceActiveTabKey)
+		: undefined;
 	const reorderAuxiliaryTabs = useCallback(
 		(nextKeys: string[]) => {
 			const available = new Set(availableTabKeys);
@@ -795,9 +798,10 @@ export function ChatWorkspace({
 	useEffect(
 		() =>
 			aoBridge.app.onCloseShellTerminalShortcut(() => {
-				if (shellTarget) onCloseShellTerminal?.(shellTarget.handleId);
+				if (activeWorkspaceTab?.onClose) activeWorkspaceTab.onClose();
+				else if (shellTarget) onCloseShellTerminal?.(shellTarget.handleId);
 			}),
-		[onCloseShellTerminal, shellTarget],
+		[activeWorkspaceTab, onCloseShellTerminal, shellTarget],
 	);
 
 	useEffect(() => {
@@ -810,9 +814,11 @@ export function ChatWorkspace({
 	}, [selectAdjacentTab]);
 
 	useEffect(() => {
-		aoBridge.app.setCloseShellTerminalShortcutEnabled(Boolean(shellTarget && onCloseShellTerminal));
+		aoBridge.app.setCloseShellTerminalShortcutEnabled(
+			Boolean(activeWorkspaceTab?.onClose) || Boolean(shellTarget && onCloseShellTerminal),
+		);
 		return () => aoBridge.app.setCloseShellTerminalShortcutEnabled(false);
-	}, [onCloseShellTerminal, shellTarget]);
+	}, [activeWorkspaceTab, onCloseShellTerminal, shellTarget]);
 
 	// Offered only while the agent is idle. The daemon refuses a rollback mid-turn,
 	// and a control that exists to be refused is worse than one that waits.


### PR DESCRIPTION
## Summary
- allow selecting and copying text in plain file previews and workspace diffs
- close the active center-pane file tab with Ctrl/Cmd+W in both terminal and chat layouts
- add regression coverage for selection and shortcut behavior

## Testing
- `cd frontend && npm run typecheck` — passed
- focused Vitest coverage for CenterPane, ChatWorkspace, ReadOnlyFileView, and WorkspaceDiffView — passed
- manual Windows Electron test against existing AO session data — passed
- full frontend suite — 3,740 passed; 57 unrelated platform/environment failures across 23 files
- `npm run lint` — blocked by existing Windows/POSIX, symlink, and ACL test assumptions before golangci-lint ran
- `npx @redwoodjs/agent-ci run --all` — not run because the local Docker engine is unavailable
- frontend build — not run because the current frontend package has no build script