### PR TITLE
fix: confine terminal drag selection

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -52,6 +52,7 @@ const state = vi.hoisted(() => ({
 				enable: ReturnType<typeof vi.fn>;
 				shouldForceSelection: (event: MouseEvent) => boolean;
 				_mouseMoveListener?: EventListener;
+				_dragScrollAmount?: number;
 			};
 		};
 	},
@@ -107,6 +108,7 @@ vi.mock("@xterm/xterm", () => ({
 				enable: vi.fn(),
 				shouldForceSelection: () => false,
 				_mouseMoveListener: state.mouseMoveListener,
+				_dragScrollAmount: 0,
 			},
 		};
 
@@ -2045,12 +2047,17 @@ describe("XtermTerminal", () => {
 		expect(saveDroppedFile).not.toHaveBeenCalled();
 	});
 
-	it("does not extend a drag selection into a neighboring pane", () => {
+	it("does not extend a drag selection into a neighboring pane or keep auto-scrolling", () => {
 		render(<XtermTerminal theme="dark" />);
-		const listener = state.lastTerminal!._core._selectionService._mouseMoveListener!;
+		const selectionService = state.lastTerminal!._core._selectionService;
+		const listener = selectionService._mouseMoveListener!;
 
+		// Simulate xterm's timer having been armed by a previous drag below the
+		// terminal before the pointer crosses horizontally into the sidebar.
+		selectionService._dragScrollAmount = 1;
 		listener(new MouseEvent("mousemove", { clientX: 801 }));
 		expect(state.mouseMoveListener).not.toHaveBeenCalled();
+		expect(selectionService._dragScrollAmount).toBe(0);
 
 		listener(new MouseEvent("mousemove", { clientX: 800 }));
 		expect(state.mouseMoveListener).toHaveBeenCalledTimes(1);

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -17,6 +17,7 @@ const state = vi.hoisted(() => ({
 		findPrevious: ReturnType<typeof vi.fn>;
 		resultListeners: Set<(results: { resultCount: number; resultIndex: number }) => void>;
 	},
+	mouseMoveListener: vi.fn(),
 	lastTerminal: null as null | {
 		write(data: Uint8Array, done?: () => void): void;
 		keyHandler?: (event: KeyboardEvent) => boolean;
@@ -42,11 +43,15 @@ const state = vi.hoisted(() => ({
 		selectionListeners: Set<() => void>;
 		scrollListeners: Set<() => void>;
 		_core: {
-			element: { classList: { add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> } };
+			element: {
+				classList: { add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> };
+				getBoundingClientRect: () => DOMRect;
+			};
 			viewport: { scrollBarWidth: number };
 			_selectionService: {
 				enable: ReturnType<typeof vi.fn>;
 				shouldForceSelection: (event: MouseEvent) => boolean;
+				_mouseMoveListener?: EventListener;
 			};
 		};
 	},
@@ -93,11 +98,15 @@ vi.mock("@xterm/xterm", () => ({
 		scrollListeners = new Set<() => void>();
 		writeBuffer = "";
 		_core = {
-			element: { classList: { add: vi.fn(), remove: vi.fn() } },
+			element: {
+				classList: { add: vi.fn(), remove: vi.fn() },
+				getBoundingClientRect: () => ({ left: 0, right: 800 }) as DOMRect,
+			},
 			viewport: { scrollBarWidth: 15 },
 			_selectionService: {
 				enable: vi.fn(),
 				shouldForceSelection: () => false,
+				_mouseMoveListener: state.mouseMoveListener,
 			},
 		};
 
@@ -224,6 +233,7 @@ describe("XtermTerminal", () => {
 		state.lastTerminal = null;
 		state.linkHandler = null;
 		state.searchAddon = null;
+		state.mouseMoveListener.mockClear();
 		setNavigatorPlatform("Linux x86_64");
 		window.ao!.clipboard.writeText = vi.fn().mockResolvedValue(undefined);
 		window.ao!.clipboard.readText = vi.fn().mockResolvedValue("");
@@ -2033,5 +2043,16 @@ describe("XtermTerminal", () => {
 		window.removeEventListener("drop", bubbled);
 		expect(bubbled).toHaveBeenCalledTimes(1);
 		expect(saveDroppedFile).not.toHaveBeenCalled();
+	});
+
+	it("does not extend a drag selection into a neighboring pane", () => {
+		render(<XtermTerminal theme="dark" />);
+		const listener = state.lastTerminal!._core._selectionService._mouseMoveListener!;
+
+		listener(new MouseEvent("mousemove", { clientX: 801 }));
+		expect(state.mouseMoveListener).not.toHaveBeenCalled();
+
+		listener(new MouseEvent("mousemove", { clientX: 800 }));
+		expect(state.mouseMoveListener).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -274,6 +274,7 @@ type XtermInternal = Terminal & {
 			// active. It is private, but xterm exposes no public hook for changing
 			// the document-wide drag behavior.
 			_mouseMoveListener?: EventListener;
+			_dragScrollAmount?: number;
 		};
 	};
 };
@@ -352,7 +353,14 @@ function confineDragSelectionToTerminalWidth(term: Terminal): void {
 	selectionService._mouseMoveListener = (event: Event) => {
 		if (!(event instanceof MouseEvent)) return;
 		const { left, right } = element.getBoundingClientRect();
-		if (event.clientX < left || event.clientX > right) return;
+		if (event.clientX < left || event.clientX > right) {
+			// xterm's document-level drag timer continues using its last vertical
+			// overflow value. Clear that value when the pointer enters a sibling
+			// pane, otherwise a previous below-the-terminal drag keeps scrolling and
+			// extends the frozen selection.
+			selectionService._dragScrollAmount = 0;
+			return;
+		}
 		originalMouseMoveListener(event);
 	};
 }

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -270,6 +270,10 @@ type XtermInternal = Terminal & {
 		_selectionService?: {
 			enable: () => void;
 			shouldForceSelection: (event: MouseEvent) => boolean;
+			// xterm installs this listener on document while a drag selection is
+			// active. It is private, but xterm exposes no public hook for changing
+			// the document-wide drag behavior.
+			_mouseMoveListener?: EventListener;
 		};
 	};
 };
@@ -330,6 +334,27 @@ function forceSelectionMode(term: Terminal): void {
 function configureScrollbarReservation(term: Terminal): void {
 	const viewport = (term as XtermInternal)._core?.viewport;
 	if (viewport) viewport.scrollBarWidth = isMacPlatform() ? MAC_TERMINAL_SCROLLBAR_WIDTH : 0;
+}
+
+// xterm deliberately keeps drag selection listening on document. When a drag
+// leaves the terminal horizontally, its coordinate conversion clamps the pointer
+// to the last terminal column. In split layouts that turns a drag into the
+// neighboring inspector into a selection of a full-width TUI sidebar (OpenCode
+// is the visible example). Keep vertical overflow intact for xterm's standard
+// drag-to-scroll behavior, but do not extend a selection into a sibling pane.
+function confineDragSelectionToTerminalWidth(term: Terminal): void {
+	const internal = term as XtermInternal;
+	const selectionService = internal._core?._selectionService;
+	const element = internal._core?.element;
+	const originalMouseMoveListener = selectionService?._mouseMoveListener;
+	if (!selectionService || !element || !originalMouseMoveListener) return;
+
+	selectionService._mouseMoveListener = (event: Event) => {
+		if (!(event instanceof MouseEvent)) return;
+		const { left, right } = element.getBoundingClientRect();
+		if (event.clientX < left || event.clientX > right) return;
+		originalMouseMoveListener(event);
+	};
 }
 
 export function XtermTerminal(props: XtermTerminalProps) {
@@ -584,6 +609,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		loadRenderer(term);
 		term.options.macOptionClickForcesSelection = true;
 		forceSelectionMode(term);
+		confineDragSelectionToTerminalWidth(term);
 
 		// xterm 5's native viewport scrollbar follows macOS's system auto-hide
 		// preference even when its WebKit pseudo-elements are styled. Keep the


### PR DESCRIPTION
## Summary
- stop xterm document drag selection when the pointer leaves the terminal horizontally
- preserve vertical drag-to-scroll while preventing an adjacent pane from being clamped into terminal selection
- cover the boundary guard with an XtermTerminal regression test

Fixes #4290

## Tests
- `npm test`
- `npm run typecheck`

## Risk
- Uses xterm’s existing private selection listener because xterm 5.5 exposes no public hook for document-wide drag selection. The guard safely no-ops if that internal listener is unavailable.