### PR TITLE
fix(chat): restore staged draft attachments after restart

### DIFF
--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -6,6 +6,8 @@ import userEvent from "@testing-library/user-event";
 import { Activity, Profiler } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ChatComposer } from "./ChatComposer";
+import { attachmentURL } from "./messageAttachments";
+import { getApiBaseUrl } from "../../lib/api-client";
 import { TooltipProvider } from "../ui/tooltip";
 import type { ChatSkill } from "../../types/conversation";
 import {
@@ -1931,4 +1933,24 @@ it("does not dispatch a restored image after its session incarnation was replace
 		fetch.mockRestore();
 		reader.mockRestore();
 	}
+});
+
+
+it("restores an image thumbnail from its durable path after the composer remounts", async () => {
+	const sessionId = "composer-restored-thumbnail";
+	const path = ".ao/attachments/restored-thumbnail.png";
+	const props = { onSend: vi.fn(), draftSessionId: sessionId,
+		onStageAttachments: vi.fn().mockResolvedValue([path]) };
+	const view = render(<ChatComposer {...props} />);
+	fireEvent.paste(screen.getByLabelText("Message the agent"), { clipboardData: clipboardData([png()]) });
+	await screen.findByLabelText("Remove shot.png");
+	expect(screen.getByRole("list", { name: "Attached files" }).querySelector("img"))
+		.toHaveAttribute("src", expect.stringContaining("data:image/png;base64,"));
+	view.unmount();
+	// A new renderer only has persisted descriptors, never cached image bytes.
+	purgeFileAttachmentsForSession(sessionId);
+	render(<ChatComposer {...props} />);
+	expect(screen.getByRole("list", { name: "Attached files" }).querySelector("img"))
+		.toHaveAttribute("src", attachmentURL(getApiBaseUrl(), sessionId, path));
+	expect(props.onStageAttachments).toHaveBeenCalledOnce();
 });

--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -1326,6 +1326,21 @@ describe("attachments", () => {
 		]);
 	});
 
+	// A message claiming an attachment the agent cannot open is worse than a refusal.
+	it("does not accept a chip when durable staging fails, and says so", async () => {
+		const stage = vi.fn().mockRejectedValue(new Error("disk full"));
+		const { onSend, field } = renderComposer({ onStageAttachments: stage });
+
+		fireEvent.paste(field, { clipboardData: clipboardData([png()]) });
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"Files couldn’t be saved. Nothing was attached.",
+		);
+		expect(stage).toHaveBeenCalledTimes(1);
+		expect(onSend).not.toHaveBeenCalled();
+		expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+		expect(field.textContent).toBe("");
+	});
+
 	it("keeps attachments after a failed send and reuses their staged paths on retry", async () => {
 		const stage = vi.fn().mockResolvedValue([".ao/attachments/attachment-retry.png"]);
 		const onSend = vi.fn().mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce(undefined);
@@ -1464,6 +1479,53 @@ describe("attachments", () => {
 			fireEvent.paste(field, { clipboardData: clipboardData([png("safe-attachment.png")]) });
 			await screen.findByLabelText("Remove safe-attachment.png");
 			expect(getChatDraftBoundary(sessionId)).toBe("persistence-failed");
+		} finally {
+			view.unmount();
+			localStorage.mockRestore();
+		}
+	});
+
+	it("reports failed text persistence and pending attachment staging together", async () => {
+		const sessionId = "composer-mixed-storage-failure";
+		const durableStorage = window.localStorage;
+		let failTextWrite = true;
+		let finishStaging!: (paths: string[]) => void;
+		const storage = {
+			getItem: durableStorage.getItem.bind(durableStorage),
+			removeItem: durableStorage.removeItem.bind(durableStorage),
+			setItem: (key: string, value: string) => {
+				if (failTextWrite && key.includes(encodeURIComponent(sessionId))) {
+					failTextWrite = false;
+					throw new DOMException("full", "QuotaExceededError");
+				}
+				durableStorage.setItem(key, value);
+			},
+		} as Storage;
+		const localStorage = vi.spyOn(window, "localStorage", "get").mockReturnValue(storage);
+		const view = render(
+			<ChatComposer
+				onSend={vi.fn()}
+				draftSessionId={sessionId}
+				onStageAttachments={() =>
+					new Promise<string[]>((resolve) => {
+						finishStaging = resolve;
+					})
+				}
+			/>,
+		);
+		try {
+			const field = screen.getByLabelText("Message the agent");
+			await typeInComposer(field, "unsafe text");
+			await waitFor(() => expect(getChatDraftBoundary(sessionId)).toBe("persistence-failed"));
+
+			fireEvent.paste(field, { clipboardData: clipboardData([png("pending.png")]) });
+			await waitFor(() => expect(finishStaging).toBeTypeOf("function"));
+			expect(getChatDraftBoundaries(sessionId)).toEqual([
+				"persistence-failed",
+				"pending-attachments",
+			]);
+
+			await act(async () => finishStaging([".ao/attachments/pending.png"]));
 		} finally {
 			view.unmount();
 			localStorage.mockRestore();
@@ -1757,6 +1819,50 @@ it("locks an uncertain steer after restart until the user explicitly abandons re
 	await act(async () => { await Promise.resolve(); });
 	expect(onSteer).not.toHaveBeenCalled();
 	expect(onSend).not.toHaveBeenCalled();
+});
+
+it("reserves the composer before pending staging yields to a replacement surface", async () => {
+	const sessionId = "composer-stage-reservation";
+	const pending = deferred<string[]>();
+	const stage = vi.fn(() => pending.promise);
+	const send = vi.fn().mockResolvedValue(undefined);
+	let view = render(<ChatComposer onSend={send} onStageAttachments={stage} draftSessionId={sessionId} />);
+	let field = screen.getByLabelText("Message the agent");
+	await typeInComposer(field, "original request");
+	fireEvent.paste(field, { clipboardData: clipboardData([png("pending.png")]) });
+	await waitFor(() => expect(stage).toHaveBeenCalledOnce());
+	fireEvent.keyDown(field, { key: "Enter" });
+	view.unmount();
+	view = render(<ChatComposer onSend={send} onStageAttachments={stage} draftSessionId={sessionId} />);
+	field = screen.getByLabelText("Message the agent");
+	expect(field).toHaveAttribute("contenteditable", "false");
+	expect(send).not.toHaveBeenCalled();
+	await act(async () => { pending.resolve([".ao/attachments/pending.png"]); });
+	await waitFor(() => expect(send).toHaveBeenCalledOnce());
+	await waitFor(() => expect(field).toHaveTextContent(/^$/));
+	expect(readChatSessionDraft(sessionId).composer.text).toBe("");
+	view.unmount();
+});
+
+it("does not let Enter omit an image still staging on the previous surface", async () => {
+	const sessionId = "composer-shared-pending-image";
+	const pending = deferred<string[]>();
+	const stage = vi.fn(() => pending.promise);
+	const send = vi.fn().mockResolvedValue(undefined);
+	let view = render(<ChatComposer onSend={send} onStageAttachments={stage} draftSessionId={sessionId} />);
+	await typeInComposer(screen.getByLabelText("Message the agent"), "inspect the image");
+	fireEvent.paste(screen.getByLabelText("Message the agent"), { clipboardData: clipboardData([png("pending.png")]) });
+	await waitFor(() => expect(stage).toHaveBeenCalledOnce());
+	view.unmount();
+	view = render(<ChatComposer onSend={send} onStageAttachments={stage} draftSessionId={sessionId} />);
+	fireEvent.keyDown(screen.getByLabelText("Message the agent"), { key: "Enter" });
+	await act(async () => { await Promise.resolve(); });
+	expect(send).not.toHaveBeenCalled();
+	await act(async () => { pending.resolve([".ao/attachments/pending.png"]); });
+	await screen.findByLabelText("Remove pending.png");
+	await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+	await waitFor(() => expect(send).toHaveBeenCalledWith(expect.stringContaining(".ao/attachments/pending.png"), undefined, expect.any(String)));
+	view.unmount();
 });
 
 it("keeps staged paths authoritative across a remount until acceptance clears the exact draft", async () => {

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -359,10 +359,9 @@ export const ChatComposer = memo(function ChatComposer({
 	);
 	const persistAttachments = useCallback(
 		(attachments: FileAttachment[]) => {
-			const descriptors = attachments.map((attachment) => ({
-				id: attachment.id, path: attachment.stagedPath ?? "", name: attachment.name,
-				mimeType: attachment.mimeType, bytes: attachment.bytes,
-			}));
+			const descriptors = attachments.flatMap((attachment) => attachment.stagedPath
+				? [{ id: attachment.id, path: attachment.stagedPath, name: attachment.name, mimeType: attachment.mimeType, bytes: attachment.bytes }]
+				: []);
 			if (!draftScope) {
 					return;
 			}
@@ -375,6 +374,24 @@ export const ChatComposer = memo(function ChatComposer({
 			);
 		},
 		[draftScope],
+	);
+	const prepareAttachments = useCallback(
+		async (attachments: FileAttachment[]): Promise<FileAttachment[]> => {
+			if (!onStageAttachments) throw new Error("Attachment staging is unavailable");
+			const paths = await onStageAttachments(
+				attachments.flatMap(({ mimeType, data }) =>
+					data ? [{ mimeType, data }] : [],
+				),
+			);
+			if (paths.length !== attachments.length) {
+				throw new Error("Attachment staging returned an incomplete result");
+			}
+			return attachments.map((attachment, index) => ({
+				...attachment,
+				stagedPath: paths[index],
+			}));
+		},
+		[onStageAttachments],
 	);
 	useEffect(() => {
 		if (restoredSessionId.current === draftScopeKey) return;
@@ -393,6 +410,7 @@ export const ChatComposer = memo(function ChatComposer({
 	const fileAttachments = useFileAttachments({
 		initialAttachments: restoredAttachments,
 		initialKey: attachmentScopeKey,
+		prepareAttachments: onStageAttachments ? prepareAttachments : undefined,
 		onAttachmentsChange: persistAttachments,
 	});
 	const canAttach = Boolean(onStageAttachments);
@@ -976,8 +994,8 @@ export const ChatComposer = memo(function ChatComposer({
 		const attachmentPayloads = await fileAttachments.toSettledPayload();
 		// A replacement hook can still have staging work owned by the old surface.
 		if (fileAttachments.hasPendingReads()) return;
-		let settledAttachments = fileAttachments.getAttachments();
-		let settledPaths = settledAttachments.flatMap((attachment) =>
+		const settledAttachments = fileAttachments.getAttachments();
+		const settledPaths = settledAttachments.flatMap((attachment) =>
 			attachment.stagedPath ? [attachment.stagedPath] : []);
 		const hasAttachments = settledAttachments.length > 0 || visibleRetainedAttachments.length > 0;
 		const canSubmitNow =
@@ -994,29 +1012,9 @@ export const ChatComposer = memo(function ChatComposer({
 			}
 			return;
 		}
-		if (settledPaths.length !== settledAttachments.length) {
-			// Text drafts also retain a filename reminder. Bytes remain local until
-			// submission; a reminder restored after restart must never send text alone.
-			const unstaged = settledAttachments.filter((attachment) => !attachment.stagedPath);
-			if (!onStageAttachments || unstaged.some((attachment) => !attachment.data)) {
-				setSendError("chat.draft.filesUnavailable");
-				return;
-			}
-			try {
-				const paths = await onStageAttachments(unstaged.map((attachment) => ({
-					mimeType: attachment.mimeType, data: attachment.data!,
-				})));
-				if (paths.length !== unstaged.length) throw new Error("Incomplete attachment staging");
-				// Publish paths before journaling so a replacement surface cannot restore
-				// the old filename-only reminder over the delivery's exact revision.
-				settledAttachments = fileAttachments.recordStagedPaths(new Map(
-					unstaged.map((attachment, index) => [attachment.id, paths[index]]),
-				));
-				settledPaths = settledAttachments.map((attachment) => attachment.stagedPath!);
-			} catch {
-				setSendError("chat.draft.sendAttachmentsFailed");
-				return;
-			}
+		if (hasAttachments && settledPaths.length !== settledAttachments.length) {
+			setSendError("chat.draft.filesUnavailable");
+			return;
 		}
 		const shouldSteer = Boolean(forceSteer && !savingQueuedEdit);
 		const message = withAttachmentReferences(body, [

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -1417,13 +1417,17 @@ export const ChatComposer = memo(function ChatComposer({
 				) : null}
 				{staged ? (
 					<ul className="flex flex-wrap gap-1.5" aria-label="Attached files">
-						{[...visibleRetainedAttachments, ...fileAttachments.attachments].map((file) => (
+						{[...visibleRetainedAttachments, ...fileAttachments.attachments].map((file) => {
+							const path = "stagedPath" in file ? file.stagedPath : "path" in file ? file.path : undefined;
+							const preview = file.dataUrl ?? (path && IMAGE_ATTACHMENT_PATH.test(path)
+								? attachmentURL(getApiBaseUrl(), boundarySessionId ?? "", path) : undefined);
+							return (
 							<li
 								key={file.id}
 								className="flex items-center gap-1.5 rounded border border-border bg-background py-0.5 pl-0.5 pr-1"
 							>
-								{file.dataUrl || ("path" in file && file.path && IMAGE_ATTACHMENT_PATH.test(file.path)) ? (
-									<img src={file.dataUrl ?? ("path" in file && file.path ? attachmentURL(getApiBaseUrl(), boundarySessionId ?? "", file.path) : undefined)} alt="" className="size-6 rounded-sm object-cover" />
+								{preview ? (
+									<img src={preview} alt="" className="size-6 rounded-sm object-cover" />
 								) : (
 									<div className="flex size-6 items-center justify-center rounded-sm bg-surface">
 										<File aria-hidden="true" className="size-3.5 text-muted-foreground" />
@@ -1451,7 +1455,8 @@ export const ChatComposer = memo(function ChatComposer({
 									<X aria-hidden="true" className="size-3" />
 								</button>
 							</li>
-						))}
+							);
+						})}
 					</ul>
 				) : null}
 

--- a/frontend/src/renderer/hooks/useFileAttachments.ts
+++ b/frontend/src/renderer/hooks/useFileAttachments.ts
@@ -80,12 +80,12 @@ export type PendingFileAttachmentCapture = {
 };
 
 function sharedAttachmentDescriptors(attachments: FileAttachment[]): FileAttachment[] {
-	return attachments.map(({ id, mimeType, bytes, name, stagedPath, data, dataUrl }) => ({
+	return attachments.map(({ id, mimeType, bytes, name, stagedPath }) => ({
 		id,
 		mimeType,
 		bytes,
 		name,
-		...(stagedPath ? { stagedPath } : { data, dataUrl }),
+		...(stagedPath ? { stagedPath } : {}),
 	}));
 }
 
@@ -492,21 +492,6 @@ export function useFileAttachments(options: FileAttachmentOptions = {}) {
 		setError(null);
 	}, [initialKey, onAttachmentsChange]);
 
-	const recordStagedPaths = useCallback((paths: ReadonlyMap<string, string>): FileAttachment[] => {
-		const next = attachmentsRef.current.map((attachment) => {
-			const path = paths.get(attachment.id);
-			return path ? { ...attachment, stagedPath: path } : attachment;
-		});
-		attachmentsRef.current = next;
-		setAttachments(next);
-		onAttachmentsChange?.(next);
-		if (initialKey) {
-			notifySharedAttachmentEntry(initialKey,
-				{ attachments: sharedAttachmentDescriptors(next) }, listenerTokenRef.current);
-		}
-		return next;
-	}, [initialKey, onAttachmentsChange]);
-
 	const clear = useCallback(() => {
 		generationRef.current++;
 		pendingReadsRef.current.clear();
@@ -575,7 +560,6 @@ export function useFileAttachments(options: FileAttachmentOptions = {}) {
 		preparing,
 		addFiles,
 		remove,
-		recordStagedPaths,
 		clear,
 		reconcilePersistedAttachments,
 		getAttachments: () => attachmentsRef.current,


### PR DESCRIPTION
Code changes: +38 -51  
Tests: +128 -0  
Others: +0 -0  

### Merge preparation — 11 September 2026

Merge candidate: `5a8012827f1db5550b7d1817a85e97611013eb1c`; base: `main`. Rebased onto main after #5106 merged; both attachment commits are patch-equivalent to the reviewed versions. Both local typechecks, the full Vitest suite, all 59 renderer smoke tests, and all four current-head CI jobs passed. The dated review and evidence below apply to the heads they record.

### Re-review — 11 September 2026

Implementation unchanged at `92bf1117f67008d10d3de1779bcf2643a7420ebf`. All local validation and current-head CI checks passed. Independent re-review is complete. [Native edit recovery evidence](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Local test results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). Native inline-edit submission, controller stop/resume and same-ID replay succeeded with one stored replacement message. The linked results record validation for those reviewed heads; earlier dated records below retain their original heads.

### Conflict resolution — 10 September 2026

Rebased onto main `8343bcc089982e202f0fbc37ff43aa09de3110d4` and restacked in the existing dependency order. Current head: `92bf1117f67008d10d3de1779bcf2643a7420ebf`. GitHub reports this PR mergeable. The agreed feature scope and earlier correctness fixes are preserved.

Fresh validation on this head: complete frontend suite **4,206 passed, 6 skipped**; all **59 renderer smoke tests passed**; frontend and E2E typechecks passed. The cumulative Go race suite, build, vet, pinned linter, shared package checks and native macOS helper checks passed. All **18 latest CI workflows / 48 jobs passed** across the six PRs.

[Conflict resolution diff](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Local test results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). Earlier validation records and screenshots/recordings below retain their recorded pre-rebase commits.

An unsent image disappears after a renderer restart because its bytes only live in the component. Stage files through the existing daemon attachment endpoint when they are added; persist descriptors and restore native image bytes when needed.

This builds on the text draft foundation. Storage keeps file descriptors, not base64 data. Pending reads/staging remain owned across remounts, and send waits for shared file work so Enter cannot omit an image. Failed staging keeps the draft recoverable.

Part 2/5 split from #4463, stacked on `codex/chat-draft-text`. The two-file xterm prerequisite is #5105. Original #4463 stays draft. Review this PR against its configured base; merge in dependency order.

Validation at `7ff1ca3a5`: full frontend suite 4,089 passed, 6 skipped; all 58 renderer smoke tests passed; frontend and E2E typechecks passed. Shared package tests/typechecks and generated API drift checks pass. Latest current-head workflows all passed.

Evidence: [recording](https://github.com/Untrivial-ai/agent-orchestrator/pull/5107#issuecomment-5638403728), [recorded renderer requests](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). This recording runs production renderer code with deterministic daemon/preload/PTY fixtures. Local validation is macOS with Node 24; Linux container, native Windows and signed packaged-app gates must be verified in CI.

[Restored attachments draft in the renderer contract check](https://github.com/Untrivial-ai/agent-orchestrator/pull/5107#issuecomment-5638403728)

Before this correctness follow-up, the cumulative stack was also exercised in real Electron with the real daemon, native preload and a live Codex scratch session:

[Native Electron verification](https://github.com/Untrivial-ai/agent-orchestrator/pull/5107#issuecomment-5638403728)

Stack order:

- #5105 — terminal disposal prerequisite
- #5106 — persist composer text across lifecycle boundaries
- #5107 — restore staged draft attachments after restart
- #5109 — persist queued edits with atomic delivery receipts
- #5110 — recover inline edits with durable branch receipts
- #5111 — reconcile steer delivery without repeating provider actions

[Original validation CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549).


### Correctness re-review — 8 September 2026

Restored image chips now load thumbnails from their durable staged paths, including after renderer restart.

Both independent final reviews (behavior and implementation standards) found no remaining actionable correctness defects at the corrected stack head. The agreed feature scope is preserved.

[Before/after captures and regression evidence](https://github.com/Untrivial-ai/agent-orchestrator/pull/5107#issuecomment-5638403728). These new recordings use the production renderer with deterministic daemon/preload/PTY fixtures.

| Reloaded image before | After the fix |
| --- | --- |
| [Generic file icon](https://github.com/Untrivial-ai/agent-orchestrator/pull/5107#issuecomment-5638403728) | [Restored thumbnail](https://github.com/Untrivial-ai/agent-orchestrator/pull/5107#issuecomment-5638403728) |


[Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). The complete cumulative Go race suite, build, vet, CLI E2E and pinned linter pass; the latest CI jobs cover the Linux container and native Windows gaps.
