### PR TITLE
fix: retain partial push delivery and receipt progress

### DIFF
--- a/backend/internal/push/dispatcher.go
+++ b/backend/internal/push/dispatcher.go
@@ -55,6 +55,9 @@ type sentTicket struct {
 	id     string
 	token  string
 	sentAt time.Time
+	// A receipt ID seen with different tokens must never identify a token to
+	// prune, even after the conflicting record expires or is dropped at the cap.
+	pruneAmbiguous bool
 }
 
 // Dispatcher subscribes to the notification hub and, per new notification, sends
@@ -139,10 +142,9 @@ func (d *Dispatcher) dispatch(ctx context.Context, rec domain.NotificationRecord
 	tickets, err := d.sender.Send(ctx, messages)
 	if err != nil {
 		d.log.Warn("push send failed", "err", err, "notification", rec.ID, "devices", len(messages))
-		return
 	}
-	// Tickets are 1:1 with messages, in order. Prune tokens Expo already knows are
-	// dead, and remember accepted tickets so the sweep can check their receipts.
+	// Even on error, earlier successful batches return a prefix of tickets in
+	// message order. Prune known dead tokens and track accepted deliveries once.
 	now := d.clock()
 	var accepted []sentTicket
 	for i, t := range tickets {
@@ -179,6 +181,23 @@ func (d *Dispatcher) trackAccepted(tickets []sentTicket) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.pending = append(d.pending, tickets...)
+	// Mark conflicting IDs before the cap can discard either record. Keep this
+	// decision on the surviving records so expiry cannot make an ID trustworthy.
+	tokenOf := make(map[string]string, len(d.pending))
+	for _, t := range d.pending {
+		token, exists := tokenOf[t.id]
+		if !exists {
+			tokenOf[t.id] = t.token
+		}
+		if t.pruneAmbiguous || (exists && token != t.token) {
+			tokenOf[t.id] = ""
+		}
+	}
+	for i := range d.pending {
+		if tokenOf[d.pending[i].id] == "" {
+			d.pending[i].pruneAmbiguous = true
+		}
+	}
 	if over := len(d.pending) - maxPendingReceipts; over > 0 {
 		d.pending = d.pending[over:]
 	}
@@ -190,47 +209,66 @@ func (d *Dispatcher) trackAccepted(tickets []sentTicket) {
 func (d *Dispatcher) sweepReceipts(ctx context.Context) {
 	now := d.clock()
 
-	// Split pending into "due" (old enough to check or expired) and "keep".
+	// Leave due tickets in place while fetching so retries preserve their age
+	// and position under the cap. Only records in this snapshot can be resolved.
 	d.mu.Lock()
-	var due, keep []sentTicket
+	due := make(map[sentTicket]struct{})
+	var ids []string
+	seen := make(map[string]struct{})
 	for _, t := range d.pending {
-		if now.Sub(t.sentAt) >= receiptDelay {
-			due = append(due, t)
-		} else {
-			keep = append(keep, t)
+		age := now.Sub(t.sentAt)
+		if t.id == "" || age < receiptDelay || age >= receiptMaxAge {
+			continue
+		}
+		due[t] = struct{}{}
+		if _, exists := seen[t.id]; !exists {
+			ids = append(ids, t.id)
+			seen[t.id] = struct{}{}
 		}
 	}
-	d.pending = keep
 	d.mu.Unlock()
-	if len(due) == 0 {
-		return
+
+	var receipts map[string]Receipt
+	if len(ids) > 0 {
+		var err error
+		receipts, err = d.sender.GetReceipts(ctx, ids)
+		if err != nil {
+			d.log.Warn("fetch push receipts failed", "err", err, "tickets", len(ids))
+		}
 	}
 
-	// Expired tickets (no receipt after receiptMaxAge) are dropped, not queried.
-	ids := make([]string, 0, len(due))
-	tokenOf := make(map[string]string, len(due))
-	for _, t := range due {
+	// Receipt fetching can cross the expiry boundary. Process partial responses
+	// even on error, keeping omitted or nonterminal results at their original age.
+	now = d.clock()
+	d.mu.Lock()
+	keep := d.pending[:0]
+	var deadTokens []string
+	pruned := make(map[string]struct{})
+	for _, t := range d.pending {
 		if now.Sub(t.sentAt) >= receiptMaxAge {
 			continue
 		}
-		ids = append(ids, t.id)
-		tokenOf[t.id] = t.token
-	}
-	if len(ids) == 0 {
-		return
-	}
-
-	receipts, err := d.sender.GetReceipts(ctx, ids)
-	if err != nil {
-		d.log.Warn("fetch push receipts failed", "err", err, "tickets", len(ids))
-		return
-	}
-	for id, r := range receipts {
+		r, found := receipts[t.id]
+		_, queried := due[t]
+		if !queried || !found || (r.Status != "ok" && r.Status != "error") {
+			keep = append(keep, t)
+			continue
+		}
 		if r.IsDeviceNotRegistered() {
-			d.prune(tokenOf[id])
+			token := t.token
+			if _, seen := pruned[token]; !t.pruneAmbiguous && token != "" && !seen {
+				deadTokens = append(deadTokens, token)
+				pruned[token] = struct{}{}
+			}
 		} else if r.Status == "error" {
 			d.log.Warn("push delivery error", "err", r.Details.Error, "message", r.Message)
 		}
+	}
+	clear(d.pending[len(keep):])
+	d.pending = keep
+	d.mu.Unlock()
+	for _, token := range deadTokens {
+		d.prune(token)
 	}
 }
 

--- a/backend/internal/push/dispatcher.go
+++ b/backend/internal/push/dispatcher.go
@@ -55,8 +55,8 @@ type sentTicket struct {
 	id     string
 	token  string
 	sentAt time.Time
-	// A receipt ID seen with different tokens must never identify a token to
-	// prune, even after the conflicting record expires or is dropped at the cap.
+	// pruneAmbiguous prevents pruning from an ID shared by different tokens.
+	// The conflict is remembered only while a marked record remains in pending.
 	pruneAmbiguous bool
 }
 
@@ -181,8 +181,9 @@ func (d *Dispatcher) trackAccepted(tickets []sentTicket) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.pending = append(d.pending, tickets...)
-	// Mark conflicting IDs before the cap can discard either record. Keep this
-	// decision on the surviving records so expiry cannot make an ID trustworthy.
+	// Mark conflicting IDs before the cap can discard either record. An ID stays
+	// ambiguous while a marked record remains in pending; after all are removed,
+	// a new ticket reusing the ID is trusted again.
 	tokenOf := make(map[string]string, len(d.pending))
 	for _, t := range d.pending {
 		token, exists := tokenOf[t.id]

--- a/backend/internal/push/dispatcher_test.go
+++ b/backend/internal/push/dispatcher_test.go
@@ -2,8 +2,11 @@ package push
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -44,15 +47,16 @@ func (f *fakeDeviceStore) UnregisterToken(token string) error {
 }
 
 type fakeSender struct {
-	mu         sync.Mutex
-	gotMsgs    []Message
-	tickets    []Ticket
-	sendErr    error
-	sentCond   *sync.Cond
-	sent       bool
-	gotIDs     []string           // ids passed to GetReceipts
-	receipts   map[string]Receipt // returned by GetReceipts
-	receiptErr error
+	mu          sync.Mutex
+	gotMsgs     []Message
+	tickets     []Ticket
+	sendErr     error
+	sentCond    *sync.Cond
+	sent        bool
+	gotIDs      []string           // ids passed to GetReceipts
+	receipts    map[string]Receipt // returned by GetReceipts
+	receiptErr  error
+	receiptHook func()
 }
 
 func newFakeSender(tickets []Ticket) *fakeSender {
@@ -67,16 +71,16 @@ func (f *fakeSender) Send(_ context.Context, messages []Message) ([]Ticket, erro
 	f.gotMsgs = append(f.gotMsgs, messages...)
 	f.sent = true
 	f.sentCond.Broadcast()
-	if f.sendErr != nil {
-		return nil, f.sendErr
-	}
-	return f.tickets, nil
+	return f.tickets, f.sendErr
 }
 
 func (f *fakeSender) GetReceipts(_ context.Context, ids []string) (map[string]Receipt, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.gotIDs = append(f.gotIDs, ids...)
+	if f.receiptHook != nil {
+		f.receiptHook()
+	}
 	return f.receipts, f.receiptErr
 }
 
@@ -344,5 +348,317 @@ func TestDispatcherSweepSkipsFreshAndDropsExpired(t *testing.T) {
 	d.mu.Unlock()
 	if pending != 1 {
 		t.Fatalf("pending = %d, want 1 (only the fresh ticket remains)", pending)
+	}
+}
+
+func TestDispatcherPartialSendTracksAcceptedPrefix(t *testing.T) {
+	now := time.Unix(10000, 0)
+	store := &fakeDeviceStore{devices: []mobilebridge.PushDevice{
+		{Token: "muted", Muted: true},
+		{Token: ""},
+		{Token: "accepted"},
+		{Token: "dead"},
+		{Token: "unsent"},
+	}}
+	dead := Ticket{Status: "error"}
+	dead.Details.Error = "DeviceNotRegistered"
+	sender := newFakeSender([]Ticket{{Status: "ok", ID: "accepted-ticket"}, dead})
+	sender.sendErr = errors.New("later batch failed")
+	d := NewDispatcher(nil, store, sender, nil)
+	d.clock = func() time.Time { return now }
+
+	d.dispatch(t.Context(), domain.NotificationRecord{ID: "notification"})
+	want := []sentTicket{{id: "accepted-ticket", token: "accepted", sentAt: now}}
+	if !slices.Equal(d.pending, want) {
+		t.Errorf("pending = %+v, want %+v", d.pending, want)
+	}
+	if !slices.Equal(store.deleted, []string{"dead"}) {
+		t.Errorf("pruned = %v, want [dead]", store.deleted)
+	}
+	if len(sender.gotMsgs) != 3 || sender.gotMsgs[0].To != "accepted" || sender.gotMsgs[1].To != "dead" {
+		t.Errorf("messages = %+v, want accepted/dead/unsent once", sender.gotMsgs)
+	}
+
+	now = now.Add(receiptDelay)
+	receipt := Receipt{Status: "error"}
+	receipt.Details.Error = "DeviceNotRegistered"
+	sender.receipts = map[string]Receipt{"accepted-ticket": receipt}
+	d.sweepReceipts(t.Context())
+	if !slices.Equal(store.deleted, []string{"dead", "accepted"}) || len(d.pending) != 0 {
+		t.Errorf("receipt tracking: pruned = %v, pending = %+v", store.deleted, d.pending)
+	}
+	if len(sender.gotMsgs) != 3 {
+		t.Error("receipt sweep resent messages")
+	}
+}
+
+func TestDispatcherReceiptRetryPreservesPartialResults(t *testing.T) {
+	dead := Receipt{Status: "error"}
+	dead.Details.Error = "DeviceNotRegistered"
+	for _, tt := range []struct {
+		name       string
+		receipts   map[string]Receipt
+		err        error
+		keepFirst  bool
+		pruneFirst bool
+	}{
+		{name: "transport error", err: errors.New("offline"), keepFirst: true},
+		{name: "omitted receipt", receipts: map[string]Receipt{"first": {Status: "ok"}}},
+		{name: "partial error", receipts: map[string]Receipt{"first": dead}, err: errors.New("later batch failed"), pruneFirst: true},
+		{name: "partial success", receipts: map[string]Receipt{"first": dead}, pruneFirst: true},
+		{name: "unknown status", receipts: map[string]Receipt{"first": {Status: "ok"}, "retry": {}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Unix(10000, 0)
+			store := &fakeDeviceStore{}
+			sender := newFakeSender(nil)
+			sender.receipts, sender.receiptErr = tt.receipts, tt.err
+			d := NewDispatcher(nil, store, sender, nil)
+			d.clock = func() time.Time { return now }
+			first := sentTicket{id: "first", token: "first-token", sentAt: now.Add(-20 * time.Minute)}
+			retry := sentTicket{id: "retry", token: "retry-token", sentAt: now.Add(-16 * time.Minute)}
+			d.trackAccepted([]sentTicket{first, retry})
+
+			d.sweepReceipts(t.Context())
+			wantPending := []sentTicket{retry}
+			if tt.keepFirst {
+				wantPending = []sentTicket{first, retry}
+			}
+			if !slices.Equal(d.pending, wantPending) {
+				t.Errorf("pending = %+v, want original tickets %+v", d.pending, wantPending)
+			}
+			var wantPruned []string
+			if tt.pruneFirst {
+				wantPruned = []string{"first-token"}
+			}
+			if !slices.Equal(store.deleted, wantPruned) {
+				t.Errorf("pruned = %v, want %v", store.deleted, wantPruned)
+			}
+
+			now = now.Add(receiptSweepInterval)
+			sender.receipts = map[string]Receipt{"first": {Status: "ok"}, "retry": dead}
+			sender.receiptErr = nil
+			sender.gotIDs = nil
+			d.sweepReceipts(t.Context())
+			if len(d.pending) != 0 {
+				t.Errorf("resolved tickets still pending: %+v", d.pending)
+			}
+			wantPruned = append(wantPruned, "retry-token")
+			if !slices.Equal(store.deleted, wantPruned) {
+				t.Errorf("pruned after retry = %v, want %v", store.deleted, wantPruned)
+			}
+			wantIDs := []string{"retry"}
+			if tt.keepFirst {
+				wantIDs = []string{"first", "retry"}
+			}
+			if !slices.Equal(sender.gotIDs, wantIDs) {
+				t.Errorf("retried IDs = %v, want %v", sender.gotIDs, wantIDs)
+			}
+			d.sweepReceipts(t.Context())
+			if !slices.Equal(sender.gotIDs, wantIDs) || !slices.Equal(store.deleted, wantPruned) {
+				t.Error("resolved tickets were processed again")
+			}
+		})
+	}
+}
+
+func TestDispatcherReceiptExpiryUsesOriginalSendTime(t *testing.T) {
+	now := time.Unix(10000, 0)
+	sender := newFakeSender(nil)
+	d := NewDispatcher(nil, &fakeDeviceStore{}, sender, nil)
+	d.clock = func() time.Time { return now }
+	original := sentTicket{id: "retry", token: "token", sentAt: now.Add(-receiptDelay)}
+	d.trackAccepted([]sentTicket{original})
+	d.sweepReceipts(t.Context())
+	if !slices.Equal(d.pending, []sentTicket{original}) {
+		t.Errorf("missing receipt lost or changed original ticket: %+v", d.pending)
+	}
+	now = original.sentAt.Add(receiptMaxAge)
+	sender.gotIDs = nil
+	d.sweepReceipts(t.Context())
+	if len(d.pending) != 0 || len(sender.gotIDs) != 0 {
+		t.Errorf("expired ticket retained or queried: pending = %+v, queried = %v", d.pending, sender.gotIDs)
+	}
+}
+
+func TestDispatcherReceiptExpiresDuringFetch(t *testing.T) {
+	for _, response := range []string{"missing", "error", "dead"} {
+		t.Run(response, func(t *testing.T) {
+			now := time.Unix(10000, 0)
+			store := &fakeDeviceStore{}
+			sender := newFakeSender(nil)
+			d := NewDispatcher(nil, store, sender, nil)
+			d.clock = func() time.Time { return now }
+			d.trackAccepted([]sentTicket{{id: "expires", token: "token", sentAt: now.Add(-receiptMaxAge + time.Minute)}})
+			sender.receiptHook = func() { now = now.Add(time.Minute) }
+			if response == "error" {
+				sender.receiptErr = errors.New("offline")
+			}
+			if response == "dead" {
+				dead := Receipt{Status: "error"}
+				dead.Details.Error = "DeviceNotRegistered"
+				sender.receipts = map[string]Receipt{"expires": dead}
+			}
+			d.sweepReceipts(t.Context())
+			if len(d.pending) != 0 || len(store.deleted) != 0 {
+				t.Errorf("expired during fetch: pending = %+v, pruned = %v", d.pending, store.deleted)
+			}
+		})
+	}
+}
+
+func TestDispatcherReceiptRetriesPreserveCapacityOrder(t *testing.T) {
+	for _, duringFetch := range []bool{false, true} {
+		t.Run(fmt.Sprintf("new ticket during fetch %t", duringFetch), func(t *testing.T) {
+			now := time.Unix(10000, 0)
+			sender := newFakeSender(nil)
+			d := NewDispatcher(nil, &fakeDeviceStore{}, sender, nil)
+			d.clock = func() time.Time { return now }
+			tickets := []sentTicket{{id: "old-retry", token: "old-token", sentAt: now.Add(-receiptDelay)}}
+			for i := 1; i < maxPendingReceipts; i++ {
+				tickets = append(tickets, sentTicket{id: fmt.Sprintf("fresh-%d", i), token: "fresh-token", sentAt: now})
+			}
+			d.trackAccepted(tickets)
+			newest := sentTicket{id: "newest", token: "newest-token", sentAt: now}
+			if duringFetch {
+				sender.receiptHook = func() { d.trackAccepted([]sentTicket{newest}) }
+			}
+			d.sweepReceipts(t.Context())
+			if !duringFetch {
+				if len(d.pending) != maxPendingReceipts || d.pending[0].id != "old-retry" {
+					t.Errorf("sweep lost or reordered the oldest unresolved ticket; pending count = %d", len(d.pending))
+				}
+				d.trackAccepted([]sentTicket{newest})
+			}
+			if len(d.pending) != maxPendingReceipts {
+				t.Fatalf("pending = %d, want cap %d", len(d.pending), maxPendingReceipts)
+			}
+			if d.pending[0].id != "fresh-1" || d.pending[len(d.pending)-1].id != "newest" {
+				t.Errorf("cap evicted a newer ticket: first = %s, last = %s", d.pending[0].id, d.pending[len(d.pending)-1].id)
+			}
+		})
+	}
+}
+
+func TestDispatcherReceiptDuplicatesDoNotMisattributeTokens(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		token  string
+		fresh  bool
+		pruned []string
+	}{
+		{name: "same token", token: "first-token", pruned: []string{"first-token"}},
+		{name: "different tokens", token: "other-token"},
+		{name: "fresh collision", token: "other-token", fresh: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Unix(10000, 0)
+			store := &fakeDeviceStore{}
+			sender := newFakeSender(nil)
+			dead := Receipt{Status: "error"}
+			dead.Details.Error = "DeviceNotRegistered"
+			sender.receipts = map[string]Receipt{"duplicate": dead, "unsolicited": dead, "": dead}
+			d := NewDispatcher(nil, store, sender, nil)
+			d.clock = func() time.Time { return now }
+			second := sentTicket{id: "duplicate", token: tt.token, sentAt: now.Add(-receiptDelay)}
+			if tt.fresh {
+				second.sentAt = now
+			}
+			d.trackAccepted([]sentTicket{
+				{id: "duplicate", token: "first-token", sentAt: now.Add(-receiptDelay)}, second,
+			})
+			d.sweepReceipts(t.Context())
+			if !slices.Equal(sender.gotIDs, []string{"duplicate"}) {
+				t.Errorf("queried = %v, want unique [duplicate]", sender.gotIDs)
+			}
+			if !slices.Equal(store.deleted, tt.pruned) {
+				t.Errorf("pruned = %v, want %v", store.deleted, tt.pruned)
+			}
+			var wantPending []sentTicket
+			if tt.fresh {
+				wantPending = []sentTicket{second}
+			}
+			if len(d.pending) != len(wantPending) || (tt.fresh &&
+				(d.pending[0].id != second.id || d.pending[0].token != second.token || d.pending[0].sentAt != second.sentAt)) {
+				t.Errorf("pending = %+v, want %+v", d.pending, wantPending)
+			}
+		})
+	}
+}
+
+func TestDispatcherReceiptAmbiguitySurvivesConflictingTicketExpiry(t *testing.T) {
+	now := time.Unix(10000, 0)
+	store := &fakeDeviceStore{}
+	sender := newFakeSender(nil)
+	d := NewDispatcher(nil, store, sender, nil)
+	d.clock = func() time.Time { return now }
+	d.trackAccepted([]sentTicket{
+		{id: "duplicate", token: "old-token", sentAt: now.Add(-receiptMaxAge + time.Minute)},
+		{id: "duplicate", token: "newer-token", sentAt: now.Add(-receiptDelay)},
+	})
+	d.sweepReceipts(t.Context()) // Neither conflicting record has a receipt yet.
+	now = now.Add(time.Minute)
+	d.sweepReceipts(t.Context()) // The older conflicting record expires.
+	if len(d.pending) != 1 || d.pending[0].token != "newer-token" {
+		t.Fatalf("expected only the unexpired conflicting ticket: %+v", d.pending)
+	}
+	dead := Receipt{Status: "error"}
+	dead.Details.Error = "DeviceNotRegistered"
+	sender.receipts = map[string]Receipt{"duplicate": dead}
+	d.sweepReceipts(t.Context())
+	if len(store.deleted) != 0 || len(d.pending) != 0 {
+		t.Errorf("ambiguous receipt after expiry: pruned = %v, pending = %+v", store.deleted, d.pending)
+	}
+}
+
+func TestDispatcherReceiptIgnoresUnqueriedPendingTickets(t *testing.T) {
+	for _, duringFetch := range []bool{false, true} {
+		t.Run(fmt.Sprintf("registered during fetch %t", duringFetch), func(t *testing.T) {
+			now := time.Unix(10000, 0)
+			store := &fakeDeviceStore{}
+			sender := newFakeSender(nil)
+			d := NewDispatcher(nil, store, sender, nil)
+			d.clock = func() time.Time { return now }
+			d.trackAccepted([]sentTicket{{id: "queried", token: "queried-token", sentAt: now.Add(-receiptDelay)}})
+			fresh := sentTicket{id: "unqueried", token: "fresh-token", sentAt: now}
+			if duringFetch {
+				sender.receiptHook = func() { d.trackAccepted([]sentTicket{fresh}) }
+			} else {
+				d.trackAccepted([]sentTicket{fresh})
+			}
+			dead := Receipt{Status: "error"}
+			dead.Details.Error = "DeviceNotRegistered"
+			sender.receipts = map[string]Receipt{"queried": {Status: "ok"}, "unqueried": dead}
+			d.sweepReceipts(t.Context())
+			if !slices.Equal(sender.gotIDs, []string{"queried"}) || !slices.Equal(d.pending, []sentTicket{fresh}) || len(store.deleted) != 0 {
+				t.Errorf("unqueried receipt affected pending: queried = %v, pending = %+v, pruned = %v", sender.gotIDs, d.pending, store.deleted)
+			}
+		})
+	}
+}
+
+func TestDispatcherReceiptAmbiguitySurvivesCapacityEviction(t *testing.T) {
+	now := time.Unix(10000, 0)
+	store := &fakeDeviceStore{}
+	sender := newFakeSender(nil)
+	d := NewDispatcher(nil, store, sender, nil)
+	d.clock = func() time.Time { return now }
+	tickets := []sentTicket{{id: "duplicate", token: "old-token", sentAt: now.Add(-receiptDelay)}}
+	for i := 1; i < maxPendingReceipts; i++ {
+		tickets = append(tickets, sentTicket{id: fmt.Sprintf("fresh-%d", i), token: "fresh-token", sentAt: now})
+	}
+	d.trackAccepted(tickets)
+	// The old conflicting record is evicted before the first receipt sweep.
+	d.trackAccepted([]sentTicket{{id: "duplicate", token: "newer-token", sentAt: now}})
+	now = now.Add(receiptDelay)
+	dead := Receipt{Status: "error"}
+	dead.Details.Error = "DeviceNotRegistered"
+	sender.receipts = map[string]Receipt{"duplicate": dead}
+	d.sweepReceipts(t.Context())
+	if len(store.deleted) != 0 {
+		t.Errorf("ambiguous receipt after cap eviction pruned %q", store.deleted)
+	}
+	if len(d.pending) != maxPendingReceipts-1 {
+		t.Errorf("pending = %d, want %d unresolved fresh tickets", len(d.pending), maxPendingReceipts-1)
 	}
 }


### PR DESCRIPTION
## What

Keep tracking accepted push deliveries when a later send batch fails, and retain unresolved receipts for later sweeps instead of losing them after one unsuccessful lookup.

## Why

The sender can return an accepted prefix of tickets together with an error. The dispatcher previously discarded that progress. It also removed due tickets before fetching receipts, so a transport failure or omitted receipt permanently ended tracking and prevented later invalid-device cleanup. This addresses backend audit findings SUP11 and SUP12 through one focused dispatcher change.

## How

- Process returned tickets even when sending reports an error, preserving their order against the filtered device messages. Track accepted tickets and prune explicitly rejected devices without resending messages.
- Keep unresolved tickets at their original send time and capacity position. Process terminal receipts from partial responses and retry omitted or nonterminal results on later sweeps.
- Resolve only tickets included in the request snapshot. Preserve expiry and the 10,000-ticket cap, including expiry or new admissions during a receipt fetch.
- Deduplicate receipt IDs and prevent ambiguous IDs associated with different device tokens from pruning either token. Preserve that ambiguity after expiry or capacity eviction; perform device removal outside the pending-ticket lock.

Receipt tracking remains bounded and in memory. Durable delivery queues, automatic resend of failed batches and broader dispatcher lifecycle changes are outside this PR.

## Testing

Local validation passed at `694f46f94b6e` on Linux. The checked-in workspace selected Go 1.26.5. Test subprocesses used a clean environment with a POSIX shell and isolated tmux sockets.

Added regressions cover partial sends, partial/missing/error receipts and later recovery, original-age expiry, expiry during fetch, capacity order, concurrent admissions and conflicting or unsolicited receipt IDs. They also check that receipt processing does not resend notifications.

Focused verification command, from `backend/`:

```sh
go test -race ./internal/push/...
```

Complete backend checks passed: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race -timeout=15m ./...`, and golangci-lint v2.12.2 with zero findings. The full native Linux CLI suite passed with `go test -tags e2e -v ./internal/cli/...`.

The API drift workflow passed using Node 24.20.0: `npm ci`, `npm run api`, and byte comparison of both generated artifacts. The pinned gitleaks v7.4.0 scan covered this PR commit and reported no leaks. The unchanged fresh-install Dockerfile built successfully, and its container smoke check passed.

Native macOS and Windows execution is pending remote CI because this host is Linux. Remote checks have not run before publication.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
