### PR TITLE
fix(sessions): offer relaunch after permission changes

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2152,6 +2152,97 @@ paths:
       summary: Replace a project's per-project config
       tags:
       - projects
+  /api/v1/projects/{id}/permission-relaunch:
+    post:
+      operationId: relaunchForPermissionChange
+      parameters:
+      - description: Project identifier (registry key).
+        in: path
+        name: id
+        required: true
+        schema:
+          description: Project identifier (registry key).
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PermissionRelaunchResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Relaunch live workers with the current project permission setting
+      tags:
+      - sessions
+  /api/v1/projects/{id}/permission-relaunch/affected:
+    get:
+      operationId: affectedByPermissionChange
+      parameters:
+      - description: Project identifier (registry key).
+        in: path
+        name: id
+        required: true
+        schema:
+          description: Project identifier (registry key).
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AffectedPermissionRelaunchResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: List live workers that need a relaunch to apply the project permission
+        setting
+      tags:
+      - sessions
   /api/v1/projects/{id}/permissions:
     patch:
       operationId: setProjectPermissions
@@ -6813,6 +6904,18 @@ components:
       required:
       - path
       type: object
+    AffectedPermissionRelaunchResponse:
+      properties:
+        affected:
+          items:
+            $ref: '#/components/schemas/PermissionRelaunchSessionItem'
+          type: array
+        count:
+          type: integer
+      required:
+      - affected
+      - count
+      type: object
     AgentAuthPlan:
       properties:
         action:
@@ -10008,6 +10111,52 @@ components:
       - title
       - targetSha
       - status
+      type: object
+    PermissionRelaunchOutcomeItem:
+      properties:
+        error:
+          type: string
+        ok:
+          type: boolean
+        sessionId:
+          type: string
+      required:
+      - sessionId
+      - ok
+      type: object
+    PermissionRelaunchResponse:
+      properties:
+        failed:
+          type: integer
+        relaunched:
+          type: integer
+        results:
+          items:
+            $ref: '#/components/schemas/PermissionRelaunchOutcomeItem'
+          type: array
+      required:
+      - results
+      - relaunched
+      - failed
+      type: object
+    PermissionRelaunchSessionItem:
+      properties:
+        fromMode:
+          type: string
+        kind:
+          type: string
+        sessionId:
+          type: string
+        title:
+          type: string
+        toMode:
+          type: string
+      required:
+      - sessionId
+      - title
+      - kind
+      - fromMode
+      - toMode
       type: object
     PreviewServerStatusResponse:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -217,6 +217,10 @@ var schemaNames = map[string]string{ //nolint:gosec // Public OpenAPI type names
 	"ControllersProjectOrDegraded":                        "ProjectOrDegraded",
 	"ControllersListSessionsQuery":                        "ListSessionsQuery",
 	"ControllersCleanupSessionsQuery":                     "CleanupSessionsQuery",
+	"ControllersAffectedPermissionRelaunchResponse":       "AffectedPermissionRelaunchResponse",
+	"ControllersPermissionRelaunchSessionItem":            "PermissionRelaunchSessionItem",
+	"ControllersPermissionRelaunchResponse":               "PermissionRelaunchResponse",
+	"ControllersPermissionRelaunchOutcomeItem":            "PermissionRelaunchOutcomeItem",
 	"ControllersListSessionsResponse":                     "ListSessionsResponse",
 	"ControllersSpawnSessionRequest":                      "SpawnSessionRequest",
 	"ControllersSpawnSessionResponse":                     "SpawnSessionResponse",
@@ -1821,6 +1825,30 @@ func projectOperations() []operation {
 
 func sessionOperations() []operation {
 	return []operation{
+		{
+			method: http.MethodGet, path: "/api/v1/projects/{id}/permission-relaunch/affected", id: "affectedByPermissionChange", tag: "sessions",
+			summary:    "List live workers that need a relaunch to apply the project permission setting",
+			pathParams: []any{controllers.ProjectIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.AffectedPermissionRelaunchResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodPost, path: "/api/v1/projects/{id}/permission-relaunch", id: "relaunchForPermissionChange", tag: "sessions",
+			summary:    "Relaunch live workers with the current project permission setting",
+			pathParams: []any{controllers.ProjectIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.PermissionRelaunchResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
 		{
 			method: http.MethodGet, path: "/api/v1/sessions", id: "listSessions", tag: "sessions",
 			summary:    "List sessions",

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -157,6 +157,38 @@ type ListSessionsQuery struct {
 	Fresh            *bool  `query:"fresh,omitempty" description:"When true, return only fresh non-terminated sessions."`
 }
 
+// AffectedPermissionRelaunchResponse is the body of GET
+// /api/v1/projects/{id}/permission-relaunch/affected.
+type AffectedPermissionRelaunchResponse struct {
+	Affected []PermissionRelaunchSessionItem `json:"affected"`
+	Count    int                             `json:"count"`
+}
+
+// PermissionRelaunchSessionItem is one running worker whose approval policy
+// differs from the project's current default.
+type PermissionRelaunchSessionItem struct {
+	SessionID string `json:"sessionId"`
+	Title     string `json:"title"`
+	Kind      string `json:"kind"`
+	FromMode  string `json:"fromMode"`
+	ToMode    string `json:"toMode"`
+}
+
+// PermissionRelaunchResponse is the body of POST
+// /api/v1/projects/{id}/permission-relaunch.
+type PermissionRelaunchResponse struct {
+	Results    []PermissionRelaunchOutcomeItem `json:"results"`
+	Relaunched int                             `json:"relaunched"`
+	Failed     int                             `json:"failed"`
+}
+
+// PermissionRelaunchOutcomeItem reports one worker's relaunch result.
+type PermissionRelaunchOutcomeItem struct {
+	SessionID string `json:"sessionId"`
+	OK        bool   `json:"ok"`
+	Error     string `json:"error,omitempty"`
+}
+
 // CleanupSessionsQuery is the query string accepted by POST /api/v1/sessions/cleanup.
 type CleanupSessionsQuery struct {
 	Project string `query:"project,omitempty" description:"Project id filter. When omitted, clean terminated sessions across all projects."`

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -233,6 +233,21 @@ func TestProjectsAPI_UpdateSettings(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_JSON")
 }
 
+func TestProjectsAPI_UpdateSettingsPreservesLegacyLongName(t *testing.T) {
+	srv := newTestServer(t)
+	repo := gitRepo(t, "04-registered-project")
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/projects", `{"path":`+quote(repo)+`,"projectId":"04-registered-project"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("seed create = %d, want 201; body=%s", status, body)
+	}
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/04-registered-project", `{"displayName":"04-registered-project","config":{"agentConfig":{"permissions":"bypass-permissions"}}}`)
+	if status != http.StatusOK {
+		t.Fatalf("PUT settings for unchanged legacy name = %d, want 200; body=%s", status, body)
+	}
+}
+
 func TestProjectsAPI_AddValidationAndConflicts(t *testing.T) {
 
 	srv := newTestServer(t)

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -116,6 +116,11 @@ type SessionService interface {
 	Unpin(ctx context.Context, id domain.SessionID) (domain.Session, error)
 }
 
+type permissionRelaunchService interface {
+	AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionsvc.PermissionRelaunchSession, error)
+	RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionsvc.PermissionRelaunchOutcome, error)
+}
+
 // ActivityRecorder applies an agent activity-state signal to a session. It is
 // satisfied directly by *lifecycle.Manager: an activity signal is a pure
 // lifecycle reduction (no runtime/workspace teardown), so it bypasses
@@ -203,6 +208,51 @@ func (c *SessionsController) Register(r chi.Router) {
 	r.Post("/orchestrators", c.spawnOrchestrator)
 	r.Post("/orchestrators/delegate", c.delegateTask)
 	r.Get("/orchestrators/{id}", c.getOrchestrator)
+	r.Get("/projects/{id}/permission-relaunch/affected", c.affectedByPermissionChange)
+	r.Post("/projects/{id}/permission-relaunch", c.relaunchForPermissionChange)
+}
+
+func (c *SessionsController) affectedByPermissionChange(w http.ResponseWriter, r *http.Request) {
+	service, ok := c.Svc.(permissionRelaunchService)
+	if !ok {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/projects/{id}/permission-relaunch/affected")
+		return
+	}
+	affected, err := service.AffectedByPermissionChange(r.Context(), projectID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	items := make([]PermissionRelaunchSessionItem, 0, len(affected))
+	for _, item := range affected {
+		items = append(items, PermissionRelaunchSessionItem{
+			SessionID: string(item.SessionID), Title: item.Title, Kind: string(item.Kind),
+			FromMode: string(item.FromMode), ToMode: string(item.ToMode),
+		})
+	}
+	envelope.WriteJSON(w, http.StatusOK, AffectedPermissionRelaunchResponse{Affected: items, Count: len(items)})
+}
+
+func (c *SessionsController) relaunchForPermissionChange(w http.ResponseWriter, r *http.Request) {
+	service, ok := c.Svc.(permissionRelaunchService)
+	if !ok {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/projects/{id}/permission-relaunch")
+		return
+	}
+	outcomes, err := service.RelaunchForPermissionChange(r.Context(), projectID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	items := make([]PermissionRelaunchOutcomeItem, 0, len(outcomes))
+	relaunched := 0
+	for _, item := range outcomes {
+		items = append(items, PermissionRelaunchOutcomeItem{SessionID: string(item.SessionID), OK: item.OK, Error: item.Error})
+		if item.OK {
+			relaunched++
+		}
+	}
+	envelope.WriteJSON(w, http.StatusOK, PermissionRelaunchResponse{Results: items, Relaunched: relaunched, Failed: len(items) - relaunched})
 }
 
 // RegisterStreams mounts long-lived session streams outside the REST timeout

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -66,6 +66,9 @@ type fakeSessionService struct {
 	handoffSource        domain.AgentGenerationID
 	autoInjectCISession  domain.SessionID
 	autoInjectCIEnabled  bool
+	permissionProjectID  domain.ProjectID
+	permissionAffected   []sessionsvc.PermissionRelaunchSession
+	permissionOutcomes   []sessionsvc.PermissionRelaunchOutcome
 }
 
 type fakeInterfaceTransitionSessionService struct {
@@ -437,6 +440,16 @@ func (f *fakeSessionService) Cleanup(_ context.Context, project domain.ProjectID
 		cleaned = []domain.SessionID{"ao-1"}
 	}
 	return sessionsvc.CleanupOutcome{Cleaned: cleaned, Skipped: f.cleanupSkipped}, nil
+}
+
+func (f *fakeSessionService) AffectedByPermissionChange(_ context.Context, projectID domain.ProjectID) ([]sessionsvc.PermissionRelaunchSession, error) {
+	f.permissionProjectID = projectID
+	return f.permissionAffected, nil
+}
+
+func (f *fakeSessionService) RelaunchForPermissionChange(_ context.Context, projectID domain.ProjectID) ([]sessionsvc.PermissionRelaunchOutcome, error) {
+	f.permissionProjectID = projectID
+	return f.permissionOutcomes, nil
 }
 
 func (f *fakeSessionService) Rename(_ context.Context, id domain.SessionID, displayName string) error {
@@ -868,6 +881,28 @@ func (f *fakeSessionService) InvalidateWorkspaceCache(_ domain.SessionID) {}
 
 func newSessionTestServer(t *testing.T, svc *fakeSessionService) *httptest.Server {
 	return newSessionTestServerWithPreview(t, svc, nil)
+}
+
+func TestSessionsAPI_PermissionRelaunch(t *testing.T) {
+	svc := newFakeSessionService()
+	svc.permissionAffected = []sessionsvc.PermissionRelaunchSession{{
+		SessionID: "ao-1", Title: "Fix permission flow", Kind: domain.KindWorker,
+		FromMode: domain.PermissionModeAuto, ToMode: domain.PermissionModeBypassPermissions,
+	}}
+	svc.permissionOutcomes = []sessionsvc.PermissionRelaunchOutcome{{SessionID: "ao-1", OK: true}}
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, http.MethodGet, "/api/v1/projects/project-1/permission-relaunch/affected", "")
+	if status != http.StatusOK || !strings.Contains(string(body), `"count":1`) || !strings.Contains(string(body), `"fromMode":"auto"`) {
+		t.Fatalf("affected = %d %s", status, body)
+	}
+	body, status, _ = doRequest(t, srv, http.MethodPost, "/api/v1/projects/project-1/permission-relaunch", "")
+	if status != http.StatusOK || !strings.Contains(string(body), `"relaunched":1`) || !strings.Contains(string(body), `"failed":0`) {
+		t.Fatalf("relaunch = %d %s", status, body)
+	}
+	if svc.permissionProjectID != "project-1" {
+		t.Fatalf("project id = %q, want project-1", svc.permissionProjectID)
+	}
 }
 
 func newSessionTestServerWithPreview(

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -601,22 +601,25 @@ func (m *Service) UpdateSettings(ctx context.Context, id domain.ProjectID, in Up
 	if err := validateProjectID(id); err != nil {
 		return Project{}, err
 	}
-	displayName := strings.TrimSpace(in.DisplayName)
-	if displayName == "" {
-		return Project{}, apierr.Invalid("DISPLAY_NAME_REQUIRED", "Display name is required", nil)
-	}
-	if utf8.RuneCountInString(displayName) > maxDisplayNameLen {
-		return Project{}, apierr.Invalid("DISPLAY_NAME_TOO_LONG", "Display name must be 20 characters or fewer", nil)
-	}
-	if err := in.Config.Validate(); err != nil {
-		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
-	}
 	row, ok, err := m.store.GetProject(ctx, string(id))
 	if err != nil {
 		return Project{}, apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load project")
 	}
 	if !ok || !row.ArchivedAt.IsZero() {
 		return Project{}, apierr.NotFound("PROJECT_NOT_FOUND", "Unknown project")
+	}
+	displayName := strings.TrimSpace(in.DisplayName)
+	if displayName == "" {
+		return Project{}, apierr.Invalid("DISPLAY_NAME_REQUIRED", "Display name is required", nil)
+	}
+	// Keep settings saves working for projects created before the 20-character
+	// limit was introduced. An unchanged legacy name is safe to preserve, but
+	// newly changing it still enforces the current limit.
+	if utf8.RuneCountInString(displayName) > maxDisplayNameLen && displayName != row.DisplayName {
+		return Project{}, apierr.Invalid("DISPLAY_NAME_TOO_LONG", "Display name must be 20 characters or fewer", nil)
+	}
+	if err := in.Config.Validate(); err != nil {
+		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
 	}
 	if row.Kind.WithDefault() == domain.ProjectKindScratch {
 		if err := validateScratchProjectConfig(in.Config); err != nil {

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -77,6 +77,11 @@ type commander interface {
 	StageAttachments(ctx context.Context, id domain.SessionID, attachments []ports.SpawnAttachment) ([]string, error)
 }
 
+type permissionRelaunchCommander interface {
+	AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.AffectedSession, error)
+	RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]sessionmanager.RelaunchOutcome, error)
+}
+
 // interfaceTransitionCommander is an optional command capability. Keeping it
 // separate avoids widening every focused session-service fake while production
 // can expose the feature through the concrete Session Manager.
@@ -131,6 +136,23 @@ const (
 type RestoreOutcome struct {
 	Session domain.Session  `json:"session"`
 	Mode    RestoreModeView `json:"restoreMode"`
+}
+
+// PermissionRelaunchSession is a running worker that will keep its previous
+// approval policy unless the user explicitly relaunches it.
+type PermissionRelaunchSession struct {
+	SessionID domain.SessionID      `json:"sessionId"`
+	Title     string                `json:"title"`
+	Kind      domain.SessionKind    `json:"kind"`
+	FromMode  domain.PermissionMode `json:"fromMode"`
+	ToMode    domain.PermissionMode `json:"toMode"`
+}
+
+// PermissionRelaunchOutcome reports one worker's requested relaunch result.
+type PermissionRelaunchOutcome struct {
+	SessionID domain.SessionID `json:"sessionId"`
+	OK        bool             `json:"ok"`
+	Error     string           `json:"error,omitempty"`
 }
 
 // ResumeAgentOutcome reports the resumed read model and how AO relaunched it.
@@ -579,6 +601,52 @@ func (s *Service) Restore(ctx context.Context, id domain.SessionID) (RestoreOutc
 		return RestoreOutcome{}, err
 	}
 	return RestoreOutcome{Session: session, Mode: restoreModeView(res.Mode)}, nil
+}
+
+// AffectedByPermissionChange lists live workers whose pinned launch permission
+// differs from the project's current setting. The caller uses this read before
+// asking the user whether interrupting those workers is acceptable.
+func (s *Service) AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]PermissionRelaunchSession, error) {
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return nil, err
+	}
+	manager, ok := s.manager.(permissionRelaunchCommander)
+	if !ok {
+		return nil, apierr.Conflict("PERMISSION_RELAUNCH_UNSUPPORTED", "This build cannot relaunch sessions for a permission change", nil)
+	}
+	affected, err := manager.AffectedByPermissionChange(ctx, projectID)
+	if err != nil {
+		return nil, toAPIError(err)
+	}
+	result := make([]PermissionRelaunchSession, 0, len(affected))
+	for _, item := range affected {
+		result = append(result, PermissionRelaunchSession{
+			SessionID: item.SessionID, Title: item.Title, Kind: item.Kind,
+			FromMode: item.FromMode, ToMode: item.ToMode,
+		})
+	}
+	return result, nil
+}
+
+// RelaunchForPermissionChange applies the current project permission to each
+// worker the user explicitly chose to interrupt.
+func (s *Service) RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]PermissionRelaunchOutcome, error) {
+	if _, err := s.requireProject(ctx, projectID); err != nil {
+		return nil, err
+	}
+	manager, ok := s.manager.(permissionRelaunchCommander)
+	if !ok {
+		return nil, apierr.Conflict("PERMISSION_RELAUNCH_UNSUPPORTED", "This build cannot relaunch sessions for a permission change", nil)
+	}
+	outcomes, err := manager.RelaunchForPermissionChange(ctx, projectID)
+	if err != nil {
+		return nil, toAPIError(err)
+	}
+	result := make([]PermissionRelaunchOutcome, 0, len(outcomes))
+	for _, item := range outcomes {
+		result = append(result, PermissionRelaunchOutcome{SessionID: item.SessionID, OK: item.OK, Error: item.Error})
+	}
+	return result, nil
 }
 
 // ExitAgent stops only the agent controller while preserving the AO session,

--- a/backend/internal/session_manager/permission_relaunch.go
+++ b/backend/internal/session_manager/permission_relaunch.go
@@ -1,0 +1,128 @@
+package sessionmanager
+
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// AffectedSession describes a live worker whose pinned launch permission
+// differs from the permission a new worker would receive from project settings.
+type AffectedSession struct {
+	SessionID domain.SessionID
+	Title     string
+	Kind      domain.SessionKind
+	FromMode  domain.PermissionMode
+	ToMode    domain.PermissionMode
+}
+
+// RelaunchOutcome reports the result of applying a project's new permission
+// mode to one running worker.
+type RelaunchOutcome struct {
+	SessionID domain.SessionID
+	OK        bool
+	Error     string
+}
+
+// AffectedByPermissionChange returns workers that need an explicit relaunch to
+// adopt their project's new permission setting. It never includes terminated
+// sessions or the orchestrator: neither is a live agent that needs interrupting.
+func (m *Manager) AffectedByPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]AffectedSession, error) {
+	project, err := m.loadProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	records, err := m.store.ListSessions(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	affected := make([]AffectedSession, 0)
+	for _, record := range records {
+		if record.IsTerminated || record.Kind != domain.KindWorker || !hasRestorableWorkspace(record, project) {
+			continue
+		}
+		from := launchedPermission(record.Metadata.Permissions)
+		to := permissionRelaunchTarget(record.Kind, project.Config)
+		if from == to {
+			continue
+		}
+		title := record.DisplayName
+		if title == "" {
+			title = string(record.ID)
+		}
+		affected = append(affected, AffectedSession{
+			SessionID: record.ID,
+			Title:     title,
+			Kind:      record.Kind,
+			FromMode:  from,
+			ToMode:    to,
+		})
+	}
+	return affected, nil
+}
+
+func hasRestorableWorkspace(record domain.SessionRecord, project domain.ProjectRecord) bool {
+	if record.Metadata.WorkspacePath == "" {
+		return false
+	}
+	return record.Metadata.Branch != "" || project.Kind.WithDefault() == domain.ProjectKindScratch
+}
+
+func launchedPermission(permission domain.PermissionMode) domain.PermissionMode {
+	if permission == "" {
+		return ports.PermissionModeAuto
+	}
+	return permission
+}
+
+func permissionRelaunchTarget(kind domain.SessionKind, config domain.ProjectConfig) domain.PermissionMode {
+	return applySpawnAgentConfig(effectiveAgentConfig(kind, config), ports.AgentConfig{}).Permissions
+}
+
+// RelaunchForPermissionChange stops and restores every worker still affected by
+// the project's current permission setting. It deliberately updates the
+// session's pinned launch policy after a successful stop and before restore:
+// ordinary restores preserve that pin, while this explicitly confirmed action
+// is the one path that replaces it. One failure does not prevent later workers
+// from being restarted.
+func (m *Manager) RelaunchForPermissionChange(ctx context.Context, projectID domain.ProjectID) ([]RelaunchOutcome, error) {
+	affected, err := m.AffectedByPermissionChange(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	outcomes := make([]RelaunchOutcome, 0, len(affected))
+	for _, session := range affected {
+		if _, err := m.Kill(ctx, session.SessionID); err != nil {
+			outcomes = append(outcomes, RelaunchOutcome{SessionID: session.SessionID, Error: err.Error()})
+			continue
+		}
+		if err := m.replaceLaunchedPermission(ctx, session.SessionID, session.ToMode); err != nil {
+			outcomes = append(outcomes, RelaunchOutcome{SessionID: session.SessionID, Error: err.Error()})
+			continue
+		}
+		if _, err := m.RestoreWithMode(ctx, session.SessionID); err != nil {
+			outcomes = append(outcomes, RelaunchOutcome{SessionID: session.SessionID, Error: err.Error()})
+			continue
+		}
+		outcomes = append(outcomes, RelaunchOutcome{SessionID: session.SessionID, OK: true})
+	}
+	return outcomes, nil
+}
+
+func (m *Manager) replaceLaunchedPermission(ctx context.Context, id domain.SessionID, permission domain.PermissionMode) error {
+	record, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrNotFound
+	}
+	if !record.IsTerminated {
+		return ErrNotRestorable
+	}
+	record.Metadata.Permissions = permission
+	return m.store.UpdateSession(ctx, record)
+}

--- a/backend/internal/session_manager/permission_relaunch_test.go
+++ b/backend/internal/session_manager/permission_relaunch_test.go
@@ -1,0 +1,89 @@
+package sessionmanager
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestAffectedByPermissionChangeListsOnlyLiveWorkersWithStaleLaunchPermissions(t *testing.T) {
+	m, store, _, _ := newManager()
+	store.projects["mer"] = domain.ProjectRecord{
+		ID: "mer",
+		Config: domain.ProjectConfig{
+			AgentConfig: domain.AgentConfig{Permissions: domain.PermissionModeBypassPermissions},
+			Worker:      domain.RoleOverride{Harness: domain.HarnessClaudeCode},
+		},
+	}
+	store.sessions["mer-stale"] = domain.SessionRecord{
+		ID: "mer-stale", ProjectID: "mer", Kind: domain.KindWorker, DisplayName: "Stale worker",
+		Metadata: domain.SessionMetadata{Permissions: domain.PermissionModeAuto, WorkspacePath: "/tmp/mer-stale", Branch: "ao/mer-stale"},
+	}
+	store.sessions["mer-current"] = domain.SessionRecord{
+		ID: "mer-current", ProjectID: "mer", Kind: domain.KindWorker,
+		Metadata: domain.SessionMetadata{Permissions: domain.PermissionModeBypassPermissions, WorkspacePath: "/tmp/mer-current", Branch: "ao/mer-current"},
+	}
+	store.sessions["mer-orchestrator"] = domain.SessionRecord{
+		ID: "mer-orchestrator", ProjectID: "mer", Kind: domain.KindOrchestrator,
+		Metadata: domain.SessionMetadata{Permissions: domain.PermissionModeAuto, WorkspacePath: "/tmp/mer-orchestrator", Branch: "ao/mer-orchestrator"},
+	}
+
+	affected, err := m.AffectedByPermissionChange(ctx, "mer")
+	if err != nil {
+		t.Fatalf("AffectedByPermissionChange: %v", err)
+	}
+	if len(affected) != 1 {
+		t.Fatalf("affected = %#v, want one stale worker", affected)
+	}
+	if got := affected[0]; got.SessionID != "mer-stale" || got.FromMode != domain.PermissionModeAuto || got.ToMode != domain.PermissionModeBypassPermissions {
+		t.Fatalf("affected[0] = %#v, want stale worker auto -> bypass-permissions", got)
+	}
+}
+
+func TestRelaunchForPermissionChangeRestartsWorkerWithNewPermission(t *testing.T) {
+	store := newFakeStore()
+	store.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	agent := &recordingAgent{}
+	manager := New(Deps{
+		Runtime:   &fakeRuntime{},
+		Agents:    singleAgent{agent: agent},
+		Workspace: &fakeWorkspace{},
+		Store:     store,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: store},
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	record, _, _, err := manager.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		AgentConfig: ports.AgentConfig{
+			Permissions: domain.PermissionModeAuto,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	stored := store.sessions[record.ID]
+	stored.Metadata.AgentSessionID = "native-1"
+	store.sessions[record.ID] = stored
+
+	project := store.projects["mer"]
+	project.Config.AgentConfig.Permissions = domain.PermissionModeBypassPermissions
+	store.projects["mer"] = project
+
+	outcomes, err := manager.RelaunchForPermissionChange(ctx, "mer")
+	if err != nil {
+		t.Fatalf("RelaunchForPermissionChange: %v", err)
+	}
+	if len(outcomes) != 1 || !outcomes[0].OK || outcomes[0].SessionID != record.ID {
+		t.Fatalf("outcomes = %#v, want one successful relaunch for %s", outcomes, record.ID)
+	}
+	if agent.lastRestore.Permissions != domain.PermissionModeBypassPermissions {
+		t.Fatalf("restore permissions = %q, want %q", agent.lastRestore.Permissions, domain.PermissionModeBypassPermissions)
+	}
+	if got := store.sessions[record.ID].Metadata.Permissions; got != domain.PermissionModeBypassPermissions {
+		t.Fatalf("persisted permissions = %q, want %q", got, domain.PermissionModeBypassPermissions)
+	}
+}

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -912,6 +912,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects/{id}/permission-relaunch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Relaunch live workers with the current project permission setting */
+        post: operations["relaunchForPermissionChange"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{id}/permission-relaunch/affected": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List live workers that need a relaunch to apply the project permission setting */
+        get: operations["affectedByPermissionChange"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/projects/{id}/permissions": {
         parameters: {
             query?: never;
@@ -2417,6 +2451,10 @@ export interface components {
             path: string;
             projectId?: null | string;
         };
+        AffectedPermissionRelaunchResponse: {
+            affected: components["schemas"]["PermissionRelaunchSessionItem"][];
+            count: number;
+        };
         AgentAuthPlan: {
             action: string;
             agentId: string;
@@ -3573,6 +3611,23 @@ export interface components {
             status: "needs_review" | "running" | "up_to_date" | "changes_requested" | "ineligible";
             targetSha: string;
             title: string;
+        };
+        PermissionRelaunchOutcomeItem: {
+            error?: string;
+            ok: boolean;
+            sessionId: string;
+        };
+        PermissionRelaunchResponse: {
+            failed: number;
+            relaunched: number;
+            results: components["schemas"]["PermissionRelaunchOutcomeItem"][];
+        };
+        PermissionRelaunchSessionItem: {
+            fromMode: string;
+            kind: string;
+            sessionId: string;
+            title: string;
+            toMode: string;
         };
         PreviewServerStatusResponse: {
             configuration?: string;
@@ -7220,6 +7275,124 @@ export interface operations {
             };
             /** @description Internal Server Error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    relaunchForPermissionChange: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project identifier (registry key). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PermissionRelaunchResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    affectedByPermissionChange: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project identifier (registry key). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AffectedPermissionRelaunchResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/renderer/components/PermissionRelaunchDialog.test.tsx
+++ b/frontend/src/renderer/components/PermissionRelaunchDialog.test.tsx
@@ -1,0 +1,39 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PermissionRelaunchDialog } from "./PermissionRelaunchDialog";
+
+const { getMock, postMock } = vi.hoisted(() => ({ getMock: vi.fn(), postMock: vi.fn() }));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { GET: getMock, POST: postMock },
+	apiErrorMessage: (error: { message?: string }) => error.message ?? "Request failed",
+}));
+
+describe("PermissionRelaunchDialog", () => {
+	it("lists affected workers and relaunches them only after confirmation", async () => {
+		getMock.mockResolvedValue({
+			data: {
+				count: 1,
+				affected: [{ sessionId: "worker-1", title: "Fix login", kind: "worker", fromMode: "auto", toMode: "bypass-permissions" }],
+			},
+			error: undefined,
+		});
+		postMock.mockResolvedValue({ data: { results: [{ sessionId: "worker-1", ok: true }], relaunched: 1, failed: 0 }, error: undefined });
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const onOpenChange = vi.fn();
+		render(
+			<QueryClientProvider client={queryClient}>
+				<PermissionRelaunchDialog open projectId="project-1" onOpenChange={onOpenChange} />
+			</QueryClientProvider>,
+		);
+
+		expect(await screen.findByText("Fix login")).toBeInTheDocument();
+		expect(postMock).not.toHaveBeenCalled();
+		fireEvent.click(screen.getByRole("button", { name: "Relaunch 1 session" }));
+		await waitFor(() => expect(postMock).toHaveBeenCalledWith("/api/v1/projects/{id}/permission-relaunch", {
+			params: { path: { id: "project-1" } },
+		}));
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+});

--- a/frontend/src/renderer/components/PermissionRelaunchDialog.tsx
+++ b/frontend/src/renderer/components/PermissionRelaunchDialog.tsx
@@ -1,0 +1,113 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, RotateCw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { Button } from "./ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	settingsDialogBodyClass,
+	settingsDialogContentClass,
+	settingsDialogFooterClass,
+	settingsDialogHeaderClass,
+} from "./ui/dialog";
+
+type PermissionRelaunchDialogProps = {
+	open: boolean;
+	projectId: string;
+	onOpenChange: (open: boolean) => void;
+};
+
+export function PermissionRelaunchDialog({ open, projectId, onOpenChange }: PermissionRelaunchDialogProps) {
+	const queryClient = useQueryClient();
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string>();
+	const [result, setResult] = useState<{ relaunched: number; failed: number }>();
+	const affectedQuery = useQuery({
+		queryKey: ["permission-relaunch-affected", projectId],
+		enabled: open,
+		queryFn: async () => {
+			const { data, error } = await apiClient.GET("/api/v1/projects/{id}/permission-relaunch/affected", {
+				params: { path: { id: projectId } },
+			});
+			if (error) throw new Error(apiErrorMessage(error));
+			return data;
+		},
+	});
+	const count = affectedQuery.data?.count ?? 0;
+
+	useEffect(() => {
+		if (affectedQuery.data && count === 0) onOpenChange(false);
+	}, [affectedQuery.data, count, onOpenChange]);
+
+	const relaunch = async () => {
+		setBusy(true);
+		setError(undefined);
+		try {
+			const { data, error } = await apiClient.POST("/api/v1/projects/{id}/permission-relaunch", {
+				params: { path: { id: projectId } },
+			});
+			if (error) throw new Error(apiErrorMessage(error));
+			setResult({ relaunched: data?.relaunched ?? 0, failed: data?.failed ?? 0 });
+			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			if ((data?.failed ?? 0) === 0) onOpenChange(false);
+		} catch (caught) {
+			setError(caught instanceof Error ? caught.message : "Could not relaunch sessions");
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!busy) onOpenChange(nextOpen);
+			}}
+		>
+			<DialogContent className={`${settingsDialogContentClass} w-dialog-orchestrator`} showCloseButton={!busy}>
+				<DialogHeader className={settingsDialogHeaderClass}>
+					<DialogTitle className="settings-dialog-title">Relaunch sessions with the new permission mode?</DialogTitle>
+					<DialogDescription className="text-control leading-5 text-settings-muted">
+						The new setting applies to future sessions. Relaunching restarts these agents in place; their branches and
+						uncommitted work are kept, but any in-progress turn is interrupted.
+					</DialogDescription>
+				</DialogHeader>
+				<div className={settingsDialogBodyClass}>
+					{affectedQuery.isLoading ? <Loader2 className="mx-auto size-5 animate-spin text-settings-muted" /> : null}
+					{affectedQuery.isError ? (
+						<p className="text-sm text-error">{affectedQuery.error instanceof Error ? affectedQuery.error.message : "Could not load sessions"}</p>
+					) : null}
+					{affectedQuery.data && !result ? (
+						<ul className="space-y-2 text-sm">
+							{affectedQuery.data.affected.map((session) => (
+								<li key={session.sessionId} className="flex items-center justify-between gap-3">
+									<span className="truncate font-medium">{session.title}</span>
+									<span className="shrink-0 text-settings-muted">{session.fromMode} → {session.toMode}</span>
+								</li>
+							))}
+						</ul>
+					) : null}
+					{result ? <p className="text-sm text-settings-muted">Relaunched {result.relaunched}; failed {result.failed}.</p> : null}
+					{error ? <p className="text-sm text-error">{error}</p> : null}
+				</div>
+				<DialogFooter className={settingsDialogFooterClass}>
+					<Button type="button" variant="footer" disabled={busy} onClick={() => onOpenChange(false)}>
+						{result ? "Close" : "Cancel"}
+					</Button>
+					{!result && count > 0 ? (
+						<Button type="button" variant="footer-primary" disabled={busy || affectedQuery.isLoading} onClick={relaunch}>
+							{busy ? <Loader2 className="size-3.5 animate-spin" /> : <RotateCw className="size-3.5" />}
+							Relaunch {count} session{count === 1 ? "" : "s"}
+						</Button>
+					) : null}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/frontend/src/renderer/components/PermissionRelaunchDialog.tsx
+++ b/frontend/src/renderer/components/PermissionRelaunchDialog.tsx
@@ -40,6 +40,7 @@ export function PermissionRelaunchDialog({ open, projectId, onOpenChange }: Perm
 		},
 	});
 	const count = affectedQuery.data?.count ?? 0;
+	const affected = affectedQuery.data?.affected ?? [];
 
 	useEffect(() => {
 		if (affectedQuery.data && count === 0) onOpenChange(false);
@@ -85,7 +86,7 @@ export function PermissionRelaunchDialog({ open, projectId, onOpenChange }: Perm
 					) : null}
 					{affectedQuery.data && !result ? (
 						<ul className="space-y-2 text-sm">
-							{affectedQuery.data.affected.map((session) => (
+							{affected.map((session) => (
 								<li key={session.sessionId} className="flex items-center justify-between gap-3">
 									<span className="truncate font-medium">{session.title}</span>
 									<span className="shrink-0 text-settings-muted">{session.fromMode} → {session.toMode}</span>

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -31,6 +31,7 @@ import { newestActiveOrchestrator } from "../types/workspace";
 import { RequiredAgentField } from "./CreateProjectAgentSheet";
 import { buildIntake, deriveRepoPath, deriveRepoHost, IntakeFields, type IntakeForm } from "./IntakeFields";
 import { ProductExternalLink } from "./ProductExternalLink";
+import { PermissionRelaunchDialog } from "./PermissionRelaunchDialog";
 import { ReviewerSelect, reviewerTrustWarning } from "./ReviewerSelect";
 import { AgentModelCombobox } from "./settings/AgentModelCombobox";
 import { SettingsOptionMenu } from "./settings/SettingsOptionMenu";
@@ -48,6 +49,7 @@ const DEFAULT_BRANCH_AUTO = "auto";
 const projectQueryKey = (id: string) => ["project", id] as const;
 
 type SettingsSaveResult = {
+	permissionChanged: boolean;
 	replacementError: string | null;
 	replacementSessionId: string | null;
 	replacementFailure: OrchestratorReplacementFailure | null;
@@ -158,7 +160,9 @@ function SettingsBody({
 	const [showSaving, setShowSaving] = useState(false);
 	const [replacementError, setReplacementError] = useState<string | null>(null);
 	const [validationError, setValidationError] = useState<string | null>(null);
+	const [permissionRelaunchOpen, setPermissionRelaunchOpen] = useState(false);
 	const initialOrchestratorAgent = config.orchestrator?.agent ?? "";
+	const initialPermissions = config.agentConfig?.permissions ?? "";
 	const missingRequiredAgent = form.workerAgent === "" || form.orchestratorAgent === "";
 	const agentsQuery = useAgentReadinessQuery();
 	useEnsureAgentReadiness();
@@ -257,6 +261,7 @@ function SettingsBody({
 				body: { displayName, config: next },
 			});
 			if (error) throw new Error(apiErrorMessage(error));
+			const permissionChanged = form.permissions !== initialPermissions;
 			if (
 				form.orchestratorAgent !== initialOrchestratorAgent ||
 				(activeOrchestrator && activeOrchestrator.provider !== form.orchestratorAgent)
@@ -264,6 +269,7 @@ function SettingsBody({
 				try {
 					const sessionId = await spawnOrchestrator(projectId, "settings", true);
 					return {
+						permissionChanged,
 						replacementError: null,
 						replacementSessionId: sessionId,
 						replacementFailure: null,
@@ -278,6 +284,7 @@ function SettingsBody({
 							: {}),
 					};
 					return {
+						permissionChanged,
 						replacementError: replacementFailure.message,
 						replacementSessionId: null,
 						replacementFailure,
@@ -286,6 +293,7 @@ function SettingsBody({
 				}
 			}
 			return {
+				permissionChanged,
 				replacementError: null,
 				replacementSessionId: null,
 				replacementFailure: null,
@@ -296,6 +304,7 @@ function SettingsBody({
 			void captureRendererEvent("ao.renderer.settings_save_succeeded", { project_id: projectId });
 			setSavedAt(Date.now());
 			setReplacementError(result.replacementError);
+			if (result.permissionChanged) setPermissionRelaunchOpen(true);
 			setValidationError(null);
 			void queryClient.invalidateQueries({ queryKey: ["project", projectId] });
 			const workspaceRefresh = onSaved();
@@ -370,6 +379,7 @@ function SettingsBody({
 	}, [savedAt]);
 
 	return (
+		<>
 		<ProjectSettingsFormView
 			id="project-settings-form"
 			onSubmit={() => {
@@ -615,6 +625,12 @@ function SettingsBody({
 				</>
 			)}
 		</ProjectSettingsFormView>
+		<PermissionRelaunchDialog
+			open={permissionRelaunchOpen}
+			projectId={projectId}
+			onOpenChange={setPermissionRelaunchOpen}
+		/>
+		</>
 	);
 }
 


### PR DESCRIPTION
## Summary
- detect live workers still running with a previous project permission setting
- offer an explicit settings dialog to relaunch only those workers
- replace the per-session permission pin only after the worker has stopped, then restore it

Existing sessions cannot safely mutate provider launch flags in place. This preserves their branch and uncommitted work while interrupting any active turn; orchestrators and already-terminated sessions are never included.

## Validation
- `go test ./internal/session_manager ./internal/service/session ./internal/httpd/controllers`
- `go test ./internal/httpd/...`
- `npm --prefix frontend test -- PermissionRelaunchDialog.test.tsx`
- `npm run frontend:typecheck`

`npm run lint` was attempted. The new/affected packages passed, but the full suite has pre-existing environment-sensitive failures in `internal/adapters/agent/crush` (local authorization state) and `internal/adapters/runtime/tmux` (temporary tmux server exits).

Closes #2504.