### PR TITLE
fix(mobile): make notification toggles clickable

### DIFF
--- a/frontend/src/renderer/components/settings/MobileDevicesSection.test.tsx
+++ b/frontend/src/renderer/components/settings/MobileDevicesSection.test.tsx
@@ -69,6 +69,40 @@ describe("MobileDevicesSection", () => {
 		});
 	});
 
+	it("updates the visible switch after muting and unmuting", async () => {
+		let muted = false;
+		vi.spyOn(apiClient, "GET").mockImplementation(async () => ({
+			data: { devices: [{ ...twoDevices.data.devices[0], muted }] },
+		}) as never);
+		const patch = vi.spyOn(apiClient, "PATCH").mockImplementation(async (_path, options) => {
+			muted = (options as { body: { muted: boolean } }).body.muted;
+			return { data: { muted } } as never;
+		});
+		renderSection();
+		const toggle = await screen.findByRole("switch", { name: /notifications for iPhone/i });
+		expect(toggle).toBeChecked();
+		fireEvent.click(toggle);
+		await waitFor(() => expect(toggle).not.toBeChecked());
+		fireEvent.click(toggle);
+		await waitFor(() => expect(toggle).toBeChecked());
+		expect(patch).toHaveBeenCalledTimes(2);
+	});
+
+	it("removes phone setup guidance after registration while keeping the preference", async () => {
+		const device = twoDevices.data.devices[0];
+		vi.spyOn(apiClient, "GET").mockResolvedValue({
+			data: { devices: [{ ...device, notificationsEnabled: false }] },
+		} as never);
+		const { client } = renderSection();
+		await screen.findByText(/open Settings in the AO phone app/i);
+		expect(screen.getByRole("switch")).toBeEnabled();
+		act(() => { client.setQueryData(mobileDevicesQueryKey, [device]); });
+		const toggle = await screen.findByRole("switch", { name: /notifications for iPhone/i });
+		expect(toggle).toBeEnabled();
+		expect(toggle).toBeChecked();
+		expect(screen.queryByText(/open Settings in the AO phone app/i)).not.toBeInTheDocument();
+	});
+
 	it("removes a device only after confirmation", async () => {
 		vi.spyOn(apiClient, "GET").mockResolvedValue(twoDevices as never);
 		const del = vi.spyOn(apiClient, "DELETE").mockResolvedValue({ data: undefined } as never);
@@ -181,7 +215,7 @@ describe("MobileDevicesSection", () => {
 		expect(names).toEqual(["iPhone", "M31s"]);
 	});
 
-	it("keeps a device without a push token manageable without extra status copy", async () => {
+	it("lets a tokenless phone save its mute preference and explains phone setup", async () => {
 		const noToken = {
 			data: {
 				devices: [
@@ -199,10 +233,15 @@ describe("MobileDevicesSection", () => {
 
 		expect(await screen.findByText("Pixel Announce")).toBeInTheDocument();
 		expect(screen.queryByText("Live")).not.toBeInTheDocument();
-		expect(screen.queryByText(/Notifications not enabled on this device/i)).not.toBeInTheDocument();
+		expect(screen.getByText(/open Settings in the AO phone app and turn on Agent notifications/i)).toBeInTheDocument();
 
-		const toggle = screen.getByRole("switch", { name: /notifications for Pixel Announce/i });
-		expect(toggle).toBeDisabled();
+		expect(screen.getByRole("switch")).toBeEnabled();
+		expect(screen.getByTestId("bell")).toBeInTheDocument();
+		const patch = vi.spyOn(apiClient, "PATCH").mockResolvedValue({ data: { muted: true } } as never);
+		fireEvent.click(screen.getByRole("switch"));
+		await waitFor(() => expect(patch).toHaveBeenCalledWith("/api/v1/mobile/devices/{installId}", {
+			params: { path: { installId: "i3" } }, body: { muted: true },
+		}));
 
 		// Still removable.
 		fireEvent.click(screen.getByRole("button", { name: /remove Pixel Announce/i }));

--- a/frontend/src/renderer/components/settings/MobileDevicesSection.tsx
+++ b/frontend/src/renderer/components/settings/MobileDevicesSection.tsx
@@ -138,18 +138,25 @@ export function MobileDevicesSection() {
 									<Smartphone className="size-4 shrink-0 text-settings-muted" aria-hidden="true" />
 									<div className="min-w-0 flex-1">
 										<div className="truncate text-sm">{name}</div>
+										{!device.notificationsEnabled && (
+											<p className="mt-1 text-caption text-settings-muted">
+												{t("mobile.devices.enableOnPhone")}
+											</p>
+										)}
 									</div>
 
 									<div className="flex items-center gap-2" title={t("mobile.devices.notificationsFor", { name })}>
 										<Bell className="size-4 text-settings-muted" aria-hidden="true" data-testid="bell" />
 										<Switch
-											checked={device.notificationsEnabled && !device.muted}
-											disabled={mute.isPending || !device.notificationsEnabled}
+											checked={!device.muted}
+											disabled={mute.isPending}
+											className="data-[state=checked]:bg-settings-switch-on data-[state=unchecked]:bg-[var(--color-border-settings-input)] **:data-[slot=switch-thumb]:bg-white"
 											aria-label={t("mobile.devices.notificationsFor", { name })}
 											onCheckedChange={(next) =>
 												mute.mutate({ installId: device.installId, muted: !next })
 											}
 										/>
+
 									</div>
 
 									{confirmingRemoval === device.installId ? (

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -513,6 +513,7 @@
 	"mobile.devices.confirmRemove": "Entfernen bestätigen",
 	"mobile.devices.empty": "Noch keine Geräte gekoppelt.",
 	"mobile.devices.loading": "Geräte werden geladen…",
+	"mobile.devices.enableOnPhone": "Um Benachrichtigungen zu aktivieren, öffne die Einstellungen in der AO-App auf deinem Smartphone und aktiviere „Agent notifications“.",
 	"mobile.devices.notificationsFor": "Benachrichtigungen für {{name}}",
 	"mobile.devices.registryUnavailable": "Geräteregister nicht verfügbar — AO konnte Ihre gespeicherten Geräte nicht lesen.",
 	"mobile.devices.removeAria": "{{name}} entfernen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -513,6 +513,7 @@
 	"mobile.devices.confirmRemove": "Confirm remove",
 	"mobile.devices.empty": "No devices paired yet.",
 	"mobile.devices.loading": "Loading devices…",
+	"mobile.devices.enableOnPhone": "To enable notifications, open Settings in the AO phone app and turn on Agent notifications.",
 	"mobile.devices.notificationsFor": "Notifications for {{name}}",
 	"mobile.devices.registryUnavailable": "Device registry unavailable — AO could not read your saved devices.",
 	"mobile.devices.removeAria": "Remove {{name}}",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -515,6 +515,7 @@
 	"mobile.devices.confirmRemove": "Confirmar eliminación",
 	"mobile.devices.empty": "Aún no hay dispositivos emparejados.",
 	"mobile.devices.loading": "Cargando dispositivos…",
+	"mobile.devices.enableOnPhone": "Para activar las notificaciones, abre Ajustes en la app AO del teléfono y activa «Agent notifications».",
 	"mobile.devices.notificationsFor": "Notificaciones de {{name}}",
 	"mobile.devices.registryUnavailable": "Registro de dispositivos no disponible — AO no pudo leer tus dispositivos guardados.",
 	"mobile.devices.removeAria": "Eliminar {{name}}",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -515,6 +515,7 @@
 	"mobile.devices.confirmRemove": "Confirmer la suppression",
 	"mobile.devices.empty": "Aucun appareil associé pour le moment.",
 	"mobile.devices.loading": "Chargement des appareils…",
+	"mobile.devices.enableOnPhone": "Pour activer les notifications, ouvre les paramètres de l’application AO sur ton téléphone et active « Agent notifications ».",
 	"mobile.devices.notificationsFor": "Notifications pour {{name}}",
 	"mobile.devices.registryUnavailable": "Registre des appareils indisponible — AO n'a pas pu lire vos appareils enregistrés.",
 	"mobile.devices.removeAria": "Supprimer {{name}}",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -513,6 +513,7 @@
 	"mobile.devices.confirmRemove": "削除を確定",
 	"mobile.devices.empty": "まだペアリングされたデバイスはありません。",
 	"mobile.devices.loading": "デバイスを読み込み中…",
+	"mobile.devices.enableOnPhone": "通知を有効にするには、スマートフォンのAOアプリで設定を開き、「Agent notifications」をオンにしてください。",
 	"mobile.devices.notificationsFor": "{{name}} の通知",
 	"mobile.devices.registryUnavailable": "デバイスレジストリを利用できません — AO は保存済みのデバイスを読み込めませんでした。",
 	"mobile.devices.removeAria": "{{name}} を削除",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -513,6 +513,7 @@
 	"mobile.devices.confirmRemove": "제거 확인",
 	"mobile.devices.empty": "아직 페어링된 기기가 없습니다.",
 	"mobile.devices.loading": "기기를 불러오는 중…",
+	"mobile.devices.enableOnPhone": "알림을 활성화하려면 휴대폰의 AO 앱에서 설정을 열고 «Agent notifications»를 켜세요.",
 	"mobile.devices.notificationsFor": "{{name}}의 알림",
 	"mobile.devices.registryUnavailable": "기기 레지스트리를 사용할 수 없습니다 — AO가 저장된 기기를 읽지 못했습니다.",
 	"mobile.devices.removeAria": "{{name}} 제거",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -515,6 +515,7 @@
 	"mobile.devices.confirmRemove": "Confirmar remoção",
 	"mobile.devices.empty": "Nenhum dispositivo emparelhado ainda.",
 	"mobile.devices.loading": "Carregando dispositivos…",
+	"mobile.devices.enableOnPhone": "Para ativar as notificações, abra as configurações do app AO no celular e ative «Agent notifications».",
 	"mobile.devices.notificationsFor": "Notificações de {{name}}",
 	"mobile.devices.registryUnavailable": "Registro de dispositivos indisponível — o AO não conseguiu ler seus dispositivos salvos.",
 	"mobile.devices.removeAria": "Remover {{name}}",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -513,6 +513,7 @@
 	"mobile.devices.confirmRemove": "确认移除",
 	"mobile.devices.empty": "尚未配对任何设备。",
 	"mobile.devices.loading": "正在加载设备…",
+	"mobile.devices.enableOnPhone": "要启用通知，请打开手机上 AO 应用的设置，然后开启“Agent notifications”。",
 	"mobile.devices.notificationsFor": "{{name}} 的通知",
 	"mobile.devices.registryUnavailable": "设备注册表不可用 — AO 无法读取已保存的设备。",
 	"mobile.devices.removeAria": "移除 {{name}}",


### PR DESCRIPTION
Fixes the notification toggle ignoring clicks when a phone has not registered for push notifications. The toggle now saves the mute setting and shows a note about enabling notifications on the phone.

Tested switching off/on and reopening Settings in the Windows app. All CI checks pass. Phone notification delivery was not tested.

Fixes #5161.
