### PR TITLE
fix(a11y): expose selected chat settings choices

### DIFF
--- a/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.test.tsx
@@ -83,6 +83,9 @@ describe("ACP session config options", () => {
 		expect(screen.getByText("Effort")).toBeInTheDocument();
 		expect(screen.getByRole("switch", { name: "Plan Mode" })).toBeInTheDocument();
 		expect(screen.getByRole("switch", { name: "Fast mode" })).toBeInTheDocument();
+		await user.click(screen.getByRole("menuitem", { name: /Model/ }));
+		expect(screen.getByRole("menuitemradio", { name: "Opus 5", checked: true })).toBeInTheDocument();
+		expect(screen.getByRole("menuitemradio", { name: "Sonnet 5", checked: false })).toBeInTheDocument();
 		expect(screen.queryByText("Agent")).not.toBeInTheDocument();
 		expect(screen.queryByText("More")).not.toBeInTheDocument();
 	});
@@ -224,8 +227,8 @@ describe("ACP session config options", () => {
 		);
 
 		await user.click(screen.getByRole("button", { name: "Permission mode" }));
-		expect(screen.getByRole("menuitem", { name: "Manual" })).toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: "Bypass Permissions" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitemradio", { name: "Manual" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitemradio", { name: "Bypass Permissions" })).toBeInTheDocument();
 		expect(screen.queryByRole("menuitem", { name: "Plan Mode" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("menuitem", { name: "Agent Mode" })).not.toBeInTheDocument();
 	});
@@ -243,7 +246,7 @@ describe("ACP session config options", () => {
 		);
 
 		await user.click(screen.getByRole("button", { name: "Model" }));
-		await user.click(screen.getByRole("menuitem", { name: "Sonnet 5" }));
+		await user.click(screen.getByRole("menuitemradio", { name: "Sonnet 5" }));
 		expect(onChange).toHaveBeenCalledWith("model", { value: "sonnet" });
 	});
 
@@ -263,15 +266,15 @@ describe("ACP session config options", () => {
 			"Full access",
 		);
 		await user.click(screen.getByRole("button", { name: "Approval policy for the next turn" }));
-		expect(screen.getByRole("menuitem", { name: "Ask for approval" })).toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: "Approve for me" })).toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: "Bypass permissions" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitemradio", { name: "Ask for approval" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitemradio", { name: "Approve for me" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitemradio", { name: "Bypass permissions" })).toBeInTheDocument();
 		expect(screen.queryByRole("menuitem", { name: "Default approvals" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("menuitem", { name: "Accept edits" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("menuitem", { name: "Auto-approve" })).not.toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: "Full access" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitemradio", { name: "Full access" })).toBeInTheDocument();
 
-		await user.click(screen.getByRole("menuitem", { name: "Approve for me" }));
+		await user.click(screen.getByRole("menuitemradio", { name: "Approve for me" }));
 		expect(onChange).toHaveBeenCalledWith({ approvalMode: "auto" });
 	});
 
@@ -347,7 +350,7 @@ describe("remember project permissions", () => {
 		const { rerender } = render(<TurnSettingsBar models={[]} harness="codex"
 			settings={{ approvalMode: "auto" }} onChange={onChange} onRememberPermissions={remember} />);
 		await user.click(screen.getByRole("button", { name: "Approval policy for the next turn" }));
-		await user.click(screen.getByRole("menuitem", { name: "Full access" }));
+		await user.click(screen.getByRole("menuitemradio", { name: "Full access" }));
 		expect(onChange).toHaveBeenCalledWith({ approvalMode: "default" });
 		expect(remember).not.toHaveBeenCalled();
 		rerender(<TurnSettingsBar models={[]} harness="codex"

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -227,6 +227,7 @@ export function TurnSettingsBar({
 								{approvalOrder.map((mode) => (
 									<OptionMenuItem
 										key={mode}
+										active={mode === (settings.approvalMode ?? "default")}
 										onSelect={() => onChange({ ...settings, approvalMode: mode })}
 										className={cn("text-xs")}
 									>

--- a/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
+++ b/frontend/src/renderer/components/chat/TurnSettingsBar.tsx
@@ -228,6 +228,7 @@ export function TurnSettingsBar({
 									<OptionMenuItem
 										key={mode}
 										active={mode === (settings.approvalMode ?? "default")}
+										radio
 										onSelect={() => onChange({ ...settings, approvalMode: mode })}
 										className={cn("text-xs")}
 									>
@@ -363,6 +364,7 @@ function ModelEffortPicker({
 									<OptionMenuItem
 									key={model.id}
 									active={model.id === settings.model}
+									radio
 									onSelect={() =>
 										onChange({ ...settings, model: model.id, reasoningEffort: undefined })
 									}
@@ -399,6 +401,7 @@ function ModelEffortPicker({
 								<OptionMenuItem
 									key={effort}
 									active={effort === settings.reasoningEffort}
+									radio
 									onSelect={() => onChange({ ...settings, reasoningEffort: effort })}
 									className={cn("text-xs")}
 								>
@@ -686,8 +689,9 @@ function ConfigOptionChoices({
 			<>
 				{[true, false].map((enabled) => (
 					<OptionMenuItem
-						key={String(enabled)}
-						active={enabled === option.currentBoolean}
+							key={String(enabled)}
+							active={enabled === option.currentBoolean}
+							radio
 						onSelect={() => onChange({ enabled })}
 						className={cn("text-xs")}
 					>
@@ -719,6 +723,7 @@ function ConfigOptionChoices({
 						) : null}
 						<OptionMenuItem
 							active={choice.value === option.currentValue}
+							radio
 							onSelect={() => onChange({ value: choice.value })}
 							className={cn("text-xs")}
 						>

--- a/frontend/src/renderer/components/ui/option-menu.tsx
+++ b/frontend/src/renderer/components/ui/option-menu.tsx
@@ -107,6 +107,9 @@ export function OptionMenuItem({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & { active?: boolean }) {
 	return (
 		<DropdownMenuPrimitive.Item
+			{...(active === undefined
+				? {}
+				: { role: "menuitemradio" as const, "aria-checked": active })}
 			data-active={active || undefined}
 			className={cn(ROW, className)}
 			{...props}

--- a/frontend/src/renderer/components/ui/option-menu.tsx
+++ b/frontend/src/renderer/components/ui/option-menu.tsx
@@ -103,11 +103,12 @@ export function OptionMenuLabel({
 export function OptionMenuItem({
 	className,
 	active,
+	radio,
 	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & { active?: boolean }) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & { active?: boolean; radio?: boolean }) {
 	return (
 		<DropdownMenuPrimitive.Item
-			{...(active === undefined
+			{...(radio === undefined
 				? {}
 				: { role: "menuitemradio" as const, "aria-checked": active })}
 			data-active={active || undefined}


### PR DESCRIPTION
## Summary

- expose active model, effort, permission, and provider config choices as `menuitemradio` entries
- provide dynamic `aria-checked` state while preserving existing visual styling and menu behavior
- mark the native approval picker’s current choice as active
- update chat settings tests to assert selected and unselected accessibility state

Fixes #4428

## Validation

- `npm run test -- --run src/renderer/components/chat/TurnSettingsBar.test.tsx` (21 passed)
- `npm run typecheck`

The current main branch has already replaced the issue’s original inert Queue/Steer spans with real queue-dock buttons; this PR covers the remaining selected-state defect in the settings menus.
