### PR TITLE
docs: add documentation map for the machine-readable contract layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ When showing or demoing frontend changes, run `ao preview [url]` from inside the
 
 - `README.md` — current run/config/test quickstart.
 - `docs/README.md` — docs index.
+- `docs/documentation-map.md` — which artifacts are the machine-readable contract layer (`openapi.yaml`, `AGENTS.md`, `skills/`, sqlc `gen/`), what each is source of truth for, and how CI keeps them from drifting.
 - `docs/architecture.md` — backend mental model, package layout, lifecycle/session/service boundaries, and load-bearing rules.
 - `docs/STATUS.md` — what is shipped on `main` today and what is still in flight.
 - `docs/cli/README.md` — intended CLI shape: thin Cobra client over daemon HTTP, never direct storage/runtime access.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Non-trivial work? Comment on the issue or ping Discord first. Get a thumbs-up, t
 ## Quick start
 
 1. **Join Discord** — say hi and get guidance
-2. **Read the contract** — [AGENTS.md](AGENTS.md) (layout, commands, hard rules, PR hygiene)
+2. **Read the contract** — [AGENTS.md](AGENTS.md) (layout, commands, hard rules, PR hygiene); [docs/documentation-map.md](docs/documentation-map.md) explains which docs are contracts and which are prose
 3. **Pick something focused** — [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues); prefer `good-first-issue` / `help wanted`
 4. **Claim it** — comment `I'd like to work on this` and wait for assignment
 5. **Open a clear PR** — narrow change, link the issue, user-visible impact, tests

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Start with the [development guide](docs/development.md) for prerequisites, local
 | Document                                                         | Start here when you need                                                                     |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | [Product documentation](https://useao.dev/docs)                  | Installation, agent setup, and day-to-day product usage.                                     |
+| [docs/documentation-map.md](docs/documentation-map.md)           | Which docs are human-facing, which are machine-readable contracts, and which wins on drift.  |
 | [docs/architecture.md](docs/architecture.md)                     | Backend mental model, lifecycle, persistence, CDC, status derivation, and daemon boundaries. |
 | [docs/backend-code-structure.md](docs/backend-code-structure.md) | Package ownership and where each backend concern belongs.                                    |
 | [docs/cli/README.md](docs/cli/README.md)                         | CLI behavior and daemon route mapping.                                                       |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 
 | Doc                                                    | What it covers                                                                                                        |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| [documentation-map.md](documentation-map.md)           | Human-facing docs vs the machine-readable contract layer, source of truth per concern, and the CI gates that hold it. |
 | [architecture.md](architecture.md)                     | Current backend model, package layout, status derivation, persistence/CDC, and load-bearing rules.                    |
 | [scm-observer.md](scm-observer.md)                     | SCM subsystem: polling pipeline, durable-state invariants, PR identity model, and the rename/transfer design.         |
 | [backend-code-structure.md](backend-code-structure.md) | Package ownership rules for the Go backend: domain, services, ports, adapters, storage, HTTP, CLI, and daemon wiring. |

--- a/docs/documentation-map.md
+++ b/docs/documentation-map.md
@@ -1,0 +1,76 @@
+# Documentation map
+
+This repository is edited by humans and by coding agents. Both need to know two
+things quickly: which document describes a given concern, and which artifact is
+the **source of truth** for it when documents disagree.
+
+AO's documentation has two layers. They grew organically; this page names them
+so the split is intentional rather than incidental.
+
+| Layer                     | Audience                      | Examples                                                        | How it stays correct                                    |
+| ------------------------- | ----------------------------- | --------------------------------------------------------------- | ------------------------------------------------------- |
+| Human-facing docs         | Contributors, users           | `README.md`, `CONTRIBUTING.md`, `docs/`, https://useao.dev/docs | Review. Prose describes code; it can lag behind it.     |
+| Machine-readable contract | Coding agents, CI, generators | `openapi.yaml`, `AGENTS.md`, `skills/`, sqlc `gen/`             | Generated from source and/or checked by CI drift gates. |
+
+The rule of thumb: **if an artifact in the contract layer disagrees with prose,
+the contract layer wins**, because it is either generated from the code or gated
+in CI. Fix the prose.
+
+## Human-facing layer
+
+| Document                                                    | Covers                                                                       |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [README.md](../README.md)                                   | Product overview, install, quickstart, top-level doc index.                  |
+| [CONTRIBUTING.md](../CONTRIBUTING.md)                       | How to pick up work, claim issues, and open PRs.                             |
+| [docs/README.md](README.md)                                 | Index of the repository's architecture and reference docs.                   |
+| [docs/architecture.md](architecture.md)                     | Backend mental model, lifecycle, persistence/CDC, status derivation.         |
+| [docs/backend-code-structure.md](backend-code-structure.md) | Package ownership rules for the Go backend.                                  |
+| [docs/development.md](development.md)                       | Prerequisites, build, test, and troubleshooting for local development.       |
+| [docs/STATUS.md](STATUS.md)                                 | What ships on `main` today and what is in flight.                            |
+| [docs/adr/](adr/)                                           | Architecture decision records: why a boundary exists, not just what it is.   |
+| https://useao.dev/docs                                      | Published product documentation for end users.                               |
+| https://useao.dev/llms.txt                                  | Index of the published docs for LLM consumption. Navigation, not a contract. |
+
+These documents explain intent and rationale. They are reviewed by people and
+are not machine-checked, so treat them as the _why_ and confirm the _what_
+against the contract layer below.
+
+## Machine-readable contract layer
+
+| Artifact                                                               | Source of truth for                                                     | Generated from / defined in                                                                                            | Drift gate                                                                                                                                                               |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `backend/internal/httpd/apispec/openapi.yaml`                          | Daemon HTTP API: routes, request/response shapes, errors                | `backend/internal/httpd/controllers/dto.go` + `backend/internal/httpd/apispec/specgen/build.go` via `npm run api:spec` | `TestBuild_MatchesEmbedded` (embedded spec matches generator output) and `TestRouteSpecParity` (every registered route is in the spec) in `go test ./internal/httpd/...` |
+| `frontend/src/api/schema.ts`                                           | Typed client the frontend uses to talk to the daemon                    | `openapi.yaml` via `npm run api:ts`                                                                                    | `api-drift` job in `.github/workflows/go.yml` regenerates and fails on `git diff`                                                                                        |
+| `backend/internal/storage/sqlite/gen/`                                 | Query/DTO code for SQLite storage                                       | `backend/internal/storage/sqlite/queries/*` + migrations via `npm run sqlc`                                            | `sqlc-drift` job in `.github/workflows/go.yml`                                                                                                                           |
+| [AGENTS.md](../AGENTS.md)                                              | Agent operating contract: repo layout, commands, hard rules, PR hygiene | Hand-written; `CLAUDE.md` is a pointer to it                                                                           | Not machine-checked. The hard rules it names are enforced by tests (for example loopback-only routing, status derivation) rather than by a doc gate.                     |
+| `backend/internal/skillassets/using-ao/`                               | The `ao` CLI catalog installed into agent workspaces                    | Hand-written Markdown with YAML frontmatter, embedded in the binary                                                    | `TestEmbeddedSkillFrontmatterIsValidYAML` and sibling tests in `backend/internal/skillassets`                                                                            |
+| `MobileAPIVersion` in `backend/internal/httpd/controllers/identity.go` | Contract version negotiated by the mobile client                        | Go constant                                                                                                            | Bump rule documented in the constant's comment and `docs/adr/0003-unauthenticated-identity-probe.md`                                                                     |
+| `ao <command> --help`                                                  | Authoritative flag list for every CLI command                           | Cobra command definitions in `backend/internal/cli/`                                                                   | Table tests in `backend/internal/cli/*_test.go`                                                                                                                          |
+
+The CLI's hand-mirrored DTOs (`backend/internal/cli/`) are a deliberate manual
+boundary: they are not generated from `openapi.yaml`, and wire compatibility is
+covered by tests rather than a generator. See "API contract changes" in
+[AGENTS.md](../AGENTS.md).
+
+## How to keep the layers in sync
+
+- **Changing the daemon API**: edit `dto.go` and `build.go`, run `npm run api`,
+  commit `openapi.yaml` and `schema.ts` with the Go change. CI fails otherwise.
+- **Changing storage**: edit queries or add a migration, run `npm run sqlc`,
+  commit `gen/`. Never hand-edit `gen/` or already-merged migrations.
+- **Changing a hard rule or boundary**: update `AGENTS.md` in the same PR, and
+  add an ADR under `docs/adr/` when the rule is a decision that needs rationale.
+- **Changing `ao` CLI behavior**: update the command, its table test, and the
+  matching page under `backend/internal/skillassets/using-ao/commands/`.
+- **Changing prose only**: fine, but if the prose describes a contract artifact,
+  re-read that artifact first. Prose follows the contract, not the reverse.
+
+## Where to add new documentation
+
+- A user needs it to use the product: https://useao.dev/docs (source under
+  `frontend/src/landing/content/docs/`).
+- A contributor needs it to change the code: `docs/`, and add a row to
+  [docs/README.md](README.md).
+- An agent needs it to operate safely in the repo: `AGENTS.md`.
+- An agent needs it to use the `ao` CLI at runtime: `backend/internal/skillassets/using-ao/`.
+- It is a decision with trade-offs: `docs/adr/`.

--- a/frontend/src/landing/src/lib/llms.ts
+++ b/frontend/src/landing/src/lib/llms.ts
@@ -71,6 +71,7 @@ export function buildDeveloperResourcesSection(
 		`- [Agent instructions](${baseUrl}/agents.md): when and how AI agents should use Agent Orchestrator`,
 		`- [Blog llms.txt](${baseUrl}/blog/llms.txt): scoped index of blog posts`,
 		`- [GitHub](${COMPANY.GITHUB_URL}): source code and releases`,
+		`- [Documentation map](${COMPANY.GITHUB_URL}/blob/main/docs/documentation-map.md): which repository artifacts are machine-readable contracts (OpenAPI spec, AGENTS.md, skills) versus human prose, and how CI keeps them in sync`,
 	];
 }
 


### PR DESCRIPTION
## What

Add `docs/documentation-map.md`, which names AO's two documentation layers: human-facing prose (`README`, `CONTRIBUTING`, `docs/`, useao.dev) and the machine-readable contract layer (`openapi.yaml`, `schema.ts`, sqlc `gen/`, `AGENTS.md`, the embedded `using-ao` skill, `MobileAPIVersion`, `ao --help`). Link it from `README.md`, `docs/README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and the generated `llms.txt`.

## Why

Fixes #2976. The contract layer already exists and is CI-gated, but nothing names it, so a new contributor or agent has no map saying which artifact is source of truth for what, and `llms.txt` only leads to prose.

## How

- Per contract artifact the page records: what it is source of truth for, what it is generated from, and the exact drift guard (`TestBuild_MatchesEmbedded`, `TestRouteSpecParity`, `api-drift`, `sqlc-drift`, skillassets frontmatter test). It states the tie-break rule: contract wins over prose.
- The `llms.txt` pointer is added in `frontend/src/landing/src/lib/llms.ts` under Developer resources and links to the GitHub page, so the agent index reaches the contract without a new docs-site page.
- Intentional omission: no new docs-site page and no CI check for the map itself. This is the smallest first version the issue asked for; a machine-checkable invariants artifact can follow if maintainers want it.

## Testing

- `npx tsc --noEmit -p frontend/src/landing` passes.
- Every path, test name, and CI job name cited in the new doc was verified against the tree.
- No runtime behavior changed; Go tests not affected.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense (docs only; none needed)
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)


