### PR TITLE
fix(updates): keep failures out of sidebar

### DIFF
--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1280,6 +1280,24 @@ describe("startAutoUpdates", () => {
     });
   });
 
+  it("stops showing checking when an error event fires before the check promise settles", async () => {
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+    autoUpdater.checkForUpdates.mockImplementation(() => new Promise(() => undefined));
+
+    void module.checkForUpdatesNow(stateDir, { requestId: "manual-update-1" });
+    await flushMicrotasks();
+    expect(module.getUpdateStatus()).toMatchObject({ state: "checking" });
+
+    updaterEvents.get("error")?.(new Error("net::ERR_SSL_PROTOCOL_ERROR"));
+
+    expect(module.getUpdateStatus()).toMatchObject({
+      state: "error",
+      message: "net::ERR_SSL_PROTOCOL_ERROR",
+      netError: true,
+      requestId: "manual-update-1",
+    });
+  });
+
   it("keeps non-net manual check errors verbatim", async () => {
     const { module, autoUpdater } = await importAutoUpdater();
     autoUpdater.checkForUpdates.mockRejectedValueOnce(new Error("boom"));

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -2108,23 +2108,40 @@ describe("Sidebar", () => {
 		expect(screen.queryByLabelText(/Hide update/)).not.toBeInTheDocument();
 	});
 
-	it("offers a retry when automatic update checks keep failing", async () => {
-		// The state stays truthful (the suppressed automatic failure never
-		// replaced it); the flag is what makes the dead end visible.
+	it("keeps automatic update check failures out of the sidebar", async () => {
 		updateStatusMock.mockResolvedValue({ state: "idle", checksFailing: true });
 		renderSidebar();
 
-		// Both footer variants (expanded row and collapsed rail icon) are mounted.
-		const buttons = await screen.findAllByLabelText("Retry update check");
-		expect(buttons.length).toBeGreaterThan(0);
-		expect(screen.getByText("Update check failed")).toBeInTheDocument();
-		const failedRow = screen.getByTestId("sidebar-update-failed");
-		expect(failedRow).toHaveClass("border", "border-warning/35", "bg-warning/12", "text-warning");
-		expect(within(failedRow).getByText("Retry update check")).toBeVisible();
-		expect(failedRow.querySelector(".rounded-full")).toBeNull();
+		await waitFor(() => expect(updateStatusMock).toHaveBeenCalled());
+		expect(screen.queryByLabelText("Retry update check")).not.toBeInTheDocument();
+		expect(screen.queryByText("Update check failed")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("sidebar-update-failed")).not.toBeInTheDocument();
+	});
 
-		await userEvent.click(buttons[0]);
-		expect(checkUpdateMock).toHaveBeenCalledTimes(1);
+	it("keeps explicit update errors out of the sidebar", async () => {
+		updateStatusMock.mockResolvedValue({
+			state: "error",
+			message: "net::ERR_SSL_PROTOCOL_ERROR",
+			netError: true,
+		});
+		renderSidebar();
+
+		await waitFor(() => expect(updateStatusMock).toHaveBeenCalled());
+		expect(screen.queryByText("net::ERR_SSL_PROTOCOL_ERROR")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Retry update check")).not.toBeInTheDocument();
+	});
+
+	it("keeps a ready install action when a later check fails", async () => {
+		updateStatusMock.mockResolvedValue({
+			state: "error",
+			message: "net::ERR_SSL_PROTOCOL_ERROR",
+			staged: { version: "9.9.9", stagedAt: Date.now(), escalated: false },
+		});
+		renderSidebar();
+
+		expect(await screen.findByTestId("sidebar-update-ready")).toBeVisible();
+		expect(screen.getAllByLabelText("Restart to install update v9.9.9")).not.toHaveLength(0);
+		expect(screen.queryByText("net::ERR_SSL_PROTOCOL_ERROR")).not.toBeInTheDocument();
 	});
 
 	it("keeps a staged build's restart action ahead of the failing-checks retry", async () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -22,7 +22,6 @@ import {
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import {
-	AlertTriangle,
 	ChevronRight,
 	Download,
 	Folder,
@@ -2068,11 +2067,12 @@ type SidebarUpdateAction =
 	| { kind: "downloading"; percent?: number; preparing: boolean }
 	| { kind: "download"; version?: string }
 	| { kind: "install"; version?: string; escalated: boolean }
-	| { kind: "retry" }
 	| null;
 
 function sidebarUpdateAction(status: UpdateStatus, availableDismissed: boolean): SidebarUpdateAction {
-	if (status.state === "error" && status.staged?.ready !== true) return { kind: "retry" };
+	// Update failures belong in Settings, where the full message and recovery
+	// action have room. The sidebar stays focused on update progress and actions.
+	if (status.state === "error" && (status.staged === undefined || status.staged.ready === false)) return null;
 	if (status.state === "downloading" || status.state === "preparing" || status.staged?.ready === false) {
 		return { kind: "downloading", percent: status.percent, preparing: status.state === "preparing" || status.staged?.ready === false };
 	}
@@ -2095,11 +2095,6 @@ function sidebarUpdateAction(status: UpdateStatus, availableDismissed: boolean):
 		return { kind: "download", version: status.version };
 	}
 	if (staged) return { kind: "install", version: staged.version, escalated: staged.escalated };
-	// Ranked below a staged build on purpose: an update ready to install is more
-	// actionable than "checks are failing". Only when there is nothing better to
-	// show does the failure take the row — it used to render nothing at all,
-	// which reads as "up to date" rather than "checks are not getting through".
-	if (status.state === "error" || status.checkError || status.checksFailing === true) return { kind: "retry" };
 	return null;
 }
 
@@ -2205,27 +2200,6 @@ function UpdateStatusRow({
 		);
 	}
 
-	if (action.kind === "retry") {
-		return (
-			<button
-				aria-label={t("shell.retryUpdateCheck")}
-				className="flex w-full items-center gap-2.5 rounded-lg border border-warning/35 bg-warning/12 p-2.5 text-left text-control font-medium text-warning transition-colors hover:bg-warning/18 [&_svg]:text-warning"
-				data-testid="sidebar-update-failed"
-				onClick={() => void aoBridge.updates.check()}
-				tabIndex={tabIndex}
-				type="button"
-			>
-				<AlertTriangle aria-hidden="true" className="size-icon-lg shrink-0" />
-				<span className="min-w-0 flex-1">
-					<span className="block truncate tracking-tight">{status.message ?? status.checkError ?? t("shell.updateCheckFailed")}</span>
-					<span className="block truncate text-caption font-normal text-warning">
-						{t("shell.retryUpdateCheck")}
-					</span>
-				</span>
-			</button>
-		);
-	}
-
 	const versionLabel = updateVersionLabel(action.version, "ready", t, locale);
 	return (
 		<button
@@ -2309,27 +2283,6 @@ function UpdateStatusRail({
 					</span>
 				</TooltipTrigger>
 				<TooltipContent side="right">{label}</TooltipContent>
-			</Tooltip>
-		);
-	}
-
-	if (action.kind === "retry") {
-		return (
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						aria-label={t("shell.retryUpdateCheck")}
-						className="grid size-9 place-items-center rounded-lg bg-warning/12 text-warning transition-colors hover:bg-warning/18 [&_svg]:size-4"
-						onClick={() => void aoBridge.updates.check()}
-						tabIndex={tabIndex}
-						type="button"
-					>
-						<AlertTriangle aria-hidden="true" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="right">
-					{t("shell.updateCheckFailed")} · {t("shell.retryUpdateCheck")}
-				</TooltipContent>
 			</Tooltip>
 		);
 	}


### PR DESCRIPTION
Update check and download failures currently appear as a warning row in the sidebar. This makes transient updater problems compete with sessions and primary navigation.

This followup to #5041 keeps failures and retry details in Settings > Updates. The sidebar continues to show update availability, live download and preparation progress, and the green install action when a staged build is ready. A ready install remains visible even if a later check fails.

The updater regression coverage also confirms that an emitted SSL error immediately replaces the visible Checking state even when Electron's check promise does not settle.

Verification:

* `npm run frontend:typecheck`
* `npm exec vitest run src/main/auto-updater.test.ts`, 138 passed
* `npm exec vitest run src/renderer/components/Sidebar.test.tsx`, 96 passed
