### PR TITLE
Preserve tracker intake configuration on settings saves

### DIFF
--- a/frontend/src/renderer/components/IntakeFields.tsx
+++ b/frontend/src/renderer/components/IntakeFields.tsx
@@ -34,10 +34,13 @@ export function intakeNeedsRule(form: IntakeForm): boolean {
 // buildIntake produces the payload field, scrubbing empties so a disabled or
 // blank intake serializes to `undefined` (omit) rather than an empty object the
 // daemon would persist.
-export function buildIntake(form: IntakeForm): TrackerIntakeConfig | undefined {
+export function buildIntake(
+	form: IntakeForm,
+	existing?: TrackerIntakeConfig,
+): TrackerIntakeConfig | undefined {
 	const next: TrackerIntakeConfig = {
+		...existing,
 		enabled: form.enabled || undefined,
-		provider: undefined,
 		repo: form.repo.trim() || undefined,
 		assignee: form.assignee.trim() || undefined,
 	};

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -1527,6 +1527,48 @@ describe("ProjectSettingsForm", () => {
 		});
 	});
 
+	it("preserves explicit provider and unmodeled tracker intake fields on save", async () => {
+		getMock.mockResolvedValue({
+			data: {
+				status: "ok",
+				project: {
+					id: "proj-1",
+					name: "Project One",
+					kind: "single_repo",
+					path: "/repo/project-one",
+					repo: "git@gitlab.example.com:acme/project-one.git",
+					defaultBranch: "main",
+					config: {
+						worker: { agent: "codex" },
+						orchestrator: { agent: "claude-code" },
+						trackerIntake: {
+							enabled: true,
+							provider: "gitlab",
+							repo: "acme/project-one",
+							assignee: "octocat",
+							labels: ["agent-ready"],
+						},
+					},
+				},
+			},
+			error: undefined,
+		});
+
+		renderSettings("proj-1", undefined, "general");
+		await screen.findByRole("button", { name: "Edit Project name" });
+		submitSettings();
+
+		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+		const body = putMock.mock.calls[0]?.[1]?.body;
+		expect(body.config.trackerIntake).toEqual({
+			enabled: true,
+			provider: "gitlab",
+			repo: "acme/project-one",
+			assignee: "octocat",
+			labels: ["agent-ready"],
+		});
+	});
+
 	it("blocks save when intake is enabled with no assignee", async () => {
 		getMock.mockResolvedValue({
 			data: {

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -249,7 +249,7 @@ function SettingsBody({
 									},
 								]
 							: undefined,
-						trackerIntake: buildIntake(intakeForm),
+						trackerIntake: buildIntake(intakeForm, config.trackerIntake),
 						autoReview: form.autoReview,
 					};
 			const { error } = await apiClient.PUT("/api/v1/projects/{id}", {


### PR DESCRIPTION
## Summary

- preserve the existing tracker provider and forward-compatible intake fields when project settings are saved
- continue applying the intake fields modeled by the dashboard over the preserved configuration
- add regression coverage for unrelated saves with explicit GitLab intake configuration

## Validation

- `npm test -- --run src/renderer/components/ProjectSettingsForm.test.tsx` (41 tests)
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run typecheck:e2e`
- `npm run product-ui:check` (126 tests)
- `npm run cloud:check` (21 tests)

The full frontend suite was attempted, but the shared runner became resource-starved while several parallel issue branches were validating. It produced unrelated timeouts in browser history, global settings, and landing tests before being stopped. The focused suite and all typechecks pass; remote CI will run the full isolated suite.

Closes #2283
