### PR TITLE
fix: refresh mobile status after disable errors

### DIFF
--- a/frontend/src/renderer/components/ConnectMobileModal.test.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.test.tsx
@@ -129,6 +129,48 @@ test("can turn off the generated mobile connection", async () => {
 	expect(apiClient.POST).toHaveBeenCalledWith("/api/v1/mobile/disable");
 });
 
+test.each([
+	{ outcome: "success", serverEnabled: false, failed: false },
+	{ outcome: "error after shutdown", serverEnabled: false, failed: true },
+	{ outcome: "error while still running", serverEnabled: true, failed: true },
+])("refreshes mobile status after disable $outcome", async ({ serverEnabled, failed }) => {
+	let statusReads = 0;
+	const get = vi.spyOn(apiClient, "GET").mockImplementation(async (path) => {
+		if (path === "/api/v1/mobile/devices") {
+			return { data: { devices: [] }, error: undefined };
+		}
+		statusReads++;
+		// Each response is a snapshot. Updating the fake server must not mutate
+		// the cached response and conceal a missing status refetch.
+		return { data: { ...mobileStatus }, error: undefined };
+	});
+	vi.mocked(apiClient.POST).mockImplementationOnce(async () => {
+		mobileStatus.enabled = serverEnabled;
+		return failed
+			? { data: undefined, error: { message: "shutdown failed" } }
+			: { data: {}, error: undefined };
+	});
+
+	try {
+		renderMobileSettings();
+		await userEvent.click(await screen.findByRole("button", { name: "Turn off mobile connection" }));
+		await waitFor(() => expect(statusReads).toBeGreaterThan(1));
+		await waitFor(() => {
+			const disableButton = screen.queryByRole("button", { name: "Turn off mobile connection" });
+			if (serverEnabled) {
+				expect(disableButton).toBeVisible();
+				expect(qrPayload()).not.toBeNull();
+			} else {
+				expect(disableButton).not.toBeInTheDocument();
+				expect(screen.getByRole("button", { name: "Generate" })).toBeVisible();
+			}
+		});
+		if (failed) expect(screen.getByText("failed")).toBeVisible();
+	} finally {
+		get.mockRestore();
+	}
+});
+
 // SKIPPED: drives the connection picker, which is commented out in
 // ConnectMobileContent. Un-skip with it — the behaviour is unchanged, only
 // the way in is gone. TLS coverage does NOT live here any more: it keys off

--- a/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileContent.tsx
@@ -304,7 +304,9 @@ export function ConnectMobileContent({ active }: { active: boolean }) {
 			const { error } = await apiClient.POST("/api/v1/mobile/disable");
 			if (error) throw new Error(apiErrorMessage(error));
 		},
-		onSuccess: invalidate,
+		// Shutdown can finish before returning an error. Refresh the actual
+		// server state while retaining the mutation error for the user.
+		onSettled: invalidate,
 		onError: () => setOptimisticEnabled(null),
 	});
 


### PR DESCRIPTION
## What

Refresh the Connect Mobile panel after Disable finishes, including error responses, so it displays the current server state.

## Why

Shutdown can complete before returning an error. The panel previously restored its cached enabled state without refetching, leaving stale pairing information visible. This also occurs on main; it is an independent follow-up to #5087.

## How

Invalidate mobile status in the Disable mutation's `onSettled` callback. Preserve the existing error message and use the refreshed state instead of assuming an error means the listener stayed enabled.

## Testing

- Added UI regressions for successful disable, an error after shutdown, and an error while the listener remains running. Both error regressions failed on main.
- Mobile panel suite: 31 passed, 6 existing skips.
- Full frontend suite: 3,962 passed, 6 existing skips; frontend and E2E typechecks passed.
- Pinned Playwright container: all 57 renderer smoke tests passed.
- Cloud client/product UI generation, typechecks, tests, and package dry runs passed; pinned browser runtime enabled for the frontend suite.
- Pinned gitleaks scan passed for the exact commit.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
