### PR TITLE
fix(electron): return cancellation results for aborted browser commands

### DIFF
--- a/frontend/src/main/browser-runtime-link.test.ts
+++ b/frontend/src/main/browser-runtime-link.test.ts
@@ -136,7 +136,7 @@ describe("browser runtime link", () => {
 		serverSocket!.destroy();
 	});
 
-	it("queues per session and cancels work from a closed connection", async () => {
+	it("queues per session, cancels on server close, and reconnects", async () => {
 		let serverSocket: net.Socket | null = null;
 		const messages: Array<Record<string, unknown>> = [];
 		const executed: string[] = [];
@@ -182,10 +182,132 @@ describe("browser runtime link", () => {
 		await vi.waitFor(() => expect(executed).toContain("independent"));
 		expect(executed).not.toContain("queued");
 
-		serverSocket!.destroy();
+		serverSocket!.end();
+		for (const requestId of ["blocked", "queued"] as const) {
+			await vi.waitFor(() =>
+				expect(messages).toContainEqual({
+					type: "result",
+					requestId,
+					ok: false,
+					error: { code: "BROWSER_COMMAND_CANCELED", message: "Browser runtime link closed" },
+				}),
+			);
+		}
+		expect(
+			messages.filter(
+				(message) =>
+					message.type === "result" &&
+					message.requestId === "blocked" &&
+					message.ok === false &&
+					(message.error as { code?: string })?.code === "BROWSER_COMMAND_CANCELED",
+			),
+		).toHaveLength(1);
 		await vi.waitFor(() => expect(handle.connected).toBe(false));
 		await vi.waitFor(() => expect(handle.connected).toBe(true));
 		expect(executed).not.toContain("queued");
-		expect(messages.some((message) => message.requestId === "blocked" && message.type === "result")).toBe(false);
+	});
+
+	it("returns structured cancellation errors before disposing the link", async () => {
+		let serverSocket: net.Socket | null = null;
+		const messages: Array<Record<string, unknown>> = [];
+		const executed: string[] = [];
+		const server = net.createServer((socket) => {
+			serverSocket = socket;
+			let inbound = "";
+			socket.on("data", (chunk) => {
+				inbound += chunk.toString("utf8");
+				const lines = inbound.split("\n");
+				inbound = lines.pop() ?? "";
+				for (const line of lines) if (line) messages.push(JSON.parse(line));
+			});
+		});
+		servers.push(server);
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as net.AddressInfo;
+		const handle = connectBrowserRuntime(
+			{ host: address.address, port: address.port },
+			{
+				execute: async (command, signal) => {
+					executed.push(command.requestId);
+					if (command.requestId === "blocked") {
+						await new Promise<void>((_, reject) => {
+							signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+						});
+					}
+					return { requestId: command.requestId };
+				},
+			},
+		);
+		handles.push(handle);
+		await vi.waitFor(() => expect(handle.connected).toBe(true));
+
+		serverSocket!.write(
+			[
+				{ type: "command", requestId: "blocked", sessionId: "s1", action: "wait" },
+				{ type: "command", requestId: "queued", sessionId: "s1", action: "click" },
+			]
+				.map((message) => JSON.stringify(message))
+				.join("\n") + "\n",
+		);
+		await vi.waitFor(() => expect(executed).toContain("blocked"));
+
+		handle.dispose();
+		for (const requestId of ["blocked", "queued"] as const) {
+			await vi.waitFor(() =>
+				expect(messages).toContainEqual({
+					type: "result",
+					requestId,
+					ok: false,
+					error: { code: "BROWSER_COMMAND_CANCELED", message: "Browser runtime link closed" },
+				}),
+			);
+		}
+		expect(
+			messages.filter(
+				(message) =>
+					message.type === "result" &&
+					message.requestId === "blocked" &&
+					message.ok === false &&
+					(message.error as { code?: string })?.code === "BROWSER_COMMAND_CANCELED",
+			),
+		).toHaveLength(1);
+	});
+
+	it("returns structured cancellation errors for daemon-initiated cancel frames", async () => {
+		let serverSocket: net.Socket | null = null;
+		let inbound = "";
+		const messages: unknown[] = [];
+		const execute = vi.fn(async (_command, signal) => {
+			await new Promise<void>((_, reject) => {
+				signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+			});
+		});
+		const server = net.createServer((socket) => {
+			serverSocket = socket;
+			socket.on("data", (chunk) => {
+				inbound += chunk.toString("utf8");
+				const lines = inbound.split("\n");
+				inbound = lines.pop() ?? "";
+				for (const line of lines) if (line) messages.push(JSON.parse(line));
+			});
+		});
+		servers.push(server);
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as net.AddressInfo;
+		const handle = connectBrowserRuntime({ host: address.address, port: address.port }, { execute });
+		handles.push(handle);
+		await vi.waitFor(() => expect(handle.connected).toBe(true));
+
+		serverSocket!.write(`${JSON.stringify({ type: "command", requestId: "r3", sessionId: "s1", action: "wait" })}\n`);
+		await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+		serverSocket!.write(`${JSON.stringify({ type: "cancel", requestId: "r3" })}\n`);
+		await vi.waitFor(() =>
+			expect(messages).toContainEqual({
+				type: "result",
+				requestId: "r3",
+				ok: false,
+				error: { code: "BROWSER_COMMAND_CANCELED", message: "Browser runtime link closed" },
+			}),
+		);
 	});
 });

--- a/frontend/src/main/browser-runtime-link.ts
+++ b/frontend/src/main/browser-runtime-link.ts
@@ -51,8 +51,33 @@ export function connectBrowserRuntime(
 	let connectionEpoch = 0;
 	const commandChains = new Map<string, Promise<void>>();
 	const commandControllers = new Map<string, AbortController>();
+	const activeCommands = new Map<
+		string,
+		{ command: BrowserRuntimeCommand; target: net.Socket; epoch: number }
+	>();
+
+	const sendCancelledResultOnTarget = (command: BrowserRuntimeCommand, target: net.Socket) => {
+		if (target.destroyed) return;
+		const frame = `${JSON.stringify({
+			type: "result",
+			requestId: command.requestId,
+			ok: false,
+			error: { code: "BROWSER_COMMAND_CANCELED", message: "Browser runtime link closed" },
+		})}\n`;
+		try {
+			target.write(frame);
+		} catch {
+			// Socket already torn down; the daemon will observe disconnect.
+		}
+	};
 
 	const cancelConnectionCommands = () => {
+		for (const { command, target } of activeCommands.values()) {
+			sendCancelledResultOnTarget(command, target);
+		}
+		// Drop tracking before aborting so in-flight respond() catch paths do not
+		// emit a second cancellation frame for the same requestId.
+		activeCommands.clear();
 		for (const controller of commandControllers.values()) controller.abort();
 		commandControllers.clear();
 		commandChains.clear();
@@ -67,10 +92,11 @@ export function connectBrowserRuntime(
 
 	const destroySocket = () => {
 		if (!socket) return;
-		connectionEpoch += 1;
+		const target = socket;
 		cancelConnectionCommands();
-		socket.removeAllListeners();
-		socket.destroy();
+		connectionEpoch += 1;
+		target.removeAllListeners();
+		target.destroy();
 		socket = null;
 	};
 
@@ -96,6 +122,27 @@ export function connectBrowserRuntime(
 		});
 	};
 
+	const sendCancelledResult = async (
+		command: BrowserRuntimeCommand,
+		target: net.Socket,
+		epoch: number,
+	) => {
+		try {
+			await send(
+				{
+					type: "result",
+					requestId: command.requestId,
+					ok: false,
+					error: { code: "BROWSER_COMMAND_CANCELED", message: "Browser runtime link closed" },
+				},
+				target,
+				epoch,
+			);
+		} catch {
+			// Socket already torn down; the daemon will observe disconnect.
+		}
+	};
+
 	const respond = async (
 		command: BrowserRuntimeCommand,
 		target: net.Socket,
@@ -108,7 +155,14 @@ export function connectBrowserRuntime(
 			controller.signal.throwIfAborted();
 			await send({ type: "result", requestId: command.requestId, ok: true, result }, target, epoch);
 		} catch (error) {
-			if (controller.signal.aborted) return;
+			if (controller.signal.aborted) {
+				// Daemon-initiated cancel frames abort one controller without clearing
+				// activeCommands; connection teardown clears the map before aborting.
+				if (activeCommands.has(command.requestId)) {
+					await sendCancelledResult(command, target, epoch);
+				}
+				return;
+			}
 			const normalized = normalizeCommandError(error);
 			try {
 				await send({ type: "result", requestId: command.requestId, ok: false, error: normalized }, target, epoch);
@@ -117,6 +171,7 @@ export function connectBrowserRuntime(
 				target.destroy();
 			}
 		} finally {
+			activeCommands.delete(command.requestId);
 			if (commandControllers.get(command.requestId) === controller) {
 				commandControllers.delete(command.requestId);
 			}
@@ -146,6 +201,7 @@ export function connectBrowserRuntime(
 		}
 		const controller = new AbortController();
 		commandControllers.set(command.requestId, controller);
+		activeCommands.set(command.requestId, { command, target, epoch });
 		const previous = commandChains.get(command.sessionId) ?? Promise.resolve();
 		const next = previous.then(() => respond(command, target, epoch, controller));
 		commandChains.set(command.sessionId, next);
@@ -208,14 +264,19 @@ export function connectBrowserRuntime(
 		});
 		next.on("data", (chunk) => consume(chunk, next, epoch));
 		next.on("error", (error) => log(`browser-runtime-link: error: ${error.message}`));
-		next.on("close", () => {
-			if (socket !== next || connectionEpoch !== epoch) return;
+		let connectionTornDown = false;
+		const tearDownConnection = () => {
+			if (connectionTornDown || socket !== next || connectionEpoch !== epoch) return;
+			connectionTornDown = true;
 			connected = false;
+			cancelConnectionCommands();
 			socket = null;
 			connectionEpoch += 1;
-			cancelConnectionCommands();
 			if (!disposed) scheduleReconnect();
-		});
+		};
+		// Cancel while the socket may still accept writes; 'close' can arrive too late.
+		next.on("end", tearDownConnection);
+		next.on("close", tearDownConnection);
 	}
 
 	connect();


### PR DESCRIPTION
## Summary
- When the Electron browser runtime link reconnects or disposes, emit `BROWSER_COMMAND_CANCELED` result frames for every accepted command (including queued per-session work) before tearing down the socket.
- Handle daemon-initiated `cancel` frames by returning a structured cancellation result instead of silently dropping the response.
- Tear down on socket `end` as well as `close`, and clear `activeCommands` before aborting controllers to avoid duplicate cancellation frames.

## Problem
If the daemon-to-Electron browser bridge dropped while a command was in flight, the frontend aborted locally but never told the daemon the command failed. The broker kept waiting on the pending request until TCP disconnect was detected or the command timed out.

## Test plan
- [x] `cd frontend && npx vitest run src/main/browser-runtime-link.test.ts` (6 tests pass)
- [ ] Verify `ao browser wait` recovers promptly after restarting the desktop app mid-command


Made with [Cursor](https://cursor.com)