### PR TITLE
feat(desktop): link a session's issue reference to its forge page

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -1409,6 +1409,30 @@ describe("SessionsBoard", () => {
 		]);
 	});
 
+	it("opens the session's tracker issue in a new tab from the board card", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				workspaceWithSessions([
+					boardSession({
+						id: "s-issue",
+						title: "intake worker",
+						status: "idle",
+						issueId: "github:acme/demo#12",
+					}),
+				]),
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		const issue = screen.getByRole("link", { name: "Intake issue: #12" });
+		expect(issue).toHaveAttribute("href", "https://github.com/acme/demo/issues/12");
+		expect(issue).toHaveAttribute("target", "_blank");
+		expect(issue).toHaveTextContent("#12");
+	});
+
 	it("uses the shared minimal scrollbar styling for every Kanban lane", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [

--- a/frontend/src/renderer/components/SessionsBoardAdapters.tsx
+++ b/frontend/src/renderer/components/SessionsBoardAdapters.tsx
@@ -26,6 +26,7 @@ import {
 } from "../lib/agent-switch-presentation";
 import type { WorkspaceSession } from "../types/workspace";
 import { canonicalTrackerIssueId } from "../types/workspace";
+import { trackerIssueLink } from "../lib/issue-url";
 import { useSessionScmSummary } from "../hooks/useSessionScmSummary";
 import type { SessionUsageSummary } from "../hooks/useSessionUsageSummaries";
 import {
@@ -44,6 +45,7 @@ export function toBoardSessionPresentation(
 ): BoardSessionPresentation {
 	const switchPresentation = deriveSessionAgentSwitchPresentation(session);
 	const switchVisual = switchPresentation ? agentSwitchStatusVisual(switchPresentation) : undefined;
+	const issueLink = trackerIssueLink(session.issueId);
 	return {
 		activity: session.activity,
 		branch: session.branch,
@@ -64,6 +66,8 @@ export function toBoardSessionPresentation(
 				: undefined,
 		title: session.title,
 		trackerIssueId: canonicalTrackerIssueId(session.issueId),
+		trackerIssueLabel: issueLink?.label,
+		trackerIssueUrl: issueLink?.url,
 		updatedAt: session.updatedAt,
 		lastUserMessageAt: session.lastUserMessageAt,
 	};

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -227,6 +227,20 @@ describe("ShellTopbar status pill", () => {
 		expect(identity.querySelector(".workspace-topbar__identity-separator")).not.toBeNull();
 	});
 
+	it("links the worker's tracker issue in the topbar when the repo is in the id", () => {
+		renderTopbar(sessionWith({ issueId: "github:acme/demo#12" }));
+
+		const issue = screen.getByRole("link", { name: "Intake issue: acme/demo#12" });
+		expect(issue).toHaveAttribute("href", "https://github.com/acme/demo/issues/12");
+		expect(issue).toHaveTextContent("#12");
+	});
+
+	it("does not invent an issue link for a number-only or missing tracker id", () => {
+		renderTopbar(sessionWith({ issueId: "github:42" }));
+
+		expect(screen.queryByRole("link", { name: /intake issue/i })).not.toBeInTheDocument();
+	});
+
 	it("shows project identity and activity without redundant Orchestrator text", () => {
 		renderTopbar(
 			sessionWith({

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -30,6 +30,8 @@ import { isLinuxPlatform, isMacPlatform, usesBoardActionsInPanel } from "../lib/
 import { cn } from "../lib/utils";
 import { SHELL_PANEL_SPRING } from "../lib/motion-spring";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
+import { trackerIssueLink } from "../lib/issue-url";
+import { ProductExternalLink } from "./ProductExternalLink";
 import { StatusPill } from "./StatusPill";
 import { TopbarActionError, TopbarButton, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
 import { SessionTerminationPopover } from "./SessionTerminationPopover";
@@ -117,6 +119,7 @@ export function ShellTopbar({
 	const session = workspaceScope?.session;
 	const isSessionRoute = Boolean(params.sessionId);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
+	const issueLink = session && !isOrchestrator ? trackerIssueLink(session.issueId) : undefined;
 	// Project in scope: the session's workspace wins over the route param so the
 	// cross-project /sessions/$sessionId route still resolves a crumb. A
 	// projectId that no longer resolves (stale route after the project was
@@ -233,7 +236,18 @@ export function ShellTopbar({
 								<span className="max-w-content-max truncate">{projectLabel}</span>
 							</span>
 						) : (
-							<span className={cn(topbarProjectLabelClass, "max-w-content-max truncate")}>{session.title}</span>
+							<span className="inline-flex min-w-0 items-center gap-1.5">
+								<span className={cn(topbarProjectLabelClass, "max-w-content-max truncate")}>{session.title}</span>
+								{issueLink ? (
+									<ProductExternalLink
+										ariaLabel={t("shell.intakeIssue", { id: issueLink.nativeId })}
+										className="shrink-0 font-mono text-xs text-muted-foreground hover:underline"
+										href={issueLink.url}
+									>
+										{issueLink.label}
+									</ProductExternalLink>
+								) : null}
+							</span>
 						)}
 						<span aria-hidden="true" className="workspace-topbar__identity-separator" />
 						<SessionStatusPill session={session} />

--- a/frontend/src/renderer/lib/issue-url.test.ts
+++ b/frontend/src/renderer/lib/issue-url.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { trackerIssueLink } from "./issue-url";
+
+describe("trackerIssueLink", () => {
+	it("links GitHub intake ids that already include owner/repo", () => {
+		expect(trackerIssueLink("github:acme/demo#12")).toEqual({
+			url: "https://github.com/acme/demo/issues/12",
+			label: "#12",
+			nativeId: "acme/demo#12",
+		});
+	});
+
+	it("links GitLab.com and self-managed canonical ids", () => {
+		expect(trackerIssueLink("gitlab:group/project#7")).toEqual({
+			url: "https://gitlab.com/group/project/-/issues/7",
+			label: "#7",
+			nativeId: "group/project#7",
+		});
+		expect(trackerIssueLink("gitlab:group/sub/project#9@gitlab.internal")).toEqual({
+			url: "https://gitlab.internal/group/sub/project/-/issues/9",
+			label: "#9",
+			nativeId: "group/sub/project#9",
+		});
+		expect(trackerIssueLink("gitlab:group/repo#7@gitlab.local:8443")).toEqual({
+			url: "https://gitlab.local:8443/group/repo/-/issues/7",
+			label: "#7",
+			nativeId: "group/repo#7",
+		});
+	});
+
+	it("links issue web URLs and ignores pull-request paths", () => {
+		expect(trackerIssueLink("https://github.com/acme/demo/issues/12")).toEqual({
+			url: "https://github.com/acme/demo/issues/12",
+			label: "#12",
+			nativeId: "acme/demo#12",
+		});
+		expect(trackerIssueLink("https://gitlab.com/group/project/-/issues/7")).toEqual({
+			url: "https://gitlab.com/group/project/-/issues/7",
+			label: "#7",
+			nativeId: "group/project#7",
+		});
+		expect(trackerIssueLink("https://github.com/acme/demo/pull/12")).toBeUndefined();
+	});
+
+	it("does not guess a repo for number-only or non-tracker ids", () => {
+		expect(trackerIssueLink("github:42")).toBeUndefined();
+		expect(trackerIssueLink("42")).toBeUndefined();
+		expect(trackerIssueLink("github:INT-17")).toBeUndefined();
+		expect(trackerIssueLink("Fix the renderer")).toBeUndefined();
+		expect(trackerIssueLink(undefined)).toBeUndefined();
+	});
+
+	it("resolves a bare number only against a single project origin", () => {
+		expect(
+			trackerIssueLink("github:42", { originUrl: "https://github.com/acme/demo.git" }),
+		).toEqual({
+			url: "https://github.com/acme/demo/issues/42",
+			label: "#42",
+			nativeId: "acme/demo#42",
+		});
+		expect(
+			trackerIssueLink("7", { originUrl: "git@gitlab.internal:group/project.git" }),
+		).toEqual({
+			url: "https://gitlab.internal/group/project/-/issues/7",
+			label: "#7",
+			nativeId: "group/project#7",
+		});
+		expect(trackerIssueLink("42", { originUrl: "" })).toBeUndefined();
+	});
+});

--- a/frontend/src/renderer/lib/issue-url.test.ts
+++ b/frontend/src/renderer/lib/issue-url.test.ts
@@ -50,7 +50,7 @@ describe("trackerIssueLink", () => {
 		expect(trackerIssueLink(undefined)).toBeUndefined();
 	});
 
-	it("resolves a bare number only against a single project origin", () => {
+	it("resolves a bare number only against a single project origin (unused by board/topbar today)", () => {
 		expect(
 			trackerIssueLink("github:42", { originUrl: "https://github.com/acme/demo.git" }),
 		).toEqual({

--- a/frontend/src/renderer/lib/issue-url.ts
+++ b/frontend/src/renderer/lib/issue-url.ts
@@ -41,6 +41,9 @@ export function trackerIssueLink(
 	const canonical = parseCanonicalIssueId(raw);
 	if (canonical) return toLink(canonical);
 
+	// Future-proofing: board/topbar currently pass only `issueId`, so this
+	// origin-backed path is unused in production. Keep it so a later caller
+	// can supply a single project origin without guessing from PRs.
 	const number = parseBareIssueNumber(raw);
 	if (number === undefined) return undefined;
 	const fromOrigin = parseOrigin(project?.originUrl);

--- a/frontend/src/renderer/lib/issue-url.ts
+++ b/frontend/src/renderer/lib/issue-url.ts
@@ -1,0 +1,185 @@
+/**
+ * Turn a session issue id into a forge URL when the repository is unambiguous.
+ *
+ * Intake stamps `github:owner/repo#12` / `gitlab:group/repo#7[@host]`. Those
+ * already name the repo, so they link without consulting the project. A bare
+ * number (`42`, `github:42`) only links when the caller supplies exactly one
+ * project origin — never by guessing from a PR or a multi-repo workspace.
+ */
+
+export type TrackerIssueLink = {
+	url: string;
+	label: string;
+	nativeId: string;
+};
+
+export type ProjectIssueOrigin = {
+	/** HTTPS or SSH origin for the project's single repository. */
+	originUrl?: string;
+};
+
+type CanonicalIssue = {
+	provider: "github" | "gitlab";
+	repo: string;
+	number: number;
+	host?: string;
+};
+
+const PROVIDER_PREFIX = /^(github|gitlab):/i;
+
+export function trackerIssueLink(
+	issueId?: string,
+	project?: ProjectIssueOrigin,
+): TrackerIssueLink | undefined {
+	const raw = issueId?.trim();
+	if (!raw) return undefined;
+
+	if (/^https?:\/\//i.test(raw)) {
+		return linkFromWebUrl(raw);
+	}
+
+	const canonical = parseCanonicalIssueId(raw);
+	if (canonical) return toLink(canonical);
+
+	const number = parseBareIssueNumber(raw);
+	if (number === undefined) return undefined;
+	const fromOrigin = parseOrigin(project?.originUrl);
+	if (!fromOrigin) return undefined;
+	return toLink({ ...fromOrigin, number });
+}
+
+function toLink(issue: CanonicalIssue): TrackerIssueLink | undefined {
+	const url = issueUrl(issue);
+	if (!url) return undefined;
+	return {
+		url,
+		label: `#${issue.number}`,
+		nativeId: `${issue.repo}#${issue.number}`,
+	};
+}
+
+function parseCanonicalIssueId(raw: string): CanonicalIssue | undefined {
+	const match = /^(github|gitlab):(.+)#(\d+)(?:@(.+))?$/i.exec(raw);
+	if (!match) return undefined;
+	const provider = match[1].toLowerCase() as CanonicalIssue["provider"];
+	const repo = normalizeRepoPath(match[2]);
+	const number = Number(match[3]);
+	const host = match[4]?.trim();
+	if (!Number.isInteger(number) || number <= 0 || !isPlausibleRepo(provider, repo)) return undefined;
+	return { provider, repo, number, host: host || undefined };
+}
+
+function parseBareIssueNumber(raw: string): number | undefined {
+	const stripped = raw.replace(PROVIDER_PREFIX, "").replace(/^#/, "");
+	if (!/^\d+$/.test(stripped)) return undefined;
+	const number = Number(stripped);
+	return Number.isInteger(number) && number > 0 ? number : undefined;
+}
+
+function linkFromWebUrl(raw: string): TrackerIssueLink | undefined {
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		return undefined;
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+
+	const gitlab = parseGitLabIssuePath(url.pathname);
+	if (gitlab) {
+		return toLink({
+			provider: "gitlab",
+			repo: gitlab.repo,
+			number: gitlab.number,
+			host: gitlabHost(url.host),
+		});
+	}
+
+	const github = parseGitHubIssuePath(url.pathname);
+	if (!github || !isGitHubHost(url.hostname)) return undefined;
+	return toLink({ provider: "github", repo: github.repo, number: github.number });
+}
+
+function parseOrigin(originUrl?: string): Omit<CanonicalIssue, "number"> | undefined {
+	const raw = originUrl?.trim();
+	if (!raw) return undefined;
+	const normalized = sshToHttps(raw);
+	let url: URL;
+	try {
+		url = new URL(normalized);
+	} catch {
+		return undefined;
+	}
+	const repoPath = normalizeRepoPath(url.pathname);
+	if (!repoPath) return undefined;
+	if (isGitHubHost(url.hostname)) {
+		if (!isPlausibleRepo("github", repoPath)) return undefined;
+		return { provider: "github", repo: repoPath };
+	}
+	if (!isPlausibleRepo("gitlab", repoPath)) return undefined;
+	return { provider: "gitlab", repo: repoPath, host: gitlabHost(url.host) };
+}
+
+function issueUrl(issue: CanonicalIssue): string | undefined {
+	if (issue.provider === "github") {
+		const host = issue.host?.trim() || "github.com";
+		return `https://${host}/${issue.repo}/issues/${issue.number}`;
+	}
+	const host = issue.host?.trim() || "gitlab.com";
+	return `https://${host}/${issue.repo}/-/issues/${issue.number}`;
+}
+
+function parseGitHubIssuePath(pathname: string): { repo: string; number: number } | undefined {
+	const match = /^\/([^/]+\/[^/]+)\/issues\/(\d+)\/?$/.exec(pathname);
+	if (!match) return undefined;
+	const number = Number(match[2]);
+	const repo = normalizeRepoPath(match[1]);
+	if (!Number.isInteger(number) || number <= 0 || !isPlausibleRepo("github", repo)) return undefined;
+	return { repo, number };
+}
+
+function parseGitLabIssuePath(pathname: string): { repo: string; number: number } | undefined {
+	const idx = pathname.indexOf("/-/issues/");
+	if (idx <= 0) return undefined;
+	const repo = normalizeRepoPath(pathname.slice(0, idx));
+	const rest = pathname.slice(idx + "/-/issues/".length).replace(/\/$/, "");
+	if (!/^\d+$/.test(rest)) return undefined;
+	const number = Number(rest);
+	if (!Number.isInteger(number) || number <= 0 || !isPlausibleRepo("gitlab", repo)) return undefined;
+	return { repo, number };
+}
+
+function isPlausibleRepo(provider: CanonicalIssue["provider"], repo: string): boolean {
+	const parts = repo.split("/");
+	if (parts.some((part) => part === "")) return false;
+	if (provider === "github") return parts.length === 2;
+	return parts.length >= 2;
+}
+
+function normalizeRepoPath(path: string): string {
+	const parts = path
+		.split("/")
+		.map((part) => part.trim())
+		.filter(Boolean);
+	if (parts.length === 0) return "";
+	parts[parts.length - 1] = parts[parts.length - 1].replace(/\.git$/i, "");
+	return parts.join("/");
+}
+
+function sshToHttps(raw: string): string {
+	if (!raw.startsWith("git@")) return raw;
+	const cut = raw.indexOf(":");
+	if (cut <= 4) return raw;
+	return `https://${raw.slice(4, cut)}/${raw.slice(cut + 1)}`;
+}
+
+function isGitHubHost(hostname: string): boolean {
+	const host = hostname.toLowerCase().replace(/^www\./, "");
+	return host === "github.com" || host.endsWith(".github.com") || host.endsWith(".ghe.io");
+}
+
+function gitlabHost(host: string): string | undefined {
+	const normalized = host.toLowerCase();
+	if (normalized === "gitlab.com" || normalized === "www.gitlab.com") return undefined;
+	return host;
+}

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -26,6 +26,7 @@ import {
 describe("canonicalTrackerIssueId", () => {
 	it("keeps provider-prefixed intake ids and rejects manual task titles", () => {
 		expect(canonicalTrackerIssueId("github:acme/project#42")).toBe("github:acme/project#42");
+		expect(canonicalTrackerIssueId("gitlab:group/repo#7")).toBe("gitlab:group/repo#7");
 		expect(canonicalTrackerIssueId("Fix fallback renderer")).toBeUndefined();
 		expect(canonicalTrackerIssueId(undefined)).toBeUndefined();
 	});

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -164,7 +164,7 @@ export type WorkspaceSession = {
 // "<provider>:<native>" form. Adding a provider (Linear, Jira, ...) later is
 // just another prefix in this list — no caller of canonicalTrackerIssueId
 // needs to change.
-const TRACKER_PROVIDER_PREFIXES = ["github:"] as const;
+const TRACKER_PROVIDER_PREFIXES = ["github:", "gitlab:"] as const;
 
 /**
  * The provider-prefixed issue id if `issueId` came from tracker intake, or

--- a/packages/product-ui/src/SessionsBoardView.test.tsx
+++ b/packages/product-ui/src/SessionsBoardView.test.tsx
@@ -398,6 +398,38 @@ describe("SessionsBoardView", () => {
 		expect(onOpen).toHaveBeenCalledOnce();
 	});
 
+	it("links a tracker issue when the forge URL is unambiguous", () => {
+		const onOpen = vi.fn();
+		render(
+			<SessionCardView
+				externalLink={ExternalLink}
+				labels={{
+					formatTime: () => "5m ago",
+					intakeIssue: (id) => `Issue ${id}`,
+					pr: {
+						short: "PR",
+						states: { closed: "closed", draft: "draft", merged: "merged", open: "open" },
+					},
+					updatedAt: (timestamp) => `Updated ${timestamp}`,
+				}}
+				onOpen={onOpen}
+				renderAvatar={(provider) => <span role="img" aria-label={provider}>C</span>}
+				session={{
+					...baseSession,
+					trackerIssueId: "github:acme/demo#12",
+					trackerIssueLabel: "#12",
+					trackerIssueUrl: "https://github.com/acme/demo/issues/12",
+				}}
+			/>,
+		);
+
+		const issue = screen.getByRole("link", { name: "Issue #12" });
+		expect(issue).toHaveAttribute("href", "https://github.com/acme/demo/issues/12");
+		expect(issue).toHaveTextContent("#12");
+		fireEvent.click(issue);
+		expect(onOpen).not.toHaveBeenCalled();
+	});
+
 	it("uses the shared loading and error fallback for reviewer avatars", () => {
 		const avatarUrl = "https://avatars.githubusercontent.com/ada?size=64";
 		render(

--- a/packages/product-ui/src/SessionsBoardView.tsx
+++ b/packages/product-ui/src/SessionsBoardView.tsx
@@ -65,6 +65,10 @@ export type BoardSessionPresentation = {
 	statusPresentation?: BoardSessionStatusPresentation;
 	title: string;
 	trackerIssueId?: string;
+	/** Compact visible label, e.g. `#12`. Absent when the issue cannot be linked. */
+	trackerIssueLabel?: string;
+	/** Forge URL for the session's tracker issue. Omit rather than guess. */
+	trackerIssueUrl?: string;
 	updatedAt: string;
 	lastUserMessageAt?: string;
 };
@@ -242,7 +246,7 @@ export function SessionCardView({
 	branchAction,
 	branchIcon,
 	error,
-	externalLink,
+	externalLink: ExternalLink,
 	footer,
 	interactive = true,
 	labels,
@@ -334,11 +338,27 @@ export function SessionCardView({
 						</div>
 					) : null}
 				</div>
-				{showBranch && (
+				{(showBranch || session.trackerIssueUrl) && (
 					<div className="mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-2xs text-muted-foreground">
-						{branchIcon ?? <GitBranchIcon aria-hidden="true" className="size-icon-2xs shrink-0" />}
-						<span className="truncate text-muted-foreground">{branch}</span>
-						{branchAction}
+						{showBranch ? (
+							<>
+								{branchIcon ?? <GitBranchIcon aria-hidden="true" className="size-icon-2xs shrink-0" />}
+								<span className="truncate text-muted-foreground">{branch}</span>
+								{branchAction}
+							</>
+						) : null}
+						{session.trackerIssueUrl && ExternalLink ? (
+							<ExternalLink
+								ariaLabel={labels.intakeIssue(session.trackerIssueLabel ?? session.trackerIssueId ?? session.trackerIssueUrl)}
+								className="pr-link relative z-10 hover:underline"
+								href={session.trackerIssueUrl}
+								stopPropagation
+							>
+								<span className="font-mono text-xs font-medium text-foreground">
+									{session.trackerIssueLabel ?? session.trackerIssueId}
+								</span>
+							</ExternalLink>
+						) : null}
 					</div>
 				)}
 			</div>
@@ -355,7 +375,7 @@ export function SessionCardView({
 								];
 							}).map((group) => (
 								<BoardPullRequestGroup
-									externalLink={externalLink}
+									externalLink={ExternalLink}
 									group={group}
 									key={`${group.state}-${group.prs.map((pr) => pr.url || pr.number).join("-")}`}
 									labels={labels.pr}


### PR DESCRIPTION
## What

Make a session's tracker issue a clickable link to its page on the forge (GitHub or GitLab), the same way PR references already deep-link.

## Why

Fixes #3606. The issue id is already on the session record, but it was inert text — getting to the issue meant copying the number and finding the right repo by hand.

## How

- Resolve intake ids that already name a repo (`github:owner/repo#12`, `gitlab:group/repo#7[@host]`) into an HTTPS issue URL.
- Also accept a full issue web URL stored as the session `issueId`.
- Show `#N` as an external link on the kanban card and in the session topbar, matching existing PR link behavior (`target="_blank"`).
- Do not guess: a bare number (`42`, `github:42`) stays unlinked unless a single project origin is supplied. PRs and multi-repo workspaces are not used as a fallback.

## Testing

- `cd frontend && npm test -- src/renderer/lib/issue-url.test.ts src/renderer/types/workspace.test.ts src/renderer/components/ShellTopbar.test.tsx src/renderer/components/SessionsBoard.test.tsx` (176 passed)
- `cd packages/product-ui && npm test -- src/SessionsBoardView.test.tsx` (24 passed)
- Manual: intake session with `github:owner/repo#N` — card and topbar `#N` open the issue; number-only / no-issue sessions unchanged

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior
- [x] Relevant CI checks pass for the area touched