### PR TITLE
fix(chat): keep controllers registered until StopAll detach finishes

### DIFF
--- a/backend/internal/service/chat/controller_test.go
+++ b/backend/internal/service/chat/controller_test.go
@@ -3695,6 +3695,37 @@ func TestServiceStopTerminatesPersistentConversation(t *testing.T) {
 	}
 }
 
+func TestServiceStopAllRetainsControllerUntilItsEventStreamActuallyEnds(t *testing.T) {
+	base := newFakeConversation()
+	h := newHarnessWithConversation(t, &stuckConversation{
+		fakeConversation: base,
+		closeErr:         errors.New("provider close failed"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	h.svc.StopAll(ctx)
+	if _, err := h.svc.Controller(testSession); err != nil {
+		t.Fatalf("controller was forgotten while its stream was still live: %v", err)
+	}
+	if !h.svc.HasLiveChatController(testSession) {
+		t.Fatal("live-controller guard cleared before the provider stream ended")
+	}
+
+	base.closeOnce.Do(func() { close(base.events) })
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := h.svc.Controller(testSession); errors.Is(err, chatsvc.ErrNoController) {
+			if h.svc.HasLiveChatController(testSession) {
+				t.Fatal("live-controller guard remained set after registry release")
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("controller registry did not release the stopped stream")
+}
+
 func TestServiceStopAllOnlyDetachesPersistentConversation(t *testing.T) {
 	provider := &terminatingConversation{fakeConversation: newFakeConversation()}
 	h := newHarnessWithConversation(t, provider)

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -936,18 +936,43 @@ func (s *Service) Stop(ctx context.Context, id domain.SessionID) error {
 // StopAll closes every controller, for daemon shutdown.
 func (s *Service) StopAll(ctx context.Context) {
 	s.mu.Lock()
-	controllers := make([]*Controller, 0, len(s.controllers))
+	type shutdownTarget struct {
+		id         domain.SessionID
+		controller *Controller
+	}
+	targets := make([]shutdownTarget, 0, len(s.controllers))
 	for id, controller := range s.controllers {
-		controllers = append(controllers, controller)
-		delete(s.controllers, id)
-		delete(s.startConfigs, id)
+		targets = append(targets, shutdownTarget{id: id, controller: controller})
 	}
 	s.mu.Unlock()
 
-	for _, controller := range controllers {
-		if err := controller.Close(ctx); err != nil {
-			s.log.Error("failed to close chat controller", "error", err)
+	for _, target := range targets {
+		gate := s.controllerGate(target.id)
+		if err := gate.lock(ctx); err != nil {
+			s.log.Error("failed to lock chat controller gate during shutdown", "session", target.id, "error", err)
+			continue
 		}
+		s.mu.RLock()
+		current, ok := s.controllers[target.id]
+		s.mu.RUnlock()
+		if !ok || current != target.controller {
+			gate.unlock()
+			continue
+		}
+		if err := target.controller.Close(ctx); err != nil {
+			s.log.Error("failed to close chat controller", "session", target.id, "error", err)
+		}
+		select {
+		case <-target.controller.stopped:
+			s.mu.Lock()
+			if current, ok := s.controllers[target.id]; ok && current == target.controller {
+				delete(s.controllers, target.id)
+				delete(s.startConfigs, target.id)
+			}
+			s.mu.Unlock()
+		default:
+		}
+		gate.unlock()
 	}
 }
 


### PR DESCRIPTION
## Summary
- During daemon shutdown, `StopAll` now holds each session's controller gate and keeps registry entries until the controller's event stream actually ends.
- Registry cleanup mirrors explicit `Stop` semantics instead of deleting controllers before `Close()` finishes.

## Problem
`StopAll` removed chat controllers from the in-memory registry before their detach/close completed and did not take the per-session controller gate. A concurrent `Start` could observe an empty registry while the old controller was still shutting down and create a second writer for the same session.

## Test plan
- [x] `cd backend && go test ./internal/service/chat/ -count=1`
- [x] Added `TestServiceStopAllRetainsControllerUntilItsEventStreamActuallyEnds`


Made with [Cursor](https://cursor.com)