### PR TITLE
fix(lifecycle): honor session toggle when injecting review feedback (#3840)

### DIFF
--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -2021,6 +2021,28 @@ func TestPRObservation_ReviewFeedbackNotInjectedWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestPRObservation_ReviewFeedbackNotDeliveredWhenSessionToggleTurnedOff(t *testing.T) {
+	m, st, msg := newManager()
+	rec := working("mer-1")
+	rec.AutoInjectReview = false
+	st.sessions[rec.ID] = rec
+	st.comments["pr1"] = []domain.PullRequestComment{{ID: "1", Author: "alice", Body: "fix this", AutoInjectReview: true}}
+	st.reviews["pr1"] = []domain.PullRequestReview{{ID: "r1", Author: "alice", State: domain.ReviewChangesRequest, Body: "change this too", AutoInjectReview: true}}
+	o := ports.PRObservation{
+		Fetched: true,
+		URL:     "pr1",
+		CI:      domain.CIFailing,
+		Checks:  []ports.PRCheckObservation{{Name: "build", Status: domain.PRCheckFailed, LogTail: "boom"}},
+		Review:  domain.ReviewChangesRequest,
+	}
+	if err := m.ApplyPRObservation(ctx, rec.ID, o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 || !strings.Contains(msg.msgs[0], "boom") || strings.Contains(msg.msgs[0], "fix this") || strings.Contains(msg.msgs[0], "change this too") {
+		t.Fatalf("messages = %v, want CI only when session review auto-injection toggle is turned off", msg.msgs)
+	}
+}
+
 func TestPRObservation_MixedPersistedCommentDecisions(t *testing.T) {
 	m, st, msg := newManager()
 	st.sessions["mer-1"] = working("mer-1")
@@ -3136,6 +3158,11 @@ func TestApplyReviewBatchNoopsWhenWorkerCannotBeNudged(t *testing.T) {
 			name:   "worker agent exited",
 			result: ReviewResult{RunID: "run-1", PRURL: "pr1", Verdict: domain.VerdictChangesRequested},
 			rec:    func() domain.SessionRecord { r := working("mer-1"); r.Activity.State = domain.ActivityExited; return r }(),
+		},
+		{
+			name:   "worker review auto-inject toggle disabled",
+			result: ReviewResult{RunID: "run-1", PRURL: "pr1", Verdict: domain.VerdictChangesRequested},
+			rec:    func() domain.SessionRecord { r := working("mer-1"); r.AutoInjectReview = false; return r }(),
 		},
 	}
 	for _, tt := range tests {

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -56,7 +56,7 @@ func (m *Manager) ApplyReviewBatch(ctx context.Context, workerID domain.SessionI
 	if err != nil || !ok {
 		return ReviewDeliveryNoop, err
 	}
-	if cannotNudge(rec) {
+	if cannotNudge(rec) || !rec.AutoInjectReview {
 		return ReviewDeliveryNoop, nil
 	}
 	if m.guard == nil {
@@ -261,7 +261,7 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			}
 		}
 
-		if hasUnresolvedComments(o.Comments) {
+		if rec.AutoInjectReview && hasUnresolvedComments(o.Comments) {
 			comments := unresolvedReviewComments(o.Comments)
 			for _, comment := range comments {
 				if !comment.AutoInjectReview {
@@ -283,7 +283,7 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			}
 		}
 
-		if o.Review == domain.ReviewChangesRequest {
+		if rec.AutoInjectReview && o.Review == domain.ReviewChangesRequest {
 			for _, review := range reviews {
 				if review.State != domain.ReviewChangesRequest || !review.AutoInjectReview {
 					continue

--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -784,6 +784,13 @@ func (s *Service) deliverSubmitted(ctx context.Context, workerID domain.SessionI
 }
 
 func (s *Service) deliverableRuns(ctx context.Context, workerID domain.SessionID, runs []domain.ReviewRun) ([]domain.ReviewRun, error) {
+	session, found, err := s.store.GetSession(ctx, workerID)
+	if err != nil {
+		return nil, err
+	}
+	if !found || !session.AutoInjectReview {
+		return nil, nil
+	}
 	currentHeads, err := s.currentHeadsByPR(ctx, workerID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -362,6 +362,37 @@ func TestSubmitSnapshotsDisabledPolicyAndNeverDeliversOnRetry(t *testing.T) {
 	}
 }
 
+func TestSubmitDoesNotDeliverWhenSessionToggleTurnedOffAfterRun(t *testing.T) {
+	st := &fakeStore{
+		ok: true,
+		run: domain.ReviewRun{
+			ID:               "run-1",
+			SessionID:        "mer-1",
+			BatchID:          "batch-1",
+			PRURL:            "pr1",
+			TargetSHA:        "sha1",
+			Status:           domain.ReviewRunComplete,
+			Verdict:          domain.VerdictChangesRequested,
+			Body:             "fix it",
+			GithubReviewID:   "987",
+			AutoInjectReview: true,
+		},
+		prs: []domain.PullRequest{{URL: "pr1", HeadSHA: "sha1"}},
+	}
+	disabled := false
+	st.sessionAutoInjectReview = &disabled
+	reducer := &fakeReducer{outcome: lifecycle.ReviewDeliverySent}
+	svc := New(nil, st, WithLifecycleReducer(reducer))
+
+	run, err := svc.Submit(context.Background(), "mer-1", "run-1", domain.VerdictChangesRequested, "fix it", "987")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != domain.ReviewRunComplete || reducer.batchCalls != 0 || st.markCalls != 0 {
+		t.Fatalf("run delivered despite session toggle off = %+v reducerCalls=%d markCalls=%d", run, reducer.batchCalls, st.markCalls)
+	}
+}
+
 func TestSubmitBatchRunDoesNotWaitForOtherRunningRuns(t *testing.T) {
 	now := time.Unix(100, 0).UTC()
 	st := &fakeStore{
@@ -430,6 +461,36 @@ func TestSubmitManySendsCombinedChangesRequested(t *testing.T) {
 	if runs[0].Status != domain.ReviewRunDelivered || runs[0].DeliveredAt == nil || !runs[0].DeliveredAt.Equal(now) ||
 		runs[1].Status != domain.ReviewRunDelivered || runs[1].DeliveredAt == nil || !runs[1].DeliveredAt.Equal(now) {
 		t.Fatalf("submitted runs not stamped delivered: %+v", runs)
+	}
+}
+
+func TestSubmitManyDoesNotDeliverWhenSessionToggleDisabled(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	disabled := false
+	st := &fakeStore{
+		ok:                      true,
+		sessionAutoInjectReview: &disabled,
+		batchRuns: []domain.ReviewRun{
+			{ID: "run-1", SessionID: "mer-1", BatchID: "batch-1", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunRunning},
+		},
+		prs: []domain.PullRequest{
+			{URL: "pr1", HeadSHA: "sha1"},
+		},
+	}
+	reducer := &fakeReducer{outcome: lifecycle.ReviewDeliverySent}
+	svc := New(nil, st, WithLifecycleReducer(reducer), WithClock(func() time.Time { return now }))
+
+	runs, err := svc.SubmitMany(context.Background(), "mer-1", []SubmittedReview{
+		{RunID: "run-1", Verdict: domain.VerdictChangesRequested, Body: "fix pr1", GithubReviewID: "101"},
+	})
+	if err != nil {
+		t.Fatalf("SubmitMany: %v", err)
+	}
+	if reducer.batchCalls != 0 || st.markCalls != 0 {
+		t.Fatalf("batch delivery should not occur when toggle is off: batchCalls=%d markCalls=%d", reducer.batchCalls, st.markCalls)
+	}
+	if runs[0].Status == domain.ReviewRunDelivered || runs[0].DeliveredAt != nil {
+		t.Fatalf("run should not be delivered when toggle is off: %+v", runs[0])
 	}
 }
 


### PR DESCRIPTION
Fixes #3840

## Problem

Turning off "Automatically send review feedback" (`session.AutoInjectReview = false`) did not reliably stop review feedback from being injected into the worker. Review feedback captured while the toggle was enabled remained marked injectable (`auto_inject_review = true` snapshot) and was still delivered by later observation and delivery passes even after the user explicitly turned the session-level toggle off.

## Root cause

1. In `backend/internal/lifecycle/reactions.go`:
   - `ApplyPRObservation` only inspected the per-comment and per-review snapshots (`comment.AutoInjectReview` / `review.AutoInjectReview`) saved when the items were first ingested, without requiring the live `rec.AutoInjectReview` setting.
   - `ApplyReviewBatch` checked `cannotNudge(rec)` but did not check `!rec.AutoInjectReview`.
2. In `backend/internal/service/review/review.go`:
   - `deliverableRuns` only checked `!run.AutoInjectReview` without verifying if the worker session currently has `session.AutoInjectReview` enabled.

## Fix

Treat injection eligibility as the conjunction of both policies (`persisted_feedback.auto_inject_review && current_session.auto_inject_review`):

- `backend/internal/lifecycle/reactions.go`:
  - Gate both `hasUnresolvedComments` and `ReviewChangesRequest` delivery on `rec.AutoInjectReview && ...`.
  - Gate `ApplyReviewBatch` on `!rec.AutoInjectReview` (returns `ReviewDeliveryNoop, nil`).
- `backend/internal/service/review/review.go`:
  - In `deliverableRuns`, check `session.AutoInjectReview` via `s.store.GetSession` and return empty deliverable runs if disabled.
- Per-feedback snapshots remain intact so re-enabling later does not retroactively inject feedback captured while disabled.

## Testing

Added regression and race tests covering all 4 lifecycle scenarios:
1. `TestPRObservation_ReviewFeedbackNotDeliveredWhenSessionToggleTurnedOff` (`manager_test.go`): captured enabled -> toggle off before lifecycle delivery -> not injected (CI failure nudge still fires independently).
2. `TestPRObservation_ReviewFeedbackNotInjectedWhenDisabled` (`manager_test.go`) & `TestSubmitSnapshotsDisabledPolicyAndNeverDeliversOnRetry` (`review_test.go`): captured disabled -> toggle on later -> not injected.
3. `TestPRObservation_CIFailingAndReviewBothNudge` (`manager_test.go`) & `TestSubmitPersistsThenAppliesThenStampsDelivered` (`review_test.go`): captured enabled and still enabled -> injected.
4. `TestApplyReviewBatchNoopsWhenWorkerCannotBeNudged` (`manager_test.go`) & `TestSubmitDoesNotDeliverWhenSessionToggleTurnedOffAfterRun` / `TestSubmitManyDoesNotDeliverWhenSessionToggleDisabled` (`review_test.go`): AO internal review batch follows the same rules.

Validation passes:
- `go test -race ./internal/lifecycle/... ./internal/service/review/...` -> PASS
- `go vet ./...` -> PASS
- `npm run lint` -> PASS (0 issues)
- `npm run frontend:typecheck` -> PASS