### PR TITLE
fix(chat): hold queued turns when a turn fails instead of draining

### DIFF
--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -1386,13 +1386,16 @@ func (c *Controller) dispatch(
 func (c *Controller) drain(ctx context.Context) {
 	c.sendMu.Lock()
 	defer c.sendMu.Unlock()
-	c.drainLocked(ctx)
+	c.drainLocked(ctx, true)
 }
 
 // drainLocked is drain with the dispatch lock already held. Turn completion
 // uses it so committing the completion, clearing primary ownership, and claiming
 // the next queued request are one serialized lifecycle transition.
-func (c *Controller) drainLocked(ctx context.Context) {
+//
+// allowDispatch gates sending the next queued turn. A pending Stop cutoff forces
+// it true so messages typed after Stop still send.
+func (c *Controller) drainLocked(ctx context.Context, allowDispatch bool) {
 	c.mu.Lock()
 	cutoff := c.cancelQueuedAt
 	c.cancelQueuedAt = time.Time{}
@@ -1407,14 +1410,17 @@ func (c *Controller) drainLocked(ctx context.Context) {
 
 	if !cutoff.IsZero() {
 		// The user stopped the agent. Everything queued at that moment is
-		// cancelled; anything typed afterwards is still theirs to send, and falls
-		// through to the dispatch below.
+		// cancelled; anything typed afterwards is still theirs to send.
 		if err := c.store.CancelQueuedTurns(ctx, c.conversation.ID, cutoff, c.now()); err != nil {
 			c.log.Error("failed to cancel queued turns", "session", c.sessionID, "error", err)
 			return
 		}
+		allowDispatch = true
 	}
 	if handoff != controllerHandoffNone && handoff != controllerHandoffInterfaceDrain {
+		return
+	}
+	if !allowDispatch {
 		return
 	}
 
@@ -1559,7 +1565,7 @@ func (c *Controller) BeginHandoff(
 				c.AbortHandoff()
 				return fmt.Errorf("check queued turns before handoff: %w", err)
 			case policy == domain.SessionInterfaceTransitionDrain:
-				c.drainLocked(ctx)
+				c.drainLocked(ctx, true)
 			}
 		}
 		c.sendMu.Unlock()
@@ -1909,7 +1915,7 @@ func (c *Controller) reconcileDurableTurnsLocked(
 	c.reportActivity(ctx, domain.ActivityIdle, "chat.interrupt.reconciled", now)
 	// drainLocked consumes cancelQueuedAt, cancels only the pre-Stop queue, and
 	// immediately dispatches the oldest surviving post-Stop prompt.
-	c.drainLocked(ctx)
+	c.drainLocked(ctx, true)
 	return nil
 }
 
@@ -2713,8 +2719,9 @@ func (c *Controller) afterProject(ctx context.Context, event ports.ChatEvent, pr
 			return
 		}
 		c.reportActivity(ctx, domain.ActivityIdle, "chat.turn.completed", now)
-		// The settled turn is committed before another queued turn can dispatch.
-		c.drainLocked(ctx)
+		// Only a completed turn releases queued work; a failed or recovered one holds
+		// the queue so it cannot cascade through the same outage (issue #4861).
+		c.drainLocked(ctx, event.TurnState == domain.TurnStateCompleted)
 	case ports.ChatEventApprovalRequested:
 		c.reportActivity(ctx, domain.ActivityWaitingInput, "chat.approval.requested", now)
 	case ports.ChatEventApprovalResolved:

--- a/backend/internal/service/chat/controller_hold_queue_test.go
+++ b/backend/internal/service/chat/controller_hold_queue_test.go
@@ -1,0 +1,100 @@
+package chat_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite/store"
+)
+
+// assertTurnStaysQueued fails if the named turn leaves queued within a short settle
+// window. A drain that should not have run would move it to running almost at once.
+func assertTurnStaysQueued(t *testing.T, h *harness, text string) {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		snapshot, err := h.st.LoadConversationSnapshot(context.Background(), h.ctrl.ConversationID())
+		if err != nil {
+			t.Fatalf("load snapshot: %v", err)
+		}
+		if got := turnStateByText(t, snapshot)[text]; got != domain.TurnStateQueued {
+			t.Fatalf("queued turn %q became %q; a non-success terminal turn must hold the queue", text, got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A failed primary turn must not release queued work into the same outage; only a
+// completed turn may. Regression for issue #4861.
+func TestFailedPrimaryTurnHoldsQueuedWork(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "root", ClientMessageID: "c1", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("send root: %v", err)
+	}
+	h.conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root"] == domain.TurnStateRunning
+	})
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "automation", ClientMessageID: "c2", Origin: domain.MessageOriginAutomation,
+	}); err != nil {
+		t.Fatalf("queue automation: %v", err)
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-1",
+		TurnState: domain.TurnStateFailed,
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root"] == domain.TurnStateFailed
+	})
+
+	assertTurnStaysQueued(t, h, "automation")
+	if got := h.conv.sentTexts(); len(got) != 1 || got[0] != "root" {
+		t.Fatalf("provider received %v, want only the root prompt", got)
+	}
+}
+
+// A recovered turn is terminal but carries no portable outcome, so it is no proof
+// the next turn will succeed. It holds the queue like a failed turn.
+func TestRecoveredPrimaryTurnHoldsQueuedWork(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "root", ClientMessageID: "c1", Origin: domain.MessageOriginHuman,
+	}); err != nil {
+		t.Fatalf("send root: %v", err)
+	}
+	h.conv.emit(ports.ChatEvent{Kind: ports.ChatEventTurnStarted, ProviderTurnID: "provider-turn-1"})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root"] == domain.TurnStateRunning
+	})
+
+	if _, err := h.svc.Send(ctx, testSession, ports.ChatUserMessage{
+		Text: "automation", ClientMessageID: "c2", Origin: domain.MessageOriginAutomation,
+	}); err != nil {
+		t.Fatalf("queue automation: %v", err)
+	}
+
+	h.conv.emit(ports.ChatEvent{
+		Kind: ports.ChatEventTurnCompleted, ProviderTurnID: "provider-turn-1",
+		TurnState: domain.TurnStateRecovered,
+	})
+	h.awaitSnapshot(t, func(s store.ConversationSnapshot) bool {
+		return turnStateByText(t, s)["root"] == domain.TurnStateRecovered
+	})
+
+	assertTurnStaysQueued(t, h, "automation")
+	if got := h.conv.sentTexts(); len(got) != 1 || got[0] != "root" {
+		t.Fatalf("provider received %v, want only the root prompt", got)
+	}
+}


### PR DESCRIPTION
Fixes #4861.

## Problem

A terminal provider failure on a busy chat conversation dispatched the next durable queued turn immediately. On a systemic provider outage every queued turn failed in turn and the whole queue drained into failed history. The original report saw one OpenAI incident become 35 failed AO turns in 83 seconds.

## Root cause

`afterProject` called `drainLocked` after every primary `ChatEventTurnCompleted` with no check on terminal state. `drainLocked` only guarded on the pending turn and the Stop cutoff, never on whether the turn that just ended succeeded. So a `failed` or `recovered` completion released the next queued turn into the same broken provider, which failed the same way, and by induction the queue emptied.

The existing sync-dispatch-error guard does not help here: a systemic outage takes the async path (dispatch succeeds and returns a provider turn ID, the failure arrives later as `turn/completed` with `failed`), so the sync guard never runs.

## Fix

`drainLocked` now takes an `allowDispatch` decision:

- `afterProject` passes `true` only for a proven `completed` turn.
- A `failed`, `recovered`, or status-less completion holds the queue at `queued`, durable and retryable.
- The Stop cutoff inside `drainLocked` still re-enables dispatch, so messages typed after an intentional Stop are sent. This is the subtlety a naive "drain only on completed" would break: the Stop path relies on the completion event draining the post-Stop survivors.
- The three explicit drain callers (handoff claim, interface drain, interrupt reconcile) keep dispatching.

## Reproduction

Reproduced on current `main` both as a deterministic unit test and live in the desktop app against a fake 404 provider: a running root turn plus three queued automation messages all drained into the outage and settled `failed`.

## Tests

- New `controller_hold_queue_test.go`: `failed` and `recovered` primary turns hold the queue; the provider receives only the first prompt.
- The existing suite already covers `completed` draining (`TestSendWhileBusyQueuesUntilTheTurnEnds`) and post-Stop delivery (`TestMessageTypedAfterStopIsStillDelivered`, `TestInterruptDurableFallbackPreservesPostStopSend`).
- Full `npm run lint` (`go test ./...` + golangci-lint) is green locally.

## Follow-up (not in this PR)

The issue also asks for explicit recovery UX. Held automation turns currently re-release only when a later turn completes successfully. An explicit operator resume/retry, plus extending `RetryTurn` to accept automation turns (it rejects them today), is worth a separate issue.
