### PR TITLE
docs: simplify human bug reports and evidence triage

### DIFF
--- a/.agents/skills/bug-triage/SKILL.md
+++ b/.agents/skills/bug-triage/SKILL.md
@@ -1,421 +1,131 @@
 ---
 name: bug-triage
-description: Triage bugs reported in chat/issues, search for duplicates, file or update GitHub issues with full context, and push fix PRs.
-trigger: User reports a bug, or asks to triage/file an issue for a reported problem.
+description: Help clarify human bug reports, search for duplicates, and gather diagnostic evidence separately from a concise issue draft.
 ---
 
-# Bug Triage Skill
+# Bug triage
 
-Triage bugs into well-structured GitHub issues on the Agent Orchestrator repo.
+Help the reporter describe what they observed and add useful evidence. A short human
+observation is enough to report a bug; reproduction, logs, and a diagnosis are optional.
+Use this skill for reports from chat, an existing issue, or a local user.
 
-> **Agent Orchestrator is Go + Electron.** The backend is a Go daemon (`backend/`)
-> exposing a loopback HTTP API on `127.0.0.1:3001`; the frontend is an Electron +
-> React supervisor (`frontend/`). There is **no** pm2/tmux/Node runtime here —
-> the daemon owns lifecycle and sessions run under the **Zellij** runtime
-> adapter. Triage against _this_ stack, not the old TypeScript agent-orchestrator.
+## Clarify the observation
 
-## ⚠️ Which `ao` are you running?
+Read the available report, screenshots, and follow-ups first. Preserve the original
+reporter's words and attribution, including when someone else relays their report.
+Don't infer a GitHub username from a chat display name.
 
-**`Agent Orchestrator` ships no `ao` on your PATH.** A bare `ao` very likely resolves to a
-**different** AO install — e.g. an old npm build at `~/.nvm/.../bin/ao` that talks
-to port **:3000**. Triaging with the wrong binary produces bugs that don't exist
-in Agent Orchestrator (and miss ones that do).
+Ask only questions that would materially clarify the symptom, a few at a time. Don't
+repeat questions already answered or turn these suggestions into required fields:
 
-Before any diagnostics:
+- What did you do, and what happened instead of what you expected?
+- Where did it happen, and does it happen every time or only sometimes?
+- For a visual problem, can you share a screenshot or short recording showing it?
+- If relevant, which AO version and OS were you using, and did it start after a change?
 
-```bash
-which -a ao                      # see every ao on PATH — expect surprises
-ao status 2>/dev/null            # if this shows port 3000, it is NOT Agent Orchestrator
-```
+If a screenshot is unavailable, accept a description. If the reporter cannot remember
+steps or reproduce the problem, preserve that uncertainty and proceed with what is
+known. Never invent steps or make the reporter diagnose the bug before accepting it.
 
-Use an Agent Orchestrator binary explicitly:
+## Keep the report and investigation separate
 
-```bash
-# Option A — build from this repo (preferred during triage)
-cd backend && go build -o /tmp/ao ./cmd/ao
-/tmp/ao status                   # must report port: 3001
+Draft a specific symptom-based title and a short body, normally one paragraph or a few
+bullets. Include only details supplied directly by the human: their observation,
+expected behavior, steps, frequency, environment, and impact when they provided them.
+Light editing for clarity is fine; preserve meaning and uncertainty. Omit empty
+sections and unnecessary background. Do not add agent-inferred impact, root cause,
+confidence scores, or proposed fixes to the report.
 
-# Option B — the packaged app's bundled daemon
-"/Applications/Agent Orchestrator.app/Contents/Resources/daemon/ao" status
-```
+Example human report:
 
-**Confirm `ao status` reports `port: 3001` before trusting any output.** Throughout
-this skill, `ao` means _your verified Agent Orchestrator binary_ (`/tmp/ao` or the bundled
-one), never a bare PATH lookup.
+> After I switched projects, the terminal stayed blank. I expected to see the session
+> prompt. It happened twice today on macOS; I don't know how to reproduce it reliably.
 
-> Note: spawned sessions get a PATH pin so the _session's_ `ao` resolves to the
-> daemon's own executable (see `hookPATH` in
-> `backend/internal/session_manager/manager.go`). That pin only applies inside
-> sessions — your interactive shell is still on its own PATH, so pin it yourself.
+Keep agent-discovered information in a separate attachment labeled **Agent-collected
+evidence**, even when it confirms the report. Include only relevant excerpts and:
 
-## 1. Pre-flight
+- The command or read-only query used, collection time, and relevant AO version or
+  checkout commit, so another person can interpret the result.
+- Observed output, screenshots, or reproduction results, with enough context to verify
+  the finding. Distinguish the reporter's environment from a separate test build.
+- A brief explanation of what the evidence supports and its limits. Label hypotheses
+  explicitly; don't present a code-path guess as a confirmed cause.
 
-- **Pull latest code:** `git pull origin main`. Stale code = bad triage.
-- **Target repo:** Always file on **`Untrivial-ai/agent-orchestrator`** (the current product repo, not
-  a fork). Agent Orchestrator is the product, not a thin fork of upstream.
-- **Verify your binary:** confirm `ao status` shows port **3001** (see warning above).
-- **Record source:** chat URL, reporter name, attachments.
+If no useful evidence is available, deliver the human report alone. Never pad it with
+speculation or claim a reproduction succeeded when it didn't.
 
-## 2. Gather Context
+## Gather relevant evidence
 
-### 2a. Extract the report
+Use diagnostics that fit the symptom, within the user's requested scope. Prefer
+read-only checks against the affected installation. Don't restart sessions, upgrade
+AO, change live data, or alter the user's checkout just to collect evidence.
 
-| Source                   | How to gather                                                                                                                        |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **Discord/Slack thread** | Read full thread. Extract: reporter name, original description (the thread starter, not whoever tagged you), screenshots, follow-ups |
-| **GitHub issue**         | `gh issue view <number> --repo Untrivial-ai/agent-orchestrator --json body,comments`                                                             |
-| **Live observation**     | Pull live state via the daemon: `ao status`, `ao session ls`, `ao session get <id>`                                                  |
+AO uses a Go daemon and an Electron/React frontend. Read `docs/architecture.md` for
+current boundaries and locate actual files with `rg` before citing code. Do not rely
+on the old TypeScript implementation or assume which runtime backs a session.
 
-### 2b. Minimum viable report gate
+Before trusting diagnostics, identify the AO executable and affected daemon. A PATH
+lookup may resolve to a legacy install. Check the executable's version and status,
+and the configured run file/data directory (`AO_RUN_FILE` / `AO_DATA_DIR` when set).
+The primary daemon normally uses loopback port 3001; port alone does not establish
+which version or installation is affected. Consult the installed CLI help for commands.
 
-Before tracing code, verify the report has enough substance:
+Collect only what helps explain this symptom:
 
-**Required (ALL):** what happened, where (page/command/feature), when (after upgrade? first time?)
+| Symptom | Potential evidence |
+| --- | --- |
+| UI rendering or interaction | Screenshot/recording, relevant console errors, affected view |
+| Session or terminal state | Affected session's daemon state, relevant log excerpt, runtime details |
+| Daemon or CLI failure | Version/status, exact command and error, relevant daemon logs |
+| Persisted state mismatch | Relevant rows and schema from a read-only SQLite query |
 
-**Required (2 of 4):** OS/shell, AO version (`ao version`), reproducibility (consistent vs intermittent), reproduction steps
+Use the daemon API/CLI for state first. If database evidence is needed, discover the
+actual database location and schema, open it read-only, and select only relevant rows
+and columns. Never attach an entire database or broad log dump. Redact tokens,
+credentials, private prompts, and unrelated personal or repository data from every
+artifact, including screenshots. Keep diagnostic artifacts under `~/.ao` and out of
+Git commits. Share a useful excerpt rather than a wall of output.
 
-If insufficient, ask:
+Try a safe reproduction when practical, recording the build actually tested. Failure
+to reproduce does not invalidate the human report. Code tracing or dependency research
+is optional when it can add concrete evidence. Keep findings in the attachment.
 
-> "I'd like to triage this but need more info: (1) **What happened?** (error/behavior), (2) **Where?** (page/command), (3) **When did it start?**, (4) **How to reproduce?**"
+## Check for duplicates
 
-### 2c. Local diagnostics (if bug is on same machine)
-
-Gather everything yourself before asking the reporter. Use your **verified**
-Agent Orchestrator binary (`/tmp/ao` here) for every `ao` call:
-
-```bash
-# Environment
-/tmp/ao version && go version && echo $SHELL && uname -a
-which -a ao                                         # confirm no rogue ao shadows the build
-cat ~/.ao/running.json                              # PID + port handshake (expect port 3001)
-
-# Daemon health
-/tmp/ao status                                      # daemon up? port? health/ready probes
-/tmp/ao doctor                                      # local health checks
-lsof -i :3001                                       # who's bound to the daemon port
-tail -n 100 ~/.ao/daemon.log                        # daemon log
-
-# Sessions & runtime
-/tmp/ao session ls                                  # all sessions and their state
-/tmp/ao session get <id>                            # one session: spawn config, runtime, lifecycle
-zellij list-sessions                                # Zellij runtime sessions backing terminals
-
-# Durable state (SQLite at ~/.ao/data)
-sqlite3 ~/.ao/data/ao.db '.tables'                  # inspect schema/rows if state looks wrong
-```
-
-The daemon owns lifecycle, sessions, storage, and the terminal mux; structured
-state lives in `~/.ao/data/ao.db` (WAL: `ao.db-wal`, `ao.db-shm`). The PID+port
-handshake is `~/.ao/running.json`.
-
-**Try the reproduction steps.** Running the actual command against the daemon on
-:3001 is worth 100 lines of code tracing.
-
-## 3. Investigate
-
-### 3a. Trace the code path
-
-**Always trace the actual code** — don't surface-level diagnose. A symptom that
-looks like a simple `ao stop` issue is often a lifecycle/session-manager problem
-one layer down. Agent Orchestrator's layers:
-
-- CLI (Cobra, thin client over daemon HTTP): `backend/internal/cli/`, entrypoint
-  `backend/cmd/ao/main.go`
-- Daemon (loopback HTTP on :3001): `backend/internal/daemon/daemon.go`,
-  controllers under `backend/internal/httpd/controllers/`
-- Sessions & lifecycle: `backend/internal/session_manager/manager.go`
-- Runtime adapter (Zellij): `backend/internal/adapters/runtime/`
-- Agent harness adapters: `backend/internal/adapters/agent/<harness>/`
-- Terminal mux: `backend/internal/terminal/`
-- Agent hooks: `backend/internal/cli/hooks.go`
+Search open and closed issues and related PRs using the symptom or exact error:
 
 ```bash
-git fetch origin main && git log --oneline origin/main -5   # current HEAD
-# Record the commit hash you're analyzing against
+gh issue list --repo Untrivial-ai/agent-orchestrator --state all --search '<symptom or error>'
+gh pr list --repo Untrivial-ai/agent-orchestrator --state all --search '<symptom or error>'
 ```
 
-**Git archaeology** — find which commits introduced/removed specific code:
-
-```bash
-git log --oneline -S 'exact-string' -- <file>
-git show <sha> -- <file> | grep -B 5 -A 10 'pattern'
-```
-
-**Research dependencies** (Zellij, the agent harness binary, Electron, React, the
-SQLite driver) — check installed vs latest version, search their issue trackers,
-check changelogs. Root cause is sometimes in a dependency, not Agent Orchestrator.
-
-### 3b. Cross-platform check
-
-AO targets **macOS, Linux, and Windows**. If env info indicates Windows (or is
-unknown), check for these patterns:
-
-- **Path separators** — hardcoded `/` or `\`; use `filepath.Join`, not string concat
-- **Shell syntax** — PowerShell lacks `&&`, `$VAR`, `$(cat ...)`, `/dev/null`, here-docs
-- **`runtime.GOOS == "windows"` scattered inline** — centralize platform checks
-- **Process-tree kills** — POSIX process groups vs Windows job objects
-- **`localhost`** — Windows resolves to `::1` first; the daemon binds the explicit
-  loopback host (see `config.LoopbackHost`) to avoid IPv4/IPv6 stalls
-- **Case-insensitive filesystems** — don't compare paths with raw `==`
-- **PATH / binary resolution** — `.exe`/`PATHEXT` lookup, the session PATH pin
-  (`hookPATH` in `backend/internal/session_manager/manager.go`)
-
-Key files: `backend/internal/config/config.go`, `backend/internal/session_manager/manager.go`,
-`backend/internal/adapters/runtime/`, `backend/internal/terminal/`.
-
-### 3c. Stop-and-ask triggers
-
-Stop and ask for more info if:
-
-- **3 failed hypotheses** — traced 3 code paths, none explain it
-- **Root cause is a dependency** — file with the dependency reference, don't guess a local fix
-- **UI-only bug** and you can't screenshot — ask reporter to describe
-- **Can't reproduce** — ask for different config/sequence
-
-## 4. Search for Duplicates
-
-Search with multiple strategies, always using `--state all` (closed bugs regress):
-
-```bash
-gh issue list --repo Untrivial-ai/agent-orchestrator --state all --search "<symptom>"
-gh issue list --repo Untrivial-ai/agent-orchestrator --state all --search "<component-name>"
-gh issue list --repo Untrivial-ai/agent-orchestrator --state all --search "<error-message>"
-gh pr list --repo Untrivial-ai/agent-orchestrator --state all --search "<keywords>"
-```
-
-### Duplicate found → comment on existing issue
-
-```bash
-gh issue comment <number> --repo Untrivial-ai/agent-orchestrator --body "$(cat <<'EOF'
-## New Report
-**Reported by:** @<reporter> in [chat](<url>)
-**Date:** <YYYY-MM-DD> | **Checkout:** `<commit-hash>`
-<context, differences from original, screenshots>
-EOF
-)"
-```
-
-### No duplicate → file new issue (next section)
-
-## 5. File New Issue
-
-### 5a. Pre-submission checklist
-
-- [ ] Reporter attribution correct (original reporter, not who tagged you)
-- [ ] Commit hash recorded
-- [ ] AO version recorded (`ao version`)
-- [ ] Reproduced against Agent Orchestrator (:3001 / Go code path), not another AO install
-- [ ] Root cause confidence scored (see 5c)
-- [ ] Related issues cross-linked
-- [ ] Reproduction steps are concrete
-- [ ] Screenshots uploaded with real URLs (see 5b)
-
-### 5b. Upload screenshots
-
-**⛔ NEVER use placeholder URLs.** Upload BEFORE creating the issue.
-
-```bash
-SLUG="descriptive-slug"
-# Create asset branch
-gh api -X POST repos/Untrivial-ai/agent-orchestrator/git/refs \
-  -f ref="refs/heads/issue-assets-${SLUG}" \
-  -f sha=$(git rev-parse origin/main)
-
-# Upload (portable base64)
-IMG_B64=$(base64 < /path/to/screenshot.png | tr -d '\n')
-gh api -X PUT "repos/Untrivial-ai/agent-orchestrator/contents/.issue-assets/${SLUG}/name.png" \
-  -f message="chore: upload screenshot" \
-  -f content="$IMG_B64" \
-  -f branch="issue-assets-${SLUG}"
-# Use: ![screenshot](https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/issue-assets-<slug>/.issue-assets/<file>)
-```
-
-### 5c. Create the issue
-
-```bash
-gh issue create --repo Untrivial-ai/agent-orchestrator --title "<title>" --body "$(cat <<'EOF'
-## Bug
-<summary>
-
-**Source:** <url> | **Reported by:** @<reporter> | **Analyzed against:** `<hash>`
-**Confidence:** High/Medium/Low
-
-## Reproduction
-1. <step>
-
-## Root Cause
-<file paths, line numbers, explanation>
-
-## Fix
-<suggested approach>
-
-## Impact
-- <effects>
-EOF
-)"
-```
-
-### 5d. Label and prioritize
-
-**Check which labels actually exist first**, then apply only those:
-
-```bash
-gh label list --repo Untrivial-ai/agent-orchestrator          # source of truth — apply only these
-gh issue edit <number> --repo Untrivial-ai/agent-orchestrator --add-label "bug"
-```
-
-The repo currently carries `bug`, `enhancement`, `priority: critical/high/medium/low`,
-lane labels (`daemon`, `frontend`, `storage`, `coding-agents`, `lcm-sm`, `scm`,
-`core`, `port`, `adapter`, `domain`), and workflow labels (`needs-triage`,
-`needs-review`, `blocked`). **Do not invent labels** — if a priority or confidence
-label you want doesn't exist, **state it in the issue body instead** (e.g.
-"**Priority:** high — core feature broken, no workaround" / "**Confidence:** medium").
-
-| Priority             | Criteria                            |
-| -------------------- | ----------------------------------- |
-| `priority: critical` | Data loss, security, system down    |
-| `priority: high`     | Core feature broken, no workaround  |
-| `priority: medium`   | Feature degraded, workaround exists |
-| `priority: low`      | Cosmetic, edge case                 |
-
-**Confidence scoring** (always state in the issue body):
-
-| Level      | Meaning                                                     |
-| ---------- | ----------------------------------------------------------- |
-| **High**   | Traced exact code path, specific lines, mechanism explained |
-| **Medium** | Strong hypothesis but unconfirmed                           |
-| **Low**    | Can't trace, multiple conflicting theories                  |
-
-### 5e. Cross-link related issues
-
-Search by subsystem and add a `## Related` section to the issue body:
-
-```
-## Related
-- [#20](url) — stale session blocking ao start (same subsystem)
-- [#35](url) — same race condition
-```
-
-### 5f. Push a fix PR (always attempt)
-
-Agent Orchestrator is a Go repo — fixes go through a local branch, build, and `gh pr create`.
-There is no remote-patch script.
-
-- **Unclear fix:** Don't push a guess. Document and flag in the issue.
-- **Trivial, verifiable fix** (you can build and test it yourself):
-
-  ```bash
-  git checkout -b fix/<slug> origin/main
-  # make the edit
-  cd backend && go build ./... && go test ./...   # must pass before pushing
-  git commit -am "fix(<scope>): <summary>
-
-  Fixes #<n>"
-  git push -u origin fix/<slug>
-  gh pr create --repo Untrivial-ai/agent-orchestrator --fill \
-    --title "fix(<scope>): <summary>" \
-    --body "Fixes #<n>
-
-  ## Summary
-  <what changed>
-
-  ## Test
-  cd backend && go build ./... && go test ./..."
-  ```
-
-- **Non-trivial fix** (broad change, needs iteration, or you can't fully verify):
-  spawn an Agent Orchestrator worker session to do the work in its own worktree instead of
-  pushing a guess:
-
-  ```bash
-  ao spawn --project agent-orchestrator --prompt "Fix #<n>: <one-line problem statement>. \
-  Root cause: <file:line + mechanism>. Suggested approach: <approach>. \
-  Build with 'cd backend && go build ./... && go test ./...' before opening a PR against Untrivial-ai/agent-orchestrator."
-  ```
-
-  Note the issue with which path you took (PR or spawned worker).
-
-### 5g. Report back
-
-Issue URL, PR URL (if created) or spawned worker session ID, labels applied (and
-any priority/confidence stated in the body), root cause summary.
-
----
-
-## Appendix
-
-### A. Subsystem Quick Reference
-
-| Subsystem                       | Collect                                   | Key files                                                                  |
-| ------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------- |
-| **CLI** (`ao start/stop/spawn`) | Version, install method, OS, which binary | `backend/internal/cli/`, `backend/cmd/ao/main.go`                          |
-| **Daemon / HTTP API**           | `ao status`, port, daemon.log             | `backend/internal/daemon/daemon.go`, `backend/internal/httpd/controllers/` |
-| **Sessions / Lifecycle**        | Session ID, spawn config, runtime, state  | `backend/internal/session_manager/manager.go`                              |
-| **Runtime (Zellij)**            | Zellij version, `zellij list-sessions`    | `backend/internal/adapters/runtime/`                                       |
-| **Terminal mux**                | Runtime type, shell, attach behavior      | `backend/internal/terminal/`                                               |
-| **Agent harness**               | Harness name + version                    | `backend/internal/adapters/agent/<harness>/`                               |
-| **Storage**                     | DB state, migrations                      | `backend/internal/storage/sqlite/`, `~/.ao/data/ao.db`                     |
-| **Hooks**                       | Hook event, agent, payload                | `backend/internal/cli/hooks.go`                                            |
-| **Frontend (Electron/React)**   | Screenshot, viewport, daemon connectivity | `frontend/src/`                                                            |
-
-**Misrouting patterns:**
-
-- Terminal bugs → Zellij runtime adapter vs the terminal mux vs the Electron xterm
-  surface. Trace where bytes flow (daemon → mux → frontend).
-- "Session stuck" → lifecycle/session-manager state vs agent harness process vs
-  Zellij runtime connection.
-- "Config not saving" → config loading (`backend/internal/config/config.go`) vs
-  project registration vs SQLite write (`~/.ao/data/ao.db`).
-- "Command does nothing / wrong port" → you're on the wrong `ao` binary (:3000 vs
-  :3001). Re-check `which -a ao` and `ao status`.
-
-### B. Remote Code Inspection (no local clone)
-
-```bash
-gh api repos/Untrivial-ai/agent-orchestrator/git/trees/main?recursive=1 --jq '.tree[].path'    # list files
-gh api repos/Untrivial-ai/agent-orchestrator/contents/{path} --jq '.content' | python3 -c "import base64,sys; sys.stdout.buffer.write(base64.b64decode(sys.stdin.read()))"  # read file
-gh search code "term" --repo Untrivial-ai/agent-orchestrator --json path --jq '.[].path'        # search code
-gh api "repos/Untrivial-ai/agent-orchestrator/commits?path={path}&per_page=10" --jq '.[] | "\(.sha[0:8]) \(.commit.message | split("\n")[0])"'  # file history
-```
-
-### C. Build / Version Diagnostics
-
-Agent Orchestrator is built from source, not published to npm. Pin the binary under test
-and reproduce against a known build:
-
-```bash
-cd backend && go build -o /tmp/ao ./cmd/ao    # build the binary under test
-/tmp/ao version                               # record version/commit
-go version                                    # toolchain (build issues are often here)
-git log --oneline origin/main -1              # the commit you're analyzing against
-```
-
-To bisect a regression, build `ao` at two commits and compare behavior:
-
-```bash
-git stash; git checkout <good-sha>; (cd backend && go build -o /tmp/ao-good ./cmd/ao)
-git checkout <bad-sha>;             (cd backend && go build -o /tmp/ao-bad  ./cmd/ao)
-git checkout - ; git stash pop
-# run the repro against /tmp/ao-good vs /tmp/ao-bad
-```
-
-## Formatting Rules
-
-- **Linkify all issue/PR refs:** `[#123](https://github.com/Untrivial-ai/agent-orchestrator/issues/123)`, `[PR #456](url)`. Never bare `#123`.
-
-## Pitfalls
-
-- **Wrong `ao` binary.** A bare `ao` may be a different AO install (old npm build on
-  :3000). Always pin an Agent Orchestrator binary and confirm `ao status` shows port **3001**.
-- **Verify the bug reproduces against Agent Orchestrator (:3001 / Go code path) before
-  filing** — symptoms first seen in another AO install may not reproduce here.
-- **Reporter ≠ person who tagged you.** Always attribute to the original reporter.
-- **Record the commit hash** you analyzed — code changes fast.
-- **GitHub issue is mandatory** — every triaged bug gets one, even if fix is trivial.
-- **Only apply labels that exist** (`gh label list --repo Untrivial-ai/agent-orchestrator`).
-  State priority/confidence in the body when no matching label exists.
-- **Build before you push.** `cd backend && go build ./... && go test ./...` must
-  pass; never open a PR with an unverified Go change.
-- **`gh api --jq .content` truncates large files** (>~100KB). Use local git instead.
-- **Don't invent Go file paths.** Grep the repo to confirm a path before citing it
-  in an issue.
+Read likely matches before calling a report a duplicate. If one matches, give the
+reporter its link and draft only their new observation for a comment, with evidence
+attached separately. If a closed issue appears to have regressed, explain that to the
+reporter rather than silently treating it as resolved. If search is unavailable,
+state that briefly; it does not block preparing the report.
+
+## Preserve attribution and submission scope
+
+Recommend that the reporter submit the issue or comment from their own GitHub account.
+Do not use AO Bot or another shared bot account to file human reports on their behalf.
+A local coding agent may help draft and gather attachments. If explicitly asked to
+submit using the reporter's account, verify the authenticated identity first; do not
+silently publish under a different identity. Existing authorization still applies;
+triage alone is not permission to publish.
+
+For an existing issue, preserve its human body and attribution. Add evidence as a
+separate attachment in a clearly labeled comment when authorized. Don't rewrite the
+report into an investigation narrative.
+
+Use the GitHub attachment UI when available. Otherwise give the reporter the local
+artifact paths and ask them to drag the files into the issue or comment. Never invent
+attachment URLs or create asset branches to host diagnostics. Keep the report body
+limited to human details and attachment links, with analysis inside the attachments.
+When submitting via CLI, use `--body-file` for reviewed text. Apply only existing,
+relevant labels; don't add priority/confidence prose just to fill a template.
+
+Finish with the concise draft (or issue link if submitted), any duplicate link, and
+attachment paths/links. Do not automatically file an issue, implement a fix, push a
+PR, or spawn a worker. Follow the user's requested scope and the repository's normal
+contribution workflow if they separately ask for implementation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing
 
 We love contributions — code, docs, triage, examples, and tests.
-Start on Discord so scope is clear before you invest time.
+For implementation work, start on Discord so scope is clear before you invest time.
+Bug reports can go straight to GitHub.
 
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white&logoSize=auto)](https://discord.com/invite/UZv7JjxbwG)
 
@@ -41,8 +42,21 @@ Two onboarding notes matter on current `main`:
 
 ### Bugs and features
 
-Use the GitHub issue forms (**Bug report** / **Feature request**) so reports stay reproducible.
-Bug reports should include AO version, environment, repro steps, and expected vs actual behavior.
+Use the [GitHub issue forms](https://github.com/Untrivial-ai/agent-orchestrator/issues/new/choose) for bugs and feature requests. For bugs, only a description is required. Write a short, concrete report in your own words: what you did and what went wrong. When available, add what you expected, steps to reproduce, how often it happens, AO version and OS, or screenshots/a recording. You can report an intermittent bug even if you cannot reproduce it reliably.
+
+Search existing issues when possible; add your observations to a matching issue. Submit from your own GitHub account so maintainers can follow up with the person who experienced the problem. Please don't ask AO Bot to file reports on your behalf.
+
+Agent assistance is welcome. We recommend asking your local coding agent to use the [bug-triage skill](.agents/skills/bug-triage/SKILL.md) to ask useful follow-up questions and gather supporting evidence. The issue body should contain only observations you supplied, without invented steps, impact, or root-cause claims. Keep agent-collected logs, relevant database excerpts, and analysis in separate, clearly labeled attachments; remove secrets and unrelated personal data before sharing. Evidence and screenshots are optional, and can be added later.
+
+For example, ask your local agent:
+
+```text
+Use .agents/skills/bug-triage/SKILL.md to help with this bug: <what I observed>.
+Ask about missing details that would help, draft a concise report using only
+what I tell you, and collect relevant evidence separately for me to attach.
+```
+
+Review the draft and attachments before submitting. A clear observation is useful on its own; no diagnosis or proposed fix is needed.
 
 ### Pull requests
 

--- a/README.md
+++ b/README.md
@@ -182,19 +182,11 @@ AO works with the coding agents and source-control workflow you already use. Age
 
 ## Report a bug
 
-The recommended way to report a bug is to ask your coding agent to follow the repository's [bug-triage skill](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/.agents/skills/bug-triage/SKILL.md). It guides the agent through reproducing the problem on current code, gathering diagnostics, tracing the relevant code path, checking for duplicates, and filing or updating a detailed GitHub issue.
+[Open a bug report](https://github.com/Untrivial-ai/agent-orchestrator/issues/new?template=bug_report.yml) from your own GitHub account. A few sentences in your own words about what you did and what went wrong are enough. Add what you expected, reproduction steps, your AO version and OS, or a screenshot if you have them; these are helpful, not prerequisites.
 
-Whether you ask a local coding agent or AO Bot on Discord, attach screenshots and share as much relevant context as possible. Include what happened, where and when it happened, steps to reproduce it, your OS and AO version, and whether the problem is consistent or intermittent. This gives the agent the best chance of reproducing the bug and filing an actionable report.
+A local coding agent can help you clarify the report and gather evidence using the [bug-triage skill](.agents/skills/bug-triage/SKILL.md). Keep the issue body focused on your observations, with agent-collected logs, database excerpts, and investigation notes in separate attachments. Review any draft before submitting it under your own account. Please don't ask AO Bot to file issues on your behalf; reporter attribution matters.
 
-```text
-Read and follow https://github.com/Untrivial-ai/agent-orchestrator/blob/main/.agents/skills/bug-triage/SKILL.md. Please reproduce and triage this bug, then file or update the GitHub issue. Context: <what happened, where, when, reproduction steps, OS, AO version, and frequency>. Screenshots: <attach any screenshots>.
-```
-
-You can also report a bug in the [bug-triaging channel on Discord](https://discord.com/channels/1476302178913357958/1491735678156013588). Tag `@AO Bot#8425`, describe what happened, and ask it to use the bug-triage skill.
-
-```text
-@AO Bot#8425 Please reproduce and triage this bug using the bug-triage skill, then file or update the GitHub issue. Context: <what happened, where, when, reproduction steps, OS, AO version, and frequency>. Screenshots: <attach any screenshots>.
-```
+For help describing a problem, join the [bug-triaging channel on Discord](https://discord.com/channels/1476302178913357958/1491735678156013588). See [contribution guidance](CONTRIBUTING.md#bugs-and-features) for more detail.
 
 ## Develop and contribute
 


### PR DESCRIPTION
## What
Simplify bug reporting to one required description field, with optional screenshots and supporting evidence.

## Why
Contributor feedback on Discord highlighted verbose agent-generated issues, too many mandatory fields, and lost reporter attribution when AO Bot files on someone's behalf.

## How
- Update README and CONTRIBUTING to encourage concise human observations and submission from the reporter's own account.
- Rewrite bug-triage to ask focused follow-up questions and keep agent-collected logs, database excerpts, and investigation notes in separate attachments.
- Remove reproduction gates, mandatory root-cause sections, bot-filing examples, and automatic issue/fix-PR workflows from triage. Missing evidence does not block a report.

## Testing
- Skill creator `quick_validate.py`: passed.
- Bug form YAML parsed; verified exactly one required field and unique field IDs.
- Local Markdown link checks and `git diff --check`: passed.
- Ran CI's pinned gitleaks v7.4.0 Docker image against the new commit: 1 commit scanned, no leaks.
- Application suites are outside the pull-request workflow path filters for these four documentation/template files. No application code changed.

## Checklist
- [x] Branched from main
- [x] One focused change based on contributor feedback
- [x] Follows AGENTS.md conventions
- [x] Relevant documentation/template validation completed
- [x] Remote CI checks pass (gitleaks scan)

