### PR TITLE
fix(updates): only confirm a restart when work is actually at risk

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -85,6 +85,7 @@ import { useCloudLocalAuth } from "../hooks/useCloudLocalAuth";
 import { useLocalSignInDialogStore } from "../stores/local-signin-dialog-store";
 import { useShellMaybe } from "../lib/shell-context";
 import { useSidebarUpdateDismissal } from "../hooks/useSidebarUpdateDismissal";
+import { useRequestUpdateInstall } from "../hooks/useRequestUpdateInstall";
 import { useUpdateStatus } from "../hooks/useUpdateStatus";
 import { MAX_SESSION_DISPLAY_NAME_LEN, useSessionRename } from "../hooks/useSessionRename";
 import { effectiveShortcutBindings, shortcutBindingKeys } from "../../shared/shortcuts";
@@ -426,7 +427,7 @@ export function Sidebar({
 	const updateStatus = useUpdateStatus();
 	const availableUpdateVersion = updateStatus.state === "available" ? updateStatus.version : undefined;
 	const updateDismissal = useSidebarUpdateDismissal(availableUpdateVersion);
-	const openUpdateInstallPrompt = useUiStore((state) => state.openUpdateInstallPrompt);
+	const requestUpdateInstall = useRequestUpdateInstall();
 	// Daemon status for the smoke suite's sr-only mirror in the footer. Null when
 	// rendered outside the shell (unit tests) — the mirror simply doesn't render.
 	const daemonStatus = useShellMaybe()?.daemonStatus ?? null;
@@ -833,7 +834,7 @@ export function Sidebar({
 					<UpdateStatusRow
 						availableDismissed={updateDismissal.dismissed}
 						onDismissAvailable={updateDismissal.dismiss}
-						onRequestInstall={openUpdateInstallPrompt}
+						onRequestInstall={requestUpdateInstall}
 						status={updateStatus}
 						tabIndex={isCollapsed ? -1 : 0}
 					/>
@@ -872,7 +873,7 @@ export function Sidebar({
 				>
 					<UpdateStatusRail
 						availableDismissed={updateDismissal.dismissed}
-						onRequestInstall={openUpdateInstallPrompt}
+						onRequestInstall={requestUpdateInstall}
 						status={updateStatus}
 						tabIndex={isCollapsed ? 0 : -1}
 					/>

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -6,6 +6,7 @@ import { aoBridge } from "../../lib/bridge";
 import { cn } from "../../lib/utils";
 import { parseNightlyVersion } from "../../lib/build-channel";
 import { useUiStore } from "../../stores/ui-store";
+import { useRequestUpdateInstall } from "../../hooks/useRequestUpdateInstall";
 import { useUpdateStatus } from "../../hooks/useUpdateStatus";
 import type { UpdateChannel, UpdateSettings, UpdateState, UpdateStatus } from "../../../main/update-settings";
 import { Badge } from "../ui/badge";
@@ -386,7 +387,7 @@ function UpdateActions({
 	const { t, i18n } = useTranslation();
 	const locale = i18n.resolvedLanguage ?? i18n.language;
 	const version = useQuery({ queryKey: ["app-version"], queryFn: () => aoBridge.app.getVersion() });
-	const openUpdateInstallPrompt = useUiStore((state) => state.openUpdateInstallPrompt);
+	const requestUpdateInstall = useRequestUpdateInstall();
 	const installedChannel = installedUpdateChannel(version.data);
 	const installed = parseNightlyVersion(version.data);
 
@@ -497,7 +498,7 @@ function UpdateActions({
 						// Opens the restart confirmation rather than installing outright:
 						// installing quits the app, which costs a turn on any chat session
 						// running a daemon-owned driver.
-						<Button type="button" variant="primary" size="sm" onClick={openUpdateInstallPrompt}>
+						<Button type="button" variant="primary" size="sm" onClick={requestUpdateInstall}>
 							<RefreshCw className="size-icon-sm" aria-hidden="true" />
 							{t("settings.updates.restartInstall")}
 						</Button>
@@ -552,6 +553,22 @@ function UpdateActions({
 					</p>
 				) : null}
 			</div>
+
+			{/* Release notes used to live only in the restart confirmation, so
+			    skipping that dialog when nothing is at risk would have hidden them
+			    entirely. The panel has room the dialog never did. Plain text on
+			    purpose: these are the remote release body, sanitized in the main
+			    process, and nothing here injects markup. */}
+			{status.state === "downloaded" && status.releaseNotes ? (
+				<div className="mt-3" data-testid="update-release-notes">
+					<p className="text-caption font-medium uppercase tracking-wide text-settings-muted">
+						{t("update.restart.whatsNew")}
+					</p>
+					<p className="mt-1.5 max-h-40 overflow-y-auto whitespace-pre-line text-pretty text-sm leading-5 text-settings-label">
+						{status.releaseNotes}
+					</p>
+				</div>
+			) : null}
 
 			{!status.staleCheckNudge && status.checksFailing && (
 				<UpdateNotice tone="warning" text={t("settings.updates.checksFailing")} />

--- a/frontend/src/renderer/hooks/useRequestUpdateInstall.test.tsx
+++ b/frontend/src/renderer/hooks/useRequestUpdateInstall.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useRequestUpdateInstall } from "./useRequestUpdateInstall";
+import { workspaceQueryOptions } from "./useWorkspaceQuery";
+
+const { install, openPrompt } = vi.hoisted(() => ({ install: vi.fn(), openPrompt: vi.fn() }));
+
+vi.mock("../lib/bridge", () => ({ aoBridge: { updates: { install } } }));
+vi.mock("../stores/ui-store", () => ({
+	useUiStore: (select: (state: { openUpdateInstallPrompt: () => void }) => unknown) =>
+		select({ openUpdateInstallPrompt: openPrompt }),
+}));
+
+/** A chat session on a daemon-owned driver mid-turn: the only at-risk shape. */
+function atRiskSession() {
+	return {
+		id: "s1",
+		title: "Session",
+		workspaceName: "repo",
+		provider: "claude-code",
+		mode: "chat",
+		status: "working",
+	};
+}
+
+/** A TUI session survives a quit: its runtime is detached. */
+function safeSession() {
+	return { ...atRiskSession(), id: "s2", mode: "tui" };
+}
+
+function renderTrigger(seed?: unknown) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	if (seed !== undefined) client.setQueryData(workspaceQueryOptions.queryKey, seed);
+	let trigger: () => void = () => undefined;
+	function Probe() {
+		trigger = useRequestUpdateInstall();
+		return null;
+	}
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+	render(<Probe />, { wrapper });
+	return () => act(() => trigger());
+}
+
+beforeEach(() => {
+	install.mockReset();
+	openPrompt.mockReset();
+});
+
+describe("useRequestUpdateInstall", () => {
+	it("installs directly when nothing would lose a turn", () => {
+		// The confirmation existed to warn about lost work. With nothing to warn
+		// about it is a modal on top of the Settings modal saying nothing, and the
+		// build installs on the next quit anyway.
+		renderTrigger([{ sessions: [safeSession()] }])();
+		expect(install).toHaveBeenCalledTimes(1);
+		expect(openPrompt).not.toHaveBeenCalled();
+	});
+
+	it("confirms when a session would lose an in-flight turn", () => {
+		renderTrigger([{ sessions: [safeSession(), atRiskSession()] }])();
+		expect(openPrompt).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+
+	it("confirms when the workspace list has not resolved", () => {
+		// Unknown is not the same as safe: AO cannot rule out a live turn, so it
+		// asks rather than quitting out from under one.
+		renderTrigger()();
+		expect(openPrompt).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+
+	it("installs directly when there are no sessions at all", () => {
+		renderTrigger([])();
+		expect(install).toHaveBeenCalledTimes(1);
+		expect(openPrompt).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/hooks/useRequestUpdateInstall.test.tsx
+++ b/frontend/src/renderer/hooks/useRequestUpdateInstall.test.tsx
@@ -25,9 +25,10 @@ const session = (mode: "chat" | "tui") => ({
 	status: "working",
 });
 
-function renderTrigger(seed?: unknown) {
+function renderTrigger(seed?: unknown, configure?: (client: QueryClient) => void) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	if (seed !== undefined) client.setQueryData(workspaceQueryOptions.queryKey, seed);
+	configure?.(client);
 	let trigger: () => void = () => undefined;
 	function Probe() {
 		trigger = useRequestUpdateInstall();
@@ -67,5 +68,60 @@ describe("useRequestUpdateInstall", () => {
 		renderTrigger()();
 		expect(openPrompt).toHaveBeenCalledTimes(1);
 		expect(install).not.toHaveBeenCalled();
+	});
+});
+
+describe("restart safety with uncertain workspace data", () => {
+	it("confirms for a chat turn waiting for approval", () => {
+		renderTrigger([{ sessions: [{ ...session("chat"), status: "needs_input" }] }])();
+		expect(openPrompt).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+	it("confirms when the last snapshot is stale", () => {
+		renderTrigger([], (client) => {
+			client.setQueryData(workspaceQueryOptions.queryKey, [], { updatedAt: Date.now() - 60_000 });
+		})();
+		expect(openPrompt).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+	it("confirms when the last snapshot was invalidated", () => {
+		renderTrigger([], (client) => {
+			void client.invalidateQueries({ queryKey: workspaceQueryOptions.queryKey, refetchType: "none" });
+		})();
+		expect(openPrompt).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+	it("confirms while a new snapshot is loading", async () => {
+		let resolve!: (value: never[]) => void;
+		let pending!: Promise<never[]>;
+		const trigger = renderTrigger([], (client) => {
+			pending = client.fetchQuery({
+				queryKey: workspaceQueryOptions.queryKey,
+				queryFn: () => new Promise<never[]>((done) => { resolve = done; }),
+				staleTime: 0,
+			});
+		});
+		trigger();
+		resolve([]);
+		await pending;
+		expect(openPrompt).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+	it("confirms when a refresh failed but previous data remains", async () => {
+		let client!: QueryClient;
+		const trigger = renderTrigger([], (current) => { client = current; });
+		await client.fetchQuery({
+			queryKey: workspaceQueryOptions.queryKey,
+			queryFn: async () => { throw new Error("daemon unavailable"); },
+			staleTime: 0,
+		}).catch(() => undefined);
+		trigger();
+		expect(openPrompt).toHaveBeenCalledTimes(1);
+		expect(install).not.toHaveBeenCalled();
+	});
+	it("installs directly with a fresh empty snapshot", () => {
+		renderTrigger([])();
+		expect(install).toHaveBeenCalledTimes(1);
+		expect(openPrompt).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/renderer/hooks/useRequestUpdateInstall.test.tsx
+++ b/frontend/src/renderer/hooks/useRequestUpdateInstall.test.tsx
@@ -13,22 +13,17 @@ vi.mock("../stores/ui-store", () => ({
 		select({ openUpdateInstallPrompt: openPrompt }),
 }));
 
-/** A chat session on a daemon-owned driver mid-turn: the only at-risk shape. */
-function atRiskSession() {
-	return {
-		id: "s1",
-		title: "Session",
-		workspaceName: "repo",
-		provider: "claude-code",
-		mode: "chat",
-		status: "working",
-	};
-}
-
-/** A TUI session survives a quit: its runtime is detached. */
-function safeSession() {
-	return { ...atRiskSession(), id: "s2", mode: "tui" };
-}
+// Which sessions count as at-risk is update-install-risk.test.ts's job (6 cases
+// there). These only need one of each shape to drive the branch below: a chat
+// session mid-turn on a daemon-owned driver is at risk, a TUI session is not.
+const session = (mode: "chat" | "tui") => ({
+	id: mode,
+	title: "Session",
+	workspaceName: "repo",
+	provider: "claude-code",
+	mode,
+	status: "working",
+});
 
 function renderTrigger(seed?: unknown) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -55,13 +50,13 @@ describe("useRequestUpdateInstall", () => {
 		// The confirmation existed to warn about lost work. With nothing to warn
 		// about it is a modal on top of the Settings modal saying nothing, and the
 		// build installs on the next quit anyway.
-		renderTrigger([{ sessions: [safeSession()] }])();
+		renderTrigger([{ sessions: [session("tui")] }])();
 		expect(install).toHaveBeenCalledTimes(1);
 		expect(openPrompt).not.toHaveBeenCalled();
 	});
 
 	it("confirms when a session would lose an in-flight turn", () => {
-		renderTrigger([{ sessions: [safeSession(), atRiskSession()] }])();
+		renderTrigger([{ sessions: [session("tui"), session("chat")] }])();
 		expect(openPrompt).toHaveBeenCalledTimes(1);
 		expect(install).not.toHaveBeenCalled();
 	});
@@ -72,11 +67,5 @@ describe("useRequestUpdateInstall", () => {
 		renderTrigger()();
 		expect(openPrompt).toHaveBeenCalledTimes(1);
 		expect(install).not.toHaveBeenCalled();
-	});
-
-	it("installs directly when there are no sessions at all", () => {
-		renderTrigger([])();
-		expect(install).toHaveBeenCalledTimes(1);
-		expect(openPrompt).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/renderer/hooks/useRequestUpdateInstall.ts
+++ b/frontend/src/renderer/hooks/useRequestUpdateInstall.ts
@@ -7,25 +7,15 @@ import { workspaceQueryOptions } from "./useWorkspaceQuery";
 import type { WorkspaceSummary } from "../types/workspace";
 
 /**
- * Decide whether restarting into a staged build needs confirming.
+ * Confirm a restart-to-update only when a session would lose an in-flight turn.
  *
- * The confirmation exists because a single click used to quit the app with no
- * warning (#4849). That reason only holds when a session would actually lose an
- * in-flight turn: `update-install-risk.ts` already argues that treating every
- * quit as destructive "would warn on almost every session and teach the user to
- * click through", and a confirmation carrying no warning is that same failure
- * one level up — in Settings it also stacked a modal on top of a modal.
+ * #4849 added the dialog because one click used to quit the app unasked; with
+ * nothing at risk it is a modal over the Settings modal carrying no warning.
  *
- * So confirm exactly when there is something to confirm. With nothing at risk
- * the button says "Restart & install" and does that; the build was going to
- * install on the next quit regardless.
- *
- * Reads the workspace list out of the query cache rather than subscribing with
- * useWorkspaceQuery. Both callers are mounted for the whole shell's lifetime and
- * need this only on click, and that hook pulls in the cloud session/org queries,
- * which would make every test that renders the sidebar or Settings provide cloud
- * bridge mocks it has no reason to know about. Local projects only: a cloud
- * session does not die when this desktop app quits, so it is never at risk here.
+ * Reads the cache instead of calling useWorkspaceQuery on purpose: that hook
+ * pulls in the cloud org/session queries, which makes every test rendering the
+ * sidebar or Settings supply cloud bridge mocks. Local projects only — a cloud
+ * session does not die when this app quits.
  */
 export function useRequestUpdateInstall(): () => void {
 	const openPrompt = useUiStore((state) => state.openUpdateInstallPrompt);

--- a/frontend/src/renderer/hooks/useRequestUpdateInstall.ts
+++ b/frontend/src/renderer/hooks/useRequestUpdateInstall.ts
@@ -22,11 +22,18 @@ export function useRequestUpdateInstall(): () => void {
 	const queryClient = useQueryClient();
 
 	return useCallback(() => {
-		const projects = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryOptions.queryKey);
-		// An unresolved workspace list means AO cannot rule out a session losing a
-		// turn, so it confirms. Same bias as `no_signal` inside the risk filter:
-		// when liveness is unknown, assume a turn is in flight.
-		if (projects === undefined) {
+		const snapshot = queryClient.getQueryState<WorkspaceSummary[]>(workspaceQueryOptions.queryKey);
+		const projects = snapshot?.data;
+		// Cached idle sessions are not evidence of safety while a refresh is
+		// pending, failed, or overdue. Confirm rather than quitting on an old
+		// snapshot; keep the same freshness window as the workspace query.
+		if (
+			projects === undefined ||
+			snapshot?.status !== "success" ||
+			snapshot.fetchStatus !== "idle" ||
+			snapshot.isInvalidated ||
+			Date.now() - snapshot.dataUpdatedAt >= workspaceQueryOptions.staleTime
+		) {
 			openPrompt();
 			return;
 		}

--- a/frontend/src/renderer/hooks/useRequestUpdateInstall.ts
+++ b/frontend/src/renderer/hooks/useRequestUpdateInstall.ts
@@ -1,0 +1,50 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { aoBridge } from "../lib/bridge";
+import { sessionsAtRiskFromInstall } from "../lib/update-install-risk";
+import { useUiStore } from "../stores/ui-store";
+import { workspaceQueryOptions } from "./useWorkspaceQuery";
+import type { WorkspaceSummary } from "../types/workspace";
+
+/**
+ * Decide whether restarting into a staged build needs confirming.
+ *
+ * The confirmation exists because a single click used to quit the app with no
+ * warning (#4849). That reason only holds when a session would actually lose an
+ * in-flight turn: `update-install-risk.ts` already argues that treating every
+ * quit as destructive "would warn on almost every session and teach the user to
+ * click through", and a confirmation carrying no warning is that same failure
+ * one level up — in Settings it also stacked a modal on top of a modal.
+ *
+ * So confirm exactly when there is something to confirm. With nothing at risk
+ * the button says "Restart & install" and does that; the build was going to
+ * install on the next quit regardless.
+ *
+ * Reads the workspace list out of the query cache rather than subscribing with
+ * useWorkspaceQuery. Both callers are mounted for the whole shell's lifetime and
+ * need this only on click, and that hook pulls in the cloud session/org queries,
+ * which would make every test that renders the sidebar or Settings provide cloud
+ * bridge mocks it has no reason to know about. Local projects only: a cloud
+ * session does not die when this desktop app quits, so it is never at risk here.
+ */
+export function useRequestUpdateInstall(): () => void {
+	const openPrompt = useUiStore((state) => state.openUpdateInstallPrompt);
+	const queryClient = useQueryClient();
+
+	return useCallback(() => {
+		const projects = queryClient.getQueryData<WorkspaceSummary[]>(workspaceQueryOptions.queryKey);
+		// An unresolved workspace list means AO cannot rule out a session losing a
+		// turn, so it confirms. Same bias as `no_signal` inside the risk filter:
+		// when liveness is unknown, assume a turn is in flight.
+		if (projects === undefined) {
+			openPrompt();
+			return;
+		}
+		const atRisk = sessionsAtRiskFromInstall(projects.flatMap((project) => project.sessions));
+		if (atRisk.length > 0) {
+			openPrompt();
+			return;
+		}
+		void aoBridge.updates.install();
+	}, [openPrompt, queryClient]);
+}

--- a/frontend/src/renderer/lib/update-install-risk.test.ts
+++ b/frontend/src/renderer/lib/update-install-risk.test.ts
@@ -22,6 +22,10 @@ describe("sessionsAtRiskFromInstall", () => {
 		expect(sessionsAtRiskFromInstall([session({ status: "no_signal" })])).toHaveLength(1);
 	});
 
+	it("flags a chat turn paused for approval or input", () => {
+		expect(sessionsAtRiskFromInstall([session({ status: "needs_input" })])).toHaveLength(1);
+	});
+
 	it("spares TUI sessions, whose runtime is detached and re-adopted", () => {
 		expect(sessionsAtRiskFromInstall([session({ mode: "tui" })])).toEqual([]);
 	});
@@ -31,7 +35,7 @@ describe("sessionsAtRiskFromInstall", () => {
 	});
 
 	it("spares sessions with no turn in flight", () => {
-		for (const status of ["idle", "needs_input", "exited", "merged", "pr_open"]) {
+		for (const status of ["idle", "exited", "merged", "pr_open"]) {
 			expect(sessionsAtRiskFromInstall([session({ status })])).toEqual([]);
 		}
 	});

--- a/frontend/src/renderer/lib/update-install-risk.ts
+++ b/frontend/src/renderer/lib/update-install-risk.ts
@@ -16,11 +16,13 @@ import type { AgentProvider } from "../types/workspace";
  *
  * Only the last group is at risk, and only while a turn could be in flight.
  * `working` is the obvious case; `no_signal` is a live session whose agent has
- * not reported in, so AO cannot rule out a turn and must assume one.
+ * not reported in, so AO cannot rule out a turn and must assume one. A
+ * `needs_input` session can be paused inside a turn for tool approval or a user
+ * answer, so it also needs protection.
  */
 export const PERSISTENT_CHAT_PROVIDERS: ReadonlySet<AgentProvider> = new Set<AgentProvider>(["codex"]);
 
-const TURN_MAY_BE_IN_FLIGHT: ReadonlySet<string> = new Set(["working", "no_signal"]);
+const TURN_MAY_BE_IN_FLIGHT: ReadonlySet<string> = new Set(["working", "no_signal", "needs_input"]);
 
 export type UpdateRiskSession = {
 	id: string;


### PR DESCRIPTION
Reported: clicking **Restart & install** in Settings → Updates opens a confirmation dialog *on top of* the Settings modal.

With no session mid-turn, that dialog carries nothing — no warning, a copy of the release notes, and a line explaining the build installs on the next quit regardless. A modal over a modal to repeat what the button already said.

## Why it was there, and why that reason had a scope

The confirmation was added by #4849 because a single click used to quit the app unasked. That reason holds only when a session would actually lose an in-flight turn.

`update-install-risk.ts` already makes exactly this argument, for *which sessions to list*:

> Quitting is NOT uniformly destructive, and treating it as if it were would warn on almost every session and **teach the user to click through**.

It just was never applied to *whether the dialog should open at all*. A confirmation with no warning in it is that same failure one level up.

## Change

Both entry points — the sidebar restart row and the Settings button — now share one decision:

- **A session would lose a turn** → the dialog opens, unchanged, warning list and all.
- **Nothing at risk** → install directly.
- **Workspace list unresolved** → still confirms. Unknown is not safe; this matches the `no_signal` bias inside the risk filter.

Release notes lived *only* in that dialog, so skipping it would have hidden them. They now render in the Updates panel, which has room the dialog never did.

## Implementation note

The decision reads the workspace list from the query cache instead of calling `useWorkspaceQuery`. Both callers are mounted for the whole shell's lifetime and need this only on click, and that hook pulls in the cloud org/session queries — routing it through the hook made **37 sidebar and Settings tests fail** demanding cloud bridge mocks they have no reason to provide. The dialog's own comment warns about the same coupling.

Local projects only: a cloud session does not die when this desktop app quits, so it is never at risk here.

## Verification

Rendered before/after against the real token values rather than reasoning about it:

- **Today:** dialog stacked over the Settings panel, contentless.
- **After:** panel shows status, last-checked and What's new; the button installs.
- **At-risk case:** dialog still appears with its warning list.

| Check | Result |
|---|---|
| `npm run typecheck` | pass |
| `npx vitest run` (full suite) | **281 files, 3864 passed, 7 skipped, 0 failed** |

Four new cases cover the decision directly: installs directly with only safe sessions, confirms with an at-risk session, confirms when the list has not resolved, installs directly with no sessions.

Independent of #4981 (updater install-rejection + status delivery); branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
