### PR TITLE
fix(settings): send support email to prasad with prateek on cc

### DIFF
--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -661,10 +661,10 @@ describe("GlobalSettingsForm", () => {
 
 		await waitFor(() => expect(writeText).toHaveBeenCalledTimes(2));
 		expect(writeText.mock.calls[0][0]).toContain("Daemon: unknown");
-		expect(writeText.mock.calls[1][0]).toContain("To: prateek@untrivial.ai");
+		expect(writeText.mock.calls[1][0]).toContain("To: prasad@untrivial.ai");
 		expect(writeText.mock.calls[1][0]).toContain("AO feedback");
 		expect(openExternal).toHaveBeenCalledWith("https://discord.com/invite/UZv7JjxbwG");
-		expect(openExternal).toHaveBeenCalledWith(expect.stringContaining("mailto:prateek@untrivial.ai"));
+		expect(openExternal).toHaveBeenCalledWith(expect.stringContaining("mailto:prasad@untrivial.ai"));
 		expect(open).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/renderer/lib/report-problem.test.ts
+++ b/frontend/src/renderer/lib/report-problem.test.ts
@@ -99,7 +99,8 @@ describe("report problem drafts", () => {
 		const draft = formatReportProblemDraft({ summary: "", details: "" }, diagnostics, "email");
 
 		expect(draft).toContain("AO feedback");
-		expect(draft).toContain("To: prateek@untrivial.ai");
+		expect(draft).toContain("To: prasad@untrivial.ai");
+		expect(draft).toContain("Cc: prateek@untrivial.ai");
 		expect(draft).toContain("Not provided");
 		expect(draft).toContain("Safe diagnostics");
 		expect(draft).toContain("AO version: 1.2.3-test");
@@ -133,7 +134,8 @@ describe("report problem drafts", () => {
 
 		const email = new URL(reportProblemDestinationUrl(completeInput, diagnostics, "email")!);
 		expect(email.protocol).toBe("mailto:");
-		expect(email.pathname).toBe("prateek@untrivial.ai");
+		expect(email.pathname).toBe("prasad@untrivial.ai");
+		expect(email.searchParams.get("cc")).toBe("prateek@untrivial.ai");
 		expect(email.searchParams.get("subject")).toBe("AO feedback: Terminal keeps reconnecting after daemon restart");
 		expect(email.searchParams.get("body")).toContain("AO feedback");
 		expect(email.searchParams.get("body")).toContain("AO version: 1.2.3-test");

--- a/frontend/src/renderer/lib/report-problem.ts
+++ b/frontend/src/renderer/lib/report-problem.ts
@@ -23,7 +23,8 @@ const REDACTED_LOCAL_URL = "[redacted-local-url]";
 const REDACTED_SECRET = "[redacted-secret]";
 const DISCORD_INVITE_URL = "https://discord.com/invite/UZv7JjxbwG";
 const GITHUB_NEW_ISSUE_URL = "https://github.com/Untrivial-ai/agent-orchestrator/issues/new";
-const SUPPORT_EMAIL = "prateek@untrivial.ai";
+const SUPPORT_EMAIL = "prasad@untrivial.ai";
+const SUPPORT_CC_EMAIL = "prateek@untrivial.ai";
 
 const LOCAL_URL_PATTERN =
 	/(?:\bfile:\/\/\/\S+|\bapp:\/\/renderer\/\S+|\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?\S*)/gi;
@@ -93,6 +94,7 @@ export function formatReportProblemDraft(
 	if (output === "email") {
 		return [
 			`To: ${SUPPORT_EMAIL}`,
+			`Cc: ${SUPPORT_CC_EMAIL}`,
 			`Subject: AO feedback: ${fields.summary}`,
 			"",
 			formatEmailBody(fields, diagnosticsBlock),
@@ -121,6 +123,7 @@ export function reportProblemDestinationUrl(
 	if (output === "discord") return DISCORD_INVITE_URL;
 	if (output === "email") {
 		const url = new URL(`mailto:${SUPPORT_EMAIL}`);
+		url.searchParams.set("cc", SUPPORT_CC_EMAIL);
 		url.searchParams.set("subject", `AO feedback: ${reportTitle(input)}`);
 		url.searchParams.set("body", formatEmailBody(normalizeInput(input), formatDiagnostics(diagnostics)));
 		return url.toString();


### PR DESCRIPTION
## What

Settings → Help → **Report a problem** addressed the email handoff only to `prateek@untrivial.ai`. This makes `prasad@untrivial.ai` the primary recipient and puts `prateek@untrivial.ai` on Cc, so both receive support mail.

## Changes

- `frontend/src/renderer/lib/report-problem.ts` — `SUPPORT_EMAIL` is now `prasad@untrivial.ai`; new `SUPPORT_CC_EMAIL` holds `prateek@untrivial.ai`.
- The copied draft gains a `Cc:` line under `To:`.
- The mailto URL sets a `cc` param: `mailto:prasad@untrivial.ai?cc=prateek%40untrivial.ai&subject=...&body=...`.

Cc was chosen over two comma-separated `To:` addresses because every mail client honors the `cc` param, while classic Outlook for Windows needs "Allow comma as address separator" enabled to parse a multi-recipient `mailto:` path.

No change needed in `frontend/src/main/external-open.ts` — it allowlists the `mailto:` protocol, not a specific address.

## Testing

`npx vitest run src/renderer/lib/report-problem.test.ts src/renderer/components/GlobalSettingsForm.test.tsx` — 44 passed, run on this branch against the latest `main`. Assertions for the recipient and the new Cc were updated in both suites.