### PR TITLE
docs: explain fork contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Non-trivial work? Comment on the issue or ping Discord first. Get a thumbs-up, t
 
 1. **Join Discord** — say hi and get guidance
 2. **Read the contract** — [AGENTS.md](AGENTS.md) (layout, commands, hard rules, PR hygiene)
-3. **Pick something focused** — [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues); prefer `good-first-issue` / `help wanted`
+3. **Pick something focused** — [open issues](https://github.com/Untrivial-ai/agent-orchestrator/issues); prefer `good-first-issue` / `help wanted`
 4. **Claim it** — comment `I'd like to work on this` and wait for assignment
 5. **Open a clear PR** — narrow change, link the issue, user-visible impact, tests
 6. **Iterate** — address review; maintainers merge
@@ -62,6 +62,14 @@ Review the draft and attachments before submitting. A clear observation is usefu
 
 New PRs are prefilled from [`.github/pull_request_template.md`](.github/pull_request_template.md).
 Also follow **PR hygiene** in [AGENTS.md](AGENTS.md): branch from `main`, one issue per PR, conventional commits, explain intentional omissions, and keep CI green for the area you touched.
+
+Fork contributors should keep their fork as `origin` and add this repository as
+`upstream`. Create contribution branches from `upstream/main`, push those
+branches to `origin`, and open pull requests into
+`Untrivial-ai/agent-orchestrator:main`. Your fork's `main` may contain personal
+changes, but do not base a contribution on it unless every commit belongs in
+the pull request. See the [development guide](docs/development.md#getting-the-code)
+for the complete command sequence.
 
 ## Code of Conduct
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,24 +42,66 @@ agent-orchestrator/
 
 ## Getting the code
 
+If you plan to contribute through a fork, clone your fork as `origin` and add
+the canonical repository as `upstream`:
+
 ```bash
-git clone https://github.com/AgentWrapper/agent-orchestrator.git
+git clone https://github.com/<your-user>/agent-orchestrator.git
 cd agent-orchestrator
+git remote add upstream https://github.com/Untrivial-ai/agent-orchestrator.git
+git remote -v
 npm ci
 ```
 
+In this setup, `origin` is your writable fork and `upstream` is the parent
+repository. Direct collaborators can instead clone the parent repository as
+`origin` and use `origin/main` wherever this guide uses `upstream/main`.
+
 ### Branching
 
-```bash
-git checkout -b my-feature-branch
-```
-
-Keep your branch up to date by rebasing on main:
+Create each contribution branch from the current parent branch:
 
 ```bash
-git fetch origin
-git rebase origin/main
+git fetch upstream
+git switch -c my-feature-branch upstream/main
 ```
+
+This matters when your fork's `main` contains personal changes: starting from
+`upstream/main` keeps unrelated commits out of the pull request. Keep the
+feature branch current by rebasing it on the parent branch:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+Push the feature branch to your fork and open a pull request against the parent
+repository:
+
+```bash
+git push -u origin my-feature-branch
+gh pr create \
+  --repo Untrivial-ai/agent-orchestrator \
+  --base main \
+  --head <your-user>:my-feature-branch
+```
+
+The pull request runs from your fork's feature branch into
+`Untrivial-ai/agent-orchestrator:main`. Follow the repository's pull request
+template and address CI and review feedback on the same branch.
+
+If your fork's `main` has no personal commits, you can fast-forward it to the
+parent at any time:
+
+```bash
+git fetch upstream
+git switch main
+git merge --ff-only upstream/main
+git push origin main
+```
+
+If your fork's `main` intentionally diverges, keep it as your integration
+branch and continue creating contribution branches from `upstream/main`.
 
 ### Committing
 


### PR DESCRIPTION
## Summary

- document the standard fork (`origin`) and canonical parent (`upstream`) remote layout
- show how to base focused contribution branches on `upstream/main` and open cross-fork PRs
- explain how personal fork changes can coexist without leaking into parent PRs
- update the stale issues link to the current GitHub organization

## Validation

- `git diff --check`

Documentation-only change; no runtime behavior changed.
