### PR TITLE
fix(chat): stop reporting a starting controller as a crash

### DIFF
--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -943,6 +943,22 @@ type ConversationRows struct {
 	HasMoreBefore                    bool
 }
 
+// preConversationControllerState answers what a session that has never had a
+// conversation should report. Such a session has never had a controller either,
+// so "stopped" claims an ending that never happened — and the chat surface paints
+// that claim as a crash banner offering to resume an agent that has not yet run.
+//
+// The reading is taken from durable state alone, never from the row's age: a
+// terminated session, and one whose agent process exited, keep reporting stopped
+// from the first poll, so a real failure is never masked by a startup grace
+// period.
+func preConversationControllerState(record domain.SessionRecord) ports.ChatControllerState {
+	if record.IsTerminated || record.Activity.State == domain.ActivityExited {
+		return ports.ChatControllerStopped
+	}
+	return ports.ChatControllerConnecting
+}
+
 // Snapshot reads a session's conversation.
 //
 // It does not require a live controller: history must remain readable after the
@@ -964,7 +980,7 @@ func (s *Service) Snapshot(ctx context.Context, id domain.SessionID) (Snapshot, 
 			SessionID:  id,
 			Harness:    record.Harness,
 			Mode:       domain.NormalizeSessionMode(record.Mode),
-			Controller: ports.ChatControllerStopped,
+			Controller: preConversationControllerState(record),
 		}, nil
 	}
 	if err != nil {
@@ -1016,7 +1032,7 @@ func (s *Service) SnapshotPage(ctx context.Context, id domain.SessionID, beforeS
 			SessionID:  id,
 			Harness:    record.Harness,
 			Mode:       domain.NormalizeSessionMode(record.Mode),
-			Controller: ports.ChatControllerStopped,
+			Controller: preConversationControllerState(record),
 		}, nil
 	}
 	if err != nil {

--- a/backend/internal/service/chat/startup_controller_state_test.go
+++ b/backend/internal/service/chat/startup_controller_state_test.go
@@ -1,0 +1,174 @@
+package chat_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	chatsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/chat"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// The chat surface paints a "stopped" controller as a destructive alert offering
+// to resume the agent. A session created seconds ago whose controller has not
+// opened its conversation yet has nothing to resume — reporting it as stopped is
+// a crash claim about an event that never happened, and the desktop app showed it
+// on every spawn for the 3–13s the conversation row takes to appear.
+// See https://github.com/Untrivial-ai/agent-orchestrator/issues/5131.
+
+// newSessionService builds a Service over a real store with no controller ever
+// started, which is exactly the state a session is in between its durable row
+// and its first conversation row.
+func newSessionService(t *testing.T) (*chatsvc.Service, *sqlite.Store) {
+	t.Helper()
+	st := openStore(t)
+	svc := chatsvc.New(chatsvc.Options{
+		Store:    st,
+		Reader:   fullSnapshotReader(st),
+		Sessions: st,
+		Drivers:  fakeRegistry{driver: fakeDriver{conv: newFakeConversation()}},
+		Log:      slog.New(slog.DiscardHandler),
+		Now:      func() time.Time { return time.Date(2026, 9, 8, 22, 48, 1, 0, time.UTC) },
+	})
+	return svc, st
+}
+
+// seedChatSession writes one more chat session alongside the one openStore seeds,
+// so a test can shape termination and activity without disturbing the shared row.
+func seedChatSession(t *testing.T, st *sqlite.Store, mutate func(*domain.SessionRecord)) domain.SessionID {
+	t.Helper()
+	now := time.Now().UTC()
+	rec := domain.SessionRecord{
+		ProjectID: testProject,
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessCodex,
+		Mode:      domain.SessionModeChat,
+		Activity:  domain.Activity{State: domain.ActivityIdle, LastActivityAt: now},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if mutate != nil {
+		mutate(&rec)
+	}
+	created, err := st.CreateSession(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("seed chat session: %v", err)
+	}
+	if mutate != nil {
+		// CreateSession assigns the id, so anything the row must carry beyond the
+		// insert defaults is written back against the real id.
+		created.Activity = rec.Activity
+		created.IsTerminated = rec.IsTerminated
+		if err := st.UpdateSession(context.Background(), created); err != nil {
+			t.Fatalf("shape seeded session: %v", err)
+		}
+	}
+	return created.ID
+}
+
+func TestSnapshotReportsAStartingControllerRatherThanACrash(t *testing.T) {
+	svc, st := newSessionService(t)
+	id := seedChatSession(t, st, nil)
+
+	snapshot, err := svc.Snapshot(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snapshot.Controller != ports.ChatControllerConnecting {
+		t.Fatalf("controller = %q, want %q for a session that has never had one",
+			snapshot.Controller, ports.ChatControllerConnecting)
+	}
+	if snapshot.Conversation.ID != "" {
+		t.Fatalf("conversation id = %q, want empty before the controller opens one",
+			snapshot.Conversation.ID)
+	}
+}
+
+// The paged read is what the desktop app actually calls, so it must not keep the
+// old answer while the full read is fixed.
+func TestSnapshotPageReportsAStartingControllerRatherThanACrash(t *testing.T) {
+	svc, st := newSessionService(t)
+	id := seedChatSession(t, st, nil)
+
+	snapshot, err := svc.SnapshotPage(context.Background(), id, 0, 50)
+	if err != nil {
+		t.Fatalf("SnapshotPage: %v", err)
+	}
+	if snapshot.Controller != ports.ChatControllerConnecting {
+		t.Fatalf("controller = %q, want %q for a session that has never had one",
+			snapshot.Controller, ports.ChatControllerConnecting)
+	}
+}
+
+// The whole risk of the fix is masking a real failure behind a startup spinner.
+// Termination and a process that exited are durable facts, and both keep saying
+// stopped from the first poll — no grace period, no age check.
+func TestSnapshotStillReportsStoppedForSessionsThatReallyEnded(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*domain.SessionRecord)
+	}{
+		{
+			name:   "terminated",
+			mutate: func(rec *domain.SessionRecord) { rec.IsTerminated = true },
+		},
+		{
+			name: "agent process exited",
+			mutate: func(rec *domain.SessionRecord) {
+				rec.Activity = domain.Activity{
+					State:          domain.ActivityExited,
+					LastActivityAt: time.Now().UTC(),
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, st := newSessionService(t)
+			id := seedChatSession(t, st, tc.mutate)
+
+			snapshot, err := svc.Snapshot(context.Background(), id)
+			if err != nil {
+				t.Fatalf("Snapshot: %v", err)
+			}
+			if snapshot.Controller != ports.ChatControllerStopped {
+				t.Fatalf("controller = %q, want %q — a real ending must not be masked",
+					snapshot.Controller, ports.ChatControllerStopped)
+			}
+
+			paged, err := svc.SnapshotPage(context.Background(), id, 0, 50)
+			if err != nil {
+				t.Fatalf("SnapshotPage: %v", err)
+			}
+			if paged.Controller != ports.ChatControllerStopped {
+				t.Fatalf("paged controller = %q, want %q",
+					paged.Controller, ports.ChatControllerStopped)
+			}
+		})
+	}
+}
+
+// A session that HAS a conversation but no live controller is the genuine
+// stopped case — the agent ran and its controller is gone. It must keep the
+// crash banner and its Resume affordance.
+func TestSnapshotReportsStoppedOnceAConversationExistsWithoutAController(t *testing.T) {
+	svc, st := newSessionService(t)
+	id := seedChatSession(t, st, nil)
+	if _, err := st.CreateConversation(
+		context.Background(), "conv-1", domain.ConversationScopeSession,
+		testProject, id, time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	snapshot, err := svc.Snapshot(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snapshot.Controller != ports.ChatControllerStopped {
+		t.Fatalf("controller = %q, want %q after a real controller stopped",
+			snapshot.Controller, ports.ChatControllerStopped)
+	}
+}

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -1024,6 +1024,56 @@ describe("ChatWorkspace timeline", () => {
 		expect(screen.getByRole("combobox", { name: "Message the agent" })).toHaveAttribute("contenteditable", "true");
 	});
 
+	// A session spawned seconds ago has no conversation row yet, so the daemon has
+	// no controller to report on. That is a startup, not a crash — the surface must
+	// not offer to resume an agent that has never run.
+	// https://github.com/Untrivial-ai/agent-orchestrator/issues/5131
+	it("says it is connecting while a brand-new session's controller is still coming up", () => {
+		const { rerender } = render(
+			<ChatWorkspace
+				snapshot={{
+					...chatFixtureEmpty,
+					conversationId: "",
+					controller: { state: "connecting" },
+				}}
+				onResumeAgent={vi.fn()}
+				onOpenShell={vi.fn()}
+			/>,
+		);
+
+		expect(screen.queryByText("The agent controller stopped")).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Resume agent" })).not.toBeInTheDocument();
+		expect(screen.queryByText("The controller is not connected")).not.toBeInTheDocument();
+		// Announced as progress, never as an alert.
+		expect(screen.getByRole("status")).toHaveTextContent("Connecting to the agent…");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		// The banner is the only place that says it: the composer stays empty rather
+		// than painting a second label over the editor.
+		expect(screen.getAllByText("Connecting to the agent…")).toHaveLength(1);
+		// Nothing exists to send to yet, so the composer stays inert.
+		expect(screen.getByRole("combobox", { name: "Message the agent" })).toHaveAttribute("contenteditable", "false");
+
+		rerender(<ChatWorkspace snapshot={chatFixtureEmpty} />);
+		expect(screen.queryByText("Connecting to the agent…")).not.toBeInTheDocument();
+		expect(screen.getByRole("combobox", { name: "Message the agent" })).toHaveAttribute("contenteditable", "true");
+	});
+
+	// A live controller that is reconnecting already has a conversation, and a send
+	// against it is durably queued. Disabling that composer would be a regression.
+	it("keeps the composer live while an existing conversation's controller reconnects", () => {
+		render(
+			<ChatWorkspace
+				snapshot={{
+					...chatFixtureEmpty,
+					controller: { state: "connecting" },
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Connecting to the agent…")).toBeInTheDocument();
+		expect(screen.getByRole("combobox", { name: "Message the agent" })).toHaveAttribute("contenteditable", "true");
+	});
+
 	it("announces thread and tool-server failures", () => {
 		const { rerender } = render(<ChatWorkspace snapshot={chatFixtureThreadError} />);
 		expect(screen.getByRole("alert")).toHaveTextContent("thread hit an internal error");

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -473,6 +473,11 @@ export function ChatWorkspace({
 	mcpReloadError,
 }: ChatWorkspaceProps) {
 	const turn = activeTurn(snapshot);
+	// A session whose controller has not opened a conversation yet is still coming
+	// up, not connecting to something already there. It has nothing to send to, so
+	// the controls stay disabled exactly as before — but the copy must not claim a
+	// stop that never happened.
+	const controllerStarting = snapshot.controller.state === "connecting" && !snapshot.conversationId;
 	const hasPendingInteraction = snapshot.items.some(
 		(item) =>
 			item.kind === "activity" &&
@@ -881,7 +886,7 @@ export function ChatWorkspace({
 					configPending={configOptionPending}
 					error={configOptionError}
 					disabled={
-						snapshot.controller.state === "stopped" || controllerTransitioning || configOptionPending || newWorkDisabled
+						snapshot.controller.state === "stopped" || controllerStarting || controllerTransitioning || configOptionPending || newWorkDisabled
 					}
 				/>
 			) : null,
@@ -889,6 +894,7 @@ export function ChatWorkspace({
 			configOptionError,
 			configOptionPending,
 			configOptions,
+			controllerStarting,
 			controllerTransitioning,
 			models,
 			newWorkDisabled,
@@ -1184,10 +1190,13 @@ export function ChatWorkspace({
 									settings={composerSettings}
 									busy={busy}
 									willQueue={Boolean(turn)}
-									disabled={snapshot.controller.state === "stopped" || controllerTransitioning || newWorkDisabled}
+									disabled={snapshot.controller.state === "stopped" || controllerStarting || controllerTransitioning || newWorkDisabled}
 									// Switch/reconnect status is the topbar spinner beside ⋮ — not composer text.
+									// A controller still coming up is the same kind of progress, and the
+									// controller banner already announces it, so the composer stays silent
+									// rather than claiming it is "not connected".
 									disabledPlaceholder={
-										controllerTransitioning || newWorkDisabled ? "" : undefined
+										controllerStarting || controllerTransitioning || newWorkDisabled ? "" : undefined
 									}
 									skills={skills}
 									filePaths={filePaths}


### PR DESCRIPTION
Fixes #5131

## Summary

A brand-new Chat session showed a **red "The agent controller stopped" crash banner for the first seconds of its own startup**, with a "Resume agent" button for an agent that had never run, and a "The controller is not connected" composer. It cleared itself once the controller came up.

`Service.Snapshot` / `Service.SnapshotPage` used `ChatControllerStopped` as the fallback for a session with **no conversation row yet** (`backend/internal/service/chat/service.go`). But `stopped` is a claim that something ran and ended, and the renderer faithfully paints it as a destructive `role="alert"` with recovery affordances (`ChatWorkspace.tsx:1590`, `ChatComposer.tsx:882`).

This reports the durable fact instead: **a session that has never had a conversation has never had a controller, so it is connecting.**

```go
func preConversationControllerState(record domain.SessionRecord) ports.ChatControllerState {
	if record.IsTerminated || record.Activity.State == domain.ActivityExited {
		return ports.ChatControllerStopped
	}
	return ports.ChatControllerConnecting
}
```

The reading comes from durable state alone — **no age check, no grace period**. A terminated session and one whose agent process exited keep reporting `stopped` from the first poll, so a genuine failure is never masked by a startup window.

On the renderer, the composer and turn-settings bar stay disabled while starting (there is no controller to `Send` to — `Service.Send` returns `ErrNoController`), but reuse the "Connecting to the agent…" copy the existing `controllerTransitioning` path already shows. `ControllerBanner` already renders `connecting` as a muted spinner with `role="status"`, so no banner change was needed.

A *reconnecting* controller that does have a conversation keeps its live composer — a send against it is durably queued, and disabling it would be a regression. That distinction is `!snapshot.conversationId`, and it is covered by a test.

The wire enum already carried `connecting` (`dto.go:2105`), so there is no API contract change.

## Measured window

Read-only against the live store, session row vs. conversation row creation:

| session | gap |
|---|---|
| `agent-orchestrator-326` | 2.83s |
| `agent-orchestrator-327` (the reported one) | **5.69s** |
| `agent-orchestrator-328` | 6.17s |
| `agent-orchestrator-329` | 12.95s |
| `agent-orchestrator-325` | 8.69s |

Every snapshot poll inside that gap returned `stopped`.

## Test

New coverage, each verified to **fail without the fix and pass with it**:

**`backend/internal/service/chat/startup_controller_state_test.go`** (real SQLite store, no controller ever started)
- `TestSnapshotReportsAStartingControllerRatherThanACrash` — never-started session reports `connecting`
- `TestSnapshotPageReportsAStartingControllerRatherThanACrash` — the paged read the desktop app actually calls
- `TestSnapshotStillReportsStoppedForSessionsThatReallyEnded` — terminated, and agent-process-exited, both still report `stopped` on both read paths
- `TestSnapshotReportsStoppedOnceAConversationExistsWithoutAController` — a conversation with no live controller is the genuine stopped case and keeps its banner

**`frontend/src/renderer/components/chat/ChatWorkspace.test.tsx`**
- brand-new session: no alert, no "Resume agent", no "The controller is not connected"; `role="status"` says "Connecting to the agent…"; composer inert; recovers to a live composer when the controller is ready
- reconnecting controller *with* a conversation keeps its live composer

Verification run:
- `go test ./internal/service/chat/... -count=1` — ok (20.1s)
- `go vet ./internal/service/chat/` — clean
- `npm run test -- src/renderer/components/chat` — 25 files, 513 tests passed
- `npm run typecheck` — 0 errors under `frontend/src` (the reported errors are all in the uninstalled sibling `packages/product-ui` workspace, pre-existing and unrelated)

## Risks / follow-ups

- **The risk this change carries is masking a real failure behind a startup spinner.** It is bounded by using only durable facts: `IsTerminated` and `ActivityExited`. A chat session whose spawn fails without ever setting either would sit on "Connecting to the agent…" rather than "stopped" — a known gap in how lifecycle records "could not" versus "did not" (#4850), not introduced here.
- The topbar half of the same startup gap ("Session workspace is not available") is #4531 / #4532, already merged; untouched here.
- #4573 is the same false-crash presentation for *existing* sessions during desktop restart recovery (conversation exists, controller not yet reconciled). That window is deliberately left reporting `stopped` by this change and needs its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
