### PR TITLE
fix(cli): report metadata-only PR claims truthfully

### DIFF
--- a/backend/internal/cli/claim_output_test.go
+++ b/backend/internal/cli/claim_output_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Both commands must report what the claim response establishes, without
+// interpreting branchChanged=false as proof that HEAD matches the PR branch.
+func TestClaimCommandsCheckoutOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		branchChanged bool
+		emptyPRs      bool
+		wantCheckout  string
+	}{
+		{"metadata only", false, false, "not performed; workspace unchanged"},
+		{"checkout reported by daemon", true, false, "switched to PR branch"},
+		{"metadata only without PR facts", false, true, "not performed; workspace unchanged"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := setConfigEnv(t)
+			prs := `[{"url":"https://github.com/acme/repo/pull/7","number":7}]`
+			if tc.emptyPRs {
+				prs = `[]`
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method + " " + r.URL.Path {
+				case "GET /api/v1/projects/demo":
+					_, _ = io.WriteString(w, `{"project":{"id":"demo","repo":"https://github.com/acme/repo"}}`)
+				case "GET /api/v1/sessions/demo-1", "POST /api/v1/sessions":
+					_, _ = io.WriteString(w, `{"session":{"id":"demo-1","projectId":"demo","status":"idle"}}`)
+				case "POST /api/v1/sessions/demo-1/pr/claim":
+					_, _ = fmt.Fprintf(w, `{"ok":true,"sessionId":"demo-1","prs":%s,"branchChanged":%t}`, prs, tc.branchChanged)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			writeRunFileFor(t, cfg, srv)
+			deps := Deps{ProcessAlive: func(int) bool { return true }}
+			for _, args := range [][]string{
+				{"session", "claim-pr", "demo-1", "7"},
+				{"spawn", "--project", "demo", "--agent", "codex", "--name", "worker", "--skip-agent-check", "--claim-pr", "7"},
+			} {
+				out, errOut, err := executeCLI(t, deps, args...)
+				if err != nil {
+					t.Fatalf("%v: %v stderr=%s", args, err, errOut)
+				}
+				if want := "  checkout: " + tc.wantCheckout + "\n"; !strings.Contains(out, want) {
+					t.Errorf("%v output = %q, want %q", args, out, want)
+				}
+				if strings.Contains(out, "already on PR branch") || strings.Contains(out, "switched to PR branch") != tc.branchChanged {
+					t.Errorf("%v output contradicts branchChanged=%t: %s", args, tc.branchChanged, out)
+				}
+			}
+			// spawn has no --json mode; its human output above must agree with
+			// the same daemon field that session claim-pr exposes as JSON.
+			out, errOut, err := executeCLI(t, deps, "session", "claim-pr", "demo-1", "7", "--json")
+			if err != nil {
+				t.Fatalf("claim-pr --json: %v stderr=%s", err, errOut)
+			}
+			var got struct {
+				BranchChanged *bool `json:"branchChanged"`
+			}
+			if err := json.Unmarshal([]byte(out), &got); err != nil || got.BranchChanged == nil || *got.BranchChanged != tc.branchChanged {
+				t.Fatalf("JSON branchChanged does not match daemon response: err=%v out=%s", err, out)
+			}
+		})
+	}
+}
+
+func TestClaimCommandsHelpDocumentsMetadataOnly(t *testing.T) {
+	for _, args := range [][]string{{"session", "claim-pr", "--help"}, {"spawn", "--help"}} {
+		out, _, err := executeCLI(t, Deps{}, args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "metadata only") || !strings.Contains(out, "does not check out the PR branch") {
+			t.Errorf("%v help must explain metadata-only claiming: %s", args, out)
+		}
+	}
+}

--- a/backend/internal/cli/output.go
+++ b/backend/internal/cli/output.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -9,4 +10,14 @@ func writeJSON(w io.Writer, v any) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(v)
+}
+
+func writeClaimPRCheckout(w io.Writer, branchChanged bool) error {
+	// An unchanged branch does not establish that HEAD matches the PR head.
+	checkout := "not performed; workspace unchanged"
+	if branchChanged {
+		checkout = "switched to PR branch"
+	}
+	_, err := fmt.Fprintf(w, "  checkout: %s\n", checkout)
+	return err
 }

--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -324,7 +324,8 @@ func newSessionClaimPRCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "claim-pr [<session-id>] <pr-ref>",
 		Short: "Attach an existing PR to a session",
-		Long:  "Attach an existing PR to a session. When session-id is omitted, the current session is read from AO_SESSION_ID.",
+		Long: "Attach an existing PR to a session. When session-id is omitted, the current session is read from AO_SESSION_ID.\n\n" +
+			"Claiming updates PR ownership metadata only; it does not check out the PR branch. Verify the workspace branch and HEAD before editing.",
 		Example: `  # From inside an AO worker session
   ao session claim-pr 88
 
@@ -428,21 +429,19 @@ func (c *commandContext) fetchProjectDetails(ctx context.Context, id string) (pr
 func writeClaimPRResult(cmd *cobra.Command, res claimPRResponse) error {
 	out := cmd.OutOrStdout()
 	if len(res.PRs) == 0 {
-		_, err := fmt.Fprintf(out, "session %s claimed PR\n", res.SessionID)
-		return err
+		if _, err := fmt.Fprintf(out, "session %s claimed PR\n", res.SessionID); err != nil {
+			return err
+		}
+	} else {
+		pr := res.PRs[0]
+		if _, err := fmt.Fprintf(out, "session %s claimed PR #%d\n", res.SessionID, pr.Number); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "  pr:       %s\n", pr.URL); err != nil {
+			return err
+		}
 	}
-	pr := res.PRs[0]
-	if _, err := fmt.Fprintf(out, "session %s claimed PR #%d\n", res.SessionID, pr.Number); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "  pr:       %s\n", pr.URL); err != nil {
-		return err
-	}
-	checkout := "already on PR branch"
-	if res.BranchChanged {
-		checkout = "switched to PR branch"
-	}
-	if _, err := fmt.Fprintf(out, "  checkout: %s\n", checkout); err != nil {
+	if err := writeClaimPRCheckout(out, res.BranchChanged); err != nil {
 		return err
 	}
 	for _, owner := range res.TakenOverFrom {

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -152,8 +152,8 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 				return fmt.Errorf("daemon returned empty session id for spawn")
 			}
 			claimed := ""
+			var claim claimPRResponse
 			if opts.claimPR != "" {
-				var claim claimPRResponse
 				if err := ctx.postJSON(cmd.Context(), "sessions/"+url.PathEscape(res.Session.ID)+"/pr/claim", claimPRRequest{PR: claimRef, AllowTakeover: !opts.noTakeover}, &claim); err != nil {
 					if killErr := ctx.rollbackSpawnedSession(cmd.Context(), res.Session.ID); killErr != nil {
 						return fmt.Errorf("failed to claim PR %s: %w; rollback of session %s failed: %w", opts.claimPR, err, res.Session.ID, killErr)
@@ -177,8 +177,13 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			if displayName == "" {
 				displayName = name
 			}
-			_, err = fmt.Fprintf(out, "spawned session %s %q (%s)%s%s\n", res.Session.ID, displayName, res.Session.Status, claimLabel, promptSize)
-			return err
+			if _, err := fmt.Fprintf(out, "spawned session %s %q (%s)%s%s\n", res.Session.ID, displayName, res.Session.Status, claimLabel, promptSize); err != nil {
+				return err
+			}
+			if opts.claimPR != "" {
+				return writeClaimPRCheckout(out, claim.BranchChanged)
+			}
+			return nil
 		},
 	}
 	f := cmd.Flags()
@@ -200,7 +205,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 	f.StringVar(&opts.issue, "issue", "", "Issue id to associate with the session")
 	f.StringVar(&opts.trackerProvider, "tracker-provider", "github", "Issue tracker provider: github or gitlab (default: github)")
 	f.StringVar(&opts.name, "name", "", "Display name shown in the sidebar (required, max 20 characters)")
-	f.StringVar(&opts.claimPR, "claim-pr", "", "Immediately claim an existing PR for the spawned session")
+	f.StringVar(&opts.claimPR, "claim-pr", "", "Claim PR ownership metadata only for the spawned session; does not check out the PR branch")
 	f.BoolVar(&opts.noTakeover, "no-takeover", false, "Refuse if another active session owns the claimed PR (requires --claim-pr)")
 	f.BoolVar(&opts.skipAgentCheck, "skip-agent-check", false, "Skip CLI readiness warnings (the daemon still validates launch readiness)")
 	return cmd

--- a/backend/internal/service/session/claim_checkout_test.go
+++ b/backend/internal/service/session/claim_checkout_test.go
@@ -1,0 +1,56 @@
+package session
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestClaimPRMetadataOnlyPreservesWorkspace(t *testing.T) {
+	for _, branch := range []string{"ao/mer-1/root", "pr-topic"} {
+		t.Run(branch, func(t *testing.T) {
+			repo := newWorkspaceRepo(t)
+			runGit(t, repo, "branch", "ao/mer-1/root")
+			runGit(t, repo, "checkout", "-b", "pr-topic")
+			runGit(t, repo, "commit", "--allow-empty", "-m", "PR head")
+			prHead := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+			runGit(t, repo, "checkout", branch)
+			beforeHead := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD"))
+			if (beforeHead == prHead) != (branch == "pr-topic") {
+				t.Fatal("fixture must distinguish the PR head from the worker base")
+			}
+
+			st := newFakeStore()
+			st.sessions["mer-1"] = domain.SessionRecord{
+				ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker,
+				Metadata: domain.SessionMetadata{WorkspacePath: repo, Branch: branch},
+			}
+			st.projects["mer"] = domain.ProjectRecord{ID: "mer", RepoOriginURL: "https://github.com/acme/repo"}
+			st.pr["mer-1"] = domain.PRFacts{URL: "https://github.com/acme/repo/pull/7", Number: 7}
+			claimer := &fakePRClaimer{}
+			svc := NewWithDeps(Deps{Store: st, PRClaimer: claimer, SCM: fakeSCM{obs: ports.SCMObservation{
+				Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo",
+				PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7, SourceBranch: "pr-topic", HeadSHA: prHead},
+			}}})
+			res, err := svc.ClaimPR(context.Background(), "mer-1", "7", ClaimPROptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !claimer.called || len(res.PRs) != 1 || res.BranchChanged {
+				t.Fatalf("metadata-only claim: called=%t result=%+v", claimer.called, res)
+			}
+			if got := strings.TrimSpace(runGit(t, repo, "branch", "--show-current")); got != branch {
+				t.Fatalf("workspace branch = %q, want unchanged %q", got, branch)
+			}
+			if got := strings.TrimSpace(runGit(t, repo, "rev-parse", "HEAD")); got != beforeHead {
+				t.Fatalf("workspace HEAD = %q, want unchanged %q", got, beforeHead)
+			}
+			if got := runGit(t, repo, "status", "--porcelain"); got != "" {
+				t.Fatalf("claim modified workspace: %s", got)
+			}
+		})
+	}
+}

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -139,8 +139,8 @@ func (s *Service) ClaimPR(ctx context.Context, id domain.SessionID, ref string, 
 	}
 	prs = claimedFirst(prs, prURL)
 	// TODO: implement workspace branch checkout. Until then, leave BranchChanged
-	// false and let CLI output omit the checkout line rather than claiming the
-	// session was already on the PR branch.
+	// false and have CLI output report that the workspace was unchanged, without
+	// assuming the session was already on the PR branch.
 	res := ClaimPRResult{PRs: prs, BranchChanged: false, DonorWasTerminated: outcome.OwnerTerminated}
 	if outcome.PreviousOwner != "" && outcome.PreviousOwner != id {
 		res.TakenOverFrom = []domain.SessionID{outcome.PreviousOwner}

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -114,6 +114,22 @@ native history and compaction.
 explicitly with `ao session claim-pr <session-id> <pr-ref>`. The explicit form
 remains supported for backward compatibility and cross-session coordination.
 
+Both `ao session claim-pr` and `ao spawn --claim-pr` currently claim PR ownership
+metadata only. Claiming does not check out the PR branch or change the workspace
+HEAD. Both commands report `checkout: not performed; workspace unchanged` when
+the claim response has `branchChanged: false`. For `spawn`, this describes the
+claim step after the new workspace has been created.
+
+`ao session claim-pr --json` preserves the daemon's `branchChanged` field;
+`spawn` currently has no `--json` mode. A false value reports that claiming did
+not change the branch. It does **not** establish whether the workspace was
+already on the PR branch, or whether HEAD matches the current provider PR head.
+Verify those separately before editing or pushing, even after a successful claim.
+
+Automatic checkout is deferred. A future implementation must handle exact PR
+head verification, ownership/takeover, concurrent provider changes, and worktree
+preservation together; metadata-only success does not promise those guarantees.
+
 If `--agent` / `--harness` is omitted, `ao spawn` uses the resolved project's
 `worker.agent` config. Before spawning, the CLI performs one targeted launch
 ensure. It fails early for unsupported or definitely missing harnesses and


### PR DESCRIPTION
Code changes: +36 -21  
Tests: +145 -0  
Others: +16 -0  

## What

When the daemon returned `branchChanged: false`, `ao session claim-pr` said the workspace was already on the PR branch, and `ao spawn --claim-pr` gave no checkout status. Both now report `checkout: not performed; workspace unchanged`. A true response still reports `switched to PR branch`.

## Why

Fixes #4940 using the issue's accepted truthful partial-success approach. A successful metadata claim does not establish that the workspace branch or HEAD matches the current provider PR head.

## How

- Share the checkout formatter between both CLI paths, including responses with no PR facts.
- Preserve `ao session claim-pr --json` and its `branchChanged` field. `spawn` has no JSON mode; its human output now honors the same claim endpoint field.
- Document metadata-only claiming in CLI help and the CLI guide. Automatic checkout and its exact-head, takeover, concurrent-provider-change, and worktree-preservation guarantees remain deferred.
- Cover both CLI paths and JSON consistency, plus real temporary Git repositories whose HEAD is either the PR head or a distinct worker base.

Coordinated with the #5068 worker; repository validation and SCM attribution remain in that issue. #4953 and spawn/takeover lifecycle changes are outside this PR.

## Testing

Passed locally before validation was stopped:
- Focused claim regressions: `go test ./internal/cli ./internal/service/session -run 'ClaimPR|ClaimCommands' -count=1` (including a red/green reproduction of the original CLI output bug).
- Complete CLI and session-service packages in the clean-environment backend run.
- `go build ./...`, `go vet ./...`, formatting, and diff whitespace checks.
- API regeneration with Node 24 and openapi-typescript 7.4.4; no generated API/spec drift.

Local gaps, failures, and interruptions:
- The full non-race backend suite completed with one failure in the unchanged `systemexec` package: `TestRunInstallScriptCancellationCleansUp` uses a 50 ms deadline, which expired before `installers/tmp` was created. `npm run lint` therefore did not reach its linter step. The exact base commit's Go CI passed.
- The full race suite was interrupted to reduce severe host load. It has no completed local pass.
- Standalone golangci-lint v2.12.2 reported stale cached findings from other/deleted worktrees. A rerun with private caches was interrupted; lint has no conclusive local result.
- The initial native CLI E2E run had inherited worker-environment failures and startup timing failures. The clean-environment rerun had not started when validation was stopped.
- Docker did not respond to a bounded availability probe, so container smoke/gitleaks validation and native Linux/Windows checks require CI.

No local checks were restarted after the orchestrator requested the stop. All **9 remote CI checks passed** for actual head `03d7706d0c1ce64ed3efc5bc0443fae34667d499`: [Go build/vet/race, Windows workspace, lint, and API drift](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34470793814); [CLI E2E on Linux/macOS/Windows and container smoke](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34470793838); and [secret scan](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34470793763). Required review remains pending.

## Current integration validation

Merged main `ab968d5e7` into head `725701af5`. The complete backend race suite, build, vet, golangci-lint v2.12.2 (zero issues), cloud build/vet/race suite, native macOS CLI E2E with inherited AO variables removed, and API/sqlc regeneration drift checks passed locally. The earlier interrupted validation above describes the prior head. Docker is unavailable locally, so container smoke and container secret scanning require CI; native Linux/Windows jobs also require CI. Hosted checks on this new head are pending.

## Current takeover integration

Merged main `ab968d5e7`. Complete local backend race, build, vet, golangci-lint v2.12.2, cloud build/vet/race, clean-environment macOS CLI E2E, and API/sqlc drift checks pass. All 11 hosted checks pass on `725701af5`, including Linux/Windows and container checks unavailable locally. Earlier validation entries refer to prior heads.
