### PR TITLE
fix: refine tabs and file feedback composer

### DIFF
--- a/frontend/src/renderer/components/SessionFileTabs.test.tsx
+++ b/frontend/src/renderer/components/SessionFileTabs.test.tsx
@@ -26,8 +26,8 @@ describe("SessionFileTabs", () => {
 		expect(languageIcon).toBeInTheDocument();
 		const closeButton = screen.getByRole("button", { name: "Close App.tsx" });
 		const feedbackButton = screen.getByRole("button", { name: "Add feedback for file src/App.tsx" });
-		expect(closeButton.parentElement).toHaveClass("left-2");
-		expect(feedbackButton.parentElement).toHaveClass("right-1");
+		expect(feedbackButton.parentElement).toHaveClass("left-2");
+		expect(closeButton.parentElement).toHaveClass("right-1");
 		expect(tab.closest("[data-terminal-tab-frame]")).toHaveClass("max-w-shell-tab-max");
 		expect(tab.closest("[data-terminal-tab-frame]")).not.toHaveClass(
 			"session-tab-icon-floor",

--- a/frontend/src/renderer/components/SessionFileTabs.test.tsx
+++ b/frontend/src/renderer/components/SessionFileTabs.test.tsx
@@ -26,8 +26,8 @@ describe("SessionFileTabs", () => {
 		expect(languageIcon).toBeInTheDocument();
 		const closeButton = screen.getByRole("button", { name: "Close App.tsx" });
 		const feedbackButton = screen.getByRole("button", { name: "Add feedback for file src/App.tsx" });
-		expect(feedbackButton.parentElement).toHaveClass("left-2");
-		expect(closeButton.parentElement).toHaveClass("right-1");
+		expect(feedbackButton.parentElement).toHaveClass("pl-1");
+		expect(closeButton.parentElement).toHaveClass("pr-1");
 		expect(tab.closest("[data-terminal-tab-frame]")).toHaveClass("max-w-shell-tab-max");
 		expect(tab.closest("[data-terminal-tab-frame]")).not.toHaveClass(
 			"session-tab-icon-floor",

--- a/frontend/src/renderer/components/SessionFileTabs.tsx
+++ b/frontend/src/renderer/components/SessionFileTabs.tsx
@@ -90,13 +90,13 @@ export function SessionFileTab({
 	) : undefined;
 	return (
 		<TerminalTabFrame
-			action={closeAction}
+			action={feedbackAction}
+			actionLayout="inline"
 			actionPosition="leading"
 			active={active}
 			buttonProps={{
 				"aria-label": name,
 				"aria-selected": active,
-				className: "pr-9",
 				onClick: onActivate,
 				role: "tab",
 				tabIndex: active ? 0 : -1,
@@ -105,10 +105,10 @@ export function SessionFileTab({
 			}}
 			className="max-w-shell-tab-max"
 			contentClassName="font-medium"
-			trailingAction={feedbackAction}
+			trailingAction={closeAction}
 		>
 			<WorkspaceEntryIcon
-				className="size-icon-base shrink-0 group-hover:opacity-0 group-focus-within:opacity-0"
+				className="size-icon-base shrink-0"
 				kind="file"
 				name={name}
 			/>

--- a/frontend/src/renderer/components/SessionFileWorkspace.tsx
+++ b/frontend/src/renderer/components/SessionFileWorkspace.tsx
@@ -12,8 +12,14 @@ export function SessionFileWorkspace({
 }) {
 	const fileFeedbackActive = annotation.target?.path === path && annotation.target.side === "file";
 	return (
-		<section className="flex h-full min-h-0 flex-col bg-background" data-testid="session-file-workspace">
-			{fileFeedbackActive ? <FileAnnotationComposer annotation={annotation} /> : null}
+		<section className="relative flex h-full min-h-0 flex-col bg-background" data-testid="session-file-workspace">
+			{fileFeedbackActive ? (
+				<div className="pointer-events-none absolute inset-x-4 top-4 z-30 flex justify-center">
+					<div className="pointer-events-auto w-full max-w-xl">
+						<FileAnnotationComposer annotation={annotation} />
+					</div>
+				</div>
+			) : null}
 			<div className="board-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain">
 				<FileContentPane annotation={annotation} path={path} sessionId={sessionId} split={false} wrap />
 			</div>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -571,13 +571,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	useEffect(() => {
 		setAuxiliaryTabOrderBySession((current) => {
 			const currentOrder = current[sessionId] ?? [];
-			if (
-				currentOrder.length === resolvedAuxiliaryTabOrder.length &&
-				currentOrder.every((key, index) => key === resolvedAuxiliaryTabOrder[index])
-			) {
+			const newKeys = resolvedAuxiliaryTabOrder.filter((key) => !currentOrder.includes(key));
+			if (newKeys.length === 0) {
 				return current;
 			}
-			return { ...current, [sessionId]: resolvedAuxiliaryTabOrder };
+			return { ...current, [sessionId]: [...currentOrder, ...newKeys] };
 		});
 	}, [resolvedAuxiliaryTabOrder, sessionId]);
 	const openShellTerminal = useOpenShellTerminal();

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -554,10 +554,12 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		[allShellTerminals, sessionId],
 	);
 	const resolvedAuxiliaryTabOrder = useMemo(() => {
+		const openFileKeys = fileTabs.openPaths.map((path) => `file:${path}`);
+		const openShellKeys = shellTerminals.map((shell) => shell.handleId);
 		const available = [
 			...(reviewerTerminal ? [`reviewer:${reviewerTerminal.handleId}`] : []),
-			...shellTerminals.map((shell) => shell.handleId),
-			...fileTabs.openPaths.map((path) => `file:${path}`),
+			...openFileKeys,
+			...openShellKeys,
 		];
 		const availableKeys = new Set(available);
 		const resolved = auxiliaryTabOrder.filter((key) => availableKeys.has(key));
@@ -566,6 +568,18 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		}
 		return resolved;
 	}, [auxiliaryTabOrder, fileTabs.openPaths, reviewerTerminal, shellTerminals]);
+	useEffect(() => {
+		setAuxiliaryTabOrderBySession((current) => {
+			const currentOrder = current[sessionId] ?? [];
+			if (
+				currentOrder.length === resolvedAuxiliaryTabOrder.length &&
+				currentOrder.every((key, index) => key === resolvedAuxiliaryTabOrder[index])
+			) {
+				return current;
+			}
+			return { ...current, [sessionId]: resolvedAuxiliaryTabOrder };
+		});
+	}, [resolvedAuxiliaryTabOrder, sessionId]);
 	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
 	const renameShellTerminal = useRenameShellTerminal();

--- a/frontend/src/renderer/components/ShellTerminalTab.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.test.tsx
@@ -98,7 +98,7 @@ describe("ShellTerminalTab rename", () => {
 		renderTab({ appearance: "connected", isActive: true });
 
 		const closeButton = screen.getByRole("button", { name: "Close terminal ao" });
-		expect(closeButton.parentElement).toHaveClass("absolute", "left-2", "inset-y-0");
+		expect(closeButton.parentElement).toHaveClass("absolute", "right-2", "inset-y-0");
 		expect(closeButton).toHaveClass(
 			"opacity-0",
 			"pointer-events-none",

--- a/frontend/src/renderer/components/ShellTerminalTab.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.test.tsx
@@ -94,11 +94,11 @@ describe("ShellTerminalTab rename", () => {
 		expect(onSelect).toHaveBeenCalledOnce();
 	});
 
-	it("swaps the terminal glyph for close on hover without reserving a trailing close column", () => {
+	it("keeps the terminal glyph visible while showing close on hover", () => {
 		renderTab({ appearance: "connected", isActive: true });
 
 		const closeButton = screen.getByRole("button", { name: "Close terminal ao" });
-		expect(closeButton.parentElement).toHaveClass("absolute", "right-2", "inset-y-0");
+		expect(closeButton.parentElement).toHaveClass("flex", "shrink-0", "pr-1");
 		expect(closeButton).toHaveClass(
 			"opacity-0",
 			"pointer-events-none",
@@ -106,9 +106,7 @@ describe("ShellTerminalTab rename", () => {
 		);
 		expect(closeButton).not.toHaveClass("transition-opacity", "transition-[opacity,background,color]");
 		expect(closeButton).not.toHaveClass("w-control-sm");
-		expect(screen.getByRole("tab", { name: "ao" }).querySelector("svg")).toHaveClass(
-			"group-hover:opacity-0",
-		);
+		expect(screen.getByRole("tab", { name: "ao" }).querySelector("svg")).not.toHaveClass("group-hover:opacity-0");
 		expect(screen.getByRole("tab", { name: "ao" })).toHaveAttribute("aria-selected", "true");
 	});
 

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -154,10 +154,11 @@ export function ShellTerminalTab({
 			/>
 		) : undefined;
 		return (
-			<TerminalTabFrame
-				action={closeAction}
-				actionPosition="leading"
-				active={isActive}
+		<TerminalTabFrame
+			action={closeAction}
+			actionLayout="inline"
+			actionPosition="trailing"
+			active={isActive}
 				buttonProps={{
 					"aria-current": isActive,
 					"aria-selected": isActive,
@@ -177,7 +178,7 @@ export function ShellTerminalTab({
 			>
 				<SquareTerminal
 					aria-hidden="true"
-					className={cn("size-icon-sm shrink-0", "group-hover:opacity-0 group-focus-within:opacity-0")}
+					className="size-icon-sm shrink-0"
 				/>
 				<span className="truncate">{title}</span>
 			</TerminalTabFrame>
@@ -275,10 +276,10 @@ export function ShellTerminalTab({
 							{...closeControl}
 							className={
 								isConnected
-									? "absolute top-[calc(50%_-_1px)] left-2 z-20 grid size-icon-sm -translate-y-1/2 place-items-center text-passive opacity-0 pointer-events-none before:absolute before:-inset-1.5 before:content-[''] transition-colors duration-fast ease-out hover:text-foreground group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
+									? "absolute inset-y-0 right-2 z-20 grid size-icon-sm place-items-center text-passive opacity-0 pointer-events-none before:absolute before:-inset-1.5 before:content-[''] transition-colors duration-fast ease-out hover:text-foreground group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
 									: "inline-flex h-control-sm w-control-sm shrink-0 items-center justify-center overflow-hidden text-passive opacity-0 transition-colors duration-fast ease-out hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 motion-reduce:transition-none"
-							}
-						>
+								}
+							>
 							<X
 								aria-hidden="true"
 								className={isConnected ? "size-icon-sm translate-y-px" : "size-icon-sm"}

--- a/frontend/src/renderer/components/TerminalTabFrame.tsx
+++ b/frontend/src/renderer/components/TerminalTabFrame.tsx
@@ -68,7 +68,7 @@ export function TerminalTabFrame({
 					<button
 						ref={buttonRef}
 						className={cn(
-							"inline-flex h-full max-w-full min-w-0 cursor-pointer items-center overflow-hidden px-2 text-left text-control leading-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
+							"inline-flex h-full max-w-full min-w-0 flex-1 cursor-pointer items-center overflow-hidden px-2 text-left text-control leading-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
 							overlayTrailing && "pr-7",
 							buttonClassName,
 						)}

--- a/frontend/src/renderer/components/TerminalTabFrame.tsx
+++ b/frontend/src/renderer/components/TerminalTabFrame.tsx
@@ -35,8 +35,7 @@ export function TerminalTabFrame({
 	"data-terminal-role": terminalRole,
 }: TerminalTabFrameProps) {
 	const { className: buttonClassName, ...restButtonProps } = buttonProps ?? {};
-	const overlayTrailing =
-		actionLayout === "overlay" && ((actionPosition === "trailing" && action) || trailingAction);
+	const overlayTrailing = actionLayout === "overlay" && actionPosition === "trailing" && action;
 	const inlineAction =
 		action && actionLayout === "inline" ? (
 			<div
@@ -63,19 +62,19 @@ export function TerminalTabFrame({
 				restButtonProps.onClick?.(event as unknown as ReactMouseEvent<HTMLButtonElement>);
 			}}
 		>
-			<span className="relative inline-flex h-[calc(100%-2px)] min-w-0 flex-1 self-stretch">
+			<span className="relative inline-flex h-[calc(100%-2px)] min-w-0 self-stretch">
 				{actionPosition === "leading" ? inlineAction : null}
 				{editingContent ?? (
 					<button
 						ref={buttonRef}
 						className={cn(
-							"inline-flex h-full min-w-0 flex-1 cursor-pointer items-center px-2 text-left text-control leading-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
-							overlayTrailing && "pr-9",
+							"inline-flex h-full max-w-full min-w-0 cursor-pointer items-center overflow-hidden px-2 text-left text-control leading-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent/50",
+							overlayTrailing && "pr-7",
 							buttonClassName,
 						)}
 						{...restButtonProps}
 					>
-						<span className={cn("inline-flex min-w-0 items-center gap-2", contentClassName)}>
+						<span className={cn("inline-flex max-w-full min-w-0 items-center gap-2 overflow-hidden", contentClassName)}>
 							{children}
 						</span>
 					</button>
@@ -94,7 +93,7 @@ export function TerminalTabFrame({
 				) : null}
 				{trailingAction ? (
 					<div
-						className="absolute inset-y-0 right-1 z-10 flex items-center"
+						className="flex shrink-0 items-center pr-1"
 						data-terminal-tab-action
 					>
 						{trailingAction}

--- a/frontend/src/renderer/components/WorkspaceDiffView.tsx
+++ b/frontend/src/renderer/components/WorkspaceDiffView.tsx
@@ -12,7 +12,7 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
-import { Check, Plus, Send as SendIcon } from "lucide-react";
+import { Plus, Send as SendIcon } from "lucide-react";
 import type { FileAnnotationTarget } from "../../shared/file-annotations";
 import {
 	type WorkspaceCompareMode,
@@ -721,59 +721,53 @@ function LineFeedbackButton({
 
 export function FileAnnotationComposer({ annotation }: { annotation: FileAnnotationModel }) {
 	const { t } = useTranslation();
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	useEffect(() => {
+		const textarea = textareaRef.current;
+		if (!textarea) return;
+		textarea.style.height = "0px";
+		textarea.style.height = `${textarea.scrollHeight}px`;
+	}, [annotation.draft]);
 	const target = annotation.target;
 	if (!target) return null;
 	const side = target.side === "file" ? "" : t(target.side === "old" ? "files.oldSide" : "files.newSide");
 	const targetLabel =
-		target.side === "file"
+			target.side === "file"
 			? t("files.fileFeedbackTarget", { file: target.path })
 			: t("files.lineFeedbackTarget", { file: target.path, line: target.line, side });
 	const submit = () => void annotation.submit();
 
 	return (
 		<form
-			className="border-y border-border/70 bg-surface px-3 py-2 font-sans"
+			className="w-full overflow-hidden rounded-2xl border border-border-strong bg-surface font-sans shadow-2xl shadow-black/35"
 			onSubmit={(event) => {
 				event.preventDefault();
 				submit();
 			}}
 		>
-			<div className="mb-1.5 flex items-center justify-between gap-2">
-				<span className="min-w-0 truncate font-mono text-caption text-passive">{targetLabel}</span>
-				{annotation.status === "sent" ? (
-					<span className="inline-flex items-center gap-1 text-caption text-success" role="status">
-						<Check className="size-icon-sm" aria-hidden="true" />
-						{t("files.feedbackSent")}
-					</span>
-				) : null}
+			<div className="px-4 pb-2.5 pt-3.5">
+				<textarea
+					aria-label={t("files.feedbackLabel", { target: targetLabel })}
+					autoFocus
+					className="block min-h-7 w-full resize-none overflow-hidden border-0 bg-transparent px-0 py-0.5 text-base text-foreground outline-none placeholder:text-passive focus-visible:outline-none disabled:opacity-60"
+					disabled={annotation.status === "sending" || annotation.status === "sent"}
+					onChange={(event) => annotation.setDraft(event.target.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Escape") {
+							event.preventDefault();
+							annotation.cancel();
+						}
+					}}
+					placeholder={t("files.feedbackPlaceholder")}
+					ref={textareaRef}
+					value={annotation.draft}
+				/>
 			</div>
-			<textarea
-				aria-label={t("files.feedbackLabel", { target: targetLabel })}
-				autoFocus
-				className="min-h-20 w-full resize-y rounded-md border border-input bg-background px-2.5 py-2 text-sm text-foreground outline-none placeholder:text-passive focus-visible:outline-none disabled:opacity-60"
-				disabled={annotation.status === "sending" || annotation.status === "sent"}
-				onChange={(event) => annotation.setDraft(event.target.value)}
-				onKeyDown={(event) => {
-					if (event.key === "Escape") {
-						event.preventDefault();
-						annotation.cancel();
-					} else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-						event.preventDefault();
-						submit();
-					}
-				}}
-				placeholder={t("files.feedbackPlaceholder")}
-				value={annotation.draft}
-			/>
-			{annotation.status === "error" ? (
-				<p className="mt-1.5 text-xs text-error" role="alert">
-					{annotation.error}
-				</p>
-			) : null}
-			<div className="mt-2 flex items-center justify-end gap-1.5">
-				<span className="mr-auto text-caption text-passive">{t("files.feedbackShortcut")}</span>
+			{annotation.status === "error" ? <p className="px-4 pb-2 text-xs text-error" role="alert">{annotation.error}</p> : null}
+			<div className="flex items-center justify-between gap-3 px-4 pb-3.5">
 				<Button
 					disabled={annotation.status === "sending" || annotation.status === "sent"}
+					className="h-9 rounded-full border border-border/70 px-4"
 					onClick={annotation.cancel}
 					size="sm"
 					type="button"
@@ -782,12 +776,13 @@ export function FileAnnotationComposer({ annotation }: { annotation: FileAnnotat
 					{t("files.cancelFeedback")}
 				</Button>
 				<Button
+					aria-label={t("files.sendFeedback")}
 					disabled={!annotation.draft.trim() || annotation.status === "sending" || annotation.status === "sent"}
-					size="sm"
+					className="grid size-10 place-items-center rounded-full bg-[#e8e8eb] p-0 text-[#1b1b1f] shadow-sm hover:bg-white"
+					size={null}
 					type="submit"
 				>
-					<SendIcon className="size-icon-sm" aria-hidden="true" />
-					{annotation.status === "sending" ? t("files.sendingFeedback") : t("files.sendFeedback")}
+					<SendIcon className="size-5" aria-hidden="true" />
 				</Button>
 			</div>
 		</form>

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1679,7 +1679,7 @@
 	"files.fileFeedbackTarget": "{{file}} · whole file",
 	"files.lineFeedbackTarget": "{{file}} · {{side}} line {{line}}",
 	"files.feedbackLabel": "Feedback for {{target}}",
-	"files.feedbackPlaceholder": "Describe what the agent should change...",
+	"files.feedbackPlaceholder": "Describe the changes...",
 	"files.feedbackShortcut": "⌘/Ctrl + Enter to send · Esc to cancel",
 	"files.cancelFeedback": "Cancel",
 	"files.sendFeedback": "Send feedback",


### PR DESCRIPTION
## Summary
- Append newly opened file and terminal tabs after the current tab order.
- Move tab close controls to the trailing side while keeping file feedback on the leading side and preserving workspace icons on hover.
- Simplify the file feedback composer into a compact auto-growing overlay with the circular send action and no shortcut strip.

## Tests
- Not run; the focused tab test updates are included for CI.

## Known follow-up
- Local `frontend/package.json` and `frontend/package-lock.json` changes were intentionally left unstaged because they are unrelated to this UI change.