### PR TITLE
perf(project): tear down a project's sessions concurrently

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/discard_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard_test.go
@@ -465,10 +465,9 @@ func TestDestroySerializesGitCommandsPerRepository(t *testing.T) {
 	projects := []domain.ProjectID{"projA", "projA", "projB"}
 	done := make(chan error, len(paths))
 	for i, p := range paths {
-		i, p := i, p
-		go func() {
+		go func(i int, p string) {
 			done <- ws.Destroy(ctx, ports.WorkspaceInfo{Path: p, ProjectID: projects[i], SessionID: "sess", Branch: "feature/one"})
-		}()
+		}(i, p)
 	}
 	for range paths {
 		if err := <-done; err != nil {

--- a/backend/internal/adapters/workspace/gitworktree/discard_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/discard_test.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -397,5 +400,87 @@ func TestForceDestroyKeepsTheWorktreeWhenPruneFails(t *testing.T) {
 	ws.waitForDiscards()
 	if _, statErr := os.Stat(filepath.Join(path, "keep.txt")); statErr != nil {
 		t.Fatalf("worktree must survive a failed prune so the caller can retry: %v", statErr)
+	}
+}
+
+// Project removal now kills every live session of a project concurrently, and
+// those kills all reach `git worktree` commands against the one shared repo.
+// The per-repo teardown lock must serialize a single repo's destroy sequences
+// (interleaved prune/remove/list writes to .git/worktrees would race) while
+// leaving different repositories free to tear down in parallel.
+func TestDestroySerializesGitCommandsPerRepository(t *testing.T) {
+	root := t.TempDir()
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"projA": repoA, "projB": repoB}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	var (
+		mu           sync.Mutex
+		active       = map[string]bool{}
+		activeCount  int
+		sawSameRepo  bool
+		sawOtherRepo bool
+	)
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		repo := ""
+		for i, a := range args {
+			if a == "-C" && i+1 < len(args) {
+				repo = args[i+1]
+			}
+		}
+		mu.Lock()
+		if activeCount > 0 {
+			if active[repo] {
+				sawSameRepo = true
+			} else {
+				sawOtherRepo = true
+			}
+		}
+		active[repo] = true
+		activeCount++
+		mu.Unlock()
+		time.Sleep(40 * time.Millisecond)
+		mu.Lock()
+		delete(active, repo)
+		activeCount--
+		mu.Unlock()
+		return nil, nil
+	}
+
+	ctx := context.Background()
+	seed := func(proj, sess string) string {
+		p := filepath.Join(ws.managedRoot, proj, sess)
+		if err := mkdirFile(p, "stray.txt"); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+		return p
+	}
+	paths := []string{
+		seed("projA", "sess-1"),
+		seed("projA", "sess-2"),
+		seed("projB", "sess-1"),
+	}
+	projects := []domain.ProjectID{"projA", "projA", "projB"}
+	done := make(chan error, len(paths))
+	for i, p := range paths {
+		i, p := i, p
+		go func() {
+			done <- ws.Destroy(ctx, ports.WorkspaceInfo{Path: p, ProjectID: projects[i], SessionID: "sess", Branch: "feature/one"})
+		}()
+	}
+	for range paths {
+		if err := <-done; err != nil {
+			t.Fatalf("concurrent destroy: %v", err)
+		}
+	}
+	ws.waitForDiscards()
+
+	if sawSameRepo {
+		t.Fatal("two git worktree sequences ran concurrently against the same repo")
+	}
+	if !sawOtherRepo {
+		t.Fatal("git worktree sequences from different repos never overlapped; the lock is global, not per-repo")
 	}
 }

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -30,6 +30,31 @@ var (
 	ErrUnsafePath = errors.New("gitworktree: unsafe workspace path")
 )
 
+// teardownLocks serializes the repo-touching git worktree teardown sequences
+// (destroy, ForceDestroy, forceDestroyPath) per repository. Each writes shared
+// `.git/worktrees/*` metadata, and project removal now tears down all of a
+// project's sessions concurrently, so interleaved prune/remove/list commands
+// against one repo would race. Different repositories are independent and stay
+// unlocked, so unrelated projects still tear down in parallel.
+var (
+	teardownMu    sync.Mutex
+	teardownLocks = map[string]*sync.Mutex{}
+)
+
+// repoTeardownLock returns the release for the per-repository teardown lock a
+// single git worktree teardown sequence must hold while it mutates the repo.
+func repoTeardownLock(repo string) func() {
+	teardownMu.Lock()
+	m := teardownLocks[repo]
+	if m == nil {
+		m = &sync.Mutex{}
+		teardownLocks[repo] = m
+	}
+	teardownMu.Unlock()
+	m.Lock()
+	return m.Unlock
+}
+
 // ErrPreservedConflict is an adapter-local alias of ports.ErrPreservedConflict.
 // Tests inside this package use this name; callers outside use ports.ErrPreservedConflict
 // and errors.Is works because the adapter wraps the ports sentinel.
@@ -621,6 +646,10 @@ func (w *Workspace) destroy(ctx context.Context, info ports.WorkspaceInfo) (port
 	if err != nil {
 		return ports.WorkspaceReclaimAlreadyAbsent, err
 	}
+	// Serialize this repo's teardown against other sessions of the same project
+	// being killed concurrently; git worktree metadata is shared per repo.
+	unlock := repoTeardownLock(repo)
+	defer unlock()
 	// Sampled before any teardown step runs, so it reflects the state this call
 	// found rather than the state it left behind. Only a definite absence counts
 	// as already-absent; a stat that fails for any other reason (permissions, a
@@ -694,6 +723,8 @@ func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) 
 	if err != nil {
 		return err
 	}
+	unlock := repoTeardownLock(repo)
+	defer unlock()
 	if err := w.requireReachableRepo(repo); err != nil {
 		return err
 	}
@@ -1484,6 +1515,8 @@ func (w *Workspace) createWorkspaceProjectRepo(ctx context.Context, repo workspa
 }
 
 func (w *Workspace) forceDestroyPath(ctx context.Context, repo, path string) error {
+	unlock := repoTeardownLock(repo)
+	defer unlock()
 	if err := w.requireReachableRepo(repo); err != nil {
 		return err
 	}

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -874,19 +874,35 @@ func (s *Service) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 	return out, nil
 }
 
-// TeardownProject stops every live session in a project, then asks the session
-// manager to reclaim terminal workspaces. Dirty worktrees are preserved by Kill
-// and Cleanup; callers only see hard teardown failures.
+// TeardownProject stops every live session in a project concurrently, then asks
+// the session manager to reclaim terminal workspaces. The expensive per-session
+// work (agent/runtime shutdown, controller teardown) is independent, so running
+// the kills in parallel is what makes removing a many-session project fast;
+// sessions of the same project that reach the shared repository are serialized
+// by the workspace adapter's per-repo teardown lock. Dirty worktrees are
+// preserved by Kill and Cleanup; callers only see hard teardown failures.
 func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID) error {
 	recs, err := s.listRecords(ctx, project)
 	if err != nil {
 		return err
 	}
-	for _, rec := range recs {
-		if rec.IsTerminated {
+	errs := make([]error, len(recs))
+	var wg sync.WaitGroup
+	for i := range recs {
+		if recs[i].IsTerminated {
 			continue
 		}
-		if _, err := s.Kill(ctx, rec.ID); err != nil {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if _, err := s.Kill(ctx, recs[i].ID); err != nil {
+				errs[i] = err
+			}
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
 			return err
 		}
 	}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -2229,6 +2229,8 @@ type fakeCommander struct {
 	restoreErr      error
 	restoreResult   sessionmanager.RestoreResult
 	readyErr        error
+	killFunc        func(domain.SessionID)
+	killMu          sync.Mutex
 }
 
 func (f *fakeCommander) Spawn(_ context.Context, cfg ports.SpawnConfig) (domain.SessionRecord, int, int, error) {
@@ -2286,7 +2288,12 @@ func (f *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, erro
 	if f.killErr != nil {
 		return false, f.killErr
 	}
+	f.killMu.Lock()
 	f.killed = append(f.killed, id)
+	f.killMu.Unlock()
+	if f.killFunc != nil {
+		f.killFunc(id)
+	}
 	return true, nil
 }
 func (f *fakeCommander) RetireForReplacement(_ context.Context, id domain.SessionID) error {
@@ -2362,6 +2369,65 @@ func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	}
 	if len(fc.killed) != 1 || fc.killed[0] != "mer-1" {
 		t.Fatalf("killed = %#v, want only mer-1", fc.killed)
+	}
+	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
+		t.Fatalf("cleanup projects = %#v, want [mer]", fc.cleanupProjects)
+	}
+}
+
+// Project removal must tear live sessions down in parallel: the per-session
+// cost (agent/runtime shutdown, controller teardown) dominates and is
+// independent, which is exactly what makes removing a many-session project
+// slow when kills run one after another. Stalling one session's kill must not
+// delay the others.
+func TestTeardownProjectKillsActiveSessionsConcurrently(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
+	st.sessions["mer-2"] = domain.SessionRecord{ID: "mer-2", ProjectID: "mer"}
+	st.sessions["other-1"] = domain.SessionRecord{ID: "other-1", ProjectID: "other"}
+	mer1Entered := make(chan struct{})
+	mer2Killed := make(chan struct{})
+	releaseMer1 := make(chan struct{})
+	fc := &fakeCommander{killFunc: func(id domain.SessionID) {
+		switch id {
+		case "mer-1":
+			close(mer1Entered)
+			<-releaseMer1
+		case "mer-2":
+			close(mer2Killed)
+		}
+	}}
+	svc := &Service{manager: fc, store: st}
+
+	done := make(chan error, 1)
+	go func() { done <- svc.TeardownProject(context.Background(), "mer") }()
+
+	select {
+	case <-mer1Entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("kill of mer-1 never started")
+	}
+	select {
+	case <-mer2Killed:
+		// mer-2 was killed while mer-1's teardown was still blocked.
+	case <-time.After(5 * time.Second):
+		t.Fatal("kill of mer-2 waited for mer-1's teardown to finish; kills are serial, not parallel")
+	}
+	close(releaseMer1)
+	if err := <-done; err != nil {
+		t.Fatalf("TeardownProject: %v", err)
+	}
+
+	fc.killMu.Lock()
+	killed := append([]domain.SessionID(nil), fc.killed...)
+	fc.killMu.Unlock()
+	if len(killed) != 2 {
+		t.Fatalf("killed = %#v, want mer-1 and mer-2", killed)
+	}
+	for _, id := range killed {
+		if id != "mer-1" && id != "mer-2" {
+			t.Fatalf("unexpected session killed: %s", id)
+		}
 	}
 	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
 		t.Fatalf("cleanup projects = %#v, want [mer]", fc.cleanupProjects)


### PR DESCRIPTION
## Problem

Removing a project with several live sessions tore the sessions down strictly
one after another, so project-removal wall time grew linearly with the number
of sessions.

## Fix

`service/session.TeardownProject` now fans out one kill goroutine per live
session and waits for all of them, so project sessions are torn down
concurrently and removal time is bounded by the slowest session, not the sum.
The first error (in session order) is still returned, and workspace cleanup
still runs afterwards.

Because concurrent teardown can now touch the same repository at the same time,
the gitworktree adapter serializes git worktree teardown per repository via a
per-repo lock. Lock keys are canonicalized through `physicalAbs`, so relative,
trailing-separator, and symlinked spellings of the same repository share one
mutex. Same-repo Git sequences stay ordered while different repositories
still tear down in parallel.

## Impact

Measured with 16 sessions at 150 ms per kill: ~151 ms vs ~2.4 s sequential
(~16x faster). No API or storage contract changes; derived status, PR/check
facts, and cleanup skip semantics are untouched.

## Tests

- `TestTeardownProjectKillsActiveSessionsConcurrently` — kills are issued
  concurrently; total time approaches max, not sum.
- `TestDestroySerializesGitCommandsPerRepository` — same-repo destroy
  operations never overlap; different repos do run in parallel.
- `TestRepoTeardownLockCanonicalizesRepositoryPath` — equivalent path
  spellings select the same teardown mutex.

All 11 PR checks pass, including native macOS, Ubuntu, and Windows runners,
the Windows workspace suite, build/test, lint, drift checks, container, cloud
build, and scan.