### PR TITLE
fix: count turn diff lines from real deltas

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/client.go
+++ b/backend/internal/adapters/chatdriver/acp/client.go
@@ -946,36 +946,42 @@ func toolTerminal(status acpsdk.ToolCallStatus) bool {
 }
 
 func (c *conversation) emitDiffs(turnID string, content []acpsdk.ToolCallContent) {
-	files := make([]ports.ChatDiffFile, 0)
+	c.mu.Lock()
+	if c.turnDiffTurnID != turnID {
+		c.turnDiffs = make(map[string]*turnFileSnap)
+		c.turnDiffTurnID = turnID
+	}
+	changed := false
 	for _, item := range content {
 		if item.Diff == nil {
 			continue
 		}
-		status := "modified"
-		deletions := 0
-		if item.Diff.OldText == nil {
-			status = "added"
-		} else {
-			deletions = lineCount(*item.Diff.OldText)
-			if item.Diff.NewText == "" {
-				status = "deleted"
-			}
+		changed = true
+		path := item.Diff.Path
+		snap := c.turnDiffs[path]
+		if snap == nil {
+			snap = &turnFileSnap{}
+			c.turnDiffs[path] = snap
 		}
+		snap.apply(path, item.Diff.OldText, item.Diff.NewText)
+	}
+	if !changed {
+		c.mu.Unlock()
+		return
+	}
+	files := make([]ports.ChatDiffFile, 0, len(c.turnDiffs))
+	for _, path := range sortedKeys(c.turnDiffs) {
+		snap := c.turnDiffs[path]
+		additions, deletions := snap.additionsDeletions()
 		files = append(files, ports.ChatDiffFile{
-			Path: item.Diff.Path, Status: status,
-			Additions: lineCount(item.Diff.NewText), Deletions: deletions,
+			Path:      snap.path,
+			Status:    snap.status,
+			Additions: additions,
+			Deletions: deletions,
 		})
 	}
-	if len(files) > 0 {
-		c.emit(ports.ChatEvent{Kind: ports.ChatEventTurnDiff, ProviderTurnID: turnID, Diff: &ports.ChatTurnDiff{Files: files}})
-	}
-}
-
-func lineCount(value string) int {
-	if value == "" {
-		return 0
-	}
-	return strings.Count(value, "\n") + 1
+	c.mu.Unlock()
+	c.emit(ports.ChatEvent{Kind: ports.ChatEventTurnDiff, ProviderTurnID: turnID, Diff: &ports.ChatTurnDiff{Files: files}})
 }
 
 func normalizePlan(entries []acpsdk.PlanEntry) *domain.ConversationPlan {

--- a/backend/internal/adapters/chatdriver/acp/client.go
+++ b/backend/internal/adapters/chatdriver/acp/client.go
@@ -539,7 +539,7 @@ func (c *conversation) SessionUpdate(_ context.Context, params acpsdk.SessionNot
 		c.tools[tool.id] = tool
 		c.mu.Unlock()
 		c.emit(c.toolEvent(turnID, tool, toolTerminal(tool.status)))
-		c.emitDiffs(turnID, tool.content)
+		c.emitDiffs(turnID, tool.id, tool.content)
 	case update.ToolCallUpdate != nil:
 		tool := c.mergeToolUpdate(update.ToolCallUpdate)
 		if delta := terminalOutput(update.ToolCallUpdate.Meta); delta != "" {
@@ -547,7 +547,7 @@ func (c *conversation) SessionUpdate(_ context.Context, params acpsdk.SessionNot
 				ProviderItemID: c.providerItemID(tool.id), Delta: delta})
 		}
 		c.emit(c.toolEvent(turnID, tool, toolTerminal(tool.status)))
-		c.emitDiffs(turnID, tool.content)
+		c.emitDiffs(turnID, tool.id, tool.content)
 	case update.Plan != nil:
 		c.emit(ports.ChatEvent{Kind: ports.ChatEventPlanUpdated, ProviderTurnID: turnID, Plan: normalizePlan(update.Plan.Entries)})
 	case update.SessionInfoUpdate != nil:
@@ -945,43 +945,40 @@ func toolTerminal(status acpsdk.ToolCallStatus) bool {
 	return status == acpsdk.ToolCallStatusCompleted || status == acpsdk.ToolCallStatusFailed
 }
 
-func (c *conversation) emitDiffs(turnID string, content []acpsdk.ToolCallContent) {
-	c.mu.Lock()
-	if c.turnDiffTurnID != turnID {
-		c.turnDiffs = make(map[string]*turnFileSnap)
-		c.turnDiffTurnID = turnID
-	}
-	changed := false
+func (c *conversation) emitDiffs(turnID, toolID string, content []acpsdk.ToolCallContent) {
+	// One tool call contributes at most one entry per path. If the provider
+	// lists the same path more than once in a single content payload, the last
+	// snapshot wins — summing those would reintroduce inflated counts.
+	byPath := make(map[string]ports.ChatDiffFile)
+	var pathOrder []string
 	for _, item := range content {
 		if item.Diff == nil {
 			continue
 		}
-		changed = true
 		path := item.Diff.Path
-		snap := c.turnDiffs[path]
-		if snap == nil {
-			snap = &turnFileSnap{}
-			c.turnDiffs[path] = snap
+		if _, exists := byPath[path]; !exists {
+			pathOrder = append(pathOrder, path)
 		}
-		snap.apply(path, item.Diff.OldText, item.Diff.NewText)
+		byPath[path] = diffFileFromSnapshot(path, item.Diff.OldText, item.Diff.NewText)
 	}
-	if !changed {
-		c.mu.Unlock()
+	if len(byPath) == 0 {
 		return
 	}
-	files := make([]ports.ChatDiffFile, 0, len(c.turnDiffs))
-	for _, path := range sortedKeys(c.turnDiffs) {
-		snap := c.turnDiffs[path]
-		additions, deletions := snap.additionsDeletions()
-		files = append(files, ports.ChatDiffFile{
-			Path:      snap.path,
-			Status:    snap.status,
-			Additions: additions,
-			Deletions: deletions,
-		})
+	files := make([]ports.ChatDiffFile, 0, len(pathOrder))
+	for _, path := range pathOrder {
+		files = append(files, byPath[path])
 	}
+
+	c.mu.Lock()
+	if c.turnDiffTurnID != turnID || c.turnDiffs == nil {
+		c.turnDiffs = &turnDiffAccumulator{}
+		c.turnDiffTurnID = turnID
+	}
+	c.turnDiffs.replaceTool(toolID, files)
+	aggregated := c.turnDiffs.aggregate()
 	c.mu.Unlock()
-	c.emit(ports.ChatEvent{Kind: ports.ChatEventTurnDiff, ProviderTurnID: turnID, Diff: &ports.ChatTurnDiff{Files: files}})
+
+	c.emit(ports.ChatEvent{Kind: ports.ChatEventTurnDiff, ProviderTurnID: turnID, Diff: &ports.ChatTurnDiff{Files: aggregated}})
 }
 
 func normalizePlan(entries []acpsdk.PlanEntry) *domain.ConversationPlan {

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -85,24 +85,24 @@ type conversation struct {
 	log             *slog.Logger
 	providerScopeID string
 
-	mu                sync.Mutex
-	sessionID         string
-	capabilities      ports.ChatCapabilities
-	prepared          *preparedTurn
-	activeTurn        string
-	settlingTurn      string
-	turnCancel        context.CancelFunc
-	interrupt         *interruptAttempt
-	pending           map[string]*parkedPermission
-	pendingInputs     map[string]*parkedInput
-	messages          map[string]string
-	thoughts          map[string]string
-	nestedMessages    map[string]nestedMessageState
-	tools             map[string]*toolState
-	// turnDiffs accumulates per-path file snapshots for the active turn. ACP
-	// tool calls only carry that call's old/new text; without this map each
-	// emitDiffs would replace the turn card with the latest tool alone.
-	turnDiffs         map[string]*turnFileSnap
+	mu             sync.Mutex
+	sessionID      string
+	capabilities   ports.ChatCapabilities
+	prepared       *preparedTurn
+	activeTurn     string
+	settlingTurn   string
+	turnCancel     context.CancelFunc
+	interrupt      *interruptAttempt
+	pending        map[string]*parkedPermission
+	pendingInputs  map[string]*parkedInput
+	messages       map[string]string
+	thoughts       map[string]string
+	nestedMessages map[string]nestedMessageState
+	tools          map[string]*toolState
+	// turnDiffs stores each tool call's latest file contribution for the active
+	// turn. ACP may re-send the same tool with expanded old/new context; those
+	// updates replace that tool's contribution rather than merging snapshots.
+	turnDiffs         *turnDiffAccumulator
 	turnDiffTurnID    string
 	providerFailure   *ports.ChatEvent
 	configOptions     []ports.ChatConfigOption

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -99,6 +99,11 @@ type conversation struct {
 	thoughts          map[string]string
 	nestedMessages    map[string]nestedMessageState
 	tools             map[string]*toolState
+	// turnDiffs accumulates per-path file snapshots for the active turn. ACP
+	// tool calls only carry that call's old/new text; without this map each
+	// emitDiffs would replace the turn card with the latest tool alone.
+	turnDiffs         map[string]*turnFileSnap
+	turnDiffTurnID    string
 	providerFailure   *ports.ChatEvent
 	configOptions     []ports.ChatConfigOption
 	skills            []ports.ChatSkill
@@ -434,6 +439,8 @@ func (c *conversation) StartDeferredTurn(providerTurnID string) error {
 	c.thoughts = make(map[string]string)
 	c.nestedMessages = make(map[string]nestedMessageState)
 	c.tools = make(map[string]*toolState)
+	c.turnDiffs = nil
+	c.turnDiffTurnID = ""
 	c.providerFailure = nil
 	c.mu.Unlock()
 

--- a/backend/internal/adapters/chatdriver/acp/diff_stats.go
+++ b/backend/internal/adapters/chatdriver/acp/diff_stats.go
@@ -1,0 +1,108 @@
+package acp
+
+import "strings"
+
+// lineDelta reports how many lines were added and removed between two file
+// snapshots. ACP tool diffs send full old/new text, not a unified patch — counting
+// each side's length would make a one-line edit in a 1400-line file show as
+// +1400 −1400.
+func lineDelta(oldText, newText string) (additions, deletions int) {
+	if oldText == newText {
+		return 0, 0
+	}
+	oldLines := splitLines(oldText)
+	newLines := splitLines(newText)
+	if len(oldLines) == 0 {
+		return len(newLines), 0
+	}
+	if len(newLines) == 0 {
+		return 0, len(oldLines)
+	}
+	lcs := longestCommonSubsequenceLen(oldLines, newLines)
+	return len(newLines) - lcs, len(oldLines) - lcs
+}
+
+func splitLines(value string) []string {
+	if value == "" {
+		return nil
+	}
+	lines := strings.Split(value, "\n")
+	// A trailing newline marks "file ends with newline", not an extra blank line.
+	if strings.HasSuffix(value, "\n") {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// longestCommonSubsequenceLen is a rolling-row LCS length over line tokens.
+// Space is O(min(len(a), len(b))); callers already hold both full file bodies.
+func longestCommonSubsequenceLen(a, b []string) int {
+	if len(a) < len(b) {
+		a, b = b, a
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for i := 1; i <= len(a); i++ {
+		for j := 1; j <= len(b); j++ {
+			if a[i-1] == b[j-1] {
+				curr[j] = prev[j-1] + 1
+			} else if prev[j] >= curr[j-1] {
+				curr[j] = prev[j]
+			} else {
+				curr[j] = curr[j-1]
+			}
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+// turnFileSnap is one path's turn-scoped before/after. ACP emits per-tool
+// snapshots, not an aggregated turn diff, so AO has to keep the first old text
+// and the latest new text to report net line counts the way Codex's turn diff does.
+type turnFileSnap struct {
+	path      string
+	status    string
+	baseOld   string
+	latestNew string
+	seen      bool
+}
+
+func (s *turnFileSnap) apply(path string, oldText *string, newText string) {
+	if !s.seen {
+		s.seen = true
+		s.path = path
+		if oldText == nil {
+			s.status = "added"
+			s.baseOld = ""
+		} else {
+			s.baseOld = *oldText
+			if newText == "" {
+				s.status = "deleted"
+			} else {
+				s.status = "modified"
+			}
+		}
+		s.latestNew = newText
+		return
+	}
+	s.path = path
+	s.latestNew = newText
+	switch {
+	case s.baseOld == "" && s.status == "added":
+		// Still a turn-local add, even after further edits.
+		if newText == "" {
+			s.status = "deleted"
+		} else {
+			s.status = "added"
+		}
+	case newText == "":
+		s.status = "deleted"
+	default:
+		s.status = "modified"
+	}
+}
+
+func (s turnFileSnap) additionsDeletions() (additions, deletions int) {
+	return lineDelta(s.baseOld, s.latestNew)
+}

--- a/backend/internal/adapters/chatdriver/acp/diff_stats.go
+++ b/backend/internal/adapters/chatdriver/acp/diff_stats.go
@@ -1,11 +1,15 @@
 package acp
 
-import "strings"
+import (
+	"strings"
 
-// lineDelta reports how many lines were added and removed between two file
-// snapshots. ACP tool diffs send full old/new text, not a unified patch — counting
-// each side's length would make a one-line edit in a 1400-line file show as
-// +1400 −1400.
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// lineDelta reports how many lines were added and removed between two texts.
+// ACP tool diffs send old/new snapshots (sometimes a hunk, sometimes a wider
+// view of the same edit), not a unified patch — counting each side's length
+// would make a one-line edit in an N-line file show as +N −N.
 func lineDelta(oldText, newText string) (additions, deletions int) {
 	if oldText == newText {
 		return 0, 0
@@ -35,7 +39,7 @@ func splitLines(value string) []string {
 }
 
 // longestCommonSubsequenceLen is a rolling-row LCS length over line tokens.
-// Space is O(min(len(a), len(b))); callers already hold both full file bodies.
+// Space is O(min(len(a), len(b))); callers already hold both texts.
 func longestCommonSubsequenceLen(a, b []string) int {
 	if len(a) < len(b) {
 		a, b = b, a
@@ -57,52 +61,78 @@ func longestCommonSubsequenceLen(a, b []string) int {
 	return prev[len(b)]
 }
 
-// turnFileSnap is one path's turn-scoped before/after. ACP emits per-tool
-// snapshots, not an aggregated turn diff, so AO has to keep the first old text
-// and the latest new text to report net line counts the way Codex's turn diff does.
-type turnFileSnap struct {
-	path      string
-	status    string
-	baseOld   string
-	latestNew string
-	seen      bool
-}
-
-func (s *turnFileSnap) apply(path string, oldText *string, newText string) {
-	if !s.seen {
-		s.seen = true
-		s.path = path
-		if oldText == nil {
-			s.status = "added"
-			s.baseOld = ""
-		} else {
-			s.baseOld = *oldText
-			if newText == "" {
-				s.status = "deleted"
-			} else {
-				s.status = "modified"
-			}
-		}
-		s.latestNew = newText
-		return
-	}
-	s.path = path
-	s.latestNew = newText
-	switch {
-	case s.baseOld == "" && s.status == "added":
-		// Still a turn-local add, even after further edits.
+func diffFileFromSnapshot(path string, oldText *string, newText string) ports.ChatDiffFile {
+	old := ""
+	status := "modified"
+	if oldText == nil {
+		status = "added"
+	} else {
+		old = *oldText
 		if newText == "" {
-			s.status = "deleted"
-		} else {
-			s.status = "added"
+			status = "deleted"
 		}
-	case newText == "":
-		s.status = "deleted"
-	default:
-		s.status = "modified"
+	}
+	additions, deletions := lineDelta(old, newText)
+	return ports.ChatDiffFile{
+		Path:      path,
+		Status:    status,
+		Additions: additions,
+		Deletions: deletions,
 	}
 }
 
-func (s turnFileSnap) additionsDeletions() (additions, deletions int) {
-	return lineDelta(s.baseOld, s.latestNew)
+// turnDiffAccumulator stores each tool call's latest file contribution for the
+// active turn. ACP re-sends a tool call with expanded old/new context as the
+// edit settles; those updates must replace that tool's contribution, not be
+// combined with an earlier narrower snapshot (first-old + latest-new).
+type turnDiffAccumulator struct {
+	toolOrder []string
+	byTool    map[string][]ports.ChatDiffFile
+}
+
+func (a *turnDiffAccumulator) replaceTool(toolID string, files []ports.ChatDiffFile) {
+	if a.byTool == nil {
+		a.byTool = make(map[string][]ports.ChatDiffFile)
+	}
+	if _, exists := a.byTool[toolID]; !exists {
+		a.toolOrder = append(a.toolOrder, toolID)
+	}
+	a.byTool[toolID] = files
+}
+
+func (a *turnDiffAccumulator) aggregate() []ports.ChatDiffFile {
+	if len(a.byTool) == 0 {
+		return nil
+	}
+	type agg struct {
+		path                 string
+		status               string
+		additions, deletions int
+	}
+	byPath := make(map[string]*agg)
+	var pathOrder []string
+	for _, toolID := range a.toolOrder {
+		for _, file := range a.byTool[toolID] {
+			cur := byPath[file.Path]
+			if cur == nil {
+				cur = &agg{path: file.Path}
+				byPath[file.Path] = cur
+				pathOrder = append(pathOrder, file.Path)
+			}
+			cur.additions += file.Additions
+			cur.deletions += file.Deletions
+			cur.status = file.Status
+		}
+	}
+	out := make([]ports.ChatDiffFile, 0, len(pathOrder))
+	for _, path := range pathOrder {
+		cur := byPath[path]
+		out = append(out, ports.ChatDiffFile{
+			Path:      cur.path,
+			Status:    cur.status,
+			Additions: cur.additions,
+			Deletions: cur.deletions,
+		})
+	}
+	return out
 }

--- a/backend/internal/adapters/chatdriver/acp/diff_stats_test.go
+++ b/backend/internal/adapters/chatdriver/acp/diff_stats_test.go
@@ -1,8 +1,11 @@
 package acp
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 func TestLineDeltaCountsActualEditsNotWholeFiles(t *testing.T) {
@@ -50,36 +53,69 @@ func TestLineDeltaAppendOnly(t *testing.T) {
 	}
 }
 
-func TestTurnFileSnapNetsRepeatedEditsAgainstFirstSnapshot(t *testing.T) {
-	var snap turnFileSnap
-	base := "a\nb\nc\n"
-	mid := "a\nb\nX\n"
-	final := "a\nb\nX\nY\n"
+func TestTurnDiffReplacesExpandedContextForSameTool(t *testing.T) {
+	// Claude ACP often re-sends the same edit with a wider old/new window.
+	// Combining the first narrow oldText with the later expanded newText inflates
+	// the count (live: +1000 then +1002 / −2). Replacement keeps +1000.
+	const appended = 1000
+	prefix := lines("keep", 5)
+	extraContext := lines("ctx", 2)
+	suffix := lines("line", appended)
 
-	old := base
-	snap.apply("f.txt", &old, mid)
-	additions, deletions := snap.additionsDeletions()
-	if snap.status != "modified" || additions != 1 || deletions != 1 {
-		t.Fatalf("after first edit: status=%s +%d −%d", snap.status, additions, deletions)
+	tightOld := prefix
+	tightNew := prefix + suffix
+	expandedOld := extraContext + prefix
+	expandedNew := extraContext + prefix + suffix
+
+	add, del := lineDelta(tightOld, tightNew)
+	if add != appended || del != 0 {
+		t.Fatalf("tight update = +%d −%d, want +%d −0", add, del, appended)
+	}
+	add, del = lineDelta(expandedOld, expandedNew)
+	if add != appended || del != 0 {
+		t.Fatalf("expanded update = +%d −%d, want +%d −0", add, del, appended)
 	}
 
-	old = mid
-	snap.apply("f.txt", &old, final)
-	additions, deletions = snap.additionsDeletions()
-	// Net turn delta is base → final (+2 −1), not mid → final alone.
-	if snap.status != "modified" || additions != 2 || deletions != 1 {
-		t.Fatalf("after second edit: status=%s +%d −%d, want modified +2 −1", snap.status, additions, deletions)
+	// The buggy first-old + latest-new merge that this regression guards against.
+	wrongAdd, wrongDel := lineDelta(tightOld, expandedNew)
+	if wrongAdd == appended && wrongDel == 0 {
+		t.Fatal("fixture no longer reproduces the expanded-context inflation")
+	}
+
+	var acc turnDiffAccumulator
+	path := "big.txt"
+	toolID := "tool-edit-1"
+	acc.replaceTool(toolID, []ports.ChatDiffFile{diffFileFromSnapshot(path, strPtr(tightOld), tightNew)})
+	got := acc.aggregate()
+	if len(got) != 1 || got[0].Additions != appended || got[0].Deletions != 0 {
+		t.Fatalf("after tight update: %+v, want +%d −0", got, appended)
+	}
+
+	acc.replaceTool(toolID, []ports.ChatDiffFile{diffFileFromSnapshot(path, strPtr(expandedOld), expandedNew)})
+	got = acc.aggregate()
+	if len(got) != 1 || got[0].Additions != appended || got[0].Deletions != 0 {
+		t.Fatalf("after expanded replace: +%d −%d (wrong merge was +%d −%d), want +%d −0",
+			got[0].Additions, got[0].Deletions, wrongAdd, wrongDel, appended)
 	}
 }
 
-func TestTurnFileSnapKeepsAddStatusAcrossFollowUpEdits(t *testing.T) {
-	var snap turnFileSnap
-	snap.apply("new.txt", nil, "one\n")
-	snap.apply("new.txt", strPtr("one\n"), "one\ntwo\n")
-	additions, deletions := snap.additionsDeletions()
-	if snap.status != "added" || additions != 2 || deletions != 0 {
-		t.Fatalf("turn-local add = status=%s +%d −%d, want added +2 −0", snap.status, additions, deletions)
+func TestTurnDiffSumsDistinctToolCallsOnSamePath(t *testing.T) {
+	var acc turnDiffAccumulator
+	path := "f.txt"
+	acc.replaceTool("t1", []ports.ChatDiffFile{diffFileFromSnapshot(path, strPtr("a\n"), "a\nb\n")})
+	acc.replaceTool("t2", []ports.ChatDiffFile{diffFileFromSnapshot(path, strPtr("a\nb\n"), "a\nb\nc\n")})
+	got := acc.aggregate()
+	if len(got) != 1 || got[0].Additions != 2 || got[0].Deletions != 0 {
+		t.Fatalf("aggregate = %+v, want +2 −0", got)
 	}
+}
+
+func lines(prefix string, n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%s-%d\n", prefix, i)
+	}
+	return b.String()
 }
 
 func strPtr(value string) *string { return &value }

--- a/backend/internal/adapters/chatdriver/acp/diff_stats_test.go
+++ b/backend/internal/adapters/chatdriver/acp/diff_stats_test.go
@@ -1,0 +1,85 @@
+package acp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLineDeltaCountsActualEditsNotWholeFiles(t *testing.T) {
+	// A one-line rewrite inside a large file must not report +N −N for N=len(file).
+	const n = 1415
+	var oldBuilder, newBuilder strings.Builder
+	for i := 0; i < n; i++ {
+		oldBuilder.WriteString("line\n")
+		if i == 100 {
+			newBuilder.WriteString("changed\n")
+		} else {
+			newBuilder.WriteString("line\n")
+		}
+	}
+
+	additions, deletions := lineDelta(oldBuilder.String(), newBuilder.String())
+	if additions != 1 || deletions != 1 {
+		t.Fatalf("lineDelta = +%d −%d, want +1 −1", additions, deletions)
+	}
+}
+
+func TestLineDeltaAddedAndDeletedFiles(t *testing.T) {
+	additions, deletions := lineDelta("", "one\ntwo\nthree")
+	if additions != 3 || deletions != 0 {
+		t.Fatalf("added file = +%d −%d, want +3 −0", additions, deletions)
+	}
+
+	additions, deletions = lineDelta("one\ntwo\nthree", "")
+	if additions != 0 || deletions != 3 {
+		t.Fatalf("deleted file = +%d −%d, want +0 −3", additions, deletions)
+	}
+}
+
+func TestLineDeltaIdenticalSnapshots(t *testing.T) {
+	additions, deletions := lineDelta("same\nfile\n", "same\nfile\n")
+	if additions != 0 || deletions != 0 {
+		t.Fatalf("identical = +%d −%d, want +0 −0", additions, deletions)
+	}
+}
+
+func TestLineDeltaAppendOnly(t *testing.T) {
+	additions, deletions := lineDelta("a\nb\n", "a\nb\nc\n")
+	if additions != 1 || deletions != 0 {
+		t.Fatalf("append = +%d −%d, want +1 −0", additions, deletions)
+	}
+}
+
+func TestTurnFileSnapNetsRepeatedEditsAgainstFirstSnapshot(t *testing.T) {
+	var snap turnFileSnap
+	base := "a\nb\nc\n"
+	mid := "a\nb\nX\n"
+	final := "a\nb\nX\nY\n"
+
+	old := base
+	snap.apply("f.txt", &old, mid)
+	additions, deletions := snap.additionsDeletions()
+	if snap.status != "modified" || additions != 1 || deletions != 1 {
+		t.Fatalf("after first edit: status=%s +%d −%d", snap.status, additions, deletions)
+	}
+
+	old = mid
+	snap.apply("f.txt", &old, final)
+	additions, deletions = snap.additionsDeletions()
+	// Net turn delta is base → final (+2 −1), not mid → final alone.
+	if snap.status != "modified" || additions != 2 || deletions != 1 {
+		t.Fatalf("after second edit: status=%s +%d −%d, want modified +2 −1", snap.status, additions, deletions)
+	}
+}
+
+func TestTurnFileSnapKeepsAddStatusAcrossFollowUpEdits(t *testing.T) {
+	var snap turnFileSnap
+	snap.apply("new.txt", nil, "one\n")
+	snap.apply("new.txt", strPtr("one\n"), "one\ntwo\n")
+	additions, deletions := snap.additionsDeletions()
+	if snap.status != "added" || additions != 2 || deletions != 0 {
+		t.Fatalf("turn-local add = status=%s +%d −%d, want added +2 −0", snap.status, additions, deletions)
+	}
+}
+
+func strPtr(value string) *string { return &value }


### PR DESCRIPTION
## Summary
- ACP turn diff stats were using whole-file line counts from `oldText`/`newText`, so a one-line edit in an N-line file showed as `+N −N`.
- Compute real line deltas, keep the turn’s first snapshot per path, and accumulate across tool calls so the turn card matches the net change.

## Test plan
- [ ] `go test ./internal/adapters/chatdriver/acp/ -count=1`
- [ ] In an ACP session (e.g. Claude), edit one line in a large file and confirm the turn changed-files card is roughly `+1 −1`, not `+N −N`
- [ ] Edit two different files in one turn and confirm both remain on the turn card
- [ ] Edit the same file twice in one turn and confirm counts reflect the net turn delta