### PR TITLE
fix(sessions): accept a workspace project's per-session orchestrator branch

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -521,9 +521,16 @@ func (s *Service) verifyOrchestratorReplacement(project domain.ProjectRecord, se
 	if expected := project.Config.Orchestrator.Harness; expected != "" && sess.Harness != expected {
 		return fmt.Errorf("orchestrator replacement verification failed: new session %s uses harness %q, want %q", sess.ID, sess.Harness, expected)
 	}
-	expectedBranch := sessionmanager.DefaultOrchestratorBranch(serviceSessionPrefix(project), s.dataDir)
-	if sess.Metadata.Branch != "" && sess.Metadata.Branch != expectedBranch {
-		return fmt.Errorf("orchestrator replacement verification failed: new session %s uses branch %q, want %q", sess.ID, sess.Metadata.Branch, expectedBranch)
+	// Workspace projects share one branch name across the root and every child
+	// repo; gitworktree disambiguates with a numeric suffix whenever that name
+	// is already taken (e.g. by a still-registered worktree from a prior
+	// restart), so there is no single fixed name to check the result against.
+	if project.Kind != domain.ProjectKindWorkspace {
+		expectedBranch := sessionmanager.DefaultSpawnBranch(
+			sess.ID, domain.KindOrchestrator, serviceSessionPrefix(project), project.Kind, s.dataDir)
+		if sess.Metadata.Branch != "" && sess.Metadata.Branch != expectedBranch {
+			return fmt.Errorf("orchestrator replacement verification failed: new session %s uses branch %q, want %q", sess.ID, sess.Metadata.Branch, expectedBranch)
+		}
 	}
 	return nil
 }

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -3635,6 +3635,44 @@ func TestSpawnOrchestratorVerifiesReplacementHarness(t *testing.T) {
 	}
 }
 
+// TestSpawnOrchestratorAcceptsWorkspaceProjectPerSessionBranch guards a real
+// incident: for a workspace-kind project (a parent root plus child repos),
+// gitworktree.CreateWorkspaceProject gives every session — orchestrator
+// included — its own "ao/<id>" branch, and disambiguates with a numeric
+// suffix ("ao/<id>-2") whenever that name is already taken by a
+// still-registered worktree from a prior restart. There is no single fixed
+// branch name to check a workspace orchestrator's result against. The
+// verification step used to recompute an expected branch via a helper that
+// didn't know about workspace projects at all, so it always expected the
+// single-repo canonical "ao/<prefix>-orchestrator" name and rejected every
+// real workspace-project orchestrator spawn/restart — including this
+// ordinary collision-suffixed case — with a spurious "orchestrator
+// replacement verification failed" error.
+func TestSpawnOrchestratorAcceptsWorkspaceProjectPerSessionBranch(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Kind: domain.ProjectKindWorkspace}
+	fc := &fakeCommander{
+		spawnRecord: domain.SessionRecord{
+			ID:        "mer-9",
+			ProjectID: "mer",
+			Kind:      domain.KindOrchestrator,
+			Harness:   domain.HarnessClaudeCode,
+			// Collision-suffixed, as gitworktree produces when "ao/mer-9" is
+			// already taken by a leftover worktree from an earlier restart.
+			Metadata: domain.SessionMetadata{Branch: "ao/mer-9-2"},
+		},
+	}
+	svc := &Service{manager: fc, store: st}
+
+	got, err := svc.SpawnOrchestrator(context.Background(), "mer", false, "")
+	if err != nil {
+		t.Fatalf("SpawnOrchestrator for workspace project: %v", err)
+	}
+	if got.ID != "mer-9" {
+		t.Fatalf("returned id = %q, want mer-9", got.ID)
+	}
+}
+
 func TestDelegateTaskPassesAttachmentsToSpawnConfig(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -3839,12 +3839,6 @@ func DefaultSpawnBranch(id domain.SessionID, kind domain.SessionKind, prefix str
 	return defaultSessionBranch(id, kind, prefix, branchNamespace)
 }
 
-// DefaultOrchestratorBranch returns the generated canonical orchestrator branch
-// for a project in the current data-dir namespace.
-func DefaultOrchestratorBranch(prefix, dataDir string) string {
-	return defaultSessionBranch("", domain.KindOrchestrator, prefix, generatedBranchNamespace(dataDir))
-}
-
 func aoBranch(namespace string, parts ...string) string {
 	all := []string{"ao"}
 	if namespace != "" {


### PR DESCRIPTION
## What

Replacing a workspace project's orchestrator no longer fails verification
against a single fixed generated branch name.

## Why

A workspace project shares one branch name across its root and every child
repo, so gitworktree disambiguates with a numeric suffix whenever that name
is already taken — including by the still-registered worktree of the very
orchestrator being replaced. Verification compared the new session's branch
against one fixed name and rejected the legitimately-suffixed result,
failing every workspace-project orchestrator replacement.

Found in practice by using #5256's Restart action on a workspace project —
the two are related, even though they touch different code.

## How

Skips the fixed-name check for workspace projects (no single expected name
exists there) and checks the per-session generated name for single-repo
projects, which do have one. Removes `DefaultOrchestratorBranch`, which has
no remaining callers after this change.

## Testing

- `go build ./...`
- `go test ./internal/service/session/...` (new test:
  `TestSpawnOrchestratorAcceptsWorkspaceProjectPerSessionBranch`)
- Manually verified: restarting an orchestrator on a real workspace project
  no longer fails verification.

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for the new behavior
- [x] `go build`, relevant `go test` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)