### PR TITLE
Open chat file paths in Files

### DIFF
--- a/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.test.tsx
@@ -27,6 +27,18 @@ function renderWithLinkHandler(text: string, onLinkOpen: (url: string) => void) 
 	);
 }
 
+function renderWithFileHandler(
+	text: string,
+	onFileOpen: (path: string) => void,
+	filePaths: string[] = [],
+) {
+	return render(
+		<ChatLinkProvider filePaths={filePaths} onFileOpen={onFileOpen}>
+			<ChatMarkdown text={text} />
+		</ChatLinkProvider>,
+	);
+}
+
 describe("ChatMarkdown", () => {
 	it("renders headings as headings rather than literal hashes", () => {
 		render(<ChatMarkdown text={"## Findings\n\nTwo files changed."} />);
@@ -108,6 +120,57 @@ describe("ChatMarkdown", () => {
 		render(<ChatMarkdown text={"Compare `README.md` with `backend/service.go:42`."} />);
 		expect(screen.getByText("README.md")).toHaveClass("text-markdown-code");
 		expect(screen.getByText("backend/service.go:42")).toHaveClass("text-markdown-code");
+	});
+
+	it("opens a known inline-code file path in Files", async () => {
+		const onFileOpen = vi.fn();
+		renderWithFileHandler(
+			"Open `backend/service.go:42` but keep `--resume` as code.",
+			onFileOpen,
+			["backend/service.go"],
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open backend/service.go in Files" }));
+
+		expect(onFileOpen).toHaveBeenCalledWith("backend/service.go");
+		expect(screen.getByText("--resume").closest("button")).toBeNull();
+	});
+
+	it("opens an absolute markdown file link in Files instead of externally", async () => {
+		const onFileOpen = vi.fn();
+		const openExternal = vi.spyOn(aoBridge.app, "openExternal").mockResolvedValue(undefined);
+		renderWithFileHandler(
+			"See [the component](/Users/me/project/frontend/src/App.tsx:42).",
+			onFileOpen,
+			["frontend/src/App.tsx"],
+		);
+
+		await userEvent.click(screen.getByRole("link", { name: "the component" }));
+
+		expect(onFileOpen).toHaveBeenCalledWith("frontend/src/App.tsx");
+		expect(openExternal).not.toHaveBeenCalled();
+		expect(screen.getByRole("link", { name: "the component" })).not.toHaveAttribute("target");
+		openExternal.mockRestore();
+	});
+
+	it("does not nest a file-path button inside a markdown file link", () => {
+		renderWithFileHandler(
+			"See [`frontend/src/App.tsx`](frontend/src/App.tsx).",
+			vi.fn(),
+			["frontend/src/App.tsx"],
+		);
+
+		const link = screen.getByRole("link", { name: "frontend/src/App.tsx" });
+		expect(link.querySelector("button")).toBeNull();
+	});
+
+	it("opens an explicit relative file link before the workspace catalog catches up", async () => {
+		const onFileOpen = vi.fn();
+		renderWithFileHandler("See [the new file](src/generated/new-file.ts#L8).", onFileOpen);
+
+		await userEvent.click(screen.getByRole("link", { name: "the new file" }));
+
+		expect(onFileOpen).toHaveBeenCalledWith("src/generated/new-file.ts");
 	});
 
 	it("escapes raw HTML instead of rendering it", () => {

--- a/frontend/src/renderer/components/chat/ChatMarkdown.tsx
+++ b/frontend/src/renderer/components/chat/ChatMarkdown.tsx
@@ -31,6 +31,7 @@ import {
 	Fragment,
 	memo,
 	useContext,
+	useMemo,
 	useState,
 	type ReactNode,
 } from "react";
@@ -42,6 +43,10 @@ import { aoBridge } from "../../lib/bridge";
 import { canonicalLanguage } from "../../lib/code-highlight";
 import { fenceOf } from "../../lib/markdown-fence";
 import { isWebLink, openLinkInSystemBrowser } from "../../lib/external-link-policy";
+import {
+	explicitWorkspaceFilePath,
+	findWorkspaceFilePath,
+} from "../../lib/workspace-file-path";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -79,16 +84,33 @@ const PLUGINS = [remarkGfm];
  * and re-parse every message on every poll.
  */
 const StreamingProse = createContext(false);
-const OpenChatLink = createContext<((url: string) => void) | undefined>(undefined);
+const InsideMarkdownLink = createContext(false);
+const ChatNavigation = createContext<{
+	filePaths: readonly string[];
+	onFileOpen?: (path: string) => void;
+	onLinkOpen?: (url: string) => void;
+}>({ filePaths: [] });
 
 export function ChatLinkProvider({
 	onLinkOpen,
+	onFileOpen,
+	filePaths = [],
 	children,
 }: {
 	onLinkOpen?: (url: string) => void;
+	onFileOpen?: (path: string) => void;
+	filePaths?: readonly string[];
 	children: ReactNode;
 }) {
-	return <OpenChatLink.Provider value={onLinkOpen}>{children}</OpenChatLink.Provider>;
+	const navigation = useMemo(
+		() => ({ filePaths, onFileOpen, onLinkOpen }),
+		[filePaths, onFileOpen, onLinkOpen],
+	);
+	return (
+		<ChatNavigation.Provider value={navigation}>
+			{children}
+		</ChatNavigation.Provider>
+	);
 }
 
 export const ChatMarkdown = memo(function ChatMarkdown({
@@ -214,15 +236,22 @@ function compactEmoji(children: ReactNode): ReactNode {
 }
 
 function MarkdownLink({ href, children }: { href?: string; children?: ReactNode }) {
-	const onLinkOpen = useContext(OpenChatLink);
+	const { filePaths, onFileOpen, onLinkOpen } = useContext(ChatNavigation);
+	const filePath = href && onFileOpen
+		? findWorkspaceFilePath(href, filePaths) ?? explicitWorkspaceFilePath(href)
+		: undefined;
 	const anchor = (
 		<a
 			href={href}
-			target="_blank"
-			rel="noreferrer noopener"
+			target={filePath ? undefined : "_blank"}
+			rel={filePath ? undefined : "noreferrer noopener"}
 			onClick={(event) => {
 				if (!href) return;
 				event.preventDefault();
+				if (filePath && onFileOpen) {
+					onFileOpen(filePath);
+					return;
+				}
 				// Cmd/Ctrl-click (the VS Code/Slack convention) and Option/Alt-click
 				// escape the in-app panel and go straight to the system browser.
 				const toSystemBrowser = event.metaKey || event.ctrlKey || event.altKey;
@@ -234,7 +263,7 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
 			}}
 			className="text-markdown-link underline decoration-markdown-link/45 underline-offset-2 transition-colors hover:text-markdown-link-hover hover:decoration-markdown-link-hover/75"
 		>
-			{children}
+			<InsideMarkdownLink.Provider value>{children}</InsideMarkdownLink.Provider>
 		</a>
 	);
 	if (!href) return anchor;
@@ -242,6 +271,11 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
 		<ContextMenu>
 			<ContextMenuTrigger asChild>{anchor}</ContextMenuTrigger>
 			<ContextMenuContent className="min-w-44">
+				{filePath && onFileOpen ? (
+					<ContextMenuItem onSelect={() => onFileOpen(filePath)}>
+						Open in Files
+					</ContextMenuItem>
+				) : null}
 				{/* Only http(s) may reach shell.openExternal from here; other schemes
 				    still get their address copied. */}
 				{isWebLink(href) ? (
@@ -249,8 +283,8 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
 						Open in system browser
 					</ContextMenuItem>
 				) : null}
-				<ContextMenuItem onSelect={() => void aoBridge.clipboard.writeText(href)}>
-					Copy link address
+				<ContextMenuItem onSelect={() => void aoBridge.clipboard.writeText(filePath ?? href)}>
+					{filePath ? "Copy file path" : "Copy link address"}
 				</ContextMenuItem>
 			</ContextMenuContent>
 		</ContextMenu>
@@ -266,8 +300,31 @@ function MarkdownLink({ href, children }: { href?: string; children?: ReactNode 
  */
 function MermaidFence({ code }: { code: string }) {
 	const streaming = useContext(StreamingProse);
-	const onLinkOpen = useContext(OpenChatLink);
+	const { onLinkOpen } = useContext(ChatNavigation);
 	return <MermaidBlock code={code} streaming={streaming} onLinkOpen={onLinkOpen} />;
+}
+
+function InlineCode({ children }: { children?: ReactNode }) {
+	const { filePaths, onFileOpen } = useContext(ChatNavigation);
+	const insideLink = useContext(InsideMarkdownLink);
+	const text = typeof children === "string" ? children : undefined;
+	const filePath = text && onFileOpen ? findWorkspaceFilePath(text, filePaths) : undefined;
+	const code = (
+		<code className="rounded bg-surface px-[5px] py-[2px] font-mono text-[11.5px] text-markdown-code">
+			{children}
+		</code>
+	);
+	if (!filePath || !onFileOpen || insideLink) return code;
+	return (
+		<button
+			type="button"
+			onClick={() => onFileOpen(filePath)}
+			aria-label={`Open ${filePath} in Files`}
+			className="inline rounded text-left transition-colors hover:bg-interactive-hover"
+		>
+			{code}
+		</button>
+	);
 }
 
 const COMPONENTS: Components = {
@@ -332,11 +389,7 @@ const COMPONENTS: Components = {
 		return <CodeBlock code={fence.code} language={fence.language} />;
 	},
 	// Only inline code reaches here; `pre` above takes every fence.
-	code: ({ children }) => (
-		<code className="rounded bg-surface px-[5px] py-[2px] font-mono text-[11.5px] text-markdown-code">
-			{children}
-		</code>
-	),
+	code: InlineCode,
 
 	// Wide tables scroll inside their own container so the conversation column
 	// never scrolls sideways.

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -1133,7 +1133,11 @@ export function ChatWorkspace({
 						className={cn("flex min-h-0 flex-1 flex-col", conversationEmpty && "justify-center")}
 						data-composer-placement={conversationEmpty ? "center" : "dock"}
 					>
-						<ChatLinkProvider onLinkOpen={onLinkOpen}>
+						<ChatLinkProvider
+							filePaths={filePaths}
+							onFileOpen={onOpenFile}
+							onLinkOpen={onLinkOpen}
+						>
 							<Timeline
 								snapshot={snapshot}
 								hasOlder={hasOlder}

--- a/frontend/src/renderer/lib/workspace-file-path.test.ts
+++ b/frontend/src/renderer/lib/workspace-file-path.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { matchWorkspaceFilePath } from "./workspace-file-path";
+import {
+	explicitWorkspaceFilePath,
+	findWorkspaceFilePath,
+	matchWorkspaceFilePath,
+	normalizeWorkspaceFileReference,
+} from "./workspace-file-path";
 
 describe("matchWorkspaceFilePath", () => {
 	const files = [
@@ -23,6 +28,17 @@ describe("matchWorkspaceFilePath", () => {
 		expect(matchWorkspaceFilePath("./src/a.ts", files)).toBe("src/a.ts");
 	});
 
+	it("strips editor line locations before matching", () => {
+		expect(matchWorkspaceFilePath("src/a.ts:42:7", files)).toBe("src/a.ts");
+		expect(matchWorkspaceFilePath("docs/report.md#L12-L18", files)).toBe("docs/report.md");
+	});
+
+	it("resolves encoded absolute file urls against workspace files", () => {
+		expect(
+			matchWorkspaceFilePath("file:///Users/me/project/docs/report.md%3A42", files),
+		).toBe("docs/report.md");
+	});
+
 	it("falls back to the normalized request when nothing matches", () => {
 		expect(matchWorkspaceFilePath("missing.txt", files)).toBe("missing.txt");
 	});
@@ -35,5 +51,25 @@ describe("matchWorkspaceFilePath", () => {
 		];
 		expect(matchWorkspaceFilePath("frontend/index.ts", duplicateFiles)).toBe("frontend/index.ts");
 		expect(matchWorkspaceFilePath("backend/index.ts", duplicateFiles)).toBe("backend/index.ts");
+	});
+
+	it("only resolves a basename when it is unambiguous", () => {
+		expect(findWorkspaceFilePath("index.ts:10", ["frontend/index.ts", "backend/index.ts"])).toBeUndefined();
+	});
+
+	it("recognizes explicit local links without mistaking urls for files", () => {
+		expect(explicitWorkspaceFilePath("/repo/src/new.ts:12")).toBe("/repo/src/new.ts");
+		expect(explicitWorkspaceFilePath("docs/new.ts#L4")).toBe("docs/new.ts");
+		expect(explicitWorkspaceFilePath("https://example.com/docs/new.ts")).toBeUndefined();
+		expect(explicitWorkspaceFilePath("//example.com/docs/new.ts")).toBeUndefined();
+		expect(explicitWorkspaceFilePath("mailto:dev@example.com")).toBeUndefined();
+	});
+
+	it("does not match a web url by its path suffix", () => {
+		expect(findWorkspaceFilePath("https://example.com/src/a.ts", ["src/a.ts"])).toBeUndefined();
+	});
+
+	it("normalizes Windows file references", () => {
+		expect(normalizeWorkspaceFileReference("C:\\repo\\src\\app.ts:9")).toBe("C:/repo/src/app.ts");
 	});
 });

--- a/frontend/src/renderer/lib/workspace-file-path.ts
+++ b/frontend/src/renderer/lib/workspace-file-path.ts
@@ -4,9 +4,85 @@ function normalizeWorkspacePath(path: string): string {
 	return path.trim().replace(/^\.\//, "").replace(/\\/g, "/");
 }
 
+function decodePath(path: string): string {
+	try {
+		return decodeURIComponent(path);
+	} catch {
+		return path;
+	}
+}
+
+function hasNonFileScheme(reference: string): boolean {
+	const trimmed = reference.trim();
+	return (
+		trimmed.startsWith("//") ||
+		(/^[A-Za-z][A-Za-z\d+.-]*:/.test(trimmed) &&
+			!/^file:\/\//i.test(trimmed) &&
+			!/^\/?[A-Za-z]:[\\/]/.test(trimmed))
+	);
+}
+
+/** Remove markdown/editor location syntax while retaining the referenced file. */
+export function normalizeWorkspaceFileReference(reference: string): string {
+	let path = reference.trim();
+	if (/^file:\/\//i.test(path)) {
+		try {
+			path = new URL(path).pathname;
+			// file:///C:/path is the URL form of a Windows drive path.
+			if (/^\/[A-Za-z]:\//.test(path)) path = path.slice(1);
+		} catch {
+			return "";
+		}
+	}
+	path = decodePath(path)
+		.replace(/#L\d+(?:C\d+)?(?:-L?\d+(?:C\d+)?)?$/i, "")
+		.replace(/:\d+(?::\d+)?$/, "");
+	return normalizeWorkspacePath(path);
+}
+
 function fileBasename(path: string): string {
 	const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
 	return slash >= 0 ? path.slice(slash + 1) : path;
+}
+
+/** Resolve a file reference only when it identifies a known workspace file. */
+export function findWorkspaceFilePath(
+	rawPath: string,
+	paths: readonly string[],
+): string | undefined {
+	if (hasNonFileScheme(rawPath)) return undefined;
+	const normalized = normalizeWorkspaceFileReference(rawPath);
+	if (!normalized) return undefined;
+
+	const exact = paths.find((path) => normalizeWorkspacePath(path) === normalized);
+	if (exact) return exact;
+
+	const suffixes = paths.filter((path) => {
+		const candidate = normalizeWorkspacePath(path);
+		return normalized.endsWith(`/${candidate}`) || candidate.endsWith(`/${normalized}`);
+	});
+	if (suffixes.length === 1) return suffixes[0];
+
+	const base = fileBasename(normalized);
+	const byBase = paths.filter((path) => fileBasename(normalizeWorkspacePath(path)) === base);
+	return byBase.length === 1 ? byBase[0] : undefined;
+}
+
+/** A link-shaped local path can still target a new file absent from a stale catalog. */
+export function explicitWorkspaceFilePath(reference: string): string | undefined {
+	if (!reference.trim() || reference.trim().startsWith("#") || hasNonFileScheme(reference)) return undefined;
+	const normalized = normalizeWorkspaceFileReference(reference);
+	if (!normalized) return undefined;
+	if (
+		/^\//.test(normalized) ||
+		/^\.\.\//.test(normalized) ||
+		/^~\//.test(normalized) ||
+		/^[A-Za-z]:\//.test(normalized) ||
+		normalized.includes("/")
+	) {
+		return normalized;
+	}
+	return undefined;
 }
 
 /**
@@ -18,21 +94,20 @@ export function matchWorkspaceFilePath(
 	rawPath: string,
 	files: readonly WorkspaceFileSummary[],
 ): string {
-	const normalized = normalizeWorkspacePath(rawPath);
+	const normalized = normalizeWorkspaceFileReference(rawPath);
 	if (!normalized) return rawPath;
 
-	const exact =
-		files.find((file) => file.path === rawPath) ??
-		files.find((file) => file.path === normalized);
+	const exact = files.find((file) => normalizeWorkspacePath(file.path) === normalized);
 	if (exact) return exact.path;
 
-	const suffix = files.find(
-		(file) => file.path.endsWith(`/${normalized}`) || file.path.endsWith(`/${rawPath}`),
-	);
+	const suffix = files.find((file) => {
+		const candidate = normalizeWorkspacePath(file.path);
+		return normalized.endsWith(`/${candidate}`) || candidate.endsWith(`/${normalized}`);
+	});
 	if (suffix) return suffix.path;
 
 	const base = fileBasename(normalized);
-	const byBase = files.filter((file) => fileBasename(file.path) === base);
+	const byBase = files.filter((file) => fileBasename(normalizeWorkspacePath(file.path)) === base);
 	if (byBase.length === 1) return byBase[0]!.path;
 
 	return normalized;


### PR DESCRIPTION
Code changes: +149 -22  
Tests: +102 -3  
Others: +0 -0

## Summary

- open Markdown file links and known inline-code paths from chat in the Files inspector
- normalize absolute paths, file URLs, Windows separators, and line suffixes while preserving web-link behavior
- preserve known workspace HTML links in the AO Browser
- add focused coverage for file navigation, ambiguous paths, and URL safety

## Testing

- `npm exec vitest run src/renderer/lib/workspace-file-path.test.ts src/renderer/components/chat/ChatMarkdown.test.tsx` (50 passed)
- `npm run typecheck` started but exceeded the local command time limit without reporting errors
- `git diff --check` passed

No dedicated issue exists for this UX fix.