### PR TITLE
feat: prettier tool calls in chat ui

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,276 +1,402 @@
-# Design System — ReverbCode
+---
+name: agent-orchestrator-design-system
+description: "Use for any renderer UI, visual polish, component, layout, theme, motion, or interaction change in Agent Orchestrator. Read before proposing or implementing visual work."
+---
 
-> Source of truth for the ReverbCode desktop UI (Electron + React 19 + Tailwind v4
->
-> - Radix/shadcn + xterm, in `frontend/src/renderer`). Read this before any visual
->   or UI change. Created by `/design-consultation` on 2026-06-09.
+# Design system — Agent Orchestrator
 
-## ⚠️ Design direction — clone agent-orchestrator verbatim (SUPERSEDES prior direction · 2026-06-10)
+Agent Orchestrator (AO) is serious desktop software for supervising parallel AI coding work. It makes the state of a project legible: what is running, what needs a human, what is safe to ship, and where intervention will have the most leverage.
 
-By explicit user decision (2026-06-10), the renderer **clones the
-agent-orchestrator web app verbatim** in looks and design. This **supersedes the
-"match the reference" direction** documented in _Aesthetic Direction_ and the palette
-sections below — where they conflict, **agent-orchestrator wins**. Do not re-flag
-"this doesn't match the old reference" in QA/review; flag divergence from **agent-orchestrator**.
+This is a product UI, not a marketing site. It must feel calm under sustained use, reward scanning, and preserve the terminal as a first-class working surface.
 
-- **Reference (the user's own app):** `~/Projects/agent-orchestrator/packages/web/src`
-  — `app/globals.css`, `app/mc-board.css`, `app/mc-sidebar.css`,
-  `components/{ProjectSidebar,Dashboard,SessionCard,SessionDetailHeader,SessionInspector,StatusBadge}.tsx`.
-- **Palette (live in `frontend/src/renderer/styles.css` `:root`):** `--bg #0a0b0d`,
-  `--bg-1 #15171b`, `--fg #f4f5f7`, `--fg-muted #9ba1aa`, `--fg-passive #646a73`,
-  hairline white-alpha borders, accent `--accent #4d8dff`; status palette updated in
-  PR 3 (token layer): working=blue `#60a5fa` (`--color-status-working`), needs-you=orange
-  `#fb923c` (`--color-status-needs-you`), in-review=yellow `#facc15`
-  (`--color-status-in-review`), ready/mergeable=green `#4ade80` (`--color-status-ready`),
-  fail=red via `--destructive` (`--color-status-exited`).
-  The sidebar rail is the cooler `#08090b`.
-- **Cloned surfaces:** the four-column gradient kanban board, the `ProjectSidebar`
-  (brand + project disclosure + nested session rows + Settings menu footer), the
-  session topbar (Kanban back button + identity + breathing `StatusBadge` pill), and
-  the shared `DashboardTopbar`/`DashboardSubhead` chrome (Coding/Reviews tabs · "N
-  working" pill · subhead) reused across board/review/PR/settings.
-- **Build with shadcn primitives** where a component fits (`components/ui/*`:
-  dropdown-menu, select, card, table, tooltip, …); agent-orchestrator's own
-  hand-rolled CSS components are structure/behaviour reference only.
-- The one carried-over divergence still holds: the **accent is refined blue**, and
-  the **terminal keeps its own palette**. Everything else tracks agent-orchestrator.
-- **Approved divergence (2026-06-10):** on macOS, a titlebar cluster (sidebar toggle +
-  back/forward history arrows, `TitlebarNav`) lives in the sidebar header below the
-  traffic lights — the web reference has no window chrome, so no analogue exists.
-  The toggle is pinned in the icon-rail column so it stays put during expand/collapse;
-  arrows hide when the sidebar is collapsed.
-- **Approved divergence (2026-06-10):** the session inspector rail is fully
-  collapsible, built on the shadcn resizable primitive (`pnpm dlx shadcn add
-resizable`, react-resizable-panels v4 `collapsible` panel + imperative API,
-  user-requested). The panel animates to 0% via a flex-grow transition while the
-  content keeps a stable min-width (yyork-style, no mid-animation reflow). Toggled
-  by a `PanelRight` icon button in the session topbar and ⌘⇧B; open state + split
-  width persist. The AO reference keeps the rail always visible.
-- **Approved divergence (2026-06-12):** on Win/Linux the shell topbar spans the
-  window and the sidebar hangs below it so the sidebar border stops at the header.
-  On macOS the shell topbar is hidden (in-panel actions) and the sidebar is
-  full-height; traffic-light clearance uses `--size-traffic-light-clearance` for
-  both the sidebar header pad and the window-drag strip.
+## Reference boundary and migration stance
 
-## Product Context
+This guide is deliberately based only on these approved visual references: the app shell; sidebar and its project section; tooltips; iconography; typography; tokens and themes; borders, shadows and outlines; the New Task, Clone Repository, Settings and Add Project flows; dropdowns used in Settings and New Task; and the kanban board with its cards.
 
-- **What this is:** ReverbCode is an Electron desktop app for supervising many parallel
-  AI coding-agent sessions, backed by a Go daemon (`backend/`). The `ao` CLI is the
-  thin client over the same daemon.
-- **Who it's for:** professional software engineers running multiple coding agents at
-  once who need to delegate, watch, intervene, and ship PRs.
-- **Space/peers:** agent orchestration / parallel-agent desktop tools.
-- **Project type:** dark-mode-primary desktop app; terminal-dense; keyboard-driven;
-  runs all day.
-- **The one memorable thing:** leverage and speed — "I'm more in control here than
-  babysitting N terminal tabs myself."
+Do **not** infer a visual rule from another AO screen merely because it exists today. Much of the application is still being de-slopped. Existing rounded cards, isolated borders, shadows, all-caps metadata, extra helper copy, or one-off button styling outside the approved references are migration debt, not precedent.
 
-### Product flow (what the UI must serve)
+The guide is a future-state standard and a review tool. When current code conflicts with it, preserve functional behavior but move the surface toward this standard in the smallest safe change. Do not copy a legacy inconsistency into new work.
 
-ReverbCode is **orchestrator-led**, which is the one thing that differs from a flat
-list of independent sessions. Grounded in the daemon
-(`backend/internal/session_manager/manager.go`, `docs/architecture.md`):
+### Reference implementation map
 
-- A **Project** is a registered git repo.
-- Per project there is **one active Orchestrator** session plus **N Worker** sessions.
-  Both are the same underlying "session" (durable facts: `activity_state`,
-  `is_terminated`, PR facts); they differ only by `Kind` (`KindOrchestrator` vs the
-  default worker). A project may run the orchestrator on a different agent than its workers.
-- The **Orchestrator is the human-facing coordinator**: you talk to it; it spawns
-  workers (`ao spawn`), messages them (`ao send`), tracks progress, and synthesizes
-  results. It avoids implementing unless necessary.
-- A **Worker is a normal agent session** — nothing special-cased. It runs one focused
-  task in an isolated git worktree + branch, with the agent CLI in a terminal as the
-  conversation, producing a diff → commit/push → PR. It escalates to the orchestrator
-  only for true blockers or cross-session coordination.
-- The daemon **observes** runtime + PR/CI/review facts and **derives** display status
-  at read time: `working`, `needs_input`, `ci_failed`, `changes_requested`,
-  `mergeable`, `approved`, `review_pending`, `pr_open`, `idle`, `terminated`, `merged`.
-  Never store display status; keep session facts small.
+Use these files to inspect the approved references. They show current behavior and component boundaries; this guide decides which details are intentional future-state rules.
 
-## Aesthetic Direction
+| Surface | Primary reference files |
+| --- | --- |
+| App shell, page layout, topbar | [center-panel shell](frontend/src/renderer/components/CenterPanelShell.tsx), [topbar](frontend/src/renderer/components/ShellTopbar.tsx), [shell styles](frontend/src/renderer/styles.css) |
+| Sidebar, sidebar buttons, project rows | [Sidebar](frontend/src/renderer/components/Sidebar.tsx), [sidebar primitive](frontend/src/renderer/components/ui/sidebar.tsx), [topbar button](frontend/src/renderer/components/TopbarButton.tsx) |
+| Tokens, themes, typography | [tokens](frontend/src/styles/tokens.css), [renderer semantic styles](frontend/src/renderer/styles.css), [site-theme tokens](frontend/src/site-theme/tokens.css) |
+| Tooltips, icons, buttons | [Tooltip](frontend/src/renderer/components/ui/tooltip.tsx), [Button](frontend/src/renderer/components/ui/button.tsx), [icon usage](frontend/src/renderer/components/icons.tsx) |
+| Shared dialog and field primitives | [Dialog](frontend/src/renderer/components/ui/dialog.tsx), [Input](frontend/src/renderer/components/ui/input.tsx), [Label](frontend/src/renderer/components/ui/label.tsx) |
+| New Task and its selectors | [New Task dialog](frontend/src/renderer/components/NewTaskDialog.tsx), [Task composer](frontend/src/renderer/components/TaskComposer.tsx), [settings option menu](frontend/src/renderer/components/settings/SettingsOptionMenu.tsx) |
+| Clone Repository and Add Project | [Clone Repository](frontend/src/renderer/components/CloneRepositoryDialog.tsx), [Add Project flow](frontend/src/renderer/components/CreateProjectFlow.tsx), [agent sheet](frontend/src/renderer/components/CreateProjectAgentSheet.tsx) |
+| Settings and settings selectors | [Settings dialog](frontend/src/renderer/components/SettingsDialog.tsx), [global settings](frontend/src/renderer/components/GlobalSettingsForm.tsx), [project settings](frontend/src/renderer/components/ProjectSettingsForm.tsx), [Select](frontend/src/renderer/components/ui/select.tsx), [Dropdown menu](frontend/src/renderer/components/ui/dropdown-menu.tsx) |
+| Kanban board and cards | [Board route](frontend/src/renderer/components/SessionsBoard.tsx), [renderer adapter](frontend/src/renderer/components/SessionsBoardAdapters.tsx), [shared board/card view](packages/product-ui/src/SessionsBoardView.tsx), [board state presentation](frontend/src/renderer/lib/session-presentation.ts) |
 
-> **Superseded (2026-06-10):** see the _Design direction — clone agent-orchestrator
-> verbatim_ banner at the top. The earlier reference framing below is retained for
-> history; the live look tracks agent-orchestrator (same flat near-black / hairline
-> family, so most of this still reads true).
+When a referenced file and this guide disagree, follow this guide for new work and log a targeted migration rather than spreading the discrepancy.
 
-- **Direction:** flat, near-black, hairline-bordered, utilitarian. Industrial control
-  surface, calm chrome, the terminal as the center of gravity.
-- **Decoration level:** minimal. Type + 1px hairlines do all the work. No gradients,
-  glow, blobs, or emoji.
-- **Mood:** low-glare, dense, keyboard-native; signal-over-noise.
-- **Reference:** a flat, hairline-bordered desktop control surface (primary, visual +
-  structural). Tokens below were derived from that reference's renderer CSS.
-- **Deliberate tradeoff:** to match that reference, we use the **system font stack** (not
-  a custom typeface) and its neutral palette. We diverge in exactly one place: the
-  accent is ReverbCode's **refined blue**, not the reference's jade green. The terminal
-  keeps green (it is the agent CLI).
+## 1. Product and reader
 
-## Typography
+- **Reader:** an engineer coordinating several coding-agent sessions, often while switching among repositories, terminals, pull requests, and reviews.
+- **Reader's job:** understand the current state in seconds; open the right session; make a precise intervention; return to the board without losing context.
+- **Core object:** a session. Each session carries a task, agent, worktree, conversation or terminal, files, PR, checks, review facts, and derived status.
+- **Memorable promise:** “I can run several agents without losing the thread.”
+- **Product posture:** operational, technically literate, compact, direct. AO does not pretend that software delivery is effortless; it makes the work visible and tractable.
 
-System fonts only — no custom/Google fonts, zero font payload.
+### Working preferences for design changes
 
-- **UI / body / display:** `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-Oxygen, Ubuntu, Cantarell, "Fira Sans", "Helvetica Neue", sans-serif` (San Francisco
-  on macOS).
-- **Mono / terminal / code / eyebrow labels:** `Menlo, Monaco, Consolas,
-"Liberation Mono", "Courier New", monospace`.
-- **Eyebrow labels** (section titles, dialog titles, the rail "PROJECTS" header):
-  mono, **uppercase**, `letter-spacing: .12–.14em`, `--foreground-passive`.
-- **Scale:** 14px base UI / sidebar (`text-sm`, weight 400) · 12px secondary + labels
-  (`text-xs`) · 13px code/mono/terminal · 11px tiny · 10px micro + badges · 9px sidebar
-  badge label. Buttons are `font-normal` (400), not bold.
+- Prefer direct implementation over a long planning conversation when the intended change is clear. Inspect the existing component and nearby primitives first, then make the smallest coherent change.
+- Keep updates and handoffs concise. Explain the user-visible result, meaningful tradeoffs, files or surfaces affected, and verification status; do not narrate routine tool use.
+- Preserve unrelated work in a dirty worktree. Do not reset, overwrite, or broaden a change without explicit scope.
+- Reuse existing primitives, tokens, and interaction patterns before proposing a new abstraction. If a visual mismatch is local, fix it locally.
+- Verify visual changes with the narrowest relevant tests and, when possible, the real renderer surface. Report pre-existing verification blockers separately from regressions introduced by the change.
+- Treat repeated feedback as a design rule. When a preference recurs—compact copy, sentence case, alignment, no redundant subtext—encode it here instead of solving it as a one-off.
 
-## Color
+### Non-negotiable hierarchy
 
-A flat Radix-neutral near-black ramp carries the whole interface; color is rare
-and meaningful. Values are sRGB approximations of the reference's `color(display-p3 …)` tokens.
+When design requirements compete, preserve them in this order:
 
-### Dark (primary)
+1. Truthful operational state and safe actions.
+2. The user's active task and their next useful action.
+3. Terminal, conversation, file, PR, and review context for the active session.
+4. Fast scanning across projects and sessions.
+5. A coherent visual system and refined motion.
 
-| Role                                 | Hex             |
-| ------------------------------------ | --------------- |
-| `--bg` canvas                        | `#111111`       |
-| `--bg-1` surface                     | `#191919`       |
-| `--bg-2` raised / hover / active row | `#222222`       |
-| `--bg-3`                             | `#2a2a2a`       |
-| `--fg` text                          | `#eeeeee`       |
-| `--fg-muted`                         | `#b4b4b4`       |
-| `--fg-passive`                       | `#6e6e6e`       |
-| `--border` hairline                  | `#3a3a3a`       |
-| `--border-1`                         | `#484848`       |
-| **`--accent` (blue)**                | **`#5b9dff`**   |
-| `--needs-you` / in-progress (amber)  | `#ffcc4a`       |
-| `--success` / mergeable (green)      | `#6cb16c`       |
-| terminal green                       | `#7bd88f`       |
-| `--error` (red)                      | `#d4544f`       |
-| text selection                       | `#3f8ef7` @ 35% |
-| terminal bg                          | `#161616`       |
+Never use visual polish to obscure a state transition, destructive action, connection failure, or uncertainty.
 
-### Light (supported, not primary)
+## 2. Visual thesis
 
-| Role                      | Hex                               |
-| ------------------------- | --------------------------------- |
-| canvas / surface / raised | `#fcfcfc` / `#ffffff` / `#ededee` |
-| text / muted / passive    | `#1a1a1a` / `#666666` / `#9a9a9a` |
-| border                    | `#e3e3e5`                         |
-| accent (blue)             | `#2563eb`                         |
-| amber / green / red       | `#9a6b00` / `#1a7f37` / `#c0392b` |
+**Dark-first precision instrument.** AO is a low-glare, near-neutral control surface with calm typography, disciplined color, and dense but breathable information. The visual result should feel more like a thoughtful desktop tool than a generic SaaS dashboard.
+
+- **Decoration:** minimal. Type, alignment, spacing, surface tone, and only necessary one-pixel boundaries establish hierarchy.
+- **Material:** layered charcoal surfaces—not pure black—with small tonal shifts reserved for nesting, hover, and elevation.
+- **Color:** rare, semantic, and stateful. A colored element must answer “what does this mean?”
+- **Shape:** modest radius, not a field of pills. A rounded control should read as a control; a panel should read as one composed container; ordinary metadata should remain text.
+- **Density:** compact by default. AO is used all day and needs high information capacity without cramped target sizes.
+- **Personality:** quiet competence. No gradients, glass, glow, stock imagery, decorative textures, emoji, or novelty visual language in the working UI.
+
+## 3. App architecture expressed visually
+
+AO has one persistent shell; routes replace the center surface rather than replacing the app's orientation.
+
+### Shell
+
+- **Sidebar:** persistent project navigation and global utility. It answers “where am I?” and “what can I switch to?”
+- **Center:** the primary task surface: home, board, session, terminals, settings, or setup.
+- **Inspector:** contextual detail and secondary actions. It is collapsible, resizable, and must never make the center task unreadable.
+- **Topbar/titlebar:** orientation and high-value actions only. It must not duplicate the entire page's controls.
+
+The layout is desktop-first. On constrained widths, preserve task content first, compact or hide sidebar chrome second, and collapse secondary inspector content before reducing control targets below usable size.
+
+### Route rules
+
+- **Home:** intentionally minimal. It introduces the next meaningful action, not a fake dashboard.
+- **Board:** the operational overview. Each lane has a semantic reason to exist and derived status determines placement.
+- **Session:** the working room. The conversation or terminal is primary; tabs, files, PRs, and inspector are supporting context.
+- **Terminals:** a dedicated surface for standalone shells; do not accidentally route users here from unrelated project-board shortcuts.
+- **Settings:** a deliberate configuration surface with grouped sections, explicit save feedback, and no dashboard chrome masquerading as preferences.
+
+## 4. Navigation and project rows
+
+The sidebar is a compact directory, not a second dashboard.
+
+- Use a quiet sentence-case section label only when a section needs disambiguation. Prefer no label to ornamental chrome. Never use ALL CAPS labels.
+- Projects form one shared list container: no card gap and no individual row border. Use a subtle divider only between sibling rows.
+- Project rows are compact: 28–32px visual height in expanded rail, 12–13px label text, and 14px folder/provider icon. Keep the hit target at least 32px high.
+- Project icon/avatar and label are the primary scan anchors. Do not place status pills, branches, diffs, or PR counts in the row by default.
+- Expanded sessions are visibly children through indentation and reduced contrast, never through heavy nesting or permanent decorative rails.
+- The active project/session uses restrained surface contrast plus a clear selection cue; blue is acceptable for focus/active edge, not as a broad row fill.
+- Row actions appear on hover or focus without moving the label. Actions must not change the row's measured width or trigger navigation.
+- The collapsed rail is icon-first and keeps tooltips, keyboard focus, and fixed titlebar controls usable.
+
+## 5. Operational state and color
+
+Status is derived from durable runtime, PR, CI, and review facts. The renderer communicates it; it does not invent or store a separate display truth.
+
+### Semantic mapping
+
+| Meaning | Token / visual treatment | Use |
+| --- | --- | --- |
+| Working | `--color-status-working` / #60a5fa | active spinner, live activity, progress that is currently observed |
+| Needs human input | `--color-status-needs-you` / #f06445 | blocked, question, actionable interruption |
+| Validating | `--color-status-validating` / #facc15 | checks or verification in progress |
+| Review / caution | `--color-status-in-review` / #f59e0b | review pending, changes requested |
+| Ready / success | `--color-status-ready` / #4ade80 | mergeable, approved, completed actionable success |
+| Merged | `--color-status-merged` / #c084fc | historical terminal completion state |
+| Failure | `--color-status-exited` / `--destructive` | failed CI, destructive or failed operation |
+| Idle / unknown | muted or passive tokens | neutral, not a hidden failure |
+
+### Status glyph rules
+
+Use one fixed status slot where status belongs. Prefer an icon/glyph over a prose badge.
+
+1. If the session is actively working, show the working spinner.
+2. Otherwise, if a PR is relevant, show the PR glyph tinted by its actionable state.
+3. Otherwise, show a dot: amber/red for attention, muted for idle/complete.
+
+Do not show multiple competing status chips on a session card or sidebar row. Text labels are allowed when needed for accessibility, an empty state, an inspector summary, or a decision the user must make.
+
+## 6. Tokens: source of truth
+
+Do not introduce one-off hex values, arbitrary radius, or unreviewed spacing. Use `frontend/src/styles/tokens.css` and the semantic aliases in `frontend/src/renderer/styles.css`.
+
+### Surface stack
+
+- Canvas: `--color-bg-primary`
+- Raised card / grouped content: `--color-bg-secondary`
+- Hover or selected sub-surface: `--color-bg-tertiary` or `--color-interactive-active`
+- Popover / modal elevation: `--color-bg-elevated`
+- Sidebar: `--color-bg-sidebar`
+- Terminal: `--color-bg-terminal-opaque` as a painted surface; preserve terminal-specific text colors
+- Boundaries: `--color-border` for ordinary hairlines; `--color-border-strong` only when separation must survive dense content
+
+### Text stack
+
+- Primary content: `--color-text-primary`
+- Secondary explanation: `--color-text-muted`
+- Passive metadata / de-emphasized chrome: `--color-text-passive`
+- Code and links: `--color-text-markdown-code` and `--color-text-markdown-link`
+- Never reduce essential task information to passive contrast.
 
 ### Accent rules
 
-- **Blue** = the live edge only: primary buttons, the active/selected session, focus
-  rings. Never decorative.
-- **Amber** = an agent needs you (blocked / `needs_input` / `review_pending`).
-- **Green** = `mergeable`/success and terminal/agent CLI text.
-- **Red** = `ci_failed` / destructive.
-- These map 1:1 to the daemon's derived statuses.
+- `--color-accent` is for the live edge: primary action, focus ring, meaningful selected state, or progress.
+- Success, warning, and destructive colors never decorate neutral UI.
+- Do not use color as the only state signal. Pair it with a distinct icon, label, position, or action affordance.
 
-### Status indicator (no text badges)
+## 7. Typography
 
-Session status is a single ~14px glyph in one fixed slot, never a text pill/badge:
+Use the loaded Geist families. Do not add a new web font or substitute a generic font for visual novelty.
 
-- **Working / active** → an animated spinner (accent).
-- **Has an open PR** → a PR icon, tinted by PR state: mergeable/approved green,
-  `ci_failed` red, review/`changes_requested` amber, plain `pr_open` muted.
-- **Otherwise** → a filled dot: `needs_input` amber (pulsing), idle/done muted gray.
+- **UI and body:** `--font-family-base` (`Geist Variable` first).
+- **Code, terminal, compact labels:** `--font-family-mono` (`Geist Mono Variable` first).
+- **Weights:** 500 medium for controls and small hierarchy; 600 only for headings, selected values, and genuinely primary emphasis.
+- **Numbers:** use tabular figures for metrics, timestamps, diffs, and columns where alignment matters.
 
-Precedence: **working spinner > PR icon > dot**. Implemented as `StatusGlyph` in
-`components/SideRail.tsx`; used in the orchestrator's Workers list. (Worker rows in the
-left rail stay name-only — no glyph.)
+### Type scale
 
-## Spacing
+| Role | Token | Intended use |
+| --- | --- | --- |
+| Nano | 8px | exceptional compact rail chrome only |
+| Micro | 10px / `--font-size-xs` | compact metadata and tight pills |
+| Caption | 11px / `--font-size-caption` | lane labels, secondary labels, compact metadata |
+| Secondary | 12px / `--font-size-sm` | helper copy and compact list detail |
+| Dense control | 13px / `--font-size-base` | buttons, board controls, project rows |
+| Body | 14px / `--font-size-md` | readable prose and normal UI content |
+| Dialog title | 15px / `--font-size-subtitle` | modal and section titles |
+| Empty state | 17px / `--font-size-heading-sm` | short guidance headings |
+| Page heading | 21–22px | route-level title only |
 
-- **Base unit:** 4px (Tailwind scale: 1=4, 1.5=6, 2=8, 3=12, 4=16, 5=20, 6=24).
-- **Density:** compact / desktop-tight.
-- **Control + row height:** `h-8` = 32px default; `h-7` = 28px small; `h-6` = 24px xs.
-- Inputs `px-2.5 py-1`; buttons `px-2.5`, gap 1–1.5.
+Use sentence case everywhere a user reads or acts: page titles, buttons, menu items, field labels, section labels, statuses, and compact metadata. Mono is for code-like values (branches, paths, repository URLs, commands, aligned numbers), not for making ordinary UI feel technical. Never use ALL CAPS labels.
 
-## Layout
+## 8. Spacing, dimensions, and shape
 
-- **Approach:** fixed three-pane app shell, opens into the workbench (no marketing/dashboard home).
-- **Panes:** `[ rail 240px ] [ center 1fr ] [ side rail 316px ]`.
-- **Rail (240px), top → bottom:**
-  1. **Orchestrator anchor** — pinned, single, visually distinct (blue 2px left bar,
-     `--bg-2` fill, hub/`waypoints` icon, name "Orchestrator", a `5 agents · 2 need you`
-     mono summary). This is ReverbCode's one addition over the reference. Default landing view.
-  2. `PROJECTS` eyebrow label + a `+`.
-  3. Project rows (folder icon + name) with nested **worker rows beneath**. Each project
-     row has a hover-revealed **`+`** that opens the New-worker modal pre-scoped to that
-     project (distinct from the `PROJECTS` header `+`, which registers a repo).
-  4. **Footer:** `Search ⌘K`, `Settings ⌘,`. (No Library.)
-  5. **Account** row pinned at the very bottom.
-- **Worker rows are name-only.** Just the session name, truncated. Status, branch, diff,
-  and PR live in the panes and topbar, never in the row. Selection = `--bg-2` fill + a
-  2px blue left bar. (the reference itself shows a faint trailing timestamp; we omit it by choice.)
-- **Center = the conversation.** Orchestrator → its coordination terminal (delegate here;
-  composer reads "tell the orchestrator what to build"). Worker → the agent CLI terminal
-  (tabbed per agent, e.g. `claude-code (1)`), with a composer (model selector, worktree
-  path, `Accept edits`). The terminal **is** the conversation; no separate chat surface.
-- **Side rail (316px):** orchestrator → a quiet **Workers** list (name + project + derived
-  status). Worker → the **Git review rail**: `Changed N` → All files / Discard all / Stage
-  all → file rows (`+adds −dels`, stage toggle) → `Commit message` + `Description` →
-  **Commit & Push** (primary blue) → branch + `Create PR`.
-- **Border radius:** `sm` 4px (scrollbar) · `md` 6px (buttons, inputs, toggles) ·
-  `lg` 8px (rows, cards, panels) · `xl` 12px (modals) · `full` (badges/pills/dots).
-- **Icons:** **lucide** only. No emoji.
+### Spacing
 
-### Topbar
+The base unit is 4px. Use the token scale, with 4/6/8/10/12/14/16/18px as the normal dense rhythm. Use 24/32/40px for meaningful section separation, not for routine card padding.
 
-- **Left (both):** `project / session` breadcrumb + pin; for the orchestrator, a hub icon
-  - `Orchestrator`.
-- **Right — worker session:** a **PR/CI status pill** that is the action
-  (`PR #156 · mergeable` green / `CI failed` red / `review requested` amber /
-  `Open PR` when none) → **Changes / Files / Terminal** view toggles → **⋯ session menu**
-  (rename, restart, kill, claim PR — the `ao session …` commands).
-- **Right — orchestrator:** **+ New worker** → Terminal toggle → **⋯ menu**. No diff toggles.
+- In a component, keep label → value → helper text close.
+- Between peer controls, use 4–8px.
+- Between related groups, use 12–16px.
+- Between distinct regions, use 20–32px.
+- Avoid gaps that only exist to make cards feel separate; let containment and dividers do the work.
 
-### Spawn-worker modal (mirrors the reference's Create Task)
+### Fixed dimensions
 
-You mostly let the orchestrator spawn workers from its conversation; the manual paths
-(the topbar `+ New worker`, a project row's hover `+`, or `ao spawn`) open a modal that
-mirrors the reference exactly. Launching from a project row pre-fills the Project field:
+- Compact icon control: 20–24px.
+- Standard compact control: 28–32px.
+- Board action: 30–36px.
+- Minimum pointer target for an ordinary row: 32px; use 36px when the interaction is high-frequency or imprecise.
+- Default sidebar: 240px; icon rail: 48px; mobile overlay: 288px.
+- Standard topbar row: 36px; Windows shell topbar: 56px.
 
-- Centered dialog, **12px radius**, `max-w` ~512px, `bg` canvas, `ring-1` at 10% fg,
-  fade + zoom-95 enter.
-- **Header:** eyebrow mono-uppercase title `New worker` + `×` close.
-- **Body** (`gap` 15–16px): a **borderless large name field** (18px, auto-focus, slug
-  rule "letters, numbers, hyphens") → **Project** selector → **Agent** selector
-  (claude-code / codex / opencode / …) → a **"Based on"** bordered card with a segmented
-  control `Branch · Issue · Pull Request` revealing a combobox → a **Prompt / Workspace**
-  tab where Prompt is the worker's initial task (textarea).
-- **Footer:** right-aligned single primary **`Spawn worker`** (blue) with a `⌘↵` keycap,
-  disabled until valid.
+### Radius and borders
 
-## Motion
+- Borders are exceptional structure, never default decoration. Start with spacing, alignment, type, and a restrained surface shift.
+- A hairline is 1px and may separate durable regions: shell panes, a modal from its backdrop, a shared list's adjacent rows, a board lane boundary, or an input's hit area when contrast needs it.
+- Do not give every card, row, input group, and nested region its own outline. Never add a border simply because a component is rectangular.
+- `--radius-xs` and `--radius-sm` suit tiny controls; `--radius-md` suits buttons and inputs; `--radius-lg` is the maximum routine component radius.
+- `--radius-panel` is reserved for route-level framed surfaces and larger dialogs.
+- `--radius-full` is only for avatars, dots, and intentional pills.
+- Shadows are elevation cues for transient layers only: dialogs, menus, and tooltips. They are subtle, short-range, and neutral. No permanent card shadows, glow, or decorative drop shadow.
+- Focus is not decoration: use the semantic focus ring/outline with sufficient contrast. Never remove it or replace it with a barely visible background shift.
+- Avoid cards inside cards. If hierarchy is weak, fix spacing, typography, or surface contrast before adding another border.
 
-- **Approach:** minimal-functional. The one expressive exception: a status dot/spinner
-  pulse on active/working sessions (opacity breathe) so "alive" is glanceable. Never
-  animate text or layout.
-- **Easing:** enter `ease-out`, exit `ease-in`, move `ease-in-out`.
-- **Duration:** micro 80ms · short 160ms · medium 240ms · status pulse 1.8s loop ·
-  modal enter ~150ms fade+zoom-95.
+## 9. Components and interaction contracts
 
-## Implementation notes
+### Buttons
 
-- The renderer (`frontend/src/renderer/styles.css`) currently uses **Inter** and a
-  grayscale-blue theme. Migrate to this system: drop the Inter `font-family`, adopt the
-  system stack, and replace the token values with the neutral ramp + blue accent above.
-- Keep tokens as CSS custom properties under `:root` (dark) and `:root[data-theme="light"]`.
-- A faithful HTML reference of all of the above (both views + topbar + spawn modal,
-  light/dark) is saved under
-  `~/.gstack/projects/aoagents-agent-orchestrator/designs/design-system-20260609/`.
+- One clear primary action per focused region. It uses accent fill or strong foreground contrast.
+- Secondary actions use a quiet surface; tertiary actions are text/icon controls. An outline is a contrast fallback, not the default secondary-button style.
+- Icon-only buttons require an accessible label and tooltip when their meaning is not universally obvious.
+- Destructive actions require destructive color and confirmation when the operation is difficult to reverse.
+- Disabled states explain why when the missing prerequisite is not obvious.
 
-## Decisions Log
+### Tooltips and iconography
 
-| Date       | Decision                                                               | Rationale                                                                                          |
-| ---------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| 2026-06-09 | Match the reference's visual language exactly                          | User direction; the reference is the demonstrated model for this app's UI.                         |
-| 2026-06-09 | System font, not a custom typeface (e.g. Geist)                        | The reference uses the system stack; fidelity + native feel + zero font payload over brand type.   |
-| 2026-06-09 | Refined **blue** accent, not the reference's jade green                | User's explicit pick; blue for primary/active/focus, terminal stays green.                         |
-| 2026-06-09 | Single global **Orchestrator** anchor, orchestrator-first default view | The one real difference from the reference; orchestrator is the human-facing coordinator.          |
-| 2026-06-09 | **Name-only** worker rows                                              | User direction; status/branch/diff live in panes + topbar, not the row.                            |
-| 2026-06-09 | Removed **Library** from the rail footer                               | User direction; footer is Search + Settings only.                                                  |
-| 2026-06-09 | Topbar right = PR/CI pill + view toggles + ⋯ menu (worker)             | Surfaces the actionable PR/CI state from the daemon; desktop-tool precedent.                       |
-| 2026-06-09 | Spawn modal mirrors the reference's Create Task                        | Consistency with the reference; mapped to `ao spawn` params.                                       |
+- Use Lucide icons through the existing shared icon/button primitives. Icons are functional marks, never decoration or a substitute for a missing information hierarchy.
+- Default UI icons are 14–16px; use 12px only for dense metadata and 18–20px only for a high-level source choice or empty-state action. Do not enlarge an icon merely to fill empty space.
+- Keep stroke weight, optical size, and alignment consistent with nearby controls. Do not mix filled, multicolor, emoji, or custom illustration styles into the working UI.
+- A tooltip names an icon-only action, disambiguates a truncated value, or reveals a compact metric. It must be a short phrase, not a paragraph, help article, or duplicate of visible text.
+- Tooltips appear after the existing deliberate hover delay, never block pointer interaction, and remain available to keyboard focus. They should use elevated surface contrast and at most a subtle transient elevation—no dramatic shadow, animation, or callout treatment.
+
+### Inputs, dropdowns, menus, and dialogs
+
+- Labels precede inputs. Placeholder text is an example, never the sole label.
+- Validation appears close to the field and uses both wording and semantic color.
+- A select/dropdown trigger is one compact control: selected value first, chevron second; it should not add a second visible label when the surrounding field label already establishes meaning.
+- Dropdown content is a single elevated surface with a quiet edge, consistent item height, clear selected/focus state, and dividers only between meaningful groups. Never make each option a separately bordered mini-card.
+- Settings and New Task selectors use the same shared menu/select primitive and option rhythm. Model, agent, mode, and settings choices must not invent bespoke pills or popovers.
+- Menus group related actions, separate destructive actions once, preserve focus order, and close after a completed single-choice action. Do not use a tooltip to explain a menu item that can be named clearly.
+- Dialogs interrupt for a real decision; do not use them for ordinary navigation or success confirmation.
+- Dialogs retain the route context beneath them and restore focus to the trigger on close.
+
+### Modal composition
+
+Every modal is one composed, elevated surface: a restrained overlay, one clear title, a close control, the decision/form body, and a concise action area when needed. Modal content has no ornamental header band, no nested card stack, no gradient, and no explanatory prose unless it changes the user's decision.
+
+- **New Task:** a single title line and the composer. The task input is the visual center; agent/model/mode controls are compact supporting choices. Do not repeat instructions the composer itself makes obvious. Submission feedback must stay in place and not rearrange the composer.
+- **Clone Repository:** compact back, title, and close controls establish its place in the Add Project sequence. Repository URL is code-like and uses mono; owner/provider identity may be an unobtrusive visual cue. Destination is one full-width chooser row with its action embedded at the trailing edge. Validate after intent to continue and place field errors directly below the field; do not turn errors into a large alarm card.
+- **Add Project:** present one decision at a time. The source picker is a shared container of adjacent choices with dividers—not three floating cards. Each row has a modest icon, a concise source name, and only the one line of detail needed to distinguish Clone, Local, and Workspace. Local/Cloud is a compact segmented choice; show the one decision-relevant hint below it only while the choice is ambiguous. Cloud sign-in and project creation remain part of this same flow rather than a competing dashboard.
+- **Settings:** use one modal split into a quiet navigation rail and a content pane. The rail is a list of compact icon-and-text rows with a restrained selected surface; it is not a collection of pills. The content pane gives the active section one sentence-case title, fields in logical groups, and no redundant introduction. For project settings, keep the persistent save action anchored in the rail/footer position so it is predictable and does not float beside every field.
+- **Errors and status:** show error text close to the failed action or field. Reserve a full-width alert region for a blocking, form-level failure; it is a state treatment, not a permanently outlined component.
+
+#### Settings language and agent-management rules
+
+- Settings names describe the user's job, not internal vocabulary. Use **Agents** for installing and configuring agent tools, and **Accounts** for signing in and managing Codex accounts. Do not use “Harness” or “Subscriptions” as navigation labels for these surfaces.
+- Remove introductory copy when the title, control, or nearby status already explains the task. Keep only text that changes a decision, explains a failure, or provides a required next step.
+- Use concise, sentence-case labels and ordinary search placeholders such as “Search agents”. Avoid trailing ellipses in simple search fields and avoid repeating the same context in a label, placeholder, and subtext.
+- Agent installation rows use one shared install control. The installed state is terminal: show a disabled **Installed** button, hide installation details, and do not show a separate check icon or retry/details affordance.
+- When a completed install method is trustworthy, the secondary line may say “Installed via Homebrew”, “Installed via npm”, or “Installed via Official”. Never display internal cache fingerprints, hashes, or other implementation identifiers as user-facing versions.
+- Installation details are an expandable disclosure below the row's primary controls. Animate the details region between collapsed and expanded states, keep the disclosure control below the details, and align the content with the agent icon/list edge.
+- Icon-only actions must have an accessible name and a tooltip when their meaning is not obvious. If a text action already fits naturally, prefer the text action over an icon-only control.
+
+### Kanban board and cards
+
+- The board is the project’s operational overview, not a KPI dashboard. The canonical delivery lanes are Working, Needs you, In review, and Ready to merge; archive is a separate history state.
+- Lanes are one continuous grid separated by shared vertical dividers, with a compact header: semantic dot, sentence-case name, and count. Do not turn every lane into a rounded panel.
+- A board card represents one session—the legitimate exception to “no individual borders.” It is an actionable object with a bounded, draggable/clickable area. Keep its edge quiet; attention is expressed by the single semantic status treatment, not extra colored strips, badges, or shadows.
+- Card information order: agent avatar + task title; branch only when it adds identity; PR/review evidence only when present; one derived status line; then compact time/usage metadata. Avoid duplicate status words, repeated provider names, and metric clutter.
+- Title gets the visual weight. Avatar is small and recognisable, branch is mono and muted, PRs are compact evidence links, and timestamps/numbers use tabular figures where they scan in columns.
+- One fixed action slot may appear on hover/focus without shifting the title. Destructive action remains visually quiet until intentional hover/focus but always keyboard reachable.
+- Needs-human attention may use the dedicated semantic color and restrained motion. Do not pulse multiple cards, animate lane counts, or make success/caution states compete for attention.
+
+### Shared-list rule
+
+When several peer objects are primarily chosen or scanned—projects, settings sections, source choices, dropdown options—use a shared surface with adjacent rows and subtle dividers where necessary. Use individual cards only when each object carries a distinct, actionable operational payload, as board sessions do.
+
+### Terminal and conversation
+
+- The terminal is a working surface, not a decorative dark panel. Preserve its own palette, contrast, scroll behavior, and selection semantics.
+- Never layer translucent UI or decorative gradients over live terminal content.
+- Chat and TUI are alternate interfaces for the same session. Their surrounding orientation and actions must remain coherent across mode changes.
+
+## 10. Motion, transitions, and feedback
+
+Motion is functional and modest.
+
+- Fast feedback: `--duration-fast` (120ms) for hover, color, icon, and small opacity changes.
+- Normal movement: `--duration-normal` (150ms) for small layout and panel state changes.
+- Sidebar and route shell may use the established ~280ms settle transition where layout must remain spatially legible.
+- Use ease-out for entry, ease-in for exit, and ease-in-out for positional movement.
+- The working spinner/pulse may animate to show liveness. Do not animate text, metrics, or layout merely to make the interface feel busy.
+- Respect reduced-motion preferences: remove nonessential transforms and reduce transitions to immediate state changes.
+
+## 11. Platform and responsive behavior
+
+- **macOS:** maintain traffic-light clearance and the fixed titlebar navigation cluster. The shell topbar may be hidden when session-local chrome owns orientation.
+- **Windows/Linux:** shell topbar spans above the sidebar; preserve native/window-titlebar accommodations.
+- **Narrow center panels:** compact secondary actions, then inspector content, before hiding the task itself.
+- **Sidebar:** may collapse to its icon rail or an overlay; every icon must remain labeled through tooltip and accessible name.
+- **Inspector:** collapses to zero without reflowing the active terminal/chat into an unusable transient width.
+- **Keyboard:** every action that is visible on hover must be reachable by focus; shortcuts must respect the current route and never trigger a surprising cross-surface navigation.
+
+## 12. Accessibility and resilience
+
+- Meet contrast requirements in both dark and light themes; test real token pairs rather than assumed hex values.
+- Visible focus rings use the semantic focus/ring token and are never removed for mouse-centric aesthetics.
+- Communicate loading, error, offline, empty, and permission states explicitly.
+- Preserve text alternatives for icons, provider avatars, status glyphs, and action-only buttons.
+- Do not infer that a session is dead from an absent or failed runtime probe; the UI must communicate uncertainty accurately.
+- Preserve spatial continuity while data streams: avoid flicker, sudden reorder, and broad skeleton replacement for a small local update.
+
+### Interaction lifecycle to design and test
+
+For every approved surface, design the full lifecycle rather than only the happy-path screenshot:
+
+| Moment | Required question |
+| --- | --- |
+| Arrive | Is the purpose and next action clear without tutorial copy? |
+| Leave untouched | Is there a calm, complete default state with no fake urgency? |
+| Begin | Does focus move predictably and does the control state make the pending decision obvious? |
+| Active / submitting | Is progress local, truthful, and free of layout shift or duplicate submit affordances? |
+| Finish | Does success move the user forward naturally; does failure explain the actionable next step in place? |
+| Interrupt | Do Escape, close, navigation, lost focus, daemon/network failure, disabled actions, and changed project/session state preserve user work and restore a predictable focus target? |
+
+Test meaningful variants: dark/light theme, expanded/collapsed sidebar, long project or task text, keyboard-only use, narrow central pane, loading/error/empty state, and a state change arriving while the surface is open.
+
+## 13. Explicit anti-patterns
+
+Reject these patterns in renderer work unless a specific exception is approved:
+
+- Generic SaaS hero/feature-grid language inside the application shell.
+- Decorative gradients, glows, glass, blobs, textures, or ornamental shadows.
+- ALL CAPS labels, uppercase tracking used as decoration, or mono used to make ordinary prose look technical.
+- A rainbow of status colors, decorative accent borders, or color-only meaning.
+- Oversized avatars or icons that compete with task names and state.
+- Large empty padding that lowers operational density without aiding comprehension.
+- Uniform rounded cards separated by gaps when a shared container with dividers better expresses a list.
+- A border around every row, field, option, card, and nested panel; stacks of outlined containers; or a drop shadow on permanent content.
+- Repeated labels, helper paragraphs, captions, or subtext that merely restate an obvious control or choice.
+- A new button, select, tooltip, menu, dialog, or icon treatment when the matching shared primitive already exists.
+- Repeated metric tiles when one table, timeline, or state glyph is clearer.
+- Tiny low-contrast explanatory copy that conceals an important system state.
+- Fake terminal screenshots, fake progress, or generic “AI” illustration.
+- Moving controls on hover, layout shifts on data refresh, or shortcut behavior that changes routes unexpectedly.
+
+## 14. Implementation rules
+
+- Start with existing renderer components, shadcn primitives, semantic tokens, and nearby patterns.
+- Do not create a parallel token system, raw inline color palette, or one-off global style for a single screen.
+- Keep visual behavior in the renderer; daemon facts and lifecycle logic remain in the backend.
+- For a new named token, prove that existing semantic roles cannot express the need. Add it to `frontend/src/styles/tokens.css`, then expose it through `styles.css` only when Tailwind/component usage requires it.
+- For visual changes, test dark and light themes, compact sidebar, narrow center panel, keyboard focus, disabled/loading/error states, and at least one screen with real long project/session names.
+
+## 15. Design QA checklist
+
+Before calling a visual change done, verify:
+
+1. Does the reader see the active task and next useful action before secondary metadata?
+2. Is every color semantic and every status truthful?
+3. Did we reuse existing tokens and primitives?
+4. Is every word sentence case, necessary, and at the right point in the decision—not a label or subtext duplicate?
+5. Did we remove default borders/shadows and then add back only the structural ones this surface genuinely needs?
+6. Are peer choices a shared list with dividers rather than spaced, individually bordered cards?
+7. Are dense lists grouped and scan-friendly without becoming cramped? Are project rows compact enough for an all-day sidebar?
+8. Does focus work without hover? Does reduced motion remain coherent? Are icon-only actions named by accessible label and, where needed, tooltip?
+9. Does the change hold on dark/light themes, all desktop platforms, compact sidebar, narrow center width, long text, and loading/error/empty states?
+10. Did we avoid introducing a generic dashboard/card-grid pattern where AO already has a stronger operational model?
+
+### Review outcome
+
+Approve only when the answer to every applicable check is yes. Otherwise classify the finding so the next step is concrete:
+
+- **Blocker:** creates misleading operational state, inaccessible action/focus, unsafe destructive affordance, or a new one-off primitive.
+- **Must fix:** violates an explicit visual rule: heavy/individual borders, gradient, permanent decorative shadow, ALL CAPS label, noisy helper copy, or duplicated component treatment.
+- **Follow-up migration:** a legacy surface outside this reference boundary that should be aligned later; record it without using it to lower the standard for this change.
+
+## Decisions log
+
+| Date | Decision | Rationale |
+| --- | --- | --- |
+| 2026-09-03 | Dark-first, token-led, compact operational UI | Matches AO's long-running desktop workflow and renderer source of truth. |
+| 2026-09-03 | Geist/Geist Mono remain the typographic system | They are bundled, legible at dense sizes, and already define renderer hierarchy. |
+| 2026-09-03 | Color is reserved for semantics and active focus | Parallel-agent supervision depends on fast, trustworthy scanning. |
+| 2026-09-03 | Shared list containers with dividers are preferred over spaced sibling cards | Better density and clearer grouping for projects and sessions. |
+| 2026-09-03 | Existing platform shell behavior is part of the design system | macOS traffic lights, Windows titlebar, and collapsible inspector are product behavior, not incidental CSS. |
+| 2026-09-03 | The approved reference set is intentionally narrow | AO is mid-migration; unfinished screens must not become accidental design authority. |
+| 2026-09-03 | Sentence case and concise decision-relevant copy are mandatory | The interface should carry operational clarity through hierarchy and state, not verbose explanation or technical-looking labels. |
+| 2026-09-03 | Borders and shadows are structural/elevational exceptions | The future UI favors one composed surface, shared lists, quiet dividers, and stable hierarchy over a field of outlined cards. |
+| 2026-09-04 | Settings language follows the user's task, not internal architecture | “Agents” describes installation/setup and “Accounts” describes sign-in/account management more clearly than “Harness” or “Subscriptions”. |
+| 2026-09-04 | Installed agent rows use a terminal, compact state | A disabled Installed button is clearer than a detached check icon; stale details must not make a completed installation look actionable. |
+| 2026-09-04 | Only trustworthy user-facing data belongs below an agent name | The model catalog's `binaryVersion` is an internal cache fingerprint, so it must not be presented as a CLI version. |

--- a/backend/internal/adapters/chatdriver/acp/client.go
+++ b/backend/internal/adapters/chatdriver/acp/client.go
@@ -722,7 +722,8 @@ func acpFilePatch(path string, oldText *string, newText string) string {
 		oldLines = strings.Split(strings.ReplaceAll(*oldText, "\r\n", "\n"), "\n")
 	}
 	newLines := strings.Split(strings.ReplaceAll(newText, "\r\n", "\n"), "\n")
-	lines := []string{"--- " + path, "+++ " + path}
+	lines := make([]string, 0, 2+len(oldLines)+len(newLines))
+	lines = append(lines, "--- "+path, "+++ "+path)
 	for _, line := range oldLines {
 		lines = append(lines, "-"+line)
 	}

--- a/backend/internal/adapters/chatdriver/acp/client.go
+++ b/backend/internal/adapters/chatdriver/acp/client.go
@@ -643,9 +643,37 @@ func (c *conversation) toolEvent(turnID string, tool *toolState, completed bool)
 	if tool.terminalOutput != "" {
 		output = tool.terminalOutput
 	}
+	activityKind := activityKindFromTool(tool.kind)
 	detailMap := map[string]any{
 		"protocol": "acp", "toolKind": tool.kind, "locations": tool.locations,
 		"input": tool.rawInput, "output": output, "content": tool.content,
+	}
+	if activityKind == domain.ActivityKindFileChange {
+		files := make([]map[string]any, 0)
+		for _, item := range tool.content {
+			if item.Diff == nil {
+				continue
+			}
+			status := "modified"
+			deletions := 0
+			if item.Diff.OldText == nil {
+				status = "added"
+			} else {
+				deletions = lineCount(*item.Diff.OldText)
+				if item.Diff.NewText == "" {
+					status = "deleted"
+				}
+			}
+			files = append(files, map[string]any{
+				"path": item.Diff.Path, "status": status,
+				"additions": lineCount(item.Diff.NewText), "deletions": deletions,
+				"patch":   acpFilePatch(item.Diff.Path, item.Diff.OldText, item.Diff.NewText),
+				"oldText": item.Diff.OldText, "newText": item.Diff.NewText,
+			})
+		}
+		if len(files) > 0 {
+			detailMap["files"] = files
+		}
 	}
 	if claude := nestedMap(tool.meta, "claudeCode"); claude != nil {
 		copyDetail(detailMap, claude, "toolName", "providerToolName")
@@ -666,7 +694,7 @@ func (c *conversation) toolEvent(turnID string, tool *toolState, completed bool)
 		copyDetail(detailMap, terminal, "exit_code", "exitCode")
 		copyDetail(detailMap, terminal, "signal", "signal")
 	}
-	if activityKindFromTool(tool.kind) == domain.ActivityKindCommand {
+	if activityKind == domain.ActivityKindCommand {
 		if rawCommand := rawCommandFromInput(tool.rawInput); rawCommand != "" {
 			// The neutral command-detail contract (`detail.command`) is what the
 			// chat timeline renders as the row's subject. rawInput is a
@@ -692,9 +720,29 @@ func (c *conversation) toolEvent(turnID string, tool *toolState, completed bool)
 	}
 	return ports.ChatEvent{
 		Kind: kind, ProviderTurnID: turnID, ProviderItemID: c.providerItemID(tool.id),
-		ActivityKind: activityKindFromTool(tool.kind), ActivityStatus: status,
+		ActivityKind: activityKind, ActivityStatus: status,
 		Summary: summary, Detail: detail,
 	}
+}
+
+// acpFilePatch turns ACP's before/after file text into the small unified patch
+// the chat client renders. ACP gives us complete file contents rather than a
+// git-style patch; keeping the conversion here means every client sees the same
+// durable diff and never falls back to the provider's prose success message.
+func acpFilePatch(path string, oldText *string, newText string) string {
+	oldLines := []string{}
+	if oldText != nil {
+		oldLines = strings.Split(strings.ReplaceAll(*oldText, "\r\n", "\n"), "\n")
+	}
+	newLines := strings.Split(strings.ReplaceAll(newText, "\r\n", "\n"), "\n")
+	lines := []string{"--- " + path, "+++ " + path}
+	for _, line := range oldLines {
+		lines = append(lines, "-"+line)
+	}
+	for _, line := range newLines {
+		lines = append(lines, "+"+line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // toolOutputText translates ACP's provider-defined rawOutput into AO's neutral

--- a/backend/internal/adapters/chatdriver/acp/client.go
+++ b/backend/internal/adapters/chatdriver/acp/client.go
@@ -539,7 +539,7 @@ func (c *conversation) SessionUpdate(_ context.Context, params acpsdk.SessionNot
 		c.tools[tool.id] = tool
 		c.mu.Unlock()
 		c.emit(c.toolEvent(turnID, tool, toolTerminal(tool.status)))
-		c.emitDiffs(turnID, tool.content)
+		c.emitDiffs(turnID, tool.id, tool.content)
 	case update.ToolCallUpdate != nil:
 		tool := c.mergeToolUpdate(update.ToolCallUpdate)
 		if delta := terminalOutput(update.ToolCallUpdate.Meta); delta != "" {
@@ -547,7 +547,7 @@ func (c *conversation) SessionUpdate(_ context.Context, params acpsdk.SessionNot
 				ProviderItemID: c.providerItemID(tool.id), Delta: delta})
 		}
 		c.emit(c.toolEvent(turnID, tool, toolTerminal(tool.status)))
-		c.emitDiffs(turnID, tool.content)
+		c.emitDiffs(turnID, tool.id, tool.content)
 	case update.Plan != nil:
 		c.emit(ports.ChatEvent{Kind: ports.ChatEventPlanUpdated, ProviderTurnID: turnID, Plan: normalizePlan(update.Plan.Entries)})
 	case update.SessionInfoUpdate != nil:
@@ -654,19 +654,10 @@ func (c *conversation) toolEvent(turnID string, tool *toolState, completed bool)
 			if item.Diff == nil {
 				continue
 			}
-			status := "modified"
-			deletions := 0
-			if item.Diff.OldText == nil {
-				status = "added"
-			} else {
-				deletions = lineCount(*item.Diff.OldText)
-				if item.Diff.NewText == "" {
-					status = "deleted"
-				}
-			}
+			stats := diffFileFromSnapshot(item.Diff.Path, item.Diff.OldText, item.Diff.NewText)
 			files = append(files, map[string]any{
-				"path": item.Diff.Path, "status": status,
-				"additions": lineCount(item.Diff.NewText), "deletions": deletions,
+				"path": item.Diff.Path, "status": stats.Status,
+				"additions": stats.Additions, "deletions": stats.Deletions,
 				"patch":   acpFilePatch(item.Diff.Path, item.Diff.OldText, item.Diff.NewText),
 				"oldText": item.Diff.OldText, "newText": item.Diff.NewText,
 			})
@@ -989,37 +980,35 @@ func toolTerminal(status acpsdk.ToolCallStatus) bool {
 	return status == acpsdk.ToolCallStatusCompleted || status == acpsdk.ToolCallStatusFailed
 }
 
-func (c *conversation) emitDiffs(turnID string, content []acpsdk.ToolCallContent) {
-	files := make([]ports.ChatDiffFile, 0)
+func (c *conversation) emitDiffs(turnID, toolID string, content []acpsdk.ToolCallContent) {
+	byPath := make(map[string]ports.ChatDiffFile)
+	var pathOrder []string
 	for _, item := range content {
 		if item.Diff == nil {
 			continue
 		}
-		status := "modified"
-		deletions := 0
-		if item.Diff.OldText == nil {
-			status = "added"
-		} else {
-			deletions = lineCount(*item.Diff.OldText)
-			if item.Diff.NewText == "" {
-				status = "deleted"
-			}
+		path := item.Diff.Path
+		if _, exists := byPath[path]; !exists {
+			pathOrder = append(pathOrder, path)
 		}
-		files = append(files, ports.ChatDiffFile{
-			Path: item.Diff.Path, Status: status,
-			Additions: lineCount(item.Diff.NewText), Deletions: deletions,
-		})
+		byPath[path] = diffFileFromSnapshot(path, item.Diff.OldText, item.Diff.NewText)
 	}
-	if len(files) > 0 {
-		c.emit(ports.ChatEvent{Kind: ports.ChatEventTurnDiff, ProviderTurnID: turnID, Diff: &ports.ChatTurnDiff{Files: files}})
+	if len(byPath) == 0 {
+		return
 	}
-}
-
-func lineCount(value string) int {
-	if value == "" {
-		return 0
+	files := make([]ports.ChatDiffFile, 0, len(pathOrder))
+	for _, path := range pathOrder {
+		files = append(files, byPath[path])
 	}
-	return strings.Count(value, "\n") + 1
+	c.mu.Lock()
+	if c.turnDiffTurnID != turnID || c.turnDiffs == nil {
+		c.turnDiffs = &turnDiffAccumulator{}
+		c.turnDiffTurnID = turnID
+	}
+	c.turnDiffs.replaceTool(toolID, files)
+	aggregated := c.turnDiffs.aggregate()
+	c.mu.Unlock()
+	c.emit(ports.ChatEvent{Kind: ports.ChatEventTurnDiff, ProviderTurnID: turnID, Diff: &ports.ChatTurnDiff{Files: aggregated}})
 }
 
 func normalizePlan(entries []acpsdk.PlanEntry) *domain.ConversationPlan {

--- a/backend/internal/adapters/chatdriver/acp/client.go
+++ b/backend/internal/adapters/chatdriver/acp/client.go
@@ -725,10 +725,6 @@ func (c *conversation) toolEvent(turnID string, tool *toolState, completed bool)
 	}
 }
 
-// acpFilePatch turns ACP's before/after file text into the small unified patch
-// the chat client renders. ACP gives us complete file contents rather than a
-// git-style patch; keeping the conversion here means every client sees the same
-// durable diff and never falls back to the provider's prose success message.
 func acpFilePatch(path string, oldText *string, newText string) string {
 	oldLines := []string{}
 	if oldText != nil {

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -99,6 +99,8 @@ type conversation struct {
 	thoughts          map[string]string
 	nestedMessages    map[string]nestedMessageState
 	tools             map[string]*toolState
+	turnDiffs         *turnDiffAccumulator
+	turnDiffTurnID    string
 	providerFailure   *ports.ChatEvent
 	configOptions     []ports.ChatConfigOption
 	skills            []ports.ChatSkill
@@ -434,6 +436,8 @@ func (c *conversation) StartDeferredTurn(providerTurnID string) error {
 	c.thoughts = make(map[string]string)
 	c.nestedMessages = make(map[string]nestedMessageState)
 	c.tools = make(map[string]*toolState)
+	c.turnDiffs = nil
+	c.turnDiffTurnID = ""
 	c.providerFailure = nil
 	c.mu.Unlock()
 

--- a/backend/internal/adapters/chatdriver/acp/diff_stats.go
+++ b/backend/internal/adapters/chatdriver/acp/diff_stats.go
@@ -1,0 +1,120 @@
+package acp
+
+import (
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func lineDelta(oldText, newText string) (additions, deletions int) {
+	if oldText == newText {
+		return 0, 0
+	}
+	oldLines := splitLines(oldText)
+	newLines := splitLines(newText)
+	if len(oldLines) == 0 {
+		return len(newLines), 0
+	}
+	if len(newLines) == 0 {
+		return 0, len(oldLines)
+	}
+	lcs := longestCommonSubsequenceLen(oldLines, newLines)
+	return len(newLines) - lcs, len(oldLines) - lcs
+}
+
+func splitLines(value string) []string {
+	if value == "" {
+		return nil
+	}
+	lines := strings.Split(value, "\n")
+	if strings.HasSuffix(value, "\n") {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func longestCommonSubsequenceLen(a, b []string) int {
+	if len(a) < len(b) {
+		a, b = b, a
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for i := 1; i <= len(a); i++ {
+		for j := 1; j <= len(b); j++ {
+			if a[i-1] == b[j-1] {
+				curr[j] = prev[j-1] + 1
+			} else if prev[j] >= curr[j-1] {
+				curr[j] = prev[j]
+			} else {
+				curr[j] = curr[j-1]
+			}
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func diffFileFromSnapshot(path string, oldText *string, newText string) ports.ChatDiffFile {
+	old := ""
+	status := "modified"
+	if oldText == nil {
+		status = "added"
+	} else {
+		old = *oldText
+		if newText == "" {
+			status = "deleted"
+		}
+	}
+	additions, deletions := lineDelta(old, newText)
+	return ports.ChatDiffFile{Path: path, Status: status, Additions: additions, Deletions: deletions}
+}
+
+type turnDiffAccumulator struct {
+	toolOrder []string
+	byTool    map[string][]ports.ChatDiffFile
+}
+
+func (a *turnDiffAccumulator) replaceTool(toolID string, files []ports.ChatDiffFile) {
+	if a.byTool == nil {
+		a.byTool = make(map[string][]ports.ChatDiffFile)
+	}
+	if _, exists := a.byTool[toolID]; !exists {
+		a.toolOrder = append(a.toolOrder, toolID)
+	}
+	a.byTool[toolID] = files
+}
+
+func (a *turnDiffAccumulator) aggregate() []ports.ChatDiffFile {
+	if len(a.byTool) == 0 {
+		return nil
+	}
+	type aggregate struct {
+		path                 string
+		status               string
+		additions, deletions int
+	}
+	byPath := make(map[string]*aggregate)
+	var pathOrder []string
+	for _, toolID := range a.toolOrder {
+		for _, file := range a.byTool[toolID] {
+			current := byPath[file.Path]
+			if current == nil {
+				current = &aggregate{path: file.Path}
+				byPath[file.Path] = current
+				pathOrder = append(pathOrder, file.Path)
+			}
+			current.additions += file.Additions
+			current.deletions += file.Deletions
+			current.status = file.Status
+		}
+	}
+	files := make([]ports.ChatDiffFile, 0, len(pathOrder))
+	for _, path := range pathOrder {
+		current := byPath[path]
+		files = append(files, ports.ChatDiffFile{
+			Path: path, Status: current.status,
+			Additions: current.additions, Deletions: current.deletions,
+		})
+	}
+	return files
+}

--- a/frontend/src/renderer/components/chat/ActivityRun.test.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.test.tsx
@@ -37,14 +37,14 @@ describe("ActivityRun nested agents", () => {
 		);
 
 		await user.click(screen.getByRole("button", { name: /Ran 2 tool calls/i }));
-		expect(screen.getByRole("button", { name: /Subagent 1 step/i })).toHaveAttribute(
+		expect(await screen.findByRole("button", { name: /Subagent 1 step/i })).toHaveAttribute(
 			"aria-expanded",
 			"false",
 		);
 		expect(screen.queryByText("Search source files")).not.toBeInTheDocument();
 
 		await user.click(screen.getByRole("button", { name: /Subagent 1 step/i }));
-		expect(screen.getByText("Search source files")).toBeInTheDocument();
+		expect(await screen.findByText("Search source files")).toBeInTheDocument();
 	});
 
 	it("keeps malformed provider cycles visible at the top level", async () => {
@@ -58,7 +58,7 @@ describe("ActivityRun nested agents", () => {
 			/>,
 		);
 		await user.click(screen.getByRole("button", { name: /Ran 2 tool calls/i }));
-		expect(screen.getByText("First")).toBeInTheDocument();
-		expect(screen.getByText("Second")).toBeInTheDocument();
+		expect(await screen.findByText("First")).toBeInTheDocument();
+		expect(await screen.findByText("Second")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -176,8 +176,12 @@ function ActivitySubgroup({
 	activities: ConversationActivity[];
 	hierarchy: ActivityNode[];
 }) {
-	const [open, setOpen] = useState(false);
+	const [override, setOverride] = useState<boolean | null>(null);
 	const reducedMotion = useReducedMotion();
+	const streamingOutput = activities.some((activity) =>
+		activity.status === "running" && Boolean(activity.detail?.output),
+	);
+	const open = override ?? streamingOutput;
 	const hasNestedAgent = activities.some((activity) =>
 		hierarchy.some((node) => node.activity.id === activity.id && node.children.length > 0),
 	);
@@ -201,7 +205,7 @@ function ActivitySubgroup({
 		<div className="activity-subgroup">
 			<button
 				type="button"
-				onClick={() => setOpen((current) => !current)}
+				onClick={() => setOverride(!open)}
 				aria-expanded={open}
 				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-subgroup-toggle")}
 			>

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -64,8 +64,8 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 
 	return (
 		<motion.div
-			initial={reducedMotion ? false : { opacity: 0, filter: "blur(2px)" }}
-			animate={{ opacity: 1, filter: "blur(0px)" }}
+			initial={reducedMotion ? false : { opacity: 0 }}
+			animate={{ opacity: 1 }}
 			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
 			className="flex flex-col"
 		>
@@ -161,11 +161,11 @@ function ActivityLabelTransition({ value, children }: { value: string; children:
 
 	return (
 		<motion.span
-			initial={reducedMotion ? false : { opacity: 0, filter: "blur(2px)" }}
+			initial={reducedMotion ? false : { opacity: 0 }}
 			animate={
 				reducedMotion || !settling
-					? { opacity: 1, filter: "blur(0px)" }
-					: { opacity: 0.72, filter: "blur(2px)" }
+					? { opacity: 1 }
+					: { opacity: 0.72 }
 			}
 			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
 			onAnimationComplete={() => setSettling(false)}

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { ActivityRow } from "./ChatTimelineItems";
@@ -20,23 +21,37 @@ import {
 	commandCategory,
 	isNonzeroCommandExit,
 } from "./activity-command";
-import type { ConversationActivity } from "../../types/conversation";
+import { fileChangeFiles, type ConversationActivity } from "../../types/conversation";
 
 export function ActivityRun({ activities }: { activities: ConversationActivity[] }) {
 	// null until someone decides, so a run holding a command that is printing right
 	// now can open itself and close again once everything settles. A click pins the
 	// choice either way.
 	const [override, setOverride] = useState<boolean | null>(null);
+	const reducedMotion = useReducedMotion();
 	const running = activities.some((a) => a.status === "running");
 	const nonzeroExits = activities.filter(isNonzeroCommandExit).length;
 	const failed = activities.filter(
 		(activity) => activity.status === "failed" && !isNonzeroCommandExit(activity),
 	).length;
 	const cancelled = activities.filter((a) => a.status === "cancelled").length;
+	const diffTotals = activities.reduce(
+		(totals, activity) => {
+			if (activity.activityKind !== "file_change") return totals;
+			for (const file of fileChangeFiles(activity)) {
+				totals.additions += file.additions;
+				totals.deletions += file.deletions;
+			}
+			return totals;
+		},
+		{ additions: 0, deletions: 0 },
+	);
 
 	// A single call is its own best summary — collapsing one row into a count of
 	// one would be worse than just showing it.
 	const hierarchy = buildHierarchy(activities);
+	const rootActivities = hierarchy.map((node) => node.activity);
+	const subgroups = groupSimilarActivities(rootActivities);
 	if (activities.length === 1 && hierarchy[0]?.children.length === 0) {
 		return <ActivityRow activity={activities[0]!} />;
 	}
@@ -52,9 +67,11 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 				type="button"
 				onClick={() => setOverride(!open)}
 				aria-expanded={open}
-				className={ACTIVITY_SUMMARY_BUTTON_CLASS}
+				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-run-toggle")}
 			>
-				<span className="text-[11.5px] text-muted-foreground">{summarize(activities)}</span>
+				<span className="activity-summary-label text-[11.5px] text-muted-foreground">
+					{summarize(activities)}
+				</span>
 				{nonzeroExits > 0 ? (
 					<span className="text-[11px] text-muted-foreground/70">
 						{nonzeroExits} exited
@@ -68,6 +85,17 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 				{cancelled > 0 ? (
 					<span className="text-[11px] text-muted-foreground/70">
 						{cancelled} stopped
+					</span>
+				) : null}
+				{diffTotals.additions > 0 || diffTotals.deletions > 0 ? (
+					<span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/70">
+						{diffTotals.additions > 0 ? (
+							<span className="text-success">+{diffTotals.additions}</span>
+						) : null}
+						{diffTotals.additions > 0 && diffTotals.deletions > 0 ? " " : null}
+						{diffTotals.deletions > 0 ? (
+							<span className="text-destructive">−{diffTotals.deletions}</span>
+						) : null}
 					</span>
 				) : null}
 				{running ? (
@@ -84,11 +112,121 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 				/>
 			</button>
 
-			{open ? (
-				<div className="mt-1 flex flex-col gap-1">
-					{hierarchy.map((node) => <ActivityTree key={node.activity.id} node={node} />)}
-				</div>
-			) : null}
+			<AnimatePresence initial={false}>
+				{open ? (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
+						className="overflow-hidden"
+					>
+						<div className="flex flex-col gap-1 pt-1">
+							{subgroups.length === 1
+								? subgroups[0]!.activities.map((activity) => {
+										const node = hierarchy.find((candidate) => candidate.activity.id === activity.id);
+										return node ? (
+											<ActivityTree key={activity.id} node={node} />
+										) : (
+											<ActivityRow key={activity.id} activity={activity} />
+										);
+								  })
+								: subgroups.map((group) => (
+										<ActivitySubgroup key={group.key} activities={group.activities} hierarchy={hierarchy} />
+								  ))}
+						</div>
+					</motion.div>
+				) : null}
+			</AnimatePresence>
+		</div>
+	);
+}
+
+type ActivitySubgroupData = { key: string; activities: ConversationActivity[] };
+
+/** Keep related mechanics together while the outer run preserves their timeline order. */
+function groupSimilarActivities(activities: ConversationActivity[]): ActivitySubgroupData[] {
+	const groups: ActivitySubgroupData[] = [];
+	for (const activity of activities) {
+		const key = activityGroupKey(activity);
+		const previous = groups.at(-1);
+		if (previous?.key === key) previous.activities.push(activity);
+		else groups.push({ key, activities: [activity] });
+	}
+	return groups;
+}
+
+function activityGroupKey(activity: ConversationActivity): string {
+	const parentSuffix = activity.detail?.parentProviderItemId ? ":nested" : "";
+	if (activity.activityKind === "command") {
+		return `command:${commandCategory(activity.detail?.command ?? activity.summary)}${parentSuffix}`;
+	}
+	return `${activity.activityKind}${parentSuffix}`;
+}
+
+function ActivitySubgroup({
+	activities,
+	hierarchy,
+}: {
+	activities: ConversationActivity[];
+	hierarchy: ActivityNode[];
+}) {
+	const [open, setOpen] = useState(false);
+	const reducedMotion = useReducedMotion();
+	const hasNestedAgent = activities.some((activity) =>
+		hierarchy.some((node) => node.activity.id === activity.id && node.children.length > 0),
+	);
+	const isStructural = activities.some((activity) => Boolean(activity.detail?.parentProviderItemId));
+	if (activities.length === 1 || hasNestedAgent || isStructural) {
+		return (
+			<>
+				{activities.map((activity) => {
+					const node = hierarchy.find((candidate) => candidate.activity.id === activity.id);
+					return node ? (
+						<ActivityTree key={activity.id} node={node} />
+					) : (
+						<ActivityRow key={activity.id} activity={activity} />
+					);
+				})}
+			</>
+		);
+	}
+
+	return (
+		<div className="activity-subgroup">
+			<button
+				type="button"
+				onClick={() => setOpen((current) => !current)}
+				aria-expanded={open}
+				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-subgroup-toggle")}
+			>
+				<span className="activity-summary-label text-[11px] text-muted-foreground">
+					{summarize(activities)}
+				</span>
+				<ChevronRight aria-hidden="true" className={cn("size-3 shrink-0 transition-transform", open && "rotate-90")} />
+			</button>
+			<AnimatePresence initial={false}>
+				{open ? (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: reducedMotion ? 0 : 0.16, ease: [0.22, 1, 0.36, 1] }}
+						className="overflow-hidden"
+					>
+						<div className="flex flex-col gap-1">
+							{activities.map((activity) => {
+								const node = hierarchy.find((candidate) => candidate.activity.id === activity.id);
+								return node ? (
+									<ActivityTree key={activity.id} node={node} />
+								) : (
+									<ActivityRow key={activity.id} activity={activity} />
+								);
+							})}
+						</div>
+					</motion.div>
+				) : null}
+			</AnimatePresence>
 		</div>
 	);
 }
@@ -106,27 +244,36 @@ function ActivityTree({ node }: { node: ActivityNode }) {
 
 function NestedAgentRun({ nodes }: { nodes: ActivityNode[] }) {
 	const [open, setOpen] = useState(false);
+	const reducedMotion = useReducedMotion();
 	const count = countNodes(nodes);
 	const running = nodes.some(nodeRunning);
 	return (
-		<div className="mx-3 mb-2 ml-8 overflow-hidden rounded-md border border-border/70 bg-background/40">
+		<div className="mb-2 overflow-hidden bg-background/40">
 			<button
 				type="button"
 				onClick={() => setOpen((current) => !current)}
 				aria-label={`Subagent ${count} ${count === 1 ? "step" : "steps"}`}
 				aria-expanded={open}
-				className="flex min-h-8 w-full items-center gap-2 px-2.5 text-left text-[11px] text-muted-foreground outline-none transition-colors hover:bg-interactive-hover focus-visible:outline-none"
+				className="activity-row-toggle flex min-h-8 w-full select-none items-center gap-2 text-left text-[11px] text-muted-foreground outline-none hover:text-foreground focus-visible:outline-none"
 			>
-				<ChevronRight aria-hidden="true" className={cn("size-3 transition-transform", open && "rotate-90")} />
 				<span className="font-medium text-foreground/80">Subagent</span>
 				<span>{count} {count === 1 ? "step" : "steps"}</span>
-				{running ? <Loader2 aria-hidden="true" className="ml-auto size-3 animate-spin" /> : null}
+				{running ? <Loader2 aria-hidden="true" className="size-3 animate-spin" /> : null}
+				<ChevronRight aria-hidden="true" className={cn("size-3 transition-transform", open && "rotate-90")} />
 			</button>
-			{open ? (
-				<div className="border-t border-border/70">
+			<AnimatePresence initial={false}>
+				{open ? (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: reducedMotion ? 0 : 0.16, ease: [0.22, 1, 0.36, 1] }}
+						className="border-t border-border/70"
+					>
 					{nodes.map((node) => <ActivityTree key={node.activity.id} node={node} />)}
-				</div>
-			) : null}
+					</motion.div>
+				) : null}
+			</AnimatePresence>
 		</div>
 	);
 }
@@ -172,65 +319,37 @@ function nodeRunning(node: ActivityNode): boolean {
 	return node.activity.status === "running" || node.children.some(nodeRunning);
 }
 
-/**
- * Describe a run by what it did, not by how many rows it has.
- *
- * "Ran 15 commands" tells the reader nothing they can act on. "Explored 6 files,
- * 4 searches" tells them the agent was looking rather than changing — which is
- * the distinction that decides whether they need to open it.
- */
+/** Describe a mixed batch compactly; the expanded children carry the detail. */
 function summarize(activities: ConversationActivity[]): string {
-	let reads = 0;
-	let searches = 0;
-	let vcs = 0;
-	let other = 0;
-	let plans = 0;
-	let tools = 0;
-	let reviews = 0;
+	let toolCalls = 0;
+	let changedFiles = 0;
+	let exploratory = true;
+	let hasPlan = false;
 
 	for (const activity of activities) {
 		if (activity.activityKind === "plan") {
-			plans += 1;
+			hasPlan = true;
 			continue;
 		}
-		// Counted apart from commands, and named apart, because that is the whole
-		// distinction the kind exists to draw: nothing ran in the worktree.
-		if (activity.activityKind === "mcp_tool") {
-			tools += 1;
-			continue;
-		}
-		if (activity.activityKind === "auto_review") {
-			reviews += 1;
-			continue;
-		}
-		switch (commandCategory(activity.detail?.command ?? activity.summary)) {
-			case "read":
-				reads += 1;
-				break;
-			case "search":
-				searches += 1;
-				break;
-			case "vcs":
-				vcs += 1;
-				break;
-			default:
-				other += 1;
+		toolCalls += 1;
+		if (activity.activityKind === "file_change") {
+			changedFiles += Math.max(1, fileChangeFiles(activity).length);
+			exploratory = false;
+		} else if (
+			activity.activityKind !== "command" ||
+			!(["read", "search"] as const).includes(commandCategory(activity.detail?.command ?? activity.summary))
+		) {
+			exploratory = false;
 		}
 	}
 
-	const parts: string[] = [];
-	if (reads > 0) parts.push(`${reads} ${reads === 1 ? "file" : "files"}`);
-	if (searches > 0) parts.push(`${searches} ${searches === 1 ? "search" : "searches"}`);
-	if (vcs > 0) parts.push(`${vcs} git ${vcs === 1 ? "check" : "checks"}`);
-	if (other > 0) parts.push(`${other} ${other === 1 ? "command" : "commands"}`);
-	if (tools > 0) parts.push(`${tools} tool ${tools === 1 ? "call" : "calls"}`);
-	// Said even though nobody was asked, because "the provider decided 3 things for
-	// you" is not something a summary should quietly leave out.
-	if (reviews > 0) parts.push(`${reviews} auto-${reviews === 1 ? "decision" : "decisions"}`);
-	if (plans > 0) parts.push("updated plan");
-
-	if (parts.length === 0) return `${activities.length} steps`;
-	// "Explored" when the agent was reading or searching; "Ran" when it was doing.
-	const verb = reads > 0 || searches > 0 ? "Explored" : "Ran";
-	return `${verb} ${parts.join(", ")}`;
+	if (toolCalls === 0) return hasPlan ? "Updated plan" : `${activities.length} steps`;
+	const label = `${exploratory ? "Explored" : "Ran"} ${toolCalls} ${toolCalls === 1 ? "tool call" : "tool calls"}`;
+	const details = [
+		changedFiles > 0
+			? `${changedFiles} ${changedFiles === 1 ? "file changed" : "files changed"}`
+			: undefined,
+		hasPlan ? "updated plan" : undefined,
+	].filter(Boolean);
+	return details.length ? `${label} · ${details.join(" · ")}` : label;
 }

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -11,7 +11,7 @@
  * changed something" without opening anything.
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "../../lib/utils";
@@ -52,6 +52,7 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 	const hierarchy = buildHierarchy(activities);
 	const rootActivities = hierarchy.map((node) => node.activity);
 	const subgroups = groupSimilarActivities(rootActivities);
+	const summary = summarize(activities);
 	if (activities.length === 1 && hierarchy[0]?.children.length === 0) {
 		return <ActivityRow activity={activities[0]!} />;
 	}
@@ -62,7 +63,12 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 	const open = override ?? streamingOutput;
 
 	return (
-		<div className="flex flex-col">
+		<motion.div
+			initial={reducedMotion ? false : { opacity: 0, filter: "blur(2px)" }}
+			animate={{ opacity: 1, filter: "blur(0px)" }}
+			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
+			className="flex flex-col"
+		>
 			<button
 				type="button"
 				onClick={() => setOverride(!open)}
@@ -70,7 +76,7 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-run-toggle")}
 			>
 				<span className="activity-summary-label text-[11.5px] text-muted-foreground">
-					{summarize(activities)}
+					<ActivityLabelTransition value={summary}>{summary}</ActivityLabelTransition>
 				</span>
 				{nonzeroExits > 0 ? (
 					<span className="text-[11px] text-muted-foreground/70">
@@ -138,7 +144,34 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 					</motion.div>
 				) : null}
 			</AnimatePresence>
-		</div>
+		</motion.div>
+	);
+}
+
+function ActivityLabelTransition({ value, children }: { value: string; children: ReactNode }) {
+	const reducedMotion = useReducedMotion();
+	const previousValue = useRef(value);
+	const [settling, setSettling] = useState(false);
+
+	useEffect(() => {
+		if (previousValue.current === value) return;
+		previousValue.current = value;
+		setSettling(true);
+	}, [value]);
+
+	return (
+		<motion.span
+			initial={reducedMotion ? false : { opacity: 0, filter: "blur(2px)" }}
+			animate={
+				reducedMotion || !settling
+					? { opacity: 1, filter: "blur(0px)" }
+					: { opacity: 0.72, filter: "blur(2px)" }
+			}
+			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
+			onAnimationComplete={() => setSettling(false)}
+		>
+			{children}
+		</motion.span>
 	);
 }
 
@@ -201,7 +234,9 @@ function ActivitySubgroup({
 				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-subgroup-toggle")}
 			>
 				<span className="activity-summary-label text-[11px] text-muted-foreground">
-					{summarizeSubgroup(activities)}
+					<ActivityLabelTransition value={summarizeSubgroup(activities)}>
+						{summarizeSubgroup(activities)}
+					</ActivityLabelTransition>
 				</span>
 				<ChevronRight aria-hidden="true" className={cn("size-3 shrink-0 transition-transform", open && "rotate-90")} />
 			</button>

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -360,12 +360,13 @@ function summarize(activities: ConversationActivity[]): string {
 			continue;
 		}
 		toolCalls += 1;
+		const category = commandCategory(activity.detail?.command ?? activity.summary);
 		if (activity.activityKind === "file_change") {
 			changedFiles += Math.max(1, fileChangeFiles(activity).length);
 			exploratory = false;
 		} else if (
 			activity.activityKind !== "command" ||
-			!(["read", "search"] as const).includes(commandCategory(activity.detail?.command ?? activity.summary))
+			(category !== "read" && category !== "search")
 		) {
 			exploratory = false;
 		}

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -201,7 +201,7 @@ function ActivitySubgroup({
 				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-subgroup-toggle")}
 			>
 				<span className="activity-summary-label text-[11px] text-muted-foreground">
-					{summarize(activities)}
+					{summarizeSubgroup(activities)}
 				</span>
 				<ChevronRight aria-hidden="true" className={cn("size-3 shrink-0 transition-transform", open && "rotate-90")} />
 			</button>
@@ -229,6 +229,29 @@ function ActivitySubgroup({
 			</AnimatePresence>
 		</div>
 	);
+}
+
+/** A subgroup names its shared category so it cannot be mistaken for another batch. */
+function summarizeSubgroup(activities: ConversationActivity[]): string {
+	const first = activities[0];
+	if (!first) return "Related calls";
+	if (first.activityKind === "file_change") {
+		const files = activities.reduce(
+			(count, activity) => count + Math.max(1, fileChangeFiles(activity).length),
+			0,
+		);
+		return `Changed ${files} ${files === 1 ? "file" : "files"}`;
+	}
+	if (first.activityKind === "mcp_tool") {
+		return `Used ${activities.length} ${activities.length === 1 ? "tool call" : "tool calls"}`;
+	}
+	if (first.activityKind === "auto_review") {
+		return `Checked ${activities.length} ${activities.length === 1 ? "decision" : "decisions"}`;
+	}
+	if (first.activityKind === "plan") return "Updated plan";
+	const category = commandCategory(first.detail?.command ?? first.summary);
+	const verb = category === "read" || category === "search" ? "Explored" : "Ran";
+	return `${verb} ${activities.length} ${activities.length === 1 ? "tool call" : "tool calls"}`;
 }
 
 type ActivityNode = { activity: ConversationActivity; children: ActivityNode[] };

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -50,6 +50,7 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 	// A single call is its own best summary — collapsing one row into a count of
 	// one would be worse than just showing it.
 	const hierarchy = buildHierarchy(activities);
+	const nodesByActivityID = new Map(hierarchy.map((node) => [node.activity.id, node]));
 	const rootActivities = hierarchy.map((node) => node.activity);
 	const subgroups = groupSimilarActivities(rootActivities);
 	const summary = summarize(activities);
@@ -130,7 +131,7 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 						<div className="flex flex-col gap-1 pt-1">
 							{subgroups.length === 1
 								? subgroups[0]!.activities.map((activity) => {
-										const node = hierarchy.find((candidate) => candidate.activity.id === activity.id);
+										const node = nodesByActivityID.get(activity.id);
 										return node ? (
 											<ActivityTree key={activity.id} node={node} />
 										) : (
@@ -138,7 +139,7 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 										);
 								  })
 								: subgroups.map((group) => (
-										<ActivitySubgroup key={group.key} activities={group.activities} hierarchy={hierarchy} />
+										<ActivitySubgroup key={group.key} activities={group.activities} nodesByActivityID={nodesByActivityID} />
 								  ))}
 						</div>
 					</motion.div>
@@ -171,10 +172,10 @@ function activityGroupKey(activity: ConversationActivity): string {
 
 function ActivitySubgroup({
 	activities,
-	hierarchy,
+	nodesByActivityID,
 }: {
 	activities: ConversationActivity[];
-	hierarchy: ActivityNode[];
+	nodesByActivityID: ReadonlyMap<string, ActivityNode>;
 }) {
 	const [override, setOverride] = useState<boolean | null>(null);
 	const reducedMotion = useReducedMotion();
@@ -183,14 +184,14 @@ function ActivitySubgroup({
 	);
 	const open = override ?? streamingOutput;
 	const hasNestedAgent = activities.some((activity) =>
-		hierarchy.some((node) => node.activity.id === activity.id && node.children.length > 0),
+		nodesByActivityID.get(activity.id)?.children.length,
 	);
 	const isStructural = activities.some((activity) => Boolean(activity.detail?.parentProviderItemId));
 	if (activities.length === 1 || hasNestedAgent || isStructural) {
 		return (
 			<>
 				{activities.map((activity) => {
-					const node = hierarchy.find((candidate) => candidate.activity.id === activity.id);
+					const node = nodesByActivityID.get(activity.id);
 					return node ? (
 						<ActivityTree key={activity.id} node={node} />
 					) : (
@@ -227,7 +228,7 @@ function ActivitySubgroup({
 					>
 						<div className="flex flex-col gap-1">
 							{activities.map((activity) => {
-								const node = hierarchy.find((candidate) => candidate.activity.id === activity.id);
+								const node = nodesByActivityID.get(activity.id);
 								return node ? (
 									<ActivityTree key={activity.id} node={node} />
 								) : (

--- a/frontend/src/renderer/components/chat/ActivityRun.tsx
+++ b/frontend/src/renderer/components/chat/ActivityRun.tsx
@@ -11,11 +11,11 @@
  * changed something" without opening anything.
  */
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ChevronRight, Loader2 } from "lucide-react";
 import { cn } from "../../lib/utils";
-import { ActivityRow } from "./ChatTimelineItems";
+import { ActivityRow, ActivityTransition } from "./ChatTimelineItems";
 import {
 	ACTIVITY_SUMMARY_BUTTON_CLASS,
 	commandCategory,
@@ -76,7 +76,7 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-run-toggle")}
 			>
 				<span className="activity-summary-label text-[11.5px] text-muted-foreground">
-					<ActivityLabelTransition value={summary}>{summary}</ActivityLabelTransition>
+					<ActivityTransition value={summary} inline>{summary}</ActivityTransition>
 				</span>
 				{nonzeroExits > 0 ? (
 					<span className="text-[11px] text-muted-foreground/70">
@@ -148,36 +148,8 @@ export function ActivityRun({ activities }: { activities: ConversationActivity[]
 	);
 }
 
-function ActivityLabelTransition({ value, children }: { value: string; children: ReactNode }) {
-	const reducedMotion = useReducedMotion();
-	const previousValue = useRef(value);
-	const [settling, setSettling] = useState(false);
-
-	useEffect(() => {
-		if (previousValue.current === value) return;
-		previousValue.current = value;
-		setSettling(true);
-	}, [value]);
-
-	return (
-		<motion.span
-			initial={reducedMotion ? false : { opacity: 0 }}
-			animate={
-				reducedMotion || !settling
-					? { opacity: 1 }
-					: { opacity: 0.72 }
-			}
-			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
-			onAnimationComplete={() => setSettling(false)}
-		>
-			{children}
-		</motion.span>
-	);
-}
-
 type ActivitySubgroupData = { key: string; activities: ConversationActivity[] };
 
-/** Keep related mechanics together while the outer run preserves their timeline order. */
 function groupSimilarActivities(activities: ConversationActivity[]): ActivitySubgroupData[] {
 	const groups: ActivitySubgroupData[] = [];
 	for (const activity of activities) {
@@ -234,9 +206,9 @@ function ActivitySubgroup({
 				className={cn(ACTIVITY_SUMMARY_BUTTON_CLASS, "activity-subgroup-toggle")}
 			>
 				<span className="activity-summary-label text-[11px] text-muted-foreground">
-					<ActivityLabelTransition value={summarizeSubgroup(activities)}>
+					<ActivityTransition value={summarizeSubgroup(activities)} inline>
 						{summarizeSubgroup(activities)}
-					</ActivityLabelTransition>
+					</ActivityTransition>
 				</span>
 				<ChevronRight aria-hidden="true" className={cn("size-3 shrink-0 transition-transform", open && "rotate-90")} />
 			</button>
@@ -266,7 +238,6 @@ function ActivitySubgroup({
 	);
 }
 
-/** A subgroup names its shared category so it cannot be mistaken for another batch. */
 function summarizeSubgroup(activities: ConversationActivity[]): string {
 	const first = activities[0];
 	if (!first) return "Related calls";
@@ -377,7 +348,6 @@ function nodeRunning(node: ActivityNode): boolean {
 	return node.activity.status === "running" || node.children.some(nodeRunning);
 }
 
-/** Describe a mixed batch compactly; the expanded children carry the detail. */
 function summarize(activities: ConversationActivity[]): string {
 	let toolCalls = 0;
 	let changedFiles = 0;

--- a/frontend/src/renderer/components/chat/ChatProviderSignal.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatProviderSignal.test.tsx
@@ -97,10 +97,9 @@ describe("MCP tool call", () => {
 
 	it("names the server and the tool, not a shell command", () => {
 		render(<ActivityRow activity={call} />);
-		expect(screen.getByText("github")).toBeInTheDocument();
 		expect(screen.getByText("search_issues")).toBeInTheDocument();
 		// The distinction the kind exists to draw: nothing ran in the worktree.
-		expect(screen.getByText("MCP tool")).toBeInTheDocument();
+		expect(screen.getByText("MCP · github")).toBeInTheDocument();
 	});
 
 	it("shows the arguments and the answer when opened", async () => {

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
 	AlertTriangle,
 	Brain,
@@ -805,17 +806,19 @@ function GenericActivityRow({ activity }: { activity: ConversationActivity }) {
 	// choice sticks: auto-collapsing a log someone is reading is worse than leaving
 	// a finished row open.
 	const [override, setOverride] = useState<boolean | null>(null);
+	const reducedMotion = useReducedMotion();
 	const Icon = activityIcon[activity.activityKind] ?? SquareTerminal;
 	const detail = activity.detail;
 	const files = fileChangeFiles(activity);
+	const isFileChange = activity.activityKind === "file_change";
 	// A single edit with no patch has nothing to expand into — the header already
 	// named the file. Multi-file edits expand to a list; a lone patch expands to
 	// the diff itself.
 	const hasFileBody =
-		files.length > 1 || (files.length === 1 && Boolean(files[0]?.patch));
+		files.length > 1 || (files.length === 1 && Boolean(fileChangePatch(files[0])));
 	const hasBody = Boolean(
 		detail?.command ||
-			detail?.output || detail?.reason || detail?.text || detail?.terminalInput || hasFileBody,
+		(!isFileChange && (detail?.output || detail?.reason || detail?.text || detail?.terminalInput)) || hasFileBody,
 	);
 	const { label, path } = splitSummary(activity);
 	// Commands and file edits share the explore-style summary line: muted label,
@@ -845,8 +848,9 @@ function GenericActivityRow({ activity }: { activity: ConversationActivity }) {
 				className={cn(
 					compactSummary
 						? ACTIVITY_SUMMARY_BUTTON_CLASS
-						: "flex min-h-[35px] w-full min-w-0 items-center gap-[9px] px-[11px] py-2 text-left text-[11px] transition-colors",
-					hasBody && !compactSummary && "hover:bg-interactive-hover",
+						: "flex min-h-[35px] w-full min-w-0 select-none items-center gap-[9px] px-[11px] py-2 text-left text-[11px]",
+					"activity-row-toggle",
+					hasBody && !compactSummary && "hover:text-foreground",
 					!hasBody && "cursor-default",
 				)}
 			>
@@ -866,12 +870,22 @@ function GenericActivityRow({ activity }: { activity: ConversationActivity }) {
 							{fileChangeVerb(singleEdit.status ?? "modified")}
 						</span>
 						<FileLocationLabel path={singleEdit.path} oldPath={singleEdit.oldPath} />
+						{singleEdit.additions > 0 ? (
+							<span className="shrink-0 font-mono text-[10px] tabular-nums text-success">
+								+{singleEdit.additions}
+						</span>
+						) : null}
+						{singleEdit.deletions > 0 ? (
+							<span className="shrink-0 font-mono text-[10px] tabular-nums text-destructive">
+								&minus;{singleEdit.deletions}
+							</span>
+						) : null}
 					</span>
 				) : (
 					<strong
 						className={cn(
 							compactSummary
-								? "shrink-0 text-[11.5px] font-normal text-muted-foreground"
+								? "activity-row-label shrink-0 text-[11.5px] font-normal text-muted-foreground group-hover/activity:text-foreground"
 								: "min-w-0 truncate font-medium",
 							!compactSummary &&
 								(activity.status === "failed" ? "text-destructive" : "text-foreground"),
@@ -883,7 +897,7 @@ function GenericActivityRow({ activity }: { activity: ConversationActivity }) {
 				)}
 				{path && !singleEdit ? (
 					<span
-						className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-muted-foreground"
+						className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-muted-foreground group-hover/activity:text-foreground"
 						title={path}
 					>
 						{path}
@@ -895,6 +909,7 @@ function GenericActivityRow({ activity }: { activity: ConversationActivity }) {
 					activity={activity}
 					open={open}
 					hasBody={hasBody}
+					inlineFileStats={Boolean(singleEdit)}
 					showDisclosure={!compactSummary}
 				/>
 				{compactSummary && hasBody ? (
@@ -908,42 +923,52 @@ function GenericActivityRow({ activity }: { activity: ConversationActivity }) {
 				) : null}
 			</button>
 
-			{open && hasBody ? (
-				compactSummary &&
-				activity.activityKind === "command" &&
-				(detail?.command || detail?.output || detail?.terminalInput) ? (
-					<CommandExploreBody activity={activity} />
-				) : (
-					<div className="flex flex-col gap-1.5 px-1 pb-1 pt-0.5">
+			<AnimatePresence initial={false}>
+				{open && hasBody ? (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: reducedMotion ? 0 : 0.18, ease: [0.22, 1, 0.36, 1] }}
+						className="overflow-hidden rounded-lg"
+					>
+						{compactSummary &&
+						activity.activityKind === "command" &&
+						(detail?.command || detail?.output || detail?.terminalInput) ? (
+							<CommandExploreBody activity={activity} />
+						) : (
+							<div className="flex flex-col gap-1.5 px-1 pb-1 pt-0.5">
 						{/* One file: open straight onto its patch. Listing the same
 						    basename again under "Edited name" is noise. */}
-						{files.length === 1 && files[0]?.patch ? (
-							<Patch patch={files[0].patch} truncated={files[0].patchTruncated} />
+						{files.length === 1 && fileChangePatch(files[0]) ? (
+							<Patch patch={fileChangePatch(files[0])!} truncated={files[0].patchTruncated} />
 						) : null}
 						{files.length > 1 ? <FileChangeList files={files} /> : null}
-						{detail?.command ? (
+						{!isFileChange && detail?.command ? (
 							// Said explicitly rather than implied by the label: "Ran command"
 							// alone never tells the reader what ran, and the collapsed row
 							// deliberately keeps only the category.
-							<pre className="scrollbar-none overflow-x-auto rounded-md border border-border bg-background px-2.5 py-1.5 font-mono text-[10.5px] leading-relaxed text-foreground">
+							<pre className="scrollbar-none overflow-x-auto border border-border bg-background px-2.5 py-1.5 font-mono text-[10.5px] leading-relaxed text-foreground">
 								{detail.command}
 							</pre>
 						) : null}
-						{detail?.reason || detail?.text ? (
+						{!isFileChange && (detail?.reason || detail?.text) ? (
 							<p className="whitespace-pre-wrap px-1 text-[11px] leading-relaxed text-muted-foreground">
 								{detail.reason ?? detail.text}
 							</p>
 						) : null}
-						{detail?.terminalInput ? (
+						{!isFileChange && detail?.terminalInput ? (
 							<TerminalInput
 								text={detail.terminalInput}
 								truncated={detail.terminalInputTruncated}
 							/>
 						) : null}
-						{detail?.output ? <CommandOutput activity={activity} /> : null}
-					</div>
-				)
-			) : null}
+						{!isFileChange && detail?.output ? <CommandOutput activity={activity} /> : null}
+							</div>
+						)}
+					</motion.div>
+				) : null}
+			</AnimatePresence>
 		</div>
 	);
 }
@@ -961,7 +986,7 @@ function CommandExploreBody({ activity }: { activity: ConversationActivity }) {
 	const showPrompt = Boolean(reason && reason !== command);
 
 	return (
-		<div className="cursor-chat-explore-box mt-1 flex min-w-0 flex-col overflow-hidden rounded-[10px] border">
+		<div className="cursor-chat-explore-box mt-1 flex min-w-0 flex-col overflow-hidden rounded-lg border">
 			{showPrompt ? (
 				<div className="flex min-w-0 items-start gap-2 border-b border-border/60 px-3 py-2">
 					<span
@@ -1028,7 +1053,7 @@ function TerminalInput({ text, truncated }: { text: string; truncated?: boolean 
 				<Keyboard aria-hidden="true" className="size-3" />
 				Agent typed
 			</span>
-			<pre className="scrollbar-none overflow-x-auto rounded-md border border-dashed border-border-strong bg-background px-2.5 py-1.5 font-mono text-[10.5px] leading-relaxed text-accent">
+			<pre className="scrollbar-none overflow-x-auto border border-dashed border-border-strong bg-background px-2.5 py-1.5 font-mono text-[10.5px] leading-relaxed text-accent">
 				{shown}
 			</pre>
 			{truncated ? (
@@ -1093,7 +1118,7 @@ function CommandOutput({
 					"scrollbar-none max-h-64 overflow-auto font-mono leading-relaxed text-muted-foreground",
 					embedded
 						? "cursor-chat-explore-output px-3 py-2 text-[11px]"
-						: "rounded-md border border-border bg-background px-2.5 py-2 text-[10.5px]",
+						: "border border-border bg-background px-2.5 py-2 text-[10.5px]",
 				)}
 			>
 				{output}
@@ -1136,7 +1161,8 @@ function splitSummary(activity: ConversationActivity): { label: string; path?: s
 		const category = commandCategory(rawCommand);
 		if (category === "read" || category === "search") {
 			const count = exploredFileCount(rawCommand);
-			return { label: count ? `Explored ${count} ${count === 1 ? "file" : "files"}` : "Explored files" };
+			if (category === "search") return { label: "Search" };
+			return { label: count && count > 1 ? "Read files" : "Read file" };
 		}
 		return { label: category === "vcs" ? "Checked repository" : "Ran command" };
 	}
@@ -1154,11 +1180,13 @@ function ActivityState({
 	activity,
 	open,
 	hasBody,
+	inlineFileStats = false,
 	showDisclosure = true,
 }: {
 	activity: ConversationActivity;
 	open: boolean;
 	hasBody: boolean;
+	inlineFileStats?: boolean;
 	showDisclosure?: boolean;
 }) {
 	const { status, detail } = activity;
@@ -1172,7 +1200,7 @@ function ActivityState({
 			/>
 		);
 	}
-	if (files.length) {
+	if (files.length && !inlineFileStats) {
 		const additions = files.reduce((sum, file) => sum + file.additions, 0);
 		const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
 		return (
@@ -1309,16 +1337,26 @@ function FileChangeRow({ file }: { file: FileChangeFile }) {
  * grammar renders as plain text. That is the right outcome: there is no diff to
  * colour, only a new file to read.
  */
+function fileChangePatch(file: FileChangeFile | undefined): string | undefined {
+	if (!file) return undefined;
+	if (file.patch) return file.patch;
+	if (file.oldText === undefined && file.newText === undefined) return undefined;
+	const oldLines = file.oldText?.split("\n") ?? [];
+	const newLines = file.newText?.split("\n") ?? [];
+	const header = `--- ${file.path}\n+++ ${file.path}`;
+	return [
+		header,
+		...oldLines.map((line) => `-${line}`),
+		...newLines.map((line) => `+${line}`),
+	].join("\n");
+}
+
 function Patch({ patch, truncated }: { patch: string; truncated?: boolean }) {
 	return (
 		// `chat-code` is what the token colours are scoped to, so a patch without it
 		// tokenizes correctly and renders in one flat colour.
-		<div className="chat-code mb-1 mt-0.5 overflow-hidden rounded-md border border-border bg-background">
-			<pre className="scrollbar-none max-h-72 overflow-auto px-2.5 py-2">
-				<code className="font-mono text-[10.5px] leading-[1.55] text-foreground">
-					<HighlightedCode code={patch} language="diff" />
-				</code>
-			</pre>
+			<div className="mb-1 mt-0.5 overflow-hidden bg-background">
+			<ToolDiffCode text={patch} />
 			{truncated ? (
 				<p className="border-t border-border px-2.5 py-1.5 text-[10px] leading-relaxed text-warning">
 					This patch is longer than AO stores, so it stops early. The whole change is in the
@@ -1393,59 +1431,46 @@ function ReasoningBlock({ activity }: { activity: ConversationActivity }) {
  */
 function McpToolRow({ activity }: { activity: ConversationActivity }) {
 	const [open, setOpen] = useState(false);
+	const reducedMotion = useReducedMotion();
 	const detail = activity.detail;
 	const tool = detail?.toolName ?? activity.summary;
 	const server = detail?.server ?? detail?.namespace;
+	const sourceLabel = server ? `MCP · ${server}` : detail?.progress ? lastLine(detail.progress) : undefined;
 	const failed = activity.status === "failed" || detail?.success === false || Boolean(detail?.error);
 	const hasBody = Boolean(
-		detail?.arguments !== undefined ||
+			detail?.arguments !== undefined ||
 			detail?.result !== undefined ||
+			detail?.content !== undefined ||
 			detail?.error ||
 			detail?.progress,
 	);
 
 	return (
-		<div className="group/activity border-t border-border first:border-t-0">
+		<div className="min-w-0 max-w-full">
 			<button
 				type="button"
 				onClick={() => setOpen((prev) => !prev)}
 				disabled={!hasBody}
 				aria-expanded={hasBody ? open : undefined}
 				className={cn(
-					"flex min-h-[35px] w-full items-center gap-[9px] px-[11px] py-2 text-left text-[11px] transition-colors",
-					hasBody && "hover:bg-interactive-hover",
+					ACTIVITY_SUMMARY_BUTTON_CLASS,
+					"activity-row-toggle",
 					!hasBody && "cursor-default",
 				)}
 			>
-				<Plug
-					aria-hidden="true"
-					className={cn(
-						"w-[15px] shrink-0 text-center",
-						failed ? "text-destructive" : "text-accent-dim",
-					)}
-					size={13}
-				/>
-				{/* The server is named first and in its own colour: which server answered is
-				    the part a shell command row could never have said. */}
-				{server ? (
-					<span className="shrink-0 font-mono text-[10.5px] text-muted-foreground">
-						{server}
-						<span aria-hidden="true" className="px-0.5 text-muted-foreground/40">
-							/
-						</span>
-					</span>
-				) : null}
 				<strong
 					className={cn(
-						"shrink-0 text-[10.5px] font-medium",
-						failed ? "text-destructive" : "text-foreground",
+						"activity-row-label shrink-0 text-[11.5px] font-normal",
+						failed ? "text-destructive" : "text-muted-foreground",
 					)}
 				>
-					{tool}
+					<span>{tool}</span>
 				</strong>
-				<span className="min-w-0 flex-1 truncate text-[10.5px] text-muted-foreground/70">
-					{detail?.progress ? lastLine(detail.progress) : "MCP tool"}
-				</span>
+				{sourceLabel ? (
+					<span className="min-w-0 flex-1 truncate text-[10.5px] text-muted-foreground group-hover/activity:text-foreground">
+						{sourceLabel}
+					</span>
+				) : null}
 				{activity.status === "running" ? (
 					<Loader2
 						aria-label="running"
@@ -1460,18 +1485,23 @@ function McpToolRow({ activity }: { activity: ConversationActivity }) {
 				) : hasBody ? (
 					<ChevronRight
 						aria-hidden="true"
-						className={cn(
-							"size-3 shrink-0 text-muted-foreground/50 transition-all",
-							open ? "rotate-90 opacity-100" : "opacity-0 group-hover/activity:opacity-100",
-						)}
+						className={cn("size-3 shrink-0 text-muted-foreground/40 transition-transform", open && "rotate-90")}
 					/>
 				) : null}
 			</button>
 
-			{open && hasBody ? (
-				<div className="flex flex-col gap-2 px-[11px] pb-2.5">
+			<AnimatePresence initial={false}>
+				{open && hasBody ? (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={{ duration: reducedMotion ? 0 : 0.18, ease: [0.22, 1, 0.36, 1] }}
+						className="overflow-hidden rounded-lg"
+					>
+						<div className="flex flex-col gap-2 pb-2.5">
 					{detail?.error ? (
-						<p className="rounded border border-destructive/30 bg-background px-2.5 py-1.5 text-[10.5px] leading-relaxed text-destructive">
+						<p className="border border-destructive/30 bg-background px-2.5 py-1.5 text-[10.5px] leading-relaxed text-destructive">
 							{detail.error}
 						</p>
 					) : null}
@@ -1481,20 +1511,113 @@ function McpToolRow({ activity }: { activity: ConversationActivity }) {
 					{detail?.result !== undefined ? (
 						<JsonPayload label="Result" value={detail.result} />
 					) : null}
+					{detail?.content !== undefined ? <ToolContent value={detail.content} /> : null}
 					{detail?.progress ? (
 						<div className="flex flex-col gap-1">
 							<span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/70">
 								Progress
 							</span>
-							<pre className="scrollbar-none max-h-40 overflow-auto rounded-md border border-border bg-background px-2.5 py-1.5 font-mono text-[10.5px] leading-relaxed text-muted-foreground">
+							<pre className="scrollbar-none max-h-40 overflow-auto border border-border bg-background px-2.5 py-1.5 font-mono text-[10.5px] leading-relaxed text-muted-foreground">
 								{detail.progress}
 							</pre>
 						</div>
 					) : null}
-				</div>
-			) : null}
+						</div>
+					</motion.div>
+				) : null}
+			</AnimatePresence>
 		</div>
 	);
+}
+
+function ToolContent({ value }: { value: unknown }) {
+	const text = normalizeToolCode(toolContentText(value));
+	if (text) {
+		if (looksLikeUnifiedDiff(text)) return <ToolDiffCode text={text} />;
+		return (
+			<pre className="chat-code max-h-64 overflow-auto whitespace-pre rounded-lg border border-border bg-background px-2.5 py-1.5">
+				<code className="block whitespace-pre font-mono text-[10.5px] leading-relaxed text-muted-foreground">
+					{ text }
+				</code>
+			</pre>
+		);
+	}
+	const truncated = truncationNote(value);
+	return (
+		<pre className="chat-code max-h-56 overflow-auto rounded-lg border border-border bg-background px-2.5 py-1.5">
+			<code className="font-mono text-[10.5px] leading-[1.55] text-foreground">
+				{truncated ?? formatJson(value)}
+			</code>
+		</pre>
+	);
+}
+
+function normalizeToolCode(text: string): string {
+	const fenced = text.match(/^\s*```[^\n]*\n([\s\S]*?)\n```\s*$/);
+	return (fenced?.[1] ?? text).replace(/\r\n?/g, "\n");
+}
+
+function looksLikeUnifiedDiff(text: string): boolean {
+	const lines = text.split("\n");
+	return (
+		lines.some((line) => line.startsWith("@@")) ||
+		(lines.some((line) => line.startsWith("---")) && lines.some((line) => line.startsWith("+++"))) ||
+		(lines.some((line) => line.startsWith("-")) && lines.some((line) => line.startsWith("+")))
+	);
+}
+
+/**
+ * Read tools sometimes return a unified patch as their content rather than as a
+ * file-change activity. Keep those lines visually identical to the Files diff:
+ * one row per line, a fixed marker gutter, and a subtle tint for additions and
+ * deletions. In particular, do not let a syntax highlighter turn the whole patch
+ * into one wrapped paragraph.
+ */
+function ToolDiffCode({ text }: { text: string }) {
+	return (
+		<div className="chat-code max-h-64 overflow-auto rounded-lg border border-border bg-background px-0 py-1 font-mono text-[10.5px] leading-[1.55]">
+			{ text.split("\n").map((line, index) => {
+				const kind = line.startsWith("+") ? "add" : line.startsWith("-") ? "del" : "context";
+				const marker = kind === "add" ? "+" : kind === "del" ? "-" : " ";
+				const content = kind === "context" ? line : line.slice(1);
+				return (
+					<div
+						key={`${index}-${line}`}
+						data-tool-diff-row=""
+						className={cn(
+							"flex min-w-max whitespace-pre px-2.5",
+							kind === "add" && "bg-success/10",
+							kind === "del" && "bg-error/10",
+						)}
+					>
+						<span
+							aria-hidden="true"
+							className={cn(
+								"w-4 shrink-0 select-none text-center",
+								kind === "add" && "text-success",
+								kind === "del" && "text-error",
+							)}
+						>
+							{marker}
+						</span>
+						<span className="whitespace-pre text-foreground/90">{content}</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function toolContentText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value)) return value.map(toolContentText).filter(Boolean).join("\n");
+	if (!value || typeof value !== "object") return "";
+	const record = value as Record<string, unknown>;
+	for (const key of ["text", "content", "output", "data"]) {
+		const text = toolContentText(record[key]);
+		if (text) return text;
+	}
+	return "";
 }
 
 /**
@@ -1514,11 +1637,11 @@ function JsonPayload({ label, value }: { label: string; value: unknown }) {
 				{label}
 			</span>
 			{capped ? (
-				<p className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[10.5px] leading-relaxed text-muted-foreground">
+				<p className="border border-border bg-background px-2.5 py-1.5 text-[10.5px] leading-relaxed text-muted-foreground">
 					{capped}
 				</p>
 			) : (
-				<pre className="chat-code max-h-56 overflow-auto rounded-md border border-border bg-background px-2.5 py-1.5">
+				<pre className="chat-code max-h-56 overflow-auto rounded-lg border border-border bg-background px-2.5 py-1.5">
 					<code className="font-mono text-[10.5px] leading-[1.55] text-foreground">
 						<HighlightedCode code={text} language="json" />
 					</code>
@@ -1596,8 +1719,8 @@ function AutoReviewRow({ activity }: { activity: ConversationActivity }) {
 				disabled={!hasBody}
 				aria-expanded={hasBody ? open : undefined}
 				className={cn(
-					"flex min-h-[35px] w-full items-center gap-[9px] px-[11px] py-2 text-left text-[11px] transition-colors",
-					hasBody && "hover:bg-interactive-hover",
+					"activity-row-toggle flex min-h-[35px] w-full select-none items-center gap-[9px] px-[11px] py-2 text-left text-[11px]",
+					hasBody && "hover:text-foreground",
 					!hasBody && "cursor-default",
 				)}
 			>

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -802,13 +802,13 @@ export function ActivityRow({ activity }: { activity: ConversationActivity }) {
 
 	if (!toolActivity) return content;
 	return (
-		<SoftActivityTransition value={`${activity.revision}:${activity.summary}:${activity.status}`}>
+		<ActivityTransition value={`${activity.revision}:${activity.summary}:${activity.status}`}>
 			{content}
-		</SoftActivityTransition>
+		</ActivityTransition>
 	);
 }
 
-function SoftActivityTransition({
+export function ActivityTransition({
 	value,
 	children,
 	inline = false,
@@ -1616,13 +1616,6 @@ function looksLikeUnifiedDiff(text: string): boolean {
 	);
 }
 
-/**
- * Read tools sometimes return a unified patch as their content rather than as a
- * file-change activity. Keep those lines visually identical to the Files diff:
- * one row per line, a fixed marker gutter, and a subtle tint for additions and
- * deletions. In particular, do not let a syntax highlighter turn the whole patch
- * into one wrapped paragraph.
- */
 function ToolDiffCode({ text }: { text: string }) {
 	return (
 		<div className="chat-code max-h-64 overflow-auto rounded-lg border border-border bg-background px-0 py-1 font-mono text-[10.5px] leading-[1.55]">

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -785,20 +785,11 @@ function DeliveryNote({ state }: { state: DeliveryState }) {
  * would hide work the agent really did.
  */
 export function ActivityRow({ activity }: { activity: ConversationActivity }) {
-	const reducedMotion = useReducedMotion();
-	const previousRevision = useRef(activity.revision);
-	const [settling, setSettling] = useState(true);
 	const toolActivity =
 		activity.activityKind === "command" ||
 		activity.activityKind === "file_change" ||
 		activity.activityKind === "mcp_tool" ||
 		activity.activityKind === "auto_review";
-
-	useEffect(() => {
-		if (previousRevision.current === activity.revision) return;
-		previousRevision.current = activity.revision;
-		setSettling(true);
-	}, [activity.revision]);
 
 	let content: ReactNode;
 	if (activity.activityKind === "mcp_tool") content = <McpToolRow activity={activity} />;
@@ -811,7 +802,34 @@ export function ActivityRow({ activity }: { activity: ConversationActivity }) {
 
 	if (!toolActivity) return content;
 	return (
-		<motion.div
+		<SoftActivityTransition value={`${activity.revision}:${activity.summary}:${activity.status}`}>
+			{content}
+		</SoftActivityTransition>
+	);
+}
+
+function SoftActivityTransition({
+	value,
+	children,
+	inline = false,
+}: {
+	value: string;
+	children: ReactNode;
+	inline?: boolean;
+}) {
+	const reducedMotion = useReducedMotion();
+	const previousValue = useRef(value);
+	const [settling, setSettling] = useState(false);
+
+	useEffect(() => {
+		if (previousValue.current === value) return;
+		previousValue.current = value;
+		setSettling(true);
+	}, [value]);
+
+	const MotionElement = inline ? motion.span : motion.div;
+	return (
+		<MotionElement
 			initial={reducedMotion ? false : { opacity: 0, filter: "blur(2px)" }}
 			animate={
 				reducedMotion || !settling
@@ -821,8 +839,8 @@ export function ActivityRow({ activity }: { activity: ConversationActivity }) {
 			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
 			onAnimationComplete={() => setSettling(false)}
 		>
-			{content}
-		</motion.div>
+			{children}
+		</MotionElement>
 	);
 }
 

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -830,11 +830,11 @@ function SoftActivityTransition({
 	const MotionElement = inline ? motion.span : motion.div;
 	return (
 		<MotionElement
-			initial={reducedMotion ? false : { opacity: 0, filter: "blur(2px)" }}
+			initial={reducedMotion ? false : { opacity: 0 }}
 			animate={
 				reducedMotion || !settling
-					? { opacity: 1, filter: "blur(0px)" }
-					: { opacity: 0.72, filter: "blur(2px)" }
+					? { opacity: 1 }
+					: { opacity: 0.72 }
 			}
 			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
 			onAnimationComplete={() => setSettling(false)}

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -785,13 +785,45 @@ function DeliveryNote({ state }: { state: DeliveryState }) {
  * would hide work the agent really did.
  */
 export function ActivityRow({ activity }: { activity: ConversationActivity }) {
-	if (activity.activityKind === "mcp_tool") return <McpToolRow activity={activity} />;
-	if (activity.activityKind === "auto_review") return <AutoReviewRow activity={activity} />;
-	if (activity.activityKind === "reasoning") return <ReasoningBlock activity={activity} />;
-	if (activity.activityKind === "error") return <ErrorActivityRow activity={activity} />;
-	if (activity.detail?.event === "model.rerouted") return <RerouteRow activity={activity} />;
-	if (activity.detail?.event === "auth.reauth_required") return <ReauthRow activity={activity} />;
-	return <GenericActivityRow activity={activity} />;
+	const reducedMotion = useReducedMotion();
+	const previousRevision = useRef(activity.revision);
+	const [settling, setSettling] = useState(true);
+	const toolActivity =
+		activity.activityKind === "command" ||
+		activity.activityKind === "file_change" ||
+		activity.activityKind === "mcp_tool" ||
+		activity.activityKind === "auto_review";
+
+	useEffect(() => {
+		if (previousRevision.current === activity.revision) return;
+		previousRevision.current = activity.revision;
+		setSettling(true);
+	}, [activity.revision]);
+
+	let content: ReactNode;
+	if (activity.activityKind === "mcp_tool") content = <McpToolRow activity={activity} />;
+	else if (activity.activityKind === "auto_review") content = <AutoReviewRow activity={activity} />;
+	else if (activity.activityKind === "reasoning") content = <ReasoningBlock activity={activity} />;
+	else if (activity.activityKind === "error") content = <ErrorActivityRow activity={activity} />;
+	else if (activity.detail?.event === "model.rerouted") content = <RerouteRow activity={activity} />;
+	else if (activity.detail?.event === "auth.reauth_required") content = <ReauthRow activity={activity} />;
+	else content = <GenericActivityRow activity={activity} />;
+
+	if (!toolActivity) return content;
+	return (
+		<motion.div
+			initial={reducedMotion ? false : { opacity: 0, filter: "blur(2px)" }}
+			animate={
+				reducedMotion || !settling
+					? { opacity: 1, filter: "blur(0px)" }
+					: { opacity: 0.72, filter: "blur(2px)" }
+			}
+			transition={{ duration: reducedMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
+			onAnimationComplete={() => setSettling(false)}
+		>
+			{content}
+		</motion.div>
+	);
 }
 
 /**

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1262,9 +1262,6 @@ function runsOf(items: ConversationItem[]): TimelineRun[] {
 			item.activityKind !== "approval" &&
 			item.activityKind !== "user_input" &&
 			item.activityKind !== "error" &&
-			// An edit is a result, not a mechanic. Burying it in a summary would hide
-			// the one kind of activity that changed the user's worktree.
-			item.activityKind !== "file_change" &&
 			// Reasoning only reaches the timeline when the reader asked for it, so
 			// folding it into "Explored 4 files" would answer that request with the
 			// summary they were trying to get past.
@@ -2018,6 +2015,17 @@ function Timeline({
 		updateScrollbar();
 	}, [syncPromptSpacer, updateScrollbar]);
 
+	// A disclosure animation changes the content box but is not new conversation
+	// content. Re-measure it without re-pinning the viewport to the bottom; doing
+	// that during a height animation makes the whole chat jump under the reader.
+	const syncScrollMetrics = useCallback(() => {
+		anchorGeometry.current = null;
+		// UI-only disclosure resizes must not rewrite the trailing spacer. Doing so
+		// every animation frame changes the scroll range and causes a small jerk when
+		// a panel collapses near the bottom of the viewport.
+		updateScrollbar();
+	}, [updateScrollbar]);
+
 	useEffect(() => {
 		syncScrollLayout();
 	}, [pinned, snapshot.latestSequence, groups.length, messageEdit?.turnId, syncScrollLayout]);
@@ -2040,11 +2048,11 @@ function Timeline({
 	useEffect(() => {
 		syncScrollLayout();
 		if (typeof ResizeObserver === "undefined") return;
-		const observer = new ResizeObserver(syncScrollLayout);
+		const observer = new ResizeObserver(syncScrollMetrics);
 		if (scroller.current) observer.observe(scroller.current);
 		if (scrollContent.current) observer.observe(scrollContent.current);
 		return () => observer.disconnect();
-	}, [groups.length, syncScrollLayout]);
+	}, [groups.length, syncScrollMetrics]);
 
 	function onScroll() {
 		const node = scroller.current;
@@ -2507,12 +2515,11 @@ const TurnGroup = memo(function TurnGroup({
 			    list that grows both change while the reader watches, and at the end of a
 			    turn neither pushes anything the reader is already looking at. */}
 			{group.plan ? <TurnPlan plan={group.plan} live={group.live} /> : null}
-			{/* Above the outcome divider: the changed files are part of what the turn
-			    did, and belong inside it rather than after it closes. */}
-			{group.diff ? (
+			{/* Changed-files review is a settled result, not live activity. Keep it
+			    below the completed assistant response and its bottom action row. */}
+			{group.diff && group.outcome?.state === "completed" && copyableMessageId ? (
 				<TurnChangedFiles
 					diff={group.diff}
-					live={group.live}
 					items={group.items}
 					onReview={onOpenFiles}
 					onOpenFile={onOpenFile}

--- a/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
@@ -430,7 +430,7 @@ describe("ActivityRow command labels", () => {
 				)}
 			/>,
 		);
-		expect(screen.getByText("Explored 2 files")).toBeInTheDocument();
+		expect(screen.getByText("Read files")).toBeInTheDocument();
 		expect(screen.queryByText(/sed -n/)).not.toBeInTheDocument();
 	});
 
@@ -475,7 +475,7 @@ describe("ActivityRow command labels", () => {
 			/>,
 		);
 		const row = screen.getByRole("button");
-		expect(row).toHaveClass("py-0.5", "gap-1.5", "rounded-sm");
+		expect(row).toHaveClass("py-0.5", "gap-1.5", "select-none");
 		expect(screen.getByText("Checked repository")).toHaveClass(
 			"text-[11.5px]",
 			"font-normal",

--- a/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnChangedFiles.test.tsx
@@ -350,7 +350,7 @@ describe("ActivityRun with a streaming command", () => {
 	}
 
 	it("opens itself so live output inside it is visible", () => {
-		const { container } = render(
+		render(
 			<ActivityRun
 				activities={[
 					commandActivity(
@@ -361,7 +361,28 @@ describe("ActivityRun with a streaming command", () => {
 				]}
 			/>,
 		);
-		expect(container.querySelector("pre")?.textContent).toBe("compiling…\n");
+		expect(screen.getByText("compiling…")).toBeInTheDocument();
+	});
+
+	it("opens the matching subgroup when a grouped command is streaming", () => {
+		const completedCommand = commandActivity({ command: "pwd" }, "completed");
+		completedCommand.id = "act-2";
+		completedCommand.sequence = 2;
+
+		render(
+			<ActivityRun
+				activities={[
+					commandActivity(
+						{ command: "npm run build", output: "compiling…\n", outputSource: "stream", outputMayBePartial: true },
+						"running",
+					),
+					completedCommand,
+					plan("act-3"),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("compiling…")).toBeInTheDocument();
 	});
 
 	it("stays collapsed when nothing inside it is printing", () => {

--- a/frontend/src/renderer/components/chat/activity-command.ts
+++ b/frontend/src/renderer/components/chat/activity-command.ts
@@ -5,7 +5,7 @@ export type CommandCategory = "read" | "search" | "vcs" | "run";
 
 /** Shared chrome for one command summary and a collapsed run of commands. */
 export const ACTIVITY_SUMMARY_BUTTON_CLASS =
-	"group/run flex w-full items-center gap-1.5 rounded-sm py-0.5 pr-1 text-left outline-none focus-visible:outline-none";
+	"activity-summary-button group/run flex w-full select-none items-center gap-1.5 py-0.5 pr-1 text-left outline-none focus-visible:outline-none";
 
 /** A completed shell command that reported an ordinary non-zero process exit. */
 export function isNonzeroCommandExit(activity: ConversationActivity): boolean {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -2075,6 +2075,39 @@ html.sidebar-reordering * {
 	transform: scale(0.96);
 }
 
+/* Timeline summaries are disclosure controls, not raised buttons. Keeping their
+   footprint fixed prevents the label from shifting when the pointer lands. */
+.cursor-chat-surface .activity-summary-button:not(:disabled):active {
+	transform: none;
+}
+
+.activity-run-toggle {
+	border-bottom: 1px solid color-mix(in oklch, var(--color-border) 48%, transparent);
+	color: var(--color-text-muted);
+}
+
+.activity-run-toggle:hover,
+.activity-subgroup-toggle:hover {
+	color: var(--color-text-primary);
+}
+
+.activity-summary-button:hover > .activity-summary-label {
+	color: var(--color-text-primary);
+}
+
+.activity-row-toggle:hover > .activity-row-label {
+	color: var(--color-text-primary);
+}
+
+.cursor-chat-surface .activity-summary-button:not(:disabled),
+.cursor-chat-surface .activity-row-toggle:not(:disabled) {
+	transition: none;
+}
+
+.activity-subgroup {
+	min-width: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.cursor-chat-surface button:not(:disabled) {
 		transition: none;

--- a/frontend/src/renderer/types/conversation.ts
+++ b/frontend/src/renderer/types/conversation.ts
@@ -292,6 +292,9 @@ export interface FileChangeFile {
 	additions: number;
 	deletions: number;
 	patch?: string;
+	/** Native provider before/after text, used to render a fallback diff. */
+	oldText?: string;
+	newText?: string;
 	/** The patch was cut at the daemon's cap, so it is not the whole change. */
 	patchTruncated?: boolean;
 }
@@ -324,6 +327,8 @@ export interface McpToolDetail {
 	namespace?: string;
 	arguments?: unknown;
 	result?: unknown;
+	/** Structured provider content, including native ACP read output. */
+	content?: unknown;
 	error?: string;
 	success?: boolean;
 	/** Progress notes streamed while a long call runs. */


### PR DESCRIPTION
## Summary\n- group consecutive tool calls into compact batches with meaningful child groups\n- add smooth expansion, flat hierarchy styling, and aggregate diff stats\n- render file edits and read/tool payloads as clipped, color-coded diff/code surfaces\n- show settled changed-files review after the completed assistant response\n\n<img width="669" height="505" alt="image" src="https://github.com/user-attachments/assets/8a531cfb-08e6-452c-a77a-1eb2cbdfabac" />\n^^^^^\n\n## Validation\n- Frontend focused chat tests: 151 passed\n- Backend ACP tests passed\n-  passed\n\nNo generated artifacts or runtime state included.\n\nFixes #4651