### PR TITLE
fix: serialize mobile bridge state transitions

### DIFF
--- a/backend/internal/httpd/controllers/mobile.go
+++ b/backend/internal/httpd/controllers/mobile.go
@@ -159,10 +159,18 @@ type BridgeService struct {
 	// until AO was restarted. Nil in tests that set Tunnel directly.
 	ResolveTunnel func() TunnelController
 
+	// transitionMu serializes every operation that changes persisted bridge
+	// state, listener state, or connector state. Status deliberately does not
+	// take it, so a slow listener or connector operation cannot freeze polling.
+	transitionMu sync.Mutex
+
 	// Guards Tunnel, which ensureTunnel may replace while HTTP handlers read it.
 	tunnelMu sync.RWMutex
 
-	// serveErr records the last Apply failure so Status can report serve_failed.
+	// stateMu protects only the short-lived in-memory status snapshot below. No
+	// listener, filesystem, or connector call may run while it is held.
+	stateMu sync.RWMutex
+	// serveErr records the last Apply/Clear failure for Status.
 	serveErr error
 }
 
@@ -249,19 +257,27 @@ func (b *BridgeService) ensureTunnel() TunnelController {
 	if b.ResolveTunnel == nil {
 		return nil
 	}
+	// Resolution may inspect the filesystem. Keep it outside tunnelMu so Status
+	// can continue reporting the currently known connector snapshot while that
+	// work is slow. transitionMu ensures only one mutator resolves at a time.
+	resolved := b.ResolveTunnel()
+	if resolved == nil {
+		return nil
+	}
 	b.tunnelMu.Lock()
 	defer b.tunnelMu.Unlock()
 	if b.Tunnel == nil {
-		b.Tunnel = b.ResolveTunnel()
+		b.Tunnel = resolved
 	}
 	return b.Tunnel
 }
 
 func (b *BridgeService) tunnelEndpoint() *mobilebridge.TunnelEndpoint {
-	if b.tunnel() == nil {
+	t := b.tunnel()
+	if t == nil {
 		return nil
 	}
-	return b.tunnel().Endpoint()
+	return t.Endpoint()
 }
 
 func (b *BridgeService) tunnelStatus() mobilebridge.TunnelStatus {
@@ -302,15 +318,28 @@ func (b *BridgeService) serveTarget() int {
 	return mobilebridge.NewServe().Target(context.Background())
 }
 
+func (b *BridgeService) serveError() error {
+	b.stateMu.RLock()
+	defer b.stateMu.RUnlock()
+	return b.serveErr
+}
+
+func (b *BridgeService) setServeError(err error) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	b.serveErr = err
+}
+
 // securePairingStatus assembles the SecurePairing block of Status from the
 // persisted mode flag and current bridge/proxy state.
 func (b *BridgeService) securePairingStatus(on, bridgeUp bool) SecurePairingStatus {
+	serveErr := b.serveError()
 	sp := SecurePairingStatus{Enabled: on}
 	if !on {
 		// The mode is off, but a failed Clear may have left the proxy live —
 		// report that without touching the network (no queryTS/serveTarget
 		// calls when the mode is off).
-		if b.serveErr != nil {
+		if serveErr != nil {
 			sp.Reason = "clear_failed"
 		}
 		return sp
@@ -329,7 +358,7 @@ func (b *BridgeService) securePairingStatus(on, bridgeUp bool) SecurePairingStat
 	if !bridgeUp {
 		return sp
 	}
-	if b.serveErr != nil {
+	if serveErr != nil {
 		sp.Reason = "serve_failed"
 		return sp
 	}
@@ -345,26 +374,31 @@ func (b *BridgeService) securePairingStatus(on, bridgeUp bool) SecurePairingStat
 // choice. Turning it on applies the proxy immediately when the bridge is
 // already running; turning it off always tears the proxy down.
 func (b *BridgeService) SetSecurePairing(on bool) (MobileStatusResponse, error) {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
 	st, _ := mobilebridge.Load(b.ConfigPath)
 	st.SecurePairing = on
 	if err := mobilebridge.Save(b.ConfigPath, st); err != nil {
 		return MobileStatusResponse{}, err
 	}
-	b.serveErr = nil
+	b.setServeError(nil)
 	if on {
 		if b.LAN.Running() {
-			b.serveErr = b.applyServe(b.LAN.BoundPort())
+			b.setServeError(b.applyServe(b.LAN.BoundPort()))
 		}
 	} else {
 		// Record rather than return: the flag is already persisted off, so a
 		// failure here means the proxy may still be live and the user needs to
 		// be told — the same contract the enable path uses for applyServe.
-		b.serveErr = b.clearServe()
+		b.setServeError(b.clearServe())
 	}
 	return b.Status(), nil
 }
 
-func (b *BridgeService) enableWithPassword(pw string) (MobileStatusResponse, error) {
+// enableWithPasswordLocked performs an enable or password rotation while the
+// caller owns transitionMu.
+func (b *BridgeService) enableWithPasswordLocked(pw string) (MobileStatusResponse, error) {
 	// Snapshot state so we can roll back the in-memory side effects (armed hash,
 	// running listener) if we fail before durable state is written. Otherwise a
 	// failed enable would leave a LAN listener open on 0.0.0.0 with the new
@@ -402,9 +436,16 @@ func (b *BridgeService) enableWithPassword(pw string) (MobileStatusResponse, err
 	// method (it has no password to rotate); see RestoreOnBoot, which mirrors
 	// this same post-Start apply. A failure is recorded, never fatal: the
 	// bridge stays up in plaintext mode and Status reports serve_failed.
-	b.serveErr = nil
-	if st, _ := mobilebridge.Load(b.ConfigPath); st.SecurePairing {
-		b.serveErr = b.applyServe(port)
+	b.startConnectorsLocked(port, prevSt.SecurePairing)
+	return b.Status(), nil
+}
+
+// startConnectorsLocked is the shared post-Start step for fresh enables,
+// password rotations, and boot restoration. The caller owns transitionMu.
+func (b *BridgeService) startConnectorsLocked(port int, securePairing bool) {
+	b.setServeError(nil)
+	if securePairing {
+		b.setServeError(b.applyServe(port))
 	}
 	// Point the connector at the port Start actually bound, not DefaultPort:
 	// Start falls back to an ephemeral port when the default is taken, and a
@@ -416,7 +457,6 @@ func (b *BridgeService) enableWithPassword(pw string) (MobileStatusResponse, err
 	if t := b.ensureTunnel(); t != nil {
 		t.Start(port)
 	}
-	return b.Status(), nil
 }
 
 // RestoreOnBoot re-arms the LAN listener from persisted state across a daemon
@@ -430,33 +470,31 @@ func (b *BridgeService) enableWithPassword(pw string) (MobileStatusResponse, err
 // serveErr, never returned — the caller (restoreMobileOnBoot) treats this as
 // best-effort and must never block daemon boot on it.
 func (b *BridgeService) RestoreOnBoot(state mobilebridge.State) error {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
+	prevHash := b.LAN.PasswordHash()
 	b.LAN.SetPasswordHash(mobilebridge.HashPassword(state.Password))
 	port, err := b.LAN.Start(state.LastPort)
 	if err != nil {
+		b.LAN.SetPasswordHash(prevHash)
 		return err
 	}
-	b.serveErr = nil
-	if state.SecurePairing {
-		b.serveErr = b.applyServe(port)
-	}
-	// A restart does not go through enableWithPassword — there is no password to
-	// rotate — so the connector has to be started here too. Without it the
-	// bridge comes back LAN-only and the UI shows Connect Mobile enabled while
-	// remote access is silently gone until the user toggles it off and on.
-	if t := b.ensureTunnel(); t != nil {
-		t.Start(port)
-	}
+	b.startConnectorsLocked(port, state.SecurePairing)
 	return nil
 }
 
 // Enable generates a fresh password, arms the auth hash, and starts the LAN
 // listener, persisting the enabled state.
 func (b *BridgeService) Enable() (MobileStatusResponse, error) {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
 	pw, err := mobilebridge.GeneratePassword()
 	if err != nil {
 		return MobileStatusResponse{}, err
 	}
-	return b.enableWithPassword(pw)
+	return b.enableWithPasswordLocked(pw)
 }
 
 // StartRemoteAccess looks for a connector again and starts it against the port
@@ -472,6 +510,9 @@ func (b *BridgeService) Enable() (MobileStatusResponse, error) {
 // and enabling is the user's decision to make, not a side effect of installing
 // a binary.
 func (b *BridgeService) StartRemoteAccess() (MobileStatusResponse, error) {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
 	st, err := mobilebridge.Load(b.ConfigPath)
 	if err != nil {
 		return MobileStatusResponse{}, err
@@ -488,15 +529,21 @@ func (b *BridgeService) StartRemoteAccess() (MobileStatusResponse, error) {
 // Regenerate rotates the connection password on the running listener, which
 // drops the currently paired phone (it authenticates against the new hash).
 func (b *BridgeService) Regenerate() (MobileStatusResponse, error) {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
 	pw, err := mobilebridge.GeneratePassword()
 	if err != nil {
 		return MobileStatusResponse{}, err
 	}
-	return b.enableWithPassword(pw) // rotate → drops current phone (new hash)
+	return b.enableWithPasswordLocked(pw) // rotate → drops current phone (new hash)
 }
 
 // Disable stops the LAN listener and persists the disabled state.
 func (b *BridgeService) Disable() error {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	// Stop the connector first. Leaving it up after the user turned Connect
@@ -534,6 +581,9 @@ func (b *BridgeService) Disable() error {
 // restore brings the connector back on the next start. This ends the process,
 // not the user's preference.
 func (b *BridgeService) ShutdownTunnel() {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
 	t := b.tunnel()
 	if t == nil {
 		return // Remote access is optional; nothing to stop without cloudflared.
@@ -549,6 +599,9 @@ func (b *BridgeService) ShutdownTunnel() {
 // place. The persisted SecurePairing preference is deliberately left set, so
 // RestoreOnBoot re-applies the proxy against the next bound port.
 func (b *BridgeService) ShutdownServe() {
+	b.transitionMu.Lock()
+	defer b.transitionMu.Unlock()
+
 	st, _ := mobilebridge.Load(b.ConfigPath)
 	if !st.Enabled || !st.SecurePairing {
 		return

--- a/backend/internal/httpd/controllers/mobile_concurrency_test.go
+++ b/backend/internal/httpd/controllers/mobile_concurrency_test.go
@@ -1,0 +1,300 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
+)
+
+// concurrencyLAN is a channel-controlled, race-safe LANController. The
+// production LAN manager owns its own synchronization; this fake does the same
+// so race failures in these tests identify BridgeService rather than the fake.
+type concurrencyLAN struct {
+	mu sync.Mutex
+
+	running bool
+	bound   int
+	hash    string
+
+	startEntered chan struct{}
+	startRelease chan struct{}
+	stopEntered  chan struct{}
+	startOnce    sync.Once
+	stopOnce     sync.Once
+}
+
+func (f *concurrencyLAN) Start(port int) (int, error) {
+	if f.startEntered != nil {
+		f.startOnce.Do(func() { close(f.startEntered) })
+	}
+	if f.startRelease != nil {
+		<-f.startRelease
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.running = true
+	f.bound = port
+	return port, nil
+}
+
+func (f *concurrencyLAN) Stop(context.Context) error {
+	if f.stopEntered != nil {
+		f.stopOnce.Do(func() { close(f.stopEntered) })
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.running = false
+	f.bound = 0
+	return nil
+}
+
+func (f *concurrencyLAN) Running() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.running
+}
+
+func (f *concurrencyLAN) BoundPort() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.bound
+}
+
+func (f *concurrencyLAN) SetPasswordHash(hash string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.hash = hash
+}
+
+func (f *concurrencyLAN) PasswordHash() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.hash
+}
+
+// Removing synchronization around the serve error snapshot makes this test
+// fail under the race detector: Status reads it while the secure-pairing
+// transition replaces it after each failed clear.
+func TestBridgeStatusConcurrentSecurePairing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mobile.json")
+	if err := mobilebridge.Save(path, mobilebridge.State{Enabled: true, Password: "pw", LastPort: 3011}); err != nil {
+		t.Fatal(err)
+	}
+	bridge := &BridgeService{
+		LAN:                &concurrencyLAN{running: true, bound: 3011},
+		ConfigPath:         path,
+		PickLANHosts:       func() []string { return nil },
+		PickTailscaleHosts: func() []string { return nil },
+		ClearServe:         func() error { return errors.New("clear failed") },
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 200 {
+			if _, err := bridge.SetSecurePairing(false); err != nil {
+				t.Errorf("SetSecurePairing: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 2_000 {
+			_ = bridge.Status()
+		}
+	}()
+	close(start)
+	wg.Wait()
+}
+
+// Removing the transition mutex lets Disable reach LAN.Stop while Enable is
+// still inside LAN.Start. Besides overlapping listener operations, the later
+// Enable save can overwrite the disabled state with a password/hash for a
+// listener the caller expected Disable to stop.
+func TestBridgeSerializesConcurrentEnableAndDisable(t *testing.T) {
+	startEntered := make(chan struct{})
+	startRelease := make(chan struct{})
+	stopEntered := make(chan struct{})
+	lan := &concurrencyLAN{
+		startEntered: startEntered,
+		startRelease: startRelease,
+		stopEntered:  stopEntered,
+	}
+	bridge := &BridgeService{
+		LAN:                lan,
+		ConfigPath:         filepath.Join(t.TempDir(), "mobile.json"),
+		DefaultPort:        3011,
+		PickLANHosts:       func() []string { return nil },
+		PickTailscaleHosts: func() []string { return nil },
+	}
+
+	enableDone := make(chan error, 1)
+	go func() {
+		_, err := bridge.Enable()
+		enableDone <- err
+	}()
+	awaitSignal(t, startEntered, "Enable to enter LAN.Start")
+
+	disableCalling := make(chan struct{})
+	disableDone := make(chan error, 1)
+	go func() {
+		close(disableCalling)
+		disableDone <- bridge.Disable()
+	}()
+	awaitSignal(t, disableCalling, "Disable goroutine to start")
+
+	overlapped := false
+	select {
+	case <-stopEntered:
+		overlapped = true
+	case <-time.After(100 * time.Millisecond):
+		// Disable is waiting at the transition boundary, as required.
+	}
+	close(startRelease)
+	if err := awaitResult(t, enableDone, "Enable"); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	if err := awaitResult(t, disableDone, "Disable"); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if overlapped {
+		t.Fatal("Disable reached LAN.Stop before Enable completed LAN.Start")
+	}
+
+	state, err := mobilebridge.Load(bridge.ConfigPath)
+	if err != nil {
+		t.Fatalf("load final state: %v", err)
+	}
+	if state.Enabled || lan.Running() {
+		t.Fatalf("final bridge state disagrees: persisted enabled=%t, listener running=%t", state.Enabled, lan.Running())
+	}
+	if state.Password == "" || !mobilebridge.PasswordMatches(lan.PasswordHash(), state.Password) {
+		t.Fatal("persisted password and armed listener hash disagree after serialized transitions")
+	}
+}
+
+// Status must not hold the short error-snapshot lock while a connector call is
+// blocked. Otherwise ordinary UI polling freezes behind a slow Tailscale CLI.
+func TestBridgeStatusResponsiveWhileSecurePairingConnectorIsSlow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mobile.json")
+	if err := mobilebridge.Save(path, mobilebridge.State{Enabled: true, Password: "pw", LastPort: 3011}); err != nil {
+		t.Fatal(err)
+	}
+	clearEntered := make(chan struct{})
+	clearRelease := make(chan struct{})
+	bridge := &BridgeService{
+		LAN:                &concurrencyLAN{running: true, bound: 3011},
+		ConfigPath:         path,
+		PickLANHosts:       func() []string { return nil },
+		PickTailscaleHosts: func() []string { return nil },
+		ClearServe: func() error {
+			close(clearEntered)
+			<-clearRelease
+			return errors.New("clear failed")
+		},
+	}
+
+	transitionDone := make(chan error, 1)
+	go func() {
+		_, err := bridge.SetSecurePairing(false)
+		transitionDone <- err
+	}()
+	awaitSignal(t, clearEntered, "secure-pairing connector call")
+
+	statusDone := make(chan MobileStatusResponse, 1)
+	go func() { statusDone <- bridge.Status() }()
+	var status MobileStatusResponse
+	select {
+	case status = <-statusDone:
+	case <-time.After(time.Second):
+		close(clearRelease)
+		t.Fatal("Status blocked behind the slow secure-pairing connector")
+	}
+	close(clearRelease)
+	if err := awaitResult(t, transitionDone, "SetSecurePairing"); err != nil {
+		t.Fatalf("SetSecurePairing: %v", err)
+	}
+	if !status.Enabled || status.SecurePairing.Enabled {
+		t.Fatalf("Status returned an unexpected persisted snapshot: %+v", status)
+	}
+}
+
+// Resolving a connector may inspect the filesystem and launch a version probe.
+// Holding tunnelMu across that work makes Status wait before it can report the
+// last known connector state.
+func TestBridgeStatusResponsiveWhileTunnelResolutionIsSlow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mobile.json")
+	if err := mobilebridge.Save(path, mobilebridge.State{Enabled: true, Password: "pw", LastPort: 3011}); err != nil {
+		t.Fatal(err)
+	}
+	resolveEntered := make(chan struct{})
+	resolveRelease := make(chan struct{})
+	bridge := &BridgeService{
+		LAN:                &concurrencyLAN{running: true, bound: 3011},
+		ConfigPath:         path,
+		PickLANHosts:       func() []string { return nil },
+		PickTailscaleHosts: func() []string { return nil },
+		ResolveTunnel: func() TunnelController {
+			close(resolveEntered)
+			<-resolveRelease
+			return nil
+		},
+	}
+
+	transitionDone := make(chan error, 1)
+	go func() {
+		_, err := bridge.StartRemoteAccess()
+		transitionDone <- err
+	}()
+	awaitSignal(t, resolveEntered, "tunnel resolution")
+
+	statusDone := make(chan struct{})
+	go func() {
+		_ = bridge.Status()
+		close(statusDone)
+	}()
+	responsive := true
+	select {
+	case <-statusDone:
+	case <-time.After(time.Second):
+		responsive = false
+	}
+	close(resolveRelease)
+	if err := awaitResult(t, transitionDone, "StartRemoteAccess"); err != nil {
+		t.Fatalf("StartRemoteAccess: %v", err)
+	}
+	if !responsive {
+		awaitSignal(t, statusDone, "Status after tunnel resolution")
+		t.Fatal("Status blocked behind slow tunnel resolution")
+	}
+}
+
+func awaitSignal(t *testing.T, ch <-chan struct{}, operation string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+	}
+}
+
+func awaitResult(t *testing.T, ch <-chan error, operation string) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+		return nil
+	}
+}

--- a/backend/internal/httpd/controllers/mobile_test.go
+++ b/backend/internal/httpd/controllers/mobile_test.go
@@ -673,7 +673,7 @@ func TestMobileAdvertisesNothingWhileTheBridgeIsOff(t *testing.T) {
 // access then stayed silently off — the UI showed the bridge enabled while the
 // tunnel never came back — until the user toggled it off and on.
 //
-// A restart does not go through enableWithPassword (there is no password to
+// A restart does not go through enableWithPasswordLocked (there is no password to
 // rotate), so RestoreOnBoot has to mirror its post-Start work.
 func TestMobileRestoreOnBootStartsTheTunnel(t *testing.T) {
 	tun := &fakeTunnel{}
@@ -853,5 +853,26 @@ func TestStartRemoteAccessWhileDisabledDoesNothing(t *testing.T) {
 	}
 	if tun.startedOn != 0 {
 		t.Fatal("connector started while the bridge is disabled")
+	}
+}
+
+type startErrorLAN struct {
+	fakeLAN
+	err error
+}
+
+func (f *startErrorLAN) Start(int) (int, error) { return 0, f.err }
+
+func TestMobileRestoreOnBootRollsBackHashWhenStartFails(t *testing.T) {
+	startErr := errors.New("bind failed")
+	lan := &startErrorLAN{fakeLAN: fakeLAN{hash: "previous-hash"}, err: startErr}
+	bridge := &BridgeService{LAN: lan}
+
+	err := bridge.RestoreOnBoot(mobilebridge.State{Enabled: true, Password: "restored-password", LastPort: 3011})
+	if !errors.Is(err, startErr) {
+		t.Fatalf("RestoreOnBoot error = %v, want %v", err, startErr)
+	}
+	if got := lan.PasswordHash(); got != "previous-hash" {
+		t.Fatalf("password hash after failed restore = %q, want previous-hash", got)
 	}
 }


### PR DESCRIPTION
## What

Serialize Connect Mobile state changes and synchronize the status error snapshot.

## Why

Concurrent Enable/Disable calls could overlap listener operations and overwrite each other's saved settings. Status polling also read `serveErr` while secure-pairing changes wrote it, producing a Go data race.

## How

Use one transition mutex for mutators and short locks for status/connector snapshots, keeping status polling responsive during slow connector work. Share post-start connector setup and restore the previous authentication hash if boot startup fails. Active LAN connection shutdown is a separate follow-up.

## Testing

- Reproduced the data race, overlapping Enable/Disable, and failed-start hash drift against the original implementation.
- Backend: HTTP race regressions; full `go test ./...` and `go test -race -timeout=15m ./...`; `go build ./...`; `go vet ./...`; formatting; golangci-lint v2.12.2.
- Integration: Linux `go test -tags e2e -v ./internal/cli/...`; fresh-install Docker check; `npm ci` and `npm run api` with Node 24, with no generated drift.
- Secret scan: CI-pinned gitleaks v7.4.0 scanned the single PR commit with no leaks.
- Local checks use Go 1.26.5 and an explicit `/bin/sh` for shell-sensitive tests. All nine GitHub CI jobs passed, including native Windows/macOS checks.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Regression tests added for the changed behavior
- [x] Relevant CI checks pass
