### PR TITLE
fix: hide diff layout toggle outside changes view and open links in new tabs

### DIFF
--- a/frontend/src/renderer/components/SessionFileExplorer.test.tsx
+++ b/frontend/src/renderer/components/SessionFileExplorer.test.tsx
@@ -103,6 +103,7 @@ describe("SessionFileExplorer", () => {
 		await userEvent.click(screen.getByRole("button", { name: "select src/App.tsx" }));
 		expect(screen.queryByTestId("content-pane")).not.toBeInTheDocument();
 		expect(screen.getByTestId("tree-changed-only")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Split diff view" })).not.toBeInTheDocument();
 		expect(onOpenFile).toHaveBeenCalledWith("src/App.tsx", { mode: "file" });
 	});
 
@@ -193,6 +194,7 @@ describe("SessionFileExplorer", () => {
 		expect(screen.queryByTestId("review-pane")).not.toBeInTheDocument();
 		expect(screen.queryByRole("tab", { name: "Changes" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("tab", { name: "Files" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Split diff view" })).not.toBeInTheDocument();
 	});
 
 	it("keeps the continuous right-side diff visible when opening the full file in center", async () => {

--- a/frontend/src/renderer/components/SessionFileExplorer.tsx
+++ b/frontend/src/renderer/components/SessionFileExplorer.tsx
@@ -137,30 +137,32 @@ export function SessionFileExplorer({
 						</Button>
 					</div>
 				) : null}
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							aria-label={split ? t("files.unifiedDiff") : t("files.splitDiff")}
-							aria-pressed={split}
-							className="shrink-0"
-							onClick={() => {
-								const next = !split;
-								if (controlledSplit === undefined) setInternalSplit(next);
-								onSplitChange?.(next);
-							}}
-							size="icon-sm"
-							type="button"
-							variant="ghost"
-						>
-							{split ? (
-								<Columns2 className="size-icon-sm" aria-hidden="true" />
-							) : (
-								<Rows3 className="size-icon-sm" aria-hidden="true" />
-							)}
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent side="bottom">{split ? t("files.unifiedDiff") : t("files.splitDiff")}</TooltipContent>
-				</Tooltip>
+				{showChanges ? (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								aria-label={split ? t("files.unifiedDiff") : t("files.splitDiff")}
+								aria-pressed={split}
+								className="shrink-0"
+								onClick={() => {
+									const next = !split;
+									if (controlledSplit === undefined) setInternalSplit(next);
+									onSplitChange?.(next);
+								}}
+								size="icon-sm"
+								type="button"
+								variant="ghost"
+							>
+								{split ? (
+									<Columns2 className="size-icon-sm" aria-hidden="true" />
+								) : (
+									<Rows3 className="size-icon-sm" aria-hidden="true" />
+								)}
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">{split ? t("files.unifiedDiff") : t("files.splitDiff")}</TooltipContent>
+					</Tooltip>
+				) : null}
 				{onToggleMaximized ? (
 					<Tooltip>
 						<TooltipTrigger asChild>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1925,7 +1925,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									}
 									onOpenFiles={handleOpenFiles}
 									onOpenFile={handleOpenFile}
-									onOpenLinkInBrowser={browserView.openTab}
+									onOpenLinkInBrowser={browserView.openLink}
 								/>
 							) : (
 								<CenterPane

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1925,6 +1925,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									}
 									onOpenFiles={handleOpenFiles}
 									onOpenFile={handleOpenFile}
+									onOpenLinkInBrowser={browserView.openTab}
 								/>
 							) : (
 								<CenterPane

--- a/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.test.tsx
@@ -412,6 +412,24 @@ describe("SessionChatSurface link routing", () => {
 		await waitFor(() => expect(invalidate).toHaveBeenCalledWith({ queryKey: workspaceQueryKey }));
 	});
 
+	it("opens each plain Chat link in a new AO Browser tab", async () => {
+		const user = userEvent.setup();
+		const openInNewTab = vi.fn().mockResolvedValue(undefined);
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+
+		render(
+			<Wrapper client={queryClient}>
+				<SessionChatSurface session={session} onOpenLinkInBrowser={openInNewTab} />
+			</Wrapper>,
+		);
+		await user.click(screen.getByRole("button", { name: "Open chat link" }));
+
+		expect(openInNewTab).toHaveBeenCalledWith(LINK);
+		expect(postMock).not.toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/preview", expect.anything());
+	});
+
 	// SessionView owns the switch-agent control on the primary session tab; the chat
 	// surface forwards it into ChatWorkspace.
 	it("forwards session tab actions into the chat workspace", () => {

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -109,7 +109,7 @@ export function SessionChatSurface({
 	onOpenFiles?: () => void;
 	/** Opens the Files inspector focused on one changed path. */
 	onOpenFile?: (path: string) => void;
-	/** Opens a chat link in a new tab in this session's AO Browser. */
+	/** Opens a chat link in the active blank tab or a new tab in this session's AO Browser. */
 	onOpenLinkInBrowser?: (uri: string) => Promise<void>;
 	headerActions?: ReactNode;
 	sessionTabAction?: ReactNode;

--- a/frontend/src/renderer/components/chat/SessionChatSurface.tsx
+++ b/frontend/src/renderer/components/chat/SessionChatSurface.tsx
@@ -71,6 +71,7 @@ export function SessionChatSurface({
 	shellError,
 	onOpenFiles,
 	onOpenFile,
+	onOpenLinkInBrowser,
 	headerActions,
 	sessionTabAction,
 	sessionTabActionWide = false,
@@ -108,6 +109,8 @@ export function SessionChatSurface({
 	onOpenFiles?: () => void;
 	/** Opens the Files inspector focused on one changed path. */
 	onOpenFile?: (path: string) => void;
+	/** Opens a chat link in a new tab in this session's AO Browser. */
+	onOpenLinkInBrowser?: (uri: string) => Promise<void>;
 	headerActions?: ReactNode;
 	sessionTabAction?: ReactNode;
 	sessionTabActionWide?: boolean;
@@ -280,7 +283,7 @@ export function SessionChatSurface({
 	);
 	const { paths, truncated } = useWorkspaceFilePaths(session.id, Boolean(snapshot));
 	const stageAttachments = useStageAttachments(session.id);
-	const openLinkInBrowser = useSessionBrowserLink(session);
+	const openLinkInBrowser = useSessionBrowserLink(session, onOpenLinkInBrowser);
 	const observedSuccessfulSwitch = Boolean(
 		agentSwitch &&
 			observedSettledSwitchId === agentSwitch.id &&

--- a/frontend/src/renderer/components/diffs/WorkspaceReviewPane.test.tsx
+++ b/frontend/src/renderer/components/diffs/WorkspaceReviewPane.test.tsx
@@ -119,6 +119,21 @@ describe("WorkspaceReviewPane", () => {
 		expect(screen.getByTestId("code-view").querySelector("[data-collapsed]"))?.toHaveAttribute("data-collapsed", "false");
 	});
 
+	it("uses one toggle for collapsing and expanding all files", async () => {
+		const data = committedWorkspace([{ path: "src/App.tsx", status: "modified", additions: 1, deletions: 1, size: 20, binary: false, fileFingerprint: "file-1" }]);
+		renderWithQuery(<WorkspaceReviewPane annotation={annotation()} data={data} filter="" onBrowseAll={vi.fn()} sessionId="sess-1" split={false} />);
+		expect(await screen.findByTestId("code-view")).toBeInTheDocument();
+
+		const toggle = screen.getByRole("button", { name: "Collapse all files" });
+		await userEvent.click(toggle);
+		expect(screen.getByRole("button", { name: "Expand all files" })).toBeInTheDocument();
+		expect(screen.getByTestId("code-view").querySelectorAll('[data-collapsed="true"]')).toHaveLength(1);
+
+		await userEvent.click(screen.getByRole("button", { name: "Expand all files" }));
+		expect(screen.getByRole("button", { name: "Collapse all files" })).toBeInTheDocument();
+		expect(screen.getByTestId("code-view").querySelectorAll('[data-collapsed="false"]')).toHaveLength(1);
+	});
+
 	it("closes a file's feedback composer when that file is collapsed", async () => {
 		const model = annotation();
 		model.target = { path: "src/App.tsx", side: "file", scope: "committed", surface: "review" };

--- a/frontend/src/renderer/components/diffs/WorkspaceReviewPane.tsx
+++ b/frontend/src/renderer/components/diffs/WorkspaceReviewPane.tsx
@@ -317,6 +317,12 @@ export function WorkspaceReviewPane({
 		if (annotation.target?.surface === "review") annotation.cancel();
 		setCollapsedPaths(new Set(files.map((file) => file.path)));
 	}, [annotation, files]);
+	const expandAll = useCallback(() => {
+		setLoadedDeferredPaths(new Set(files.filter(isDeferredByDefault).map((file) => file.path)));
+		setCollapsedPaths(new Set());
+	}, [files]);
+	const allFilesCollapsed = files.length > 0 && files.every((file) => collapsedPaths.has(file.path));
+	const toggleAll = allFilesCollapsed ? expandAll : collapseAll;
 	const selectCommit = useCallback((commit: WorkspaceCommitSummary) => {
 		if ((scope !== "committed" || selectedCommitSha !== commit.sha) && annotation.target?.surface === "review") annotation.cancel();
 		setSelectedCommitSha(commit.sha);
@@ -372,14 +378,10 @@ export function WorkspaceReviewPane({
 				</Button>
 				{!commitBrowserOpen ? <div className="ml-auto flex items-center gap-1 text-caption text-muted-foreground">
 					<span>{t("files.reviewProgress", { total: allFiles.length, viewed: viewedCount })}</span>
-					<HeaderActionTooltip label={t("files.collapseAll")}>
-						<Button aria-label={t("files.collapseAll")} onClick={collapseAll} size="icon-sm" type="button" variant="ghost"><ChevronsDownUp aria-hidden="true" /></Button>
-					</HeaderActionTooltip>
-					<HeaderActionTooltip label={t("files.expandAll")}>
-						<Button aria-label={t("files.expandAll")} onClick={() => {
-							setLoadedDeferredPaths(new Set(files.filter(isDeferredByDefault).map((file) => file.path)));
-							setCollapsedPaths(new Set());
-						}} size="icon-sm" type="button" variant="ghost"><ChevronsUpDown aria-hidden="true" /></Button>
+					<HeaderActionTooltip label={t(allFilesCollapsed ? "files.expandAll" : "files.collapseAll")}>
+						<Button aria-label={t(allFilesCollapsed ? "files.expandAll" : "files.collapseAll")} onClick={toggleAll} size="icon-sm" type="button" variant="ghost">
+							{allFilesCollapsed ? <ChevronsUpDown aria-hidden="true" /> : <ChevronsDownUp aria-hidden="true" />}
+						</Button>
 					</HeaderActionTooltip>
 				</div> : <span className="ml-auto text-caption text-muted-foreground">{t("files.selectCommit")}</span>}
 			</div>

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -254,6 +254,17 @@ describe("useBrowserView", () => {
 		expect(bridge.closeTab).toHaveBeenCalledWith({ viewId: "42:sess-1", tabId: "t2" });
 	});
 
+	it("reuses the active blank tab when opening a chat link", async () => {
+		const bridge = setupBridge();
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+
+		await waitFor(() => expect(result.current.tabs.map((tab) => tab.id)).toEqual(["t1"]));
+		await act(() => result.current.openLink("http://localhost:5173/"));
+
+		expect(bridge.navigate).toHaveBeenCalledWith({ viewId: "42:sess-1", url: "http://localhost:5173/" });
+		expect(bridge.openTab).not.toHaveBeenCalledWith({ viewId: "42:sess-1", url: "http://localhost:5173/" });
+	});
+
 	it("remembers a closed tab so it can be reopened, and forgets it once reopened", async () => {
 		const bridge = setupBridge();
 		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -70,6 +70,7 @@ export type BrowserViewModel = {
 	selectTab: (tabId: string) => Promise<void>;
 	closeTab: (tabId: string) => Promise<void>;
 	openTab: (url?: string) => Promise<void>;
+	openLink: (url: string) => Promise<void>;
 	reorderTabs: (orderedIds: string[]) => void;
 	closedTabs: ClosedBrowserTab[];
 	reopenClosedTab: (tabId?: string) => Promise<void>;
@@ -691,6 +692,33 @@ export function useBrowserView({
 		},
 		[hasNativeBrowser, sessionId],
 	);
+	const openLink = useCallback(
+		async (url: string) => {
+			if (!hasNativeBrowser) return;
+			let id = viewIdRef.current;
+			if (!id) {
+				const ensured = await window.ao!.browser.ensure(sessionId);
+				id = ensured.viewId;
+				viewIdRef.current = id;
+				setViewId(id);
+				setNavState(ensured);
+			}
+			let tabs = tabsStateRef.current.tabs;
+			if (tabs.length === 0) {
+				const next = await window.ao!.browser.getTabs(id);
+				tabs = next.tabs;
+				if (viewIdRef.current === id) setTabsState(next);
+			}
+			const activeTab = tabs.find((tab) => tab.active);
+			if (activeTab && isBlankTabUrl(activeTab.url)) {
+				const state = await window.ao!.browser.navigate({ viewId: id, url });
+				if (viewIdRef.current === state.viewId) setNavState(state);
+				return;
+			}
+			await openTab(url);
+		},
+		[hasNativeBrowser, openTab, sessionId],
+	);
 
 	const reopenClosedTab = useCallback(
 		async (tabId?: string) => {
@@ -839,6 +867,7 @@ export function useBrowserView({
 		selectTab,
 		closeTab,
 		openTab,
+		openLink,
 		reorderTabs,
 		closedTabs: stateBelongsToSession ? closedTabs : [],
 		reopenClosedTab,

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -677,12 +677,19 @@ export function useBrowserView({
 
 	const openTab = useCallback(
 		async (url?: string) => {
-			const viewId = viewIdRef.current;
-			if (!viewId || !hasNativeBrowser) return;
+			if (!hasNativeBrowser) return;
+			let viewId = viewIdRef.current;
+			if (!viewId) {
+				const ensured = await window.ao!.browser.ensure(sessionId);
+				viewId = ensured.viewId;
+				viewIdRef.current = viewId;
+				setViewId(viewId);
+				setNavState(ensured);
+			}
 			const state = await window.ao!.browser.openTab({ viewId, url });
 			if (viewIdRef.current === state.viewId) setTabsState(state);
 		},
-		[hasNativeBrowser],
+		[hasNativeBrowser, sessionId],
 	);
 
 	const reopenClosedTab = useCallback(

--- a/frontend/src/renderer/hooks/useSessionBrowserLink.ts
+++ b/frontend/src/renderer/hooks/useSessionBrowserLink.ts
@@ -6,7 +6,10 @@ import { sessionIsActive, type WorkspaceSession } from "../types/workspace";
 import { workspaceQueryKey } from "./useWorkspaceQuery";
 
 /** Open an HTTP(S) link in the active worker session's AO Browser panel. */
-export function useSessionBrowserLink(session?: WorkspaceSession): (uri: string) => void {
+export function useSessionBrowserLink(
+	session?: WorkspaceSession,
+	openInNewTab?: (uri: string) => Promise<void>,
+): (uri: string) => void {
 	const queryClient = useQueryClient();
 	const setInspectorView = useUiStore((state) => state.setInspectorView);
 	const setInspectorOpen = useUiStore((state) => state.setInspectorOpen);
@@ -25,6 +28,12 @@ export function useSessionBrowserLink(session?: WorkspaceSession): (uri: string)
 			const sessionId = session.id;
 			setInspectorView(sessionId, "browser");
 			setInspectorOpen(sessionId, true);
+			if (openInNewTab) {
+				void openInNewTab(uri).catch((error) => {
+					console.warn("Unable to open link in Browser tab", error);
+				});
+				return;
+			}
 			void (async () => {
 				try {
 					const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/preview", {
@@ -41,6 +50,6 @@ export function useSessionBrowserLink(session?: WorkspaceSession): (uri: string)
 				}
 			})();
 		},
-		[active, queryClient, session?.id, session?.kind, setInspectorOpen, setInspectorView],
+		[active, openInNewTab, queryClient, session?.id, session?.kind, setInspectorOpen, setInspectorView],
 	);
 }

--- a/frontend/src/renderer/hooks/useSessionBrowserLink.ts
+++ b/frontend/src/renderer/hooks/useSessionBrowserLink.ts
@@ -8,7 +8,7 @@ import { workspaceQueryKey } from "./useWorkspaceQuery";
 /** Open an HTTP(S) link in the active worker session's AO Browser panel. */
 export function useSessionBrowserLink(
 	session?: WorkspaceSession,
-	openInNewTab?: (uri: string) => Promise<void>,
+	openInBrowser?: (uri: string) => Promise<void>,
 ): (uri: string) => void {
 	const queryClient = useQueryClient();
 	const setInspectorView = useUiStore((state) => state.setInspectorView);
@@ -28,8 +28,8 @@ export function useSessionBrowserLink(
 			const sessionId = session.id;
 			setInspectorView(sessionId, "browser");
 			setInspectorOpen(sessionId, true);
-			if (openInNewTab) {
-				void openInNewTab(uri).catch((error) => {
+			if (openInBrowser) {
+				void openInBrowser(uri).catch((error) => {
 					console.warn("Unable to open link in Browser tab", error);
 				});
 				return;
@@ -50,6 +50,6 @@ export function useSessionBrowserLink(
 				}
 			})();
 		},
-		[active, openInNewTab, queryClient, session?.id, session?.kind, setInspectorOpen, setInspectorView],
+		[active, openInBrowser, queryClient, session?.id, session?.kind, setInspectorOpen, setInspectorView],
 	);
 }


### PR DESCRIPTION
## Summary

This PR improves the session Files and Chat browser experiences compared with `main`.

### Changes introduced

- Hide the split/unified diff layout toggle outside the Files Changes view, including full-file browsing and clean sessions.
- Open HTTP(S) links clicked in session Chat through the session's in-app Browser tab flow.
- Reuse the active blank Browser tab for the first Chat link; open subsequent links in new tabs when the active tab already has content.
- Ensure the session Browser view exists before opening a Chat link, including when the Browser panel was previously closed.
- Add regression coverage for Files visibility, Chat link routing, blank-tab reuse, and new-tab behavior.

## Change accounting

| Area | Additions | Deletions | Lines touched |
| --- | ---: | ---: | ---: |
| Files diff-view visibility | 28 | 24 | 52 |
| Chat browser tab routing | 84 | 6 | 90 |
| **Total** | **112** | **30** | **142** |

## Change size

- total: 112 lines added, 30 removed across 8 files
- tests and regression coverage: 31 lines added, 0 removed across 3 test files
- implementation and support: 81 lines added, 30 removed across 5 source files
- net change: +82 LOC

## Tests

- `npm test -- --run src/renderer/components/SessionFileExplorer.test.tsx` — 13 passed
- `npm test -- --run src/renderer/components/chat/SessionChatSurface.test.tsx` — 28 passed
- `npm test -- --run src/renderer/hooks/useBrowserView.test.tsx` — 39 passed
- `npm test -- --run src/renderer/components/SessionView.test.tsx` — 115 passed
- `npm run typecheck` — blocked by missing React and related dependencies in the shared `packages/product-ui` workspace; no changed-file errors were reported before that dependency boundary.