### PR TITLE
feat(ui): inherit Omarchy theme palette

### DIFF
--- a/docs/features/omarchy-theme.md
+++ b/docs/features/omarchy-theme.md
@@ -1,0 +1,32 @@
+# Omarchy theme inheritance
+
+In Settings → Appearance, choose **Automatic (Omarchy)** as the color theme and
+**System** as the appearance. Automatic is the default when no color theme has
+been saved. Existing named color themes (including Orchestrate) and explicit
+Light/Dark preferences are preserved. Automatic with an explicit appearance
+uses Orchestrate in that appearance.
+
+On Linux, Electron main reads `~/.local/state/omarchy/current/theme/colors.toml`,
+with `~/.config/omarchy/current/theme/colors.toml` as the legacy location when
+the current location is absent. AO checks again every two seconds while the
+shell is mounted, following file edits, active symlink replacement, removal,
+and recovery. No Omarchy hook or OS configuration change is needed.
+
+The reader accepts only an allowlisted set of quoted six-digit hex colors,
+with a 16 KiB limit and regular-file checks. It never evaluates TOML expressions,
+CSS, scripts, or commands. Filesystem access stays in Electron main; preload
+returns only normalized palette data. Missing, unreadable, incomplete, oversized,
+or invalid palettes fall back to AO's existing System/Orchestrate behavior.
+
+Application surfaces use the palette's background, panel/sidebar shades, and
+accent through existing tokens. Foregrounds are adjusted when necessary for
+readable controls and menus. Terminals receive the palette's background,
+foreground, cursor, selection, and ANSI slots through existing xterm plumbing,
+without losing scrollback. Palette brightness determines light/dark appearance.
+Agent TUIs that draw their own true-color UI and embedded web content retain
+control of their own colors; AO does not inject styles into them.
+
+Implementation plan: keep discovery/validation in Electron main; expose a typed
+preload read; add Automatic to existing preferences without migrating saved
+choices; refresh shared surface/terminal tokens; verify parser failures, active
+link replacement, preference precedence, live terminal updates, and menu contrast.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,3 +1,4 @@
+import { readOmarchyPalette } from "./main/omarchy-theme";
 import { finishUpdateQuit } from "./main/update-quit";
 import { acknowledgeMacUpdateRestart } from "./main/mac-update-progress";
 import {
@@ -1905,6 +1906,8 @@ ipcMain.handle("window:isMaximized", () => mainWindow?.isMaximized() ?? false);
 // preview WebContentsViews (which follow prefers-color-scheme) flip in step with
 // the shell. The three preference values map 1:1 onto themeSource; "system" keeps
 // both the preview and the shell's own matchMedia following the OS.
+ipcMain.handle("theme:omarchy", () => readOmarchyPalette());
+
 ipcMain.handle("theme:set", (_event, preference: "light" | "dark" | "system") => {
 	if (preference === "light" || preference === "dark" || preference === "system") {
 		nativeTheme.themeSource = preference;

--- a/frontend/src/main/omarchy-theme.test.ts
+++ b/frontend/src/main/omarchy-theme.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, rename, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { MAX_PALETTE_BYTES, parseOmarchyPalette, readOmarchyPalette } from "./omarchy-theme";
+
+const palette = `background = "#1d150f"
+foreground = "#e3ddd0"
+accent = "#d4b24a"
+selection = "#4d3e23"
+red = "#f25107"
+green = "#9fae4a"
+yellow = "#c9ae4b"
+blue = "#d1a86a"
+magenta = "#c97a5a"
+cyan = "#9bb8a8"`;
+
+describe("Omarchy palette boundary", () => {
+	it("reads the installed semantic format and optional ANSI overrides", () => {
+		const result = parseOmarchyPalette(palette + '\ncolor0 = "#123ABC"');
+		expect(result?.background).toBe("#1d150f");
+		expect(result?.ansi).toHaveLength(16);
+		expect(result?.ansi[0]).toBe("#1d150f");
+		expect(result?.ansi[9]).toBe("#f57439");
+	});
+	it("reads legacy numbered palettes", () => {
+		const source = 'background="#111111"\nforeground="#eeeeee"\naccent="#abcdef"\n'
+			+ Array.from({ length: 16 }, (_, i) => `color${i}="#123456"`).join("\n");
+		expect(parseOmarchyPalette(source)?.ansi).toEqual(["#111111", ...Array(6).fill("#123456"), "#eeeeee", ...Array(8).fill("#123456")]);
+	});
+	it.each([
+		palette.replace('#1d150f', 'red; background: url(https://example.com)'),
+		palette + '\naccent = "#ffffff"',
+		palette.replace('accent = "#d4b24a"', ''),
+		palette + ' '.repeat(MAX_PALETTE_BYTES),
+	])("rejects invalid, duplicate, missing and oversized color data", (source) => {
+		expect(parseOmarchyPalette(source)).toBeNull();
+	});
+	it("ignores non-color data without evaluating it", () => {
+		expect(parseOmarchyPalette(palette + '\nscript = "$(touch /tmp/no)"\n__proto__ = "bad"')).toEqual(parseOmarchyPalette(palette));
+	});
+	it("follows active-link replacement, invalidation, removal and recovery", async () => {
+		const dir = await mkdtemp(path.join(os.tmpdir(), "ao-omarchy-"));
+		try {
+			for (const name of ["one", "two"]) await mkdir(path.join(dir, name));
+			await writeFile(path.join(dir, "one/colors.toml"), palette);
+			await writeFile(path.join(dir, "two/colors.toml"), palette.replace("#1d150f", "#eeeeee"));
+			const active = path.join(dir, "active");
+			const files = [path.join(active, "colors.toml")];
+			await symlink(path.join(dir, "one"), active);
+			expect((await readOmarchyPalette(files, "linux"))?.background).toBe("#1d150f");
+			await symlink(path.join(dir, "two"), path.join(dir, "next"));
+			await rename(path.join(dir, "next"), active);
+			expect((await readOmarchyPalette(files, "linux"))?.background).toBe("#eeeeee");
+			await writeFile(files[0], "invalid");
+			expect(await readOmarchyPalette(files, "linux")).toBeNull();
+			await rm(active);
+			expect(await readOmarchyPalette(files, "linux")).toBeNull();
+			await symlink(path.join(dir, "one"), active);
+			expect(await readOmarchyPalette(files, "linux")).not.toBeNull();
+			expect(await readOmarchyPalette(files, "darwin")).toBeNull();
+			expect(await readOmarchyPalette([dir], "linux")).toBeNull();
+		} finally { await rm(dir, { recursive: true, force: true }); }
+	});
+});

--- a/frontend/src/main/omarchy-theme.ts
+++ b/frontend/src/main/omarchy-theme.ts
@@ -1,0 +1,78 @@
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OmarchyPalette } from "../shared/omarchy-theme";
+
+export const MAX_PALETTE_BYTES = 16 * 1024;
+const ansiNames = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"];
+const keys = new Set([
+	"background", "foreground", "accent", "cursor", "selection", "selection_background",
+	"dark_background", "lighter_background", "dark_foreground", "bright_foreground", "muted", "purple", "bright_purple",
+	"bg", "fg", "dark_fg", "bright_fg",
+	...ansiNames, ...ansiNames.map((name) => `bright_${name}`),
+	...Array.from({ length: 16 }, (_, i) => `color${i}`),
+]);
+
+/** Deliberately a flat color subset, not a TOML/CSS interpreter. */
+export function parseOmarchyPalette(source: string): OmarchyPalette | null {
+	if (Buffer.byteLength(source) > MAX_PALETTE_BYTES) return null;
+	const colors: Record<string, string> = Object.create(null);
+	for (const line of source.split(/\r?\n/)) {
+		const key = /^\s*([a-z_0-9]+)\s*=/.exec(line)?.[1];
+		if (!key || !keys.has(key)) continue;
+		const match = /^\s*[a-z_0-9]+\s*=\s*(["'])(#[0-9a-fA-F]{6})\1\s*(?:#.*)?$/.exec(line);
+		if (!match || colors[key]) return null;
+		colors[key] = match[2].toLowerCase();
+	}
+	const background = colors.background ?? colors.bg ?? colors.color0;
+	const foreground = colors.foreground ?? colors.fg ?? colors.color7;
+	const accent = colors.accent;
+	if (!background || !foreground || !accent) return null;
+	const brightForeground = colors.bright_foreground ?? colors.bright_fg ?? colors.color15 ?? foreground;
+	const ansi = Array.from({ length: 16 }, (_, i) => {
+		if (i === 0) return background;
+		if (i === 7) return foreground;
+		if (i === 8) return colors.color8 ?? colors.muted ?? colors.dark_foreground ?? colors.dark_fg ?? foreground;
+		if (i === 15) return colors.color15 ?? brightForeground;
+		const name = ansiNames[i % 8];
+		const base = colors[name] ?? (name === "magenta" ? colors.purple : undefined) ?? colors[`color${i % 8}`];
+		if (!base) return "";
+		return colors[`color${i}`] ?? (i < 8 ? base : colors[`bright_${name}`]
+			?? (name === "magenta" ? colors.bright_purple : undefined) ?? brighten(base));
+	});
+	if (ansi.some((color) => !color)) return null;
+	return { background, foreground, accent, ansi, surface: colors.lighter_background, sidebar: colors.dark_background, cursor: colors.cursor ?? brightForeground,
+		selection: colors.selection_background ?? colors.selection ?? colors.color8 ?? background };
+}
+
+function brighten(color: string): string {
+	return "#" + [1, 3, 5].map((offset) => Math.round(Number.parseInt(color.slice(offset, offset + 2), 16) * 0.8 + 255 * 0.2).toString(16).padStart(2, "0")).join("");
+}
+
+export function omarchyPalettePaths(home = os.homedir()): string[] {
+	return [path.join(home, ".local/state/omarchy/current/theme/colors.toml"),
+		path.join(home, ".config/omarchy/current/theme/colors.toml")];
+}
+
+export async function readOmarchyPalette(paths = omarchyPalettePaths(), platform = process.platform): Promise<OmarchyPalette | null> {
+	if (platform !== "linux") return null;
+	for (const filename of paths) {
+		let file;
+		try {
+			// NONBLOCK prevents a substituted FIFO from hanging Electron. Symlinks
+			// are intentional: Omarchy atomically replaces its active theme link.
+			file = await open(filename, constants.O_RDONLY | constants.O_NONBLOCK);
+			const stat = await file.stat();
+			if (!stat.isFile() || stat.size > MAX_PALETTE_BYTES) return null;
+			const buffer = Buffer.alloc(MAX_PALETTE_BYTES + 1);
+			const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+			return parseOmarchyPalette(buffer.subarray(0, bytesRead).toString("utf8"));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") return null;
+		} finally {
+			await file?.close();
+		}
+	}
+	return null;
+}

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -1,3 +1,4 @@
+import type { OmarchyPalette } from "./shared/omarchy-theme";
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { CLOSE_SHELL_TERMINAL_SHORTCUT_CHANNEL, FOCUS_TERMINAL_SHORTCUT_CHANNEL, KEYBOARD_SHORTCUTS_HELP_CHANNEL, NEXT_SESSION_SHORTCUT_CHANNEL, NEXT_TAB_SHORTCUT_CHANNEL, NEW_SESSION_SHORTCUT_CHANNEL, NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL, OPEN_SETTINGS_SHORTCUT_CHANNEL, PREVIOUS_SESSION_SHORTCUT_CHANNEL, PREVIOUS_TAB_SHORTCUT_CHANNEL, SET_CLOSE_SHELL_TERMINAL_SHORTCUT_ENABLED_CHANNEL, SET_TERMINAL_FOCUSED_CHANNEL, TERMINAL_FONT_SIZE_SHORTCUT_CHANNEL, type KeybindingOverrides } from "./shared/shortcuts";
 import type {
@@ -306,6 +307,7 @@ const api = {
 		},
 	},
 	theme: {
+		getOmarchy: () => ipcRenderer.invoke("theme:omarchy") as Promise<OmarchyPalette | null>,
 		// Propagate the app's theme preference to Electron's nativeTheme so embedded
 		// WebContentsView previews (which follow prefers-color-scheme) stay in sync
 		// with the shell. "system" lets both follow the OS.

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -453,6 +453,35 @@ describe("XtermTerminal", () => {
 		}
 	});
 
+	it("refreshes inherited terminal colors and explicit Dark without recreating the terminal", () => {
+		const style = document.createElement("style");
+		style.textContent = ":root { --color-bg-terminal-opaque: #101317; --color-text-terminal: #d7d7d2; }";
+		document.head.appendChild(style);
+		localStorage.setItem("ao.theme", "system");
+		localStorage.setItem("ao.theme-style", "automatic");
+		useUiStore.setState({ themeStyle: "automatic", themePreference: "system" });
+		const palette = { background: "#1d150f", foreground: "#e3ddd0", accent: "#d4b24a", cursor: "#f2ede2", selection: "#4d3e23", ansi: Array(16).fill("#f25107") };
+		try {
+			useUiStore.getState().updateOmarchy(palette);
+			render(<XtermTerminal theme="dark" />);
+			const terminal = state.lastTerminal!;
+			expect(terminal.options.theme).toMatchObject({ background: palette.background, red: "#f25107" });
+			act(() => useUiStore.getState().updateOmarchy({ ...palette, ansi: Array(16).fill("#123456") }));
+			expect(terminal.options.theme).toMatchObject({ red: "#123456" });
+			act(() => useUiStore.getState().setThemePreference("dark"));
+			expect(terminal.options.theme).toMatchObject({ background: "#101317" });
+			expect(state.lastTerminal).toBe(terminal);
+		} finally {
+			style.remove();
+			localStorage.removeItem("ao.theme");
+			localStorage.removeItem("ao.theme-style");
+			act(() => {
+				useUiStore.getState().updateOmarchy(null);
+				useUiStore.setState({ themeStyle: "orchestrate", themePreference: "system" });
+			});
+		}
+	});
+
 	it("uses the terminal foreground for the light-mode block cursor", () => {
 		const style = document.createElement("style");
 		style.textContent = `

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -318,6 +318,8 @@ function configureScrollbarReservation(term: Terminal): void {
 export function XtermTerminal(props: XtermTerminalProps) {
 	const { t } = useTranslation();
 	const themeStyle = useUiStore((state) => state.themeStyle);
+	const omarchyRevision = useUiStore((state) => state.omarchyRevision);
+	const themePreference = useUiStore((state) => state.themePreference);
 	const macPlatform = isMacPlatform();
 	const shellRef = useRef<HTMLDivElement | null>(null);
 	const hostRef = useRef<HTMLDivElement | null>(null);
@@ -431,7 +433,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		const { dark, light } = buildTerminalThemes();
 		term.options.theme = props.theme === "dark" ? dark : light;
 		colorSchemeReporterRef.current?.(props.theme, themeStyle);
-	}, [props.theme, themeStyle]);
+	}, [props.theme, themeStyle, themePreference, omarchyRevision]);
 
 	useEffect(() => {
 		if (!termRef.current || !props.supportsCursorColorScheme) return;

--- a/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
+++ b/frontend/src/renderer/components/settings/GeneralSettingsSection.tsx
@@ -175,12 +175,12 @@ export function GeneralSettingsSection({
 		<>
 			{/* Appearance */}
 			<SettingsSection title={t("settings.appearance")} titleHidden={titleHidden} grouped>
-				<SettingsRow label={t("settings.theme")}>
+				<SettingsRow label={t("settings.theme")} description={t("settings.theme.automaticDescription")} className="[&>div:first-child]:max-w-[55%]">
 					<div className="flex items-center gap-1.5">
 						<SettingsOptionMenu
 							aria-label={t("settings.colorTheme")}
 							value={themeStyle}
-							options={COLOR_THEME_OPTIONS}
+							options={[{ value: "automatic", label: t("settings.theme.automatic") }, ...COLOR_THEME_OPTIONS]}
 							onChange={setThemeStyle}
 						/>
 						<SettingsOptionMenu

--- a/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
+++ b/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
@@ -129,6 +129,7 @@ export function SettingsOptionMenu<T extends string>({
 								onSelect={() => onChange(option.value)}
 								className={cn(
 									SETTINGS_MENU_ITEM,
+									"text-settings-title",
 									option.value === value && "border-settings-menu bg-settings-menu-selected text-settings-title",
 									menuItemClassName,
 								)}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1020,6 +1020,8 @@
 	"settings.theme.dark": "Dunkel",
 	"settings.theme.light": "Hell",
 	"settings.theme.system": "System",
+	"settings.theme.automatic": "Automatisch (Omarchy)",
+	"settings.theme.automaticDescription": "Automatisch folgt Omarchy bei der Darstellung System; andernfalls wird Orchestrate verwendet.",
 	"settings.title": "Einstellungen",
 	"update.restart.title": "Neu starten und aktualisieren",
 	"update.restart.whatsNew": "Neu in dieser Version",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1141,6 +1141,8 @@
 	"settings.theme.dark": "Dark",
 	"settings.theme.light": "Light",
 	"settings.theme.system": "System",
+	"settings.theme.automatic": "Automatic (Omarchy)",
+	"settings.theme.automaticDescription": "Automatic follows Omarchy with System appearance; otherwise it uses Orchestrate.",
 	"settings.title": "Settings",
 	"update.restart.title": "Restart to update",
 	"update.restart.whatsNew": "What's new",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1039,6 +1039,8 @@
 	"settings.theme.dark": "Oscuro",
 	"settings.theme.light": "Claro",
 	"settings.theme.system": "Sistema",
+	"settings.theme.automatic": "Automático (Omarchy)",
+	"settings.theme.automaticDescription": "Automático sigue Omarchy con la apariencia Sistema; en otros casos usa Orchestrate.",
 	"settings.title": "Ajustes",
 	"update.restart.title": "Reiniciar para actualizar",
 	"update.restart.whatsNew": "Novedades",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1039,6 +1039,8 @@
 	"settings.theme.dark": "Sombre",
 	"settings.theme.light": "Clair",
 	"settings.theme.system": "Système",
+	"settings.theme.automatic": "Automatique (Omarchy)",
+	"settings.theme.automaticDescription": "Automatique suit Omarchy avec l’apparence Système ; sinon, Orchestrate est utilisé.",
 	"settings.title": "Paramètres",
 	"update.restart.title": "Redémarrer pour mettre à jour",
 	"update.restart.whatsNew": "Nouveautés",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1020,6 +1020,8 @@
 	"settings.theme.dark": "ダーク",
 	"settings.theme.light": "ライト",
 	"settings.theme.system": "システム",
+	"settings.theme.automatic": "自動 (Omarchy)",
+	"settings.theme.automaticDescription": "外観が「システム」の場合、自動は Omarchy に従います。それ以外は Orchestrate を使用します。",
 	"settings.title": "設定",
 	"update.restart.title": "再起動して更新",
 	"update.restart.whatsNew": "変更内容",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1020,6 +1020,8 @@
 	"settings.theme.dark": "다크",
 	"settings.theme.light": "라이트",
 	"settings.theme.system": "시스템",
+	"settings.theme.automatic": "자동 (Omarchy)",
+	"settings.theme.automaticDescription": "시스템 모양에서는 Omarchy를 자동으로 따르며, 그 외에는 Orchestrate를 사용합니다.",
 	"settings.title": "설정",
 	"update.restart.title": "다시 시작하여 업데이트",
 	"update.restart.whatsNew": "변경 사항",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1039,6 +1039,8 @@
 	"settings.theme.dark": "Escuro",
 	"settings.theme.light": "Claro",
 	"settings.theme.system": "Sistema",
+	"settings.theme.automatic": "Automático (Omarchy)",
+	"settings.theme.automaticDescription": "Automático segue o Omarchy com a aparência Sistema; caso contrário, usa o Orchestrate.",
 	"settings.title": "Configurações",
 	"update.restart.title": "Reiniciar para atualizar",
 	"update.restart.whatsNew": "O que mudou",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1004,6 +1004,8 @@
 	"settings.theme.dark": "深色",
 	"settings.theme.light": "浅色",
 	"settings.theme.system": "跟随系统",
+	"settings.theme.automatic": "自动 (Omarchy)",
+	"settings.theme.automaticDescription": "选择系统外观时，自动跟随 Omarchy；否则使用 Orchestrate。",
 	"settings.title": "设置",
 	"update.restart.title": "重启以更新",
 	"update.restart.whatsNew": "更新内容",

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -46,6 +46,7 @@ export const aoBridge: AoBridge =
 			onFullScreen: () => () => undefined,
 		},
 		theme: {
+			getOmarchy: async () => null,
 			set: async () => undefined,
 			persistTerminal: async () => undefined,
 		},

--- a/frontend/src/renderer/lib/omarchy-store.test.ts
+++ b/frontend/src/renderer/lib/omarchy-store.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useUiStore } from "../stores/ui-store";
+const palette = { background: "#1d150f", foreground: "#e3ddd0", accent: "#d4b24a", cursor: "#d4b24a", selection: "#4d3e23", ansi: Array(16).fill("#f25107") };
+afterEach(() => {
+	localStorage.clear();
+	useUiStore.getState().updateOmarchy(null);
+	useUiStore.setState({ themeStyle: "automatic", themePreference: "system" });
+});
+describe("live Omarchy store integration", () => {
+	it("updates scheme and revision without changing stored preferences", () => {
+		const state = useUiStore.getState();
+		state.updateOmarchy(palette);
+		expect(useUiStore.getState().resolvedTheme).toBe("dark");
+		state.updateOmarchy({ ...palette, background: "#ffffff" });
+		expect(useUiStore.getState().resolvedTheme).toBe("light");
+		expect(useUiStore.getState().omarchyRevision).toBe(state.omarchyRevision + 2);
+		expect(localStorage.getItem("ao.theme")).toBeNull();
+		expect(localStorage.getItem("ao.theme-style")).toBeNull();
+	});
+	it("preserves explicit appearance and clears inherited tokens immediately", () => {
+		const state = useUiStore.getState();
+		state.updateOmarchy(palette);
+		state.setThemePreference("light");
+		expect(useUiStore.getState().resolvedTheme).toBe("light");
+		expect(document.documentElement.style.getPropertyValue("--background")).toBe("");
+		state.updateOmarchy(palette);
+		expect(useUiStore.getState().resolvedTheme).toBe("light");
+	});
+	it("restores inheritance after switching back from a named style", () => {
+		const state = useUiStore.getState();
+		state.updateOmarchy(palette);
+		state.setThemeStyle("nord");
+		expect(document.documentElement.style.getPropertyValue("--background")).toBe("");
+		state.setThemeStyle("automatic");
+		expect(document.documentElement.style.getPropertyValue("--background")).toBe(palette.background);
+		state.updateOmarchy(null);
+		expect(document.documentElement.dataset.styleTheme).toBeUndefined();
+	});
+});

--- a/frontend/src/renderer/lib/omarchy-theme.test.ts
+++ b/frontend/src/renderer/lib/omarchy-theme.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { contrast } from "../../shared/omarchy-theme";
+import { applyDocumentThemeStyle, readStoredThemeStyle, resolveTheme, setOmarchyPalette } from "./theme";
+import { buildTerminalThemes } from "./terminal-themes";
+const palette = { background: "#1d150f", foreground: "#e3ddd0", accent: "#d4b24a", cursor: "#d4b24a", selection: "#4d3e23", ansi: Array(16).fill("#f25107") };
+
+afterEach(() => { localStorage.clear(); setOmarchyPalette(null); applyDocumentThemeStyle("orchestrate"); });
+describe("automatic color style", () => {
+	it("defaults to automatic but preserves every saved explicit style", () => {
+		expect(readStoredThemeStyle()).toBe("automatic");
+		for (const style of ["orchestrate", "nord", "solarized"]) {
+			localStorage.setItem("ao.theme-style", style);
+			expect(readStoredThemeStyle()).toBe(style);
+		}
+	});
+	it("applies the actual palette and refreshes terminal ANSI colors", () => {
+		setOmarchyPalette(palette);
+		applyDocumentThemeStyle("automatic");
+		expect(resolveTheme("system")).toBe("dark");
+		expect(buildTerminalThemes().dark).toMatchObject({ foreground: palette.foreground, black: "#f25107", red: "#f25107", cursor: palette.cursor });
+		setOmarchyPalette({ ...palette, background: "#ffffff", ansi: Array(16).fill("#123456") });
+		applyDocumentThemeStyle("automatic");
+		expect(resolveTheme("system")).toBe("light");
+		expect(buildTerminalThemes().light.red).toBe("#123456");
+	});
+	it("clears inherited tokens for explicit style, explicit appearance, and unavailable data", () => {
+		for (const reason of ["style", "appearance", "missing"]) {
+			localStorage.clear(); setOmarchyPalette(palette); applyDocumentThemeStyle("automatic");
+			if (reason === "appearance") localStorage.setItem("ao.theme", "light");
+			if (reason === "missing") setOmarchyPalette(null);
+			applyDocumentThemeStyle(reason === "style" ? "nord" : "automatic");
+			expect(document.documentElement.style.getPropertyValue("--background")).toBe("");
+		}
+	});
+	it("keeps menu and selected text readable even for poor source contrast", () => {
+		setOmarchyPalette({ ...palette, foreground: palette.background, surface: "#ffffff", selection: "#ffffff" });
+		applyDocumentThemeStyle("automatic");
+		const css = document.documentElement.style;
+		for (const [bg, fg] of [["popover", "popover-foreground"], ["accent", "accent-foreground"], ["primary", "primary-foreground"]]) {
+			expect(contrast(css.getPropertyValue(`--${bg}`), css.getPropertyValue(`--${fg}`))).toBeGreaterThanOrEqual(4.5);
+		}
+	});
+});

--- a/frontend/src/renderer/lib/terminal-themes.ts
+++ b/frontend/src/renderer/lib/terminal-themes.ts
@@ -19,11 +19,13 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 	// Collapse ANSI black into the plate. Agent TUIs (Cursor's prompt bar) fill
 	// rows with "black"; leaving the slot as a true dark color paints a black
 	// stripe on the light canvas. Same approach as packages/mobile/lib/theme.ts.
-	const ansiBlack = terminalBg;
+	const omarchy = typeof document !== "undefined" && document.documentElement.dataset.styleTheme === "automatic";
+	const ansiBlack = omarchy ? cssVar("--color-term-black") : terminalBg;
 	const dark: ITheme = {
 		background: terminalBg,
-		foreground: terminalForeground,
-		cursor: terminalCursor,
+		foreground: omarchy ? cssVar("--color-text-terminal") : terminalForeground,
+		selectionForeground: omarchy ? cssVar("--color-term-selection-foreground") : undefined,
+		cursor: omarchy ? cssVar("--color-term-cursor") : terminalCursor,
 		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-dark"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive"),
@@ -47,12 +49,13 @@ export function buildTerminalThemes(): { dark: ITheme; light: ITheme } {
 
 	const light: ITheme = {
 		background: terminalBg,
-		foreground: terminalForeground,
+		foreground: omarchy ? cssVar("--color-text-terminal") : terminalForeground,
+		selectionForeground: omarchy ? cssVar("--color-term-selection-foreground") : undefined,
 		// xterm block cursor fills with `cursor` and paints cell text in
 		// `cursorAccent`. --color-working is fine on dark plates but reads as a
 		// low-contrast wash on the light terminal bg (#f5f5f4), especially while
 		// blinking. Use the terminal foreground so the block stays visible.
-		cursor: terminalForeground,
+		cursor: omarchy ? cssVar("--color-term-cursor") : terminalForeground,
 		cursorAccent: terminalBg,
 		selectionBackground: cssVar("--color-term-selection-light"),
 		selectionInactiveBackground: cssVar("--color-term-selection-inactive-light"),

--- a/frontend/src/renderer/lib/theme.ts
+++ b/frontend/src/renderer/lib/theme.ts
@@ -1,7 +1,9 @@
+import { contrast, luminance, readableText, type OmarchyPalette } from "../../shared/omarchy-theme";
 export type Theme = "light" | "dark";
 export type ThemePreference = Theme | "system";
 
 export type ThemeStyle =
+	| "automatic"
 	| "orchestrate"
 	| "github"
 	| "catppuccin"
@@ -37,7 +39,10 @@ export function readStoredThemePreference(): ThemePreference {
 
 /** Resolve the active light/dark appearance from a stored preference. */
 export function resolveTheme(preference: ThemePreference = readStoredThemePreference()): Theme {
-	if (preference === "system") return systemTheme();
+	if (preference === "system") {
+		if (readStoredThemeStyle() === "automatic" && omarchyPalette) return luminance(omarchyPalette.background) > 0.179 ? "light" : "dark";
+		return systemTheme();
+	}
 	return preference;
 }
 
@@ -45,6 +50,7 @@ export function readStoredThemeStyle(): ThemeStyle {
 	try {
 		const stored = getLocalStorage()?.getItem(themeStyleStorageKey);
 		if (
+			stored === "automatic" ||
 			stored === "orchestrate" ||
 			stored === "github" ||
 			stored === "catppuccin" ||
@@ -60,7 +66,7 @@ export function readStoredThemeStyle(): ThemeStyle {
 	} catch {
 		// ignore
 	}
-	return "orchestrate";
+	return "automatic";
 }
 
 export function applyDocumentTheme(theme: Theme): void {
@@ -71,7 +77,8 @@ export function applyDocumentTheme(theme: Theme): void {
 
 export function applyDocumentThemeStyle(style: ThemeStyle): void {
 	if (typeof document === "undefined") return;
-	if (style === "orchestrate") {
+	applyOmarchyTokens(style === "automatic" && readStoredThemePreference() === "system" ? omarchyPalette : null);
+	if (style === "orchestrate" || (style === "automatic" && !isOmarchyActive())) {
 		delete document.documentElement.dataset.styleTheme;
 	} else {
 		document.documentElement.dataset.styleTheme = style;
@@ -113,4 +120,46 @@ export function runThemeTransition(update: () => void): void {
 		run();
 	});
 	void transition.finished.finally(finish);
+}
+
+let omarchyPalette: OmarchyPalette | null = null;
+let appliedTokens: string[] = [];
+export function setOmarchyPalette(palette: OmarchyPalette | null): void { omarchyPalette = palette; }
+export function isOmarchyActive(): boolean {
+	return readStoredThemeStyle() === "automatic" && readStoredThemePreference() === "system" && omarchyPalette !== null;
+}
+
+function applyOmarchyTokens(p: OmarchyPalette | null): void {
+	const root = document.documentElement;
+	for (const key of appliedTokens) root.style.removeProperty(key);
+	appliedTokens = [];
+	if (!p) return;
+	const fg = readableText(p.background, p.foreground);
+	const onAccent = readableText(p.accent, p.background);
+	const surface = p.surface && contrast(p.surface, fg) >= 4.5 ? p.surface : p.background;
+	const surfaceText = readableText(surface, p.foreground);
+	const sidebar = p.sidebar && contrast(p.sidebar, fg) >= 4.5 ? p.sidebar : p.background;
+	const tokens: Record<string, string> = {
+		background: p.background, foreground: fg, card: surface, "card-foreground": surfaceText,
+		popover: surface, "popover-foreground": surfaceText, primary: p.accent, "primary-foreground": onAccent,
+		secondary: p.selection, "secondary-foreground": readableText(p.selection, fg),
+		muted: p.background, "muted-foreground": fg, accent: p.selection, "accent-foreground": readableText(p.selection, fg),
+		border: p.accent, input: p.background, ring: p.accent,
+		sidebar, "sidebar-foreground": readableText(sidebar, p.foreground), "sidebar-primary": p.accent,
+		"sidebar-primary-foreground": onAccent, "sidebar-accent": p.selection,
+		"sidebar-accent-foreground": readableText(p.selection, fg), "sidebar-ring": p.accent,
+		"chart-1": p.accent, "chart-3": fg,
+		"color-text-terminal": p.foreground, "color-term-cursor": p.cursor,
+		"color-term-selection-dark": p.selection, "color-term-selection-light": p.selection,
+		"color-term-selection-inactive": p.selection, "color-term-selection-inactive-light": p.selection,
+		"color-term-selection-foreground": readableText(p.selection, p.foreground),
+		"color-brand-logo": p.accent, "color-brand-logo-bright": p.accent,
+		"color-brand-logo-foreground": onAccent,
+	};
+	const names = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"];
+	p.ansi.forEach((color, i) => { tokens[`color-term-${i >= 8 ? "bright-" : ""}${names[i % 8]}`] = color; });
+	for (const [key, value] of Object.entries(tokens)) {
+		root.style.setProperty(`--${key}`, value);
+		appliedTokens.push(`--${key}`);
+	}
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,3 +1,4 @@
+import { isOmarchyActive } from "../lib/theme";
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { memo, type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -176,6 +177,7 @@ function ShellLayout() {
 	const themePreference = useUiStore((state) => state.themePreference);
 	const resolvedTheme = useUiStore((state) => state.resolvedTheme);
 	const themeStyle = useUiStore((state) => state.themeStyle);
+	const omarchyRevision = useUiStore((state) => state.omarchyRevision);
 	const isSidebarOpen = useUiStore(sidebarIsVisible);
 	const toggleSidebar = useUiStore((state) => state.toggleSidebar);
 	const sidebarHasLayout = useUiStore(sidebarOccupiesLayout);
@@ -743,11 +745,31 @@ function ShellLayout() {
 
 	// Keep Electron's nativeTheme in step with the shell so the embedded preview
 	// WebContentsView (which follows prefers-color-scheme) flips at the same time.
-	// Send the preference, not the resolved theme, so "system" keeps both surfaces
-	// following the OS instead of freezing matchMedia to a forced value.
+	// Omarchy supplies its palette brightness; otherwise System follows the OS.
 	useEffect(() => {
-		void aoBridge.theme?.set(themePreference);
-	}, [themePreference]);
+		void aoBridge.theme?.set(isOmarchyActive() ? resolvedTheme : themePreference);
+	}, [themePreference, resolvedTheme, themeStyle, omarchyRevision]);
+
+	useEffect(() => {
+		let stopped = false;
+		let timer: ReturnType<typeof setTimeout>;
+		let previous: string | undefined;
+		const refresh = async () => {
+			const palette = await aoBridge.theme?.getOmarchy?.().catch(() => null) ?? null;
+			if (stopped) return;
+			const next = JSON.stringify(palette);
+			if (next !== previous) {
+				previous = next;
+				useUiStore.getState().updateOmarchy(palette);
+			}
+			timer = setTimeout(refresh, 2000);
+		};
+		void refresh();
+		return () => {
+			stopped = true;
+			clearTimeout(timer);
+		};
+	}, []);
 
 	// Cursor Agent reads TERM_THEME at spawn from this file. Persist the same
 	// resolved light/dark scheme the terminal uses, not nativeTheme alone.

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -1,3 +1,5 @@
+import type { OmarchyPalette } from "../../shared/omarchy-theme";
+import { setOmarchyPalette } from "../lib/theme";
 import { create } from "zustand";
 import type { TerminalTarget } from "../types/terminal";
 import {
@@ -7,7 +9,6 @@ import {
 	readStoredThemeStyle,
 	resolveTheme,
 	runThemeTransition,
-	systemTheme,
 	themeStorageKey,
 	themeStyleStorageKey,
 	type Theme,
@@ -77,6 +78,8 @@ export type UiState = {
 	resolvedTheme: Theme;
 	/** Named color style theme (e.g. "catppuccin", "nord") — independent of light/dark mode. */
 	themeStyle: ThemeStyle;
+	omarchyRevision: number;
+	updateOmarchy: (palette: OmarchyPalette | null) => void;
 	/** When true, developer-only release controls are available. Default off. */
 	developerMode: boolean;
 	restartingProjectIds: ReadonlySet<string>;
@@ -210,6 +213,14 @@ export const useUiStore = create<UiState>((set, get) => ({
 	themePreference: initialThemePreference,
 	resolvedTheme: resolveTheme(initialThemePreference),
 	themeStyle: initialThemeStyle,
+	omarchyRevision: 0,
+	updateOmarchy: (palette) => {
+		setOmarchyPalette(palette);
+		const resolvedTheme = resolveTheme(get().themePreference);
+		applyDocumentTheme(resolvedTheme);
+		applyDocumentThemeStyle(get().themeStyle);
+		set({ resolvedTheme, omarchyRevision: get().omarchyRevision + 1 });
+	},
 	developerMode: initialDeveloperMode(),
 	restartingProjectIds: new Set<string>(),
 	provisioningProjectIds: new Set<string>(),
@@ -228,8 +239,9 @@ export const useUiStore = create<UiState>((set, get) => ({
 	setThemePreference: (themePreference) => {
 		if (get().themePreference === themePreference) return;
 		runThemeTransition(() => {
-			const resolvedTheme = resolveTheme(themePreference);
 			getLocalStorage()?.setItem(themeStorageKey, themePreference);
+			const resolvedTheme = resolveTheme(themePreference);
+			applyDocumentThemeStyle(get().themeStyle);
 			applyDocumentTheme(resolvedTheme);
 			set({ themePreference, resolvedTheme });
 		});
@@ -239,7 +251,9 @@ export const useUiStore = create<UiState>((set, get) => ({
 		runThemeTransition(() => {
 			getLocalStorage()?.setItem(themeStyleStorageKey, themeStyle);
 			applyDocumentThemeStyle(themeStyle);
-			set({ themeStyle });
+			const resolvedTheme = resolveTheme(get().themePreference);
+			applyDocumentTheme(resolvedTheme);
+			set({ themeStyle, resolvedTheme });
 		});
 	},
 	setDeveloperMode: (developerMode) => {
@@ -255,7 +269,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	syncSystemTheme: () => {
 		const { themePreference, resolvedTheme } = get();
 		if (themePreference !== "system") return;
-		const next = systemTheme();
+		const next = resolveTheme(themePreference);
 		if (next === resolvedTheme) return;
 		runThemeTransition(() => {
 			applyDocumentTheme(next);

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -135,6 +135,7 @@ if (typeof window !== "undefined") {
 			onFullScreen: () => () => undefined,
 		},
 		theme: {
+			getOmarchy: async () => null,
 			set: async () => undefined,
 			persistTerminal: async () => undefined,
 		},

--- a/frontend/src/shared/omarchy-theme.ts
+++ b/frontend/src/shared/omarchy-theme.ts
@@ -1,0 +1,29 @@
+/** Only normalized colors cross the main/preload boundary. */
+export interface OmarchyPalette {
+	background: string;
+	surface?: string;
+	sidebar?: string;
+	foreground: string;
+	accent: string;
+	selection: string;
+	cursor: string;
+	ansi: string[];
+}
+
+export function luminance(hex: string): number {
+	const rgb = [1, 3, 5].map((offset) => {
+		const c = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+		return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+	});
+	return rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722;
+}
+
+export function contrast(a: string, b: string): number {
+	const x = luminance(a), y = luminance(b);
+	return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}
+
+export function readableText(background: string, preferred: string): string {
+	if (contrast(background, preferred) >= 4.5) return preferred;
+	return contrast(background, "#ffffff") > contrast(background, "#000000") ? "#ffffff" : "#000000";
+}


### PR DESCRIPTION
## What

Add an Automatic (Omarchy) color theme that inherits the active Omarchy palette on Linux, updates while AO is running, and applies the palette to application surfaces and xterm terminals.

## Why

AO currently follows only light or dark system appearance. Omarchy users expect applications to inherit the active palette as well as its brightness, while saved AO theme choices must remain authoritative.

No linked issue; this change follows the requested local feature scope.

## How

- Read only allowlisted six-digit hex colors from the active Omarchy `colors.toml` in Electron main, with a 16 KiB limit and regular-file validation.
- Pass normalized palette data through preload; the renderer never accesses the filesystem or evaluates external CSS or scripts.
- Poll the active palette every two seconds to follow file edits, symlink replacement, removal, and recovery.
- Add Automatic (Omarchy) to existing Appearance settings. Saved named styles and explicit Light or Dark choices remain unchanged.
- Apply validated colors through existing UI and terminal tokens, including readable foreground fallback for menus and controls.
- Refresh retained xterm instances in place so scrollback survives palette changes.

Embedded pages and agent TUIs that draw their own true-color interfaces continue to own their colors.

## Testing

- `npm test --prefix frontend -- src/main src/shared src/renderer`
  - 263 files passed; 3,839 tests passed; 7 skipped.
- `npm run typecheck --prefix frontend`
- `npx vite build --config vite.renderer.config.ts` from `frontend`
- `git diff --check`
- Native Electron validation with isolated AO data:
  - Confirmed the real preload returned the active Amber HUD palette.
  - Opened and inspected color-theme menus under inherited dark and explicit light appearance.
  - Confirmed Nord persists across reload.
  - Confirmed System restores Automatic inheritance.
  - Confirmed the isolated daemon and debugger listeners stopped afterward.

The all-workflow local CI command could not start because `build-artifacts.yml` requires `VITE_WORKOS_CLIENT_ID`. A frontend-only local CI attempt also could not connect its Docker runners to the local controller at `host.docker.internal`. The equivalent frontend checks above pass; GitHub CI remains the authoritative workflow run. The macOS-only helper job was not run locally.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows `AGENTS.md` conventions and PR hygiene
- [x] Tests added and updated for user-visible behavior
- [x] Relevant frontend checks pass locally
