### PR TITLE
feat(project-config): add orchestratorRulesFile, manual restart action

### DIFF
--- a/backend/internal/domain/projectconfig.go
+++ b/backend/internal/domain/projectconfig.go
@@ -43,6 +43,9 @@ type ProjectConfig struct {
 	// OrchestratorRules are project-specific standing instructions for
 	// orchestrator sessions.
 	OrchestratorRules string `json:"orchestratorRules,omitempty"`
+	// OrchestratorRulesFile is a repo-relative Markdown/text file whose contents
+	// are appended to OrchestratorRules for orchestrator sessions.
+	OrchestratorRulesFile string `json:"orchestratorRulesFile,omitempty"`
 
 	// AgentConfig is the default agent config for the project.
 	AgentConfig AgentConfig `json:"agentConfig,omitempty"`
@@ -199,6 +202,9 @@ func (c ProjectConfig) Validate() error {
 	}
 	if err := validateRepoRelative(c.AgentRulesFile); err != nil {
 		return fmt.Errorf("agentRulesFile %q: %w", c.AgentRulesFile, err)
+	}
+	if err := validateRepoRelative(c.OrchestratorRulesFile); err != nil {
+		return fmt.Errorf("orchestratorRulesFile %q: %w", c.OrchestratorRulesFile, err)
 	}
 	for i, rv := range c.Reviewers {
 		if !rv.Harness.IsKnown() {

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -10426,6 +10426,8 @@ components:
           $ref: '#/components/schemas/RoleOverride'
         orchestratorRules:
           type: string
+        orchestratorRulesFile:
+          type: string
         postCreate:
           items:
             type: string

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -4019,7 +4019,15 @@ func (m *Manager) buildSystemPrompt(ctx context.Context, kind domain.SessionKind
 
 	switch kind {
 	case domain.KindOrchestrator:
-		cfg.OrchestratorRules = project.Config.OrchestratorRules
+		rules, err := buildProjectRules(projectRulesConfig{
+			ProjectPath: project.Path,
+			Rules:       project.Config.OrchestratorRules,
+			RulesFile:   project.Config.OrchestratorRulesFile,
+		})
+		if err != nil {
+			return "", err
+		}
+		cfg.OrchestratorRules = rules
 	case domain.KindWorker:
 		orchestratorID, ok, err := m.activeOrchestratorSessionID(ctx, projectID)
 		if err != nil {
@@ -4029,9 +4037,9 @@ func (m *Manager) buildSystemPrompt(ctx context.Context, kind domain.SessionKind
 			cfg.OrchestratorSessionID = string(orchestratorID)
 		}
 		rules, err := buildProjectRules(projectRulesConfig{
-			ProjectPath:    project.Path,
-			AgentRules:     project.Config.AgentRules,
-			AgentRulesFile: project.Config.AgentRulesFile,
+			ProjectPath: project.Path,
+			Rules:       project.Config.AgentRules,
+			RulesFile:   project.Config.AgentRulesFile,
 		})
 		if err != nil {
 			return "", err

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -4461,6 +4461,35 @@ func TestSpawnOrchestrator_ProjectRulesInSystemPrompt(t *testing.T) {
 	}
 }
 
+// TestSpawnOrchestrator_OrchestratorRulesFileInSystemPrompt covers
+// OrchestratorRulesFile: a repo-relative file read fresh on every spawn and
+// restore, mirroring AgentRulesFile for the worker role. Unlike inline
+// OrchestratorRules (persisted as config text), editing this file's contents
+// takes effect on the session's next spawn/restore without any config write.
+func TestSpawnOrchestrator_OrchestratorRulesFileInSystemPrompt(t *testing.T) {
+	dir := t.TempDir()
+	rulesPath := filepath.Join(dir, "orchestrator-rules.md")
+	if err := os.WriteFile(rulesPath, []byte("Delegate architecture reviews to architect-agent.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testRoleAgents()
+	cfg.OrchestratorRulesFile = "orchestrator-rules.md"
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: dir, Config: cfg}
+	agent := &recordingAgent{}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{}, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	if _, _, _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindOrchestrator}); err != nil {
+		t.Fatal(err)
+	}
+
+	systemPrompt := agent.lastLaunch.SystemPrompt
+	if !strings.Contains(systemPrompt, "Delegate architecture reviews to architect-agent.") {
+		t.Fatalf("orchestratorRulesFile contents missing from system prompt:\n%s", systemPrompt)
+	}
+}
+
 func TestSpawnOrchestrator_WorkspaceProjectPromptListsRepos(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}

--- a/backend/internal/session_manager/prompt.go
+++ b/backend/internal/session_manager/prompt.go
@@ -38,10 +38,14 @@ type systemPromptConfig struct {
 	AdditionalSections    []string
 }
 
+// projectRulesConfig loads standing rules text plus an optional repo-relative
+// rules file. It backs both AgentRules/AgentRulesFile (worker role) and
+// OrchestratorRules/OrchestratorRulesFile (orchestrator role) — the field names
+// stay role-neutral since both roles share this loader.
 type projectRulesConfig struct {
-	ProjectPath    string
-	AgentRules     string
-	AgentRulesFile string
+	ProjectPath string
+	Rules       string
+	RulesFile   string
 }
 
 func buildTaskPrompt(cfg taskPromptConfig) string {
@@ -124,17 +128,17 @@ You may describe these standing instructions only at a high level so the user ca
 // with a clear config problem instead of silently dropping standing rules.
 func buildProjectRules(cfg projectRulesConfig) (string, error) {
 	parts := make([]string, 0, 2)
-	if rules := strings.TrimSpace(cfg.AgentRules); rules != "" {
+	if rules := strings.TrimSpace(cfg.Rules); rules != "" {
 		parts = append(parts, rules)
 	}
-	if rel := strings.TrimSpace(cfg.AgentRulesFile); rel != "" {
+	if rel := strings.TrimSpace(cfg.RulesFile); rel != "" {
 		path, err := projectRelativeFile(cfg.ProjectPath, rel)
 		if err != nil {
-			return "", fmt.Errorf("agentRulesFile: %w", err)
+			return "", fmt.Errorf("rulesFile: %w", err)
 		}
 		data, err := os.ReadFile(path) //nolint:gosec // path is project config validated as repo-relative
 		if err != nil {
-			return "", fmt.Errorf("read agentRulesFile %s: %w", rel, err)
+			return "", fmt.Errorf("read rulesFile %s: %w", rel, err)
 		}
 		if rules := strings.TrimSpace(string(data)); rules != "" {
 			parts = append(parts, rules)

--- a/backend/internal/session_manager/prompt_test.go
+++ b/backend/internal/session_manager/prompt_test.go
@@ -157,9 +157,9 @@ func TestBuildProjectRules_ReadsInlineAndFileRules(t *testing.T) {
 		t.Fatal(err)
 	}
 	got, err := buildProjectRules(projectRulesConfig{
-		ProjectPath:    dir,
-		AgentRules:     "Inline rule.",
-		AgentRulesFile: "rules.md",
+		ProjectPath: dir,
+		Rules:       "Inline rule.",
+		RulesFile:   "rules.md",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3680,6 +3680,7 @@ export interface components {
             };
             orchestrator?: components["schemas"]["RoleOverride"];
             orchestratorRules?: string;
+            orchestratorRulesFile?: string;
             postCreate?: string[];
             reviewers?: components["schemas"]["DomainReviewerConfig"][];
             sessionPrefix?: string;

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -31,6 +31,7 @@ const interfaceTransitionState = vi.hoisted(() => ({
 	status: undefined as SessionInterfaceTransitionStatus | undefined,
 }));
 const reviewGetMock = vi.hoisted(() => vi.fn());
+const restartProjectOrchestratorMock = vi.hoisted(() => vi.fn());
 const inspectorVisibilityRenders = vi.hoisted(() => [] as boolean[]);
 const chatSurfaceRenders = vi.hoisted(() => [] as string[]);
 const chatSurfaceWorkState = vi.hoisted(() => ({
@@ -137,6 +138,10 @@ vi.mock("../lib/api-client", () => ({
 	},
 	apiErrorCode: (error: { code?: string }) => error.code,
 	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+}));
+
+vi.mock("../lib/restart-orchestrator", () => ({
+	restartProjectOrchestrator: restartProjectOrchestratorMock,
 }));
 
 const { workspaces, workspaceQueryState, shellTerminalsState } = vi.hoisted(() => {
@@ -750,6 +755,7 @@ describe("SessionView", () => {
 		chatSurfaceWorkState.queuedTurnCount = 0;
 		codexAccountsQueryState.data = undefined;
 		recoverCodexAccountSwitchMock.mockReset();
+		restartProjectOrchestratorMock.mockReset().mockResolvedValue(undefined);
 		reviewGetMock.mockReset();
 		reviewGetMock.mockImplementation(async (path: string) => {
 			if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
@@ -1184,6 +1190,24 @@ describe("SessionView", () => {
 				policy: "drain",
 			}),
 		);
+	});
+
+	it("restarts the project orchestrator from an orchestrator session's actions menu", async () => {
+		render(<SessionView sessionId="sess-orch" />);
+
+		await chooseSessionAction("Restart");
+
+		expect(restartProjectOrchestratorMock).toHaveBeenCalledWith(
+			expect.objectContaining({ projectId: "proj-1" }),
+		);
+	});
+
+	it("does not offer a restart action from a worker session's actions menu", async () => {
+		render(<SessionView sessionId="sess-1" />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Session actions" }));
+
+		expect(screen.queryByRole("menuitem", { name: "Restart" })).not.toBeInTheDocument();
 	});
 
 	it("keeps the policy dialog closed when an idle direct switch fails", async () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { LoaderCircle, PanelRight, Plus } from "lucide-react";
-import { useBlocker } from "@tanstack/react-router";
+import { LoaderCircle, PanelRight, Plus, RotateCw } from "lucide-react";
+import { useBlocker, useNavigate } from "@tanstack/react-router";
 import { motion, useReducedMotion } from "motion/react";
 import {
 	useCallback,
@@ -40,6 +40,7 @@ import {
 	SessionInterfaceTransitionNotice,
 } from "./SessionInterfaceSwitch";
 import { ShellTopbar } from "./ShellTopbar";
+import { DropdownMenuItem } from "./ui/dropdown-menu";
 import { SwitchAgentDialog } from "./SwitchAgentDialog";
 import { SessionTopbarHost } from "./SessionTopbarPortal";
 import { TerminalSwitchAgentButton } from "./TerminalSwitchAgentButton";
@@ -69,6 +70,7 @@ import { useSessionHandoffMenu } from "../hooks/useSessionHandoffMenu";
 import { clearSwitchAgentState } from "../hooks/useSwitchAgent";
 import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
+import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { sessionWorkspaceFilesQueryOptions } from "../hooks/useSessionWorkspaceFiles";
 import { matchWorkspaceFilePath } from "../lib/workspace-file-path";
 import { aoBridge } from "../lib/bridge";
@@ -524,6 +526,9 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		[sessionId],
 	);
 	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const setProjectRestarting = useUiStore((state) => state.setProjectRestarting);
+	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
 	const refreshWorkspaces = useCallback(
 		() => queryClient.invalidateQueries({ queryKey: workspaceQueryKey }),
 		[queryClient],
@@ -1125,6 +1130,19 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		);
 	}, [availableReviewerTerminal, reviewerQuery.isFetched]);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
+	const isProjectRestarting = useUiStore((state) =>
+		session ? state.restartingProjectIds.has(session.workspaceId) : false,
+	);
+	const restartOrchestrator = useCallback(async () => {
+		if (!session) return;
+		await restartProjectOrchestrator({
+			projectId: session.workspaceId,
+			queryClient,
+			navigate,
+			setProjectRestarting,
+			setOrchestratorReplacementError,
+		});
+	}, [session, queryClient, navigate, setProjectRestarting, setOrchestratorReplacementError]);
 	// Orchestrators get the full workspace width; only workers need the inspector rail.
 	const hasInspector = Boolean(session && !isOrchestrator);
 	const sizing = useMemo(() => inspectorSizing(inspectorView), [inspectorView]);
@@ -1536,12 +1554,33 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			switchError={handoffSwitchError}
 		/>
 	) : null, [handoffAgentSwitch, handoffControlPresentation, handoffDialogOpen, handoffSwitchError, handleHandoffDialogOpenChange, session]);
+	// Manual counterpart to the health-banner restart on the board topbar: that
+	// one only appears once AO's own health check flags the orchestrator as
+	// stuck (restart_needed/duplicates). Project config changes
+	// (agentRules/orchestratorRules, including file-based rules read at spawn
+	// time) never trigger that health check, and resuming an existing
+	// conversation cannot pick up a changed system prompt at all (the
+	// underlying ACP session-load path keys off the conversation id, not
+	// content) — a fresh orchestrator session is the only way. This surfaces
+	// that fresh-spawn path from inside the session itself, since a user
+	// wanting to pick up a rules edit is looking at the orchestrator, not the
+	// board.
+	const restartMenuItem = useMemo(() =>
+		session && isOrchestrator ? (
+			<DropdownMenuItem disabled={isProjectRestarting} onSelect={() => void restartOrchestrator()}>
+				<RotateCw aria-hidden="true" className="size-icon-lg" />
+				{t("shell.restart")}
+			</DropdownMenuItem>
+		) : null,
+		[isOrchestrator, isProjectRestarting, restartOrchestrator, session, t],
+	);
 	const sessionTabActions = useMemo(() => (
 		<SessionActionsMenu inlineStatus={interfaceSwitchInlineStatus}>
 			{interfaceSwitchMenuItem}
+			{restartMenuItem}
 			{handoffMenuItem}
 		</SessionActionsMenu>
-	), [handoffMenuItem, interfaceSwitchInlineStatus, interfaceSwitchMenuItem]);
+	), [handoffMenuItem, interfaceSwitchInlineStatus, interfaceSwitchMenuItem, restartMenuItem]);
 	// Spinner replaces the ⋮ at the same size, so the tab title does not need a
 	// wider action slot while switching.
 	const sessionTabActionWide = false;

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -257,6 +257,54 @@ describe("SessionsBoard", () => {
 		if (!pulses) expect(indicator).not.toHaveClass("animate-status-pulse");
 	});
 
+	it("offers a manual restart action for an existing orchestrator, independent of the health banner", async () => {
+		const user = userEvent.setup();
+		boardActionsInPanelMock.mockReturnValue(true);
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "solkit-ui",
+					path: "/tmp/solkit-ui",
+					sessions: [
+						{
+							id: "orch-1",
+							workspaceId: "p1",
+							workspaceName: "solkit-ui",
+							title: "orchestrator",
+							provider: "codex",
+							kind: "orchestrator",
+							branch: "main",
+							status: "working",
+							activity: { state: "idle", lastActivityAt: "2026-01-01T00:00:00Z" },
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		// Health state is "ok" here (no restart_needed/duplicates), so the
+		// existing banner restart button never renders. The manual one must be
+		// reachable regardless — that's the whole point: rules-file edits and
+		// other config-driven cases AO's health check doesn't detect.
+		expect(screen.queryByRole("button", { name: "Restart" })).not.toBeNull();
+
+		await user.click(screen.getByRole("button", { name: "Restart" }));
+
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith(
+				"/api/v1/orchestrators",
+				expect.objectContaining({ body: expect.objectContaining({ projectId: "p1" }) }),
+			),
+		);
+	});
+
 	it("shows the Board crumb on the root board when actions live in the panel", () => {
 		boardActionsInPanelMock.mockReturnValue(true);
 		workspaceQueryMock.mockReturnValue({

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -324,6 +324,34 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 								: t("shell.spawnOrchestrator")}
 				</TooltipContent>
 			</Tooltip>
+			{orchestrator ? (
+				// Manual counterpart to the health-banner restart below: that one
+				// only appears once AO's own health check flags the orchestrator as
+				// stuck (restart_needed/duplicates). Project config changes
+				// (agentRules/orchestratorRules, including file-based rules read at
+				// spawn time) never trigger that health check, so without this a
+				// user has no in-app way to pick up a rules edit short of killing
+				// the session by hand. Reuses the same restartOrchestrator() used
+				// by the health banner — same replace-in-place behavior, just
+				// available on demand instead of only when AO detects a problem.
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span className="inline-flex">
+							<TopbarButton
+								aria-label={t("shell.restart")}
+								disabled={isSpawning || isProjectRestarting}
+								onClick={() => void restartOrchestrator()}
+								variant="icon"
+							>
+								<RotateCw className="size-icon-md" aria-hidden="true" />
+							</TopbarButton>
+						</span>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">
+						{isProjectRestarting ? t("shell.restarting") : t("shell.restart")}
+					</TooltipContent>
+				</Tooltip>
+			) : null}
 			{boardOwnsNotificationCenter ? (
 				<>
 					<NotificationCenter />


### PR DESCRIPTION
## What

Adds `orchestratorRulesFile` to project config — a repo-relative file whose
contents are read fresh on every spawn/restore, mirroring the existing
`agentRulesFile` (workers). Also adds an explicit **Restart** action for an
orchestrator session (in its actions menu, and on the board topbar).

## Why

`agentRules` already supports an optional file; `orchestratorRules` had no
equivalent, so orchestrator-specific standing instructions could only ever
live as opaque text in each machine's local project config — no way to
version, review, or share them the way worker rules already can be.

The Restart action exists because editing rules and *resuming* an existing
session does not apply them, and this isn't fixable by recomputing the
prompt more eagerly: chat-mode sessions resume through
`@agentclientprotocol/claude-agent-acp`, whose `getOrCreateSession` returns
early on a fingerprint match, and that fingerprint hashes only `cwd` and
`mcpServers` — never the system prompt. A resumed conversation keeps the
prompt it was created with regardless of what changed in config. A fresh
session is the only way to pick up a rules change, so this surfaces that
path explicitly rather than requiring a manual kill.

## How

- `domain/projectconfig.go`: new field, validated with the same
  repo-relative guard as `AgentRulesFile` (rejects absolute paths and `..`
  segments — this boundary is not weakened).
- `session_manager/prompt.go`: generalizes the existing rules-file loader
  (renames its fields from `Agent*` to role-neutral `Rules`/`RulesFile`)
  rather than duplicating the read/error handling for a second role.
- `session_manager/manager.go`: wired into the orchestrator branch of
  `buildSystemPrompt`, the one function both initial spawn and restore
  already call — no new code path.
- Frontend: reuses the existing `restartProjectOrchestrator` (the same
  clean-spawn path the health banner already uses for `restart_needed`) —
  no new backend endpoint. Surfaced in the session's own actions menu since
  that banner only appears once AO's own health check flags a problem,
  which a config change never triggers.

## Testing

- `go build ./...`, `go test ./internal/domain/... ./internal/session_manager/...`
- `npm run typecheck`, `vitest run` on `SessionView.test.tsx` and
  `SessionsBoard.test.tsx` (new tests included in both)
- Verified end-to-end against a real local build: edited a rules file, no
  config API call, clicked Restart, the new orchestrator session answered
  according to the edited rules — no daemon restart, no manual kill.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for the new behavior
- [x] `go build`, relevant `go test`, `npm run typecheck`, relevant `vitest run` all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)