### PR TITLE
chore: version bump to 1.3.1

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -2,7 +2,7 @@
 	"expo": {
 		"name": "AO",
 		"slug": "ao-mobile",
-		"version": "1.3.0",
+		"version": "1.3.1",
 		"runtimeVersion": {
 			"policy": "fingerprint"
 		},


### PR DESCRIPTION
Bumps AO Mobile to **1.3.1** ahead of the store build carrying the Ruto app icons (#5238). One line in `packages/mobile/app.json`, matching #4742.

Build numbers are not touched: `eas.json` sets `appVersionSource: "remote"` with `autoIncrement: true` on the production profile, so EAS assigns iOS 15 and Android 9 itself.

## Why a build rather than an update

The icons change the fingerprint, so this cannot ship over the air:

| Platform | 1.3.0 (live) | this branch |
|---|---|---|
| iOS | `fbd4805bc05dbabdb9c377157b570a3bf703b555` | `ad3999c715b02869988c6cab86d8467c5617e36c` |
| Android | `bcfb745ef3a294b08d2324b090febfc0a900bc0f` | `8290ea0d05c84b32f809b415c5a6cc9e04818c09` |

Those new values are what any future 1.3.1 update must match.

The JS in this build already reached 1.3.0 users over the air on 2026-09-11 (board re-render on change, Switch to Chat readiness poll, project filter fallback, chat/tui telemetry tags). Until 1.3.1 is live in both stores, an OTA hotfix for users still on 1.3.0 has to be published from a pre-icon tree — branch `chore/mobile-changes-since-1.3.0` sits at `715e0e06f` for exactly that.

## Checks

```
npx tsc --noEmit    0 errors
npx vitest run      787 passed (79 files)
```
