### PR TITLE
fix(updater): own a download the check itself started

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -2038,6 +2038,96 @@ describe("startAutoUpdates", () => {
     await checking;
   });
 
+  // A check that starts a download returns its promise WITHOUT awaiting it
+  // (AppUpdater marks that `noinspection ES6MissingAwait`). Every path that can
+  // force a download therefore has to own it, or the download, the localhost
+  // handoff to Squirrel and the native staging behind it outlive the operation
+  // that started them — and the queue lets the next one run on top.
+  const deferredDownload = () => {
+    let finish!: () => void;
+    const downloadPromise = new Promise<void>((resolve) => { finish = resolve; });
+    return { finish, result: {
+      isUpdateAvailable: true,
+      updateInfo: { version: "2.0.0" },
+      downloadPromise,
+    } };
+  };
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("owns a forced download on the automatic path with auto-download off", async () => {
+    // The gate used to be `if (settings.enabled)`, but a stale staged build
+    // forces a download precisely WHEN the preference is off — it has to be
+    // superseded or quitting installs the channel the user left.
+    const h = await importAutoUpdater({
+      enabled: false, channel: "latest", nightlyAck: false, feature: null,
+    });
+    const { finish, result } = deferredDownload();
+    h.autoUpdater.checkForUpdates.mockResolvedValue(result);
+
+    let settled = false;
+    const checking = h.module.startAutoUpdates(stateDir).then(() => { settled = true; });
+    await settle();
+
+    expect(h.autoUpdater.checkForUpdates).toHaveBeenCalled();
+    expect(settled).toBe(false);
+
+    finish();
+    await checking;
+    expect(settled).toBe(true);
+  });
+
+  it("holds a manual check open until a forced download finishes", async () => {
+    const { module, autoUpdater } = await importAutoUpdater();
+    const { finish, result } = deferredDownload();
+    autoUpdater.checkForUpdates.mockResolvedValue(result);
+
+    let settled = false;
+    const checking = module.checkForUpdatesNow(stateDir).then(() => { settled = true; });
+    await settle();
+    expect(settled).toBe(false);
+
+    finish();
+    await checking;
+    expect(settled).toBe(true);
+  });
+
+  it("holds return-home open until a forced download finishes", async () => {
+    const { module, autoUpdater } = await importAutoUpdater();
+    const { finish, result } = deferredDownload();
+    autoUpdater.checkForUpdates.mockResolvedValue(result);
+
+    let settled = false;
+    const returning = module.returnToHome(stateDir).then(() => { settled = true; });
+    await settle();
+    expect(settled).toBe(false);
+
+    finish();
+    await returning;
+    expect(settled).toBe(true);
+  });
+
+  it("blocks the next queued operation until a forced download finishes", async () => {
+    // The point of owning the download: the queue must not hand the updater to
+    // another operation while a handoff is still in flight.
+    const { module, autoUpdater } = await importAutoUpdater();
+    const { finish, result } = deferredDownload();
+    autoUpdater.checkForUpdates
+      .mockResolvedValueOnce(result)
+      .mockResolvedValue({ isUpdateAvailable: false, updateInfo: { version: "2.0.0" } });
+
+    const first = module.checkForUpdatesNow(stateDir, { requestId: "one" });
+    await settle();
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    const second = module.checkForUpdatesNow(stateDir, { requestId: "two" });
+    await settle();
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    finish();
+    await Promise.all([first, second]);
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+
   // Regression: electron-updater returns the in-flight promise when a check is
   // already running, so a second caller's events were consumed elsewhere and
   // nothing ever moved the status off "checking". Settings keys its spinner and

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1142,6 +1142,35 @@ function automaticUpdateCheckInterval(settings: UpdateSettings): number {
     : STABLE_AUTOMATIC_UPDATE_CHECK_INTERVAL_MS;
 }
 
+/**
+ * Own a download that the check itself started.
+ *
+ * With `autoDownload` set, `doCheckForUpdates()` kicks the download off and
+ * returns its promise WITHOUT awaiting it — deliberately, marked
+ * `noinspection ES6MissingAwait` in AppUpdater. If the serialized operation
+ * returns without awaiting that promise, the download, the localhost handoff to
+ * Squirrel and the native staging behind it all continue after the operation has
+ * settled: the queue lets the next check or download start on top of them, and a
+ * `finally` that restores the feed runs while the download is still using it.
+ *
+ * Awaited regardless of the auto-update preference. The preference governs
+ * whether a download is STARTED, not whether one already running is owned — and
+ * a stale staged build forces a download precisely when the preference is off,
+ * to supersede a build the user has moved away from.
+ *
+ * Sets the download phase so a failure here is attributed to the download rather
+ * than to the check that started it.
+ */
+async function awaitStartedDownload(result: UpdateCheckOutcome): Promise<void> {
+  if (!result?.downloadPromise) return;
+  activeUpdaterPhase = "download";
+  pendingUpdateVersion = result.updateInfo?.version;
+  // The provider owns this download's token; hand it to the watchdog so a stall
+  // can actually be cancelled rather than just reported.
+  activeDownloadCancellation = result.cancellationToken;
+  await result.downloadPromise;
+}
+
 async function runAutomaticUpdateCheck(
   stateDir: string,
 ): Promise<number> {
@@ -1186,13 +1215,10 @@ async function runAutomaticUpdateCheck(
       try {
         const result = await checkForUpdatesWithDeadline();
         settleCheckStatus(result);
-        if (settings.enabled) {
-          if (result?.downloadPromise) {
-            // The provider owns this download's token; hand it to the watchdog
-            // so a stall can actually be cancelled rather than just reported.
-            activeDownloadCancellation = result.cancellationToken;
-            await result.downloadPromise;
-          } else if (
+        if (result?.downloadPromise) {
+          await awaitStartedDownload(result);
+        } else if (settings.enabled) {
+          if (
             result?.isUpdateAvailable === true &&
             supersedesStagedBuild(result.updateInfo?.version)
           ) {
@@ -1340,6 +1366,12 @@ export async function checkForUpdatesNow(
     });
     return;
   }
+  // Which phase a failure came from. The queue clears global operation state in
+  // its own `finally` before this function's catch runs, and a queued operation
+  // can reset the module-level phase, so the distinction is captured locally
+  // while the operation is still on the stack. Boxed because the assignment
+  // happens inside the operation closure.
+  const failed: { phase: UpdatePhase } = { phase: "check" };
   try {
     await runSerializedUpdaterOperation(
       "manual-check",
@@ -1361,7 +1393,13 @@ export async function checkForUpdatesNow(
         broadcastUpdaterStatus({ state: "checking" });
         const restoreFeed = await configureDirectPrereleaseFeed(settings);
         try {
-          settleCheckStatus(await checkForUpdatesWithDeadline());
+          const result = await checkForUpdatesWithDeadline();
+          settleCheckStatus(result);
+          // A stale staged build forces a download above; own it here so the
+          // feed is not restored, and the next operation not started, while it
+          // is still running.
+          if (result?.downloadPromise) failed.phase = "download";
+          await awaitStartedDownload(result);
         } finally {
           restoreFeed?.();
         }
@@ -1370,11 +1408,13 @@ export async function checkForUpdatesNow(
     );
   } catch (err) {
     if (isManifest404Error(err)) {
-      console.info("manual update check failed:", err);
+      console.info(`manual update ${failed.phase} failed:`, err);
       broadcastCompletedCheck({
         state: "error",
         message:
-          "Couldn't check for updates — the update information was not found on the server.",
+          failed.phase === "download"
+            ? "Download failed — the update file was not found on the server."
+            : "Couldn't check for updates — the update information was not found on the server.",
         ...(options.requestId === undefined ? {} : { requestId: options.requestId }),
       });
       if (stagedAtMs !== undefined) broadcast(stagedDownloadedStatus());
@@ -1415,6 +1455,8 @@ export async function returnToHome(
     });
     return;
   }
+  // See checkForUpdatesNow: boxed so the closure assignment is visible here.
+  const failed: { phase: UpdatePhase } = { phase: "check" };
   try {
     await runSerializedUpdaterOperation(
       "return-home",
@@ -1432,14 +1474,21 @@ export async function returnToHome(
         autoUpdater.autoDownload = staleStaged;
         applyInstallOnQuitPolicy();
         broadcastUpdaterStatus({ state: "checking" });
-        settleCheckStatus(await checkForUpdatesWithDeadline());
+        const result = await checkForUpdatesWithDeadline();
+        settleCheckStatus(result);
+        // Same ownership rule as the other two paths: leaving a pinned build is
+        // a channel switch, so the replacement download is forced here too.
+        if (result?.downloadPromise) failed.phase = "download";
+        await awaitStartedDownload(result);
       },
       requestId,
     );
   } catch (err) {
     broadcast({
       state: "error",
-      message: (err as Error)?.message ?? "Return failed",
+      message:
+        (err as Error)?.message ??
+        (failed.phase === "download" ? "Download failed" : "Return failed"),
       ...(requestId === undefined ? {} : { requestId }),
     });
   }


### PR DESCRIPTION
Closes a verified serialization leak in the updater: three entry points can start a download and then let it outlive the operation that started it.

## The defect

With `autoDownload` set, `doCheckForUpdates()` starts the download and returns its promise **without awaiting it** — deliberately, marked `noinspection ES6MissingAwait` in `AppUpdater.js:416-422`. On macOS that promise does not resolve until the whole archive has been served to Squirrel over the localhost proxy (`executeDownload` awaits `done()`, which resolves on the HTTP response's `finish` event).

So when the promise escapes, the serialized operation settles while the download, the handoff and the native staging behind it are still running. The queue then hands the updater to the next operation on top of them, and the manual check's `finally` restores the feed while the download is still using it.

### The automatic path had it in its most surprising form

```js
autoUpdater.autoDownload = staleStaged || (settings.enabled && !hasStagedBuild());
// ...
if (settings.enabled) {
  if (result?.downloadPromise) await result.downloadPromise;   // never reached when disabled
}
```

`staleStaged` forces a download **precisely when the preference is off** — that is the case the force exists for, since a build from a channel the user has left is already armed with the OS installer and must be superseded, or quitting installs the build they moved away from. The existing comment in that block says exactly this; the gate below it then skipped the await for those users.

`checkForUpdatesNow` and `returnToHome` set `autoDownload = staleStaged` and awaited only the check.

## The fix

One invariant, applied to all three paths via a new `awaitStartedDownload()`:

> If a check returns a download promise, own and await it **regardless of the auto-update preference.** The preference gates only the separate decision to *start* an additional download.

The helper also sets the download phase, so a failure is attributed to the download rather than to the check that began it. Both manual paths capture that phase in a local box, because `runSerializedUpdaterOperation` clears global operation state in its own `finally` before their `catch` runs — a manifest 404 during a forced download now reads "Download failed — the update file was not found on the server." instead of the check wording.

No new access to library internals: `downloadPromise` and `cancellationToken` are both on the public `UpdateCheckResult`.

## Tests

Four new cases, each **verified to fail against the previous behaviour**:

- automatic path owns a forced download with auto-download **off**
- manual check stays open until the forced download finishes
- return-home stays open until the forced download finishes
- the **next queued operation** does not start until it finishes

Two probes were run to prove they bite. Removing ownership everywhere fails all four plus one pre-existing test that already depended on it. Restoring just the `settings.enabled` gate fails **exactly one** — the automatic path with the preference off, which is the defect this PR fixes.

`typecheck` clean; full suite `3852 passed`. Unrelated local failures: `browser-profile-import.test.ts` (a `better_sqlite3` native ABI mismatch from running tests on node 20.19, because vitest will not start on this machine's node 22.11) and one `Sidebar.test.tsx` timing flake that passes in isolation — neither is reachable from this main-process change.

## Risk and scope

Low blast radius on the manual paths: they only set `autoDownload` when a staged build is stale, so behaviour is unchanged in the common case. The automatic path changes for users with auto-download **disabled** and a stale staged build — who previously got an unowned download.

Deliberately not in scope: readiness/staging semantics (`stagedAtMs` still lands on electron-updater's optimistic `update-downloaded`) and the install-rejection recovery in #4981. Both are tracked separately; this PR is independent of #4981 and touches no overlapping regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
