### PR TITLE
fix(electron): bound browser profile data operation waits

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -137,7 +137,7 @@ import {
 	shouldHandleAppShortcutInBrowserContext,
 	type BrowserViewHost,
 } from "./main/browser-view-host";
-import { createBrowserProfileStore } from "./main/browser-profile-store";
+import { createBrowserProfileStore, withBrowserProfileOperationTimeout } from "./main/browser-profile-store";
 import { BrowserHistoryStore } from "./main/browser-history-store";
 import { createBrowserDownloadManager } from "./main/browser-download-manager";
 import { BrowserProfileImportService } from "./main/browser-profile-import";
@@ -537,7 +537,9 @@ function browserProfileStateDir(): string {
 
 async function clearElectronBrowserProfileData(partition: string): Promise<void> {
 	const browserSession = session.fromPartition(partition);
-	await Promise.all([browserSession.clearStorageData(), browserSession.clearCache()]);
+	await withBrowserProfileOperationTimeout(() =>
+		Promise.all([browserSession.clearStorageData(), browserSession.clearCache()]),
+	);
 }
 
 async function disposeAllBrowserViewHosts(): Promise<void> {

--- a/frontend/src/main/browser-profile-store.test.ts
+++ b/frontend/src/main/browser-profile-store.test.ts
@@ -1,14 +1,14 @@
 import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	BROWSER_PROFILE_MAX_COUNT,
 	BROWSER_PROFILE_REGISTRY_VERSION,
 	browserProfilePartition,
 	type BrowserProfileRegistry,
 } from "../shared/browser-profiles";
-import { BrowserProfileStore } from "./browser-profile-store";
+import { BROWSER_PROFILE_OPERATION_TIMEOUT_MS, BrowserProfileStore } from "./browser-profile-store";
 
 const tempDirectories: string[] = [];
 
@@ -171,5 +171,24 @@ describe("BrowserProfileStore", () => {
 		expect(await second).toBe("second");
 		await drain;
 		expect(store.isProfileOperationInProgress(profile.id)).toBe(false);
+	});
+
+	it("times out profile data operations that run too long", async () => {
+		vi.useFakeTimers();
+		try {
+			const store = new BrowserProfileStore({ stateDir: await makeStateDir() });
+			const profile = await store.createProfile("Work");
+			const operation = store.runProfileOperation(profile.id, () => false, async () => {
+				await new Promise<void>(() => undefined);
+			});
+			const expectation = expect(operation).rejects.toMatchObject({
+				code: "BROWSER_PROFILE_OPERATION_TIMEOUT",
+			});
+			await vi.advanceTimersByTimeAsync(BROWSER_PROFILE_OPERATION_TIMEOUT_MS);
+			await expectation;
+			expect(store.isProfileOperationInProgress(profile.id)).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/frontend/src/main/browser-profile-store.ts
+++ b/frontend/src/main/browser-profile-store.ts
@@ -19,8 +19,11 @@ import {
 
 export { BROWSER_PROFILE_REGISTRY_FILE_NAME };
 
+/** Upper bound for profile clear/delete work and for browser commands waiting on it. */
+export const BROWSER_PROFILE_OPERATION_TIMEOUT_MS = 60_000;
+
 export class BrowserProfileStoreError extends Error {
-	readonly code: BrowserProfileStoreErrorInfo["code"] | "BROWSER_PROFILE_ACTIVE" | "BROWSER_PROFILE_NOT_FOUND" | "BROWSER_PROFILE_NAME_TAKEN" | "BROWSER_PROFILE_LIMIT" | "BROWSER_PROFILE_BINDING_LIMIT" | "BROWSER_PROFILE_OPERATION_IN_PROGRESS" | "INVALID_ARGUMENT";
+	readonly code: BrowserProfileStoreErrorInfo["code"] | "BROWSER_PROFILE_ACTIVE" | "BROWSER_PROFILE_NOT_FOUND" | "BROWSER_PROFILE_NAME_TAKEN" | "BROWSER_PROFILE_LIMIT" | "BROWSER_PROFILE_BINDING_LIMIT" | "BROWSER_PROFILE_OPERATION_IN_PROGRESS" | "BROWSER_PROFILE_OPERATION_TIMEOUT" | "INVALID_ARGUMENT";
 
 	constructor(
 		code: BrowserProfileStoreError["code"],
@@ -38,6 +41,32 @@ export type BrowserProfileStoreOptions = {
 };
 
 type ProfileOperation<T> = () => Promise<T>;
+
+export async function withBrowserProfileOperationTimeout<T>(
+	operation: () => Promise<T>,
+	timeoutMs = BROWSER_PROFILE_OPERATION_TIMEOUT_MS,
+): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			operation(),
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() =>
+						reject(
+							new BrowserProfileStoreError(
+								"BROWSER_PROFILE_OPERATION_TIMEOUT",
+								"Browser profile data operation timed out.",
+							),
+						),
+					timeoutMs,
+				);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
 
 const DEFAULT_REGISTRY: BrowserProfileRegistry = {
 	version: BROWSER_PROFILE_REGISTRY_VERSION,
@@ -362,7 +391,7 @@ export class BrowserProfileStore {
 			if (isLive()) throw new BrowserProfileStoreError("BROWSER_PROFILE_ACTIVE", "The browser profile is currently in use.");
 			this.profileOperationsInProgress.add(profileId);
 			try {
-				const result = await operation();
+				const result = await withBrowserProfileOperationTimeout(operation);
 				if (isLive()) {
 					throw new BrowserProfileStoreError("BROWSER_PROFILE_ACTIVE", "The browser profile became active while it was being changed.");
 				}

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -13,7 +13,7 @@ import {
 	scaleBoundsForZoom,
 } from "./browser-view-host";
 import { browserProfilePartition, type BrowserProfile } from "../shared/browser-profiles";
-import type { BrowserProfileStore } from "./browser-profile-store";
+import { BROWSER_PROFILE_OPERATION_TIMEOUT_MS, type BrowserProfileStore } from "./browser-profile-store";
 import type { BrowserHistoryStore } from "./browser-history-store";
 import {
 	FOCUS_TERMINAL_SHORTCUT_CHANNEL,
@@ -1459,6 +1459,24 @@ describe("browser profile partitions and replacement", () => {
 		release();
 		await ensuring;
 		expect(constructorOptions[0]!.webPreferences.partition).toBe(browserProfilePartition(profile.id));
+	});
+
+	it("times out browser commands waiting on a stuck profile data operation", async () => {
+		vi.useFakeTimers();
+		try {
+			const store = fakeBrowserProfileStore(profile, { "worker-1": profile.id });
+			store.isProfileOperationInProgress = vi.fn(() => true);
+			store.waitForProfileOperation = vi.fn(() => new Promise<void>(() => undefined));
+			const { host } = setupTabHost(store);
+			const command = host.execute("worker-1", "snapshot");
+			const expectation = expect(command).rejects.toMatchObject({
+				code: "BROWSER_PROFILE_OPERATION_TIMEOUT",
+			});
+			await vi.advanceTimersByTimeAsync(BROWSER_PROFILE_OPERATION_TIMEOUT_MS);
+			await expectation;
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("refuses switching while renderer navigation is still in flight", async () => {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -33,7 +33,7 @@ import { attachAppShortcuts } from "./app-shortcuts";
 import type { AppShortcutId, KeybindingOverrides, ShortcutChord } from "../shared/shortcuts";
 import type { AgentBrowserRuntime } from "./agent-browser-runtime";
 import type { AgentBrowserTarget, AgentBrowserTargetProvider } from "./agent-browser-cdp-bridge";
-import type { BrowserProfileStore } from "./browser-profile-store";
+import { withBrowserProfileOperationTimeout, type BrowserProfileStore } from "./browser-profile-store";
 import type { BrowserHistoryStore } from "./browser-history-store";
 import type { BrowserDownloadManager } from "./browser-download-manager";
 import type { BrowserDownloadActionInput } from "../shared/browser-downloads";
@@ -861,7 +861,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			for (;;) {
 				const boundProfileId = store.getSessionProfileId(sessionId);
 				if (!boundProfileId || !store.isProfileOperationInProgress(boundProfileId)) break;
-				await store.waitForProfileOperation(boundProfileId);
+				await withBrowserProfileOperationTimeout(() => store.waitForProfileOperation(boundProfileId));
 			}
 		}
 		if (isUnavailable?.()) {


### PR DESCRIPTION
## Summary
- Add a 60s timeout (`BROWSER_PROFILE_OPERATION_TIMEOUT_MS`) for profile clear/delete work and for browser commands waiting on that queue in `ensureSessionReady()`.
- Wrap Electron `clearStorageData` / `clearCache` with the same bound so a stuck storage call cannot hold the profile operation queue forever.
- Fail with `BROWSER_PROFILE_OPERATION_TIMEOUT` instead of leaving automation hung for the session.

## Problem
Before running a browser command, the desktop app waits in a `for (;;)` loop until bound profile clear/delete operations finish. That wait had no timeout. If profile data work stalled (for example on Electron session storage APIs), `ensureSessionReady()` and every subsequent browser command for that session would wait indefinitely.

## Test plan
- [x] `cd frontend && npx vitest run src/main/browser-profile-store.test.ts` (8 tests pass, including new timeout case)
- [x] Added `browser-view-host` regression test for stuck profile-operation wait (runs in CI)
- [ ] Manually start a profile clear, simulate a hang, and confirm `ao browser snapshot` fails within ~60s with `BROWSER_PROFILE_OPERATION_TIMEOUT` instead of hanging


Made with [Cursor](https://cursor.com)