### PR TITLE
fix(landing): reduce eager downloads and size hero before hydration

### DIFF
--- a/frontend/src/landing/scripts/check-hero-layout.mjs
+++ b/frontend/src/landing/scripts/check-hero-layout.mjs
@@ -1,0 +1,160 @@
+// Run after `npm run build` in the landing workspace:
+// node --test scripts/check-hero-layout.mjs
+// Uses the frontend workspace's existing Playwright dependency/browsers.
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { after, before, test } from "node:test";
+import { chromium, webkit } from "playwright";
+
+const output = fileURLToPath(new URL("../out/", import.meta.url));
+const browserType = process.env.LANDING_TEST_BROWSER === "webkit" ? webkit : chromium;
+let browser;
+let server;
+let origin;
+const mime = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".svg": "image/svg+xml", ".woff2": "font/woff2" };
+
+before(async () => {
+  await readFile(path.join(output, "index.html"));
+  server = createServer(async (req, res) => {
+    const pathname = new URL(req.url, "http://localhost").pathname;
+    const filename = path.resolve(output, `.${pathname.endsWith("/") ? `${pathname}index.html` : pathname}`);
+    if (!filename.startsWith(output)) { res.writeHead(403).end(); return; }
+    try {
+      const body = await readFile(filename);
+      res.setHeader("Content-Type", mime[path.extname(filename)] ?? "application/octet-stream");
+      res.end(body);
+    } catch { res.writeHead(404).end(); }
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  origin = `http://127.0.0.1:${server.address().port}`;
+  browser = await browserType.launch({
+    headless: true,
+    executablePath: process.env.LANDING_TEST_EXECUTABLE || undefined,
+  });
+});
+after(async () => {
+  await browser?.close();
+  await new Promise(resolve => server ? server.close(resolve) : resolve());
+});
+
+async function newPage(options) {
+  const context = await browser.newContext(options);
+  // The export is the fixture: never contact GitHub, analytics, or other hosts.
+  await context.route("**/*", route => route.request().url().startsWith(`${origin}/`) ? route.continue() : route.abort());
+  return { context, page: await context.newPage() };
+}
+
+async function geometry(page) {
+  return page.locator(".hero-mockup-window").evaluate(window => {
+    const frame = window.closest(".hero-mockup-viewport").parentElement.getBoundingClientRect();
+    const rect = window.getBoundingClientRect();
+    return {
+      frame: { x: frame.x, y: frame.y, width: frame.width, height: frame.height },
+      window: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      visible: getComputedStyle(window).visibility,
+      layoutWidth: window.offsetWidth,
+    };
+  });
+}
+function assertFits({ frame, window, visible, layoutWidth }) {
+  assert.equal(visible, "visible");
+  assert.equal(layoutWidth, 1140, "board layout must not reflow on mobile");
+  const scale = Math.min(1, (frame.width - 8) / 1140, (frame.height - 8) / 615);
+  for (const [actual, expected] of [
+    [window.width, 1140 * scale], [window.height, 615 * scale],
+    [window.x, frame.x + (frame.width - window.width) / 2],
+    [window.y, frame.y + (frame.height - window.height) / 2],
+  ]) assert.ok(Math.abs(actual - expected) < 1, `${actual} should be within 1px of ${expected}`);
+}
+
+for (const width of [320, 390, 768, 1440]) {
+  test(`visible and correctly fitted without JavaScript at ${width}px`, async () => {
+    const { context, page } = await newPage({ javaScriptEnabled: false, viewport: { width, height: 900 } });
+    try {
+      await page.goto(origin, { waitUntil: "load" });
+      assertFits(await geometry(page));
+    } finally { await context.close(); }
+  });
+}
+
+test("delayed hydration preserves geometry; resize and height constraints still fit", { timeout: 60000 }, async () => {
+  const { context, page } = await newPage({ viewport: { width: 390, height: 844 } });
+  const errors = [];
+  page.on("pageerror", error => errors.push(error.message));
+  let release;
+  const gate = new Promise(resolve => { release = resolve; });
+  await page.route("**/*.js", async route => {
+    if (!route.request().url().startsWith(`${origin}/`)) { await route.abort(); return; }
+    await gate;
+    await route.continue();
+  });
+  try {
+    await page.goto(origin, { waitUntil: "commit" });
+    await page.locator(".hero-mockup-window").waitFor({ state: "visible" });
+    await page.evaluate(() => Promise.all([400, 500, 600, 700].map(weight =>
+      document.fonts.load(`${weight} 16px ${getComputedStyle(document.body).fontFamily}`))));
+    const first = await geometry(page);
+    assertFits(first);
+    const initialText = await page.locator(".hero-mockup-window").textContent();
+    release();
+    await page.waitForLoadState("load");
+    // An actual board update proves the component has hydrated and its timers run.
+    await page.waitForFunction(text => document.querySelector(".hero-mockup-window").textContent !== text, initialText);
+    const hydrated = await geometry(page);
+    assertFits(hydrated);
+    for (const key of ["x", "y", "width", "height"]) {
+      assert.ok(Math.abs(first.window[key] - hydrated.window[key]) < 1, `hydration changed ${key}`);
+    }
+    await page.setViewportSize({ width: 844, height: 390 });
+    assertFits(await geometry(page));
+    await page.locator(".hero-mockup-viewport").evaluate(frame => {
+      frame.parentElement.style.cssText += ";height:160px;min-height:0;aspect-ratio:auto";
+    });
+    assertFits(await geometry(page));
+    assert.deepEqual(errors, []);
+  } finally { release(); await context.close(); }
+});
+
+// Wide/tall frames must never upscale the board past its design size.
+test("large frames retain the design size without JavaScript", async () => {
+  const { context, page } = await newPage({ javaScriptEnabled: false, viewport: { width: 1600, height: 1200 } });
+  try {
+    await page.goto(origin, { waitUntil: "load" });
+    await page.locator(".hero-mockup-viewport").evaluate(frame => {
+      frame.parentElement.style.cssText += ";width:1400px;height:1000px;min-height:0";
+    });
+    const result = await geometry(page);
+    assertFits(result);
+    assert.equal(result.window.width, 1140);
+    assert.equal(result.window.height, 615);
+  } finally { await context.close(); }
+});
+
+test("legacy fallback measures before revealing and updates after resize", async () => {
+  const { context, page } = await newPage({ viewport: { width: 390, height: 844 } });
+  await context.addInitScript(() => {
+    delete CSS.registerProperty;
+  });
+  // Emulate an engine that ignores @property; plain custom properties still work.
+  await page.route("**/*.css", async route => {
+    const response = await route.fetch();
+    const body = (await response.text()).replace(/@property --mockup-[^{]+\{[^}]*\}/g, "");
+    await route.fulfill({ response, body });
+  });
+  try {
+    await page.goto(origin, { waitUntil: "load" });
+    await page.waitForFunction(() => document.querySelector(".hero-mockup-window")?.style.visibility === "visible");
+    assertFits(await geometry(page));
+    await page.setViewportSize({ width: 844, height: 390 });
+    await page.waitForFunction(() => {
+      const el = document.querySelector(".hero-mockup-window");
+      const frame = el.parentElement.getBoundingClientRect();
+      const expected = Math.min(1, frame.width / 1140, frame.height / 615);
+      return Math.abs(el.getBoundingClientRect().width - expected * 1140) < 1;
+    });
+    assertFits(await geometry(page));
+  } finally { await context.close(); }
+});

--- a/frontend/src/landing/src/app/components/FeaturesSection/FeaturesSection.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/FeaturesSection.tsx
@@ -68,7 +68,6 @@ export function FeaturesSection() {
 										backgroundImage={
 											FEATURE_BACKGROUNDS[index % FEATURE_BACKGROUNDS.length]
 										}
-										preload
 									>
 										{DemoComponent && <DemoComponent />}
 									</FeatureDemo>

--- a/frontend/src/landing/src/app/components/FeaturesSection/components/FleetBoardDemo/FleetBoardDemo.test.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/FleetBoardDemo/FleetBoardDemo.test.tsx
@@ -1,0 +1,51 @@
+import { StrictMode, act, type PropsWithChildren } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { FleetBoardDemo } from "./FleetBoardDemo";
+
+vi.mock("motion/react", () => ({
+	AnimatePresence: ({ children }: PropsWithChildren) => children,
+	LayoutGroup: ({ children }: PropsWithChildren) => children,
+	motion: { div: ({ children }: PropsWithChildren) => <div>{children}</div> },
+}));
+vi.mock("../usePreviewScale", () => ({
+	usePreviewScale: () => ({ viewportRef: null, viewportStyle: {}, canvasStyle: {} }),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+	container = document.createElement("div");
+	document.body.append(container);
+	root = createRoot(container);
+});
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+it("advances and spawns once per tick under StrictMode", () => {
+	vi.spyOn(Math, "random").mockReturnValue(0);
+	act(() => root.render(<StrictMode><FleetBoardDemo /></StrictMode>));
+	expect(container.textContent).not.toContain("Add keyboard shortcut for session focus");
+	act(() => vi.advanceTimersByTime(5000));
+	expect(container.textContent).toContain("Add keyboard shortcut for session focus");
+	expect(container.textContent).not.toContain("Lazy-load session terminal on first open");
+	act(() => vi.advanceTimersByTime(5000));
+	expect(container.textContent).toContain("Lazy-load session terminal on first open");
+});
+
+it("cancels pending card removal and animation ticks on unmount", () => {
+	vi.spyOn(Math, "random").mockReturnValue(0.999);
+	act(() => root.render(<StrictMode><FleetBoardDemo /></StrictMode>));
+	act(() => vi.advanceTimersByTime(10994));
+	// The selected merge card has a pending zero-delay removal timer.
+	expect(vi.getTimerCount()).toBeGreaterThanOrEqual(2);
+	act(() => root.unmount());
+	expect(vi.getTimerCount()).toBe(0);
+});

--- a/frontend/src/landing/src/app/components/FeaturesSection/components/FleetBoardDemo/FleetBoardDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/FleetBoardDemo/FleetBoardDemo.tsx
@@ -116,7 +116,7 @@ function advanceCard(card: Card): Card {
 const INITIAL_CARDS: Card[] = [
 	{
 		id: "c1", title: "Confirm download labels are platform-aware",
-		branch: "landing/platform-copy", icon: "/app-icons/cursor.svg",
+		branch: "landing/platform-copy", icon: "/app-icons/agents/cursor.svg",
 		column: "working", activity: "Editing copy", activityState: "running",
 		pr: "draft", time: "14m ago",
 	},
@@ -487,7 +487,7 @@ export function FleetBoardDemo() {
 					const templates = [
 						{ title: "Throttle agent spawn rate under load",      branch: "backend/spawn-throttle",      icon: "/app-icons/coverage-claude-code.svg" },
 						{ title: "Add keyboard shortcut for session focus",    branch: "feat/session-focus-shortcut", icon: "/app-icons/coverage-codex.svg"       },
-						{ title: "Lazy-load session terminal on first open",   branch: "perf/lazy-terminal",          icon: "/app-icons/cursor.svg"               },
+						{ title: "Lazy-load session terminal on first open",   branch: "perf/lazy-terminal",          icon: "/app-icons/agents/cursor.svg"        },
 						{ title: "Fix memory leak in terminal resize handler", branch: "fix/terminal-resize-leak",    icon: "/app-icons/coverage-claude-code.svg" },
 						{ title: "Migrate auth tokens to short-lived JWTs",   branch: "auth/jwt-rotation",           icon: "/app-icons/opencode.svg"             },
 					];

--- a/frontend/src/landing/src/app/components/FeaturesSection/components/FleetBoardDemo/FleetBoardDemo.tsx
+++ b/frontend/src/landing/src/app/components/FeaturesSection/components/FleetBoardDemo/FleetBoardDemo.tsx
@@ -416,102 +416,106 @@ function BoardColumn({ cards, color, title }: { cards: Card[]; color: string; ti
 
 export function FleetBoardDemo() {
 	const [cards, setCards] = useState<Card[]>(INITIAL_CARDS);
-	const incomingIdx = useRef(0);
+	const simulation = useRef({ cards: INITIAL_CARDS, incomingIdx: 0 });
 	const { viewportRef, viewportStyle, canvasStyle } = usePreviewScale(570, 318);
-
-	// Remove a merged card after its exit animation
-	const mergeCard = (id: string) => {
-		setCards((c) => c.filter((card) => card.id !== id));
-	};
 
 	useEffect(() => {
 		let timeoutId: number;
+		let mergeTimeoutId: number | undefined;
 		const scheduleNext = () => { timeoutId = window.setTimeout(runStep, randomDelay()); };
+		const mergeCard = (id: string) => {
+			simulation.current.cards = simulation.current.cards.filter((card) => card.id !== id);
+			setCards(simulation.current.cards);
+		};
 
 		const runStep = () => {
-			setCards((current) => {
-				// Pick a card to advance (weighted towards earlier columns)
-				let total = 0;
-				for (const c of current) {
-					if (!c.merging) total += COLUMN_CONFIG[c.column].weight;
-				}
-				let threshold = Math.random() * total;
-				let chosen: Card | null = null;
-				for (const c of current) {
-					if (c.merging) continue;
-					threshold -= COLUMN_CONFIG[c.column].weight;
-					if (threshold <= 0) { chosen = c; break; }
-				}
-				if (!chosen) chosen = current.find((c) => !c.merging) ?? null;
+			// Advance the simulation once per timer tick, outside React updater callbacks.
+			const current = simulation.current.cards;
+			// Pick a card to advance (weighted towards earlier columns)
+			let total = 0;
+			for (const c of current) {
+				if (!c.merging) total += COLUMN_CONFIG[c.column].weight;
+			}
+			let threshold = Math.random() * total;
+			let chosen: Card | null = null;
+			for (const c of current) {
+				if (c.merging) continue;
+				threshold -= COLUMN_CONFIG[c.column].weight;
+				if (threshold <= 0) { chosen = c; break; }
+			}
+			if (!chosen) chosen = current.find((c) => !c.merging) ?? null;
 
-				let next = current;
-				if (chosen) {
-					if (chosen.column === "merge") {
-						window.setTimeout(() => mergeCard(chosen!.id), 0);
-						next = next.map((c) => c.id === chosen!.id ? { ...c, merging: true } : c);
-					} else {
-						next = next.map((c) => c.id === chosen!.id ? advanceCard(c) : c);
-					}
+			let next = current;
+			if (chosen) {
+				if (chosen.column === "merge") {
+					mergeTimeoutId = window.setTimeout(() => mergeCard(chosen!.id), 0);
+					next = next.map((c) => c.id === chosen!.id ? { ...c, merging: true } : c);
+				} else {
+					next = next.map((c) => c.id === chosen!.id ? advanceCard(c) : c);
 				}
+			}
 
-				// Ensure no column is ever empty
-				for (let i = 1; i < COLUMN_ORDER.length; i++) {
-					const col = COLUMN_ORDER[i]!;
-					const prev = COLUMN_ORDER[i - 1]!;
-					if (next.filter((c) => c.column === col && !c.merging).length === 0) {
-						const donor = next.find((c) => c.column === prev && !c.merging);
-						if (donor) next = next.map((c) => c.id === donor.id ? advanceCard(c) : c);
-					}
+			// Ensure no column is ever empty
+			for (let i = 1; i < COLUMN_ORDER.length; i++) {
+				const col = COLUMN_ORDER[i]!;
+				const prev = COLUMN_ORDER[i - 1]!;
+				if (next.filter((c) => c.column === col && !c.merging).length === 0) {
+					const donor = next.find((c) => c.column === prev && !c.merging);
+					if (donor) next = next.map((c) => c.id === donor.id ? advanceCard(c) : c);
 				}
+			}
 
-				// Occasionally flip a card to waiting
-				if (Math.random() < 0.1) {
-					const candidates = next.filter((c) => !c.merging && c.activityState !== "waiting" && c.column !== "merge");
-					const target = candidates[Math.floor(Math.random() * candidates.length)];
-					if (target) {
-						next = next.map((c) =>
-							c.id === target.id ? {
-								...c,
-								activityState: "waiting" as const,
-								activity: c.column === "in_review" ? "Changes requested" : "Needs your input",
-								time: randomTime(),
-							} : c,
-						);
-					}
+			// Occasionally flip a card to waiting
+			if (Math.random() < 0.1) {
+				const candidates = next.filter((c) => !c.merging && c.activityState !== "waiting" && c.column !== "merge");
+				const target = candidates[Math.floor(Math.random() * candidates.length)];
+				if (target) {
+					next = next.map((c) =>
+						c.id === target.id ? {
+							...c,
+							activityState: "waiting" as const,
+							activity: c.column === "in_review" ? "Changes requested" : "Needs your input",
+							time: randomTime(),
+						} : c,
+					);
 				}
+			}
 
-				// Spawn a new working card if column is thin
-				const workingCount = next.filter((c) => c.column === "working" && !c.merging).length;
-				if (workingCount < 2 && next.filter((c) => !c.merging).length < 8) {
-					const newId = `spawned-${++incomingIdx.current}`;
-					const templates = [
-						{ title: "Throttle agent spawn rate under load",      branch: "backend/spawn-throttle",      icon: "/app-icons/coverage-claude-code.svg" },
-						{ title: "Add keyboard shortcut for session focus",    branch: "feat/session-focus-shortcut", icon: "/app-icons/coverage-codex.svg"       },
-						{ title: "Lazy-load session terminal on first open",   branch: "perf/lazy-terminal",          icon: "/app-icons/agents/cursor.svg"        },
-						{ title: "Fix memory leak in terminal resize handler", branch: "fix/terminal-resize-leak",    icon: "/app-icons/coverage-claude-code.svg" },
-						{ title: "Migrate auth tokens to short-lived JWTs",   branch: "auth/jwt-rotation",           icon: "/app-icons/opencode.svg"             },
-					];
-					const t = templates[incomingIdx.current % templates.length]!;
-					next = [{
-						id: newId,
-						title: t.title,
-						branch: t.branch,
-						icon: t.icon,
-						column: "working",
-						activity: "Writing implementation",
-						activityState: "running",
-						pr: "draft",
-						time: randomTime(),
-					}, ...next];
-				}
+			// Spawn a new working card if column is thin
+			const workingCount = next.filter((c) => c.column === "working" && !c.merging).length;
+			if (workingCount < 2 && next.filter((c) => !c.merging).length < 8) {
+				const newId = `spawned-${++simulation.current.incomingIdx}`;
+				const templates = [
+					{ title: "Throttle agent spawn rate under load",      branch: "backend/spawn-throttle",      icon: "/app-icons/coverage-claude-code.svg" },
+					{ title: "Add keyboard shortcut for session focus",    branch: "feat/session-focus-shortcut", icon: "/app-icons/coverage-codex.svg"       },
+					{ title: "Lazy-load session terminal on first open",   branch: "perf/lazy-terminal",          icon: "/app-icons/agents/cursor.svg"        },
+					{ title: "Fix memory leak in terminal resize handler", branch: "fix/terminal-resize-leak",    icon: "/app-icons/coverage-claude-code.svg" },
+					{ title: "Migrate auth tokens to short-lived JWTs",   branch: "auth/jwt-rotation",           icon: "/app-icons/opencode.svg"             },
+				];
+				const t = templates[simulation.current.incomingIdx % templates.length]!;
+				next = [{
+					id: newId,
+					title: t.title,
+					branch: t.branch,
+					icon: t.icon,
+					column: "working",
+					activity: "Writing implementation",
+					activityState: "running",
+					pr: "draft",
+					time: randomTime(),
+				}, ...next];
+			}
 
-				return next;
-			});
+			simulation.current.cards = next;
+			setCards(next);
 			scheduleNext();
 		};
 
 		scheduleNext();
-		return () => window.clearTimeout(timeoutId);
+		return () => {
+			window.clearTimeout(timeoutId);
+			window.clearTimeout(mergeTimeoutId);
+		};
 	}, []);
 
 	const boardColumns = COLUMN_ORDER.map((id) => ({

--- a/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.css
+++ b/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.css
@@ -1,0 +1,53 @@
+/* Resolve container units to lengths before atan2. WebKit can miscompute the
+ * ratio when unresolved container units are passed directly to the function. */
+@property --mockup-available-w {
+	syntax: "<length>";
+	inherits: false;
+	initial-value: 0px;
+}
+@property --mockup-available-h {
+	syntax: "<length>";
+	inherits: false;
+	initial-value: 0px;
+}
+/* An engine without @property leaves this undefined, so the window stays
+ * hidden until the JavaScript fallback measures it. */
+@property --mockup-css-visibility {
+	syntax: "visible | hidden";
+	inherits: false;
+	initial-value: visible;
+}
+
+/* The overlay gets a definite size from ProductDemo's aspect ratio / minimum
+ * height. Its inset reserves the margin without mixed-unit atan2 arithmetic.
+ * Do not put size containment on ProductDemo's auto-height frame itself. */
+.hero-mockup-viewport {
+	position: absolute;
+	inset: 4px;
+	container-type: size;
+}
+
+.hero-mockup-window {
+	left: 50%;
+	top: 50%;
+	width: var(--mockup-design-w);
+	height: var(--mockup-design-h);
+	transform: translate(-50%, -50%) scale(var(--mockup-scale, 1));
+	transform-origin: center;
+	visibility: hidden;
+}
+
+@supports (container-type: size) and (transform: scale(min(1, tan(atan2(100cqw, 1px)), tan(atan2(100cqh, 1px))))) {
+	.hero-mockup-window {
+		--mockup-available-w: 100cqw;
+		--mockup-available-h: 100cqh;
+		/* tan(atan2(available, design)) gives the unitless scale without
+		 * requiring newer CSS typed division. Keep the whole board fixed-size. */
+		--mockup-scale: min(
+			1,
+			tan(atan2(var(--mockup-available-w), var(--mockup-design-w))),
+			tan(atan2(var(--mockup-available-h), var(--mockup-design-h)))
+		);
+		visibility: var(--mockup-css-visibility, hidden);
+	}
+}

--- a/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
+++ b/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
@@ -3,6 +3,8 @@
 import { AnimatePresence, LayoutGroup, motion } from "motion/react";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 
+import "./AppMockup.css";
+
 export type { ActiveDemo } from "./types";
 
 type BoardColumnId = "working" | "action" | "pending" | "merge";
@@ -711,41 +713,7 @@ const incomingCardsByTrack: Record<TrackId, StaticPreviewCard[]> = {
 
 const BASE_WIDTH = 1140;
 const BASE_HEIGHT = 615;
-const WINDOW_ASPECT = BASE_WIDTH / BASE_HEIGHT;
-const WINDOW_MARGIN = 4;
-// Shell can shrink with the hero frame; inner board stays at BASE_* and CSS-scales.
-// Keep the shell aspect-locked so the scaled board fills both axes (no letterbox gaps).
-
-interface WindowState {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-}
-
-function sizeFromWidth(width: number): Pick<WindowState, "width" | "height"> {
-	return { width, height: width / WINDOW_ASPECT };
-}
-
-function createInitialWindowState(
-	containerWidth: number,
-	containerHeight: number,
-): WindowState {
-	const availableWidth = containerWidth - WINDOW_MARGIN * 2;
-	const availableHeight = containerHeight - WINDOW_MARGIN * 2;
-	const scale = Math.min(
-		1,
-		availableWidth / BASE_WIDTH,
-		availableHeight / BASE_HEIGHT,
-	);
-	const { width, height } = sizeFromWidth(BASE_WIDTH * scale);
-	return {
-		x: (containerWidth - width) / 2,
-		y: (containerHeight - height) / 2,
-		width,
-		height,
-	};
-}
+const CSS_SCALE_SUPPORT = "scale(min(1, tan(atan2(100cqw, 1px)), tan(atan2(100cqh, 1px))))";
 
 const mockupShellStyle = {
 	...previewTokenStyle,
@@ -753,55 +721,30 @@ const mockupShellStyle = {
 	"--mockup-design-h": `${BASE_HEIGHT}px`,
 	"--mockup-shell-radius": "20px",
 	"--mockup-inner-radius": "17px",
-	left: "50%",
-	top: "50%",
-	width: `min(calc(100% - ${WINDOW_MARGIN * 2}px), ${BASE_WIDTH}px)`,
-	maxHeight: `calc(100% - ${WINDOW_MARGIN * 2}px)`,
-	aspectRatio: `${BASE_WIDTH} / ${BASE_HEIGHT}`,
-	transform: "translate(-50%, -50%)",
 } as CSSProperties;
 
-function useFloatingWindow(
-	outerRef: React.RefObject<HTMLElement | null>,
-) {
-	const stateRef = useRef<WindowState | null>(null);
-
-	const applyState = useCallback(() => {
-		const outer = outerRef.current;
-		const state = stateRef.current;
-		if (!outer || !state) return;
-		const scale = state.width / BASE_WIDTH;
-		outer.style.left = `${state.x}px`;
-		outer.style.top = `${state.y}px`;
-		outer.style.width = `${state.width}px`;
-		outer.style.height = `${state.height}px`;
-		outer.style.setProperty("--mockup-shell-radius", `${20 * scale}px`);
-		outer.style.setProperty("--mockup-inner-radius", `${17 * scale}px`);
-		outer.style.transform = "none";
-	}, [outerRef]);
-
-	const updateContainer = useCallback(() => {
-		const outer = outerRef.current;
-		const parent = outer?.offsetParent as HTMLElement | null;
-		if (!parent) return;
-		const rect = parent.getBoundingClientRect();
-		stateRef.current = createInitialWindowState(rect.width, rect.height);
-		applyState();
-	}, [applyState, outerRef]);
-
+// CSS handles first paint. Only older engines need hidden-until-measured sizing.
+function useLegacyMockupScale(rootRef: React.RefObject<HTMLDivElement | null>) {
 	useLayoutEffect(() => {
-		updateContainer();
-		const outer = outerRef.current;
-		const parent = outer?.offsetParent as HTMLElement | null;
-		if (!parent) return;
-		const observer = new ResizeObserver(updateContainer);
-		observer.observe(parent);
-		window.addEventListener("resize", updateContainer);
-		return () => {
-			observer.disconnect();
-			window.removeEventListener("resize", updateContainer);
+		if (
+			"registerProperty" in CSS &&
+			CSS.supports("container-type", "size") &&
+			CSS.supports("transform", CSS_SCALE_SUPPORT)
+		) return;
+		const root = rootRef.current;
+		const frame = root?.parentElement;
+		if (!root || !frame) return;
+		const syncScale = () => {
+			const { width, height } = frame.getBoundingClientRect();
+			if (width <= 0 || height <= 0) return;
+			root.style.setProperty("--mockup-scale", String(Math.min(1, width / BASE_WIDTH, height / BASE_HEIGHT)));
+			root.style.visibility = "visible";
 		};
-	}, [updateContainer, outerRef]);
+		syncScale();
+		const observer = new ResizeObserver(syncScale);
+		observer.observe(frame);
+		return () => observer.disconnect();
+	}, [rootRef]);
 }
 
 function createInitialCards(trackId: TrackId): PreviewCard[] {
@@ -1913,35 +1856,8 @@ export function AppMockup() {
 		footer: 0,
 	});
 	const windowRef = useRef<HTMLDivElement>(null);
-	const contentRef = useRef<HTMLDivElement>(null);
-	useFloatingWindow(windowRef);
+	useLegacyMockupScale(windowRef);
 	useDecorativeSubtree(windowRef);
-
-	// Keep the board at the design size and scale the whole chrome to the shell.
-	// Shrinking the layout box itself reflows columns and clips Mergeable / Merge.
-	// Shell resize is aspect-locked, so width/BASE_WIDTH fills both axes with no gaps.
-	// Keep the SSR canvas hidden until this scale is applied to avoid a full-size mobile flash.
-	useLayoutEffect(() => {
-		const outer = windowRef.current;
-		const content = contentRef.current;
-		if (!outer || !content) return;
-
-		const syncScale = () => {
-			const width = outer.clientWidth;
-			if (width <= 0) return;
-			content.style.transform = `scale(${width / BASE_WIDTH})`;
-			content.style.visibility = "visible";
-		};
-
-		syncScale();
-		const observer = new ResizeObserver(syncScale);
-		observer.observe(outer);
-		window.addEventListener("resize", syncScale);
-		return () => {
-			observer.disconnect();
-			window.removeEventListener("resize", syncScale);
-		};
-	}, []);
 
 	const selectedTrack =
 		projectItems.find((item) => item.id === selectedTrackId) ?? projectItems[0];
@@ -2049,53 +1965,52 @@ export function AppMockup() {
 	});
 
 	return (
-		<div
-			ref={windowRef}
-			role="img"
-			aria-label="Preview of the Agent Orchestrator board: agent tasks move across Pending Work, Iterating, In Review, and Ready to merge."
-			className="absolute z-10 select-none overflow-hidden rounded-[var(--mockup-shell-radius)] border border-[var(--preview-border)] bg-[var(--preview-sidebar)] font-sans tracking-tight text-[var(--preview-foreground)] antialiased shadow-[0_30px_80px_-24px_rgba(0,0,0,0.75)] [&_.font-mono]:tracking-normal"
-			style={mockupShellStyle}
-		>
-			<style>{`
-				@keyframes ao-attention-pulse-frames {
-					0%, 100% { box-shadow: 0 0 0 0 rgba(251, 146, 60, 0.35); }
-					50% { box-shadow: 0 0 0 4px rgba(251, 146, 60, 0); }
-				}
-				.ao-attention-pulse {
-					animation: ao-attention-pulse-frames 1.2s ease-in-out infinite;
-				}
-				@media (prefers-reduced-motion: reduce) {
-					.ao-attention-pulse { animation: none; }
-				}
-			`}</style>
-			<div className="relative h-full w-full overflow-hidden">
-				<div
-					ref={contentRef}
-					className="invisible h-(--mockup-design-h) w-(--mockup-design-w) origin-top-left"
-				>
-					<div className="flex h-full min-h-0">
-						<Sidebar cards={cards} />
-						<div className="flex min-h-0 min-w-0 flex-1 flex-col p-[2px]">
-							<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[var(--mockup-inner-radius)] border border-[var(--preview-border-strong)] bg-[var(--preview-background)]">
-								<BoardChrome viewMode={viewMode} />
-								<>
-									<div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-										<LayoutGroup key={selectedTrack.id}>
-											<div className="grid min-h-0 flex-1 grid-cols-4 overflow-hidden">
-												{boardColumns.map((column) => (
-													<BoardColumn
-														key={column.id}
-														cards={column.cards}
-														color={COLUMN_COLORS[column.id]}
-														count={column.count}
-														title={column.title}
-													/>
-												))}
-											</div>
-										</LayoutGroup>
-									</div>
-									<ArchiveBar count={mergedCount} />
-								</>
+		<div className="hero-mockup-viewport">
+			<div
+				ref={windowRef}
+				role="img"
+				aria-label="Preview of the Agent Orchestrator board: agent tasks move across Pending Work, Iterating, In Review, and Ready to merge."
+				className="hero-mockup-window absolute z-10 select-none overflow-hidden rounded-[var(--mockup-shell-radius)] border border-[var(--preview-border)] bg-[var(--preview-sidebar)] font-sans tracking-tight text-[var(--preview-foreground)] antialiased shadow-[0_30px_80px_-24px_rgba(0,0,0,0.75)] [&_.font-mono]:tracking-normal"
+				style={mockupShellStyle}
+			>
+				<style>{`
+					@keyframes ao-attention-pulse-frames {
+						0%, 100% { box-shadow: 0 0 0 0 rgba(251, 146, 60, 0.35); }
+						50% { box-shadow: 0 0 0 4px rgba(251, 146, 60, 0); }
+					}
+					.ao-attention-pulse {
+						animation: ao-attention-pulse-frames 1.2s ease-in-out infinite;
+					}
+					@media (prefers-reduced-motion: reduce) {
+						.ao-attention-pulse { animation: none; }
+					}
+				`}</style>
+				<div className="relative h-full w-full overflow-hidden">
+					<div className="h-full w-full">
+						<div className="flex h-full min-h-0">
+							<Sidebar cards={cards} />
+							<div className="flex min-h-0 min-w-0 flex-1 flex-col p-[2px]">
+								<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[var(--mockup-inner-radius)] border border-[var(--preview-border-strong)] bg-[var(--preview-background)]">
+									<BoardChrome viewMode={viewMode} />
+									<>
+										<div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+											<LayoutGroup key={selectedTrack.id}>
+												<div className="grid min-h-0 flex-1 grid-cols-4 overflow-hidden">
+													{boardColumns.map((column) => (
+														<BoardColumn
+															key={column.id}
+															cards={column.cards}
+															color={COLUMN_COLORS[column.id]}
+															count={column.count}
+															title={column.title}
+														/>
+													))}
+												</div>
+											</LayoutGroup>
+										</div>
+										<ArchiveBar count={mergedCount} />
+									</>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/frontend/src/landing/src/app/layout.tsx
+++ b/frontend/src/landing/src/app/layout.tsx
@@ -107,11 +107,6 @@ export default function RootLayout({
         <OrganizationJsonLd />
         <SoftwareApplicationJsonLd />
         <WebsiteJsonLd />
-        <link rel="preload" as="image" href="/optimized/hero-background.webp" type="image/webp" />
-        <link rel="preload" as="image" href="/optimized/feature.webp" type="image/webp" />
-        <link rel="preload" as="image" href="/optimized/feature2.webp" type="image/webp" />
-        <link rel="preload" as="image" href="/optimized/feature3.webp" type="image/webp" />
-        <link rel="preload" as="image" href="/optimized/feature4.webp" type="image/webp" />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/frontend/src/landing/tsconfig.json
+++ b/frontend/src/landing/tsconfig.json
@@ -35,6 +35,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
+    "**/*.test.tsx",
     "node_modules"
   ]
 }


### PR DESCRIPTION
## What

Reduce unnecessary landing-page downloads and render the hero mockup at the correct mobile size before hydration.

## Why

The live homepage preloaded a tiny Cursor icon that transferred 1.17 MB compressed, plus 376 KB of below-the-fold backgrounds. Its hero board stayed invisible until two JavaScript measurement effects ran; simply revealing the server-rendered board would restore the mobile layout flash.

## How

- Reuse the lightweight Cursor logo already loaded by the hero. Let feature backgrounds load lazily and keep the hero background's component-owned preload.
- Fit the complete fixed-size hero window with CSS before first paint, without reflowing its columns. Registered length properties resolve container dimensions before scale arithmetic, avoiding WebKit's unresolved-unit behavior.
- Preserve a single hidden-until-measured fallback for older engines. Keep the existing design and animation behavior.
- Add an exported-page browser regression script covering JavaScript-disabled rendering at four widths, delayed hydration, resizing, height constraints, the size cap, and legacy fallback.

- Move FleetBoardDemo animation side effects out of React state updaters and clean up both timers, with Strict Mode and unmount regression coverage.

## Testing

- React Doctor changed-file scan against `origin/main`: no new issues.
- Node 24.20.0: landing `npm run build`, including TypeScript and Markdown export.
- Landing `node --test scripts/check-hero-layout.mjs`: 7 Chromium + 7 WebKit checks passed.
- `npm run shared:check`: passed.
- Frontend `npm run typecheck` and `npm run typecheck:e2e`: passed.
- Full frontend `npx vitest run --maxWorkers=4`: 287 suites passed; 3,961 tests passed, 6 skipped.
- Full renderer smoke suite: 57 passed (rerun with one worker after a resource-constrained parallel attempt).
- Export inspection: no oversized Cursor reference or feature-background preloads; all five feature images remain lazy; exactly one hero-background preload.
- Gitleaks 8.30.1 scan of this commit: no leaks. CI uses its separately pinned scanner.
- User reviewed and approved the production export on mobile through Tailscale. Chromium/WebKit screenshots also checked locally.

Local browser/desktop checks ran on macOS; the Linux CI runner remains the authority for its environment. Byte measurements describe downloaded assets, not a claimed LCP improvement.

## Checklist

- [x] Branched from `main`
- [x] One focused landing-page performance change
- [x] Regression coverage for user-visible behavior
- [x] Relevant remote CI checks pass
