### PR TITLE
fix(chat): recover inline edits with durable branch receipts

### DIFF
--- a/backend/internal/adapters/chatdriver/codexappserver/conversation.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/conversation.go
@@ -80,6 +80,7 @@ type conversation struct {
 
 	pumpDone  chan struct{}
 	closeOnce sync.Once
+	closeErr  error
 }
 
 var _ ports.ChatConversation = (*conversation)(nil)
@@ -829,10 +830,10 @@ func (c *conversation) Close() error {
 			c.failPendingApprovals()
 		}
 		if c.proc.stop != nil {
-			_ = c.proc.stop()
+			c.closeErr = c.proc.stop()
 		}
 	})
-	return nil
+	return c.closeErr
 }
 
 // Terminate destroys the provider host. Close only detaches and is used by
@@ -841,12 +842,12 @@ func (c *conversation) Terminate() error {
 	c.closeOnce.Do(func() {
 		c.failPendingApprovals()
 		if c.proc.terminate != nil {
-			_ = c.proc.terminate()
+			c.closeErr = c.proc.terminate()
 		} else if c.proc.stop != nil {
-			_ = c.proc.stop()
+			c.closeErr = c.proc.stop()
 		}
 	})
-	return nil
+	return c.closeErr
 }
 
 // approvalPayload is the subset of an approval request AO renders.

--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -480,8 +480,9 @@ func bindConnToContext(ctx context.Context, conn net.Conn) func(error) error {
 	}
 }
 
-// Shutdown terminates current session ownership after explicit destruction or
-// orphan reap. Missing/dead hosts are harmless; unknown live owners fail closed.
+// Shutdown terminates current session ownership and waits for it to end.
+// Missing/dead hosts are harmless; unknown live owners fail closed.
+// The protocol acknowledgement only confirms that shutdown was requested.
 func Shutdown(ctx context.Context, dataDir, sessionID string) error {
 	d, err := readDescriptor(dataDir, sessionID)
 	if errors.Is(err, os.ErrNotExist) {
@@ -517,7 +518,31 @@ func Shutdown(ctx context.Context, dataDir, sessionID string) error {
 	if !response.OK {
 		return errors.New(response.Error)
 	}
-	return nil
+	waitCtx, stop := context.WithTimeout(ctx, 5*time.Second)
+	defer stop()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		current, readErr := readDescriptor(dataDir, sessionID)
+		if readErr == nil && current.Token != d.Token {
+			return nil // A new owner could only publish after the old lock released.
+		}
+		if errors.Is(readErr, os.ErrNotExist) {
+			path, _ := lockPath(dataDir, sessionID)
+			if _, lockErr := os.Stat(path); errors.Is(lockErr, os.ErrNotExist) {
+				return nil
+			} else if lockErr != nil {
+				return lockErr
+			}
+		} else if readErr != nil {
+			return readErr
+		}
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("wait for chat host shutdown: %w", waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 // Run owns the provider until it exits or an authenticated shutdown arrives.

--- a/backend/internal/adapters/chatdriver/persistenthost/host_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_test.go
@@ -75,6 +75,9 @@ func TestProviderHelper(t *testing.T) {
 		}
 		_, _ = fmt.Fprintf(os.Stdout, `{"id":%d,"result":{"pid":%d}}`+"\n", frame.ID, os.Getpid())
 	}
+	if os.Getenv("AO_CHAT_HOST_DELAY_EXIT") == "1" {
+		time.Sleep(300 * time.Millisecond)
+	}
 	os.Exit(0)
 }
 
@@ -269,6 +272,33 @@ func readFrame(t *testing.T, reader *bufio.Reader) []byte {
 		t.Fatalf("read frame: %v", err)
 	}
 	return line
+}
+
+func TestShutdownReleasesHostBeforeFreshReplacement(t *testing.T) {
+	cfg := Config{SessionID: "replace", DataDir: t.TempDir(), Workdir: t.TempDir(),
+		Env:  append(os.Environ(), "AO_CHAT_HOST_PROVIDER_HELPER=1", "AO_CHAT_HOST_DELAY_EXIT=1"),
+		Argv: []string{os.Args[0], "-test.run=TestProviderHelper"}}
+	first, err := ConnectOrStart(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = Shutdown(context.Background(), cfg.DataDir, cfg.SessionID) })
+	oldPID := requestProviderPID(t, first, 1, "pid")
+	_ = first.Stdin.Close()
+	if err := Shutdown(context.Background(), cfg.DataDir, cfg.SessionID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readDescriptor(cfg.DataDir, cfg.SessionID); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("shutdown returned before host released descriptor: %v", err)
+	}
+	next, err := ConnectOrStart(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = next.Stdin.Close() }()
+	if next.Reconnected || requestProviderPID(t, next, 1, "pid") == oldPID {
+		t.Fatal("fresh replacement reconnected to the retired provider")
+	}
 }
 
 func TestHostReconnectsSameProviderAndReplaysDetachedOutput(t *testing.T) {

--- a/backend/internal/domain/conversation.go
+++ b/backend/internal/domain/conversation.go
@@ -683,21 +683,22 @@ type ConversationQueuedEditDelivery struct {
 }
 
 // ConversationEditDelivery is AO's durable answer to one caller-owned inline
-// edit handle. Reserved means provider delivery may have happened and therefore
-// cannot be attempted automatically again. Accepted and rejected are replayable
-// across active-lineage changes and daemon restarts.
+// edit handle. A reservation with ProviderWorkStarted set cannot be dispatched
+// again without proof of its outcome. Earlier reservations can resume safely.
+// Accepted and rejected results replay across branch changes and daemon restarts.
 type ConversationEditDelivery struct {
-	ConversationID   string
-	ClientMessageID  string
-	RequestJSON      string
-	State            ConversationEditDeliveryState
-	SourceBranchID   string
-	ActiveBranchID   string
-	Turn             ConversationTurn
-	RejectionKind    ConversationEditRejectionKind
-	RejectionMessage string
-	CreatedAt        time.Time
-	SettledAt        *time.Time
+	ConversationID      string
+	ClientMessageID     string
+	RequestJSON         string
+	ProviderWorkStarted bool
+	State               ConversationEditDeliveryState
+	SourceBranchID      string
+	ActiveBranchID      string
+	Turn                ConversationTurn
+	RejectionKind       ConversationEditRejectionKind
+	RejectionMessage    string
+	CreatedAt           time.Time
+	SettledAt           *time.Time
 }
 
 // ConversationEditDeliveryState records whether a reserved edit was accepted
@@ -718,6 +719,7 @@ type ConversationEditRejectionKind string
 // Conversation edit rejection kinds.
 const (
 	ConversationEditRejectedInvalid             ConversationEditRejectionKind = "invalid_turn"
+	ConversationEditRejectedMissingTurn         ConversationEditRejectionKind = "missing_turn"
 	ConversationEditRejectedUnsupported         ConversationEditRejectionKind = "unsupported"
 	ConversationEditRejectedBusy                ConversationEditRejectionKind = "busy"
 	ConversationEditRejectedInterfaceTransition ConversationEditRejectionKind = "interface_transition"

--- a/backend/internal/domain/conversation.go
+++ b/backend/internal/domain/conversation.go
@@ -681,3 +681,50 @@ type ConversationQueuedEditDelivery struct {
 	ClientMessageID string
 	RequestHash     string
 }
+
+// ConversationEditDelivery is AO's durable answer to one caller-owned inline
+// edit handle. Reserved means provider delivery may have happened and therefore
+// cannot be attempted automatically again. Accepted and rejected are replayable
+// across active-lineage changes and daemon restarts.
+type ConversationEditDelivery struct {
+	ConversationID   string
+	ClientMessageID  string
+	RequestJSON      string
+	State            ConversationEditDeliveryState
+	SourceBranchID   string
+	ActiveBranchID   string
+	Turn             ConversationTurn
+	RejectionKind    ConversationEditRejectionKind
+	RejectionMessage string
+	CreatedAt        time.Time
+	SettledAt        *time.Time
+}
+
+// ConversationEditDeliveryState records whether a reserved edit was accepted
+// or definitively rejected.
+type ConversationEditDeliveryState string
+
+// Conversation edit delivery states.
+const (
+	ConversationEditReserved ConversationEditDeliveryState = "reserved"
+	ConversationEditAccepted ConversationEditDeliveryState = "accepted"
+	ConversationEditRejected ConversationEditDeliveryState = "rejected"
+)
+
+// ConversationEditRejectionKind reconstructs errors.Is behavior for definitive
+// edit failures after the controller that observed them no longer exists.
+type ConversationEditRejectionKind string
+
+// Conversation edit rejection kinds.
+const (
+	ConversationEditRejectedInvalid             ConversationEditRejectionKind = "invalid_turn"
+	ConversationEditRejectedUnsupported         ConversationEditRejectionKind = "unsupported"
+	ConversationEditRejectedBusy                ConversationEditRejectionKind = "busy"
+	ConversationEditRejectedInterfaceTransition ConversationEditRejectionKind = "interface_transition"
+	ConversationEditRejectedByProvider          ConversationEditRejectionKind = "provider_refused"
+	// ConversationEditRejectedProviderFailure records a generic local preparation
+	// failure when AO can prove provider dispatch never occurred. It also replays
+	// reservations settled by older builds that treated generic provider/transport
+	// errors as definitive.
+	ConversationEditRejectedProviderFailure ConversationEditRejectionKind = "provider_failure"
+)

--- a/backend/internal/httpd/controllers/conversation_history_test.go
+++ b/backend/internal/httpd/controllers/conversation_history_test.go
@@ -271,6 +271,10 @@ func TestEditConversationRouteRefusalsUseEditCodes(t *testing.T) {
 		{"blank", nil, http.StatusBadRequest, "CHAT_EDIT_TURN_INVALID"},
 		{"unsupported", chatsvc.ErrForkUnsupported, http.StatusConflict, "CHAT_EDIT_UNSUPPORTED"},
 		{"busy", chatsvc.ErrTurnRunning, http.StatusConflict, "CHAT_EDIT_BUSY"},
+		{"ambiguous provider delivery", fmt.Errorf("%w: send turn: provider unavailable", chatsvc.ErrEditDeliveryUncertain), http.StatusConflict, "CHAT_EDIT_UNCERTAIN"},
+		{"idempotency conflict", chatsvc.ErrEditIdempotencyConflict, http.StatusConflict, "CHAT_EDIT_IDEMPOTENCY_CONFLICT"},
+		{"legacy durable rejection", chatsvc.ErrEditDeliveryRejected, http.StatusConflict, "CHAT_EDIT_REJECTED"},
+		{"provider refused", chatsvc.ErrProviderRefused, http.StatusConflict, "CHAT_PROVIDER_REFUSED"},
 		{"missing turn", fmt.Errorf("%w: %w", chatsvc.ErrEditTurnInvalid, domain.ErrNoConversationTurn), http.StatusNotFound, "CHAT_EDIT_TURN_INVALID"},
 		{"invalid stored content", chatsvc.ErrEditTurnInvalid, http.StatusBadRequest, "CHAT_EDIT_TURN_INVALID"},
 	}

--- a/backend/internal/httpd/controllers/conversations.go
+++ b/backend/internal/httpd/controllers/conversations.go
@@ -215,6 +215,18 @@ func (c *ConversationsController) activateBranch(w http.ResponseWriter, r *http.
 
 func writeConversationEditError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
+	case errors.Is(err, chatsvc.ErrEditDeliveryUncertain):
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict",
+			"CHAT_EDIT_UNCERTAIN",
+			"the provider may have received this edit; retry only with the same recovery action", nil)
+	case errors.Is(err, chatsvc.ErrEditIdempotencyConflict):
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict",
+			"CHAT_EDIT_IDEMPOTENCY_CONFLICT",
+			"this delivery handle belongs to a different edit", nil)
+	case errors.Is(err, chatsvc.ErrEditDeliveryRejected):
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict",
+			"CHAT_EDIT_REJECTED",
+			"the edit was not accepted; retry deliberately with a new delivery handle", nil)
 	case errors.Is(err, chatsvc.ErrForkUnsupported):
 		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict",
 			"CHAT_EDIT_UNSUPPORTED", "this agent cannot branch an earlier prompt", nil)

--- a/backend/internal/service/chat/branch_shutdown_test.go
+++ b/backend/internal/service/chat/branch_shutdown_test.go
@@ -1,0 +1,123 @@
+package chat_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	browsersvc "github.com/aoagents/agent-orchestrator/backend/internal/service/browser"
+	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/store"
+)
+
+// Models the real Codex termination order: detaching the transport stops the
+// controller's event stream; a failed authenticated shutdown leaves the provider
+// process alive with its original, immutable environment.
+type shutdownRefusingHost struct {
+	*historyRecorder
+	browserToken string
+}
+
+func (h *shutdownRefusingHost) PreservesProviderOnClose() bool { return true }
+func (h *shutdownRefusingHost) Terminate() error {
+	_ = h.fakeConversation.Close()
+	return errors.New("read shutdown acknowledgement: connection reset by peer")
+}
+
+func TestFailedBranchShutdownPreservesSurvivingHostCredentials(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	st := openStore(t)
+	source := &shutdownRefusingHost{historyRecorder: newHistoryRecorder()}
+	reattached := newFakeConversation()
+	reattached.providerConversationID = "thread-1"
+	authority := browsersvc.NewAuthority()
+	var ids atomic.Int64
+	rotations := 0
+	reattachments := 0
+	prepare := func(ctx context.Context, expected domain.SessionControllerOwner) (map[string]string, error) {
+		token, verifier, err := authority.Issue(testSession)
+		if err != nil {
+			return nil, err
+		}
+		applied, err := st.UpdateBrowserCapabilityVerifier(ctx, testSession, expected, verifier, time.Now())
+		if err != nil {
+			return nil, err
+		}
+		if !applied {
+			return nil, errors.New("credential owner changed")
+		}
+		rotations++
+		return map[string]string{"AO_BROWSER_CAPABILITY": token}, nil
+	}
+	driver := fakeDriver{
+		start: func(cfg ports.ChatStartConfig) (ports.ChatConversation, error) {
+			source.browserToken = cfg.Env["AO_BROWSER_CAPABILITY"]
+			return source, nil
+		},
+		resume: func(cfg ports.ChatResumeConfig) (ports.ChatConversation, error) {
+			reattachments++
+			if cfg.ProviderConversationID != "thread-1" {
+				return nil, fmt.Errorf("unexpected resume %s", cfg.ProviderConversationID)
+			}
+			// The real Codex Resume reconnected path reuses the host without
+			// applying cfg.Env or issuing thread/resume. Preserve its old token.
+			return reattached, nil
+		},
+	}
+	svc := chatsvc.New(chatsvc.Options{
+		Store: st, Sessions: st, Reader: fullSnapshotReader(st),
+		Drivers: fakeRegistry{driver: driver}, Log: slog.New(slog.DiscardHandler),
+		NewID: func() string { return fmt.Sprintf("shutdown-test-%d", ids.Add(1)) },
+	})
+	rec, found, err := st.GetSession(ctx, testSession)
+	if err != nil || !found {
+		t.Fatalf("read initial session: %v", err)
+	}
+	ctrl, err := svc.Start(ctx, chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Kind: domain.KindWorker,
+		Harness: domain.HarnessCodex, WorkspacePath: t.TempDir(),
+		ExpectedControllerOwner: rec.ControllerOwner(), PrepareControllerEnv: prepare,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+	rec, found, err = st.GetSession(ctx, testSession)
+	if err != nil || !found {
+		t.Fatalf("read started session: %v", err)
+	}
+	rec.Metadata.ProviderConversationID = "thread-1"
+	rec.Metadata.ControllerGeneration = ctrl.Generation()
+	if err := st.UpdateSession(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+	h := &harness{svc: svc, st: st, conv: source.fakeConversation, ctrl: ctrl}
+	completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	second := completeTurn(t, h, "B", "provider-turn-2")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 4 })
+	_, editErr := svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
+		Text: "B edited", ClientMessageID: "unconfirmed-host", Origin: domain.MessageOriginHuman,
+	})
+	if editErr == nil {
+		t.Fatal("edit succeeded despite rejected shutdown")
+	}
+	rec, found, err = st.GetSession(ctx, testSession)
+	if err != nil || !found {
+		t.Fatalf("read after edit: %v", err)
+	}
+	current, controllerErr := svc.Controller(testSession)
+	if rotations != 1 || reattachments != 0 || controllerErr != nil || current != ctrl {
+		t.Fatalf("unconfirmed host was replaced: rotations=%d reattachments=%d controllerErr=%v", rotations, reattachments, controllerErr)
+	}
+	if !authority.Valid(testSession, source.browserToken, rec.Metadata.BrowserCapabilityVerifier) {
+		t.Fatal("surviving host browser token became unauthorized before confirmed termination")
+	}
+}

--- a/backend/internal/service/chat/branch_shutdown_test.go
+++ b/backend/internal/service/chat/branch_shutdown_test.go
@@ -26,7 +26,7 @@ type shutdownRefusingHost struct {
 
 func (h *shutdownRefusingHost) PreservesProviderOnClose() bool { return true }
 func (h *shutdownRefusingHost) Terminate() error {
-	_ = h.fakeConversation.Close()
+	_ = h.Close()
 	return errors.New("read shutdown acknowledgement: connection reset by peer")
 }
 

--- a/backend/internal/service/chat/branch_shutdown_test.go
+++ b/backend/internal/service/chat/branch_shutdown_test.go
@@ -31,8 +31,7 @@ func (h *shutdownRefusingHost) Terminate() error {
 }
 
 func TestFailedBranchShutdownPreservesSurvivingHostCredentials(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	ctx := context.Background()
 	st := openStore(t)
 	source := &shutdownRefusingHost{historyRecorder: newHistoryRecorder()}
 	reattached := newFakeConversation()
@@ -114,7 +113,12 @@ func TestFailedBranchShutdownPreservesSurvivingHostCredentials(t *testing.T) {
 		t.Fatalf("read after edit: %v", err)
 	}
 	current, controllerErr := svc.Controller(testSession)
-	if rotations != 1 || reattachments != 0 || controllerErr != nil || current != ctrl {
+	// The watcher may already have removed the stopped source after handoff
+	// aborts. Neither timing may publish a replacement for the surviving host.
+	if controllerErr != nil && !errors.Is(controllerErr, chatsvc.ErrNoController) {
+		t.Fatal(controllerErr)
+	}
+	if rotations != 1 || reattachments != 0 || (current != nil && current != ctrl) {
 		t.Fatalf("unconfirmed host was replaced: rotations=%d reattachments=%d controllerErr=%v", rotations, reattachments, controllerErr)
 	}
 	if !authority.Valid(testSession, source.browserToken, rec.Metadata.BrowserCapabilityVerifier) {

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -74,6 +74,10 @@ type Store interface {
 	ReserveQueuedTurnForPromotion(ctx context.Context, conversationID, turnID string, now time.Time) (domain.QueuedTurn, error)
 	ReleaseQueuedTurnPromotion(ctx context.Context, conversationID, turnID string) error
 	CompleteQueuedTurnPromotion(ctx context.Context, conversationID, sourceTurnID, providerTurnID string, activity domain.ConversationActivity, now time.Time) error
+	EditDelivery(ctx context.Context, conversationID, clientMessageID string) (domain.ConversationEditDelivery, bool, error)
+	ReserveEditDelivery(ctx context.Context, conversationID, clientMessageID, requestJSON string, now time.Time) (domain.ConversationEditDelivery, bool, error)
+	CompleteEditDelivery(ctx context.Context, conversationID, clientMessageID, sourceBranchID, activeBranchID string, turn domain.ConversationTurn, now time.Time) error
+	RejectEditDelivery(ctx context.Context, conversationID, clientMessageID string, kind domain.ConversationEditRejectionKind, message string, now time.Time) error
 	CancelQueuedTurns(ctx context.Context, conversationID string, cutoff, now time.Time) error
 	CancelAllQueuedTurns(ctx context.Context, conversationID string, now time.Time) error
 	CancelQueuedTurnByID(ctx context.Context, conversationID, turnID string, now time.Time) error

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -76,6 +76,8 @@ type Store interface {
 	CompleteQueuedTurnPromotion(ctx context.Context, conversationID, sourceTurnID, providerTurnID string, activity domain.ConversationActivity, now time.Time) error
 	EditDelivery(ctx context.Context, conversationID, clientMessageID string) (domain.ConversationEditDelivery, bool, error)
 	ReserveEditDelivery(ctx context.Context, conversationID, clientMessageID, requestJSON string, now time.Time) (domain.ConversationEditDelivery, bool, error)
+	BeginEditProviderWork(ctx context.Context, conversationID, clientMessageID, generation string) error
+	RecoverCompletedEditDelivery(ctx context.Context, conversationID, clientMessageID string, now time.Time) error
 	CompleteEditDelivery(ctx context.Context, conversationID, clientMessageID, sourceBranchID, activeBranchID string, turn domain.ConversationTurn, now time.Time) error
 	RejectEditDelivery(ctx context.Context, conversationID, clientMessageID string, kind domain.ConversationEditRejectionKind, message string, now time.Time) error
 	CancelQueuedTurns(ctx context.Context, conversationID string, cutoff, now time.Time) error

--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -82,6 +82,7 @@ type fakeConversation struct {
 	sent               []ports.ChatUserMessage
 	caps               ports.ChatCapabilities
 	resolved           map[string]ports.ChatDecision
+	sendCalls          int
 	turnSeq            int
 	sendErr            error
 	onSend             func(providerTurnID string)
@@ -234,6 +235,7 @@ func (f *fakeConversation) Events() <-chan ports.ChatEvent { return f.events }
 
 func (f *fakeConversation) SendTurn(_ context.Context, msg ports.ChatUserMessage) (ports.ChatTurnRef, error) {
 	f.mu.Lock()
+	f.sendCalls++
 	if f.sendErr != nil {
 		f.mu.Unlock()
 		return ports.ChatTurnRef{}, f.sendErr
@@ -265,6 +267,12 @@ func (f *fakeConversation) sentMessages() []ports.ChatUserMessage {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]ports.ChatUserMessage(nil), f.sent...)
+}
+
+func (f *fakeConversation) sendCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sendCalls
 }
 
 func (f *fakeConversation) Interrupt(context.Context, string) error { return nil }

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -58,8 +58,18 @@ var (
 	// ErrEditTurnInvalid reports a prompt that cannot be safely reconstructed from
 	// durable history, including malformed legacy structured content.
 	ErrEditTurnInvalid = errors.New("conversation turn cannot be edited")
-	// ErrBranchProviderMismatch refuses a historical branch that the active
-	// provider binding cannot reopen.
+	// ErrEditDeliveryUncertain means AO reserved the edit handle but cannot prove
+	// whether provider delivery and the durable branch result committed together.
+	ErrEditDeliveryUncertain = errors.New("edit delivery is uncertain")
+	// ErrEditIdempotencyConflict refuses reuse of one edit handle for a different
+	// source prompt or replacement payload.
+	ErrEditIdempotencyConflict = errors.New("edit idempotency handle belongs to a different request")
+	// ErrEditDeliveryRejected reports a durably rejected generic failure, including
+	// local preparation failures that prove the replacement prompt was not sent.
+	// Ambiguous failures after provider dispatch remain reserved.
+	ErrEditDeliveryRejected = errors.New("edit delivery was rejected")
+	// ErrBranchProviderMismatch refuses a historical branch whose opaque provider
+	// conversation id belongs to an earlier agent ownership epoch.
 	ErrBranchProviderMismatch = errors.New("conversation branch belongs to a different agent provider")
 )
 
@@ -161,6 +171,23 @@ func (s *Service) EditMessage(
 	}
 	defer gate.unlock()
 
+	requestJSON, err := encodeEditDeliveryRequest(turnID, msg)
+	if err != nil {
+		return EditMessageResult{}, err
+	}
+	if msg.ClientMessageID != "" {
+		conversation, loadErr := s.store.ConversationForSession(ctx, id)
+		if loadErr != nil {
+			return EditMessageResult{}, fmt.Errorf("%w: load conversation: %w", ErrEditDeliveryUncertain, loadErr)
+		}
+		delivery, found, loadErr := s.store.EditDelivery(ctx, conversation.ID, msg.ClientMessageID)
+		if loadErr != nil {
+			return EditMessageResult{}, fmt.Errorf("%w: load prior result: %w", ErrEditDeliveryUncertain, loadErr)
+		}
+		if found {
+			return replayEditDelivery(delivery, requestJSON)
+		}
+	}
 	if _, err := s.requireChatSession(ctx, id); err != nil {
 		return EditMessageResult{}, err
 	}
@@ -168,32 +195,50 @@ func (s *Service) EditMessage(
 	if err != nil {
 		return EditMessageResult{}, err
 	}
+	if msg.ClientMessageID != "" {
+		delivery, created, reserveErr := s.store.ReserveEditDelivery(
+			ctx, source.conversation.ID, msg.ClientMessageID, requestJSON, s.now())
+		if reserveErr != nil {
+			return EditMessageResult{}, fmt.Errorf("%w: reserve delivery: %w",
+				ErrEditDeliveryUncertain, reserveErr)
+		}
+		if !created {
+			return replayEditDelivery(delivery, requestJSON)
+		}
+	}
+	reject := func(result EditMessageResult, cause error) (EditMessageResult, error) {
+		return s.rejectEditDelivery(ctx, source.conversation.ID, msg.ClientMessageID, result, cause)
+	}
 	forker, canFork := source.conv.(ports.ChatForker)
 	canReplay := supportsApproximateReplay(source.conv)
 	anchor, err := s.store.ConversationEditAnchor(ctx, source.conversation.ID, turnID)
 	if err != nil {
-		return EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditTurnInvalid, err)
+		return reject(EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditTurnInvalid, err))
 	}
 	var content []ports.ChatContent
 	if anchor.OriginalDeliveryContentJSON != "" {
 		if err := json.Unmarshal([]byte(anchor.OriginalDeliveryContentJSON), &content); err != nil {
-			return EditMessageResult{}, fmt.Errorf("%w: decode stored prompt content: %w", ErrEditTurnInvalid, err)
+			return reject(EditMessageResult{}, fmt.Errorf("%w: decode stored prompt content: %w", ErrEditTurnInvalid, err))
 		}
 	}
 	msg.Content = withoutInternalReplayContent(content)
 	if anchor.RetryActiveBranch {
 		branch, err := s.store.ConversationBranch(ctx, source.conversation.ID, anchor.SourceBranchID)
 		if err != nil {
-			return EditMessageResult{}, fmt.Errorf("load pending edited conversation: %w", err)
+			return reject(EditMessageResult{}, fmt.Errorf("load pending edited conversation: %w", err))
 		}
 		if domain.NormalizeConversationBranchStrategy(branch.Strategy) == domain.ConversationBranchStrategyApproximateContext {
 			if !canReplay {
-				return EditMessageResult{}, ErrForkUnsupported
+				return s.rejectUndispatchedEditDelivery(
+					ctx, source.conversation.ID, msg.ClientMessageID,
+					ErrForkUnsupported)
 			}
 			replay, _, replayErr := s.approximateReplayContent(
 				ctx, source.conversation.ID, anchor.ReplayFloorSequence, branch.ReplayCutoffSequence)
 			if replayErr != nil {
-				return EditMessageResult{}, fmt.Errorf("prepare edited conversation retry: %w", replayErr)
+				return s.rejectUndispatchedEditDelivery(
+					ctx, source.conversation.ID, msg.ClientMessageID,
+					fmt.Errorf("prepare edited conversation retry: %w", replayErr))
 			}
 			msg.Content = append([]ports.ChatContent{replay}, msg.Content...)
 		}
@@ -201,16 +246,16 @@ func (s *Service) EditMessage(
 	}
 	sourceBranch, err := s.store.ConversationBranch(ctx, source.conversation.ID, anchor.SourceBranchID)
 	if err != nil {
-		return EditMessageResult{}, fmt.Errorf("load source conversation branch: %w", err)
+		return reject(EditMessageResult{}, fmt.Errorf("load source conversation branch: %w", err))
 	}
 	canNativeFork := anchor.PreviousProviderTurnID != "" && canFork
 	needsPriorContext := anchor.HasPriorContext
 	needsReplay := !canNativeFork && needsPriorContext
 	if needsReplay && !canReplay {
-		return EditMessageResult{}, ErrForkUnsupported
+		return reject(EditMessageResult{}, ErrForkUnsupported)
 	}
 	if err := source.BeginIdleBranchHandoff(ctx); err != nil {
-		return EditMessageResult{}, err
+		return reject(EditMessageResult{}, err)
 	}
 	abortSource := true
 	defer func() {
@@ -221,7 +266,7 @@ func (s *Service) EditMessage(
 
 	cfg, driver, err := s.branchLaunchConfig(id, source)
 	if err != nil {
-		return EditMessageResult{}, err
+		return reject(EditMessageResult{}, err)
 	}
 	var providerConversationID string
 	var provider ports.ChatConversation
@@ -270,7 +315,9 @@ func (s *Service) EditMessage(
 			replayContent, replayTruncated, replayErr = s.approximateReplayContent(
 				ctx, source.conversation.ID, anchor.ReplayFloorSequence, anchor.ForkAfterSequence)
 			if replayErr != nil {
-				return EditMessageResult{}, fmt.Errorf("prepare edited conversation: %w", replayErr)
+				return s.rejectUndispatchedEditDelivery(
+					ctx, source.conversation.ID, msg.ClientMessageID,
+					fmt.Errorf("prepare edited conversation: %w", replayErr))
 			}
 		}
 		// A fresh replay process is also a controller replacement. Stop the old
@@ -309,7 +356,7 @@ func (s *Service) EditMessage(
 				abortSource = false
 			}
 		}
-		return EditMessageResult{}, prepareErr
+		return reject(EditMessageResult{}, prepareErr)
 	}
 	if provider == nil || providerConversationID == "" {
 		if provider != nil {
@@ -324,7 +371,7 @@ func (s *Service) EditMessage(
 				abortSource = false
 			}
 		}
-		return EditMessageResult{}, prepareErr
+		return reject(EditMessageResult{}, prepareErr)
 	}
 	if replayContent.Type != "" && !supportsApproximateReplay(provider) {
 		_ = provider.Close()
@@ -337,7 +384,8 @@ func (s *Service) EditMessage(
 				abortSource = false
 			}
 		}
-		return EditMessageResult{}, unsupportedErr
+		return s.rejectUndispatchedEditDelivery(
+			ctx, source.conversation.ID, msg.ClientMessageID, unsupportedErr)
 	}
 
 	branchID := s.newID()
@@ -370,7 +418,7 @@ func (s *Service) EditMessage(
 				abortSource = false
 			}
 		}
-		return EditMessageResult{}, activateErr
+		return reject(EditMessageResult{}, activateErr)
 	}
 	// Consume the replacement privately while its bootstrap prompt is recorded.
 	// The source remains the registry owner with its intake fence installed, so a
@@ -554,7 +602,8 @@ func (s *Service) sendEditedMessage(
 				sendErr = errors.Join(sendErr, fmt.Errorf("restore source after undispatched edit: %w", err))
 			}
 		}
-		return result, classify(sendErr)
+		return s.rejectEditDelivery(
+			ctx, controller.conversation.ID, msg.ClientMessageID, result, classify(sendErr))
 	}
 	if sendErr != nil {
 		if err := s.store.UpdateConversationBranchReplacement(ctx, activeBranchID, turn.ID); err != nil {
@@ -566,12 +615,17 @@ func (s *Service) sendEditedMessage(
 				sendErr = errors.Join(sendErr, fmt.Errorf("restore source after refused edit: %w", err))
 			}
 		}
-		return result, classify(sendErr)
+		return s.rejectEditDelivery(
+			ctx, controller.conversation.ID, msg.ClientMessageID, result, classify(sendErr))
 	}
-	if turn.ID != "" {
-		if err := s.store.UpdateConversationBranchReplacement(ctx, activeBranchID, turn.ID); err != nil {
-			return result, err
+	if msg.ClientMessageID != "" {
+		if err := s.store.CompleteEditDelivery(
+			context.WithoutCancel(ctx), controller.conversation.ID, msg.ClientMessageID,
+			sourceBranchID, activeBranchID, turn, s.now()); err != nil {
+			return result, fmt.Errorf("%w: complete delivery: %w", ErrEditDeliveryUncertain, err)
 		}
+	} else if err := s.store.UpdateConversationBranchReplacement(ctx, activeBranchID, turn.ID); err != nil {
+		return result, err
 	}
 	return result, nil
 }
@@ -581,6 +635,164 @@ type EditMessageResult struct {
 	SourceBranchID string
 	ActiveBranchID string
 	Turn           domain.ConversationTurn
+}
+
+type editDeliveryRequest struct {
+	SourceTurnID string                  `json:"sourceTurnId"`
+	Text         string                  `json:"text"`
+	Content      []ports.ChatContent     `json:"content,omitempty"`
+	Origin       domain.MessageOrigin    `json:"origin"`
+	Settings     deliveryRequestSettings `json:"settings"`
+}
+
+func encodeEditDeliveryRequest(turnID string, msg ports.ChatUserMessage) (string, error) {
+	encoded, err := json.Marshal(editDeliveryRequest{
+		SourceTurnID: turnID, Text: msg.Text, Content: msg.Content,
+		Origin: normalizeOrigin(msg.Origin),
+		Settings: deliveryRequestSettings{
+			Model: msg.Settings.Model, Effort: msg.Settings.Effort, Approval: msg.Settings.Approval,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode edit delivery request: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func replayEditDelivery(
+	delivery domain.ConversationEditDelivery,
+	requestJSON string,
+) (EditMessageResult, error) {
+	if delivery.RequestJSON != requestJSON {
+		return EditMessageResult{}, ErrEditIdempotencyConflict
+	}
+	switch delivery.State {
+	case domain.ConversationEditAccepted:
+		return EditMessageResult{
+			SourceBranchID: delivery.SourceBranchID,
+			ActiveBranchID: delivery.ActiveBranchID,
+			Turn:           delivery.Turn,
+		}, nil
+	case domain.ConversationEditRejected:
+		return EditMessageResult{}, replayEditRejection(delivery)
+	case domain.ConversationEditReserved:
+		return EditMessageResult{}, ErrEditDeliveryUncertain
+	default:
+		return EditMessageResult{}, fmt.Errorf("%w: invalid durable state %q",
+			ErrEditDeliveryUncertain, delivery.State)
+	}
+}
+
+type storedEditRejection struct {
+	message string
+	cause   error
+}
+
+func (e storedEditRejection) Error() string { return e.message }
+func (e storedEditRejection) Unwrap() error { return e.cause }
+
+func replayEditRejection(delivery domain.ConversationEditDelivery) error {
+	var cause error
+	switch delivery.RejectionKind {
+	case domain.ConversationEditRejectedInvalid:
+		cause = ErrEditTurnInvalid
+	case domain.ConversationEditRejectedUnsupported:
+		cause = ErrForkUnsupported
+	case domain.ConversationEditRejectedBusy:
+		cause = ErrTurnRunning
+	case domain.ConversationEditRejectedInterfaceTransition:
+		cause = ErrControllerHandoff
+	case domain.ConversationEditRejectedByProvider:
+		cause = ErrProviderRefused
+	case domain.ConversationEditRejectedProviderFailure:
+		cause = ErrEditDeliveryRejected
+	default:
+		return fmt.Errorf("%w: invalid durable rejection %q",
+			ErrEditDeliveryUncertain, delivery.RejectionKind)
+	}
+	return storedEditRejection{message: delivery.RejectionMessage, cause: cause}
+}
+
+// classifyEditRejection separates facts that prove no provider delivery occurred
+// from generic errors whose delivery outcome the Controller.Send contract cannot
+// establish. Only the former may settle a reservation as rejected.
+func classifyEditRejection(
+	err error,
+) (domain.ConversationEditRejectionKind, bool, error) {
+	err = classify(err)
+	switch {
+	case errors.Is(err, ErrEditTurnInvalid), errors.Is(err, domain.ErrNoConversationTurn):
+		return domain.ConversationEditRejectedInvalid, true, err
+	case errors.Is(err, ErrForkUnsupported):
+		return domain.ConversationEditRejectedUnsupported, true, err
+	case errors.Is(err, ErrControllerHandoff):
+		return domain.ConversationEditRejectedInterfaceTransition, true, err
+	case errors.Is(err, ErrTurnRunning):
+		return domain.ConversationEditRejectedBusy, true, err
+	case errors.Is(err, ErrProviderRefused):
+		return domain.ConversationEditRejectedByProvider, true, err
+	default:
+		return "", false, err
+	}
+}
+
+func (s *Service) rejectEditDelivery(
+	ctx context.Context,
+	conversationID, clientMessageID string,
+	result EditMessageResult,
+	cause error,
+) (EditMessageResult, error) {
+	if clientMessageID == "" {
+		return result, cause
+	}
+	kind, definitive, classified := classifyEditRejection(cause)
+	if !definitive {
+		return result, fmt.Errorf("%w: %w", ErrEditDeliveryUncertain, classified)
+	}
+	return s.persistRejectedEditDelivery(
+		ctx, conversationID, clientMessageID, result, kind, classified)
+}
+
+// rejectUndispatchedEditDelivery settles a reserved edit after local preparation
+// proves that the edited prompt never reached Controller.Send. Generic provider
+// and transport errors after Send remain uncertain; local replay/capability
+// failures are safe to record as rejected so the same delivery ID cannot become
+// permanently reserved after a lost response or restart.
+func (s *Service) rejectUndispatchedEditDelivery(
+	ctx context.Context,
+	conversationID, clientMessageID string,
+	cause error,
+) (EditMessageResult, error) {
+	if clientMessageID == "" {
+		return EditMessageResult{}, cause
+	}
+	kind, definitive, classified := classifyEditRejection(cause)
+	if !definitive {
+		kind = domain.ConversationEditRejectedProviderFailure
+		diagnostic := classify(cause)
+		classified = storedEditRejection{
+			message: diagnostic.Error(),
+			cause:   ErrEditDeliveryRejected,
+		}
+	}
+	return s.persistRejectedEditDelivery(
+		ctx, conversationID, clientMessageID, EditMessageResult{}, kind, classified)
+}
+
+func (s *Service) persistRejectedEditDelivery(
+	ctx context.Context,
+	conversationID, clientMessageID string,
+	result EditMessageResult,
+	kind domain.ConversationEditRejectionKind,
+	cause error,
+) (EditMessageResult, error) {
+	if err := s.store.RejectEditDelivery(
+		context.WithoutCancel(ctx), conversationID, clientMessageID,
+		kind, cause.Error(), s.now()); err != nil {
+		return result, fmt.Errorf("%w: persist rejected result: %w",
+			ErrEditDeliveryUncertain, err)
+	}
+	return result, cause
 }
 
 // ActivateBranch resumes a durable provider branch in the same worktree and
@@ -924,4 +1136,13 @@ func truncateAtWord(title string, limit int) string {
 		return strings.TrimRight(cut[:idx], " ")
 	}
 	return strings.TrimRight(cut, " ")
+}
+
+// Explicit JSON names freeze the durable request identity independently of the
+// provider port's Go field names. A later refactor must not turn a safe retry into
+// an idempotency conflict after an app upgrade.
+type deliveryRequestSettings struct {
+	Model    string               `json:"model,omitempty"`
+	Effort   string               `json:"effort,omitempty"`
+	Approval ports.PermissionMode `json:"approval,omitempty"`
 }

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -983,15 +983,10 @@ func (s *Service) restoreClosedSourceController(
 	recoveryCtx, cancel := context.WithTimeout(
 		context.WithoutCancel(ctx), nativeEditHandoffLimit)
 	defer cancel()
-	if source.State() != ports.ChatControllerStopped {
-		closeErr := source.closeForBranchHandoff(recoveryCtx)
-		if source.State() != ports.ChatControllerStopped {
-			if closeErr == nil {
-				closeErr = errors.New("source controller did not stop")
-			}
-			return fmt.Errorf(
-				"confirm source stopped before failed native edit recovery: %w", closeErr)
-		}
+	// A closed event stream can project "stopped" before host termination
+	// succeeds. Preserve any termination error before rotating its credentials.
+	if err := source.closeForBranchHandoff(recoveryCtx); err != nil {
+		return fmt.Errorf("confirm source stopped before failed native edit recovery: %w", err)
 	}
 	providerConversationID := source.ProviderConversationID()
 	launchEnv, err := s.prepareBranchControllerEnv(recoveryCtx, cfg)

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -184,7 +184,16 @@ func (s *Service) EditMessage(
 		if loadErr != nil {
 			return EditMessageResult{}, fmt.Errorf("%w: load prior result: %w", ErrEditDeliveryUncertain, loadErr)
 		}
-		if found {
+		if found && (delivery.RequestJSON != requestJSON || delivery.State != domain.ConversationEditReserved || delivery.ProviderWorkStarted) {
+			if delivery.RequestJSON == requestJSON && delivery.State == domain.ConversationEditReserved {
+				if err := s.store.RecoverCompletedEditDelivery(ctx, conversation.ID, msg.ClientMessageID, s.now()); err != nil {
+					return EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditDeliveryUncertain, err)
+				}
+				delivery, _, loadErr = s.store.EditDelivery(ctx, conversation.ID, msg.ClientMessageID)
+				if loadErr != nil {
+					return EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditDeliveryUncertain, loadErr)
+				}
+			}
 			return replayEditDelivery(delivery, requestJSON)
 		}
 	}
@@ -202,7 +211,7 @@ func (s *Service) EditMessage(
 			return EditMessageResult{}, fmt.Errorf("%w: reserve delivery: %w",
 				ErrEditDeliveryUncertain, reserveErr)
 		}
-		if !created {
+		if !created && (delivery.RequestJSON != requestJSON || delivery.State != domain.ConversationEditReserved || delivery.ProviderWorkStarted) {
 			return replayEditDelivery(delivery, requestJSON)
 		}
 	}
@@ -213,6 +222,9 @@ func (s *Service) EditMessage(
 	canReplay := supportsApproximateReplay(source.conv)
 	anchor, err := s.store.ConversationEditAnchor(ctx, source.conversation.ID, turnID)
 	if err != nil {
+		if !errors.Is(err, domain.ErrNoConversationTurn) {
+			return EditMessageResult{}, fmt.Errorf("%w: load edit anchor: %w", ErrEditDeliveryUncertain, err)
+		}
 		return reject(EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditTurnInvalid, err))
 	}
 	var content []ports.ChatContent
@@ -223,6 +235,11 @@ func (s *Service) EditMessage(
 	}
 	msg.Content = withoutInternalReplayContent(content)
 	if anchor.RetryActiveBranch {
+		if msg.ClientMessageID != "" {
+			if err := s.store.BeginEditProviderWork(ctx, source.conversation.ID, msg.ClientMessageID, source.generation); err != nil {
+				return EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditDeliveryUncertain, err)
+			}
+		}
 		branch, err := s.store.ConversationBranch(ctx, source.conversation.ID, anchor.SourceBranchID)
 		if err != nil {
 			return reject(EditMessageResult{}, fmt.Errorf("load pending edited conversation: %w", err))
@@ -275,6 +292,11 @@ func (s *Service) EditMessage(
 	var providerScopeID string
 	operationCtx := ctx
 	sourceStopInitiated := false
+	if msg.ClientMessageID != "" {
+		if err := s.store.BeginEditProviderWork(ctx, source.conversation.ID, msg.ClientMessageID, source.generation); err != nil {
+			return EditMessageResult{}, fmt.Errorf("%w: %w", ErrEditDeliveryUncertain, err)
+		}
+	}
 	if canNativeFork {
 		forkAnchor := anchor.PreviousProviderTurnID
 		providerConversationID, err = forker.Fork(ctx, &forkAnchor)
@@ -694,6 +716,8 @@ func (e storedEditRejection) Unwrap() error { return e.cause }
 func replayEditRejection(delivery domain.ConversationEditDelivery) error {
 	var cause error
 	switch delivery.RejectionKind {
+	case domain.ConversationEditRejectedMissingTurn:
+		cause = errors.Join(ErrEditTurnInvalid, domain.ErrNoConversationTurn)
 	case domain.ConversationEditRejectedInvalid:
 		cause = ErrEditTurnInvalid
 	case domain.ConversationEditRejectedUnsupported:
@@ -721,7 +745,9 @@ func classifyEditRejection(
 ) (domain.ConversationEditRejectionKind, bool, error) {
 	err = classify(err)
 	switch {
-	case errors.Is(err, ErrEditTurnInvalid), errors.Is(err, domain.ErrNoConversationTurn):
+	case errors.Is(err, domain.ErrNoConversationTurn):
+		return domain.ConversationEditRejectedMissingTurn, true, err
+	case errors.Is(err, ErrEditTurnInvalid):
 		return domain.ConversationEditRejectedInvalid, true, err
 	case errors.Is(err, ErrForkUnsupported):
 		return domain.ConversationEditRejectedUnsupported, true, err

--- a/backend/internal/service/chat/history_adversarial_test.go
+++ b/backend/internal/service/chat/history_adversarial_test.go
@@ -111,6 +111,12 @@ func TestEditMessageRequiresBothApproximateReplayCapabilitiesBeforeStartingProvi
 				if startCalls != 1 {
 					t.Fatalf("provider Start calls = %d, want refusal before a fresh start", startCalls)
 				}
+				_, retryErr := h.svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
+					Text: "B edited", ClientMessageID: "capability-matrix", Origin: domain.MessageOriginHuman,
+				})
+				if !errors.Is(retryErr, chatsvc.ErrForkUnsupported) {
+					t.Fatalf("same-ID replay error = %v, want ErrForkUnsupported", retryErr)
+				}
 				return
 			}
 

--- a/backend/internal/service/chat/history_test.go
+++ b/backend/internal/service/chat/history_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -530,18 +531,53 @@ type editDriverState struct {
 	startCalls   int
 	startConfigs []ports.ChatStartConfig
 	resumeCalls  []ports.ChatResumeConfig
+	startErr     error
+	resumeErr    error
 	beforeResume func(ports.ChatResumeConfig) error
 	fresh        *fakeConversation
 	resumed      map[string]*fakeConversation
 }
 
 func newEditHarness(t *testing.T, supportsPromptReplay bool) (*harness, *historyRecorder, *editDriverState) {
-	return newEditHarnessWithControllerEnv(t, supportsPromptReplay, nil)
+	return newEditHarnessWithStore(
+		t, supportsPromptReplay, func(st *store.Store) chatsvc.Store { return st })
+}
+
+func newEditHarnessWithStore(
+	t *testing.T,
+	supportsPromptReplay bool,
+	wrapStore func(*store.Store) chatsvc.Store,
+) (*harness, *historyRecorder, *editDriverState) {
+	return newEditHarnessWithStoreAndReader(
+		t, supportsPromptReplay, wrapStore, func(reader chatsvc.SnapshotReader) chatsvc.SnapshotReader {
+			return reader
+		})
+}
+
+func newEditHarnessWithStoreAndReader(
+	t *testing.T,
+	supportsPromptReplay bool,
+	wrapStore func(*store.Store) chatsvc.Store,
+	wrapReader func(chatsvc.SnapshotReader) chatsvc.SnapshotReader,
+) (*harness, *historyRecorder, *editDriverState) {
+	return newEditHarnessWithOptions(t, supportsPromptReplay, wrapStore, wrapReader, nil)
 }
 
 func newEditHarnessWithControllerEnv(
 	t *testing.T,
 	supportsPromptReplay bool,
+	prepare func(context.Context, domain.SessionControllerOwner) (map[string]string, error),
+) (*harness, *historyRecorder, *editDriverState) {
+	return newEditHarnessWithOptions(t, supportsPromptReplay,
+		func(st *store.Store) chatsvc.Store { return st },
+		func(reader chatsvc.SnapshotReader) chatsvc.SnapshotReader { return reader }, prepare)
+}
+
+func newEditHarnessWithOptions(
+	t *testing.T,
+	supportsPromptReplay bool,
+	wrapStore func(*store.Store) chatsvc.Store,
+	wrapReader func(chatsvc.SnapshotReader) chatsvc.SnapshotReader,
 	prepare func(context.Context, domain.SessionControllerOwner) (map[string]string, error),
 ) (*harness, *historyRecorder, *editDriverState) {
 	t.Helper()
@@ -587,6 +623,9 @@ func newEditHarnessWithControllerEnv(
 		if state.startCalls == 1 {
 			return initial, nil
 		}
+		if state.startErr != nil {
+			return nil, state.startErr
+		}
 		if state.startCalls == 2 {
 			return state.fresh, nil
 		}
@@ -602,6 +641,10 @@ func newEditHarnessWithControllerEnv(
 	driver.resume = func(cfg ports.ChatResumeConfig) (ports.ChatConversation, error) {
 		state.mu.Lock()
 		state.resumeCalls = append(state.resumeCalls, cfg)
+		if state.resumeErr != nil {
+			state.mu.Unlock()
+			return nil, state.resumeErr
+		}
 		beforeResume := state.beforeResume
 		conv := state.resumed[cfg.ProviderConversationID]
 		state.mu.Unlock()
@@ -620,23 +663,24 @@ func newEditHarnessWithControllerEnv(
 	activity := &recordingActivity{}
 	var idMu sync.Mutex
 	nextID := 0
+	reader := chatsvc.SnapshotReaderFunc(func(ctx context.Context, conversationID string) (chatsvc.ConversationRows, error) {
+		snapshot, err := st.LoadConversationSnapshot(ctx, conversationID)
+		if err != nil {
+			return chatsvc.ConversationRows{}, err
+		}
+		return chatsvc.ConversationRows{
+			Conversation: snapshot.Conversation, ActiveBranch: snapshot.ActiveBranch,
+			Turns: snapshot.Turns, Messages: snapshot.Messages,
+			Activities: snapshot.Activities, BranchPoints: snapshot.BranchPoints,
+			BranchedFromEarlierMessage: snapshot.BranchedFromEarlierMessage,
+		}, nil
+	})
 	svc := chatsvc.New(chatsvc.Options{
-		Store: st, Sessions: st,
-		Reader: chatsvc.SnapshotReaderFunc(func(ctx context.Context, conversationID string) (chatsvc.ConversationRows, error) {
-			snapshot, err := st.LoadConversationSnapshot(ctx, conversationID)
-			if err != nil {
-				return chatsvc.ConversationRows{}, err
-			}
-			return chatsvc.ConversationRows{
-				Conversation: snapshot.Conversation, ActiveBranch: snapshot.ActiveBranch,
-				Turns: snapshot.Turns, Messages: snapshot.Messages,
-				Activities: snapshot.Activities, BranchPoints: snapshot.BranchPoints,
-				BranchedFromEarlierMessage: snapshot.BranchedFromEarlierMessage,
-			}, nil
-		}),
+		Store: wrapStore(st), Sessions: st,
+		Reader:   wrapReader(reader),
 		Drivers:  fakeRegistry{driver: driver},
-		Activity: activity,
 		Log:      slog.New(slog.DiscardHandler),
+		Activity: activity,
 		NewID: func() string {
 			idMu.Lock()
 			defer idMu.Unlock()
@@ -805,11 +849,25 @@ func TestEditMessageRejectsReplayWhenFreshProviderNegotiatesFewerCapabilities(t 
 	delete(capabilities, ports.ChatCapabilityEmbeddedContext)
 	driver.fresh.setCapabilities(capabilities)
 
-	_, err = h.svc.EditMessage(ctx, testSession, second, ports.ChatUserMessage{
-		Text: "B edited", Origin: domain.MessageOriginHuman,
-	})
+	edit := ports.ChatUserMessage{
+		Text: "B edited", ClientMessageID: "fresh-capability-rejection", Origin: domain.MessageOriginHuman,
+	}
+	_, err = h.svc.EditMessage(ctx, testSession, second, edit)
 	if !errors.Is(err, chatsvc.ErrForkUnsupported) {
 		t.Fatalf("EditMessage error = %v, want ErrForkUnsupported", err)
+	}
+	driver.mu.Lock()
+	startsAfterRejection := driver.startCalls
+	driver.mu.Unlock()
+	_, retryErr := h.svc.EditMessage(ctx, testSession, second, edit)
+	if !errors.Is(retryErr, chatsvc.ErrForkUnsupported) {
+		t.Fatalf("same-controller replay error = %v, want ErrForkUnsupported", retryErr)
+	}
+	driver.mu.Lock()
+	startsAfterReplay := driver.startCalls
+	driver.mu.Unlock()
+	if startsAfterReplay != startsAfterRejection {
+		t.Fatalf("same-controller replay started provider: calls %d -> %d", startsAfterRejection, startsAfterReplay)
 	}
 	after, snapshotErr := h.st.LoadConversationSnapshot(ctx, h.ctrl.ConversationID())
 	if snapshotErr != nil {
@@ -827,6 +885,65 @@ func TestEditMessageRejectsReplayWhenFreshProviderNegotiatesFewerCapabilities(t 
 	}
 	if len(branches) != 1 {
 		t.Fatalf("branches = %d, want only source after capability refusal: %#v", len(branches), branches)
+	}
+
+	restarted, provider, driverCalls := restartEditServiceWithDriverCalls(t, h)
+	startsBefore, resumesBefore := driverCalls.counts()
+	_, restartErr := restarted.EditMessage(ctx, testSession, second, edit)
+	if !errors.Is(restartErr, chatsvc.ErrForkUnsupported) {
+		t.Fatalf("restart replay error = %v, want ErrForkUnsupported", restartErr)
+	}
+	startsAfter, resumesAfter := driverCalls.counts()
+	if startsAfter != startsBefore || resumesAfter != resumesBefore {
+		t.Fatalf("restart replay reached driver: starts %d->%d resumes %d->%d",
+			startsBefore, startsAfter, resumesBefore, resumesAfter)
+	}
+	if sends := provider.sendCallCount(); sends != 0 {
+		t.Fatalf("restart replay sent %d prompts, want none", sends)
+	}
+}
+
+func TestEditMessageReportsUndispatchedReplayPreparationFailureAsRejected(t *testing.T) {
+	var failReplay atomic.Bool
+	h, _, driver := newEditHarnessWithStoreAndReader(
+		t,
+		true,
+		func(st *store.Store) chatsvc.Store { return st },
+		func(reader chatsvc.SnapshotReader) chatsvc.SnapshotReader {
+			return chatsvc.SnapshotReaderFunc(func(ctx context.Context, conversationID string) (chatsvc.ConversationRows, error) {
+				if failReplay.Load() {
+					return chatsvc.ConversationRows{}, errors.New("read replay transcript")
+				}
+				return reader.LoadConversationSnapshot(ctx, conversationID)
+			})
+		},
+	)
+	ctx := context.Background()
+	completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(snapshot store.ConversationSnapshot) bool { return len(snapshot.Messages) == 2 })
+	second := completeTurn(t, h, "B", "provider-turn-2")
+	h.awaitSnapshot(t, func(snapshot store.ConversationSnapshot) bool { return len(snapshot.Messages) == 4 })
+	failReplay.Store(true)
+
+	edit := ports.ChatUserMessage{
+		Text: "B edited", ClientMessageID: "replay-preparation-rejection", Origin: domain.MessageOriginHuman,
+	}
+	_, err := h.svc.EditMessage(ctx, testSession, second, edit)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryRejected) {
+		t.Fatalf("first response error = %v, want ErrEditDeliveryRejected", err)
+	}
+	if errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("first response error = %v, must not claim delivery uncertainty", err)
+	}
+	_, retryErr := h.svc.EditMessage(ctx, testSession, second, edit)
+	if !errors.Is(retryErr, chatsvc.ErrEditDeliveryRejected) {
+		t.Fatalf("same-ID replay error = %v, want ErrEditDeliveryRejected", retryErr)
+	}
+	driver.mu.Lock()
+	startCalls := driver.startCalls
+	driver.mu.Unlock()
+	if startCalls != 1 {
+		t.Fatalf("provider Start calls = %d, want no replacement provider start", startCalls)
 	}
 }
 
@@ -1178,6 +1295,165 @@ func TestEditMessageAmbiguousApproximateFailureRemainsNavigableAcrossRestart(t *
 	}
 	requireMessageTexts(t, restartedSnapshot.Messages, []string{"A", "reply to A", "B edited"})
 	requireBranchPoint(t, restartedSnapshot, failed.Turn.ID, failed.SourceBranchID, "")
+}
+
+type failEditCompletionStore struct{ chatsvc.Store }
+
+func (s *failEditCompletionStore) CompleteEditDelivery(
+	context.Context,
+	string,
+	string,
+	string,
+	string,
+	domain.ConversationTurn,
+	time.Time,
+) error {
+	return errors.New("injected edit completion failure")
+}
+
+type failEditOperationStore struct {
+	chatsvc.Store
+
+	mu                    sync.Mutex
+	bindErr               error
+	bindFailures          int
+	branchInstallErr      error
+	branchInstallFailures int
+}
+
+func (s *failEditOperationStore) BindTurnToProvider(
+	ctx context.Context,
+	turnID, providerTurnID string,
+	now time.Time,
+) error {
+	s.mu.Lock()
+	err := s.bindErr
+	if err != nil {
+		s.bindFailures++
+	}
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.BindTurnToProvider(ctx, turnID, providerTurnID, now)
+}
+
+func (s *failEditOperationStore) CreateAndActivateConversationBranch(
+	ctx context.Context,
+	sessionID domain.SessionID,
+	branch domain.ConversationBranch,
+	generation string,
+	now time.Time,
+) error {
+	s.mu.Lock()
+	err := s.branchInstallErr
+	if err != nil {
+		s.branchInstallFailures++
+	}
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.CreateAndActivateConversationBranch(ctx, sessionID, branch, generation, now)
+}
+
+type editRestartDriverCalls struct {
+	mu      sync.Mutex
+	starts  int
+	resumes int
+}
+
+func (c *editRestartDriverCalls) counts() (starts, resumes int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.starts, c.resumes
+}
+
+func restartEditService(
+	t *testing.T,
+	h *harness,
+) (*chatsvc.Service, *historyRecorder) {
+	t.Helper()
+	svc, provider, _ := restartEditServiceWithDriverCalls(t, h)
+	return svc, provider
+}
+
+func restartEditServiceWithDriverCalls(
+	t *testing.T,
+	h *harness,
+) (*chatsvc.Service, *historyRecorder, *editRestartDriverCalls) {
+	t.Helper()
+	controller, err := h.svc.Controller(testSession)
+	if err != nil {
+		t.Fatalf("Controller before restart: %v", err)
+	}
+	providerConversationID := controller.ProviderConversationID()
+	if err := h.svc.Stop(context.Background(), testSession); err != nil {
+		t.Fatalf("stop original edit service: %v", err)
+	}
+	provider := newHistoryRecorder()
+	provider.providerConversationID = providerConversationID
+	driverCalls := &editRestartDriverCalls{}
+	driver := fakeDriver{conv: provider}
+	driver.start = func(ports.ChatStartConfig) (ports.ChatConversation, error) {
+		driverCalls.mu.Lock()
+		driverCalls.starts++
+		driverCalls.mu.Unlock()
+		return provider, nil
+	}
+	driver.resume = func(ports.ChatResumeConfig) (ports.ChatConversation, error) {
+		driverCalls.mu.Lock()
+		driverCalls.resumes++
+		driverCalls.mu.Unlock()
+		return provider, nil
+	}
+	var (
+		idMu sync.Mutex
+		id   int
+	)
+	svc := chatsvc.New(chatsvc.Options{
+		Store: h.st, Sessions: h.st,
+		Drivers: fakeRegistry{driver: driver},
+		Log:     slog.New(slog.DiscardHandler),
+		NewID: func() string {
+			idMu.Lock()
+			defer idMu.Unlock()
+			id++
+			return fmt.Sprintf("restart-edit-%d", id)
+		},
+		Now: h.now,
+	})
+	if _, err := svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: providerConversationID,
+	}); err != nil {
+		t.Fatalf("restart edit service: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Stop(context.Background(), testSession) })
+	return svc, provider, driverCalls
+}
+
+func requireUncertainEditReplayAfterRestart(
+	t *testing.T,
+	h *harness,
+	turnID string,
+	msg ports.ChatUserMessage,
+) {
+	t.Helper()
+	restarted, provider, driverCalls := restartEditServiceWithDriverCalls(t, h)
+	startsBefore, resumesBefore := driverCalls.counts()
+	_, err := restarted.EditMessage(context.Background(), testSession, turnID, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("restart replay error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	startsAfter, resumesAfter := driverCalls.counts()
+	if startsAfter != startsBefore || resumesAfter != resumesBefore {
+		t.Fatalf("restart replay reached driver: starts %d->%d resumes %d->%d",
+			startsBefore, startsAfter, resumesBefore, resumesAfter)
+	}
+	if calls := provider.sendCallCount(); calls != 0 {
+		t.Fatalf("restarted provider received %d sends for uncertain edit replay, want none", calls)
+	}
 }
 
 func TestEditMessageClosesSourceWriterBeforeResumingNativeFork(t *testing.T) {
@@ -1658,8 +1934,368 @@ func TestEditMessageUndispatchedAttemptRestoresSourceBranch(t *testing.T) {
 	}
 }
 
+func TestAcceptedEditReplaysBeforeAnchorLookupAndRejectsChangedPayload(t *testing.T) {
+	h, _, driver := newEditHarness(t, false)
+	ctx := context.Background()
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-replay", Origin: domain.MessageOriginHuman,
+	}
+
+	original, err := h.svc.EditMessage(ctx, testSession, first, msg)
+	if err != nil {
+		t.Fatalf("first EditMessage: %v", err)
+	}
+	if err := h.svc.Stop(ctx, testSession); err != nil {
+		t.Fatalf("stop controller before replay: %v", err)
+	}
+	replayed, err := h.svc.EditMessage(ctx, testSession, first, msg)
+	if err != nil {
+		t.Fatalf("replayed EditMessage: %v", err)
+	}
+	if replayed != original {
+		t.Fatalf("replayed result = %+v, want original %+v", replayed, original)
+	}
+	if sent := driver.fresh.sentTexts(); len(sent) != 1 || sent[0] != "A edited" {
+		t.Fatalf("provider sends after replay = %v, want one", sent)
+	}
+
+	_, err = h.svc.EditMessage(ctx, testSession, first, ports.ChatUserMessage{
+		Text: "different edit", ClientMessageID: msg.ClientMessageID,
+		Origin: domain.MessageOriginHuman,
+	})
+	if !errors.Is(err, chatsvc.ErrEditIdempotencyConflict) {
+		t.Fatalf("changed edit error = %v, want ErrEditIdempotencyConflict", err)
+	}
+	if sent := driver.fresh.sentTexts(); len(sent) != 1 {
+		t.Fatalf("changed payload reached provider; sends=%v", sent)
+	}
+}
+
+func TestAmbiguousEditSendFailureStaysUncertainWithoutProviderRedispatch(t *testing.T) {
+	h, _, driver := newEditHarness(t, false)
+	ctx := context.Background()
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	driver.fresh.mu.Lock()
+	driver.fresh.sendErr = errors.New("provider unavailable")
+	driver.fresh.mu.Unlock()
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-rejected", Origin: domain.MessageOriginHuman,
+	}
+
+	failed, err := h.svc.EditMessage(ctx, testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("first EditMessage error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	if failed.ActiveBranchID == "" {
+		t.Fatalf("failed edit did not identify its selected branch: %+v", failed)
+	}
+	if calls := driver.fresh.sendCallCount(); calls != 1 {
+		t.Fatalf("provider send calls after ambiguous failure = %d, want one", calls)
+	}
+	driver.fresh.mu.Lock()
+	driver.fresh.sendErr = nil
+	driver.fresh.mu.Unlock()
+	_, retryErr := h.svc.EditMessage(ctx, testSession, first, msg)
+	if !errors.Is(retryErr, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("same-controller replay error = %v, want ErrEditDeliveryUncertain", retryErr)
+	}
+	if calls := driver.fresh.sendCallCount(); calls != 1 {
+		t.Fatalf("provider send calls after same-id replay = %d, want one", calls)
+	}
+	restarted, restartedProvider := restartEditService(t, h)
+	_, retryErr = restarted.EditMessage(ctx, testSession, first, msg)
+	if !errors.Is(retryErr, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("restart replay error = %v, want ErrEditDeliveryUncertain", retryErr)
+	}
+	if calls := restartedProvider.sendCallCount(); calls != 0 {
+		t.Fatalf("restarted provider received %d sends for uncertain edit replay, want none", calls)
+	}
+}
+
+func TestGenericEditBranchStartFailureStaysUncertainWithoutProviderRedispatch(t *testing.T) {
+	h, _, driver := newEditHarness(t, false)
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	driver.mu.Lock()
+	driver.startErr = errors.New("branch start transport failed")
+	driver.mu.Unlock()
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-start-uncertain", Origin: domain.MessageOriginHuman,
+	}
+
+	_, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("first EditMessage error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	driver.mu.Lock()
+	startCalls := driver.startCalls
+	resumeCalls := len(driver.resumeCalls)
+	if resumeCalls != 1 || driver.resumeCalls[0].ProviderConversationID != "thread-1" {
+		t.Fatalf("failed branch start must restore only the source controller: %+v", driver.resumeCalls)
+	}
+	driver.mu.Unlock()
+	if startCalls != 2 || resumeCalls != 1 || driver.fresh.sendCallCount() != 0 {
+		t.Fatalf("provider operations after branch start failure: starts=%d resumes=%d sends=%d",
+			startCalls, resumeCalls, driver.fresh.sendCallCount())
+	}
+	_, err = h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("same-controller replay error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	driver.mu.Lock()
+	startCalls = driver.startCalls
+	resumeCalls = len(driver.resumeCalls)
+	driver.mu.Unlock()
+	if startCalls != 2 || resumeCalls != 1 || driver.fresh.sendCallCount() != 0 {
+		t.Fatalf("same-id replay reached provider: starts=%d resumes=%d sends=%d",
+			startCalls, resumeCalls, driver.fresh.sendCallCount())
+	}
+	requireUncertainEditReplayAfterRestart(t, h, first, msg)
+}
+
+func TestGenericEditBranchResumeFailureStaysUncertainWithoutProviderRedispatch(t *testing.T) {
+	h, source, driver := newEditHarness(t, false)
+	completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	second := completeTurn(t, h, "B", "provider-turn-2")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 4 })
+	driver.mu.Lock()
+	driver.beforeResume = func(cfg ports.ChatResumeConfig) error {
+		if cfg.ProviderConversationID == "thread-forked" {
+			return errors.New("branch resume transport failed")
+		}
+		return nil
+	}
+	driver.mu.Unlock()
+	msg := ports.ChatUserMessage{
+		Text: "B edited", ClientMessageID: "edit-resume-uncertain", Origin: domain.MessageOriginHuman,
+	}
+
+	_, err := h.svc.EditMessage(context.Background(), testSession, second, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("first EditMessage error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	source.mu.Lock()
+	forkCalls := len(source.forkAnchors)
+	source.mu.Unlock()
+	driver.mu.Lock()
+	resumeCalls := len(driver.resumeCalls)
+	if resumeCalls != 2 || driver.resumeCalls[0].ProviderConversationID != "thread-forked" || driver.resumeCalls[1].ProviderConversationID != "thread-1" {
+		t.Fatalf("failed branch resume must restore the source controller: %+v", driver.resumeCalls)
+	}
+	driver.mu.Unlock()
+	if forkCalls != 1 || resumeCalls != 2 {
+		t.Fatalf("provider operations after branch resume failure: forks=%d resumes=%d", forkCalls, resumeCalls)
+	}
+	_, err = h.svc.EditMessage(context.Background(), testSession, second, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("same-controller replay error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	source.mu.Lock()
+	forkCalls = len(source.forkAnchors)
+	source.mu.Unlock()
+	driver.mu.Lock()
+	resumeCalls = len(driver.resumeCalls)
+	driver.mu.Unlock()
+	if forkCalls != 1 || resumeCalls != 2 {
+		t.Fatalf("same-id replay reached provider: forks=%d resumes=%d", forkCalls, resumeCalls)
+	}
+	requireUncertainEditReplayAfterRestart(t, h, second, msg)
+}
+
+func TestGenericEditBindFailureStaysUncertainWithoutProviderRedispatch(t *testing.T) {
+	var faults *failEditOperationStore
+	h, _, driver := newEditHarnessWithStore(t, false, func(st *store.Store) chatsvc.Store {
+		faults = &failEditOperationStore{Store: st}
+		return faults
+	})
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	faults.mu.Lock()
+	faults.bindErr = errors.New("bind provider turn failed")
+	faults.mu.Unlock()
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-bind-uncertain", Origin: domain.MessageOriginHuman,
+	}
+
+	_, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("first EditMessage error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	faults.mu.Lock()
+	bindFailures := faults.bindFailures
+	faults.mu.Unlock()
+	if bindFailures != 1 || driver.fresh.sendCallCount() != 1 {
+		t.Fatalf("provider operations after bind failure: binds=%d sends=%d",
+			bindFailures, driver.fresh.sendCallCount())
+	}
+	_, err = h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("same-controller replay error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	faults.mu.Lock()
+	bindFailures = faults.bindFailures
+	faults.mu.Unlock()
+	if bindFailures != 1 || driver.fresh.sendCallCount() != 1 {
+		t.Fatalf("same-id replay repeated ambiguous bind/send: binds=%d sends=%d",
+			bindFailures, driver.fresh.sendCallCount())
+	}
+	requireUncertainEditReplayAfterRestart(t, h, first, msg)
+}
+
+func TestGenericEditBranchInstallationFailureStaysUncertainWithoutProviderRedispatch(t *testing.T) {
+	var faults *failEditOperationStore
+	h, _, driver := newEditHarnessWithStore(t, false, func(st *store.Store) chatsvc.Store {
+		faults = &failEditOperationStore{Store: st}
+		return faults
+	})
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	faults.mu.Lock()
+	faults.branchInstallErr = errors.New("install branch failed")
+	faults.mu.Unlock()
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-install-uncertain", Origin: domain.MessageOriginHuman,
+	}
+
+	_, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("first EditMessage error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	faults.mu.Lock()
+	installFailures := faults.branchInstallFailures
+	faults.mu.Unlock()
+	driver.mu.Lock()
+	startCalls := driver.startCalls
+	driver.mu.Unlock()
+	if installFailures != 1 || startCalls != 2 || driver.fresh.sendCallCount() != 0 {
+		t.Fatalf("provider operations after branch installation failure: installs=%d starts=%d sends=%d",
+			installFailures, startCalls, driver.fresh.sendCallCount())
+	}
+	_, err = h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("same-controller replay error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	faults.mu.Lock()
+	installFailures = faults.branchInstallFailures
+	faults.mu.Unlock()
+	driver.mu.Lock()
+	startCalls = driver.startCalls
+	driver.mu.Unlock()
+	if installFailures != 1 || startCalls != 2 || driver.fresh.sendCallCount() != 0 {
+		t.Fatalf("same-id replay repeated branch installation: installs=%d starts=%d sends=%d",
+			installFailures, startCalls, driver.fresh.sendCallCount())
+	}
+	requireUncertainEditReplayAfterRestart(t, h, first, msg)
+}
+
+func TestTypedProviderEditRefusalDurablyReplaysWithoutProviderRedispatch(t *testing.T) {
+	h, _, driver := newEditHarness(t, false)
+	ctx := context.Background()
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	driver.fresh.mu.Lock()
+	driver.fresh.sendErr = refusedError{msg: "provider declined the replacement"}
+	driver.fresh.mu.Unlock()
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-provider-refused", Origin: domain.MessageOriginHuman,
+	}
+
+	_, err := h.svc.EditMessage(ctx, testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrProviderRefused) {
+		t.Fatalf("first EditMessage error = %v, want ErrProviderRefused", err)
+	}
+	if calls := driver.fresh.sendCallCount(); calls != 1 {
+		t.Fatalf("provider send calls after refusal = %d, want one", calls)
+	}
+	driver.fresh.mu.Lock()
+	driver.fresh.sendErr = nil
+	driver.fresh.mu.Unlock()
+	_, err = h.svc.EditMessage(ctx, testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrProviderRefused) {
+		t.Fatalf("same-controller replay error = %v, want ErrProviderRefused", err)
+	}
+	if calls := driver.fresh.sendCallCount(); calls != 1 {
+		t.Fatalf("provider send calls after refusal replay = %d, want one", calls)
+	}
+
+	restarted, restartedProvider := restartEditService(t, h)
+	_, err = restarted.EditMessage(ctx, testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrProviderRefused) {
+		t.Fatalf("restart replay error = %v, want ErrProviderRefused", err)
+	}
+	if calls := restartedProvider.sendCallCount(); calls != 0 {
+		t.Fatalf("restarted provider received %d sends for refused edit replay, want none", calls)
+	}
+}
+
+func TestAcceptedEditReplaysAfterControllerRestartWithoutProviderRedispatch(t *testing.T) {
+	h, _, driver := newEditHarness(t, false)
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-restart", Origin: domain.MessageOriginHuman,
+	}
+	original, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if err != nil {
+		t.Fatalf("first EditMessage: %v", err)
+	}
+	if sent := driver.fresh.sentTexts(); len(sent) != 1 {
+		t.Fatalf("original provider sends = %v, want one", sent)
+	}
+
+	restarted, restartedProvider := restartEditService(t, h)
+	replayed, err := restarted.EditMessage(context.Background(), testSession, first, msg)
+	if err != nil {
+		t.Fatalf("EditMessage after restart: %v", err)
+	}
+	if replayed != original {
+		t.Fatalf("restart replay = %+v, want %+v", replayed, original)
+	}
+	if sent := restartedProvider.sentTexts(); len(sent) != 0 {
+		t.Fatalf("restarted provider received edit replay: %v", sent)
+	}
+}
+
+func TestEditCompletionGapStaysUncertainAcrossRetryAndControllerRestart(t *testing.T) {
+	var flaky *failEditCompletionStore
+	h, _, driver := newEditHarnessWithStore(t, false, func(st *store.Store) chatsvc.Store {
+		flaky = &failEditCompletionStore{Store: st}
+		return flaky
+	})
+	first := completeTurn(t, h, "A", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	msg := ports.ChatUserMessage{
+		Text: "A edited", ClientMessageID: "edit-uncertain", Origin: domain.MessageOriginHuman,
+	}
+
+	_, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("completion gap error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	_, err = h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("same-controller retry error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	if sent := driver.fresh.sentTexts(); len(sent) != 1 {
+		t.Fatalf("provider received %d sends after uncertain retry, want one", len(sent))
+	}
+
+	restarted, restartedProvider := restartEditService(t, h)
+	_, err = restarted.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("restart retry error = %v, want ErrEditDeliveryUncertain", err)
+	}
+	if sent := restartedProvider.sentTexts(); len(sent) != 0 {
+		t.Fatalf("restarted provider received uncertain edit replay: %v", sent)
+	}
+}
+
 func TestEditMessageRejectsMalformedStoredContentBeforeFork(t *testing.T) {
-	h, source, _ := newEditHarness(t, false)
+	h, source, driver := newEditHarness(t, false)
 	created, err := h.st.AppendUserMessage(context.Background(), h.ctrl.ConversationID(), testSession,
 		h.ctrl.Generation(), domain.ConversationMessage{
 			ID: "legacy-message", Text: "legacy", Origin: domain.MessageOriginHuman,
@@ -1668,12 +2304,36 @@ func TestEditMessageRejectsMalformedStoredContentBeforeFork(t *testing.T) {
 	if err != nil || !created {
 		t.Fatalf("AppendUserMessage legacy: created=%v err=%v", created, err)
 	}
-	_, err = h.svc.EditMessage(context.Background(), testSession, "legacy-turn", ports.ChatUserMessage{Text: "edited"})
+	msg := ports.ChatUserMessage{
+		Text: "edited", ClientMessageID: "edit-invalid-content", Origin: domain.MessageOriginHuman,
+	}
+	_, err = h.svc.EditMessage(context.Background(), testSession, "legacy-turn", msg)
 	if !errors.Is(err, chatsvc.ErrEditTurnInvalid) {
 		t.Fatalf("EditMessage malformed content error = %v, want ErrEditTurnInvalid", err)
 	}
-	if anchor := source.lastForkAnchor(); anchor != nil {
-		t.Fatalf("malformed content called Fork at %#v", anchor)
+	_, err = h.svc.EditMessage(context.Background(), testSession, "legacy-turn", msg)
+	if !errors.Is(err, chatsvc.ErrEditTurnInvalid) {
+		t.Fatalf("same-controller replay error = %v, want ErrEditTurnInvalid", err)
+	}
+	source.mu.Lock()
+	forkCalls := len(source.forkAnchors)
+	source.mu.Unlock()
+	driver.mu.Lock()
+	startCalls := driver.startCalls
+	resumeCalls := len(driver.resumeCalls)
+	driver.mu.Unlock()
+	if forkCalls != 0 || startCalls != 1 || resumeCalls != 0 || source.sendCallCount() != 0 {
+		t.Fatalf("provider calls after pre-provider rejection: forks=%d starts=%d resumes=%d sends=%d",
+			forkCalls, startCalls, resumeCalls, source.sendCallCount())
+	}
+
+	restarted, restartedProvider := restartEditService(t, h)
+	_, err = restarted.EditMessage(context.Background(), testSession, "legacy-turn", msg)
+	if !errors.Is(err, chatsvc.ErrEditTurnInvalid) {
+		t.Fatalf("restart replay error = %v, want ErrEditTurnInvalid", err)
+	}
+	if calls := restartedProvider.sendCallCount(); calls != 0 {
+		t.Fatalf("restarted provider received %d sends for validation rejection, want none", calls)
 	}
 }
 

--- a/backend/internal/service/chat/history_test.go
+++ b/backend/internal/service/chat/history_test.go
@@ -5,13 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/store"
@@ -1299,6 +1303,49 @@ func TestEditMessageAmbiguousApproximateFailureRemainsNavigableAcrossRestart(t *
 
 type failEditCompletionStore struct{ chatsvc.Store }
 
+type loseEditReservationReplyStore struct{ chatsvc.Store }
+
+func (s *loseEditReservationReplyStore) ReserveEditDelivery(ctx context.Context, conversationID, clientID, request string, now time.Time) (domain.ConversationEditDelivery, bool, error) {
+	delivery, created, err := s.Store.ReserveEditDelivery(ctx, conversationID, clientID, request, now)
+	if err == nil && created {
+		return delivery, false, context.Canceled
+	}
+	return delivery, created, err
+}
+
+func TestReservedEditRecoversAfterControllerStopAndResume(t *testing.T) {
+	h, _, driver := newEditHarnessWithStore(t, false, func(st *store.Store) chatsvc.Store {
+		return &loseEditReservationReplyStore{Store: st}
+	})
+	first := completeTurn(t, h, "original", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	msg := ports.ChatUserMessage{Text: "replacement", ClientMessageID: "edit-stop-resume", Origin: domain.MessageOriginHuman}
+	_, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("interrupted reservation = %v, want uncertain", err)
+	}
+	if driver.fresh.sendCallCount() != 0 {
+		t.Fatal("replacement reached provider before interrupted reservation returned")
+	}
+	if err := h.svc.Stop(context.Background(), testSession); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.svc.Start(context.Background(), chatsvc.StartConfig{
+		SessionID: testSession, ProjectID: testProject, Harness: domain.HarnessCodex,
+		WorkspacePath: t.TempDir(), ProviderConversationID: "thread-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if err != nil || result.Turn.ID == "" {
+		t.Fatalf("retry after controller resume = %+v, %v; want one accepted replacement", result, err)
+	}
+	replay, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if err != nil || replay != result || driver.fresh.sendCallCount() != 1 {
+		t.Fatalf("receipt replay = %+v, %v; provider sends=%d", replay, err, driver.fresh.sendCallCount())
+	}
+}
+
 func (s *failEditCompletionStore) CompleteEditDelivery(
 	context.Context,
 	string,
@@ -2291,6 +2338,62 @@ func TestEditCompletionGapStaysUncertainAcrossRetryAndControllerRestart(t *testi
 	}
 	if sent := restartedProvider.sentTexts(); len(sent) != 0 {
 		t.Fatalf("restarted provider received uncertain edit replay: %v", sent)
+	}
+}
+
+func TestCompletedEditRepairsReceiptAfterControllerRestart(t *testing.T) {
+	h, _, driver := newEditHarnessWithStore(t, false, func(st *store.Store) chatsvc.Store {
+		return &failEditCompletionStore{Store: st}
+	})
+	first := completeTurn(t, h, "original", "provider-turn-1")
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool { return len(s.Messages) == 2 })
+	msg := ports.ChatUserMessage{Text: "replacement", ClientMessageID: "edit-completion-recovery", Origin: domain.MessageOriginHuman}
+	result, err := h.svc.EditMessage(context.Background(), testSession, first, msg)
+	if !errors.Is(err, chatsvc.ErrEditDeliveryUncertain) {
+		t.Fatalf("lost completion = %v", err)
+	}
+	driver.fresh.emit(ports.ChatEvent{Kind: ports.ChatEventTurnCompleted,
+		ProviderTurnID: result.Turn.ProviderTurnID, TurnState: domain.TurnStateCompleted})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		for _, turn := range s.Turns {
+			if turn.ID == result.Turn.ID {
+				return turn.State == domain.TurnStateCompleted
+			}
+		}
+		return false
+	})
+	restarted, provider := restartEditService(t, h)
+	recovered, err := restarted.EditMessage(context.Background(), testSession, first, msg)
+	if err != nil || recovered.Turn.ID != result.Turn.ID || recovered.ActiveBranchID != result.ActiveBranchID {
+		t.Fatalf("completed edit recovery = %+v, %v; want original turn %s", recovered, err, result.Turn.ID)
+	}
+	if driver.fresh.sendCallCount() != 1 || provider.sendCallCount() != 0 {
+		t.Fatal("receipt recovery dispatched a second replacement")
+	}
+}
+
+func TestMissingEditTurnReplaysOriginalHTTPStatusAfterRestart(t *testing.T) {
+	h, _, _ := newEditHarness(t, false)
+	check := func(svc *chatsvc.Service) {
+		t.Helper()
+		router := httpd.NewRouterWithControl(config.Config{}, slog.New(slog.DiscardHandler), nil,
+			httpd.APIDeps{Conversations: svc}, httpd.ControlDeps{})
+		request := httptest.NewRequest(http.MethodPost,
+			"/api/v1/sessions/"+string(testSession)+"/conversation/turns/missing/edit",
+			strings.NewReader(`{"text":"replacement","clientMessageId":"missing-turn-replay"}`))
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if response.Code != http.StatusNotFound || !strings.Contains(response.Body.String(), `"code":"CHAT_EDIT_TURN_INVALID"`) {
+			t.Errorf("missing edit response = %d %s, want 404 CHAT_EDIT_TURN_INVALID", response.Code, response.Body.String())
+		}
+	}
+	check(h.svc)
+	check(h.svc)
+	restarted, provider := restartEditService(t, h)
+	check(restarted)
+	if calls := provider.sendCallCount(); calls != 0 {
+		t.Fatalf("missing edit dispatched %d provider requests", calls)
 	}
 }
 

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -13,6 +13,56 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+const acceptConversationEditDelivery = `-- name: AcceptConversationEditDelivery :execrows
+UPDATE conversation_edit_deliveries
+SET state = 'accepted',
+    source_branch_id = ?,
+    active_branch_id = ?,
+    turn_id = ?,
+    handled_by_session_id = ?,
+    provider_turn_id = ?,
+    turn_state = ?,
+    turn_requested_at = ?,
+    rejection_kind = '',
+    rejection_message = '',
+    settled_at = ?
+WHERE conversation_id = ?
+  AND client_message_id = ?
+  AND state = 'reserved'
+`
+
+type AcceptConversationEditDeliveryParams struct {
+	SourceBranchID     string
+	ActiveBranchID     string
+	TurnID             string
+	HandledBySessionID string
+	ProviderTurnID     string
+	TurnState          string
+	TurnRequestedAt    sql.NullTime
+	SettledAt          sql.NullTime
+	ConversationID     string
+	ClientMessageID    string
+}
+
+func (q *Queries) AcceptConversationEditDelivery(ctx context.Context, arg AcceptConversationEditDeliveryParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, acceptConversationEditDelivery,
+		arg.SourceBranchID,
+		arg.ActiveBranchID,
+		arg.TurnID,
+		arg.HandledBySessionID,
+		arg.ProviderTurnID,
+		arg.TurnState,
+		arg.TurnRequestedAt,
+		arg.SettledAt,
+		arg.ConversationID,
+		arg.ClientMessageID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const activateConversationBranch = `-- name: ActivateConversationBranch :execrows
 UPDATE conversations
 SET active_branch_id = ?, updated_at = ?
@@ -744,6 +794,32 @@ func (q *Queries) InsertConversationBranch(ctx context.Context, arg InsertConver
 	return err
 }
 
+const insertConversationEditDeliveryReservation = `-- name: InsertConversationEditDeliveryReservation :execrows
+INSERT OR IGNORE INTO conversation_edit_deliveries (
+    conversation_id, client_message_id, request_json, state, created_at
+) VALUES (?, ?, ?, 'reserved', ?)
+`
+
+type InsertConversationEditDeliveryReservationParams struct {
+	ConversationID  string
+	ClientMessageID string
+	RequestJson     string
+	CreatedAt       time.Time
+}
+
+func (q *Queries) InsertConversationEditDeliveryReservation(ctx context.Context, arg InsertConversationEditDeliveryReservationParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, insertConversationEditDeliveryReservation,
+		arg.ConversationID,
+		arg.ClientMessageID,
+		arg.RequestJson,
+		arg.CreatedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const insertConversationMessage = `-- name: InsertConversationMessage :exec
 INSERT INTO conversation_messages (
     id, conversation_id, turn_id, sequence, revision, role, origin,
@@ -1075,6 +1151,39 @@ type RecomputeConversationCompactedAtParams struct {
 func (q *Queries) RecomputeConversationCompactedAt(ctx context.Context, arg RecomputeConversationCompactedAtParams) error {
 	_, err := q.db.ExecContext(ctx, recomputeConversationCompactedAt, arg.UpdatedAt, arg.TargetConversationID)
 	return err
+}
+
+const rejectConversationEditDelivery = `-- name: RejectConversationEditDelivery :execrows
+UPDATE conversation_edit_deliveries
+SET state = 'rejected',
+    rejection_kind = ?,
+    rejection_message = ?,
+    settled_at = ?
+WHERE conversation_id = ?
+  AND client_message_id = ?
+  AND state = 'reserved'
+`
+
+type RejectConversationEditDeliveryParams struct {
+	RejectionKind    string
+	RejectionMessage string
+	SettledAt        sql.NullTime
+	ConversationID   string
+	ClientMessageID  string
+}
+
+func (q *Queries) RejectConversationEditDelivery(ctx context.Context, arg RejectConversationEditDeliveryParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, rejectConversationEditDelivery,
+		arg.RejectionKind,
+		arg.RejectionMessage,
+		arg.SettledAt,
+		arg.ConversationID,
+		arg.ClientMessageID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const releaseQueuedConversationTurnPromotion = `-- name: ReleaseQueuedConversationTurnPromotion :execrows
@@ -1856,6 +1965,40 @@ func (q *Queries) SelectConversationEditAnchor(ctx context.Context, arg SelectCo
 		&i.HasPriorContext,
 		&i.OriginalDeliveryContentJson,
 		&i.RetryActiveBranch,
+	)
+	return i, err
+}
+
+const selectConversationEditDelivery = `-- name: SelectConversationEditDelivery :one
+SELECT conversation_id, client_message_id, request_json, state, source_branch_id, active_branch_id, turn_id, handled_by_session_id, provider_turn_id, turn_state, turn_requested_at, rejection_kind, rejection_message, created_at, settled_at FROM conversation_edit_deliveries
+WHERE conversation_id = ? AND client_message_id = ?
+LIMIT 1
+`
+
+type SelectConversationEditDeliveryParams struct {
+	ConversationID  string
+	ClientMessageID string
+}
+
+func (q *Queries) SelectConversationEditDelivery(ctx context.Context, arg SelectConversationEditDeliveryParams) (ConversationEditDelivery, error) {
+	row := q.db.QueryRowContext(ctx, selectConversationEditDelivery, arg.ConversationID, arg.ClientMessageID)
+	var i ConversationEditDelivery
+	err := row.Scan(
+		&i.ConversationID,
+		&i.ClientMessageID,
+		&i.RequestJson,
+		&i.State,
+		&i.SourceBranchID,
+		&i.ActiveBranchID,
+		&i.TurnID,
+		&i.HandledBySessionID,
+		&i.ProviderTurnID,
+		&i.TurnState,
+		&i.TurnRequestedAt,
+		&i.RejectionKind,
+		&i.RejectionMessage,
+		&i.CreatedAt,
+		&i.SettledAt,
 	)
 	return i, err
 }

--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -324,6 +324,34 @@ func (q *Queries) AttachLegacyCompactionsToRollbackAnchor(ctx context.Context, a
 	return err
 }
 
+const beginConversationEditProviderWork = `-- name: BeginConversationEditProviderWork :execrows
+UPDATE conversation_edit_deliveries
+SET provider_work_started = 1
+WHERE conversation_id = ?1
+  AND client_message_id = ?2
+  AND state = 'reserved' AND provider_work_started = 0
+  AND EXISTS (
+    SELECT 1 FROM conversations c JOIN sessions s ON s.id = c.session_id
+    WHERE c.id = conversation_edit_deliveries.conversation_id
+      AND s.controller_generation = ?3
+      AND s.session_mode = 'chat' AND s.is_terminated = 0
+  )
+`
+
+type BeginConversationEditProviderWorkParams struct {
+	ConversationID  string
+	ClientMessageID string
+	Generation      string
+}
+
+func (q *Queries) BeginConversationEditProviderWork(ctx context.Context, arg BeginConversationEditProviderWorkParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, beginConversationEditProviderWork, arg.ConversationID, arg.ClientMessageID, arg.Generation)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const bindConversationTurnProviderID = `-- name: BindConversationTurnProviderID :exec
 UPDATE conversation_turns
 SET provider_turn_id = ?, started_at = COALESCE(started_at, ?)
@@ -796,8 +824,8 @@ func (q *Queries) InsertConversationBranch(ctx context.Context, arg InsertConver
 
 const insertConversationEditDeliveryReservation = `-- name: InsertConversationEditDeliveryReservation :execrows
 INSERT OR IGNORE INTO conversation_edit_deliveries (
-    conversation_id, client_message_id, request_json, state, created_at
-) VALUES (?, ?, ?, 'reserved', ?)
+    conversation_id, client_message_id, request_json, state, created_at, provider_work_started
+) VALUES (?, ?, ?, 'reserved', ?, 0)
 `
 
 type InsertConversationEditDeliveryReservationParams struct {
@@ -1311,6 +1339,56 @@ func (q *Queries) ResolveConversationApproval(ctx context.Context, arg ResolveCo
 		arg.RequestID,
 	)
 	return err
+}
+
+const selectCompletedEditReplacement = `-- name: SelectCompletedEditReplacement :one
+SELECT t.id, t.conversation_id, t.handled_by_session_id, t.provider_turn_id, t.controller_generation, t.state, t.error_message, t.requested_at, t.started_at, t.completed_at, t.diff_json, t.rolled_back_at, t.plan_json, t.branch_id, t.promotion_started_at, t.promoted_to_turn_id, t.retry_of_turn_id, b.parent_branch_id
+FROM conversation_messages m
+JOIN conversation_turns t ON t.id = m.turn_id
+JOIN conversation_branches b ON b.id = m.branch_id
+JOIN conversation_edit_deliveries d ON d.conversation_id = m.conversation_id
+  AND d.client_message_id = m.client_message_id
+WHERE d.conversation_id = ? AND d.client_message_id = ?
+  AND d.state = 'reserved' AND t.state = 'completed'
+  AND b.replaced_turn_id = json_extract(d.request_json, '$.sourceTurnId')
+  AND m.role = 'user'
+LIMIT 1
+`
+
+type SelectCompletedEditReplacementParams struct {
+	ConversationID  string
+	ClientMessageID string
+}
+
+type SelectCompletedEditReplacementRow struct {
+	ConversationTurn ConversationTurn
+	ParentBranchID   sql.NullString
+}
+
+func (q *Queries) SelectCompletedEditReplacement(ctx context.Context, arg SelectCompletedEditReplacementParams) (SelectCompletedEditReplacementRow, error) {
+	row := q.db.QueryRowContext(ctx, selectCompletedEditReplacement, arg.ConversationID, arg.ClientMessageID)
+	var i SelectCompletedEditReplacementRow
+	err := row.Scan(
+		&i.ConversationTurn.ID,
+		&i.ConversationTurn.ConversationID,
+		&i.ConversationTurn.HandledBySessionID,
+		&i.ConversationTurn.ProviderTurnID,
+		&i.ConversationTurn.ControllerGeneration,
+		&i.ConversationTurn.State,
+		&i.ConversationTurn.ErrorMessage,
+		&i.ConversationTurn.RequestedAt,
+		&i.ConversationTurn.StartedAt,
+		&i.ConversationTurn.CompletedAt,
+		&i.ConversationTurn.DiffJson,
+		&i.ConversationTurn.RolledBackAt,
+		&i.ConversationTurn.PlanJson,
+		&i.ConversationTurn.BranchID,
+		&i.ConversationTurn.PromotionStartedAt,
+		&i.ConversationTurn.PromotedToTurnID,
+		&i.ConversationTurn.RetryOfTurnID,
+		&i.ParentBranchID,
+	)
+	return i, err
 }
 
 const selectConversationActivities = `-- name: SelectConversationActivities :many
@@ -1970,7 +2048,7 @@ func (q *Queries) SelectConversationEditAnchor(ctx context.Context, arg SelectCo
 }
 
 const selectConversationEditDelivery = `-- name: SelectConversationEditDelivery :one
-SELECT conversation_id, client_message_id, request_json, state, source_branch_id, active_branch_id, turn_id, handled_by_session_id, provider_turn_id, turn_state, turn_requested_at, rejection_kind, rejection_message, created_at, settled_at FROM conversation_edit_deliveries
+SELECT conversation_id, client_message_id, request_json, state, source_branch_id, active_branch_id, turn_id, handled_by_session_id, provider_turn_id, turn_state, turn_requested_at, rejection_kind, rejection_message, created_at, settled_at, provider_work_started FROM conversation_edit_deliveries
 WHERE conversation_id = ? AND client_message_id = ?
 LIMIT 1
 `
@@ -1999,6 +2077,7 @@ func (q *Queries) SelectConversationEditDelivery(ctx context.Context, arg Select
 		&i.RejectionMessage,
 		&i.CreatedAt,
 		&i.SettledAt,
+		&i.ProviderWorkStarted,
 	)
 	return i, err
 }

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -276,21 +276,22 @@ type ConversationBranch struct {
 }
 
 type ConversationEditDelivery struct {
-	ConversationID     string
-	ClientMessageID    string
-	RequestJson        string
-	State              string
-	SourceBranchID     string
-	ActiveBranchID     string
-	TurnID             string
-	HandledBySessionID string
-	ProviderTurnID     string
-	TurnState          string
-	TurnRequestedAt    sql.NullTime
-	RejectionKind      string
-	RejectionMessage   string
-	CreatedAt          time.Time
-	SettledAt          sql.NullTime
+	ConversationID      string
+	ClientMessageID     string
+	RequestJson         string
+	State               string
+	SourceBranchID      string
+	ActiveBranchID      string
+	TurnID              string
+	HandledBySessionID  string
+	ProviderTurnID      string
+	TurnState           string
+	TurnRequestedAt     sql.NullTime
+	RejectionKind       string
+	RejectionMessage    string
+	CreatedAt           time.Time
+	SettledAt           sql.NullTime
+	ProviderWorkStarted int64
 }
 
 type ConversationMessage struct {

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -275,6 +275,24 @@ type ConversationBranch struct {
 	ProviderScopeID        string
 }
 
+type ConversationEditDelivery struct {
+	ConversationID     string
+	ClientMessageID    string
+	RequestJson        string
+	State              string
+	SourceBranchID     string
+	ActiveBranchID     string
+	TurnID             string
+	HandledBySessionID string
+	ProviderTurnID     string
+	TurnState          string
+	TurnRequestedAt    sql.NullTime
+	RejectionKind      string
+	RejectionMessage   string
+	CreatedAt          time.Time
+	SettledAt          sql.NullTime
+}
+
 type ConversationMessage struct {
 	ID                  string
 	ConversationID      string

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -141,6 +141,7 @@ var shippedMigrations = map[int64]string{
 	134: "0134_review_activity_state.sql",
 	135: "0135_review_launch_id.sql",
 	136: "0136_conversation_queued_edit_delivery.sql",
+	137: "0137_conversation_edit_delivery.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrate_burned_versions_test.go
+++ b/backend/internal/storage/sqlite/migrate_burned_versions_test.go
@@ -142,6 +142,7 @@ var shippedMigrations = map[int64]string{
 	135: "0135_review_launch_id.sql",
 	136: "0136_conversation_queued_edit_delivery.sql",
 	137: "0137_conversation_edit_delivery.sql",
+	138: "0138_conversation_edit_dispatch_boundary.sql",
 }
 
 // burnedVersion reports version numbers that must never be (re)used: they

--- a/backend/internal/storage/sqlite/migrations/0137_conversation_edit_delivery.sql
+++ b/backend/internal/storage/sqlite/migrations/0137_conversation_edit_delivery.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Edit delivery changes both the provider's conversation branch and AO's active
+-- lineage. Reserve the renderer's delivery handle before either boundary so a
+-- lost response can replay a known result without asking the provider twice.
+CREATE TABLE conversation_edit_deliveries (
+    conversation_id    TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    client_message_id  TEXT NOT NULL,
+    request_json       TEXT NOT NULL,
+    state              TEXT NOT NULL CHECK (state IN ('reserved', 'accepted', 'rejected')),
+    source_branch_id   TEXT NOT NULL DEFAULT '',
+    active_branch_id   TEXT NOT NULL DEFAULT '',
+    turn_id            TEXT NOT NULL DEFAULT '',
+    handled_by_session_id TEXT NOT NULL DEFAULT '',
+    provider_turn_id   TEXT NOT NULL DEFAULT '',
+    turn_state         TEXT NOT NULL DEFAULT '',
+    turn_requested_at  TIMESTAMP,
+    rejection_kind     TEXT NOT NULL DEFAULT '',
+    rejection_message  TEXT NOT NULL DEFAULT '',
+    created_at          TIMESTAMP NOT NULL,
+    settled_at          TIMESTAMP,
+    PRIMARY KEY (conversation_id, client_message_id)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE conversation_edit_deliveries;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/migrations/0138_conversation_edit_dispatch_boundary.sql
+++ b/backend/internal/storage/sqlite/migrations/0138_conversation_edit_dispatch_boundary.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- Existing reservations cannot prove whether provider work started. New
+-- reservations explicitly start at zero and claim this boundary before I/O.
+ALTER TABLE conversation_edit_deliveries ADD COLUMN provider_work_started INTEGER NOT NULL DEFAULT 1 CHECK (provider_work_started IN (0, 1));
+
+-- +goose Down
+ALTER TABLE conversation_edit_deliveries DROP COLUMN provider_work_started;

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -1389,3 +1389,48 @@ WHERE conversation_id = ? AND client_message_id = ?;
 INSERT INTO conversation_queued_edit_deliveries
 (conversation_id, client_message_id, request_hash, created_at)
 VALUES (?, ?, ?, ?);
+
+-- name: SelectConversationEditDelivery :one
+SELECT * FROM conversation_edit_deliveries
+WHERE conversation_id = ? AND client_message_id = ?
+LIMIT 1;
+
+
+-- name: InsertConversationEditDeliveryReservation :execrows
+INSERT OR IGNORE INTO conversation_edit_deliveries (
+    conversation_id, client_message_id, request_json, state, created_at
+) VALUES (?, ?, ?, 'reserved', ?);
+
+
+-- name: AcceptConversationEditDelivery :execrows
+UPDATE conversation_edit_deliveries
+SET state = 'accepted',
+    source_branch_id = ?,
+    active_branch_id = ?,
+    turn_id = ?,
+    handled_by_session_id = ?,
+    provider_turn_id = ?,
+    turn_state = ?,
+    turn_requested_at = ?,
+    rejection_kind = '',
+    rejection_message = '',
+    settled_at = ?
+WHERE conversation_id = ?
+  AND client_message_id = ?
+  AND state = 'reserved';
+
+
+-- name: RejectConversationEditDelivery :execrows
+UPDATE conversation_edit_deliveries
+SET state = 'rejected',
+    rejection_kind = ?,
+    rejection_message = ?,
+    settled_at = ?
+WHERE conversation_id = ?
+  AND client_message_id = ?
+  AND state = 'reserved';
+
+-- Stopping the agent stops the queue with it: a brake that starts new work
+-- instead of ending it would be the wrong shape for the button the user pressed.
+-- The cutoff is the moment the user pressed stop, so a message typed after that
+-- is still delivered rather than swept up by a cancellation it predates.

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -1398,8 +1398,21 @@ LIMIT 1;
 
 -- name: InsertConversationEditDeliveryReservation :execrows
 INSERT OR IGNORE INTO conversation_edit_deliveries (
-    conversation_id, client_message_id, request_json, state, created_at
-) VALUES (?, ?, ?, 'reserved', ?);
+    conversation_id, client_message_id, request_json, state, created_at, provider_work_started
+) VALUES (?, ?, ?, 'reserved', ?, 0);
+
+-- name: BeginConversationEditProviderWork :execrows
+UPDATE conversation_edit_deliveries
+SET provider_work_started = 1
+WHERE conversation_id = sqlc.arg(conversation_id)
+  AND client_message_id = sqlc.arg(client_message_id)
+  AND state = 'reserved' AND provider_work_started = 0
+  AND EXISTS (
+    SELECT 1 FROM conversations c JOIN sessions s ON s.id = c.session_id
+    WHERE c.id = conversation_edit_deliveries.conversation_id
+      AND s.controller_generation = sqlc.arg(generation)
+      AND s.session_mode = 'chat' AND s.is_terminated = 0
+  );
 
 
 -- name: AcceptConversationEditDelivery :execrows
@@ -1418,6 +1431,19 @@ SET state = 'accepted',
 WHERE conversation_id = ?
   AND client_message_id = ?
   AND state = 'reserved';
+
+-- name: SelectCompletedEditReplacement :one
+SELECT sqlc.embed(t), b.parent_branch_id
+FROM conversation_messages m
+JOIN conversation_turns t ON t.id = m.turn_id
+JOIN conversation_branches b ON b.id = m.branch_id
+JOIN conversation_edit_deliveries d ON d.conversation_id = m.conversation_id
+  AND d.client_message_id = m.client_message_id
+WHERE d.conversation_id = ? AND d.client_message_id = ?
+  AND d.state = 'reserved' AND t.state = 'completed'
+  AND b.replaced_turn_id = json_extract(d.request_json, '$.sourceTurnId')
+  AND m.role = 'user'
+LIMIT 1;
 
 
 -- name: RejectConversationEditDelivery :execrows

--- a/backend/internal/storage/sqlite/store/conversation_branch_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_branch_store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -436,6 +437,98 @@ func TestConversationEditAnchorRejectsMissingOrNonHumanTurn(t *testing.T) {
 	s, _, conversation := seededChatConversation(t)
 	if _, err := s.ConversationEditAnchor(ctx, conversation.ID, "missing"); !errors.Is(err, store.ErrConversationTurnNotFound) {
 		t.Fatalf("missing edit anchor error = %v", err)
+	}
+}
+
+func TestEditDeliveryReservationHasOneConcurrentWinner(t *testing.T) {
+	ctx := context.Background()
+	s, _, conversation := seededChatConversation(t)
+	const workers = 8
+	created := make(chan bool, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, won, err := s.ReserveEditDelivery(
+				ctx, conversation.ID, "edit-concurrent", `{"sourceTurnId":"turn-1","text":"edited"}`, testNow)
+			created <- won
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(created)
+	close(errs)
+	winners := 0
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("ReserveEditDelivery: %v", err)
+		}
+	}
+	for won := range created {
+		if won {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("reservation winners = %d, want exactly one", winners)
+	}
+}
+
+func TestCompleteEditDeliveryRollsBackBranchMutationWhenResultCannotSettle(t *testing.T) {
+	ctx := context.Background()
+	s, session, conversation := seededChatConversation(t)
+	seedBranchTurns(t, s, session, conversation)
+	child := domain.ConversationBranch{
+		ID: "branch-edit-atomic", ConversationID: conversation.ID, SessionID: session.ID,
+		ProviderConversationID: "thread-edit-atomic", ParentBranchID: conversation.ActiveBranchID,
+		ForkAfterTurnID: "turn-1", ReplacedTurnID: "turn-2", ForkAfterSequence: 2,
+	}
+	if err := s.CreateConversationBranch(ctx, child, testNow.Add(time.Minute)); err != nil {
+		t.Fatalf("CreateConversationBranch: %v", err)
+	}
+	activateTestBranch(t, s, session, conversation, child.ID, child.ProviderConversationID, "generation-edit")
+	appendBranchPrompt(t, s, session, conversation, "generation-edit", "replacement", "edited second prompt")
+	turn, err := s.TurnByID(ctx, "turn-replacement")
+	if err != nil {
+		t.Fatalf("TurnByID: %v", err)
+	}
+	if _, created, err := s.ReserveEditDelivery(
+		ctx, conversation.ID, "edit-atomic", `{"sourceTurnId":"turn-2","text":"edited second prompt"}`, testNow); err != nil || !created {
+		t.Fatalf("ReserveEditDelivery: created=%v err=%v", created, err)
+	}
+
+	// The branch update executes first inside CompleteEditDelivery. Settling an
+	// absent handle then fails, and the transaction must undo that first write.
+	err = s.CompleteEditDelivery(ctx, conversation.ID, "missing-edit-handle",
+		conversation.ActiveBranchID, child.ID, turn, testNow.Add(2*time.Minute))
+	if err == nil {
+		t.Fatal("CompleteEditDelivery unexpectedly settled a missing reservation")
+	}
+	gotBranch, err := s.ConversationBranch(ctx, conversation.ID, child.ID)
+	if err != nil {
+		t.Fatalf("ConversationBranch after rollback: %v", err)
+	}
+	if gotBranch.ReplacementTurnID != "" {
+		t.Fatalf("branch replacement survived failed transaction: %q", gotBranch.ReplacementTurnID)
+	}
+	delivery, found, err := s.EditDelivery(ctx, conversation.ID, "edit-atomic")
+	if err != nil || !found || delivery.State != domain.ConversationEditReserved {
+		t.Fatalf("delivery after rollback = %+v found=%v err=%v, want reserved", delivery, found, err)
+	}
+
+	if err := s.CompleteEditDelivery(ctx, conversation.ID, "edit-atomic",
+		conversation.ActiveBranchID, child.ID, turn, testNow.Add(3*time.Minute)); err != nil {
+		t.Fatalf("CompleteEditDelivery valid: %v", err)
+	}
+	gotBranch, err = s.ConversationBranch(ctx, conversation.ID, child.ID)
+	if err != nil || gotBranch.ReplacementTurnID != turn.ID {
+		t.Fatalf("completed branch = %+v err=%v", gotBranch, err)
+	}
+	delivery, found, err = s.EditDelivery(ctx, conversation.ID, "edit-atomic")
+	if err != nil || !found || delivery.State != domain.ConversationEditAccepted || delivery.Turn.ID != turn.ID {
+		t.Fatalf("completed delivery = %+v found=%v err=%v", delivery, found, err)
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -3252,3 +3252,162 @@ func (s *Store) QueuedEditDelivery(ctx context.Context, conversationID, clientMe
 	}
 	return hash, err == nil, err
 }
+
+func reserveConversationDelivery[Row, Delivery any](
+	ctx context.Context,
+	s *Store,
+	insert func(context.Context) (int64, error),
+	load func(context.Context) (Row, error),
+	toDomain func(Row) Delivery,
+	insertError, loadError string,
+) (delivery Delivery, created bool, err error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	rows, err := insert(ctx)
+	if err != nil {
+		return delivery, false, fmt.Errorf("%s: %w", insertError, err)
+	}
+	row, err := load(ctx)
+	if err != nil {
+		return delivery, false, fmt.Errorf("%s: %w", loadError, err)
+	}
+	return toDomain(row), rows == 1, nil
+}
+
+// EditDelivery loads the durable outcome for one caller-owned inline edit key.
+func (s *Store) EditDelivery(
+	ctx context.Context,
+	conversationID, clientMessageID string,
+) (domain.ConversationEditDelivery, bool, error) {
+	row, err := s.conversationReader(ctx).SelectConversationEditDelivery(ctx,
+		gen.SelectConversationEditDeliveryParams{
+			ConversationID: conversationID, ClientMessageID: clientMessageID,
+		})
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.ConversationEditDelivery{}, false, nil
+	}
+	if err != nil {
+		return domain.ConversationEditDelivery{}, false,
+			fmt.Errorf("select edit delivery %s: %w", clientMessageID, err)
+	}
+	return editDeliveryToDomain(row), true, nil
+}
+
+// ReserveEditDelivery claims a client handle before anchor lookup or provider
+// I/O. created is false when another request already owns the handle.
+func (s *Store) ReserveEditDelivery(
+	ctx context.Context,
+	conversationID, clientMessageID, requestJSON string,
+	now time.Time,
+) (delivery domain.ConversationEditDelivery, created bool, err error) {
+	return reserveConversationDelivery(
+		ctx,
+		s,
+		func(ctx context.Context) (int64, error) {
+			return s.qw.InsertConversationEditDeliveryReservation(ctx,
+				gen.InsertConversationEditDeliveryReservationParams{
+					ConversationID: conversationID, ClientMessageID: clientMessageID,
+					RequestJson: requestJSON, CreatedAt: now,
+				})
+		},
+		func(ctx context.Context) (gen.ConversationEditDelivery, error) {
+			return s.qw.SelectConversationEditDelivery(ctx,
+				gen.SelectConversationEditDeliveryParams{
+					ConversationID: conversationID, ClientMessageID: clientMessageID,
+				})
+		},
+		editDeliveryToDomain,
+		"reserve edit delivery "+clientMessageID,
+		"read edit delivery reservation "+clientMessageID,
+	)
+}
+
+// CompleteEditDelivery attaches the replacement turn to its branch and records
+// the replayable accepted result in one transaction. A crash cannot publish one
+// fact without the other.
+func (s *Store) CompleteEditDelivery(
+	ctx context.Context,
+	conversationID, clientMessageID, sourceBranchID, activeBranchID string,
+	turn domain.ConversationTurn,
+	now time.Time,
+) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.inTx(ctx, "complete edit delivery", func(q *gen.Queries) error {
+		rows, err := q.UpdateConversationBranchReplacement(ctx,
+			gen.UpdateConversationBranchReplacementParams{
+				ReplacementTurnID: nullableString(turn.ID), BranchID: activeBranchID,
+			})
+		if err != nil {
+			return fmt.Errorf("update conversation branch %s replacement: %w", activeBranchID, err)
+		}
+		if rows != 1 {
+			return fmt.Errorf("%w: %s", domain.ErrNoConversationBranch, activeBranchID)
+		}
+		rows, err = q.AcceptConversationEditDelivery(ctx,
+			gen.AcceptConversationEditDeliveryParams{
+				SourceBranchID: sourceBranchID, ActiveBranchID: activeBranchID,
+				TurnID: turn.ID, HandledBySessionID: string(turn.HandledBySessionID),
+				ProviderTurnID: turn.ProviderTurnID, TurnState: string(turn.State),
+				TurnRequestedAt: sql.NullTime{Time: turn.RequestedAt, Valid: !turn.RequestedAt.IsZero()},
+				SettledAt:       sql.NullTime{Time: now, Valid: true},
+				ConversationID:  conversationID, ClientMessageID: clientMessageID,
+			})
+		if err != nil {
+			return fmt.Errorf("accept edit delivery %s: %w", clientMessageID, err)
+		}
+		if rows != 1 {
+			return fmt.Errorf("accept edit delivery %s: reservation is not active", clientMessageID)
+		}
+		return nil
+	})
+}
+
+// RejectEditDelivery settles a definitive edit non-acceptance for replay after
+// active lineage changes or daemon restart.
+func (s *Store) RejectEditDelivery(
+	ctx context.Context,
+	conversationID, clientMessageID string,
+	kind domain.ConversationEditRejectionKind,
+	message string,
+	now time.Time,
+) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	rows, err := s.qw.RejectConversationEditDelivery(ctx,
+		gen.RejectConversationEditDeliveryParams{
+			RejectionKind: string(kind), RejectionMessage: message,
+			SettledAt:      sql.NullTime{Time: now, Valid: true},
+			ConversationID: conversationID, ClientMessageID: clientMessageID,
+		})
+	if err != nil {
+		return fmt.Errorf("reject edit delivery %s: %w", clientMessageID, err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("reject edit delivery %s: reservation is not active", clientMessageID)
+	}
+	return nil
+}
+
+func editDeliveryToDomain(row gen.ConversationEditDelivery) domain.ConversationEditDelivery {
+	delivery := domain.ConversationEditDelivery{
+		ConversationID: row.ConversationID, ClientMessageID: row.ClientMessageID,
+		RequestJSON: row.RequestJson, State: domain.ConversationEditDeliveryState(row.State),
+		SourceBranchID: row.SourceBranchID, ActiveBranchID: row.ActiveBranchID,
+		Turn: domain.ConversationTurn{
+			ID: row.TurnID, ConversationID: row.ConversationID,
+			HandledBySessionID: domain.SessionID(row.HandledBySessionID),
+			ProviderTurnID:     row.ProviderTurnID, State: domain.TurnState(row.TurnState),
+		},
+		RejectionKind:    domain.ConversationEditRejectionKind(row.RejectionKind),
+		RejectionMessage: row.RejectionMessage, CreatedAt: row.CreatedAt,
+	}
+	if row.SettledAt.Valid {
+		settled := row.SettledAt.Time
+		delivery.SettledAt = &settled
+	}
+	if row.TurnRequestedAt.Valid {
+		delivery.Turn.RequestedAt = row.TurnRequestedAt.Time
+	}
+	return delivery
+}

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -3322,6 +3322,38 @@ func (s *Store) ReserveEditDelivery(
 	)
 }
 
+// RecoverCompletedEditDelivery uses provider completion as proof of acceptance.
+// A queued, bound, or failed turn alone does not prove provider execution.
+func (s *Store) RecoverCompletedEditDelivery(ctx context.Context, conversationID, clientMessageID string, now time.Time) error {
+	row, err := s.conversationReader(ctx).SelectCompletedEditReplacement(ctx, gen.SelectCompletedEditReplacementParams{
+		ConversationID: conversationID, ClientMessageID: clientMessageID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("load completed edit replacement: %w", err)
+	}
+	turn := turnToDomain(row.ConversationTurn)
+	return s.CompleteEditDelivery(ctx, conversationID, clientMessageID, row.ParentBranchID.String, turn.BranchID, turn, now)
+}
+
+// BeginEditProviderWork fences retries before any provider operation can occur.
+func (s *Store) BeginEditProviderWork(ctx context.Context, conversationID, clientMessageID, generation string) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	rows, err := s.qw.BeginConversationEditProviderWork(ctx, gen.BeginConversationEditProviderWorkParams{
+		ConversationID: conversationID, ClientMessageID: clientMessageID, Generation: generation,
+	})
+	if err != nil {
+		return fmt.Errorf("begin edit provider work: %w", err)
+	}
+	if rows != 1 {
+		return errors.New("edit provider work already started or controller replaced")
+	}
+	return nil
+}
+
 // CompleteEditDelivery attaches the replacement turn to its branch and records
 // the replayable accepted result in one transaction. A crash cannot publish one
 // fact without the other.
@@ -3393,7 +3425,8 @@ func editDeliveryToDomain(row gen.ConversationEditDelivery) domain.ConversationE
 	delivery := domain.ConversationEditDelivery{
 		ConversationID: row.ConversationID, ClientMessageID: row.ClientMessageID,
 		RequestJSON: row.RequestJson, State: domain.ConversationEditDeliveryState(row.State),
-		SourceBranchID: row.SourceBranchID, ActiveBranchID: row.ActiveBranchID,
+		ProviderWorkStarted: row.ProviderWorkStarted != 0,
+		SourceBranchID:      row.SourceBranchID, ActiveBranchID: row.ActiveBranchID,
 		Turn: domain.ConversationTurn{
 			ID: row.TurnID, ConversationID: row.ConversationID,
 			HandledBySessionID: domain.SessionID(row.HandledBySessionID),

--- a/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
+++ b/frontend/src/renderer/components/chat/ChatTimelineItems.tsx
@@ -472,7 +472,10 @@ export function HumanMessage({
 	onEditStart,
 	onEditDraftChange,
 	onEditCancel,
+	onEditAbandonRecovery,
 	editPending = false,
+	editSendBlocked = false,
+	editRecoveryLabel,
 	editBusy = false,
 	editError,
 	branchPoint,
@@ -496,7 +499,10 @@ export function HumanMessage({
 	onEditStart?: () => void;
 	onEditDraftChange?: (text: string) => void;
 	onEditCancel?: () => void;
+	onEditAbandonRecovery?: () => void;
 	editPending?: boolean;
+	editSendBlocked?: boolean;
+	editRecoveryLabel?: string;
 	editBusy?: boolean;
 	editError?: string;
 	branchPoint?: ConversationBranchPoint;
@@ -514,11 +520,15 @@ export function HumanMessage({
 					text={editText ?? message.text}
 					content={message.content ?? []}
 					pending={editPending}
+					locked={Boolean(editRecoveryLabel)}
+					recoveryLabel={editRecoveryLabel}
+					sendBlocked={editSendBlocked}
 					busy={editBusy}
 					reconstructedContext={editReconstructedContext}
 					error={editError}
 					onDraftChange={onEditDraftChange}
 					onCancel={() => onEditCancel?.()}
+					onAbandonRecovery={onEditAbandonRecovery}
 					onSend={(text) => {
 						if (!message.turnId || !onEdit) return;
 						return onEdit(message.turnId, text);

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render as rtlRender, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Activity } from "react";
 import type { ReactElement } from "react";
 import { typeInLexicalEditor } from "../../test/lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,6 +19,17 @@ import type { ConversationMessage, ConversationSnapshot } from "../../types/conv
 import { setApiBaseUrl } from "../../lib/api-client";
 import { useUiStore } from "../../stores/ui-store";
 import type { WorkspaceSession } from "../../types/workspace";
+import {
+	getChatComposerMutation,
+	getChatInlineEditMutation,
+	prepareChatInlineEditDelivery,
+	readChatSessionDraft,
+	writeChatInlineEdit,
+} from "../../lib/chat-drafts";
+import {
+	getChatDraftBoundaries,
+	getChatDraftBoundary,
+} from "../../lib/chat-draft-boundary";
 import { TooltipProvider } from "../ui/tooltip";
 
 const renameSessionMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -1013,6 +1025,7 @@ describe("ChatWorkspace timeline", () => {
 
 		expect(screen.queryByText("The agent controller stopped")).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Resume agent" })).not.toBeInTheDocument();
+		expect(screen.getByTestId("chat-conversation-panel")).toHaveAttribute("inert");
 		// Progress is the topbar spinner; the composer stays empty rather than
 		// painting a second "Connecting…" / "Switching…" label over the editor.
 		expect(screen.queryByText("Connecting to the agent…")).not.toBeInTheDocument();
@@ -1541,7 +1554,11 @@ describe("ChatWorkspace message actions", () => {
 		await user.type(editor, "Replace the first prompt exactly.");
 		await user.click(screen.getByRole("button", { name: "Send edited message" }));
 
-		expect(onEditMessage).toHaveBeenCalledWith("turn-1", "Replace the first prompt exactly.");
+		expect(onEditMessage).toHaveBeenCalledWith(
+			"turn-1",
+			"Replace the first prompt exactly.",
+			expect.any(String),
+		);
 	});
 
 	it("uses the server's first eligible prompt after a provider boundary", () => {
@@ -1730,6 +1747,764 @@ describe("ChatWorkspace message actions", () => {
 		expect(screen.queryByText(/Reconstructed context:/)).not.toBeInTheDocument();
 	});
 
+	it("restores the latest composer text after the same session fully remounts", async () => {
+		const first = idleSnapshot();
+		const draft = "persist every character across a full surface remount";
+		const firstView = render(<ChatWorkspace snapshot={first} onSend={vi.fn()} />);
+		await typeInLexicalEditor(screen.getByLabelText("Message the agent"), draft);
+
+		firstView.unmount();
+		render(
+			<ChatWorkspace
+				snapshot={{ ...first, conversationId: "replacement-controller-conversation" }}
+				onSend={vi.fn()}
+			/>,
+		);
+
+		await waitFor(() =>
+			expect(screen.getByLabelText("Message the agent")).toHaveTextContent(draft),
+		);
+	});
+
+	it("keeps independent composer drafts for remounted sessions", async () => {
+		const sessionA = idleSnapshot();
+		const sessionB = {
+			...sessionA,
+			sessionId: "independent-draft-session",
+			conversationId: "independent-draft-conversation",
+		};
+
+		const firstView = render(<ChatWorkspace snapshot={sessionA} onSend={vi.fn()} />);
+		await typeInLexicalEditor(screen.getByLabelText("Message the agent"), "session A draft");
+		firstView.unmount();
+
+		const secondView = render(<ChatWorkspace snapshot={sessionB} onSend={vi.fn()} />);
+		const secondComposer = screen.getByLabelText("Message the agent");
+		expect(secondComposer).toHaveTextContent("");
+		await typeInLexicalEditor(secondComposer, "session B draft");
+		secondView.unmount();
+
+		const restoredA = render(<ChatWorkspace snapshot={sessionA} onSend={vi.fn()} />);
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("session A draft");
+		restoredA.unmount();
+
+		render(<ChatWorkspace snapshot={sessionB} onSend={vi.fn()} />);
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("session B draft");
+	});
+
+	it("lets only the newest daemon session incarnation own restored drafts", async () => {
+		const snapshot = idleSnapshot();
+		const firstIncarnation = {
+			...chatSession,
+			createdAt: "2026-08-25T09:00:00.000Z",
+		};
+		const replacementIncarnation = {
+			...chatSession,
+			createdAt: "2026-08-26T09:00:00.000Z",
+		};
+		const view = render(
+			<ChatWorkspace
+				snapshot={snapshot}
+				session={firstIncarnation}
+				onSend={vi.fn()}
+			/>,
+		);
+		await typeInLexicalEditor(
+			screen.getByLabelText("Message the agent"),
+			"draft from deleted incarnation",
+		);
+
+		view.rerender(
+			<ChatWorkspace
+				snapshot={snapshot}
+				session={replacementIncarnation}
+				onSend={vi.fn()}
+			/>,
+		);
+		const replacementComposer = await screen.findByLabelText("Message the agent");
+		expect(replacementComposer).toHaveTextContent("");
+		await typeInLexicalEditor(replacementComposer, "replacement draft");
+		await waitFor(() =>
+			expect(
+				readChatSessionDraft({
+					sessionId: snapshot.sessionId,
+					incarnation: replacementIncarnation.createdAt,
+				}).composer.text,
+			).toBe("replacement draft"),
+		);
+
+		view.rerender(
+			<ChatWorkspace
+				snapshot={snapshot}
+				session={firstIncarnation}
+				onSend={vi.fn()}
+			/>,
+		);
+		expect(await screen.findByRole("alert")).toHaveTextContent("older session incarnation");
+		expect(screen.queryByLabelText("Message the agent")).not.toBeInTheDocument();
+		expect(
+			readChatSessionDraft({
+				sessionId: snapshot.sessionId,
+				incarnation: replacementIncarnation.createdAt,
+			}).composer.text,
+		).toBe("replacement draft");
+	});
+
+	it("stays fail-closed until exact incarnation activation storage recovers", async () => {
+		const snapshot = idleSnapshot();
+		const session = {
+			...chatSession,
+			createdAt: "2026-08-26T09:30:00.000Z",
+		};
+		const backing = window.localStorage;
+		let failWrites = true;
+		const storage = {
+			getItem: backing.getItem.bind(backing),
+			removeItem: backing.removeItem.bind(backing),
+			setItem: (key: string, value: string) => {
+				if (failWrites) throw new DOMException("blocked", "SecurityError");
+				backing.setItem(key, value);
+			},
+		} as Storage;
+		const localStorage = vi.spyOn(window, "localStorage", "get").mockReturnValue(storage);
+
+		try {
+			render(<ChatWorkspace snapshot={snapshot} session={session} onSend={vi.fn()} />);
+			expect(await screen.findByRole("alert")).toHaveTextContent(
+				"Chat draft storage could not be activated",
+			);
+			expect(screen.queryByLabelText("Message the agent")).not.toBeInTheDocument();
+
+			failWrites = false;
+			await userEvent.click(screen.getByRole("button", { name: "Retry draft restore" }));
+			const composer = await screen.findByLabelText("Message the agent");
+			await typeInLexicalEditor(composer, "durable after recovery");
+			await waitFor(() =>
+				expect(
+					readChatSessionDraft(
+						{ sessionId: snapshot.sessionId, incarnation: session.createdAt },
+						backing,
+					).composer.text,
+				).toBe("durable after recovery"),
+			);
+		} finally {
+			localStorage.mockRestore();
+		}
+	});
+
+	it("retains a rejected send and removes only the accepted session draft", async () => {
+		const snapshot = idleSnapshot();
+		const onSend = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("offline"))
+			.mockResolvedValueOnce(undefined);
+		const firstView = render(<ChatWorkspace snapshot={snapshot} onSend={onSend} />);
+		const composer = screen.getByLabelText("Message the agent");
+		await typeInLexicalEditor(composer, "retry this exact draft");
+		fireEvent.keyDown(composer, { key: "Enter" });
+		await screen.findByText(/delivery wasn’t confirmed/);
+		const firstClientMessageId = onSend.mock.calls[0]?.[2];
+		expect(firstClientMessageId).toEqual(expect.any(String));
+		firstView.unmount();
+
+		const retryView = render(<ChatWorkspace snapshot={snapshot} onSend={onSend} />);
+		const restored = screen.getByLabelText("Message the agent");
+		expect(restored).toHaveTextContent("retry this exact draft");
+		await userEvent.click(screen.getByRole("button", { name: "Retry message safely" }));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+		expect(onSend.mock.calls[1]?.[2]).toBe(firstClientMessageId);
+		await waitFor(() =>
+			expect(readChatSessionDraft(snapshot.sessionId).composer.text).toBe(""),
+		);
+		await waitFor(() => expect(restored).toHaveTextContent(""));
+		retryView.unmount();
+
+		render(<ChatWorkspace snapshot={snapshot} onSend={onSend} />);
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("");
+	});
+
+	it("locks and clears an accepted composer draft across a same-session remount", async () => {
+		const snapshot = idleSnapshot();
+		let acceptSend!: () => void;
+		const onSend = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					acceptSend = resolve;
+				}),
+		);
+		const firstView = render(<ChatWorkspace snapshot={snapshot} onSend={onSend} />);
+		const firstComposer = screen.getByLabelText("Message the agent");
+		await typeInLexicalEditor(firstComposer, "send exactly once");
+		fireEvent.keyDown(firstComposer, { key: "Enter" });
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+		firstView.unmount();
+
+		render(<ChatWorkspace snapshot={snapshot} onSend={onSend} />);
+		const replacement = screen.getByLabelText("Message the agent");
+		expect(replacement).toHaveTextContent("send exactly once");
+		expect(replacement).toHaveAttribute("contenteditable", "false");
+		fireEvent.keyDown(replacement, { key: "Enter" });
+		expect(onSend).toHaveBeenCalledTimes(1);
+
+		await act(async () => acceptSend());
+		await waitFor(() => expect(replacement).toHaveTextContent(""));
+		expect(readChatSessionDraft(snapshot.sessionId).composer.text).toBe("");
+		expect(getChatComposerMutation(snapshot.sessionId)).toEqual({ pending: false });
+	});
+
+	it("restores an inline edit independently and cancelling it preserves the composer draft", async () => {
+		const user = userEvent.setup();
+		const snapshot = idleSnapshot();
+		const common = {
+			snapshot,
+			onEditMessage: vi.fn(async () => undefined),
+		};
+		const firstView = render(<ChatWorkspace {...common} />);
+		const composer = screen.getByLabelText("Message the agent");
+		await typeInLexicalEditor(composer, "independent composer draft");
+		await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+		const edit = screen.getByRole("textbox", { name: "Edit message" });
+		await user.clear(edit);
+		await user.type(edit, "persist this inline edit");
+		firstView.unmount();
+
+		const restoredView = render(<ChatWorkspace {...common} />);
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent(
+			"independent composer draft",
+		);
+		expect(await screen.findByRole("textbox", { name: "Edit message" })).toHaveValue(
+			"persist this inline edit",
+		);
+		await user.click(screen.getByRole("button", { name: "Cancel edit" }));
+		expect(screen.queryByRole("textbox", { name: "Edit message" })).not.toBeInTheDocument();
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent(
+			"independent composer draft",
+		);
+		restoredView.unmount();
+
+		render(<ChatWorkspace {...common} />);
+		expect(screen.queryByRole("textbox", { name: "Edit message" })).not.toBeInTheDocument();
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent(
+			"independent composer draft",
+		);
+	});
+
+	it("locks and clears an accepted inline edit across a same-session remount", async () => {
+		const user = userEvent.setup();
+		const snapshot = idleSnapshot();
+		let acceptEdit!: () => void;
+		const editPending = new Promise<void>((resolve) => {
+			acceptEdit = resolve;
+		});
+		const onEditMessage = vi.fn(() => editPending);
+		const common = { snapshot, onEditMessage };
+
+		const firstView = render(<ChatWorkspace {...common} />);
+		await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+		const firstEditor = screen.getByRole("textbox", { name: "Edit message" });
+		await user.clear(firstEditor);
+		await user.type(firstEditor, "accepted edit");
+		fireEvent.keyDown(firstEditor, { key: "Enter", ctrlKey: true });
+		await waitFor(() =>
+			expect(onEditMessage).toHaveBeenCalledWith(
+				"turn-1",
+				"accepted edit",
+				expect.any(String),
+			),
+		);
+		firstView.unmount();
+
+		render(<ChatWorkspace {...common} />);
+		const remountedEditor = await screen.findByRole("textbox", { name: "Edit message" });
+		expect(remountedEditor).toBeDisabled();
+		expect(remountedEditor).toHaveValue("accepted edit");
+
+		await act(async () => acceptEdit());
+		await waitFor(() =>
+			expect(screen.queryByRole("textbox", { name: "Edit message" })).not.toBeInTheDocument(),
+		);
+		expect(readChatSessionDraft(snapshot.sessionId).inlineEdit).toBeUndefined();
+		expect(getChatInlineEditMutation(snapshot.sessionId)).toEqual({ pending: false });
+	});
+
+	it("durably unlocks a definitively rejected inline edit without consuming its text", async () => {
+		const user = userEvent.setup();
+		const snapshot = idleSnapshot();
+		const onEditMessage = vi.fn(async () => ({
+			status: "not-accepted" as const,
+			reason: "The provider rejected this edit before accepting it.",
+		}));
+		const first = render(<ChatWorkspace snapshot={snapshot} onEditMessage={onEditMessage} />);
+		await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+		const editor = screen.getByRole("textbox", { name: "Edit message" });
+		await user.clear(editor);
+		await user.type(editor, "preserve rejected edit");
+		await user.click(screen.getByRole("button", { name: "Send edited message" }));
+
+		await waitFor(() => expect(onEditMessage).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(editor).not.toBeDisabled());
+		expect(editor).toHaveValue("preserve rejected edit");
+		expect(screen.getByRole("alert")).toHaveTextContent("provider rejected this edit");
+		expect(screen.queryByRole("button", { name: "Retry edit safely" })).not.toBeInTheDocument();
+		expect(readChatSessionDraft(snapshot.sessionId).inlineEditDelivery).toBeUndefined();
+		first.unmount();
+
+		render(<ChatWorkspace snapshot={snapshot} onEditMessage={onEditMessage} />);
+		expect(await screen.findByRole("textbox", { name: "Edit message" })).toHaveValue(
+			"preserve rejected edit",
+		);
+		expect(screen.queryByRole("button", { name: "Retry edit safely" })).not.toBeInTheDocument();
+		expect(onEditMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("warns before explicitly abandoning uncertain inline-edit recovery after remount", async () => {
+		const user = userEvent.setup();
+		const snapshot = idleSnapshot();
+		const onEditMessage = vi.fn().mockRejectedValue(new Error("outcome unknown"));
+		const common = { snapshot, onEditMessage };
+		const first = render(<ChatWorkspace {...common} />);
+		await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+		const editor = screen.getByRole("textbox", { name: "Edit message" });
+		await user.clear(editor);
+		await user.type(editor, "possibly delivered edit");
+		await user.click(screen.getByRole("button", { name: "Send edited message" }));
+
+		await waitFor(() => expect(onEditMessage).toHaveBeenCalledTimes(1));
+		await waitFor(() =>
+			expect(screen.getByRole("alert")).toHaveTextContent("may already have been delivered"),
+		);
+		expect(screen.getByRole("alert")).toHaveTextContent("may duplicate it");
+		first.unmount();
+
+		render(<ChatWorkspace {...common} />);
+		const restored = await screen.findByRole("textbox", { name: "Edit message" });
+		expect(restored).toBeDisabled();
+		expect(restored).toHaveValue("possibly delivered edit");
+		expect(onEditMessage).toHaveBeenCalledTimes(1);
+		await user.click(screen.getByRole("button", { name: "Abandon edit recovery" }));
+
+		await waitFor(() => expect(restored).not.toBeDisabled());
+		expect(restored).toHaveValue("possibly delivered edit");
+		expect(onEditMessage).toHaveBeenCalledTimes(1);
+		expect(screen.queryByRole("button", { name: "Retry edit safely" })).not.toBeInTheDocument();
+		expect(screen.getByRole("alert")).toHaveTextContent("may already have been delivered");
+		expect(readChatSessionDraft(snapshot.sessionId).inlineEditDelivery).toBeUndefined();
+	});
+
+	it("reports a restored inline delivery as pending recovery without claiming persistence failed", async () => {
+		const snapshot = {
+			...idleSnapshot(),
+			sessionId: "inline-edit-restored-delivery-boundary",
+		};
+		prepareChatInlineEditDelivery(snapshot.sessionId, {
+			turnId: "turn-1",
+			text: "recover this edit",
+			content: [],
+			clientMessageId: "inline-edit-restored-delivery-id",
+		});
+
+		render(<ChatWorkspace snapshot={snapshot} onEditMessage={vi.fn()} />);
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"earlier edit may already have been delivered before Chat restarted",
+		);
+		await waitFor(() => expect(getChatDraftBoundary(snapshot.sessionId)).toBeUndefined());
+	});
+
+	it("reconciles an accepted inline delivery without clearing or blocking a later edit", async () => {
+		const user = userEvent.setup();
+		const snapshot = idleSnapshot();
+		let acceptEdit!: () => void;
+		const onEditMessage = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					acceptEdit = resolve;
+				}),
+		);
+		const first = render(<ChatWorkspace snapshot={snapshot} onEditMessage={onEditMessage} />);
+		await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+		const editor = screen.getByRole("textbox", { name: "Edit message" });
+		await user.clear(editor);
+		await user.type(editor, "submitted edit revision");
+		fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+		await waitFor(() => expect(onEditMessage).toHaveBeenCalledTimes(1));
+		first.unmount();
+		writeChatInlineEdit(snapshot.sessionId, {
+			turnId: "turn-1",
+			text: "later edit revision",
+			content: [],
+		});
+
+		render(<ChatWorkspace snapshot={snapshot} onEditMessage={onEditMessage} />);
+		const restored = await screen.findByRole("textbox", { name: "Edit message" });
+		expect(restored).toHaveValue("later edit revision");
+		expect(restored).toBeDisabled();
+
+		await act(async () => acceptEdit());
+		await waitFor(() => expect(restored).not.toBeDisabled());
+		expect(restored).toHaveValue("later edit revision");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		await waitFor(() => expect(getChatDraftBoundary(snapshot.sessionId)).toBeUndefined());
+	});
+
+	it("does not expose an accepted inline edit when a hidden replacement committed a later revision", async () => {
+		const snapshot = idleSnapshot();
+		let acceptFirstEdit!: () => void;
+		const firstEditPending = new Promise<void>((resolve) => {
+			acceptFirstEdit = resolve;
+		});
+		const onEditMessage = vi
+			.fn()
+			.mockImplementationOnce(() => firstEditPending)
+			.mockResolvedValue(undefined);
+		const common = { snapshot, onEditMessage };
+		const surfaces = (
+			showOriginal: boolean,
+			replacementMode?: "hidden" | "visible",
+		) => (
+			<>
+				{showOriginal ? (
+					<div data-testid="original-inline-edit-surface">
+						<ChatWorkspace {...common} />
+					</div>
+				) : null}
+				{replacementMode ? (
+					<Activity key="replacement" mode={replacementMode}>
+						<div data-testid="replacement-inline-edit-surface">
+							<ChatWorkspace {...common} />
+						</div>
+					</Activity>
+				) : null}
+			</>
+		);
+
+		const view = render(surfaces(true));
+		const originalSurface = within(screen.getByTestId("original-inline-edit-surface"));
+		fireEvent.click(originalSurface.getAllByRole("button", { name: "Edit user message" })[0]!);
+		const originalEditor = originalSurface.getByRole("textbox", { name: "Edit message" });
+		fireEvent.change(originalEditor, { target: { value: "accepted inline edit" } });
+
+		// Mount once before hiding so React preserves a replacement editor whose local
+		// state was seeded from the exact revision that is about to be accepted.
+		await act(async () => {
+			view.rerender(surfaces(true, "visible"));
+		});
+		const replacementSurface = within(
+			await screen.findByTestId("replacement-inline-edit-surface"),
+		);
+		expect(replacementSurface.getByRole("textbox", { name: "Edit message" })).toHaveValue(
+			"accepted inline edit",
+		);
+		await act(async () => {
+			view.rerender(surfaces(true, "hidden"));
+		});
+
+		// The edit event was already queued when submission locked the surface. React
+		// processes both in one batch: A is delivered, while B becomes the later durable
+		// revision that accepted-clear must preserve.
+		await act(async () => {
+			fireEvent.keyDown(originalEditor, { key: "Enter", ctrlKey: true });
+			fireEvent.change(originalEditor, { target: { value: "later inline edit" } });
+		});
+		await waitFor(() =>
+			expect(onEditMessage).toHaveBeenCalledWith(
+				"turn-1",
+				"accepted inline edit",
+				expect.any(String),
+			),
+		);
+		expect(readChatSessionDraft(snapshot.sessionId).inlineEdit?.text).toBe(
+			"later inline edit",
+		);
+
+		await act(async () => acceptFirstEdit());
+		await waitFor(() => expect(originalEditor).not.toBeDisabled());
+		expect(originalEditor).toHaveValue("later inline edit");
+		expect(readChatSessionDraft(snapshot.sessionId).inlineEdit?.text).toBe(
+			"later inline edit",
+		);
+		expect(getChatInlineEditMutation(snapshot.sessionId)).toEqual({ pending: false });
+
+		await act(async () => {
+			view.rerender(surfaces(false, "visible"));
+		});
+		const committedReplacement = within(
+			screen.getByTestId("replacement-inline-edit-surface"),
+		).getByRole("textbox", { name: "Edit message" });
+		await waitFor(() => expect(committedReplacement).toHaveValue("later inline edit"));
+		expect(onEditMessage).toHaveBeenCalledTimes(1);
+
+		fireEvent.keyDown(committedReplacement, { key: "Enter", ctrlKey: true });
+		await waitFor(() => expect(onEditMessage).toHaveBeenCalledTimes(2));
+		expect(onEditMessage.mock.calls[1]).toEqual([
+			"turn-1",
+			"later inline edit",
+			expect.any(String),
+		]);
+		expect(onEditMessage.mock.calls[1]?.[2]).not.toBe(onEditMessage.mock.calls[0]?.[2]);
+		await waitFor(() => expect(committedReplacement).not.toBeInTheDocument());
+	});
+
+	it("locks an accepted inline edit whose durable clear failed and clears without redispatch", async () => {
+		const user = userEvent.setup();
+		const snapshot = idleSnapshot();
+		const durableStorage = window.localStorage;
+		let failRemoval = true;
+		const storage = {
+			getItem: durableStorage.getItem.bind(durableStorage),
+			setItem: durableStorage.setItem.bind(durableStorage),
+			removeItem: (key: string) => {
+				if (failRemoval) throw new DOMException("blocked", "SecurityError");
+				durableStorage.removeItem(key);
+			},
+		} as unknown as Storage;
+		const localStorage = vi.spyOn(window, "localStorage", "get").mockReturnValue(storage);
+		const onEditMessage = vi.fn(async () => undefined);
+		const view = render(<ChatWorkspace snapshot={snapshot} onEditMessage={onEditMessage} />);
+		try {
+			await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+			const editor = screen.getByRole("textbox", { name: "Edit message" });
+			await user.clear(editor);
+			await user.type(editor, "accepted but not cleared");
+			fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+			await waitFor(() => expect(onEditMessage).toHaveBeenCalledTimes(1));
+			expect(await screen.findByRole("alert")).toHaveTextContent("couldn’t be cleared");
+			expect(getChatDraftBoundaries(snapshot.sessionId)).toEqual([
+				"persistence-failed",
+			]);
+
+			fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+			expect(onEditMessage).toHaveBeenCalledTimes(1);
+
+			expect(editor).toBeDisabled();
+			failRemoval = false;
+			await user.click(
+				screen.getByRole("button", { name: "Finish clearing accepted edit" }),
+			);
+			await waitFor(() => expect(editor).not.toBeInTheDocument());
+			expect(onEditMessage).toHaveBeenCalledTimes(1);
+
+			await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+			const nextEditor = screen.getByRole("textbox", { name: "Edit message" });
+			await user.clear(nextEditor);
+			await user.type(nextEditor, "new edit after recovery");
+			fireEvent.keyDown(nextEditor, { key: "Enter", ctrlKey: true });
+			await waitFor(() => expect(onEditMessage).toHaveBeenCalledTimes(2));
+		} finally {
+			view.unmount();
+			localStorage.mockRestore();
+		}
+	});
+
+	it.each(["read", "write"] as const)(
+		"does not dispatch an inline edit until its exact draft survives a storage %s failure",
+		async (failure) => {
+			const user = userEvent.setup();
+			const snapshot = idleSnapshot();
+			const durableStorage = window.localStorage;
+			let storageAvailable = true;
+			const storage = {
+				getItem: (key: string) => {
+					if (!storageAvailable && failure === "read") {
+						throw new DOMException("blocked", "SecurityError");
+					}
+					return durableStorage.getItem(key);
+				},
+				setItem: (key: string, value: string) => {
+					if (!storageAvailable && failure === "write") {
+						throw new DOMException("full", "QuotaExceededError");
+					}
+					durableStorage.setItem(key, value);
+				},
+				removeItem: durableStorage.removeItem.bind(durableStorage),
+			} as Storage;
+			const localStorage = vi.spyOn(window, "localStorage", "get").mockReturnValue(storage);
+			const onEditMessage = vi.fn(async () => undefined);
+			const view = render(<ChatWorkspace snapshot={snapshot} onEditMessage={onEditMessage} />);
+			try {
+				await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+				const editor = screen.getByRole("textbox", { name: "Edit message" });
+				await user.clear(editor);
+				await user.type(editor, "prove exact inline edit");
+				storageAvailable = false;
+				fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+
+				await waitFor(() =>
+					expect(screen.getByRole("alert")).toHaveTextContent("Nothing was sent"),
+				);
+				expect(onEditMessage).not.toHaveBeenCalled();
+
+				storageAvailable = true;
+				fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+				await waitFor(() => expect(onEditMessage).toHaveBeenCalledTimes(1));
+				expect(onEditMessage).toHaveBeenCalledWith(
+					"turn-1",
+					"prove exact inline edit",
+					expect.any(String),
+				);
+			} finally {
+				view.unmount();
+				localStorage.mockRestore();
+			}
+		},
+	);
+
+	it("blocks destructive boundaries when an inline edit cannot be persisted", async () => {
+		const user = userEvent.setup();
+		const snapshot = idleSnapshot();
+		const durableStorage = window.localStorage;
+		const storage = {
+			getItem: durableStorage.getItem.bind(durableStorage),
+			removeItem: durableStorage.removeItem.bind(durableStorage),
+			setItem: (key: string, value: string) => {
+				if (key.includes(encodeURIComponent(snapshot.sessionId))) {
+					throw new DOMException("full", "QuotaExceededError");
+				}
+				durableStorage.setItem(key, value);
+			},
+		} as Storage;
+		const localStorage = vi.spyOn(window, "localStorage", "get").mockReturnValue(storage);
+		const view = render(
+			<ChatWorkspace snapshot={snapshot} onEditMessage={vi.fn(async () => undefined)} />,
+		);
+		try {
+			await user.click(screen.getAllByRole("button", { name: "Edit user message" })[0]!);
+			await waitFor(() =>
+				expect(getChatDraftBoundary(snapshot.sessionId)).toBe("persistence-failed"),
+			);
+			expect(screen.getByRole("alert")).toHaveTextContent("Inline edit couldn’t be saved");
+		} finally {
+			view.unmount();
+			localStorage.mockRestore();
+		}
+		expect(getChatDraftBoundary(snapshot.sessionId)).toBeUndefined();
+	});
+
+	it("carries pending attachment staging through a same-session remount", async () => {
+		const snapshot = idleSnapshot();
+		let finishStaging!: (paths: string[]) => void;
+		const onStageAttachments = vi.fn(
+			() =>
+				new Promise<string[]>((resolve) => {
+					finishStaging = resolve;
+				}),
+		);
+		const common = { snapshot, onSend: vi.fn(), onStageAttachments };
+		const firstView = render(<ChatWorkspace {...common} />);
+		fireEvent.paste(screen.getByLabelText("Message the agent"), {
+			clipboardData: {
+				files: [new File([new Uint8Array([1, 2, 3])], "pending.txt", { type: "text/plain" })],
+				items: [],
+			},
+		});
+		await waitFor(() => expect(onStageAttachments).toHaveBeenCalledTimes(1));
+		expect(screen.getByRole("status")).toHaveTextContent("Saving attachments");
+		firstView.unmount();
+
+		render(<ChatWorkspace {...common} />);
+		expect(screen.getByRole("status")).toHaveTextContent("Saving attachments");
+		await act(async () => finishStaging([".ao/attachments/attachment-pending.txt"]));
+
+		expect(await screen.findByLabelText("Remove pending.txt")).toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByText("Saving attachments… Wait before leaving this chat.")).toBeNull());
+		expect(readChatSessionDraft(snapshot.sessionId).composer.attachments).toEqual([
+			expect.objectContaining({
+				name: "pending.txt",
+				path: ".ao/attachments/attachment-pending.txt",
+			}),
+		]);
+	});
+
+	it("keeps the replacement surface unsafe when remounted attachment persistence fails", async () => {
+		const snapshot = idleSnapshot();
+		const durableStorage = window.localStorage;
+		const storage = {
+			getItem: durableStorage.getItem.bind(durableStorage),
+			removeItem: durableStorage.removeItem.bind(durableStorage),
+			setItem: (key: string, value: string) => {
+				if (key.includes(encodeURIComponent(snapshot.sessionId))) {
+					throw new DOMException("full", "QuotaExceededError");
+				}
+				durableStorage.setItem(key, value);
+			},
+		} as Storage;
+		const localStorage = vi.spyOn(window, "localStorage", "get").mockReturnValue(storage);
+		let finishStaging!: (paths: string[]) => void;
+		const onStageAttachments = vi.fn(
+			() =>
+				new Promise<string[]>((resolve) => {
+					finishStaging = resolve;
+				}),
+		);
+		const common = { snapshot, onSend: vi.fn(), onStageAttachments };
+		const firstView = render(<ChatWorkspace {...common} />);
+		fireEvent.paste(screen.getByLabelText("Message the agent"), {
+			clipboardData: {
+				files: [new File([new Uint8Array([1])], "unsafe.txt", { type: "text/plain" })],
+				items: [],
+			},
+		});
+		await waitFor(() => expect(onStageAttachments).toHaveBeenCalledTimes(1));
+		firstView.unmount();
+		await act(async () => {
+			finishStaging([".ao/attachments/attachment-unsafe.txt"]);
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		const replacement = render(<ChatWorkspace {...common} />);
+		try {
+			expect(await screen.findByLabelText("Remove unsafe.txt")).toBeInTheDocument();
+			expect(await screen.findByRole("alert")).toHaveTextContent("Draft couldn’t be saved");
+			await waitFor(() =>
+				expect(getChatDraftBoundary(snapshot.sessionId)).toBe("persistence-failed"),
+			);
+		} finally {
+			replacement.unmount();
+			localStorage.mockRestore();
+		}
+	});
+
+	it("restores only durably staged attachments and does not resurrect them after an accepted send", async () => {
+		const snapshot = idleSnapshot();
+		const onStageAttachments = vi.fn(async () => [
+			".ao/attachments/attachment-durable.png",
+		]);
+		const onSend = vi.fn(async (_text: string) => undefined);
+		const common = { snapshot, onSend, onStageAttachments };
+		const firstView = render(<ChatWorkspace {...common} />);
+		const composer = screen.getByLabelText("Message the agent");
+		fireEvent.paste(composer, {
+			clipboardData: {
+				files: [
+					new File([new Uint8Array([137, 80, 78, 71])], "durable.png", {
+						type: "image/png",
+					}),
+				],
+				items: [],
+			},
+		});
+		await waitFor(() => expect(onStageAttachments).toHaveBeenCalledTimes(1));
+		await screen.findByLabelText("Remove durable.png");
+		firstView.unmount();
+
+		const restoredView = render(<ChatWorkspace {...common} />);
+		expect(await screen.findByLabelText("Remove durable.png")).toBeInTheDocument();
+		const restoredComposer = screen.getByLabelText("Message the agent");
+		await typeInLexicalEditor(restoredComposer, "send the restored attachment");
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+		expect(onSend.mock.calls[0]?.[0]).toContain(
+			".ao/attachments/attachment-durable.png",
+		);
+		expect(onStageAttachments).toHaveBeenCalledTimes(1);
+		restoredView.unmount();
+
+		render(<ChatWorkspace {...common} />);
+		expect(screen.queryByLabelText("Remove durable.png")).not.toBeInTheDocument();
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("");
+	});
+
 	it("copies a human message as the exact text the user sent", async () => {
 		const user = userEvent.setup();
 		render(<ChatWorkspace snapshot={chatFixture} />);
@@ -1773,6 +2548,7 @@ describe("ChatWorkspace message actions", () => {
 			expect(onEditMessage).toHaveBeenCalledWith(
 				"turn-1",
 				"Check worktree state, including staged files.",
+				expect.any(String),
 			),
 		);
 		expect(onRollback).not.toHaveBeenCalled();
@@ -1808,7 +2584,13 @@ describe("ChatWorkspace message actions", () => {
 		await user.type(editor, "keep this draft");
 		fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
 
-		await waitFor(() => expect(onEditMessage).toHaveBeenCalledWith("turn-2", "keep this draft"));
+		await waitFor(() =>
+			expect(onEditMessage).toHaveBeenCalledWith(
+				"turn-2",
+				"keep this draft",
+				expect.any(String),
+			),
+		);
 		expect(screen.getByRole("textbox", { name: "Edit message" })).toHaveValue("keep this draft");
 		expect(screen.getByRole("alert")).toHaveTextContent("branch failed");
 		expect(screen.getByText(/Reconstructed context:/)).toBeVisible();
@@ -1829,7 +2611,8 @@ describe("ChatWorkspace message actions", () => {
 		expect(screen.getByText(/Reconstructed context:/)).toBeVisible();
 
 		// An ambiguous provider failure can durably activate the replacement branch.
-		// Once that refetch arrives, the source-branch draft is stale and must close.
+		// Keep its journal actionable when that branch refetch arrives: the user still
+		// needs the exact editor to retry with the same ID or abandon recovery.
 		view.rerender(
 			<ChatWorkspace
 				snapshot={{
@@ -1843,8 +2626,13 @@ describe("ChatWorkspace message actions", () => {
 				editMessageError="branch failed"
 			/>,
 		);
+		const recoveringEditor = await screen.findByRole("textbox", { name: "Edit message" });
+		expect(recoveringEditor).toBeDisabled();
+		expect(recoveringEditor).toHaveValue("keep this draft");
+		expect(screen.getByRole("button", { name: "Retry edit safely" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Abandon edit recovery" })).toBeInTheDocument();
 		await waitFor(() =>
-			expect(screen.queryByRole("textbox", { name: "Edit message" })).not.toBeInTheDocument(),
+			expect(getChatDraftBoundary(approximateSnapshot.sessionId)).toBeUndefined(),
 		);
 	});
 
@@ -2023,7 +2811,9 @@ describe("ChatWorkspace reviewer tabs", () => {
 			onOpenReviewerTerminal: vi.fn(),
 			onSelectChat: vi.fn(),
 			onEditMessage: vi.fn(async () => undefined),
-			onStageAttachments: vi.fn(async () => [".ao/attachments/review.png"]),
+			onStageAttachments: vi.fn(async () => [
+				".ao/attachments/attachment-review.png",
+			]),
 		};
 		const view = render(<ChatWorkspace {...common} />);
 		const composer = screen.getByRole("combobox", {
@@ -2434,5 +3224,110 @@ describe("ChatWorkspace shell tabs", () => {
 		expect(closeShellTerminalShortcutStates.at(-1)).toBe(true);
 		act(() => [...closeShellTerminalListeners][0]?.());
 		expect(onClose).toHaveBeenCalledOnce();
+	});
+});
+
+describe("durable queued edits", () => {
+	function queuedSnapshot(): ConversationSnapshot {
+		return {
+			...chatFixtureEmpty,
+			sessionId: "queued-draft-session",
+			turns: [
+				{ id: "running", state: "running", requestedAt: "2026-09-07T00:00:00Z" },
+				{ id: "queued", state: "queued", requestedAt: "2026-09-07T00:00:00Z" },
+			],
+			items: [{ kind: "message", id: "queued-message", turnId: "queued", role: "user", origin: "human", streaming: false, text: "queued text", sequence: 1, revision: 0, createdAt: "2026-09-07T00:00:00Z" }],
+		};
+	}
+
+	it("restores the queue target across remount and keeps the independent composer after accepted save", async () => {
+		const snapshot = queuedSnapshot();
+		const save = vi.fn().mockResolvedValue(undefined);
+		const send = vi.fn();
+		const props = { snapshot, onSend: send, onEditQueuedTurn: save };
+		const first = render(<ChatWorkspace {...props} />);
+		await typeInLexicalEditor(screen.getByLabelText("Message the agent"), "independent prompt");
+		await userEvent.click(screen.getByRole("button", { name: "Edit queued message" }));
+		await typeInLexicalEditor(screen.getByLabelText("Message the agent"), " updated");
+		expect(readChatSessionDraft(snapshot.sessionId).composer.text).toBe("independent prompt");
+		expect(readChatSessionDraft(snapshot.sessionId).queuedEdit?.text).toBe("queued text updated");
+		first.unmount();
+		const second = render(<ChatWorkspace {...props} />);
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("queued text updated");
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() => expect(save).toHaveBeenCalledWith("queued", "queued text updated", { clientMessageId: expect.any(String), expectedRevision: 0, retainedContent: [] }));
+		await waitFor(() => expect(readChatSessionDraft(snapshot.sessionId).queuedEdit).toBeUndefined());
+		expect(send).not.toHaveBeenCalled();
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("independent prompt");
+		second.unmount();
+		render(<ChatWorkspace {...props} />);
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("independent prompt");
+	});
+
+	it("finishes an ordinary send before allowing a queued editor to replace it", async () => {
+		const snapshot = queuedSnapshot();
+		let settle!: (paths: string[]) => void;
+		const stage = vi.fn(() => new Promise<string[]>((resolve) => { settle = resolve; }));
+		const save = vi.fn();
+		const send = vi.fn().mockResolvedValue(undefined);
+		render(<ChatWorkspace snapshot={snapshot} onSend={send} onEditQueuedTurn={save} onStageAttachments={stage} />);
+		const composer = screen.getByLabelText("Message the agent");
+		await typeInLexicalEditor(composer, "ordinary prompt");
+		fireEvent.paste(composer, { clipboardData: { files: [new File(["file"], "note.txt", { type: "text/plain" })], items: [] } });
+		await waitFor(() => expect(stage).toHaveBeenCalledOnce());
+		fireEvent.keyDown(composer, { key: "Enter" });
+		expect(screen.getByRole("button", { name: "Edit queued message" })).toBeDisabled();
+		await act(async () => settle([".ao/attachments/note.txt"]));
+		await waitFor(() => expect(send).toHaveBeenCalledOnce());
+		expect(send.mock.calls[0]?.[0]).toContain("ordinary prompt");
+		await waitFor(() => expect(screen.getByRole("button", { name: "Edit queued message" })).toBeEnabled());
+		await userEvent.click(screen.getByRole("button", { name: "Edit queued message" }));
+		expect(save).not.toHaveBeenCalled();
+		expect(readChatSessionDraft(snapshot.sessionId).queuedEdit?.text).toBe("queued text");
+		expect(readChatSessionDraft(snapshot.sessionId).composer.text).toBe("");
+	});
+
+	it("keeps queued text visible when durable cancellation fails", async () => {
+		const snapshot = queuedSnapshot();
+		render(<ChatWorkspace snapshot={snapshot} onSend={vi.fn()} onEditQueuedTurn={vi.fn()} />);
+		await userEvent.click(screen.getByRole("button", { name: "Edit queued message" }));
+		const composer = screen.getByLabelText("Message the agent");
+		await typeInLexicalEditor(composer, " keep this");
+		const durableStorage = window.localStorage;
+		const storage = vi.spyOn(window, "localStorage", "get").mockReturnValue({
+			length: 0,
+			clear: durableStorage.clear.bind(durableStorage),
+			key: () => null,
+			getItem: durableStorage.getItem.bind(durableStorage),
+			setItem: () => { throw new DOMException("full", "QuotaExceededError"); },
+			removeItem: () => { throw new DOMException("blocked", "SecurityError"); },
+		});
+		try {
+			fireEvent.keyDown(composer, { key: "Escape" });
+			expect(composer).toHaveTextContent("queued text keep this");
+			expect(readChatSessionDraft(snapshot.sessionId).queuedEdit?.text).toBe("queued text keep this");
+			expect(screen.getByRole("alert")).toHaveTextContent("Queued edit could not be saved");
+		} finally { storage.mockRestore(); }
+	});
+
+	it("preserves an unavailable queue target and never converts its recovery into a send", async () => {
+		const snapshot = queuedSnapshot();
+		const save = vi.fn().mockRejectedValue(new Error("response lost"));
+		const send = vi.fn();
+		const first = render(<ChatWorkspace snapshot={snapshot} onSend={send} onEditQueuedTurn={save} />);
+		await userEvent.click(screen.getByRole("button", { name: "Edit queued message" }));
+		await typeInLexicalEditor(screen.getByLabelText("Message the agent"), " uncertain");
+		await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+		await waitFor(() => expect(save).toHaveBeenCalledOnce());
+		first.unmount();
+		render(<ChatWorkspace snapshot={{ ...snapshot, turns: [] }} onSend={send} onEditQueuedTurn={save} />);
+		expect(screen.getByLabelText("Message the agent")).toHaveTextContent("queued text uncertain");
+		expect(screen.getByLabelText("Message the agent")).toHaveAttribute("contenteditable", "false");
+		await userEvent.click(screen.getByRole("button", { name: "Retry edit safely" }));
+		await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+		expect(save.mock.calls[1]).toEqual(save.mock.calls[0]);
+		expect(send).not.toHaveBeenCalled();
+		fireEvent.keyDown(screen.getByLabelText("Message the agent"), { key: "Escape" });
+		await waitFor(() => expect(readChatSessionDraft(snapshot.sessionId).queuedEdit).toBeUndefined());
 	});
 });

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -3327,7 +3327,9 @@ describe("durable queued edits", () => {
 		await waitFor(() => expect(save).toHaveBeenCalledTimes(2));
 		expect(save.mock.calls[1]).toEqual(save.mock.calls[0]);
 		expect(send).not.toHaveBeenCalled();
+		const pending = readChatSessionDraft(snapshot.sessionId).queuedEdit;
+		expect(pending?.clientMessageId).toBeTruthy();
 		fireEvent.keyDown(screen.getByLabelText("Message the agent"), { key: "Escape" });
-		await waitFor(() => expect(readChatSessionDraft(snapshot.sessionId).queuedEdit).toBeUndefined());
+		expect(readChatSessionDraft(snapshot.sessionId).queuedEdit).toEqual(pending);
 	});
 });

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1,4 +1,3 @@
-import type { ConversationContentSummary } from "../../types/conversation";
 import { useChatDraftTranslation } from "../../lib/chat-draft-messages";
 /**
  * The Chat surface for a session whose persisted mode is `chat`.
@@ -35,15 +34,30 @@ import { Reorder, useDragControls } from "motion/react";
 import { useTranslation } from "react-i18next";
 import { cn } from "../../lib/utils";
 import {
+	acknowledgeChatInlineEditMutation,
+	beginChatInlineEditMutation,
+	cancelChatInlineEditMutation,
+	clearAcceptedChatInlineEdit,
+	clearRejectedChatInlineEditDelivery,
+	clearUncertainChatInlineEditDelivery,
+	finishChatInlineEditMutation,
+	getChatInlineEditMutation,
+	markChatInlineEditDeliveryAccepted,
+	prepareChatInlineEditDelivery,
 	activateChatDraftScope,
 	chatDraftScopeKey,
 	chatQueuedAttachmentScopeKey,
 	readChatSessionDraft,
+	subscribeChatDraftRuntime,
+	writeChatInlineEdit,
 	writeChatQueuedEdit,
 	type ChatDraftQueuedEdit,
 	type ChatDraftAttachment,
 	type ChatDraftRetainedAttachment,
+	type DraftClearResult,
+	type ChatDraftInlineEdit,
 	type ChatDraftScope,
+	type ChatInlineEditDelivery,
 } from "../../lib/chat-drafts";
 import { purgeFileAttachments, purgeFileAttachmentsForSession } from "../../hooks/useFileAttachments";
 import { setChatDraftBoundary } from "../../lib/chat-draft-boundary";
@@ -117,6 +131,7 @@ import {
 	type ChatModel,
 	type ChatSkill,
 	type ChatSteerOutcome,
+	type ChatEditOutcome,
 	type ConversationActivity,
 	type ConversationBranchPoint,
 	type ConversationItem,
@@ -190,12 +205,7 @@ type TopbarBounds = {
 	width: number;
 };
 
-type MessageEditDraft = {
-	turnId: string;
-	text: string;
-	content: ConversationContentSummary[];
-	reconstructedContext: boolean;
-};
+type MessageEditDraft = ChatDraftInlineEdit;
 
 /**
  * A stream refresh replaces the complete snapshot object. Queue prompts do not
@@ -350,7 +360,11 @@ export interface ChatWorkspaceProps {
 	 */
 	retryControl?: ChatRetryControl;
 	/** Create a conversation branch by replacing a prior human prompt. */
-	onEditMessage?: (turnId: string, text: string) => void | Promise<unknown>;
+	onEditMessage?: (
+		turnId: string,
+		text: string,
+		clientMessageId?: string,
+	) => void | ChatEditOutcome | Promise<ChatEditOutcome | void>;
 	editMessagePending?: boolean;
 	editMessageError?: string;
 	/** Switch the visible conversation to another branch. */
@@ -1352,6 +1366,7 @@ function ChatWorkspaceContent({
 							<Timeline
 								key={draftScopeKey}
 								snapshot={snapshot}
+								draftScope={draftScope}
 								hasOlder={hasOlder}
 								loadingOlder={loadingOlder}
 								onLoadOlder={onLoadOlder}
@@ -1903,6 +1918,7 @@ function ControllerBanner({
  */
 function Timeline({
 	snapshot,
+	draftScope,
 	hasOlder,
 	loadingOlder,
 	onLoadOlder,
@@ -1923,6 +1939,7 @@ function Timeline({
 	newWorkDisabled,
 }: {
 	snapshot: ConversationSnapshot;
+	draftScope: ChatDraftScope;
 	hasOlder?: boolean;
 	loadingOlder?: boolean;
 	onLoadOlder?: () => void;
@@ -1933,7 +1950,7 @@ function Timeline({
 	onOpenFiles?: () => void;
 	onOpenFile?: (path: string) => void;
 	retryControl?: ChatRetryControl;
-	onEditHumanMessage?: (turnId: string, text: string) => Promise<unknown> | void;
+	onEditHumanMessage?: ChatWorkspaceProps["onEditMessage"];
 	editPending?: boolean;
 	editBusy?: boolean;
 	editError?: string;
@@ -1942,6 +1959,7 @@ function Timeline({
 	activateBranchError?: string;
 	newWorkDisabled?: boolean;
 }) {
+	const translateDraft = useChatDraftTranslation();
 	const scroller = useRef<HTMLDivElement>(null);
 	const scrollContent = useRef<HTMLDivElement>(null);
 	const promptSpacer = useRef<HTMLDivElement>(null);
@@ -1954,7 +1972,65 @@ function Timeline({
 	const pinnedRef = useRef(true);
 	const [pinned, setPinned] = useState(true);
 	const [hoveredMarker, setHoveredMarker] = useState<number | null>(null);
-	const [messageEdit, setMessageEdit] = useState<MessageEditDraft>();
+	const [messageEdit, setMessageEdit] = useState<MessageEditDraft | undefined>(
+		() => readChatSessionDraft(draftScope).inlineEdit,
+	);
+	const messageEditRef = useRef(messageEdit);
+	const [durableInlineEditDelivery, setDurableInlineEditDelivery] =
+		useState<ChatInlineEditDelivery | undefined>(
+			() => readChatSessionDraft(draftScope).inlineEditDelivery,
+		);
+	const [inlineEditUncertain, setInlineEditUncertain] = useState(
+		() => readChatSessionDraft(draftScope).inlineEditDelivery?.state === "dispatching",
+	);
+	const automaticInlineRecoveryAttempted = useRef<string | undefined>(undefined);
+	const [draftPersistenceError, setDraftPersistenceError] = useState<string>();
+	const [inlineEditRecoveryNotice, setInlineEditRecoveryNotice] = useState<string>();
+	const [inlineEditOutcomeNotice, setInlineEditOutcomeNotice] = useState<string>();
+	const subscribeInlineEditMutation = useCallback(
+		(listener: () => void) => subscribeChatDraftRuntime(draftScope, listener),
+		[draftScope],
+	);
+	const getInlineEditMutation = useCallback(
+		() => getChatInlineEditMutation(draftScope),
+		[draftScope],
+	);
+	const inlineEditMutation = useSyncExternalStore(
+		subscribeInlineEditMutation,
+		getInlineEditMutation,
+		getInlineEditMutation,
+	);
+	const [appliedEditAcceptanceSequence, setAppliedEditAcceptanceSequence] = useState(0);
+	const acceptedEditWaiting = Boolean(
+		inlineEditMutation.accepted &&
+			inlineEditMutation.accepted.sequence > appliedEditAcceptanceSequence,
+	);
+	const acceptedEditClearFailed = inlineEditMutation.accepted?.result.ok === false;
+	const inlineEditPending = Boolean(editPending) || inlineEditMutation.pending || acceptedEditWaiting;
+	const inlineEditLocked = inlineEditPending || Boolean(durableInlineEditDelivery);
+	const inlineEditSendBlocked =
+		inlineEditPending || (acceptedEditClearFailed && !durableInlineEditDelivery);
+	const inlineEditRecoveryLabel = durableInlineEditDelivery
+		? durableInlineEditDelivery.state === "accepted"
+			? "chat.draft.clearEdit"
+			: "chat.draft.retryEdit"
+		: undefined;
+	const canAbandonInlineEditRecovery = Boolean(
+		inlineEditUncertain && durableInlineEditDelivery?.state === "dispatching",
+	);
+	useEffect(() => {
+		setChatDraftBoundary(
+			snapshot.sessionId,
+			"inline-edit",
+			[
+				...(draftPersistenceError ? (["persistence-failed"] as const) : []),
+			],
+		);
+	}, [draftPersistenceError, snapshot.sessionId]);
+	useEffect(
+		() => () => setChatDraftBoundary(snapshot.sessionId, "inline-edit", undefined),
+		[snapshot.sessionId],
+	);
 	const isInspectorOpen = useUiStore(
 		(state) => state.inspectorSessions[snapshot.sessionId]?.isOpen ?? true,
 	);
@@ -2055,10 +2131,14 @@ function Timeline({
 		snapshot.turns,
 	]);
 
-	// An edit draft belongs to the branch where it began. A replacement branch can
-	// become active even when the provider send ends ambiguously; once that durable
-	// state arrives, the old prompt is no longer the message being edited.
-	useEffect(() => setMessageEdit(undefined), [snapshot.activeBranchId, snapshot.sessionId]);
+	// An ordinary branch change hides an edit that belongs to the previous branch.
+	// An unresolved delivery is different: its exact persisted editor owns the only
+	// Retry/Abandon controls, so keep it actionable when an ambiguous send activates
+	// and refetches the replacement branch.
+	useEffect(() => {
+		if (readChatSessionDraft(draftScope).inlineEditDelivery) return;
+		setMessageEdit(undefined);
+	}, [draftScope, snapshot.activeBranchId, snapshot.sessionId]);
 	useEffect(() => {
 		if (isInspectorOpen) {
 			drag.current = null;
@@ -2085,30 +2165,266 @@ function Timeline({
 		pinnedRef.current = pinned;
 	}, [pinned]);
 
-	const startMessageEdit = useCallback(
-		(message: ConversationMessage) => {
-			if (!message.turnId) return;
-			setMessageEdit({
-				turnId: message.turnId,
-				text: message.text,
-				content: message.content ?? [],
-				reconstructedContext: reconstructedTurns.has(message.turnId),
-			});
-		},
-		[reconstructedTurns],
-	);
-	const updateMessageEdit = useCallback((text: string) => {
-		setMessageEdit((current) => (current ? { ...current, text } : current));
+	useEffect(() => {
+		const restored = readChatSessionDraft(draftScope);
+		messageEditRef.current = restored.inlineEdit;
+		setMessageEdit(restored.inlineEdit);
+		setDurableInlineEditDelivery(restored.inlineEditDelivery);
+		setInlineEditUncertain(restored.inlineEditDelivery?.state === "dispatching");
+		setDraftPersistenceError(undefined);
+		setInlineEditRecoveryNotice(
+			restored.inlineEditDelivery
+				? restored.inlineEditDelivery.state === "accepted"
+					? "chat.draft.acceptedEdit"
+					: "chat.draft.editRestart"
+				: undefined,
+		);
+		setAppliedEditAcceptanceSequence(0);
+		setInlineEditOutcomeNotice(undefined);
+		automaticInlineRecoveryAttempted.current = undefined;
+	}, [draftScope]);
+
+	const applyAcceptedInlineEditResult = useCallback((result: DraftClearResult) => {
+		setDurableInlineEditDelivery(result.draft.inlineEditDelivery);
+		if (!result.ok) {
+			setInlineEditRecoveryNotice(
+				"chat.draft.acceptedEdit",
+			);
+			setDraftPersistenceError(
+				"chat.draft.clearEditFailed",
+			);
+			return;
+		}
+		setDraftPersistenceError(undefined);
+		setInlineEditRecoveryNotice(undefined);
+		if (!result.cleared) return;
+		messageEditRef.current = undefined;
+		setMessageEdit(undefined);
 	}, []);
-	const cancelMessageEdit = useCallback(() => setMessageEdit(undefined), []);
+
+	const acceptAndClearInlineEditDelivery = useCallback(
+		(delivery: ChatInlineEditDelivery, mutationToken?: symbol) => {
+			const accepted = markChatInlineEditDeliveryAccepted(
+				draftScope,
+				delivery.clientMessageId,
+				delivery.revision,
+			);
+			if (!accepted.ok) {
+				if (mutationToken) {
+					cancelChatInlineEditMutation(draftScope, mutationToken);
+				}
+				setDurableInlineEditDelivery(delivery);
+				setDraftPersistenceError(
+					"chat.draft.recordEditFailed",
+				);
+				return false;
+			}
+			setDurableInlineEditDelivery(
+				accepted.draft.inlineEditDelivery ?? { ...delivery, state: "accepted" },
+			);
+			const result = clearAcceptedChatInlineEdit(draftScope, delivery.revision);
+			if (mutationToken) {
+				finishChatInlineEditMutation(
+					draftScope,
+					mutationToken,
+					delivery.revision,
+					result,
+				);
+				return result.ok;
+			}
+			applyAcceptedInlineEditResult(result);
+			return result.ok;
+		},
+		[applyAcceptedInlineEditResult, draftScope],
+	);
+
+	const abandonUncertainInlineEdit = useCallback(() => {
+		if (!durableInlineEditDelivery) return;
+		const result = clearUncertainChatInlineEditDelivery(
+			draftScope,
+			durableInlineEditDelivery.clientMessageId,
+			durableInlineEditDelivery.revision,
+		);
+		setDurableInlineEditDelivery(result.draft.inlineEditDelivery);
+		if (!result.ok) {
+			setDraftPersistenceError(
+				"chat.draft.abandonEditFailed",
+			);
+			return;
+		}
+		setInlineEditUncertain(false);
+		setDraftPersistenceError(undefined);
+		setInlineEditRecoveryNotice(undefined);
+		setInlineEditOutcomeNotice(
+			"chat.draft.abandonedEdit",
+		);
+	}, [draftScope, durableInlineEditDelivery]);
+
+	useEffect(() => {
+		if (!durableInlineEditDelivery || durableInlineEditDelivery.state !== "accepted") return;
+		if (
+			automaticInlineRecoveryAttempted.current ===
+			durableInlineEditDelivery.clientMessageId
+		) return;
+		automaticInlineRecoveryAttempted.current = durableInlineEditDelivery.clientMessageId;
+		acceptAndClearInlineEditDelivery(durableInlineEditDelivery);
+	}, [acceptAndClearInlineEditDelivery, durableInlineEditDelivery]);
+
+	useEffect(() => {
+		const accepted = inlineEditMutation.accepted;
+		if (!accepted || accepted.sequence <= appliedEditAcceptanceSequence) return;
+		applyAcceptedInlineEditResult(accepted.result);
+		setAppliedEditAcceptanceSequence(accepted.sequence);
+		acknowledgeChatInlineEditMutation(draftScope, accepted.sequence);
+	}, [
+		appliedEditAcceptanceSequence,
+		applyAcceptedInlineEditResult,
+		draftScope,
+		inlineEditMutation.accepted,
+	]);
+
+	const startMessageEdit = useCallback((message: ConversationMessage) => {
+		if (!message.turnId || inlineEditLocked) return;
+		const result = writeChatInlineEdit(draftScope, {
+			turnId: message.turnId,
+			text: message.text,
+			content: message.content ?? [],
+			reconstructedContext: reconstructedTurns.has(message.turnId),
+		});
+		const next = result.draft.inlineEdit;
+		if (!next) return;
+		messageEditRef.current = next;
+		setMessageEdit(next);
+		setInlineEditRecoveryNotice(undefined);
+		setInlineEditOutcomeNotice(undefined);
+		setDraftPersistenceError(
+			result.ok
+				? undefined
+				: "chat.draft.editSaveFailed",
+		);
+	}, [draftScope, inlineEditLocked, reconstructedTurns]);
+	const updateMessageEdit = useCallback((text: string) => {
+		if (inlineEditLocked) return;
+		const current = messageEditRef.current;
+		if (!current) return;
+		const result = writeChatInlineEdit(draftScope, {
+			turnId: current.turnId,
+			text,
+			content: current.content,
+			reconstructedContext: current.reconstructedContext,
+		});
+		const next = result.draft.inlineEdit;
+		if (!next) return;
+		messageEditRef.current = next;
+		setMessageEdit(next);
+		setInlineEditRecoveryNotice(undefined);
+		setInlineEditOutcomeNotice(undefined);
+		setDraftPersistenceError(
+			result.ok
+				? undefined
+				: "chat.draft.editSaveFailed",
+		);
+	}, [draftScope, inlineEditLocked]);
+	const cancelMessageEdit = useCallback(() => {
+		if (inlineEditLocked) return;
+		const result = writeChatInlineEdit(draftScope, undefined);
+		if (!result.ok) {
+			setDraftPersistenceError(
+				"chat.draft.editDiscardFailed",
+			);
+			return;
+		}
+		messageEditRef.current = undefined;
+		setMessageEdit(undefined);
+		setInlineEditRecoveryNotice(undefined);
+		setInlineEditOutcomeNotice(undefined);
+		setDraftPersistenceError(undefined);
+	}, [draftScope, inlineEditLocked]);
 	const submitMessageEdit = useCallback(
 		async (text: string) => {
-			const current = messageEdit;
-			if (!current || !onEditHumanMessage) return;
-			await editHumanMessage(current.turnId, text);
-			setMessageEdit((active) => (active?.turnId === current.turnId ? undefined : active));
+			const current = messageEditRef.current;
+			if (
+				!current ||
+				!onEditHumanMessage ||
+				inlineEditPending ||
+				(!durableInlineEditDelivery &&
+					getChatInlineEditMutation(draftScope).accepted?.result.ok === false)
+			) return;
+				const prepared = prepareChatInlineEditDelivery(draftScope, {
+					turnId: current.turnId,
+					text,
+					content: current.content,
+					reconstructedContext: current.reconstructedContext,
+					clientMessageId:
+					durableInlineEditDelivery?.clientMessageId ?? crypto.randomUUID(),
+			});
+			if (!prepared.ok) {
+				setDraftPersistenceError(
+					"chat.draft.prepareEditFailed",
+				);
+				return;
+			}
+			const delivery = prepared.mutation;
+			setInlineEditUncertain(false);
+			setDurableInlineEditDelivery(delivery);
+			setDraftPersistenceError(undefined);
+			setInlineEditRecoveryNotice(
+				delivery.state === "accepted"
+					? "chat.draft.acceptedEdit"
+					: undefined,
+			);
+			if (delivery.state === "accepted") {
+				acceptAndClearInlineEditDelivery(delivery);
+				return;
+			}
+			const mutationToken = beginChatInlineEditMutation(draftScope);
+			if (!mutationToken) return;
+			let mutationFinished = false;
+			try {
+				const outcome = await editHumanMessage(
+					delivery.turnId,
+					delivery.requestText,
+					delivery.clientMessageId,
+				);
+				if (outcome?.status === "not-accepted") {
+					const cleared = clearRejectedChatInlineEditDelivery(
+						draftScope,
+							delivery.clientMessageId,
+							delivery.revision,
+						);
+						setDurableInlineEditDelivery(cleared.draft.inlineEditDelivery);
+						if (cleared.ok) {
+							setDraftPersistenceError(undefined);
+							setInlineEditRecoveryNotice(undefined);
+							setInlineEditOutcomeNotice(outcome.reason);
+						} else {
+						setDraftPersistenceError(
+							"chat.draft.clearRefusedEditFailed",
+						);
+					}
+					return;
+				}
+				acceptAndClearInlineEditDelivery(delivery, mutationToken);
+				mutationFinished = true;
+			} catch {
+				setInlineEditUncertain(true);
+				setInlineEditRecoveryNotice(
+					"chat.draft.editUncertain",
+				);
+			} finally {
+				if (!mutationFinished) {
+					cancelChatInlineEditMutation(draftScope, mutationToken);
+				}
+			}
 		},
-		[editHumanMessage, messageEdit, onEditHumanMessage],
+		[
+			acceptAndClearInlineEditDelivery,
+			durableInlineEditDelivery,
+			editHumanMessage,
+			inlineEditPending,
+			onEditHumanMessage,
+			draftScope,
+		],
 	);
 
 	const readable = useMemo(() => readableItems(snapshot), [snapshot]);
@@ -2482,10 +2798,18 @@ function Timeline({
 									onStartMessageEdit={startMessageEdit}
 									onUpdateMessageEdit={updateMessageEdit}
 									onCancelMessageEdit={cancelMessageEdit}
+									onAbandonEditRecovery={
+										canAbandonInlineEditRecovery ? abandonUncertainInlineEdit : undefined
+									}
 									onSubmitMessageEdit={submitMessageEdit}
-									editPending={editPending}
+									editPending={inlineEditPending}
+									editSendBlocked={inlineEditSendBlocked}
+									editRecoveryLabel={translateDraft(inlineEditRecoveryLabel)}
 									editBusy={Boolean(editBusy || newWorkDisabled)}
-									editError={editError}
+									editError={translateDraft(editError ??
+										draftPersistenceError ??
+										inlineEditRecoveryNotice ??
+										inlineEditOutcomeNotice)}
 									branchPoints={branchPoints}
 									editableTurns={editableTurns}
 									newHumanMessageIds={newHumanMessageIds}
@@ -2510,12 +2834,21 @@ function Timeline({
 							<HumanMessageEditor
 								text={messageEdit.text}
 								content={messageEdit.content}
-								pending={Boolean(editPending)}
+								pending={inlineEditPending}
+								locked={Boolean(inlineEditRecoveryLabel)}
+								recoveryLabel={translateDraft(inlineEditRecoveryLabel)}
+								sendBlocked={inlineEditSendBlocked}
 								busy={Boolean(editBusy || newWorkDisabled)}
-								error={editError}
+								error={translateDraft(editError ??
+									draftPersistenceError ??
+									inlineEditRecoveryNotice ??
+									inlineEditOutcomeNotice)}
 								reconstructedContext={messageEdit.reconstructedContext}
 								onDraftChange={updateMessageEdit}
 								onCancel={cancelMessageEdit}
+								onAbandonRecovery={
+									canAbandonInlineEditRecovery ? abandonUncertainInlineEdit : undefined
+								}
 								onSend={submitMessageEdit}
 							/>
 						</div>
@@ -2655,8 +2988,11 @@ const TurnGroup = memo(function TurnGroup({
 	onStartMessageEdit,
 	onUpdateMessageEdit,
 	onCancelMessageEdit,
+	onAbandonEditRecovery,
 	onSubmitMessageEdit,
 	editPending,
+	editSendBlocked,
+	editRecoveryLabel,
 	editBusy,
 	editError,
 	branchPoints,
@@ -2678,13 +3014,16 @@ const TurnGroup = memo(function TurnGroup({
 	onRollback: (turnId: string) => void;
 	onOpenFiles?: () => void;
 	onOpenFile?: (path: string) => void;
-	onEditHumanMessage?: (turnId: string, text: string) => Promise<unknown> | void;
+	onEditHumanMessage?: ChatWorkspaceProps["onEditMessage"];
 	messageEdit?: MessageEditDraft;
 	onStartMessageEdit: (message: ConversationMessage) => void;
 	onUpdateMessageEdit: (text: string) => void;
 	onCancelMessageEdit: () => void;
+	onAbandonEditRecovery?: () => void;
 	onSubmitMessageEdit: (text: string) => Promise<void>;
 	editPending?: boolean;
+	editSendBlocked?: boolean;
+	editRecoveryLabel?: string;
 	editBusy?: boolean;
 	editError?: string;
 	branchPoints: Map<string, ConversationBranchPoint>;
@@ -2738,8 +3077,11 @@ const TurnGroup = memo(function TurnGroup({
 						onStartMessageEdit={onStartMessageEdit}
 						onUpdateMessageEdit={onUpdateMessageEdit}
 						onCancelMessageEdit={onCancelMessageEdit}
+						onAbandonEditRecovery={onAbandonEditRecovery}
 						onSubmitMessageEdit={onSubmitMessageEdit}
 						editPending={editPending}
+						editSendBlocked={editSendBlocked}
+						editRecoveryLabel={editRecoveryLabel}
 						editBusy={editBusy}
 						editError={editError}
 						branchPoints={branchPoints}
@@ -2902,8 +3244,11 @@ function TimelineItem({
 	onStartMessageEdit,
 	onUpdateMessageEdit,
 	onCancelMessageEdit,
+	onAbandonEditRecovery,
 	onSubmitMessageEdit,
 	editPending,
+	editSendBlocked,
+	editRecoveryLabel,
 	editBusy,
 	editError,
 	branchPoints,
@@ -2923,13 +3268,16 @@ function TimelineItem({
 	apiBaseUrl: string;
 	onDecide?: (requestId: string, decisionId: string) => void;
 	onResolveInput?: ChatWorkspaceProps["onResolveInput"];
-	onEditHumanMessage?: (turnId: string, text: string) => Promise<unknown> | void;
+	onEditHumanMessage?: ChatWorkspaceProps["onEditMessage"];
 	messageEdit?: MessageEditDraft;
 	onStartMessageEdit: (message: ConversationMessage) => void;
 	onUpdateMessageEdit: (text: string) => void;
 	onCancelMessageEdit: () => void;
+	onAbandonEditRecovery?: () => void;
 	onSubmitMessageEdit: (text: string) => Promise<void>;
 	editPending?: boolean;
+	editSendBlocked?: boolean;
+	editRecoveryLabel?: string;
 	editBusy?: boolean;
 	editError?: string;
 	branchPoints: Map<string, ConversationBranchPoint>;
@@ -2985,7 +3333,10 @@ function TimelineItem({
 					onEditStart={editAvailable ? () => onStartMessageEdit(item) : undefined}
 					onEditDraftChange={onUpdateMessageEdit}
 					onEditCancel={onCancelMessageEdit}
+					onEditAbandonRecovery={onAbandonEditRecovery}
 					editPending={editPending}
+					editSendBlocked={editSendBlocked}
+					editRecoveryLabel={editRecoveryLabel}
 					editBusy={editBusy}
 					editError={editError}
 					branchPoint={item.turnId ? branchPoints.get(item.turnId) : undefined}

--- a/frontend/src/renderer/components/chat/HumanMessageEditor.tsx
+++ b/frontend/src/renderer/components/chat/HumanMessageEditor.tsx
@@ -11,6 +11,11 @@ export interface HumanMessageEditorProps {
 	text: string;
 	content: ConversationContentSummary[];
 	pending: boolean;
+	/** Durable unresolved delivery: lock edits, but allow explicit safe recovery. */
+	locked?: boolean;
+	recoveryLabel?: string;
+	onAbandonRecovery?: () => void;
+	sendBlocked?: boolean;
 	busy: boolean;
 	reconstructedContext?: boolean;
 	error?: string;
@@ -23,6 +28,10 @@ export function HumanMessageEditor({
 	text,
 	content,
 	pending,
+	locked = false,
+	recoveryLabel,
+	onAbandonRecovery,
+	sendBlocked = false,
 	busy,
 	reconstructedContext = false,
 	error,
@@ -34,8 +43,18 @@ export function HumanMessageEditor({
 	const [draft, setDraft] = useState(text);
 	const textarea = useRef<HTMLTextAreaElement>(null);
 	const reconstructedContextId = useId();
-	const sendDisabled = pending || busy || draft.trim().length === 0;
+	const sendDisabled =
+		pending || sendBlocked || busy || draft.trim().length === 0 || (locked && !recoveryLabel);
 	const busyMessage = busy ? t("chat.edit.stopCurrentTurn") : undefined;
+
+	useEffect(() => {
+		// React can preserve this editor while its Chat surface is hidden. If another
+		// committed surface advances the durable revision in that interval, the parent
+		// restores the newer text when this surface reconnects and it must replace the
+		// stale local seed. Ordinary typing already publishes the same text upward, so
+		// this equality-preserving update does not reset an active edit.
+		setDraft(text);
+	}, [text]);
 
 	useEffect(() => {
 		const node = textarea.current;
@@ -73,6 +92,7 @@ export function HumanMessageEditor({
 			onKeyDown={onKeyDown}
 			aria-label={t("chat.edit.label")}
 			aria-describedby={reconstructedContext ? reconstructedContextId : undefined}
+			disabled={pending || locked}
 			autoFocus
 			rows={2}
 			className="chat-composer-scrollbar max-h-56 min-h-[3.25rem] w-full resize-none overflow-y-auto overscroll-contain bg-transparent px-0 py-1 text-sm leading-relaxed text-foreground outline-none"
@@ -96,6 +116,16 @@ export function HumanMessageEditor({
 			) : busyMessage ? (
 				<span className="mr-auto text-[11px] text-muted-foreground">{busyMessage}</span>
 			) : null}
+			{onAbandonRecovery ? (
+				<Button
+					type="button"
+					size="sm"
+					variant="outline"
+					onClick={onAbandonRecovery}
+				>
+					{t("chat.edit.abandonRecovery")}
+				</Button>
+			) : null}
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<span className="inline-flex">
@@ -104,7 +134,7 @@ export function HumanMessageEditor({
 							size="icon-sm"
 							variant="ghost"
 							onClick={onCancel}
-							disabled={pending}
+							disabled={pending || locked}
 							aria-label={t("chat.edit.cancel")}
 							className="size-7"
 						>
@@ -123,7 +153,7 @@ export function HumanMessageEditor({
 							size="icon-sm"
 							onClick={submit}
 							disabled={sendDisabled}
-							aria-label={t("chat.edit.send")}
+							aria-label={recoveryLabel ?? t("chat.edit.send")}
 							className={cn(
 								"size-7 rounded-full border-transparent",
 								sendDisabled
@@ -135,7 +165,7 @@ export function HumanMessageEditor({
 						</Button>
 					</span>
 				</TooltipTrigger>
-				<TooltipContent side="bottom">{busyMessage ?? t("chat.edit.sendShortcut")}</TooltipContent>
+				<TooltipContent side="bottom">{busyMessage ?? recoveryLabel ?? t("chat.edit.sendShortcut")}</TooltipContent>
 			</Tooltip>
 		</div>
 	</div>

--- a/frontend/src/renderer/hooks/useConversation.ts
+++ b/frontend/src/renderer/hooks/useConversation.ts
@@ -1,3 +1,4 @@
+import type { ChatEditOutcome } from "../types/conversation";
 import type { ChatSteerOutcome } from "../types/conversation";
 /**
  * Live conversation data for a Chat session.
@@ -882,18 +883,25 @@ export function useConversationCommands(sessionId: string | undefined) {
 						? retryTurn.variables?.sourceTurnId
 						: undefined,
 		},
-		editMessage: (turnId: string, text: string) => {
+		editMessage: async (turnId: string, text: string, clientMessageId?: string): Promise<ChatEditOutcome> => {
 			if (!sessionId) return Promise.reject(new Error("No conversation session is selected."));
-			const requestId = crypto.randomUUID();
+			const requestId = clientMessageId ?? crypto.randomUUID();
 			if (!claimConversationDispatch(queryClient, sessionId, requestId, "edit", turnId)) {
 				return Promise.reject(new Error("Conversation work is already being sent for this session."));
 			}
-			return editMessage.mutateAsync({
+			try {
+			await editMessage.mutateAsync({
 				requestId,
 				sourceTurnId: turnId,
 				targetSessionId: sessionId,
 				text,
 			});
+			return { status: "accepted" };
+			} catch (error) {
+				const outcome = editNonAcceptance(error);
+				if (outcome) return outcome;
+				throw error;
+			}
 		},
 		editMessagePending:
 			trackedDispatch?.operation === "edit" ||
@@ -1518,4 +1526,29 @@ function steerNonAcceptance(error: unknown): ChatSteerOutcome | undefined {
 		status: "not-accepted",
 		reason: steerRefusal(error) ?? apiErrorMessage(error),
 	};
+}
+
+
+
+
+
+const DEFINITIVE_EDIT_NON_ACCEPTANCE_CODES = new Set([
+	"CHAT_EDIT_REJECTED",
+	"CHAT_EDIT_UNSUPPORTED",
+	"CHAT_EDIT_BUSY",
+	"CHAT_EDIT_TURN_INVALID",
+	"CHAT_PROVIDER_REFUSED",
+	"SESSION_MODE_MISMATCH",
+	"SESSION_NOT_FOUND",
+	"CHAT_CONTROLLER_NOT_READY",
+	"CHAT_AUTH_REQUIRED",
+]);
+
+
+
+
+function editNonAcceptance(error: unknown): ChatEditOutcome | undefined {
+	const code = apiErrorCode(error);
+	if (!code || !DEFINITIVE_EDIT_NON_ACCEPTANCE_CODES.has(code)) return undefined;
+	return { status: "not-accepted", reason: apiErrorMessage(error) };
 }

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1930,7 +1930,19 @@
 	"chat.draft.queueReplaced": "Diese Änderung der wartenden Nachricht wurde ersetzt. Es wurde nichts gesendet.",
 	"chat.draft.queuePrepareFailed": "Der Entwurf und seine Wiederherstellungs-ID konnten nicht lokal gespeichert werden. Es wurde nichts gesendet. Stellen Sie den lokalen Speicher wieder her und versuchen Sie es erneut.",
 	"chat.draft.queueClearFailed": "Der Inhalt wurde angenommen, aber der lokale Entwurf muss noch gelöscht werden.",
+	"chat.draft.clearEdit": "Angenommenen Entwurf fertig löschen",
 	"chat.draft.retryEdit": "Sicher erneut versuchen",
+	"chat.draft.acceptedEdit": "Der Inhalt wurde angenommen, aber der lokale Entwurf muss noch gelöscht werden.",
+	"chat.draft.editRestart": "AO kann nicht feststellen, ob dieser Inhalt den Agenten bereits erreicht hat. Versuchen Sie es mit derselben Zustellungs-ID erneut oder brechen Sie die Wiederherstellung ab, um ihn zu bearbeiten. Erneutes Senden nach dem Abbruch kann zu einer doppelten Zustellung führen.",
+	"chat.draft.clearEditFailed": "Der Inhalt wurde angenommen, aber der lokale Entwurf konnte nicht gelöscht werden. Versuchen Sie das Löschen vor dem Verlassen erneut; AO sendet ihn nicht noch einmal.",
+	"chat.draft.recordEditFailed": "Die Annahme konnte nicht lokal gespeichert werden. Versuchen Sie es mit derselben Zustellungs-ID erneut, um sie abzugleichen.",
+	"chat.draft.abandonEditFailed": "Die Wiederherstellung konnte nicht abgebrochen werden, da der lokale Eintrag nicht gelöscht werden konnte. Es wird nichts automatisch erneut gesendet.",
+	"chat.draft.abandonedEdit": "Die Wiederherstellung wurde abgebrochen. Der vorherige Inhalt wurde möglicherweise bereits zugestellt; erneutes Senden kann zu einer doppelten Zustellung führen.",
+	"chat.draft.editSaveFailed": "Der Entwurf konnte nicht gespeichert werden. Lassen Sie diesen Chat geöffnet oder kopieren Sie den Entwurf vor dem Verlassen.",
+	"chat.draft.editDiscardFailed": "Die Änderung konnte nicht verworfen werden. Lassen Sie diesen Chat geöffnet und versuchen Sie es erneut.",
+	"chat.draft.prepareEditFailed": "Der Entwurf und seine Wiederherstellungs-ID konnten nicht lokal gespeichert werden. Es wurde nichts gesendet. Stellen Sie den lokalen Speicher wieder her und versuchen Sie es erneut.",
+	"chat.draft.clearRefusedEditFailed": "Die Zustellung wurde abgelehnt, aber der lokale Wiederherstellungseintrag konnte nicht gelöscht werden. Es wird nichts automatisch erneut gesendet.",
+	"chat.draft.editUncertain": "AO kann nicht feststellen, ob dieser Inhalt den Agenten bereits erreicht hat. Versuchen Sie es mit derselben Zustellungs-ID erneut oder brechen Sie die Wiederherstellung ab, um ihn zu bearbeiten. Erneutes Senden nach dem Abbruch kann zu einer doppelten Zustellung führen.",
 	"chat.draft.abandon": "Wiederherstellung abbrechen",
 	"chat.draft.filesUnavailable": "Die Dateien sind nicht dauerhaft verfügbar. Es wurde nichts gesendet.",
 	"chat.draftDiscard.title": "Unsicheren Chat-Entwurf verwerfen?",
@@ -1941,5 +1953,6 @@
 	"chat.draftDiscard.nativeTitle": "Ungespeicherter Chatentwurf",
 	"chat.draftDiscard.nativeMessage": "Dieser Chatentwurf ist noch nicht sicher gespeichert.",
 	"chat.draftDiscard.stay": "Bleiben",
-	"chat.draftDiscard.leaveAnyway": "Trotzdem verlassen"
+	"chat.draftDiscard.leaveAnyway": "Trotzdem verlassen",
+	"chat.edit.abandonRecovery": "Bearbeitungswiederherstellung aufgeben"
 }

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1950,7 +1950,19 @@
 	"chat.draft.queueReplaced": "This queued edit was replaced. Nothing was sent.",
 	"chat.draft.queuePrepareFailed": "Queued edit could not be saved locally. Nothing was sent.",
 	"chat.draft.queueClearFailed": "The edit was saved, but its local draft could not be cleared.",
+	"chat.draft.clearEdit": "Finish clearing accepted edit",
 	"chat.draft.retryEdit": "Retry edit safely",
+	"chat.draft.acceptedEdit": "Edited message was accepted, but its local draft still needs to be cleared.",
+	"chat.draft.editRestart": "AO can’t determine whether the earlier edit may already have been delivered before Chat restarted. Retry safely with the same delivery ID, or abandon recovery to edit it. Sending it again after abandonment may duplicate it.",
+	"chat.draft.clearEditFailed": "Edited message was accepted, but its local draft couldn’t be cleared. Retry clearing before leaving; AO will not branch it again.",
+	"chat.draft.recordEditFailed": "Edited-message acceptance couldn’t be recorded locally. Retry safely to reconcile it with the same delivery ID.",
+	"chat.draft.abandonEditFailed": "Edit recovery couldn’t be abandoned because its local record could not be cleared. Nothing will be resent automatically.",
+	"chat.draft.abandonedEdit": "Recovery was abandoned. The earlier edit may already have been delivered; sending this edit again may duplicate it.",
+	"chat.draft.editSaveFailed": "Inline edit couldn’t be saved. Keep this chat open or copy it before leaving.",
+	"chat.draft.editDiscardFailed": "Inline edit couldn’t be discarded. Keep this chat open and try again.",
+	"chat.draft.prepareEditFailed": "This exact inline edit and its recovery ID couldn’t be saved locally. Nothing was sent. Restore local storage and try again.",
+	"chat.draft.clearRefusedEditFailed": "The edit was rejected, but its local recovery record couldn’t be cleared. Nothing will be resent automatically.",
+	"chat.draft.editUncertain": "AO can’t determine whether the earlier edit may already have been delivered. Retry safely with the same delivery ID, or abandon recovery to edit it. Sending it again after abandonment may duplicate it.",
 	"chat.draft.abandon": "Abandon recovery",
 	"chat.draft.filesUnavailable": "The files are not durably available. Nothing was sent.",
 	"chat.draftDiscard.title": "Discard unsafe Chat draft state?",
@@ -1961,5 +1973,6 @@
 	"chat.draftDiscard.nativeTitle": "Unsaved Chat draft",
 	"chat.draftDiscard.nativeMessage": "This Chat draft is not safely saved yet.",
 	"chat.draftDiscard.stay": "Stay",
-	"chat.draftDiscard.leaveAnyway": "Leave anyway"
+	"chat.draftDiscard.leaveAnyway": "Leave anyway",
+	"chat.edit.abandonRecovery": "Abandon edit recovery"
 }

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1958,7 +1958,19 @@
 	"chat.draft.queueReplaced": "Esta edición del mensaje en cola se reemplazó. No se envió nada.",
 	"chat.draft.queuePrepareFailed": "No se pudieron guardar localmente el borrador y su ID de recuperación. No se envió nada. Restablece el almacenamiento local y reintenta.",
 	"chat.draft.queueClearFailed": "El contenido se aceptó, pero aún hay que borrar su borrador local.",
+	"chat.draft.clearEdit": "Terminar de borrar el borrador aceptado",
 	"chat.draft.retryEdit": "Reintentar de forma segura",
+	"chat.draft.acceptedEdit": "El contenido se aceptó, pero aún hay que borrar su borrador local.",
+	"chat.draft.editRestart": "AO no puede determinar si el agente ya recibió este contenido. Reintenta con el mismo ID de entrega o abandona la recuperación para editarlo. Volver a enviarlo tras abandonar puede duplicarlo.",
+	"chat.draft.clearEditFailed": "El contenido se aceptó, pero no se pudo borrar su borrador local. Reintenta borrarlo antes de salir; AO no lo enviará de nuevo.",
+	"chat.draft.recordEditFailed": "No se pudo registrar la aceptación localmente. Reintenta con el mismo ID de entrega para confirmarla.",
+	"chat.draft.abandonEditFailed": "No se pudo abandonar la recuperación porque no se pudo borrar su registro local. No se reenviará nada automáticamente.",
+	"chat.draft.abandonedEdit": "Se abandonó la recuperación. Es posible que el contenido anterior ya se haya entregado; volver a enviarlo puede duplicarlo.",
+	"chat.draft.editSaveFailed": "No se pudo guardar el borrador. Mantén este chat abierto o cópialo antes de salir.",
+	"chat.draft.editDiscardFailed": "No se pudo descartar la edición. Mantén este chat abierto y reintenta.",
+	"chat.draft.prepareEditFailed": "No se pudieron guardar localmente el borrador y su ID de recuperación. No se envió nada. Restablece el almacenamiento local y reintenta.",
+	"chat.draft.clearRefusedEditFailed": "Se rechazó el envío, pero no se pudo borrar su registro local de recuperación. No se reenviará nada automáticamente.",
+	"chat.draft.editUncertain": "AO no puede determinar si el agente ya recibió este contenido. Reintenta con el mismo ID de entrega o abandona la recuperación para editarlo. Volver a enviarlo tras abandonar puede duplicarlo.",
 	"chat.draft.abandon": "Abandonar recuperación",
 	"chat.draft.filesUnavailable": "Los archivos no están guardados de forma duradera. No se envió nada.",
 	"chat.draftDiscard.title": "¿Descartar el borrador de chat no guardado?",
@@ -1969,5 +1981,6 @@
 	"chat.draftDiscard.nativeTitle": "Borrador de chat sin guardar",
 	"chat.draftDiscard.nativeMessage": "Este borrador de chat aún no está guardado de forma segura.",
 	"chat.draftDiscard.stay": "Quedarse",
-	"chat.draftDiscard.leaveAnyway": "Salir de todos modos"
+	"chat.draftDiscard.leaveAnyway": "Salir de todos modos",
+	"chat.edit.abandonRecovery": "Abandonar recuperación de edición"
 }

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1958,7 +1958,19 @@
 	"chat.draft.queueReplaced": "Cette modification du message en attente a été remplacée. Rien n’a été envoyé.",
 	"chat.draft.queuePrepareFailed": "Le brouillon et son identifiant de récupération n’ont pas pu être enregistrés localement. Rien n’a été envoyé. Rétablissez le stockage local et réessayez.",
 	"chat.draft.queueClearFailed": "Le contenu a été accepté, mais son brouillon local doit encore être effacé.",
+	"chat.draft.clearEdit": "Terminer l’effacement du brouillon accepté",
 	"chat.draft.retryEdit": "Réessayer sans risque de doublon",
+	"chat.draft.acceptedEdit": "Le contenu a été accepté, mais son brouillon local doit encore être effacé.",
+	"chat.draft.editRestart": "AO ne peut pas déterminer si ce contenu a déjà été transmis à l’agent. Réessayez avec le même identifiant de livraison, ou abandonnez la récupération pour le modifier. Un nouvel envoi après abandon peut créer un doublon.",
+	"chat.draft.clearEditFailed": "Le contenu a été accepté, mais son brouillon local n’a pas pu être effacé. Réessayez de l’effacer avant de partir ; AO ne le renverra pas.",
+	"chat.draft.recordEditFailed": "L’acceptation n’a pas pu être enregistrée localement. Réessayez avec le même identifiant de livraison pour la confirmer.",
+	"chat.draft.abandonEditFailed": "Impossible d’abandonner la récupération : son enregistrement local n’a pas pu être effacé. Aucun renvoi automatique n’aura lieu.",
+	"chat.draft.abandonedEdit": "La récupération a été abandonnée. Le contenu précédent a peut-être déjà été transmis ; un nouvel envoi peut créer un doublon.",
+	"chat.draft.editSaveFailed": "Le brouillon n’a pas pu être enregistré. Gardez cette conversation ouverte ou copiez-le avant de partir.",
+	"chat.draft.editDiscardFailed": "La modification n’a pas pu être abandonnée. Gardez cette conversation ouverte et réessayez.",
+	"chat.draft.prepareEditFailed": "Le brouillon et son identifiant de récupération n’ont pas pu être enregistrés localement. Rien n’a été envoyé. Rétablissez le stockage local et réessayez.",
+	"chat.draft.clearRefusedEditFailed": "L’envoi a été refusé, mais son enregistrement de récupération local n’a pas pu être effacé. Aucun renvoi automatique n’aura lieu.",
+	"chat.draft.editUncertain": "AO ne peut pas déterminer si ce contenu a déjà été transmis à l’agent. Réessayez avec le même identifiant de livraison, ou abandonnez la récupération pour le modifier. Un nouvel envoi après abandon peut créer un doublon.",
 	"chat.draft.abandon": "Abandonner la récupération",
 	"chat.draft.filesUnavailable": "Les fichiers ne sont pas enregistrés durablement. Rien n’a été envoyé.",
 	"chat.draftDiscard.title": "Abandonner le brouillon de chat non sécurisé ?",
@@ -1969,5 +1981,6 @@
 	"chat.draftDiscard.nativeTitle": "Brouillon de conversation non enregistré",
 	"chat.draftDiscard.nativeMessage": "Ce brouillon de conversation n’est pas encore enregistré de façon sûre.",
 	"chat.draftDiscard.stay": "Rester",
-	"chat.draftDiscard.leaveAnyway": "Quitter quand même"
+	"chat.draftDiscard.leaveAnyway": "Quitter quand même",
+	"chat.edit.abandonRecovery": "Abandonner la récupération de la modification"
 }

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1930,7 +1930,19 @@
 	"chat.draft.queueReplaced": "この待機中のメッセージの編集は置き換えられました。何も送信されていません。",
 	"chat.draft.queuePrepareFailed": "下書きと復元 ID をローカルに保存できませんでした。何も送信されていません。ローカルストレージへのアクセスを復旧して再試行してください。",
 	"chat.draft.queueClearFailed": "内容は受け付けられましたが、ローカルの下書きをまだ削除する必要があります。",
+	"chat.draft.clearEdit": "受け付け済みの下書きの削除を完了",
 	"chat.draft.retryEdit": "安全に再試行",
+	"chat.draft.acceptedEdit": "内容は受け付けられましたが、ローカルの下書きをまだ削除する必要があります。",
+	"chat.draft.editRestart": "この内容がすでにエージェントに届いたかどうかを AO は判断できません。同じ配信 ID で安全に再試行するか、復元を中止して編集してください。中止後の再送信は重複する可能性があります。",
+	"chat.draft.clearEditFailed": "内容は受け付けられましたが、ローカルの下書きを削除できませんでした。離れる前に削除を再試行してください。AO は再送信しません。",
+	"chat.draft.recordEditFailed": "受け付け結果をローカルに記録できませんでした。同じ配信 ID で安全に再試行して結果を確認してください。",
+	"chat.draft.abandonEditFailed": "ローカルの記録を削除できないため、復元を中止できませんでした。自動的に再送信されることはありません。",
+	"chat.draft.abandonedEdit": "復元を中止しました。以前の内容はすでに配信された可能性があります。再送信すると重複する場合があります。",
+	"chat.draft.editSaveFailed": "下書きを保存できませんでした。このチャットを開いたままにするか、離れる前に下書きをコピーしてください。",
+	"chat.draft.editDiscardFailed": "編集を破棄できませんでした。このチャットを開いたままにして再試行してください。",
+	"chat.draft.prepareEditFailed": "下書きと復元 ID をローカルに保存できませんでした。何も送信されていません。ローカルストレージへのアクセスを復旧して再試行してください。",
+	"chat.draft.clearRefusedEditFailed": "配信は拒否されましたが、ローカルの復元記録を削除できませんでした。自動的に再送信されることはありません。",
+	"chat.draft.editUncertain": "この内容がすでにエージェントに届いたかどうかを AO は判断できません。同じ配信 ID で安全に再試行するか、復元を中止して編集してください。中止後の再送信は重複する可能性があります。",
 	"chat.draft.abandon": "復元を中止",
 	"chat.draft.filesUnavailable": "ファイルはまだ永続的に保存されていません。何も送信されていません。",
 	"chat.draftDiscard.title": "安全に保存されていないチャットの下書きを破棄しますか？",
@@ -1941,5 +1953,6 @@
 	"chat.draftDiscard.nativeTitle": "未保存のチャットの下書き",
 	"chat.draftDiscard.nativeMessage": "このチャットの下書きはまだ安全に保存されていません。",
 	"chat.draftDiscard.stay": "留まる",
-	"chat.draftDiscard.leaveAnyway": "離れる"
+	"chat.draftDiscard.leaveAnyway": "離れる",
+	"chat.edit.abandonRecovery": "編集の復旧を中止"
 }

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1930,7 +1930,19 @@
 	"chat.draft.queueReplaced": "이 대기 중인 메시지의 편집 내용이 교체되었습니다. 아무것도 전송하지 않았습니다.",
 	"chat.draft.queuePrepareFailed": "초안과 복구 ID를 로컬에 저장할 수 없습니다. 아무것도 전송하지 않았습니다. 로컬 저장소 접근을 복원하고 재시도하세요.",
 	"chat.draft.queueClearFailed": "내용이 수락되었지만 로컬 초안을 아직 지워야 합니다.",
+	"chat.draft.clearEdit": "수락된 초안 지우기 완료",
 	"chat.draft.retryEdit": "안전하게 재시도",
+	"chat.draft.acceptedEdit": "내용이 수락되었지만 로컬 초안을 아직 지워야 합니다.",
+	"chat.draft.editRestart": "AO는 에이전트가 이미 이 내용을 받았는지 확인할 수 없습니다. 동일한 전송 ID로 안전하게 재시도하거나 복구를 포기한 후 편집하세요. 포기 후 다시 보내면 중복 전송될 수 있습니다.",
+	"chat.draft.clearEditFailed": "내용이 수락되었지만 로컬 초안을 지울 수 없습니다. 나가기 전에 다시 지워 보세요. AO는 다시 전송하지 않습니다.",
+	"chat.draft.recordEditFailed": "수락 결과를 로컬에 기록할 수 없습니다. 동일한 전송 ID로 안전하게 재시도하여 결과를 확인하세요.",
+	"chat.draft.abandonEditFailed": "로컬 기록을 지울 수 없어 복구를 포기할 수 없습니다. 자동으로 다시 전송하지 않습니다.",
+	"chat.draft.abandonedEdit": "복구를 포기했습니다. 이전 내용이 이미 전송되었을 수 있으며, 다시 보내면 중복될 수 있습니다.",
+	"chat.draft.editSaveFailed": "초안을 저장할 수 없습니다. 이 채팅을 열어 두거나 나가기 전에 초안을 복사하세요.",
+	"chat.draft.editDiscardFailed": "편집 내용을 버릴 수 없습니다. 이 채팅을 열어 두고 재시도하세요.",
+	"chat.draft.prepareEditFailed": "초안과 복구 ID를 로컬에 저장할 수 없습니다. 아무것도 전송하지 않았습니다. 로컬 저장소 접근을 복원하고 재시도하세요.",
+	"chat.draft.clearRefusedEditFailed": "전송이 거부되었지만 로컬 복구 기록을 지울 수 없습니다. 자동으로 다시 전송하지 않습니다.",
+	"chat.draft.editUncertain": "AO는 에이전트가 이미 이 내용을 받았는지 확인할 수 없습니다. 동일한 전송 ID로 안전하게 재시도하거나 복구를 포기한 후 편집하세요. 포기 후 다시 보내면 중복 전송될 수 있습니다.",
 	"chat.draft.abandon": "복구 포기",
 	"chat.draft.filesUnavailable": "파일이 아직 영구적으로 저장되지 않았습니다. 아무것도 전송하지 않았습니다.",
 	"chat.draftDiscard.title": "안전하게 저장되지 않은 채팅 초안을 삭제할까요?",
@@ -1941,5 +1953,6 @@
 	"chat.draftDiscard.nativeTitle": "저장하지 않은 채팅 초안",
 	"chat.draftDiscard.nativeMessage": "이 채팅 초안은 아직 안전하게 저장되지 않았습니다.",
 	"chat.draftDiscard.stay": "머무르기",
-	"chat.draftDiscard.leaveAnyway": "그래도 나가기"
+	"chat.draftDiscard.leaveAnyway": "그래도 나가기",
+	"chat.edit.abandonRecovery": "편집 복구 포기"
 }

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1958,7 +1958,19 @@
 	"chat.draft.queueReplaced": "Esta edição da mensagem na fila foi substituída. Nada foi enviado.",
 	"chat.draft.queuePrepareFailed": "Não foi possível salvar localmente o rascunho e seu ID de recuperação. Nada foi enviado. Restaure o armazenamento local e tente novamente.",
 	"chat.draft.queueClearFailed": "O conteúdo foi aceito, mas seu rascunho local ainda precisa ser apagado.",
+	"chat.draft.clearEdit": "Concluir a exclusão do rascunho aceito",
 	"chat.draft.retryEdit": "Tentar novamente com segurança",
+	"chat.draft.acceptedEdit": "O conteúdo foi aceito, mas seu rascunho local ainda precisa ser apagado.",
+	"chat.draft.editRestart": "O AO não consegue determinar se o agente já recebeu este conteúdo. Tente novamente com o mesmo ID de entrega ou abandone a recuperação para editá-lo. Enviar novamente após abandonar pode duplicá-lo.",
+	"chat.draft.clearEditFailed": "O conteúdo foi aceito, mas não foi possível apagar seu rascunho local. Tente apagá-lo novamente antes de sair; o AO não o enviará outra vez.",
+	"chat.draft.recordEditFailed": "Não foi possível registrar a aceitação localmente. Tente novamente com o mesmo ID de entrega para confirmá-la.",
+	"chat.draft.abandonEditFailed": "Não foi possível abandonar a recuperação porque seu registro local não pôde ser apagado. Nada será reenviado automaticamente.",
+	"chat.draft.abandonedEdit": "A recuperação foi abandonada. O conteúdo anterior pode já ter sido entregue; enviá-lo novamente pode duplicá-lo.",
+	"chat.draft.editSaveFailed": "Não foi possível salvar o rascunho. Mantenha este chat aberto ou copie o rascunho antes de sair.",
+	"chat.draft.editDiscardFailed": "Não foi possível descartar a edição. Mantenha este chat aberto e tente novamente.",
+	"chat.draft.prepareEditFailed": "Não foi possível salvar localmente o rascunho e seu ID de recuperação. Nada foi enviado. Restaure o armazenamento local e tente novamente.",
+	"chat.draft.clearRefusedEditFailed": "O envio foi recusado, mas não foi possível apagar seu registro local de recuperação. Nada será reenviado automaticamente.",
+	"chat.draft.editUncertain": "O AO não consegue determinar se o agente já recebeu este conteúdo. Tente novamente com o mesmo ID de entrega ou abandone a recuperação para editá-lo. Enviar novamente após abandonar pode duplicá-lo.",
 	"chat.draft.abandon": "Abandonar recuperação",
 	"chat.draft.filesUnavailable": "Os arquivos não estão salvos de forma duradoura. Nada foi enviado.",
 	"chat.draftDiscard.title": "Descartar o rascunho de chat não salvo?",
@@ -1969,5 +1981,6 @@
 	"chat.draftDiscard.nativeTitle": "Rascunho de chat não salvo",
 	"chat.draftDiscard.nativeMessage": "Este rascunho de chat ainda não foi salvo com segurança.",
 	"chat.draftDiscard.stay": "Ficar",
-	"chat.draftDiscard.leaveAnyway": "Sair mesmo assim"
+	"chat.draftDiscard.leaveAnyway": "Sair mesmo assim",
+	"chat.edit.abandonRecovery": "Abandonar recuperação da edição"
 }

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1912,7 +1912,19 @@
 	"chat.draft.queueReplaced": "此排队消息编辑已被替换。未发送任何内容。",
 	"chat.draft.queuePrepareFailed": "无法在本地保存草稿及其恢复 ID。未发送任何内容。请恢复本地存储后重试。",
 	"chat.draft.queueClearFailed": "内容已被接受，但仍需清除本地草稿。",
+	"chat.draft.clearEdit": "完成清除已接受的草稿",
 	"chat.draft.retryEdit": "安全重试",
+	"chat.draft.acceptedEdit": "内容已被接受，但仍需清除本地草稿。",
+	"chat.draft.editRestart": "AO 无法确定代理是否已收到此内容。请使用相同的投递 ID 安全重试，或放弃恢复后再编辑。放弃后再次发送可能导致重复投递。",
+	"chat.draft.clearEditFailed": "内容已被接受，但无法清除本地草稿。请在离开前重试清除；AO 不会再次发送。",
+	"chat.draft.recordEditFailed": "无法在本地记录接受结果。请使用相同的投递 ID 安全重试以确认结果。",
+	"chat.draft.abandonEditFailed": "无法清除本地记录，因此无法放弃恢复。不会自动重新发送任何内容。",
+	"chat.draft.abandonedEdit": "已放弃恢复。之前的内容可能已投递；再次发送可能导致重复。",
+	"chat.draft.editSaveFailed": "无法保存草稿。请保持此聊天打开，或在离开前复制草稿。",
+	"chat.draft.editDiscardFailed": "无法放弃此编辑。请保持此聊天打开并重试。",
+	"chat.draft.prepareEditFailed": "无法在本地保存草稿及其恢复 ID。未发送任何内容。请恢复本地存储后重试。",
+	"chat.draft.clearRefusedEditFailed": "投递被拒绝，但无法清除本地恢复记录。不会自动重新发送任何内容。",
+	"chat.draft.editUncertain": "AO 无法确定代理是否已收到此内容。请使用相同的投递 ID 安全重试，或放弃恢复后再编辑。放弃后再次发送可能导致重复投递。",
 	"chat.draft.abandon": "放弃恢复",
 	"chat.draft.filesUnavailable": "文件尚未持久保存。未发送任何内容。",
 	"chat.draftDiscard.title": "放弃尚未安全保存的聊天草稿？",
@@ -1923,5 +1935,6 @@
 	"chat.draftDiscard.nativeTitle": "未保存的聊天草稿",
 	"chat.draftDiscard.nativeMessage": "此聊天草稿尚未安全保存。",
 	"chat.draftDiscard.stay": "留下",
-	"chat.draftDiscard.leaveAnyway": "仍然离开"
+	"chat.draftDiscard.leaveAnyway": "仍然离开",
+	"chat.edit.abandonRecovery": "放弃编辑恢复"
 }

--- a/frontend/src/renderer/lib/chat-drafts.test.ts
+++ b/frontend/src/renderer/lib/chat-drafts.test.ts
@@ -2,20 +2,31 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
 	acknowledgeChatComposerMutation,
+	acknowledgeChatInlineEditMutation,
 	activateChatDraftScope,
 	beginChatComposerMutation,
+	beginChatInlineEditMutation,
 	cancelChatComposerMutation,
+	cancelChatInlineEditMutation,
 	clearAcceptedChatComposer,
+	clearAcceptedChatInlineEdit,
 	clearRejectedChatComposerDelivery,
+	clearRejectedChatInlineEditDelivery,
+	clearUncertainChatInlineEditDelivery,
 	clearUncertainChatComposerDelivery,
 	finishChatComposerMutation,
+	finishChatInlineEditMutation,
 	getChatComposerMutation,
+	getChatInlineEditMutation,
 	markChatComposerDeliveryAccepted,
+	markChatInlineEditDeliveryAccepted,
 	prepareChatComposerDelivery,
+	prepareChatInlineEditDelivery,
 	readChatSessionDraft,
 	subscribeChatDraftRuntime,
 	writeChatAttachments,
 	writeChatComposerText,
+	writeChatInlineEdit,
 	type DraftStorage,
 	type ChatDraftScope,
 } from "./chat-drafts";
@@ -37,6 +48,138 @@ class MemoryStorage implements DraftStorage {
 }
 
 describe("Chat draft storage", () => {
+	it("lets authoritative recreation purge once while every late obsolete callback fails closed", () => {
+		const storage = new MemoryStorage();
+		const first: ChatDraftScope = {
+			sessionId: "session-recreated",
+			incarnation: "2026-08-25T09:00:00.000Z",
+		};
+		const replacement: ChatDraftScope = {
+			sessionId: first.sessionId,
+			incarnation: "2026-08-26T09:00:00.000Z",
+		};
+		expect(activateChatDraftScope(first, storage)).toMatchObject({ ok: true });
+		writeChatComposerText(first, "belongs to deleted session", storage);
+		writeChatAttachments(
+			first,
+			[
+				{
+					id: "old-attachment",
+					path: ".ao/attachments/old.png",
+					name: "old.png",
+					mimeType: "image/png",
+					bytes: 10,
+				},
+			],
+			storage,
+		);
+		const oldSend = prepareChatComposerDelivery(
+			first,
+			{
+				kind: "steer",
+				composerText: "belongs to deleted session",
+				attachments: [],
+				requestText: "belongs to deleted session",
+				clientMessageId: "old-unresolved-delivery",
+			},
+			storage,
+		);
+		const oldEdit = prepareChatInlineEditDelivery(
+			first,
+			{
+				turnId: "old-turn",
+				text: "old edit",
+				content: [],
+				clientMessageId: "old-edit-delivery",
+			},
+			storage,
+		);
+		expect(oldSend.ok).toBe(true);
+		expect(oldEdit.ok).toBe(true);
+		expect(beginChatComposerMutation(first)).toBeTypeOf("symbol");
+		expect(beginChatInlineEditMutation(first)).toBeTypeOf("symbol");
+
+		expect(activateChatDraftScope(replacement, storage)).toMatchObject({
+			ok: true,
+			replaced: true,
+		});
+		expect(writeChatComposerText(replacement, "replacement draft", storage).ok).toBe(true);
+		expect(
+			writeChatAttachments(
+				replacement,
+				[
+					{
+						id: "new-attachment",
+						path: ".ao/attachments/new.png",
+						name: "new.png",
+						mimeType: "image/png",
+						bytes: 20,
+					},
+				],
+				storage,
+			).ok,
+		).toBe(true);
+		expect(
+			writeChatInlineEdit(
+				replacement,
+				{ turnId: "new-turn", text: "replacement edit", content: [] },
+				storage,
+			).ok,
+		).toBe(true);
+
+		// These model late FileReader/staging, send, edit, and stale-render callbacks
+		// from the deleted incarnation after the replacement already owns storage.
+		expect(writeChatComposerText(first, "late old text", storage).ok).toBe(false);
+		expect(
+			writeChatAttachments(
+				first,
+				[
+					{
+						id: "late-old-attachment",
+						path: ".ao/attachments/late-old.png",
+						name: "late-old.png",
+						mimeType: "image/png",
+						bytes: 30,
+					},
+				],
+				storage,
+			).ok,
+		).toBe(false);
+		expect(
+			markChatComposerDeliveryAccepted(
+				first,
+				"old-unresolved-delivery",
+				oldSend.mutation!.revision,
+				storage,
+			).ok,
+		).toBe(false);
+		expect(
+			markChatInlineEditDeliveryAccepted(
+				first,
+				"old-edit-delivery",
+				oldEdit.mutation!.revision,
+				storage,
+			).ok,
+		).toBe(false);
+		expect(activateChatDraftScope(first, storage)).toMatchObject({
+			ok: false,
+			reason: "obsolete",
+		});
+
+		const restored = readChatSessionDraft(replacement, storage);
+		expect(restored).toMatchObject({
+			sessionId: replacement.sessionId,
+			incarnation: replacement.incarnation,
+			composer: {
+				text: "replacement draft",
+				attachments: [{ id: "new-attachment", path: ".ao/attachments/new.png" }],
+			},
+			inlineEdit: { turnId: "new-turn", text: "replacement edit" },
+		});
+		expect(restored.composer.delivery).toBeUndefined();
+		expect(getChatComposerMutation(first)).toEqual({ pending: false });
+		expect(getChatInlineEditMutation(first)).toEqual({ pending: false });
+	});
 
 	it("keeps both incarnations fail closed until an interrupted authoritative purge finishes", () => {
 		const backing = new MemoryStorage();
@@ -77,6 +220,51 @@ describe("Chat draft storage", () => {
 		expect(writeChatComposerText(first, "still obsolete", backing).ok).toBe(false);
 	});
 
+	it("purges retained receipts when an authoritative incarnation replaces their scope", () => {
+		const storage = new MemoryStorage();
+		const first: ChatDraftScope = {
+			sessionId: "session-retained-receipts",
+			incarnation: "2026-08-25T09:00:00.000Z",
+		};
+		const replacement: ChatDraftScope = {
+			sessionId: first.sessionId,
+			incarnation: "2026-08-26T09:00:00.000Z",
+		};
+		expect(activateChatDraftScope(first, storage)).toMatchObject({ ok: true });
+
+		const composerRevision = writeChatComposerText(first, "accepted", storage).draft.composer
+			.revision;
+		const composerToken = beginChatComposerMutation(first)!;
+		finishChatComposerMutation(
+			first,
+			composerToken,
+			composerRevision,
+			clearAcceptedChatComposer(first, composerRevision, storage),
+		);
+		const inlineRevision = writeChatInlineEdit(
+			first,
+			{ turnId: "turn-1", text: "accepted edit", content: [] },
+			storage,
+		).draft.inlineEdit!.revision;
+		const inlineToken = beginChatInlineEditMutation(first)!;
+		finishChatInlineEditMutation(
+			first,
+			inlineToken,
+			inlineRevision,
+			clearAcceptedChatInlineEdit(first, inlineRevision, storage),
+		);
+		expect(getChatComposerMutation(first).accepted).toBeDefined();
+		expect(getChatInlineEditMutation(first).accepted).toBeDefined();
+
+		expect(activateChatDraftScope(replacement, storage)).toMatchObject({
+			ok: true,
+			replaced: true,
+			previousIncarnation: first.incarnation,
+		});
+		expect(getChatComposerMutation(first)).toEqual({ pending: false });
+		expect(getChatInlineEditMutation(first)).toEqual({ pending: false });
+	});
+
 	it("warned abandon clears only an uncertain steer journal", () => {
 		const storage = new MemoryStorage();
 		const scope: ChatDraftScope = { sessionId: "session-abandon", incarnation: "one" };
@@ -114,6 +302,44 @@ describe("Chat draft storage", () => {
 		});
 		expect(readChatSessionDraft(scope, storage).composer.delivery).toBeUndefined();
 	});
+	it("round-trips independent composer, attachment, and inline-edit state per session", () => {
+		const storage = new MemoryStorage();
+		writeChatComposerText("session/a", "composer A", storage);
+		writeChatAttachments(
+			"session/a",
+			[
+				{
+					id: "attachment-a",
+					path: ".ao/attachments/attachment-a.png",
+					name: "a.png",
+					mimeType: "image/png",
+					bytes: 4,
+				},
+			],
+			storage,
+		);
+		writeChatInlineEdit(
+			"session/a",
+			{
+				turnId: "turn-a",
+				text: "edit A",
+				content: [{ type: "image", name: "a.png" }],
+			},
+			storage,
+		);
+		writeChatComposerText("session/b", "composer B", storage);
+
+		const sessionA = readChatSessionDraft("session/a", storage);
+		expect(sessionA.composer.text).toBe("composer A");
+		expect(sessionA.composer.attachments).toEqual([
+			expect.objectContaining({
+				id: "attachment-a",
+				path: ".ao/attachments/attachment-a.png",
+			}),
+		]);
+		expect(sessionA.inlineEdit).toEqual(expect.objectContaining({ turnId: "turn-a", text: "edit A" }));
+		expect(readChatSessionDraft("session/b", storage).composer.text).toBe("composer B");
+	});
 
 	it("does not clear a composer revision changed while an accepted send was pending", () => {
 		const storage = new MemoryStorage();
@@ -136,6 +362,34 @@ describe("Chat draft storage", () => {
 			cleared: true,
 		});
 		expect(readChatSessionDraft("session-a", storage).composer.text).toBe("");
+	});
+
+	it("clears inline-edit metadata without touching the independent composer", () => {
+		const storage = new MemoryStorage();
+		writeChatComposerText("session-a", "keep composer", storage);
+		writeChatInlineEdit("session-a", { turnId: "turn-a", text: "discard edit", content: [] }, storage);
+
+		expect(writeChatInlineEdit("session-a", undefined, storage).ok).toBe(true);
+		const restored = readChatSessionDraft("session-a", storage);
+		expect(restored.inlineEdit).toBeUndefined();
+		expect(restored.composer.text).toBe("keep composer");
+	});
+
+	it("does not clear a newer inline edit when an older accepted edit completes", () => {
+		const storage = new MemoryStorage();
+		const accepted = writeChatInlineEdit(
+			"session-a",
+			{ turnId: "turn-a", text: "submitted edit", content: [] },
+			storage,
+		).draft.inlineEdit?.revision;
+		expect(accepted).toBeTypeOf("string");
+		writeChatInlineEdit("session-a", { turnId: "turn-a", text: "newer remounted edit", content: [] }, storage);
+
+		expect(clearAcceptedChatInlineEdit("session-a", accepted!, storage)).toMatchObject({
+			ok: true,
+			cleared: false,
+		});
+		expect(readChatSessionDraft("session-a", storage).inlineEdit?.text).toBe("newer remounted edit");
 	});
 
 	it("rejects corrupt and foreign-session records", () => {
@@ -409,6 +663,168 @@ describe("Chat draft storage", () => {
 		expect(restored.composer.delivery).toBeUndefined();
 	});
 
+	it("persists and accepts an inline-edit delivery with one stable client id", () => {
+		const storage = new MemoryStorage();
+		const prepared = prepareChatInlineEditDelivery(
+			"session-edit-proof",
+			{
+				turnId: "turn-1",
+				text: "durable edit",
+				content: [],
+				clientMessageId: "edit-proof-1",
+			},
+			storage,
+		);
+
+		expect(prepared).toMatchObject({
+			ok: true,
+			mutation: {
+				state: "dispatching",
+				turnId: "turn-1",
+				requestText: "durable edit",
+				clientMessageId: "edit-proof-1",
+			},
+		});
+		expect(
+			markChatInlineEditDeliveryAccepted(
+				"session-edit-proof",
+				"edit-proof-1",
+				prepared.mutation!.revision,
+				storage,
+			),
+		).toMatchObject({ ok: true });
+		expect(readChatSessionDraft("session-edit-proof", storage).inlineEditDelivery?.state).toBe(
+			"accepted",
+		);
+	});
+
+	it("clears only a definitively rejected inline-edit journal", () => {
+		const storage = new MemoryStorage();
+		const prepared = prepareChatInlineEditDelivery(
+			"session-edit-rejected",
+			{
+				turnId: "turn-1",
+				text: "keep rejected edit",
+				content: [],
+				clientMessageId: "edit-rejected-1",
+			},
+			storage,
+		);
+		expect(prepared.ok).toBe(true);
+
+		expect(
+			clearRejectedChatInlineEditDelivery(
+				"session-edit-rejected",
+				"edit-rejected-1",
+				prepared.mutation!.revision,
+				storage,
+			),
+		).toMatchObject({ ok: true });
+		const restored = readChatSessionDraft("session-edit-rejected", storage);
+		expect(restored.inlineEdit?.text).toBe("keep rejected edit");
+		expect(restored.inlineEditDelivery).toBeUndefined();
+	});
+
+	it("explicitly abandons only an uncertain inline-edit journal", () => {
+		const storage = new MemoryStorage();
+		const prepared = prepareChatInlineEditDelivery(
+			"session-edit-uncertain",
+			{
+				turnId: "turn-1",
+				text: "possibly delivered edit",
+				content: [{ type: "image", name: "preserved.png" }],
+				clientMessageId: "edit-uncertain-1",
+			},
+			storage,
+		);
+		expect(prepared.ok).toBe(true);
+
+		expect(
+			clearUncertainChatInlineEditDelivery(
+				"session-edit-uncertain",
+				"edit-uncertain-1",
+				prepared.mutation!.revision,
+				storage,
+			),
+		).toMatchObject({ ok: true });
+		const restored = readChatSessionDraft("session-edit-uncertain", storage);
+		expect(restored.inlineEdit).toMatchObject({
+			turnId: "turn-1",
+			text: "possibly delivered edit",
+			content: [{ type: "image", name: "preserved.png" }],
+		});
+		expect(restored.inlineEditDelivery).toBeUndefined();
+	});
+
+	it("clears only the accepted delivery journal when a later inline edit exists", () => {
+		const storage = new MemoryStorage();
+		const prepared = prepareChatInlineEditDelivery(
+			"session-later-edit",
+			{
+				turnId: "turn-1",
+				text: "submitted edit",
+				content: [],
+				clientMessageId: "submitted-edit-1",
+			},
+			storage,
+		);
+		expect(prepared.ok).toBe(true);
+		writeChatInlineEdit(
+			"session-later-edit",
+			{ turnId: "turn-1", text: "newer edit", content: [] },
+			storage,
+		);
+
+		expect(
+			clearAcceptedChatInlineEdit(
+				"session-later-edit",
+				prepared.mutation!.revision,
+				storage,
+			),
+		).toMatchObject({ ok: true, cleared: false });
+		const restored = readChatSessionDraft("session-later-edit", storage);
+		expect(restored.inlineEdit?.text).toBe("newer edit");
+		expect(restored.inlineEditDelivery).toBeUndefined();
+	});
+
+	it("keeps only in-flight mutation ownership across remounts and evicts it once settled", () => {
+		const storage = new MemoryStorage();
+		const sessionId = "runtime-session-a";
+		const revision = writeChatComposerText(sessionId, "send once", storage).draft.composer.revision;
+		const unsubscribeFirstMount = subscribeChatDraftRuntime(sessionId, () => undefined);
+		const token = beginChatComposerMutation(sessionId);
+		expect(token).toBeTypeOf("symbol");
+		expect(beginChatComposerMutation(sessionId)).toBeUndefined();
+		expect(getChatComposerMutation(sessionId).pending).toBe(true);
+		expect(getChatComposerMutation("runtime-session-b").pending).toBe(false);
+
+		unsubscribeFirstMount();
+		expect(getChatComposerMutation(sessionId).pending).toBe(true);
+		const unsubscribeRemount = subscribeChatDraftRuntime(sessionId, () => undefined);
+		cancelChatComposerMutation(sessionId, Symbol("stale"));
+		expect(getChatComposerMutation(sessionId).pending).toBe(true);
+		const result = clearAcceptedChatComposer(sessionId, revision, storage);
+		finishChatComposerMutation(sessionId, token!, revision, result);
+		expect(getChatComposerMutation(sessionId)).toMatchObject({
+			pending: false,
+			accepted: { revision, result: { ok: true, cleared: true } },
+		});
+
+		const inlineToken = beginChatInlineEditMutation(sessionId);
+		expect(inlineToken).toBeTypeOf("symbol");
+		expect(getChatInlineEditMutation(sessionId).pending).toBe(true);
+		cancelChatInlineEditMutation(sessionId, inlineToken!);
+		expect(getChatInlineEditMutation(sessionId)).toEqual({ pending: false });
+
+		acknowledgeChatComposerMutation(
+			sessionId,
+			getChatComposerMutation(sessionId).accepted!.sequence,
+		);
+		unsubscribeRemount();
+		expect(getChatComposerMutation(sessionId)).toEqual({ pending: false });
+		expect(getChatInlineEditMutation(sessionId)).toEqual({ pending: false });
+	});
+
 	it("keeps an accepted send when the old passive cleanup runs before the replacement subscribes", () => {
 		const storage = new MemoryStorage();
 		const sessionId = "runtime-old-cleanup-before-new-subscribe";
@@ -499,6 +915,62 @@ describe("Chat draft storage", () => {
 		expect(getChatComposerMutation(sessionId)).toEqual({ pending: false });
 	});
 
+	it("keeps more than 64 delayed composer and inline handoffs until each replacement acknowledges", () => {
+		const storage = new MemoryStorage();
+		const sessionIds = Array.from(
+			{ length: 65 },
+			(_, index) => `runtime-delayed-handoff-${index}`,
+		);
+		for (const sessionId of sessionIds) {
+			const composerRevision = writeChatComposerText(sessionId, "accepted", storage).draft.composer
+				.revision;
+			const inlineRevision = writeChatInlineEdit(
+				sessionId,
+				{ turnId: "turn-1", text: "accepted edit", content: [] },
+				storage,
+			).draft.inlineEdit!.revision;
+			const unsubscribeOldSurface = subscribeChatDraftRuntime(sessionId, () => undefined);
+			const composerToken = beginChatComposerMutation(sessionId)!;
+			const inlineToken = beginChatInlineEditMutation(sessionId)!;
+			// The replacement has rendered from the in-flight snapshot, but its passive
+			// subscription is deliberately delayed until every request below settles.
+			expect(getChatComposerMutation(sessionId)).toEqual({ pending: true });
+			expect(getChatInlineEditMutation(sessionId)).toEqual({ pending: true });
+			finishChatComposerMutation(
+				sessionId,
+				composerToken,
+				composerRevision,
+				clearAcceptedChatComposer(sessionId, composerRevision, storage),
+			);
+			finishChatInlineEditMutation(
+				sessionId,
+				inlineToken,
+				inlineRevision,
+				clearAcceptedChatInlineEdit(sessionId, inlineRevision, storage),
+			);
+			unsubscribeOldSurface();
+		}
+
+		for (const sessionId of sessionIds) {
+			const unsubscribeReplacement = subscribeChatDraftRuntime(sessionId, () => undefined);
+			const acceptedComposer = getChatComposerMutation(sessionId).accepted;
+			const acceptedInline = getChatInlineEditMutation(sessionId).accepted;
+			expect(acceptedComposer).toBeDefined();
+			expect(acceptedInline).toBeDefined();
+			acknowledgeChatComposerMutation(sessionId, acceptedComposer!.sequence);
+			expect(getChatComposerMutation(sessionId)).toEqual({ pending: false });
+			expect(getChatInlineEditMutation(sessionId).accepted).toBe(acceptedInline);
+			acknowledgeChatInlineEditMutation(sessionId, acceptedInline!.sequence);
+			expect(getChatInlineEditMutation(sessionId)).toEqual({ pending: false });
+			unsubscribeReplacement();
+
+			const unsubscribeLaterMount = subscribeChatDraftRuntime(sessionId, () => undefined);
+			expect(getChatComposerMutation(sessionId)).toEqual({ pending: false });
+			expect(getChatInlineEditMutation(sessionId)).toEqual({ pending: false });
+			unsubscribeLaterMount();
+		}
+	});
+
 	it("evicts an acknowledged failed-clear receipt after the final subscriber leaves", () => {
 		const backing = new MemoryStorage();
 		const sessionId = "runtime-failed-clear";
@@ -528,6 +1000,53 @@ describe("Chat draft storage", () => {
 		);
 		unsubscribe();
 		expect(getChatComposerMutation(sessionId)).toEqual({ pending: false });
+	});
+
+	it("waits for every mutation receipt to be acknowledged before evicting an unmounted runtime", () => {
+		const storage = new MemoryStorage();
+		const sessionId = "runtime-two-pending-mutations";
+		const composerRevision = writeChatComposerText(sessionId, "send once", storage).draft
+			.composer.revision;
+		const inlineRevision = writeChatInlineEdit(
+			sessionId,
+			{ turnId: "turn-1", text: "edit once", content: [] },
+			storage,
+		).draft.inlineEdit!.revision;
+		const unsubscribe = subscribeChatDraftRuntime(sessionId, () => undefined);
+		const composerToken = beginChatComposerMutation(sessionId)!;
+		const inlineToken = beginChatInlineEditMutation(sessionId)!;
+		unsubscribe();
+
+		finishChatComposerMutation(
+			sessionId,
+			composerToken,
+			composerRevision,
+			clearAcceptedChatComposer(sessionId, composerRevision, storage),
+		);
+		expect(getChatComposerMutation(sessionId).accepted?.revision).toBe(composerRevision);
+		expect(getChatInlineEditMutation(sessionId).pending).toBe(true);
+
+		finishChatInlineEditMutation(
+			sessionId,
+			inlineToken,
+			inlineRevision,
+			clearAcceptedChatInlineEdit(sessionId, inlineRevision, storage),
+		);
+		expect(getChatComposerMutation(sessionId).accepted?.revision).toBe(composerRevision);
+		expect(getChatInlineEditMutation(sessionId).accepted?.revision).toBe(inlineRevision);
+
+		acknowledgeChatComposerMutation(
+			sessionId,
+			getChatComposerMutation(sessionId).accepted!.sequence,
+		);
+		expect(getChatComposerMutation(sessionId)).toEqual({ pending: false });
+		expect(getChatInlineEditMutation(sessionId).accepted?.revision).toBe(inlineRevision);
+		acknowledgeChatInlineEditMutation(
+			sessionId,
+			getChatInlineEditMutation(sessionId).accepted!.sequence,
+		);
+		expect(getChatComposerMutation(sessionId)).toEqual({ pending: false });
+		expect(getChatInlineEditMutation(sessionId)).toEqual({ pending: false });
 	});
 
 	it("does not let a deleted runtime's late unsubscribe evict a later in-flight owner", () => {

--- a/frontend/src/renderer/lib/chat-drafts.ts
+++ b/frontend/src/renderer/lib/chat-drafts.ts
@@ -1,3 +1,4 @@
+import type { ConversationContentSummary } from "../types/conversation";
 
 /**
  * Renderer-owned, session-scoped Chat drafts.
@@ -44,6 +45,43 @@ export interface ChatDraftAttachment {
 	bytes: number;
 }
 
+export interface ChatDraftInlineEdit {
+	/** Changes whenever the inline edit changes. Used for accepted-edit CAS. */
+	revision: string;
+	turnId: string;
+	text: string;
+	content: ConversationContentSummary[];
+	/** True when the edit replays portable history instead of using a native fork. */
+	reconstructedContext?: boolean;
+}
+
+export interface ChatDraftQueuedEdit {
+	/** Original request mode, independent of current controller capabilities. */
+	nativeImages?: boolean;
+	/** Stable daemon receipt key for the exact pending save. */
+	clientMessageId?: string;
+	/** Stable for one editing attempt, including remounts and staged reads. */
+	ownerId?: string;
+	revision: string;
+	turnId: string;
+	text: string;
+	/** Daemon message revision, held fixed across retries of this edit. */
+	expectedRevision?: number;
+	attachments?: ChatDraftRetainedAttachment[];
+	stagedAttachments?: ChatDraftAttachment[];
+	/** The daemon may have saved this exact edit before the response was lost. */
+	saving?: boolean;
+}
+
+/** Server-owned content selected for retention; never stores attachment bytes. */
+export interface ChatDraftRetainedAttachment {
+	id: string;
+	name: string;
+	path?: string;
+	contentIndex?: number;
+	contentType?: string;
+}
+
 export type ChatDraftDeliveryState = "dispatching" | "accepted";
 
 export interface ChatComposerDelivery {
@@ -59,6 +97,18 @@ export interface ChatComposerDelivery {
 	requestText: string;
 }
 
+export interface ChatInlineEditDelivery {
+	kind: "inline-edit";
+	state: ChatDraftDeliveryState;
+	/** Exact inline-edit revision this delivery was created from. */
+	revision: string;
+	clientMessageId: string;
+	turnId: string;
+	requestText: string;
+}
+
+export type ChatDraftInlineEditInput = Omit<ChatDraftInlineEdit, "revision">;
+
 export interface ChatSessionDraft {
 	schemaVersion: typeof CHAT_DRAFT_SCHEMA_VERSION;
 	sessionId: string;
@@ -72,6 +122,9 @@ export interface ChatSessionDraft {
 		delivery?: ChatComposerDelivery;
 	};
 	queuedEdit?: ChatDraftQueuedEdit;
+	inlineEdit?: ChatDraftInlineEdit;
+	/** Durable delivery journal for an inline branch edit. */
+	inlineEditDelivery?: ChatInlineEditDelivery;
 }
 
 export type DraftStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
@@ -95,6 +148,10 @@ export interface PrepareChatComposerDeliveryInput {
 	clientMessageId: string;
 }
 
+export interface PrepareChatInlineEditDeliveryInput extends ChatDraftInlineEditInput {
+	clientMessageId: string;
+}
+
 export type ChatDraftMutationToken = symbol;
 
 export interface ChatDraftMutationSnapshot<Revision> {
@@ -106,16 +163,19 @@ export interface ChatDraftMutationSnapshot<Revision> {
 	};
 }
 
-type DraftMutationKind = "composer";
+type DraftMutationKind = "composer" | "inline-edit";
 
 type ChatDraftRuntime = {
 	sessionId: string;
 	listeners: Set<() => void>;
 	composerToken?: ChatDraftMutationToken;
+	inlineEditToken?: ChatDraftMutationToken;
 	composer: ChatDraftMutationSnapshot<number>;
+	inlineEdit: ChatDraftMutationSnapshot<string>;
 };
 
 const EMPTY_COMPOSER_MUTATION: ChatDraftMutationSnapshot<number> = { pending: false };
+const EMPTY_INLINE_EDIT_MUTATION: ChatDraftMutationSnapshot<string> = { pending: false };
 const draftRuntimes = new Map<string, ChatDraftRuntime>();
 let draftMutationSequence = 0;
 
@@ -156,9 +216,9 @@ function purgeDraftRuntimes(sessionId: string): void {
 	for (const [key, runtime] of draftRuntimes) {
 		if (runtime.sessionId !== sessionId) continue;
 		runtime.composerToken = undefined;
-
+		runtime.inlineEditToken = undefined;
 		runtime.composer = EMPTY_COMPOSER_MUTATION;
-
+		runtime.inlineEdit = EMPTY_INLINE_EDIT_MUTATION;
 		draftRuntimes.delete(key);
 	}
 }
@@ -172,6 +232,7 @@ function draftRuntime(scope: ChatDraftScopeInput): ChatDraftRuntime {
 			sessionId: identity.sessionId,
 			listeners: new Set(),
 			composer: EMPTY_COMPOSER_MUTATION,
+			inlineEdit: EMPTY_INLINE_EDIT_MUTATION,
 		};
 		draftRuntimes.set(key, runtime);
 	}
@@ -182,7 +243,9 @@ function evictSettledDraftRuntime(key: string, runtime: ChatDraftRuntime): void 
 	if (
 		runtime.listeners.size > 0 ||
 		runtime.composer.pending ||
+		runtime.inlineEdit.pending ||
 		runtime.composer.accepted ||
+		runtime.inlineEdit.accepted ||
 		draftRuntimes.get(key) !== runtime
 	) return;
 	draftRuntimes.delete(key);
@@ -197,7 +260,7 @@ function clearDraftMutationReceipt(
 		runtime.composer = { pending: pending ?? runtime.composer.pending };
 		return;
 	}
-
+	runtime.inlineEdit = { pending: pending ?? runtime.inlineEdit.pending };
 }
 
 function emitDraftRuntime(runtime: ChatDraftRuntime): void {
@@ -231,6 +294,14 @@ export function isChatComposerMutationCurrent(
 	return draftRuntimes.get(draftRuntimeKey(scope))?.composerToken === token;
 }
 
+export function getChatInlineEditMutation(
+	scope: ChatDraftScopeInput,
+): ChatDraftMutationSnapshot<string> {
+	const runtime = draftRuntimes.get(draftRuntimeKey(scope));
+	if (!runtime) return EMPTY_INLINE_EDIT_MUTATION;
+	return runtime.inlineEdit;
+}
+
 function beginDraftMutation(
 	scope: ChatDraftScopeInput,
 	kind: DraftMutationKind,
@@ -245,11 +316,20 @@ function beginDraftMutation(
 		emitDraftRuntime(runtime);
 		return token;
 	}
-	return undefined;
+	if (runtime.inlineEdit.pending || runtime.inlineEdit.accepted) return undefined;
+	const token = Symbol("chat-inline-edit-mutation");
+	runtime.inlineEditToken = token;
+	runtime.inlineEdit = { pending: true };
+	emitDraftRuntime(runtime);
+	return token;
 }
 
 export function beginChatComposerMutation(scope: ChatDraftScopeInput): ChatDraftMutationToken | undefined {
 	return beginDraftMutation(scope, "composer");
+}
+
+export function beginChatInlineEditMutation(scope: ChatDraftScopeInput): ChatDraftMutationToken | undefined {
+	return beginDraftMutation(scope, "inline-edit");
 }
 
 function cancelDraftMutation(
@@ -264,6 +344,10 @@ function cancelDraftMutation(
 		if (runtime.composerToken !== token) return;
 		runtime.composerToken = undefined;
 		clearDraftMutationReceipt(runtime, "composer", false);
+	} else {
+		if (runtime.inlineEditToken !== token) return;
+		runtime.inlineEditToken = undefined;
+		clearDraftMutationReceipt(runtime, "inline-edit", false);
 	}
 	emitDraftRuntime(runtime);
 	evictSettledDraftRuntime(key, runtime);
@@ -274,6 +358,13 @@ export function cancelChatComposerMutation(
 	token: ChatDraftMutationToken,
 ): void {
 	cancelDraftMutation(scope, "composer", token);
+}
+
+export function cancelChatInlineEditMutation(
+	scope: ChatDraftScopeInput,
+	token: ChatDraftMutationToken,
+): void {
+	cancelDraftMutation(scope, "inline-edit", token);
 }
 
 export function finishChatComposerMutation(
@@ -295,6 +386,25 @@ export function finishChatComposerMutation(
 	evictSettledDraftRuntime(key, runtime);
 }
 
+export function finishChatInlineEditMutation(
+	scope: ChatDraftScopeInput,
+	token: ChatDraftMutationToken,
+	revision: string,
+	result: DraftClearResult,
+): void {
+	const key = draftRuntimeKey(scope);
+	const runtime = draftRuntimes.get(key);
+	if (!runtime || runtime.inlineEditToken !== token) return;
+	runtime.inlineEditToken = undefined;
+	const sequence = ++draftMutationSequence;
+	runtime.inlineEdit = {
+		pending: false,
+		accepted: { sequence, revision, result },
+	};
+	emitDraftRuntime(runtime);
+	evictSettledDraftRuntime(key, runtime);
+}
+
 function acknowledgeDraftMutation(
 	scope: ChatDraftScopeInput,
 	kind: DraftMutationKind,
@@ -306,6 +416,9 @@ function acknowledgeDraftMutation(
 	if (kind === "composer") {
 		if (runtime.composer.accepted?.sequence !== sequence) return;
 		clearDraftMutationReceipt(runtime, "composer");
+	} else {
+		if (runtime.inlineEdit.accepted?.sequence !== sequence) return;
+		clearDraftMutationReceipt(runtime, "inline-edit");
 	}
 	emitDraftRuntime(runtime);
 	evictSettledDraftRuntime(key, runtime);
@@ -314,7 +427,7 @@ function acknowledgeDraftMutation(
 /**
  * Release a settled composer receipt only after a committed subscriber applied
  * it. No task duration or global pressure decides this lifetime. Each exact
- * session incarnation owns at most one composer receipt;
+ * session incarnation owns at most one composer and one inline-edit receipt;
  * acknowledgement, a superseding durable edit, or authoritative incarnation
  * cleanup retires them.
  */
@@ -325,6 +438,14 @@ export function acknowledgeChatComposerMutation(
 	acknowledgeDraftMutation(scope, "composer", sequence);
 }
 
+/** See acknowledgeChatComposerMutation. */
+export function acknowledgeChatInlineEditMutation(
+	scope: ChatDraftScopeInput,
+	sequence: number,
+): void {
+	acknowledgeDraftMutation(scope, "inline-edit", sequence);
+}
+
 function invalidateAcceptedDraftMutation(scope: ChatDraftScopeInput, kind: DraftMutationKind): void {
 	const key = draftRuntimeKey(scope);
 	const runtime = draftRuntimes.get(key);
@@ -332,6 +453,9 @@ function invalidateAcceptedDraftMutation(scope: ChatDraftScopeInput, kind: Draft
 	if (kind === "composer") {
 		if (!runtime.composer.accepted) return;
 		clearDraftMutationReceipt(runtime, "composer");
+	} else {
+		if (!runtime.inlineEdit.accepted) return;
+		clearDraftMutationReceipt(runtime, "inline-edit");
 	}
 	emitDraftRuntime(runtime);
 	evictSettledDraftRuntime(key, runtime);
@@ -538,6 +662,17 @@ function emptyDraft(scope: ChatDraftScopeInput): ChatSessionDraft {
 	};
 }
 
+function isContentSummary(value: unknown): value is ConversationContentSummary {
+	if (!value || typeof value !== "object") return false;
+	const content = value as Partial<ConversationContentSummary>;
+	return (
+		typeof content.type === "string" &&
+		(content.mimeType === undefined || typeof content.mimeType === "string") &&
+		(content.uri === undefined || typeof content.uri === "string") &&
+		(content.name === undefined || typeof content.name === "string")
+	);
+}
+
 function isAttachment(value: unknown): value is ChatDraftAttachment {
 	if (!value || typeof value !== "object") return false;
 	const attachment = value as Partial<ChatDraftAttachment>;
@@ -551,6 +686,22 @@ function isAttachment(value: unknown): value is ChatDraftAttachment {
 		typeof attachment.bytes === "number" &&
 		Number.isFinite(attachment.bytes) &&
 		attachment.bytes >= 0
+	);
+}
+
+function isInlineEdit(value: unknown): value is ChatDraftInlineEdit {
+	if (!value || typeof value !== "object") return false;
+	const edit = value as Partial<ChatDraftInlineEdit>;
+	return (
+		typeof edit.revision === "string" &&
+		edit.revision.length > 0 &&
+			typeof edit.turnId === "string" &&
+			edit.turnId.length > 0 &&
+			typeof edit.text === "string" &&
+			(edit.reconstructedContext === undefined ||
+				typeof edit.reconstructedContext === "boolean") &&
+			Array.isArray(edit.content) &&
+			edit.content.every(isContentSummary)
 	);
 }
 
@@ -572,6 +723,27 @@ function isComposerDelivery(value: unknown): value is ChatComposerDelivery {
 		typeof delivery.requestText === "string" &&
 		(!("nativeImages" in delivery) || typeof delivery.nativeImages === "boolean")
 	);
+}
+
+function isInlineEditDelivery(value: unknown): value is ChatInlineEditDelivery {
+	if (!value || typeof value !== "object") return false;
+	const delivery = value as Partial<ChatInlineEditDelivery>;
+	return (
+		delivery.kind === "inline-edit" &&
+		isDeliveryState(delivery.state) &&
+		typeof delivery.revision === "string" &&
+		delivery.revision.length > 0 &&
+		typeof delivery.clientMessageId === "string" &&
+		delivery.clientMessageId.length > 0 &&
+		typeof delivery.turnId === "string" &&
+		delivery.turnId.length > 0 &&
+		typeof delivery.requestText === "string"
+	);
+}
+
+function draftEditRevision(): string {
+	if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+	return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
 function isChatSessionDraft(value: unknown, scope: ChatDraftScope): value is ChatSessionDraft {
@@ -605,7 +777,9 @@ function isChatSessionDraft(value: unknown, scope: ChatDraftScope): value is Cha
 				(item.contentIndex === undefined || (Number.isSafeInteger(item.contentIndex) && item.contentIndex >= 0)) &&
 				(item.contentType === undefined || typeof item.contentType === "string")))) &&
 			(draft.queuedEdit.saving === undefined || typeof draft.queuedEdit.saving === "boolean")
-		))
+		)) &&
+		(draft.inlineEdit === undefined || isInlineEdit(draft.inlineEdit)) &&
+		(draft.inlineEditDelivery === undefined || isInlineEditDelivery(draft.inlineEditDelivery))
 	);
 }
 
@@ -662,7 +836,10 @@ function hasContent(draft: ChatSessionDraft): boolean {
 	return (
 		draft.composer.text !== "" ||
 		draft.composer.attachments.length > 0 ||
-		Boolean(draft.composer.delivery) || Boolean(draft.queuedEdit)
+		Boolean(draft.composer.delivery) ||
+		Boolean(draft.queuedEdit) ||
+		Boolean(draft.inlineEdit) ||
+		Boolean(draft.inlineEditDelivery)
 	);
 }
 
@@ -904,6 +1081,128 @@ export function clearUncertainChatComposerDelivery(
 	return result.ok ? result : { ok: false, draft: loaded.draft };
 }
 
+/**
+ * Atomically proves an inline edit and its stable branch-mutation id before
+ * dispatch. A restored journal is returned unchanged for explicit safe retry.
+ */
+export function prepareChatInlineEditDelivery(
+	scope: ChatDraftScopeInput,
+	input: PrepareChatInlineEditDeliveryInput,
+	storage: DraftStorage | undefined = rendererStorage(),
+): DraftDeliveryResult<ChatInlineEditDelivery> {
+	const loaded = loadChatSessionDraft(scope, storage);
+	if (!loaded.ok) return { ok: false, recovered: false, draft: loaded.draft };
+	if (loaded.draft.inlineEditDelivery) {
+		const proof = persistDraftProven(loaded.draft, storage);
+		return proof.ok
+			? {
+					ok: true,
+					recovered: true,
+					draft: proof.draft,
+					mutation: loaded.draft.inlineEditDelivery,
+				}
+			: { ok: false, recovered: true, draft: loaded.draft };
+	}
+	const current = loaded.draft.inlineEdit;
+	const exact =
+			current?.turnId === input.turnId &&
+			current.text === input.text &&
+			current.reconstructedContext === input.reconstructedContext &&
+			JSON.stringify(current.content) === JSON.stringify(input.content);
+	const inlineEdit: ChatDraftInlineEdit = exact
+		? current
+		: {
+					turnId: input.turnId,
+					text: input.text,
+					content: input.content,
+					reconstructedContext: input.reconstructedContext,
+					revision: draftEditRevision(),
+			};
+	const mutation: ChatInlineEditDelivery = {
+		kind: "inline-edit",
+		state: "dispatching",
+		revision: inlineEdit.revision,
+		clientMessageId: input.clientMessageId,
+		turnId: input.turnId,
+		requestText: input.text,
+	};
+	const next: ChatSessionDraft = {
+		...loaded.draft,
+		inlineEdit,
+		inlineEditDelivery: mutation,
+	};
+	const result = persistDraftProven(next, storage);
+	return result.ok
+		? { ok: true, recovered: false, draft: result.draft, mutation }
+		: { ok: false, recovered: false, draft: loaded.draft };
+}
+
+export function markChatInlineEditDeliveryAccepted(
+	scope: ChatDraftScopeInput,
+	clientMessageId: string,
+	revision: string,
+	storage: DraftStorage | undefined = rendererStorage(),
+): DraftWriteResult {
+	const loaded = loadChatSessionDraft(scope, storage);
+	const delivery = loaded.draft.inlineEditDelivery;
+	if (
+		!loaded.ok ||
+		!delivery ||
+		delivery.clientMessageId !== clientMessageId ||
+		delivery.revision !== revision
+	) {
+		return { ok: false, draft: loaded.draft };
+	}
+	if (delivery.state === "accepted") return { ok: true, draft: loaded.draft };
+	const result = persistDraftProven(
+		{
+			...loaded.draft,
+			inlineEditDelivery: { ...delivery, state: "accepted" },
+		},
+		storage,
+	);
+	return result.ok ? result : { ok: false, draft: loaded.draft };
+}
+
+/** Remove only the journal for an edit the daemon durably proved it rejected. */
+export function clearRejectedChatInlineEditDelivery(
+	scope: ChatDraftScopeInput,
+	clientMessageId: string,
+	revision: string,
+	storage: DraftStorage | undefined = rendererStorage(),
+): DraftWriteResult {
+	const loaded = loadChatSessionDraft(scope, storage);
+	const delivery = loaded.draft.inlineEditDelivery;
+	if (
+		!loaded.ok ||
+		!delivery ||
+		delivery.state !== "dispatching" ||
+		delivery.clientMessageId !== clientMessageId ||
+		delivery.revision !== revision
+	) {
+		return { ok: false, draft: loaded.draft };
+	}
+	const next = { ...loaded.draft };
+	delete next.inlineEditDelivery;
+	const result = persistDraftProven(next, storage);
+	return result.ok ? result : { ok: false, draft: loaded.draft };
+}
+
+/** Explicitly abandon an inline edit whose provider acceptance is unknowable. */
+export function clearUncertainChatInlineEditDelivery(
+	scope: ChatDraftScopeInput,
+	clientMessageId: string,
+	revision: string,
+	storage: DraftStorage | undefined = rendererStorage(),
+): DraftWriteResult {
+	return clearRejectedChatInlineEditDelivery(
+		scope,
+		clientMessageId,
+		revision,
+		storage,
+	);
+}
+
 function mutateDraft(
 	scope: ChatDraftScopeInput,
 	mutate: (draft: ChatSessionDraft) => ChatSessionDraft,
@@ -968,6 +1267,84 @@ export function writeChatAttachments(
 	return result;
 }
 
+/** Queue edits are independent from both the ordinary prompt and history edits. */
+export function writeChatQueuedEdit(
+	scope: ChatDraftScopeInput,
+	edit: Omit<ChatDraftQueuedEdit, "revision"> | undefined,
+	expectedRevision?: string,
+	storage: DraftStorage | undefined = rendererStorage(),
+	previousUnprovenWrite?: { revisions: (string | undefined)[] },
+): DraftWriteResult & { attempted?: { revisions: (string | undefined)[] } } {
+	const loaded = loadChatSessionDraft(scope, storage);
+	if (!loaded.ok || (expectedRevision !== undefined && loaded.draft.queuedEdit?.revision !== expectedRevision &&
+		(!previousUnprovenWrite || !previousUnprovenWrite.revisions.includes(loaded.draft.queuedEdit?.revision)))) {
+		return { ok: false, draft: loaded.draft };
+	}
+	const next = { ...loaded.draft };
+	if (edit) next.queuedEdit = { ...edit, revision: draftEditRevision() };
+	else delete next.queuedEdit;
+	const result = persistDraftProven(next, storage);
+	// A write can commit before its readback fails. Permit a later attempt to
+	// recognize only the loaded or attempted revision, never another editor's
+	// changes. Retain both in case the write itself failed before changing storage.
+	return { ...result, attempted: { revisions: [loaded.draft.queuedEdit?.revision, next.queuedEdit?.revision] } };
+}
+
+export function writeChatInlineEdit(
+	scope: ChatDraftScopeInput,
+	inlineEdit: ChatDraftInlineEditInput | undefined,
+	storage: DraftStorage | undefined = rendererStorage(),
+): DraftWriteResult {
+	const result = mutateDraft(
+		scope,
+		(draft) => {
+			const next = { ...draft };
+			if (inlineEdit) {
+				next.inlineEdit = {
+					...inlineEdit,
+					revision: draftEditRevision(),
+				};
+			} else delete next.inlineEdit;
+			return next;
+		},
+		storage,
+	);
+	if (result.ok) invalidateAcceptedDraftMutation(scope, "inline-edit");
+	return result;
+}
+
+/**
+ * Clear an edit accepted by the daemon only if no later renderer has changed it.
+ * This protects a remounted editor from a stale request completing afterward.
+ */
+export function clearAcceptedChatInlineEdit(
+	scope: ChatDraftScopeInput,
+	acceptedRevision: string,
+	storage: DraftStorage | undefined = rendererStorage(),
+): DraftClearResult {
+	const loaded = loadChatSessionDraft(scope, storage);
+	const current = loaded.draft;
+	if (!loaded.ok) return { ok: false, cleared: false, draft: current };
+	if (!current.inlineEdit || current.inlineEdit.revision !== acceptedRevision) {
+		if (current.inlineEditDelivery?.revision !== acceptedRevision) {
+			return { ok: true, cleared: false, draft: current };
+		}
+		const next = { ...current };
+		delete next.inlineEditDelivery;
+		const result = persistDraftProven(next, storage);
+		return result.ok
+			? { ok: true, cleared: false, draft: result.draft }
+			: { ok: false, cleared: false, draft: current };
+	}
+	const next = { ...current };
+	delete next.inlineEdit;
+	delete next.inlineEditDelivery;
+	const result = persistDraftProven(next, storage);
+	return result.ok
+		? { ok: true, cleared: true, draft: result.draft }
+		: { ok: false, cleared: false, draft: current };
+}
+
 /**
  * Clear the composer accepted by the daemon only if it is still the same
  * revision. A keystroke or attachment change that happened while send awaited
@@ -1010,70 +1387,4 @@ export function clearAcceptedChatComposer(
 	return result.ok
 		? { ok: true, cleared: true, draft: result.draft }
 		: { ok: false, cleared: false, draft: current };
-}
-
-
-
-
-export interface ChatDraftQueuedEdit {
-	/** Original request mode, independent of current controller capabilities. */
-	nativeImages?: boolean;
-	/** Stable daemon receipt key for the exact pending save. */
-	clientMessageId?: string;
-	/** Stable for one editing attempt, including remounts and staged reads. */
-	ownerId?: string;
-	revision: string;
-	turnId: string;
-	text: string;
-	/** Daemon message revision, held fixed across retries of this edit. */
-	expectedRevision?: number;
-	attachments?: ChatDraftRetainedAttachment[];
-	stagedAttachments?: ChatDraftAttachment[];
-	/** The daemon may have saved this exact edit before the response was lost. */
-	saving?: boolean;
-}
-
-
-
-
-/** Server-owned content selected for retention; never stores attachment bytes. */
-export interface ChatDraftRetainedAttachment {
-	id: string;
-	name: string;
-	path?: string;
-	contentIndex?: number;
-	contentType?: string;
-}
-
-
-
-
-/** Queue edits are independent from both the ordinary prompt and history edits. */
-export function writeChatQueuedEdit(
-	scope: ChatDraftScopeInput,
-	edit: Omit<ChatDraftQueuedEdit, "revision"> | undefined,
-	expectedRevision?: string,
-	storage: DraftStorage | undefined = rendererStorage(),
-	previousUnprovenWrite?: { revisions: (string | undefined)[] },
-): DraftWriteResult & { attempted?: { revisions: (string | undefined)[] } } {
-	const loaded = loadChatSessionDraft(scope, storage);
-	if (!loaded.ok || (expectedRevision !== undefined && loaded.draft.queuedEdit?.revision !== expectedRevision &&
-		(!previousUnprovenWrite || !previousUnprovenWrite.revisions.includes(loaded.draft.queuedEdit?.revision)))) {
-		return { ok: false, draft: loaded.draft };
-	}
-	const next = { ...loaded.draft };
-	if (edit) next.queuedEdit = { ...edit, revision: draftEditRevision() };
-	else delete next.queuedEdit;
-	const result = persistDraftProven(next, storage);
-	// A write can commit before its readback fails. Permit a later attempt to
-	// recognize only the loaded or attempted revision, never another editor's
-	// changes. Retain both in case the write itself failed before changing storage.
-	return { ...result, attempted: { revisions: [loaded.draft.queuedEdit?.revision, next.queuedEdit?.revision] } };
-}
-
-
-
-function draftEditRevision(): string {
-	if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
-	return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }

--- a/frontend/src/renderer/types/conversation.ts
+++ b/frontend/src/renderer/types/conversation.ts
@@ -870,3 +870,9 @@ export function pendingUserInput(snapshot: ConversationSnapshot): ConversationAc
 			item.kind === "activity" && item.activityKind === "user_input" && item.status === "pending",
 	);
 }
+
+
+
+
+/** Durable inline-edit acceptance; uncertainty remains a rejected promise. */
+export type ChatEditOutcome = ChatSteerOutcome;


### PR DESCRIPTION
Code changes: +1533 -158  
Tests: +2476 -27  
Others: +353 -8  

### Merge preparation — 11 September 2026

Merge candidate: `7a1bff12210a3e47f91f22888ce8d4cf39d312ae`; base: `main`. Rebased after the preceding stack changes. Unmerged migrations are now 0137 and 0138; current main ACP provider behavior and tests are preserved alongside the reviewed host-shutdown wait. Both local typechecks, 4,413 Vitest tests (6 skipped), all 59 renderer smoke tests, and API/sqlc generation with zero drift passed. All 13 CI jobs passed on `2554956b406c9e9e2dd3ce5efc7a8ca0be0c305e`. The final squash-parent rebase changes ancestry only: its entire Git tree is identical (`8cac9ecf5b237b971782abc5ad1c9df8e6db0ff6`). GitHub has also started fresh CI for the reparented commit. The dated review and evidence below apply to the heads they record.

### Review corrections — 11 September 2026

Missing-turn receipts replay HTTP 404 after restart. Reserved edits with no provider work can recover; completed provider turns can repair their receipts without redispatch. Provider replacement waits for the persistent host to release ownership, and failed shutdown cannot rotate a surviving host’s browser credential.

Current head: `e992529fcde291d36e7bcdf023c16b1b3efcd3d0`. All local validation and current-head CI checks passed. Independent re-review is complete. [Native edit recovery evidence](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Local test results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). Native inline-edit submission, controller stop/resume and same-ID replay succeeded with one stored replacement message. The linked results record validation for those reviewed heads; earlier dated records below retain their original heads.

[Real Electron edit after controller stop and resume](https://github.com/Untrivial-ai/agent-orchestrator/pull/5110#issuecomment-5638403970)

### Conflict resolution — 10 September 2026

Rebased onto main `8343bcc089982e202f0fbc37ff43aa09de3110d4` and restacked in the existing dependency order. Current head: `8bd0986ffdc3c5dba5601bfc047b2b289023ae35`. GitHub reports this PR mergeable. The agreed feature scope and earlier correctness fixes are preserved.

The conflict resolution preserves main’s absence of duplicate composer status text and the inline-edit inert-state assertion.

Fresh validation on this head: complete frontend suite **4,255 passed, 6 skipped**; all **59 renderer smoke tests passed**; frontend and E2E typechecks passed. The cumulative Go race suite, build, vet, pinned linter, shared package checks and native macOS helper checks passed. All **18 latest CI workflows / 48 jobs passed** across the six PRs.

[Conflict resolution diff](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Local test results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549) · [Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). Earlier validation records and screenshots/recordings below retain their recorded pre-rebase commits.

Reloading while editing an earlier prompt loses the inline edit; replaying a lost branch-edit response can fork history twice. Persist the inline editor independently and reserve a durable delivery receipt before the provider history action.

A completed receipt replays its original branch/turn result. A reservation resumes only when its durable dispatch marker proves provider work has not begun. Otherwise it remains uncertain unless a matching completed replacement turn can repair the receipt; recovery never repeats an unproven provider action. Keep acceptance cleanup tied to the submitted edit revision. Adds migrations 0130 and 0132 and SQLC output. This slice has no steer recovery endpoint.

Part 4/5 split from #4463, stacked on `codex/chat-draft-queue`. The two-file xterm prerequisite is #5105. Original #4463 stays draft. Review this PR against its configured base; merge in dependency order.

Validation at `3829c4dcb`: full frontend suite 4,138 passed, 6 skipped; all 58 renderer smoke tests passed; frontend and E2E typechecks passed. Shared package tests/typechecks and generated API drift checks pass. Latest current-head workflows all passed.

Evidence: [recording](https://github.com/Untrivial-ai/agent-orchestrator/pull/5110#issuecomment-5638403970), [recorded renderer requests](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). This recording runs production renderer code with deterministic daemon/preload/PTY fixtures. Local validation is macOS with Node 24; Linux container, native Windows and signed packaged-app gates must be verified in CI.

[Restored inline draft in the renderer contract check](https://github.com/Untrivial-ai/agent-orchestrator/pull/5110#issuecomment-5638403970)

Before this correctness follow-up, the cumulative stack was also exercised in real Electron with the real daemon, native preload and a live Codex scratch session:

[Native Electron verification](https://github.com/Untrivial-ai/agent-orchestrator/pull/5110#issuecomment-5638403970)

[Real service/SQLite restart proof with counted provider calls](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549).

Local validation limit: the full backend race suite was attempted, but the machine ran out of disk space (`link: mapping output file failed: no space left on device`; subsequent TempDir/mkdir failures). It is not a local pass. The additional race runs were stopped to prevent more disk exhaustion. Docker also failed to answer `docker info` within 15 seconds, so the fresh-install container and the native Windows/Linux jobs require CI. Native macOS CLI E2E passed.

Stack order:

- #5105 — terminal disposal prerequisite
- #5106 — persist composer text across lifecycle boundaries
- #5107 — restore staged draft attachments after restart
- #5109 — persist queued edits with atomic delivery receipts
- #5110 — recover inline edits with durable branch receipts
- #5111 — reconcile steer delivery without repeating provider actions

[Original validation CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549).


### Correctness re-review — 8 September 2026

Restacked with the corrected parent PRs. Composer and inline-edit mutation helpers both remain intact; no new inline-edit defect was found.

Both independent final reviews (behavior and implementation standards) found no remaining actionable correctness defects at the corrected stack head. The agreed feature scope is preserved.

[Before/after captures and regression evidence](https://github.com/Untrivial-ai/agent-orchestrator/pull/5110#issuecomment-5638403970). These new recordings use the production renderer with deterministic daemon/preload/PTY fixtures.


[Recorded CI results](https://github.com/Untrivial-ai/agent-orchestrator/pull/5106#issuecomment-5638373549). The complete cumulative Go race suite, build, vet, CLI E2E and pinned linter pass; the latest CI jobs cover the Linux container and native Windows gaps.
