### PR TITLE
fix(codex): skip Windows volume root in vault validation

### DIFF
--- a/backend/internal/service/agent/codex_secure_fs_windows.go
+++ b/backend/internal/service/agent/codex_secure_fs_windows.go
@@ -56,6 +56,16 @@ func validateCodexDirectoryAncestors(path string) error {
 		return errors.New("codex directory path is invalid")
 	}
 	for current := abs; ; current = filepath.Dir(current) {
+		// A Windows volume root is administered by the operating system, not by
+		// the user who owns the credential vault.  Standard Windows ACLs commonly
+		// grant Authenticated Users the ability to create entries directly at that
+		// root.  Treating that system-level policy as a vault-ancestor grant makes
+		// every vault on the volume unusable, even when each user-controlled
+		// ancestor has been verified.  Stop before inspecting the volume root;
+		// all intervening, user-controlled ancestors remain checked below.
+		if isCodexWindowsVolumeRoot(current) {
+			return nil
+		}
 		ptr, ptrErr := windows.UTF16PtrFromString(current)
 		if ptrErr != nil {
 			return errors.New("codex directory path is invalid")
@@ -78,10 +88,15 @@ func validateCodexDirectoryAncestors(path string) error {
 		if !codexWindowsPathMetadataIsSafe(codexWindowsMetadata(info, ownerTrusted, aclSafe), true, false) {
 			return errors.New("codex directory ancestor ACL is unsafe")
 		}
-		if parent := filepath.Dir(current); parent == current {
-			return nil
-		}
 	}
+}
+
+func isCodexWindowsVolumeRoot(path string) bool {
+	volume := filepath.VolumeName(path)
+	if volume == "" {
+		return false
+	}
+	return filepath.Clean(path) == filepath.Clean(volume+string(filepath.Separator))
 }
 
 func openCodexWindowsPath(path string, directory, requirePrivate bool) (windows.Handle, windows.ByHandleFileInformation, bool, bool, bool, error) {

--- a/backend/internal/service/agent/codex_windows_security_test.go
+++ b/backend/internal/service/agent/codex_windows_security_test.go
@@ -37,6 +37,22 @@ func TestWindowsAncestorACLPolicyAllowsReadButRejectsMutation(t *testing.T) {
 	}
 }
 
+func TestWindowsVolumeRootDetection(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{path: `C:\`, want: true},
+		{path: `C:\Users`, want: false},
+		{path: `\\server\share\`, want: true},
+		{path: `\\server\share\vault`, want: false},
+	} {
+		if got := isCodexWindowsVolumeRoot(tc.path); got != tc.want {
+			t.Errorf("isCodexWindowsVolumeRoot(%q) = %t, want %t", tc.path, got, tc.want)
+		}
+	}
+}
+
 func TestWindowsNoFollowAndWriteThroughPolicies(t *testing.T) {
 	if got := codexWindowsNoFollowOpenFlags(); got&codexWindowsOpenReparsePoint == 0 || got&codexWindowsBackupSemantics == 0 {
 		t.Fatalf("no-follow open flags = %#x", got)


### PR DESCRIPTION
## Summary
- stop private Codex vault ancestor validation before the Windows filesystem volume root
- retain validation of every user-controlled ancestor and the vault itself
- add regression coverage for drive and UNC share root detection

## Why
On a standard Windows installation, the volume root can grant Authenticated Users permission to create entries directly at the root. AO treated that OS-level ACL as an untrusted mutable vault ancestor, which prevented Codex account bootstrap from creating the managed vault and blocked all Codex task creation with ccount_storage_unsafe.

The volume root is not user-controlled vault storage. Skipping that final system-level check preserves the existing security checks for all intervening user-controlled paths.

## Validation
- go test ./internal/service/agent -run '^TestWindowsVolumeRootDetection$' -count=1
- Live Windows verification: Codex account bootstrap completed and AO launched a no-edit Codex worker in an isolated worktree.