### PR TITLE
fix: make telemetry destination shutdown safe for concurrent emitters

### DIFF
--- a/backend/internal/adapters/telemetry/localsqlite.go
+++ b/backend/internal/adapters/telemetry/localsqlite.go
@@ -33,6 +33,8 @@ type LocalSQLiteSink struct {
 	ch        chan ports.TelemetryEvent
 	wg        sync.WaitGroup
 	closeOnce sync.Once
+	queueMu   sync.RWMutex
+	closed    bool
 	now       func() time.Time
 	newID     func() string
 
@@ -56,16 +58,31 @@ func NewLocalSQLiteSink(store localStore, log *slog.Logger) *LocalSQLiteSink {
 
 // Emit enqueues an event for best-effort persistence.
 func (s *LocalSQLiteSink) Emit(_ context.Context, ev ports.TelemetryEvent) {
+	s.queueMu.RLock()
+	if s.closed {
+		s.queueMu.RUnlock()
+		return
+	}
+	queued := false
 	select {
 	case s.ch <- ev:
+		queued = true
 	default:
+	}
+	s.queueMu.RUnlock()
+	if !queued {
 		s.log.Warn("telemetry local sink buffer full; dropping event", "name", ev.Name, "source", ev.Source)
 	}
 }
 
 // Close drains the worker until completion or context cancellation.
 func (s *LocalSQLiteSink) Close(ctx context.Context) error {
-	s.closeOnce.Do(func() { close(s.ch) })
+	s.closeOnce.Do(func() {
+		s.queueMu.Lock()
+		s.closed = true
+		close(s.ch)
+		s.queueMu.Unlock()
+	})
 	done := make(chan struct{})
 	go func() {
 		defer close(done)

--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -230,6 +230,8 @@ type PostHogSink struct {
 	ch         chan ports.TelemetryEvent
 	wg         sync.WaitGroup
 	closeOnce  sync.Once
+	queueMu    sync.RWMutex
+	closed     bool
 	// ctx bounds every in-flight send and its retry backoff. Close cancels it
 	// when the caller's shutdown context is done, so pending retry work stops
 	// promptly instead of outliving shutdown on an uncancellable sleep or a
@@ -274,16 +276,31 @@ func NewPostHogSink(dataDir, apiKey, host, appVersion, defaultAgent string, clie
 
 // Emit enqueues an event for best-effort export.
 func (s *PostHogSink) Emit(_ context.Context, ev ports.TelemetryEvent) {
+	s.queueMu.RLock()
+	if s.closed {
+		s.queueMu.RUnlock()
+		return
+	}
+	queued := false
 	select {
 	case s.ch <- ev:
+		queued = true
 	default:
+	}
+	s.queueMu.RUnlock()
+	if !queued {
 		s.log.Warn("telemetry posthog sink buffer full; dropping event", "name", ev.Name, "source", ev.Source)
 	}
 }
 
 // Close drains the exporter until completion or context cancellation.
 func (s *PostHogSink) Close(ctx context.Context) error {
-	s.closeOnce.Do(func() { close(s.ch) })
+	s.closeOnce.Do(func() {
+		s.queueMu.Lock()
+		s.closed = true
+		close(s.ch)
+		s.queueMu.Unlock()
+	})
 	done := make(chan struct{})
 	go func() {
 		defer close(done)

--- a/backend/internal/adapters/telemetry/shutdown_test.go
+++ b/backend/internal/adapters/telemetry/shutdown_test.go
@@ -1,0 +1,253 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	sqlitestore "github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/store"
+)
+
+type shutdownLocalStore func(context.Context) error
+
+func (s shutdownLocalStore) CreateTelemetryEvent(ctx context.Context, _ sqlitestore.TelemetryEventRecord) error {
+	return s(ctx)
+}
+
+func (shutdownLocalStore) PruneTelemetryEventsBefore(context.Context, time.Time, int64) (int64, error) {
+	return 0, nil
+}
+
+func newShutdownTestSink(t *testing.T, kind string, consume func(context.Context) error) (ports.EventSink, int) {
+	t.Helper()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	var sink ports.EventSink
+	bufferSize := localBufferSize
+	if kind == "local" {
+		sink = NewLocalSQLiteSink(shutdownLocalStore(consume), log)
+	} else {
+		var err error
+		sink, err = NewPostHogSink(t.TempDir(), "phc_test", "https://posthog.test", "", "", roundTripClient(func(req *http.Request) (*http.Response, error) {
+			defer req.Body.Close()
+			if err := consume(req.Context()); err != nil {
+				return nil, err
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}), log)
+		if err != nil {
+			t.Fatalf("NewPostHogSink: %v", err)
+		}
+		bufferSize = postHogBufferSize
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := sink.Close(ctx); err != nil {
+			t.Errorf("cleanup Close: %v", err)
+		}
+	})
+	return sink, bufferSize
+}
+
+func TestDestinationSinkEmitAfterCloseIsDropped(t *testing.T) {
+	for _, kind := range []string{"local", "posthog"} {
+		t.Run(kind, func(t *testing.T) {
+			var consumed atomic.Int32
+			sink, _ := newShutdownTestSink(t, kind, func(context.Context) error { consumed.Add(1); return nil })
+			if err := sink.Close(context.Background()); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("Emit after Close panicked: %v", p)
+				}
+			}()
+			sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.test.late"})
+			if got := consumed.Load(); got != 0 {
+				t.Errorf("late events consumed = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestDestinationSinkConcurrentEmitAndClose(t *testing.T) {
+	for _, kind := range []string{"local", "posthog"} {
+		t.Run(kind, func(t *testing.T) {
+			sink, _ := newShutdownTestSink(t, kind, func(context.Context) error { return nil })
+			start := make(chan struct{})
+			const producers = 8
+			panics := make(chan any, producers)
+			var wg sync.WaitGroup
+			for range producers {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer func() {
+						if p := recover(); p != nil {
+							panics <- p
+						}
+					}()
+					<-start
+					for range 2_000 {
+						sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.test.concurrent"})
+					}
+				}()
+			}
+			closed := make(chan error, 1)
+			go func() { <-start; closed <- sink.Close(context.Background()) }()
+			close(start)
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+			waitShutdownSignal(t, done)
+			waitShutdownClose(t, closed)
+			close(panics)
+			for p := range panics {
+				t.Errorf("Emit concurrent with Close panicked: %v", p)
+			}
+		})
+	}
+}
+
+func TestDestinationSinkCloseDrainsQueueAndFullBufferDoesNotBlock(t *testing.T) {
+	for _, kind := range []string{"local", "posthog"} {
+		t.Run(kind, func(t *testing.T) {
+			started := make(chan struct{})
+			release := make(chan struct{})
+			var startOnce, releaseOnce sync.Once
+			var consumed atomic.Int32
+			sink, capacity := newShutdownTestSink(t, kind, func(context.Context) error {
+				startOnce.Do(func() { close(started) })
+				<-release
+				consumed.Add(1)
+				return nil
+			})
+			unblock := func() { releaseOnce.Do(func() { close(release) }) }
+			t.Cleanup(unblock) // Release the worker before the sink's cleanup, even after a failure.
+			sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.test.first"})
+			waitShutdownSignal(t, started)
+			filled := make(chan struct{})
+			go func() {
+				defer close(filled)
+				for range capacity + 1 {
+					sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.test.queued"})
+				}
+			}()
+			waitShutdownSignal(t, filled)
+			const closers = 4
+			results := make(chan error, closers)
+			for range closers {
+				go func() { results <- sink.Close(context.Background()) }()
+			}
+			select {
+			case err := <-results:
+				t.Fatalf("Close returned before worker was released: %v", err)
+			case <-time.After(50 * time.Millisecond):
+			}
+			unblock()
+			for range closers {
+				waitShutdownClose(t, results)
+			}
+			if got, want := consumed.Load(), int32(capacity+1); got != want {
+				t.Errorf("consumed = %d, want %d (in-flight event plus full queue)", got, want)
+			}
+			if err := sink.Close(context.Background()); err != nil {
+				t.Errorf("repeated Close: %v", err)
+			}
+		})
+	}
+}
+
+func TestLocalSQLiteSinkCancelledCloseAllowsLaterDrain(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	sink, _ := newShutdownTestSink(t, "local", func(context.Context) error {
+		close(started)
+		<-release
+		return nil
+	})
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(unblock)
+	sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.test.blocked"})
+	waitShutdownSignal(t, started)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	closed := make(chan error, 1)
+	go func() { closed <- sink.Close(ctx) }()
+	select {
+	case err := <-closed:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Close = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled Close did not return while the write was blocked")
+	}
+	go func() { closed <- sink.Close(context.Background()) }()
+	unblock()
+	waitShutdownClose(t, closed)
+}
+
+func TestPostHogSinkCancelledCloseCancelsInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	sink, _ := newShutdownTestSink(t, "posthog", func(ctx context.Context) error {
+		close(started)
+		select {
+		case <-ctx.Done():
+		case <-release:
+		}
+		close(finished)
+		return ctx.Err()
+	})
+	// Cleanup must also release the fake if request cancellation regresses.
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.test.blocked"})
+	waitShutdownSignal(t, started)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	closed := make(chan error, 1)
+	go func() { closed <- sink.Close(ctx) }()
+	select {
+	case err := <-closed:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Close = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not cancel its in-flight request")
+	}
+	select {
+	case <-finished:
+	default:
+		t.Fatal("Close returned before the request finished")
+	}
+}
+
+func waitShutdownSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for telemetry worker or producer")
+	}
+}
+
+func waitShutdownClose(t *testing.T, ch <-chan error) {
+	t.Helper()
+	select {
+	case err := <-ch:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not finish")
+	}
+}


### PR DESCRIPTION
## What

Make local SQLite and PostHog telemetry queues safe when events arrive during or after shutdown.

## Why

Emit could send on a channel that Close had already closed, causing a panic. Both queues date back to [ReverbCode #307](https://github.com/aoagents/ReverbCode/pull/307).

## How

Synchronize each nonblocking enqueue with queue closure and drop late events. Keep full-buffer logging outside the lock and preserve the existing drain/cancellation behavior. Aggregating-sink flush ordering is a separate follow-up.

## Testing

- Reproduced send-on-closed-channel panics and data races on unchanged main; fixed telemetry race tests pass.
- Cover late/concurrent Emit, full queues, queued drain, repeated/concurrent Close, and each destination's cancellation behavior.
- Full backend tests and race suite, build, vet, formatting, and golangci-lint v2.12.2 pass. Independent review has no outstanding findings.
- API regeneration has no drift; Linux CLI E2E, fresh-install container, and the pinned Gitleaks scan of the new commit pass.
- All nine remote CI checks pass, including native Windows workspace tests and macOS/Windows CLI E2E.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions
- [x] Regression tests added
- [x] Relevant CI checks pass
