### PR TITLE
fix: keep GitHub validators paired with cached bodies

### DIFF
--- a/backend/internal/adapters/scm/github/client.go
+++ b/backend/internal/adapters/scm/github/client.go
@@ -79,9 +79,15 @@ type Client struct {
 	userAgent  string
 
 	mu       sync.Mutex
-	etagOut  map[string]string // key (method+path+query) -> last-seen ETag
-	bodyOut  map[string][]byte // key -> last-seen body for 304 replay
-	cacheLRU []string          // insertion-order keys for FIFO eviction
+	cache    map[string]*restCacheEntry // key (method+path+query) -> immutable entry
+	cacheLRU []string                   // insertion-order keys for FIFO eviction
+}
+
+// restCacheEntry keeps a validator paired with its representation. Entries and
+// their bytes are immutable so an in-flight request can retain their identity.
+type restCacheEntry struct {
+	etag string
+	body []byte
 }
 
 // cacheMaxEntries caps the number of distinct (method,path,query) tuples
@@ -101,8 +107,7 @@ func NewClient(opts ClientOptions) *Client {
 		restBase:   opts.RESTBase,
 		graphqlURL: opts.GraphQLURL,
 		userAgent:  opts.UserAgent,
-		etagOut:    map[string]string{},
-		bodyOut:    map[string][]byte{},
+		cache:      map[string]*restCacheEntry{},
 	}
 	if c.http == nil {
 		c.http = &http.Client{Timeout: 30 * time.Second}
@@ -120,8 +125,7 @@ func NewClient(opts ClientOptions) *Client {
 }
 
 // RESTResponse is what doREST returns to the Provider. NotModified=true
-// means the cached body is being served; the byte slice is unchanged from
-// the previous fresh fetch.
+// means a copy of the revalidated cached body is being served. Callers own Body.
 type RESTResponse struct {
 	StatusCode  int
 	NotModified bool
@@ -181,12 +185,10 @@ func (c *Client) doRESTWithETag(ctx context.Context, path string, q url.Values, 
 func (c *Client) doREST(ctx context.Context, method, path string, q url.Values, body any) (RESTResponse, error) {
 	cacheable := method == http.MethodGet
 	cacheKey := method + " " + path + "?" + q.Encode()
-	var prevETag string
-	var prevBody []byte
+	var prev *restCacheEntry
 	if cacheable {
 		c.mu.Lock()
-		prevETag = c.etagOut[cacheKey]
-		prevBody = c.bodyOut[cacheKey]
+		prev = c.cache[cacheKey]
 		c.mu.Unlock()
 	}
 
@@ -213,8 +215,8 @@ func (c *Client) doREST(ctx context.Context, method, path string, q url.Values, 
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	req.Header.Set("User-Agent", c.userAgent)
-	if prevETag != "" {
-		req.Header.Set("If-None-Match", prevETag)
+	if prev != nil {
+		req.Header.Set("If-None-Match", prev.etag)
 	}
 	if err := c.authorize(ctx, req); err != nil {
 		return RESTResponse{}, err
@@ -227,15 +229,20 @@ func (c *Client) doREST(ctx context.Context, method, path string, q url.Values, 
 	defer func() { _ = resp.Body.Close() }()
 
 	if cacheable && resp.StatusCode == http.StatusNotModified {
-		// Replay the cached body. Update the ETag if GitHub returned a
-		// fresher one — some endpoints rotate ETags on weak revalidation.
-		newETag := resp.Header.Get("ETag")
-		if newETag != "" && newETag != prevETag {
+		if prev == nil {
+			return RESTResponse{StatusCode: resp.StatusCode}, fmt.Errorf("github scm: GET %s returned 304 without a cached body", path)
+		}
+		newETag := firstNonEmptyHeader(resp.Header.Get("ETag"), prev.etag)
+		if newETag != prev.etag {
 			c.mu.Lock()
-			c.etagOut[cacheKey] = newETag
+			// A concurrent fetch or revalidation may have replaced this entry,
+			// or eviction may have removed it. Refresh only the pair we sent.
+			if c.cache[cacheKey] == prev {
+				c.cache[cacheKey] = &restCacheEntry{etag: newETag, body: prev.body}
+			}
 			c.mu.Unlock()
 		}
-		return RESTResponse{StatusCode: resp.StatusCode, NotModified: true, ETag: newETag, Body: prevBody}, nil
+		return RESTResponse{StatusCode: resp.StatusCode, NotModified: true, ETag: newETag, Body: bytes.Clone(prev.body)}, nil
 	}
 
 	b, readErr := io.ReadAll(resp.Body)
@@ -246,10 +253,7 @@ func (c *Client) doREST(ctx context.Context, method, path string, q url.Values, 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		etag := resp.Header.Get("ETag")
 		if cacheable && etag != "" {
-			// Defensive copy: GitHub's HTTP body is owned by net/http's
-			// buffer pool. Holding the raw slice in our cache would let a
-			// later caller mutate or alias the same backing array.
-			c.storeCacheEntry(cacheKey, etag, append([]byte(nil), b...))
+			c.storeCacheEntry(cacheKey, etag, b)
 		}
 		return RESTResponse{StatusCode: resp.StatusCode, ETag: etag, Body: b}, nil
 	}
@@ -371,18 +375,17 @@ func (c *Client) fetchPlainText(ctx context.Context, path string) ([]byte, error
 // the access pattern is "one PR per poll cycle"; an LRU would just add
 // bookkeeping without changing eviction order in practice.
 func (c *Client) storeCacheEntry(cacheKey, etag string, body []byte) {
+	entry := &restCacheEntry{etag: etag, body: bytes.Clone(body)}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if _, exists := c.etagOut[cacheKey]; !exists {
+	if _, exists := c.cache[cacheKey]; !exists {
 		c.cacheLRU = append(c.cacheLRU, cacheKey)
 	}
-	c.etagOut[cacheKey] = etag
-	c.bodyOut[cacheKey] = body
+	c.cache[cacheKey] = entry
 	for len(c.cacheLRU) > cacheMaxEntries {
 		evict := c.cacheLRU[0]
 		c.cacheLRU = c.cacheLRU[1:]
-		delete(c.etagOut, evict)
-		delete(c.bodyOut, evict)
+		delete(c.cache, evict)
 	}
 }
 

--- a/backend/internal/adapters/scm/github/client_cache_test.go
+++ b/backend/internal/adapters/scm/github/client_cache_test.go
@@ -1,0 +1,320 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type cacheTestTransport func(*http.Request) (*http.Response, error)
+
+func (f cacheTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type cacheRequestKey struct{}
+
+func cacheTestRequest(ctx context.Context, client *Client, stage, path string) (RESTResponse, error) {
+	return client.doREST(context.WithValue(ctx, cacheRequestKey{}, stage), http.MethodGet, path, nil, nil)
+}
+
+func cacheTestResponse(status int, etag, body string) *http.Response {
+	header := make(http.Header)
+	if etag != "" {
+		header.Set("ETag", etag)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestRESTCacheRotatedETagDoesNotReplaceCurrentEntry(t *testing.T) {
+	for _, interleave := range []string{"replacement", "eviction", "eviction_then_reinsert", "replacement_then_original"} {
+		t.Run(interleave, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			started, release := make(chan struct{}), make(chan struct{})
+			const path = "/repos/example/project/pulls/7"
+			const oldETag, oldBody = `W/"original"`, `{"state":"open"}`
+			const nextETag, nextBody = `W/"replacement"`, `{"state":"closed"}`
+			const rotatedETag = `W/"original-revalidated"`
+			wantETag, wantBody := nextETag, nextBody
+			switch interleave {
+			case "eviction":
+				wantETag = ""
+			case "eviction_then_reinsert", "replacement_then_original":
+				wantETag, wantBody = oldETag, oldBody
+			}
+			client := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: cacheTestTransport(func(req *http.Request) (*http.Response, error) {
+				switch req.Context().Value(cacheRequestKey{}) {
+				case "seed", "reinsert":
+					return cacheTestResponse(http.StatusOK, oldETag, oldBody), nil
+				case "conditional":
+					if got := req.Header.Get("If-None-Match"); got != oldETag {
+						return nil, fmt.Errorf("conditional validator = %q, want %q", got, oldETag)
+					}
+					close(started)
+					select {
+					case <-release:
+						return cacheTestResponse(http.StatusNotModified, rotatedETag, ""), nil
+					case <-req.Context().Done():
+						return nil, req.Context().Err()
+					}
+				case "replace", "fill":
+					return cacheTestResponse(http.StatusOK, nextETag, nextBody), nil
+				case "probe":
+					if got := req.Header.Get("If-None-Match"); got != wantETag {
+						return nil, fmt.Errorf("subsequent validator = %q, want %q after %s", got, wantETag, interleave)
+					}
+					if wantETag == "" {
+						return cacheTestResponse(http.StatusOK, nextETag, nextBody), nil
+					}
+					return cacheTestResponse(http.StatusNotModified, wantETag, ""), nil
+				default:
+					return nil, fmt.Errorf("unexpected request stage: %v", req.Context().Value(cacheRequestKey{}))
+				}
+			})}})
+			if _, err := cacheTestRequest(ctx, client, "seed", path); err != nil {
+				t.Fatal(err)
+			}
+			type result struct {
+				response RESTResponse
+				err      error
+			}
+			done := make(chan result, 1)
+			go func() {
+				response, err := cacheTestRequest(ctx, client, "conditional", path)
+				done <- result{response, err}
+			}()
+			select {
+			case <-started:
+			case <-ctx.Done():
+				t.Fatal("conditional request did not start")
+			}
+			if interleave == "replacement" || interleave == "replacement_then_original" {
+				if _, err := cacheTestRequest(ctx, client, "replace", path); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				for i := 0; i < cacheMaxEntries; i++ {
+					if _, err := cacheTestRequest(ctx, client, "fill", fmt.Sprintf("/repos/example/project/pulls/%d", i+100)); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if interleave == "eviction_then_reinsert" || interleave == "replacement_then_original" {
+				if _, err := cacheTestRequest(ctx, client, "reinsert", path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			close(release)
+			select {
+			case got := <-done:
+				if got.err != nil {
+					t.Fatal(got.err)
+				}
+				if got.response.StatusCode != http.StatusNotModified || !got.response.NotModified || got.response.ETag != rotatedETag || string(got.response.Body) != oldBody {
+					t.Fatalf("revalidated snapshot = %+v, want original body with rotated validator", got.response)
+				}
+			case <-ctx.Done():
+				t.Fatal("conditional request did not finish")
+			}
+			response, err := cacheTestRequest(ctx, client, "probe", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(response.Body) != wantBody {
+				t.Fatalf("subsequent body = %q, want %q", response.Body, wantBody)
+			}
+		})
+	}
+}
+
+func TestRESTCacheRevalidationAndBodyOwnership(t *testing.T) {
+	for _, body := range []string{`{"state":"open"}`, ""} {
+		for _, responseETag := range []string{`W/"rotated"`, `W/"original"`, ""} {
+			t.Run(fmt.Sprintf("body=%q/etag=%q", body, responseETag), func(t *testing.T) {
+				const originalETag = `W/"original"`
+				wantETag := originalETag
+				if responseETag != "" {
+					wantETag = responseETag
+				}
+				calls := 0
+				client := NewClient(ClientOptions{
+					Token: StaticTokenSource("test-token"),
+					HTTPClient: &http.Client{Transport: cacheTestTransport(func(req *http.Request) (*http.Response, error) {
+						calls++
+						if req.Method != http.MethodGet || req.Header.Get("Authorization") != "Bearer test-token" || req.Header.Get("Accept") != "application/vnd.github+json" || req.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+							return nil, fmt.Errorf("unexpected REST request contract: %s %+v", req.Method, req.Header)
+						}
+						expected := ""
+						if calls == 2 {
+							expected = originalETag
+						} else if calls > 2 {
+							expected = wantETag
+						}
+						if got := req.Header.Get("If-None-Match"); got != expected {
+							return nil, fmt.Errorf("request %d validator = %q, want %q", calls, got, expected)
+						}
+						if calls == 1 {
+							return cacheTestResponse(http.StatusOK, originalETag, body), nil
+						}
+						return cacheTestResponse(http.StatusNotModified, responseETag, ""), nil
+					})},
+				})
+				for i := 0; i < 4; i++ {
+					response, err := cacheTestRequest(context.Background(), client, "", "/repos/example/project/pulls/7")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(response.Body) != body {
+						t.Fatalf("response %d body = %q, want %q", i, response.Body, body)
+					}
+					if i > 0 && (response.StatusCode != http.StatusNotModified || !response.NotModified || response.ETag != wantETag) {
+						t.Fatalf("revalidated response = %+v, want ETag %q", response, wantETag)
+					}
+					if len(response.Body) > 0 {
+						response.Body[0] = '!'
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRESTCacheNotModifiedWithoutEntry(t *testing.T) {
+	calls := 0
+	client := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: cacheTestTransport(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if got := req.Header.Get("If-None-Match"); got != "" {
+			return nil, fmt.Errorf("uncached request sent validator %q", got)
+		}
+		return cacheTestResponse(http.StatusNotModified, `W/"unsolicited"`, ""), nil
+	})}})
+	for i := 0; i < 2; i++ {
+		response, err := cacheTestRequest(context.Background(), client, "", "/repos/example/project/pulls/7")
+		if err == nil || response.StatusCode != http.StatusNotModified || response.NotModified || response.ETag != "" || len(response.Body) != 0 {
+			t.Fatalf("uncached 304 = %+v, %v; want an error without a usable cached response", response, err)
+		}
+	}
+	if calls != 2 {
+		t.Fatalf("requests = %d, want 2", calls)
+	}
+}
+
+func TestRESTCacheOverlappingRotationsKeepFirstCompletedEntry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	started := make(chan string, 2)
+	firstRelease, secondRelease := make(chan struct{}), make(chan struct{})
+	client := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: cacheTestTransport(func(req *http.Request) (*http.Response, error) {
+		stage, _ := req.Context().Value(cacheRequestKey{}).(string)
+		switch stage {
+		case "seed":
+			return cacheTestResponse(http.StatusOK, `W/"original"`, "original body"), nil
+		case "first", "second":
+			if got := req.Header.Get("If-None-Match"); got != `W/"original"` {
+				return nil, fmt.Errorf("%s validator = %q, want original", stage, got)
+			}
+			started <- stage
+			release := firstRelease
+			if stage == "second" {
+				release = secondRelease
+			}
+			select {
+			case <-release:
+				return cacheTestResponse(http.StatusNotModified, fmt.Sprintf(`W/"%s"`, stage), ""), nil
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+		case "probe":
+			if got := req.Header.Get("If-None-Match"); got != `W/"first"` {
+				return nil, fmt.Errorf("completed rotation was overwritten: validator = %q, want first", got)
+			}
+			return cacheTestResponse(http.StatusNotModified, "", ""), nil
+		default:
+			return nil, fmt.Errorf("unexpected request stage %q", stage)
+		}
+	})}})
+	const path = "/repos/example/project/pulls/7"
+	if _, err := cacheTestRequest(ctx, client, "seed", path); err != nil {
+		t.Fatal(err)
+	}
+	firstDone, secondDone := make(chan error, 1), make(chan error, 1)
+	for _, request := range []struct {
+		stage string
+		done  chan error
+	}{{"first", firstDone}, {"second", secondDone}} {
+		go func() {
+			response, err := cacheTestRequest(ctx, client, request.stage, path)
+			if err == nil && (response.ETag != fmt.Sprintf(`W/"%s"`, request.stage) || string(response.Body) != "original body") {
+				err = fmt.Errorf("%s response = %+v, want its revalidated snapshot", request.stage, response)
+			}
+			request.done <- err
+		}()
+	}
+	for range 2 {
+		select {
+		case <-started:
+		case <-ctx.Done():
+			t.Fatal("both conditional requests did not start")
+		}
+	}
+	for _, step := range []struct {
+		release chan struct{}
+		done    chan error
+	}{{firstRelease, firstDone}, {secondRelease, secondDone}} {
+		close(step.release)
+		select {
+		case err := <-step.done:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-ctx.Done():
+			t.Fatal("conditional request did not finish")
+		}
+	}
+	if _, err := cacheTestRequest(ctx, client, "probe", path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRESTCacheConcurrentResponseOwnership(t *testing.T) {
+	client := NewClient(ClientOptions{HTTPClient: &http.Client{Transport: cacheTestTransport(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("If-None-Match") == "" {
+			return cacheTestResponse(http.StatusOK, `W/"original"`, "original body"), nil
+		}
+		return cacheTestResponse(http.StatusNotModified, `W/"original"`, ""), nil
+	})}})
+	const path = "/repos/example/project/pulls/7"
+	if _, err := cacheTestRequest(context.Background(), client, "", path); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			response, err := cacheTestRequest(context.Background(), client, "", path)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if string(response.Body) != "original body" {
+				t.Errorf("body = %q, want original body", response.Body)
+				return
+			}
+			response.Body[0] = '!'
+		})
+	}
+	wg.Wait()
+	response, err := cacheTestRequest(context.Background(), client, "", path)
+	if err != nil || string(response.Body) != "original body" {
+		t.Fatalf("cached response after caller mutations = %+v, %v", response, err)
+	}
+}


### PR DESCRIPTION
## What

Keep GitHub REST ETags paired with the body that a conditional request revalidated.

## Why

The remaining GitHub portion of audit AD-05 allows a delayed 304 response to replace the validator after another request has replaced or evicted its cached body. Subsequent requests can then send a validator belonging to a different representation.

## How

Store immutable ETag/body entries and refresh a rotated validator only while the original entry is still current. Return owned body copies so callers cannot change retained representations. Preserve valid empty bodies, retain the sent validator when a 304 omits it, and return an error for an unsolicited 304 without a cached representation.

The existing cache keys, 512-entry FIFO policy, authentication, and HTTP error classification remain in place. The GitLab portion was merged in #5148. GitHub error classification remains outside this change.

## Testing

Full local validation covers commit `0f98a2d9fa0c10c6abc21991e6b65785d3d0b21a`. The original-source regressions fail on the selected base and pass with the fix. Regression coverage includes deterministic replacement, eviction/reinsertion, overlapping rotations, missing validators, empty bodies, unsolicited 304 responses and concurrent caller mutation.

- Full backend: formatting, `go build ./...`, `go vet ./...`, fresh `go test -count=1 -timeout=15m ./...`, and fresh `go test -race -count=1 -timeout=15m ./...`.
- Full `golangci-lint` v2.12.2 ruleset.
- Native Linux CLI e2e: `go test -tags e2e -count=1 -v ./internal/cli/...`. Exact fresh-install Docker build and smoke run also passed.
- Node 24 `npm ci`, `npm run api`, and generated spec/types drift checks.
- Pinned gitleaks v7.4.0 scan of the single introduced commit.
- Independent source review and combined build/vet/affected-package race checks across all five batch patches.

Affected package tests cross-compiled for Windows amd64 and macOS arm64. Native execution of those package suites was not run locally; remote native jobs cover the workflow's scoped CLI e2e tests.

Publication preflight against `main` at `715e0e06f4746bea969efa30349b26b82116a063`: a clean synthetic merge passed the affected package race suite. The unchanged prepared head also passed `npm run sqlc` using sqlc v1.31.1, with no tracked or untracked generated-code drift. Local checks used Linux, Go 1.26.5 (the workspace version) and Node 24.

## Checklist

- [x] One independent commit from `main` at the recorded batch base
- [x] One focused change for local audit AD-05
- [x] Repository conventions and relevant regression coverage
- [x] Applicable local Linux validation passed; platform gaps documented
- [x] All 10 remote CI checks, including scoped native Linux/macOS/Windows jobs
