### PR TITLE
Restore the all sessions board

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -638,6 +638,15 @@ describe("Sidebar", () => {
 		expect(await screen.findByRole("dialog", { name: "Add a project" })).toBeInTheDocument();
 	});
 
+	it("opens the all sessions board from the AO logo", async () => {
+		const user = userEvent.setup();
+		renderSidebar();
+
+		await user.click(screen.getByRole("button", { name: "Open all sessions" }));
+
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions" });
+	});
+
 	it("keeps the create-project shortcut available when there are no projects", async () => {
 		renderSidebar({ workspaces: [] });
 

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -356,6 +356,7 @@ function useSelection() {
 		select: (state) => state.location.pathname,
 	});
 	const goHome = useCallback(() => void navigate({ to: "/" }), [navigate]);
+	const goAllSessions = useCallback(() => void navigate({ to: "/sessions" }), [navigate]);
 	const goGlobalSettings = useCallback(() => openGlobalSettings(), [openGlobalSettings]);
 	const goConnectMobile = useCallback(() => openGlobalSettings("mobile"), [openGlobalSettings]);
 	const goSettings = useCallback((projectId: string) => openProjectSettings(projectId), [openProjectSettings]);
@@ -373,9 +374,11 @@ function useSelection() {
 	);
 	return useMemo(() => ({
 		isHome: pathname === "/",
+		isAllSessions: pathname === "/sessions",
 		activeProjectId: params.projectId,
 		activeSessionId: params.sessionId,
 		goHome,
+		goAllSessions,
 		// Settings is a modal — open it in place so the current page (session
 		// terminal, board, etc.) stays underneath.
 		goGlobalSettings,
@@ -383,7 +386,7 @@ function useSelection() {
 		goSettings,
 		goProject,
 		goSession,
-	}), [goConnectMobile, goGlobalSettings, goHome, goProject, goSession, goSettings, params.projectId, params.sessionId, pathname]);
+	}), [goAllSessions, goConnectMobile, goGlobalSettings, goHome, goProject, goSession, goSettings, params.projectId, params.sessionId, pathname]);
 }
 
 // Colour tracks the session's board section, preserving SCM state while the
@@ -660,14 +663,18 @@ export function Sidebar({
 						commandPaletteEnabled ? "pb-2" : "pb-3",
 					)}
 				>
-					<span
+					<button
+						aria-label={t("shell.openAllSessions")}
 						className={cn(
-							"grid h-5.5 w-5.5 shrink-0 place-items-center",
-							"group-data-[collapsible=icon]:size-control-board group-data-[collapsible=icon]:rounded-lg",
+							"grid h-5.5 w-5.5 shrink-0 place-items-center rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent/50",
+							"group-data-[collapsible=icon]:size-control-board group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:hover:bg-interactive-hover",
+							selection.isAllSessions && "group-data-[collapsible=icon]:bg-interactive-active",
 						)}
+						onClick={selection.goAllSessions}
+						type="button"
 					>
 						<img src={aoLogo} alt="" aria-hidden="true" className="h-5.5 w-5.5 -translate-y-[3px] rounded-md object-cover" />
-					</span>
+					</button>
 					{isWindows ? (
 						<span
 							className="sidebar-expanded-chrome min-w-0 flex-1 truncate text-sm font-bold leading-tight tracking-tight-lg text-foreground group-data-[collapsible=icon]:hidden"

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1187,6 +1187,7 @@
 	"shell.nightly": "nightly",
 	"shell.openInspector": "Inspektor-Panel öffnen",
 	"shell.openInspectorTitle": "Inspektor öffnen · ⌘⇧B",
+	"shell.openAllSessions": "Alle Sitzungen öffnen",
 	"shell.openKanban": "Kanban öffnen",
 	"shell.openProjectDashboard": "Dashboard von {{name}} öffnen",
 	"shell.openProjectOrchestrator": "Orchestrator von {{name}} öffnen",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -1308,6 +1308,7 @@
 	"shell.nightly": "nightly",
 	"shell.openInspector": "Open inspector panel",
 	"shell.openInspectorTitle": "Open inspector · ⌘⇧B",
+	"shell.openAllSessions": "Open all sessions",
 	"shell.openKanban": "Open Kanban",
 	"shell.openProjectDashboard": "Open {{name}} dashboard",
 	"shell.openProjectOrchestrator": "Open {{name}} orchestrator",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1208,6 +1208,7 @@
 	"shell.nightly": "nightly",
 	"shell.openInspector": "Abrir panel del inspector",
 	"shell.openInspectorTitle": "Abrir inspector · ⌘⇧B",
+	"shell.openAllSessions": "Abrir todas las sesiones",
 	"shell.openKanban": "Abrir Kanban",
 	"shell.openProjectDashboard": "Abrir panel de {{name}}",
 	"shell.openProjectOrchestrator": "Abrir orquestador de {{name}}",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1208,6 +1208,7 @@
 	"shell.nightly": "nightly",
 	"shell.openInspector": "Ouvrir le panneau inspecteur",
 	"shell.openInspectorTitle": "Ouvrir l'inspecteur · ⌘⇧B",
+	"shell.openAllSessions": "Ouvrir toutes les sessions",
 	"shell.openKanban": "Ouvrir le Kanban",
 	"shell.openProjectDashboard": "Ouvrir le tableau de bord de {{name}}",
 	"shell.openProjectOrchestrator": "Ouvrir l'orchestrateur de {{name}}",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1187,6 +1187,7 @@
 	"shell.nightly": "nightly",
 	"shell.openInspector": "インスペクターパネルを開く",
 	"shell.openInspectorTitle": "インスペクターを開く · ⌘⇧B",
+	"shell.openAllSessions": "すべてのセッションを開く",
 	"shell.openKanban": "カンバンを開く",
 	"shell.openProjectDashboard": "{{name}} のダッシュボードを開く",
 	"shell.openProjectOrchestrator": "{{name}} のオーケストレーターを開く",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1187,6 +1187,7 @@
 	"shell.nightly": "nightly",
 	"shell.openInspector": "인스펙터 패널 열기",
 	"shell.openInspectorTitle": "인스펙터 열기 · ⌘⇧B",
+	"shell.openAllSessions": "모든 세션 열기",
 	"shell.openKanban": "칸반 열기",
 	"shell.openProjectDashboard": "{{name}} 대시보드 열기",
 	"shell.openProjectOrchestrator": "{{name}} 오케스트레이터 열기",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1208,6 +1208,7 @@
 	"shell.nightly": "nightly",
 	"shell.openInspector": "Abrir painel do inspetor",
 	"shell.openInspectorTitle": "Abrir inspetor · ⌘⇧B",
+	"shell.openAllSessions": "Abrir todas as sessões",
 	"shell.openKanban": "Abrir Kanban",
 	"shell.openProjectDashboard": "Abrir painel de {{name}}",
 	"shell.openProjectOrchestrator": "Abrir orchestrator de {{name}}",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1171,6 +1171,7 @@
 	"shell.nightly": "每日构建",
 	"shell.openInspector": "打开检查器面板",
 	"shell.openInspectorTitle": "打开检查器 · ⌘⇧B",
+	"shell.openAllSessions": "打开所有会话",
 	"shell.openKanban": "打开看板",
 	"shell.openProjectDashboard": "打开 {{name}} 看板",
 	"shell.openProjectOrchestrator": "打开 {{name}} 编排器",

--- a/frontend/src/renderer/routeTree.gen.ts
+++ b/frontend/src/renderer/routeTree.gen.ts
@@ -13,6 +13,8 @@ import { Route as ShellRouteImport } from './routes/_shell'
 import { Route as ShellIndexRouteImport } from './routes/_shell.index'
 import { Route as ShellTerminalsRouteImport } from './routes/_shell.terminals'
 import { Route as ShellSettingsRouteImport } from './routes/_shell.settings'
+import { Route as ShellSessionsRouteImport } from './routes/_shell.sessions'
+import { Route as ShellSessionsIndexRouteImport } from './routes/_shell.sessions.index'
 import { Route as ShellSessionsSessionIdRouteImport } from './routes/_shell.sessions.$sessionId'
 import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.projects.$projectId'
 import { Route as ShellProjectsProjectIdSettingsRouteImport } from './routes/_shell.projects.$projectId_.settings'
@@ -37,10 +39,20 @@ const ShellSettingsRoute = ShellSettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => ShellRoute,
 } as any)
-const ShellSessionsSessionIdRoute = ShellSessionsSessionIdRouteImport.update({
-  id: '/sessions/$sessionId',
-  path: '/sessions/$sessionId',
+const ShellSessionsRoute = ShellSessionsRouteImport.update({
+  id: '/sessions',
+  path: '/sessions',
   getParentRoute: () => ShellRoute,
+} as any)
+const ShellSessionsIndexRoute = ShellSessionsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ShellSessionsRoute,
+} as any)
+const ShellSessionsSessionIdRoute = ShellSessionsSessionIdRouteImport.update({
+  id: '/$sessionId',
+  path: '/$sessionId',
+  getParentRoute: () => ShellSessionsRoute,
 } as any)
 const ShellProjectsProjectIdRoute = ShellProjectsProjectIdRouteImport.update({
   id: '/projects/$projectId',
@@ -62,10 +74,12 @@ const ShellProjectsProjectIdSessionsSessionIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof ShellIndexRoute
+  '/sessions': typeof ShellSessionsRouteWithChildren
   '/settings': typeof ShellSettingsRoute
   '/terminals': typeof ShellTerminalsRoute
   '/projects/$projectId': typeof ShellProjectsProjectIdRoute
   '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
+  '/sessions/': typeof ShellSessionsIndexRoute
   '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
   '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
@@ -75,17 +89,20 @@ export interface FileRoutesByTo {
   '/': typeof ShellIndexRoute
   '/projects/$projectId': typeof ShellProjectsProjectIdRoute
   '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
+  '/sessions': typeof ShellSessionsIndexRoute
   '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
   '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_shell': typeof ShellRouteWithChildren
+  '/_shell/sessions': typeof ShellSessionsRouteWithChildren
   '/_shell/settings': typeof ShellSettingsRoute
   '/_shell/terminals': typeof ShellTerminalsRoute
   '/_shell/': typeof ShellIndexRoute
   '/_shell/projects/$projectId': typeof ShellProjectsProjectIdRoute
   '/_shell/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
+  '/_shell/sessions/': typeof ShellSessionsIndexRoute
   '/_shell/projects/$projectId_/settings': typeof ShellProjectsProjectIdSettingsRoute
   '/_shell/projects/$projectId_/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
@@ -93,10 +110,12 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/sessions'
     | '/settings'
     | '/terminals'
     | '/projects/$projectId'
     | '/sessions/$sessionId'
+    | '/sessions/'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/sessions/$sessionId'
   fileRoutesByTo: FileRoutesByTo
@@ -106,16 +125,19 @@ export interface FileRouteTypes {
     | '/'
     | '/projects/$projectId'
     | '/sessions/$sessionId'
+    | '/sessions'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/sessions/$sessionId'
   id:
     | '__root__'
     | '/_shell'
+    | '/_shell/sessions'
     | '/_shell/settings'
     | '/_shell/terminals'
     | '/_shell/'
     | '/_shell/projects/$projectId'
     | '/_shell/sessions/$sessionId'
+    | '/_shell/sessions/'
     | '/_shell/projects/$projectId_/settings'
     | '/_shell/projects/$projectId_/sessions/$sessionId'
   fileRoutesById: FileRoutesById
@@ -154,12 +176,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShellSettingsRouteImport
       parentRoute: typeof ShellRoute
     }
+    '/_shell/sessions': {
+      id: '/_shell/sessions'
+      path: '/sessions'
+      fullPath: '/sessions'
+      preLoaderRoute: typeof ShellSessionsRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/sessions/': {
+      id: '/_shell/sessions/'
+      path: '/'
+      fullPath: '/sessions/'
+      preLoaderRoute: typeof ShellSessionsIndexRouteImport
+      parentRoute: typeof ShellSessionsRoute
+    }
     '/_shell/sessions/$sessionId': {
       id: '/_shell/sessions/$sessionId'
-      path: '/sessions/$sessionId'
+      path: '/$sessionId'
       fullPath: '/sessions/$sessionId'
       preLoaderRoute: typeof ShellSessionsSessionIdRouteImport
-      parentRoute: typeof ShellRoute
+      parentRoute: typeof ShellSessionsRoute
     }
     '/_shell/projects/$projectId': {
       id: '/_shell/projects/$projectId'
@@ -185,22 +221,36 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface ShellSessionsRouteChildren {
+  ShellSessionsSessionIdRoute: typeof ShellSessionsSessionIdRoute
+  ShellSessionsIndexRoute: typeof ShellSessionsIndexRoute
+}
+
+const ShellSessionsRouteChildren: ShellSessionsRouteChildren = {
+  ShellSessionsSessionIdRoute: ShellSessionsSessionIdRoute,
+  ShellSessionsIndexRoute: ShellSessionsIndexRoute,
+}
+
+const ShellSessionsRouteWithChildren = ShellSessionsRoute._addFileChildren(
+  ShellSessionsRouteChildren,
+)
+
 interface ShellRouteChildren {
+  ShellSessionsRoute: typeof ShellSessionsRouteWithChildren
   ShellSettingsRoute: typeof ShellSettingsRoute
   ShellTerminalsRoute: typeof ShellTerminalsRoute
   ShellIndexRoute: typeof ShellIndexRoute
   ShellProjectsProjectIdRoute: typeof ShellProjectsProjectIdRoute
-  ShellSessionsSessionIdRoute: typeof ShellSessionsSessionIdRoute
   ShellProjectsProjectIdSettingsRoute: typeof ShellProjectsProjectIdSettingsRoute
   ShellProjectsProjectIdSessionsSessionIdRoute: typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
 
 const ShellRouteChildren: ShellRouteChildren = {
+  ShellSessionsRoute: ShellSessionsRouteWithChildren,
   ShellSettingsRoute: ShellSettingsRoute,
   ShellTerminalsRoute: ShellTerminalsRoute,
   ShellIndexRoute: ShellIndexRoute,
   ShellProjectsProjectIdRoute: ShellProjectsProjectIdRoute,
-  ShellSessionsSessionIdRoute: ShellSessionsSessionIdRoute,
   ShellProjectsProjectIdSettingsRoute: ShellProjectsProjectIdSettingsRoute,
   ShellProjectsProjectIdSessionsSessionIdRoute:
     ShellProjectsProjectIdSessionsSessionIdRoute,

--- a/frontend/src/renderer/routes/_shell.sessions.index.tsx
+++ b/frontend/src/renderer/routes/_shell.sessions.index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SessionsBoard } from "../components/SessionsBoard";
+
+export const Route = createFileRoute("/_shell/sessions/")({
+	component: AllSessionsBoardRoute,
+});
+
+function AllSessionsBoardRoute() {
+	return <SessionsBoard />;
+}

--- a/frontend/src/renderer/routes/_shell.sessions.tsx
+++ b/frontend/src/renderer/routes/_shell.sessions.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_shell/sessions")({
+	component: SessionsRoute,
+});
+
+function SessionsRoute() {
+	return <Outlet />;
+}


### PR DESCRIPTION
## Summary

- add a cross-project sessions board at `/sessions`
- make the AO logo an accessible sidebar entry point for the board
- preserve existing projectless session deep links through a nested route outlet
- localize the new navigation label across supported languages

## Testing

- `npx vite build --config vite.renderer.config.ts`
- `npm --prefix frontend test -- Sidebar SessionsBoard instance`
- `npm run frontend:typecheck`

Closes #4809