### PR TITLE
fix(review): sanitize reviewer pane handle for dotted session ids

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -3,8 +3,6 @@ package tmux
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -1113,43 +1111,7 @@ func tmuxSessionName(id domain.SessionID) (string, error) {
 	if raw == "" {
 		return "", errors.New("tmux runtime: session id is required")
 	}
-	return SessionName(raw), nil
-}
-
-// SessionName returns the tmux session name the runtime registers for a given
-// session id, applying the same sanitisation Create does. Callers that print an
-// attach hint must use this rather than the raw id.
-func SessionName(id string) string {
-	if sessionIDPattern.MatchString(id) && len(id) <= 48 {
-		return id
-	}
-	return sanitizedSessionName(id)
-}
-
-func sanitizedSessionName(raw string) string {
-	var b strings.Builder
-	lastDash := false
-	for _, r := range raw {
-		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
-		if valid {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
-	base := strings.Trim(b.String(), "-")
-	if base == "" {
-		base = "session"
-	}
-	if len(base) > 32 {
-		base = strings.TrimRight(base[:32], "-")
-	}
-	sum := sha256.Sum256([]byte(raw))
-	return base + "-" + hex.EncodeToString(sum[:4])
+	return domain.RuntimeHandleName(raw), nil
 }
 
 func handleID(handle ports.RuntimeHandle) (string, error) {

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -266,7 +266,7 @@ func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 	id := strings.ReplaceAll(t.Name(), "/", "_")
 	const launchID = "launch-1"
 	r := New(Options{Timeout: 5 * time.Second})
-	tmuxID := SessionName(id)
+	tmuxID := domain.RuntimeHandleName(id)
 	workspace := t.TempDir()
 	_ = r.Destroy(ctx, ports.RuntimeHandle{ID: tmuxID})
 	t.Cleanup(func() { _ = r.Destroy(context.Background(), ports.RuntimeHandle{ID: tmuxID}) })

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -302,7 +302,7 @@ func TestSessionNameSanitizesSpecialChars(t *testing.T) {
 }
 
 func TestSessionNamePassesThroughShortConforming(t *testing.T) {
-	if got := SessionName("myproj-1"); got != "myproj-1" {
+	if got := domain.RuntimeHandleName("myproj-1"); got != "myproj-1" {
 		t.Fatalf("SessionName = %q, want unchanged", got)
 	}
 }
@@ -313,10 +313,10 @@ func TestSessionNameMatchesCreateNaming(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tmuxSessionName: %v", err)
 	}
-	if got := SessionName(string(long)); got != viaCreate {
+	if got := domain.RuntimeHandleName(string(long)); got != viaCreate {
 		t.Fatalf("SessionName = %q, but Create uses %q", got, viaCreate)
 	}
-	if SessionName(string(long)) == string(long) {
+	if domain.RuntimeHandleName(string(long)) == string(long) {
 		t.Fatal("expected long id to be sanitised to a different name")
 	}
 }

--- a/backend/internal/domain/session_name.go
+++ b/backend/internal/domain/session_name.go
@@ -1,0 +1,52 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// sessionIDPattern matches runtime-safe session ids across runtimes (tmux,
+// conpty). Dots are legal in session ids because they derive from project
+// names, so ids need sanitising — not rejecting — before they become runtime
+// handles.
+var sessionIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// RuntimeHandleName returns the runtime-safe name for a session id, applying
+// the shared runtime sanitisation. Callers building runtime handles from raw
+// session ids (attach hints, per-worker panes) must use this rather than the
+// raw id, which can contain dots and other characters the runtimes' validators
+// reject.
+func RuntimeHandleName(id string) string {
+	if sessionIDPattern.MatchString(id) && len(id) <= 48 {
+		return id
+	}
+	return sanitizedSessionName(id)
+}
+
+func sanitizedSessionName(raw string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range raw {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+		if valid {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	base := strings.Trim(b.String(), "-")
+	if base == "" {
+		base = "session"
+	}
+	if len(base) > 32 {
+		base = strings.TrimRight(base[:32], "-")
+	}
+	sum := sha256.Sum256([]byte(raw))
+	return base + "-" + hex.EncodeToString(sum[:4])
+}

--- a/backend/internal/domain/session_name_test.go
+++ b/backend/internal/domain/session_name_test.go
@@ -1,0 +1,36 @@
+package domain
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestRuntimeHandleNamePassesThroughConforming(t *testing.T) {
+	if got := RuntimeHandleName("myproj-1"); got != "myproj-1" {
+		t.Fatalf("RuntimeHandleName = %q, want unchanged", got)
+	}
+}
+
+func TestRuntimeHandleNameSanitizesDottedProjectIDs(t *testing.T) {
+	got := RuntimeHandleName("axisrow.github.io-38")
+	if got == "axisrow.github.io-38" {
+		t.Fatalf("dot-containing id must be sanitized, got %q", got)
+	}
+	if !regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString(got) {
+		t.Fatalf("sanitized name %q is not runtime-safe", got)
+	}
+	// Deterministic and distinct from other ids of the same slug.
+	if again := RuntimeHandleName("axisrow.github.io-38"); again != got {
+		t.Fatalf("not deterministic: %q vs %q", got, again)
+	}
+	if other := RuntimeHandleName("axisrow.github.io-40"); other == got {
+		t.Fatalf("distinct ids collapsed to the same name %q", got)
+	}
+}
+
+func TestRuntimeHandleNameEmptyInput(t *testing.T) {
+	got := RuntimeHandleName("///")
+	if got == "" || !regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString(got) {
+		t.Fatalf("RuntimeHandleName(///) = %q, want a runtime-safe fallback", got)
+	}
+}

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -233,9 +233,11 @@ func looksLikeAuthFailure(err error) bool {
 }
 
 // reviewerHandleID is the stable runtime handle for a worker's reviewer pane, so
-// one live reviewer is reused across passes.
+// one live reviewer is reused across passes. It must go through the shared
+// sanitiser: worker ids derive from project names and can contain dots, which
+// runtime handle validators reject (issue #37).
 func reviewerHandleID(workerID domain.SessionID) string {
-	return "review-" + string(workerID)
+	return "review-" + domain.RuntimeHandleName(string(workerID))
 }
 
 func (l *agentLauncher) invocation(spec LaunchSpec) ports.ReviewInvocation {

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -940,3 +940,15 @@ func TestLauncherPreflightEnvPrefixWithMissingBinary(t *testing.T) {
 		t.Fatalf("err = %v, want 'not found'", err)
 	}
 }
+
+func TestReviewerHandleIDIsRuntimeSafe(t *testing.T) {
+	// Issue #37: a dotted project id flowed raw into the handle id and the
+	// tmux validator rejected it, failing every review trigger for the project.
+	got := reviewerHandleID(domain.SessionID("axisrow.github.io-38"))
+	if !strings.HasPrefix(got, "review-") || strings.Contains(got, ".") {
+		t.Fatalf("reviewerHandleID = %q, want review- prefixed id without the dot", got)
+	}
+	if reviewerHandleID(domain.SessionID("plain-1")) != "review-plain-1" {
+		t.Fatalf("conforming id must stay unchanged")
+	}
+}


### PR DESCRIPTION
Closes #37

Related: #4479 — same reject-vs-sanitize class on the conpty/Windows side. The conpty path is intentionally left a validator (it enforces the `Handle.ID == SessionID` ownership invariant at probe/destroy), so #4479 needs id normalization at SessionID mint time rather than this fix; this PR only repairs the tmux-side reviewer path where the raw id reached the validator.

## Summary

Triggering a review for any worker of a project whose id contains a dot failed with `REVIEW_OPERATION_FAILED`:

```
launch reviewer: reviewer replace stale pane:
tmux runtime: invalid handle id "review-<dotted-id>"
```

The reviewer pane handle was a raw concatenation `"review-" + workerID` (`review/launcher.go`), and the tmux `handleID` validator (`^[a-zA-Z0-9_-]+$`) **rejects** instead of sanitizing. Worker panes were unaffected because they go through `tmux.SessionName()`, which sanitizes (slug + short hash) — the same asymmetry #4479 documents on the conpty side.

## Fix

- New `domain.RuntimeHandleName(id)` — the shared sanitizer (conforming id passes through unchanged; otherwise slug + 4-byte sha256 suffix), moved verbatim from the tmux runtime so tmux and the review launcher share one implementation.
- `reviewerHandleID()` routes through it. Conforming ids are unchanged, so existing handles keep working; dotted ids previously never produced a live handle, so there is no migration concern.
- The tmux runtime now delegates to the shared helper (its local copy is deleted); the trivial exported `SessionName` wrapper had no external callers and was removed.

## Tests

- `domain/session_name_test.go`: passthrough for conforming ids, dotted id sanitized to a runtime-safe deterministic name, distinct ids don't collapse.
- `review/launcher_test.go`: regression — `reviewerHandleID` of a dotted id is `review-` prefixed and dot-free, conforming id unchanged.

`go build ./...`, package tests (`domain`, `review`, `adapters/runtime/tmux`), `gofmt -l`, `go vet` all green.

## Live verification (macOS, self-built daemon)

Same project (dotted id, session ids `-34`…`-38`), before and after the fix landed — from the `review_run` table:

```
-- before
...|<project>-34|failed|launch reviewer: reviewer replace stale pane:
   tmux runtime: invalid handle id "review-<project>-34"|...

-- after (fixed daemon, 5 runs in one sweep)
...|<project>-34|complete|Approving. ...|...
...|<project>-35|running|...|...
...|<project>-37|complete|Verdict: approving.|...
...|<project>-36|complete|Approved ✅ — no changes requested.|...
...|<project>-38|complete|## Review: **Approved** ✅ ...|...
```

Reviewer panes now live on sanitized handles and run real reviewers:

```
$ tmux -L ao list-sessions | grep <project>
<project-slug>-33-<hash>: 1 windows ...
<project-slug>-38-<hash>: 1 windows ...

$ pgrep -fl review-
... ao pty-host review-<project-slug>-34-<hash> ... claude --permission-mode auto ...
```

`ao review trigger <project>-38` returns cleanly instead of the 500:

```
reused the existing review for <project>-38
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
