### PR TITLE
fix(frontend): offer merge when the provider requires no review

### DIFF
--- a/backend/internal/service/pr/action_service_test.go
+++ b/backend/internal/service/pr/action_service_test.go
@@ -74,6 +74,21 @@ func TestActionServiceMerge_GuardsAndSquashMergesExactHead(t *testing.T) {
 	}
 }
 
+func TestActionServiceMerge_MergesAPRThatNeedsNoReview(t *testing.T) {
+	pr, scm := mergeableActionFixture()
+	scm.review = ports.SCMReviewObservation{
+		Decision: string(domain.ReviewNone),
+		Reviews:  []ports.SCMReviewSummaryObservation{{ID: "r1", State: "COMMENTED"}},
+	}
+	svc := NewActionService(ActionDeps{Store: &fakeActionStore{pr: pr, ok: true}, Reader: scm, Merger: scm})
+	if _, err := svc.Merge(context.Background(), MergeRequest{PRID: "42", PRURL: pr.URL, ExpectedHeadSHA: pr.HeadSHA}); err != nil {
+		t.Fatal(err)
+	}
+	if scm.mergeCalls != 1 {
+		t.Fatalf("merge calls = %d, want 1", scm.mergeCalls)
+	}
+}
+
 func TestActionServiceMerge_FailsClosedForStaleHeadOrReadiness(t *testing.T) {
 	pr, scm := mergeableActionFixture()
 	svc := NewActionService(ActionDeps{Store: &fakeActionStore{pr: pr, ok: true}, Reader: scm, Merger: scm})

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -648,6 +648,21 @@ describe("SessionInspector PR section", () => {
     },
   );
 
+  it("does not offer Merge while human review comments are unresolved", () => {
+    renderWithQuery(
+      <SessionInspector session={session([pr(7, "open")])} />,
+      undefined,
+      (client) => {
+        client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [
+          prSummary(7, "open", {
+            review: { decision: "none", hasUnresolvedHumanComments: true, unresolvedBy: [] },
+          }),
+        ]);
+      },
+    );
+    expect(screen.queryByRole("button", { name: "Merge PR #7" })).not.toBeInTheDocument();
+  });
+
   it("uses the state chip as the single merged-state indicator", () => {
     renderWithQuery(
       <SessionInspector

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -616,6 +616,38 @@ describe("SessionInspector PR section", () => {
     expect(screen.queryByRole("button", { name: "Merge PR #7" })).not.toBeInTheDocument();
   });
 
+  it("offers Merge when the provider requires no review", () => {
+    renderWithQuery(
+      <SessionInspector session={session([pr(7, "open", { review: "none" })])} />,
+      undefined,
+      (client) => {
+        client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [prSummary(7, "open")]);
+      },
+    );
+
+    expect(screen.getByRole("button", { name: "Merge PR #7" })).toBeEnabled();
+    expect(prSection("Pull request").getByText("No review required")).toBeInTheDocument();
+    expect(prSection("Pull request").queryByText("Review pending")).not.toBeInTheDocument();
+  });
+
+  it.each(["review_required", "changes_requested"] as const)(
+    "does not offer Merge when the review decision is %s",
+    (decision) => {
+      renderWithQuery(
+        <SessionInspector session={session([pr(7, "open")])} />,
+        undefined,
+        (client) => {
+          client.setQueryData(sessionScmSummaryQueryKey("sess-1"), [
+            prSummary(7, "open", {
+              review: { decision, hasUnresolvedHumanComments: false, unresolvedBy: [] },
+            }),
+          ]);
+        },
+      );
+      expect(screen.queryByRole("button", { name: "Merge PR #7" })).not.toBeInTheDocument();
+    },
+  );
+
   it("uses the state chip as the single merged-state indicator", () => {
     renderWithQuery(
       <SessionInspector

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -53,7 +53,7 @@ import { useSessionWorkspaceFilesChangedCount } from "../hooks/useSessionWorkspa
 import { useSessionBrowserLink } from "../hooks/useSessionBrowserLink";
 import { clearTerminateSessionState, useTerminateSession } from "../hooks/useTerminateSession";
 import { formatEstimatedCost, type EstimatedCost } from "../lib/format-cost";
-import { prBrowserUrl, prCardPresentation, prNounKeys, sessionPRDisplaySummaries } from "../lib/pr-display";
+import { prBrowserUrl, prCanMerge, prCardPresentation, prNounKeys, sessionPRDisplaySummaries } from "../lib/pr-display";
 import { formatTokenCount } from "../lib/format-token-count";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { findProjectOrchestrator, sortedPRs } from "../types/workspace";
@@ -1189,12 +1189,7 @@ function PRSummaryCard({
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
 	const presentation = prCardPresentation(pr);
-	const canMerge =
-		pr.state === "open" &&
-		pr.ci.state === "passing" &&
-		pr.review.decision === "approved" &&
-		pr.mergeability.state === "mergeable" &&
-		Boolean(pr.url && pr.headSha);
+	const canMerge = prCanMerge(pr) && Boolean(pr.url && pr.headSha);
 	const mergePr = useMutation({
 		mutationFn: async () => {
 			if (usePreviewData) return;

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -1868,6 +1868,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.review.requirementSatisfied": "PR approved",
 	"pr.review.viewDetails": "View review details",

--- a/frontend/src/renderer/i18n/de.json
+++ b/frontend/src/renderer/i18n/de.json
@@ -710,6 +710,7 @@
 	"pr.review.changesRequested": "Änderungen angefordert",
 	"pr.review.draftNotReady": "Entwurfs-PR · Noch nicht bereit für Review",
 	"pr.review.none": "Keine",
+	"pr.review.notRequired": "Kein Review erforderlich",
 	"pr.review.openPR": "Pull Request öffnen",
 	"pr.review.pending": "Ausstehend",
 	"pr.review.requiredNotSubmitted": "Erforderliches Review nicht eingereicht",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -656,6 +656,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.merge.openConflicts": "Open merge conflicts",
 	"pr.merge.providerBlocked": "GitHub currently reports this pull request can't be merged.",

--- a/frontend/src/renderer/i18n/en.json
+++ b/frontend/src/renderer/i18n/en.json
@@ -695,6 +695,7 @@
 	"pr.review.changesRequested": "Changes requested",
 	"pr.review.draftNotReady": "Draft PR · Not ready for review",
 	"pr.review.none": "None",
+	"pr.review.notRequired": "No review required",
 	"pr.review.openPR": "Open pull request",
 	"pr.review.pending": "Review pending",
 	"pr.review.requiredNotSubmitted": "Required review not submitted",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -722,6 +722,7 @@
 	"pr.review.changesRequested": "Cambios solicitados",
 	"pr.review.draftNotReady": "PR en borrador · No listo para revisión",
 	"pr.review.none": "Ninguno",
+	"pr.review.notRequired": "No se requiere revisión",
 	"pr.review.openPR": "Abrir pull request",
 	"pr.review.pending": "Pendiente",
 	"pr.review.requiredNotSubmitted": "Revisión requerida no enviada",

--- a/frontend/src/renderer/i18n/es.json
+++ b/frontend/src/renderer/i18n/es.json
@@ -1895,6 +1895,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.review.requirementSatisfied": "PR approved",
 	"pr.review.viewDetails": "View review details",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -1895,6 +1895,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.review.requirementSatisfied": "PR approved",
 	"pr.review.viewDetails": "View review details",

--- a/frontend/src/renderer/i18n/fr.json
+++ b/frontend/src/renderer/i18n/fr.json
@@ -722,6 +722,7 @@
 	"pr.review.changesRequested": "Modifications demandées",
 	"pr.review.draftNotReady": "PR en brouillon · Pas prêt pour la revue",
 	"pr.review.none": "Aucun",
+	"pr.review.notRequired": "Aucune revue requise",
 	"pr.review.openPR": "Ouvrir la pull request",
 	"pr.review.pending": "En attente",
 	"pr.review.requiredNotSubmitted": "Revue requise non soumise",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -710,6 +710,7 @@
 	"pr.review.changesRequested": "変更リクエストあり",
 	"pr.review.draftNotReady": "下書き PR · レビュー準備ができていません",
 	"pr.review.none": "なし",
+	"pr.review.notRequired": "レビュー不要",
 	"pr.review.openPR": "プルリクエストを開く",
 	"pr.review.pending": "保留中",
 	"pr.review.requiredNotSubmitted": "必須レビューが未提出",

--- a/frontend/src/renderer/i18n/ja.json
+++ b/frontend/src/renderer/i18n/ja.json
@@ -1868,6 +1868,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.review.requirementSatisfied": "PR approved",
 	"pr.review.viewDetails": "View review details",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -1868,6 +1868,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.review.requirementSatisfied": "PR approved",
 	"pr.review.viewDetails": "View review details",

--- a/frontend/src/renderer/i18n/ko.json
+++ b/frontend/src/renderer/i18n/ko.json
@@ -710,6 +710,7 @@
 	"pr.review.changesRequested": "변경 요청됨",
 	"pr.review.draftNotReady": "초안 PR · 리뷰 준비되지 않음",
 	"pr.review.none": "없음",
+	"pr.review.notRequired": "리뷰 필요 없음",
 	"pr.review.openPR": "풀 리퀘스트 열기",
 	"pr.review.pending": "대기 중",
 	"pr.review.requiredNotSubmitted": "필수 리뷰가 제출되지 않음",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -1895,6 +1895,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.review.requirementSatisfied": "PR approved",
 	"pr.review.viewDetails": "View review details",

--- a/frontend/src/renderer/i18n/pt-BR.json
+++ b/frontend/src/renderer/i18n/pt-BR.json
@@ -722,6 +722,7 @@
 	"pr.review.changesRequested": "Alterações solicitadas",
 	"pr.review.draftNotReady": "PR em rascunho · Não pronto para revisão",
 	"pr.review.none": "Nenhuma",
+	"pr.review.notRequired": "Revisão não obrigatória",
 	"pr.review.openPR": "Abrir pull request",
 	"pr.review.pending": "Pendente",
 	"pr.review.requiredNotSubmitted": "Revisão obrigatória não enviada",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -1850,6 +1850,7 @@
 	"pr.merge.reasonConflict": "One approval is sufficient, but the merge conflict still blocks this PR.",
 	"pr.merge.reasonChecksFailing": "The review requirement is satisfied, but failing checks still block this PR.",
 	"pr.merge.reasonReview": "A required review must be completed before this PR can merge.",
+	"pr.merge.reasonComments": "Unresolved review comments must be resolved before this PR can merge.",
 	"pr.merge.reasonReady": "No merge conflict, checks are passing, and the review requirement is satisfied.",
 	"pr.review.requirementSatisfied": "PR approved",
 	"pr.review.viewDetails": "View review details",

--- a/frontend/src/renderer/i18n/zh-CN.json
+++ b/frontend/src/renderer/i18n/zh-CN.json
@@ -692,6 +692,7 @@
 	"pr.review.changesRequested": "请求修改",
 	"pr.review.draftNotReady": "草稿 PR · 尚未准备好评审",
 	"pr.review.none": "无",
+	"pr.review.notRequired": "无需评审",
 	"pr.review.openPR": "打开拉取请求",
 	"pr.review.pending": "待评审",
 	"pr.review.requiredNotSubmitted": "尚未提交所需评审",

--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -237,6 +237,38 @@ describe("prCardPresentation", () => {
 		expect(presentation.supporting.map((status) => status.label)).toEqual(["Checks passing"]);
 	});
 
+	it("treats a PR that needs no review as mergeable", () => {
+		const presentation = prCardPresentation(
+			summary({ review: { decision: "none", hasUnresolvedHumanComments: false, unresolvedBy: [] } }),
+		);
+
+		expect(presentation.readiness).toMatchObject({
+			label: "Mergeable",
+			detail: "No merge conflict, checks are passing, and the review requirement is satisfied.",
+			tone: "success",
+		});
+		expect(presentation.statusRows?.find((status) => status.key === "review")?.detail).toBe("No review required");
+	});
+
+	it.each(["review_required", "changes_requested"] as const)("does not call a %s PR mergeable", (decision) => {
+		const presentation = prCardPresentation(
+			summary({ review: { decision, hasUnresolvedHumanComments: false, unresolvedBy: [] } }),
+		);
+
+		expect(presentation.readiness?.label).toBe("Not mergeable yet");
+	});
+
+	it.each(["blocked", "unstable"] as const)("does not call a %s PR mergeable", (state) => {
+		const presentation = prCardPresentation(
+			summary({ mergeability: { state, reasons: [], prUrl: "https://github.com/acme/repo/pull/7" } }),
+		);
+
+		expect(presentation.readiness).toMatchObject({
+			label: "Not mergeable yet",
+			detail: "GitHub currently reports this pull request can't be merged.",
+		});
+	});
+
 	it("shows checking merge readiness while provider state is pending", () => {
 		const presentation = prCardPresentation(
 			summary({

--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -269,6 +269,17 @@ describe("prCardPresentation", () => {
 		});
 	});
 
+	it.each(["approved", "none"] as const)("does not call a %s PR with unresolved review comments mergeable", (decision) => {
+		const presentation = prCardPresentation(
+			summary({ review: { decision, hasUnresolvedHumanComments: true, unresolvedBy: [] } }),
+		);
+
+		expect(presentation.readiness).toMatchObject({
+			label: "Not mergeable yet",
+			detail: "Unresolved review comments must be resolved before this PR can merge.",
+		});
+	});
+
 	it("shows checking merge readiness while provider state is pending", () => {
 		const presentation = prCardPresentation(
 			summary({

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -270,7 +270,8 @@ export function prCanMerge(pr: SessionPRSummary): boolean {
 		pr.state === "open" &&
 		pr.ci.state === "passing" &&
 		pr.mergeability.state === "mergeable" &&
-		reviewAllowsMerge(pr.review.decision)
+		reviewAllowsMerge(pr.review.decision) &&
+		!pr.review.hasUnresolvedHumanComments
 	);
 }
 
@@ -291,6 +292,7 @@ function mergeReadinessDetail(pr: SessionPRSummary): string {
 	if (pr.mergeability.state === "conflicting") return appI18n.t("pr.merge.reasonConflict");
 	if (pr.ci.state === "failing") return appI18n.t("pr.merge.reasonChecksFailing");
 	if (!reviewAllowsMerge(pr.review.decision)) return appI18n.t("pr.merge.reasonReview");
+	if (pr.review.hasUnresolvedHumanComments) return appI18n.t("pr.merge.reasonComments");
 	if (pr.mergeability.state !== "mergeable") return appI18n.t("pr.merge.providerBlocked");
 	return appI18n.t("pr.merge.reasonReady");
 }

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -226,7 +226,7 @@ export function prCardPresentation(pr: SessionPRSummary): PRCardPresentation {
 			statusRows.push(cardStatus("ci", pr.ci.state === "pending" ? "pr.card.checksPending" : "pr.card.checksLoading", "neutral", undefined, [], prChecksUrl(pr), true));
 		}
 		statusRows.push(cardStatus("review", "pr.card.reviewStatus", reviewTone(pr.review.decision, pr.review.hasUnresolvedHumanComments), reviewStatusDetail(pr)));
-		const mergeable = pr.mergeability.state !== "conflicting" && pr.ci.state === "passing" && pr.review.decision === "approved";
+		const mergeable = prCanMerge(pr);
 		const checkingReadiness = pr.ci.state === "pending" || pr.ci.state === "unknown" || pr.mergeability.state === "unknown";
 		return { primary, supporting, statusRows, readiness: {
 			label: appI18n.t(checkingReadiness ? "pr.merge.checkingReadiness" : mergeable ? "pr.merge.mergeable" : "pr.merge.notMergeableYet"),
@@ -265,19 +265,33 @@ function cardStatus(
 	return { key, label: appI18n.t(labelKey), detail, href, breathe, links, tone };
 }
 
+export function prCanMerge(pr: SessionPRSummary): boolean {
+	return (
+		pr.state === "open" &&
+		pr.ci.state === "passing" &&
+		pr.mergeability.state === "mergeable" &&
+		reviewAllowsMerge(pr.review.decision)
+	);
+}
+
+function reviewAllowsMerge(decision: SessionPRSummary["review"]["decision"]): boolean {
+	return decision === "approved" || decision === "none";
+}
+
 function reviewStatusDetail(pr: SessionPRSummary): string {
 	switch (pr.review.decision) {
 		case "approved": return appI18n.t("pr.review.requirementSatisfied");
 		case "changes_requested": return appI18n.t("pr.review.changesActive");
 		case "review_required": return appI18n.t("pr.review.requiredNotSubmitted");
-		default: return appI18n.t("pr.review.pending");
+		case "none": return appI18n.t("pr.review.notRequired");
 	}
 }
 
 function mergeReadinessDetail(pr: SessionPRSummary): string {
 	if (pr.mergeability.state === "conflicting") return appI18n.t("pr.merge.reasonConflict");
 	if (pr.ci.state === "failing") return appI18n.t("pr.merge.reasonChecksFailing");
-	if (pr.review.decision !== "approved") return appI18n.t("pr.merge.reasonReview");
+	if (!reviewAllowsMerge(pr.review.decision)) return appI18n.t("pr.merge.reasonReview");
+	if (pr.mergeability.state !== "mergeable") return appI18n.t("pr.merge.providerBlocked");
 	return appI18n.t("pr.merge.reasonReady");
 }
 


### PR DESCRIPTION
## What

In a repository that does not require reviews, a PR authored and reviewed from the same GitHub account showed **Review pending** and **Not mergeable yet** in the session inspector, and AO hid the Merge action. The PR card now reads **No review required**, reports the PR as **Mergeable**, and offers **Merge**, which is what the daemon's merge gate already allowed.

## Why

Fixes #4935.

GitHub never records a self-review as `APPROVED`, so in a single-user repository the review decision stays empty (`reviewDecision: ""`), which AO stores as `none`. `none` means GitHub requires no review: a branch protection rule or ruleset that requires one makes GitHub return `REVIEW_REQUIRED` and `mergeStateStatus: BLOCKED` instead.

The daemon already treats `none` as satisfied. `domain.MergeReadiness.ReadyToMerge`, which `POST /api/v1/prs/{id}/merge` checks against a fresh fetch, only blocks on requested changes, unresolved human comments, CI and provider mergeability. The renderer did not:

- `SessionInspector` offered Merge only for `review.decision === "approved"`.
- `prCardPresentation` labelled a PR Mergeable only when approved, otherwise "A required review must be completed before this PR can merge."
- `reviewStatusDetail` fell through to **Review pending** for `none`.

The "Review pending" in the report is that renderer string, not the backend `review_pending` session status, which only `review_required` produces.

## How

- **One rule for the label and the button.** `prCanMerge()` in `lib/pr-display.ts` mirrors `ReadyToMerge`: open, checks passing, provider mergeability `mergeable`, review decision `approved` or `none`, and no unresolved human review comments. `prCardPresentation` and `SessionInspector` both use it.
- **`none` reads "No review required"** (new `pr.review.notRequired`, all 8 locales).
- **Two consequences of sharing the rule**, both matching what the daemon already enforces:
  - An approved PR the provider reports as `blocked` or `unstable` is no longer labelled Mergeable. The detail reuses `pr.merge.providerBlocked`.
  - A PR with unresolved human review threads no longer shows Merge; clicking it used to fail with `PR_PRECONDITIONS_UNMET`. This matters for #4935 specifically: the AO reviewer posts inline comments from the author's own account, so they count as human. The reason is a new `pr.merge.reasonComments`, kept in English in every locale like the other `pr.merge.reason*` strings.
- **No backend behaviour change.** `TestActionServiceMerge_MergesAPRThatNeedsNoReview` pins the daemon side so the two cannot drift apart.

**Scope.** This does not treat AO's own review verdict as an approval and does not relax any provider blocker. #2073 was closed on the basis that AO should keep respecting required reviews and merge blockers; this change only acts where GitHub itself reports that no review is required.

### Intentional omissions

Found while tracing #4935; each is a separate problem:

- **`ao pr merge <n>` cannot succeed.** The CLI posts `{}`, and since #3599 the merge endpoint rejects a body without `prUrl` and `expectedHeadSha` with 400 `INVALID_PR`. That, not an approval check, is why the CLI refused in the report. Fixing it means deciding how the CLI supplies the head SHA it expects to merge.
- **A repository with no CI checks never becomes mergeable in AO.** With no status rollup the CI state is `unknown`, which both the card and `ReadyToMerge` treat as a blocker. If the reporter's repository has no workflows at all, this PR alone does not unblock them.
- **AO's own inline review comments count as human comments.** `review_comments` in `pr.sql` lacks the `review_run` exclusion that `external_comments` has, so they block merge until resolved.
- **Existing copy left as is:** `pr.merge.reasonConflict` says "One approval is sufficient…" whatever the review requirement.

## Testing

### Before and after

The same PR state in both: open, checks passing, GitHub mergeable, no review decision. These are the real Session inspector rendered in the renderer harness (`dev:web` with `installFakeAgent`), with the PR summary served for a placeholder `acme/notes-app#7`, not a live GitHub PR. None of the commits on `main` since the before capture touch the PR card.

| Before (`main`) | After (this branch) |
| --- | --- |
| <img width="499" height="886" alt="Before: Review pending, Not mergeable yet, no Merge button" src="https://github.com/user-attachments/assets/26cce833-b0af-4774-9125-bf433c6a28ce" /> | <img width="499" height="886" alt="After: No review required, Mergeable, Merge button shown" src="https://github.com/user-attachments/assets/8cb3fa84-f642-4e1c-9ebe-af7ac47c10a8" /> |

| | Before | After |
| --- | --- | --- |
| Review status | Review pending | **No review required** |
| Readiness | Not mergeable yet: "A required review must be completed before this PR can merge." | **Mergeable**: "No merge conflict, checks are passing, and the review requirement is satisfied." |
| Merge button | Hidden | **Shown** |

### New tests

Each renderer test below failed before its change.

- `pr-display.test.ts`: a `none` PR is Mergeable and reads "No review required"; `blocked` and `unstable` PRs are not Mergeable; `approved` and `none` PRs with unresolved human comments are not Mergeable. `review_required` and `changes_requested` stay not Mergeable (these passed before too and guard the rule).
- `SessionInspector.test.tsx`: Merge is offered for a `none` PR without "Review pending"; not offered for `review_required`, `changes_requested`, or unresolved human comments.
- `action_service_test.go`: the daemon merges a PR whose decision is `none` with only a `COMMENTED` review (passes on `main` too; it pins existing behaviour).

### CI jobs run locally

Run on `f79eca38c`, rebased onto `cadde8c9f`.

- **Go** (`golang:1.25.7` container, `GOTOOLCHAIN=auto` resolving to go1.26.5 as `go.work` requires): gofmt, `go build ./...`, `go vet ./...` clean. `go test -race -timeout=15m ./...`: 167 packages ok, including `internal/service/pr`. 2 packages failed, neither touched here, both explained by the container rather than this change:
  - `internal/mobilebridge` write-failure tests: the run was as root, which ignores the read-only permissions they rely on. Re-run as uid 1001, the package passes on this branch and on `cadde8c9f`.
  - `internal/adapters/agent/fake` `TestFullLifecycleSpawnToTermination` ("read hook log … no such file or directory"): fails identically on `cadde8c9f` in the same `golang` image, so I have not verified it locally; CI is the check for this one.
- **golangci-lint** v2.12.2: 0 issues
- **sqlc drift** and **api drift** (`npm run sqlc`, `npm run api`): no diff
- **gitleaks** v7.4.0 (pinned digest) over the 3 commits in this PR: no leaks
- **Frontend test job** (`node:24` container, non-root): cloud-client and product-ui verify, browser-runtime prepare, landing icons check, `npm run typecheck`, `npm run typecheck:e2e`, `npx vitest run`: **4,497 passed**, 6 skipped, 0 failed
- **Renderer smoke** (`mcr.microsoft.com/playwright:v1.60.0-noble` container, uid 1001, Node 24.21.0): `npm run typecheck:e2e` clean, `CI=true npm run test:e2e:renderer`: **59 passed**

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
