### PR TITLE
fix(updates): parse nightly build stamps as UTC, not local wall time

### DIFF
--- a/frontend/src/renderer/components/RestartToUpdateDialog.test.tsx
+++ b/frontend/src/renderer/components/RestartToUpdateDialog.test.tsx
@@ -67,6 +67,20 @@ it("shows what the build changes", async () => {
 	expect(screen.getByText("Nightly 0.12.11 · Sep 2")).toBeVisible();
 });
 
+it("renders the nightly build date from the UTC instant", async () => {
+	// The stamp 202609070300 encodes 03:00 UTC. Near the UTC day boundary the
+	// date-only dialog label must show the device-local calendar day of the
+	// correct instant, not the stamp digits re-read as local wall time
+	// (issue #5059). The expected label is derived from the absolute instant,
+	// so this holds in every timezone.
+	useUiStore.setState({ updateInstallPromptOpen: true });
+	renderDialog({ state: "downloaded", version: "0.12.11-nightly.202609070300" });
+	const expected = new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(
+		new Date(Date.UTC(2026, 8, 7, 3, 0)),
+	);
+	expect(await screen.findByText(`Nightly 0.12.11 · ${expected}`)).toBeVisible();
+});
+
 it("names the sessions that would lose a turn and waits for confirmation", async () => {
 	workspaceData.current = [
 		{ sessions: [session(), session({ id: "s2", mode: "tui", title: "Terminal one" })] },

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -2244,6 +2244,26 @@ describe("Sidebar", () => {
 		expect(within(readyRow).getByText("Nightly 0.12.11 · Sep 2")).toBeVisible();
 	});
 
+	it("shows the device-local calendar day for a UTC-day-boundary nightly", async () => {
+		// 03:00 UTC on Sep 7 is already Sep 7 in Kolkata but still Sep 6 in Los
+		// Angeles. The date-only label must follow the device-local calendar day
+		// of the correct instant, not the stamp digits re-read as local wall
+		// time (issue #5059). The expected label is derived from the absolute
+		// instant, so this holds in every timezone.
+		updateStatusMock.mockResolvedValue({
+			state: "downloaded",
+			version: "0.12.11-nightly.202609070300",
+			stagedAt: Date.now(),
+		});
+		renderSidebar();
+
+		const readyRow = await screen.findByTestId("sidebar-update-ready");
+		const expected = new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(
+			new Date(Date.UTC(2026, 8, 7, 3, 0)),
+		);
+		expect(within(readyRow).getByText(`Nightly 0.12.11 · ${expected}`)).toBeVisible();
+	});
+
 	it("stays quiet for a one-off update failure that has not become a streak", async () => {
 		updateStatusMock.mockResolvedValue({ state: "idle" });
 		renderSidebar();

--- a/frontend/src/renderer/components/settings/UpdatesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.test.tsx
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+import { UpdatesSection } from "./UpdatesSection";
+import { useUiStore } from "../../stores/ui-store";
+import type { UpdateStatus } from "../../../main/update-settings";
+
+const {
+	updGetStatus,
+	updOnStatus,
+	settingsGet,
+	settingsSet,
+	getVersion,
+	featureBuildsList,
+	featureBuildsGetActive,
+	telemetryCapture,
+} = vi.hoisted(() => ({
+	updGetStatus: vi.fn(),
+	updOnStatus: vi.fn(),
+	settingsGet: vi.fn(),
+	settingsSet: vi.fn(),
+	getVersion: vi.fn(),
+	featureBuildsList: vi.fn(),
+	featureBuildsGetActive: vi.fn(),
+	telemetryCapture: vi.fn(),
+}));
+
+vi.mock("../../lib/bridge", () => ({
+	aoBridge: {
+		app: { getVersion },
+		updates: {
+			getStatus: updGetStatus,
+			onStatus: updOnStatus,
+			install: vi.fn(),
+			download: vi.fn(),
+			check: vi.fn(),
+			returnHome: vi.fn(),
+		},
+		updateSettings: { get: settingsGet, set: settingsSet },
+		featureBuilds: { getActive: featureBuildsGetActive, list: featureBuildsList },
+	},
+}));
+
+vi.mock("../../lib/telemetry", () => ({
+	captureRendererEvent: telemetryCapture,
+	releaseChannelFrom: vi.fn(),
+	setReleaseChannelContext: vi.fn(),
+}));
+
+vi.mock("../../hooks/useRequestUpdateInstall", () => ({
+	useRequestUpdateInstall: () => () => undefined,
+}));
+
+function renderUpdates() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	render(
+		<QueryClientProvider client={queryClient}>
+			<UpdatesSection />
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	for (const m of [updGetStatus, updOnStatus, settingsGet, settingsSet, getVersion, featureBuildsList, featureBuildsGetActive, telemetryCapture]) {
+		m.mockReset();
+	}
+	updOnStatus.mockReturnValue(() => undefined);
+	settingsGet.mockResolvedValue({ enabled: false, channel: "latest", nightlyAck: true, feature: null });
+	settingsSet.mockResolvedValue({ enabled: false, channel: "latest", nightlyAck: true, feature: null });
+	getVersion.mockResolvedValue("0.12.11-nightly.202609070300");
+	featureBuildsList.mockResolvedValue([]);
+	featureBuildsGetActive.mockResolvedValue(null);
+	updGetStatus.mockResolvedValue({ state: "idle" } satisfies UpdateStatus);
+	useUiStore.setState({ developerMode: false });
+});
+
+it("renders the installed nightly build time as the device-local instant", async () => {
+	// The stamp 202609070300 encodes 03:00 UTC. The expected string is derived
+	// from that absolute instant, so the assertion holds in every timezone —
+	// and it can only hold at all when the stamp is parsed as UTC, never as
+	// local wall time (issue #5059).
+	renderUpdates();
+
+	const builtAt = new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short" }).format(
+		new Date(Date.UTC(2026, 8, 7, 3, 0)),
+	);
+	expect(await screen.findByText(`Built ${builtAt}`)).toBeVisible();
+});

--- a/frontend/src/renderer/lib/build-channel.test.ts
+++ b/frontend/src/renderer/lib/build-channel.test.ts
@@ -22,14 +22,56 @@ describe("isCommandPaletteEnabled", () => {
 });
 
 describe("parseNightlyVersion", () => {
-	it("splits a nightly stamp into base version and build date", () => {
+	it("splits a nightly stamp into base version and UTC build instant", () => {
 		const parsed = parseNightlyVersion("0.12.11-nightly.202609021713");
 		expect(parsed?.base).toBe("0.12.11");
-		expect(parsed?.builtAt.getFullYear()).toBe(2026);
-		expect(parsed?.builtAt.getMonth()).toBe(8);
-		expect(parsed?.builtAt.getDate()).toBe(2);
-		expect(parsed?.builtAt.getHours()).toBe(17);
-		expect(parsed?.builtAt.getMinutes()).toBe(13);
+		// The stamp encodes the build time in UTC. Assert the absolute instant,
+		// not local getters: the value must not depend on the timezone of the
+		// machine running the tests.
+		expect(parsed?.builtAt.toISOString()).toBe("2026-09-02T17:13:00.000Z");
+		expect(parsed?.builtAt.getTime()).toBe(Date.UTC(2026, 8, 2, 17, 13));
+	});
+
+	it("renders the same instant in positive and negative offsets", () => {
+		const parsed = parseNightlyVersion("0.12.11-nightly.202609071035");
+		if (!parsed) throw new Error("expected a valid nightly stamp to parse");
+		const time = new Intl.DateTimeFormat("en-US", {
+			timeZone: "Asia/Kolkata",
+			month: "short",
+			day: "numeric",
+			hour: "numeric",
+			minute: "2-digit",
+			hour12: true,
+		}).format(parsed.builtAt);
+		expect(time).toBe("Sep 7, 4:05 PM");
+		const pacificTime = new Intl.DateTimeFormat("en-US", {
+			timeZone: "America/Los_Angeles",
+			month: "short",
+			day: "numeric",
+			hour: "numeric",
+			minute: "2-digit",
+			hour12: true,
+		}).format(parsed.builtAt);
+		expect(pacificTime).toBe("Sep 7, 3:35 AM");
+	});
+
+	it("lands on the correct local calendar day across the UTC day boundary", () => {
+		// 03:00 UTC is already the next calendar day in Kolkata but still the
+		// previous evening in Los Angeles; date-only surfaces must show Sep 6
+		// to a user in Los Angeles.
+		const parsed = parseNightlyVersion("0.12.11-nightly.202609070300");
+		if (!parsed) throw new Error("expected a valid nightly stamp to parse");
+		expect(parsed.builtAt.toISOString()).toBe("2026-09-07T03:00:00.000Z");
+		expect(
+			new Intl.DateTimeFormat("en-US", { timeZone: "Asia/Kolkata", month: "short", day: "numeric" }).format(
+				parsed.builtAt,
+			),
+		).toBe("Sep 7");
+		expect(
+			new Intl.DateTimeFormat("en-US", { timeZone: "America/Los_Angeles", month: "short", day: "numeric" }).format(
+				parsed.builtAt,
+			),
+		).toBe("Sep 6");
 	});
 
 	it("tolerates a trailing commit stamp", () => {

--- a/frontend/src/renderer/lib/build-channel.ts
+++ b/frontend/src/renderer/lib/build-channel.ts
@@ -19,15 +19,17 @@ export function parseNightlyVersion(version?: string): { base: string; builtAt: 
 	const match = /^(\d+\.\d+\.\d+)-nightly\.(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(?:[.+]|$)/.exec(version ?? "");
 	if (!match) return null;
 	const [, base, year, month, day, hour, minute] = match;
+	// The nightly stamp encodes the build time in UTC, so it must be parsed as
+	// UTC components. The local Date constructor would read the stamp as local
+	// wall time and shift the instant by the machine's UTC offset, which then
+	// renders a wrong time (or the wrong calendar day) in the sidebar, the
+	// Settings Updates section, and the restart dialog.
 	const builtAt = new Date(
-		Number(year),
-		Number(month) - 1,
-		Number(day),
-		Number(hour),
-		Number(minute),
+		Date.UTC(Number(year), Number(month) - 1, Number(day), Number(hour), Number(minute)),
 	);
 	// A stamp like 202699999999 parses into a nonsense date; treat it as unusable
-	// rather than rendering "Invalid Date" into the sidebar.
-	if (Number.isNaN(builtAt.getTime()) || builtAt.getMonth() !== Number(month) - 1) return null;
+	// rather than rendering "Invalid Date" into the sidebar. Validate with the
+	// UTC getters so the check does not depend on the machine timezone either.
+	if (Number.isNaN(builtAt.getTime()) || builtAt.getUTCMonth() !== Number(month) - 1) return null;
 	return { base, builtAt };
 }


### PR DESCRIPTION
## Summary

Fixes #5059.

`parseNightlyVersion` read the UTC-encoded nightly stamp (e.g. `202609071035`) with the **local** component `Date` constructor, so the parsed instant shifted by the machine's UTC offset. Every renderer surface that shows the nightly build date — the sidebar update row, the Settings Updates section, and the restart-to-update dialog — then rendered the wrong time (or the wrong calendar day near UTC midnight).

Reproduced against `main` (commit 24e101914): with `TZ=Asia/Kolkata` the stamp `202609071035` parsed to `2026-09-07T05:05:00.000Z` instead of `10:35:00.000Z` (rendered "Sep 7, 10:35 AM" instead of "Sep 7, 4:05 PM"); with `TZ=America/Los_Angeles` it parsed to `17:35:00.000Z`. Under UTC it was correct only by accident. The existing parser tests asserted local getters, so they passed in every timezone and encoded the wrong interpretation.

## Root cause

The stamp digits encode the build time in UTC. `new Date(y, m-1, d, h, min)` interprets them as local wall time; the subsequent validity check also used local getters (`getMonth`).

## Fix

`frontend/src/renderer/lib/build-channel.ts` — two functional lines:

- construct the instant with `Date.UTC(...)`;
- validate the round-trip with `getUTCMonth()` instead of `getMonth()`.

No consumer changes are needed: `Sidebar.tsx`, `settings/UpdatesSection.tsx`, and `RestartToUpdateDialog.tsx` all format through `Intl.DateTimeFormat`, which renders the equivalent device-local time once the `Date` represents the correct instant.

## Tests

- `build-channel.test.ts`: parser assertions rewritten to `builtAt.toISOString()` / `getTime()` against `Date.UTC(...)` (no local getters, timezone-independent), plus new positive/negative offset coverage (`Sep 7, 4:05 PM` in `Asia/Kolkata`, `Sep 7, 3:35 AM` in `America/Los_Angeles`) and a UTC day-boundary case. Malformed/stable/feature and trailing-commit coverage kept.
- `Sidebar.test.tsx`: new staged-nightly case at the UTC day boundary; the expected date-only label is derived from the absolute instant, so the assertion holds in every timezone.
- `RestartToUpdateDialog.test.tsx`: same day-boundary coverage for the dialog label.
- `UpdatesSection.test.tsx` (new): covers the full device-local "Built {{date}}" timestamp for an installed nightly.

All validated locally under `TZ=Asia/Kolkata`: build-channel 7/7, RestartToUpdateDialog 6/6, UpdatesSection 1/1, Sidebar 97/97.

## Intentional omissions

- The separate "Last checked" display is untouched: it formats epoch milliseconds and was never affected (per the issue).
- No UTC timestamps in GitHub metadata, updater feeds, or version strings are rewritten anywhere; only the renderer-side parse was wrong, matching the issue's acceptance criteria.
