### PR TITLE
Show token counts on kanban session cards

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -316,7 +316,7 @@ describe("SessionsBoard", () => {
 		expect(within(idleCard).getByText("brand-font-pipeline")).toHaveClass("font-semibold", "line-clamp-2");
 	});
 
-	it("shows coverage-aware cost with tokens on active and archived cards", async () => {
+	it("shows token counts with coverage-aware cost details on active and archived cards", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				workspaceWithSessions([
@@ -390,11 +390,11 @@ describe("SessionsBoard", () => {
 
 		renderBoard("p1");
 
-		// The card shows dollar cost by default; the token count remains in the
-		// hover tooltip and accessible label.
-		const activeUsage = screen.getByText("$1.24", { selector: "span" });
+		// The card shows tokens by default; cost remains in the hover tooltip and
+		// accessible label.
+		const activeUsage = screen.getByText("12.3K", { selector: "span" });
 		expect(activeUsage).toHaveAttribute("aria-hidden", "true");
-		expect(screen.getByText("$1.24 · 12,300 tokens")).toHaveClass("sr-only");
+		expect(screen.getByText("12,300 tokens · $1.24")).toHaveClass("sr-only");
 		expect(screen.queryByText(/processed/i)).not.toBeInTheDocument();
 		// Sessions without a dollar estimate stay visible if they still have
 		// token usage; sessions with no cost and no tokens still show nothing.
@@ -407,11 +407,11 @@ describe("SessionsBoard", () => {
 		expect(usageQueryMock).toHaveBeenCalledWith("p1");
 
 		const archive = await expandArchive();
-		expect(within(archive).getByText("$0.02")).toHaveAttribute("aria-hidden", "true");
-		expect(within(archive).getByText("$0.02 · 1,900 tokens")).toHaveClass("sr-only");
+		expect(within(archive).getByText("1.9K")).toHaveAttribute("aria-hidden", "true");
+		expect(within(archive).getByText("1,900 tokens · $0.02")).toHaveClass("sr-only");
 	});
 
-	it("shows cost by default and cost plus tokens on hover without a tab stop", async () => {
+	it("shows tokens by default and tokens plus cost on hover without a tab stop", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				workspaceWithSessions([
@@ -446,20 +446,20 @@ describe("SessionsBoard", () => {
 		renderBoard("p1");
 
 		const card = screen.getByText("keyboard worker").closest('[data-testid="board-session-card"]') as HTMLElement;
-		const usage = within(card).getByText("$1.24", { selector: "span" });
+		const usage = within(card).getByText("12.4K", { selector: "span" });
 		expect(usage.tagName).toBe("SPAN");
 		// The compact text is decorative; the full label is real off-screen text
 		// rather than an aria-label on a generic span, which is not reliably
 		// exposed. The hover trigger is not a tab stop.
 		expect(usage).toHaveAttribute("aria-hidden", "true");
-		expect(within(card).getByText("$1.24 · 12,400 tokens")).toHaveClass("sr-only");
+		expect(within(card).getByText("12,400 tokens · $1.24")).toHaveClass("sr-only");
 
 		within(card).getByRole("button", { name: "keyboard worker" }).focus();
 		await userEvent.tab();
 		expect(within(card).getByRole("button", { name: "Terminate keyboard worker" })).toHaveFocus();
 
 		await userEvent.hover(usage);
-		expect(await screen.findByRole("tooltip")).toHaveTextContent("$1.24 · 12,400 tokens");
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("12,400 tokens · $1.24");
 	});
 
 	it("shows token-only usage when pricing is unavailable", async () => {

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -283,39 +283,24 @@ function pullRequestProgressLabel(
 		.join(" · ");
 }
 
-// Keep the board metric scannable by showing cost only. The full cost/token
-// summary remains available from the hover tooltip and to screen readers.
+// Keep the board metric scannable by showing processed tokens. The full
+// cost/token summary remains available from the hover tooltip and to screen readers.
 function toUsagePresentation(
 	usage: SessionUsageSummary | undefined,
 	t: TFunction,
 ): BoardUsagePresentation | undefined {
 	const processedTokens = usage?.processedTokens ?? null;
-	if (!usage) {
+	if (!usage || processedTokens === null || processedTokens <= 0) {
 		return undefined;
 	}
-	const cost = formatEstimatedCost(usage.estimatedCost);
-	if (!cost) {
-		if (processedTokens === null || processedTokens <= 0) {
-			return undefined;
-		}
-		const compactTokens = formatTokenCount(processedTokens).replace(/ tok$/, "");
-		const accessibleTokens = t("shell.usageTokens", {
-			count: processedTokens.toLocaleString("en-US"),
-		});
-		return {
-			accessibleLabel: accessibleTokens,
-			compactLabel: compactTokens,
-		};
-	}
-	if (processedTokens === null) {
-		return { accessibleLabel: cost, compactLabel: cost };
-	}
+	const compactTokens = formatTokenCount(processedTokens).replace(/ tok$/, "");
 	const accessibleTokens = t("shell.usageTokens", {
 		count: processedTokens.toLocaleString("en-US"),
 	});
+	const cost = formatEstimatedCost(usage.estimatedCost);
 	return {
-		accessibleLabel: `${cost} · ${accessibleTokens}`,
-		compactLabel: cost,
+		accessibleLabel: cost ? `${accessibleTokens} · ${cost}` : accessibleTokens,
+		compactLabel: compactTokens,
 	};
 }
 


### PR DESCRIPTION
## Summary

- show compact processed-token counts on active and archived session cards
- keep exact token counts and estimated cost details in the tooltip and screen-reader text
- omit the usage chip when processed-token telemetry is missing or zero

## Testing

- `npm --prefix frontend test -- SessionsBoard`
- `npm run frontend:typecheck`
- `npm run product-ui:check`
- `npm run cloud:check`
- `npm run typecheck:e2e --prefix frontend`

Closes #5026