### PR TITLE
fix: bound persistent host controller I/O

### DIFF
--- a/backend/internal/adapters/chatdriver/persistenthost/host.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host.go
@@ -33,6 +33,8 @@ const (
 	startupTimeout   = 10 * time.Second
 	// Host hello is local control-plane I/O and must not stall daemon recovery.
 	handshakeTimeout = time.Second
+	// A stalled controller is detached; its provider and replay state survive.
+	controllerWriteTimeout = 5 * time.Second
 )
 
 // Protocol selects the provider-wire behavior owned by the host.
@@ -522,6 +524,8 @@ func Shutdown(ctx context.Context, dataDir, sessionID string) error {
 
 // Run owns the provider until it exits or an authenticated shutdown arrives.
 func Run(ctx context.Context, cfg Config) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	if len(cfg.Argv) == 0 || !filepath.IsAbs(cfg.Workdir) {
 		return errors.New("chat host requires provider argv and absolute workdir")
 	}
@@ -580,7 +584,12 @@ func Run(ctx context.Context, cfg Config) error {
 			_ = killProviderProcess(context.WithoutCancel(ctx), child)
 			return err
 		}
-		defer func() { _ = h.acp.close(context.WithoutCancel(ctx)) }()
+		defer func() {
+			cancel()
+			h.outputMu.Lock()
+			defer h.outputMu.Unlock()
+			_ = h.acp.close(context.WithoutCancel(ctx))
+		}()
 	}
 	h.cond = sync.NewCond(&h.mu)
 	providerDone := make(chan error, 1)
@@ -605,6 +614,7 @@ func Run(ctx context.Context, cfg Config) error {
 	case runErr = <-providerDone:
 		_ = killProviderProcess(context.WithoutCancel(ctx), child)
 	case <-h.shutdown:
+		cancel()
 		stopProvider()
 	case <-ctx.Done():
 		runErr = ctx.Err()
@@ -615,6 +625,7 @@ func Run(ctx context.Context, cfg Config) error {
 			return err
 		}
 	}
+	cancel()
 	_ = listener.Close()
 	_ = child.Wait()
 	return runErr
@@ -628,6 +639,10 @@ type host struct {
 	token    string
 	acp      *acpRelay
 
+	// outputMu orders controller replay, live frames and relay responses. Take it
+	// before mu, and release mu for network I/O. Detach never needs outputMu.
+	// Relay state also stays stable while its journal is replayed to a controller.
+	outputMu         sync.Mutex
 	mu               sync.Mutex
 	cond             *sync.Cond
 	client           net.Conn
@@ -657,6 +672,12 @@ func (h *host) accept() error {
 }
 
 func (h *host) handle(conn net.Conn) {
+	defer h.detach(conn)
+	stop := context.AfterFunc(h.ctx, func() { _ = conn.Close() })
+	defer stop()
+	if err := conn.SetDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		return
+	}
 	reader := bufio.NewReader(conn)
 	var request hello
 	if err := json.NewDecoder(reader).Decode(&request); err != nil {
@@ -686,11 +707,42 @@ func (h *host) handle(conn net.Conn) {
 	}
 
 	h.mu.Lock()
+	attached := h.client != nil
+	h.mu.Unlock()
+	if attached {
+		_ = json.NewEncoder(conn).Encode(helloResponse{Error: ErrAttached.Error()})
+		return
+	}
+	generation, err := h.attachController(conn)
+	if err != nil {
+		return
+	}
+
+	for {
+		frame, readErr := reader.ReadBytes('\n')
+		if len(frame) > 0 {
+			if err := h.forwardClientFrame(conn, generation, frame); err != nil {
+				return
+			}
+		}
+		if readErr != nil {
+			return
+		}
+	}
+}
+
+func (h *host) attachController(conn net.Conn) (uint64, error) {
+	h.outputMu.Lock()
+	defer h.outputMu.Unlock()
+	h.mu.Lock()
 	if h.client != nil {
 		h.mu.Unlock()
 		_ = json.NewEncoder(conn).Encode(helloResponse{Error: ErrAttached.Error()})
-		_ = conn.Close()
-		return
+		return 0, ErrAttached
+	}
+	if err := h.ctx.Err(); err != nil {
+		h.mu.Unlock()
+		return 0, err
 	}
 	h.client = conn
 	h.clientGeneration++
@@ -699,16 +751,30 @@ func (h *host) handle(conn net.Conn) {
 	if h.acp != nil {
 		response.ACPState = h.acp.snapshot()
 	}
+	detached := append([][]byte(nil), h.detached...)
+	h.mu.Unlock()
 	writeErr := json.NewEncoder(conn).Encode(response)
+	if writeErr == nil {
+		// The authenticated controller outlives the hello budget. Replay has one
+		// total write budget, including every journal span and detached frame.
+		writeErr = conn.SetDeadline(time.Time{})
+	}
+	if writeErr == nil {
+		writeErr = conn.SetWriteDeadline(time.Now().Add(controllerWriteTimeout))
+	}
 	if writeErr == nil && h.acp != nil {
 		writeErr = h.acp.replayTo(h.ctx, conn)
 	}
 	if writeErr == nil {
-		for _, frame := range h.detached {
+		for _, frame := range detached {
 			if _, writeErr = conn.Write(frame); writeErr != nil {
 				break
 			}
 		}
+	}
+	h.mu.Lock()
+	if writeErr == nil && h.client != conn {
+		writeErr = net.ErrClosed
 	}
 	if writeErr == nil {
 		h.detached = h.detached[:0]
@@ -719,49 +785,50 @@ func (h *host) handle(conn net.Conn) {
 		h.cond.Broadcast()
 	}
 	h.mu.Unlock()
-	if writeErr != nil {
-		h.detach(conn)
-		return
-	}
+	return generation, writeErr
+}
 
-	for {
-		frame, readErr := reader.ReadBytes('\n')
-		if len(frame) > 0 {
-			providerFrame := frame
-			var clientFrame []byte
-			h.mu.Lock()
-			if h.acp != nil {
-				var relayErr error
-				var relayed acpClientFrames
-				relayed, relayErr = h.acp.clientFrame(h.ctx, frame, generation)
-				providerFrame = relayed.provider
-				clientFrame = relayed.client
-				if relayErr != nil {
-					h.shutdownOnce.Do(func() { close(h.shutdown) })
-					h.mu.Unlock()
-					h.detach(conn)
-					return
-				}
-			}
-			h.mu.Unlock()
-			if len(providerFrame) > 0 {
-				if _, err := h.stdin.Write(providerFrame); err != nil {
-					readErr = err
-				} else {
-					h.observeClientFrame(providerFrame)
-				}
-			}
-			if readErr == nil && len(clientFrame) > 0 {
-				if _, err := conn.Write(clientFrame); err != nil {
-					readErr = err
-				}
-			}
-		}
-		if readErr != nil {
-			h.detach(conn)
-			return
+func (h *host) forwardClientFrame(conn net.Conn, generation uint64, frame []byte) error {
+	h.outputMu.Lock()
+	h.mu.Lock()
+	if h.client != conn || h.clientGeneration != generation || h.ctx.Err() != nil {
+		h.mu.Unlock()
+		h.outputMu.Unlock()
+		return net.ErrClosed
+	}
+	frames := acpClientFrames{provider: frame}
+	var err error
+	if h.acp != nil {
+		frames, err = h.acp.clientFrame(h.ctx, frame, generation)
+		if err != nil {
+			h.shutdownOnce.Do(func() { close(h.shutdown) })
 		}
 	}
+	h.mu.Unlock()
+	if err == nil && len(frames.client) > 0 {
+		err = writeControllerFrame(conn, frames.client)
+	}
+	h.outputMu.Unlock()
+	if err != nil {
+		return err
+	}
+	// Provider stdin can apply backpressure independently of controller output.
+	// Never keep output ownership while waiting for the provider to read stdin.
+	if len(frames.provider) > 0 {
+		if _, err := h.stdin.Write(frames.provider); err != nil {
+			return err
+		}
+		h.observeClientFrame(frames.provider)
+	}
+	return nil
+}
+
+func writeControllerFrame(conn net.Conn, frame []byte) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(controllerWriteTimeout)); err != nil {
+		return err
+	}
+	_, err := conn.Write(frame)
+	return err
 }
 
 func (h *host) observeClientFrame(frame []byte) {
@@ -804,61 +871,88 @@ func (h *host) detach(conn net.Conn) {
 }
 
 func (h *host) forwardProvider(stdout io.Reader) error {
+	stop := context.AfterFunc(h.ctx, func() {
+		h.mu.Lock()
+		h.cond.Broadcast()
+		h.mu.Unlock()
+	})
+	defer stop()
 	reader := bufio.NewReader(stdout)
 	for {
 		frame, err := reader.ReadBytes('\n')
 		if len(frame) > 0 {
-			h.mu.Lock()
-			retainedByACP := false
-			if h.acp != nil {
-				var relayErr error
-				frame, retainedByACP, relayErr = h.acp.providerFrame(
-					h.ctx, frame, h.clientGeneration, h.client != nil,
-				)
-				if relayErr != nil {
-					h.mu.Unlock()
-					return relayErr
-				}
+			if forwardErr := h.forwardProviderFrame(frame); forwardErr != nil {
+				return forwardErr
 			}
-			if len(frame) == 0 {
-				h.mu.Unlock()
-				if err != nil {
-					return err
-				}
-				continue
-			}
-			if requestID, ok := serverRequestID(frame); ok && !retainedByACP {
-				if _, exists := h.pendingRequests[requestID]; !exists {
-					h.pendingRequests[requestID] = &pendingRequest{frame: append([]byte(nil), frame...)}
-					h.pendingOrder = append(h.pendingOrder, requestID)
-				}
-			}
-			for h.client == nil && h.detachedBytes+len(frame) > maxDetachedBytes {
-				h.cond.Wait()
-			}
-			if h.client != nil {
-				if _, writeErr := h.client.Write(frame); writeErr != nil {
-					_ = h.client.Close()
-					h.client = nil
-					h.bufferPendingRequestsLocked()
-					if _, pending := serverRequestID(frame); !pending && !retainedByACP {
-						h.bufferFrameLocked(frame)
-					}
-				}
-			} else if !retainedByACP {
-				if requestID, pending := serverRequestID(frame); !pending || !h.pendingRequests[requestID].buffered {
-					h.bufferFrameLocked(frame)
-					if pending {
-						h.pendingRequests[requestID].buffered = true
-					}
-				}
-			}
-			h.mu.Unlock()
 		}
 		if err != nil {
 			return err
 		}
 	}
+}
+
+func (h *host) forwardProviderFrame(frame []byte) error {
+	h.outputMu.Lock()
+	defer h.outputMu.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err := h.ctx.Err(); err != nil {
+		return err
+	}
+	retainedByACP := false
+	if h.acp != nil {
+		var err error
+		frame, retainedByACP, err = h.acp.providerFrame(h.ctx, frame, h.clientGeneration, h.client != nil)
+		if err != nil {
+			return err
+		}
+	}
+	if len(frame) == 0 {
+		return nil
+	}
+	if requestID, ok := serverRequestID(frame); ok && !retainedByACP {
+		if _, exists := h.pendingRequests[requestID]; !exists {
+			h.pendingRequests[requestID] = &pendingRequest{frame: append([]byte(nil), frame...)}
+			h.pendingOrder = append(h.pendingOrder, requestID)
+		}
+	}
+	for h.client == nil && !retainedByACP && h.detachedBytes+len(frame) > maxDetachedBytes {
+		if err := h.ctx.Err(); err != nil {
+			return err
+		}
+		// A replacement must acquire output ownership to drain the replay. Drop
+		// that ownership while waiting, then restore the normal lock order.
+		h.outputMu.Unlock()
+		h.cond.Wait()
+		h.mu.Unlock()
+		h.outputMu.Lock()
+		h.mu.Lock()
+	}
+	if conn := h.client; conn != nil {
+		h.mu.Unlock()
+		writeErr := writeControllerFrame(conn, frame)
+		h.mu.Lock()
+		if writeErr != nil {
+			if h.client == conn {
+				h.client = nil
+				h.bufferPendingRequestsLocked()
+			}
+			if _, pending := serverRequestID(frame); !pending && !retainedByACP {
+				h.bufferFrameLocked(frame)
+			}
+			h.mu.Unlock()
+			_ = conn.Close()
+			h.mu.Lock()
+		}
+	} else if !retainedByACP {
+		if requestID, pending := serverRequestID(frame); !pending || !h.pendingRequests[requestID].buffered {
+			h.bufferFrameLocked(frame)
+			if pending {
+				h.pendingRequests[requestID].buffered = true
+			}
+		}
+	}
+	return nil
 }
 
 func serverRequestID(frame []byte) (string, bool) {

--- a/backend/internal/adapters/chatdriver/persistenthost/host_io_test.go
+++ b/backend/internal/adapters/chatdriver/persistenthost/host_io_test.go
@@ -1,0 +1,319 @@
+package persistenthost
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type hostIOWriter struct{}
+
+func (hostIOWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (hostIOWriter) Close() error                { return nil }
+
+type observedHostWait struct {
+	sync.Locker
+	waiting chan struct{}
+	once    sync.Once
+}
+
+func (l *observedHostWait) Unlock() {
+	l.once.Do(func() { close(l.waiting) })
+	l.Locker.Unlock()
+}
+
+type observedHostConn struct {
+	net.Conn
+	writeStarted chan struct{}
+	once         sync.Once
+}
+
+func (c *observedHostConn) Write(p []byte) (int, error) {
+	if len(p) >= 32<<10 {
+		c.once.Do(func() { close(c.writeStarted) })
+	}
+	return c.Conn.Write(p)
+}
+
+func newIOTestHost(t *testing.T) *host {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	h := &host{ctx: ctx, stdin: hostIOWriter{}, token: "test-capability", pendingRequests: make(map[string]*pendingRequest), shutdown: make(chan struct{})}
+	h.cond = sync.NewCond(&h.mu)
+	return h
+}
+
+func connectIOTestHost(t *testing.T, h *host) (net.Conn, *observedHostConn, <-chan struct{}) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	accepted := make(chan *observedHostConn, 1)
+	done := make(chan struct{})
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			close(done)
+			return
+		}
+		_ = conn.(*net.TCPConn).SetWriteBuffer(1024)
+		observed := &observedHostConn{Conn: conn, writeStarted: make(chan struct{})}
+		accepted <- observed
+		h.handle(observed)
+		close(done)
+	}()
+	peer, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := <-accepted
+	t.Cleanup(func() {
+		_ = peer.Close()
+		_ = server.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("controller handler did not exit after socket close")
+		}
+	})
+	return peer, server, done
+}
+
+func attachIOTestHost(t *testing.T, h *host) (net.Conn, *observedHostConn, *bufio.Reader, helloResponse) {
+	t.Helper()
+	peer, server, _ := connectIOTestHost(t, h)
+	_ = peer.SetReadDeadline(time.Now().Add(8 * time.Second))
+	if err := json.NewEncoder(peer).Encode(hello{Version: ProtocolVersion, Token: h.token, Action: "attach"}); err != nil {
+		t.Fatal(err)
+	}
+	reader := bufio.NewReader(peer)
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response helloResponse
+	if err := json.Unmarshal(line, &response); err != nil || !response.OK {
+		t.Fatalf("hello = %s, error = %v", line, err)
+	}
+	return peer, server, reader, response
+}
+
+func assertHostStateAvailable(t *testing.T, h *host) {
+	t.Helper()
+	available := make(chan struct{})
+	go func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		close(available)
+	}()
+	select {
+	case <-available:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("controller socket write held the shared host mutex")
+	}
+}
+
+func TestHostServerExpiresIncompleteHello(t *testing.T) {
+	h := newIOTestHost(t)
+	peer, _, done := connectIOTestHost(t, h)
+	if _, err := io.WriteString(peer, `{"version":`); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * handshakeTimeout):
+		t.Fatal("incomplete unauthenticated hello outlived the server handshake budget")
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.client != nil || h.clientGeneration != 0 {
+		t.Fatal("incomplete hello acquired provider ownership")
+	}
+}
+
+func TestHostStalledControllerReleasesStateAndReplaysReplacement(t *testing.T) {
+	h := newIOTestHost(t)
+	peer, server, reader, _ := attachIOTestHost(t, h)
+	provider, output := io.Pipe()
+	forwardDone := make(chan error, 1)
+	go func() { forwardDone <- h.forwardProvider(provider) }()
+	t.Cleanup(func() {
+		_ = peer.Close()
+		_ = output.Close()
+		_ = provider.Close()
+		select {
+		case <-forwardDone:
+		case <-time.After(2 * time.Second):
+			t.Error("provider forwarding did not exit")
+		}
+	})
+	request := []byte("{\"id\":700,\"method\":\"approval\"}\n")
+	if _, err := output.Write(request); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFrame(t, reader); !bytes.Equal(got, request) {
+		t.Fatal("pending provider request changed")
+	}
+	h.observeClientFrame([]byte(`{"id":42,"method":"work"}`))
+	large := []byte("{\"method\":\"update\",\"data\":\"" + strings.Repeat("x", 2<<20) + "\"}\n")
+	continued := make(chan error, 1)
+	go func() {
+		_, writeErr := output.Write(large)
+		if writeErr == nil {
+			_, writeErr = output.Write([]byte("{\"method\":\"after-stall\"}\n"))
+		}
+		continued <- writeErr
+	}()
+	<-server.writeStarted
+	assertHostStateAvailable(t, h)
+	// An authenticated rival should receive the ownership error promptly even
+	// while the current controller has stopped consuming provider output.
+	rival, _, _ := connectIOTestHost(t, h)
+	_ = rival.SetDeadline(time.Now().Add(handshakeTimeout))
+	if err := json.NewEncoder(rival).Encode(hello{Version: ProtocolVersion, Token: h.token, Action: "attach"}); err != nil {
+		t.Fatal(err)
+	}
+	var rejected helloResponse
+	if err := json.NewDecoder(rival).Decode(&rejected); err != nil || rejected.Error != ErrAttached.Error() {
+		t.Fatalf("rival hello = %+v, error = %v", rejected, err)
+	}
+	select {
+	case err := <-continued:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("nonreading controller prevented provider forwarding from continuing")
+	}
+	h.mu.Lock()
+	attached := h.client != nil
+	h.mu.Unlock()
+	if attached {
+		t.Fatal("nonreading controller was not detached")
+	}
+	_, _, replacement, response := attachIOTestHost(t, h)
+	if response.NextRequestID != 42 {
+		t.Fatalf("replacement request id = %d, want 42", response.NextRequestID)
+	}
+	for i, want := range [][]byte{request, large, []byte("{\"method\":\"after-stall\"}\n")} {
+		if got := readFrame(t, replacement); !bytes.Equal(got, want) {
+			t.Fatalf("replacement frame %d changed or reordered", i)
+		}
+	}
+	select {
+	case <-h.shutdown:
+		t.Fatal("controller timeout shut down provider ownership")
+	default:
+	}
+}
+
+func TestHostACPReplayReleasesStateAndSurvivesStalledController(t *testing.T) {
+	h := newIOTestHost(t)
+	h.acp = newTestACPRelay(t)
+	prompt := relayClientFrame(t, h.acp, []byte(`{"id":1,"method":"session/prompt","params":{}}`), 0)
+	update := []byte("{\"method\":\"session/update\",\"params\":{\"data\":\"" + strings.Repeat("x", 2<<20) + "\"}}\n")
+	_, _ = relayProviderFrame(t, h.acp, update, 0, false)
+	_, _ = relayProviderFrame(t, h.acp, []byte(`{"id":`+frameID(t, prompt)+`,"result":{"stopReason":"end_turn"}}`), 0, false)
+	expected := bytes.Join(relayReplayFrames(t, h.acp), nil)
+	peer, server, _, response := attachIOTestHost(t, h)
+	if response.ACPState == nil || response.ACPState.PendingResultEventID == "" {
+		t.Fatal("handshake lost durable prompt state")
+	}
+	<-server.writeStarted
+	assertHostStateAvailable(t, h)
+	_ = peer.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.mu.Lock()
+		detached := h.client == nil
+		h.mu.Unlock()
+		if detached {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("failed ACP replay retained the closed controller")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	_, _, reader, replacement := attachIOTestHost(t, h)
+	if replacement.ACPState.PendingResultEventID != response.ACPState.PendingResultEventID {
+		t.Fatal("replacement changed the durable result identity")
+	}
+	actual := append(readFrame(t, reader), readFrame(t, reader)...)
+	if !bytes.Equal(actual, expected) {
+		t.Fatal("replacement ACP replay changed journal contents or order")
+	}
+	if errors.Is(h.ctx.Err(), context.Canceled) {
+		t.Fatal("controller disconnection canceled host ownership")
+	}
+}
+
+func TestHostServerClearsHelloDeadlineForIdleController(t *testing.T) {
+	h := newIOTestHost(t)
+	_, _, reader, _ := attachIOTestHost(t, h)
+	time.Sleep(handshakeTimeout + 50*time.Millisecond)
+	frame := "{\"method\":\"after-idle\"}\n"
+	if err := h.forwardProvider(strings.NewReader(frame)); !errors.Is(err, io.EOF) {
+		t.Fatal(err)
+	}
+	if got := readFrame(t, reader); string(got) != frame {
+		t.Fatal("idle controller did not receive the later provider frame")
+	}
+}
+
+func TestHostCancellationReleasesDetachedCapacityWait(t *testing.T) {
+	h := newIOTestHost(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h.ctx = ctx
+	waiting := make(chan struct{})
+	h.cond = sync.NewCond(&observedHostWait{Locker: &h.mu, waiting: waiting})
+	// Exercise a full replay's capacity accounting without retaining 32 MiB in
+	// this cancellation-only test. No replay or buffer content is consumed.
+	h.detachedBytes = maxDetachedBytes
+	done := make(chan error, 1)
+	go func() { done <- h.forwardProvider(strings.NewReader("next\n")) }()
+	// Cond.Wait releases its locker after registering the waiter, so this signal
+	// proves cancellation reaches the capacity wait rather than an earlier check.
+	select {
+	case <-waiting:
+	case <-time.After(time.Second):
+		t.Fatal("provider forwarding did not enter the capacity wait")
+	}
+	assertHostStateAvailable(t, h)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("capacity wait error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled host remained blocked on detached capacity")
+	}
+}
+
+func TestHostOldGenerationCannotForwardAfterReplacement(t *testing.T) {
+	h := newIOTestHost(t)
+	_, first, _, _ := attachIOTestHost(t, h)
+	h.detach(first)
+	_, _, _, _ = attachIOTestHost(t, h)
+	if err := h.forwardClientFrame(first, 1, []byte(`{"id":99,"method":"stale"}`)); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("stale controller error = %v", err)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.maxRequestID != 0 || h.clientGeneration != 2 {
+		t.Fatal("stale controller changed replacement request state")
+	}
+}


### PR DESCRIPTION
## What

Bound persistent-host server hellos to one second and controller writes to five seconds. A nonreading controller is detached so another controller can reconnect to the same provider and replay retained output.

## Why

Addresses cleanup finding AD-10 (RUNTIME-3). An incomplete local hello previously kept its handler alive indefinitely. Controller replay and live output also performed unbounded socket writes while holding the shared host mutex, preventing attachment-state changes when a controller stopped reading.

## How

An output mutex orders controller hello, replay, live frames, and local ACP responses. The state mutex is released for controller network I/O, and detachment can close the socket independently. ACP relay changes use the same output ownership so replay cannot race journal truncation or request-state changes.

The complete replay shares one five-second write budget. A failed replay keeps its pending requests and durable ACP journal available for a replacement. Successful authenticated controllers have their hello read deadline cleared, so an idle controller remains attached. Cancellation closes controller connections and wakes a provider waiting for detached replay capacity.

Provider-stdin backpressure remains outside both host mutexes. Frame-size limits and the hello decoder's buffered-frame handling belong to AD-11 and are intentionally omitted. A controller that cannot consume replay within five seconds is disconnected even if it is still making slow progress; provider ownership and retained replay survive.

## Testing

Full local validation covers commit `78152ec4b4e819adf4945ae96a4ddaf9484a1b16`. The original-source regressions fail on the selected base and pass with the fix. Regression coverage includes incomplete hellos, stalled live output and ACP replay, shared-state availability, ordered replacement replay, pending requests, idle controllers, cancellation during a capacity wait and stale generations.

- Full backend: formatting, `go build ./...`, `go vet ./...`, fresh `go test -count=1 -timeout=15m ./...`, and fresh `go test -race -count=1 -timeout=15m ./...`.
- Full `golangci-lint` v2.12.2 ruleset.
- Native Linux CLI e2e: `go test -tags e2e -count=1 -v ./internal/cli/...`. Exact fresh-install Docker build and smoke run also passed.
- Node 24 `npm ci`, `npm run api`, and generated spec/types drift checks.
- Pinned gitleaks v7.4.0 scan of the single introduced commit.
- Independent source review and combined build/vet/affected-package race checks across all five batch patches.

macOS arm64 test compilation and Windows amd64 production-package compilation passed. Windows test compilation fails identically on base and head because unchanged host_race_test.go uses syscall.Kill. Native macOS/Windows execution was not run locally; remote native jobs cover the workflow's scoped CLI e2e tests.

One initial complete ordinary suite failed the unchanged TestQueuedEditAttachmentChanges/append_at_size_limit attachment assertion in the chat package. The full rerun at the same head passed. The isolated subtest passed ten times per head/base comparison and the full table passed three times each. The cause remains unestablished; the failed log and diagnostic overlays are preserved.

Publication preflight against `main` at `715e0e06f4746bea969efa30349b26b82116a063`: a clean synthetic merge passed the affected package race suite. The unchanged prepared head also passed `npm run sqlc` using sqlc v1.31.1, with no tracked or untracked generated-code drift. Local checks used Linux, Go 1.26.5 (the workspace version) and Node 24. The merged tree also passed the full backend build.

## Checklist

- [x] One independent commit from `main` at the recorded batch base
- [x] One focused change for local audit AD-10
- [x] Repository conventions and relevant regression coverage
- [x] Applicable local Linux validation passed; platform gaps documented
- [x] All 10 remote CI checks, including scoped native Linux/macOS/Windows jobs
