### PR TITLE
fix(codex): deduplicate accounts on login, stop transient reauth lockouts

### DIFF
--- a/backend/internal/service/agent/codex_account_login.go
+++ b/backend/internal/service/agent/codex_account_login.go
@@ -264,17 +264,37 @@ func (m *codexAccountManager) verifyLogin(ctx context.Context, operationID strin
 			snapshot.Label = accountLabel(snapshot.ID, observation.Method, observation.Email)
 		})
 	} else {
-		var err error
-		record, err = m.catalog.commitPending(pendingDir, observation)
-		if err != nil {
-			return m.finishLogin(operationID, domain.CodexAccountLoginFailed, domain.CodexAccountLoginReasonFailed, "The verified Codex account could not be saved.", nil), nil
+		if existing, found := m.findExistingAccountForLogin(observation); found {
+			credential, credentialErr := readOpaqueCredential(filepath.Join(home, codexCredentialFilename))
+			if credentialErr != nil {
+				return m.finishLogin(operationID, domain.CodexAccountLoginFailed, domain.CodexAccountLoginReasonFailed, "The verified Codex account could not be saved.", nil), nil
+			}
+			var replaceErr error
+			record, replaceErr = m.catalog.replaceCredential(existing.Snapshot.ID, credential, observation)
+			if replaceErr != nil {
+				return m.finishLogin(operationID, domain.CodexAccountLoginFailed, domain.CodexAccountLoginReasonFailed, "The verified Codex account could not be saved.", nil), nil
+			}
+			_ = os.RemoveAll(pendingDir)
+			m.clearReauthenticationRequired(existing.Snapshot.ID)
+			m.catalog.updateSnapshot(existing.Snapshot.ID, func(s *domain.CodexAccountSnapshot) {
+				s.Authentication = accountAuthenticationObservation(m.now(), observation.Authentication)
+				s.AuthMethod = observation.Method
+				s.AccountEmail = observation.Email
+				s.Label = accountLabel(s.ID, observation.Method, observation.Email)
+			})
+		} else {
+			var err error
+			record, err = m.catalog.commitPending(pendingDir, observation)
+			if err != nil {
+				return m.finishLogin(operationID, domain.CodexAccountLoginFailed, domain.CodexAccountLoginReasonFailed, "The verified Codex account could not be saved.", nil), nil
+			}
+			m.catalog.updateSnapshot(record.Snapshot.ID, func(s *domain.CodexAccountSnapshot) {
+				s.Authentication = accountAuthenticationObservation(m.now(), observation.Authentication)
+				s.AuthMethod = observation.Method
+				s.AccountEmail = observation.Email
+				s.Label = accountLabel(s.ID, observation.Method, observation.Email)
+			})
 		}
-		m.catalog.updateSnapshot(record.Snapshot.ID, func(s *domain.CodexAccountSnapshot) {
-			s.Authentication = accountAuthenticationObservation(m.now(), observation.Authentication)
-			s.AuthMethod = observation.Method
-			s.AccountEmail = observation.Email
-			s.Label = accountLabel(s.ID, observation.Method, observation.Email)
-		})
 		m.mu.Lock()
 		activateFirst := m.active.AccountID == "" && m.globalAuth.State == domain.AgentAuthenticationUnauthorized
 		m.mu.Unlock()
@@ -451,4 +471,29 @@ func (m *codexAccountManager) expireLogin(ctx context.Context, id string, at tim
 		m.finishLogin(id, domain.CodexAccountLoginExpired, domain.CodexAccountLoginReasonExpired, "Codex account login expired.", nil)
 		return
 	}
+}
+
+func (m *codexAccountManager) findExistingAccountForLogin(observation ports.CodexAccountObservation) (codexAccountRecord, bool) {
+	if !distinguishableCodexIdentity(observation) {
+		return codexAccountRecord{}, false
+	}
+	records, err := m.catalog.recordsFor(nil)
+	if err != nil {
+		return codexAccountRecord{}, false
+	}
+	var best *codexAccountRecord
+	for i := range records {
+		r := records[i]
+		if r.Snapshot.Status != domain.CodexAccountStatusValid && r.Snapshot.Status != domain.CodexAccountStatusSignedOut {
+			continue
+		}
+		if sameCodexStructuredIdentity(r.Snapshot, observation) && (best == nil || r.VerifiedAt.After(best.VerifiedAt)) {
+			candidate := r
+			best = &candidate
+		}
+	}
+	if best != nil {
+		return *best, true
+	}
+	return codexAccountRecord{}, false
 }

--- a/backend/internal/service/agent/codex_account_service.go
+++ b/backend/internal/service/agent/codex_account_service.go
@@ -534,16 +534,22 @@ func (s *Service) VerifyCodexAccountForSwitch(ctx context.Context, accountID str
 	}
 	client, err := s.codexAccounts.factory.Open(verifyCtx, ports.CodexAccountContext{Home: record.Home, Managed: true})
 	if err != nil {
+		s.codexAccounts.invalidate(record.Snapshot.ID)
 		return apierr.Unavailable("CODEX_ACCOUNT_VERIFICATION_UNAVAILABLE", "The Codex account could not be checked. Try again.")
 	}
 	defer func() { _ = client.Close() }()
 	observation, err := client.Read(verifyCtx, false)
 	if err != nil {
+		s.codexAccounts.invalidate(record.Snapshot.ID)
 		return apierr.Unavailable("CODEX_ACCOUNT_VERIFICATION_UNAVAILABLE", "The Codex account could not be checked. Try again.")
 	}
-	if observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable {
+	if observation.Authentication == domain.AgentAuthenticationUnauthorized {
 		s.codexAccounts.requireReauthentication(record.Snapshot.ID)
 		return apierr.Conflict("CODEX_ACCOUNT_REAUTHENTICATION_REQUIRED", "Sign in again before switching to this Codex account", nil)
+	}
+	if observation.Authentication != domain.AgentAuthenticationAuthorized && observation.Authentication != domain.AgentAuthenticationNotApplicable {
+		s.codexAccounts.invalidate(record.Snapshot.ID)
+		return apierr.Unavailable("CODEX_ACCOUNT_VERIFICATION_UNAVAILABLE", "The Codex account could not be checked. Try again.")
 	}
 	protectedVerified := false
 	if observation.Authentication == domain.AgentAuthenticationAuthorized && observation.Method == domain.CodexAuthMethodChatGPT {
@@ -558,6 +564,7 @@ func (s *Service) VerifyCodexAccountForSwitch(ctx context.Context, accountID str
 			return apierr.Conflict("CODEX_ACCOUNT_REAUTHENTICATION_REQUIRED", "Sign in again before switching to this Codex account", nil)
 		}
 		if err != nil {
+			s.codexAccounts.invalidate(record.Snapshot.ID)
 			return apierr.Unavailable("CODEX_ACCOUNT_VERIFICATION_UNAVAILABLE", "The Codex account could not be checked. Try again.")
 		}
 		protectedVerified = true
@@ -565,7 +572,8 @@ func (s *Service) VerifyCodexAccountForSwitch(ctx context.Context, accountID str
 	latestCredential, latest, latestErr := readCodexFileState(credentialPath, false)
 	stableOpaqueIdentity := distinguishableCodexIdentity(observation) || (latestErr == nil && sameCodexFileState(admitted, latest))
 	if latestErr != nil || !stableOpaqueIdentity || !s.codexAccounts.observationAndCredentialIdentifyRecord(record, observation, latestCredential) || (!distinguishableCodexIdentity(observation) && !bytes.Equal(credential, latestCredential)) {
-		return apierr.Unavailable("CODEX_ACCOUNT_VERIFICATION_UNAVAILABLE", "The Codex account could not be checked. Try again.")
+		s.codexAccounts.invalidate(record.Snapshot.ID)
+		return apierr.Conflict("CODEX_ACCOUNT_IDENTITY_CHANGED", "The Codex account changed during verification, try again", nil)
 	}
 	if protectedVerified {
 		s.codexAccounts.confirmAuthentication(record.Snapshot.ID)

--- a/backend/internal/service/agent/codex_accounts_test.go
+++ b/backend/internal/service/agent/codex_accounts_test.go
@@ -1747,3 +1747,194 @@ func TestAuthenticationRequestCancellationDoesNotCancelSharedRead(t *testing.T) 
 		}
 	}
 }
+
+func TestLoginDeduplicatesExistingAccountByEmail(t *testing.T) {
+	email := "duplicate@example.com"
+	observation := ports.CodexAccountObservation{
+		Authentication: domain.AgentAuthenticationAuthorized,
+		Method:         domain.CodexAuthMethodChatGPT,
+		Email:          &email,
+	}
+	client := &fakeCodexAccountClient{read: observation}
+	factory := &fakeCodexAccountFactory{
+		capabilities: supportedCodexAccountCapabilities(),
+		open: func(ports.CodexAccountContext) (ports.CodexAccountClient, error) {
+			return client, nil
+		},
+	}
+	state := &fakeCodexAccountStateStore{}
+	manager := newTestCodexAccountManager(t, factory, state)
+	manager.globalAuth = accountAuthenticationObservation(time.Now().UTC(), domain.AgentAuthenticationUnauthorized)
+
+	existingID := "a1111111-1111-4111-8111-111111111111"
+	manager.catalog.newID = func() string { return existingID }
+	existing := commitTestAccount(t, manager.catalog, manager.pendingRoot, "c1111111-1111-4111-8111-111111111111", observation)
+	if existing.Snapshot.ID != existingID {
+		t.Fatalf("existing account id = %q", existing.Snapshot.ID)
+	}
+
+	loginID := "d2222222-2222-4222-8222-222222222222"
+	newAccountID := "b2222222-2222-4222-8222-222222222222"
+	manager.newID = func() string { return loginID }
+	manager.catalog.newID = func() string { return newAccountID }
+	manager.executable = func() (string, error) { return "/ao", nil }
+	manager.terminal = &fakeCodexLoginTerminal{
+		writeCredential: true,
+		result:          shellterm.ShellTerminal{HandleID: "shellterm-dedup", Title: "Add Codex account"},
+	}
+
+	started, err := manager.openLoginTerminal(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, err := manager.verifyLogin(context.Background(), started.Operation.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if completed.Status != domain.CodexAccountLoginCompleted {
+		t.Fatalf("login status = %q", completed.Status)
+	}
+	snapshots := manager.catalog.snapshots()
+	if len(snapshots) != 1 {
+		t.Fatalf("expected 1 account after dedup login, got %d", len(snapshots))
+	}
+	if snapshots[0].ID != existingID {
+		t.Fatalf("expected existing account %q to be reused, got %q", existingID, snapshots[0].ID)
+	}
+	credential, err := readOpaqueCredential(filepath.Join(existing.Home, codexCredentialFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(credential) != "opaque-login-credential" {
+		t.Fatalf("credential was not replaced: %q", credential)
+	}
+}
+
+func newSwitchAdmissionFixture(t *testing.T, factory *fakeCodexAccountFactory, observation ports.CodexAccountObservation) (*codexAccountManager, *Service, codexAccountRecord) {
+	t.Helper()
+	root := t.TempDir()
+	globalHome := filepath.Join(root, "global-codex")
+	if err := ensurePrivateDirectory(globalHome); err != nil {
+		t.Fatal(err)
+	}
+	sourceID := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	state := &fakeCodexAccountStateStore{
+		active: domain.CodexActiveAccount{AccountID: sourceID, Revision: 1},
+		found:  true,
+	}
+	manager := newCodexAccountManager(context.Background(),
+		filepath.Join(root, "accounts"), filepath.Join(root, "pending"),
+		filepath.Join(root, "staging"), globalHome, factory, state, nil)
+	ids := []string{sourceID, testAccountID}
+	idx := 0
+	manager.catalog.newID = func() string { id := ids[idx]; idx++; return id }
+	sourceObs := ports.CodexAccountObservation{Authentication: domain.AgentAuthenticationAuthorized, Method: domain.CodexAuthMethodChatGPT}
+	commitTestAccount(t, manager.catalog, manager.pendingRoot, "b60a377d-da68-4a61-86f2-f31f04c571f2", sourceObs)
+	record := commitTestAccount(t, manager.catalog, manager.pendingRoot, "1c5de3ab-82d0-4a68-a06b-8495cdeab909", observation)
+	if err := writeGlobalCredentialAtomic(manager.globalCredentialPath(), []byte("source-credential")); err != nil {
+		t.Fatal(err)
+	}
+	manager.active = state.active
+	manager.bootstrapOnce.Do(func() {
+		manager.bootstrapped = true
+		close(manager.bootstrapDone)
+	})
+	svc := &Service{codexAccounts: manager, readiness: newReadinessCoordinator(readinessCoordinatorConfig{})}
+	return manager, svc, record
+}
+
+func TestSwitchAdmissionTransientErrorDoesNotRequireReauthentication(t *testing.T) {
+	email := "switch-test@example.com"
+	observation := ports.CodexAccountObservation{
+		Authentication: domain.AgentAuthenticationAuthorized,
+		Method:         domain.CodexAuthMethodChatGPT,
+		Email:          &email,
+	}
+	callCount := 0
+	factory := &fakeCodexAccountFactory{
+		capabilities: supportedCodexAccountCapabilities(),
+		open: func(ports.CodexAccountContext) (ports.CodexAccountClient, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, errors.New("transient process spawn failure")
+			}
+			return &fakeCodexAccountClient{read: observation}, nil
+		},
+	}
+	manager, svc, record := newSwitchAdmissionFixture(t, factory, observation)
+
+	err := svc.VerifyCodexAccountForSwitch(context.Background(), record.Snapshot.ID)
+	if err == nil {
+		t.Fatal("expected transient error, got nil")
+	}
+	latest, _ := manager.catalog.record(record.Snapshot.ID)
+	if latest.Snapshot.Authentication.State == domain.AgentAuthenticationUnauthorized {
+		t.Fatal("transient factory.Open failure incorrectly triggered requireReauthentication")
+	}
+
+	auth, authErr := manager.ensureAuthentication(context.Background(), record, domain.AgentReadinessPurposeDisplay, false)
+	if authErr != nil {
+		t.Fatal(authErr)
+	}
+	if auth.State == domain.AgentAuthenticationUnauthorized {
+		t.Fatal("account is permanently locked out after transient error")
+	}
+}
+
+func TestSwitchAdmissionReadErrorDoesNotRequireReauthentication(t *testing.T) {
+	email := "read-err@example.com"
+	observation := ports.CodexAccountObservation{
+		Authentication: domain.AgentAuthenticationAuthorized,
+		Method:         domain.CodexAuthMethodChatGPT,
+		Email:          &email,
+	}
+	callCount := 0
+	factory := &fakeCodexAccountFactory{
+		capabilities: supportedCodexAccountCapabilities(),
+		open: func(ports.CodexAccountContext) (ports.CodexAccountClient, error) {
+			callCount++
+			if callCount == 1 {
+				return &fakeCodexAccountClient{readErr: errors.New("timeout reading account")}, nil
+			}
+			return &fakeCodexAccountClient{read: observation}, nil
+		},
+	}
+	manager, svc, record := newSwitchAdmissionFixture(t, factory, observation)
+
+	err := svc.VerifyCodexAccountForSwitch(context.Background(), record.Snapshot.ID)
+	if err == nil {
+		t.Fatal("expected transient error, got nil")
+	}
+	latest, _ := manager.catalog.record(record.Snapshot.ID)
+	if latest.Snapshot.Authentication.State == domain.AgentAuthenticationUnauthorized {
+		t.Fatal("transient client.Read failure incorrectly triggered requireReauthentication")
+	}
+}
+
+func TestSwitchAdmissionUnauthorizedRequiresReauthentication(t *testing.T) {
+	email := "unauth@example.com"
+	factory := &fakeCodexAccountFactory{
+		capabilities: supportedCodexAccountCapabilities(),
+		open: func(ports.CodexAccountContext) (ports.CodexAccountClient, error) {
+			return &fakeCodexAccountClient{read: ports.CodexAccountObservation{
+				Authentication: domain.AgentAuthenticationUnauthorized,
+				Method:         domain.CodexAuthMethodChatGPT,
+				Email:          &email,
+			}}, nil
+		},
+	}
+	_, svc, record := newSwitchAdmissionFixture(t, factory, ports.CodexAccountObservation{
+		Authentication: domain.AgentAuthenticationAuthorized,
+		Method:         domain.CodexAuthMethodChatGPT,
+		Email:          &email,
+	})
+
+	err := svc.VerifyCodexAccountForSwitch(context.Background(), record.Snapshot.ID)
+	if err == nil {
+		t.Fatal("expected reauth error for unauthorized account")
+	}
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != "CODEX_ACCOUNT_REAUTHENTICATION_REQUIRED" {
+		t.Fatalf("expected CODEX_ACCOUNT_REAUTHENTICATION_REQUIRED, got %v", err)
+	}
+}

--- a/backend/internal/service/agent/codex_accounts_test.go
+++ b/backend/internal/service/agent/codex_accounts_test.go
@@ -1835,10 +1835,10 @@ func newSwitchAdmissionFixture(t *testing.T, factory *fakeCodexAccountFactory, o
 		t.Fatal(err)
 	}
 	manager.active = state.active
-	manager.bootstrapOnce.Do(func() {
-		manager.bootstrapped = true
-		close(manager.bootstrapDone)
-	})
+	manager.accountStoreReady = true
+	manager.reconciliation = domain.CodexDeviceReconciliation{
+		Status: domain.CodexDeviceReconciliationVerified, ActiveAccountVerified: true,
+	}
 	svc := &Service{codexAccounts: manager, readiness: newReadinessCoordinator(readinessCoordinatorConfig{})}
 	return manager, svc, record
 }
@@ -1872,7 +1872,7 @@ func TestSwitchAdmissionTransientErrorDoesNotRequireReauthentication(t *testing.
 		t.Fatal("transient factory.Open failure incorrectly triggered requireReauthentication")
 	}
 
-	auth, authErr := manager.ensureAuthentication(context.Background(), record, domain.AgentReadinessPurposeDisplay, false)
+	auth, authErr := manager.ensureAuthentication(context.Background(), record, domain.AgentReadinessPurposeDisplay)
 	if authErr != nil {
 		t.Fatal(authErr)
 	}


### PR DESCRIPTION
## Summary
- Login now matches existing accounts by email+method before creating a new slot, preventing duplicate account entries for the same Codex identity
- Switch admission no longer permanently locks out accounts on transient failures (process spawn errors, timeouts, network blips); only a definitive unauthorized response from the Codex process triggers reauthentication
- Credential identity mismatches during switch verification return a retryable error instead of permanent lockout

## Test plan
- [x] `TestLoginDeduplicatesExistingAccountByEmail`: logs in with an email already in the catalog, verifies one slot remains with updated credential
- [x] `TestSwitchAdmissionTransientErrorDoesNotRequireReauthentication`: process spawn failure during switch does not permanently lock out the account
- [x] `TestSwitchAdmissionReadErrorDoesNotRequireReauthentication`: client.Read timeout does not permanently lock out the account
- [x] `TestSwitchAdmissionUnauthorizedRequiresReauthentication`: genuine unauthorized response still correctly triggers reauthentication
- [x] All existing Codex account, HTTP controller, and session manager tests pass