### PR TITLE
fix(desktop): improve editor handoff guidance UX and add Antigravity IDE support

### DIFF
--- a/frontend/src/main/editor-handoff.test.ts
+++ b/frontend/src/main/editor-handoff.test.ts
@@ -13,8 +13,8 @@ function deps(overrides: Partial<EditorHandoffDeps> = {}): EditorHandoffDeps {
 		writePreference: vi.fn().mockResolvedValue(undefined),
 		launch: vi.fn().mockResolvedValue(undefined),
 		openDirectory: vi.fn().mockResolvedValue(undefined),
-		isExecutable: (candidatePath) => candidatePath === "/bin/code",
-		isDirectory: (candidatePath) => candidatePath === "/Applications/Cursor.app",
+		isExecutable: (candidatePath) => path.normalize(candidatePath) === path.normalize("/bin/code"),
+		isDirectory: (candidatePath) => path.normalize(candidatePath) === path.normalize("/Applications/Cursor.app"),
 		...overrides,
 	};
 }
@@ -73,7 +73,7 @@ describe("editor handoff", () => {
 			id: "vscode",
 			kind: "editor",
 		});
-		expect(input.launch).toHaveBeenCalledWith("/bin/code", ["/worktrees/ao-1"], "/worktrees/ao-1");
+		expect(input.launch).toHaveBeenCalledWith(path.normalize("/bin/code"), ["/worktrees/ao-1"], "/worktrees/ao-1");
 		expect(input.writePreference).toHaveBeenCalledWith("vscode");
 	});
 
@@ -116,6 +116,14 @@ describe("editor handoff (win32 fallback discovery)", () => {
 		const state = await handoff.getState("ao-1");
 		const cursor = state.targets.find(({ id }) => id === "cursor");
 		expect(cursor).toBeDefined();
+	});
+
+	it("finds Antigravity IDE when present in LOCALAPPDATA install dir", async () => {
+		const antigravityBin = path.join("C:", "Users", "tester", "AppData", "Local", "Programs", "Antigravity IDE", "bin", "antigravity-ide.cmd");
+		const handoff = createEditorHandoff(winDeps({ isExecutable: installedExecutables(antigravityBin) }));
+		const state = await handoff.getState("ao-1");
+		const antigravity = state.targets.find(({ id }) => id === "antigravity");
+		expect(antigravity).toEqual({ id: "antigravity", name: "Antigravity IDE", kind: "editor" });
 	});
 
 	it("prefers a Windows-native .cmd shim over a bare extension-less sh script on PATH", async () => {

--- a/frontend/src/main/editor-handoff.ts
+++ b/frontend/src/main/editor-handoff.ts
@@ -56,6 +56,7 @@ const EDITOR_CANDIDATES: EditorCandidate[] = [
 	{ id: "rider", name: "Rider", commands: ["rider"], macApps: ["Rider"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "Rider", "bin"], [LOCAL_APPDATA_PROGRAMS, "JetBrains", "Rider", "bin"]] },
 	{ id: "android-studio", name: "Android Studio", commands: ["studio"], macApps: ["Android Studio"], winInstallDirs: [[PROGRAM_FILES, "Android", "Android Studio", "bin"]] },
 	{ id: "fleet", name: "Fleet", commands: ["fleet"], macApps: ["Fleet"], winInstallDirs: [[PROGRAM_FILES, "JetBrains", "Fleet", "bin"]] },
+	{ id: "antigravity", name: "Antigravity IDE", commands: ["antigravity-ide", "antigravity"], macApps: ["Antigravity IDE", "Antigravity"], winInstallDirs: [[LOCAL_APPDATA_PROGRAMS, "Antigravity IDE", "bin"], [PROGRAM_FILES, "Antigravity IDE", "bin"]] },
 ];
 
 const WIN_INSTALL_ROOTS: Record<string, (env: NodeJS.ProcessEnv) => string | undefined> = {

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx
@@ -146,13 +146,14 @@ describe("TopbarOpenEditorButton", () => {
 			workspaceAvailable: true,
 		});
 		renderButton();
-		expect(await screen.findByRole("alert")).toHaveTextContent("No supported editor found");
-		expect(screen.getByRole("button", { name: "Choose editor" })).toBeDisabled();
+		expect(await screen.findByRole("button", { name: "Choose editor" })).toBeDisabled();
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 		await userEvent.click(screen.getByRole("button", { name: "Open workspace options" }));
 		expect((await screen.findAllByRole("menuitem")).map((item) => item.textContent)).toEqual([
 			"Open in Finder",
 			"Open in Terminal",
 		]);
+		expect(screen.getByRole("note")).toHaveTextContent("No supported editor found");
 	});
 
 	it("shows a missing workspace and disables every launch action", async () => {

--- a/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
+++ b/frontend/src/renderer/components/TopbarOpenEditorButton.tsx
@@ -15,6 +15,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import {
 	AndroidStudioIcon,
+	AntigravityIcon,
 	CursorIcon,
 	JetBrainsIcon,
 	SublimeIcon,
@@ -31,6 +32,7 @@ const editorIcons: Record<string, typeof VSCodeIcon> = {
 	cursor: CursorIcon,
 	windsurf: WindsurfIcon,
 	zed: ZedIcon,
+	antigravity: AntigravityIcon,
 	sublime: SublimeIcon,
 	"android-studio": AndroidStudioIcon,
 	intellij: JetBrainsIcon,
@@ -48,6 +50,7 @@ const editorColors: Record<string, string> = {
 	vscode: "#1F9CF0",
 	"vscode-insiders": "#1F9CF0",
 	vscodium: "#2F80ED",
+	antigravity: "#4285F4",
 	sublime: "#FF9800",
 	"android-studio": "#3DDC84",
 };
@@ -97,21 +100,25 @@ export function TopbarOpenEditorButton({
 		open.mutate({ sessionId, projectId, ...(targetId ? { targetId } : {}) });
 	};
 	const launchError = open.error instanceof Error ? open.error.message : null;
-	const guidance = !stateQuery.isPending && !workspaceAvailable
+	const workspaceError = !stateQuery.isPending && !workspaceAvailable
 		? state?.unavailableReason ?? t("editor.workspaceUnavailable")
-		: !stateQuery.isPending && editors.length === 0
-			? t("editor.noEditorGuidance", { fileManager: fileManagerName, terminal: terminalName })
-			: null;
+		: null;
+	const visibleActionError = launchError ?? workspaceError;
+	const noEditorGuidance = !stateQuery.isPending && workspaceAvailable && editors.length === 0
+		? t("editor.noEditorGuidance", { fileManager: fileManagerName, terminal: terminalName })
+		: null;
 	const mainTitle = stateQuery.isPending
 		? t("editor.preparingWorkspace")
-		: (guidance
-			?? (preferred ? t("editor.openWorkspaceInTitle", { name: preferred.name }) : t("editor.chooseEditorTitle")));
+		: (workspaceError
+			?? (preferred
+				? t("editor.openWorkspaceInTitle", { name: preferred.name })
+				: (noEditorGuidance ?? t("editor.chooseEditorTitle"))));
 
 	return (
 		<>
-			{launchError || guidance ? (
-				<TopbarActionError className="max-w-content-max truncate" title={launchError ?? guidance ?? undefined}>
-					{launchError ?? guidance}
+			{visibleActionError ? (
+				<TopbarActionError className="max-w-content-max truncate" title={visibleActionError}>
+					{visibleActionError}
 				</TopbarActionError>
 			) : null}
 			<div
@@ -172,6 +179,17 @@ export function TopbarOpenEditorButton({
 								{editor.name}
 							</DropdownMenuItem>
 						))}
+						{editors.length === 0 && noEditorGuidance ? (
+							<>
+								<DropdownMenuSeparator />
+								<div
+									className="px-2 py-1.5 text-micro leading-relaxed text-passive select-none max-w-60"
+									role="note"
+								>
+									{noEditorGuidance}
+								</div>
+							</>
+						) : null}
 					</DropdownMenuContent>
 				</DropdownMenu>
 			</div>

--- a/frontend/src/renderer/components/icons.tsx
+++ b/frontend/src/renderer/components/icons.tsx
@@ -81,13 +81,18 @@ export function VSCodeIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
 // "Open with" list shows each editor's own logo rather than a stand-in. Paths
 // are simple-icons' (cursor, windsurf, zedindustries); VS Code is hand-authored
 // because simple-icons does not carry that restricted brand.
-function BrandGlyph({ d, className, ...props }: SVGProps<SVGSVGElement> & { d: string }) {
+function BrandGlyph({
+	d,
+	className,
+	viewBox = "0 0 24 24",
+	...props
+}: SVGProps<SVGSVGElement> & { d: string; viewBox?: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			width="24"
 			height="24"
-			viewBox="0 0 24 24"
+			viewBox={viewBox}
 			fill="currentColor"
 			className={className}
 			{...props}
@@ -144,4 +149,11 @@ export function VSCodiumIcon(props: SVGProps<SVGSVGElement>) {
 
 export function AndroidStudioIcon(props: SVGProps<SVGSVGElement>) {
 	return <BrandGlyph d={ANDROID_STUDIO_PATH} {...props} />;
+}
+
+const ANTIGRAVITY_PATH =
+	"M144.248 149.062c7.5 5.626 18.75 1.876 8.437-8.437-30.937-30-24.375-112.5-62.812-112.5-38.438 0-31.875 82.5-62.813 112.5-11.25 11.25.938 14.063 8.438 8.437 29.062-19.687 27.187-54.375 54.375-54.375 27.187 0 25.312 34.688 54.375 54.375Z";
+
+export function AntigravityIcon(props: SVGProps<SVGSVGElement>) {
+	return <BrandGlyph d={ANTIGRAVITY_PATH} viewBox="0 0 180 180" {...props} />;
 }

--- a/frontend/src/shared/editor-handoff.ts
+++ b/frontend/src/shared/editor-handoff.ts
@@ -19,6 +19,7 @@ export const EDITOR_IDS = [
 	"rider",
 	"android-studio",
 	"fleet",
+	"antigravity",
 ] as const;
 
 export type EditorId = (typeof EDITOR_IDS)[number];


### PR DESCRIPTION
## Summary

Improves the Editor Handoff user experience by relocating the "no supported editor found" guidance message from an alarming, truncated red alert in the top navigation bar into the options dropdown menu and hover tooltip. Additionally, adds native discovery support and the official brand icon for Antigravity IDE.

## What We Did

- **Topbar Error Cleanup**: Decoupled missing editor guidance from genuine system errors in `TopbarOpenEditorButton`. `<TopbarActionError>` (bright red `role="alert"`) is now reserved exclusively for actual launch failures (`launchError`) and inaccessible workspaces (`!workspaceAvailable`).
- **Dropdown Guidance**: Added a non-destructive informational note (`role="note"`) inside `DropdownMenuContent` below the native fallback options (File Explorer and Terminal), styled with `text-passive text-micro` to match design system tokens.
- **Tooltip Explanation**: Preserved the complete, untruncated guidance in the editor handoff button's hover tooltip.
- **Antigravity IDE Detection**: Added `"antigravity"` to `EDITOR_IDS` and configured candidate detection in `editor-handoff.ts` (`antigravity-ide` and `antigravity` CLI shims, `%LOCALAPPDATA%\Programs\Antigravity IDE\bin`, `%ProgramFiles%\Antigravity IDE\bin`, and macOS app bundle names).
- **Icon & Branding**: Added the official Antigravity SVG mark and exported `AntigravityIcon` in `icons.tsx` using `BrandGlyph`, registered in `TopbarOpenEditorButton` with its Google Blue `#4285F4` brand color.
- **Tests**: Added Antigravity detection coverage in `editor-handoff.test.ts` and updated `TopbarOpenEditorButton.test.tsx` to assert the clean topbar and dropdown guidance note.

## Before and After Behaviour

- **Before**: When no external editor was installed or detected on PATH, the top navigation bar permanently displayed an alarming, bright red error message truncated with an ellipsis (`"No supported editor found. Use File Explorer or ..."`), crowding out navigation controls and giving the false impression that the workspace or session had crashed. Furthermore, Antigravity IDE was not recognized as an editor even when installed.
- **After**: The top navigation bar remains clean and free of false-alarm red text. The guidance is presented gracefully inside the workspace options dropdown menu (under File Explorer and Terminal) and on hover in the button's tooltip. Additionally, Antigravity IDE is now recognized as a first-class editor with its official brand mark and 1-click launch capability.

## Files Affected

- `frontend/src/shared/editor-handoff.ts` — Added `"antigravity"` to `EDITOR_IDS`
- `frontend/src/main/editor-handoff.ts` — Added Antigravity IDE discovery candidate
- `frontend/src/main/editor-handoff.test.ts` — Added Antigravity IDE win32 discovery test & path normalization
- `frontend/src/renderer/components/icons.tsx` — Extended `BrandGlyph` with optional `viewBox` and added `AntigravityIcon`
- `frontend/src/renderer/components/TopbarOpenEditorButton.tsx` — Cleaned up topbar alert, added dropdown note, registered Antigravity icon & color
- `frontend/src/renderer/components/TopbarOpenEditorButton.test.tsx` — Updated test assertions to verify clean topbar and dropdown note

## Tests We Ran

- [x] `npm --prefix frontend test src/main/editor-handoff.test.ts` (17/17 tests passed)
- [x] `npm --prefix frontend test src/renderer/components/TopbarOpenEditorButton.test.tsx` (13/13 tests passed)
- [x] `npm --prefix frontend test src/renderer/components/ShellTopbar.test.tsx` (38/38 tests passed)
