### PR TITLE
fix: bound terminal scrollback by bytes

### DIFF
--- a/backend/internal/adapters/runtime/conpty/ring.go
+++ b/backend/internal/adapters/runtime/conpty/ring.go
@@ -1,95 +1,153 @@
 package conpty
 
 import (
-	"strings"
+	"bytes"
 	"sync"
 )
 
-// MaxOutputLines is the rolling line-buffer cap, matching MAX_OUTPUT_LINES in pty-host.ts.
+// MaxOutputLines is the maximum number of completed lines retained.
 const MaxOutputLines = 1000
 
-// Ring is a bounded rolling buffer of terminal output lines, ANSI codes preserved.
-// It mirrors the appendOutput state machine from pty-host.ts.
-// Concurrent Append and Snapshot/Tail calls are safe.
+// MaxOutputBytes bounds retained output, including the unfinished line. A TUI
+// can repaint indefinitely without producing a newline.
+const MaxOutputBytes = 1 << 20
+
+// Ring stores a bounded suffix of terminal output. Bytes are preserved verbatim,
+// but eviction can cut through a line, UTF-8 character, or ANSI sequence. Replay
+// is truncated history, not a reconstructed screen snapshot.
+// All methods are safe to call concurrently.
 type Ring struct {
-	mu          sync.Mutex
-	lines       []string // each entry is "line\n" (or bare text on FlushPartial)
-	partialLine string
+	mu sync.Mutex
+
+	data  []byte // circular storage, grown lazily up to MaxOutputBytes
+	start int
+	size  int
+
+	lineLengths [MaxOutputLines]int
+	lineStart   int
+	lineCount   int
+	partial     int
 }
 
 // NewRing returns an empty Ring.
-func NewRing() *Ring {
-	return &Ring{}
-}
+func NewRing() *Ring { return &Ring{} }
 
-// Append mirrors appendOutput from pty-host.ts: prepend the current partialLine,
-// split on newlines, store completed lines with "\n" re-appended, keep the last
-// element as the new partialLine, then trim to MaxOutputLines.
+// Append retains completed lines and the trailing unfinished fragment. Appending
+// to a long unfinished line copies only new bytes once storage has grown.
 func (r *Ring) Append(raw []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	text := r.partialLine + string(raw)
-	parts := strings.Split(text, "\n")
-	// The last element is either "" (text ended with \n) or an incomplete line.
-	r.partialLine = parts[len(parts)-1]
-	for _, line := range parts[:len(parts)-1] {
-		r.lines = append(r.lines, line+"\n")
-	}
-	if len(r.lines) > MaxOutputLines {
-		// ponytail: slice off the head; ceiling: O(n) copy on every trim cycle.
-		// Upgrade path: circular buffer if trim rate is very high.
-		r.lines = r.lines[len(r.lines)-MaxOutputLines:]
+	for len(raw) > 0 {
+		end := bytes.IndexByte(raw, '\n')
+		if end < 0 {
+			r.appendBytes(raw)
+			return
+		}
+		r.appendBytes(raw[:end+1])
+		r.completeLine()
+		raw = raw[end+1:]
 	}
 }
 
-// FlushPartial pushes any in-progress partial line as a final entry.
-// Called on PTY exit to mirror the pty-host.ts onExit handler.
+// FlushPartial stores the unfinished fragment as a final line on PTY exit.
 func (r *Ring) FlushPartial() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	if r.partialLine == "" {
-		return
+	if r.partial > 0 {
+		r.completeLine()
 	}
-	r.lines = append(r.lines, r.partialLine)
-	r.partialLine = ""
 }
 
-// Snapshot returns all stored lines concatenated as raw bytes for scrollback replay.
-// The in-progress partialLine is NOT included (matches TS outputBuffer.join("")).
+// Snapshot returns completed output, excluding the unfinished fragment.
 func (r *Ring) Snapshot() []byte {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	return []byte(strings.Join(r.lines, ""))
+	return r.copyRange(0, r.size-r.partial)
 }
 
-// Replay returns the complete terminal byte stream retained for a newly
-// attached viewer, including the current non-newline-terminated fragment.
-// Full-screen TUIs commonly repaint with cursor-control sequences and carriage
-// returns instead of newlines, so excluding partialLine can otherwise replay an
-// empty screen even though the process has already drawn its UI.
+// Replay includes the unfinished fragment, so newline-free TUI output is visible
+// to a newly attached viewer. The caller owns the returned bytes.
 func (r *Ring) Replay() []byte {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	return []byte(strings.Join(r.lines, "") + r.partialLine)
+	return r.copyRange(0, r.size)
 }
 
-// Tail returns the last n stored lines joined as a string.
-// Mirrors the MSG_GET_OUTPUT_REQ handler: start = max(0, len-lines).
-// n <= 0 returns "".
+// Tail returns the newest n completed lines. n <= 0 returns an empty string.
 func (r *Ring) Tail(n int) string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
 	if n <= 0 {
 		return ""
 	}
-	start := len(r.lines) - n
-	if start < 0 {
-		start = 0
+	length := 0
+	for i := 0; i < min(n, r.lineCount); i++ {
+		length += r.lineLengths[(r.lineStart+r.lineCount-1-i)%MaxOutputLines]
 	}
-	return strings.Join(r.lines[start:], "")
+	return string(r.copyRange(r.size-r.partial-length, length))
+}
+
+// The helpers below require mu.
+func (r *Ring) appendBytes(raw []byte) {
+	if len(raw) > MaxOutputBytes {
+		raw = raw[len(raw)-MaxOutputBytes:]
+	}
+	if excess := r.size + len(raw) - MaxOutputBytes; excess > 0 {
+		r.dropBytes(excess)
+	}
+	needed := r.size + len(raw)
+	if needed > len(r.data) {
+		capacity := min(MaxOutputBytes, max(4096, max(needed, 2*len(r.data))))
+		data := make([]byte, capacity)
+		r.copyInto(data[:r.size], 0)
+		r.data = data
+		r.start = 0
+	}
+	end := (r.start + r.size) % len(r.data)
+	n := copy(r.data[end:], raw)
+	copy(r.data, raw[n:])
+	r.size += len(raw)
+	r.partial += len(raw)
+}
+
+func (r *Ring) completeLine() {
+	if r.lineCount == MaxOutputLines {
+		r.dropBytes(r.lineLengths[r.lineStart])
+	}
+	r.lineLengths[(r.lineStart+r.lineCount)%MaxOutputLines] = r.partial
+	r.lineCount++
+	r.partial = 0
+}
+
+func (r *Ring) dropBytes(n int) {
+	r.start = (r.start + n) % len(r.data)
+	r.size -= n
+	for n > 0 && r.lineCount > 0 {
+		length := r.lineLengths[r.lineStart]
+		if n < length {
+			r.lineLengths[r.lineStart] -= n
+			return
+		}
+		n -= length
+		r.lineLengths[r.lineStart] = 0
+		r.lineStart = (r.lineStart + 1) % MaxOutputLines
+		r.lineCount--
+	}
+	r.partial -= n
+}
+
+func (r *Ring) copyRange(offset, length int) []byte {
+	out := make([]byte, length)
+	r.copyInto(out, offset)
+	return out
+}
+
+func (r *Ring) copyInto(out []byte, offset int) {
+	if len(out) == 0 {
+		return
+	}
+	start := (r.start + offset) % len(r.data)
+	n := copy(out, r.data[start:])
+	copy(out[n:], r.data)
 }

--- a/backend/internal/adapters/runtime/conpty/ring_boundary_review_test.go
+++ b/backend/internal/adapters/runtime/conpty/ring_boundary_review_test.go
@@ -1,0 +1,85 @@
+package conpty
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRingWrapAndByteEvictionPreserveFlushBoundaries(t *testing.T) {
+	r := NewRing()
+	var lines []string
+	// Wrap both circular buffers repeatedly while the line limit determines
+	// retention. Distinct lines make a reordered or duplicated tail visible.
+	for i := range 3*MaxOutputLines + 1 {
+		line := fmt.Sprintf("%06d:", i) + strings.Repeat(string(rune('a'+i%26)), 1000) + "\n"
+		r.Append([]byte(line))
+		lines = append(lines, line)
+		if len(lines) > MaxOutputLines {
+			lines = lines[1:]
+		}
+		if i%500 == 0 && string(r.Snapshot()) != strings.Join(lines, "") {
+			t.Fatalf("completed output differs after line %d", i)
+		}
+		if r.Tail(1) != line {
+			t.Fatalf("last completed line differs after line %d", i)
+		}
+	}
+	completed := strings.Join(lines, "")
+	partial := strings.Repeat("z", scrollbackByteBudget-len(completed)+1)
+	r.Append([]byte(partial))
+	// Exactly one byte is evicted from the oldest completed line. The
+	// unfinished fragment must not appear in Snapshot or Tail yet.
+	if string(r.Snapshot()) != completed[1:] || r.Tail(MaxOutputLines) != completed[1:] {
+		t.Fatal("partial byte eviction lost the completed-line boundary")
+	}
+	if string(r.Replay()) != completed[1:]+partial {
+		t.Fatal("replay differs after byte eviction")
+	}
+	r.FlushPartial()
+	want := strings.Join(lines[1:], "") + partial
+	if string(r.Snapshot()) != want || r.Tail(1) != partial {
+		t.Fatal("flush failed to evict the clipped oldest line at the line limit")
+	}
+	if r.Tail(2) != lines[len(lines)-1]+partial {
+		t.Fatal("flush changed the previous completed line")
+	}
+	r.Append(nil)
+	r.FlushPartial()
+	if string(r.Snapshot()) != want {
+		t.Fatal("empty append or repeated flush changed completed output")
+	}
+	r.Append([]byte("after\n"))
+	if r.Tail(2) != partial+"after\n" {
+		t.Fatal("append after flush merged or reordered completed lines")
+	}
+}
+
+func TestRingByteLimitPreservesRawSuffixWhenSequenceIsClipped(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		prefix string
+	}{
+		{"utf8", "\xe2\x82\xac"},
+		{"ansi", "\x1b[31m"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewRing()
+			raw := append([]byte(tt.prefix), bytes.Repeat([]byte("x"), scrollbackByteBudget-len(tt.prefix))...)
+			r.Append(raw)
+			r.Append([]byte("!"))
+			want := append(bytes.Clone(raw[1:]), '!')
+			if !bytes.Equal(r.Replay(), want) {
+				t.Fatal("clipping changed the retained raw bytes")
+			}
+			if len(r.Snapshot()) != 0 {
+				t.Fatal("clipped unfinished output appeared in Snapshot")
+			}
+			r.FlushPartial()
+			if !bytes.Equal(r.Snapshot(), want) || r.Tail(1) != string(want) {
+				t.Fatal("flush changed the clipped raw suffix")
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/runtime/conpty/ring_bounds_test.go
+++ b/backend/internal/adapters/runtime/conpty/ring_bounds_test.go
@@ -1,0 +1,136 @@
+package conpty
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// Keep the expected public budget explicit so this test also runs on the base.
+const scrollbackByteBudget = 1 << 20
+
+func TestRingByteBoundIncludesPartialAndCompleted(t *testing.T) {
+	for _, completed := range []bool{false, true} {
+		t.Run(fmt.Sprint(completed), func(t *testing.T) {
+			r := NewRing()
+			r.Append([]byte("old\n"))
+			stream := bytes.Repeat([]byte("\x1b[2K\rrepaint"), scrollbackByteBudget/4)
+			if completed {
+				stream = append(stream, '\n')
+			}
+			for start := 0; start < len(stream); start += 8192 {
+				r.Append(stream[start:min(start+8192, len(stream))])
+			}
+			want := stream[len(stream)-scrollbackByteBudget:]
+			if got := r.Replay(); !bytes.Equal(got, want) {
+				t.Fatalf("Replay has %d bytes, want the newest %d bytes", len(got), len(want))
+			}
+			if !completed && len(r.Snapshot()) != 0 {
+				t.Fatal("Snapshot retained evicted completed output or included partial output")
+			}
+			r.FlushPartial()
+			if got := r.Snapshot(); !bytes.Equal(got, want) {
+				t.Fatalf("Snapshot after flush has %d bytes, want %d", len(got), len(want))
+			}
+		})
+	}
+}
+
+func TestRingOversizedAppendOwnsItsBytes(t *testing.T) {
+	r := NewRing()
+	raw := bytes.Repeat([]byte("x"), 2*scrollbackByteBudget)
+	raw = append(raw, '\n')
+	r.Append(raw)
+	clear(raw)
+	want := strings.Repeat("x", scrollbackByteBudget-1) + "\n"
+	if got := r.Tail(1); got != want {
+		t.Fatalf("Tail retained %d bytes, want %d independent bytes", len(got), len(want))
+	}
+	replay := r.Replay()
+	clear(replay)
+	if string(r.Snapshot()) != want {
+		t.Fatal("mutating Replay changed stored output")
+	}
+}
+
+func TestRingFlushPartialEnforcesLineLimit(t *testing.T) {
+	r := NewRing()
+	r.Append([]byte("first\n" + strings.Repeat("line\n", MaxOutputLines-1) + "last"))
+	r.FlushPartial()
+	want := strings.Repeat("line\n", MaxOutputLines-1) + "last"
+	if got := string(r.Snapshot()); got != want {
+		t.Fatalf("flush retained %d bytes, want %d with first line evicted", len(got), len(want))
+	}
+	if r.Tail(1) != "last" {
+		t.Fatal("flush did not preserve the final unterminated line")
+	}
+}
+
+func TestRingMixedOperationsMatchRetainedSuffix(t *testing.T) {
+	r := NewRing()
+	var lines []string
+	partial := ""
+	rng := rand.New(rand.NewSource(42))
+	for step := 0; step < 250; step++ {
+		if step%7 == 0 {
+			r.FlushPartial()
+			if partial != "" {
+				lines = append(lines, partial)
+				partial = ""
+			}
+		} else {
+			fragment := strings.Repeat("x", rng.Intn(65536)) + "\r\x1b[0m"
+			if step%3 == 0 {
+				fragment += "\nnext\n"
+			}
+			r.Append([]byte(fragment))
+			parts := strings.SplitAfter(partial+fragment, "\n")
+			partial = parts[len(parts)-1]
+			lines = append(lines, parts[:len(parts)-1]...)
+		}
+		if len(lines) > MaxOutputLines {
+			lines = lines[len(lines)-MaxOutputLines:]
+		}
+		excess := len(strings.Join(lines, "")) + len(partial) - scrollbackByteBudget
+		for excess > 0 && len(lines) > 0 {
+			if len(lines[0]) <= excess {
+				excess -= len(lines[0])
+				lines = lines[1:]
+			} else {
+				lines[0] = lines[0][excess:]
+				excess = 0
+			}
+		}
+		if excess > 0 {
+			partial = partial[excess:]
+		}
+		completed := strings.Join(lines, "")
+		if string(r.Replay()) != completed+partial || string(r.Snapshot()) != completed {
+			t.Fatalf("retained output differs at step %d", step)
+		}
+		for _, count := range []int{0, 1, 4, MaxOutputLines + 1} {
+			want := strings.Join(lines[max(0, len(lines)-count):], "")
+			if r.Tail(count) != want {
+				t.Fatalf("Tail(%d) differs at step %d", count, step)
+			}
+		}
+	}
+}
+
+func BenchmarkRingNewlineFreeStream(b *testing.B) {
+	chunk := bytes.Repeat([]byte("\r\x1b[2Kxx"), 1024)
+	for _, chunks := range []int{8, 128, 512} {
+		b.Run(fmt.Sprint(chunks), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(chunks * len(chunk)))
+			for i := 0; i < b.N; i++ {
+				r := NewRing()
+				for j := 0; j < chunks; j++ {
+					r.Append(chunk)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Cap terminal scrollback at 1 MiB across completed and unfinished output, while retaining the existing 1,000 completed-line limit. Flushing on exit now enforces both limits.

## Why

Audit AD-01: newline-free terminal repainting accumulated without a byte limit and recopied the entire unfinished line on every append. Flushing after 1,000 completed lines also retained a 1,001st entry.

## How

Use lazily grown circular byte storage and a circular list of completed-line lengths. Appends copy new bytes; eviction updates line boundaries and removes the oldest bytes. Snapshot and Tail still exclude unfinished output, and Replay includes it.

Clipping preserves a raw byte suffix and can start inside a character or escape sequence. Replay remains truncated history; the existing rendered terminal surface remains the screen representation. Live output delivery and the host protocol are unchanged.

## Testing

Full local validation covers commit `012a4504f3f59cd20006e6a2c737644e2da9036a`. The original-source regressions fail on the selected base and pass with the fix. Regression coverage includes oversized completed and partial streams, input/output ownership, mixed operations, both circular buffers wrapping, flush boundaries, and raw clipped suffixes.

- Full backend: formatting, `go build ./...`, `go vet ./...`, fresh `go test -count=1 -timeout=15m ./...`, and fresh `go test -race -count=1 -timeout=15m ./...`.
- Full `golangci-lint` v2.12.2 ruleset.
- Native Linux CLI e2e: `go test -tags e2e -count=1 -v ./internal/cli/...`. Exact fresh-install Docker build and smoke run also passed.
- Node 24 `npm ci`, `npm run api`, and generated spec/types drift checks.
- Pinned gitleaks v7.4.0 scan of the single introduced commit.
- Independent source review and combined build/vet/affected-package race checks across all five batch patches.

Affected package tests cross-compiled for Windows amd64 and macOS arm64. Native execution of those package suites was not run locally; remote native jobs cover the workflow's scoped CLI e2e tests.

The 512-chunk synthetic benchmark allocated about 2.9 MB per stream versus 947 MB before the fix (three iterations), with retained history capped at 1 MiB. One earlier focused run failed the unchanged TestKillReq dial assertion; 50 isolated repetitions each on changed and original ring code did not reproduce it. The final focused and full suites passed; the unexplained failure log is preserved.

Publication preflight against `main` at `715e0e06f4746bea969efa30349b26b82116a063`: a clean synthetic merge passed the affected package race suite. The unchanged prepared head also passed `npm run sqlc` using sqlc v1.31.1, with no tracked or untracked generated-code drift. Local checks used Linux, Go 1.26.5 (the workspace version) and Node 24. The merged tree also passed the terminal package race suite and full backend build.

## Checklist

- [x] One independent commit from `main` at the recorded batch base
- [x] One focused change for local audit AD-01
- [x] Repository conventions and relevant regression coverage
- [x] Applicable local Linux validation passed; platform gaps documented
- [x] All 10 remote CI checks, including scoped native Linux/macOS/Windows jobs
