### PR TITLE
modelcatalog: add Muse Spark 1.3 (+ contributor) to the muse catalog

### DIFF
--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -72,6 +72,8 @@ func Base(agentID string) ports.AgentModelCatalog {
 			model("muse-spark", "Muse Spark", true),
 			model("muse-spark-1.1", "Muse Spark 1.1", false),
 			model("muse-spark-1.2", "Muse Spark 1.2", false),
+			model("muse-spark-1.3", "Muse Spark 1.3", false),
+			model("muse-spark-1.3-contributor", "Muse Spark 1.3 (Contributor)", false),
 		)
 	case "amp":
 		c := catalog(agentID, "official-modes", entryMode, now,

--- a/backend/internal/adapters/agent/modelcatalog/catalog_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog_test.go
@@ -101,7 +101,7 @@ func TestBaseClassifiesStaticTextAndModeAgents(t *testing.T) {
 		{agent: "claude-code", mode: ports.ModelSelectionCatalog},
 		{agent: "codex", mode: ports.ModelSelectionCatalog},
 		{agent: "amp", mode: ports.ModelSelectionModeList, count: 4},
-		{agent: "muse", mode: ports.ModelSelectionCatalog, count: 3},
+		{agent: "muse", mode: ports.ModelSelectionCatalog, count: 5},
 		{agent: "aider", mode: ports.ModelSelectionCatalog},
 		{agent: "autohand", mode: ports.ModelSelectionCatalog},
 		{agent: "kimchi", mode: ports.ModelSelectionCatalog},
@@ -135,6 +135,8 @@ func TestMuseReturnsStaticCatalogWithoutStartingAgent(t *testing.T) {
 		{ID: "muse-spark", Label: "Muse Spark", IsDefault: true},
 		{ID: "muse-spark-1.1", Label: "Muse Spark 1.1"},
 		{ID: "muse-spark-1.2", Label: "Muse Spark 1.2"},
+		{ID: "muse-spark-1.3", Label: "Muse Spark 1.3"},
+		{ID: "muse-spark-1.3-contributor", Label: "Muse Spark 1.3 (Contributor)"},
 	}
 	if got.Source != "official-catalog" || !reflect.DeepEqual(got.Models, want) {
 		t.Fatalf("catalog = %#v, want models %#v", got, want)


### PR DESCRIPTION
## What
Adds `muse-spark-1.3` and `muse-spark-1.3 (Contributor)` to the `muse` agent's model catalog in `backend/internal/adapters/agent/modelcatalog/catalog.go`, and updates `catalog_test.go` to match.

## Why
The muse picker is currently capped at `muse-spark-1.1` / `muse-spark-1.2`. Meta now serves `muse-spark-1.3` and `muse-spark-1.3-contributor` on the same OpenAI-compatible Model API (`https://api.meta.ai/v1`), so users can't select the current generation from the muse connection. This adds them to the static catalog (default stays the generic `muse-spark`).

## Changes
- `catalog.go`: two new `model(...)` entries under `case "muse"`.
- `catalog_test.go`: bump the muse model count 3 → 5 and add the two entries to the expected list.

Verified the models respond on `muse-spark-1.3` / `-contributor` via the live API, including `reasoning_effort` up to `max`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)