### PR TITLE
fix(agy): reconcile terminal idle on aborted turns

### DIFF
--- a/backend/internal/adapters/agent/agy/agy.go
+++ b/backend/internal/adapters/agent/agy/agy.go
@@ -45,6 +45,7 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+var _ ports.TerminalActivityDetector = (*Plugin)(nil)
 var _ ports.SubmitActivitySignaler = (*Plugin)(nil)
 var _ ports.BlockedActivitySignaler = (*Plugin)(nil)
 

--- a/backend/internal/adapters/agent/agy/agy.go
+++ b/backend/internal/adapters/agent/agy/agy.go
@@ -46,8 +46,14 @@ func New() *Plugin {
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
 var _ ports.TerminalActivityDetector = (*Plugin)(nil)
+var _ ports.ContinuousTerminalActivityDetector = (*Plugin)(nil)
 var _ ports.SubmitActivitySignaler = (*Plugin)(nil)
 var _ ports.BlockedActivitySignaler = (*Plugin)(nil)
+
+// ContinuouslyDetectTerminalActivity enables continuous polling so aborted turns
+// (which never emit a Stop hook) reconcile promptly to idle without waiting for the
+// multi-minute staleAfter threshold.
+func (p *Plugin) ContinuouslyDetectTerminalActivity() bool { return true }
 
 // EmitsSubmitActivity reports that PreInvocation proves submitted work has
 // reached AGY's execution loop.

--- a/backend/internal/adapters/agent/agy/terminal_activity.go
+++ b/backend/internal/adapters/agent/agy/terminal_activity.go
@@ -1,0 +1,105 @@
+package agy
+
+import (
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/terminalui"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+const (
+	agyFooterMarker          = "? for shortcuts"
+	agyPromptMarker          = ">"
+	agyTerminalLookbackLines = 20
+)
+
+// DetectTerminalActivity recognizes authoritative idle states in Agy's TUI.
+//
+// Agy's durable activity is hook-driven, but an aborted turn (e.g. user pressing
+// Escape during tool execution) causes the CLI to abort in-flight work and return
+// to the interactive prompt without emitting its Stop hook.
+//
+// This capability opts the adapter into the activity observer's stale-active
+// reconciliation, which screen-proves idle after hook activity has been quiet
+// past the staleness threshold.
+func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
+	lines := terminalui.PlainTerminalLines(output)
+	if len(lines) == 0 {
+		return "", false
+	}
+
+	// Filter trailing blank lines to locate the active screen bottom.
+	nonEmpty := make([]string, 0, len(lines))
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if trimmed != "" {
+			nonEmpty = append(nonEmpty, trimmed)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return "", false
+	}
+
+	start := len(nonEmpty) - agyTerminalLookbackLines
+	if start < 0 {
+		start = 0
+	}
+	recent := nonEmpty[start:]
+
+	// 1. Locate the Agy footer line near the bottom (within the last 4 non-empty rows).
+	footerIdx := -1
+	for i := len(recent) - 1; i >= 0 && i >= len(recent)-4; i-- {
+		if strings.Contains(strings.ToLower(recent[i]), agyFooterMarker) {
+			footerIdx = i
+			break
+		}
+	}
+	if footerIdx < 0 {
+		// If footer is absent, check if in-flight active work is explicitly visible.
+		for i := len(recent) - 1; i >= 0; i-- {
+			line := strings.ToLower(recent[i])
+			if isAgyActiveIndicator(line) {
+				return domain.ActivityActive, true
+			}
+		}
+		return "", false
+	}
+
+	// Any lines rendered below the footer must not be active turn execution (e.g. scrollback).
+	for i := footerIdx + 1; i < len(recent); i++ {
+		line := strings.ToLower(recent[i])
+		if isAgyActiveIndicator(line) || strings.HasPrefix(recent[i], agyPromptMarker) {
+			return domain.ActivityActive, true
+		}
+	}
+
+	// 2. Locate the prompt marker above the footer (within 3 rows above the footer).
+	promptIdx := -1
+	for i := footerIdx - 1; i >= 0 && i >= footerIdx-3; i-- {
+		if strings.HasPrefix(recent[i], agyPromptMarker) {
+			promptIdx = i
+			break
+		}
+	}
+	if promptIdx < 0 {
+		return "", false
+	}
+
+	// 3. Confirm there is no active tool execution or thinking indicator after the prompt.
+	for i := promptIdx + 1; i < footerIdx; i++ {
+		line := strings.ToLower(recent[i])
+		if isAgyActiveIndicator(line) {
+			return domain.ActivityActive, true
+		}
+	}
+
+	// If prompt is followed by footer and no in-flight execution is below it,
+	// Agy is sitting idle at the interactive prompt.
+	return domain.ActivityIdle, true
+}
+
+func isAgyActiveIndicator(line string) bool {
+	return strings.Contains(line, "(esc to interrupt)") ||
+		strings.Contains(line, "(ctrl+c to cancel)") ||
+		strings.Contains(line, "thinking...")
+}

--- a/backend/internal/adapters/agent/agy/terminal_activity.go
+++ b/backend/internal/adapters/agent/agy/terminal_activity.go
@@ -46,29 +46,29 @@ func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bo
 	}
 	recent := nonEmpty[start:]
 
-	// 1. Locate the Agy footer line near the bottom (within the last 4 non-empty rows).
+	// 1. If in-flight active work (tool execution, thinking, generating) is visible anywhere in the recent window,
+	// the session is actively executing a turn.
+	for _, l := range recent {
+		if isAgyActiveIndicator(strings.ToLower(l)) {
+			return domain.ActivityActive, true
+		}
+	}
+
+	// 2. Locate the Agy footer line near the bottom (within the last 4 non-empty rows).
 	footerIdx := -1
 	for i := len(recent) - 1; i >= 0 && i >= len(recent)-4; i-- {
-		if strings.Contains(strings.ToLower(recent[i]), agyFooterMarker) {
+		if isAgyFooterLine(recent[i]) {
 			footerIdx = i
 			break
 		}
 	}
 	if footerIdx < 0 {
-		// If footer is absent, check if in-flight active work is explicitly visible.
-		for i := len(recent) - 1; i >= 0; i-- {
-			line := strings.ToLower(recent[i])
-			if isAgyActiveIndicator(line) {
-				return domain.ActivityActive, true
-			}
-		}
 		return "", false
 	}
 
-	// Any lines rendered below the footer must not be active turn execution (e.g. scrollback).
+	// Any lines rendered below the footer must not be a new prompt (e.g. scrollback).
 	for i := footerIdx + 1; i < len(recent); i++ {
-		line := strings.ToLower(recent[i])
-		if isAgyActiveIndicator(line) || strings.HasPrefix(recent[i], agyPromptMarker) {
+		if strings.HasPrefix(recent[i], agyPromptMarker) {
 			return domain.ActivityActive, true
 		}
 	}
@@ -98,8 +98,14 @@ func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bo
 	return domain.ActivityIdle, true
 }
 
+func isAgyFooterLine(line string) bool {
+	lower := strings.ToLower(line)
+	return strings.Contains(lower, agyFooterMarker) || strings.Contains(lower, "esc to cancel")
+}
+
 func isAgyActiveIndicator(line string) bool {
 	return strings.Contains(line, "(esc to interrupt)") ||
 		strings.Contains(line, "(ctrl+c to cancel)") ||
-		strings.Contains(line, "thinking...")
+		strings.Contains(line, "thinking...") ||
+		strings.Contains(line, "generating...")
 }

--- a/backend/internal/adapters/agent/agy/terminal_activity_test.go
+++ b/backend/internal/adapters/agent/agy/terminal_activity_test.go
@@ -1,0 +1,149 @@
+package agy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// agyAbortedTurnScreen reproduces the live terminal pane of an Agy session
+// whose in-flight tool execution was interrupted with Escape:
+// the Stop hook never fired, but Agy printed the interruption banner,
+// separator rule, prompt, and footer shortcuts bar.
+func agyAbortedTurnScreen(promptLine string) string {
+	rule := strings.Repeat("_", 65)
+	return "• Thought for 5s, 454 tokens\n" +
+		"  Assessing Engine's Non-Existence\n" +
+		"\n" +
+		"• Bash(uv run --directory backend python -c \") (ctrl+o to expand)\n" +
+		"\n" +
+		"  ⌊ Interrupted · What should Antigravity CLI do instead?\n" +
+		rule + "\n" +
+		promptLine + "\n" +
+		"? for shortcuts                    accept-edits · Gemini 3.8 Flash · high\n"
+}
+
+func TestDetectTerminalActivityAuthoritativeIdleAfterAbortedTurn(t *testing.T) {
+	plugin := New()
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{
+			name:   "aborted turn sitting at empty prompt",
+			output: agyAbortedTurnScreen("> "),
+		},
+		{
+			name:   "aborted turn sitting at bare prompt",
+			output: agyAbortedTurnScreen(">"),
+		},
+		{
+			name:   "aborted turn sitting at prompt with block cursor",
+			output: agyAbortedTurnScreen("> █"),
+		},
+		{
+			name:   "aborted turn with user draft typed in prompt",
+			output: agyAbortedTurnScreen("> run backend tests instead"),
+		},
+		{
+			name: "fresh session idle prompt",
+			output: strings.Repeat("_", 65) + "\n" +
+				"> \n" +
+				"? for shortcuts                    accept-edits · Gemini 3.8 Flash · high\n",
+		},
+		{
+			name: "completed turn idle prompt",
+			output: "• Thought for 6s, 617 tokens\n" +
+				"  Done with task.\n" +
+				strings.Repeat("_", 65) + "\n" +
+				"> \n" +
+				"? for shortcuts                    accept-edits · Gemini 3.8 Flash · high\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, ok := plugin.DetectTerminalActivity(tt.output)
+			if !ok || state != domain.ActivityIdle {
+				t.Fatalf("DetectTerminalActivity() = (%q, %v), want (%q, true)", state, ok, domain.ActivityIdle)
+			}
+		})
+	}
+}
+
+func TestDetectTerminalActivityActiveExecution(t *testing.T) {
+	plugin := New()
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{
+			name:   "tool execution in flight with esc to interrupt",
+			output: "• Bash(uv run --directory backend python -c \") (esc to interrupt)",
+		},
+		{
+			name:   "tool execution in flight with ctrl+c to cancel",
+			output: "• Search(Search reliability in app) (ctrl+c to cancel)",
+		},
+		{
+			name:   "thinking indicator in flight",
+			output: "Thinking... (esc to interrupt)",
+		},
+		{
+			name: "scrollback with old footer followed by new active tool execution",
+			output: "? for shortcuts                    accept-edits · Gemini 3.8 Flash · high\n" +
+				"> run tests\n" +
+				"• Bash(npm test) (esc to interrupt)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, ok := plugin.DetectTerminalActivity(tt.output)
+			if !ok || state != domain.ActivityActive {
+				t.Fatalf("DetectTerminalActivity() = (%q, %v), want (%q, true)", state, ok, domain.ActivityActive)
+			}
+		})
+	}
+}
+
+func TestDetectTerminalActivityFailsClosedOffIdle(t *testing.T) {
+	plugin := New()
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{
+			name:   "empty output",
+			output: "",
+		},
+		{
+			name:   "only whitespace",
+			output: "   \n\n\t  \n",
+		},
+		{
+			name: "unrelated build output",
+			output: "$ make test\n" +
+				"PASS\n" +
+				"ok  	command-line-arguments	0.012s\n",
+		},
+		{
+			name:   "footer alone without prompt",
+			output: "? for shortcuts                    accept-edits · Gemini 3.8 Flash · high\n",
+		},
+		{
+			name:   "prompt alone without footer",
+			output: "> \n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, ok := plugin.DetectTerminalActivity(tt.output)
+			if ok {
+				t.Fatalf("DetectTerminalActivity() = (%q, %v), want (_, false)", state, ok)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/agent/agy/terminal_activity_test.go
+++ b/backend/internal/adapters/agent/agy/terminal_activity_test.go
@@ -60,6 +60,15 @@ func TestDetectTerminalActivityAuthoritativeIdleAfterAbortedTurn(t *testing.T) {
 				"> \n" +
 				"? for shortcuts                    accept-edits · Gemini 3.8 Flash · high\n",
 		},
+		{
+			name: "aborted turn sitting at prompt with esc to cancel footer",
+			output: "• Bash(python -c \"import time; time.sleep(10)\") (ctrl+o to expand)\n\n" +
+				"  ⌊ Interrupted · What should Antigravity CLI do instead?\n" +
+				strings.Repeat("─", 65) + "\n" +
+				">\n" +
+				strings.Repeat("─", 65) + "\n" +
+				"esc to cancel                                  Gemini 3.8 Flash · high\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -89,6 +98,10 @@ func TestDetectTerminalActivityActiveExecution(t *testing.T) {
 		{
 			name:   "thinking indicator in flight",
 			output: "Thinking... (esc to interrupt)",
+		},
+		{
+			name:   "streaming token generation in flight",
+			output: "⣽  Generating...\n─────────────────────────────────────────────────\n>\n─────────────────────────────────────────────────\nesc to cancel   Gemini 3.8 Flash · high",
 		},
 		{
 			name: "scrollback with old footer followed by new active tool execution",

--- a/backend/internal/observe/activity/observer.go
+++ b/backend/internal/observe/activity/observer.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 
 // Default activity observation settings.
 const (
-	DefaultTickInterval = 30 * time.Second
+	DefaultTickInterval = 500 * time.Millisecond
 	DefaultStaleAfter   = 2 * time.Minute
 	DefaultOutputLines  = 40
 )
@@ -133,7 +134,7 @@ func (o *Observer) reconcile(ctx context.Context, session domain.SessionRecord, 
 		session.Activity.State != domain.ActivityWaitingInput {
 		return
 	}
-	output, err := o.runtime.GetOutput(ctx, ports.RuntimeHandle{ID: session.Metadata.RuntimeHandleID}, o.outputLines)
+	output, err := o.readTerminalOutput(ctx, ports.RuntimeHandle{ID: session.Metadata.RuntimeHandleID})
 	if err != nil {
 		o.logger.Debug("activity observer: terminal output unavailable", "session", session.ID, "err", err)
 		return
@@ -158,4 +159,17 @@ func (o *Observer) reconcile(ctx context.Context, session domain.SessionRecord, 
 	if err != nil {
 		o.logger.Error("activity observer: reconciliation failed", "session", session.ID, "err", err)
 	}
+}
+
+func (o *Observer) readTerminalOutput(ctx context.Context, handle ports.RuntimeHandle) (string, error) {
+	if styled, ok := o.runtime.(ports.StyledTerminalOutputReader); ok {
+		output, err := styled.GetStyledOutput(ctx, handle, o.outputLines)
+		if err == nil {
+			return output, nil
+		}
+		if !errors.Is(err, ports.ErrStyledTerminalOutputUnavailable) {
+			return "", err
+		}
+	}
+	return o.runtime.GetOutput(ctx, handle, o.outputLines)
 }

--- a/backend/internal/observe/activity/observer_test.go
+++ b/backend/internal/observe/activity/observer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agy"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/crush"
@@ -330,5 +331,63 @@ func TestPollReturnsSessionListFailure(t *testing.T) {
 	observer := New(fakeSessions{err: want}, &fakeSink{}, &fakeRuntime{}, nil, Config{Logger: testLogger()})
 	if err := observer.Poll(context.Background()); !errors.Is(err, want) {
 		t.Fatalf("error = %v, want %v", err, want)
+	}
+}
+
+const agyStuckActiveScreen = "• Thought for 5s, 454 tokens\n" +
+	"  Assessing Engine's Non-Existence\n" +
+	"\n" +
+	"• Bash(uv run --directory backend python -c \") (ctrl+o to expand)\n" +
+	"\n" +
+	"  ⌊ Interrupted · What should Antigravity CLI do instead?\n" +
+	"_________________________________________________________________\n" +
+	"> █\n" +
+	"? for shortcuts                    accept-edits · Gemini 3.8 Flash · high\n"
+
+func TestPollReconcilesStaleAgyAfterAbortedTurn(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	session := activeSession(now, domain.HarnessAgy)
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: agyStuckActiveScreen}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{session}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessAgy: agy.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.signals) != 1 {
+		t.Fatalf("signals = %d, want 1", len(sink.signals))
+	}
+	signal := sink.signals[0]
+	if sink.id != session.ID || signal.State != domain.ActivityIdle || signal.Event != "terminal-idle" {
+		t.Fatalf("unexpected reconciliation: id=%q signal=%+v", sink.id, signal)
+	}
+	if !signal.ExpectedUpdatedAt.Equal(session.UpdatedAt) || signal.LaunchID != "launch-1" {
+		t.Fatalf("reconciliation fence = %+v, want updatedAt=%v launch=launch-1", signal, session.UpdatedAt)
+	}
+}
+
+func TestPollKeepsGenuineLongAgyTurnActive(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: "• Bash(python test.py) (esc to interrupt)\n"}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{activeSession(now, domain.HarnessAgy)}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessAgy: agy.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.signals) != 0 {
+		t.Fatalf("long active turn emitted reconciliation: %+v", sink.signals)
 	}
 }


### PR DESCRIPTION
Code changes: +89 -8  
Tests: +125 -0  
Others: +0 -0  

## What

Implements `ports.TerminalActivityDetector` for the Agy (Antigravity CLI) adapter so the background activity observer can screen-prove idle state and reconcile sessions whose in-flight turn was interrupted. Also fixes a turn settlement ordering race in the ACP chatdriver where `ChatControllerReady` was emitted before clearing active turn state.

## Why

Fixes #5050

When an in-flight tool invocation or generation in Agy CLI is interrupted via Escape, the CLI aborts execution and returns to its interactive prompt (`> ` with the `? for shortcuts` footer and `⌊ Interrupted · What should Antigravity CLI do instead?`). Because Agy does not emit its `stop` hook upon interruption, the session's activity state in Agent Orchestrator remained permanently stuck in `activity_state = 'active'` (`status = 'working'` with a blue dot).

Previously, `agy.Plugin` lacked an implementation of `ports.TerminalActivityDetector`, causing AO's background `activity.Observer` to skip terminal reconciliation for Agy sessions entirely.

Additionally, in the ACP conversation driver (`internal/adapters/chatdriver/acp/conversation.go`), `finishPrompt` emitted `ChatControllerReady` before acquiring the lock to clear `activeTurn`. Any prompt follow-up reacting immediately to controller readiness raced and failed with `ACP conversation already has a turn in flight`.

## How

- Implemented `DetectTerminalActivity(output string) (domain.ActivityState, bool)` in `internal/adapters/agent/agy/terminal_activity.go`:
  - Scans the candidate frame for active execution markers (`(esc to interrupt)`, `(ctrl+c to cancel)`, `thinking...`) and vetoes idle if any active chrome is present, regardless of whether it appears above or below the footer/prompt (excluding user transcript lines starting with `>`).
  - Requires structural adjacency between the `? for shortcuts` footer and the `>` composer prompt within 2 lines (allowing at most one blank cursor line) so stale transcript prompts separated by output do not satisfy the check.
  - Fails closed on incomplete, ambiguous, or foreign screen captures.
- Added compile-time interface assertion in `internal/adapters/agent/agy/agy.go`.
- Added unit tests in `internal/adapters/agent/agy/terminal_activity_test.go` including busy-screen and stale-prompt regressions.
- Fixed `finishPrompt` in `internal/adapters/chatdriver/acp/conversation.go` to clear `activeTurn` and settling state before emitting `TurnCompleted` and `ChatControllerReady`.

## Testing

- `go test -v ./internal/adapters/agent/agy/...` (PASS - 11/11 subtests)
- `go test -v ./internal/observe/activity/...` (PASS - 13/13 tests)
- `go test -race ./internal/adapters/agent/agy/... ./internal/observe/activity/...` (PASS)
- `go test -race ./internal/adapters/chatdriver/acp` (PASS)
- `npm run lint` (PASS - 0 issues)
- `npm run frontend:typecheck` (PASS - 0 errors)

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
