### PR TITLE
fix: forward reasoning effort to OpenCode ACP sessions

### DIFF
--- a/backend/internal/adapters/chatdriver/acp/driver.go
+++ b/backend/internal/adapters/chatdriver/acp/driver.go
@@ -187,7 +187,7 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 	}
 	if d.cfg.ValidateTurnSettings != nil {
 		if err := d.cfg.ValidateTurnSettings(cfg.Permissions, ports.ChatTurnSettings{
-			Model: cfg.Model, Approval: cfg.Permissions,
+			Model: cfg.Model, Effort: cfg.Effort, Approval: cfg.Permissions,
 		}); err != nil {
 			return nil, fmt.Errorf("validate ACP session settings: %w", err)
 		}
@@ -250,7 +250,7 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 		cfg.Permissions, d.cfg.ValidateTurnSettings, resp.ConfigOptions,
 		conv.legacyWire.modelState(), resp.Modes,
 	)
-	if err := conv.applyTurnSettings(ctx, ports.ChatTurnSettings{Model: cfg.Model, Approval: cfg.Permissions}); err != nil {
+	if err := conv.applyTurnSettings(ctx, ports.ChatTurnSettings{Model: cfg.Model, Effort: cfg.Effort, Approval: cfg.Permissions}); err != nil {
 		// Initial model and permission mode may have been applied via launch-time
 		// flags (e.g. kimchiacp passes --model, --auto, --yolo). An agent that
 		// does not implement the runtime ACP setters returns -32601; tolerate it

--- a/backend/internal/adapters/chatdriver/codexappserver/driver.go
+++ b/backend/internal/adapters/chatdriver/codexappserver/driver.go
@@ -291,6 +291,12 @@ func (d *Driver) Start(ctx context.Context, cfg ports.ChatStartConfig) (ports.Ch
 	if cfg.Model != "" {
 		params["model"] = cfg.Model
 	}
+	// thread/start has no top-level effort field either; carry the durable AO
+	// choice as a config override like thread/resume does, so a fresh thread
+	// does not silently fall back to the provider default.
+	if cfg.Effort != "" {
+		params["config"] = map[string]any{"model_reasoning_effort": cfg.Effort}
+	}
 	if cfg.SystemPrompt != "" {
 		params["developerInstructions"] = cfg.SystemPrompt
 	}

--- a/backend/internal/adapters/chatdriver/opencodeacp/driver.go
+++ b/backend/internal/adapters/chatdriver/opencodeacp/driver.go
@@ -40,10 +40,21 @@ func configure(_ context.Context, cfg acpdriver.LaunchConfig) ([]string, map[str
 }
 
 func sessionOptions(settings ports.ChatTurnSettings) []acpdriver.SessionOption {
-	if settings.Model == "" {
+	options := make([]acpdriver.SessionOption, 0, 2)
+	if settings.Model != "" {
+		options = append(options, acpdriver.SessionOption{ID: "model", Value: settings.Model})
+	}
+	// OpenCode advertises effort as id "effort" (category "thought_level") with
+	// the model's variant names as values. The model setter resets the variant
+	// to "default" else the first variant when no explicit variant is given,
+	// so the model must be applied first and the effort second.
+	if settings.Effort != "" {
+		options = append(options, acpdriver.SessionOption{ID: "effort", Value: settings.Effort})
+	}
+	if len(options) == 0 {
 		return nil
 	}
-	return []acpdriver.SessionOption{{ID: "model", Value: settings.Model}}
+	return options
 }
 
 // OpenCode parses model overrides as provider/model. A provider display name is

--- a/backend/internal/adapters/chatdriver/opencodeacp/driver_test.go
+++ b/backend/internal/adapters/chatdriver/opencodeacp/driver_test.go
@@ -130,3 +130,14 @@ func TestValidateTurnSettingsModelFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestSessionOptionsForwardsEffortAfterModel(t *testing.T) {
+	got := sessionOptions(ports.ChatTurnSettings{Model: "opencode-go/deepseek-v4.1-flash", Effort: "max"})
+	if len(got) != 2 || got[0].ID != "model" || got[1].ID != "effort" || got[1].Value != "max" {
+		t.Fatalf("model+effort settings = %#v", got)
+	}
+	got = sessionOptions(ports.ChatTurnSettings{Effort: "xhigh"})
+	if len(got) != 1 || got[0].ID != "effort" || got[0].Value != "xhigh" {
+		t.Fatalf("effort-only settings = %#v", got)
+	}
+}

--- a/backend/internal/ports/chat.go
+++ b/backend/internal/ports/chat.go
@@ -226,6 +226,8 @@ type ChatStartConfig struct {
 	PrepareEnv func(context.Context) (map[string]string, error)
 	// Model is optional; empty defers to the provider's configured default.
 	Model string
+	// Effort is optional; empty defers to the provider's configured default.
+	Effort string
 	// Permissions is AO's existing per-session approval policy. Drivers map it
 	// onto their provider's native approval and sandbox settings.
 	Permissions PermissionMode

--- a/backend/internal/service/chat/history.go
+++ b/backend/internal/service/chat/history.go
@@ -321,7 +321,7 @@ func (s *Service) EditMessage(
 					provider, err = driver.Resume(operationCtx, ports.ChatResumeConfig{
 						SessionID: cfg.SessionID, ProviderConversationID: providerConversationID,
 						DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath, Env: launchEnv,
-						Model: cfg.Model, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
+						Model: cfg.Model, Effort: cfg.Effort, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
 						ProviderScopeID:       sourceBranch.ProviderScopeID,
 						AdditionalDirectories: cfg.AdditionalDirectories, MCPServers: cfg.MCPServers,
 					})
@@ -358,7 +358,7 @@ func (s *Service) EditMessage(
 			} else {
 				provider, err = driver.Start(operationCtx, ports.ChatStartConfig{
 					SessionID: cfg.SessionID, DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath,
-					Env: launchEnv, Model: cfg.Model, Permissions: cfg.Permissions,
+					Env: launchEnv, Model: cfg.Model, Effort: cfg.Effort, Permissions: cfg.Permissions,
 					SystemPrompt: cfg.SystemPrompt, AdditionalDirectories: cfg.AdditionalDirectories,
 					MCPServers: cfg.MCPServers, ProviderScopeID: providerScopeID,
 				})
@@ -898,7 +898,7 @@ func (s *Service) activateBranchLocked(ctx context.Context, id domain.SessionID,
 	provider, err := driver.Resume(operationCtx, ports.ChatResumeConfig{
 		SessionID: cfg.SessionID, ProviderConversationID: branch.ProviderConversationID,
 		DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath, Env: launchEnv,
-		Model: cfg.Model, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
+		Model: cfg.Model, Effort: cfg.Effort, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
 		ProviderScopeID:       branch.ProviderScopeID,
 		AdditionalDirectories: cfg.AdditionalDirectories, MCPServers: cfg.MCPServers,
 	})
@@ -996,7 +996,7 @@ func (s *Service) restoreClosedSourceController(
 	provider, err := driver.Resume(recoveryCtx, ports.ChatResumeConfig{
 		SessionID: cfg.SessionID, ProviderConversationID: providerConversationID,
 		DataDir: cfg.DataDir, WorkspacePath: cfg.WorkspacePath, Env: launchEnv,
-		Model: cfg.Model, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
+		Model: cfg.Model, Effort: cfg.Effort, Permissions: cfg.Permissions, SystemPrompt: cfg.SystemPrompt,
 		ProviderScopeID:       branch.ProviderScopeID,
 		AdditionalDirectories: cfg.AdditionalDirectories, MCPServers: cfg.MCPServers,
 	})

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -481,6 +481,7 @@ func (s *Service) Start(ctx context.Context, cfg StartConfig) (*Controller, erro
 			Env:                   cfg.Env,
 			PrepareEnv:            prepareEnv,
 			Model:                 cfg.Model,
+			Effort:                cfg.Effort,
 			Permissions:           cfg.Permissions,
 			SystemPrompt:          cfg.SystemPrompt,
 			ProviderScopeID:       providerScopeID,


### PR DESCRIPTION
Fixes Untrivial-ai/agent-orchestrator#5268 — native Chat with the OpenCode harness ignored the selected reasoning effort and OpenCode fell back to the lowest variant (`minimal`/`low`).

**Root cause (two drops in the AO -> OpenCode handoff):**
- `opencodeacp/sessionOptions()` mapped only `Model` and discarded `Effort`, so no per-turn effort ever reached OpenCode via `session/set_config_option`.
- `ChatStartConfig` had no `Effort` field, so ACP `Start()` applied `{Model, Approval}` while `Resume()` already applied `{Model, Effort, Approval}`.

OpenCode''s model setter resets the variant to `default`, else the first variant, when no explicit variant is given — hence `minimal` for Muse and `low` for DeepSeek despite AO storing `xhigh`/`Max`.

**Changes:**
- `ports/chat.go`: add `Effort` to `ChatStartConfig`.
- `chatdriver/acp/driver.go`: `Start()` validates/applies `{Model, Effort, Approval}` like `Resume()`.
- `chatdriver/opencodeacp/driver.go`: forward `Effort` as the advertised `effort` option (category `thought_level`), model first then effort so the reset happens before the variant is applied. New `TestSessionOptionsForwardsEffortAfterModel`.
- `service/chat/service.go` + `history.go`: pass durable `cfg.Effort` into every `driver.Start`/`Resume`.
- `chatdriver/codexappserver/driver.go`: `Start()` now sends `config: {model_reasoning_effort}` like its `Resume()` does (same fresh-start drop class; per-turn `turn/start` already carried it).

**Intentional omissions / notes:**
- No OpenAPI regen: only internal port structs changed, no controller DTOs or `apispec` operations.
- No live OpenCode verification in CI: needs a local OpenCode install + credentials (`AO_LIVE_OPENCODE_ACP=1` test stays skipped). Unit-level repro confirmed the drop before the fix and the forward after.
- `codexappserver` full suite fails on Windows (`/tmp/ws` not absolute) — pre-existing, fails at the `IsAbs` guard before any changed code.