### PR TITLE
fix(cloud): no-lag terminal reconnect to idle/paused sandboxes (Layer 1, provider-neutral)

### DIFF
--- a/cloud/internal/postgres/worker_transport_store.go
+++ b/cloud/internal/postgres/worker_transport_store.go
@@ -30,6 +30,11 @@ const (
 	// tickets but never opening a WebSocket would otherwise keep a sandbox
 	// awake — and billed — indefinitely.
 	unconsumedTicketThreshold = 10
+	// interactionRefreshThrottle bounds how often active terminal input rewrites
+	// the interactive lease. Within one lease window the lease is refreshed at
+	// most once per (interactiveSessionLease - interactionRefreshThrottle), so a
+	// fast typist does not rewrite ao_sandboxes on every keystroke.
+	interactionRefreshThrottle = 30 * time.Second
 )
 
 func (s *Store) CreateWorkspaceRequest(
@@ -756,6 +761,37 @@ func (s *Store) queueTerminalRequest(
 	payload []byte,
 ) error {
 	return s.withOrg(ctx, terminal.OrgID, func(tx pgx.Tx) error {
+		// Typing or resizing a terminal is active proof of life for BOTH terminal
+		// surfaces (workspace and agent): keep an in-use sandbox awake, and wake a
+		// paused one so the keystroke that arrives after an idle pause resumes the
+		// box instead of being silently dropped. Idle-but-open output streams never
+		// reach here, so they still pause normally. The lease rewrite is throttled
+		// so a fast typist does not rewrite ao_sandboxes on every keystroke. This
+		// mirrors the wake in IssueTerminalTicket for the in-session case where the
+		// box paused underneath an already-open terminal.
+		if kind == "terminal.input" || kind == "terminal.resize" {
+			if _, err := tx.Exec(ctx,
+				`UPDATE ao_sandboxes
+				SET desired_state = CASE WHEN desired_state = 'paused' THEN 'running' ELSE desired_state END,
+					reconcile_after = CASE WHEN desired_state = 'paused' THEN now() ELSE reconcile_after END,
+					startup_started_at = CASE WHEN desired_state = 'paused' THEN now() ELSE startup_started_at END,
+					interactive_until = now() + $3::interval,
+					updated_at = now()
+				WHERE org_id = $1 AND session_id = $2
+				  AND desired_state IN ('running', 'paused')
+				  AND (
+					desired_state = 'paused'
+					OR interactive_until IS NULL
+					OR interactive_until < now() + $4::interval
+				  )`,
+				terminal.OrgID, terminal.SessionID,
+				intervalString(interactiveSessionLease),
+				intervalString(interactiveSessionLease-interactionRefreshThrottle),
+			); err != nil {
+				return err
+			}
+		}
+
 		var current bool
 		if err := tx.QueryRow(ctx,
 			`SELECT EXISTS (

--- a/cloud/internal/reconcile/reconciler.go
+++ b/cloud/internal/reconcile/reconciler.go
@@ -532,6 +532,13 @@ func (r *Reconciler) reconcileSandbox(ctx context.Context, record domain.Sandbox
 			if err := provider.Stop(ctx, environment.ID); err != nil {
 				return r.fail(ctx, record, err)
 			}
+			// A paused sandbox has no live worker. Mark its connection
+			// disconnected so terminal input correctly sees "no worker" and wakes
+			// the box, instead of enqueuing keystrokes to a dead worker that expire
+			// unclaimed. On resume the worker reconnects under a fresh epoch.
+			if err := r.store.DisconnectSessionWorkers(ctx, record.OrgID, record.SessionID); err != nil {
+				r.log.Warn("disconnect worker on pause", "session_id", record.SessionID, "err", err)
+			}
 		}
 		return r.observe(ctx, record, string(environment.ID), domain.SandboxObservedStopped, "", 30*time.Second)
 	}

--- a/cloud/internal/reconcile/reconciler_test.go
+++ b/cloud/internal/reconcile/reconciler_test.go
@@ -141,3 +141,94 @@ func TestCoderRestoreBootstrapRequiresDurableIdentity(t *testing.T) {
 		t.Fatal("first Coder bootstrap unexpectedly required an existing identity")
 	}
 }
+
+// pausePathStore spies on the two store calls the pause path makes.
+type pausePathStore struct {
+	Store
+	disconnected int
+	observed     string
+}
+
+func (s *pausePathStore) DisconnectSessionWorkers(context.Context, string, string) error {
+	s.disconnected++
+	return nil
+}
+
+func (s *pausePathStore) UpdateSandboxObservation(
+	_ context.Context, _, _, _, _, observedState, _ string, _ time.Time,
+) error {
+	s.observed = observedState
+	return nil
+}
+
+// stopSpyProvider fakes just the two provider calls the pause path uses.
+type stopSpyProvider struct {
+	sandbox.Provider
+	state   string
+	stopped int
+}
+
+func (p *stopSpyProvider) Get(context.Context, sandbox.ID) (sandbox.Environment, error) {
+	return sandbox.Environment{ID: "env-1", State: p.state}, nil
+}
+
+func (p *stopSpyProvider) Stop(context.Context, sandbox.ID) error {
+	p.stopped++
+	return nil
+}
+
+type fixedResolver struct{ provider sandbox.Provider }
+
+func (r fixedResolver) Resolve(context.Context, domain.Sandbox) (sandbox.Provider, error) {
+	return r.provider, nil
+}
+
+// Pausing a running sandbox must stop the provider AND disconnect its worker,
+// so a subsequent terminal keystroke sees "no worker" and wakes the box instead
+// of enqueuing input to a dead worker that expires unclaimed.
+func TestReconcilePauseDisconnectsWorker(t *testing.T) {
+	t.Parallel()
+	store := &pausePathStore{}
+	provider := &stopSpyProvider{state: sandbox.StateRunning}
+	reconciler := New(store, fixedResolver{provider}, Options{})
+	if err := reconciler.reconcileSandbox(context.Background(), domain.Sandbox{
+		SessionID: "session-1", OrgID: "org-1", Provider: sandbox.ProviderNodeOps,
+		DesiredState:          domain.SandboxDesiredPaused,
+		ObservedState:         domain.SandboxObservedRunning,
+		ProviderEnvironmentID: "env-1",
+	}); err != nil {
+		t.Fatalf("reconcileSandbox: %v", err)
+	}
+	if provider.stopped != 1 {
+		t.Fatalf("provider.Stop called %d times, want 1", provider.stopped)
+	}
+	if store.disconnected != 1 {
+		t.Fatalf("DisconnectSessionWorkers called %d times, want 1", store.disconnected)
+	}
+	if store.observed != domain.SandboxObservedStopped {
+		t.Fatalf("observed = %q, want %q", store.observed, domain.SandboxObservedStopped)
+	}
+}
+
+// A sandbox already stopped provider-side must not re-stop or re-disconnect on
+// every reconcile tick while it stays paused.
+func TestReconcilePauseAlreadyStoppedSkipsDisconnect(t *testing.T) {
+	t.Parallel()
+	store := &pausePathStore{}
+	provider := &stopSpyProvider{state: sandbox.StateStopped}
+	reconciler := New(store, fixedResolver{provider}, Options{})
+	if err := reconciler.reconcileSandbox(context.Background(), domain.Sandbox{
+		SessionID: "session-1", OrgID: "org-1", Provider: sandbox.ProviderNodeOps,
+		DesiredState:          domain.SandboxDesiredPaused,
+		ObservedState:         domain.SandboxObservedStopped,
+		ProviderEnvironmentID: "env-1",
+	}); err != nil {
+		t.Fatalf("reconcileSandbox: %v", err)
+	}
+	if provider.stopped != 0 {
+		t.Fatalf("provider.Stop called %d times on an already-stopped env, want 0", provider.stopped)
+	}
+	if store.disconnected != 0 {
+		t.Fatalf("DisconnectSessionWorkers called %d times on an already-stopped env, want 0", store.disconnected)
+	}
+}


### PR DESCRIPTION
## What

Makes writing to the terminal of a cloud session that has been idle for a while lag-free and lossless, for **both** providers (nodeops and coder). Fixes the class of bug seen on orchestrator a-22: an idle-paused sandbox's terminal went dead (keystrokes silently dropped) and an actively-used agent/orchestrator terminal got re-paused underneath the user.

This is **Layer 1** of the two-layer plan: a provider-neutral control-plane fix. It lives entirely in `queueTerminalRequest` + the reconciler pause path, so it applies to every provider on this branch without provider-specific code.

## Why

Two verified gaps in the existing interaction-lease machinery:

1. **Agent/orchestrator terminals never kept the box alive.** `RefreshTerminalInteraction` refreshed the lease only for `workspace` terminals, and the idle timer is driven solely by the last chat message (terminal I/O was deliberately excluded). So an actively-typed agent terminal was re-paused ~1 min after resume.
2. **Typing into a paused box neither woke it nor delivered.** The terminal-input path never set `desired_state=running` (chat does), and pausing did not disconnect the worker connection, so keystrokes were enqueued to a dead worker and expired unclaimed after 15s, with no wake and no error.

## How

Three provider-neutral changes:

- **`queueTerminalRequest`**: `terminal.input` / `terminal.resize` now refreshes the interactive lease (throttled) and wakes a paused sandbox (`desired_state paused -> running`), for both terminal surfaces. An in-use box stays warm and never idle-pauses; a box that did pause resumes on the next keystroke instead of dropping it. Mirrors the existing wake in `IssueTerminalTicket`, for the in-session case where the box paused under an already-open terminal.
- **Reconciler pause path**: disconnects the session's worker when the box is paused, so the input readiness check honestly reports "no worker" and wakes the box instead of enqueuing to a dead connection. On resume the worker reconnects under a fresh epoch.
- **`interactionRefreshThrottle`**: bounds the lease rewrite so a fast typist does not update `ao_sandboxes` on every keystroke (at most once per ~90s within a 2 min lease).

Keep-alive is on real input, not on a merely-open stream, so an idle-but-open terminal still pauses normally (no billing regression).

## Provider coverage

- **nodeops**: pause is an in-place suspend, resume is in-place in seconds, so keep-warm + wake-on-input make reconnect feel instant and lossless. Fully covered here.
- **coder**: the same keep-warm/wake logic runs (coder is on this branch). Because a coder stop destroys the container (only the durable volume persists), a genuinely cold resume is still slow until the worker binary is baked into the customer template. The control plane already advertises `AO_WORKER_EXPECTED_SHA256` for coder self-heal; baking the template is the Layer 2 fast-follow below.

## Testing

- New reconciler tests: pausing a running box stops the provider and disconnects the worker; an already-stopped box is not re-stopped or re-disconnected on subsequent ticks.
- `go build ./... && go vet ./... && go test ./...` green for the cloud module.
- Recommend an E2E pass on staging: idle-pause a nodeops session, then type into its terminal and confirm it resumes and delivers without a dropped keystroke, and that an actively-used terminal is not paused underneath the user.

## Layer 2 (not in this PR)

The coder-specific latency work is infra/customer-side or existing PRs, not new code here:
- Bake `ao-worker` into the eleven_x Coder template so a cold resume self-heals (~100s -> ~seconds) instead of re-streaming the binary over PTY. Gated on the external customer template; CP self-heal env already wired.
- Honor Coder autostop + deadline-extend active work (existing PR #4737) and tune `AO_CLOUD_IDLE_PAUSE_THRESHOLD` (deploy config) so in-use coder sessions are not stopped.
- Warm/standby pool of pre-baked sandboxes: deferred (can be done later).

## Notes

- No schema migration.
- Base branch is `test/cloud-e2e-happy` (#5023), which was first updated to the latest `main` (conflicts resolved) before this branch was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)