### PR TITLE
Optimistic project import: load board first, provision in background

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -300,16 +300,40 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		p.WorkspaceRepos = workspaceReposFromRecords(row.Path, repos)
 		return p, nil
 	}
-	if !isGitRepo(path) {
+	// The three repository probes are independent git subprocesses; run them
+	// concurrently so registration pays one wave instead of three serial
+	// spawns. Error precedence stays sequential below (not-a-repo wins over
+	// unborn), preserving the existing error contract.
+	var (
+		isRepo    bool
+		hasCommit bool
+		originURL string
+	)
+	var probes sync.WaitGroup
+	probes.Add(3)
+	go func() {
+		defer probes.Done()
+		isRepo = isGitRepo(path)
+	}()
+	go func() {
+		defer probes.Done()
+		hasCommit = repoHasCommit(ctx, path)
+	}()
+	go func() {
+		defer probes.Done()
+		originURL = resolveGitOriginURL(path)
+	}()
+	probes.Wait()
+	if !isRepo {
 		return Project{}, apierr.Invalid("NOT_A_GIT_REPO", "AO needs a Git repository with an initial commit before it can create agent workspaces.", nil)
 	}
-	if !repoHasCommit(ctx, path) {
+	if !hasCommit {
 		return Project{}, apierr.Invalid("PROJECT_UNBORN", "AO needs a Git repository with an initial commit before it can create agent workspaces.", map[string]any{
 			"path":         path,
 			"suggestedFix": "Run `git commit --allow-empty -m \"initial commit\"` in this folder, then try again.",
 		})
 	}
-	row.RepoOriginURL = resolveGitOriginURL(path)
+	row.RepoOriginURL = originURL
 	if err := row.Config.ValidateCanonicalRepository(row.RepoOriginURL); err != nil {
 		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
 	}

--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -191,6 +191,7 @@ beforeEach(() => {
 	useUiStore.setState({
 		orchestratorReplacementErrors: {},
 		orchestratorStartupErrors: {},
+		provisioningProjectIds: new Set(),
 		restartingProjectIds: new Set(),
 		settingsModal: null,
 	});
@@ -396,6 +397,19 @@ describe("project board with no sessions", () => {
 
 		expect(await screen.findByText(/Project added, but orchestrator did not start/)).toBeInTheDocument();
 		expect(screen.getByText(/branch is already checked out/)).toBeInTheDocument();
+	});
+
+	it("shows a provisioning banner and gates actions while the orchestrator starts in the background", async () => {
+		respondWith([project], []);
+		useUiStore.getState().setProjectProvisioning("proj-1", true);
+		renderBoard(<SessionsBoard projectId="proj-1" />);
+
+		expect(await screen.findByRole("status")).toHaveTextContent(/Setting up the project/);
+		for (const button of screen.getAllByRole("button", { name: "Spawn Orchestrator" })) {
+			expect(button).toBeDisabled();
+		}
+		useUiStore.getState().setProjectProvisioning("proj-1", false);
+		await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument());
 	});
 
 	it("clears the project creation startup error when retrying orchestrator spawn", async () => {

--- a/frontend/src/renderer/components/BoardEmptyStates.tsx
+++ b/frontend/src/renderer/components/BoardEmptyStates.tsx
@@ -38,6 +38,7 @@ export function BoardWelcome() {
 export function ProjectBoardEmpty({
 	hasOrchestrator,
 	isProjectRestarting,
+	isProvisioning = false,
 	isSpawning,
 	onNewTask,
 	onOpenOrchestrator,
@@ -46,6 +47,7 @@ export function ProjectBoardEmpty({
 }: {
 	hasOrchestrator: boolean;
 	isProjectRestarting: boolean;
+	isProvisioning?: boolean;
 	isSpawning: boolean;
 	onNewTask: () => void;
 	onOpenOrchestrator: () => void;
@@ -56,9 +58,11 @@ export function ProjectBoardEmpty({
 	const orchestratorLabel = hasOrchestrator ? t("shell.orchestrator") : t("shell.spawnOrchestrator");
 	const busyLabel = isProjectRestarting
 		? t("shell.restartingDots")
-		: isSpawning
-			? t("shell.spawningDots")
-			: orchestratorLabel;
+		: isProvisioning
+			? t("shell.provisioningDots", { defaultValue: "Setting up…" })
+			: isSpawning
+				? t("shell.spawningDots")
+				: orchestratorLabel;
 
 	return (
 		<div className="flex h-full min-h-0 items-center justify-center overflow-y-auto">
@@ -68,14 +72,14 @@ export function ProjectBoardEmpty({
 				<div className="mt-5 flex items-center gap-2">
 					<TopbarButton
 						aria-label={orchestratorLabel}
-						disabled={isSpawning || isProjectRestarting}
+						disabled={isSpawning || isProjectRestarting || isProvisioning}
 						onClick={onOpenOrchestrator}
 						variant="primary"
 					>
 						<OrchestratorIcon className="size-icon-md" aria-hidden="true" />
 						{busyLabel}
 					</TopbarButton>
-					<TopbarButton aria-label={t("shell.newTask")} disabled={isProjectRestarting} onClick={onNewTask} variant="accent">
+					<TopbarButton aria-label={t("shell.newTask")} disabled={isProjectRestarting || isProvisioning} onClick={onNewTask} variant="accent">
 						<Plus className="size-icon-md" aria-hidden="true" />
 						{t("shell.newTask")}
 					</TopbarButton>
@@ -86,7 +90,7 @@ export function ProjectBoardEmpty({
 							{spawnError}
 						</p>
 						{onOpenOrchestratorAsTui ? (
-							<TopbarButton disabled={isSpawning || isProjectRestarting} onClick={onOpenOrchestratorAsTui}>
+							<TopbarButton disabled={isSpawning || isProjectRestarting || isProvisioning} onClick={onOpenOrchestratorAsTui}>
 								{t("newTask.createAsTui")}
 							</TopbarButton>
 						) : null}

--- a/frontend/src/renderer/components/CreateProjectFlow.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.test.tsx
@@ -1083,11 +1083,10 @@ describe("CreateProjectFlow project import validation", () => {
 		await waitFor(() => expect(sheet).toHaveClass("modal-shake"));
 	});
 
-	it.each(["single_repo", "workspace"] as const)("passes the checked-out root branch when importing %s", async (kind) => {
+	it.each(["single_repo", "workspace"] as const)("submits %s imports without a blocking branch lookup", async (kind) => {
 		const user = userEvent.setup();
 		const onCreateProject = vi.fn(async () => undefined);
 		bridgeMocks.chooseDirectory.mockResolvedValue("/repo/project");
-		bridgeMocks.getRepositoryBranch.mockResolvedValue("main");
 		if (kind === "workspace") {
 			bridgeMocks.scanImportFolder.mockResolvedValue({
 				path: "/repo/project",
@@ -1120,12 +1119,13 @@ describe("CreateProjectFlow project import validation", () => {
 			expect(onCreateProject).toHaveBeenCalledWith({
 				path: "/repo/project",
 				asWorkspace: kind === "workspace",
-				defaultBranch: "main",
 				workerAgent: "codex",
 				orchestratorAgent: "codex",
 			}),
 		);
-		expect(bridgeMocks.getRepositoryBranch).toHaveBeenCalledWith("/repo/project");
+		// The daemon resolves the base branch itself; the import must not
+		// block on a branch lookup before submitting.
+		expect(bridgeMocks.getRepositoryBranch).not.toHaveBeenCalled();
 	});
 
 	it("shows queued and running setup progress after continue is clicked", async () => {

--- a/frontend/src/renderer/components/CreateProjectFlow.test.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.test.tsx
@@ -1083,42 +1083,20 @@ describe("CreateProjectFlow project import validation", () => {
 		await waitFor(() => expect(sheet).toHaveClass("modal-shake"));
 	});
 
-	it.each(["single_repo", "workspace"] as const)("submits %s imports without a blocking branch lookup", async (kind) => {
+	it("submits single_repo imports without a blocking branch lookup", async () => {
 		const user = userEvent.setup();
 		const onCreateProject = vi.fn(async () => undefined);
 		bridgeMocks.chooseDirectory.mockResolvedValue("/repo/project");
-		if (kind === "workspace") {
-			bridgeMocks.scanImportFolder.mockResolvedValue({
-				path: "/repo/project",
-				repos: [{ ...okScan("/repo/project/app").repos[0], name: "app", relativePath: "app" }],
-			});
-			apiMocks.POST.mockResolvedValueOnce({
-				data: {
-					...projectValidation("/repo/project", {
-						root: { isRepo: false, hasCommit: false, hasOrigin: false, needsGitInit: true },
-						childRepos: [{
-							repoPath: "/repo/project/app", isRepo: true, hasCommit: true, hasOrigin: true,
-							isEmptyFolder: false, needsGitInit: false, requiredActions: [], blockingErrors: [],
-						}],
-					}),
-					importKind: "workspace",
-				},
-			});
-		} else {
-			apiMocks.POST.mockResolvedValueOnce({ data: projectValidation("/repo/project") });
-		}
+		apiMocks.POST.mockResolvedValueOnce({ data: projectValidation("/repo/project") });
 
 		renderChooseFlow({ onCreateProject });
-		await openSource(user, kind === "workspace" ? "Import a workspace folder" : "Import an existing project");
-		if (kind === "workspace") {
-			await user.click(await screen.findByRole("button", { name: "Continue" }));
-		}
+		await openSource(user, "Import an existing project");
 		await user.click(await screen.findByRole("button", { name: "Submit agents" }));
 
 		await waitFor(() =>
 			expect(onCreateProject).toHaveBeenCalledWith({
 				path: "/repo/project",
-				asWorkspace: kind === "workspace",
+				asWorkspace: false,
 				workerAgent: "codex",
 				orchestratorAgent: "codex",
 			}),
@@ -1126,6 +1104,45 @@ describe("CreateProjectFlow project import validation", () => {
 		// The daemon resolves the base branch itself; the import must not
 		// block on a branch lookup before submitting.
 		expect(bridgeMocks.getRepositoryBranch).not.toHaveBeenCalled();
+	});
+
+	it("preserves the checked-out root branch when importing a workspace", async () => {
+		const user = userEvent.setup();
+		const onCreateProject = vi.fn(async () => undefined);
+		bridgeMocks.chooseDirectory.mockResolvedValue("/repo/project");
+		bridgeMocks.getRepositoryBranch.mockResolvedValue("main");
+		bridgeMocks.scanImportFolder.mockResolvedValue({
+			path: "/repo/project",
+			repos: [{ ...okScan("/repo/project/app").repos[0], name: "app", relativePath: "app" }],
+		});
+		apiMocks.POST.mockResolvedValueOnce({
+			data: {
+				...projectValidation("/repo/project", {
+					root: { isRepo: false, hasCommit: false, hasOrigin: false, needsGitInit: true },
+					childRepos: [{
+						repoPath: "/repo/project/app", isRepo: true, hasCommit: true, hasOrigin: true,
+						isEmptyFolder: false, needsGitInit: false, requiredActions: [], blockingErrors: [],
+					}],
+				}),
+				importKind: "workspace",
+			},
+		});
+
+		renderChooseFlow({ onCreateProject });
+		await openSource(user, "Import a workspace folder");
+		await user.click(await screen.findByRole("button", { name: "Continue" }));
+		await user.click(await screen.findByRole("button", { name: "Submit agents" }));
+
+		await waitFor(() =>
+			expect(onCreateProject).toHaveBeenCalledWith({
+				path: "/repo/project",
+				asWorkspace: true,
+				defaultBranch: "main",
+				workerAgent: "codex",
+				orchestratorAgent: "codex",
+			}),
+		);
+		expect(bridgeMocks.getRepositoryBranch).toHaveBeenCalledWith("/repo/project");
 	});
 
 	it("shows queued and running setup progress after continue is clicked", async () => {

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -41,7 +41,6 @@ import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
 export type CreateProjectInput = {
 	path: string;
 	asWorkspace?: boolean;
-	defaultBranch?: string;
 	clonePreparationId?: string;
 } & CreateProjectAgentSelection;
 export type CloneProjectInput = Pick<CloneRepositorySelection, "remoteUrl" | "destinationParent"> &
@@ -482,15 +481,14 @@ export function CreateProjectFlow({
 				setIsInitializing(false);
 				setIsCreating(true);
 			}
-			// Workspace imports can adopt an existing local Git root too. Preserve
-			// its branch just as for a single repository; child defaults stay separate.
-			const defaultBranch = await aoBridge.app.getRepositoryBranch(selectedPath);
-			await onCreateProject({
-				path: selectedPath,
-				asWorkspace: selectedKind === "workspace",
-				...(defaultBranch ? { defaultBranch } : {}),
-				...selection,
-			});
+		// The daemon resolves the worktree base branch itself at registration
+		// and spawn time, so the import submits without a blocking branch
+		// lookup here — one less IPC round-trip on the critical path.
+		await onCreateProject({
+			path: selectedPath,
+			asWorkspace: selectedKind === "workspace",
+			...selection,
+		});
 			if (showProgress) {
 				setCreateProgress({ open: true, stage: "complete", value: 100 });
 				await new Promise((resolve) => window.setTimeout(resolve, 180));

--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -41,6 +41,7 @@ import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
 export type CreateProjectInput = {
 	path: string;
 	asWorkspace?: boolean;
+	defaultBranch?: string;
 	clonePreparationId?: string;
 } & CreateProjectAgentSelection;
 export type CloneProjectInput = Pick<CloneRepositorySelection, "remoteUrl" | "destinationParent"> &
@@ -481,12 +482,17 @@ export function CreateProjectFlow({
 				setIsInitializing(false);
 				setIsCreating(true);
 			}
-		// The daemon resolves the worktree base branch itself at registration
-		// and spawn time, so the import submits without a blocking branch
-		// lookup here — one less IPC round-trip on the critical path.
+		// Workspace imports can adopt an existing local Git root. Preserve its
+		// checked-out branch as the workspace default (child defaults stay
+		// separate); the daemon resolves it at spawn time. Single-repo imports
+		// skip this lookup entirely — the daemon resolves their base branch
+		// itself, saving a blocking IPC round-trip on the critical path.
+		const defaultBranch =
+			selectedKind === "workspace" ? await aoBridge.app.getRepositoryBranch(selectedPath) : undefined;
 		await onCreateProject({
 			path: selectedPath,
 			asWorkspace: selectedKind === "workspace",
+			...(defaultBranch ? { defaultBranch } : {}),
 			...selection,
 		});
 			if (showProgress) {

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -129,6 +129,9 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const setOrchestratorStartupError = useUiStore((state) => state.setOrchestratorStartupError);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
+	const isProvisioning = useUiStore((state) =>
+		projectId ? state.provisioningProjectIds.has(projectId) : false,
+	);
 	const health = workspace ? orchestratorHealth(workspace, isProjectRestarting) : { state: "ok" as const };
 	const visibleSpawnError = formatOrchestratorStartupError(spawnError ?? orchestratorStartupError ?? "");
 
@@ -189,6 +192,9 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const openOrchestrator = async (mode?: "tui") => {
 		if (!projectId || isProjectRestarting) return;
+		// The shell already has a background spawn in flight for this project;
+		// a second spawn would create a duplicate orchestrator.
+		if (isProvisioning) return;
 		if (orchestrator) {
 			void navigate({
 				to: "/projects/$projectId/sessions/$sessionId",
@@ -265,7 +271,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				</TopbarActionError>
 			)}
 			{visibleSpawnError && canCreateAsTui && !showProjectEmpty ? (
-				<TopbarButton disabled={isSpawning || isProjectRestarting} onClick={() => void openOrchestrator("tui")}>
+				<TopbarButton disabled={isSpawning || isProjectRestarting || isProvisioning} onClick={() => void openOrchestrator("tui")}>
 					{t("newTask.createAsTui")}
 				</TopbarButton>
 			) : null}
@@ -276,7 +282,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							aria-label={t("shell.newTask")}
 							className="topbar-control--labeled"
 							data-priority="primary"
-							disabled={isProjectRestarting}
+							disabled={isProjectRestarting || isProvisioning}
 							onClick={() => projectId && requestNewTask(projectId)}
 							variant="accent"
 						>
@@ -298,7 +304,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							}
 							className="topbar-control--labeled"
 							data-priority="secondary"
-							disabled={isSpawning || isProjectRestarting}
+							disabled={isSpawning || isProjectRestarting || isProvisioning}
 							onClick={() => void openOrchestrator()}
 							variant="primary"
 						>
@@ -378,21 +384,36 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						) : null}
 					</div>
 				) : null}
-				{workspace?.folderMissing ? (
-					<div className="mx-3 my-3 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2 text-xs text-muted-foreground">
-						<AlertTriangle className="size-icon-base shrink-0 text-warning" aria-hidden="true" />
-						<span className="min-w-0 flex-1">{t("home.folderMissing")}</span>
-					</div>
-				) : null}
-				{workspaceStartupState === "error" || workspaceQuery.isError ? (
-					<p className="py-10 text-center text-xs text-passive">{t("shell.couldNotLoadSessions")}</p>
-				) : showWelcome ? (
-					<BoardWelcome />
-				) : showProjectEmpty ? (
-					<ProjectBoardEmpty
-						hasOrchestrator={orchestrator !== undefined}
-						isSpawning={isSpawning}
-						isProjectRestarting={isProjectRestarting}
+			{workspace?.folderMissing ? (
+				<div className="mx-3 my-3 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2 text-xs text-muted-foreground">
+					<AlertTriangle className="size-icon-base shrink-0 text-warning" aria-hidden="true" />
+					<span className="min-w-0 flex-1">{t("home.folderMissing")}</span>
+				</div>
+			) : null}
+			{projectId && isProvisioning ? (
+				<div
+					className="mx-3 my-3 flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2 text-xs text-muted-foreground"
+					role="status"
+				>
+					<span
+						className="size-icon-base shrink-0 animate-spin rounded-full border-2 border-current border-r-transparent"
+						aria-hidden="true"
+					/>
+					<span className="min-w-0 flex-1">
+						{t("shell.provisioning", { defaultValue: "Setting up the project — starting the orchestrator…" })}
+					</span>
+				</div>
+			) : null}
+			{workspaceStartupState === "error" || workspaceQuery.isError ? (
+				<p className="py-10 text-center text-xs text-passive">{t("shell.couldNotLoadSessions")}</p>
+			) : showWelcome ? (
+				<BoardWelcome />
+			) : showProjectEmpty ? (
+				<ProjectBoardEmpty
+					hasOrchestrator={orchestrator !== undefined}
+					isSpawning={isSpawning}
+					isProvisioning={isProvisioning}
+					isProjectRestarting={isProjectRestarting}
 						onNewTask={() => projectId && requestNewTask(projectId)}
 						onOpenOrchestrator={() => void openOrchestrator()}
 						onOpenOrchestratorAsTui={canCreateAsTui ? () => void openOrchestrator("tui") : undefined}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -126,6 +126,9 @@ export function ShellTopbar({
 	const isProjectRestarting = useUiStore((state) =>
 		projectId ? state.restartingProjectIds.has(projectId) : false,
 	);
+	const isProvisioning = useUiStore((state) =>
+		projectId ? state.provisioningProjectIds.has(projectId) : false,
+	);
 	const isProjectBoardRoute = !isSessionRoute && Boolean(projectId);
 	const isRootBoardRoute = !isSessionRoute && !isProjectBoardRoute;
 	const project = workspaceScope?.project;
@@ -143,12 +146,12 @@ export function ShellTopbar({
 		projectId ? void navigate({ to: "/projects/$projectId", params: { projectId } }) : void navigate({ to: "/" });
 
 	const openNewTask = () => {
-		if (!projectId || isProjectRestarting) return;
+		if (!projectId || isProjectRestarting || isProvisioning) return;
 		requestNewTask(projectId);
 	};
 
 	const openOrchestrator = async () => {
-		if (!projectId) return;
+		if (!projectId || isProvisioning) return;
 		setBoardSpawnError(null);
 		void addRendererExceptionStep("Orchestrator open requested", {
 			source: "orchestrator-open",
@@ -273,7 +276,7 @@ export function ShellTopbar({
 										aria-label={t("shell.newTask")}
 										className="topbar-control--labeled"
 										data-priority="primary"
-										disabled={isProjectRestarting}
+										disabled={isProjectRestarting || isProvisioning}
 										onClick={openNewTask}
 										variant="accent"
 									>
@@ -295,7 +298,7 @@ export function ShellTopbar({
 										}
 										className="topbar-control--labeled"
 										data-priority="secondary"
-										disabled={isSpawning || isProjectRestarting}
+										disabled={isSpawning || isProjectRestarting || isProvisioning}
 										onClick={() => void openOrchestrator()}
 										variant="primary"
 									>
@@ -326,7 +329,7 @@ export function ShellTopbar({
 												aria-label={t("shell.newTask")}
 												className="topbar-control--labeled"
 												data-priority="primary"
-												disabled={isProjectRestarting}
+												disabled={isProjectRestarting || isProvisioning}
 												onClick={openNewTask}
 												variant="accent"
 											>
@@ -410,7 +413,7 @@ export function ShellTopbar({
 											aria-label={t("shell.openOrchestrator")}
 											className="topbar-control--labeled -mr-1"
 											data-priority="secondary"
-											disabled={isSpawning || isProjectRestarting}
+											disabled={isSpawning || isProjectRestarting || isProvisioning}
 											onClick={() => void openOrchestrator()}
 											variant="primary"
 										>

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -526,6 +526,23 @@ describe("Sidebar", () => {
 		expect(spawnMock).not.toHaveBeenCalled();
 	});
 
+	it("does not spawn from the sidebar while the orchestrator is provisioning", async () => {
+		const user = userEvent.setup();
+		useUiStore.getState().setProjectProvisioning("proj-1", true);
+		try {
+			renderSidebar();
+
+			const spawnButton = screen.getByRole("button", { name: "Spawn Project One orchestrator" });
+			expect(spawnButton).toBeDisabled();
+			await user.click(spawnButton);
+
+			expect(spawnMock).not.toHaveBeenCalled();
+			expect(navigateMock).not.toHaveBeenCalled();
+		} finally {
+			useUiStore.getState().setProjectProvisioning("proj-1", false);
+		}
+	});
+
 	it("shows a ConfirmDialog and calls onRemoveProject when confirmed", async () => {
 		const user = userEvent.setup();
 		const onRemoveProject = renderSidebar();

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1045,6 +1045,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 		return () => cancelAnimationFrame(id);
 	}, []);
 	const isProjectRestarting = useUiStore((state) => state.restartingProjectIds.has(workspace.id));
+	const isProvisioning = useUiStore((state) => state.provisioningProjectIds.has(workspace.id));
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const projectIsDragging = draggingProjectId === workspace.id;
 	// Keep completed PR sessions reachable while their runtime still exists.
@@ -1406,7 +1407,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 										</TooltipContent>
 									</Tooltip>
 									<DropdownMenuContent side="right" align="start" className="min-w-44">
-										<DropdownMenuItem disabled={isProjectRestarting} onSelect={() => requestNewTask(workspace.id)}>
+										<DropdownMenuItem disabled={isProjectRestarting || isProvisioning} onSelect={() => requestNewTask(workspace.id)}>
 											<Plus aria-hidden="true" />
 											{t("shell.newSession")}
 										</DropdownMenuItem>
@@ -1531,7 +1532,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 				</motion.li>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="min-w-44">
-				<ContextMenuItem disabled={isProjectRestarting} onSelect={() => requestNewTask(workspace.id)}>
+				<ContextMenuItem disabled={isProjectRestarting || isProvisioning} onSelect={() => requestNewTask(workspace.id)}>
 					<Plus aria-hidden="true" />
 					{t("shell.newSession")}
 				</ContextMenuItem>

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1122,7 +1122,7 @@ const ProjectItemContent = memo(function ProjectItemContent({
 	// Expand a collapsed project so opening the orchestrator also reveals its
 	// session list — otherwise the tree stays shut while you're inside it.
 	const openOrchestrator = async () => {
-		if (isProjectRestarting) return;
+		if (isProjectRestarting || isProvisioning) return;
 		if (!expanded) toggleDisclosure();
 		if (orchestrator) {
 			selection.goSession(workspace.id, orchestrator.id);
@@ -1366,8 +1366,8 @@ const ProjectItemContent = memo(function ProjectItemContent({
 																name: workspace.name,
 															})
 												}
-												className={cn(HOVER_ACTION_CLASS, orchestratorActive && "text-foreground")}
-												disabled={isSpawning || isProjectRestarting}
+											className={cn(HOVER_ACTION_CLASS, orchestratorActive && "text-foreground")}
+											disabled={isSpawning || isProjectRestarting || isProvisioning}
 												onClick={() => void openOrchestrator()}
 												type="button"
 											>

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1184,6 +1184,8 @@
 	"shell.projects": "Projekte",
 	"shell.projectActions": "Projektaktionen für {{name}}",
 	"shell.projectSettings": "Projekteinstellungen",
+	"shell.provisioning": "Projekt wird eingerichtet — Orchestrator wird gestartet…",
+	"shell.provisioningDots": "Wird eingerichtet...",
 	"shell.restart": "Neu starten",
 	"shell.remove": "Entfernen",
 	"shell.removeProjectBody": "Dadurch werden live laufende Sitzungen gestoppt und das Projekt aus der Seitenleiste entfernt, der Repository-Ordner und der gespeicherte Verlauf bleiben jedoch auf dem Datenträger.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1307,6 +1307,8 @@
 	"shell.projects": "Projects",
 	"shell.projectActions": "Project actions for {{name}}",
 	"shell.projectSettings": "Project settings",
+	"shell.provisioning": "Setting up the project — starting the orchestrator…",
+	"shell.provisioningDots": "Setting up...",
 	"shell.restart": "Restart",
 	"shell.remove": "Remove",
 	"shell.removeProjectBody": "This stops its live sessions and removes it from the sidebar, but keeps the repository folder and stored history on disk.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1205,6 +1205,8 @@
 	"shell.projects": "Proyectos",
 	"shell.projectActions": "Acciones del proyecto {{name}}",
 	"shell.projectSettings": "Ajustes del proyecto",
+	"shell.provisioning": "Configurando el proyecto: iniciando el orquestador…",
+	"shell.provisioningDots": "Configurando...",
 	"shell.restart": "Reiniciar",
 	"shell.remove": "Eliminar",
 	"shell.removeProjectBody": "Esto detiene sus sesiones activas y lo quita de la barra lateral, pero conserva la carpeta del repositorio y el historial almacenado en disco.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1205,6 +1205,8 @@
 	"shell.projects": "Projets",
 	"shell.projectActions": "Actions du projet {{name}}",
 	"shell.projectSettings": "Paramètres du projet",
+	"shell.provisioning": "Configuration du projet — démarrage de l'orchestrateur…",
+	"shell.provisioningDots": "Configuration...",
 	"shell.restart": "Redémarrer",
 	"shell.remove": "Supprimer",
 	"shell.removeProjectBody": "Cela arrête ses sessions actives et le retire de la barre latérale, mais conserve le dossier du dépôt et l'historique stocké sur le disque.",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1184,6 +1184,8 @@
 	"shell.projects": "プロジェクト",
 	"shell.projectActions": "{{name}} のプロジェクト操作",
 	"shell.projectSettings": "プロジェクト設定",
+	"shell.provisioning": "プロジェクトをセットアップしています — オーケストレーターを起動中…",
+	"shell.provisioningDots": "セットアップ中...",
 	"shell.restart": "再起動",
 	"shell.remove": "削除",
 	"shell.removeProjectBody": "稼働中のセッションを停止し、サイドバーから削除しますが、リポジトリフォルダーと保存済み履歴はディスクに残ります。",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1184,6 +1184,8 @@
 	"shell.projects": "프로젝트",
 	"shell.projectActions": "{{name}} 프로젝트 작업",
 	"shell.projectSettings": "프로젝트 설정",
+	"shell.provisioning": "프로젝트를 설정하는 중 — 오케스트레이터를 시작하고 있습니다…",
+	"shell.provisioningDots": "설정 중...",
 	"shell.restart": "다시 시작",
 	"shell.remove": "제거",
 	"shell.removeProjectBody": "실행 중인 세션을 중지하고 사이드바에서 제거하지만, 저장소 폴더와 저장된 기록은 디스크에 유지됩니다.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1205,6 +1205,8 @@
 	"shell.projects": "Projetos",
 	"shell.projectActions": "Ações do projeto {{name}}",
 	"shell.projectSettings": "Configurações do projeto",
+	"shell.provisioning": "Configurando o projeto — iniciando o orquestrador…",
+	"shell.provisioningDots": "Configurando...",
 	"shell.restart": "Reiniciar",
 	"shell.remove": "Remover",
 	"shell.removeProjectBody": "Isso interrompe as sessões ativas e remove o projeto da barra lateral, mas mantém a pasta do repositório e o histórico armazenado em disco.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1170,6 +1170,8 @@
 	"shell.projects": "项目",
 	"shell.projectActions": "{{name}} 的项目操作",
 	"shell.projectSettings": "项目设置",
+	"shell.provisioning": "正在设置项目 — 正在启动编排器…",
+	"shell.provisioningDots": "设置中...",
 	"shell.restart": "重启",
 	"shell.remove": "移除",
 	"shell.removeProjectBody": "会停止其活跃会话并从侧边栏移除，但保留磁盘上的仓库文件夹与历史记录。",

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
-import { isCancelledError, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { memo, type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FolderPlus } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -96,21 +96,10 @@ export function createProjectConfig(input: CreateProjectConfigInput): components
 	};
 }
 
-async function waitForWorkspaceSession(
-	queryClient: QueryClient,
-	projectId: string,
-	sessionId: string,
-): Promise<boolean> {
-	for (let attempt = 0; attempt < 3; attempt += 1) {
-		const workspaces = await queryClient.fetchQuery({ ...workspaceQueryOptions, staleTime: 0 });
-		const found = workspaces
-			.find((workspace) => workspace.id === projectId)
-			?.sessions.some((session) => session.id === sessionId);
-		if (found) return true;
-		await new Promise((resolve) => window.setTimeout(resolve, 250));
-	}
-	return false;
-}
+// Upper bound for the background orchestrator spawn after project creation.
+// Past this the board releases the provisioning gate and shows the retry
+// banner instead of staying gated forever on a hung spawn.
+const PROVISIONING_TIMEOUT_MS = 120_000;
 
 const isMac = isMacPlatform();
 const isWindows = isWindowsPlatform();
@@ -346,6 +335,7 @@ function ShellLayout() {
 	const orchestratorReplacementErrors = useUiStore((state) => state.orchestratorReplacementErrors);
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
 	const setOrchestratorStartupError = useUiStore((state) => state.setOrchestratorStartupError);
+	const setProjectProvisioning = useUiStore((state) => state.setProjectProvisioning);
 	const showGlobalToast = useUiStore((state) => state.showGlobalToast);
 	const replacementErrorProjectId = Object.keys(orchestratorReplacementErrors)[0] ?? null;
 	const isStartupLoading =
@@ -399,57 +389,77 @@ function ShellLayout() {
 				orchestratorAgent: input.orchestratorAgent as WorkspaceSummary["orchestratorAgent"],
 				sessions: [],
 			};
-			void captureRendererEvent(`ao.renderer.${source}_succeeded`, { project_id: workspace.id });
-			updateWorkspaces((current) => [workspace, ...current.filter((item) => item.id !== workspace.id)]);
-			setOrchestratorStartupError(workspace.id, null);
-			try {
-				void captureRendererEvent("ao.renderer.orchestrator_spawn_requested", {
-					project_id: workspace.id,
-					source,
-				});
-				const {
-					data: spawnData,
-					error: spawnError,
-					response: spawnResponse,
-				} = await apiClient.POST("/api/v1/sessions", {
-					body: {
-						projectId: workspace.id,
-						kind: "orchestrator",
-						harness: input.orchestratorAgent as components["schemas"]["SpawnSessionRequest"]["harness"],
-					},
-				});
-				if (spawnError || !spawnData?.session?.id) {
-					const message = spawnError
-						? apiErrorMessage(spawnError, `Failed to spawn orchestrator (${spawnResponse.status})`)
-						: `Failed to spawn orchestrator (${spawnResponse.status})`;
-					throw new Error(message);
-				}
-					void captureRendererEvent("ao.renderer.orchestrator_spawn_succeeded", {
-						project_id: workspace.id,
-						source,
-					});
-					const sessionId = spawnData.session.id;
-					const sessionVisible = await waitForWorkspaceSession(queryClient, workspace.id, sessionId);
-					if (!sessionVisible) {
-						await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-					}
-					void navigate({
-						to: "/projects/$projectId/sessions/$sessionId",
-						params: { projectId: workspace.id, sessionId },
-				});
-			} catch (spawnError) {
-				void captureRendererEvent("ao.renderer.orchestrator_spawn_failed", {
-					project_id: workspace.id,
-					source,
-				});
-				void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
-				const message = spawnError instanceof Error ? spawnError.message : "Could not start orchestrator";
-				const startupMessage = `Project added, but orchestrator did not start: ${message}`;
-				setOrchestratorStartupError(workspace.id, startupMessage);
+		void captureRendererEvent(`ao.renderer.${source}_succeeded`, { project_id: workspace.id });
+		updateWorkspaces((current) => [workspace, ...current.filter((item) => item.id !== workspace.id)]);
+		setOrchestratorStartupError(workspace.id, null);
+		setProjectProvisioning(workspace.id, true);
+		// Navigate to the project board immediately so the IDE paints while
+		// the orchestrator spawn (git fetch + worktree + runtime) finishes in
+		// the background. Session actions stay gated until it settles.
+		void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
+		// Safety: a hung spawn must never wedge the board behind the
+		// provisioning gate. If it outlives this budget, release the gate and
+		// surface the retry banner; a late success still navigates below and
+		// the board clears the banner once the orchestrator appears.
+		const provisioningGuard = window.setTimeout(() => {
+			setProjectProvisioning(workspace.id, false);
+			setOrchestratorStartupError(
+				workspace.id,
+				"Project added, but the orchestrator is taking longer than expected to start. Retry from the board if it does not appear.",
+			);
+		}, PROVISIONING_TIMEOUT_MS);
+		try {
+			void captureRendererEvent("ao.renderer.orchestrator_spawn_requested", {
+				project_id: workspace.id,
+				source,
+			});
+			const {
+				data: spawnData,
+				error: spawnError,
+				response: spawnResponse,
+			} = await apiClient.POST("/api/v1/sessions", {
+				body: {
+					projectId: workspace.id,
+					kind: "orchestrator",
+					harness: input.orchestratorAgent as components["schemas"]["SpawnSessionRequest"]["harness"],
+				},
+			});
+			if (spawnError || !spawnData?.session?.id) {
+				const message = spawnError
+					? apiErrorMessage(spawnError, `Failed to spawn orchestrator (${spawnResponse.status})`)
+					: `Failed to spawn orchestrator (${spawnResponse.status})`;
+				throw new Error(message);
 			}
-		},
-		[navigate, queryClient, setOrchestratorStartupError, updateWorkspaces],
-	);
+			void captureRendererEvent("ao.renderer.orchestrator_spawn_succeeded", {
+				project_id: workspace.id,
+				source,
+			});
+			const sessionId = spawnData.session.id;
+			window.clearTimeout(provisioningGuard);
+			setProjectProvisioning(workspace.id, false);
+			// Wait for the refetch so the session route never renders before
+			// the new session is in the workspace query (which would flash
+			// the session-not-found state). The daemon just created it, so
+			// one invalidate is enough — no polling loop.
+			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			void navigate({
+				to: "/projects/$projectId/sessions/$sessionId",
+				params: { projectId: workspace.id, sessionId },
+			});
+		} catch (spawnError) {
+			window.clearTimeout(provisioningGuard);
+			setProjectProvisioning(workspace.id, false);
+			void captureRendererEvent("ao.renderer.orchestrator_spawn_failed", {
+				project_id: workspace.id,
+				source,
+			});
+			const message = spawnError instanceof Error ? spawnError.message : "Could not start orchestrator";
+			const startupMessage = `Project added, but orchestrator did not start: ${message}`;
+			setOrchestratorStartupError(workspace.id, startupMessage);
+		}
+	},
+	[navigate, queryClient, setOrchestratorStartupError, setProjectProvisioning, updateWorkspaces],
+);
 
 	const createProject = useCallback(
 		async (input: {

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -373,30 +373,15 @@ function ShellLayout() {
 		[queryClient],
 	);
 
-	const completeProjectCreation = useCallback(
+	// Background orchestrator provisioning for a newly created project. Owns
+	// the provisioning flag, the hung-spawn timeout, the session refresh, and
+	// the retry error end to end — callers must fire and forget it, never await.
+	const provisionOrchestrator = useCallback(
 		async (
-			project: components["schemas"]["Project"],
+			workspace: WorkspaceSummary,
 			input: CreateProjectConfigInput,
 			source: "project_add" | "project_clone",
 		) => {
-			const workspace: WorkspaceSummary = {
-				id: project.id,
-				name: project.name,
-				kind: toProjectKind(project.kind),
-				path: project.path,
-				workspaceRepos: project.workspaceRepos,
-				type: "main",
-				orchestratorAgent: input.orchestratorAgent as WorkspaceSummary["orchestratorAgent"],
-				sessions: [],
-			};
-		void captureRendererEvent(`ao.renderer.${source}_succeeded`, { project_id: workspace.id });
-		updateWorkspaces((current) => [workspace, ...current.filter((item) => item.id !== workspace.id)]);
-		setOrchestratorStartupError(workspace.id, null);
-		setProjectProvisioning(workspace.id, true);
-		// Navigate to the project board immediately so the IDE paints while
-		// the orchestrator spawn (git fetch + worktree + runtime) finishes in
-		// the background. Session actions stay gated until it settles.
-		void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
 		// Safety: a hung spawn must never wedge the board behind the
 		// provisioning gate. If it outlives this budget, release the gate and
 		// surface the retry banner; a late success still navigates below and
@@ -458,8 +443,38 @@ function ShellLayout() {
 			setOrchestratorStartupError(workspace.id, startupMessage);
 		}
 	},
-	[navigate, queryClient, setOrchestratorStartupError, setProjectProvisioning, updateWorkspaces],
+	[navigate, queryClient, setOrchestratorStartupError, setProjectProvisioning],
 );
+
+	const completeProjectCreation = useCallback(
+		async (
+			project: components["schemas"]["Project"],
+			input: CreateProjectConfigInput,
+			source: "project_add" | "project_clone",
+		) => {
+			const workspace: WorkspaceSummary = {
+				id: project.id,
+				name: project.name,
+				kind: toProjectKind(project.kind),
+				path: project.path,
+				workspaceRepos: project.workspaceRepos,
+				type: "main",
+				orchestratorAgent: input.orchestratorAgent as WorkspaceSummary["orchestratorAgent"],
+				sessions: [],
+			};
+			void captureRendererEvent(`ao.renderer.${source}_succeeded`, { project_id: workspace.id });
+			updateWorkspaces((current) => [workspace, ...current.filter((item) => item.id !== workspace.id)]);
+			setOrchestratorStartupError(workspace.id, null);
+			setProjectProvisioning(workspace.id, true);
+			// Navigate to the project board immediately so the IDE paints, then
+			// hand off to the detached provisioning flow. Resolving here (rather
+			// than after the spawn) is what closes the setup modal and makes
+			// the board usable while the orchestrator starts in the background.
+			void navigate({ to: "/projects/$projectId", params: { projectId: workspace.id } });
+			void provisionOrchestrator(workspace, input, source);
+		},
+		[navigate, provisionOrchestrator, setOrchestratorStartupError, setProjectProvisioning, updateWorkspaces],
+	);
 
 	const createProject = useCallback(
 		async (input: {

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -80,6 +80,10 @@ export type UiState = {
 	/** When true, developer-only release controls are available. Default off. */
 	developerMode: boolean;
 	restartingProjectIds: ReadonlySet<string>;
+	// Projects whose initial orchestrator spawn (after import/clone) is still
+	// running in the background. The board renders a progress banner and gates
+	// session actions until the spawn settles, instead of blocking navigation.
+	provisioningProjectIds: ReadonlySet<string>;
 	orchestratorReplacementErrors: Record<string, OrchestratorReplacementFailure>;
 	orchestratorStartupErrors: Record<string, string>;
 	globalToasts: GlobalToast[];
@@ -145,6 +149,7 @@ export type UiState = {
 	setFilesChangedOnly: (sessionId: string, changedOnly: boolean) => void;
 	setCommandPaletteOpen: (open: boolean) => void;
 	setProjectRestarting: (projectId: string, restarting: boolean) => void;
+	setProjectProvisioning: (projectId: string, provisioning: boolean) => void;
 	setOrchestratorReplacementError: (projectId: string, failure: OrchestratorReplacementFailure | null) => void;
 	setOrchestratorStartupError: (projectId: string, message: string | null) => void;
 	showGlobalToast: (title: string, body?: string, style?: GlobalToast["tone"] | GlobalToast["placement"]) => void;
@@ -207,6 +212,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	themeStyle: initialThemeStyle,
 	developerMode: initialDeveloperMode(),
 	restartingProjectIds: new Set<string>(),
+	provisioningProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
 	orchestratorStartupErrors: {},
 	globalToasts: [],
@@ -361,6 +367,16 @@ export const useUiStore = create<UiState>((set, get) => ({
 			}
 			return { restartingProjectIds };
 		}),
+	setProjectProvisioning: (projectId, provisioning) =>
+		set((state) => {
+			const provisioningProjectIds = new Set(state.provisioningProjectIds);
+			if (provisioning) {
+				provisioningProjectIds.add(projectId);
+			} else {
+				provisioningProjectIds.delete(projectId);
+			}
+			return { provisioningProjectIds };
+		}),
 	setOrchestratorReplacementError: (projectId, failure) =>
 		set((state) => {
 			const orchestratorReplacementErrors = { ...state.orchestratorReplacementErrors };
@@ -395,8 +411,20 @@ export const useUiStore = create<UiState>((set, get) => ({
 			globalToast: state.globalToast?.nonce === nonce ? null : state.globalToast,
 		})),
 	clearGlobalToast: () => set({ globalToast: null, globalToasts: [], globalToastSequence: 0 }),
-	requestNewTask: (projectId) =>
-		set((state) => ({ newTaskRequest: { projectId, nonce: (state.newTaskRequest?.nonce ?? 0) + 1 } })),
+	requestNewTask: (projectId) => {
+		// Central gate: every New Task entry point (buttons, sidebar menus,
+		// shortcuts) funnels through here, so a project whose orchestrator is
+		// still provisioning cannot start tasks before it exists.
+		if (get().provisioningProjectIds.has(projectId)) {
+			get().showGlobalToast(
+				"Project is still being set up",
+				"The orchestrator is starting. Try again in a moment.",
+				"info",
+			);
+			return;
+		}
+		set((state) => ({ newTaskRequest: { projectId, nonce: (state.newTaskRequest?.nonce ?? 0) + 1 } }));
+	},
 	requestCreateProject: () => set((state) => ({ createProjectNonce: state.createProjectNonce + 1 })),
 	requestCreateProjectFromPath: (path) =>
 		set((state) => ({ folderDropRequest: { path, nonce: (state.folderDropRequest?.nonce ?? 0) + 1 } })),


### PR DESCRIPTION
## Summary

Importing an existing project no longer blocks on the full setup chain. The board navigates immediately after registration while the orchestrator spawn (git fetch + worktree + runtime) finishes in the background behind a provisioning gate with progress banner, 120s timeout escape, and retry. The pre-submit branch lookup IPC is removed and registration git probes run concurrently.

## Why

Importing an existing project showed 3-4s of blocking latency after agent selection: serial branch lookup, serial registration probes, blocking orchestrator spawn, and a 3x250ms session poll loop. Total work is unchanged; it is moved off the critical path so time-to-board drops to well under a second.

## Tests

- [x] `cd backend && go build ./...`
- [x] `go test -race ./internal/service/project/ ./internal/httpd/controllers/`
- [x] `npm run frontend:typecheck`
- [x] vitest: CreateProjectFlow, Sidebar, SessionsBoard, board-empty-states, shell-new-session-shortcut, ShellTopbar, i18n parity
- [x] live daemon timing run: POST /projects before/after on a 248MB repo

## Files impacted

- `frontend/src/renderer/routes/_shell.tsx` — optimistic navigate, background spawn, 120s guard
- `frontend/src/renderer/stores/ui-store.ts` — provisioningProjectIds, gated requestNewTask
- `frontend/src/renderer/components/SessionsBoard.tsx`, `BoardEmptyStates.tsx`, `ShellTopbar.tsx`, `Sidebar.tsx` — banner + gating
- `frontend/src/renderer/components/CreateProjectFlow.tsx` — no blocking branch lookup
- `backend/internal/service/project/service.go` — concurrent registration probes
- `frontend/src/renderer/i18n/*.json` — shell.provisioning keys (8 locales)
- `frontend/src/renderer/components/CreateProjectFlow.test.tsx`, `__tests__/integration/board-empty-states.test.tsx` — coverage

## Measured numbers

Live daemon (`ao daemon`, isolated data dir) against a 248MB / 3408-file clone, 3 runs each:

| Stage | Before | After |
|---|---|---|
| POST /projects | ~28-32ms | ~17-21ms |
| getRepositoryBranch IPC (2 git procs) | ~10ms | removed |
| git worktree add | 1.1s blocking | 1.1s backgrounded |
| git fetch (up-to-date) | 33ms | 33ms backgrounded |
| session poll loop | up to 750ms | single awaited refetch |

Note: per-spawn git costs are ~5ms on fast SSDs and 50-200ms on typical macOS/Windows machines, so slow-hardware savings scale proportionally. Full spawn could not run to completion in the sandbox (no agent binary/tmux); it correctly rejects pre-workspace with AGENT_BINARY_NOT_FOUND.