### PR TITLE
Add Safari profile import support on macOS

### DIFF
--- a/frontend/src/main/browser-profile-import.test.ts
+++ b/frontend/src/main/browser-profile-import.test.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, stat, symlink, truncate, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import Database from "better-sqlite3";
@@ -135,7 +135,263 @@ function chromiumMicros(iso: string): number {
 	return Math.round((Date.parse(iso) / 1_000 + 11_644_473_600) * 1_000_000);
 }
 
+function safariSeconds(iso: string): number {
+	return Date.parse(iso) / 1_000 - 978_307_200;
+}
+
+function safariBinaryCookies(cookies: Array<{
+	domain: string;
+	name: string;
+	value: string;
+	path?: string;
+	expires: string;
+	flags?: number;
+}>): Buffer {
+	const records = cookies.map((cookie) => {
+		const strings = [cookie.domain, cookie.name, cookie.path ?? "/", cookie.value]
+			.map((value) => Buffer.from(`${value}\0`, "utf8"));
+		const offsets: number[] = [];
+		let size = 56;
+		for (const value of strings) {
+			offsets.push(size);
+			size += value.length;
+		}
+		const record = Buffer.alloc(size);
+		record.writeUInt32LE(size, 0);
+		record.writeUInt32LE(cookie.flags ?? 0, 8);
+		offsets.forEach((offset, index) => record.writeUInt32LE(offset, 16 + index * 4));
+		record.writeDoubleLE(safariSeconds(cookie.expires), 40);
+		record.writeDoubleLE(safariSeconds("2025-01-01T00:00:00.000Z"), 48);
+		strings.forEach((value, index) => value.copy(record, offsets[index]));
+		return record;
+	});
+	const headerSize = 12 + records.length * 4;
+	const page = Buffer.alloc(headerSize + records.reduce((total, record) => total + record.length, 0));
+	page.writeUInt32BE(0x100, 0);
+	page.writeUInt32LE(records.length, 4);
+	let recordOffset = headerSize;
+	records.forEach((record, index) => {
+		page.writeUInt32LE(recordOffset, 8 + index * 4);
+		record.copy(page, recordOffset);
+		recordOffset += record.length;
+	});
+	const file = Buffer.alloc(12 + page.length + 8);
+	file.write("cook", 0, "ascii");
+	file.writeUInt32BE(1, 4);
+	file.writeUInt32BE(page.length, 8);
+	page.copy(file, 12);
+	return file;
+}
+
+async function createSafariFixture(root: string): Promise<{ library: string; namedProfileId: string }> {
+	const library = path.join(root, "Library");
+	const container = path.join(library, "Containers", "com.apple.Safari", "Data", "Library");
+	const namedProfileId = "5604E6F5-02ED-4E40-8249-63DE7BC986C8";
+	const safariData = path.join(container, "Safari");
+	await mkdir(path.join(library, "Safari"), { recursive: true });
+	await mkdir(path.join(container, "Cookies"), { recursive: true });
+	await mkdir(path.join(safariData, "Profiles", namedProfileId), { recursive: true });
+	await mkdir(path.join(
+		container,
+		"WebKit",
+		"WebsiteDataStore",
+		namedProfileId.toLowerCase(),
+		"Cookies",
+	), { recursive: true });
+
+	const tabs = new Database(path.join(safariData, "SafariTabs.db"));
+	tabs.exec("CREATE TABLE bookmarks (subtype INTEGER, external_uuid TEXT, title TEXT)");
+	tabs.prepare("INSERT INTO bookmarks VALUES (?, ?, ?)").run(2, "DefaultProfile", "Personal browsing");
+	tabs.prepare("INSERT INTO bookmarks VALUES (?, ?, ?)").run(2, namedProfileId.toLowerCase(), "Work");
+	tabs.close();
+
+	const writeHistory = (file: string, url: string, title: string, visits: number, visitedAt: string) => {
+		const database = new Database(file);
+		database.exec(`
+			CREATE TABLE history_items (id INTEGER PRIMARY KEY, url TEXT, visit_count INTEGER);
+			CREATE TABLE history_visits (id INTEGER PRIMARY KEY, history_item INTEGER, visit_time REAL, title TEXT);
+		`);
+		database.prepare("INSERT INTO history_items VALUES (1, ?, ?)").run(url, visits);
+		database.prepare("INSERT INTO history_visits VALUES (1, 1, ?, ?)").run(safariSeconds(visitedAt), title);
+		database.close();
+	};
+	writeHistory(path.join(library, "Safari", "History.db"), "https://webkit.org/from-safari", "Safari history", 4, "2026-03-01T00:00:00.000Z");
+	writeHistory(path.join(safariData, "Profiles", namedProfileId, "History.db"), "https://example.com/work", "Work history", 2, "2026-03-02T00:00:00.000Z");
+
+	await writeFile(path.join(container, "Cookies", "Cookies.binarycookies"), safariBinaryCookies([
+		{ domain: ".webkit.org", name: "session", value: "safari", expires: "2030-01-01T00:00:00.000Z", flags: 0x25 },
+		{ domain: ".webkit.org", name: "expired", value: "old", expires: "2020-01-01T00:00:00.000Z" },
+	]));
+	await writeFile(path.join(
+		container,
+		"WebKit",
+		"WebsiteDataStore",
+		namedProfileId.toLowerCase(),
+		"Cookies",
+		"Cookies.binarycookies",
+	), safariBinaryCookies([
+		{ domain: ".example.com", name: "work", value: "named", expires: "2030-01-01T00:00:00.000Z", flags: 0x2c },
+	]));
+	return { library, namedProfileId };
+}
+
 describe("BrowserProfileImportService", () => {
+	it("discovers Safari profiles only on macOS and keeps their paths private", async () => {
+		const root = await fixtureRoot();
+		await createSafariFixture(root);
+		const stateDir = path.join(root, "ao-state");
+		const profileStore = new BrowserProfileStore({ stateDir });
+		await profileStore.load();
+		const createService = (platform: NodeJS.Platform) => new BrowserProfileImportService({
+			stateDir,
+			profileStore,
+			historyStore: new BrowserHistoryStore({ stateDir }),
+			platform,
+			homeDir: root,
+			env: {},
+			fromPartition: () => ({ cookies: { set: async () => undefined }, clearStorageData: async () => undefined, clearCache: async () => undefined }),
+		});
+
+		expect((await createService("win32").discover()).sources).toEqual([]);
+		const discovery = await createService("darwin").discover();
+		expect(discovery.sources).toEqual([expect.objectContaining({
+			name: "Safari",
+			family: "safari",
+			cookieSupport: "supported",
+			profiles: [
+				expect.objectContaining({ name: "Personal browsing", default: true }),
+				expect.objectContaining({ name: "Work", default: false }),
+			],
+		})]);
+		expect(JSON.stringify(discovery)).not.toContain(root);
+	});
+
+	it("imports Safari BinaryCookies and Core Data history into a new profile", async () => {
+		const root = await fixtureRoot();
+		await createSafariFixture(root);
+		const stateDir = path.join(root, "ao-state");
+		const profileStore = new BrowserProfileStore({ stateDir });
+		await profileStore.load();
+		const historyStore = new BrowserHistoryStore({ stateDir });
+		const importedCookies: Array<{ name?: string; value?: string; sameSite?: string; secure?: boolean; httpOnly?: boolean }> = [];
+		const service = new BrowserProfileImportService({
+			stateDir,
+			profileStore,
+			historyStore,
+			platform: "darwin",
+			homeDir: root,
+			env: {},
+			now: () => new Date("2026-01-01T00:00:00.000Z"),
+			fromPartition: () => ({
+				cookies: { set: async (cookie) => { importedCookies.push(cookie); } },
+				clearStorageData: async () => undefined,
+				clearCache: async () => undefined,
+			}),
+		});
+		const source = (await service.discover()).sources[0]!;
+		const result = await service.import({
+			requestId: "15151515-1515-4515-8515-151515151515",
+			sourceId: source.id,
+			profileIds: [source.profiles[0]!.id],
+			includeCookies: true,
+			includeHistory: true,
+			destination: { mode: "merge", name: "Imported Safari" },
+		}, vi.fn());
+
+		expect(importedCookies).toEqual([expect.objectContaining({
+			name: "session",
+			value: "safari",
+			secure: true,
+			httpOnly: true,
+			sameSite: "no_restriction",
+		})]);
+		expect(result.entries[0]).toMatchObject({ importedCookies: 1, skippedCookies: 1, importedHistoryEntries: 1 });
+		expect(result.entries[0]!.warnings).toContainEqual({ code: "expired-cookies-skipped", count: 1 });
+		const profileId = result.entries[0]!.destinationProfile.id;
+		expect(await historyStore.suggest(profileId, "webkit")).toEqual([
+			{ url: "https://webkit.org/from-safari", title: "Safari history" },
+		]);
+		expect(await readdir(path.join(stateDir, "browser-import-staging"))).toEqual([]);
+	});
+
+	it("imports a named Safari profile from its profile-specific stores", async () => {
+		const root = await fixtureRoot();
+		await createSafariFixture(root);
+		const stateDir = path.join(root, "ao-state");
+		const profileStore = new BrowserProfileStore({ stateDir });
+		await profileStore.load();
+		const historyStore = new BrowserHistoryStore({ stateDir });
+		const importedCookies: Array<{ name?: string; value?: string; sameSite?: string; secure?: boolean; httpOnly?: boolean }> = [];
+		const service = new BrowserProfileImportService({
+			stateDir,
+			profileStore,
+			historyStore,
+			platform: "darwin",
+			homeDir: root,
+			env: {},
+			now: () => new Date("2026-01-01T00:00:00.000Z"),
+			fromPartition: () => ({
+				cookies: { set: async (cookie) => { importedCookies.push(cookie); } },
+				clearStorageData: async () => undefined,
+				clearCache: async () => undefined,
+			}),
+		});
+		const source = (await service.discover()).sources[0]!;
+		const work = source.profiles.find((profile) => profile.name === "Work")!;
+		const result = await service.import({
+			requestId: "16161616-1616-4616-8616-161616161616",
+			sourceId: source.id,
+			profileIds: [work.id],
+			includeCookies: true,
+			includeHistory: true,
+			destination: { mode: "merge", name: "Safari Work" },
+		}, vi.fn());
+
+		expect(importedCookies).toEqual([expect.objectContaining({ name: "work", value: "named", sameSite: "lax" })]);
+		expect(result.entries[0]).toMatchObject({ importedCookies: 1, importedHistoryEntries: 1 });
+		expect(await historyStore.suggest(result.entries[0]!.destinationProfile.id, "work")).toEqual([
+			{ url: "https://example.com/work", title: "Work history" },
+		]);
+	});
+
+	it("rejects malformed Safari cookie files before creating a destination", async () => {
+		const root = await fixtureRoot();
+		const { library } = await createSafariFixture(root);
+		await writeFile(path.join(
+			library,
+			"Containers",
+			"com.apple.Safari",
+			"Data",
+			"Library",
+			"Cookies",
+			"Cookies.binarycookies",
+		), Buffer.from("cook\0\0\0\x01broken", "binary"));
+		const stateDir = path.join(root, "ao-state");
+		const profileStore = new BrowserProfileStore({ stateDir });
+		await profileStore.load();
+		const service = new BrowserProfileImportService({
+			stateDir,
+			profileStore,
+			historyStore: new BrowserHistoryStore({ stateDir }),
+			platform: "darwin",
+			homeDir: root,
+			env: {},
+			fromPartition: () => ({ cookies: { set: async () => undefined }, clearStorageData: async () => undefined, clearCache: async () => undefined }),
+		});
+		const source = (await service.discover()).sources[0]!;
+
+		await expect(service.import({
+			requestId: "17171717-1717-4717-8717-171717171717",
+			sourceId: source.id,
+			profileIds: [source.profiles[0]!.id],
+			includeCookies: true,
+			includeHistory: false,
+			destination: { mode: "merge", name: "Broken Safari" },
+		}, vi.fn())).rejects.toThrow("supported cookie data");
+		expect(profileStore.profiles).toEqual([]);
+		expect(await readdir(path.join(stateDir, "browser-import-staging"))).toEqual([]);
+	});
+
 	it("removes Chromium v24's domain hash from decrypted Windows cookie values", () => {
 		const host = ".example.com";
 		const key = Buffer.alloc(32, 0x11);

--- a/frontend/src/main/browser-profile-import.test.ts
+++ b/frontend/src/main/browser-profile-import.test.ts
@@ -1,4 +1,5 @@
 import { createCipheriv, createHash } from "node:crypto";
+import fs from "node:fs/promises";
 import { mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,6 +13,7 @@ import { BROWSER_PROFILE_MAX_COUNT } from "../shared/browser-profiles";
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
 });
 
@@ -236,6 +238,58 @@ async function createSafariFixture(root: string): Promise<{ library: string; nam
 }
 
 describe("BrowserProfileImportService", () => {
+	it("keeps other browsers discoverable and importable when Safari access is denied", async () => {
+		const root = await fixtureRoot();
+		await createSafariFixture(root);
+		const firefox = path.join(root, "Library", "Application Support", "Firefox", "Profiles", "test.default");
+		await mkdir(firefox, { recursive: true });
+		const db = new Database(path.join(firefox, "places.sqlite"));
+		db.exec("CREATE TABLE moz_places (url TEXT, title TEXT, visit_count INTEGER, last_visit_date INTEGER); INSERT INTO moz_places VALUES ('https://example.com', 'Firefox', 1, 1767225600000000)");
+		db.close();
+		const original = fs.lstat;
+		const sourceLstat = ((file: Parameters<typeof fs.lstat>[0], options: never) => {
+			if (String(file).includes("com.apple.Safari")) return Promise.reject(Object.assign(new Error("blocked"), { code: "EPERM" }));
+			return original(file, options);
+		}) as typeof fs.lstat;
+		const stateDir = path.join(root, "ao-state");
+		const profileStore = new BrowserProfileStore({ stateDir });
+		await profileStore.load();
+		const service = new BrowserProfileImportService({ stateDir, profileStore, sourceLstat,
+			historyStore: new BrowserHistoryStore({ stateDir }), platform: "darwin", homeDir: root, env: {},
+			fromPartition: () => ({ cookies: { set: async () => undefined }, clearStorageData: async () => undefined, clearCache: async () => undefined }),
+		});
+		const discovery = await service.discover();
+		expect(discovery.warnings).toEqual(["safari-access-denied"]);
+		expect(discovery.sources.map((source) => source.name)).toEqual(["Firefox"]);
+		const source = discovery.sources[0]!;
+		await expect(service.import({ requestId: "18181818-1818-4818-8818-181818181818", sourceId: source.id,
+			profileIds: [source.profiles[0]!.id], includeCookies: false, includeHistory: true,
+			destination: { mode: "merge", name: "Firefox despite Safari" },
+		}, vi.fn())).resolves.toMatchObject({ entries: [{ importedHistoryEntries: 1 }] });
+	});
+
+	it("bounds Safari metadata snapshots and removes discovery staging", async () => {
+		const root = await fixtureRoot();
+		const { library } = await createSafariFixture(root);
+		const stateDir = path.join(root, "ao-state");
+		const profileStore = new BrowserProfileStore({ stateDir });
+		await profileStore.load();
+		const service = new BrowserProfileImportService({ stateDir, profileStore,
+			historyStore: new BrowserHistoryStore({ stateDir }), platform: "darwin", homeDir: root, env: {},
+			fromPartition: () => ({ cookies: { set: async () => undefined }, clearStorageData: async () => undefined, clearCache: async () => undefined }),
+		});
+		const backup = vi.spyOn(Database.prototype, "backup");
+		await service.discover();
+		expect(backup).toHaveBeenCalledWith(expect.stringContaining(path.join(stateDir, "browser-import-staging")));
+		expect(await readdir(path.join(stateDir, "browser-import-staging"))).toEqual([]);
+		backup.mockClear();
+		await truncate(path.join(library, "Containers", "com.apple.Safari", "Data", "Library", "Safari", "SafariTabs.db"), 256 * 1024 * 1024 + 1);
+		const discovery = await service.discover();
+		expect(backup).not.toHaveBeenCalled();
+		expect(discovery.sources[0]!.profiles[0]!.name).toBe("Personal");
+		expect(await readdir(path.join(stateDir, "browser-import-staging"))).toEqual([]);
+	});
+
 	it("discovers Safari profiles only on macOS and keeps their paths private", async () => {
 		const root = await fixtureRoot();
 		await createSafariFixture(root);

--- a/frontend/src/main/browser-profile-import.ts
+++ b/frontend/src/main/browser-profile-import.ts
@@ -106,6 +106,7 @@ export type BrowserProfileImportOptions = {
 	homeDir?: string;
 	env?: NodeJS.ProcessEnv;
 	now?: () => Date;
+	sourceLstat?: typeof lstat;
 };
 
 class SourceBudget {
@@ -248,10 +249,10 @@ function contained(root: string, candidate: string): boolean {
 	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
-async function existingRealDirectory(candidate: string, throwAccessDenied = false): Promise<string | null> {
+async function existingRealDirectory(candidate: string, throwAccessDenied = false, sourceLstat = lstat): Promise<string | null> {
 	if (!candidate) return null;
 	try {
-		const metadata = await lstat(candidate);
+		const metadata = await sourceLstat(candidate);
 		if (!metadata.isDirectory() || metadata.isSymbolicLink()) return null;
 		return await realpath(candidate);
 	} catch (error) {
@@ -266,10 +267,10 @@ function isAccessDenied(error: unknown): boolean {
 }
 
 function safariAccessError(): Error {
-	return new Error(
+	return Object.assign(new Error(
 		"AO couldn't access Safari's data. In System Settings, open Privacy & Security > Full Disk Access, "
 		+ "allow AO, then restart AO and try the import again.",
-	);
+	), { code: "EACCES" });
 }
 
 async function readSmallJSON(file: string, maxBytes: number): Promise<unknown> {
@@ -354,16 +355,16 @@ const SAFARI_DEFAULT_COOKIES = [
 ];
 const SAFARI_PROFILE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-async function discoverSafariProfiles(descriptor: BrowserDescriptor, root: string): Promise<InternalSourceProfile[]> {
+async function discoverSafariProfiles(descriptor: BrowserDescriptor, root: string, stagingRoot: string, sourceLstat = lstat): Promise<InternalSourceProfile[]> {
 	const containerSafari = path.join("Containers", "com.apple.Safari", "Data", "Library", "Safari");
 	const profileParentRelative = path.join(containerSafari, "Profiles");
 	let profileParent: string | null;
 	try {
-		profileParent = await existingRealDirectory(path.join(root, profileParentRelative), true);
+		profileParent = await existingRealDirectory(path.join(root, profileParentRelative), true, sourceLstat);
 	} catch {
 		throw safariAccessError();
 	}
-	const names = await readSafariProfileNames(root, path.join(containerSafari, "SafariTabs.db"));
+	const names = await readSafariProfileNames(root, path.join(containerSafari, "SafariTabs.db"), stagingRoot);
 	const profiles: InternalSourceProfile[] = [];
 	const defaultProfile: InternalSourceProfile = {
 		id: opaqueSourceId(`${descriptor.id}:profile`, "DefaultProfile"),
@@ -376,7 +377,7 @@ async function discoverSafariProfiles(descriptor: BrowserDescriptor, root: strin
 	if (await hasImportableDatabase(root, "safari", defaultProfile)) profiles.push(defaultProfile);
 
 	if (profileParent && contained(root, profileParent)) {
-		const entries = await readdir(profileParent, { withFileTypes: true }).catch(() => []);
+		const entries = await readdir(profileParent, { withFileTypes: true });
 		for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
 			if (!entry.isDirectory() || !SAFARI_PROFILE_ID.test(entry.name)) continue;
 			const uuidUpper = entry.name.toUpperCase();
@@ -398,18 +399,22 @@ async function discoverSafariProfiles(descriptor: BrowserDescriptor, root: strin
 	return profiles.slice(0, BROWSER_IMPORT_MAX_SOURCE_PROFILES);
 }
 
-async function readSafariProfileNames(root: string, relativeDatabase: string): Promise<Map<string, string>> {
+async function readSafariProfileNames(root: string, relativeDatabase: string, stagingRoot: string): Promise<Map<string, string>> {
 	const names = new Map<string, string>();
+	const staging = path.join(stagingRoot, randomUUID());
 	try {
 		const databaseFile = await findDatabase(root, [relativeDatabase]);
 		if (!databaseFile) return names;
-		withReadOnlyDatabase(databaseFile, (database) => {
+		await mkdir(staging, { recursive: true, mode: 0o700 });
+		const snapshot = await snapshotSQLite(databaseFile, root, staging, new SourceBudget());
+		withReadOnlyDatabase(snapshot, (database) => {
 			if (!hasTable(database, "bookmarks")) return;
 			const rows = database.prepare(`
 				SELECT external_uuid, title
 				FROM bookmarks
 				WHERE subtype = 2 AND external_uuid IS NOT NULL
 				ORDER BY rowid
+				LIMIT 1024
 			`).all() as Record<string, unknown>[];
 			for (const row of rows) {
 				const rawId = stringValue(row.external_uuid).trim();
@@ -420,6 +425,8 @@ async function readSafariProfileNames(root: string, relativeDatabase: string): P
 		});
 	} catch {
 		// TCC may block SafariTabs.db. UUID directory discovery still works.
+	} finally {
+		await rm(staging, { recursive: true, force: true }).catch(() => undefined);
 	}
 	return names;
 }
@@ -499,20 +506,29 @@ export class BrowserProfileImportService {
 	}
 
 	async discover(): Promise<BrowserImportDiscovery> {
-		return { sources: (await this.discoverInternal()).map((source) => source.public) };
+		const warnings: NonNullable<BrowserImportDiscovery["warnings"]> = [];
+		const sources = await this.discoverInternal(warnings);
+		return { sources: sources.map((source) => source.public), ...(warnings.length ? { warnings } : {}) };
 	}
 
-	private async discoverInternal(): Promise<InternalSource[]> {
+	private async discoverInternal(warnings: NonNullable<BrowserImportDiscovery["warnings"]> = []): Promise<InternalSource[]> {
 		const sources: InternalSource[] = [];
 		for (const descriptor of DESCRIPTORS) {
 			for (const candidate of descriptor.roots(this.context)) {
 				const root = await existingRealDirectory(candidate);
 				if (!root) continue;
-				const profiles = descriptor.family === "chromium"
-					? await discoverChromiumProfiles(descriptor, root)
-					: descriptor.family === "firefox"
-						? await discoverFirefoxProfiles(descriptor, root)
-						: await discoverSafariProfiles(descriptor, root);
+				let profiles: InternalSourceProfile[];
+				try {
+					profiles = descriptor.family === "chromium"
+						? await discoverChromiumProfiles(descriptor, root)
+						: descriptor.family === "firefox"
+							? await discoverFirefoxProfiles(descriptor, root)
+							: await discoverSafariProfiles(descriptor, root, this.stagingRoot(), this.options.sourceLstat);
+				} catch (error) {
+					if (descriptor.family !== "safari" || !isAccessDenied(error)) throw error;
+					warnings.push("safari-access-denied");
+					continue;
+				}
 				if (profiles.length === 0) continue;
 				const capability = cookieCapability(descriptor.family, this.context.platform);
 				sources.push({

--- a/frontend/src/main/browser-profile-import.ts
+++ b/frontend/src/main/browser-profile-import.ts
@@ -5,6 +5,7 @@ import {
 	lstat,
 	mkdir,
 	open,
+	readFile,
 	readdir,
 	realpath,
 	rm,
@@ -46,7 +47,7 @@ const IMPORT_TOTAL_MAX_BYTES = 512 * 1024 * 1024;
 const LOCAL_STATE_MAX_BYTES = 4 * 1024 * 1024;
 const SOURCE_ID_PATTERN = /^[0-9a-f]{32}$/;
 
-type BrowserFamily = "chromium" | "firefox";
+type BrowserFamily = "chromium" | "firefox" | "safari";
 
 type BrowserDescriptor = {
 	id: string;
@@ -67,6 +68,8 @@ type InternalSourceProfile = {
 	name: string;
 	default: boolean;
 	root: string;
+	cookieRelatives?: string[];
+	historyRelatives?: string[];
 };
 
 type InternalSource = {
@@ -188,6 +191,16 @@ const DESCRIPTORS: BrowserDescriptor[] = [
 		}),
 	},
 	{
+		id: "safari",
+		name: "Safari",
+		family: "safari",
+		roots: (c) => platformPaths(c, {
+			win32: [],
+			darwin: [path.join(c.homeDir, "Library")],
+			linux: [],
+		}),
+	},
+	{
 		id: "firefox",
 		name: "Firefox",
 		family: "firefox",
@@ -235,15 +248,28 @@ function contained(root: string, candidate: string): boolean {
 	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
-async function existingRealDirectory(candidate: string): Promise<string | null> {
+async function existingRealDirectory(candidate: string, throwAccessDenied = false): Promise<string | null> {
 	if (!candidate) return null;
 	try {
 		const metadata = await lstat(candidate);
 		if (!metadata.isDirectory() || metadata.isSymbolicLink()) return null;
 		return await realpath(candidate);
-	} catch {
+	} catch (error) {
+		if (throwAccessDenied && isAccessDenied(error)) throw error;
 		return null;
 	}
+}
+
+function isAccessDenied(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return code === "EACCES" || code === "EPERM";
+}
+
+function safariAccessError(): Error {
+	return new Error(
+		"AO couldn't access Safari's data. In System Settings, open Privacy & Security > Full Disk Access, "
+		+ "allow AO, then restart AO and try the import again.",
+	);
 }
 
 async function readSmallJSON(file: string, maxBytes: number): Promise<unknown> {
@@ -321,16 +347,100 @@ async function discoverFirefoxProfiles(descriptor: BrowserDescriptor, root: stri
 	return profiles.sort((a, b) => Number(b.default) - Number(a.default) || a.name.localeCompare(b.name));
 }
 
-async function hasImportableDatabase(profileRoot: string, family: BrowserFamily): Promise<boolean> {
+const SAFARI_DEFAULT_HISTORY = path.join("Safari", "History.db");
+const SAFARI_DEFAULT_COOKIES = [
+	path.join("Containers", "com.apple.Safari", "Data", "Library", "Cookies", "Cookies.binarycookies"),
+	path.join("Cookies", "Cookies.binarycookies"),
+];
+const SAFARI_PROFILE_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+async function discoverSafariProfiles(descriptor: BrowserDescriptor, root: string): Promise<InternalSourceProfile[]> {
+	const containerSafari = path.join("Containers", "com.apple.Safari", "Data", "Library", "Safari");
+	const profileParentRelative = path.join(containerSafari, "Profiles");
+	let profileParent: string | null;
+	try {
+		profileParent = await existingRealDirectory(path.join(root, profileParentRelative), true);
+	} catch {
+		throw safariAccessError();
+	}
+	const names = await readSafariProfileNames(root, path.join(containerSafari, "SafariTabs.db"));
+	const profiles: InternalSourceProfile[] = [];
+	const defaultProfile: InternalSourceProfile = {
+		id: opaqueSourceId(`${descriptor.id}:profile`, "DefaultProfile"),
+		name: names.get("DefaultProfile") || "Personal",
+		default: true,
+		root,
+		cookieRelatives: SAFARI_DEFAULT_COOKIES,
+		historyRelatives: [SAFARI_DEFAULT_HISTORY],
+	};
+	if (await hasImportableDatabase(root, "safari", defaultProfile)) profiles.push(defaultProfile);
+
+	if (profileParent && contained(root, profileParent)) {
+		const entries = await readdir(profileParent, { withFileTypes: true }).catch(() => []);
+		for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+			if (!entry.isDirectory() || !SAFARI_PROFILE_ID.test(entry.name)) continue;
+			const uuidUpper = entry.name.toUpperCase();
+			const uuidLower = entry.name.toLowerCase();
+			const profile: InternalSourceProfile = {
+				id: opaqueSourceId(`${descriptor.id}:profile`, uuidUpper),
+				name: names.get(uuidUpper) || `Profile ${uuidUpper.slice(0, 8)}`,
+				default: false,
+				root,
+				cookieRelatives: [path.join(
+					"Containers", "com.apple.Safari", "Data", "Library", "WebKit", "WebsiteDataStore",
+					uuidLower, "Cookies", "Cookies.binarycookies",
+				)],
+				historyRelatives: [path.join(profileParentRelative, entry.name, "History.db")],
+			};
+			if (await hasImportableDatabase(root, "safari", profile)) profiles.push(profile);
+		}
+	}
+	return profiles.slice(0, BROWSER_IMPORT_MAX_SOURCE_PROFILES);
+}
+
+async function readSafariProfileNames(root: string, relativeDatabase: string): Promise<Map<string, string>> {
+	const names = new Map<string, string>();
+	try {
+		const databaseFile = await findDatabase(root, [relativeDatabase]);
+		if (!databaseFile) return names;
+		withReadOnlyDatabase(databaseFile, (database) => {
+			if (!hasTable(database, "bookmarks")) return;
+			const rows = database.prepare(`
+				SELECT external_uuid, title
+				FROM bookmarks
+				WHERE subtype = 2 AND external_uuid IS NOT NULL
+				ORDER BY rowid
+			`).all() as Record<string, unknown>[];
+			for (const row of rows) {
+				const rawId = stringValue(row.external_uuid).trim();
+				const id = rawId === "DefaultProfile" ? rawId : rawId.toUpperCase();
+				const name = stringValue(row.title).trim().slice(0, 64);
+				if ((id === "DefaultProfile" || SAFARI_PROFILE_ID.test(id)) && name && !names.has(id)) names.set(id, name);
+			}
+		});
+	} catch {
+		// TCC may block SafariTabs.db. UUID directory discovery still works.
+	}
+	return names;
+}
+
+async function hasImportableDatabase(
+	profileRoot: string,
+	family: BrowserFamily,
+	profile?: InternalSourceProfile,
+): Promise<boolean> {
 	const candidates =
 		family === "chromium"
 			? ["History", path.join("Network", "Cookies"), "Cookies"]
-			: ["places.sqlite", "cookies.sqlite"];
+			: family === "firefox"
+				? ["places.sqlite", "cookies.sqlite"]
+				: [...(profile?.historyRelatives ?? []), ...(profile?.cookieRelatives ?? [])];
 	for (const relative of candidates) {
 		try {
 			const metadata = await lstat(path.join(profileRoot, relative));
 			if (metadata.isFile() && !metadata.isSymbolicLink()) return true;
-		} catch {
+		} catch (error) {
+			if (family === "safari" && isAccessDenied(error)) throw safariAccessError();
 			// Continue looking for another supported database.
 		}
 	}
@@ -342,6 +452,7 @@ function cookieCapability(
 	platform: NodeJS.Platform,
 ): { support: BrowserImportSource["cookieSupport"]; reason: BrowserImportCookieSupportReason } {
 	if (family === "firefox") return { support: "supported", reason: "firefox-plaintext" };
+	if (family === "safari") return { support: "supported", reason: "safari-plaintext" };
 	return {
 		support: "partial",
 		reason: platform === "linux" ? "chromium-encryption-unsupported" : "chromium-encryption-partial",
@@ -397,10 +508,11 @@ export class BrowserProfileImportService {
 			for (const candidate of descriptor.roots(this.context)) {
 				const root = await existingRealDirectory(candidate);
 				if (!root) continue;
-				const profiles =
-					descriptor.family === "chromium"
-						? await discoverChromiumProfiles(descriptor, root)
-						: await discoverFirefoxProfiles(descriptor, root);
+				const profiles = descriptor.family === "chromium"
+					? await discoverChromiumProfiles(descriptor, root)
+					: descriptor.family === "firefox"
+						? await discoverFirefoxProfiles(descriptor, root)
+						: await discoverSafariProfiles(descriptor, root);
 				if (profiles.length === 0) continue;
 				const capability = cookieCapability(descriptor.family, this.context.platform);
 				sources.push({
@@ -639,16 +751,19 @@ async function readProfileData(
 	let history: BrowserHistoryEntry[] = [];
 	let skippedCookies = 0;
 	if (request.includeCookies) {
-		const cookieDatabase = await findDatabase(profile.root, source.descriptor.family === "chromium"
-			? [path.join("Network", "Cookies"), "Cookies"]
-			: ["cookies.sqlite"]);
+		const cookieDatabase = await findDatabase(profile.root, profile.cookieRelatives ?? (
+			source.descriptor.family === "chromium"
+				? [path.join("Network", "Cookies"), "Cookies"]
+				: ["cookies.sqlite"]
+		), source.descriptor.family === "safari");
 		if (!cookieDatabase) {
 			warnings.push({ code: "cookie-database-missing" });
 		} else {
-			const snapshot = await snapshotSQLite(cookieDatabase, profile.root, staging, budget);
-			const outcome = source.descriptor.family === "chromium"
-				? readChromiumCookies(snapshot, decryptor, now)
-				: readFirefoxCookies(snapshot, now);
+			const outcome = source.descriptor.family === "safari"
+				? readSafariCookies(await readFile(await snapshotFile(cookieDatabase, profile.root, staging, budget)), now)
+				: source.descriptor.family === "chromium"
+					? readChromiumCookies(await snapshotSQLite(cookieDatabase, profile.root, staging, budget), decryptor, now)
+					: readFirefoxCookies(await snapshotSQLite(cookieDatabase, profile.root, staging, budget), now);
 			if (!outcome) {
 				warnings.push({ code: "cookie-database-missing" });
 			} else {
@@ -659,14 +774,18 @@ async function readProfileData(
 		}
 	}
 	if (request.includeHistory) {
-		const historyDatabase = await findDatabase(profile.root, source.descriptor.family === "chromium" ? ["History"] : ["places.sqlite"]);
+		const historyDatabase = await findDatabase(profile.root, profile.historyRelatives ?? (
+			source.descriptor.family === "chromium" ? ["History"] : ["places.sqlite"]
+		), source.descriptor.family === "safari");
 		if (!historyDatabase) {
 			warnings.push({ code: "history-database-missing" });
 		} else {
 			const snapshot = await snapshotSQLite(historyDatabase, profile.root, staging, budget);
 			const outcome = source.descriptor.family === "chromium"
 				? readChromiumHistory(snapshot)
-				: readFirefoxHistory(snapshot);
+				: source.descriptor.family === "firefox"
+					? readFirefoxHistory(snapshot)
+					: readSafariHistory(snapshot);
 			history = outcome.history;
 			warnings.push(...outcome.warnings);
 		}
@@ -674,7 +793,39 @@ async function readProfileData(
 	return { profile, cookies, history, warnings: mergeWarnings(warnings), skippedCookies };
 }
 
-async function findDatabase(profileRoot: string, relatives: string[]): Promise<string | null> {
+async function snapshotFile(
+	file: string,
+	profileRoot: string,
+	staging: string,
+	budget: SourceBudget,
+): Promise<string> {
+	const destination = path.join(staging, `${randomUUID()}-${path.basename(file)}`);
+	const canonical = await preflightContainedFile(file, profileRoot, SOURCE_FILE_MAX_BYTES, budget);
+	const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+	const source = await open(canonical, constants.O_RDONLY | noFollow);
+	try {
+		const opened = await source.stat();
+		if (!opened.isFile() || opened.size > SOURCE_FILE_MAX_BYTES) {
+			throw new Error("Browser source file exceeds the snapshot size limit.");
+		}
+		const bytes = await source.readFile();
+		if (bytes.length !== opened.size) throw new Error("Browser source file changed during import.");
+		const output = await open(destination, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+		try {
+			await output.writeFile(bytes);
+		} finally {
+			await output.close();
+		}
+		return destination;
+	} catch (error) {
+		await rm(destination, { force: true }).catch(() => undefined);
+		throw error;
+	} finally {
+		await source.close();
+	}
+}
+
+async function findDatabase(profileRoot: string, relatives: string[], throwAccessDenied = false): Promise<string | null> {
 	for (const relative of relatives) {
 		const candidate = path.join(profileRoot, relative);
 		try {
@@ -682,7 +833,8 @@ async function findDatabase(profileRoot: string, relatives: string[]): Promise<s
 			if (!metadata.isFile() || metadata.isSymbolicLink()) continue;
 			const canonical = await realpath(candidate);
 			if (contained(profileRoot, canonical)) return canonical;
-		} catch {
+		} catch (error) {
+			if (throwAccessDenied && isAccessDenied(error)) throw error;
 			// Try the next known location.
 		}
 	}
@@ -844,6 +996,94 @@ function readChromiumCookies(
 	});
 }
 
+function readSafariCookies(
+	bytes: Buffer,
+	now: Date,
+): { cookies: ImportedCookie[]; skipped: number; warnings: BrowserImportWarning[] } {
+	const parsed = parseSafariBinaryCookies(bytes);
+	const normalized = normalizeCookieRows(parsed.rows, now);
+	if (parsed.invalid > 0) normalized.warnings.push({ code: "invalid-cookies-skipped", count: parsed.invalid });
+	if (parsed.truncated > 0) normalized.warnings.push({ code: "cookie-limit-truncated", count: parsed.truncated });
+	normalized.skipped += parsed.invalid + parsed.truncated;
+	normalized.warnings = mergeWarnings(normalized.warnings);
+	return normalized;
+}
+
+function parseSafariBinaryCookies(bytes: Buffer): {
+	rows: Array<Record<string, unknown>>;
+	invalid: number;
+	truncated: number;
+} {
+	const unsupported = () => new Error("The selected Safari profile does not contain supported cookie data.");
+	if (bytes.length < 16 || bytes.subarray(0, 4).toString("ascii") !== "cook") throw unsupported();
+	const pageCount = bytes.readUInt32BE(4);
+	if (pageCount > Math.floor((bytes.length - 8) / 4)) throw unsupported();
+	const pageSizes: number[] = [];
+	let cursor = 8;
+	let totalPageBytes = 0;
+	for (let index = 0; index < pageCount; index += 1) {
+		const pageSize = bytes.readUInt32BE(cursor);
+		pageSizes.push(pageSize);
+		totalPageBytes += pageSize;
+		cursor += 4;
+	}
+	if (!Number.isSafeInteger(totalPageBytes) || cursor + totalPageBytes + 8 > bytes.length) throw unsupported();
+	const rows: Array<Record<string, unknown>> = [];
+	let invalid = 0;
+	let truncated = 0;
+	for (const pageSize of pageSizes) {
+		if (pageSize < 12 || cursor + pageSize > bytes.length) throw unsupported();
+		const page = bytes.subarray(cursor, cursor + pageSize);
+		cursor += pageSize;
+		if (page.readUInt32BE(0) !== 0x100) throw unsupported();
+		const cookieCount = page.readUInt32LE(4);
+		if (cookieCount > Math.floor((page.length - 12) / 4)) throw unsupported();
+		if (page.readUInt32LE(8 + cookieCount * 4) !== 0) throw unsupported();
+		const parseCount = Math.min(cookieCount, Math.max(0, BROWSER_IMPORT_MAX_COOKIES - rows.length));
+		for (let index = 0; index < parseCount; index += 1) {
+			const recordOffset = page.readUInt32LE(8 + index * 4);
+			if (recordOffset + 56 > page.length) {
+				invalid += 1;
+				continue;
+			}
+			const recordSize = page.readUInt32LE(recordOffset);
+			if (recordSize < 56 || recordOffset + recordSize > page.length) {
+				invalid += 1;
+				continue;
+			}
+			const record = page.subarray(recordOffset, recordOffset + recordSize);
+			const offsets = [16, 20, 24, 28].map((offset) => record.readUInt32LE(offset));
+			if (offsets.some((offset) => offset < 56 || offset >= record.length)) {
+				invalid += 1;
+				continue;
+			}
+			try {
+				const flags = record.readUInt32LE(8);
+				rows.push({
+					domain: readNullTerminatedUTF8(record, offsets[0]!),
+					name: readNullTerminatedUTF8(record, offsets[1]!),
+					path: readNullTerminatedUTF8(record, offsets[2]!),
+					value: readNullTerminatedUTF8(record, offsets[3]!),
+					expires: safariTimestamp(record.readDoubleLE(40)),
+					secure: (flags & 0x1) !== 0,
+					httpOnly: (flags & 0x4) !== 0,
+					sameSite: safariSameSite((flags >> 3) & 0x7),
+				});
+			} catch {
+				invalid += 1;
+			}
+		}
+		truncated += cookieCount - parseCount;
+	}
+	return { rows, invalid, truncated };
+}
+
+function readNullTerminatedUTF8(record: Buffer, offset: number): string {
+	const end = record.indexOf(0, offset);
+	if (end < 0) throw new Error("Safari cookie string is not terminated.");
+	return new TextDecoder("utf-8", { fatal: true }).decode(record.subarray(offset, end));
+}
+
 function normalizeCookieRows(
 	rows: Array<Record<string, unknown>>,
 	now: Date,
@@ -939,6 +1179,39 @@ function readChromiumHistory(file: string): { history: BrowserHistoryEntry[]; wa
 	});
 }
 
+function readSafariHistory(file: string): { history: BrowserHistoryEntry[]; warnings: BrowserImportWarning[] } {
+	return withReadOnlyDatabase(file, (database) => {
+		requireTable(database, "history_items", "The selected Safari profile does not contain supported history data.");
+		requireTable(database, "history_visits", "The selected Safari profile does not contain supported history data.");
+		const eligible = countRows(database, "history_items", "WHERE url LIKE 'http%'");
+		const truncated = Math.max(0, eligible - BROWSER_IMPORT_MAX_HISTORY_ENTRIES);
+		const history = (database.prepare(`
+			SELECT item.url,
+				(SELECT recent.title FROM history_visits recent
+				 WHERE recent.history_item = item.id ORDER BY recent.visit_time DESC, recent.id DESC LIMIT 1) AS title,
+				item.visit_count,
+				MAX(visit.visit_time) AS last_visit_time
+			FROM history_items item
+			LEFT JOIN history_visits visit ON visit.history_item = item.id
+			WHERE item.url LIKE 'http%'
+			GROUP BY item.id
+			ORDER BY last_visit_time DESC, item.id DESC
+			LIMIT ${BROWSER_IMPORT_MAX_HISTORY_ENTRIES}
+		`).all() as Record<string, unknown>[]).flatMap((row) =>
+			normalizeHistoryRow(
+				row.url,
+				row.title,
+				row.visit_count,
+				safariTimestamp(numberValue(row.last_visit_time)) * 1_000,
+			),
+		);
+		return {
+			history,
+			warnings: truncated > 0 ? [{ code: "history-limit-truncated", count: truncated }] : [],
+		};
+	});
+}
+
 function requireTable(database: Database, table: string, message: string): void {
 	if (!hasTable(database, table)) throw new Error(message);
 }
@@ -957,7 +1230,7 @@ function tableColumns(database: Database, table: "cookies" | "moz_cookies"): Set
 
 function countRows(
 	database: Database,
-	table: "cookies" | "moz_cookies" | "urls" | "moz_places",
+	table: "cookies" | "moz_cookies" | "urls" | "moz_places" | "history_items",
 	where = "",
 ): number {
 	const row = database.prepare(`SELECT COUNT(*) AS count FROM ${table} ${where}`).get() as { count?: unknown };
@@ -994,6 +1267,18 @@ function normalizeHistoryRow(
 function chromiumTimestamp(rawMicroseconds: number): number {
 	if (!Number.isFinite(rawMicroseconds) || rawMicroseconds <= 0) return 0;
 	return rawMicroseconds / 1_000_000 - 11_644_473_600;
+}
+
+function safariTimestamp(rawSeconds: number): number {
+	if (!Number.isFinite(rawSeconds) || rawSeconds <= 0) return 0;
+	return rawSeconds + 978_307_200;
+}
+
+function safariSameSite(value: number): CookiesSetDetails["sameSite"] {
+	if (value === 7) return "strict";
+	if (value === 5) return "lax";
+	if (value === 4) return "no_restriction";
+	return "unspecified";
 }
 
 function firefoxSameSite(value: number): CookiesSetDetails["sameSite"] {

--- a/frontend/src/renderer/components/settings/BrowserImportDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/BrowserImportDialog.test.tsx
@@ -58,7 +58,7 @@ describe("BrowserImportDialog", () => {
 			rename: vi.fn(),
 			clear: vi.fn(),
 			delete: vi.fn(),
-			discoverImportSources: vi.fn(async () => ({ sources: [source, firefoxSource] })),
+			discoverImportSources: vi.fn(async () => ({ sources: [source, firefoxSource], warnings: ["safari-access-denied" as const] })),
 			import: vi.fn(async () => ({
 				sourceName: source.name,
 				entries: [{
@@ -77,6 +77,8 @@ describe("BrowserImportDialog", () => {
 
 		render(<BrowserImportDialog onImported={onImported} onOpenChange={() => undefined} open />);
 		expect(await screen.findByText("Google Chrome")).toBeInTheDocument();
+		expect(screen.getByRole("status")).toHaveTextContent("Full Disk Access");
+		expect(screen.getByRole("button", { name: "Start import" })).toBeEnabled();
 		const sourcePicker = screen.getByRole("combobox", { name: "From" });
 		expect(sourcePicker).toHaveTextContent("Google Chrome");
 		await userEvent.click(sourcePicker);

--- a/frontend/src/renderer/components/settings/BrowserImportDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/BrowserImportDialog.test.tsx
@@ -28,6 +28,16 @@ const firefoxSource = {
 	historySupport: true as const,
 };
 
+const safariSource = {
+	id: "f".repeat(32),
+	name: "Safari",
+	family: "safari" as const,
+	profiles: [{ id: "1".repeat(32), name: "Personal", default: true }],
+	cookieSupport: "supported" as const,
+	cookieSupportReason: "safari-plaintext" as const,
+	historySupport: true as const,
+};
+
 describe("BrowserImportDialog", () => {
 	const originalBridge = aoBridge.browserProfiles;
 
@@ -149,6 +159,28 @@ describe("BrowserImportDialog", () => {
 		expect(alert).toHaveTextContent("Fully close Brave, including background processes, then try again");
 		expect(alert).toHaveTextContent("Encrypted cookies are handled separately");
 		expect(alert).not.toHaveTextContent("Error invoking remote method");
+	});
+
+	it("points Safari users to Full Disk Access when macOS blocks its data", async () => {
+		const bridge: AoBridge["browserProfiles"] = {
+			list: vi.fn(async () => ({ profiles: [] })),
+			create: vi.fn(),
+			rename: vi.fn(),
+			clear: vi.fn(),
+			delete: vi.fn(),
+			discoverImportSources: vi.fn(async () => ({ sources: [safariSource] })),
+			import: vi.fn(async () => { throw new Error("EPERM: operation not permitted"); }),
+			onImportProgress: vi.fn(() => () => undefined),
+		};
+		aoBridge.browserProfiles = bridge;
+
+		render(<BrowserImportDialog onImported={() => undefined} onOpenChange={() => undefined} open />);
+		await screen.findByText("Safari");
+		await userEvent.click(screen.getByRole("button", { name: "Start import" }));
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"Privacy & Security > Full Disk Access, allow AO, then restart AO",
+		);
 	});
 
 	it("keeps discovery failures visible and disables import", async () => {

--- a/frontend/src/renderer/components/settings/BrowserImportDialog.tsx
+++ b/frontend/src/renderer/components/settings/BrowserImportDialog.tsx
@@ -248,6 +248,7 @@ function importFailureMessage(reason: unknown, browser: string): string {
 		.replace(/^Error:\s*/i, "")
 		.trim();
 	if (/unable to open database file|database is locked|SQLITE_(?:BUSY|CANTOPEN|LOCKED)|\b(?:EACCES|EBUSY|EPERM)\b/i.test(message)) {
+		if (browser === "Safari") return appI18n.t("settings.browserImport.safariAccessUnavailable");
 		return appI18n.t("settings.browserImport.sourceDatabaseUnavailable", { browser });
 	}
 	return message || fallback;

--- a/frontend/src/renderer/components/settings/BrowserImportDialog.tsx
+++ b/frontend/src/renderer/components/settings/BrowserImportDialog.tsx
@@ -50,6 +50,7 @@ export function BrowserImportDialog({
 	const [mergeName, setMergeName] = useState("");
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState("");
+	const [safariAccessDenied, setSafariAccessDenied] = useState(false);
 	const [progress, setProgress] = useState<BrowserImportProgress | null>(null);
 	const [result, setResult] = useState<BrowserImportResult | null>(null);
 
@@ -62,6 +63,7 @@ export function BrowserImportDialog({
 		if (!open) return;
 		setView("form");
 		setSources([]);
+		setSafariAccessDenied(false);
 		setSourceId("");
 		setSelectedProfileIds([]);
 		setIncludeCookies(true);
@@ -80,6 +82,7 @@ export function BrowserImportDialog({
 		void bridge.discoverImportSources().then(
 			(discovery) => {
 				setSources(discovery.sources);
+				setSafariAccessDenied(discovery.warnings?.includes("safari-access-denied") ?? false);
 				const first = discovery.sources[0];
 				if (first) applySourceDefaults(first, setSourceId, setSelectedProfileIds, setDestinationNames, setMergeName, setDestinationMode);
 			},
@@ -177,6 +180,9 @@ export function BrowserImportDialog({
 				</div>
 
 				<div className={settingsDialogBodyClass}>
+					{view === "form" && safariAccessDenied ? (
+						<p className="text-xs text-warning" role="status">{t("settings.browserImport.safariAccessUnavailable")}</p>
+					) : null}
 					{view === "form" ? (
 						<ImportForm
 							destinationMode={destinationMode}

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1698,6 +1698,7 @@
 	"settings.browserImport.discoveryFailed": "Installierte Browser konnten nicht geprüft werden.",
 	"settings.browserImport.failed": "Browserdaten konnten nicht importiert werden.",
 	"settings.browserImport.sourceDatabaseUnavailable": "AO konnte nicht auf die Profildatenbank von {{browser}} zugreifen. {{browser}} verwendet sie möglicherweise noch oder das Betriebssystem blockiert den Zugriff. Schließen Sie {{browser}} vollständig, einschließlich aller Hintergrundprozesse, und versuchen Sie es erneut. Falls der Fehler weiterhin auftritt, prüfen Sie, ob die Browserprofildateien zugänglich sind. Verschlüsselte Cookies werden separat behandelt und haben diesen Fehler nicht verursacht.",
+	"settings.browserImport.safariAccessUnavailable": "AO konnte nicht auf die Safari-Daten zugreifen. Öffnen Sie in den Systemeinstellungen Datenschutz & Sicherheit > Festplattenvollzugriff, erlauben Sie AO den Zugriff, starten Sie AO neu und versuchen Sie den Import erneut.",
 	"settings.browserImport.profileCount": "{{count}} Profile gefunden",
 	"settings.browserImport.selectProfiles": "Wähle die {{browser}}-Profile aus, die du in AO übernehmen möchtest.",
 	"settings.browserImport.defaultProfile": "Standard",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -958,6 +958,7 @@
 	"settings.browserImport.discoveryFailed": "Could not inspect installed browsers.",
 	"settings.browserImport.failed": "Browser data could not be imported.",
 	"settings.browserImport.sourceDatabaseUnavailable": "AO couldn't access {{browser}}'s profile database. {{browser}} may still be using it, or the operating system may be blocking access. Fully close {{browser}}, including background processes, then try again. If it still fails, check that the browser profile files are accessible. Encrypted cookies are handled separately and did not cause this error.",
+	"settings.browserImport.safariAccessUnavailable": "AO couldn't access Safari's data. In System Settings, open Privacy & Security > Full Disk Access, allow AO, then restart AO and try the import again.",
 	"settings.browserImport.profileCount": "{{count}} profiles found",
 	"settings.browserImport.selectProfiles": "Choose the {{browser}} profiles you want to bring into AO.",
 	"settings.browserImport.defaultProfile": "Default",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1724,6 +1724,7 @@
 	"settings.browserImport.discoveryFailed": "No se pudieron revisar los navegadores instalados.",
 	"settings.browserImport.failed": "No se pudieron importar los datos del navegador.",
 	"settings.browserImport.sourceDatabaseUnavailable": "AO no pudo acceder a la base de datos del perfil de {{browser}}. Es posible que {{browser}} todavía la esté usando o que el sistema operativo bloquee el acceso. Cierra {{browser}} por completo, incluidos los procesos en segundo plano, e inténtalo de nuevo. Si sigue fallando, comprueba que se pueda acceder a los archivos del perfil. Las cookies cifradas se gestionan por separado y no causaron este error.",
+	"settings.browserImport.safariAccessUnavailable": "AO no pudo acceder a los datos de Safari. En Ajustes del Sistema, abre Privacidad y seguridad > Acceso total al disco, permite el acceso a AO, reinicia AO e intenta importar de nuevo.",
 	"settings.browserImport.profileCount": "{{count}} perfiles encontrados",
 	"settings.browserImport.selectProfiles": "Elige los perfiles de {{browser}} que quieres traer a AO.",
 	"settings.browserImport.defaultProfile": "Predeterminado",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1724,6 +1724,7 @@
 	"settings.browserImport.discoveryFailed": "Impossible d’examiner les navigateurs installés.",
 	"settings.browserImport.failed": "Impossible d’importer les données du navigateur.",
 	"settings.browserImport.sourceDatabaseUnavailable": "AO n’a pas pu accéder à la base de données du profil de {{browser}}. {{browser}} l’utilise peut-être encore, ou le système d’exploitation bloque l’accès. Fermez complètement {{browser}}, y compris ses processus en arrière-plan, puis réessayez. Si le problème persiste, vérifiez que les fichiers du profil sont accessibles. Les cookies chiffrés sont traités séparément et ne sont pas à l’origine de cette erreur.",
+	"settings.browserImport.safariAccessUnavailable": "AO n’a pas pu accéder aux données de Safari. Dans Réglages Système, ouvrez Confidentialité et sécurité > Accès complet au disque, autorisez AO, redémarrez AO, puis relancez l’importation.",
 	"settings.browserImport.profileCount": "{{count}} profils trouvés",
 	"settings.browserImport.selectProfiles": "Choisissez les profils {{browser}} à importer dans AO.",
 	"settings.browserImport.defaultProfile": "Par défaut",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1698,6 +1698,7 @@
 	"settings.browserImport.discoveryFailed": "インストール済みブラウザを確認できませんでした。",
 	"settings.browserImport.failed": "ブラウザデータをインポートできませんでした。",
 	"settings.browserImport.sourceDatabaseUnavailable": "AO は {{browser}} のプロファイルデータベースにアクセスできませんでした。{{browser}} がまだ使用しているか、OS がアクセスをブロックしている可能性があります。バックグラウンドプロセスを含めて {{browser}} を完全に終了し、もう一度お試しください。それでも失敗する場合は、ブラウザのプロファイルファイルにアクセスできることを確認してください。暗号化された Cookie は別途処理されるため、このエラーの原因ではありません。",
+	"settings.browserImport.safariAccessUnavailable": "AO は Safari のデータにアクセスできませんでした。システム設定で「プライバシーとセキュリティ」>「フルディスクアクセス」を開き、AO を許可してから AO を再起動し、もう一度インポートしてください。",
 	"settings.browserImport.profileCount": "{{count}} 件のプロファイルが見つかりました",
 	"settings.browserImport.selectProfiles": "AOに取り込む{{browser}}プロファイルを選択してください。",
 	"settings.browserImport.defaultProfile": "デフォルト",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1698,6 +1698,7 @@
 	"settings.browserImport.discoveryFailed": "설치된 브라우저를 확인하지 못했습니다.",
 	"settings.browserImport.failed": "브라우저 데이터를 가져오지 못했습니다.",
 	"settings.browserImport.sourceDatabaseUnavailable": "AO가 {{browser}}의 프로필 데이터베이스에 접근하지 못했습니다. {{browser}}가 아직 데이터베이스를 사용 중이거나 운영 체제가 접근을 차단하고 있을 수 있습니다. 백그라운드 프로세스를 포함해 {{browser}}를 완전히 종료한 후 다시 시도하세요. 계속 실패하면 브라우저 프로필 파일에 접근할 수 있는지 확인하세요. 암호화된 쿠키는 별도로 처리되며 이 오류의 원인이 아닙니다.",
+	"settings.browserImport.safariAccessUnavailable": "AO가 Safari 데이터에 접근하지 못했습니다. 시스템 설정에서 개인정보 보호 및 보안 > 전체 디스크 접근을 열고 AO를 허용한 다음 AO를 다시 시작하여 가져오기를 다시 시도하세요.",
 	"settings.browserImport.profileCount": "프로필 {{count}}개 발견",
 	"settings.browserImport.selectProfiles": "AO로 가져올 {{browser}} 프로필을 선택하세요.",
 	"settings.browserImport.defaultProfile": "기본값",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1724,6 +1724,7 @@
 	"settings.browserImport.discoveryFailed": "Não foi possível verificar os navegadores instalados.",
 	"settings.browserImport.failed": "Não foi possível importar os dados do navegador.",
 	"settings.browserImport.sourceDatabaseUnavailable": "O AO não conseguiu acessar o banco de dados do perfil do {{browser}}. O {{browser}} ainda pode estar usando o arquivo, ou o sistema operacional pode estar bloqueando o acesso. Feche completamente o {{browser}}, incluindo os processos em segundo plano, e tente novamente. Se ainda falhar, verifique se os arquivos do perfil estão acessíveis. Cookies criptografados são tratados separadamente e não causaram este erro.",
+	"settings.browserImport.safariAccessUnavailable": "O AO não conseguiu acessar os dados do Safari. Nos Ajustes do Sistema, abra Privacidade e Segurança > Acesso Total ao Disco, permita o acesso ao AO, reinicie o AO e tente importar novamente.",
 	"settings.browserImport.profileCount": "{{count}} perfis encontrados",
 	"settings.browserImport.selectProfiles": "Escolha os perfis do {{browser}} que você quer trazer para o AO.",
 	"settings.browserImport.defaultProfile": "Padrão",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1710,6 +1710,7 @@
 	"settings.browserImport.discoveryFailed": "无法检查已安装的浏览器。",
 	"settings.browserImport.failed": "无法导入浏览器数据。",
 	"settings.browserImport.sourceDatabaseUnavailable": "AO 无法访问 {{browser}} 的配置文件数据库。{{browser}} 可能仍在使用该数据库，或者操作系统阻止了访问。请完全关闭 {{browser}}（包括后台进程），然后重试。如果仍然失败，请检查浏览器配置文件是否可访问。加密 Cookie 会单独处理，并不是此错误的原因。",
+	"settings.browserImport.safariAccessUnavailable": "AO 无法访问 Safari 数据。请在系统设置中打开隐私与安全性 > 完全磁盘访问权限，允许 AO 访问，然后重新启动 AO 并再次尝试导入。",
 	"settings.browserImport.profileCount": "找到 {{count}} 个配置文件",
 	"settings.browserImport.selectProfiles": "选择要导入 AO 的 {{browser}} 配置文件。",
 	"settings.browserImport.defaultProfile": "默认",

--- a/frontend/src/shared/browser-profile-import.ts
+++ b/frontend/src/shared/browser-profile-import.ts
@@ -30,6 +30,7 @@ export type BrowserImportSource = {
 
 export type BrowserImportDiscovery = {
 	sources: BrowserImportSource[];
+	warnings?: Array<"safari-access-denied">;
 };
 
 export type BrowserImportDestination =

--- a/frontend/src/shared/browser-profile-import.ts
+++ b/frontend/src/shared/browser-profile-import.ts
@@ -4,10 +4,11 @@ export const BROWSER_IMPORT_MAX_SOURCE_PROFILES = 16;
 export const BROWSER_IMPORT_MAX_HISTORY_ENTRIES = 5_000;
 export const BROWSER_IMPORT_MAX_COOKIES = 20_000;
 
-export type BrowserImportFamily = "chromium" | "firefox";
+export type BrowserImportFamily = "chromium" | "firefox" | "safari";
 export type BrowserImportCookieSupport = "supported" | "partial" | "unsupported";
 export type BrowserImportCookieSupportReason =
 	| "firefox-plaintext"
+	| "safari-plaintext"
 	| "chromium-encryption-partial"
 	| "chromium-encryption-unsupported";
 


### PR DESCRIPTION
## Issue

The browser import flow supports Chromium and Firefox profiles, but macOS users cannot import their Safari data.

## Fix

- Discover Safari’s default profile and named Safari 17 profiles on macOS.
- Import browsing history from Safari SQLite databases.
- Parse and import cookies from Safari’s `Cookies.binarycookies` format.
- Snapshot Safari source files into AO-controlled staging before reading them, with existing size and path-safety limits.
- Keep Chrome and Firefox discovery working when macOS denies access to Safari data.
- Show localized guidance when AO needs Full Disk Access to read Safari profiles.
- Preserve the existing profile, history, and cookie import limits.

## Files affected

- `frontend/src/main/browser-profile-import.ts`
  - Adds Safari discovery, history import, binary cookie parsing, safe snapshots, and permission handling.
- `frontend/src/shared/browser-profile-import.ts`
  - Extends the import contract with Safari support and discovery warnings.
- `frontend/src/renderer/components/settings/BrowserImportDialog.tsx`
  - Displays guidance when Safari access is denied.
- `frontend/src/renderer/i18n/*.json`
  - Adds the Safari permission message in supported languages.
- Browser import and dialog tests
  - Cover Safari discovery, parsing, safety limits, cleanup, and permission failures.

## Validation

- Focused browser import and dialog tests: 42 passed.
- Frontend TypeScript typecheck passed.
- `git diff --check` passed.
- An earlier full frontend test run completed with 4,389 passing tests and 45 unrelated platform/environment failures.