### PR TITLE
Prevent bundled tmux from crashing on Linux

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -48,7 +48,9 @@ jobs:
           - os: windows-latest
             platform: win32-x64
             artifact: win
-          - os: ubuntu-latest
+          # Linux tmux links glibc dynamically (#4616). Build on the oldest
+          # supported glibc baseline so the bundle also runs on Ubuntu 22.04.
+          - os: ubuntu-22.04
             platform: linux-x64
             artifact: linux
     runs-on: ${{ matrix.os }}

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -7,8 +7,9 @@ import MakerNSIS from "./makers/maker-nsis";
 import MakerDMG, { isSigningConfigured, sealDmg, verifyDmg, verifyMacArtifact } from "./makers/maker-dmg";
 import { machoHasX86_64Slice } from "./makers/macho-archs";
 import MakerAppImage from "./makers/maker-appimage";
-import { existsSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 // Default GitHub release target (production). Releases land on Untrivial-ai
@@ -214,6 +215,20 @@ const config: ForgeConfig = {
 				const version = spawnSync(binary, ["-V"], { encoding: "utf8" });
 				if (version.status !== 0 || version.stdout.trim() !== "tmux 3.5a") {
 					throw new Error(`packaged tmux failed verification at ${binary}: ${version.stderr || version.stdout}`);
+				}
+				const socket = path.join(tmpdir(), `ao-packaged-tmux-${process.pid}-${path.basename(outputPath)}.sock`);
+				const smoke = spawnSync(binary, ["-S", socket, "-f", "/dev/null", "new-session", "-d", "true"], {
+					encoding: "utf8",
+				});
+				try {
+					if (smoke.status !== 0) {
+						throw new Error(
+							`packaged tmux could not create a session at ${binary}: ${smoke.stderr || smoke.stdout}`,
+						);
+					}
+				} finally {
+					spawnSync(binary, ["-S", socket, "kill-server"], { stdio: "ignore" });
+					rmSync(socket, { force: true });
 				}
 			}
 		},

--- a/frontend/scripts/build-tmux.mjs
+++ b/frontend/scripts/build-tmux.mjs
@@ -47,7 +47,10 @@ const UTF8PROC = {
 	license: "LICENSE.md",
 };
 const SOURCES = [TMUX, LIBEVENT, NCURSES, UTF8PROC];
-const BUILD_REVISION = 4;
+// Linux intentionally links glibc dynamically. A fully static glibc tmux can
+// enter __libc_early_init with an unset page size and SIGFPE on new-session
+// even though `tmux -V` succeeds (#4616).
+const BUILD_REVISION = 5;
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const frontendRoot = resolve(scriptsDir, "..");
@@ -203,7 +206,6 @@ async function build() {
 
 	const tmuxDir = join(sourceRoot, TMUX.directory);
 	const tmuxConfigureArgs = ["--enable-utf8proc"];
-	if (process.platform === "linux") tmuxConfigureArgs.push("--enable-static");
 	const tmuxEnv = {
 		...commonEnv,
 		LIBTINFO_CFLAGS: `-I${join(prefix, "include", "ncursesw")} -I${join(prefix, "include")}`,


### PR DESCRIPTION
Code changes: +20 -3  
Tests: +0 -0  
Others: +3 -1

## summary

- link the Linux tmux bundle dynamically against glibc while keeping its other pinned dependencies self-contained
- build Linux release artifacts on Ubuntu 22.04 so the resulting glibc baseline matches the oldest supported host
- make packaging create a real tmux session, catching crashes that `tmux -V` cannot detect

## validation

- rebuilt bundled tmux 3.5a locally
- `ldd` shows only standard glibc runtime dependencies
- exact `tmux -S <socket> -f /dev/null new-session -d true` reproduction passed
- bundled tmux tests passed: 8/8
- frontend typecheck passed
- `git diff --check` passed

## validation gaps

- the build script reached its existing attach smoke check but this host lacks the `script` utility; the issue-specific `new-session` smoke was run directly and passed
- the full frontend suite was attempted but unrelated socket/CDP, landing-doc, and settings timing tests failed in this environment; the focused suite passed
- local workflow validation could not start because `VITE_WORKOS_CLIENT_ID` is unavailable; remote CI is required for the complete release matrix

this addresses the bundled tmux SIGFPE crash reported in #4616. runtime startup diagnostics and an `AO_TMUX_BIN` override remain follow-up work outside this pr's scope. the ubuntu runner retirement risk is also a follow-up; this pr keeps the jammy build leg to verify the glibc baseline.

