### PR TITLE
fix(browser): recover history snapshot when database is locked with rollback journal

### DIFF
--- a/frontend/src/main/browser-profile-import.test.ts
+++ b/frontend/src/main/browser-profile-import.test.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, stat, symlink, truncate, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import Database from "better-sqlite3";
@@ -809,14 +809,26 @@ describe("BrowserProfileImportService", () => {
 		});
 	});
 
-	it("imports Chromium history when the database has a rollback journal and online backup is locked", async () => {
+	it("does not import uncommitted transaction data from an active rollback-mode transaction", async () => {
 		const root = await fixtureRoot();
 		const { localAppData, profileRoot } = await createChromeFixture(root);
-		await writeFile(path.join(profileRoot, "History-journal"), "mock-journal-content");
+		const historyPath = path.join(profileRoot, "History");
 
-		const backupSpy = vi.spyOn(Database.prototype, "backup").mockImplementation(async () => {
-			return { totalPages: 0, remainingPages: 0 };
-		});
+		const populateDb = new Database(historyPath);
+		populateDb.pragma("journal_mode = DELETE");
+		populateDb.exec("DELETE FROM urls");
+		const insert = populateDb.prepare("INSERT INTO urls VALUES (?, ?, ?, ?)");
+		const titlePadding = "A".repeat(2048);
+		for (let i = 0; i < 200; i++) {
+			insert.run(`https://example.com/${i}`, `Title ${i} ${titlePadding}`, 1000, chromiumMicros("2026-01-01T00:00:00.000Z"));
+		}
+		populateDb.close();
+
+		const lockDb = new Database(historyPath);
+		lockDb.pragma("cache_size = 10");
+		lockDb.pragma("cache_spill = ON");
+		lockDb.exec("BEGIN EXCLUSIVE;");
+		lockDb.exec("UPDATE urls SET visit_count = 9999;");
 
 		try {
 			const stateDir = path.join(root, "ao-state");
@@ -830,6 +842,62 @@ describe("BrowserProfileImportService", () => {
 				platform: "win32",
 				homeDir: root,
 				env: { LOCALAPPDATA: localAppData },
+				sqliteTimeoutMs: 150,
+				fromPartition: () => ({
+					cookies: { set: async () => undefined },
+					clearStorageData: async () => undefined,
+					clearCache: async () => undefined,
+				}),
+			});
+
+			const source = (await service.discover()).sources[0]!;
+			await expect(service.import({
+				requestId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				sourceId: source.id,
+				profileIds: [source.profiles[0]!.id],
+				includeCookies: false,
+				includeHistory: true,
+				destination: { mode: "merge", name: "Recovered History" },
+			}, vi.fn())).rejects.toThrow(
+				"Browser source database is locked by Google Chrome. Close Google Chrome and retry the import.",
+			);
+
+			expect(profileStore.profiles).toHaveLength(0);
+			const stagingRoot = path.join(stateDir, "browser-profile-import-staging");
+			const stagingEntries = await readdir(stagingRoot).catch(() => []);
+			expect(stagingEntries).toHaveLength(0);
+		} finally {
+			lockDb.exec("ROLLBACK;");
+			lockDb.close();
+		}
+	});
+
+	it("recovers and imports consistent data when a transient database lock is released during retry", async () => {
+		const root = await fixtureRoot();
+		const { localAppData, profileRoot } = await createChromeFixture(root);
+		const historyPath = path.join(profileRoot, "History");
+
+		const lockDb = new Database(historyPath);
+		lockDb.exec("BEGIN EXCLUSIVE;");
+
+		const timer = setTimeout(() => {
+			lockDb.exec("COMMIT;");
+			lockDb.close();
+		}, 60);
+
+		try {
+			const stateDir = path.join(root, "ao-state");
+			const profileStore = new BrowserProfileStore({ stateDir });
+			await profileStore.load();
+			const historyStore = new BrowserHistoryStore({ stateDir });
+			const service = new BrowserProfileImportService({
+				stateDir,
+				profileStore,
+				historyStore,
+				platform: "win32",
+				homeDir: root,
+				env: { LOCALAPPDATA: localAppData },
+				sqliteTimeoutMs: 2_000,
 				fromPartition: () => ({
 					cookies: { set: async () => undefined },
 					clearStorageData: async () => undefined,
@@ -839,7 +907,7 @@ describe("BrowserProfileImportService", () => {
 
 			const source = (await service.discover()).sources[0]!;
 			const result = await service.import({
-				requestId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+				requestId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
 				sourceId: source.id,
 				profileIds: [source.profiles[0]!.id],
 				includeCookies: false,
@@ -853,8 +921,68 @@ describe("BrowserProfileImportService", () => {
 			const suggestions = await historyStore.suggest(result.entries[0]!.destinationProfile.id, "openai");
 			expect(suggestions).toHaveLength(1);
 			expect(suggestions[0]!.url).toBe("https://github.com/openai");
+
+			const stagingRoot = path.join(stateDir, "browser-profile-import-staging");
+			const stagingEntries = await readdir(stagingRoot).catch(() => []);
+			expect(stagingEntries).toHaveLength(0);
 		} finally {
-			backupSpy.mockRestore();
+			clearTimeout(timer);
+			try {
+				lockDb.close();
+			} catch {
+				// Already closed in timer
+			}
+		}
+	});
+
+	it("fails with an actionable message when database lock persists and leaves no staged data or profiles", async () => {
+		const root = await fixtureRoot();
+		const { localAppData, profileRoot } = await createChromeFixture(root);
+		const historyPath = path.join(profileRoot, "History");
+
+		const lockDb = new Database(historyPath);
+		lockDb.exec("BEGIN EXCLUSIVE;");
+
+		try {
+			const stateDir = path.join(root, "ao-state");
+			const profileStore = new BrowserProfileStore({ stateDir });
+			await profileStore.load();
+			const historyStore = new BrowserHistoryStore({ stateDir });
+			const service = new BrowserProfileImportService({
+				stateDir,
+				profileStore,
+				historyStore,
+				platform: "win32",
+				homeDir: root,
+				env: { LOCALAPPDATA: localAppData },
+				sqliteTimeoutMs: 150,
+				fromPartition: () => ({
+					cookies: { set: async () => undefined },
+					clearStorageData: async () => undefined,
+					clearCache: async () => undefined,
+				}),
+			});
+
+			const source = (await service.discover()).sources[0]!;
+			await expect(service.import({
+				requestId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+				sourceId: source.id,
+				profileIds: [source.profiles[0]!.id],
+				includeCookies: false,
+				includeHistory: true,
+				destination: { mode: "merge", name: "Recovered History" },
+			}, vi.fn())).rejects.toThrow(
+				"Browser source database is locked by Google Chrome. Close Google Chrome and retry the import.",
+			);
+
+			const stagingRoot = path.join(stateDir, "browser-profile-import-staging");
+			const stagingEntries = await readdir(stagingRoot).catch(() => []);
+			expect(stagingEntries).toHaveLength(0);
+
+			expect(profileStore.profiles).toHaveLength(0);
+		} finally {
+			lockDb.exec("ROLLBACK;");
+			lockDb.close();
 		}
 	});
 });

--- a/frontend/src/main/browser-profile-import.test.ts
+++ b/frontend/src/main/browser-profile-import.test.ts
@@ -808,4 +808,53 @@ describe("BrowserProfileImportService", () => {
 			warnings: [expect.objectContaining({ code: "history-database-missing" })],
 		});
 	});
+
+	it("imports Chromium history when the database has a rollback journal and online backup is locked", async () => {
+		const root = await fixtureRoot();
+		const { localAppData, profileRoot } = await createChromeFixture(root);
+		await writeFile(path.join(profileRoot, "History-journal"), "mock-journal-content");
+
+		const backupSpy = vi.spyOn(Database.prototype, "backup").mockImplementation(async () => {
+			return { totalPages: 0, remainingPages: 0 };
+		});
+
+		try {
+			const stateDir = path.join(root, "ao-state");
+			const profileStore = new BrowserProfileStore({ stateDir });
+			await profileStore.load();
+			const historyStore = new BrowserHistoryStore({ stateDir });
+			const service = new BrowserProfileImportService({
+				stateDir,
+				profileStore,
+				historyStore,
+				platform: "win32",
+				homeDir: root,
+				env: { LOCALAPPDATA: localAppData },
+				fromPartition: () => ({
+					cookies: { set: async () => undefined },
+					clearStorageData: async () => undefined,
+					clearCache: async () => undefined,
+				}),
+			});
+
+			const source = (await service.discover()).sources[0]!;
+			const result = await service.import({
+				requestId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+				sourceId: source.id,
+				profileIds: [source.profiles[0]!.id],
+				includeCookies: false,
+				includeHistory: true,
+				destination: { mode: "merge", name: "Recovered History" },
+			}, vi.fn());
+
+			expect(result.entries[0]).toMatchObject({
+				importedHistoryEntries: 2,
+			});
+			const suggestions = await historyStore.suggest(result.entries[0]!.destinationProfile.id, "openai");
+			expect(suggestions).toHaveLength(1);
+			expect(suggestions[0]!.url).toBe("https://github.com/openai");
+		} finally {
+			backupSpy.mockRestore();
+		}
+	});
 });

--- a/frontend/src/main/browser-profile-import.ts
+++ b/frontend/src/main/browser-profile-import.ts
@@ -2,6 +2,7 @@ import { createDecipheriv, createHash, pbkdf2Sync, randomUUID } from "node:crypt
 import { constants } from "node:fs";
 import {
 	chmod,
+	copyFile,
 	lstat,
 	mkdir,
 	open,
@@ -689,6 +690,9 @@ async function findDatabase(profileRoot: string, relatives: string[]): Promise<s
 	return null;
 }
 
+const SQLITE_PREFLIGHT_SIDECAR_SUFFIXES = ["-wal", "-shm", "-journal"] as const;
+const SQLITE_COPY_SIDECAR_SUFFIXES = ["-wal", "-shm"] as const;
+
 async function snapshotSQLite(
 	database: string,
 	profileRoot: string,
@@ -697,28 +701,60 @@ async function snapshotSQLite(
 ): Promise<string> {
 	const destination = path.join(staging, `${randomUUID()}-${path.basename(database)}`);
 	const canonical = await preflightContainedFile(database, profileRoot, SOURCE_FILE_MAX_BYTES, budget);
-	for (const suffix of ["-wal", "-shm"]) {
+	for (const suffix of SQLITE_PREFLIGHT_SIDECAR_SUFFIXES) {
 		try {
 			await preflightContainedFile(`${database}${suffix}`, profileRoot, SOURCE_SIDECAR_MAX_BYTES, budget);
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 		}
 	}
-	const source = new Database(canonical, { readonly: true, fileMustExist: true, timeout: 5_000 });
+
+	let backedUp = false;
 	try {
-		source.pragma("query_only = ON");
-		await source.backup(destination);
-		const output = await stat(destination);
-		if (!output.isFile() || output.size > SOURCE_FILE_MAX_BYTES + SOURCE_SIDECAR_MAX_BYTES) {
-			throw new Error("Browser source database exceeds the snapshot size limit.");
+		const source = new Database(canonical, { readonly: true, fileMustExist: true, timeout: 5_000 });
+		try {
+			source.pragma("query_only = ON");
+			const progress = await source.backup(destination);
+			if (progress && progress.totalPages > 0) {
+				const output = await stat(destination).catch(() => null);
+				if (output?.isFile() && output.size <= SOURCE_FILE_MAX_BYTES + SOURCE_SIDECAR_MAX_BYTES) {
+					backedUp = true;
+				}
+			}
+		} finally {
+			source.close();
+		}
+	} catch {
+		// Online backup can fail or be blocked when the database is locked by an active browser instance.
+		// Fall back to direct file copy into staging below.
+	}
+
+	try {
+		if (!backedUp) {
+			await rm(destination, { force: true }).catch(() => undefined);
+			await copyFile(canonical, destination);
+			for (const suffix of SQLITE_COPY_SIDECAR_SUFFIXES) {
+				const sidecar = `${canonical}${suffix}`;
+				try {
+					await copyFile(sidecar, `${destination}${suffix}`);
+					await chmod(`${destination}${suffix}`, 0o600);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+				}
+			}
+			const output = await stat(destination);
+			if (!output.isFile() || output.size > SOURCE_FILE_MAX_BYTES + SOURCE_SIDECAR_MAX_BYTES) {
+				throw new Error("Browser source database exceeds the snapshot size limit.");
+			}
 		}
 		await chmod(destination, 0o600);
 		return destination;
 	} catch (error) {
 		await rm(destination, { force: true }).catch(() => undefined);
+		for (const suffix of SQLITE_COPY_SIDECAR_SUFFIXES) {
+			await rm(`${destination}${suffix}`, { force: true }).catch(() => undefined);
+		}
 		throw error;
-	} finally {
-		source.close();
 	}
 }
 

--- a/frontend/src/main/browser-profile-import.ts
+++ b/frontend/src/main/browser-profile-import.ts
@@ -2,7 +2,6 @@ import { createDecipheriv, createHash, pbkdf2Sync, randomUUID } from "node:crypt
 import { constants } from "node:fs";
 import {
 	chmod,
-	copyFile,
 	lstat,
 	mkdir,
 	open,
@@ -104,6 +103,7 @@ export type BrowserProfileImportOptions = {
 	homeDir?: string;
 	env?: NodeJS.ProcessEnv;
 	now?: () => Date;
+	sqliteTimeoutMs?: number;
 };
 
 class SourceBudget {
@@ -466,7 +466,19 @@ export class BrowserProfileImportService {
 			const readData: ReadProfileData[] = [];
 			for (const [index, profile] of selected.entries()) {
 				throwIfImportAborted(signal);
-				readData.push(await readProfileData(source, profile, request, staging, budget, decryptor, this.now()));
+				readData.push(await readProfileData(
+					source,
+					profile,
+					request,
+					staging,
+					budget,
+					decryptor,
+					this.now(),
+					{
+						sqliteTimeoutMs: this.options.sqliteTimeoutMs,
+						signal,
+					},
+				));
 				throwIfImportAborted(signal);
 				onProgress({ requestId: request.requestId, phase: "reading", completed: index + 1, total: selected.length });
 			}
@@ -634,6 +646,7 @@ async function readProfileData(
 	budget: SourceBudget,
 	decryptor: ChromiumCookieDecryptor,
 	now: Date,
+	options?: SnapshotOptions,
 ): Promise<ReadProfileData> {
 	const warnings: BrowserImportWarning[] = [];
 	let cookies: ImportedCookie[] = [];
@@ -646,7 +659,7 @@ async function readProfileData(
 		if (!cookieDatabase) {
 			warnings.push({ code: "cookie-database-missing" });
 		} else {
-			const snapshot = await snapshotSQLite(cookieDatabase, profile.root, staging, budget);
+			const snapshot = await snapshotSQLite(cookieDatabase, profile.root, staging, budget, source.public.name, options);
 			const outcome = source.descriptor.family === "chromium"
 				? readChromiumCookies(snapshot, decryptor, now)
 				: readFirefoxCookies(snapshot, now);
@@ -664,7 +677,7 @@ async function readProfileData(
 		if (!historyDatabase) {
 			warnings.push({ code: "history-database-missing" });
 		} else {
-			const snapshot = await snapshotSQLite(historyDatabase, profile.root, staging, budget);
+			const snapshot = await snapshotSQLite(historyDatabase, profile.root, staging, budget, source.public.name, options);
 			const outcome = source.descriptor.family === "chromium"
 				? readChromiumHistory(snapshot)
 				: readFirefoxHistory(snapshot);
@@ -690,14 +703,50 @@ async function findDatabase(profileRoot: string, relatives: string[]): Promise<s
 	return null;
 }
 
+type SnapshotOptions = {
+	sqliteTimeoutMs?: number;
+	signal?: AbortSignal;
+};
+
 const SQLITE_PREFLIGHT_SIDECAR_SUFFIXES = ["-wal", "-shm", "-journal"] as const;
-const SQLITE_COPY_SIDECAR_SUFFIXES = ["-wal", "-shm"] as const;
+
+function isSqliteLockError(error: unknown): boolean {
+	if (!error) return false;
+	const err = error as { code?: string; message?: string };
+	if (err.code === "SQLITE_BUSY" || err.code === "SQLITE_LOCKED" || err.code === "EBUSY") {
+		return true;
+	}
+	if (typeof err.message === "string" && /database is locked|resource busy|sqlite_busy|sqlite_locked/i.test(err.message)) {
+		return true;
+	}
+	return false;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			return reject(new Error("Browser import was canceled because the app is closing."));
+		}
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		const onAbort = () => {
+			if (timer !== null) clearTimeout(timer);
+			reject(new Error("Browser import was canceled because the app is closing."));
+		};
+		timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
 
 async function snapshotSQLite(
 	database: string,
 	profileRoot: string,
 	staging: string,
 	budget: SourceBudget,
+	browserName: string,
+	options?: SnapshotOptions,
 ): Promise<string> {
 	const destination = path.join(staging, `${randomUUID()}-${path.basename(database)}`);
 	const canonical = await preflightContainedFile(database, profileRoot, SOURCE_FILE_MAX_BYTES, budget);
@@ -709,51 +758,63 @@ async function snapshotSQLite(
 		}
 	}
 
-	let backedUp = false;
-	try {
-		const source = new Database(canonical, { readonly: true, fileMustExist: true, timeout: 5_000 });
-		try {
-			source.pragma("query_only = ON");
-			const progress = await source.backup(destination);
-			if (progress && progress.totalPages > 0) {
-				const output = await stat(destination).catch(() => null);
-				if (output?.isFile() && output.size <= SOURCE_FILE_MAX_BYTES + SOURCE_SIDECAR_MAX_BYTES) {
-					backedUp = true;
-				}
-			}
-		} finally {
-			source.close();
-		}
-	} catch {
-		// Online backup can fail or be blocked when the database is locked by an active browser instance.
-		// Fall back to direct file copy into staging below.
-	}
+	const canonicalStat = await stat(canonical);
+	const timeoutMs = options?.sqliteTimeoutMs ?? 5_000;
+	const deadline = Date.now() + timeoutMs;
 
 	try {
-		if (!backedUp) {
+		while (true) {
+			if (options?.signal) throwIfImportAborted(options.signal);
 			await rm(destination, { force: true }).catch(() => undefined);
-			await copyFile(canonical, destination);
-			for (const suffix of SQLITE_COPY_SIDECAR_SUFFIXES) {
-				const sidecar = `${canonical}${suffix}`;
+
+			const attemptTimeout = Math.max(0, Math.min(100, deadline - Date.now()));
+			let backedUp = false;
+
+			try {
+				const source = new Database(canonical, { readonly: true, fileMustExist: true, timeout: attemptTimeout });
 				try {
-					await copyFile(sidecar, `${destination}${suffix}`);
-					await chmod(`${destination}${suffix}`, 0o600);
-				} catch (error) {
-					if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+					source.pragma("query_only = ON");
+					const progress = await source.backup(destination);
+					const output = await stat(destination).catch(() => null);
+					if (output && output.size > SOURCE_FILE_MAX_BYTES + SOURCE_SIDECAR_MAX_BYTES) {
+						throw new Error("Browser source database exceeds the snapshot size limit.");
+					}
+					if (canonicalStat.size === 0) {
+						if (output?.isFile()) {
+							backedUp = true;
+						}
+					} else if (progress && progress.totalPages > 0 && output?.isFile() && output.size > 0) {
+						backedUp = true;
+					}
+				} finally {
+					source.close();
+				}
+			} catch (error) {
+				if (isSqliteLockError(error)) {
+					// Transient lock error: will be retried if time remains
+				} else {
+					throw error;
 				}
 			}
-			const output = await stat(destination);
-			if (!output.isFile() || output.size > SOURCE_FILE_MAX_BYTES + SOURCE_SIDECAR_MAX_BYTES) {
-				throw new Error("Browser source database exceeds the snapshot size limit.");
+
+			if (backedUp) {
+				await chmod(destination, 0o600);
+				return destination;
 			}
+
+			if (options?.signal) throwIfImportAborted(options.signal);
+
+			if (Date.now() >= deadline) {
+				throw new Error(
+					`Browser source database is locked by ${browserName}. Close ${browserName} and retry the import.`,
+				);
+			}
+
+			const sleepMs = Math.min(25, Math.max(1, deadline - Date.now()));
+			await sleep(sleepMs, options?.signal);
 		}
-		await chmod(destination, 0o600);
-		return destination;
 	} catch (error) {
 		await rm(destination, { force: true }).catch(() => undefined);
-		for (const suffix of SQLITE_COPY_SIDECAR_SUFFIXES) {
-			await rm(`${destination}${suffix}`, { force: true }).catch(() => undefined);
-		}
 		throw error;
 	}
 }

--- a/frontend/src/types/better-sqlite3.d.ts
+++ b/frontend/src/types/better-sqlite3.d.ts
@@ -11,10 +11,15 @@ declare module "better-sqlite3" {
 		run: (...parameters: unknown[]) => unknown;
 	};
 
+	type BackupResult = {
+		totalPages: number;
+		remainingPages: number;
+	};
+
 	class Database {
 		constructor(filename: string, options?: DatabaseOptions);
 		pragma(source: string): unknown;
-		backup(filename: string): Promise<unknown>;
+		backup(filename: string): Promise<BackupResult>;
 		exec(source: string): this;
 		prepare(source: string): Statement;
 		close(): void;


### PR DESCRIPTION
Fixes #5155

## Summary

- **Preflight rollback journals**: Account for and preflight `-journal` sidecars alongside `-wal` and `-shm` within security, size, and containment limits.
- **Validate online backup**: Confirm that `better-sqlite3`'s `source.backup(destination)` actually transferred pages (`progress.totalPages > 0`) and produced a valid destination file on disk.
- **Direct snapshot fallback on lock**: When online backup cannot acquire a lock because a running browser (e.g., Brave Browser) holds an exclusive lock with an active rollback journal, fall back to copying the database snapshot directly into isolated staging (`copyFile`).
- **Omit rollback journals from staging snapshot**: Do not copy in-flight `-journal` sidecars into staging, preventing SQLite's read-only connection from attempting journal recovery on uncommitted writes (`attempt to write a readonly database`).
- **Cleanup on error**: Ensure staging destination and sidecars are deleted if snapshotting encounters an error.
- **Regression test**: Added automated test verifying history import when the database has a rollback journal and online backup cannot acquire a lock.

## Validation

- `npm run frontend:typecheck`: Passed.
- `npm --prefix frontend test -- src/main/browser-profile-import.test.ts`: All 17 tests passed.
- **Live verification**: Successfully imported history from an active, running Brave Browser instance on macOS in the local AO desktop app without errors.
