### PR TITLE
fix(desktop): make killed-session page explain itself and offer a visible restore

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1212,6 +1212,21 @@ describe("BrowserPanel", () => {
 		expect(screen.getByText("Connection refused")).toBeInTheDocument();
 	});
 
+	it("shows a session-ended state with disabled controls for terminated sessions", () => {
+		const terminated = { ...session, status: "terminated", isTerminated: true } as const;
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={terminated} />);
+
+		expect(screen.getByText("Session ended — browser preview unavailable.")).toBeInTheDocument();
+		expect(screen.queryByText("Enter a URL or click one in the terminal.")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Forward" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Reload" })).toBeDisabled();
+		expect(screen.getByRole("textbox", { name: "Browser URL" })).toBeDisabled();
+		for (const button of screen.getAllByRole("button", { name: "Open new tab" })) {
+			expect(button).toBeDisabled();
+		}
+	});
+
 	it("toggles pop-out mode", async () => {
 		const onTogglePopOut = vi.fn();
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -56,7 +56,7 @@ import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { useBrowserView, type BrowserViewModel } from "../hooks/useBrowserView";
 import { formatBrowserAnnotationMessage, type BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 import type { BrowserProfile } from "../../shared/browser-profiles";
-import type { WorkspaceSession } from "../types/workspace";
+import { sessionIsActive, type WorkspaceSession } from "../types/workspace";
 import { Button } from "./ui/button";
 import {
 	DropdownMenu,
@@ -347,8 +347,13 @@ export function BrowserPanelView({
 	onTogglePopOut,
 	browserView,
 	annotationQueue,
+	session,
 }: BrowserPanelProps & { annotationQueue: BrowserAnnotationQueueModel; browserView: BrowserViewModel }) {
 	const { t } = useTranslation();
+	// A killed/exited session has no live preview and no terminal to click
+	// links in, so the toolbar becomes a dead-end of false affordances unless
+	// it knows the session lifecycle. Both call sites pass `session` through.
+	const sessionEnded = !sessionIsActive(session);
 	const {
 		viewId,
 		navState,
@@ -776,6 +781,7 @@ export function BrowserPanelView({
 						"browser-panel__tab-new",
 						draggedTopTabId && "browser-panel__tab-new--dragging",
 					)}
+					disabled={sessionEnded}
 					onClick={() => void handleOpenTab()}
 					title={t("browser.openNewTab")}
 					type="button"
@@ -797,7 +803,7 @@ export function BrowserPanelView({
 							<Button
 								aria-label={t("browser.back")}
 								className="browser-panel__navigation-btn"
-								disabled={!navState.canGoBack}
+								disabled={!navState.canGoBack || sessionEnded}
 								onClick={() => void goBack()}
 								size="icon-sm"
 								type="button"
@@ -815,7 +821,7 @@ export function BrowserPanelView({
 							<Button
 								aria-label={t("browser.forward")}
 								className="browser-panel__navigation-btn"
-								disabled={!navState.canGoForward}
+								disabled={!navState.canGoForward || sessionEnded}
 								onClick={() => void goForward()}
 								size="icon-sm"
 								type="button"
@@ -832,6 +838,7 @@ export function BrowserPanelView({
 						<Button
 							aria-label={navState.isLoading ? t("browser.stop") : t("browser.reload")}
 							className="browser-panel__navigation-btn"
+							disabled={sessionEnded}
 							onClick={() => void (navState.isLoading ? stop() : reload())}
 							size="icon-sm"
 							type="button"
@@ -862,6 +869,7 @@ export function BrowserPanelView({
 							"browser-panel__url-input h-browser-url font-mono text-xs",
 							poppedOut ? "pr-9" : !urlEditing && "px-9 text-center",
 						)}
+						disabled={sessionEnded}
 						list={historySuggestions.length > 0 ? historyListId : undefined}
 						onBlur={endUrlEditing}
 						onChange={(event) => handleURLChange(event.target.value)}
@@ -1244,6 +1252,7 @@ export function BrowserPanelView({
 							<TooltipTrigger asChild>
 								<Button
 									aria-label={t("browser.openNewTab")}
+									disabled={sessionEnded}
 									onClick={() => void handleOpenTab()}
 									size="icon-sm"
 									type="button"
@@ -1292,7 +1301,7 @@ export function BrowserPanelView({
 					{showStaticPreview ? <StaticPreview url={navState.url} /> : null}
 					{navState.url === "" ? (
 						<div className="pointer-events-none absolute inset-0 grid place-items-center p-5 text-center font-mono text-xs text-passive">
-							<p>{t("browser.emptyUrl")}</p>
+							<p>{sessionEnded ? t("browser.sessionEnded") : t("browser.emptyUrl")}</p>
 						</div>
 					) : null}
 					{navState.error ? (

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -768,7 +768,11 @@ describe("terminal restore", () => {
 			terminalHandleId: "term-1",
 		});
 		try {
-			expect(screen.getByRole("button", { name: "Restore session" })).toBeInTheDocument();
+			const restore = screen.getByRole("button", { name: "Restore session" });
+			expect(restore).toBeInTheDocument();
+			// The restore action must be a visible labeled CTA, not an icon-only
+			// button floating in the corner of the strip (issue #3300).
+			expect(restore).toHaveTextContent("Restore session");
 		} finally {
 			view.restore();
 		}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -1168,11 +1168,12 @@ function TerminalEndedStrip({ canRestore, error, isRestoring, onRestore, variant
 								<button
 									type="button"
 									aria-label={t("terminal.restoreSession")}
-									className="inline-flex size-control-form shrink-0 items-center justify-center rounded-md border border-border bg-raised text-foreground transition hover:bg-interactive-hover disabled:cursor-not-allowed disabled:opacity-50"
+									className="inline-flex h-control-form shrink-0 items-center justify-center gap-1.5 rounded-md border border-border bg-raised px-3 text-xs font-medium text-foreground transition hover:bg-interactive-hover disabled:cursor-not-allowed disabled:opacity-50"
 									disabled={isRestoring}
 									onClick={onRestore}
 								>
 									<RotateCcw className={cn("size-icon-base", isRestoring && "animate-spin")} aria-hidden="true" />
+									{t("terminal.restoreSession")}
 								</button>
 							</span>
 						</TooltipTrigger>

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -62,6 +62,7 @@
 	"browser.deviceFit": "Auf Panel anpassen",
 	"browser.devicePreset": "Geräte-Voreinstellung",
 	"browser.emptyUrl": "Geben Sie eine URL ein oder klicken Sie eine im Terminal an.",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "Vorwärts",
 	"browser.newTab": "Neuer Tab",
 	"browser.onlyTab": "Der einzige Tab kann nicht geschlossen werden",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -32,6 +32,7 @@
 	"browser.deviceFit": "Fit panel",
 	"browser.devicePreset": "Device preset",
 	"browser.emptyUrl": "Enter a URL or click one in the terminal.",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "Forward",
 	"browser.newTab": "New tab",
 	"browser.onlyTab": "The only tab cannot be closed",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -62,6 +62,7 @@
 	"browser.deviceFit": "Ajustar al panel",
 	"browser.devicePreset": "Preajuste de dispositivo",
 	"browser.emptyUrl": "Introduce una URL o haz clic en una en el terminal.",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "Adelante",
 	"browser.newTab": "Nueva pestaña",
 	"browser.onlyTab": "No se puede cerrar la única pestaña",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -62,6 +62,7 @@
 	"browser.deviceFit": "Ajuster au panneau",
 	"browser.devicePreset": "Préréglage d'appareil",
 	"browser.emptyUrl": "Saisissez une URL ou cliquez-en une dans le terminal.",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "Suivant",
 	"browser.newTab": "Nouvel onglet",
 	"browser.onlyTab": "L'unique onglet ne peut pas être fermé",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -62,6 +62,7 @@
 	"browser.deviceFit": "パネルに合わせる",
 	"browser.devicePreset": "デバイスプリセット",
 	"browser.emptyUrl": "URL を入力するか、ターミナル内のリンクをクリックしてください。",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "進む",
 	"browser.newTab": "新しいタブ",
 	"browser.onlyTab": "最後のタブは閉じられません",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -62,6 +62,7 @@
 	"browser.deviceFit": "패널에 맞추기",
 	"browser.devicePreset": "기기 사전 설정",
 	"browser.emptyUrl": "URL을 입력하거나 터미널에서 링크를 클릭하세요.",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "앞으로",
 	"browser.newTab": "새 탭",
 	"browser.onlyTab": "마지막 탭은 닫을 수 없습니다",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -62,6 +62,7 @@
 	"browser.deviceFit": "Ajustar ao painel",
 	"browser.devicePreset": "Predefinição de dispositivo",
 	"browser.emptyUrl": "Digite uma URL ou clique em uma no terminal.",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "Avançar",
 	"browser.newTab": "Nova aba",
 	"browser.onlyTab": "A única aba não pode ser fechada",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -62,6 +62,7 @@
 	"browser.deviceFit": "适应面板",
 	"browser.devicePreset": "设备预设",
 	"browser.emptyUrl": "输入网址，或在终端中点击链接。",
+	"browser.sessionEnded": "Session ended — browser preview unavailable.",
 	"browser.forward": "前进",
 	"browser.newTab": "新标签",
 	"browser.onlyTab": "无法关闭唯一标签",


### PR DESCRIPTION
Closes #3300.

## What & why
When a session is killed or its process exits, the detail page was a confusing dead-end: the Browser tab showed "Enter a URL or click one in the terminal" with live-looking controls on a dead environment, and the restore action was a 24px icon-only button disconnected from its instruction text.

## Changes
- **Browser tab** (`BrowserPanelView`): now reads the session lifecycle via `sessionIsActive` (both call sites already passed `session` through; the view just never destructured it). Terminated sessions show "Session ended — browser preview unavailable." and Back/Forward/Reload/URL input/new-tab controls are disabled.
- **Restore CTA** (`TerminalEndedStrip`): the icon-only button is now a labeled "Restore session" button next to the instruction text. Same gate, same flow, same accessible name.
- **i18n**: new `browser.sessionEnded` key in all 8 locales (English text as placeholder outside en).

## How to test
1. `cd frontend && ./node_modules/.bin/vitest run src/renderer/components/BrowserPanel.test.tsx src/renderer/components/TerminalPane.test.tsx src/renderer/components/SessionView.test.tsx src/renderer/components/SessionInspector.test.tsx src/renderer/i18n/` — 363 passed locally.
2. Kill a session, open it: Browser shows the ended message with disabled controls; the terminal strip shows a labeled Restore button.

## Risks & notes
- No daemon API, storage, migration, or network changes. Frontend-only.
- The raw `[process exited]` xterm scrollback line is unchanged: the PTY exit event carries no reason payload, so the React-side strip (which knows the session record) is where the context lives.