### PR TITLE
fix(files): keep the docked file tree expanded when returning from a file

### DIFF
--- a/frontend/src/renderer/components/FileTree.test.tsx
+++ b/frontend/src/renderer/components/FileTree.test.tsx
@@ -22,10 +22,14 @@ function renderWithQuery(children: ReactNode) {
 	// FileTree only mounts react-arborist's <Tree> once its container has a
 	// measured size; the test setup's ResizeObserver stub never invokes its
 	// callback, so drive it here the same way XtermTerminal.test.tsx does.
-	act(() => {
-		for (const callback of resizeCallbacks) callback([{ contentRect: { width: 400, height: 400 } }] as never, {} as ResizeObserver);
-	});
+	resizeTo(400, 400);
 	return view;
+}
+
+function resizeTo(width: number, height: number) {
+	act(() => {
+		for (const callback of resizeCallbacks) callback([{ contentRect: { width, height } }] as never, {} as ResizeObserver);
+	});
 }
 
 const resizeCallbacks: ResizeObserverCallback[] = [];
@@ -111,6 +115,33 @@ describe("FileTree", () => {
 				params: { path: { sessionId: "sess-1" }, query: { path: "src" } },
 			}),
 		);
+		expect(await screen.findByText("app.go")).toBeInTheDocument();
+	});
+
+	it("keeps expanded folders open while the docked explorer hides the tree behind a file preview", async () => {
+		getMock.mockImplementation(async (_path: string, options: unknown) => {
+			const query = (options as { params?: { query?: { path?: string } } }).params?.query?.path;
+			if (!query) return treeResponse("", [{ name: "src", path: "src", type: "dir", hasChanges: false }]);
+			if (query === "src") {
+				return treeResponse("src", [{ name: "app.go", path: "src/app.go", type: "file", status: "unmodified" }]);
+			}
+			return treeResponse(query, []);
+		});
+
+		renderWithQuery(
+			<FileTree changedOnly={false} changedOnlyData={[]} onSelectPath={vi.fn()} selectedPath={null} sessionId="sess-1" filterText="" />,
+		);
+
+		await userEvent.click(await screen.findByText("src"));
+		expect(await screen.findByText("app.go")).toBeInTheDocument();
+
+		// Docked, SessionFileExplorer keeps the tree mounted but display:none
+		// behind the file preview, which the browser reports as a 0x0 resize.
+		// Going back must return to the folder the file was opened from, not to
+		// a collapsed root.
+		resizeTo(0, 0);
+		resizeTo(400, 400);
+
 		expect(await screen.findByText("app.go")).toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/FileTree.tsx
+++ b/frontend/src/renderer/components/FileTree.tsx
@@ -62,6 +62,13 @@ function useContainerSize(): [RefObject<HTMLDivElement | null>, { width: number;
 		const observer = new ResizeObserver(([entry]) => {
 			if (!entry) return;
 			const { width, height } = entry.contentRect;
+			// Docked, SessionFileExplorer keeps the tree mounted but display:none
+			// behind the file preview, and the browser reports that as a 0x0
+			// resize. Unmounting react-arborist's <Tree> there would throw away
+			// the open/closed state it holds internally, so going back from a
+			// file would drop the user at a collapsed root instead of the folder
+			// they opened it from. Keep the last measured size instead.
+			if (width === 0 || height === 0) return;
 			setSize({ width, height });
 		});
 		observer.observe(el);


### PR DESCRIPTION
## What

Keep the docked Files-tab tree mounted while a file is previewed, so the back arrow returns to the folder the file was opened from instead of a collapsed workspace root.

## Why

Fixes #5168.

`SessionFileExplorer` deliberately keeps the tree **mounted** behind the docked file preview — it only hides it (`cn("min-h-0 flex-1", selectedPath && "hidden")`, i.e. `display: none`) so expanded folders and scroll position survive the round trip.

`FileTree`, though, only renders react-arborist's `<Tree>` once its container has a non-zero measured size:

```tsx
{size.width > 0 && size.height > 0 ? <Tree ... /> : null}
```

Chromium fires the `ResizeObserver` with a `0 x 0` content rect when an element loses its box, so hiding the tree zeroed `size` and unmounted `<Tree>` — exactly what the "keep it mounted" design was avoiding. react-arborist holds the open/closed map in a redux store created inside `TreeProvider`'s `useRef`, so the unmount destroyed it and the remount re-seeded from `initialOpenState` (not passed) with `openByDefault={false}` → every folder collapsed. `lazyData` survives (it lives in `FileTree`), which is why the folders were still there, just closed.

Reproduced against the shipped desktop build `0.12.12` on macOS; `FileTree.tsx` is unchanged between `v0.12.12` and `main`.

## How

`useContainerSize` now ignores `0 x 0` measurements and keeps the last real size, so a hidden tree stays mounted with its state intact. One guard clause, no change to the render path or to the maximized layout (which shows tree and content side by side and was never affected).

Considered and rejected: threading react-arborist's open map out into `FileTree` state via `initialOpenState` + `onToggle`. It reimplements state the library already owns and would still lose the tree's scroll offset on every unmount.

## Testing

- New regression test in `FileTree.test.tsx` — expands `src`, drives the ResizeObserver to `0x0` and back (what `display: none` does), and asserts `src/app.go` is still visible. Fails on `main`, passes with this change.
- Verified the underlying browser behavior in real Chromium (playwright): observing the tree container across `display:none` → visible logs `[[316,400],[0,0],[316,400]]`; `316` is the docked inspector rail width.
In `frontend/`:

- `npm run typecheck` — pass
- `npm run typecheck:e2e` — pass
- `npx vitest run` — 291 files, 4003 tests, all passing (7 skipped)

In `packages/product-ui/`: `npm run typecheck` + `npm test` — pass.

Not run locally: the `renderer-smoke` Playwright job (needs the pinned `mcr.microsoft.com/playwright` container) and the packaged build jobs — verified in CI instead.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/Untrivial-ai/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
