### PR TITLE
fix(reviews): stop probing every reviewer's CLI when the menu opens

### DIFF
--- a/frontend/src/renderer/components/ReviewerSelect.test.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The daemon answers a cold model-catalog read by running that agent's own CLI, so
+// every entry here is a real subprocess on the user's machine. What the menu asks
+// for is therefore a correctness question, not a performance one.
+const requestedAgents: string[] = [];
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: {
+		GET: async (_path: string, opts: { params: { path: { agent: string } } }) => {
+			requestedAgents.push(opts.params.path.agent);
+			return {
+				data: { agentId: opts.params.path.agent, selectionMode: "catalog", models: [] },
+				error: undefined,
+			};
+		},
+		POST: async () => ({ data: {}, error: undefined }),
+	},
+	apiErrorMessage: () => "failed",
+}));
+
+import { ReviewerSelect } from "./ReviewerSelect";
+
+function renderMenu(ui: ReactElement) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+// Give any stray fetch a chance to land before asserting on absence.
+async function settle() {
+	await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+describe("ReviewerSelect catalog reads", () => {
+	beforeEach(() => {
+		requestedAgents.length = 0;
+	});
+
+	// Opening the menu used to prefetch a catalog for all 21 reviewer harnesses,
+	// running the CLI of every agent the user was not choosing — including agents
+	// they had never signed in to.
+	// https://github.com/Untrivial-ai/agent-orchestrator/issues/5307
+	it("does not read a catalog for harnesses the user is not choosing", async () => {
+		const user = userEvent.setup();
+		renderMenu(<ReviewerSelect value="claude-code" onChange={vi.fn()} projectId="p1" />);
+
+		await user.click(screen.getByRole("button", { name: "Default reviewer agent" }));
+		await settle();
+
+		expect(requestedAgents).not.toContain("kiro");
+		expect(new Set(requestedAgents)).toEqual(new Set(["claude-code"]));
+	});
+
+	// The trigger has to name the selected model, so the harness in effect is the
+	// one read AO is entitled to make.
+	it("still reads the catalog of the harness in effect", async () => {
+		renderMenu(<ReviewerSelect value="codex" onChange={vi.fn()} projectId="p1" />);
+		await waitFor(() => expect(requestedAgents).toContain("codex"));
+	});
+
+	it("reads a harness catalog once its own submenu is opened", async () => {
+		const user = userEvent.setup();
+		renderMenu(<ReviewerSelect value="claude-code" onChange={vi.fn()} projectId="p1" />);
+
+		await user.click(screen.getByRole("button", { name: "Default reviewer agent" }));
+		await settle();
+		expect(requestedAgents).not.toContain("kiro");
+
+		// Hovering a sub-trigger is what opens it; clicking a harness that is not the
+		// current one selects it instead.
+		await user.hover(await screen.findByRole("menuitem", { name: /Kiro/ }));
+		await waitFor(() => expect(requestedAgents).toContain("kiro"));
+	});
+
+	// Choosing a different reviewer must not become a reason to run some third
+	// agent's binary.
+	it("reads no further catalogs when a harness is selected", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		renderMenu(<ReviewerSelect value="claude-code" onChange={onChange} projectId="p1" />);
+
+		await user.click(screen.getByRole("button", { name: "Default reviewer agent" }));
+		await settle();
+		requestedAgents.length = 0;
+
+		await user.click(await screen.findByRole("menuitem", { name: /Codex/ }));
+		await settle();
+
+		expect(onChange).toHaveBeenCalledWith("codex");
+		expect(requestedAgents).not.toContain("kiro");
+	});
+});

--- a/frontend/src/renderer/components/ReviewerSelect.tsx
+++ b/frontend/src/renderer/components/ReviewerSelect.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { components } from "../../api/schema";
@@ -81,7 +81,6 @@ export function ReviewerSelect({
 	excludedHarness?: string;
 }) {
 	const { t } = useTranslation();
-	const queryClient = useQueryClient();
 	const [menuOpen, setMenuOpen] = useState(false);
 	// Until the daemon's catalog arrives these entries carry the whole menu, so
 	// label them the way the catalog would rather than printing bare ids: without
@@ -103,20 +102,16 @@ export function ReviewerSelect({
 	});
 	const effectiveHarness = value || defaultHarness || "";
 	const menuProjectID = projectId ?? "";
+	// Reading a harness's catalog is not free: the daemon answers a cold cache by
+	// running that agent's own CLI. The menu used to prefetch every reviewer's
+	// catalog on open, which launched the binary of each agent the user was not
+	// choosing and may never have signed in to — that is how picking a reviewer
+	// could start an unrelated agent's login flow.
+	// https://github.com/Untrivial-ai/agent-orchestrator/issues/5307
+	// Only the harness in effect is read up front, because the trigger label needs
+	// it; the rest load if and when their submenu is actually opened.
 	const triggerCatalog = useQuery(agentModelsQueryOptions(effectiveHarness, menuProjectID));
 
-	useEffect(() => {
-		if (!menuOpen) return;
-		const harnesses = new Set<string>();
-		if (defaultHarness) harnesses.add(defaultHarness);
-		for (const agent of selectableOptions) {
-			harnesses.add(agent.id);
-		}
-		for (const harness of harnesses) {
-			if (!harness) continue;
-			void queryClient.prefetchQuery(agentModelsQueryOptions(harness, menuProjectID));
-		}
-	}, [defaultHarness, menuOpen, menuProjectID, queryClient, selectableOptions]);
 	const selectedModelLabel = modelOrModeLabel(triggerCatalog.data, model, mode, t("settings.models.agentDefault"));
 	const triggerLabel = [value ? agentLabel(value) : (defaultTriggerLabel ?? defaultOptionLabel ?? defaultHarness), selectedModelLabel]
 		.filter(Boolean)
@@ -202,9 +197,12 @@ function ReviewerHarnessOption({
 }) {
 	const { t } = useTranslation();
 	const [open, setOpen] = useState(false);
+	// Clicking a harness that is not the current one selects it outright rather
+	// than opening its submenu, so only the current harness and a submenu the user
+	// deliberately opened need a catalog. Everything else reads cache-only.
 	const catalogQuery = useQuery({
 		...agentModelsQueryOptions(resolvedHarness ?? "", projectId),
-		enabled: false,
+		enabled: open,
 	});
 	const catalog = catalogQuery.data;
 	const effectiveCurrentHarness =


### PR DESCRIPTION
Fixes #5307

## What was wrong

`ReviewerSelect` prefetched a model catalog for **every** selectable reviewer harness the moment the menu opened. That read is not free: the daemon answers a cold catalog with the agent's own CLI, so a single menu-open ran the binary of all 21 reviewer harnesses — including agents the user was not choosing and had never signed in to.

For Kiro that discovery command is its **chat entrypoint**:

```go
// backend/internal/adapters/agent/modelcatalog/catalog.go:58
"kiro": {args: []string{"chat", "--list-models", "--format", "json"}, parser: parseJSONModels},
```

which is how picking an unrelated reviewer could pop a Kiro OAuth sign-in in the reporter's browser.

## What changed

Only the harness in effect is read up front — the trigger label needs it anyway. Each option now fetches its own catalog if and when its submenu is opened. Clicking a harness that is *not* the current one selects it outright rather than opening its submenu, so the common path needs no extra read at all.

One menu-open goes from 21 catalog reads to 1.

## Tests

New `ReviewerSelect.test.tsx` counts which agents a menu interaction reads catalogs for. Two of the four fail on `main` with exactly the reported shape:

```
× does not read a catalog for harnesses the user is not choosing
× reads a harness catalog once its own submenu is opened
  AssertionError: expected [ 'claude-code', 'codex', …(19) ] to not include 'kiro'
```

All four pass here. The other two guard the reads that *should* still happen (the harness in effect; a submenu the user deliberately opened) so this cannot be "fixed" by removing catalog reads altogether.

Also run: `npm run typecheck` clean; renderer suite `207 passed / 3203 passed`, matching `main` exactly plus the 4 added tests. The one remaining renderer failure (`GlobalSettingsForm > renders the settings sections`) reproduces on unmodified `main`.

## Scope / what this does not do

This narrows what a **passive** menu probes. It does not change what an explicitly chosen or launched agent may do — selecting Kiro as your reviewer still reads its catalog, and so may still trigger a sign-in.

Two deeper questions are left open and written up on the issue rather than guessed at here:

- Kiro's discovery command being `chat` rather than a dedicated subcommand. Fixing that needs someone who can verify `kiro-cli`'s actual surface.
- Gating discovery on the adapter's existing side-effect-free auth probe (`kiro-cli whoami`). That looked attractive but its effectiveness is unproven — [#5048](https://github.com/Untrivial-ai/agent-orchestrator/issues/5048) documents that probe returning `unknown` for a genuinely signed-in user, so a gate keyed on it may simply not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
