### PR TITLE
feat(mobile-telemetry): tag chat vs tui on spawn, conductor, and handoff

### DIFF
--- a/packages/mobile/lib/session/useInterfaceTransition.ts
+++ b/packages/mobile/lib/session/useInterfaceTransition.ts
@@ -15,6 +15,7 @@ import {
 	interfaceTransitionNextPoll,
 	mobileInterfaceTransitionIsActive,
 } from "./interfaceTransition";
+import { trackFeature } from "../telemetry/runtime";
 
 export {
 	interfaceSwitchAlert,
@@ -236,7 +237,13 @@ export function useInterfaceTransition(
 			setStarting(true);
 			setError(undefined);
 			try {
-				const transition = await startSessionInterfaceTransition(cfg, sessionId, targetMode, policy);
+				// A live chat<->tui handoff. `mode` is the target the user switched to;
+				// in a two-mode world it also names the direction (to tui = from chat).
+				const transition = await trackFeature(
+					"handoff",
+					() => startSessionInterfaceTransition(cfg, sessionId, targetMode, policy),
+					{ mode: targetMode },
+				);
 				noteRequestLanded();
 				setStatus((current) => ({
 					supported: current?.supported ?? true,

--- a/packages/mobile/lib/store.tsx
+++ b/packages/mobile/lib/store.tsx
@@ -475,32 +475,42 @@ export function AppProvider({ children }: { children: ReactNode }) {
 	}, [activeProjectId, projects]);
 
 	const spawn = useCallback(
-		async ({ projectId, prompt, harness, model, mode }: SpawnOptions) =>
-			trackFeature("spawn", async () => {
-				const c = cfgRef.current;
-				const proj = projectId ?? targetProject();
-				if (!c || !proj) throw new Error("Pick a project first");
-				const session = await delegateTask(c, {
-					projectId: proj,
-					brief: prompt ?? "",
-					agent: harness,
-					model,
-					mode: mode ?? "chat",
-				});
-				await fetchAll();
-				return session;
-			}),
+		async ({ projectId, prompt, harness, model, mode }: SpawnOptions) => {
+			const resolvedMode = mode ?? "chat";
+			return trackFeature(
+				"spawn",
+				async () => {
+					const c = cfgRef.current;
+					const proj = projectId ?? targetProject();
+					if (!c || !proj) throw new Error("Pick a project first");
+					const session = await delegateTask(c, {
+						projectId: proj,
+						brief: prompt ?? "",
+						agent: harness,
+						model,
+						mode: resolvedMode,
+					});
+					await fetchAll();
+					return session;
+				},
+				{ mode: resolvedMode },
+			);
+		},
 		[targetProject, fetchAll],
 	);
 
 	const launchConductor = useCallback(
 		async (projectId: string, clean = false, mode: SessionMode = "chat") =>
-			trackFeature("conductor", async () => {
-				const c = cfgRef.current!;
-				const link = await apiLaunchOrchestrator(c, projectId, clean, mode);
-				await fetchAll();
-				return link;
-			}),
+			trackFeature(
+				"conductor",
+				async () => {
+					const c = cfgRef.current!;
+					const link = await apiLaunchOrchestrator(c, projectId, clean, mode);
+					await fetchAll();
+					return link;
+				},
+				{ mode },
+			),
 		[fetchAll],
 	);
 

--- a/packages/mobile/lib/telemetry/events.ts
+++ b/packages/mobile/lib/telemetry/events.ts
@@ -71,8 +71,13 @@ export const MOBILE_ALLOWLIST: Record<string, Readonly<Record<string, PropRule>>
 	},
 	[MOBILE_EVENTS.featureUsed]: {
 		feature: {
-			oneOf: ["spawn", "merge", "kill", "restore", "conductor", "send"],
+			oneOf: ["spawn", "merge", "kill", "restore", "conductor", "send", "handoff"],
 		},
 		outcome: { oneOf: ["succeeded", "failed"] },
+		// The chat/tui interface. Set on spawn and conductor (the mode the session
+		// starts in) and on handoff (the mode it switches to). Absent on the other
+		// features, which are mode-agnostic. Only the two enum values ever leave the
+		// device; no titles or paths ride on this.
+		mode: { oneOf: ["chat", "tui"] },
 	},
 };

--- a/packages/mobile/lib/telemetry/runtime.ts
+++ b/packages/mobile/lib/telemetry/runtime.ts
@@ -3,6 +3,7 @@ import Constants from "expo-constants";
 import * as Device from "expo-device";
 import { Platform } from "react-native";
 import PostHog from "posthog-react-native";
+import type { SessionMode } from "../api";
 import { buildMobileContext } from "./context";
 import { type ActiveStorage } from "./dailyActive";
 import {
@@ -112,20 +113,29 @@ export const telemetryActiveStorage: ActiveStorage = {
 };
 
 /** Feature ids the featureUsed allowlist accepts. */
-export type MobileFeature = "spawn" | "merge" | "kill" | "restore" | "conductor" | "send";
+export type MobileFeature = "spawn" | "merge" | "kill" | "restore" | "conductor" | "send" | "handoff";
+
+/** Extra allowlisted context for a feature event. `mode` distinguishes chat vs tui. */
+export type FeatureContext = { mode?: SessionMode };
 
 /**
  * Runs an action and reports feature_used with its outcome, without changing the
- * action's own return value or error. Best-effort: a null client (pre-init) is a
- * no-op, and telemetry never swallows or alters the action's result.
+ * action's own return value or error. `context` carries allowlisted extras (e.g.
+ * the chat/tui `mode`) onto both the success and failure event. Best-effort: a
+ * null client (pre-init) is a no-op, and telemetry never swallows or alters the
+ * action's result.
  */
-export async function trackFeature<T>(feature: MobileFeature, run: () => Promise<T>): Promise<T> {
+export async function trackFeature<T>(
+	feature: MobileFeature,
+	run: () => Promise<T>,
+	context?: FeatureContext,
+): Promise<T> {
 	try {
 		const result = await run();
-		telemetry?.capture(MOBILE_EVENTS.featureUsed, { feature, outcome: "succeeded" });
+		telemetry?.capture(MOBILE_EVENTS.featureUsed, { feature, outcome: "succeeded", ...context });
 		return result;
 	} catch (error) {
-		telemetry?.capture(MOBILE_EVENTS.featureUsed, { feature, outcome: "failed" });
+		telemetry?.capture(MOBILE_EVENTS.featureUsed, { feature, outcome: "failed", ...context });
 		throw error;
 	}
 }

--- a/packages/mobile/lib/telemetry/sanitize.test.ts
+++ b/packages/mobile/lib/telemetry/sanitize.test.ts
@@ -29,6 +29,33 @@ describe("sanitizeMobileProperties", () => {
 		).toEqual({ feature: "spawn", outcome: "succeeded" });
 	});
 
+	it("keeps mode on a spawn feature event and accepts the handoff feature", () => {
+		expect(
+			sanitizeMobileProperties(MOBILE_EVENTS.featureUsed, {
+				feature: "spawn",
+				outcome: "succeeded",
+				mode: "tui",
+			}),
+		).toEqual({ feature: "spawn", outcome: "succeeded", mode: "tui" });
+		expect(
+			sanitizeMobileProperties(MOBILE_EVENTS.featureUsed, {
+				feature: "handoff",
+				outcome: "succeeded",
+				mode: "chat",
+			}),
+		).toEqual({ feature: "handoff", outcome: "succeeded", mode: "chat" });
+	});
+
+	it("drops a mode value outside the chat/tui set", () => {
+		expect(
+			sanitizeMobileProperties(MOBILE_EVENTS.featureUsed, {
+				feature: "spawn",
+				outcome: "succeeded",
+				mode: "gui",
+			}),
+		).toEqual({ feature: "spawn", outcome: "succeeded" });
+	});
+
 	it("returns {} for an unknown event rather than passing the payload through", () => {
 		expect(sanitizeMobileProperties("ao.mobile_app.not_a_real_event", { anything: "x" })).toEqual({});
 	});


### PR DESCRIPTION
## Why

The mobile app runs a session in one of two interfaces, a native **Chat UI** or the agent's **TUI**, chosen per session via the `mode: "chat" | "tui"` field (`lib/api.ts`). Nothing recorded which one, so "how many sessions run in chat vs TUI, and do people switch" was unanswerable from PostHog. `ao.session.spawned` only carries `client = cli | null`, no surface split.

## What

Adds a single closed-enum `mode` (`chat` | `tui`) to `ao.v2.mobile_app.feature_used` and sets it on every place a mode is chosen:

- **spawn** (`lib/store.tsx`) tags the interface the session is created with.
- **conductor** / orchestrator launch (`lib/store.tsx`) does the same for the second spawn path, so it isn't undercounted.
- **handoff** (new `feature` value): a live in-session Chat<->TUI switch, instrumented once at the hook both call sites funnel through (`lib/session/useInterfaceTransition.ts`). Its `mode` is the target the user switched to, which in a two-mode world also names the direction (to `tui` = from chat).

This lets you separate:
- **what they choose** at creation (spawn/conductor `mode`), from
- **whether chat is carrying the work** (handoff volume and direction).

`trackFeature` gains an optional `context` arg so the `mode` rides on both the success and failure event without touching the action's own result.

## Privacy

`mode` is a closed enum in the allowlist (`lib/telemetry/events.ts`); the mobile contract's "no free-text property" rule is preserved, so no title, path, or prompt can ride along. Sanitisation still iterates the allowlist, and a `mode` outside `chat`/`tui` is dropped (covered by a test).

## Testing

- `npm run typecheck` (tsc --noEmit): clean.
- `npm test` (vitest): 787 passed, including new `sanitize.test.ts` cases for `mode` being kept on spawn/handoff and dropped when outside the enum.
- Both are exactly what `.github/workflows/mobile.yml` runs.

## Notes

- Not retroactive: only spawns/handoffs after this ships carry `mode`.
- `feature_used` for `merge`/`kill`/`restore`/`send` stays mode-agnostic (no `mode` passed), by design.