### PR TITLE
fix(chat): ignore replay checkpoints from unsettled turns

### DIFF
--- a/backend/internal/service/chat/checkpoint_provenance_test.go
+++ b/backend/internal/service/chat/checkpoint_provenance_test.go
@@ -1,0 +1,103 @@
+package chat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// completedReplay is what ACP session/load reproduces for a settled provider
+// thread: one completed turn, its user prompt, and its answer.
+func completedReplay() []ports.ChatEvent {
+	return []ports.ChatEvent{
+		{
+			Kind: ports.ChatEventUserMessageCompleted, ProviderEventID: "history-user",
+			ProviderTurnID: "native-turn-1", ProviderItemID: "native-user-1", Text: "Say hi",
+		},
+		{
+			Kind: ports.ChatEventMessageCompleted, ProviderEventID: "history-answer",
+			ProviderTurnID: "native-turn-1", ProviderItemID: "native-answer-1", Text: "Hi!",
+		},
+		{
+			Kind: ports.ChatEventTurnCompleted, ProviderEventID: "history-complete",
+			ProviderTurnID: "native-turn-1", TurnState: domain.TurnStateCompleted,
+		},
+	}
+}
+
+// poisonedRows mirrors a session whose newest hook fact came from a turn the
+// provider never settled: the prompt is durable in AO, but session/load replays
+// only the completed turn before it.
+func poisonedRows(state domain.TurnState) ([]domain.ConversationTurn, []domain.ConversationMessage) {
+	base := time.Date(2026, 9, 7, 14, 33, 20, 0, time.UTC)
+	turns := []domain.ConversationTurn{
+		{
+			ID: "completed-turn", HandledBySessionID: testCheckpointSession,
+			ProviderTurnID: "native-turn-1", State: domain.TurnStateCompleted, RequestedAt: base,
+		},
+		{
+			ID: "unsettled-turn", HandledBySessionID: testCheckpointSession,
+			State: state, RequestedAt: base.Add(2 * time.Minute),
+		},
+	}
+	messages := []domain.ConversationMessage{
+		{
+			TurnID: "completed-turn", Sequence: 1, Role: domain.MessageRoleUser,
+			Text: "Say hi", ProviderItemID: "native-user-1",
+		},
+		{
+			TurnID: "completed-turn", Sequence: 2, Role: domain.MessageRoleAssistant,
+			Text: "Hi!", ProviderItemID: "native-answer-1",
+		},
+		{TurnID: "unsettled-turn", Sequence: 3, Role: domain.MessageRoleUser, Text: "Say hi to"},
+	}
+	return turns, messages
+}
+
+const testCheckpointSession = domain.SessionID("checkpoint-session")
+
+// A prompt AO recorded on a cancelled or interrupted turn is not something the
+// provider promises to replay, so gating the native-history import on it can
+// never be satisfied: the settle loop burns its full budget and the interface
+// transition rolls back to Terminal for good. See #4424.
+func TestCheckpointIgnoresPromptFromUnsettledTurn(t *testing.T) {
+	for _, state := range []domain.TurnState{
+		domain.TurnStateCancelled,
+		domain.TurnStateInterrupted,
+		domain.TurnStateFailed,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			turns, messages := poisonedRows(state)
+			checkpoint := nativeHistoryCheckpoint{latestUserPrompt: "Say hi to"}
+			checkpoint.captureAOHighWater(testCheckpointSession, turns, messages, nil)
+
+			if !checkpoint.reached(completedReplay()) {
+				t.Fatalf("replay checkpoint gates on a %s turn's prompt; TUI-to-Chat would "+
+					"time out after nativeHistorySettleLimit and roll back", state)
+			}
+		})
+	}
+}
+
+// The guard must stay narrow: a prompt from a completed turn is still a hard
+// gate, so a replay that has not caught up with settled work is rejected.
+func TestCheckpointStillGatesOnCompletedPrompt(t *testing.T) {
+	base := time.Date(2026, 9, 7, 14, 33, 20, 0, time.UTC)
+	turns := []domain.ConversationTurn{{
+		ID: "completed-turn", HandledBySessionID: testCheckpointSession,
+		ProviderTurnID: "native-turn-1", State: domain.TurnStateCompleted, RequestedAt: base,
+	}}
+	messages := []domain.ConversationMessage{{
+		TurnID: "completed-turn", Sequence: 1, Role: domain.MessageRoleUser,
+		Text: "Say hi", ProviderItemID: "native-user-1",
+	}}
+
+	checkpoint := nativeHistoryCheckpoint{latestUserPrompt: "Run the final verification."}
+	checkpoint.captureAOHighWater(testCheckpointSession, turns, messages, nil)
+
+	if checkpoint.reached(completedReplay()) {
+		t.Fatal("a settled prompt the replay has not reached must keep gating the import")
+	}
+}

--- a/backend/internal/service/chat/controller.go
+++ b/backend/internal/service/chat/controller.go
@@ -383,6 +383,50 @@ type nativeHistoryCheckpoint struct {
 	aoHighWater           nativeHistoryHighWater
 }
 
+// dropUnsettledHookFacts retires checkpoint text that AO durably recorded on a
+// turn the provider never settled. A provider promises to reproduce settled work
+// during history load, but a cancelled, interrupted or failed turn carries no
+// such promise: Claude forks its next prompt from the pre-failure transcript
+// entry, so `session/load` never replays that prompt as a completed user
+// message. Requiring one is unsatisfiable — the settle loop then spends its full
+// `nativeHistorySettleLimit` and the interface transition rolls back to Terminal
+// on every future attempt, which is the same trap the high-water anchor below
+// already avoids by only anchoring on completed turns.
+//
+// Evidence is required to drop a fact. A checkpoint AO cannot tie to any of its
+// own turns is left in place: absence of a row is not proof the work was
+// unsettled, and these facts are what stop a stale replay from being imported as
+// if it were current.
+func (p *nativeHistoryCheckpoint) dropUnsettledHookFacts(
+	turnsByID map[string]*domain.ConversationTurn,
+	messages []domain.ConversationMessage,
+) {
+	settled := func(text string, role domain.MessageRole) bool {
+		var newest *domain.ConversationTurn
+		for _, message := range messages {
+			if message.Role != role || !nativeHistoryTextMatches(text, message.Text) {
+				continue
+			}
+			turn := turnsByID[message.TurnID]
+			if turn == nil {
+				continue
+			}
+			// The newest matching turn decides: the same prompt can be sent again
+			// after a cancellation, and that later completed turn is replayable.
+			if newest == nil || turn.RequestedAt.After(newest.RequestedAt) {
+				newest = turn
+			}
+		}
+		return newest == nil || newest.State == domain.TurnStateCompleted
+	}
+	if p.latestUserPrompt != "" && !settled(p.latestUserPrompt, domain.MessageRoleUser) {
+		p.latestUserPrompt = ""
+	}
+	if p.latestAssistantUpdate != "" && !settled(p.latestAssistantUpdate, domain.MessageRoleAssistant) {
+		p.latestAssistantUpdate = ""
+	}
+}
+
 func (p *nativeHistoryCheckpoint) captureAOHighWater(
 	sessionID domain.SessionID,
 	turns []domain.ConversationTurn,
@@ -393,6 +437,7 @@ func (p *nativeHistoryCheckpoint) captureAOHighWater(
 	for i := range turns {
 		turnsByID[turns[i].ID] = &turns[i]
 	}
+	p.dropUnsettledHookFacts(turnsByID, messages)
 	// An agent switch starts a new provider-native thread with an AO coordination
 	// turn. Completed turns before it belong to the previous provider: their
 	// opaque ids remain useful timeline facts, but the new provider cannot replay


### PR DESCRIPTION
Interim guard for #4424. Deliberately narrow: two files, +148/−0, no schema change.

> [!NOTE]
> This does **not** replace #4466. That PR carries the full model — checkpoint trust/provenance columns, coordination-prompt handling, recovery-consent fencing, and the **Retry / Use provider history / Stay in Terminal** actions — and should still land. It is currently stacked on the unmerged #4463 and its migrations (`0120`/`0121`) now collide with `main` (already at `0135`), so this guard closes the hole in the meantime.

## Problem

A session whose newest hook fact came from a turn the provider never settled can **never** return to Chat. Every `tui -> chat` transition fails `TARGET_HISTORY_UNSETTLED` after the full 45s `nativeHistorySettleLimit`, then rolls back to Terminal.

`nativeHistoryCheckpoint.reached` requires the latest completed user message in the ACP `session/load` replay to text-match `sessions.latest_user_prompt`. A cancelled turn's prompt is never replayed as a completed message — Claude forks its next prompt from the pre-cancellation transcript entry — so the comparison can never succeed. `lifecycle/manager.go` only overwrites that field with a non-empty value, so the poisoned fact never ages out on its own.

`captureAOHighWater` already refuses to anchor on non-completed turns, with a comment noting that requiring one "would make every future switch time out". That is precisely what happens here — the hook-derived text facts simply had no equivalent filter.

## Evidence from a live reproduction

Session `meetyou-26`, packaged nightly `v0.12.13-nightly.202609091711` (daemon `378f9f713b`), Claude Code over ACP. `sessions.latest_user_prompt` held `"Say hi to"` from **2026-09-07**, and `conversation_turns` shows the turn requested at that exact timestamp is `state = cancelled`.

Eight consecutive attempts failed, each at ~46s. Clearing that one field — changing nothing else — produced this:

| Time (UTC) | Phase | Error | Duration |
|---|---|---|---|
| 15:28:47 | failed | TARGET_HISTORY_UNSETTLED | 46.4s |
| **15:29:59** | **completed** | — | **2.6s** |

Same daemon process, same provider transcript, 72 seconds apart. Other sessions (`meetyou-24`, `oddswell-24`) completed `tui -> chat` in ~4s throughout, ruling out provider health, account rate limits, and anything global.

## Fix

`dropUnsettledHookFacts` retires checkpoint text that AO durably recorded on a cancelled, interrupted or failed turn, applying the rule `captureAOHighWater` already uses for its own anchor.

It only acts **on evidence**: a checkpoint AO cannot tie to one of its own turns is left in place, because absence of a row is not proof the work was unsettled, and these facts are what stop a stale replay from being imported as current. The newest matching turn decides, so re-sending a prompt after a cancellation restores it as a valid gate.

## Tests

`TestCheckpointIgnoresPromptFromUnsettledTurn` — cancelled / interrupted / failed, modelled on the rows above. Fails on `main`, passes here.
`TestCheckpointStillGatesOnCompletedPrompt` — control: a settled prompt the replay has not reached must still block the import. Passes both before and after, so the guard is not over-broad.

```
go test ./internal/service/chat/...    ok  17.610s
go test ./internal/session_manager/... ok  21.620s
go vet ./internal/service/chat/        clean
gofmt                                  clean
```

## Limitations

The guard acts only on evidence, so it covers a **subset** of poisoned sessions: those whose checkpoint text can be tied to one of AO's own conversation turns. Two cases are **not** covered, and both fail identically to the user, with no way to tell them apart:

- **A session that has only ever run in TUI.** TUI turns are never projected into `conversation_turns`, so there are no rows to consult and nothing is dropped. In the reproduction session the rows stop at 2026-09-07 while the TUI work preceding the failures ran on 2026-09-11 — it was rescued only because it had been in Chat days earlier. Since #4424's own reproduction is "Stop now and switch" on a busy TUI turn, this is plausibly the more common shape.
- **A turn cancelled before its user message is projected**, which leaves no matching row either. (Raised by @Pulkit7070 in review.)

Extending the guard to those would mean distrusting the hook text with no evidence — in practice, after a previous `TARGET_HISTORY_UNSETTLED` failure — which imports possibly-stale provider history automatically. That is what #4466 puts behind explicit consent via **Use provider history**, and it belongs in that trust model rather than in an interim guard.

## Impact

Within the evidenced subset, a poisoned session recovers on its next switch attempt with no SQL edit and no migration. Outside it, the behaviour is unchanged and #4466 remains the fix.

Today the only escape from any of these is `update sessions set latest_user_prompt='' where id='<session>'` against `ao.db`, which is not something a user can reasonably be asked to do — the switch simply keeps failing with no actionable UI, and on mobile the screen bounces back to Terminal with nothing surfaced at all.
