### PR TITLE
docs: Add commit and PR message skills

### DIFF
--- a/.agents/skills/commit-and-pr-messages/SKILL.md
+++ b/.agents/skills/commit-and-pr-messages/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: commit-and-pr-messages
+description: Write Git commit messages and pull request titles/descriptions for Agent Orchestrator using Chris Beams / Tim Pope conventions (subject/body split, ~50-char subject, imperative mood, why-not-how body) plus Simplified Technical English for bodies and PR text. Use when creating commits, drafting or editing PR descriptions, writing PR titles, or when the user asks for help with commit/PR wording or git history style.
+trigger: User creates or amends a commit message, opens or updates a pull request, or asks for help with commit/PR wording.
+---
+
+# Commit and PR Messages
+
+Write history that future readers can scan, search, and trust. A diff shows
+*what* changed; the message must explain *why*.
+
+Based on [How to Write a Git Commit Message](https://cbea.ms/git-commit/)
+(Chris Beams) and [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+(Tim Pope), adapted for Agent Orchestrator's Conventional Commits and PR hygiene.
+
+**Language:** Write commit bodies and PR text in ASD-STE100 Simplified
+Technical English style. Follow
+[simplified-technical-english](../simplified-technical-english/SKILL.md)
+before you finalize wording.
+
+## When to use
+
+- Creating or amending a commit message
+- Opening or updating a pull request (title and body)
+- Reviewing whether a PR description is useful to reviewers
+
+## Commit messages — seven rules
+
+1. **Separate subject from body with a blank line.**
+2. **Limit the subject line to ~50 characters** (72 hard max). Use the
+   Conventional Commits shape this repo uses:
+   `type(scope): Imperative summary`. Keep the whole subject readable.
+3. **Capitalize the subject line** after the type prefix
+   (`fix(board): Stop spinner on settled session cards`).
+4. **Do not end the subject line with a period.**
+5. **Use the imperative mood in the subject line** — as if completing:
+   *If applied, this commit will ________.*
+   Prefer `Fix`, `Add`, `Remove`, `Refactor` over `Fixed`, `Adds`, `Fixing`.
+6. **Wrap the body at 72 characters.**
+7. **Use the body to explain what and why, not how.** The code shows how.
+   Cover motivation, prior behavior, trade-offs, and non-obvious side effects.
+
+### Model commit
+
+```text
+Capitalized, short (50 chars or less) summary
+
+More detailed explanatory text, if necessary. Wrap it to about 72
+characters or so. The blank line after the subject is mandatory when a
+body is present.
+
+Explain the problem this commit solves and why this approach was chosen.
+Leave mechanical how-details to the diff unless the approach is surprising.
+
+Further paragraphs come after blank lines.
+
+- Bullet points are okay
+
+Fixes #123
+```
+
+### Agent Orchestrator commit extras
+
+- Use the types from [AGENTS.md](../../../AGENTS.md): `feat:`, `fix:`,
+  `docs:`, `test:`, `chore:`. Add a scope for the area when it helps:
+  `fix(onboarding): …`, `fix(board): …`, `fix(desktop): …`,
+  `fix(mobile): …`, `fix(chat): …`, `feat(board): …`.
+- **Do not add a DCO `Signed-off-by` trailer.** This repo does not use DCO.
+  Preserve `Co-authored-by:` trailers when co-authors exist.
+- Put issue references at the end of the body (`Fixes #123`, `Closes #123`).
+  Do not stuff them into the subject and do not invent ticket IDs.
+- Keep one logical change per commit when practical. If the subject is hard
+  to write, the commit may be doing too much.
+- Squash context: GitHub appends `(#NNNN)` to the squash-commit subject from
+  the PR number. Do not hand-write `(#NNNN)` in the PR title field.
+
+## Pull request titles
+
+PR titles are the public subject line for a whole change set, and they become
+the squash-commit subject.
+
+- Start with a Conventional Commits prefix: `feat:`, `fix:`, `docs:`,
+  `test:`, or `chore:`, plus a scope when it helps (`fix(board): …`).
+- After the prefix, write an imperative, capitalized summary with no trailing
+  period — same mood test as commits.
+- Keep the title scannable; put nuance in the body, not a novel in the title.
+
+**Good:** `fix(board): Stop spinner on settled session cards`
+**Good:** `feat: Create GitHub repository during project import`
+**Weak:** `fix: Updated some stuff for onboarding`
+**Weak:** `Fixed the bug.`
+
+## Pull request descriptions
+
+New PRs are prefilled from `.github/pull_request_template.md`. Fill that
+template; do not replace it with another shape. Lead with purpose; do not
+narrate the diff file-by-file. Write `Why` and `Testing` in STE
+([simplified-technical-english](../simplified-technical-english/SKILL.md)).
+
+### Required shape (the repo template)
+
+```markdown
+## What
+
+<1–3 STE sentences: the change in present orientation.>
+
+## Why
+
+<Problem this solves and motivation. Reference the issue, for example
+`Fixes #123`. State before/after behavior and impact.>
+
+## How
+
+<Key implementation decisions, trade-offs, and reviewer focus areas.
+Call out intentional omissions, especially versus older TypeScript
+behavior, when relevant. This is the only section for approach detail.>
+
+## Testing
+
+<How you validated the change: commands, scenarios, screenshots for UI.
+Use STE procedural steps: max 20 words, one imperative instruction each.>
+
+## Checklist
+
+<Keep the template checklist current: branch base, focus, conventions,
+tests, CI for the area touched.>
+```
+
+### Writing rules
+
+- **STE first.** Short sentences, active voice, no contractions, no slang.
+- **Why over how.** State the before/after behavior and the reason for the
+  change outside `How`. Mention approach only in `How`, and only what a
+  reviewer needs.
+- **Present / imperative orientation.** Describe what the PR *does*
+  (`Adds…`, `Fixes…`, `Removes…`), not a diary of yesterday's work.
+- **Honest scope.** Call out follow-ups, known gaps, and intentional
+  non-goals. Per [AGENTS.md](../../../AGENTS.md) PR hygiene, explain
+  intentional omissions versus the old TypeScript behavior when relevant.
+- **One issue per PR.** Branch from `main` unless continuing an existing PR
+  branch. Link the related issue when applicable.
+- **Scannable.** Short paragraphs or bullets; no wall of implementation notes
+  that duplicates the diff.
+- **Link context.** Reference issues (`Fixes #123`) when they exist; do not
+  invent ticket IDs.
+
+### Avoid
+
+- Subject-only PRs with an empty or placeholder body when the change needs
+  context
+- Restating every file touched (`Updated Foo.go, Bar.tsx, …`)
+- Past-tense changelog dumping with no problem statement
+- Marketing or hype language
+
+### Quick quality check
+
+Before submitting a PR description, confirm:
+
+- [ ] Title completes: *If merged, this PR will ________.*
+- [ ] `Why` explains **why**, not a file list
+- [ ] `How` covers decisions, trade-offs, and intentional omissions
+- [ ] `Why` and `Testing` obey STE sentence limits and style
+- [ ] `Testing` has actionable checks (commands, scenarios, screenshots for UI)
+- [ ] No trailing period / non-imperative mush in the title
+- [ ] Body still makes sense months later without the author present
+- [ ] [AGENTS.md](../../../AGENTS.md) PR hygiene holds: correct base,
+      one focused change, conventions followed, tests added where useful,
+      relevant CI checks addressed

--- a/.agents/skills/simplified-technical-english/SKILL.md
+++ b/.agents/skills/simplified-technical-english/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: simplified-technical-english
+description: Write reviewer-facing and user-facing technical text for Agent Orchestrator in ASD-STE100 Simplified Technical English style. Use when drafting PR descriptions, commit message bodies, docs, runbooks, error messages, or any technical wording that must stay clear for non-native readers.
+trigger: User drafts or edits a PR description, commit body, docs page, runbook, or error message, or asks for clear technical wording.
+---
+
+# Simplified Technical English (ASD-STE100)
+
+Write clear, unambiguous technical English. Prefer STE writing rules over clever
+or idiomatic phrasing.
+
+This skill applies **STE writing rules** (grammar and style). It does **not**
+embed the copyrighted STE dictionary (~900 approved words). Use simple words
+with one clear meaning; use Agent Orchestrator **technical nouns** for product
+terms. For full dictionary compliance, consult the official standard:
+[ASD-STE100](https://asd-ste100.org/).
+
+Source: ASD-STE100 Issue 9 (January 2025), Standard for technical documentation.
+ASD owns the STE trademark and standard; this skill is an operational distillation
+for agents, not a substitute for the official document.
+
+## When this applies
+
+| Text | STE mode |
+| --- | --- |
+| PR body (`What`, `Why`, `Testing`) | Descriptive + procedural |
+| Commit message **body** | Descriptive |
+| Docs, runbooks, onboarding steps | Procedural and/or descriptive |
+| Error messages, confirmations, helper text | Procedural / short descriptive |
+
+**Exceptions (do not rewrite these into STE):**
+
+- Conventional Commits type prefixes (`feat:`, `fix:`, …)
+- Code identifiers, API paths, table names, log lines, and quoted error codes
+- Proper nouns and product names (`Agent Orchestrator`, `AO`, `GitHub`, `Electron`)
+- Issue IDs and `Co-authored-by:` trailers
+
+## Core rules (must follow)
+
+### Words
+
+1. Prefer plain words with **one meaning**. Do not use synonyms for the same idea
+   in the same surface (`start` vs `begin` vs `initiate` — pick one and keep it).
+2. Keep **one technical noun per concept**. Use Agent Orchestrator vocabulary
+   consistently (see list below). Spell the product **Agent Orchestrator** or
+   **AO**; do not invent variants.
+3. Do not use slang, idioms, humor, or jargon that the reader cannot act on.
+4. Use **American English** spelling.
+5. Prefer verbs for actions. Do not hide actions in nouns
+   (`Create a session`, not `Perform session creation`).
+6. Keep multi-word technical nouns to **three words or fewer** when you invent
+   a phrase (`session spawn step`, not `daemon session spawn lifecycle workflow step`).
+
+### Verbs and voice
+
+1. Prefer these forms: infinitive, **imperative**, simple present, simple past,
+   simple future (`will`), past participle as adjective.
+2. Avoid complex constructions: progressive (`is creating`), perfect
+   (`has created`), and stacked auxiliaries when a simple form works.
+3. Use the **active voice**. Use passive only in descriptive text when the actor
+   is unknown.
+4. Instructions and button labels use the **imperative** (`Start the daemon`,
+   `Delete the session`).
+
+### Sentences
+
+1. Write short, clear sentences. Do not omit necessary words or use contractions
+   to fake brevity (`do not`, not `don't`; `cannot`, not `can't`).
+2. **Procedures / instructions / test steps:** maximum **20 words** per sentence.
+   One instruction per sentence unless two actions occur at the same time.
+3. **Descriptions** (PR `What`/`Why`, commit bodies, notes): maximum **25 words**
+   per sentence.
+4. One topic per paragraph; keep paragraphs short (about six sentences or fewer).
+5. Use a vertical list when a sentence would list many items or steps.
+6. Give information gradually: problem or goal first, then necessary detail.
+
+### Procedural pattern
+
+When the reader must do something (test plan, runbook steps, recovery text):
+
+```text
+If the condition is true, do the action.
+```
+
+- Put the condition first when the reader must know it before acting.
+- Separate condition and command with a comma.
+- Name the object and the outcome (`Delete "Fix login flow".`).
+
+## Agent Orchestrator technical nouns (approved for PRs and docs)
+
+Use these as stable technical nouns. Do not invent synonyms for the same thing:
+
+- Agent Orchestrator
+- AO
+- daemon
+- session
+- project
+- workspace
+- worktree
+- harness
+- runtime
+- lifecycle
+- supervisor
+- board
+- chat
+- observer
+- reaper
+- controller
+- handoff
+
+Code-only names (package paths, harness names, table names, port names) stay
+out of prose unless the reader must act on them.
+
+## Before / after
+
+**Weak (not STE):**
+`We've basically reworked how the onboarding bits kinda wire up GitHub login and stuff so it's nicer.`
+
+**STE:**
+`This change starts the GitHub login terminal automatically.`
+`The new flow shows auth status and the next required step.`
+
+**Weak PR test step:**
+`Just make sure everything still works when you click around importing a workspace and then going back.`
+
+**STE test step:**
+`- [ ] Import a workspace from the onboarding screen.`
+`- [ ] Confirm the board shows the new session.`
+`- [ ] Go back one step and confirm the session stays ready.`
+
+**Weak error:**
+`Oops! Something went wrong on our end.`
+
+**STE error:**
+`AO could not connect to the daemon.`
+`Check that the daemon runs on 127.0.0.1:3001 and try again.`
+
+## Quality checklist
+
+- [ ] Sentences stay within 20 words (instructions) or 25 words (descriptions)
+- [ ] Active voice; imperative for commands
+- [ ] No contractions, slang, idioms, or hype
+- [ ] One term per concept; Agent Orchestrator vocabulary is consistent
+- [ ] Lists used when steps or items would crowd a sentence
+- [ ] PR/commit text explains **why** without narrative filler
+- [ ] Error text states the action, object, and outcome
+
+## Related skills
+
+- PR titles, commit subjects, and PR structure:
+  [commit-and-pr-messages](../commit-and-pr-messages/SKILL.md)

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ frontend/agent-browser/
 !.agents/skills/bug-triage/**
 !.agents/skills/commit-and-pr-messages/
 !.agents/skills/commit-and-pr-messages/**
+!.agents/skills/simplified-technical-english/
+!.agents/skills/simplified-technical-english/**
 skills-lock.json
 
 # e2e pod gate: downloaded pod logs/traces (uploaded as CI artifacts, not committed)

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ frontend/agent-browser/
 !.agents/skills/ao-desktop-dev/**
 !.agents/skills/bug-triage/
 !.agents/skills/bug-triage/**
+!.agents/skills/commit-and-pr-messages/
+!.agents/skills/commit-and-pr-messages/**
 skills-lock.json
 
 # e2e pod gate: downloaded pod logs/traces (uploaded as CI artifacts, not committed)


### PR DESCRIPTION
## What

Adds two curated agent skills under .agents/skills: commit-and-pr-messages and simplified-technical-english. Both adapt upstream SuperPlane skills to Agent Orchestrator conventions. Extends the .gitignore curated-skills allowlist so both paths stay committable.

## Why

Agents who write commits and PRs in this repo had no shared wording standard. The upstream skills assume a DCO trailer and a Summary/Test-plan PR shape. Both conflict with this repo template and history. This change gives agents AO-native rules and STE wording for reviewer-facing text.

## How

- Kept the Beams/Pope seven rules and the STE rule skeleton. Replaced product nouns, trailers, and PR shape with AO equivalents. Verified each choice against git log, the PR template, and AGENTS.md.
- Intentional omissions: no .claude/skills mirror, no DCO trailer, no Summary/Test-plan enforcement, no UI-microcopy scope, no docs-index updates.
- Reviewer focus: SKILL.md wording accuracy and the .gitignore allowlist additions.

## Testing

- Ran git status and confirmed only the two skills plus .gitignore changed.
- Searched both skills for SuperPlane leftovers and confirmed none remain.
- Confirmed AGENTS.md relative links resolve from the new skill paths.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; no related issue (user-requested skills work)
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense (docs-only change, nothing to test)
- [ ] Relevant CI checks pass for the area touched (pending CI)