### PR TITLE
fix(cloud): delete cloud projects and their sandboxes

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1605,6 +1605,21 @@ describe("Sidebar", () => {
 		expect(dialog).toHaveTextContent("repository folder");
 	});
 
+	it("warns that a cloud project's sandboxes are destroyed instead of promising a folder on disk", async () => {
+		const user = userEvent.setup();
+		// A cloud project has no local checkout: removing it deletes the project in
+		// the control plane and tears down the sandboxes running its sessions.
+		renderSidebar({ workspaces: [{ ...workspace, name: "Cloud One", kind: "cloud", path: "" }] });
+
+		await user.click(screen.getByLabelText("Project actions for Cloud One"));
+		await user.click(await screen.findByRole("menuitem", { name: "Remove project" }));
+
+		const dialog = await screen.findByRole("dialog", { name: "Remove project" });
+		expect(dialog).toHaveTextContent("Cloud One");
+		expect(dialog).toHaveTextContent("sandboxes");
+		expect(dialog).not.toHaveTextContent("repository folder");
+	});
+
 	it("renames a session inline by double-clicking its name", async () => {
 		const user = userEvent.setup();
 		const workspaceWithSession = { ...workspace, sessions: [session] };

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -1521,7 +1521,9 @@ const ProjectItemContent = memo(function ProjectItemContent({
 						description={
 							<>
 								<p className="text-sm font-medium text-foreground">{t("shell.removeProjectLead", { name: workspace.name })}</p>
-								<p className="mt-1 text-xs text-muted-foreground">{t("shell.removeProjectBody")}</p>
+								<p className="mt-1 text-xs text-muted-foreground">
+									{t(workspace.kind === "cloud" ? "shell.removeCloudProjectBody" : "shell.removeProjectBody")}
+								</p>
 							</>
 						}
 						confirmLabel={t("shell.remove")}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1193,6 +1193,7 @@
 	"shell.projectSettings": "Projekteinstellungen",
 	"shell.restart": "Neu starten",
 	"shell.remove": "Entfernen",
+	"shell.removeCloudProjectBody": "Dadurch wird das Projekt aus AO Cloud gelöscht und die Sandboxes, die seine Sitzungen ausführen, werden zerstört. Der Sitzungsverlauf bleibt erhalten.",
 	"shell.removeProjectBody": "Dadurch werden live laufende Sitzungen gestoppt und das Projekt aus der Seitenleiste entfernt, der Repository-Ordner und der gespeicherte Verlauf bleiben jedoch auf dem Datenträger.",
 	"shell.removeProjectLead": "Dadurch wird {{name}} aus AO entfernt",
 	"shell.removeProjectTitle": "Projekt entfernen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1316,6 +1316,7 @@
 	"shell.projectSettings": "Project settings",
 	"shell.restart": "Restart",
 	"shell.remove": "Remove",
+	"shell.removeCloudProjectBody": "This deletes the project from AO Cloud and destroys the sandboxes running its sessions. Session history is kept.",
 	"shell.removeProjectBody": "This stops its live sessions and removes it from the sidebar, but keeps the repository folder and stored history on disk.",
 	"shell.removeProjectLead": "This will remove {{name}} from AO",
 	"shell.removeProjectTitle": "Remove project",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1214,6 +1214,7 @@
 	"shell.projectSettings": "Ajustes del proyecto",
 	"shell.restart": "Reiniciar",
 	"shell.remove": "Eliminar",
+	"shell.removeCloudProjectBody": "Esto elimina el proyecto de AO Cloud y destruye los sandboxes que ejecutan sus sesiones. El historial de sesiones se conserva.",
 	"shell.removeProjectBody": "Esto detiene sus sesiones activas y lo quita de la barra lateral, pero conserva la carpeta del repositorio y el historial almacenado en disco.",
 	"shell.removeProjectLead": "Esto eliminará {{name}} de AO",
 	"shell.removeProjectTitle": "Eliminar proyecto",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1214,6 +1214,7 @@
 	"shell.projectSettings": "Paramètres du projet",
 	"shell.restart": "Redémarrer",
 	"shell.remove": "Supprimer",
+	"shell.removeCloudProjectBody": "Cela supprime le projet d'AO Cloud et détruit les bacs à sable qui exécutent ses sessions. L'historique des sessions est conservé.",
 	"shell.removeProjectBody": "Cela arrête ses sessions actives et le retire de la barre latérale, mais conserve le dossier du dépôt et l'historique stocké sur le disque.",
 	"shell.removeProjectLead": "Cela supprimera {{name}} d'AO",
 	"shell.removeProjectTitle": "Supprimer le projet",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1193,6 +1193,7 @@
 	"shell.projectSettings": "プロジェクト設定",
 	"shell.restart": "再起動",
 	"shell.remove": "削除",
+	"shell.removeCloudProjectBody": "プロジェクトを AO Cloud から削除し、そのセッションを実行しているサンドボックスを破棄します。セッション履歴は保持されます。",
 	"shell.removeProjectBody": "稼働中のセッションを停止し、サイドバーから削除しますが、リポジトリフォルダーと保存済み履歴はディスクに残ります。",
 	"shell.removeProjectLead": "{{name}} を AO から削除します",
 	"shell.removeProjectTitle": "プロジェクトを削除",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1193,6 +1193,7 @@
 	"shell.projectSettings": "프로젝트 설정",
 	"shell.restart": "다시 시작",
 	"shell.remove": "제거",
+	"shell.removeCloudProjectBody": "프로젝트를 AO Cloud에서 삭제하고 해당 세션을 실행 중인 샌드박스를 제거합니다. 세션 기록은 유지됩니다.",
 	"shell.removeProjectBody": "실행 중인 세션을 중지하고 사이드바에서 제거하지만, 저장소 폴더와 저장된 기록은 디스크에 유지됩니다.",
 	"shell.removeProjectLead": "AO에서 {{name}}을(를) 제거합니다",
 	"shell.removeProjectTitle": "프로젝트 제거",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1214,6 +1214,7 @@
 	"shell.projectSettings": "Configurações do projeto",
 	"shell.restart": "Reiniciar",
 	"shell.remove": "Remover",
+	"shell.removeCloudProjectBody": "Isso exclui o projeto do AO Cloud e destrói os sandboxes que executam suas sessões. O histórico das sessões é mantido.",
 	"shell.removeProjectBody": "Isso interrompe as sessões ativas e remove o projeto da barra lateral, mas mantém a pasta do repositório e o histórico armazenado em disco.",
 	"shell.removeProjectLead": "Isso removerá {{name}} do AO",
 	"shell.removeProjectTitle": "Remover projeto",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1179,6 +1179,7 @@
 	"shell.projectSettings": "项目设置",
 	"shell.restart": "重启",
 	"shell.remove": "移除",
+	"shell.removeCloudProjectBody": "这会从 AO Cloud 删除该项目，并销毁运行其会话的沙箱。会话历史将保留。",
 	"shell.removeProjectBody": "会停止其活跃会话并从侧边栏移除，但保留磁盘上的仓库文件夹与历史记录。",
 	"shell.removeProjectLead": "这将从 AO 中移除 {{name}}",
 	"shell.removeProjectTitle": "移除项目",

--- a/frontend/src/renderer/lib/cloud-project.test.ts
+++ b/frontend/src/renderer/lib/cloud-project.test.ts
@@ -1,0 +1,44 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { cloudProjectsQueryKey, cloudSessionsQueryKey } from "../hooks/useWorkspaceQuery";
+import type { CloudCpClient } from "./cloud-cp";
+import { deleteCloudProject } from "./cloud-project";
+
+function clientWithDelete(deleteProject: CloudCpClient["deleteProject"]): CloudCpClient {
+	return { deleteProject } as unknown as CloudCpClient;
+}
+
+describe("deleteCloudProject", () => {
+	it("deletes the project in the control plane and refreshes the cloud queries", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+		const deleteProject = vi.fn().mockResolvedValue({ project: { id: "project-1", deleted: true } });
+
+		await deleteCloudProject(queryClient, clientWithDelete(deleteProject), "org-1", "project-1");
+
+		expect(deleteProject).toHaveBeenCalledWith("org-1", "project-1");
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: cloudProjectsQueryKey });
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: cloudSessionsQueryKey });
+	});
+
+	it("fails without deleting anything when no organization is resolved", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const deleteProject = vi.fn();
+
+		await expect(
+			deleteCloudProject(queryClient, clientWithDelete(deleteProject), undefined, "project-1"),
+		).rejects.toThrow("No cloud organization is available.");
+		expect(deleteProject).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a control-plane failure and leaves the cloud queries alone", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+		const deleteProject = vi.fn().mockRejectedValue(new Error("The project could not be deleted."));
+
+		await expect(
+			deleteCloudProject(queryClient, clientWithDelete(deleteProject), "org-1", "project-1"),
+		).rejects.toThrow("The project could not be deleted.");
+		expect(invalidateSpy).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/lib/cloud-project.ts
+++ b/frontend/src/renderer/lib/cloud-project.ts
@@ -1,0 +1,27 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { cloudProjectsQueryKey, cloudSessionsQueryKey } from "../hooks/useWorkspaceQuery";
+import type { CloudCpClient } from "./cloud-cp";
+
+/**
+ * Removes a cloud project through the control plane.
+ *
+ * A cloud project has no local daemon record, so the daemon's project DELETE
+ * can only ever answer "project not found" for one. The control-plane DELETE
+ * archives the project and queues every sandbox its sessions own for
+ * reconciler teardown, so the project's compute is released with it; durable
+ * session history is retained on purpose.
+ */
+export async function deleteCloudProject(
+	queryClient: QueryClient,
+	client: CloudCpClient,
+	orgId: string | undefined,
+	projectId: string,
+): Promise<void> {
+	if (orgId === undefined) throw new Error("No cloud organization is available.");
+	await client.deleteProject(orgId, projectId);
+	// The local workspace cache never held this project: the cloud project and
+	// session queries are what render it, so refetch those to drop the project
+	// and the sessions the board attached to it.
+	await queryClient.invalidateQueries({ queryKey: cloudProjectsQueryKey });
+	await queryClient.invalidateQueries({ queryKey: cloudSessionsQueryKey });
+}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -28,11 +28,14 @@ import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
+import { useCloudCp } from "../hooks/useCloudCp";
+import { useCloudOrg } from "../hooks/useCloudOrg";
 import { apiClient, apiErrorCode, apiErrorDetails, apiErrorMessage, apiErrorRequestId, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { ShellProvider } from "../lib/shell-context";
+import { deleteCloudProject } from "../lib/cloud-project";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-replacement-telemetry";
 import { applyDocumentTheme, applyDocumentThemeStyle } from "../lib/theme";
@@ -49,7 +52,7 @@ import {
 } from "../lib/platform";
 import { sidebarIsVisible, sidebarOccupiesLayout, useUiStore } from "../stores/ui-store";
 import { matchesRendererShortcut } from "../stores/keybindings-store";
-import { sessionIsActive, toProjectKind, type WorkspaceSummary } from "../types/workspace";
+import { CLOUD_PROJECT_KIND, sessionIsActive, toProjectKind, type WorkspaceSummary } from "../types/workspace";
 import type { components } from "../../api/schema";
 import { useAgentInventoryTelemetry } from "../hooks/useAgentInventoryTelemetry";
 
@@ -177,6 +180,11 @@ function ShellLayout() {
 	const queryClient = useQueryClient();
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
+	// Cloud projects are merged into the same board, so removal has to reach the
+	// control plane for them. Both hooks share their queries with
+	// useWorkspaceQuery above, so subscribing here costs no extra request.
+	const { client: cloudClient } = useCloudCp();
+	const { org: cloudOrg } = useCloudOrg();
 	// Global shortcut listeners need the latest workspace list, but recreating
 	// those subscriptions for every streamed activity update is avoidable.
 	const workspacesRef = useRef(workspaces);
@@ -600,6 +608,7 @@ function ShellLayout() {
 
 	const removeProject = useCallback(
 		async (projectId: string) => {
+			const isCloudProject = workspaces.find((item) => item.id === projectId)?.kind === CLOUD_PROJECT_KIND;
 			const isLastWorkspace =
               workspaces.length === 1 && workspaces[0]?.id === projectId;
 			void addRendererExceptionStep("Project removal requested", {
@@ -608,19 +617,36 @@ function ShellLayout() {
 				surface: "project_board",
 				project_id: projectId,
 			});
-			const { error } = await apiClient.DELETE("/api/v1/projects/{id}", {
-				params: { path: { id: projectId } },
-			});
-			if (error) {
-				const failure = new Error(apiErrorMessage(error)) as Error & { code?: string };
-				failure.code = apiErrorCode(error);
+			const captureFailure = (failure: Error & { code?: string }) => {
 				void captureRendererException(failure, {
 					source: "project-remove",
 					operation: "project_remove",
 					surface: "project_board",
 					project_id: projectId,
 				});
-				throw failure;
+				return failure;
+			};
+			// The board merges cloud projects into the same list, but the daemon
+			// DELETE below only knows local ones; the control plane owns those.
+			if (isCloudProject) {
+				try {
+					await deleteCloudProject(queryClient, cloudClient, cloudOrg?.id, projectId);
+				} catch (err) {
+					throw captureFailure(err instanceof Error ? err : new Error(String(err)));
+				}
+				void captureRendererEvent("ao.renderer.project_removed", { project_id: projectId });
+				if (isLastWorkspace) {
+					void navigate({ to: "/" });
+				}
+				return;
+			}
+			const { error } = await apiClient.DELETE("/api/v1/projects/{id}", {
+				params: { path: { id: projectId } },
+			});
+			if (error) {
+				const failure = new Error(apiErrorMessage(error)) as Error & { code?: string };
+				failure.code = apiErrorCode(error);
+				throw captureFailure(failure);
 			}
 			void captureRendererEvent("ao.renderer.project_removed", { project_id: projectId });
 			updateWorkspaces((current) => current.filter((item) => item.id !== projectId));
@@ -628,7 +654,7 @@ function ShellLayout() {
               void navigate({ to: "/" });
 }
 		},
-		[navigate, updateWorkspaces, workspaces],
+		[cloudClient, cloudOrg, navigate, queryClient, updateWorkspaces, workspaces],
 	);
 
 	const restartOrchestrator = useCallback(

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -178,6 +178,13 @@ vi.mock("../hooks/useCloudCp", () => ({
 	useCloudCp: () => ({ client: {}, ready: false, baseUrl: "" }),
 }));
 
+// The shell resolves the cloud org so it can delete a cloud project through the
+// control plane. This provider-free harness has no QueryClient for the org
+// query, and these tests only exercise local projects.
+vi.mock("../hooks/useCloudOrg", () => ({
+	useCloudOrg: () => ({ org: undefined, isLoading: false, error: undefined, ready: false }),
+}));
+
 // The shell layout opens standalone terminals; this suite only covers the
 // shortcut subscriptions, so the mutation is stubbed rather than driven.
 vi.mock("../hooks/useShellTerminals", () => ({


### PR DESCRIPTION
Fixes #4605

## Problem

Removing a cloud project from the sidebar always failed. The board merges cloud projects into the same workspace list as local ones (`useWorkspaceQuery.ts`, `kind: "cloud"`), but `removeProject` unconditionally called the local daemon:

```ts
await apiClient.DELETE("/api/v1/projects/{id}", …)   // _shell.tsx
```

A cloud project has no daemon record, so that call could only ever answer "project not found", and the confirmation dialog surfaced the error. The control-plane client already had `deleteProject` (`lib/cloud-cp/client.ts`) and nothing in the app ever called it.

The control-plane side was already correct and is unchanged here: `DELETE /orgs/{orgId}/projects/{projectId}` → `Store.ArchiveProject` stamps `archived_at` **and** flips every sandbox belonging to that project's sessions to `desired_state = 'deleted'` with `reconcile_after = now()`; the reconciler's deletion path (`reconcileDeletion`) issues the provider `Delete`, waits for the box to converge, and calls `CompleteSandboxDeletion` to release quota. Routing the click there is what also tears the sandboxes down.

## Changes

- **`lib/cloud-project.ts`** (new) — `deleteCloudProject()`: calls the control-plane DELETE, then invalidates the cloud project and session queries. The local workspace cache never held this project, so the existing `updateWorkspaces` filter was a no-op for it.
- **`routes/_shell.tsx`** — `removeProject` dispatches on `kind === CLOUD_PROJECT_KIND`; local projects keep the daemon path unchanged. Telemetry (`project_remove` step, `project_removed` event, exception capture) fires on both paths. The client and org come from `useCloudCp`/`useCloudOrg`, which the shell's `useWorkspaceQuery` already subscribes to, so this adds no extra requests.
- **`components/Sidebar.tsx` + 8 locale catalogs** — the confirm dialog claimed removal "keeps the repository folder and stored history on disk", which is false for a cloud delete. Cloud projects now show `shell.removeCloudProjectBody`: the sandboxes are destroyed, session history is kept.

## Tests

- `frontend/src/renderer/lib/cloud-project.test.ts` (new): deletes via the control plane with the org id and refreshes both cloud queries; refuses without a resolved org; propagates a control-plane failure without invalidating.
- `frontend/src/renderer/components/Sidebar.test.tsx`: a cloud project's confirm dialog warns about sandboxes and no longer promises a folder on disk.
- `frontend/src/renderer/test/shell-new-session-shortcut.test.tsx`: added a `useCloudOrg` mock alongside the existing `useCloudCp` one — that harness has no `QueryClientProvider`.

```
cd frontend && npx vitest run src/renderer/lib/cloud-project.test.ts \
  src/renderer/components/Sidebar.test.tsx \
  src/renderer/test/shell-new-session-shortcut.test.tsx \
  src/renderer/i18n src/renderer/hooks/useWorkspaceQuery.test.tsx
npm run frontend:typecheck
```

Full frontend suite matches the pre-change baseline (the remaining failures are files that fail at import on missing local deps — `mermaid`, `lexical`, landing, forge — and are unrelated).

## Not verified

The sandbox teardown itself is pre-existing Go that I verified by reading, not by running: Docker is unavailable in my environment, so `npm run cloud:local:smoke` skips.

Supersedes the approach in #4913, which is built on the pre-monorepo `backend/internal/cloud/**` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)