### PR TITLE
fix(lan): stop blocking Codex model routes on the LAN listener

### DIFF
--- a/backend/internal/httpd/lan_listener.go
+++ b/backend/internal/httpd/lan_listener.go
@@ -50,7 +50,9 @@ func NewLANManager(handler http.Handler, state *authState, defaultPort int, log 
 // the telemetry routes under /internal/, and the Connect Mobile control
 // surface under /api/v1/mobile, developer maintenance routes under /api/v1/dev,
 // host-mutating installer routes under /api/v1/system/install, and personal
-// Codex account-management routes under /api/v1/agents/codex. Some routes
+// Codex account-management routes under /api/v1/agents/codex/accounts and
+// /api/v1/agents/codex/account-switches (the harmless read-only Codex model
+// routes stay reachable so mobile can pick a model). Some routes
 // are gated in the shared router by localControlRequest, which trusts the
 // client-supplied Host header. That header is spoofable by any LAN client. The
 // LAN listener is the one thing a caller cannot spoof: it is the physical socket
@@ -64,7 +66,8 @@ var lanControlBlockedPrefixes = []string{
 	"/api/v1/browser",
 	"/api/v1/desktop",
 	"/api/v1/system/install",
-	"/api/v1/agents/codex",
+	"/api/v1/agents/codex/accounts",
+	"/api/v1/agents/codex/account-switches",
 }
 
 // lanControlBlock returns 404 for any request whose path is, or is nested

--- a/backend/internal/httpd/lan_listener_test.go
+++ b/backend/internal/httpd/lan_listener_test.go
@@ -9,7 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	agentsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/agent"
 )
 
 func TestLANManagerAuthGatesSharedHandler(t *testing.T) {
@@ -200,5 +206,105 @@ func TestLANManagerServesIdentityProbeWithoutAPassword(t *testing.T) {
 	}
 	if code := get("/api/v1/sessions"); code != http.StatusUnauthorized {
 		t.Errorf("unauthenticated GET /api/v1/sessions got %d, want 401", code)
+	}
+}
+
+// lanFakeAgentCatalog is a controllers.AgentCatalog that records whether the
+// real handler was actually reached. Only the Codex model/probe routes are
+// exercised; the rest satisfy the interface.
+type lanFakeAgentCatalog struct{ calls int }
+
+func (c *lanFakeAgentCatalog) CachedReadiness(context.Context) (agentsvc.Readiness, error) {
+	return agentsvc.Readiness{}, nil
+}
+
+func (c *lanFakeAgentCatalog) EnsureReadiness(context.Context, []string, domain.AgentReadinessPurpose) (agentsvc.Readiness, error) {
+	return agentsvc.Readiness{}, nil
+}
+
+func (c *lanFakeAgentCatalog) List(context.Context) (agentsvc.Inventory, error) {
+	return agentsvc.Inventory{}, nil
+}
+
+func (c *lanFakeAgentCatalog) Refresh(context.Context) (agentsvc.Inventory, error) {
+	return agentsvc.Inventory{}, nil
+}
+
+func (c *lanFakeAgentCatalog) Probe(context.Context, string) (agentsvc.ProbeResult, error) {
+	c.calls++
+	return agentsvc.ProbeResult{}, nil
+}
+
+func (c *lanFakeAgentCatalog) Models(_ context.Context, agentID, _ string, _ bool) (ports.AgentModelCatalog, error) {
+	c.calls++
+	return ports.AgentModelCatalog{AgentID: agentID}, nil
+}
+
+func (c *lanFakeAgentCatalog) RevalidateModels(_ context.Context, agentID, _ string) (ports.AgentModelCatalog, error) {
+	c.calls++
+	return ports.AgentModelCatalog{AgentID: agentID}, nil
+}
+
+// TestLANListenerServesCodexModelRoutesFromRealRouter pins the actual bug: the
+// LAN control block used to list the whole /api/v1/agents/codex prefix, so the
+// model routes mobile calls answered 404 even though the router mounts them.
+// A stub inner handler cannot prove that (it answers anything), so this drives
+// the real AgentsController routes through the real LAN listener over a real
+// socket and asserts the handler ran, while the credential routes stay blocked.
+func TestLANListenerServesCodexModelRoutesFromRealRouter(t *testing.T) {
+	catalog := &lanFakeAgentCatalog{}
+	router := chi.NewRouter()
+	router.Route("/api/v1", func(r chi.Router) {
+		(&controllers.AgentsController{Catalog: catalog}).Register(r)
+	})
+
+	st := &authState{}
+	st.setHash(mobilebridge.HashPassword("secret12"))
+	m := NewLANManager(router, st, 0, slog.Default(), nil)
+	port, err := m.Start(0)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer m.Stop(context.Background())
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/v1/agents/codex/models?projectId=project%20one"},
+		{http.MethodPost, "/api/v1/agents/codex/models/refresh"},
+		{http.MethodPost, "/api/v1/agents/codex/probe"},
+	} {
+		req, _ := http.NewRequest(tc.method, fmt.Sprintf("http://127.0.0.1:%d%s", port, tc.path), nil)
+		req.Header.Set("Authorization", "Bearer secret12")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: request failed: %v", tc.method, tc.path, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s %s: got %d (%s) want 200 — LAN block must not swallow Codex model routes", tc.method, tc.path, resp.StatusCode, body)
+		}
+	}
+	if catalog.calls != 3 {
+		t.Fatalf("catalog calls = %d, want 3 — requests never reached the real handler", catalog.calls)
+	}
+
+	// The credential surface stays unreachable over LAN, even with a spoofed
+	// loopback Host and valid auth.
+	for _, path := range []string{
+		"/api/v1/agents/codex/accounts",
+		"/api/v1/agents/codex/accounts/events",
+		"/api/v1/agents/codex/account-switches",
+	} {
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d%s", port, path), nil)
+		req.Host = "127.0.0.1"
+		req.Header.Set("Authorization", "Bearer secret12")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: request failed: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s: got %d want 404", path, resp.StatusCode)
+		}
 	}
 }

--- a/backend/internal/httpd/lan_listener_test.go
+++ b/backend/internal/httpd/lan_listener_test.go
@@ -45,7 +45,9 @@ func TestLANManagerAuthGatesSharedHandler(t *testing.T) {
 
 // TestLANManagerBlocksLoopbackOnlyControlRoutes proves the LAN listener never
 // serves /shutdown, /internal/*, /api/v1/mobile*, /api/v1/dev*,
-// /api/v1/browser*, or /api/v1/agents/codex* — even when the request carries a spoofed Host: 127.0.0.1
+// /api/v1/browser*, or the Codex credential routes under
+// /api/v1/agents/codex/accounts* and /api/v1/agents/codex/account-switches* —
+// even when the request carries a spoofed Host: 127.0.0.1
 // and valid LAN auth, since gating on Host alone (localControlRequest) is what
 // let a LAN client reach these routes.
 func TestLANManagerBlocksLoopbackOnlyControlRoutes(t *testing.T) {
@@ -103,6 +105,26 @@ func TestLANManagerBlocksLoopbackOnlyControlRoutes(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("agent install: got %d want 404", resp.StatusCode)
+	}
+
+	// The read-only Codex model routes are not credential surfaces and must
+	// stay reachable so mobile can list and refresh models.
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/agents/codex/models"},
+		{http.MethodPost, "/api/v1/agents/codex/models/refresh"},
+	} {
+		req, _ := http.NewRequest(tc.method, fmt.Sprintf("http://127.0.0.1:%d%s", port, tc.path), nil)
+		req.Header.Set("Authorization", "Bearer secret12")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: request failed: %v", tc.path, err)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			t.Fatalf("%s: got 404, must not be blocked by the control-route filter", tc.path)
+		}
 	}
 
 	// A normal app route must still be reachable through the LAN listener


### PR DESCRIPTION
## Summary

The LAN control block listed the whole `/api/v1/agents/codex` prefix, which also covered the harmless read-only model routes mobile legitimately needs:

- `GET /api/v1/agents/codex/models`
- `POST /api/v1/agents/codex/models/refresh`

Mobile (LAN listener) therefore got an intentional-looking `404`, while desktop (loopback listener, not subject to the block) worked fine — easy to misread as "mobile just doesn't support Codex model selection".

This narrows the block to the two sub-trees that are actually sensitive:

- `/api/v1/agents/codex/accounts` (login / logout / verify / delete)
- `/api/v1/agents/codex/account-switches`

Security posture is unchanged — credential routes stay loopback-only — while `/models`, `/models/refresh` and `/probe` become reachable over LAN so mobile model selection works.

Note: `GET /api/v1/sessions/{sessionId}/conversation/models` was never affected; it lives under `/api/v1/sessions/`. `cors.go` already listed only the two narrow prefixes, so it needed no change.

## Tests

- Extended `TestLANManagerBlocksLoopbackOnlyControlRoutes`: credential paths still 404; added positive assertions that `GET /models` and `POST /models/refresh` are not swallowed by the control-route filter.
- `GOWORK=off go test ./internal/httpd/...` — all pass.

## Risks

Low. Only widens LAN reachability for two read-only/refresh model routes, which remain behind `authMiddleware`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCgrqCHgFv8F83gXwHd43o