### PR TITLE
docs: define local device runtime prerequisites

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | [stack.md](stack.md)                                   | Accepted library/runtime choices, pending stack decisions, and dependencies explicitly avoided for V1.                |
 | [telemetry.md](telemetry.md)                           | User-facing overview of product telemetry, privacy safeguards, and opt-out controls.                                    |
 | [posthog-cost-controls.md](posthog-cost-controls.md)   | PostHog event-name migration, ingestion drop rules, and dashboard queries for reducing telemetry spend.              |
+| [research/2026-09-13-local-device-runtime-prerequisites.md](research/2026-09-13-local-device-runtime-prerequisites.md) | Evidence, dependency/license audit, compatibility findings, and release gates for local iOS/Android virtual-device support. |
+| [superpowers/specs/2026-09-13-local-device-support-design.md](superpowers/specs/2026-09-13-local-device-support-design.md) | Proposed AO architecture, CLI/skill contract, security model, test plan, and stacked rollout for local virtual devices. |
 
 ## Mental model
 

--- a/docs/adr/0005-local-virtual-device-runtime-boundary.md
+++ b/docs/adr/0005-local-virtual-device-runtime-boundary.md
@@ -1,0 +1,187 @@
+# 5. An AO-owned boundary for local virtual devices
+
+Date: 2026-09-13
+Status: Proposed
+
+## Context
+
+AO needs a macOS-only first release that can discover, boot, display, inspect,
+and control existing iOS Simulators and Android Emulators. The same operations
+must be available to the person using the desktop app and to the coding agent
+in that AO session.
+
+The platform tooling already exists: Xcode owns CoreSimulator and `simctl`, and
+the Android SDK owns `adb`, `emulator`, and AVDs. Reimplementing live capture,
+input injection, and accessibility traversal would add substantial native code
+without improving AO's product boundary. Conversely, exposing a third-party
+device server or CLI directly would bypass AO's session isolation, error
+envelopes, LAN restrictions, and process lifecycle.
+
+The prerequisite audit in
+[the device runtime evidence note](../research/2026-09-13-local-device-runtime-prerequisites.md)
+evaluates the exact upstream artifacts. The implementation plan in
+[the local device support design](../superpowers/specs/2026-09-13-local-device-support-design.md)
+defines the first user-visible PR.
+
+## Decision
+
+AO owns the public device contract and delegates narrowly defined mechanics to
+pinned open-source helpers.
+
+```text
+React device panel          ao device
+         |                      |
+         +---- typed daemon API-+
+                        |
+              Go device service
+              policy / auth / lifecycle
+                 |             |
+       allowlisted proxy     typed RPC adapter
+                 |             |
+       expo-device-hub      agent-device
+          live stream       inspect + act
+                 \             /
+                  existing Xcode / Android SDK
+```
+
+The Go daemon owns:
+
+- platform-neutral device, session, capability, and action types;
+- capability discovery and display-safe diagnostics;
+- session-scoped authorization and device ownership;
+- helper startup, readiness, restart, teardown, and stale-process recovery;
+- every route and operation allowlist exposed to the renderer or CLI;
+- validation, timeouts, size limits, rate limits, and API error mapping.
+
+The renderer remains a thin client. The `ao device` CLI is another thin client
+to the same daemon routes; it never invokes `simctl`, `adb`, an emulator, or a
+helper directly.
+
+### Selected helpers
+
+The first implementation will evaluate and pin these exact versions behind the
+AO boundary:
+
+- `expo-device-hub@0.9.0` for live iOS/Android display transport and basic
+  pointer input;
+- `agent-device@0.20.10` for token-efficient accessibility snapshots and typed
+  device actions.
+
+The helpers are build-time dependencies of the desktop artifact, not software
+downloaded with `npx` or installed from the registry on first use. Their entire
+resolved npm graph must be locked and integrity checked. AO runs them with its
+pinned Node 22 runtime and does not depend on a user's Node installation.
+
+Xcode, iOS Simulator runtimes, Android SDK tools, Android system images, and
+AVDs are **not** bundled or installed by AO. Capability discovery points the
+user to Xcode or Android Studio when one is missing.
+
+This is conditional approval, not permission to package the audited tarballs
+unchanged. The audit found architecture, minimum-OS, code-signing, and state
+confinement gates that the feature PR must close.
+
+### Supported host contract
+
+The initial verified target is Apple Silicon macOS 14 or newer. AO continues to
+build and work on Intel macOS, but the iOS streaming artifact in
+`expo-device-hub@0.9.0` is intentionally arm64-only. The feature must report a
+clear unavailable capability on an unsupported host; it must never attempt to
+load the wrong Mach-O binary or break the rest of AO.
+
+Intel device support requires a separately reviewed backend, such as an
+AO-owned `simctl` screenshot transport, or upstream universal/x64 artifacts.
+It is not achieved by copying or translating the arm64 binaries.
+
+Windows and Linux keep only the neutral daemon seam in this release. They do
+not advertise device support. Later Android adapters may implement the same
+contract without changing the renderer or agent command vocabulary.
+
+### Security and network boundary
+
+Both helpers bind random ports on `127.0.0.1` only. Their ports and credentials
+stay inside the daemon and are never returned to the renderer or an agent.
+
+`expo-device-hub` is unauthenticated and includes vendor routes that can execute
+commands. AO therefore does not publish its origin wholesale. A daemon-owned
+reverse proxy forwards only the exact read, stream, and input routes required
+by the product, constrains methods, strips credentials and hop-by-hop headers,
+and rejects every dashboard, shell/exec, application-install, remote, and
+unrecognized route.
+
+`agent-device` runs in loopback HTTP mode with a random bearer token stored in
+an AO-owned `0600` state file. Only the Go adapter holds that token. It sends a
+fixed catalog of typed requests and does not expose the helper's CLI, MCP
+server, generic RPC method, upload endpoints, cloud providers, or arbitrary
+flags.
+
+All `/api/v1/devices` routes are added to the LAN listener's outer
+`lanControlBlockedPrefixes` gate. This remains true even though the opt-in LAN
+listener has bearer authentication: local virtual-device control is a desktop
+and local-agent capability, not a Connect Mobile capability.
+
+Agent requests use the existing browser-capability pattern: `AO_SESSION_ID`
+selects the owning session, `AO_DEVICE_CAPABILITY` carries an unguessable token,
+and `X-AO-Device-Capability` presents it to the daemon. AO stores only a
+session-bound verifier and rotates the capability with each supervised worker
+generation. The renderer uses its privileged desktop bridge and cannot mint
+agent capabilities.
+
+### State and process boundary
+
+Every helper state, cache, claim, lease, log, and temporary path must resolve
+under `<AO_DATA_DIR>/devices`. The feature sets every supported agent-device
+path override explicitly and adds an integration test that fails on a write
+outside the AO-owned root. A helper defaulting to `~/.agent-device` is a release
+blocker, not an exception to AO's state-location rule.
+
+AO records enough PID identity to distinguish an owned helper from a recycled
+PID before cleanup. It terminates only helpers it started, waits with bounded
+timeouts, escalates process-tree termination when required, and treats failed
+or unknown probes as unknown rather than proof that a device is dead. AO does
+not claim ownership of Xcode's Simulator processes, Android Studio, `adb`, or
+emulators that the user started elsewhere.
+
+Transient frames and display status are not durable state. Device availability
+and running state are derived from live helper/platform facts. Durable storage
+is limited to consent/settings and session capability verifiers if restart
+recovery requires them.
+
+### Scope of the first user-visible device PR
+
+The first feature PR includes both human and agent access to:
+
+- status and missing-prerequisite diagnostics;
+- device discovery;
+- boot/open, attach, close, and explicit device shutdown;
+- live view or the explicitly documented fallback transport;
+- screenshot capture;
+- accessibility/UI-tree inspection;
+- tap, swipe, text, key, and back/home actions supported by the target.
+
+It also adds `ao device ...` commands and the matching embedded
+`using-ao/commands/device.md` page in the same PR. There is no partial release
+where the panel can control a device but an authorized agent cannot.
+
+The first feature PR does not install SDKs or simulator runtimes, create AVDs,
+build projects, install application packages, automate signing/provisioning,
+control physical devices, or add remote/SSH device hosts.
+
+## Consequences
+
+AO gets mature native mechanics without making a Node helper its product API.
+The daemon can replace either helper later while retaining its public DTOs and
+agent workflow.
+
+The desktop artifact grows by roughly 49 MB unpacked for the audited combined
+npm tree before packaging compression. Native resources must participate in
+AO's per-architecture build, signing, notarization, license, and artifact
+verification gates.
+
+The initial support matrix is narrower than "all Macs." That is preferable to
+silently shipping arm64 binaries in AO's Intel build. A future Intel backend
+can be added behind the same capability model.
+
+AO becomes responsible for tracking two upstream releases and their transitive
+dependency/license changes. Version bumps require rerunning the prerequisite
+audit, reviewing route and filesystem behavior, and updating the lockfile and
+integrity manifest together.

--- a/docs/research/2026-09-13-local-device-runtime-prerequisites.md
+++ b/docs/research/2026-09-13-local-device-runtime-prerequisites.md
@@ -1,0 +1,368 @@
+# Local virtual-device runtime prerequisite audit
+
+Date: 2026-09-13
+Status: Evidence for the proposed device-runtime architecture; no runtime is
+shipped by this document.
+
+## Question
+
+Can AO use existing open-source components to add local iOS Simulator and
+Android Emulator control on macOS without violating AO's daemon, security,
+state, packaging, or cross-platform boundaries?
+
+## Conclusion
+
+Yes, conditionally. `expo-device-hub` and `agent-device` are strong building
+blocks, but the current artifacts cannot be copied into AO unchanged.
+
+- The architecture fits AO if the Go daemon owns the public API, authorization,
+  process lifecycle, route allowlists, and error normalization.
+- The audited licenses permit redistribution, subject to retaining license and
+  notice material and meeting the `node-datachannel` MPL-2.0 obligations.
+- AO's pinned Node 22.23.2 satisfies the helpers' declared requirements.
+- The exact Expo iOS binaries are arm64-only and require macOS 14 or newer.
+  The initial verified feature target must therefore be Apple Silicon macOS
+  14+, unless another iOS capture transport is implemented and tested.
+- Both helpers can start without SDKs present and report missing-tool facts, but
+  their raw diagnostics are not safe public errors.
+- The helper npm graph has an install script and native binaries. AO must build
+  and verify a locked, per-architecture runtime during packaging; it must not
+  run npm or download helpers on first use.
+- Live iOS/Android device acceptance remains a feature-PR gate because the
+  audit machine had neither full Xcode nor the Android SDK/emulator toolchain.
+
+This prerequisite PR deliberately adds no device API, CLI, skill page, UI, or
+packaged dependency. Those surfaces must land atomically in the first
+user-visible device PR.
+
+## Sources and reproducibility
+
+The audit used immutable versions and commits:
+
+| Component | Version / revision | Source |
+| --- | --- | --- |
+| Existing AO Android experiment | PR #3882, open at audit time | [Untrivial-ai/agent-orchestrator#3882](https://github.com/Untrivial-ai/agent-orchestrator/pull/3882) |
+| T3 Code local-device reference | PR #10677, merged 2026-09-10 | [pingdotgg/t3code#10677](https://github.com/pingdotgg/t3code/pull/10677) |
+| T3 helper selection | `expo-device-hub@0.9.0`, `agent-device@0.20.10` | [DeviceToolchain.ts at the reviewed T3 commit](https://github.com/pingdotgg/t3code/blob/3486451525ecaf3a8379aa6d08c885c7cc5335e3/apps/server/src/device/DeviceToolchain.ts) |
+| Expo Device Hub | npm `0.9.0`, git `87c2037f517bbbae76a1bb7bdca8324fd6d4272e` | [Expo source at the npm git head](https://github.com/expo/expo-device-hub/tree/87c2037f517bbbae76a1bb7bdca8324fd6d4272e) |
+| Vendored Expo serve-sim | git `55fec25295316e9757bf376c136275b59aea3df5` | [Expo serve-sim source](https://github.com/expo/serve-sim/tree/55fec25295316e9757bf376c136275b59aea3df5) |
+| Agent Device | npm `0.20.10`, git `fda81c5121f0a4307966040c763bfb5edf0ccdf3` | [Callstack source at the npm git head](https://github.com/callstack/agent-device/tree/fda81c5121f0a4307966040c763bfb5edf0ccdf3) |
+| Apple platform prerequisites | Current Apple documentation | [Downloading and installing additional Xcode components](https://developer.apple.com/documentation/xcode/downloading-and-installing-additional-xcode-components) |
+| Android platform prerequisites | Current Android documentation | [SDK command-line tools](https://developer.android.com/tools) and [emulator acceleration](https://developer.android.com/studio/run/emulator-acceleration) |
+
+Registry metadata and tarballs were queried with:
+
+```text
+npm view <package>@<version> name version license repository engines dependencies dist gitHead --json
+npm pack expo-device-hub@0.9.0 agent-device@0.20.10 --json
+```
+
+The tarballs were unpacked under a temporary directory. Their manifests,
+licenses, executable formats, load commands, and minimum OS versions were
+inspected with `jq`, `file`, `otool`, `vtool`, and `codesign`. A temporary npm
+install supplied the resolved dependency graph and smoke-test runtime.
+
+## Artifact identity
+
+| Package | npm integrity | SHA-1 shasum | Packed / unpacked | Declared license |
+| --- | --- | --- | --- | --- |
+| `expo-device-hub@0.9.0` | `sha512-zDiSNQIKldjat1emL5X5/XCMMtVbXGtQYkQYlnK77CxtEaRBQKqKbBxjKF3+qtpMAPKxGZYOvc9uk4HmYdO3sg==` | `8d7c32ed21ab5b8c4c6118f6c86a5b8d71c6cba0` | 9,317,432 / 19,540,126 bytes | MIT |
+| `agent-device@0.20.10` | `sha512-baj3tQQ1JH/FbJ3x3FVmSn4nctOlFmdYsiz4LNZh3rEOj/8g3hkIq07lcUii07lMSQ7hCiY1m8+SyWPAX1ykow==` | `67715507e377c00abe3173e319407472d3f8a01b` | 913,655 / 3,121,970 bytes | MIT |
+
+Both registry records carried npm signatures. Expo's record also carried an
+npm SLSA provenance attestation. These facts help establish origin; they do not
+replace AO's checked-in lockfile, per-file integrity manifest, or source review.
+
+Installing both packages together resolved 68 npm packages and occupied about
+49 MB unpacked on the audit host. The exact total will change if caret-ranged
+transitives are resolved again, which is why a reproducible AO build must use a
+committed lockfile and `npm ci` rather than two direct version pins alone.
+
+## License inventory
+
+The resolved temporary lock contained:
+
+| SPDX declaration | Package count |
+| --- | ---: |
+| MIT | 46 |
+| Apache-2.0 | 11 |
+| ISC | 7 |
+| MPL-2.0 | 1 |
+| BSD-3-Clause | 1 |
+| `(BSD-2-Clause OR MIT OR Apache-2.0)` | 1 |
+| `(MIT OR WTFPL)` | 1 |
+
+No GPL, AGPL, SSPL, or source-available-only declaration appeared in the
+resolved package manifests.
+
+Material findings:
+
+- `expo-device-hub` is MIT and ships its license in the tarball.
+- Its vendored `serve-sim` and `serve-emu` copies are Apache-2.0 and ship their
+  license files. `serve-sim` also ships its attribution `NOTICE`.
+- The bundled LiveKit WebRTC framework contains a WebRTC BSD-style license in
+  `Resources/LICENSE.webrtc`; binary redistribution requires keeping it.
+- `agent-device` is MIT and ships its license.
+- `node-datachannel@0.32.3`, used for Android WebRTC, declares MPL-2.0. AO must
+  preserve its license and make the corresponding covered source available as
+  required when distributing the executable form. If the package is pruned to
+  binaries, the release process must retain a source/notice path rather than
+  silently dropping it.
+- `agent-device` also ships Android helper APKs and Apple runner source. They
+  are part of the reviewed distribution and must be covered by the packaged
+  third-party notice and integrity manifest.
+
+This is an engineering inventory, not legal advice. The release PR should have
+the final third-party notice and MPL handling reviewed before publication.
+
+## Runtime and architecture compatibility
+
+`agent-device@0.20.10` declares Node `>=22.12`. The AO desktop already builds a
+per-platform Node 22.23.2 runtime, so no user-installed Node is needed. Expo
+Device Hub declares no top-level engine, while its pinned serve-sim revision
+documents Node 20+.
+
+The Expo tarball's native files were inspected directly:
+
+| Artifact | Mach-O target | Minimum OS | Finding |
+| --- | --- | --- | --- |
+| `serve-sim-native.node` | macOS arm64 | macOS 14.0 | Required for iOS native capture; ad-hoc signed upstream |
+| `LiveKitWebRTC` | macOS arm64 | macOS 11.0 | Runtime framework; ad-hoc signed upstream |
+| `serve-sim-camera-helper` | macOS arm64 | macOS 14.0 | Optional camera injection helper |
+| `serve-sim-ax-settings` | iOS Simulator arm64 | iOS 15.0 | Runs inside the simulator |
+| `libSimCameraInjector.dylib` | iOS Simulator arm64 | iOS 15.0 | Optional camera injection payload |
+| `node_datachannel.node` from the audit install | macOS arm64 | macOS 14.0 | Native WebRTC dependency; produced by an npm install script |
+
+This is intentional upstream behavior, not a bad local download. The exact
+serve-sim source declares `cpu: ["arm64"]`, documents Apple Silicon as a
+requirement, and has tests that reject non-arm64 packages. Expo's outer
+`expo-device-hub` manifest does not carry that CPU constraint even though it
+vendors those binaries. AO must therefore add its own packaging and runtime
+architecture checks.
+
+AO currently publishes separate `darwin-arm64` and `darwin-x64` artifacts. The
+device runtime must be an optional, target-specific resource so an unsupported
+helper can never make the Intel app fail to package, sign, start, or update.
+The honest initial capability matrix is:
+
+| AO host | iOS Simulator | Android Emulator | Rest of AO |
+| --- | --- | --- | --- |
+| Apple Silicon, macOS 14+ | Candidate, pending live E2E | Candidate, pending live E2E | Unchanged |
+| Apple Silicon, older macOS | Unavailable: native minimum OS | Unavailable for the audited live runtime | Unchanged |
+| Intel macOS | Unavailable until a compatible iOS transport exists | May be technically possible, but not release-verified in this stack | Unchanged |
+| Windows / Linux | Not in the first release | Later adapter | Unchanged |
+
+## Installation and packaging findings
+
+A temporary install completed and both CLI help paths ran. The npm client
+reported that `node-datachannel@0.32.3` has this install script:
+
+```text
+prebuild-install -r napi || (npm install --ignore-scripts --production=false && npm run _prebuild)
+```
+
+The installed native addon imported successfully on the arm64 audit host.
+Nevertheless, arbitrary dependency install scripts must remain disabled. The
+feature packaging step must explicitly allow only this reviewed package, then
+assert the resulting target architecture, minimum OS, and loadability with the
+packaged Node runtime.
+
+Recommended packaging rules for the feature PR:
+
+1. Add a dedicated, committed runtime manifest and lockfile containing the two
+   direct versions and their full transitive graph.
+2. Build with AO's normal artifact job on the target architecture; never
+   install at end-user runtime.
+3. Allow only the reviewed `node-datachannel` install script.
+4. Copy a minimal runtime to `Contents/Resources/device-runtime` (or the
+   equivalent platform resource directory) with all required licenses/notices.
+5. Generate and verify a SHA-256 manifest for entry scripts, native modules,
+   frameworks, helper binaries, and APK payloads.
+6. Fail packaging if any executable has the wrong architecture, unexpected
+   minimum OS, missing dependency, missing license, or unresolved dynamic
+   library.
+7. Re-sign all nested Mach-O code with AO's release identity before the outer
+   app seal, then use the existing canonical macOS artifact verifier after
+   packaging and notarization.
+8. Assert the runtime is absent or capability-disabled on unsupported AO
+   targets without affecting application startup.
+
+The feature may share AO's pinned Node distribution, but it should not couple
+the Go device service to an "ACP-only" filesystem detail. The packaging layer
+must expose a stable internal Node-runtime path used by both subsystems, or
+document and test the existing resource path as a shared runtime contract.
+
+## Runtime smoke evidence
+
+Audit host:
+
+```text
+macOS 26.4 arm64
+Node 26.8.1 for the temporary install/smoke
+Xcode Command Line Tools only; no simctl
+Android SDK/emulator tools absent
+```
+
+Observed results:
+
+- `expo-device-hub --help` and `agent-device --help` completed.
+- Expo Device Hub started on the explicitly supplied `127.0.0.1` address and
+  answered `/api/devices` with HTTP 200.
+- With platform tools absent, its response contained raw command failures,
+  absolute user paths, command lines, and JavaScript stack traces. AO must map
+  these to bounded codes such as `XCODE_REQUIRED` and `ANDROID_SDK_REQUIRED`;
+  the raw body must never be returned directly or persisted as telemetry.
+- Agent Device started its HTTP daemon on a random `127.0.0.1` port. Its
+  `daemon.json` mode was `0600` and contained a random token. `/rpc` returned
+  HTTP 401 for both missing and invalid bearer tokens. `/health` was readable
+  without a token.
+- Agent Device stopped cleanly through its daemon command.
+
+The smoke confirms basic process and loopback behavior only. It does not prove
+frame streaming, input, UI snapshots, concurrent ownership, crash recovery, or
+packaged-app code signing.
+
+## Lessons from the T3 reference
+
+T3 Code PR #10677 proves that the two helpers can support one coherent local
+device experience, including an agent path, in a substantial product PR. It
+does not prove that the change was independent: the PR was based on the shared
+wizard foundation in [#10832](https://github.com/pingdotgg/t3code/pull/10832),
+while multi-host and SSH work was stacked above it in
+[#10854](https://github.com/pingdotgg/t3code/pull/10854)-[#10856](https://github.com/pingdotgg/t3code/pull/10856).
+AO follows the same dependency discipline by putting this
+non-feature prerequisite below one complete macOS feature PR and keeping later
+host adapters above it.
+
+The reusable ideas are the split between streaming and agent automation,
+loopback helper processes, explicit readiness, stale-process cleanup, a strict
+same-origin allowlist, and separate consent/capability state. AO intentionally
+does not copy T3's runtime npm installation: the requested AO product bundles
+the helpers, and AO's release process already has architecture, signing,
+notarization, integrity, and offline-start requirements that are better checked
+at build time.
+
+T3's route comments also confirm why a raw proxy is unacceptable: serve-sim
+has an exec surface and serve-emu action routes are not independently
+authenticated. The helper origin is an implementation detail even when it
+binds loopback.
+
+## Existing AO Android experiment
+
+AO PR #3882 remains useful implementation evidence for Android SDK detection,
+emulator process-tree supervision, readiness/crash behavior, gRPC input/frame
+transport, UI integration, and real-device failure cases. At audit time it was
+an open 126-file change with 21,579 additions, an Android-specific public API,
+AO-managed SDK downloads, and no iOS implementation.
+
+The new feature should reuse focused tests and platform lessons from that PR,
+not merge it wholesale or preserve its public `/android-device` contract. In
+particular, the following findings remain applicable regardless of helper:
+
+- an emulator launcher PID is not the entire process tree;
+- readiness must race process exit and retain the last bounded diagnostic;
+- stale AVD locks can survive a crash;
+- Android ABI names and emulator CPU architecture names are not interchangeable;
+- a tap requires both touch-down and touch-up;
+- long-running setup must not inherit an HTTP request's cancellation context.
+
+SDK download/install and AO-owned AVD creation are outside the newly fixed
+scope. The neutral `/devices` service and existing-SDK-only behavior supersede
+those parts of #3882.
+
+## Security findings
+
+### Expo Device Hub
+
+The standalone CLI defaults to `127.0.0.1`, but accepts `--host 0.0.0.0` and
+does not authenticate callers. Its vendored surface includes more authority
+than AO needs, including serve-sim exec/WebSocket behavior and device/app
+management routes. AO must always pass an explicit loopback host and must proxy
+a positive allowlist rather than a path prefix or the full origin.
+
+At minimum, the feature review must prove:
+
+- no helper origin, port, PID, or token reaches a renderer response;
+- HTTP method checks happen before forwarding;
+- input WebSockets require the same AO session authority as REST mutations;
+- cookies, AO bearer tokens, host, origin, and hop-by-hop headers do not leak
+  upstream;
+- redirects and unknown paths are not forwarded;
+- the LAN listener returns its ordinary 404 envelope for every device prefix.
+
+### Agent Device
+
+The daemon's HTTP mode is loopback and bearer-protected for RPC, but its RPC
+catalog is much broader than AO's first release. AO must use a private adapter
+with a fixed mapping for the selected commands. It must not expose `/rpc`,
+upload/download routes, MCP, remote providers, arbitrary output paths, or the
+agent-device binary to the worker.
+
+Set `AGENT_DEVICE_NO_UPDATE_NOTIFIER=1` and do not enable cloud authentication,
+remote configuration, companion tunnels, or update checks. The Go service must
+redact helper diagnostics and bound returned accessibility/screenshot data.
+
+## State-location findings
+
+`AGENT_DEVICE_STATE_DIR` relocates the daemon's primary state, but source
+inspection found other defaults under `~/.agent-device`, including device
+claims, Apple runner leases/derived products, configuration, helper/cache, and
+some diagnostic paths. The feature must set every applicable supported
+override beneath `<AO_DATA_DIR>/devices`:
+
+- `AGENT_DEVICE_STATE_DIR`;
+- `AGENT_DEVICE_CLAIMS_DIR`;
+- `AGENT_DEVICE_IOS_RUNNER_LEASE_DIR`;
+- `AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH`;
+- `AGENT_DEVICE_SWIFT_CACHE_DIR`;
+- `AGENT_DEVICE_CONFIG` when config loading cannot be disabled.
+
+The exact list is not assumed complete. A feature-PR confinement test must run
+the real helper workflow with filesystem observation and fail if any new path
+outside the AO root appears. If an unavoidable active code path has no override,
+AO must patch upstream, contribute the override, or defer that capability.
+
+Temporary files created by system libraries remain subject to OS conventions,
+but durable AO-owned state, caches, snapshots, and helper products do not.
+
+## AO architecture fit
+
+The helpers fit only behind these existing boundaries:
+
+- Go daemon service for policy and lifecycle;
+- ports/adapters for helper processes and platform probes;
+- code-first HTTP DTOs and generated OpenAPI/frontend types;
+- session-bound capability verifier modeled on `service/browser/authority.go`;
+- thin Cobra client over daemon HTTP;
+- thin renderer over the generated client;
+- embedded `using-ao` command documentation added with the CLI;
+- `<AO_DATA_DIR>` for all owned state;
+- `lanControlBlockedPrefixes` for the entire device API.
+
+The public DTOs must not contain Expo routes, agent-device flags, `simctl`
+payloads, ADB payloads, or Node concepts. That keeps a later Windows/Linux
+Android adapter and a future helper replacement possible without a client
+redesign.
+
+## Release gates for the feature PR
+
+The audited stack is approved for implementation only after the feature PR
+proves all of the following:
+
+- [ ] Exact locked dependency graph and integrity manifest are checked in.
+- [ ] Third-party license/notice bundle is complete, including MPL-2.0 handling.
+- [ ] Target architecture and minimum-OS checks fail packaging closed.
+- [ ] Nested native code survives AO signing, notarization, and artifact verification.
+- [ ] Packaged Node, not system Node/npm, starts both helpers.
+- [ ] Every helper socket is loopback-only and internal to the daemon.
+- [ ] Expo proxy and Agent Device RPC allowlists have negative-path tests.
+- [ ] Every device route is physically unreachable from the LAN listener.
+- [ ] Agent capabilities rotate and cannot cross sessions.
+- [ ] Real helper workflows write durable data only under `AO_DATA_DIR`.
+- [ ] Missing SDKs return bounded, display-safe capability diagnostics.
+- [ ] Real Apple Silicon macOS E2E covers iOS and Android discovery, boot,
+      stream, screenshot, UI tree, input, close, shutdown, and daemon restart.
+- [ ] Intel and unsupported-OS builds keep all non-device AO functionality and
+      report explicit unsupported capability.
+
+Any unchecked item is a release blocker, not follow-up polish.

--- a/docs/superpowers/specs/2026-09-13-local-device-support-design.md
+++ b/docs/superpowers/specs/2026-09-13-local-device-support-design.md
@@ -1,0 +1,480 @@
+# Local iOS Simulator and Android Emulator Support Design
+
+Date: 2026-09-13
+Status: Proposed implementation plan for the first user-visible device PR.
+
+## Goal
+
+On a supported Mac, AO users and the agent in the current AO session can share
+an existing local iOS Simulator or Android Emulator: discover it, boot or
+attach, see its screen, inspect accessible UI, act on it, take evidence, and
+release or explicitly shut it down.
+
+The first user-visible device PR is complete only when the agent-control path
+ships with the desktop path. The prerequisite documentation PR is intentionally
+not counted as that feature PR.
+
+## Fixed scope
+
+### Included
+
+- Apple Silicon macOS 14+ as the first verified host.
+- Existing Xcode/iOS Simulator and Android SDK/AVD installations.
+- iOS Simulator and Android Emulator discovery.
+- Boot, attach/open, close/detach, and explicit shutdown.
+- Live display through a daemon-controlled stream proxy.
+- Screenshot and accessibility/UI-tree capture.
+- Tap/press, swipe/scroll, text/fill, key, back, and home where supported.
+- One selected device attachment per AO session, isolated from other sessions.
+- A Device panel for the user.
+- An `ao device` CLI and embedded `using-ao` command page for the agent.
+- Capability-only unsupported results on Intel macOS, older macOS, Windows,
+  Linux, and hosts missing the vendor SDKs.
+
+### Excluded
+
+- Downloading Xcode, Simulator runtimes, Android SDK tools, system images, or
+  AVDs.
+- Creating or editing AVDs.
+- Project detection, builds, application install/reinstall, app-data reset,
+  signing, provisioning, TestFlight, or store deployment.
+- Physical iOS or Android devices.
+- Remote, SSH, cloud, CI, or LAN-hosted device control.
+- Generic `simctl`, `adb`, shell, helper CLI, helper RPC, or MCP access.
+- Windows/Linux Android execution in this PR.
+- Camera, location, push-notification, logcat, network, profiling, recording,
+  replay, and deep-link surfaces in this PR.
+
+Those omissions keep the first feature focused on a safe inspect-act-verify
+loop. They can be added as separately authorized actions after this boundary is
+proven.
+
+## Support matrix
+
+| Host | iOS Simulator | Android Emulator | Result |
+| --- | --- | --- | --- |
+| Apple Silicon macOS 14+ with full Xcode | Enabled | Depends on Android SDK | First verified target |
+| Apple Silicon macOS 14+ without full Xcode | `XCODE_REQUIRED` | Depends on Android SDK | Android may still be enabled |
+| Apple Silicon macOS 14+ without Android SDK/emulator | Depends on Xcode | `ANDROID_SDK_REQUIRED` | iOS may still be enabled |
+| Apple Silicon macOS below 14 | `HOST_OS_UNSUPPORTED` | `HOST_OS_UNSUPPORTED` for audited runtime | AO otherwise works |
+| Intel macOS | `HOST_ARCH_UNSUPPORTED` | Not release-verified; unavailable in this PR | AO otherwise works |
+| Windows / Linux | `HOST_PLATFORM_UNSUPPORTED` | `NOT_IMPLEMENTED` | Later adapters reuse the public contract |
+
+Availability is per platform. A missing Android installation must not disable
+iOS, and a missing Xcode installation must not disable Android.
+
+## User experience
+
+The session inspector gains a Device tab. It has four states:
+
+1. **Unavailable** — shows the exact host/platform reason and a link to the
+   official Xcode or Android Studio instructions. There is no AO Install button.
+2. **No device selected** — lists discovered simulators/emulators with platform,
+   model, runtime/API, boot state, and busy state.
+3. **Starting** — shows bounded boot/attachment progress and a Cancel action.
+4. **Attached** — shows the live device, connection quality, screenshot action,
+   input controls, Close, and a separately confirmed Shut down action.
+
+Opening an already booted device attaches without claiming AO started it.
+Opening a stopped device requests the platform tool to boot it and then waits
+for readiness. Closing always releases the AO attachment and helper session; it
+does not power off the simulator/emulator. Shutting down is explicit and warns
+that it affects other tools using that virtual device.
+
+The panel stops its stream when hidden but keeps the session attachment so the
+agent can continue. Returning to the tab requests a new short-lived stream
+ticket and reconnects.
+
+## Architecture
+
+### Package ownership
+
+Add neutral domain vocabulary under `backend/internal/domain`:
+
+- `DevicePlatform`: `ios`, `android`;
+- `DeviceKind`: `simulator`, `emulator`;
+- `DeviceID`, `DeviceAttachmentID`;
+- lifecycle facts: `stopped`, `booting`, `booted`, `unavailable`, `unknown`;
+- capability and supported-action values.
+
+Do not place Expo paths, Agent Device commands, `simctl` JSON, ADB output, HTTP
+DTOs, or UI labels in the domain package.
+
+Add narrow ports under `backend/internal/ports`:
+
+```go
+type DeviceHost interface {
+    Capabilities(context.Context) ([]DevicePlatformCapability, error)
+    List(context.Context) ([]Device, error)
+    Boot(context.Context, DeviceID) error
+    Shutdown(context.Context, DeviceID) error
+}
+
+type DeviceRuntime interface {
+    Attach(context.Context, AttachRequest) (Attachment, error)
+    Snapshot(context.Context, AttachmentID, SnapshotOptions) (Snapshot, error)
+    Screenshot(context.Context, AttachmentID) (Screenshot, error)
+    Act(context.Context, AttachmentID, DeviceAction) (ActionResult, error)
+    Detach(context.Context, AttachmentID) error
+}
+```
+
+The exact Go types may combine these interfaces if the real call sites are
+simpler, but public and domain types remain helper-neutral.
+
+Concrete process/protocol code belongs under
+`backend/internal/adapters/device`. The adapter may use:
+
+- Expo Device Hub for device inventory, boot coordination, stream bytes, and
+  basic stream input;
+- Agent Device's authenticated loopback daemon for accessibility snapshots,
+  element refs/selectors, screenshots, and typed actions;
+- small official platform probes only when needed to validate helper results.
+
+The device service under `backend/internal/service/device` owns capability
+derivation, attachment leases, authorization, lifecycle, retries, and public
+error mapping. The helpers never become service interfaces.
+
+### Helper runtime
+
+The feature PR adds a dedicated manifest/lock and packaging preparation script
+following the existing agent-browser and ACP-runtime patterns:
+
+```text
+frontend/device-runtime/
+├── package.json
+└── package-lock.json
+
+frontend/resources/device-runtime/
+├── node_modules/...
+├── licenses/...
+└── integrity.json
+```
+
+The generated resource directory stays uncommitted; the manifest, lockfile,
+preparation script, tests, and license inventory are committed. Packaging runs
+`npm ci` with install scripts denied except for the reviewed
+`node-datachannel` build, verifies every expected entry/native payload, and
+copies the resource through `extraResourcesForPlatform` only on supported
+targets.
+
+Use AO's Node 22.23.2 distribution. If the existing ACP resource is shared,
+rename or wrap its lookup as a general internal Node runtime contract rather
+than making device code know an ACP-specific path. Do not ship a second Node
+copy without an artifact-size comparison and explicit justification.
+
+The packaging tests assert:
+
+- exact `expo-device-hub@0.9.0` and `agent-device@0.20.10` entrypoints;
+- lockfile integrity and approved install-script set;
+- licenses/notices and SHA-256 manifest;
+- Mach-O architecture and minimum OS;
+- dynamic library resolution;
+- packaged-Node imports and CLI help;
+- target exclusion on unsupported platforms;
+- nested code signing and canonical artifact verification.
+
+### Helper supervision
+
+Helpers start lazily on the first supported device operation, not at daemon
+startup. The daemon passes explicit environment and argv:
+
+```text
+<node> expo-device-hub/dist/server/cli.mjs
+  --host 127.0.0.1 --port <reserved> --hide-sidebar --hide-boot-device
+
+AGENT_DEVICE_STATE_DIR=<AO_DATA_DIR>/devices/agent-device
+AGENT_DEVICE_CLAIMS_DIR=<AO_DATA_DIR>/devices/agent-device/claims
+AGENT_DEVICE_IOS_RUNNER_LEASE_DIR=<AO_DATA_DIR>/devices/agent-device/apple-runner/leases
+AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH=<AO_DATA_DIR>/devices/agent-device/apple-runner/derived
+AGENT_DEVICE_SWIFT_CACHE_DIR=<AO_DATA_DIR>/devices/agent-device/swift-cache
+AGENT_DEVICE_CONFIG=<AO_DATA_DIR>/devices/agent-device/config.json
+AGENT_DEVICE_DAEMON_SERVER_MODE=http
+AGENT_DEVICE_DAEMON_IDLE_TIMEOUT_MS=0
+AGENT_DEVICE_NO_UPDATE_NOTIFIER=1
+```
+
+Both ports are reserved on `127.0.0.1`, readiness is bounded, and the Agent
+Device token is read from its `0600` state file without logging it. PID state
+contains executable identity and process start time so stale cleanup does not
+kill a recycled PID. Repeated crashes use a bounded backoff and eventually
+surface `DEVICE_RUNTIME_UNAVAILABLE` rather than restart forever.
+
+Daemon shutdown detaches AO helper sessions and stops both helpers. It does not
+kill Simulator.app, Android Studio, `adb`, or a virtual device unless AO is
+executing an explicit, authorized shutdown request.
+
+## Authorization model
+
+Every device API operation requires one of two principals:
+
+- **Agent principal:** `AO_SESSION_ID` plus a fresh
+  `AO_DEVICE_CAPABILITY`, presented as `X-AO-Device-Capability`. The daemon
+  validates it against a session-bound verifier in constant time.
+- **Desktop principal:** an Electron-main-only runtime token handed to the
+  daemon out of band and attached by typed main-process IPC. The renderer never
+  receives the token and cannot set arbitrary helper requests.
+
+The token implementation follows the existing browser capability authority and
+worker-generation rotation. A device capability authorizes only its session;
+it does not authorize a specific device until `open` establishes an
+attachment. Cross-session attachment or action returns a generic not-found or
+conflict result without leaking another session's details.
+
+The service permits at most one controlling AO attachment per virtual device.
+Other sessions can list the device as busy but cannot inspect its app, screen,
+or owner identity. Close, session termination, worker replacement, and daemon
+shutdown release the AO attachment.
+
+All `/api/v1/devices` paths are blocked at the LAN listener before LAN auth.
+There is no exception for read-only inventory or stream traffic.
+
+## HTTP contract
+
+Keep the public API small and action-oriented, similar to the browser runtime:
+
+```text
+GET  /api/v1/devices/status?sessionId=<id>
+GET  /api/v1/devices?sessionId=<id>
+POST /api/v1/devices/commands
+POST /api/v1/devices/stream-tickets
+GET  /api/v1/devices/streams/<ticket>
+```
+
+`DeviceCommandRequest` contains `sessionId`, an enum action, and a typed union
+of action arguments. It does not accept commands, argv, paths, URLs, helper
+routes, environment, output filenames, or vendor-specific options.
+
+Initial actions:
+
+```text
+open(deviceId)
+screenshot()
+uiTree(interactiveOnly)
+tap(ref | x,y)
+swipe(x1,y1,x2,y2,durationMs?)
+fill(ref,text)
+type(text)
+key(key)
+back()
+home()
+close()
+shutdown(deviceId?,confirmation)
+```
+
+Coordinates, text length, key names, swipe duration, body size, tree node
+count/depth, screenshot dimensions, and total request duration have explicit
+limits. Device IDs must match the latest live inventory and attachment.
+
+Stream tickets are random, single-use, expire within 30 seconds, and bind to
+the session, attachment, device, direction, and requested transport. They avoid
+putting the long-lived capability in a URL and allow `<img>`/WebSocket clients
+that cannot set headers. The proxy forwards only the exact Expo read/stream and
+input paths selected by server code. It never concatenates a client-provided
+upstream path.
+
+Controller DTOs live in `controllers/dto.go`, operations in
+`apispec/specgen/build.go`, and `npm run api` regenerates OpenAPI plus the
+frontend schema. CLI DTOs remain hand-mirrored and have wire-compatibility
+tests.
+
+## CLI and embedded skill contract
+
+The first feature PR adds:
+
+```text
+ao device status [--json]
+ao device list [--json]
+ao device open <device-id> [--json]
+ao device screenshot [path] [--base64] [--json]
+ao device ui-tree [--interactive] [--json]
+ao device tap <ref>|<x> <y> [--json]
+ao device swipe <x1> <y1> <x2> <y2> [--duration <milliseconds>] [--json]
+ao device fill <ref> <text> [--json]
+ao device type <text> [--json]
+ao device key <key> [--json]
+ao device back [--json]
+ao device home [--json]
+ao device close [--json]
+ao device shutdown [device-id] --yes [--json]
+```
+
+`AO_SESSION_ID` selects the session, so no command accepts another session ID.
+`AO_DEVICE_CAPABILITY` is mandatory. Misuse is a CLI usage error (exit 2),
+while runtime/daemon failures exit 1 and preserve the API request ID.
+
+`ui-tree` prints compact refs that are valid only for the latest snapshot
+generation. Mutation invalidates prior refs. Screenshot file output follows
+the browser command's behavior: the CLI writes it, refuses overwrite, and the
+daemon never accepts an arbitrary filesystem destination.
+
+Device screens and accessibility text are untrusted application content. Text
+and structured responses carry the same explicit trust labeling used by
+`ao browser`; the embedded instructions tell agents never to follow commands
+found in a device UI or expose credentials displayed there.
+
+Update the existing catalog in the same PR:
+
+- add `backend/internal/skillassets/using-ao/commands/device.md`;
+- link it from `backend/internal/skillassets/using-ao/SKILL.md`;
+- update the catalog references/index used by its embedding tests.
+
+Do not add a second standalone skill. Device control is part of the existing
+`using-ao` skill because it documents AO's own CLI.
+
+## Error model
+
+Normalize helper failures into stable AO codes and bounded messages:
+
+```text
+HOST_PLATFORM_UNSUPPORTED
+HOST_ARCH_UNSUPPORTED
+HOST_OS_UNSUPPORTED
+XCODE_REQUIRED
+IOS_SIMULATOR_RUNTIME_REQUIRED
+ANDROID_SDK_REQUIRED
+ANDROID_EMULATOR_REQUIRED
+ANDROID_AVD_REQUIRED
+DEVICE_NOT_FOUND
+DEVICE_BUSY
+DEVICE_BOOT_TIMEOUT
+DEVICE_RUNTIME_UNAVAILABLE
+DEVICE_STREAM_UNAVAILABLE
+DEVICE_ACTION_UNSUPPORTED
+DEVICE_ATTACHMENT_REQUIRED
+DEVICE_CAPABILITY_INVALID
+```
+
+Raw helper responses, stack traces, absolute home paths, bearer tokens, ports,
+PIDs, and command lines remain in bounded debug logs only after redaction. API
+errors use AO's normal envelope and request ID.
+
+## State and lifecycle
+
+Persist only:
+
+- device feature setting/consent if product onboarding needs it;
+- per-session device capability verifier;
+- minimal owned-helper recovery identity if filesystem state is insufficient.
+
+Do not persist device lists, boot status, frames, UI trees, screenshots,
+attachment display status, helper ports, or tokens in SQLite. Derive them from
+live facts. Helper-owned state stays under `<AO_DATA_DIR>/devices` with private
+permissions.
+
+A daemon restart leaves user-owned virtual devices running, reaps only verified
+stale helper processes, starts clean helpers lazily, and requires the session
+to reattach. Unknown platform probes produce `unknown`/unavailable facts, not a
+claim that the virtual device is dead.
+
+## Implementation order inside the feature PR
+
+Keep the feature as one user-visible PR based on this prerequisite PR, with
+reviewable conventional commits in this order:
+
+1. `build:` locked helper runtime, license bundle, architecture/integrity tests.
+2. `feat:` neutral domain, ports, capability probes, and helper supervisors.
+3. `feat:` attachment service, Agent Device adapter, and Expo allowlisted proxy.
+4. `feat:` session capability minting/rotation, LAN block, controller, DTOs,
+   OpenAPI, and generated frontend types.
+5. `feat:` `ao device` commands and embedded `using-ao` documentation.
+6. `feat:` Electron main IPC and the session Device panel.
+7. `test:` packaged-runtime, failure, concurrency, and real-device coverage.
+8. `docs:` user-facing support matrix, setup, privacy, and troubleshooting.
+
+The branch may be kept as a draft while early commits are incomplete. It is not
+ready for review or release until the CLI/skill and Device panel both exercise
+the same complete daemon capability set.
+
+## Test plan
+
+### Backend and CLI
+
+- capability matrix across OS, architecture, SDK presence, and probe failure;
+- parsing and redaction of representative Expo, `simctl`, ADB, and Agent Device
+  responses;
+- helper argv/environment, loopback binding, readiness, crash backoff, stale
+  PID protection, and teardown;
+- positive proxy paths plus every rejected route/method/header/redirect case;
+- Agent Device command mapping and proof generic RPC/upload/cloud operations
+  cannot be selected;
+- attachment exclusivity, cross-session denial, capability rotation, session
+  end, daemon restart, and explicit shutdown confirmation;
+- input/tree/frame/body/time bounds;
+- LAN 404 for every `/api/v1/devices` path;
+- happy path, usage errors, API envelopes, request IDs, and screenshot
+  no-overwrite behavior for every CLI command;
+- API route/schema parity and embedded skill frontmatter/link coverage.
+
+### Frontend and Electron main
+
+- unavailable reason and official setup-link rendering;
+- independent iOS/Android capability states;
+- device inventory, busy state, boot/cancel/error transitions;
+- stream ticket mint, reconnect, expiry, panel-hide cleanup, and target switch;
+- pointer/keyboard action conversion without renderer-supplied helper paths;
+- screenshot and UI-tree states;
+- close versus confirmed shutdown semantics;
+- Electron main holds the desktop token and exposes only typed device IPC;
+- no regression on unsupported macOS, Windows, or Linux builds.
+
+### Packaging and release
+
+- reproducible `npm ci` from the committed device lockfile;
+- dependency license inventory and notice bundle drift;
+- native architecture, minimum OS, dynamic libraries, and integrity manifest;
+- packaged Node startup and native module import;
+- arm64 signed/notarized zip and dmg through
+  `frontend/scripts/verify-mac-artifact.sh`;
+- x64 package starts and updates with device runtime absent/unavailable;
+- artifact-size delta recorded in the PR.
+
+### Manual acceptance on an isolated Mac
+
+Use an isolated `AO_DATA_DIR` and the real Electron app. Test both iOS and
+Android with at least one stopped and one already-running virtual device:
+
+1. detect prerequisites and list devices;
+2. boot, wait ready, attach, and display the live screen;
+3. inspect the UI and act by ref plus coordinates;
+4. type/fill, key, back/home, and swipe;
+5. take a screenshot through UI and CLI;
+6. repeat the same inspect-act-verify loop from an authorized agent;
+7. prove a second AO session cannot take over the attachment;
+8. close without powering off, reattach, then explicitly shut down;
+9. restart the daemon and recover without killing the virtual device;
+10. kill each helper and verify bounded recovery/error behavior;
+11. inspect sockets and filesystem writes for loopback/state confinement;
+12. verify missing-Xcode and missing-Android-SDK states separately.
+
+The acceptance report records macOS version, Mac architecture, Xcode version,
+iOS runtime/device, Android SDK/emulator version, AVD/API/ABI, AO artifact, and
+every command/check result.
+
+## Stacked PR sequence
+
+The work is stacked intentionally:
+
+```text
+main
+  └─ prerequisite architecture/license audit (this PR; no feature surface)
+       └─ macOS local-device feature (first user-visible PR; UI + agent together)
+            ├─ Intel macOS capture backend, if selected
+            ├─ Windows Android adapter
+            └─ Linux Android adapter
+```
+
+Each follow-up targets the branch directly below it until its parent merges,
+then retargets to the new base. Remote device hosts, SDK installation, and
+build/deploy workflows remain separate product decisions rather than implicit
+parts of the Windows/Linux adapters.
+
+## Definition of done
+
+The first user-visible PR is done when all release gates in
+[the prerequisite audit](../../research/2026-09-13-local-device-runtime-prerequisites.md)
+are checked and a fresh supported AO desktop artifact lets both the user and
+the authorized session agent complete the same iOS and Android
+inspect-act-verify workflow without exposing helper internals, crossing session
+boundaries, reaching the LAN listener, writing outside `AO_DATA_DIR`, or
+regressing unsupported AO builds.


### PR DESCRIPTION
## Summary

- define the AO-owned architecture and security boundary for local iOS Simulator and Android Emulator support
- record reproducible dependency, license, integrity, architecture, state-location, and runtime-smoke findings for the selected open-source helpers
- specify the first user-visible PR contract, including desktop and agent control, `ao device` commands, the existing `using-ao` skill update, test gates, and the subsequent stacked PR sequence

## Important compatibility finding

`expo-device-hub@0.9.0` currently ships an arm64-only macOS iOS native payload. The first verified device release is therefore scoped to Apple Silicon macOS 14+; AO remains supported on Intel Macs, but the device feature must report itself unavailable there until a compatible capture backend is added.

## Validation

- `git diff --cached --check`
- neutral-environment `npm run lint` (backend `go test ./...` plus golangci-lint): passed
- `npm run frontend:typecheck`: passed
- helper package metadata, license inventory, native binary inspection, and loopback smoke checks recorded in the audit document
- `npx @redwoodjs/agent-ci run --all`: not runnable locally because this host has no `/var/run/docker.sock`; remote PR checks will be used for that gate

## Scope

Documentation and prerequisite research only. This PR intentionally adds no runtime, API, CLI, skill, or UI behavior.