### PR TITLE
fix(updater): clear stale remembered build when automatic checks keep failing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Desktop version floor: force-update lever that can block every user's app.
+# Changes require approval from the repo owner or the desktop maintainer.
+/desktop-version-floor.json @AgentWrapper @Pulkit7070

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Desktop version floor: force-update lever that can block every user's app.
 # Changes require approval from the repo owner or the desktop maintainer.
-/desktop-version-floor.json @AgentWrapper @Pulkit7070
+/desktop-version-floor.json @AgentWrapper @Pulkit7070 @illegalcall

--- a/.github/workflows/version-floor-guard.yml
+++ b/.github/workflows/version-floor-guard.yml
@@ -1,0 +1,56 @@
+name: Version Floor Guard
+on:
+  pull_request:
+    paths:
+      - desktop-version-floor.json
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate JSON structure
+        run: |
+          node -e "
+            const fs = require('fs');
+            const floor = JSON.parse(fs.readFileSync('desktop-version-floor.json', 'utf8'));
+
+            const allowed = new Set(['min', 'latest', 'downloadUrl']);
+            const extra = Object.keys(floor).filter(k => !allowed.has(k));
+            if (extra.length) {
+              console.error('ERROR: unexpected keys:', extra.join(', '));
+              process.exit(1);
+            }
+
+            for (const key of ['min', 'latest']) {
+              const v = floor[key];
+              if (v === undefined || v === '') continue;
+              if (typeof v !== 'string') {
+                console.error('ERROR:', key, 'must be a string, got', typeof v);
+                process.exit(1);
+              }
+              if (!/^\d{1,4}(\.\d{1,4}){1,3}$/.test(v)) {
+                console.error('ERROR:', key, 'is not a valid dotted version:', v);
+                process.exit(1);
+              }
+            }
+
+            if (floor.min && floor.min !== '') {
+              console.log('');
+              console.log('========================================');
+              console.log('WARNING: min is set to', floor.min);
+              console.log('This will BLOCK every desktop user below this version.');
+              console.log('They will see a forced quit dialog on next launch.');
+              console.log('Make sure this is intentional.');
+              console.log('========================================');
+              console.log('');
+            }
+
+            if (floor.latest && floor.latest !== '') {
+              console.log('NOTE: latest is set to', floor.latest);
+              console.log('Users below this will see a dismissible update nudge.');
+            }
+
+            console.log('Validation passed.');
+          "

--- a/desktop-version-floor.json
+++ b/desktop-version-floor.json
@@ -1,0 +1,5 @@
+{
+  "min": "",
+  "latest": "",
+  "downloadUrl": "https://github.com/Untrivial-ai/agent-orchestrator/releases/latest"
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2562,6 +2562,12 @@ async function writeAppStateOnLaunch(): Promise<void> {
 }
 
 app.whenReady().then(async () => {
+	if (app.isPackaged) {
+		const { checkDesktopVersionFloor } = await import("./main/desktop-version-floor");
+		await checkDesktopVersionFloor().catch((err) =>
+			console.warn("desktop version floor check failed:", err),
+		);
+	}
 	void refreshGitHubOwners();
 	const visibilityKillSwitched = (process.env.AO_TELEMETRY_DISABLED_EVENTS ?? "").split(",").some((name) => name.trim() === "ao.agent_switch.visibility_failure");
 	// The approved release gate is intentionally closed. Tests inject the

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1166,6 +1166,67 @@ describe("startAutoUpdates", () => {
     expect(module.getUpdateStatus().checksFailing).toBeUndefined();
   });
 
+  it("clears a remembered macOS build once automatic checks exhaust the threshold", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const restore = stubProcess("darwin", "/usr/bin/node");
+    try {
+      writeFileSync(nodePath.join(stateDir, "staged-update.json"), JSON.stringify({
+        version: "2.1.0", stagedAt: Date.now(), channel: "latest",
+      }));
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater(
+        { enabled: true, channel: "latest", nightlyAck: false, feature: null },
+      );
+      autoUpdater.checkForUpdates.mockImplementation(() => {
+        updaterEvents.get("error")?.(new Error("HttpError: 404 latest-mac.yml"));
+        return Promise.resolve();
+      });
+      await module.startAutoUpdates(stateDir);
+      expect(module.getUpdateStatus().staged?.version).toBe("2.1.0");
+      await module.startAutoUpdates(stateDir);
+      expect(module.getUpdateStatus().staged?.version).toBe("2.1.0");
+      await module.startAutoUpdates(stateDir);
+      expect(module.getUpdateStatus().staged).toBeUndefined();
+      // The file deletion is async (fire-and-forget queue); give it a tick.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(existsSync(nodePath.join(stateDir, "staged-update.json"))).toBe(false);
+    } finally { restore(); }
+  });
+
+  it("does not clear a remembered build on non-darwin platforms", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    writeFileSync(nodePath.join(stateDir, "staged-update.json"), JSON.stringify({
+      version: "2.1.0", stagedAt: Date.now(), channel: "latest",
+    }));
+    const { module, autoUpdater, updaterEvents } = await importAutoUpdater(
+      { enabled: true, channel: "latest", nightlyAck: false, feature: null },
+    );
+    autoUpdater.checkForUpdates.mockImplementation(() => {
+      updaterEvents.get("error")?.(new Error("HttpError: 404 latest-mac.yml"));
+      return Promise.resolve();
+    });
+    for (let i = 0; i < 4; i += 1) await module.startAutoUpdates(stateDir);
+    expect(module.getUpdateStatus().staged?.version).toBe("2.1.0");
+  });
+
+  it("keeps a current-process staged build even when checks fail", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const restore = stubProcess("darwin", "/usr/bin/node");
+    try {
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater(
+        { enabled: true, channel: "latest", nightlyAck: false, feature: null },
+      );
+      await module.startAutoUpdates(stateDir);
+      updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+      autoUpdater.checkForUpdates.mockImplementation(() => {
+        updaterEvents.get("error")?.(new Error("HttpError: 404 latest-mac.yml"));
+        return Promise.resolve();
+      });
+      for (let i = 0; i < 4; i += 1) await module.startAutoUpdates(stateDir);
+      expect(module.getUpdateStatus().staged?.version).toBe("2.1.0");
+    } finally { restore(); }
+  });
+
   it("does not overwrite a newer staged escalation when an automatic check fails", async () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1193,8 +1193,9 @@ describe("startAutoUpdates", () => {
     } finally { restore(); }
   });
 
-  it("does not clear a remembered build on non-darwin platforms", async () => {
+  it("clears a remembered build on non-darwin platforms too", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
     writeFileSync(nodePath.join(stateDir, "staged-update.json"), JSON.stringify({
       version: "2.1.0", stagedAt: Date.now(), channel: "latest",
     }));
@@ -1202,11 +1203,14 @@ describe("startAutoUpdates", () => {
       { enabled: true, channel: "latest", nightlyAck: false, feature: null },
     );
     autoUpdater.checkForUpdates.mockImplementation(() => {
-      updaterEvents.get("error")?.(new Error("HttpError: 404 latest-mac.yml"));
+      updaterEvents.get("error")?.(new Error("HttpError: 404 latest.yml"));
       return Promise.resolve();
     });
-    for (let i = 0; i < 4; i += 1) await module.startAutoUpdates(stateDir);
+    await module.startAutoUpdates(stateDir);
+    await module.startAutoUpdates(stateDir);
     expect(module.getUpdateStatus().staged?.version).toBe("2.1.0");
+    await module.startAutoUpdates(stateDir);
+    expect(module.getUpdateStatus().staged).toBeUndefined();
   });
 
   it("keeps a current-process staged build even when checks fail", async () => {
@@ -3213,6 +3217,35 @@ describe("quitAndInstallUpdate", () => {
       const { module, autoUpdater } = await importAutoUpdater();
       await module.checkForUpdatesNow(stateDir);
       await expect(module.quitAndInstallUpdate()).rejects.toThrow(/not ready/);
+      expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+    } finally { restore(); }
+  });
+
+  it.each(["win32", "linux"] as const)("re-downloads a remembered build before install on %s", async (platform) => {
+    const restore = stubProcess(platform, "/usr/bin/node");
+    try {
+      writeFileSync(nodePath.join(stateDir, "staged-update.json"), JSON.stringify({ version: "2.1.0", stagedAt: Date.now(), channel: "latest" }));
+      const { module, autoUpdater, updaterEvents } = await importAutoUpdater();
+      await module.startAutoUpdates(stateDir);
+      autoUpdater.checkForUpdates.mockResolvedValue({ isUpdateAvailable: true, updateInfo: { version: "2.1.0" } });
+      autoUpdater.downloadUpdate.mockImplementation(async () => {
+        updaterEvents.get("update-downloaded")?.({ version: "2.1.0" });
+        return [];
+      });
+      await module.quitAndInstallUpdate();
+      expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    } finally { restore(); }
+  });
+
+  it.each(["win32", "linux"] as const)("throws when a remembered build is no longer available on %s", async (platform) => {
+    const restore = stubProcess(platform, "/usr/bin/node");
+    try {
+      writeFileSync(nodePath.join(stateDir, "staged-update.json"), JSON.stringify({ version: "2.1.0", stagedAt: Date.now(), channel: "latest" }));
+      const { module, autoUpdater } = await importAutoUpdater();
+      await module.startAutoUpdates(stateDir);
+      autoUpdater.checkForUpdates.mockResolvedValue({ isUpdateAvailable: false, updateInfo: { version: "2.1.0" } });
+      await expect(module.quitAndInstallUpdate()).rejects.toThrow(/no longer available/);
       expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
     } finally { restore(); }
   });

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -2275,7 +2275,9 @@ export async function quitAndInstallUpdate(confirmedVersion?: string): Promise<U
       throw new Error("The update is not ready to install. Check for updates again.");
     }
     if (!stagedInCurrentProcess) {
-      await prepareRememberedNonDarwinUpdate();
+      await runSerializedUpdaterOperation("manual-install", async () => {
+        await prepareRememberedNonDarwinUpdate();
+      });
     }
     if (confirmedVersion !== undefined && stagedVersion && confirmedVersion !== stagedVersion) {
       return { state: "confirmation-required", version: stagedVersion,

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1095,14 +1095,14 @@ function publishFailingChecks(): void {
   broadcast(lastStatus);
 }
 
-// On macOS, a build remembered from staged-update.json but never re-established
-// in the current process leaves the sidebar showing "Restart to update" for a
-// build that cannot be installed: the native updater has no handoff for it. If
+// A build remembered from staged-update.json but never re-established in the
+// current process leaves the sidebar showing "Restart to update" for a build
+// that may not be installable: on macOS the native updater has no handoff, and
+// on Windows/Linux the cached installer exe may be missing or stale. If
 // automatic checks keep failing (network down, rate limited, feed 404), the
 // self-healing re-download never happens and the button is a permanent no-op.
 // Clear the stale metadata so the UI stops advertising an uninstallable build.
 function clearUnrecoverableRememberedBuild(): void {
-  if (process.platform !== "darwin") return;
   if (stagedInCurrentProcess) return;
   if (!hasStagedBuild()) return;
   console.warn(
@@ -2274,6 +2274,9 @@ export async function quitAndInstallUpdate(confirmedVersion?: string): Promise<U
     if (!hasStagedBuild() || lastStatus.state === "downloading" || lastStatus.state === "preparing") {
       throw new Error("The update is not ready to install. Check for updates again.");
     }
+    if (!stagedInCurrentProcess) {
+      await prepareRememberedNonDarwinUpdate();
+    }
     if (confirmedVersion !== undefined && stagedVersion && confirmedVersion !== stagedVersion) {
       return { state: "confirmation-required", version: stagedVersion,
         releaseNotes: lastStatus.state === "downloaded" && lastStatus.version === stagedVersion ? lastStatus.releaseNotes : undefined };
@@ -2366,6 +2369,32 @@ async function prepareRememberedMacUpdate(confirmedVersion?: string): Promise<Up
     activeDownloadCancellation = token;
     // A cache hit re-establishes the native feed. The download promise is not
     // native readiness: waitForNativePreparation separately gates the quit.
+    await autoUpdater.downloadUpdate(token);
+  } finally {
+    restoreFeed?.();
+  }
+}
+
+// On Windows and Linux, a remembered staged build has no installer file in
+// electron-updater's in-memory state (downloadedUpdateHelper is null). Calling
+// quitAndInstall against that throws "No update filepath provided." Re-download
+// the build so the installer exe/AppImage is present before requesting install.
+async function prepareRememberedNonDarwinUpdate(): Promise<void> {
+  if (!escalationStateDir) throw new Error("Check for updates before restarting to install.");
+  const settings = await reconcileAndPersist(escalationStateDir, await readUpdateSettings(escalationStateDir));
+  configureFeed(settings);
+  autoUpdater.autoDownload = false;
+  broadcastUpdaterStatus({ state: "checking" });
+  const restoreFeed = await configureDirectPrereleaseFeed(settings);
+  try {
+    const result = await checkForUpdatesWithDeadline();
+    if (result?.isUpdateAvailable !== true) {
+      throw new Error("The remembered update is no longer available. Check for updates and try again.");
+    }
+    activeUpdaterPhase = "download";
+    pendingUpdateVersion = result.updateInfo.version;
+    const token = new CancellationToken();
+    activeDownloadCancellation = token;
     await autoUpdater.downloadUpdate(token);
   } finally {
     restoreFeed?.();

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1091,7 +1091,32 @@ function automaticChecksAreFailing(): boolean {
 function publishFailingChecks(): void {
   if (!automaticChecksAreFailing() || failingChecksPublished) return;
   failingChecksPublished = true;
+  clearUnrecoverableRememberedBuild();
   broadcast(lastStatus);
+}
+
+// On macOS, a build remembered from staged-update.json but never re-established
+// in the current process leaves the sidebar showing "Restart to update" for a
+// build that cannot be installed: the native updater has no handoff for it. If
+// automatic checks keep failing (network down, rate limited, feed 404), the
+// self-healing re-download never happens and the button is a permanent no-op.
+// Clear the stale metadata so the UI stops advertising an uninstallable build.
+function clearUnrecoverableRememberedBuild(): void {
+  if (process.platform !== "darwin") return;
+  if (stagedInCurrentProcess) return;
+  if (!hasStagedBuild()) return;
+  console.warn(
+    "clearing remembered staged build %s: automatic checks have failed %d times without re-establishing native readiness",
+    stagedVersion,
+    consecutiveAutomaticCheckFailures,
+  );
+  forgetPersistedStagedBuild(escalationStateDir);
+  stagedVersion = undefined;
+  stagedAtMs = undefined;
+  stagedChannel = undefined;
+  stagedEscalated = false;
+  stagedRequestId = undefined;
+  stopEscalationTimer();
 }
 
 // errorMessage extracts the user-facing message for an update error status,

--- a/frontend/src/main/desktop-version-floor.test.ts
+++ b/frontend/src/main/desktop-version-floor.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("checkDesktopVersionFloor", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function importModule(options: {
+    isPackaged?: boolean;
+    version?: string;
+    floor?: { min?: string; latest?: string; downloadUrl?: string };
+    fetchError?: boolean;
+    fetchStatus?: number;
+  } = {}) {
+    const dialog = { showMessageBox: vi.fn(() => Promise.resolve({ response: 1 })) };
+    const shellMock = { openExternal: vi.fn(() => Promise.resolve()) };
+    const quit = vi.fn();
+    vi.doMock("electron", () => ({
+      app: {
+        isPackaged: options.isPackaged ?? true,
+        getVersion: () => options.version ?? "0.12.12",
+        quit,
+      },
+      dialog,
+      shell: shellMock,
+    }));
+
+    const fetchMock = vi.fn(async () => {
+      if (options.fetchError) throw new Error("network error");
+      return {
+        ok: (options.fetchStatus ?? 200) === 200,
+        status: options.fetchStatus ?? 200,
+        json: async () => options.floor ?? { min: "", latest: "" },
+      } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("./desktop-version-floor");
+    return { mod, dialog, shellMock, quit, fetchMock };
+  }
+
+  it("does nothing when app is not packaged", async () => {
+    const { mod, fetchMock } = await importModule({ isPackaged: false });
+    await mod.checkDesktopVersionFloor();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when floor is empty", async () => {
+    const { mod, dialog } = await importModule({ floor: { min: "", latest: "" } });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when fetch fails", async () => {
+    const { mod, dialog } = await importModule({ fetchError: true });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when fetch returns non-200", async () => {
+    const { mod, dialog } = await importModule({ fetchStatus: 404 });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when running version is at or above min", async () => {
+    const { mod, dialog } = await importModule({
+      version: "0.12.13",
+      floor: { min: "0.12.13" },
+    });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("shows a blocking dialog and quits when below min", async () => {
+    const { mod, dialog, quit } = await importModule({
+      version: "0.12.12",
+      floor: { min: "0.12.13" },
+    });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "warning",
+        title: "Update Required",
+      }),
+    );
+    expect(quit).toHaveBeenCalled();
+  });
+
+  it("opens the download URL when user clicks Download on required update", async () => {
+    const { mod, dialog, shellMock, quit } = await importModule({
+      version: "0.12.12",
+      floor: { min: "0.12.13", downloadUrl: "https://example.com/releases" },
+    });
+    dialog.showMessageBox.mockResolvedValue({ response: 0 });
+    await mod.checkDesktopVersionFloor();
+    expect(shellMock.openExternal).toHaveBeenCalledWith("https://example.com/releases");
+    expect(quit).toHaveBeenCalled();
+  });
+
+  it("shows a dismissible dialog when below latest but at or above min", async () => {
+    const { mod, dialog, quit } = await importModule({
+      version: "0.12.12",
+      floor: { min: "0.12.11", latest: "0.12.13" },
+    });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        title: "Update Available",
+      }),
+    );
+    expect(quit).not.toHaveBeenCalled();
+  });
+
+  it("does not show the latest nudge when at or above latest", async () => {
+    const { mod, dialog } = await importModule({
+      version: "0.12.14",
+      floor: { latest: "0.12.13" },
+    });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed version strings in the floor", async () => {
+    const { mod, dialog } = await importModule({
+      version: "0.12.12",
+      floor: { min: "not-a-version", latest: "also bad" },
+    });
+    await mod.checkDesktopVersionFloor();
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/main/desktop-version-floor.test.ts
+++ b/frontend/src/main/desktop-version-floor.test.ts
@@ -92,11 +92,11 @@ describe("checkDesktopVersionFloor", () => {
   it("opens the download URL when user clicks Download on required update", async () => {
     const { mod, dialog, shellMock, quit } = await importModule({
       version: "0.12.12",
-      floor: { min: "0.12.13", downloadUrl: "https://example.com/releases" },
+      floor: { min: "0.12.13", downloadUrl: "https://github.com/Untrivial-ai/agent-orchestrator/releases/tag/v0.12.13" },
     });
     dialog.showMessageBox.mockResolvedValue({ response: 0 });
     await mod.checkDesktopVersionFloor();
-    expect(shellMock.openExternal).toHaveBeenCalledWith("https://example.com/releases");
+    expect(shellMock.openExternal).toHaveBeenCalledWith("https://github.com/Untrivial-ai/agent-orchestrator/releases/tag/v0.12.13");
     expect(quit).toHaveBeenCalled();
   });
 

--- a/frontend/src/main/desktop-version-floor.ts
+++ b/frontend/src/main/desktop-version-floor.ts
@@ -1,0 +1,92 @@
+import { app, dialog, shell } from "electron";
+import semver from "semver";
+
+const FLOOR_URL =
+  "https://raw.githubusercontent.com/Untrivial-ai/agent-orchestrator/main/desktop-version-floor.json";
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+type Floor = {
+  min?: string;
+  latest?: string;
+  downloadUrl?: string;
+};
+
+const DEFAULT_DOWNLOAD_URL =
+  "https://github.com/Untrivial-ai/agent-orchestrator/releases/latest";
+
+function usableVersion(v: string | null | undefined): string | null {
+  const trimmed = v?.trim();
+  return trimmed && /^\d{1,4}(\.\d{1,4}){0,3}(-[a-zA-Z0-9.]+)?$/.test(trimmed)
+    ? trimmed
+    : null;
+}
+
+function isBelow(running: string, floor: string): boolean {
+  const r = semver.valid(semver.coerce(running));
+  const f = semver.valid(semver.coerce(floor));
+  if (!r || !f) return false;
+  return semver.lt(r, f);
+}
+
+export async function checkDesktopVersionFloor(): Promise<void> {
+  if (!app.isPackaged) return;
+  let floor: Floor;
+  try {
+    const response = await fetch(FLOOR_URL, {
+      cache: "no-store",
+      headers: {
+        "User-Agent": `ao-desktop/${app.getVersion()}`,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return;
+    floor = (await response.json()) as Floor;
+  } catch {
+    return;
+  }
+
+  const running = app.getVersion();
+  const downloadUrl = floor.downloadUrl || DEFAULT_DOWNLOAD_URL;
+  const minVersion = usableVersion(floor.min);
+  const latestVersion = usableVersion(floor.latest);
+
+  if (minVersion && isBelow(running, minVersion)) {
+    const result = await dialog.showMessageBox({
+      type: "warning",
+      buttons: ["Download Update", "Quit"],
+      defaultId: 0,
+      cancelId: 1,
+      title: "Update Required",
+      message: `Agent Orchestrator v${running} is no longer supported.`,
+      detail:
+        `Version ${minVersion} or later is required. ` +
+        "Download the latest release to continue using the app.",
+      noLink: true,
+    });
+    if (result.response === 0) {
+      void shell.openExternal(downloadUrl);
+    }
+    app.quit();
+    return;
+  }
+
+  if (latestVersion && isBelow(running, latestVersion)) {
+    const result = await dialog.showMessageBox({
+      type: "info",
+      buttons: ["Download Update", "Later"],
+      defaultId: 0,
+      cancelId: 1,
+      title: "Update Available",
+      message: "A newer version of Agent Orchestrator is available.",
+      detail:
+        `You are on v${running}. Version ${latestVersion} is recommended. ` +
+        "You can update now or continue using the current version.",
+      noLink: true,
+    });
+    if (result.response === 0) {
+      void shell.openExternal(downloadUrl);
+    }
+  }
+}

--- a/frontend/src/main/desktop-version-floor.ts
+++ b/frontend/src/main/desktop-version-floor.ts
@@ -48,7 +48,8 @@ export async function checkDesktopVersionFloor(): Promise<void> {
   }
 
   const running = app.getVersion();
-  const downloadUrl = floor.downloadUrl || DEFAULT_DOWNLOAD_URL;
+  const rawUrl = floor.downloadUrl || DEFAULT_DOWNLOAD_URL;
+  const downloadUrl = rawUrl.startsWith("https://github.com/") ? rawUrl : DEFAULT_DOWNLOAD_URL;
   const minVersion = usableVersion(floor.min);
   const latestVersion = usableVersion(floor.latest);
 


### PR DESCRIPTION
## Summary
- **Stale build health check (all platforms):** When `staged-update.json` outlives the process that created it and automatic checks fail 3+ times, clears the stale metadata so the sidebar stops showing "Restart to update" for a build that can't be installed.
- **Windows/Linux re-download:** On non-darwin, a remembered staged build has no installer file in electron-updater's in-memory state. Calling `quitAndInstall` throws "No update filepath provided." Now re-downloads the build (serialized through the operation queue) before requesting install.
- **Desktop version floor:** On startup, fetches `desktop-version-floor.json` from the main branch. `min` = blocking dialog + quit (force update). `latest` = dismissible nudge. Download URL pinned to `github.com`. Operators bump the JSON in one commit to remotely gate stuck users.
- **Access controls:** CODEOWNERS requires approval from @AgentWrapper, @Pulkit7070, or @illegalcall for floor changes. CI workflow validates JSON structure and warns when `min` is set.

## Test plan
- [x] `npx vitest run src/main/auto-updater.test.ts` (172 pass)
- [x] `npx vitest run src/main/desktop-version-floor.test.ts` (10 pass)
- [ ] On macOS: write a `staged-update.json` for a version that doesn't exist on the feed, start AO, verify the sidebar clears "Restart to update" after 3 automatic check cycles
- [ ] On Windows: same scenario, verify "No update filepath provided" no longer appears when clicking Restart & install
- [ ] Set `min` in `desktop-version-floor.json` to a version above the running one, verify the blocking dialog appears on launch

Fixes https://github.com/Untrivial-ai/agent-orchestrator/issues/5062