### PR TITLE
fix: prevent invalidated workspace loads from repopulating cache

### DIFF
--- a/backend/internal/service/session/workspace_cache.go
+++ b/backend/internal/service/session/workspace_cache.go
@@ -41,16 +41,21 @@ type workspaceCache struct {
 	ttl     time.Duration
 	now     func() time.Time
 	entries map[workspaceCacheKey]workspaceCacheEntry
+	loads   map[workspaceCacheKey]*workspaceCacheEntry
 }
 
 func newWorkspaceCache(ttl time.Duration, now func() time.Time) *workspaceCache {
 	if now == nil {
 		now = time.Now
 	}
-	return &workspaceCache{ttl: ttl, now: now, entries: make(map[workspaceCacheKey]workspaceCacheEntry)}
+	return &workspaceCache{
+		ttl: ttl, now: now,
+		entries: make(map[workspaceCacheKey]workspaceCacheEntry),
+		loads:   make(map[workspaceCacheKey]*workspaceCacheEntry),
+	}
 }
 
-// get, set, and invalidateSession are nil-receiver-safe: a *Service built via
+// Cache methods are nil-receiver-safe: a *Service built via
 // a bare struct literal (common in this package's tests) leaves
 // workspaceCache nil, and a nil cache should behave as permanently empty
 // rather than panicking or requiring every construction site to remember
@@ -72,17 +77,40 @@ func (c *workspaceCache) get(key workspaceCacheKey) (workspaceCacheEntry, bool) 
 	return entry, true
 }
 
-func (c *workspaceCache) set(key workspaceCacheKey, entry workspaceCacheEntry) {
+// beginLoad reserves publication before Git work starts. The entry's identity
+// is the token, so invalidation needs no retained per-session generation map.
+func (c *workspaceCache) beginLoad(key workspaceCacheKey) *workspaceCacheEntry {
+	entry := new(workspaceCacheEntry)
+	if c == nil {
+		return entry
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.loads[key] = entry
+	return entry
+}
+
+// finishLoad releases this load's reservation and optionally publishes it.
+// An invalidated or superseded load must neither publish nor remove a newer
+// load's reservation. The caller defers a non-publishing finish for error paths.
+func (c *workspaceCache) finishLoad(key workspaceCacheKey, entry *workspaceCacheEntry, publish bool) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[key] = entry
+	if c.loads[key] != entry {
+		return
+	}
+	delete(c.loads, key)
+	if publish {
+		c.entries[key] = *entry
+	}
 }
 
 // invalidateSession purges every cached entry for a session, across every
-// worktree root it spans (workspace projects can span several repos).
+// worktree root it spans (workspace projects can span several repos), and
+// prevents loads already in progress from repopulating the cache.
 func (c *workspaceCache) invalidateSession(id domain.SessionID) {
 	if c == nil {
 		return
@@ -92,6 +120,11 @@ func (c *workspaceCache) invalidateSession(id domain.SessionID) {
 	for key := range c.entries {
 		if key.session == id {
 			delete(c.entries, key)
+		}
+	}
+	for key := range c.loads {
+		if key.session == id {
+			delete(c.loads, key)
 		}
 	}
 }

--- a/backend/internal/service/session/workspace_cache_test.go
+++ b/backend/internal/service/session/workspace_cache_test.go
@@ -1,0 +1,214 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestWorkspaceCacheInvalidationDuringLoad(t *testing.T) {
+	for _, invalidations := range []int{0, 1, 3} {
+		t.Run(map[int]string{0: "no invalidation", 1: "one invalidation", 3: "repeated invalidation"}[invalidations], func(t *testing.T) {
+			roots := []string{newWorkspaceRepo(t), newWorkspaceRepo(t)}
+			now := func() time.Time { return time.Unix(100, 0) }
+			s := &Service{clock: now, workspaceCache: newWorkspaceCache(workspaceCacheTTL, now)}
+			keys := []workspaceCacheKey{
+				{session: "changed", root: roots[0]},
+				{session: "changed", root: roots[1]},
+				{session: "unrelated", root: roots[0]},
+			}
+			type result struct {
+				compare workspaceCompareTarget
+				err     error
+			}
+			started := make(chan struct{}, len(keys))
+			release := make(chan struct{})
+			done := make([]chan result, len(keys))
+			for i, key := range keys {
+				done[i] = make(chan result, 1)
+				go func() {
+					compare, _, err := s.resolveWorkspaceChanges(t.Context(), key.session, key.root, func(context.Context) workspaceCompareTarget {
+						started <- struct{}{}
+						<-release
+						return workspaceCompareTarget{BaseRef: "before"}
+					})
+					done[i] <- result{compare, err}
+				}()
+			}
+			for range keys {
+				<-started
+			}
+			for range invalidations {
+				s.InvalidateWorkspaceCache("changed")
+			}
+			close(release)
+			for i, key := range keys {
+				loaded := <-done[i]
+				if loaded.err != nil {
+					t.Fatalf("load %v: %v", key, loaded.err)
+				}
+				if loaded.compare.BaseRef != "before" {
+					t.Errorf("racing load %v = %q, want before", key, loaded.compare.BaseRef)
+				}
+				compare, _, err := s.resolveWorkspaceChanges(t.Context(), key.session, key.root, func(context.Context) workspaceCompareTarget {
+					return workspaceCompareTarget{BaseRef: "after"}
+				})
+				if err != nil {
+					t.Fatalf("next load %v: %v", key, err)
+				}
+				want := "before"
+				if invalidations > 0 && key.session == "changed" {
+					want = "after"
+				}
+				if compare.BaseRef != want {
+					t.Errorf("next load %v = %q, want %q", key, compare.BaseRef, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWorkspaceCacheInvalidatedFlightStillCoalesces(t *testing.T) {
+	root := newWorkspaceRepo(t)
+	synctest.Test(t, func(t *testing.T) {
+		now := func() time.Time { return time.Unix(100, 0) }
+		s := &Service{clock: now, workspaceCache: newWorkspaceCache(workspaceCacheTTL, now)}
+		id := domain.SessionID("session")
+		started := make(chan struct{})
+		release := make(chan struct{})
+		done := make(chan workspaceCompareTarget, 2)
+		load := func(resolve func(context.Context) workspaceCompareTarget) {
+			compare, _, err := s.resolveWorkspaceChanges(t.Context(), id, root, resolve)
+			if err != nil {
+				t.Errorf("resolve changes: %v", err)
+			}
+			done <- compare
+		}
+		go load(func(context.Context) workspaceCompareTarget {
+			close(started)
+			<-release
+			return workspaceCompareTarget{BaseRef: "before"}
+		})
+		<-started
+		s.InvalidateWorkspaceCache(id)
+		go load(func(context.Context) workspaceCompareTarget {
+			t.Error("caller joining an invalidated flight started a separate load")
+			return workspaceCompareTarget{BaseRef: "separate"}
+		})
+		// Both callers must be blocked in the same flight before it completes.
+		synctest.Wait()
+		close(release)
+		for range 2 {
+			if compare := <-done; compare.BaseRef != "before" {
+				t.Errorf("shared snapshot = %q, want before", compare.BaseRef)
+			}
+		}
+		compare, _, err := s.resolveWorkspaceChanges(t.Context(), id, root, func(context.Context) workspaceCompareTarget {
+			return workspaceCompareTarget{BaseRef: "after"}
+		})
+		if err != nil {
+			t.Fatalf("next load: %v", err)
+		}
+		if compare.BaseRef != "after" {
+			t.Errorf("next load = %q, want after", compare.BaseRef)
+		}
+	})
+}
+
+func TestWorkspaceCacheOldLoadCannotAffectReplacement(t *testing.T) {
+	for _, publishOld := range []bool{false, true} {
+		t.Run(map[bool]string{false: "cleanup", true: "publication"}[publishOld], func(t *testing.T) {
+			c := newWorkspaceCache(workspaceCacheTTL, nil)
+			key := workspaceCacheKey{session: "session", root: "root"}
+			old := c.beginLoad(key)
+			old.compare.BaseRef = "old"
+			c.invalidateSession(key.session)
+			c.invalidateSession(key.session)
+			if len(c.loads) != 0 {
+				t.Fatal("invalidation retained a load reservation")
+			}
+			replacement := c.beginLoad(key)
+			*replacement = workspaceCacheEntry{at: c.now(), compare: workspaceCompareTarget{BaseRef: "replacement"}}
+			c.finishLoad(key, old, publishOld)
+			c.finishLoad(key, replacement, true)
+			// A late finish must also leave the replacement's cached result intact.
+			c.finishLoad(key, old, publishOld)
+			got, ok := c.get(key)
+			if !ok || got.compare.BaseRef != "replacement" {
+				t.Fatalf("replacement cache = %+v, %v; want replacement", got, ok)
+			}
+			if len(c.loads) != 0 {
+				t.Fatal("completed loads retained reservations")
+			}
+			c.invalidateSession(key.session)
+			c.invalidateSession("never loaded")
+			if len(c.entries) != 0 || len(c.loads) != 0 {
+				t.Fatal("invalidation retained session bookkeeping")
+			}
+		})
+	}
+}
+
+func TestWorkspaceCacheFailedLoadReleasesReservation(t *testing.T) {
+	root := t.TempDir() // Git must fail for a directory that is not a repository.
+	c := newWorkspaceCache(workspaceCacheTTL, nil)
+	s := &Service{workspaceCache: c}
+	_, _, err := s.resolveWorkspaceChanges(t.Context(), "session", root, func(context.Context) workspaceCompareTarget {
+		return workspaceCompareTarget{}
+	})
+	if err == nil {
+		t.Fatal("expected Git error")
+	}
+	if len(c.loads) != 0 || len(c.entries) != 0 {
+		t.Fatal("failed load retained cache bookkeeping")
+	}
+}
+
+func TestWorkspaceCacheNilRemainsUncached(t *testing.T) {
+	root := newWorkspaceRepo(t)
+	s := &Service{}
+	s.InvalidateWorkspaceCache("session")
+	for _, ref := range []string{"first", "second"} {
+		compare, _, err := s.resolveWorkspaceChanges(t.Context(), "session", root, func(context.Context) workspaceCompareTarget {
+			return workspaceCompareTarget{BaseRef: ref}
+		})
+		if err != nil {
+			t.Fatalf("load %s: %v", ref, err)
+		}
+		if compare.BaseRef != ref {
+			t.Errorf("load = %q, want %q", compare.BaseRef, ref)
+		}
+	}
+}
+
+func TestWorkspaceCacheExpiresAtConfiguredTTL(t *testing.T) {
+	root := newWorkspaceRepo(t)
+	const ttl = 250 * time.Millisecond
+	start := time.Unix(100, 0)
+	now := start
+	clock := func() time.Time { return now }
+	s := &Service{clock: clock, workspaceCache: newWorkspaceCache(ttl, clock)}
+	for _, tt := range []struct {
+		elapsed  time.Duration
+		resolved string
+		want     string
+	}{
+		{elapsed: 0, resolved: "initial", want: "initial"},
+		{elapsed: ttl, resolved: "refreshed", want: "initial"},
+		{elapsed: ttl + time.Nanosecond, resolved: "refreshed", want: "refreshed"},
+	} {
+		now = start.Add(tt.elapsed)
+		compare, _, err := s.resolveWorkspaceChanges(t.Context(), "session", root, func(context.Context) workspaceCompareTarget {
+			return workspaceCompareTarget{BaseRef: tt.resolved}
+		})
+		if err != nil {
+			t.Fatalf("load at %s: %v", tt.elapsed, err)
+		}
+		if compare.BaseRef != tt.want {
+			t.Errorf("load at %s = %q, want %q", tt.elapsed, compare.BaseRef, tt.want)
+		}
+	}
+}

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -189,9 +189,9 @@ func (s *Service) WorkspaceWatchPaths(ctx context.Context, id domain.SessionID) 
 }
 
 // InvalidateWorkspaceCache purges cached compare-base and git-status data for
-// a session. Called from the workspace SSE stream the instant its filesystem
-// watcher observes a real change, so a list/detail request racing a fresh
-// git mutation never returns stale cached state.
+// a session when the workspace SSE filesystem watcher observes a change.
+// Callers sharing an in-flight load may still receive its uncached snapshot;
+// the first request after that load completes recomputes the data.
 func (s *Service) InvalidateWorkspaceCache(id domain.SessionID) {
 	s.workspaceCache.invalidateSession(id)
 }
@@ -949,14 +949,16 @@ func (s *Service) resolveWorkspaceChanges(
 		if cached, ok := s.workspaceCache.get(key); ok {
 			return cached, nil
 		}
+		entry := s.workspaceCache.beginLoad(key)
+		defer s.workspaceCache.finishLoad(key, entry, false)
 		compare := resolve(ctx)
 		changes, err := workspaceChangeMaps(ctx, root, compare.gitBase())
 		if err != nil {
 			return nil, err
 		}
-		entry := workspaceCacheEntry{at: s.now(), compare: compare, changes: changes}
-		s.workspaceCache.set(key, entry)
-		return entry, nil
+		*entry = workspaceCacheEntry{at: s.now(), compare: compare, changes: changes}
+		s.workspaceCache.finishLoad(key, entry, true)
+		return *entry, nil
 	})
 	if err != nil {
 		return workspaceCompareTarget{}, workspaceChangeSet{}, err


### PR DESCRIPTION
## What

Prevent an in-progress workspace Git lookup from repopulating the cache after a filesystem change invalidates its session.

## Why

Invalidation previously removed completed cache entries only. A lookup already running could publish its old compare/status result afterward, so subsequent list and file-detail requests reused stale data until the cache expired. This addresses backend audit finding CORE-10.

## How

- Reserve publication for each session/root before resolving the compare base and running Git queries.
- Remove both cached entries and active reservations when invalidating a session, including all its repository roots.
- Publish only while the load still owns its reservation. Deferred cleanup releases failed loads without removing a replacement reservation or its cached result.

Concurrent callers still share one in-progress lookup. Callers joining an invalidated lookup may receive its uncached snapshot; the first request after it completes recomputes the data. The existing three-second TTL and nil-cache behavior remain. Watcher sharing, broader cache eviction and cancellation of shared Git work are outside this change.

## Testing

Local validation passed at `959635c4e945` on Linux. The checked-in workspace selected Go 1.26.5. Test subprocesses used a clean environment with a POSIX shell and isolated tmux sockets.

Added regressions coordinate invalidation with blocked loads across two roots and an unrelated session. Coverage includes repeated invalidation, callers sharing an invalidated lookup, replacement reservations, failed-load cleanup, nil caches and the exact TTL boundary.

Focused verification command, from `backend/`:

```sh
go test -race ./internal/service/session/...
```

Complete backend checks passed: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race -timeout=15m ./...`, and golangci-lint v2.12.2 with zero findings. The full native Linux CLI suite passed with `go test -tags e2e -v ./internal/cli/...`.

The API drift workflow passed using Node 24.20.0: `npm ci`, `npm run api`, and byte comparison of both generated artifacts. The pinned gitleaks v7.4.0 scan covered this PR commit and reported no leaks. The unchanged fresh-install Dockerfile built successfully, and its container smoke check passed.

Native macOS and Windows execution is pending remote CI because this host is Linux. Remote checks have not run before publication.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
