### PR TITLE
fix(chat): decode percent-encoded ACP approval request ids

### DIFF
--- a/backend/internal/httpd/controllers/conversations.go
+++ b/backend/internal/httpd/controllers/conversations.go
@@ -641,8 +641,12 @@ func (c *ConversationsController) resolve(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	requestID, ok := conversationRequestID(w, r)
+	if !ok {
+		return
+	}
 	err := c.Svc.Resolve(r.Context(), domain.SessionID(chi.URLParam(r, "sessionId")),
-		chi.URLParam(r, "requestId"), ports.ChatDecision{ID: req.DecisionID})
+		requestID, ports.ChatDecision{ID: req.DecisionID})
 	if err != nil {
 		writeConversationError(w, r, err)
 		return
@@ -671,9 +675,13 @@ func (c *ConversationsController) resolveInput(w http.ResponseWriter, r *http.Re
 			"CHAT_INPUT_CONTENT_INVALID", "content is only allowed with accept", nil)
 		return
 	}
+	requestID, ok := conversationRequestID(w, r)
+	if !ok {
+		return
+	}
 	if err := c.Svc.ResolveInput(
 		r.Context(), domain.SessionID(chi.URLParam(r, "sessionId")),
-		chi.URLParam(r, "requestId"),
+		requestID,
 		ports.ChatInputResponse{Action: action, Content: req.Content},
 	); err != nil {
 		writeConversationError(w, r, err)
@@ -693,6 +701,20 @@ func (c *ConversationsController) interrupt(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// conversationRequestID decodes the path id the Electron client percent-encodes.
+// ACP persistent hosts mint ids such as `acp-request:<host>:<n>`; openapi-fetch
+// turns the colons into %3A, and chi.URLParam leaves that encoding in place —
+// the same trap ActivateBranch already handles for `conversation-1:root`.
+func conversationRequestID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	requestID, err := url.PathUnescape(chi.URLParam(r, "requestId"))
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "validation",
+			"CHAT_REQUEST_INVALID", "conversation request identifier is invalid", nil)
+		return "", false
+	}
+	return requestID, true
 }
 
 func decodeConversationBody(w http.ResponseWriter, r *http.Request, into any) bool {

--- a/backend/internal/httpd/controllers/conversations_test.go
+++ b/backend/internal/httpd/controllers/conversations_test.go
@@ -34,18 +34,20 @@ func conversationTestServer(t *testing.T, service *fakeConversationService) *htt
 // JSON a client actually parses is what is checked.
 
 type fakeConversationService struct {
-	snapshot       chatsvc.Snapshot
-	skills         []ports.ChatSkill
-	skillErr       error
-	configOptions  []ports.ChatConfigOption
-	configErr      error
-	setConfigID    string
-	setConfigValue ports.ChatConfigOptionValue
-	mcpServers     []domain.ConversationMCPServer
-	reloadErr      error
-	sent           ports.ChatUserMessage
-	inputRequestID string
-	inputResponse  ports.ChatInputResponse
+	snapshot          chatsvc.Snapshot
+	skills            []ports.ChatSkill
+	skillErr          error
+	configOptions     []ports.ChatConfigOption
+	configErr         error
+	setConfigID       string
+	setConfigValue    ports.ChatConfigOptionValue
+	mcpServers        []domain.ConversationMCPServer
+	reloadErr         error
+	sent              ports.ChatUserMessage
+	approvalRequestID string
+	approvalDecision  ports.ChatDecision
+	inputRequestID    string
+	inputResponse     ports.ChatInputResponse
 }
 
 func (f *fakeConversationService) EditMessage(context.Context, domain.SessionID, string, ports.ChatUserMessage) (chatsvc.EditMessageResult, error) {
@@ -65,7 +67,9 @@ func (f *fakeConversationService) Send(_ context.Context, _ domain.SessionID, me
 	return domain.ConversationTurn{ID: "turn-1", State: domain.TurnStateRunning}, nil
 }
 
-func (f *fakeConversationService) Resolve(context.Context, domain.SessionID, string, ports.ChatDecision) error {
+func (f *fakeConversationService) Resolve(_ context.Context, _ domain.SessionID, requestID string, decision ports.ChatDecision) error {
+	f.approvalRequestID = requestID
+	f.approvalDecision = decision
 	return nil
 }
 
@@ -356,6 +360,46 @@ func TestResolveConversationInputCarriesActionAndStructuredContent(t *testing.T)
 	}
 	if service.inputRequestID != "request-7" || service.inputResponse.Action != "accept" || service.inputResponse.Content["choice"] != "native" {
 		t.Fatalf("input = %q %#v", service.inputRequestID, service.inputResponse)
+	}
+}
+
+func TestResolveConversationApprovalDecodesEscapedACPRequestID(t *testing.T) {
+	service := &fakeConversationService{}
+	server := conversationTestServer(t, service)
+	postConversationJSON(t, server,
+		"/api/v1/sessions/p1-1/conversation/approvals/acp-request%3Ahost%3A1/resolve",
+		`{"decisionId":"allow-once"}`, http.StatusNoContent)
+	if service.approvalRequestID != "acp-request:host:1" || service.approvalDecision.ID != "allow-once" {
+		t.Fatalf("approval = %q %#v", service.approvalRequestID, service.approvalDecision)
+	}
+}
+
+func TestResolveConversationInputDecodesEscapedACPRequestID(t *testing.T) {
+	service := &fakeConversationService{}
+	server := conversationTestServer(t, service)
+	postConversationJSON(t, server,
+		"/api/v1/sessions/p1-1/conversation/inputs/acp-request%3Ahost%3A2/resolve",
+		`{"action":"decline"}`, http.StatusNoContent)
+	if service.inputRequestID != "acp-request:host:2" || service.inputResponse.Action != "decline" {
+		t.Fatalf("input = %q %#v", service.inputRequestID, service.inputResponse)
+	}
+}
+
+func postConversationJSON(t *testing.T, server *httptest.Server, path, body string, wantStatus int) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != wantStatus {
+		got, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, body = %s, want %d", response.StatusCode, got, wantStatus)
 	}
 }
 


### PR DESCRIPTION
## What
Allow and Deny in Electron Chat both failed for Cursor/ACP sessions because the resolve routes did not decode percent-encoded request ids.

## Why
Persistent ACP hosts mint ids such as `acp-request:<host>:<n>`. The Electron client posts through openapi-fetch, which encodes the colons as `%3A`. `chi.URLParam` leaves that encoding in place, so the daemon looked up a different id than the one still pending and returned `CHAT_REQUEST_NOT_PENDING` for every decision.

This is the same trap `ActivateBranch` already handles for `conversation-1:root`.

## How
Unescape `{requestId}` on approval and structured-input resolve, matching the existing branch-id path. Invalid encodings are refused as `CHAT_REQUEST_INVALID`.

## Testing
- `go test ./internal/httpd/controllers/ -count=1`
- New tests cover escaped ACP ids on both `/approvals/{requestId}/resolve` and `/inputs/{requestId}/resolve`

## Test plan
- [ ] Open AO Electron, import a project, start a Cursor (or other ACP) Chat session in Default approvals
- [ ] Send a prompt that causes a shell/MCP permission card (Allow once / Deny)
- [ ] Click **Allow once** — the command should run and the card should resolve
- [ ] Repeat with **Deny** on a later command — the card should resolve without `this request has already been answered or is no longer waiting`


Made with [Cursor](https://cursor.com)