### PR TITLE
fix: improve clone destinations and startup before first push

### DIFF
--- a/backend/internal/gitdefault/resolver.go
+++ b/backend/internal/gitdefault/resolver.go
@@ -71,6 +71,24 @@ func New(binary string, run Runner) *Resolver {
 	return &Resolver{binary: binary, run: run}
 }
 
+// RecordInitialBranch records the branch AO is about to give its first commit.
+// Call only while initializing an unborn repository; ordinary default-branch
+// resolution must never infer a default from the current checkout.
+func (r *Resolver) RecordInitialBranch(ctx context.Context, repo string) error {
+	out, err := r.run(ctx, r.binary, "-C", repo, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		return fmt.Errorf("determine initial branch: %w", err)
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "" {
+		return errors.New("determine initial branch: empty symbolic HEAD")
+	}
+	if _, err := r.run(ctx, r.binary, "-C", repo, "config", "--local", ManagedDefaultConfigKey, branch); err != nil {
+		return fmt.Errorf("record initial branch: %w", err)
+	}
+	return nil
+}
+
 // Inspect resolves from local, durable repository metadata only. It never
 // contacts a remote, so it is suitable for project read models and registration.
 func (r *Resolver) Inspect(ctx context.Context, repo string) (Resolution, error) {

--- a/backend/internal/gitdefault/resolver.go
+++ b/backend/internal/gitdefault/resolver.go
@@ -20,7 +20,7 @@ const (
 	legacyWorkspaceCommitSubject = "chore: initialize AO workspace root"
 	// ManagedDefaultConfigKey records the branch AO selected when it initialized
 	// a repository itself. It is intentionally repo-local and is only consulted
-	// when the repository has no remotes.
+	// when the repository has no remote branches yet.
 	ManagedDefaultConfigKey = "ao.defaultBranch"
 )
 
@@ -83,6 +83,9 @@ func (r *Resolver) Inspect(ctx context.Context, repo string) (Resolution, error)
 	}
 	if cached, ok := r.cachedRemoteHead(ctx, repo, remote); ok {
 		return cached, nil
+	}
+	if initialized, ok := r.initializedBeforeFirstPush(ctx, repo, remote); ok {
+		return initialized, nil
 	}
 	return Resolution{}, unresolvedf(
 		"remote %q in repository %q has no cached HEAD", remote, repo,
@@ -157,12 +160,31 @@ func (r *Resolver) Resolve(ctx, remoteCtx context.Context, repo string) (Resolut
 	if cached, ok := r.cachedRemoteHead(ctx, repo, remote); ok {
 		return cached, nil
 	}
+	// A known live default must not be replaced by the initial local branch
+	// merely because fetching it failed.
+	if branch == "" {
+		if initialized, ok := r.initializedBeforeFirstPush(ctx, repo, remote); ok {
+			return initialized, nil
+		}
+	}
 	if liveErr == nil {
 		liveErr = errors.New("remote did not advertise a symbolic HEAD")
 	}
 	return Resolution{}, unresolvedf(
 		"could not resolve remote %q HEAD for repository %q (%v)", remote, repo, liveErr,
 	)
+}
+
+// An empty clone can have an AO-created initial commit before its first push.
+// Keep remote HEAD authoritative once available, and never use this fallback
+// when the selected remote already has fetched branches.
+func (r *Resolver) initializedBeforeFirstPush(ctx context.Context, repo, remote string) (Resolution, bool) {
+	out, err := r.run(ctx, r.binary, "-C", repo, "for-each-ref", "--format=%(refname)", "refs/remotes/"+remote+"/")
+	if err != nil || strings.TrimSpace(string(out)) != "" {
+		return Resolution{}, false
+	}
+	resolved, err := r.resolveAOInitialized(ctx, repo)
+	return resolved, err == nil
 }
 
 func (r *Resolver) selectRemote(ctx context.Context, repo string) (string, []string, error) {

--- a/backend/internal/gitdefault/resolver_test.go
+++ b/backend/internal/gitdefault/resolver_test.go
@@ -3,6 +3,7 @@ package gitdefault
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -220,5 +221,70 @@ func run(t *testing.T, binary string, args ...string) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s %s: %v\n%s", binary, strings.Join(args, " "), err, out)
+	}
+}
+
+func TestResolveAOInitializedEmptyCloneBeforeAndAfterFirstPush(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		t.Run(fmt.Sprint("legacy=", legacy), func(t *testing.T) {
+			ctx := context.Background()
+			origin := filepath.Join(t.TempDir(), "empty.git")
+			run(t, "git", "init", "--bare", "-b", "main", origin)
+			repo := filepath.Join(t.TempDir(), "clone")
+			run(t, "git", "clone", origin, repo)
+			configureGit(t, repo)
+			runGit(t, repo, "-c", "user.name=Agent Orchestrator", "commit", "--allow-empty", "-m", "initial commit")
+			if !legacy {
+				runGit(t, repo, "config", "--local", ManagedDefaultConfigKey, "main")
+			}
+			runGit(t, repo, "switch", "-c", "feature/work")
+			resolver := New("", nil)
+			for _, inspect := range []bool{true, false} {
+				var got Resolution
+				var err error
+				if inspect {
+					got, err = resolver.Inspect(ctx, repo)
+				} else {
+					got, err = resolver.Resolve(ctx, ctx, repo)
+				}
+				if err != nil || got.Ref != "refs/heads/main" || got.Source != SourceAOInitialized {
+					t.Fatalf("before first push (inspect=%v): %#v, %v", inspect, got, err)
+				}
+			}
+			runGit(t, repo, "push", "origin", "main:trunk")
+			runGit(t, origin, "symbolic-ref", "HEAD", "refs/heads/trunk")
+			got, err := resolver.Resolve(ctx, ctx, repo)
+			if err != nil || got.Branch != "trunk" || got.Source != SourceLiveRemoteHead {
+				t.Fatalf("after first push: %#v, %v", got, err)
+			}
+		})
+	}
+}
+
+func TestAOInitializedFallbackRejectsExistingRemoteBranches(t *testing.T) {
+	origin, repo := remoteRepo(t, "main")
+	runGit(t, repo, "config", "--local", ManagedDefaultConfigKey, "main")
+	runGit(t, repo, "symbolic-ref", "--delete", "refs/remotes/origin/HEAD")
+	runGit(t, origin, "symbolic-ref", "HEAD", "refs/heads/missing")
+	_, err := New("", nil).Resolve(context.Background(), context.Background(), repo)
+	if !errors.Is(err, ErrUnresolved) {
+		t.Fatalf("Resolve = %v, want unresolved remote", err)
+	}
+}
+
+func TestAOInitializedFallbackDoesNotOverrideKnownRemoteDefault(t *testing.T) {
+	origin, _ := remoteRepo(t, "trunk")
+	repo := localRepo(t, "main")
+	runGit(t, repo, "config", "--local", ManagedDefaultConfigKey, "main")
+	runGit(t, repo, "remote", "add", "origin", origin)
+	resolver := New("", func(ctx context.Context, binary string, args ...string) ([]byte, error) {
+		if len(args) > 2 && args[2] == "fetch" {
+			return nil, errors.New("fetch unavailable")
+		}
+		return runCommand(ctx, binary, args...)
+	})
+	_, err := resolver.Resolve(context.Background(), context.Background(), repo)
+	if !errors.Is(err, ErrUnresolved) {
+		t.Fatalf("Resolve = %v, want unresolved fetch rather than local main", err)
 	}
 }

--- a/backend/internal/service/importer/importer.go
+++ b/backend/internal/service/importer/importer.go
@@ -544,6 +544,11 @@ func runGitPreparationAction(ctx context.Context, path, action string, in GitRep
 			return fmt.Errorf("record default branch: %w", err)
 		}
 	case GitPreparationActionCommit:
+		// Empty clones already have .git and skip the init action. Record their
+		// actual initial branch too, before committing so a retry cannot lose it.
+		if err := gitdefault.New("git", nil).RecordInitialBranch(ctx, path); err != nil {
+			return err
+		}
 		if _, err := importGitOutput(ctx, path, "add", "-A"); err != nil {
 			return fmt.Errorf("stage files: %w", err)
 		}

--- a/backend/internal/service/importer/importer_test.go
+++ b/backend/internal/service/importer/importer_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/gitdefault"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 )
 
@@ -1132,5 +1133,37 @@ func wantCode(t *testing.T, err error, code string) {
 	}
 	if apiErr.Code != code {
 		t.Fatalf("code = %q, want %q", apiErr.Code, code)
+	}
+}
+
+func TestPrepareGitEmptyCloneRecordsInitialBranchForWorkspaceResolution(t *testing.T) {
+	for _, branch := range []string{"main", "trunk"} {
+		t.Run(branch, func(t *testing.T) {
+			ctx := context.Background()
+			origin := filepath.Join(t.TempDir(), "empty.git")
+			repo := filepath.Join(t.TempDir(), "clone")
+			for _, args := range [][]string{
+				{"init", "--bare", "-b", branch, origin},
+				{"clone", origin, repo},
+				{"-C", repo, "symbolic-ref", "HEAD", "refs/heads/" + branch},
+			} {
+				if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+					t.Fatalf("git %v: %v (%s)", args, err, out)
+				}
+			}
+			svc := New(Deps{Store: newFakeStore()})
+			result, err := svc.PrepareGit(ctx, GitPreparationInput{
+				ImportKind: ImportKindProject, Path: repo,
+				ApprovedActions:  []string{GitPreparationActionCommit},
+				InitialCommitMsg: "Start my project",
+			})
+			if err != nil || result.Validation.NextStep != ImportNextStepContinue {
+				t.Fatalf("PrepareGit: %#v, %v", result, err)
+			}
+			resolved, err := gitdefault.New("", nil).Resolve(ctx, ctx, repo)
+			if err != nil || resolved.Branch != branch || resolved.Source != gitdefault.SourceAOInitialized {
+				t.Fatalf("resolve prepared clone: %#v, %v", resolved, err)
+			}
+		})
 	}
 }

--- a/backend/internal/service/project/clone.go
+++ b/backend/internal/service/project/clone.go
@@ -114,9 +114,6 @@ func (m *Service) prepareClone(ctx context.Context, in CloneInput) (ClonePrepara
 	if err != nil {
 		return ClonePreparationResult{}, err
 	}
-	if err := ensureDirectoryPath(parent); err != nil {
-		return ClonePreparationResult{}, err
-	}
 	if in.Config != nil {
 		if err := in.Config.Validate(); err != nil {
 			return ClonePreparationResult{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
@@ -138,6 +135,9 @@ func (m *Service) prepareClone(ctx context.Context, in CloneInput) (ClonePrepara
 		return ClonePreparationResult{}, apierr.Invalid("CLONE_DESTINATION_UNAVAILABLE", "The clone destination could not be inspected.", map[string]any{"path": target})
 	}
 
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return ClonePreparationResult{}, apierr.Invalid("CLONE_DESTINATION_UNAVAILABLE", "AO could not create the destination folder.", nil)
+	}
 	temporaryPath, err := os.MkdirTemp(parent, ".ao-clone-")
 	if err != nil {
 		return ClonePreparationResult{}, apierr.Invalid("CLONE_DESTINATION_UNAVAILABLE", "AO could not prepare the selected clone destination.", nil)

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -366,19 +366,7 @@ func (m *Service) InitializeRepository(ctx context.Context, in InitializeReposit
 			return InitializeRepositoryResult{}, apierr.Invalid("GIT_INIT_FAILED", "Could not initialize a Git repository in this folder.", map[string]any{"error": err.Error()})
 		}
 	}
-	managedBranch := domain.DefaultBranchName
-	if target == repositorySetupUnbornRepo {
-		out, err := gitOutput(ctx, path, "symbolic-ref", "--quiet", "--short", "HEAD")
-		if err != nil || strings.TrimSpace(out) == "" {
-			detail := "empty symbolic HEAD"
-			if err != nil {
-				detail = err.Error()
-			}
-			return InitializeRepositoryResult{}, apierr.Invalid("GIT_INIT_FAILED", "Could not determine the initial branch for this repository.", map[string]any{"error": detail})
-		}
-		managedBranch = strings.TrimSpace(out)
-	}
-	if _, err := gitOutput(ctx, path, "config", "--local", gitdefault.ManagedDefaultConfigKey, managedBranch); err != nil {
+	if err := gitdefault.New("git", nil).RecordInitialBranch(ctx, path); err != nil {
 		return InitializeRepositoryResult{}, apierr.Invalid("GIT_INIT_FAILED", "Could not record the default branch for this repository.", map[string]any{"error": err.Error()})
 	}
 

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -2186,3 +2186,21 @@ func TestManager_RememberPortablePermissions(t *testing.T) {
 		t.Fatal("accepted unknown harness")
 	}
 }
+
+func TestPrepareCloneCreatesDestinationParents(t *testing.T) {
+	m := newManager(t)
+	source := gitRepo(t)
+	parent := filepath.Join(t.TempDir(), "Projects", "new folder")
+	prepared, err := m.PrepareClone(context.Background(), project.CloneInput{
+		RemoteURL: (&url.URL{Scheme: "file", Path: source}).String(), DestinationParent: parent,
+	})
+	if err != nil {
+		t.Fatalf("PrepareClone: %v", err)
+	}
+	if prepared.Path != filepath.Join(parent, filepath.Base(source)) {
+		t.Fatalf("unexpected clone path %q", prepared.Path)
+	}
+	if out, err := exec.Command("git", "-C", prepared.Path, "rev-parse", "--verify", "HEAD").CombinedOutput(); err != nil {
+		t.Fatalf("clone missing commit: %v (%s)", err, out)
+	}
+}

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -16,10 +16,12 @@ import (
 
 	"github.com/go-chi/chi/v5/middleware"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/gitdefault"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/service/importer"
 	"github.com/aoagents/agent-orchestrator/backend/internal/service/project"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
 )
@@ -2202,5 +2204,58 @@ func TestPrepareCloneCreatesDestinationParents(t *testing.T) {
 	}
 	if out, err := exec.Command("git", "-C", prepared.Path, "rev-parse", "--verify", "HEAD").CombinedOutput(); err != nil {
 		t.Fatalf("clone missing commit: %v (%s)", err, out)
+	}
+}
+
+func TestEmptyCloneOnboardingCreatesFirstWorkspace(t *testing.T) {
+	for _, branch := range []string{"main", "trunk"} {
+		t.Run(branch, func(t *testing.T) {
+			ctx := context.Background()
+			m := newManager(t)
+			origin := filepath.Join(t.TempDir(), "empty.git")
+			if out, err := exec.Command("git", "init", "--bare", "-b", branch, origin).CombinedOutput(); err != nil {
+				t.Fatalf("init remote: %v (%s)", err, out)
+			}
+			prepared, err := m.PrepareClone(ctx, project.CloneInput{
+				RemoteURL:         (&url.URL{Scheme: "file", Path: origin}).String(),
+				DestinationParent: filepath.Join(t.TempDir(), "Projects"),
+			})
+			if err != nil {
+				t.Fatalf("prepare clone: %v", err)
+			}
+			// Select the advertised unborn branch explicitly for Git versions that
+			// do not negotiate an empty remote's HEAD during clone.
+			if out, err := exec.Command("git", "-C", prepared.Path, "symbolic-ref", "HEAD", "refs/heads/"+branch).CombinedOutput(); err != nil {
+				t.Fatalf("select initial branch: %v (%s)", err, out)
+			}
+			setup, err := importer.New(importer.Deps{}).PrepareGit(ctx, importer.GitPreparationInput{
+				ImportKind: importer.ImportKindProject, Path: prepared.Path,
+				ApprovedActions:  []string{importer.GitPreparationActionCommit},
+				InitialCommitMsg: "Start project",
+			})
+			if err != nil || setup.Validation.NextStep != importer.ImportNextStepContinue {
+				t.Fatalf("prepare git: %#v, %v", setup, err)
+			}
+			registered, err := m.Add(ctx, project.AddInput{Path: prepared.Path, ClonePreparationID: prepared.PreparationID})
+			if err != nil {
+				t.Fatalf("register: %v", err)
+			}
+			if registered.DefaultBranch != branch {
+				t.Fatalf("registered default = %q, want %q", registered.DefaultBranch, branch)
+			}
+			ws, err := gitworktree.New(gitworktree.Options{
+				ManagedRoot: t.TempDir(), RepoResolver: gitworktree.StaticRepoResolver{registered.ID: registered.Path},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: registered.ID, SessionID: "first", Branch: "ao/first"})
+			if err != nil {
+				t.Fatalf("first workspace: %v", err)
+			}
+			if out, err := exec.Command("git", "-C", info.Path, "log", "-1", "--format=%s").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "Start project" {
+				t.Fatalf("first workspace commit: %s, %v", out, err)
+			}
+		})
 	}
 }

--- a/docs/onboarding-contract-review.md
+++ b/docs/onboarding-contract-review.md
@@ -22,10 +22,10 @@ workspace can be created. The reported failure crossed precisely that boundary.
 
 ## Changes in PR #5126
 
-- Clone destinations default to `~/ao/projects` without a saved selection.
-  The destination row opens a native picker at that folder, creating it if
-  needed; the picker permits folder creation. Existing user selections remain
-  respected. Direct path editing is not available in the current UI.
+- Clone destinations can be typed and default to `~/ao/projects` without a
+  saved selection. A separate button opens the native picker at that folder,
+  creating it if needed; the picker permits folder creation. Existing user
+  selections remain respected, and cloning creates missing destination parents.
 - Default resolution accepts an AO-initialized local branch before the first
   push, without guessing from an arbitrary current checkout. Remote defaults
   retain precedence, and a failed fetch of a known default still fails.

--- a/docs/onboarding-contract-review.md
+++ b/docs/onboarding-contract-review.md
@@ -1,0 +1,111 @@
+# Desktop project onboarding contract review
+
+Scope: local desktop project creation, cloning, existing-folder imports,
+workspace imports, Git preparation, registration, and first orchestrator startup.
+This is a code-path review prompted by the `untrivial` empty-clone failure, not
+an exhaustive interactive audit. Cloud provisioning, mobile onboarding, and
+all native picker/platform combinations remain outside this review.
+
+## Root cause across stages
+
+Onboarding currently has several different definitions of readiness:
+
+- `service/importer.Validate` checks repository metadata, commit/origin presence,
+  and required preparation actions.
+- `service/project.Add` validates and registers a repository with a commit.
+- The workspace adapter later requires a resolvable base ref to create a session.
+- The selected agent/runtime has separate launch prerequisites.
+
+These distinctions are legitimate, but the flow does not expose them as an
+explicit contract. Completing Git preparation does not establish that the next
+workspace can be created. The reported failure crossed precisely that boundary.
+
+## Changes in PR #5126
+
+- Clone destinations can be typed, default to `~/Projects` without a saved
+  selection, and can name missing parent folders. Native pickers permit folder
+  creation. Existing user selections remain respected.
+- Default resolution accepts an AO-initialized local branch before the first
+  push, without guessing from an arbitrary current checkout. Remote defaults
+  retain precedence, and a failed fetch of a known default still fails.
+- Both the project initializer and the import preparation commit action use
+  `gitdefault.Resolver.RecordInitialBranch`. Empty clones already have `.git`
+  and skip `git init`, so recording the branch only in the init action was
+  insufficient. Branch identity is recorded before the initial commit to retain
+  it across a failed commit/retry.
+- Legacy detection remains compatibility support for already-created projects;
+  new onboarding does not depend on a particular commit message or `main`.
+- Tests cover `main` and `trunk`, custom initial-commit messages, the real
+  clone → Git preparation → registration → first-worktree sequence, and the
+  transition to an advertised remote default after pushing. They do not launch
+  an external agent or claim to cover the whole native desktop interaction.
+
+## Further findings and design direction
+
+### One branch-selection policy across entry points
+
+`CreateProjectFlow.createProject` reads the checked-out branch for local imports
+and submits it as an explicit default override. Its clone path does not do so
+and relies on automatic resolution. The same checkout can therefore acquire
+incompatible base-selection policies depending on how it was added.
+
+Define the product choice explicitly: automatic repository default versus a
+user-selected base branch. The daemon should resolve automatic defaults using
+the same policy for every client. Merely opening a local repository on a feature
+branch should not silently count as choosing that feature as its default.
+This policy discrepancy is not changed by #5126.
+
+### Distinguish registration from launch readiness
+
+Keep registering a project separate from launching an agent: an unavailable
+agent or an offline remote should not erase a successfully registered project.
+Expose typed, actionable readiness facts for workspace creation and agent launch,
+and check the same prerequisites again at launch because external state can
+change. The UI should show “project added; startup needs attention” with a
+specific repair/retry action, rather than treating every preceding green step
+as evidence that startup must succeed.
+
+Reuse existing Git resolution and agent readiness services for these facts;
+do not introduce another independent validator in the renderer.
+
+### Consolidate orchestrator startup and errors
+
+Automatic startup in `routes/_shell.tsx` calls `/sessions` directly and converts
+failures to strings. Later startup uses `spawnOrchestrator`, `/orchestrators`,
+and a typed error. The formatter then interprets codes and repository details
+embedded in text. Review the endpoint defaults and consolidate the shared
+startup/error contract while preserving the chosen harness and session mode.
+This is an architectural follow-up, not part of #5126.
+
+### Make preparation recovery explicit
+
+Prepared clones already have server-side ownership markers and registration
+checks, which protect cleanup from removing registered projects. However,
+`usePreparedClone` holds the client's preparation identity only in memory.
+There is no resume flow in this hook after a renderer restart. Define how an
+interrupted preparation is discovered and resumed or deliberately abandoned;
+do not solve this by blindly deleting leftover checkouts.
+
+Existing-folder preparation and remote repository creation also have external
+side effects. Preserve completed work on retry and clearly identify what was
+created, what failed, and what the next attempt will repeat.
+
+### Validate journeys, not just components
+
+Retain focused tests, but add boundary/acceptance coverage for these journeys:
+
+| Journey | Required outcome |
+| --- | --- |
+| Populated remote clone, including non-main defaults | First workspace uses the repository default |
+| Empty remote clone | AO's initial branch seeds the first workspace; first push supersedes local fallback |
+| Existing local repository on a feature branch | Explicit, consistent base-selection policy |
+| Plain folder or unborn local repository | Approved initialization preserves contents and records branch identity |
+| Workspace with mixed child readiness | Each child has an actionable result; failed preparation is retryable |
+| Missing Git, agent, auth, or offline remote | Failure identifies the stage and preserves completed project setup |
+| Cancel, restart, or lost response during preparation | No accidental deletion, duplicate registration, or invisible abandoned operation |
+| Project registration succeeds, startup fails | Project remains available and startup alone can be retried |
+| Repeated submission or duplicate/aliased path | One registered project with deterministic recovery |
+
+Some of these have individual tests already. The remaining work is to exercise
+stage-to-stage guarantees through shared services and desktop acceptance tests,
+not to infer journey coverage from the total count of unit tests.

--- a/docs/onboarding-contract-review.md
+++ b/docs/onboarding-contract-review.md
@@ -22,9 +22,10 @@ workspace can be created. The reported failure crossed precisely that boundary.
 
 ## Changes in PR #5126
 
-- Clone destinations can be typed, default to `~/Projects` without a saved
-  selection, and can name missing parent folders. Native pickers permit folder
-  creation. Existing user selections remain respected.
+- Clone destinations default to `~/ao/projects` without a saved selection.
+  The destination row opens a native picker at that folder, creating it if
+  needed; the picker permits folder creation. Existing user selections remain
+  respected. Direct path editing is not available in the current UI.
 - Default resolution accepts an AO-initialized local branch before the first
   push, without guessing from an arbitrary current checkout. Remote defaults
   retain precedence, and a failed fetch of a known default still fails.

--- a/frontend/e2e/clone-preparation-lifecycle.spec.ts
+++ b/frontend/e2e/clone-preparation-lifecycle.spec.ts
@@ -3,82 +3,93 @@ import type { AoBridge } from "../src/preload";
 import { agentReadiness } from "../src/renderer/test/agent-readiness-fixtures";
 import { installFakeAgent } from "./support/fake-bridge";
 
-test("renderer: clone cancel and retry use the matching preparation ID @T0", async ({ page }) => {
-	await installFakeAgent(page);
-	let preparation = 0;
-	const cleanupRequests: Array<{ path: string; preparationId: string }> = [];
-	let addRequest: Record<string, unknown> | null = null;
+for (const destinationMode of ["picker", "typed"] as const) {
+	test(`renderer: clone cancel and retry use the matching preparation ID with ${destinationMode} destination @T0`, async ({ page }) => {
+		await installFakeAgent(page);
+		let preparation = 0;
+		const cleanupRequests: Array<{ path: string; preparationId: string }> = [];
+		let addRequest: Record<string, unknown> | null = null;
 
-	await page.route("http://127.0.0.1:8080/api/v1/**", async (route) => {
-		const pathname = new URL(route.request().url()).pathname;
-		if (pathname.startsWith("/api/v1/agents/readiness")) {
-			await route.fulfill({ json: { agents: [agentReadiness("codex", "Codex")] } });
-			return;
-		}
-		if (pathname === "/api/v1/projects/clone/prepare") {
-			expect(route.request().postDataJSON()).toEqual({
-				remoteUrl: "https://example.com/example.git", destinationParent: "/repos",
-			});
-			preparation += 1;
-			await route.fulfill({ json: {
-				path: "/repos/example", remoteUrl: "https://example.com/example.git",
-				preparationId: `prep-${preparation}`,
-			} });
-			return;
-		}
-		if (pathname === "/api/v1/projects/clone/cleanup") {
-			cleanupRequests.push(route.request().postDataJSON());
-			await route.fulfill({ status: 204 });
-			return;
-		}
-		if (pathname === "/api/v1/imports/validate") {
-			await route.fulfill({ json: {
-				importKind: "project", isValid: true, blockingErrors: [], nextStep: "continue",
-				root: { repoPath: "/repos/example", isRepo: true, hasCommit: true, hasOrigin: true, isEmptyFolder: false, needsGitInit: false, requiredActions: [], blockingErrors: [] },
-			} });
-			return;
-		}
-		if (pathname === "/api/v1/projects" && route.request().method() === "POST") {
-			addRequest = route.request().postDataJSON();
-			await route.fulfill({ status: 201, json: { project: {
-				id: "example", name: "example", kind: "single_repo", path: "/repos/example", config: {},
-			} } });
-			return;
-		}
-		if (pathname === "/api/v1/sessions" && route.request().method() === "POST") {
-			await route.fulfill({ status: 422, json: { error: "invalid", code: "START_FAILED", message: "test stop" } });
-			return;
-		}
-		await route.fulfill({ json: {} });
-	});
+		await page.route("http://127.0.0.1:8080/api/v1/**", async (route) => {
+			const pathname = new URL(route.request().url()).pathname;
+			if (pathname.startsWith("/api/v1/agents/readiness")) {
+				await route.fulfill({ json: { agents: [agentReadiness("codex", "Codex")] } });
+				return;
+			}
+			if (pathname === "/api/v1/projects/clone/prepare") {
+				expect(route.request().postDataJSON()).toEqual({
+					remoteUrl: "https://example.com/example.git", destinationParent: "/repos",
+				});
+				preparation += 1;
+				await route.fulfill({ json: {
+					path: "/repos/example", remoteUrl: "https://example.com/example.git",
+					preparationId: `prep-${preparation}`,
+				} });
+				return;
+			}
+			if (pathname === "/api/v1/projects/clone/cleanup") {
+				cleanupRequests.push(route.request().postDataJSON());
+				await route.fulfill({ status: 204 });
+				return;
+			}
+			if (pathname === "/api/v1/imports/validate") {
+				await route.fulfill({ json: {
+					importKind: "project", isValid: true, blockingErrors: [], nextStep: "continue",
+					root: { repoPath: "/repos/example", isRepo: true, hasCommit: true, hasOrigin: true, isEmptyFolder: false, needsGitInit: false, requiredActions: [], blockingErrors: [] },
+				} });
+				return;
+			}
+			if (pathname === "/api/v1/projects" && route.request().method() === "POST") {
+				addRequest = route.request().postDataJSON();
+				await route.fulfill({ status: 201, json: { project: {
+					id: "example", name: "example", kind: "single_repo", path: "/repos/example", config: {},
+				} } });
+				return;
+			}
+			if (pathname === "/api/v1/sessions" && route.request().method() === "POST") {
+				await route.fulfill({ status: 422, json: { error: "invalid", code: "START_FAILED", message: "test stop" } });
+				return;
+			}
+			await route.fulfill({ json: {} });
+		});
 
-	await page.goto("/#/");
-	await page.evaluate(() => {
-		const bridge = (window as unknown as { ao: AoBridge }).ao;
-		bridge.app.chooseDirectory = async () => "/repos";
-		bridge.app.checkGitRepository = async () => true;
-	});
+		await page.goto("/#/");
+		await page.evaluate(() => {
+			const bridge = (window as unknown as { ao: AoBridge }).ao;
+			bridge.app.chooseDirectory = async () => "/repos";
+			bridge.app.checkGitRepository = async () => true;
+		});
 
-	const openClone = async () => {
-		await page.getByRole("button", { name: "New project", exact: true }).first().click();
-		await page.getByRole("button", { name: "Clone from Git", exact: true }).click();
+		const selectDestination = async () => {
+			if (destinationMode === "typed") {
+				await page.getByRole("textbox", { name: "Destination folder" }).fill("/repos");
+			} else {
+				await page.getByRole("button", { name: "Choose where to clone the repository", exact: true }).click();
+			}
+			await expect(page.getByRole("textbox", { name: "Destination folder" })).toHaveValue("/repos");
+		};
+
+		const openClone = async () => {
+			await page.getByRole("button", { name: "New project", exact: true }).first().click();
+			await page.getByRole("button", { name: "Clone from Git", exact: true }).click();
+			await page.getByRole("textbox", { name: "Repository URL" }).fill("https://example.com/example.git");
+			await selectDestination();
+			await page.getByRole("button", { name: "Continue", exact: true }).click();
+		};
+
+		await openClone();
+		await page.getByRole("button", { name: "Back to clone details" }).click();
+		await expect.poll(() => cleanupRequests).toEqual([{ path: "/repos/example", preparationId: "prep-1" }]);
+
 		await page.getByRole("textbox", { name: "Repository URL" }).fill("https://example.com/example.git");
-		await page.getByRole("button", { name: "Choose where to clone the repository", exact: true }).click();
+		await selectDestination();
 		await page.getByRole("button", { name: "Continue", exact: true }).click();
-	};
+		await page.getByRole("button", { name: "Clone", exact: true }).click();
 
-	await openClone();
-	await page.getByRole("button", { name: "Back to clone details" }).click();
-	await expect.poll(() => cleanupRequests).toEqual([{ path: "/repos/example", preparationId: "prep-1" }]);
-
-	await page.getByRole("textbox", { name: "Repository URL" }).fill("https://example.com/example.git");
-	await page.getByRole("button", { name: "Choose where to clone the repository", exact: true }).click();
-	await page.getByRole("button", { name: "Continue", exact: true }).click();
-	await page.getByRole("button", { name: "Clone", exact: true }).click();
-
-	await expect.poll(() => addRequest).toMatchObject({
-		path: "/repos/example",
-		clonePreparationId: "prep-2",
+		await expect.poll(() => addRequest).toMatchObject({
+			path: "/repos/example",
+			clonePreparationId: "prep-2",
+		});
+		expect(cleanupRequests).toEqual([{ path: "/repos/example", preparationId: "prep-1" }]);
 	});
-	expect(cleanupRequests).toEqual([{ path: "/repos/example", preparationId: "prep-1" }]);
-});
+}

--- a/frontend/e2e/clone-preparation-lifecycle.spec.ts
+++ b/frontend/e2e/clone-preparation-lifecycle.spec.ts
@@ -16,6 +16,9 @@ test("renderer: clone cancel and retry use the matching preparation ID @T0", asy
 			return;
 		}
 		if (pathname === "/api/v1/projects/clone/prepare") {
+			expect(route.request().postDataJSON()).toEqual({
+				remoteUrl: "https://example.com/example.git", destinationParent: "/repos",
+			});
 			preparation += 1;
 			await route.fulfill({ json: {
 				path: "/repos/example", remoteUrl: "https://example.com/example.git",
@@ -60,7 +63,7 @@ test("renderer: clone cancel and retry use the matching preparation ID @T0", asy
 		await page.getByRole("button", { name: "New project", exact: true }).first().click();
 		await page.getByRole("button", { name: "Clone from Git", exact: true }).click();
 		await page.getByRole("textbox", { name: "Repository URL" }).fill("https://example.com/example.git");
-		await page.getByRole("button", { name: "Choose", exact: true }).click();
+		await page.getByRole("button", { name: "Choose where to clone the repository", exact: true }).click();
 		await page.getByRole("button", { name: "Continue", exact: true }).click();
 	};
 
@@ -69,7 +72,7 @@ test("renderer: clone cancel and retry use the matching preparation ID @T0", asy
 	await expect.poll(() => cleanupRequests).toEqual([{ path: "/repos/example", preparationId: "prep-1" }]);
 
 	await page.getByRole("textbox", { name: "Repository URL" }).fill("https://example.com/example.git");
-	await page.getByRole("button", { name: "Choose", exact: true }).click();
+	await page.getByRole("button", { name: "Choose where to clone the repository", exact: true }).click();
 	await page.getByRole("button", { name: "Continue", exact: true }).click();
 	await page.getByRole("button", { name: "Clone", exact: true }).click();
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2033,7 +2033,7 @@ function failClosedTelemetryPolicyView(): TelemetryPolicyView {
 }
 async function chooseDirectory(title: string): Promise<string | null> {
 	const options: OpenDialogOptions = {
-		properties: ["openDirectory"],
+		properties: ["openDirectory", "createDirectory"],
 		title,
 	};
 	// On Windows, parenting the common file dialog forces a repaint of the main

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2031,8 +2031,10 @@ ipcMain.on(AGENT_SWITCH_VISIBILITY_IPC_CHANNEL, (event, request: unknown) => {
 function failClosedTelemetryPolicyView(): TelemetryPolicyView {
 	return { eventsEnabled: false, consentGeneration: "unavailable", updatedAt: new Date(0).toISOString(), acknowledged: false, state: "cleanup_failed", environmentVeto: true, durabilitySupported: false, reason: "invalid_authority" };
 }
-async function chooseDirectory(title: string): Promise<string | null> {
+async function chooseDirectory(title: string, defaultPath?: string): Promise<string | null> {
+	if (defaultPath) await mkdir(defaultPath, { recursive: true });
 	const options: OpenDialogOptions = {
+		defaultPath,
 		properties: ["openDirectory", "createDirectory"],
 		title,
 	};
@@ -2046,8 +2048,14 @@ async function chooseDirectory(title: string): Promise<string | null> {
 	return result.filePaths[0] ?? null;
 }
 
-ipcMain.handle("app:chooseDirectory", async (_event, title?: string) => {
-	return chooseDirectory(typeof title === "string" && title.trim() ? title : "Choose a git repository");
+ipcMain.handle("app:chooseDirectory", async (_event, input?: string | { title?: string; defaultPath?: string }) => {
+	const title = typeof input === "string"
+		? input
+		: input?.title;
+	const defaultPath = typeof input === "object" && input !== null && typeof input.defaultPath === "string"
+		? input.defaultPath.trim()
+		: "";
+	return chooseDirectory(title?.trim() || "Choose a git repository", defaultPath === "~/ao/projects" ? path.join(os.homedir(), "ao", "projects") : undefined);
 });
 ipcMain.handle("app:checkGitRepository", async (_event, remoteUrl: string) => {
 	await ensureShellEnv();

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -165,7 +165,7 @@ function isRendererQueuePurgeRequest(value: unknown): value is RendererTelemetry
 const api = {
 	app: {
 		getVersion: () => ipcRenderer.invoke("app:getVersion") as Promise<string>,
-		chooseDirectory: (title?: string) => ipcRenderer.invoke("app:chooseDirectory", title) as Promise<string | null>,
+		chooseDirectory: (input?: string | { title?: string; defaultPath?: string }) => ipcRenderer.invoke("app:chooseDirectory", input) as Promise<string | null>,
 		checkGitRepository: (remoteUrl: string) => ipcRenderer.invoke("app:checkGitRepository", remoteUrl) as Promise<boolean>,
 		openExternal: (url: string) => ipcRenderer.invoke("app:openExternal", url) as Promise<void>,
 		scanImportFolder: (input: { path: string; mode: ImportFolderMode }) =>

--- a/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
@@ -33,15 +33,15 @@ afterEach(() => {
 });
 
 describe("clone repository input", () => {
-	it("edits the destination without opening the picker and submits the updated path", async () => {
+	it("opens the destination picker at the default folder and submits its selection", async () => {
 		window.ao!.app.checkGitRepository = vi.fn().mockResolvedValue(true);
-		window.ao!.app.chooseDirectory = vi.fn();
+		window.ao!.app.chooseDirectory = vi.fn().mockResolvedValue("/Projects/new folder");
 		const { props, view } = renderCloneDialog();
-		const input = screen.getByRole("textbox", { name: "Destination folder" });
-		fireEvent.click(input);
-		fireEvent.change(input, { target: { value: "/Projects/new folder" } });
-		expect(window.ao!.app.chooseDirectory).not.toHaveBeenCalled();
-		expect(props.onChange).toHaveBeenCalledWith({ ...props.value, destinationParent: "/Projects/new folder" });
+		fireEvent.click(screen.getByRole("button", { name: "Choose where to clone the repository" }));
+		expect(window.ao!.app.chooseDirectory).toHaveBeenCalledWith({
+			title: "Choose where to clone the repository", defaultPath: "~/ao/projects",
+		});
+		await waitFor(() => expect(props.onChange).toHaveBeenCalledWith({ ...props.value, destinationParent: "/Projects/new folder" }));
 		view.rerender(React.createElement(CloneRepositoryDialog, { ...props, value: { ...props.value, destinationParent: "/Projects/new folder" } }));
 		expect(screen.getByText("Repository will be created at /Projects/new folder/web-app.")).toBeInTheDocument();
 		await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
@@ -246,7 +246,7 @@ describe("clone repository input", () => {
 		const onChange = vi.fn();
 		const { props, view } = renderCloneDialog({ onChange });
 
-		fireEvent.click(screen.getByRole("button", { name: "Choose" }));
+		fireEvent.click(screen.getByRole("button", { name: "Choose where to clone the repository" }));
 		await waitFor(() => expect(window.ao!.app.chooseDirectory).toHaveBeenCalledOnce());
 		view.rerender(React.createElement(CloneRepositoryDialog, { ...props, open: false }));
 		await act(async () => resolvePicker?.("/stale/path"));

--- a/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
@@ -28,10 +28,28 @@ function renderCloneDialog(
 }
 
 afterEach(() => {
+	window.localStorage.removeItem("ao.clone.lastDestinationParent");
 	vi.restoreAllMocks();
 });
 
 describe("clone repository input", () => {
+	it("edits the destination without opening the picker and submits the updated path", async () => {
+		window.ao!.app.checkGitRepository = vi.fn().mockResolvedValue(true);
+		window.ao!.app.chooseDirectory = vi.fn();
+		const { props, view } = renderCloneDialog();
+		const input = screen.getByRole("textbox", { name: "Destination folder" });
+		fireEvent.click(input);
+		fireEvent.change(input, { target: { value: "/Projects/new folder" } });
+		expect(window.ao!.app.chooseDirectory).not.toHaveBeenCalled();
+		expect(props.onChange).toHaveBeenCalledWith({ ...props.value, destinationParent: "/Projects/new folder" });
+		view.rerender(React.createElement(CloneRepositoryDialog, { ...props, value: { ...props.value, destinationParent: "/Projects/new folder" } }));
+		expect(screen.getByText("Repository will be created at /Projects/new folder/web-app.")).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(props.onContinue).toHaveBeenCalledWith({ ...props.value, destinationParent: "/Projects/new folder", targetPath: "/Projects/new folder/web-app" });
+		expect(window.localStorage.getItem("ao.clone.lastDestinationParent")).toBe("/Projects/new folder");
+	});
+
 	it("describes the destination consistently and shows the exact checkout path", () => {
 		renderCloneDialog();
 

--- a/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.test.ts
@@ -33,6 +33,23 @@ afterEach(() => {
 });
 
 describe("clone repository input", () => {
+	it("edits the destination without opening the picker and submits the updated path", async () => {
+		window.ao!.app.checkGitRepository = vi.fn().mockResolvedValue(true);
+		window.ao!.app.chooseDirectory = vi.fn();
+		const { props, view } = renderCloneDialog();
+		const input = screen.getByRole("textbox", { name: "Destination folder" });
+		fireEvent.click(input);
+		fireEvent.change(input, { target: { value: "/Projects/new folder" } });
+		expect(window.ao!.app.chooseDirectory).not.toHaveBeenCalled();
+		expect(props.onChange).toHaveBeenCalledWith({ ...props.value, destinationParent: "/Projects/new folder" });
+		view.rerender(React.createElement(CloneRepositoryDialog, { ...props, value: { ...props.value, destinationParent: "/Projects/new folder" } }));
+		expect(screen.getByText("Repository will be created at /Projects/new folder/web-app.")).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(props.onContinue).toHaveBeenCalledWith({ ...props.value, destinationParent: "/Projects/new folder", targetPath: "/Projects/new folder/web-app" });
+		expect(window.localStorage.getItem("ao.clone.lastDestinationParent")).toBe("/Projects/new folder");
+	});
+
 	it("opens the destination picker at the default folder and submits its selection", async () => {
 		window.ao!.app.checkGitRepository = vi.fn().mockResolvedValue(true);
 		window.ao!.app.chooseDirectory = vi.fn().mockResolvedValue("/Projects/new folder");

--- a/frontend/src/renderer/components/CloneRepositoryDialog.tsx
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.tsx
@@ -5,7 +5,6 @@ import { type FormEvent, useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { aoBridge } from "../lib/bridge";
 import { isMacPlatform, isWindowsPlatform } from "../lib/platform";
-import { PathRow } from "./PathRow";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -309,18 +308,27 @@ export default function CloneRepositoryDialog({
 								<Label htmlFor="cloneDestination" className="text-[13px] font-semibold text-[var(--color-text-import-title)]">
 									{t("createProject.cloneDestination")}
 								</Label>
-								<PathRow
-									action={t("createProject.cloneChoose")}
-									ariaDescribedBy={`cloneDestinationHelp${destinationError ? " cloneDestinationError" : ""}`}
-									ariaInvalid={Boolean(destinationError)}
-									ariaLabel={t("createProject.cloneChooseDestination")}
-									disabled={disabled || choosingDestination}
-									id="cloneDestination"
-									icon={<Folder className="size-4 shrink-0 text-[var(--color-text-import-muted)]" aria-hidden="true" />}
-									onClick={() => void chooseDestination()}
-								>
-									{value.destinationParent || "~/ao/projects"}
-								</PathRow>
+								<div className="flex items-center overflow-hidden rounded-md bg-[var(--color-bg-import-card)]">
+									<div className="relative min-w-0 flex-1">
+										<Folder className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-text-import-muted)]" aria-hidden="true" />
+										<Input
+											id="cloneDestination"
+											className="border-transparent bg-transparent pl-10 font-mono text-[13px]"
+											aria-describedby={`cloneDestinationHelp${destinationError ? " cloneDestinationError" : ""}`}
+											aria-invalid={Boolean(destinationError)}
+											disabled={disabled || choosingDestination}
+											autoCapitalize="none"
+											autoComplete="off"
+											spellCheck={false}
+											placeholder={t("createProject.cloneDestinationPlaceholder")}
+											value={value.destinationParent}
+											onChange={(event) => onChange({ ...value, destinationParent: event.target.value })}
+										/>
+									</div>
+									<Button type="button" aria-label={t("createProject.cloneChooseDestination")} variant="ghost" className="shrink-0 rounded-none border-l border-border/60" disabled={disabled || choosingDestination} onClick={() => void chooseDestination()}>
+										{t("createProject.cloneChoose")}
+									</Button>
+								</div>
 								<p id="cloneDestinationHelp" className="text-pretty text-[12px] leading-5 text-[var(--color-text-import-muted)]">
 									{targetPath
 										? t("createProject.cloneDestinationTarget", { path: targetPath })

--- a/frontend/src/renderer/components/CloneRepositoryDialog.tsx
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.tsx
@@ -5,7 +5,6 @@ import { type FormEvent, useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { aoBridge } from "../lib/bridge";
 import { isMacPlatform, isWindowsPlatform } from "../lib/platform";
-import { PathRow } from "./PathRow";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -64,7 +63,7 @@ export default function CloneRepositoryDialog({
 	const hasRemoteUrl = value.remoteUrl.trim().length > 0;
 	const hasDestination = value.destinationParent.trim().length > 0;
 	const targetPath = repositoryName && hasDestination
-		? joinCloneDestination(value.destinationParent, repositoryName)
+		? joinCloneDestination(value.destinationParent.trim(), repositoryName)
 		: "";
 	const projectExists = Boolean(
 		targetPath && existingProjectPaths.some((path) => sameProjectPath(path, targetPath)),
@@ -199,9 +198,15 @@ export default function CloneRepositoryDialog({
 			}
 			return;
 		}
+		try {
+			window.localStorage.setItem(LAST_CLONE_DESTINATION_KEY, value.destinationParent.trim());
+		} catch {
+			// Remembering the folder is optional.
+		}
 		onContinue({
 			...value,
 			remoteUrl: value.remoteUrl.trim(),
+			destinationParent: value.destinationParent.trim(),
 			targetPath,
 		});
 	};
@@ -300,18 +305,27 @@ export default function CloneRepositoryDialog({
 								<Label htmlFor="cloneDestination" className="text-[13px] font-semibold text-[var(--color-text-import-title)]">
 									{t("createProject.cloneDestination")}
 								</Label>
-								<PathRow
-									action={t("createProject.cloneChoose")}
-									ariaDescribedBy={`cloneDestinationHelp${destinationError ? " cloneDestinationError" : ""}`}
-									ariaInvalid={Boolean(destinationError)}
-									ariaLabel={t("createProject.cloneChoose")}
-									disabled={disabled || choosingDestination}
-									icon={<Folder className="size-4 shrink-0 text-[var(--color-text-import-muted)]" aria-hidden="true" />}
-									id="cloneDestination"
-									onClick={() => void chooseDestination()}
-								>
-									{value.destinationParent || t("createProject.cloneDestinationPlaceholder")}
-								</PathRow>
+								<div className="flex items-center overflow-hidden rounded-md bg-[var(--color-bg-import-card)]">
+									<div className="relative min-w-0 flex-1">
+										<Folder className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-text-import-muted)]" aria-hidden="true" />
+										<Input
+											id="cloneDestination"
+											className="border-transparent bg-transparent pl-10 font-mono text-[13px]"
+											aria-describedby={`cloneDestinationHelp${destinationError ? " cloneDestinationError" : ""}`}
+											aria-invalid={Boolean(destinationError)}
+											disabled={disabled || choosingDestination}
+											autoCapitalize="none"
+											autoComplete="off"
+											spellCheck={false}
+											placeholder={t("createProject.cloneDestinationPlaceholder")}
+											value={value.destinationParent}
+											onChange={(event) => onChange({ ...value, destinationParent: event.target.value })}
+										/>
+									</div>
+									<Button type="button" variant="ghost" className="shrink-0 rounded-none border-l border-border/60" disabled={disabled || choosingDestination} onClick={() => void chooseDestination()}>
+										{t("createProject.cloneChoose")}
+									</Button>
+								</div>
 								<p id="cloneDestinationHelp" className="text-pretty text-[12px] leading-5 text-[var(--color-text-import-muted)]">
 									{targetPath
 										? t("createProject.cloneDestinationTarget", { path: targetPath })

--- a/frontend/src/renderer/components/CloneRepositoryDialog.tsx
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.tsx
@@ -5,6 +5,7 @@ import { type FormEvent, useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { aoBridge } from "../lib/bridge";
 import { isMacPlatform, isWindowsPlatform } from "../lib/platform";
+import { PathRow } from "./PathRow";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -166,7 +167,10 @@ export default function CloneRepositoryDialog({
 		setDestinationPickerError(null);
 		setChoosingDestination(true);
 		try {
-			const selected = await aoBridge.app.chooseDirectory(t("createProject.cloneChooseDestination"));
+			const selected = await aoBridge.app.chooseDirectory({
+				title: t("createProject.cloneChooseDestination"),
+				defaultPath: "~/ao/projects",
+			});
 			if (requestId !== destinationPickerRequest.current) return;
 			if (!selected) return;
 			try {
@@ -305,27 +309,18 @@ export default function CloneRepositoryDialog({
 								<Label htmlFor="cloneDestination" className="text-[13px] font-semibold text-[var(--color-text-import-title)]">
 									{t("createProject.cloneDestination")}
 								</Label>
-								<div className="flex items-center overflow-hidden rounded-md bg-[var(--color-bg-import-card)]">
-									<div className="relative min-w-0 flex-1">
-										<Folder className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-text-import-muted)]" aria-hidden="true" />
-										<Input
-											id="cloneDestination"
-											className="border-transparent bg-transparent pl-10 font-mono text-[13px]"
-											aria-describedby={`cloneDestinationHelp${destinationError ? " cloneDestinationError" : ""}`}
-											aria-invalid={Boolean(destinationError)}
-											disabled={disabled || choosingDestination}
-											autoCapitalize="none"
-											autoComplete="off"
-											spellCheck={false}
-											placeholder={t("createProject.cloneDestinationPlaceholder")}
-											value={value.destinationParent}
-											onChange={(event) => onChange({ ...value, destinationParent: event.target.value })}
-										/>
-									</div>
-									<Button type="button" variant="ghost" className="shrink-0 rounded-none border-l border-border/60" disabled={disabled || choosingDestination} onClick={() => void chooseDestination()}>
-										{t("createProject.cloneChoose")}
-									</Button>
-								</div>
+								<PathRow
+									action={t("createProject.cloneChoose")}
+									ariaDescribedBy={`cloneDestinationHelp${destinationError ? " cloneDestinationError" : ""}`}
+									ariaInvalid={Boolean(destinationError)}
+									ariaLabel={t("createProject.cloneChooseDestination")}
+									disabled={disabled || choosingDestination}
+									id="cloneDestination"
+									icon={<Folder className="size-4 shrink-0 text-[var(--color-text-import-muted)]" aria-hidden="true" />}
+									onClick={() => void chooseDestination()}
+								>
+									{value.destinationParent || "~/ao/projects"}
+								</PathRow>
 								<p id="cloneDestinationHelp" className="text-pretty text-[12px] leading-5 text-[var(--color-text-import-muted)]">
 									{targetPath
 										? t("createProject.cloneDestinationTarget", { path: targetPath })

--- a/frontend/src/renderer/components/CloneRepositoryDialog.tsx
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.tsx
@@ -308,7 +308,7 @@ export default function CloneRepositoryDialog({
 								<Label htmlFor="cloneDestination" className="text-[13px] font-semibold text-[var(--color-text-import-title)]">
 									{t("createProject.cloneDestination")}
 								</Label>
-								<div className="flex h-control-form items-center overflow-hidden rounded-md border border-transparent bg-[var(--color-bg-import-card)] text-[13px] text-foreground outline-none focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/50">
+								<div className="flex h-control-form items-center overflow-hidden rounded-md border border-transparent bg-[var(--color-bg-import-card)] text-[13px] text-foreground">
 									<div className="relative min-w-0 flex-1">
 										<Folder className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-text-import-muted)]" aria-hidden="true" />
 										<Input

--- a/frontend/src/renderer/components/CloneRepositoryDialog.tsx
+++ b/frontend/src/renderer/components/CloneRepositoryDialog.tsx
@@ -308,7 +308,7 @@ export default function CloneRepositoryDialog({
 								<Label htmlFor="cloneDestination" className="text-[13px] font-semibold text-[var(--color-text-import-title)]">
 									{t("createProject.cloneDestination")}
 								</Label>
-								<div className="flex items-center overflow-hidden rounded-md bg-[var(--color-bg-import-card)]">
+								<div className="flex h-control-form items-center overflow-hidden rounded-md border border-transparent bg-[var(--color-bg-import-card)] text-[13px] text-foreground outline-none focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/50">
 									<div className="relative min-w-0 flex-1">
 										<Folder className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--color-text-import-muted)]" aria-hidden="true" />
 										<Input
@@ -325,9 +325,15 @@ export default function CloneRepositoryDialog({
 											onChange={(event) => onChange({ ...value, destinationParent: event.target.value })}
 										/>
 									</div>
-									<Button type="button" aria-label={t("createProject.cloneChooseDestination")} variant="ghost" className="shrink-0 rounded-none border-l border-border/60" disabled={disabled || choosingDestination} onClick={() => void chooseDestination()}>
+									<button
+										aria-label={t("createProject.cloneChooseDestination")}
+										className="flex h-full shrink-0 items-center border-l border-border/60 px-4 text-foreground outline-none transition-colors hover:bg-foreground/10 focus-visible:bg-foreground/10 disabled:pointer-events-none disabled:opacity-50"
+										disabled={disabled || choosingDestination}
+										type="button"
+										onClick={() => void chooseDestination()}
+									>
 										{t("createProject.cloneChoose")}
-									</Button>
+									</button>
 								</div>
 								<p id="cloneDestinationHelp" className="text-pretty text-[12px] leading-5 text-[var(--color-text-import-muted)]">
 									{targetPath

--- a/frontend/src/renderer/components/CreateProjectFlow.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.test.tsx
@@ -140,7 +140,7 @@ vi.mock("./CloneRepositoryDialog", () => ({
 		value: { remoteUrl: string; destinationParent: string };
 	}) =>
 		open ? (
-			<div data-testid="clone-dialog">
+			<div data-testid="clone-dialog" data-destination={value.destinationParent}>
 				<input
 					aria-label="Clone URL"
 					value={value.remoteUrl}
@@ -352,6 +352,17 @@ describe("CreateProjectFlow droppedPath", () => {
 
 		expect(screen.getByTestId("agent-sheet")).toHaveAttribute("data-path", "/dropped/first");
 		expect(screen.queryByRole("button", { name: "Import an existing project" })).not.toBeInTheDocument();
+	});
+
+	it.each([null, "/chosen/projects"])("uses a sensible clone destination with saved folder %s", async (saved) => {
+		window.localStorage.removeItem("ao.clone.lastDestinationParent");
+		if (saved) window.localStorage.setItem("ao.clone.lastDestinationParent", saved);
+		const user = userEvent.setup();
+		const { rerender } = render(<CreateProjectFlow mode="choose" {...noop} openSignal={0} />);
+		rerender(<CreateProjectFlow mode="choose" {...noop} openSignal={1} />);
+		await user.click(await screen.findByRole("button", { name: "Clone from Git" }));
+		expect(await screen.findByTestId("clone-dialog")).toHaveAttribute("data-destination", saved ?? "~/Projects");
+		window.localStorage.removeItem("ao.clone.lastDestinationParent");
 	});
 
 	it("ignores a drop while the clone-from-Git dialog is open", async () => {

--- a/frontend/src/renderer/components/CreateProjectFlow.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.test.tsx
@@ -361,7 +361,7 @@ describe("CreateProjectFlow droppedPath", () => {
 		const { rerender } = render(<CreateProjectFlow mode="choose" {...noop} openSignal={0} />);
 		rerender(<CreateProjectFlow mode="choose" {...noop} openSignal={1} />);
 		await user.click(await screen.findByRole("button", { name: "Clone from Git" }));
-		expect(await screen.findByTestId("clone-dialog")).toHaveAttribute("data-destination", saved ?? "~/Projects");
+		expect(await screen.findByTestId("clone-dialog")).toHaveAttribute("data-destination", saved ?? "~/ao/projects");
 		window.localStorage.removeItem("ao.clone.lastDestinationParent");
 	});
 

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -96,7 +96,7 @@ function initialCloneDetails(): CloneRepositoryDetails {
 	return {
 		remoteUrl: "",
 		destinationParent:
-			typeof window === "undefined" ? "~/Projects" : (window.localStorage.getItem(LAST_CLONE_DESTINATION_KEY) || "~/Projects"),
+			typeof window === "undefined" ? "~/ao/projects" : (window.localStorage.getItem(LAST_CLONE_DESTINATION_KEY) || "~/ao/projects"),
 	};
 }
 

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -96,7 +96,7 @@ function initialCloneDetails(): CloneRepositoryDetails {
 	return {
 		remoteUrl: "",
 		destinationParent:
-			typeof window === "undefined" ? "" : (window.localStorage.getItem(LAST_CLONE_DESTINATION_KEY) ?? ""),
+			typeof window === "undefined" ? "~/Projects" : (window.localStorage.getItem(LAST_CLONE_DESTINATION_KEY) || "~/Projects"),
 	};
 }
 

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -945,8 +945,8 @@ describe("Sidebar", () => {
 			await screen.findByRole("textbox", { name: "Repository URL" }),
 			"git@github.com:acme/web-app.git",
 		);
-		await user.click(screen.getByRole("button", { name: "Choose" }));
-		expect(window.ao!.app.chooseDirectory).toHaveBeenCalledWith("Choose where to clone the repository");
+		await user.click(screen.getByRole("button", { name: "Choose where to clone the repository" }));
+		expect(window.ao!.app.chooseDirectory).toHaveBeenCalledWith({ title: "Choose where to clone the repository", defaultPath: "~/ao/projects" });
 		await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
 		await user.click(screen.getByRole("button", { name: "Continue" }));
 
@@ -991,7 +991,7 @@ describe("Sidebar", () => {
 			await screen.findByRole("textbox", { name: "Repository URL" }),
 			"git@github.com:acme/web-app.git",
 		);
-		await user.click(screen.getByRole("button", { name: "Choose" }));
+		await user.click(screen.getByRole("button", { name: "Choose where to clone the repository" }));
 		await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
 		await user.click(await screen.findByRole("button", { name: "Continue" }));
 


### PR DESCRIPTION
## Summary
Clone onboarding lacked a sensible initial destination, and an empty remote initialized by AO could register successfully but fail to spawn its orchestrator because no remote default branch existed yet.

- Default to `~/ao/projects` when no destination is saved; allow direct path editing with a separate native picker button and remember the destination on Continue. Preserve the picker’s default-folder and folder-creation support.
- Enable folder creation in the native picker and create missing destination parents during cloning.
- Use AO's recorded initial branch (including legacy AO initial commits) before the first push when there are no fetched remote branches. Preserve live/cached remote defaults and fail rather than substitute a local branch when fetching a known remote default fails.
- Share initial-branch recording between the project initializer and import Git preparation, including empty clones that skip `git init`. Record identity before committing so retries preserve it.
- Add regression coverage for typed, picker-selected, and saved destinations, missing folders, custom initial-commit messages, non-main branches, and initialization before and after the first push. Exercise real clone → preparation → registration → first-worktree creation.
- Document the broader onboarding contract review in [docs/onboarding-contract-review.md](https://github.com/Untrivial-ai/agent-orchestrator/blob/5ae8c00bd/docs/onboarding-contract-review.md), including remaining branch-policy, readiness, startup-path, and interrupted-preparation inconsistencies.

Reported in the desktop create-project flow for the local `untrivial` project. `AO_TEST` was a saved destination, not a hardcoded default; existing saved choices remain respected.

## Validation
- Full backend `go test ./...` passed after removing inherited `AO_*` session variables from the test environment.
- Backend `go build ./...` passed.
- Focused race tests passed for gitdefault, project service, importer, and gitworktree; vet passed for the original affected packages.
- Full backend suite and lint rerun for the initialization follow-up; the new real clone-to-worktree regression passes for main and trunk.
- golangci-lint v2.12.2 passed; affected packages rechecked after the final resolver change.
- Frontend TypeScript and E2E TypeScript checks passed.
- Full renderer smoke suite passed after restoration: 59 tests, including typed and picker-selected clone/cancel/retry paths. An initial macOS project-menu timeout did not reproduce in the complete isolated rerun.
- Full frontend suite passed after restoration: 287 files, 4,028 tests, 7 skipped. Four timing failures in the initial concurrent run did not reproduce in the complete isolated rerun.
- `git diff --check` passed.

## Verification gaps
Local checks ran on macOS with Node 22, rather than CI's Linux/Node 24 environment. Shared-package contract checks and platform-specific CI jobs have not been validated locally; test and renderer-smoke passed on 5ae8c00bd, along with all other checks except the still-running backend build-test job. The AO preview was opened, but its screenshot request returned SERVICE_UNAVAILABLE; native folder-dialog visual verification remains outstanding. No installed desktop app or user repository was modified by this fix.


