### PR TITLE
fix(chat): allow untouched sessions to switch to terminal

### DIFF
--- a/backend/internal/adapters/agent/claudecode/terminal_freshness_test.go
+++ b/backend/internal/adapters/agent/claudecode/terminal_freshness_test.go
@@ -1,0 +1,34 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInspectTerminalSurfaceOnlyProvesUntouchedClaudeComposer(t *testing.T) {
+	header := " ▐▛███▜▌   Claude Code v2.1.233\n▝▜█████▛▘  Opus · Claude Team\n  ▘▘ ▝▝    /workspace\n\n"
+	rule := strings.Repeat("─", 48)
+	composer := rule + "\n❯ \n" + rule + "\n⏵⏵ auto mode on"
+	for _, tc := range []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"initial composer", header + composer, true},
+		{"animated banner", strings.Replace(header, "Claude Code v", "Claude CodClaude█Code v", 1) + composer, true},
+		{"header missing", composer, false},
+		{"composer missing", header, false},
+		{"draft", header + strings.Replace(composer, "❯ ", "❯ keep this draft", 1), false},
+		{"previous prompt", header + "❯ hello\n\n" + composer, false},
+		{"assistant output", header + "⏺ Hello\n\n" + composer, false},
+		{"active", header + "✻ Working… (esc to interrupt)\n" + composer, false},
+		{"decision", header + "Allow this?\n❯ 1. Yes\n  2. No\nEsc to cancel", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := New().InspectTerminalSurface(tc.output)
+			if got.NativeConversationNotStarted != tc.want {
+				t.Fatalf("untouched = %v, want %v: %+v", got.NativeConversationNotStarted, tc.want, got)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/agent/claudecode/terminal_surface.go
+++ b/backend/internal/adapters/agent/claudecode/terminal_surface.go
@@ -30,6 +30,26 @@ func (p *Plugin) InspectTerminalSurface(output string) ports.TerminalSurfaceObse
 	case observation.Composer != ports.TerminalComposerUnknown:
 		observation.Work = ports.TerminalSurfaceWorkIdle
 	}
+	if observation.Work == ports.TerminalSurfaceWorkIdle && observation.Composer == ports.TerminalComposerEmpty {
+		// The banner must still be visible, with only the current composer and
+		// no provider response. An empty composer alone also follows real work.
+		header, prompts, response := false, 0, false
+		for _, line := range terminalui.PlainTerminalLines(output) {
+			line = strings.TrimSpace(line)
+			// The startup mascot animation can overwrite the brand separator
+			// in the captured viewport while leaving both banner labels intact.
+			if strings.Contains(line, "Claude") && strings.Contains(line, "Code v") {
+				header = true
+			}
+			if strings.HasPrefix(line, "❯") {
+				prompts++
+			}
+			if strings.HasPrefix(line, "⏺") {
+				response = true
+			}
+		}
+		observation.NativeConversationNotStarted = header && prompts == 1 && !response
+	}
 	return observation
 }
 

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -489,12 +491,11 @@ func (m *Manager) runInterfaceTransition(
 }
 
 // nativeConversationID resolves the adapter's native conversation id for the
-// session's current interface. An empty id is only safe to pass through when
-// the adapter supports history probing AND the source has positive untouched
-// terminal or durable Chat evidence. If any conversation metadata is set but
-// the native id is empty, the hooks fired but failed to capture the id — a
-// bug state where fresh-starting would silently discard the conversation, so
-// hard-block with ErrNativeConversationMissing instead.
+// session's current interface. A missing id requires positive untouched-terminal
+// or durable empty-Chat proof. Chat may also reserve a ProviderConversationID
+// before persisting history; persistedNativeConversationID checks whether that
+// id can resume or qualifies for a fresh launch. Conversation activity without
+// a resumable identity must fail closed instead of discarding existing work.
 func (m *Manager) nativeConversationID(
 	ctx context.Context,
 	rec domain.SessionRecord,
@@ -550,13 +551,20 @@ func (m *Manager) nativeConversationNotStarted(
 	rec domain.SessionRecord,
 	agent ports.Agent,
 ) bool {
-	if rec.Metadata.LatestUserPrompt != "" ||
-		rec.Metadata.LatestAssistantUpdate != "" ||
-		rec.Metadata.NativeTranscriptPath != "" {
+	if rec.Metadata.LatestUserPrompt != "" || rec.Metadata.LatestAssistantUpdate != "" {
 		return false
 	}
-	if _, ok := agent.(ports.AgentInterfaceHandoffHistoryProbe); !ok {
-		return false
+	if path := rec.Metadata.NativeTranscriptPath; path != "" {
+		// SessionStart may announce a filename before creating the transcript;
+		// that hint can survive a fresh switch back to Chat. Only a definitely
+		// absent absolute path can accompany the mode-specific freshness proof.
+		// Existing entries (including symlinks) and lookup errors block it.
+		if !filepath.IsAbs(path) {
+			return false
+		}
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			return false
+		}
 	}
 	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
 		if rec.Metadata.Prompt != "" {
@@ -582,6 +590,9 @@ func (m *Manager) nativeConversationNotStarted(
 		// a sequence. Include those turns, even if they were later hidden.
 		hasTurns, err := store.HasConversationTurns(ctx, conversation.ID)
 		return err == nil && !hasTurns
+	}
+	if _, ok := agent.(ports.AgentInterfaceHandoffHistoryProbe); !ok {
+		return false
 	}
 	return m.terminalProvesNativeConversationNotStarted(ctx, rec, agent)
 }
@@ -614,7 +625,7 @@ func (m *Manager) terminalProvesNativeConversationNotStarted(
 
 // persistedNativeConversationID verifies that a reserved native id has durable
 // provider history behind it. A failed lookup is not proof of freshness: only
-// positive untouched-composer evidence may produce the explicit fresh sentinel.
+// positive untouched-terminal or durable empty-Chat proof may start fresh.
 func (m *Manager) persistedNativeConversationID(
 	ctx context.Context,
 	rec domain.SessionRecord,

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -53,6 +53,12 @@ type chatHandoffLauncher interface {
 	AbortChatHandoff(domain.SessionID)
 }
 
+type chatHandoffHistoryStore interface {
+	ConversationForSession(context.Context, domain.SessionID) (domain.ConversationRecord, error)
+	ConversationBranch(context.Context, string, string) (domain.ConversationBranch, error)
+	HasConversationTurns(context.Context, string) (bool, error)
+}
+
 type runtimeInterrupter interface {
 	Interrupt(context.Context, ports.RuntimeHandle) error
 }
@@ -381,13 +387,13 @@ func (m *Manager) runInterfaceTransition(
 		return
 	}
 	sourcePrepared = true
-	// A promptless TUI may not create a provider conversation until its first
-	// submitted turn. When the transition was admitted from positive initial-
-	// composer proof, resolve again after input is frozen and drain is complete.
+	// A promptless session may not persist a provider conversation until its first
+	// submitted turn. When admitted from untouched-conversation proof, resolve
+	// again after input is frozen and drain is complete.
 	// This closes the race where a turn starts between the admission snapshot and
-	// the terminal input gate: the new native id is transferred, or the switch
+	// the input gate: the new native id is transferred, or the switch
 	// fails before stopping the source if identity still cannot be proven.
-	if transition.SourceMode == domain.SessionModeTUI && transition.NativeConversationID == "" {
+	if transition.NativeConversationID == "" {
 		current, found, refreshErr := m.store.GetSession(ctx, rec.ID)
 		if refreshErr != nil || !found {
 			if refreshErr == nil {
@@ -397,6 +403,7 @@ func (m *Manager) runInterfaceTransition(
 			return
 		}
 		if current.Metadata.RuntimeLaunchID != rec.Metadata.RuntimeLaunchID ||
+			current.Metadata.ControllerGeneration != rec.Metadata.ControllerGeneration ||
 			domain.NormalizeSessionMode(current.Mode) != transition.SourceMode {
 			fail("SESSION_CHANGED", fmt.Errorf("session changed while the interface switch was draining"))
 			return
@@ -483,9 +490,8 @@ func (m *Manager) runInterfaceTransition(
 
 // nativeConversationID resolves the adapter's native conversation id for the
 // session's current interface. An empty id is only safe to pass through when
-// the adapter can distinguish a fresh TUI from a real conversation (it
-// implements AgentInterfaceHandoffHistoryProbe) AND the session has no
-// hook-derived conversation history. If any conversation metadata is set but
+// the adapter supports history probing AND the source has positive untouched
+// terminal or durable Chat evidence. If any conversation metadata is set but
 // the native id is empty, the hooks fired but failed to capture the id — a
 // bug state where fresh-starting would silently discard the conversation, so
 // hard-block with ErrNativeConversationMissing instead.
@@ -536,22 +542,46 @@ func (m *Manager) nativeConversationID(
 // nativeConversationNotStarted is the only evidence that may turn a missing
 // provider history into an intentional fresh handoff. A missing file or a
 // reserved native id is not enough: both are also observable when persistence
-// is lagging or broken after real work. The current rendered provider surface
-// must positively identify its untouched initial composer, and AO must have no
-// hook-derived conversation facts that contradict it.
+// is lagging or broken after real work. Chat requires a durable empty root
+// conversation; TUI requires an untouched initial composer. AO must have no
+// hook-derived conversation facts that contradict either proof.
 func (m *Manager) nativeConversationNotStarted(
 	ctx context.Context,
 	rec domain.SessionRecord,
 	agent ports.Agent,
 ) bool {
-	if domain.NormalizeSessionMode(rec.Mode) != domain.SessionModeTUI ||
-		rec.Metadata.LatestUserPrompt != "" ||
+	if rec.Metadata.LatestUserPrompt != "" ||
 		rec.Metadata.LatestAssistantUpdate != "" ||
 		rec.Metadata.NativeTranscriptPath != "" {
 		return false
 	}
 	if _, ok := agent.(ports.AgentInterfaceHandoffHistoryProbe); !ok {
 		return false
+	}
+	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
+		if rec.Metadata.Prompt != "" {
+			return false
+		}
+		store, ok := m.store.(chatHandoffHistoryStore)
+		if !ok {
+			return false
+		}
+		// The sequence is monotonic even when turns are rolled back or hidden.
+		// Zero proves no message or activity was ever accepted; an empty visible
+		// timeline would not. Startup settings do not consume this sequence.
+		conversation, err := store.ConversationForSession(ctx, rec.ID)
+		if err != nil || conversation.SessionID != rec.ID || conversation.LatestSequence != 0 {
+			return false
+		}
+		branch, err := store.ConversationBranch(ctx, conversation.ID, conversation.ActiveBranchID)
+		if err != nil || branch.SessionID != rec.ID || branch.ParentBranchID != "" ||
+			branch.ProviderConversationID != rec.Metadata.ProviderConversationID {
+			return false
+		}
+		// A provider can announce a turn before its first message/activity takes
+		// a sequence. Include those turns, even if they were later hidden.
+		hasTurns, err := store.HasConversationTurns(ctx, conversation.ID)
+		return err == nil && !hasTurns
 	}
 	return m.terminalProvesNativeConversationNotStarted(ctx, rec, agent)
 }

--- a/backend/internal/session_manager/interface_transition_fresh_chat_test.go
+++ b/backend/internal/session_manager/interface_transition_fresh_chat_test.go
@@ -1,0 +1,213 @@
+package sessionmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	claudeagent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
+	codexagent "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
+)
+
+type freshChatTransitionStore struct {
+	*transitionStore
+	conversation domain.ConversationRecord
+	branch       domain.ConversationBranch
+	historyErr   error
+	hasTurns     bool
+}
+
+func (s *freshChatTransitionStore) ConversationForSession(context.Context, domain.SessionID) (domain.ConversationRecord, error) {
+	return s.conversation, s.historyErr
+}
+
+func (s *freshChatTransitionStore) ConversationBranch(context.Context, string, string) (domain.ConversationBranch, error) {
+	return s.branch, s.historyErr
+}
+
+func (s *freshChatTransitionStore) HasConversationTurns(context.Context, string) (bool, error) {
+	return s.hasTurns, s.historyErr
+}
+
+func withFreshChatHistory(manager *Manager, store *transitionStore) *freshChatTransitionStore {
+	rec := store.sessions["session-1"]
+	history := &freshChatTransitionStore{
+		transitionStore: store,
+		conversation:    domain.ConversationRecord{ID: "conversation-1", SessionID: rec.ID, ActiveBranchID: "branch-1"},
+		branch: domain.ConversationBranch{ID: "branch-1", ConversationID: "conversation-1", SessionID: rec.ID,
+			ProviderConversationID: rec.Metadata.ProviderConversationID},
+	}
+	manager.store = history
+	return history
+}
+
+func TestInterfaceTransitionUnpromptedChatToTUI(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		harness      domain.AgentHarness
+		agent        ports.Agent
+		providerTurn bool
+	}{
+		{"claude", domain.HarnessClaudeCode, claudeagent.New(), false},
+		{"codex", domain.HarnessCodex, codexagent.New(), false},
+		{"claude with provider turn but no text", domain.HarnessClaudeCode, claudeagent.New(), true},
+		{"codex with provider turn but no text", domain.HarnessCodex, codexagent.New(), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+			t.Setenv("CODEX_HOME", t.TempDir())
+			manager, store, runtime, _, log := newTransitionManager(t, domain.SessionModeChat)
+			manager.agents = singleAgent{agent: tc.agent}
+			manager.dataDir = t.TempDir()
+			rec := store.sessions["session-1"]
+			rec.Harness = tc.harness
+			rec.Metadata.WorkspacePath = t.TempDir()
+			rec.Metadata.AgentSessionID = ""
+			rec.Metadata.ProviderConversationID = "019fc430-1234-7abc-8def-0123456789ab"
+			store.sessions[rec.ID] = rec
+			// Exercise the production conversation/branch reads. Runtime and
+			// lifecycle effects stay in the existing handoff fixture.
+			ctx := context.Background()
+			history := sqlitetest.MustOpenAt(t, t.TempDir())
+			if err := history.UpsertProject(ctx, store.projects["proj"]); err != nil {
+				t.Fatal(err)
+			}
+			created, err := history.CreateSession(ctx, rec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			delete(store.sessions, rec.ID)
+			rec.ID = created.ID
+			store.sessions[rec.ID] = rec
+			if _, err := history.CreateConversation(ctx, "conversation-1", domain.ConversationScopeSession,
+				rec.ProjectID, rec.ID, time.Now()); err != nil {
+				t.Fatal(err)
+			}
+			manager.store = struct {
+				*transitionStore
+				chatHandoffHistoryStore
+			}{store, history}
+			if tc.providerTurn {
+				if err := history.AdoptProviderTurn(ctx, "conversation-1", rec.ID,
+					rec.Metadata.ControllerGeneration, "turn-1", "provider-turn-1", time.Now()); err != nil {
+					t.Fatal(err)
+				}
+			}
+			transition, err := manager.StartInterfaceTransition(context.Background(), rec.ID,
+				domain.SessionModeTUI, domain.SessionInterfaceTransitionInterrupt)
+			if tc.providerTurn {
+				if !errors.Is(err, ErrNativeConversationMissing) || len(*log) != 0 {
+					t.Fatalf("provider turn without text was treated as untouched: err=%v log=%v", err, *log)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unprompted Chat-to-terminal switch was refused: %v", err)
+			}
+			settled := awaitTransition(t, store, transition.ID)
+			if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+				t.Fatalf("switch = %s (%s): %s", settled.Phase, settled.ErrorCode, settled.ErrorDetail)
+			}
+			if settled.NativeConversationID != "" {
+				t.Fatalf("reserved id was passed to resume: %q", settled.NativeConversationID)
+			}
+			if got := fmt.Sprint(*log); got != "[prepare:chat:interrupt stop:chat start:tui]" {
+				t.Fatalf("controller order = %s", got)
+			}
+			if runtime.created != 1 || strings.Contains(strings.Join(runtime.lastCfg.Argv, " "), "resume") {
+				t.Fatalf("expected one fresh terminal launch: %+v", runtime.lastCfg)
+			}
+		})
+	}
+}
+
+func TestInterfaceTransitionUnpromptedChatWithoutNativeID(t *testing.T) {
+	manager, store, _, _, _ := newTransitionManager(t, domain.SessionModeChat)
+	manager.agents = singleAgent{agent: emptyTransitionAgent{}}
+	rec := store.sessions["session-1"]
+	rec.Metadata.AgentSessionID = ""
+	rec.Metadata.ProviderConversationID = ""
+	store.sessions[rec.ID] = rec
+	withFreshChatHistory(manager, store)
+	status, err := manager.InterfaceTransitionStatus(context.Background(), rec.ID)
+	if err != nil || !status.Supported {
+		t.Fatalf("untouched Chat status = %+v, err=%v", status, err)
+	}
+	transition, err := manager.StartInterfaceTransition(context.Background(), rec.ID,
+		domain.SessionModeTUI, domain.SessionInterfaceTransitionInterrupt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settled := awaitTransition(t, store, transition.ID); settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("switch = %s (%s): %s", settled.Phase, settled.ErrorCode, settled.ErrorDetail)
+	}
+}
+
+func TestInterfaceTransitionChatRequiresUntouchedConversationProof(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*freshChatTransitionStore)
+	}{
+		{"accepted message or activity", func(s *freshChatTransitionStore) { s.conversation.LatestSequence = 1 }},
+		{"provider turn without text", func(s *freshChatTransitionStore) { s.hasTurns = true }},
+		{"missing conversation", func(s *freshChatTransitionStore) { s.historyErr = domain.ErrNoConversation }},
+		{"history read failed", func(s *freshChatTransitionStore) { s.historyErr = errors.New("database unavailable") }},
+		{"different owner", func(s *freshChatTransitionStore) { s.conversation.SessionID = "session-2" }},
+		{"different branch owner", func(s *freshChatTransitionStore) { s.branch.SessionID = "session-2" }},
+		{"different provider", func(s *freshChatTransitionStore) { s.branch.ProviderConversationID = "other-native" }},
+		{"branch with inherited context", func(s *freshChatTransitionStore) { s.branch.ParentBranchID = "parent" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, store, runtime, chat, log := newTransitionManager(t, domain.SessionModeChat)
+			manager.agents = singleAgent{agent: emptyTransitionAgent{}}
+			tc.mutate(withFreshChatHistory(manager, store))
+			_, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+				domain.SessionModeTUI, domain.SessionInterfaceTransitionInterrupt)
+			if !errors.Is(err, ErrNativeConversationMissing) {
+				t.Fatalf("switch without untouched proof = %v", err)
+			}
+			if len(store.transitions) != 0 || runtime.created != 0 || chat.preparedPolicy != "" || len(*log) != 0 {
+				t.Fatalf("refusal mutated source: transitions=%d log=%v", len(store.transitions), *log)
+			}
+		})
+	}
+}
+
+type racingFreshChat struct {
+	*transitionChat
+	beforePrepare func()
+}
+
+func (c *racingFreshChat) PrepareChatHandoff(ctx context.Context, id domain.SessionID, policy domain.SessionInterfaceTransitionPolicy) error {
+	c.beforePrepare()
+	return c.transitionChat.PrepareChatHandoff(ctx, id, policy)
+}
+
+func TestInterfaceTransitionFreshChatRechecksAfterFencing(t *testing.T) {
+	manager, store, runtime, chat, log := newTransitionManager(t, domain.SessionModeChat)
+	manager.agents = singleAgent{agent: emptyTransitionAgent{}}
+	history := withFreshChatHistory(manager, store)
+	manager.chat = &racingFreshChat{transitionChat: chat, beforePrepare: func() {
+		// Message intake won the race with ArmChatHandoff. Its durable sequence
+		// remains even if interrupt settles it before a native transcript exists.
+		history.conversation.LatestSequence = 1
+	}}
+	transition, err := manager.StartInterfaceTransition(context.Background(), "session-1",
+		domain.SessionModeTUI, domain.SessionInterfaceTransitionInterrupt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionFailed || settled.ErrorCode != "NATIVE_SESSION_MISSING" {
+		t.Fatalf("switch after accepted message = %s (%s)", settled.Phase, settled.ErrorCode)
+	}
+	if runtime.created != 0 || fmt.Sprint(*log) != "[prepare:chat:interrupt]" {
+		t.Fatalf("source stopped after losing untouched proof: %v", *log)
+	}
+}

--- a/backend/internal/session_manager/interface_transition_fresh_chat_test.go
+++ b/backend/internal/session_manager/interface_transition_fresh_chat_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -48,6 +51,18 @@ func withFreshChatHistory(manager *Manager, store *transitionStore) *freshChatTr
 }
 
 func TestInterfaceTransitionUnpromptedChatToTUI(t *testing.T) {
+	// Keep production argv generation without requiring installed providers.
+	// The fake runtime records these paths but never executes the files.
+	binDir := t.TempDir()
+	for _, name := range []string{"claude", "codex"} {
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte("test executable"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", binDir)
 	for _, tc := range []struct {
 		name         string
 		harness      domain.AgentHarness

--- a/backend/internal/session_manager/interface_transition_fresh_chat_test.go
+++ b/backend/internal/session_manager/interface_transition_fresh_chat_test.go
@@ -50,7 +50,7 @@ func withFreshChatHistory(manager *Manager, store *transitionStore) *freshChatTr
 	return history
 }
 
-func TestInterfaceTransitionUnpromptedChatToTUI(t *testing.T) {
+func TestInterfaceTransitionUnpromptedChatRoundTrip(t *testing.T) {
 	// Keep production argv generation without requiring installed providers.
 	// The fake runtime records these paths but never executes the files.
 	binDir := t.TempDir()
@@ -68,16 +68,21 @@ func TestInterfaceTransitionUnpromptedChatToTUI(t *testing.T) {
 		harness      domain.AgentHarness
 		agent        ports.Agent
 		providerTurn bool
+		terminalTurn bool
 	}{
-		{"claude", domain.HarnessClaudeCode, claudeagent.New(), false},
-		{"codex", domain.HarnessCodex, codexagent.New(), false},
-		{"claude with provider turn but no text", domain.HarnessClaudeCode, claudeagent.New(), true},
-		{"codex with provider turn but no text", domain.HarnessCodex, codexagent.New(), true},
+		{"claude", domain.HarnessClaudeCode, claudeagent.New(), false, false},
+		{"codex", domain.HarnessCodex, codexagent.New(), false, false},
+		{"claude with provider turn but no text", domain.HarnessClaudeCode, claudeagent.New(), true, false},
+		{"codex with provider turn but no text", domain.HarnessCodex, codexagent.New(), true, false},
+		{"claude after terminal message", domain.HarnessClaudeCode, claudeagent.New(), false, true},
+		{"codex after terminal message", domain.HarnessCodex, codexagent.New(), false, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
-			t.Setenv("CODEX_HOME", t.TempDir())
-			manager, store, runtime, _, log := newTransitionManager(t, domain.SessionModeChat)
+			claudeConfig, codexHome := t.TempDir(), t.TempDir()
+			t.Setenv("CLAUDE_CONFIG_DIR", claudeConfig)
+			t.Setenv("CODEX_HOME", codexHome)
+			manager, store, runtime, chat, log := newTransitionManager(t, domain.SessionModeChat)
+			useFastInterfaceTransitionTimings(manager)
 			manager.agents = singleAgent{agent: tc.agent}
 			manager.dataDir = t.TempDir()
 			rec := store.sessions["session-1"]
@@ -138,13 +143,64 @@ func TestInterfaceTransitionUnpromptedChatToTUI(t *testing.T) {
 			if runtime.created != 1 || strings.Contains(strings.Join(runtime.lastCfg.Argv, " "), "resume") {
 				t.Fatalf("expected one fresh terminal launch: %+v", runtime.lastCfg)
 			}
+			// SessionStart reserves a transcript path before the first prompt
+			// creates that file. Exercise the immediate reverse handoff too.
+			rec = store.sessions[rec.ID]
+			rec.Metadata.AgentSessionID = "019fc430-1234-7abc-8def-0123456789ab"
+			rec.Metadata.AgentSessionIDLaunchID = rec.Metadata.RuntimeLaunchID
+			rec.Metadata.NativeTranscriptPath = filepath.Join(t.TempDir(), "reserved.jsonl")
+			wantNativeID := ""
+			if tc.terminalTurn {
+				wantNativeID = rec.Metadata.AgentSessionID
+				rec.Metadata.LatestUserPrompt = "hello"
+				rec.Metadata.LatestAssistantUpdate = "hello back"
+				path := filepath.Join(claudeConfig, "projects", "workspace", wantNativeID+".jsonl")
+				if tc.harness == domain.HarnessCodex {
+					path = filepath.Join(codexHome, "sessions", "2026", "09", "08", "rollout-2026-09-08T10-00-00-"+wantNativeID+".jsonl")
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte("{\"type\":\"user\",\"message\":\"hello\"}\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				rec.Metadata.NativeTranscriptPath = path
+			}
+			store.sessions[rec.ID] = rec
+			runtime.outputForCall = func(int) string {
+				if tc.harness == domain.HarnessClaudeCode {
+					return " ▐▛███▜▌   Claude Code v2.1.233\n" +
+						"▝▜█████▛▘  Opus · Claude Team\n  ▘▘ ▝▝    /workspace\n\n" +
+						strings.Repeat("─", 48) + "\n❯ \n" + strings.Repeat("─", 48) + "\n⏵⏵ auto mode on"
+				}
+				return "│ >_ OpenAI Codex (v0.153.4) │\n\n" +
+					"\x1b[1m›\x1b[0m \x1b[2mSummarize recent commits\x1b[0m\n\ngpt-6-astra · /workspace\n"
+			}
+			transition, err = manager.StartInterfaceTransition(ctx, rec.ID,
+				domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+			if err != nil {
+				t.Fatalf("unprompted terminal-to-Chat return was refused: %v", err)
+			}
+			settled = awaitTransition(t, store, transition.ID)
+			if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+				t.Fatalf("return = %s (%s): %s", settled.Phase, settled.ErrorCode, settled.ErrorDetail)
+			}
+			if settled.NativeConversationID != wantNativeID || chat.start.ProviderConversationID != wantNativeID ||
+				chat.start.RequireNativeHistory != tc.terminalTurn {
+				t.Fatalf("return identity=%q, target=%q, requireHistory=%v; want identity=%q, requireHistory=%v",
+					settled.NativeConversationID, chat.start.ProviderConversationID, chat.start.RequireNativeHistory, wantNativeID, tc.terminalTurn)
+			}
+			if got := fmt.Sprint(*log); got != "[prepare:chat:interrupt stop:chat start:tui stop:tui:h1 start:chat]" {
+				t.Fatalf("round-trip controller order = %s", got)
+			}
 		})
 	}
 }
 
 func TestInterfaceTransitionUnpromptedChatWithoutNativeID(t *testing.T) {
 	manager, store, _, _, _ := newTransitionManager(t, domain.SessionModeChat)
-	manager.agents = singleAgent{agent: emptyTransitionAgent{}}
+	// Chat's durable empty-root proof does not need a provider file probe.
+	manager.agents = singleAgent{agent: transitionAgent{}}
 	rec := store.sessions["session-1"]
 	rec.Metadata.AgentSessionID = ""
 	rec.Metadata.ProviderConversationID = ""

--- a/backend/internal/session_manager/interface_transition_fresh_terminal_test.go
+++ b/backend/internal/session_manager/interface_transition_fresh_terminal_test.go
@@ -1,0 +1,110 @@
+package sessionmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestInterfaceTransitionReservedTranscriptRequiresUntouchedTerminal(t *testing.T) {
+	for _, name := range []string{
+		"absent", "existing", "empty", "directory", "relative", "lookup error",
+		"user prompt", "assistant response", "unknown surface", "chat",
+	} {
+		t.Run(name, func(t *testing.T) {
+			manager, store, runtime, _, log := newTransitionManager(t, domain.SessionModeTUI)
+			useFastInterfaceTransitionTimings(manager)
+			manager.agents = singleAgent{agent: untouchedEmptyTransitionAgent{}}
+			rec := store.sessions["session-1"]
+			path := filepath.Join(t.TempDir(), "reserved.jsonl")
+			switch name {
+			case "existing", "empty", "lookup error":
+				content := []byte("transcript")
+				if name == "empty" {
+					content = nil
+				}
+				if err := os.WriteFile(path, content, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if name == "lookup error" {
+					path = filepath.Join(path, "child.jsonl")
+				}
+			case "directory":
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			case "relative":
+				path = "reserved.jsonl"
+			case "user prompt":
+				rec.Metadata.LatestUserPrompt = "preserve this work"
+			case "assistant response":
+				rec.Metadata.LatestAssistantUpdate = "completed work"
+			case "unknown surface":
+				manager.agents = singleAgent{agent: emptyTransitionAgent{}}
+			case "chat":
+				rec.Mode = domain.SessionModeChat
+			}
+			rec.Metadata.NativeTranscriptPath = path
+			store.sessions[rec.ID] = rec
+			withFreshChatHistory(manager, store)
+			target := domain.SessionModeChat
+			if rec.Mode == domain.SessionModeChat {
+				target = domain.SessionModeTUI
+			}
+			transition, err := manager.StartInterfaceTransition(context.Background(), rec.ID,
+				target, domain.SessionInterfaceTransitionDrain)
+			if name == "absent" || name == "chat" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if settled := awaitTransition(t, store, transition.ID); settled.Phase != domain.SessionInterfaceTransitionCompleted {
+					t.Fatalf("reserved path handoff = %+v", settled)
+				}
+				return
+			}
+			if !errors.Is(err, ErrNativeConversationMissing) {
+				t.Fatalf("unsafe fresh handoff = %v", err)
+			}
+			if len(store.transitions) != 0 || runtime.destroyed != 0 || len(*log) != 0 {
+				t.Fatalf("checking freshness mutated the source: %v", *log)
+			}
+		})
+	}
+}
+
+func TestInterfaceTransitionReservedTranscriptRechecksAfterFencing(t *testing.T) {
+	manager, store, runtime, _, log := newTransitionManager(t, domain.SessionModeTUI)
+	useFastInterfaceTransitionTimings(manager)
+	manager.agents = singleAgent{agent: untouchedEmptyTransitionAgent{}}
+	rec := store.sessions["session-1"]
+	rec.Metadata.NativeTranscriptPath = filepath.Join(t.TempDir(), "reserved.jsonl")
+	store.sessions[rec.ID] = rec
+	runtime.outputForCall = func(call int) string {
+		if call == 1 {
+			// Persistence starts after admission's missing-file check. The
+			// provider probe still cannot resume it, so stopping would lose work.
+			if err := os.WriteFile(rec.Metadata.NativeTranscriptPath, []byte("new turn"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return idleTerminalOutput
+	}
+	transition, err := manager.StartInterfaceTransition(context.Background(), rec.ID,
+		domain.SessionModeChat, domain.SessionInterfaceTransitionDrain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionFailed || settled.ErrorCode != "NATIVE_SESSION_MISSING" {
+		t.Fatalf("switch after persistence started = %+v", settled)
+	}
+	if runtime.destroyed != 0 || strings.Contains(fmt.Sprint(*log), "start:chat") {
+		t.Fatalf("source stopped despite losing untouched proof: %v", *log)
+	}
+}

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -582,6 +582,17 @@ func (q *Queries) FinalizeConversationPlanActivity(ctx context.Context, arg Fina
 	return err
 }
 
+const hasConversationTurns = `-- name: HasConversationTurns :one
+SELECT EXISTS (SELECT 1 FROM conversation_turns WHERE conversation_id = ?)
+`
+
+func (q *Queries) HasConversationTurns(ctx context.Context, conversationID string) (bool, error) {
+	row := q.db.QueryRowContext(ctx, hasConversationTurns, conversationID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const hasPendingConversationInteractions = `-- name: HasPendingConversationInteractions :one
 SELECT EXISTS (
     SELECT 1

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -1078,6 +1078,33 @@ func (q *Queries) ReleaseQueuedConversationTurnPromotion(ctx context.Context, ar
 	return result.RowsAffected()
 }
 
+const releaseUntouchedConversationProvider = `-- name: ReleaseUntouchedConversationProvider :execrows
+UPDATE conversation_branches
+SET provider_conversation_id = '', provider_scope_id = ?1
+WHERE conversation_branches.session_id = ?2 AND parent_branch_id IS NULL
+  AND conversation_branches.id = (
+      SELECT c.active_branch_id FROM conversations AS c
+      WHERE c.session_id = ?2 AND c.current_session_id = ?2
+        AND c.latest_sequence = 0
+        AND NOT EXISTS (
+            SELECT 1 FROM conversation_turns WHERE conversation_id = c.id
+        )
+  )
+`
+
+type ReleaseUntouchedConversationProviderParams struct {
+	ProviderScopeID string
+	SessionID       sql.NullString
+}
+
+func (q *Queries) ReleaseUntouchedConversationProvider(ctx context.Context, arg ReleaseUntouchedConversationProviderParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, releaseUntouchedConversationProvider, arg.ProviderScopeID, arg.SessionID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const reserveQueuedConversationTurnForPromotion = `-- name: ReserveQueuedConversationTurnForPromotion :execrows
 UPDATE conversation_turns
 SET promotion_started_at = ?1

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -25,6 +25,9 @@ WHERE id = ? AND scope = 'project';
 -- name: SelectConversationByID :one
 SELECT * FROM conversations WHERE id = ? LIMIT 1;
 
+-- name: HasConversationTurns :one
+SELECT EXISTS (SELECT 1 FROM conversation_turns WHERE conversation_id = ?);
+
 -- name: InsertConversationBranch :exec
 INSERT INTO conversation_branches (
     id, conversation_id, session_id, provider_conversation_id,

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -28,6 +28,19 @@ SELECT * FROM conversations WHERE id = ? LIMIT 1;
 -- name: HasConversationTurns :one
 SELECT EXISTS (SELECT 1 FROM conversation_turns WHERE conversation_id = ?);
 
+-- name: ReleaseUntouchedConversationProvider :execrows
+UPDATE conversation_branches
+SET provider_conversation_id = '', provider_scope_id = sqlc.arg(provider_scope_id)
+WHERE conversation_branches.session_id = sqlc.arg(session_id) AND parent_branch_id IS NULL
+  AND conversation_branches.id = (
+      SELECT c.active_branch_id FROM conversations AS c
+      WHERE c.session_id = sqlc.arg(session_id) AND c.current_session_id = sqlc.arg(session_id)
+        AND c.latest_sequence = 0
+        AND NOT EXISTS (
+            SELECT 1 FROM conversation_turns WHERE conversation_id = c.id
+        )
+  );
+
 -- name: InsertConversationBranch :exec
 INSERT INTO conversation_branches (
     id, conversation_id, session_id, provider_conversation_id,

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -742,6 +742,16 @@ func (s *Store) ConversationForSession(
 	return conversationToDomain(row), nil
 }
 
+// HasConversationTurns includes hidden and settled turns: an empty visible
+// timeline is not proof that the provider conversation never started.
+func (s *Store) HasConversationTurns(ctx context.Context, conversationID string) (bool, error) {
+	hasTurns, err := s.qr.HasConversationTurns(ctx, conversationID)
+	if err != nil {
+		return false, fmt.Errorf("check conversation turns %s: %w", conversationID, err)
+	}
+	return hasTurns, nil
+}
+
 // AppendUserMessage records an inbound message and the turn it opens.
 //
 // Idempotent on clientMessageID: a retried send returns the message and turn that

--- a/backend/internal/storage/sqlite/store/session_interface_fresh_test.go
+++ b/backend/internal/storage/sqlite/store/session_interface_fresh_test.go
@@ -1,0 +1,74 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestFreshInterfaceEpochReleasesOnlyUntouchedRootProvider(t *testing.T) {
+	for _, name := range []string{"fresh", "provider turn", "stale mode"} {
+		t.Run(name, func(t *testing.T) {
+			st := newTestStore(t)
+			ctx := context.Background()
+			seedProject(t, st, "fresh-switch")
+			now := time.Now()
+			rec := sampleRecord("fresh-switch")
+			rec.Mode = domain.SessionModeChat
+			rec.Metadata.ProviderConversationID = "reserved-chat-id"
+			rec.Metadata.ControllerGeneration = "chat-generation"
+			sess, err := st.CreateSession(ctx, rec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conversation, err := st.CreateConversation(ctx, "fresh-conversation", domain.ConversationScopeSession,
+				sess.ProjectID, sess.ID, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, err := st.ConversationBranch(ctx, conversation.ID, conversation.ActiveBranchID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if name == "provider turn" {
+				if err := st.AdoptProviderTurn(ctx, conversation.ID, sess.ID, "chat-generation", "turn-1", "provider-turn-1", now); err != nil {
+					t.Fatal(err)
+				}
+			}
+			source := domain.SessionModeChat
+			if name == "stale mode" {
+				source = domain.SessionModeTUI
+			}
+			changed, err := st.CommitSessionControllerEpoch(ctx, sess.ID, source, domain.SessionModeTUI, "", now)
+			if name == "fresh" {
+				if err != nil || !changed {
+					t.Fatalf("fresh epoch changed=%v err=%v", changed, err)
+				}
+			} else if changed || (name == "provider turn" && err == nil) {
+				t.Fatalf("unsafe epoch changed=%v err=%v", changed, err)
+			}
+			after, err := st.ConversationBranch(ctx, conversation.ID, conversation.ActiveBranchID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			current, _, err := st.GetSession(ctx, sess.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if name == "fresh" {
+				if after.ProviderConversationID != "" || after.ProviderScopeID == before.ProviderScopeID || after.ProviderScopeID == "" {
+					t.Fatalf("unused provider binding was retained: before=%+v after=%+v", before, after)
+				}
+				if after.ID != before.ID || current.Mode != domain.SessionModeTUI {
+					t.Fatalf("fresh root was replaced or mode not committed: branch=%+v mode=%s", after, current.Mode)
+				}
+			} else if after.ProviderConversationID != before.ProviderConversationID ||
+				after.ProviderScopeID != before.ProviderScopeID || current.Mode != domain.SessionModeChat ||
+				current.Metadata.ProviderConversationID != "reserved-chat-id" {
+				t.Fatalf("failed epoch changed ownership: branch=%+v session=%+v", after, current)
+			}
+		})
+	}
+}

--- a/backend/internal/storage/sqlite/store/session_interface_transition_store.go
+++ b/backend/internal/storage/sqlite/store/session_interface_transition_store.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/gen"
-	"github.com/google/uuid"
 )
 
 // CreateSessionInterfaceTransition claims the one active transition slot for a

--- a/backend/internal/storage/sqlite/store/session_interface_transition_store.go
+++ b/backend/internal/storage/sqlite/store/session_interface_transition_store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/gen"
+	"github.com/google/uuid"
 )
 
 // CreateSessionInterfaceTransition claims the one active transition slot for a
@@ -190,7 +191,13 @@ func (s *Store) CommitSessionControllerEpoch(
 ) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	rows, err := s.qw.CommitSessionControllerEpoch(ctx, gen.CommitSessionControllerEpochParams{
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin controller epoch for %s: %w", id, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	q := s.qw.WithTx(tx)
+	rows, err := q.CommitSessionControllerEpoch(ctx, gen.CommitSessionControllerEpochParams{
 		SessionMode:            target,
 		AgentSessionID:         nativeID,
 		ProviderConversationID: nativeID,
@@ -202,7 +209,28 @@ func (s *Store) CommitSessionControllerEpoch(
 	if err != nil {
 		return false, fmt.Errorf("commit controller epoch for %s: %w", id, err)
 	}
-	return rows > 0, nil
+	if rows == 0 {
+		return false, nil
+	}
+	if source == domain.SessionModeChat && target == domain.SessionModeTUI && nativeID == "" {
+		// A fresh TUI will choose its own native identity. Release the unused
+		// Chat reservation and event namespace in the same transaction, so a
+		// later return can bind that identity without inventing inherited history.
+		released, err := q.ReleaseUntouchedConversationProvider(ctx, gen.ReleaseUntouchedConversationProviderParams{
+			SessionID:       sql.NullString{String: string(id), Valid: true},
+			ProviderScopeID: uuid.NewString(),
+		})
+		if err != nil {
+			return false, fmt.Errorf("release untouched Chat provider for %s: %w", id, err)
+		}
+		if released != 1 {
+			return false, fmt.Errorf("release untouched Chat provider for %s: empty root proof changed", id)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit controller epoch transaction for %s: %w", id, err)
+	}
+	return true, nil
 }
 
 // EnqueueSessionInterfaceTransitionMessage queues a user message while an interface transition is active.

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -81,7 +81,7 @@ export const ChatComposer = memo(function ChatComposer({
 	busy,
 	willQueue,
 	disabled,
-	connecting,
+	disabledPlaceholder,
 	settings,
 	approval,
 	skills = [],
@@ -118,8 +118,8 @@ export const ChatComposer = memo(function ChatComposer({
 	/** The agent is mid-turn, so this message is held until the turn ends. */
 	willQueue?: boolean;
 	disabled?: boolean;
-	/** An interface handoff is still installing the Chat controller. */
-	connecting?: boolean;
+	/** Explains why message entry is temporarily blocked. */
+	disabledPlaceholder?: string;
 	/** The provider's skills. Empty leaves `/` an ordinary character. */
 	skills?: ChatSkill[];
 	/** Worktree-relative paths offered for `@`. Empty leaves `@` ordinary. */
@@ -817,13 +817,11 @@ export const ChatComposer = memo(function ChatComposer({
 					disabled={controlsDisabled}
 					label="Message the agent"
 					placeholder={
-						connecting
-							? "Connecting to the agent…"
-							: disabled
-								? "The controller is not connected"
-									: willQueue
-										? "Agent is working — this sends when it finishes"
-										: "Message the agent…"
+						disabledPlaceholder ?? (disabled
+							? "The controller is not connected"
+							: willQueue
+								? "Agent is working — this sends when it finishes"
+								: "Message the agent…")
 					}
 					menuOpen={menuOpen}
 					menuId={menuId}

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -81,6 +81,7 @@ export const ChatComposer = memo(function ChatComposer({
 	busy,
 	willQueue,
 	disabled,
+	connecting,
 	settings,
 	approval,
 	skills = [],
@@ -117,6 +118,8 @@ export const ChatComposer = memo(function ChatComposer({
 	/** The agent is mid-turn, so this message is held until the turn ends. */
 	willQueue?: boolean;
 	disabled?: boolean;
+	/** An interface handoff is still installing the Chat controller. */
+	connecting?: boolean;
 	/** The provider's skills. Empty leaves `/` an ordinary character. */
 	skills?: ChatSkill[];
 	/** Worktree-relative paths offered for `@`. Empty leaves `@` ordinary. */
@@ -814,11 +817,13 @@ export const ChatComposer = memo(function ChatComposer({
 					disabled={controlsDisabled}
 					label="Message the agent"
 					placeholder={
-						disabled
-							? "The controller is not connected"
-							: willQueue
-								? "Agent is working — this sends when it finishes"
-								: "Message the agent…"
+						connecting
+							? "Connecting to the agent…"
+							: disabled
+								? "The controller is not connected"
+									: willQueue
+										? "Agent is working — this sends when it finishes"
+										: "Message the agent…"
 					}
 					menuOpen={menuOpen}
 					menuId={menuId}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -338,6 +338,8 @@ describe("ChatWorkspace timeline", () => {
 		const user = userEvent.setup();
 		const onDecide = vi.fn();
 		const view = render(<ChatWorkspace snapshot={idleSnapshot()} newWorkDisabled />);
+		expect(screen.getByText("Switching to terminal UI…")).toBeInTheDocument();
+		expect(screen.queryByText("The controller is not connected")).not.toBeInTheDocument();
 
 		expect(screen.getByTestId("chat-conversation-panel")).not.toHaveAttribute("inert");
 		expect(screen.getByLabelText("Message the agent")).toHaveAttribute("aria-disabled", "true");

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -989,14 +989,15 @@ describe("ChatWorkspace timeline", () => {
 		);
 
 		expect(screen.getByRole("alert")).toHaveTextContent("The agent controller stopped");
+		expect(screen.getByText("The controller is not connected")).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: "Resume agent" }));
 		await user.click(screen.getByRole("button", { name: "Open shell" }));
 		expect(resume).toHaveBeenCalledOnce();
 		expect(openShell).toHaveBeenCalledOnce();
 	});
 
-	it("does not report the intentional controller gap during an interface handoff as a crash", () => {
-		render(
+	it("shows connecting during the controller gap, then restores the composer when ready", () => {
+		const { rerender } = render(
 			<ChatWorkspace
 				snapshot={{
 					...chatFixtureSettled,
@@ -1010,6 +1011,13 @@ describe("ChatWorkspace timeline", () => {
 
 		expect(screen.queryByText("The agent controller stopped")).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Resume agent" })).not.toBeInTheDocument();
+		expect(screen.getByText("Connecting to the agent…")).toBeInTheDocument();
+		expect(screen.queryByText("The controller is not connected")).not.toBeInTheDocument();
+		expect(screen.getByRole("combobox", { name: "Message the agent" })).toHaveAttribute("contenteditable", "false");
+
+		rerender(<ChatWorkspace snapshot={chatFixtureEmpty} />);
+		expect(screen.queryByText("Connecting to the agent…")).not.toBeInTheDocument();
+		expect(screen.getByRole("combobox", { name: "Message the agent" })).toHaveAttribute("contenteditable", "true");
 	});
 
 	it("announces thread and tool-server failures", () => {

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -865,7 +865,7 @@ export function ChatWorkspace({
 					configPending={configOptionPending}
 					error={configOptionError}
 					disabled={
-						snapshot.controller.state === "stopped" || configOptionPending || newWorkDisabled
+						snapshot.controller.state === "stopped" || controllerTransitioning || configOptionPending || newWorkDisabled
 					}
 				/>
 			) : null,
@@ -873,6 +873,7 @@ export function ChatWorkspace({
 			configOptionError,
 			configOptionPending,
 			configOptions,
+			controllerTransitioning,
 			models,
 			newWorkDisabled,
 			onChooseConfigOption,
@@ -1166,7 +1167,8 @@ export function ChatWorkspace({
 									settings={composerSettings}
 									busy={busy}
 									willQueue={Boolean(turn)}
-									disabled={snapshot.controller.state === "stopped" || newWorkDisabled}
+									disabled={snapshot.controller.state === "stopped" || controllerTransitioning || newWorkDisabled}
+									connecting={controllerTransitioning}
 									skills={skills}
 									filePaths={filePaths}
 									filePathsTruncated={filePathsTruncated}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1168,7 +1168,9 @@ export function ChatWorkspace({
 									busy={busy}
 									willQueue={Boolean(turn)}
 									disabled={snapshot.controller.state === "stopped" || controllerTransitioning || newWorkDisabled}
-									connecting={controllerTransitioning}
+									disabledPlaceholder={controllerTransitioning
+										? "Connecting to the agent…"
+										: newWorkDisabled ? "Switching to terminal UI…" : undefined}
 									skills={skills}
 									filePaths={filePaths}
 									filePathsTruncated={filePathsTruncated}

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -8,6 +8,7 @@ import type { ChatConfigOption, ConversationSnapshot } from "../../types/convers
 import type { AgentSwitchSummary, WorkspaceSession } from "../../types/workspace";
 import { useUiStore } from "../../stores/ui-store";
 import { workspaceQueryKey } from "../../hooks/useWorkspaceQuery";
+import { useConversationConfigOptions, useConversationModels, useConversationSkills } from "../../hooks/useConversation";
 
 const LINK = "http://localhost:5173";
 
@@ -81,9 +82,9 @@ vi.mock("../../hooks/useConversation", () => ({
 			: undefined,
 	}),
 	useConversationCommands: () => conversationCommandState,
-	useConversationConfigOptions: () => configState,
-	useConversationModels: () => ({ models: [] }),
-	useConversationSkills: () => ({ skills: [] }),
+	useConversationConfigOptions: vi.fn(() => configState),
+	useConversationModels: vi.fn(() => ({ models: [] })),
+	useConversationSkills: vi.fn(() => ({ skills: [] })),
 	useStageAttachments: () => undefined,
 	useWorkspaceFilePaths: () => ({ paths: [], truncated: false }),
 }));
@@ -729,6 +730,31 @@ describe("SessionChatSurface link routing", () => {
 	});
 });
 
+
+describe("controller catalogs during an interface handoff", () => {
+	it.each(["stopped", "connecting", "ready"] as const)("waits through handoff with a %s snapshot, then loads catalogs", (state) => {
+		conversationState.snapshot = { capabilities: ["config_options"], controller: { state } };
+		const client = new QueryClient();
+		const { rerender } = render(<Wrapper client={client}><SessionChatSurface session={session} controllerTransitioning /></Wrapper>);
+		for (const hook of [useConversationConfigOptions, useConversationModels, useConversationSkills]) {
+			expect(hook).toHaveBeenLastCalledWith(session.id, false);
+		}
+
+		conversationState.snapshot = { capabilities: ["config_options"], controller: { state: "ready" } };
+		rerender(<Wrapper client={client}><SessionChatSurface session={session} /></Wrapper>);
+		for (const hook of [useConversationConfigOptions, useConversationModels, useConversationSkills]) {
+			expect(hook).toHaveBeenLastCalledWith(session.id, true);
+		}
+	});
+
+	it("does not poll an unavailable controller after a failed handoff", () => {
+		conversationState.snapshot = { capabilities: ["config_options"], controller: { state: "stopped" } };
+		render(<Wrapper client={new QueryClient()}><SessionChatSurface session={session} /></Wrapper>);
+		for (const hook of [useConversationConfigOptions, useConversationModels, useConversationSkills]) {
+			expect(hook).toHaveBeenLastCalledWith(session.id, false);
+		}
+	});
+});
 
 describe("project remembering waits for provider permissions", () => {
 	it.each([undefined, "Catalog unavailable"])("withholds Remember when provider catalog is not known (%s)", (error) => {

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -158,9 +158,14 @@ export function SessionChatSurface({
 		if (!conversationWorkKnown) return;
 		onConversationWorkChange?.({ controllerBusy, hasRunningTurn, queuedTurnCount });
 	}, [controllerBusy, conversationWorkKnown, hasRunningTurn, onConversationWorkChange, queuedTurnCount]);
+	const targetChatControllerReady =
+		snapshot?.controller?.state === "ready" || snapshot?.controller?.state === "busy";
+	// Mode commits before the target controller starts. A cached ready snapshot
+	// can also outlive the source, so wait for the handoff's final snapshot refresh.
+	const controllerCatalogsEnabled = targetChatControllerReady && !controllerTransitioning && !newWorkDisabled;
 	const configOptions = useConversationConfigOptions(
 		session.id,
-		Boolean(snapshot && can(snapshot, "config_options")),
+		Boolean(controllerCatalogsEnabled && snapshot && can(snapshot, "config_options")),
 	);
 	// A provider config catalog may cover only model, only mode, or both.
 	// Suppress native controls only for dimensions the provider catalog replaces;
@@ -176,9 +181,9 @@ export function SessionChatSurface({
 	// from the live controller, so there is nothing to fetch before then.
 	const { models } = useConversationModels(
 		session.id,
-		Boolean(snapshot) && !hasProviderModel,
+		controllerCatalogsEnabled && !hasProviderModel,
 	);
-	const { skills } = useConversationSkills(session.id, Boolean(snapshot));
+	const { skills } = useConversationSkills(session.id, controllerCatalogsEnabled);
 	const { paths, truncated } = useWorkspaceFilePaths(session.id, Boolean(snapshot));
 	const stageAttachments = useStageAttachments(session.id);
 	const openLinkInBrowser = useSessionBrowserLink(session);
@@ -224,8 +229,6 @@ export function SessionChatSurface({
 			: undefined;
 	const agentSwitch = durableAgentSwitch ?? admissionAgentSwitch ?? observedTerminalSwitch;
 	useAgentSwitchRouteVisibility(`session/${session.id}`, agentSwitch && agentSwitch.state !== "completed" && agentSwitch.state !== "failed" ? "active" : "history", undefined, false);
-	const targetChatControllerReady =
-		snapshot?.controller?.state === "ready" || snapshot?.controller?.state === "busy";
 	const switchPresentation = agentSwitch
 		? deriveAgentSwitchPresentation({
 				agentSwitch,


### PR DESCRIPTION
Code changes: +157 -31  
Tests: +543 -5  
Others: +38 -0 (generated sqlc)

## Controller startup follow-up

Terminal → Chat commits the interface mode before installing the new controller. Chat previously requested Claude's provider settings and skills during that interval and rendered `CHAT_CONTROLLER_NOT_READY` from HTTP 409 as a red error. Wait for a dispatchable controller and the handoff's final snapshot refresh before loading provider catalogs. Keep the composer and settings disabled with “Connecting to the agent…” during the return, and “Switching to terminal UI…” during the outward handoff. A genuinely stopped controller still exposes its error and recovery actions.

## Desktop verification of Nikhil’s reproduction

Verified on **`7035c185f03ba64ed82323c684be7355531d648e`** using the real AO Electron app, installed Claude Code 2.1.263 and Codex 0.153.4, and isolated local daemon/state.

**Both new recordings show the complete Chat → TUI → Chat → TUI sequence**, including the final ready terminal. These are continuous, uncut captures at normal speed: no waiting intervals or error frames have been removed. No prompts were submitted. Each provider completed all three transitions, returned to a ready, empty Chat with **sequence 0, 0 turns, 0 messages**, and reached the terminal again. All settings/models/skills reads for these tasks returned HTTP 200; none returned 409.

**Claude — 81 seconds, full uncut sequence**

[Watch/download MP4](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/claude-full-loop-uncut.mp4) · [Original MOV capture](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/claude-full-loop-uncut.mov)

![Claude: complete uncut Chat → TUI → Chat → TUI, without the controller error](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/claude-full-loop-uncut.gif)

**Codex — 128 seconds, full uncut sequence**

[Watch/download MP4](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/codex-full-loop-uncut.mp4) · [Original MOV capture](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/codex-full-loop-uncut.mov)

![Codex: complete uncut Chat → TUI → Chat → TUI, without the controller error](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/codex-full-loop-uncut.gif)

[Task IDs, all three transition timestamps, HTTP results, zero-history assertions, source hashes, and full-recording frame audit](https://github.com/Untrivial-ai/agent-orchestrator/blob/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/full-loop-uncut-evidence.json). The MP4s preserve every encoded video packet from the original MOVs, verified by matching packet hashes: **4,051 Claude frames and 6,430 Codex frames**. Visual review and the red-composer-pixel check across every decoded source frame found no controller-error flash. The same check detected the earlier Claude error in 107 frames. GIF previews retain the full timeline at normal speed with a lower frame rate and resolution. Media remains on the separate evidence branch, outside this PR’s code diff.

These full recordings replace the partial 11-second Claude and 25-second Codex clips. The earlier Claude recording **did contain** the startup error at 00:23; the implementation fix described above addresses it. The faulty recording is retained as [historical evidence](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/claude-review-roundtrip-short.mp4), alongside its [original assertions](https://github.com/Untrivial-ai/agent-orchestrator/blob/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/desktop-roundtrip-evidence.json). The new recordings demonstrate the complete untouched round trip after [Nikhil’s report](https://github.com/Untrivial-ai/agent-orchestrator/pull/5053#issuecomment-5574988987).

### Startup-fix validation

- Regression tests failed before the fix. They cover stopped/connecting/cached-ready snapshots during handoff, enabling catalogs after readiness, unavailable controllers after failed handoffs, composer readiness, outward handoff text, and preserving real recovery actions.
- Node 24: full frontend Vitest suite **281 files, 3,902 tests passed, six skipped**; frontend and E2E TypeScript checks passed.
- Full local renderer Playwright smoke suite: **55 passed**. The first run had a five-second initial-page timeout in the task-focus test; the complete rerun passed. These renderer tests use the repository's fake bridge; the desktop recordings above use real providers and daemon.
- Product UI: typecheck, 120 tests, and package dry run passed. Cloud client: generated schema has no diff, typecheck, 21 tests, and package dry run passed. Local native SQLite bindings and landing/client dependencies were repaired before the complete passing suites.
- All **11 CI checks passed on `7035c185f`**, including the full Linux backend race suite, frontend tests, renderer smoke, API drift, lint, all three native CLI jobs, container install, Windows workspace tests, and secret scanning. [Backend results](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34208952399), [frontend results](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34208952395). Backend code is unchanged by this renderer follow-up; full local backend validation on `f13c15f58` is recorded below. Linux container and native Windows validation are verified in CI, not claimed as local macOS passes.

## Review follow-up

Allow untouched Claude and Codex tasks to return from Terminal to Chat when the startup hook has only reserved a nonexistent transcript path. Keep prompt, response, current-terminal, and post-fence checks; reject existing paths and lookup errors. Recognize Claude’s initial composer, move the history-probe requirement into the TUI branch, and clarify reserved Chat IDs. A fresh Chat-to-TUI commit atomically releases the unused root provider binding and rotates its event namespace so repeated switches and the first real terminal conversation can bind correctly.

### Follow-up validation

- Reproduced the review failures with regression tests before fixing them. Tests cover both production provider adapters, real SQLite conversation ownership, reserved-path rejection, existing-history preservation, and a transcript appearing after input is fenced.
- Real local Claude Code 2.1.263 and Codex 0.153.4 both passed Chat → Terminal → Chat before any prompt, another switch to Terminal, and return to Chat after a real provider response. Untouched returns retained sequence 0, 0 turns, and 0 messages; used returns preserved the native conversation identity and replayed the assistant response.
- Claude's post-response drain correctly refused a visible composer draft. The explicit interrupt policy discarded that test draft and completed the history-preserving return. Codex's post-response return completed with drain.
- [Live-provider E2E results and transition timestamps](https://github.com/Untrivial-ai/agent-orchestrator/blob/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/review-followup-e2e.json). These earlier checks use the real isolated daemon and installed providers. The subsequent native desktop recordings above now verify the full untouched round trip visually; the original forward-flow recordings remain below as historical evidence.
- On `f13c15f58`, the full Go suite (`go test -p 2 -timeout=15m ./...`), full race suite (`go test -race -p 2 -timeout=15m ./...`), build, vet, golangci-lint v2.12.2 (zero findings), Node 24 API generation (no drift), and native macOS CLI E2E all passed locally. SQLC was regenerated from the query source.
- All **9 GitHub Actions checks passed** on `f13c15f58ca3d427fa4e3f403550b3b095a3ddfe`: full Linux backend race suite, Windows workspace tests, native CLI E2E on Linux/macOS/Windows, container install, lint, API drift, and secret scanning. [Final CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5053/checks).

Local environment: macOS arm64, Node 24.14.0, effective Go 1.26.5. Docker was unavailable locally, so the container-install and Docker-based secret-scan checks are verified in CI; Windows/Linux native execution is also verified in CI.

### Original problem and forward-switch implementation

Switching a new Chat task to the terminal before sending its first message currently fails with `NATIVE_SESSION_MISSING`, including Claude Code and Codex. Allow a fresh terminal launch only when durable history proves that the task has never accepted a message, activity, or provider turn and has no inherited branch context.

Recheck that proof after fencing input and draining the source, so a racing first message cannot be discarded. Existing conversations still require a resumable provider identity. Regression coverage uses both production provider adapters and real SQLite conversation storage, and checks refusal and input-race paths.

Related: [issue #4921](https://github.com/Untrivial-ai/agent-orchestrator/issues/4921), [PR #4925](https://github.com/Untrivial-ai/agent-orchestrator/pull/4925).

## Original forward-switch validation (862445ae7)

- Regression reproduced against the original implementation for both Claude and Codex, then passed with this change. The adapter tests use temporary provider executables and a fixture-only PATH; they require no Claude/Codex installation.
- Full Go suite passed; full race suite passed with `go test -race -p 4 -timeout=15m ./...`. The initial unrestricted parallel run hit a Pi timing test; the complete Pi package rerun and subsequent full race run passed.
- `go build ./...`, `go vet ./...`, golangci-lint v2.12.2: passed, zero lint findings.
- Pinned gitleaks v7.4.0: local scan passed on the production fix; the final test-only commit passed the scan in CI. The local rescan was blocked by Docker storage I/O failure.
- Node 24 `npm run api`: passed with no generated API/type drift.
- Native macOS CLI E2E: `go test -tags e2e -v ./internal/cli/...` passed.
- Clean Linux Docker install: `docker build -f test/cli/Dockerfile ...` and `docker run --rm --init ...` passed.
- Live isolated daemon: untouched Claude and Codex Chat tasks both completed Chat → TUI, with zero conversation messages/turns. No prompt was sent.
- Actual Electron desktop E2E: created a blank Claude task, opened Session actions, selected Switch to terminal UI, and observed the real Claude composer. The attached screen recording captures this flow. The Codex desktop flow was subsequently recorded too: blank Codex task → Switch to terminal UI → ready native Codex composer, with zero messages and turns.

The recording exercises the production code in `19109e591`; `862445ae7` changes only test fixtures. Full local race/build/vet/lint checks passed on the final commit. A supplementary Linux-container regression attempt was blocked by Docker storage becoming read-only; Linux validation is covered by CI.

Local environment: macOS arm64, Node 24.14.0, effective Go 1.26.5 (required by the checked-in `go.work`). Windows execution and the hosted Linux/macOS matrix are checked in GitHub Actions, not claimed as local native passes.

## Original forward-switch recordings

Claude Code: create an empty Chat task → switch to terminal before the first message → ready Claude terminal composer. Recorded from this checkout in an isolated AO Electron profile and daemon; runtime state is outside the repository.

[Watch the 59-second screen recording (MP4)](https://github.com/Untrivial-ai/agent-orchestrator/blob/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/claude-unprompted.mp4)

[![Screen recording: empty Claude Chat task switching to a ready terminal](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/claude-unprompted.gif)](https://github.com/Untrivial-ai/agent-orchestrator/blob/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/claude-unprompted.mp4)

The inline GIF preserves the full flow and timing; the MP4 is linked above. Recording and preview are uploaded to a separate evidence branch; they are not part of this code diff.

All **9 GitHub Actions checks passed** on `862445ae73244319e8ed728fb6a3862b96662fc9`, including the complete Linux backend race suite, Windows workspace tests, native CLI E2E on Linux/macOS/Windows, container install, lint, API drift, and secret scanning. [CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5053/checks).


### Codex screen recording

Recorded on the final commit `862445ae7` in the real Electron app, with isolated data at `~/.ao/dev/fresh-chat-pr-codex`. Created an empty Codex Chat task, selected **Switch to terminal UI**, and reached OpenAI Codex v0.153.4 with an empty composer. No message was sent. The transition completed and durable history remained at sequence 0 with 0 turns.

[Download the Codex recording (MP4, 60 seconds)](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/codex-unprompted.mp4)

![Codex: blank Chat task to ready native terminal before the first message](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-fresh-chat-switch-5053/.issue-assets/fresh-chat-switch-5053/codex-unprompted.gif)
