### PR TITLE
fix(ui): remove session navigation delay

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1568,29 +1568,23 @@ describe("Sidebar", () => {
 		renderSidebar({ workspaces: [workspaceWithSession] });
 
 		await user.dblClick(screen.getByRole("button", { name: "Open fix login" }));
-		expect(navigateMock).not.toHaveBeenCalled();
+		expect(navigateMock).toHaveBeenCalledTimes(1);
 		const input = screen.getByLabelText("Rename fix login");
 		await user.clear(input);
 		await user.type(input, "  polish login  {Enter}");
 
 		await waitFor(() => expect(renameSessionMock).toHaveBeenCalledWith("proj-1-1", "polish login"));
-		expect(navigateMock).not.toHaveBeenCalled();
+		expect(navigateMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("still opens a session after an unpaired single click", async () => {
 		renderSidebar({ workspaces: [{ ...workspace, sessions: [session] }] });
 
 		fireEvent.click(screen.getByRole("button", { name: "Open fix login" }), { detail: 1 });
-		expect(navigateMock).not.toHaveBeenCalled();
-
-		await waitFor(
-			() =>
-				expect(navigateMock).toHaveBeenCalledWith({
-					to: "/projects/$projectId/sessions/$sessionId",
-					params: { projectId: "proj-1", sessionId: "proj-1-1" },
-				}),
-			{ timeout: 1_000 },
-		);
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "proj-1-1" },
+		});
 	});
 
 	it("starts the same inline rename from the session context menu", async () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1697,17 +1697,9 @@ function SessionRow({
 	const [sessionPressed, setSessionPressed] = useState(false);
 	const lastTouchAtRef = useRef(0);
 	const suppressTouchOpenRef = useRef(false);
-	const pendingOpenRef = useRef<number | null>(null);
-	const cancelPendingOpen = useCallback(() => {
-		if (pendingOpenRef.current === null) return;
-		window.clearTimeout(pendingOpenRef.current);
-		pendingOpenRef.current = null;
-	}, []);
-	useEffect(() => cancelPendingOpen, [cancelPendingOpen]);
 	const beginRename = useCallback(() => {
-		cancelPendingOpen();
 		rename.begin();
-	}, [cancelPendingOpen, rename.begin]);
+	}, [rename.begin]);
 
 	if (rename.isEditing) {
 		return (
@@ -1795,26 +1787,12 @@ function SessionRow({
 							)}
 							{...(reorder?.listeners ?? {})}
 							onClick={(event) => {
-								if (event.detail === 0) {
-									cancelPendingOpen();
-									onOpen();
-									return;
-								}
-								if (event.detail > 1) {
-									cancelPendingOpen();
-									return;
-								}
+								if (event.detail > 1) return;
 								if (suppressTouchOpenRef.current) {
 									suppressTouchOpenRef.current = false;
 									return;
 								}
-								// Wait for the native double-click window before navigating. A
-								// second click cancels this so inline rename has no route side effect.
-								cancelPendingOpen();
-								pendingOpenRef.current = window.setTimeout(() => {
-									pendingOpenRef.current = null;
-									onOpen();
-								}, 500);
+								onOpen();
 							}}
 							onKeyDown={(event) => {
 								if (event.key !== "F2") return;


### PR DESCRIPTION
## Summary

- navigate to sessions immediately on a single click
- retain double-click and context-menu rename behavior
- update sidebar tests to cover synchronous navigation

## Root cause

Session navigation waited 500 ms to distinguish a single click from a double-click rename. The supplied DevTools trace shows this timer firing after every session click, making the regression deterministic.

## Validation

- `npm --prefix frontend run test -- --run src/renderer/components/Sidebar.test.tsx` (94 passed)
- `npm run frontend:typecheck`
- `git diff --check`