### PR TITLE
fix: close active LAN connections when mobile access stops

### DIFF
--- a/backend/internal/httpd/controllers/mobile.go
+++ b/backend/internal/httpd/controllers/mobile.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -505,9 +506,12 @@ func (b *BridgeService) Disable() error {
 	if t := b.tunnel(); t != nil {
 		t.Stop()
 	}
-	if err := b.LAN.Stop(ctx); err != nil {
-		return err
+	stopErr := b.LAN.Stop(ctx)
+	if stopErr != nil && b.LAN.Running() {
+		return stopErr
 	}
+	// Forced cleanup can finish after the graceful-shutdown deadline. Persist
+	// the disabled preference once stopped, while still returning that error.
 	st, _ := mobilebridge.Load(b.ConfigPath)
 	// Only touch the tailnet proxy when this bridge actually installed one.
 	// `tailscale serve --https=443 off` is node-global state: clearing it
@@ -518,7 +522,7 @@ func (b *BridgeService) Disable() error {
 		_ = b.clearServe()
 	}
 	st.Enabled = false
-	return mobilebridge.Save(b.ConfigPath, st)
+	return errors.Join(stopErr, mobilebridge.Save(b.ConfigPath, st))
 }
 
 // ShutdownTunnel stops the managed connector on the way out.

--- a/backend/internal/httpd/controllers/mobile_test.go
+++ b/backend/internal/httpd/controllers/mobile_test.go
@@ -531,6 +531,95 @@ func TestMobileEnableStartsTheTunnelOnTheBoundPort(t *testing.T) {
 	}
 }
 
+type stopErrorLAN struct {
+	fakeLAN
+	err          error
+	stillRunning bool
+}
+
+func (f *stopErrorLAN) Stop(context.Context) error {
+	f.stopCalls++
+	f.running = f.stillRunning
+	return f.err
+}
+
+func TestMobileDisableFinishesCleanupAfterStopErrorWhenListenerStopped(t *testing.T) {
+	stopErr := errors.New("shutdown deadline exceeded")
+	path := filepath.Join(t.TempDir(), "mobile.json")
+	if err := mobilebridge.Save(path, mobilebridge.State{
+		Enabled:       true,
+		Password:      "paired-password",
+		LastPort:      3011,
+		SecurePairing: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cleared := 0
+	lan := &stopErrorLAN{
+		fakeLAN: fakeLAN{running: true, hash: mobilebridge.HashPassword("paired-password")},
+		err:     stopErr,
+	}
+	bridge := &BridgeService{
+		LAN:         lan,
+		ConfigPath:  path,
+		ClearServe:  func() error { cleared++; return nil },
+		DefaultPort: 3011,
+	}
+
+	if err := bridge.Disable(); !errors.Is(err, stopErr) {
+		t.Fatalf("Disable error = %v, want %v", err, stopErr)
+	}
+	state, err := mobilebridge.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Enabled {
+		t.Fatal("persisted bridge remained enabled after the listener stopped")
+	}
+	if cleared != 1 {
+		t.Fatalf("owned secure-pairing proxy cleared %d times, want 1", cleared)
+	}
+}
+
+func TestMobileDisablePreservesEnabledStateWhenStopErrorLeavesListenerRunning(t *testing.T) {
+	stopErr := errors.New("listener still running")
+	path := filepath.Join(t.TempDir(), "mobile.json")
+	if err := mobilebridge.Save(path, mobilebridge.State{
+		Enabled:       true,
+		Password:      "paired-password",
+		LastPort:      3011,
+		SecurePairing: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cleared := 0
+	lan := &stopErrorLAN{
+		fakeLAN:      fakeLAN{running: true, hash: mobilebridge.HashPassword("paired-password")},
+		err:          stopErr,
+		stillRunning: true,
+	}
+	bridge := &BridgeService{
+		LAN:         lan,
+		ConfigPath:  path,
+		ClearServe:  func() error { cleared++; return nil },
+		DefaultPort: 3011,
+	}
+
+	if err := bridge.Disable(); !errors.Is(err, stopErr) {
+		t.Fatalf("Disable error = %v, want %v", err, stopErr)
+	}
+	state, err := mobilebridge.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Enabled {
+		t.Fatal("persisted bridge was disabled while the listener remained running")
+	}
+	if cleared != 0 {
+		t.Fatalf("secure-pairing proxy cleared %d times while listener remained live", cleared)
+	}
+}
+
 func TestMobileDisableStopsTheTunnel(t *testing.T) {
 	// Leaving a public tunnel up after the user turned Connect Mobile off would
 	// keep the machine reachable from the internet with the UI saying it is not.

--- a/backend/internal/httpd/lan_listener.go
+++ b/backend/internal/httpd/lan_listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -23,10 +24,12 @@ type LANManager struct {
 	log         *slog.Logger
 	state       *authState // shared with authMiddleware; SetPasswordHash writes through here
 
-	mu    sync.Mutex
-	srv   *http.Server
-	ln    net.Listener
-	bound int
+	transitionMu sync.Mutex // serializes Start and Stop without blocking status reads
+	mu           sync.Mutex
+	srv          *http.Server
+	ln           *lanListener
+	cancel       context.CancelFunc
+	bound        int
 }
 
 // NewLANManager wraps handler in the LAN control-block and authMiddleware
@@ -135,6 +138,8 @@ func (m *LANManager) PasswordHash() string {
 // ephemeral port if that port is in use) and serves the wrapped handler. It is
 // idempotent: a second call while running returns the already-bound port.
 func (m *LANManager) Start(port int) (int, error) {
+	m.transitionMu.Lock()
+	defer m.transitionMu.Unlock()
 	m.mu.Lock()
 	if m.srv != nil {
 		defer m.mu.Unlock()
@@ -156,20 +161,26 @@ func (m *LANManager) Start(port int) (int, error) {
 		}
 		m.log.Warn("LAN port in use; bound ephemeral", "wanted", port, "bound", ln.Addr())
 	}
-	m.ln = ln
 	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
 	if !ok {
 		m.mu.Unlock()
 		_ = ln.Close()
 		return 0, fmt.Errorf("bind LAN: unexpected listener address type %T", ln.Addr())
 	}
+	streamCtx, cancel := context.WithCancel(context.Background())
+	tracked := &lanListener{Listener: ln, conns: make(map[*lanConn]struct{})}
+	m.ln, m.cancel = tracked, cancel
 	m.bound = tcpAddr.Port
-	m.srv = &http.Server{Handler: m.handler, ReadHeaderTimeout: 10 * time.Second}
+	m.srv = &http.Server{
+		Handler:           m.handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return streamCtx },
+	}
 	srv := m.srv
 	boundPort := m.bound
 	m.mu.Unlock()
 	go func() {
-		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := srv.Serve(tracked); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			m.log.Error("LAN listener serve", "err", err)
 		}
 	}()
@@ -177,17 +188,110 @@ func (m *LANManager) Start(port int) (int, error) {
 	return boundPort, nil
 }
 
-// Stop gracefully shuts down the listener (honoring ctx) and clears the bound
-// state. It is a no-op if the listener is not running.
+// Stop cancels LAN request contexts and drains the listener within ctx. It
+// closes remaining connections, including hijacked WebSockets, before clearing
+// the bound state. A grace-period error is returned after cleanup completes.
 func (m *LANManager) Stop(ctx context.Context) error {
+	m.transitionMu.Lock()
+	defer m.transitionMu.Unlock()
 	m.mu.Lock()
-	srv := m.srv
-	m.srv, m.ln, m.bound = nil, nil, 0
+	srv, ln, cancel := m.srv, m.ln, m.cancel
 	m.mu.Unlock()
 	if srv == nil {
 		return nil
 	}
-	return srv.Shutdown(ctx)
+	cancel()
+	err := srv.Shutdown(ctx)
+	if err != nil {
+		err = errors.Join(err, srv.Close())
+	}
+	// Stop may run before Serve registers its listener with http.Server.
+	// Close our listener explicitly even when Shutdown had nothing to close.
+	err = errors.Join(err, ln.Close())
+	// Shutdown and Close deliberately leave hijacked connections alone. The
+	// listener owns them until their actual Close, even after HTTP's handoff.
+	err = errors.Join(err, ln.closeConnections())
+	m.mu.Lock()
+	m.srv, m.ln, m.cancel, m.bound = nil, nil, nil, 0
+	m.mu.Unlock()
+	return err
+}
+
+// lanListener tracks the lifetime of the underlying connections rather than
+// HTTP states: a WebSocket leaves http.Server's registry when it is hijacked.
+type lanListener struct {
+	net.Listener
+	mu        sync.Mutex
+	conns     map[*lanConn]struct{}
+	closed    bool
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (l *lanListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		_ = conn.Close()
+		return nil, net.ErrClosed
+	}
+	tracked := &lanConn{Conn: conn, owner: l}
+	l.conns[tracked] = struct{}{}
+	return tracked, nil
+}
+
+func (l *lanListener) Close() error {
+	l.closeOnce.Do(func() {
+		l.mu.Lock()
+		l.closed = true
+		l.mu.Unlock()
+		l.closeErr = l.Listener.Close()
+	})
+	return l.closeErr
+}
+
+func (l *lanListener) closeConnections() error {
+	l.mu.Lock()
+	conns := make([]*lanConn, 0, len(l.conns))
+	for conn := range l.conns {
+		conns = append(conns, conn)
+	}
+	l.mu.Unlock()
+	var errs []error
+	for _, conn := range conns {
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type lanConn struct {
+	net.Conn
+	owner *lanListener
+}
+
+// Preserve the TCP capabilities net/http uses for response copying and sending
+// a FIN before closing connections with unread request bodies.
+func (c *lanConn) ReadFrom(r io.Reader) (int64, error) { return io.Copy(c.Conn, r) }
+
+func (c *lanConn) CloseWrite() error {
+	if conn, ok := c.Conn.(interface{ CloseWrite() error }); ok {
+		return conn.CloseWrite()
+	}
+	return nil
+}
+
+func (c *lanConn) Close() error {
+	err := c.Conn.Close()
+	c.owner.mu.Lock()
+	delete(c.owner.conns, c)
+	c.owner.mu.Unlock()
+	return err
 }
 
 // Running reports whether the LAN listener is currently serving.

--- a/backend/internal/httpd/lan_shutdown_test.go
+++ b/backend/internal/httpd/lan_shutdown_test.go
@@ -1,0 +1,399 @@
+package httpd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
+)
+
+func startShutdownTestLAN(t *testing.T, handler http.Handler) (*LANManager, string) {
+	t.Helper()
+	m := NewMobileLAN(handler, 0, nil, nil)
+	m.SetPasswordHash(mobilebridge.HashPassword("secret12"))
+	port, err := m.Start(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = m.Stop(ctx)
+	})
+	return m, fmt.Sprintf("http://127.0.0.1:%d", port)
+}
+
+func openLANShutdownStream(t *testing.T, url string) *http.Response {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer secret12")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = res.Body.Close() })
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d", res.StatusCode)
+	}
+	return res
+}
+
+func assertLANStreamClosed(t *testing.T, res *http.Response) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.ReadAll(res.Body)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("stream ended only because the client timed out: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("LAN stream remained open after Stop returned")
+	}
+}
+
+func TestLANManagerStopCancelsStreamAndAllowsRestart(t *testing.T) {
+	ended := make(chan struct{})
+	m, base := startShutdownTestLAN(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_, _ = io.WriteString(w, "ready")
+			return
+		}
+		defer close(ended)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	res := openLANShutdownStream(t, base+"/events")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := m.Stop(ctx); err != nil {
+		t.Fatalf("cooperative stream did not stop gracefully: %v", err)
+	}
+	assertLANStreamClosed(t, res)
+	select {
+	case <-ended:
+	case <-time.After(time.Second):
+		t.Fatal("handler context was not cancelled")
+	}
+	if m.Running() || m.BoundPort() != 0 {
+		t.Fatal("stopped listener still advertised")
+	}
+	port, err := m.Start(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	health := openLANShutdownStream(t, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	body, err := io.ReadAll(health.Body)
+	if err != nil || string(body) != "ready" {
+		t.Fatalf("restarted listener: body=%q err=%v", body, err)
+	}
+}
+
+func TestLANManagerStopClosesConnectionAfterCancelledGrace(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	m, base := startShutdownTestLAN(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		// Deliberately ignore cancellation to exercise forced connection close.
+		<-release
+	}))
+	res := openLANShutdownStream(t, base+"/events")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := m.Stop(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Stop error = %v, want cancelled grace context", err)
+	}
+	assertLANStreamClosed(t, res)
+}
+
+func TestLANManagerStartWaitsForPreviousStop(t *testing.T) {
+	stopping := make(chan struct{})
+	release := make(chan struct{})
+	releaseHandler := sync.OnceFunc(func() { close(release) })
+	defer releaseHandler()
+	m, base := startShutdownTestLAN(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+		close(stopping)
+		<-release
+	}))
+	res := openLANShutdownStream(t, base+"/events")
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- m.Stop(stopCtx) }()
+	select {
+	case <-stopping:
+	case <-time.After(time.Second):
+		releaseHandler()
+		t.Fatal("stop did not cancel the old request")
+	}
+	statusDone := make(chan bool, 1)
+	go func() { statusDone <- m.Running() && m.BoundPort() != 0 }()
+	select {
+	case running := <-statusDone:
+		if !running {
+			t.Fatal("listener advertised stopped before cleanup finished")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("status reads blocked behind graceful shutdown")
+	}
+	startDone := make(chan error, 1)
+	go func() {
+		_, err := m.Start(0)
+		startDone <- err
+	}()
+	select {
+	case err := <-startDone:
+		releaseHandler()
+		t.Fatalf("Start returned before the old listener finished stopping: %v", err)
+	case <-time.After(50 * time.Millisecond):
+		// The old handler is held open, so a completed restart is premature.
+	}
+	releaseHandler()
+	if err := <-stopDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-startDone; err != nil {
+		t.Fatal(err)
+	}
+	assertLANStreamClosed(t, res)
+	if !m.Running() || m.BoundPort() == 0 {
+		t.Fatal("old Stop cleared the new listener state")
+	}
+}
+
+func TestLANManagerStopClosesHijackedWebSocket(t *testing.T) {
+	ended := make(chan struct{})
+	m, base := startShutdownTestLAN(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(ended)
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		for {
+			// A hijacked connection is no longer owned by http.Server. Even a
+			// handler that does not use the request context must lose access.
+			kind, data, err := conn.Read(context.Background())
+			if err != nil {
+				return
+			}
+			if err := conn.Write(context.Background(), kind, data); err != nil {
+				return
+			}
+		}
+	}))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, base+"/mux", &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": {"Bearer secret12"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+	if err := conn.Write(ctx, websocket.MessageText, []byte("before")); err != nil {
+		t.Fatal(err)
+	}
+	if _, data, err := conn.Read(ctx); err != nil || string(data) != "before" {
+		t.Fatalf("echo before stop: data=%q err=%v", data, err)
+	}
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+	defer stopCancel()
+	if err := m.Stop(stopCtx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ended:
+	case <-time.After(time.Second):
+		t.Fatal("hijacked connection remained open after Stop returned")
+	}
+	if _, _, err := conn.Read(ctx); err == nil {
+		t.Fatal("WebSocket remained readable after Stop")
+	}
+}
+
+func TestLANManagerStopBeforeServeRegistersListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	streamCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := NewMobileLAN(http.NotFoundHandler(), 0, nil, nil)
+	// This is Start's published state before its Serve goroutine is scheduled.
+	// Delay Serve explicitly so this ownership boundary is deterministic.
+	m.ln = &lanListener{Listener: ln, conns: make(map[*lanConn]struct{})}
+	m.cancel = cancel
+	m.bound = ln.Addr().(*net.TCPAddr).Port
+	m.srv = &http.Server{
+		Handler:     m.handler,
+		BaseContext: func(net.Listener) context.Context { return streamCtx },
+	}
+	srv, tracked := m.srv, m.ln
+	if err := m.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	rebound, err := net.Listen("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Stop left the unregistered listener bound: %v", err)
+	}
+	defer rebound.Close()
+	if err := srv.Serve(tracked); !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("late Serve returned %v, want ErrServerClosed", err)
+	}
+}
+
+// Keeping already-closed hijacked sockets in the registry would grow memory
+// with every mobile reconnect until the listener is finally disabled.
+func TestLANManagerReleasesClosedWebSocket(t *testing.T) {
+	ended := make(chan struct{})
+	m, base := startShutdownTestLAN(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(ended)
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer conn.CloseNow()
+		_, _, _ = conn.Read(context.Background())
+	}))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, base+"/mux", &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": {"Bearer secret12"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
+	m.mu.Lock()
+	listener := m.ln
+	m.mu.Unlock()
+	listener.mu.Lock()
+	active := len(listener.conns)
+	listener.mu.Unlock()
+	if active != 1 {
+		t.Fatalf("tracked active connections = %d, want 1", active)
+	}
+	if err := conn.CloseNow(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ended:
+	case <-time.After(time.Second):
+		t.Fatal("WebSocket handler did not finish after client close")
+	}
+	listener.mu.Lock()
+	retained := len(listener.conns)
+	listener.mu.Unlock()
+	if retained != 0 {
+		t.Fatalf("retained closed connections = %d, want 0", retained)
+	}
+	if !m.Running() {
+		t.Fatal("closing one client stopped the listener")
+	}
+}
+
+func TestLANConnPreservesTCPHalfClose(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	listener := &lanListener{Listener: ln, conns: make(map[*lanConn]struct{})}
+	peer, err := net.DialTimeout("tcp", ln.Addr().String(), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer peer.Close()
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := peer.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	closeWriter, ok := conn.(interface{ CloseWrite() error })
+	if !ok {
+		t.Fatal("tracked TCP connection lost CloseWrite")
+	}
+	if err := closeWriter.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1)
+	if n, err := peer.Read(buf); n != 0 || !errors.Is(err, io.EOF) {
+		t.Fatalf("peer read after half-close = %d, %v; want EOF", n, err)
+	}
+	if _, err := peer.Write([]byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := conn.Read(buf); err != nil || n != 1 || buf[0] != 'x' {
+		t.Fatalf("read side after half-close = %q, %v", buf[:n], err)
+	}
+	if len(listener.conns) != 1 {
+		t.Fatal("half-closed connection lost shutdown ownership")
+	}
+}
+
+// net/http uses the optional ReaderFrom method for efficient response copies.
+// A connection wrapper must keep that path available to the server.
+func TestLANConnPreservesReadFrom(t *testing.T) {
+	underlying := &readFromLANTestConn{}
+	conn := &lanConn{Conn: underlying}
+	readerFrom, ok := any(conn).(io.ReaderFrom)
+	if !ok {
+		t.Fatal("tracked connection lost ReaderFrom")
+	}
+	src := struct{ io.Reader }{strings.NewReader("response body")}
+	n, err := readerFrom.ReadFrom(src)
+	if err != nil || n != 13 || underlying.received.String() != "response body" {
+		t.Fatalf("ReadFrom = %d, %v; body=%q", n, err, underlying.received.String())
+	}
+	if !underlying.usedReadFrom {
+		t.Fatal("response copy bypassed the underlying ReaderFrom")
+	}
+}
+
+type readFromLANTestConn struct {
+	net.Conn
+	received     bytes.Buffer
+	usedReadFrom bool
+}
+
+func (c *readFromLANTestConn) ReadFrom(r io.Reader) (int64, error) {
+	c.usedReadFrom = true
+	return c.received.ReadFrom(r)
+}
+
+func (c *readFromLANTestConn) Write(p []byte) (int, error) { return c.received.Write(p) }


### PR DESCRIPTION
## What

Disabling Connect Mobile now closes active LAN streams and WebSockets before reporting the listener stopped.

## Why

A shutdown timeout could leave HTTP clients connected, and Go's HTTP shutdown does not close hijacked WebSockets. Disable also returned early on a shutdown error without saving the disabled preference, so a stopped bridge could return on the next daemon boot.

## How

Give each listener its own cancellation context and connection registry. Serialize Start/Stop, force-close remaining connections after the grace period, and retain shutdown errors while completing disabled-state persistence. The connection wrapper preserves TCP half-close and efficient response copying.

This is independent of #5084's controller transition locking; their combined HTTP race tests pass. LAN authentication and route boundaries are unchanged.

## Testing

- Reproduced stream, WebSocket, and persistence failures on main; added restart, registry cleanup, responsive status, and TCP compatibility coverage.
- `go test -race -count=1 ./internal/httpd/...`
- Full backend tests/race suite, build, vet, formatting, and golangci-lint v2.12.2.
- Node 24 API regeneration/drift, Linux CLI E2E, container fresh-install, and pinned gitleaks scan.
- Native macOS/Windows checks require CI and cannot run locally on Linux.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
