### PR TITLE
fix: preserve user fields during Codex hook cleanup

### DIFF
--- a/backend/internal/adapters/agent/codex/hooks.go
+++ b/backend/internal/adapters/agent/codex/hooks.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/pkg/agentruntime"
@@ -48,16 +49,10 @@ type codexHookFile struct {
 	Hooks map[string][]codexMatcherGroup `json:"hooks"`
 }
 
-type codexMatcherGroup struct {
-	Matcher *string          `json:"matcher,omitempty"`
-	Hooks   []codexHookEntry `json:"hooks"`
-}
-
-type codexHookEntry struct {
-	Type    string `json:"type"`
-	Command string `json:"command"`
-	Timeout int    `json:"timeout,omitempty"`
-}
+// Reuse the lossless hook types so removing an AO entry preserves fields on
+// user hooks and matcher groups that Codex added before AO knew about them.
+type codexMatcherGroup = hooksjson.MatcherGroup
+type codexHookEntry = hooksjson.HookEntry
 
 // codexHookSpec describes one hook AO delivers via launch-command config.
 type codexHookSpec struct {

--- a/backend/internal/adapters/agent/codex/hooks_cleanup_test.go
+++ b/backend/internal/adapters/agent/codex/hooks_cleanup_test.go
@@ -1,0 +1,119 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestUninstallHooksPreservesUnknownFieldsOnSurvivingUserHooksAndGroups(t *testing.T) {
+	const seed = `{
+  "hooks": {
+    "%s": [
+      {
+        "groupConfig": {"mode": "serial", "limits": [1, 2]},
+        "hooks": [
+          {
+            "type": "command",
+            "command": "custom mixed-group hook",
+            "timeout": 3,
+            "async": true,
+            "metadata": {"owner": "user", "labels": ["one", "two"]}
+          },
+          {
+            "type": "command",
+            "command": "%s",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "user-only",
+        "groupConfig": {"mode": "parallel", "enabled": true},
+        "hooks": [
+          {
+            "type": "command",
+            "command": "custom untouched-group hook",
+            "timeout": 7,
+            "platform": {"windows": {"command": "custom.exe"}}
+          }
+        ]
+      }
+    ]
+  }
+}`
+	const expected = `{
+  "hooks": {
+    "%s": [
+      {
+        "groupConfig": {"mode": "serial", "limits": [1, 2]},
+        "hooks": [
+          {
+            "type": "command",
+            "command": "custom mixed-group hook",
+            "timeout": 3,
+            "async": true,
+            "metadata": {"owner": "user", "labels": ["one", "two"]}
+          }
+        ]
+      },
+      {
+        "matcher": "user-only",
+        "groupConfig": {"mode": "parallel", "enabled": true},
+        "hooks": [
+          {
+            "type": "command",
+            "command": "custom untouched-group hook",
+            "timeout": 7,
+            "platform": {"windows": {"command": "custom.exe"}}
+          }
+        ]
+      }
+    ]
+  }
+}`
+	for _, tt := range []struct {
+		event   string
+		command string
+	}{
+		{event: "SessionStart", command: "ao hooks codex session-start"},
+		{event: "UserPromptSubmit", command: "ao hooks codex user-prompt-submit"},
+		{event: "PermissionRequest", command: "ao hooks codex permission-request"},
+		{event: "Stop", command: "ao hooks codex stop"},
+	} {
+		t.Run(tt.event, func(t *testing.T) {
+			workspace := t.TempDir()
+			hooksPath := filepath.Join(workspace, codexHooksDirName, codexHooksFileName)
+			if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(hooksPath, []byte(fmt.Sprintf(seed, tt.event, tt.command)), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := (&Plugin{}).UninstallHooks(context.Background(), workspace); err != nil {
+				t.Fatal(err)
+			}
+
+			data, err := os.ReadFile(hooksPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatal(err)
+			}
+			var want any
+			if err := json.Unmarshal([]byte(fmt.Sprintf(expected, tt.event)), &want); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("hooks after cleanup\nwant: %#v\n got: %#v", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Preserve unknown fields on surviving user hooks and matcher groups when removing legacy AO entries from `.codex/hooks.json`.

## Why

Cleanup decoded the changed event through private structs that discarded fields such as `async`, nested metadata, and group configuration. The representation originated in [ReverbCode #65](https://github.com/aoagents/ReverbCode/pull/65); [#170](https://github.com/aoagents/ReverbCode/pull/170) introduced the current legacy cleanup path.

## How

Reuse the existing lossless hooksjson types. Preserve AO command matching and the byte-for-byte early return for files without AO hooks.

## Testing

- The preservation regression failed on unchanged main for all four managed events, then passed with the fix.
- Tests cover unknown fields in mixed and separate user-only groups; existing tests cover startup cleanup and unchanged AO-free bytes.
- Full backend tests and race suite, build, vet, formatting, and golangci-lint v2.12.2 pass. Independent review has no outstanding findings.
- API regeneration has no drift; Linux CLI E2E, fresh-install container, and the pinned Gitleaks scan of the new commit pass.
- All nine remote CI checks pass, including native Windows workspace tests and macOS/Windows CLI E2E.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions
- [x] Regression tests added
- [x] Relevant CI checks pass
