### PR TITLE
fix(terminal): let xterm initialization finish before disposal

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -10,7 +10,9 @@ import { XtermTerminal } from "./XtermTerminal";
 
 const state = vi.hoisted(() => ({
 	fit: vi.fn(),
+	lifecycle: [] as string[],
 	linkHandler: null as null | ((event: MouseEvent, uri: string) => void),
+	queueViewportSyncOnOpen: false,
 	searchAddon: null as null | {
 		clearDecorations: ReturnType<typeof vi.fn>;
 		findNext: ReturnType<typeof vi.fn>;
@@ -109,6 +111,9 @@ vi.mock("@xterm/xterm", () => ({
 		loadAddon() {}
 		open(host: HTMLElement) {
 			host.appendChild(document.createElement("textarea"));
+			if (state.queueViewportSyncOnOpen) {
+				window.setTimeout(() => state.lifecycle.push("viewport-sync"), 0);
+			}
 		}
 		write(data: Uint8Array, done?: () => void) {
 			this.writeBuffer += new TextDecoder().decode(data);
@@ -119,7 +124,9 @@ vi.mock("@xterm/xterm", () => ({
 			done?.();
 		}
 		writeln() {}
-		dispose = vi.fn();
+		dispose = vi.fn(() => {
+			state.lifecycle.push("dispose");
+		});
 		onData(listener: (data: string) => void) {
 			this.dataListeners.add(listener);
 			return { dispose: () => this.dataListeners.delete(listener) };
@@ -221,8 +228,10 @@ function setNavigatorPlatform(platform: string) {
 describe("XtermTerminal", () => {
 	beforeEach(() => {
 		state.fit.mockReset();
+		state.lifecycle.length = 0;
 		state.lastTerminal = null;
 		state.linkHandler = null;
+		state.queueViewportSyncOnOpen = false;
 		state.searchAddon = null;
 		setNavigatorPlatform("Linux x86_64");
 		window.ao!.clipboard.writeText = vi.fn().mockResolvedValue(undefined);
@@ -291,19 +300,23 @@ describe("XtermTerminal", () => {
 		}
 	});
 
-	it("defers disposal behind xterm's pending viewport callback", () => {
+	it.each([true, false])("lets xterm drain viewport initialization before disposal (DEV=%s)", (development) => {
+		vi.stubEnv("DEV", development);
 		vi.useFakeTimers();
+		state.queueViewportSyncOnOpen = true;
 		try {
-			const { unmount } = render(<XtermTerminal theme="dark" />);
+			const view = render(<XtermTerminal theme="dark" />);
 			const terminal = state.lastTerminal!;
+			view.unmount();
 
-			unmount();
 			expect(terminal.dispose).not.toHaveBeenCalled();
-
+			expect(state.lifecycle).toEqual([]);
 			act(() => vi.runOnlyPendingTimers());
+			expect(state.lifecycle).toEqual(["viewport-sync", "dispose"]);
 			expect(terminal.dispose).toHaveBeenCalledOnce();
 		} finally {
 			vi.useRealTimers();
+			vi.unstubAllEnvs();
 		}
 	});
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -1331,23 +1331,20 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			notifyCursorSchemeRef.current = () => {};
 			announcedCursorSchemeRef.current = null;
 			userInputListeners.clear();
-			const disposeTerminal = () => {
+			// xterm's Viewport queues an untracked zero-delay scroll-area sync during
+			// open(). React StrictMode immediately runs this cleanup once after mount;
+			// disposing the renderer before that queued sync runs makes xterm read the
+			// now-missing renderer dimensions. Queue disposal behind xterm's task so
+			// the terminal remains internally valid until its own initialization work
+			// has drained. All AO listeners and attachment state are already detached.
+			window.setTimeout(() => {
 				try {
 					term.dispose();
 				} catch {
 					// Some renderer addons can throw during dispose in certain GPU
 					// environments; the terminal is being torn down regardless.
 				}
-			};
-			if (import.meta.env.DEV) {
-				// xterm's Viewport constructor queues an untracked zero-delay
-				// syncScrollArea(). React StrictMode immediately runs this cleanup after
-				// its development probe mount; queue disposal behind that callback so it
-				// cannot read the already-cleared renderer dimensions.
-				window.setTimeout(disposeTerminal, 0);
-			} else {
-				disposeTerminal();
-			}
+			}, 0);
 		};
 	}, []);
 


### PR DESCRIPTION
Code changes: +8 -11  
Tests: +18 -5  
Others: +0 -0  

### Re-review — 11 September 2026

Implementation unchanged at `fabbcd6ada7f68e244a07b423f6401d6608e43b2`. All local validation and current-head CI checks passed. Independent re-review is complete. [Native edit recovery evidence](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Local test results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). Native inline-edit submission, controller stop/resume and same-ID replay succeeded with one stored replacement message. The linked results record validation for those reviewed heads; earlier dated records below retain their original heads.

### Conflict resolution — 10 September 2026

Rebased onto main `8343bcc089982e202f0fbc37ff43aa09de3110d4` and restacked in the existing dependency order. Current head: `fabbcd6ada7f68e244a07b423f6401d6608e43b2`. GitHub reports this PR mergeable. The agreed feature scope and earlier correctness fixes are preserved.

The strengthened test fails against current main only with `DEV=false`; all 99 terminal tests pass on this head, including both development and production disposal ordering.

Fresh validation on this head: complete frontend suite **4,120 passed, 6 skipped**; all **59 renderer smoke tests passed**; frontend and E2E typechecks passed. The cumulative Go race suite, build, vet, pinned linter, shared package checks and native macOS helper checks passed. All **18 latest CI workflows / 48 jobs passed** across the six PRs.

[Conflict resolution diff](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Local test results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). Earlier validation records and screenshots/recordings below retain their recorded pre-rebase commits.

xterm queues viewport initialization during `open()`. Disposing before that task runs can leave it reading cleared renderer dimensions. Current main already defers disposal in development builds; this PR applies the same ordering in production and strengthens the regression test to assert viewport initialization happens before disposal in both modes. AO listeners still detach synchronously.

This is the two-file prerequisite extracted from #4463. The draft-persistence stack will build on it; no draft behavior or backend changes are included here.

Direct before/after reproduction against parent `09effe55` and fixed head `40816926`: three Chat → Terminal → Chat cycles produced **3 uncaught errors before and 0 after**. Both versions returned to Chat with the same visible UI; no visible crash or layout difference was reproduced. This is development-mode/StrictMode evidence using the real renderer and real xterm with a simulated daemon/preload/PTY, unmodified timers, and no injected failures.

[Direct before and after: identical Chat screen, three xterm errors before and zero after](https://github.com/Untrivial-ai/agent-orchestrator/pull/5105#issuecomment-5638389002)

[Before recording](https://github.com/Untrivial-ai/agent-orchestrator/pull/5105#issuecomment-5638389002) · [After recording](https://github.com/Untrivial-ai/agent-orchestrator/pull/5105#issuecomment-5638389002) · [Raw before errors](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Raw after errors](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Reproduction test](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549)

Historical validation at `40816926`: Frontend and gitleaks passed. The recordings above predate main’s development-only disposal fix; current-main regression coverage is described below.

Evidence: [terminal session-switch recording](https://github.com/Untrivial-ai/agent-orchestrator/pull/5105#issuecomment-5638389002). The recording uses production renderer code with a fake daemon/preload/PTY. The screenshot below is separate cumulative-stack verification in real Electron with the real daemon and native shell PTY.

[Native Electron terminal with real PTY input](https://github.com/Untrivial-ai/agent-orchestrator/pull/5105#issuecomment-5638389002)

Stack order:

- #5105 — terminal disposal prerequisite
- #5106 — persist composer text across lifecycle boundaries
- #5107 — restore staged draft attachments after restart
- #5109 — persist queued edits with atomic delivery receipts
- #5110 — recover inline edits with durable branch receipts
- #5111 — reconcile steer delivery without repeating provider actions

[Original validation CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549).


### Correctness re-review — 8 September 2026

Reviewed again against current main: no additional correctness change was needed. This remains the terminal-disposal prerequisite.

Both independent final reviews (behavior and implementation standards) found no remaining actionable correctness defects at the corrected stack head. The agreed feature scope is preserved.

[Before/after captures and regression evidence](https://github.com/Untrivial-ai/agent-orchestrator/pull/5105#issuecomment-5638389002). These new recordings use the production renderer with deterministic daemon/preload/PTY fixtures.


[Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). The complete cumulative Go race suite, build, vet, CLI E2E and pinned linter pass; the latest CI jobs cover the Linux container and native Windows gaps.

GitHub still requires an approving review before this PR can merge into protected main.
