### PR TITLE
fix: preserve GitLab response and cache consistency

### DIFF
--- a/backend/internal/adapters/scm/gitlab/client.go
+++ b/backend/internal/adapters/scm/gitlab/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -166,7 +167,10 @@ func (c *Client) doRESTWithETag(ctx context.Context, path string, q url.Values, 
 		return RESTResponse{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
+	body, err := readResponseBody(resp, path)
+	if err != nil {
+		return RESTResponse{StatusCode: resp.StatusCode}, err
+	}
 	if resp.StatusCode == http.StatusNotModified {
 		return RESTResponse{StatusCode: 304, NotModified: true, ETag: etag}, nil
 	}
@@ -212,7 +216,10 @@ func (c *Client) doMERGE(ctx context.Context, path string, q url.Values, body an
 		return RESTResponse{}, fmt.Errorf("gitlab scm: PUT %s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	b, _ := io.ReadAll(resp.Body)
+	b, err := readResponseBody(resp, path)
+	if err != nil {
+		return RESTResponse{StatusCode: resp.StatusCode}, err
+	}
 	if resp.StatusCode >= 400 {
 		return RESTResponse{StatusCode: resp.StatusCode, Body: b}, classifyError(resp, b)
 	}
@@ -233,23 +240,34 @@ func (c *Client) doGET(ctx context.Context, path string, q url.Values) (RESTResp
 	req.Header.Set("User-Agent", c.userAgent)
 
 	c.mu.Lock()
-	if etag, ok := c.etagOut[cacheKey]; ok {
-		req.Header.Set("If-None-Match", etag)
-	}
+	prevETag := c.etagOut[cacheKey]
+	prevBody := c.bodyOut[cacheKey]
 	c.mu.Unlock()
+	if prevETag != "" && prevBody != nil {
+		req.Header.Set("If-None-Match", prevETag)
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return RESTResponse{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
+	body, err := readResponseBody(resp, path)
+	if err != nil {
+		return RESTResponse{StatusCode: resp.StatusCode}, err
+	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		c.mu.Lock()
-		cached := c.bodyOut[cacheKey]
-		c.mu.Unlock()
-		return RESTResponse{StatusCode: 200, NotModified: true, ETag: resp.Header.Get("ETag"), Body: cached}, nil
+		if prevETag == "" || prevBody == nil {
+			return RESTResponse{StatusCode: resp.StatusCode}, fmt.Errorf("gitlab scm: GET %s returned 304 without a cached body", path)
+		}
+		// Another request may have replaced or evicted the cache entry while
+		// this request was in flight. Replay only the body we revalidated.
+		etag := resp.Header.Get("ETag")
+		if etag == "" {
+			etag = prevETag
+		}
+		return RESTResponse{StatusCode: 200, NotModified: true, ETag: etag, Body: bytes.Clone(prevBody)}, nil
 	}
 	if resp.StatusCode >= 400 {
 		return RESTResponse{StatusCode: resp.StatusCode}, classifyError(resp, body)
@@ -357,8 +375,11 @@ func (c *Client) doGETPaginated(ctx context.Context, path string, q url.Values, 
 		if err != nil {
 			return false, err
 		}
-		body, _ := io.ReadAll(resp.Body)
+		body, err := readResponseBody(resp, path)
 		_ = resp.Body.Close()
+		if err != nil {
+			return false, err
+		}
 		if resp.StatusCode == http.StatusNotModified {
 			// 304 on the first page means nothing changed; stop.
 			return false, nil
@@ -474,7 +495,8 @@ func (c *Client) storeCacheEntry(cacheKey, etag string, body []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.etagOut[cacheKey] = etag
-	c.bodyOut[cacheKey] = body
+	// Cached bytes remain immutable even if a caller modifies its response.
+	c.bodyOut[cacheKey] = bytes.Clone(body)
 	c.cacheLRU = append(c.cacheLRU, cacheKey)
 	for len(c.cacheLRU) > cacheMaxEntries {
 		evict := c.cacheLRU[0]
@@ -482,6 +504,21 @@ func (c *Client) storeCacheEntry(cacheKey, etag string, body []byte) {
 		delete(c.etagOut, evict)
 		delete(c.bodyOut, evict)
 	}
+}
+
+// readResponseBody rejects incomplete reads before callers can publish validators
+// or consume a page. Callers own closing the body. Preserve status-derived errors
+// as well, including rate-limit retry hints from the response headers.
+func readResponseBody(resp *http.Response, path string) ([]byte, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("gitlab scm: read %s body: %w", path, err)
+		if resp.StatusCode >= 400 {
+			err = errors.Join(err, classifyError(resp, body))
+		}
+		return nil, err
+	}
+	return body, nil
 }
 
 func (c *Client) authorize(ctx context.Context, req *http.Request) error {

--- a/backend/internal/adapters/scm/gitlab/client_response_test.go
+++ b/backend/internal/adapters/scm/gitlab/client_response_test.go
@@ -1,0 +1,271 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type responseRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f responseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type failingResponseBody struct {
+	err    error
+	closed bool
+}
+
+func (b *failingResponseBody) Read(p []byte) (int, error) {
+	return copy(p, `{"id":42}`), b.err
+}
+
+func (b *failingResponseBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func testResponse(status int, etag, body string) *http.Response {
+	header := make(http.Header)
+	if etag != "" {
+		header.Set("ETag", etag)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// Even syntactically complete JSON is unusable when the transport reports
+// that its response body was not read successfully.
+func TestResponseReadFailure(t *testing.T) {
+	for _, operation := range []string{"external_etag", "merge", "get", "pagination"} {
+		for _, status := range []int{200, 304, 401, 403, 404, 409, 429, 500} {
+			t.Run(fmt.Sprintf("%s/%d", operation, status), func(t *testing.T) {
+				readErr := errors.New("response interrupted")
+				body := &failingResponseBody{err: readErr}
+				c := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: responseRoundTripper(func(req *http.Request) (*http.Response, error) {
+					wantMethod := http.MethodGet
+					if operation == "merge" {
+						wantMethod = http.MethodPut
+					}
+					if req.Method != wantMethod {
+						t.Errorf("request method = %s, want %s", req.Method, wantMethod)
+					}
+					resp := testResponse(status, `"new"`, "")
+					resp.Header.Set("Retry-After", "60")
+					resp.Body = body
+					return resp, nil
+				})}})
+				const path = "/projects/1/merge_requests/42"
+				c.storeCacheEntry(c.restURL(path, nil), `"old"`, []byte(`{"id":1}`))
+				var resp RESTResponse
+				var err error
+				handlerCalls := 0
+				switch operation {
+				case "external_etag":
+					resp, err = c.doRESTWithETag(context.Background(), path, nil, `"old"`)
+				case "merge":
+					resp, err = c.doMERGE(context.Background(), path, nil, nil)
+				case "get":
+					resp, err = c.doGET(context.Background(), path, nil)
+				case "pagination":
+					_, err = c.doGETPaginated(context.Background(), path, nil, func([]byte) error {
+						handlerCalls++
+						return nil
+					})
+				}
+				if !errors.Is(err, readErr) {
+					t.Errorf("error = %v, want wrapped response read failure", err)
+				}
+				if operation != "pagination" && resp.StatusCode != status {
+					t.Errorf("status = %d, want %d", resp.StatusCode, status)
+				}
+				if len(resp.Body) != 0 || resp.ETag != "" || resp.NotModified {
+					t.Errorf("failed read exposed a usable response: %+v", resp)
+				}
+				if !body.closed {
+					t.Error("response body was not closed")
+				}
+				if handlerCalls != 0 {
+					t.Errorf("pagination handler called %d times after failed read", handlerCalls)
+				}
+				assertResponseErrorClass(t, status, err)
+				c.http.Transport = responseRoundTripper(func(req *http.Request) (*http.Response, error) {
+					if got := req.Header.Get("If-None-Match"); got != `"old"` {
+						t.Errorf("validator after failed read = %q, want old", got)
+					}
+					return testResponse(304, `"old"`, ""), nil
+				})
+				cached, err := c.doGET(context.Background(), path, nil)
+				if err != nil || string(cached.Body) != `{"id":1}` {
+					t.Errorf("cached response after failed read = %+v, %v", cached, err)
+				}
+			})
+		}
+	}
+}
+
+func assertResponseErrorClass(t *testing.T, status int, err error) {
+	t.Helper()
+	var want error
+	switch status {
+	case 401, 403:
+		want = ErrAuthFailed
+	case 404:
+		want = ErrNotFound
+	case 429:
+		want = ErrRateLimited
+		var rateLimit *RateLimitError
+		if !errors.As(err, &rateLimit) || rateLimit.RetryAfter != time.Minute {
+			t.Errorf("rate limit hint lost: %v", err)
+		}
+	}
+	if want != nil && !errors.Is(err, want) {
+		t.Errorf("error = %v, want status classification %v", err, want)
+	}
+}
+
+func TestDoGETNotModifiedUsesRequestSnapshot(t *testing.T) {
+	for _, interleave := range []string{"replace", "evict"} {
+		t.Run(interleave, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			started := make(chan struct{})
+			release := make(chan struct{})
+			const path = "/projects/1/merge_requests/42"
+			c := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: responseRoundTripper(func(req *http.Request) (*http.Response, error) {
+				if req.Context().Value(snapshotRequestKey{}) != nil {
+					if got := req.Header.Get("If-None-Match"); got != `"old"` {
+						return nil, fmt.Errorf("conditional validator = %q, want old", got)
+					}
+					close(started)
+					select {
+					case <-release:
+						return testResponse(304, "", ""), nil
+					case <-req.Context().Done():
+						return nil, req.Context().Err()
+					}
+				}
+				return testResponse(200, `"new"`, `{"id":2}`), nil
+			})}})
+			c.storeCacheEntry(c.restURL(path, nil), `"old"`, []byte(`{"id":1}`))
+			type result struct {
+				response RESTResponse
+				err      error
+			}
+			done := make(chan result, 1)
+			go func() {
+				resp, err := c.doGET(context.WithValue(ctx, snapshotRequestKey{}, true), path, nil)
+				done <- result{resp, err}
+			}()
+			select {
+			case <-started:
+			case <-ctx.Done():
+				t.Fatal("conditional request did not start")
+			}
+			if interleave == "replace" {
+				if _, err := c.doGET(ctx, path, nil); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				for i := 0; i < cacheMaxEntries; i++ {
+					if _, err := c.doGET(ctx, fmt.Sprintf("/projects/%d", i), nil); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			close(release)
+			select {
+			case got := <-done:
+				if got.err != nil {
+					t.Fatal(got.err)
+				}
+				if got.response.StatusCode != http.StatusOK || !got.response.NotModified || got.response.ETag != `"old"` || string(got.response.Body) != `{"id":1}` {
+					t.Errorf("304 response = %+v, want original conditional body and validator", got.response)
+				}
+			case <-ctx.Done():
+				t.Fatal("conditional request did not finish")
+			}
+			c.http.Transport = responseRoundTripper(func(req *http.Request) (*http.Response, error) {
+				want := `"new"`
+				if interleave == "evict" {
+					want = ""
+				}
+				if got := req.Header.Get("If-None-Match"); got != want {
+					t.Errorf("validator after interleaved 304 = %q, want %q", got, want)
+				}
+				return testResponse(200, `"new"`, `{"id":2}`), nil
+			})
+			if _, err := c.doGET(ctx, path, nil); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+type snapshotRequestKey struct{}
+
+func TestDoGETNotModifiedWithoutCachedBody(t *testing.T) {
+	c := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: responseRoundTripper(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("If-None-Match"); got != "" {
+			t.Errorf("uncached request sent validator %q", got)
+		}
+		return testResponse(304, `"unknown"`, ""), nil
+	})}})
+	resp, err := c.doGET(context.Background(), "/projects/1", nil)
+	if err == nil || resp.NotModified || len(resp.Body) != 0 {
+		t.Errorf("uncached 304 = %+v, %v; want error", resp, err)
+	}
+}
+
+func TestDoGETCacheBodyOwnership(t *testing.T) {
+	calls := 0
+	c := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: responseRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return testResponse(200, `"old"`, `{"id":1}`), nil
+		}
+		return testResponse(304, `"old"`, ""), nil
+	})}})
+	for i := 0; i < 3; i++ {
+		resp, err := c.doGET(context.Background(), "/projects/1", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(resp.Body) != `{"id":1}` {
+			t.Fatalf("response %d body = %q, cache was changed by caller", i, resp.Body)
+		}
+		resp.Body[0] = '!'
+	}
+}
+
+func TestDoGETPaginatedReadFailureStopsNextPage(t *testing.T) {
+	readErr := errors.New("second page interrupted")
+	calls, handled := 0, 0
+	c := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: responseRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		resp := testResponse(200, "", `[{"id":1}]`)
+		resp.Header.Set("Link", `<https://gitlab.com/api/v4/projects/1?page=2>; rel="next"`)
+		if calls == 2 {
+			resp.Body = &failingResponseBody{err: readErr}
+		}
+		return resp, nil
+	})}})
+	truncated, err := c.doGETPaginated(context.Background(), "/projects/1", url.Values{}, func([]byte) error {
+		handled++
+		return nil
+	})
+	if !errors.Is(err, readErr) || truncated || calls != 2 || handled != 1 {
+		t.Errorf("pagination = truncated %v, error %v, requests %d, handled %d; want read error after first page", truncated, err, calls, handled)
+	}
+}


### PR DESCRIPTION
## What

Reject incomplete GitLab response bodies and make a `304 Not Modified` response reuse the body paired with the validator sent by that request.

## Why

Response read errors were ignored, allowing truncated content to reach callers or cache state. Separately, a concurrent request could replace or evict the cached body while another request was revalidating it, causing the latter to return a different body or no body. This addresses AD-03 and the GitLab portion of AD-05 from the backend audit.

## How

- Check body reads in ordinary GET, caller-managed ETag, merge and paginated requests before consuming content or publishing validators. Preserve both read errors and status-derived errors, including rate-limit hints.
- Capture the cached ETag/body pair before sending a GET and use that request's snapshot for a subsequent 304 response.
- Reject a 304 without a usable cached body and retain the sent validator if the response omits its ETag.
- Copy bytes when storing and replaying cached bodies so callers cannot mutate cache contents through a returned response.

This changes the GitLab client only. The GitHub portion of AD-05 remains separate, and this PR does not redesign cache eviction or provider pagination contracts.

## Testing

Local validation passed at `40498b0849ba` on Linux. The checked-in workspace selected Go 1.26.5. Test subprocesses used a clean environment with a POSIX shell and isolated tmux sockets.

Added regressions cover interrupted body reads across request variants, preservation of status errors, concurrent cache replacement/eviction during revalidation, missing cached bodies, caller mutation and stopping pagination at a failed page after processing completed pages.

Focused verification command, from `backend/`:

```sh
go test -race ./internal/adapters/scm/gitlab/...
```

Complete backend checks passed: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race -timeout=15m ./...`, and golangci-lint v2.12.2 with zero findings. The full native Linux CLI suite passed with `go test -tags e2e -v ./internal/cli/...`.

The API drift workflow passed using Node 24.20.0: `npm ci`, `npm run api`, and byte comparison of both generated artifacts. The pinned gitleaks v7.4.0 scan covered this PR commit and reported no leaks. The unchanged fresh-install Dockerfile built successfully, and its container smoke check passed.

Native macOS and Windows execution is pending remote CI because this host is Linux. Remote checks have not run before publication.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
