### PR TITLE
fix: prevent Windows terminal popups from mobile tunnels

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Test Windows Chat environment precedence
         run: go test -race ./internal/adapters/chatdriver/processenv/ ./internal/agentlaunch/
 
+      - name: Test Windows mobile tunnel subprocesses
+        run: go test -race -run 'Cloudflared|Tunnel|Command' ./internal/mobilebridge/ ./internal/process/
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/backend/internal/mobilebridge/process.go
+++ b/backend/internal/mobilebridge/process.go
@@ -3,12 +3,13 @@ package mobilebridge
 import (
 	"context"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // processProbeTimeout bounds the shell-out used to identify a process. A hung
@@ -30,7 +31,7 @@ func IsLiveCloudflared(pid int) bool {
 	defer cancel()
 
 	if runtime.GOOS == "windows" {
-		out, err := exec.CommandContext(ctx, "tasklist",
+		out, err := aoprocess.CommandContext(ctx, "tasklist",
 			"/FI", "PID eq "+strconv.Itoa(pid), "/NH", "/FO", "CSV").Output()
 		if err != nil {
 			return false
@@ -38,7 +39,7 @@ func IsLiveCloudflared(pid int) bool {
 		return strings.Contains(strings.ToLower(string(out)), "cloudflared")
 	}
 
-	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	out, err := aoprocess.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
 	if err != nil {
 		return false // no such process, or ps unavailable
 	}
@@ -53,7 +54,7 @@ func KillProcess(pid int) error {
 		defer cancel()
 		// Windows has no signals; /T takes the child tree with it, which
 		// matters because cloudflared may have spawned helpers.
-		return exec.CommandContext(ctx, "taskkill", "/PID", strconv.Itoa(pid), "/T", "/F").Run()
+		return aoprocess.CommandContext(ctx, "taskkill", "/PID", strconv.Itoa(pid), "/T", "/F").Run()
 	}
 	p, err := os.FindProcess(pid)
 	if err != nil {

--- a/backend/internal/mobilebridge/tunnel.go
+++ b/backend/internal/mobilebridge/tunnel.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // The hostname of a quick tunnel is only ever available by scraping
@@ -205,7 +207,7 @@ func LocalCloudflaredLookup(dataDir string) CloudflaredLookup {
 		Version: func(p string) (CloudflaredVersion, bool) {
 			ctx, cancel := context.WithTimeout(context.Background(), cloudflaredVersionTimeout)
 			defer cancel()
-			out, err := exec.CommandContext(ctx, p, "--version").CombinedOutput()
+			out, err := aoprocess.CommandContext(ctx, p, "--version").CombinedOutput()
 			if err != nil {
 				return CloudflaredVersion{}, false
 			}

--- a/backend/internal/mobilebridge/tunnel_runner.go
+++ b/backend/internal/mobilebridge/tunnel_runner.go
@@ -8,8 +8,9 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"os/exec"
 	"time"
+
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // TunnelRunner supervises one managed cloudflared connector: spawn, stream its
@@ -69,7 +70,7 @@ func (t *TunnelRunner) runOnce(ctx context.Context) error {
 		return fmt.Errorf("reserve metrics port: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, t.Binary, CloudflaredArgs(t.LocalPort, metricsPort)...)
+	cmd := aoprocess.CommandContext(ctx, t.Binary, CloudflaredArgs(t.LocalPort, metricsPort)...)
 	// cloudflared logs to stderr; the hostname is only available there.
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/backend/internal/mobilebridge/tunnel_windows_test.go
+++ b/backend/internal/mobilebridge/tunnel_windows_test.go
@@ -1,0 +1,135 @@
+//go:build windows
+
+package mobilebridge
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// Run the test executable as a console-subsystem cloudflared stand-in so the
+// production discovery and runner paths can be checked without network access.
+func TestMain(m *testing.M) {
+	if report := os.Getenv("AO_TEST_CLOUDFLARED_CONSOLE"); report != "" {
+		console, _, _ := windows.NewLazySystemDLL("kernel32.dll").NewProc("GetConsoleWindow").Call()
+		if err := os.WriteFile(report, []byte(strconv.FormatUint(uint64(console), 10)), 0o600); err != nil {
+			os.Exit(2)
+		}
+		if len(os.Args) == 2 && os.Args[1] == "--version" {
+			fmt.Println("cloudflared version 2026.7.2")
+			os.Exit(0)
+		}
+		if len(os.Args) > 1 && os.Args[1] == "tunnel" {
+			fmt.Fprintln(os.Stderr, cloudflaredStartup)
+			for {
+				time.Sleep(time.Second)
+			}
+		}
+		os.Exit(2)
+	}
+	os.Exit(m.Run())
+}
+
+func TestCloudflaredVersionHasNoConsole(t *testing.T) {
+	if runInDetachedProcess(t) {
+		return
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(t.TempDir(), "console")
+	t.Setenv("AO_TEST_CLOUDFLARED_CONSOLE", report)
+	version, ok := LocalCloudflaredLookup(t.TempDir()).Version(binary)
+	if !ok || version != (CloudflaredVersion{2026, 7, 2}) {
+		t.Fatalf("version = %+v, ok = %v", version, ok)
+	}
+	assertNoCloudflaredConsole(t, report)
+}
+
+func TestCloudflaredRunnerHasNoConsoleAndStops(t *testing.T) {
+	if runInDetachedProcess(t) {
+		return
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	report := filepath.Join(dir, "console")
+	t.Setenv("AO_TEST_CLOUDFLARED_CONSOLE", report)
+	runner := &TunnelRunner{
+		Binary: binary, LocalPort: 3002, PIDPath: filepath.Join(dir, "tunnel.pid"),
+		Runtime: &TunnelRuntime{}, SettleDelay: time.Millisecond,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	done := make(chan error, 1)
+	go func() { done <- runner.runOnce(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("cloudflared did not stop after cancellation")
+		}
+		if runner.Runtime.Snapshot().Running {
+			t.Error("stopped cloudflared is still reported as running")
+		}
+		if _, ok := ReadTunnelPID(runner.PIDPath); ok {
+			t.Error("stopped cloudflared left its PID record behind")
+		}
+	})
+	for runner.Runtime.Endpoint() == nil {
+		select {
+		case <-ctx.Done():
+			t.Fatal("cloudflared did not become ready")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if _, ok := ReadTunnelPID(runner.PIDPath); !ok {
+		t.Fatal("running cloudflared has no PID record")
+	}
+	assertNoCloudflaredConsole(t, report)
+}
+
+// Electron starts the daemon detached. Reproduce that parent process state:
+// an ordinary go test console can otherwise mask the unwanted window.
+func runInDetachedProcess(t *testing.T) bool {
+	t.Helper()
+	if os.Getenv("AO_TEST_DETACHED_TUNNEL") == "1" {
+		return false
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, "-test.run=^"+t.Name()+"$", "-test.v")
+	cmd.Env = append(os.Environ(), "AO_TEST_DETACHED_TUNNEL=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.DETACHED_PROCESS}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("detached daemon test: %v\n%s", err, output)
+	}
+	return true
+}
+
+func assertNoCloudflaredConsole(t *testing.T, report string) {
+	t.Helper()
+	data, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "0" {
+		t.Fatalf("cloudflared has console window handle %s; want no console", data)
+	}
+}


### PR DESCRIPTION
Starting or restoring a Connect Mobile tunnel on Windows opens a standalone cloudflared terminal over the desktop app. The daemon is detached, and the tunnel commands used plain process creation without the Windows console suppression already provided by the shared process helper.

Use that helper for the connector, version probe, and stale-process inspection/cleanup. Add Windows regression tests that launch from a detached parent, assert the child has no console, and verify readiness, cancellation, and PID-file cleanup. Run the tunnel tests in Windows CI.

Hosted CI: all 13 checks passed on commit 7a0ccb6e5, including the full Go race suite, frontend suite, Windows tunnel regression step, native CLI E2E on Windows/macOS/Linux, renderer smoke, container install, lint, generated-file checks, and secret scan.

Validation:
- Both new console tests reproduced the bug before the fix and pass afterward, including with the race detector.
- `go test -race -run 'Cloudflared|Tunnel|Command' ./internal/mobilebridge/ ./internal/process/` passed on Windows.
- Real Windows desktop: startup and mobile disable/re-enable created no terminal popup; disabling removed the connector process and advertised endpoint.
- Real cloudflared: tunnel identity matched the local host; authenticated project access returned 200 and unauthenticated access returned 401.
- Phone verification: paired with the desktop QR, disabled Wi-Fi, and successfully connected and loaded projects over cellular.
- Backend build, frontend/E2E typechecks, shared UI and cloud-client checks, landing icons, and API/SQL regeneration checks passed.

Local validation limitations: the full Windows Go race run completed with existing Unix syscall, path/permission, and other platform-specific failures outside this change; local lint also reports unrelated Windows/line-ending findings. The CLI E2E run fails on an existing temporary-directory file lock during cleanup. The full frontend rerun, with CI dependencies installed, completed with 4,102 passing tests and 54 failures in unchanged Windows/platform-sensitive tests. Linux and macOS runners, Docker-based fresh-install/renderer/secret checks, and native macOS helper checks were unavailable locally and were verified successfully in hosted CI. No generated-file drift is included.


