### PR TITLE
test(storage): guard reproducible pinned sqlc generation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -107,6 +107,28 @@ jobs:
           # Blocking on the full ruleset: the tree is clean at zero findings, so
           # any new issue fails CI rather than being grandfathered.
 
+  sqlc-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Regenerate storage queries with pinned sqlc
+        run: npm run sqlc
+
+      - name: Check for generated storage drift
+        run: |
+          git diff --exit-code -- backend/internal/storage/sqlite/gen
+          test -z "$(git ls-files --others --exclude-standard -- backend/internal/storage/sqlite/gen)"
+
   api-drift:
     runs-on: ubuntu-latest
     steps:

--- a/backend/internal/storage/sqlite/sqlc_config_test.go
+++ b/backend/internal/storage/sqlite/sqlc_config_test.go
@@ -1,0 +1,59 @@
+package sqlite
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Generation is checked separately in CI with the pinned npm run sqlc command.
+// Keep this test offline so the normal storage suite also catches malformed
+// YAML and missing boolean overrides before generated code masks the problem.
+func TestSQLCBooleanOverrides(t *testing.T) {
+	data, err := os.ReadFile("../../../sqlc.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		SQL []struct {
+			Gen struct {
+				Go struct {
+					Out       string `yaml:"out"`
+					Overrides []struct {
+						Column string `yaml:"column"`
+						GoType any    `yaml:"go_type"`
+					} `yaml:"overrides"`
+				} `yaml:"go"`
+			} `yaml:"gen"`
+		} `yaml:"sql"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse sqlc.yaml: %v", err)
+	}
+	for _, column := range []string{
+		"agent_switch_failure_policy.enabled",
+		"app_settings.cloud_offering",
+	} {
+		t.Run(column, func(t *testing.T) {
+			matches := 0
+			for _, query := range config.SQL {
+				if query.Gen.Go.Out != "internal/storage/sqlite/gen" {
+					continue
+				}
+				for _, override := range query.Gen.Go.Overrides {
+					if override.Column != column {
+						continue
+					}
+					matches++
+					if goType, ok := override.GoType.(string); !ok || goType != "bool" {
+						t.Errorf("go_type = %v, want bool", override.GoType)
+					}
+				}
+			}
+			if matches != 1 {
+				t.Errorf("found %d overrides, want exactly one", matches)
+			}
+		})
+	}
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -264,6 +264,21 @@ go run ./cmd/ao --help
 
 ### Code generation drift
 
+If CI fails on `sqlc-drift`, run the pinned generator from the repository root
+and commit the generated storage changes together with their SQL/config source:
+
+```bash
+npm run sqlc
+git diff --exit-code -- backend/internal/storage/sqlite/gen
+```
+
+The diff check should pass after committing the regenerated files. Do not edit
+`gen/` by hand or use a different sqlc version; the version in `package.json` is
+authoritative. Review any unexpected query or generated type changes before
+committing. The storage tests also check that the config is valid YAML and keeps
+the boolean overrides for `agent_switch_failure_policy.enabled` and
+`app_settings.cloud_offering`.
+
 If CI fails on the `api-drift` check, the OpenAPI-generated files are out of sync with source. Regenerate them locally and commit the updated files:
 
 ```bash


### PR DESCRIPTION
Code changes: +0 -0  
Tests: +59 -0  
Others: +37 -0  

Closes #4953. Related: #4621; generation prerequisite for #4951 / #4968.

The malformed YAML and both independent boolean overrides were already repaired on main by #4956 (66fb21ae5). That commit also aligned agent-switch query column order with generated parameters and scans. The earlier cloud-offering override landed in #4589. This PR adds the missing regression protection without duplicating those fixes or changing the orchestration outbox.

- Add an offline storage test that parses the real sqlc config and requires exactly one `bool` override for both `agent_switch_failure_policy.enabled` and `app_settings.cloud_offering`.
- Add a `sqlc-drift` CI job using only `npm run sqlc` (sqlc v1.31.1); reject both tracked and newly generated untracked drift.
- Document the pinned regeneration and drift-check workflow.

Regeneration review: current main and this branch produce **zero query/generated drift**. Two consecutive pinned runs from a clean export of commit 8ee2ce0c1 reproduced all generated files exactly. No generated files, query sources, migrations, or production implementation are changed.

Validation passed:
- Focused `TestSQLCBooleanOverrides`; mutation checks reject the original tab-indented YAML and each missing `go_type: bool`. The pinned generator also reproduces the original YAML parse failure.
- `npm run sqlc` and tracked/untracked drift checks, including two runs from a clean committed-source export without node_modules.
- `go build ./...`, `go vet ./...`, and `npm run api` with clean API artifacts.
- Shared Cloud/client and product UI typechecks, tests, builds, and package dry runs; landing favicon check.
- macOS update-helper script tests, x64/arm64 compilation, and native update-state tests.

Local validation gaps (not claimed passed): Docker health probing hung, so the container CLI and pinned Linux renderer environment could not run. The shared host reached load averages above 170: native CLI E2E repeatedly hit its 10-second isolated-daemon startup deadline; renderer smoke timed out and was interrupted; full backend and frontend runs were interrupted to reduce load. Inherited AO variables also contaminated the first attempt; retries stripped them and used isolated AO state. The local full storage race suite exceeded its 15-minute timeout under the same load; the shared lint cache also produced stale paths from deleted worktrees. All 13 GitHub CI checks passed on `8ee2ce0c1`, including [full backend formatting/build/vet/race tests](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34469590400/job/102846109672), [pinned sqlc regeneration with zero drift](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34469590400/job/102846109787), pinned lint, API drift, full frontend typechecks/tests, all native CLI platforms, container CLI, Windows workspace, renderer smoke, macOS helper, and secret scanning. Interrupted local checks are not counted as passes. No maintainer desktop/daemon or other worker session was controlled during validation.

Risk: this adds a CI gate and regression coverage only. Broader #4621 follow-up and #4951/#4968 outbox behavior remain outside this PR.
