### PR TITLE
fix(board): stop spinning a loader on settled session cards

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -523,6 +523,84 @@ describe("SessionsBoard", () => {
 		expect(working.querySelector('[aria-hidden="true"]')).toHaveClass("animate-spin");
 	});
 
+	// A multi-PR session aggregates `status` from its worst open PR while
+	// `displayStatus` comes from its best one, so a settled "Mergeable" card can
+	// carry status `review_pending`. The loader must follow the label the card
+	// actually shows, not the hidden aggregate, or an idle session spins forever.
+	it("does not spin a settled Mergeable card whose worst PR aggregates to review_pending", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				workspaceWithSessions([
+					boardSession({
+						id: "s-mergeable",
+						title: "mergeable-card-task",
+						status: "review_pending",
+						displayStatus: "Mergeable",
+						kanbanColumn: "ready",
+						activity: { state: "idle", lastActivityAt: "2026-01-01T00:00:00Z" },
+					}),
+				]),
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+		const card = screen.getByText("mergeable-card-task").closest('[data-testid="board-session-card"]') as HTMLElement;
+		const status = within(card).getByTestId("session-status");
+		expect(status).toHaveTextContent("Mergeable");
+		expect(status.querySelector(".animate-spin")).toBeNull();
+	});
+
+	it("keeps the loader on a Review pending card", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				workspaceWithSessions([
+					boardSession({
+						id: "s-review-pending",
+						title: "review-pending-card-task",
+						status: "review_pending",
+						displayStatus: "Review pending",
+						kanbanColumn: "needs_review",
+						activity: { state: "idle", lastActivityAt: "2026-01-01T00:00:00Z" },
+					}),
+				]),
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+		const card = screen.getByText("review-pending-card-task").closest('[data-testid="board-session-card"]') as HTMLElement;
+		const status = within(card).getByTestId("session-status");
+		expect(status).toHaveTextContent("Review pending");
+		expect(status.querySelector(".animate-spin")).not.toBeNull();
+	});
+
+	it("keeps the loader on a Mergeable card while its agent is actually working", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				workspaceWithSessions([
+					boardSession({
+						id: "s-mergeable-active",
+						title: "mergeable-active-task",
+						status: "working",
+						displayStatus: "Mergeable",
+						kanbanColumn: "ready",
+						activity: { state: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
+					}),
+				]),
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+		const card = screen.getByText("mergeable-active-task").closest('[data-testid="board-session-card"]') as HTMLElement;
+		const status = within(card).getByTestId("session-status");
+		expect(status.querySelector(".animate-spin")).not.toBeNull();
+	});
+
 	it("keeps a spawning card labeled Working when raw activity has not become active", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -71,6 +71,17 @@ export type BoardSessionStatusPresentation = {
 
 export type BoardPullRequestState = "closed" | "open" | "draft" | "merged";
 
+// Display statuses that mean work is still turning, and so earn the spinning
+// loader beside the card's status label: the review the PR is waiting on, or an
+// AO-driven loop working the PR. Settled phrases ("Mergeable", "Approved",
+// "Merged") are deliberately absent — see #4725 and #5081.
+const IN_PROGRESS_DISPLAY_STATUSES = new Set<string>([
+	"Review pending",
+	"Fixing CI failures",
+	"Addressing comments",
+	"Reviewing",
+]);
+
 export type BoardReviewerPresentation = {
 	id: string;
 	avatarUrl?: string;
@@ -246,10 +257,15 @@ export function SessionCardView({
 		!needsAttention &&
 		session.displayStatus !== "Needs human review" &&
 		(session.status === "working" ||
-			session.status === "review_pending" ||
-			session.displayStatus === "Fixing CI failures" ||
-			session.displayStatus === "Addressing comments" ||
-			session.displayStatus === "Reviewing");
+			// The label reads `displayStatus`, so the loader must too. `status`
+			// aggregates the session's WORST open PR while `displayStatus` describes
+			// its BEST one, so keying the loader off `status` spun a settled
+			// "Mergeable" card forever whenever a sibling PR was still review-pending
+			// (#5081). Fall back to `status` only for a daemon too old to send
+			// `displayStatus`.
+			(session.displayStatus
+				? IN_PROGRESS_DISPLAY_STATUSES.has(session.displayStatus)
+				: session.status === "review_pending"));
 
 	return (
 		<div


### PR DESCRIPTION
Fixes #5081

## Summary

A board card read its status **label** from `displayStatus` but its **loader** from `status`. The daemon derives those two from opposite ends of a session's PR set — `displayStatus` from the session's best PR (`contract/kanban.go`, `kanbanPriority`, `ready` first), `status` from its worst open PR (`contract/status.go`, `aggregatePRStatus` + severity table). A session with one mergeable PR and one still awaiting review therefore rendered a green **Mergeable** label next to a loader that spun forever. The predicate contained no `session.activity` term, so an idle agent could not switch it off, and `animate-spin` is `spin 1s linear infinite` with no terminating state.

The fix keys the loader off the label the card actually renders:

- keep the loader while the agent is genuinely working (`status === "working"`);
- otherwise show it only when the rendered `displayStatus` is itself an in-progress phrase — `Review pending`, `Fixing CI failures`, `Addressing comments`, `Reviewing`;
- fall back to the old `status === "review_pending"` check only when the daemon sent no `displayStatus`, so an older daemon against a newer client is unaffected.

`Review pending` keeps its loader and `Mergeable` loses it, which is exactly what #4725 specifies ("Mergable should not show a loader / Review pending should show loader").

**The daemon's multi-PR aggregation is deliberate and is unchanged** — this is a presentation-only fix in `packages/product-ui`.

## Test

Three new cases in `frontend/src/renderer/components/SessionsBoard.test.tsx`, covering both directions:

| Case | Expected |
|---|---|
| idle agent, `status: review_pending`, `displayStatus: "Mergeable"`, `ready` lane | **no** loader (the reported bug) |
| idle agent, `status: review_pending`, `displayStatus: "Review pending"` | loader present (#4725 intent) |
| active agent, `status: working`, `displayStatus: "Mergeable"` | loader present (truly-active still covered) |

The first case fails on `ddf1e54f` with `expected SVGSVGElement … to be null` (the `lucide-loader-circle animate-spin` node) and passes here. The pre-existing `status: "working"` + `activity: active` test is untouched and still passes.

Verification run locally on node 24 (matching `.github/workflows/frontend.yml`):

```
npm --prefix packages/product-ui run typecheck   # clean
npm --prefix packages/product-ui test            # 10 files, 124 tests passed
npm --prefix packages/product-ui run build       # built
npm --prefix frontend run typecheck              # clean
cd frontend && npx vitest run src/renderer       # 197 files, 2828 passed, 6 skipped
```

### Environment limitation, proven not a regression

The full `frontend` suite in this checkout also reports 17 failures across 8 files — all under `src/landing/**` and `src/main/browser-profile-import.test.ts`. None of them import the board or `product-ui`. Two independent checks confirm they are pre-existing environment gaps, not regressions from this change:

1. **Baseline on pristine `origin/main`.** Reverting this PR's two files and re-running *only those 8 files* reproduces the identical 8 files / 17 tests failing. Failure mode is `ERR_MODULE_NOT_FOUND` and missing native deps.
2. **CI is green on this PR.** The `test` job runs the same full `npx vitest run`, but only after `npm ci --prefix src/landing` and `npm run browser-runtime:prepare` — two setup steps this local checkout never performed. It passed in 5m29s, alongside `renderer-smoke` (2m50s) and `scan` (17s).

So the local failures are missing landing sub-app and browser-runtime dependencies here, and no unrelated code was touched to make anything pass.
