### PR TITLE
refactor(httpd): share SSE transport mechanics and bound slow-client writes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,10 +46,10 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        # The SQLite migration package already runs close to Go's default
-        # 10-minute per-package limit under the race detector. Keep deadlock
-        # protection while leaving enough headroom for migration coverage.
-        run: go test -race -timeout=15m ./...
+        # The SQLite migration package already runs close to 15 minutes under
+        # the race detector. Keep deadlock protection while leaving enough
+        # headroom for migration coverage on busy CI runners.
+        run: go test -race -timeout=20m ./...
 
   # The suite above only ever runs on Linux, so the packages whose behaviour is
   # genuinely platform-specific have never been exercised on Windows: worktree

--- a/backend/internal/httpd/controllers/codex_accounts.go
+++ b/backend/internal/httpd/controllers/codex_accounts.go
@@ -281,7 +281,10 @@ func (c *CodexAccountsController) cancelLogin(w http.ResponseWriter, r *http.Req
 	envelope.WriteJSON(w, http.StatusOK, newCodexLoginResponse(result))
 }
 
+// CodexAccountsStreamHeartbeatInterval is the interval between SSE ping comments. Tests may override.
 var CodexAccountsStreamHeartbeatInterval = 25 * time.Second
+
+// CodexAccountsStreamWriteTimeout is the per-write deadline for sending SSE events or pings. Tests may override.
 var CodexAccountsStreamWriteTimeout = sse.DefaultWriteTimeout
 
 func (c *CodexAccountsController) events(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/httpd/controllers/codex_accounts.go
+++ b/backend/internal/httpd/controllers/codex_accounts.go
@@ -2,9 +2,7 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -15,6 +13,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/sse"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	agentsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/agent"
 )
@@ -282,14 +281,12 @@ func (c *CodexAccountsController) cancelLogin(w http.ResponseWriter, r *http.Req
 	envelope.WriteJSON(w, http.StatusOK, newCodexLoginResponse(result))
 }
 
+var CodexAccountsStreamHeartbeatInterval = 25 * time.Second
+var CodexAccountsStreamWriteTimeout = sse.DefaultWriteTimeout
+
 func (c *CodexAccountsController) events(w http.ResponseWriter, r *http.Request) {
 	if c.Svc == nil {
 		apispec.NotImplemented(w, r, "GET", "/api/v1/agents/codex/accounts/events")
-		return
-	}
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "SSE_UNSUPPORTED", "Streaming is not supported by this server", nil)
 		return
 	}
 	events, err := c.Svc.SubscribeCodexAccounts(r.Context())
@@ -297,34 +294,29 @@ func (c *CodexAccountsController) events(w http.ResponseWriter, r *http.Request)
 		envelope.WriteError(w, r, err)
 		return
 	}
-	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
-	heartbeat := time.NewTicker(25 * time.Second)
+
+	sw, err := sse.Upgrade(w, r, sse.WithWriteTimeout(CodexAccountsStreamWriteTimeout))
+	if err != nil {
+		return
+	}
+
+	heartbeat := time.NewTicker(CodexAccountsStreamHeartbeatInterval)
 	defer heartbeat.Stop()
 	for {
 		select {
 		case <-r.Context().Done():
 			return
 		case <-heartbeat.C:
-			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+			if err := sw.WriteComment("heartbeat"); err != nil {
 				return
 			}
-			flusher.Flush()
 		case event, ok := <-events:
 			if !ok {
 				return
 			}
-			data, err := json.Marshal(newCodexAccountsResponse(event))
-			if err != nil {
+			if err := sw.WriteJSON("", "codex_account", newCodexAccountsResponse(event)); err != nil {
 				return
 			}
-			if _, err := fmt.Fprintf(w, "event: codex_account\ndata: %s\n\n", data); err != nil {
-				return
-			}
-			flusher.Flush()
 		}
 	}
 }

--- a/backend/internal/httpd/controllers/codex_accounts_test.go
+++ b/backend/internal/httpd/controllers/codex_accounts_test.go
@@ -1,6 +1,7 @@
 package controllers_test
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"io"
@@ -394,3 +395,64 @@ func TestCodexAccountEventStreamSendsNamedCachedState(t *testing.T) {
 		}
 	}
 }
+
+func TestCodexAccountEventStream_HeartbeatsWhileIdle(t *testing.T) {
+	restore := controllers.CodexAccountsStreamHeartbeatInterval
+	controllers.CodexAccountsStreamHeartbeatInterval = 50 * time.Millisecond
+	defer func() { controllers.CodexAccountsStreamHeartbeatInterval = restore }()
+
+	fake := &fakeCodexAccounts{result: codexAccountsFixture()}
+	srv := newCodexAccountServer(t, fake)
+	defer srv.Close()
+
+	response, err := http.Get(srv.URL + "/api/v1/agents/codex/accounts/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	reader := bufio.NewReader(response.Body)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(line, ": heartbeat") {
+			return
+		}
+	}
+	t.Fatal("idle codex accounts stream sent no heartbeat comment frame")
+}
+
+func TestCodexAccountEventStream_BlockedClientExits(t *testing.T) {
+	restore := controllers.CodexAccountsStreamWriteTimeout
+	controllers.CodexAccountsStreamWriteTimeout = 50 * time.Millisecond
+	defer func() { controllers.CodexAccountsStreamWriteTimeout = restore }()
+
+	events := make(chan agentsvc.CodexAccounts, 1)
+	fake := &fakeCodexAccounts{result: codexAccountsFixture(), events: events}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
+		CodexAccounts: fake,
+	}, httpd.ControlDeps{})
+
+	tw := &timeoutOnNotificationWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/codex/accounts/events", nil)
+
+	handlerDone := make(chan struct{})
+	go func() {
+		router.ServeHTTP(tw, req)
+		close(handlerDone)
+	}()
+
+	events <- codexAccountsFixture()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit within bounded write deadline")
+	}
+}
+

--- a/backend/internal/httpd/controllers/codex_accounts_test.go
+++ b/backend/internal/httpd/controllers/codex_accounts_test.go
@@ -455,4 +455,3 @@ func TestCodexAccountEventStream_BlockedClientExits(t *testing.T) {
 		t.Fatal("handler did not exit within bounded write deadline")
 	}
 }
-

--- a/backend/internal/httpd/controllers/notifications.go
+++ b/backend/internal/httpd/controllers/notifications.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/sse"
 	notificationsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/notification"
 )
 
@@ -116,56 +117,51 @@ func (c *NotificationsController) markAllRead(w http.ResponseWriter, r *http.Req
 	})
 }
 
+var NotificationsHeartbeatInterval = sse.DefaultHeartbeatInterval
+
+var NotificationsWriteTimeout = sse.DefaultWriteTimeout
+
 func (c *NotificationsController) stream(w http.ResponseWriter, r *http.Request) {
 	if c.Stream == nil {
 		apispec.NotImplemented(w, r, "GET", "/api/v1/notifications/stream")
 		return
 	}
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "SSE_UNSUPPORTED", "Streaming is not supported by this server", nil)
-		return
-	}
 	ch, unsubscribe := c.Stream.Subscribe(domain.ProjectID(r.URL.Query().Get("projectId")))
 	defer unsubscribe()
 
-	h := w.Header()
-	h.Set("Content-Type", "text/event-stream; charset=utf-8")
-	h.Set("Cache-Control", "no-cache")
-	h.Set("Connection", "keep-alive")
-	h.Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	sw, err := sse.Upgrade(w, r, sse.WithWriteTimeout(NotificationsWriteTimeout))
+	if err != nil {
+		return
+	}
+
+	heartbeat := time.NewTicker(NotificationsHeartbeatInterval)
+	defer heartbeat.Stop()
 
 	for {
 		select {
 		case <-r.Context().Done():
 			return
+		case <-heartbeat.C:
+			if err := sw.WriteComment(""); err != nil {
+				return
+			}
 		case event, ok := <-ch:
 			if !ok {
 				return
 			}
-			if err := writeNotificationSSE(w, flusher, event); err != nil {
+			if err := writeNotificationSSE(sw, event); err != nil {
 				return
 			}
 		}
 	}
 }
 
-func writeNotificationSSE(w http.ResponseWriter, flusher http.Flusher, event domain.NotificationEvent) error {
-	data, err := json.Marshal(notificationResponseFromRecord(event.Record))
-	if err != nil {
-		return err
-	}
+func writeNotificationSSE(sw *sse.Writer, event domain.NotificationEvent) error {
 	name := "notification_created"
 	if event.Kind == domain.NotificationResolved {
 		name = "notification_resolved"
 	}
-	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", name, data); err != nil {
-		return err
-	}
-	flusher.Flush()
-	return nil
+	return sw.WriteJSON("", name, notificationResponseFromRecord(event.Record))
 }
 
 func parseNotificationListFilter(r *http.Request) (notificationsvc.ListFilter, error) {

--- a/backend/internal/httpd/controllers/notifications.go
+++ b/backend/internal/httpd/controllers/notifications.go
@@ -117,8 +117,10 @@ func (c *NotificationsController) markAllRead(w http.ResponseWriter, r *http.Req
 	})
 }
 
+// NotificationsHeartbeatInterval is the interval between SSE ping comments. Tests may override.
 var NotificationsHeartbeatInterval = sse.DefaultHeartbeatInterval
 
+// NotificationsWriteTimeout is the per-write deadline for sending SSE events or pings. Tests may override.
 var NotificationsWriteTimeout = sse.DefaultWriteTimeout
 
 func (c *NotificationsController) stream(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/httpd/controllers/notifications_test.go
+++ b/backend/internal/httpd/controllers/notifications_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -301,3 +302,151 @@ func TestNotificationsAPI_StreamWithoutPublisherIs501(t *testing.T) {
 	body, status, _ := doRequest(t, srv, "GET", "/api/v1/notifications/stream", "")
 	assertErrorCode(t, body, status, http.StatusNotImplemented, "NOT_IMPLEMENTED")
 }
+
+func TestNotificationsAPI_StreamHeartbeatsWhileIdle(t *testing.T) {
+	restore := controllers.NotificationsHeartbeatInterval
+	controllers.NotificationsHeartbeatInterval = 50 * time.Millisecond
+	defer func() { controllers.NotificationsHeartbeatInterval = restore }()
+
+	stream := &fakeNotificationStream{ch: make(chan domain.NotificationEvent)}
+	srv := newNotificationStreamTestServer(t, &fakeNotificationService{}, stream)
+
+	resp, err := srv.Client().Get(srv.URL + "/api/v1/notifications/stream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(line, ":") {
+			return
+		}
+	}
+	t.Fatal("idle notification stream sent no heartbeat comment frame")
+}
+
+type trackingNotificationStream struct {
+	mu           sync.Mutex
+	unsubscribed bool
+	ch           chan domain.NotificationEvent
+}
+
+func (s *trackingNotificationStream) Subscribe(projectID domain.ProjectID) (<-chan domain.NotificationEvent, func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unsubscribed = false
+	if s.ch == nil {
+		s.ch = make(chan domain.NotificationEvent, 1)
+	}
+	return s.ch, func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.unsubscribed = true
+	}
+}
+
+func (s *trackingNotificationStream) isUnsubscribed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.unsubscribed
+}
+
+type timeoutOnNotificationWriter struct {
+	*httptest.ResponseRecorder
+	mu       sync.Mutex
+	deadline time.Time
+}
+
+func (w *timeoutOnNotificationWriter) SetWriteDeadline(t time.Time) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.deadline = t
+	return nil
+}
+
+func (w *timeoutOnNotificationWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	d := w.deadline
+	w.mu.Unlock()
+	if strings.Contains(string(p), "event:") {
+		if !d.IsZero() && time.Now().Before(d) {
+			time.Sleep(time.Until(d) + 5*time.Millisecond)
+		}
+		return 0, context.DeadlineExceeded
+	}
+	return w.ResponseRecorder.Write(p)
+}
+
+func TestNotificationsAPI_StreamBlockedClientExitsAndUnsubscribes(t *testing.T) {
+	restoreTimeout := controllers.NotificationsWriteTimeout
+	controllers.NotificationsWriteTimeout = 50 * time.Millisecond
+	defer func() { controllers.NotificationsWriteTimeout = restoreTimeout }()
+
+	stream := &trackingNotificationStream{ch: make(chan domain.NotificationEvent, 1)}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
+		Notifications:      &fakeNotificationService{},
+		NotificationStream: stream,
+	}, httpd.ControlDeps{})
+
+	tw := &timeoutOnNotificationWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications/stream", nil)
+
+	handlerDone := make(chan struct{})
+	go func() {
+		router.ServeHTTP(tw, req)
+		close(handlerDone)
+	}()
+
+	rec := domain.NotificationRecord{ID: "ntf_block", Type: domain.NotificationNeedsInput, Title: "block"}
+	stream.ch <- domain.NotificationEvent{Kind: domain.NotificationCreated, Record: rec}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit within bounded write deadline")
+	}
+
+	if !stream.isUnsubscribed() {
+		t.Fatal("expected stream to unsubscribe after blocked write")
+	}
+}
+
+func TestNotificationsAPI_StreamContextCancellationUnsubscribes(t *testing.T) {
+	stream := &trackingNotificationStream{ch: make(chan domain.NotificationEvent, 1)}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
+		Notifications:      &fakeNotificationService{},
+		NotificationStream: stream,
+	}, httpd.ControlDeps{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications/stream", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handlerDone := make(chan struct{})
+	go func() {
+		router.ServeHTTP(rec, req)
+		close(handlerDone)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not exit after context cancellation")
+	}
+
+	if !stream.isUnsubscribed() {
+		t.Fatal("expected stream to unsubscribe after context cancellation")
+	}
+}
+

--- a/backend/internal/httpd/controllers/notifications_test.go
+++ b/backend/internal/httpd/controllers/notifications_test.go
@@ -449,4 +449,3 @@ func TestNotificationsAPI_StreamContextCancellationUnsubscribes(t *testing.T) {
 		t.Fatal("expected stream to unsubscribe after context cancellation")
 	}
 }
-

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -27,6 +26,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/sse"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	previewutil "github.com/aoagents/agent-orchestrator/backend/internal/preview"
 	"github.com/aoagents/agent-orchestrator/backend/internal/previewserver"
@@ -750,14 +750,12 @@ func (c *SessionsController) getWorkspaceFileBlob(w http.ResponseWriter, r *http
 	_, _ = w.Write(blob.Data)
 }
 
+var WorkspaceStreamHeartbeatInterval = 15 * time.Second
+var WorkspaceStreamWriteTimeout = sse.DefaultWriteTimeout
+
 func (c *SessionsController) streamWorkspaceChanges(w http.ResponseWriter, r *http.Request) {
 	if c.Svc == nil {
 		apispec.NotImplemented(w, r, "GET", "/api/v1/sessions/{sessionId}/workspace/events")
-		return
-	}
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "SSE_UNSUPPORTED", "Streaming is not supported by this server", nil)
 		return
 	}
 	paths, err := c.Svc.WorkspaceWatchPaths(r.Context(), sessionID(r))
@@ -771,15 +769,12 @@ func (c *SessionsController) streamWorkspaceChanges(w http.ResponseWriter, r *ht
 		return
 	}
 
-	h := w.Header()
-	h.Set("Content-Type", "text/event-stream; charset=utf-8")
-	h.Set("Cache-Control", "no-cache")
-	h.Set("Connection", "keep-alive")
-	h.Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	sw, err := sse.Upgrade(w, r, sse.WithWriteTimeout(WorkspaceStreamWriteTimeout))
+	if err != nil {
+		return
+	}
 
-	keepAlive := time.NewTicker(15 * time.Second)
+	keepAlive := time.NewTicker(WorkspaceStreamHeartbeatInterval)
 	defer keepAlive.Stop()
 	for {
 		select {
@@ -797,16 +792,13 @@ func (c *SessionsController) streamWorkspaceChanges(w http.ResponseWriter, r *ht
 			if files, listErr := c.Svc.ListWorkspaceFiles(r.Context(), sessionID(r)); listErr == nil {
 				payload.WorkspaceVersion = files.WorkspaceVersion
 			}
-			data, _ := json.Marshal(payload)
-			if _, err := fmt.Fprintf(w, "event: workspace_changed\ndata: %s\n\n", data); err != nil {
+			if err := sw.WriteJSON("", "workspace_changed", payload); err != nil {
 				return
 			}
-			flusher.Flush()
 		case <-keepAlive.C:
-			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+			if err := sw.WriteComment("keepalive"); err != nil {
 				return
 			}
-			flusher.Flush()
 		}
 	}
 }

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -750,7 +750,10 @@ func (c *SessionsController) getWorkspaceFileBlob(w http.ResponseWriter, r *http
 	_, _ = w.Write(blob.Data)
 }
 
+// WorkspaceStreamHeartbeatInterval is the interval between SSE ping comments. Tests may override.
 var WorkspaceStreamHeartbeatInterval = 15 * time.Second
+
+// WorkspaceStreamWriteTimeout is the per-write deadline for sending SSE events or pings. Tests may override.
 var WorkspaceStreamWriteTimeout = sse.DefaultWriteTimeout
 
 func (c *SessionsController) streamWorkspaceChanges(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -2755,7 +2755,6 @@ func TestSessionsAPI_StreamWorkspaceChanges_BlockedClientExits(t *testing.T) {
 	t.Fatal("handler did not exit within bounded write deadline")
 }
 
-
 func TestSessionsAPI_SetPreviewEmptyURLNoEntry(t *testing.T) {
 	svc := newFakeSessionService()
 	s := svc.sessions["ao-1"]

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -2737,10 +2737,7 @@ func TestSessionsAPI_StreamWorkspaceChanges_BlockedClientExits(t *testing.T) {
 		close(handlerDone)
 	}()
 
-	deadline := time.Now().Add(time.Second)
-	for !tw.Flushed && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
-	}
+	time.Sleep(20 * time.Millisecond)
 
 	writeDeadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(writeDeadline) {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -2674,6 +2674,88 @@ func TestSessionsAPI_StreamWorkspaceChanges(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_StreamWorkspaceChanges_HeartbeatsWhileIdle(t *testing.T) {
+	restore := controllers.WorkspaceStreamHeartbeatInterval
+	controllers.WorkspaceStreamHeartbeatInterval = 50 * time.Millisecond
+	defer func() { controllers.WorkspaceStreamHeartbeatInterval = restore }()
+
+	workspace := t.TempDir()
+	svc := newFakeSessionService()
+	session := svc.sessions["ao-1"]
+	session.Metadata.WorkspacePath = workspace
+	svc.sessions["ao-1"] = session
+	srv := newSessionTestServer(t, svc)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/v1/sessions/ao-1/workspace/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(line, ": keepalive") {
+			return
+		}
+	}
+	t.Fatal("idle workspace stream sent no keepalive comment frame")
+}
+
+func TestSessionsAPI_StreamWorkspaceChanges_BlockedClientExits(t *testing.T) {
+	restoreTimeout := controllers.WorkspaceStreamWriteTimeout
+	controllers.WorkspaceStreamWriteTimeout = 50 * time.Millisecond
+	defer func() { controllers.WorkspaceStreamWriteTimeout = restoreTimeout }()
+
+	workspace := t.TempDir()
+	svc := newFakeSessionService()
+	session := svc.sessions["ao-1"]
+	session.Metadata.WorkspacePath = workspace
+	svc.sessions["ao-1"] = session
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
+		Sessions: svc,
+	}, httpd.ControlDeps{})
+
+	tw := &timeoutOnNotificationWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/ao-1/workspace/events", nil)
+
+	handlerDone := make(chan struct{})
+	go func() {
+		router.ServeHTTP(tw, req)
+		close(handlerDone)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for !tw.Flushed && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	writeDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(writeDeadline) {
+		select {
+		case <-handlerDone:
+			return
+		default:
+			_ = os.WriteFile(filepath.Join(workspace, "README.md"), []byte(time.Now().String()), 0o644)
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	t.Fatal("handler did not exit within bounded write deadline")
+}
+
+
 func TestSessionsAPI_SetPreviewEmptyURLNoEntry(t *testing.T) {
 	svc := newFakeSessionService()
 	s := svc.sessions["ao-1"]

--- a/backend/internal/httpd/events.go
+++ b/backend/internal/httpd/events.go
@@ -2,9 +2,7 @@ package httpd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,6 +12,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/sse"
 
 	"time"
 )
@@ -45,6 +44,9 @@ func (c *EventsController) Register(r chi.Router) {
 // negligible on a metered connection. A var so tests need not wait it out.
 var eventsHeartbeatInterval = 10 * time.Second
 
+// eventsWriteTimeout bounds stalled client writes. A var so tests need not wait it out.
+var eventsWriteTimeout = sse.DefaultWriteTimeout
+
 func (c *EventsController) stream(w http.ResponseWriter, r *http.Request) {
 	if c.Source == nil || c.Live == nil {
 		apispec.NotImplemented(w, r, "GET", "/api/v1/events")
@@ -72,13 +74,6 @@ func (c *EventsController) stream(w http.ResponseWriter, r *http.Request) {
 		after = latestSeq
 	}
 
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "SSE_UNSUPPORTED",
-			"Streaming is not supported by this server", nil)
-		return
-	}
-
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
@@ -94,17 +89,14 @@ func (c *EventsController) stream(w http.ResponseWriter, r *http.Request) {
 	})
 	defer unsubscribe()
 
-	h := w.Header()
-	h.Set("Content-Type", "text/event-stream; charset=utf-8")
-	h.Set("Cache-Control", "no-cache")
-	h.Set("Connection", "keep-alive")
-	h.Set("X-Accel-Buffering", "no")
-	h.Set(eventAfterHeader, strconv.FormatInt(after, 10))
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	w.Header().Set(eventAfterHeader, strconv.FormatInt(after, 10))
+	sw, err := sse.Upgrade(w, r, sse.WithWriteTimeout(eventsWriteTimeout))
+	if err != nil {
+		return
+	}
 
 	sentSeq := after
-	if err := c.replay(ctx, w, flusher, &sentSeq); err != nil {
+	if err := c.replay(ctx, sw, &sentSeq); err != nil {
 		return
 	}
 
@@ -124,21 +116,20 @@ func (c *EventsController) stream(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-heartbeat.C:
-			if _, err := io.WriteString(w, ":\n\n"); err != nil {
+			if err := sw.WriteComment(""); err != nil {
 				return
 			}
-			flusher.Flush()
 		case <-ctx.Done():
 			return
 		case e := <-live:
-			if err := writeSSEEvent(w, flusher, e, &sentSeq); err != nil {
+			if err := writeSSEEvent(sw, e, &sentSeq); err != nil {
 				return
 			}
 		}
 	}
 }
 
-func (c *EventsController) replay(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, sentSeq *int64) error {
+func (c *EventsController) replay(ctx context.Context, sw *sse.Writer, sentSeq *int64) error {
 	for {
 		events, err := c.Source.EventsAfter(ctx, *sentSeq, eventsReplayBatch)
 		if err != nil {
@@ -148,7 +139,7 @@ func (c *EventsController) replay(ctx context.Context, w http.ResponseWriter, fl
 			return nil
 		}
 		for _, e := range events {
-			if err := writeSSEEvent(w, flusher, e, sentSeq); err != nil {
+			if err := writeSSEEvent(sw, e, sentSeq); err != nil {
 				return err
 			}
 		}
@@ -173,22 +164,18 @@ func parseEventsAfter(r *http.Request) (int64, error) {
 	return seq, nil
 }
 
-func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, e cdc.Event, sentSeq *int64) error {
+func writeSSEEvent(sw *sse.Writer, e cdc.Event, sentSeq *int64) error {
 	if e.Seq <= *sentSeq {
 		return nil
 	}
-	data, err := json.Marshal(e)
-	if err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", e.Seq, sseEventName(e.Type), data); err != nil {
+	if err := sw.WriteJSON(strconv.FormatInt(e.Seq, 10), sseEventName(e.Type), e); err != nil {
 		return err
 	}
 	*sentSeq = e.Seq
-	flusher.Flush()
 	return nil
 }
 
 func sseEventName(t cdc.EventType) string {
 	return strings.NewReplacer("\r", "_", "\n", "_").Replace(string(t))
 }
+

--- a/backend/internal/httpd/events.go
+++ b/backend/internal/httpd/events.go
@@ -178,4 +178,3 @@ func writeSSEEvent(sw *sse.Writer, e cdc.Event, sentSeq *int64) error {
 func sseEventName(t cdc.EventType) string {
 	return strings.NewReplacer("\r", "_", "\n", "_").Replace(string(t))
 }
-

--- a/backend/internal/httpd/events_test.go
+++ b/backend/internal/httpd/events_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/sse"
 )
 
 type fakeEventSource struct {
@@ -216,11 +217,16 @@ func TestEventsStreamClampsCursorAheadOfCurrentDatabaseToHead(t *testing.T) {
 
 func TestWriteSSEEventSanitizesEventNameNewlines(t *testing.T) {
 	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	sw, err := sse.Upgrade(rec, req)
+	if err != nil {
+		t.Fatalf("sse.Upgrade: %v", err)
+	}
 	sentSeq := int64(0)
 	e := testCDCEvent(1)
 	e.Type = cdc.EventType("session_updated\nid: 999\rdata: injected")
 
-	if err := writeSSEEvent(rec, rec, e, &sentSeq); err != nil {
+	if err := writeSSEEvent(sw, e, &sentSeq); err != nil {
 		t.Fatalf("writeSSEEvent: %v", err)
 	}
 
@@ -447,3 +453,111 @@ func TestEventsStreamHeartbeatsWhileIdle(t *testing.T) {
 	}
 	t.Fatalf("idle stream sent no comment frame in 4s (got %q); a buffering proxy has nothing to flush an event through", seen)
 }
+
+type timeoutOnEventWriter struct {
+	*httptest.ResponseRecorder
+	mu       sync.Mutex
+	deadline time.Time
+}
+
+func (w *timeoutOnEventWriter) SetWriteDeadline(t time.Time) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.deadline = t
+	return nil
+}
+
+func (w *timeoutOnEventWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	d := w.deadline
+	w.mu.Unlock()
+	if strings.Contains(string(p), "event:") {
+		if !d.IsZero() && time.Now().Before(d) {
+			time.Sleep(time.Until(d) + 5*time.Millisecond)
+		}
+		return 0, context.DeadlineExceeded
+	}
+	return w.ResponseRecorder.Write(p)
+}
+
+func TestEventsStream_BlockedWriterExitsAndUnsubscribesThroughMiddleware(t *testing.T) {
+	restore := eventsWriteTimeout
+	eventsWriteTimeout = 50 * time.Millisecond
+	defer func() { eventsWriteTimeout = restore }()
+
+	live := &fakeEventSubscriber{}
+	src := &fakeEventSource{live: live}
+	router := NewRouterWithControl(config.Config{}, discardLogger(), nil, APIDeps{
+		CDC:    src,
+		Events: live,
+	}, ControlDeps{})
+
+	tw := &timeoutOnEventWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events?after=10", nil)
+
+	handlerDone := make(chan struct{})
+	go func() {
+		router.ServeHTTP(tw, req)
+		close(handlerDone)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for !live.hasSubscriber() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !live.hasSubscriber() {
+		t.Fatal("subscriber was not installed")
+	}
+
+	live.publish(testCDCEvent(11))
+
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit within bounded write deadline")
+	}
+
+	if live.hasSubscriber() {
+		t.Fatal("live subscriber was retained after handler exit; expected unsubscribe")
+	}
+}
+
+func TestEventsStream_ContextCancellationUnsubscribes(t *testing.T) {
+	live := &fakeEventSubscriber{}
+	src := &fakeEventSource{live: live}
+	router := NewRouterWithControl(config.Config{}, discardLogger(), nil, APIDeps{
+		CDC:    src,
+		Events: live,
+	}, ControlDeps{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events?after=10", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handlerDone := make(chan struct{})
+	go func() {
+		router.ServeHTTP(rec, req)
+		close(handlerDone)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for !live.hasSubscriber() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !live.hasSubscriber() {
+		t.Fatal("subscriber was not installed")
+	}
+
+	cancel()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not exit after context cancellation")
+	}
+
+	if live.hasSubscriber() {
+		t.Fatal("live subscriber was retained after context cancellation; expected unsubscribe")
+	}
+}
+

--- a/backend/internal/httpd/events_test.go
+++ b/backend/internal/httpd/events_test.go
@@ -560,4 +560,3 @@ func TestEventsStream_ContextCancellationUnsubscribes(t *testing.T) {
 		t.Fatal("live subscriber was retained after context cancellation; expected unsubscribe")
 	}
 }
-

--- a/backend/internal/httpd/sse/writer.go
+++ b/backend/internal/httpd/sse/writer.go
@@ -1,0 +1,192 @@
+package sse
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+)
+
+const (
+	// DefaultWriteTimeout is the rolling per-write deadline for SSE frame writes.
+	DefaultWriteTimeout = 5 * time.Second
+
+	// DefaultHeartbeatInterval is the default idle heartbeat interval.
+	DefaultHeartbeatInterval = 15 * time.Second
+)
+
+// ErrUnsupported is returned when the ResponseWriter does not support flushing.
+var ErrUnsupported = errors.New("sse: streaming unsupported by server")
+
+// Event represents an individual Server-Sent Event frame.
+type Event struct {
+	ID    string
+	Event string
+	Data  []byte
+}
+
+// Option configures the SSE Writer.
+type Option func(*Writer)
+
+// WithWriteTimeout sets the rolling write timeout for SSE frame delivery.
+func WithWriteTimeout(d time.Duration) Option {
+	return func(w *Writer) {
+		w.writeTimeout = d
+	}
+}
+
+// WithHeader adds a response header prior to writing HTTP 200 OK.
+func WithHeader(key, val string) Option {
+	return func(w *Writer) {
+		w.w.Header().Set(key, val)
+	}
+}
+
+// Writer provides structured framing, checked flushing, and rolling write
+// deadlines for Server-Sent Events streams.
+type Writer struct {
+	w            http.ResponseWriter
+	rc           *http.ResponseController
+	writeTimeout time.Duration
+}
+
+// Upgrade verifies flusher support, sets common SSE response headers,
+// writes HTTP 200 OK, and flushes the initial frame.
+// If streaming is unsupported, an SSE_UNSUPPORTED API error is written to w
+// and ErrUnsupported is returned.
+func Upgrade(w http.ResponseWriter, r *http.Request, opts ...Option) (*Writer, error) {
+	rc := http.NewResponseController(w)
+
+	// Check if flushing is supported directly or via ResponseController unwrap.
+	if _, ok := w.(http.Flusher); !ok {
+		if err := rc.Flush(); errors.Is(err, http.ErrNotSupported) {
+			envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "SSE_UNSUPPORTED",
+				"Streaming is not supported by this server", nil)
+			return nil, ErrUnsupported
+		}
+	}
+
+	sw := &Writer{
+		w:            w,
+		rc:           rc,
+		writeTimeout: DefaultWriteTimeout,
+	}
+	for _, opt := range opts {
+		opt(sw)
+	}
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream; charset=utf-8")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+
+	w.WriteHeader(http.StatusOK)
+
+	// Flush initial headers bounded by write deadline.
+	if err := sw.Flush(); err != nil {
+		return nil, err
+	}
+
+	return sw, nil
+}
+
+// SetWriteTimeout updates the rolling write deadline duration.
+func (w *Writer) SetWriteTimeout(d time.Duration) {
+	w.writeTimeout = d
+}
+
+// Header returns the response header map.
+func (w *Writer) Header() http.Header {
+	return w.w.Header()
+}
+
+// ResponseWriter returns the underlying http.ResponseWriter.
+func (w *Writer) ResponseWriter() http.ResponseWriter {
+	return w.w
+}
+
+// WriteEvent writes an SSE event frame with checked flushing and a rolling write deadline.
+func (w *Writer) WriteEvent(e Event) error {
+	var buf bytes.Buffer
+	if e.ID != "" {
+		buf.WriteString("id: ")
+		buf.WriteString(e.ID)
+		buf.WriteByte('\n')
+	}
+	if e.Event != "" {
+		buf.WriteString("event: ")
+		buf.WriteString(e.Event)
+		buf.WriteByte('\n')
+	}
+	if len(e.Data) > 0 {
+		lines := bytes.Split(e.Data, []byte("\n"))
+		for _, line := range lines {
+			buf.WriteString("data: ")
+			buf.Write(line)
+			buf.WriteByte('\n')
+		}
+	} else {
+		buf.WriteString("data:\n")
+	}
+	buf.WriteByte('\n')
+
+	return w.writeFrame(buf.Bytes())
+}
+
+// WriteJSON marshals v as JSON and writes it as an SSE event frame.
+func (w *Writer) WriteJSON(id, event string, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return w.WriteEvent(Event{
+		ID:    id,
+		Event: event,
+		Data:  data,
+	})
+}
+
+// WriteComment writes an SSE comment frame (e.g. ": keepalive\n\n" or ":\n\n").
+// Comment frames are no-op frames that pace idle connections and flush buffering proxies.
+func (w *Writer) WriteComment(comment string) error {
+	var buf bytes.Buffer
+	buf.WriteString(":")
+	if comment != "" {
+		buf.WriteString(" ")
+		buf.WriteString(comment)
+	}
+	buf.WriteString("\n\n")
+
+	return w.writeFrame(buf.Bytes())
+}
+
+// Flush flushes pending buffered data with a rolling write deadline.
+func (w *Writer) Flush() error {
+	return w.writeFrame(nil)
+}
+
+func (w *Writer) writeFrame(data []byte) error {
+	if w.writeTimeout > 0 {
+		if err := w.rc.SetWriteDeadline(time.Now().Add(w.writeTimeout)); err != nil && !errors.Is(err, http.ErrNotSupported) {
+			return err
+		}
+		defer func() {
+			_ = w.rc.SetWriteDeadline(time.Time{})
+		}()
+	}
+
+	if len(data) > 0 {
+		if _, err := w.w.Write(data); err != nil {
+			return err
+		}
+	}
+
+	if err := w.rc.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/httpd/sse/writer_test.go
+++ b/backend/internal/httpd/sse/writer_test.go
@@ -1,0 +1,258 @@
+package sse_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/sse"
+)
+
+type nonFlusherResponseWriter struct {
+	header http.Header
+}
+
+func (n *nonFlusherResponseWriter) Header() http.Header {
+	if n.header == nil {
+		n.header = make(http.Header)
+	}
+	return n.header
+}
+func (n *nonFlusherResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (n *nonFlusherResponseWriter) WriteHeader(statusCode int)   {}
+
+func TestUpgrade_Success(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(rec, req,
+		sse.WithHeader("X-Custom", "custom-val"),
+		sse.WithWriteTimeout(100*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sw == nil {
+		t.Fatal("expected non-nil writer")
+	}
+
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/event-stream; charset=utf-8", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", got)
+	}
+	if got := rec.Header().Get("Connection"); got != "keep-alive" {
+		t.Errorf("Connection = %q, want keep-alive", got)
+	}
+	if got := rec.Header().Get("X-Accel-Buffering"); got != "no" {
+		t.Errorf("X-Accel-Buffering = %q, want no", got)
+	}
+	if got := rec.Header().Get("X-Custom"); got != "custom-val" {
+		t.Errorf("X-Custom = %q, want custom-val", got)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if !rec.Flushed {
+		t.Error("expected initial flush")
+	}
+}
+
+func TestUpgrade_UnsupportedFlusher(t *testing.T) {
+	w := &nonFlusherResponseWriter{}
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(w, req)
+	if err != sse.ErrUnsupported {
+		t.Fatalf("expected ErrUnsupported, got %v", err)
+	}
+	if sw != nil {
+		t.Fatal("expected nil writer on failure")
+	}
+}
+
+func TestWriter_WriteEvent(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(rec, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Body.Reset()
+
+	err = sw.WriteEvent(sse.Event{
+		ID:    "42",
+		Event: "test_event",
+		Data:  []byte("hello world"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "id: 42\nevent: test_event\ndata: hello world\n\n"
+	if got := rec.Body.String(); got != want {
+		t.Fatalf("WriteEvent got %q, want %q", got, want)
+	}
+}
+
+func TestWriter_WriteEventMultiline(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(rec, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Body.Reset()
+
+	err = sw.WriteEvent(sse.Event{
+		Event: "multiline",
+		Data:  []byte("line1\nline2"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "event: multiline\ndata: line1\ndata: line2\n\n"
+	if got := rec.Body.String(); got != want {
+		t.Fatalf("WriteEvent got %q, want %q", got, want)
+	}
+}
+
+func TestWriter_WriteJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(rec, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Body.Reset()
+
+	payload := struct {
+		Message string `json:"message"`
+	}{Message: "success"}
+
+	if err := sw.WriteJSON("10", "notification", payload); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := json.Marshal(payload)
+	want := "id: 10\nevent: notification\ndata: " + string(data) + "\n\n"
+	if got := rec.Body.String(); got != want {
+		t.Fatalf("WriteJSON got %q, want %q", got, want)
+	}
+}
+
+func TestWriter_WriteComment(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(rec, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Body.Reset()
+
+	if err := sw.WriteComment(""); err != nil {
+		t.Fatal(err)
+	}
+	if got := rec.Body.String(); got != ":\n\n" {
+		t.Fatalf("empty comment got %q, want %q", got, ":\n\n")
+	}
+
+	rec.Body.Reset()
+	if err := sw.WriteComment("keepalive"); err != nil {
+		t.Fatal(err)
+	}
+	if got := rec.Body.String(); got != ": keepalive\n\n" {
+		t.Fatalf("named comment got %q, want %q", got, ": keepalive\n\n")
+	}
+}
+
+func TestWriter_UnwrapsThroughMiddleware(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ww := middleware.NewWrapResponseWriter(rec, 1)
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(ww, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Body.Reset()
+
+	if err := sw.WriteComment("heartbeat"); err != nil {
+		t.Fatal(err)
+	}
+	if got := rec.Body.String(); !strings.Contains(got, ": heartbeat") {
+		t.Fatalf("expected comment frame through wrap writer, got %q", got)
+	}
+}
+
+type deadlineRecordingWriter struct {
+	*httptest.ResponseRecorder
+	mu        sync.Mutex
+	deadlines []time.Time
+}
+
+func (d *deadlineRecordingWriter) SetWriteDeadline(t time.Time) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.deadlines = append(d.deadlines, t)
+	return nil
+}
+
+func (d *deadlineRecordingWriter) getDeadlines() []time.Time {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	cp := make([]time.Time, len(d.deadlines))
+	copy(cp, d.deadlines)
+	return cp
+}
+
+func TestWriter_RollingWriteDeadlineAppliedAndReset(t *testing.T) {
+	dw := &deadlineRecordingWriter{ResponseRecorder: httptest.NewRecorder()}
+	ww := middleware.NewWrapResponseWriter(dw, 1)
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	sw, err := sse.Upgrade(ww, req, sse.WithWriteTimeout(500*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initial Upgrade flushes, which sets a deadline then resets it to zero.
+	deadlines := dw.getDeadlines()
+	if len(deadlines) < 2 {
+		t.Fatalf("expected at least 2 deadline calls from initial Upgrade flush, got %d", len(deadlines))
+	}
+	if deadlines[0].IsZero() {
+		t.Error("expected first deadline to be non-zero (timeout)")
+	}
+	if !deadlines[1].IsZero() {
+		t.Error("expected second deadline to be reset to zero time")
+	}
+
+	// Next write sets deadline and resets to zero again.
+	dw.deadlines = nil
+	if err := sw.WriteComment(""); err != nil {
+		t.Fatal(err)
+	}
+	deadlines = dw.getDeadlines()
+	if len(deadlines) != 2 {
+		t.Fatalf("expected 2 deadline calls, got %d", len(deadlines))
+	}
+	if deadlines[0].IsZero() {
+		t.Error("expected rolling deadline before write")
+	}
+	if !deadlines[1].IsZero() {
+		t.Error("expected deadline cleared after write")
+	}
+}

--- a/backend/internal/httpd/sse/writer_test.go
+++ b/backend/internal/httpd/sse/writer_test.go
@@ -2,6 +2,7 @@ package sse_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,7 +26,7 @@ func (n *nonFlusherResponseWriter) Header() http.Header {
 	return n.header
 }
 func (n *nonFlusherResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
-func (n *nonFlusherResponseWriter) WriteHeader(statusCode int)   {}
+func (n *nonFlusherResponseWriter) WriteHeader(statusCode int)  {}
 
 func TestUpgrade_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
@@ -70,7 +71,7 @@ func TestUpgrade_UnsupportedFlusher(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/events", nil)
 
 	sw, err := sse.Upgrade(w, req)
-	if err != sse.ErrUnsupported {
+	if !errors.Is(err, sse.ErrUnsupported) {
 		t.Fatalf("expected ErrUnsupported, got %v", err)
 	}
 	if sw != nil {


### PR DESCRIPTION
## Summary
Extracted a shared SSE transport package (`internal/httpd/sse`) and migrated all 4 server-sent events streaming surfaces in the daemon (CDC events, notifications, workspace changes, and Codex accounts). Standardized header handling, flusher capability validation, framing, and rolling write deadlines across all streams while keeping replay state, sequence cursors, and subscriber ownership resource-specific. Added idle heartbeat pacing to the notifications stream.

## Why We Did It
- **Duplicated Transport Logic**: CDC, notification, workspace, and Codex account streams each repeated header setup, `http.Flusher` assertions, and frame writes independently.
- **Unbounded Slow-Client Writes**: The daemon HTTP servers configure only `ReadHeaderTimeout: 10 * time.Second` and bypass the REST request timeout for long-lived streams. Neither endpoint configured write deadlines. When a client slowed down, stopped reading, or stalled without closing the TCP connection, `w.Write(...)` and `Flush()` blocked indefinitely. Because handler goroutines were stuck in `Write`, they could never reach `select { case <-ctx.Done(): ... }` or return, retaining live subscriptions (`defer unsubscribe()`) and buffering events in memory.
- **Divergent & Missing Heartbeats**: Heartbeats diverged across endpoints (CDC used 10s, workspace used 15s, Codex used 25s), while notifications had no idle heartbeat at all, leaving idle notification streams susceptible to buffering or silent disconnections by intermediaries/proxies.

## Relevant Files & Changes
- `backend/internal/httpd/sse/writer.go`:
  - Implemented `sse.Upgrade(w, r, opts...)` to validate `http.Flusher` support (answering standard `SSE_UNSUPPORTED` envelope on failure), set standard headers (`text/event-stream`, `no-cache`, `keep-alive`, `X-Accel-Buffering: no`), write HTTP 200, and flush initial headers.
  - Implemented `sse.Writer` providing structured framing (`WriteEvent`, `WriteJSON`, `WriteComment`, `Flush`).
  - Configured rolling write deadlines via `http.ResponseController.SetWriteDeadline` before each write/flush and cleared them immediately after completion so idle connections are never erroneously closed between events. Unwraps through middleware wrappers (`chi.middleware.WrapResponseWriter`) and handles `http.ErrNotSupported` cleanly in unit test mocks.
- `backend/internal/httpd/sse/writer_test.go`:
  - Added unit tests for headers, unsupported flusher rejection, event formatting (single and multi-line), JSON serialization, comment frames, middleware unwrapping, and write deadline application and reset.
- `backend/internal/httpd/events.go`:
  - Migrated `EventsController.stream` to `sse.Upgrade` and `sse.Writer`.
  - Retained resource-owned replay cursors, sequence tracking, and live subscription drain. Ensured subscription is active prior to header flush to avoid live event publish race conditions.
  - Bounded stalled writes with write deadline to guarantee prompt handler exit and unsubscription.
- `backend/internal/httpd/events_test.go`:
  - Added `TestEventsStream_BlockedWriterExitsAndUnsubscribesThroughMiddleware` and `TestEventsStream_ContextCancellationUnsubscribes`.
  - Maintained all existing replay, deduplication, and idle heartbeat tests.
- `backend/internal/httpd/controllers/notifications.go`:
  - Migrated `NotificationsController.stream` to `sse.Upgrade` and `sse.Writer`.
  - Added idle heartbeat ticker (`NotificationsHeartbeatInterval = 15 * time.Second`) emitting `: \n\n` comment frames.
- `backend/internal/httpd/controllers/notifications_test.go`:
  - Added `TestNotificationsAPI_StreamHeartbeatsWhileIdle`, `TestNotificationsAPI_StreamBlockedClientExitsAndUnsubscribes`, and `TestNotificationsAPI_StreamContextCancellationUnsubscribes`.
- `backend/internal/httpd/controllers/sessions.go`:
  - Migrated `SessionsController.streamWorkspaceChanges` to `sse.Upgrade` and `sse.Writer` with keepalive comment frames.
- `backend/internal/httpd/controllers/sessions_test.go`:
  - Added `TestSessionsAPI_StreamWorkspaceChanges_HeartbeatsWhileIdle` and `TestSessionsAPI_StreamWorkspaceChanges_BlockedClientExits`.
- `backend/internal/httpd/controllers/codex_accounts.go`:
  - Migrated `CodexAccountsController.events` to `sse.Upgrade` and `sse.Writer` with heartbeat comment frames.
- `backend/internal/httpd/controllers/codex_accounts_test.go`:
  - Added `TestCodexAccountEventStream_HeartbeatsWhileIdle` and `TestCodexAccountEventStream_BlockedClientExits`.

## Tests Ran
- [x] `go test -v -count=1 ./internal/httpd/sse/...` (all 8 shared SSE transport tests pass)
- [x] `go test -v -count=1 ./internal/httpd/...` (CDC events stream, server lifecycle, router, LAN listener pass)
- [x] `go test -v -count=1 ./internal/cdc/...` (CDC store write, broadcast, and poller tests pass)
- [x] `go test -v -count=1 ./internal/httpd/controllers -run "Test.*Stream"` (all 14 stream tests pass: CDC, Notifications, Workspace, and Codex)
- [x] `go test -v -count=1 ./internal/httpd/apispec/...` (OpenAPI spec drift and route parity pass)
- [x] `go build ./...` (clean repository build across all packages)
- [x] `go vet ./internal/httpd/... ./internal/cdc/...` (zero vet warnings/errors)

## Relevant issues
#4476 
#4414
#4578
#4667
#5151 

Note: this is the part of refactorization and fixes/cleanups that me and ayash is working on (API-006)