### PR TITLE
fix(workspace): classify signal-killed git probes as transient, not INVALID_BRANCH

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -44,7 +44,11 @@ var (
 	ErrBranchCheckedOutElsewhere = ports.ErrWorkspaceBranchCheckedOutElsewhere
 	ErrBranchNotFetched          = ports.ErrWorkspaceBranchNotFetched
 	ErrBranchInvalid             = ports.ErrWorkspaceBranchInvalid
-	ErrDefaultBranchUnresolved   = ports.ErrWorkspaceDefaultBranchUnresolved
+	// ErrBranchProbeFailed is an adapter-local alias of ports.ErrWorkspaceProbeFailed:
+	// a check-ref-format probe that was killed by a signal or cancelled/timed out,
+	// so git never judged the name. Distinct from ErrBranchInvalid on purpose.
+	ErrBranchProbeFailed       = ports.ErrWorkspaceProbeFailed
+	ErrDefaultBranchUnresolved = ports.ErrWorkspaceDefaultBranchUnresolved
 	// ErrWorktreeLocked is an adapter-local alias of ports.ErrWorkspaceLocked,
 	// following the same aliasing convention as the branch sentinels above.
 	ErrWorktreeLocked = ports.ErrWorkspaceLocked
@@ -1533,9 +1537,38 @@ func (w *Workspace) revParse(ctx context.Context, repo, ref string) (string, err
 
 func (w *Workspace) validateBranch(ctx context.Context, repo, branch string) error {
 	if _, err := w.run(ctx, w.binary, checkRefFormatBranchArgs(repo, branch)...); err != nil {
+		// A probe that was killed by a signal or cut short by context
+		// cancellation/timeout never let git judge the name. Reporting that as
+		// INVALID_BRANCH sends users to check a ref that is actually fine and
+		// pollutes the invalid-name telemetry with environment failures.
+		if probeInterrupted(err) {
+			return fmt.Errorf("%w: %q (%w)", ErrBranchProbeFailed, branch, err)
+		}
 		return fmt.Errorf("%w: %q (%w)", ErrBranchInvalid, branch, err)
 	}
 	return nil
+}
+
+// signaledExitCode is what (*os.ProcessState).ExitCode() reports for a process
+// that did not exit normally — on Unix, one terminated by a signal such as
+// SIGKILL. It is the portable signal-kill marker (syscall.WaitStatus.Signaled()
+// does not exist on Windows).
+const signaledExitCode = -1
+
+// probeInterrupted reports whether a git probe failed because the process was
+// killed by a signal or its context was cancelled/timed out, rather than
+// because git ran and rejected its input. Such failures mean git never
+// evaluated the request, so callers must not classify them as user-facing
+// name/validation errors.
+func probeInterrupted(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == signaledExitCode {
+		return true
+	}
+	return false
 }
 
 // errNoBaseRef is an internal sentinel: every candidate base ref is missing.

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -3,13 +3,16 @@ package gitworktree
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -1021,6 +1024,115 @@ func TestCreateRejectsInvalidBranchName(t *testing.T) {
 	if !strings.Contains(err.Error(), "bad branch!!") {
 		t.Fatalf("err = %v, want message to include the rejected branch name", err)
 	}
+}
+
+// TestValidateBranchClassifiesTransientProbeFailures covers #5043: when the
+// `git check-ref-format` probe never gets to judge the name — because it was
+// killed by a signal (macOS jetsam) or its context was cancelled/timed out —
+// validateBranch must surface ErrWorkspaceProbeFailed (retryable), NOT
+// ErrWorkspaceBranchInvalid, so users are not told a perfectly valid ref is
+// bad and INVALID_BRANCH telemetry is not polluted with environment failures.
+// A genuine git rejection (real exit code) must still map to invalid.
+func TestValidateBranchClassifiesTransientProbeFailures(t *testing.T) {
+	const validBranch = "ao/agent-orchestrator-291/root" // the real, valid ref from the report
+
+	newWS := func(t *testing.T, runErr error) *Workspace {
+		t.Helper()
+		ws, err := New(Options{ManagedRoot: t.TempDir(), RepoResolver: StaticRepoResolver{"proj": t.TempDir()}})
+		if err != nil {
+			t.Fatalf("new: %v", err)
+		}
+		ws.run = func(_ context.Context, _ string, _ ...string) ([]byte, error) { return nil, runErr }
+		return ws
+	}
+
+	t.Run("context cancelled maps to probe failure", func(t *testing.T) {
+		ws := newWS(t, fmt.Errorf("git wrapper: %w", context.Canceled))
+		err := ws.validateBranch(context.Background(), "/repo", validBranch)
+		if !errors.Is(err, ports.ErrWorkspaceProbeFailed) {
+			t.Fatalf("err = %v, want ErrWorkspaceProbeFailed", err)
+		}
+		if errors.Is(err, ports.ErrWorkspaceBranchInvalid) {
+			t.Fatalf("valid branch must not be reported as invalid: %v", err)
+		}
+	})
+
+	t.Run("context deadline maps to probe failure", func(t *testing.T) {
+		ws := newWS(t, fmt.Errorf("git wrapper: %w", context.DeadlineExceeded))
+		err := ws.validateBranch(context.Background(), "/repo", validBranch)
+		if !errors.Is(err, ports.ErrWorkspaceProbeFailed) {
+			t.Fatalf("err = %v, want ErrWorkspaceProbeFailed", err)
+		}
+	})
+
+	t.Run("signal-killed probe maps to probe failure", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("signal termination (ExitCode -1) is a Unix concept; Windows kills yield a real exit code")
+		}
+		ws := newWS(t, signalKilledErr(t))
+		err := ws.validateBranch(context.Background(), "/repo", validBranch)
+		if !errors.Is(err, ports.ErrWorkspaceProbeFailed) {
+			t.Fatalf("err = %v, want ErrWorkspaceProbeFailed", err)
+		}
+		if errors.Is(err, ports.ErrWorkspaceBranchInvalid) {
+			t.Fatalf("signal-killed probe must not be reported as invalid branch: %v", err)
+		}
+	})
+
+	t.Run("genuine git rejection still maps to invalid branch", func(t *testing.T) {
+		// exitStatusOne is a real *exec.ExitError with a normal exit code — git
+		// ran and rejected the input. This is the true INVALID_BRANCH case and
+		// must be preserved.
+		ws := newWS(t, exitStatusOne(t))
+		err := ws.validateBranch(context.Background(), "/repo", "bad branch!!")
+		if !errors.Is(err, ports.ErrWorkspaceBranchInvalid) {
+			t.Fatalf("err = %v, want ErrWorkspaceBranchInvalid", err)
+		}
+		if errors.Is(err, ports.ErrWorkspaceProbeFailed) {
+			t.Fatalf("a real git rejection must not be reclassified as a probe failure: %v", err)
+		}
+	})
+}
+
+// sleepHelperEnv gates TestGitWorktreeSleepHelper so it only blocks when spawned
+// as a child of signalKilledErr; sleepHelperBackstop bounds that block as a leak
+// guard if the parent dies before killing it.
+const (
+	sleepHelperEnv      = "GO_WANT_GITWORKTREE_SLEEP"
+	sleepHelperBackstop = 30 * time.Second
+)
+
+// signalKilledErr returns a real *exec.ExitError produced by SIGKILL-ing a child
+// process, so (*exec.ExitError).ExitCode() reports -1 exactly as it does when
+// the OS kills git under memory pressure. Unix-only; guarded by the caller.
+func signalKilledErr(t *testing.T) error {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestGitWorktreeSleepHelper")
+	cmd.Env = append(os.Environ(), sleepHelperEnv+"=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep helper: %v", err)
+	}
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill sleep helper: %v", err)
+	}
+	err := cmd.Wait()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("wait err = %v, want *exec.ExitError from a killed process", err)
+	}
+	if exitErr.ExitCode() != signaledExitCode {
+		t.Fatalf("killed process ExitCode = %d, want %d", exitErr.ExitCode(), signaledExitCode)
+	}
+	return err
+}
+
+func TestGitWorktreeSleepHelper(t *testing.T) {
+	if os.Getenv(sleepHelperEnv) != "1" {
+		return
+	}
+	// Block long enough for the parent to kill us; self-exit is only a backstop
+	// against a leaked process if the parent dies first.
+	time.Sleep(sleepHelperBackstop)
 }
 
 // TestAddWorktreeReportsBranchNotFetched covers Bug 3 (b): if no local head,

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -417,6 +417,13 @@ var (
 	// ErrWorkspaceBranchInvalid reports the requested branch name is not a valid
 	// git ref (rejected by `git check-ref-format`).
 	ErrWorkspaceBranchInvalid = errors.New("workspace: invalid branch name")
+	// ErrWorkspaceProbeFailed reports that a git probe (for example
+	// `check-ref-format`) could not complete because the process was killed by a
+	// signal or its context was cancelled/timed out, so git never evaluated the
+	// request. This is a transient environment failure (e.g. OS memory pressure
+	// killing the child), not a bad branch name or a missing ref; callers may
+	// retry rather than tell the user their input is wrong.
+	ErrWorkspaceProbeFailed = errors.New("workspace: git probe failed")
 	// ErrWorkspaceDirty reports Destroy refused to remove a workspace because
 	// it holds uncommitted changes or untracked files. Teardown is never
 	// forced; callers treat the workspace as intentionally preserved.

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -1135,6 +1135,8 @@ func mapSessionError(err error) error {
 		return apierr.Invalid("BRANCH_NOT_FETCHED", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchInvalid):
 		return apierr.Invalid("INVALID_BRANCH", err.Error(), nil)
+	case errors.Is(err, ports.ErrWorkspaceProbeFailed):
+		return apierr.Unavailable("WORKSPACE_PROBE_FAILED", err.Error())
 	case errors.Is(err, ports.ErrAgentBinaryNotFound):
 		return apierr.Invalid("AGENT_BINARY_NOT_FOUND", err.Error(), nil)
 	case errors.Is(err, ports.ErrRuntimePrerequisite):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -3049,6 +3049,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"default branch unresolved", fmt.Errorf("spawn mer-1: %w: configure defaultBranch", ports.ErrWorkspaceDefaultBranchUnresolved), apierr.KindInvalid, "DEFAULT_BRANCH_UNRESOLVED"},
 		{"not fetched", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" has no local head", ports.ErrWorkspaceBranchNotFetched), apierr.KindInvalid, "BRANCH_NOT_FETCHED"},
 		{"invalid branch", fmt.Errorf("spawn mer-1: workspace: %w: \"bad!!\" (exit 1)", ports.ErrWorkspaceBranchInvalid), apierr.KindInvalid, "INVALID_BRANCH"},
+		{"probe failed", fmt.Errorf("spawn mer-1: workspace: %w: \"ao/mer-1/root\" (signal: killed)", ports.ErrWorkspaceProbeFailed), apierr.KindUnavailable, "WORKSPACE_PROBE_FAILED"},
 		{"agent binary not found", fmt.Errorf("spawn mer-1: %w", ports.ErrAgentBinaryNotFound), apierr.KindInvalid, "AGENT_BINARY_NOT_FOUND"},
 		{"runtime prerequisite missing", fmt.Errorf("spawn: %w: tmux required on macOS/Linux but not in PATH", ports.ErrRuntimePrerequisite), apierr.KindInvalid, "RUNTIME_PREREQUISITE_MISSING"},
 		{"Windows command line too long", fmt.Errorf("spawn: %w: escaped command line is 32769 UTF-16 code units", ports.ErrRuntimeCommandLineTooLong), apierr.KindInvalid, "WINDOWS_COMMAND_LINE_TOO_LONG"},


### PR DESCRIPTION
## What

`validateBranch` in `backend/internal/adapters/workspace/gitworktree/workspace.go` mapped **every** `git check-ref-format` failure to `ErrWorkspaceBranchInvalid` → `INVALID_BRANCH`. When the probe process is killed by a signal (e.g. macOS memory pressure / jetsam) or its context is cancelled/times out, git never evaluated the ref name, yet spawn failed with:

```
workspace: workspace: invalid branch name: "ao/agent-orchestrator-291/root" (signal: killed) — INVALID_BRANCH
```

`ao/<session-id>/root` is always a legal ref (`git check-ref-format --branch` exits 0), so this is an **error-classification bug**: "git was killed" was filed under "the branch name is bad". It sends users to check a ref that is fine and pollutes the `INVALID_BRANCH` telemetry bucket (#3942) with environment failures.

## Fix

Classify transient probe failures separately from genuine name rejections:

- New sentinel `ports.ErrWorkspaceProbeFailed` (transient, retryable), surfaced by the service layer as a **503 `WORKSPACE_PROBE_FAILED`** instead of a 400 `INVALID_BRANCH`.
- `validateBranch` now routes context cancellation/deadline **and** signal-killed probes to that sentinel. Signal-kill is detected portably via `(*exec.ExitError).ExitCode() == -1` (the value `os.ProcessState.ExitCode()` reports for a process terminated by a signal) — deliberately avoiding `syscall.WaitStatus.Signaled()`, which does not exist on Windows.
- Genuine git rejections (a real exit code) still map to `INVALID_BRANCH`.

## Scope / intentional omissions

- Surgical to the `INVALID_BRANCH` path named in the issue. The cosmetic `workspace: workspace:` double-prefix and the optional "one cheap retry" mentioned in the issue are left out to keep the diff minimal.
- The sibling `validateBranch` in `internal/gitdefault/resolver.go` wraps its own default-branch message (not `ErrWorkspaceBranchInvalid`) and does not feed the `INVALID_BRANCH` metric, so it is intentionally untouched.
- The signal-kill detection is inherently Unix (the reported failure is macOS jetsam, `signal: killed`). On Windows a killed process yields a real exit code, so `ExitCode() == -1` does not fire there — but the `signal: killed` failure mode also does not occur on Windows, so this is a documented limitation, not a regression. The signal-kill test is skipped on Windows; the context-cancellation branch stays cross-platform.

## Test verification (RED → GREEN)

New unit tests drive the classifier directly (the package already injects a fake `commandRunner`). A real signal-killed child process is used to produce the exact `ExitCode() == -1` shape (Unix-only; skipped on Windows where a killed process yields a real exit code).

**RED — on unmodified `main`** (a temporary test asserting the valid ref must NOT be reported invalid):

```
--- FAIL: TestRED5043/context_cancelled_misclassified_as_invalid_branch
    RED: valid branch reported as INVALID_BRANCH on a cancelled probe:
    workspace: invalid branch name: "ao/agent-orchestrator-291/root" (git wrapper: context canceled)
--- FAIL: TestRED5043/signal-killed_probe_misclassified_as_invalid_branch
    RED: valid branch reported as INVALID_BRANCH on a signal-killed probe:
    workspace: invalid branch name: "ao/agent-orchestrator-291/root" (signal: killed)
FAIL
```

**GREEN — with the fix** (`go test ./internal/adapters/workspace/gitworktree/...` and the service mapping):

```
--- PASS: TestValidateBranchClassifiesTransientProbeFailures
    --- PASS: .../context_cancelled_maps_to_probe_failure
    --- PASS: .../context_deadline_maps_to_probe_failure
    --- PASS: .../signal-killed_probe_maps_to_probe_failure
    --- PASS: .../genuine_git_rejection_still_maps_to_invalid_branch
ok  	.../internal/adapters/workspace/gitworktree	5.9s
--- PASS: TestToAPIErrorMapsWorkspaceBranchSentinels/probe_failed   (WORKSPACE_PROBE_FAILED, 503)
ok  	.../internal/service/session
```

Validated locally against the Go 1.26.5 toolchain: `go build ./...`, `go vet`, `go test` + `go test -race` for the touched packages, and `golangci-lint v2.12.2` — all green. Diff-coverage: 100% (18/18) of changed production lines.

Fixes #5043
