### PR TITLE
fix(desktop): keep interface-switch status off the session tab title

### DIFF
--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -75,6 +75,8 @@ type CenterPaneProps = {
 	topbarActions?: ReactNode;
 	/** Agent-session actions (interface switch, handoff) on the primary session tab. */
 	sessionTabAction?: ReactNode;
+	/** Widen the primary tab's action slot while an interface switch spinner is showing. */
+	sessionTabActionWide?: boolean;
 	/** Pinned beside the tab strip, before the workspace topbar actions. */
 	tabStripAction?: ReactNode;
 	handoffDialogOpen?: boolean;
@@ -157,6 +159,7 @@ export function CenterPane({
 	onRenameShellTerminal,
 	topbarActions,
 	sessionTabAction,
+	sessionTabActionWide = false,
 	tabStripAction,
 	handoffDialogOpen = false,
 	workspaceTabs,
@@ -634,6 +637,7 @@ export function CenterPane({
 											onRenamed={refreshWorkspaces}
 											session={session}
 											tabAction={sessionTabAction}
+											tabActionWide={sessionTabActionWide}
 										/>
 									) : (
 										<SessionPaneTab isActive={target.kind === "worker"} label={sessionTabLabel} />
@@ -931,6 +935,8 @@ type SessionPaneTabProps = {
 	title?: string;
 	/** Session-scoped controls (interface switch, handoff) beside the tab label. */
 	tabAction?: ReactNode;
+	/** Only while switching: reserve action width so the spinner does not cover the title. */
+	tabActionWide?: boolean;
 };
 
 // Shared tab chrome: the open tab is highlighted with the same rounded
@@ -947,6 +953,7 @@ export function SessionPaneTab({
 	icon,
 	title,
 	tabAction,
+	tabActionWide = false,
 }: SessionPaneTabProps) {
 	const { t } = useTranslation();
 	const { ref, isTruncated } = useTruncatedText<HTMLButtonElement>(label);
@@ -986,6 +993,9 @@ export function SessionPaneTab({
 	const tabFrame = (
 		<TerminalTabFrame
 			action={!rename.isEditing && tabAction ? <span data-testid="session-tab-action">{tabAction}</span> : undefined}
+			// Idle tabs keep the overlay ⋮ slot (title looks like before). Only while
+			// switching do we reserve width so the spinner cannot cover the label.
+			actionLayout={tabActionWide ? "inline" : "overlay"}
 			active={isActive}
 			buttonProps={{
 				"aria-current": isActive,

--- a/frontend/src/renderer/components/SessionActionsMenu.tsx
+++ b/frontend/src/renderer/components/SessionActionsMenu.tsx
@@ -20,8 +20,7 @@ export function SessionActionsMenu({
 	if (menuItems.length === 0 && !inlineStatus) return null;
 
 	return (
-		<div className="inline-flex shrink-0 items-center gap-1">
-			{inlineStatus}
+		<div className="inline-flex shrink-0 items-center gap-0.5">
 			{menuItems.length > 0 ? (
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
@@ -41,6 +40,7 @@ export function SessionActionsMenu({
 					</DropdownMenuContent>
 				</DropdownMenu>
 			) : null}
+			{inlineStatus}
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/SessionActionsMenu.tsx
+++ b/frontend/src/renderer/components/SessionActionsMenu.tsx
@@ -19,28 +19,31 @@ export function SessionActionsMenu({
 	const menuItems = Children.toArray(children).filter(Boolean);
 	if (menuItems.length === 0 && !inlineStatus) return null;
 
+	// While an interface switch is running, replace the ⋮ entirely with the
+	// status spinner so handoff/cancel controls cannot interrupt a half-applied switch.
+	if (inlineStatus) {
+		return <div className="inline-flex shrink-0 items-center">{inlineStatus}</div>;
+	}
+
 	return (
 		<div className="inline-flex shrink-0 items-center gap-0.5">
-			{menuItems.length > 0 ? (
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<TopbarButton
-							aria-label={t("session.actionsMenu")}
-							className="size-7 !bg-transparent text-muted-foreground hover:!bg-transparent active:!bg-transparent focus:!bg-transparent data-[state=open]:!bg-transparent hover:text-foreground"
-							data-session-actions-trigger
-							title={t("session.actionsMenu")}
-							type="button"
-							variant="icon"
-						>
-							<MoreVertical aria-hidden="true" className="size-icon-md" />
-						</TopbarButton>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" className="min-w-44">
-						{menuItems}
-					</DropdownMenuContent>
-				</DropdownMenu>
-			) : null}
-			{inlineStatus}
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<TopbarButton
+						aria-label={t("session.actionsMenu")}
+						className="size-7 !bg-transparent text-muted-foreground hover:!bg-transparent active:!bg-transparent focus:!bg-transparent data-[state=open]:!bg-transparent hover:text-foreground"
+						data-session-actions-trigger
+						title={t("session.actionsMenu")}
+						type="button"
+						variant="icon"
+					>
+						<MoreVertical aria-hidden="true" className="size-icon-md" />
+					</TopbarButton>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="min-w-44">
+					{menuItems}
+				</DropdownMenuContent>
+			</DropdownMenu>
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.test.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.test.tsx
@@ -47,19 +47,28 @@ describe("SessionInterfaceSwitchButton", () => {
 		expect(group).not.toHaveClass("gap-px");
 	});
 
-	it("keeps a draining switch in the top bar with an adjacent Cancel action", () => {
+	it("keeps a draining switch in the top bar as an icon-only loader with Cancel", () => {
 		const onCancel = vi.fn();
 		render(
-			<SessionInterfaceSwitchButton
-				target="chat"
-				supported
-				transition={transition("draining")}
-				onClick={vi.fn()}
-				onCancel={onCancel}
-			/>,
+			<TooltipProvider>
+				<SessionInterfaceSwitchButton
+					target="chat"
+					supported
+					transition={transition("draining")}
+					onClick={vi.fn()}
+					onCancel={onCancel}
+				/>
+			</TooltipProvider>,
 		);
 
-		expect(screen.getByRole("status")).toHaveTextContent("Waiting to switch… Chat UI");
+		const status = screen.getByRole("status");
+		expect(status).toHaveAttribute(
+			"aria-label",
+			"Waiting to switch… Switching to Chat UI.",
+		);
+		expect(status).not.toHaveTextContent("Waiting to switch…");
+		expect(status).not.toHaveTextContent("Chat UI");
+		expect(status.querySelector(".animate-spin")).not.toBeNull();
 		const cancel = screen.getByRole("button", { name: "Cancel switch to Chat UI" });
 		fireEvent.click(cancel);
 		expect(onCancel).toHaveBeenCalledOnce();
@@ -67,16 +76,23 @@ describe("SessionInterfaceSwitchButton", () => {
 
 	it("stays non-interactive after the source controller begins stopping", () => {
 		render(
-			<SessionInterfaceSwitchButton
-				target="chat"
-				supported
-				transition={transition("source_stopping")}
-				onClick={vi.fn()}
-				onCancel={vi.fn()}
-			/>,
+			<TooltipProvider>
+				<SessionInterfaceSwitchButton
+					target="chat"
+					supported
+					transition={transition("source_stopping")}
+					onClick={vi.fn()}
+					onCancel={vi.fn()}
+				/>
+			</TooltipProvider>,
 		);
 
-		expect(screen.getByRole("status")).toHaveTextContent("Stopping controller… Chat UI");
+		const status = screen.getByRole("status");
+		expect(status).toHaveAttribute(
+			"aria-label",
+			"Stopping controller… Switching to Chat UI.",
+		);
+		expect(status).not.toHaveTextContent("Stopping controller…");
 		expect(screen.queryByRole("button", { name: "Cancel switch to Chat UI" })).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.test.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.test.tsx
@@ -47,17 +47,20 @@ describe("SessionInterfaceSwitchButton", () => {
 		expect(group).not.toHaveClass("gap-px");
 	});
 
-	it("keeps a draining switch in the top bar as an icon-only loader with Cancel", () => {
+	it("shows a spinner while switching and reveals cancel on the tab hover target", () => {
 		const onCancel = vi.fn();
 		render(
 			<TooltipProvider>
-				<SessionInterfaceSwitchButton
-					target="chat"
-					supported
-					transition={transition("draining")}
-					onClick={vi.fn()}
-					onCancel={onCancel}
-				/>
+				{/* TerminalTabFrame marks the session tab with Tailwind `group`. */}
+				<div className="group">
+					<SessionInterfaceSwitchButton
+						target="chat"
+						supported
+						transition={transition("draining")}
+						onClick={vi.fn()}
+						onCancel={onCancel}
+					/>
+				</div>
 			</TooltipProvider>,
 		);
 
@@ -66,10 +69,9 @@ describe("SessionInterfaceSwitchButton", () => {
 			"aria-label",
 			"Waiting to switch… Switching to Chat UI.",
 		);
-		expect(status).not.toHaveTextContent("Waiting to switch…");
-		expect(status).not.toHaveTextContent("Chat UI");
 		expect(status.querySelector(".animate-spin")).not.toBeNull();
 		const cancel = screen.getByRole("button", { name: "Cancel switch to Chat UI" });
+		expect(cancel).toHaveClass("opacity-0", "group-hover:opacity-100");
 		fireEvent.click(cancel);
 		expect(onCancel).toHaveBeenCalledOnce();
 	});
@@ -92,7 +94,7 @@ describe("SessionInterfaceSwitchButton", () => {
 			"aria-label",
 			"Stopping controller… Switching to Chat UI.",
 		);
-		expect(status).not.toHaveTextContent("Stopping controller…");
+		expect(status.querySelector(".animate-spin")).not.toBeNull();
 		expect(screen.queryByRole("button", { name: "Cancel switch to Chat UI" })).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
@@ -78,48 +78,47 @@ export function SessionInterfaceSwitchButton({
 }) {
 	if (transition && interfaceTransitionIsActive(transition)) {
 		const cancellable = interfaceTransitionIsCancellable(transition) && Boolean(onCancel);
-		const statusLabel = cancelError
-			? cancelError
-			: `${phaseCopy[transition.phase]} Switching to ${targetTitleLabel(transition.targetMode)}.`;
+		const statusLabel =
+			cancelError ||
+			`${phaseCopy[transition.phase]} Switching to ${targetTitleLabel(transition.targetMode)}.`;
+		const cancelLabel = `Cancel switch to ${targetTitleLabel(transition.targetMode)}`;
 		return (
 			<div
 				role="status"
 				aria-live="polite"
 				aria-label={statusLabel}
-				className={cn("inline-flex h-7 shrink-0 items-center gap-0.5", className)}
+				className={cn("relative inline-flex size-7 shrink-0 items-center justify-center text-muted-foreground", className)}
+				title={statusLabel}
 			>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<span className="inline-flex size-7 items-center justify-center text-muted-foreground">
-							<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
-						</span>
-					</TooltipTrigger>
-					<TooltipContent side="bottom">{statusLabel}</TooltipContent>
-				</Tooltip>
+				{/* TerminalTabFrame is a Tailwind `group`; tab hover swaps spinner → cancel. */}
+				<Loader2
+					aria-hidden="true"
+					className={cn(
+						"size-3.5 animate-spin",
+						cancellable && "pointer-events-none group-hover:opacity-0",
+					)}
+				/>
 				{cancellable ? (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<span className="inline-flex">
-								<TopbarButton
-									type="button"
-									variant="icon"
-									disabled={cancelling}
-									onClick={onCancel}
-									aria-label={`Cancel switch to ${targetTitleLabel(transition.targetMode)}`}
-									className="text-muted-foreground hover:text-foreground"
-								>
-									{cancelling ? (
-										<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
-									) : (
-										<X aria-hidden="true" className="size-3.5" />
-									)}
-								</TopbarButton>
-							</span>
-						</TooltipTrigger>
-						<TooltipContent side="bottom">
-							{cancelling ? "Cancelling…" : `Cancel switch to ${targetTitleLabel(transition.targetMode)}`}
-						</TooltipContent>
-					</Tooltip>
+					<button
+						type="button"
+						aria-label={cancelLabel}
+						title={cancelling ? "Cancelling…" : cancelLabel}
+						disabled={cancelling}
+						onClick={(event) => {
+							event.stopPropagation();
+							onCancel?.();
+						}}
+						className={cn(
+							"absolute inset-0 inline-flex items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50 group-hover:opacity-100",
+							cancelling && "opacity-100",
+						)}
+					>
+						{cancelling ? (
+							<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+						) : (
+							<X aria-hidden="true" className="size-3.5" />
+						)}
+					</button>
 				) : null}
 			</div>
 		);

--- a/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
+++ b/frontend/src/renderer/components/SessionInterfaceSwitch.tsx
@@ -78,39 +78,48 @@ export function SessionInterfaceSwitchButton({
 }) {
 	if (transition && interfaceTransitionIsActive(transition)) {
 		const cancellable = interfaceTransitionIsCancellable(transition) && Boolean(onCancel);
+		const statusLabel = cancelError
+			? cancelError
+			: `${phaseCopy[transition.phase]} Switching to ${targetTitleLabel(transition.targetMode)}.`;
 		return (
 			<div
 				role="status"
 				aria-live="polite"
-				className={cn(
-					"flex h-7 items-center gap-1 rounded-md bg-muted/55 pl-2 text-xs text-muted-foreground",
-					cancellable ? "pr-0.5" : "pr-2",
-					className,
-				)}
-				title={cancelError || `${phaseCopy[transition.phase]} Switching to ${targetTitleLabel(transition.targetMode)}.`}
+				aria-label={statusLabel}
+				className={cn("inline-flex h-7 shrink-0 items-center gap-0.5", className)}
 			>
-				<Loader2 aria-hidden="true" className="size-3.5 shrink-0 animate-spin" />
-				<span className="whitespace-nowrap">
-					{phaseCopy[transition.phase]} <span className="text-foreground">{targetTitleLabel(transition.targetMode)}</span>
-				</span>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span className="inline-flex size-7 items-center justify-center text-muted-foreground">
+							<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+						</span>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">{statusLabel}</TooltipContent>
+				</Tooltip>
 				{cancellable ? (
-					<Button
-						type="button"
-						size="sm"
-						variant="ghost"
-						className="ml-1 h-6 gap-1 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
-						disabled={cancelling}
-						onClick={onCancel}
-						aria-label={`Cancel switch to ${targetTitleLabel(transition.targetMode)}`}
-					>
-						{cancelling ? <Loader2 aria-hidden="true" className="size-3 animate-spin" /> : <X aria-hidden="true" className="size-3" />}
-						{cancelling ? "Cancelling" : "Cancel"}
-					</Button>
-				) : null}
-				{cancelError ? (
-					<span role="alert" className="ml-1 whitespace-nowrap pr-1.5 text-[11px] text-destructive">
-						Cancel failed
-					</span>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span className="inline-flex">
+								<TopbarButton
+									type="button"
+									variant="icon"
+									disabled={cancelling}
+									onClick={onCancel}
+									aria-label={`Cancel switch to ${targetTitleLabel(transition.targetMode)}`}
+									className="text-muted-foreground hover:text-foreground"
+								>
+									{cancelling ? (
+										<Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+									) : (
+										<X aria-hidden="true" className="size-3.5" />
+									)}
+								</TopbarButton>
+							</span>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">
+							{cancelling ? "Cancelling…" : `Cancel switch to ${targetTitleLabel(transition.targetMode)}`}
+						</TooltipContent>
+					</Tooltip>
 				) : null}
 			</div>
 		);

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1146,6 +1146,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			{handoffMenuItem}
 		</SessionActionsMenu>
 	);
+	const sessionTabActionWide = Boolean(interfaceSwitchInlineStatus);
 	const sessionHeaderActions = (
 		<div
 			className="session-topbar-session-chrome flex shrink-0 items-center"
@@ -1549,6 +1550,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									theme={theme}
 									headerActions={sessionHeaderActions}
 									sessionTabAction={sessionTabActions}
+									sessionTabActionWide={sessionTabActionWide}
 									tabStripAction={newShellTerminalAction}
 									handoffDialogOpen={handoffDialogOpen}
 									workspaceTabs={centerFileTabs}
@@ -1585,6 +1587,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									theme={theme}
 									topbarActions={sessionHeaderActions}
 									sessionTabAction={sessionTabActions}
+									sessionTabActionWide={sessionTabActionWide}
 									tabStripAction={newShellTerminalAction}
 									handoffDialogOpen={handoffDialogOpen}
 									workspaceTabs={centerFileTabs}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1146,7 +1146,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			{handoffMenuItem}
 		</SessionActionsMenu>
 	);
-	const sessionTabActionWide = Boolean(interfaceSwitchInlineStatus);
+	// Spinner replaces the ⋮ at the same size, so the tab title does not need a
+	// wider action slot while switching.
+	const sessionTabActionWide = false;
 	const sessionHeaderActions = (
 		<div
 			className="session-topbar-session-chrome flex shrink-0 items-center"

--- a/frontend/src/renderer/components/TerminalTabFrame.tsx
+++ b/frontend/src/renderer/components/TerminalTabFrame.tsx
@@ -4,6 +4,8 @@ import { cn } from "../lib/utils";
 type TerminalTabFrameProps = {
 	active: boolean;
 	action?: ReactNode;
+	/** overlay = absolute over the label (close buttons). inline = reserves width so status never covers the title. */
+	actionLayout?: "overlay" | "inline";
 	actionPosition?: "leading" | "trailing";
 	trailingAction?: ReactNode;
 	buttonRef?: Ref<HTMLButtonElement>;
@@ -21,6 +23,7 @@ type TerminalTabFrameProps = {
 export function TerminalTabFrame({
 	active,
 	action,
+	actionLayout = "overlay",
 	actionPosition = "trailing",
 	trailingAction,
 	buttonRef,
@@ -32,6 +35,20 @@ export function TerminalTabFrame({
 	"data-terminal-role": terminalRole,
 }: TerminalTabFrameProps) {
 	const { className: buttonClassName, ...restButtonProps } = buttonProps ?? {};
+	const overlayTrailing =
+		actionLayout === "overlay" && ((actionPosition === "trailing" && action) || trailingAction);
+	const inlineAction =
+		action && actionLayout === "inline" ? (
+			<div
+				className={cn(
+					"flex shrink-0 items-center self-stretch",
+					actionPosition === "leading" ? "pl-1" : "pr-1",
+				)}
+				data-terminal-tab-action
+			>
+				{action}
+			</div>
+		) : null;
 	return (
 		<span
 			className={cn(
@@ -47,12 +64,13 @@ export function TerminalTabFrame({
 			}}
 		>
 			<span className="relative inline-flex h-[calc(100%-2px)] min-w-0 flex-1 self-stretch">
+				{actionPosition === "leading" ? inlineAction : null}
 				{editingContent ?? (
 					<button
 						ref={buttonRef}
 						className={cn(
 							"inline-flex h-full min-w-0 flex-1 cursor-pointer items-center px-2 text-left text-control leading-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
-							((actionPosition === "trailing" && action) || trailingAction) && "pr-9",
+							overlayTrailing && "pr-9",
 							buttonClassName,
 						)}
 						{...restButtonProps}
@@ -62,7 +80,8 @@ export function TerminalTabFrame({
 						</span>
 					</button>
 				)}
-				{action ? (
+				{actionPosition === "trailing" ? inlineAction : null}
+				{action && actionLayout === "overlay" ? (
 					<div
 						className={cn(
 							"absolute inset-y-0 z-20 flex items-center",

--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -338,7 +338,7 @@ describe("ChatWorkspace timeline", () => {
 		const user = userEvent.setup();
 		const onDecide = vi.fn();
 		const view = render(<ChatWorkspace snapshot={idleSnapshot()} newWorkDisabled />);
-		expect(screen.getByText("Switching to terminal UI…")).toBeInTheDocument();
+		expect(screen.queryByText("Switching to terminal UI…")).not.toBeInTheDocument();
 		expect(screen.queryByText("The controller is not connected")).not.toBeInTheDocument();
 
 		expect(screen.getByTestId("chat-conversation-panel")).not.toHaveAttribute("inert");
@@ -1013,7 +1013,9 @@ describe("ChatWorkspace timeline", () => {
 
 		expect(screen.queryByText("The agent controller stopped")).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Resume agent" })).not.toBeInTheDocument();
-		expect(screen.getByText("Connecting to the agent…")).toBeInTheDocument();
+		// Progress is the topbar spinner; the composer stays empty rather than
+		// painting a second "Connecting…" / "Switching…" label over the editor.
+		expect(screen.queryByText("Connecting to the agent…")).not.toBeInTheDocument();
 		expect(screen.queryByText("The controller is not connected")).not.toBeInTheDocument();
 		expect(screen.getByRole("combobox", { name: "Message the agent" })).toHaveAttribute("contenteditable", "false");
 

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -231,6 +231,8 @@ export interface ChatWorkspaceProps {
 	headerActions?: ReactNode;
 	/** Agent-session actions on the primary chat tab (interface switch, handoff). */
 	sessionTabAction?: ReactNode;
+	/** Widen the primary tab action slot only while an interface switch spinner is showing. */
+	sessionTabActionWide?: boolean;
 	/** Pinned beside the tab strip, before the workspace topbar actions. */
 	tabStripAction?: ReactNode;
 	/** File tabs coordinated by SessionView, appended to the native chat tab strip. */
@@ -386,6 +388,7 @@ export function ChatWorkspace({
 	sessionRole = "worker",
 	headerActions,
 	sessionTabAction,
+	sessionTabActionWide = false,
 	tabStripAction,
 	workspaceTabs,
 	workspaceTabActions,
@@ -1042,6 +1045,7 @@ export function ChatWorkspace({
 				session={session}
 				onSessionRenamed={onSessionRenamed}
 				sessionTabAction={sessionTabAction}
+				sessionTabActionWide={sessionTabActionWide}
 				tabStripAction={tabStripAction}
 				workspaceTabActions={workspaceTabActions}
 				workspaceActiveTabKey={workspaceActiveTabKey}
@@ -1181,9 +1185,10 @@ export function ChatWorkspace({
 									busy={busy}
 									willQueue={Boolean(turn)}
 									disabled={snapshot.controller.state === "stopped" || controllerTransitioning || newWorkDisabled}
-									disabledPlaceholder={controllerTransitioning
-										? "Connecting to the agent…"
-										: newWorkDisabled ? "Switching to terminal UI…" : undefined}
+									// Switch/reconnect status is the topbar spinner beside ⋮ — not composer text.
+									disabledPlaceholder={
+										controllerTransitioning || newWorkDisabled ? "" : undefined
+									}
 									skills={skills}
 									filePaths={filePaths}
 									filePathsTruncated={filePathsTruncated}
@@ -1363,6 +1368,7 @@ function ChatHeader({
 	onTabsKeyDown,
 	headerActions,
 	sessionTabAction,
+	sessionTabActionWide = false,
 	tabStripAction,
 	workspaceTabActions,
 	workspaceActiveTabKey,
@@ -1389,6 +1395,7 @@ function ChatHeader({
 	onTabsKeyDown?: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
 	headerActions?: ReactNode;
 	sessionTabAction?: ReactNode;
+	sessionTabActionWide?: boolean;
 	tabStripAction?: ReactNode;
 	workspaceTabActions?: ReactNode;
 	workspaceActiveTabKey?: string;
@@ -1457,6 +1464,7 @@ function ChatHeader({
 								onRenamed={onSessionRenamed}
 								session={session}
 								tabAction={sessionTabAction}
+								tabActionWide={sessionTabActionWide}
 							/>
 						) : (
 							<button

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -71,6 +71,7 @@ export function SessionChatSurface({
 	onOpenFile,
 	headerActions,
 	sessionTabAction,
+	sessionTabActionWide = false,
 	tabStripAction,
 	handoffDialogOpen = false,
 	workspaceTabs,
@@ -107,6 +108,7 @@ export function SessionChatSurface({
 	onOpenFile?: (path: string) => void;
 	headerActions?: ReactNode;
 	sessionTabAction?: ReactNode;
+	sessionTabActionWide?: boolean;
 	tabStripAction?: ReactNode;
 	handoffDialogOpen?: boolean;
 	workspaceTabs?: Array<{ key: string; content: ReactNode; onSelect: () => void }>;
@@ -346,6 +348,7 @@ export function SessionChatSurface({
 				theme={theme}
 				headerActions={headerActions}
 				sessionTabAction={sessionTabAction}
+				sessionTabActionWide={sessionTabActionWide}
 				tabStripAction={tabStripAction}
 				workspaceTabs={workspaceTabs}
 				workspaceTabActions={workspaceTabActions}


### PR DESCRIPTION
Fixes #4848 
## Summary
- Replace the wide “Resuming agent… Chat UI” status pill with a compact spinner beside the session tab ⋮ menu (icon-only cancel when cancellable).
- Stop putting “Switching to terminal UI…” / “Connecting…” text into the chat composer during a switch.
- Only reserve extra tab width while a switch is in progress, so idle titles stay full like before.

## Test plan
- [ ] Idle session tab shows full title (e.g. “Untitled task”) with ⋮, no spinner/truncation from this change
- [ ] Start Chat ↔ Terminal switch: spinner appears after ⋮, title may truncate only then, no overlap
- [ ] Composer stays empty (no “Switching…” placeholder) while switch runs
- [ ] Cancel still works when the switch is cancellable (X next to spinner)

<img width="413" height="96" alt="image" src="https://github.com/user-attachments/assets/70b57fc4-fb2c-408d-aac3-1cf556bd3784" />

