### PR TITLE
fix(chat): tolerate an approval mode the selected model does not offer

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/config_options.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options.go
@@ -299,6 +299,22 @@ func choiceOffered(choices []ports.ChatConfigOptionChoice, value string) bool {
 	return false
 }
 
+// modeOffered reports whether the synthetic "mode" config option — populated
+// by normalizeSessionOptions from the agent's legacy SessionModeState — lists
+// modeID among its current choices. Availability can be model-dependent (for
+// example, Claude Code only advertises "auto" for models whose SDK reports
+// classifier support), so this must be checked fresh against the live catalog
+// rather than assumed from a static AO-vocabulary mapping.
+func modeOffered(options []ports.ChatConfigOption, modeID string) bool {
+	for _, option := range options {
+		if option.ID != "mode" {
+			continue
+		}
+		return choiceOffered(option.Choices, modeID)
+	}
+	return false
+}
+
 // resolveLegacyModelChoice translates a CLI-facing model alias into the exact
 // opaque value an ACP agent advertised. Cursor's CLI lists aliases such as
 // composer-2.5-fast and gpt-5.5-medium while its legacy ACP selector includes

--- a/backend/internal/adapters/chatdriver/acp/config_options_test.go
+++ b/backend/internal/adapters/chatdriver/acp/config_options_test.go
@@ -1,6 +1,7 @@
 package acp
 
 import (
+	"errors"
 	"testing"
 
 	acpsdk "github.com/coder/acp-go-sdk"
@@ -136,3 +137,86 @@ func TestApplyAcceptedConfigOptionIgnoresUnknownID(t *testing.T) {
 }
 
 func boolPtr(v bool) *bool { return &v }
+
+// TestModeOfferedChecksLiveCatalogNotStaticMapping guards the fix for a real
+// incident: Claude Code only advertises the "auto" permission mode when the
+// current model's SDK reports classifier support (e.g. Haiku does not), so a
+// static AO-vocabulary mapping (permission "auto" -> ACP mode id "auto") can
+// name a mode the live session never offered.
+func TestModeOfferedChecksLiveCatalogNotStaticMapping(t *testing.T) {
+	options := normalizeSessionOptions(nil, nil, &acpsdk.SessionModeState{
+		CurrentModeId: "default",
+		AvailableModes: []acpsdk.SessionMode{
+			{Id: "default", Name: "Manual"},
+			{Id: "acceptEdits", Name: "Accept Edits"},
+		},
+	})
+
+	if modeOffered(options, "auto") {
+		t.Fatal("modeOffered(auto) = true, want false — auto is not in AvailableModes")
+	}
+	if !modeOffered(options, "acceptEdits") {
+		t.Fatal("modeOffered(acceptEdits) = false, want true — acceptEdits is in AvailableModes")
+	}
+}
+
+// TestApplyTurnSettingsToleratesModeUnavailableOnThisModel verifies that
+// applyTurnSettings does not call session/set_mode with a mode the agent's
+// live catalog does not offer. Calling it anyway trips the agent's own hard
+// validation (session.modes.availableModes.some(...) throw), which surfaced
+// as a fatal spawn failure instead of the graceful degrade every other
+// unsupported-setter path already gets.
+func TestApplyTurnSettingsToleratesModeUnavailableOnThisModel(t *testing.T) {
+	c := &conversation{
+		sessionID:    "sess-1",
+		capabilities: make(ports.ChatCapabilities),
+		modeFor:      func(ports.PermissionMode) string { return "auto" },
+		legacyMode:   true,
+		configOptions: normalizeSessionOptions(nil, nil, &acpsdk.SessionModeState{
+			CurrentModeId: "default",
+			AvailableModes: []acpsdk.SessionMode{
+				{Id: "default", Name: "Manual"},
+				{Id: "acceptEdits", Name: "Accept Edits"},
+			},
+		}),
+	}
+
+	err := c.applyTurnSettings(t.Context(), ports.ChatTurnSettings{Approval: ports.PermissionModeAuto})
+	if !errors.Is(err, ErrACPSetterUnsupported) {
+		t.Fatalf("applyTurnSettings with unavailable mode: err = %v, want ErrACPSetterUnsupported", err)
+	}
+}
+
+// TestApplyTurnSettingsSkipsModeReapplicationWhenUnchanged guards a real
+// incident: Start tolerates ErrACPSetterUnsupported for the initial mode
+// (the mode may already have reached the agent via launch-time flags or the
+// ACP Initialize meta), but SendTurn does not — it must surface a genuine
+// runtime mode *change* the agent refuses. Without this guard, the very
+// first SendTurn re-sends the session's own unchanged initial settings,
+// hits the same unavailable-mode condition Start already tolerated, and
+// fails the user's first message instead of just running in whatever mode
+// the agent actually started in.
+func TestApplyTurnSettingsSkipsModeReapplicationWhenUnchanged(t *testing.T) {
+	c := &conversation{
+		sessionID:         "sess-1",
+		capabilities:      make(ports.ChatCapabilities),
+		modeFor:           func(ports.PermissionMode) string { return "auto" },
+		legacyMode:        true,
+		initialPermission: ports.PermissionModeAuto,
+		permissionMode:    ports.PermissionModeAuto, // set by start(), as if Start() already ran
+		configOptions: normalizeSessionOptions(nil, nil, &acpsdk.SessionModeState{
+			CurrentModeId: "default",
+			AvailableModes: []acpsdk.SessionMode{
+				{Id: "default", Name: "Manual"},
+				{Id: "acceptEdits", Name: "Accept Edits"},
+			},
+		}),
+	}
+
+	// Re-sending the same initial Approval on the first real turn must not
+	// re-trigger the mode-unavailable failure Start() already tolerated.
+	err := c.applyTurnSettings(t.Context(), ports.ChatTurnSettings{Approval: ports.PermissionModeAuto})
+	if err != nil {
+		t.Fatalf("applyTurnSettings reapplying unchanged initial mode: err = %v, want nil", err)
+	}
+}

--- a/backend/internal/adapters/chatdriver/acp/conversation.go
+++ b/backend/internal/adapters/chatdriver/acp/conversation.go
@@ -397,6 +397,7 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 	modeFor := c.modeFor
 	optionsFor := c.optionsFor
 	initialPermission := c.initialPermission
+	currentPermission := c.permissionMode
 	validateSettings := c.validateSettings
 	legacyModel := c.legacyModel
 	legacyMode := c.legacyMode
@@ -436,8 +437,17 @@ func (c *conversation) applyTurnSettings(ctx context.Context, settings ports.Cha
 		}
 		c.applyAcceptedConfigOption("model", ports.ChatConfigOptionValue{Select: model})
 	}
-	if modeFor != nil {
+	if modeFor != nil && ports.NormalizePermissionMode(settings.Approval) != currentPermission {
 		if mode := modeFor(settings.Approval); mode != "" {
+			// A model-dependent mode (e.g. Claude's "auto" classifier, unsupported
+			// by some models such as Haiku) may not be in the agent's advertised
+			// choices even though modeFor's static AO-vocabulary mapping offers it.
+			// Treat that the same as an unimplemented setter: Start/Resume already
+			// tolerate ErrACPSetterUnsupported because the initial mode may have
+			// reached the agent via launch-time flags instead.
+			if legacyMode && !modeOffered(configOptions, mode) {
+				return fmt.Errorf("%w: session/set_mode %q not offered by this session", ErrACPSetterUnsupported, mode)
+			}
 			if _, err := c.conn.SetSessionMode(ctx, acpsdk.SetSessionModeRequest{
 				SessionId: acpsdk.SessionId(sessionID), ModeId: acpsdk.SessionModeId(mode),
 			}); err != nil {


### PR DESCRIPTION
## What

Checks the agent's advertised mode choices before calling `session/set_mode`,
and skips the call (reporting `ErrACPSetterUnsupported`) when the mapped mode
isn't among them, instead of failing the turn.

## Why

Claude Code only offers the `auto` classifier mode for models whose SDK
reports classifier support. Selecting a model without it (e.g. Haiku) left
the static AO-vocabulary mapping asking for a mode the live session never
advertised, and the turn failed outright rather than degrading gracefully.

## How

`modeFor`'s static mapping stays as the source of the AO-vocabulary → agent
mode translation; this only gates the live `session/set_mode` call behind
whether the agent's current advertised choices actually include that mode.
When absent, it returns `ErrACPSetterUnsupported` — the same error class
`Start`/`Resume` already tolerate elsewhere, since an initial mode can
legitimately reach the agent via launch-time flags instead of the setter.
Also skips `set_mode` entirely when the requested approval mode already
matches the session's current one, so an unchanged setting can't fail a turn.

**Cross-provider scope — please double-check if you maintain one of these**:
this touches the *shared* `internal/adapters/chatdriver/acp` package, not
Claude-specific code. Ten provider drivers build on it (claudeacp, piacp,
cursoracp, kimchiacp, ompacp, droidacp, opencodeacp, kimiacp, nativeacp).
`legacyMode` is set dynamically per-session from whichever agent's own
initialize response includes legacy mode data, not statically per provider,
so any of them could exercise this path. I only tested Claude Code and
opencode by hand. Before submitting I confirmed the change builds and all 8
other providers' own test suites still pass — but none of them, including
Claude's own `claudeacp` package, had any test coverage of mode-switching
before or after this patch, so that confirms no regression *elsewhere* in
those packages, not that mode-switching itself is correct for the untested
providers. The change can only convert a would-be hard protocol error into
graceful degradation for a mode the agent's own live catalog doesn't list —
the one risk I can't rule out without live-testing all ten is a
non-compliant agent that would accept `session/set_mode` for a mode it
doesn't advertise as a choice.

## Testing

- `go build ./...`
- `go test ./internal/adapters/chatdriver/acp/...` (3 new tests) and the
  other 8 providers sharing this base (`piacp`, `cursoracp`, `kimchiacp`,
  `ompacp`, `droidacp`, `opencodeacp`, `kimiacp`, `nativeacp`) — all pass,
  see caveat above on what that does/doesn't confirm
- Manually verified against Claude Code: switching to Haiku mid-session no
  longer fails the turn

## Checklist

- [x] Branched from `main`
- [x] One focused change
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for the new behavior
- [x] `go build`, relevant `go test` pass locally
- [ ] Not verified against the 8 other ACP-based providers beyond their existing (mode-switching-agnostic) test suites — see cross-provider note above

🤖 Generated with [Claude Code](https://claude.com/claude-code)