### PR TITLE
fix: restyle Install Update cue above footer actions

### DIFF
--- a/frontend/e2e/updates-settings.spec.ts
+++ b/frontend/e2e/updates-settings.spec.ts
@@ -78,6 +78,7 @@ test("@P0 live update flow stays synchronized without reopening Settings", async
 		window.ao!.updates.getStatus = async () => ({ state: "downloaded", version: "2.0.0" });
 	});
 	await expect(page.getByTestId("sidebar-update-ready")).toContainText("Install Update");
-	await expect(page.getByTestId("sidebar-update-ready")).toHaveClass(/text-success/);
+	await expect(page.getByTestId("sidebar-update-ready")).toHaveClass(/bg-muted/);
+	await expect(page.getByTestId("sidebar-update-ready")).not.toHaveClass(/text-success/);
 	await expect(page.getByRole("button", { name: "Install Update", exact: true })).toBeEnabled();
 });

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -2211,10 +2211,15 @@ describe("Sidebar", () => {
 		// A build ready to install is more actionable than "checks are failing".
 		expect(await screen.findAllByLabelText("Restart to install update v9.9.9")).not.toHaveLength(0);
 		const readyRow = screen.getByTestId("sidebar-update-ready");
-		expect(readyRow).toHaveClass("border", "border-success/35", "bg-success/12", "text-success");
+		expect(readyRow).toHaveClass("bg-muted", "rounded-xl", "shadow-md", "w-full");
+		expect(readyRow).not.toHaveClass("absolute", "bottom-2", "text-success", "border-success/35", "bg-success/12");
+		expect(within(readyRow).getByText("Install Update")).toBeVisible();
 		expect(within(readyRow).getByText("v9.9.9 ready")).toBeVisible();
 		expect(readyRow.querySelector(".rounded-full")).toBeNull();
 		expect(screen.queryByLabelText("Retry update check")).not.toBeInTheDocument();
+		// Stays above Connect mobile / Settings — not overlaid on them.
+		const connectMobile = screen.getByRole("button", { name: "Connect mobile" });
+		expect(readyRow.compareDocumentPosition(connectMobile) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 		expect(screen.queryByLabelText(/Hide update/)).not.toBeInTheDocument();
 	});
 
@@ -2277,7 +2282,7 @@ describe("Sidebar", () => {
 		expect(screen.queryByText("Update check failed")).not.toBeInTheDocument();
 	});
 
-	it("renders the restart-to-update row with the green treatment even when escalated", async () => {
+	it("keeps the muted install cue when the staged update is escalated", async () => {
 		updateStatusMock.mockResolvedValue({
 			state: "downloaded",
 			version: "9.9.9",
@@ -2290,9 +2295,24 @@ describe("Sidebar", () => {
 		const buttons = await screen.findAllByLabelText("Restart to install update v9.9.9");
 		expect(buttons.length).toBeGreaterThan(0);
 		for (const button of buttons) {
-		expect(button).toHaveClass("text-success");
+			expect(button).toHaveClass("bg-muted");
+			expect(button).not.toHaveClass("text-success");
 		}
 		expect(screen.getByText("v9.9.9 ready")).toBeInTheDocument();
+	});
+
+	it("stacks install label above build details so nightly copy can wrap", async () => {
+		updateStatusMock.mockResolvedValue({
+			state: "downloaded",
+			version: "0.12.11-nightly.202609021713",
+			stagedAt: Date.now(),
+		});
+		renderSidebar();
+
+		const readyRow = await screen.findByTestId("sidebar-update-ready");
+		expect(within(readyRow).getByText("Install Update")).toBeVisible();
+		expect(within(readyRow).getByText(/^Nightly 0\.12\.11 · /)).toBeVisible();
+		expect(readyRow.querySelectorAll(".block").length).toBeGreaterThanOrEqual(2);
 	});
 
 	it("commits a project drop", () => {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -2214,7 +2214,7 @@ describe("Sidebar", () => {
 		expect(readyRow).toHaveClass("bg-muted", "rounded-xl", "shadow-md", "w-full");
 		expect(readyRow).not.toHaveClass("absolute", "bottom-2", "text-success", "border-success/35", "bg-success/12");
 		expect(within(readyRow).getByText("Install Update")).toBeVisible();
-		expect(within(readyRow).getByText("v9.9.9 ready")).toBeVisible();
+		expect(within(readyRow).queryByText(/ready|Nightly/)).not.toBeInTheDocument();
 		expect(readyRow.querySelector(".rounded-full")).toBeNull();
 		expect(screen.queryByLabelText("Retry update check")).not.toBeInTheDocument();
 		// Stays above Connect mobile / Settings — not overlaid on them.
@@ -2239,9 +2239,7 @@ describe("Sidebar", () => {
 		expect(screen.getByTestId("sidebar-update-ready")).toBeVisible();
 	});
 
-	it("names the channel and build date for a staged nightly", async () => {
-		// A raw nightly string truncates to noise in the sidebar, and two
-		// consecutive nightlies differ only in the trailing digits.
+	it("keeps the install cue label-only for a staged nightly", async () => {
 		updateStatusMock.mockResolvedValue({
 			state: "downloaded",
 			version: "0.12.11-nightly.202609021713",
@@ -2250,27 +2248,8 @@ describe("Sidebar", () => {
 		renderSidebar();
 
 		const readyRow = await screen.findByTestId("sidebar-update-ready");
-		expect(within(readyRow).getByText("Nightly 0.12.11 · Sep 2")).toBeVisible();
-	});
-
-	it("shows the device-local calendar day for a UTC-day-boundary nightly", async () => {
-		// 03:00 UTC on Sep 7 is already Sep 7 in Kolkata but still Sep 6 in Los
-		// Angeles. The date-only label must follow the device-local calendar day
-		// of the correct instant, not the stamp digits re-read as local wall
-		// time (issue #5059). The expected label is derived from the absolute
-		// instant, so this holds in every timezone.
-		updateStatusMock.mockResolvedValue({
-			state: "downloaded",
-			version: "0.12.11-nightly.202609070300",
-			stagedAt: Date.now(),
-		});
-		renderSidebar();
-
-		const readyRow = await screen.findByTestId("sidebar-update-ready");
-		const expected = new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(
-			new Date(Date.UTC(2026, 8, 7, 3, 0)),
-		);
-		expect(within(readyRow).getByText(`Nightly 0.12.11 · ${expected}`)).toBeVisible();
+		expect(within(readyRow).getByText("Install Update")).toBeVisible();
+		expect(within(readyRow).queryByText(/Nightly|Sep/)).not.toBeInTheDocument();
 	});
 
 	it("stays quiet for a one-off update failure that has not become a streak", async () => {
@@ -2298,10 +2277,11 @@ describe("Sidebar", () => {
 			expect(button).toHaveClass("bg-muted");
 			expect(button).not.toHaveClass("text-success");
 		}
-		expect(screen.getByText("v9.9.9 ready")).toBeInTheDocument();
+		expect(screen.getByTestId("sidebar-update-ready")).toHaveTextContent("Install Update");
+		expect(screen.queryByText("v9.9.9 ready")).not.toBeInTheDocument();
 	});
 
-	it("stacks install label above build details so nightly copy can wrap", async () => {
+	it("shows only the install label without nightly or version subtext", async () => {
 		updateStatusMock.mockResolvedValue({
 			state: "downloaded",
 			version: "0.12.11-nightly.202609021713",
@@ -2310,9 +2290,8 @@ describe("Sidebar", () => {
 		renderSidebar();
 
 		const readyRow = await screen.findByTestId("sidebar-update-ready");
-		expect(within(readyRow).getByText("Install Update")).toBeVisible();
-		expect(within(readyRow).getByText(/^Nightly 0\.12\.11 · /)).toBeVisible();
-		expect(readyRow.querySelectorAll(".block").length).toBeGreaterThanOrEqual(2);
+		expect(readyRow).toHaveTextContent("Install Update");
+		expect(within(readyRow).queryByText(/Nightly|ready/)).not.toBeInTheDocument();
 	});
 
 	it("commits a project drop", () => {

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -2214,6 +2214,7 @@ describe("Sidebar", () => {
 		expect(readyRow).toHaveClass("bg-muted", "rounded-xl", "shadow-md", "w-full");
 		expect(readyRow).not.toHaveClass("absolute", "bottom-2", "text-success", "border-success/35", "bg-success/12");
 		expect(within(readyRow).getByText("Install Update")).toBeVisible();
+		expect(within(readyRow).getByText("9.9.9")).toBeVisible();
 		expect(within(readyRow).queryByText(/ready|Nightly/)).not.toBeInTheDocument();
 		expect(readyRow.querySelector(".rounded-full")).toBeNull();
 		expect(screen.queryByLabelText("Retry update check")).not.toBeInTheDocument();
@@ -2239,7 +2240,7 @@ describe("Sidebar", () => {
 		expect(screen.getByTestId("sidebar-update-ready")).toBeVisible();
 	});
 
-	it("keeps the install cue label-only for a staged nightly", async () => {
+	it("shows the base version number for a staged nightly without channel or date", async () => {
 		updateStatusMock.mockResolvedValue({
 			state: "downloaded",
 			version: "0.12.11-nightly.202609021713",
@@ -2249,6 +2250,7 @@ describe("Sidebar", () => {
 
 		const readyRow = await screen.findByTestId("sidebar-update-ready");
 		expect(within(readyRow).getByText("Install Update")).toBeVisible();
+		expect(within(readyRow).getByText("0.12.11")).toBeVisible();
 		expect(within(readyRow).queryByText(/Nightly|Sep/)).not.toBeInTheDocument();
 	});
 
@@ -2278,10 +2280,11 @@ describe("Sidebar", () => {
 			expect(button).not.toHaveClass("text-success");
 		}
 		expect(screen.getByTestId("sidebar-update-ready")).toHaveTextContent("Install Update");
+		expect(within(screen.getByTestId("sidebar-update-ready")).getByText("9.9.9")).toBeVisible();
 		expect(screen.queryByText("v9.9.9 ready")).not.toBeInTheDocument();
 	});
 
-	it("shows only the install label without nightly or version subtext", async () => {
+	it("keeps install label and version number on one line without nightly copy", async () => {
 		updateStatusMock.mockResolvedValue({
 			state: "downloaded",
 			version: "0.12.11-nightly.202609021713",
@@ -2290,7 +2293,7 @@ describe("Sidebar", () => {
 		renderSidebar();
 
 		const readyRow = await screen.findByTestId("sidebar-update-ready");
-		expect(readyRow).toHaveTextContent("Install Update");
+		expect(readyRow.textContent?.replace(/\s+/g, " ").trim()).toMatch(/^Install Update 0\.12\.11$/);
 		expect(within(readyRow).queryByText(/Nightly|ready/)).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -2211,8 +2211,8 @@ describe("Sidebar", () => {
 		// A build ready to install is more actionable than "checks are failing".
 		expect(await screen.findAllByLabelText("Restart to install update v9.9.9")).not.toHaveLength(0);
 		const readyRow = screen.getByTestId("sidebar-update-ready");
-		expect(readyRow).toHaveClass("bg-muted", "rounded-xl", "shadow-md", "w-full");
-		expect(readyRow).not.toHaveClass("absolute", "bottom-2", "text-success", "border-success/35", "bg-success/12");
+		expect(readyRow).toHaveClass("bg-muted", "rounded-lg", "w-full");
+		expect(readyRow).not.toHaveClass("shadow-md", "rounded-xl", "absolute", "bottom-2", "text-success", "border-success/35", "bg-success/12");
 		expect(within(readyRow).getByText("Install Update")).toBeVisible();
 		expect(within(readyRow).getByText("9.9.9")).toBeVisible();
 		expect(within(readyRow).queryByText(/ready|Nightly/)).not.toBeInTheDocument();
@@ -2252,6 +2252,8 @@ describe("Sidebar", () => {
 		expect(within(readyRow).getByText("Install Update")).toBeVisible();
 		expect(within(readyRow).getByText("0.12.11")).toBeVisible();
 		expect(within(readyRow).queryByText(/Nightly|Sep/)).not.toBeInTheDocument();
+		expect(screen.getAllByLabelText("Restart to install update v0.12.11")).not.toHaveLength(0);
+		expect(screen.queryByLabelText(/nightly/i)).not.toBeInTheDocument();
 	});
 
 	it("stays quiet for a one-off update failure that has not become a streak", async () => {
@@ -2295,6 +2297,7 @@ describe("Sidebar", () => {
 		const readyRow = await screen.findByTestId("sidebar-update-ready");
 		expect(readyRow.textContent?.replace(/\s+/g, " ").trim()).toMatch(/^Install Update 0\.12\.11$/);
 		expect(within(readyRow).queryByText(/Nightly|ready/)).not.toBeInTheDocument();
+		expect(readyRow).toHaveAccessibleName("Restart to install update v0.12.11");
 	});
 
 	it("commits a project drop", () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -2238,7 +2238,7 @@ function UpdateStatusRow({
 
 /**
  * Alert-style install cue above Connect mobile / Settings. Muted fill + shadow so
- * it reads apart from nav rows; wraps onto two lines so nightly copy is not clipped.
+ * it reads apart from nav rows; label only — version details live in the restart dialog.
  */
 function UpdateInstallSlide({
 	availableDismissed,
@@ -2251,12 +2251,10 @@ function UpdateInstallSlide({
 	status: UpdateStatus;
 	tabIndex: number;
 }) {
-	const { t, i18n } = useTranslation();
-	const locale = i18n.resolvedLanguage ?? i18n.language;
+	const { t } = useTranslation();
 	const action = sidebarUpdateAction(status, availableDismissed);
 	if (action?.kind !== "install") return null;
 
-	const versionLabel = updateVersionLabel(action.version, "ready", t, locale);
 	return (
 		<button
 			aria-label={
@@ -2265,7 +2263,7 @@ function UpdateInstallSlide({
 					: t("shell.restartInstallUpdate")
 			}
 			className={cn(
-				"mb-1 flex w-full items-center gap-2.5 rounded-xl bg-muted px-3 py-2.5 text-left text-sm font-normal text-foreground shadow-md",
+				"mb-1 flex h-9 w-full items-center gap-2.5 rounded-xl bg-muted px-3 text-left text-sm font-normal text-foreground shadow-md",
 				"transition-colors hover:bg-interactive-hover",
 				"motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200",
 			)}
@@ -2275,14 +2273,7 @@ function UpdateInstallSlide({
 			type="button"
 		>
 			<RefreshCw aria-hidden="true" className="size-icon-sm shrink-0 text-muted-foreground" />
-			<span className="min-w-0 flex-1">
-				<span className="block tracking-tight">{t("shell.restartToUpdate")}</span>
-				{versionLabel ? (
-					<span className="mt-0.5 block break-words text-caption font-normal text-muted-foreground">
-						{versionLabel}
-					</span>
-				) : null}
-			</span>
+			<span className="min-w-0 flex-1 truncate tracking-tight">{t("shell.restartToUpdate")}</span>
 		</button>
 	);
 }
@@ -2301,8 +2292,7 @@ function UpdateStatusRail({
 	status: UpdateStatus;
 	tabIndex: number;
 }) {
-	const { t, i18n } = useTranslation();
-	const locale = i18n.resolvedLanguage ?? i18n.language;
+	const { t } = useTranslation();
 	const action = sidebarUpdateAction(status, availableDismissed);
 	if (action === null) return null;
 
@@ -2349,7 +2339,6 @@ function UpdateStatusRail({
 		);
 	}
 
-	const versionLabel = updateVersionLabel(action.version, "ready", t, locale);
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
@@ -2369,10 +2358,7 @@ function UpdateStatusRail({
 					<RefreshCw aria-hidden="true" />
 				</button>
 			</TooltipTrigger>
-			<TooltipContent side="right">
-				{t("shell.restartToUpdate")}
-				{versionLabel ? ` · ${versionLabel}` : ""}
-			</TooltipContent>
+			<TooltipContent side="right">{t("shell.restartToUpdate")}</TooltipContent>
 		</Tooltip>
 	);
 }

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -860,12 +860,18 @@ export function Sidebar({
 					<UpdateStatusRow
 						availableDismissed={updateDismissal.dismissed}
 						onDismissAvailable={updateDismissal.dismiss}
-						onRequestInstall={requestUpdateInstall}
 						status={updateStatus}
 						tabIndex={isCollapsed ? -1 : 0}
 					/>
 					<CloudSignInRow tabIndex={isCollapsed ? -1 : 0} />
 					<CloudAccountRow tabIndex={isCollapsed ? -1 : 0} />
+					{/* Install cue sits above Connect mobile / Settings — never overlays them. */}
+					<UpdateInstallSlide
+						availableDismissed={updateDismissal.dismissed}
+						onRequestInstall={requestUpdateInstall}
+						status={updateStatus}
+						tabIndex={isCollapsed ? -1 : 0}
+					/>
 					<button
 						aria-label={t("settings.connectMobile")}
 						className={cn(
@@ -2156,28 +2162,23 @@ function updateVersionLabel(
 	return t(variant === "ready" ? "shell.versionReady" : "shell.versionAvailable", { version });
 }
 
-// UpdateStatusRow makes update activity visible and actionable from the
-// sidebar: an available build downloads on click, progress reports itself, and
-// a staged build becomes the restart action. Idle/checking states stay quiet so
-// routine background checks do not flash in the sidebar.
+// UpdateStatusRow makes download progress visible in the footer. A staged build
+// ready to install renders as UpdateInstallSlide above Connect mobile / Settings.
 function UpdateStatusRow({
 	availableDismissed,
 	onDismissAvailable,
-	onRequestInstall,
 	status,
 	tabIndex,
 }: {
 	availableDismissed: boolean;
 	onDismissAvailable: () => void;
-	/** Opens the restart confirmation; installing outright would quit the app. */
-	onRequestInstall: () => void;
 	status: UpdateStatus;
 	tabIndex: number;
 }) {
 	const { t, i18n } = useTranslation();
 	const locale = i18n.resolvedLanguage ?? i18n.language;
 	const action = sidebarUpdateAction(status, availableDismissed);
-	if (action === null) return null;
+	if (action === null || action.kind === "install") return null;
 
 	if (action.kind === "download") {
 		const versionLabel = updateVersionLabel(action.version, "available", t, locale);
@@ -2219,22 +2220,41 @@ function UpdateStatusRow({
 		);
 	}
 
-	if (action.kind === "downloading") {
-		return (
-			<div
-				aria-live="polite"
-				className={cn(NAV_ROW_CLASS, "flex w-full items-center text-left [&_svg]:size-icon-md [&_svg]:shrink-0")}
-				data-testid="sidebar-update-downloading"
-				role="status"
-			>
-				<Download aria-hidden="true" className="size-icon-lg shrink-0" />
-				<span className="min-w-0 flex-1 truncate tabular-nums">
-					{action.preparing ? t("settings.updates.preparing", { defaultValue: "Preparing update…" }) : action.percent === undefined ? t("settings.updates.startingDownload", { defaultValue: "Starting download…" }) : t("settings.updates.downloading", { percent: action.percent })}
-					{!action.preparing && action.percent !== undefined && <progress aria-label={t("settings.updates.progress")} max={100} value={action.percent} className="block h-1 w-full mt-1" />}
-				</span>
-			</div>
-		);
-	}
+	return (
+		<div
+			aria-live="polite"
+			className={cn(NAV_ROW_CLASS, "flex w-full items-center text-left [&_svg]:size-icon-md [&_svg]:shrink-0")}
+			data-testid="sidebar-update-downloading"
+			role="status"
+		>
+			<Download aria-hidden="true" className="size-icon-lg shrink-0" />
+			<span className="min-w-0 flex-1 truncate tabular-nums">
+				{action.preparing ? t("settings.updates.preparing", { defaultValue: "Preparing update…" }) : action.percent === undefined ? t("settings.updates.startingDownload", { defaultValue: "Starting download…" }) : t("settings.updates.downloading", { percent: action.percent })}
+				{!action.preparing && action.percent !== undefined && <progress aria-label={t("settings.updates.progress")} max={100} value={action.percent} className="block h-1 w-full mt-1" />}
+			</span>
+		</div>
+	);
+}
+
+/**
+ * Alert-style install cue above Connect mobile / Settings. Muted fill + shadow so
+ * it reads apart from nav rows; wraps onto two lines so nightly copy is not clipped.
+ */
+function UpdateInstallSlide({
+	availableDismissed,
+	onRequestInstall,
+	status,
+	tabIndex,
+}: {
+	availableDismissed: boolean;
+	onRequestInstall: () => void;
+	status: UpdateStatus;
+	tabIndex: number;
+}) {
+	const { t, i18n } = useTranslation();
+	const locale = i18n.resolvedLanguage ?? i18n.language;
+	const action = sidebarUpdateAction(status, availableDismissed);
+	if (action?.kind !== "install") return null;
 
 	const versionLabel = updateVersionLabel(action.version, "ready", t, locale);
 	return (
@@ -2245,17 +2265,23 @@ function UpdateStatusRow({
 					: t("shell.restartInstallUpdate")
 			}
 			className={cn(
-				"flex w-full items-center gap-2.5 rounded-lg border border-success/35 bg-success/12 p-2.5 text-left text-control font-medium text-success transition-colors hover:bg-success/18 [&_svg]:text-success",
+				"mb-1 flex w-full items-center gap-2.5 rounded-xl bg-muted px-3 py-2.5 text-left text-sm font-normal text-foreground shadow-md",
+				"transition-colors hover:bg-interactive-hover",
+				"motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200",
 			)}
 			data-testid="sidebar-update-ready"
 			onClick={onRequestInstall}
 			tabIndex={tabIndex}
 			type="button"
 		>
-			<RefreshCw aria-hidden="true" className="size-icon-lg shrink-0" />
+			<RefreshCw aria-hidden="true" className="size-icon-sm shrink-0 text-muted-foreground" />
 			<span className="min-w-0 flex-1">
-				<span className="block truncate tracking-tight">{t("shell.restartToUpdate")}</span>
-				{versionLabel && <span className="block truncate text-caption font-normal">{versionLabel}</span>}
+				<span className="block tracking-tight">{t("shell.restartToUpdate")}</span>
+				{versionLabel ? (
+					<span className="mt-0.5 block break-words text-caption font-normal text-muted-foreground">
+						{versionLabel}
+					</span>
+				) : null}
 			</span>
 		</button>
 	);
@@ -2334,8 +2360,7 @@ function UpdateStatusRail({
 							: t("shell.restartInstallUpdate")
 					}
 					className={cn(
-						"grid size-9 place-items-center rounded-lg transition-colors [&_svg]:size-4",
-						"bg-success/12 text-success hover:bg-success/18",
+						"grid size-9 place-items-center rounded-lg bg-muted text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-4",
 					)}
 					onClick={onRequestInstall}
 					tabIndex={tabIndex}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -2243,8 +2243,8 @@ function UpdateStatusRow({
 }
 
 /**
- * Alert-style install cue above Connect mobile / Settings. Muted fill + shadow so
- * it reads apart from nav rows; shows the version number only (no Nightly/date).
+ * Alert-style install cue above Connect mobile / Settings. Muted fill so it
+ * reads apart from nav rows; shows the version number only (no Nightly/date).
  */
 function UpdateInstallSlide({
 	availableDismissed,
@@ -2265,12 +2265,12 @@ function UpdateInstallSlide({
 	return (
 		<button
 			aria-label={
-				action.version
-					? t("shell.restartInstallUpdateVersion", { version: action.version })
+				versionNumber
+					? t("shell.restartInstallUpdateVersion", { version: versionNumber })
 					: t("shell.restartInstallUpdate")
 			}
 			className={cn(
-				"mb-1 flex h-9 w-full items-center gap-2.5 rounded-xl bg-muted px-3 text-left text-sm font-normal text-foreground shadow-md",
+				"mb-1 flex h-9 w-full items-center gap-2.5 rounded-lg bg-muted px-3 text-left text-sm font-normal text-foreground",
 				"transition-colors hover:bg-interactive-hover",
 				"motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200",
 			)}
@@ -2360,8 +2360,8 @@ function UpdateStatusRail({
 			<TooltipTrigger asChild>
 				<button
 					aria-label={
-						action.version
-							? t("shell.restartInstallUpdateVersion", { version: action.version })
+						versionNumber
+							? t("shell.restartInstallUpdateVersion", { version: versionNumber })
 							: t("shell.restartInstallUpdate")
 					}
 					className={cn(

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -2162,6 +2162,12 @@ function updateVersionLabel(
 	return t(variant === "ready" ? "shell.versionReady" : "shell.versionAvailable", { version });
 }
 
+/** Plain version number for the install cue — base for nightlies, no channel/date. */
+function installVersionNumber(version: string | undefined): string | null {
+	if (!version) return null;
+	return parseNightlyVersion(version)?.base ?? version;
+}
+
 // UpdateStatusRow makes download progress visible in the footer. A staged build
 // ready to install renders as UpdateInstallSlide above Connect mobile / Settings.
 function UpdateStatusRow({
@@ -2238,7 +2244,7 @@ function UpdateStatusRow({
 
 /**
  * Alert-style install cue above Connect mobile / Settings. Muted fill + shadow so
- * it reads apart from nav rows; label only — version details live in the restart dialog.
+ * it reads apart from nav rows; shows the version number only (no Nightly/date).
  */
 function UpdateInstallSlide({
 	availableDismissed,
@@ -2255,6 +2261,7 @@ function UpdateInstallSlide({
 	const action = sidebarUpdateAction(status, availableDismissed);
 	if (action?.kind !== "install") return null;
 
+	const versionNumber = installVersionNumber(action.version);
 	return (
 		<button
 			aria-label={
@@ -2273,7 +2280,15 @@ function UpdateInstallSlide({
 			type="button"
 		>
 			<RefreshCw aria-hidden="true" className="size-icon-sm shrink-0 text-muted-foreground" />
-			<span className="min-w-0 flex-1 truncate tracking-tight">{t("shell.restartToUpdate")}</span>
+			<span className="min-w-0 flex-1 truncate tracking-tight">
+				{t("shell.restartToUpdate")}
+				{versionNumber ? (
+					<>
+						{" "}
+						<span className="text-muted-foreground">{versionNumber}</span>
+					</>
+				) : null}
+			</span>
 		</button>
 	);
 }
@@ -2339,6 +2354,7 @@ function UpdateStatusRail({
 		);
 	}
 
+	const versionNumber = installVersionNumber(action.version);
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
@@ -2358,7 +2374,10 @@ function UpdateStatusRail({
 					<RefreshCw aria-hidden="true" />
 				</button>
 			</TooltipTrigger>
-			<TooltipContent side="right">{t("shell.restartToUpdate")}</TooltipContent>
+			<TooltipContent side="right">
+				{t("shell.restartToUpdate")}
+				{versionNumber ? ` ${versionNumber}` : ""}
+			</TooltipContent>
 		</Tooltip>
 	);
 }


### PR DESCRIPTION
## Summary
- Restyle the staged Install Update cue as a muted alert chip above Connect mobile / Settings (no overlap, no green treatment)
- Show label-only copy (`Install Update`); nightly/version/date stay in the restart dialog
- Click still installs / opens the existing restart confirmation when sessions are at risk

## Test plan
- [ ] With a staged update (or local demo), confirm the chip sits above Connect mobile / Settings with no overlap
- [ ] Confirm the chip shows only “Install Update”
- [ ] Click the chip → restart dialog or install path still works
- [ ] Collapsed sidebar rail still shows the muted install icon
- [ ] `frontend` Sidebar update-related tests pass

