### PR TITLE
fix(session-manager): don't inherit role model on harness mismatch

### DIFF
--- a/backend/internal/session_manager/agent_switching.go
+++ b/backend/internal/session_manager/agent_switching.go
@@ -1354,11 +1354,7 @@ func (m *Manager) prepareTargetActivation(ctx context.Context, store ports.Agent
 	if err != nil {
 		return preparedTargetActivation{}, fmt.Errorf("system prompt file: %w", err)
 	}
-	config := effectiveAgentConfig(rec.Kind, project.Config)
-	if roleOverride(rec.Kind, project.Config).Harness != harness {
-		config.Model = ""
-		config.Mode = ""
-	}
+	config := effectiveAgentConfig(harness, rec.Kind, project.Config)
 	if model := strings.TrimSpace(modelOverride); model != "" {
 		config.Model = model
 	}

--- a/backend/internal/session_manager/agent_switching_chat.go
+++ b/backend/internal/session_manager/agent_switching_chat.go
@@ -163,7 +163,7 @@ func (m *Manager) executeChatAgentSwitch(
 	if err := m.chat.PreflightChat(
 		ctx,
 		cfg.TargetHarness,
-		effectiveAgentConfig(rec.Kind, project.Config).Permissions,
+		effectiveAgentConfig(cfg.TargetHarness, rec.Kind, project.Config).Permissions,
 	); err != nil {
 		return result, fmt.Errorf("switch Chat agent %s: target preflight: %w", id, err)
 	}
@@ -177,11 +177,7 @@ func (m *Manager) executeChatAgentSwitch(
 		return result, fmt.Errorf("switch Chat agent %s: system prompt: %w", id, err)
 	}
 	systemPrompt = appendAgentContinuationProtocol(systemPrompt)
-	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
-	if roleOverride(rec.Kind, project.Config).Harness != cfg.TargetHarness {
-		agentConfig.Model = ""
-		agentConfig.Mode = ""
-	}
+	agentConfig := effectiveAgentConfig(cfg.TargetHarness, rec.Kind, project.Config)
 	if model := strings.TrimSpace(cfg.Model); model != "" {
 		agentConfig.Model = model
 	}
@@ -616,7 +612,7 @@ func (m *Manager) rollbackStoppedChatAgentSwitchSource(
 	if err != nil {
 		return err
 	}
-	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
+	agentConfig := effectiveAgentConfig(rec.Harness, rec.Kind, project.Config)
 	env := m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env)
 	m.augmentAgentRuntimeEnv(sourceAgent, env)
 	if err := m.prepareWorkspace(

--- a/backend/internal/session_manager/chat_spawn.go
+++ b/backend/internal/session_manager/chat_spawn.go
@@ -163,7 +163,7 @@ func (m *Manager) launchChatController(ctx context.Context, in chatSpawn) (domai
 	}
 	defer releaseCodexAdmission()
 	agentConfig := applySpawnAgentConfig(
-		effectiveAgentConfig(in.cfg.Kind, in.project.Config),
+		effectiveAgentConfig(in.cfg.Harness, in.cfg.Kind, in.project.Config),
 		in.cfg.AgentConfig,
 	)
 

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -677,7 +677,7 @@ func (m *Manager) preflightInterfaceTarget(
 		if err != nil {
 			return err
 		}
-		permissions := effectiveAgentConfig(rec.Kind, project.Config).Permissions
+		permissions := effectiveAgentConfig(rec.Harness, rec.Kind, project.Config).Permissions
 		return m.chat.PreflightChat(ctx, rec.Harness, permissions)
 	}
 	agent, ok := m.agents.Agent(rec.Harness)
@@ -692,7 +692,7 @@ func (m *Manager) preflightInterfaceTarget(
 	if err != nil {
 		return err
 	}
-	config := effectiveAgentConfig(rec.Kind, project.Config)
+	config := effectiveAgentConfig(rec.Harness, rec.Kind, project.Config)
 	var cmd []string
 	if transition.NativeConversationID == "" {
 		cmd, _, _, err = freshLaunchArgv(ctx, agent, rec.ID, rec.Metadata.WorkspacePath,

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1526,11 +1526,30 @@ func validateSpawnModel(harness domain.AgentHarness, model string) error {
 	return fmt.Errorf("model %q is not supported by harness %q", model, harness)
 }
 
+// roleOverride returns the role-specific override for kind, with an unpinned
+// override's Model/Mode dropped.
+//
+// A role Model/Mode is authored against a specific harness — a provider alias
+// like "custom/gpt-5.5" is meaningful only to the agent it was configured for.
+// An override that pins no Harness cannot claim one, and effectiveAgentConfig
+// treats an empty role harness as matching any launch harness, so leaving the
+// values in place would apply them to whatever agent happens to launch.
+//
+// The settings form already enforces this: the role agent is required, and
+// changing it clears the role's model and mode. ProjectConfig.Validate does
+// not, so a config written through the API, edited by hand, or saved before
+// the agent became required can still carry this shape. Normalizing on read
+// repairs those without failing to load them.
 func roleOverride(kind domain.SessionKind, cfg domain.ProjectConfig) domain.RoleOverride {
+	role := cfg.Worker
 	if kind == domain.KindOrchestrator {
-		return cfg.Orchestrator
+		role = cfg.Orchestrator
 	}
-	return cfg.Worker
+	if role.Harness == "" {
+		role.AgentConfig.Model = ""
+		role.AgentConfig.Mode = ""
+	}
+	return role
 }
 
 // sessionPrefix returns the display prefix for a project: the explicit

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -858,7 +858,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// Resolve the effective agent config (project base + role override + spawn
 	// override) and validate the model before any durable state is created. A
 	// model the harness cannot honor should not leave a seed row behind.
-	agentConfig := applySpawnAgentConfig(effectiveAgentConfig(cfg.Kind, project.Config), cfg.AgentConfig)
+	agentConfig := applySpawnAgentConfig(effectiveAgentConfig(cfg.Harness, cfg.Kind, project.Config), cfg.AgentConfig)
 	if err := validateSpawnModel(cfg.Harness, agentConfig.Model); err != nil {
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: %w: %s", ErrUnsupportedModel, err.Error())
 	}
@@ -1418,13 +1418,21 @@ func roleConfigName(kind domain.SessionKind) string {
 
 // effectiveAgentConfig merges the role override's agent config over the
 // project's base agent config; set override fields win.
-func effectiveAgentConfig(kind domain.SessionKind, cfg domain.ProjectConfig) ports.AgentConfig {
+//
+// Model/Mode are inherited only when the launch harness matches the role's
+// configured harness — otherwise they were tuned for a different agent and
+// would leak a provider-specific alias onto the wrong harness. An empty role
+// harness means "not pinned" and always matches. Permissions is
+// harness-neutral and is always inherited.
+func effectiveAgentConfig(harness domain.AgentHarness, kind domain.SessionKind, cfg domain.ProjectConfig) ports.AgentConfig {
 	merged := cfg.AgentConfig
-	override := roleOverride(kind, cfg).AgentConfig
-	if override.Model != "" {
+	role := roleOverride(kind, cfg)
+	override := role.AgentConfig
+	harnessMatches := role.Harness == "" || role.Harness == harness
+	if harnessMatches && override.Model != "" {
 		merged.Model = override.Model
 	}
-	if override.Mode != "" {
+	if harnessMatches && override.Mode != "" {
 		merged.Mode = override.Mode
 	}
 	if override.Permissions != "" {
@@ -1436,7 +1444,7 @@ func effectiveAgentConfig(kind domain.SessionKind, cfg domain.ProjectConfig) por
 // restoredAgentConfig resolves project settings while preserving a Claude
 // session's recorded model selection.
 func restoredAgentConfig(rec domain.SessionRecord, cfg domain.ProjectConfig) ports.AgentConfig {
-	merged := effectiveAgentConfig(rec.Kind, cfg)
+	merged := effectiveAgentConfig(rec.Harness, rec.Kind, cfg)
 	if rec.Harness == domain.HarnessClaudeCode {
 		// A blank snapshot means either agent default or an older session whose
 		// selection was not recorded. Leave it unset so native resume can keep
@@ -3819,7 +3827,7 @@ func seedRecord(cfg ports.SpawnConfig, projectConfig domain.ProjectConfig, now t
 		// Resolved before this point and persisted here. There is no UPDATE
 		// statement that can change it afterwards.
 		Mode:              domain.NormalizeSessionMode(cfg.RequestedMode),
-		Metadata:          domain.SessionMetadata{Permissions: applySpawnAgentConfig(effectiveAgentConfig(cfg.Kind, projectConfig), cfg.AgentConfig).Permissions},
+		Metadata:          domain.SessionMetadata{Permissions: applySpawnAgentConfig(effectiveAgentConfig(cfg.Harness, cfg.Kind, projectConfig), cfg.AgentConfig).Permissions},
 		AutoReviewEnabled: projectConfig.AutoReview,
 		AutoInjectReview:  true,
 		AutoInjectCI:      true,

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1577,6 +1577,60 @@ func TestSpawnModelPersisted(t *testing.T) {
 	}
 }
 
+// A spawn that names a harness other than the role override's must not inherit
+// that role's model: it was tuned for the other agent and would reach the
+// selected harness as an unknown provider alias. The harness picks its own
+// default instead, while harness-neutral permissions still carry over.
+// Both roles resolve through the same override, so both leak the same way; the
+// orchestrator case is asserted explicitly rather than left implied.
+func TestSpawn_DropsRoleModelOnHarnessMismatch(t *testing.T) {
+	roleConfig := domain.RoleOverride{
+		Harness:     domain.HarnessOpenCode,
+		AgentConfig: domain.AgentConfig{Model: "custom/gpt-5.5", Permissions: domain.PermissionModeAuto},
+	}
+	for _, tc := range []struct {
+		name string
+		kind domain.SessionKind
+		cfg  domain.ProjectConfig
+	}{
+		{"worker", domain.KindWorker, domain.ProjectConfig{Worker: roleConfig}},
+		{"orchestrator", domain.KindOrchestrator, domain.ProjectConfig{Orchestrator: roleConfig}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeStore()
+			st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: tc.cfg}
+			agent := &recordingAgent{}
+			m := New(Deps{
+				Runtime: &fakeRuntime{}, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{},
+				Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+				LookPath: func(string) (string, error) { return "/bin/true", nil },
+			})
+
+			rec, _, _, err := m.Spawn(ctx, ports.SpawnConfig{
+				ProjectID: "mer", Kind: tc.kind, Harness: domain.HarnessCodex,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if agent.lastConfig.Model != "" {
+				t.Fatalf("launch model = %q, want empty so codex uses its own default", agent.lastConfig.Model)
+			}
+			if agent.lastConfig.Permissions != domain.PermissionModeAuto {
+				t.Fatalf("launch permissions = %q, want auto (harness-neutral)", agent.lastConfig.Permissions)
+			}
+			// The mismatched model must not survive into the record the API
+			// and UI read back either.
+			stored, ok, err := st.GetSession(ctx, rec.ID)
+			if err != nil || !ok {
+				t.Fatalf("get session: err=%v ok=%v", err, ok)
+			}
+			if stored.Metadata.Model != "" {
+				t.Fatalf("persisted metadata model = %q, want empty", stored.Metadata.Model)
+			}
+		})
+	}
+}
+
 func TestSpawnRecordsDiffBaseForSingleRepoSessions(t *testing.T) {
 	m, st, _, ws := newManager()
 	repo := newManagerGitRepo(t)

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -231,20 +231,31 @@ func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 	if got := effectiveAgentConfig(domain.HarnessAider, domain.KindWorker, cfg); got.Model != "base" || got.Mode != "low" || got.Permissions != domain.PermissionModeAuto {
 		t.Fatalf("mismatched-harness worker config = %#v, want model=base mode=low permissions=auto", got)
 	}
-	// A role override with no harness pinned is deliberately treated as
-	// "applies to any harness", so its model/mode are inherited whichever
-	// harness the session launches with. This is a behavior decision, not a
-	// side effect: assert it across two unrelated harnesses so it cannot
-	// silently flip back to the old drop-on-every-switch behavior.
+	// A role override that pins no harness cannot claim one, so its model/mode
+	// are dropped rather than applied to whatever agent happens to launch: the
+	// values were authored against some specific harness and nothing records
+	// which. Permissions is harness-neutral and survives. Assert it across two
+	// unrelated harnesses so the leak cannot silently come back.
 	unpinned := domain.ProjectConfig{
 		AgentConfig: domain.AgentConfig{Model: "base", Mode: "low"},
-		Worker:      domain.RoleOverride{AgentConfig: domain.AgentConfig{Model: "worker", Mode: "high"}},
+		Worker: domain.RoleOverride{AgentConfig: domain.AgentConfig{
+			Model: "custom/gpt-5.5", Mode: "high", Permissions: domain.PermissionModeAuto,
+		}},
 	}
 	for _, harness := range []domain.AgentHarness{domain.HarnessAider, domain.HarnessCodex} {
 		got := effectiveAgentConfig(harness, domain.KindWorker, unpinned)
-		if got.Model != "worker" || got.Mode != "high" {
-			t.Fatalf("unpinned worker config for %q = %#v, want model=worker mode=high", harness, got)
+		if got.Model != "base" || got.Mode != "low" {
+			t.Fatalf("unpinned worker config for %q = %#v, want model=base mode=low", harness, got)
 		}
+		if got.Permissions != domain.PermissionModeAuto {
+			t.Fatalf("unpinned worker permissions for %q = %q, want auto", harness, got.Permissions)
+		}
+	}
+
+	// effectiveHarness reads only the pinned harness, so an unpinned override
+	// still resolves to "no harness" and leaves the caller's choice intact.
+	if h := effectiveHarness("", domain.KindWorker, unpinned); h != "" {
+		t.Fatalf("unpinned worker harness = %q, want empty", h)
 	}
 }
 

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -217,13 +217,34 @@ func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 	}
 
 	// Role override merges over the base agent config (set fields win; unset keep base).
-	got := effectiveAgentConfig(domain.KindWorker, cfg)
+	got := effectiveAgentConfig(domain.HarnessCodex, domain.KindWorker, cfg)
 	if got.Model != "worker" || got.Mode != "high" || got.Permissions != domain.PermissionModeAuto {
 		t.Fatalf("merged worker config = %#v, want model=worker mode=high permissions=auto", got)
 	}
 	// Orchestrator has no agent-config override, so the base config is used as-is.
-	if got := effectiveAgentConfig(domain.KindOrchestrator, cfg); got.Model != "base" {
+	if got := effectiveAgentConfig(domain.HarnessClaudeCode, domain.KindOrchestrator, cfg); got.Model != "base" {
 		t.Fatalf("orchestrator config = %#v, want base", got)
+	}
+	// A launch harness that differs from the role's configured harness drops the
+	// role's model/mode — they were tuned for the other agent — but keeps the
+	// harness-neutral permissions.
+	if got := effectiveAgentConfig(domain.HarnessAider, domain.KindWorker, cfg); got.Model != "base" || got.Mode != "low" || got.Permissions != domain.PermissionModeAuto {
+		t.Fatalf("mismatched-harness worker config = %#v, want model=base mode=low permissions=auto", got)
+	}
+	// A role override with no harness pinned is deliberately treated as
+	// "applies to any harness", so its model/mode are inherited whichever
+	// harness the session launches with. This is a behavior decision, not a
+	// side effect: assert it across two unrelated harnesses so it cannot
+	// silently flip back to the old drop-on-every-switch behavior.
+	unpinned := domain.ProjectConfig{
+		AgentConfig: domain.AgentConfig{Model: "base", Mode: "low"},
+		Worker:      domain.RoleOverride{AgentConfig: domain.AgentConfig{Model: "worker", Mode: "high"}},
+	}
+	for _, harness := range []domain.AgentHarness{domain.HarnessAider, domain.HarnessCodex} {
+		got := effectiveAgentConfig(harness, domain.KindWorker, unpinned)
+		if got.Model != "worker" || got.Mode != "high" {
+			t.Fatalf("unpinned worker config for %q = %#v, want model=worker mode=high", harness, got)
+		}
 	}
 }
 
@@ -290,14 +311,14 @@ func TestSpawnPermissionPrecedence(t *testing.T) {
 		} {
 			t.Run(string(kind)+"/"+tc.name, func(t *testing.T) {
 				cfg := domain.ProjectConfig{AgentConfig: domain.AgentConfig{Permissions: tc.base}, Worker: domain.RoleOverride{AgentConfig: domain.AgentConfig{Permissions: tc.role}}, Orchestrator: domain.RoleOverride{AgentConfig: domain.AgentConfig{Permissions: tc.role}}}
-				got := applySpawnAgentConfig(effectiveAgentConfig(kind, cfg), domain.AgentConfig{Permissions: tc.spawn})
+				got := applySpawnAgentConfig(effectiveAgentConfig(domain.HarnessCodex, kind, cfg), domain.AgentConfig{Permissions: tc.spawn})
 				if got.Permissions != tc.want {
 					t.Fatalf("got %q want %q", got.Permissions, tc.want)
 				}
 			})
 		}
 	}
-	if got := effectiveAgentConfig(domain.KindWorker, domain.ProjectConfig{}); got.Permissions != "" {
+	if got := effectiveAgentConfig(domain.HarnessCodex, domain.KindWorker, domain.ProjectConfig{}); got.Permissions != "" {
 		t.Fatalf("non-spawn resolution changed: %q", got.Permissions)
 	}
 }


### PR DESCRIPTION
Closes #4873.

## Summary

A spawn that selects a harness other than the project's configured `Worker.Harness`/`Orchestrator.Harness` still inherited that role override's `Model`/`Mode`, leaking a provider-specific model alias onto the wrong agent.

The agent-switch paths already guarded against this with a post-hoc `config.Model = ""` block. This moves the rule into `effectiveAgentConfig` itself so every caller — spawn, restore, chat spawn/restore, interface transition, and both switch paths — shares one definition:

- `Model`/`Mode` are inherited only when the launch harness matches the role's pinned harness (an unset role harness means "not pinned" and matches anything).
- `Permissions` is harness-neutral and is always inherited.

The duplicated gates in `agent_switching.go` and `agent_switching_chat.go` are removed; those paths now pass the *target* harness into `effectiveAgentConfig` instead. Restore keeps pinning `rec.Metadata.Permissions` over the project config, unchanged.

## Tests

- `TestEffectiveHarnessAndAgentConfig` extended: a mismatched harness drops model/mode but keeps permissions; an unpinned role override still applies to any harness.
- New `TestSpawn_DropsRoleModelOnHarnessMismatch`: `Worker.Harness=opencode` with `Model="custom/gpt-5.5"`, spawn with `Harness=codex` → launched model is empty (codex uses its own default), permissions still `auto`.
- Both mandatory gates run locally and pass on this base: `npm run lint` (`go test ./...` + golangci-lint v2.12.2) and `npm run frontend:typecheck`.

## Risks / notes

- The stricter behavior for unpinned overrides is **kept**. An earlier revision of this branch treated a role override with no harness pinned as "applies to any harness"; that reopened the same leak by a second route, since a role `Model`/`Mode` saved without an agent would reach whatever harness launched. The second commit drops model/mode from an unpinned override instead, normalizing in `roleOverride` — the single point both `effectiveHarness` and `effectiveAgentConfig` read through — so the harness-match rule in `effectiveAgentConfig` is unchanged and simply has no model left to inherit. `Permissions` remains harness-neutral and is still inherited.
- The settings form already enforces this (the role agent is required, and changing it clears the role's model/mode). `ProjectConfig.Validate` does not, so a config written through the API, hand-edited, or saved before the agent became required can still carry the shape. Normalizing on read repairs those rather than failing to load them — deliberately not a `Validate` error, which would make existing stored configs fail to load.
- Catalog-based model validation was considered and rejected: codex is `CustomModelEntryDirect` (`modelcatalog/catalog.go`), so `custom/gpt-5.5` is a legitimate free-form value there and a catalog cannot distinguish the leak from a deliberate alias.





