### PR TITLE
fix(updates): avoid duplicate check failure messages

### DIFF
--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -423,6 +423,34 @@ describe("GlobalSettingsForm", () => {
 		await waitFor(() => expect(screen.getByTestId("installed-update-channel")).toHaveTextContent("Nightly"));
 	});
 
+	it("shows a repeated timeout once and keeps manual retry available", async () => {
+		const message = "Update check timed out. Check your connection and try again.";
+		updGetStatus.mockResolvedValue({ state: "error", message, checkError: message });
+		renderForm("updates");
+		await screen.findByText(message);
+		expect(screen.getAllByText(message)).toHaveLength(1);
+		const retry = screen.getByRole("button", { name: "Check for updates" });
+		expect(retry).toBeEnabled();
+		await userEvent.click(retry);
+		expect(updCheck).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves a check failure beside a staged update", async () => {
+		const message = "Update check timed out. Check your connection and try again.";
+		updGetStatus.mockResolvedValue({ state: "downloaded", version: "2.0.0", checkError: message });
+		renderForm("updates");
+		expect(await screen.findByText(message)).toBeVisible();
+		expect(screen.getAllByText(message)).toHaveLength(1);
+		expect(screen.getByRole("button", { name: "Install Update" })).toBeEnabled();
+	});
+
+	it("preserves a different check failure beside an install error", async () => {
+		updGetStatus.mockResolvedValue({ state: "error", message: "Installation failed", checkError: "Update check timed out" });
+		renderForm("updates");
+		expect(await screen.findByText("Installation failed")).toBeVisible();
+		expect(screen.getByText("Update check timed out")).toBeVisible();
+	});
+
 	it("shows an explicit idle update state and triggers a manual check", async () => {
 		renderForm();
 		await waitFor(() => expect(screen.getByTestId("app-version")).toHaveTextContent("v1.4.0"));

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -581,7 +581,11 @@ function UpdateActions({
 				</div>
 			) : null}
 
-			{status.checkError && <UpdateNotice tone="error" text={status.checkError} />}
+			{/* The primary error already explains the failed check. Keep a separate
+			    notice only when it adds information (for example beside a staged build). */}
+			{status.checkError && !(displayState === "error" && status.message === status.checkError) && (
+				<UpdateNotice tone="error" text={status.checkError} />
+			)}
 
 			{!status.checkError && !status.staleCheckNudge && status.checksFailing && (
 				<UpdateNotice tone="warning" text={t("settings.updates.checksFailing")} />


### PR DESCRIPTION
## Problem and change

A failed update check can populate both `message` and `checkError` with the same timeout. Updates rendered both the primary error and a second red notice, making one failure appear twice.

Suppress the second notice only when the visible primary error already contains that exact message. Preserve check failures beside staged builds and preserve separate errors with different information. The Check for updates action remains available.

## Validation

- Regression reproduced before the change: the timeout appeared twice.
- Focused updater and settings suites: 177 passed, including the new duplicate/retry, staged-build, and distinct-error cases.
- Frontend and E2E TypeScript checks passed.
- Cloud-client generation/drift, types, 21 tests and package dry run passed. Product UI types, 124 tests and package dry run passed.
- Final complete local unit rerun: 285 files passed; 3,949 tests passed and 6 skipped.
- Final complete local browser smoke rerun: all 57 tests passed. Initial runs exposed missing/shared dependency setup and timing failures under heavy machine load; those runs are not counted as passes. Dependencies were corrected and no test time limits were increased.
- GitHub security scan and Linux/container renderer smoke passed. The final-head frontend test job is still running.


## Limits

This fixes the duplicated error shown in the reported screenshot. It does not establish why that user's metadata request exceeded 60 seconds, change network timeout/cancellation policy, or claim to eliminate real network failures. Existing cancellation/queued-retry tests pass, but are not a reproduction of the affected Mac's network conditions.

No fresh native AO interaction was performed: the isolated dev port is occupied by another daemon, which was left untouched. Docker is unavailable locally, so the exact Linux browser-container validation is delegated to CI. This PR is separate from #5002 and does not resolve its current merge conflicts.
