### PR TITLE
fix(kiro): recognize authorized identity in whoami --format json output

### DIFF
--- a/backend/internal/adapters/agent/kiro/auth.go
+++ b/backend/internal/adapters/agent/kiro/auth.go
@@ -1,9 +1,12 @@
 package kiro
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -23,11 +26,51 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	return kiroWhoamiAuthStatus(ctx, binary)
 }
 
+// kiroWhoamiIdentity is the leading JSON object `kiro-cli whoami --format
+// json` prints for a signed-in identity. kiro-cli follows it with a
+// plain-text "Profile:" trailer, so stdout as a whole is not valid JSON.
+type kiroWhoamiIdentity struct {
+	AccountType string `json:"accountType"`
+	Email       string `json:"email"`
+	StartURL    string `json:"startUrl"`
+}
+
 func kiroWhoamiAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {
 	if binary == "" {
 		return ports.AgentAuthStatusUnknown, nil
 	}
 	// Kiro documents `whoami` as its authentication-status command. Keep the
 	// probe bounded so catalog refresh cannot hang on a broken CLI install.
-	return authprobe.CLIStatus(ctx, binary, [][]string{{"whoami", "--format", "json"}})
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	out, err := authprobe.CmdRunner(probeCtx, binary, "whoami", "--format", "json")
+	if probeCtx.Err() != nil {
+		if probeCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+			return ports.AgentAuthStatusUnknown, nil
+		}
+		return ports.AgentAuthStatusUnknown, probeCtx.Err()
+	}
+
+	// Keyword-based classification first: it recognizes kiro-cli's plain-text
+	// "not logged in" message regardless of the JSON path below.
+	if status := authprobe.StatusFromText(string(out)); status != ports.AgentAuthStatusUnknown {
+		return status, nil
+	}
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, nil
+	}
+
+	// `--format json` prints a JSON object followed by a plain-text "Profile:"
+	// trailer, which is not valid JSON as a whole. Decode only the first JSON
+	// value and ignore what follows it. Presence of any identity field is
+	// treated as evidence of a signed-in session.
+	var identity kiroWhoamiIdentity
+	if decErr := json.NewDecoder(bytes.NewReader(out)).Decode(&identity); decErr == nil {
+		if identity.AccountType != "" || identity.Email != "" || identity.StartURL != "" {
+			return ports.AgentAuthStatusAuthorized, nil
+		}
+	}
+
+	return ports.AgentAuthStatusUnknown, nil
 }

--- a/backend/internal/adapters/agent/kiro/auth.go
+++ b/backend/internal/adapters/agent/kiro/auth.go
@@ -26,9 +26,6 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	return kiroWhoamiAuthStatus(ctx, binary)
 }
 
-// kiroWhoamiIdentity is the leading JSON object `kiro-cli whoami --format
-// json` prints for a signed-in identity. kiro-cli follows it with a
-// plain-text "Profile:" trailer, so stdout as a whole is not valid JSON.
 type kiroWhoamiIdentity struct {
 	AccountType string `json:"accountType"`
 	Email       string `json:"email"`
@@ -61,10 +58,7 @@ func kiroWhoamiAuthStatus(ctx context.Context, binary string) (ports.AgentAuthSt
 		return ports.AgentAuthStatusUnknown, nil
 	}
 
-	// `--format json` prints a JSON object followed by a plain-text "Profile:"
-	// trailer, which is not valid JSON as a whole. Decode only the first JSON
-	// value and ignore what follows it. Presence of any identity field is
-	// treated as evidence of a signed-in session.
+	// kiro-cli appends a plain-text "Profile:" trailer after the JSON object.
 	var identity kiroWhoamiIdentity
 	if decErr := json.NewDecoder(bytes.NewReader(out)).Decode(&identity); decErr == nil {
 		if identity.AccountType != "" || identity.Email != "" || identity.StartURL != "" {

--- a/backend/internal/adapters/agent/kiro/kiro_test.go
+++ b/backend/internal/adapters/agent/kiro/kiro_test.go
@@ -411,6 +411,49 @@ func TestAuthStatusUnauthorizedFromKiroWhoami(t *testing.T) {
 	}
 }
 
+// TestAuthStatusHandlesJSONFormatTrailer covers kiro-cli's actual
+// `whoami --format json` output: a JSON object followed by a plain-text
+// "Profile:" trailer, which makes the full stdout invalid JSON. The probe
+// must still report the session as authorized.
+func TestAuthStatusHandlesJSONFormatTrailer(t *testing.T) {
+	restore := stubKiroAuthRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte(`{"accountType":"IamIdentityCenter","email":"<redacted>","region":"eu-west-1","startUrl":"https://d-9367796492.awsapps.com/start"}
+
+Profile:
+KiroProfile-us-east-1
+arn:aws:codewhisperer:us-east-1:<redacted>:profile/<redacted>
+`), nil
+	})
+	defer restore()
+
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+	status, err := plugin.AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+// TestAuthStatusUnknownForEmptyJSONIdentity guards against treating an empty
+// or malformed JSON object as a signed-in identity.
+func TestAuthStatusUnknownForEmptyJSONIdentity(t *testing.T) {
+	restore := stubKiroAuthRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("{}\n"), nil
+	})
+	defer restore()
+
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+	status, err := plugin.AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
+	}
+}
+
 func TestGetAgentHooksInstallsKiroHooks(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "kiro-cli"}
 	workspace := t.TempDir()

--- a/backend/internal/adapters/agent/kiro/kiro_test.go
+++ b/backend/internal/adapters/agent/kiro/kiro_test.go
@@ -417,7 +417,7 @@ func TestAuthStatusUnauthorizedFromKiroWhoami(t *testing.T) {
 // must still report the session as authorized.
 func TestAuthStatusHandlesJSONFormatTrailer(t *testing.T) {
 	restore := stubKiroAuthRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
-		return []byte(`{"accountType":"IamIdentityCenter","email":"<redacted>","region":"eu-west-1","startUrl":"https://d-9367796492.awsapps.com/start"}
+		return []byte(`{"accountType":"IamIdentityCenter","email":"<redacted>","region":"eu-west-1","startUrl":"https://d-<redacted>.awsapps.com/start"}
 
 Profile:
 KiroProfile-us-east-1


### PR DESCRIPTION
## What

Fixes the Kiro auth probe so a valid `kiro-cli` login is reported as authorized instead of `unknown`.

## Why

`ao agent ls --refresh` always shows:

```
kiro  Kiro  installed  auth unknown
```

even when `kiro-cli whoami` proves an active, valid login.

Fixes #5048

## How

`kiro.kiroWhoamiAuthStatus` (`backend/internal/adapters/agent/kiro/auth.go`) ran `kiro-cli whoami --format json` and handed the raw stdout to the generic `authprobe.StatusFromText` keyword classifier. Two things broke it:

1. `kiro-cli whoami --format json` prints a JSON identity object followed by a plain-text `Profile:` trailer, so stdout as a whole is not valid JSON.
2. Even ignoring the trailer, the JSON object's field names (`accountType`, `email`, `region`, `startUrl`) never match any of the keyword classifier's phrases (`logged in`, `authenticated`, `"loggedin": true`, …), so a signed-in session was always classified `unknown`.

The fix keeps the existing keyword-based "not logged in" detection (unchanged behavior for the logged-out case) but, when that classifier returns `unknown`, decodes only the leading JSON value from stdout with `json.NewDecoder(...).Decode(...)` (which stops at the end of the first JSON value and ignores the trailing text) and treats a non-empty `accountType`, `email`, or `startUrl` as evidence of an authorized session.

## Testing

```
cd backend && go test ./internal/adapters/agent/kiro/... -v
```

All tests pass, including two new cases:

- `TestAuthStatusHandlesJSONFormatTrailer` — uses the exact (redacted) `whoami --format json` + `Profile:` trailer output and asserts `authorized`.
- `TestAuthStatusUnknownForEmptyJSONIdentity` — an empty `{}` JSON object still reports `unknown`.

Also ran:

```
gofmt -l backend/internal/adapters/agent/kiro/auth.go backend/internal/adapters/agent/kiro/kiro_test.go   # no output
cd backend && go vet ./internal/adapters/agent/kiro/...                                                    # clean
golangci-lint run ./internal/adapters/agent/kiro/...  (v2.12.2, matching npm run lint)                     # 0 issues
```

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue (#5048)
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant CI checks pass for the area touched (`go`)

---
This PR was generated by Claude Code Agent.
