### PR TITLE
fix(windows): hide persistent chat provider console

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Test workspace teardown and session kill
         run: go test -race -v -run 'Destroy|Discard|Sweep|Kill' ./internal/adapters/workspace/... ./internal/session_manager/
 
+      - name: Test persistent provider host console isolation
+        run: go test -race -v -run '^TestDetachedHostProviderDoesNotAllocateConsoleWindow$' ./internal/adapters/chatdriver/persistenthost
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
 )
 
@@ -448,7 +449,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	defer func() { _ = listener.Close() }()
 
-	child := exec.Command(cfg.Argv[0], cfg.Argv[1:]...) //nolint:gosec // provider argv is constructed by AO's driver.
+	child := aoprocess.Command(cfg.Argv[0], cfg.Argv[1:]...) //nolint:gosec // provider argv is constructed by AO's driver.
 	child.Dir = cfg.Workdir
 	child.Env = cfg.Env
 	stdin, err := child.StdinPipe()

--- a/backend/internal/adapters/chatdriver/persistenthost/host_race_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_race_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package persistenthost
 
 import (

--- a/backend/internal/adapters/chatdriver/persistenthost/host_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_test.go
@@ -51,6 +51,10 @@ func TestProviderHelper(t *testing.T) {
 			_, _ = fmt.Fprintln(os.Stdout, `{"id":700,"method":"item/commandExecution/requestApproval","params":{"turnId":"turn-live"}}`)
 			continue
 		}
+		if frame.Method == "console-window" {
+			_, _ = fmt.Fprintf(os.Stdout, `{"id":%d,"result":{"attached":%t}}`+"\n", frame.ID, providerHasConsoleWindow())
+			continue
+		}
 		if frame.Method == "" && frame.ID == 700 {
 			_, _ = fmt.Fprintln(os.Stdout, `{"method":"approval/received","params":{"turnId":"turn-live"}}`)
 			continue

--- a/backend/internal/adapters/chatdriver/persistenthost/host_windows_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_windows_test.go
@@ -6,9 +6,11 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestDetachedHostProviderDoesNotAllocateConsoleWindow(t *testing.T) {
@@ -24,7 +26,18 @@ func TestDetachedHostProviderDoesNotAllocateConsoleWindow(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = transport.Stdin.Close()
-		_ = Shutdown(context.Background(), dataDir, cfg.SessionID)
+		if err := Shutdown(context.Background(), dataDir, cfg.SessionID); err != nil {
+			t.Errorf("Shutdown: %v", err)
+		}
+		path, _ := descriptorPath(dataDir, cfg.SessionID)
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Error("detached host did not exit after shutdown")
 	})
 
 	if _, err := fmt.Fprintln(transport.Stdin, `{"id":1,"method":"console-window"}`); err != nil {

--- a/backend/internal/adapters/chatdriver/persistenthost/host_windows_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_windows_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package persistenthost
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestDetachedHostProviderDoesNotAllocateConsoleWindow(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := Config{
+		SessionID: "hidden-provider", DataDir: dataDir, Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"},
+	}
+	transport, err := ConnectOrStart(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ConnectOrStart: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = transport.Stdin.Close()
+		_ = Shutdown(context.Background(), dataDir, cfg.SessionID)
+	})
+
+	if _, err := fmt.Fprintln(transport.Stdin, `{"id":1,"method":"console-window"}`); err != nil {
+		t.Fatalf("request console state: %v", err)
+	}
+	var response struct {
+		Result struct {
+			Attached bool `json:"attached"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(bufio.NewReader(transport.Stdout)).Decode(&response); err != nil {
+		t.Fatalf("decode console state: %v", err)
+	}
+	if response.Result.Attached {
+		t.Fatal("provider inherited or allocated a Windows console window")
+	}
+}

--- a/backend/internal/adapters/chatdriver/persistenthost/provider_console_other_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/provider_console_other_test.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package persistenthost
+
+func providerHasConsoleWindow() bool { return false }

--- a/backend/internal/adapters/chatdriver/persistenthost/provider_console_windows_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/provider_console_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package persistenthost
+
+import "golang.org/x/sys/windows"
+
+var getConsoleWindow = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetConsoleWindow")
+
+func providerHasConsoleWindow() bool {
+	handle, _, _ := getConsoleWindow.Call()
+	return handle != 0
+}

--- a/backend/internal/service/agent/codex_account_catalog_test.go
+++ b/backend/internal/service/agent/codex_account_catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -56,7 +57,21 @@ func TestCodexAccountCatalogCommitsStrictPrivateOpaqueSlot(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := info.Mode().Perm(); got != want {
+		if runtime.GOOS == "windows" {
+			// Windows privacy is enforced by the DACL, not Unix mode bits.
+			if info.IsDir() {
+				if err := validateCodexDirectory(path, true); err != nil {
+					t.Error(err)
+				}
+			} else {
+				file, err := openCodexFileNoFollow(path)
+				if err != nil {
+					t.Error(err)
+				} else {
+					_ = file.Close()
+				}
+			}
+		} else if got := info.Mode().Perm(); got != want {
 			t.Errorf("%s mode = %o, want %o", path, got, want)
 		}
 	}

--- a/backend/internal/service/agent/codex_ancestor_acl_windows_test.go
+++ b/backend/internal/service/agent/codex_ancestor_acl_windows_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// Exercise real NTFS descriptors, not only synthetic ACEs. The ordinary Write
+// grant used by Windows sandbox tooling permits sibling creation, not deletion.
+func TestWindowsCredentialVaultUnderWritableAncestor(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		rights   string
+		empty    bool
+		wantSafe bool
+	}{
+		{"sibling creation", "0x1201bf", false, true},
+		{"empty read only", "0x1200a9", true, true},
+		{"removable only child", "0x1201bf", false, false},
+		{"empty writable junction target", "0x1201bf", true, false},
+		{"delete child", "0x1201ff", false, false},
+		{"change ACL", "0x1601bf", false, false},
+		{"take ownership", "0x1a01bf", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if !tc.empty {
+				if err := os.WriteFile(filepath.Join(root, "existing-child"), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			token, err := windows.OpenCurrentProcessToken()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer token.Close()
+			user, err := token.GetTokenUser()
+			if err != nil {
+				t.Fatal(err)
+			}
+			sd, err := windows.SecurityDescriptorFromString("D:P(A;OICI;FA;;;" + user.User.Sid.String() + ")(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;;" + tc.rights + ";;;WD)")
+			if err != nil {
+				t.Fatal(err)
+			}
+			dacl, _, err := sd.DACL()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := windows.SetNamedSecurityInfo(root, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, dacl, nil); err != nil {
+				t.Fatal(err)
+			}
+			if tc.name == "removable only child" {
+				childSD, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;" + user.User.Sid.String() + ")(A;;SD;;;WD)")
+				if err != nil {
+					t.Fatal(err)
+				}
+				childACL, _, err := childSD.DACL()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := windows.SetNamedSecurityInfo(filepath.Join(root, "existing-child"), windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, childACL, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+			vault := filepath.Join(root, "vault")
+			err = ensurePrivateDirectory(vault)
+			if (err == nil) != tc.wantSafe {
+				t.Fatalf("ensurePrivateDirectory = %v, want safe=%v", err, tc.wantSafe)
+			}
+			if tc.wantSafe {
+				if err := validateCodexDirectory(vault, true); err != nil {
+					t.Fatal(err)
+				}
+				if err := writePrivateFileAtomic(filepath.Join(vault, "test.json"), []byte("{}")); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := readOpaqueCredential(filepath.Join(vault, "test.json")); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/service/agent/codex_secure_fs_windows.go
+++ b/backend/internal/service/agent/codex_secure_fs_windows.go
@@ -74,12 +74,44 @@ func validateCodexDirectoryAncestors(path string) error {
 		if openErr != nil {
 			return errors.New("codex directory ancestor could not be verified")
 		}
-		_ = windows.CloseHandle(handle)
 		if !codexWindowsPathMetadataIsSafe(codexWindowsMetadata(info, ownerTrusted, aclSafe), true, false) {
+			_ = windows.CloseHandle(handle)
 			return errors.New("codex directory ancestor ACL is unsafe")
+		}
+		_, _, safeEmpty, securityErr := codexWindowsHandleSecurityForPath(handle, false, true)
+		_ = windows.CloseHandle(handle)
+		// A writable directory can become a junction if emptied. Require a
+		// child that untrusted callers cannot remove, either via DELETE on the
+		// child or DELETE_CHILD on this parent (already rejected above).
+		if securityErr != nil || (!safeEmpty && !codexWindowsHasProtectedChild(current)) {
+			return errors.New("codex ancestor can be converted to a reparse point")
 		}
 		if parent := filepath.Dir(current); parent == current {
 			return nil
+		}
+	}
+}
+
+func codexWindowsHasProtectedChild(path string) bool {
+	dir, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer dir.Close()
+	for {
+		entries, readErr := dir.Readdir(32)
+		for _, entry := range entries {
+			handle, info, _, ownerTrusted, aclSafe, err := openCodexWindowsPath(filepath.Join(path, entry.Name()), entry.IsDir(), false)
+			if err != nil {
+				continue
+			}
+			_ = windows.CloseHandle(handle)
+			if codexWindowsPathMetadataIsSafe(codexWindowsMetadata(info, ownerTrusted, aclSafe), entry.IsDir(), false) {
+				return true
+			}
+		}
+		if readErr != nil {
+			return false
 		}
 	}
 }
@@ -131,6 +163,10 @@ func codexWindowsMetadata(info windows.ByHandleFileInformation, ownerTrusted, ac
 }
 
 func codexWindowsHandleSecurity(handle windows.Handle, requirePrivate bool) (bool, bool, bool, error) {
+	return codexWindowsHandleSecurityForPath(handle, requirePrivate, false)
+}
+
+func codexWindowsHandleSecurityForPath(handle windows.Handle, requirePrivate, emptyAncestor bool) (bool, bool, bool, error) {
 	token, err := windows.OpenCurrentProcessToken()
 	if err != nil {
 		return false, false, false, err
@@ -158,6 +194,16 @@ func codexWindowsHandleSecurity(handle windows.Handle, requirePrivate bool) (boo
 	}
 	ownerCurrent := owner.Equals(user.User.Sid)
 	ownerTrusted := ownerCurrent || owner.Equals(system) || owner.Equals(administrators)
+	// Windows system directories (including the volume root on some installs)
+	// can belong to the Windows Modules Installer service. This is ancestor
+	// ownership only: private credential directories must still be user-owned.
+	trustedInstaller, err := windows.StringToSid("S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464")
+	if err != nil {
+		return false, false, false, err
+	}
+	if !requirePrivate && owner.Equals(trustedInstaller) {
+		ownerTrusted = true
+	}
 	dacl, _, err := sd.DACL()
 	if err != nil || dacl == nil {
 		return ownerCurrent, ownerTrusted, false, nil
@@ -184,6 +230,15 @@ func codexWindowsHandleSecurity(handle windows.Handle, requirePrivate bool) (boo
 		aces = append(aces, ace)
 	}
 	aclSafe := codexWindowsAncestorACLIsSafe(ownerTrusted, aces)
+	if emptyAncestor {
+		// Keep read-only ancestors usable, but do not accept rights that could
+		// turn an empty ancestor into a reparse point before its child exists.
+		for _, ace := range aces {
+			if ace.Allowed && !ace.PrincipalTrusted && ace.Mask&(codexWindowsGenericWrite|codexWindowsWriteData|codexWindowsAppendData|codexWindowsWriteEA|codexWindowsWriteAttributes) != 0 {
+				aclSafe = false
+			}
+		}
+	}
 	if requirePrivate {
 		aclSafe = codexWindowsVaultACLIsSafe(ownerTrusted, aces)
 	}

--- a/backend/internal/service/agent/codex_windows_security.go
+++ b/backend/internal/service/agent/codex_windows_security.go
@@ -55,9 +55,11 @@ func codexWindowsSameStableIdentity(left, right codexWindowsPathMetadata) bool {
 	return left.VolumeSerial == right.VolumeSerial && left.FileIndexHigh == right.FileIndexHigh && left.FileIndexLow == right.FileIndexLow
 }
 
-const codexWindowsMutationMask = codexWindowsWriteData | codexWindowsAppendData | codexWindowsWriteEA |
-	codexWindowsDeleteChild | codexWindowsWriteAttributes | codexWindowsDelete | codexWindowsWriteDAC |
-	codexWindowsWriteOwner | codexWindowsGenericAll | codexWindowsGenericWrite
+// Directory ADD_FILE/ADD_SUBDIRECTORY rights create siblings; they do not
+// authorize replacing an existing child. Keep replacement and ACL takeover
+// rights separate from the much stricter credential-file policy below.
+const codexWindowsAncestorReplacementMask = codexWindowsDeleteChild | codexWindowsDelete |
+	codexWindowsWriteDAC | codexWindowsWriteOwner | codexWindowsGenericAll
 
 type codexWindowsACE struct {
 	Allowed          bool
@@ -85,7 +87,7 @@ func codexWindowsAncestorACLIsSafe(ownerTrusted bool, aces []codexWindowsACE) bo
 		return false
 	}
 	for _, ace := range aces {
-		if ace.Allowed && !ace.PrincipalTrusted && ace.Mask&codexWindowsMutationMask != 0 {
+		if ace.Allowed && !ace.PrincipalTrusted && ace.Mask&codexWindowsAncestorReplacementMask != 0 {
 			return false
 		}
 	}

--- a/backend/internal/service/agent/codex_windows_security_test.go
+++ b/backend/internal/service/agent/codex_windows_security_test.go
@@ -37,6 +37,22 @@ func TestWindowsAncestorACLPolicyAllowsReadButRejectsMutation(t *testing.T) {
 	}
 }
 
+func TestWindowsAncestorACLSeparatesSiblingCreationFromReplacement(t *testing.T) {
+	for _, mask := range []uint32{codexWindowsWriteData, codexWindowsAppendData, codexWindowsGenericWrite, codexWindowsWriteEA | codexWindowsWriteAttributes} {
+		if !codexWindowsAncestorACLIsSafe(true, []codexWindowsACE{{Allowed: true, Mask: mask}}) {
+			t.Fatalf("directory creation/metadata rights rejected: %#x", mask)
+		}
+		if codexWindowsVaultACLIsSafe(true, []codexWindowsACE{{Allowed: true, Mask: mask}}) {
+			t.Fatalf("credential vault accepted untrusted access: %#x", mask)
+		}
+	}
+	for _, mask := range []uint32{codexWindowsDelete, codexWindowsDeleteChild, codexWindowsWriteDAC, codexWindowsWriteOwner, codexWindowsGenericAll} {
+		if codexWindowsAncestorACLIsSafe(true, []codexWindowsACE{{Allowed: true, Mask: mask}}) {
+			t.Fatalf("ancestor replacement rights accepted: %#x", mask)
+		}
+	}
+}
+
 func TestWindowsNoFollowAndWriteThroughPolicies(t *testing.T) {
 	if got := codexWindowsNoFollowOpenFlags(); got&codexWindowsOpenReparsePoint == 0 || got&codexWindowsBackupSemantics == 0 {
 		t.Fatalf("no-follow open flags = %#x", got)


### PR DESCRIPTION
Fixes https://github.com/Untrivial-ai/agent-orchestrator/issues/5018

## Summary
- launch persistent chat-provider children through AO's shared process helper
- suppress the provider console window on Windows without changing non-Windows behavior
- add a Windows regression test that exercises the detached host path and asks the provider whether it received a console window

## Root cause
The persistent chat host launched Codex with raw `exec.Command`, bypassing AO's Windows process attributes (`CREATE_NO_WINDOW` and `HideWindow`). Windows therefore allocated a visible console for the provider. Closing that console terminated the provider, so AO correctly reported the session as exited.

## Regression testing
Passed locally on Windows:
- focused native regression: `TestDetachedHostProviderDoesNotAllocateConsoleWindow`
- `go test ./internal/process -count=1`
- `go build ./...`
- Linux/amd64 compile-only check for `internal/adapters/chatdriver/persistenthost`
- `npm run frontend:typecheck`
- manual real-Codex verification: provider reached idle with `MainWindowHandle=0`

Local suite limitations:
- `go test ./...`, `go vet ./...`, and the pinned golangci-lint run encounter existing Windows failures, led by `host_race_test.go` using unavailable `syscall.Kill`; the linter also reports existing findings in unrelated Windows files.
- `go test -race ./...` cannot run because CGO is disabled in this Windows environment.
- `npx @redwoodjs/agent-ci run --all` cannot run because Docker Desktop/the Docker socket is unavailable.