### PR TITLE
fix(review): reclaim worker locks and honor queued cancellation

### DIFF
--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -89,11 +89,15 @@ type Engine struct {
 	clock    func() time.Time
 	newID    func() string
 
-	// triggerMu guards triggerLocks; triggerLocks holds one mutex per worker
-	// session so concurrent Trigger calls for the same worker serialise (see
-	// lockWorker). Distinct workers never contend.
+	// triggerMu guards triggerLocks and their reference counts. Each entry
+	// serialises operations for one worker and lives only while held or awaited.
 	triggerMu    sync.Mutex
-	triggerLocks map[domain.SessionID]*sync.Mutex
+	triggerLocks map[domain.SessionID]*workerLock
+}
+
+type workerLock struct {
+	held chan struct{}
+	refs int
 }
 
 const autoReviewFailedRetryLimit = 3
@@ -116,28 +120,55 @@ func New(d Deps) *Engine {
 		launcher:     d.Launcher,
 		clock:        clock,
 		newID:        newID,
-		triggerLocks: make(map[domain.SessionID]*sync.Mutex),
+		triggerLocks: make(map[domain.SessionID]*workerLock),
 	}
 }
 
-// lockWorker serialises Trigger calls for a single worker session and returns
+// lockWorker serialises operations for a single worker session and returns
 // the unlock func. Without it, two concurrent triggers for the same worker can
 // both pass the per-commit idempotency check and each spawn a reviewer against
 // the same deterministic handle, leaving two running runs for one commit (#242).
 //
-// The per-worker mutex is created on first use and kept for the lifetime of the
-// engine; the entry is a single pointer, so the unbounded-by-session-count map
-// is a negligible, bounded-in-practice cost.
-func (e *Engine) lockWorker(id domain.SessionID) func() {
-	e.triggerMu.Lock()
-	mu, ok := e.triggerLocks[id]
-	if !ok {
-		mu = &sync.Mutex{}
-		e.triggerLocks[id] = mu
+// References include the holder and every waiter so releasing or cancelling
+// one caller cannot replace an entry still used by another. Waiting is
+// cancellable; the holder keeps the lock until its operation returns.
+func (e *Engine) lockWorker(ctx stdctx.Context, id domain.SessionID) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+	e.triggerMu.Lock()
+	lock := e.triggerLocks[id]
+	if lock == nil {
+		lock = &workerLock{held: make(chan struct{}, 1)}
+		e.triggerLocks[id] = lock
+	}
+	lock.refs++
 	e.triggerMu.Unlock()
-	mu.Lock()
-	return mu.Unlock
+	release := func() {
+		e.triggerMu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(e.triggerLocks, id)
+		}
+		e.triggerMu.Unlock()
+	}
+	select {
+	case <-ctx.Done():
+		release()
+		return nil, ctx.Err()
+	case lock.held <- struct{}{}:
+		unlock := sync.OnceFunc(func() {
+			<-lock.held
+			release()
+		})
+		// Cancellation and acquisition can become ready together. Do not start
+		// an operation for a caller already cancelled during the handoff.
+		if err := ctx.Err(); err != nil {
+			unlock()
+			return nil, err
+		}
+		return unlock, nil
+	}
 }
 
 // TriggerResult is the outcome of a trigger: the (new or existing) run, the live
@@ -214,7 +245,10 @@ func (e *Engine) TriggerWithSource(ctx stdctx.Context, workerID domain.SessionID
 	// below (and the reviewer spawn that follows it) can't be raced into a
 	// double-spawn. Held across the spawn deliberately: the loser then re-reads
 	// the freshly-recorded run and short-circuits to Created:false.
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return TriggerResult{}, err
+	}
 	defer unlock()
 
 	worker, ok, err := e.sessions.GetSession(ctx, workerID)
@@ -514,7 +548,10 @@ func (e *Engine) SwitchReviewer(
 	if err := config.Validate(); err != nil {
 		return SessionReviews{}, fmt.Errorf("%w: reviewer config: %w", ErrInvalid, err)
 	}
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return SessionReviews{}, err
+	}
 	defer unlock()
 
 	worker, ok, err := e.sessions.GetSession(ctx, workerID)
@@ -618,7 +655,10 @@ func (e *Engine) RestoreReviewer(ctx stdctx.Context, workerID domain.SessionID) 
 	if workerID == "" {
 		return RestoreReviewerResult{}, fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return RestoreReviewerResult{}, err
+	}
 	defer unlock()
 	worker, ok, err := e.sessions.GetSession(ctx, workerID)
 	if err != nil {
@@ -651,7 +691,10 @@ func (e *Engine) SnapshotCodexReviewer(ctx stdctx.Context, workerID domain.Sessi
 	if workerID == "" {
 		return ports.CodexReviewerControllerSnapshot{}, fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return ports.CodexReviewerControllerSnapshot{}, err
+	}
 	defer unlock()
 	reviewRow, ok, err := e.store.GetReviewBySessionAndHarness(ctx, workerID, domain.ReviewerCodex)
 	if err != nil || !ok {
@@ -713,7 +756,10 @@ func (e *Engine) SuspendCodexReviewerExact(ctx stdctx.Context, workerID domain.S
 	if workerID == "" {
 		return false, fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return false, err
+	}
 	defer unlock()
 	reviewRow, ok, err := e.store.GetReviewBySessionAndHarness(ctx, workerID, domain.ReviewerCodex)
 	if err != nil || !ok || reviewRow.ReviewerHandleID == "" {
@@ -751,7 +797,10 @@ func (e *Engine) RestoreCodexReviewerExact(ctx stdctx.Context, workerID domain.S
 	if workerID == "" {
 		return fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return err
+	}
 	defer unlock()
 	worker, ok, err := e.sessions.GetSession(ctx, workerID)
 	if err != nil {
@@ -856,7 +905,10 @@ func (e *Engine) TeardownReviewerTerminal(ctx stdctx.Context, workerID domain.Se
 	if workerID == "" {
 		return fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return err
+	}
 	defer unlock()
 	reviews, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {
@@ -1200,7 +1252,10 @@ func (e *Engine) TerminateReviewer(ctx stdctx.Context, workerID domain.SessionID
 	if workerID == "" {
 		return TerminateResult{}, fmt.Errorf("%w: worker session id is required", ErrInvalid)
 	}
-	unlock := e.lockWorker(workerID)
+	unlock, err := e.lockWorker(ctx, workerID)
+	if err != nil {
+		return TerminateResult{}, err
+	}
 	defer unlock()
 	reviews, err := e.store.ListReviewsBySession(ctx, workerID)
 	if err != nil {

--- a/backend/internal/review/worker_lock_test.go
+++ b/backend/internal/review/worker_lock_test.go
@@ -1,0 +1,322 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestTriggerCancelledWhileReviewerSpawns(t *testing.T) {
+	spawnStarted := make(chan struct{})
+	unblockSpawn := make(chan struct{})
+	launcher := &fakeLauncher{
+		handle: "review-mer-1", spawnStarted: spawnStarted, unblockSpawn: unblockSpawn,
+	}
+	store := &fakeStore{}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+	var wg sync.WaitGroup
+	var unblock sync.Once
+	t.Cleanup(func() {
+		unblock.Do(func() { close(unblockSpawn) })
+		wg.Wait()
+	})
+	firstDone := make(chan error, 1)
+	wg.Go(func() {
+		_, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{})
+		firstDone <- err
+	})
+	<-spawnStarted
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	waiterDone := make(chan error, 1)
+	wg.Go(func() {
+		close(started)
+		_, err := eng.Trigger(ctx, "mer-1", "", domain.AgentConfig{})
+		waiterDone <- err
+	})
+	<-started
+	cancel()
+	select {
+	case err := <-waiterDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled trigger error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled trigger remained blocked behind reviewer spawn")
+	}
+
+	unblock.Do(func() { close(unblockSpawn) })
+	wg.Wait()
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first trigger: %v", err)
+	}
+	if launcher.spawnCount != 1 || len(store.runs) != 1 {
+		t.Fatalf("spawn count = %d, runs = %d, want one each", launcher.spawnCount, len(store.runs))
+	}
+	if _, err := eng.Trigger(context.Background(), "mer-1", "", domain.AgentConfig{}); err != nil {
+		t.Fatalf("trigger after cancellation: %v", err)
+	}
+	if launcher.spawnCount != 1 {
+		t.Fatalf("spawn count after retry = %d, want 1", launcher.spawnCount)
+	}
+	assertWorkerLocksReleased(t, eng)
+}
+
+func TestTriggerMissingWorkersReleaseLocks(t *testing.T) {
+	eng := newEngineForTest(nil, fakeSessions{}, nil, nil, nil)
+	for i := range 1000 {
+		id := domain.SessionID(fmt.Sprintf("missing-%d", i))
+		if _, err := eng.Trigger(context.Background(), id, "", domain.AgentConfig{}); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("trigger %q: %v, want ErrNotFound", id, err)
+		}
+	}
+	assertWorkerLocksReleased(t, eng)
+}
+
+func TestWorkerOperationsCancelWhileWaiting(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		call func(context.Context, *Engine) error
+	}{
+		{"trigger", func(ctx context.Context, eng *Engine) error {
+			_, err := eng.Trigger(ctx, "worker", "", domain.AgentConfig{})
+			return err
+		}},
+		{"switch", func(ctx context.Context, eng *Engine) error {
+			_, err := eng.SwitchReviewer(ctx, "worker", "", domain.AgentConfig{})
+			return err
+		}},
+		{"restore", func(ctx context.Context, eng *Engine) error {
+			_, err := eng.RestoreReviewer(ctx, "worker")
+			return err
+		}},
+		{"snapshot", func(ctx context.Context, eng *Engine) error {
+			_, err := eng.SnapshotCodexReviewer(ctx, "worker")
+			return err
+		}},
+		{"suspend", func(ctx context.Context, eng *Engine) error {
+			_, err := eng.SuspendCodexReviewerExact(ctx, "worker", "handle", "native")
+			return err
+		}},
+		{"restore exact", func(ctx context.Context, eng *Engine) error {
+			return eng.RestoreCodexReviewerExact(ctx, "worker", "native")
+		}},
+		{"teardown", func(ctx context.Context, eng *Engine) error {
+			return eng.TeardownReviewerTerminal(ctx, "worker")
+		}},
+		{"terminate", func(ctx context.Context, eng *Engine) error {
+			_, err := eng.TerminateReviewer(ctx, "worker", "")
+			return err
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			eng := New(Deps{})
+			unlock, err := eng.lockWorker(context.Background(), "worker")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer unlock()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			waiting := &workerWaitContext{Context: ctx, waiting: make(chan struct{})}
+			done := make(chan error, 1)
+			go func() { done <- tt.call(waiting, eng) }()
+			waitForWorkerWaiter(t, waiting)
+			cancel()
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("cancelled operation: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("operation did not stop waiting after cancellation")
+			}
+			eng.triggerMu.Lock()
+			refs := eng.triggerLocks["worker"].refs
+			eng.triggerMu.Unlock()
+			if refs != 1 {
+				t.Fatalf("references after cancellation = %d, want holder only", refs)
+			}
+			unlock()
+			assertWorkerLocksReleased(t, eng)
+		})
+	}
+}
+
+func TestWorkerLockHandoffKeepsWaitersOnOneEntry(t *testing.T) {
+	eng := New(Deps{})
+	unlockFirst, err := eng.lockWorker(context.Background(), "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlockFirst()
+	eng.triggerMu.Lock()
+	original := eng.triggerLocks["worker"]
+	eng.triggerMu.Unlock()
+
+	queue := func() <-chan func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		waiting := &workerWaitContext{Context: ctx, waiting: make(chan struct{})}
+		acquired := make(chan func(), 1)
+		go func() {
+			unlock, err := eng.lockWorker(waiting, "worker")
+			if err == nil {
+				acquired <- unlock
+			}
+		}()
+		waitForWorkerWaiter(t, waiting)
+		return acquired
+	}
+	second := queue()
+	third := queue()
+	unlockFirst()
+	var unlockSecond func()
+	select {
+	case unlockSecond = <-second:
+	case unlockSecond = <-third:
+		third = second
+	case <-time.After(time.Second):
+		t.Fatal("lock was not handed to a waiter")
+	}
+	defer unlockSecond()
+	fourth := queue()
+	eng.triggerMu.Lock()
+	current := eng.triggerLocks["worker"]
+	refs := current.refs
+	eng.triggerMu.Unlock()
+	if current != original || refs != 3 {
+		t.Fatalf("handoff replaced the shared entry or lost references: same=%v refs=%d", current == original, refs)
+	}
+	select {
+	case unlock := <-fourth:
+		unlock()
+		t.Fatal("new caller acquired a split lock while a waiter held the original")
+	default:
+	}
+	unlockSecond()
+	for range 2 {
+		select {
+		case unlock := <-third:
+			unlock()
+		case unlock := <-fourth:
+			unlock()
+		case <-time.After(time.Second):
+			t.Fatal("remaining waiter never acquired the lock")
+		}
+	}
+	assertWorkerLocksReleased(t, eng)
+}
+
+func TestWorkerLocksAllowIndependentWorkers(t *testing.T) {
+	eng := New(Deps{})
+	unlockFirst, err := eng.lockWorker(context.Background(), "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlockFirst()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	unlockSecond, err := eng.lockWorker(ctx, "second")
+	if err != nil {
+		t.Fatalf("independent worker blocked: %v", err)
+	}
+	unlockSecond()
+	unlockFirst()
+	assertWorkerLocksReleased(t, eng)
+}
+
+func TestWorkerLockCancellationAndReleaseRace(t *testing.T) {
+	eng := New(Deps{})
+	var active atomic.Int32
+	var overlap atomic.Bool
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			for range 100 {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancelled := make(chan struct{})
+				go func() {
+					cancel()
+					close(cancelled)
+				}()
+				unlock, err := eng.lockWorker(ctx, "worker")
+				if err == nil {
+					if active.Add(1) != 1 {
+						overlap.Store(true)
+					}
+					active.Add(-1)
+					unlock()
+				} else if !errors.Is(err, context.Canceled) {
+					t.Errorf("lock error = %v", err)
+				}
+				<-cancelled
+			}
+		})
+	}
+	wg.Wait()
+	if overlap.Load() {
+		t.Fatal("same-worker operations overlapped")
+	}
+	assertWorkerLocksReleased(t, eng)
+}
+
+func TestWorkerLockReturnsContextErrors(t *testing.T) {
+	eng := New(Deps{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if unlock, err := eng.lockWorker(ctx, "worker"); unlock != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("already cancelled acquisition: unlock present=%v error=%v", unlock != nil, err)
+	}
+	assertWorkerLocksReleased(t, eng)
+	unlock, err := eng.lockWorker(context.Background(), "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if release, err := eng.lockWorker(ctx, "worker"); release != nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waiting past deadline: unlock present=%v error=%v", release != nil, err)
+	}
+	unlock()
+	assertWorkerLocksReleased(t, eng)
+}
+
+// Done is evaluated after the waiter retains its entry and before acquisition.
+type workerWaitContext struct {
+	context.Context
+	waiting chan struct{}
+	once    sync.Once
+}
+
+func (ctx *workerWaitContext) Done() <-chan struct{} {
+	ctx.once.Do(func() { close(ctx.waiting) })
+	return ctx.Context.Done()
+}
+
+func waitForWorkerWaiter(t *testing.T, ctx *workerWaitContext) {
+	t.Helper()
+	select {
+	case <-ctx.waiting:
+	case <-time.After(time.Second):
+		t.Fatal("caller did not reach worker lock acquisition")
+	}
+}
+
+func assertWorkerLocksReleased(t *testing.T, eng *Engine) {
+	t.Helper()
+	eng.triggerMu.Lock()
+	defer eng.triggerMu.Unlock()
+	if got := len(eng.triggerLocks); got != 0 {
+		t.Errorf("retained worker locks = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## What

Allow cancelled review operations to stop waiting for a worker lock, and remove idle lock entries when their last holder or waiter leaves.

## Why

A review trigger waiting behind a slow reviewer spawn previously ignored cancellation until that spawn finished. Every worker ID also kept a mutex for the engine lifetime, including missing IDs. A regression against the original code retained 1,000 locks after 1,000 missing-worker requests.

This addresses the SUP07 backend review lock finding.

## How

Use one channel lease per active worker, with reference counts protected by the lock-map mutex. References cover both the holder and queued callers, so handoffs cannot create separate locks for the same worker. Cancellation releases only the waiter's reference; unlock releases the token and its reference.

Propagate cancellation through all eight operations already using the worker lock. Keep the lock across the trigger's idempotency check and reviewer spawn. Active operations retain their existing context behavior; automatic review policy and previously unlocked methods are outside this change.

## Testing

Full local validation covers commit `b32cf2984664caf68d91a6cab80331f1a6782e6b`. The original-source regressions fail on the selected base and pass with the fix. Regression coverage includes cancelled triggers while launch is blocked, missing worker IDs, queued handoff identity, all eight caller paths, independent workers, deadlines and cancellation/release contention.

- Full backend: formatting, `go build ./...`, `go vet ./...`, fresh `go test -count=1 -timeout=15m ./...`, and fresh `go test -race -count=1 -timeout=15m ./...`.
- Full `golangci-lint` v2.12.2 ruleset.
- Native Linux CLI e2e: `go test -tags e2e -count=1 -v ./internal/cli/...`. Exact fresh-install Docker build and smoke run also passed.
- Node 24 `npm ci`, `npm run api`, and generated spec/types drift checks.
- Pinned gitleaks v7.4.0 scan of the single introduced commit.
- Independent source review and combined build/vet/affected-package race checks across all five batch patches.

Affected package tests cross-compiled for Windows amd64 and macOS arm64. Native execution of those package suites was not run locally; remote native jobs cover the workflow's scoped CLI e2e tests.

Publication preflight against `main` at `715e0e06f4746bea969efa30349b26b82116a063`: a clean synthetic merge passed the affected package race suite. The unchanged prepared head also passed `npm run sqlc` using sqlc v1.31.1, with no tracked or untracked generated-code drift. Local checks used Linux, Go 1.26.5 (the workspace version) and Node 24. The merged tree also passed full backend build/vet; current reviewer-restore changes and all eight lock callers were reviewed together.

## Checklist

- [x] One independent commit from `main` at the recorded batch base
- [x] One focused change for local audit SUP07
- [x] Repository conventions and relevant regression coverage
- [x] Applicable local Linux validation passed; platform gaps documented
- [x] All 10 remote CI checks, including scoped native Linux/macOS/Windows jobs
