### PR TITLE
fix(omp): verify persisted session before --resume restore

### DIFF
--- a/backend/internal/adapters/agent/omp/omp.go
+++ b/backend/internal/adapters/agent/omp/omp.go
@@ -5,7 +5,9 @@ package omp
 
 import (
 	"context"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -34,6 +36,7 @@ var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
 var _ ports.AgentBinaryResolver = (*Plugin)(nil)
+var _ ports.AgentInterfaceHandoffHistoryProbe = (*Plugin)(nil)
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {
@@ -109,6 +112,54 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 	}
 	info, ok := agentbase.StandardSessionInfo(session)
 	return info, ok, nil
+}
+
+// NativeConversationExists reports whether OMP has a persisted session file for id.
+func (p *Plugin) NativeConversationExists(ctx context.Context, _ ports.SessionRef, nativeConversationID string, env map[string]string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	id := strings.TrimSpace(nativeConversationID)
+	if id == "" {
+		return false, nil
+	}
+	configDir := strings.TrimSpace(env["PI_CODING_AGENT_DIR"])
+	if configDir == "" {
+		var ok bool
+		configDir, ok = ompConfigDir()
+		if !ok {
+			return false, nil
+		}
+	}
+	found := false
+	sessionsDir := filepath.Join(configDir, "sessions")
+	err := filepath.WalkDir(sessionsDir, func(_ string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_"+id+".jsonl") {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return found, nil
 }
 
 func appendSystemPrompt(cmd *[]string, inline, file string) error {

--- a/backend/internal/adapters/agent/omp/omp.go
+++ b/backend/internal/adapters/agent/omp/omp.go
@@ -125,11 +125,14 @@ func (p *Plugin) NativeConversationExists(ctx context.Context, _ ports.SessionRe
 	}
 	configDir := strings.TrimSpace(env["PI_CODING_AGENT_DIR"])
 	if configDir == "" {
-		var ok bool
-		configDir, ok = ompConfigDir()
-		if !ok {
-			return false, nil
+		configDir = strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR"))
+	}
+	if configDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return false, err
 		}
+		configDir = filepath.Join(home, ".omp", "agent")
 	}
 	found := false
 	sessionsDir := filepath.Join(configDir, "sessions")

--- a/backend/internal/adapters/agent/omp/omp_test.go
+++ b/backend/internal/adapters/agent/omp/omp_test.go
@@ -307,6 +307,63 @@ func TestGetAgentHooksHonorsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestNativeConversationExistsRequiresPersistedSessionFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+	id := "01a08c38-8b17-728d-acf2-60c5d9d84851"
+	sessionDir := filepath.Join(dir, "sessions", "-.ao-dev-data-worktrees-scratch-workers-scratch-3")
+	if err := os.MkdirAll(sessionDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, "2026-09-10T16-48-30-999Z_"+id+".jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Plugin{}
+	exists, err := p.NativeConversationExists(context.Background(), ports.SessionRef{}, id, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatalf("exists = false for persisted session file, want true")
+	}
+
+	exists, err = p.NativeConversationExists(context.Background(), ports.SessionRef{}, "01a07a5f-dd88-7537-9bbd-7165ecba238f", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("exists = true for unknown session id, want false")
+	}
+
+	exists, err = p.NativeConversationExists(context.Background(), ports.SessionRef{}, "  ", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("exists = true for blank session id, want false")
+	}
+}
+
+func TestNativeConversationExistsFalseWithoutSessionsDir(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+	exists, err := (&Plugin{}).NativeConversationExists(context.Background(), ports.SessionRef{}, "01a08c38-8b17-728d-acf2-60c5d9d84851", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("exists = true with no sessions dir, want false")
+	}
+}
+
+func TestNativeConversationExistsHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := (&Plugin{}).NativeConversationExists(ctx, ports.SessionRef{}, "some-id", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
 func fakeOMPVersionBinary(t *testing.T, version string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "omp")

--- a/docs/harnesses/omp.md
+++ b/docs/harnesses/omp.md
@@ -92,8 +92,9 @@ When AO has captured an OMP native session id in session metadata, restore uses:
 omp --resume <native-session-id>
 ```
 
-If no native session id is available, AO falls back to a fresh interactive
-launch.
+AO first verifies a session file for that id exists under the OMP sessions
+dir. If the file is missing or no native session id is available, AO falls
+back to a fresh interactive launch.
 
 ## Auth
 


### PR DESCRIPTION
Fixes #5036.

- OMP restore used omp --resume for any stored id, even one OMP never persisted. It failed with Session not found in a loop.
- OMP adapter now implements NativeConversationExists. It checks the OMP sessions dir for the session file.
- Missing session falls back to a fresh launch in the same workspace via the existing restore path.
- Verified against the real ~/.omp/agent store: persisted id returns true, unknown id returns false.