### PR TITLE
fix: bound preview log retention by bytes

### DIFF
--- a/backend/internal/previewserver/line_buffer_test.go
+++ b/backend/internal/previewserver/line_buffer_test.go
@@ -1,0 +1,266 @@
+package previewserver
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func writeLog(t *testing.T, buffer *lineBuffer, text string) {
+	t.Helper()
+	n, err := buffer.Write([]byte(text))
+	if n != len(text) || err != nil {
+		t.Fatalf("Write = %d, %v; want %d, nil", n, err, len(text))
+	}
+}
+
+func TestLineBufferOversizedCompleteLine(t *testing.T) {
+	buffer := newLineBuffer(maxBufferedLogLines)
+	line := strings.Repeat("older text ", 100000) + "newest text"
+	writeLog(t, buffer, line+"\n")
+	got := buffer.Last(1)
+	if len(got) != 1 {
+		t.Fatalf("Last length = %d, want 1", len(got))
+	}
+	if len(got[0]) > maxBufferedPartialBytes {
+		t.Fatalf("completed line retained %d bytes, want at most %d", len(got[0]), maxBufferedPartialBytes)
+	}
+	if got[0] != line[len(line)-maxBufferedPartialBytes:] {
+		t.Fatal("completed line did not retain its newest suffix")
+	}
+}
+
+func TestLineBufferCombinedByteBudget(t *testing.T) {
+	const budget = 256 * 1024
+	buffer := newLineBuffer(maxBufferedLogLines)
+	var want []string
+	for i := 0; i < budget/maxBufferedPartialBytes+4; i++ {
+		line := fmt.Sprintf("%04d", i) + strings.Repeat("x", maxBufferedPartialBytes-4)
+		writeLog(t, buffer, line+"\n")
+		want = append(want, line)
+	}
+	writeLog(t, buffer, "partial")
+	got := buffer.Last(maxBufferedLogLines + 1)
+	retained := 0
+	for _, text := range got {
+		retained += len(text)
+	}
+	if retained > budget {
+		t.Fatalf("completed and partial text retained %d bytes, want at most %d", retained, budget)
+	}
+	if len(got) != budget/maxBufferedPartialBytes || got[len(got)-1] != "partial" {
+		t.Fatalf("retained %d lines, want %d including newest partial", len(got), budget/maxBufferedPartialBytes)
+	}
+	want = append(want[len(want)-(budget/maxBufferedPartialBytes-1):], "partial")
+	if !slices.Equal(got, want) {
+		t.Fatal("byte eviction did not retain the newest completed lines followed by partial text")
+	}
+}
+
+func TestLineBufferChunkBoundariesAndCRLF(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		chunks []string
+		want   []string
+	}{
+		{"empty", []string{""}, []string{}},
+		{"empty_lines", []string{"\n\n"}, []string{"", ""}},
+		{"split_crlf", []string{"first\r", "\nsecond\n", "\nthird\r", "\nlast\r"}, []string{"first", "second", "", "third", "last\r"}},
+		{"bare_cr", []string{"first\rsecond\r\r\n"}, []string{"first\rsecond\r"}},
+		{"partial_join", []string{"fir", "", "st\nse", "cond"}, []string{"first", "second"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			buffer := newLineBuffer(10)
+			for _, chunk := range test.chunks {
+				writeLog(t, buffer, chunk)
+			}
+			if got := buffer.Last(10); !slices.Equal(got, test.want) {
+				t.Fatalf("Last = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestLineBufferOversizedChunking(t *testing.T) {
+	line := strings.Repeat("0123456789", 1700) + "\r"
+	partial := strings.Repeat("abcdefghij", 1700) + "newest"
+	text := line + "\nmiddle\n" + partial
+	want := []string{strings.TrimSuffix(line[len(line)-maxBufferedPartialBytes:], "\r"), "middle", partial[len(partial)-maxBufferedPartialBytes:]}
+	for _, size := range []int{1, 7, 4096, len(text)} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			buffer := newLineBuffer(10)
+			for offset := 0; offset < len(text); offset += size {
+				writeLog(t, buffer, text[offset:min(offset+size, len(text))])
+			}
+			if got := buffer.Last(10); !slices.Equal(got, want) {
+				t.Fatalf("chunk size %d produced a different retained suffix", size)
+			}
+		})
+	}
+}
+
+func TestLineBufferLineLimitAndLast(t *testing.T) {
+	buffer := newLineBuffer(3)
+	writeLog(t, buffer, "first\nsecond\nthird\nfourth\nfifth\npartial")
+	for _, test := range []struct {
+		limit int
+		want  []string
+	}{
+		{-1, []string{}},
+		{0, []string{}},
+		{1, []string{"partial"}},
+		{2, []string{"fifth", "partial"}},
+		{3, []string{"fourth", "fifth", "partial"}},
+		{4, []string{"third", "fourth", "fifth", "partial"}},
+		{100, []string{"third", "fourth", "fifth", "partial"}},
+	} {
+		t.Run(fmt.Sprint(test.limit), func(t *testing.T) {
+			if got := buffer.Last(test.limit); !slices.Equal(got, test.want) {
+				t.Fatalf("Last(%d) = %q, want %q", test.limit, got, test.want)
+			}
+		})
+	}
+	writeLog(t, buffer, "\n")
+	if got, want := buffer.Last(100), []string{"fourth", "fifth", "partial"}; !slices.Equal(got, want) {
+		t.Fatalf("completed partial = %q, want %q", got, want)
+	}
+}
+
+func TestLineBufferByteEvictionAtCRLFBoundary(t *testing.T) {
+	for _, chunks := range [][]string{{"\r\n"}, {"\r", "\n"}} {
+		buffer := newLineBuffer(maxBufferedLogLines)
+		line := strings.Repeat("x", maxBufferedPartialBytes)
+		for range maxBufferedLogBytes / maxBufferedPartialBytes {
+			writeLog(t, buffer, line+"\n")
+		}
+		for _, chunk := range chunks {
+			writeLog(t, buffer, chunk)
+		}
+		got := buffer.Last(maxBufferedLogLines)
+		if len(got) != maxBufferedLogBytes/maxBufferedPartialBytes || got[len(got)-1] != "" {
+			t.Fatalf("chunks %q retained %d lines, want byte eviction before the CRLF completes", chunks, len(got))
+		}
+	}
+}
+
+func TestLineBufferSustainedPartialOutput(t *testing.T) {
+	buffer := newLineBuffer(maxBufferedLogLines)
+	chunk := strings.Repeat("x", 8*1024)
+	for i := 0; i < 128; i++ {
+		writeLog(t, buffer, chunk)
+		got := buffer.Last(1)
+		if len(got) != 1 || len(got[0]) != min((i+1)*len(chunk), maxBufferedPartialBytes) {
+			t.Fatalf("write %d did not retain a bounded partial suffix", i)
+		}
+	}
+	writeLog(t, buffer, "newest\n")
+	got := buffer.Last(1)
+	if len(got) != 1 || len(got[0]) != maxBufferedPartialBytes || !strings.HasSuffix(got[0], "newest") {
+		t.Fatal("completing sustained partial output lost the newest suffix")
+	}
+}
+
+func TestLineBufferZeroLineCapacity(t *testing.T) {
+	for _, capacity := range []int{0, -1} {
+		buffer := newLineBuffer(capacity)
+		writeLog(t, buffer, "discarded\npartial")
+		if got := buffer.Last(10); !slices.Equal(got, []string{"partial"}) {
+			t.Fatalf("capacity %d: Last = %q, want partial", capacity, got)
+		}
+		writeLog(t, buffer, "\n")
+		if got := buffer.Last(10); len(got) != 0 {
+			t.Fatalf("capacity %d retained completed lines: %q", capacity, got)
+		}
+	}
+}
+
+func TestLineBufferSnapshotOwnership(t *testing.T) {
+	buffer := newLineBuffer(2)
+	input := []byte("first\npartial")
+	if _, err := buffer.Write(input); err != nil {
+		t.Fatal(err)
+	}
+	clear(input)
+	snapshot := buffer.Last(10)
+	if !slices.Equal(snapshot, []string{"first", "partial"}) {
+		t.Fatalf("input mutation changed retained text: %q", snapshot)
+	}
+	snapshot[0] = "changed"
+	writeLog(t, buffer, "-continued\nlast\n")
+	if snapshot[1] != "partial" {
+		t.Fatalf("later writes changed prior snapshot: %q", snapshot)
+	}
+	if got := buffer.Last(10); !slices.Equal(got, []string{"partial-continued", "last"}) {
+		t.Fatalf("snapshot mutation or later write corrupted retained text: %q", got)
+	}
+}
+
+func TestLineBufferConcurrentReadersAndWriters(t *testing.T) {
+	buffer := newLineBuffer(maxBufferedLogLines)
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			for range 100 {
+				writeLog(t, buffer, "a complete line\n")
+			}
+		})
+		wg.Go(func() {
+			for range 100 {
+				for _, line := range buffer.Last(40) {
+					if line != "a complete line" {
+						t.Errorf("read incomplete or corrupt line %q", line)
+					}
+				}
+			}
+		})
+	}
+	wg.Wait()
+	if got := len(buffer.Last(maxBufferedLogLines + 1)); got != maxBufferedLogLines {
+		t.Fatalf("completed lines = %d, want %d", got, maxBufferedLogLines)
+	}
+}
+
+func BenchmarkLineBufferFullWrites(b *testing.B) {
+	for _, capacity := range []int{1, 200, 2000} {
+		b.Run(fmt.Sprint(capacity), func(b *testing.B) {
+			buffer := newLineBuffer(capacity)
+			line := []byte("a complete log line\n")
+			for range capacity {
+				_, _ = buffer.Write(line)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = buffer.Write(line)
+			}
+		})
+	}
+}
+
+func BenchmarkLineBufferLast(b *testing.B) {
+	for _, limit := range []int{1, 40, 200} {
+		b.Run(fmt.Sprint(limit), func(b *testing.B) {
+			buffer := newLineBuffer(maxBufferedLogLines)
+			for range maxBufferedLogLines {
+				_, _ = buffer.Write([]byte("a complete log line\n"))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = buffer.Last(limit)
+			}
+		})
+	}
+}
+
+func BenchmarkLineBufferOversizedWrites(b *testing.B) {
+	buffer := newLineBuffer(maxBufferedLogLines)
+	data := []byte(strings.Repeat("x", 4*1024*1024) + "\nshort\n")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = buffer.Write(data)
+	}
+}

--- a/backend/internal/previewserver/manager.go
+++ b/backend/internal/previewserver/manager.go
@@ -37,6 +37,7 @@ const (
 	statusLogLines          = 40
 	maxBufferedLogLines     = 200
 	maxBufferedPartialBytes = 16 * 1024
+	maxBufferedLogBytes     = 256 * 1024
 	failedStatusRetention   = 5 * time.Minute
 	processRegistryFile     = "preview-processes.json"
 )
@@ -973,48 +974,103 @@ func serviceError(code, message string) Error {
 	return Error{Code: code, Message: message}
 }
 
+// lineBuffer retains at most maxBufferedLogBytes of text. Each line keeps its
+// newest maxBufferedPartialBytes, and growing partial text evicts older lines.
 type lineBuffer struct {
-	mu      sync.Mutex
-	max     int
-	lines   []string
-	partial string
+	mu             sync.Mutex
+	lines          []string
+	start          int
+	count          int
+	completedBytes int
+	partial        []byte
 }
 
 func newLineBuffer(capacity int) *lineBuffer {
-	return &lineBuffer{max: capacity}
+	return &lineBuffer{lines: make([]string, max(0, capacity))}
 }
 
 func (b *lineBuffer) Write(data []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	text := b.partial + string(data)
-	parts := strings.Split(text, "\n")
-	b.partial = parts[len(parts)-1]
-	if len(b.partial) > maxBufferedPartialBytes {
-		b.partial = b.partial[len(b.partial)-maxBufferedPartialBytes:]
+	written := len(data)
+	for len(data) > 0 {
+		end := bytes.IndexByte(data, '\n')
+		if end < 0 {
+			b.appendPartialLocked(data)
+			break
+		}
+		b.appendPartialLocked(data[:end])
+		line := bytes.TrimSuffix(b.partial, []byte{'\r'})
+		b.partial = b.partial[:0]
+		b.appendLocked(string(line))
+		data = data[end+1:]
 	}
-	for _, line := range parts[:len(parts)-1] {
-		b.appendLocked(strings.TrimSuffix(line, "\r"))
-	}
-	return len(data), nil
+	return written, nil
 }
 
 func (b *lineBuffer) Last(limit int) []string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	lines := append([]string{}, b.lines...)
-	if b.partial != "" {
-		lines = append(lines, b.partial)
+	if limit <= 0 {
+		return []string{}
 	}
-	if len(lines) > limit {
-		lines = lines[len(lines)-limit:]
+	total := b.count
+	if len(b.partial) > 0 {
+		total++
+	}
+	count := min(limit, total)
+	lines := make([]string, count)
+	completed := count
+	if len(b.partial) > 0 && count > 0 {
+		lines[count-1] = string(b.partial)
+		completed--
+	}
+	if completed > 0 {
+		first := (b.start + b.count - completed) % len(b.lines)
+		beforeWrap := min(completed, len(b.lines)-first)
+		copy(lines, b.lines[first:first+beforeWrap])
+		copy(lines[beforeWrap:completed], b.lines[:completed-beforeWrap])
 	}
 	return lines
 }
 
-func (b *lineBuffer) appendLocked(line string) {
-	b.lines = append(b.lines, line)
-	if len(b.lines) > b.max {
-		b.lines = append([]string{}, b.lines[len(b.lines)-b.max:]...)
+// Keep a line's newest bytes before removing the CR in a completed CRLF. The
+// same limit applies before and after LF, independent of Write chunk boundaries.
+func (b *lineBuffer) appendPartialLocked(data []byte) {
+	if len(data) >= maxBufferedPartialBytes {
+		b.partial = append(b.partial[:0], data[len(data)-maxBufferedPartialBytes:]...)
+	} else {
+		if discard := len(b.partial) + len(data) - maxBufferedPartialBytes; discard > 0 {
+			copy(b.partial, b.partial[discard:])
+			b.partial = b.partial[:len(b.partial)-discard]
+		}
+		b.partial = append(b.partial, data...)
 	}
+	b.trimBytesLocked()
+}
+
+func (b *lineBuffer) appendLocked(line string) {
+	if len(b.lines) == 0 {
+		return
+	}
+	if b.count == len(b.lines) {
+		b.evictLocked()
+	}
+	b.lines[(b.start+b.count)%len(b.lines)] = line
+	b.count++
+	b.completedBytes += len(line)
+	b.trimBytesLocked()
+}
+
+func (b *lineBuffer) trimBytesLocked() {
+	for b.count > 0 && b.completedBytes+len(b.partial) > maxBufferedLogBytes {
+		b.evictLocked()
+	}
+}
+
+func (b *lineBuffer) evictLocked() {
+	b.completedBytes -= len(b.lines[b.start])
+	b.lines[b.start] = ""
+	b.start = (b.start + 1) % len(b.lines)
+	b.count--
 }


### PR DESCRIPTION
## What

Bound preview logs to 256 KiB of retained text using a circular completed-line buffer.

## Why

Audit SUP04 found that completed preview log lines had no byte limit. A single completed line could retain its entire large input, and every write into a full 200-line buffer copied the retained string slice. Status reads also copied all lines before selecting the requested tail.

## How

Retain the newest 16 KiB of each completed or partial line, keep the existing 200 completed-line cap, and evict old completed lines as partial text grows beyond the shared budget. Clear evicted string slots and own retained bytes so small suffixes cannot pin giant input strings. Last copies only the requested suffix.

CRLF normalization and chunked writes remain consistent, including eager byte eviction before a trailing CR is removed by LF. Clipping is byte-based. Process management, readiness and API shapes remain unchanged; PTY scrollback changes are separate.

## Testing

Full local validation covers commit `58dadf22e3672df1b1cd708c674a4b9d915a3136`. The original-source regressions fail on the selected base and pass with the fix. Regression coverage includes oversized completed/partial lines, total retained bytes, CRLF/chunk boundaries, circular wrap, tail limits, snapshot ownership and concurrent access.

- Full backend: formatting, `go build ./...`, `go vet ./...`, fresh `go test -count=1 -timeout=15m ./...`, and fresh `go test -race -count=1 -timeout=15m ./...`.
- Full `golangci-lint` v2.12.2 ruleset.
- Native Linux CLI e2e: `go test -tags e2e -count=1 -v ./internal/cli/...`. Exact fresh-install Docker build and smoke run also passed.
- Node 24 `npm ci`, `npm run api`, and generated spec/types drift checks.
- Pinned gitleaks v7.4.0 scan of the single introduced commit.
- Independent source review and combined build/vet/affected-package race checks across all five batch patches.

Affected package tests cross-compiled for Windows amd64 and macOS arm64. Native execution of those package suites was not run locally; remote native jobs cover the workflow's scoped CLI e2e tests.

Repeated benchmarks reduced writes to a full 200-line buffer from 3,512 to 24 allocated bytes per operation, and Last(1) from 3,456 to 16 bytes. These are helper benchmarks, not production profiles.

Publication preflight against `main` at `715e0e06f4746bea969efa30349b26b82116a063`: a clean synthetic merge passed the affected package race suite. The unchanged prepared head also passed `npm run sqlc` using sqlc v1.31.1, with no tracked or untracked generated-code drift. Local checks used Linux, Go 1.26.5 (the workspace version) and Node 24.

## Checklist

- [x] One independent commit from `main` at the recorded batch base
- [x] One focused change for local audit SUP04
- [x] Repository conventions and relevant regression coverage
- [x] Applicable local Linux validation passed; platform gaps documented
- [x] All 10 remote CI checks, including scoped native Linux/macOS/Windows jobs
