### PR TITLE
perf(mobile): decode PTY frames with atob instead of the hand-rolled loop

### DIFF
--- a/packages/mobile/lib/mux.test.ts
+++ b/packages/mobile/lib/mux.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+// mux.ts imports ./config, which reaches React Native's Flow-typed sources
+// through these two. Same preamble as lib/chat/eventCursor.test.ts.
+vi.mock("@react-native-async-storage/async-storage", () => ({
+	default: { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() },
+}));
+vi.mock("expo-secure-store", () => ({
+	getItemAsync: vi.fn(), setItemAsync: vi.fn(), deleteItemAsync: vi.fn(),
+}));
+
+import { base64ToBytes, bytesToBase64 } from "./mux";
+
+/**
+ * Every literal below was produced by Go's `base64.StdEncoding`, the daemon's
+ * only encode site for terminal payloads (backend/internal/terminal/manager.go:449),
+ * rather than by bytesToBase64. Pinning the wire contract to the encoder we ship
+ * would let both sides drift together without a test noticing.
+ */
+const WIRE: { name: string; bytes: number[]; b64: string }[] = [
+	// Reachable today: mux.ts decodes String(msg.data ?? "").
+	{ name: "an empty frame", bytes: [], b64: "" },
+	{ name: "a one-byte tail (==)", bytes: [0x41], b64: "QQ==" },
+	{ name: "a two-byte tail (=)", bytes: [0x41, 0x42], b64: "QUI=" },
+	{ name: "an exact three-byte group", bytes: [0x41, 0x42, 0x43], b64: "QUJD" },
+	{
+		// A real PTY chunk: NUL, CSI 31m, and bytes above 0x7f that are not valid
+		// UTF-8 on their own - the reason the wire is base64 at all.
+		name: "an ANSI chunk carrying high bytes",
+		bytes: [0x00, 0x1b, 0x5b, 0x33, 0x31, 0x6d, 0xff, 0xfe, 0x7f, 0x80, 0x0a],
+		b64: "ABtbMzFt//5/gAo=",
+	},
+];
+
+describe("base64ToBytes", () => {
+	for (const { name, bytes, b64 } of WIRE) {
+		it(`decodes ${name} exactly as the daemon encoded it`, () => {
+			expect(Array.from(base64ToBytes(b64))).toEqual(bytes);
+		});
+	}
+
+	it("preserves every byte value 0x00-0xff", () => {
+		// Go: base64.StdEncoding.EncodeToString(0..255). A decoder that masked or
+		// sign-extended the high half would show up here and nowhere else.
+		const all256 =
+			"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BB" +
+			"QkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKD" +
+			"hIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TF" +
+			"xsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==";
+		const got = base64ToBytes(all256);
+		expect(got).toHaveLength(256);
+		expect(Array.from(got)).toEqual(Array.from({ length: 256 }, (_, i) => i));
+	});
+
+	it("decodes a full 32 KiB frame", () => {
+		// The daemon reads PTY output into a 32 KiB buffer (attachment.go:196), so
+		// this is the largest single frame the phone has to decode.
+		const bytes = Uint8Array.from({ length: 32 * 1024 }, (_, i) => i & 0xff);
+		const b64 = bytesToBase64(bytes);
+		expect(b64).toHaveLength(43692);
+		expect(b64.slice(0, 32)).toBe("AAECAwQFBgcICQoLDA0ODxAREhMUFRYX");
+		expect(b64.slice(-32)).toBe("6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8=");
+		expect(base64ToBytes(b64)).toEqual(bytes);
+	});
+
+	it("yields an empty frame for a payload it cannot decode, rather than throwing", () => {
+		// atob rejects input the previous decoder silently filtered out. `handle` is
+		// called outside the JSON.parse guard in ws.onmessage, so a throw would escape
+		// the socket callback; drop the frame instead, as that guard already does.
+		expect(() => base64ToBytes("not base64!")).not.toThrow();
+		expect(base64ToBytes("not base64!")).toEqual(new Uint8Array(0));
+		expect(base64ToBytes("QQ=")).toEqual(new Uint8Array(0)); // wrong padding
+	});
+
+	it("still decodes a payload carrying whitespace, as the prefilter it replaced did", () => {
+		// atob strips ASCII whitespace itself, so dropping the prefilter loses nothing.
+		// vitest runs on Node, so every atob case here was re-checked on the
+		// simulator's Hermes (250829098.0.17) and behaves identically.
+		expect(base64ToBytes("QU\nJD")).toEqual(new Uint8Array([0x41, 0x42, 0x43]));
+		expect(base64ToBytes("QU JD")).toEqual(new Uint8Array([0x41, 0x42, 0x43]));
+	});
+});
+
+describe("bytesToBase64", () => {
+	for (const { name, bytes, b64 } of WIRE) {
+		it(`encodes ${name} the way Go's StdEncoding decodes it`, () => {
+			expect(bytesToBase64(Uint8Array.from(bytes))).toBe(b64);
+		});
+	}
+
+	it("round-trips arbitrary non-UTF8 bytes", () => {
+		const bytes = new Uint8Array([0x00, 0x1b, 0x5b, 0xff, 0xfe, 0x7f, 0x41]);
+		expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes);
+	});
+});

--- a/packages/mobile/lib/mux.ts
+++ b/packages/mobile/lib/mux.ts
@@ -51,34 +51,37 @@ function utf8Encode(str: string): Uint8Array {
 
 // The Go daemon carries terminal payloads as base64 (Go base64.StdEncoding),
 // because raw PTY bytes aren't valid UTF-8 and can't ride in a JSON string.
-// These helpers avoid depending on atob/btoa (not guaranteed in Hermes).
+//
+// Decoding runs once per PTY frame, so it uses atob and a pre-sized Uint8Array -
+// the shape the desktop renderer already uses (frontend/src/renderer/lib/terminal-mux.ts).
+// The "atob isn't guaranteed in Hermes" caution this replaced was already moot:
+// pairingCode.ts calls atob on the live pair path. Encoding keeps the table below,
+// since it runs once per input event rather than once per frame. See #4876.
 const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-const B64_LOOKUP = (() => {
-	const t = new Int16Array(256).fill(-1);
-	for (let i = 0; i < B64.length; i++) t[B64.charCodeAt(i)] = i;
-	return t;
-})();
 
-function base64ToBytes(b64: string): Uint8Array {
-	let clean = "";
-	for (let i = 0; i < b64.length; i++) {
-		const ch = b64.charCodeAt(i);
-		if (ch < 256 && B64_LOOKUP[ch] !== -1) clean += b64[i];
+/**
+ * Decodes one base64 payload from the daemon.
+ *
+ * Returns empty instead of throwing: `handle` is called outside the JSON.parse
+ * guard in ws.onmessage, so a throw here would escape the socket callback. An
+ * unreadable frame is dropped, which is what that guard already does one level
+ * up. The daemon cannot send one - base64.StdEncoding is the only encode site
+ * for terminal output, and it cannot emit whitespace.
+ */
+export function base64ToBytes(b64: string): Uint8Array {
+	let binary: string;
+	try {
+		binary = atob(b64);
+	} catch {
+		return new Uint8Array(0);
 	}
-	const out: number[] = [];
-	for (let i = 0; i < clean.length; i += 4) {
-		const a = B64_LOOKUP[clean.charCodeAt(i)] ?? 0;
-		const b = B64_LOOKUP[clean.charCodeAt(i + 1)] ?? 0;
-		const c = i + 2 < clean.length ? (B64_LOOKUP[clean.charCodeAt(i + 2)] ?? 0) : -1;
-		const d = i + 3 < clean.length ? (B64_LOOKUP[clean.charCodeAt(i + 3)] ?? 0) : -1;
-		out.push((a << 2) | (b >> 4));
-		if (c !== -1) out.push(((b & 15) << 4) | (c >> 2));
-		if (d !== -1) out.push(((c & 3) << 6) | d);
-	}
-	return new Uint8Array(out);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+	return bytes;
 }
 
-function bytesToBase64(bytes: Uint8Array): string {
+/** Encodes one input event for the daemon, which decodes it with Go's StdEncoding. */
+export function bytesToBase64(bytes: Uint8Array): string {
 	let out = "";
 	for (let i = 0; i < bytes.length; i += 3) {
 		const a = bytes[i];


### PR DESCRIPTION
## Summary

`base64ToBytes` runs once per PTY frame. It pre-filtered its input by building a new string one character at a time, then accumulated into a boxed `number[]` before copying that into a `Uint8Array` — neither allocation is necessary, since the output length is known up front.

The comment that kept it that way is stale for this app:

```ts
// These helpers avoid depending on atob/btoa (not guaranteed in Hermes).
```

`lib/pairingCode.ts:32` already calls `atob` on the live pair path (reached from `app/pair.tsx:84`), so QR pairing would be broken if Hermes lacked it. The desktop renderer already does this job with `atob` plus a pre-sized `Uint8Array`, at `frontend/src/renderer/lib/terminal-mux.ts:35-42`.

Closes #4876.

## Numbers

Simulator Hermes `250829098.0.17`, one full 32 KiB frame — the daemon's PTY read buffer (`backend/internal/terminal/attachment.go:196`) — 200 iterations after warm-up. All three variants returned byte-identical output:

| variant | ms/frame | vs current |
|---|---|---|
| current | 9.84 | 1.0x |
| pre-sized `Uint8Array`, no prefilter, no atob | 3.56 | 2.8x |
| **`atob` + `charCodeAt` copy (this PR)** | **2.24** | **4.4x** |

Two corrections, because the issue's estimate was wrong and I would rather flag that than repeat it:

- #4876 quoted ~7x for the atob route, from a desktop-class Hermes CLI. On the simulator's Hermes it is 4.4x.
- **These came from a Debug bundle**, where Hermes compiles at runtime without `-O`, so read 4.4x as an upper bound. The direction is still safe: Hermes has no JIT, so optimised bytecode is still interpreted while `atob` is native. The split shows which half is at risk — old → pre-sized (2.8x) is JS-vs-JS and sensitive to compilation quality; pre-sized → atob (1.6x) is interpreted-vs-native and is not.

I did not measure a release build. Doing that properly means putting benchmark code in the app, which does not belong in this PR — say the word if you want the number before merging.

## Changes

- `base64ToBytes` → `atob` plus a pre-sized `Uint8Array`.
- `bytesToBase64` keeps its lookup table. It runs once per input event, not once per frame, so it never sees the sizes that motivate the change; switching it would mean adopting the desktop's chunked `String.fromCharCode` spread, whose argument-count limit is engine-dependent, for no gain on that path.
- Both are exported so they can be tested. `lib/mux.test.ts` is this module's first test.

## The one behaviour change

`atob` throws where the old loop silently pre-filtered. `handle` is called *outside* the `JSON.parse` guard in `ws.onmessage`, so a throw would escape the socket callback — `base64ToBytes` is therefore total, and a payload it cannot read yields an empty frame.

The daemon cannot send one: terminal output has a single encode site (`backend/internal/terminal/manager.go:449`, `base64.StdEncoding`), which structurally cannot emit whitespace or line breaks.

It drops silently because the `JSON.parse` guard directly above it is `catch { return; }`, also silent — warning here but not there would be inconsistent, and the case is unreachable from the daemon. Happy to add a `__DEV__` warn if you would rather have the breadcrumb.

## Verification

- `npx tsc --noEmit` clean. `npx expo export` bundles on **ios and android** — CI runs only `npm ci` → typecheck → `npm test`, so nothing upstream catches a Metro-level break.
- `npx vitest run`, in a clean worktree off `main`: **787 → 802** (+15).
- **Revert test.** Restoring the old decoder (keeping the exports, so the tests still import) fails **1 of 15**: the empty-frame case. The other 14 pass on *both* implementations by design — they pin the wire contract, which must stay byte-identical. Saying so rather than implying all 15 catch the change.
- Fixtures are Go `base64.StdEncoding` output, not `bytesToBase64` output, so the encoder and its test cannot drift together unnoticed.
- **Hermes, not Node.** vitest runs on Node, which proves nothing about the shipping engine, so every `atob` case in the file was re-run on the simulator's Hermes over CDP:

| case | result |
|---|---|
| `typeof atob` | `"function"` |
| `atob("QU\nJD")`, `atob("QU JD")` | `[65,66,67]` — whitespace stripped |
| `atob("not base64!")`, `atob("QQ=")` | both throw |
| `atob("QQ")` unpadded | `[65]` |
| `atob("ABtbMzFt//5/gAo=")` | `[0,27,91,51,49,109,255,254,127,128,10]` |

## Not verified

- **iOS simulator only.** Hermes is pinned once for both platforms in this RN (`sdks/.hermesversion` → `hermes-v0.17.03`, RN 0.86.3), so the `atob` semantics are not iOS-specific — but Android was checked by `expo export`, not by running it.
- **No physical device, no release build** (above).
- **No renderer in `packages/mobile`** — 79 `*.test.ts`, zero `*.test.tsx` — so `handle`'s dispatch to `onTerminalData` is covered by reading, not by running.
