### PR TITLE
feat: add durable model catalog caching

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -510,7 +510,7 @@ func Run() error {
 	lcStack.LCM.SetSessionInputLease(sessMgr)
 	lcStack.LCM.SetSessionOperationGate(sessMgr)
 	termMgr.SetSessionInputLease(sessMgr)
-	projectSvc := projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink, Logger: log})
+	projectSvc := projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink, Logger: log, OnModelScopeChanged: agentSvc.InvalidateProjectModelCatalogs})
 	if err := seedScratchProjectOnBoot(ctx, cfg, projectSvc); err != nil {
 		stop()
 		lcStack.Stop()

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6993,12 +6993,35 @@ components:
         fetchedAt:
           format: date-time
           type: string
+        inputFingerprint:
+          type: string
+        lastSuccessAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        metadata:
+          additionalProperties:
+            type: string
+          type: object
         models:
           items:
             $ref: '#/components/schemas/AgentModelInfo'
           type: array
+        refreshError:
+          type: string
         refreshRecommended:
           type: boolean
+        refreshState:
+          enum:
+          - idle
+          - queued
+          - refreshing
+          - error
+          type: string
+        retryAt:
+          format: date-time
+          type: string
         selectionMode:
           enum:
           - catalog

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -7021,7 +7021,9 @@ components:
           type: string
         retryAt:
           format: date-time
-          type: string
+          type:
+          - "null"
+          - string
         selectionMode:
           enum:
           - catalog

--- a/backend/internal/httpd/controllers/agents_test.go
+++ b/backend/internal/httpd/controllers/agents_test.go
@@ -268,6 +268,7 @@ func TestGetAndRefreshAgentModels(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			lastSuccess := time.Date(2026, 9, 7, 8, 0, 0, 0, time.UTC)
+			retryAt := lastSuccess.Add(time.Minute)
 			catalog := &fakeAgentCatalog{models: ports.AgentModelCatalog{
 				AgentID:          "codex",
 				SelectionMode:    ports.ModelSelectionCatalog,
@@ -280,7 +281,7 @@ func TestGetAndRefreshAgentModels(t *testing.T) {
 				LastSuccessAt:    &lastSuccess,
 				RefreshState:     "error",
 				RefreshError:     "temporary failure",
-				RetryAt:          lastSuccess.Add(time.Minute),
+				RetryAt:          &retryAt,
 			}}
 			srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{Agents: catalog}, httpd.ControlDeps{}))
 			defer srv.Close()

--- a/backend/internal/httpd/controllers/agents_test.go
+++ b/backend/internal/httpd/controllers/agents_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -266,6 +267,7 @@ func TestGetAndRefreshAgentModels(t *testing.T) {
 		{name: "revalidate", method: http.MethodPost, path: "/api/v1/agents/codex/models/refresh?projectId=proj-1&revalidate=true", wantRevalidate: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			lastSuccess := time.Date(2026, 9, 7, 8, 0, 0, 0, time.UTC)
 			catalog := &fakeAgentCatalog{models: ports.AgentModelCatalog{
 				AgentID:          "codex",
 				SelectionMode:    ports.ModelSelectionCatalog,
@@ -273,6 +275,12 @@ func TestGetAndRefreshAgentModels(t *testing.T) {
 				CustomModelEntry: ports.CustomModelEntryDirect,
 				AllowCustom:      true,
 				Source:           "official-catalog",
+				Metadata:         map[string]string{"scope": "project"},
+				InputFingerprint: "fingerprint-v2",
+				LastSuccessAt:    &lastSuccess,
+				RefreshState:     "error",
+				RefreshError:     "temporary failure",
+				RetryAt:          lastSuccess.Add(time.Minute),
 			}}
 			srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{Agents: catalog}, httpd.ControlDeps{}))
 			defer srv.Close()
@@ -281,7 +289,7 @@ func TestGetAndRefreshAgentModels(t *testing.T) {
 			if status != http.StatusOK {
 				t.Fatalf("%s %s = %d, body=%s", tc.method, tc.path, status, body)
 			}
-			for _, want := range []string{`"agentId":"codex"`, `"selectionMode":"catalog"`, `"customModelEntry":"direct"`, `"allowCustom":true`, `"id":"gpt-5.6-sol"`} {
+			for _, want := range []string{`"agentId":"codex"`, `"selectionMode":"catalog"`, `"customModelEntry":"direct"`, `"allowCustom":true`, `"id":"gpt-5.6-sol"`, `"metadata":{"scope":"project"}`, `"inputFingerprint":"fingerprint-v2"`, `"lastSuccessAt":"2026-09-07T08:00:00Z"`, `"refreshState":"error"`, `"refreshError":"temporary failure"`, `"retryAt":"2026-09-07T08:01:00Z"`} {
 				if !strings.Contains(string(body), want) {
 					t.Fatalf("body missing %s: %s", want, body)
 				}

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -182,7 +182,7 @@ type AgentModelCatalog struct {
 	LastSuccessAt *time.Time `json:"lastSuccessAt,omitempty"`
 	RefreshState  string     `json:"refreshState,omitempty" enum:"idle,queued,refreshing,error"`
 	RefreshError  string     `json:"refreshError,omitempty"`
-	RetryAt       time.Time  `json:"retryAt,omitempty"`
+	RetryAt       *time.Time `json:"retryAt,omitempty"`
 	// RefreshRecommended tells cache-first clients to revalidate in the
 	// background while continuing to display the cached catalog.
 	RefreshRecommended bool   `json:"refreshRecommended,omitempty"`

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -168,11 +168,21 @@ type AgentModelCatalog struct {
 	// AllowCustom is retained for compatibility and is true only for direct entry.
 	AllowCustom bool   `json:"allowCustom"`
 	Source      string `json:"source"`
+	// Metadata describes the non-sensitive installed adapter inputs used for
+	// discovery (for example the resolved binary and adapter source kind).
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// InputFingerprint changes whenever an upgrade, auth/config input, or
+	// project scope could produce a different catalog.
+	InputFingerprint string `json:"inputFingerprint,omitempty"`
 	// BinaryVersion is the legacy wire name for AO's non-sensitive executable
 	// and configuration metadata fingerprint.
-	BinaryVersion string    `json:"binaryVersion,omitempty"`
-	FetchedAt     time.Time `json:"fetchedAt"`
-	ValidatedAt   time.Time `json:"validatedAt,omitempty"`
+	BinaryVersion string     `json:"binaryVersion,omitempty"`
+	FetchedAt     time.Time  `json:"fetchedAt"`
+	ValidatedAt   time.Time  `json:"validatedAt,omitempty"`
+	LastSuccessAt *time.Time `json:"lastSuccessAt,omitempty"`
+	RefreshState  string     `json:"refreshState,omitempty" enum:"idle,queued,refreshing,error"`
+	RefreshError  string     `json:"refreshError,omitempty"`
+	RetryAt       time.Time  `json:"retryAt,omitempty"`
 	// RefreshRecommended tells cache-first clients to revalidate in the
 	// background while continuing to display the cached catalog.
 	RefreshRecommended bool   `json:"refreshRecommended,omitempty"`
@@ -183,12 +193,20 @@ type AgentModelCatalog struct {
 // CachedAgentModelCatalog is the persistence record used by the model-catalog
 // service. CatalogJSON contains a serialized AgentModelCatalog.
 type CachedAgentModelCatalog struct {
-	AgentID       string
-	ProjectID     string
-	BinaryVersion string // Legacy field name for the discovery-input metadata fingerprint.
-	CatalogJSON   string
-	Source        string
-	FetchedAt     time.Time
+	AgentID          string
+	ProjectID        string
+	BinaryVersion    string // Legacy field name for the discovery-input metadata fingerprint.
+	CatalogJSON      string
+	Source           string
+	FetchedAt        time.Time
+	MetadataJSON     string
+	InputFingerprint string
+	LastSuccessAt    time.Time
+	RefreshState     string
+	RefreshError     string
+	RetryCount       int64
+	RetryAt          time.Time
+	Generation       int64
 }
 
 // AgentModelCatalogCache persists normalized model catalogs across daemon
@@ -197,6 +215,12 @@ type AgentModelCatalogCache interface {
 	GetAgentModelCatalog(ctx context.Context, agentID, projectID string) (CachedAgentModelCatalog, bool, error)
 	ListAgentModelCatalogsByAgent(ctx context.Context, agentID string) ([]CachedAgentModelCatalog, error)
 	UpsertAgentModelCatalog(ctx context.Context, record CachedAgentModelCatalog) error
+}
+
+// AgentModelCatalogScopeCache supports daemon-wide startup prefetch while
+// keeping the smaller cache contract easy to fake at focused boundaries.
+type AgentModelCatalogScopeCache interface {
+	ListAgentModelCatalogs(ctx context.Context) ([]CachedAgentModelCatalog, error)
 }
 
 // AgentModelDiscoveryRequest describes one bounded, adapter-defined model

--- a/backend/internal/service/agent/catalog_test.go
+++ b/backend/internal/service/agent/catalog_test.go
@@ -112,6 +112,7 @@ type fakeModelDiscoverer struct {
 	catalog                ports.AgentModelCatalog
 	err                    error
 	discoverCalls          atomic.Int32
+	successfulCalls        atomic.Int32
 	lastRequest            ports.AgentModelDiscoveryRequest
 	fingerprintRequests    atomic.Int32
 	lastFingerprintRequest atomic.Pointer[ports.AgentModelDiscoveryRequest]
@@ -121,7 +122,7 @@ type fakeModelDiscoverer struct {
 	overlap                atomic.Bool
 }
 
-func (f *fakeModelDiscoverer) Discover(_ context.Context, request ports.AgentModelDiscoveryRequest) (ports.AgentModelCatalog, error) {
+func (f *fakeModelDiscoverer) Discover(ctx context.Context, request ports.AgentModelDiscoveryRequest) (ports.AgentModelCatalog, error) {
 	f.discoverCalls.Add(1)
 	active := f.active.Add(1)
 	for {
@@ -135,12 +136,19 @@ func (f *fakeModelDiscoverer) Discover(_ context.Context, request ports.AgentMod
 	}
 	defer f.active.Add(-1)
 	if f.delay > 0 {
-		time.Sleep(f.delay)
+		timer := time.NewTimer(f.delay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return ports.AgentModelCatalog{AgentID: request.AgentID, Models: []ports.AgentModelInfo{}}, ctx.Err()
+		}
 	}
 	f.mu.Lock()
 	f.lastRequest = request
-	f.mu.Unlock()
 	catalog := f.catalog
+	discoverErr := f.err
+	f.mu.Unlock()
 	if catalog.AgentID == "" {
 		catalog.AgentID = request.AgentID
 	}
@@ -150,7 +158,10 @@ func (f *fakeModelDiscoverer) Discover(_ context.Context, request ports.AgentMod
 	if catalog.FetchedAt.IsZero() {
 		catalog.FetchedAt = time.Now().UTC()
 	}
-	return catalog, f.err
+	if discoverErr == nil {
+		f.successfulCalls.Add(1)
+	}
+	return catalog, discoverErr
 }
 
 func TestCatalogFreshnessUsesMachineLocalDateAndTimezone(t *testing.T) {
@@ -190,6 +201,26 @@ func TestStartupPrefetchCreatesEveryUsableAgentProjectScope(t *testing.T) {
 	}
 	if got := discoverer.discoverCalls.Load(); got != 4 {
 		t.Fatalf("discoveries = %d, want two agents across two active projects", got)
+	}
+}
+
+func TestStartupPrefetchDoesNotConsumeDiscoveryTimeoutWhileQueued(t *testing.T) {
+	previousTimeout := modelCatalogLoadTimeout
+	modelCatalogLoadTimeout = 35 * time.Millisecond
+	t.Cleanup(func() { modelCatalogLoadTimeout = previousTimeout })
+	discoverer := successfulModelDiscoverer()
+	discoverer.delay = 20 * time.Millisecond
+	projects := &fakeProjectLookup{records: map[string]domain.ProjectRecord{
+		"one": {ID: "one", Path: t.TempDir()}, "two": {ID: "two", Path: t.TempDir()},
+		"three": {ID: "three", Path: t.TempDir()}, "four": {ID: "four", Path: t.TempDir()},
+	}}
+	svc := newService([]agentregistry.HarnessAgent{
+		harnessAgent("codex", "Codex", nil), harnessAgent("gemini", "Gemini", nil),
+	}, &fakeModelCache{}, projects, discoverer)
+
+	svc.prefetchModelCatalogs(context.Background(), false)
+	if got := discoverer.successfulCalls.Load(); got != 8 {
+		t.Fatalf("successful discoveries = %d, want every queued scope to receive a fresh timeout", got)
 	}
 }
 
@@ -330,6 +361,37 @@ func TestModelDiscoveryRetryBackoffStopsAfterBound(t *testing.T) {
 	}
 	if strings.Contains(string(wire), `"retryAt"`) {
 		t.Fatalf("response serialized an absent retry time: %s", wire)
+	}
+}
+
+func TestObsoleteRetryTimerDoesNotRunAfterManualRefreshSucceeds(t *testing.T) {
+	previousDelay := modelCatalogRetryDelays[0]
+	modelCatalogRetryDelays[0] = 80 * time.Millisecond
+	t.Cleanup(func() { modelCatalogRetryDelays[0] = previousDelay })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cache := &fakeModelCache{}
+	discoverer := successfulModelDiscoverer()
+	discoverer.err = errors.New("offline")
+	svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, cache, nil, discoverer)
+	svc.ctx = ctx
+
+	if _, err := svc.Models(context.Background(), "codex", "project-a", true); err != nil {
+		t.Fatal(err)
+	}
+	discoverer.mu.Lock()
+	discoverer.err = nil
+	discoverer.mu.Unlock()
+	if _, err := svc.Models(context.Background(), "codex", "project-a", true); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(2 * modelCatalogRetryDelays[0])
+	if got := discoverer.discoverCalls.Load(); got != 2 {
+		t.Fatalf("discoveries = %d, want obsolete retry timer to remain a no-op after success", got)
+	}
+	record, ok, err := cache.GetAgentModelCatalog(context.Background(), "codex", "project-a")
+	if err != nil || !ok || record.RefreshState != "idle" || record.RetryCount != 0 {
+		t.Fatalf("fresh catalog state = (%#v, %v, %v), want successful manual refresh preserved", record, ok, err)
 	}
 }
 

--- a/backend/internal/service/agent/catalog_test.go
+++ b/backend/internal/service/agent/catalog_test.go
@@ -73,15 +73,28 @@ type blockingResolverAgent struct {
 }
 
 type fakeModelCache struct {
+	mu      sync.RWMutex
 	records map[string]ports.CachedAgentModelCatalog
 	puts    int
 	putErr  error
 }
 
 type fakeProjectLookup struct {
+	mu      sync.Mutex
 	records map[string]domain.ProjectRecord
 	gotID   string
 	err     error
+}
+
+func (f *fakeProjectLookup) ListProjects(context.Context) ([]domain.ProjectRecord, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	records := make([]domain.ProjectRecord, 0, len(f.records))
+	for _, record := range f.records {
+		records = append(records, record)
+	}
+	return records, nil
 }
 
 type fakeSessionUsageLookup struct {
@@ -94,6 +107,7 @@ func (f fakeSessionUsageLookup) ListAllSessions(context.Context) ([]domain.Sessi
 }
 
 type fakeModelDiscoverer struct {
+	mu                     sync.Mutex
 	version                string
 	catalog                ports.AgentModelCatalog
 	err                    error
@@ -103,19 +117,29 @@ type fakeModelDiscoverer struct {
 	lastFingerprintRequest atomic.Pointer[ports.AgentModelDiscoveryRequest]
 	delay                  time.Duration
 	active                 atomic.Int32
+	maxActive              atomic.Int32
 	overlap                atomic.Bool
 }
 
 func (f *fakeModelDiscoverer) Discover(_ context.Context, request ports.AgentModelDiscoveryRequest) (ports.AgentModelCatalog, error) {
 	f.discoverCalls.Add(1)
-	if f.active.Add(1) != 1 {
+	active := f.active.Add(1)
+	for {
+		maximum := f.maxActive.Load()
+		if active <= maximum || f.maxActive.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+	if active != 1 {
 		f.overlap.Store(true)
 	}
 	defer f.active.Add(-1)
 	if f.delay > 0 {
 		time.Sleep(f.delay)
 	}
+	f.mu.Lock()
 	f.lastRequest = request
+	f.mu.Unlock()
 	catalog := f.catalog
 	if catalog.AgentID == "" {
 		catalog.AgentID = request.AgentID
@@ -127,6 +151,142 @@ func (f *fakeModelDiscoverer) Discover(_ context.Context, request ports.AgentMod
 		catalog.FetchedAt = time.Now().UTC()
 	}
 	return catalog, f.err
+}
+
+func TestCatalogFreshnessUsesMachineLocalDateAndTimezone(t *testing.T) {
+	lineIslands := time.FixedZone("LINT", 14*60*60)
+	utcMinus12 := time.FixedZone("UTC-12", -12*60*60)
+	last := time.Date(2026, 9, 7, 0, 30, 0, 0, lineIslands)
+	if catalogNeedsRevalidation(last, time.Date(2026, 9, 7, 23, 59, 0, 0, lineIslands)) {
+		t.Fatal("same local calendar day was stale")
+	}
+	if !catalogNeedsRevalidation(last, time.Date(2026, 9, 8, 0, 1, 0, 0, lineIslands)) {
+		t.Fatal("midnight rollover did not stale catalog")
+	}
+	previousZone, previousOffset := last.Zone()
+	if !catalogClockDiscontinuity(last, last.In(utcMinus12), previousZone, previousOffset) {
+		t.Fatal("timezone move to a different machine-local date did not stale catalog")
+	}
+	sameOffsetDifferentZone := time.FixedZone("KIRITIMATI", 14*60*60)
+	if !catalogClockDiscontinuity(last, last.In(sameOffsetDifferentZone), previousZone, previousOffset) {
+		t.Fatal("timezone identity change with the same offset was not detected")
+	}
+}
+
+func TestStartupPrefetchCreatesEveryUsableAgentProjectScope(t *testing.T) {
+	discoverer := successfulModelDiscoverer()
+	projects := &fakeProjectLookup{records: map[string]domain.ProjectRecord{
+		"one": {ID: "one", Path: t.TempDir()},
+		"two": {ID: "two", Path: t.TempDir()},
+	}}
+	svc := newService([]agentregistry.HarnessAgent{
+		harnessAgent("codex", "Codex", nil),
+		harnessAgent("gemini", "Gemini", nil),
+	}, &fakeModelCache{}, projects, discoverer)
+	svc.prefetchModelCatalogs(context.Background(), false)
+	deadline := time.Now().Add(time.Second)
+	for (discoverer.discoverCalls.Load() < 4 || discoverer.active.Load() != 0) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := discoverer.discoverCalls.Load(); got != 4 {
+		t.Fatalf("discoveries = %d, want two agents across two active projects", got)
+	}
+}
+
+func TestModelDiscoveryIsGloballyBoundedAtTwoAndDeduplicatedPerScope(t *testing.T) {
+	discoverer := successfulModelDiscoverer()
+	discoverer.delay = 40 * time.Millisecond
+	svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, &fakeModelCache{}, nil, discoverer)
+	var wg sync.WaitGroup
+	for _, projectID := range []string{"a", "a", "b", "c", "d"} {
+		wg.Add(1)
+		go func() { defer wg.Done(); _, _ = svc.Models(context.Background(), "codex", projectID, true) }()
+	}
+	wg.Wait()
+	if got := discoverer.maxActive.Load(); got > 2 {
+		t.Fatalf("max concurrent discoveries = %d, want <= 2", got)
+	}
+	if got := discoverer.discoverCalls.Load(); got != 4 {
+		t.Fatalf("discoveries = %d, want four unique scopes", got)
+	}
+}
+
+func TestManualRefreshBypassesPersistedRetryBackoff(t *testing.T) {
+	now := time.Now().UTC()
+	record := cachedModelRecord(t, "codex", "project-a", now.Add(-24*time.Hour), true)
+	record.RetryAt = now.Add(time.Hour)
+	record.RefreshState = "error"
+	record.RetryCount = 1
+	cache := &fakeModelCache{records: map[string]ports.CachedAgentModelCatalog{"codex\x00project-a": record}}
+	discoverer := successfulModelDiscoverer()
+	svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, cache, nil, discoverer)
+	if _, err := svc.RevalidateModels(context.Background(), "codex", "project-a"); err != nil {
+		t.Fatal(err)
+	}
+	if discoverer.discoverCalls.Load() != 0 {
+		t.Fatal("automatic revalidation bypassed retry backoff")
+	}
+	if _, err := svc.Models(context.Background(), "codex", "project-a", true); err != nil {
+		t.Fatal(err)
+	}
+	if discoverer.discoverCalls.Load() != 1 {
+		t.Fatal("manual refresh did not bypass retry backoff")
+	}
+}
+
+func TestModelDiscoveryRetryBackoffStopsAfterBound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cache := &fakeModelCache{}
+	discoverer := successfulModelDiscoverer()
+	discoverer.err = errors.New("offline")
+	svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, cache, nil, discoverer)
+	svc.ctx = ctx
+	for range modelCatalogMaxRetries + 1 {
+		if _, err := svc.Models(context.Background(), "codex", "project-a", true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	record, ok, err := cache.GetAgentModelCatalog(context.Background(), "codex", "project-a")
+	if err != nil || !ok {
+		t.Fatalf("cached failure = (%#v, %v, %v)", record, ok, err)
+	}
+	if record.RetryCount != int64(modelCatalogMaxRetries+1) {
+		t.Fatalf("retry count = %d, want %d", record.RetryCount, modelCatalogMaxRetries+1)
+	}
+	if !record.RetryAt.IsZero() {
+		t.Fatalf("retry remained scheduled after bound: %s", record.RetryAt)
+	}
+}
+
+type cancelAwareModelDiscoverer struct{ started chan struct{} }
+
+func (d *cancelAwareModelDiscoverer) Discover(ctx context.Context, request ports.AgentModelDiscoveryRequest) (ports.AgentModelCatalog, error) {
+	close(d.started)
+	<-ctx.Done()
+	return ports.AgentModelCatalog{AgentID: request.AgentID}, ctx.Err()
+}
+func (*cancelAwareModelDiscoverer) CatalogFingerprint(context.Context, ports.AgentModelDiscoveryRequest) string {
+	return "v1"
+}
+func (*cancelAwareModelDiscoverer) Manual(agentID string) ports.AgentModelCatalog {
+	return ports.AgentModelCatalog{AgentID: agentID, Models: []ports.AgentModelInfo{}}
+}
+
+func TestModelDiscoveryStopsOnServiceShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	discoverer := &cancelAwareModelDiscoverer{started: make(chan struct{})}
+	svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, nil, nil, discoverer)
+	svc.ctx = ctx
+	done := make(chan error, 1)
+	go func() { _, err := svc.Models(context.Background(), "codex", "project-a", true); done <- err }()
+	<-discoverer.started
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("discovery did not stop on service shutdown")
+	}
 }
 
 func (f *fakeModelDiscoverer) CatalogFingerprint(_ context.Context, request ports.AgentModelDiscoveryRequest) string {
@@ -159,6 +319,8 @@ func successfulModelDiscoverer() *fakeModelDiscoverer {
 }
 
 func (f *fakeProjectLookup) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.gotID = id
 	if f.err != nil {
 		return domain.ProjectRecord{}, false, f.err
@@ -168,11 +330,15 @@ func (f *fakeProjectLookup) GetProject(_ context.Context, id string) (domain.Pro
 }
 
 func (f *fakeModelCache) GetAgentModelCatalog(_ context.Context, agentID, projectID string) (ports.CachedAgentModelCatalog, bool, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	record, ok := f.records[agentID+"\x00"+projectID]
 	return record, ok, nil
 }
 
 func (f *fakeModelCache) ListAgentModelCatalogsByAgent(_ context.Context, agentID string) ([]ports.CachedAgentModelCatalog, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	records := make([]ports.CachedAgentModelCatalog, 0)
 	for _, record := range f.records {
 		if record.AgentID == agentID {
@@ -183,6 +349,8 @@ func (f *fakeModelCache) ListAgentModelCatalogsByAgent(_ context.Context, agentI
 }
 
 func (f *fakeModelCache) UpsertAgentModelCatalog(_ context.Context, record ports.CachedAgentModelCatalog) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.putErr != nil {
 		return f.putErr
 	}
@@ -809,8 +977,8 @@ func TestModelsReusesCacheWhileBinaryVersionMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if agent.calls.Load() != resolveCalls+1 {
-		t.Fatalf("cache hit resolve calls=%d want=%d", agent.calls.Load(), resolveCalls+1)
+	if agent.calls.Load() != resolveCalls {
+		t.Fatalf("cache hit synchronously resolved the binary: calls=%d want=%d", agent.calls.Load(), resolveCalls)
 	}
 	if discoverer.discoverCalls.Load() != 1 {
 		t.Fatalf("discovery calls=%d, want cached result", discoverer.discoverCalls.Load())
@@ -845,11 +1013,19 @@ func TestModelsRediscoversWhenBinaryVersionChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if discoverer.discoverCalls.Load() != 2 || len(got.Models) != 1 || got.Models[0].ID != "model-two" {
-		t.Fatalf("catalog=%#v calls=%d, want rediscovery for v2", got, discoverer.discoverCalls.Load())
+	if len(got.Models) != 1 || got.Models[0].ID != "model-one" {
+		t.Fatalf("cache-first catalog=%#v, want model-one while v2 validates", got)
 	}
-	if got.BinaryVersion != "v2" || !got.FetchedAt.After(first.FetchedAt) {
-		t.Fatalf("catalog=%#v, want refreshed v2 catalog", got)
+	deadline := time.Now().Add(time.Second)
+	for discoverer.discoverCalls.Load() != 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	got, err = svc.Models(context.Background(), "codex", "proj-1", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BinaryVersion != "v2" || len(got.Models) != 1 || got.Models[0].ID != "model-two" || !got.FetchedAt.After(first.FetchedAt) {
+		t.Fatalf("catalog=%#v, want asynchronously refreshed v2 catalog", got)
 	}
 }
 
@@ -1150,8 +1326,9 @@ func TestModelsUsesNewestAgentWideCacheWhenCurrentProjectDiscoveryFails(t *testi
 	if !strings.Contains(got.Warning, "timed out") {
 		t.Fatalf("warning = %q, want discovery failure", got.Warning)
 	}
-	if _, exists := cache.records["cursor\x00project-c"]; exists {
-		t.Fatal("agent-wide fallback must not be persisted as project-specific discovery")
+	stored, exists, err := cache.GetAgentModelCatalog(context.Background(), "cursor", "project-c")
+	if err != nil || !exists || stored.RefreshState != "error" {
+		t.Fatalf("project fallback = (%#v, %v, %v), want durable retryable stale cache", stored, exists, err)
 	}
 }
 
@@ -1252,6 +1429,8 @@ func TestModelsAsksClientsToRevalidateAnAgedCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 	aged.ValidatedAt = time.Now().Add(-modelCatalogTrustWindow - time.Hour)
+	lastSuccess := time.Now().Add(-24 * time.Hour)
+	aged.LastSuccessAt = &lastSuccess
 	data, err := json.Marshal(aged)
 	if err != nil {
 		t.Fatal(err)
@@ -1320,7 +1499,7 @@ func cachedModelRecord(t *testing.T, agentID, projectID string, validatedAt time
 }
 
 func TestWarmModelCatalogsRevalidatesOnlyCachedClaudeAndMuseScopesSequentially(t *testing.T) {
-	old := time.Now().Add(-time.Hour)
+	old := time.Now().Add(-24 * time.Hour)
 	cache := &fakeModelCache{records: map[string]ports.CachedAgentModelCatalog{
 		"claude-code\x00project-a": cachedModelRecord(t, "claude-code", "project-a", old, false),
 		"muse\x00project-b":        cachedModelRecord(t, "muse", "project-b", old, false),

--- a/backend/internal/service/agent/catalog_test.go
+++ b/backend/internal/service/agent/catalog_test.go
@@ -214,6 +214,8 @@ func TestModelDiscoveryIsGloballyBoundedAtTwoAndDeduplicatedPerScope(t *testing.
 func TestManualRefreshBypassesPersistedRetryBackoff(t *testing.T) {
 	now := time.Now().UTC()
 	record := cachedModelRecord(t, "codex", "project-a", now.Add(-24*time.Hour), true)
+	record.BinaryVersion = "v1"
+	record.InputFingerprint = "v1"
 	record.RetryAt = now.Add(time.Hour)
 	record.RefreshState = "error"
 	record.RetryCount = 1
@@ -234,6 +236,65 @@ func TestManualRefreshBypassesPersistedRetryBackoff(t *testing.T) {
 	}
 }
 
+func TestChangedInputsAndQueuedInvalidationBypassPersistedRetryBackoff(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		fingerprint string
+		state       string
+	}{
+		{name: "changed fingerprint", fingerprint: "v2", state: "error"},
+		{name: "queued invalidation", fingerprint: "v1", state: "queued"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			record := cachedModelRecord(t, "codex", "project-a", now, true)
+			record.BinaryVersion = "v1"
+			record.InputFingerprint = "v1"
+			record.RetryAt = now.Add(time.Hour)
+			record.RefreshState = tc.state
+			record.RetryCount = 1
+			cache := &fakeModelCache{records: map[string]ports.CachedAgentModelCatalog{"codex\x00project-a": record}}
+			discoverer := successfulModelDiscoverer()
+			discoverer.version = tc.fingerprint
+			svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, cache, nil, discoverer)
+
+			if _, err := svc.RevalidateModels(context.Background(), "codex", "project-a"); err != nil {
+				t.Fatal(err)
+			}
+			if got := discoverer.discoverCalls.Load(); got != 1 {
+				t.Fatalf("discoveries = %d, want changed or explicitly invalidated inputs to bypass backoff", got)
+			}
+		})
+	}
+}
+
+func TestChangedInputsStartANewRetrySequence(t *testing.T) {
+	now := time.Now().UTC()
+	record := cachedModelRecord(t, "codex", "project-a", now, true)
+	record.BinaryVersion = "v1"
+	record.InputFingerprint = "v1"
+	record.RetryAt = now.Add(time.Hour)
+	record.RefreshState = "error"
+	record.RetryCount = int64(modelCatalogMaxRetries)
+	cache := &fakeModelCache{records: map[string]ports.CachedAgentModelCatalog{"codex\x00project-a": record}}
+	discoverer := successfulModelDiscoverer()
+	discoverer.version = "v2"
+	discoverer.err = errors.New("offline")
+	svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, cache, nil, discoverer)
+	svc.now = func() time.Time { return now }
+
+	if _, err := svc.RevalidateModels(context.Background(), "codex", "project-a"); err != nil {
+		t.Fatal(err)
+	}
+	updated, ok, err := cache.GetAgentModelCatalog(context.Background(), "codex", "project-a")
+	if err != nil || !ok {
+		t.Fatalf("updated cache = (%#v, %v, %v)", updated, ok, err)
+	}
+	if updated.RetryCount != 1 || updated.RetryAt.IsZero() {
+		t.Fatalf("retry state = count:%d at:%s, want a new scheduled sequence", updated.RetryCount, updated.RetryAt)
+	}
+}
+
 func TestModelDiscoveryRetryBackoffStopsAfterBound(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -242,8 +303,11 @@ func TestModelDiscoveryRetryBackoffStopsAfterBound(t *testing.T) {
 	discoverer.err = errors.New("offline")
 	svc := newService([]agentregistry.HarnessAgent{harnessAgent("codex", "Codex", nil)}, cache, nil, discoverer)
 	svc.ctx = ctx
+	var got ports.AgentModelCatalog
 	for range modelCatalogMaxRetries + 1 {
-		if _, err := svc.Models(context.Background(), "codex", "project-a", true); err != nil {
+		var err error
+		got, err = svc.Models(context.Background(), "codex", "project-a", true)
+		if err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -256,6 +320,16 @@ func TestModelDiscoveryRetryBackoffStopsAfterBound(t *testing.T) {
 	}
 	if !record.RetryAt.IsZero() {
 		t.Fatalf("retry remained scheduled after bound: %s", record.RetryAt)
+	}
+	if got.RetryAt != nil {
+		t.Fatalf("response retryAt = %s after retry bound, want absent", got.RetryAt)
+	}
+	wire, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(wire), `"retryAt"`) {
+		t.Fatalf("response serialized an absent retry time: %s", wire)
 	}
 }
 

--- a/backend/internal/service/agent/readiness.go
+++ b/backend/internal/service/agent/readiness.go
@@ -82,11 +82,13 @@ func (s *Service) EnsureAgentReadiness(ctx context.Context, agentID string, purp
 // InvalidateAgentInstallation marks an agent's installation observation stale.
 func (s *Service) InvalidateAgentInstallation(agentID string) {
 	s.readiness.Invalidate(agentID, readinessInvalidateInstallation)
+	s.InvalidateModelCatalogs(agentID)
 }
 
 // InvalidateAgentAuthentication marks an agent's authentication observation stale.
 func (s *Service) InvalidateAgentAuthentication(agentID string) {
 	s.readiness.Invalidate(agentID, readinessInvalidateAuthentication)
+	s.InvalidateModelCatalogs(agentID)
 	if agentID == string(domain.HarnessCodex) && s.codexAccounts != nil {
 		if accountID := s.codexAccounts.activeAccountID(); accountID != "" {
 			s.codexAccounts.invalidate(accountID)

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -515,9 +515,8 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 		cached.Catalog.RefreshRecommended = true
 		return cached.Catalog, nil
 	}
-	if err := s.persistCatalogState(ctx, projectID, cached, hasCached, "refreshing", "", time.Time{}, generation); err != nil && !hasCached {
-		// Cache state is advisory; discovery remains usable without persistence.
-	}
+	// Cache state is advisory; discovery remains usable without persistence.
+	_ = s.persistCatalogState(ctx, projectID, cached, hasCached, "refreshing", "", time.Time{}, generation)
 	select {
 	case s.discoverySlots <- struct{}{}:
 		defer func() { <-s.discoverySlots }()

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -240,6 +240,7 @@ func (s *Service) prefetchModelCatalogs(ctx context.Context, force bool) {
 		}
 	}
 	sort.SliceStable(records, func(i, j int) bool { return priority[records[i].AgentID] < priority[records[j].AgentID] })
+	jobs := make(chan ports.CachedAgentModelCatalog, len(records))
 	for _, record := range records {
 		if _, eligible := priority[record.AgentID]; !eligible {
 			continue
@@ -248,9 +249,24 @@ func (s *Service) prefetchModelCatalogs(ctx context.Context, force bool) {
 			return
 		}
 		if force || catalogNeedsRevalidation(record.LastSuccessAt, s.now()) || record.RefreshState == "error" {
-			go func(agentID, projectID string) { _, _ = s.RevalidateModels(ctx, agentID, projectID) }(record.AgentID, record.ProjectID)
+			jobs <- record
 		}
 	}
+	close(jobs)
+	var workers sync.WaitGroup
+	for range cap(s.discoverySlots) {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for record := range jobs {
+				if ctx.Err() != nil {
+					return
+				}
+				_, _ = s.RevalidateModels(ctx, record.AgentID, record.ProjectID)
+			}
+		}()
+	}
+	workers.Wait()
 }
 
 // warmModelCatalogs retains the focused synchronous test seam used by the
@@ -443,8 +459,19 @@ func (s *Service) coalesceModelLoad(
 	if baseCtx == nil {
 		baseCtx = context.Background()
 	}
-	loadCtx, cancel := context.WithTimeout(baseCtx, modelCatalogLoadTimeout)
 	go func() {
+		select {
+		case s.discoverySlots <- struct{}{}:
+			defer func() { <-s.discoverySlots }()
+		case <-baseCtx.Done():
+			call.err = baseCtx.Err()
+			s.modelCallMu.Lock()
+			delete(s.modelCalls, key)
+			close(call.done)
+			s.modelCallMu.Unlock()
+			return
+		}
+		loadCtx, cancel := context.WithTimeout(baseCtx, modelCatalogLoadTimeout)
 		defer cancel()
 		call.catalog, call.err = s.loadModels(loadCtx, agentID, projectID, mode, call.generation)
 		s.modelCallMu.Lock()
@@ -527,12 +554,6 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 	}
 	// Cache state is advisory; discovery remains usable without persistence.
 	_ = s.persistCatalogState(ctx, projectID, cached, hasCached, "refreshing", "", time.Time{}, generation)
-	select {
-	case s.discoverySlots <- struct{}{}:
-		defer func() { <-s.discoverySlots }()
-	case <-ctx.Done():
-		return ports.AgentModelCatalog{}, ctx.Err()
-	}
 	discovered, discoverErr := s.discoverer.Discover(ctx, request)
 	discovered = applyCustomModelEntryPolicy(discovered, policy)
 	discovered.BinaryVersion = version
@@ -778,17 +799,29 @@ func (s *Service) saveFailedCatalog(ctx context.Context, projectID string, previ
 	catalog.InputFingerprint = catalog.BinaryVersion
 	catalog.Metadata = previous.Catalog.Metadata
 	catalog.RetryAt = nil
+	var retryDelay time.Duration
 	if retryCount <= int64(modelCatalogMaxRetries) {
-		delay := modelCatalogRetryDelays[retryCount-1]
-		retryAt := s.now().Add(delay).UTC()
+		retryDelay = modelCatalogRetryDelays[retryCount-1]
+		retryAt := s.now().Add(retryDelay).UTC()
 		catalog.RetryAt = &retryAt
-		time.AfterFunc(delay, func() {
-			if s.ctx.Err() == nil {
-				_, _ = s.RevalidateModels(s.ctx, catalog.AgentID, projectID)
+	}
+	if err := s.saveCatalog(ctx, projectID, catalog, generation, retryCount); err != nil {
+		return err
+	}
+	if catalog.RetryAt != nil && s.cache != nil {
+		retryAt := *catalog.RetryAt
+		time.AfterFunc(retryDelay, func() {
+			if s.ctx.Err() != nil {
+				return
 			}
+			record, ok, err := s.cache.GetAgentModelCatalog(s.ctx, catalog.AgentID, projectID)
+			if err != nil || !ok || record.Generation != generation || record.RefreshState != "error" || !record.RetryAt.Equal(retryAt) {
+				return
+			}
+			_, _ = s.RevalidateModels(s.ctx, catalog.AgentID, projectID)
 		})
 	}
-	return s.saveCatalog(ctx, projectID, catalog, generation, retryCount)
+	return nil
 }
 
 func modelCatalogRetryAt(value time.Time) *time.Time {

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -385,8 +385,10 @@ func (s *Service) InvalidateModelCatalogs(agentID string) {
 			if json.Unmarshal([]byte(record.CatalogJSON), &catalog) == nil {
 				catalog.RefreshRecommended = true
 				catalog.RefreshState = "queued"
+				catalog.RefreshError = ""
 				catalog.LastSuccessAt = nil
-				_ = s.saveCatalog(s.ctx, record.ProjectID, catalog, time.Now().UTC().UnixNano(), record.RetryCount)
+				catalog.RetryAt = nil
+				_ = s.saveCatalog(s.ctx, record.ProjectID, catalog, time.Now().UTC().UnixNano(), 0)
 			}
 			go func(projectID string) { _, _ = s.RevalidateModels(s.ctx, agentID, projectID) }(record.ProjectID)
 		}
@@ -498,6 +500,8 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 	// Fingerprints the same inputs the discovery run would read, so a change to
 	// either the executable or the configuration behind it invalidates the cache.
 	version := s.discoverer.CatalogFingerprint(ctx, request)
+	inputsChanged := hasCached && cached.BinaryVersion != version
+	explicitlyInvalidated := hasCached && cached.RefreshState == "queued"
 	if hasCached && mode == modelLoadCached && cached.BinaryVersion == version {
 		// A command-backed catalog can drift without the binary or its config
 		// changing (a provider adds a model), which no fingerprint can see. Ask
@@ -508,12 +512,18 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 		return cached.Catalog, nil
 	}
 
-	if mode != modelLoadRefresh && hasCached && !cached.RetryAt.IsZero() && s.now().Before(cached.RetryAt) {
+	if mode != modelLoadRefresh && hasCached && !inputsChanged && !explicitlyInvalidated && !cached.RetryAt.IsZero() && s.now().Before(cached.RetryAt) {
 		cached.Catalog.RefreshState = "error"
 		cached.Catalog.RefreshError = cached.RefreshError
-		cached.Catalog.RetryAt = cached.RetryAt
+		cached.Catalog.RetryAt = modelCatalogRetryAt(cached.RetryAt)
 		cached.Catalog.RefreshRecommended = true
 		return cached.Catalog, nil
+	}
+	if inputsChanged || explicitlyInvalidated {
+		cached.RetryCount = 0
+		cached.RetryAt = time.Time{}
+		cached.RefreshError = ""
+		cached.Catalog.RetryAt = nil
 	}
 	// Cache state is advisory; discovery remains usable without persistence.
 	_ = s.persistCatalogState(ctx, projectID, cached, hasCached, "refreshing", "", time.Time{}, generation)
@@ -581,7 +591,7 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 	discovered.Metadata = catalogMetadata(request)
 	discovered.RefreshState = "idle"
 	discovered.RefreshError = ""
-	discovered.RetryAt = time.Time{}
+	discovered.RetryAt = nil
 	discovered.RefreshRecommended = false
 	if err := s.saveCatalog(ctx, projectID, discovered, generation, 0); err != nil {
 		discovered.Warning = appendCacheWarning(discovered.Warning)
@@ -700,7 +710,7 @@ func (s *Service) cachedCatalog(ctx context.Context, agentID, projectID string) 
 	}
 	catalog.RefreshState = record.RefreshState
 	catalog.RefreshError = record.RefreshError
-	catalog.RetryAt = record.RetryAt
+	catalog.RetryAt = modelCatalogRetryAt(record.RetryAt)
 	return decodedCatalog{Catalog: catalog, BinaryVersion: record.BinaryVersion, LastSuccessAt: catalogLastSuccess(catalog), RefreshState: record.RefreshState, RefreshError: record.RefreshError, RetryCount: record.RetryCount, RetryAt: record.RetryAt, Generation: record.Generation}, true, nil
 }
 
@@ -733,7 +743,7 @@ func (s *Service) saveCatalog(ctx context.Context, projectID string, catalog por
 		RefreshState:     catalog.RefreshState,
 		RefreshError:     catalog.RefreshError,
 		RetryCount:       retryCount,
-		RetryAt:          catalog.RetryAt,
+		RetryAt:          catalogRetryTime(catalog.RetryAt),
 		Generation:       generation,
 	})
 }
@@ -756,7 +766,7 @@ func (s *Service) persistCatalogState(ctx context.Context, projectID string, cac
 	catalog := cached.Catalog
 	catalog.RefreshState = state
 	catalog.RefreshError = message
-	catalog.RetryAt = retryAt
+	catalog.RetryAt = modelCatalogRetryAt(retryAt)
 	return s.saveCatalog(ctx, projectID, catalog, generation, cached.RetryCount)
 }
 
@@ -767,10 +777,11 @@ func (s *Service) saveFailedCatalog(ctx context.Context, projectID string, previ
 	catalog.RefreshError = catalog.Warning
 	catalog.InputFingerprint = catalog.BinaryVersion
 	catalog.Metadata = previous.Catalog.Metadata
-	catalog.RetryAt = time.Time{}
+	catalog.RetryAt = nil
 	if retryCount <= int64(modelCatalogMaxRetries) {
 		delay := modelCatalogRetryDelays[retryCount-1]
-		catalog.RetryAt = s.now().Add(delay).UTC()
+		retryAt := s.now().Add(delay).UTC()
+		catalog.RetryAt = &retryAt
 		time.AfterFunc(delay, func() {
 			if s.ctx.Err() == nil {
 				_, _ = s.RevalidateModels(s.ctx, catalog.AgentID, projectID)
@@ -778,6 +789,21 @@ func (s *Service) saveFailedCatalog(ctx context.Context, projectID string, previ
 		})
 	}
 	return s.saveCatalog(ctx, projectID, catalog, generation, retryCount)
+}
+
+func modelCatalogRetryAt(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}
+
+func catalogRetryTime(value *time.Time) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return value.UTC()
 }
 
 func (s *Service) agent(agentID string) (agentregistry.HarnessAgent, bool) {

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strconv"
+	"sort"
 	"sync"
 	"time"
 
@@ -17,20 +17,33 @@ import (
 
 var (
 	modelCatalogLoadTimeout = 30 * time.Second
+	// Retained for compatibility with focused tests that construct an obviously
+	// old timestamp; production freshness is calendar-day based below.
+	modelCatalogTrustWindow = 6 * time.Hour
 	// How long a cached catalog is trusted before AO asks a cache-first client to
 	// revalidate in the background. Long, because rediscovery runs an agent CLI:
 	// this covers drift a fingerprint cannot see, not routine correctness.
-	modelCatalogTrustWindow = 6 * time.Hour
-	// Suppress repeated successful catalog refreshes across rapid daemon restarts.
-	// Failed validations are stale and remain eligible for the next startup.
-	modelCatalogStartupGuard = 10 * time.Minute
+	modelCatalogMonitorInterval = time.Minute
+	modelCatalogWakeThreshold   = 3 * time.Minute
+	modelCatalogMaxRetries      = 3
+	modelCatalogRetryDelays     = [...]time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute}
 )
 
-// catalogNeedsRevalidation reports whether a cached catalog is old enough to
-// re-check. A zero timestamp comes from a record written before validation was
-// tracked, so it counts as due.
-func catalogNeedsRevalidation(validatedAt time.Time) bool {
-	return validatedAt.IsZero() || time.Since(validatedAt) > modelCatalogTrustWindow
+// catalogNeedsRevalidation uses the machine's calendar date, not an elapsed
+// duration. A catalog remains fresh through the user's local day and becomes
+// due after midnight, including after timezone changes or sleep/wake.
+func catalogNeedsRevalidation(lastSuccess, now time.Time) bool {
+	if lastSuccess.IsZero() {
+		return true
+	}
+	y, m, d := now.Date()
+	ly, lm, ld := lastSuccess.In(now.Location()).Date()
+	return y != ly || m != lm || d != ld
+}
+
+func catalogClockDiscontinuity(previous, now time.Time, previousZone string, previousOffset int) bool {
+	zone, offset := now.Zone()
+	return catalogNeedsRevalidation(previous, now) || now.Sub(previous) > modelCatalogWakeThreshold || zone != previousZone || offset != previousOffset || now.Before(previous)
 }
 
 type modelLoadMode uint8
@@ -42,25 +55,30 @@ const (
 )
 
 type modelCatalogCall struct {
-	done    chan struct{}
-	catalog ports.AgentModelCatalog
-	err     error
+	done       chan struct{}
+	catalog    ports.AgentModelCatalog
+	err        error
+	generation int64
 }
 
 // Service owns normalized harness readiness and the unchanged model catalog.
 // Consumers share coordinator checks instead of probing adapters directly.
 type Service struct {
-	agents        []agentregistry.HarnessAgent
-	readiness     *readinessCoordinator
-	cache         ports.AgentModelCatalogCache
-	discoverer    ports.AgentModelDiscoverer
-	projects      ProjectLookup
-	sessions      SessionUsageLookup
-	resolverMu    map[string]*sync.Mutex
-	modelCallMu   sync.Mutex
-	modelCalls    map[string]*modelCatalogCall
-	codexAccounts *codexAccountManager
-	codexSwitches CodexAccountSwitchCoordinator
+	agents          []agentregistry.HarnessAgent
+	readiness       *readinessCoordinator
+	cache           ports.AgentModelCatalogCache
+	discoverer      ports.AgentModelDiscoverer
+	projects        ProjectLookup
+	sessions        SessionUsageLookup
+	resolverMu      map[string]*sync.Mutex
+	modelCallMu     sync.Mutex
+	modelCalls      map[string]*modelCatalogCall
+	modelGeneration map[string]int64
+	discoverySlots  chan struct{}
+	ctx             context.Context
+	now             func() time.Time
+	codexAccounts   *codexAccountManager
+	codexSwitches   CodexAccountSwitchCoordinator
 }
 
 // CodexAccountSwitchCoordinator owns global switch execution and recovery.
@@ -96,6 +114,10 @@ type ProjectLookup interface {
 	GetProject(ctx context.Context, id string) (domain.ProjectRecord, bool, error)
 }
 
+type projectListLookup interface {
+	ListProjects(ctx context.Context) ([]domain.ProjectRecord, error)
+}
+
 // SessionUsageLookup provides durable session facts used to rank agent choices.
 // The SQLite store satisfies this narrow read boundary.
 type SessionUsageLookup interface {
@@ -123,6 +145,12 @@ func NewWithDeps(deps Deps) *Service {
 		AuthenticationCheck: svc.structuredCodexAuthentication,
 	})
 	svc.sessions = deps.Sessions
+	if deps.Context != nil {
+		svc.ctx = deps.Context
+	}
+	if deps.Clock != nil {
+		svc.now = deps.Clock
+	}
 	return svc
 }
 
@@ -139,19 +167,94 @@ func newService(agents []agentregistry.HarnessAgent, cache ports.AgentModelCatal
 	for _, item := range agents {
 		resolverMu[string(item.Harness)] = &sync.Mutex{}
 	}
-	return &Service{agents: agents, readiness: newReadinessCoordinator(readinessCoordinatorConfig{Agents: agents}), cache: cache, discoverer: discoverer, projects: projects, resolverMu: resolverMu, modelCalls: map[string]*modelCatalogCall{}}
+	return &Service{agents: agents, readiness: newReadinessCoordinator(readinessCoordinatorConfig{Agents: agents}), cache: cache, discoverer: discoverer, projects: projects, resolverMu: resolverMu, modelCalls: map[string]*modelCatalogCall{}, modelGeneration: map[string]int64{}, discoverySlots: make(chan struct{}, 2), ctx: context.Background(), now: time.Now}
 }
 
-// WarmModelCatalogs starts a non-blocking, sequential refresh of the Claude
-// Code and Muse scopes that already have durable cache records. Unseen scopes
-// remain lazy and are discovered only when their picker is first opened.
+// WarmModelCatalogs starts the bounded cache scheduler. Readiness is never held
+// up by model discovery; at most two adapter discoveries run at once.
 func (s *Service) WarmModelCatalogs(ctx context.Context) {
 	if s.cache == nil || s.discoverer == nil {
 		return
 	}
-	go s.warmModelCatalogs(ctx)
+	go func() {
+		s.prefetchModelCatalogs(ctx, false)
+		s.monitorModelCatalogFreshness(ctx)
+	}()
 }
 
+func (s *Service) prefetchModelCatalogs(ctx context.Context, force bool) {
+	scopeCache, ok := s.cache.(ports.AgentModelCatalogScopeCache)
+	var records []ports.CachedAgentModelCatalog
+	var err error
+	if ok {
+		records, err = scopeCache.ListAgentModelCatalogs(ctx)
+	} else {
+		for _, item := range s.agents {
+			rows, listErr := s.cache.ListAgentModelCatalogsByAgent(ctx, string(item.Harness))
+			if listErr != nil {
+				err = listErr
+				break
+			}
+			records = append(records, rows...)
+		}
+	}
+	if err != nil || ctx.Err() != nil {
+		return
+	}
+	readiness, _ := s.EnsureReadiness(ctx, nil, domain.AgentReadinessPurposeDisplay)
+	priority := make(map[string]int, len(readiness.Agents))
+	for _, item := range readiness.Agents {
+		if item.Authentication.State == domain.AgentAuthenticationAuthorized || item.Authentication.State == domain.AgentAuthenticationNotApplicable {
+			priority[item.ID] = 0
+		} else if item.Installation.State == domain.AgentInstallationInstalled {
+			priority[item.ID] = 1
+		}
+	}
+	// Preserve and validate previously cached static catalogs even if their
+	// executable is temporarily unavailable.
+	priority["claude-code"] = 0
+	priority["muse"] = 0
+	// Include every active project scope for adapters AO can currently use. This
+	// makes startup prefetch useful on a fresh database instead of limiting it to
+	// scopes that were opened before the daemon restarted.
+	if projects, listable := s.projects.(projectListLookup); listable {
+		projectRows, listErr := projects.ListProjects(ctx)
+		if listErr == nil {
+			known := make(map[string]struct{}, len(records))
+			for _, record := range records {
+				known[record.AgentID+"\x00"+record.ProjectID] = struct{}{}
+			}
+			for _, project := range projectRows {
+				if !project.ArchivedAt.IsZero() {
+					continue
+				}
+				for agentID := range priority {
+					key := agentID + "\x00" + project.ID
+					if _, exists := known[key]; exists {
+						continue
+					}
+					known[key] = struct{}{}
+					records = append(records, ports.CachedAgentModelCatalog{AgentID: agentID, ProjectID: project.ID})
+				}
+			}
+		}
+	}
+	sort.SliceStable(records, func(i, j int) bool { return priority[records[i].AgentID] < priority[records[j].AgentID] })
+	for _, record := range records {
+		if _, eligible := priority[record.AgentID]; !eligible {
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if force || catalogNeedsRevalidation(record.LastSuccessAt, s.now()) || record.RefreshState == "error" {
+			go func(agentID, projectID string) { _, _ = s.RevalidateModels(ctx, agentID, projectID) }(record.AgentID, record.ProjectID)
+		}
+	}
+}
+
+// warmModelCatalogs retains the focused synchronous test seam used by the
+// original static-catalog warmer. Production uses the generalized scheduler.
 func (s *Service) warmModelCatalogs(ctx context.Context) {
 	for _, agentID := range []string{"claude-code", "muse"} {
 		records, err := s.cache.ListAgentModelCatalogsByAgent(ctx, agentID)
@@ -159,17 +262,38 @@ func (s *Service) warmModelCatalogs(ctx context.Context) {
 			continue
 		}
 		for _, record := range records {
-			if err := ctx.Err(); err != nil {
-				return
-			}
 			var cached ports.AgentModelCatalog
-			if err := json.Unmarshal([]byte(record.CatalogJSON), &cached); err != nil {
+			if json.Unmarshal([]byte(record.CatalogJSON), &cached) != nil {
 				continue
 			}
-			if !cached.Stale && !cached.ValidatedAt.IsZero() && time.Since(cached.ValidatedAt) < modelCatalogStartupGuard {
+			lastSuccess := record.LastSuccessAt
+			if lastSuccess.IsZero() {
+				lastSuccess = cached.ValidatedAt
+			}
+			if !cached.Stale && !catalogNeedsRevalidation(lastSuccess, s.now()) {
 				continue
 			}
 			_, _ = s.RevalidateModels(ctx, agentID, record.ProjectID)
+		}
+	}
+}
+
+func (s *Service) monitorModelCatalogFreshness(ctx context.Context) {
+	ticker := time.NewTicker(modelCatalogMonitorInterval)
+	defer ticker.Stop()
+	last := s.now()
+	lastZone, lastOffset := last.Zone()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := s.now()
+			zone, offset := now.Zone()
+			if catalogClockDiscontinuity(last, now, lastZone, lastOffset) {
+				s.prefetchModelCatalogs(ctx, true)
+			}
+			last, lastZone, lastOffset = now, zone, offset
 		}
 	}
 }
@@ -178,11 +302,62 @@ func (s *Service) warmModelCatalogs(ctx context.Context) {
 // restarts; refresh forces a new documented CLI discovery attempt. Discovery
 // failures degrade to the last cached catalog or a custom model input.
 func (s *Service) Models(ctx context.Context, agentID, projectID string, refresh bool) (ports.AgentModelCatalog, error) {
+	if s.discoverer == nil {
+		return ports.AgentModelCatalog{}, apierr.Internal("MODEL_DISCOVERY_UNAVAILABLE", "Model discovery is unavailable")
+	}
+	if !refresh {
+		if _, ok := s.agent(agentID); !ok {
+			return ports.AgentModelCatalog{}, apierr.NotFound("AGENT_NOT_FOUND", "Unknown agent adapter")
+		}
+		cached, ok, err := s.cachedCatalog(ctx, agentID, projectID)
+		if err != nil {
+			return ports.AgentModelCatalog{}, err
+		}
+		if ok {
+			cached.Catalog = applyCustomModelEntryPolicy(cached.Catalog, s.discoverer.Manual(agentID))
+			due := catalogNeedsRevalidation(catalogLastSuccess(cached.Catalog), s.now())
+			cached.Catalog.RefreshRecommended = due || cached.RefreshState == "error" || cached.RefreshState == "queued"
+			if due && (cached.RetryAt.IsZero() || !s.now().Before(cached.RetryAt)) {
+				go func() { _, _ = s.RevalidateModels(s.ctx, agentID, projectID) }()
+			} else if !due {
+				go s.revalidateChangedInputs(agentID, projectID, cached.BinaryVersion)
+			}
+			return cached.Catalog, nil
+		}
+	}
 	mode := modelLoadCached
 	if refresh {
 		mode = modelLoadRefresh
 	}
 	return s.coalesceModelLoad(ctx, agentID, projectID, mode)
+}
+
+func (s *Service) revalidateChangedInputs(agentID, projectID, cachedFingerprint string) {
+	if s.ctx.Err() != nil {
+		return
+	}
+	item, ok := s.agent(agentID)
+	if !ok {
+		return
+	}
+	discovery, err := s.projectDiscoveryContext(s.ctx, projectID)
+	if err != nil {
+		return
+	}
+	var binary string
+	if resolver, ok := item.Agent.(ports.AgentBinaryResolver); ok {
+		lock := s.resolverMu[agentID]
+		lock.Lock()
+		binary, err = resolver.ResolveBinary(s.ctx)
+		lock.Unlock()
+		if err != nil {
+			return
+		}
+	}
+	request := ports.AgentModelDiscoveryRequest{AgentID: agentID, Binary: binary, WorkingDir: discovery.workingDir, Env: discovery.env}
+	if s.discoverer.CatalogFingerprint(s.ctx, request) != cachedFingerprint {
+		_, _ = s.RevalidateModels(s.ctx, agentID, projectID)
+	}
 }
 
 // RevalidateModels rediscovers a cache-first catalog after the normal read path
@@ -191,12 +366,57 @@ func (s *Service) RevalidateModels(ctx context.Context, agentID, projectID strin
 	return s.coalesceModelLoad(ctx, agentID, projectID, modelLoadRevalidate)
 }
 
+// InvalidateModelCatalogs marks existing scopes due and schedules cache-first
+// revalidation. The last successful choices remain visible throughout.
+func (s *Service) InvalidateModelCatalogs(agentID string) {
+	if s.cache == nil {
+		return
+	}
+	go func() {
+		records, err := s.cache.ListAgentModelCatalogsByAgent(s.ctx, agentID)
+		if err != nil {
+			return
+		}
+		for _, record := range records {
+			if s.ctx.Err() != nil {
+				return
+			}
+			var catalog ports.AgentModelCatalog
+			if json.Unmarshal([]byte(record.CatalogJSON), &catalog) == nil {
+				catalog.RefreshRecommended = true
+				catalog.RefreshState = "queued"
+				catalog.LastSuccessAt = nil
+				_ = s.saveCatalog(s.ctx, record.ProjectID, catalog, time.Now().UTC().UnixNano(), record.RetryCount)
+			}
+			go func(projectID string) { _, _ = s.RevalidateModels(s.ctx, agentID, projectID) }(record.ProjectID)
+		}
+	}()
+}
+
+// InvalidateProjectModelCatalogs is called after project creation/config
+// changes. New scopes are prefetched for every installed/authorized adapter;
+// existing scopes retain their choices while being revalidated.
+func (s *Service) InvalidateProjectModelCatalogs(projectID string) {
+	go func() {
+		readiness, err := s.EnsureReadiness(s.ctx, nil, domain.AgentReadinessPurposeDisplay)
+		if err != nil {
+			return
+		}
+		for _, item := range readiness.Agents {
+			if item.Installation.State != domain.AgentInstallationInstalled && item.Authentication.State != domain.AgentAuthenticationAuthorized && item.Authentication.State != domain.AgentAuthenticationNotApplicable {
+				continue
+			}
+			go func(agentID string) { _, _ = s.RevalidateModels(s.ctx, agentID, projectID) }(item.ID)
+		}
+	}()
+}
+
 func (s *Service) coalesceModelLoad(
 	ctx context.Context,
 	agentID, projectID string,
 	mode modelLoadMode,
 ) (ports.AgentModelCatalog, error) {
-	key := agentID + "\x00" + projectID + "\x00" + strconv.Itoa(int(mode))
+	key := agentID + "\x00" + projectID
 	s.modelCallMu.Lock()
 	if active := s.modelCalls[key]; active != nil {
 		s.modelCallMu.Unlock()
@@ -207,14 +427,24 @@ func (s *Service) coalesceModelLoad(
 			return ports.AgentModelCatalog{}, ctx.Err()
 		}
 	}
-	call := &modelCatalogCall{done: make(chan struct{})}
+	wallGeneration := time.Now().UTC().UnixNano()
+	if s.modelGeneration[key] < wallGeneration {
+		s.modelGeneration[key] = wallGeneration
+	} else {
+		s.modelGeneration[key]++
+	}
+	call := &modelCatalogCall{done: make(chan struct{}), generation: s.modelGeneration[key]}
 	s.modelCalls[key] = call
 	s.modelCallMu.Unlock()
 
-	loadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), modelCatalogLoadTimeout)
+	baseCtx := s.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	loadCtx, cancel := context.WithTimeout(baseCtx, modelCatalogLoadTimeout)
 	go func() {
 		defer cancel()
-		call.catalog, call.err = s.loadModels(loadCtx, agentID, projectID, mode)
+		call.catalog, call.err = s.loadModels(loadCtx, agentID, projectID, mode, call.generation)
 		s.modelCallMu.Lock()
 		delete(s.modelCalls, key)
 		close(call.done)
@@ -229,7 +459,7 @@ func (s *Service) coalesceModelLoad(
 	}
 }
 
-func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mode modelLoadMode) (ports.AgentModelCatalog, error) {
+func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mode modelLoadMode, generation int64) (ports.AgentModelCatalog, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.AgentModelCatalog{}, err
 	}
@@ -274,20 +504,38 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 		// cache-first clients to revalidate in the background once the catalog is
 		// old enough, so staleness resolves itself instead of waiting for someone
 		// to press a refresh button.
-		cached.Catalog.RefreshRecommended = catalogNeedsRevalidation(cached.Catalog.ValidatedAt)
+		cached.Catalog.RefreshRecommended = catalogNeedsRevalidation(catalogLastSuccess(cached.Catalog), s.now())
 		return cached.Catalog, nil
 	}
 
+	if mode != modelLoadRefresh && hasCached && !cached.RetryAt.IsZero() && s.now().Before(cached.RetryAt) {
+		cached.Catalog.RefreshState = "error"
+		cached.Catalog.RefreshError = cached.RefreshError
+		cached.Catalog.RetryAt = cached.RetryAt
+		cached.Catalog.RefreshRecommended = true
+		return cached.Catalog, nil
+	}
+	if err := s.persistCatalogState(ctx, projectID, cached, hasCached, "refreshing", "", time.Time{}, generation); err != nil && !hasCached {
+		// Cache state is advisory; discovery remains usable without persistence.
+	}
+	select {
+	case s.discoverySlots <- struct{}{}:
+		defer func() { <-s.discoverySlots }()
+	case <-ctx.Done():
+		return ports.AgentModelCatalog{}, ctx.Err()
+	}
 	discovered, discoverErr := s.discoverer.Discover(ctx, request)
 	discovered = applyCustomModelEntryPolicy(discovered, policy)
 	discovered.BinaryVersion = version
 	if discoverErr != nil {
-		if hasCached && len(cached.Catalog.Models) > len(discovered.Models) {
+		if hasCached {
 			cached.Catalog.Stale = true
 			cached.Catalog.Warning = discoverErr.Error()
 			cached.Catalog.RefreshRecommended = true
-			if err := s.saveCatalog(ctx, projectID, cached.Catalog); err != nil {
+			if err := s.saveFailedCatalog(ctx, projectID, cached, cached.Catalog, generation); err != nil {
 				cached.Catalog.Warning = appendCacheWarning(cached.Catalog.Warning)
+			} else if updated, ok, _ := s.cachedCatalog(ctx, agentID, projectID); ok {
+				return updated.Catalog, nil
 			}
 			return cached.Catalog, nil
 		}
@@ -295,25 +543,24 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 			discovered.Stale = true
 			discovered.Warning = discoverErr.Error()
 			discovered.RefreshRecommended = true
-			if err := s.saveCatalog(ctx, projectID, discovered); err != nil {
+			if err := s.saveFailedCatalog(ctx, projectID, cached, discovered, generation); err != nil {
 				discovered.Warning = appendCacheWarning(discovered.Warning)
+			} else if updated, ok, _ := s.cachedCatalog(ctx, agentID, projectID); ok {
+				return updated.Catalog, nil
 			}
 			return discovered, nil
-		}
-		if hasCached {
-			cached.Catalog.Stale = true
-			cached.Catalog.Warning = discoverErr.Error()
-			cached.Catalog.RefreshRecommended = true
-			if err := s.saveCatalog(ctx, projectID, cached.Catalog); err != nil {
-				cached.Catalog.Warning = appendCacheWarning(cached.Catalog.Warning)
-			}
-			return cached.Catalog, nil
 		}
 		if shared, ok := s.latestAgentCatalog(ctx, agentID, projectID); ok {
 			shared = applyCustomModelEntryPolicy(shared, policy)
 			shared.Stale = true
 			shared.Warning = discoverErr.Error()
 			shared.RefreshRecommended = true
+			previous := decodedCatalog{Catalog: shared, RetryCount: 0}
+			if err := s.saveFailedCatalog(ctx, projectID, previous, shared, generation); err == nil {
+				if updated, found, _ := s.cachedCatalog(ctx, agentID, projectID); found {
+					return updated.Catalog, nil
+				}
+			}
 			return shared, nil
 		}
 		fallback := policy
@@ -321,11 +568,23 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 		fallback.Stale = true
 		fallback.Warning = discoverErr.Error()
 		fallback.RefreshRecommended = true
+		if err := s.saveFailedCatalog(ctx, projectID, decodedCatalog{Catalog: fallback}, fallback, generation); err == nil {
+			if updated, found, _ := s.cachedCatalog(ctx, agentID, projectID); found {
+				return updated.Catalog, nil
+			}
+		}
 		return fallback, nil
 	}
-	discovered.ValidatedAt = time.Now().UTC()
+	now := s.now().UTC()
+	discovered.ValidatedAt = now
+	discovered.LastSuccessAt = &now
+	discovered.InputFingerprint = version
+	discovered.Metadata = catalogMetadata(request)
+	discovered.RefreshState = "idle"
+	discovered.RefreshError = ""
+	discovered.RetryAt = time.Time{}
 	discovered.RefreshRecommended = false
-	if err := s.saveCatalog(ctx, projectID, discovered); err != nil {
+	if err := s.saveCatalog(ctx, projectID, discovered, generation, 0); err != nil {
 		discovered.Warning = appendCacheWarning(discovered.Warning)
 	}
 	return discovered, nil
@@ -408,6 +667,12 @@ func (s *Service) projectDiscoveryContext(ctx context.Context, projectID string)
 type decodedCatalog struct {
 	Catalog       ports.AgentModelCatalog
 	BinaryVersion string
+	LastSuccessAt time.Time
+	RefreshState  string
+	RefreshError  string
+	RetryCount    int64
+	RetryAt       time.Time
+	Generation    int64
 }
 
 func (s *Service) cachedCatalog(ctx context.Context, agentID, projectID string) (decodedCatalog, bool, error) {
@@ -425,10 +690,29 @@ func (s *Service) cachedCatalog(ctx context.Context, agentID, projectID string) 
 	if catalog.Models == nil {
 		catalog.Models = []ports.AgentModelInfo{}
 	}
-	return decodedCatalog{Catalog: catalog, BinaryVersion: record.BinaryVersion}, true, nil
+	if catalog.LastSuccessAt == nil || catalog.LastSuccessAt.IsZero() {
+		lastSuccess := record.LastSuccessAt
+		if lastSuccess.IsZero() {
+			lastSuccess = catalog.ValidatedAt
+		}
+		if !lastSuccess.IsZero() {
+			catalog.LastSuccessAt = &lastSuccess
+		}
+	}
+	catalog.RefreshState = record.RefreshState
+	catalog.RefreshError = record.RefreshError
+	catalog.RetryAt = record.RetryAt
+	return decodedCatalog{Catalog: catalog, BinaryVersion: record.BinaryVersion, LastSuccessAt: catalogLastSuccess(catalog), RefreshState: record.RefreshState, RefreshError: record.RefreshError, RetryCount: record.RetryCount, RetryAt: record.RetryAt, Generation: record.Generation}, true, nil
 }
 
-func (s *Service) saveCatalog(ctx context.Context, projectID string, catalog ports.AgentModelCatalog) error {
+func catalogLastSuccess(catalog ports.AgentModelCatalog) time.Time {
+	if catalog.LastSuccessAt == nil {
+		return time.Time{}
+	}
+	return *catalog.LastSuccessAt
+}
+
+func (s *Service) saveCatalog(ctx context.Context, projectID string, catalog ports.AgentModelCatalog, generation, retryCount int64) error {
 	if s.cache == nil {
 		return nil
 	}
@@ -436,14 +720,65 @@ func (s *Service) saveCatalog(ctx context.Context, projectID string, catalog por
 	if err != nil {
 		return fmt.Errorf("encode model catalog for %s: %w", catalog.AgentID, err)
 	}
+	metadata, _ := json.Marshal(catalog.Metadata)
 	return s.cache.UpsertAgentModelCatalog(ctx, ports.CachedAgentModelCatalog{
-		AgentID:       catalog.AgentID,
-		ProjectID:     projectID,
-		BinaryVersion: catalog.BinaryVersion,
-		CatalogJSON:   string(data),
-		Source:        catalog.Source,
-		FetchedAt:     catalog.FetchedAt,
+		AgentID:          catalog.AgentID,
+		ProjectID:        projectID,
+		BinaryVersion:    catalog.BinaryVersion,
+		CatalogJSON:      string(data),
+		Source:           catalog.Source,
+		FetchedAt:        catalog.FetchedAt,
+		MetadataJSON:     string(metadata),
+		InputFingerprint: catalog.InputFingerprint,
+		LastSuccessAt:    catalogLastSuccess(catalog),
+		RefreshState:     catalog.RefreshState,
+		RefreshError:     catalog.RefreshError,
+		RetryCount:       retryCount,
+		RetryAt:          catalog.RetryAt,
+		Generation:       generation,
 	})
+}
+
+func catalogMetadata(request ports.AgentModelDiscoveryRequest) map[string]string {
+	metadata := map[string]string{"scope": "global"}
+	if request.WorkingDir != "" {
+		metadata["scope"] = "project"
+	}
+	if request.Binary != "" {
+		metadata["binary"] = request.Binary
+	}
+	return metadata
+}
+
+func (s *Service) persistCatalogState(ctx context.Context, projectID string, cached decodedCatalog, hasCached bool, state, message string, retryAt time.Time, generation int64) error {
+	if !hasCached {
+		return nil
+	}
+	catalog := cached.Catalog
+	catalog.RefreshState = state
+	catalog.RefreshError = message
+	catalog.RetryAt = retryAt
+	return s.saveCatalog(ctx, projectID, catalog, generation, cached.RetryCount)
+}
+
+func (s *Service) saveFailedCatalog(ctx context.Context, projectID string, previous decodedCatalog, catalog ports.AgentModelCatalog, generation int64) error {
+	retryCount := previous.RetryCount + 1
+	catalog.LastSuccessAt = previous.Catalog.LastSuccessAt
+	catalog.RefreshState = "error"
+	catalog.RefreshError = catalog.Warning
+	catalog.InputFingerprint = catalog.BinaryVersion
+	catalog.Metadata = previous.Catalog.Metadata
+	catalog.RetryAt = time.Time{}
+	if retryCount <= int64(modelCatalogMaxRetries) {
+		delay := modelCatalogRetryDelays[retryCount-1]
+		catalog.RetryAt = s.now().Add(delay).UTC()
+		time.AfterFunc(delay, func() {
+			if s.ctx.Err() == nil {
+				_, _ = s.RevalidateModels(s.ctx, catalog.AgentID, projectID)
+			}
+		})
+	}
+	return s.saveCatalog(ctx, projectID, catalog, generation, retryCount)
 }
 
 func (s *Service) agent(agentID string) (agentregistry.HarnessAgent, bool) {

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -64,12 +64,13 @@ type SessionTeardowner interface {
 
 // Service implements project registration and lookup use-cases for controllers.
 type Service struct {
-	store          Store
-	sessions       SessionTeardowner
-	clock          func() time.Time
-	telemetry      ports.EventSink
-	defaultHarness domain.AgentHarness
-	logger         *slog.Logger
+	store               Store
+	sessions            SessionTeardowner
+	clock               func() time.Time
+	telemetry           ports.EventSink
+	defaultHarness      domain.AgentHarness
+	logger              *slog.Logger
+	onModelScopeChanged func(projectID string)
 	// addMu serialises the whole body of Add. Workspace registration performs
 	// filesystem mutations (git init, .gitignore writes, commits) that are not
 	// covered by the store's own writeMu, so path/id conflict checks plus the
@@ -93,6 +94,9 @@ type Deps struct {
 	// Logger receives structured logs. Left nil, the service falls back to
 	// slog.Default, keeping service-focused tests logger-free.
 	Logger *slog.Logger
+	// OnModelScopeChanged schedules non-blocking model-catalog invalidation
+	// after a project is created or its agent-relevant config changes.
+	OnModelScopeChanged func(projectID string)
 }
 
 // New returns a project service backed by the given durable store.
@@ -107,12 +111,13 @@ func NewWithDeps(d Deps) *Service {
 		defaultHarness = domain.AgentHarness(config.DefaultAgent)
 	}
 	s := &Service{
-		store:          d.Store,
-		sessions:       d.Sessions,
-		clock:          d.Clock,
-		telemetry:      d.Telemetry,
-		defaultHarness: defaultHarness,
-		logger:         d.Logger,
+		store:               d.Store,
+		sessions:            d.Sessions,
+		clock:               d.Clock,
+		telemetry:           d.Telemetry,
+		defaultHarness:      defaultHarness,
+		logger:              d.Logger,
+		onModelScopeChanged: d.OnModelScopeChanged,
 	}
 	if s.clock == nil {
 		s.clock = time.Now
@@ -281,6 +286,7 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		if err := m.store.UpsertWorkspaceProject(ctx, row, repos); err != nil {
 			return Project{}, apierr.Internal("PROJECT_ADD_FAILED", "Failed to register workspace project")
 		}
+		m.modelScopeChanged(row.ID)
 		m.emitProjectAdded(ctx, row, projectCountBefore == 0)
 		p := m.projectFromRow(ctx, row)
 		p.WorkspaceRepos = workspaceReposFromRecords(repos)
@@ -302,6 +308,7 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 	if err := m.store.UpsertProject(ctx, row); err != nil {
 		return Project{}, apierr.Internal("PROJECT_ADD_FAILED", "Failed to register project")
 	}
+	m.modelScopeChanged(row.ID)
 	m.emitProjectAdded(ctx, row, projectCountBefore == 0)
 	return m.projectFromRow(ctx, row), nil
 }
@@ -630,6 +637,7 @@ func (m *Service) UpdateSettings(ctx context.Context, id domain.ProjectID, in Up
 	}
 	row.DisplayName = displayName
 	row.Config = in.Config
+	m.modelScopeChanged(row.ID)
 	return m.projectFromRow(ctx, row), nil
 }
 
@@ -681,7 +689,14 @@ func (m *Service) EnsureDefaultScratchProject(ctx context.Context, scratchPath s
 	if err := m.store.UpsertProject(ctx, row); err != nil {
 		return Project{}, apierr.Internal("SCRATCH_PROJECT_SEED_FAILED", "Failed to create scratch project")
 	}
+	m.modelScopeChanged(row.ID)
 	return m.projectFromRow(ctx, row), nil
+}
+
+func (m *Service) modelScopeChanged(projectID string) {
+	if m.onModelScopeChanged != nil {
+		m.onModelScopeChanged(projectID)
+	}
 }
 
 // SetConfig replaces the project's stored config. The typed config is validated
@@ -712,6 +727,7 @@ func (m *Service) SetConfig(ctx context.Context, id domain.ProjectID, in SetConf
 	if err := m.store.UpsertProject(ctx, row); err != nil {
 		return Project{}, apierr.Internal("PROJECT_CONFIG_UPDATE_FAILED", "Failed to update project config")
 	}
+	m.modelScopeChanged(row.ID)
 	return m.projectFromRow(ctx, row), nil
 }
 

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -1199,6 +1199,32 @@ func TestManager_AddAllocatesUniqueIDForCollidingDerivedIDs(t *testing.T) {
 	})
 }
 
+func TestManager_InvalidatesModelScopeAfterProjectAndConfigWrites(t *testing.T) {
+	configureCommitter(t)
+	store, err := sqlitetest.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	var changed []string
+	m := project.NewWithDeps(project.Deps{
+		Store: store,
+		OnModelScopeChanged: func(projectID string) {
+			changed = append(changed, projectID)
+		},
+	})
+	created, err := m.Add(context.Background(), project.AddInput{Path: gitRepo(t), ProjectID: ptr("catalog-scope")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.SetConfig(context.Background(), domain.ProjectID(created.ID), project.SetConfigInput{Config: domain.ProjectConfig{Env: map[string]string{"MODEL_PROFILE": "new"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"catalog-scope", "catalog-scope"}; !reflect.DeepEqual(changed, want) {
+		t.Fatalf("changed scopes = %v, want %v", changed, want)
+	}
+}
+
 // gitRepoWithOrigin creates a real git repo with an `origin` remote pointing
 // at `originURL`. Used to assert project.Add captures the origin at add time.
 func gitRepoWithOrigin(t *testing.T, originURL string) string {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -1217,7 +1217,7 @@ func TestManager_InvalidatesModelScopeAfterProjectAndConfigWrites(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.SetConfig(context.Background(), domain.ProjectID(created.ID), project.SetConfigInput{Config: domain.ProjectConfig{Env: map[string]string{"MODEL_PROFILE": "new"}}}); err != nil {
+	if _, err := m.SetConfig(context.Background(), created.ID, project.SetConfigInput{Config: domain.ProjectConfig{Env: map[string]string{"MODEL_PROFILE": "new"}}}); err != nil {
 		t.Fatal(err)
 	}
 	if want := []string{"catalog-scope", "catalog-scope"}; !reflect.DeepEqual(changed, want) {

--- a/backend/internal/storage/sqlite/gen/agent_models.sql.go
+++ b/backend/internal/storage/sqlite/gen/agent_models.sql.go
@@ -7,11 +7,14 @@ package gen
 
 import (
 	"context"
+	"database/sql"
 	"time"
 )
 
 const getAgentModelCatalog = `-- name: GetAgentModelCatalog :one
-SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at
+SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+       metadata_json, input_fingerprint, last_success_at, refresh_state,
+       refresh_error, retry_count, retry_at, generation
 FROM agent_model_catalog
 WHERE agent_id = ? AND project_id = ?
 `
@@ -31,12 +34,68 @@ func (q *Queries) GetAgentModelCatalog(ctx context.Context, arg GetAgentModelCat
 		&i.CatalogJson,
 		&i.Source,
 		&i.FetchedAt,
+		&i.MetadataJson,
+		&i.InputFingerprint,
+		&i.LastSuccessAt,
+		&i.RefreshState,
+		&i.RefreshError,
+		&i.RetryCount,
+		&i.RetryAt,
+		&i.Generation,
 	)
 	return i, err
 }
 
+const listAgentModelCatalogs = `-- name: ListAgentModelCatalogs :many
+SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+       metadata_json, input_fingerprint, last_success_at, refresh_state,
+       refresh_error, retry_count, retry_at, generation
+FROM agent_model_catalog
+ORDER BY project_id, agent_id
+`
+
+func (q *Queries) ListAgentModelCatalogs(ctx context.Context) ([]AgentModelCatalog, error) {
+	rows, err := q.db.QueryContext(ctx, listAgentModelCatalogs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentModelCatalog{}
+	for rows.Next() {
+		var i AgentModelCatalog
+		if err := rows.Scan(
+			&i.AgentID,
+			&i.ProjectID,
+			&i.BinaryVersion,
+			&i.CatalogJson,
+			&i.Source,
+			&i.FetchedAt,
+			&i.MetadataJson,
+			&i.InputFingerprint,
+			&i.LastSuccessAt,
+			&i.RefreshState,
+			&i.RefreshError,
+			&i.RetryCount,
+			&i.RetryAt,
+			&i.Generation,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentModelCatalogsByAgent = `-- name: ListAgentModelCatalogsByAgent :many
-SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at
+SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+       metadata_json, input_fingerprint, last_success_at, refresh_state,
+       refresh_error, retry_count, retry_at, generation
 FROM agent_model_catalog
 WHERE agent_id = ?
 ORDER BY project_id
@@ -58,6 +117,14 @@ func (q *Queries) ListAgentModelCatalogsByAgent(ctx context.Context, agentID str
 			&i.CatalogJson,
 			&i.Source,
 			&i.FetchedAt,
+			&i.MetadataJson,
+			&i.InputFingerprint,
+			&i.LastSuccessAt,
+			&i.RefreshState,
+			&i.RefreshError,
+			&i.RetryCount,
+			&i.RetryAt,
+			&i.Generation,
 		); err != nil {
 			return nil, err
 		}
@@ -74,22 +141,41 @@ func (q *Queries) ListAgentModelCatalogsByAgent(ctx context.Context, agentID str
 
 const upsertAgentModelCatalog = `-- name: UpsertAgentModelCatalog :exec
 INSERT INTO agent_model_catalog (
-    agent_id, project_id, binary_version, catalog_json, source, fetched_at
-) VALUES (?, ?, ?, ?, ?, ?)
+    agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+    metadata_json, input_fingerprint, last_success_at, refresh_state,
+    refresh_error, retry_count, retry_at, generation
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(agent_id, project_id) DO UPDATE SET
     binary_version = excluded.binary_version,
     catalog_json = excluded.catalog_json,
     source = excluded.source,
-    fetched_at = excluded.fetched_at
+    fetched_at = excluded.fetched_at,
+    metadata_json = excluded.metadata_json,
+    input_fingerprint = excluded.input_fingerprint,
+    last_success_at = excluded.last_success_at,
+    refresh_state = excluded.refresh_state,
+    refresh_error = excluded.refresh_error,
+    retry_count = excluded.retry_count,
+    retry_at = excluded.retry_at,
+    generation = excluded.generation
+WHERE excluded.generation >= agent_model_catalog.generation
 `
 
 type UpsertAgentModelCatalogParams struct {
-	AgentID       string
-	ProjectID     string
-	BinaryVersion string
-	CatalogJson   string
-	Source        string
-	FetchedAt     time.Time
+	AgentID          string
+	ProjectID        string
+	BinaryVersion    string
+	CatalogJson      string
+	Source           string
+	FetchedAt        time.Time
+	MetadataJson     string
+	InputFingerprint string
+	LastSuccessAt    sql.NullTime
+	RefreshState     string
+	RefreshError     string
+	RetryCount       int64
+	RetryAt          sql.NullTime
+	Generation       int64
 }
 
 func (q *Queries) UpsertAgentModelCatalog(ctx context.Context, arg UpsertAgentModelCatalogParams) error {
@@ -100,6 +186,14 @@ func (q *Queries) UpsertAgentModelCatalog(ctx context.Context, arg UpsertAgentMo
 		arg.CatalogJson,
 		arg.Source,
 		arg.FetchedAt,
+		arg.MetadataJson,
+		arg.InputFingerprint,
+		arg.LastSuccessAt,
+		arg.RefreshState,
+		arg.RefreshError,
+		arg.RetryCount,
+		arg.RetryAt,
+		arg.Generation,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -26,12 +26,20 @@ type AgentInstallJob struct {
 }
 
 type AgentModelCatalog struct {
-	AgentID       string
-	ProjectID     string
-	BinaryVersion string
-	CatalogJson   string
-	Source        string
-	FetchedAt     time.Time
+	AgentID          string
+	ProjectID        string
+	BinaryVersion    string
+	CatalogJson      string
+	Source           string
+	FetchedAt        time.Time
+	MetadataJson     string
+	InputFingerprint string
+	LastSuccessAt    sql.NullTime
+	RefreshState     string
+	RefreshError     string
+	RetryCount       int64
+	RetryAt          sql.NullTime
+	Generation       int64
 }
 
 type AgentNativeSession struct {

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -133,6 +133,7 @@ var shippedMigrations = map[int64]string{
 	126: "0126_canonical_repository_identity.sql",
 	127: "0127_session_permissions.sql",
 	128: "0128_pr_author_avatar_url.sql",
+	129: "0129_agent_model_catalog_cache_state.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0129_agent_model_catalog_cache_state.sql
+++ b/backend/internal/storage/sqlite/migrations/0129_agent_model_catalog_cache_state.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE agent_model_catalog ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'
+    CHECK (json_valid(metadata_json));
+ALTER TABLE agent_model_catalog ADD COLUMN input_fingerprint TEXT NOT NULL DEFAULT '';
+ALTER TABLE agent_model_catalog ADD COLUMN last_success_at TIMESTAMP;
+ALTER TABLE agent_model_catalog ADD COLUMN refresh_state TEXT NOT NULL DEFAULT 'idle'
+    CHECK (refresh_state IN ('idle', 'queued', 'refreshing', 'error'));
+ALTER TABLE agent_model_catalog ADD COLUMN refresh_error TEXT NOT NULL DEFAULT '';
+ALTER TABLE agent_model_catalog ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE agent_model_catalog ADD COLUMN retry_at TIMESTAMP;
+ALTER TABLE agent_model_catalog ADD COLUMN generation INTEGER NOT NULL DEFAULT 0;
+
+CREATE TRIGGER agent_model_catalog_cdc_insert
+AFTER INSERT ON agent_model_catalog
+WHEN NEW.project_id <> '' AND EXISTS (SELECT 1 FROM projects WHERE id = NEW.project_id)
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'session_updated',
+        json_object('kind', 'model_catalog', 'agentId', NEW.agent_id, 'projectId', NEW.project_id),
+        datetime('now'));
+END;
+
+CREATE TRIGGER agent_model_catalog_cdc_update
+AFTER UPDATE ON agent_model_catalog
+WHEN NEW.project_id <> '' AND EXISTS (SELECT 1 FROM projects WHERE id = NEW.project_id)
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NULL, 'session_updated',
+        json_object('kind', 'model_catalog', 'agentId', NEW.agent_id, 'projectId', NEW.project_id),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS agent_model_catalog_cdc_update;
+DROP TRIGGER IF EXISTS agent_model_catalog_cdc_insert;
+ALTER TABLE agent_model_catalog DROP COLUMN generation;
+ALTER TABLE agent_model_catalog DROP COLUMN retry_at;
+ALTER TABLE agent_model_catalog DROP COLUMN retry_count;
+ALTER TABLE agent_model_catalog DROP COLUMN refresh_error;
+ALTER TABLE agent_model_catalog DROP COLUMN refresh_state;
+ALTER TABLE agent_model_catalog DROP COLUMN last_success_at;
+ALTER TABLE agent_model_catalog DROP COLUMN input_fingerprint;
+ALTER TABLE agent_model_catalog DROP COLUMN metadata_json;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/agent_models.sql
+++ b/backend/internal/storage/sqlite/queries/agent_models.sql
@@ -1,20 +1,42 @@
 -- name: GetAgentModelCatalog :one
-SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at
+SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+       metadata_json, input_fingerprint, last_success_at, refresh_state,
+       refresh_error, retry_count, retry_at, generation
 FROM agent_model_catalog
 WHERE agent_id = ? AND project_id = ?;
 
 -- name: ListAgentModelCatalogsByAgent :many
-SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at
+SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+       metadata_json, input_fingerprint, last_success_at, refresh_state,
+       refresh_error, retry_count, retry_at, generation
 FROM agent_model_catalog
 WHERE agent_id = ?
 ORDER BY project_id;
 
 -- name: UpsertAgentModelCatalog :exec
 INSERT INTO agent_model_catalog (
-    agent_id, project_id, binary_version, catalog_json, source, fetched_at
-) VALUES (?, ?, ?, ?, ?, ?)
+    agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+    metadata_json, input_fingerprint, last_success_at, refresh_state,
+    refresh_error, retry_count, retry_at, generation
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(agent_id, project_id) DO UPDATE SET
     binary_version = excluded.binary_version,
     catalog_json = excluded.catalog_json,
     source = excluded.source,
-    fetched_at = excluded.fetched_at;
+    fetched_at = excluded.fetched_at,
+    metadata_json = excluded.metadata_json,
+    input_fingerprint = excluded.input_fingerprint,
+    last_success_at = excluded.last_success_at,
+    refresh_state = excluded.refresh_state,
+    refresh_error = excluded.refresh_error,
+    retry_count = excluded.retry_count,
+    retry_at = excluded.retry_at,
+    generation = excluded.generation
+WHERE excluded.generation >= agent_model_catalog.generation;
+
+-- name: ListAgentModelCatalogs :many
+SELECT agent_id, project_id, binary_version, catalog_json, source, fetched_at,
+       metadata_json, input_fingerprint, last_success_at, refresh_state,
+       refresh_error, retry_count, retry_at, generation
+FROM agent_model_catalog
+ORDER BY project_id, agent_id;

--- a/backend/internal/storage/sqlite/store/agent_model_catalog_store.go
+++ b/backend/internal/storage/sqlite/store/agent_model_catalog_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/gen"
@@ -22,14 +23,7 @@ func (s *Store) GetAgentModelCatalog(ctx context.Context, agentID, projectID str
 	if err != nil {
 		return ports.CachedAgentModelCatalog{}, false, fmt.Errorf("get agent model catalog %s: %w", agentID, err)
 	}
-	return ports.CachedAgentModelCatalog{
-		AgentID:       row.AgentID,
-		ProjectID:     row.ProjectID,
-		BinaryVersion: row.BinaryVersion,
-		CatalogJSON:   row.CatalogJson,
-		Source:        row.Source,
-		FetchedAt:     row.FetchedAt,
-	}, true, nil
+	return cachedAgentModelCatalog(row), true, nil
 }
 
 // ListAgentModelCatalogsByAgent returns every previously discovered project
@@ -41,29 +35,72 @@ func (s *Store) ListAgentModelCatalogsByAgent(ctx context.Context, agentID strin
 	}
 	records := make([]ports.CachedAgentModelCatalog, 0, len(rows))
 	for _, row := range rows {
-		records = append(records, ports.CachedAgentModelCatalog{
-			AgentID:       row.AgentID,
-			ProjectID:     row.ProjectID,
-			BinaryVersion: row.BinaryVersion,
-			CatalogJSON:   row.CatalogJson,
-			Source:        row.Source,
-			FetchedAt:     row.FetchedAt,
-		})
+		records = append(records, cachedAgentModelCatalog(row))
+	}
+	return records, nil
+}
+
+// ListAgentModelCatalogs returns every known scope for prioritized startup
+// prefetch. It never creates speculative scopes.
+func (s *Store) ListAgentModelCatalogs(ctx context.Context) ([]ports.CachedAgentModelCatalog, error) {
+	rows, err := s.qr.ListAgentModelCatalogs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list agent model catalogs: %w", err)
+	}
+	records := make([]ports.CachedAgentModelCatalog, 0, len(rows))
+	for _, row := range rows {
+		records = append(records, cachedAgentModelCatalog(row))
 	}
 	return records, nil
 }
 
 // UpsertAgentModelCatalog stores the latest successfully discovered catalog.
 func (s *Store) UpsertAgentModelCatalog(ctx context.Context, record ports.CachedAgentModelCatalog) error {
+	legacyRecord := record.RefreshState == "" && record.Generation == 0
+	if record.MetadataJSON == "" {
+		record.MetadataJSON = "{}"
+	}
+	if record.InputFingerprint == "" {
+		record.InputFingerprint = record.BinaryVersion
+	}
+	if record.RefreshState == "" {
+		record.RefreshState = "idle"
+	}
+	if legacyRecord && record.LastSuccessAt.IsZero() {
+		record.LastSuccessAt = record.FetchedAt
+	}
 	if err := s.qw.UpsertAgentModelCatalog(ctx, gen.UpsertAgentModelCatalogParams{
-		AgentID:       record.AgentID,
-		ProjectID:     record.ProjectID,
-		BinaryVersion: record.BinaryVersion,
-		CatalogJson:   record.CatalogJSON,
-		Source:        record.Source,
-		FetchedAt:     record.FetchedAt.UTC(),
+		AgentID:          record.AgentID,
+		ProjectID:        record.ProjectID,
+		BinaryVersion:    record.BinaryVersion,
+		CatalogJson:      record.CatalogJSON,
+		Source:           record.Source,
+		FetchedAt:        record.FetchedAt.UTC(),
+		MetadataJson:     record.MetadataJSON,
+		InputFingerprint: record.InputFingerprint,
+		LastSuccessAt:    nullableTime(record.LastSuccessAt),
+		RefreshState:     record.RefreshState,
+		RefreshError:     record.RefreshError,
+		RetryCount:       record.RetryCount,
+		RetryAt:          nullableTime(record.RetryAt),
+		Generation:       record.Generation,
 	}); err != nil {
 		return fmt.Errorf("upsert agent model catalog %s: %w", record.AgentID, err)
 	}
 	return nil
+}
+
+func cachedAgentModelCatalog(row gen.AgentModelCatalog) ports.CachedAgentModelCatalog {
+	return ports.CachedAgentModelCatalog{
+		AgentID: row.AgentID, ProjectID: row.ProjectID, BinaryVersion: row.BinaryVersion,
+		CatalogJSON: row.CatalogJson, Source: row.Source, FetchedAt: row.FetchedAt,
+		MetadataJSON: row.MetadataJson, InputFingerprint: row.InputFingerprint,
+		LastSuccessAt: row.LastSuccessAt.Time, RefreshState: row.RefreshState,
+		RefreshError: row.RefreshError, RetryCount: row.RetryCount,
+		RetryAt: row.RetryAt.Time, Generation: row.Generation,
+	}
+}
+
+func nullableTime(value time.Time) sql.NullTime {
+	return sql.NullTime{Time: value.UTC(), Valid: !value.IsZero()}
 }

--- a/backend/internal/storage/sqlite/store/agent_model_catalog_store_test.go
+++ b/backend/internal/storage/sqlite/store/agent_model_catalog_store_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -28,5 +30,57 @@ func TestListAgentModelCatalogsByAgentReturnsOnlyRequestedScopes(t *testing.T) {
 	}
 	if len(records) != 2 || records[0].ProjectID != "project-a" || records[1].ProjectID != "project-b" {
 		t.Fatalf("records = %#v", records)
+	}
+}
+
+func TestAgentModelCatalogPersistsRefreshMetadataAndRejectsStaleGeneration(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	newer := ports.CachedAgentModelCatalog{
+		AgentID: "codex", ProjectID: "project-a", BinaryVersion: "fp-2",
+		CatalogJSON: `{"models":[{"id":"new"}]}`, Source: "app-server", FetchedAt: now,
+		MetadataJSON: `{"binary":"/bin/codex"}`, InputFingerprint: "fp-2", LastSuccessAt: now,
+		RefreshState: "error", RefreshError: "offline", RetryCount: 2,
+		RetryAt: now.Add(time.Minute), Generation: 20,
+	}
+	if err := store.UpsertAgentModelCatalog(ctx, newer); err != nil {
+		t.Fatal(err)
+	}
+	older := newer
+	older.CatalogJSON = `{"models":[{"id":"old"}]}`
+	older.Generation = 19
+	if err := store.UpsertAgentModelCatalog(ctx, older); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := store.GetAgentModelCatalog(ctx, "codex", "project-a")
+	if err != nil || !ok {
+		t.Fatalf("get = (%#v, %v, %v)", got, ok, err)
+	}
+	if got.Generation != 20 || got.CatalogJSON != newer.CatalogJSON || got.InputFingerprint != "fp-2" || got.LastSuccessAt != now || got.RefreshError != "offline" {
+		t.Fatalf("catalog = %#v, want newer generation and metadata", got)
+	}
+	all, err := store.ListAgentModelCatalogs(ctx)
+	if err != nil || len(all) != 1 {
+		t.Fatalf("list all = (%#v, %v)", all, err)
+	}
+}
+
+func TestAgentModelCatalogWriteEmitsProjectScopedDatabaseChange(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "project-a", Path: t.TempDir(), RegisteredAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertAgentModelCatalog(ctx, ports.CachedAgentModelCatalog{AgentID: "codex", ProjectID: "project-a", CatalogJSON: `{}`, FetchedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.EventsAfter(ctx, 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Type != cdc.EventSessionUpdated || events[0].ProjectID != "project-a" || string(events[0].Payload) != `{"kind":"model_catalog","agentId":"codex","projectId":"project-a"}` {
+		t.Fatalf("events = %#v", events)
 	}
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2481,8 +2481,19 @@ export interface components {
             customModelEntry: "none" | "direct" | "configured";
             /** Format: date-time */
             fetchedAt: string;
+            inputFingerprint?: string;
+            /** Format: date-time */
+            lastSuccessAt?: null | string;
+            metadata?: {
+                [key: string]: string;
+            };
             models: components["schemas"]["AgentModelInfo"][];
+            refreshError?: string;
             refreshRecommended?: boolean;
+            /** @enum {string} */
+            refreshState?: "idle" | "queued" | "refreshing" | "error";
+            /** Format: date-time */
+            retryAt?: string;
             /** @enum {string} */
             selectionMode: "catalog" | "text" | "mode";
             source: string;

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2493,7 +2493,7 @@ export interface components {
             /** @enum {string} */
             refreshState?: "idle" | "queued" | "refreshing" | "error";
             /** Format: date-time */
-            retryAt?: string;
+            retryAt?: null | string;
             /** @enum {string} */
             selectionMode: "catalog" | "text" | "mode";
             source: string;

--- a/frontend/src/renderer/components/AgentModelPicker.tsx
+++ b/frontend/src/renderer/components/AgentModelPicker.tsx
@@ -132,8 +132,12 @@ export function AgentModelPicker({
 			customModelEntry={customModelEntry}
 			agentLabel={agentLabel}
 			onRefresh={refreshCatalog}
+			refreshing={catalog?.refreshState === "queued" || catalog?.refreshState === "refreshing"}
+			lastSuccessAt={catalog?.lastSuccessAt}
+			refreshError={catalog?.refreshError}
+			retryAt={catalog?.retryAt}
 			disabled={disabled || agentId === ""}
-			emptyLabel={query.isFetching ? t("settings.models.loading") : noOverrideLabel}
+			emptyLabel={query.isFetching && !catalog ? t("settings.models.loading") : noOverrideLabel}
 			onChange={selectCatalogModel}
 			onCustom={selectCustomModel}
 			compact

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -723,7 +723,11 @@ function AgentModelField({
 						customModelEntry={customModelEntry}
 						agentLabel={agentId}
 						onRefresh={refreshCatalog}
-						disabled={query.isFetching || agentId === ""}
+						refreshing={catalog?.refreshState === "queued" || catalog?.refreshState === "refreshing"}
+						lastSuccessAt={catalog?.lastSuccessAt}
+						refreshError={catalog?.refreshError}
+						retryAt={catalog?.retryAt}
+						disabled={(query.isFetching && !catalog) || agentId === ""}
 						onChange={selectCatalogModel}
 						onCustom={selectCustomModel}
 						triggerClassName="justify-end"

--- a/frontend/src/renderer/components/TaskComposer.tsx
+++ b/frontend/src/renderer/components/TaskComposer.tsx
@@ -547,8 +547,12 @@ function TaskModelPicker({
 			customModelEntry={customModelEntry}
 			agentLabel={agentLabel}
 			onRefresh={onRefresh}
+			refreshing={catalog?.refreshState === "queued" || catalog?.refreshState === "refreshing"}
+			lastSuccessAt={catalog?.lastSuccessAt}
+			refreshError={catalog?.refreshError}
+			retryAt={catalog?.retryAt}
 			disabled={disabled || agentId === ""}
-			emptyLabel={fetching ? t("settings.models.loading") : noOverrideLabel}
+			emptyLabel={fetching && !catalog ? t("settings.models.loading") : noOverrideLabel}
 			onChange={selectCatalogModel}
 			onCustom={selectCustomModel}
 			compact

--- a/frontend/src/renderer/components/settings/AgentModelCombobox.test.tsx
+++ b/frontend/src/renderer/components/settings/AgentModelCombobox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentModelCombobox, buildModelSearchIndex, searchModelIndex } from "./AgentModelCombobox";
@@ -148,6 +148,57 @@ describe("AgentModelCombobox", () => {
 		expect(screen.getByText("Configure the model in OpenCode, then refresh.")).toBeInTheDocument();
 		await userEvent.click(screen.getByRole("button", { name: "Refresh models" }));
 		expect(onRefresh).toHaveBeenCalledOnce();
+	});
+
+	it("keeps refresh visible beside search and prevents duplicate scope refreshes", async () => {
+		let finish!: () => void;
+		const onRefresh = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));
+		renderCombobox(Array.from({ length: 10 }, (_, index) => ({ id: `model-${index}`, label: `Model ${index}` })), {
+			onRefresh,
+			lastSuccessAt: "2026-09-07T08:00:00Z",
+		});
+		await userEvent.click(screen.getByRole("button", { name: "Worker model" }));
+		const search = screen.getByRole("searchbox", { name: "Search worker model" });
+		const refresh = screen.getByRole("button", { name: "Refresh models" });
+		expect(search.parentElement?.parentElement).toContainElement(refresh);
+		expect(screen.getByText(/Last updated/)).toBeInTheDocument();
+		await userEvent.click(refresh);
+		const busy = screen.getByRole("button", { name: /Refreshing/ });
+		expect(busy).toBeDisabled();
+		await userEvent.click(busy);
+		expect(onRefresh).toHaveBeenCalledOnce();
+		finish();
+		await waitFor(() => expect(screen.getByRole("button", { name: "Refresh models" })).toBeEnabled());
+	});
+
+	it("shows a compact retryable persisted refresh error", async () => {
+		const onRefresh = vi.fn();
+		renderCombobox([{ id: "cached", label: "Cached model" }], {
+			onRefresh,
+			refreshError: "Provider temporarily unavailable",
+			retryAt: "2026-09-07T09:30:00Z",
+		});
+		await userEvent.click(screen.getByRole("button", { name: "Worker model" }));
+		const retry = screen.getByRole("button", { name: /Retry refresh/ });
+		expect(retry).toHaveAttribute("title", "Provider temporarily unavailable");
+		await userEvent.click(retry);
+		expect(onRefresh).toHaveBeenCalledOnce();
+	});
+
+	it("preserves a saved selection while a refreshed catalog no longer lists it", async () => {
+		const view = renderCombobox([{ id: "saved-model", label: "Saved model" }], { value: "saved-model" });
+		expect(screen.getByRole("button", { name: "Worker model" })).toHaveTextContent("Saved model");
+		view.rerender(
+			<AgentModelCombobox
+				aria-label="Worker model"
+				value="saved-model"
+				models={[{ id: "new-model", label: "New model" }]}
+				allowCustom
+				onChange={view.onChange}
+				onCustom={view.onCustom}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Worker model" })).toHaveTextContent("saved-model");
 	});
 
 	it("does not expose free text for fixed model catalogs", async () => {

--- a/frontend/src/renderer/components/settings/AgentModelCombobox.test.tsx
+++ b/frontend/src/renderer/components/settings/AgentModelCombobox.test.tsx
@@ -185,6 +185,15 @@ describe("AgentModelCombobox", () => {
 		expect(onRefresh).toHaveBeenCalledOnce();
 	});
 
+	it("does not display a retry time when no retry is scheduled", async () => {
+		renderCombobox([{ id: "cached", label: "Cached model" }], {
+			refreshError: "Retries exhausted",
+			retryAt: null,
+		});
+		await userEvent.click(screen.getByRole("button", { name: "Worker model" }));
+		expect(screen.getByRole("button", { name: /Retry refresh/ })).not.toHaveTextContent("·");
+	});
+
 	it("preserves a saved selection while a refreshed catalog no longer lists it", async () => {
 		const view = renderCombobox([{ id: "saved-model", label: "Saved model" }], { value: "saved-model" });
 		expect(screen.getByRole("button", { name: "Worker model" })).toHaveTextContent("Saved model");

--- a/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
+++ b/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Search } from "lucide-react";
+import { ChevronDown, Loader2, RefreshCw, Search } from "lucide-react";
 import { type ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AgentModelCatalog } from "../../hooks/useAgentModelsQuery";
@@ -51,6 +51,10 @@ export function AgentModelCombobox({
 	customModelEntry,
 	agentLabel,
 	onRefresh,
+	refreshing = false,
+	lastSuccessAt,
+	refreshError,
+	retryAt,
 	onChange,
 	onCustom,
 	emptyLabel,
@@ -69,6 +73,10 @@ export function AgentModelCombobox({
 	customModelEntry?: AgentModelCatalog["customModelEntry"];
 	agentLabel?: string;
 	onRefresh?: () => void | Promise<void>;
+	refreshing?: boolean;
+	lastSuccessAt?: string | null;
+	refreshError?: string;
+	retryAt?: string;
 	onChange: (value: string) => void;
 	onCustom: (value: string) => void;
 	/** Names what happens with no override, e.g. "Use codex's default". */
@@ -94,6 +102,7 @@ export function AgentModelCombobox({
 	const [search, setSearch] = useState("");
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [refreshFailed, setRefreshFailed] = useState(false);
+	const [refreshingLocal, setRefreshingLocal] = useState(false);
 	const [sessionRecentModels, setSessionRecentModels] = useState<Record<string, string[]>>({});
 	const recentKey = recentScope ?? "";
 	const storedRecentModels = useMemo(() => readRecentModels(recentScope), [recentScope]);
@@ -162,6 +171,13 @@ export function AgentModelCombobox({
 		}
 		onChange(modelID);
 	};
+	const refreshBusy = refreshing || refreshingLocal;
+	const runRefresh = () => {
+		if (!onRefresh || refreshBusy) return;
+		setRefreshFailed(false);
+		setRefreshingLocal(true);
+		void Promise.resolve(onRefresh()).catch(() => setRefreshFailed(true)).finally(() => setRefreshingLocal(false));
+	};
 
 	return (
 		<DropdownMenu
@@ -198,24 +214,74 @@ export function AgentModelCombobox({
 				onCloseAutoFocus={onCloseAutoFocus}
 				className="settings-menu-surface max-h-select-menu-max! w-[min(22rem,calc(100vw-2rem))] overflow-hidden! rounded-(--radius-settings-panel) border-settings-menu bg-settings-menu"
 			>
-				{showSearch && (
-					<div className="relative shrink-0 p-1" onKeyDown={(event) => event.stopPropagation()}>
-						<Search
-							className="pointer-events-none absolute left-3.5 top-1/2 size-icon-sm -translate-y-1/2 text-settings-muted"
-							aria-hidden="true"
-						/>
-						<input
-							type="search"
-							aria-label={t("settings.models.searchAria", { label: ariaLabel.toLocaleLowerCase() })}
-							value={search}
-							onChange={(event) => setSearch(event.target.value)}
-							placeholder={t(
-								hasMultipleProviders
-									? "settings.models.searchModelsOrProvidersPlaceholder"
-									: "settings.models.searchPlaceholder",
-							)}
-							className="menu-search-input pl-8!"
-						/>
+				{(showSearch || onRefresh) && (
+					<div className="flex shrink-0 items-center gap-1 p-1" onKeyDown={(event) => event.stopPropagation()}>
+						{showSearch && (
+							<div className="relative min-w-0 flex-1">
+								<Search
+									className="pointer-events-none absolute left-3.5 top-1/2 size-icon-sm -translate-y-1/2 text-settings-muted"
+									aria-hidden="true"
+								/>
+								<input
+									type="search"
+									aria-label={t("settings.models.searchAria", { label: ariaLabel.toLocaleLowerCase() })}
+									value={search}
+									onChange={(event) => setSearch(event.target.value)}
+									placeholder={t(
+										hasMultipleProviders
+											? "settings.models.searchModelsOrProvidersPlaceholder"
+											: "settings.models.searchPlaceholder",
+									)}
+									className="menu-search-input pl-8!"
+								/>
+							</div>
+						)}
+						{onRefresh && (
+							<button
+								type="button"
+								className="flex size-8 shrink-0 items-center justify-center rounded-md text-settings-muted hover:bg-settings-menu-selected hover:text-settings-label disabled:cursor-not-allowed disabled:opacity-50"
+								aria-label={refreshBusy ? t("settings.models.refreshing") : t("settings.models.refresh")}
+								disabled={refreshBusy}
+								onClick={(event) => {
+									event.stopPropagation();
+									runRefresh();
+								}}
+							>
+								{refreshBusy ? (
+									<Loader2 className="size-icon-sm animate-spin" aria-hidden="true" />
+								) : (
+									<RefreshCw className="size-icon-sm" aria-hidden="true" />
+								)}
+							</button>
+						)}
+					</div>
+				)}
+				{(lastSuccessAt || refreshError || refreshFailed) && (
+					<div className="flex items-center gap-2 px-2 pb-1 text-xs text-settings-muted" aria-live="polite">
+						{lastSuccessAt && (
+							<span>
+								{t("settings.models.lastSuccess", {
+									time: new Date(lastSuccessAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+								})}
+							</span>
+						)}
+						{(refreshError || refreshFailed) && (
+							<button
+								type="button"
+								className="truncate text-warning underline underline-offset-2"
+								title={refreshError}
+								onClick={(event) => {
+									event.stopPropagation();
+									runRefresh();
+								}}
+								disabled={refreshBusy}
+							>
+								{t("settings.models.retry")}
+								{retryAt
+									? ` · ${new Date(retryAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
+									: ""}
+							</button>
+						)}
 					</div>
 				)}
 
@@ -294,20 +360,6 @@ export function AgentModelCombobox({
 												})
 											: t("settings.models.unavailable")}
 									</p>
-									{onRefresh && (
-										<button
-											type="button"
-											className="text-settings-label underline underline-offset-2"
-											onClick={(event) => {
-												event.stopPropagation();
-												setRefreshFailed(false);
-												void Promise.resolve(onRefresh()).catch(() => setRefreshFailed(true));
-											}}
-										>
-											{t("settings.models.refresh")}
-										</button>
-									)}
-									{refreshFailed && <p className="text-warning">{t("settings.models.refreshFailed")}</p>}
 								</div>
 							</>
 						)}

--- a/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
+++ b/frontend/src/renderer/components/settings/AgentModelCombobox.tsx
@@ -76,7 +76,7 @@ export function AgentModelCombobox({
 	refreshing?: boolean;
 	lastSuccessAt?: string | null;
 	refreshError?: string;
-	retryAt?: string;
+	retryAt?: string | null;
 	onChange: (value: string) => void;
 	onCustom: (value: string) => void;
 	/** Names what happens with no override, e.g. "Use codex's default". */

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -887,6 +887,8 @@
 	"settings.models.refreshAria": "Liste für {{label}} aktualisieren",
 	"settings.models.refreshFailed": "Modelle konnten nicht aktualisiert werden.",
 	"settings.models.refresh": "Modelle aktualisieren",
+	"settings.models.lastSuccess": "Zuletzt aktualisiert: {{time}}",
+	"settings.models.retry": "Aktualisierung wiederholen",
 	"settings.models.searchAria": "{{label}} durchsuchen",
 	"settings.models.searchPlaceholder": "Modelle durchsuchen…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "Modelle oder Anbieter durchsuchen…",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1001,6 +1001,8 @@
 	"settings.models.refreshAria": "Refresh {{label}} list",
 	"settings.models.refreshFailed": "Could not refresh models.",
 	"settings.models.refresh": "Refresh models",
+	"settings.models.lastSuccess": "Last updated {{time}}",
+	"settings.models.retry": "Retry refresh",
 	"settings.models.searchAria": "Search {{label}}",
 	"settings.models.searchPlaceholder": "Search models…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "Search models or providers…",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -902,6 +902,8 @@
 	"settings.models.refreshAria": "Actualizar lista de {{label}}",
 	"settings.models.refreshFailed": "No se pudieron actualizar los modelos.",
 	"settings.models.refresh": "Actualizar modelos",
+	"settings.models.lastSuccess": "Última actualización: {{time}}",
+	"settings.models.retry": "Reintentar actualización",
 	"settings.models.searchAria": "Buscar {{label}}",
 	"settings.models.searchPlaceholder": "Buscar modelos…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "Buscar modelos o proveedores…",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -902,6 +902,8 @@
 	"settings.models.refreshAria": "Actualiser la liste de {{label}}",
 	"settings.models.refreshFailed": "Impossible d’actualiser les modèles.",
 	"settings.models.refresh": "Actualiser les modèles",
+	"settings.models.lastSuccess": "Dernière mise à jour : {{time}}",
+	"settings.models.retry": "Réessayer l’actualisation",
 	"settings.models.searchAria": "Rechercher {{label}}",
 	"settings.models.searchPlaceholder": "Rechercher des modèles…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "Rechercher des modèles ou des fournisseurs…",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -887,6 +887,8 @@
 	"settings.models.refreshAria": "{{label}}の一覧を更新",
 	"settings.models.refreshFailed": "モデルを更新できませんでした。",
 	"settings.models.refresh": "モデルを更新",
+	"settings.models.lastSuccess": "最終更新: {{time}}",
+	"settings.models.retry": "更新を再試行",
 	"settings.models.searchAria": "{{label}}を検索",
 	"settings.models.searchPlaceholder": "モデルを検索…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "モデルまたはプロバイダーを検索…",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -887,6 +887,8 @@
 	"settings.models.refreshAria": "{{label}} 목록 새로 고침",
 	"settings.models.refreshFailed": "모델을 새로 고칠 수 없습니다.",
 	"settings.models.refresh": "모델 새로 고침",
+	"settings.models.lastSuccess": "마지막 업데이트: {{time}}",
+	"settings.models.retry": "새로 고침 다시 시도",
 	"settings.models.searchAria": "{{label}} 검색",
 	"settings.models.searchPlaceholder": "모델 검색…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "모델 또는 제공업체 검색…",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -902,6 +902,8 @@
 	"settings.models.refreshAria": "Atualizar lista de {{label}}",
 	"settings.models.refreshFailed": "Não foi possível atualizar os modelos.",
 	"settings.models.refresh": "Atualizar modelos",
+	"settings.models.lastSuccess": "Última atualização: {{time}}",
+	"settings.models.retry": "Tentar atualizar novamente",
 	"settings.models.searchAria": "Pesquisar {{label}}",
 	"settings.models.searchPlaceholder": "Pesquisar modelos…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "Pesquisar modelos ou provedores…",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -869,6 +869,8 @@
 	"settings.models.refreshAria": "刷新{{label}}列表",
 	"settings.models.refreshFailed": "无法刷新模型。",
 	"settings.models.refresh": "刷新模型",
+	"settings.models.lastSuccess": "上次更新：{{time}}",
+	"settings.models.retry": "重试刷新",
 	"settings.models.searchAria": "搜索{{label}}",
 	"settings.models.searchPlaceholder": "搜索模型…",
 	"settings.models.searchModelsOrProvidersPlaceholder": "搜索模型或提供商…",

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -289,6 +289,26 @@ describe("createEventTransport", () => {
 		}
 	});
 
+	it("invalidates only the changed model-catalog scope for catalog CDC", () => {
+		vi.useFakeTimers();
+		try {
+			const queryClient = fakeQueryClient();
+			createEventTransport(queryClient).connect();
+			cdcSources()[0].emit("session_updated", JSON.stringify({
+				seq: 44,
+				projectId: "proj-1",
+				type: "session_updated",
+				payload: { kind: "model_catalog", agentId: "codex", projectId: "proj-1" },
+				createdAt: "2026-09-07T08:00:00Z",
+			}));
+			vi.advanceTimersByTime(200);
+			expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["agent-models", "codex", "proj-1"] }, { cancelRefetch: false });
+			expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ["workspaces"] }, { cancelRefetch: false });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("invalidates the named interface transition status for transition CDC", () => {
 		vi.useFakeTimers();
 		try {

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -54,6 +54,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			let refreshTimer: ReturnType<typeof setTimeout> | undefined;
 			const pendingConversationSessions = new Set<string>();
 			const pendingInterfaceTransitionSessions = new Set<string>();
+			const pendingModelCatalogScopes = new Map<string, { agentId: string; projectId: string }>();
 			let workspaceInvalidationPending = false;
 			let allConversationsInvalidationPending = false;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -95,6 +96,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 			const refreshWorkspaces = (event?: Event) => {
 				if (disposed) return;
 				let conversationOnly = false;
+				let modelCatalogOnly = false;
 				if (event === undefined) {
 					// A lifecycle refresh -- reconnect, daemon status change, base-URL change --
 					// carries no event, so we cannot know which conversations moved. Normally the
@@ -120,8 +122,18 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 								? (decoded.payload as {
 										conversationId?: unknown;
 										interfaceTransitionId?: unknown;
+										kind?: unknown;
+										agentId?: unknown;
+										projectId?: unknown;
 								  })
 								: undefined;
+						if (payload?.kind === "model_catalog" && typeof payload.agentId === "string" && typeof payload.projectId === "string") {
+							pendingModelCatalogScopes.set(`${payload.agentId}\0${payload.projectId}`, {
+								agentId: payload.agentId,
+								projectId: payload.projectId,
+							});
+							modelCatalogOnly = true;
+						}
 						if (
 							typeof decoded.sessionId === "string" &&
 							decoded.sessionId &&
@@ -144,7 +156,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						// cannot target a conversation cache precisely.
 					}
 				}
-				if (!conversationOnly) workspaceInvalidationPending = true;
+				if (!conversationOnly && !modelCatalogOnly) workspaceInvalidationPending = true;
 				// Keep the first event's deadline: a busy stream must not postpone
 				// visible updates until traffic stops. Later events join this window.
 				if (refreshTimer !== undefined) return;
@@ -169,6 +181,10 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 						invalidate(["session-interface-transition", sessionId]);
 					}
 					pendingInterfaceTransitionSessions.clear();
+					for (const scope of pendingModelCatalogScopes.values()) {
+						invalidate(["agent-models", scope.agentId, scope.projectId]);
+					}
+					pendingModelCatalogScopes.clear();
 				}, INVALIDATE_WINDOW_MS);
 			};
 
@@ -291,6 +307,7 @@ export function createEventTransport(queryClient: QueryClient): EventTransport {
 				if (refreshTimer !== undefined) clearTimeout(refreshTimer);
 				pendingConversationSessions.clear();
 				pendingInterfaceTransitionSessions.clear();
+				pendingModelCatalogScopes.clear();
 				refreshes.clear();
 				if (retryTimer) clearTimeout(retryTimer);
 				removeDaemonListener();

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -60,7 +60,11 @@ export type TaskComposerModelOption = {
 export type TaskComposerModelCatalog = {
 	allowCustom: boolean;
 	customModelEntry: "none" | "direct" | "configured";
+	lastSuccessAt?: string;
 	models: TaskComposerModelOption[];
+	refreshError?: string;
+	refreshState?: "idle" | "queued" | "refreshing" | "error";
+	retryAt?: string;
 	selectionMode: "catalog" | "text" | "mode";
 };
 

--- a/packages/product-ui/src/TaskComposerView.tsx
+++ b/packages/product-ui/src/TaskComposerView.tsx
@@ -64,7 +64,7 @@ export type TaskComposerModelCatalog = {
 	models: TaskComposerModelOption[];
 	refreshError?: string;
 	refreshState?: "idle" | "queued" | "refreshing" | "error";
-	retryAt?: string;
+	retryAt?: string | null;
 	selectionMode: "catalog" | "text" | "mode";
 };
 


### PR DESCRIPTION
Code changes: +787 -148  
Tests: +606 -17  
Others: +171 -17 (generated artifacts and translations)

## Summary

- add a durable SQLite model-catalog cache keyed by agent and project, including discovery metadata/source, input fingerprint, refresh state, bounded retry metadata, UTC last-success time, and generation-fenced writes
- add local-calendar freshness with midnight, timezone, clock discontinuity, and sleep/wake detection; prioritized nonblocking startup prefetch; two-discovery global concurrency; per-scope deduplication; shutdown cancellation; and invalidation after readiness/auth/project/config changes
- make model pickers cached-first and event-driven, preserve saved selections, and add an always-visible refresh action beside search with progress, duplicate-click prevention, last-success time, and compact retryable errors
- add backend/frontend coverage and regenerate sqlc/OpenAPI artifacts

## Verification

Passed:

- `GOWORK=off npm run sqlc`
- `GOWORK=off npm run api`
- `GOWORK=off go test ./internal/service/agent ./internal/storage/sqlite ./internal/storage/sqlite/store ./internal/service/project ./internal/httpd/... ./internal/daemon ./internal/adapters/agent/modelcatalog -count=1`
- `GOWORK=off go test -race ./internal/service/agent -count=1`
- focused race tests for the model-catalog SQLite store
- focused `go vet` for all touched backend packages
- frontend model-picker, task-composer, project-settings, and event-transport tests: 113 passed
- frontend TypeScript check
- renderer production build with Vite
- product UI typecheck, tests (120 passed), and build
- `git diff --check`

Visual verification used `ao preview` and the shared `ao browser` against the local renderer, including navigation into the demo project board. The browser-only demo bridge did not reliably open the New Task modal, so the model-dropdown interaction is covered by DOM tests rather than claimed as a completed browser interaction.

## Known baseline limitations

- the complete Go workspace run currently encounters missing `modernc.org/libc` workspace packages and unrelated tmux harness failures
- the complete frontend suite currently has unrelated failures in browser-profile import, notification center, Markdown rendering, landing generation, and analytics tests
- `frontend/package.json` currently has no `build` script, so the equivalent Vite renderer production build was run directly

fixes #5070 
