### PR TITLE
docs: add desktop lab runbook for agent-run UI review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,24 @@ npm run build
 
 When showing or demoing frontend changes, run `ao preview [url]` from inside the session so the change renders in the desktop browser panel (the inspector rail's Browser tab); do not just describe it.
 
+### Desktop lab (running the real Electron app for UI review)
+
+For visual verification that needs the real app rather than `ao preview` or `dev:web`, run the checkout in an isolated worktree against scratch data. Never use the invoking working tree (it may hold unrelated uncommitted work) and never touch the user's real `~/.ao` data.
+
+```bash
+git worktree add /tmp/ao-lab <branch>   # the PR branch under review
+cd /tmp/ao-lab/frontend
+npm ci                                  # never symlink node_modules from another checkout (see below)
+npm run build:daemon -- --dev
+AO_DATA_DIR=/tmp/ao-lab-data ./node_modules/.bin/electron-forge start
+```
+
+- **Run a real `npm ci`.** Symlinking another checkout's `node_modules` makes React resolve from two physical paths and shares the Vite optimizer cache across checkouts: the symptom is a black window with `Invalid hook call` / `useSyncExternalStore` errors in the renderer console. It also writes `.vite/deps` output into the other checkout's tree.
+- **Isolate data with `AO_DATA_DIR`.** The lab starts with an empty board; create throwaway sessions inside it to exercise list/detail flows. The Electron `userData` dir already defaults to a dev path, not the production one.
+- **Diagnose with `ELECTRON_ENABLE_LOGGING=1`.** Renderer console errors (the cause of most blank windows) land in the launcher's stdout.
+- **Killing the forge wrapper is not enough.** The Electron main process cmdline is just `Electron .`, so `pkill -f electron-forge` leaves the app running and the next launch exits silently. Kill the `Electron.app/.../MacOS/Electron` main process explicitly before relaunching.
+- A missing-dependency warning for a lazily imported module (for example `mermaid`, which is dynamically imported on first use) does not blank the window; treat it as informational.
+
 ## Where to look first
 
 - `README.md` — current run/config/test quickstart.


### PR DESCRIPTION
Documents the isolated-worktree Electron lab flow (real npm ci, AO_DATA_DIR scratch data, ELECTRON_ENABLE_LOGGING diagnosis, fully killing orphaned Electron mains) so agents verifying UI changes stop hitting the symlinked-node_modules black window and silent relaunch failures. Distilled from the PR #5249 local review session. Frontend-only docs change; no runtime behavior.