### PR TITLE
fix(chat): keep conversation minimap when transcript fits viewport

### DIFF
--- a/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.test.tsx
@@ -1137,6 +1137,31 @@ describe("ChatWorkspace timeline", () => {
 		expect(log.scrollTop).toBe(1000);
 	});
 
+	it("keeps conversation minimap markers when the transcript fits the viewport", () => {
+		useUiStore.setState({
+			inspectorSessions: { "ao-long": { isOpen: false, view: "summary" } },
+		});
+		render(<ChatWorkspace snapshot={chatFixtureLongHistory(4)} />);
+		const log = screen.getByRole("log");
+		const scrollbar = screen.getByTestId("chat-conversation-minimap");
+		// Closing the inspector widens chat; a short history can stop overflowing.
+		stubGeometry(log, {
+			scrollHeight: 600,
+			clientHeight: 600,
+			scrollTop: 0,
+		});
+		stubGeometry(scrollbar, {
+			scrollHeight: 600,
+			clientHeight: 600,
+			scrollTop: 0,
+		});
+		fireEvent.scroll(log);
+
+		expect(scrollbar).not.toHaveAttribute("aria-hidden", "true");
+		expect(scrollbar).not.toHaveClass("pointer-events-none");
+		expect(scrollbar.querySelectorAll("[data-chat-scroll-marker]").length).toBeGreaterThan(1);
+	});
+
 	it("re-enables the conversation minimap when the inspector closes again", async () => {
 		useUiStore.setState({
 			inspectorSessions: { "ao-long": { isOpen: false, view: "summary" } },

--- a/frontend/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/frontend/src/renderer/components/chat/ChatWorkspace.tsx
@@ -2047,7 +2047,11 @@ function Timeline({
 			visible: boolean;
 		}>,
 	});
-	const minimapEnabled = scrollbar.visible && !isInspectorOpen;
+	// Show turn ticks whenever the inspector is closed and there are human
+	// prompts — not only when the transcript overflows. Closing the rail
+	// widens chat; shorter histories (common on non-Codex harnesses) often
+	// stop overflowing and used to lose the minimap exactly then.
+	const minimapEnabled = !isInspectorOpen && scrollbar.markers.length > 0;
 	const queued = useMemo(() => queuedTurnIds(snapshot), [snapshot]);
 	const decide = useStableCallback(onDecide);
 	const resolveInput = useStableCallback(onResolveInput);


### PR DESCRIPTION
## Summary
- Keep chat conversation minimap markers visible whenever the inspector is closed and human prompts exist, not only when the transcript overflows.
- Closing the inspector widens chat; shorter histories often stop overflowing and previously lost the minimap.
- Adds a regression test for the non-overflowing viewport case.

## Test plan
- [ ] Open a short chat history with the inspector closed — minimap markers should still appear
- [ ] Open the inspector — minimap interaction should still disable as before
- [ ] Close the inspector again — markers should return
- [ ] Confirm the new ChatWorkspace unit test passes


Made with [Cursor](https://cursor.com)