### PR TITLE
ci: guard frontend/package.json version against latest stable release

### DIFF
--- a/.github/workflows/release-latest-guard.yml
+++ b/.github/workflows/release-latest-guard.yml
@@ -59,3 +59,39 @@ jobs:
               exit 1
             fi
           done
+
+  package-version:
+    # frontend/package.json's version feeds CFBundleShortVersionString and the
+    # in-app Settings -> Updates display, so main must not fall behind the
+    # latest stable tag (see #4467).
+    if: github.repository == 'Untrivial-ai/agent-orchestrator'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          sparse-checkout: frontend/package.json
+          sparse-checkout-cone-mode: false
+
+      - name: Verify frontend/package.json tracks latest stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="$(gh release view --repo "$REPO" --json tagName -q '.tagName')"
+          release_version="${tag#v}"
+          package_version="$(jq -r '.version' frontend/package.json)"
+
+          echo "Latest stable release: $release_version"
+          echo "frontend/package.json on main: $package_version"
+
+          lowest="$(printf '%s\n%s\n' "$release_version" "$package_version" | sort -V | head -n1)"
+          if [[ "$lowest" != "$release_version" ]]; then
+            echo "::error::frontend/package.json version '$package_version' on main is behind latest stable release '$release_version'. Bump it so the desktop app reports the shipped version."
+            exit 1
+          fi


### PR DESCRIPTION
## What

I added a `package-version` job to `.github/workflows/release-latest-guard.yml` that fails when `frontend/package.json` on `main` is behind the latest published stable release tag.

## Why

Fixes #4467. `frontend/package.json` sat at `0.10.3` while releases reached `v0.12.12`, so every desktop build showed "Current version — v0.10.3" in Settings → Updates. #5278 has since stamped `0.13.0`, but nothing stops the same drift from happening again — this makes it fail loudly.

## How

Runs alongside the existing `latest-release` job (release publish, hourly cron, manual dispatch; canonical repo only). It sparse-checks-out `frontend/package.json` from `main`, reads the latest stable tag via `gh release view`, and compares with `sort -V`. Passes when package version ≥ release version. Deliberately does not auto-bump — that stays with the release step.

## Testing

Workflow YAML parses (both jobs listed). Ran the compare logic locally: `0.13.0` vs `0.12.12` passes; `0.10.3` vs `0.12.12` fails as expected. Not exercised in Actions yet — the job only runs on the canonical repo.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [ ] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
