### PR TITLE
docs: list OMP among supported coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ AO works with the coding agents and source-control workflow you already use. Age
 
 ## Supported agents
 
-**26 coding agents supported** through one supervised workflow.
+**27 coding agents supported** through one supervised workflow.
 
 <table>
   <tr valign="middle">
@@ -172,7 +172,7 @@ AO works with the coding agents and source-control workflow you already use. Age
   <tr valign="middle">
     <td valign="middle" nowrap><img src="frontend/src/renderer/assets/agents/kimchi.svg" alt="Kimchi" width="24" height="24" align="middle" /> &nbsp; <b>Kimchi</b></td>
     <td valign="middle" nowrap><img src="docs/assets/readme/agents/prime-agent.svg" alt="Prime Agent" width="24" height="24" align="middle" /> &nbsp; <b>Prime Agent</b></td>
-    <td valign="middle" nowrap></td>
+    <td valign="middle" nowrap><img src="frontend/src/renderer/assets/agents/omp.png" alt="OMP" width="24" height="24" align="middle" /> &nbsp; <b>OMP</b></td>
   </tr>
 </table>
 

--- a/frontend/src/landing/content/docs/plugins/agents/index.mdx
+++ b/frontend/src/landing/content/docs/plugins/agents/index.mdx
@@ -7,7 +7,7 @@ AO compiles agent adapters into the daemon. It uses your locally installed agent
 
 ## Shipped terminal harnesses
 
-The daemon registry currently advertises 26 worker harnesses:
+The daemon registry currently advertises 27 worker harnesses:
 
 | | | | |
 | --- | --- | --- | --- |
@@ -17,7 +17,7 @@ The daemon registry currently advertises 26 worker harnesses:
 | `crush` | `aider` | `goose` | `auggie` |
 | `continue` | `devin` | `cline` | `kiro` |
 | `kilocode` | `vibe` | `pi` | `kimchi` |
-| `prime-agent` | `autohand` | | |
+| `prime-agent` | `autohand` | `omp` | |
 
 Run the catalog instead of relying on a static page when scripting:
 


### PR DESCRIPTION
The daemon ships 27 coding-agent adapters, but the README and agent setup index list only 26 and omit OMP. Add OMP with its existing logo and correct both counts to 27.

Validation:
- Checked all 27 README entries against the compiled catalog and verified every image path; the setup index exactly matches the registered harness IDs.
- Previewed the README in AO's Browser panel.
- Landing production build, frontend and E2E typechecks, Cloud client contract/typecheck/tests, and product UI typecheck/tests passed.
- Full frontend suite with the pinned native browser enabled: 4,048 passed, 6 skipped (Node 24, macOS, two workers).
- Renderer smoke suite: 58 passed (Node 24, Playwright v1.60.0-noble Linux container, two workers).
- Initial higher-concurrency runs hit UI timing failures; the affected settings-form test and both complete suites passed on rerun. GitHub CI will independently verify its Linux runner configuration.
- Pinned gitleaks v7.4.0 scanned the new commit with no leaks; React Doctor found no changed source files to scan.

Scope: documentation only. The separately discovered stale Chat-driver table and the research into future harness additions are follow-ups, not part of this PR.
