### PR TITLE
fix: default ambiguous Mac downloads to Apple Silicon

### DIFF
--- a/frontend/src/landing/src/app/hooks/useOS/useOS.test.ts
+++ b/frontend/src/landing/src/app/hooks/useOS/useOS.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { macPlatformFromRenderer, Platform } from "./useOS";
+
+describe("macPlatformFromRenderer", () => {
+	it.each([
+		"Intel Iris OpenGL Engine",
+		"AMD Radeon Pro 5500M OpenGL Engine",
+		"ATI Radeon HD 5770 OpenGL Engine",
+		"NVIDIA GeForce GT 750M OpenGL Engine",
+	])("selects the Intel build for an Intel-era Mac GPU: %s", (renderer) => {
+		expect(macPlatformFromRenderer(renderer)).toBe(Platform.MacIntel);
+	});
+
+	it.each([
+		"Apple M3",
+		"Apple GPU",
+		"ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device))",
+		"WebKit WebGL",
+		"",
+		undefined,
+	])("defaults to Apple Silicon for an Apple or ambiguous renderer: %s", (renderer) => {
+		expect(macPlatformFromRenderer(renderer)).toBe(Platform.MacAppleSilicon);
+	});
+});

--- a/frontend/src/landing/src/app/hooks/useOS/useOS.ts
+++ b/frontend/src/landing/src/app/hooks/useOS/useOS.ts
@@ -18,6 +18,20 @@ export interface PlatformInfo {
 	mobileOS: MobileOS;
 }
 
+export function macPlatformFromRenderer(
+	renderer: unknown,
+): typeof Platform.MacAppleSilicon | typeof Platform.MacIntel {
+	if (typeof renderer !== "string") return Platform.MacAppleSilicon;
+
+	// Apple Silicon only exposes Apple GPUs. Intel Macs can expose Intel's
+	// integrated GPU or a discrete AMD/Nvidia GPU, so require one of those
+	// explicit signals before offering the x64 build. Masked and software
+	// renderer strings are ambiguous and must keep the safer arm64 default.
+	return /\b(?:intel|amd|ati|nvidia)\b/i.test(renderer)
+		? Platform.MacIntel
+		: Platform.MacAppleSilicon;
+}
+
 function detectMacArch():
 	| typeof Platform.MacAppleSilicon
 	| typeof Platform.MacIntel {
@@ -36,10 +50,7 @@ function detectMacArch():
 		const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) as
 			| string
 			| undefined;
-		if (typeof renderer !== "string") return Platform.MacAppleSilicon;
-		return renderer.toLowerCase().includes("apple")
-			? Platform.MacAppleSilicon
-			: Platform.MacIntel;
+		return macPlatformFromRenderer(renderer);
 	} catch {
 		return Platform.MacAppleSilicon;
 	}


### PR DESCRIPTION
## Summary
- select the Intel download only when the WebGL renderer explicitly identifies an Intel-era GPU
- default masked, software, and otherwise ambiguous renderers to the Apple Silicon download
- add focused regression coverage for Apple, Intel-era, masked, and missing renderer values

## Validation
- `npm run frontend:typecheck`
- `npx vitest run --config vite.renderer.config.ts src/landing` (121 tests)
- `npm run build` from `frontend/src/landing`
- `git diff --check`

Fixes #5337