### PR TITLE
fix(chat): prevent recovery from completing live sends twice

### DIFF
--- a/frontend/src/renderer/components/chat/ChatComposer.test.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.test.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from "../ui/tooltip";
 import type { ChatSkill } from "../../types/conversation";
 import {
 	activateChatDraftScope,
+	markChatComposerDeliveryAccepted,
 	prepareChatComposerDelivery,
 	readChatSessionDraft,
 	writeChatComposerText,
@@ -328,6 +329,30 @@ describe("send keys", () => {
 		expect(field.textContent).toBe("do not lose this task");
 	});
 
+	it.each([false, true])("keeps the composer editable after a successful live send (queued: %s)", async (willQueue) => {
+		const sessionId = `composer-live-send-acceptance-${willQueue}`;
+		const pending = deferred<void>();
+		const onSend = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValue(undefined);
+		render(<ChatComposer draftSessionId={sessionId} onSend={onSend} willQueue={willQueue} />);
+		const field = screen.getByLabelText("Message the agent");
+		await typeInComposer(field, "send this once");
+		fireEvent.keyDown(field, { key: "Enter" });
+
+		await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+		expect(field).toHaveAttribute("contenteditable", "false");
+		await act(async () => pending.resolve());
+		await waitFor(() => expect(field.textContent).toBe(""));
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(field).toHaveAttribute("contenteditable", "true");
+		expect(readChatSessionDraft(sessionId).composer.delivery).toBeUndefined();
+
+		await typeInComposer(field, "send a second message");
+		fireEvent.keyDown(field, { key: "Enter" });
+		await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+		await waitFor(() => expect(field).toHaveAttribute("contenteditable", "true"));
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
 	it("unlocks a definitively rejected first send and gives the edited send a new identity", async () => {
 		const sessionId = "composer-first-send-refused";
 		const onSend = vi.fn()
@@ -419,6 +444,80 @@ describe("send keys", () => {
 			await typeInComposer(field, "a new message after recovery");
 			fireEvent.keyDown(field, { key: "Enter" });
 			await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+		} finally {
+			view.unmount();
+			localStorage.mockRestore();
+		}
+	});
+
+	it.each([false, true])("finishes a restored accepted delivery without sending again (delayed mount: %s)", async (delayedMount) => {
+		const sessionId = `composer-restarted-accepted-delivery-${delayedMount}`;
+		const prepared = prepareChatComposerDelivery(sessionId, {
+			kind: "send",
+			composerText: "already sent before restart",
+			attachments: [],
+			requestText: "already sent before restart",
+			clientMessageId: "restarted-accepted-delivery",
+		});
+		if (!prepared.ok) throw new Error("Failed to prepare test delivery");
+		markChatComposerDeliveryAccepted(sessionId, prepared.mutation.clientMessageId, prepared.mutation.revision);
+		const onSend = vi.fn();
+		const surface = (mode: "hidden" | "visible") => (
+			<Activity mode={mode}>
+				<ChatComposer draftSessionId={sessionId} onSend={onSend} />
+			</Activity>
+		);
+		const view = render(surface(delayedMount ? "hidden" : "visible"));
+		if (delayedMount) {
+			await screen.findByLabelText("Message the agent");
+			const active = render(<ChatComposer draftSessionId={sessionId} onSend={onSend} />);
+			await waitFor(() => expect(readChatSessionDraft(sessionId).composer.delivery).toBeUndefined());
+			active.unmount();
+			view.rerender(surface("visible"));
+		}
+
+		const field = screen.getByLabelText("Message the agent");
+		await waitFor(() => expect(field).toHaveAttribute("contenteditable", "true"));
+		expect(field.textContent).toBe("");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(readChatSessionDraft(sessionId).composer.delivery).toBeUndefined();
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
+	it.each(["read", "write"])("preserves safe retry when recording acceptance fails to %s storage", async (failure) => {
+		const sessionId = `composer-live-acceptance-storage-failure-${failure}`;
+		const durableStorage = window.localStorage;
+		let failAcceptance = false;
+		const storage = {
+			getItem: (key: string) => {
+				if (failAcceptance && failure === "read") throw new DOMException("blocked", "SecurityError");
+				return durableStorage.getItem(key);
+			},
+			removeItem: durableStorage.removeItem.bind(durableStorage),
+			setItem: (key: string, value: string) => {
+				if (failAcceptance && failure === "write" && key.includes(sessionId) && JSON.parse(value).composer?.delivery?.state === "accepted") {
+					throw new DOMException("full", "QuotaExceededError");
+				}
+				durableStorage.setItem(key, value);
+			},
+		} as Storage;
+		const localStorage = vi.spyOn(window, "localStorage", "get").mockReturnValue(storage);
+		const onSend = vi.fn().mockImplementationOnce(async () => { failAcceptance = true; }).mockResolvedValue(undefined);
+		const view = render(<ChatComposer draftSessionId={sessionId} onSend={onSend} />);
+		try {
+			const field = screen.getByLabelText("Message the agent");
+			await typeInComposer(field, "accepted but not recorded");
+			fireEvent.keyDown(field, { key: "Enter" });
+			expect(await screen.findByRole("alert")).toHaveTextContent("acceptance couldn’t be recorded");
+			expect(field).toHaveAttribute("contenteditable", "false");
+
+			failAcceptance = false;
+			expect(readChatSessionDraft(sessionId).composer.delivery?.state).toBe("dispatching");
+			await userEvent.click(screen.getByRole("button", { name: "Retry message safely" }));
+			await waitFor(() => expect(field).toHaveAttribute("contenteditable", "true"));
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+			expect(onSend).toHaveBeenCalledTimes(2);
+			expect(onSend.mock.calls[1]).toEqual(onSend.mock.calls[0]);
 		} finally {
 			view.unmount();
 			localStorage.mockRestore();
@@ -899,6 +998,39 @@ describe("steering", () => {
 		const draft = readChatSessionDraft({ sessionId, incarnation });
 		expect(draft.composer.text).toBe("possibly delivered guidance");
 		expect(draft.composer.delivery).toBeUndefined();
+	});
+
+	it.each([false, true])("keeps live steer completion owned until its response settles (response lost: %s)", async (responseLost) => {
+		const sessionId = `steer-live-snapshot-${responseLost}`;
+		const pending = deferred<void>();
+		const onSteer = vi.fn(async () => {
+			await pending.promise;
+			if (responseLost) throw new Error("response lost");
+		});
+		const props = {
+			onSend: vi.fn().mockResolvedValue(undefined),
+			onSteer,
+			canSteer: true,
+			willQueue: true,
+			draftSessionId: sessionId,
+		};
+		const view = render(<ChatComposer {...props} />);
+		const field = screen.getByLabelText("Message the agent");
+		await typeInComposer(field, "steer exactly once");
+		fireEvent.keyDown(field, { key: "Enter", ctrlKey: true });
+		await waitFor(() => expect(onSteer).toHaveBeenCalledOnce());
+		const clientMessageId = readChatSessionDraft(sessionId).composer.delivery!.clientMessageId;
+
+		view.rerender(<ChatComposer {...props} acceptedClientMessageIds={new Set([clientMessageId])} />);
+		expect(field).toHaveAttribute("contenteditable", "false");
+		expect(readChatSessionDraft(sessionId).composer.delivery?.state).toBe("dispatching");
+		await act(async () => pending.resolve());
+
+		await waitFor(() => expect(field).toHaveAttribute("contenteditable", "true"));
+		expect(field.textContent).toBe("");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(readChatSessionDraft(sessionId).composer.delivery).toBeUndefined();
+		expect(onSteer).toHaveBeenCalledOnce();
 	});
 
 	it("reconciles a restored steer from the daemon snapshot without redispatch", async () => {

--- a/frontend/src/renderer/components/chat/ChatComposer.tsx
+++ b/frontend/src/renderer/components/chat/ChatComposer.tsx
@@ -80,6 +80,7 @@ import {
 	finishChatComposerMutation,
 	getChatComposerMutation,
 	isChatComposerMutationCurrent,
+	loadChatSessionDraft,
 	markChatComposerDeliveryAccepted,
 	prepareChatComposerDelivery,
 	readChatSessionDraft,
@@ -684,11 +685,6 @@ export const ChatComposer = memo(function ChatComposer({
 				);
 				return false;
 			}
-			const acceptedDelivery = accepted.draft.composer.delivery ?? {
-				...delivery,
-				state: "accepted" as const,
-			};
-			setDurableDelivery(acceptedDelivery);
 			return clearAcceptedDraft(delivery.revision, mutationToken);
 		},
 		[clearAcceptedDraft, draftScope],
@@ -790,16 +786,28 @@ export const ChatComposer = memo(function ChatComposer({
 
 	useEffect(() => {
 		if (!durableDelivery || !draftScope) return;
+		// The live send owns completion until its receipt has been applied.
+		if (composerMutation.pending || composerMutation.accepted) return;
+		// A replacement can commit after another surface cleared its rendered seed.
+		const current = loadChatSessionDraft(draftScope);
+		// A failed read cannot prove that the delivery was cleared.
+		const delivery = current.ok ? current.draft.composer.delivery : durableDelivery;
+		if (!delivery || delivery.clientMessageId !== durableDelivery.clientMessageId) {
+			setDurableDelivery(delivery);
+			return;
+		}
 		const observedSteer =
-			durableDelivery.kind === "steer" &&
-			acceptedClientMessageIds?.has(durableDelivery.clientMessageId);
-		if (durableDelivery.state !== "accepted" && !observedSteer) return;
-		if (automaticDeliveryRecoveryAttempted.current === durableDelivery.clientMessageId) return;
-		automaticDeliveryRecoveryAttempted.current = durableDelivery.clientMessageId;
-		acceptAndClearDurableDelivery(durableDelivery);
+			delivery.kind === "steer" &&
+			acceptedClientMessageIds?.has(delivery.clientMessageId);
+		if (delivery.state !== "accepted" && !observedSteer) return;
+		if (automaticDeliveryRecoveryAttempted.current === delivery.clientMessageId) return;
+		automaticDeliveryRecoveryAttempted.current = delivery.clientMessageId;
+		acceptAndClearDurableDelivery(delivery);
 	}, [
 		acceptAndClearDurableDelivery,
 		acceptedClientMessageIds,
+		composerMutation.pending,
+		composerMutation.accepted,
 		draftScope,
 		durableDelivery,
 	]);

--- a/frontend/src/renderer/lib/chat-drafts.ts
+++ b/frontend/src/renderer/lib/chat-drafts.ts
@@ -785,7 +785,10 @@ function isChatSessionDraft(value: unknown, scope: ChatDraftScope): value is Cha
 
 type DraftReadResult = { ok: true; draft: ChatSessionDraft } | { ok: false; draft: ChatSessionDraft };
 
-function loadChatSessionDraft(scopeInput: ChatDraftScopeInput, storage: DraftStorage | undefined): DraftReadResult {
+export function loadChatSessionDraft(
+	scopeInput: ChatDraftScopeInput,
+	storage: DraftStorage | undefined = rendererStorage(),
+): DraftReadResult {
 	const scope = normalizeScope(scopeInput);
 	const empty = emptyDraft(scope);
 	if (!scope.sessionId || !scope.incarnation || !storage) return { ok: false, draft: empty };


### PR DESCRIPTION
Code changes: +23 -12  
Tests: +132 -0  
Others: +0 -0

A successful send could display “Message acceptance couldn’t be recorded locally” and leave the composer disabled until switching chats. This fixes the regression introduced in #5106.

The live send now owns completion until its result has been applied. It no longer publishes an intermediate accepted UI state that wakes recovery and acknowledges the same delivery twice. Recovery rereads the saved journal before acting, so a replacement composer cannot resurrect a delivery another surface already cleared. Actual storage failures still preserve the delivery ID for safe retry.

Validation:

- Reproduced the reported false error twice on the original implementation; the regression passes with this fix.
- Eight new regression cases cover ordinary and queued sends, immediate second sends, restored accepted deliveries, delayed composer mounts, storage read/write failures, and steer receipt races (including a lost response).
- The composer, draft-storage, and chat-workspace suites pass: 254 tests.
- Full frontend suite passes: 301 files, 4,431 tests passed and 6 skipped (`AO_AGENT_BROWSER_TEST_BINARY=... npx vitest run --maxWorkers=2`, Node 24).
- Frontend and E2E TypeScript checks pass.
- Shared product UI checks pass (126 tests, typecheck, build/package dry-run); cloud client checks pass (21 tests, generated-contract drift, typecheck, build/package dry-run).
- Landing favicon verification passes.
- Native macOS helper checks pass: 13 Node tests, x64 and arm64 compilation/architecture checks, and Swift state tests.
- Renderer smoke suite passes: 59 tests on local macOS Chromium with the CI smoke command.
