### PR TITLE
fix(browser): stabilize native surface layout

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -105,6 +105,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					onMaximized: () => () => undefined,
 					isFullScreen: async () => false,
 					onFullScreen: () => () => undefined,
+					onBrowserLayoutChanged: () => () => undefined,
 				},
 				theme: {
 					set: async () => undefined,
@@ -643,6 +644,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					onMaximized: () => () => undefined,
 					isFullScreen: async () => false,
 					onFullScreen: () => () => undefined,
+					onBrowserLayoutChanged: () => () => undefined,
 				},
 				theme: {
 					set: async () => undefined,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -135,6 +135,7 @@ import {
 	type BrowserProfileMenuItem,
 } from "./main/browser-profile-ipc";
 import type { BrowserProfileMenuInput } from "./shared/browser-profiles";
+import type { BrowserSurfaceLayoutReason, BrowserSurfaceLayoutSignal } from "./shared/browser-surface";
 import { createWindowComposition, type WindowComposition } from "./main/window-composition";
 import { AgentBrowserRuntime } from "./main/agent-browser-runtime";
 import { sameBrowserRuntimeIdentity, type BrowserRuntimeIdentity } from "./main/browser-runtime-identity";
@@ -725,18 +726,29 @@ async function createWindowInternal(): Promise<void> {
 	// macOS: traffic lights vanish in native fullscreen, so the renderer drops
 	// the clearance pad above TitlebarNav. Push state so the sidebar can react
 	// without polling isFullScreen().
-	const pushFullScreen = () => {
+	let browserLayoutSequence = 0;
+	const pushBrowserLayout = (reason: BrowserSurfaceLayoutReason) => {
+		getShellWebContents()?.send("window:browserLayoutChanged", {
+			sequence: ++browserLayoutSequence,
+			reason,
+		} satisfies BrowserSurfaceLayoutSignal);
+	};
+	const pushFullScreen = (reason: "enter-full-screen" | "leave-full-screen") => {
 		if (!mainWindow) return;
 		getShellWebContents()?.send("window:fullscreen", mainWindow.isFullScreen());
+		pushBrowserLayout(reason);
 	};
-	const pushMaximized = () => {
+	const pushMaximized = (reason: "maximize" | "unmaximize") => {
 		if (!mainWindow) return;
 		getShellWebContents()?.send("window:maximized", mainWindow.isMaximized());
+		pushBrowserLayout(reason);
 	};
-	mainWindow.on("enter-full-screen", pushFullScreen);
-	mainWindow.on("leave-full-screen", pushFullScreen);
-	mainWindow.on("maximize", pushMaximized);
-	mainWindow.on("unmaximize", pushMaximized);
+	mainWindow.on("resize", () => pushBrowserLayout("resize"));
+	mainWindow.on("move", () => pushBrowserLayout("move"));
+	mainWindow.on("enter-full-screen", () => pushFullScreen("enter-full-screen"));
+	mainWindow.on("leave-full-screen", () => pushFullScreen("leave-full-screen"));
+	mainWindow.on("maximize", () => pushMaximized("maximize"));
+	mainWindow.on("unmaximize", () => pushMaximized("unmaximize"));
 	mainWindow.on("blur", () => {
 		keybindingRecordingActive = false;
 	});

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { net } from "electron";
 import {
 	type BrowserNavState,
+	type BrowserRect,
 	type BrowserTabsState,
 	browserShortcutAction,
 	clampBoundsToWindow,
@@ -265,7 +266,7 @@ function setupHost(agentBrowserRuntime?: import("./agent-browser-runtime").Agent
 	});
 	const rendererFrame = { processId: 5, routingId: 7 };
 	const invoke = (channel: string, ...args: unknown[]) =>
-		handlers.get(channel)!({ sender: { id: 1 }, senderFrame: rendererFrame }, ...args) as Promise<BrowserNavState>;
+		handlers.get(channel)!({ sender: { id: 1, getZoomFactor: () => 1 }, senderFrame: rendererFrame }, ...args) as Promise<BrowserNavState>;
 	// browser:annotation:submit is a handle() (invoke/await), not an on() —
 	// unlike invoke() above it must impersonate the browser tab's own
 	// webContents (senderId), not the shell window's, so forwardAnnotationSubmit
@@ -1674,6 +1675,31 @@ describe("native browser visibility", () => {
 		expect(view.setVisible).toHaveBeenLastCalledWith(true);
 	});
 
+	it("lets only the newest overlapping surface refresh restore the live page", async () => {
+		vi.useFakeTimers();
+		try {
+			const { emit, host, invoke, view } = setupHost();
+			await invoke("browser:ensure", "sess-1");
+			emit("browser:setBounds", 1, {
+				viewId: "1:sess-1",
+				rect: { x: 10, y: 20, width: 320, height: 240 },
+				visible: true,
+			});
+			await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:3000" });
+			view.setBounds.mockClear();
+			view.setVisible.mockClear();
+
+			host.refreshLastFocusedPanelSurface();
+			host.refreshLastFocusedPanelSurface();
+			await vi.runAllTimersAsync();
+
+			expect(view.setVisible.mock.calls.filter(([visible]) => visible === true)).toHaveLength(1);
+			expect(view.setBounds).toHaveBeenLastCalledWith({ x: 10, y: 20, width: 320, height: 240 });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("does nothing when nothing has been focused yet, or the panel is hidden", async () => {
 		const { host, view } = setupHost();
 		host.refreshLastFocusedPanelSurface();
@@ -2570,6 +2596,95 @@ describe("browser:setBounds", () => {
 
 		expect(view.setVisible).not.toHaveBeenCalled();
 		expect(sent).not.toContainEqual(expect.objectContaining({ channel: "browser:navState" }));
+	});
+});
+
+describe("browser:applyBounds", () => {
+	it("rejects stale revisions and acknowledges the authoritative native rectangle", async () => {
+		const { invoke, view } = setupHost();
+		await invoke("browser:ensure", "sess-1", "renderer-lifetime-a");
+		view.setBounds.mockClear();
+
+		const latest = await invoke("browser:applyBounds", {
+			viewId: "1:sess-1",
+			sourceId: "renderer-lifetime-a",
+			revision: 2,
+			rect: { x: 200, y: 30, width: 320, height: 240 },
+			visible: true,
+		}) as unknown as { applied: boolean; revision: number; rect: BrowserRect };
+		const stale = await invoke("browser:applyBounds", {
+			viewId: "1:sess-1",
+			sourceId: "renderer-lifetime-a",
+			revision: 1,
+			rect: { x: 100, y: 30, width: 320, height: 240 },
+			visible: true,
+		}) as unknown as { applied: boolean; revision: number; rect: BrowserRect };
+
+		expect(latest).toMatchObject({ applied: true, revision: 2, rect: { x: 200, y: 30, width: 320, height: 240 } });
+		expect(stale).toMatchObject({ applied: false, revision: 2, rect: { x: 200, y: 30, width: 320, height: 240 } });
+		expect(view.setBounds).toHaveBeenCalledTimes(1);
+		expect(view.setBounds).toHaveBeenLastCalledWith({ x: 200, y: 30, width: 320, height: 240 });
+	});
+
+	it("makes a new preload lifetime authoritative after a shell reload", async () => {
+		const { invoke, view } = setupHost();
+		await invoke("browser:ensure", "sess-1", "renderer-lifetime-a");
+		await invoke("browser:applyBounds", {
+			viewId: "1:sess-1",
+			sourceId: "renderer-lifetime-a",
+			revision: 40,
+			rect: { x: 40, y: 20, width: 320, height: 240 },
+			visible: true,
+		});
+		await invoke("browser:ensure", "sess-1", "renderer-lifetime-b");
+		view.setBounds.mockClear();
+
+		const current = await invoke("browser:applyBounds", {
+			viewId: "1:sess-1",
+			sourceId: "renderer-lifetime-b",
+			revision: 1,
+			rect: { x: 300, y: 20, width: 320, height: 240 },
+			visible: true,
+		}) as unknown as { applied: boolean };
+		const departed = await invoke("browser:applyBounds", {
+			viewId: "1:sess-1",
+			sourceId: "renderer-lifetime-a",
+			revision: 41,
+			rect: { x: 10, y: 20, width: 320, height: 240 },
+			visible: true,
+		}) as unknown as { applied: boolean };
+
+		expect(current.applied).toBe(true);
+		expect(departed.applied).toBe(false);
+		expect(view.setBounds).toHaveBeenCalledTimes(1);
+		expect(view.setBounds).toHaveBeenLastCalledWith({ x: 300, y: 20, width: 320, height: 240 });
+	});
+
+	it("coalesces identical accepted layouts without recreating or resizing the native surface", async () => {
+		const { invoke, mainContentView, view } = setupHost();
+		await invoke("browser:ensure", "sess-1", "renderer-lifetime-a");
+		await invoke("browser:applyBounds", {
+			viewId: "1:sess-1",
+			sourceId: "renderer-lifetime-a",
+			revision: 1,
+			rect: { x: 100, y: 20, width: 320, height: 240 },
+			visible: true,
+		});
+		view.setBounds.mockClear();
+		mainContentView.addChildView.mockClear();
+
+		for (let revision = 2; revision <= 200; revision += 1) {
+			await invoke("browser:applyBounds", {
+				viewId: "1:sess-1",
+				sourceId: "renderer-lifetime-a",
+				revision,
+				rect: { x: 100, y: 20, width: 320, height: 240 },
+				visible: true,
+			});
+		}
+
+		expect(view.setBounds).not.toHaveBeenCalled();
+		expect(mainContentView.addChildView).not.toHaveBeenCalled();
 	});
 });
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -3,7 +3,6 @@ import type {
 	IpcMain,
 	IpcMainEvent,
 	IpcMainInvokeEvent,
-	Rectangle,
 	Session,
 	View,
 	WebContents,
@@ -37,6 +36,12 @@ import type { BrowserProfileStore } from "./browser-profile-store";
 import type { BrowserHistoryStore } from "./browser-history-store";
 import type { BrowserDownloadManager } from "./browser-download-manager";
 import type { BrowserDownloadActionInput } from "../shared/browser-downloads";
+import {
+	browserSurfaceRectsEqual,
+	type BrowserSurfaceLayoutInput,
+	type BrowserSurfaceLayoutResult,
+	type BrowserSurfaceRect,
+} from "../shared/browser-surface";
 import { matchInstruction } from "./browser-act-matcher";
 
 function isValidAnnotationContext(value: unknown): value is BrowserAnnotationContext {
@@ -76,7 +81,7 @@ function isValidAnnotationSelection(value: unknown): value is BrowserAnnotationS
 	return false;
 }
 
-export type BrowserRect = Pick<Rectangle, "x" | "y" | "width" | "height">;
+export type BrowserRect = BrowserSurfaceRect;
 
 export type BrowserNavState = {
 	viewId: string;
@@ -381,6 +386,9 @@ type BrowserSessionEntry = {
 	rendererBounds: BrowserRect;
 	zoomFactor: number;
 	visible: boolean;
+	layoutSourceId?: string;
+	layoutRevision: number;
+	surfaceRefreshRevision: number;
 	networkTabId?: string;
 	agentBrowserCommands: number;
 	browserOperations: number;
@@ -813,6 +821,8 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 				rendererBounds: OFFSCREEN_BOUNDS,
 				zoomFactor: 1,
 				visible: false,
+				layoutRevision: 0,
+				surfaceRefreshRevision: 0,
 				agentBrowserCommands: 0,
 				browserOperations: 0,
 				profileSwitching: false,
@@ -1412,26 +1422,37 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		}
 	}
 
-	const setBounds = ({ viewId, rect, visible }: BrowserBoundsInput, zoomFactor = 1): void => {
+	const setBounds = ({ viewId, rect, visible }: BrowserBoundsInput, zoomFactor = 1): BrowserRect | null => {
 		const session = entries.get(viewId);
-		if (!session) return;
+		if (!session) return null;
 		const effectiveZoomFactor = Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
-		session.zoomFactor = effectiveZoomFactor;
 		if (!visible) {
+			forgetIfFocused(viewId);
+			if (!session.visible && session.zoomFactor === effectiveZoomFactor) return session.bounds;
+			session.zoomFactor = effectiveZoomFactor;
 			session.bounds = OFFSCREEN_BOUNDS;
 			session.visible = false;
 			if (!session.profileSwitching && session.tabs.size > 0) applySessionBounds(session, activeEntry(session));
-			forgetIfFocused(viewId);
-			return;
+			return session.bounds;
 		}
 		// The renderer measures the slot in page-zoomed CSS pixels, while
 		// WebContentsView bounds are window coordinates. Convert before clamping so
 		// Cmd+/Cmd- page zoom does not detach the native view from its React slot.
-		session.rendererBounds = { ...rect };
-		session.bounds = clampBoundsToWindow(
+		const nextBounds = clampBoundsToWindow(
 			scaleBoundsForZoom(rect, effectiveZoomFactor),
 			options.mainWindow.getContentBounds(),
 		);
+		if (
+			session.visible &&
+			session.zoomFactor === effectiveZoomFactor &&
+			browserSurfaceRectsEqual(session.rendererBounds, rect) &&
+			browserSurfaceRectsEqual(session.bounds, nextBounds)
+		) {
+			return session.bounds;
+		}
+		session.zoomFactor = effectiveZoomFactor;
+		session.rendererBounds = { ...rect };
+		session.bounds = nextBounds;
 		session.visible = true;
 		// A profile replacement may temporarily have no active tab. Keep accepting
 		// renderer geometry during that interval; rebuilt tabs receive the latest
@@ -1441,6 +1462,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		// becomes visible. Remember that active panel too, so the DevTools shortcut
 		// still targets the browser even when the native page itself is not focused.
 		lastFocusedViewId = viewId;
+		return session.bounds;
 	};
 
 	const navigate = async ({ viewId, url }: BrowserNavigateInput): Promise<BrowserNavState> => {
@@ -1890,14 +1912,72 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		ipcDisposers.push(() => options.ipcMain.off(channel, fn));
 	};
 
-	handle("browser:ensure", async (event, sessionId: string) => {
+	handle("browser:ensure", async (event, sessionId: string, layoutSourceId?: string) => {
 		const session = await ensureSessionReady(sessionId, event.sender.id, () => event.sender.isDestroyed?.() ?? false);
+		if (
+			typeof layoutSourceId === "string" &&
+			layoutSourceId.length > 0 &&
+			layoutSourceId.length <= 128 &&
+			session.layoutSourceId !== layoutSourceId
+		) {
+			// A shell reload keeps the native session alive. Make the new preload
+			// lifetime authoritative before it starts measuring so delayed messages
+			// from the departed renderer cannot move the retained view afterward.
+			session.layoutSourceId = layoutSourceId;
+			session.layoutRevision = 0;
+		}
 		pushDevToolsState(session);
 		pushProfileState(session);
 		return pushNavState(options, activeEntry(session));
 	});
+	handle("browser:applyBounds", (event, input: BrowserSurfaceLayoutInput): BrowserSurfaceLayoutResult => {
+		if (
+			!input ||
+			typeof input.viewId !== "string" ||
+			typeof input.sourceId !== "string" ||
+			input.sourceId.length === 0 ||
+			input.sourceId.length > 128 ||
+			!Number.isSafeInteger(input.revision) ||
+			input.revision <= 0 ||
+			typeof input.visible !== "boolean" ||
+			!input.rect ||
+			![input.rect.x, input.rect.y, input.rect.width, input.rect.height].every(Number.isFinite)
+		) {
+			throw browserError("INVALID_ARGUMENT", "Invalid browser surface layout");
+		}
+		const session = entries.get(input.viewId);
+		if (!session || !isRendererOwned(event, input.viewId)) {
+			return { ...input, applied: false };
+		}
+		if (session.layoutSourceId !== input.sourceId || input.revision <= session.layoutRevision) {
+			return {
+				viewId: session.viewId,
+				sourceId: session.layoutSourceId ?? input.sourceId,
+				revision: session.layoutRevision,
+				rect: session.bounds,
+				visible: session.visible,
+				applied: false,
+			};
+		}
+		session.layoutRevision = input.revision;
+		const rect = setBounds(input, event.sender.getZoomFactor());
+		return {
+			viewId: session.viewId,
+			sourceId: input.sourceId,
+			revision: input.revision,
+			rect: rect ?? session.bounds,
+			visible: session.visible,
+			applied: true,
+		};
+	});
+	// Kept as a narrow compatibility path for an older shell during a desktop
+	// auto-update handoff. Current preloads use the acknowledged, revisioned
+	// browser:applyBounds channel above.
 	on("browser:setBounds", (event, input: BrowserBoundsInput) => {
-		if (isRendererOwned(event, input.viewId)) setBounds(input, event.sender.getZoomFactor());
+		const session = entries.get(input.viewId);
+		if (session && session.layoutSourceId === undefined && isRendererOwned(event, input.viewId)) {
+			setBounds(input, event.sender.getZoomFactor());
+		}
 	});
 	handle("browser:navigate", (event, input: BrowserNavigateInput) =>
 		isRendererOwned(event, input.viewId) ? navigate(input) : emptyNavState(input.viewId),
@@ -2383,16 +2463,18 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		// a 1px bounds change alone, so do both.
 		refreshLastFocusedPanelSurface: () => {
 			if (lastFocusedViewId === null) return;
-			const session = entries.get(lastFocusedViewId);
+			const viewId = lastFocusedViewId;
+			const session = entries.get(viewId);
 			if (!session || !session.visible) return;
 			const entry = activeEntry(session);
 			const bounds = session.bounds;
 			if (bounds.width <= 0 || bounds.height <= 0) return;
+			const refreshRevision = ++session.surfaceRefreshRevision;
 			entry.view.setVisible?.(false);
 			applyBrowserViewBounds(entry.view, { ...bounds, height: Math.max(1, bounds.height - 1) });
 			setTimeout(() => {
-				const current = lastFocusedViewId !== null ? entries.get(lastFocusedViewId) : undefined;
-				if (!current || !current.visible) return;
+				const current = entries.get(viewId);
+				if (!current || !current.visible || current.surfaceRefreshRevision !== refreshRevision) return;
 				applyBrowserViewBounds(activeEntry(current).view, current.bounds, true);
 			}, 0);
 		},

--- a/frontend/src/main/window-composition.test.ts
+++ b/frontend/src/main/window-composition.test.ts
@@ -90,6 +90,23 @@ describe("createWindowComposition", () => {
 		}
 	});
 
+	it("does not let a stale macOS refresh timer override a newer overlay transition", () => {
+		vi.useFakeTimers();
+		try {
+			const { composition, view } = setup("darwin");
+			(view.setBounds as ReturnType<typeof vi.fn>).mockClear();
+
+			composition.setOverlayOpen(true);
+			composition.setOverlayOpen(false);
+			composition.setOverlayOpen(true);
+			vi.runAllTimers();
+
+			expect(view.setBounds).toHaveBeenLastCalledWith({ x: 0, y: 0, width: 900, height: 640 });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("resizes and disposes the explicit shell without recreating it", () => {
 		const { bounds, close, composition, emitBoundsChanged, removeChildView, removeListener, setBounds, view } = setup();
 

--- a/frontend/src/main/window-composition.ts
+++ b/frontend/src/main/window-composition.ts
@@ -41,6 +41,7 @@ export function createWindowComposition(options: {
 	options.mainWindow.contentView.addChildView(shellView, 0);
 
 	let overlayOpen = false;
+	let surfaceRefreshRevision = 0;
 	const resize = (): void => {
 		if (options.mainWindow.isDestroyed?.()) return;
 		const bounds = options.mainWindow.contentView.getBounds();
@@ -56,9 +57,10 @@ export function createWindowComposition(options: {
 		if (options.mainWindow.isDestroyed?.()) return;
 		const bounds = options.mainWindow.contentView.getBounds();
 		if (bounds.width <= 0 || bounds.height <= 0) return;
+		const refreshRevision = ++surfaceRefreshRevision;
 		shellView.setBounds({ x: 0, y: 0, width: bounds.width, height: Math.max(1, bounds.height - 1) });
 		setTimeout(() => {
-			if (options.mainWindow.isDestroyed?.()) return;
+			if (options.mainWindow.isDestroyed?.() || surfaceRefreshRevision !== refreshRevision) return;
 			const current = options.mainWindow.contentView.getBounds();
 			shellView.setBounds({ x: 0, y: 0, width: current.width, height: current.height });
 		}, 0);
@@ -73,6 +75,11 @@ export function createWindowComposition(options: {
 		} else {
 			// Index zero leaves every live native surface above the transparent shell.
 			options.mainWindow.contentView.addChildView(shellView, 0);
+			// Invalidate any pending macOS nudge restore and synchronously return the
+			// shell to current window bounds. A rapid open-close-open sequence must
+			// never let an earlier timer mutate the newer compositor transaction.
+			surfaceRefreshRevision += 1;
+			resize();
 		}
 		// Restacking alone does not re-establish the shell's compositing surface:
 		// on macOS the freshly-raised shell can present a stale surface that hides

--- a/frontend/src/preload.test.ts
+++ b/frontend/src/preload.test.ts
@@ -75,6 +75,44 @@ describe("preload repository branch bridge", () => {
 	});
 });
 
+describe("preload browser surface bridge", () => {
+	it("tags acknowledged bounds with one preload lifetime and increasing revisions", async () => {
+		const bridge = exposedBridge();
+		await bridge.browser.ensure("worker-1");
+		bridge.browser.setBounds({
+			viewId: "1:worker-1",
+			rect: { x: 10, y: 20, width: 300, height: 200 },
+			visible: true,
+		});
+		bridge.browser.setBounds({
+			viewId: "1:worker-1",
+			rect: { x: 11, y: 20, width: 300, height: 200 },
+			visible: true,
+		});
+
+		const ensureCall = electronMocks.invoke.mock.calls[0]!;
+		const firstLayout = electronMocks.invoke.mock.calls[1]![1] as { sourceId: string; revision: number };
+		const secondLayout = electronMocks.invoke.mock.calls[2]![1] as { sourceId: string; revision: number };
+		expect(ensureCall).toEqual(["browser:ensure", "worker-1", firstLayout.sourceId]);
+		expect(firstLayout.sourceId).toBeTruthy();
+		expect(secondLayout.sourceId).toBe(firstLayout.sourceId);
+		expect(secondLayout.revision).toBe(firstLayout.revision + 1);
+		expect(electronMocks.invoke.mock.calls[1]![0]).toBe("browser:applyBounds");
+		expect(electronMocks.send).not.toHaveBeenCalledWith("browser:setBounds", expect.anything());
+	});
+
+	it("subscribes to native window layout signals and disposes the wrapped listener", () => {
+		const listener = vi.fn();
+		const dispose = exposedBridge().window.onBrowserLayoutChanged(listener);
+		const wrapped = electronMocks.listeners.get("window:browserLayoutChanged");
+
+		wrapped?.({}, { sequence: 7, reason: "maximize" });
+		expect(listener).toHaveBeenCalledWith({ sequence: 7, reason: "maximize" });
+		dispose();
+		expect(electronMocks.off).toHaveBeenCalledWith("window:browserLayoutChanged", wrapped);
+	});
+});
+
 describe("preload telemetry generation bridge", () => {
 	it("tags captures with the latest broadcast generation without a renderer reload", async () => {
 		telemetryPolicyBroadcastListener?.({}, { eventsEnabled: false, consentGeneration: "generation-off", updatedAt: "2026-08-28T10:15:30.000Z", acknowledged: true, state: "applied", environmentVeto: false, durabilitySupported: true });

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -70,6 +70,11 @@ import type {
 	BrowserDownloadActionInput,
 	BrowserDownloadsState,
 } from "./shared/browser-downloads";
+import type {
+	BrowserSurfaceLayoutInput,
+	BrowserSurfaceLayoutResult,
+	BrowserSurfaceLayoutSignal,
+} from "./shared/browser-surface";
 
 if (typeof document !== "undefined") {
 	const markNativeBrowserComposition = () => {
@@ -91,6 +96,25 @@ export type BrowserBoundsInput = {
 	rect: BrowserRect;
 	visible: boolean;
 };
+
+const browserLayoutSourceId = globalThis.crypto.randomUUID();
+const browserLayoutRevisions = new Map<string, number>();
+
+function applyBrowserBounds(input: BrowserBoundsInput): void {
+	const revision = (browserLayoutRevisions.get(input.viewId) ?? 0) + 1;
+	browserLayoutRevisions.set(input.viewId, revision);
+	const layout: BrowserSurfaceLayoutInput = {
+		...input,
+		sourceId: browserLayoutSourceId,
+		revision,
+	};
+	// The invocation is intentionally fire-and-forget to keep React layout work
+	// off the IPC round trip, but unlike send() it is acknowledged by main. Main
+	// rejects an older revision even if Electron delivers or finishes it late.
+	void Promise.resolve(ipcRenderer.invoke("browser:applyBounds", layout) as Promise<BrowserSurfaceLayoutResult>).catch(
+		() => undefined,
+	);
+}
 
 export type BrowserNavigateInput = {
 	viewId: string;
@@ -304,6 +328,13 @@ const api = {
 				ipcRenderer.off("window:fullscreen", wrapped);
 			};
 		},
+		onBrowserLayoutChanged: (listener: (signal: BrowserSurfaceLayoutSignal) => void) => {
+			const wrapped = (_event: Electron.IpcRendererEvent, signal: BrowserSurfaceLayoutSignal) => listener(signal);
+			ipcRenderer.on("window:browserLayoutChanged", wrapped);
+			return () => {
+				ipcRenderer.off("window:browserLayoutChanged", wrapped);
+			};
+		},
 	},
 	theme: {
 		// Propagate the app's theme preference to Electron's nativeTheme so embedded
@@ -367,8 +398,9 @@ const api = {
 	},
 	browser: {
 		nativeCompositionEnabled: true,
-		ensure: (sessionId: string) => ipcRenderer.invoke("browser:ensure", sessionId) as Promise<BrowserNavState>,
-		setBounds: (input: BrowserBoundsInput) => ipcRenderer.send("browser:setBounds", input),
+		ensure: (sessionId: string) =>
+			ipcRenderer.invoke("browser:ensure", sessionId, browserLayoutSourceId) as Promise<BrowserNavState>,
+		setBounds: applyBrowserBounds,
 		setOverlayOpen: (open: boolean) => ipcRenderer.send("browser:overlay", open),
 		navigate: (input: BrowserNavigateInput) =>
 			ipcRenderer.invoke("browser:navigate", input) as Promise<BrowserNavState>,

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -720,10 +720,7 @@ describe("BrowserPanel", () => {
 		expect(hookState.stop).toHaveBeenCalled();
 	});
 
-	it("marks toolbar tooltips as browser overlays so they paint above the live page", async () => {
-		// Same reasoning as the pinned-favicon overlay test: the toolbar sits
-		// directly above the native browser view, so an unmarked tooltip here
-		// would render behind the live page.
+	it("keeps toolbar tooltips in shell-owned chrome without restacking the native page", async () => {
 		hookState.navState = {
 			viewId: "42:sess-1",
 			url: "http://localhost:5173/",
@@ -737,10 +734,11 @@ describe("BrowserPanel", () => {
 		fireEvent.focus(screen.getByRole("button", { name: /back/i }));
 
 		const tooltip = await screen.findByRole("tooltip");
-		expect(tooltip.closest('[data-browser-native-overlay="true"]')).not.toBeNull();
+		expect(tooltip.closest('[data-browser-native-overlay="true"]')).toBeNull();
+		expect(tooltip.closest('[data-side="top"]')).not.toBeNull();
 	});
 
-	it("uses the same styled browser overlay tooltip while maximized", async () => {
+	it("keeps the same non-restacking tooltip behavior while maximized", async () => {
 		hookState.navState = {
 			viewId: "42:sess-1",
 			url: "http://localhost:5173/",
@@ -757,7 +755,8 @@ describe("BrowserPanel", () => {
 
 		const tooltip = await screen.findByRole("tooltip");
 		expect(tooltip).toHaveTextContent("Annotate page");
-		expect(tooltip.closest('[data-browser-native-overlay="true"]')).not.toBeNull();
+		expect(tooltip.closest('[data-browser-native-overlay="true"]')).toBeNull();
+		expect(tooltip.closest('[data-side="top"]')).not.toBeNull();
 	});
 
 	it("still opens a tooltip for a disabled toolbar button", async () => {

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -8,6 +8,7 @@ import {
 	useState,
 	type FocusEvent,
 	type FormEvent,
+	type ComponentProps,
 } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -76,6 +77,16 @@ import { handleTabListKeyDown } from "../lib/terminal-tabs";
 import { useBrowserDownloads } from "../hooks/useBrowserDownloads";
 import { BrowserDownloadsList } from "./BrowserDownloadsList";
 import { isWebLink, openLinkInSystemBrowser } from "../lib/external-link-policy";
+
+/**
+ * Browser toolbar tooltips must stay entirely in the shell-owned chrome above
+ * the native page. Marking them as native overlays restacks WebContentsViews
+ * for every hover and produces a visible compositor flash. Collision handling
+ * is deliberately disabled so Radix cannot flip one back over the page.
+ */
+function BrowserToolbarTooltipContent(props: ComponentProps<typeof TooltipContent>) {
+	return <TooltipContent avoidCollisions={false} side="top" sideOffset={2} {...props} />;
+}
 
 // One-click viewport width presets for responsive testing — height is shown
 // for reference but not enforced (only width drives CSS breakpoints, and
@@ -807,7 +818,7 @@ export function BrowserPanelView({
 							</Button>
 						</span>
 					</TooltipTrigger>
-					<TooltipContent data-browser-native-overlay="true" side="bottom">{t("browser.back")}</TooltipContent>
+					<BrowserToolbarTooltipContent>{t("browser.back")}</BrowserToolbarTooltipContent>
 				</Tooltip>
 				<Tooltip>
 					<TooltipTrigger asChild>
@@ -825,7 +836,7 @@ export function BrowserPanelView({
 							</Button>
 						</span>
 					</TooltipTrigger>
-					<TooltipContent data-browser-native-overlay="true" side="bottom">{t("browser.forward")}</TooltipContent>
+					<BrowserToolbarTooltipContent>{t("browser.forward")}</BrowserToolbarTooltipContent>
 				</Tooltip>
 				<Tooltip>
 					<TooltipTrigger asChild>
@@ -844,7 +855,7 @@ export function BrowserPanelView({
 							)}
 						</Button>
 					</TooltipTrigger>
-					<TooltipContent data-browser-native-overlay="true" side="bottom">{navState.isLoading ? t("browser.stop") : t("browser.reload")}</TooltipContent>
+					<BrowserToolbarTooltipContent>{navState.isLoading ? t("browser.stop") : t("browser.reload")}</BrowserToolbarTooltipContent>
 				</Tooltip>
 				{annotationStatusLabel ? (
 					<span className="sr-only" role="status">
@@ -884,9 +895,9 @@ export function BrowserPanelView({
 									<ExternalLink aria-hidden="true" className="size-icon-sm" />
 								</Button>
 							</TooltipTrigger>
-							<TooltipContent data-browser-native-overlay="true" side="bottom">
+							<BrowserToolbarTooltipContent>
 								{t("inspector.openInSystemBrowser")}
-							</TooltipContent>
+							</BrowserToolbarTooltipContent>
 						</Tooltip>
 					) : null}
 					<datalist id={historyListId}>
@@ -936,9 +947,9 @@ export function BrowserPanelView({
 							</Button>
 						</span>
 					</TooltipTrigger>
-					<TooltipContent data-browser-native-overlay="true" side="bottom">
+					<BrowserToolbarTooltipContent>
 						{annotationStatusLabel || agentStatusLabel || (canRetryAnnotation ? t("browser.retryAnnotation") : t("browser.annotate"))}
-					</TooltipContent>
+					</BrowserToolbarTooltipContent>
 				</Tooltip>
 				{browserDownloads.downloads.length > 0 ? (
 					<DropdownMenu
@@ -965,7 +976,7 @@ export function BrowserPanelView({
 									</Button>
 								</DropdownMenuTrigger>
 							</TooltipTrigger>
-							<TooltipContent data-browser-native-overlay="true" side="bottom">{t("browser.downloads.title")}</TooltipContent>
+							<BrowserToolbarTooltipContent>{t("browser.downloads.title")}</BrowserToolbarTooltipContent>
 						</Tooltip>
 						<DropdownMenuContent
 							align="end"
@@ -1017,7 +1028,7 @@ export function BrowserPanelView({
 								</Button>
 							</DropdownMenuTrigger>
 						</TooltipTrigger>
-						<TooltipContent data-browser-native-overlay="true" side="bottom">{t("browser.controls")}</TooltipContent>
+						<BrowserToolbarTooltipContent>{t("browser.controls")}</BrowserToolbarTooltipContent>
 					</Tooltip>
 					{/* Opens directly over the live page (the toolbar sits right above the
 					    native browser view), so without this it renders behind the native
@@ -1200,7 +1211,7 @@ export function BrowserPanelView({
 							)}
 						</Button>
 					</TooltipTrigger>
-					<TooltipContent data-browser-native-overlay="true" side="bottom">{poppedOut ? t("browser.returnToPanel") : t("browser.popOut")}</TooltipContent>
+					<BrowserToolbarTooltipContent>{poppedOut ? t("browser.returnToPanel") : t("browser.popOut")}</BrowserToolbarTooltipContent>
 				</Tooltip>
 				{/* Docked mode has no reserved rail column by default (see
 				    BrowserTabsRail.tsx) — this trigger is the only way to reach the tab
@@ -1252,7 +1263,7 @@ export function BrowserPanelView({
 									<Plus aria-hidden="true" className="size-icon-base" />
 								</Button>
 							</TooltipTrigger>
-							<TooltipContent data-browser-native-overlay="true" side="bottom">{t("browser.openNewTab")}</TooltipContent>
+							<BrowserToolbarTooltipContent>{t("browser.openNewTab")}</BrowserToolbarTooltipContent>
 						</Tooltip>
 					</div>
 				) : null}

--- a/frontend/src/renderer/components/BrowserTabsRail.tsx
+++ b/frontend/src/renderer/components/BrowserTabsRail.tsx
@@ -287,7 +287,9 @@ export const BrowserTabsRail = forwardRef<BrowserTabsRailHandle, BrowserTabsRail
 							<PinOff aria-hidden="true" className="size-icon-base" />
 						</button>
 					</TooltipTrigger>
-					<TooltipContent data-browser-native-overlay="true" side="bottom">{t("browser.unpinTabs")}</TooltipContent>
+					{/* Keep passive hover UI inside the shell-owned toolbar band. A tooltip
+					    must not restack the native page just to become visible. */}
+					<TooltipContent avoidCollisions={false} side="top" sideOffset={2}>{t("browser.unpinTabs")}</TooltipContent>
 				</Tooltip>
 			) : null}
 			<nav

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -7,6 +7,7 @@ import {
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrowserSurfaceLayoutSignal } from "../../shared/browser-surface";
 
 type Listener = (state: BrowserNavState) => void;
 type TabsListener = (state: import("../../main/browser-view-host").BrowserTabsState) => void;
@@ -38,6 +39,7 @@ function setupBridge() {
 	const devtoolsListeners = new Set<DevToolsListener>();
 	const activityListeners = new Set<ActivityListener>();
 	const profileListeners = new Set<ProfileListener>();
+	const layoutListeners = new Set<(signal: BrowserSurfaceLayoutSignal) => void>();
 	const bridge = {
 		nativeCompositionEnabled: false,
 		stateFor(viewId: string): BrowserNavState {
@@ -157,8 +159,21 @@ function setupBridge() {
 		emitProfile(state: Parameters<ProfileListener>[0]) {
 			profileListeners.forEach((listener) => listener(state));
 		},
+		emitLayout(reason: BrowserSurfaceLayoutSignal["reason"] = "resize") {
+			layoutListeners.forEach((listener) => listener({ sequence: 1, reason }));
+		},
 	};
-	window.ao = { ...window.ao!, browser: bridge };
+	window.ao = {
+		...window.ao!,
+		window: {
+			...window.ao!.window,
+			onBrowserLayoutChanged: (listener) => {
+				layoutListeners.add(listener);
+				return () => layoutListeners.delete(listener);
+			},
+		},
+		browser: bridge,
+	};
 	return bridge;
 }
 
@@ -628,6 +643,17 @@ describe("useBrowserView", () => {
 			}),
 		);
 		bridge.setBounds.mockClear();
+		slot.getBoundingClientRect = vi.fn(() => ({
+			x: 240,
+			y: 34,
+			width: 320,
+			height: 240,
+			top: 34,
+			right: 560,
+			bottom: 274,
+			left: 240,
+			toJSON: () => ({}),
+		}));
 
 		act(() => {
 			rerender({ poppedOut: true });
@@ -636,10 +662,62 @@ describe("useBrowserView", () => {
 		await waitFor(() =>
 			expect(bridge.setBounds).toHaveBeenCalledWith({
 				viewId: "42:sess-1",
-				rect: { x: 12, y: 34, width: 320, height: 240 },
+				rect: { x: 240, y: 34, width: 320, height: 240 },
 				visible: true,
 			}),
 		);
+	});
+
+	it("converges again when Electron reports a native window layout transition", async () => {
+		const bridge = setupBridge();
+		const slot = createSlot();
+		const { result } = renderHook(() =>
+			useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }),
+		);
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-1"));
+		act(() => result.current.slotRef(slot));
+		await waitFor(() => expect(bridge.setBounds).toHaveBeenCalled());
+		await new Promise((resolve) => setTimeout(resolve, 140));
+		bridge.setBounds.mockClear();
+		slot.getBoundingClientRect = vi.fn(() => ({
+			x: 180,
+			y: 40,
+			width: 500,
+			height: 360,
+			top: 40,
+			right: 680,
+			bottom: 400,
+			left: 180,
+			toJSON: () => ({}),
+		}));
+
+		act(() => bridge.emitLayout("maximize"));
+
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 180, y: 40, width: 500, height: 360 },
+				visible: true,
+			}),
+		);
+	});
+
+	it("does not resend unchanged geometry throughout a settling window", async () => {
+		const bridge = setupBridge();
+		const slot = createSlot();
+		const { result } = renderHook(() =>
+			useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }),
+		);
+		await waitFor(() => expect(result.current.viewId).toBe("42:sess-1"));
+		act(() => result.current.slotRef(slot));
+		await waitFor(() => expect(bridge.setBounds).toHaveBeenCalled());
+		await new Promise((resolve) => setTimeout(resolve, 140));
+		bridge.setBounds.mockClear();
+
+		act(() => bridge.emitLayout("resize"));
+		await new Promise((resolve) => setTimeout(resolve, 140));
+
+		expect(bridge.setBounds).not.toHaveBeenCalled();
 	});
 
 	it("clamps the native view to its resizable-panel column when the slot overspills", async () => {

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -10,7 +10,11 @@ import type {
 } from "../../main/browser-view-host";
 import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 import type { BrowserProfileViewState } from "../../shared/browser-profiles";
-import { OPEN_BROWSER_OVERLAY_SELECTOR } from "../lib/dom-selectors";
+import {
+	hasRelevantBrowserOverlayMutation,
+	OPEN_BROWSER_OVERLAY_SELECTOR,
+} from "../lib/dom-selectors";
+import { browserSurfaceRectsEqual } from "../../shared/browser-surface";
 
 export type { BrowserNavState };
 
@@ -114,6 +118,11 @@ const EMPTY_PROFILE_STATE: BrowserProfileViewState = {
 };
 
 type PreviewTrigger = { revision: number | null; target: string };
+type BrowserBoundsInput = {
+	viewId: string;
+	rect: BrowserRect;
+	visible: boolean;
+};
 
 // The native view survives React session switches, so remember which preview
 // trigger was already consumed for each session. This prevents switching back
@@ -146,6 +155,9 @@ const HIDDEN_RECT: BrowserRect = { x: 0, y: 0, width: 0, height: 0 };
 // loaded (only continuing an already-started drag is handled elsewhere, via
 // the `is-resizing-x` watcher below). Keep in sync with tokens.css.
 const RESIZE_HANDLE_RESERVE_PX = 6;
+const LAYOUT_SETTLE_MIN_MS = 80;
+const LAYOUT_SETTLE_MAX_MS = 1_000;
+const LAYOUT_SETTLE_STABLE_FRAMES = 3;
 
 // The native WebContentsView is a window-level overlay, so DOM `overflow:
 // hidden` never clips it — it paints wherever the slot's bounding box lands.
@@ -215,14 +227,15 @@ export function useBrowserView({
 	const viewIdRef = useRef("");
 	const annotationModeRef = useRef(false);
 	const activeRef = useRef(active);
-	const poppedOutRef = useRef(poppedOut);
 	const frameRef = useRef<number | null>(null);
-	const settleTimerRef = useRef<number | null>(null);
+	const settleFrameRef = useRef<number | null>(null);
+	const settleGenerationRef = useRef(0);
 	const observerRef = useRef<ResizeObserver | null>(null);
 	const previewTriggerRef = useRef<{ revision: number | null; target: string } | null>(null);
 	const overlayOpenRef = useRef(false);
 	const tabNoticeTimerRef = useRef<number | null>(null);
 	const tabsStateRef = useRef(tabsState);
+	const lastSentBoundsRef = useRef<BrowserBoundsInput | null>(null);
 	const hasNativeBrowser = Boolean(window.ao?.browser);
 
 	useEffect(() => {
@@ -259,38 +272,41 @@ export function useBrowserView({
 		[sessionId],
 	);
 
-	const sendHiddenBounds = useCallback((id = viewIdRef.current) => {
-		if (!id) return;
-		window.ao?.browser.setBounds({ viewId: id, rect: HIDDEN_RECT, visible: false });
-	}, []);
-
-	const measureAndSend = useCallback(() => {
-		// measureAndSend runs both from the scheduleMeasure() rAF callback and as a
-		// direct synchronous call (parking on overlay open, the settle timer). A
-		// direct call may land while a scheduled frame is still queued, so cancel
-		// that live handle rather than blindly nulling it — otherwise the
-		// scheduleMeasure() dedupe guard and cancelScheduledMeasure() cleanup would
-		// both trust a frameRef that no longer reflects the pending frame.
-		if (frameRef.current !== null) {
-			if (window.cancelAnimationFrame) window.cancelAnimationFrame(frameRef.current);
-			window.clearTimeout(frameRef.current);
-		}
-		frameRef.current = null;
-		const id = viewIdRef.current;
-		const node = slotNodeRef.current;
-		if (!id) return;
-		if (!activeRef.current || !node || !node.isConnected || hiddenByFullscreen(node)) {
-			sendHiddenBounds(id);
+	const sendBounds = useCallback((input: BrowserBoundsInput) => {
+		const previous = lastSentBoundsRef.current;
+		if (
+			previous?.viewId === input.viewId &&
+			previous.visible === input.visible &&
+			browserSurfaceRectsEqual(previous.rect, input.rect)
+		) {
 			return;
 		}
+		lastSentBoundsRef.current = { ...input, rect: { ...input.rect } };
+		window.ao?.browser.setBounds(input);
+	}, []);
+
+	const sendHiddenBounds = useCallback((id = viewIdRef.current) => {
+		if (!id) return;
+		sendBounds({ viewId: id, rect: HIDDEN_RECT, visible: false });
+	}, [sendBounds]);
+
+	const measureAndSend = useCallback((): BrowserBoundsInput | null => {
+		const id = viewIdRef.current;
+		const node = slotNodeRef.current;
+		if (!id) return null;
+		if (!activeRef.current || !node || !node.isConnected || hiddenByFullscreen(node)) {
+			sendHiddenBounds(id);
+			return { viewId: id, rect: HIDDEN_RECT, visible: false };
+		}
 		const rect = visibleSlotRect(node);
-		const payload = {
+		const payload: BrowserBoundsInput = {
 			viewId: id,
 			rect,
 			visible: rect.width > 0 && rect.height > 0,
 		};
-		window.ao?.browser.setBounds(payload);
-	}, [sendHiddenBounds]);
+		sendBounds(payload);
+		return payload;
+	}, [sendBounds, sendHiddenBounds]);
 
 	const cancelScheduledMeasure = useCallback(() => {
 		if (frameRef.current === null) return;
@@ -304,26 +320,62 @@ export function useBrowserView({
 	const scheduleMeasure = useCallback(() => {
 		if (frameRef.current !== null) return;
 		frameRef.current = window.requestAnimationFrame
-			? window.requestAnimationFrame(() => measureAndSend())
-			: window.setTimeout(() => measureAndSend(), 16);
+			? window.requestAnimationFrame(() => {
+					frameRef.current = null;
+					measureAndSend();
+				})
+			: window.setTimeout(() => {
+					frameRef.current = null;
+					measureAndSend();
+				}, 16);
 	}, [measureAndSend]);
 
-	// A ResizeObserver only fires on size changes, so a position-only layout shift
-	// leaves the native overlay at stale bounds: entering/leaving pop-out moves the
-	// slot into a different panel, and opening the inspector (what `ao preview`
-	// does) reflows the slot's x without changing the observed node's box size.
-	// Neither fires the observer, so the view visibly spills over the sidebar/
-	// terminal until an unrelated window resize re-measures it. Re-measure now and
-	// again once the panel transition has settled (~240ms) so the final geometry
-	// always wins.
+	const cancelSettleMeasure = useCallback(() => {
+		settleGenerationRef.current += 1;
+		if (settleFrameRef.current === null) return;
+		if (window.cancelAnimationFrame) window.cancelAnimationFrame(settleFrameRef.current);
+		window.clearTimeout(settleFrameRef.current);
+		settleFrameRef.current = null;
+	}, []);
+
+	// ResizeObserver misses position-only transforms, and a fixed timeout can fire
+	// too early or restore obsolete geometry when transitions overlap. Sample at
+	// most once per frame until the rectangle has converged, with a hard ceiling so
+	// a perpetually animating page can never keep this loop alive indefinitely.
 	const scheduleSettleMeasure = useCallback(() => {
-		scheduleMeasure();
-		if (settleTimerRef.current !== null) window.clearTimeout(settleTimerRef.current);
-		settleTimerRef.current = window.setTimeout(() => {
-			settleTimerRef.current = null;
-			measureAndSend();
-		}, 280);
-	}, [measureAndSend, scheduleMeasure]);
+		cancelSettleMeasure();
+		const generation = settleGenerationRef.current;
+		const startedAt = performance.now();
+		let stableFrames = 0;
+		let previous: BrowserBoundsInput | null = null;
+		const tick = () => {
+			if (settleGenerationRef.current !== generation) return;
+			settleFrameRef.current = null;
+			const current = measureAndSend();
+			const unchanged =
+				current !== null &&
+				previous !== null &&
+				current.viewId === previous.viewId &&
+				current.visible === previous.visible &&
+				browserSurfaceRectsEqual(current.rect, previous.rect);
+			stableFrames = unchanged ? stableFrames + 1 : 0;
+			previous = current;
+			const elapsed = performance.now() - startedAt;
+			if (
+				current === null ||
+				elapsed >= LAYOUT_SETTLE_MAX_MS ||
+				(elapsed >= LAYOUT_SETTLE_MIN_MS && stableFrames >= LAYOUT_SETTLE_STABLE_FRAMES)
+			) {
+				return;
+			}
+			settleFrameRef.current = window.requestAnimationFrame
+				? window.requestAnimationFrame(tick)
+				: window.setTimeout(tick, 16);
+		};
+		settleFrameRef.current = window.requestAnimationFrame
+			? window.requestAnimationFrame(tick)
+			: window.setTimeout(tick, 16);
+	}, [cancelSettleMeasure, measureAndSend]);
 
 	const slotRef = useCallback(
 		(node: HTMLDivElement | null) => {
@@ -513,20 +565,6 @@ export function useBrowserView({
 	}, [active, navState.url, poppedOut, scheduleSettleMeasure, sendHiddenBounds]);
 
 	useEffect(() => {
-		if (poppedOutRef.current === poppedOut) return;
-		poppedOutRef.current = poppedOut;
-		if (!hasNativeBrowser || !activeRef.current) {
-			scheduleSettleMeasure();
-			return;
-		}
-		measureAndSend();
-		window.setTimeout(() => {
-			measureAndSend();
-		}, 0);
-		scheduleSettleMeasure();
-	}, [hasNativeBrowser, measureAndSend, poppedOut, scheduleSettleMeasure]);
-
-	useEffect(() => {
 		if (!hasNativeBrowser) return;
 		const update = () => {
 			const open =
@@ -540,15 +578,15 @@ export function useBrowserView({
 			if (!open) scheduleSettleMeasure();
 		};
 		update();
-		const observer = new MutationObserver(update);
+		const observer = new MutationObserver((records) => {
+			if (hasRelevantBrowserOverlayMutation(records)) update();
+		});
 		// Radix reuses its portal node and flips `data-state` in place rather than
 		// adding/removing a body child, so a `childList`-only observer misses the
 		// open/close transition under rapid toggling and the overlay state desyncs.
 		// Watch subtree attribute flips on `data-state` too so the transition is
-		// always observed. This widens the firing rate a lot — `data-state` is used
-		// across Radix (tooltips, accordions, selects, switches, …), so `update()`
-		// now runs a document-wide querySelector on activity anywhere in the app
-		// before it can bail. Cheap enough in practice, but not free.
+		// always observed. The callback filters records before querying the document,
+		// so unrelated Radix data-state activity never touches browser composition.
 		observer.observe(document.body, {
 			childList: true,
 			subtree: true,
@@ -581,15 +619,17 @@ export function useBrowserView({
 		window.addEventListener("resize", handle);
 		window.addEventListener("scroll", handle, true);
 		document.addEventListener("fullscreenchange", handleFullscreenChange);
+		const offNativeLayout = window.ao?.window.onBrowserLayoutChanged?.(() => scheduleSettleMeasure());
 		return () => {
 			window.removeEventListener("resize", handle);
 			window.removeEventListener("scroll", handle, true);
 			document.removeEventListener("fullscreenchange", handleFullscreenChange);
+			offNativeLayout?.();
 			observerRef.current?.disconnect();
 			cancelScheduledMeasure();
-			if (settleTimerRef.current !== null) window.clearTimeout(settleTimerRef.current);
+			cancelSettleMeasure();
 		};
-	}, [cancelScheduledMeasure, scheduleMeasure, scheduleSettleMeasure]);
+	}, [cancelScheduledMeasure, cancelSettleMeasure, scheduleMeasure, scheduleSettleMeasure]);
 
 	const withView = useCallback(async (fn: (id: string) => Promise<BrowserNavState | void>) => {
 		const id = viewIdRef.current;

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -44,6 +44,7 @@ export const aoBridge: AoBridge =
 			onMaximized: () => () => undefined,
 			isFullScreen: async () => false,
 			onFullScreen: () => () => undefined,
+			onBrowserLayoutChanged: () => () => undefined,
 		},
 		theme: {
 			set: async () => undefined,

--- a/frontend/src/renderer/lib/dom-selectors.test.ts
+++ b/frontend/src/renderer/lib/dom-selectors.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { hasRelevantBrowserOverlayMutation } from "./dom-selectors";
+
+afterEach(() => document.body.replaceChildren());
+
+function observeOneMutation(mutate: () => void): Promise<boolean> {
+	return new Promise((resolve) => {
+		const observer = new MutationObserver((records) => {
+			observer.disconnect();
+			resolve(hasRelevantBrowserOverlayMutation(records));
+		});
+		observer.observe(document.body, {
+			attributes: true,
+			attributeFilter: ["data-state"],
+			childList: true,
+			subtree: true,
+		});
+		mutate();
+	});
+}
+
+describe("hasRelevantBrowserOverlayMutation", () => {
+	it("ignores unrelated Radix data-state churn", async () => {
+		const accordion = document.createElement("div");
+		document.body.appendChild(accordion);
+
+		expect(await observeOneMutation(() => accordion.setAttribute("data-state", "open"))).toBe(false);
+	});
+
+	it("does not restack the native page for passive tooltips", async () => {
+		const tooltip = document.createElement("div");
+		tooltip.setAttribute("role", "tooltip");
+		tooltip.dataset.state = "delayed-open";
+
+		expect(await observeOneMutation(() => document.body.appendChild(tooltip))).toBe(false);
+	});
+
+	it("tracks browser overlays added, removed, or flipped in place", async () => {
+		const overlay = document.createElement("div");
+		overlay.dataset.browserNativeOverlay = "true";
+		overlay.dataset.state = "closed";
+
+		expect(await observeOneMutation(() => document.body.appendChild(overlay))).toBe(true);
+		expect(await observeOneMutation(() => overlay.setAttribute("data-state", "open"))).toBe(true);
+		expect(await observeOneMutation(() => overlay.remove())).toBe(true);
+	});
+});

--- a/frontend/src/renderer/lib/dom-selectors.ts
+++ b/frontend/src/renderer/lib/dom-selectors.ts
@@ -13,6 +13,27 @@ export const OPEN_DIALOG_OR_MENU_SELECTOR =
 export const OPEN_BROWSER_OVERLAY_SELECTOR =
 	'[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [data-browser-native-overlay="true"][data-state="open"], [data-browser-native-overlay="true"][data-state="delayed-open"], [data-browser-native-overlay="true"][data-state="instant-open"]';
 
+const BROWSER_OVERLAY_CANDIDATE_SELECTOR =
+	'[role="dialog"], [role="alertdialog"], [data-browser-native-overlay="true"]';
+
+function containsBrowserOverlayCandidate(node: Node): boolean {
+	if (!(node instanceof Element)) return false;
+	return node.matches(BROWSER_OVERLAY_CANDIDATE_SELECTOR) || node.querySelector(BROWSER_OVERLAY_CANDIDATE_SELECTOR) !== null;
+}
+
+/**
+ * MutationObserver is still needed for portaled Radix content whose open state
+ * is owned inside the primitive. Filter its records before doing the one global
+ * open-overlay lookup: unrelated accordions, switches, menus, and other
+ * data-state churn must not make the browser compositor do work.
+ */
+export function hasRelevantBrowserOverlayMutation(records: MutationRecord[]): boolean {
+	return records.some((record) => {
+		if (record.type === "attributes") return containsBrowserOverlayCandidate(record.target);
+		return [...record.addedNodes, ...record.removedNodes].some(containsBrowserOverlayCandidate);
+	});
+}
+
 export function isDialogOrMenuOpen(): boolean {
 	if (typeof document === "undefined") return false;
 	return document.querySelector(OPEN_DIALOG_OR_MENU_SELECTOR) !== null;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -4824,8 +4824,8 @@ html[data-native-browser-composition="true"] .browser-popout-backdrop {
  * (SessionView.tsx's portal) and paints its own opaque `background: var(--bg)`
  * plate. It is NOT covered by the `:has(.browser-popout-overlay)` shell clears
  * above — those target ancestors under #root — and leaving it opaque blanked
- * the live page to black on Windows whenever an overlay (tooltip, menu) raised
- * the transparent shell over the native view in a maximized window. */
+ * the live page to black on Windows whenever an interactive overlay such as a
+ * menu raised the transparent shell over the native view in a maximized window. */
 html[data-native-browser-composition="true"] .browser-popout-frame {
 	background: transparent;
 }

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -133,6 +133,7 @@ if (typeof window !== "undefined") {
 			onMaximized: () => () => undefined,
 			isFullScreen: async () => false,
 			onFullScreen: () => () => undefined,
+			onBrowserLayoutChanged: () => () => undefined,
 		},
 		theme: {
 			set: async () => undefined,

--- a/frontend/src/shared/browser-surface.ts
+++ b/frontend/src/shared/browser-surface.ts
@@ -1,0 +1,48 @@
+export type BrowserSurfaceRect = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
+/**
+ * A renderer measurement applied to the native browser surface.
+ *
+ * `sourceId` changes with each shell preload lifetime and `revision` is
+ * monotonic within that lifetime. Together they prevent a delayed IPC message
+ * from an older layout (or an older renderer after reload) from moving the
+ * native WebContentsView after a newer layout has already won.
+ */
+export type BrowserSurfaceLayoutInput = {
+	viewId: string;
+	sourceId: string;
+	revision: number;
+	rect: BrowserSurfaceRect;
+	visible: boolean;
+};
+
+export type BrowserSurfaceLayoutResult = {
+	viewId: string;
+	sourceId: string;
+	revision: number;
+	rect: BrowserSurfaceRect;
+	visible: boolean;
+	applied: boolean;
+};
+
+export type BrowserSurfaceLayoutReason =
+	| "resize"
+	| "move"
+	| "maximize"
+	| "unmaximize"
+	| "enter-full-screen"
+	| "leave-full-screen";
+
+export type BrowserSurfaceLayoutSignal = {
+	sequence: number;
+	reason: BrowserSurfaceLayoutReason;
+};
+
+export function browserSurfaceRectsEqual(a: BrowserSurfaceRect, b: BrowserSurfaceRect): boolean {
+	return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+}


### PR DESCRIPTION
Fixes #5184

## Summary

- make browser bounds updates revisioned and renderer-lifetime scoped so stale layout work cannot move a retained native view
- converge on the final slot geometry across window resize, move, maximize, fullscreen, panel pop-out, and overlapping transitions instead of relying on one fixed timer
- deduplicate unchanged renderer and native bounds to reduce WebContentsView/compositor work
- revision-fence overlapping macOS shell and live-page refreshes
- keep passive browser tooltips in shell-owned chrome so hover no longer restacks or flashes the native page; retain native overlay composition for interactive menus, dialogs, flyouts, and resize handles
- filter unrelated Radix DOM mutations before browser overlay detection

The live WebContentsView remains the source of truth throughout. This does not restore bitmap parking, screenshots, or view recreation.

## Change size

- total: 660 lines added, 107 removed across 19 files
- tests and test support: 306 lines added, 10 removed
- implementation/support: 354 lines added, 97 removed

## Validation

- `npm test -- --run src/renderer/components/BrowserPanel.test.tsx src/renderer/hooks/useBrowserView.test.tsx src/renderer/lib/dom-selectors.test.ts` — 129 passed
- `npm test` — 292 files passed; 4,157 tests passed, 7 skipped
- `npm run typecheck` — passed
- `npm run typecheck:e2e` — passed
- `npx electron-forge package` — exited successfully and compiled the production main, preload, and renderer bundles
- real-data AO dev clone launched from this branch; renderer and daemon loaded existing projects/sessions successfully

## Notes / risk

- macOS is the available native review platform. Windows-specific black-surface guards remain intact; Windows maximize/overlay behavior should still be exercised by CI or a Windows reviewer.
- `npm run lint` includes the backend suite and was not a clean local signal in this active AO worker environment: unrelated backend tests attached to the live daemon/tmux/data state. No backend files are changed here; remote CI runs those checks in a clean environment.
- related prior timer-only approach: #3898. This PR handles stale ordering, redundant work, renderer reloads, and overlay churn in addition to window layout notifications.