### PR TITLE
fix(session): make interface transition status match start readiness

### DIFF
--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -104,7 +104,7 @@ func (m *Manager) InterfaceTransitionStatus(
 	} else if target == domain.SessionModeChat && (m.chat == nil || !m.chat.SupportsChat(rec.Harness)) {
 		status.ReasonCode = "CHAT_UNSUPPORTED"
 		status.Reason = fmt.Sprintf("%s does not support Chat UI.", rec.Harness)
-	} else if _, _, err := m.handoffNativeConversationID(ctx, rec); err != nil {
+	} else if _, err := m.handoffNativeConversationID(ctx, rec); err != nil {
 		if errors.Is(err, ErrInterfaceHandoffUnsupported) {
 			status.ReasonCode = "INTERFACE_HANDOFF_UNSUPPORTED"
 		} else if errors.Is(err, ErrNativeConversationMissing) {
@@ -167,7 +167,7 @@ func (m *Manager) StartInterfaceTransition(
 		return domain.SessionInterfaceTransition{}, fmt.Errorf("%w: session %s is already in %s mode",
 			ErrInterfaceAlreadySelected, id, source)
 	}
-	nativeID, _, err := m.handoffNativeConversationID(ctx, rec)
+	nativeID, err := m.handoffNativeConversationID(ctx, rec)
 	if err != nil {
 		return domain.SessionInterfaceTransition{}, err
 	}
@@ -495,16 +495,12 @@ func (m *Manager) runInterfaceTransition(
 func (m *Manager) handoffNativeConversationID(
 	ctx context.Context,
 	rec domain.SessionRecord,
-) (string, ports.AgentInterfaceHandoff, error) {
+) (string, error) {
 	id, handoff, err := m.nativeConversationID(ctx, rec)
 	if err != nil {
-		return "", handoff, err
+		return "", err
 	}
-	id, err = m.persistedNativeConversationID(ctx, rec, id, handoff)
-	if err != nil {
-		return "", handoff, err
-	}
-	return id, handoff, nil
+	return m.persistedNativeConversationID(ctx, rec, id, handoff)
 }
 
 // nativeConversationID resolves the adapter's native conversation id for the

--- a/backend/internal/session_manager/interface_transition.go
+++ b/backend/internal/session_manager/interface_transition.go
@@ -81,8 +81,10 @@ type InterfaceTransitionStatus struct {
 }
 
 // InterfaceTransitionStatus reports static adapter support plus the latest
-// durable attempt. Read-only: target binary/auth checks happen on POST so a
-// status render never launches a provider process.
+// durable attempt. It runs the same native-conversation readiness check as
+// StartInterfaceTransition so the two never disagree: that check may stat the
+// provider transcript and read the current terminal screen, but never launches
+// a provider process. Target binary/auth checks still happen only on POST.
 func (m *Manager) InterfaceTransitionStatus(
 	ctx context.Context,
 	id domain.SessionID,
@@ -102,7 +104,7 @@ func (m *Manager) InterfaceTransitionStatus(
 	} else if target == domain.SessionModeChat && (m.chat == nil || !m.chat.SupportsChat(rec.Harness)) {
 		status.ReasonCode = "CHAT_UNSUPPORTED"
 		status.Reason = fmt.Sprintf("%s does not support Chat UI.", rec.Harness)
-	} else if _, _, err := m.nativeConversationID(ctx, rec); err != nil {
+	} else if _, _, err := m.handoffNativeConversationID(ctx, rec); err != nil {
 		if errors.Is(err, ErrInterfaceHandoffUnsupported) {
 			status.ReasonCode = "INTERFACE_HANDOFF_UNSUPPORTED"
 		} else if errors.Is(err, ErrNativeConversationMissing) {
@@ -165,11 +167,7 @@ func (m *Manager) StartInterfaceTransition(
 		return domain.SessionInterfaceTransition{}, fmt.Errorf("%w: session %s is already in %s mode",
 			ErrInterfaceAlreadySelected, id, source)
 	}
-	nativeID, handoff, err := m.nativeConversationID(ctx, rec)
-	if err != nil {
-		return domain.SessionInterfaceTransition{}, err
-	}
-	nativeID, err = m.persistedNativeConversationID(ctx, rec, nativeID, handoff)
+	nativeID, _, err := m.handoffNativeConversationID(ctx, rec)
 	if err != nil {
 		return domain.SessionInterfaceTransition{}, err
 	}
@@ -488,6 +486,25 @@ func (m *Manager) runInterfaceTransition(
 			"sessionID", rec.ID, "transitionID", transition.ID, "error", err)
 		return
 	}
+}
+
+// handoffNativeConversationID is the readiness check shared by status and
+// start. A reserved native id alone is not enough for a handoff: Claude Code
+// only writes its transcript after the first prompt, so the id must also have
+// durable provider history behind it (or positive fresh-start proof).
+func (m *Manager) handoffNativeConversationID(
+	ctx context.Context,
+	rec domain.SessionRecord,
+) (string, ports.AgentInterfaceHandoff, error) {
+	id, handoff, err := m.nativeConversationID(ctx, rec)
+	if err != nil {
+		return "", handoff, err
+	}
+	id, err = m.persistedNativeConversationID(ctx, rec, id, handoff)
+	if err != nil {
+		return "", handoff, err
+	}
+	return id, handoff, nil
 }
 
 // nativeConversationID resolves the adapter's native conversation id for the

--- a/backend/internal/session_manager/interface_transition_test.go
+++ b/backend/internal/session_manager/interface_transition_test.go
@@ -661,6 +661,68 @@ func TestInterfaceTransitionStatusBlocksFreshStartWithoutPositiveTerminalProof(t
 	}
 }
 
+// Regression for #4842: a fresh TUI session has a hook-confirmed native id but
+// no transcript on disk yet. Status must agree with start instead of drawing an
+// enabled switch that fails with NATIVE_SESSION_MISSING on POST.
+func TestInterfaceTransitionStatusBlocksReservedNativeIDWithoutHistoryOrFreshProof(t *testing.T) {
+	manager, store, runtime, _, _ := newTransitionManager(t, domain.SessionModeTUI)
+	manager.agents = singleAgent{agent: emptyTransitionAgent{}}
+	runtime.outputForCall = func(int) string { return ambiguousTerminalOutput }
+	rec := store.sessions["session-1"]
+	rec.Metadata.AgentSessionID = "native-fresh"
+	rec.Metadata.AgentSessionIDLaunchID = rec.Metadata.RuntimeLaunchID
+	store.sessions["session-1"] = rec
+
+	status, err := manager.InterfaceTransitionStatus(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("InterfaceTransitionStatus: %v", err)
+	}
+	if status.Supported {
+		t.Fatal("status enabled a switch whose native id has no durable history")
+	}
+	if status.ReasonCode != "NATIVE_SESSION_MISSING" {
+		t.Fatalf("reasonCode = %q, want NATIVE_SESSION_MISSING", status.ReasonCode)
+	}
+	if _, err := manager.StartInterfaceTransition(
+		context.Background(), "session-1", domain.SessionModeChat, domain.SessionInterfaceTransitionDrain,
+	); !errors.Is(err, ErrNativeConversationMissing) {
+		t.Fatalf("StartInterfaceTransition error = %v, want ErrNativeConversationMissing", err)
+	}
+}
+
+func TestInterfaceTransitionStatusAllowsReservedNativeIDWithUntouchedTerminalProof(t *testing.T) {
+	manager, store, _, chat, _ := newTransitionManager(t, domain.SessionModeTUI)
+	manager.agents = singleAgent{agent: untouchedEmptyTransitionAgent{}}
+	rec := store.sessions["session-1"]
+	rec.Metadata.AgentSessionID = "native-fresh"
+	rec.Metadata.AgentSessionIDLaunchID = rec.Metadata.RuntimeLaunchID
+	store.sessions["session-1"] = rec
+
+	status, err := manager.InterfaceTransitionStatus(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("InterfaceTransitionStatus: %v", err)
+	}
+	if !status.Supported {
+		t.Fatalf("untouched terminal should allow a fresh handoff: %s (%s)", status.Reason, status.ReasonCode)
+	}
+	transition, err := manager.StartInterfaceTransition(
+		context.Background(), "session-1", domain.SessionModeChat, domain.SessionInterfaceTransitionDrain,
+	)
+	if err != nil {
+		t.Fatalf("StartInterfaceTransition: %v", err)
+	}
+	if transition.NativeConversationID != "" {
+		t.Fatalf("fresh handoff carried native id %q, want empty", transition.NativeConversationID)
+	}
+	settled := awaitTransition(t, store, transition.ID)
+	if settled.Phase != domain.SessionInterfaceTransitionCompleted {
+		t.Fatalf("phase = %s, error = %s", settled.Phase, settled.ErrorDetail)
+	}
+	if chat.start.ProviderConversationID != "" {
+		t.Fatalf("fresh handoff resumed provider conversation %q", chat.start.ProviderConversationID)
+	}
+}
+
 func TestInterfaceTransitionStatusBlocksFreshStartWhenConversationMetadataExists(t *testing.T) {
 	manager, store, runtime, _, _ := newTransitionManager(t, domain.SessionModeTUI)
 	manager.agents = singleAgent{agent: codexagent.New()}


### PR DESCRIPTION
Code: +25 −11
Tests: +93 −0
Files removed: 0

## What

Make the interface-transition status (GET) run the same native-conversation readiness check as the start (POST), so the switch control is disabled until the session can actually switch.

## Why

A fresh Claude Code TUI session has a hook-confirmed native id but no transcript on disk yet (Claude only writes it after the first prompt). GET only checked the id and said `supported: true`; POST also required durable history or positive fresh-start proof and returned 409 `NATIVE_SESSION_MISSING`. The UI drew an enabled switch that failed with a toast.

Fixes #4842

## How

- `backend/internal/session_manager/interface_transition.go` — I added `handoffNativeConversationID`, which runs `nativeConversationID` then `persistedNativeConversationID`, and call it from both `InterfaceTransitionStatus` and `StartInterfaceTransition`.
- The status path now stats the provider transcript and may read the current terminal screen; it still never launches a provider process (doc comment updated).
- Review follow-up: the status path can now hit `loadProject` and `NativeConversationExists` errors that map to no reason code. Instead of failing the polled GET (which stops the client poll when it is the first load), I report `NATIVE_SESSION_UNVERIFIED` so the control stays disabled and the client keeps polling. POST still fails hard on those errors.
- No frontend change: `useSessionInterfaceTransition.ts:173` already polls on `NATIVE_SESSION_MISSING` / `NATIVE_SESSION_UNVERIFIED` and re-enables the control once the first prompt lands.

## Testing

- Added `TestInterfaceTransitionStatusBlocksReservedNativeIDWithoutHistoryOrFreshProof` (GET and POST both report missing), `TestInterfaceTransitionStatusAllowsReservedNativeIDWithUntouchedTerminalProof` (fresh handoff still allowed with untouched-terminal proof), and `TestInterfaceTransitionStatusReportsUnverifiedWhenInspectionFails` (probe error degrades GET to unverified, POST still errors).
- `go test ./backend/internal/session_manager/ ./backend/internal/httpd/controllers/ ./backend/internal/service/session/` passes; `go vet` and `gofmt` clean.
- Not yet verified in the desktop app.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
