### PR TITLE
fix(kiro): never run the model-discovery CLI while signed out

### DIFF
--- a/backend/internal/adapters/agent/authprobe/authprobe.go
+++ b/backend/internal/adapters/agent/authprobe/authprobe.go
@@ -2,6 +2,8 @@ package authprobe
 
 import (
 	"context"
+	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +15,40 @@ import (
 // It is exposed as a package variable to allow mocking in tests.
 var CmdRunner = func(ctx context.Context, name string, arg ...string) ([]byte, error) {
 	return aoprocess.CommandContext(ctx, name, arg...).CombinedOutput()
+}
+
+// CmdRunnerEnv is CmdRunner with an environment overlay applied over the
+// daemon's own. A probe whose answer gates a command that will itself run with
+// a project-scoped environment must observe that same environment, or it
+// reports on credentials the real command would never have used.
+var CmdRunnerEnv = func(ctx context.Context, env map[string]string, name string, arg ...string) ([]byte, error) {
+	cmd := aoprocess.CommandContext(ctx, name, arg...)
+	if len(env) > 0 {
+		cmd.Env = mergedEnvironment(os.Environ(), env)
+	}
+	return cmd.CombinedOutput()
+}
+
+func mergedEnvironment(base []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	out := make([]string, 0, len(base)+len(overrides))
+	for _, item := range base {
+		key, _, _ := strings.Cut(item, "=")
+		if _, replaced := overrides[key]; !replaced {
+			out = append(out, item)
+		}
+	}
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		out = append(out, key+"="+overrides[key])
+	}
+	return out
 }
 
 // CLIStatus runs bounded local CLI probes and classifies their output.

--- a/backend/internal/adapters/agent/kiro/auth.go
+++ b/backend/internal/adapters/agent/kiro/auth.go
@@ -12,33 +12,56 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-var _ ports.AgentAuthChecker = (*Plugin)(nil)
+var (
+	_ ports.AgentAuthChecker        = (*Plugin)(nil)
+	_ ports.AgentAuthCheckerWithEnv = (*Plugin)(nil)
+)
 
 // kiroAuthProbeTimeout bounds `whoami` so a broken install cannot stall the
 // callers that gate real work on this answer.
 const kiroAuthProbeTimeout = 3 * time.Second
 
-// AuthStatus returns the plugin's local authentication status.
+// AuthStatus returns the plugin's local authentication status in the daemon's
+// own environment.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
+	return p.AuthStatusInEnv(ctx, nil)
+}
+
+// AuthStatusInEnv answers for the environment a command would run in, with env
+// layered over the daemon's own. Kiro reads KIRO_API_KEY from the environment
+// and `whoami` resolves credentials from it too, so a project-scoped
+// environment can authenticate a session the daemon's own environment cannot
+// see. Answering without it would report a signed-in agent as signed out.
+func (p *Plugin) AuthStatusInEnv(ctx context.Context, env map[string]string) (ports.AgentAuthStatus, error) {
 	binary, err := p.kiroBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	if strings.TrimSpace(os.Getenv("KIRO_API_KEY")) != "" {
+	if kiroAPIKey(env) != "" {
 		return ports.AgentAuthStatusAuthorized, nil
 	}
-	return kiroWhoamiAuthStatus(ctx, binary)
+	return kiroWhoamiAuthStatus(ctx, binary, env)
 }
 
-func kiroWhoamiAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {
+// kiroAPIKey prefers the overlay, then the daemon's environment, matching how
+// the merged environment a real command receives would resolve it.
+func kiroAPIKey(env map[string]string) string {
+	if value, ok := env["KIRO_API_KEY"]; ok {
+		return strings.TrimSpace(value)
+	}
+	return strings.TrimSpace(os.Getenv("KIRO_API_KEY"))
+}
+
+func kiroWhoamiAuthStatus(ctx context.Context, binary string, env map[string]string) (ports.AgentAuthStatus, error) {
 	if binary == "" {
 		return ports.AgentAuthStatusUnknown, nil
 	}
 	// Kiro documents `whoami` as its authentication-status command. Keep the
-	// probe bounded so catalog refresh cannot hang on a broken CLI install.
+	// probe bounded so catalog refresh cannot hang on a broken CLI install, and
+	// run it under the same environment the gated command would use.
 	probeCtx, cancel := context.WithTimeout(ctx, kiroAuthProbeTimeout)
 	defer cancel()
-	out, runErr := authprobe.CmdRunner(probeCtx, binary, "whoami", "--format", "json")
+	out, runErr := authprobe.CmdRunnerEnv(probeCtx, env, binary, "whoami", "--format", "json")
 	if ctx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, ctx.Err()
 	}

--- a/backend/internal/adapters/agent/kiro/auth.go
+++ b/backend/internal/adapters/agent/kiro/auth.go
@@ -1,15 +1,22 @@
 package kiro
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
+
+// kiroAuthProbeTimeout bounds `whoami` so a broken install cannot stall the
+// callers that gate real work on this answer.
+const kiroAuthProbeTimeout = 3 * time.Second
 
 // AuthStatus returns the plugin's local authentication status.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
@@ -29,5 +36,59 @@ func kiroWhoamiAuthStatus(ctx context.Context, binary string) (ports.AgentAuthSt
 	}
 	// Kiro documents `whoami` as its authentication-status command. Keep the
 	// probe bounded so catalog refresh cannot hang on a broken CLI install.
-	return authprobe.CLIStatus(ctx, binary, [][]string{{"whoami", "--format", "json"}})
+	probeCtx, cancel := context.WithTimeout(ctx, kiroAuthProbeTimeout)
+	defer cancel()
+	out, runErr := authprobe.CmdRunner(probeCtx, binary, "whoami", "--format", "json")
+	if ctx.Err() != nil {
+		return ports.AgentAuthStatusUnknown, ctx.Err()
+	}
+	if status, ok := kiroStatusFromWhoami(out); ok {
+		return status, nil
+	}
+	if runErr != nil {
+		return ports.AgentAuthStatusUnknown, nil
+	}
+	// Unrecognized shape: defer to the shared prose classifier rather than
+	// guessing. Unknown is not a denial — callers must not read it as "logged out".
+	return authprobe.StatusFromText(string(out)), nil
+}
+
+// kiroStatusFromWhoami classifies `kiro-cli whoami --format json`.
+//
+// The generic keyword classifier cannot read this output: signed out prints
+// `{"account":null}` and signed in prints an account object, neither of which
+// contains any of the phrases it looks for, so both classified as unknown — a
+// probe that could never distinguish the two states. Signed-in output is also
+// followed by a plain-text "Profile:" block, so the payload as a whole is not
+// valid JSON; decoding only the leading value skips that trailer.
+func kiroStatusFromWhoami(out []byte) (ports.AgentAuthStatus, bool) {
+	var payload map[string]json.RawMessage
+	if err := json.NewDecoder(bytes.NewReader(out)).Decode(&payload); err != nil {
+		return "", false
+	}
+	if raw, ok := payload["account"]; ok {
+		if isJSONNull(raw) {
+			return ports.AgentAuthStatusUnauthorized, true
+		}
+		return ports.AgentAuthStatusAuthorized, true
+	}
+	// Older/other builds report the identity inline instead of under "account".
+	for _, key := range []string{"email", "accountType", "startUrl"} {
+		if raw, ok := payload[key]; ok && !isJSONNull(raw) && !isEmptyJSONString(raw) {
+			return ports.AgentAuthStatusAuthorized, true
+		}
+	}
+	return "", false
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return string(bytes.TrimSpace(raw)) == "null"
+}
+
+func isEmptyJSONString(raw json.RawMessage) bool {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return false
+	}
+	return strings.TrimSpace(s) == ""
 }

--- a/backend/internal/adapters/agent/kiro/auth_whoami_test.go
+++ b/backend/internal/adapters/agent/kiro/auth_whoami_test.go
@@ -23,13 +23,16 @@ arn:aws:codewhisperer:us-east-1:111122223333:profile/ABCDEF
 `
 )
 
-func withRunner(t *testing.T, out string, err error) {
+func withRunner(t *testing.T, out string, err error) *map[string]string {
 	t.Helper()
-	original := authprobe.CmdRunner
-	authprobe.CmdRunner = func(context.Context, string, ...string) ([]byte, error) {
+	seen := new(map[string]string)
+	original := authprobe.CmdRunnerEnv
+	authprobe.CmdRunnerEnv = func(_ context.Context, env map[string]string, _ string, _ ...string) ([]byte, error) {
+		*seen = env
 		return []byte(out), err
 	}
-	t.Cleanup(func() { authprobe.CmdRunner = original })
+	t.Cleanup(func() { authprobe.CmdRunnerEnv = original })
+	return seen
 }
 
 func TestKiroWhoamiAuthStatus(t *testing.T) {
@@ -48,8 +51,8 @@ func TestKiroWhoamiAuthStatus(t *testing.T) {
 		{"empty identity fields stay unknown", `{"email":"  "}`, ports.AgentAuthStatusUnknown},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			withRunner(t, tc.out, nil)
-			got, err := kiroWhoamiAuthStatus(context.Background(), "kiro-cli")
+			_ = withRunner(t, tc.out, nil)
+			got, err := kiroWhoamiAuthStatus(context.Background(), "kiro-cli", nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -63,8 +66,8 @@ func TestKiroWhoamiAuthStatus(t *testing.T) {
 // A signed-out answer is worth trusting even when the CLI exits non-zero,
 // because that is the state AO must not run `chat --list-models` in.
 func TestKiroWhoamiClassifiesSignedOutDespiteExitCode(t *testing.T) {
-	withRunner(t, signedOutWhoami, context.DeadlineExceeded)
-	got, err := kiroWhoamiAuthStatus(context.Background(), "kiro-cli")
+	_ = withRunner(t, signedOutWhoami, context.DeadlineExceeded)
+	got, err := kiroWhoamiAuthStatus(context.Background(), "kiro-cli", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -74,11 +77,37 @@ func TestKiroWhoamiClassifiesSignedOutDespiteExitCode(t *testing.T) {
 }
 
 func TestKiroWhoamiWithoutBinaryIsUnknown(t *testing.T) {
-	got, err := kiroWhoamiAuthStatus(context.Background(), "")
+	got, err := kiroWhoamiAuthStatus(context.Background(), "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got != ports.AgentAuthStatusUnknown {
 		t.Fatalf("status = %q, want unknown", got)
+	}
+}
+
+// The probe must run under the same environment the gated command would use,
+// or it reports on credentials that command would never have seen.
+// https://github.com/Untrivial-ai/agent-orchestrator/pull/5321#discussion_r3999115728
+func TestKiroWhoamiRunsUnderTheGivenEnvironment(t *testing.T) {
+	seen := withRunner(t, signedOutWhoami, nil)
+	env := map[string]string{"AWS_PROFILE": "work"}
+	if _, err := kiroWhoamiAuthStatus(context.Background(), "kiro-cli", env); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if (*seen)["AWS_PROFILE"] != "work" {
+		t.Fatalf("probe ran with env %#v, want the caller's overlay", *seen)
+	}
+}
+
+// A project-scoped KIRO_API_KEY authenticates the agent even though the
+// daemon's own environment has none, so the probe must not shell out at all.
+func TestKiroAPIKeyFromProjectEnvIsAuthorized(t *testing.T) {
+	t.Setenv("KIRO_API_KEY", "")
+	if got := kiroAPIKey(map[string]string{"KIRO_API_KEY": "project-key"}); got != "project-key" {
+		t.Fatalf("kiroAPIKey = %q, want the project overlay value", got)
+	}
+	if got := kiroAPIKey(nil); got != "" {
+		t.Fatalf("kiroAPIKey = %q, want empty when neither source sets it", got)
 	}
 }

--- a/backend/internal/adapters/agent/kiro/auth_whoami_test.go
+++ b/backend/internal/adapters/agent/kiro/auth_whoami_test.go
@@ -1,0 +1,84 @@
+package kiro
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// The two payloads below are verbatim from kiro-cli on macOS: the signed-out
+// one measured against 2.21.0, the signed-in one reported in #5048 against
+// 2.21.1 (identifiers redacted). Neither contains a phrase the shared prose
+// classifier looks for, so before this both answered "unknown" and the probe
+// could not tell the states apart.
+const (
+	signedOutWhoami = `{"account":null}`
+	signedInWhoami  = `{"accountType":"IamIdentityCenter","email":"user@example.com","region":"eu-west-1","startUrl":"https://d-abc.awsapps.com/start"}
+
+Profile:
+KiroProfile-us-east-1
+arn:aws:codewhisperer:us-east-1:111122223333:profile/ABCDEF
+`
+)
+
+func withRunner(t *testing.T, out string, err error) {
+	t.Helper()
+	original := authprobe.CmdRunner
+	authprobe.CmdRunner = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(out), err
+	}
+	t.Cleanup(func() { authprobe.CmdRunner = original })
+}
+
+func TestKiroWhoamiAuthStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		want ports.AgentAuthStatus
+	}{
+		{"signed out reports unauthorized", signedOutWhoami, ports.AgentAuthStatusUnauthorized},
+		{"signed in reports authorized despite the non-JSON profile trailer", signedInWhoami, ports.AgentAuthStatusAuthorized},
+		{"account object present means signed in", `{"account":{"id":"abc"}}`, ports.AgentAuthStatusAuthorized},
+		// Never invent a denial from output we do not recognize: unknown keeps
+		// discovery working rather than silently disabling it.
+		{"unrecognized shape stays unknown", `{"somethingElse":1}`, ports.AgentAuthStatusUnknown},
+		{"non-JSON stays unknown", `command not found`, ports.AgentAuthStatusUnknown},
+		{"empty identity fields stay unknown", `{"email":"  "}`, ports.AgentAuthStatusUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withRunner(t, tc.out, nil)
+			got, err := kiroWhoamiAuthStatus(context.Background(), "kiro-cli")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A signed-out answer is worth trusting even when the CLI exits non-zero,
+// because that is the state AO must not run `chat --list-models` in.
+func TestKiroWhoamiClassifiesSignedOutDespiteExitCode(t *testing.T) {
+	withRunner(t, signedOutWhoami, context.DeadlineExceeded)
+	got, err := kiroWhoamiAuthStatus(context.Background(), "kiro-cli")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ports.AgentAuthStatusUnauthorized {
+		t.Fatalf("status = %q, want unauthorized", got)
+	}
+}
+
+func TestKiroWhoamiWithoutBinaryIsUnknown(t *testing.T) {
+	got, err := kiroWhoamiAuthStatus(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ports.AgentAuthStatusUnknown {
+		t.Fatalf("status = %q, want unknown", got)
+	}
+}

--- a/backend/internal/adapters/agent/kiro/kiro_test.go
+++ b/backend/internal/adapters/agent/kiro/kiro_test.go
@@ -976,11 +976,22 @@ func containsSubsequence(values []string, needle []string) bool {
 	return false
 }
 
+// stubKiroAuthRunner intercepts the auth probe. Kiro runs `whoami` through the
+// env-aware runner so the probe observes the same environment the gated command
+// would, so both entry points are stubbed — leaving either live would let a test
+// shell out to the real Kiro CLI.
 func stubKiroAuthRunner(t *testing.T, runner func(context.Context, string, ...string) ([]byte, error)) func() {
 	t.Helper()
 	previous := authprobe.CmdRunner
+	previousEnv := authprobe.CmdRunnerEnv
 	authprobe.CmdRunner = runner
-	return func() { authprobe.CmdRunner = previous }
+	authprobe.CmdRunnerEnv = func(ctx context.Context, _ map[string]string, name string, arg ...string) ([]byte, error) {
+		return runner(ctx, name, arg...)
+	}
+	return func() {
+		authprobe.CmdRunner = previous
+		authprobe.CmdRunnerEnv = previousEnv
+	}
 }
 
 func countKiroHookCommand(entries []kiroHookEntry, command string) int {

--- a/backend/internal/adapters/agent/modelcatalog/catalog.go
+++ b/backend/internal/adapters/agent/modelcatalog/catalog.go
@@ -137,6 +137,25 @@ type Discoverer struct {
 	ClineOptions ClineConfigOptionListFunc
 }
 
+// RunsAgentCommand reports whether Discover executes the agent for this id.
+//
+// Claude Code and Muse return a static catalog and Discover never spawns for
+// them. Codex answers through its app-server, which does start the agent. The
+// command-backed adapters run their CLI by definition. Config-derived catalogs
+// only read files, so they are not reported here: under-reporting merely leaves
+// today's behavior in place, while over-reporting would let a caller suppress a
+// catalog that costs nothing to produce.
+func (Discoverer) RunsAgentCommand(agentID string) bool {
+	switch agentID {
+	case "claude-code", "muse":
+		return false
+	case "codex":
+		return true
+	}
+	_, ok := commandSpecs[agentID]
+	return ok
+}
+
 // CodexModelListFunc obtains Codex's account-scoped app-server catalog without
 // opening a provider thread.
 type CodexModelListFunc func(context.Context, ports.AgentModelDiscoveryRequest) ([]ports.ChatModel, error)

--- a/backend/internal/adapters/agent/modelcatalog/runs_agent_command_test.go
+++ b/backend/internal/adapters/agent/modelcatalog/runs_agent_command_test.go
@@ -1,0 +1,15 @@
+package modelcatalog
+
+import "testing"
+
+func TestRunsAgentCommandClassification(t *testing.T) {
+	for id, want := range map[string]bool{
+		"claude-code": false, "muse": false,
+		"codex": true, "kiro": true, "cursor": true, "devin": true,
+		"qwen": false, "goose": false, "amp": false,
+	} {
+		if got := (Discoverer{}).RunsAgentCommand(id); got != want {
+			t.Errorf("RunsAgentCommand(%q) = %v, want %v", id, got, want)
+		}
+	}
+}

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -65,6 +65,22 @@ type AgentAuthChecker interface {
 	AuthStatus(ctx context.Context) (AgentAuthStatus, error)
 }
 
+// AgentAuthCheckerWithEnv refines AgentAuthChecker for adapters whose
+// credentials can come from a project-scoped environment rather than only the
+// daemon's own.
+//
+// A caller that gates an agent command on auth must ask about the environment
+// that command will actually run in. AuthStatus alone answers for the daemon's
+// environment, so a project-supplied credential is invisible to it and the
+// agent looks signed out when it is not. Adapters that read credentials from
+// the environment should implement this; callers that apply an env overlay
+// should prefer it and must not treat a plain AuthStatus answer as authoritative
+// about an environment it never saw.
+type AgentAuthCheckerWithEnv interface {
+	AgentAuthChecker
+	AuthStatusInEnv(ctx context.Context, env map[string]string) (AgentAuthStatus, error)
+}
+
 // AgentBinaryResolver is the optional capability adapters expose when their
 // binary can be checked without constructing a real session launch command.
 type AgentBinaryResolver interface {

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -235,6 +235,12 @@ type AgentModelDiscoverer interface {
 	// stay cheap enough to compute before deciding to skip discovery.
 	CatalogFingerprint(ctx context.Context, request AgentModelDiscoveryRequest) string
 	Manual(agentID string) AgentModelCatalog
+	// RunsAgentCommand reports whether discovering this agent's catalog executes
+	// the agent itself. Static and config-derived catalogs do not, so a caller
+	// that declines discovery because of what running the agent might do has no
+	// reason to withhold those — and withholding them would remove a model list
+	// that was never at risk.
+	RunsAgentCommand(agentID string) bool
 }
 
 // AgentExitDetectionMode describes how AO learns that an agent CLI process

--- a/backend/internal/service/agent/catalog_test.go
+++ b/backend/internal/service/agent/catalog_test.go
@@ -1390,3 +1390,7 @@ func TestWarmModelCatalogsStartsAsynchronously(t *testing.T) {
 		t.Fatal("background warm did not finish")
 	}
 }
+
+// Test fakes stand in for command-backed adapters, which is the case the auth
+// gate applies to.
+func (f *fakeModelDiscoverer) RunsAgentCommand(string) bool { return true }

--- a/backend/internal/service/agent/model_discovery_auth_test.go
+++ b/backend/internal/service/agent/model_discovery_auth_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 // countingDiscoverer records whether AO actually executed an agent's CLI.
-type countingDiscoverer struct{ runs atomic.Int32 }
+type countingDiscoverer struct {
+	runs        atomic.Int32
+	runsCommand bool
+}
 
 func (d *countingDiscoverer) Discover(context.Context, ports.AgentModelDiscoveryRequest) (ports.AgentModelCatalog, error) {
 	d.runs.Add(1)
@@ -29,8 +32,12 @@ func (d *countingDiscoverer) Manual(agentID string) ports.AgentModelCatalog {
 	return ports.AgentModelCatalog{AgentID: agentID, Source: "manual"}
 }
 
+// runsCommand mirrors whether this agent's discovery executes the agent. The
+// gate only applies when it does.
+func (d *countingDiscoverer) RunsAgentCommand(string) bool { return d.runsCommand }
+
 func authGateService(status ports.AgentAuthStatus, authErr error) (*Service, *countingDiscoverer) {
-	discoverer := &countingDiscoverer{}
+	discoverer := &countingDiscoverer{runsCommand: true}
 	stub := &readinessTestAgent{
 		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
 		auth:    func(context.Context) (ports.AgentAuthStatus, error) { return status, authErr },
@@ -135,7 +142,7 @@ func TestUnknownAuthStatusStillRunsDiscovery(t *testing.T) {
 // run that would have worked.
 // https://github.com/Untrivial-ai/agent-orchestrator/pull/5321#discussion_r3999115728
 func TestProjectScopedCredentialIsHonoredBeforeBlocking(t *testing.T) {
-	discoverer := &countingDiscoverer{}
+	discoverer := &countingDiscoverer{runsCommand: true}
 	stub := &envAwareAgent{readinessTestAgent: &readinessTestAgent{
 		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
 		// The daemon's own environment has no key, so this is what a
@@ -166,7 +173,7 @@ func TestProjectScopedCredentialIsHonoredBeforeBlocking(t *testing.T) {
 // Still block when the project environment carries no credential either: the
 // overlay must not become a blanket excuse to skip the gate.
 func TestProjectEnvWithoutCredentialStillBlocks(t *testing.T) {
-	discoverer := &countingDiscoverer{}
+	discoverer := &countingDiscoverer{runsCommand: true}
 	stub := &envAwareAgent{readinessTestAgent: &readinessTestAgent{
 		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
 		auth: func(context.Context) (ports.AgentAuthStatus, error) {
@@ -188,7 +195,7 @@ func TestProjectEnvWithoutCredentialStillBlocks(t *testing.T) {
 // An adapter that can only answer for the daemon's environment must not block a
 // run whose environment it never saw.
 func TestEnvUnawareAdapterDoesNotBlockUnderAnOverlay(t *testing.T) {
-	discoverer := &countingDiscoverer{}
+	discoverer := &countingDiscoverer{runsCommand: true}
 	stub := &readinessTestAgent{
 		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
 		auth: func(context.Context) (ports.AgentAuthStatus, error) {
@@ -204,5 +211,35 @@ func TestEnvUnawareAdapterDoesNotBlockUnderAnOverlay(t *testing.T) {
 	}
 	if got := discoverer.runs.Load(); got != 1 {
 		t.Fatalf("discovery ran %d times, want 1 — a stale-environment answer must not block", got)
+	}
+}
+
+// Claude Code's catalog is static — Discover returns a fixed list and never
+// spawns anything, so it cannot start a sign-in. Gating it on auth would strip
+// the model picker from every signed-out Claude Code user to prevent a risk
+// that does not exist for them.
+func TestStaticCatalogIsNotGatedOnAuth(t *testing.T) {
+	discoverer := &countingDiscoverer{runsCommand: false}
+	stub := &readinessTestAgent{
+		resolve: func(context.Context) (string, error) { return "claude", nil },
+		auth: func(context.Context) (ports.AgentAuthStatus, error) {
+			return ports.AgentAuthStatusUnauthorized, nil
+		},
+	}
+	agents := []agentregistry.HarnessAgent{readinessHarness("claude-code", "Claude Code", stub)}
+	svc := newService(agents, nil, nil, discoverer)
+
+	catalog, err := svc.Models(context.Background(), "claude-code", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := discoverer.runs.Load(); got != 1 {
+		t.Fatalf("discovery ran %d times for a static catalog, want 1 even when signed out", got)
+	}
+	if len(catalog.Models) != 1 {
+		t.Fatalf("models = %d, want the static catalog a signed-out user still gets", len(catalog.Models))
+	}
+	if catalog.Warning != "" {
+		t.Fatalf("warning = %q, want none: nothing was withheld", catalog.Warning)
 	}
 }

--- a/backend/internal/service/agent/model_discovery_auth_test.go
+++ b/backend/internal/service/agent/model_discovery_auth_test.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
 	agentregistry "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/registry"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -35,6 +37,32 @@ func authGateService(status ports.AgentAuthStatus, authErr error) (*Service, *co
 	}
 	agents := []agentregistry.HarnessAgent{readinessHarness("kiro", "Kiro", stub)}
 	return newService(agents, nil, nil, discoverer), discoverer
+}
+
+// envAwareAgent models an adapter that can take its credential from the
+// project-scoped environment, as Kiro does with KIRO_API_KEY.
+type envAwareAgent struct {
+	*readinessTestAgent
+	sawEnv map[string]string
+}
+
+func (a *envAwareAgent) AuthStatusInEnv(ctx context.Context, env map[string]string) (ports.AgentAuthStatus, error) {
+	a.sawEnv = env
+	if strings.TrimSpace(env["KIRO_API_KEY"]) != "" {
+		return ports.AgentAuthStatusAuthorized, nil
+	}
+	return a.AuthStatus(ctx)
+}
+
+// staticProjects serves one project whose config carries the env overlay that
+// discovery — and therefore the auth gate — must run under.
+type staticProjects struct {
+	id  string
+	env map[string]string
+}
+
+func (p staticProjects) GetProject(context.Context, string) (domain.ProjectRecord, bool, error) {
+	return domain.ProjectRecord{ID: p.id, Path: "/tmp/project", Config: domain.ProjectConfig{Env: p.env}}, true, nil
 }
 
 // Discovery executes the agent's own CLI, and Kiro's discovery command is its
@@ -98,5 +126,83 @@ func TestUnknownAuthStatusStillRunsDiscovery(t *testing.T) {
 				t.Fatalf("discovery ran %d times, want 1", got)
 			}
 		})
+	}
+}
+
+// Discovery deliberately runs with the project-scoped environment, so the gate
+// must ask about that same environment. Asking about the daemon's own instead
+// reports a project-authenticated Kiro as signed out and suppresses a discovery
+// run that would have worked.
+// https://github.com/Untrivial-ai/agent-orchestrator/pull/5321#discussion_r3999115728
+func TestProjectScopedCredentialIsHonoredBeforeBlocking(t *testing.T) {
+	discoverer := &countingDiscoverer{}
+	stub := &envAwareAgent{readinessTestAgent: &readinessTestAgent{
+		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
+		// The daemon's own environment has no key, so this is what a
+		// non-env-aware question would have answered.
+		auth: func(context.Context) (ports.AgentAuthStatus, error) {
+			return ports.AgentAuthStatusUnauthorized, nil
+		},
+	}}
+	agents := []agentregistry.HarnessAgent{readinessHarness("kiro", "Kiro", stub)}
+	projects := staticProjects{id: "p1", env: map[string]string{"KIRO_API_KEY": "project-scoped-key"}}
+	svc := newService(agents, nil, projects, discoverer)
+
+	catalog, err := svc.Models(context.Background(), "kiro", "p1", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := discoverer.runs.Load(); got != 1 {
+		t.Fatalf("discovery ran %d times with a project-scoped credential, want 1", got)
+	}
+	if len(catalog.Models) != 1 {
+		t.Fatalf("models = %d, want the discovered catalog", len(catalog.Models))
+	}
+	if stub.sawEnv["KIRO_API_KEY"] != "project-scoped-key" {
+		t.Fatalf("auth check saw env %#v, want the project overlay discovery runs under", stub.sawEnv)
+	}
+}
+
+// Still block when the project environment carries no credential either: the
+// overlay must not become a blanket excuse to skip the gate.
+func TestProjectEnvWithoutCredentialStillBlocks(t *testing.T) {
+	discoverer := &countingDiscoverer{}
+	stub := &envAwareAgent{readinessTestAgent: &readinessTestAgent{
+		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
+		auth: func(context.Context) (ports.AgentAuthStatus, error) {
+			return ports.AgentAuthStatusUnauthorized, nil
+		},
+	}}
+	agents := []agentregistry.HarnessAgent{readinessHarness("kiro", "Kiro", stub)}
+	projects := staticProjects{id: "p1", env: map[string]string{"UNRELATED": "1"}}
+	svc := newService(agents, nil, projects, discoverer)
+
+	if _, err := svc.Models(context.Background(), "kiro", "p1", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := discoverer.runs.Load(); got != 0 {
+		t.Fatalf("discovery ran %d times for a signed-out agent, want 0", got)
+	}
+}
+
+// An adapter that can only answer for the daemon's environment must not block a
+// run whose environment it never saw.
+func TestEnvUnawareAdapterDoesNotBlockUnderAnOverlay(t *testing.T) {
+	discoverer := &countingDiscoverer{}
+	stub := &readinessTestAgent{
+		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
+		auth: func(context.Context) (ports.AgentAuthStatus, error) {
+			return ports.AgentAuthStatusUnauthorized, nil
+		},
+	}
+	agents := []agentregistry.HarnessAgent{readinessHarness("kiro", "Kiro", stub)}
+	projects := staticProjects{id: "p1", env: map[string]string{"SOMETHING": "1"}}
+	svc := newService(agents, nil, projects, discoverer)
+
+	if _, err := svc.Models(context.Background(), "kiro", "p1", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := discoverer.runs.Load(); got != 1 {
+		t.Fatalf("discovery ran %d times, want 1 — a stale-environment answer must not block", got)
 	}
 }

--- a/backend/internal/service/agent/model_discovery_auth_test.go
+++ b/backend/internal/service/agent/model_discovery_auth_test.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	agentregistry "github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/registry"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// countingDiscoverer records whether AO actually executed an agent's CLI.
+type countingDiscoverer struct{ runs atomic.Int32 }
+
+func (d *countingDiscoverer) Discover(context.Context, ports.AgentModelDiscoveryRequest) (ports.AgentModelCatalog, error) {
+	d.runs.Add(1)
+	return ports.AgentModelCatalog{AgentID: "kiro", Models: []ports.AgentModelInfo{{ID: "m1", Label: "M1"}}}, nil
+}
+
+func (d *countingDiscoverer) CatalogFingerprint(context.Context, ports.AgentModelDiscoveryRequest) string {
+	return "fp"
+}
+
+func (d *countingDiscoverer) Manual(agentID string) ports.AgentModelCatalog {
+	return ports.AgentModelCatalog{AgentID: agentID, Source: "manual"}
+}
+
+func authGateService(status ports.AgentAuthStatus, authErr error) (*Service, *countingDiscoverer) {
+	discoverer := &countingDiscoverer{}
+	stub := &readinessTestAgent{
+		resolve: func(context.Context) (string, error) { return "kiro-cli", nil },
+		auth:    func(context.Context) (ports.AgentAuthStatus, error) { return status, authErr },
+	}
+	agents := []agentregistry.HarnessAgent{readinessHarness("kiro", "Kiro", stub)}
+	return newService(agents, nil, nil, discoverer), discoverer
+}
+
+// Discovery executes the agent's own CLI, and Kiro's discovery command is its
+// chat entrypoint — `chat --list-models` — which starts a browser OAuth sign-in
+// when it finds no token. A signed-out agent must therefore never reach
+// Discover, or rendering a model picker can log the user in.
+// https://github.com/Untrivial-ai/agent-orchestrator/issues/5307
+func TestSignedOutAgentNeverRunsItsDiscoveryCommand(t *testing.T) {
+	svc, discoverer := authGateService(ports.AgentAuthStatusUnauthorized, nil)
+
+	catalog, err := svc.Models(context.Background(), "kiro", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := discoverer.runs.Load(); got != 0 {
+		t.Fatalf("discovery ran %d times for a signed-out agent, want 0", got)
+	}
+	// The caller still gets a usable catalog and is told why it is empty.
+	if !strings.Contains(catalog.Warning, "signed out") {
+		t.Fatalf("warning = %q, want it to explain the agent is signed out", catalog.Warning)
+	}
+	if !catalog.RefreshRecommended {
+		t.Fatal("want RefreshRecommended so the picker retries after the user signs in")
+	}
+}
+
+// Signing in must restore normal behavior with no further action.
+func TestSignedInAgentRunsItsDiscoveryCommand(t *testing.T) {
+	svc, discoverer := authGateService(ports.AgentAuthStatusAuthorized, nil)
+
+	catalog, err := svc.Models(context.Background(), "kiro", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := discoverer.runs.Load(); got != 1 {
+		t.Fatalf("discovery ran %d times for a signed-in agent, want 1", got)
+	}
+	if len(catalog.Models) != 1 {
+		t.Fatalf("models = %d, want the discovered catalog", len(catalog.Models))
+	}
+}
+
+// Unknown is not a denial. A probe that cannot tell must not silently disable
+// discovery — that would break model listing for every agent whose status AO
+// cannot read, which before the Kiro probe fix was Kiro itself in both states.
+func TestUnknownAuthStatusStillRunsDiscovery(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status ports.AgentAuthStatus
+		err    error
+	}{
+		{"probe cannot tell", ports.AgentAuthStatusUnknown, nil},
+		{"probe failed outright", ports.AgentAuthStatusUnauthorized, errors.New("probe exploded")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, discoverer := authGateService(tc.status, tc.err)
+			if _, err := svc.Models(context.Background(), "kiro", "", false); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := discoverer.runs.Load(); got != 1 {
+				t.Fatalf("discovery ran %d times, want 1", got)
+			}
+		})
+	}
+}

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -470,6 +470,12 @@ func (s *Service) discoverModels(
 	agentID string,
 	request ports.AgentModelDiscoveryRequest,
 ) (ports.AgentModelCatalog, error) {
+	// Only decline runs that would actually execute the agent. A static or
+	// config-derived catalog cannot start a sign-in, so gating it would strip a
+	// model list from a signed-out user for no benefit.
+	if !s.discoverer.RunsAgentCommand(agentID) {
+		return s.discoverer.Discover(ctx, request)
+	}
 	status, ok := s.discoveryAuthStatus(ctx, item, request)
 	if !ok {
 		return s.discoverer.Discover(ctx, request)

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -470,17 +470,49 @@ func (s *Service) discoverModels(
 	agentID string,
 	request ports.AgentModelDiscoveryRequest,
 ) (ports.AgentModelCatalog, error) {
-	checker, ok := item.Agent.(ports.AgentAuthChecker)
+	status, ok := s.discoveryAuthStatus(ctx, item, request)
 	if !ok {
 		return s.discoverer.Discover(ctx, request)
 	}
-	status, err := checker.AuthStatus(ctx)
-	if err == nil && status == ports.AgentAuthStatusUnauthorized {
+	if status == ports.AgentAuthStatusUnauthorized {
 		return ports.AgentModelCatalog{}, fmt.Errorf(
 			"%s is signed out, so AO did not run its model-discovery command: %w. Sign in to the agent, then refresh",
 			agentID, errAgentNotSignedIn)
 	}
 	return s.discoverer.Discover(ctx, request)
+}
+
+// discoveryAuthStatus reads the adapter's auth status for the environment the
+// discovery command would actually run in. The bool reports whether the answer
+// is usable at all.
+//
+// Discovery runs with a project-scoped environment overlay, and an adapter can
+// take credentials from it — Kiro reads KIRO_API_KEY that way. Asking an
+// adapter that only answers for the daemon's own environment would then report
+// a project-authenticated agent as signed out and suppress a discovery run that
+// would have succeeded. When an overlay is in play and the adapter cannot
+// account for it, this reports no usable answer rather than a wrong one.
+func (s *Service) discoveryAuthStatus(
+	ctx context.Context,
+	item agentregistry.HarnessAgent,
+	request ports.AgentModelDiscoveryRequest,
+) (ports.AgentAuthStatus, bool) {
+	if envChecker, ok := item.Agent.(ports.AgentAuthCheckerWithEnv); ok {
+		status, err := envChecker.AuthStatusInEnv(ctx, request.Env)
+		return status, err == nil
+	}
+	checker, ok := item.Agent.(ports.AgentAuthChecker)
+	if !ok {
+		return "", false
+	}
+	if len(request.Env) > 0 {
+		// The overlay could carry the very credential that authenticates this
+		// agent, and this adapter cannot be asked about it. Never block on an
+		// answer that describes a different environment.
+		return "", false
+	}
+	status, err := checker.AuthStatus(ctx)
+	return status, err == nil
 }
 
 func (s *Service) agent(agentID string) (agentregistry.HarnessAgent, bool) {

--- a/backend/internal/service/agent/service.go
+++ b/backend/internal/service/agent/service.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -278,7 +279,7 @@ func (s *Service) loadModels(ctx context.Context, agentID, projectID string, mod
 		return cached.Catalog, nil
 	}
 
-	discovered, discoverErr := s.discoverer.Discover(ctx, request)
+	discovered, discoverErr := s.discoverModels(ctx, item, agentID, request)
 	discovered = applyCustomModelEntryPolicy(discovered, policy)
 	discovered.BinaryVersion = version
 	if discoverErr != nil {
@@ -444,6 +445,42 @@ func (s *Service) saveCatalog(ctx context.Context, projectID string, catalog por
 		Source:        catalog.Source,
 		FetchedAt:     catalog.FetchedAt,
 	})
+}
+
+// errAgentNotSignedIn marks a discovery run AO declined to start. It flows
+// through the normal discovery-failure path, so the caller still gets the
+// cached, shared, or manual catalog exactly as it would for a failed run.
+var errAgentNotSignedIn = errors.New("agent is not signed in")
+
+// discoverModels runs the adapter's model-discovery command, unless the adapter
+// can tell us the agent is signed out.
+//
+// Discovery executes the agent's own CLI, and some of those commands are the
+// agent's interactive entrypoint: Kiro's is `chat --list-models`, which starts a
+// browser OAuth sign-in when it finds no token. Rendering a model picker must
+// never be able to do that, so an adapter that positively reports "signed out"
+// stops the run before it begins.
+//
+// Only an explicit Unauthorized blocks. Unknown means the probe could not tell,
+// which is not a denial — treating it as one would silently disable discovery
+// for every adapter whose probe is imprecise.
+func (s *Service) discoverModels(
+	ctx context.Context,
+	item agentregistry.HarnessAgent,
+	agentID string,
+	request ports.AgentModelDiscoveryRequest,
+) (ports.AgentModelCatalog, error) {
+	checker, ok := item.Agent.(ports.AgentAuthChecker)
+	if !ok {
+		return s.discoverer.Discover(ctx, request)
+	}
+	status, err := checker.AuthStatus(ctx)
+	if err == nil && status == ports.AgentAuthStatusUnauthorized {
+		return ports.AgentModelCatalog{}, fmt.Errorf(
+			"%s is signed out, so AO did not run its model-discovery command: %w. Sign in to the agent, then refresh",
+			agentID, errAgentNotSignedIn)
+	}
+	return s.discoverer.Discover(ctx, request)
 }
 
 func (s *Service) agent(agentID string) (agentregistry.HarnessAgent, bool) {


### PR DESCRIPTION
Fixes #5307 · Refs #5048

## The problem

Listing an agent's models executes that agent's own CLI. Kiro's discovery command is its **chat entrypoint**:

```go
// backend/internal/adapters/agent/modelcatalog/catalog.go:58
"kiro": {args: []string{"chat", "--list-models", "--format", "json"}, parser: parseJSONModels},
```

With no Kiro session that command starts a browser OAuth sign-in, so simply rendering a picker could open `app.kiro.dev/signin`.

Verified directly against the installed `kiro-cli 2.21.0`, with an isolated `HOME` and a stubbed browser opener (no real browser was launched, no account touched):

```
$ kiro-cli chat --list-models --format json      # signed out
⠿ Opening browser... | Press (^) + C to cancel
```

## Why not just ask Kiro not to open a browser

There is no way to. I checked all three:

| Avenue | Result |
| --- | --- |
| A `--no-browser` flag | `chat --help` has none |
| An env var | Only `KIRO_AUTH_PORTAL_URL` and autosuggest/router vars — no browser or headless switch |
| `--no-interactive` | **Tested — still opens the browser** |

So AO has to decline the run.

## Which needed a working auth probe first

`kiro-cli whoami --format json` reports:

```
signed out:  {"account":null}
signed in:   {"accountType":"IamIdentityCenter","email":"…", …}
             \n\nProfile:\nKiroProfile-…      <- plain text, so the whole payload is not valid JSON
```

Neither contains a phrase `authprobe.StatusFromText` matches, so **both states classified as `unknown`** — the probe could never distinguish them. (The signed-in half of that is [#5048](https://github.com/Untrivial-ai/agent-orchestrator/issues/5048); the signed-out half is measured here.) This decodes the leading JSON value instead, skipping the trailer.

## The gate

Discovery now skips the command for an agent that positively reports signed out, returning the cached, shared, or manual catalog through the **existing** discovery-failure path — so the fallback behavior is the one already in place and tested — with a warning explaining why and `RefreshRecommended` set.

Only an explicit `Unauthorized` blocks. `unknown` is not a denial: treating it as one would silently disable model listing for every adapter whose probe is imprecise — which, before this change, was Kiro itself in both states.

An explicit `kiro-cli login`, and launching Kiro as a worker or reviewer, are untouched.

## Tests

Both new files fail on `main` with exactly the reported shape:

```
--- FAIL: TestKiroWhoamiAuthStatus/signed_out_reports_unauthorized
        status = "unknown", want "unauthorized"
--- FAIL: TestKiroWhoamiAuthStatus/signed_in_reports_authorized_despite_the_non-JSON_profile_trailer
        status = "unknown", want "authorized"
--- FAIL: TestSignedOutAgentNeverRunsItsDiscoveryCommand
        discovery ran 1 times for a signed-out agent, want 0
```

The probe cases use the verbatim payloads above. The gate tests assert the negative (signed out ⇒ `Discover` never called) **and** both positives (signed in ⇒ called; `unknown` or a failed probe ⇒ still called), so this cannot be satisfied by disabling discovery.

Run locally: `go build ./...` clean; `go vet` clean; `golangci-lint` **0 issues**; `kiro`, `service/agent`, `authprobe`, `modelcatalog` packages all pass.

## Relationship to PR #5310

Independent, and this is the one that closes #5307. [#5310](https://github.com/Untrivial-ai/agent-orchestrator/pull/5310) stops the reviewer menu probing all 21 harnesses — worth having on its own merits, but it does not prevent the sign-in, since hovering Kiro would still trigger it. This does, whichever route reaches discovery. They do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
