### PR TITLE
fix(chat): authorize edits against current conversation owner

### DIFF
--- a/backend/internal/storage/sqlite/gen/conversations.sql.go
+++ b/backend/internal/storage/sqlite/gen/conversations.sql.go
@@ -366,7 +366,7 @@ WHERE conversation_id = ?1
   AND client_message_id = ?2
   AND state = 'reserved' AND provider_work_started = 0
   AND EXISTS (
-    SELECT 1 FROM conversations c JOIN sessions s ON s.id = c.session_id
+    SELECT 1 FROM conversations c JOIN sessions s ON s.id = c.current_session_id
     WHERE c.id = conversation_edit_deliveries.conversation_id
       AND s.controller_generation = ?3
       AND s.session_mode = 'chat' AND s.is_terminated = 0

--- a/backend/internal/storage/sqlite/queries/conversations.sql
+++ b/backend/internal/storage/sqlite/queries/conversations.sql
@@ -1408,7 +1408,7 @@ WHERE conversation_id = sqlc.arg(conversation_id)
   AND client_message_id = sqlc.arg(client_message_id)
   AND state = 'reserved' AND provider_work_started = 0
   AND EXISTS (
-    SELECT 1 FROM conversations c JOIN sessions s ON s.id = c.session_id
+    SELECT 1 FROM conversations c JOIN sessions s ON s.id = c.current_session_id
     WHERE c.id = conversation_edit_deliveries.conversation_id
       AND s.controller_generation = sqlc.arg(generation)
       AND s.session_mode = 'chat' AND s.is_terminated = 0

--- a/backend/internal/storage/sqlite/store/conversation_branch_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_branch_store_test.go
@@ -499,7 +499,7 @@ func TestBeginEditProviderWorkUsesCurrentConversationOwner(t *testing.T) {
 			s := newTestStore(t)
 			seedProject(t, s, "edit-owner")
 			rec := sampleRecord("edit-owner")
-			rec.Mode = domain.SessionModeChat
+			rec.Mode = tt.mode
 			rec.Metadata.ControllerGeneration = "generation-source"
 			source, err := s.CreateSession(ctx, rec)
 			if err != nil {

--- a/backend/internal/storage/sqlite/store/conversation_branch_store_test.go
+++ b/backend/internal/storage/sqlite/store/conversation_branch_store_test.go
@@ -476,6 +476,78 @@ func TestEditDeliveryReservationHasOneConcurrentWinner(t *testing.T) {
 	}
 }
 
+func TestBeginEditProviderWorkUsesCurrentConversationOwner(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		scope      domain.ConversationScope
+		rebind     bool
+		stale      bool
+		mode       domain.SessionMode
+		terminated bool
+		wantErr    bool
+	}{
+		{name: "worker", scope: domain.ConversationScopeSession, mode: domain.SessionModeChat},
+		{name: "orchestrator", scope: domain.ConversationScopeProject, mode: domain.SessionModeChat},
+		{name: "rebound orchestrator", scope: domain.ConversationScopeProject, rebind: true, mode: domain.SessionModeChat},
+		{name: "previous orchestrator", scope: domain.ConversationScopeProject, rebind: true, stale: true, mode: domain.SessionModeChat, wantErr: true},
+		{name: "stale generation", scope: domain.ConversationScopeSession, stale: true, mode: domain.SessionModeChat, wantErr: true},
+		{name: "terminal owner", scope: domain.ConversationScopeProject, mode: domain.SessionModeTUI, wantErr: true},
+		{name: "terminated owner", scope: domain.ConversationScopeProject, mode: domain.SessionModeChat, terminated: true, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := newTestStore(t)
+			seedProject(t, s, "edit-owner")
+			rec := sampleRecord("edit-owner")
+			rec.Mode = domain.SessionModeChat
+			rec.Metadata.ControllerGeneration = "generation-source"
+			source, err := s.CreateSession(ctx, rec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conversation, err := s.CreateConversation(ctx, "edit-owner-conversation", tt.scope, source.ProjectID, source.ID, testNow)
+			if err != nil {
+				t.Fatal(err)
+			}
+			owner := source
+			if tt.rebind {
+				rec.Metadata.ControllerGeneration = "generation-target"
+				owner, err = s.CreateSession(ctx, rec)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rebound, err := s.CreateConversation(ctx, "unused", tt.scope, owner.ProjectID, owner.ID, testNow.Add(time.Minute))
+				if err != nil || rebound.ID != conversation.ID {
+					t.Fatalf("rebind: conversation=%+v err=%v", rebound, err)
+				}
+			}
+			owner.Mode, owner.IsTerminated = tt.mode, tt.terminated
+			if err := s.UpdateSession(ctx, owner); err != nil {
+				t.Fatal(err)
+			}
+			if _, won, err := s.ReserveEditDelivery(ctx, conversation.ID, "edit-client", "{}", testNow); err != nil || !won {
+				t.Fatalf("reserve: won=%v err=%v", won, err)
+			}
+			generation := owner.Metadata.ControllerGeneration
+			if tt.stale {
+				generation = "stale-generation"
+				if tt.rebind {
+					generation = source.Metadata.ControllerGeneration
+				}
+			}
+			err = s.BeginEditProviderWork(ctx, conversation.ID, "edit-client", generation)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("begin provider work: err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if err := s.BeginEditProviderWork(ctx, conversation.ID, "edit-client", generation); err == nil {
+					t.Fatal("same reservation started provider work twice")
+				}
+			}
+		})
+	}
+}
+
 func TestCompleteEditDeliveryRollsBackBranchMutationWhenResultCannotSettle(t *testing.T) {
 	ctx := context.Background()
 	s, session, conversation := seededChatConversation(t)


### PR DESCRIPTION
Code changes: +1 -1  
Tests: +72 -0  
Others: +1 -1 (generated sqlc)  

## Problem / fix

Project-scoped orchestrator conversations store `session_id=NULL`; their live owner is `current_session_id`. The edit-delivery CAS joined the former, so an edit failed with `CHAT_EDIT_UNCERTAIN` before any provider operation.

Join the current owner instead. Preserve the exact controller generation, live Chat mode, and single-start reservation checks. No migration or API change.

Closes #5300. Found during [#4466 QA](https://github.com/Untrivial-ai/agent-orchestrator/pull/4466); kept separate to avoid expanding that recovery PR.

## Validation

- SQLite regression failed before the fix for project-scoped/rebound orchestrators, then passed twice after it.
- Race-enabled edit/branch store tests passed; Go build passed.
- Broad backend run hit failures in fake/Pi/daemon/Chat tests under concurrent load; all four affected packages passed when rerun serially. The original broad run is not claimed as green.
- Real Claude orchestrator: retried the **original saved client ID** that previously returned409. It now returns202, creates branch2/2, and completes `C4466_C_EDIT`.
- The same edited branch completed a TUI→Chat round trip with exactly six visible messages, unchanged identity and no duplicate/lost suffix.
- Independent Standards review: no findings. Independent Spec review: no findings.

Native verification used local integration head `17402f3f3` = #4466 head `9a34cdad2` plus this one-line fix. Main has the identical faulty query; unit/race/build checks ran on this main-based branch.

## Native evidence

Before: original imported conversation fails editing; provider work remained unstarted.

![Before: imported-origin edit blocked](https://github.com/user-attachments/assets/8b91e402-120e-4dc5-8c4a-ba608670ce2b)

After: the same failed edit now completes `C4466_C_EDIT` on branch 2/2. The subsequent Terminal → Chat round trip preserved this branch and all six messages, without restoring the replaced suffix.

![After: original imported conversation edit succeeds](https://github.com/user-attachments/assets/191aa9c9-af58-4644-a310-574bd4b3da06)

Exact round-trip trace retained locally. No screenshots, reports, or runtime data are committed.
