### PR TITLE
feat(reviews): expose available reviewer harness catalog via API (#3516)

### DIFF
--- a/backend/internal/domain/reviewerharness.go
+++ b/backend/internal/domain/reviewerharness.go
@@ -76,3 +76,61 @@ func (h ReviewerHarness) IsKnown() bool {
 	}
 	return false
 }
+
+// Label returns the human-readable display name for this reviewer harness.
+func (h ReviewerHarness) Label() string {
+	switch h {
+	case ReviewerClaudeCode:
+		return "Claude Code"
+	case ReviewerCodex:
+		return "Codex"
+	case ReviewerCopilot:
+		return "GitHub Copilot"
+	case ReviewerCursor:
+		return "Cursor"
+	case ReviewerKiloCode:
+		return "Kilo Code"
+	case ReviewerKimchi:
+		return "Kimchi"
+	case ReviewerOpenCode:
+		return "OpenCode"
+	case ReviewerKiro:
+		return "Kiro"
+	case ReviewerPi:
+		return "Pi"
+	case ReviewerQwen:
+		return "Qwen"
+	case ReviewerAgy:
+		return "AGY"
+	case ReviewerContinue:
+		return "Continue"
+	case ReviewerGoose:
+		return "Goose"
+	case ReviewerVibe:
+		return "Vibe"
+	case ReviewerDevin:
+		return "Devin"
+	case ReviewerDroid:
+		return "Droid"
+	case ReviewerKimi:
+		return "Kimi"
+	case ReviewerMuse:
+		return "Muse"
+	case ReviewerAmp:
+		return "Amp"
+	case ReviewerAider:
+		return "Aider"
+	case ReviewerGrok:
+		return "Grok"
+	case ReviewerCrush:
+		return "Crush"
+	case ReviewerAuggie:
+		return "Auggie"
+	case ReviewerCline:
+		return "Cline"
+	case ReviewerAutohand:
+		return "Autohand"
+	default:
+		return string(h)
+	}
+}

--- a/backend/internal/domain/reviewerharness_test.go
+++ b/backend/internal/domain/reviewerharness_test.go
@@ -1,0 +1,25 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestReviewerHarnessLabel(t *testing.T) {
+	for _, h := range domain.AllReviewerHarnesses {
+		label := h.Label()
+		if label == "" {
+			t.Errorf("expected non-empty label for reviewer harness %q", h)
+		}
+		if label == string(h) {
+			t.Errorf("expected custom display label for reviewer harness %q, got bare id", h)
+		}
+	}
+
+	// Unknown harness fallback
+	unknown := domain.ReviewerHarness("unknown-reviewer")
+	if got := unknown.Label(); got != "unknown-reviewer" {
+		t.Errorf("expected unknown harness to return bare id, got %q", got)
+	}
+}

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2530,6 +2530,25 @@ paths:
       summary: Unpair this phone from the daemon, removing it from the roster
       tags:
       - push
+  /api/v1/reviewers:
+    get:
+      operationId: listReviewers
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListReviewersResponse'
+          description: OK
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: List supported code-reviewer harnesses
+      tags:
+      - reviews
   /api/v1/reviews/{reviewSessionID}/activity:
     post:
       operationId: setReviewActivity
@@ -9577,6 +9596,15 @@ components:
       required:
       - projects
       type: object
+    ListReviewersResponse:
+      properties:
+        reviewers:
+          items:
+            $ref: '#/components/schemas/ReviewerHarnessInfo'
+          type: array
+      required:
+      - reviewers
+      type: object
     ListReviewsResponse:
       properties:
         reviewerHandleId:
@@ -10524,6 +10552,42 @@ components:
       - review
       - reviews
       - reviewerHandleId
+      type: object
+    ReviewerHarnessInfo:
+      properties:
+        id:
+          enum:
+          - claude-code
+          - codex
+          - copilot
+          - cursor
+          - kilocode
+          - opencode
+          - kiro
+          - pi
+          - qwen
+          - agy
+          - continue
+          - goose
+          - vibe
+          - devin
+          - droid
+          - kimi
+          - kimchi
+          - muse
+          - amp
+          - aider
+          - grok
+          - crush
+          - auggie
+          - cline
+          - autohand
+          type: string
+        label:
+          type: string
+      required:
+      - id
+      - label
       type: object
     RoleOverride:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -382,6 +382,8 @@ var schemaNames = map[string]string{ //nolint:gosec // Public OpenAPI type names
 	"ControllersResolveCommentsRequest":  "ResolveCommentsRequest",
 	"ControllersResolveCommentsResponse": "ResolveCommentsResponse",
 	// httpd/controllers — review wire envelopes
+	"ControllersListReviewersResponse": "ListReviewersResponse",
+	"ControllersReviewerHarnessInfo":   "ReviewerHarnessInfo",
 	"ControllersListReviewsResponse":   "ListReviewsResponse",
 	"ControllersReviewRunResponse":     "ReviewRunResponse",
 	"ControllersTriggerReviewResponse": "TriggerReviewResponse",
@@ -1559,6 +1561,14 @@ func pushOperations() []operation {
 
 func reviewOperations() []operation {
 	return []operation{
+		{
+			method: http.MethodGet, path: "/api/v1/reviewers", id: "listReviewers", tag: "reviews",
+			summary: "List supported code-reviewer harnesses",
+			resps: []respUnit{
+				{http.StatusOK, controllers.ListReviewersResponse{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
 		{
 			method: http.MethodGet, path: "/api/v1/sessions/{sessionId}/reviews", id: "listReviews", tag: "reviews",
 			summary:    "List a worker's code-review runs",

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -2391,6 +2391,17 @@ func capabilityNames(caps ports.ChatCapabilities) []string {
 	return names
 }
 
+// ReviewerHarnessInfo describes a supported reviewer harness and its display label.
+type ReviewerHarnessInfo struct {
+	ID    domain.ReviewerHarness `json:"id" enum:"claude-code,codex,copilot,cursor,kilocode,opencode,kiro,pi,qwen,agy,continue,goose,vibe,devin,droid,kimi,kimchi,muse,amp,aider,grok,crush,auggie,cline,autohand"`
+	Label string                 `json:"label"`
+}
+
+// ListReviewersResponse is the body of GET /api/v1/reviewers.
+type ListReviewersResponse struct {
+	Reviewers []ReviewerHarnessInfo `json:"reviewers"`
+}
+
 // TriggerReviewRequest is the optional body of the review trigger route. An
 // empty harness keeps the project's configured reviewer; setting one overrides
 // it for this pass only, without editing project config, so one session's choice

--- a/backend/internal/httpd/controllers/reviews.go
+++ b/backend/internal/httpd/controllers/reviews.go
@@ -95,6 +95,7 @@ type ReviewsController struct {
 
 // Register mounts the review routes on the supplied router.
 func (c *ReviewsController) Register(r chi.Router) {
+	r.Get("/reviewers", c.listReviewers)
 	r.Post("/reviews/{reviewSessionID}/activity", c.activity)
 	r.Get("/sessions/{sessionId}/reviews", c.list)
 	r.Post("/sessions/{sessionId}/reviews/trigger", c.trigger)
@@ -105,6 +106,23 @@ func (c *ReviewsController) Register(r chi.Router) {
 	r.Post("/sessions/{sessionId}/reviews/restore", c.restore)
 	r.Post("/sessions/{sessionId}/reviews/switch", c.switchReviewer)
 	r.Post("/sessions/{sessionId}/reviews/submit", c.submit)
+}
+
+func (c *ReviewsController) listReviewers(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, http.MethodGet, "/api/v1/reviewers")
+		return
+	}
+	items := make([]ReviewerHarnessInfo, 0, len(domain.AllReviewerHarnesses))
+	for _, h := range domain.AllReviewerHarnesses {
+		items = append(items, ReviewerHarnessInfo{
+			ID:    h,
+			Label: h.Label(),
+		})
+	}
+	envelope.WriteJSON(w, http.StatusOK, ListReviewersResponse{
+		Reviewers: items,
+	})
 }
 
 func (c *ReviewsController) activity(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/httpd/controllers/reviews_test.go
+++ b/backend/internal/httpd/controllers/reviews_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	reviewcore "github.com/aoagents/agent-orchestrator/backend/internal/review"
 	reviewsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/review"
@@ -386,5 +387,48 @@ func TestReviewsSubmitAcceptsBatchedReviews(t *testing.T) {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("body missing %s: %s", want, body)
 		}
+	}
+}
+
+func TestListReviewers_ReturnsSupportedCatalog(t *testing.T) {
+	srv := newReviewTestServer(t, &fakeReviewService{})
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/reviewers", "")
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d body=%s", status, body)
+	}
+
+	var got controllers.ListReviewersResponse
+	mustJSON(t, body, &got)
+	if len(got.Reviewers) != len(domain.AllReviewerHarnesses) {
+		t.Fatalf("got %d reviewers, want %d", len(got.Reviewers), len(domain.AllReviewerHarnesses))
+	}
+
+	seen := make(map[domain.ReviewerHarness]string)
+	for _, r := range got.Reviewers {
+		if r.ID == "" {
+			t.Fatal("reviewer id is empty")
+		}
+		if r.Label == "" {
+			t.Fatalf("reviewer %s has empty label", r.ID)
+		}
+		seen[r.ID] = r.Label
+	}
+
+	for _, want := range domain.AllReviewerHarnesses {
+		if _, ok := seen[want]; !ok {
+			t.Fatalf("missing reviewer harness %q in catalog", want)
+		}
+	}
+}
+
+func TestListReviewers_NilServiceReturns501(t *testing.T) {
+	srv := newReviewTestServer(t, nil)
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/reviewers", "")
+	assertJSON(t, headers)
+	if status != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501; body=%s", status, body)
 	}
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1082,6 +1082,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/reviewers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List supported code-reviewer harnesses */
+        get: operations["listReviewers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/reviews/{reviewSessionID}/activity": {
         parameters: {
             query?: never;
@@ -3405,6 +3422,9 @@ export interface components {
         ListProjectsResponse: {
             projects: components["schemas"]["ProjectSummary"][];
         };
+        ListReviewersResponse: {
+            reviewers: components["schemas"]["ReviewerHarnessInfo"][];
+        };
         ListReviewsResponse: {
             reviewerHandleId: string;
             reviewerHarness?: string;
@@ -3773,6 +3793,11 @@ export interface components {
             review: components["schemas"]["ReviewRun"];
             reviewerHandleId: string;
             reviews: components["schemas"]["ReviewRun"][];
+        };
+        ReviewerHarnessInfo: {
+            /** @enum {string} */
+            id: "claude-code" | "codex" | "copilot" | "cursor" | "kilocode" | "opencode" | "kiro" | "pi" | "qwen" | "agy" | "continue" | "goose" | "vibe" | "devin" | "droid" | "kimi" | "kimchi" | "muse" | "amp" | "aider" | "grok" | "crush" | "auggie" | "cline" | "autohand";
+            label: string;
         };
         RoleOverride: {
             agent?: string;
@@ -7718,6 +7743,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    listReviewers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListReviewersResponse"];
                 };
             };
             /** @description Not Implemented */

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -11,7 +11,7 @@ import {
 	type RankedAgentOption,
 	unknownAgentReadiness,
 } from "../lib/agent-select-options";
-import { KNOWN_REVIEWER_HARNESS_IDS } from "../lib/reviewer-harnesses";
+import { KNOWN_REVIEWER_HARNESS_IDS, reviewerCatalogQueryOptions } from "../lib/reviewer-harnesses";
 import { cn } from "../lib/utils";
 import { AgentAvatar } from "./AgentAvatar";
 import { AgentSelectMenuItem } from "./settings/AgentSelectMenuItem";
@@ -83,14 +83,27 @@ export function ReviewerSelect({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const [menuOpen, setMenuOpen] = useState(false);
-	// Until the daemon's catalog arrives these entries carry the whole menu, so
-	// label them the way the catalog would rather than printing bare ids: without
-	// this the same row reads "claude-code" now and "Claude Code" a moment later.
-	const fallbackAgents: AgentInfo[] = [...KNOWN_REVIEWER_HARNESS_IDS].map(
-		(id) => unknownAgentReadiness(id, agentLabel(id)),
-	);
-	const filteredSupported = (agents ?? fallbackAgents).filter((a) => KNOWN_REVIEWER_HARNESS_IDS.has(a.id));
-	const supportedAgents = filteredSupported.length > 0 ? filteredSupported : fallbackAgents;
+	const reviewerCatalog = useQuery(reviewerCatalogQueryOptions());
+	const catalogReviewers = reviewerCatalog.data;
+
+	const fallbackAgents: AgentInfo[] = useMemo(() => {
+		if (catalogReviewers && catalogReviewers.length > 0) {
+			return catalogReviewers.map((r) => unknownAgentReadiness(r.id, r.label || agentLabel(r.id)));
+		}
+		return [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => unknownAgentReadiness(id, agentLabel(id)));
+	}, [catalogReviewers]);
+
+	const supportedAgents: AgentInfo[] = useMemo(() => {
+		if (!agents || agents.length === 0) {
+			return fallbackAgents;
+		}
+		const agentMap = new Map(agents.map((a) => [a.id, a]));
+		return fallbackAgents.map((fallback) => {
+			const existing = agentMap.get(fallback.id);
+			return existing ? { ...existing, label: existing.label || fallback.label } : fallback;
+		});
+	}, [agents, fallbackAgents]);
+
 	const options = buildRankedAgentOptions({
 		agents: supportedAgents,
 		priorityRank: REVIEWER_AGENT_PRIORITY_RANK,
@@ -118,7 +131,12 @@ export function ReviewerSelect({
 		}
 	}, [defaultHarness, menuOpen, menuProjectID, queryClient, selectableOptions]);
 	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
-	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
+	const activeReviewerLabel = useMemo(() => {
+		if (!value) return undefined;
+		const fromCatalog = catalogReviewers?.find((r) => r.id === value)?.label;
+		return fromCatalog || agentLabel(value);
+	}, [catalogReviewers, value]);
+	const triggerLabel = [activeReviewerLabel ?? (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
 		.filter(Boolean)
 		.join(" · ");
 

--- a/frontend/src/renderer/lib/reviewer-harnesses.ts
+++ b/frontend/src/renderer/lib/reviewer-harnesses.ts
@@ -1,4 +1,10 @@
+import { queryOptions } from "@tanstack/react-query";
 import type { components } from "../../api/schema";
+import { apiClient, apiErrorMessage } from "./api-client";
+import { usesPreviewWorkspaceData as usePreviewData } from "./preview-mode";
+import { agentLabel } from "./agent-options";
+
+export type ReviewerHarnessInfo = components["schemas"]["ReviewerHarnessInfo"];
 
 // Reviewers are a narrower vocabulary than worker agents on purpose: a
 // reviewer-only tool must not become a valid worker, and the daemon rejects
@@ -46,4 +52,22 @@ export const KNOWN_REVIEWER_HARNESS_IDS: ReadonlySet<string> = new Set(REVIEWER_
 
 export function toReviewerHarnessId(value?: string): ReviewerHarnessId | undefined {
 	return value && KNOWN_REVIEWER_HARNESS_IDS.has(value) ? (value as ReviewerHarnessId) : undefined;
+}
+
+export function reviewerCatalogQueryOptions() {
+	return queryOptions({
+		queryKey: ["reviewer-catalog"] as const,
+		queryFn: async (): Promise<ReviewerHarnessInfo[]> => {
+			if (usePreviewData) {
+				return [...KNOWN_REVIEWER_HARNESS_IDS].map((id) => ({
+					id: id as ReviewerHarnessInfo["id"],
+					label: agentLabel(id),
+				}));
+			}
+			const { data, error } = await apiClient.GET("/api/v1/reviewers");
+			if (error) throw new Error(apiErrorMessage(error, "Unable to load reviewer catalog"));
+			return data?.reviewers ?? [];
+		},
+		staleTime: 60_000,
+	});
 }


### PR DESCRIPTION
## What

Exposes a new daemon endpoint `GET /api/v1/reviewers` returning all 25 supported code-reviewer harnesses and their display labels (`id` and `label`). Connects the frontend reviewer selector (`ReviewerSelect.tsx`) to this endpoint via a TanStack query with graceful fallback.

## Why

Closes #3516. 
Follow-up to #3384. Previously, the reviewer harness catalog was only defined internally, leaving clients and frontend selectors without a single source of truth for supported reviewers and their display names.

## How

1. **Domain**: Added `(h ReviewerHarness) Label() string` on `ReviewerHarness` in `backend/internal/domain/reviewerharness.go` mapping all 25 supported harnesses to human-readable labels.
2. **HTTP Controller**:
   - Added `ReviewerHarnessInfo` and `ListReviewersResponse` in `backend/internal/httpd/controllers/dto.go`.
   - Mounted `GET /reviewers` on `ReviewsController.Register` returning `200 OK` (or `501 Not Implemented` if review service is disabled).
3. **OpenAPI & Types**:
   - Registered `listReviewers` route in `specgen/build.go`.
   - Regenerated `openapi.yaml` (`npm run api:spec`) and typed TS schema `schema.ts` (`npm run api:ts`).
4. **Frontend**:
   - Added `reviewerCatalogQueryOptions` in `frontend/src/renderer/lib/reviewer-harnesses.ts`.
   - Integrated into `ReviewerSelect.tsx` to dynamically populate fallback options and labels.

## Testing

- **Domain unit tests**: `go test -v -run TestReviewerHarnessLabel ./internal/domain/...` (PASS)
- **Controller unit tests**: `go test -v -run TestListReviewers ./internal/httpd/controllers/...` (PASS)
- **Spec drift / parity tests**: `go test -v ./internal/httpd/apispec/...` (PASS)
- **Frontend typecheck**: `npm run frontend:typecheck` (PASS, 0 errors)
- **Go Vet**: `go vet ./...` (PASS)
- **Live App & API Verification**:
  - BEFORE: `GET /api/v1/reviewers` returned `404 Not Found` (`ROUTE_NOT_FOUND`).
  - AFTER: `GET /api/v1/reviewers` returns `200 OK` with all 25 reviewer harnesses (`id` and `label`).

### Before
<img width="553" height="213" alt="Screenshot 2026-09-10 at 9 40 40 PM" src="https://github.com/user-attachments/assets/8bc6297b-96ab-4002-baba-1c9de7d3af3c" />

`GET /api/v1/reviewers` returned `404 Not Found` (`ROUTE_NOT_FOUND`).

### After
<img width="595" height="774" alt="Screenshot 2026-09-10 at 10 19 40 PM" src="https://github.com/user-attachments/assets/104e8d03-4a17-4b9d-a56f-6e3bbc7f2431" />

<!-- Drag and drop your AFTER screenshot here -->
`GET /api/v1/reviewers` returns `200 OK` with all 25 reviewer harnesses (`id` and `label`).


## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
