### PR TITLE
fix(codex): preserve launch PATH for account bootstrap

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/account.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/account.go
@@ -89,7 +89,7 @@ func (f *AccountFactory) Open(ctx context.Context, account ports.CodexAccountCon
 	if account.Managed {
 		args = []string{"-c", `cli_auth_credentials_store="file"`, "app-server"}
 	}
-	proc, err := f.spawn(ctx, bin, account.Home, envSlice(map[string]string{"CODEX_HOME": account.Home}), args)
+	proc, err := f.spawn(ctx, bin, account.Home, codexProcessEnv(ctx, bin, map[string]string{"CODEX_HOME": account.Home}), args)
 	if err != nil {
 		return nil, fmt.Errorf("launch Codex account client: %w", err)
 	}

--- a/backend/internal/adapters/chatdriver/codexappserver/account_test.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/account_test.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/chatdriver/codexappserver/codexproto"
@@ -54,6 +56,97 @@ func TestAccountFactoryUsesManagedHomeAndFileCredentialStore(t *testing.T) {
 	if account.Authentication != domain.AgentAuthenticationAuthorized || account.Method != domain.CodexAuthMethodChatGPT || account.Email == nil || *account.Email != "person@example.com" {
 		t.Fatalf("account = %#v", account)
 	}
+}
+
+func TestAccountFactoryAugmentsPathForResolvedBinary(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "environment.txt")
+	bin := filepath.Join(t.TempDir(), "codex.exe")
+	binary, err := os.ReadFile(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, binary, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	t.Setenv("AO_ACCOUNT_HELPER", "1")
+	t.Setenv("AO_ACCOUNT_HELPER_OUTPUT", output)
+	t.Setenv("PATH", "base-path")
+	factory := NewAccountFactoryWithResolver(func(context.Context) (string, error) {
+		return bin, nil
+	}, nil)
+	client, err := factory.Open(context.Background(), ports.CodexAccountContext{Home: home})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	recorded, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pathValue string
+	var pathEntries, homeEntries []string
+	for _, line := range strings.Split(strings.TrimSpace(string(recorded)), "\n") {
+		switch {
+		case strings.HasPrefix(line, "PATH="):
+			pathValue = strings.TrimPrefix(line, "PATH=")
+		case strings.HasPrefix(line, "PATH_ENTRY="):
+			pathEntries = append(pathEntries, strings.TrimPrefix(line, "PATH_ENTRY="))
+		case strings.HasPrefix(line, "CODEX_HOME_ENTRY="):
+			homeEntries = append(homeEntries, strings.TrimPrefix(line, "CODEX_HOME_ENTRY="))
+		}
+	}
+	parts := strings.Split(pathValue, string(os.PathListSeparator))
+	if len(parts) == 0 || parts[0] != filepath.Dir(bin) {
+		t.Fatalf("child PATH = %q, want executable directory %q first", pathValue, filepath.Dir(bin))
+	}
+	if len(pathEntries) != 1 || !strings.EqualFold(pathEntries[0], "PATH="+pathValue) {
+		t.Fatalf("child PATH entries = %#v, want one effective PATH entry", pathEntries)
+	}
+	if len(homeEntries) != 1 || homeEntries[0] != "CODEX_HOME="+home {
+		t.Fatalf("child CODEX_HOME entries = %#v, want one entry for %q", homeEntries, home)
+	}
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv("AO_ACCOUNT_HELPER") == "1" {
+		accountAppServerTestHelper()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func accountAppServerTestHelper() {
+	request, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
+	if err != nil {
+		panic(err)
+	}
+	var message struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(request, &message); err != nil {
+		panic(err)
+	}
+	var records []string
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		switch {
+		case strings.EqualFold(key, "PATH"):
+			records = append(records, "PATH_ENTRY="+entry)
+		case strings.EqualFold(key, "CODEX_HOME"):
+			records = append(records, "CODEX_HOME_ENTRY="+entry)
+		}
+	}
+	records = append(records, "PATH="+os.Getenv("PATH"))
+	if err := os.WriteFile(os.Getenv("AO_ACCOUNT_HELPER_OUTPUT"), []byte(strings.Join(records, "\n")+"\n"), 0o600); err != nil {
+		panic(err)
+	}
+	response, err := json.Marshal(map[string]any{"id": message.ID, "result": map[string]any{}})
+	if err != nil {
+		panic(err)
+	}
+	_, _ = fmt.Fprintln(os.Stdout, string(response))
 }
 
 func TestAccountReadMapsExplicitSignedOutAndNotApplicable(t *testing.T) {


### PR DESCRIPTION
## Problem

On Windows, the Codex account bootstrap path starts codex app-server with CODEX_HOME but does not apply the executable-aware PATH augmentation already used by the normal Codex app-server path. This can let the daemon resolve Codex while the account process fails during initialization with CODEX_ACCOUNT_MANAGEMENT_UNAVAILABLE.

## Change

Reuse codexProcessEnv for account-scoped app-server launches so the resolved Codex directory is available in PATH, including when the daemon was launched from the desktop environment.

The regression test launches a copied Windows test executable through the real spawnAccountAppServer boundary. The child records its effective environment, and the test verifies that the resolved executable directory is first in PATH and that PATH and CODEX_HOME each arrive exactly once.

## Scope

This addresses the post-launch account app-server environment handoff failure. A separate pre-launch Windows ancestor-ACL failure related to #4989 is tracked in #5080.

## Verification

- go test ./internal/adapters/chatdriver/codexappserver -run ^TestAccountFactoryAugmentsPathForResolvedBinary$ -count=1 — passes on Windows
- go test ./internal/adapters/chatdriver/codexappserver -run ^Test(AccountFactoryAugmentsPathForResolvedBinary|AccountFactoryDeviceDetectionDoesNotOverrideCredentialStore)$ -count=1 — passes on Windows
- go build ./... — passes
- git diff --check — passes

The broader existing Windows suites remain environment-blocked by ACL/symlink fixtures and a missing Bash fixture; those failures are outside this change.

Refs #4989
Related #5080