### PR TITLE
fix: join telemetry aggregation before downstream shutdown

### DIFF
--- a/backend/internal/adapters/telemetry/aggregate.go
+++ b/backend/internal/adapters/telemetry/aggregate.go
@@ -30,7 +30,12 @@ type AggregatingSink struct {
 	mu      sync.Mutex
 	buckets map[string]*aggBucket
 	closed  bool
-	done    chan struct{}
+
+	done      chan struct{}
+	flushDone chan struct{}
+	closeOnce sync.Once
+	closeDone chan struct{}
+	closeErr  error
 }
 
 type aggBucket struct {
@@ -54,6 +59,8 @@ func NewAggregatingSink(next ports.EventSink, names []string, flushEvery time.Du
 		flushEvery: flushEvery,
 		buckets:    make(map[string]*aggBucket),
 		done:       make(chan struct{}),
+		flushDone:  make(chan struct{}),
+		closeDone:  make(chan struct{}),
 	}
 	go s.flushLoop()
 	return s
@@ -69,6 +76,10 @@ func (s *AggregatingSink) Emit(ctx context.Context, ev ports.TelemetryEvent) {
 	}
 
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
 	b, ok := s.buckets[ev.Name]
 	if !ok {
 		b = &aggBucket{windowStart: time.Now()}
@@ -80,6 +91,7 @@ func (s *AggregatingSink) Emit(ctx context.Context, ev ports.TelemetryEvent) {
 }
 
 func (s *AggregatingSink) flushLoop() {
+	defer close(s.flushDone)
 	ticker := time.NewTicker(s.flushEvery)
 	defer ticker.Stop()
 	for {
@@ -126,18 +138,28 @@ func (s *AggregatingSink) flush(ctx context.Context) {
 	}
 }
 
-// Close stops the flush loop, emits one final rollup for anything buffered
-// since the last tick, and closes the wrapped sink.
+// Close stops and joins the flush loop before the final rollup and downstream
+// close. Calls share the first close operation and its result. A canceled caller
+// may stop waiting while shutdown continues in that order.
 func (s *AggregatingSink) Close(ctx context.Context) error {
-	s.mu.Lock()
-	if s.closed {
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
 		s.mu.Unlock()
-		return s.next.Close(ctx)
-	}
-	s.closed = true
-	s.mu.Unlock()
 
-	close(s.done)
-	s.flush(ctx)
-	return s.next.Close(ctx)
+		close(s.done)
+		go func() {
+			<-s.flushDone
+			s.flush(ctx)
+			s.closeErr = s.next.Close(ctx)
+			close(s.closeDone)
+		}()
+	})
+
+	select {
+	case <-s.closeDone:
+		return s.closeErr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/backend/internal/adapters/telemetry/aggregate_test.go
+++ b/backend/internal/adapters/telemetry/aggregate_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -150,5 +151,213 @@ func TestAggregatingSinkClosedTwiceDoesNotFlushAgain(t *testing.T) {
 
 	if got := len(rec.snapshot()); got != 1 {
 		t.Fatalf("events after double Close = %d, want 1 (no duplicate rollup)", got)
+	}
+}
+
+type blockingFlushSink struct {
+	emitStarted  chan struct{}
+	releaseEmit  chan struct{}
+	closeStarted chan struct{}
+	closeErr     error
+
+	emitOnce        sync.Once
+	closeOnce       sync.Once
+	releaseOnce     sync.Once
+	mu              sync.Mutex
+	closes          int
+	counts          []int
+	emitsAfterClose int
+}
+
+func (s *blockingFlushSink) Emit(_ context.Context, ev ports.TelemetryEvent) {
+	s.emitOnce.Do(func() { close(s.emitStarted) })
+	<-s.releaseEmit
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closes > 0 {
+		s.emitsAfterClose++
+	}
+	count, _ := ev.Payload["count"].(int)
+	s.counts = append(s.counts, count)
+}
+
+func (s *blockingFlushSink) unblock() {
+	s.releaseOnce.Do(func() { close(s.releaseEmit) })
+}
+
+func (s *blockingFlushSink) Close(context.Context) error {
+	s.mu.Lock()
+	s.closes++
+	s.mu.Unlock()
+	s.closeOnce.Do(func() { close(s.closeStarted) })
+	return s.closeErr
+}
+
+func (s *blockingFlushSink) closeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closes
+}
+
+func newBlockedAggregatingSink(t *testing.T, closeErr error) (*AggregatingSink, *blockingFlushSink) {
+	t.Helper()
+	next := &blockingFlushSink{
+		emitStarted:  make(chan struct{}),
+		releaseEmit:  make(chan struct{}),
+		closeStarted: make(chan struct{}),
+		closeErr:     closeErr,
+	}
+	sink := NewAggregatingSink(next, []string{"ao.http.5xx"}, time.Millisecond)
+	t.Cleanup(func() {
+		next.unblock()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = sink.Close(ctx)
+	})
+	sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.http.5xx"})
+	select {
+	case <-next.emitStarted:
+	case <-time.After(time.Second):
+		t.Fatal("ticker flush did not reach downstream sink")
+	}
+	return sink, next
+}
+
+func TestAggregatingSinkCloseJoinsTickerFlushAndSharesResult(t *testing.T) {
+	downstreamErr := errors.New("downstream close failed")
+	sink, next := newBlockedAggregatingSink(t, downstreamErr)
+	// The ticker already owns the first window. These belong to the final one.
+	sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.http.5xx"})
+	sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.http.5xx"})
+
+	beginClose := make(chan struct{})
+	callersReady := make(chan struct{}, 2)
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			callersReady <- struct{}{}
+			<-beginClose
+			results <- sink.Close(context.Background())
+		}()
+	}
+	<-callersReady
+	<-callersReady
+	close(beginClose)
+
+	closedBeforeFlushFinished := false
+	select {
+	case <-next.closeStarted:
+		closedBeforeFlushFinished = true
+	case <-time.After(50 * time.Millisecond):
+	}
+	next.unblock()
+
+	for range 2 {
+		select {
+		case err := <-results:
+			if !errors.Is(err, downstreamErr) {
+				t.Errorf("Close() error = %v, want %v", err, downstreamErr)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Close() did not finish after ticker flush was released")
+		}
+	}
+	if closedBeforeFlushFinished {
+		t.Error("downstream Close started before the ticker flush finished")
+	}
+	if got := next.closeCount(); got != 1 {
+		t.Errorf("downstream Close calls = %d, want 1", got)
+	}
+	next.mu.Lock()
+	defer next.mu.Unlock()
+	if next.emitsAfterClose != 0 {
+		t.Errorf("rollups emitted after downstream close = %d, want 0", next.emitsAfterClose)
+	}
+	if len(next.counts) != 2 || next.counts[0] != 1 || next.counts[1] != 2 {
+		t.Errorf("rollup counts = %v, want [1 2]", next.counts)
+	}
+}
+
+func TestAggregatingSinkCloseJoinsTickerWithoutFinalBucket(t *testing.T) {
+	sink, next := newBlockedAggregatingSink(t, nil)
+	// The ticker already owns the only bucket. A final flush has no Emit
+	// to block on, so only joining the ticker can hold downstream Close.
+	result := make(chan error, 1)
+	go func() { result <- sink.Close(context.Background()) }()
+
+	select {
+	case <-next.closeStarted:
+		t.Error("downstream Close started while the ticker's only rollup was blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+	next.unblock()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close() did not finish after ticker flush was released")
+	}
+	next.mu.Lock()
+	defer next.mu.Unlock()
+	if next.closes != 1 || next.emitsAfterClose != 0 {
+		t.Errorf("downstream closes = %d, emits after close = %d; want 1 and 0", next.closes, next.emitsAfterClose)
+	}
+	if len(next.counts) != 1 || next.counts[0] != 1 {
+		t.Errorf("rollup counts = %v, want [1]", next.counts)
+	}
+}
+
+func TestAggregatingSinkCanceledCloseLeavesShutdownForLaterCaller(t *testing.T) {
+	downstreamErr := errors.New("downstream close failed")
+	sink, next := newBlockedAggregatingSink(t, downstreamErr)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := sink.Close(canceled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Close(canceled) error = %v, want context canceled", err)
+	}
+	select {
+	case <-next.closeStarted:
+		t.Fatal("downstream Close started while the ticker flush was blocked")
+	default:
+	}
+
+	laterResult := make(chan error, 1)
+	go func() { laterResult <- sink.Close(context.Background()) }()
+	select {
+	case err := <-laterResult:
+		t.Fatalf("later Close returned before the ticker flush finished: %v", err)
+	default:
+	}
+
+	next.unblock()
+	select {
+	case err := <-laterResult:
+		if !errors.Is(err, downstreamErr) {
+			t.Fatalf("later Close error = %v, want %v", err, downstreamErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("later Close did not observe shutdown completion")
+	}
+	if got := next.closeCount(); got != 1 {
+		t.Errorf("downstream Close calls = %d, want 1", got)
+	}
+}
+
+func TestAggregatingSinkDiscardsAggregatedEventsAfterClose(t *testing.T) {
+	rec := &syncRecordingSink{}
+	sink := NewAggregatingSink(rec, []string{"ao.http.5xx"}, time.Hour)
+	if err := sink.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for range 100 {
+		sink.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.http.5xx"})
+	}
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.buckets) != 0 {
+		t.Fatalf("closed aggregator retained %d buckets without a flush loop", len(sink.buckets))
 	}
 }


### PR DESCRIPTION
## What

Wait for the telemetry aggregation ticker to finish its active flush before sending the final rollup and closing the downstream sink. Concurrent `Close` callers share one shutdown operation.

## Why

If shutdown starts while a ticker flush is emitting, the previous implementation could close the destination before that flush finished. It also called downstream `Close` again for subsequent callers. This addresses the aggregation portion of backend audit finding AD-02.

## How

- Join the flush loop, flush the remaining buckets, then close downstream exactly once.
- Stop accepting aggregated events when shutdown starts. Preserve immediate forwarding for event names outside the aggregation set.
- Let each caller stop waiting when its context is canceled. Shutdown continues in order using the first caller's context; delivery remains best effort.

Companion to #5112, which protects destination queues against concurrent and late emitters. This branch is independently based on `main` and has no code dependency on #5112. Prefer merging #5112 first because pass-through events and other emitters still need its destination protection. Both changes are needed to complete AD-02.

## Testing

Local validation passed at `23add584f853` on Linux. The checked-in workspace selected Go 1.26.5. Test subprocesses used a clean environment with a POSIX shell and isolated tmux sockets.

Added regressions cover a blocked ticker flush during shutdown, final rollup ordering, concurrent close callers, downstream errors, caller cancellation and late aggregated events.

Focused verification command, from `backend/`:

```sh
go test -race ./internal/adapters/telemetry/...
```

Complete backend checks passed: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race -timeout=15m ./...`, and golangci-lint v2.12.2 with zero findings. The full native Linux CLI suite passed with `go test -tags e2e -v ./internal/cli/...`.

The API drift workflow passed using Node 24.20.0: `npm ci`, `npm run api`, and byte comparison of both generated artifacts. The pinned gitleaks v7.4.0 scan covered this PR commit and reported no leaks. The unchanged fresh-install Dockerfile built successfully, and its container smoke check passed.

Native macOS and Windows execution is pending remote CI because this host is Linux. Remote checks have not run before publication.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
