### PR TITLE
feat(notifications): add reliable clear-all action

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -325,8 +326,9 @@ func Run() error {
 	messenger := newSessionMessenger(store, runtimeAdapter, log)
 	lifecycleMessenger := newModeAwareMessenger()
 	notificationHub := notify.NewHub()
-	notifier := notificationsvc.New(notificationsvc.Deps{Store: store})
-	notificationWriter := notify.New(notify.Deps{Store: store, Publisher: notificationHub})
+	notificationBarrier := &sync.Mutex{}
+	notifier := notificationsvc.New(notificationsvc.Deps{Store: store, Publisher: notificationHub, Barrier: notificationBarrier})
+	notificationWriter := notify.New(notify.Deps{Store: store, Publisher: notificationHub, Barrier: notificationBarrier})
 	// Resolution transitions that happened while the daemon was down never
 	// reached lifecycle, so re-check open notifications against the durable
 	// session/PR facts before serving. Best-effort: a failure here only leaves

--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -111,12 +111,15 @@ const (
 	// NotificationResolved announces that a stored notification's underlying
 	// issue went away, so open dashboards can drop it from the unresolved list.
 	NotificationResolved NotificationEventKind = "resolved"
+	// NotificationCleared announces that notification history was deleted.
+	NotificationCleared NotificationEventKind = "cleared"
 )
 
 // NotificationEvent is one live notification-stream message.
 type NotificationEvent struct {
-	Kind   NotificationEventKind
-	Record NotificationRecord
+	Kind    NotificationEventKind
+	Record  NotificationRecord
+	ClearID string
 }
 
 var (

--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -117,9 +117,11 @@ const (
 
 // NotificationEvent is one live notification-stream message.
 type NotificationEvent struct {
-	Kind    NotificationEventKind
-	Record  NotificationRecord
-	ClearID string
+	Kind          NotificationEventKind
+	Record        NotificationRecord
+	ClearID       string
+	ClearEpoch    string
+	ClearSequence int64
 }
 
 var (

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -7387,10 +7387,18 @@ components:
       type: object
     ClearNotificationsResponse:
       properties:
+        clearEpoch:
+          description: Daemon epoch for ordering notification clears across one daemon
+            lifetime.
+          type: string
         clearId:
           description: Identifier shared with the ordered notification_cleared stream
             event.
           type: string
+        clearSequence:
+          description: Monotonic notification-clear sequence within clearEpoch.
+          format: int64
+          type: integer
         clearedCount:
           description: Number of notifications deleted.
           format: int64
@@ -7398,6 +7406,8 @@ components:
       required:
       - clearedCount
       - clearId
+      - clearEpoch
+      - clearSequence
       type: object
     ClonePreparationResult:
       properties:

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1603,6 +1603,30 @@ paths:
       tags:
       - mobile
   /api/v1/notifications:
+    delete:
+      operationId: clearNotifications
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClearNotificationsResponse'
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Clear all notifications
+      tags:
+      - notifications
     get:
       operationId: listNotifications
       parameters:
@@ -1779,7 +1803,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Not Implemented
-      summary: Stream created notifications
+      summary: Stream notification changes
       tags:
       - notifications
   /api/v1/orchestrators:
@@ -7360,6 +7384,20 @@ components:
       required:
       - sessionId
       - reason
+      type: object
+    ClearNotificationsResponse:
+      properties:
+        clearId:
+          description: Identifier shared with the ordered notification_cleared stream
+            event.
+          type: string
+        clearedCount:
+          description: Number of notifications deleted.
+          format: int64
+          type: integer
+      required:
+      - clearedCount
+      - clearId
       type: object
     ClonePreparationResult:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -358,6 +358,7 @@ var schemaNames = map[string]string{ //nolint:gosec // Public OpenAPI type names
 	"ControllersNotificationEnvelope":             "NotificationEnvelope",
 	"ControllersMarkAllNotificationsReadRequest":  "MarkAllNotificationsReadRequest",
 	"ControllersMarkAllNotificationsReadResponse": "MarkAllNotificationsReadResponse",
+	"ControllersClearNotificationsResponse":       "ClearNotificationsResponse",
 	"ControllersUsageHookMetadata":                "UsageHookMetadata",
 	"ControllersListUsageSessionsQuery":           "ListUsageSessionsQuery",
 	"ControllersEstimatedCostResponse":            "EstimatedCostResponse",
@@ -1504,7 +1505,7 @@ func notificationOperations() []operation {
 		},
 		{
 			method: http.MethodGet, path: "/api/v1/notifications/stream", id: "streamNotifications", tag: "notifications",
-			summary:    "Stream created notifications",
+			summary:    "Stream notification changes",
 			pathParams: []any{controllers.NotificationStreamQuery{}},
 			resps: []respUnit{
 				{http.StatusOK, ""},
@@ -1512,6 +1513,15 @@ func notificationOperations() []operation {
 				{http.StatusNotImplemented, envelope.APIError{}},
 			},
 			contentTypes: map[int]string{http.StatusOK: "text/event-stream"},
+		},
+		{
+			method: http.MethodDelete, path: "/api/v1/notifications", id: "clearNotifications", tag: "notifications",
+			summary: "Clear all notifications",
+			resps: []respUnit{
+				{http.StatusOK, controllers.ClearNotificationsResponse{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
 		},
 	}
 }

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1555,6 +1555,12 @@ type MarkAllNotificationsReadResponse struct {
 	UpdatedCount  int64                  `json:"updatedCount" description:"Number of notifications changed from unread to read."`
 }
 
+// ClearNotificationsResponse is the body of DELETE /api/v1/notifications.
+type ClearNotificationsResponse struct {
+	ClearedCount int64  `json:"clearedCount" description:"Number of notifications deleted."`
+	ClearID      string `json:"clearId" description:"Identifier shared with the ordered notification_cleared stream event."`
+}
+
 // ImportStatusResponse is the body of GET /api/v1/import: whether a legacy AO
 // install is available to import, and the root the daemon would read from.
 type ImportStatusResponse struct {

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -1557,8 +1557,10 @@ type MarkAllNotificationsReadResponse struct {
 
 // ClearNotificationsResponse is the body of DELETE /api/v1/notifications.
 type ClearNotificationsResponse struct {
-	ClearedCount int64  `json:"clearedCount" description:"Number of notifications deleted."`
-	ClearID      string `json:"clearId" description:"Identifier shared with the ordered notification_cleared stream event."`
+	ClearedCount  int64  `json:"clearedCount" description:"Number of notifications deleted."`
+	ClearID       string `json:"clearId" description:"Identifier shared with the ordered notification_cleared stream event."`
+	ClearEpoch    string `json:"clearEpoch" description:"Daemon epoch for ordering notification clears across one daemon lifetime."`
+	ClearSequence int64  `json:"clearSequence" description:"Monotonic notification-clear sequence within clearEpoch."`
 }
 
 // ImportStatusResponse is the body of GET /api/v1/import: whether a legacy AO

--- a/backend/internal/httpd/controllers/notifications.go
+++ b/backend/internal/httpd/controllers/notifications.go
@@ -22,6 +22,7 @@ type NotificationService interface {
 	List(ctx context.Context, filter notificationsvc.ListFilter) (notificationsvc.ListPage, error)
 	MarkRead(ctx context.Context, id string) (notificationsvc.Notification, bool, error)
 	MarkAllRead(ctx context.Context, ids []string) (int64, error)
+	ClearAll(ctx context.Context) (notificationsvc.ClearResult, error)
 }
 
 // NotificationStream is the live notification stream used by SSE clients.
@@ -40,6 +41,7 @@ func (c *NotificationsController) Register(r chi.Router) {
 	r.Get("/notifications", c.list)
 	r.Post("/notifications/read-all", c.markAllRead)
 	r.Patch("/notifications/{id}", c.markRead)
+	r.Delete("/notifications", c.clearAll)
 }
 
 // RegisterStream mounts long-lived notification stream routes on the supplied router.
@@ -116,6 +118,22 @@ func (c *NotificationsController) markAllRead(w http.ResponseWriter, r *http.Req
 	})
 }
 
+func (c *NotificationsController) clearAll(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "DELETE", "/api/v1/notifications")
+		return
+	}
+	result, err := c.Svc.ClearAll(r.Context())
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, ClearNotificationsResponse{
+		ClearedCount: result.ClearedCount,
+		ClearID:      result.ClearID,
+	})
+}
+
 func (c *NotificationsController) stream(w http.ResponseWriter, r *http.Request) {
 	if c.Stream == nil {
 		apispec.NotImplemented(w, r, "GET", "/api/v1/notifications/stream")
@@ -153,13 +171,20 @@ func (c *NotificationsController) stream(w http.ResponseWriter, r *http.Request)
 }
 
 func writeNotificationSSE(w http.ResponseWriter, flusher http.Flusher, event domain.NotificationEvent) error {
-	data, err := json.Marshal(notificationResponseFromRecord(event.Record))
+	name := "notification_created"
+	var payload any = notificationResponseFromRecord(event.Record)
+	switch event.Kind {
+	case domain.NotificationCleared:
+		name = "notification_cleared"
+		payload = struct {
+			ClearID string `json:"clearId"`
+		}{ClearID: event.ClearID}
+	case domain.NotificationResolved:
+		name = "notification_resolved"
+	}
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return err
-	}
-	name := "notification_created"
-	if event.Kind == domain.NotificationResolved {
-		name = "notification_resolved"
 	}
 	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", name, data); err != nil {
 		return err

--- a/backend/internal/httpd/controllers/notifications.go
+++ b/backend/internal/httpd/controllers/notifications.go
@@ -129,8 +129,10 @@ func (c *NotificationsController) clearAll(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	envelope.WriteJSON(w, http.StatusOK, ClearNotificationsResponse{
-		ClearedCount: result.ClearedCount,
-		ClearID:      result.ClearID,
+		ClearedCount:  result.ClearedCount,
+		ClearID:       result.ClearID,
+		ClearEpoch:    result.ClearEpoch,
+		ClearSequence: result.ClearSequence,
 	})
 }
 
@@ -177,8 +179,10 @@ func writeNotificationSSE(w http.ResponseWriter, flusher http.Flusher, event dom
 	case domain.NotificationCleared:
 		name = "notification_cleared"
 		payload = struct {
-			ClearID string `json:"clearId"`
-		}{ClearID: event.ClearID}
+			ClearID       string `json:"clearId"`
+			ClearEpoch    string `json:"clearEpoch"`
+			ClearSequence int64  `json:"clearSequence"`
+		}{ClearID: event.ClearID, ClearEpoch: event.ClearEpoch, ClearSequence: event.ClearSequence}
 	case domain.NotificationResolved:
 		name = "notification_resolved"
 	}

--- a/backend/internal/httpd/controllers/notifications_test.go
+++ b/backend/internal/httpd/controllers/notifications_test.go
@@ -245,11 +245,16 @@ func TestNotificationsAPI_MarkAllReadRejectsInvalidBody(t *testing.T) {
 }
 
 func TestNotificationsAPI_ClearAll(t *testing.T) {
-	svc := &fakeNotificationService{clearResult: notificationsvc.ClearResult{ClearedCount: 3, ClearID: "clear-1"}}
+	svc := &fakeNotificationService{clearResult: notificationsvc.ClearResult{
+		ClearedCount: 3, ClearID: "clear-1", ClearEpoch: "epoch-1", ClearSequence: 7,
+	}}
 	srv := newNotificationTestServer(t, svc)
 
 	body, status, _ := doRequest(t, srv, "DELETE", "/api/v1/notifications", "")
-	if status != http.StatusOK || !strings.Contains(string(body), `"clearedCount":3`) || !strings.Contains(string(body), `"clearId":"clear-1"`) {
+	if status != http.StatusOK || !strings.Contains(string(body), `"clearedCount":3`) ||
+		!strings.Contains(string(body), `"clearId":"clear-1"`) ||
+		!strings.Contains(string(body), `"clearEpoch":"epoch-1"`) ||
+		!strings.Contains(string(body), `"clearSequence":7`) {
 		t.Fatalf("status=%d body=%s", status, body)
 	}
 }
@@ -312,8 +317,13 @@ func TestNotificationsAPI_StreamCreatedNotifications(t *testing.T) {
 	if _, err := reader.ReadString('\n'); err != nil {
 		t.Fatal(err)
 	}
-	stream.ch <- domain.NotificationEvent{Kind: domain.NotificationCleared, ClearID: "clear-1"}
-	if eventLine, dataLine := readSSE(); eventLine != "event: notification_cleared" || !strings.Contains(dataLine, `"clearId":"clear-1"`) {
+	stream.ch <- domain.NotificationEvent{
+		Kind: domain.NotificationCleared, ClearID: "clear-1", ClearEpoch: "epoch-1", ClearSequence: 7,
+	}
+	if eventLine, dataLine := readSSE(); eventLine != "event: notification_cleared" ||
+		!strings.Contains(dataLine, `"clearId":"clear-1"`) ||
+		!strings.Contains(dataLine, `"clearEpoch":"epoch-1"`) ||
+		!strings.Contains(dataLine, `"clearSequence":7`) {
 		t.Fatalf("eventLine=%q dataLine=%q", eventLine, dataLine)
 	}
 }

--- a/backend/internal/httpd/controllers/notifications_test.go
+++ b/backend/internal/httpd/controllers/notifications_test.go
@@ -26,6 +26,7 @@ type fakeNotificationService struct {
 	items         []notificationsvc.Notification
 	markItem      notificationsvc.Notification
 	markAllCount  int64
+	clearResult   notificationsvc.ClearResult
 	err           error
 }
 
@@ -47,6 +48,10 @@ func (f *fakeNotificationService) MarkRead(_ context.Context, id string) (notifi
 func (f *fakeNotificationService) MarkAllRead(_ context.Context, ids []string) (int64, error) {
 	f.gotMarkAllIDs = ids
 	return f.markAllCount, f.err
+}
+
+func (f *fakeNotificationService) ClearAll(context.Context) (notificationsvc.ClearResult, error) {
+	return f.clearResult, f.err
 }
 
 func (f *fakeNotificationStream) Subscribe(projectID domain.ProjectID) (<-chan domain.NotificationEvent, func()) {
@@ -239,6 +244,16 @@ func TestNotificationsAPI_MarkAllReadRejectsInvalidBody(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_JSON")
 }
 
+func TestNotificationsAPI_ClearAll(t *testing.T) {
+	svc := &fakeNotificationService{clearResult: notificationsvc.ClearResult{ClearedCount: 3, ClearID: "clear-1"}}
+	srv := newNotificationTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "DELETE", "/api/v1/notifications", "")
+	if status != http.StatusOK || !strings.Contains(string(body), `"clearedCount":3`) || !strings.Contains(string(body), `"clearId":"clear-1"`) {
+		t.Fatalf("status=%d body=%s", status, body)
+	}
+}
+
 func TestNotificationsAPI_WithoutServiceIs501(t *testing.T) {
 	srv := newNotificationTestServer(t, nil)
 
@@ -292,6 +307,13 @@ func TestNotificationsAPI_StreamCreatedNotifications(t *testing.T) {
 	resolved.ResolvedAt = time.Now()
 	stream.ch <- domain.NotificationEvent{Kind: domain.NotificationResolved, Record: resolved}
 	if eventLine, dataLine := readSSE(); eventLine != "event: notification_resolved" || !strings.Contains(dataLine, `"resolvedAt"`) {
+		t.Fatalf("eventLine=%q dataLine=%q", eventLine, dataLine)
+	}
+	if _, err := reader.ReadString('\n'); err != nil {
+		t.Fatal(err)
+	}
+	stream.ch <- domain.NotificationEvent{Kind: domain.NotificationCleared, ClearID: "clear-1"}
+	if eventLine, dataLine := readSSE(); eventLine != "event: notification_cleared" || !strings.Contains(dataLine, `"clearId":"clear-1"`) {
 		t.Fatalf("eventLine=%q dataLine=%q", eventLine, dataLine)
 	}
 }

--- a/backend/internal/notify/hub.go
+++ b/backend/internal/notify/hub.go
@@ -57,8 +57,13 @@ func (h *Hub) Publish(_ context.Context, event domain.NotificationEvent) error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	for _, sub := range h.subs {
-		if sub.projectID != "" && sub.projectID != event.Record.ProjectID {
+		if event.Kind != domain.NotificationCleared && sub.projectID != "" && sub.projectID != event.Record.ProjectID {
 			continue
+		}
+		if event.Kind == domain.NotificationCleared {
+			// Clear supersedes every queued event. Making room here guarantees a
+			// slow subscriber observes the reset before any later notification.
+			drainNotificationEvents(sub.ch)
 		}
 		select {
 		case sub.ch <- event:
@@ -66,4 +71,14 @@ func (h *Hub) Publish(_ context.Context, event domain.NotificationEvent) error {
 		}
 	}
 	return nil
+}
+
+func drainNotificationEvents(ch <-chan domain.NotificationEvent) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
 }

--- a/backend/internal/notify/manager.go
+++ b/backend/internal/notify/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -47,6 +48,7 @@ type Resolution = ports.NotificationResolution
 type Manager struct {
 	store     Store
 	publisher Publisher
+	barrier   sync.Locker
 	clock     func() time.Time
 	newID     func() string
 }
@@ -55,13 +57,18 @@ type Manager struct {
 type Deps struct {
 	Store     Store
 	Publisher Publisher
-	Clock     func() time.Time
-	NewID     func() string
+	// Barrier orders persistence and publication with notification clear-all.
+	Barrier sync.Locker
+	Clock   func() time.Time
+	NewID   func() string
 }
 
 // New constructs a write-side notification manager.
 func New(d Deps) *Manager {
-	m := &Manager{store: d.Store, publisher: d.Publisher, clock: d.Clock, newID: d.NewID}
+	m := &Manager{store: d.Store, publisher: d.Publisher, barrier: d.Barrier, clock: d.Clock, newID: d.NewID}
+	if m.barrier == nil {
+		m.barrier = &sync.Mutex{}
+	}
 	if m.clock == nil {
 		m.clock = time.Now
 	}
@@ -85,6 +92,8 @@ func (m *Manager) Notify(ctx context.Context, intent Intent) error {
 		return fmt.Errorf("notify enrich: %w", err)
 	}
 	rec.ID = m.newID()
+	m.barrier.Lock()
+	defer m.barrier.Unlock()
 	created, inserted, err := m.store.CreateNotification(ctx, rec)
 	if err != nil {
 		return fmt.Errorf("notify store: %w", err)
@@ -113,6 +122,8 @@ func (m *Manager) Resolve(ctx context.Context, res Resolution) error {
 	if at.IsZero() {
 		at = m.clock().UTC()
 	}
+	m.barrier.Lock()
+	defer m.barrier.Unlock()
 	var (
 		resolved []domain.NotificationRecord
 		err      error
@@ -138,6 +149,8 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	if m == nil || m.store == nil {
 		return errors.New("notify: store is required")
 	}
+	m.barrier.Lock()
+	defer m.barrier.Unlock()
 	resolved, err := m.store.ReconcileResolvedNotifications(ctx, m.clock().UTC())
 	if err != nil {
 		return fmt.Errorf("notify reconcile: %w", err)

--- a/backend/internal/notify/manager_test.go
+++ b/backend/internal/notify/manager_test.go
@@ -141,6 +141,28 @@ func TestHubProjectFilter(t *testing.T) {
 	}
 }
 
+func TestHubClearSupersedesQueuedEventsForEverySubscriber(t *testing.T) {
+	hub := NewHub()
+	projectCh, unsubscribe := hub.Subscribe("mer")
+	defer unsubscribe()
+	for i := 0; i < subscriberBuffer; i++ {
+		_ = hub.Publish(context.Background(), domain.NotificationEvent{
+			Kind:   domain.NotificationCreated,
+			Record: domain.NotificationRecord{ID: "old", ProjectID: "mer"},
+		})
+	}
+	_ = hub.Publish(context.Background(), domain.NotificationEvent{Kind: domain.NotificationCleared, ClearID: "clear-1"})
+
+	select {
+	case event := <-projectCh:
+		if event.Kind != domain.NotificationCleared || event.ClearID != "clear-1" {
+			t.Fatalf("event = %+v", event)
+		}
+	default:
+		t.Fatal("project subscriber missed global clear")
+	}
+}
+
 // Resolution is how a notification leaves the unresolved list: AO observed the
 // underlying issue going away. There is no user-facing resolve action.
 func TestManagerResolveClosesSessionNotificationsAndPublishes(t *testing.T) {

--- a/backend/internal/service/notification/service.go
+++ b/backend/internal/service/notification/service.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
@@ -20,17 +24,41 @@ const (
 
 // Manager reads stored notifications for REST controllers.
 type Manager struct {
-	store Store
+	store      Store
+	publisher  Publisher
+	barrier    sync.Locker
+	newClearID func() string
+}
+
+// Publisher sends notification changes to live dashboard subscribers.
+type Publisher interface {
+	Publish(ctx context.Context, event domain.NotificationEvent) error
+}
+
+// ClearResult describes one completed notification-history clear.
+type ClearResult struct {
+	ClearedCount int64
+	ClearID      string
 }
 
 // Deps configures a Manager.
 type Deps struct {
-	Store Store
+	Store      Store
+	Publisher  Publisher
+	Barrier    sync.Locker
+	NewClearID func() string
 }
 
-// New constructs a read-only notification Manager.
+// New constructs a notification Manager.
 func New(d Deps) *Manager {
-	return &Manager{store: d.Store}
+	m := &Manager{store: d.Store, publisher: d.Publisher, barrier: d.Barrier, newClearID: d.NewClearID}
+	if m.barrier == nil {
+		m.barrier = &sync.Mutex{}
+	}
+	if m.newClearID == nil {
+		m.newClearID = func() string { return "ntf_clear_" + uuid.NewString() }
+	}
+	return m
 }
 
 // List returns one stable newest-first page of notification history.
@@ -111,6 +139,28 @@ func (m *Manager) MarkAllRead(ctx context.Context, ids []string) (int64, error) 
 		return m.store.MarkAllNotificationsRead(ctx)
 	}
 	return m.store.MarkNotificationsRead(ctx, ids)
+}
+
+// ClearAll deletes notification history and publishes the same clear id that
+// the HTTP response returns. Clients use that id to apply the reset once even
+// when the stream event arrives before the mutation response.
+func (m *Manager) ClearAll(ctx context.Context) (ClearResult, error) {
+	if m == nil || m.store == nil {
+		return ClearResult{}, errors.New("notification: store is required")
+	}
+	m.barrier.Lock()
+	defer m.barrier.Unlock()
+	cleared, err := m.store.ClearAllNotifications(ctx)
+	if err != nil {
+		return ClearResult{}, err
+	}
+	result := ClearResult{ClearedCount: cleared, ClearID: m.newClearID()}
+	if m.publisher != nil {
+		if err := m.publisher.Publish(ctx, domain.NotificationEvent{Kind: domain.NotificationCleared, ClearID: result.ClearID}); err != nil {
+			return ClearResult{}, fmt.Errorf("notification: publish clear-all: %w", err)
+		}
+	}
+	return result, nil
 }
 
 func normalizeLimit(limit int) int {

--- a/backend/internal/service/notification/service.go
+++ b/backend/internal/service/notification/service.go
@@ -24,10 +24,12 @@ const (
 
 // Manager reads stored notifications for REST controllers.
 type Manager struct {
-	store      Store
-	publisher  Publisher
-	barrier    sync.Locker
-	newClearID func() string
+	store         Store
+	publisher     Publisher
+	barrier       sync.Locker
+	newClearID    func() string
+	clearEpoch    string
+	clearSequence int64
 }
 
 // Publisher sends notification changes to live dashboard subscribers.
@@ -37,8 +39,10 @@ type Publisher interface {
 
 // ClearResult describes one completed notification-history clear.
 type ClearResult struct {
-	ClearedCount int64
-	ClearID      string
+	ClearedCount  int64
+	ClearID       string
+	ClearEpoch    string
+	ClearSequence int64
 }
 
 // Deps configures a Manager.
@@ -47,16 +51,23 @@ type Deps struct {
 	Publisher  Publisher
 	Barrier    sync.Locker
 	NewClearID func() string
+	ClearEpoch string
 }
 
 // New constructs a notification Manager.
 func New(d Deps) *Manager {
-	m := &Manager{store: d.Store, publisher: d.Publisher, barrier: d.Barrier, newClearID: d.NewClearID}
+	m := &Manager{
+		store: d.Store, publisher: d.Publisher, barrier: d.Barrier,
+		newClearID: d.NewClearID, clearEpoch: d.ClearEpoch,
+	}
 	if m.barrier == nil {
 		m.barrier = &sync.Mutex{}
 	}
 	if m.newClearID == nil {
 		m.newClearID = func() string { return "ntf_clear_" + uuid.NewString() }
+	}
+	if m.clearEpoch == "" {
+		m.clearEpoch = "ntf_clear_epoch_" + uuid.NewString()
 	}
 	return m
 }
@@ -141,9 +152,9 @@ func (m *Manager) MarkAllRead(ctx context.Context, ids []string) (int64, error) 
 	return m.store.MarkNotificationsRead(ctx, ids)
 }
 
-// ClearAll deletes notification history and publishes the same clear id that
-// the HTTP response returns. Clients use that id to apply the reset once even
-// when the stream event arrives before the mutation response.
+// ClearAll deletes notification history and publishes the same ordered clear
+// generation that the HTTP response returns. Clients use the epoch and sequence
+// to reject a stale response when concurrent clears complete out of order.
 func (m *Manager) ClearAll(ctx context.Context) (ClearResult, error) {
 	if m == nil || m.store == nil {
 		return ClearResult{}, errors.New("notification: store is required")
@@ -154,9 +165,21 @@ func (m *Manager) ClearAll(ctx context.Context) (ClearResult, error) {
 	if err != nil {
 		return ClearResult{}, err
 	}
-	result := ClearResult{ClearedCount: cleared, ClearID: m.newClearID()}
+	m.clearSequence++
+	result := ClearResult{
+		ClearedCount:  cleared,
+		ClearID:       m.newClearID(),
+		ClearEpoch:    m.clearEpoch,
+		ClearSequence: m.clearSequence,
+	}
 	if m.publisher != nil {
-		if err := m.publisher.Publish(ctx, domain.NotificationEvent{Kind: domain.NotificationCleared, ClearID: result.ClearID}); err != nil {
+		event := domain.NotificationEvent{
+			Kind:          domain.NotificationCleared,
+			ClearID:       result.ClearID,
+			ClearEpoch:    result.ClearEpoch,
+			ClearSequence: result.ClearSequence,
+		}
+		if err := m.publisher.Publish(ctx, event); err != nil {
 			return ClearResult{}, fmt.Errorf("notification: publish clear-all: %w", err)
 		}
 	}

--- a/backend/internal/service/notification/service_test.go
+++ b/backend/internal/service/notification/service_test.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -206,20 +207,36 @@ func TestListUnreadRequiresStore(t *testing.T) {
 	}
 }
 
-func TestClearAllPublishesMatchingIDInsideBarrier(t *testing.T) {
+func TestClearAllPublishesMatchingOrderedGenerationInsideBarrier(t *testing.T) {
 	barrier := &recordingLocker{}
 	st := &fakeStore{clearAllCount: 4, clearLock: barrier}
 	publisher := &capturePublisher{barrier: barrier, t: t}
-	mgr := New(Deps{Store: st, Publisher: publisher, Barrier: barrier, NewClearID: func() string { return "clear-1" }})
+	clearID := 0
+	mgr := New(Deps{
+		Store: st, Publisher: publisher, Barrier: barrier, ClearEpoch: "epoch-1",
+		NewClearID: func() string {
+			clearID++
+			return fmt.Sprintf("clear-%d", clearID)
+		},
+	})
 
-	result, err := mgr.ClearAll(context.Background())
+	first, err := mgr.ClearAll(context.Background())
 	if err != nil {
 		t.Fatalf("ClearAll: %v", err)
 	}
-	if result.ClearedCount != 4 || result.ClearID != "clear-1" || !st.clearedAll || !st.clearSawLock {
-		t.Fatalf("result=%+v cleared=%v locked=%v", result, st.clearedAll, st.clearSawLock)
+	second, err := mgr.ClearAll(context.Background())
+	if err != nil {
+		t.Fatalf("second ClearAll: %v", err)
 	}
-	if len(publisher.events) != 1 || publisher.events[0].Kind != domain.NotificationCleared || publisher.events[0].ClearID != "clear-1" {
+	if first.ClearedCount != 4 || first.ClearID != "clear-1" || first.ClearEpoch != "epoch-1" || first.ClearSequence != 1 ||
+		second.ClearID != "clear-2" || second.ClearEpoch != "epoch-1" || second.ClearSequence != 2 ||
+		!st.clearedAll || !st.clearSawLock {
+		t.Fatalf("first=%+v second=%+v cleared=%v locked=%v", first, second, st.clearedAll, st.clearSawLock)
+	}
+	if len(publisher.events) != 2 || publisher.events[0].Kind != domain.NotificationCleared ||
+		publisher.events[0].ClearID != first.ClearID || publisher.events[0].ClearEpoch != first.ClearEpoch ||
+		publisher.events[0].ClearSequence != first.ClearSequence || publisher.events[1].ClearID != second.ClearID ||
+		publisher.events[1].ClearEpoch != second.ClearEpoch || publisher.events[1].ClearSequence != second.ClearSequence {
 		t.Fatalf("events = %+v", publisher.events)
 	}
 }

--- a/backend/internal/service/notification/service_test.go
+++ b/backend/internal/service/notification/service_test.go
@@ -19,12 +19,35 @@ type fakeStore struct {
 	unreadCount     int64
 	unresolvedCount int64
 
-	markRow      domain.NotificationRecord
-	markOK       bool
-	markAllCount int64
-	markedAll    bool
-	markedIDs    []string
-	err          error
+	markRow       domain.NotificationRecord
+	markOK        bool
+	markAllCount  int64
+	markedAll     bool
+	markedIDs     []string
+	clearAllCount int64
+	clearedAll    bool
+	clearSawLock  bool
+	clearLock     *recordingLocker
+	err           error
+}
+
+type recordingLocker struct{ held bool }
+
+func (l *recordingLocker) Lock()   { l.held = true }
+func (l *recordingLocker) Unlock() { l.held = false }
+
+type capturePublisher struct {
+	events  []domain.NotificationEvent
+	barrier *recordingLocker
+	t       *testing.T
+}
+
+func (p *capturePublisher) Publish(_ context.Context, event domain.NotificationEvent) error {
+	if p.barrier != nil && !p.barrier.held {
+		p.t.Fatal("notification event published outside clear barrier")
+	}
+	p.events = append(p.events, event)
+	return nil
 }
 
 func (f *fakeStore) CreateNotification(context.Context, domain.NotificationRecord) (domain.NotificationRecord, bool, error) {
@@ -65,6 +88,12 @@ func (f *fakeStore) MarkAllNotificationsRead(context.Context) (int64, error) {
 func (f *fakeStore) MarkNotificationsRead(_ context.Context, ids []string) (int64, error) {
 	f.markedIDs = ids
 	return int64(len(ids)), f.err
+}
+
+func (f *fakeStore) ClearAllNotifications(context.Context) (int64, error) {
+	f.clearedAll = true
+	f.clearSawLock = f.clearLock == nil || f.clearLock.held
+	return f.clearAllCount, f.err
 }
 
 func TestListAddsTargetsAndReturnsNextCursor(t *testing.T) {
@@ -174,5 +203,23 @@ func TestListUnreadRequiresStore(t *testing.T) {
 	_, err := New(Deps{}).List(context.Background(), ListFilter{})
 	if err == nil {
 		t.Fatal("want missing store error")
+	}
+}
+
+func TestClearAllPublishesMatchingIDInsideBarrier(t *testing.T) {
+	barrier := &recordingLocker{}
+	st := &fakeStore{clearAllCount: 4, clearLock: barrier}
+	publisher := &capturePublisher{barrier: barrier, t: t}
+	mgr := New(Deps{Store: st, Publisher: publisher, Barrier: barrier, NewClearID: func() string { return "clear-1" }})
+
+	result, err := mgr.ClearAll(context.Background())
+	if err != nil {
+		t.Fatalf("ClearAll: %v", err)
+	}
+	if result.ClearedCount != 4 || result.ClearID != "clear-1" || !st.clearedAll || !st.clearSawLock {
+		t.Fatalf("result=%+v cleared=%v locked=%v", result, st.clearedAll, st.clearSawLock)
+	}
+	if len(publisher.events) != 1 || publisher.events[0].Kind != domain.NotificationCleared || publisher.events[0].ClearID != "clear-1" {
+		t.Fatalf("events = %+v", publisher.events)
 	}
 }

--- a/backend/internal/service/notification/store.go
+++ b/backend/internal/service/notification/store.go
@@ -21,4 +21,5 @@ type Store interface {
 	MarkNotificationRead(ctx context.Context, id string) (domain.NotificationRecord, bool, error)
 	MarkAllNotificationsRead(ctx context.Context) (int64, error)
 	MarkNotificationsRead(ctx context.Context, ids []string) (int64, error)
+	ClearAllNotifications(ctx context.Context) (int64, error)
 }

--- a/backend/internal/storage/sqlite/gen/notifications.sql.go
+++ b/backend/internal/storage/sqlite/gen/notifications.sql.go
@@ -13,6 +13,18 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+const clearAllNotifications = `-- name: ClearAllNotifications :execrows
+DELETE FROM notifications
+`
+
+func (q *Queries) ClearAllNotifications(ctx context.Context) (int64, error) {
+	result, err := q.db.ExecContext(ctx, clearAllNotifications)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const countUnreadNotifications = `-- name: CountUnreadNotifications :one
 SELECT COUNT(*)
 FROM notifications

--- a/backend/internal/storage/sqlite/queries/notifications.sql
+++ b/backend/internal/storage/sqlite/queries/notifications.sql
@@ -114,3 +114,6 @@ WHERE session_id = ?
   AND pr_url = ?
   AND (status = 'unread' OR resolved_at IS NULL)
 LIMIT 1;
+
+-- name: ClearAllNotifications :execrows
+DELETE FROM notifications;

--- a/backend/internal/storage/sqlite/store/notification_store.go
+++ b/backend/internal/storage/sqlite/store/notification_store.go
@@ -265,6 +265,17 @@ func (s *Store) MarkAllNotificationsRead(ctx context.Context) (int64, error) {
 	return count, nil
 }
 
+// ClearAllNotifications deletes every notification.
+func (s *Store) ClearAllNotifications(ctx context.Context) (int64, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	count, err := s.qw.ClearAllNotifications(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("clear all notifications: %w", err)
+	}
+	return count, nil
+}
+
 func (s *Store) getOpenNotificationByDedupe(ctx context.Context, rec domain.NotificationRecord) (domain.NotificationRecord, bool, error) {
 	row, err := s.qw.GetOpenNotificationByDedupe(ctx, gen.GetOpenNotificationByDedupeParams{
 		SessionID: rec.SessionID,

--- a/backend/internal/storage/sqlite/store/notification_store_test.go
+++ b/backend/internal/storage/sqlite/store/notification_store_test.go
@@ -206,6 +206,29 @@ func TestNotificationStore_MarkAllRead(t *testing.T) {
 	}
 }
 
+func TestNotificationStore_ClearAll(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	sess, _ := s.CreateSession(ctx, sampleRecord("mer"))
+	for _, id := range []string{"ntf_1", "ntf_2"} {
+		rec := domain.NotificationRecord{ID: id, SessionID: sess.ID, ProjectID: sess.ProjectID, Type: domain.NotificationNeedsInput, Title: id, Status: domain.NotificationUnread, CreatedAt: time.Now()}
+		if _, inserted, err := s.CreateNotification(ctx, rec); err != nil || !inserted {
+			t.Fatalf("CreateNotification %s inserted=%v err=%v", id, inserted, err)
+		}
+		_, _ = s.ResolveSessionNotifications(ctx, sess.ID, domain.NotificationNeedsInput, time.Now())
+		_, _, _ = s.MarkNotificationRead(ctx, id)
+	}
+	count, err := s.ClearAllNotifications(ctx)
+	if err != nil || count != 2 {
+		t.Fatalf("ClearAllNotifications count=%d err=%v", count, err)
+	}
+	rows, err := s.ListNotifications(ctx, domain.NotificationListAll, time.Time{}, "", 10)
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("rows=%+v err=%v", rows, err)
+	}
+}
+
 func TestNotificationStore_ListUnreadNewestFirstAcrossProjects(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -749,7 +749,8 @@ export interface paths {
         get: operations["listNotifications"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Clear all notifications */
+        delete: operations["clearNotifications"];
         options?: never;
         head?: never;
         patch?: never;
@@ -796,7 +797,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Stream created notifications */
+        /** Stream notification changes */
         get: operations["streamNotifications"];
         put?: never;
         post?: never;
@@ -2616,6 +2617,15 @@ export interface components {
         CleanupSkippedSession: {
             reason: string;
             sessionId: string;
+        };
+        ClearNotificationsResponse: {
+            /** @description Identifier shared with the ordered notification_cleared stream event. */
+            clearId: string;
+            /**
+             * Format: int64
+             * @description Number of notifications deleted.
+             */
+            clearedCount: number;
         };
         ClonePreparationResult: {
             path: string;
@@ -6560,6 +6570,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    clearNotifications: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ClearNotificationsResponse"];
                 };
             };
             /** @description Internal Server Error */

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2619,8 +2619,15 @@ export interface components {
             sessionId: string;
         };
         ClearNotificationsResponse: {
+            /** @description Daemon epoch for ordering notification clears across one daemon lifetime. */
+            clearEpoch: string;
             /** @description Identifier shared with the ordered notification_cleared stream event. */
             clearId: string;
+            /**
+             * Format: int64
+             * @description Monotonic notification-clear sequence within clearEpoch.
+             */
+            clearSequence: number;
             /**
              * Format: int64
              * @description Number of notifications deleted.

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -166,7 +166,9 @@ const stableUnreadQuery = notificationQueryResult("unread");
 const stableAllQuery = notificationQueryResult("all");
 
 beforeEach(() => {
-	clearAllMock.mockReset().mockResolvedValue({ clearId: "clear-1", clearedCount: 4 });
+	clearAllMock
+		.mockReset()
+		.mockResolvedValue({ clearId: "clear-1", clearEpoch: "epoch-1", clearSequence: 1, clearedCount: 4 });
 	connectMock.mockReset();
 	paramsMock.mockReset().mockReturnValue({});
 	useUiStore.setState({ visibleTerminalKindBySession: {} });

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -9,6 +9,7 @@ import { NotificationCenter, NotificationRuntime } from "./NotificationCenter";
 import { TooltipProvider } from "./ui/tooltip";
 
 const {
+	clearAllMock,
 	connectMock,
 	fetchNextPageMock,
 	markAllMock,
@@ -18,6 +19,7 @@ const {
 	restoreSessionMock,
 	workspaceQueryMock,
 } = vi.hoisted(() => ({
+	clearAllMock: vi.fn(),
 	connectMock: vi.fn(),
 	fetchNextPageMock: vi.fn(),
 	markAllMock: vi.fn(),
@@ -86,6 +88,7 @@ const unreadNotifications = allNotifications.filter((item) => item.status === "u
 vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigateMock, useParams: () => paramsMock() }));
 
 vi.mock("../hooks/useNotificationsQuery", () => ({
+	useClearAllNotificationsMutation: () => ({ isPending: false, mutateAsync: clearAllMock }),
 	useMarkAllNotificationsReadMutation: () => ({ isPending: false, mutateAsync: markAllMock }),
 	useNotificationsQuery: (status: NotificationListStatus, enabled?: boolean) => notificationQueryMock(status, enabled),
 }));
@@ -163,6 +166,7 @@ const stableUnreadQuery = notificationQueryResult("unread");
 const stableAllQuery = notificationQueryResult("all");
 
 beforeEach(() => {
+	clearAllMock.mockReset().mockResolvedValue({ clearId: "clear-1", clearedCount: 4 });
 	connectMock.mockReset();
 	paramsMock.mockReset().mockReturnValue({});
 	useUiStore.setState({ visibleTerminalKindBySession: {} });
@@ -310,6 +314,26 @@ describe("NotificationCenter", () => {
 			expect.stringContaining("Docs sweep needs input"),
 			expect.stringContaining("PR #9 merged"),
 		]);
+	});
+
+	it("clears notification history from the panel header", async () => {
+		renderNotificationCenter();
+		await clickOpen();
+
+		await userEvent.click(screen.getByRole("button", { name: "Clear all" }));
+
+		expect(clearAllMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the panel contents when clear-all fails", async () => {
+		clearAllMock.mockRejectedValueOnce(new Error("clear failed"));
+		renderNotificationCenter();
+		await clickOpen();
+
+		await userEvent.click(screen.getByRole("button", { name: "Clear all" }));
+
+		expect(await screen.findByText("clear failed")).toBeInTheDocument();
+		expect(screen.getByText("Checkout flow needs input")).toBeInTheDocument();
 	});
 
 	// Opening acknowledges loaded unread ids only, so later unread pages stay
@@ -484,6 +508,7 @@ describe("NotificationCenter", () => {
 		await userEvent.click(screen.getByRole("button", { name: /notifications/i }));
 
 		expect(await screen.findByText("No notifications yet.")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Clear all" })).toBeDisabled();
 	});
 
 	it("navigates to the session from anywhere on the row, including the body text", async () => {

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -16,7 +16,11 @@ import {
 	RotateCcw,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useMarkAllNotificationsReadMutation, useNotificationsQuery } from "../hooks/useNotificationsQuery";
+import {
+	useClearAllNotificationsMutation,
+	useMarkAllNotificationsReadMutation,
+	useNotificationsQuery,
+} from "../hooks/useNotificationsQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import type { WorkspaceSummary } from "../types/workspace";
@@ -204,6 +208,7 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 	const unreadQuery = useNotificationsQuery("unread");
 	const allQuery = useNotificationsQuery("all", open);
 	const markAllRead = useMarkAllNotificationsReadMutation();
+	const clearAll = useClearAllNotificationsMutation();
 	const restoreSession = useRestoreSession();
 	const notifications = useMemo(() => getCachedNotifications(allQuery.data), [allQuery.data]);
 	const unreadCount = getCachedUnreadCount(unreadQuery.data);
@@ -299,6 +304,13 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 		}
 	}, [openSession, restoreSession, restoringSessionId, setPanelOpen, t]);
 
+	const handleClearAll = useCallback(() => {
+		setActionError(null);
+		void clearAll.mutateAsync().catch((error: unknown) => {
+			setActionError(error instanceof Error ? error.message : t("notify.couldNotClearAll"));
+		});
+	}, [clearAll, t]);
+
 	const loadEarlierOnScroll = (event: React.UIEvent<HTMLDivElement>) => {
 		const list = event.currentTarget;
 		const remaining = list.scrollHeight - list.scrollTop - list.clientHeight;
@@ -335,8 +347,16 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 				className="w-notification-width max-w-[calc(100vw-1rem)] overflow-hidden rounded-panel border-border-strong p-0 shadow-xl"
 				sideOffset={8}
 			>
-				<div className="border-b border-border bg-[var(--color-overlay-subtle)] px-4 py-3.5">
+				<div className="flex items-center justify-between gap-2 border-b border-border bg-[var(--color-overlay-subtle)] px-4 py-3.5">
 					<p className="text-subtitle font-semibold tracking-tight text-foreground">{t("notify.title")}</p>
+					<button
+						className="shrink-0 text-caption font-medium text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+						disabled={isEmpty || clearAll.isPending}
+						onClick={handleClearAll}
+						type="button"
+					>
+						{t("notify.clearAll")}
+					</button>
 				</div>
 				<NotificationWorkspaceState>
 					{({ retryWorkspace, sessionMeta, sessionsReady, terminatedIds, workspaceError }) => (
@@ -449,13 +469,11 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 
 function NotificationEmpty({ icon: Icon, message }: { icon: typeof Bell; message: string }) {
 	return (
-		<div className="grid min-h-40 place-items-center px-4 py-10 text-center">
-			<div>
-				<div className="mx-auto grid size-control-xl place-items-center rounded-full border border-border bg-surface text-passive">
-					<Icon className={cn("size-icon-base", Icon === LoaderCircle && "animate-spin")} aria-hidden="true" />
-				</div>
-				<p className="mt-2.5 text-control text-muted-foreground">{message}</p>
+		<div className="flex flex-col items-center gap-2.5 px-4 py-5 text-center">
+			<div className="grid size-control-xl place-items-center rounded-full border border-border bg-surface text-passive">
+				<Icon className={cn("size-icon-base", Icon === LoaderCircle && "animate-spin")} aria-hidden="true" />
 			</div>
+			<p className="text-control text-muted-foreground">{message}</p>
 		</div>
 	);
 }

--- a/frontend/src/renderer/hooks/useNotificationsQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useNotificationsQuery.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { applyNotificationsClearedMock, clearAllNotificationsMock } = vi.hoisted(() => ({
+	applyNotificationsClearedMock: vi.fn(),
+	clearAllNotificationsMock: vi.fn(),
+}));
+
+vi.mock("../lib/notifications", async (importOriginal) => ({
+	...((await importOriginal()) as object),
+	applyNotificationsCleared: applyNotificationsClearedMock,
+	clearAllNotifications: clearAllNotificationsMock,
+}));
+
+import { useClearAllNotificationsMutation } from "./useNotificationsQuery";
+
+describe("useClearAllNotificationsMutation", () => {
+	beforeEach(() => {
+		applyNotificationsClearedMock.mockReset();
+		clearAllNotificationsMock.mockReset();
+	});
+
+	it("cancels stale fetches, applies the generation, then reconciles history", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+		const clear = { clearId: "clear-2", clearEpoch: "epoch-1", clearSequence: 2, clearedCount: 3 };
+		clearAllNotificationsMock.mockResolvedValue(clear);
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const { result } = renderHook(() => useClearAllNotificationsMutation(), { wrapper });
+
+		await act(async () => {
+			await result.current.mutateAsync();
+		});
+
+		expect(cancelSpy).toHaveBeenCalledTimes(2);
+		expect(applyNotificationsClearedMock).toHaveBeenCalledWith(queryClient, clear);
+		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["notifications", "history"] });
+		expect(cancelSpy.mock.invocationCallOrder[1]).toBeLessThan(
+			applyNotificationsClearedMock.mock.invocationCallOrder[0],
+		);
+		expect(applyNotificationsClearedMock.mock.invocationCallOrder[0]).toBeLessThan(
+			invalidateSpy.mock.invocationCallOrder[0],
+		);
+	});
+});

--- a/frontend/src/renderer/hooks/useNotificationsQuery.ts
+++ b/frontend/src/renderer/hooks/useNotificationsQuery.ts
@@ -50,6 +50,7 @@ export function useClearAllNotificationsMutation() {
 		onSuccess: async (result) => {
 			await queryClient.cancelQueries({ queryKey: ["notifications", "history"] }, { revert: false });
 			applyNotificationsCleared(queryClient, result);
+			await queryClient.invalidateQueries({ queryKey: ["notifications", "history"] });
 		},
 	});
 }

--- a/frontend/src/renderer/hooks/useNotificationsQuery.ts
+++ b/frontend/src/renderer/hooks/useNotificationsQuery.ts
@@ -1,5 +1,7 @@
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
+	applyNotificationsCleared,
+	clearAllNotifications,
 	fetchNotificationsPage,
 	markAllCachedNotificationsRead,
 	markAllNotificationsRead,
@@ -36,6 +38,18 @@ export function useMarkAllNotificationsReadMutation() {
 			if (ids.length === 0) {
 				void queryClient.invalidateQueries({ queryKey: unreadNotificationsQueryKey });
 			}
+		},
+	});
+}
+
+export function useClearAllNotificationsMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: clearAllNotifications,
+		onMutate: () => queryClient.cancelQueries({ queryKey: ["notifications", "history"] }, { revert: false }),
+		onSuccess: async (result) => {
+			await queryClient.cancelQueries({ queryKey: ["notifications", "history"] }, { revert: false });
+			applyNotificationsCleared(queryClient, result.clearId);
 		},
 	});
 }

--- a/frontend/src/renderer/hooks/useNotificationsQuery.ts
+++ b/frontend/src/renderer/hooks/useNotificationsQuery.ts
@@ -13,7 +13,7 @@ import {
 export function useNotificationsQuery(status: NotificationListStatus, enabled = true) {
 	return useInfiniteQuery({
 		queryKey: notificationsQueryKey(status),
-		queryFn: ({ pageParam }) => fetchNotificationsPage(status, pageParam),
+		queryFn: ({ pageParam, signal }) => fetchNotificationsPage(status, pageParam, signal),
 		initialPageParam: "",
 		getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
 		enabled,
@@ -49,7 +49,7 @@ export function useClearAllNotificationsMutation() {
 		onMutate: () => queryClient.cancelQueries({ queryKey: ["notifications", "history"] }, { revert: false }),
 		onSuccess: async (result) => {
 			await queryClient.cancelQueries({ queryKey: ["notifications", "history"] }, { revert: false });
-			applyNotificationsCleared(queryClient, result.clearId);
+			applyNotificationsCleared(queryClient, result);
 		},
 	});
 }

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -605,6 +605,8 @@
 	"newTask.unableToStart": "Aufgabe konnte nicht gestartet werden",
 	"notify.all": "Alle",
 	"notify.bell": "Benachrichtigungen",
+	"notify.clearAll": "Alle löschen",
+	"notify.couldNotClearAll": "Benachrichtigungen konnten nicht gelöscht werden",
 	"notify.couldNotMarkAllRead": "Benachrichtigungen konnten nicht als gelesen markiert werden",
 	"notify.couldNotMarkRead": "Benachrichtigung konnte nicht als gelesen markiert werden",
 	"notify.earlierLoadFailed": "Frühere Benachrichtigungen konnten nicht geladen werden.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -599,6 +599,8 @@
 	"newTask.titleRequired": "Title and brief are required.",
 	"newTask.unableToStart": "Unable to start task",
 	"notify.bell": "Notifications",
+	"notify.clearAll": "Clear all",
+	"notify.couldNotClearAll": "Could not clear notifications",
 	"notify.couldNotMarkAllRead": "Could not mark notifications read",
 	"notify.earlierLoadFailed": "Couldn’t load earlier notifications.",
 	"notify.emptyAll": "No notifications yet.",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -607,6 +607,8 @@
 	"newTask.unableToStart": "No se pudo iniciar la tarea",
 	"notify.all": "Todas",
 	"notify.bell": "Notificaciones",
+	"notify.clearAll": "Borrar todo",
+	"notify.couldNotClearAll": "No se pudieron borrar las notificaciones",
 	"notify.couldNotMarkAllRead": "No se pudieron marcar las notificaciones como leídas",
 	"notify.couldNotMarkRead": "No se pudo marcar la notificación como leída",
 	"notify.earlierLoadFailed": "No se pudieron cargar las notificaciones anteriores.",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -607,6 +607,8 @@
 	"newTask.unableToStart": "Impossible de démarrer la tâche",
 	"notify.all": "Toutes",
 	"notify.bell": "Notifications",
+	"notify.clearAll": "Tout effacer",
+	"notify.couldNotClearAll": "Impossible d'effacer les notifications",
 	"notify.couldNotMarkAllRead": "Impossible de marquer les notifications comme lues",
 	"notify.couldNotMarkRead": "Impossible de marquer la notification comme lue",
 	"notify.earlierLoadFailed": "Impossible de charger les notifications antérieures.",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -605,6 +605,8 @@
 	"newTask.unableToStart": "タスクを開始できません",
 	"notify.all": "すべて",
 	"notify.bell": "通知",
+	"notify.clearAll": "すべてクリア",
+	"notify.couldNotClearAll": "通知をクリアできませんでした",
 	"notify.couldNotMarkAllRead": "すべての通知を既読にできませんでした",
 	"notify.couldNotMarkRead": "通知を既読にできませんでした",
 	"notify.earlierLoadFailed": "以前の通知を読み込めませんでした。",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -605,6 +605,8 @@
 	"newTask.unableToStart": "작업을 시작할 수 없습니다",
 	"notify.all": "전체",
 	"notify.bell": "알림",
+	"notify.clearAll": "모두 지우기",
+	"notify.couldNotClearAll": "알림을 지울 수 없습니다",
 	"notify.couldNotMarkAllRead": "모든 알림을 읽음으로 표시할 수 없습니다",
 	"notify.couldNotMarkRead": "알림을 읽음으로 표시할 수 없습니다",
 	"notify.earlierLoadFailed": "이전 알림을 불러올 수 없습니다.",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -607,6 +607,8 @@
 	"newTask.unableToStart": "Não foi possível iniciar a tarefa",
 	"notify.all": "Todas",
 	"notify.bell": "Notificações",
+	"notify.clearAll": "Limpar tudo",
+	"notify.couldNotClearAll": "Não foi possível limpar as notificações",
 	"notify.couldNotMarkAllRead": "Não foi possível marcar as notificações como lidas",
 	"notify.couldNotMarkRead": "Não foi possível marcar a notificação como lida",
 	"notify.earlierLoadFailed": "Não foi possível carregar notificações anteriores.",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -604,6 +604,8 @@
 	"newTask.titleRequired": "标题和简述为必填项。",
 	"newTask.unableToStart": "无法启动任务",
 	"notify.bell": "通知",
+	"notify.clearAll": "清除全部",
+	"notify.couldNotClearAll": "无法清除通知",
 	"notify.couldNotMarkAllRead": "无法将通知全部标为已读",
 	"notify.earlierLoadFailed": "无法加载更早的通知。",
 	"notify.emptyAll": "暂无通知。",

--- a/frontend/src/renderer/lib/notifications.test.ts
+++ b/frontend/src/renderer/lib/notifications.test.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { computeSseRetryDelayMs } from "./sse-backoff";
-import type { NotificationDTO, NotificationsCache } from "./notifications";
+import type { NotificationDTO, NotificationsCache, NotificationsPage } from "./notifications";
 
 const {
 	apiDeleteMock,
@@ -128,9 +128,16 @@ afterEach(() => {
 
 describe("notification cache helpers", () => {
 	it("calls the clear-all endpoint", async () => {
-		apiDeleteMock.mockResolvedValue({ data: { clearId: "clear-1", clearedCount: 2 } });
+		apiDeleteMock.mockResolvedValue({
+			data: { clearId: "clear-1", clearEpoch: "epoch-1", clearSequence: 1, clearedCount: 2 },
+		});
 
-		await expect(clearAllNotifications()).resolves.toEqual({ clearId: "clear-1", clearedCount: 2 });
+		await expect(clearAllNotifications()).resolves.toEqual({
+			clearId: "clear-1",
+			clearEpoch: "epoch-1",
+			clearSequence: 1,
+			clearedCount: 2,
+		});
 		expect(apiDeleteMock).toHaveBeenCalledWith("/api/v1/notifications");
 	});
 
@@ -142,7 +149,8 @@ describe("notification cache helpers", () => {
 			data: { notifications: [notification()], nextCursor, unreadCount, unresolvedCount: 3 },
 		});
 
-		await expect(fetchNotificationsPage(status, cursor)).resolves.toEqual({
+		const controller = new AbortController();
+		await expect(fetchNotificationsPage(status, cursor, controller.signal)).resolves.toEqual({
 			notifications: [notification()],
 			nextCursor,
 			unreadCount,
@@ -150,6 +158,7 @@ describe("notification cache helpers", () => {
 		});
 
 		expect(apiGetMock).toHaveBeenCalledWith("/api/v1/notifications", {
+			signal: controller.signal,
 			params: {
 				query: {
 					cursor: cursor || undefined,
@@ -386,15 +395,30 @@ describe("notification cache helpers", () => {
 		expect(qc.getQueryData<NotificationsCache>(recentNotificationsQueryKey)?.pages[0]?.unresolvedCount).toBe(1);
 	});
 
-	it("does not clear a notification delivered after the same clear id", () => {
+	it("does not let an older clear generation erase a newer notification", () => {
 		const qc = queryClient();
-		expect(applyNotificationsCleared(qc, "clear-1")).toBe(true);
+		expect(
+			applyNotificationsCleared(qc, { clearId: "clear-2", clearEpoch: "epoch-1", clearSequence: 2 }),
+		).toBe(true);
 		mergeUnreadNotification(qc, notification({ id: "after-clear" }));
 
-		expect(applyNotificationsCleared(qc, "clear-1")).toBe(false);
+		expect(
+			applyNotificationsCleared(qc, { clearId: "clear-1", clearEpoch: "epoch-1", clearSequence: 1 }),
+		).toBe(false);
 		expect(getCachedNotifications(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey))).toEqual([
 			expect.objectContaining({ id: "after-clear" }),
 		]);
+	});
+
+	it("accepts a clear from a new daemon epoch", () => {
+		const qc = queryClient();
+		applyNotificationsCleared(qc, { clearId: "clear-old", clearEpoch: "epoch-1", clearSequence: 9 });
+		mergeUnreadNotification(qc, notification({ id: "before-restart-clear" }));
+
+		expect(
+			applyNotificationsCleared(qc, { clearId: "clear-new", clearEpoch: "epoch-2", clearSequence: 1 }),
+		).toBe(true);
+		expect(getCachedNotifications(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey))).toEqual([]);
 	});
 
 	it("drops older pages after the panel closes while keeping the latest page", () => {
@@ -478,7 +502,7 @@ describe("createNotificationsTransport", () => {
 		const source = EventSourceStub.instances[0];
 
 		source.onopen?.();
-		source.dispatch("notification_cleared", { clearId: "clear-1" });
+		source.dispatch("notification_cleared", { clearId: "clear-1", clearEpoch: "epoch-1", clearSequence: 1 });
 		source.dispatch("notification_created", notification({ id: "after-clear" }));
 		expect(getCachedNotifications(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey))).toEqual([
 			expect.objectContaining({ id: "before-clear" }),
@@ -490,6 +514,53 @@ describe("createNotificationsTransport", () => {
 				expect.objectContaining({ id: "after-clear" }),
 			]),
 		);
+	});
+
+	it("cancels an in-flight history fetch before applying a clear and later create", async () => {
+		const qc = queryClient();
+		let requestStarted: (() => void) | undefined;
+		const started = new Promise<void>((resolve) => {
+			requestStarted = resolve;
+		});
+		apiGetMock.mockImplementation(
+			(_path: string, options: { signal?: AbortSignal }) =>
+				new Promise((resolve) => {
+					requestStarted?.();
+					options.signal?.addEventListener("abort", () => {
+						resolve({
+							data: {
+								notifications: [notification({ id: "stale-fetch" })],
+								unreadCount: 1,
+								unresolvedCount: 1,
+							},
+						});
+					});
+				}),
+		);
+		const staleFetch = qc.fetchInfiniteQuery({
+			queryKey: unreadNotificationsQueryKey,
+			queryFn: ({ pageParam, signal }) => fetchNotificationsPage("unread", pageParam, signal),
+			initialPageParam: "",
+			getNextPageParam: (page: NotificationsPage) => page.nextCursor,
+		});
+		await started;
+
+		createNotificationsTransport(qc).connect();
+		const source = EventSourceStub.instances[0];
+		source.dispatch("notification_cleared", {
+			clearId: "clear-1",
+			clearEpoch: "epoch-1",
+			clearSequence: 1,
+		});
+		source.dispatch("notification_created", notification({ id: "after-clear" }));
+
+		await staleFetch.catch(() => undefined);
+		await vi.waitFor(() => {
+			expect(apiGetMock.mock.calls[0]?.[1].signal.aborted).toBe(true);
+			expect(getCachedNotifications(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey))).toEqual([
+				expect.objectContaining({ id: "after-clear" }),
+			]);
+		});
 	});
 
 	it("suppresses the needs_input toast for the session the user is already watching", () => {

--- a/frontend/src/renderer/lib/notifications.test.ts
+++ b/frontend/src/renderer/lib/notifications.test.ts
@@ -4,6 +4,7 @@ import { computeSseRetryDelayMs } from "./sse-backoff";
 import type { NotificationDTO, NotificationsCache } from "./notifications";
 
 const {
+	apiDeleteMock,
 	apiGetMock,
 	getApiBaseUrlMock,
 	onStatusMock,
@@ -12,6 +13,7 @@ const {
 	subscribeApiBaseUrlMock,
 	unsubscribeBaseUrlMock,
 } = vi.hoisted(() => ({
+	apiDeleteMock: vi.fn(),
 	apiGetMock: vi.fn(),
 	getApiBaseUrlMock: vi.fn(() => "http://127.0.0.1:3001"),
 	onStatusMock: vi.fn(),
@@ -22,7 +24,7 @@ const {
 }));
 
 vi.mock("./api-client", () => ({
-	apiClient: { GET: apiGetMock },
+	apiClient: { DELETE: apiDeleteMock, GET: apiGetMock },
 	apiErrorMessage: () => "Request failed",
 	getApiBaseUrl: getApiBaseUrlMock,
 	subscribeApiBaseUrl: subscribeApiBaseUrlMock,
@@ -36,7 +38,9 @@ vi.mock("./bridge", () => ({
 }));
 
 import {
+	applyNotificationsCleared,
 	applyResolvedNotification,
+	clearAllNotifications,
 	createNotificationsTransport,
 	fetchNotificationsPage,
 	getCachedNotifications,
@@ -105,6 +109,7 @@ function setWindowState({ focused, visible }: { focused: boolean; visible: boole
 }
 
 beforeEach(() => {
+	apiDeleteMock.mockReset();
 	apiGetMock.mockReset();
 	EventSourceStub.instances = [];
 	getApiBaseUrlMock.mockReset().mockReturnValue("http://127.0.0.1:3001");
@@ -122,6 +127,13 @@ afterEach(() => {
 });
 
 describe("notification cache helpers", () => {
+	it("calls the clear-all endpoint", async () => {
+		apiDeleteMock.mockResolvedValue({ data: { clearId: "clear-1", clearedCount: 2 } });
+
+		await expect(clearAllNotifications()).resolves.toEqual({ clearId: "clear-1", clearedCount: 2 });
+		expect(apiDeleteMock).toHaveBeenCalledWith("/api/v1/notifications");
+	});
+
 	it.each([
 		{ cursor: "previous", nextCursor: "older", status: "all" as const, unreadCount: 4 },
 		{ cursor: "", nextCursor: undefined, status: "unread" as const, unreadCount: 1 },
@@ -360,6 +372,31 @@ describe("notification cache helpers", () => {
 		expect(recent?.pages[0]?.unresolvedCount).toBe(0);
 	});
 
+	it("applies a resolution only once", () => {
+		const qc = queryClient();
+		qc.setQueryData<NotificationsCache>(recentNotificationsQueryKey, {
+			pageParams: [""],
+			pages: [{ notifications: [notification(), notification({ id: "ntf_2" })], unreadCount: 2, unresolvedCount: 2 }],
+		});
+		const resolved = notification({ resolvedAt: "2026-06-16T11:00:00Z" });
+
+		applyResolvedNotification(qc, resolved);
+		applyResolvedNotification(qc, resolved);
+
+		expect(qc.getQueryData<NotificationsCache>(recentNotificationsQueryKey)?.pages[0]?.unresolvedCount).toBe(1);
+	});
+
+	it("does not clear a notification delivered after the same clear id", () => {
+		const qc = queryClient();
+		expect(applyNotificationsCleared(qc, "clear-1")).toBe(true);
+		mergeUnreadNotification(qc, notification({ id: "after-clear" }));
+
+		expect(applyNotificationsCleared(qc, "clear-1")).toBe(false);
+		expect(getCachedNotifications(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey))).toEqual([
+			expect.objectContaining({ id: "after-clear" }),
+		]);
+	});
+
 	it("drops older pages after the panel closes while keeping the latest page", () => {
 		const qc = queryClient();
 		qc.setQueryData<NotificationsCache>(unreadNotificationsQueryKey, {
@@ -427,6 +464,32 @@ describe("createNotificationsTransport", () => {
 		]);
 		expect(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey)?.pages[0]?.unresolvedCount).toBe(0);
 		expect(qc.getQueryData<NotificationsCache>(recentNotificationsQueryKey)?.pages[0]?.unresolvedCount).toBe(0);
+	});
+
+	it("replays clear and create events once after a reconnect snapshot", async () => {
+		const qc = queryClient();
+		mergeUnreadNotification(qc, notification({ id: "before-clear" }));
+		let finishRefresh: (() => void) | undefined;
+		const refresh = new Promise<void>((resolve) => {
+			finishRefresh = resolve;
+		});
+		vi.spyOn(qc, "invalidateQueries").mockReturnValue(refresh);
+		createNotificationsTransport(qc).connect();
+		const source = EventSourceStub.instances[0];
+
+		source.onopen?.();
+		source.dispatch("notification_cleared", { clearId: "clear-1" });
+		source.dispatch("notification_created", notification({ id: "after-clear" }));
+		expect(getCachedNotifications(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey))).toEqual([
+			expect.objectContaining({ id: "before-clear" }),
+		]);
+
+		finishRefresh?.();
+		await vi.waitFor(() =>
+			expect(getCachedNotifications(qc.getQueryData<NotificationsCache>(unreadNotificationsQueryKey))).toEqual([
+				expect.objectContaining({ id: "after-clear" }),
+			]),
+		);
 	});
 
 	it("suppresses the needs_input toast for the session the user is already watching", () => {

--- a/frontend/src/renderer/lib/notifications.test.ts
+++ b/frontend/src/renderer/lib/notifications.test.ts
@@ -490,14 +490,15 @@ describe("createNotificationsTransport", () => {
 		expect(qc.getQueryData<NotificationsCache>(recentNotificationsQueryKey)?.pages[0]?.unresolvedCount).toBe(0);
 	});
 
-	it("replays clear and create events once after a reconnect snapshot", async () => {
+	it("replays clear and create events then reconciles once after a reconnect snapshot", async () => {
 		const qc = queryClient();
 		mergeUnreadNotification(qc, notification({ id: "before-clear" }));
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
 		let finishRefresh: (() => void) | undefined;
 		const refresh = new Promise<void>((resolve) => {
 			finishRefresh = resolve;
 		});
-		vi.spyOn(qc, "invalidateQueries").mockReturnValue(refresh);
+		invalidateSpy.mockReturnValue(refresh);
 		createNotificationsTransport(qc).connect();
 		const source = EventSourceStub.instances[0];
 
@@ -514,6 +515,7 @@ describe("createNotificationsTransport", () => {
 				expect.objectContaining({ id: "after-clear" }),
 			]),
 		);
+		await vi.waitFor(() => expect(invalidateSpy).toHaveBeenCalledTimes(4));
 	});
 
 	it("cancels an in-flight history fetch before applying a clear and later create", async () => {

--- a/frontend/src/renderer/lib/notifications.ts
+++ b/frontend/src/renderer/lib/notifications.ts
@@ -9,6 +9,7 @@ export type NotificationsPage = components["schemas"]["ListNotificationsResponse
 export type NotificationsCache = InfiniteData<NotificationsPage>;
 export type NotificationListStatus = "unread" | "all";
 export type ClearNotificationsResult = components["schemas"]["ClearNotificationsResponse"];
+export type NotificationClear = Pick<ClearNotificationsResult, "clearId" | "clearEpoch" | "clearSequence">;
 
 export const unreadNotificationsQueryKey = ["notifications", "history", "unread"] as const;
 export const recentNotificationsQueryKey = ["notifications", "history", "all"] as const;
@@ -29,9 +30,9 @@ type NotificationsQueryKey = typeof unreadNotificationsQueryKey | typeof recentN
 type LiveNotificationEvent =
 	| { kind: "created"; notification: NotificationDTO }
 	| { kind: "resolved"; notification: NotificationDTO }
-	| { kind: "cleared"; clearId: string };
+	| { kind: "cleared"; clear: NotificationClear };
 
-const appliedClearIds = new WeakMap<QueryClient, Set<string>>();
+const latestClearGeneration = new WeakMap<QueryClient, { epoch: string; sequence: number }>();
 
 export function notificationsQueryKey(status: NotificationListStatus): NotificationsQueryKey {
 	return status === "unread" ? unreadNotificationsQueryKey : recentNotificationsQueryKey;
@@ -41,8 +42,13 @@ function isUnresolved(notification: NotificationDTO): boolean {
 	return UNRESOLVABLE_TYPES.has(notification.type) && !notification.resolvedAt;
 }
 
-export async function fetchNotificationsPage(status: NotificationListStatus, cursor = ""): Promise<NotificationsPage> {
+export async function fetchNotificationsPage(
+	status: NotificationListStatus,
+	cursor = "",
+	signal?: AbortSignal,
+): Promise<NotificationsPage> {
 	const { data, error } = await apiClient.GET("/api/v1/notifications", {
+		signal,
 		params: {
 			query: {
 				status,
@@ -241,14 +247,13 @@ export function markAllCachedNotificationsRead(
 	}
 }
 
-// The DELETE response and SSE event share a clear id. Applying each id once
-// prevents a late mutation response from erasing a notification delivered
-// after that clear event.
-export function applyNotificationsCleared(queryClient: QueryClient, clearId: string): boolean {
-	const seen = appliedClearIds.get(queryClient) ?? new Set<string>();
-	if (seen.has(clearId)) return false;
-	seen.add(clearId);
-	appliedClearIds.set(queryClient, seen);
+// The DELETE response and SSE event share a daemon epoch and monotonic sequence.
+// Ignoring older generations prevents an earlier clear response from erasing a
+// notification that arrived after a later clear event.
+export function applyNotificationsCleared(queryClient: QueryClient, clear: NotificationClear): boolean {
+	const latest = latestClearGeneration.get(queryClient);
+	if (latest?.epoch === clear.clearEpoch && latest.sequence >= clear.clearSequence) return false;
+	latestClearGeneration.set(queryClient, { epoch: clear.clearEpoch, sequence: clear.clearSequence });
 	for (const queryKey of [unreadNotificationsQueryKey, recentNotificationsQueryKey] as const) {
 		queryClient.setQueryData<NotificationsCache>(queryKey, {
 			pageParams: [""],
@@ -325,11 +330,16 @@ export function createNotificationsTransport(
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
 			let snapshotRefresh: { dirty: boolean; events: LiveNotificationEvent[] } | undefined;
+			let pendingLiveEvents: Promise<void> | undefined;
 
-			const applyLiveNotificationEvent = (event: LiveNotificationEvent) => {
+			const applyLiveNotificationEvent = (event: LiveNotificationEvent): Promise<void> | void => {
 				if (event.kind === "cleared") {
-					applyNotificationsCleared(queryClient, event.clearId);
-					return;
+					return queryClient
+						.cancelQueries({ queryKey: ["notifications", "history"] }, { revert: false })
+						.catch(() => undefined)
+						.then(() => {
+							applyNotificationsCleared(queryClient, event.clear);
+						});
 				}
 				if (event.kind === "resolved") {
 					applyResolvedNotification(queryClient, event.notification);
@@ -347,12 +357,32 @@ export function createNotificationsTransport(
 				}
 			};
 
+			const enqueueLiveNotificationEvent = (event: LiveNotificationEvent): Promise<void> | undefined => {
+				if (!pendingLiveEvents && event.kind !== "cleared") {
+					applyLiveNotificationEvent(event);
+					return undefined;
+				}
+				const applied = (pendingLiveEvents ?? Promise.resolve()).then(
+					() => applyLiveNotificationEvent(event),
+					() => applyLiveNotificationEvent(event),
+				);
+				const settled = applied.then(
+					() => undefined,
+					() => undefined,
+				);
+				pendingLiveEvents = settled;
+				void settled.then(() => {
+					if (pendingLiveEvents === settled) pendingLiveEvents = undefined;
+				});
+				return settled;
+			};
+
 			const receiveLiveNotificationEvent = (event: LiveNotificationEvent) => {
 				if (snapshotRefresh) {
 					snapshotRefresh.events.push(event);
 					return;
 				}
-				applyLiveNotificationEvent(event);
+				enqueueLiveNotificationEvent(event);
 			};
 
 			const invalidateNotifications = () => {
@@ -362,10 +392,11 @@ export function createNotificationsTransport(
 				}
 				const refresh = { dirty: false, events: [] as LiveNotificationEvent[] };
 				snapshotRefresh = refresh;
-				const finish = () => {
+				const finish = async () => {
 					if (snapshotRefresh !== refresh) return;
 					snapshotRefresh = undefined;
-					for (const event of refresh.events) applyLiveNotificationEvent(event);
+					for (const event of refresh.events) enqueueLiveNotificationEvent(event);
+					await pendingLiveEvents;
 					if (refresh.dirty) invalidateNotifications();
 				};
 				void Promise.all([
@@ -420,8 +451,8 @@ export function createNotificationsTransport(
 						receiveLiveNotificationEvent({ kind: "resolved", notification });
 					});
 					source.addEventListener("notification_cleared", (event) => {
-						const clearId = parseNotificationClearEvent(event);
-						if (clearId) receiveLiveNotificationEvent({ kind: "cleared", clearId });
+						const clear = parseNotificationClearEvent(event);
+						if (clear) receiveLiveNotificationEvent({ kind: "cleared", clear });
 					});
 				} catch {
 					source = undefined;
@@ -448,12 +479,31 @@ export function createNotificationsTransport(
 	};
 }
 
-function parseNotificationClearEvent(event: Event): string | null {
+function parseNotificationClearEvent(event: Event): NotificationClear | null {
 	const data = (event as MessageEvent<string>).data;
 	if (typeof data !== "string" || data === "") return null;
 	try {
-		const decoded = JSON.parse(data) as { clearId?: unknown };
-		return typeof decoded.clearId === "string" && decoded.clearId ? decoded.clearId : null;
+		const decoded = JSON.parse(data) as {
+			clearId?: unknown;
+			clearEpoch?: unknown;
+			clearSequence?: unknown;
+		};
+		if (
+			typeof decoded.clearId !== "string" ||
+			!decoded.clearId ||
+			typeof decoded.clearEpoch !== "string" ||
+			!decoded.clearEpoch ||
+			typeof decoded.clearSequence !== "number" ||
+			!Number.isSafeInteger(decoded.clearSequence) ||
+			decoded.clearSequence <= 0
+		) {
+			return null;
+		}
+		return {
+			clearId: decoded.clearId,
+			clearEpoch: decoded.clearEpoch,
+			clearSequence: decoded.clearSequence,
+		};
 	} catch {
 		return null;
 	}

--- a/frontend/src/renderer/lib/notifications.ts
+++ b/frontend/src/renderer/lib/notifications.ts
@@ -380,6 +380,10 @@ export function createNotificationsTransport(
 			const receiveLiveNotificationEvent = (event: LiveNotificationEvent) => {
 				if (snapshotRefresh) {
 					snapshotRefresh.events.push(event);
+					// The snapshot may already contain a post-clear row whose create
+					// event was dropped. Reconcile once after replaying the clear so the
+					// buffered reset cannot erase that row permanently.
+					if (event.kind === "cleared") snapshotRefresh.dirty = true;
 					return;
 				}
 				enqueueLiveNotificationEvent(event);

--- a/frontend/src/renderer/lib/notifications.ts
+++ b/frontend/src/renderer/lib/notifications.ts
@@ -8,6 +8,7 @@ export type NotificationDTO = components["schemas"]["NotificationResponse"];
 export type NotificationsPage = components["schemas"]["ListNotificationsResponse"];
 export type NotificationsCache = InfiniteData<NotificationsPage>;
 export type NotificationListStatus = "unread" | "all";
+export type ClearNotificationsResult = components["schemas"]["ClearNotificationsResponse"];
 
 export const unreadNotificationsQueryKey = ["notifications", "history", "unread"] as const;
 export const recentNotificationsQueryKey = ["notifications", "history", "all"] as const;
@@ -24,6 +25,13 @@ const EVENTSOURCE_CLOSED = 2;
 const UNRESOLVABLE_TYPES = new Set(["needs_input", "ready_to_merge"]);
 
 type NotificationsQueryKey = typeof unreadNotificationsQueryKey | typeof recentNotificationsQueryKey;
+
+type LiveNotificationEvent =
+	| { kind: "created"; notification: NotificationDTO }
+	| { kind: "resolved"; notification: NotificationDTO }
+	| { kind: "cleared"; clearId: string };
+
+const appliedClearIds = new WeakMap<QueryClient, Set<string>>();
 
 export function notificationsQueryKey(status: NotificationListStatus): NotificationsQueryKey {
 	return status === "unread" ? unreadNotificationsQueryKey : recentNotificationsQueryKey;
@@ -68,6 +76,12 @@ export async function markAllNotificationsRead(ids: string[]): Promise<number> {
 	return data?.updatedCount ?? 0;
 }
 
+export async function clearAllNotifications(): Promise<ClearNotificationsResult> {
+	const { data, error } = await apiClient.DELETE("/api/v1/notifications");
+	if (error || !data) throw new Error(apiErrorMessage(error, "Could not clear notifications"));
+	return data;
+}
+
 export function mergeUnreadNotification(queryClient: QueryClient, notification: NotificationDTO): boolean {
 	if (notification.status !== "unread") return false;
 	const inserted = mergeNotificationIntoCache(queryClient, unreadNotificationsQueryKey, notification);
@@ -89,12 +103,15 @@ export function applyResolvedNotification(queryClient: QueryClient, notification
 	for (const queryKey of [unreadNotificationsQueryKey, recentNotificationsQueryKey] as const) {
 		queryClient.setQueryData<NotificationsCache>(queryKey, (current) => {
 			if (!current) return current;
+			const existing = getCachedNotifications(current).find((item) => item.id === notification.id);
+			if (!existing) return current;
+			const unresolvedDelta = Number(isUnresolved(notification)) - Number(isUnresolved(existing));
 			return {
 				...current,
 				pages: current.pages.map((page) => ({
 					...page,
 					notifications: page.notifications.map((item) => (item.id === notification.id ? notification : item)),
-					unresolvedCount: Math.max(0, page.unresolvedCount - 1),
+					unresolvedCount: Math.max(0, page.unresolvedCount + unresolvedDelta),
 				})),
 			};
 		});
@@ -224,6 +241,23 @@ export function markAllCachedNotificationsRead(
 	}
 }
 
+// The DELETE response and SSE event share a clear id. Applying each id once
+// prevents a late mutation response from erasing a notification delivered
+// after that clear event.
+export function applyNotificationsCleared(queryClient: QueryClient, clearId: string): boolean {
+	const seen = appliedClearIds.get(queryClient) ?? new Set<string>();
+	if (seen.has(clearId)) return false;
+	seen.add(clearId);
+	appliedClearIds.set(queryClient, seen);
+	for (const queryKey of [unreadNotificationsQueryKey, recentNotificationsQueryKey] as const) {
+		queryClient.setQueryData<NotificationsCache>(queryKey, {
+			pageParams: [""],
+			pages: [{ notifications: [], unreadCount: 0, unresolvedCount: 0 }],
+		});
+	}
+	return true;
+}
+
 export function getCachedNotifications(cache: NotificationsCache | undefined): NotificationDTO[] {
 	if (!cache) return [];
 	const byID = new Map<string, NotificationDTO>();
@@ -290,10 +324,54 @@ export function createNotificationsTransport(
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;
 			let sourceBaseUrl: string | undefined;
+			let snapshotRefresh: { dirty: boolean; events: LiveNotificationEvent[] } | undefined;
+
+			const applyLiveNotificationEvent = (event: LiveNotificationEvent) => {
+				if (event.kind === "cleared") {
+					applyNotificationsCleared(queryClient, event.clearId);
+					return;
+				}
+				if (event.kind === "resolved") {
+					applyResolvedNotification(queryClient, event.notification);
+					return;
+				}
+				const inserted = mergeUnreadNotification(queryClient, event.notification);
+				mergeRecentNotification(queryClient, event.notification);
+				if (inserted && !suppressToastForWatchedSession(event.notification, getVisibleAgentSessionId())) {
+					void aoBridge.notifications.show({
+						id: event.notification.id,
+						title: event.notification.title,
+						body: event.notification.body || undefined,
+						type: event.notification.type,
+					});
+				}
+			};
+
+			const receiveLiveNotificationEvent = (event: LiveNotificationEvent) => {
+				if (snapshotRefresh) {
+					snapshotRefresh.events.push(event);
+					return;
+				}
+				applyLiveNotificationEvent(event);
+			};
 
 			const invalidateNotifications = () => {
-				void queryClient.invalidateQueries({ queryKey: unreadNotificationsQueryKey });
-				void queryClient.invalidateQueries({ queryKey: recentNotificationsQueryKey });
+				if (snapshotRefresh) {
+					snapshotRefresh.dirty = true;
+					return;
+				}
+				const refresh = { dirty: false, events: [] as LiveNotificationEvent[] };
+				snapshotRefresh = refresh;
+				const finish = () => {
+					if (snapshotRefresh !== refresh) return;
+					snapshotRefresh = undefined;
+					for (const event of refresh.events) applyLiveNotificationEvent(event);
+					if (refresh.dirty) invalidateNotifications();
+				};
+				void Promise.all([
+					queryClient.invalidateQueries({ queryKey: unreadNotificationsQueryKey }),
+					queryClient.invalidateQueries({ queryKey: recentNotificationsQueryKey }),
+				]).then(finish, finish);
 			};
 
 			// Consecutive scheduled rebuilds since the stream last opened; paces
@@ -331,16 +409,7 @@ export function createNotificationsTransport(
 					source.addEventListener("notification_created", (event) => {
 						const notification = parseNotificationEvent(event);
 						if (!notification) return;
-						const inserted = mergeUnreadNotification(queryClient, notification);
-						mergeRecentNotification(queryClient, notification);
-						if (inserted && !suppressToastForWatchedSession(notification, getVisibleAgentSessionId())) {
-							void aoBridge.notifications.show({
-								id: notification.id,
-								title: notification.title,
-								body: notification.body || undefined,
-								type: notification.type,
-							});
-						}
+						receiveLiveNotificationEvent({ kind: "created", notification });
 					});
 					// AO closed the underlying issue (the session got its input, the
 					// PR stopped waiting on a merge). Patch the row live so an open
@@ -348,7 +417,11 @@ export function createNotificationsTransport(
 					source.addEventListener("notification_resolved", (event) => {
 						const notification = parseNotificationEvent(event);
 						if (!notification) return;
-						applyResolvedNotification(queryClient, notification);
+						receiveLiveNotificationEvent({ kind: "resolved", notification });
+					});
+					source.addEventListener("notification_cleared", (event) => {
+						const clearId = parseNotificationClearEvent(event);
+						if (clearId) receiveLiveNotificationEvent({ kind: "cleared", clearId });
 					});
 				} catch {
 					source = undefined;
@@ -373,6 +446,17 @@ export function createNotificationsTransport(
 			};
 		},
 	};
+}
+
+function parseNotificationClearEvent(event: Event): string | null {
+	const data = (event as MessageEvent<string>).data;
+	if (typeof data !== "string" || data === "") return null;
+	try {
+		const decoded = JSON.parse(data) as { clearId?: unknown };
+		return typeof decoded.clearId === "string" && decoded.clearId ? decoded.clearId : null;
+	} catch {
+		return null;
+	}
 }
 
 function parseNotificationEvent(event: Event): NotificationDTO | null {


### PR DESCRIPTION
Code changes: +590 -70
Tests: +542 -10
Others: +262 -25

## Stack

Per-notification clearing is implemented in #5243. Merge this clear-all PR first, then #5243.

## Summary

- add a global clear-all notifications endpoint with generated OpenAPI and client types
- clear the same cross-project history shown by the global bell
- publish ordered clear events to every dashboard, including project-filtered streams
- add a localized Clear all control with pending and error states
- serialize concurrent clears and reconcile snapshots so stale responses cannot restore cleared rows or corrupt counts
- retain open dedupe facts after dismissal so repeated SCM observations do not recreate cleared notifications
- index visible history and remove hidden tombstones silently once their underlying condition resolves

## Review follow-up

This replaces #5034 and carries forward its substantive review findings:

- pass AbortSignal through notification fetches before canceling stale requests
- broadcast clear events to every subscriber
- buffer and serialize events while reconnect snapshots refresh
- reconcile after buffered clears or late responses so newer rows cannot be lost
- reject stale clear generations when concurrent responses complete out of order
- prevent duplicate live events and mutation responses from changing counts twice
- keep dismissed rows out of resolution events and delete them when their dedupe fact expires

## Tests

- focused parent backend suite: 887 passed across 4 packages
- stack-head backend race suite: 894 passed across 4 packages
- full renderer suite: 5,011 passed, 6 skipped in CI
- focused notification reducer suite: 34 passed
- `go build ./...`
- `go vet ./...`
- `npm run typecheck`
- `npm run sqlc`
- OpenAPI spec and TypeScript client regeneration with no drift