### PR TITLE
test(desktop): make nightly update assertion timezone independent

### DIFF
--- a/frontend/src/renderer/components/RestartToUpdateDialog.test.tsx
+++ b/frontend/src/renderer/components/RestartToUpdateDialog.test.tsx
@@ -64,7 +64,10 @@ it("shows what the build changes", async () => {
 		releaseNotes: "Fixed the re-stage loop\nRebuilt the Updates page",
 	});
 	expect(await screen.findByText(/Fixed the re-stage loop/)).toBeVisible();
-	expect(screen.getByText("Nightly 0.12.11 · Sep 2")).toBeVisible();
+	const expected = new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(
+		new Date(Date.UTC(2026, 8, 2, 17, 13)),
+	);
+	expect(screen.getByText(`Nightly 0.12.11 · ${expected}`)).toBeVisible();
 	expect(screen.queryByText(/Leave AO closed until it reopens/)).toBeNull();
 });
 


### PR DESCRIPTION
## What

Make the nightly build-date assertion in RestartToUpdateDialog timezone-independent.

## Why

Fixes #5283. The hardcoded Sep 2 expectation fails when the build instant falls on Sep 3 in the device's timezone.

## How

Derive the expected label from the fixed UTC build instant using Intl.DateTimeFormat, matching the neighboring regression test.

Sidebar no longer contains the reported hardcoded assertion, so no change is needed there.

## Testing

- Reproduced the original failure with TZ=Asia/Seoul.
- Focused suite: 16 passed under both TZ=UTC and TZ=Asia/Seoul.
- Full frontend suite under TZ=Asia/Seoul: 4486 passed, 6 skipped.
- Frontend typecheck and E2E typecheck passed.
- Full cross-platform CI and runtime E2E have not been verified.

## Checklist

- [x] Branched from main
- [x] One focused change; links the related issue
- [ ] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated where appropriate
- [ ] Relevant CI checks pass for the area touched
