### PR TITLE
chore(release): add 0.13.0 changelog entry, stamp version 0.13.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "agent-orchestrator",
-	"version": "0.10.3",
+	"version": "0.13.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "agent-orchestrator",
-			"version": "0.10.3",
+			"version": "0.13.0",
 			"license": "MIT",
 			"dependencies": {
 				"@aoagents/product-ui": "file:../packages/product-ui",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agent-orchestrator",
 	"productName": "Agent Orchestrator",
-	"version": "0.10.3",
+	"version": "0.13.0",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",
 	"author": "Agent Orchestrator",

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-12-0.mdx
@@ -1,0 +1,99 @@
+---
+title: "Agent Orchestrator 0.12.0"
+description: "80 commits since 0.11.2. The desktop app now speaks eight languages, sits on a new color palette, and lets you pin sessions and pick a reviewer per session. The mobile app got theming and hold-to-talk dictation. Containers a session started get cleaned up when it dies."
+date: "2026-08-05T06:52:44Z"
+---
+
+> Covers everything since **v0.11.2**.
+>
+> **macOS users should go straight to [0.12.1](/changelog/agent-orchestrator-0-12-1) or later.** This build leaks file descriptors and breaks the Files view and task creation after a few hours of use.
+
+0.11.0 was about the foundation holding weight. 0.12.0 is what got built on it: the app now speaks eight languages, the sidebar and settings work the way you would expect them to, and a class of failure that could wipe every session off your board is gone.
+
+80 commits from 22 authors, 26 features and 44 fixes, no breaking changes.
+
+---
+
+## Highlights
+
+### The app speaks eight languages
+
+The desktop app has a real localization layer now, built on i18next, with the language picked under **Settings > General** and remembered in `~/.ao/ui-settings.json`. Simplified Chinese landed first and covers the shell chrome, sidebar, board, settings, dialogs, inspector tabs, command palette and terminal copy. Japanese, Korean, Spanish, French, German and Brazilian Portuguese followed, along with READMEs in each. English stays the default and the fallback, so an untranslated string shows English rather than a key. (#3465, #3541)
+
+### Mobile: themes, native sheets, and hold-to-talk
+
+The mobile app is no longer dark-only. It ships light and dark palettes plus a "system" preference that keeps following the OS instead of latching onto whatever it read at launch, with the app shell rebuilt on native sheets and the session board splitting on terminated runtime rather than finished status.
+
+It also has **push-to-talk dictation**. Hold the mic key in the composer to speak, release to insert, or swipe up to latch it hands-free. Recognition runs on-device (iOS `SFSpeechRecognizer`, Android `SpeechRecognizer`), so there is no API key and no per-minute cost, and it is biased toward the vocabulary that agent prompts are full of, so you get "git" and "npm" instead of "get" and "MPM". The transcript lands in the composer as an editable draft rather than sending, because speech-to-text mishears code often enough that silent submission is not safe. Held bursts append, so several presses build one prompt.
+
+Plus a Liquid Glass app icon matching the desktop build, and a fix for the default LAN port, which pointed at the loopback-only daemon port instead of the mobile bridge on 3011, so a fresh install could not connect without hand-editing it. (#3399, #3400, #3304, #3494)
+
+### A new color foundation
+
+The renderer moved onto an oklch design token palette with Geist as the UI font and shadcn color aliases mapped onto it, replacing hardcoded values across the component library. Session status now has one consistent palette everywhere it appears: working is blue, needs-you is orange, in-review is yellow, ready is green. (#3421)
+
+### Pin the sessions you keep coming back to
+
+Sessions can be pinned to a **Pinned** section at the top of the sidebar, persisted server-side so the pin survives a restart. The sidebar itself became collapsible: Pinned and Projects each fold away, and a click on a project's folder icon expands or collapses it without switching to it first. (#3511, #3310)
+
+### Pick the reviewer per session
+
+The reviewer agent used to be a single project-wide setting. You can now pick one for an individual session, and running that pass will not change what any other session in the project uses. The Reviews tab also lists every recorded pass for the session instead of only the current and previous run for a PR, so you can compare what two different reviewers said. A declined review, when the daemon reuses an existing pass rather than running a new one, no longer reports itself as a success. (#3477)
+
+### Settings opens as a modal
+
+Settings and project settings open over the board instead of navigating away from it, with a sidebar for General, Updates, Developer and Help. Escape or a click outside closes it, and you land back where you were. (#3497)
+
+### Notifications you can act on
+
+When a session needs you and the window is not focused, the macOS dock bounces, the Windows taskbar flashes until you come back, and the badge count of unread notifications stays in sync on macOS, Windows and Linux.
+
+Inside the panel, whole rows are click targets rather than just the title text, and the manual Unread/All tabs and mark-as-read are gone. Notifications now track two independent things: whether you have seen it (cleared when you open the panel) and whether the underlying issue is still open (written only by lifecycle). A notification you already read stays listed while the thing it reported is unresolved, and closes itself when the session leaves the needs-input state, terminates, or the PR merges or closes. Transitions that happened while the daemon was down are re-checked at startup. (#2534, #3296, #3495, #3558)
+
+### Command palette actions and a menu bar tray
+
+Cmd/Ctrl+K now carries session actions, not just navigation, and the task composer behind New Task was extracted so the palette can spawn work with the same UI. macOS also gets an attention tray icon in the menu bar for sessions waiting on you. (#3531)
+
+### Containers a session started get cleaned up
+
+Docker containers a session launched are removed when that session reaches a terminal state, including when it crashes or is SIGKILLed rather than only when you kill it explicitly. Label a container `ao.session=$AO_SESSION_ID` to have it reaped, or `ao.spare=true` for shared infrastructure that should outlive the session. Docker calls are bounded by a timeout, and a project that fails to load fails closed rather than reaping. (#3153)
+
+### Files and diffs
+
+The Files panel replaced its toggled search button and file-count label with an always-visible search input, dropped the refresh button (the list already polls), and rebuilt the list as an accordion with a live file count on the tab. The diff viewer streams workspace changes as they happen, has a clearer layout toggle and inline per-file feedback, and expands properly in the maximized view. Workspace diffs are also base-aware now, so a child session diffs against the branch it actually came from instead of a fixed base. (#3466, #3503, #3492, #3369, #3214)
+
+---
+
+## Reliability
+
+**One outage no longer wipes your board.** This was the big one (#3475). Three separate bugs could archive every session at once. Preview teardown group-killed a bare PID without re-verifying it still belonged to the process it launched, and a recycled PID number took out an unrelated process family; because a tmux server is its own group leader, one stale group kill destroyed every session. A tmux "no server running" probe was read as per-session death when it says nothing about any individual session, so a server hiccup archived the board. And a burned migration returned 500s that the board treated as absent sessions. Liveness probes now report inconclusive instead of dead, the reaper refuses to conclude a pass where most of the board probes dead simultaneously, and the migration ledger repairs itself on histories that were already burned. (#3491, #3598)
+
+**Orchestrators.** Duplicate active orchestrators can no longer be created for the same project, `ao session ls` surfaces hidden orchestrator sessions and counts hidden terminated ones instead of quietly dropping them, and the automated orchestrator re-engagement messages were reverted after they proved noisier than useful. (#3397, #3393, #3394)
+
+**Agents.** Droid forwards role-specific model config through its settings file, written under the data dir rather than a temp directory. Grok prompts are delivered after its TUI finishes starting instead of into a terminal that is not listening yet, and its terminal scrolls with the wheel. The internal fake test harness no longer shows up in agent pickers. (#3156, #3534, #3533, #3518)
+
+**Browser.** Annotation selection is locked while a prompt is in flight so a click cannot retarget it mid-send, native views no longer paint over the app when hidden, URL editing works in the maximized browser on macOS, the element selector badge is out of the annotation dialog, and switching away from a session and back no longer re-asserts a preview URL you had already navigated away from. (#3232, #3295, #3488, #3464, #3538, #3370)
+
+**Desktop.** The auto-updater logs 404s on missing release manifests instead of raising a dialog telling you to check an auth token you do not have. Sidebar and inspector drags clamp at their minimum width rather than snapping shut. The daemon ignores SIGPIPE on closed output. PR and Completion sections in the inspector stay hidden when there is nothing in them, and duplicate PR summaries are deduped. Alongside those, a pass of chrome fixes: titlebar nav aligned to the macOS traffic lights, terminal tab bar polish, settings and archive hairlines, terminal topbar padding, and text selection disabled on app chrome and marketing pages. (#3012, #3478, #3193, #3325, #3250, #3505, #3480, #3507, #3556, #3508, #3520)
+
+---
+
+## Under the hood
+
+Telemetry gained a runtime kill switch: `AO_TELEMETRY_DISABLED_EVENTS` silences named streams (with `*` prefix matching) without shipping a release, and silenced streams still land in local SQLite so they stay debuggable. Daemon events are stamped with a version, update events are recorded, PostHog controls were hardened, and autocapture is asserted off in tests. CI now emits a Linux `.rpm` alongside the `.deb`.
+
+On the site: docs are published as Markdown twins with the full hierarchy exposed in `llms.txt`, agent comparison pages were added, the hero board, delegation demo and mobile mockup were rebuilt to match what the desktop app actually looks like, and the iOS beta CTA went live. Duplicate Organization structured data was removed and content signals now apply to allowed crawlers. (#3401, #3388, #3406, #3395, #3363, #3438, #3344, #3430, #3496, #3428, #3429, #3500, #3521, #3522, #3144, #3367, #3365, #3389)
+
+---
+
+## Upgrading
+
+GitHub Releases and Homebrew are the supported install paths. Existing installs update in place. If a previous update left your migration ledger in a broken state, 0.12.0 repairs it on start rather than failing the boot.
+
+---
+
+## Contributors
+
+22 authors landed work in this range. Thanks to Just_Anniee, prateek, ronish, VenkataSakethDakuri, Vaibhaav Tiwari, Prasad Ware, Pulkit Saraf, Khushi Diwan, Harshit Singh Bhandari, Tamish Mhatre, Maaz, Hardik Sharma, Anmol, AllBeingsFuture, Aditi, vanshx999, i-trytoohard, achal, Yash Maheshwari, Keshav Varshney, AshutoshIIT1234 and Apoorv Singh.
+
+**Full changelog:** https://github.com/Untrivial-ai/agent-orchestrator/compare/v0.11.2...v0.12.0

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-13-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-13-0.mdx
@@ -1,0 +1,82 @@
+---
+title: "Agent Orchestrator 0.13.0"
+description: "99 commits since 0.12.12. Diffs and files big enough to lag before now scroll smoothly, chat providers stay alive across daemon restarts, ao doctor checks every installed harness, and project import can create the GitHub repo for you. 74 fixes behind that."
+date: "2026-09-12T11:50:00+05:30"
+---
+
+> Covers everything since **v0.12.12**. If you are on 0.12.x and updating in place, this is all you skipped.
+
+0.12.12 was a patch train that never got its own changelog, so the smaller releases between 0.12.0 and now are folded in below only where a 0.13.0 feature builds on them. Everything else here shipped in this cycle: 99 commits from 28 authors, 18 features and 74 fixes, no breaking changes.
+
+---
+
+## Highlights
+
+### A diff viewer that keeps up
+
+The diff and file viewers are virtualized now. Only the rows on screen render, so a 5,000-line diff or a minified bundle scrolls instead of freezing the inspector, and file previews got the same treatment with selectable text and proper close buttons. (#5175, #5012)
+
+### Chat providers survive daemon restarts
+
+Codex and the ACP chat providers already survived the desktop app closing. Now they survive the daemon restarting underneath them: the provider process is detached and re-adopted after the daemon comes back, the conversation snapshot and pending approvals are restored, and an in-flight turn keeps its place instead of dying mid-stream. (#4766)
+
+### ao doctor knows every harness
+
+`ao doctor` now probes all 26 registered agent harness binaries — installed, on PATH, authenticated — instead of the handful it knew about, so "why is this agent missing from the picker" is a one-command answer. Session list status got richer alongside it, and finished sessions show PR progress instead of going quiet at merge time. (#5025, #4028, #4916)
+
+### Import a project, create the repo too
+
+Project import can now create the GitHub repository as part of onboarding instead of bouncing you to github.com, with a simpler import setup and finalized workspace import flows behind it. (#5092, #5118, #4945)
+
+### Browser screenshots and downloads
+
+Agents can capture what the browser shows and save files from it, so "screenshot this page" and "download the artifact" are things the session can actually do. (#4994)
+
+### Editor handoff and terminal shortcuts
+
+`Open in editor` hands the file to Neovim cross-platform, not just GUI editors, and macOS terminals gained line-boundary shortcuts (option/shift-arrow word and line movement) that match Terminal.app. (#4723, #5199)
+
+### Updates that finish the job
+
+The sidebar download row became a live install flow — pick a release, watch it download, install from there — with a macOS repair installer for machines where a staged build was rejected, and the updater now owns a download it started instead of dropping it mid-flight. (#5047, #5002, #4981, #5032)
+
+### Also new
+
+- The all-sessions board is back, across every project in one view (#5249)
+- Cursor's Ask and Agent show as execution modes, and tool calls render as readable cards in chat (#4978, #5027)
+- App icons on every platform derive from the desktop Ruto icon (#5079, #5238)
+- Closed sessions that never merged show in red on the board (#5165)
+
+---
+
+## Reliability
+
+**Queued messages became durable.** Edits to queued messages persist with atomic delivery receipts, inline edits recover from durable branch receipts on reconnect, attachments survive editing and restarts, and a failed turn holds the queue instead of draining it into the same error. Composer text itself persists across lifecycle boundaries. (#5109, #5110, #5006, #5107, #5188, #5106, #5274)
+
+**Terminals stop dying at the wrong moment.** PTY output is back-pressured instead of killing the WebSocket on a burst, the shell renderer is no longer leaked when the window closes, user shells are preserved across relaunches, and terminal focus is restored after fullscreen and restart. (#4552, #5150, #5040, #4988)
+
+**Mobile tunnels behave.** LAN connections close when mobile access is disabled, bridge state transitions are serialized, and Windows terminal popups no longer fire through mobile tunnels. Codex model routes no longer block on the LAN listener. (#5087, #5084, #5205, #5152)
+
+**Restore checks before it restores.** `--resume` verifies the persisted session before attaching, sessions can switch to terminal until they have real work, and OpenCode keeps its Plan Mode selection across switches. (#5214, #5053, #5015)
+
+**Smaller fixes that mattered:** change log retention is bounded so the CDC table stops growing forever, nightly build stamps parse as UTC instead of local wall time, percent-encoded ACP approval ids decode instead of failing approval, the resolve-comments route validates its PR number, GitLab responses keep cache consistency, and the board re-renders on change events instead of on poll ticks. (#5103, #5115, #5193, #5239, #5148, #4854)
+
+---
+
+## Site and housekeeping
+
+The public site migrated to useao.dev, the bug report form got shorter, and session and reviewer avatars render through one path. (#5133, #5153, #4764)
+
+---
+
+## Upgrading
+
+GitHub Releases and Homebrew are the supported install paths. Existing installs update in place. If a previous macOS update left a staged build that will not install, the repair installer in this release rebuilds in place. No migrations are destructive and no configuration changes are required.
+
+---
+
+## Contributors
+
+28 authors landed work in this range. Thanks to prateek, Dhruv Sharma, ronish, Ayash, NIKHIL ACHALE, Pulkit Saraf, Aditi, Maaz, Prasad Ware, Vaibhaav Tiwari, Harshit Singh Bhandari, Just_Anniee, Sundaram Kumar Jha, vicky prasad, Aniket Vishwakarma, Khushi Diwan, Misbah Ansari, Piyush Mudgal, Rishet Mehra, Yash Kumar Saini, Anusha, Hendrixx, Soubhagya Sadhukhan, Vansh Singhal, Yash Maheshwari, axisrow, pikachu and vanshx999.
+
+**Full changelog:** https://github.com/Untrivial-ai/agent-orchestrator/compare/v0.12.12...v0.13.0

--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-13-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-13-0.mdx
@@ -1,82 +1,111 @@
 ---
 title: "Agent Orchestrator 0.13.0"
-description: "99 commits since 0.12.12. Diffs and files big enough to lag before now scroll smoothly, chat providers stay alive across daemon restarts, ao doctor checks every installed harness, and project import can create the GitHub repo for you. 74 fixes behind that."
-date: "2026-09-12T11:50:00+05:30"
+description: "668 commits and 635 merged PRs from 51 authors since 0.12.0. AO Cloud's control plane landed in the monorepo, chat became a first-class surface whose providers survive daemon restarts, a wave of new agent harnesses joined the roster, and the terminal went real-time."
+date: "2026-09-12T11:55:00+05:30"
 ---
 
-> Covers everything since **v0.12.12**. If you are on 0.12.x and updating in place, this is all you skipped.
+> Covers everything since **v0.12.0**. The 0.12.1–0.12.12 patch releases carried most of the fixes but never got their own entries, so the whole cycle is folded into this one. If you are on 0.12.0, this is everything you skipped.
 
-0.12.12 was a patch train that never got its own changelog, so the smaller releases between 0.12.0 and now are folded in below only where a 0.13.0 feature builds on them. Everything else here shipped in this cycle: 99 commits from 28 authors, 18 features and 74 fixes, no breaking changes.
+0.12.0 was polish on the foundation: languages, palette, pins, notifications. 0.13.0 is the cycle where the product grew new limbs. A cloud control plane now lives in the repo behind a flag. Chat stopped being a view and became a durable surface. The agent roster roughly doubled. And the two ugliest classes of failure left — a restart taking your in-flight turn with it, and a big diff freezing the inspector — both got structural fixes.
+
+668 commits from 51 authors, 174 features and 409 fixes, no breaking changes.
 
 ---
 
 ## Highlights
 
+### AO Cloud is in the repo
+
+The private control plane — a separate Go service with a 28-table PostgreSQL schema, WorkOS sign-in, GitHub App installations and webhooks, organization-scoped projects and sessions, durable message queues, event replay and cluster-safe SSE reconnects — now lives in this monorepo, wired to an authenticated Next.js Cloud UI through new `@aoagents/cloud-client` and `@aoagents/product-ui` packages and a public cloud contract. Desktop sign-in gained native WorkOS auth. Everything is flag-gated; nothing changes for local-only users yet. (#4434, #3692, #4722)
+
+### Chat is first-class, and it survives restarts
+
+The composer was redesigned around resolved agent and model defaults, with a queued message dock that supports editing, cancel, drag-to-reorder and attachments that survive restarts. Queued turns can be promoted to steer the active turn. Claude Code conversations gained message editing, failed turns retry without retyping the prompt, and tool calls render as readable cards instead of raw dumps.
+
+Under it all, Codex and the ACP chat providers are owned by authenticated detached hosts now: close the desktop app, restart the daemon, and the provider is re-adopted with its conversation snapshot, pending approvals and in-flight turn intact. (#3657, #4649, #4684, #4715, #3838, #3858, #4256, #5027, #4529, #4766)
+
+### The agent roster grew
+
+New harnesses and drivers landed across the cycle: Kimchi, Kimi, Pi, OMP, Prime Agent, Muse Code, and a Cursor ACP chat driver, with adapter-aware model selection, per-provider model catalogs and discovery, `--model` on `ao spawn` with per-session scoping, and an `act` primitive that resolves instructions and retries stale references. `ao doctor` now probes all 26 registered harness binaries, so "why is this agent missing" is a one-command answer. (#2649, #4193, #4194, #4196, #3736, #3647, #4201, #3386, #4610, #4102, #4244, #5025)
+
+### Real-time terminal
+
+The terminal is a duplex stream with predictive local echo now, backed by native PTY hosts on macOS and Linux, selectable Windows shells, line-boundary editing shortcuts on macOS, and tab cycling shortcuts. Output bursts are back-pressured instead of killing the WebSocket. (#4763, #4768, #4473, #4727, #4517, #5199, #3658, #4552)
+
 ### A diff viewer that keeps up
 
-The diff and file viewers are virtualized now. Only the rows on screen render, so a 5,000-line diff or a minified bundle scrolls instead of freezing the inspector, and file previews got the same treatment with selectable text and proper close buttons. (#5175, #5012)
+Diff and file viewers are virtualized — only the rows on screen render — so a 5,000-line diff scrolls instead of freezing. Alongside them: a full-tree file explorer next to the changed-files view, GitHub-style Markdown rendering, mermaid fences drawn as diagrams, before/after previews for image files, and file previews you can select text in and close. (#5175, #4252, #4251, #4892, #4173, #5012)
 
-### Chat providers survive daemon restarts
+### Reviews, end to end
 
-Codex and the ACP chat providers already survived the desktop app closing. Now they survive the daemon restarting underneath them: the provider process is detached and re-adopted after the daemon comes back, the conversation snapshot and pending approvals are restored, and an in-flight turn keeps its place instead of dying mid-stream. (#4766)
+Interactive reviewer panes work for every agent harness, review passes can auto-start for pull requests, and the project can carry its own auto-review config. The Reviews inspector merged into one list with pagination for unresolved comments, external reviews support inline comments, PR readiness cards were redesigned, and the review funnel is instrumented end to end. (#3384, #3338, #4128, #3664, #4032, #4131, #4055, #4255)
 
-### ao doctor knows every harness
+### Mobile ships
 
-`ao doctor` now probes all 26 registered agent harness binaries — installed, on PATH, authenticated — instead of the handful it knew about, so "why is this agent missing from the picker" is a one-command answer. Session list status got richer alongside it, and finished sessions show PR progress instead of going quiet at merge time. (#5025, #4028, #4916)
+AO Mobile went live on both app stores, with a TestFlight flow, over-the-air updates via EAS, Connect Mobile pairing over Tailscale including iOS, a device roster to see, mute and remove paired phones, PostHog analytics and Sentry-ready error capture. (#4761, #3689, #4474, #3707, #3674, #3661, #4181)
 
-### Import a project, create the repo too
+### Agent switching you can trust
 
-Project import can now create the GitHub repository as part of onboarding instead of bouncing you to github.com, with a simpler import setup and finalized workspace import flows behind it. (#5092, #5118, #4945)
+Switching a session between TUI and Chat became durable, responsive and phase-aware, with failure-only observability capturing exactly where a switch dies. Interfaces without a Chat UI hide the switch instead of offering it. (#3548, #3770, #4598, #3966)
 
-### Browser screenshots and downloads
+### The desktop got a facelift
 
-Agents can capture what the browser shows and save files from it, so "screenshot this page" and "download the artifact" are things the session can actually do. (#4994)
+A focused home page, a vertical tabs rail replacing the tab dropdown, Nord, Gruvbox and Solarized themes, drag-to-reorder for projects and sessions, session renaming from navigation surfaces, and app icons derived from the Ruto mascot on every platform. (#4549, #4781, #3668, #3585, #4274, #4874, #5079, #5238)
 
-### Editor handoff and terminal shortcuts
+### Browser that agents can actually use
 
-`Open in editor` hands the file to Neovim cross-platform, not just GUI editors, and macOS terminals gained line-boundary shortcuts (option/shift-arrow word and line movement) that match Terminal.app. (#4723, #5199)
+Per-session browser profiles persist cookies and history across sessions, agents can capture screenshots and save downloads from the page, and annotation gained multi-element select with contextual shortcuts. (#4135, #4994, #3549, #4643)
 
-### Updates that finish the job
+### GitLab joins GitHub
 
-The sidebar download row became a live install flow — pick a release, watch it download, install from there — with a macOS repair installer for machines where a staged build was rejected, and the updater now owns a download it started instead of dropping it mid-flight. (#5047, #5002, #4981, #5032)
+A GitLab SCM integration landed behind a multi-provider dispatcher, with response and cache consistency handled per provider. (#2773, #5148)
+
+### Onboarding without the dead ends
+
+Import from a Git URL, a full project import flow with validation APIs and optimistic loading, GitHub repository creation during import, folder drag-and-drop, flags for projects whose local folder went missing, remembered permission defaults, and a startup gate that checks real system requirements (git, tmux, harness, gh) with one-click install. (#4104, #4872, #4760, #5127, #5092, #4065, #4894, #4956, #3825)
 
 ### Also new
 
-- The all-sessions board is back, across every project in one view (#5249)
-- Cursor's Ask and Agent show as execution modes, and tool calls render as readable cards in chat (#4978, #5027)
-- App icons on every platform derive from the desktop Ruto icon (#5079, #5238)
-- Closed sessions that never merged show in red on the board (#5165)
+- **Editor handoff**: cross-platform Neovim support next to the GUI editors, plus an Open-in-editor button beside Kill (#4723, #3284)
+- **Attention sound**: a beep when an agent needs input or a PR is ready, and the macOS Dock bounces on notifications (#4051, #4115)
+- **Harness setup in settings**: installer settings and harness login actions in one place (#4221, #4523)
+- **Usage and cost**: event-driven per-session token usage, Kimi usage observability, estimated costs (#2928, #4311, #4168)
+- **Updates**: sidebar downloads became a live install flow, with a macOS repair installer for machines where a staged build was rejected (#5047, #5002, #4981)
+- **Board**: the all-sessions board is back, finished sessions show PR progress, closed-without-merge shows in red (#5249, #4916, #5165)
+- **Connectivity**: the mobile client races every advertised endpoint to connect from any network (#4615)
 
 ---
 
 ## Reliability
 
-**Queued messages became durable.** Edits to queued messages persist with atomic delivery receipts, inline edits recover from durable branch receipts on reconnect, attachments survive editing and restarts, and a failed turn holds the queue instead of draining it into the same error. Composer text itself persists across lifecycle boundaries. (#5109, #5110, #5006, #5107, #5188, #5106, #5274)
+The 409 fixes were mostly grind work, but a few groups deserve their name in lights.
 
-**Terminals stop dying at the wrong moment.** PTY output is back-pressured instead of killing the WebSocket on a burst, the shell renderer is no longer leaked when the window closes, user shells are preserved across relaunches, and terminal focus is restored after fullscreen and restart. (#4552, #5150, #5040, #4988)
+**Queued messages became durable.** Edits persist with atomic delivery receipts, inline edits recover from durable branch receipts on reconnect, attachments survive editing and restarts, and a failed turn holds the queue instead of draining it into the same error. (#5109, #5110, #5006, #5107, #5188, #5106, #5274)
 
-**Mobile tunnels behave.** LAN connections close when mobile access is disabled, bridge state transitions are serialized, and Windows terminal popups no longer fire through mobile tunnels. Codex model routes no longer block on the LAN listener. (#5087, #5084, #5205, #5152)
+**Terminals stop dying at the wrong moment.** Back-pressured PTY output, no more leaked shell renderer on window close, user shells preserved across relaunches, and focus restored after fullscreen and restart. (#4552, #5150, #5040, #4988)
 
-**Restore checks before it restores.** `--resume` verifies the persisted session before attaching, sessions can switch to terminal until they have real work, and OpenCode keeps its Plan Mode selection across switches. (#5214, #5053, #5015)
+**Restore checks before it restores.** `--resume` verifies the persisted session before attaching, sessions can switch to terminal until they have real work, and OpenCode keeps its Plan Mode selection. (#5214, #5053, #5015)
 
-**Smaller fixes that mattered:** change log retention is bounded so the CDC table stops growing forever, nightly build stamps parse as UTC instead of local wall time, percent-encoded ACP approval ids decode instead of failing approval, the resolve-comments route validates its PR number, GitLab responses keep cache consistency, and the board re-renders on change events instead of on poll ticks. (#5103, #5115, #5193, #5239, #5148, #4854)
+**Smaller fixes that mattered:** change log retention is bounded so the CDC table stops growing forever, nightly build stamps parse as UTC, percent-encoded ACP approval ids decode instead of failing, the resolve-comments route validates its PR number, and the board re-renders on change events instead of poll ticks. (#5103, #5115, #5193, #5239, #4854)
+
+<p class="note">Note: the chat explore command (#4262) shipped and was reverted (#4289) in this window — it needs more work before it is ready. The settings and mobile pairing restructure (#4315) was briefly reverted and re-landed as #4322.</p>
 
 ---
 
-## Site and housekeeping
+## Under the hood
 
-The public site migrated to useao.dev, the bug report form got shorter, and session and reviewer avatars render through one path. (#5133, #5153, #4764)
+Sentry capture with Go stacks and triage classification landed on the daemon, renderer and mobile, wired through build DSNs. Every surface stamps a uniform client tag on telemetry. The daemon reports 5xx and panics with stacks. On the site: the public site migrated to useao.dev, the bug report form got shorter, and reviewer avatars render through one path. (#4346, #4180, #4181, #4394, #3663, #5133, #5153, #4764)
 
 ---
 
 ## Upgrading
 
-GitHub Releases and Homebrew are the supported install paths. Existing installs update in place. If a previous macOS update left a staged build that will not install, the repair installer in this release rebuilds in place. No migrations are destructive and no configuration changes are required.
+GitHub Releases and Homebrew are the supported install paths. Existing installs update in place. No migrations in this cycle are destructive and no configuration changes are required. Cloud remains flag-gated — local-only setups see nothing new there yet.
 
 ---
 
 ## Contributors
 
-28 authors landed work in this range. Thanks to prateek, Dhruv Sharma, ronish, Ayash, NIKHIL ACHALE, Pulkit Saraf, Aditi, Maaz, Prasad Ware, Vaibhaav Tiwari, Harshit Singh Bhandari, Just_Anniee, Sundaram Kumar Jha, vicky prasad, Aniket Vishwakarma, Khushi Diwan, Misbah Ansari, Piyush Mudgal, Rishet Mehra, Yash Kumar Saini, Anusha, Hendrixx, Soubhagya Sadhukhan, Vansh Singhal, Yash Maheshwari, axisrow, pikachu and vanshx999.
+51 authors landed work in this range. Thanks to Dhruv Sharma, NIKHIL ACHALE, prateek, Just_Anniee, Nihal, Pulkit Saraf, Vaibhaav Tiwari, ronish, Aditi, Prasad Ware, Khushi Diwan, Adil Shaikh, Harshit Singh Bhandari, Yash Maheshwari, Apoorv Singh, JAYATI AHUJA, Maaz, Ayash, vicky prasad, Piyush Mudgal, Pritom Mazumdar, VenkataSakethDakuri, Yash Kumar Saini, axisrow, vanshx999, Anmol, Vansh Singhal, vytautas-petrikas, Aniket Vishwakarma, N!hal, Sundaram Kumar Jha, i-trytoohard, Heet, Hendrixx, Misbah Ansari, OllieinCanada, Rishet Mehra, krish rathi, pikachu, Aniket Shukla, Anusha, Atul Upadhyay, Keshav Varshney, LaibaFirdouse, Mukul Katewa, Phan Nguyen Quoc Minh, Priyanshu Ranjan, Rishet11, Rugved Mavidipalli, Soubhagya Sadhukhan and mknayam.
 
-**Full changelog:** https://github.com/Untrivial-ai/agent-orchestrator/compare/v0.12.12...v0.13.0
+**Full changelog:** https://github.com/Untrivial-ai/agent-orchestrator/compare/v0.12.0...v0.13.0


### PR DESCRIPTION
## Summary

- **Adds a curated changelog entry for 0.13.0** at `frontend/src/landing/content/changelog/agent-orchestrator-0-13-0.mdx`, covering the **full v0.12.0 → main cycle**. The 0.12.1–0.12.12 patch releases never got their own entries, so 0.13.0 records everything since the last documented release — same pattern as the 0.11.0 entry covering all of 0.10.x. Numbers: 668 commits, 635 merged PRs, 51 authors, 174 features, 409 fixes, no breaking changes.
- **Revives the 0.12.0 changelog entry** from closed PR #3600 (copied verbatim, 99 lines). The 0.12.1 entry from that PR is intentionally not included per request.
- **Stamps `frontend/package.json` 0.10.3 → 0.13.0** with the two matching root entries in `frontend/package-lock.json` (same pattern as #3600; no dependency changes, so the lockfile diff is version-only).

## 0.13.0 entry structure

Highlights: AO Cloud control plane in the monorepo (flag-gated), chat as a durable first-class surface (queued dock, provider hosts surviving daemon restarts), the agent roster growth (Kimchi/Kimi/Pi/OMP/Prime/Muse/Cursor ACP + `ao doctor` over all 26 harnesses), real-time terminal with native PTY hosts, virtualized diff viewer, reviews end-to-end, mobile shipping to both stores, durable agent switching, desktop facelift, browser profiles/screenshots/downloads, GitLab SCM, onboarding flows — plus a reliability section, a reverted-feature note (#4262/#4289, #4315/#4322), under-the-hood (Sentry, telemetry tags, useao.dev migration), upgrading notes, and all 51 contributors.

## Notes

- The landing changelog loader (`frontend/src/landing/src/lib/changelog.ts`) auto-discovers MDX files in `content/changelog/` — no route or registration changes needed.
- A third `0.10.3` in the lockfile is `@tybys/wasm-util`'s own version, untouched.
- After this PR the site gets 0.12.0 and 0.13.0 back-to-back, closing the changelog gap.

## Test Plan

- [x] Diff contains only the four intended files
- [x] 0.12.0 entry is byte-identical to PR #3600's version
- [x] 0.13.0 numbers verified against git (commit/feat/fix/author/PR counts)
- [ ] Landing build picks up both entries (spot-check `/changelog` after merge or run `npm run build` in `frontend/src/landing`)
