### PR TITLE
docs: plan GitHub multi-account support

### DIFF
--- a/docs/superpowers/plans/2026-09-11-github-multi-account.md
+++ b/docs/superpowers/plans/2026-09-11-github-multi-account.md
@@ -18,10 +18,9 @@
 |------|--------|-----|
 | `backend/internal/domain/projectconfig.go` | modify | Add `GitHubAccount GitHubAccountRef` and validation |
 | `backend/internal/domain/projectconfig_test.go` | modify | Validation cases |
-| `backend/internal/domain/github_account.go` | create | Snapshot types, capability states, login operation |
+| `backend/internal/domain/github_account.go` | create | Ref, snapshots, context helpers |
 | `backend/internal/adapters/scm/github/auth.go` | modify | Per-account `gh auth token --hostname --user`, context ref |
 | `backend/internal/adapters/scm/github/auth_account_test.go` | create | Cache key, env override, missing user |
-| `backend/internal/domain/github_account.go` | create | Ref, validation, `WithGitHubAccount` / `GitHubAccountFrom` context helpers |
 | `backend/internal/adapters/scm/github/provider.go` | modify | Identity cache keyed by host+login |
 | `backend/internal/service/githubacct/` | create | Catalog, login terminal, logout, ensure |
 | `backend/internal/httpd/controllers/github_accounts.go` | create | HTTP routes |
@@ -34,6 +33,7 @@
 | `backend/internal/httpd/apispec/specgen/build.go` | modify | `schemaNames` + operations |
 | `backend/internal/observe/scm/observer.go` | modify | Per-project GitHub identity |
 | `backend/internal/observe/scm/scoped_identity_test.go` | modify | Two GitHub logins |
+| `backend/internal/service/systemcheck/systemcheck.go` | modify | Share `gh auth login` terminal with Settings add-account |
 | `backend/internal/session_manager/manager.go` | modify | Inject GH_TOKEN |
 | `backend/internal/session_manager/github_env_test.go` | create | Env injection tests |
 | `backend/internal/daemon/scm_wiring.go` | modify | Keep FallbackTokenSource, now account-aware |
@@ -391,7 +391,7 @@ EOF
 - Modify: `backend/internal/service/githubacct/login.go`
 - Test: `backend/internal/service/githubacct/login_test.go`
 
-Reuse `shellterm` the way Codex login does (`backend/internal/service/agent/codex_account_login.go`). Command argv is exactly `gh auth login --hostname <host> --git-protocol ssh` (or https if the existing accounts on that host use https). Do not pass tokens on argv.
+Reuse the existing onboarding GitHub auth terminal (`systemcheck.OpenGitHubAuthTerminal`, `POST /api/v1/system/github-auth/terminal`, `GitHubOnboardingNotice`) rather than cloning Codex's pending-home vault. Extract a shared “run `gh auth login` in a trusted shellterm” helper if Settings add-account and onboarding would otherwise duplicate argv/PTY setup. Command argv is exactly `gh auth login --hostname <host> --git-protocol ssh` (or https if the existing accounts on that host use https). Do not pass tokens on argv. Do not set `GH_CONFIG_DIR`.
 
 After verify:
 
@@ -533,7 +533,9 @@ func (m *Manager) applyGitHubAccountEnv(ctx context.Context, project domain.Proj
 }
 ```
 
-Protected: if `ProjectConfig.Env` already had `GH_TOKEN`, overwrite. Tests: `TestSpawnEnvProjectVarsCannotOverrideInternal` style.
+Protected: if `ProjectConfig.Env` already had `GH_TOKEN`, overwrite. Chat/TUI overlay this map on full `os.Environ()` (`processenv.Merge`, tmux `os.Environ()`), so injected keys must win over inherited daemon `GITHUB_TOKEN`/`GH_TOKEN`. Preview servers must keep stripping those keys (`previewEnvironment` / `TestPreviewEnvironmentDoesNotInheritDaemonCredentials`).
+
+Tests: `TestSpawnEnvProjectVarsCannotOverrideInternal` style, plus one overlay test that daemon env `GITHUB_TOKEN=daemon` is replaced by the bound account token in the merged child env.
 
 Skip injection when ref is zero or daemon env override is set.
 

--- a/docs/superpowers/plans/2026-09-11-github-multi-account.md
+++ b/docs/superpowers/plans/2026-09-11-github-multi-account.md
@@ -1,0 +1,679 @@
+# GitHub Multi-Account Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user keep multiple GitHub CLI accounts and bind one account per AO project without running `gh auth switch` as a product action.
+
+**Architecture:** Discover accounts from `gh auth status --json hosts`. Fetch tokens with `gh auth token --hostname --user`. Store only `{hostname, login}` on `ProjectConfig`. Inject `GH_TOKEN` into session env and pass the same ref through SCM/tracker `context.Context`. Credentials stay in `gh`. Codex/Claude account PRs are out of scope.
+
+**Tech Stack:** Go daemon (Cobra CLI, chi, sqlc/goose unchanged), React 19 settings UI, generated OpenAPI + `frontend/src/api/schema.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-github-multi-account-design.md`
+
+---
+
+## File plan
+
+| Path | Action | Why |
+|------|--------|-----|
+| `backend/internal/domain/projectconfig.go` | modify | Add `GitHubAccount GitHubAccountRef` and validation |
+| `backend/internal/domain/projectconfig_test.go` | modify | Validation cases |
+| `backend/internal/domain/github_account.go` | create | Snapshot types, capability states, login operation |
+| `backend/internal/adapters/scm/github/auth.go` | modify | Per-account `gh auth token --hostname --user`, context ref |
+| `backend/internal/adapters/scm/github/auth_account_test.go` | create | Cache key, env override, missing user |
+| `backend/internal/domain/github_account.go` | create | Ref, validation, `WithGitHubAccount` / `GitHubAccountFrom` context helpers |
+| `backend/internal/adapters/scm/github/provider.go` | modify | Identity cache keyed by host+login |
+| `backend/internal/service/githubacct/` | create | Catalog, login terminal, logout, ensure |
+| `backend/internal/httpd/controllers/github_accounts.go` | create | HTTP routes |
+| `backend/internal/httpd/controllers/github_accounts_dto.go` | create | Wire types |
+| `backend/internal/httpd/controllers/github_accounts_test.go` | create | HTTP tests |
+| `backend/internal/httpd/api.go` | modify | Wire controller |
+| `backend/internal/httpd/lan_listener.go` | modify | Block `/api/v1/scm/github/accounts` |
+| `backend/internal/httpd/lan_listener_test.go` | modify | LAN 404 cases |
+| `backend/internal/httpd/cors.go` | modify | Origin boundary |
+| `backend/internal/httpd/apispec/specgen/build.go` | modify | `schemaNames` + operations |
+| `backend/internal/observe/scm/observer.go` | modify | Per-project GitHub identity |
+| `backend/internal/observe/scm/scoped_identity_test.go` | modify | Two GitHub logins |
+| `backend/internal/session_manager/manager.go` | modify | Inject GH_TOKEN |
+| `backend/internal/session_manager/github_env_test.go` | create | Env injection tests |
+| `backend/internal/daemon/scm_wiring.go` | modify | Keep FallbackTokenSource, now account-aware |
+| `backend/internal/daemon/tracker_wiring.go` | modify | Same token helper as SCM |
+| `backend/internal/cli/project.go` | modify | `--github-account` |
+| `backend/internal/cli/github.go` | create | `ao github accounts` |
+| `backend/internal/cli/github_test.go` | create | CLI tests |
+| `frontend/src/renderer/hooks/useGitHubAccountsQuery.ts` | create | API hooks |
+| `frontend/src/renderer/components/settings/GitHubAccountsSection.tsx` | create | Settings UI |
+| `frontend/src/renderer/components/settings/settingsCatalog.tsx` | modify | Catalog entry |
+| `frontend/src/renderer/components/ProjectSettingsForm.tsx` | modify | Account picker |
+| `frontend/src/renderer/i18n/*.json` | modify | Copy |
+| `docs/STATUS.md` | modify | Shipped note after implementation |
+
+**Out of scope:** Codex/Claude account files, `gh auth switch` worker gates, GitLab UI, new SQLite migrations, LAN bind/auth changes, `~/.ao` path rules.
+
+---
+
+### Task 1: Domain ref + ProjectConfig validation
+
+**Files:**
+- Create: `backend/internal/domain/github_account.go`
+- Modify: `backend/internal/domain/projectconfig.go`
+- Test: `backend/internal/domain/projectconfig_test.go`
+
+- [ ] **Step 1: Write the failing validation tests**
+
+Append to `TestProjectConfigValidate`:
+
+```go
+{"github account empty ok", ProjectConfig{}, false},
+{"github account login only defaults later", ProjectConfig{GitHubAccount: GitHubAccountRef{Login: "octocat"}}, false},
+{"github account host without login", ProjectConfig{GitHubAccount: GitHubAccountRef{Hostname: "github.com"}}, true},
+{"github account email refused", ProjectConfig{GitHubAccount: GitHubAccountRef{Login: "a@b.com"}}, true},
+{"github account scheme refused", ProjectConfig{GitHubAccount: GitHubAccountRef{Hostname: "https://github.com", Login: "octocat"}}, true},
+{"github account path refused", ProjectConfig{GitHubAccount: GitHubAccountRef{Hostname: "github.com/foo", Login: "octocat"}}, true},
+{"github account token-shaped login refused", ProjectConfig{GitHubAccount: GitHubAccountRef{Login: "gho_notalogin"}}, true},
+```
+
+- [ ] **Step 2: Run the test and confirm it fails to compile**
+
+Run: `cd backend && go test ./internal/domain -run TestProjectConfigValidate -count=1`
+
+Expected: FAIL compile, `GitHubAccountRef` undefined.
+
+- [ ] **Step 3: Add types and validation**
+
+`backend/internal/domain/github_account.go`:
+
+```go
+package domain
+
+import (
+    "fmt"
+    "net/url"
+    "regexp"
+    "strings"
+)
+
+const DefaultGitHubHostname = "github.com"
+
+// GitHubAccountRef names one gh-stored account. It is not a credential.
+type GitHubAccountRef struct {
+    Hostname string `json:"hostname,omitempty"`
+    Login    string `json:"login,omitempty"`
+}
+
+var gitHubLoginRE = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
+
+func (r GitHubAccountRef) IsZero() bool {
+    return strings.TrimSpace(r.Hostname) == "" && strings.TrimSpace(r.Login) == ""
+}
+
+func (r GitHubAccountRef) Normalize() GitHubAccountRef {
+    r.Hostname = strings.ToLower(strings.TrimSpace(r.Hostname))
+    r.Login = strings.TrimSpace(r.Login)
+    if r.Login != "" && r.Hostname == "" {
+        r.Hostname = DefaultGitHubHostname
+    }
+    return r
+}
+
+func (r GitHubAccountRef) Validate() error {
+    r = r.Normalize()
+    if r.IsZero() {
+        return nil
+    }
+    if r.Login == "" {
+        return fmt.Errorf("githubAccount.login is required when hostname is set")
+    }
+    if !gitHubLoginRE.MatchString(r.Login) {
+        return fmt.Errorf("githubAccount.login is not a GitHub login")
+    }
+    if strings.ContainsAny(r.Hostname, "/:@ \\t") || strings.Contains(r.Hostname, "://") {
+        return fmt.Errorf("githubAccount.hostname must be a host name")
+    }
+    if _, err := url.Parse("https://" + r.Hostname); err != nil || r.Hostname == "" {
+        return fmt.Errorf("githubAccount.hostname must be a host name")
+    }
+    return nil
+}
+```
+
+On `ProjectConfig` add:
+
+```go
+GitHubAccount GitHubAccountRef `json:"githubAccount,omitempty"`
+```
+
+In `Validate()`, after tracker intake:
+
+```go
+if err := c.GitHubAccount.Validate(); err != nil {
+    return err
+}
+```
+
+Call `c.GitHubAccount = c.GitHubAccount.Normalize()` inside `WithDefaults`.
+
+- [ ] **Step 4: Re-run tests**
+
+Run: `cd backend && go test ./internal/domain -run TestProjectConfigValidate -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/domain/github_account.go backend/internal/domain/projectconfig.go backend/internal/domain/projectconfig_test.go
+git commit -m "$(cat <<'EOF'
+feat(domain): add per-project GitHub account ref
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Context-aware GitHub token source
+
+**Files:**
+- Modify: `backend/internal/domain/github_account.go` (context helpers)
+- Modify: `backend/internal/adapters/scm/github/auth.go`
+- Test: `backend/internal/adapters/scm/github/auth_account_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestGHTokenSourceUsesUserAndHostname(t *testing.T) {
+    var gotArgs []string
+    src := &GHTokenSource{
+        GHArgs: func(_ context.Context, hostname, user string) (string, error) {
+            gotArgs = []string{hostname, user}
+            return "tok-work\n", nil
+        },
+        TokenTTL: time.Hour,
+    }
+    ctx := domain.WithGitHubAccount(context.Background(), domain.GitHubAccountRef{Hostname: "github.com", Login: "work"})
+    tok, err := src.Token(ctx)
+    if err != nil || tok != "tok-work" {
+        t.Fatalf("Token = %q, %v", tok, err)
+    }
+    if gotArgs[0] != "github.com" || gotArgs[1] != "work" {
+        t.Fatalf("args = %#v", gotArgs)
+    }
+}
+
+func TestGHTokenSourceCachesPerAccount(t *testing.T) {
+    calls := 0
+    src := &GHTokenSource{
+        GHArgs: func(context.Context, string, string) (string, error) {
+            calls++
+            return "tok", nil
+        },
+        TokenTTL: time.Hour,
+    }
+    a := domain.WithGitHubAccount(context.Background(), domain.GitHubAccountRef{Login: "a"})
+    b := domain.WithGitHubAccount(context.Background(), domain.GitHubAccountRef{Login: "b"})
+    _, _ = src.Token(a)
+    _, _ = src.Token(a)
+    _, _ = src.Token(b)
+    if calls != 2 {
+        t.Fatalf("calls = %d, want 2", calls)
+    }
+}
+
+func TestGHTokenSourceEnvOverrideIgnoresAccount(t *testing.T) {
+    t.Setenv("AO_GITHUB_TOKEN", "")
+    t.Setenv("GITHUB_TOKEN", "")
+    src := FallbackTokenSource{
+        EnvTokenSource{EnvVars: []string{"AO_GITHUB_TOKEN"}},
+        &GHTokenSource{GHArgs: func(context.Context, string, string) (string, error) {
+            t.Fatal("gh should not run when env token is set")
+            return "", nil
+        }},
+    }
+    t.Setenv("AO_GITHUB_TOKEN", "env-tok")
+    tok, err := src.Token(domain.WithGitHubAccount(context.Background(), domain.GitHubAccountRef{Login: "work"}))
+    if err != nil || tok != "env-tok" {
+        t.Fatalf("Token = %q, %v", tok, err)
+    }
+}
+```
+
+Keep `TestGHTokenSourceUsesInjectedHook` passing by leaving the old `GH` func as the no-account path.
+
+- [ ] **Step 2: Run tests, expect compile failure**
+
+Run: `cd backend && go test ./internal/adapters/scm/github -run 'TestGHTokenSource' -count=1`
+
+- [ ] **Step 3: Implement context + GHArgs**
+
+Put context helpers on the domain ref so `observe/scm` never imports `adapters/scm/github`:
+
+```go
+// in backend/internal/domain/github_account.go
+type githubAccountCtxKey struct{}
+
+func WithGitHubAccount(ctx context.Context, ref GitHubAccountRef) context.Context {
+    ref = ref.Normalize()
+    if ref.IsZero() {
+        return ctx
+    }
+    return context.WithValue(ctx, githubAccountCtxKey{}, ref)
+}
+
+func GitHubAccountFrom(ctx context.Context) (GitHubAccountRef, bool) {
+    ref, ok := ctx.Value(githubAccountCtxKey{}).(GitHubAccountRef)
+    return ref, ok && !ref.IsZero()
+}
+```
+
+`GHTokenSource.Token` calls `domain.GitHubAccountFrom(ctx)`.
+
+Extend `GHTokenSource` with:
+
+```go
+// GHArgs, when set, is the test hook for `gh auth token` with optional
+// --hostname and --user. Production leaves this nil.
+GHArgs func(ctx context.Context, hostname, user string) (string, error)
+```
+
+Cache `map[string]cachedToken` keyed by `hostname+"\x00"+user`.
+
+`ghAuthToken` becomes:
+
+```go
+func ghAuthTokenFor(ctx context.Context, hostname, user string) (string, error) {
+    args := []string{"auth", "token"}
+    if hostname != "" && hostname != domain.DefaultGitHubHostname {
+        args = append(args, "--hostname", hostname)
+    }
+    if user != "" {
+        args = append(args, "--user", user)
+    }
+    out, err := aoprocess.CommandContext(ctx, "gh", args...).Output()
+    if err != nil {
+        return "", err
+    }
+    return string(out), nil
+}
+```
+
+For `github.com` + user, still pass `--user` so the non-active account is used. Pass `--hostname github.com` only when needed; `gh` defaults the host. Prefer always passing `--user` when login is set.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && go test ./internal/adapters/scm/github -run 'TestGHTokenSource' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/domain/github_account.go backend/internal/adapters/scm/github/auth.go backend/internal/adapters/scm/github/auth_account_test.go
+git commit -m "$(cat <<'EOF'
+feat(scm): fetch GitHub tokens for a named gh account
+
+EOF
+)"
+```
+
+---
+
+### Task 3: GitHub accounts catalog service
+
+**Files:**
+- Create: `backend/internal/service/githubacct/service.go`
+- Create: `backend/internal/service/githubacct/status.go`
+- Test: `backend/internal/service/githubacct/service_test.go`
+
+- [ ] **Step 1: Write catalog tests against a fake `gh auth status --json`**
+
+Fixture (no tokens):
+
+```json
+{
+  "hosts": {
+    "github.com": [
+      {"user": "personal", "active": true, "state": "success"},
+      {"user": "work", "active": false, "state": "success"}
+    ]
+  }
+}
+```
+
+Field names must match real `gh auth status --json hosts` on the implementer's `gh`. If the live schema uses `login` instead of `user`, decode both with `json.RawMessage` fallbacks. Tests inject the bytes; they never call the real binary.
+
+Assertions:
+
+- Two snapshots, `personal` marked `ActiveInGh`.
+- `ensure` is idempotent.
+- Malformed JSON returns `GITHUB_ACCOUNT_STATUS_INVALID` without leaking the payload into the API error details.
+
+- [ ] **Step 2: Run, expect package missing**
+
+Run: `cd backend && go test ./internal/service/githubacct -count=1`
+
+- [ ] **Step 3: Implement discovery**
+
+Parse only display fields. If a token-like string appears in a decoded field, drop it (`strings.HasPrefix(v, "gho_")` etc) and keep login empty → `broken`.
+
+Capabilities:
+
+```go
+type Capabilities struct {
+    AccountRead       domain.CodexCapabilityObservation // reuse observation shape or a tiny SCM copy
+    AccountManagement domain.CodexCapabilityObservation
+}
+```
+
+Prefer a small `domain.GitHubAccountCapabilities` in `github_account.go` rather than reusing Codex types in the GitHub service.
+
+When `os.Getenv("AO_GITHUB_TOKEN")` or `GITHUB_TOKEN` is set in the daemon, `AccountManagement.State = unsupported`, `ReasonCode = daemon_token_override`.
+
+- [ ] **Step 4: Tests pass**
+
+Run: `cd backend && go test ./internal/service/githubacct -count=1`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(github): discover gh CLI accounts without reading tokens
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Login terminal, restore-active, logout
+
+**Files:**
+- Modify: `backend/internal/service/githubacct/login.go`
+- Test: `backend/internal/service/githubacct/login_test.go`
+
+Reuse `shellterm` the way Codex login does (`backend/internal/service/agent/codex_account_login.go`). Command argv is exactly `gh auth login --hostname <host> --git-protocol ssh` (or https if the existing accounts on that host use https). Do not pass tokens on argv.
+
+After verify:
+
+1. Rediscover accounts.
+2. If the previously active login is no longer active, run `gh auth switch --hostname --user <previous>` once. This is login-flow recovery only.
+3. If restore fails, catalog `recovery_required` with a safe reason string.
+
+Logout: `gh auth logout --hostname --user`. Before that, list projects; if any `GitHubAccount` matches, return `apierr.Conflict("GITHUB_ACCOUNT_IN_USE", ...)`.
+
+Tests use fake shellterm + fake gh runner. Assert switch is invoked only when active login changed.
+
+- [ ] **Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(github): add account login without leaving gh switched
+
+EOF
+)"
+```
+
+---
+
+### Task 5: HTTP API, LAN block, OpenAPI
+
+**Files:**
+- Create: `backend/internal/httpd/controllers/github_accounts.go`
+- Create: `backend/internal/httpd/controllers/github_accounts_dto.go`
+- Create: `backend/internal/httpd/controllers/github_accounts_test.go`
+- Modify: `backend/internal/httpd/api.go`
+- Modify: `backend/internal/httpd/lan_listener.go`
+- Modify: `backend/internal/httpd/lan_listener_test.go`
+- Modify: `backend/internal/httpd/cors.go`
+- Modify: `backend/internal/httpd/apispec/specgen/build.go`
+
+Routes (chi, under `/api/v1` via existing Register):
+
+```go
+r.Get("/scm/github/accounts", c.list)
+r.Post("/scm/github/accounts/ensure", c.ensure)
+r.Post("/scm/github/accounts/login-terminal", c.openLoginTerminal)
+r.Post("/scm/github/accounts/{login}/login-terminal", c.openReauthTerminal)
+r.Post("/scm/github/accounts/{login}/logout", c.logout)
+r.Post("/scm/github/accounts/login-operations/{operationId}/verify", c.verify)
+r.Post("/scm/github/accounts/login-operations/{operationId}/cancel", c.cancel)
+```
+
+Register streams: `GET /scm/github/accounts/events`.
+
+LAN: append `"/api/v1/scm/github/accounts"` to `lanControlBlockedPrefixes`. Add the same paths to the existing LAN test table that covers Codex accounts.
+
+CORS: extend `isCodexAccountPath` into `isLoopbackAccountPath` that also matches `/api/v1/scm/github/accounts`. Update `TestCodexAccountOriginBoundaryBlocksPreviewAndAllowsRenderers` with a GitHub path row.
+
+Add `schemaNames` entries for every new controller type. Then:
+
+```bash
+npm run api
+cd backend && go test ./internal/httpd/...
+```
+
+Commit `openapi.yaml` and `frontend/src/api/schema.ts` with the Go changes.
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(api): add loopback GitHub account catalog routes
+
+EOF
+)"
+```
+
+---
+
+### Task 6: SCM observer per-project identity
+
+**Files:**
+- Modify: `backend/internal/observe/scm/observer.go`
+- Modify: `backend/internal/observe/scm/scoped_identity_test.go`
+- Modify: `backend/internal/adapters/scm/github/provider.go`
+- Modify: `backend/internal/daemon/scm_wiring.go`
+
+- [ ] **Step 1: Test two GitHub projects with two logins**
+
+Mirror `TestPoll_TwoGitLabHostsIdentityResolution`, but both repos are `github.com` with different `ProjectConfig.GitHubAccount.Login`. Fake store must expose config (extend `fakeStore.projects` or session lookup). Foreign authors must be filtered per project login.
+
+- [ ] **Step 2: Implement — change the observer keys, not only the GitHub client cache**
+
+`observe/scm` must stay provider-neutral: import `domain`, not `adapters/scm/github`.
+
+Required observer edits in `observer.go` (today these all collapse GitHub to one identity):
+
+1. `identityKey(provider, host)` for GitHub cannot stay `"github"`. Use `github|<hostname>|<login>` where login comes from the session project's `GitHubAccount` (or the unbound active login). GitLab remains `gitlab|<host>`.
+2. `resolveIdentities` `seen` map must key GitHub by account, not by host. Two projects on `github.com` with logins `work` and `personal` are two identity lookups.
+3. `discoverNewPRs` currently groups `byRepo` / `repos` with `prKey(repo, 0)` and filters authors with `identities[identityKey(repo.Provider, repo.Host)]`. Change listing to group by `(repoKey, accountKey)`. Call `ListPRsByRepo(domain.WithGitHubAccount(ctx, ref), repo, ...)` once per group. Filter `pr.Author` against **that group's** identity, not a single github.com identity.
+4. Shared repo + two bound accounts ⇒ two list calls. Add a test; do not skip it.
+
+Provider-side: GitHub `AuthenticatedIdentity` cache key is hostname+login. The observer sets `domain.WithGitHubAccount` on ctx; the adapter reads it.
+
+```go
+ref := project.Config.GitHubAccount.Normalize()
+ctx = domain.WithGitHubAccount(ctx, ref)
+id, err := scoped.AuthenticatedIdentityForProvider(ctx, "github", ref.Hostname)
+```
+
+- [ ] **Step 3: Tests**
+
+Run: `cd backend && go test ./internal/observe/scm -count=1`
+
+- [ ] **Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(scm): attribute GitHub PRs using the project's bound account
+
+EOF
+)"
+```
+
+---
+
+### Task 7: Session env injection
+
+**Files:**
+- Modify: `backend/internal/session_manager/manager.go`
+- Test: `backend/internal/session_manager/github_env_test.go`
+
+Inject after `runtimeEnv` builds the map, before browser capability issuance.
+
+```go
+func (m *Manager) applyGitHubAccountEnv(ctx context.Context, project domain.ProjectID, env map[string]string) error {
+    rec, ok, err := m.store.GetProject(ctx, string(project))
+    // bind from rec.Config.GitHubAccount
+    tok, err := m.githubTokens.Token(domain.WithGitHubAccount(ctx, ref))
+    env["GH_TOKEN"] = tok
+    env["GITHUB_TOKEN"] = tok
+    if ref.Hostname != "" && ref.Hostname != domain.DefaultGitHubHostname {
+        env["GH_HOST"] = ref.Hostname
+    }
+    return nil
+}
+```
+
+Protected: if `ProjectConfig.Env` already had `GH_TOKEN`, overwrite. Tests: `TestSpawnEnvProjectVarsCannotOverrideInternal` style.
+
+Skip injection when ref is zero or daemon env override is set.
+
+Wire a `TokenSource` on Manager in daemon wiring; tests inject a stub.
+
+Run: `cd backend && go test ./internal/session_manager -run GitHub -count=1`
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(session): inject bound GitHub tokens into worker env
+
+EOF
+)"
+```
+
+---
+
+### Task 8: Tracker uses the same account ref
+
+**Files:**
+- Modify: `backend/internal/daemon/tracker_wiring.go`
+- Modify: `backend/internal/adapters/tracker/github` token source if it cannot read context
+
+Issue intake is per-project. The list/get calls already have a project id in the service. Thread `domain.WithGitHubAccount` from tracker intake into the GitHub tracker token fetch. Add a unit test that two projects do not share a cached token.
+
+Do not spawn `gh auth token` at daemon boot (existing `TestWiring_NewMultiTracker_NeverTypedNilWhenNoGitHubToken` / lazy probe tests must stay green).
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(tracker): use the project's GitHub account for issue intake
+
+EOF
+)"
+```
+
+---
+
+### Task 9: CLI
+
+**Files:**
+- Create: `backend/internal/cli/github.go`
+- Create: `backend/internal/cli/github_test.go`
+- Modify: `backend/internal/cli/project.go`
+- Modify: `backend/internal/cli/root.go` (register command)
+- Modify: `docs/cli/README.md`
+
+`ao github accounts` GET `/api/v1/scm/github/accounts`. `--refresh` POST ensure. Table columns: LOGIN, HOST, ACTIVE_IN_GH, STATE.
+
+`ao project set-config --github-account work` and `--github-account work@github.example.com`. Mirror DTO in `projectConfig`:
+
+```go
+GitHubAccount *gitHubAccountRef `json:"githubAccount,omitempty"`
+```
+
+Tests: httptest daemon, missing args → exit 2 `usageError`, daemon error envelope preserved.
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(cli): list GitHub accounts and set project binding
+
+EOF
+)"
+```
+
+---
+
+### Task 10: Settings UI + project picker
+
+**Files:**
+- Create: `frontend/src/renderer/hooks/useGitHubAccountsQuery.ts`
+- Create: `frontend/src/renderer/hooks/useGitHubAccountActions.ts`
+- Create: `frontend/src/renderer/components/settings/GitHubAccountsSection.tsx`
+- Create: `frontend/src/renderer/components/settings/GitHubAccountsSection.test.tsx`
+- Modify: `frontend/src/renderer/components/settings/settingsCatalog.tsx`
+- Modify: `frontend/src/renderer/stores/ui-store.ts` (`GlobalSettingsSection` union)
+- Modify: `frontend/src/renderer/components/ProjectSettingsForm.tsx`
+- Modify: `frontend/src/renderer/i18n/en.json` and every other locale file with the same keys
+
+Clone Codex structure:
+
+- `AgentProviderGroup` with `provider="github"` (or a GitHub mark if AgentAvatar has no github harness — use the existing Github icon from product-ui).
+- Add account button, login terminal panel (reuse `CodexAccountLoginTerminalPanel` only if it is already generic; otherwise copy the thin terminal embed used by `HarnessSettingsSection` auth).
+- Project form: `SettingsOptionMenu` of accounts; save `githubAccount: { hostname, login }` or omit.
+
+Tests: picker writes the config payload; add-account calls login-terminal; override banner when capabilities.accountManagement.state === `"unsupported"`.
+
+Run: `cd frontend && npm run typecheck` and the new vitest files.
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(desktop): add GitHub account settings and project binding
+
+EOF
+)"
+```
+
+---
+
+### Task 11: Docs + STATUS
+
+**Files:**
+- Modify: `docs/STATUS.md` (backend shipped bullet)
+- Modify: `docs/cli/README.md` if not done in Task 9
+
+One paragraph: GitHub accounts are discovered from the GitHub CLI, bound per project, and never switched device-globally.
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: record GitHub multi-account support
+
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+| Spec requirement | Task |
+| --- | --- |
+| Discover `gh` accounts, no token in API | 3, 5 |
+| `gh auth token --user` | 2 |
+| Never product-level `gh auth switch` | 4 (restore-only) |
+| Per-project bind on ProjectConfig | 1, 9, 10 |
+| Observer author filter per login | 6 |
+| Session GH_TOKEN | 7 |
+| Tracker | 8 |
+| LAN / CORS / OpenAPI | 5 |
+| Settings UI cloned from Codex chrome | 10 |
+| No Codex/Claude duplication | file plan out of scope |
+| No SQLite secrets / no new migration | Task 1 JSON field only |
+
+Placeholders scanned: none remaining. Types use `GitHubAccountRef` / `hostname` / `login` consistently.
+
+## Execution
+
+Implement task-by-task in this worktree. After each backend task run the focused `go test` command in that task. After API changes run `npm run api`. Before the PR is marked ready:
+
+```bash
+cd backend && go test ./...
+cd frontend && npm run typecheck
+npm run lint
+```

--- a/docs/superpowers/specs/2026-09-11-github-multi-account-design.md
+++ b/docs/superpowers/specs/2026-09-11-github-multi-account-design.md
@@ -1,0 +1,261 @@
+# GitHub Multi-Account Design
+
+Date: 2026-09-11
+Status: proposed
+Branch: `feat/github-multi-account`
+
+## Problem Statement
+
+Agent Orchestrator is a GitHub-centric loop: add project, spawn session, observe PR, merge. GitHub identity is still process-global. The daemon, SCM observer, issue tracker, and `ao doctor` all resolve one token:
+
+1. `AO_GITHUB_TOKEN`
+2. `GITHUB_TOKEN` (daemon environment)
+3. `gh auth token` (the currently active `gh` account)
+
+A user with a work account and a personal account cannot bind different identities to different projects. The observer's author filter then treats the other account's PRs as foreign. Workers inherit whatever `gh` considers active, and `gh auth switch` is a machine-global mutation.
+
+## What already exists (do not duplicate)
+
+GitHub was checked on 2026-09-11:
+
+| Surface | State | Tracking |
+| --- | --- | --- |
+| Codex coding-agent accounts | Shipped on `main` | PR [#4722](https://github.com/Untrivial-ai/agent-orchestrator/pull/4722) |
+| Claude Code accounts + hot switch | Open PR | [#4813](https://github.com/Untrivial-ai/agent-orchestrator/pull/4813) |
+| Cloud Coder accounts | Open PR | [#4787](https://github.com/Untrivial-ai/agent-orchestrator/pull/4787) |
+| Gate worker `gh auth switch` | Closed, not planned | [#3637](https://github.com/Untrivial-ai/agent-orchestrator/issues/3637) |
+
+This design is **GitHub/SCM identity**, not Codex/Claude credential vaults and not worker command gating. #3637 stays closed: AO will not intercept `gh auth switch`. It will make the switch unnecessary for the product loop.
+
+`domain.ProjectConfig` already records the intended follow-up:
+
+> Settings whose consumers do not yet exist (tracker/SCM per-project config) are intentionally absent and land in focused follow-up PRs alongside the code that reads them.
+
+This is that PR series.
+
+## Approaches considered
+
+### A. Device-global `gh auth switch` (Codex-shaped)
+
+AO would treat one GitHub login as the machine-wide active account and call `gh auth switch` when the user picks another.
+
+Rejected. Switching is global and persists after the session. #3637 documents a worker doing exactly this and leaving the human's `gh` on the wrong account. It also cannot express "project A is work, project B is personal" at the same time.
+
+### B. Isolated `GH_CONFIG_DIR` vault (copy Codex credential homes)
+
+AO would copy `gh` config/credentials into `~/.ao/harnesses/github/accounts/<id>/` and point sessions at a private config dir.
+
+Rejected for v1. It duplicates GitHub CLI's credential store, creates a secret-handling surface AO does not need, and fights SSH git remotes plus the user's existing `gh` setup. Codex needed a vault because Codex owns `auth.json`. GitHub CLI already owns multi-account state.
+
+### C. Recommended: leave credentials in `gh`, bind per project, never switch
+
+`gh` already stores multiple accounts per host. AO discovers them with `gh auth status --json hosts` (never `--show-token`). It fetches a specific account with `gh auth token --hostname <host> --user <login>`. A project optionally binds `{hostname, login}`. Sessions receive `GH_TOKEN` / `GITHUB_TOKEN` / `GH_HOST` for that account. The SCM observer and tracker use the same token for that project's API calls. AO never runs `gh auth switch`.
+
+This is the v1 design.
+
+## Goals
+
+- A user can add a second GitHub account through Settings without changing the machine's active `gh` account.
+- A project can bind one GitHub account. Empty binding keeps today's behavior (active `gh` account / env token).
+- SCM observation, tracker intake, PR actions, and worker `gh`/`git` HTTPS credential helper calls for that project use the bound account.
+- Tokens never appear in SQLite, API JSON, logs, telemetry, or OpenAPI examples.
+- Account-management HTTP routes stay loopback-only and are blocked on the LAN listener, matching Codex.
+
+## Non-goals (v1)
+
+- Claude or Codex account work (existing PR / shipped).
+- Per-session GitHub account override (project is the grain).
+- GitLab multi-account UI (GitLab already has host-scoped tokens in daemon config; a later PR can add a picker).
+- Worker sandboxing of `gh auth switch` (#3637, not planned).
+- Copying, parsing, or storing credential files.
+- Changing the machine's active `gh` account as a product action.
+- SSH key inventory or per-account SSH identity files. SSH remotes keep using the user's SSH agent. `GH_TOKEN` still authenticates `gh` API calls.
+- Fine-grained PAT onboarding as a separate flow. `gh auth login` remains the interactive path.
+
+## User experience
+
+### Settings → GitHub
+
+New global settings catalog item, visually cloned from the Codex accounts block (`AgentProviderGroup` + rows), not a new visual language.
+
+- List discovered accounts: host, login, active-in-gh flag, last verification state.
+- **Add account** opens an inline `gh auth login` shell terminal (same shell-terminal pattern as Codex / harness auth).
+- After login, if `gh` made the new account active, AO restores the previously active account with `gh auth switch --user <previous>` **only as crash recovery for the login flow**, then rediscovers. The Settings UI must say AO does not keep a device-global GitHub switch; project binding is the selector.
+- **Sign in again** reauthenticates one account.
+- **Log out** wraps `gh auth logout --hostname --user` for an account that is not bound to any project. Bound accounts must be unbound first.
+- Daemon-wide `AO_GITHUB_TOKEN` / `GITHUB_TOKEN` shows an unmanaged override banner: listing still works for display if `gh` is logged in, but project binding cannot override the env token. Mirror Codex's "switching disabled when credential overrides are present."
+
+### Project settings → General
+
+A GitHub account dropdown under the repo row:
+
+- Default option: "Active GitHub CLI account" (empty binding).
+- One option per discovered account (`login@hostname`).
+- Saving writes `ProjectConfig.githubAccount`.
+- Scratch projects omit the control (no SCM).
+
+## Architecture
+
+```text
+Settings UI / CLI
+        |
+        v
+GitHubAccounts service  --discover-->  gh auth status --json hosts
+        |               --token----->  gh auth token --hostname --user
+        |               --login----->  shellterm: gh auth login
+        v
+ProjectConfig.githubAccount { hostname, login }
+        |
+        +--> Session Manager injects GH_TOKEN, GITHUB_TOKEN, GH_HOST
+        +--> SCM GitHub Client authorize(ctx) reads account from context
+        +--> Tracker GitHub token source reads the same ref
+```
+
+### Domain
+
+```go
+// GitHubAccountRef identifies one gh-stored account. It is display metadata
+// and a token-fetch key, not a credential.
+type GitHubAccountRef struct {
+    Hostname string `json:"hostname,omitempty"`
+    Login    string `json:"login,omitempty"`
+}
+
+type ProjectConfig struct {
+    // ...existing fields...
+    GitHubAccount GitHubAccountRef `json:"githubAccount,omitempty"`
+}
+```
+
+Validation:
+
+- Both hostname and login empty: OK (inherit active `gh` / env token).
+- Login set and hostname empty: hostname defaults to `github.com`.
+- Hostname set and login empty: invalid.
+- Hostname must be a DNS host (no scheme, path, userinfo, or whitespace).
+- Login must be a GitHub login (`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$` — refuse tokens, emails, and paths).
+
+No new SQLite table. Project config is already a JSON blob. Account catalog is derived from `gh` on ensure/list.
+
+### Token source
+
+Extend `backend/internal/adapters/scm/github/auth.go` (and the tracker twin) so `GHTokenSource` accepts hostname + user. Cache key is `hostname\x00login`. `Token(ctx)` reads an optional account ref from context; empty ref keeps `gh auth token` with no flags (today's behavior).
+
+Env precedence is unchanged and process-wide:
+
+1. `AO_GITHUB_TOKEN`
+2. `GITHUB_TOKEN` in the **daemon** environment
+3. `gh auth token [--hostname] [--user]`
+
+When (1) or (2) is set, project bindings are ignored for token fetch. The API reports `accountManagement` as unsupported with reason `daemon_token_override`.
+
+`Client.authorize` already takes `context.Context`. The observer and tracker set the account on that context from the project's config before calling the provider. Do not put tokens in the context.
+
+`WithGitHubAccount` / `GitHubAccountFrom` live in `domain` (or `ports`), not in `adapters/scm/github`. The observer package must not import a provider adapter. The GitHub token source reads the domain ref from context.
+
+### SCM observer
+
+Today `identityKey("github", host)` collapses every GitHub host to `"github"`, and `AuthenticatedIdentity` is cached for the provider lifetime as a single login. That is the foreign-PR filter bug for the second account.
+
+v1 changes:
+
+- Replace GitHub's collapsed `identityKey("github", host) == "github"` with an account-aware key: `github|<hostname>|<login>` (login from the project's `GitHubAccount`, or the active `gh` login when unbound). GitLab stays `gitlab|<host>`.
+- `resolveIdentities` must not collapse two GitHub projects on `github.com` into one `seen` entry. Key identity resolution by `(provider, host, projectID)` / account key, not by repo host alone.
+- `discoverNewPRs` groups listings by `(repoKey, accountKey)`. Two projects that share a repo with different bound logins get two `ListPRsByRepo` calls, each with that account on `ctx`. Author filtering uses the session's account identity, not `identities[identityKey(repo.Provider, repo.Host)]` as it is today.
+- Provider API calls for that session/repo go out with the matching context account.
+- `AuthenticatedIdentity` cache key includes hostname+login. Do not keep a single process-wide GitHub identity.
+- GitLab host-scoping is unchanged.
+
+### Session environment
+
+`runtimeEnv` / `spawnEnv` currently copies `ProjectConfig.Env` then pins AO internals. After that, if the project has a usable GitHub binding (and no daemon env override):
+
+- Set `GH_TOKEN` and `GITHUB_TOKEN` to the fetched token.
+- Set `GH_HOST` when hostname is not `github.com`.
+- Treat these keys as protected, same as `AO_SESSION_ID`: project `Env` cannot override them.
+
+Do not set `GH_CONFIG_DIR`. Do not put the token in session metadata, SQLite, or logs. Chat controller env uses the same helper as TUI spawn.
+
+`gh`'s git credential helper honors `GH_TOKEN` for HTTPS remotes. SSH remotes are out of scope.
+
+### HTTP API
+
+Loopback routes, Codex-shaped:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/v1/scm/github/accounts` | Cached catalog |
+| POST | `/api/v1/scm/github/accounts/ensure` | Rediscover |
+| POST | `/api/v1/scm/github/accounts/login-terminal` | Add account |
+| POST | `/api/v1/scm/github/accounts/{login}/login-terminal` | Reauthenticate (`login` is path-escaped; host query required if not github.com) |
+| POST | `/api/v1/scm/github/accounts/login-operations/{operationId}/verify` | Verify login |
+| POST | `/api/v1/scm/github/accounts/login-operations/{operationId}/cancel` | Cancel |
+| POST | `/api/v1/scm/github/accounts/{login}/logout` | Logout if unbound |
+| GET | `/api/v1/scm/github/accounts/events` | SSE catalog updates |
+
+Path identity is `login` plus `hostname` query (default `github.com`). Do not invent AO UUIDs; `gh` already keys accounts by host+login.
+
+Wire types live in `backend/internal/httpd/controllers/dto.go` (or a sibling `github_accounts_dto.go`). Register `schemaNames` in `apispec/specgen/build.go`. Run `npm run api`.
+
+LAN: add `/api/v1/scm/github/accounts` to `lanControlBlockedPrefixes`. CORS: treat these paths like Codex account paths (`isCodexAccountPath` or a renamed shared helper).
+
+Project binding uses the existing `PUT /api/v1/projects/{id}/config` / settings update. No new project route.
+
+### CLI
+
+Thin HTTP only:
+
+- `ao github accounts` → GET catalog
+- `ao github accounts --refresh` → POST ensure
+- `ao project set-config` grows `--github-account login[@hostname]`
+
+Doctor continues to probe one token; when multiple accounts exist, mention the active login and that project bindings are configured in settings.
+
+### Frontend
+
+- `GitHubAccountsSection` on a new Settings catalog id `github`, cloned from Codex row/group chrome.
+- Hooks: `useGitHubAccountsQuery`, `useGitHubAccountActions` (login terminal, verify, logout).
+- Project settings: account `<select>` in `ProjectSettingsForm` + `packages/product-ui` general view only if the control can stay presentational. Prefer keeping data fetching in the renderer form and passing the control into `ProjectGeneralSettingsView` as a slot so product-ui stays free of the daemon client.
+- i18n keys in every `frontend/src/renderer/i18n/*.json` locale.
+
+## Security
+
+- Never log token stdout. `gh auth token` output is trimmed into memory and used as a bearer; tests inject a fake `GH` func.
+- Never persist tokens in SQLite, change_log payloads, or session records.
+- API snapshots expose `hostname`, `login`, `activeInGh`, `state`, `reasonCode`, `reason`. No token, no `gho_`/`ghp_` prefixes, no hosts.yml paths.
+- Login terminal is a trusted authentication terminal (existing shellterm class), scoped to the originating app launch.
+- Logout refuses if any project binds that account (`GITHUB_ACCOUNT_IN_USE`).
+- After add-account login, restore the previous active `gh` user if it changed. Record a daemon log line without account tokens if restore fails; surface `recovery_required` in the catalog.
+- Do not add unauthenticated routes. Do not bind a new listener.
+
+## Testing seams
+
+Prefer httptest, injected `GH` hooks, and fake stores. No live GitHub network in unit tests.
+
+Minimum coverage:
+
+- `GHTokenSource` with `--user`/`--hostname`, cache keyed by account, env override wins.
+- `ProjectConfig.Validate` githubAccount cases.
+- Observer: two GitHub projects, two logins, foreign-author filter uses the project login; shared repo with two accounts lists twice.
+- Session env: bound account injects `GH_TOKEN`; project `Env` cannot override; daemon `AO_GITHUB_TOKEN` suppresses injection.
+- HTTP: list/ensure/login/logout, LAN 404, origin boundary.
+- Frontend: Settings list, add-account terminal, project picker save payload.
+- CLI: set-config round-trip of `githubAccount`.
+
+## Done when
+
+From `AGENTS.md`:
+
+```bash
+cd backend && go test ./internal/adapters/scm/github/... ./internal/observe/scm/... ./internal/httpd/... ./internal/domain/... ./internal/session_manager/... ./internal/cli/... ./internal/service/project/...
+npm run api
+npm run frontend:typecheck
+```
+
+Full `npm run lint` before merge. Manual gate: two real `gh` accounts, bind A to project 1 and B to project 2, confirm observer and `gh api user` inside each worker match the binding, and that `gh auth status` on the host still shows the original active account.
+
+## Further notes
+
+- GitHub Enterprise: hostname is first-class because `gh` is already multi-host.
+- Enterprise API base URL stays the GitHub client's current host derivation; do not invent a second host table.
+- Mobile: account mutation stays loopback-only. Project config read remains on the app API so a phone can see which login a project uses, not add accounts.

--- a/docs/superpowers/specs/2026-09-11-github-multi-account-design.md
+++ b/docs/superpowers/specs/2026-09-11-github-multi-account-design.md
@@ -71,6 +71,17 @@ This is the v1 design.
 - Changing the machine's active `gh` account as a product action.
 - SSH key inventory or per-account SSH identity files. SSH remotes keep using the user's SSH agent. `GH_TOKEN` still authenticates `gh` API calls.
 - Fine-grained PAT onboarding as a separate flow. `gh auth login` remains the interactive path.
+- Copilot's separate token chain (`COPILOT_GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN` → `gh`). That adapter stays as it is.
+
+## Existing surfaces to extend, not replace
+
+Onboarding already has `GET/POST /api/v1/system/github-auth*` (`systemcheck.OpenGitHubAuthTerminal`, `GitHubOnboardingNotice`). That flow signs in the **active** `gh` account so the daemon has any GitHub identity at all.
+
+v1 Add account in Settings should reuse that shell-terminal implementation (same `gh auth login`, same trusted auth-terminal class) rather than copying Codex login as a second PTY stack. After login it must rediscover **all** `gh` accounts and restore the previously active login if `gh` switched. The onboarding notice stays the empty-state path; Settings is the multi-account path.
+
+Comments on `EnvTokenSource` call `AO_GITHUB_TOKEN` “project-scoped.” That is the **daemon process** environment today, not SQLite project config. This design does not change that override. Per-project binding is `ProjectConfig.githubAccount`, not a new `AO_GITHUB_TOKEN` per project.
+
+Chat/TUI runtimes overlay session env on full `os.Environ()`. Injected `GH_TOKEN` / `GITHUB_TOKEN` must win over inherited daemon env for that session. Preview servers already strip daemon credentials (`previewEnvironment`); they must keep stripping GitHub tokens.
 
 ## User experience
 


### PR DESCRIPTION
## Summary

- GitHub already has **Codex** multi-account on `main` ([#4722](https://github.com/Untrivial-ai/agent-orchestrator/pull/4722)) and an open **Claude** account-management PR ([#4813](https://github.com/Untrivial-ai/agent-orchestrator/pull/4813)). This PR does not duplicate those.
- The remaining gap is **GitHub/SCM identity**: the daemon, observer, tracker, and workers still share one `gh auth token`. `domain.ProjectConfig` already reserved tracker/SCM per-project config for a follow-up that has a real consumer.
- Adds a design and TDD implementation plan: discover accounts from `gh auth status`, fetch with `gh auth token --user`, bind `{hostname, login}` per project, inject `GH_TOKEN` into session env, and never use `gh auth switch` as a product action (restore-only after add-account login). Worker `gh auth switch` gating stays out of scope ([#3637](https://github.com/Untrivial-ai/agent-orchestrator/issues/3637) closed, not planned).

## Spec and plan

- Design: `docs/superpowers/specs/2026-09-11-github-multi-account-design.md`
- Implementation plan: `docs/superpowers/plans/2026-09-11-github-multi-account.md`

## Test plan

- [ ] Review the design against Codex account patterns (vault vs `gh`-owned credentials) and confirm v1 omissions (no Claude/Codex work, no GitLab UI, no SSH key inventory).
- [ ] Confirm observer Task 6 changes `identityKey` / listing groups, and that `observe/scm` does not import `adapters/scm/github`.
- [ ] Follow-up implementation PR executes the plan task-by-task (`go test` per task, `npm run api` after HTTP changes, `npm run lint` before merge).
- [ ] Manual gate after implementation: two real `gh` accounts bound to two projects; host `gh auth status` active account unchanged.


Made with [Cursor](https://cursor.com)