### PR TITLE
fix(api): validate PR number on resolve-comments route

### DIFF
--- a/backend/internal/httpd/controllers/prs.go
+++ b/backend/internal/httpd/controllers/prs.go
@@ -60,6 +60,10 @@ func (c *PRsController) resolveComments(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	prID := chi.URLParam(r, "id")
+	if !prIDPattern.MatchString(prID) {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_PR", "Invalid PR number", nil)
+		return
+	}
 
 	// Body is optional: omitting it resolves all unresolved threads.
 	var in ResolveCommentsRequest

--- a/backend/internal/httpd/controllers/prs_test.go
+++ b/backend/internal/httpd/controllers/prs_test.go
@@ -164,3 +164,14 @@ func TestPRsRoutes_ResolveComments_422(t *testing.T) {
 	assertJSON(t, headers)
 	assertErrorCode(t, body, status, http.StatusUnprocessableEntity, "NOTHING_TO_RESOLVE")
 }
+
+func TestPRsRoutes_ResolveComments_InvalidPRID(t *testing.T) {
+	svc := &fakePRService{resolveResult: prsvc.ResolveResult{Resolved: 0}}
+	srv := newPRTestServer(t, svc)
+
+	for _, id := range []string{"0", "abc", "-1"} {
+		body, status, headers := doRequest(t, srv, "POST", "/api/v1/prs/"+id+"/resolve-comments", "")
+		assertJSON(t, headers)
+		assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_PR")
+	}
+}


### PR DESCRIPTION
## Summary

- Add the same `prIDPattern` guard to `POST /api/v1/prs/{id}/resolve-comments` that `merge` already uses
- Malformed IDs (`0`, `abc`, `-1`) now return **400 `INVALID_PR`** instead of **200 OK**

## Problem

`merge` rejects invalid `{id}` path params at the controller. `resolve-comments` did not, so the same garbage ID got a fake success response (`{"ok":true,"resolved":0}`) — especially misleading while `ResolveComments` is still a stub.

## Test plan

- [x] `go test ./internal/httpd/controllers/... -run PRsRoutes`
- [ ] `curl -X POST http://127.0.0.1:3002/api/v1/prs/abc/resolve-comments` → 400 `INVALID_PR`


Made with [Cursor](https://cursor.com)