### PR TITLE
fix(cli): reject missing required daemon response bodies

### DIFF
--- a/backend/internal/cli/client.go
+++ b/backend/internal/cli/client.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -18,6 +19,10 @@ import (
 // worktree add, tmux launch, hook install), so it is generous compared to the
 // status probe timeout.
 const commandTimeout = 2 * time.Minute
+
+// maxDrainedBodyBytes bounds how much of an unused response body the CLI
+// discards for keep-alive reuse without an unbounded read.
+const maxDrainedBodyBytes = 4 << 10
 
 // apiError is the subset of the daemon's JSON error envelope the CLI surfaces.
 // RequestID is surfaced so a failed command can be correlated with daemon logs.
@@ -164,13 +169,51 @@ func (c *commandContext) doJSONPathWithHeadersAndTimeout(
 		_ = json.NewDecoder(resp.Body).Decode(&e)
 		return apiResponseError{StatusCode: resp.StatusCode, ErrorBody: e}
 	}
-	if out != nil {
-		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+	if out == nil {
+		// Explicitly bodyless call (telemetry/activity hooks, fire-and-forget
+		// posts). Drain only a bounded remainder so the connection can be
+		// reused without an unbounded read.
+		_, _ = io.CopyN(io.Discard, resp.Body, maxDrainedBodyBytes)
+		return nil
+	}
+	// A 204 carries no body by contract; a zero-value out is the legitimate
+	// result. Any other 2xx with a required decoded result must carry a
+	// JSON document — an empty body is a broken contract, not success.
+	if resp.StatusCode == http.StatusNoContent {
+		_, _ = io.CopyN(io.Discard, resp.Body, maxDrainedBodyBytes)
+		return nil
+	}
+	// Peek at the first non-whitespace byte before decoding: an empty body
+	// surfaces as io.EOF, but a literal JSON null decodes successfully into
+	// a zero value. Both are a broken contract for a required result, so
+	// both are rejected here rather than silently succeeding.
+	br := bufio.NewReader(resp.Body)
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil
+				return fmt.Errorf("decode response: missing required response body (HTTP %d %s %s): %w", resp.StatusCode, method, path, err)
 			}
 			return fmt.Errorf("decode response: %w", err)
 		}
+		if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+			continue
+		}
+		if b == 'n' {
+			if rest, err := br.Peek(3); err == nil && string(rest) == "ull" {
+				return fmt.Errorf("decode response: missing required response body (HTTP %d %s %s): null response body", resp.StatusCode, method, path)
+			}
+		}
+		if err := br.UnreadByte(); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+		break
+	}
+	if err := json.NewDecoder(br).Decode(out); err != nil {
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("decode response: missing required response body (HTTP %d %s %s): %w", resp.StatusCode, method, path, err)
+		}
+		return fmt.Errorf("decode response: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/cli/client_transport_test.go
+++ b/backend/internal/cli/client_transport_test.go
@@ -167,6 +167,49 @@ func TestSpawnRejectsEmptySessionID(t *testing.T) {
 	}
 }
 
+// TestReviewSubmitBatchRejectsEmptyEntries ensures batch review submit fails
+// instead of printing success when any returned entry is missing its run ID
+// or verdict — including empty objects and JSON nulls.
+func TestReviewSubmitBatchRejectsEmptyEntries(t *testing.T) {
+	batchInput := `[{"runId":"run-1","verdict":"approved"}]`
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"empty entry", `{"reviews":[{}]}`},
+		{"null entry", `{"reviews":[null]}`},
+		{"id-only entry", `{"reviews":[{"id":"run-1"}]}`},
+		{"verdict-only entry", `{"reviews":[{"verdict":"approved"}]}`},
+		{"one bad entry among good", `{"reviews":[{"id":"run-1","verdict":"approved"},{}]}`},
+		{"empty array and empty single", `{"reviews":[]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setConfigEnv(t)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tt.body)
+			}))
+			t.Cleanup(srv.Close)
+			writeRunFileFor(t, cfg, srv)
+
+			deps := Deps{ProcessAlive: func(int) bool { return true }}
+			deps.In = strings.NewReader(batchInput)
+			out, _, err := executeCLI(t, deps,
+				"review", "submit", "sess-1", "--reviews", "-")
+			if err == nil {
+				t.Fatalf("body %q: expected batch submit error, got nil", tt.body)
+			}
+			if !strings.Contains(err.Error(), "empty review result") {
+				t.Fatalf("body %q: err = %q, want empty review result", tt.body, err.Error())
+			}
+			if strings.Contains(out, "recorded") {
+				t.Fatalf("body %q: must not print success, got %q", tt.body, out)
+			}
+		})
+	}
+}
+
 // TestReviewSubmitRejectsEmptyResult ensures review submit fails instead of
 // reporting a recorded review when the daemon returns nothing useful: an
 // empty body fails at the transport layer, while a valid-but-empty document

--- a/backend/internal/cli/client_transport_test.go
+++ b/backend/internal/cli/client_transport_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -125,8 +126,8 @@ func TestTransportDistinguishesEmptyResponses(t *testing.T) {
 		c := transportContext(t, cfg, srv)
 		var out spawnResult
 		err := c.postJSON(ctx, "sessions", struct{}{}, &out)
-		apiErr, ok := err.(apiResponseError)
-		if !ok {
+		var apiErr apiResponseError
+		if !errors.As(err, &apiErr) {
 			t.Fatalf("error type = %T, want apiResponseError", err)
 		}
 		if apiErr.ErrorBody.Code != "NOT_FOUND" || apiErr.ErrorBody.RequestID != "req-1" {

--- a/backend/internal/cli/client_transport_test.go
+++ b/backend/internal/cli/client_transport_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// transportServer returns an httptest server that always answers with the
+// given status and body for any CLI daemon call.
+func transportServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func transportContext(t *testing.T, cfg testConfig, srv *httptest.Server) *commandContext {
+	t.Helper()
+	writeRunFileFor(t, cfg, srv)
+	return &commandContext{deps: Deps{
+		HTTPClient:   &http.Client{},
+		ProcessAlive: func(int) bool { return true },
+	}}
+}
+
+// TestTransportDistinguishesEmptyResponses is the API-014 regression: an empty
+// 200/201 with a required decoded result must fail, while legitimate
+// bodyless calls (nil out) and 204 responses keep succeeding.
+func TestTransportDistinguishesEmptyResponses(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	t.Run("empty 200 with required body fails", func(t *testing.T) {
+		cfg := setConfigEnv(t)
+		srv := transportServer(t, http.StatusOK, ``)
+		c := transportContext(t, cfg, srv)
+		var out spawnResult
+		if err := c.postJSON(ctx, "sessions", struct{}{}, &out); err == nil {
+			t.Fatal("expected error for empty 200 with required body, got nil")
+		} else if !strings.Contains(err.Error(), "missing required response body") {
+			t.Fatalf("error = %q, want missing required response body", err.Error())
+		}
+	})
+
+	t.Run("empty 201 with required body fails", func(t *testing.T) {
+		cfg := setConfigEnv(t)
+		srv := transportServer(t, http.StatusCreated, ``)
+		c := transportContext(t, cfg, srv)
+		var out spawnResult
+		if err := c.postJSON(ctx, "sessions", struct{}{}, &out); err == nil {
+			t.Fatal("expected error for empty 201 with required body, got nil")
+		}
+	})
+
+	t.Run("204 empty with decoded result succeeds", func(t *testing.T) {
+		cfg := setConfigEnv(t)
+		srv := transportServer(t, http.StatusNoContent, ``)
+		c := transportContext(t, cfg, srv)
+		var out projectRemoveResult
+		if err := c.deleteJSON(ctx, "projects/demo", &out); err != nil {
+			t.Fatalf("204 with decoded result should succeed, got: %v", err)
+		}
+	})
+
+	t.Run("nil output tolerates empty 200", func(t *testing.T) {
+		cfg := setConfigEnv(t)
+		srv := transportServer(t, http.StatusOK, ``)
+		c := transportContext(t, cfg, srv)
+		if err := c.postJSON(ctx, "sessions/ao-1/activity", struct{}{}, nil); err != nil {
+			t.Fatalf("nil output should tolerate empty body, got: %v", err)
+		}
+	})
+
+	t.Run("valid JSON still decodes", func(t *testing.T) {
+		cfg := setConfigEnv(t)
+		srv := transportServer(t, http.StatusOK, `{"session":{"id":"demo-11","status":"idle"}}`)
+		c := transportContext(t, cfg, srv)
+		var out spawnResult
+		if err := c.postJSON(ctx, "sessions", struct{}{}, &out); err != nil {
+			t.Fatalf("valid JSON should decode, got: %v", err)
+		}
+		if out.Session.ID != "demo-11" {
+			t.Fatalf("Session.ID = %q, want demo-11", out.Session.ID)
+		}
+	})
+
+	t.Run("malformed JSON fails", func(t *testing.T) {
+		cfg := setConfigEnv(t)
+		srv := transportServer(t, http.StatusOK, `{not-json`)
+		c := transportContext(t, cfg, srv)
+		var out spawnResult
+		if err := c.postJSON(ctx, "sessions", struct{}{}, &out); err == nil {
+			t.Fatal("expected error for malformed JSON, got nil")
+		}
+	})
+
+	t.Run("literal null with required body fails", func(t *testing.T) {
+		for _, body := range []string{`null`, "  null  \n"} {
+			cfg := setConfigEnv(t)
+			srv := transportServer(t, http.StatusOK, body)
+			c := transportContext(t, cfg, srv)
+			var out spawnResult
+			err := c.postJSON(ctx, "sessions", struct{}{}, &out)
+			if err == nil {
+				t.Fatalf("body %q: expected error for null body, got nil", body)
+			}
+			if !strings.Contains(err.Error(), "missing required response body") {
+				t.Fatalf("body %q: error = %q, want missing required response body", body, err.Error())
+			}
+		}
+	})
+
+	t.Run("daemon error envelope keeps code and request id", func(t *testing.T) {
+		cfg := setConfigEnv(t)
+		srv := transportServer(t, http.StatusNotFound, `{"message":"nope","code":"NOT_FOUND","requestId":"req-1"}`)
+		c := transportContext(t, cfg, srv)
+		var out spawnResult
+		err := c.postJSON(ctx, "sessions", struct{}{}, &out)
+		apiErr, ok := err.(apiResponseError)
+		if !ok {
+			t.Fatalf("error type = %T, want apiResponseError", err)
+		}
+		if apiErr.ErrorBody.Code != "NOT_FOUND" || apiErr.ErrorBody.RequestID != "req-1" {
+			t.Fatalf("envelope = %+v, want code NOT_FOUND request req-1", apiErr.ErrorBody)
+		}
+	})
+}
+
+// TestSpawnRejectsEmptySessionID ensures a daemon that answers spawn with an
+// empty (but valid) body can never print a success line.
+func TestSpawnRejectsEmptySessionID(t *testing.T) {
+	for _, body := range []string{``, `{}`} {
+		cfg := setConfigEnv(t)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/demo":
+				_, _ = io.WriteString(w, `{"status":"ok","project":{"id":"demo","name":"Demo","path":"/repo/demo","config":{"worker":{"agent":"codex"}}}}`)
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/readiness/ensure":
+				_, _ = io.WriteString(w, authorizedAgentsJSON("codex"))
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
+				_, _ = io.WriteString(w, body)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		writeRunFileFor(t, cfg, srv)
+
+		out, _, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }},
+			"spawn", "--project", "demo", "--agent", "codex", "--name", "worker")
+		if err == nil {
+			t.Fatalf("body %q: expected spawn error, got success %q", body, out)
+		}
+		if strings.Contains(out, "spawned session") {
+			t.Fatalf("body %q: must not print success, got %q", body, out)
+		}
+	}
+}
+
+// TestReviewSubmitRejectsEmptyResult ensures review submit fails instead of
+// reporting a recorded review when the daemon returns nothing useful: an
+// empty body fails at the transport layer, while a valid-but-empty document
+// fails at the caller guard.
+func TestReviewSubmitRejectsEmptyResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{"empty body fails at transport", ``, "missing required response body"},
+		{"empty document fails at guard", `{}`, "empty review result"},
+		{"half-populated document fails at guard", `{"review":{"id":"run-1"}}`, "empty review result"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setConfigEnv(t)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tt.body)
+			}))
+			t.Cleanup(srv.Close)
+			writeRunFileFor(t, cfg, srv)
+
+			_, _, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }},
+				"review", "submit", "sess-1", "--run", "run-1", "--verdict", "approved")
+			if err == nil {
+				t.Fatalf("body %q: expected review submit error, got nil", tt.body)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("body %q: err = %q, want %q", tt.body, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -221,9 +221,17 @@ func (c *commandContext) submitReviewBatch(cmd *cobra.Command, session string, o
 	if err := c.postJSON(cmd.Context(), path, submitReviewRequest{Reviews: reviews}, &res); err != nil {
 		return err
 	}
-	// Batch success is the recorded runs array, falling back to a
-	// fully-populated single review. Anything less is a broken contract.
-	if len(res.Reviews) == 0 && (strings.TrimSpace(res.Review.ID) == "" || strings.TrimSpace(res.Review.Verdict) == "") {
+	// Batch success is the recorded runs array: every returned entry must
+	// carry its run ID and verdict. An empty array falls back to requiring
+	// a fully-populated single review. Anything less is a broken contract,
+	// not a success to print.
+	if len(res.Reviews) > 0 {
+		for _, run := range res.Reviews {
+			if strings.TrimSpace(run.ID) == "" || strings.TrimSpace(run.Verdict) == "" {
+				return fmt.Errorf("daemon returned empty review result for %s", session)
+			}
+		}
+	} else if strings.TrimSpace(res.Review.ID) == "" || strings.TrimSpace(res.Review.Verdict) == "" {
 		return fmt.Errorf("daemon returned empty review result for %s", session)
 	}
 	count := len(res.Reviews)

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -198,6 +198,12 @@ func (c *commandContext) submitReview(cmd *cobra.Command, args []string, opts re
 	if err := c.postJSON(cmd.Context(), path, submitReviewRequest{RunID: runID, Verdict: verdict, Body: body, GithubReviewID: reviewID}, &res); err != nil {
 		return err
 	}
+	// A submit response always carries the recorded run's ID and verdict; a
+	// structurally valid but half-populated result is a broken contract, not
+	// a success to print.
+	if strings.TrimSpace(res.Review.ID) == "" || strings.TrimSpace(res.Review.Verdict) == "" {
+		return fmt.Errorf("daemon returned empty review result for %s", session)
+	}
 	_, err := fmt.Fprintf(cmd.OutOrStdout(), "recorded %s review for %s\n", res.Review.Verdict, session)
 	return err
 }
@@ -214,6 +220,11 @@ func (c *commandContext) submitReviewBatch(cmd *cobra.Command, session string, o
 	var res reviewRunResponse
 	if err := c.postJSON(cmd.Context(), path, submitReviewRequest{Reviews: reviews}, &res); err != nil {
 		return err
+	}
+	// Batch success is the recorded runs array, falling back to a
+	// fully-populated single review. Anything less is a broken contract.
+	if len(res.Reviews) == 0 && (strings.TrimSpace(res.Review.ID) == "" || strings.TrimSpace(res.Review.Verdict) == "") {
+		return fmt.Errorf("daemon returned empty review result for %s", session)
 	}
 	count := len(res.Reviews)
 	if count == 0 {

--- a/backend/internal/cli/review_test.go
+++ b/backend/internal/cli/review_test.go
@@ -38,7 +38,7 @@ func aliveDeps() Deps { return Deps{ProcessAlive: func(int) bool { return true }
 
 func TestReviewSubmitReadsBodyFile(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"verdict":"changes_requested"}}`)
+	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"id":"run-1","verdict":"changes_requested"}}`)
 	writeRunFileFor(t, cfg, srv)
 
 	bodyFile := filepath.Join(t.TempDir(), "review.md")
@@ -65,7 +65,7 @@ func TestReviewSubmitReadsBodyFile(t *testing.T) {
 
 func TestReviewSubmitReadsBodyFromStdin(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"verdict":"changes_requested"}}`)
+	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"id":"run-1","verdict":"changes_requested"}}`)
 	writeRunFileFor(t, cfg, srv)
 
 	deps := aliveDeps()
@@ -86,7 +86,7 @@ func TestReviewSubmitReadsBodyFromStdin(t *testing.T) {
 
 func TestReviewSubmitAcceptsUnderscoreFlags(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"verdict":"changes_requested"}}`)
+	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"id":"run-1","verdict":"changes_requested"}}`)
 	writeRunFileFor(t, cfg, srv)
 
 	// Reviewer agents often spell --review-id as --review_id; both must work.
@@ -132,7 +132,7 @@ func TestReviewSubmitBatchReadsReviewsFromStdin(t *testing.T) {
 
 func TestReviewSubmitUsesSessionFlag(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"verdict":"approved"}}`)
+	srv, capture := reviewServer(t, http.StatusOK, `{"review":{"id":"run-7","verdict":"approved"}}`)
 	writeRunFileFor(t, cfg, srv)
 
 	if _, errOut, err := executeCLI(t, aliveDeps(), "review", "submit", "--session", "mer-7", "--run", "run-7", "--verdict", "approved"); err != nil {

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -148,6 +148,9 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			if err := ctx.postJSON(cmd.Context(), "sessions", req, &res); err != nil {
 				return err
 			}
+			if strings.TrimSpace(res.Session.ID) == "" {
+				return fmt.Errorf("daemon returned empty session id for spawn")
+			}
 			claimed := ""
 			if opts.claimPR != "" {
 				var claim claimPRResponse


### PR DESCRIPTION
## Summary
Fixes API-014 from the Backend Cleanup handoff: the shared CLI transport treated an empty 200/201 body as success whenever a decoded result was requested, so commands like spawn and review submit could print success with a zero-value DTO.

## Why
- Empty 200/201 with a required body is a broken daemon contract, not success (false-positive spawn confirmations, follow-on calls with empty IDs).
- Literal JSON null decoded the same silent zero-value way.
- Legitimate bodyless calls (nil out) and 204 responses must keep working.

## Files affected
- backend/internal/cli/client.go — required-vs-bodyless decode policy, 204 allowance, bounded 4 KiB drain, empty/null rejection with status/method/path context.
- backend/internal/cli/spawn.go — rejects empty Session.ID after POST sessions.
- backend/internal/cli/review.go — single submit requires run ID and verdict; batch requires recorded runs or a fully-populated review.
- backend/internal/cli/review_test.go — fixtures now return realistic full runs (id + verdict).
- backend/internal/cli/client_transport_test.go — new API-014 regression tests.

## Tests
- [x] go test -count=1 ./internal/cli/ (from backend/)
- [x] go test -count=1 -race ./internal/cli/
- [x] go vet ./internal/cli/
- [x] go build ./...
- [x] gofmt -l internal/cli/ clean