### PR TITLE
feat(browser): reveal the Browser panel for explicit preview/open commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,10 @@ diverges from **agent-orchestrator** — do **not** re-flag old design-reference
 
 When showing or demoing frontend changes, run `ao preview [url]` from inside the
 session so the change renders in the desktop browser panel (the inspector rail's
-Browser tab); do not just describe it. `ao preview` updates the panel non-disruptively —
-it does not steal focus or force the Browser tab open if the user is looking at
-something else, only badging it as unseen. If the Browser tab isn't already the one
-the user has open, say so in your reply (e.g. "check the Browser tab") so the change
-doesn't go unnoticed behind the badge.
+Browser tab); do not just describe it. `ao preview` and `ao browser open` are explicit
+"show this page" requests, so they reveal the Browser tab for the session the user is
+viewing. They never steal OS window focus and never change which session or project the
+user is on — a background worker previewing its own session only badges that session.
+Passive agent browser activity (`snapshot`, `click`, `fill`, `act`, `errors`, …) still
+badges the tab as unseen rather than revealing it, so mention it in your reply when only
+that has happened.

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -464,7 +464,17 @@ vi.mock("./SessionFileWorkspace", () => ({
 const { browserDestroy, browserViewOptions, browserViewState } = vi.hoisted(() => ({
 	browserDestroy: vi.fn(),
 	browserViewOptions: { current: undefined as { active: boolean; sessionId: string; terminated: boolean } | undefined },
-	browserViewState: { url: "", agentBrowserActive: false },
+	browserViewState: {
+		url: "",
+		agentBrowserActive: false,
+		agentBrowserActivity: null as {
+			viewId: string;
+			active: boolean;
+			action: string;
+			phase?: "started" | "finished";
+			commandId?: string;
+		} | null,
+	},
 }));
 vi.mock("../hooks/useBrowserView", () => ({
 	useBrowserView: (options: { active: boolean; sessionId: string; terminated: boolean }) => {
@@ -489,6 +499,7 @@ vi.mock("../hooks/useBrowserView", () => ({
 			activeTabId: "t1",
 			tabNotice: "",
 			agentBrowserActive: browserViewState.agentBrowserActive,
+			agentBrowserActivity: browserViewState.agentBrowserActivity,
 			selectTab: vi.fn(),
 			closeTab: vi.fn(),
 			annotationMode: false,
@@ -640,6 +651,7 @@ describe("SessionView", () => {
 		browserViewOptions.current = undefined;
 		browserViewState.url = "";
 		browserViewState.agentBrowserActive = false;
+		browserViewState.agentBrowserActivity = null;
 		shellTerminalsState.data = [];
 		navigateMock.mockReset();
 		openShellTerminalMock.mockReset();
@@ -2271,23 +2283,26 @@ describe("SessionView", () => {
 		expect(document.querySelector(".files-popout-overlay")).not.toHaveClass("files-popout-overlay--mac-windowed");
 	});
 
-	it("badges Browser as unseen for a new live `ao preview` target instead of auto-opening it", () => {
+	// `ao preview` is an explicit "show the user this page" request, so it reveals
+	// Browser for the session on screen. PR #4146 made every preview badge-only to
+	// stop background work grabbing the foreground; that protection now comes from
+	// SessionView only being mounted for the routed session, not from refusing to
+	// reveal at all.
+	it("reveals Browser for a new live `ao preview` target on the session being viewed", () => {
 		const worker = workerSession("sess-1");
 		const { rerender } = render(<SessionView sessionId="sess-1" />);
-		const viewBefore = inspectorButton().getAttribute("data-view");
-		const openBefore = inspectorOpen("sess-1");
 
 		worker.previewUrl = "http://localhost:5173/";
 		worker.previewRevision = 1;
 		rerender(<SessionView sessionId="sess-1" />);
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
-		expect(inspectorOpen("sess-1")).toBe(openBefore);
-		expect(inspectorButton()).toHaveAttribute("data-view", viewBefore);
-		expect(browserUnseen("sess-1")).toBe(true);
+		expect(inspectorOpen("sess-1")).toBe(true);
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(browserUnseen("sess-1")).toBe(false);
 	});
 
-	it("badges Browser as unseen without opening a collapsed inspector when a new live preview arrives", () => {
+	it("opens a collapsed inspector on Browser when a new live preview arrives", () => {
 		const worker = workerSession("sess-1");
 		act(() => useUiStore.getState().setInspectorOpen("sess-1", false));
 		const { rerender } = render(<SessionView sessionId="sess-1" />);
@@ -2296,12 +2311,14 @@ describe("SessionView", () => {
 		worker.previewRevision = 1;
 		rerender(<SessionView sessionId="sess-1" />);
 
-		expect(inspectorOpen("sess-1")).toBe(false);
-		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
-		expect(browserUnseen("sess-1")).toBe(true);
+		expect(inspectorOpen("sess-1")).toBe(true);
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(browserUnseen("sess-1")).toBe(false);
 	});
 
-	it("keeps Summary on session entry and badges Browser as unseen for later preview work", () => {
+	// Entering a session that already has a preview target is not a fresh `ao
+	// preview` — only a target that changes while the user is here is.
+	it("keeps Summary on session entry and reveals Browser only for later preview work", () => {
 		const secondWorker = workerSession("sess-2");
 		secondWorker.previewUrl = "http://localhost:5173/";
 		secondWorker.previewRevision = 1;
@@ -2318,8 +2335,100 @@ describe("SessionView", () => {
 
 		secondWorker.previewRevision = 2;
 		rerender(<SessionView sessionId="sess-2" />);
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(browserUnseen("sess-2")).toBe(false);
+	});
+
+	// `ao browser open` is the agent-side twin of `ao preview`: an explicit request
+	// to put a page in front of the user, so it reveals rather than badges.
+	it.each([["open"], ["tab-new"]])("reveals Browser for an explicit agent `%s` command", (action) => {
+		const { rerender } = render(<SessionView sessionId="sess-1" />);
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
-		expect(browserUnseen("sess-2")).toBe(true);
+
+		browserViewState.agentBrowserActive = true;
+		browserViewState.agentBrowserActivity = {
+			viewId: "browser:sess-1",
+			active: true,
+			action,
+			phase: "started",
+			commandId: "cmd-1",
+		};
+		rerender(<SessionView sessionId="sess-1" />);
+
+		expect(inspectorOpen("sess-1")).toBe(true);
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(browserUnseen("sess-1")).toBe(false);
+	});
+
+	// Passive inspection/interaction is background activity, not a request to be
+	// looked at — it must keep the badge-only treatment.
+	it.each([["snapshot"], ["click"], ["fill"], ["errors"]])(
+		"only badges Browser for a passive agent `%s` command",
+		(action) => {
+			const { rerender } = render(<SessionView sessionId="sess-1" />);
+
+			browserViewState.agentBrowserActive = true;
+			browserViewState.agentBrowserActivity = {
+				viewId: "browser:sess-1",
+				active: true,
+				action,
+				phase: "started",
+				commandId: "cmd-1",
+			};
+			rerender(<SessionView sessionId="sess-1" />);
+
+			expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+			expect(browserUnseen("sess-1")).toBe(true);
+		},
+	);
+
+	// The same command pushes activity twice (started/finished). Revealing on the
+	// second push would reopen a panel the user deliberately closed mid-command.
+	it("does not re-reveal Browser when the same agent open command finishes", () => {
+		const { rerender } = render(<SessionView sessionId="sess-1" />);
+
+		browserViewState.agentBrowserActive = true;
+		browserViewState.agentBrowserActivity = {
+			viewId: "browser:sess-1",
+			active: true,
+			action: "open",
+			phase: "started",
+			commandId: "cmd-1",
+		};
+		rerender(<SessionView sessionId="sess-1" />);
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+
+		act(() => useUiStore.getState().setInspectorView("sess-1", "summary"));
+
+		browserViewState.agentBrowserActive = false;
+		browserViewState.agentBrowserActivity = {
+			viewId: "browser:sess-1",
+			active: false,
+			action: "open",
+			phase: "finished",
+			commandId: "cmd-1",
+		};
+		rerender(<SessionView sessionId="sess-1" />);
+
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+	});
+
+	it("does not reveal Browser for an agent open command on a terminated session", () => {
+		const worker = workerSession("sess-1");
+		worker.isTerminated = true;
+		const { rerender } = render(<SessionView sessionId="sess-1" />);
+
+		browserViewState.agentBrowserActive = true;
+		browserViewState.agentBrowserActivity = {
+			viewId: "browser:sess-1",
+			active: true,
+			action: "open",
+			phase: "started",
+			commandId: "cmd-1",
+		};
+		rerender(<SessionView sessionId="sess-1" />);
+
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
 	});
 
 	// Regression: the session-entry effect that defaults a brand-new session to
@@ -2450,14 +2559,16 @@ describe("SessionView", () => {
 		worker.previewUrl = "http://localhost:5173/";
 		worker.previewRevision = 1;
 		rerender(<SessionView sessionId="sess-1" />);
-		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
-		expect(browserUnseen("sess-1")).toBe(true);
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(browserUnseen("sess-1")).toBe(false);
 
 		act(() => {
 			useUiStore.getState().setInspectorView("sess-1", "summary");
 			useUiStore.getState().setInspectorOpen("sess-1", false);
 		});
 
+		// Clearing the target is a revision bump with no URL: it must neither
+		// reveal nor badge, however a preview arriving is treated.
 		worker.previewUrl = undefined;
 		worker.previewRevision = 2;
 		rerender(<SessionView sessionId="sess-1" />);
@@ -2470,9 +2581,9 @@ describe("SessionView", () => {
 		worker.previewRevision = 3;
 		rerender(<SessionView sessionId="sess-1" />);
 
-		expect(inspectorOpen("sess-1")).toBe(false);
-		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
-		expect(browserUnseen("sess-1")).toBe(true);
+		expect(inspectorOpen("sess-1")).toBe(true);
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(browserUnseen("sess-1")).toBe(false);
 	});
 
 	// Regression: a terminated session's `previewUrl` is a stale DB fact —

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -220,6 +220,14 @@ function previewRevealKey(previewUrl?: string, previewRevision?: number): string
 	return `url:${target}`;
 }
 
+// Agent browser commands that exist to *show* the user a page, as opposed to
+// inspecting or driving one that is already open. These are the only agent
+// actions allowed to reveal the Browser panel; every other verb (snapshot,
+// click, fill, act, errors, …) stays badge-only. The strings are the action
+// names the CLI sends — see `ao browser open` / `ao browser tab new` in
+// backend/internal/cli/browser.go.
+const BROWSER_REVEALING_AGENT_ACTIONS = new Set(["open", "tab-new"]);
+
 function browserIsVisible(sessionId: string, browserPoppedOut: boolean): boolean {
 	if (browserPoppedOut) return true;
 	const current = useUiStore.getState().inspectorSessions[sessionId];
@@ -391,6 +399,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const setBrowserUnseen = useUiStore((state) => state.setBrowserUnseen);
 	const { daemonStatus } = useShell();
 	const previewBaselineRef = useRef<{ sessionId: string; key: string } | null>(null);
+	// commandId of the last explicit agent browser-open that already revealed the
+	// panel, so its "finished" push doesn't reveal a second time.
+	const revealedBrowserCommandRef = useRef<string | null>(null);
 	const sessionSplitRef = useRef<HTMLDivElement | null>(null);
 	const terminalLiveResizeTimerRef = useRef<number | null>(null);
 	const workspaceResizeTimerRef = useRef<number | null>(null);
@@ -1328,6 +1339,14 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		terminated,
 	]);
 
+	// Opens the inspector on Browser for this session. Deliberately does not
+	// touch OS window focus, the routed session, or the project — "reveal" means
+	// the panel is on screen for whoever is already here, nothing more.
+	const revealBrowserPanel = useCallback(() => {
+		setInspectorViewForSession(sessionId, "browser");
+		setInspectorOpenForSession(sessionId, true);
+	}, [sessionId, setInspectorOpenForSession, setInspectorViewForSession]);
+
 	useEffect(() => {
 		if (!hasInspector) return;
 		const previewKey = previewRevealKey(previewUrl, previewRevision);
@@ -1344,21 +1363,50 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			setBrowserUnseen(sessionId, false);
 			return;
 		}
-		// A new preview target used to force-switch the inspector to the Browser
-		// tab and pop it open, even if the user was looking at something else
-		// entirely (Reviews, a different session's Files tab, mid-typing in
-		// chat). Match the agent-activity effect below: badge it as unseen and
-		// let the user open Browser themselves when they're ready, instead of
-		// grabbing focus out from under them.
-		setBrowserUnseen(sessionId, true);
+		// `ao preview` is an explicit "show the user this page" request, so it
+		// reveals Browser rather than only badging it — the whole point of the
+		// command is that the target becomes visible. This only ever affects the
+		// session the user is looking at: SessionView is mounted for the routed
+		// session alone, so a background worker previewing its own session still
+		// can't pull the user's navigation to itself. Passive agent browser
+		// activity keeps the badge-only treatment in the effect below.
+		revealBrowserPanel();
 	}, [
 		browserPoppedOut,
 		hasInspector,
 		previewRevision,
 		previewUrl,
+		revealBrowserPanel,
 		sessionId,
 		setBrowserContentRevealed,
 		setBrowserUnseen,
+	]);
+
+	// `ao browser open` / `ao browser tab new` are the agent-side equivalents of
+	// `ao preview`: an explicit request to put a page in front of the user. Those
+	// reveal Browser; every other agent verb falls through to the badge-only
+	// effect below. Deduped on commandId so the command's "finished" push — or an
+	// unrelated rerender — can't re-open a panel the user closed mid-command.
+	useEffect(() => {
+		if (!hasInspector || terminated) return;
+		const activity = browserView.agentBrowserActivity;
+		if (!activity || !BROWSER_REVEALING_AGENT_ACTIONS.has(activity.action)) return;
+		const commandKey = activity.commandId ?? `${activity.action}:${activity.viewId}`;
+		if (revealedBrowserCommandRef.current === commandKey) return;
+		revealedBrowserCommandRef.current = commandKey;
+		if (browserIsVisible(sessionId, browserPoppedOut)) {
+			setBrowserUnseen(sessionId, false);
+			return;
+		}
+		revealBrowserPanel();
+	}, [
+		browserPoppedOut,
+		browserView.agentBrowserActivity,
+		hasInspector,
+		revealBrowserPanel,
+		sessionId,
+		setBrowserUnseen,
+		terminated,
 	]);
 
 	// Agent browser commands are genuine browser activity even when they do not


### PR DESCRIPTION
Fixes #5083

## Summary

`ao preview` and `ao browser open` succeeded but only badged the Browser tab as unseen, so the two commands whose entire purpose is "show the user this page" were the ones that didn't show it — the user had to notice a dot and click the tab.

[PR #4146](https://github.com/Untrivial-ai/agent-orchestrator/pull/4146) made every preview badge-only, deliberately, to stop a preview grabbing the foreground while the user was looking at something else. **This narrows that rule rather than reverting it.** The disruptive case #4146 was protecting against is a *background* session pulling focus; that protection now comes from `SessionView` being mounted only for the routed session, not from refusing to reveal at all.

- A new `ao preview` target reveals Browser for the session on screen.
- `ao browser open` / `ao browser tab new` reveal too — they are the agent-side equivalents of the same explicit request.
- Every passive agent verb (`snapshot`, `click`, `fill`, `act`, `errors`, …) keeps badge-only treatment, as does any preview/open in another session.
- Revealing opens the inspector on Browser and nothing else: no OS window focus, no change to the routed session or project.

The reveal is deduped on `commandId` so a command's `finished` push cannot reopen a panel the user closed mid-command.

## Intent contract — no API change

Explicit-vs-passive was already distinguishable from the existing API, so nothing crosses the daemon boundary and no contracts were regenerated:

- `BrowserAgentActivityState` (`frontend/src/main/browser-view-host.ts`) already ships `action` + `commandId` on `browser:agentActivity`, surfaced by `useBrowserView` as `agentBrowserActivity`.
- The action strings come straight from the CLI — `ao browser open` sends `"open"` (`backend/internal/cli/browser.go:91`), `ao browser tab new` sends `"tab-new"`, every passive command sends its own verb.
- `previewRevision` only changes when someone runs `ao preview`, so a preview-key change is inherently explicit.

## Test plan

- [x] `npm --prefix frontend run typecheck` — clean.
- [x] `vitest run SessionView.test.tsx BrowserPanel.test.tsx useBrowserView.test.tsx SessionInspector.test.tsx` — 346/346 passing. Three tests that asserted the old badge-only preview behavior were rewritten for the new rule; the `ao preview clear` test keeps its real subject (clearing neither reveals nor badges) with updated surrounding assertions. New coverage: reveal on `open`/`tab-new`, badge-only on `snapshot`/`click`/`fill`/`errors`, no re-reveal on the `finished` push, no reveal on a terminated session.
- [x] **Verified in the real Electron app** (isolated dev profile, driven over CDP; native `WebContentsView` target URLs read as ground truth):
  - Parked on Summary → `ao preview <url>` → Browser tab becomes selected.
  - Parked on Summary → `ao browser open http://127.0.0.1:3007/healthz` → Browser tab selected **and** the native view's target URL is that URL.
  - Parked on Summary → `ao browser snapshot` → stays on Summary, Browser shows the unseen badge.
  - Viewing session B, ran `ao browser open` **and** `ao preview` against background session A → route and tab both unchanged.

## Docs

`CLAUDE.md`'s agent guidance said `ao preview` "does not steal focus or force the Browser tab open"; updated to describe the explicit-vs-passive split.

## Known limitations

- Reveal is scoped to the routed session because only that `SessionView` is mounted. If a future change keeps multiple `SessionView`s alive at once, the cross-session guard would need to become an explicit check rather than an emergent property — called out in the comment at the preview effect.
- Unrelated pre-existing behavior seen while testing: on an exited fake-harness session the daemon clears `previewUrl` shortly after `ao preview` sets it (bumping `previewRevision` with an empty URL). That is upstream of this change and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)