### PR TITLE
fix: propagate conversation storage lookup errors

### DIFF
--- a/backend/internal/storage/sqlite/store/conversation_errors_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_errors_test.go
@@ -1,0 +1,234 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sqlitedriver "modernc.org/sqlite"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/sqlitetest"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/store"
+)
+
+type conversationQueryFailure struct {
+	query string
+	err   error
+}
+
+type conversationQueryFailureKey struct{}
+
+// Fail only the named query, including inside a real SQLite transaction. Other
+// queries still reach the migrated database so swallowed failures can commit
+// orphan projections on the broken implementation.
+type conversationErrorConnector struct{ path string }
+
+func (c conversationErrorConnector) Driver() driver.Driver { return &sqlitedriver.Driver{} }
+
+func (c conversationErrorConnector) Connect(context.Context) (driver.Conn, error) {
+	conn, err := c.Driver().Open(c.path)
+	if err != nil {
+		return nil, err
+	}
+	return conversationErrorConn{Conn: conn}, nil
+}
+
+type conversationErrorConn struct{ driver.Conn }
+
+func (c conversationErrorConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if failure, ok := ctx.Value(conversationQueryFailureKey{}).(conversationQueryFailure); ok &&
+		strings.HasPrefix(query, "-- name: "+failure.query+" ") {
+		return nil, failure.err
+	}
+	return c.Conn.(driver.QueryerContext).QueryContext(ctx, query, args)
+}
+
+func conversationErrorFixture(t *testing.T) (*store.Store, domain.SessionID, string) {
+	t.Helper()
+	dir := t.TempDir()
+	migrated, err := sqlitetest.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := migrated.Close(); err != nil {
+		t.Fatal(err)
+	}
+	connector := conversationErrorConnector{path: filepath.Join(dir, "ao.db") + "?_pragma=foreign_keys(ON)&_pragma=journal_mode(WAL)"}
+	writer, reader := sql.OpenDB(connector), sql.OpenDB(connector)
+	writer.SetMaxOpenConns(1)
+	s := store.NewStore(writer, reader)
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	seedProject(t, s, "query-errors")
+	record := sampleRecord("query-errors")
+	record.Mode = domain.SessionModeChat
+	record.Metadata.ControllerGeneration = "generation"
+	session, err := s.CreateSession(context.Background(), record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conversation, err := s.CreateConversation(context.Background(), "conversation", domain.ConversationScopeSession,
+		"query-errors", session.ID, histClock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := s.AppendUserMessage(context.Background(), conversation.ID, session.ID, "generation",
+		domain.ConversationMessage{ID: "prompt", Text: "hello", Origin: domain.MessageOriginHuman}, "turn", histClock)
+	if err != nil || !created {
+		t.Fatalf("seed prompt: created=%v err=%v", created, err)
+	}
+	if err := s.BindTurnToProvider(context.Background(), "turn", "provider-turn", histClock); err != nil {
+		t.Fatal(err)
+	}
+	return s, session.ID, conversation.ID
+}
+
+func TestConversationSnapshotPropagatesHistoryQueryErrors(t *testing.T) {
+	for _, query := range []string{"SelectConversationBranches", "SelectConversationNativeForkAvailableAfterSequence"} {
+		for _, paged := range []bool{false, true} {
+			name := "whole/"
+			if paged {
+				name = "page/"
+			}
+			t.Run(name+query, func(t *testing.T) {
+				s, _, conversation := conversationErrorFixture(t)
+				for _, queryErr := range []error{errors.New("injected SQLite query failure"), context.Canceled, context.DeadlineExceeded} {
+					ctx := context.WithValue(context.Background(), conversationQueryFailureKey{}, conversationQueryFailure{query, queryErr})
+					var snapshot store.ConversationSnapshot
+					var err error
+					if paged {
+						snapshot, err = s.LoadConversationSnapshotPage(ctx, conversation, 0, 1)
+					} else {
+						snapshot, err = s.LoadConversationSnapshot(ctx, conversation)
+					}
+					if !errors.Is(err, queryErr) {
+						t.Errorf("snapshot error = %v, want %v", err, queryErr)
+					}
+					if snapshot.Conversation.ID != "" || len(snapshot.Messages) != 0 {
+						t.Errorf("query failure returned conversation %q with %d messages", snapshot.Conversation.ID, len(snapshot.Messages))
+					}
+				}
+			})
+		}
+	}
+}
+
+func writeConversationErrorProjection(ctx context.Context, s *store.Store, conversation, providerTurn, kind string) error {
+	switch kind {
+	case "delta":
+		return s.AppendAssistantDelta(ctx, conversation, "provider-item", providerTurn, "answer", "answer", histClock)
+	case "settled":
+		return s.SettleAssistantMessage(ctx, conversation, "provider-item", providerTurn, "answer", "answer", histClock)
+	default:
+		return s.UpsertActivity(ctx, conversation, providerTurn, domain.ConversationActivity{
+			ID: "activity", ProviderItemID: "provider-item", Kind: domain.ActivityKindCommand,
+			Status: domain.ActivityStatusRunning, Summary: "go test", Detail: []byte(`{}`),
+		}, histClock)
+	}
+}
+
+func TestConversationProjectionPropagatesTurnQueryErrors(t *testing.T) {
+	for _, kind := range []string{"delta", "settled", "activity"} {
+		for _, archived := range []bool{false, true} {
+			name := kind + "/direct"
+			if archived {
+				name = kind + "/archived"
+			}
+			t.Run(name, func(t *testing.T) {
+				for _, queryErr := range []error{errors.New("injected SQLite turn lookup failure"), context.Canceled, context.DeadlineExceeded} {
+					s, session, conversation := conversationErrorFixture(t)
+					ctx := context.WithValue(context.Background(), conversationQueryFailureKey{}, conversationQueryFailure{
+						query: "SelectConversationTurnByProviderID", err: queryErr,
+					})
+					project := func(ctx context.Context) error {
+						return writeConversationErrorProjection(ctx, s, conversation, "provider-turn", kind)
+					}
+					var err error
+					if archived {
+						var applied bool
+						applied, err = s.ProjectProviderEvent(ctx, conversation, session, "generation", "event", "item", `{}`, histClock, project)
+						if applied {
+							t.Error("failed projection was reported as applied")
+						}
+					} else {
+						err = project(ctx)
+					}
+					if !errors.Is(err, queryErr) {
+						t.Errorf("projection error = %v, want %v", err, queryErr)
+					}
+					snapshot, err := s.LoadConversationSnapshot(context.Background(), conversation)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if len(snapshot.Messages) != 1 || len(snapshot.Activities) != 0 || snapshot.Conversation.LatestSequence != 1 {
+						t.Errorf("failed lookup left %d messages, %d activities, sequence %d; want 1/0/1",
+							len(snapshot.Messages), len(snapshot.Activities), snapshot.Conversation.LatestSequence)
+					}
+					events, err := s.ProviderEventsSince(context.Background(), conversation, 0, 10)
+					if err != nil || len(events) != 0 {
+						t.Errorf("failed projection archive = %+v, %v; want empty", events, err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestConversationProjectionPreservesTurnAssociation(t *testing.T) {
+	for _, kind := range []string{"delta", "settled", "activity"} {
+		for _, tc := range []struct{ name, providerTurn, wantTurn string }{
+			{"known", "provider-turn", "turn"},
+			{"unknown", "unknown-provider-turn", ""},
+			{"empty", "", ""},
+		} {
+			t.Run(kind+"/"+tc.name, func(t *testing.T) {
+				s, session, conversation := conversationErrorFixture(t)
+				ctx := context.Background()
+				if tc.providerTurn == "" {
+					// Empty IDs need no lookup, even if that query is unavailable.
+					ctx = context.WithValue(ctx, conversationQueryFailureKey{}, conversationQueryFailure{
+						query: "SelectConversationTurnByProviderID", err: errors.New("unexpected turn lookup"),
+					})
+				}
+				applied, err := s.ProjectProviderEvent(ctx, conversation, session, "generation", "event", "item", `{}`, histClock,
+					func(ctx context.Context) error {
+						return writeConversationErrorProjection(ctx, s, conversation, tc.providerTurn, kind)
+					})
+				if err != nil || !applied {
+					t.Fatalf("projection: applied=%v err=%v", applied, err)
+				}
+				snapshot, err := s.LoadConversationSnapshot(context.Background(), conversation)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var turnID string
+				if kind == "activity" {
+					if len(snapshot.Activities) != 1 {
+						t.Fatalf("activities = %+v, want one", snapshot.Activities)
+					}
+					turnID = snapshot.Activities[0].TurnID
+				} else {
+					if len(snapshot.Messages) != 2 {
+						t.Fatalf("messages = %+v, want prompt and answer", snapshot.Messages)
+					}
+					turnID = snapshot.Messages[1].TurnID
+				}
+				if turnID != tc.wantTurn {
+					t.Errorf("projection turn = %q, want %q", turnID, tc.wantTurn)
+				}
+				events, err := s.ProviderEventsSince(context.Background(), conversation, 0, 10)
+				if err != nil || len(events) != 1 {
+					t.Errorf("projection archive = %+v, %v; want one", events, err)
+				}
+			})
+		}
+	}
+}

--- a/backend/internal/storage/sqlite/store/conversation_store.go
+++ b/backend/internal/storage/sqlite/store/conversation_store.go
@@ -1942,7 +1942,10 @@ func (s *Store) AppendAssistantDelta(
 		return nil
 
 	case errors.Is(err, sql.ErrNoRows):
-		turnID := s.turnIDFor(ctx, conversationID, providerTurnID)
+		turnID, lookupErr := s.turnIDFor(ctx, conversationID, providerTurnID)
+		if lookupErr != nil {
+			return lookupErr
+		}
 		return s.inTx(ctx, "insert assistant message", func(q *gen.Queries) error {
 			sequence, seqErr := q.NextConversationSequence(ctx, gen.NextConversationSequenceParams{
 				UpdatedAt: now,
@@ -1989,7 +1992,10 @@ func (s *Store) SettleAssistantMessage(
 	if errors.Is(err, sql.ErrNoRows) {
 		// A message whose deltas AO never saw — possible if it completed inside a
 		// reconnect window. Record it whole rather than dropping it.
-		turnID := s.turnIDFor(ctx, conversationID, providerTurnID)
+		turnID, lookupErr := s.turnIDFor(ctx, conversationID, providerTurnID)
+		if lookupErr != nil {
+			return lookupErr
+		}
 		return s.inTx(ctx, "insert assistant message", func(q *gen.Queries) error {
 			sequence, seqErr := q.NextConversationSequence(ctx, gen.NextConversationSequenceParams{
 				UpdatedAt: now,
@@ -2064,7 +2070,10 @@ func (s *Store) UpsertActivity(
 		}
 	}
 
-	turnID := s.turnIDFor(ctx, conversationID, providerTurnID)
+	turnID, err := s.turnIDFor(ctx, conversationID, providerTurnID)
+	if err != nil {
+		return err
+	}
 	return s.inTx(ctx, "insert activity", func(q *gen.Queries) error {
 		sequence, seqErr := q.NextConversationSequence(ctx, gen.NextConversationSequenceParams{
 			UpdatedAt: now,
@@ -2548,7 +2557,10 @@ func (s *Store) LoadConversationSnapshotPage(
 	if err != nil {
 		return ConversationSnapshot{}, err
 	}
-	presentation := s.conversationHistoryPresentation(ctx, conversationID)
+	presentation, err := s.conversationHistoryPresentation(ctx, conversationID)
+	if err != nil {
+		return ConversationSnapshot{}, err
+	}
 	if beforeSequence <= visibleAfterSequence {
 		snapshot := ConversationSnapshot{
 			Conversation:                     conversationToDomain(conv),
@@ -2752,7 +2764,10 @@ func (s *Store) LoadConversationSnapshot(
 		return ConversationSnapshot{}, fmt.Errorf("select activities: %w", err)
 	}
 
-	presentation := s.conversationHistoryPresentation(ctx, conversationID)
+	presentation, err := s.conversationHistoryPresentation(ctx, conversationID)
+	if err != nil {
+		return ConversationSnapshot{}, err
+	}
 	snapshot := ConversationSnapshot{
 		Conversation:                     conversationToDomain(conv),
 		ActiveBranch:                     presentation.activeBranch,
@@ -2818,10 +2833,10 @@ func (p conversationHistoryPresentation) filterInactiveProviderTurn(turn *domain
 func (s *Store) conversationHistoryPresentation(
 	ctx context.Context,
 	conversationID string,
-) conversationHistoryPresentation {
+) (conversationHistoryPresentation, error) {
 	branches, err := s.ConversationBranches(ctx, conversationID)
 	if err != nil {
-		return conversationHistoryPresentation{}
+		return conversationHistoryPresentation{}, err
 	}
 	presentation := conversationHistoryPresentation{
 		branchProviderScopes: make(map[string]string, len(branches)),
@@ -2836,9 +2851,11 @@ func (s *Store) conversationHistoryPresentation(
 				branch.ParentBranchID != "" && branch.ReplacedTurnID != ""
 		}
 	}
-	if sequence, queryErr := s.qr.SelectConversationNativeForkAvailableAfterSequence(ctx, conversationID); queryErr == nil {
-		presentation.nativeForkAvailableAfterSequence = sequence
+	sequence, err := s.qr.SelectConversationNativeForkAvailableAfterSequence(ctx, conversationID)
+	if err != nil {
+		return conversationHistoryPresentation{}, fmt.Errorf("select native fork boundary for conversation %s: %w", conversationID, err)
 	}
+	presentation.nativeForkAvailableAfterSequence = sequence
 	for _, branch := range branches {
 		if branch.ID == presentation.activeProviderBindingID {
 			presentation.editFloorSequence = branch.ForkAfterSequence
@@ -2847,7 +2864,7 @@ func (s *Store) conversationHistoryPresentation(
 	}
 	presentation.branchPoints = conversationBranchPointsForProviderBinding(
 		branches, presentation.activeProviderBindingID)
-	return presentation
+	return presentation, nil
 }
 
 func conversationBranchPointsForProviderBinding(
@@ -2903,22 +2920,24 @@ func conversationBranchPointsForProviderBinding(
 
 /* ---- helpers ---------------------------------------------------------- */
 
-// turnIDFor resolves a provider turn id to AO's turn id, or nil when the turn is
-// unknown. An item with no turn still belongs in the timeline, so an unresolved
-// lookup is not an error.
-func (s *Store) turnIDFor(ctx context.Context, conversationID, providerTurnID string) sql.NullString {
+// turnIDFor resolves a provider turn id to AO's turn id. An empty or unknown
+// provider turn leaves the item unlinked; a failed lookup must stop the write.
+func (s *Store) turnIDFor(ctx context.Context, conversationID, providerTurnID string) (sql.NullString, error) {
 	if providerTurnID == "" {
-		return sql.NullString{}
+		return sql.NullString{}, nil
 	}
 	row, err := s.conversationReader(ctx).SelectConversationTurnByProviderID(ctx,
 		gen.SelectConversationTurnByProviderIDParams{
 			ConversationID: conversationID,
 			ProviderTurnID: providerTurnID,
 		})
-	if err != nil {
-		return sql.NullString{}
+	if errors.Is(err, sql.ErrNoRows) {
+		return sql.NullString{}, nil
 	}
-	return sql.NullString{String: row.ID, Valid: true}
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf("select provider turn %s in conversation %s: %w", providerTurnID, conversationID, err)
+	}
+	return sql.NullString{String: row.ID, Valid: true}, nil
 }
 
 func conversationToDomain(row gen.Conversation) domain.ConversationRecord {


### PR DESCRIPTION
## What

Return conversation history and provider-turn lookup failures to callers instead of producing an incomplete snapshot or committing an unlinked timeline item.

## Why

A failed branch query previously looked like missing history metadata. A failed provider-turn lookup could still commit an assistant message or activity without its turn association, making the timeline inconsistent with its raw event archive. This addresses backend audit finding CORE-02.

## How

- Propagate branch and native-fork-boundary query errors from both full and paged conversation snapshots, returning no partial snapshot.
- Distinguish an unknown provider turn (`sql.ErrNoRows`) from a failed query. Empty and unknown IDs retain the existing unlinked-item behavior.
- Stop new assistant-message and activity writes when the lookup fails. Within provider-event projection, the enclosing transaction rolls back the archive and timeline changes together. Wrapped errors preserve `errors.Is` matching, including cancellation.

This change covers storage error propagation. It adds no schema or API fields and does not introduce an event retry scheduler; the existing controller continues logging projection errors and can process later provider replay.

## Testing

Local validation passed at `728edd2b00a9` on Linux. The checked-in workspace selected Go 1.26.5. Test subprocesses used a clean environment with a POSIX shell and isolated tmux sockets.

Added regressions inject SQLite query failures and cancellation errors into full/paged snapshots and direct/transactional message and activity writes. They check unchanged sequence allocation, rollback of the event archive, and preservation of known, unknown and empty turn associations.

Focused verification command, from `backend/`:

```sh
go test -race ./internal/storage/sqlite/store/...
```

Complete backend checks passed: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race -timeout=15m ./...`, and golangci-lint v2.12.2 with zero findings. The full native Linux CLI suite passed with `go test -tags e2e -v ./internal/cli/...`.

The API drift workflow passed using Node 24.20.0: `npm ci`, `npm run api`, and byte comparison of both generated artifacts. The pinned gitleaks v7.4.0 scan covered this PR commit and reported no leaks. The unchanged fresh-install Dockerfile built successfully, and its container smoke check passed.

Native macOS and Windows execution is pending remote CI because this host is Linux. Remote checks have not run before publication.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
