### PR TITLE
feat(cli): register PRs from successful Claude Code creation hooks

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -23,6 +23,7 @@ require (
 	golang.org/x/sys v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
+	mvdan.cc/sh/v3 v3.11.0
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -168,3 +168,5 @@ modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+mvdan.cc/sh/v3 v3.11.0 h1:q5h+XMDRfUGUedCqFFsjoFjrhwf2Mvtt1rkMvVz0blw=
+mvdan.cc/sh/v3 v3.11.0/go.mod h1:LRM+1NjoYCzuq/WZ6y44x14YNAI0NK7FLPeQSaFagGg=

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -372,6 +372,9 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 	if isCursorPermissionHook(agent, event) {
 		return c.runCursorPermissionHook(ctx, agent, event, sessionID, payload)
 	}
+	if ref := hookCreatedPR(agent, event, payload); ref != "" {
+		c.registerHookPR(ctx, agent, event, sessionID, ref)
+	}
 
 	state, hasActivity := activitydispatch.Derive(agent, event, payload)
 	agentSessionID := ""

--- a/backend/internal/cli/hooks_pr.go
+++ b/backend/internal/cli/hooks_pr.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// Only accept gh's complete stdout result, not URLs embedded in help, prose,
+// stderr, or a command that merely views/prints an existing PR. The daemon
+// verifies the provider facts and repository before persisting ownership.
+var createdGitHubPRURL = regexp.MustCompile(`^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[1-9][0-9]*$`)
+
+func hookCreatedPR(agent, event string, payload []byte) string {
+	if agent != "claude-code" || event != "post-tool-use" {
+		return ""
+	}
+	var p struct {
+		ToolName string `json:"tool_name"`
+		Input    struct {
+			Command    string `json:"command"`
+			Background bool   `json:"run_in_background"`
+		} `json:"tool_input"`
+		Response struct {
+			Stdout        string `json:"stdout"`
+			Interrupted   bool   `json:"interrupted"`
+			ExitCode      *int   `json:"exitCode"`
+			ExitCodeSnake *int   `json:"exit_code"`
+		} `json:"tool_response"`
+	}
+	if json.Unmarshal(payload, &p) != nil || p.ToolName != "Bash" || p.Input.Background || p.Response.Interrupted {
+		return ""
+	}
+	if p.Response.ExitCode != nil && *p.Response.ExitCode != 0 || p.Response.ExitCodeSnake != nil && *p.Response.ExitCodeSnake != 0 {
+		return ""
+	}
+	ref := strings.TrimSpace(p.Response.Stdout)
+	if !createdGitHubPRURL.MatchString(ref) || !isGHPRCreate(p.Input.Command) {
+		return ""
+	}
+	return ref
+}
+
+// Parse, never execute, shell syntax. A successful tool result only proves the
+// shell's final status: "gh pr create ... || echo <url>" must not register a PR.
+// Recognize a standalone create, optionally preceded by a quiet `cd ... &&`.
+// Other scripts, pipelines, wrappers and background jobs use polling instead.
+func isGHPRCreate(command string) bool {
+	if len(command) > maxHookInteractionLen {
+		return false
+	}
+	f, err := syntax.NewParser().Parse(strings.NewReader(command), "")
+	if err != nil || len(f.Stmts) != 1 {
+		return false
+	}
+	stmt := f.Stmts[0]
+	if !plainPRHookStmt(stmt) {
+		return false
+	}
+	if binary, ok := stmt.Cmd.(*syntax.BinaryCmd); ok {
+		if binary.Op != syntax.AndStmt || !plainPRHookStmt(binary.X) || !plainPRHookStmt(binary.Y) {
+			return false
+		}
+		cd, ok := binary.X.Cmd.(*syntax.CallExpr)
+		if !ok || len(cd.Assigns) != 0 || len(cd.Args) != 2 || cd.Args[0].Lit() != "cd" {
+			return false
+		}
+		// Avoid `cd -`, which prints a path, and expansions with side effects.
+		if cd.Args[1].Lit() == "" || strings.HasPrefix(cd.Args[1].Lit(), "-") {
+			return false
+		}
+		stmt = binary.Y
+	}
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	return ok && len(call.Assigns) == 0 && len(call.Args) >= 3 &&
+		call.Args[0].Lit() == "gh" && call.Args[1].Lit() == "pr" && call.Args[2].Lit() == "create"
+}
+
+func plainPRHookStmt(stmt *syntax.Stmt) bool {
+	return !stmt.Negated && !stmt.Background && !stmt.Coprocess && len(stmt.Redirs) == 0
+}
+
+func (c *commandContext) registerHookPR(ctx context.Context, agent, event, sessionID, ref string) {
+	// Native hooks have a 30s deadline. A slow provider must not hold the
+	// agent for the CLI's normal two-minute mutation timeout.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req := claimPRRequest{PR: ref, AllowTakeover: false}
+	if err := c.postJSON(ctx, "sessions/"+url.PathEscape(sessionID)+"/pr/claim", req, nil); err != nil {
+		c.reportHookFailure(agent, event, sessionID, fmt.Errorf("register created PR: %w", err))
+	}
+}

--- a/backend/internal/cli/hooks_pr_test.go
+++ b/backend/internal/cli/hooks_pr_test.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const hookPRURL = "https://github.com/example/frontend/pull/123"
+
+func createdPRHookPayload(command, stdout string) string {
+	payload, _ := json.Marshal(map[string]any{
+		"tool_name":     "Bash",
+		"tool_input":    map[string]any{"command": command},
+		"tool_response": map[string]any{"stdout": stdout, "stderr": "", "interrupted": false},
+	})
+	return string(payload)
+}
+
+func TestHookCreatedPR(t *testing.T) {
+	command := "gh pr create --repo example/frontend \\\n  --base dev \\\n  --head ao/workspace-4-dependabot-stage1 \\\n  --title \"chore(deps): Stage 1 safe Dependabot bumps\" \\\n  --body-file /tmp/pr_body.md"
+	good := createdPRHookPayload(command, hookPRURL+"\n")
+	for _, tt := range []struct {
+		name, agent, event, payload string
+		want                        bool
+	}{
+		{"multiline create on renamed branch", "claude-code", "post-tool-use", good, true},
+		{"change directory", "claude-code", "post-tool-use", createdPRHookPayload("cd frontend && gh pr create --fill", hookPRURL), true},
+		{"failure event", "claude-code", "post-tool-use-failure", good, false},
+		{"before execution", "claude-code", "pre-tool-use", good, false},
+		{"other harness", "codex", "post-tool-use", good, false},
+		{"wrong tool", "claude-code", "post-tool-use", strings.Replace(good, `"Bash"`, `"Read"`, 1), false},
+		{"malformed", "claude-code", "post-tool-use", `{`, false},
+		{"interrupted", "claude-code", "post-tool-use", strings.Replace(good, `"interrupted":false`, `"interrupted":true`, 1), false},
+		{"nonzero camel exit", "claude-code", "post-tool-use", strings.Replace(good, `"interrupted":false`, `"interrupted":false,"exitCode":1`, 1), false},
+		{"nonzero snake exit", "claude-code", "post-tool-use", strings.Replace(good, `"interrupted":false`, `"interrupted":false,"exit_code":1`, 1), false},
+		{"zero exit", "claude-code", "post-tool-use", strings.Replace(good, `"interrupted":false`, `"interrupted":false,"exitCode":0`, 1), true},
+		{"background tool", "claude-code", "post-tool-use", strings.Replace(good, `"command":`, `"run_in_background":true,"command":`, 1), false},
+		{"stderr only", "claude-code", "post-tool-use", strings.Replace(createdPRHookPayload("gh pr create --fill", ""), `"stderr":""`, `"stderr":"`+hookPRURL+`"`, 1), false},
+		{"view existing", "claude-code", "post-tool-use", createdPRHookPayload("gh pr view --json url --jq .url", hookPRURL), false},
+		{"printed command", "claude-code", "post-tool-use", createdPRHookPayload("echo 'gh pr create'", hookPRURL), false},
+		{"masked failure", "claude-code", "post-tool-use", createdPRHookPayload("gh pr create || echo "+hookPRURL, hookPRURL), false},
+		{"later output", "claude-code", "post-tool-use", createdPRHookPayload("gh pr create --help; echo "+hookPRURL, hookPRURL), false},
+		{"pipeline", "claude-code", "post-tool-use", createdPRHookPayload("gh pr create | cat", hookPRURL), false},
+		{"background shell", "claude-code", "post-tool-use", createdPRHookPayload("gh pr create &", hookPRURL), false},
+		{"negated", "claude-code", "post-tool-use", createdPRHookPayload("! gh pr create", hookPRURL), false},
+		{"unexecuted branch", "claude-code", "post-tool-use", createdPRHookPayload("if false; then gh pr create; fi", hookPRURL), false},
+		{"heredoc", "claude-code", "post-tool-use", createdPRHookPayload("cat <<'EOF'\ngh pr create\nEOF", hookPRURL), false},
+		{"shell parse error", "claude-code", "post-tool-use", createdPRHookPayload("gh pr create '", hookPRURL), false},
+		{"redirect", "claude-code", "post-tool-use", createdPRHookPayload("gh pr create > /tmp/pr", hookPRURL), false},
+		{"oversize command", "claude-code", "post-tool-use", createdPRHookPayload("gh pr create --title "+strings.Repeat("a", maxHookInteractionLen), hookPRURL), false},
+		{"multiple URLs", "claude-code", "post-tool-use", createdPRHookPayload(command, hookPRURL+"\n"+hookPRURL), false},
+		{"prose", "claude-code", "post-tool-use", createdPRHookPayload(command, "See "+hookPRURL), false},
+		{"lookalike host", "claude-code", "post-tool-use", createdPRHookPayload(command, "https://github.com.evil.test/o/r/pull/1"), false},
+		{"credentials", "claude-code", "post-tool-use", createdPRHookPayload(command, "https://github.com@evil.test/o/r/pull/1"), false},
+		{"fragment", "claude-code", "post-tool-use", createdPRHookPayload(command, hookPRURL+"#comment"), false},
+		{"zero PR", "claude-code", "post-tool-use", createdPRHookPayload(command, "https://github.com/o/r/pull/0"), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hookCreatedPR(tt.agent, tt.event, []byte(tt.payload))
+			want := ""
+			if tt.want {
+				want = hookPRURL
+			}
+			if got != want {
+				t.Fatalf("created PR = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestHooks_RegisterCreatedPR(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusConflict, http.StatusBadGateway} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Setenv("AO_SESSION_ID", "workspace-4")
+			t.Setenv("AO_REVIEW_SESSION_ID", "")
+			cfg := setConfigEnv(t)
+			dataDir := t.TempDir()
+			t.Setenv("AO_DATA_DIR", dataDir)
+			claims, activity := 0, 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v1/sessions/workspace-4/pr/claim":
+					claims++
+					var req claimPRRequest
+					if r.Method != http.MethodPost || json.NewDecoder(r.Body).Decode(&req) != nil || req.PR != hookPRURL || req.AllowTakeover {
+						t.Errorf("unexpected claim: method=%s request=%+v", r.Method, req)
+					}
+					w.WriteHeader(status)
+					if status != http.StatusOK {
+						_, _ = io.WriteString(w, `{"code":"PR_CLAIM_FAILED","message":"cannot claim","requestId":"hook-request"}`)
+					}
+				case "/api/v1/sessions/workspace-4/activity":
+					activity++
+					_, _ = io.WriteString(w, `{}`)
+				default:
+					t.Errorf("unexpected request: %s", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+			writeRunFileFor(t, cfg, srv)
+			out, errOut, err := executeCLI(t, Deps{In: strings.NewReader(createdPRHookPayload("gh pr create --fill", hookPRURL)), ProcessAlive: func(int) bool { return true }}, "hooks", "claude-code", "post-tool-use")
+			if err != nil || out != "" || claims != 1 || activity != 1 {
+				t.Fatalf("err=%v stdout=%q claims=%d activity=%d stderr=%s", err, out, claims, activity, errOut)
+			}
+			if status == http.StatusOK {
+				if errOut != "" {
+					t.Fatalf("stderr=%s", errOut)
+				}
+			} else {
+				log, err := os.ReadFile(filepath.Join(dataDir, hooksLogName))
+				if err != nil || !strings.Contains(string(log), "register created PR") || !strings.Contains(errOut, "hook-request") {
+					t.Fatalf("missing diagnostic: log=%s err=%v stderr=%s", log, err, errOut)
+				}
+			}
+		})
+	}
+}
+
+func TestHooks_ReviewerDoesNotRegisterPR(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "worker-1")
+	t.Setenv("AO_REVIEW_SESSION_ID", "review-1")
+	cfg := setConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/reviews/review-1/activity" {
+			t.Errorf("unexpected request: %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+	writeRunFileFor(t, cfg, srv)
+	_, _, err := executeCLI(t, Deps{In: strings.NewReader(createdPRHookPayload("gh pr create --fill", hookPRURL)), ProcessAlive: func(int) bool { return true }}, "hooks", "claude-code", "post-tool-use")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRegisterHookPRBoundsRequest(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "worker-1")
+	t.Setenv("AO_REVIEW_SESSION_ID", "")
+	cfg := setConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { t.Error("unexpected real request") }))
+	defer srv.Close()
+	writeRunFileFor(t, cfg, srv)
+	// Inspect the transport deadline without sleeping through the timeout.
+	claims := 0
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if !strings.HasSuffix(r.URL.Path, "/pr/claim") {
+			return nil, context.DeadlineExceeded
+		}
+		claims++
+		deadline, ok := r.Context().Deadline()
+		if !ok || time.Until(deadline) > 5*time.Second {
+			t.Errorf("unbounded hook request: %v", deadline)
+		}
+		return nil, context.DeadlineExceeded
+	})}
+	_, _, err := executeCLI(t, Deps{HTTPClient: client, In: strings.NewReader(createdPRHookPayload("gh pr create --fill", hookPRURL)), ProcessAlive: func(int) bool { return true }}, "hooks", "claude-code", "post-tool-use")
+	if err != nil || claims != 1 {
+		t.Fatalf("err=%v claims=%d", err, claims)
+	}
+}

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -63,7 +63,7 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao preview [url]`                  | `POST /api/v1/sessions/{id}/preview`           |
 | `ao preview start/status/stop`      | `POST/GET/DELETE /api/v1/sessions/{id}/preview/server` |
 | `ao browser ...`                    | `GET /api/v1/browser/status`, `POST /api/v1/browser/commands` |
-| `ao hooks <agent> <event>`          | `POST /api/v1/sessions/{id}/activity` (hidden) |
+| `ao hooks <agent> <event>`          | `POST /api/v1/sessions/{id}/activity`; successful Claude Code PR creation also uses `/pr/claim` (hidden) |
 
 `ao agent ls` asks the daemon to ensure display readiness, then prints the
 existing table or legacy JSON projection. The daemon alone decides whether a

--- a/docs/scm-observer.md
+++ b/docs/scm-observer.md
@@ -76,9 +76,24 @@ identity resolution and alias collapse:
    persists a baseline row before the first detail fetch.
 2. **Observer refresh** (the rest of `Poll`): batch GraphQL detail fetches,
    review-thread refreshes, and terminal reconciliation update existing rows.
-3. **Explicit claim** (`ao session claim-pr`, `spawn --claim-pr`, gh-wrapper
-   capture): resolves a PR ref against the project origin and claims the row
-   for a session, including takeover rules for terminated owners.
+3. **Explicit claim** (`ao session claim-pr`, `spawn --claim-pr`, Claude Code
+   creation hooks): resolves a PR ref against the project origin and claims the
+   row for a session, including takeover rules for terminated owners.
+
+Claude Code's `PostToolUse` hook provides a best-effort registration fast path
+for successful Bash `gh pr create` calls. It accepts a standalone command or
+`cd <literal-path> && gh pr create ...`, with one GitHub PR URL as the complete
+stdout result. Failed/interrupted/background calls, scripts, pipelines, and
+output that only mentions a URL are not registration evidence. The CLI parses
+the shell command without executing it and sends the ref to the existing daemon
+claim endpoint with takeover disabled and a five-second deadline. Provider and
+repository validation stay in the daemon. Review-session hooks never claim PRs.
+Failures go to stderr and `$AO_DATA_DIR/hooks.log`, without failing the hook.
+
+This fast path currently covers Claude Code and github.com only. Polling remains
+unchanged for every harness and is still needed for unsupported command forms,
+API/MCP/browser creation, and missed hooks. This does not relax workspace claim
+validation or allow claiming an already merged/closed PR.
 
 The **read model** (`ListPRSummaries`) groups rows through `pr_url_alias` so a
 PR observed under multiple URLs renders as one card, then derives the summary


### PR DESCRIPTION
A Claude Code worker can create a PR on a branch that polling cannot attribute, leaving the session in Building. Successful Bash `gh pr create` hooks now register the returned GitHub PR URL through the existing daemon claim API, independently of branch naming.

The hook parses shell syntax and accepts a standalone creation command or a simple `cd <literal-path> && gh pr create` call with one PR URL as stdout. Failed/interrupted/background calls, unrelated URL output, and compound scripts that can mask failure are ignored. Claims disable takeover, retain daemon repository/provider validation, and have a five-second deadline. Failures are logged without failing the hook or suppressing activity reporting; reviewer hooks never claim PRs.

Fixes #2629.

Validation:
- Focused hook parsing and HTTP-boundary tests, including error envelopes, ownership conflict, reviewer exclusion, and request deadline.
- Backend build, vet, and complete race suite.
- Complete native macOS CLI E2E suite and Docker fresh-install smoke test.
- golangci-lint v2.12.2; API and sqlc regeneration with no generated drift; pinned CI gitleaks image scanned the new commit with no findings.
- All ten hosted checks passed, including the full backend race suite, Linux/macOS/Windows CLI E2E, and Windows workspace checks. Native Linux/Windows and Windows-specific suites were verified in CI, not locally. [Go checks](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34568642713), [CLI E2E](https://github.com/Untrivial-ai/agent-orchestrator/actions/runs/34568642697).

Scope: Claude Code and github.com only. Polling cadence and attribution rules remain unchanged. Other harnesses, shell wrappers/scripts, MCP/browser creation, and GitHub Enterprise remain on existing discovery. Workspace child-repository claims still require #5192; merged/closed PR recovery remains #2632. This PR does not bypass either claim restriction.
